### PR TITLE
spec-decode: support DFlash drafts under decode context parallelism

### DIFF
--- a/vllm/model_executor/models/qwen3_dflash.py
+++ b/vllm/model_executor/models/qwen3_dflash.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import dataclasses
 from collections.abc import Iterable, Mapping
 
 import torch
@@ -102,6 +103,11 @@ class DFlashAttention(Attention):
     """
 
     def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec | None:
+        # The draft attends over the full context with a backend that cannot
+        # reduce across DCP ranks; replicate the draft cache on every rank.
+        dcp_replicated = (
+            vllm_config.parallel_config.decode_context_parallel_size > 1
+        )
         if self.sliding_window is not None:
             # Build the full spec directly instead of converting the parent's
             # SlidingWindowSpec: Attention.get_kv_cache_spec asserts against
@@ -116,8 +122,12 @@ class DFlashAttention(Attention):
                 head_size_v=self.head_size_v,
                 dtype=self.kv_cache_torch_dtype,
                 kv_quant_mode=get_kv_quant_mode(self.kv_cache_dtype),
+                dcp_replicated=dcp_replicated,
             )
-        return super().get_kv_cache_spec(vllm_config)
+        spec = super().get_kv_cache_spec(vllm_config)
+        if dcp_replicated and isinstance(spec, FullAttentionSpec):
+            spec = dataclasses.replace(spec, dcp_replicated=True)
+        return spec
 
 
 class DFlashQwen3Attention(nn.Module):

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -504,11 +504,21 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
         self.hash_block_size = hash_block_size
         self.dcp_world_size = dcp_world_size
         self.pcp_world_size = pcp_world_size
+        # Prefix caching is unsupported for hybrid groups under DCP. Besides
+        # the DeepseekV4 MLA/SWA hybrid, this also covers an MLA target plus a
+        # DCP-replicated DFlash draft group (different block sizes / cp).
+        _has_dcp_replicated = any(
+            getattr(g.kv_cache_spec, "dcp_replicated", False)
+            for g in kv_cache_config.kv_cache_groups
+        )
         self.disable_prefix_cache_for_dsv4_dcp = (
             enable_caching
             and dcp_world_size > 1
             and pcp_world_size == 1
-            and is_deepseek_v4_hybrid_kv_cache_config(kv_cache_config)
+            and (
+                is_deepseek_v4_hybrid_kv_cache_config(kv_cache_config)
+                or _has_dcp_replicated
+            )
         )
         if not self.disable_prefix_cache_for_dsv4_dcp:
             assert all(

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -623,6 +623,19 @@ def resolve_kv_cache_block_sizes(
             group_block_sizes = [g.kv_cache_spec.block_size for g in groups]
             scheduler_block_size = math.lcm(*group_block_sizes) * dcp
             return scheduler_block_size, scheduler_block_size
+        if dcp > 1 and pcp == 1:
+            # Mixed sharded/replicated groups (e.g. an MLA target plus a
+            # dcp_replicated draft group): each group's scheduler-visible
+            # block covers block_size tokens when replicated and
+            # block_size * dcp when sharded.
+            effective_block_sizes = [
+                g.kv_cache_spec.block_size
+                if getattr(g.kv_cache_spec, "dcp_replicated", False)
+                else g.kv_cache_spec.block_size * dcp
+                for g in groups
+            ]
+            scheduler_block_size = math.lcm(*effective_block_sizes)
+            return scheduler_block_size, scheduler_block_size
         raise ValueError(
             "Hybrid KV cache groups with multiple block sizes do not "
             "support context parallelism (dcp_world_size/pcp_world_size > 1)."
@@ -1464,15 +1477,27 @@ def group_and_unify_kv_cache_specs(
     Group the KV cache specs and unify each group into one UniformTypeKVCacheSpecs.
     Currently, this is only used for DeepseekV4.
     """
-    if not any(
+    has_swa = any(
         isinstance(spec, SlidingWindowMLASpec) for spec in kv_cache_spec.values()
-    ):
+    )
+    # DFlash-under-DCP draft: full-attention layers replicated on every DCP
+    # rank. They have a different page size than the MLA target and need their
+    # own group, but the DeepseekV4 multi-group allocator (with page-size
+    # padding) handles exactly that, so route them through here too.
+    has_repl = any(
+        getattr(spec, "dcp_replicated", False)
+        and not isinstance(spec, MLAAttentionSpec)
+        for spec in kv_cache_spec.values()
+    )
+    if not (has_swa or has_repl):
         return None
 
     mla_specs: dict[str, KVCacheSpec] = {}
     grouped_swa_mla_specs: dict[
         tuple[int, int, bool], dict[str, KVCacheSpec]
     ] = defaultdict(dict)
