### PR TITLE
[eldritch] DS4: recover non-B12X-WO graph split

### DIFF
--- a/vllm/models/deepseek_v4/attention.py
+++ b/vllm/models/deepseek_v4/attention.py
@@ -14,6 +14,7 @@ import torch.nn.functional as F
 from transformers import DeepseekV2Config, DeepseekV3Config
 
 import vllm.envs as envs
+from vllm.compilation.breakable_cudagraph import eager_break_during_capture
 from vllm.model_executor.layers.linear import (
     ColumnParallelLinear,
     MergedColumnParallelLinear,
@@ -484,24 +485,52 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
             device=hidden_states.device,
         )
 
-        # Attention runs inside a single `out`-mutating custom op (the
-        # torch.compile / breakable-cudagraph boundary). This is load-bearing:
-        # without it, `attention_impl` is traced inline and the o_padded buffer
-        # is threaded around the internal graph breaks (indexer / kv-cache
-        # update) as TWO aliasing outputs of its producer piece. The AOT
-        # piecewise runtime then merges that aliased pair into a single flat
-        # 1-D synthetic base (torch.empty((0,)).set_(storage)), so the WO
-        # consumer's assert_size_stride(o_padded, (tokens, heads, dim)) fails
-        # with "wrong number of dimensions". Wrapping the whole attention as one
-        # op makes o_padded the op's single mutated output, threaded cleanly
-        # across the boundary, and keeps the attention's internal CUDA streams /
-        # events out of the compiled artifact (so it stays serializable).
-        torch.ops.vllm.deepseek_v4_attention(
-            hidden_states,
-            positions,
-            o_padded,
-            self.prefix,
-        )
+        if envs.VLLM_USE_BREAKABLE_CUDAGRAPH and not self._use_b12x_wo:
+            # DS4 breakable-cudagraph serving is faster when metadata-free
+            # input GEMMs/RMSNorm stay in the captured graph and only the
+            # metadata-dependent sparse attention body enters the eager break.
+            # Keep the opaque custom op for AOT/non-breakable execution and for
+            # B12X WO, where it prevents o_padded aliasing across graph pieces.
+            qr_kv, kv_score, indexer_kv_score, indexer_weights = (
+                self.attn_gemm_parallel_execute(hidden_states)
+            )
+            qr, kv = qr_kv.split([self.q_lora_rank, self.head_dim], dim=-1)
+            qr, kv = fused_q_kv_rmsnorm(
+                qr,
+                kv,
+                self.q_norm.weight.data,
+                self.kv_norm.weight.data,
+                self.eps,
+            )
+            self.attention_impl(
+                hidden_states,
+                qr,
+                kv,
+                kv_score,
+                indexer_kv_score,
+                indexer_weights,
+                positions,
+                o_padded,
+            )
+        else:
+            # Attention runs inside a single `out`-mutating custom op (the
+            # torch.compile / breakable-cudagraph boundary). This is load-bearing:
+            # without it, `attention_impl` is traced inline and the o_padded buffer
+            # is threaded around the internal graph breaks (indexer / kv-cache
+            # update) as TWO aliasing outputs of its producer piece. The AOT
+            # piecewise runtime then merges that aliased pair into a single flat
+            # 1-D synthetic base (torch.empty((0,)).set_(storage)), so the WO
+            # consumer's assert_size_stride(o_padded, (tokens, heads, dim)) fails
+            # with "wrong number of dimensions". Wrapping the whole attention as one
+            # op makes o_padded the op's single mutated output, threaded cleanly
+            # across the boundary, and keeps the attention's internal CUDA streams /
+            # events out of the compiled artifact (so it stays serializable).
+            torch.ops.vllm.deepseek_v4_attention(
+                hidden_states,
+                positions,
+                o_padded,
+                self.prefix,
+            )
         o = o_padded[:, : self.n_local_heads, :]
 
         if self._use_b12x_wo:
@@ -580,6 +609,7 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
 
         return qr_kv, kv_score, indexer_kv_score, indexer_weights
 
+    @eager_break_during_capture
     def attention_impl(
         self,
         hidden_states: torch.Tensor,


### PR DESCRIPTION
## Summary

Restore the upstream-like fast breakable-cudagraph split for DeepSeek V4 when the B12X WO projection path is not enabled.

This is an Eldritch-local regression fix. `dev/eldritch-enlightenment` already contains upstream DS4 SM120 support, but a later local B12X patch re-wrapped the whole attention prelude/body in the opaque `deepseek_v4_attention` custom op. That opaque boundary is still useful for B12X WO/AOT aliasing safety, but it slows the Lucifer/FlashInfer path where `VLLM_USE_B12X_WO_PROJECTION=0`.

## Root Cause

Upstream DS4 keeps metadata-independent input GEMMs and RMSNorm in the captured graph, then runs only the metadata-dependent attention body through `@eager_break_during_capture`.

The Eldritch B12X integration changed `DeepseekV4Attention.forward()` to always call one opaque full-attention custom op. For non-B12X-WO serving this moved graph-friendly GEMMs/RMSNorm out of the fast graph shape and regressed DS4 FlashInfer/Lucifer decode throughput.

## Changes

- Re-import `eager_break_during_capture` and annotate `attention_impl()`.
- For `VLLM_USE_BREAKABLE_CUDAGRAPH=1` and `VLLM_USE_B12X_WO_PROJECTION=0`, run:
  - `attn_gemm_parallel_execute(hidden_states)`
  - `fused_q_kv_rmsnorm(...)`
  - `attention_impl(...)` behind the eager break.
- Preserve the existing opaque `deepseek_v4_attention` custom op for AOT/non-breakable execution and B12X WO, where it protects the `o_padded` alias/stride contract across graph pieces.

## Validation

Static:

```text
python3 -m py_compile vllm/models/deepseek_v4/attention.py
```

Runtime validation from the same fix before splitting this PR:

- Model: DeepSeek-V4-Flash
- Mode: TP2, MTP off, FP8 KV, FlashInfer sparse MLA, FlashInfer CUTLASS MXFP4 MoE
- GPUs: 10,11
- v3 baseline: `1951.5 tok/s`
- Eldritch current before this fix: `1913.8 tok/s`
- Eldritch with this attention split: `1952.8 tok/s` after warmup, with a previous warmed run at `1994.4 tok/s`

This PR intentionally does not include the separate FlashInfer CUTLASS no-bias cleanup or the clean-build TileLang/DeepGEMM wrappers.
