### PR TITLE
[eldritch] Fix Kimi DCP speculative decoding under graph capture

### DIFF
--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -1423,7 +1423,16 @@ def graph_capture(device: torch.device):
     from other kernels possibly launched on background in the default stream.
     """
     context = GraphCaptureContext(torch.cuda.Stream(device=device))
-    with get_tp_group().graph_capture(context), get_pp_group().graph_capture(context):
+    maybe_dcp_capture = (
+        get_dcp_group().graph_capture(context)
+        if _DCP is not None and get_dcp_group().world_size > 1
+        else nullcontext()
+    )
+    with (
+        get_tp_group().graph_capture(context),
+        get_pp_group().graph_capture(context),
+        maybe_dcp_capture,
+    ):
         yield context
 
 

--- a/vllm/model_executor/models/qwen3_dflash.py
+++ b/vllm/model_executor/models/qwen3_dflash.py
@@ -41,6 +41,7 @@ from vllm.v1.attention.backend import AttentionType
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheSpec,
+    SlidingWindowSpec,
     get_kv_quant_mode,
 )
 
@@ -97,30 +98,32 @@ def _get_dflash_layer_types(config: Qwen3Config) -> tuple[str, ...]:
 class DFlashAttention(Attention):
     """Attention with DFlash-specific KV allocation semantics.
 
