### PR TITLE
attention: fix MLA chunked-context merge for mismatched output strides

### DIFF
--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -283,6 +283,26 @@ logger = init_logger(__name__)
 _FP8_DTYPE = current_platform.fp8_dtype()
 
 
+def _match_merge_strides(
+    prefix_output: torch.Tensor, suffix_output: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Give both partial-attention outputs identical strides.
+
+    The merge_attn_states CUDA kernel computes one source offset from the
+    prefix strides and reads BOTH prefix and suffix with it. The FA prefill
+    backend returns padded-V views (head stride > head_size) while merged
+    chunk outputs are contiguous, so once the chunked-context loop runs more
+    than one iteration (context > workspace, i.e. > 64k tokens) the two
+    sides disagree and the kernel reads the suffix at wrong offsets.
+    """
+    if prefix_output.stride() != suffix_output.stride():
+        if not prefix_output.is_contiguous():
+            prefix_output = prefix_output.contiguous()
+        if not suffix_output.is_contiguous():
+            suffix_output = suffix_output.contiguous()
+    return prefix_output, suffix_output
+
+
 def _detect_output_quant_key(
     output: torch.Tensor,
     output_scale: torch.Tensor | None,
@@ -2176,11 +2196,11 @@ class MLACommonImpl(MLAAttentionImpl[M], Generic[M]):
                     v=v,
                 )
             )
-
             if output is None:
                 output = attn_output
                 output_lse = attn_softmax_lse
             else:
+                output, attn_output = _match_merge_strides(output, attn_output)
                 if merge_output is None:
                     merge_output = torch.empty_like(output)
                     merge_output_lse = torch.empty_like(output_lse)
@@ -2289,6 +2309,7 @@ class MLACommonImpl(MLAAttentionImpl[M], Generic[M]):
                 output = attn_output
                 output_lse = attn_softmax_lse
             else:
+                output, attn_output = _match_merge_strides(output, attn_output)
                 if merge_output is None:
                     merge_output = torch.empty_like(output)
                     merge_output_lse = torch.empty_like(output_lse)
@@ -2364,6 +2385,9 @@ class MLACommonImpl(MLAAttentionImpl[M], Generic[M]):
                 )
 
             output = output.view(-1, self.num_heads, self.v_head_dim)
+            context_output, suffix_output = _match_merge_strides(
+                context_output, suffix_output
+            )
             merge_attn_states(
                 output=output,
                 prefix_output=context_output,


### PR DESCRIPTION
## Summary

MLA chunked-context prefill silently corrupted generation once a prompt
exceeded the chunked-prefill workspace (~64k tokens), on dense-MLA models
(Kimi K2.6 / K2.7-Code). Everything below ~65k was fine; above it, output
derailed.

## Root cause

The `merge_attn_states` CUDA kernel computes a single source offset from the
**prefix** strides and reads BOTH the prefix and the suffix with it
(`merge_attn_states.cu` derives `suffix_head_ptr` from `src_head_offset`, which
is built from `prefix_head_stride`). The FlashAttention MLA prefill backend
returns padded-V views (head stride 192 for `v_head_dim` 128), while the
chunked-context loop's merged buffers are contiguous (head stride 128).

With context <= the workspace the loop runs a single iteration and both merge
inputs are FA views with identical strides, so the assumption holds. Beyond the
workspace the loop merges into a contiguous buffer, and the final
context/new-tokens merge then reads the suffix at the wrong offset — silently
corrupting every prefill chunk past the workspace size.

## Fix

Match the prefix/suffix strides at the three merge call sites before invoking
the kernel. A kernel-side fix (a separate `suffix_head_stride` parameter) would
also work but requires a rebuild; this keeps the ABI unchanged.

## Testing

- Kimi-K2.6 TP8 (`TRITON_MLA`, `--kv-cache-dtype fp8`): temp-0 needle retrieval
  at 64k / 100k / 128k / 150k / 200k prompt tokens all pass (150k+ exercises
  3–4 loop iterations). Everything above ~65k-token prompts was previously
  corrupted, on K2.6 and K2.7-Code alike.

Validated on the black-benediction `vllm72661cc` base; cherry-picks cleanly onto
`dev/chthonic-consecration` (single file, `mla_attention.py`).

## Notes

- Replaces #15, which had drifted to an unrelated/oversized diff against an
  older base. Same logical change, rebased clean.
- Independent of the fp8-gather fix; the two touch different parts of
  `mla_attention.py` and can merge in either order.
- AI assistance: drafted with Claude (Anthropic) and reviewed/validated by the
  submitter.
