### PR TITLE
Fix GLM DCP global top-k MTP

### DIFF
--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -427,6 +427,25 @@ def _get_dcp_warmup_params() -> tuple[int, int, int]:
     return dcp_world_size, dcp_rank, cp_kv_cache_interleave_size
 
 
+def _sync_dcp_warmup() -> None:
+    """Finish one-time DCP warmup on every rank before graph warmup proceeds."""
+    if current_platform.is_cuda():
+        torch.cuda.synchronize()
+
+    try:
+        from vllm.distributed.parallel_state import get_dcp_group
+
+        dcp_group = get_dcp_group()
+        if int(dcp_group.world_size) <= 1:
+            return
+        dcp_group.barrier()
+    except Exception:
+        return
+    finally:
+        if current_platform.is_cuda():
+            torch.cuda.synchronize()
+
+
 def _prewarm_b12x_dcp_topk_merge(
     *,
     q_rows: int,
@@ -439,73 +458,30 @@ def _prewarm_b12x_dcp_topk_merge(
     if dcp_world_size <= 1 or topk_tokens <= 0:
         return
 
-    rows = max(1, int(q_rows))
     topk = int(topk_tokens)
-    world_size = int(dcp_world_size)
-    candidate_width = world_size * topk
-    (
-        candidates,
-        gathered_candidates,
-        candidate_indices,
-        candidate_score_bits,
-        candidate_lengths,
-    ) = current_workspace_manager().get_simultaneous(
-        ((rows, 2, topk), torch.int32),
-        ((rows * world_size, 2, topk), torch.int32),
-        ((rows, candidate_width), torch.int32),
-        ((rows, candidate_width), torch.int32),
-        ((rows,), torch.int32),
-    )
-    if not _use_triton_dcp_remap(candidate_indices):
-        return
-
-    from b12x.attention.indexer.tiled_topk import run_row_topk
-
-    from vllm.v1.attention.backends.mla.sparse_utils import (
-        triton_convert_dcp_local_topk_to_global,
-        triton_gather_topk_ids_by_position,
-    )
-
-    topk_indices = torch.empty((rows, topk), dtype=torch.int32, device=device)
-    topk_scores = torch.empty((rows, topk), dtype=torch.float32, device=device)
-    topk_indices.copy_(
-        torch.arange(topk, dtype=torch.int32, device=device).expand(rows, topk)
-    )
-    topk_scores.zero_()
-    triton_convert_dcp_local_topk_to_global(
-        topk_indices,
-        topk_scores,
-        dcp_world_size=world_size,
-        dcp_rank=int(dcp_rank),
-        cp_kv_cache_interleave_size=int(cp_kv_cache_interleave_size),
-    )
-
-    candidates[:, 0, :].copy_(topk_indices)
-    candidates[:, 1, :].copy_(topk_scores.view(torch.int32))
-    gathered_view = gathered_candidates.view(world_size, rows, 2, topk)
-    for rank in range(world_size):
-        gathered_view[rank].copy_(candidates)
-    _unpack_b12x_dcp_gathered_candidates(
-        gathered_candidates,
-        candidate_indices,
-        candidate_score_bits,
-        dcp_world_size=world_size,
-        topk_tokens=topk,
-    )
-
-    candidate_lengths.fill_(candidate_width)
-    run_row_topk(
-        row_logits=candidate_score_bits.view(torch.float32),
-        lengths=candidate_lengths,
-        topk=topk,
-        output_values=topk_scores,
-        output_indices=topk_indices,
-    )
-    triton_gather_topk_ids_by_position(
-        candidate_indices,
-        topk_indices,
-        topk_indices,
-    )
+    # Graph warmup later exercises both small decode rows and prefill chunks.
+    # Use the real runtime merge path here, including DCP all-gather, so Triton
+    # and b12x row-topk kernels are loaded before rank-sensitive attention
+    # collectives begin.
+    warmup_rows = (1, 2, 4, max(1, int(q_rows)))
+    seen_rows: set[int] = set()
+    base_ids = torch.arange(topk, dtype=torch.int32, device=device)
+    for rows in warmup_rows:
+        rows = int(rows)
+        if rows in seen_rows:
+            continue
+        seen_rows.add(rows)
+        topk_indices = base_ids.expand(rows, topk).clone()
+        topk_scores = torch.zeros((rows, topk), dtype=torch.float32, device=device)
+        _merge_b12x_dcp_topk(
+            topk_indices=topk_indices,
+            topk_scores=topk_scores,
+            topk_tokens=topk,
+            dcp_world_size=int(dcp_world_size),
+            dcp_rank=int(dcp_rank),
+            cp_kv_cache_interleave_size=int(cp_kv_cache_interleave_size),
+        )
+        _sync_dcp_warmup()
 
 
 def _dcp_global_topk_remap(
@@ -920,6 +896,35 @@ def _merge_b12x_dcp_topk(
         candidate_indices,
         topk_indices,
         topk_indices,
+    )
+
+
+def _convert_b12x_dcp_local_topk_to_global(
+    *,
+    topk_indices: torch.Tensor,
+    topk_scores: torch.Tensor | None,
+    dcp_world_size: int,
+    dcp_rank: int,
+    cp_kv_cache_interleave_size: int,
+) -> None:
+    if dcp_world_size <= 1 or topk_indices.numel() == 0:
+        return
+    if topk_scores is None:
+        raise RuntimeError(
+            "B12X sparse indexer DCP requires a topk_scores_buffer for "
+            "local-to-global candidate conversion."
+        )
+
+    from vllm.v1.attention.backends.mla.sparse_utils import (
+        triton_convert_dcp_local_topk_to_global,
+    )
+
+    triton_convert_dcp_local_topk_to_global(
+        topk_indices,
+        topk_scores,
+        dcp_world_size=dcp_world_size,
+        dcp_rank=dcp_rank,
+        cp_kv_cache_interleave_size=cp_kv_cache_interleave_size,
     )
 
 
@@ -1383,15 +1388,34 @@ def sparse_attn_indexer(
             ]
             if chunk.total_seq_lens <= 0:
                 topk_indices.fill_(-1)
-                if dcp_global_topk and not use_b12x_indexer:
-                    _dcp_global_topk_remap(
-                        topk_indices,
-                        None,
-                        topk_tokens,
-                        dcp_rank,
-                        dcp_world_size,
-                        cp_kv_cache_interleave_size,
-                    )
+                if dcp_global_topk:
+                    if use_b12x_indexer:
+                        if topk_scores_buffer is None:
+                            raise RuntimeError(
+                                "B12X sparse indexer DCP requires topk_scores_buffer."
+                            )
+                        topk_scores = topk_scores_buffer[
+                            chunk.token_start : chunk.token_end, :topk_tokens
+                        ]
+                        topk_scores.fill_(-float("inf"))
+                        _merge_b12x_dcp_topk(
+                            topk_indices=topk_indices,
+                            topk_scores=topk_scores,
+                            topk_tokens=topk_tokens,
+                            dcp_world_size=dcp_world_size,
+                            dcp_rank=dcp_rank,
+                            cp_kv_cache_interleave_size=cp_kv_cache_interleave_size,
+                        )
+                        topk_indices.masked_fill_(topk_scores == -float("inf"), -1)
+                    else:
+                        _dcp_global_topk_remap(
+                            topk_indices,
+                            None,
+                            topk_tokens,
+                            dcp_rank,
+                            dcp_world_size,
+                            cp_kv_cache_interleave_size,
+                        )
                 continue
 
             if use_b12x_indexer:
@@ -1431,14 +1455,23 @@ def sparse_attn_indexer(
                     topk_scores=topk_scores,
                     shared_page_table=True,
                 )
-                _merge_b12x_dcp_topk(
-                    topk_indices=topk_indices,
-                    topk_scores=topk_scores,
-                    topk_tokens=topk_tokens,
-                    dcp_world_size=dcp_world_size,
-                    dcp_rank=dcp_rank,
-                    cp_kv_cache_interleave_size=cp_kv_cache_interleave_size,
-                )
+                if dcp_global_topk:
+                    _merge_b12x_dcp_topk(
+                        topk_indices=topk_indices,
+                        topk_scores=topk_scores,
+                        topk_tokens=topk_tokens,
+                        dcp_world_size=dcp_world_size,
+                        dcp_rank=dcp_rank,
+                        cp_kv_cache_interleave_size=cp_kv_cache_interleave_size,
+                    )
+                else:
+                    _convert_b12x_dcp_local_topk_to_global(
+                        topk_indices=topk_indices,
+                        topk_scores=topk_scores,
+                        dcp_world_size=dcp_world_size,
+                        dcp_rank=dcp_rank,
+                        cp_kv_cache_interleave_size=cp_kv_cache_interleave_size,
+                    )
                 topk_indices.masked_fill_(row_has_no_kv[:, None], -1)
                 continue
 
@@ -1574,14 +1607,23 @@ def sparse_attn_indexer(
                 topk_tokens=topk_tokens,
                 topk_scores=topk_scores,
             )
-            _merge_b12x_dcp_topk(
-                topk_indices=topk_indices,
-                topk_scores=topk_scores,
-                topk_tokens=topk_tokens,
-                dcp_world_size=dcp_world_size,
-                dcp_rank=dcp_rank,
-                cp_kv_cache_interleave_size=cp_kv_cache_interleave_size,
-            )
+            if dcp_global_topk:
+                _merge_b12x_dcp_topk(
+                    topk_indices=topk_indices,
+                    topk_scores=topk_scores,
+                    topk_tokens=topk_tokens,
+                    dcp_world_size=dcp_world_size,
+                    dcp_rank=dcp_rank,
+                    cp_kv_cache_interleave_size=cp_kv_cache_interleave_size,
+                )
+            else:
+                _convert_b12x_dcp_local_topk_to_global(
+                    topk_indices=topk_indices,
+                    topk_scores=topk_scores,
+                    dcp_world_size=dcp_world_size,
+                    dcp_rank=dcp_rank,
+                    cp_kv_cache_interleave_size=cp_kv_cache_interleave_size,
+                )
             return topk_indices_buffer
 
         schedule_metadata = decode_metadata.schedule_metadata

--- a/vllm/model_executor/models/deepseek_mtp.py
+++ b/vllm/model_executor/models/deepseek_mtp.py
@@ -24,6 +24,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
     GroupShape,
     scaled_dequantize,
 )
+from vllm.model_executor.layers.sparse_attn_indexer import use_b12x_sparse_indexer
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
     VocabParallelEmbedding,
@@ -321,8 +322,20 @@ class DeepSeekMultiTokenPredictorLayer(nn.Module):
                 dtype=torch.int32,
                 device=self.device,
             )
+            topk_scores_buffer = None
+            if (
+                vllm_config.parallel_config.decode_context_parallel_size > 1
+                and use_b12x_sparse_indexer()
+            ):
+                topk_scores_buffer = torch.empty(
+                    vllm_config.scheduler_config.max_num_batched_tokens,
+                    topk_tokens,
+                    dtype=torch.float32,
+                    device=self.device,
+                )
         else:
             topk_indices_buffer = None
+            topk_scores_buffer = None
 
         self.shared_head = SharedHead(
             config=config, prefix=prefix, quant_config=quant_config
@@ -332,6 +345,7 @@ class DeepSeekMultiTokenPredictorLayer(nn.Module):
             prefix,
             config=self.config,
             topk_indices_buffer=topk_indices_buffer,
+            topk_scores_buffer=topk_scores_buffer,
             quant_config=quant_config,
             layer_idx_override=0,
             is_nextn=True,

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -69,6 +69,7 @@ logger = init_logger(__name__)
 # wave-balanced planner picks num_splits <= this cap.
 _DECODE_SPLIT_TILE = 64
 _PREFILL_HEADS_PER_BLOCK = 16
+_EXTEND_PREWARM_DONE: set[tuple[int | None, int, int, int, int, int, bool]] = set()
 
 
 def _cdiv(x: int, y: int) -> int:
@@ -674,9 +675,96 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
             ((max_batched, self.num_heads, self.q_head_dim), torch.bfloat16),
             ((self._scratch_nbytes,), torch.uint8),
         )
+        self._prewarm_extend_kernels_once(max_batched)
 
         # Q arrives BF16; the unified kernel quantizes inside.
         self.supports_quant_query_input = False
+
+    def _sync_dcp_warmup(self) -> None:
+        if self.device.type == "cuda":
+            torch.cuda.synchronize(self.device)
+        if self.dcp_world_size <= 1:
+            return
+        try:
+            from vllm.distributed.parallel_state import get_dcp_group
+
+            dcp_group = get_dcp_group()
+            dcp_group.barrier()
+        except Exception:
+            return
+        finally:
+            if self.device.type == "cuda":
+                torch.cuda.synchronize(self.device)
+
+    def _prewarm_extend_kernels_once(self, max_batched: int) -> None:
+        if self.device.type != "cuda":
+            return
+        key = (
+            self.device.index,
+            self.q_head_dim,
+            self.kv_lora_rank,
+            self._prefill_num_heads,
+            int(self.topk_tokens),
+            int(self.block_size),
+            bool(self.need_to_return_lse_for_decode),
+        )
+        if key in _EXTEND_PREWARM_DONE:
+            return
+        _EXTEND_PREWARM_DONE.add(key)
+
+        rows_to_warm = (1, 2, 4, max(1, int(max_batched)))
+        seen_rows: set[int] = set()
+        # GLM fp8_ds_mla cache records are 656 B/token. One page is enough:
+        # prewarm top-k indices all point at slot zero.
+        kv_cache = torch.zeros(
+            (self.block_size, 1, 656), dtype=torch.uint8, device=self.device
+        )
+        for rows in rows_to_warm:
+            rows = int(rows)
+            if rows in seen_rows:
+                continue
+            seen_rows.add(rows)
+            q = torch.zeros(
+                (rows, self._prefill_num_heads, self.q_head_dim),
+                dtype=torch.bfloat16,
+                device=self.device,
+            )
+            selected_indices = torch.zeros(
+                (rows, self.topk_tokens), dtype=torch.int32, device=self.device
+            )
+            cache_seqlens = torch.full(
+                (1,), self.block_size, dtype=torch.int32, device=self.device
+            )
+            nsa_cache_seqlens = torch.ones(
+                (rows,), dtype=torch.int32, device=self.device
+            )
+            scratch_storage = torch.empty(
+                (self._scratch_nbytes,), dtype=torch.uint8, device=self.device
+            )
+            binding = self._extend_plan.bind(
+                scratch=scratch_storage,
+                q=q,
+                selected_indices=selected_indices,
+                cache_seqlens_int32=cache_seqlens,
+                nsa_cache_seqlens_int32=nsa_cache_seqlens,
+            )
+            if self.need_to_return_lse_for_decode:
+                self._sparse_mla_extend_forward(
+                    binding=binding,
+                    kv_cache=kv_cache,
+                    sm_scale=self.scale,
+                    v_head_dim=self.kv_lora_rank,
+                    return_lse=True,
+                    lse_scale="natural",
+                )
+            else:
+                self._sparse_mla_extend_forward(
+                    binding=binding,
+                    kv_cache=kv_cache,
+                    sm_scale=self.scale,
+                    v_head_dim=self.kv_lora_rank,
+                )
+            self._sync_dcp_warmup()
 
     def forward_mqa(
         self,

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -957,7 +957,13 @@ def build_prefill_chunk_metadata(
         total_seq_lens = int(compressed_seq_lens_np[start_idx:end_idx].sum())
     else:
         total_seq_lens = compressed_seq_lens_cpu[start_idx:end_idx].sum().item()
-    if total_seq_lens == 0:
+    keep_empty_dcp_chunk = (
+        envs.VLLM_USE_B12X_SPARSE_INDEXER
+        and dcp_world_size > 1
+        and os.environ.get("VLLM_DCP_GLOBAL_TOPK", "1").lower()
+        in ("1", "true", "yes", "on")
+    )
+    if total_seq_lens == 0 and not keep_empty_dcp_chunk:
         return None
 
     num_reqs = end_idx - start_idx


### PR DESCRIPTION
## Summary

This replaces the previous PR contents with one clean commit for the validated fast GLM-5.2 TP8/DCP4/MTP3 path on current `dev/dark-devotion`.

The fix keeps the B12X DCP global-topk path rank-consistent during graph warmup and makes the MTP draft path provide the same top-k score buffer that the target GLM path already provides.

Changes included:
- Keep empty DCP prefill chunks for the B12X sparse-indexer global-topk path instead of dropping them on ranks with no local KV.
- Prewarm the actual B12X DCP global-topk merge path, not a shape-only placeholder, so graph/JIT ordering is stable before MLA attention collectives begin.
- Keep no-local-KV B12X top-k chunks in the same global merge path with `-inf` scores and mask results back to `-1`.
- Prewarm B12X sparse MLA extend kernels using caller-owned scratch via `plan.bind(scratch=...)`, matching the vLLM eager binding rule.
- Allocate and pass `topk_scores_buffer` from the MTP draft layer when DCP + B12X sparse indexer is active. Without this, the latest B12X global-topk stack failed or ran in non-comparable slow paths for MTP.

No B12X source patch is included in this PR. The validated run uses B12X `5af873a7b6c81fbf533ef96bede13fbf4744ad2a` unchanged.

## Validation

Clean image built through the standard `blackwell-llm-docker` pipeline:

`voipmonitor/vllm:dark-devotion-df8ad3b-b12x5af873a-mtptopkscores-cu132-20260621`

Build inputs:
- vLLM: this PR, `000807e2b0e33277ac6b3ae51ae2e52d8472c9ab`
- Base: `dev/dark-devotion` at `4e4a0b91a73d474374e8e5da528a24bb6a16b0eb`
- B12X: `5af873a7b6c81fbf533ef96bede13fbf4744ad2a`
- FlashInfer: `9c5ed7c194e7412780862491742fc655daaad6ac`
- torch: `2.12.0+cu132`
- local NCCL: `2.30.4`
- cublas runtime symlinked to `13.4.1.2`

Validated runtime matching the fast reference:
- GLM-5.2 NVFP4
- TP8 / DCP4 / MTP3
- `--dcp-comm-backend ag_rs`
- `--attention-backend B12X_MLA_SPARSE`
- `--moe-backend b12x`
- `B12X_MOE_FORCE_A16=1`
- `VLLM_USE_B12X_SPARSE_INDEXER=1`
- `VLLM_DCP_GLOBAL_TOPK=1`
- `VLLM_DCP_SHARD_DRAFT=1`
- FP8 KV
- `--max-model-len 256000`
- `--max-num-seqs 4`
- `--max-num-batched-tokens 8192`
- `--max-cudagraph-capture-size 24`

Measured with `/mnt/test.py --port 5543 -L`:
- 4 samples
- mean `128.18 tok/s`
- median `127.91 tok/s`
- min `126.17 tok/s`
- max `130.73 tok/s`
- CJK `0`

Reference PR30 image on the same host measured `/mnt/test.py --port 5544 -L`:
- 25 samples
- mean `119.96 tok/s`
- median `120.27 tok/s`
- max `128.47 tok/s`
- CJK `0`

Engine logs for the fixed latest stack showed MTP acceptance around `0.95 / 0.83 / 0.64-0.70`, average draft acceptance about `78-82%`.

## Notes

The B12X vLLM bindings remain eager and caller-scratch-owned. This PR does not introduce workspace/arena ownership or cached workspace binding in the vLLM path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Enhanced sparse attention synchronization and warmup for distributed computing setups.
  * Optimized kernel initialization procedures for multi-GPU environments.

* **Bug Fixes**
  * Improved handling of distributed prefill chunk metadata to prevent early returns in specific multi-GPU scenarios.
  * Enhanced buffer allocation logic for multi-GPU sparse attention operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->