### PR TITLE
[codex] Fix GLM ModelOpt NVFP4 A16 force path

### DIFF
--- a/vllm/model_executor/layers/fused_moe/b12x_moe.py
+++ b/vllm/model_executor/layers/fused_moe/b12x_moe.py
@@ -2,11 +2,14 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """B12X modular fused-MoE backend for FP4 weights."""
 
+import os
+from types import SimpleNamespace
 from typing import Any, cast
 
 import torch
 
 import vllm.envs as envs
+from vllm.logger import init_logger
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
 from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 from vllm.model_executor.layers.fused_moe.config import (
@@ -25,6 +28,15 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
 )
 from vllm.model_executor.utils import replace_parameter
 from vllm.platforms import current_platform
+
+logger = init_logger(__name__)
+
+
+def _env_flag(name: str, default: bool = False) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.strip().lower() not in ("", "0", "false", "no", "off")
 
 
 def _dtype_element_size(dtype: torch.dtype) -> int:
@@ -341,6 +353,15 @@ class B12xExperts(mk.FusedMoEExpertsModular):
         self._unit_scale_by_device: dict[torch.device, torch.Tensor] = {}
 
     def _quant_mode(self) -> str:
+        if (
+            self.quant_config.quant_dtype == "nvfp4"
+            and _env_flag("B12X_MOE_FORCE_A16")
+        ):
+            logger.warning_once(
+                "B12X_MOE_FORCE_A16=1 forcing B12X MoE quant_mode=w4a16 "
+                "for NVFP4 weights."
+            )
+            return "w4a16"
         return "nvfp4" if self.quant_config.quant_dtype == "nvfp4" else "w4a16"
 
     def _source_format(self) -> str:
@@ -349,6 +370,11 @@ class B12xExperts(mk.FusedMoEExpertsModular):
         return "fp4_e8m0_k32"
 
     def _w13_layout(self) -> str:
+        if (
+            self._source_format() == "modelopt_nvfp4"
+            and self._quant_mode() == "w4a16"
+        ):
+            return "w13"
         # vLLM fused MoE loading stores fused W13 as [w1/gate, w3/up], which is
         # the row order consumed by b12x for the runtime SwiGLU path. Declaring
         # "up_gate" here swaps gate/up in every expert -> corrupted MoE output.
@@ -554,6 +580,31 @@ class B12xExperts(mk.FusedMoEExpertsModular):
             w2_global_scale = self._weight_global_scale(
                 w2.device, num_experts, weight_name="w2"
             )
+            if self._source_format() == "modelopt_nvfp4":
+                from b12x.moe.fused.w4a16.prepare import (
+                    prepare_w4a16_modelopt_native_weights,
+                )
+
+                w4a16 = prepare_w4a16_modelopt_native_weights(
+                    w1,
+                    self.w1_scale,
+                    w1_global_scale,
+                    w2,
+                    self.w2_scale,
+                    w2_global_scale,
+                    activation=_b12x_activation_name(activation),
+                    params_dtype=params_dtype,
+                    w13_layout=self._w13_layout(),
+                )
+                prepared = SimpleNamespace(
+                    source_format=self._source_format(),
+                    w13_layout=self._w13_layout(),
+                    w1_runtime_alphas=None,
+                    w2_runtime_alphas=None,
+                    w4a16=w4a16,
+                )
+                self._prepared_fp4_moe_by_dtype[params_dtype] = prepared
+                return prepared
             a1_gscale = unit_scale
             a2_gscale = unit_scale
 


### PR DESCRIPTION
## Summary

This patch makes the GLM ModelOpt NVFP4 B12X MoE wrapper actually honor
`B12X_MOE_FORCE_A16=1`, and routes the forced W4A16 path through B12X's native
ModelOpt W4A16 prepare API instead of the packed serving repack path.

## Root Cause

The vLLM wrapper always passed an explicit `quant_mode="nvfp4"` for NVFP4
checkpoints. That bypassed B12X's `default_moe_quant_mode()` env handling, so
setting `B12X_MOE_FORCE_A16=1` did not change the actual MoE quant mode.

After making the env force effective, the default packed ModelOpt NVFP4 W4A16
prepare path produced broken GLM numerics. Prefill KLD against the BF16 reference
jumped from the normal ~0.08 range to ~8-9. The native ModelOpt W4A16 prepare
path was numerically sane, so this patch uses that path for forced A16 on
ModelOpt NVFP4.

## What Changed

- Add local env flag parsing for `B12X_MOE_FORCE_A16` in the vLLM B12X MoE
  wrapper.
- When the checkpoint is ModelOpt NVFP4 and the env flag is enabled, return
  `quant_mode="w4a16"` and log the forced mode once.
- Use `w13_layout="w13"` for ModelOpt NVFP4 W4A16, matching the native ModelOpt
  W4A16 contract.
- Prepare forced ModelOpt NVFP4 A16 weights with
  `prepare_w4a16_modelopt_native_weights()` instead of the packed W4A16 repack
  helper.

## Validation

- `git diff --check`
- `python3 -m py_compile vllm/model_executor/layers/fused_moe/b12x_moe.py`
- Built image:
  `voipmonitor/vllm:cu132-vllm611a842-b12xf9226c-a16nativew4a16-20260606`
- GLM-5.1 NVFP4 TP8/DCP1 prefill KLD, `B12X_MOE_FORCE_A16=1`, native ModelOpt
  W4A16:
  - `Mean KLD: 0.052297` over `2047` positions
- Same setup with the packed W4A16 path was numerically broken:
  - packed default: `Mean KLD: 8.613591`
  - packed + attempted scale folding: `Mean KLD: 9.499678`
  - packed + `w13_layout="w13"`: `Mean KLD: 9.499678`
- Runtime smoke on patched image:
  - launched GLM-5.1 on port `5329`
  - log confirmed `B12X_MOE_FORCE_A16=1 forcing B12X MoE quant_mode=w4a16`
  - API startup completed
  - `/mnt/test.py --port 5329 --model GLM-5.1 --max-tokens 80`: TTFT `0.69s`,
    generation-only `76.13 tok/s`, CJK `0`

## Caveat

The native ModelOpt W4A16 path fixes correctness but is not yet the performance
fix for prefill. The KLD harness with `prompt_logprobs=-1` reproduced ~64 input
tok/s for a 2048-token prompt. The next optimization target is the B12X packed
ModelOpt NVFP4 W4A16 repack/runtime contract, which is currently fast but
numerically wrong for GLM.
