### PR TITLE
[eldritch] DS4: wrap Lucifer kernels for compile

### DIFF
--- a/vllm/model_executor/kernels/mhc/tilelang.py
+++ b/vllm/model_executor/kernels/mhc/tilelang.py
@@ -674,25 +674,49 @@ def _hc_head_fused_kernel_tilelang_fake(
     )
 
 
+_mhc_pre_tilelang_impl = mhc_pre_tilelang
+_mhc_post_tilelang_impl = mhc_post_tilelang
+_mhc_fused_post_pre_tilelang_impl = mhc_fused_post_pre_tilelang
+
 direct_register_custom_op(
     op_name="mhc_pre_tilelang",
-    op_func=mhc_pre_tilelang,
+    op_func=_mhc_pre_tilelang_impl,
     mutates_args=[],
     fake_impl=_mhc_pre_tilelang_fake,
 )
 direct_register_custom_op(
     op_name="mhc_post_tilelang",
-    op_func=mhc_post_tilelang,
+    op_func=_mhc_post_tilelang_impl,
     mutates_args=[],
     fake_impl=_mhc_post_tilelang_fake,
 )
 
 direct_register_custom_op(
     op_name="mhc_fused_post_pre_tilelang",
-    op_func=mhc_fused_post_pre_tilelang,
+    op_func=_mhc_fused_post_pre_tilelang_impl,
     mutates_args=[],
     fake_impl=_mhc_fused_post_pre_tilelang_fake,
 )
+
+
+def mhc_pre_tilelang(*args, **kwargs):
+    """Call MHC pre through the registered custom op.
+
+    Model code imports this symbol directly. Keeping the public symbol as a
+    thin custom-op wrapper prevents torch.compile from tracing into TileLang
+    Python/JIT internals during memory profiling and CUDA graph capture.
+    """
+    return torch.ops.vllm.mhc_pre_tilelang(*args, **kwargs)
+
+
+def mhc_post_tilelang(*args, **kwargs):
+    """Call MHC post through the registered custom op."""
+    return torch.ops.vllm.mhc_post_tilelang(*args, **kwargs)
+
+
+def mhc_fused_post_pre_tilelang(*args, **kwargs):
+    """Call fused MHC post/pre through the registered custom op."""
+    return torch.ops.vllm.mhc_fused_post_pre_tilelang(*args, **kwargs)
 
 direct_register_custom_op(
     op_name="hc_head_fused_kernel_tilelang",

--- a/vllm/models/deepseek_v4/nvidia/ops/o_proj.py
+++ b/vllm/models/deepseek_v4/nvidia/ops/o_proj.py
@@ -8,6 +8,47 @@ from vllm.models.deepseek_v4.common.ops.fused_inv_rope_fp8_quant import (
 )
 from vllm.platforms import current_platform
 from vllm.utils.deep_gemm import fp8_einsum
+from vllm.utils.torch_utils import direct_register_custom_op
+
+
+def _deepseek_v4_fp8_o_proj_einsum(
+    o_fp8: torch.Tensor,
+    o_scale: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale_inv: torch.Tensor,
+    z: torch.Tensor,
+    recipe_0: int,
+    recipe_1: int,
+    recipe_2: int,
+) -> None:
+    fp8_einsum(
+        "bhr,hdr->bhd",
+        (o_fp8, o_scale),
+        (weight, weight_scale_inv),
+        z,
+        recipe=(recipe_0, recipe_1, recipe_2),
+    )
+
+
+def _deepseek_v4_fp8_o_proj_einsum_fake(
+    o_fp8: torch.Tensor,
+    o_scale: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale_inv: torch.Tensor,
+    z: torch.Tensor,
+    recipe_0: int,
+    recipe_1: int,
+    recipe_2: int,
+) -> None:
+    return None
+
+
+direct_register_custom_op(
+    op_name="deepseek_v4_fp8_o_proj_einsum",
+    op_func=_deepseek_v4_fp8_o_proj_einsum,
+    mutates_args=["z"],
+    fake_impl=_deepseek_v4_fp8_o_proj_einsum_fake,
+)
 
 
 def compute_fp8_einsum_recipe() -> tuple[tuple[int, int, int], bool]:
@@ -60,11 +101,14 @@ def deep_gemm_fp8_o_proj(
         device=o.device,
         dtype=torch.bfloat16,
     )
-    fp8_einsum(
-        "bhr,hdr->bhd",
-        (o_fp8, o_scale),
-        (wo_a.weight, wo_a.weight_scale_inv),
+    torch.ops.vllm.deepseek_v4_fp8_o_proj_einsum(
+        o_fp8,
+        o_scale,
+        wo_a.weight,
+        wo_a.weight_scale_inv,
         z,
-        recipe=einsum_recipe,
+        einsum_recipe[0],
+        einsum_recipe[1],
+        einsum_recipe[2],
     )
     return wo_b(z.flatten(1))


### PR DESCRIPTION
## Summary

Route the DS4 Lucifer TileLang mHC helpers and DeepGEMM FP8 o-projection einsum through explicit vLLM custom-op boundaries.

## Why

The DS4 Lucifer path calls two families of external/JIT kernels from Python:

- TileLang mHC helpers imported as `mhc_pre_tilelang`, `mhc_post_tilelang`, and `mhc_fused_post_pre_tilelang`.
- DeepGEMM `fp8_einsum` used by the DS4 FP8 output projection path.

During clean Docker builds with torch.compile / memory profiling / CUDA graph capture enabled, these Python entrypoints can be pulled into Dynamo tracing instead of being treated as opaque kernel launches. That is not the desired boundary: model code should see a stable vLLM op, while the actual TileLang/DeepGEMM internals stay outside Dynamo's graph.

## Changes

- Keep the original TileLang mHC functions as private implementation callables registered with `direct_register_custom_op`.
- Re-export the public mHC symbols as thin `torch.ops.vllm.*` wrappers, preserving existing call sites and kwargs.
- Register the DS4 FP8 o-proj DeepGEMM einsum as `torch.ops.vllm.deepseek_v4_fp8_o_proj_einsum` with `z` marked mutable.
- Call the registered op from `deep_gemm_fp8_o_proj` instead of invoking `fp8_einsum` directly.

## Scope notes

This PR is intentionally narrow:

- It does not include DS4 packed-KV adapter changes.
- It does not include the non-B12X-WO graph split throughput fix.
- It does not include the FlashInfer CUTLASS no-bias cleanup.
- It does not change the mHC DeepGEMM selection policy or introduce new environment gates.

## Validation

- `python3 -m py_compile vllm/model_executor/kernels/mhc/tilelang.py vllm/models/deepseek_v4/nvidia/ops/o_proj.py`
- `git diff --cached --check`
