### PR TITLE
[eldritch] Load GLM MXFP8 sparse-indexer and MTP tensors

### DIFF
--- a/tests/models/test_deepseek_mtp_mxfp8_loader.py
+++ b/tests/models/test_deepseek_mtp_mxfp8_loader.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import json
+
+import torch
+from transformers import PretrainedConfig
+
+from vllm.config.speculative import SpeculativeConfig
+from vllm.model_executor.layers.quantization.utils.mxfp8_utils import (
+    dequant_mxfp8_to_bf16,
+)
+from vllm.model_executor.models.deepseek_mtp import _try_load_fp8_linear_as_bf16
+
+
+def _write_serialized_nextn_index(model_dir, layer: int) -> None:
+    prefix = f"model.layers.{layer}.mlp.experts.0.down_proj"
+    required = {
+        f"{prefix}.weight": "model.safetensors",
+        f"{prefix}.weight_scale": "model.safetensors",
+        f"{prefix}.weight_scale_2": "model.safetensors",
+        f"{prefix}.input_scale": "model.safetensors",
+    }
+    (model_dir / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": required})
+    )
+
+
+def test_glm_nextn_keeps_serialized_quantized_modules_targeted_by_config(
+    tmp_path,
+):
+    _write_serialized_nextn_index(tmp_path, layer=2)
+    hf_config = PretrainedConfig()
+    hf_config.architectures = ["Glm4MoeForCausalLM"]
+    hf_config.model_type = "glm_moe_dsa"
+    hf_config.num_hidden_layers = 2
+    hf_config.num_nextn_predict_layers = 1
+    hf_config._name_or_path = str(tmp_path)
+    hf_config.quantization_config = {
+        "ignore": [],
+        "quantized_layers": {
+            "model.layers.2.self_attn.fused_qkv_a_proj": {},
+            "model.layers.2.mlp.shared_experts.gate_up_proj": {},
+        },
+    }
+
+    SpeculativeConfig.hf_config_override(hf_config)
+
+    ignored = hf_config.quantization_config["ignore"]
+    assert "model.layers.2.self_attn*" not in ignored
+    assert "model.layers.2.mlp.shared_experts*" not in ignored
+    assert "model.layers.2.eh_proj*" in ignored
+    assert hf_config.model_type == "deepseek_mtp"
+
+
+def test_mtp_fallback_loader_accepts_mxfp8_weight_scale():
+    weight_bf16 = torch.arange(64, dtype=torch.float32).reshape(2, 32)
+    weight_fp8 = weight_bf16.to(torch.float8_e4m3fn)
+    scales = torch.full((2, 1), 127, dtype=torch.uint8)
+    param = torch.nn.Parameter(torch.empty_like(weight_bf16, dtype=torch.bfloat16))
+    params = {"model.layers.78.self_attn.fused_qkv_a_proj.weight": param}
+    pending: dict[str, dict[str, torch.Tensor]] = {}
+    loaded: set[str] = set()
+
+    assert _try_load_fp8_linear_as_bf16(
+        "model.layers.78.self_attn.fused_qkv_a_proj.weight",
+        weight_fp8,
+        pending,
+        params,
+        loaded,
+    )
+    assert _try_load_fp8_linear_as_bf16(
+        "model.layers.78.self_attn.fused_qkv_a_proj.weight_scale",
+        scales,
+        pending,
+        params,
+        loaded,
+    )
+
+    expected = dequant_mxfp8_to_bf16(weight_fp8, scales)
+    assert torch.equal(param.data, expected)
+    assert "model.layers.78.self_attn.fused_qkv_a_proj.weight" in loaded
+    assert pending == {}

