### PR TITLE
Fix B12X NVFP4 prepare for forced W4A16

### DIFF
--- a/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import os
 from enum import Enum
 
 import torch
@@ -56,6 +57,13 @@ FLASHINFER_NVFP4_MOE_BACKENDS = [
     NvFp4MoeBackend.FLASHINFER_CUTEDSL_BATCHED,
     NvFp4MoeBackend.FLASHINFER_B12X,
 ]
+
+
+def _env_flag(name: str, default: bool = False) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.strip().lower() not in ("", "0", "false", "no", "off")
 
 
 def is_global_sf_supported_for_nvfp4_backend(backend: NvFp4MoeBackend) -> bool:
@@ -324,6 +332,7 @@ def convert_to_nvfp4_moe_kernel_format(
     w2_scale_2: torch.Tensor,
     a2_scale: torch.Tensor | None,
     is_act_and_mul: bool,
+    use_a16: bool = False,
 ) -> tuple[
     torch.Tensor,
     torch.Tensor,
@@ -335,26 +344,50 @@ def convert_to_nvfp4_moe_kernel_format(
     torch.Tensor,
 ]:
     if nvfp4_backend == NvFp4MoeBackend.B12X:
-        (
-            w13,
-            w13_scale,
-            w13_scale_2,
-            a13_scale,
-            w2,
-            w2_scale,
-            w2_scale_2,
-            a2_scale,
-        ) = prepare_nvfp4_moe_layer_for_b12x(
-            w13=w13,
-            w13_scale=w13_scale,
-            w13_scale_2=w13_scale_2,
-            a13_scale=a13_scale,
-            w2=w2,
-            w2_scale=w2_scale,
-            w2_scale_2=w2_scale_2,
-            a2_scale=a2_scale,
-            is_act_and_mul=is_act_and_mul,
-        )
+        if use_a16 or _env_flag("B12X_MOE_FORCE_A16"):
+            (
+                w13,
+                w13_scale,
+                w13_scale_2,
+                a13_scale,
+                w2,
+                w2_scale,
+                w2_scale_2,
+                a2_scale,
+            ) = prepare_nvfp4_moe_layer_for_fi_or_cutlass(
+                backend=NvFp4MoeBackend.FLASHINFER_B12X,
+                layer=layer,
+                w13=w13,
+                w13_scale=w13_scale,
+                w13_scale_2=w13_scale_2,
+                a13_scale=a13_scale,
+                w2=w2,
+                w2_scale=w2_scale,
+                w2_scale_2=w2_scale_2,
+                a2_scale=a2_scale,
+                is_act_and_mul=is_act_and_mul,
+            )
+        else:
+            (
+                w13,
+                w13_scale,
+                w13_scale_2,
+                a13_scale,
+                w2,
+                w2_scale,
+                w2_scale_2,
+                a2_scale,
+            ) = prepare_nvfp4_moe_layer_for_b12x(
+                w13=w13,
+                w13_scale=w13_scale,
+                w13_scale_2=w13_scale_2,
+                a13_scale=a13_scale,
+                w2=w2,
+                w2_scale=w2_scale,
+                w2_scale_2=w2_scale_2,
+                a2_scale=a2_scale,
+                is_act_and_mul=is_act_and_mul,
+            )
     elif nvfp4_backend == NvFp4MoeBackend.FLASHINFER_CUTEDSL:
         (
             w13,

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -1576,6 +1576,7 @@ class ModelOptNvFp4FusedMoE(FusedMoEMethodBase):
             w2_scale_2=layer.w2_weight_scale_2,
             a2_scale=layer.w2_input_scale,
             is_act_and_mul=self.moe.is_act_and_mul,
+            use_a16=self.use_a16,
         )
 
         replace_parameter(layer, "w13_weight", w13)


### PR DESCRIPTION
## Summary

Fix GLM 5.1 NVFP4 corruption when `B12X_MOE_FORCE_A16=1` forces the B12X MoE path to prepare ModelOpt NVFP4 experts as W4A16.

The normal native B12X NVFP4 prepare path is correct for A16-off. The forced W4A16 path, however, needs the existing FI/B12X gated W13 reorder before `B12xExperts` prepares W4A16 weights. Without that reorder, the gate/up halves are consumed in the wrong order and GLM emits corrupted output immediately.

This PR keeps native B12X NVFP4 on `prepare_nvfp4_moe_layer_for_b12x`, switches to the FI/B12X prepare only when `use_a16` or `B12X_MOE_FORCE_A16=1` is active, and propagates ModelOpt's explicit `use_a16` flag into the converter.

## Validation

Tested on `voipmonitor/vllm:chthonic-consecration-5e83948-b12x-465cb6e-cu132` with only these fix files bind-mounted:

- GLM v10 recipe, DCP1, MTP off, port 5329, `B12X_MOE_FORCE_A16=1`.
- GLM v10 recipe, DCP1, MTP off, port 5330, `B12X_MOE_FORCE_A16=0`.
- Both runs logged V2 model runner, `B12X_MLA_SPARSE`, and `Using 'B12X' NvFp4 MoE backend`.
- Both runs completed `/mnt/test.py -L` until timeout with coherent output and `CJK characters in output: 0`.
- `git diff --check` passed.
- `python3 -m py_compile vllm/model_executor/layers/fused_moe/oracle/nvfp4.py vllm/model_executor/layers/quantization/modelopt.py` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable NVFP4 Mixture of Experts kernel preparation options via environment variables and new parameters to optimize activation precision handling during inference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->