### PR TITLE
spec-decode: honor the speculative-config attention backend for the DFlash draft

### DIFF
--- a/vllm/v1/worker/gpu/spec_decode/dflash/utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/utils.py
@@ -26,7 +26,13 @@ def load_dflash_model(target_model: nn.Module, vllm_config: VllmConfig) -> nn.Mo
     draft_vllm_config = replace(
         vllm_config,
         attention_config=replace(
-            vllm_config.attention_config, use_non_causal=not causal
+            vllm_config.attention_config,
+            use_non_causal=not causal,
+            # Honor the speculative-config attention backend for the draft
+            # (matches llm_base_proposer): otherwise auto-select picks
+            # FlashInfer, which downgrades the spec-decode cudagraph to
+            # PIECEWISE and cannot do non-causal prefill under DCP.
+            backend=speculative_config.attention_backend,
         ),
     )
     with set_model_tag("dflash_head"):


### PR DESCRIPTION
## Summary

The V2 DFlash draft loader (`load_dflash_model`) rewrites the draft's attention
config to set its causal/non-causal mode, but drops
`speculative_config.attention_backend`. The draft then **auto-selects** an
attention backend, which on Blackwell prefers **FlashInfer** regardless of what
the speculative config requests (e.g. `TRITON_ATTN`).

## Symptoms (DFlash draft beside an MLA target, e.g. Kimi-K2.7-Code)

- **Under DCP the engine fails to start:**
  `FlashInfer non-causal prefill is not supported with DCP yet`.
- **Without DCP the spec-decode cudagraph is downgraded** FULL → PIECEWISE:
  `CUDAGraphMode.FULL_AND_PIECEWISE is not supported with spec-decode for
  attention backend FlashInferBackend`.
- The user's `speculative_config.attention_backend` is silently ignored.

## Root cause / fix

`load_dflash_model` does `replace(attention_config, use_non_causal=...)` but
never sets `backend=`. The V1 `llm_base_proposer` already threads the
spec-config backend through (with the comment *"never inherit the attention
backend from base ... unless explicitly specified in the speculative config"*).
This restores that one line for the V2 DFlash path. When the spec config leaves
`attention_backend` unset, behaviour is unchanged (auto-select).

## Testing

Kimi-K2.7-Code TP8 + Kimi-K2.6 DFlash draft, V2 model runner, kv-fp8,
`--speculative-config '{"method":"dflash", ..., "attention_backend":"TRITON_ATTN"}'`.
Smoke + throughput at 0k context, concurrency 1:

| Config | Before (auto/FlashInfer) | After (this PR, TRITON_ATTN) |
| --- | --- | --- |
| **DCP8 + DFlash** | fails to start | boots, **FULL** draft graph, **113.6 tok/s** (vs 81.5 target-only, **+39%**), coherent |
| **DCP1 + DFlash** | 125 tok/s, PIECEWISE only | **140 tok/s**, coherent |

Both configurations confirmed running on the **V2 model runner** with coherent
output.

## Why this is not duplicating an existing PR

`gh pr list --repo local-inference-lab/vllm --state open` — the only open PR (#8,
`codex/ds4-step35-mtp-local-argmax-spec-step`) targets MTP local-argmax, an
unrelated area. No open PR touches the DFlash draft attention backend.

## AI assistance

This change was drafted with AI assistance (Claude, Anthropic) and reviewed,
built, and validated end-to-end by the submitter on a Blackwell rig.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed speculative decoding with DFlash backend to correctly configure attention backend and causal mode settings for draft models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->