### PR TITLE
[eldritch] attention: support DCP in SM120 FlashInfer sparse MLA

### DIFF
--- a/vllm/v1/attention/backends/mla/flashinfer_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/flashinfer_mla_sparse.py
@@ -325,19 +325,32 @@ class FlashInferMLASparseMetadataBuilder(
         )
 
 
-# Global workspace buffer (lazily initialized)
-_fi_sparse_workspace: torch.Tensor | None = None
+# Global FlashInfer sparse-MLA workspaces, one per CUDA device.
+#
+# vLLM workers are single-device in normal serving, but tests and warmup helpers
+# can construct this backend on different CUDA devices in one process. Keying
+# the scratch buffer by device avoids reusing a tensor allocated on another GPU.
+_fi_sparse_workspace_by_device: dict[torch.device, torch.Tensor] = {}
+
+
+def _normalize_workspace_device(device: torch.device) -> torch.device:
+    device = torch.device(device)
+    if device.type == "cuda" and device.index is None:
+        device = torch.device(f"cuda:{torch.cuda.current_device()}")
+    return device
 
 
 def _get_workspace_buffer(device: torch.device) -> torch.Tensor:
-    global _fi_sparse_workspace
-    if _fi_sparse_workspace is None:
-        _fi_sparse_workspace = torch.zeros(
+    device = _normalize_workspace_device(device)
+    workspace = _fi_sparse_workspace_by_device.get(device)
+    if workspace is None:
+        workspace = torch.zeros(
             FLASHINFER_MLA_SPARSE_WORKSPACE_BUFFER_SIZE,
             dtype=torch.uint8,
             device=device,
         )
-    return _fi_sparse_workspace
+        _fi_sparse_workspace_by_device[device] = workspace
+    return workspace
 
 
 class FlashInferMLASparseImpl(SparseMLAAttentionImpl[FlashInferMLASparseMetadata]):

--- a/vllm/v1/attention/backends/mla/flashinfer_mla_sparse_sm120.py
+++ b/vllm/v1/attention/backends/mla/flashinfer_mla_sparse_sm120.py
@@ -16,6 +16,7 @@ from vllm.v1.attention.backends.mla.flashinfer_mla_sparse import (
     _get_workspace_buffer,
 )
 from vllm.v1.attention.backends.mla.sparse_utils import (
+    triton_convert_dcp_global_index_to_local_index,
     triton_convert_req_index_to_global_index,
 )
 
@@ -31,6 +32,8 @@ def _kv_scale_format_for_model(model_type: str | None) -> str:
 
 class FlashInferMLASparseSM120Impl(SparseMLAAttentionImpl[FlashInferMLASparseMetadata]):
     """SM120 FlashInfer sparse-MLA implementation."""
+
+    can_return_lse_for_decode: bool = True
 
     def __init__(
         self,
@@ -100,7 +103,38 @@ class FlashInferMLASparseSM120Impl(SparseMLAAttentionImpl[FlashInferMLASparseMet
         assert self.topk_indices_buffer is not None
 
         self.supports_quant_query_input = False
-        self._workspace_buffer: torch.Tensor | None = None
+        self.supports_dcp_quant_query_input = False
+
+        parallel_config = vllm_config.parallel_config
+        self.pcp_world_size = 1
+        self.pcp_rank = 0
+        self.dcp_world_size = int(parallel_config.decode_context_parallel_size)
+        self.dcp_rank = 0
+        if self.dcp_world_size > 1:
+            from vllm.distributed.parallel_state import get_dcp_group
+
+            dcp_group = get_dcp_group()
+            self.dcp_rank = dcp_group.rank_in_group
+            if dcp_group.world_size != self.dcp_world_size:
+                raise RuntimeError(
+                    "FLASHINFER_MLA_SPARSE_SM120 DCP group size "
+                    f"{dcp_group.world_size} does not match configured "
+                    f"decode_context_parallel_size={self.dcp_world_size}"
+                )
+        self.total_cp_world_size = self.pcp_world_size * self.dcp_world_size
+        self.total_cp_rank = self.pcp_rank * self.dcp_world_size + self.dcp_rank
+        self.cp_kv_cache_interleave_size = (
+            parallel_config.cp_kv_cache_interleave_size
+        )
+        self.need_to_return_lse_for_decode = self.dcp_world_size > 1
+
+        # Allocate before memory profiling so KV sizing accounts for FlashInfer's
+        # TRTLLM sparse MLA scratch instead of discovering it at first decode.
+        if torch.cuda.is_available():
+            device = torch.device(f"cuda:{torch.cuda.current_device()}")
+            self._workspace_buffer: torch.Tensor | None = _get_workspace_buffer(device)
+        else:
+            self._workspace_buffer = None
 
     def forward_mqa(
         self,
@@ -113,24 +147,49 @@ class FlashInferMLASparseSM120Impl(SparseMLAAttentionImpl[FlashInferMLASparseMet
             q = torch.cat(q, dim=-1)
 
         num_actual_toks = q.shape[0]
+        num_actual_heads = q.shape[1]
 
         assert self.topk_indices_buffer is not None
         topk_indices = self.topk_indices_buffer[:num_actual_toks]
 
-        topk_indices_physical = cast(
-            torch.Tensor,
-            triton_convert_req_index_to_global_index(
-                attn_metadata.req_id_per_token[:num_actual_toks],
-                attn_metadata.block_table,
-                topk_indices,
-                BLOCK_SIZE=attn_metadata.block_size,
-                NUM_TOPK_TOKENS=topk_indices.shape[1],
-            ),
-        )
+        if self.dcp_world_size > 1:
+            seq_lens = torch.empty(
+                num_actual_toks, dtype=torch.int32, device=q.device
+            )
+            topk_indices_physical, seq_lens = (
+                triton_convert_dcp_global_index_to_local_index(
+                    attn_metadata.req_id_per_token[:num_actual_toks],
+                    attn_metadata.block_table,
+                    topk_indices,
+                    dcp_world_size=self.dcp_world_size,
+                    dcp_rank=self.dcp_rank,
+                    cp_kv_cache_interleave_size=self.cp_kv_cache_interleave_size,
+                    BLOCK_SIZE=attn_metadata.block_size,
+                    NUM_TOPK_TOKENS=topk_indices.shape[1],
+                    valid_counts=seq_lens,
+                )
+            )
+        else:
+            topk_indices_physical = cast(
+                torch.Tensor,
+                triton_convert_req_index_to_global_index(
+                    attn_metadata.req_id_per_token[:num_actual_toks],
+                    attn_metadata.block_table,
+                    topk_indices,
+                    BLOCK_SIZE=attn_metadata.block_size,
+                    NUM_TOPK_TOKENS=topk_indices.shape[1],
+                ),
+            )
+            seq_lens = None
 
         output = q.new_empty(
-            (num_actual_toks, self.num_heads, self.kv_lora_rank),
+            (num_actual_toks, num_actual_heads, self.kv_lora_rank),
             dtype=q.dtype,
+        )
+        lse = (
+            q.new_empty((num_actual_toks, num_actual_heads), dtype=torch.float32)
+            if self.need_to_return_lse_for_decode
+            else None
         )
 
         if self._workspace_buffer is None:
@@ -140,7 +199,7 @@ class FlashInferMLASparseSM120Impl(SparseMLAAttentionImpl[FlashInferMLASparseMet
             flashinfer_trtllm_batch_decode_with_kv_cache_mla,
         )
 
-        out = flashinfer_trtllm_batch_decode_with_kv_cache_mla(
+        ret = flashinfer_trtllm_batch_decode_with_kv_cache_mla(
             query=q.unsqueeze(1),
             kv_cache=kv_c_and_k_pe_cache.view(torch.uint8).unsqueeze(1),
             workspace_buffer=self._workspace_buffer,
@@ -148,12 +207,22 @@ class FlashInferMLASparseSM120Impl(SparseMLAAttentionImpl[FlashInferMLASparseMet
             kv_lora_rank=self.kv_lora_rank,
             qk_rope_head_dim=self.qk_rope_head_dim,
             block_tables=topk_indices_physical.unsqueeze(1),
-            seq_lens=None,
+            seq_lens=seq_lens,
             max_seq_len=attn_metadata.topk_tokens,
             out=output.unsqueeze(1),
             bmm1_scale=self.scale,
             bmm2_scale=1.0,
             sparse_mla_top_k=attn_metadata.topk_tokens,
             kv_scale_format=self.kv_scale_format,
+            lse=None if lse is None else lse.unsqueeze(1),
+            return_lse=self.need_to_return_lse_for_decode,
         )
-        return out.squeeze(1), None
+        if not self.need_to_return_lse_for_decode:
+            return ret.squeeze(1), None
+        if isinstance(ret, tuple):
+            out, lse = ret
+        else:
+            out = ret
+            assert lse is not None
+        lse = lse.reshape(num_actual_toks, -1)[:, :num_actual_heads].contiguous()
+        return out.squeeze(1), lse

--- a/vllm/v1/worker/gpu/warmup.py
+++ b/vllm/v1/worker/gpu/warmup.py
@@ -45,15 +45,34 @@ def run_mixed_prefill_decode_warmup(
 
     decode_req_id = f"{req_id_prefix}_decode_"
     prefill_req_id = f"{req_id_prefix}_prefill_"
-    decode_prompt_len = 2
     decode_scheduled_tokens = 1
-    prefill_len = num_tokens - decode_scheduled_tokens
-    decode_token_ids = list(range(decode_prompt_len))
-    prefill_token_ids = list(range(prefill_len))
 
     kv_cache_groups = model_runner.kv_cache_config.kv_cache_groups
     num_kv_cache_groups = len(kv_cache_groups)
     group_block_sizes = [g.kv_cache_spec.block_size for g in kv_cache_groups]
+
+    # Under DCP, the sparse decode kernels expect every DCP rank to have a
+    # non-empty local KV range. A two-token synthetic decode prompt can occupy
+    # only the first cache block, leaving later DCP ranks with zero local slots
+    # during mixed prefill+decode autotune. Span one block per DCP rank so the
+    # warmup exercises a valid DCP decode shape.
+    dcp_size = max(1, getattr(model_runner, "dcp_size", 1))
+    cp_interleave = max(1, getattr(model_runner, "cp_interleave", 1))
+    min_dcp_decode_prompt_len = max(group_block_sizes) * dcp_size * cp_interleave
+    decode_prompt_len = max(2, min_dcp_decode_prompt_len)
+    if decode_prompt_len > model_runner.scheduler_config.max_num_batched_tokens:
+        logger.warning(
+            "Skipping V2 mixed prefill+decode warmup because DCP decode prompt "
+            "length %d exceeds max_num_batched_tokens=%d.",
+            decode_prompt_len,
+            model_runner.scheduler_config.max_num_batched_tokens,
+        )
+        return False
+
+    prefill_len = num_tokens - decode_scheduled_tokens
+    decode_token_ids = list(range(decode_prompt_len))
+    prefill_token_ids = list(range(prefill_len))
+
     decode_prefill_block_counts = [
         cdiv(decode_prompt_len, block_size) for block_size in group_block_sizes
     ]


### PR DESCRIPTION
## Summary

This is a cleaned-up SM120 FlashInfer sparse-MLA DCP patch for the Eldritch release branch (`codex/eldritch-enlightenment-release-20260627`). It makes `FLASHINFER_MLA_SPARSE_SM120` usable with `--decode-context-parallel-size > 1` without carrying the unrelated B12X hybrid/debug experiments from earlier overlays.

The PR touches only the FlashInfer sparse MLA path plus one generic warmup shape guard needed for DCP production launches:

- keep one FlashInfer sparse-MLA scratch buffer per CUDA device instead of one process-global tensor;
- initialize the SM120 backend's DCP/CP bookkeeping from vLLM parallel config;
- convert global sparse top-k token ids to this DCP rank's local physical KV slots;
- pass per-token valid counts as `seq_lens` to the FlashInfer SM120 launcher;
- request and return decode softmax LSE so the common MLA DCP merge can reduce partial attention results;
- make mixed prefill+decode warmup use a DCP-valid synthetic decode prompt, so production `max_num_seqs > 1` launches do not autotune invalid zero-local-KV DCP shapes.

No B12X binding, arena, workspace, or kernel path is changed here. The B12X sparse MLA implementation was used only as the behavioral reference for DCP index conversion and LSE return semantics.

## Why

Before this change, `FLASHINFER_MLA_SPARSE_SM120` was effectively DCP1-only. Under DCP, the common MLA attention layer requires each backend to return decode softmax LSE so the partial results from DCP ranks can be merged correctly. The SM120 FlashInfer backend returned `(out, None)`, so DCP serving had to use `B12X_MLA_SPARSE` even when the SM120 FlashInfer sparse decode kernel was faster.

The SM120 FlashInfer launcher already supports returning LSE. The missing pieces were the vLLM-side DCP index mapping, valid-count plumbing, head/LSE buffer sizing after DCP query gather, and per-device scratch allocation that is visible during memory profiling.

A second issue showed up only in production-style launches. `run_mixed_prefill_decode_warmup()` used a two-token synthetic decode prompt. With DCP sparse decode, that prompt can occupy only the first cache block and leave later DCP ranks with an empty local KV range. The warmup then autotunes an invalid DCP shape and can corrupt startup. The fix mirrors the existing DCP warmup constraint: span at least one KV block per DCP rank for the synthetic decode request.

## Implementation Notes

The global-to-local DCP mapping reuses `triton_convert_dcp_global_index_to_local_index`, keeping the sparse top-k contract aligned with the existing DCP-capable sparse MLA implementation.

The SM120 path sizes output and LSE buffers from the runtime query head count (`q.shape[1]`) rather than the constructor's local `num_heads`, because DCP decode can present a query tensor whose head dimension has already been gathered across DCP ranks.

The FlashInfer scratch buffer is still caller scratch for the FlashInfer launcher, but it is keyed by CUDA device and allocated during backend initialization. This avoids cross-device tensor reuse and avoids first-decode lazy allocation after vLLM has already sized KV cache.

## Validation

Validated on 8x RTX PRO 6000 / SM120 with GLM-5.2 NVFP4, TP8/DCP2 and TP8/DCP4, MTP off, `--attention-backend FLASHINFER_MLA_SPARSE_SM120`, `--moe-backend b12x`, `--kv-cache-dtype fp8`, V2 runner.

Static checks:

```bash
python3 -m py_compile \
  vllm/v1/attention/backends/mla/flashinfer_mla_sparse.py \
  vllm/v1/attention/backends/mla/flashinfer_mla_sparse_sm120.py \
  vllm/v1/worker/gpu/warmup.py
```

Debug/smoke validation, TP8/DCP4, `max_num_seqs=1`, graph cap 4:

```text
python3 /mnt/test.py --port 5966 -L
11 iterations before timeout interrupt
8746 completion tokens
CJK: 0
average generation-only throughput: 67.07 tok/s
average incl. TTFT throughput: 65.98 tok/s
```

Production-start validation, TP8/DCP2, `max_num_seqs=32`, graph cap 4:

- startup completes with `Application startup complete`;
- KV cache size: `1,357,696 tokens`;
- mixed prefill+decode autotune completes without the previous cublas/NCCL illegal-address cascade;
- short smoke produces coherent Python, CJK `0`, generation-only throughput around `67.4 tok/s`.

Observed startup/log checks:

- `Using V2 Model Runner`
- `Using AttentionBackendEnum.FLASHINFER_MLA_SPARSE_SM120 backend`
- `Using 'B12X' NvFp4 MoE backend`
- TP all-reduce uses `['B12X_PCIE_ONESHOT', 'PYNCCL']` for decode-sized tensors; DCP/EP groups remain PyNCCL.

The stored B12X DCP4/no-MTP reference for the same GLM recipe is about `62.3 tok/s`, so the SM120 path is consistently faster on the coding smoke while preserving coherent output.

## Scope / Limitations

This validates the `ag_rs` DCP flow used on our PCIe SM120 machines. I did not claim `a2a` coverage here.

The path assumes the same sparse MLA prerequisites already required by the backend: packed `fp8_ds_mla` KV cache layout, a FlashInfer build with the SM120 sparse MLA decode API, and a global top-k sparse indexer contract that can be mapped to local DCP KV slots.