### PR TITLE
[eldritch] Route non-GPT-OSS MXFP4 experts to native MoE

### DIFF
--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -3,6 +3,7 @@
 
 import torch
 
+from vllm.config import get_current_vllm_config
 from vllm.logger import init_logger
 from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.fused_moe import (
@@ -256,7 +257,17 @@ class Mxfp4Config(QuantizationConfig):
             )
             return UnquantizedLinearMethod()
         elif isinstance(layer, RoutedExperts):
-            return GptOssMxfp4MoEMethod(layer.moe_config)
+            model_type = getattr(
+                get_current_vllm_config().model_config.hf_config,
+                "model_type",
+                None,
+            )
+            if model_type == "gpt_oss":
+                return GptOssMxfp4MoEMethod(layer.moe_config)
+            logger.info_once(
+                "Using native MXFP4 MoE method for model_type=%s.", model_type
+            )
+            return Mxfp4MoEMethod(layer.moe_config)
         elif isinstance(layer, Attention):
             logger.debug_once(
                 "MXFP4 attention layer is not implemented. "


### PR DESCRIPTION
## Summary

Make the generic MXFP4 quantization path route non-GPT-OSS `RoutedExperts` to the native MXFP4 MoE method instead of always using the GPT-OSS-specific method.

This is needed for GLM/AMD-style MXFP4 checkpoints where the expert layout is not GPT-OSS.

## Changes

- Inspect `hf_config.model_type` at quant-method selection time.
- Keep `GptOssMxfp4MoEMethod` for `model_type == "gpt_oss"`.
- Use `Mxfp4MoEMethod` for other model types.

## Validation

- `git diff --check lil/dev/eldritch-enlightenment..HEAD`
- `python3 -m py_compile` on changed Python files

Runtime validation for MXFP4 checkpoints is separate from the initial GLM NVFP4 validation.
