### PR TITLE
[codex] Fix B12X sparse MLA DCP cudagraph support

### DIFF
--- a/tests/v1/attention/test_sparse_mla_backends.py
+++ b/tests/v1/attention/test_sparse_mla_backends.py
@@ -36,7 +36,10 @@ if not current_platform.is_cuda():
     )
 
 from vllm.utils.math_utils import cdiv
-from vllm.v1.attention.backends.mla.b12x_mla_sparse import B12xMLASparseBackend
+from vllm.v1.attention.backends.mla.b12x_mla_sparse import (
+    B12xMLASparseBackend,
+    B12xMLASparseMetadataBuilder,
+)
 from vllm.v1.attention.backends.mla.flashinfer_mla_sparse import (
     FlashInferMLASparseBackend,
 )
@@ -46,6 +49,7 @@ from vllm.v1.attention.backends.mla.flashmla_sparse import (
 )
 from vllm.v1.attention.backends.mla.indexer import split_indexer_prefill_chunks
 from vllm.v1.attention.backends.utils import split_prefill_chunks
+from vllm.v1.attention.backend import AttentionCGSupport
 from vllm.v1.attention.ops import flashmla
 
 SPARSE_BACKEND_BATCH_SPECS = {
@@ -67,6 +71,27 @@ SPARSE_BACKEND_BATCH_SPECS["large_q_pure_prefill"] = BatchSpec(
 )
 
 DEVICE_TYPE = current_platform.device_type
+
+
+@pytest.mark.parametrize(
+    ("dcp_size", "expected"),
+    [
+        (1, AttentionCGSupport.UNIFORM_BATCH),
+        (2, AttentionCGSupport.NEVER),
+        (4, AttentionCGSupport.NEVER),
+    ],
+)
+def test_b12x_sparse_mla_dcp_disables_full_cudagraph(dcp_size, expected):
+    vllm_config = SimpleNamespace(
+        parallel_config=SimpleNamespace(decode_context_parallel_size=dcp_size)
+    )
+
+    assert (
+        B12xMLASparseMetadataBuilder.get_cudagraph_support(
+            vllm_config, kv_cache_spec=None  # type: ignore[arg-type]
+        )
+        == expected
+    )
 
 
 def _float_to_e8m0_truncate(f: float) -> float:

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -302,6 +302,19 @@ class B12xMLASparseMetadataBuilder(AttentionMetadataBuilder[B12xMLASparseMetadat
 
     _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.UNIFORM_BATCH
 
+    @classmethod
+    def get_cudagraph_support(
+        cls,
+        vllm_config: VllmConfig,
+        kv_cache_spec: AttentionSpec,
+    ) -> AttentionCGSupport:
+        if vllm_config.parallel_config.decode_context_parallel_size > 1:
+            # DCP sparse-MLA metadata/scratch is not full-graph-stable yet.
+            # Keep attention outside full CUDA graph replay; the resolver will
+            # use PIECEWISE when VLLM_COMPILE attention splitting is available.
+            return AttentionCGSupport.NEVER
+        return cls._cudagraph_support
+
     def __init__(
         self,
         kv_cache_spec: AttentionSpec,


### PR DESCRIPTION
## Summary

Fixes GLM-5.1 DCP>1 incoherent generation when using `B12X_MLA_SPARSE` with the default `FULL_AND_PIECEWISE` CUDA graph mode.

`B12xMLASparseMetadataBuilder` previously reported `UNIFORM_BATCH` CUDA graph support for all configurations. With DCP enabled, vLLM therefore captured a full decode CUDA graph. On GLM-5.1 DCP4 this replays incorrectly and produces incoherent short outputs, while the same configuration with eager/no full graph is coherent.

This changes B12X sparse MLA to report `AttentionCGSupport.NEVER` when `decode_context_parallel_size > 1`. The existing vLLM resolver then downgrades default `FULL_AND_PIECEWISE` to `PIECEWISE` under `VLLM_COMPILE`, keeping attention outside full CUDA graph replay. DCP1 behavior is unchanged.

## Validation

- `python3 -m py_compile vllm/v1/attention/backends/mla/b12x_mla_sparse.py tests/v1/attention/test_sparse_mla_backends.py`
- `git diff --check`
- Runtime repro on current GLM image without patch: DCP4/MTP off/A16, FULL graph captured, short output incoherent (`1zhou $`).
- Runtime control on same image with `--enforce-eager`: DCP4/MTP off/A16 produced coherent short output and coherent `-L -c10000` output.
- Runtime validation with this patched file mounted into the same image: log shows `CUDAGraphMode.FULL_AND_PIECEWISE ... setting cudagraph_mode=PIECEWISE`; only PIECEWISE capture occurs; short output coherent; `python3 /mnt/test.py --port 5331 --model GLM-5.1 --max-tokens 240 -L -c10000` produced multiple coherent iterations with CJK=0.
- Runtime assertion in container: DCP1 returns `UNIFORM_BATCH`, DCP2/DCP4 return `NEVER`.
- GLM-5.1 patched-image correctness smoke covered DCP2, DCP4, DCP8, with MTP off/on where relevant; DCP>1 logs consistently show downgrade to PIECEWISE.
- Full 30-second decode sweeps were recorded for DCP1/2/4/8, MTP off/on, A16 on/off, contexts `0,16k,32k,64k,128k`, concurrency `1,2,4,8,16,32,64`; results are documented in https://github.com/local-inference-lab/rtx6kpro/blob/master/models/glm5.1_v8.md.

`pytest` is not installed on the host or in the current image, so the added pytest test was not executed through pytest in this environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CUDA graph optimization behavior for distributed inference scenarios. Full CUDA graph replay is now properly disabled when using multi-GPU decode context parallelization, preventing performance issues and ensuring reliable execution across different configuration setups.

* **Tests**
  * Enhanced test coverage to validate CUDA graph optimization behavior across various parallel configuration scenarios, ensuring correctness in distributed inference deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->