### PR TITLE
models: load serialized MXFP8 MTP modules

### DIFF
--- a/tests/models/test_deepseek_mtp_mxfp8_loader.py
+++ b/tests/models/test_deepseek_mtp_mxfp8_loader.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import json
+
+import torch
+from transformers import PretrainedConfig
+
+from vllm.config.speculative import SpeculativeConfig
+from vllm.model_executor.layers.quantization.utils.mxfp8_utils import (
+    dequant_mxfp8_to_bf16,
+)
+from vllm.model_executor.models.deepseek_mtp import _try_load_fp8_linear_as_bf16
+
+
+def _write_serialized_nextn_index(model_dir, layer: int) -> None:
+    prefix = f"model.layers.{layer}.mlp.experts.0.down_proj"
+    required = {
+        f"{prefix}.weight": "model.safetensors",
+        f"{prefix}.weight_scale": "model.safetensors",
+        f"{prefix}.weight_scale_2": "model.safetensors",
+        f"{prefix}.input_scale": "model.safetensors",
+    }
+    (model_dir / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": required})
+    )
+
+
+def test_glm_nextn_keeps_serialized_quantized_modules_targeted_by_config(
+    tmp_path,
+):
+    _write_serialized_nextn_index(tmp_path, layer=2)
+    hf_config = PretrainedConfig()
+    hf_config.architectures = ["Glm4MoeForCausalLM"]
+    hf_config.model_type = "glm_moe_dsa"
+    hf_config.num_hidden_layers = 2
+    hf_config.num_nextn_predict_layers = 1
+    hf_config._name_or_path = str(tmp_path)
+    hf_config.quantization_config = {
+        "ignore": [],
+        "quantized_layers": {
+            "model.layers.2.self_attn.fused_qkv_a_proj": {},
+            "model.layers.2.mlp.shared_experts.gate_up_proj": {},
+        },
+    }
+
+    SpeculativeConfig.hf_config_override(hf_config)
+
+    ignored = hf_config.quantization_config["ignore"]
+    assert "model.layers.2.self_attn*" not in ignored
+    assert "model.layers.2.mlp.shared_experts*" not in ignored
+    assert "model.layers.2.eh_proj*" in ignored
+    assert hf_config.model_type == "deepseek_mtp"
+
+
+def test_mtp_fallback_loader_accepts_mxfp8_weight_scale():
+    weight_bf16 = torch.arange(64, dtype=torch.float32).reshape(2, 32)
+    weight_fp8 = weight_bf16.to(torch.float8_e4m3fn)
+    scales = torch.full((2, 1), 127, dtype=torch.uint8)
+    param = torch.nn.Parameter(torch.empty_like(weight_bf16, dtype=torch.bfloat16))
+    params = {"model.layers.78.self_attn.fused_qkv_a_proj.weight": param}
+    pending: dict[str, dict[str, torch.Tensor]] = {}
+    loaded: set[str] = set()
+
+    assert _try_load_fp8_linear_as_bf16(
+        "model.layers.78.self_attn.fused_qkv_a_proj.weight",
+        weight_fp8,
+        pending,
+        params,
+        loaded,
+    )
+    assert _try_load_fp8_linear_as_bf16(
+        "model.layers.78.self_attn.fused_qkv_a_proj.weight_scale",
+        scales,
+        pending,
+        params,
+        loaded,
+    )
+
+    expected = dequant_mxfp8_to_bf16(weight_fp8, scales)
+    assert torch.equal(param.data, expected)
+    assert "model.layers.78.self_attn.fused_qkv_a_proj.weight" in loaded
+    assert pending == {}

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -438,18 +438,28 @@ class SpeculativeConfig:
                         for layer_idx in range(mtp_start, mtp_start + mtp_layers):
                             prefix = f"model.layers.{layer_idx}"
                             if has_serialized_nextn_experts:
