### PR TITLE
Avoid unnecessary GLM virtual TP head padding and fix DCP MTP check

### DIFF
--- a/tests/config/test_virtual_tp.py
+++ b/tests/config/test_virtual_tp.py
@@ -283,21 +283,21 @@ def test_b12x_virtual_tp_padding_glm_dsa_tp6():
     maybe_apply_b12x_virtual_tp_padding(cast(Any, vllm_config))
 
     text_config = vllm_config.model_config.hf_text_config
-    assert text_config.num_attention_heads == 96
+    assert text_config.num_attention_heads == 66
     assert text_config.moe_intermediate_size == 2112
     assert text_config.vocab_size == 129280
     assert text_config.original_num_attention_heads == 64
     assert text_config.original_moe_intermediate_size == 2048
-    assert vllm_config.model_config.model_arch_config.total_num_attention_heads == 96
+    assert vllm_config.model_config.model_arch_config.total_num_attention_heads == 66
 
     plan = getattr(text_config, VIRTUAL_TP_PLAN_ATTR)
     assert "output_groups" not in plan
     assert "shared_expert_intermediate_size" not in plan
     assert plan["attention_heads"] == {
         "original_size": 64,
-        "padded_size": 96,
+        "padded_size": 66,
         "tp_size": 6,
-        "local_size": 16,
+        "local_size": 11,
     }
     assert plan["moe_intermediate_size"] == {
         "original_size": 2048,
@@ -329,9 +329,9 @@ def test_b12x_virtual_tp_padding_glm_dsa_draft_tp6():
     SpeculativeConfig._maybe_apply_virtual_tp_to_draft(cast(Any, spec_config))
 
     text_config = draft_model_config.hf_text_config
-    assert text_config.num_attention_heads == 96
+    assert text_config.num_attention_heads == 66
     assert text_config.moe_intermediate_size == 2112
-    assert draft_model_config.model_arch_config.total_num_attention_heads == 96
+    assert draft_model_config.model_arch_config.total_num_attention_heads == 66
 
 
 def test_b12x_virtual_tp_padding_minimax_m3_tp3_only():

--- a/vllm/config/virtual_tp.py
+++ b/vllm/config/virtual_tp.py
@@ -98,10 +98,14 @@ def _build_b12x_virtual_tp_plan(
     is_deepseek_v4 = _is_deepseek_v4_config(model_config)
 
     original_attention_heads = _require_int_attr(text_config, "num_attention_heads")
+    # DeepSeek V4 carries output-group constraints tied to padded head count.
+    # GLM/DSA sparse MLA only needs divisibility by TP; backend kernels handle
+    # their own local tiling, so avoid inflating KV/cache shapes there.
+    attention_head_alignment = _ATTENTION_HEAD_LOCAL_ALIGNMENT if is_deepseek_v4 else 1
     attention_axis = _make_virtual_axis(
         original_attention_heads,
         attention_tp_size,
-        _ATTENTION_HEAD_LOCAL_ALIGNMENT,
+        attention_head_alignment,
     )
     if is_deepseek_v4:
         original_output_groups = _require_int_attr(text_config, "o_groups")

--- a/vllm/v1/worker/cp_utils.py
+++ b/vllm/v1/worker/cp_utils.py
@@ -38,7 +38,10 @@ def check_attention_cp_compatibility(vllm_config: VllmConfig) -> None:
                     "MTP with cp_kv_cache_interleave_size > 1 is not "
                     f"supported in {layer_impl.__class__.__name__}."
                 )
-            if dcp_size > 1:
+            layer_dcp_size = getattr(layer_impl, "dcp_world_size", dcp_size)
+            if layer_dcp_size == -1:
+                layer_dcp_size = dcp_size
+            if layer_dcp_size > 1:
                 assert layer_impl.need_to_return_lse_for_decode, (
                     "Decode Context Parallelism (DCP) requires attention "
                     "implementations to return the softmax LSE during decode, "


### PR DESCRIPTION
## Summary

This PR carries two serving fixes needed for GLM-5.2 validation on Dark Devotion:

- avoid unnecessary B12X virtual-TP attention-head padding for GLM/DSA sparse MLA configs while keeping the existing DeepSeek V4 local-head alignment behavior;
- make the DCP LSE compatibility check use each attention layer's effective `dcp_world_size`, rather than the global DCP size for every layer.

## Root Cause

B12X virtual-TP padding used a global local attention-head alignment of `8`. That is still appropriate for the DeepSeek V4 path, where padded head count is tied to output-group handling, but it is too broad for GLM/DSA sparse MLA. GLM only needs the total query-head count to be divisible by TP; the backend kernels handle their own local tiling.

For GLM-5.2 with `64` attention heads:

- `TP8`: `64 / 8 = 8`, so the old alignment did not change the shape.
- `TP16`: old `8` alignment padded `4 -> 8` local heads, inflating `64 -> 128` heads.
- `TP6`: old `8` alignment padded `11 -> 16` local heads, inflating `64 -> 96` heads; the minimal virtual shape is `11 * 6 = 66`. This explains the roughly one-third KV/cache capacity loss observed with `--tp 6 --dcp 1`.

The fix keeps `_ATTENTION_HEAD_LOCAL_ALIGNMENT = 8`, but applies it only for DeepSeek V4. Non-DeepSeek B12X virtual-TP configs use local attention-head alignment `1`, so GLM gets the minimal padded shape required for TP divisibility.

For DCP + MTP, the global compatibility check treated the local MTP layer as if it also used the global DCP size. The backbone layers can run with DCP4 and need LSE handling, while the MTP layer may have `dcp_world_size=1`. The check now honors `layer_impl.dcp_world_size` when present, with the existing global DCP size as fallback.

## Changes

- `vllm/config/virtual_tp.py`
  - Preserve DeepSeek V4 attention-head local alignment `8`.
  - Use alignment `1` for GLM/DSA sparse MLA and other non-DeepSeek configs.
- `vllm/v1/worker/cp_utils.py`
  - Gate the DCP LSE assertion on per-layer effective `dcp_world_size`.
- `tests/config/test_virtual_tp.py`
  - Update GLM TP6 expected virtual attention heads from `64 -> 96` to `64 -> 66`.

## Validation

Static validation for the rewritten single-commit PR:

```text
python3 -m py_compile vllm/config/virtual_tp.py vllm/v1/worker/cp_utils.py tests/config/test_virtual_tp.py
git diff --check origin/dev/dark-devotion..HEAD
```

Both passed.

`pytest` was not available in the host Python environment (`No module named pytest`), so the unit test file was not executed locally in this rewrite pass.

Prior GLM-5.2 runtime validation for the same behavioral target showed DCP1, DCP4, and DCP4+MTP startup/graph-capture/coherence working; this rewrite scopes the TP alignment fix instead of globally changing the constant.
