### PR TITLE
MiMo V2.5 FP4-DFlash: runtime support, acceptance and long-context fixes

### DIFF
--- a/tests/v1/core/test_kv_sharing.py
+++ b/tests/v1/core/test_kv_sharing.py
@@ -1,9 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 
+from vllm.v1.core.kv_cache_utils import get_kv_cache_config_from_groups
 from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheGroupSpec
 from vllm.v1.worker.utils import add_kv_sharing_layers_to_kv_cache_groups
 
@@ -103,3 +106,28 @@ def test_initialize_kv_cache_for_kv_sharing_no_attn_groups():
     assert len(kv_cache_groups) == 2
     assert kv_cache_groups[0].layer_names == ["model.layers.0", "model.layers.2"]
     assert kv_cache_groups[1].layer_names == ["model.layers.1", "model.layers.3"]
+
+
+def test_dflash_draft_kv_groups_keep_hybrid_tensor_sharing():
+    spec = new_kv_cache_spec()
+    num_blocks = 8
+    vllm_config = SimpleNamespace(
+        speculative_config=SimpleNamespace(method="dflash"),
+        cache_config=SimpleNamespace(num_gpu_blocks_override=None),
+    )
+    kv_cache_groups = [
+        KVCacheGroupSpec(["model.layers.0", "model.layers.1"], spec),
+        KVCacheGroupSpec(["model.layers.2", "model.layers.3"], spec),
+    ]
+
+    kv_cache_config = get_kv_cache_config_from_groups(
+        vllm_config=vllm_config,
+        kv_cache_groups=kv_cache_groups,
+        available_memory=spec.page_size_bytes * 2 * num_blocks,
+    )
+
+    assert kv_cache_config.num_blocks == num_blocks
+    assert [tensor.shared_by for tensor in kv_cache_config.kv_cache_tensors] == [
+        ["model.layers.0", "model.layers.2"],
+        ["model.layers.1", "model.layers.3"],
+    ]

--- a/tests/v1/spec_decode/test_dflash_swa.py
+++ b/tests/v1/spec_decode/test_dflash_swa.py
@@ -1,0 +1,203 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import torch
+
+from vllm.config import SpeculativeConfig
+from vllm.model_executor.layers.attention import Attention
+from vllm.model_executor.models.qwen3_dflash import DFlashAttention
+from vllm.transformers_utils.configs.speculators import SpeculatorsConfig
+from vllm.v1.attention.backend import CommonAttentionMetadata
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    SlidingWindowSpec,
+)
+from vllm.v1.spec_decode.dflash import DFlashProposer
+
+
+class _FakeBuilder:
+    def __init__(
+        self, kv_cache_spec=None, layer_names=None, vllm_config=None, device=None
+    ):
+        self.kv_cache_spec = kv_cache_spec
+        self.layer_names = layer_names
+
+    def build_for_drafting(self, common_attn_metadata, draft_index):
+        return SimpleNamespace(
+            causal=common_attn_metadata.causal,
+            block_table_tensor=common_attn_metadata.block_table_tensor,
+            slot_mapping=common_attn_metadata.slot_mapping,
+        )
+
+
+class _FakeAttentionGroup:
+    def __init__(self, layer_names, kv_cache_group_id=0):
+        self.layer_names = layer_names
+        self.kv_cache_group_id = kv_cache_group_id
+        self._builder = _FakeBuilder()
+
+    def get_metadata_builder(self):
+        return self._builder
+
+
+def _make_cad(block_table, slot_mapping) -> CommonAttentionMetadata:
+    return CommonAttentionMetadata(
+        query_start_loc=torch.tensor([0, 2], dtype=torch.int32),
+        query_start_loc_cpu=torch.tensor([0, 2], dtype=torch.int32),
+        seq_lens=torch.tensor([2], dtype=torch.int32),
+        num_reqs=1,
+        num_actual_tokens=2,
+        max_query_len=2,
+        max_seq_len=2,
+        block_table_tensor=block_table,
+        slot_mapping=slot_mapping,
+        causal=False,
+    )
+
+
+def test_dflash_speculators_preserves_swa_config():
+    layer_types = [
+        "sliding_attention",
+        "sliding_attention",
+        "full_attention",
+    ]
+    config = {
+        "speculators_model_type": "dflash",
+        "transformer_layer_config": {
+            "num_hidden_layers": len(layer_types),
+            "sliding_window": None,
+        },
+        "draft_vocab_size": 100,
+        "target_hidden_size": 64,
+        "aux_hidden_state_layer_ids": [0, 1, 2],
+        "mask_token_id": 99,
+        "layer_types": layer_types,
+        "use_sliding_window": True,
+        "sliding_window": 2048,
+        "max_window_layers": len(layer_types),
+    }
+
+    hf_config = SpeculatorsConfig.extract_transformers_pre_trained_config(config)
+
+    assert hf_config["layer_types"] == layer_types
+    assert hf_config["use_sliding_window"] is True
+    assert hf_config["sliding_window"] == 2048
+    assert hf_config["max_window_layers"] == len(layer_types)
+    assert hf_config["eagle_aux_hidden_state_layer_ids"] == [1, 2, 3]
+    assert hf_config["dflash_config"]["target_layer_ids"] == [0, 1, 2]
+
+
+def _compute_dflash_hash(hf_config: SimpleNamespace) -> str:
+    config = object.__new__(SpeculativeConfig)
+    config.method = "dflash"
+    config.draft_model_config = SimpleNamespace(hf_config=hf_config)
+    return config.compute_hash()
+
+
+def test_dflash_compile_hash_uses_checkpoint_layer_id_semantics():
+    dflash_hash = _compute_dflash_hash(
+        SimpleNamespace(dflash_config={"target_layer_ids": [0, 2]})
+    )
+    shifted_aux_hash = _compute_dflash_hash(
+        SimpleNamespace(eagle_aux_hidden_state_layer_ids=[1, 3])
+    )
+    different_hash = _compute_dflash_hash(
+        SimpleNamespace(dflash_config={"target_layer_ids": [0, 3]})
+    )
+
+    assert dflash_hash == shifted_aux_hash
+    assert dflash_hash != different_hash
+
+
+def test_dflash_swa_layers_use_full_kv_cache_spec(monkeypatch):
+    sliding_spec = SlidingWindowSpec(
+        block_size=16,
+        num_kv_heads=1,
+        head_size=8,
+        dtype=torch.float16,
+        sliding_window=4,
+    )
+    monkeypatch.setattr(
+        Attention,
+        "get_kv_cache_spec",
+        lambda self, vllm_config: sliding_spec,
+    )
+
+    spec = DFlashAttention.get_kv_cache_spec(
+        object.__new__(DFlashAttention), SimpleNamespace()
+    )
+
+    assert isinstance(spec, FullAttentionSpec)
+    assert spec.block_size == sliding_spec.block_size
+    assert spec.num_kv_heads == sliding_spec.num_kv_heads
+    assert spec.head_size == sliding_spec.head_size
+    assert spec.sliding_window is None
+
+
+def test_dflash_swa_layers_use_causal_metadata():
+    proposer = object.__new__(DFlashProposer)
+    proposer.model = SimpleNamespace(sliding_attention_layer_names={"layer.sw"})
+    proposer.draft_attn_groups = [_FakeAttentionGroup(["layer.sw", "layer.full"])]
+    proposer.kv_cache_gid = 0
+    proposer._draft_kv_cache_group_ids = [0]
+    proposer._draft_layer_to_kv_cache_gid = {
+        "layer.sw": 0,
+        "layer.full": 0,
+    }
+    proposer._draft_block_tables = {}
+    cad = _make_cad(
+        torch.empty(1, 1, dtype=torch.int32),
+        torch.empty(2, dtype=torch.int64),
+    )
+    proposer._slot_mapping_buffers_by_gid = {0: (cad.slot_mapping, cad.slot_mapping)}
+
+    per_group, per_layer = DFlashProposer.build_per_group_and_layer_attn_metadata(
+        proposer, cad
+    )
+
+    assert per_group[0].causal is False
+    assert per_layer["layer.sw"].causal is True
+    assert per_layer["layer.full"].causal is False
+
+
+def test_dflash_metadata_uses_per_kv_group_slot_mapping():
+    proposer = object.__new__(DFlashProposer)
+    proposer.model = SimpleNamespace(sliding_attention_layer_names={"layer.sw"})
+    proposer.draft_attn_groups = [
+        _FakeAttentionGroup(["layer.full"], kv_cache_group_id=1),
+        _FakeAttentionGroup(["layer.sw"], kv_cache_group_id=2),
+    ]
+    proposer.kv_cache_gid = 1
+    proposer._draft_kv_cache_group_ids = [1, 2]
+    proposer._draft_layer_to_kv_cache_gid = {
+        "layer.full": 1,
+        "layer.sw": 2,
+    }
+
+    full_block_table = torch.tensor([[11, 12]], dtype=torch.int32)
+    sw_block_table = torch.tensor([[21, 22]], dtype=torch.int32)
+    full_slots = torch.tensor([111, 112], dtype=torch.int64)
+    sw_slots = torch.tensor([211, 212], dtype=torch.int64)
+
+    base_cad = _make_cad(full_block_table, full_slots)
+    proposer._draft_block_tables = {
+        1: full_block_table,
+        2: sw_block_table,
+    }
+    proposer._slot_mapping_buffers_by_gid = {
+        1: (full_slots, full_slots),
+        2: (sw_slots, sw_slots),
+    }
+
+    _, per_layer = DFlashProposer.build_per_group_and_layer_attn_metadata(
+        proposer, base_cad
+    )
+
+    assert per_layer["layer.full"].block_table_tensor is full_block_table
+    torch.testing.assert_close(per_layer["layer.full"].slot_mapping, full_slots)
+    assert per_layer["layer.full"].causal is False
+    assert per_layer["layer.sw"].block_table_tensor is sw_block_table
+    torch.testing.assert_close(per_layer["layer.sw"].slot_mapping, sw_slots)
+    assert per_layer["layer.sw"].causal is True

--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -722,6 +722,41 @@ def test_kv_cache_stride_order(monkeypatch, model_runner):
             assert all(not kv.is_contiguous() for kv in model_runner.kv_caches)
 
 
+@pytest.mark.parametrize(
+    "physical_order",
+    [
+        ("block", "kv", "token", "head", "dim"),
+        ("block", "kv", "head", "token", "dim"),
+    ],
+)
+def test_kv_major_cache_can_share_block_major_raw_tensor(physical_order):
+    kv_cache_shape = (2, 3, 4, 2, 8)
+    _, num_blocks, block_size, num_kv_heads, head_size = kv_cache_shape
+    block_elems = block_size * num_kv_heads * head_size
+    raw_tensor = torch.arange(2 * num_blocks * block_elems)
+    public_order = ("kv", "block", "token", "head", "dim")
+    dim_sizes = dict(zip(public_order, kv_cache_shape))
+    expected_strides = {}
+    stride = 1
+    for dim in reversed(physical_order):
+        expected_strides[dim] = stride
+        stride *= dim_sizes[dim]
+
+    kv_cache = GPUModelRunner._view_kv_cache_with_physical_order(
+        raw_tensor,
+        kv_cache_shape,
+        public_order,
+        physical_order,
+    )
+
+    assert kv_cache.shape == kv_cache_shape
+    assert kv_cache.stride() == tuple(expected_strides[dim] for dim in public_order)
+    assert kv_cache[0, 0, 0, 0, 0] == raw_tensor[0]
+    assert kv_cache[1, 0, 0, 0, 0] == raw_tensor[block_elems]
+    assert kv_cache[0, 1, 0, 0, 0] == raw_tensor[2 * block_elems]
+    assert kv_cache[1, 1, 0, 0, 0] == raw_tensor[3 * block_elems]
+
+
 def test_update_config(model_runner):
     # Simple update
     model_runner.update_config({"load_config": {"load_format": "dummy"}})

--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -1424,43 +1424,67 @@ def test_hybrid_cache_integration(default_vllm_config, dist_init):
 
 
 def test_is_uniform_decode() -> None:
+    # Helper: arrays where every request has finished prefilling, so the
+    # prefill guard is satisfied and only the (max, num_tokens, num_reqs)
+    # checks decide the result.
+    def all_decodes(num_reqs: int) -> tuple[np.ndarray, np.ndarray]:
+        prompt = np.full(num_reqs, 8, dtype=np.int32)
+        computed = np.full(num_reqs, 8, dtype=np.int32)
+        return computed, prompt
+
     # Normal
+    computed, prompt = all_decodes(16)
     assert GPUModelRunner._is_uniform_decode(
         max_num_scheduled_tokens=1,
         uniform_decode_query_len=1,
         num_tokens=16,
         num_reqs=16,
+        num_computed_tokens_cpu=computed,
+        num_prompt_tokens_cpu=prompt,
     )
     assert not GPUModelRunner._is_uniform_decode(
         max_num_scheduled_tokens=2,
         uniform_decode_query_len=1,
         num_tokens=16,
         num_reqs=16,
+        num_computed_tokens_cpu=computed,
+        num_prompt_tokens_cpu=prompt,
     )
+    computed15, prompt15 = all_decodes(15)
     assert not GPUModelRunner._is_uniform_decode(
         max_num_scheduled_tokens=1,
         uniform_decode_query_len=1,
         num_tokens=16,
         num_reqs=15,
+        num_computed_tokens_cpu=computed15,
+        num_prompt_tokens_cpu=prompt15,
     )
     # Spec decoding
+    computed6, prompt6 = all_decodes(6)
     assert GPUModelRunner._is_uniform_decode(
         max_num_scheduled_tokens=5,
         uniform_decode_query_len=5,
         num_tokens=30,
         num_reqs=6,
+        num_computed_tokens_cpu=computed6,
+        num_prompt_tokens_cpu=prompt6,
     )
     assert not GPUModelRunner._is_uniform_decode(
         max_num_scheduled_tokens=5,
         uniform_decode_query_len=4,
         num_tokens=30,
         num_reqs=6,
+        num_computed_tokens_cpu=computed6,
+        num_prompt_tokens_cpu=prompt6,
     )
