### PR TITLE
config: keep GLM B12X virtual TP heads HPB-aligned

### DIFF
--- a/vllm/config/virtual_tp.py
+++ b/vllm/config/virtual_tp.py
@@ -99,9 +99,16 @@ def _build_b12x_virtual_tp_plan(
 
     original_attention_heads = _require_int_attr(text_config, "num_attention_heads")
     # DeepSeek V4 carries output-group constraints tied to padded head count.
-    # GLM/DSA sparse MLA only needs divisibility by TP; backend kernels handle
-    # their own local tiling, so avoid inflating KV/cache shapes there.
-    attention_head_alignment = _ATTENTION_HEAD_LOCAL_ALIGNMENT if is_deepseek_v4 else 1
+    # GLM/DSA usually only needs divisibility by TP. However, when GLM needs
+    # virtual attention-head padding (for example 64 heads on TP6), B12X MG
+    # prefill must receive a full local HPB shard: 64->66 gives 11 local heads
+    # and the B12X wrapper pads that partial HPB to 16 without a valid_hpb mask,
+    # corrupting long-context output. Keep the no-padding GLM path for TP sizes
+    # that already divide the model heads, notably TP8/TP16.
+    if is_deepseek_v4 or original_attention_heads % attention_tp_size:
+        attention_head_alignment = _ATTENTION_HEAD_LOCAL_ALIGNMENT
+    else:
+        attention_head_alignment = 1
     attention_axis = _make_virtual_axis(
         original_attention_heads,
         attention_tp_size,


### PR DESCRIPTION
## Summary

Keep GLM/DSA B12X virtual-TP attention heads HPB-aligned only when GLM actually needs virtual attention-head padding.

This is a narrower follow-up to `2d040b9` / PR25. PR25 is still correct for TP sizes that already divide GLM's 64 attention heads: TP8 and TP16 should keep the low-memory no-padding path. The failure is the non-divisible TP case, specifically TP6.

For TP6, PR25 pads GLM heads only for TP divisibility: `64 -> 66`, so each rank gets 11 local attention heads. The vLLM B12X wrapper then pads that partial local shard to 16 for `B12X_MLA_SPARSE` prefill, but the current B12X MG prefill path does not carry a `valid_hpb` mask for that partial-head block. Long-context prefill output becomes corrupt.

With this patch:

- DeepSeek V4 still uses B12X local HPB alignment as before.
- GLM/DSA with divisible heads, e.g. TP8/TP16, keeps `alignment=1` and avoids the old memory blow-up.
- GLM/DSA with non-divisible heads, e.g. TP6, uses HPB alignment and pads `64 -> 96`, giving each rank a full 16-head B12X shard.

## Validation

Image under test for the failing baseline: `voipmonitor/vllm:glm52-eldritch-all-experiments-vllmbebd41b-b12x21e5cd4-cu132-20260623`
Model: `lukealonso/GLM-5.2-NVFP4`
Shape: TP6 / DCP1 / MTP off / B12X_MLA_SPARSE / B12X MoE / A16 forced / FP8 KV / `max_num_batched_tokens=8192` / `max_num_seqs=1`

Broken baseline (`64 -> 66`, local heads 11 then B12X pads 11 -> 16):

```bash
python3 /mnt/test.py --port 5592 -L -c 30000
# output starts: 1!!!!!!!!...
```

Also broken below one prefill chunk:

```bash
python3 /mnt/test.py --port 5592 -L -c 7000
# output starts: 1!!!!!!!!...
```

Eager mode still fails the same way, so this is not CUDA graph replay:

```bash
--enforce-eager
python3 /mnt/test.py --port 5592 -L -c 30000
# output starts: 1!!!!!!!!...
```

Patched diagnostic overlay (`64 -> 96`, local heads 16):

```bash
python3 /mnt/test.py --port 5593 -L -c 7000
# coherent Sieve of Eratosthenes response, no CJK/corruption

python3 /mnt/test.py --port 5593 -L -c 30000
# coherent Sieve of Eratosthenes response, no CJK/corruption
```

`python3 -m py_compile vllm/config/virtual_tp.py` passed after narrowing the fix.

## Tradeoff

This intentionally pays the extra head padding only for non-divisible GLM TP shapes such as TP6. It does not reintroduce the old TP16 memory regression, because TP16 keeps `64 -> 64`.

A future B12X-side fix can restore the lower-memory TP6 `64 -> 66` layout by adding proper valid-head/`valid_hpb` support to MG prefill.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved attention head alignment computation for sparse MLA models (including Deepseek V4, GLM, and DSA) to prevent incorrect long-context output caused by virtual attention-head padding and TP divisibility edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->