### PR TITLE
Route b12x MXFP4 MoE to DeepSeek-style method (fixes MiMo long-generation repetition)

### DIFF
--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -369,6 +369,9 @@ class Attention(nn.Module, AttentionLayerBase):
             if block_n is not None:
                 extra_impl_args.setdefault("block_n", block_n)
 
+        if self.attn_backend.get_name() == "B12X_PAGED_ATTN":
+            extra_impl_args.setdefault("head_size_v", self.head_size_v)
+
         impl_cls = self.attn_backend.get_impl_cls()
         self.impl = impl_cls(  # type: ignore[assignment]  # impl_cls always returns an AttentionImpl subclass
             num_heads,

--- a/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutlass_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutlass_moe.py
@@ -97,7 +97,26 @@ class FlashInferExperts(mk.FusedMoEExpertsModular):
         self.max_capture_size = (
             get_current_vllm_config().compilation_config.max_cudagraph_capture_size
         )
+        self.model_type = getattr(
+            get_current_vllm_config().model_config.hf_config,
+            "model_type",
+            None,
+        )
+        self.gemm1_alpha: torch.Tensor | None = None
+        self.gemm1_beta: torch.Tensor | None = None
         self.gemm1_clamp_limit: torch.Tensor | None = None
+        if quant_config.gemm1_alpha is not None:
+            self.gemm1_alpha = torch.tensor(
+                [quant_config.gemm1_alpha] * self.num_experts,
+                dtype=torch.float32,
+                device=self.device,
+            )
+        if quant_config.gemm1_beta is not None:
+            self.gemm1_beta = torch.tensor(
+                [quant_config.gemm1_beta] * self.num_experts,
+                dtype=torch.float32,
+                device=self.device,
+            )
         if quant_config.gemm1_clamp_limit is not None:
             self.gemm1_clamp_limit = torch.tensor(
                 [quant_config.gemm1_clamp_limit] * self.num_experts,
@@ -106,19 +125,37 @@ class FlashInferExperts(mk.FusedMoEExpertsModular):
             )
 
         if quant_config.weight_quant_dtype == "mxfp4":
-            # This value is used specifically for gpt-oss,
-            # Need to revisit this for other models
-            self.gemm1_alpha = torch.tensor(
-                [1.702] * self.num_experts, dtype=torch.float32, device=self.device
-            )
-            self.gemm1_beta = torch.tensor(
-                [1.0] * self.num_experts, dtype=torch.float32, device=self.device
-            )
-            if self.gemm1_clamp_limit is None:
+            # GPT-OSS uses a non-standard clamped SwiGLU. Other MXFP4 MoE
+            # models should use the standard activation unless their quant
+            # config explicitly supplies these parameters.
+            if self.model_type == "gpt_oss":
+                if self.gemm1_alpha is None:
+                    self.gemm1_alpha = torch.tensor(
+                        [1.702] * self.num_experts,
+                        dtype=torch.float32,
+                        device=self.device,
+                    )
+                if self.gemm1_beta is None:
+                    self.gemm1_beta = torch.tensor(
+                        [1.0] * self.num_experts,
+                        dtype=torch.float32,
+                        device=self.device,
+                    )
+            if self.model_type == "gpt_oss" and self.gemm1_clamp_limit is None:
                 self.gemm1_clamp_limit = torch.tensor(
                     [7.0] * self.num_experts,
                     dtype=torch.float32,
                     device=self.device,
+                )
+            elif (
+                self.gemm1_alpha is None
+                and self.gemm1_beta is None
+                and self.gemm1_clamp_limit is None
+            ):
+                logger.info_once(
+                    "Using standard SwiGLU parameters for FlashInfer MXFP4 MoE "
+                    "(model_type=%s).",
+                    self.model_type,
                 )
             if quant_config.quant_dtype == "mxfp8":
                 self.fake_input_scale = torch.ones(
@@ -326,9 +363,6 @@ class FlashInferExperts(mk.FusedMoEExpertsModular):
         elif self.weight_quant_dtype == "mxfp4":
             assert self.w1_scale is not None and self.w2_scale is not None
             assert w1.is_contiguous() and w2.is_contiguous()
-            assert self.gemm1_alpha is not None
-            assert self.gemm1_beta is not None
-            assert self.gemm1_clamp_limit is not None
             assert topk_ids.is_contiguous()
 
             fc1_expert_biases = self.w1_bias

--- a/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
@@ -1502,6 +1502,101 @@ def convert_weight_to_mxfp4_moe_kernel_format(
             w2_bias,
         )
 
+    elif mxfp4_backend in (
+        Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_BF16,
+        Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_MXFP8,
+    ):
+        # Native GLM/DeepSeek/MiMo MXFP4 loading produces contiguous
+        # [w1/gate, w3/up] rows. FlashInfer Cutlass consumes the opposite
+        # SwiGLU order, so swap the two halves without GPT-OSS de-interleave.
+        logger.info_once(
+            "Using contiguous w13 layout for FlashInfer Cutlass MXFP4 MoE."
+        )
+        w13_w = w13_weight.data
+        w1_w = w13_w[:, :intermediate_size, :]
+        w3_w = w13_w[:, intermediate_size:, :]
+        w13_weight_swapped = torch.cat([w3_w, w1_w], dim=1)
+
+        if w13_bias is None:
+            w13_bias = torch.zeros(
+                num_experts,
+                2 * intermediate_size,
+                dtype=torch.float32,
+                device=w13_weight.device,
+            )
+        else:
+            w13_bias = w13_bias.data.to(torch.float32)
+        if w2_bias is None:
+            w2_bias = torch.zeros(
+                num_experts,
+                hidden_size,
+                dtype=torch.float32,
+                device=w2_weight.device,
+            )
+        else:
+            w2_bias = w2_bias.data.to(torch.float32)
+        b1 = w13_bias[:, :intermediate_size]
+        b3 = w13_bias[:, intermediate_size:]
+        w13_bias_swapped = torch.cat([b3, b1], dim=-1).to(torch.bfloat16)
+        w2_bias = w2_bias.to(torch.bfloat16)
+
+        w13_s = w13_weight_scale.data
+        s1 = w13_s[:, :intermediate_size, :]
+        s3 = w13_s[:, intermediate_size:, :]
+        w13_scale_swapped = torch.cat([s3, s1], dim=1)
+
+        if mxfp4_backend == Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_MXFP8:
+            from flashinfer import block_scale_interleave
+
+            orig_shape = w13_scale_swapped.shape
+            w13_scale_interleaved = block_scale_interleave(
+                w13_scale_swapped.view(torch.uint8)
+            ).reshape(orig_shape)
+
+            w2_s = w2_weight_scale.data
+            orig_shape = w2_s.shape
+            w2_scale_interleaved = block_scale_interleave(
+                w2_s.view(torch.uint8)
+            ).reshape(orig_shape)
+
+            return (
+                w13_weight_swapped,
+                w2_weight.data,
+                w13_scale_interleaved,
+                w2_scale_interleaved,
+                w13_bias_swapped,
+                w2_bias,
+            )
+
+        assert mxfp4_backend == Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_BF16
+
+        from flashinfer.fused_moe import (
+            interleave_moe_scales_for_sm90_mixed_gemm,
+            interleave_moe_weights_for_sm90_mixed_gemm,
+        )
+
+        w13_weight_interleaved = interleave_moe_weights_for_sm90_mixed_gemm(
+            w13_weight_swapped.contiguous(), "fp4"
+        )
+        w2_weight_interleaved = interleave_moe_weights_for_sm90_mixed_gemm(
+            w2_weight.data.contiguous(), "fp4"
+        )
+        w31_scales_interleaved = interleave_moe_scales_for_sm90_mixed_gemm(
+            w13_scale_swapped.to(torch.uint8)
+        )
+        w2_scale_interleaved = interleave_moe_scales_for_sm90_mixed_gemm(
+            w2_weight_scale.data.to(torch.uint8)
+        )
+
+        return (
+            w13_weight_interleaved,
+            w2_weight_interleaved,
+            w31_scales_interleaved,
+            w2_scale_interleaved,
+            w13_bias_swapped,
+            w2_bias,
+        )
+
     elif mxfp4_backend in TRITON_BACKENDS:
         from triton_kernels.matmul_ogs import FlexCtx, PrecisionConfig
 
@@ -1567,7 +1662,7 @@ def convert_weight_to_mxfp4_moe_kernel_format(
     else:
         raise ValueError(
             f"Unsupported mxfp4_backend for Mxfp4MoEMethod: {mxfp4_backend}. "
-            f"Expected TRTLLM, Triton, AITER, or XPU backend."
+            f"Expected TRTLLM, Triton, AITER, XPU, or FLASHINFER_CUTLASS backend."
         )
 
 

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -106,6 +106,7 @@ class Fp8Config(QuantizationConfig):
         activation_scheme: str = "dynamic",
         ignored_layers: list[str] | None = None,
         weight_block_size: list[int] | None = None,
+        store_dtype: str | None = None,
     ) -> None:
         super().__init__()
 
@@ -133,6 +134,7 @@ class Fp8Config(QuantizationConfig):
                     f"{activation_scheme} activation scheme."
                 )
         self.weight_block_size = weight_block_size
+        self.store_dtype = store_dtype
         self.use_deep_gemm: bool | None = None
 
     @classmethod
@@ -162,6 +164,7 @@ class Fp8Config(QuantizationConfig):
         activation_scheme = cls.get_from_keys(config, ["activation_scheme"])
         ignored_layers = cls.get_from_keys_or(config, ["ignored_layers"], None)
         weight_block_size = cls.get_from_keys_or(config, ["weight_block_size"], None)
+        store_dtype = cls.get_from_keys_or(config, ["store_dtype"], None)
         if not ignored_layers:
             ignored_layers = cls.get_from_keys_or(
                 config, ["modules_to_not_convert"], None
@@ -171,6 +174,7 @@ class Fp8Config(QuantizationConfig):
             activation_scheme=activation_scheme,
             ignored_layers=ignored_layers,
             weight_block_size=weight_block_size,
+            store_dtype=store_dtype,
         )
 
     def get_quant_method(
@@ -198,6 +202,16 @@ class Fp8Config(QuantizationConfig):
                 fused_mapping=self.packed_modules_mapping,
             ):
                 return UnquantizedFusedMoEMethod(layer.moe_config)
+            if self.store_dtype == "mxfp4":
+                from vllm.model_executor.layers.quantization.mxfp4 import (
+                    GptOssMxfp4MoEMethod,
+                )
+
+                logger.info_once(
+                    "Using MXFP4 MoE method for FP8 checkpoint with "
+                    "store_dtype=mxfp4."
+                )
+                return GptOssMxfp4MoEMethod(layer.moe_config)
             if self.is_checkpoint_fp8_serialized:
                 moe_quant_method = Fp8MoEMethod(self, layer)
             else:

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -209,7 +209,14 @@ class Fp8Config(QuantizationConfig):
                 )
 
                 moe_backend = layer.moe_config.moe_backend