-                                _extend_unique(
-                                    ignored,
-                                    [
-                                        f"{prefix}.self_attn*",
-                                        f"{prefix}.eh_proj*",
-                                        f"{prefix}.enorm*",
-                                        f"{prefix}.hnorm*",
-                                        f"{prefix}.shared_head*",
-                                        f"{prefix}.mlp.gate*",
-                                        f"{prefix}.mlp.shared_experts*",
-                                    ],
-                                )
+                                # GLM NextN checkpoints can be partially
+                                # serialized. Older NVFP4 checkpoints only
+                                # carry quantized routed experts, while newer
+                                # mixed checkpoints also serialize FP8/MXFP8
+                                # attention and shared experts. Keep synthetic
+                                # ignores only for modules not explicitly
+                                # targeted by the checkpoint quant config.
+                                for module_prefix in (
+                                    f"{prefix}.self_attn",
+                                    f"{prefix}.eh_proj",
+                                    f"{prefix}.enorm",
+                                    f"{prefix}.hnorm",
+                                    f"{prefix}.shared_head",
+                                    f"{prefix}.mlp.gate",
+                                    f"{prefix}.mlp.shared_experts",
+                                ):
+                                    if not _quant_config_targets_prefix(
+                                        quant_config, module_prefix
+                                    ):
+                                        _extend_unique(
+                                            ignored, [f"{module_prefix}*"]
+                                        )
                             else:
                                 if _quant_config_targets_prefix(quant_config, prefix):
                                     continue

--- a/vllm/model_executor/models/deepseek_mtp.py
+++ b/vllm/model_executor/models/deepseek_mtp.py
@@ -233,40 +233,63 @@ def _try_load_fp8_linear_as_bf16(
     shard_id: int | str | None = None,
 ) -> bool:
     is_weight = name.endswith(".weight") and tensor.dtype == torch.float8_e4m3fn
-    is_scale = name.endswith(".weight_scale_inv")
-    if not is_weight and not is_scale:
+    is_scale_inv = name.endswith(".weight_scale_inv")
+    is_mxfp8_scale = name.endswith(".weight_scale") and tensor.dtype == torch.uint8
+    if not is_weight and not is_scale_inv and not is_mxfp8_scale:
         return False
 
-    base_name = name.rsplit(".", 1)[0] if is_weight else name.removesuffix(
-        ".weight_scale_inv"
-    )
+    if is_weight:
+        base_name = name.rsplit(".", 1)[0]
+    elif is_scale_inv:
+        base_name = name.removesuffix(".weight_scale_inv")
+    else:
+        base_name = name.removesuffix(".weight_scale")
     weight_name = f"{base_name}.weight"
-    scale_name = f"{base_name}.weight_scale_inv"
+    scale_inv_name = f"{base_name}.weight_scale_inv"
+    mxfp8_scale_name = f"{base_name}.weight_scale"
 
     # If the runtime module registered an FP8 scale parameter, let the normal
     # quantized loader handle it.
-    if _maybe_remap_fp8_scale_inv_name(scale_name, params_dict) in params_dict:
+    if (
+        _maybe_remap_fp8_scale_inv_name(scale_inv_name, params_dict) in params_dict
+        or mxfp8_scale_name in params_dict
+    ):
         return False
     if weight_name not in params_dict:
         return False
 
     buffer_key = base_name if shard_id is None else f"{base_name}:{shard_id}"
     entry = buf.setdefault(buffer_key, {})
-    entry["weight" if is_weight else "scale"] = tensor
-    if "weight" not in entry or "scale" not in entry:
+    if is_weight:
+        entry["weight"] = tensor
+    elif is_scale_inv:
+        entry["scale_inv"] = tensor
+    else:
+        entry["mxfp8_scale"] = tensor
+    if "weight" not in entry or (
+        "scale_inv" not in entry and "mxfp8_scale" not in entry
+    ):
         return True
 
     weight_fp8 = entry["weight"]
-    scale_inv = entry["scale"]
     del buf[buffer_key]
 
-    block_size = weight_fp8.shape[1] // scale_inv.shape[1]
-    weight_bf16 = scaled_dequantize(
-        weight_fp8,
-        scale_inv,
-        group_shape=GroupShape(block_size, block_size),
-        out_dtype=torch.bfloat16,
-    )
+    if "scale_inv" in entry:
+        scale_inv = entry["scale_inv"]
+        block_size = weight_fp8.shape[1] // scale_inv.shape[1]
+        weight_bf16 = scaled_dequantize(
+            weight_fp8,
+            scale_inv,
+            group_shape=GroupShape(block_size, block_size),
+            out_dtype=torch.bfloat16,
+        )
+    else:
+        from vllm.model_executor.layers.quantization.utils.mxfp8_utils import (
+            dequant_mxfp8_to_bf16,
+        )
+
+        weight_bf16 = dequant_mxfp8_to_bf16(weight_fp8, entry["mxfp8_scale"])
+
     param = params_dict[weight_name]
     weight_loader = getattr(param, "weight_loader", default_weight_loader)
     if shard_id is None:
