### PR TITLE
Enable prefix caching under DCP for GLM-5.2 / DeepSeek-V4 by DCP-sharding the MTP draft

### DIFF
--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -1061,7 +1061,15 @@ class MLAAttention(nn.Module, AttentionLayerBase):
         layer_id = int(layer_match.group(1)) if layer_match is not None else None
         num_hidden_layers = getattr(vllm_config.model_config.hf_config,
                                     "num_hidden_layers", None)
-        dcp_replicated = (layer_id is not None
+        import os as _os
+        _shard_draft = _os.environ.get("VLLM_DCP_SHARD_DRAFT", "0").lower() in (
+            "1", "true", "yes")
+        # R1 prototype: when VLLM_DCP_SHARD_DRAFT is set, DCP-shard the draft
+        # (layers >= num_hidden_layers) instead of replicating it, so the draft
+        # KV uses the same sharded layout as the target (enables prefix caching
+        # under DCP, reclaims draft VRAM). Default unset = original replication.
+        dcp_replicated = (not _shard_draft
+                          and layer_id is not None
                           and num_hidden_layers is not None
                           and layer_id >= int(num_hidden_layers))
         return MLAAttentionSpec(

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -592,7 +592,13 @@ class DeepseekV32IndexerCache(torch.nn.Module, AttentionLayerBase):
         layer_id = extract_layer_index(self.prefix)
         num_hidden_layers = getattr(vllm_config.model_config.hf_config,
                                     "num_hidden_layers", None)
-        dcp_replicated = (layer_id is not None
+        import os as _os
+        _shard_draft = _os.environ.get("VLLM_DCP_SHARD_DRAFT", "0").lower() in (
+            "1", "true", "yes")
+        # R1 prototype: see MLAAttention.get_kv_cache_spec. Shard the indexer
+        # draft cache too when VLLM_DCP_SHARD_DRAFT is set.
+        dcp_replicated = (not _shard_draft
+                          and layer_id is not None
                           and num_hidden_layers is not None
                           and int(layer_id) >= int(num_hidden_layers))
         return MLAAttentionSpec(  # Only has one vector instead of K + V

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -543,30 +543,37 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
         self.hash_block_size = hash_block_size
         self.dcp_world_size = dcp_world_size
         self.pcp_world_size = pcp_world_size
-        # Prefix caching is unsupported for hybrid groups under DCP. Besides
-        # the DeepseekV4 MLA/SWA hybrid, this also covers an MLA target plus a
-        # DCP-replicated DFlash draft group (different block sizes / cp).
-        _has_dcp_replicated = any(
-            getattr(g.kv_cache_spec, "dcp_replicated", False)
-            for g in kv_cache_config.kv_cache_groups
-        )
+        # Prefix caching under DCP is only disabled for the genuine DeepseekV4
+        # MLA/SWA hybrid. A DCP-*replicated* draft group (MTP/DFlash) keeps its
+        # full cache per rank (so cached blocks are consistent across ranks) and
+        # is now hashable alongside the sharded target via the GCD hash_block_size
+        # (see resolve_kv_cache_block_sizes) + the scaled-block-size assert below.
+        # So it no longer forces a model-wide prefix-cache disable.
         self.disable_prefix_cache_for_dsv4_dcp = (
             enable_caching
             and dcp_world_size > 1
             and pcp_world_size == 1
-            and (
-                is_deepseek_v4_hybrid_kv_cache_config(kv_cache_config)
-                or _has_dcp_replicated
-            )
+            and is_deepseek_v4_hybrid_kv_cache_config(kv_cache_config)
         )
         if not self.disable_prefix_cache_for_dsv4_dcp:
+            # R3 fix: compare against the *effective* (DCP-scaled) block size the
+            # manager actually uses, not the unscaled spec block size. Under DCP
+            # a sharded group's manager.block_size == spec.block_size * dcp, which
+            # matches hash_block_size (= LCM of effective sizes). The original
+            # used g.kv_cache_spec.block_size (unscaled) and so was structurally
+            # unsatisfiable under DCP. Mirrors UnitaryKVCacheCoordinator.
             assert all(
-                g.kv_cache_spec.block_size % hash_block_size == 0
-                for g in kv_cache_config.kv_cache_groups
+                mgr.block_size % hash_block_size == 0
+                for mgr in self.single_type_managers
             ), "block_size must be divisible by hash_block_size"
-        assert dcp_world_size == 1 or self.disable_prefix_cache_for_dsv4_dcp, (
-            "DCP not support hybrid attn now."
-        )
+        # DCP>1 is allowed with prefix caching for non-hybrid (e.g. uniformly
+        # DCP-sharded) layouts; only the genuine DeepseekV4 MLA/SWA hybrid must
+        # keep caching disabled under DCP.
+        assert (
+            dcp_world_size == 1
+            or not is_deepseek_v4_hybrid_kv_cache_config(kv_cache_config)
+            or self.disable_prefix_cache_for_dsv4_dcp
+        ), "DCP prefix caching unsupported for the DeepseekV4 MLA/SWA hybrid."
         assert pcp_world_size == 1, "PCP not support hybrid attn now."
         self.verify_and_split_kv_cache_groups()
 

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -635,7 +635,13 @@ def resolve_kv_cache_block_sizes(
                 for g in groups
             ]
             scheduler_block_size = math.lcm(*effective_block_sizes)
-            return scheduler_block_size, scheduler_block_size
+            # hash_block_size = GCD (not the LCM scheduler size) so prefix
+            # caching can hash a replicated draft group (effective block_size
+            # `base`) alongside the DCP-sharded target (effective `base*dcp`):
+            # every group's block is a multiple of the GCD. scheduler_block_size
+            # stays the LCM, so cache hits still round to whole cross-rank
+            # blocks (alignment preserved); only hash granularity gets finer.
+            return scheduler_block_size, math.gcd(*effective_block_sizes)
         raise ValueError(
             "Hybrid KV cache groups with multiple block sizes do not "
             "support context parallelism (dcp_world_size/pcp_world_size > 1)."

--- a/vllm/v1/worker/gpu/spec_decode/eagle/utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/eagle/utils.py
@@ -13,10 +13,26 @@ def _create_draft_vllm_config(vllm_config: VllmConfig) -> VllmConfig:
     speculative_config = vllm_config.speculative_config
     assert speculative_config is not None
 
+    # DCP-sharded-draft: the draft is normally built with
+    # ``draft_parallel_config`` (decode_context_parallel_size=1), correct for a
+    # *replicated* draft. When the draft KV is DCP-*sharded*
+    # (VLLM_DCP_SHARD_DRAFT), the draft attention impls must be constructed with
+    # the parent's DCP world size so their workspace/scratch is sized for the
+    # DCP head all-gather and the cross-rank LSE-reduce path is taken.
+    import os as _os
+    _draft_parallel_config = speculative_config.draft_parallel_config
+    if _os.environ.get("VLLM_DCP_SHARD_DRAFT", "0").lower() in ("1", "true", "yes"):
+        _draft_parallel_config = replace(
+            _draft_parallel_config,
+            decode_context_parallel_size=(
+                vllm_config.parallel_config.decode_context_parallel_size
+            ),
+        )
+
     draft_vllm_config = replace(
         vllm_config,
         parallel_config=replace(
-            speculative_config.draft_parallel_config,
+            _draft_parallel_config,
             rank=vllm_config.parallel_config.rank,
         ),
         model_config=speculative_config.draft_model_config,

--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -109,7 +109,11 @@ class KVBlockZeroer:
         """
         self.device = device
         self.pin_memory = pin_memory
-        self._meta: tuple[torch.Tensor, int, int, int] | None = None
+        # One zeroing meta per distinct page size. DSv4/GLM-5.2 has >1 inherent
+        # page size (main MLA latent vs DSA indexer cache); DCP-sharding the
+        # draft can also surface that split here. Each meta drives a separate
+        # kernel launch with its own PAGE_SIZE_EL.
+        self._metas: list[tuple[torch.Tensor, int, int, int]] = []
         self._id_cap: int = 0
         self._ids_pinned: torch.Tensor | None = None
         self._ids_gpu: torch.Tensor | None = None
@@ -117,8 +121,7 @@ class KVBlockZeroer:
         if runner_only_attn_layers is None:
             runner_only_attn_layers = set()
         seen_ptrs: set[int] = set()
-        seg_addrs: list[int] = []
-        page_size_el: int | None = None
+        segs_by_page: dict[int, list[int]] = {}
 
         for group in attn_groups_iter:
             spec = group.kv_cache_spec
@@ -151,12 +154,6 @@ class KVBlockZeroer:
                 assert cur_bytes % 4 == 0
                 kernel_block_el = cur_bytes // 4
                 cur_page_el = kernel_block_el * ratio
-                if page_size_el is None:
-                    page_size_el = cur_page_el
-                else:
-                    assert page_size_el == cur_page_el, (
-                        f"Non-uniform page sizes: {page_size_el} vs {cur_page_el}"
-                    )
 
                 block_stride_bytes = cur_bytes
                 outer_dims = [
@@ -165,15 +162,15 @@ class KVBlockZeroer:
                     if kv.stride(d) * el > block_stride_bytes
                 ]
                 outer_strides = [kv.stride(d) * el for d in outer_dims]
+                bucket = segs_by_page.setdefault(cur_page_el, [])
                 for outer in iprod(*(range(kv.shape[d]) for d in outer_dims)):
                     off_bytes = sum(i * s for i, s in zip(outer, outer_strides))
-                    seg_addrs.append(dp + off_bytes)
+                    bucket.append(dp + off_bytes)
 
-        if not seg_addrs or page_size_el is None:
-            self._meta = None
+        if not segs_by_page:
+            self._metas = []
             return
 
-        blk_size = min(largest_power_of_2_divisor(page_size_el), 1024)
         self._id_cap = 8192
         self._ids_pinned = torch.empty(
             self._id_cap,
@@ -181,18 +178,20 @@ class KVBlockZeroer:
             pin_memory=self.pin_memory,
         )
         self._ids_gpu = torch.empty(self._id_cap, dtype=torch.int64, device=self.device)
-        self._meta = (
-            torch.tensor(seg_addrs, dtype=torch.uint64, device=self.device),
-            page_size_el,
-            blk_size,
-            len(seg_addrs),
-        )
+        self._metas = [
+            (
+                torch.tensor(addrs, dtype=torch.uint64, device=self.device),
+                psize,
+                min(largest_power_of_2_divisor(psize), 1024),
+                len(addrs),
+            )
+            for psize, addrs in segs_by_page.items()
+        ]
 
     def zero_block_ids(self, block_ids: list[int]) -> None:
         """Zero the KV cache memory for the given block IDs."""
-        if not block_ids or self._meta is None:
+        if not block_ids or not self._metas:
             return
-        seg_addrs, page_size_el, blk_size, n_segs = self._meta
         n_blocks = len(block_ids)
         if n_blocks > self._id_cap:
             self._id_cap = n_blocks * 2
@@ -208,15 +207,16 @@ class KVBlockZeroer:
         self._ids_pinned[:n_blocks].numpy()[:] = block_ids
         idx = self._ids_gpu[:n_blocks]
         idx.copy_(self._ids_pinned[:n_blocks], non_blocking=True)
-        grid = (n_blocks * n_segs * (page_size_el // blk_size),)
-        _zero_kv_blocks_kernel[grid](
-            seg_addrs,
-            idx,
-            n_blocks,
-            N_SEGS=n_segs,
-            PAGE_SIZE_EL=page_size_el,
-            BLOCK_SIZE=blk_size,
-        )
+        for seg_addrs, page_size_el, blk_size, n_segs in self._metas:
+            grid = (n_blocks * n_segs * (page_size_el // blk_size),)
+            _zero_kv_blocks_kernel[grid](
+                seg_addrs,
+                idx,
+                n_blocks,
+                N_SEGS=n_segs,
+                PAGE_SIZE_EL=page_size_el,
+                BLOCK_SIZE=blk_size,
+            )
 
 
 @dataclass


### PR DESCRIPTION
## Problem
With `--decode-context-parallel-size > 1`, GLM-5.2 (DeepSeek-V4 sparse MLA + MTP
spec decode) reports `Prefix cache hit rate: 0.0%` permanently:
`HybridKVCacheCoordinator` force-disables prefix caching whenever a KV-cache
group is `dcp_replicated`, and the base branch marks the MTP **draft** group
`dcp_replicated=True` (it replicates draft KV across DCP ranks because the draft
*broke* when naively sharded). So MTP + DCP ⇒ no prefix caching — very costly for
long shared prefixes (agentic / multi-turn).

## Fix
DCP-**shard** the MTP draft (instead of replicating it), behind the opt-in
`VLLM_DCP_SHARD_DRAFT` env flag (default off = original replication). The
non-obvious part is *why* the draft broke when sharded, and the fix for it.

**Root cause of the sharded-draft breakage.** The draft model is built via
`eagle/utils.py:_create_draft_vllm_config` using
`speculative_config.draft_parallel_config`, whose `decode_context_parallel_size`
is **1** (correct for a replicated draft). So `B12xMLASparseImpl.__init__` —
which reads `parallel_config.decode_context_parallel_size` and sizes its
caller-owned-scratch plan via `_workspace_num_heads = num_heads * max(1, dcp)` —
built the draft attention impl **non-DCP** (`dcp_world_size=1`, `need_lse=False`,
scratch for the un-gathered head count). Meanwhile the draft KV was sharded and
the metadata builder used `dcp=4`. Result: each rank read its 1/dcp KV shard as
the *full* context and never did the cross-rank LSE reduce → garbage proposals
(spec acceptance 4.0 → 1.6; the target still verifies, so output stayed correct
— only speed was lost).

**The fix:** when the draft is DCP-sharded, build it with the parent's DCP world
size so the draft impl is *constructed* with `dcp_world_size=4` — its plan/scratch
is sized for the head all-gather and the cross-rank LSE-reduce path is taken. (A
mid-forward override does NOT work: the b12x decode/extend plan is sized once per
mode in `__init__`, so flipping `dcp_world_size` later throws
`q heads 32 do not match scratch heads 16`.)

> Note on B12X: this does not change the B12X scratch ownership model. The
> `B12xMLASparseImpl` plan is still built once per mode in `__init__` and the
> scratch is still caller-owned, fetched per call from
> `current_workspace_manager()` with `plan.bind(scratch=...)` (per
> `docs/contributing/b12x-vllm-bindings.md`). This change only routes the correct
> `decode_context_parallel_size` into the draft's config so its plan is sized
> like the target's.

## Changes (6 files)
1. **`v1/worker/gpu/spec_decode/eagle/utils.py`** — `_create_draft_vllm_config`:
   inherit the target's `decode_context_parallel_size` for the draft when
   sharding. **The core fix.**
2. **`model_executor/layers/attention/mla_attention.py`,
   `model_executor/models/deepseek_v2.py`** — gate the draft's
   `dcp_replicated` (`layer_id >= num_hidden_layers`) behind
   `VLLM_DCP_SHARD_DRAFT`; when set, the draft KV is DCP-sharded like the target.
3. **`v1/core/kv_cache_coordinator.py`** — (a) disable prefix caching under DCP
   only for the genuine DeepSeek-V4 MLA/SWA hybrid, not for a `dcp_replicated`
   group; (b) **block-size divisibility assert fix** — compare the DCP-*scaled*
   `manager.block_size` vs `hash_block_size`, not the unscaled `spec.block_size`
   (the original was structurally unsatisfiable under DCP; `Unitary` already does
   this); (c) relax `assert dcp==1 or disable` to allow DCP>1 + caching for
   non-hybrid layouts.
4. **`v1/core/kv_cache_utils.py`** — `resolve_kv_cache_block_sizes` uses the GCD
   of effective block sizes for `hash_block_size` (scheduler size stays the LCM,
   so hits still align to whole cross-rank blocks).
5. **`v1/worker/utils.py`** — `KVBlockZeroer` supports non-uniform page sizes
   (DeepSeek-V4 has two: MLA latent vs DSA indexer); one zeroing kernel per
   distinct page size. Independently useful robustness fix.

For a follow-up, the env flag should be promoted to a `speculative_config` field.

## Results (author hardware: 8×, TP=8, DCP=4, MTP=5, GLM-5.2-NVFP4; `VLLM_DCP_SHARD_DRAFT=1`)
| metric | replicated baseline | **sharded + fix** |
|---|---|---|
| prefix caching | off (0%) | **works** (hits climb; cross-request reuse) |
| spec acceptance length | 3.3–4.0 | **3.25–4.21** (preserved) |
| GPU KV cache | 1,642,855 tok / 6.42× | **1,717,248 / 6.71×** (+5%, draft VRAM reclaimed) |
| decode tok/s (single) | 22.7 | **30.1 (+33%)** |
| decode tok/s (conc=4) | 54.3 | **73.0 (+34%)** |

The sharded draft is *faster* than replicated (¼ the KV per rank → cheaper b12x
decode per step at equal acceptance), on top of enabling prefix caching and
reclaiming VRAM.

### Note on determinism
At temp=0 the engine is **not bit-deterministic** in this config (DCP reductions
+ async scheduling + spec decode → FP/ordering variance): repeated identical
requests — cache hit *or* miss — produce minor synonym-level differences. This is
pre-existing (warm-vs-warm runs also differ) and independent of this change;
prefix-cache reuse is correct (coherent outputs, preserved acceptance, hashing
verified by climbing hits). A strict `cold==warm` byte check is therefore not a
valid gate here.

## Why this is not a duplicate
This PR is **additive on top of** the base branch
`codex/glm52-dcp-mtp-replicated-kv-20260618` (open PR #26, "Fix GLM 5.2 DCP MTP
metadata and graph capture state"), which fixes DCP MTP metadata/graph-capture
for a **replicated** draft. This PR takes the opposite layout decision — it
DCP-**shards** the draft to enable prefix caching — and is gated behind a new env
flag so the base branch's replicated path remains the default. No other open PR
on this fork addresses DCP prefix caching / draft sharding (`#27` spec proposer
metadata cleanup, `#22` MiMo-V2 streaming, `#8` Step3.5 MTP argmax are
unrelated).

## Tests run
- **In this environment** (no CUDA/GPU, no built vLLM venv): static validation
  only — `python -m py_compile` passes on all 6 modified files; all added lines
  are ≤ 88 chars; the diff is exactly the 6-file change described above.
- **On author hardware** (8×GPU, config above, `VLLM_DCP_SHARD_DRAFT=1`):
  functional + performance validation per the results table — prefix-cache hit
  rate climbs across requests, spec acceptance length preserved, decode
  throughput +33–34%. Correctness validated via output coherence + acceptance +
  hit-rate (see determinism note for why a byte-exact cold==warm check is not a
  valid gate).
- **Not run here**: `pre-commit` (ruff/mypy) and the pytest suite — they require
  the `uv`/`.venv` toolchain and, for the DCP/MTP paths, multi-GPU hardware not
  available in this environment. Recommend running `pre-commit run --all-files`
  and the relevant GPU tests before merge.

## Flags / repro
`VLLM_DCP_SHARD_DRAFT=1` enables the sharded draft. `VLLM_DCP_DEBUG=1` logs
per-layer DCP attention setup.

---

> **AI assistance disclosure:** This change was prepared with AI assistance
> (Claude Code). The patch was authored/validated by a human submitter who
> reviews every changed line and is accountable for the change end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GGuk9dcSi3b1pk5JyN4Lxj
