### PR TITLE
[eldritch] attention: avoid sparse indexer host sync

### DIFF
--- a/tests/model_executor/layers/test_sparse_attn_indexer_b12x.py
+++ b/tests/model_executor/layers/test_sparse_attn_indexer_b12x.py
@@ -1160,3 +1160,132 @@ def test_b12x_schedule_metadata_uses_canonical_indexer_import(monkeypatch):
         ("uses_schedule", 2, 3),
         ("build_schedule", (64, 128), 64, 4, True),
     ]
+
+
+def test_b12x_decode_topk_max_uses_exact_cpu_shadow():
+    from vllm.v1.attention.backend import CommonAttentionMetadata
+    from vllm.v1.attention.backends.mla import indexer as mla_indexer_mod
+
+    builder = object.__new__(mla_indexer_mod.DeepseekV32IndexerMetadataBuilder)
+    builder.compress_ratio = 1
+    common = CommonAttentionMetadata(
+        query_start_loc=torch.tensor([0, 1, 2, 3], dtype=torch.int32),
+        query_start_loc_cpu=torch.tensor([0, 1, 2, 3], dtype=torch.int32),
+        seq_lens=torch.tensor([11, 23, 17], dtype=torch.int32, device="meta"),
+        _seq_lens_cpu=torch.tensor([11, 23, 17], dtype=torch.int32),
+        num_reqs=3,
+        num_actual_tokens=3,
+        max_query_len=1,
+        max_seq_len=100000,
+        block_table_tensor=torch.zeros((3, 1), dtype=torch.int32),
+        slot_mapping=torch.zeros((3,), dtype=torch.int64),
+    )
+
+    assert (
+        builder._decode_topk_max_seq_len_from_cpu(
+            common,
+            num_decodes=3,
+            decode_lens_np=np.array([1, 1, 1], dtype=np.int32),
+            max_decode_len=1,
+            use_native=True,
+            dcp_local_seq_lens_cpu=None,
+        )
+        == 23
+    )
+
+
+def test_b12x_decode_topk_max_prefers_dcp_local_cpu_shadow():
+    from vllm.v1.attention.backend import CommonAttentionMetadata
+    from vllm.v1.attention.backends.mla import indexer as mla_indexer_mod
+
+    builder = object.__new__(mla_indexer_mod.DeepseekV32IndexerMetadataBuilder)
+    builder.compress_ratio = 1
+    common = CommonAttentionMetadata(
+        query_start_loc=torch.tensor([0, 1, 2], dtype=torch.int32),
+        query_start_loc_cpu=torch.tensor([0, 1, 2], dtype=torch.int32),
+        seq_lens=torch.tensor([1000, 900], dtype=torch.int32, device="meta"),
+        _seq_lens_cpu=torch.tensor([1000, 900], dtype=torch.int32),
+        num_reqs=2,
+        num_actual_tokens=2,
+        max_query_len=1,
+        max_seq_len=1000,
+        block_table_tensor=torch.zeros((2, 1), dtype=torch.int32),
+        slot_mapping=torch.zeros((2,), dtype=torch.int64),
+    )
+    dcp_local = torch.tensor([126, 113], dtype=torch.int32)
+
+    assert (
+        builder._decode_topk_max_seq_len_from_cpu(
+            common,
+            num_decodes=2,
+            decode_lens_np=np.array([1, 1], dtype=np.int32),
+            max_decode_len=1,
+            use_native=True,
+            dcp_local_seq_lens_cpu=dcp_local,
+        )
+        == 126
+    )
+
+
+def test_b12x_decode_topk_max_ignores_flattened_mtp_padding_rows():
+    from vllm.v1.attention.backend import CommonAttentionMetadata
+    from vllm.v1.attention.backends.mla import indexer as mla_indexer_mod
+
+    builder = object.__new__(mla_indexer_mod.DeepseekV32IndexerMetadataBuilder)
+    builder.compress_ratio = 1
+    common = CommonAttentionMetadata(
+        query_start_loc=torch.tensor([0, 3, 3], dtype=torch.int32),
+        query_start_loc_cpu=torch.tensor([0, 3, 3], dtype=torch.int32),
+        seq_lens=torch.tensor([80, 200], dtype=torch.int32, device="meta"),
+        _seq_lens_cpu=torch.tensor([80, 200], dtype=torch.int32),
+        num_reqs=2,
+        num_actual_tokens=3,
+        max_query_len=3,
+        max_seq_len=200,
+        block_table_tensor=torch.zeros((2, 1), dtype=torch.int32),
+        slot_mapping=torch.zeros((3,), dtype=torch.int64),
+    )
+
+    assert (
+        builder._decode_topk_max_seq_len_from_cpu(
+            common,
+            num_decodes=2,
+            decode_lens_np=np.array([3, 0], dtype=np.int32),
+            max_decode_len=3,
+            use_native=False,
+            dcp_local_seq_lens_cpu=None,
+        )
+        == 80
+    )
+
+
+def test_b12x_decode_topk_max_returns_none_without_authoritative_cpu_shadow():
+    from vllm.v1.attention.backend import CommonAttentionMetadata
+    from vllm.v1.attention.backends.mla import indexer as mla_indexer_mod
+
+    builder = object.__new__(mla_indexer_mod.DeepseekV32IndexerMetadataBuilder)
+    builder.compress_ratio = 1
+    common = CommonAttentionMetadata(
+        query_start_loc=torch.tensor([0, 1], dtype=torch.int32),
+        query_start_loc_cpu=torch.tensor([0, 1], dtype=torch.int32),
+        seq_lens=torch.tensor([10], dtype=torch.int32, device="meta"),
+        _seq_lens_cpu=None,
+        num_reqs=1,
+        num_actual_tokens=1,
+        max_query_len=1,
+        max_seq_len=10,
+        block_table_tensor=torch.zeros((1, 1), dtype=torch.int32),
+        slot_mapping=torch.zeros((1,), dtype=torch.int64),
+    )
+
+    assert (
+        builder._decode_topk_max_seq_len_from_cpu(
+            common,
+            num_decodes=1,
+            decode_lens_np=np.array([1], dtype=np.int32),
+            max_decode_len=1,
+            use_native=True,
+            dcp_local_seq_lens_cpu=None,
+        )
+        is None
+    )

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -467,6 +467,51 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                 )
         return self.scheduler_metadata_buffer
 