-    The compute path keeps the layer's configured sliding window. The KV cache
-    spec is widened to full attention because DFlash writes every context KV
-    before drafting and cannot evict old context blocks from draft layers.
+    The draft KV cache is replicated across DCP ranks because DFlash draft
+    attention cannot reduce sharded KV. For SWA drafts we keep the cache
+    window-bounded so replicated DCP does not allocate a full-context draft KV.
     """
 
     def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec | None:
-        # The draft attends over the full context with a backend that cannot
-        # reduce across DCP ranks; replicate the draft cache on every rank.
+        # The draft attends locally over a replicated cache. DCP ranks therefore
+        # need the same draft KV, but sliding-window layers must stay windowed
+        # instead of being widened to full-context storage.
         dcp_replicated = (
             vllm_config.parallel_config.decode_context_parallel_size > 1
         )
         if self.sliding_window is not None:
-            # Build the full spec directly instead of converting the parent's
+            # Build the spec directly instead of converting the parent's
             # SlidingWindowSpec: Attention.get_kv_cache_spec asserts against
             # MLA *target* models for sliding-window layers, which would
-            # reject DFlash drafts beside MLA targets (e.g. Kimi K2.6) even
+            # reject DFlash drafts beside MLA targets (e.g. Kimi K2.7) even
             # though the draft layer itself is not MLA.
             assert self.attn_type == AttentionType.DECODER
-            return FullAttentionSpec(
+            return SlidingWindowSpec(
                 block_size=vllm_config.cache_config.block_size,
                 num_kv_heads=self.num_kv_heads,
                 head_size=self.head_size,
                 head_size_v=self.head_size_v,
                 dtype=self.kv_cache_torch_dtype,
+                sliding_window=self.sliding_window,
                 kv_quant_mode=get_kv_quant_mode(self.kv_cache_dtype),
                 dcp_replicated=dcp_replicated,
             )
@@ -258,9 +261,12 @@ class DFlashQwen3DecoderLayer(nn.Module):
         self.layer_type = layer_type
         set_default_rope_theta(config, default_theta=1000000)
         attn_type = AttentionType.DECODER
-        sliding_window = (
-            config.sliding_window if layer_type == "sliding_attention" else None
-        )
+        # Use one uniform sliding-window KV group for every draft layer. The
+        # target model verifies drafted tokens, so windowing the draft's lone
+        # full-attention layer can only affect acceptance, not correctness.
+        sliding_window = getattr(config, "sliding_window", None)
+        if sliding_window is None and layer_type == "sliding_attention":
+            sliding_window = config.sliding_window
         dflash_config = getattr(config, "dflash_config", None) or {}
         attention_sink_bias = bool(dflash_config.get("attention_sink_bias", False))
 

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -544,17 +544,27 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
         self.hash_block_size = hash_block_size
         self.dcp_world_size = dcp_world_size
         self.pcp_world_size = pcp_world_size
-        # Prefix caching under DCP is only disabled for the genuine DeepseekV4
-        # MLA/SWA hybrid. A DCP-replicated draft group keeps its full cache per
-        # rank and can be hashed alongside the sharded target using the GCD
-        # hash block size from resolve_kv_cache_block_sizes().
-        self.disable_prefix_cache_for_dsv4_dcp = (
+        has_dcp_replicated_group = any(
+            getattr(group.kv_cache_spec, "dcp_replicated", False)
+            for group in kv_cache_config.kv_cache_groups
+        )
+        # Prefix caching under DCP is unsafe for hybrid layouts whose groups do
+        # not advance from exactly the same cached prefix. For DeepSeek V4's
+        # MLA/SWA hybrid this was already disabled. DFlash drafts have the same
+        # requirement under DCP: the target KV is sharded, but the draft KV is
+        # replicated per DCP rank. Reusing a target prefix while the draft group
+        # has no matching prefix leaves DFlash verification with inconsistent
+        # KV state and can surface later as a CUDA illegal memory access.
+        self.disable_prefix_cache_for_dcp_hybrid = (
             enable_caching
             and dcp_world_size > 1
             and pcp_world_size == 1
-            and is_deepseek_v4_hybrid_kv_cache_config(kv_cache_config)
+            and (
+                is_deepseek_v4_hybrid_kv_cache_config(kv_cache_config)
+                or has_dcp_replicated_group
+            )
         )
-        if not self.disable_prefix_cache_for_dsv4_dcp:
+        if not self.disable_prefix_cache_for_dcp_hybrid:
             assert all(
                 mgr.block_size % hash_block_size == 0
                 for mgr in self.single_type_managers
@@ -562,7 +572,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
         assert (
             dcp_world_size == 1
             or not is_deepseek_v4_hybrid_kv_cache_config(kv_cache_config)
-            or self.disable_prefix_cache_for_dsv4_dcp
+            or self.disable_prefix_cache_for_dcp_hybrid
         ), "DCP prefix caching unsupported for the DeepseekV4 MLA/SWA hybrid."
         assert pcp_world_size == 1, "PCP not support hybrid attn now."
         self.verify_and_split_kv_cache_groups()
@@ -610,7 +620,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                     self.single_type_managers[gid].use_eagle = True
 
     def cache_blocks(self, request: Request, num_computed_tokens: int) -> None:
-        if self.disable_prefix_cache_for_dsv4_dcp:
+        if self.disable_prefix_cache_for_dcp_hybrid:
             return
 
         # Cache hits in this coordinator are always a multiple of
@@ -662,7 +672,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                 - A tuple of the cache hit blocks for each single type manager.
                 - The number of tokens of the longest cache hit.
         """
-        if self.disable_prefix_cache_for_dsv4_dcp:
+        if self.disable_prefix_cache_for_dcp_hybrid:
             blocks: tuple[list[KVCacheBlock], ...] = tuple(
                 [] for _ in range(len(self.kv_cache_config.kv_cache_groups))
             )
@@ -723,6 +733,8 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                     kv_cache_spec=spec,
                     drop_eagle_block=drop_eagle_block,
                     alignment_tokens=self.scheduler_block_size,
+                    dcp_world_size=self.dcp_world_size,
+                    pcp_world_size=self.pcp_world_size,
                 )
                 _new_hit_length = len(hit_blocks[0]) * spec.block_size
                 if drop_eagle_block:
@@ -788,6 +800,8 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                 kv_cache_spec=spec,
                 drop_eagle_block=use_eagle,
                 alignment_tokens=self.scheduler_block_size,
+                dcp_world_size=self.dcp_world_size,
+                pcp_world_size=self.pcp_world_size,
             )
             group_hit = len(blocks[0]) * spec.block_size
             for gid, blks in zip(group_ids, blocks):

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -544,25 +544,21 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
         self.hash_block_size = hash_block_size
         self.dcp_world_size = dcp_world_size
         self.pcp_world_size = pcp_world_size