+    # dcp_replicated non-MLA groups (e.g. the DFlash draft), keyed by block_size.
+    grouped_repl_specs: dict[tuple[int], dict[str, KVCacheSpec]] = defaultdict(dict)
     # NOTE: Here we group SWA layers by (block_size, sliding_window,
     # dcp_sharded), which separates SWA layers, C4I+C4A layers, and C128A
     # layers into different groups.
@@ -1483,18 +1508,23 @@ def group_and_unify_kv_cache_specs(
             ][name] = spec
         elif isinstance(spec, MLAAttentionSpec):
             mla_specs[name] = spec
+        elif getattr(spec, "dcp_replicated", False):
+            grouped_repl_specs[(spec.block_size,)][name] = spec
 
-    assert len(mla_specs) > 0
+    if len(mla_specs) == 0:
+        # No full-MLA group to anchor the DeepseekV4 layout; let the generic
+        # paths handle it.
+        return None
     mla_uniform_spec = UniformTypeKVCacheSpecs.from_specs(mla_specs)
     assert mla_uniform_spec is not None
 
-    swa_uniform_specs: list[UniformTypeKVCacheSpecs] = []
-    for spec_dict in grouped_swa_mla_specs.values():
+    other_uniform_specs: list[UniformTypeKVCacheSpecs] = []
+    for spec_dict in (*grouped_swa_mla_specs.values(), *grouped_repl_specs.values()):
         uniform_spec = UniformTypeKVCacheSpecs.from_specs(spec_dict)
         assert uniform_spec is not None
-        swa_uniform_specs.append(uniform_spec)
+        other_uniform_specs.append(uniform_spec)
 
-    return [mla_uniform_spec, *swa_uniform_specs]
+    return [mla_uniform_spec, *other_uniform_specs]
 
 
 def _approximate_gcd(values: Sequence[int], *, lower_bound: int | None = None) -> int:
@@ -1573,8 +1603,10 @@ def _get_kv_cache_groups_uniform_groups(
     ]
 
     swa_mla_specs = grouped_specs[1:]
+    # Non-first groups are SWA-MLA (DeepseekV4) or full-attention dcp_replicated
+    # drafts (DFlash under DCP). Both are padded to MLA buckets identically.
     assert all(
-        isinstance(spec, SlidingWindowMLASpec)
+        isinstance(spec, (SlidingWindowMLASpec, FullAttentionSpec))
         for group in swa_mla_specs
         for spec in group.kv_cache_specs.values()
     )

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -66,7 +66,15 @@ class SingleTypeKVCacheManager(ABC):
         self.block_size = kv_cache_spec.block_size
         self.dcp_world_size = dcp_world_size
         self.pcp_world_size = pcp_world_size
-        if dcp_world_size * pcp_world_size > 1:
+        # Under (D)CP a request's cache is sharded across ranks, so one local
+        # block of `block_size` slots covers `block_size * cp` tokens of the
+        # global sequence -- scale the scheduler-visible block size to match.
+        # dcp_replicated groups (e.g. the DFlash draft) instead keep the full
+        # cache on every rank, so one block covers exactly `block_size` global
+        # tokens and must not be scaled.
+        if dcp_world_size * pcp_world_size > 1 and not getattr(
+            kv_cache_spec, "dcp_replicated", False
+        ):
             self.block_size *= dcp_world_size * pcp_world_size
         self.kv_cache_spec = kv_cache_spec
         self.block_pool = block_pool

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -151,8 +151,14 @@ class KVCacheSpec:
             f"Unsupported KV cache spec type: {type(self)}. "
             "Please register it using @register_kv_cache_spec decorator."
         )
+        # Keep DCP-replicated layers (DFlash draft) out of a shared group with
+        # DCP-sharded layers (MLA target): one group carries a single cp_size.
+        # group_and_unify_kv_cache_specs then routes them as separate groups.
+        self_repl = getattr(self, "dcp_replicated", False)
         return all(
-            isinstance(spec, uniform_type_base_spec) for spec in kv_cache_specs.values()
+            isinstance(spec, uniform_type_base_spec)
+            and getattr(spec, "dcp_replicated", False) == self_repl
+            for spec in kv_cache_specs.values()
         )
 
 