+    def _decode_topk_max_seq_len_from_cpu(
+        self,
+        common_attn_metadata: CommonAttentionMetadata,
+        num_decodes: int,
+        decode_lens_np: np.ndarray,
+        max_decode_len: int,
+        use_native: bool,
+        dcp_local_seq_lens_cpu: torch.Tensor | None,
+    ) -> int | None:
+        """Return the exact decode max seq-len without reading CUDA tensors.
+
+        B12X needs a host scalar for metadata/scheduling.  Computing it with
+        ``seq_lens.max().item()`` synchronizes every decode step.  The model
+        runner already maintains CPU shadows for normal decode; use those
+        directly and mirror only the shape transforms that can affect the max.
+        If async-spec has made the CPU shadow non-authoritative, return None so
+        the caller can fall back to a safe graph-stable bound.
+        """
+        cpu_seq_lens = (
+            dcp_local_seq_lens_cpu
+            if dcp_local_seq_lens_cpu is not None
+            else common_attn_metadata._seq_lens_cpu
+        )
+        if cpu_seq_lens is None:
+            return None
+        if cpu_seq_lens.device.type != "cpu":
+            return None
+
+        seq_lens_np = cpu_seq_lens[:num_decodes].numpy()
+        if seq_lens_np.size == 0:
+            return 0
+
+        # Flattened variable-length MTP writes only real decode tokens and
+        # zero-fills the tail.  Ignore padded decode rows to match that max.
+        if not use_native and max_decode_len > 1:
+            valid_decode_rows = decode_lens_np[:num_decodes] > 0
+            if not bool(np.any(valid_decode_rows)):
+                return 0
+            seq_lens_np = seq_lens_np[valid_decode_rows]
+
+        max_seq_len = int(seq_lens_np.max())
+        if self.compress_ratio > 1:
+            max_seq_len //= self.compress_ratio
+        return max_seq_len
+
     def _prepare_decode_tensors(
         self,
         seq_lens: torch.Tensor,
@@ -785,6 +830,12 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                 and common_attn_metadata.dcp_local_seq_lens is not None
                 else None
             )
