### PR TITLE
Fix/structural tag reasoning grammar (GLM 5.2 forced tool call fix)

### DIFF
--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -500,6 +500,8 @@ class DelegatingParser(Parser):
         if not need_tool_calling:
             return request
 
+        reasoning_enabled = self._reasoning_enabled()
+
         # When the model emits a reasoning prefix (e.g. ``...</think>``) before
         # its tool call, the structural-tag grammar MUST include the reasoning
         # section. Otherwise the grammar only models the tool-call format and
@@ -509,7 +511,7 @@ class DelegatingParser(Parser):
         # the tag models this phased (reasoning -> tool) output.
         structure_tag = self._tool_parser.get_structural_tag(
             request,
-            reasoning=self._reasoning_enabled(),
+            reasoning=reasoning_enabled,
         )
         if structure_tag is None:
             return request
@@ -522,6 +524,23 @@ class DelegatingParser(Parser):
             request.text = None
         else:
             request.response_format = None
+
+        # The structural tag now models the reasoning phase itself (an
+        # unconstrained prefix terminated by the reasoning-end marker), so the
+        # structured-output engine must enforce the grammar from the FIRST
+        # token rather than deferring past a reasoning section it would no
+        # longer detect separately. Without this, tokens sampled immediately
+        # after the reasoning-end marker escape the grammar bitmask, so a
+        # forced/required tool suffix can be violated (e.g. the model samples
+        # prose instead of the tool call); the FSM advance then rejects those
+        # tokens and the request fails with an internal error. This reuses the
+        # same signal the Mistral grammar path uses to mark "the grammar
+        # handles reasoning" (-> reasoning_ended=True at generation start). The
+        # reasoning prefix is unconstrained, so thinking is not restricted; only
+        # the post-reasoning tool call is enforced. PrivateAttr exists only on
+        # ChatCompletionRequest, hence the guard.
+        if reasoning_enabled and hasattr(request, "_grammar_from_tool_parser"):
+            request._grammar_from_tool_parser = True
         return request
 
     def extract_reasoning_streaming(

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -463,6 +463,22 @@ class DelegatingParser(Parser):
             request = self._tool_parser.adjust_request(request)
         return request
 
+    def _reasoning_enabled(self) -> bool:
+        """Whether the model will emit a reasoning prefix before its answer
+        / tool call for this request.
+
+        The parser (and thus its reasoning parser) is constructed per request
+        with that request's ``chat_template_kwargs``, so the reasoning parser
+        already reflects whether thinking is enabled. Defaults to ``True`` —
+        xgrammar's own default — when the reasoning parser cannot report it,
+        so the structural-tag grammar models the reasoning phase the engine's
+        structured-output FSM expects.
+        """
+        reasoner = self._reasoning_parser
+        if reasoner is None:
+            return False
+        return bool(getattr(reasoner, "thinking_enabled", True))
+
     def _apply_structural_tag(
         self, request: ChatCompletionRequest | ResponsesRequest
     ) -> ChatCompletionRequest | ResponsesRequest:
@@ -484,9 +500,16 @@ class DelegatingParser(Parser):
         if not need_tool_calling:
             return request
 
+        # When the model emits a reasoning prefix (e.g. ``...</think>``) before
+        # its tool call, the structural-tag grammar MUST include the reasoning
+        # section. Otherwise the grammar only models the tool-call format and
+        # the structured-output FSM rejects the reasoning tokens at the
+        # reasoning->tool boundary (HTTP 500 non-streaming / mid-stream error
+        # streaming). The engine's structural-tag same-step advance also assumes
+        # the tag models this phased (reasoning -> tool) output.
         structure_tag = self._tool_parser.get_structural_tag(
             request,
-            reasoning=False,
+            reasoning=self._reasoning_enabled(),
         )
         if structure_tag is None:
             return request

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -464,15 +464,11 @@ class DelegatingParser(Parser):
         return request
 
     def _reasoning_enabled(self) -> bool:
-        """Whether the model will emit a reasoning prefix before its answer
-        / tool call for this request.
+        """Whether thinking is enabled for this request.
 
-        The parser (and thus its reasoning parser) is constructed per request
-        with that request's ``chat_template_kwargs``, so the reasoning parser
-        already reflects whether thinking is enabled. Defaults to ``True`` —
-        xgrammar's own default — when the reasoning parser cannot report it,
-        so the structural-tag grammar models the reasoning phase the engine's
-        structured-output FSM expects.
+        The reasoning parser is built per request from its
+        ``chat_template_kwargs`` and already reflects the thinking state.
+        Defaults to ``True`` to match xgrammar's default.
         """
         reasoner = self._reasoning_parser
         if reasoner is None:
@@ -502,13 +498,9 @@ class DelegatingParser(Parser):
 
         reasoning_enabled = self._reasoning_enabled()
 
-        # When the model emits a reasoning prefix (e.g. ``...</think>``) before
-        # its tool call, the structural-tag grammar MUST include the reasoning
-        # section. Otherwise the grammar only models the tool-call format and
-        # the structured-output FSM rejects the reasoning tokens at the
-        # reasoning->tool boundary (HTTP 500 non-streaming / mid-stream error
-        # streaming). The engine's structural-tag same-step advance also assumes
-        # the tag models this phased (reasoning -> tool) output.
+        # The grammar must include the reasoning section when the model thinks,
+        # else the FSM rejects the reasoning tokens at the reasoning-to-tool
+        # boundary.
         structure_tag = self._tool_parser.get_structural_tag(
             request,
             reasoning=reasoning_enabled,
@@ -525,20 +517,11 @@ class DelegatingParser(Parser):
         else:
             request.response_format = None
 
-        # The structural tag now models the reasoning phase itself (an
-        # unconstrained prefix terminated by the reasoning-end marker), so the
-        # structured-output engine must enforce the grammar from the FIRST
-        # token rather than deferring past a reasoning section it would no
-        # longer detect separately. Without this, tokens sampled immediately
-        # after the reasoning-end marker escape the grammar bitmask, so a
-        # forced/required tool suffix can be violated (e.g. the model samples
-        # prose instead of the tool call); the FSM advance then rejects those
-        # tokens and the request fails with an internal error. This reuses the
-        # same signal the Mistral grammar path uses to mark "the grammar
-        # handles reasoning" (-> reasoning_ended=True at generation start). The
-        # reasoning prefix is unconstrained, so thinking is not restricted; only
-        # the post-reasoning tool call is enforced. PrivateAttr exists only on
-        # ChatCompletionRequest, hence the guard.
+        # The tag models the reasoning prefix, so enforce the grammar from the
+        # first token rather than deferring past a reasoning section. Otherwise
+        # the tokens sampled right after the reasoning-end marker escape the
+        # bitmask and a forced tool call can be violated. The attr is a
+        # ChatCompletionRequest PrivateAttr, hence the guard.
         if reasoning_enabled and hasattr(request, "_grammar_from_tool_parser"):
             request._grammar_from_tool_parser = True
         return request

--- a/vllm/parser/engine/adapters.py
+++ b/vllm/parser/engine/adapters.py
@@ -110,6 +110,18 @@ class ParserEngineReasoningAdapter(ReasoningParser):
     def has_engine_confirmed_reasoning_end(self) -> bool:
         return self._parser_engine.reasoning_ended
 
+    @property
+    def thinking_enabled(self) -> bool:
+        """Whether reasoning/thinking output is enabled for this request.
+
+        Mirrors the wrapped parser engine, which derives this from the
+        request's ``chat_template_kwargs`` (e.g. ``enable_thinking``). Used by
+        structural-tag construction to decide whether the grammar must model a
+        reasoning prefix. Defaults to ``True`` when the engine does not expose
+        it.
+        """
+        return bool(getattr(self._parser_engine, "thinking_enabled", True))
+
     def finish_streaming(self) -> DeltaMessage | None:
         return self._parser_engine.finish_streaming()
 

--- a/vllm/parser/engine/adapters.py
+++ b/vllm/parser/engine/adapters.py
@@ -112,13 +112,11 @@ class ParserEngineReasoningAdapter(ReasoningParser):
 
     @property
     def thinking_enabled(self) -> bool:
-        """Whether reasoning/thinking output is enabled for this request.
+        """Whether thinking is enabled for this request.
 
-        Mirrors the wrapped parser engine, which derives this from the
-        request's ``chat_template_kwargs`` (e.g. ``enable_thinking``). Used by
-        structural-tag construction to decide whether the grammar must model a
-        reasoning prefix. Defaults to ``True`` when the engine does not expose
-        it.
+        Delegates to the wrapped parser engine, which derives it from the
+        request's ``chat_template_kwargs``. Defaults to ``True`` to match
+        xgrammar's default.
         """
         return bool(getattr(self._parser_engine, "thinking_enabled", True))
 


### PR DESCRIPTION
## Summary

When a request combines a **constrained `tool_choice`** (a named function, or `"required"`) with **reasoning/thinking enabled**, generation crashes at the reasoning→tool boundary:

- **non-streaming** → `HTTP 500 InternalServerError`
- **streaming** → `200`, reasoning is streamed, then an SSE error chunk is injected exactly where the tool-call arguments should begin; the request is aborted with no tool call.

Server logs show the structured-output FSM rejecting the boundary tokens:

```
ERROR backend_xgrammar.py:162] Failed to advance FSM for request ... for tokens 13. Please file an issue.
ERROR scheduler.py:1611] Unexpected: grammar rejected tokens [13, 154842, 154843, 2911, 10711, 154847] for request ... Terminating request.
```

Decoding those token ids on GLM-5.2 gives:

```
13      '.'           (last token of the reasoning text)
154842  '</think>'    (end of reasoning)
154843  '<tool_call>' (start of the GLM-native tool call)
2911    'web'
10711   '_search'
154847  '<arg_key>'
```

i.e. a single (speculative-decode) batch that spans the `reasoning → </think> → tool_call` transition is handed to a grammar that cannot accept it.

Only the **combination** fails; each axis alone is fine:

| tool_choice | thinking | result |
|---|---|---|
| named function | ON | **FAIL** (500 / mid-stream error) |
| `"required"` | ON | **FAIL** (identical) |
| `"auto"` | ON | pass |
| named function | OFF | pass |

## Root cause

For models whose tool parser declares a `structural_tag_model` (e.g. GLM: `structural_tag_model = "glm_4_7"`), a constrained `tool_choice` is enforced with an **xgrammar structural tag** (gated by `VLLM_ENFORCE_STRICT_TOOL_CALLING`, default `True`). The tag is built in `DelegatingParser._apply_structural_tag` (`vllm/parser/abstract_parser.py`), which **hardcodes `reasoning=False`**:

```python
structure_tag = self._tool_parser.get_structural_tag(request, reasoning=False)
```

xgrammar's `get_glm_4_7_structural_tag` (and the other model templates) use that flag to decide whether the grammar includes the reasoning section:

```python
# xgrammar/builtin_structural_tag.py
if not reasoning:
    return StructuralTag(format=suffix_tag)            # tool-call only, NO </think>
prefix_tag = TagFormat(begin="", content=AnyTextFormat(), end=THINK_TAG_END)
return StructuralTag(format=SequenceFormat(elements=[prefix_tag, suffix_tag]))
```

So with `reasoning=False` the grammar models **only** the tool-call format and has no `</think>`-terminated reasoning prefix. When thinking is enabled the model legitimately emits `...reasoning... </think> <tool_call>...`, which the grammar cannot accept.

This is made fatal by the engine's structured-output reasoning gate. The `STRUCTURAL_TAG` path has a deliberate **same-step advance** under speculative decoding (`vllm/v1/structured_output/__init__.py`):

```python
# Structural tags ... model phased output (e.g. thinking tag -> answer tag),
# and speculative decoding must run grammar.validate_tokens on draft tokens
# produced immediately after that transition.
if (self.vllm_config.speculative_config is not None
        and structured_req.structured_output_key[0] == StructuredOutputOptions.STRUCTURAL_TAG):
    return True
```

That code **assumes the structural tag models the reasoning phase**. Because `_apply_structural_tag` built it without one, the boundary batch `['.', '</think>', '<tool_call>', ...]` is fed to a grammar whose start state only accepts `<tool_call>` → `accept_tokens` fails → the request is terminated.

Note: the `--structured-outputs-config.enable_in_reasoning=True` flag is **not** a fix here — it forces the (reasoning-less) grammar from token 0 and suppresses thinking entirely.

## Fix

Two coupled changes, both in `DelegatingParser._apply_structural_tag`:

**1. Build the structural tag with `reasoning=<thinking enabled>` instead of hardcoding `False`,** so the grammar models the `...</think>` reasoning prefix when the model will think. Thinking-disabled requests keep `reasoning=False` (unchanged behaviour). The reasoning state comes from a new `_reasoning_enabled()` helper: the parser (and its reasoning parser) is built per request with that request's `chat_template_kwargs`, so it already knows whether thinking is on.

**2. When the tag includes the reasoning phase, mark the grammar as reasoning-handling (`request._grammar_from_tool_parser = True`)** so the engine enforces the grammar from the *first* token (`reasoning_ended=True`) rather than deferring past a reasoning section. This is required because change #1 alone is not sufficient: the engine's reasoning gate leaves the tokens sampled right after `</think>` **unmasked**, so under a forced/`required` tool_choice the model can sample *prose* instead of `<tool_call>` (e.g. emit `</think>I'll search...`), and the subsequent `grammar.accept_tokens` rejects it → another 500. With the grammar enforced from token 0 and an unconstrained `AnyText` reasoning prefix, thinking is *not* restricted, but the tool call is forced the instant `</think>` is emitted. This reuses the exact signal the Mistral grammar path already uses to mean "the grammar handles reasoning"; it is a `ChatCompletionRequest` private attr (guarded with `hasattr`).

Plus a one-line support change:

**3. `vllm/parser/engine/adapters.py`** — expose `thinking_enabled` on `ParserEngineReasoningAdapter`, mirroring the wrapped parser engine (which derives it from `chat_template_kwargs` such as `enable_thinking`), so `_reasoning_enabled()` can read it. Defaults `True` when unavailable (xgrammar's own default).

## Validation

Grammar-level replay through the real xgrammar matcher:

```
# reasoning=False (current): grammar rejects the FIRST reasoning token
  [reasoning=False] REJECTED at idx 0 token=40 'I'

# reasoning=True (fix): accepts the full reasoning -> </think> -> tool-call seq
  [reasoning=True]  ACCEPTED full reasoning->tool-call sequence

# reasoning=True grammar, state right AFTER </think> (forced tool_choice):
  reasoning prefix (18 toks incl </think>) fully accepted: True
  after </think>:  accept '<tool_call>' = True   accept 'I' (prose) = False
  #allowed tokens right after </think>: 3 of 154856   (tool call forced)
  allowed mid-reasoning: 154879 of 154856             (thinking unconstrained)
```

End-to-end against the running server:

- 4-arm matrix (temp 0): the two fatal arms (forced/`required` + thinking) go from HTTP 500 / mid-stream abort to valid tool calls *with* reasoning.
- **Sampling + streaming stress test** (forced `tool_choice`, temp 0.7 and 1.0, streaming and non-streaming, 120 requests) — **0 failures** after the fix (was ~1/12 before). Reasoning is still emitted (93–338 chars/req) and the forced tool call is always valid JSON.

Verified on vLLM `0.11.2.dev` (commit base `e8788e3`) serving `GLM-5.2-NVFP4`, launched with `--tool-call-parser glm47 --reasoning-parser glm45 --enable-auto-tool-choice`, TP=8, MTP speculative decoding (5 tokens).

### Not addressed (orthogonal, pre-existing)

Under `tool_choice:"required"` + thinking, GLM may emit an unbounded chain of tool calls (the grammar legally permits >= 1); with a tight `max_tokens` the trailing call is truncated to invalid JSON. This is model behaviour under `required`, independent of this fix (a named/forced single function is unaffected).

## Related issues

- #19051 — Qwen3 + reasoning + `tool_choice:"required"` parse failure (closed, PR #19075 fixed only `"required"`, not the grammar/reasoning interaction).
- #25253 — Mistral reasoning + `"required"` → HTTP 500 (closed).
- #16313 — structured output + tool call coexistence.

This patch addresses the structural-tag grammar construction, which is a different code path from the above and applies to any model that pairs a `structural_tag_model` tool parser with a reasoning parser.

## Suggested regression test

Compile the model structural tag with `reasoning=True` and assert an xgrammar matcher accepts a `...</think><tool_call>...` sequence; assert `_apply_structural_tag` requests `reasoning=True` when the reasoning parser reports `thinking_enabled` and `reasoning=False` otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced reasoning support for structured outputs and tool calls.
  * Improved handling of reasoning configuration propagation across the parser pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->