### PR TITLE
parser: bypass tool parser for no-tools streams

### DIFF
--- a/tests/parser/engine/test_parser_engine.py
+++ b/tests/parser/engine/test_parser_engine.py
@@ -889,9 +889,21 @@ class _CombinedDelegating(DelegatingParser):
     tool_parser_cls = _CombinedToolAdapter
 
 
-def _make_delegating_request():
+def _make_delegating_request(*, with_tools: bool = False):
     req = MagicMock(spec=ChatCompletionRequest)
-    req.tools = []
+    req.tools = (
+        [
+            ChatCompletionToolsParam(
+                type="function",
+                function={
+                    "name": "f",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            )
+        ]
+        if with_tools
+        else []
+    )
     req.tool_choice = "auto"
     return req
 
@@ -928,7 +940,7 @@ class TestAdapterFinishOnStreamEnd:
         mid-tool-call (closing brace held back in buffer)."""
         tokenizer = make_mock_tokenizer(_VOCAB)
         parser = _CombinedDelegating(tokenizer)
-        request = _make_delegating_request()
+        request = _make_delegating_request(with_tools=True)
 
         parser.parse_delta("</think>", [201], request, finished=False)
         parser.parse_delta("<tool_call>", [202], request, finished=False)
@@ -940,6 +952,25 @@ class TestAdapterFinishOnStreamEnd:
         assert delta is not None, (
             "Engine finish should produce a delta with flushed args/end"
         )
+
+    def test_no_tools_content_bypasses_tool_parser_after_reasoning(self):
+        """Post-reasoning content must not enter the tool parser when the
+        request has no tools, even if a global tool parser exists."""
+        tokenizer = make_mock_tokenizer(_VOCAB)
+        parser = _CombinedDelegating(tokenizer)
+        request = _make_delegating_request()
+
+        parser.parse_delta("thinking", [], request, finished=False)
+        parser.parse_delta("</think>", [201], request, finished=False)
+
+        first = parser.parse_delta(" limit <", [], request, finished=False)
+        second = parser.parse_delta(" 2:\n       ", [], request, finished=False)
+
+        assert first is not None
+        assert first.content == " limit <"
+        assert second is not None
+        assert second.content == " 2:\n       "
+        assert not parser._stream_state.tool_call_text_started
 
 
 # ── TestReasoningOnlyDelegatingParser ─────────────────────────────

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -694,6 +694,10 @@ class DelegatingParser(Parser):
             return False
         return state.reasoning_ended
 
+    @staticmethod
+    def _request_has_tools(request: ChatCompletionRequest | ResponsesRequest) -> bool:
+        return bool(getattr(request, "tools", None))
+
     def _append_unstreamed_tool_args(
         self,
         delta_message: DeltaMessage | None,
@@ -815,7 +819,21 @@ class DelegatingParser(Parser):
                     delta_text = current_text
 
         # Tool call extraction
-        if self._in_tool_call_phase(state):
+        #
+        # ``--enable-auto-tool-choice`` installs a tool parser globally, but a
+        # request without a tools list cannot produce valid tool calls.  Do not
+        # route plain post-reasoning content through an engine-based tool
+        # parser in that case; it may carry buffered content and re-emit text
+        # that the output processor already streamed as a clean delta.
+        if self._in_tool_call_phase(state) and not self._request_has_tools(request):
+            if current_text:
+                if delta_message is None:
+                    delta_message = DeltaMessage(content=current_text)
+                elif delta_message.content:
+                    delta_message.content += current_text
+                else:
+                    delta_message.content = current_text
+        elif self._in_tool_call_phase(state):
             if not state.tool_call_text_started:
                 state.tool_call_text_started = True
                 state.previous_text = ""
@@ -882,6 +900,11 @@ class DelegatingParser(Parser):
         reasoning_ended = self._stream_state.reasoning_ended
         for parser in (self._reasoning_parser, self._tool_parser):
             if not getattr(parser, "engine_based_streaming", False):
+                continue
+            if (
+                parser is self._tool_parser
+                and not self._stream_state.tool_call_text_started
+            ):
                 continue
             # When reasoning has ended and we transitioned to the tool
             # phase, the reasoning parser's engine may still have buffered


### PR DESCRIPTION
## Summary

Fixes a GLM-5.2 streaming corruption where plain post-reasoning content was routed through the tool parser even when the request did not provide any tools.

With `--enable-auto-tool-choice`, vLLM constructs a tool parser globally. After `</think>`, `DelegatingParser._in_tool_call_phase()` became true whenever that parser existed, regardless of whether the request had a `tools` list. For no-tools requests, the engine-based tool parser can re-emit buffered plain content and duplicate fragments in streamed deltas.

Observed on GLM-5.2 NVFP4/B12X MTP3 long-context streaming:

```text
output_processor text: " 2:\n       "
served delta content: "< 2:\n        2:\n       "
```

This produced client-visible code corruption such as:

```python
if limit < limit < 2:
    2:
```

## Changes

- Add a small request-level tools check in `DelegatingParser`.
- Bypass tool-call extraction for post-reasoning content when `request.tools` is empty/missing.
- Skip engine tool-parser final flush if tool-call streaming never started.
- Update parser-engine tests so tool-parser flush tests explicitly use tools, and add a no-tools regression test.

## Validation

- Syntax check: `python3 -m py_compile vllm/parser/abstract_parser.py tests/parser/engine/test_parser_engine.py`
- Whitespace check: `git diff --check`
- Runtime soak on the live GLM-5.2 NVFP4/B12X MTP3 instance with this file overlaid: 30/30 `/mnt/test.py` long-context streaming iterations passed without the `if limit < ... limit <` corruption.

Note: upstream vLLM PR #46149 fixes a related but separate forced/named tool-choice + reasoning grammar issue. This PR intentionally does not include that change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of generated content when no tools are configured. Content generated after reasoning is no longer incorrectly interpreted as tool call markup, preventing spurious parsing errors.
  * Added validation to bypass tool parsing logic when the request has no tools enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->