+                # FP8 checkpoints with store_dtype=mxfp4 (GLM/DeepSeek/MiMo
+                # style) use the standard SwiGLU. GptOssMxfp4MoEMethod
+                # hardcodes the GPT-OSS clamped activation
+                # (gemm1_alpha=1.702, beta=1.0, swiglu_limit=7.0); the B12X
+                # W4A16 kernel honors swiglu_limit and would clamp gate/up at
+                # +-7 in every MoE layer, distorting long generations.
                 if moe_backend in {
+                    "b12x",
                     "deep_gemm",
                     "flashinfer_cutlass",
                     "flashinfer_cutlass_afp8",

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -205,11 +205,29 @@ class Fp8Config(QuantizationConfig):
             if self.store_dtype == "mxfp4":
                 from vllm.model_executor.layers.quantization.mxfp4 import (
                     GptOssMxfp4MoEMethod,
+                    Mxfp4MoEMethod,
                 )
 
+                moe_backend = layer.moe_config.moe_backend
+                if moe_backend in {
+                    "deep_gemm",
+                    "flashinfer_cutlass",
+                    "flashinfer_cutlass_afp8",
+                    "flashinfer_trtllm",
+                    "flashinfer_trtllm_afp8",
+                }:
+                    logger.info_once(
+                        "Using DeepSeek-style MXFP4 MoE method for FP8 "
+                        "checkpoint with store_dtype=mxfp4 and "
+                        "moe_backend=%s.",
+                        moe_backend,
+                    )
+                    return Mxfp4MoEMethod(layer.moe_config)
+
                 logger.info_once(
-                    "Using MXFP4 MoE method for FP8 checkpoint with "
-                    "store_dtype=mxfp4."
+                    "Using GPT-OSS-style MXFP4 MoE method for FP8 "
+                    "checkpoint with store_dtype=mxfp4 and moe_backend=%s.",
+                    moe_backend,
                 )
                 return GptOssMxfp4MoEMethod(layer.moe_config)
             if self.is_checkpoint_fp8_serialized:

--- a/vllm/model_executor/models/mimo_v2.py
+++ b/vllm/model_executor/models/mimo_v2.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import os
 from collections.abc import Iterable
 from itertools import islice
 
@@ -47,9 +48,6 @@ from vllm.model_executor.model_loader.weight_utils import (
 from vllm.model_executor.models.utils import sequence_parallel_chunk
 from vllm.sequence import IntermediateTensors
 from vllm.v1.attention.backend import AttentionType
-from vllm.v1.attention.backends.flash_attn_diffkv import (
-    FlashAttentionDiffKVBackend,
-)
 
 from .interfaces import MixtureOfExperts, SupportsPP
 from .utils import (
@@ -284,6 +282,9 @@ class MiMoV2Attention(nn.Module):
             },
         )
 
+        if os.getenv("VLLM_MIMO_DISABLE_ATTENTION_SINKS") == "1":
+            add_swa_attention_sink_bias = False
+
         self.attention_sink_bias = (
             torch.nn.Parameter(torch.empty(self.num_heads), requires_grad=False)
             if add_swa_attention_sink_bias
@@ -292,13 +293,30 @@ class MiMoV2Attention(nn.Module):
 
         sliding_window = sliding_window_size if sliding_window_size > -1 else None
 
-        # Use DiffKV backend when V has a different head dim than K
-        if self.v_head_dim != self.head_dim:
-            FlashAttentionDiffKVBackend.set_head_size_v(self.v_head_dim)
-            attn_backend = FlashAttentionDiffKVBackend
-            logger.info_once("Using FlashAttentionDiffKVBackend for attention.")
-        else:
-            attn_backend = None
+        # FA2 paged attention expects K and V caches to have the same head dim.
+        # MiMo has head_dim=192 and v_head_dim=128, so pad V for standard FA/
+        # Triton-style cache layouts and slice the output back before o_proj.
+        configured_backend = get_current_vllm_config().attention_config.backend
+        use_flashinfer = (
+            configured_backend is not None and configured_backend.name == "FLASHINFER"
+        )
+        use_b12x_paged = (
+            configured_backend is not None
+            and configured_backend.name == "B12X_PAGED_ATTN"
+        )
+        if use_b12x_paged:
+            from vllm.v1.attention.backends.b12x_paged_attn import (
+                B12XPagedAttentionBackend,
+            )
+
+            B12XPagedAttentionBackend.set_head_size_v(self.v_head_dim)
+        self.pad_value_for_fa = (
+            self.v_head_dim != self.head_dim
+            and not use_flashinfer
+            and not use_b12x_paged
+        )
+        attn_head_size_v = self.head_dim if self.pad_value_for_fa else self.v_head_dim
+        attn_backend = None
 
         self.attn = Attention(
             self.num_heads,
@@ -312,7 +330,7 @@ class MiMoV2Attention(nn.Module):
             prefix=f"{prefix}.attn",
             sinks=self.attention_sink_bias,
             attn_backend=attn_backend,
-            head_size_v=self.v_head_dim,
+            head_size_v=attn_head_size_v,
         )
 
     def forward(
@@ -328,7 +346,18 @@ class MiMoV2Attention(nn.Module):
         if self.v_scale is not None:
             v = v * self.v_scale
 
+        if self.pad_value_for_fa:
+            v = torch.nn.functional.pad(
+                v.view(-1, self.num_kv_heads, self.v_head_dim),
+                [0, self.head_dim - self.v_head_dim],
+                value=0,
+            ).reshape(-1, self.num_kv_heads * self.head_dim)
+
         attn_output = self.attn(q, k, v)
+        if self.pad_value_for_fa:
+            attn_output = attn_output.view(-1, self.num_heads, self.head_dim)[
+                ..., : self.v_head_dim
+            ].reshape(-1, self.num_heads * self.v_head_dim)
 
         output, _ = self.o_proj(attn_output)
         return output


### PR DESCRIPTION
## Summary

Minimal standalone slice of #9 carrying just the MXFP4 MoE quant-method fix (plus the two MiMo FP4 runtime commits it depends on, already pushed earlier as `codex/mimo-v25-pro-fp4-dflash-black-unified-20260610`).

## Problem

MiMo V2.5 Pro FP4 (`quant_method=fp8, store_dtype=mxfp4`) with `--kernel-config.moe_backend b12x` produced coherent short outputs but drifted into repetition loops on long generations. FlashInfer Cutlass MoE on the same checkpoint did not loop.

Root cause chain:
1. The `store_dtype=mxfp4` router in `fp8.py` sent `moe_backend=b12x` to `GptOssMxfp4MoEMethod` (cutlass/trtllm/deep_gemm already went to the DeepSeek-style `Mxfp4MoEMethod`).
2. `GptOssMxfp4MoEMethod.get_fused_moe_quant_config` hardcodes the GPT-OSS clamped SwiGLU constants (`gemm1_alpha=1.702`, `gemm1_beta=1.0`, `swiglu_limit=7.0`).
3. For MXFP4 weights, `B12xExperts` always runs `w4a16` and forwards `gemm1_clamp_limit` as `swiglu_limit` into the b12x kernels, which clamp gate at max +7 and up at ±7 before `silu(gate)*up`.
4. MiMo is trained with unclamped SiLU; 69 clamped MoE layers systematically shifted logits and long generations fell into repetition attractors. (`gemm1_alpha/beta` are ignored by the b12x path, so the clamp was the only active wrong constant. Also: `B12X_MOE_FORCE_A16` is a no-op for MXFP4 weights — `_quant_mode()` is always `w4a16` — which is why earlier A16 on/off experiments showed no difference.)

## Fix

Add `"b12x"` to the set of moe_backends routed to `Mxfp4MoEMethod` for FP8 checkpoints with `store_dtype=mxfp4`. The b12x kernels are unchanged; `Mxfp4MoEMethod` already has full B12X support (explicit backend select, identity weight conversion, B12X w2-scale realign).

GPT-OSS is unaffected: it enters via `Mxfp4Config`/`GptOssMxfp4Config` (`quant_method=mxfp4`), never through this FP8 router, and the GPT-OSS fallthrough for other backends in this router is preserved.

## Testing

TP8 on 8x RTX PRO 6000 Blackwell, b12x MoE + b12x dense FP8, fp8 and bf16 KV, no MTP:
- startup logs show `Using DeepSeek-style MXFP4 MoE method ... moe_backend=b12x.` and no `GPT-OSS-style` line
- estonia long-generation probe (C=6/R=12): 12/12 `stop`, `hit_max_tokens: 0` — previously streams looped toward the 40k cap
- temp-0 6k-token generations: no tail cycling (worst period coverage 0.08 vs 0.85 loop threshold)
- short smokes coherent, KV cache sizing unchanged

## Notes

- Subset of #9 — merging either first is fine; the other rebases cleanly.
- AI assistance was used for the analysis and implementation; all changes were measured end-to-end as described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)