### PR TITLE
spec_decode: shard DCP draft KV by default

### DIFF
--- a/tests/models/test_dcp_shard_draft_defaults.py
+++ b/tests/models/test_dcp_shard_draft_defaults.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import torch
+
+from vllm.model_executor.models.deepseek_v2 import DeepseekV32IndexerCache
+
+
+def _vllm_config(num_hidden_layers: int = 78):
+    return SimpleNamespace(
+        cache_config=SimpleNamespace(block_size=256),
+        model_config=SimpleNamespace(
+            hf_config=SimpleNamespace(num_hidden_layers=num_hidden_layers)
+        ),
+    )
+
+
+def _indexer_cache(layer_id: int = 78):
+    cache = object.__new__(DeepseekV32IndexerCache)
+    cache.head_dim = 512
+    cache.dtype = torch.bfloat16
+    cache.prefix = f"model.layers.{layer_id}.self_attn.indexer"
+    cache.cache_config = SimpleNamespace(block_size=256)
+    return cache
+
+
+def test_dcp_shard_draft_defaults_to_sharded(monkeypatch):
+    monkeypatch.delenv("VLLM_DCP_SHARD_DRAFT", raising=False)
+
+    spec = _indexer_cache().get_kv_cache_spec(_vllm_config())
+
+    assert spec.dcp_replicated is False
+
+
+def test_dcp_shard_draft_can_restore_replicated_legacy_mode(monkeypatch):
+    monkeypatch.setenv("VLLM_DCP_SHARD_DRAFT", "0")
+
+    spec = _indexer_cache().get_kv_cache_spec(_vllm_config())
+
+    assert spec.dcp_replicated is True

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -1065,7 +1065,7 @@ class MLAAttention(nn.Module, AttentionLayerBase):
         num_hidden_layers = getattr(
             vllm_config.model_config.hf_config, "num_hidden_layers", None
         )
-        shard_draft = os.environ.get("VLLM_DCP_SHARD_DRAFT", "0").lower() in (
+        shard_draft = os.environ.get("VLLM_DCP_SHARD_DRAFT", "1").lower() in (
             "1",
             "true",
             "yes",

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -599,7 +599,7 @@ class DeepseekV32IndexerCache(torch.nn.Module, AttentionLayerBase):
         )
         import os as _os
 
-        shard_draft = _os.environ.get("VLLM_DCP_SHARD_DRAFT", "0").lower() in (
+        shard_draft = _os.environ.get("VLLM_DCP_SHARD_DRAFT", "1").lower() in (
             "1",
             "true",
             "yes",

--- a/vllm/v1/worker/gpu/spec_decode/eagle/utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/eagle/utils.py
@@ -16,7 +16,7 @@ def _create_draft_vllm_config(vllm_config: VllmConfig) -> VllmConfig:
     import os as _os
 
     draft_parallel_config = speculative_config.draft_parallel_config
-    if _os.environ.get("VLLM_DCP_SHARD_DRAFT", "0").lower() in (
+    if _os.environ.get("VLLM_DCP_SHARD_DRAFT", "1").lower() in (
         "1",
         "true",
         "yes",


### PR DESCRIPTION
## Summary

Make the fast DCP/MTP draft-KV sharding path the default.

`VLLM_DCP_GLOBAL_TOPK` already defaults to enabled in the current dark-devotion sparse-indexer paths. The remaining footgun was `VLLM_DCP_SHARD_DRAFT`: leaving it unset still replicated draft/NextN KV across DCP ranks, which is slower and wastes KV capacity. This PR flips that default to sharded while preserving the old behavior behind `VLLM_DCP_SHARD_DRAFT=0`.

Changes:

- Default `VLLM_DCP_SHARD_DRAFT` to `1` in MLA draft KV specs.
- Default `VLLM_DCP_SHARD_DRAFT` to `1` in the DeepSeek/GLM indexer cache KV spec.
- Default draft parallel config inheritance to DCP-enabled when the env is unset.
- Add a small regression test proving unset env is sharded and explicit `0` restores replicated legacy mode.

## Why

The validated GLM-5.2 DCP4/MTP3 fast path needs both global top-k and draft KV sharding. Global top-k already defaults on, but draft sharding still required a manual env var. Users who omit it get lower KV capacity and slower DCP/MTP behavior while the server appears to start normally.

## Compatibility

Existing replicated behavior is still available with:

```bash
VLLM_DCP_SHARD_DRAFT=0
```

## Validation

- `python3 -m py_compile vllm/model_executor/layers/attention/mla_attention.py vllm/model_executor/models/deepseek_v2.py vllm/v1/worker/gpu/spec_decode/eagle/utils.py tests/models/test_dcp_shard_draft_defaults.py`
- `git diff --check HEAD~1..HEAD`

`pytest` is not installed in this host environment, so the added pytest test was syntax-checked locally and is intended to run in CI/review environment.
