### PR TITLE
[Attention][MLA] FLASHINFER_MLA_SPARSE_SM120: support decode context parallel (DCP>1)

### DIFF
--- a/vllm/v1/attention/backends/mla/flashinfer_mla_sparse_sm120.py
+++ b/vllm/v1/attention/backends/mla/flashinfer_mla_sparse_sm120.py
@@ -1,6 +1,23 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""SM120 implementation variant for ``FLASHINFER_MLA_SPARSE_SM120``."""
+"""SM120 implementation variant for ``FLASHINFER_MLA_SPARSE_SM120``.
+
+PATCHED (glm52-patches/fimla-dcp): adds decode-context-parallel (DCP>1) support
+so the SM120 FlashInfer sparse-MLA fast path can serve with a sharded KV cache.
+
+Contract (see model_executor/layers/attention/mla_attention.py:839-903):
+  * When dcp_world_size>1 the layer all-gathers the query across DCP ranks in the
+    HEAD dim BEFORE calling forward_mqa, so q arrives as [B, H*dcp, 576] and we must
+    compute every gathered head against THIS rank's LOCAL KV shard.
+  * forward_mqa must return (out[B, H*dcp, kv_lora_rank], lse[B, H*dcp]); the layer
+    then merges across ranks via cp_lse_ag_out_rs (ag_rs) / dcp_a2a_lse_reduce (a2a),
+    the latter of which reduce-scatters back to [B, H, ...] per rank.
+  * The impl must advertise can_return_lse_for_decode=True or the layer raises.
+
+Blueprint: b12x_mla_sparse.py (the existing DCP-capable sparse-MLA backend).
+TWO runtime-verify points are marked [VERIFY] below — they are why this needs the
+numerical equivalence test (validate_fimla_dcp_lse.py), not just a compile check.
+"""
 
 from typing import TYPE_CHECKING, cast
 
@@ -16,6 +33,7 @@ from vllm.v1.attention.backends.mla.flashinfer_mla_sparse import (
     _get_workspace_buffer,
 )
 from vllm.v1.attention.backends.mla.sparse_utils import (
+    triton_convert_dcp_global_index_to_local_index,
     triton_convert_req_index_to_global_index,
 )
 
@@ -100,7 +118,48 @@ class FlashInferMLASparseSM120Impl(SparseMLAAttentionImpl[FlashInferMLASparseMet
         assert self.topk_indices_buffer is not None
 
         self.supports_quant_query_input = False
-        self._workspace_buffer: torch.Tensor | None = None
+        # HARDENING: eagerly allocate the 128MiB FlashInfer sparse workspace now
+        # (at model-construction __init__, before vLLM's memory profiling) so it
+        # lands in the profiling baseline and the KV cache is sized around it.
+        # Lazily allocating it in forward_mqa (the decode path) meant profiling —
+        # which may only exercise prefill — didn't count it, so at high
+        # gpu-memory-utilization the runtime DCP-merge reduce_scatter buffer had no
+        # headroom and OOM'd (forcing 0.90). The workspace is a module-global, so
+        # only the first layer actually allocates; the rest reuse. Falls back to
+        # lazy allocation if the worker device isn't selected yet.
+        try:
+            _dev = torch.device(f"cuda:{torch.cuda.current_device()}")
+            self._workspace_buffer: torch.Tensor | None = _get_workspace_buffer(_dev)
+        except Exception:
+            self._workspace_buffer = None
+
+        # ---------------- DCP (decode context parallel) setup ----------------
+        # This impl does NOT call super().__init__(), so set the CP attributes
+        # the common MLA layer reads (mla_attention.py:730/839/857) explicitly,
+        # mirroring b12x_mla_sparse.py. Base default is can_return_lse=False.
+        self.can_return_lse_for_decode = True
+        # query is pre-quantized only when supports_quant_query_input is True;
+        # we keep bf16 query, so DCP + fp8-kv pre-quant guard is not triggered.
+        self.supports_dcp_quant_query_input = False
+        self.pcp_world_size = 1
+        self.pcp_rank = 0
+        try:
+            from vllm.distributed.parallel_state import get_dcp_group
+
+            _dcp = get_dcp_group()
+            self.dcp_world_size = _dcp.world_size
+            self.dcp_rank = _dcp.rank_in_group
+        except (AssertionError, RuntimeError, KeyError):
+            self.dcp_world_size = 1
+            self.dcp_rank = 0
+        self.total_cp_world_size = self.pcp_world_size * self.dcp_world_size
+        self.total_cp_rank = self.pcp_rank * self.dcp_world_size + self.dcp_rank
+        self.need_to_return_lse_for_decode = (
+            self.dcp_world_size > 1 and self.can_return_lse_for_decode
+        )
+        self.cp_kv_cache_interleave_size = (
+            vllm_config.parallel_config.cp_kv_cache_interleave_size
+        )
 
     def forward_mqa(
         self,
@@ -113,23 +172,48 @@ class FlashInferMLASparseSM120Impl(SparseMLAAttentionImpl[FlashInferMLASparseMet
             q = torch.cat(q, dim=-1)
 
         num_actual_toks = q.shape[0]
+        # Under DCP, the layer all-gathered q in the head dim, so q.shape[1] is
+        # num_heads * dcp_world_size. Always size buffers from q, not self.num_heads.
+        num_actual_heads = q.shape[1]
+        dcp = self.dcp_world_size > 1
 
         assert self.topk_indices_buffer is not None
         topk_indices = self.topk_indices_buffer[:num_actual_toks]
 
-        topk_indices_physical = cast(
-            torch.Tensor,
-            triton_convert_req_index_to_global_index(
-                attn_metadata.req_id_per_token[:num_actual_toks],
-                attn_metadata.block_table,
-                topk_indices,
-                BLOCK_SIZE=attn_metadata.block_size,
-                NUM_TOPK_TOKENS=topk_indices.shape[1],
-            ),
-        )
+        if dcp:
+            # Global logical top-k ids -> THIS rank's local physical slots, plus the
+            # per-token count of slots that actually live on this rank (-> seq_lens).
+            seq_lens = torch.empty(
+                num_actual_toks, dtype=torch.int32, device=q.device
+            )
+            topk_indices_physical, seq_lens = (
+                triton_convert_dcp_global_index_to_local_index(
+                    attn_metadata.req_id_per_token[:num_actual_toks],
+                    attn_metadata.block_table,
+                    topk_indices,
+                    dcp_world_size=self.dcp_world_size,
+                    dcp_rank=self.dcp_rank,
+                    cp_kv_cache_interleave_size=self.cp_kv_cache_interleave_size,
+                    BLOCK_SIZE=attn_metadata.block_size,
+                    NUM_TOPK_TOKENS=topk_indices.shape[1],
+                    valid_counts=seq_lens,
+                )
+            )
+        else:
+            topk_indices_physical = cast(
+                torch.Tensor,
+                triton_convert_req_index_to_global_index(
+                    attn_metadata.req_id_per_token[:num_actual_toks],
+                    attn_metadata.block_table,
+                    topk_indices,
+                    BLOCK_SIZE=attn_metadata.block_size,
+                    NUM_TOPK_TOKENS=topk_indices.shape[1],
+                ),
+            )
+            seq_lens = None
 
         output = q.new_empty(
-            (num_actual_toks, self.num_heads, self.kv_lora_rank),
+            (num_actual_toks, num_actual_heads, self.kv_lora_rank),
             dtype=q.dtype,
         )
 
@@ -140,7 +224,18 @@ class FlashInferMLASparseSM120Impl(SparseMLAAttentionImpl[FlashInferMLASparseMet
             flashinfer_trtllm_batch_decode_with_kv_cache_mla,
         )
 
-        out = flashinfer_trtllm_batch_decode_with_kv_cache_mla(
+        want_lse = self.need_to_return_lse_for_decode
+        # [VERIFY-1] lse buffer shape: the merge op cp_lse_ag_out_rs expects [B, H]
+        # (float32). The flashinfer trtllm MLA kernel's lse layout for the sparse
+        # SM120 path must be confirmed at runtime; we allocate [B, H] and reshape
+        # the kernel's return below. validate_fimla_dcp_lse.py catches a mismatch.
+        lse_buf = (
+            q.new_empty((num_actual_toks, num_actual_heads), dtype=torch.float32)
+            if want_lse
+            else None
+        )
+
+        ret = flashinfer_trtllm_batch_decode_with_kv_cache_mla(
             query=q.unsqueeze(1),
             kv_cache=kv_c_and_k_pe_cache.view(torch.uint8).unsqueeze(1),
             workspace_buffer=self._workspace_buffer,
@@ -148,12 +243,31 @@ class FlashInferMLASparseSM120Impl(SparseMLAAttentionImpl[FlashInferMLASparseMet
             kv_lora_rank=self.kv_lora_rank,
             qk_rope_head_dim=self.qk_rope_head_dim,
             block_tables=topk_indices_physical.unsqueeze(1),
-            seq_lens=None,
+            # DCP: only attend this rank's valid local slots; non-DCP keeps None
+            # (kernel attends the full top-k as today).
+            seq_lens=seq_lens,
             max_seq_len=attn_metadata.topk_tokens,
             out=output.unsqueeze(1),
             bmm1_scale=self.scale,
             bmm2_scale=1.0,
             sparse_mla_top_k=attn_metadata.topk_tokens,
             kv_scale_format=self.kv_scale_format,
+            lse=None if lse_buf is None else lse_buf.unsqueeze(1),
+            return_lse=want_lse,
         )
-        return out.squeeze(1), None
+
+        if not want_lse:
+            # ret is the output tensor (writes into `out`), as in the stock impl.
+            return ret.squeeze(1), None
+
+        # [VERIFY-2] return convention: with return_lse=True the kernel returns
+        # (out, lse). We also passed in-place buffers, so prefer the returned
+        # tensors but fall back to our buffers if the kernel returns only `out`.
+        if isinstance(ret, tuple):
+            out_t, lse_t = ret
+        else:
+            out_t, lse_t = ret, lse_buf
+        out_t = out_t.squeeze(1)
+        # Normalize lse to [B, H] and slice to the gathered head count for the merge.
+        lse_t = lse_t.reshape(num_actual_toks, -1)[:, :num_actual_heads].contiguous()
+        return out_t, lse_t


### PR DESCRIPTION
# PR: FLASHINFER_MLA_SPARSE_SM120 — support decode context parallel (DCP>1)

Adds decode-context-parallel (`--decode-context-parallel-size > 1`) support to the
SM120 FlashInfer sparse-MLA backend (`FLASHINFER_MLA_SPARSE_SM120`). Previously this
backend only worked at DCP=1; DCP serving had to use `B12X_MLA_SPARSE`. With this
change the faster SM120 sparse decode kernel can serve a DCP-sharded (large) KV
cache.

## Problem

`FlashInferMLASparseSM120Impl.forward_mqa` returned `(out, None)` for the decode
softmax LSE. The common MLA layer
(`model_executor/layers/attention/mla_attention.py`) needs that LSE to merge
partial attention across DCP ranks (`cp_lse_ag_out_rs` for `ag_rs`,
`dcp_a2a_lse_reduce` for `a2a`). With `None`, the DCP path raised
`"<impl> cannot use DCP because it does not return decode softmax LSE."`, so the
SM120 sparse backend was DCP1-only.

## Changes (mirror `b12x_mla_sparse.py`, the existing DCP-capable sparse-MLA impl)

1. **Advertise the capability + init CP state.** Set `can_return_lse_for_decode =
   True` and initialize the DCP/CP attributes the common layer reads
   (`dcp_world_size`/`dcp_rank`, `pcp_*`, `total_cp_*`, `cp_kv_cache_interleave_size`,
   `need_to_return_lse_for_decode`). The impl does not call `super().__init__()`,
   so these are set explicitly from `get_dcp_group()`.
2. **`forward_mqa` DCP branch.** When `dcp_world_size > 1`, convert the global
   top-k logical ids to this rank's local physical slots via
   `triton_convert_dcp_global_index_to_local_index` (which also returns per-token
   valid counts → `seq_lens`), call the kernel with `return_lse=True`, and return
   `(out[B, H, D], lse[B, H])`. The non-DCP branch is unchanged
   (`triton_convert_req_index_to_global_index`, `seq_lens=None`).
3. **Head count from `q`.** Under DCP the layer all-gathers the query across ranks
   in the head dim before `forward_mqa`, so the impl sees
   `num_heads * dcp_world_size` heads; size the output/LSE buffers from `q.shape[1]`.
4. **Eager workspace allocation (memory accounting).** Allocate the 128 MiB
   FlashInfer sparse workspace in `__init__` (on the worker device) instead of
   lazily in `forward_mqa`. Lazily, it was not counted when the memory profiler
   sized the KV cache, so the runtime DCP-merge `reduce_scatter` buffer had no
   headroom and OOM'd at high `--gpu-memory-utilization`.

No kernel change: `trtllm_batch_decode_with_kv_cache_mla` already supports
`return_lse` for the SM120 sparse path.

## Validation (8× RTX 6000 Pro / SM120, TP8, DCP4, GLM-5.2-NVFP4, MTP3, `ag_rs`)

**Correctness.** Greedy output + per-token logprobs of the patched SM120-DCP4
path vs the known-good `B12X_MLA_SPARSE` DCP4 path match within **zero-mean**
numerical noise (mean |Δlogprob| ≈ 0.00, std ≈ 0.04–0.07; no systematic bias →
the LSE shape/scale/convention is correct). Long-context greedy token divergence
is inherent to DCP1↔DCP4 (the `B12X_MLA_SPARSE` path diverges from DCP1
identically), not a defect of this change.

**Performance (decode tok/s, identical pattern/config, fixed `index_topk_pattern`).**

| context | B12X_MLA_SPARSE DCP4 | FLASHINFER_MLA_SPARSE_SM120 DCP4 (this PR) | Δ |
|---|---|---|---|
| 32k, C1 | 75.4 | 87–90 | **+16–19%** |
| 128k, C1 | 73.5 | 85–86 | **+16%** |
| 32k, C8 | 350 | 391 | +12% |
| 128k, C8 | 333 | 359 | +8% |

At full `--gpu-memory-utilization 0.955` (after the eager-workspace fix): boots
without OOM, KV cache **2.54M tokens** (parity with `B12X_MLA_SPARSE`'s 2.58M),
and survives the full concurrency×context matrix including the worst-case
128k/C8 cell. MTP acceptance is on par with `B12X_MLA_SPARSE` (the speedup is raw
kernel throughput, not draft acceptance).

## Limitations / notes

- Only the **`ag_rs`** DCP comm backend is supported on SM120/PCIe; `a2a`
  (`dcp_a2a_lse_reduce`) is not viable on this hardware (no NVLink).
- Requires the SM120 sparse-MLA prerequisites already enforced by the backend:
  packed `fp8_ds_mla` KV layout, `index_topk == 2048`, and global top-k selection
  (`VLLM_DCP_GLOBAL_TOPK=1`, default) so the global→local index conversion is
  correct.
- Per-call allocation of the LSE / valid-counts / local-index buffers in
  `forward_mqa` is retained (matches the stock impl's per-call `output` alloc and
  is handled by vLLM's CUDA-graph memory pool; the allocations are unconditional
  on the DCP path, so there is no capture/replay mismatch). Pre-allocating them as
  graph-stable buffers in the metadata builder is a possible future cleanup but was
  not required for correct capture.

## Test plan

```bash
# DCP4 + SM120 sparse, forced backend:
VLLM_ATTENTION_BACKEND=FLASHINFER_MLA_SPARSE_SM120 \
vllm serve <GLM-5.2-NVFP4> --tensor-parallel-size 8 \
  --decode-context-parallel-size 4 --dcp-comm-backend ag_rs \
  --attention-backend FLASHINFER_MLA_SPARSE_SM120 --moe-backend b12x \
  --kv-cache-dtype fp8 --gpu-memory-utilization 0.955 ...
# Equivalence: compare greedy logprobs vs --attention-backend B12X_MLA_SPARSE
# (same DCP4) -> expect zero-mean drift, matching greedy tokens on short/medium.
```