+            dcp_local_seq_lens_cpu = (
+                common_attn_metadata.dcp_local_seq_lens_cpu[:num_decodes]
+                if dcp_local_seq_lens is not None
+                and common_attn_metadata.dcp_local_seq_lens_cpu is not None
+                else None
+            )
             seq_lens = (
                 dcp_local_seq_lens
                 if dcp_local_seq_lens is not None
@@ -877,7 +928,48 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
             # kernels see the same (B, next_n) layout as the MTP path.
             if seq_lens.dim() == 1:
                 seq_lens = seq_lens.unsqueeze(-1)
-            decode_topk_max_seq_len = int(seq_lens.max().item())
+
+            active_width = None
+            active_width_tokens = None
+            if envs.VLLM_USE_B12X_SPARSE_INDEXER:
+                # Live scorer window in cache tokens. ceil(max_seq_len /
+                # compress_ratio) is an upper bound on the max compressed
+                # context across the batch, so windowing to it is top-k-identical
+                # to the capacity cap and only skips wasted k-tiles. Computed on
+                # the host here (metadata-prep, outside cudagraph capture) and
+                # filled into the persistent buffer the captured kernel reads.
+                active_width_tokens = -(
+                    -int(common_attn_metadata.max_seq_len) // self.compress_ratio
+                )
+                self.b12x_active_width_buffer.fill_(active_width_tokens)
+                active_width = self.b12x_active_width_buffer
+                if self.compress_ratio > 1:
+                    # Compressed-MLA models already bound the B12X scorer with
+                    # active_width. Avoiding a host reduction here removes a
+                    # per-decode sync without changing the scorer window.
+                    decode_topk_max_seq_len = active_width_tokens
+                else:
+                    # GLM/Kimi-style uncompressed indexer rows need the exact
+                    # scalar for best throughput; use the CPU shadow maintained
+                    # by the runner instead of synchronizing on seq_lens.
+                    decode_topk_max_seq_len = (
+                        self._decode_topk_max_seq_len_from_cpu(
+                            common_attn_metadata,
+                            num_decodes,
+                            decode_lens_np,
+                            max_decode_len,
+                            use_native,
+                            dcp_local_seq_lens_cpu,
+                        )
+                    )
+                    if decode_topk_max_seq_len is None:
+                        # Async-spec can make GPU seq_lens authoritative.  In
+                        # that mode there is no exact host scalar without a
+                        # sync, so use the same graph-stable live-window bound
+                        # already consumed by the B12X scorer.
+                        decode_topk_max_seq_len = active_width_tokens
+            else:
+                decode_topk_max_seq_len = int(seq_lens.max().item())
 
             if envs.VLLM_USE_B12X_SPARSE_INDEXER:
                 schedule_metadata = self._maybe_build_b12x_schedule_metadata(
@@ -891,20 +983,6 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                 schedule_metadata = self._maybe_build_deep_gemm_schedule_metadata(
                     seq_lens
                 )
-
-            active_width = None
-            if envs.VLLM_USE_B12X_SPARSE_INDEXER:
-                # Live scorer window in cache tokens. ceil(max_seq_len /
-                # compress_ratio) is an upper bound on the max compressed
-                # context across the batch, so windowing to it is top-k-identical
-                # to the capacity cap and only skips wasted k-tiles. Computed on
-                # the host here (metadata-prep, outside cudagraph capture) and
-                # filled into the persistent buffer the captured kernel reads.
-                active_width_tokens = -(
-                    -int(common_attn_metadata.max_seq_len) // self.compress_ratio
-                )
-                self.b12x_active_width_buffer.fill_(active_width_tokens)
-                active_width = self.b12x_active_width_buffer
 
             decode_metadata = DeepSeekV32IndexerDecodeMetadata(
                 block_table=block_table,

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -931,6 +931,11 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
 
             active_width = None
             active_width_tokens = None
+            if self.compress_ratio > 1:
+                active_width_tokens = -(
+                    -int(common_attn_metadata.max_seq_len) //
+                    self.compress_ratio
+                )
             if envs.VLLM_USE_B12X_SPARSE_INDEXER:
                 # Live scorer window in cache tokens. ceil(max_seq_len /
                 # compress_ratio) is an upper bound on the max compressed
@@ -938,9 +943,8 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                 # to the capacity cap and only skips wasted k-tiles. Computed on
                 # the host here (metadata-prep, outside cudagraph capture) and
                 # filled into the persistent buffer the captured kernel reads.
-                active_width_tokens = -(
-                    -int(common_attn_metadata.max_seq_len) // self.compress_ratio
-                )
+                if active_width_tokens is None:
+                    active_width_tokens = int(common_attn_metadata.max_seq_len)
                 self.b12x_active_width_buffer.fill_(active_width_tokens)
                 active_width = self.b12x_active_width_buffer
                 if self.compress_ratio > 1:
@@ -968,6 +972,11 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                         # sync, so use the same graph-stable live-window bound
                         # already consumed by the B12X scorer.
                         decode_topk_max_seq_len = active_width_tokens
+            elif active_width_tokens is not None:
+                # DeepGEMM still receives exact per-row seq_lens on device.
+                # The scalar max_seq_len is only a host scorer bound; using the
+                # metadata upper bound avoids a per-token CUDA scalar sync.
+                decode_topk_max_seq_len = active_width_tokens
             else:
                 decode_topk_max_seq_len = int(seq_lens.max().item())
 


### PR DESCRIPTION
## Summary

Remove decode-time CUDA scalar synchronization from sparse-indexer metadata paths without widening the hot GLM/Kimi-style B12X scorer window.

The regression came from this pattern in decode metadata setup:

```python
decode_topk_max_seq_len = int(seq_lens.max().item())
```

`seq_lens` is a CUDA tensor in decode, so this host scalar read can synchronize the stream on every generated token. The scalar is needed only as metadata/scheduler input for the sparse top-k/indexer path; exact per-row `seq_lens` remains available on device for the kernels.

## Scope

This PR affects sparse MLA models that actually use `DeepseekV32IndexerMetadataBuilder` / `sparse_attn_indexer`.

Covered paths:

- `B12X_MLA_SPARSE` with `VLLM_USE_B12X_SPARSE_INDEXER=1`.
- Compressed MLA rows (`compress_ratio > 1`), e.g. DS4-style compressed KV/indexer layouts.
- Uncompressed sparse-indexer rows (`compress_ratio == 1`) when they use the B12X sparse indexer, e.g. GLM-style B12X sparse attention.
- Non-B12X compressed MLA sparse-indexer path, e.g. DS4 Lucifer / FlashInfer CUTLASS compressed path.

Not covered / not relevant:

- Normal Kimi K2.6/K2.7 launches that use `TRITON_MLA`. Those do not enter this sparse-indexer metadata path, so this PR neither helps nor hurts them.
- Non-B12X uncompressed sparse-indexer launches (`compress_ratio == 1` with `VLLM_USE_B12X_SPARSE_INDEXER=0`) still keep the existing fallback `seq_lens.max().item()`. If we want to support GLM/Kimi through a non-B12X sparse backend later, that should be handled separately.

## Implementation

The fix splits behavior by indexer layout and backend:

- **B12X compressed MLA (`compress_ratio > 1`)**: use the existing graph-stable `active_width_tokens = ceil(max_seq_len / compress_ratio)` bound. The B12X scorer already consumes this live-window bound, while exact per-row device `seq_lens` remains available to the kernel. This removes the sync without changing the scoring contract.
- **B12X uncompressed sparse-indexer rows (`compress_ratio == 1`)**: keep the exact scalar because broad `active_width` measurably slows GLM. Instead of reading the CUDA tensor, compute the exact max from runner-maintained CPU seq-len shadows. For DCP this prefers `dcp_local_seq_lens_cpu`, so the scalar stays in the same coordinate system as the rank-local `seq_lens` tensor.
- **Async-spec fallback**: if the CPU shadow is not authoritative, fall back to the graph-stable active-width bound instead of synchronizing on CUDA.
- **Non-B12X compressed MLA**: use the metadata upper bound for the host scalar. DeepGEMM still receives exact per-row device `seq_lens`; only the host `max_seq_len` scorer bound avoids the CUDA reduction.

No B12X workspace/arena behavior is introduced. The vLLM path remains eager and caller-scratch-owned; this PR only changes metadata scalar selection.

## Relationship To Upstream PR #46178

Upstream `vllm-project/vllm#46178` implements the broader DCP sparse-attention algorithm: DCP-local lengths, sparse top-k candidate all-gather, global top-k selection, local/global remap, MTP handling, and FP8 KV support for sparse MLA.

This PR is narrower. It addresses the decode-time host-sync issue in our eldritch/B12X integration and the compressed non-B12X sparse-indexer path. It does not replace the global-top-k algorithm; it only makes the metadata scalar computation sync-free in the paths we serve.

## Validation

Static checks:

```bash
python3 -m py_compile \
  vllm/v1/attention/backends/mla/indexer.py \
  tests/model_executor/layers/test_sparse_attn_indexer_b12x.py
```

Focused helper coverage was added for:

- exact CPU-shadow max
- DCP-local CPU-shadow max
- flattened variable-length MTP padded rows
- missing/non-authoritative CPU-shadow fallback

### GLM-5.2 B12X Sparse Indexer

Launch shape:

- GLM-5.2 Luke NVFP4
- TP8 / DCP1 / MTP off / A16
- `B12X_MLA_SPARSE`
- GPUs `8-15`
- `max_num_seqs=1`
- `max_cudagraph_capture_size=4`
- fixed 512-token cc1 decode

| Variant | 3x 512-token cc1 avg | `test.py -L` gen tok/s | CJK |
| --- | ---: | ---: | ---: |
| baseline with CUDA `.item()` | `77.56` | `77.52` | `0` |
| broad active-width B12X variant | `72.43` | `72.31` | `0` |
| pure revert of sync-introducing commit | `78.50` | `78.43` | `0` |
| this PR, exact CPU shadow | `78.20` | `78.09` | `0` |

Result: GLM stays close to the pure-revert speed while removing the CUDA scalar sync from the B12X exact path.

### DS4 / Non-B12X Compressed Indexer

The second commit extends the no-host-sync rule to the non-B12X compressed MLA path (`compress_ratio > 1`) used by DS4 Lucifer / FlashInfer CUTLASS.

A/B was run on:

- same image
- same GPU pair `8,9`
- DS4 Flash TP2 no-MTP
- debug startup settings only: `max_num_seqs=1`, `max_cudagraph_capture_size=4`, `max_num_batched_tokens=2048`

| Variant | 512-token cc1 gen tok/s | CUDA sync observation |
| --- | ---: | --- |
| unpatched non-B12X compressed path | `117.77` | `cudaStreamSynchronize` 1022x / 6.88s in nsys runtime stats |
| this PR with compressed metadata bound | `124.66` (`124.72-124.76` on reruns) | `cudaStreamSynchronize` no longer appears in runtime top; remaining sync is dominated by the existing event path |

Reports:

- `/root/bench-results/ds4-veloq-cc1-v3-vs-current-20260626/current-v420-unpatched-cutlass-cc1-debugseq1-gpu89-20260626-124648.nsys-rep`
- `/root/bench-results/ds4-veloq-cc1-v3-vs-current-20260626/current-v420-syncfix-cutlass-cc1-debugseq1-gpu89-20260626-123827.nsys-rep`