--- a/tests/models/test_deepseek_v2_indexer_loader.py
+++ b/tests/models/test_deepseek_v2_indexer_loader.py
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+from vllm.model_executor.layers.quantization.utils.mxfp8_utils import (
+    _mxfp8_e4m3_quantize_torch,
+    dequant_mxfp8_to_bf16,
+)
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    GroupShape,
+    scaled_dequantize,
+)
+from vllm.model_executor.models.deepseek_v2 import _try_load_fp8_indexer_wk
+
+
+class _LoadedParam:
+
+    def __init__(self):
+        self.loaded_weight = None
+        self.loaded_shard_id = None
+
+    def weight_loader(self, _param, weight, shard_id):
+        self.loaded_weight = weight
+        self.loaded_shard_id = shard_id
+
+
+def test_try_load_fp8_indexer_wk_consumes_mxfp8_weight_scale():
+    prefix = "layers.0.self_attn.indexer"
+    param = _LoadedParam()
+    params_dict = {f"{prefix}.wk_weights_proj.weight": param}
+    loaded_params: set[str] = set()
+    pending = {}
+
+    weight_bf16 = torch.arange(64, dtype=torch.float32).view(1, 64).to(torch.bfloat16)
+    weight_fp8, weight_scale = _mxfp8_e4m3_quantize_torch(weight_bf16)
+
+    assert _try_load_fp8_indexer_wk(
+        f"{prefix}.wk.weight",
+        weight_fp8,
+        pending,
+        params_dict,
+        loaded_params,
+        [],
+    )
+    assert pending
+    assert _try_load_fp8_indexer_wk(
+        f"{prefix}.wk.weight_scale",
+        weight_scale,
+        pending,
+        params_dict,
+        loaded_params,
+        [],
+    )
+
+    assert pending == {}
+    assert loaded_params == {f"{prefix}.wk_weights_proj.weight"}
+    assert param.loaded_shard_id == 0
+    torch.testing.assert_close(
+        param.loaded_weight,
+        dequant_mxfp8_to_bf16(weight_fp8, weight_scale),
+    )
+
+
+def test_try_load_fp8_indexer_wk_preserves_fp8_weight_scale_inv_path():
+    prefix = "layers.0.self_attn.indexer"
+    param = _LoadedParam()
+    params_dict = {f"{prefix}.wk_weights_proj.weight": param}
+    loaded_params: set[str] = set()
+    pending = {}
+
+    weight_fp8 = torch.linspace(-2.0, 2.0, 32 * 64, dtype=torch.float32).view(
+        32, 64
+    ).to(torch.float8_e4m3fn)
+    scale_inv = torch.full((1, 2), 0.25, dtype=torch.float32)
+
+    assert _try_load_fp8_indexer_wk(
+        f"{prefix}.wk.weight_scale_inv",
+        scale_inv,
+        pending,
+        params_dict,
+        loaded_params,
+        [],
+    )
+    assert pending
+    assert _try_load_fp8_indexer_wk(
+        f"{prefix}.wk.weight",
+        weight_fp8,
+        pending,
+        params_dict,
+        loaded_params,
+        [],
+    )
+
+    assert pending == {}
+    assert loaded_params == {f"{prefix}.wk_weights_proj.weight"}
+    assert param.loaded_shard_id == 0
+    torch.testing.assert_close(
+        param.loaded_weight,
+        scaled_dequantize(
+            weight_fp8,
+            scale_inv,
+            group_shape=GroupShape(32, 32),
+            out_dtype=torch.bfloat16,
+        ),
+    )
+
+
+def test_try_load_fp8_indexer_wk_ignores_unrelated_mxfp8_scale():
+    assert not _try_load_fp8_indexer_wk(
+        "layers.0.self_attn.indexer.wq_b.weight_scale",
+        torch.ones((1, 2), dtype=torch.uint8),
+        {},
+        {},
+        set(),
+        [],
+    )

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -438,18 +438,28 @@ class SpeculativeConfig:
                         for layer_idx in range(mtp_start, mtp_start + mtp_layers):
                             prefix = f"model.layers.{layer_idx}"
                             if has_serialized_nextn_experts:
