### PR TITLE
[codex] DS4 B12X packed KV adapter views

### DIFF
--- a/vllm/models/deepseek_v4/nvidia/b12x.py
+++ b/vllm/models/deepseek_v4/nvidia/b12x.py
@@ -42,6 +42,7 @@ if TYPE_CHECKING:
 _DSV4_HEAD_DIM = 512
 _DSV4_V_HEAD_DIM = 512
 _DSV4_CACHE_BYTES_PER_TOKEN = 584
+_DSV4_CACHE_PAD_ALIGNMENT_BYTES = 576
 _DECODE_SPLIT_TILE = 64
 _C128A_TOPK_ALIGNMENT = 128
 _VALIDATE_DCP_INDICES_ENV = "VLLM_DSV4_DCP_VALIDATE_INDICES"
@@ -51,22 +52,30 @@ def _cdiv(x: int, y: int) -> int:
     return (int(x) + int(y) - 1) // int(y)
 
 
+def _dsv4_b12x_page_nbytes(page_size: int) -> int:
+    payload_nbytes = int(page_size) * _DSV4_CACHE_BYTES_PER_TOKEN
+    return (
+        _cdiv(payload_nbytes, _DSV4_CACHE_PAD_ALIGNMENT_BYTES)
+        * _DSV4_CACHE_PAD_ALIGNMENT_BYTES
+    )
+
+
 def _b12x_cache_page_view(
     cache: torch.Tensor,
     page_size: int,
     name: str,
 ) -> torch.Tensor:
     """Return a uint8 ``[pages, padded_page_bytes]`` view for b12x kernels."""
-    min_page_nbytes = int(page_size) * _DSV4_CACHE_BYTES_PER_TOKEN
-    if min_page_nbytes <= 0:
+    page_nbytes = _dsv4_b12x_page_nbytes(page_size)
+    if page_nbytes <= 0:
         raise ValueError(f"{name} page_size must be positive, got {page_size}")
 
     byte_cache = cache if cache.dtype == torch.uint8 else cache.view(torch.uint8)
     if byte_cache.ndim == 2:
-        if int(byte_cache.shape[1]) < min_page_nbytes:
+        if int(byte_cache.shape[1]) < page_nbytes:
             raise RuntimeError(
                 f"{name} page width {int(byte_cache.shape[1])} is smaller than "
-                f"DSV4 page payload {min_page_nbytes}"
+                f"DSV4 padded page width {page_nbytes}"
             )
         if not byte_cache.is_contiguous():
             raise RuntimeError(f"{name} page cache must be contiguous")