@@ -219,6 +225,12 @@ class FullAttentionSpec(AttentionSpec):
     """
     attention_chunk_size: int | None = None
 
+    dcp_replicated: bool = False
+    """Replicate this group's KV cache on every DCP rank instead of
+    sharding it by token position. Used by draft layers whose attention
+    backend cannot reduce across DCP ranks (e.g. the DFlash draft); every
+    rank then stores and attends over the full context."""
+
     def __post_init__(self):
         if self.head_size_v is None:
             object.__setattr__(self, "head_size_v", self.head_size)
@@ -229,7 +241,7 @@ class FullAttentionSpec(AttentionSpec):
         pcp_world_size = vllm_config.parallel_config.prefill_context_parallel_size
         # Note(hc): each dcp rank only need save
         # (max_model_len//dcp_world_size) tokens locally.
-        if dcp_world_size * pcp_world_size > 1:
+        if dcp_world_size * pcp_world_size > 1 and not self.dcp_replicated:
             max_model_len = cdiv(max_model_len, dcp_world_size * pcp_world_size)
         return cdiv(max_model_len, self.block_size) * self.page_size_bytes
 
@@ -276,6 +288,7 @@ class FullAttentionSpec(AttentionSpec):
             page_size_padded=specs[0].page_size_padded,
             sliding_window=cls.merge_window_sizes(sliding_window),
             attention_chunk_size=cls.merge_window_sizes(attention_chunk_size),
+            dcp_replicated=specs[0].dcp_replicated,
         )
         for spec in specs:
             for f in fields(AttentionSpec):
@@ -769,6 +782,13 @@ class UniformTypeKVCacheSpecs(KVCacheSpec):
     @property
     def page_size_bytes(self) -> int:
         return sum(spec.page_size_bytes for spec in self.kv_cache_specs.values())
+
+    @property
+    def dcp_replicated(self) -> bool:
+        return all(
+            getattr(spec, "dcp_replicated", False)
+            for spec in self.kv_cache_specs.values()
+        )
 
     def max_memory_usage_bytes(self, vllm_config: VllmConfig) -> int:
         max_num_pages = max(

--- a/vllm/v1/worker/cp_utils.py
+++ b/vllm/v1/worker/cp_utils.py
@@ -22,6 +22,17 @@ def check_attention_cp_compatibility(vllm_config: VllmConfig) -> None:
             layer_impl = getattr(layer, "impl", None)
             if layer_impl is None:
                 continue
+            # Layers whose KV cache group is replicated across DCP ranks
+            # (e.g. the DFlash draft) attend over the full context locally
+            # and need no cross-rank LSE reduction.
+            get_spec = getattr(layer, "get_kv_cache_spec", None)
+            if get_spec is not None:
+                try:
+                    spec = get_spec(vllm_config)
+                except Exception:
+                    spec = None
+                if getattr(spec, "dcp_replicated", False):
+                    continue
             if vllm_config.speculative_config is not None and interleave_size > 1:
                 assert layer_impl.supports_mtp_with_cp_non_trivial_interleave_size, (
                     "MTP with cp_kv_cache_interleave_size > 1 is not "

--- a/vllm/v1/worker/gpu/block_table.py
+++ b/vllm/v1/worker/gpu/block_table.py
@@ -21,6 +21,7 @@ class BlockTables:
         cp_size: int = 1,
         cp_rank: int = 0,
         cp_interleave: int = 1,
+        group_cp_sizes: list[int] | None = None,
     ):
         self.block_sizes = block_sizes
         self.kernel_block_sizes = kernel_block_sizes
@@ -31,6 +32,14 @@ class BlockTables:
         self.cp_size = cp_size
         self.cp_rank = cp_rank
         self.cp_interleave = cp_interleave
+        # Per-group CP size: dcp_replicated groups keep their cache full on
+        # every rank (effective cp 1) while the rest shard by cp_size.
+        if group_cp_sizes is None:
+            group_cp_sizes = [cp_size] * len(block_sizes)
+        assert len(group_cp_sizes) == len(block_sizes)
+        self.group_cp_sizes = torch.tensor(
+            group_cp_sizes, dtype=torch.int32, device=device
+        )
 
         self.num_kv_cache_groups = len(self.block_sizes)
         assert len(max_num_blocks_per_group) == self.num_kv_cache_groups
@@ -158,6 +167,7 @@ class BlockTables:
             self.block_table_ptrs,
             self.block_table_strides,
             self.block_sizes_tensor,
+            self.group_cp_sizes,
             self.slot_mappings,
             self.slot_mappings.stride(0),
             self.cp_rank,
@@ -229,6 +239,7 @@ def _compute_slot_mappings_kernel(
     block_table_ptrs,  # [num_kv_cache_groups]
     block_table_strides,  # [num_kv_cache_groups]
     block_sizes,  # [num_kv_cache_groups]
+    group_cp_sizes,  # [num_kv_cache_groups]
     slot_mappings_ptr,  # [num_kv_cache_groups, max_num_tokens]
     slot_mappings_stride,
     cp_rank,
@@ -256,6 +267,7 @@ def _compute_slot_mappings_kernel(
     block_table_ptr = _load_ptr(block_table_ptrs + group_id, tl.int32)
     block_table_stride = tl.load(block_table_strides + group_id)
     block_size = tl.load(block_sizes + group_id)
+    group_cp_size = tl.load(group_cp_sizes + group_id)
 
     req_state_idx = tl.load(idx_mapping + batch_idx)
     start_idx = tl.load(query_start_loc + batch_idx)
@@ -264,8 +276,8 @@ def _compute_slot_mappings_kernel(
         offset = i + tl.arange(0, TRITON_BLOCK_SIZE)
         positions = tl.load(pos + offset, mask=offset < end_idx, other=0)
 
-        block_indices = positions // (block_size * CP_SIZE)
-        block_offsets = positions % (block_size * CP_SIZE)
+        block_indices = positions // (block_size * group_cp_size)
+        block_offsets = positions % (block_size * group_cp_size)
         block_numbers = tl.load(
             block_table_ptr + req_state_idx * block_table_stride + block_indices
         )
@@ -274,13 +286,17 @@ def _compute_slot_mappings_kernel(
             # Common case: Context parallelism is not used.
             slot_ids = block_numbers * block_size + block_offsets
         else:
-            # Context parallelism is used.
-            is_local = block_offsets // CP_INTERLEAVE % CP_SIZE == cp_rank
-            rounds = block_offsets // (CP_INTERLEAVE * CP_SIZE)
-            remainder = block_offsets % CP_INTERLEAVE
-            local_offsets = rounds * CP_INTERLEAVE + remainder
-            slot_ids = block_numbers * block_size + local_offsets
-            slot_ids = tl.where(is_local, slot_ids, PAD_ID)
+            # Context parallelism is used. dcp_replicated groups carry
+            # group_cp_size == 1 and store every token locally.
+            if group_cp_size == 1:
+                slot_ids = block_numbers * block_size + block_offsets
+            else:
+                is_local = block_offsets // CP_INTERLEAVE % CP_SIZE == cp_rank
+                rounds = block_offsets // (CP_INTERLEAVE * CP_SIZE)
+                remainder = block_offsets % CP_INTERLEAVE
+                local_offsets = rounds * CP_INTERLEAVE + remainder
+                slot_ids = block_numbers * block_size + local_offsets
+                slot_ids = tl.where(is_local, slot_ids, PAD_ID)
 
         tl.store(slot_mapping_ptr + offset, slot_ids, mask=offset < end_idx)
 

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -410,14 +410,20 @@ class GPUModelRunner(LoRAModelRunnerMixin):
 
         block_sizes = []
         max_num_blocks_per_group = []
+        group_cp_sizes = []
         for kv_cache_group in kv_cache_config.kv_cache_groups:
             spec = kv_cache_group.kv_cache_spec
             block_sizes.append(spec.block_size)
             # When using DCP, each request's KV cache is sharded among different ranks.
             # As a result, one block on the current rank covers `block_size * cp_size`
-            # tokens in the full, global (unsharded) sequence.
+            # tokens in the full, global (unsharded) sequence. dcp_replicated
+            # groups keep the full cache on every rank instead.
+            group_cp_size = (
+                1 if getattr(spec, "dcp_replicated", False) else self.dcp_size
+            )
+            group_cp_sizes.append(group_cp_size)
             max_num_blocks = cdiv(
-                block_table_max_model_len, spec.block_size * self.dcp_size
+                block_table_max_model_len, spec.block_size * group_cp_size
             )
             # Align to a multiple of (128 / block_size) as required by some attention
             # backends such as TRTLLM (#39324)
@@ -444,6 +450,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             cp_size=self.dcp_size,
             cp_rank=self.dcp_rank,
             cp_interleave=self.cp_interleave,
+            group_cp_sizes=group_cp_sizes,
         )
         initialize_mamba_ssu_backend(
             self.vllm_config.mamba_config, self.kv_cache_config

--- a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
@@ -40,9 +40,9 @@ logger = init_logger(__name__)
 class DFlashSpeculator(DraftModelSpeculator):
     def __init__(self, vllm_config: VllmConfig, device: torch.device):
         super().__init__(vllm_config, device)
-        assert vllm_config.parallel_config.decode_context_parallel_size == 1, (
-            "DFlash speculator does not support decode context parallelism yet."
-        )
+        # DCP is supported by replicating the draft KV cache on every DCP
+        # rank (the draft spec sets dcp_replicated): every rank writes the
+        # full context KV and the block forward attends over it locally.
 
         self.hidden_states = torch.zeros(
             self.max_num_tokens, self.hidden_size, dtype=self.dtype, device=device


### PR DESCRIPTION
## Summary

Enables DFlash speculative decoding together with decode context parallelism
(DCP). Previously the DFlash speculator asserted `decode_context_parallel_size
== 1`. The draft now runs under DCP 2/4/8 with speculative acceptance equal to
the DCP=1 baseline.

## Why DCP is hard for the draft

The DFlash draft attends over the full context with a plain-attention backend
(`TRITON_ATTN`) that cannot reduce partial attention across DCP ranks, so its KV
cache cannot be token-sharded the way the target MLA cache is. We replicate the
draft cache on every DCP rank instead: the target's auxiliary hidden states are
already replicated across TP/DCP ranks, so every rank projects and stores the
full context KV and the draft block forward runs locally with full sequence
lengths.

## Two parts

**1. Per-group replication plumbing.** A `dcp_replicated` flag on
`FullAttentionSpec` (with a `UniformTypeKVCacheSpecs` proxy) marks the draft
group; `qwen3_dflash` sets it when `dcp > 1`. Replicated groups skip the
`block_size *= dcp` scaling (scheduler + worker), the `BlockTables` slot-mapping
kernel reads a per-group cp size at runtime (replicated groups map every token
locally, sharded groups keep the interleaved DCP layout), and
`check_attention_cp_compatibility` skips replicated layers (no cross-rank decode
LSE).

**2. The draft needs its own KV cache group.** Replication alone is not enough.
A dense-MLA target (Kimi, no SWA) plus the draft's `FullAttentionSpec` otherwise
land in ONE `UniformTypeKVCacheSpecs` group. A group carries a single `cp_size`,
so the merged group resolves to `cp=dcp` and the draft's context KV is
written/read at **sharded** slots — each rank sees only 1/dcp of the context.
Generation stays correct (the target verifies every token) but speculative
acceptance silently collapses with DCP:

| | DCP1 | DCP2 | DCP8 |
|---|---|---|---|
| acceptance before | 0.24 | 0.08 | **0.04** |

This is invisible to needle/coherence tests, which only exercise the verified
output, not the draft hit rate. The fix routes `dcp_replicated` layers into
their own group via the existing DeepSeek-V4 multi-group allocator (separate
slot mapping + `cp_size`, page-size-padded to the MLA buckets, prefix caching
disabled for the hybrid). Everything is gated on `dcp_replicated`, so non-DFlash
and DCP=1 configs are byte-for-byte unaffected.

## Testing

Kimi-K2.7-Code TP8 + Kimi-K2.6 DFlash draft, DCP 2/4/8, `TRITON_MLA`, fp8 KV:

- Slot mappings are fully local (pad=0; no sharded `-1` interleave).
- **Speculative acceptance matches DCP1.** At DCP8, code/math/chat =
  0.30 / 0.54 / 0.21 vs DCP1 0.33 / 0.54 / 0.21 (was 0.04 before the grouping
  fix).
- 0k C1 decode at DCP8: **111 tok/s** vs 86 target-only (**+29%**).
- 52k-token needle retrieval passes; long-prompt generation is coherent.

> Note for reviewers: sub-~10-token prompts degenerate to token repetition at
> high DCP because the context shards to ~0–1 tokens per rank. This is inherent
> to DCP and reproduces on the target with no draft; validate with realistic
> (≥ dozens of tokens) prompts.

Validated on the black-benediction `vllm72661cc` base with the draft KV-cache
files mounted; the commit cherry-picks cleanly onto `dev/chthonic-consecration`
and the patches land in the same functions (verified by diff review). Final CI
validation on `dev/chthonic-consecration` is recommended as the merge gate.

## Notes

- No existing PR covers DFlash-under-DCP (checked open PRs); this is a new
  feature, distinct from the MLA-DCP fp8/merge correctness fixes.
- The draft block forward stays eager (`CUDAGraphMode.NONE`), same as on DCP=1 —
  the target keeps its full CUDA graph. A piecewise graph for the draft is a
  possible follow-up (~5% single-stream, small share).
- AI assistance: drafted with Claude (Anthropic) and reviewed/validated by the
  submitter.