-                                _extend_unique(
-                                    ignored,
-                                    [
-                                        f"{prefix}.self_attn*",
-                                        f"{prefix}.eh_proj*",
-                                        f"{prefix}.enorm*",
-                                        f"{prefix}.hnorm*",
-                                        f"{prefix}.shared_head*",
-                                        f"{prefix}.mlp.gate*",
-                                        f"{prefix}.mlp.shared_experts*",
-                                    ],
-                                )
+                                # GLM NextN checkpoints can be partially
+                                # serialized. Older NVFP4 checkpoints only
+                                # carry quantized routed experts, while newer
+                                # mixed checkpoints also serialize FP8/MXFP8
+                                # attention and shared experts. Keep synthetic
+                                # ignores only for modules not explicitly
+                                # targeted by the checkpoint quant config.
+                                for module_prefix in (
+                                    f"{prefix}.self_attn",
+                                    f"{prefix}.eh_proj",
+                                    f"{prefix}.enorm",
+                                    f"{prefix}.hnorm",
+                                    f"{prefix}.shared_head",
+                                    f"{prefix}.mlp.gate",
+                                    f"{prefix}.mlp.shared_experts",
+                                ):
+                                    if not _quant_config_targets_prefix(
+                                        quant_config, module_prefix
+                                    ):
+                                        _extend_unique(
+                                            ignored, [f"{module_prefix}*"]
+                                        )
                             else:
                                 if _quant_config_targets_prefix(quant_config, prefix):
                                     continue

--- a/vllm/model_executor/models/deepseek_mtp.py
+++ b/vllm/model_executor/models/deepseek_mtp.py
@@ -232,40 +232,63 @@ def _try_load_fp8_linear_as_bf16(
     shard_id: int | str | None = None,
 ) -> bool:
     is_weight = name.endswith(".weight") and tensor.dtype == torch.float8_e4m3fn
-    is_scale = name.endswith(".weight_scale_inv")
-    if not is_weight and not is_scale:
+    is_scale_inv = name.endswith(".weight_scale_inv")
+    is_mxfp8_scale = name.endswith(".weight_scale") and tensor.dtype == torch.uint8
+    if not is_weight and not is_scale_inv and not is_mxfp8_scale:
         return False
 
-    base_name = name.rsplit(".", 1)[0] if is_weight else name.removesuffix(
-        ".weight_scale_inv"
-    )
+    if is_weight:
+        base_name = name.rsplit(".", 1)[0]
+    elif is_scale_inv:
+        base_name = name.removesuffix(".weight_scale_inv")
+    else:
+        base_name = name.removesuffix(".weight_scale")
     weight_name = f"{base_name}.weight"
-    scale_name = f"{base_name}.weight_scale_inv"
+    scale_inv_name = f"{base_name}.weight_scale_inv"
+    mxfp8_scale_name = f"{base_name}.weight_scale"
 
     # If the runtime module registered an FP8 scale parameter, let the normal
     # quantized loader handle it.
-    if _maybe_remap_fp8_scale_inv_name(scale_name, params_dict) in params_dict:
+    if (
+        _maybe_remap_fp8_scale_inv_name(scale_inv_name, params_dict) in params_dict
+        or mxfp8_scale_name in params_dict
+    ):
         return False
     if weight_name not in params_dict:
         return False
 
     buffer_key = base_name if shard_id is None else f"{base_name}:{shard_id}"
     entry = buf.setdefault(buffer_key, {})
-    entry["weight" if is_weight else "scale"] = tensor
-    if "weight" not in entry or "scale" not in entry:
+    if is_weight:
+        entry["weight"] = tensor
+    elif is_scale_inv:
+        entry["scale_inv"] = tensor
+    else:
+        entry["mxfp8_scale"] = tensor
+    if "weight" not in entry or (
+        "scale_inv" not in entry and "mxfp8_scale" not in entry
+    ):
         return True
 
     weight_fp8 = entry["weight"]
-    scale_inv = entry["scale"]
     del buf[buffer_key]
 
-    block_size = weight_fp8.shape[1] // scale_inv.shape[1]
-    weight_bf16 = scaled_dequantize(
-        weight_fp8,
-        scale_inv,
-        group_shape=GroupShape(block_size, block_size),
-        out_dtype=torch.bfloat16,
-    )
+    if "scale_inv" in entry:
+        scale_inv = entry["scale_inv"]
+        block_size = weight_fp8.shape[1] // scale_inv.shape[1]
+        weight_bf16 = scaled_dequantize(
+            weight_fp8,
+            scale_inv,
+            group_shape=GroupShape(block_size, block_size),
+            out_dtype=torch.bfloat16,
+        )
+    else:
+        from vllm.model_executor.layers.quantization.utils.mxfp8_utils import (
+            dequant_mxfp8_to_bf16,
+        )
+
+        weight_bf16 = dequant_mxfp8_to_bf16(weight_fp8, entry["mxfp8_scale"])
+
     param = params_dict[weight_name]
     weight_loader = getattr(param, "weight_loader", default_weight_loader)
     if shard_id is None:
@@ -656,15 +679,22 @@ class DeepSeekMTP(nn.Module, DeepseekV2MixtureOfExperts):
                 # weight loading if it's not enabled
                 if param_name == "fused_qkv_a_proj":
                     # FP8 checkpoints provide scale tensors as
-                    # *.weight_scale_inv, while the fused runtime module may
-                    # only expose the fused weight or a remapped *.weight_scale.
-                    # Do not skip those scale tensors before the FP8 fallback
-                    # loader has a chance to pair them with the fused weight.
+                    # *.weight_scale_inv or MXFP8 *.weight_scale, while the
+                    # fused runtime module may only expose the fused BF16
+                    # weight. Do not skip those scale tensors before the
+                    # fallback loader has a chance to pair them with the fused
+                    # weight.
                     has_fused_target = name_mapped in params_dict
-                    if name_mapped.endswith(".weight_scale_inv"):
-                        fused_weight = name_mapped.removesuffix(
-                            ".weight_scale_inv"
-                        ) + ".weight"
+                    if name_mapped.endswith((".weight_scale_inv", ".weight_scale")):
+                        if name_mapped.endswith(".weight_scale_inv"):
+                            fused_weight = (
+                                name_mapped.removesuffix(".weight_scale_inv")
+                                + ".weight"
+                            )
+                        else:
+                            fused_weight = (
+                                name_mapped.removesuffix(".weight_scale") + ".weight"
+                            )
                         has_fused_target = (
                             has_fused_target
                             or fused_weight in params_dict

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -822,13 +822,29 @@ def _should_skip_index_topk(
 def _try_load_fp8_indexer_wk(
     name, tensor, buf, params_dict, loaded_params, pp_missing_layer_names
 ):
-    """
-    We fuse the WK and weights_proj projections, but in some checkpoints WK is stored
-    in FP8 with a separate weight_scale_inv or MXFP8 with a separate weight_scale,
-    while weights_proj is stored in BF16. Upcasting to BF16 during loading enables
-    the fusion. This function loads the WK weights and scale, and when both are
-    available, dequantizes to BF16 and stores into the fused
-    wk_weights_proj.weight parameter.
+    """Load isolated FP8/MXFP8 indexer WK tensors into fused WK weights.
+
+    The model fuses WK and weights_proj projections, but some checkpoints store
+    WK separately in FP8 with ``weight_scale_inv`` or MXFP8 with
+    ``weight_scale`` while weights_proj stays BF16. This loader buffers the
+    isolated WK weight and scale until both are available, dequantizes WK to
+    BF16, and stores it into the fused ``wk_weights_proj.weight`` parameter.
+
+    Args:
+        name: Checkpoint tensor name.
+        tensor: Checkpoint tensor value.
+        buf: Pending WK weight/scale tensors keyed by layer prefix.
+        params_dict: Model parameters keyed by checkpoint tensor name.
+        loaded_params: Names of parameters already loaded by a special loader.
+        pp_missing_layer_names: Pipeline-parallel layer prefixes to skip.
+
+    Returns:
+        ``True`` when the tensor was consumed or intentionally skipped by this
+        special loader, otherwise ``False``.
+
+    Raises:
+        KeyError: If a matching isolated WK pair is ready but the fused
+            ``wk_weights_proj.weight`` parameter is missing.
     """
     if "indexer.wk." not in name or "wk_weights" in name:
         return False  # Weight is not an isolated WK weight for the indexer, ignore.

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -824,17 +824,19 @@ def _try_load_fp8_indexer_wk(
 ):
     """
     We fuse the WK and weights_proj projections, but in some checkpoints WK is stored
-    in FP8 with a separate weight_scale_inv, while weights_proj is stored in BF16.
-    Upcasting to BF16 during loading enables the fusion. This function loads the FP8 WK
-    weights and scale, and when both are available, dequantizes to BF16 and stores into
-    the fused wk_weights_proj.weight parameter.
+    in FP8 with a separate weight_scale_inv or MXFP8 with a separate weight_scale,
+    while weights_proj is stored in BF16. Upcasting to BF16 during loading enables
+    the fusion. This function loads the WK weights and scale, and when both are
+    available, dequantizes to BF16 and stores into the fused
+    wk_weights_proj.weight parameter.
     """
     if "indexer.wk." not in name or "wk_weights" in name:
         return False  # Weight is not an isolated WK weight for the indexer, ignore.
     is_weight = name.endswith(".weight") and tensor.dtype == torch.float8_e4m3fn
-    is_scale = "weight_scale_inv" in name
-    if not is_weight and not is_scale:
-        return False  # WK is not in FP8 format, ignore.
+    is_scale_inv = "weight_scale_inv" in name
+    is_mxfp8_scale = name.endswith(".weight_scale") and tensor.dtype == torch.uint8
+    if not is_weight and not is_scale_inv and not is_mxfp8_scale:
+        return False  # WK is not in a fused FP8/MXFP8 format, ignore.
     # Buffer this tensor (weight or scale) until both have arrived.
     layer_prefix = name.rsplit(".wk.", 1)[0]  # e.g. "model.layers.0.self_attn.indexer"
     fused_name = f"{layer_prefix}.wk_weights_proj.weight"
@@ -844,20 +846,35 @@ def _try_load_fp8_indexer_wk(
     ):
         return True
     entry = buf.setdefault(layer_prefix, {})
-    entry["weight" if is_weight else "scale"] = tensor
-    if "weight" not in entry or "scale" not in entry:
+    if is_weight:
+        entry["weight"] = tensor
+    elif is_scale_inv:
+        entry["scale_inv"] = tensor
+    else:
+        entry["mxfp8_scale"] = tensor
+    if "weight" not in entry or (
+        "scale_inv" not in entry and "mxfp8_scale" not in entry
+    ):
         return True  # still waiting for the other param
 
     # We have both weight and scale: dequantize FP8 to BF16.
-    weight_fp8, scale_inv = entry["weight"], entry["scale"]
+    weight_fp8 = entry["weight"]
     del buf[layer_prefix]
-    block_size = weight_fp8.shape[1] // scale_inv.shape[1]
-    weight_bf16 = scaled_dequantize(
-        weight_fp8,
-        scale_inv,
-        group_shape=GroupShape(block_size, block_size),
-        out_dtype=torch.bfloat16,
-    )
+    if "scale_inv" in entry:
+        scale_inv = entry["scale_inv"]
+        block_size = weight_fp8.shape[1] // scale_inv.shape[1]
+        weight_bf16 = scaled_dequantize(
+            weight_fp8,
+            scale_inv,
+            group_shape=GroupShape(block_size, block_size),
+            out_dtype=torch.bfloat16,
+        )
+    else:
+        from vllm.model_executor.layers.quantization.utils.mxfp8_utils import (
+            dequant_mxfp8_to_bf16,
+        )
+
+        weight_bf16 = dequant_mxfp8_to_bf16(weight_fp8, entry["mxfp8_scale"])
 
     # Load the dequantized weight into shard 0 of the fused buffer.
     param = params_dict[fused_name]


### PR DESCRIPTION
## Summary

Port the GLM-5.2 MXFP8 checkpoint loader fixes onto `dev/eldritch-enlightenment`.

These changes let mixed NVFP4/MXFP8-style GLM checkpoints load serialized sparse-indexer WK scales and serialized MXFP8 MTP modules instead of silently falling back to incomplete/default tensors.

## Changes

- Load MXFP8 sparse-indexer WK scale tensors.
- Document the MXFP8 indexer WK loader behavior.
- Load serialized MXFP8 MTP modules.
- Add loader tests for indexer and MTP tensor handling.

## Validation

- `git diff --check lil/dev/eldritch-enlightenment..HEAD`
- `python3 -m py_compile` on changed Python files

Runtime validation will be done in the composed eldritch Docker stack.