@@ -670,15 +693,22 @@ class DeepSeekMTP(nn.Module, DeepseekV2MixtureOfExperts):
                 # weight loading if it's not enabled
                 if param_name == "fused_qkv_a_proj":
                     # FP8 checkpoints provide scale tensors as
-                    # *.weight_scale_inv, while the fused runtime module may
-                    # only expose the fused weight or a remapped *.weight_scale.
-                    # Do not skip those scale tensors before the FP8 fallback
-                    # loader has a chance to pair them with the fused weight.
+                    # *.weight_scale_inv or MXFP8 *.weight_scale, while the
+                    # fused runtime module may only expose the fused BF16
+                    # weight. Do not skip those scale tensors before the
+                    # fallback loader has a chance to pair them with the fused
+                    # weight.
                     has_fused_target = name_mapped in params_dict
-                    if name_mapped.endswith(".weight_scale_inv"):
-                        fused_weight = name_mapped.removesuffix(
-                            ".weight_scale_inv"
-                        ) + ".weight"
+                    if name_mapped.endswith((".weight_scale_inv", ".weight_scale")):
+                        if name_mapped.endswith(".weight_scale_inv"):
+                            fused_weight = (
+                                name_mapped.removesuffix(".weight_scale_inv")
+                                + ".weight"
+                            )
+                        else:
+                            fused_weight = (
+                                name_mapped.removesuffix(".weight_scale") + ".weight"
+                            )
                         has_fused_target = (
                             has_fused_target
                             or fused_weight in params_dict


### PR DESCRIPTION
## Summary

Add the missing runtime loading pieces for GLM/DeepSeek-style serialized NextN MTP modules that store FP8/MXFP8 attention/shared-expert tensors in the checkpoint.

This complements the separate MXFP8 sparse-indexer WK loader PR (#33). #33 fixes the target-layer fused sparse-indexer loader; this PR fixes the MTP/draft side:

- Keep synthetic GLM NextN ignore entries only for modules that are not explicitly targeted by the checkpoint quant config.
- Allow the MTP fused-QKV BF16 fallback loader to pair FP8 `.weight` tensors with MXFP8 uint8 `.weight_scale` tensors, not only legacy `.weight_scale_inv`.
- Avoid skipping remapped fused-QKV MXFP8 scale tensors before the fallback loader can consume them.
- Add focused tests for the quant-config ignore behavior and MXFP8 fallback dequant/load path.

## Why

The hybrid GLM-5.2 checkpoint can serialize MTP attention/shared-expert modules as FP8/MXFP8. The existing GLM NextN override treated serialized NextN experts as a signal to ignore several non-routed MTP modules wholesale, which is correct for older partially serialized checkpoints but wrong when the quant config explicitly targets those modules. The MTP loader also only understood FP8 `weight_scale_inv`, so MXFP8 `weight_scale` failed during fused-QKV fallback loading.

## Validation

- `python3 -m py_compile vllm/config/speculative.py vllm/model_executor/models/deepseek_mtp.py tests/models/test_deepseek_mtp_mxfp8_loader.py`
- `git diff --check HEAD~1..HEAD`

`pytest` is not installed in this host environment, so the added pytest tests were syntax-checked locally and are intended to run in CI/review environment.

Runtime validation before splitting this clean PR was done on the GLM-5.2 hybrid MXFP8 checkpoint with this patch as an overlay: TP6/DCP6/MTP3/A16 started successfully and streamed coherent `/mnt/test.py -L` output with CJK=0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DeepSeek MTP model loading with better MXFP8 quantization support for multiple checkpoint tensor variants
  * Enhanced quantization ignore pattern selection for models with partially serialized expert configurations

* **Tests**
  * Added test coverage for MXFP8 loader functionality including quantization configuration validation and weight tensor conversion

<!-- end of auto-generated comment: release notes by coderabbit.ai -->