### PR TITLE
[eldritch] mimo: keep DFlash on padded-V attention

### DIFF
--- a/vllm/model_executor/models/mimo_v2.py
+++ b/vllm/model_executor/models/mimo_v2.py
@@ -52,7 +52,6 @@ from vllm.model_executor.model_loader.weight_utils import (
 from vllm.model_executor.models.utils import sequence_parallel_chunk
 from vllm.sequence import IntermediateTensors
 from vllm.v1.attention.backend import AttentionType
-from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
 from .interfaces import (
     EagleModelMixin,
@@ -316,39 +315,27 @@ class MiMoV2Attention(nn.Module):
         use_flashinfer = configured_backend_name == "FLASHINFER"
         use_b12x_paged = configured_backend_name == "B12X_ATTN"
 
-        attn_backend = None
-        attn_head_size_v = self.v_head_dim
-        self.pad_value_for_fa = False
-
         if use_b12x_paged:
             from vllm.v1.attention.backends.b12x_attn import (
                 get_b12x_paged_attention_backend,
             )
 
             attn_backend = get_b12x_paged_attention_backend(self.v_head_dim)
+        else:
+            attn_backend = None
 
-        # Use DiffKV when V has a different head dim than K, except for
-        # backends that accept the asymmetric V size through Attention.
-        elif (
+        # MiMo has asymmetric K/V dims (head_dim=192, v_head_dim=128). Keep
+        # the historical Triton/FA cache layout by padding V to head_dim and
+        # slicing the attention output back before o_proj. The DiffKV backend
+        # is valid for target-only serving, but it changes DFlash long-context
+        # performance substantially because the target and draft paths no
+        # longer use the same unified attention kernels.
+        self.pad_value_for_fa = (
             self.v_head_dim != self.head_dim
             and not use_flashinfer
-        ):
-            requested = configured_backend
-            if requested is not None and requested.name.endswith("_DIFFKV"):
-                backend_enum = requested
-            else:
-                fa_backend = AttentionBackendEnum.FLASH_ATTN_DIFFKV.get_class()
-                if fa_backend.is_supported_on_current_device(
-                    head_size=self.head_dim,
-                    head_size_v=self.v_head_dim,
-                    has_sinks=self.attention_sink_bias is not None,
-                ):
-                    backend_enum = AttentionBackendEnum.FLASH_ATTN_DIFFKV
-                else:
-                    backend_enum = AttentionBackendEnum.TRITON_ATTN_DIFFKV
-            attn_backend = backend_enum.get_class()
-            attn_backend.set_head_size_v(self.v_head_dim)
-            logger.info_once("Using %s for attention.", attn_backend.get_name())
+            and not use_b12x_paged
+        )
+        attn_head_size_v = self.head_dim if self.pad_value_for_fa else self.v_head_dim
 
         self.attn = Attention(
             self.num_heads,

--- a/vllm/model_executor/models/mimo_v2.py
+++ b/vllm/model_executor/models/mimo_v2.py
@@ -73,9 +73,7 @@ logger = init_logger(__name__)
 
 # Escape hatch for A/B testing the DFlash aux-feature fix: set to 1 to restore
 # the old behavior of capturing the last aux hidden state before final norm.
-_DFLASH_PRENORM_LAST_AUX = (
-    os.environ.get("VLLM_DFLASH_PRENORM_LAST_AUX", "0") == "1"
-)
+_DFLASH_PRENORM_LAST_AUX = os.environ.get("VLLM_DFLASH_PRENORM_LAST_AUX", "0") == "1"
 
 
 class MiMoV2MLP(nn.Module):
@@ -331,7 +329,7 @@ class MiMoV2Attention(nn.Module):
         # performance substantially because the target and draft paths no
         # longer use the same unified attention kernels.
         self.pad_value_for_fa = (
-            self.v_head_dim != self.head_dim
+            self.v_head_dim < self.head_dim
             and not use_flashinfer
             and not use_b12x_paged
         )
@@ -873,9 +871,7 @@ class MiMoV2Model(nn.Module, EagleModelMixin):
         return True
 
 
-class MiMoV2FlashForCausalLM(
-    nn.Module, SupportsPP, MixtureOfExperts, SupportsEagle3
-):
+class MiMoV2FlashForCausalLM(nn.Module, SupportsPP, MixtureOfExperts, SupportsEagle3):
     packed_modules_mapping = {
         "qkv_proj": ["q_proj", "k_proj", "v_proj"],
         "gate_up_proj": ["gate_proj", "up_proj"],


### PR DESCRIPTION
## Summary

MiMo V2.5 uses asymmetric K/V dimensions (`head_dim=192`, `v_head_dim=128`). The current branch routes that shape through `FLASH_ATTN_DIFFKV`/`TRITON_ATTN_DIFFKV` automatically.

For MiMo FP4-DFlash long-context serving, that path is much slower than the historical padded-V path. This PR restores the padded-V behavior for Triton/FA-style MiMo attention: keep the standard attention backend, pad V to `head_dim` for the KV cache, and slice the attention output back before `o_proj`.

B12X paged attention is unchanged and still receives the real `v_head_dim`.

## Validation

Syntax:

```bash
python3 -m py_compile vllm/model_executor/models/mimo_v2.py
```

Runtime A/B on 8x RTX PRO 6000 Blackwell, latest eldritch image, `XiaomiMiMo/MiMo-V2.5-Pro-FP4-DFlash`, TP8, DFlash `num_speculative_tokens=7`, `--attention-backend TRITON_ATTN`, `flashinfer_cutlass` MoE:

```bash
python3 /mnt/test.py --port 8000 -c 100000 --quiet --json-summary -
```

Observed long-context generation-only throughput:

| Stack | Attention kernel | Throughput |
|---|---|---:|
| latest branch before this patch | `kernel_unified_attention_diffkv` | ~93 tok/s |
| old known-good black-benediction overlay | `kernel_unified_attention` | ~215 tok/s |
| latest branch + this patch | `kernel_unified_attention` | ~227 tok/s |

The patched run was coherent (`chinese_count=0`) and logged `AttentionBackendEnum.TRITON_ATTN`, not `*_DIFFKV`.

## Notes

The DiffKV backend remains useful for target-only asymmetric-K/V serving where avoiding padded V cache is preferred. The issue here is specifically MiMo DFlash long-context performance: target and draft paths are fastest when they stay on the same unified attention kernels.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized attention backend selection and handling for certain model configurations to improve execution efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->