### PR TITLE
[eldritch] Fix reasoning-aware structural tool grammar

### DIFF
--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -500,6 +500,8 @@ class DelegatingParser(Parser):
         if not need_tool_calling:
             return request
 
+        reasoning_enabled = self._reasoning_enabled()
+
         # When the model emits a reasoning prefix (e.g. ``...</think>``) before
         # its tool call, the structural-tag grammar MUST include the reasoning
         # section. Otherwise the grammar only models the tool-call format and
@@ -509,7 +511,7 @@ class DelegatingParser(Parser):
         # the tag models this phased (reasoning -> tool) output.
         structure_tag = self._tool_parser.get_structural_tag(
             request,
-            reasoning=self._reasoning_enabled(),
+            reasoning=reasoning_enabled,
         )
         if structure_tag is None:
             return request
@@ -522,6 +524,23 @@ class DelegatingParser(Parser):
             request.text = None
         else:
             request.response_format = None
+
+        # The structural tag now models the reasoning phase itself (an
+        # unconstrained prefix terminated by the reasoning-end marker), so the
+        # structured-output engine must enforce the grammar from the FIRST
+        # token rather than deferring past a reasoning section it would no
+        # longer detect separately. Without this, tokens sampled immediately
+        # after the reasoning-end marker escape the grammar bitmask, so a
+        # forced/required tool suffix can be violated (e.g. the model samples
+        # prose instead of the tool call); the FSM advance then rejects those
+        # tokens and the request fails with an internal error. This reuses the
+        # same signal the Mistral grammar path uses to mark "the grammar
+        # handles reasoning" (-> reasoning_ended=True at generation start). The
+        # reasoning prefix is unconstrained, so thinking is not restricted; only
+        # the post-reasoning tool call is enforced. PrivateAttr exists only on
+        # ChatCompletionRequest, hence the guard.
+        if reasoning_enabled and hasattr(request, "_grammar_from_tool_parser"):
+            request._grammar_from_tool_parser = True
         return request
 
     def extract_reasoning_streaming(

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -463,6 +463,22 @@ class DelegatingParser(Parser):
             request = self._tool_parser.adjust_request(request)
         return request
 
+    def _reasoning_enabled(self) -> bool:
+        """Whether the model will emit a reasoning prefix before its answer
+        / tool call for this request.
+
+        The parser (and thus its reasoning parser) is constructed per request
+        with that request's ``chat_template_kwargs``, so the reasoning parser
+        already reflects whether thinking is enabled. Defaults to ``True`` —
+        xgrammar's own default — when the reasoning parser cannot report it,
+        so the structural-tag grammar models the reasoning phase the engine's
+        structured-output FSM expects.
+        """
+        reasoner = self._reasoning_parser
+        if reasoner is None:
+            return False
+        return bool(getattr(reasoner, "thinking_enabled", True))
+
     def _apply_structural_tag(
         self, request: ChatCompletionRequest | ResponsesRequest
     ) -> ChatCompletionRequest | ResponsesRequest:
@@ -484,9 +500,16 @@ class DelegatingParser(Parser):
         if not need_tool_calling:
             return request
 
+        # When the model emits a reasoning prefix (e.g. ``...</think>``) before
+        # its tool call, the structural-tag grammar MUST include the reasoning
+        # section. Otherwise the grammar only models the tool-call format and
+        # the structured-output FSM rejects the reasoning tokens at the
+        # reasoning->tool boundary (HTTP 500 non-streaming / mid-stream error
+        # streaming). The engine's structural-tag same-step advance also assumes
+        # the tag models this phased (reasoning -> tool) output.
         structure_tag = self._tool_parser.get_structural_tag(
             request,
-            reasoning=False,
+            reasoning=self._reasoning_enabled(),
         )
         if structure_tag is None:
             return request

--- a/vllm/parser/engine/adapters.py
+++ b/vllm/parser/engine/adapters.py
@@ -110,6 +110,18 @@ class ParserEngineReasoningAdapter(ReasoningParser):
     def has_engine_confirmed_reasoning_end(self) -> bool:
         return self._parser_engine.reasoning_ended
 
+    @property
+    def thinking_enabled(self) -> bool:
+        """Whether reasoning/thinking output is enabled for this request.
+
+        Mirrors the wrapped parser engine, which derives this from the
+        request's ``chat_template_kwargs`` (e.g. ``enable_thinking``). Used by
+        structural-tag construction to decide whether the grammar must model a
+        reasoning prefix. Defaults to ``True`` when the engine does not expose
+        it.
+        """
+        return bool(getattr(self._parser_engine, "thinking_enabled", True))
+
     def finish_streaming(self) -> DeltaMessage | None:
         return self._parser_engine.finish_streaming()
 


### PR DESCRIPTION
## Summary

Port the reasoning/tool-call grammar fix onto `dev/eldritch-enlightenment`.

Reasoning models can emit a reasoning prefix before a structural tool-call tag. Without this fix, forced tool-choice / structural tag grammar can be initialized without the reasoning prefix handling and reject valid generations around the reasoning boundary.

## Changes

- Include the reasoning prefix in structural tag grammar handling.
- Set `_grammar_from_tool_parser` when structural tags include reasoning.

## Validation

- `git diff --check lil/dev/eldritch-enlightenment..HEAD`
- `python3 -m py_compile` on changed Python files

Runtime tool-call validation will be done in the composed eldritch Docker stack.