@@ -79,20 +88,43 @@ def _b12x_cache_page_view(
 
     pages = int(byte_cache.shape[0])
     page_stride_nbytes = int(byte_cache.stride(0))
-    if page_stride_nbytes < min_page_nbytes:
+    if page_stride_nbytes < page_nbytes:
         raise RuntimeError(
             f"{name} page stride {page_stride_nbytes} is smaller than DSV4 page "
-            f"payload {min_page_nbytes}"
+            f"width {page_nbytes}"
         )
 
+    # Packed DS4 KV cache views have a storage offset for this layer and a
+    # larger per-block stride for the whole packed block. Expose only this
+    # layer's page payload while preserving stride(0), so B12X can use the
+    # packed block stride without materializing/copying.
     page_view = torch.as_strided(
         byte_cache,
-        size=(pages, page_stride_nbytes),
+        size=(pages, page_nbytes),
         stride=(page_stride_nbytes, 1),
     )
-    if not page_view.is_contiguous():
-        raise RuntimeError(f"{name} padded page view must be contiguous")
     return page_view
+
+
+def _b12x_cache_page_view_key(
+    cache: torch.Tensor,
+    page_size: int,
+) -> tuple[int, int, torch.dtype, int, tuple[int, ...], tuple[int, ...]]:
+    """Stable key for cached KV page views.
+
+    Packed DS4 KV tensors are stable after vLLM cache initialization. B12X only
+    needs a static view mapping for a layer's cache tensor; the actual contents
+    mutate in-place under that view. Avoid rebuilding the same as_strided view
+    for every layer forward.
+    """
+    return (
+        int(cache.untyped_storage().data_ptr()),
+        int(cache.storage_offset()),
+        cache.dtype,
+        int(page_size),
+        tuple(int(dim) for dim in cache.shape),
+        tuple(int(stride) for stride in cache.stride()),
+    )
 
 
 def _validate_index_matrix_for_b12x(
@@ -406,6 +438,23 @@ class DeepseekV4B12xMLAAttention(DeepseekV4FlashMLAAttention):
             "(kernel requires h_q in {16, 32, 64, 128})."
         )
 
+    def _get_b12x_cache_page_view(
+        self,
+        cache: torch.Tensor,
+        page_size: int,
+        name: str,
+    ) -> torch.Tensor:
+        views = getattr(self, "_b12x_cache_page_views", None)
+        if views is None:
+            views = {}
+            setattr(self, "_b12x_cache_page_views", views)
+        key = _b12x_cache_page_view_key(cache, page_size)
+        view = views.get(key)
+        if view is None:
+            view = _b12x_cache_page_view(cache, page_size, name)
+            views[key] = view
+        return view
+
     def _reserve_dummy_compressed_mla_scratch(self, q: torch.Tensor) -> None:
         from b12x.integration.compressed_scratch import (
             B12XCompressedMLAScratchCaps,
@@ -576,7 +625,7 @@ class DeepseekV4B12xMLAAttention(DeepseekV4FlashMLAAttention):
                 topk_indices = attn_metadata.c128a_global_decode_topk_indices
                 topk_lens = attn_metadata.c128a_decode_topk_lens
             indexed_page_size = block_size
-            indexed_k_cache = _b12x_cache_page_view(
+            indexed_k_cache = self._get_b12x_cache_page_view(
                 kv_cache,
                 indexed_page_size,
                 "indexed_k_cache",
@@ -586,7 +635,7 @@ class DeepseekV4B12xMLAAttention(DeepseekV4FlashMLAAttention):
         swa_lens = swa_metadata.decode_swa_lens
         assert swa_indices is not None
         assert swa_lens is not None
-        swa_k_cache = _b12x_cache_page_view(
+        swa_k_cache = self._get_b12x_cache_page_view(
             swa_kv_cache,
             swa_metadata.block_size,
             "swa_k_cache",
@@ -703,7 +752,7 @@ class DeepseekV4B12xMLAAttention(DeepseekV4FlashMLAAttention):
                     )
                 )
             indexed_page_size = block_size
-            indexed_k_cache = _b12x_cache_page_view(
+            indexed_k_cache = self._get_b12x_cache_page_view(
                 compressed_k_cache,
                 indexed_page_size,
                 "indexed_k_cache",
@@ -711,7 +760,7 @@ class DeepseekV4B12xMLAAttention(DeepseekV4FlashMLAAttention):
 
         assert swa_metadata.prefill_swa_indices is not None
         assert swa_metadata.prefill_swa_lens is not None
-        swa_k_cache = _b12x_cache_page_view(
+        swa_k_cache = self._get_b12x_cache_page_view(
             swa_k_cache,
             swa_metadata.block_size,
             "swa_k_cache",


### PR DESCRIPTION
## Summary

Teach the DeepSeek V4 B12X vLLM adapter to consume the upstream packed KV layout without reverting the packed allocation.

The adapter now:
- exposes a padded `[pages, page_bytes]` B12X page view that preserves each layer's storage offset and the packed block stride;
- caches the static page-view tensor per attention module instead of rebuilding the same `as_strided` wrapper every forward;
- keeps KV storage caller-owned by vLLM. No B12X workspace/arena ownership is introduced in the vLLM path.

This is the vLLM-side half of the fix. It requires the matching B12X stride-aware compressed MLA PR.

## Root Cause

Upstream DS4 KV packing changed the cache from one contiguous tensor per `(slot_idx, page_size)` into a packed per-block allocation with per-layer offsets and a larger block stride.

The old B12X adapter assumed a contiguous page cache. With packed DS4 KV, that either produced out-of-bounds page views at startup or forced repeated view construction on the forward path after B12X was made stride-aware.

## Validation

Validated on 2x RTX PRO 6000 Blackwell using DS4F TP2, MTP off, FP8 KV, B12X attention/MoE/linear, clean image:

`voipmonitor/vllm:eldritch-packedkv-vb923949-b12xf81d898-cu132-20260624`

Image contents:
- vLLM `b9239499bd9305c55cdfc37e97dde518804c1920`
- B12X `f81d8985e2c387d0dec5f9f310a4e7a45be72adc`
- FlashInfer `b3baedbbef2686df91b6dc43818ee56fe26ceba2`

Functional smoke:
- `/mnt/test.py --port 5627 -L -c 1200`: coherent Python output, CJK=0, generation-only ~`125 tok/s`.

Decode A/B, same image and B12X commit, same GPUs, comparing upstream packed KV vs temporary oldKV layout overlay:

| layout | C1 | C2 | C4 | C8 |
|---|---:|---:|---:|---:|
| packed KV | 119.2 | 190.1 | 305.4 | 448.8 |
| oldKV overlay | 119.8 | 190.7 | 308.0 | 450.3* |

`*` oldKV C8 was marked capacity-limited by the benchmark. Values are aggregate decode tok/s.

GPU 8-9-only PCIe monitor from the same decode run:

| layout | C1 rx/tx MB/s | C2 rx/tx MB/s | C4 rx/tx MB/s | C8 rx/tx MB/s |
|---|---:|---:|---:|---:|
| packed KV | 398/376 | 619/610 | 837/809 | 1284/1292 |
| oldKV overlay | 425/404 | 638/627 | 830/823 | 1089/1071* |

Prefill A/B:

| layout | 8k tok/s | 8k rx/tx MB/s | 64k tok/s | 64k rx/tx MB/s |
|---|---:|---:|---:|---:|
| packed KV | 8,632 | 15191/15982 | 8,151 | 14681/15420 |
| oldKV overlay | 8,748 | 13255/13103 | 8,148 | 15089/14940 |

Interpretation: decode throughput is within normal run noise vs oldKV, while retaining the upstream packed allocation. Prefill is effectively unchanged at 64k and ~1.3% lower at 8k in this sample. PCIe numbers are coarse `nvidia-smi dmon` diagnostics and were collected in a helper container that could only see GPUs 8 and 9.
