### PR TITLE
attention: support quantized KV cache in MLA DCP context prefill

### DIFF
--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -1283,6 +1283,7 @@ class MLACommonPrefillMetadata:
         padded_local_chunk_seq_lens: list[list[int]] | None = None
         local_context_lens_allranks: list[list[int]] | None = None
         padded_local_cu_seq_lens: torch.Tensor | None = None
+        padded_local_token_to_seq: torch.Tensor | None = None
         cu_seq_lens_lst: list[list[int]] | None = None
         chunk_size: int | None = None
         prefill_tokens_with_context: int | None = None
@@ -1805,6 +1806,19 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
                         out=padded_local_cu_chunk_seq_lens_cpu[:, 1:],
                         dtype=torch.int32,
                     )
+                    max_padded_local_tokens = (
+                        padded_local_chunk_seq_lens.sum(dim=1).max().item()
+                    )
+                    padded_local_token_to_seq_tensor_cpu = torch.zeros(
+                        [num_chunks, max_padded_local_tokens], dtype=torch.int32
+                    )
+                    for i in range(num_chunks):
+                        padded_local_token_to_seq = torch.repeat_interleave(
+                            range_idx, padded_local_chunk_seq_lens[i]
+                        )
+                        padded_local_token_to_seq_tensor_cpu[
+                            i, : padded_local_token_to_seq.shape[0]
+                        ] = padded_local_token_to_seq
 
                 prefill_tokens_with_context = None
                 if num_prefills_with_context_cpu > 0:
@@ -1828,6 +1842,11 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
                         local_context_lens_allranks=local_context_lens_allranks.tolist(),
                         padded_local_cu_seq_lens=padded_local_cu_chunk_seq_lens_cpu.to(
                             device, non_blocking=True
+                        ),
+                        padded_local_token_to_seq=(
+                            padded_local_token_to_seq_tensor_cpu.to(
+                                device, non_blocking=True
+                            )
                         ),
                         cu_seq_lens_lst=cu_seq_lens_cpu.tolist(),
                         chunk_size=padded_local_max_context_chunk_across_ranks,
@@ -2205,7 +2224,6 @@ class MLACommonImpl(MLAAttentionImpl[M], Generic[M]):
         k_scale: torch.Tensor,
         dcp_world_size: int,
     ):
-        assert k_scale is None, "DCP not support scaled kvcache now."
         assert attn_metadata.prefill is not None
         prefill_metadata = attn_metadata.prefill
         assert prefill_metadata.prefill_backend is not None
@@ -2221,18 +2239,48 @@ class MLACommonImpl(MLAAttentionImpl[M], Generic[M]):
         iters = len(prefill_metadata.chunked_context.seq_tot)
         workspace = prefill_metadata.chunked_context.workspace
 
+        # Quantized KV caches store bytes while the gather workspace is in the
+        # model dtype; route through the dequantizing gather in that case.
+        needs_dequant_gather = kv_c_and_k_pe_cache.dtype != workspace.dtype
+        if needs_dequant_gather:
+            assert is_quantized_kv_cache(self.kv_cache_dtype), (
+                "DCP context prefill only supports dtype-mismatched KV cache "
+                "when the KV cache is quantized."
+            )
+            assert k_scale is not None
+            assert (
+                prefill_metadata.chunked_context.padded_local_token_to_seq is not None
+            )
+
         for i in range(iters):
             toks = prefill_metadata.chunked_context.seq_tot[i]
-            ops.cp_gather_cache(
-                src_cache=kv_c_and_k_pe_cache,
-                dst=workspace,
-                block_table=prefill_metadata.block_table,
-                cu_seq_lens=prefill_metadata.chunked_context.padded_local_cu_seq_lens[
-                    i
-                ],
-                batch_size=attn_metadata.num_prefills,
-                seq_starts=prefill_metadata.chunked_context.starts[i],
-            )
+            if needs_dequant_gather:
+                ops.gather_and_maybe_dequant_cache(
+                    src_cache=kv_c_and_k_pe_cache,
+                    dst=workspace,
+                    block_table=prefill_metadata.block_table,
+                    cu_seq_lens=prefill_metadata.chunked_context.padded_local_cu_seq_lens[
+                        i
+                    ],
+                    token_to_seq=(
+                        prefill_metadata.chunked_context.padded_local_token_to_seq[i]
+                    ),
+                    num_tokens=toks,
+                    kv_cache_dtype=self.kv_cache_dtype,
+                    scale=k_scale,
+                    seq_starts=prefill_metadata.chunked_context.starts[i],
+                )
+            else:
+                ops.cp_gather_cache(
+                    src_cache=kv_c_and_k_pe_cache,
+                    dst=workspace,
+                    block_table=prefill_metadata.block_table,
+                    cu_seq_lens=prefill_metadata.chunked_context.padded_local_cu_seq_lens[
+                        i
+                    ],
+                    batch_size=attn_metadata.num_prefills,
+                    seq_starts=prefill_metadata.chunked_context.starts[i],
+                )
             # workspace
             # |------- N tokens --------|--------- N*dcp_size tokens ----------|
             # |<- use for local_gather ->|<--------- use for allgather -------->|
@@ -2354,7 +2402,7 @@ class MLACommonImpl(MLAAttentionImpl[M], Generic[M]):
                         q,
                         kv_c_and_k_pe_cache,
                         attn_metadata,
-                        k_scale=None,
+                        k_scale=k_scale,
                         dcp_world_size=self.dcp_world_size,
                     )
                 )


### PR DESCRIPTION
## Summary

DCP chunked-context prefill gathered KV pages with `cp_gather_cache`, which
requires `src` and `dst` to share a dtype. With a quantized (fp8) KV cache it
crashed at the call site with `src_cache and dst must have the same dtype`,
making decode context parallelism unusable together with `--kv-cache-dtype fp8`.

## Root cause

`_context_parallel_compute_prefill_context` always routed the gather through
`cp_gather_cache` and hardcoded `k_scale=None`, so a fp8 cache (dtype != the
bf16 workspace) failed the kernel's dtype-equality precondition.

## Fix

- Route the gather through `gather_and_maybe_dequant_cache` when the cache
  dtype differs from the workspace dtype.
- Build the `padded_local_token_to_seq` grid the dequant gather needs.
- Pass the layer's real `k_scale` instead of `None`.

The dequant-gather path is ported from the glm51-v6 lineage, where DCP + fp8 KV
was previously validated.

## Testing

- Kimi-K2.7-Code TP8, `--kv-cache-dtype fp8`, `TRITON_MLA`, DCP 2/4/8: server
  boots and temp-0 needle retrieval passes (previously crashed on the first
  chunked-context prefill).

Validated on the black-benediction `vllm72661cc` base; the change cherry-picks
cleanly onto `dev/chthonic-consecration` (single file, `mla_attention.py`).

## Notes

- Replaces #14, which had drifted to an unrelated/oversized diff against an
  older base. This is the same logical change rebased clean onto current
  `dev/chthonic-consecration`.
- AI assistance: drafted with Claude (Anthropic) and reviewed/validated by the
  submitter.
