### PR TITLE
Restore B12X extend indexer prefill

### DIFF
--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -34,8 +34,15 @@ _B12X_COMPRESSED_INDEX_PAGE_WIDTH = _B12X_COMPRESSED_INDEX_PAGE_SIZE * (
 )
 _B12X_COMPRESSED_INDEX_SUPERTILE_K_DEFAULT = 32768
 _B12X_COMPRESSED_INDEX_TILE_BLOCK_K = 512
+_B12X_EXTEND_TOPK_SUPERTILE_K = int(
+    os.environ.get("VLLM_B12X_NSA_EXTEND_TOPK_SUPERTILE_K", "32768")
+)
 # MXFP4 layout: 2 values packed per byte, ue8m0 (1-byte) scale per block of 32.
 MXFP4_BLOCK_SIZE = 32
+
+
+def _b12x_indexer_prefill_mode() -> str:
+    return os.environ.get("VLLM_B12X_INDEXER_PREFILL_MODE", "extend").lower()
 
 
 def _get_b12x_compressed_indexer_supertile_k() -> int:
@@ -242,6 +249,43 @@ def _run_b12x_paged_topk(
     )
 
 
+def _get_b12x_indexer_extend_binding(
+    *,
+    q_fp8: torch.Tensor,
+    topk_tokens: int,
+    total_seq_lens: int,
+    fp8_dtype: torch.dtype,
+    k_start: torch.Tensor,
+    k_end: torch.Tensor,
+):
+    from b12x.integration import (
+        B12XIndexerExtendScratchCaps,
+        plan_indexer_extend_scratch,
+    )
+
+    plan = plan_indexer_extend_scratch(
+        B12XIndexerExtendScratchCaps(
+            device=q_fp8.device,
+            num_q_heads=int(q_fp8.shape[1]),
+            max_q_rows=max(1, int(q_fp8.shape[0])),
+            max_k_rows=max(1, int(total_seq_lens)),
+            topk=int(topk_tokens),
+            k_dtype=fp8_dtype,
+            supertile_k=_B12X_EXTEND_TOPK_SUPERTILE_K,
+        )
+    )
+    scratch = current_workspace_manager().get_simultaneous(
+        *plan.shapes_and_dtypes()
+    )
+    return plan.bind(
+        scratch=scratch,
+        k_start=k_start,
+        k_end=k_end,
+        gather_rows=max(1, int(total_seq_lens)),
+        topk=int(topk_tokens),
+    )
+
+
 def _reserve_b12x_paged_indexer_scratch(
     *,
     q_rows: int,
@@ -436,17 +480,69 @@ def sparse_attn_indexer(
                     int(q_slice.shape[0]),
                     int(chunk.block_table.shape[1]),
                 )
-                _run_b12x_paged_topk(
-                    q_fp8=q_slice.contiguous(),
-                    weights=weights_slice.contiguous(),
-                    kv_cache=kv_cache,
-                    seq_lens=seq_lens,
-                    block_table=block_table,
-                    schedule_metadata=None,
-                    topk_indices=topk_indices,
-                    topk_tokens=topk_tokens,
-                    shared_page_table=True,
-                )
+                q_slice_contig = q_slice.contiguous()
+                weights_slice_contig = weights_slice.contiguous()
+                prefill_mode = _b12x_indexer_prefill_mode()
+                if prefill_mode == "extend":
+                    from b12x.integration import extend_tiled_topk
+
+                    b12x_cu_seqlen_ks = torch.where(
+                        row_has_no_kv,
+                        torch.zeros_like(chunk.cu_seqlen_ks),
+                        chunk.cu_seqlen_ks,
+                    )
+                    b12x_cu_seqlen_ke = torch.where(
+                        row_has_no_kv,
+                        torch.ones_like(chunk.cu_seqlen_ke),
+                        chunk.cu_seqlen_ke,
+                    )
+                    binding = _get_b12x_indexer_extend_binding(
+                        q_fp8=q_slice_contig,
+                        topk_tokens=topk_tokens,
+                        total_seq_lens=chunk.total_seq_lens,
+                        fp8_dtype=fp8_dtype,
+                        k_start=b12x_cu_seqlen_ks,
+                        k_end=b12x_cu_seqlen_ke,
+                    )
+                    scratch = binding.scratch
+                    k_quant = scratch.k_quant[: chunk.total_seq_lens]
+                    k_scale_bytes = scratch.k_scale_bytes[: chunk.total_seq_lens]
+                    if not chunk.skip_kv_gather:
+                        ops.cp_gather_indexer_k_quant_cache(
+                            kv_cache,
+                            k_quant,
+                            k_scale_bytes,
+                            chunk.block_table,
+                            chunk.cu_seq_lens,
+                        )
+                    topk_indices.copy_(
+                        extend_tiled_topk(
+                            q_fp8=q_slice_contig,
+                            weights=weights_slice_contig,
+                            kv_fp8=(
+                                k_quant,
+                                scratch.k_scale[: chunk.total_seq_lens],
+                            ),
+                            binding=binding,
+                        )
+                    )
+                elif prefill_mode == "paged":
+                    _run_b12x_paged_topk(
+                        q_fp8=q_slice_contig,
+                        weights=weights_slice_contig,
+                        kv_cache=kv_cache,
+                        seq_lens=seq_lens,
+                        block_table=block_table,
+                        schedule_metadata=None,
+                        topk_indices=topk_indices,
+                        topk_tokens=topk_tokens,
+                        shared_page_table=True,
+                    )
+                else:
+                    raise RuntimeError(
+                        "Unsupported VLLM_B12X_INDEXER_PREFILL_MODE="
+                        f"{prefill_mode!r}; expected 'extend' or 'paged'."
+                    )
                 topk_indices.masked_fill_(row_has_no_kv[:, None], -1)
                 continue
 


### PR DESCRIPTION
## Summary

This restores the B12X sparse-indexer prefill path to the gather-K + `extend_tiled_topk` flow and keeps the new paged path available behind `VLLM_B12X_INDEXER_PREFILL_MODE=paged`.

The new implementation uses the vLLM-safe eager binding pattern:

- vLLM owns scratch via `current_workspace_manager().get_simultaneous(...)`
- B12X gets an eager `plan.bind(scratch=...)` binding per call
- no `B12XAttentionWorkspace`, `_TPCoreArena`, workspace pools, or cached `workspace.bind_*()` are introduced

Decode remains on the existing paged topk path; only B12X prefill is switched back to extend by default.

## Root Cause

The GLM NVFP4-MTP TP8/KV-fp8 prefill regression came from commit `48d745755` switching prefill from the old gathered-K extend indexer to direct paged topk over the paged KV/indexer cache. Profiling showed the paged topk prefill dominated sparse-indexer time and produced uneven PCIe traffic. Per-rank start skew was low, so this was not a Python/rank lock.

## Validation

Tested on `voipmonitor/vllm:abyssal-abjuration-611a842-a16-dcp` with GLM-5.1 NVFP4-MTP, TP8, DCP1, MTP on, A16 on, KV fp8.

Prefill throughput:

| ctx | current paged | this PR / extend | v5 reference |
| --- | ---: | ---: | ---: |
| 16k | 3,125 tok/s | 4,559 tok/s | 4,622 tok/s |
| 64k | 2,039 tok/s | 3,816 tok/s | 3,992 tok/s |
| 128k | 1,390 tok/s | 3,388 tok/s | 3,385 tok/s |

PCIe dmon uniformity:

| run | PCIe total avg | CV avg | idle frac |
| --- | ---: | ---: | ---: |
| current paged | 157,008 MB/s | 0.899 | 0.288 |
| this PR / extend 16k/64k | 346,973 MB/s | 0.279 | 0.050 |
| v5 reference | 305,430 MB/s | 0.278 | 0.033 |

Also ran a short `/mnt/test.py --port 5329 -L` smoke; first completed response had `CJK characters in output: 0`.

## Note for Luke

This is intentionally not porting the old v5 workspace/arena ownership back into vLLM. It keeps the rule: vLLM path is `plan -> bind(scratch=caller_owned) -> kernel`, fresh per call, CUDA-graph-capturable, no workspace ownership.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance & Optimization**
  * Introduced environment-controlled prefill mode selection to optimize sparse attention operations with improved kernel execution paths.
  * Enhanced memory efficiency through refined scratch buffer allocation.

* **Reliability**
  * Added runtime validation for configuration settings with error handling for unsupported modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->