+    computed7, prompt7 = all_decodes(7)
     assert not GPUModelRunner._is_uniform_decode(
         max_num_scheduled_tokens=5,
         uniform_decode_query_len=5,
         num_tokens=30,
         num_reqs=7,
+        num_computed_tokens_cpu=computed7,
+        num_prompt_tokens_cpu=prompt7,
     )
     # Force uniform decode
     assert GPUModelRunner._is_uniform_decode(
@@ -1468,6 +1492,8 @@ def test_is_uniform_decode() -> None:
         uniform_decode_query_len=1,
         num_tokens=16,
         num_reqs=16,
+        num_computed_tokens_cpu=computed,
+        num_prompt_tokens_cpu=prompt,
         force_uniform_decode=True,
     )
     assert GPUModelRunner._is_uniform_decode(
@@ -1475,6 +1501,8 @@ def test_is_uniform_decode() -> None:
         uniform_decode_query_len=1,
         num_tokens=16,
         num_reqs=16,
+        num_computed_tokens_cpu=computed,
+        num_prompt_tokens_cpu=prompt,
         force_uniform_decode=True,
     )
     assert GPUModelRunner._is_uniform_decode(
@@ -1482,6 +1510,8 @@ def test_is_uniform_decode() -> None:
         uniform_decode_query_len=1,
         num_tokens=16,
         num_reqs=15,
+        num_computed_tokens_cpu=computed15,
+        num_prompt_tokens_cpu=prompt15,
         force_uniform_decode=True,
     )
     assert not GPUModelRunner._is_uniform_decode(
@@ -1489,6 +1519,8 @@ def test_is_uniform_decode() -> None:
         uniform_decode_query_len=1,
         num_tokens=16,
         num_reqs=16,
+        num_computed_tokens_cpu=computed,
+        num_prompt_tokens_cpu=prompt,
         force_uniform_decode=False,
     )
     assert not GPUModelRunner._is_uniform_decode(
@@ -1496,6 +1528,8 @@ def test_is_uniform_decode() -> None:
         uniform_decode_query_len=1,
         num_tokens=16,
         num_reqs=16,
+        num_computed_tokens_cpu=computed,
+        num_prompt_tokens_cpu=prompt,
         force_uniform_decode=False,
     )
     assert not GPUModelRunner._is_uniform_decode(
@@ -1503,7 +1537,48 @@ def test_is_uniform_decode() -> None:
         uniform_decode_query_len=1,
         num_tokens=16,
         num_reqs=15,
+        num_computed_tokens_cpu=computed15,
+        num_prompt_tokens_cpu=prompt15,
         force_uniform_decode=False,
+    )
+    # Prefill guard: a request still prefilling (num_computed_tokens <
+    # num_prompt_tokens) should not be classified as uniform decode.
+    # First-chunk prefill (num_computed_tokens == 0).
+    assert not GPUModelRunner._is_uniform_decode(
+        max_num_scheduled_tokens=5,
+        uniform_decode_query_len=5,
+        num_tokens=10,
+        num_reqs=2,
+        num_computed_tokens_cpu=np.array([0, 100]),
+        num_prompt_tokens_cpu=np.array([200, 100]),
+    )
+    # Subsequent-chunk prefill (num_computed_tokens > 0 but still < prompt).
+    assert not GPUModelRunner._is_uniform_decode(
+        max_num_scheduled_tokens=5,
+        uniform_decode_query_len=5,
+        num_tokens=10,
+        num_reqs=2,
+        num_computed_tokens_cpu=np.array([50, 100]),
+        num_prompt_tokens_cpu=np.array([200, 100]),
+    )
+    # All-decode batch (every request finished its prompt) is uniform.
+    assert GPUModelRunner._is_uniform_decode(
+        max_num_scheduled_tokens=5,
+        uniform_decode_query_len=5,
+        num_tokens=10,
+        num_reqs=2,
+        num_computed_tokens_cpu=np.array([50, 100]),
+        num_prompt_tokens_cpu=np.array([50, 100]),
+    )
+    # force_uniform_decode=True overrides the prefill guard.
+    assert GPUModelRunner._is_uniform_decode(
+        max_num_scheduled_tokens=5,
+        uniform_decode_query_len=5,
+        num_tokens=10,
+        num_reqs=2,
+        num_computed_tokens_cpu=np.array([0, 100]),
+        num_prompt_tokens_cpu=np.array([200, 100]),
+        force_uniform_decode=True,
     )
 
 

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -384,6 +384,14 @@ class SpeculativeConfig:
                 "eagle_aux_hidden_state_layer_ids",
                 None,
             )
+            if not layer_ids:
+                dflash_config = getattr(
+                    self.draft_model_config.hf_config, "dflash_config", None
+                )
+                if dflash_config and isinstance(dflash_config, dict):
+                    layer_ids = [
+                        i + 1 for i in dflash_config.get("target_layer_ids", [])
+                    ]
             if layer_ids is not None:
                 # Convert to tuple to make it hashable
                 factors.append(tuple(layer_ids))
@@ -1223,6 +1231,10 @@ class SpeculativeConfig:
 
     def use_eagle(self) -> bool:
         return self.method in ("eagle", "eagle3", "mtp", "dflash")
+
+    def requires_eagle_cache_drop(self) -> bool:
+        """Whether prefix cache hits must drop one block for hidden states."""
+        return self.use_eagle() and not self.use_dflash()
 
     def use_dflash(self) -> bool:
         return self.method == "dflash"

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -369,6 +369,9 @@ class Attention(nn.Module, AttentionLayerBase):
             if block_n is not None:
                 extra_impl_args.setdefault("block_n", block_n)
 
+        if self.attn_backend.get_name() == "B12X_PAGED_ATTN":
+            extra_impl_args.setdefault("head_size_v", self.head_size_v)
+
         impl_cls = self.attn_backend.get_impl_cls()
         self.impl = impl_cls(  # type: ignore[assignment]  # impl_cls always returns an AttentionImpl subclass
             num_heads,

--- a/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutlass_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutlass_moe.py
@@ -97,7 +97,26 @@ class FlashInferExperts(mk.FusedMoEExpertsModular):
         self.max_capture_size = (
             get_current_vllm_config().compilation_config.max_cudagraph_capture_size
         )
+        self.model_type = getattr(
+            get_current_vllm_config().model_config.hf_config,
+            "model_type",
+            None,
+        )
+        self.gemm1_alpha: torch.Tensor | None = None
+        self.gemm1_beta: torch.Tensor | None = None
         self.gemm1_clamp_limit: torch.Tensor | None = None
+        if quant_config.gemm1_alpha is not None:
+            self.gemm1_alpha = torch.tensor(
+                [quant_config.gemm1_alpha] * self.num_experts,
+                dtype=torch.float32,
+                device=self.device,
+            )
+        if quant_config.gemm1_beta is not None:
+            self.gemm1_beta = torch.tensor(
+                [quant_config.gemm1_beta] * self.num_experts,
+                dtype=torch.float32,
+                device=self.device,
+            )
         if quant_config.gemm1_clamp_limit is not None:
             self.gemm1_clamp_limit = torch.tensor(
                 [quant_config.gemm1_clamp_limit] * self.num_experts,
@@ -106,19 +125,37 @@ class FlashInferExperts(mk.FusedMoEExpertsModular):
             )
 
         if quant_config.weight_quant_dtype == "mxfp4":
-            # This value is used specifically for gpt-oss,
-            # Need to revisit this for other models
-            self.gemm1_alpha = torch.tensor(
-                [1.702] * self.num_experts, dtype=torch.float32, device=self.device
-            )
-            self.gemm1_beta = torch.tensor(
-                [1.0] * self.num_experts, dtype=torch.float32, device=self.device
-            )
-            if self.gemm1_clamp_limit is None:
+            # GPT-OSS uses a non-standard clamped SwiGLU. Other MXFP4 MoE
+            # models should use the standard activation unless their quant
+            # config explicitly supplies these parameters.
+            if self.model_type == "gpt_oss":
+                if self.gemm1_alpha is None:
+                    self.gemm1_alpha = torch.tensor(
+                        [1.702] * self.num_experts,
+                        dtype=torch.float32,
+                        device=self.device,
+                    )
+                if self.gemm1_beta is None:
+                    self.gemm1_beta = torch.tensor(
+                        [1.0] * self.num_experts,
+                        dtype=torch.float32,
+                        device=self.device,
+                    )
+            if self.model_type == "gpt_oss" and self.gemm1_clamp_limit is None:
                 self.gemm1_clamp_limit = torch.tensor(
                     [7.0] * self.num_experts,
                     dtype=torch.float32,
                     device=self.device,
+                )
+            elif (
+                self.gemm1_alpha is None
+                and self.gemm1_beta is None
+                and self.gemm1_clamp_limit is None
+            ):
+                logger.info_once(
+                    "Using standard SwiGLU parameters for FlashInfer MXFP4 MoE "
+                    "(model_type=%s).",
+                    self.model_type,
                 )
             if quant_config.quant_dtype == "mxfp8":
                 self.fake_input_scale = torch.ones(
@@ -326,9 +363,6 @@ class FlashInferExperts(mk.FusedMoEExpertsModular):
         elif self.weight_quant_dtype == "mxfp4":
             assert self.w1_scale is not None and self.w2_scale is not None
             assert w1.is_contiguous() and w2.is_contiguous()
-            assert self.gemm1_alpha is not None
-            assert self.gemm1_beta is not None
-            assert self.gemm1_clamp_limit is not None
             assert topk_ids.is_contiguous()
 
             fc1_expert_biases = self.w1_bias

--- a/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
@@ -1502,6 +1502,101 @@ def convert_weight_to_mxfp4_moe_kernel_format(
             w2_bias,
         )
 
+    elif mxfp4_backend in (
+        Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_BF16,
+        Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_MXFP8,
+    ):
+        # Native GLM/DeepSeek/MiMo MXFP4 loading produces contiguous
+        # [w1/gate, w3/up] rows. FlashInfer Cutlass consumes the opposite
+        # SwiGLU order, so swap the two halves without GPT-OSS de-interleave.
+        logger.info_once(
+            "Using contiguous w13 layout for FlashInfer Cutlass MXFP4 MoE."
+        )
+        w13_w = w13_weight.data
+        w1_w = w13_w[:, :intermediate_size, :]
+        w3_w = w13_w[:, intermediate_size:, :]
+        w13_weight_swapped = torch.cat([w3_w, w1_w], dim=1)
+
+        if w13_bias is None:
+            w13_bias = torch.zeros(
+                num_experts,
+                2 * intermediate_size,
+                dtype=torch.float32,
+                device=w13_weight.device,
+            )
+        else:
+            w13_bias = w13_bias.data.to(torch.float32)
+        if w2_bias is None:
+            w2_bias = torch.zeros(
+                num_experts,
+                hidden_size,
+                dtype=torch.float32,
+                device=w2_weight.device,
+            )
+        else:
+            w2_bias = w2_bias.data.to(torch.float32)
+        b1 = w13_bias[:, :intermediate_size]
+        b3 = w13_bias[:, intermediate_size:]
+        w13_bias_swapped = torch.cat([b3, b1], dim=-1).to(torch.bfloat16)
+        w2_bias = w2_bias.to(torch.bfloat16)
+
+        w13_s = w13_weight_scale.data
+        s1 = w13_s[:, :intermediate_size, :]
+        s3 = w13_s[:, intermediate_size:, :]
+        w13_scale_swapped = torch.cat([s3, s1], dim=1)
+
+        if mxfp4_backend == Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_MXFP8:
+            from flashinfer import block_scale_interleave
+
+            orig_shape = w13_scale_swapped.shape
+            w13_scale_interleaved = block_scale_interleave(
+                w13_scale_swapped.view(torch.uint8)
+            ).reshape(orig_shape)
+
+            w2_s = w2_weight_scale.data
+            orig_shape = w2_s.shape
+            w2_scale_interleaved = block_scale_interleave(
+                w2_s.view(torch.uint8)
+            ).reshape(orig_shape)
+
+            return (
+                w13_weight_swapped,
+                w2_weight.data,
+                w13_scale_interleaved,
+                w2_scale_interleaved,
+                w13_bias_swapped,
+                w2_bias,
+            )
+
+        assert mxfp4_backend == Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_BF16
+
+        from flashinfer.fused_moe import (
+            interleave_moe_scales_for_sm90_mixed_gemm,
+            interleave_moe_weights_for_sm90_mixed_gemm,
+        )
+
+        w13_weight_interleaved = interleave_moe_weights_for_sm90_mixed_gemm(
+            w13_weight_swapped.contiguous(), "fp4"
+        )
+        w2_weight_interleaved = interleave_moe_weights_for_sm90_mixed_gemm(
+            w2_weight.data.contiguous(), "fp4"
+        )
+        w31_scales_interleaved = interleave_moe_scales_for_sm90_mixed_gemm(
+            w13_scale_swapped.to(torch.uint8)
+        )
+        w2_scale_interleaved = interleave_moe_scales_for_sm90_mixed_gemm(
+            w2_weight_scale.data.to(torch.uint8)
+        )
+
+        return (
+            w13_weight_interleaved,
+            w2_weight_interleaved,
+            w31_scales_interleaved,
+            w2_scale_interleaved,
+            w13_bias_swapped,
+            w2_bias,
+        )
+
     elif mxfp4_backend in TRITON_BACKENDS:
         from triton_kernels.matmul_ogs import FlexCtx, PrecisionConfig
 
@@ -1567,7 +1662,7 @@ def convert_weight_to_mxfp4_moe_kernel_format(
     else:
         raise ValueError(
             f"Unsupported mxfp4_backend for Mxfp4MoEMethod: {mxfp4_backend}. "
-            f"Expected TRTLLM, Triton, AITER, or XPU backend."
+            f"Expected TRTLLM, Triton, AITER, XPU, or FLASHINFER_CUTLASS backend."
         )
 
 

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -106,6 +106,7 @@ class Fp8Config(QuantizationConfig):
         activation_scheme: str = "dynamic",
         ignored_layers: list[str] | None = None,
         weight_block_size: list[int] | None = None,
+        store_dtype: str | None = None,
     ) -> None:
         super().__init__()
 
@@ -133,6 +134,7 @@ class Fp8Config(QuantizationConfig):
                     f"{activation_scheme} activation scheme."
                 )
         self.weight_block_size = weight_block_size
+        self.store_dtype = store_dtype
         self.use_deep_gemm: bool | None = None
 
     @classmethod
@@ -162,6 +164,7 @@ class Fp8Config(QuantizationConfig):
         activation_scheme = cls.get_from_keys(config, ["activation_scheme"])
         ignored_layers = cls.get_from_keys_or(config, ["ignored_layers"], None)
         weight_block_size = cls.get_from_keys_or(config, ["weight_block_size"], None)
+        store_dtype = cls.get_from_keys_or(config, ["store_dtype"], None)
         if not ignored_layers:
             ignored_layers = cls.get_from_keys_or(
                 config, ["modules_to_not_convert"], None
@@ -171,6 +174,7 @@ class Fp8Config(QuantizationConfig):
             activation_scheme=activation_scheme,
             ignored_layers=ignored_layers,
             weight_block_size=weight_block_size,
+            store_dtype=store_dtype,
         )
 
     def get_quant_method(
@@ -198,6 +202,16 @@ class Fp8Config(QuantizationConfig):
                 fused_mapping=self.packed_modules_mapping,
             ):
                 return UnquantizedFusedMoEMethod(layer.moe_config)
+            if self.store_dtype == "mxfp4":
+                from vllm.model_executor.layers.quantization.mxfp4 import (
+                    GptOssMxfp4MoEMethod,
+                )
+
+                logger.info_once(
+                    "Using MXFP4 MoE method for FP8 checkpoint with "
+                    "store_dtype=mxfp4."
+                )
+                return GptOssMxfp4MoEMethod(layer.moe_config)
             if self.is_checkpoint_fp8_serialized:
                 moe_quant_method = Fp8MoEMethod(self, layer)
             else:

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -209,7 +209,14 @@ class Fp8Config(QuantizationConfig):
                 )
 
                 moe_backend = layer.moe_config.moe_backend