-        has_dcp_replicated_group = any(
+        self.has_dcp_replicated_group = any(
             getattr(group.kv_cache_spec, "dcp_replicated", False)
             for group in kv_cache_config.kv_cache_groups
         )
         # Prefix caching under DCP is unsafe for hybrid layouts whose groups do
-        # not advance from exactly the same cached prefix. For DeepSeek V4's
-        # MLA/SWA hybrid this was already disabled. DFlash drafts have the same
-        # requirement under DCP: the target KV is sharded, but the draft KV is
-        # replicated per DCP rank. Reusing a target prefix while the draft group
-        # has no matching prefix leaves DFlash verification with inconsistent
-        # KV state and can surface later as a CUDA illegal memory access.
+        # not advance from exactly the same cached prefix. Keep the historical
+        # DeepSeek V4 MLA/SWA guard. DFlash is different: the draft KV cache is
+        # replicated and window-bounded under DCP, so prefix-cache hits are safe
+        # as long as the draft group can materialize its local sliding-window
+        # tail and older context slots remain padded.
         self.disable_prefix_cache_for_dcp_hybrid = (
             enable_caching
             and dcp_world_size > 1
             and pcp_world_size == 1
-            and (
-                is_deepseek_v4_hybrid_kv_cache_config(kv_cache_config)
-                or has_dcp_replicated_group
-            )
+            and is_deepseek_v4_hybrid_kv_cache_config(kv_cache_config)
         )
         if not self.disable_prefix_cache_for_dcp_hybrid:
             assert all(
@@ -618,6 +614,49 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
             if group.use_eagle:
                 for gid in group.group_ids:
                     self.single_type_managers[gid].use_eagle = True
+
+    def get_num_common_prefix_blocks(self, running_request_id: str) -> list[int]:
+        if (
+            self.dcp_world_size > 1
+            and self.pcp_world_size == 1
+            and self.has_dcp_replicated_group
+        ):
+            # This value drives cascade attention metadata, not prefix-cache
+            # lookup. A DFlash hybrid has sharded target KV plus replicated
+            # sliding-window draft KV. Reporting target common-prefix blocks
+            # while the draft group reports zero can enable cascade attention
+            # for only part of the hybrid execution. Prefix-cache reuse remains
+            # handled by find_longest_cache_hit(), where each group returns the
+            # concrete blocks it can safely replay (including draft tail blocks
+            # and null padding for evicted context).
+            return [0] * len(self.kv_cache_config.kv_cache_groups)
+        return super().get_num_common_prefix_blocks(running_request_id)
+
+    def _cache_hash_block_size(self, kv_cache_spec: KVCacheSpec) -> int:
+        """Return the token granularity used to hash this group's cache blocks.
+
+        DCP-sharded KV groups allocate/cache one scheduler-visible block per
+        DCP/PCP partition. Their block hash must therefore use the expanded
+        block size. DCP-replicated draft groups keep the model block size and
+        replay only their sliding-window tail.
+        """
+        block_size = kv_cache_spec.block_size
+        if (
+            self.dcp_world_size * self.pcp_world_size > 1
+            and not getattr(kv_cache_spec, "dcp_replicated", False)
+        ):
+            block_size *= self.dcp_world_size * self.pcp_world_size
+        return block_size
+
+    def _block_hashes_for_spec(
+        self, block_hashes: list[BlockHash], kv_cache_spec: KVCacheSpec
+    ) -> BlockHashList:
+        block_size = self._cache_hash_block_size(kv_cache_spec)
+        if block_size == self.hash_block_size:
+            return block_hashes
+        return BlockHashListWithBlockSize(
+            block_hashes, self.hash_block_size, block_size
+        )
 
     def cache_blocks(self, request: Request, num_computed_tokens: int) -> None:
         if self.disable_prefix_cache_for_dcp_hybrid:
@@ -678,13 +717,6 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
             )
             return blocks, 0
 
-        def _get_block_hashes(kv_cache_spec: KVCacheSpec) -> BlockHashList:
-            if kv_cache_spec.block_size == self.hash_block_size:
-                return block_hashes
-            return BlockHashListWithBlockSize(
-                block_hashes, self.hash_block_size, kv_cache_spec.block_size
-            )
-
         num_groups = len(self.kv_cache_config.kv_cache_groups)
         hit_length = max_cache_hit_length
         longest_hit_length = 0
@@ -726,7 +758,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                         curr_hit_length + spec.block_size, max_cache_hit_length
                     )
                 hit_blocks = manager_cls.find_longest_cache_hit(
-                    block_hashes=_get_block_hashes(spec),
+                    block_hashes=self._block_hashes_for_spec(block_hashes, spec),
                     max_length=_max_length,
                     kv_cache_group_ids=group_ids,
                     block_pool=self.block_pool,
@@ -736,7 +768,8 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                     dcp_world_size=self.dcp_world_size,
                     pcp_world_size=self.pcp_world_size,
                 )
