### PR TITLE
[eldritch] Fix SM120 sparse MLA debug warmup startup

### DIFF
--- a/vllm/v1/attention/backends/mla/flashinfer_mla_sparse_sm120.py
+++ b/vllm/v1/attention/backends/mla/flashinfer_mla_sparse_sm120.py
@@ -81,11 +81,15 @@ class FlashInferMLASparseSM120Impl(SparseMLAAttentionImpl[FlashInferMLASparseMet
             )
         self.kv_scale_format = _kv_scale_format_for_model(model_type)
 
-        assert indexer is not None, (
-            "FLASHINFER_MLA_SPARSE_SM120 requires a sparse-MLA indexer "
-            "(model with index_topk in its config)."
-        )
-        self.topk_indices_buffer: torch.Tensor | None = indexer.topk_indices_buffer
+        topk_indices_buffer = mla_args.get("topk_indices_buffer")
+        if indexer is not None:
+            topk_indices_buffer = indexer.topk_indices_buffer
+        if topk_indices_buffer is None:
+            raise ValueError(
+                "FLASHINFER_MLA_SPARSE_SM120 requires sparse-MLA top-k indices "
+                "from an indexer or a shared topk_indices_buffer."
+            )
+        self.topk_indices_buffer: torch.Tensor = topk_indices_buffer
         from vllm.utils.flashinfer import has_flashinfer_sparse_mla_sm120
 
         if not has_flashinfer_sparse_mla_sm120():

--- a/vllm/v1/worker/gpu/warmup.py
+++ b/vllm/v1/worker/gpu/warmup.py
@@ -35,6 +35,13 @@ def run_mixed_prefill_decode_warmup(
     """Run a V2 mixed prefill+decode step through normal scheduler inputs."""
     if model_runner.is_pooling_model or num_tokens < 3:
         return False
+    if model_runner.scheduler_config.max_num_seqs < 2:
+        logger.warning(
+            "Skipping V2 mixed prefill+decode warmup because max_num_seqs=%d "
+            "cannot hold both the warmup decode and prefill requests.",
+            model_runner.scheduler_config.max_num_seqs,
+        )
+        return False
 
     decode_req_id = f"{req_id_prefix}_decode_"
     prefill_req_id = f"{req_id_prefix}_prefill_"


### PR DESCRIPTION
## Summary

Port the SM120 sparse MLA warmup/startup fix onto `dev/eldritch-enlightenment`.

This avoids debug/warmup startup failures in the FlashInfer sparse MLA SM120 path while keeping the runtime attention backend behavior unchanged.

## Validation

- `git diff --check lil/dev/eldritch-enlightenment..HEAD`
- `python3 -m py_compile` on changed Python files

Runtime validation will be done in the composed eldritch Docker stack.