+                # FP8 checkpoints with store_dtype=mxfp4 (GLM/DeepSeek/MiMo
+                # style) use the standard SwiGLU. GptOssMxfp4MoEMethod
+                # hardcodes the GPT-OSS clamped activation
+                # (gemm1_alpha=1.702, beta=1.0, swiglu_limit=7.0); the B12X
+                # W4A16 kernel honors swiglu_limit and would clamp gate/up at
+                # +-7 in every MoE layer, distorting long generations.
                 if moe_backend in {
+                    "b12x",
                     "deep_gemm",
                     "flashinfer_cutlass",
                     "flashinfer_cutlass_afp8",

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -205,11 +205,29 @@ class Fp8Config(QuantizationConfig):
             if self.store_dtype == "mxfp4":
                 from vllm.model_executor.layers.quantization.mxfp4 import (
                     GptOssMxfp4MoEMethod,
+                    Mxfp4MoEMethod,
                 )
 
+                moe_backend = layer.moe_config.moe_backend
+                if moe_backend in {
+                    "deep_gemm",
+                    "flashinfer_cutlass",
+                    "flashinfer_cutlass_afp8",
+                    "flashinfer_trtllm",
+                    "flashinfer_trtllm_afp8",
+                }:
+                    logger.info_once(
+                        "Using DeepSeek-style MXFP4 MoE method for FP8 "
+                        "checkpoint with store_dtype=mxfp4 and "
+                        "moe_backend=%s.",
+                        moe_backend,
+                    )
+                    return Mxfp4MoEMethod(layer.moe_config)
+
                 logger.info_once(
-                    "Using MXFP4 MoE method for FP8 checkpoint with "
-                    "store_dtype=mxfp4."
+                    "Using GPT-OSS-style MXFP4 MoE method for FP8 "
+                    "checkpoint with store_dtype=mxfp4 and moe_backend=%s.",
+                    moe_backend,
                 )
                 return GptOssMxfp4MoEMethod(layer.moe_config)
             if self.is_checkpoint_fp8_serialized:

--- a/vllm/model_executor/models/mimo_v2.py
+++ b/vllm/model_executor/models/mimo_v2.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import os
 from collections.abc import Iterable
 from itertools import islice
 
@@ -47,9 +48,6 @@ from vllm.model_executor.model_loader.weight_utils import (
 from vllm.model_executor.models.utils import sequence_parallel_chunk
 from vllm.sequence import IntermediateTensors
 from vllm.v1.attention.backend import AttentionType
-from vllm.v1.attention.backends.flash_attn_diffkv import (
-    FlashAttentionDiffKVBackend,
-)
 
 from .interfaces import MixtureOfExperts, SupportsPP
 from .utils import (
@@ -284,6 +282,9 @@ class MiMoV2Attention(nn.Module):
             },
         )
 
+        if os.getenv("VLLM_MIMO_DISABLE_ATTENTION_SINKS") == "1":
+            add_swa_attention_sink_bias = False
+
         self.attention_sink_bias = (
             torch.nn.Parameter(torch.empty(self.num_heads), requires_grad=False)
             if add_swa_attention_sink_bias
@@ -292,13 +293,30 @@ class MiMoV2Attention(nn.Module):
 
         sliding_window = sliding_window_size if sliding_window_size > -1 else None
 
-        # Use DiffKV backend when V has a different head dim than K
-        if self.v_head_dim != self.head_dim:
-            FlashAttentionDiffKVBackend.set_head_size_v(self.v_head_dim)
-            attn_backend = FlashAttentionDiffKVBackend
-            logger.info_once("Using FlashAttentionDiffKVBackend for attention.")
-        else:
-            attn_backend = None
+        # FA2 paged attention expects K and V caches to have the same head dim.
+        # MiMo has head_dim=192 and v_head_dim=128, so pad V for standard FA/
+        # Triton-style cache layouts and slice the output back before o_proj.
+        configured_backend = get_current_vllm_config().attention_config.backend
+        use_flashinfer = (
+            configured_backend is not None and configured_backend.name == "FLASHINFER"
+        )
+        use_b12x_paged = (
+            configured_backend is not None
+            and configured_backend.name == "B12X_PAGED_ATTN"
+        )
+        if use_b12x_paged:
+            from vllm.v1.attention.backends.b12x_paged_attn import (
+                B12XPagedAttentionBackend,
+            )
+
+            B12XPagedAttentionBackend.set_head_size_v(self.v_head_dim)
+        self.pad_value_for_fa = (
+            self.v_head_dim != self.head_dim
+            and not use_flashinfer
+            and not use_b12x_paged
+        )
+        attn_head_size_v = self.head_dim if self.pad_value_for_fa else self.v_head_dim
+        attn_backend = None
 
         self.attn = Attention(
             self.num_heads,
@@ -312,7 +330,7 @@ class MiMoV2Attention(nn.Module):
             prefix=f"{prefix}.attn",
             sinks=self.attention_sink_bias,
             attn_backend=attn_backend,
-            head_size_v=self.v_head_dim,
+            head_size_v=attn_head_size_v,
         )
 
     def forward(
@@ -328,7 +346,18 @@ class MiMoV2Attention(nn.Module):
         if self.v_scale is not None:
             v = v * self.v_scale
 
+        if self.pad_value_for_fa:
+            v = torch.nn.functional.pad(
+                v.view(-1, self.num_kv_heads, self.v_head_dim),
+                [0, self.head_dim - self.v_head_dim],
+                value=0,
+            ).reshape(-1, self.num_kv_heads * self.head_dim)
+
         attn_output = self.attn(q, k, v)
+        if self.pad_value_for_fa:
+            attn_output = attn_output.view(-1, self.num_heads, self.head_dim)[
+                ..., : self.v_head_dim
+            ].reshape(-1, self.num_heads * self.v_head_dim)
 
         output, _ = self.o_proj(attn_output)
         return output

--- a/vllm/model_executor/models/mimo_v2.py
+++ b/vllm/model_executor/models/mimo_v2.py
@@ -49,7 +49,12 @@ from vllm.model_executor.models.utils import sequence_parallel_chunk
 from vllm.sequence import IntermediateTensors
 from vllm.v1.attention.backend import AttentionType
 
-from .interfaces import MixtureOfExperts, SupportsPP
+from .interfaces import (
+    EagleModelMixin,
+    MixtureOfExperts,
+    SupportsEagle3,
+    SupportsPP,
+)
 from .utils import (
     AutoWeightsLoader,
     PPMissingLayer,
@@ -61,6 +66,12 @@ from .utils import (
 )
 
 logger = init_logger(__name__)
+
+# Escape hatch for A/B testing the DFlash aux-feature fix: set to 1 to restore
+# the old behavior of capturing the last aux hidden state before final norm.
+_DFLASH_PRENORM_LAST_AUX = (
+    os.environ.get("VLLM_DFLASH_PRENORM_LAST_AUX", "0") == "1"
+)
 
 
 class MiMoV2MLP(nn.Module):
@@ -471,7 +482,7 @@ class MiMoV2FlashDecoderLayer(nn.Module):
 
 
 @support_torch_compile
-class MiMoV2Model(nn.Module):
+class MiMoV2Model(nn.Module, EagleModelMixin):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
 
@@ -534,10 +545,26 @@ class MiMoV2Model(nn.Module):
             hidden_states = intermediate_tensors["hidden_states"]
             residual = intermediate_tensors["residual"]
 
-        for idx, layer in enumerate(
-            islice(self.layers, self.start_layer, self.end_layer)
+        aux_hidden_states = self._maybe_add_hidden_state([], 0, hidden_states, residual)
+        # The DFlash reference extracts HF `output_hidden_states` entries,
+        # where the entry after the FINAL layer is the post-final-norm hidden
+        # state (all other entries are raw residual-stream values). Mirror
+        # that: capture the last aux layer after self.norm below.
+        num_layers = len(self.layers)
+        post_norm_final_aux = (
+            num_layers in getattr(self, "aux_hidden_state_layers", ())
+            and not _DFLASH_PRENORM_LAST_AUX
+        )
+        for layer_idx, layer in enumerate(
+            islice(self.layers, self.start_layer, self.end_layer),
+            start=self.start_layer,
         ):
             hidden_states, residual = layer(positions, hidden_states, residual)
+            if post_norm_final_aux and layer_idx + 1 == num_layers:
+                continue
+            self._maybe_add_hidden_state(
+                aux_hidden_states, layer_idx + 1, hidden_states, residual
+            )
 
         if not get_pp_group().is_last_rank:
             return IntermediateTensors(
@@ -545,6 +572,11 @@ class MiMoV2Model(nn.Module):
             )
 
         hidden_states, _ = self.norm(hidden_states, residual)
+        if post_norm_final_aux:
+            aux_hidden_states.append(hidden_states)
+
+        if len(aux_hidden_states) > 0:
+            return hidden_states, aux_hidden_states
 
         return hidden_states
 
@@ -682,7 +714,9 @@ class MiMoV2Model(nn.Module):
         return loaded_params
 
 
-class MiMoV2FlashForCausalLM(nn.Module, SupportsPP, MixtureOfExperts):
+class MiMoV2FlashForCausalLM(
+    nn.Module, SupportsPP, MixtureOfExperts, SupportsEagle3
+):
     packed_modules_mapping = {
         "qkv_proj": ["q_proj", "k_proj", "v_proj"],
         "gate_up_proj": ["gate_proj", "up_proj"],
@@ -718,6 +752,12 @@ class MiMoV2FlashForCausalLM(nn.Module, SupportsPP, MixtureOfExperts):
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)
+
+    def set_aux_hidden_state_layers(self, layers: tuple[int, ...]) -> None:
+        self.model.aux_hidden_state_layers = layers
+
+    def get_eagle3_aux_hidden_state_layers(self) -> tuple[int, ...]:
+        return self.model.aux_hidden_state_layers
 
     def forward(
         self,

--- a/vllm/model_executor/models/qwen3_dflash.py
+++ b/vllm/model_executor/models/qwen3_dflash.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 
 import torch
 import torch.nn.functional as F
@@ -34,6 +34,11 @@ from vllm.model_executor.model_loader.weight_utils import (
 from vllm.multimodal.inputs import NestedTensors
 from vllm.transformers_utils.config import set_default_rope_theta
 from vllm.v1.attention.backend import AttentionType
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheSpec,
+    SlidingWindowSpec,
+)
 
 from .qwen2 import Qwen2MLP as Qwen3MLP
 from .qwen3 import Qwen3ForCausalLM
@@ -45,6 +50,53 @@ from .utils import (
 )
 
 logger = init_logger(__name__)
+
+
+_DFLASH_VALID_LAYER_TYPES = frozenset({"full_attention", "sliding_attention"})
+
+
+def _get_dflash_layer_types(config: Qwen3Config) -> tuple[str, ...]:
+    layer_types = getattr(config, "layer_types", None)
+    if layer_types is None:
+        return ("full_attention",) * config.num_hidden_layers
+    if len(layer_types) != config.num_hidden_layers:
+        raise ValueError(
+            f"DFlash layer_types length {len(layer_types)} does not match "
+            f"num_hidden_layers {config.num_hidden_layers}."
+        )
+    invalid = set(layer_types) - _DFLASH_VALID_LAYER_TYPES
+    if invalid:
+        raise ValueError(f"Invalid DFlash layer_type(s): {sorted(invalid)}.")
+    if "sliding_attention" in layer_types and not getattr(
+        config, "sliding_window", None
+    ):
+        raise ValueError(
+            "DFlash sliding_attention layers require `sliding_window` in config."
+        )
+    return tuple(layer_types)
+
+
+class DFlashAttention(Attention):
+    """Attention with DFlash-specific KV allocation semantics.
+
+    The compute path keeps the layer's configured sliding window. The KV cache
+    spec is widened to full attention because DFlash writes every context KV
+    before drafting and cannot evict old context blocks from draft layers.
+    """
+
+    def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec | None:
+        spec = super().get_kv_cache_spec(vllm_config)
+        if isinstance(spec, SlidingWindowSpec):
+            return FullAttentionSpec(
+                block_size=spec.block_size,
+                num_kv_heads=spec.num_kv_heads,
+                head_size=spec.head_size,
+                head_size_v=getattr(spec, "head_size_v", spec.head_size),
+                dtype=spec.dtype,
+                kv_quant_mode=spec.kv_quant_mode,
+                page_size_padded=spec.page_size_padded,
+            )
+        return spec
 
 
 class DFlashQwen3Attention(nn.Module):
@@ -66,6 +118,7 @@ class DFlashQwen3Attention(nn.Module):
         attention_bias: bool = False,
         cache_config: CacheConfig | None = None,
         quant_config: QuantizationConfig | None = None,
+        sliding_window: int | None = None,
         prefix: str = "",
         attn_type: str = AttentionType.DECODER,
     ) -> None:
@@ -109,13 +162,14 @@ class DFlashQwen3Attention(nn.Module):
             max_position=max_position,
             rope_parameters=rope_parameters,
         )
-        self.attn = Attention(
+        self.attn = DFlashAttention(
             self.num_heads,
             self.head_dim,
             self.scaling,
             num_kv_heads=self.num_kv_heads,
             cache_config=cache_config,
             quant_config=quant_config,
+            per_layer_sliding_window=sliding_window,
             prefix=f"{prefix}.attn",
             attn_type=attn_type,
         )
@@ -158,12 +212,17 @@ class DFlashQwen3DecoderLayer(nn.Module):
         config: Qwen3Config,
         cache_config: CacheConfig | None = None,
         quant_config: QuantizationConfig | None = None,
+        layer_type: str = "full_attention",
         prefix: str = "",
     ) -> None:
         super().__init__()
         self.hidden_size = config.hidden_size
+        self.layer_type = layer_type
         set_default_rope_theta(config, default_theta=1000000)
         attn_type = AttentionType.DECODER
+        sliding_window = (
+            config.sliding_window if layer_type == "sliding_attention" else None
+        )
 
         self.self_attn = DFlashQwen3Attention(
             hidden_size=self.hidden_size,
@@ -175,6 +234,7 @@ class DFlashQwen3DecoderLayer(nn.Module):
             head_dim=getattr(config, "head_dim", None),
             cache_config=cache_config,
             quant_config=quant_config,
+            sliding_window=sliding_window,
             rope_parameters=config.rope_parameters,
             prefix=f"{prefix}.self_attn",
             attn_type=attn_type,
@@ -243,6 +303,7 @@ class DFlashQwen3Model(nn.Module):
             prefix=maybe_prefix(prefix, "embed_tokens"),
         )
 
+        self.layer_types = _get_dflash_layer_types(self.config)
         self.layers = nn.ModuleList(
             [
                 DFlashQwen3DecoderLayer(
@@ -250,11 +311,17 @@ class DFlashQwen3Model(nn.Module):
                     config=self.config,
                     cache_config=current_vllm_config.cache_config,
                     quant_config=self.quant_config,
+                    layer_type=self.layer_types[layer_idx],
                     prefix=maybe_prefix(prefix, f"layers.{layer_idx + start_layer_id}"),
                 )
                 for layer_idx in range(self.config.num_hidden_layers)
             ]
         )
+        self.sliding_attention_layer_names = {
+            layer.self_attn.attn.layer_name
+            for layer in self.layers
+            if layer.layer_type == "sliding_attention"
+        }
         if self.use_aux_hidden_state:
             num_features_to_use = self.config.num_hidden_layers
             if "target_layer_ids" in drafter_config:
@@ -345,7 +412,7 @@ class DFlashQwen3Model(nn.Module):
         self,
         context_states: torch.Tensor,
         context_positions: torch.Tensor,
-        context_slot_mapping: torch.Tensor | None = None,
+        context_slot_mapping: torch.Tensor | Mapping[str, torch.Tensor] | None = None,
     ) -> None:
         """Precompute K/V for context states write them into each layer's KV cache.
 
@@ -426,13 +493,18 @@ class DFlashQwen3Model(nn.Module):
         all_k_final = all_k_flat.view(L, num_ctx, nkv, hd)
         for i in range(L):
             attn = self._attn_layers[i]
+            layer_slot_mapping = (
+                context_slot_mapping[attn.layer_name]
+                if isinstance(context_slot_mapping, Mapping)
+                else context_slot_mapping
+            )
             kv_cache = attn.kv_cache
             attn.impl.do_kv_cache_update(
                 attn,
                 all_k_final[i],
                 all_v[i],
                 kv_cache,
-                context_slot_mapping,
+                layer_slot_mapping,
             )
 
     def forward(
@@ -511,7 +583,8 @@ class DFlashQwen3ForCausalLM(Qwen3ForCausalLM):
             prefix=maybe_prefix(prefix, "lm_head"),
         )
         self.logits_processor = LogitsProcessor(
-            self.config.draft_vocab_size, scale=logit_scale
+            self.config.draft_vocab_size,
+            scale=logit_scale,
         )
         target_vocab_size = vllm_config.model_config.get_vocab_size()
         if self.config.draft_vocab_size != target_vocab_size:
@@ -559,12 +632,16 @@ class DFlashQwen3ForCausalLM(Qwen3ForCausalLM):
         self,
         context_states: torch.Tensor,
         context_positions: torch.Tensor,
-        context_slot_mapping: torch.Tensor | None = None,
+        context_slot_mapping: torch.Tensor | Mapping[str, torch.Tensor] | None = None,
     ) -> None:
         """Precompute projected + RoPE'd K/V and write to cache."""
         self.model.precompute_and_store_context_kv(
             context_states, context_positions, context_slot_mapping
         )
+
+    @property
+    def sliding_attention_layer_names(self) -> set[str]:
+        return self.model.sliding_attention_layer_names
 
     def combine_hidden_states(
         self,

--- a/vllm/model_executor/models/qwen3_dflash.py
+++ b/vllm/model_executor/models/qwen3_dflash.py
@@ -56,7 +56,21 @@ _DFLASH_VALID_LAYER_TYPES = frozenset({"full_attention", "sliding_attention"})
 
 
 def _get_dflash_layer_types(config: Qwen3Config) -> tuple[str, ...]:
+    dflash_config = getattr(config, "dflash_config", None) or {}
     layer_types = getattr(config, "layer_types", None)
+    if dflash_config.get("use_swa") and (
+        layer_types is None or set(layer_types) == {"full_attention"}
+    ):
+        sliding_window = getattr(config, "sliding_window", None) or dflash_config.get(
+            "swa_window_size"
+        )
+        if sliding_window is None:
+            raise ValueError(
+                "DFlash dflash_config.use_swa requires `sliding_window` or "
+                "`dflash_config.swa_window_size` in config."
+            )
+        config.sliding_window = sliding_window
+        return ("sliding_attention",) * config.num_hidden_layers
     if layer_types is None:
         return ("full_attention",) * config.num_hidden_layers
     if len(layer_types) != config.num_hidden_layers:

--- a/vllm/model_executor/models/qwen3_dflash.py
+++ b/vllm/model_executor/models/qwen3_dflash.py
@@ -11,7 +11,10 @@ from transformers import Qwen3Config
 from vllm import _custom_ops as ops
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CacheConfig, VllmConfig, get_current_vllm_config
-from vllm.distributed import get_tensor_model_parallel_world_size
+from vllm.distributed import (
+    get_tensor_model_parallel_rank,
+    get_tensor_model_parallel_world_size,
+)
 from vllm.logger import init_logger
 from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.layernorm import RMSNorm
@@ -133,6 +136,7 @@ class DFlashQwen3Attention(nn.Module):
         cache_config: CacheConfig | None = None,
         quant_config: QuantizationConfig | None = None,
         sliding_window: int | None = None,
+        attention_sink_bias: bool = False,
         prefix: str = "",
         attn_type: str = AttentionType.DECODER,
     ) -> None:
@@ -176,6 +180,11 @@ class DFlashQwen3Attention(nn.Module):
             max_position=max_position,
             rope_parameters=rope_parameters,
         )
+        self.attention_sink_bias = (
+            nn.Parameter(torch.empty(self.num_heads), requires_grad=False)
+            if attention_sink_bias
+            else None
+        )
         self.attn = DFlashAttention(
             self.num_heads,
             self.head_dim,
@@ -186,6 +195,7 @@ class DFlashQwen3Attention(nn.Module):
             per_layer_sliding_window=sliding_window,
             prefix=f"{prefix}.attn",
             attn_type=attn_type,
+            sinks=self.attention_sink_bias,
         )
         self.q_norm = RMSNorm(self.head_dim, eps=rms_norm_eps)
         self.k_norm = RMSNorm(self.head_dim, eps=rms_norm_eps)
@@ -237,6 +247,8 @@ class DFlashQwen3DecoderLayer(nn.Module):
         sliding_window = (
             config.sliding_window if layer_type == "sliding_attention" else None
         )
+        dflash_config = getattr(config, "dflash_config", None) or {}
+        attention_sink_bias = bool(dflash_config.get("attention_sink_bias", False))
 
         self.self_attn = DFlashQwen3Attention(
             hidden_size=self.hidden_size,
@@ -249,6 +261,7 @@ class DFlashQwen3DecoderLayer(nn.Module):
             cache_config=cache_config,
             quant_config=quant_config,
             sliding_window=sliding_window,
+            attention_sink_bias=attention_sink_bias,
             rope_parameters=config.rope_parameters,
             prefix=f"{prefix}.self_attn",
             attn_type=attn_type,
@@ -568,7 +581,21 @@ class DFlashQwen3Model(nn.Module):
                 weight_loader(param, loaded_weight, shard_id)
                 break
             else:
+                if name not in params_dict:
+                    if "attention_sink_bias" in name:
+                        continue
+                    raise KeyError(name)
                 param = params_dict[name]
+                if "attention_sink_bias" in name:
+                    tp_size = get_tensor_model_parallel_world_size()
+                    tp_rank = get_tensor_model_parallel_rank()
+                    heads_per_rank = loaded_weight.shape[0] // tp_size
+                    head_start = tp_rank * heads_per_rank
+                    param.data.copy_(
+                        loaded_weight.narrow(0, head_start, heads_per_rank)
+                    )
+                    loaded_params.add(name)
+                    continue
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)
             loaded_params.add(name)
@@ -586,7 +613,10 @@ class DFlashQwen3ForCausalLM(Qwen3ForCausalLM):
         )
         self.model = DFlashQwen3Model(
             vllm_config=vllm_config,
-            prefix=maybe_prefix(prefix, "model"),
+            # Keep draft Attention layer names out of the target model's
+            # `model.layers.*` namespace. The Python module hierarchy remains
+            # `self.model`, so checkpoint parameter names are unchanged.
+            prefix=maybe_prefix(prefix, "dflash_model"),
             start_layer_id=target_layer_num,
         )
 

--- a/vllm/transformers_utils/configs/speculators/algos.py
+++ b/vllm/transformers_utils/configs/speculators/algos.py
@@ -85,19 +85,29 @@ def update_dflash(config_dict: dict, pre_trained_config: dict) -> None:
     - target_hidden_size: Hidden size of the target model
     - mask_token_id (required): Token ID used for parallel drafting mask
         placeholders
-    - aux_hidden_state_layer_ids (required): Layer indices from the target
-        model whose intermediate hidden states are used as context for the
-        DFlash drafter. Mapped to both eagle_aux_hidden_state_layer_ids
-        (for gpu_model_runner) and dflash_config.target_layer_ids (for the
-        DFlash model).
+    - aux_hidden_state_layer_ids (required): DFlash target layer indices whose
+        intermediate hidden states are used as context for the DFlash drafter.
+        Mapped to dflash_config.target_layer_ids for the DFlash model. The
+        runner-facing eagle_aux_hidden_state_layer_ids are shifted by one to
+        match vLLM's hidden-state extraction semantics.
     """
     pre_trained_config["architectures"] = ["DFlashDraftModel"]
     pre_trained_config["draft_vocab_size"] = config_dict.get("draft_vocab_size")
     if config_dict.get("target_hidden_size") is not None:
         pre_trained_config["target_hidden_size"] = config_dict["target_hidden_size"]
+    for key in (
+        "layer_types",
+        "use_sliding_window",
+        "sliding_window",
+        "max_window_layers",
+    ):
+        if key in config_dict:
+            pre_trained_config[key] = config_dict[key]
 
     aux_layer_ids = config_dict["aux_hidden_state_layer_ids"]
-    pre_trained_config["eagle_aux_hidden_state_layer_ids"] = aux_layer_ids
+    pre_trained_config["eagle_aux_hidden_state_layer_ids"] = [
+        i + 1 for i in aux_layer_ids
+    ]
 
     # DFlash configs use different indexing for the target layers, see #40727
     pre_trained_config["dflash_config"] = {

--- a/vllm/v1/attention/backend.py
+++ b/vllm/v1/attention/backend.py
@@ -151,6 +151,11 @@ class AttentionBackend(ABC):
         return (cls.__module__, cls.__qualname__)
 
     @classmethod
+    def get_metadata_group_key(cls, attn_layer: Any) -> tuple[Any, ...]:
+        """Return extra layer attributes that require separate metadata builders."""
+        return ()
+
+    @classmethod
     def get_supported_head_sizes(cls) -> list[int]:
         return []
 

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -4,7 +4,7 @@
 
 from dataclasses import dataclass
 from functools import partial
-from typing import ClassVar
+from typing import Any, ClassVar
 
 import numpy as np
 import torch
@@ -347,6 +347,17 @@ class FlashInferBackend(AttentionBackend):
     @classmethod
     def supports_non_causal(cls) -> bool:
         return True
+
+    @classmethod
+    def get_metadata_group_key(cls, attn_layer: Any) -> tuple[Any, ...]:
+        impl = attn_layer.impl
+        scale = getattr(impl, "scale", None)
+        return (
+            getattr(impl, "window_left", None),
+            getattr(impl, "logits_soft_cap", None),
+            float(scale) if scale is not None else None,
+            getattr(impl, "sinks", None) is not None,
+        )
 
     @staticmethod
     def get_impl_cls() -> type["FlashInferImpl"]:

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -344,6 +344,10 @@ class FlashInferBackend(AttentionBackend):
     def get_name() -> str:
         return "FLASHINFER"
 
+    @classmethod
+    def supports_non_causal(cls) -> bool:
+        return True
+
     @staticmethod
     def get_impl_cls() -> type["FlashInferImpl"]:
         return FlashInferImpl
@@ -511,6 +515,7 @@ class FlashInferMetadata:
     num_decode_tokens: int
     num_prefills: int
     num_prefill_tokens: int
+    causal: bool
 
     prefill: FIPrefill | TRTLLMPrefill | None
     """
@@ -553,6 +558,9 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         self._prefill_wrapper: (
             BatchPrefillWithPagedKVCacheWrapper | BatchDCPPrefillWrapper | None
         ) = None  # Wrapper for prefill/append
+        self._noncausal_prefill_wrapper: (
+            BatchPrefillWithPagedKVCacheWrapper | None
+        ) = None  # Wrapper for non-causal prefill (DFlash)
         self._decode_wrapper = None  # Wrapper for decode (general shape)
 
         if envs.VLLM_BATCH_INVARIANT:
@@ -765,7 +773,28 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
 
     def _get_prefill_wrapper(
         self,
+        causal: bool = True,
     ) -> BatchPrefillWithPagedKVCacheWrapper | BatchDCPPrefillWrapper:
+        if not causal:
+            if self.use_dcp:
+                raise NotImplementedError(
+                    "FlashInfer non-causal prefill is not supported with DCP yet."
+                )
+            if self.is_kvcache_nvfp4:
+                raise NotImplementedError(
+                    "FlashInfer non-causal attention is not supported with "
+                    "NVFP4 KV cache."
+                )
+            if self._noncausal_prefill_wrapper is None:
+                self._noncausal_prefill_wrapper = (
+                    BatchPrefillWithPagedKVCacheWrapper(
+                        self._get_workspace_buffer(),
+                        get_kv_cache_layout(),
+                        backend="auto",
+                    )
+                )
+            return self._noncausal_prefill_wrapper
+
         if self._prefill_wrapper is None:
             if self.use_dcp:
                 self._prefill_wrapper = BatchDCPPrefillWrapper(
@@ -896,13 +925,22 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
     ) -> FlashInferMetadata:
         num_reqs = common_attn_metadata.num_reqs
         num_actual_tokens = common_attn_metadata.num_actual_tokens
-        num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens = (
-            split_decodes_and_prefills(
-                common_attn_metadata,
-                decode_threshold=self.reorder_batch_threshold,
-                require_uniform=True,
+        causal = common_attn_metadata.causal
+        if causal:
+            num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens = (
+                split_decodes_and_prefills(
+                    common_attn_metadata,
+                    decode_threshold=self.reorder_batch_threshold,
+                    require_uniform=True,
+                )
             )
-        )
+        else:
+            # FlashInfer decode/TRTLLM paths cannot express non-causal
+            # query-query attention, so DFlash runs as native prefill.
+            num_decodes = 0
+            num_prefills = num_reqs
+            num_decode_tokens = 0
+            num_prefill_tokens = num_actual_tokens
 
         page_size = self.page_size
         max_seq_len = common_attn_metadata.max_seq_len
@@ -917,22 +955,40 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         # - Decode (FI native or TRTLLM)
         use_cascade = common_prefix_len > 0
         uses_spec_reorder = self.reorder_batch_threshold > 1
-        prefill_use_trtllm = use_trtllm_attention(
-            self.num_qo_heads,
-            self.num_kv_heads,
-            num_prefill_tokens,
-            max_seq_len,
-            self.dcp_world_size,
-            self.cache_dtype,
-            self.q_data_type,
-            is_prefill=True,
-            force_use_trtllm=self.attention_config.use_trtllm_attention,
-            has_sinks=self.has_sinks,
-            has_spec=uses_spec_reorder,
+        prefill_use_trtllm = (
+            causal
+            and use_trtllm_attention(
+                self.num_qo_heads,
+                self.num_kv_heads,
+                num_prefill_tokens,
+                max_seq_len,
+                self.dcp_world_size,
+                self.cache_dtype,
+                self.q_data_type,
+                is_prefill=True,
+                force_use_trtllm=self.attention_config.use_trtllm_attention,
+                has_sinks=self.has_sinks,
+                has_spec=uses_spec_reorder,
+            )
         )
         decode_use_trtllm = (
-            self.use_trtllm_decode_attention and self.dcp_world_size <= 1
+            causal
+            and self.use_trtllm_decode_attention
+            and self.dcp_world_size <= 1
         )
+
+        if not causal and self.use_dcp:
+            raise NotImplementedError(
+                "FlashInfer non-causal prefill is not supported with DCP yet."
+            )
+        uses_trtllm = (num_prefills > 0 and prefill_use_trtllm) or (
+            num_decodes > 0 and decode_use_trtllm
+        )
+        if not causal and uses_trtllm:
+            raise NotImplementedError(
+                "FlashInfer non-causal attention is not supported with TRTLLM "
+                "kernels yet."
+            )
 
         all_uses_trtllm = (num_prefills == 0 or prefill_use_trtllm) and (
             num_decodes == 0 or decode_use_trtllm
@@ -974,6 +1030,7 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             num_decode_tokens=num_decode_tokens,
             num_prefills=num_prefills,
             num_prefill_tokens=num_prefill_tokens,
+            causal=causal,
             use_cascade=use_cascade,
             prefill=None,
             decode=None,
@@ -1131,7 +1188,7 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                     max_seq_len=max_seq_len,
                 )
             else:
-                prefill_wrapper = self._get_prefill_wrapper()
+                prefill_wrapper = self._get_prefill_wrapper(causal=attn_metadata.causal)
                 # Slicing CPU buffers that are only needed for FI native prefills
                 paged_kv_last_page_len_prefill_cpu = self.paged_kv_last_page_len.cpu[
                     prefill_start:num_reqs
@@ -1181,7 +1238,7 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                         num_kv_heads=self.num_kv_heads,
                         head_dim_qk=self.head_dim,
                         page_size=self.page_size,
-                        causal=True,
+                        causal=attn_metadata.causal,
                         sm_scale=self.sm_scale,
                         window_left=self.window_left,
                         logits_soft_cap=self.logits_soft_cap,
@@ -1556,7 +1613,7 @@ class FlashInferImpl(AttentionImpl):
                         self.logits_soft_cap or 0.0
                     )
                     assert prefill_wrapper._sm_scale == self.scale
-                    assert prefill_wrapper._causal
+                    assert prefill_wrapper._causal == attn_metadata.causal
 
                     if self.is_kvcache_nvfp4:
                         kv_cache_permute = nvfp4_kv_data

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -69,6 +69,7 @@ class TritonAttentionMetadata:
     seq_lens: torch.Tensor
     block_table: torch.Tensor
     slot_mapping: torch.Tensor
+    causal: bool
 
     seq_threshold_3D: int
     num_par_softmax_segments: int
@@ -249,6 +250,7 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
             seq_lens=seq_lens,
             block_table=block_table_tensor,
             slot_mapping=slot_mapping,
+            causal=common_attn_metadata.causal,
             use_cascade=use_cascade,
             common_prefix_len=common_prefix_len,
             cu_prefix_query_lens=cu_prefix_query_lens,
@@ -364,6 +366,10 @@ class TritonAttentionBackend(AttentionBackend):
 
     @classmethod
     def supports_mm_prefix(cls) -> bool:
+        return True
+
+    @classmethod
+    def supports_non_causal(cls) -> bool:
         return True
 
     @classmethod
@@ -641,7 +647,7 @@ class TritonAttentionImpl(AttentionImpl):
             seqused_k=seqused_k,
             max_seqlen_k=max_seqlen_k,
             softmax_scale=self.scale,
-            causal=True,
+            causal=attn_metadata.causal,
             alibi_slopes=self.alibi_slopes,
             use_alibi_sqrt=self.use_alibi_sqrt,
             window_size=self.sliding_window,

--- a/vllm/v1/attention/ops/triton_attention_helpers.py
+++ b/vllm/v1/attention/ops/triton_attention_helpers.py
@@ -152,6 +152,7 @@ def compute_tile_loop_bounds(
     num_queries_per_kv: tl.constexpr,
     SLIDING_WINDOW: tl.constexpr,
     USE_MM_PREFIX: tl.constexpr,
+    CAUSAL: tl.constexpr,
     IS_3D: tl.constexpr,
     CHUNK_LOOKBACK: tl.constexpr = -1,
     CHUNK_SIZE: tl.constexpr = -1,
@@ -179,9 +180,11 @@ def compute_tile_loop_bounds(
         + (BLOCK_M - 1) // num_queries_per_kv
         + 1
     )
-    if USE_MM_PREFIX:
+    if not CAUSAL:
+        max_seq_prefix_len = seq_len
+    elif USE_MM_PREFIX:
         # image bidirectional attention ranges require a full range
-        # including q_block padding to make sure doc mask is correct
+        # including q_block padding to make sure doc mask is correct.
         max_seq_prefix_len = tl.maximum(max_seq_prefix_len, seq_len)
     else:
         max_seq_prefix_len = tl.minimum(max_seq_prefix_len, seq_len)
@@ -193,7 +196,7 @@ def compute_tile_loop_bounds(
     tile_start = 0
     tile_end = num_tiles
     # TODO(Isotr0py): sliding window pruning with image bidirectional mask
-    if SLIDING_WINDOW > 0 and not USE_MM_PREFIX:
+    if CAUSAL and SLIDING_WINDOW > 0 and not USE_MM_PREFIX:
         # Query rows covered by this Q-block
         qpos_lo = q_block_local_idx * BLOCK_Q
         qpos_hi = tl.minimum(
@@ -261,10 +264,12 @@ def store_segm_reduce_scalars(
 def compute_kv_seq_mask(
     query_abs_pos,
     seq_offset,
+    seq_len,
     seq_idx,
     mm_prefix_range_ptr,
     SLIDING_WINDOW: tl.constexpr,
     USE_MM_PREFIX: tl.constexpr,
+    CAUSAL: tl.constexpr,
     MAX_MM_RANGES: tl.constexpr,
     CHUNK_LOOKBACK: tl.constexpr = -1,
     CHUNK_SIZE: tl.constexpr = -1,
@@ -280,19 +285,28 @@ def compute_kv_seq_mask(
     are non-default — the launcher zeros ``CHUNK_LOOKBACK`` whenever
     sliding window is disabled.
     """
-    # Compute attention mask: causal by default (key <= query)
-    seq_mask = seq_offset[None, :] <= query_abs_pos
+    # Compute attention mask: causal by default (key <= query). DFlash uses
+    # non-causal draft attention, where every query token may attend to the
+    # entire context + draft block.
+    if CAUSAL:
+        seq_mask = seq_offset[None, :] <= query_abs_pos
+    else:
+        seq_mask = seq_offset[None, :] < seq_len
 
     # Apply sliding window / chunked attention to base mask
     # BEFORE mm_prefix OR.
     # Order must match FlexAttention:
     #   (causal AND sliding_window) OR mm_prefix
-    if CHUNK_LOOKBACK > -1:
+    if CAUSAL and CHUNK_LOOKBACK > -1:
         seq_mask = seq_mask & (
             (query_abs_pos // CHUNK_SIZE - seq_offset[None, :] // CHUNK_SIZE)
             <= CHUNK_LOOKBACK
         )
     elif SLIDING_WINDOW > 0:
+        # In non-causal mode the window only bounds how far BACK a query may
+        # look (DFlash SWA: bidirectional inside the draft block, sliding
+        # window over the older context). Keys after the query have a
+        # negative distance and always pass this check.
         seq_mask = seq_mask & ((query_abs_pos - seq_offset) < SLIDING_WINDOW)
 
     # PrefixLM: extend mask with bidirectional ranges for multimodal tokens.

--- a/vllm/v1/attention/ops/triton_attention_helpers.py
+++ b/vllm/v1/attention/ops/triton_attention_helpers.py
@@ -219,6 +219,17 @@ def compute_tile_loop_bounds(
         # Convert to tile indices and clamp
         tile_start = tl.maximum(0, first_allowed_key // TILE_SIZE)
         tile_end = tl.minimum((last_allowed_key // TILE_SIZE) + 1, num_tiles)
+    elif SLIDING_WINDOW > 0 and not USE_MM_PREFIX:
+        # Non-causal sliding window (DFlash draft): the window only bounds
+        # how far BACK a query may look, while every later key (the rest of
+        # the draft block) stays visible. Prune the leading tiles that no
+        # query in this Q-block can see; keep tile_end at num_tiles. Without
+        # this, every draft step scans the full context and per-step cost
+        # grows linearly with context length instead of staying constant.
+        qpos_lo = q_block_local_idx * BLOCK_Q
+        q_abs = context_len + qpos_lo
+        first_allowed_key = q_abs - SLIDING_WINDOW + 1
+        tile_start = tl.maximum(0, first_allowed_key // TILE_SIZE)
 
     if IS_3D:
         loop_lo = max(segm_idx_or_0 * tiles_per_segment_or_0, tile_start)

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -920,17 +920,21 @@ def unified_attention(
 
     # Launch the 2D kernel if
     # 1. No intermediate tiled softmax buffers for the 3D kernel have been allocated, or
-    # 2. The batch includes at least one prefill request, or
-    # 3. The number of sequences exceeds the configured threshold, or
-    # 4. Batch invariance is enabled
+    # 2. The batch's query tokens do not fit the segment buffers (which are
+    #    indexed by global query-token row). This also keeps prefills and
+    #    large batches on the 2D path, whose launch grid is already large
+    #    enough for full GPU utilization. Small-query batches (single-token
+    #    decode, spec-decode verify, DFlash draft blocks) take the 3D path
+    #    so long-context KV scans are segment-parallel instead of running
+    #    on a handful of CTAs.
+    # 3. Batch invariance is enabled
     use_3d = not (
         seq_threshold_3D is None
         or num_par_softmax_segments is None
         or softmax_segm_output is None
         or softmax_segm_max is None
         or softmax_segm_expsum is None
-        or max_seqlen_q > 1
-        or num_seqs > seq_threshold_3D
+        or q.shape[0] > seq_threshold_3D
         or is_batch_invariant
     )
 

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -215,6 +215,7 @@ def kernel_unified_attention(
     USE_SOFTCAP: tl.constexpr,  # bool
     USE_SINKS: tl.constexpr,  # bool
     SLIDING_WINDOW: tl.constexpr,  # int
+    CAUSAL: tl.constexpr,  # bool
     USE_MM_PREFIX: tl.constexpr,  # bool
     MAX_MM_RANGES: tl.constexpr,  # int
     mm_prefix_range_ptr,
@@ -388,6 +389,7 @@ def kernel_unified_attention(
         num_queries_per_kv,
         SLIDING_WINDOW,
         USE_MM_PREFIX,
+        CAUSAL,
         IS_3D,
         CHUNK_LOOKBACK,
         CHUNK_SIZE,
@@ -492,10 +494,12 @@ def kernel_unified_attention(
         seq_mask = compute_kv_seq_mask(
             query_abs_pos,
             seq_offset,
+            seq_len,
             seq_idx,
             mm_prefix_range_ptr,
             SLIDING_WINDOW,
             USE_MM_PREFIX,
+            CAUSAL,
             MAX_MM_RANGES,
             CHUNK_LOOKBACK,
             CHUNK_SIZE,
@@ -530,7 +534,7 @@ def kernel_unified_attention(
         M, L, P, alpha = softmax_step(S, M, L)
         acc = acc * alpha[:, None]
 
-        if SLIDING_WINDOW:
+        if CAUSAL and SLIDING_WINDOW:
             qpos_lo = q_block_local_idx * BLOCK_Q
             V = tl.where(
                 (context_len + qpos_lo - seq_offset[:, None]) < SLIDING_WINDOW,
@@ -802,7 +806,6 @@ def unified_attention(
     # disabling this flag costs nothing.
     use_td: bool = False,
 ):
-    assert causal, "Only causal attention is supported"
     if sinks is not None:
         assert sinks.shape[0] == q.shape[1], "Sinks must be num_query_heads size"
 
@@ -1003,6 +1006,7 @@ def unified_attention(
         USE_SOFTCAP=(softcap > 0),
         USE_SINKS=(sinks is not None),
         USE_MM_PREFIX=use_mm_prefix,
+        CAUSAL=causal,
         MAX_MM_RANGES=max_mm_ranges,
         mm_prefix_range_ptr=mm_prefix_range,
         SLIDING_WINDOW=(1 + window_size[0]),

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1358,9 +1358,9 @@ def get_kv_cache_config_from_groups(
         kv_cache_tensors = []
         for i in range(group_size):
             shared_by = []
-            for j in range(len(kv_cache_groups)):
-                if i < len(kv_cache_groups[j].layer_names):
-                    shared_by.append(kv_cache_groups[j].layer_names[i])
+            for group in kv_cache_groups:
+                if i < len(group.layer_names):
+                    shared_by.append(group.layer_names[i])
             kv_cache_tensors.append(
                 KVCacheTensor(size=page_size * num_blocks, shared_by=shared_by)
             )

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -211,11 +211,15 @@ class Scheduler(SchedulerInterface):
 
         speculative_config = vllm_config.speculative_config
         self.use_eagle = False
+        self.requires_eagle_cache_drop = False
         self.num_spec_tokens = self.num_lookahead_tokens = 0
         if speculative_config:
             self.num_spec_tokens = speculative_config.num_speculative_tokens
             if speculative_config.use_eagle():
                 self.use_eagle = True
+                self.requires_eagle_cache_drop = (
+                    speculative_config.requires_eagle_cache_drop()
+                )
                 self.num_lookahead_tokens = self.num_spec_tokens
             if speculative_config.uses_draft_model():
                 self.num_lookahead_tokens = self.num_spec_tokens
@@ -233,7 +237,7 @@ class Scheduler(SchedulerInterface):
             max_model_len=self.max_model_len,
             max_num_batched_tokens=self.scheduler_config.max_num_batched_tokens,
             enable_caching=self.cache_config.enable_prefix_caching,
-            use_eagle=self.use_eagle,
+            use_eagle=self.requires_eagle_cache_drop,
             log_stats=self.log_stats,
             enable_kv_cache_events=self.enable_kv_cache_events,
             dcp_world_size=self.dcp_world_size,
@@ -309,13 +313,13 @@ class Scheduler(SchedulerInterface):
             # must be a multiple of `block_size`.
             # As an exception, if `num_new_tokens` is less than `block_size`, the
             # state is simply not cached, requiring no special handling.
-            # Additionally, when Eagle mode is enabled, FullAttn prunes the last
-            # matching block. To prevent this from causing a Mamba cache miss, the
-            # last chunk must be not smaller than `block_size`.
+            # Additionally, when Eagle-style cache drop is enabled, FullAttn
+            # prunes the last matching block. To prevent this from causing a
+            # Mamba cache miss, the last chunk must be not smaller than
+            # `block_size`.
             block_size = self.cache_config.block_size
             last_cache_position = request.num_tokens - request.num_tokens % block_size
-            # eagle prune
-            if self.use_eagle:
+            if self.requires_eagle_cache_drop:
                 last_cache_position = max(last_cache_position - block_size, 0)
             num_computed_tokens_after_sched = num_computed_tokens + num_new_tokens
             if num_computed_tokens_after_sched < last_cache_position:
@@ -426,7 +430,7 @@ class Scheduler(SchedulerInterface):
                     request.num_computed_tokens,
                     num_new_tokens,
                     encoder_compute_budget,
-                    shift_computed_tokens=1 if self.use_eagle else 0,
+                    shift_computed_tokens=1 if self.requires_eagle_cache_drop else 0,
                 )
 
             if self.need_mamba_block_aligned_split:
@@ -707,7 +711,9 @@ class Scheduler(SchedulerInterface):
                             num_computed_tokens,
                             num_new_tokens,
                             encoder_compute_budget,
-                            shift_computed_tokens=1 if self.use_eagle else 0,
+                            shift_computed_tokens=1
+                            if self.requires_eagle_cache_drop
+                            else 0,
                         )
                         if num_new_tokens == 0:
                             # The request cannot be scheduled.

--- a/vllm/v1/spec_decode/dflash.py
+++ b/vllm/v1/spec_decode/dflash.py
@@ -1,17 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from dataclasses import replace
 from typing import Any
 
 import torch
 from typing_extensions import override
 
-from vllm.config import VllmConfig
+from vllm.config import VllmConfig, replace
 from vllm.forward_context import set_forward_context
 from vllm.logger import init_logger
 from vllm.triton_utils import triton
 from vllm.v1.attention.backend import CommonAttentionMetadata
+from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.spec_decode.llm_base_proposer import SpecDecodeBaseProposer
 from vllm.v1.spec_decode.utils import copy_and_expand_dflash_inputs_kernel
 
@@ -30,6 +30,7 @@ class DFlashProposer(SpecDecodeBaseProposer):
         super().__init__(
             vllm_config=vllm_config,
             device=device,
+            # Request aux hidden states; DFlash turns them into context K/V.
             pass_hidden_states_to_model=True,
             runner=runner,
         )
@@ -50,6 +51,11 @@ class DFlashProposer(SpecDecodeBaseProposer):
             dtype=torch.int64,
             device=device,
         )
+        self._slot_mapping_buffers_by_gid: dict[
+            int, tuple[torch.Tensor, torch.Tensor]
+        ] = {}
+        self._draft_block_size_by_gid: dict[int, int] = {}
+        self._draft_block_tables: dict[int, torch.Tensor] = {}
         self._context_positions_buffer = torch.zeros(
             self.max_num_tokens,
             dtype=torch.int64,
@@ -65,10 +71,42 @@ class DFlashProposer(SpecDecodeBaseProposer):
             self.max_positions + 1, device=device, dtype=torch.int32
         )
 
-        # For DFlash we use the input embeddings to embed the mask token
+        # DFlash embeds mask tokens directly.
         self.parallel_drafting_hidden_state_tensor = None
 
         self.dflash_causal = self.dflash_config.get("causal", False)
+
+    @override
+    def allow_multiple_draft_kv_cache_groups(self) -> bool:
+        return True
+
+    @override
+    def initialize_attn_backend(
+        self,
+        kv_cache_config: KVCacheConfig,
+        kernel_block_sizes: list[int] | None = None,
+    ) -> None:
+        super().initialize_attn_backend(kv_cache_config, kernel_block_sizes)
+        self._draft_block_size_by_gid.clear()
+        for attn_group in self.draft_attn_groups:
+            gid = attn_group.kv_cache_group_id
+            self._draft_block_size_by_gid[gid] = (
+                kernel_block_sizes[gid]
+                if kernel_block_sizes is not None and gid < len(kernel_block_sizes)
+                else attn_group.get_metadata_builder().kv_cache_spec.block_size
+            )
+        self._ensure_slot_mapping_buffers()
+
+    def clear_draft_block_tables(self) -> None:
+        self._draft_block_tables.clear()
+
+    def set_draft_block_table(
+        self,
+        kv_cache_gid: int,
+        block_table: torch.Tensor,
+    ) -> None:
+        if kv_cache_gid in self._draft_kv_cache_group_ids:
+            self._draft_block_tables[kv_cache_gid] = block_table
 
     @override
     def _create_draft_vllm_config(self) -> VllmConfig:
@@ -84,7 +122,84 @@ class DFlashProposer(SpecDecodeBaseProposer):
     @override
     def _warn_if_multimodal(self):
         # Override to allow multimodal inputs since DFlash supports Qwen3.5 models
+        # Support for multimodal inputs has not been tested.
         pass
+
+    def _ensure_slot_mapping_buffers(self) -> None:
+        gids = self._draft_kv_gids()
+
+        first_gid = gids[0]
+        for gid in gids:
+            if gid in self._slot_mapping_buffers_by_gid:
+                continue
+            if gid == first_gid:
+                self._slot_mapping_buffers_by_gid[gid] = (
+                    self._context_slot_mapping_buffer,
+                    self._slot_mapping_buffer,
+                )
+            else:
+                self._slot_mapping_buffers_by_gid[gid] = (
+                    torch.zeros(
+                        self.max_num_tokens,
+                        dtype=torch.int64,
+                        device=self.device,
+                    ),
+                    torch.zeros(
+                        self.max_query_tokens,
+                        dtype=torch.int64,
+                        device=self.device,
+                    ),
+                )
+
+    def _draft_kv_gids(self) -> list[int]:
+        return self._draft_kv_cache_group_ids or [
+            self.kv_cache_gid if self.kv_cache_gid >= 0 else 0
+        ]
+
+    def _get_dflash_block_table(
+        self,
+        kv_cache_gid: int,
+        cad: CommonAttentionMetadata,
+    ) -> torch.Tensor:
+        block_table = self._draft_block_tables.get(kv_cache_gid)
+        if block_table is not None:
+            return block_table
+        if kv_cache_gid == self.kv_cache_gid or self.kv_cache_gid < 0:
+            return cad.block_table_tensor
+        raise RuntimeError(
+            "Missing DFlash KV metadata for draft KV cache group "
+            f"{kv_cache_gid}. This is required when DFlash draft layers span "
+            "multiple KV cache groups."
+        )
+
+    def _get_dflash_context_slot_mapping(
+        self,
+        num_context: int,
+    ) -> torch.Tensor | dict[str, torch.Tensor]:
+        if not self._draft_layer_to_kv_cache_gid:
+            return self._context_slot_mapping_buffer[:num_context]
+        return {
+            layer_name: self._slot_mapping_buffers_by_gid[
+                self._draft_layer_to_kv_cache_gid[layer_name]
+            ][0][:num_context]
+            for layer_name in self._draft_attn_layer_names
+        }
+
+    @override
+    def _get_slot_mapping(
+        self,
+        num_tokens: int,
+        slot_mapping: torch.Tensor | None = None,
+    ) -> dict[str, torch.Tensor]:
+        self._ensure_slot_mapping_buffers()
+        if self._draft_layer_to_kv_cache_gid:
+            return {
+                layer_name: self._slot_mapping_buffers_by_gid[
+                    self._draft_layer_to_kv_cache_gid[layer_name]
+                ][1][:num_tokens]
+                for layer_name in self._draft_attn_layer_names
+            }
+        return super()._get_slot_mapping(num_tokens, slot_mapping)
 
     @override
     def set_inputs_first_pass(
@@ -104,11 +219,9 @@ class DFlashProposer(SpecDecodeBaseProposer):
         num_query_per_req = 1 + self.num_speculative_tokens
         num_query_total = batch_size * num_query_per_req
 
-        # Store for build_model_inputs_first_pass to use
         self._dflash_num_context = num_context
 
-        # We don't need to copy into a buffer here since the context preprocessing
-        # does not run in a CUDA graph
+        # Context preprocessing does not run in a CUDA graph.
         self._dflash_hidden_states = target_hidden_states
 
         token_indices_to_sample = torch.empty(
@@ -117,8 +230,7 @@ class DFlashProposer(SpecDecodeBaseProposer):
             device=self.device,
         )
 
-        # Launch fused triton kernel for input_ids, positions, slot_mapping,
-        # and token_indices_to_sample
+        # Fill query inputs and per-KV-group slot mappings.
         max_ctx_per_req = cad.max_query_len
         max_tokens_per_req = max_ctx_per_req + num_query_per_req
         BLOCK_SIZE = min(256, triton.next_power_of_2(max_tokens_per_req))
@@ -126,36 +238,48 @@ class DFlashProposer(SpecDecodeBaseProposer):
         grid = (batch_size, num_blocks)
 
         has_num_rejected = num_rejected_tokens_gpu is not None
-        copy_and_expand_dflash_inputs_kernel[grid](
-            # Inputs
-            next_token_ids_ptr=next_token_ids,
-            target_positions_ptr=target_positions,
-            # Outputs
-            out_input_ids_ptr=self.input_ids,
-            out_context_positions_ptr=self._context_positions_buffer,
-            out_query_positions_ptr=self.positions,
-            out_context_slot_mapping_ptr=self._context_slot_mapping_buffer,
-            out_query_slot_mapping_ptr=self._slot_mapping_buffer,
-            out_token_indices_ptr=token_indices_to_sample,
-            # Block table
-            block_table_ptr=cad.block_table_tensor,
-            block_table_stride=cad.block_table_tensor.stride(0),
-            # Metadata
-            query_start_loc_ptr=cad.query_start_loc,
-            num_rejected_tokens_ptr=(
-                num_rejected_tokens_gpu if has_num_rejected else 0
-            ),
-            # Scalars
-            parallel_drafting_token_id=self.parallel_drafting_token_id,
-            block_size=self.block_size,
-            num_query_per_req=num_query_per_req,
-            num_speculative_tokens=self.num_speculative_tokens,
-            total_input_tokens=num_context,
-            BLOCK_SIZE=BLOCK_SIZE,
-            HAS_NUM_REJECTED=has_num_rejected,
-        )
+        self._ensure_slot_mapping_buffers()
+        draft_kv_group_ids = self._draft_kv_gids()
+        for kv_cache_gid in draft_kv_group_ids:
+            context_slot_mapping_buffer, query_slot_mapping_buffer = (
+                self._slot_mapping_buffers_by_gid[kv_cache_gid]
+            )
+            block_table = self._get_dflash_block_table(kv_cache_gid, cad)
+            copy_and_expand_dflash_inputs_kernel[grid](
+                # Inputs
+                next_token_ids_ptr=next_token_ids,
+                target_positions_ptr=target_positions,
+                # Outputs
+                out_input_ids_ptr=self.input_ids,
+                out_context_positions_ptr=self._context_positions_buffer,
+                out_query_positions_ptr=self.positions,
+                out_context_slot_mapping_ptr=context_slot_mapping_buffer,
+                out_query_slot_mapping_ptr=query_slot_mapping_buffer,
+                out_token_indices_ptr=token_indices_to_sample,
+                # Block table
+                block_table_ptr=block_table,
+                block_table_stride=block_table.stride(0),
+                # Metadata
+                query_start_loc_ptr=cad.query_start_loc,
+                num_rejected_tokens_ptr=(
+                    num_rejected_tokens_gpu if has_num_rejected else 0
+                ),
+                # Scalars
+                parallel_drafting_token_id=self.parallel_drafting_token_id,
+                block_size=self._draft_block_size_by_gid.get(
+                    kv_cache_gid, self.block_size
+                ),
+                num_query_per_req=num_query_per_req,
+                num_speculative_tokens=self.num_speculative_tokens,
+                total_input_tokens=num_context,
+                BLOCK_SIZE=BLOCK_SIZE,
+                HAS_NUM_REJECTED=has_num_rejected,
+            )
 
-        query_slot_mapping = self._slot_mapping_buffer[:num_query_total]
+        primary_kv_cache_gid = draft_kv_group_ids[0]
+        query_slot_mapping = self._slot_mapping_buffers_by_gid[primary_kv_cache_gid][1][
+            :num_query_total
+        ]
         new_query_start_loc = self.arange[: batch_size + 1] * num_query_per_req
 
         # In padded mode, cad.seq_lens includes rejected tokens. Subtract
@@ -164,12 +288,6 @@ class DFlashProposer(SpecDecodeBaseProposer):
         if has_num_rejected:
             effective_seq_lens = effective_seq_lens - num_rejected_tokens_gpu
 
-        # Skip num_rejected_tokens (GPU-only); overestimating is fine here.
-        new_seq_lens_cpu_upper_bound = (
-            cad.seq_lens_cpu_upper_bound + num_query_per_req
-            if cad.seq_lens_cpu_upper_bound is not None
-            else None
-        )
         new_cad = CommonAttentionMetadata(
             query_start_loc=new_query_start_loc,
             seq_lens=effective_seq_lens + num_query_per_req,
@@ -179,12 +297,11 @@ class DFlashProposer(SpecDecodeBaseProposer):
             ),
             _seq_lens_cpu=None,
             _num_computed_tokens_cpu=None,
-            seq_lens_cpu_upper_bound=new_seq_lens_cpu_upper_bound,
             num_reqs=cad.num_reqs,
             num_actual_tokens=num_query_total,
             max_query_len=num_query_per_req,
             max_seq_len=cad.max_seq_len + num_query_per_req,
-            block_table_tensor=cad.block_table_tensor,
+            block_table_tensor=self._get_dflash_block_table(primary_kv_cache_gid, cad),
             slot_mapping=query_slot_mapping,
             causal=self.dflash_causal,
         )
@@ -257,15 +374,13 @@ class DFlashProposer(SpecDecodeBaseProposer):
         num_input_tokens: int,
         mm_embed_inputs: tuple[list[torch.Tensor], torch.Tensor] | None,
     ) -> tuple[dict[str, Any], int]:
-        # Context and query positions/slots were written to separate
-        # buffers by the kernel — no copy needed.
+        # Context and query positions/slots were written by the kernel.
         num_context = self._dflash_num_context
 
-        # Pre-insert context KVs directly into cache
         self.model.precompute_and_store_context_kv(
             self._dflash_hidden_states,  # Shape is already [num_context, hidden_size]
             self._context_positions_buffer[:num_context],
-            self._context_slot_mapping_buffer[:num_context],
+            self._get_dflash_context_slot_mapping(num_context),
         )
         return (
             dict(
@@ -280,17 +395,63 @@ class DFlashProposer(SpecDecodeBaseProposer):
     def build_per_group_and_layer_attn_metadata(
         self, cad: CommonAttentionMetadata, draft_index: int = 0
     ) -> tuple[list[object], dict[str, object]]:
-        per_group, per_layer = super().build_per_group_and_layer_attn_metadata(
-            cad, draft_index
+        self._ensure_slot_mapping_buffers()
+        sliding_layer_names: set[str] = getattr(
+            self.model, "sliding_attention_layer_names", set()
         )
-        if not self.dflash_causal:
-            # Require all layers to support non-causal attention when required by DFlash
-            for layer_name, attn_metadata in per_layer.items():
-                assert getattr(attn_metadata, "causal", None) is False, (
-                    f"Attention metadata for layer {layer_name} does not have"
-                    " non-causal support, which is required for DFlash."
-                    " Consider using a different attention backend, e.g FlashAttention."
+
+        per_group: list[object] = []
+        per_layer: dict[str, object] = {}
+        for attn_group in self.draft_attn_groups:
+            kv_cache_gid = attn_group.kv_cache_group_id
+            group_cad = cad.replace(
+                block_table_tensor=self._get_dflash_block_table(kv_cache_gid, cad),
+                slot_mapping=self._slot_mapping_buffers_by_gid[kv_cache_gid][1][
+                    : cad.num_actual_tokens
+                ],
+                causal=self.dflash_causal,
+            )
+            attn_metadata = attn_group.get_metadata_builder().build_for_drafting(
+                common_attn_metadata=group_cad,
+                draft_index=draft_index,
+            )
+            per_group.append(attn_metadata)
+            for layer_name in attn_group.layer_names:
+                per_layer[layer_name] = attn_metadata
+
+            # DFlash layers consume attention metadata through the per-layer
+            # forward context. Keep the non-causal group metadata for
+            # group-level spec decode checks, and specialize only the SWA
+            # layers that need a causal sliding-window mask.
+            causal_layers = sliding_layer_names & set(attn_group.layer_names)
+            if causal_layers and not self.dflash_causal:
+                causal_attn_metadata = (
+                    attn_group.get_metadata_builder().build_for_drafting(
+                        common_attn_metadata=group_cad.replace(causal=True),
+                        draft_index=draft_index,
+                    )
                 )
+                for layer_name in causal_layers:
+                    per_layer[layer_name] = causal_attn_metadata
+
+        for layer_name, attn_metadata in per_layer.items():
+            if layer_name in sliding_layer_names:
+                assert getattr(attn_metadata, "causal", None) is True, (
+                    f"Attention metadata for sliding layer {layer_name} does not have"
+                    " causal support, which is required for DFlash SWA."
+                )
+                continue
+            if self.dflash_causal:
+                assert getattr(attn_metadata, "causal", None) is True, (
+                    f"Attention metadata for layer {layer_name} does not have"
+                    " causal support, which is required by DFlash causal mode."
+                )
+                continue
+            assert getattr(attn_metadata, "causal", None) is False, (
+                f"Attention metadata for layer {layer_name} does not have"
+                " non-causal support, which is required for DFlash."
+                " Consider using a different attention backend, such as FlashAttention."
+            )
         return per_group, per_layer
 
     @override

--- a/vllm/v1/spec_decode/dflash.py
+++ b/vllm/v1/spec_decode/dflash.py
@@ -111,6 +111,16 @@ class DFlashProposer(SpecDecodeBaseProposer):
     @override
     def _create_draft_vllm_config(self) -> VllmConfig:
         base = super()._create_draft_vllm_config()
+        if base.attention_config.backend is None:
+            target_backend = self.vllm_config.attention_config.backend
+            if target_backend is not None:
+                base = replace(
+                    base,
+                    attention_config=replace(
+                        base.attention_config,
+                        backend=target_backend,
+                    ),
+                )
         return replace(
             base,
             attention_config=replace(
@@ -419,38 +429,20 @@ class DFlashProposer(SpecDecodeBaseProposer):
             for layer_name in attn_group.layer_names:
                 per_layer[layer_name] = attn_metadata
 
-            # DFlash layers consume attention metadata through the per-layer
-            # forward context. Keep the non-causal group metadata for
-            # group-level spec decode checks, and specialize only the SWA
-            # layers that need a causal sliding-window mask.
-            causal_layers = sliding_layer_names & set(attn_group.layer_names)
-            if causal_layers and not self.dflash_causal:
-                causal_attn_metadata = (
-                    attn_group.get_metadata_builder().build_for_drafting(
-                        common_attn_metadata=group_cad.replace(causal=True),
-                        draft_index=draft_index,
-                    )
-                )
-                for layer_name in causal_layers:
-                    per_layer[layer_name] = causal_attn_metadata
-
+        # DFlash draft attention is non-causal: every block slot attends to
+        # the full draft block bidirectionally. SWA layers additionally bound
+        # how far back into the context a query may look; the attention kernel
+        # applies that window on top of the non-causal mask, matching the
+        # reference DFlash semantics. (`sliding_layer_names` is kept for
+        # backends that need to identify SWA layers.)
+        del sliding_layer_names
         for layer_name, attn_metadata in per_layer.items():
-            if layer_name in sliding_layer_names:
-                assert getattr(attn_metadata, "causal", None) is True, (
-                    f"Attention metadata for sliding layer {layer_name} does not have"
-                    " causal support, which is required for DFlash SWA."
-                )
-                continue
-            if self.dflash_causal:
-                assert getattr(attn_metadata, "causal", None) is True, (
-                    f"Attention metadata for layer {layer_name} does not have"
-                    " causal support, which is required by DFlash causal mode."
-                )
-                continue
-            assert getattr(attn_metadata, "causal", None) is False, (
+            expected_causal = self.dflash_causal
+            assert getattr(attn_metadata, "causal", None) is expected_causal, (
                 f"Attention metadata for layer {layer_name} does not have"
-                " non-causal support, which is required for DFlash."
-                " Consider using a different attention backend, such as FlashAttention."
+                f" causal={expected_causal} support, which is required for"
+                " DFlash. Consider using a different attention backend, such"
+                " as FlashAttention or Triton."
             )
         return per_group, per_layer
 

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import os
 from importlib.util import find_spec
 from inspect import signature
 from typing import Any, cast
@@ -508,6 +509,7 @@ class SpecDecodeBaseProposer:
     ) -> torch.Tensor:
         self._last_draft_probs = None
         batch_size = common_attn_metadata.batch_size()
+        raw_target_hidden_states_for_dump = target_hidden_states
 
         if self.method in ("eagle3", "dflash"):
             assert isinstance(
@@ -565,6 +567,68 @@ class SpecDecodeBaseProposer:
                 last_hidden_states, hidden_states = ret_hidden_states
 
         sample_hidden_states = last_hidden_states[token_indices_to_sample]
+
+        dump_path = os.environ.get("VLLM_DFLASH_DUMP_ONCE")
+        if not dump_path and os.path.exists("/cache/dump_dflash_once"):
+            dump_path = "/cache/dflash_diag_once.pt"
+        if self.method == "dflash" and dump_path and not os.path.exists(dump_path):
+            try:
+                dump_this_rank = (
+                    not torch.distributed.is_available()
+                    or not torch.distributed.is_initialized()
+                    or torch.distributed.get_rank() == 0
+                )
+                if dump_this_rank:
+                    os.makedirs(os.path.dirname(dump_path) or ".", exist_ok=True)
+                    draft_logits = self._model_compute_logits(
+                        sample_hidden_states, spec_step_idx=0
+                    )
+                    topk = min(16, draft_logits.shape[-1])
+                    topk_values, topk_indices = torch.topk(draft_logits, k=topk, dim=-1)
+                    torch.save(
+                        {
+                            "method": self.method,
+                            "num_speculative_tokens": self.num_speculative_tokens,
+                            "batch_size": batch_size,
+                            "target_token_ids": target_token_ids.detach().cpu(),
+                            "target_positions": target_positions.detach().cpu(),
+                            "raw_target_hidden_states_shape": tuple(
+                                raw_target_hidden_states_for_dump.shape
+                            ),
+                            "raw_target_hidden_states": (
+                                raw_target_hidden_states_for_dump.detach()
+                                .to(torch.float32)
+                                .cpu()
+                            ),
+                            "combined_target_hidden_states_shape": tuple(
+                                target_hidden_states.shape
+                            ),
+                            "combined_target_hidden_states": (
+                                target_hidden_states.detach().to(torch.float32).cpu()
+                            ),
+                            "next_token_ids": next_token_ids.detach().cpu(),
+                            "input_ids": self.input_ids[:num_input_tokens]
+                            .detach()
+                            .cpu(),
+                            "positions": self._get_positions(num_input_tokens)
+                            .detach()
+                            .cpu(),
+                            "token_indices_to_sample": token_indices_to_sample.detach()
+                            .cpu(),
+                            "sample_hidden_states": (
+                                sample_hidden_states.detach().to(torch.float32).cpu()
+                            ),
+                            "draft_logits": draft_logits.detach().to(torch.float32).cpu(),
+                            "draft_topk_indices": topk_indices.detach().cpu(),
+                            "draft_topk_values": (
+                                topk_values.detach().to(torch.float32).cpu()
+                            ),
+                        },
+                        dump_path,
+                    )
+                    logger.warning("Saved DFlash diagnostic dump to %s", dump_path)
+            except Exception:
+                logger.exception("Failed to save DFlash diagnostic dump")
 
         # Early exit if there is only one draft token to be generated.
         if self.num_speculative_tokens == 1 or self.parallel_drafting:
@@ -1341,6 +1405,7 @@ class SpecDecodeBaseProposer:
 
         self._maybe_share_embeddings(target_language_model)
         self._maybe_share_lm_head(target_language_model)
+        self._maybe_load_parallel_drafting_mask_embedding()
 
         if (
             self.parallel_drafting
@@ -1356,6 +1421,73 @@ class SpecDecodeBaseProposer:
                 )
             else:
                 self.parallel_drafting_hidden_state_tensor.copy_(flat_mask)
+
+    def _maybe_load_parallel_drafting_mask_embedding(self) -> None:
+        """Load a checkpoint-provided mask token embedding into the embed table.
+
+        DFlash FP4 exports ship the trained mask embedding as
+        ``mask_embedding.pt`` next to the draft weights because the target
+        checkpoint's embedding row for ``mask_token_id`` is zeroed/untrained.
+        Without it, every masked draft slot is embedded as ~zero and the
+        drafter's per-position acceptance collapses after the first position.
+        """
+        if not self.parallel_drafting:
+            return
+        mask_path = os.path.join(self.draft_model_config.model, "mask_embedding.pt")
+        if not os.path.exists(mask_path):
+            return
+        data = torch.load(mask_path, map_location="cpu", weights_only=True)
+        if isinstance(data, dict):
+            file_token_id = data.get("mask_token_id")
+            embedding = data.get("embedding")
+        else:
+            file_token_id = None
+            embedding = data
+        if embedding is None:
+            logger.warning(
+                "Ignoring %s: no 'embedding' entry found.", mask_path
+            )
+            return
+        if file_token_id is not None and int(file_token_id) != int(
+            self.parallel_drafting_token_id
+        ):
+            logger.warning(
+                "mask_embedding.pt token id %s differs from configured "
+                "mask_token_id %s; using the file's token id.",
+                file_token_id,
+                self.parallel_drafting_token_id,
+            )
+        token_id = int(
+            file_token_id
+            if file_token_id is not None
+            else self.parallel_drafting_token_id
+        )
+        embedding = embedding.reshape(-1)
+
+        embed_tokens = self.model.model.embed_tokens
+        weight = embed_tokens.weight
+        shard_indices = getattr(embed_tokens, "shard_indices", None)
+        if shard_indices is not None:
+            start = shard_indices.org_vocab_start_index
+            end = shard_indices.org_vocab_end_index
+        else:
+            start, end = 0, weight.shape[0]
+        if start <= token_id < end:
+            row = weight.data[token_id - start]
+            embedding = embedding.to(device=row.device, dtype=row.dtype)
+            if embedding.shape != row.shape:
+                raise ValueError(
+                    "mask_embedding.pt shape "
+                    f"{tuple(embedding.shape)} does not match embedding row "
+                    f"shape {tuple(row.shape)}."
+                )
+            row.copy_(embedding)
+        logger.info_once(
+            "Loaded parallel-drafting mask embedding for token %d from %s.",
+            token_id,
+            mask_path,
+            scope="local",
+        )
 
     def _maybe_share_embeddings(self, target_language_model: nn.Module) -> None:
         """

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -1665,7 +1665,7 @@ class SpecDecodeBaseProposer:
         self.kv_cache_gid = self._draft_kv_cache_group_ids[0]
 
         attention_groups: dict[
-            tuple[int, tuple[str, str], KVCacheSpec], AttentionGroup
+            tuple[int, tuple[str, str], KVCacheSpec, tuple[Any, ...]], AttentionGroup
         ] = {}
         for layer_name in self._draft_attn_layer_names:
             gid = self._draft_layer_to_kv_cache_gid[layer_name]
@@ -1674,9 +1674,11 @@ class SpecDecodeBaseProposer:
             if isinstance(layer_kv_cache_spec, UniformTypeKVCacheSpecs):
                 layer_kv_cache_spec = layer_kv_cache_spec.kv_cache_specs[layer_name]
 
-            attn_backend = all_attn_layers[layer_name].get_attn_backend()
+            attn_layer = all_attn_layers[layer_name]
+            attn_backend = attn_layer.get_attn_backend()
             backend_key = attn_backend.full_cls_name()
-            group_key = (gid, backend_key, layer_kv_cache_spec)
+            metadata_group_key = attn_backend.get_metadata_group_key(attn_layer)
+            group_key = (gid, backend_key, layer_kv_cache_spec, metadata_group_key)
             if group_key not in attention_groups:
                 kernel_block_size = (
                     kernel_block_sizes[gid]

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -31,7 +31,11 @@ from vllm.v1.attention.backend import CommonAttentionMetadata
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 from vllm.v1.attention.backends.triton_attn import TritonAttentionMetadata
 from vllm.v1.cudagraph_dispatcher import CudagraphDispatcher
-from vllm.v1.kv_cache_interface import KVCacheConfig, UniformTypeKVCacheSpecs
+from vllm.v1.kv_cache_interface import (
+    KVCacheConfig,
+    KVCacheSpec,
+    UniformTypeKVCacheSpecs,
+)
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.ops.topk_topp_sampler import (
     empty_exponential_noise_like,
@@ -149,6 +153,8 @@ class SpecDecodeBaseProposer:
 
         self.draft_attn_groups: list[AttentionGroup] = []
         self.kv_cache_gid: int = -1
+        self._draft_layer_to_kv_cache_gid: dict[str, int] = {}
+        self._draft_kv_cache_group_ids: list[int] = []
         self.eagle3_use_aux_hidden_state: bool = (
             self._get_eagle3_use_aux_hidden_state_from_config()
         )
@@ -1619,6 +1625,9 @@ class SpecDecodeBaseProposer:
             == 1
         ), "All drafting layers should belong to the same kv cache group"
 
+    def allow_multiple_draft_kv_cache_groups(self) -> bool:
+        return False
+
     def initialize_attn_backend(
         self,
         kv_cache_config: KVCacheConfig,
@@ -1633,47 +1642,61 @@ class SpecDecodeBaseProposer:
             AttentionLayerBase,  # type: ignore[type-abstract]
         )
 
-        # Find which kv_cache_group the draft layers belong to
-        self.validate_same_kv_cache_group(kv_cache_config)
-        kv_cache_spec = None
-        for gid, group in enumerate(kv_cache_config.kv_cache_groups):
-            if self._draft_attn_layer_names & set(group.layer_names):
-                self.kv_cache_gid = gid
-                kv_cache_spec = group.kv_cache_spec
-                break
+        self._draft_layer_to_kv_cache_gid = {
+            layer_name: gid
+            for gid, group in enumerate(kv_cache_config.kv_cache_groups)
+            for layer_name in group.layer_names
+            if layer_name in self._draft_attn_layer_names
+        }
+        missing_layers = self._draft_attn_layer_names - set(
+            self._draft_layer_to_kv_cache_gid
+        )
+        assert not missing_layers, (
+            "Draft attention layers are missing from KV cache groups: "
+            f"{sorted(missing_layers)}"
+        )
+        self._draft_kv_cache_group_ids = sorted(
+            set(self._draft_layer_to_kv_cache_gid.values())
+        )
+        if not self.allow_multiple_draft_kv_cache_groups():
+            assert len(self._draft_kv_cache_group_ids) == 1, (
+                "All drafting layers should belong to the same kv cache group"
+            )
+        self.kv_cache_gid = self._draft_kv_cache_group_ids[0]
 
-        attention_groups: dict[tuple[str, str], AttentionGroup] = {}
-        if kv_cache_spec is not None:
-            for layer_name in self._draft_attn_layer_names:
-                attn_backend = all_attn_layers[layer_name].get_attn_backend()
-                backend_key = attn_backend.full_cls_name()
-                if backend_key not in attention_groups:
-                    layer_kv_cache_spec = kv_cache_spec
-                    if isinstance(layer_kv_cache_spec, UniformTypeKVCacheSpecs):
-                        layer_kv_cache_spec = layer_kv_cache_spec.kv_cache_specs[
-                            layer_name
-                        ]
+        attention_groups: dict[
+            tuple[int, tuple[str, str], KVCacheSpec], AttentionGroup
+        ] = {}
+        for layer_name in self._draft_attn_layer_names:
+            gid = self._draft_layer_to_kv_cache_gid[layer_name]
+            kv_cache_spec = kv_cache_config.kv_cache_groups[gid].kv_cache_spec
+            layer_kv_cache_spec = kv_cache_spec
+            if isinstance(layer_kv_cache_spec, UniformTypeKVCacheSpecs):
+                layer_kv_cache_spec = layer_kv_cache_spec.kv_cache_specs[layer_name]
 
-                    kernel_block_size = (
-                        kernel_block_sizes[self.kv_cache_gid]
-                        if kernel_block_sizes is not None
-                        and self.kv_cache_gid < len(kernel_block_sizes)
-                        else None
-                    )
-                    attn_group = AttentionGroup(
-                        backend=attn_backend,
-                        layer_names=[layer_name],
-                        kv_cache_spec=layer_kv_cache_spec,
-                        kv_cache_group_id=self.kv_cache_gid,
-                    )
-                    attn_group.create_metadata_builders(
-                        self.vllm_config,
-                        self.device,
-                        kernel_block_size=kernel_block_size,
-                    )
-                    attention_groups[backend_key] = attn_group
-                else:
-                    attention_groups[backend_key].layer_names.append(layer_name)
+            attn_backend = all_attn_layers[layer_name].get_attn_backend()
+            backend_key = attn_backend.full_cls_name()
+            group_key = (gid, backend_key, layer_kv_cache_spec)
+            if group_key not in attention_groups:
+                kernel_block_size = (
+                    kernel_block_sizes[gid]
+                    if kernel_block_sizes is not None and gid < len(kernel_block_sizes)
+                    else None
+                )
+                attn_group = AttentionGroup(
+                    backend=attn_backend,
+                    layer_names=[layer_name],
+                    kv_cache_spec=layer_kv_cache_spec,
+                    kv_cache_group_id=gid,
+                )
+                attn_group.create_metadata_builders(
+                    self.vllm_config,
+                    self.device,
+                    kernel_block_size=kernel_block_size,
+                )
+                attention_groups[group_key] = attn_group
+            else:
+                attention_groups[group_key].layer_names.append(layer_name)
 
         self.draft_attn_groups = list(attention_groups.values())
         self.block_size = (

--- a/vllm/v1/worker/gpu/attn_utils.py
+++ b/vllm/v1/worker/gpu/attn_utils.py
@@ -86,8 +86,10 @@ def init_attn_backend(
         layer_type = cast(type[Any], AttentionLayerBase)
         attn_layers = get_layers_from_vllm_config(vllm_config, layer_type, layer_names)
 
-        group_map: dict[tuple[tuple[str, str], KVCacheSpec], AttentionGroup] = {}
-        group_order: list[tuple[tuple[str, str], KVCacheSpec]] = []
+        group_map: dict[
+            tuple[tuple[str, str], KVCacheSpec, tuple[Any, ...]], AttentionGroup
+        ] = {}
+        group_order: list[tuple[tuple[str, str], KVCacheSpec, tuple[Any, ...]]] = []
 
         for layer_name in layer_names:
             attn_backend = attn_layers[layer_name].get_attn_backend()
@@ -96,7 +98,14 @@ def init_attn_backend(
             if isinstance(layer_kv_cache_spec, UniformTypeKVCacheSpecs):
                 layer_kv_cache_spec = layer_kv_cache_spec.kv_cache_specs[layer_name]
 
-            key = (attn_backend.full_cls_name(), layer_kv_cache_spec)
+            metadata_group_key = attn_backend.get_metadata_group_key(
+                attn_layers[layer_name]
+            )
+            key = (
+                attn_backend.full_cls_name(),
+                layer_kv_cache_spec,
+                metadata_group_key,
+            )
             if key not in group_map:
                 group_map[key] = AttentionGroup(
                     attn_backend, [layer_name], layer_kv_cache_spec, kv_cache_group_id

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -2407,6 +2407,14 @@ class GPUModelRunner(
         # Prepare the attention metadata for each KV cache group and make layers
         # in the same group share the same metadata.
         spec_decode_common_attn_metadata = None
+        dflash_drafter = (
+            self.drafter
+            if self.speculative_config and isinstance(self.drafter, DFlashProposer)
+            else None
+        )
+        if dflash_drafter is not None:
+            dflash_drafter.clear_draft_block_tables()
+
         for kv_cache_gid, kv_cache_group in enumerate(kv_cache_groups):
             cm = copy(cm_base)  # shallow copy
 
@@ -2421,6 +2429,11 @@ class GPUModelRunner(
             if kv_cache_gid > 0:
                 cm.block_table_tensor = _get_block_table(kv_cache_gid)
                 cm.slot_mapping = slot_mappings[kv_cache_gid]
+
+            if dflash_drafter is not None:
+                dflash_drafter.set_draft_block_table(
+                    kv_cache_gid, cm.block_table_tensor
+                )
 
             if self.speculative_config and spec_decode_common_attn_metadata is None:
                 if isinstance(
@@ -5313,12 +5326,12 @@ class GPUModelRunner(
             eagle_config = getattr(hf_config, "eagle_config", None)
 
             if dflash_config and isinstance(dflash_config, dict):
-                # Add 1 to convert DFlash's aux layer id semantics
+                # Add 1 to convert DFlash's aux layer id semantics.
                 layer_ids = [
                     i + 1 for i in (dflash_config.get("target_layer_ids") or [])
                 ]
 
-            if eagle_config and isinstance(eagle_config, dict):
+            if not layer_ids and eagle_config and isinstance(eagle_config, dict):
                 layer_ids = eagle_config.get("eagle_aux_hidden_state_layer_ids")
 
         if layer_ids and isinstance(layer_ids, (list, tuple)):
@@ -7045,6 +7058,122 @@ class GPUModelRunner(
         for attn_groups in self.attn_groups:
             yield from attn_groups
 
+    @staticmethod
+    def _get_kv_cache_stride_order(
+        attn_backend: type[AttentionBackend],
+        kv_cache_shape: tuple[int, ...],
+    ) -> tuple[int, ...]:
+        try:
+            kv_cache_stride_order = attn_backend.get_kv_cache_stride_order()
+            assert len(kv_cache_stride_order) == len(kv_cache_shape)
+            return kv_cache_stride_order
+        except (AttributeError, NotImplementedError):
+            return tuple(range(len(kv_cache_shape)))
+
+    @classmethod
+    def _get_standard_kv_cache_orders(
+        cls,
+        attn_backend: type[AttentionBackend],
+        kv_cache_shape: tuple[int, ...],
+        num_blocks: int,
+    ) -> tuple[tuple[int, ...], tuple[str, ...] | None, tuple[str, ...] | None]:
+        stride_order = cls._get_kv_cache_stride_order(attn_backend, kv_cache_shape)
+        if len(kv_cache_shape) != 5:
+            return stride_order, None, None
+        if kv_cache_shape[:2] == (2, num_blocks):
+            public_order = ("kv", "block", "token", "head", "dim")
+        elif kv_cache_shape[:2] == (num_blocks, 2):
+            public_order = ("block", "kv", "token", "head", "dim")
+        else:
+            return stride_order, None, None
+        return stride_order, public_order, tuple(public_order[i] for i in stride_order)
+
+    @staticmethod
+    def _view_kv_cache_with_physical_order(
+        raw_tensor: torch.Tensor,
+        kv_cache_shape: tuple[int, ...],
+        public_order: tuple[str, ...],
+        physical_order: tuple[str, ...],
+    ) -> torch.Tensor:
+        # Backends can expose the same standard KV cache with different public
+        # shapes or physical orders. When they share one raw tensor, keep each
+        # backend's public shape but map it to the shared physical layout.
+        dim_sizes = dict(zip(public_order, kv_cache_shape))
+        physical_strides: dict[str, int] = {}
+        stride = 1
+        for dim in reversed(physical_order):
+            physical_strides[dim] = stride
+            stride *= dim_sizes[dim]
+        public_strides = tuple(physical_strides[dim] for dim in public_order)
+        return torch.as_strided(
+            raw_tensor,
+            size=kv_cache_shape,
+            stride=public_strides,
+        )
+
+    @staticmethod
+    def _get_attention_kv_cache_shape(
+        attn_backend: type[AttentionBackend],
+        kv_cache_spec: AttentionSpec,
+        num_blocks: int,
+        kernel_block_size: int,
+        cache_dtype_str: str,
+    ) -> tuple[int, ...]:
+        # For MLA with compression, storage_block_size != block_size.
+        if kv_cache_spec.storage_block_size != kv_cache_spec.block_size:
+            shape_block_size = kv_cache_spec.storage_block_size
+        else:
+            shape_block_size = kernel_block_size
+        return attn_backend.get_kv_cache_shape(
+            num_blocks,
+            shape_block_size,
+            kv_cache_spec.num_kv_heads,
+            kv_cache_spec.head_size,
+            cache_dtype_str=cache_dtype_str,
+        )
+
+    def _get_raw_tensor_physical_orders(
+        self,
+        kv_cache_raw_tensors: dict[str, torch.Tensor],
+        kernel_block_sizes: list[int],
+    ) -> dict[int, set[tuple[str, ...]]]:
+        raw_tensor_physical_orders: dict[int, set[tuple[str, ...]]] = defaultdict(set)
+        for group in self._kv_cache_spec_attn_group_iterator():
+            kv_cache_spec = group.kv_cache_spec
+            if group.kv_cache_group_id == len(kernel_block_sizes) or not isinstance(
+                kv_cache_spec, AttentionSpec
+            ):
+                continue
+            kernel_block_size = kernel_block_sizes[group.kv_cache_group_id]
+            for layer_name in group.layer_names:
+                if (
+                    layer_name in self.runner_only_attn_layers
+                    or layer_name not in kv_cache_raw_tensors
+                ):
+                    continue
+                raw_tensor = kv_cache_raw_tensors[layer_name]
+                num_blocks = raw_tensor.numel() // kv_cache_spec.page_size_bytes
+                num_blocks *= kv_cache_spec.block_size // kernel_block_size
+                cache_dtype_str = (
+                    getattr(kv_cache_spec, "cache_dtype_str", None)
+                    or self.cache_config.cache_dtype
+                )
+                kv_cache_shape = self._get_attention_kv_cache_shape(
+                    group.backend,
+                    kv_cache_spec,
+                    num_blocks,
+                    kernel_block_size,
+                    cache_dtype_str,
+                )
+                _, _, physical_order = self._get_standard_kv_cache_orders(
+                    group.backend,
+                    kv_cache_shape,
+                    num_blocks,
+                )
+                if physical_order is not None:
+                    raw_tensor_physical_orders[id(raw_tensor)].add(physical_order)
+        return raw_tensor_physical_orders
+
     def _reshape_kv_cache_tensors(
         self,
         kv_cache_raw_tensors: dict[str, torch.Tensor],
@@ -7063,6 +7192,10 @@ class GPUModelRunner(
         """
         kv_caches: dict[str, torch.Tensor] = {}
         has_attn, has_mamba = False, False
+        raw_tensor_physical_orders = self._get_raw_tensor_physical_orders(
+            kv_cache_raw_tensors, kernel_block_sizes
+        )
+
         for group in self._kv_cache_spec_attn_group_iterator():
             kv_cache_spec = group.kv_cache_spec
             attn_backend = group.backend
@@ -7083,29 +7216,49 @@ class GPUModelRunner(
                     )
                     kernel_num_blocks = num_blocks * num_blocks_per_kv_block
 
-                    # For MLA with compression, storage_block_size != block_size
-                    if kv_cache_spec.storage_block_size != kv_cache_spec.block_size:
-                        shape_block_size = kv_cache_spec.storage_block_size
-                    else:
-                        shape_block_size = kernel_block_size
-
                     cache_dtype_str = (
                         getattr(kv_cache_spec, "cache_dtype_str", None)
                         or self.cache_config.cache_dtype
                     )
-                    kv_cache_shape = attn_backend.get_kv_cache_shape(
+                    kv_cache_shape = self._get_attention_kv_cache_shape(
+                        attn_backend,
+                        kv_cache_spec,
                         kernel_num_blocks,
-                        shape_block_size,
-                        kv_cache_spec.num_kv_heads,
-                        kv_cache_spec.head_size,
-                        cache_dtype_str=cache_dtype_str,
+                        kernel_block_size,
+                        cache_dtype_str,
+                    )
+                    (
+                        kv_cache_stride_order,
+                        public_order,
+                        physical_order,
+                    ) = self._get_standard_kv_cache_orders(
+                        attn_backend,
+                        kv_cache_shape,
+                        kernel_num_blocks,
                     )
                     dtype = kv_cache_spec.dtype
-                    try:
-                        kv_cache_stride_order = attn_backend.get_kv_cache_stride_order()
-                        assert len(kv_cache_stride_order) == len(kv_cache_shape)
-                    except (AttributeError, NotImplementedError):
-                        kv_cache_stride_order = tuple(range(len(kv_cache_shape)))
+                    shared_orders = raw_tensor_physical_orders[id(raw_tensor)]
+                    block_major_orders = (
+                        order for order in shared_orders if order[:2] == ("block", "kv")
+                    )
+                    shared_physical_order = next(
+                        iter(sorted(block_major_orders)), None
+                    ) or next(iter(sorted(shared_orders)), None)
+                    raw_tensor = raw_tensor.view(dtype)
+                    if (
+                        public_order is not None
+                        and physical_order != shared_physical_order
+                        and shared_physical_order is not None
+                        and kv_cache_spec.page_size_padded is None
+                    ):
+                        kv_caches[layer_name] = self._view_kv_cache_with_physical_order(
+                            raw_tensor,
+                            kv_cache_shape,
+                            public_order,
+                            shared_physical_order,
+                        )
+                        continue
+
                     # The allocation respects the backend-defined stride order
                     # to ensure the semantic remains consistent for each
                     # backend. We first obtain the generic kv cache shape and
@@ -7120,16 +7273,15 @@ class GPUModelRunner(
                         for i in range(len(kv_cache_stride_order))
                     ]
 
-                    raw_tensor = kv_cache_raw_tensors[layer_name].view(dtype)
                     if kv_cache_spec.page_size_padded is not None:
                         # Use strided view to handle page_size_bytes that
-                        # include padding. This follows
-                        # the same pattern as MambaSpec handling below.
+                        # include padding. This follows the same pattern as
+                        # MambaSpec handling below.
                         # NOTE: This assumes kv_cache_shape[0] == num_blocks
                         # (i.e. the first physical dimension is the block
                         # index), which holds for MLA backends but NOT for
-                        # standard attention backends whose shape starts with
-                        # a K/V dimension of size 2.
+                        # standard attention backends whose shape starts
+                        # with a K/V dimension of size 2.
                         dtype_size = get_dtype_size(dtype)
                         page_stride = kv_cache_spec.page_size_bytes // dtype_size
                         strides = list(torch.empty(kv_cache_shape).stride())

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6721,6 +6721,7 @@ class GPUModelRunner(
             attn_backend: type[AttentionBackend]
             kv_cache_spec: KVCacheSpec
             num_heads_q: int
+            metadata_group_key: tuple[Any, ...]
 
         def get_attn_backends_for_group(
             kv_cache_group_spec: KVCacheGroupSpec,
@@ -6756,9 +6757,20 @@ class GPUModelRunner(
                 # fallback can never spuriously merge them with attention
                 # layers.
                 num_heads_q = getattr(layers[layer_name], "num_heads", 0)
-                key = (full_cls_name, layer_kv_cache_spec, num_heads_q)
+                metadata_group_key = attn_backend.get_metadata_group_key(
+                    layers[layer_name]
+                )
+                key = (
+                    full_cls_name,
+                    layer_kv_cache_spec,
+                    num_heads_q,
+                    metadata_group_key,
+                )
                 attn_backends[key] = AttentionGroupKey(
-                    attn_backend, layer_kv_cache_spec, num_heads_q
+                    attn_backend,
+                    layer_kv_cache_spec,
+                    num_heads_q,
+                    metadata_group_key,
                 )
                 attn_backend_layers[key].append(layer_name)
             return (
@@ -6771,11 +6783,11 @@ class GPUModelRunner(
             kv_cache_group_id: int,
         ) -> list[AttentionGroup]:
             attn_groups: list[AttentionGroup] = []
-            for key, layer_names in attn_backends_map.items():
+            for group_key, layer_names in attn_backends_map.items():
                 attn_group = AttentionGroup(
-                    key.attn_backend,
+                    group_key.attn_backend,
                     layer_names,
-                    key.kv_cache_spec,
+                    group_key.kv_cache_spec,
                     kv_cache_group_id,
                 )
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3751,20 +3751,26 @@ class GPUModelRunner(
         uniform_decode_query_len: int,
         num_tokens: int,
         num_reqs: int,
+        num_computed_tokens_cpu: np.ndarray,
+        num_prompt_tokens_cpu: np.ndarray,
         force_uniform_decode: bool | None = None,
     ) -> bool:
         """
         Checks if it's a decode batch with same amount scheduled tokens
         across all requests.
+
+        Verifies that no request is still prefilling
+        (num_computed_tokens < num_prompt_tokens), which prevents
+        misclassifying a prefill whose token count happens to match
+        uniform_decode_query_len * num_reqs.
         """
-        return (
-            (
-                (max_num_scheduled_tokens == uniform_decode_query_len)
-                and (num_tokens == max_num_scheduled_tokens * num_reqs)
-            )
-            if force_uniform_decode is None
-            else force_uniform_decode
-        )
+        if force_uniform_decode is not None:
+            return force_uniform_decode
+        if (max_num_scheduled_tokens != uniform_decode_query_len) or (
+            num_tokens != max_num_scheduled_tokens * num_reqs
+        ):
+            return False
+        return bool(np.all(num_computed_tokens_cpu >= num_prompt_tokens_cpu))
 
     def _determine_batch_execution_and_padding(
         self,
@@ -3794,7 +3800,12 @@ class GPUModelRunner(
             num_tokens=num_tokens,
             num_reqs=num_reqs,
             force_uniform_decode=force_uniform_decode,
+            num_computed_tokens_cpu=(
+                self.input_batch.num_computed_tokens_cpu[:num_reqs]
+            ),
+            num_prompt_tokens_cpu=self.input_batch.num_prompt_tokens[:num_reqs],
         )
+
         # Encoder-decoder models only support CG for decoder_step > 0 (no enc_output
         # is present). Also, chunked-prefill is disabled, so batch are uniform.
         has_encoder_output = (


### PR DESCRIPTION
## Summary

Full MiMo V2.5 Pro FP4-DFlash bringup stack on top of `dev/black-benediction` (`bb6c5b7`), measured on 8x RTX PRO 6000 Blackwell (TP8, fp8 KV, b12x MoE+linear, TRITON_ATTN).

### Runtime support (ports)
- `dbdedbb1e`/`340ee7ad5`: MiMo V2.5 FP4 runtime (B12X Triton + FlashInfer Cutlass MoE routing for `quant_method=fp8, store_dtype=mxfp4` checkpoints), already pushed earlier as `codex/mimo-v25-pro-fp4-dflash-black-unified-20260610`.
- `a4f88334f`..`c34229f38`: DFlash drafter port — SWA draft layers, FlashInfer backend support, draft attention sink bias loading/TP-slicing, MiMo `dflash_config.use_swa` mapping, draft inherits the target attention backend.

### Fix 1: b12x MoE repetition (`c02e56cfd`)
`moe_backend=b12x` fell through to `GptOssMxfp4MoEMethod`, which hardcodes the GPT-OSS clamped SwiGLU (`swiglu_limit=7.0`). The B12X W4A16 kernel honors the clamp, so every MiMo MoE layer clamped gate/up at ±7 — MiMo is trained with unclamped SiLU, and long generations drifted into repetition loops (FlashInfer Cutlass did not loop because it already used `Mxfp4MoEMethod`). Route `b12x` to the DeepSeek-style method too. Estonia probe: 12/12 stop, 0 hit-max-tokens (previously streams looped to the 40k cap).

### Fix 2: DFlash acceptance far below official claims (`4313afe0b`)
Mean accept length was ~1.98–2.0 vs the official 3.18–6.30. Three divergences from the reference (`dflash/dflash.py` in the checkpoint + sglang DFLASH):
1. **`dflash/mask_embedding.pt` was never loaded.** The FP4 export zeroes the target embedding row for `mask_token_id` 151669 (norm 8e-4) and ships the trained vector separately (norm 3.9). Every masked draft slot embedded as ~zero — per-position acceptance collapsed 78/44/15/1/0%. Now loaded TP-aware after embedding sharing.
2. **SWA draft layers were forced causal.** Reference drafts the block bidirectionally; the sliding window only bounds context lookback. The triton mask now supports window+non-causal and dflash.py no longer special-cases SWA layers.
3. **Last aux feature lacked the final norm.** The reference extracts HF `hidden_states[id+1]`; index 70 is post-final-norm. Captured accordingly (escape hatch `VLLM_DFLASH_PRENORM_LAST_AUX=1`).

Result (ntok7 = official block 8, temp 0): mean accept length **code 4.96 / math 4.99 / chat 2.74** (official claims 4.54 / 5.56 / 3.18); ctx0 decode 169→175 tok/s vs 104 no-MTP.

### Fix 3: DFlash long-context collapse (`855d19819`)
Decode fell to 29.6 tok/s at 128k (below the 60.9 no-MTP baseline) while acceptance held:
1. Non-causal tile pruning was missing (`compute_tile_loop_bounds` was CAUSAL-gated) — draft SWA layers scanned the full context each step. Now pruned via the backward window bound.
2. Spec-verify (q_len 8) was locked out of the 3D segment-parallel softmax path (`max_seqlen_q > 1`) and ran the 2D kernel on a ~9-CTA grid for 128k KV scans. Now gated on query tokens fitting the segment buffers (`q.shape[0] > seq_threshold_3D`); single-token decode takes the identical path as before (tokens == seqs), prefills stay 2D.

Result: 128k decode **29.6 → 110.6 tok/s**; ~190k probe 44 → 153.8 tok/s (step 97 → 30.1 ms, accept 4.65).

## Testing
- `tmp_dflash_accept_probe.py` (temp-0 code/math/chat, /metrics per-position deltas) — numbers above
- `llm_decode_bench.py --contexts 0k/128k --skip-prefill` cc1 — numbers above
- estonia C=6/R=12 long-generation probe: 12/12 stop, 0 hit-max-tokens, no repetition with and without DFlash
- temp-0 6k-token generations: no tail cycling (worst period coverage 0.08)

## Notes
- No b12x library changes required; everything is vLLM-side.
- Known follow-ups: draft rotary_dim A/B (we use 64 = HF reference + target-consistent; upstream sglang uses full 128), sliding-window draft KV cache (sglang `use_compact_draft_cache`) to reclaim draft KV memory at long context.
- AI assistance was used for the analysis and implementation; all changes were measured end-to-end on this host as described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)