-                _new_hit_length = len(hit_blocks[0]) * spec.block_size
+                effective_block_size = self._cache_hash_block_size(spec)
+                _new_hit_length = len(hit_blocks[0]) * effective_block_size
                 if drop_eagle_block:
                     eagle_verified.add(idx)
                 elif _new_hit_length < curr_hit_length:
@@ -757,7 +790,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
         # Truncate full attention blocks to final hit_length (if present)
         first_group = self.attention_groups[0]
         if isinstance(first_group.spec, FullAttentionSpec):
-            num_blocks = hit_length // first_group.spec.block_size
+            num_blocks = hit_length // self._cache_hash_block_size(first_group.spec)
             for group_id in first_group.group_ids:
                 if (blks := hit_blocks_by_group[group_id]) is not None:
                     del blks[num_blocks:]
@@ -780,20 +813,13 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
             (blocks_per_group, hit_lengths_per_group)
         """
 
-        def _get_block_hashes(kv_cache_spec: KVCacheSpec) -> BlockHashList:
-            if kv_cache_spec.block_size == self.hash_block_size:
-                return block_hashes
-            return BlockHashListWithBlockSize(
-                block_hashes, self.hash_block_size, kv_cache_spec.block_size
-            )
-
         num_groups = len(self.kv_cache_config.kv_cache_groups)
         hit_blocks: list[list[KVCacheBlock]] = [[] for _ in range(num_groups)]
         hit_lengths: list[int] = [0] * num_groups
 
         for spec, group_ids, manager_cls, use_eagle in self.attention_groups:
             blocks = manager_cls.find_longest_cache_hit(
-                block_hashes=_get_block_hashes(spec),
+                block_hashes=self._block_hashes_for_spec(block_hashes, spec),
                 max_length=max_cache_hit_length,
                 kv_cache_group_ids=group_ids,
                 block_pool=self.block_pool,
@@ -803,7 +829,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                 dcp_world_size=self.dcp_world_size,
                 pcp_world_size=self.pcp_world_size,
             )
-            group_hit = len(blocks[0]) * spec.block_size
+            group_hit = len(blocks[0]) * self._cache_hash_block_size(spec)
             for gid, blks in zip(group_ids, blocks):
                 hit_blocks[gid] = blks
                 hit_lengths[gid] = group_hit

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1663,10 +1663,11 @@ def _get_kv_cache_groups_uniform_groups(
     ]
 
     swa_mla_specs = grouped_specs[1:]
-    # Non-first groups are SWA-MLA (DeepseekV4) or full-attention dcp_replicated
-    # drafts (DFlash under DCP). Both are padded to MLA buckets identically.
+    # Non-first groups are SWA-MLA, full-attention dcp_replicated drafts, or
+    # sliding-window dcp_replicated drafts. All are padded to MLA buckets
+    # identically.
     assert all(
-        isinstance(spec, (SlidingWindowMLASpec, FullAttentionSpec))
+        isinstance(spec, (SlidingWindowMLASpec, FullAttentionSpec, SlidingWindowSpec))
         for group in swa_mla_specs
         for spec in group.kv_cache_specs.values()
     )

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -569,7 +569,10 @@ class FullAttentionManager(SingleTypeKVCacheManager):
             [] for _ in range(len(kv_cache_group_ids))
         )
         block_size = kv_cache_spec.block_size
-        if dcp_world_size * pcp_world_size > 1:
+        if (
+            dcp_world_size * pcp_world_size > 1
+            and not getattr(kv_cache_spec, "dcp_replicated", False)
+        ):
             block_size *= dcp_world_size * pcp_world_size
         max_num_blocks = max_length // block_size
         for block_hash in itertools.islice(block_hashes, max_num_blocks):
@@ -640,8 +643,12 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
         assert isinstance(kv_cache_spec, SlidingWindowSpec), (
             "SlidingWindowManager can only be used for sliding window groups"
         )
-        assert dcp_world_size == 1, "DCP not support sliding window attn now."
-        assert pcp_world_size == 1, "PCP not support sliding window attn now."
+        assert (
+            dcp_world_size == 1 or kv_cache_spec.dcp_replicated
+        ), "DCP only supports sliding-window KV when it is dcp_replicated."
+        assert (
+            pcp_world_size == 1 or kv_cache_spec.dcp_replicated
+        ), "PCP only supports sliding-window KV when it is dcp_replicated."
 
         # The number of contiguous blocks needed for a prefix cache hit.
         sliding_window_contiguous_blocks = cls._contiguous_blocks_for_hit(

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -498,6 +498,10 @@ class ChunkedLocalAttentionSpec(AttentionSpec):
 class SlidingWindowSpec(AttentionSpec):
     sliding_window: int
     head_size_v: int = None  # type: ignore[assignment]
+    # Replicate this window-bounded KV group on every DCP rank instead of
+    # sharding by token position. Used by DFlash drafts: the target verifies
+    # every token, while draft attention cannot reduce sharded KV across DCP.
+    dcp_replicated: bool = False
 
     def __post_init__(self):
         if self.head_size_v is None:
@@ -546,9 +550,10 @@ class SlidingWindowSpec(AttentionSpec):
         return cdiv(num_tokens, self.block_size) + 1
 
     def max_memory_usage_bytes(self, vllm_config: VllmConfig) -> int:
-        assert vllm_config.parallel_config.decode_context_parallel_size == 1, (
-            "DCP not support sliding window."
-        )
+        assert (
+            vllm_config.parallel_config.decode_context_parallel_size == 1
+            or self.dcp_replicated
+        ), "DCP only supports sliding-window KV when it is dcp_replicated."
         max_model_len = vllm_config.model_config.max_model_len
         max_num_batched_tokens = vllm_config.scheduler_config.max_num_batched_tokens
         max_blocks = self.max_admission_blocks_per_request(
@@ -562,6 +567,7 @@ class SlidingWindowSpec(AttentionSpec):
         return all(
             isinstance(spec, SlidingWindowSpec)
             and spec.sliding_window == self.sliding_window
+            and spec.dcp_replicated == self.dcp_replicated
             for spec in kv_cache_specs.values()
         )
 

--- a/vllm/v1/spec_decode/dflash.py
+++ b/vllm/v1/spec_decode/dflash.py
@@ -13,7 +13,10 @@ from vllm.triton_utils import triton
 from vllm.v1.attention.backend import CommonAttentionMetadata
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.spec_decode.llm_base_proposer import SpecDecodeBaseProposer
-from vllm.v1.spec_decode.utils import copy_and_expand_dflash_inputs_kernel
+from vllm.v1.spec_decode.utils import (
+    PADDING_SLOT_ID,
+    copy_and_expand_dflash_inputs_kernel,
+)
 
 logger = init_logger(__name__)
 
@@ -287,6 +290,7 @@ class DFlashProposer(SpecDecodeBaseProposer):
                 num_query_per_req=num_query_per_req,
                 num_speculative_tokens=self.num_speculative_tokens,
                 total_input_tokens=num_context,
+                PAD_SLOT_ID=PADDING_SLOT_ID,
                 BLOCK_SIZE=BLOCK_SIZE,
                 HAS_NUM_REJECTED=has_num_rejected,
             )

--- a/vllm/v1/spec_decode/utils.py
+++ b/vllm/v1/spec_decode/utils.py
@@ -485,6 +485,7 @@ def copy_and_expand_dflash_inputs_kernel(
     num_query_per_req,  # tl.int32
     num_speculative_tokens,  # tl.int32
     total_input_tokens,  # tl.int32
+    PAD_SLOT_ID: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
     HAS_NUM_REJECTED: tl.constexpr = False,
 ):
@@ -550,7 +551,11 @@ def copy_and_expand_dflash_inputs_kernel(
         other=0,
     ).to(tl.int64)
     slot = block_id * block_size + (positions % block_size)
-    tl.store(out_context_slot_mapping_ptr + ctx_pos_out, slot, mask=is_ctx)
+    # Sliding-window DFlash draft KV can evict old context positions and leave
+    # them mapped to the null block. Do not write those K/V rows into physical
+    # block 0; mark them as padding so the cache-write path skips them.
+    context_slot = tl.where(block_id != 0, slot, PAD_SLOT_ID)
+    tl.store(out_context_slot_mapping_ptr + ctx_pos_out, context_slot, mask=is_ctx)
     tl.store(out_query_slot_mapping_ptr + query_out, slot, mask=is_query)
 
     # --- Input IDs (query tokens only) ---

--- a/vllm/v1/worker/gpu/block_table.py
+++ b/vllm/v1/worker/gpu/block_table.py
@@ -182,6 +182,8 @@ class BlockTables:
             positions,
             self.block_table_ptrs,
             self.block_table_strides,
+            self.num_blocks.gpu,
+            self.num_blocks.gpu.stride(0),
             self.block_sizes_tensor,
             self.group_cp_sizes,
             self.slot_mappings,
@@ -245,6 +247,13 @@ def _gather_block_tables_kernel(
         block_ids = tl.load(src_row_ptr + offset, mask=offset < num_blocks)
         tl.store(dst_row_ptr + offset, block_ids, mask=offset < num_blocks)
 
+    # Active rows can shrink when sliding-window / replicated draft groups
+    # recycle old blocks or replay a cached prefix tail. Clear the unused tail
+    # so consumers never read stale block IDs past num_blocks.
+    for i in tl.range(num_blocks, max_num_blocks, BLOCK_SIZE):
+        offset = i + tl.arange(0, BLOCK_SIZE)
+        tl.store(dst_row_ptr + offset, 0, mask=offset < max_num_blocks)
+
 
 @triton.jit
 def _compute_slot_mappings_kernel(
@@ -254,6 +263,8 @@ def _compute_slot_mappings_kernel(
     pos,  # [num_tokens]
     block_table_ptrs,  # [num_kv_cache_groups]
     block_table_strides,  # [num_kv_cache_groups]
+    num_blocks_ptr,  # [num_kv_cache_groups, max_num_reqs]
+    num_blocks_stride,
     block_sizes,  # [num_kv_cache_groups]
     group_cp_sizes,  # [num_kv_cache_groups]
     slot_mappings_ptr,  # [num_kv_cache_groups, max_num_tokens]
@@ -282,20 +293,26 @@ def _compute_slot_mappings_kernel(
 
     block_table_ptr = _load_ptr(block_table_ptrs + group_id, tl.int32)
     block_table_stride = tl.load(block_table_strides + group_id)
+    group_num_blocks_ptr = num_blocks_ptr + group_id * num_blocks_stride
     block_size = tl.load(block_sizes + group_id)
     group_cp_size = tl.load(group_cp_sizes + group_id)
 
     req_state_idx = tl.load(idx_mapping + batch_idx)
+    num_blocks = tl.load(group_num_blocks_ptr + req_state_idx)
     start_idx = tl.load(query_start_loc + batch_idx)
     end_idx = tl.load(query_start_loc + batch_idx + 1)
     for i in range(start_idx, end_idx, TRITON_BLOCK_SIZE):
         offset = i + tl.arange(0, TRITON_BLOCK_SIZE)
-        positions = tl.load(pos + offset, mask=offset < end_idx, other=0)
+        token_mask = offset < end_idx
+        positions = tl.load(pos + offset, mask=token_mask, other=0)
 
         block_indices = positions // (block_size * group_cp_size)
         block_offsets = positions % (block_size * group_cp_size)
+        valid_block = token_mask & (block_indices < num_blocks)
         block_numbers = tl.load(
-            block_table_ptr + req_state_idx * block_table_stride + block_indices
+            block_table_ptr + req_state_idx * block_table_stride + block_indices,
+            mask=valid_block,
+            other=0,
         )
 
         if CP_SIZE == 1:
@@ -314,4 +331,5 @@ def _compute_slot_mappings_kernel(
                 slot_ids = block_numbers * block_size + local_offsets
                 slot_ids = tl.where(is_local, slot_ids, PAD_ID)
 
+        slot_ids = tl.where(valid_block, slot_ids, PAD_ID)
         tl.store(slot_mapping_ptr + offset, slot_ids, mask=offset < end_idx)

--- a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
@@ -516,7 +516,15 @@ def _prepare_dflash_inputs_kernel(
         mask=is_ctx,
         other=0,
     ).to(tl.int64)
-    ctx_slot = ctx_block_id * block_size + (ctx_pos % block_size)
+    # Sliding-window draft KV: old context positions can be evicted and point
+    # at the null block. Map those to PAD so the cache-write kernel skips them
+    # instead of clobbering physical block 0.
+    ctx_resident = is_ctx & (ctx_block_id != 0)
+    ctx_slot = tl.where(
+        ctx_resident,
+        ctx_block_id * block_size + (ctx_pos % block_size),
+        PAD_SLOT_ID,
+    )
     tl.store(out_context_positions_ptr + ctx_start + j, ctx_pos, mask=is_ctx)
     tl.store(out_context_slot_mapping_ptr + ctx_start + j, ctx_slot, mask=is_ctx)
 

--- a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
@@ -541,7 +541,15 @@ def _prepare_dflash_inputs_kernel(
         mask=is_query,
         other=0,
     ).to(tl.int64)
-    q_slot = q_block_id * block_size + (query_pos % block_size)
+    # Prefix-cache hits for DCP-replicated DFlash replay a resident
+    # sliding-window tail with null padding for evicted/global positions.
+    # Do not treat the null block as a real writable cache slot.
+    q_resident = is_query & (q_block_id != 0)
+    q_slot = tl.where(
+        q_resident,
+        q_block_id * block_size + (query_pos % block_size),
+        PAD_SLOT_ID,
+    )
 
     tl.store(out_input_ids_ptr + query_idx, input_id, mask=is_query)
     tl.store(out_query_positions_ptr + query_idx, query_pos, mask=is_query)

--- a/vllm/v1/worker/gpu/spec_decode/eagle/utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/eagle/utils.py
@@ -16,7 +16,10 @@ def _create_draft_vllm_config(vllm_config: VllmConfig) -> VllmConfig:
     import os as _os
 
     draft_parallel_config = speculative_config.draft_parallel_config
-    if _os.environ.get("VLLM_DCP_SHARD_DRAFT", "1").lower() in (
+    # Eagle draft models have their own attention configuration and may use
+    # GQA/MQA layouts that are invalid under the target model's DCP setting.
+    # Keep the draft at its native DCP unless explicitly requested.
+    if _os.environ.get("VLLM_DCP_SHARD_DRAFT", "0").lower() in (
         "1",
         "true",
         "yes",

--- a/vllm/v1/worker/gpu/spec_decode/eagle/utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/eagle/utils.py
@@ -16,10 +16,12 @@ def _create_draft_vllm_config(vllm_config: VllmConfig) -> VllmConfig:
     import os as _os
 
     draft_parallel_config = speculative_config.draft_parallel_config
-    # Eagle draft models have their own attention configuration and may use
-    # GQA/MQA layouts that are invalid under the target model's DCP setting.
-    # Keep the draft at its native DCP unless explicitly requested.
-    if _os.environ.get("VLLM_DCP_SHARD_DRAFT", "0").lower() in (
+    # External draft models (Eagle/Eagle3/DFlash) have their own attention
+    # layouts, so keep their native DCP unless explicitly requested. Native MTP
+    # layers are part of the target model path; under DCP they need the same
+    # sharded sparse-indexer buffers as the target.
+    default_shard_draft = "1" if speculative_config.method == "mtp" else "0"
+    if _os.environ.get("VLLM_DCP_SHARD_DRAFT", default_shard_draft).lower() in (
         "1",
         "true",
         "yes",


### PR DESCRIPTION
## Summary

This PR fixes the Kimi speculative-decoding DCP stack on the Eldritch branch. It supersedes the earlier narrow DFlash-only description by covering both DFlash and Eagle3 DCP startup/runtime issues.

Changes:
- include DCP in CUDA graph capture context so DCP-specific captured graphs do not replay with the wrong layout;
- keep DFlash target/draft KV prefix metadata DCP-safe, including prefix-cache block hashing/null-padding for replicated draft KV;
- keep Eagle3 draft DCP opt-in instead of inheriting the target DCP by default. Kimi Eagle3 draft models can use GQA/MQA layouts that fail vLLM DCP validation when the target's DCP size is blindly copied.

## Root Cause

DFlash under DCP has a target KV layout and a replicated draft KV layout. CUDA graph capture and prefix-cache metadata need to distinguish those layouts; otherwise DCP4/DCP8 can either replay the wrong graph or reuse invalid prefix-cache blocks.

Eagle3 uses a separate draft model config. Inheriting target `decode_context_parallel_size` into the Eagle draft made Kimi DCP4 fail during draft `VllmConfig` validation with:

```text
Assertion failed, tensor parallel size 8 must be greater than total num kv heads 64 when enable decode context parallel for GQA/MQA
```

The draft now stays at its native parallel config by default; explicit `VLLM_DCP_SHARD_DRAFT=1` remains an opt-in override for experiments.

## Validation

Static checks:
- `py_compile` for touched files;
- diff scan shows no newly introduced `.item()`, `.cpu()`, `torch.cuda.synchronize()`, or explicit GPU host-sync calls in the new DCP/prefix-cache changes.

Runtime checks on `voipmonitor/vllm:eldritch-final-va81d072-b12x284a2ea-kimi-dflash-prefixcache-cu132-20260627` plus this branch where noted:
- GLM TP8/DCP4/no-MTP/A16 B12X attention A/B: patched `62.1 tok/s` vs baseline `62.0 tok/s` at 0ctx; 32k `61.7` vs `61.8`; no CJK/errors.
- Kimi-K2.7-Code DFlash7 TP8 DCP1/2/4/8: short and 30k smoke coherent, CJK 0; cc1 decode `132.1 / 107.2 / 112.8 / 99.8 tok/s`.
- Kimi-K2.7-Code Eagle3 TP8/DCP1: load OK, short `220.1 tok/s`, 30k `197.8 tok/s`, cc1 decode `141.5 tok/s`, CJK 0.
- Kimi-K2.7-Code Eagle3 TP8/DCP4 failure reproduced without the Eagle fix; with draft DCP left native, load/inference OK, short `188.9 tok/s`, 30k `173.7 tok/s`, cc1 decode `116.2 tok/s`, CJK 0.

Clean final image built and pushed after `bfaa36b`:

```text
voipmonitor/vllm:eldritch-final-vbfaa36b-b12x284a2ea-kimi-specdcp-cu132-20260627
voipmonitor/vllm@sha256:8a1090eaf61aa7632403060ac5fda5a6ee4b34183f8d20fb04ee616edfa9d61e
```

Final clean-image DCP4 spot checks:
- Kimi-K2.7-Code DFlash7 TP8/DCP4: short smoke CJK 0, cc1 decode `112.8 tok/s`, KV budget `1,604,480`.
- Kimi-K2.7-Code Eagle3 TP8/DCP4: short and 30k smoke CJK 0, cc1 decode `115.3 tok/s`, KV budget `1,682,944`.

Artifacts:
- `/root/bench-results/dflash-prefixcache-ab-20260627/`
- `/root/bench-results/kimi27-dcp-prefixcache-clean-20260627/`
- `/root/bench-results/kimi27-eagle3-clean-20260627/`
- `/root/bench-results/kimi27-final-bfaa36b-20260627/`
