### PR TITLE
[eldritch] MoE: keep missing FlashInfer CUTLASS MXFP4 bias as None

### DIFF
--- a/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
@@ -1498,28 +1498,15 @@ def convert_weight_to_mxfp4_moe_kernel_format(
         w3_w = w13_w[:, intermediate_size:, :]
         w13_weight_swapped = torch.cat([w3_w, w1_w], dim=1)
 
-        if w13_bias is None:
-            w13_bias = torch.zeros(
-                num_experts,
-                2 * intermediate_size,
-                dtype=torch.float32,
-                device=w13_weight.device,
-            )
-        else:
+        if w13_bias is not None:
             w13_bias = w13_bias.data.to(torch.float32)
-        if w2_bias is None:
-            w2_bias = torch.zeros(
-                num_experts,
-                hidden_size,
-                dtype=torch.float32,
-                device=w2_weight.device,
-            )
+            b1 = w13_bias[:, :intermediate_size]
+            b3 = w13_bias[:, intermediate_size:]
+            w13_bias_swapped = torch.cat([b3, b1], dim=-1).to(torch.bfloat16)
         else:
-            w2_bias = w2_bias.data.to(torch.float32)
-        b1 = w13_bias[:, :intermediate_size]
-        b3 = w13_bias[:, intermediate_size:]
-        w13_bias_swapped = torch.cat([b3, b1], dim=-1).to(torch.bfloat16)
-        w2_bias = w2_bias.to(torch.bfloat16)
+            w13_bias_swapped = None
+        if w2_bias is not None:
+            w2_bias = w2_bias.data.to(torch.float32).to(torch.bfloat16)
 
         w13_s = w13_weight_scale.data
         s1 = w13_s[:, :intermediate_size, :]


### PR DESCRIPTION
## Summary

Keep missing FlashInfer CUTLASS MXFP4 MoE biases as `None` instead of materializing synthetic zero tensors during weight conversion.

## Why

`21ebea9ee4` added the native contiguous MXFP4 layout path for FlashInfer CUTLASS backends. That path also created full-size zero `w13_bias` and `w2_bias` tensors when the checkpoint had no bias. Numerically this is equivalent to no bias, but it adds unnecessary allocation and bookkeeping for no-bias DS4/GLM/MiMo checkpoints.

The backend already accepts nullable bias descriptors, so the conversion path should preserve the checkpoint semantics: no bias in the checkpoint means no bias tensor in the runtime quant config.

## Changes

- Only swap/convert `w13_bias` when it exists.
- Only convert `w2_bias` when it exists.
- Return `None` for missing biases instead of allocating zero tensors.

## Validation

- `python3 -m py_compile vllm/model_executor/layers/fused_moe/oracle/mxfp4.py`

This PR is intentionally narrow and does not include the DS4 packed-KV adapter or the non-B12X-WO graph split changes.
