### PR TITLE
[eldritch] DFlash: backport lm_head sharing fix

### DIFF
--- a/vllm/v1/worker/gpu/spec_decode/dflash/utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/utils.py
@@ -61,16 +61,13 @@ def load_dflash_model(target_model: nn.Module, vllm_config: VllmConfig) -> nn.Mo
                 del draft_inner.embed_tokens
             draft_inner.embed_tokens = target_embed
 
-    # Share lm_head with the target when the draft has no own copy, unless
-    # the draft remaps vocab via draft_id_to_target_id.
+    # Share lm_head with the target when the draft has no own copy. DFlash
+    # may expose draft_id_to_target_id for sampled-token remapping, but its
+    # logits still need to be scored by the target-vocab head for acceptance.
     target_lm_head = getattr(target_language_model, "lm_head", None)
     draft_lm_head = getattr(dflash_model, "lm_head", None)
-    if (
-        target_lm_head is not None
-        and getattr(dflash_model, "draft_id_to_target_id", None) is None
-        and _should_share(
-            dflash_model, "has_own_lm_head", draft_lm_head, target_lm_head
-        )
+    if target_lm_head is not None and _should_share(
+        dflash_model, "has_own_lm_head", draft_lm_head, target_lm_head
     ):
         if draft_lm_head is not None:
             del dflash_model.lm_head


### PR DESCRIPTION
## Summary

Backport the DFlash lm_head sharing behavior needed by MiMo V2.5 Pro FP4-DFlash on the eldritch branch.

The eldritch DFlash/SWA/DCP commit kept target `lm_head` sharing disabled whenever the draft exposes `draft_id_to_target_id`. That is wrong for MiMo DFlash: the ID mapping is used when interpreting sampled draft tokens, but the DFlash logits still need the target-vocab head for acceptance scoring. With the separate draft head, target generation remains coherent but speculative acceptance collapses to essentially zero.

This matches the upstream vLLM fix from `#46435` / `70b4d90a6d` and keeps the change scoped to `dflash/utils.py`.

## Validation

- `python3 -m py_compile vllm/v1/worker/gpu/spec_decode/dflash/utils.py`
- Broken final image, same MiMo DFlash7 config: mean acceptance length `1.00`, per-position acceptance `0.000/0.000/0.000/0.000/0.000/0.000/0.000`, generation around `59-63 tok/s`.
- Historical good image, same config: mean acceptance length `5.28`, per-position acceptance `0.929/0.816/0.684/0.571/0.490/0.429/0.357`.
- Final image with only this overlay: mean acceptance length `4.74`, per-position acceptance `0.843/0.676/0.574/0.481/0.444/0.389/0.333`, 512-token smoke completed in `1.90s`, CJK `0`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model loading behavior for draft decoding, allowing shared output layers in more cases.
  * This helps maintain correct token acceptance even when draft-to-target vocabulary mapping is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->