### PR TITLE
[dspark] Add DeepSeek V4 DSpark speculative decoding

### DIFF
--- a/tests/v1/spec_decode/test_dspark.py
+++ b/tests/v1/spec_decode/test_dspark.py
@@ -1,0 +1,130 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import json
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.config import SpeculativeConfig
+from vllm.models.deepseek_v4.nvidia.dspark import (
+    _build_dspark_topk_idxs,
+    _read_dspark_num_layers,
+)
+from vllm.v1.worker.gpu.spec_decode.dspark.utils import _get_target_layer_ids
+
+
+def _spec_config(method: str) -> SpeculativeConfig:
+    config = object.__new__(SpeculativeConfig)
+    config.method = method
+    config.draft_model_config = None
+    return config
+
+
+def _compute_dspark_hash(layer_ids: list[int]) -> str:
+    config = _spec_config("dspark")
+    config.draft_model_config = SimpleNamespace(
+        hf_config=SimpleNamespace(dspark_target_layer_ids=layer_ids)
+    )
+    return config.compute_hash()
+
+
+def test_dspark_compile_hash_uses_target_layer_ids():
+    base_hash = _compute_dspark_hash([40, 41, 42])
+    same_hash = _compute_dspark_hash([40, 41, 42])
+    different_hash = _compute_dspark_hash([39, 40, 41])
+
+    assert base_hash == same_hash
+    assert base_hash != different_hash
+
+
+def test_dspark_does_not_require_eagle_prefix_cache_drop():
+    assert _spec_config("dspark").use_eagle()
+    assert not _spec_config("dspark").requires_eagle_cache_drop()
+    assert _spec_config("eagle3").requires_eagle_cache_drop()
+
+
+def test_dspark_target_layer_ids_from_config():
+    config = _spec_config("dspark")
+    config.draft_model_config = SimpleNamespace(
+        hf_config=SimpleNamespace(dspark_target_layer_ids=[40, 41, 42])
+    )
+
+    assert _get_target_layer_ids(config) == (40, 41, 42)
+
+
+def test_dspark_target_layer_ids_from_env(monkeypatch):
+    config = _spec_config("dspark")
+    monkeypatch.setenv("VLLM_DSPARK_TARGET_LAYER_IDS", "1, 3,5")
+
+    assert _get_target_layer_ids(config) == (1, 3, 5)
+
+
+def test_dspark_target_layer_ids_reject_invalid_env(monkeypatch):
+    config = _spec_config("dspark")
+    monkeypatch.setenv("VLLM_DSPARK_TARGET_LAYER_IDS", "40,nope,42")
+
+    with pytest.raises(RuntimeError, match="comma-separated integers"):
+        _get_target_layer_ids(config)
+
+
+def test_read_dspark_num_layers_prefers_inference_config(tmp_path):
+    inference_dir = tmp_path / "inference"
+    inference_dir.mkdir()
+    (inference_dir / "config.json").write_text(
+        json.dumps({"n_mtp_layers": 3}),
+        encoding="utf-8",
+    )
+
+    assert _read_dspark_num_layers(str(tmp_path), default=1) == 3
+
+
+def test_read_dspark_num_layers_falls_back_to_safetensors_index(tmp_path):
+    (tmp_path / "model.safetensors.index.json").write_text(
+        json.dumps(
+            {
+                "weight_map": {
+                    "model.layers.0.weight": "model-00001.safetensors",
+                    "mtp.0.block.weight": "model-00002.safetensors",
+                    "mtp.2.block.weight": "model-00003.safetensors",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert _read_dspark_num_layers(str(tmp_path), default=1) == 3
+
+
+def test_read_dspark_num_layers_uses_default_without_metadata(tmp_path):
+    assert _read_dspark_num_layers(str(tmp_path), default=1) == 1
+
+
+def test_build_dspark_topk_idxs_uses_rolling_target_window_then_draft_block():
+    positions = torch.tensor([0, 2], dtype=torch.int64)
+
+    idxs = _build_dspark_topk_idxs(
+        window_size=4,
+        batch_size=2,
+        block_size=3,
+        positions=positions,
+        device=torch.device("cpu"),
+    )
+
+    expected = torch.tensor(
+        [
+            [
+                [0, -1, -1, -1, 4, 5, 6],
+                [0, -1, -1, -1, 4, 5, 6],
+                [0, -1, -1, -1, 4, 5, 6],
+            ],
+            [
+                [0, 1, 2, -1, 4, 5, 6],
+                [0, 1, 2, -1, 4, 5, 6],
+                [0, 1, 2, -1, 4, 5, 6],
+            ],
+        ],
+        dtype=torch.int32,
+    )
+    torch.testing.assert_close(idxs, expected)

--- a/tests/v1/spec_decode/test_dspark.py
+++ b/tests/v1/spec_decode/test_dspark.py
@@ -9,6 +9,7 @@ import torch
 
 from vllm.config import SpeculativeConfig
 from vllm.models.deepseek_v4.nvidia.dspark import (
+    DeepSeekV4DSparkLayer,
     _build_dspark_topk_idxs,
     _read_dspark_num_layers,
 )
@@ -128,3 +129,71 @@ def test_build_dspark_topk_idxs_uses_rolling_target_window_then_draft_block():
         dtype=torch.int32,
     )
     torch.testing.assert_close(idxs, expected)
+
+
+def test_dspark_b12x_output_projection_uses_attention_helper():
+    layer = object.__new__(DeepSeekV4DSparkLayer)
+    layer.prefix = "model.layers.40"
+
+    class GenericWoB:
+        def __call__(self, x):
+            raise AssertionError("DSpark should not call generic wo_b in B12X mode")
+
+    out = torch.arange(12, dtype=torch.bfloat16).view(2, 2, 3)
+    draft_positions = torch.tensor([[11, 12]], dtype=torch.int64)
+    fused_out = torch.arange(8, dtype=torch.bfloat16).view(2, 4)
+    calls = {}
+
+    class B12xAttention:
+        _use_b12x_wo = True
+        hidden_size = 4
+        wo_b = GenericWoB()
+
+        def _apply_b12x_wo_projection(
+            self,
+            o,
+            positions,
+            *,
+            o_storage=None,
+            o_storage_offset=0,
+            o_stride_0=0,
+            o_stride_1=0,
+            o_stride_2=0,
+        ):
+            calls["args"] = (
+                o,
+                positions,
+                o_storage,
+                o_storage_offset,
+                o_stride_0,
+                o_stride_1,
+                o_stride_2,
+            )
+            return fused_out
+
+    layer.attn = B12xAttention()
+
+    projected = layer._dspark_output_projection(
+        out,
+        draft_positions,
+        batch_size=1,
+        block_size=2,
+        hidden_size=4,
+        start_pos=10,
+    )
+
+    torch.testing.assert_close(projected, fused_out.view(1, 2, 4))
+    (
+        o,
+        positions,
+        o_storage,
+        o_storage_offset,
+        o_stride_0,
+        o_stride_1,
+        o_stride_2,
+    ) = calls["args"]
+    assert o is out
+    assert o_storage is out
+    assert o_storage_offset == out.storage_offset()
+    assert (o_stride_0, o_stride_1, o_stride_2) == out.stride()
+    torch.testing.assert_close(positions, torch.tensor([11, 12], dtype=torch.int64))

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -470,9 +470,7 @@ class SpeculativeConfig:
                                     if not _quant_config_targets_prefix(
                                         quant_config, module_prefix
                                     ):
-                                        _extend_unique(
-                                            ignored, [f"{module_prefix}*"]
-                                        )
+                                        _extend_unique(ignored, [f"{module_prefix}*"])
                             else:
                                 if _quant_config_targets_prefix(quant_config, prefix):
                                     continue

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -149,8 +149,14 @@ MTPModelTypes = Literal[
 ]
 NgramGPUTypes = Literal["ngram_gpu"]
 DFlashModelTypes = Literal["dflash"]
+DSparkModelTypes = Literal["dspark"]
 EagleModelTypes = Literal[
-    "eagle", "eagle3", "extract_hidden_states", MTPModelTypes, DFlashModelTypes
+    "eagle",
+    "eagle3",
+    "extract_hidden_states",
+    MTPModelTypes,
+    DFlashModelTypes,
+    DSparkModelTypes,
 ]
 SpeculativeMethod = Literal[
     "ngram",
@@ -388,6 +394,7 @@ class SpeculativeConfig:
             "eagle3",
             "extract_hidden_states",
             "dflash",
+            "dspark",
         )
         factors.append(uses_aux_hidden_states)
 
@@ -406,6 +413,12 @@ class SpeculativeConfig:
                     layer_ids = [
                         i + 1 for i in dflash_config.get("target_layer_ids", [])
                     ]
+            if not layer_ids:
+                layer_ids = getattr(
+                    self.draft_model_config.hf_config,
+                    "dspark_target_layer_ids",
+                    None,
+                )
             if layer_ids is not None:
                 # Convert to tuple to make it hashable
                 factors.append(tuple(layer_ids))
@@ -764,6 +777,15 @@ class SpeculativeConfig:
                 # --quantization fp8 with a bf16 checkpoint.
                 if not self.quantization:
                     self.quantization = self.target_model_config.quantization
+            elif self.method == "dspark":
+                if self.target_model_config is None:
+                    raise ValueError("target_model_config must be present for dspark")
+                # DeepSeek V4 DSpark ships the draft module inside the target
+                # checkpoint under the mtp.* namespace. It is not the serial MTP
+                # architecture, so it is routed to its own speculator below.
+                self.model = self.target_model_config.model
+                if not self.quantization:
+                    self.quantization = self.target_model_config.quantization
             elif self.method in ("ngram", "[ngram]"):
                 self.model = "ngram"
             elif self.method == "ngram_gpu":
@@ -891,7 +913,7 @@ class SpeculativeConfig:
                 )
 
                 # Automatically detect the method
-                if self.method in ("eagle", "eagle3", "dflash"):
+                if self.method in ("eagle", "eagle3", "dflash", "dspark"):
                     pass
                 # examples:
                 # yuhuili/EAGLE-LLaMA3-Instruct-8B
@@ -903,6 +925,8 @@ class SpeculativeConfig:
                     self.method = "eagle3"
                 elif "dflash" in self.draft_model_config.model.lower():
                     self.method = "dflash"
+                elif "dspark" in self.draft_model_config.model.lower():
+                    self.method = "dspark"
                 elif self.draft_model_config.hf_config.model_type == "medusa":
                     self.method = "medusa"
                 elif self.draft_model_config.hf_config.model_type == "mlp_speculator":
@@ -951,6 +975,15 @@ class SpeculativeConfig:
 
                 if self.method == "dflash":
                     self.parallel_drafting = True
+                elif self.method == "dspark":
+                    self.parallel_drafting = True
+                    block_size = getattr(
+                        self.draft_model_config.hf_config,
+                        "dspark_block_size",
+                        None,
+                    )
+                    if self.num_speculative_tokens is None and block_size:
+                        self.num_speculative_tokens = int(block_size)
 
                 if self.num_speculative_tokens is not None and hasattr(
                     self.draft_model_config.hf_config, "num_lookahead_tokens"
@@ -1296,14 +1329,17 @@ class SpeculativeConfig:
         )
 
     def use_eagle(self) -> bool:
-        return self.method in ("eagle", "eagle3", "mtp", "dflash")
+        return self.method in ("eagle", "eagle3", "mtp", "dflash", "dspark")
 
     def requires_eagle_cache_drop(self) -> bool:
         """Whether prefix cache hits must drop one block for hidden states."""
-        return self.use_eagle() and not self.use_dflash()
+        return self.use_eagle() and not (self.use_dflash() or self.use_dspark())
 
     def use_dflash(self) -> bool:
         return self.method == "dflash"
+
+    def use_dspark(self) -> bool:
+        return self.method == "dspark"
 
     def uses_dynamic_speculative_decoding(self) -> bool:
         return self.num_speculative_tokens_per_batch_size is not None

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -2054,7 +2054,13 @@ class VllmConfig:
             # TODO: ngram / ngram_gpu are not supported by the v2 model runner yet
             if speculative_config.method in ("ngram", "ngram_gpu"):
                 unsupported.append("ngram/ngram_gpu speculative decoding")
-            elif speculative_config.method not in ("eagle", "eagle3", "mtp", "dflash"):
+            elif speculative_config.method not in (
+                "eagle",
+                "eagle3",
+                "mtp",
+                "dflash",
+                "dspark",
+            ):
                 unsupported.append(f"speculative method '{speculative_config.method}'")
 
             if speculative_config.uses_dynamic_speculative_decoding():
@@ -2065,7 +2071,7 @@ class VllmConfig:
             # whole block in one pass.
             if (
                 speculative_config.parallel_drafting
-                and speculative_config.method != "dflash"
+                and speculative_config.method not in ("dflash", "dspark")
             ):
                 unsupported.append("parallel drafting for EAGLE speculative decoding")
 

--- a/vllm/model_executor/warmup/deepseek_v4_mhc_warmup.py
+++ b/vllm/model_executor/warmup/deepseek_v4_mhc_warmup.py
@@ -66,6 +66,9 @@ def _select_mhc_warmup_token_sizes(
     *,
     max_tokens: int,
     cudagraph_capture_sizes: list[int],
+    hidden_size: int,
+    hc_mult: int,
+    num_sms: int,
 ) -> list[int]:
     if max_tokens <= 0:
         return []
@@ -74,6 +77,18 @@ def _select_mhc_warmup_token_sizes(
     candidates = list(_DEFAULT_TOKEN_SIZE_CANDIDATES)
     candidates.extend(cudagraph_capture_sizes)
     candidates.append(max_auto_tokens)
+    last_split = None
+    for grid_size in range(1, cdiv(max_auto_tokens, 64) + 1):
+        size = (grid_size - 1) * 64 + 1
+        split = _compute_mhc_pre_num_split(
+            num_tokens=size,
+            hidden_size=hidden_size,
+            hc_mult=hc_mult,
+            num_sms=num_sms,
+        )
+        if split != last_split:
+            candidates.append(size)
+            last_split = split
     return _normalize_token_sizes(candidates, max_tokens=max_auto_tokens)
 
 
@@ -225,9 +240,15 @@ def deepseek_v4_mhc_warmup(
         return
 
     deepseek_model = _find_deepseek_v4_model(model)
+    hidden_size = int(layer.hidden_size)
+    hc_mult = int(layer.hc_mult)
+    num_sms = torch.cuda.get_device_properties(device).multi_processor_count
     token_sizes = _select_mhc_warmup_token_sizes(
         max_tokens=max_tokens,
         cudagraph_capture_sizes=cudagraph_capture_sizes or [],
+        hidden_size=hidden_size,
+        hc_mult=hc_mult,
+        num_sms=num_sms,
     )
     if not token_sizes:
         return

--- a/vllm/model_executor/warmup/flashinfer_sparse_mla_warmup.py
+++ b/vllm/model_executor/warmup/flashinfer_sparse_mla_warmup.py
@@ -82,6 +82,31 @@ def _uses_v2_model_runner(runner: "GPUModelRunner") -> bool:
     return bool(getattr(vllm_config, "use_v2_model_runner", False))
 
 
+def _warmup_deepseek_v4_prefill_metadata(worker: "Worker") -> None:
+    if not current_platform.is_cuda():
+        return
+
+    runner = worker.model_runner
+    hf_config = getattr(runner.model_config, "hf_config", None)
+    window_size = int(getattr(hf_config, "sliding_window", 4096) or 4096)
+    max_num_prefills = int(worker.scheduler_config.max_num_seqs)
+
+    from vllm.v1.attention.backends.mla.sparse_swa import (
+        warmup_deepseek_v4_prefill_metadata_kernel,
+    )
+
+    launches = warmup_deepseek_v4_prefill_metadata_kernel(
+        runner.device,
+        max_num_prefills=max_num_prefills,
+        window_size=window_size,
+    )
+    if launches:
+        logger.info(
+            "Warmed up DeepSeek V4 prefill metadata kernel with %d launches.",
+            launches,
+        )
+
+
 def _run_flashinfer_sparse_mla_decode_autotune(
     worker: "Worker",
     num_tokens: int,
@@ -234,6 +259,7 @@ def deepseek_v4_sparse_mla_attention_warmup(worker: "Worker") -> None:
         "Warming up DeepSeek V4 sparse MLA attention for mixed tokens=%s.",
         mixed_tokens,
     )
+    _warmup_deepseek_v4_prefill_metadata(worker)
     mixed_warmup_done = _deepseek_v4_sparse_mla_decode_autotune(worker, mixed_tokens)
     if not mixed_warmup_done:
         if _uses_v2_model_runner(runner):

--- a/vllm/model_executor/warmup/kernel_warmup.py
+++ b/vllm/model_executor/warmup/kernel_warmup.py
@@ -121,6 +121,13 @@ def _uses_flashinfer_compute_kernels(worker: "Worker") -> bool:
 
 
 def kernel_warmup(worker: "Worker"):
+    mhc_warmup_token_sizes = list(
+        worker.vllm_config.compilation_config.cudagraph_capture_sizes or []
+    )
+    max_num_scheduled_tokens = worker.scheduler_config.max_num_scheduled_tokens
+    if max_num_scheduled_tokens is not None:
+        mhc_warmup_token_sizes.append(max_num_scheduled_tokens)
+
     # DSv4 mHC kernels run every decoder layer per token; warm them across
     # token sizes first so the first real request doesn't pay JIT cost. No-op
     # for non-DSv4 models (gated inside); still warms the boundary TileLang
@@ -128,9 +135,7 @@ def kernel_warmup(worker: "Worker"):
     deepseek_v4_mhc_warmup(
         worker.get_model(),
         max_tokens=worker.scheduler_config.max_num_batched_tokens,
-        cudagraph_capture_sizes=(
-            worker.vllm_config.compilation_config.cudagraph_capture_sizes or []
-        ),
+        cudagraph_capture_sizes=mhc_warmup_token_sizes,
     )
 
     # Run next so input-prep kernels JIT against pristine runner state.

--- a/vllm/models/deepseek_v4/attention.py
+++ b/vllm/models/deepseek_v4/attention.py
@@ -190,6 +190,8 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
         # in the compress ratio list
         if layer_id < config.num_hidden_layers:
             self.compress_ratio = max(1, config.compress_ratios[layer_id])
+        elif layer_id < len(config.compress_ratios):
+            self.compress_ratio = config.compress_ratios[layer_id]
         else:
             self.compress_ratio = 1
         self.eps = config.rms_norm_eps

--- a/vllm/models/deepseek_v4/common/rope.py
+++ b/vllm/models/deepseek_v4/common/rope.py
@@ -14,10 +14,12 @@ def build_deepseek_v4_rope(
     max_position_embeddings: int,
     compress_ratio: int,
 ) -> RotaryEmbedding:
-    rope_parameters = config.rope_parameters
+    rope_parameters = dict(config.rope_parameters)
     rope_parameters["rope_theta"] = (
         config.compress_rope_theta if compress_ratio > 1 else config.rope_theta
     )
+    if compress_ratio == 0:
+        rope_parameters["rope_type"] = "default"
     if rope_parameters["rope_type"] != "default":
         rope_parameters["rope_type"] = (
             "deepseek_yarn"

--- a/vllm/models/deepseek_v4/nvidia/dspark.py
+++ b/vllm/models/deepseek_v4/nvidia/dspark.py
@@ -1,0 +1,1812 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""DeepSeek V4 DSpark draft module scaffolding.
+
+DSpark checkpoints store their draft module under ``mtp.*`` but the module is
+not the serial DeepSeek V4 MTP architecture.  This file provides a draft-only
+module with parameter names and weight loading matching the DSpark checkpoint so
+the runtime can be implemented incrementally without accidentally falling back
+to serial MTP.
+"""
+
+import json
+import os
+import re
+import time
+import typing
+from collections.abc import Callable, Iterable
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from safetensors.torch import safe_open
+
+from vllm.config import VllmConfig
+from vllm.distributed import (
+    get_tensor_model_parallel_rank,
+    get_tensor_model_parallel_world_size,
+)
+from vllm.logger import init_logger
+from vllm.model_executor.kernels.mhc.tilelang import (
+    hc_head_fused_kernel_tilelang,
+    mhc_post_tilelang,
+)
+from vllm.model_executor.kernels.mhc.torch import (
+    mhc_post_torch,
+    mhc_pre_torch,
+)
+from vllm.model_executor.layers.fused_moe import (
+    fused_moe_make_expert_params_mapping,
+)
+from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.linear import ReplicatedLinear
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
+    VocabParallelEmbedding,
+)
+from vllm.model_executor.model_loader.utils import process_weights_after_loading
+from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+from vllm.utils.torch_utils import set_default_torch_dtype
+from vllm.v1.attention.ops.rocm_aiter_mla_sparse import (
+    _decode_e8m0_scales,
+    _fused_inverse_rope_gptj,
+    _get_cached_wo_a_bf16,
+    rocm_inv_rope_einsum,
+)
+from vllm.v1.worker.gpu.sample.gumbel import gumbel_sample
+
+from .model import (
+    DeepseekV4DecoderLayer,
+    make_deepseek_v4_expert_params_mapping,
+)
+from .ops.dspark_sparse_attn_tilelang import (
+    dspark_sparse_attn,
+    dspark_sparse_attn_reference,
+)
+
+logger = init_logger(__name__)
+
+_EXPERT_SCALE_RE = re.compile(r"\.experts\.\d+\.w[123]\.scale$")
+
+
+def _small_tensor_stats(tensor: torch.Tensor) -> dict[str, object]:
+    x = tensor.detach()
+    xf = x.float()
+    finite = torch.isfinite(xf)
+    if bool(finite.any().item()):
+        values = xf[finite]
+        mean = float(values.mean().cpu())
+        std = float(values.std(unbiased=False).cpu())
+        absmax = float(values.abs().max().cpu())
+    else:
+        mean = float("nan")
+        std = float("nan")
+        absmax = float("nan")
+    out = {
+        "shape": list(x.shape),
+        "dtype": str(x.dtype),
+        "finite": int(finite.sum().cpu()),
+        "numel": x.numel(),
+        "mean": mean,
+        "std": std,
+        "absmax": absmax,
+    }
+    if x.numel() <= 128:
+        out["values"] = x.detach().to(torch.float32).cpu().reshape(-1).tolist()
+    return out
+
+
+def _maybe_dump_stage_debug(
+    label: str,
+    tensors: dict[str, torch.Tensor],
+    extra: dict[str, object] | None = None,
+) -> None:
+    debug_dir = os.getenv("VLLM_DSPARK_DEBUG_DIR")
+    if not debug_dir:
+        return
+    max_dumps = int(os.getenv("VLLM_DSPARK_STAGE_DEBUG_MAX_DUMPS", "16"))
+    path = os.path.join(debug_dir, "stage_debug.jsonl")
+    existing = 0
+    if os.path.exists(path):
+        with open(path, encoding="utf-8") as f:
+            existing = sum(1 for _ in f)
+    if existing >= max_dumps:
+        return
+    os.makedirs(debug_dir, exist_ok=True)
+    row: dict[str, object] = {
+        "time": time.time(),
+        "label": label,
+        "tensors": {name: _small_tensor_stats(t) for name, t in tensors.items()},
+    }
+    if extra:
+        row["extra"] = extra
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+
+def _maybe_save_tensor_debug(
+    label: str,
+    tensors: dict[str, torch.Tensor],
+    extra: dict[str, object] | None = None,
+) -> None:
+    debug_dir = os.getenv("VLLM_DSPARK_TENSOR_DEBUG_DIR")
+    if not debug_dir:
+        return
+    max_dumps = int(os.getenv("VLLM_DSPARK_TENSOR_DEBUG_MAX_DUMPS", "4"))
+    os.makedirs(debug_dir, exist_ok=True)
+    rank = get_tensor_model_parallel_rank()
+    existing = sorted(
+        name for name in os.listdir(debug_dir)
+        if name.startswith(f"rank{rank:02d}_") and name.endswith(".pt")
+    )
+    if len(existing) >= max_dumps:
+        return
+    idx = len(existing)
+    payload: dict[str, object] = {
+        "time": time.time(),
+        "label": label,
+        "rank": rank,
+        "extra": extra or {},
+        "tensors": {
+            name: tensor.detach().cpu()
+            for name, tensor in tensors.items()
+            if tensor is not None
+        },
+    }
+    path = os.path.join(debug_dir, f"rank{rank:02d}_{idx:04d}_{label}.pt")
+    torch.save(payload, path)
+
+
+def _dspark_dump_layer_parts_enabled() -> bool:
+    return os.getenv("VLLM_DSPARK_TENSOR_DEBUG_LAYER_PARTS") == "1"
+
+
+def _build_dspark_topk_idxs(
+    *,
+    window_size: int,
+    batch_size: int,
+    block_size: int,
+    start_pos: int,
+    device: torch.device,
+) -> torch.Tensor:
+    """Build DSpark's rolling-window+draft attention index tensor.
+
+    The public DSpark reference uses exactly this dense gather contract: all
+    available target-window positions followed by the local draft block rows.
+    """
+    if start_pos <= 0:
+        raise ValueError("DSpark decode top-k indices require start_pos > 0.")
+    target_rows = min(window_size, start_pos + 1)
+    matrix = torch.cat(
+        [
+            torch.arange(target_rows, device=device, dtype=torch.int32),
+            window_size + torch.arange(block_size, device=device, dtype=torch.int32),
+        ]
+    )
+    return matrix.view(1, 1, -1).expand(batch_size, block_size, -1).contiguous()
+
+
+def _fake_fp8_e4m3_mxfp_inplace(x: torch.Tensor, block_size: int = 64) -> None:
+    """Mirror the public DSpark QAT KV fake-quant path.
+
+    The HF DSpark inference code applies an in-place FP8 E4M3 quant+dequant to
+    the non-RoPE KV dimensions with power-of-two scales.  This keeps the draft
+    numerics aligned with the QAT-trained module without changing the storage
+    format of the rolling KV cache.
+    """
+    if x.numel() == 0:
+        return
+    if x.shape[-1] % block_size != 0:
+        raise ValueError(
+            "DSpark fake-FP8 block size must divide the last dimension: "
+            f"{x.shape[-1]} % {block_size} != 0."
+        )
+    view = x.reshape(-1, x.shape[-1] // block_size, block_size)
+    amax = view.abs().amax(dim=-1, keepdim=True).clamp_min(1.0e-4)
+    scale = torch.exp2(torch.ceil(torch.log2(amax / 448.0)))
+    quant = torch.clamp(view / scale, -448.0, 448.0).to(torch.float8_e4m3fn)
+    view.copy_(quant.to(view.dtype) * scale.to(view.dtype))
+
+
+def _fake_fp8_e4m3_mxfp(x: torch.Tensor, block_size: int = 128) -> torch.Tensor:
+    """Return a BF16 tensor after DSpark's MXFP8 activation fake-quant."""
+    y = x.contiguous().clone()
+    _fake_fp8_e4m3_mxfp_inplace(y, block_size=block_size)
+    return y
+
+
+def _maybe_fake_fp8_main_proj_input(x: torch.Tensor) -> torch.Tensor:
+    if os.getenv("VLLM_DSPARK_FAKE_FP8_MAIN_PROJ_INPUT") == "1":
+        return _fake_fp8_e4m3_mxfp(x)
+    return x
+
+
+def _apply_dspark_kv_qat_(kv: torch.Tensor, rope_dim: int) -> None:
+    non_rope = kv[..., :-rope_dim] if rope_dim > 0 else kv
+    _fake_fp8_e4m3_mxfp_inplace(non_rope, block_size=64)
+
+
+def _apply_dspark_rope_hf(
+    x: torch.Tensor,
+    positions: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    rope_dim: int,
+) -> torch.Tensor:
+    """Apply DSpark HF-style RoPE to the trailing RoPE lanes."""
+    if rope_dim <= 0:
+        return x
+    out = x.clone()
+    rope = x[..., -rope_dim:].float()
+    cos_sin = cos_sin_cache.index_select(0, positions.reshape(-1)).float()
+    cos, sin = cos_sin.chunk(2, dim=-1)
+    rope_pairs = rope.view(*rope.shape[:-1], -1, 2)
+    even = rope_pairs[..., 0]
+    odd = rope_pairs[..., 1]
+    rotated = torch.stack(
+        (
+            even * cos[:, None, :] - odd * sin[:, None, :],
+            odd * cos[:, None, :] + even * sin[:, None, :],
+        ),
+        dim=-1,
+    ).flatten(-2)
+    out[..., -rope_dim:] = rotated.to(out.dtype)
+    return out
+
+
+def _apply_dspark_inverse_rope_hf(
+    x: torch.Tensor,
+    positions: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    rope_dim: int,
+) -> torch.Tensor:
+    """HF-style inverse RoPE on the trailing DSpark RoPE lanes.
+
+    This mirrors the public DSpark reference's
+    ``apply_rotary_emb(o[..., -rd:], freqs_cis, inverse=True)`` and exists as
+    an opt-in diagnostic to isolate fused inverse-RoPE numerics from the rest of
+    the DSpark draft path.
+    """
+    if rope_dim <= 0:
+        return x.to(torch.bfloat16)
+    out = x.to(torch.bfloat16).clone()
+    rope = x[..., -rope_dim:].float()
+    cos_sin = cos_sin_cache.index_select(0, positions.reshape(-1)).float()
+    cos, sin = cos_sin.chunk(2, dim=-1)
+    rope_pairs = rope.view(*rope.shape[:-1], -1, 2)
+    even = rope_pairs[..., 0]
+    odd = rope_pairs[..., 1]
+    rotated = torch.stack(
+        (
+            even * cos[:, None, :] + odd * sin[:, None, :],
+            odd * cos[:, None, :] - even * sin[:, None, :],
+        ),
+        dim=-1,
+    ).flatten(-2)
+    out[..., -rope_dim:] = rotated.to(torch.bfloat16)
+    return out
+
+
+def _linear_output(output: torch.Tensor | tuple[torch.Tensor, ...]) -> torch.Tensor:
+    return output[0] if isinstance(output, tuple) else output
+
+
+def _hc_head_reference(
+    x: torch.Tensor,
+    hc_fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    norm_eps: float,
+    hc_eps: float,
+) -> torch.Tensor:
+    shape = x.shape
+    dtype = x.dtype
+    x_float = x.flatten(1).float()
+    rsqrt = torch.rsqrt(x_float.square().mean(-1, keepdim=True) + norm_eps)
+    mixes = torch.nn.functional.linear(x_float, hc_fn.float()) * rsqrt
+    pre = torch.sigmoid(mixes * hc_scale.float() + hc_base.float()) + hc_eps
+    y = torch.sum(pre.unsqueeze(-1) * x_float.view(shape), dim=1)
+    return y.to(dtype)
+
+
+def _dequantize_e4m3_e8m0_block_weight(
+    weight: torch.Tensor,
+    scale: torch.Tensor,
+    *,
+    block_size: int = 128,
+    out_dtype: torch.dtype = torch.bfloat16,
+) -> torch.Tensor:
+    """Dequantize DSpark's standalone FP8 block-scaled linears.
+
+    The public DSpark inference path dispatches these weights through its own
+    FP8 GEMM.  vLLM's DeepGEMM block-FP8 path currently illegal-accesses on the
+    DSpark main projection shape, so keep this draft-only projection as a plain
+    BF16 linear until a native safe kernel is wired in.
+    """
+    if weight.ndim != 2 or scale.ndim != 2:
+        raise ValueError(
+            "DSpark FP8 block dequant expects 2D weight and scale tensors, "
+            f"got weight={tuple(weight.shape)} scale={tuple(scale.shape)}."
+        )
+    out_features, in_features = weight.shape
+    expected_scale_shape = (
+        (out_features + block_size - 1) // block_size,
+        (in_features + block_size - 1) // block_size,
+    )
+    if tuple(scale.shape) != expected_scale_shape:
+        raise ValueError(
+            "DSpark FP8 block scale shape mismatch: "
+            f"expected {expected_scale_shape}, got {tuple(scale.shape)}."
+        )
+    expanded_scale = scale.to(torch.float32).repeat_interleave(
+        block_size, dim=0).repeat_interleave(block_size, dim=1)
+    expanded_scale = expanded_scale[:out_features, :in_features]
+    return (weight.to(torch.float32) * expanded_scale).to(out_dtype)
+
+
+def _fp8_activation_quant_dequant_reference(
+    x: torch.Tensor,
+    *,
+    block_size: int = 128,
+) -> torch.Tensor:
+    """HF DSpark-style MXFP8 activation quantization, then dequantization."""
+    if x.shape[-1] % block_size != 0:
+        raise ValueError(
+            "DSpark FP8 activation reference requires block-aligned K, got "
+            f"{x.shape[-1]} with block={block_size}.")
+    original_shape = x.shape
+    xf = x.reshape(-1, x.shape[-1]).float()
+    xb = xf.view(xf.shape[0], xf.shape[1] // block_size, block_size)
+    amax = xb.abs().amax(dim=-1).clamp_min_(1e-4)
+    scale = torch.pow(
+        torch.full_like(amax, 2.0),
+        torch.ceil(torch.log2(amax / 448.0)),
+    )
+    q = (xb / scale.unsqueeze(-1)).clamp_(-448.0, 448.0)
+    dq = q.to(torch.float8_e4m3fn).float() * scale.unsqueeze(-1)
+    return dq.view(original_shape)
+
+
+def _fp8_block_linear_reference(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    scale: torch.Tensor,
+) -> torch.Tensor:
+    """Reference DSpark FP8 block linear matching HF's fp8_gemm contract."""
+    weight_bf16 = _dequantize_e4m3_e8m0_block_weight(
+        weight,
+        scale,
+        out_dtype=torch.bfloat16,
+    )
+    x_dq = _fp8_activation_quant_dequant_reference(x)
+    out = x_dq.reshape(-1, x.shape[-1]).float().matmul(
+        weight_bf16.float().t())
+    return out.to(torch.bfloat16).view(*x.shape[:-1], weight.shape[0])
+
+
+def _read_dspark_num_layers(model_path: str, default: int) -> int:
+    """Infer DSpark stage count from local checkpoint metadata.
+
+    The public DSpark top-level config currently keeps
+    ``num_nextn_predict_layers=1`` even though the attached DSpark module has
+    three ``mtp.N`` stages.  The HF inference directory carries
+    ``n_mtp_layers``; if unavailable, fall back to the safetensors index.
+    """
+    inference_config = os.path.join(model_path, "inference", "config.json")
+    if os.path.exists(inference_config):
+        with open(inference_config, encoding="utf-8") as f:
+            n_layers = json.load(f).get("n_mtp_layers")
+        if n_layers:
+            return int(n_layers)
+
+    index_path = os.path.join(model_path, "model.safetensors.index.json")
+    if os.path.exists(index_path):
+        with open(index_path, encoding="utf-8") as f:
+            weight_map = json.load(f).get("weight_map", {})
+        stage_ids: set[int] = set()
+        for name in weight_map:
+            parts = name.split(".")
+            if len(parts) > 2 and parts[0] == "mtp":
+                try:
+                    stage_ids.add(int(parts[1]))
+                except ValueError:
+                    pass
+        if stage_ids:
+            return max(stage_ids) + 1
+    return int(default)
+
+
+def _iter_mtp_safetensors(model_path: str) -> Iterable[tuple[str, torch.Tensor]]:
+    """Yield only ``mtp.*`` tensors from a local safetensors checkpoint."""
+    index_path = os.path.join(model_path, "model.safetensors.index.json")
+    if not os.path.exists(index_path):
+        raise FileNotFoundError(
+            "DSpark loader currently requires a local safetensors index at "
+            f"{index_path!r}."
+        )
+    with open(index_path, encoding="utf-8") as f:
+        weight_map = json.load(f)["weight_map"]
+
+    files = sorted({filename for name, filename in weight_map.items()
+                    if name.startswith("mtp.")})
+    if not files:
+        raise ValueError(f"No mtp.* DSpark weights found in {index_path!r}.")
+
+    for filename in files:
+        path = os.path.join(model_path, filename)
+        with safe_open(path, framework="pt", device="cpu") as f:
+            for name in f.keys():
+                if name.startswith("mtp."):
+                    yield name, f.get_tensor(name)
+
+
+class DSparkMarkovHead(nn.Module):
+    def __init__(self, vllm_config: VllmConfig, prefix: str) -> None:
+        super().__init__()
+        config = vllm_config.model_config.hf_config
+        rank = int(getattr(config, "dspark_markov_rank", 256))
+        self.markov_w1 = VocabParallelEmbedding(
+            config.vocab_size,
+            rank,
+            prefix=f"{prefix}.markov_w1",
+        )
+        self.markov_w2 = ParallelLMHead(
+            config.vocab_size,
+            rank,
+            params_dtype=torch.float32,
+            org_num_embeddings=config.vocab_size,
+            prefix=f"{prefix}.markov_w2",
+        )
+        self.logits_processor = LogitsProcessor(config.vocab_size)
+
+    def forward(self, token_ids: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        embeds = self.markov_w1(token_ids)
+        logits = self.logits_processor(
+            self.markov_w2,
+            embeds.view(-1, embeds.shape[-1]).float(),
+        )
+        return logits.view(*embeds.shape[:-1], -1), embeds
+
+
+class DSparkConfidenceHead(nn.Module):
+    def __init__(self, vllm_config: VllmConfig, prefix: str) -> None:
+        super().__init__()
+        config = vllm_config.model_config.hf_config
+        rank = int(getattr(config, "dspark_markov_rank", 256))
+        self.proj = ReplicatedLinear(
+            config.hidden_size + rank,
+            1,
+            bias=False,
+            params_dtype=torch.float32,
+            quant_config=None,
+            prefix=f"{prefix}.proj",
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        markov_embeds: torch.Tensor,
+    ) -> torch.Tensor:
+        x = torch.cat([hidden_states, markov_embeds], dim=-1)
+        confidence = _linear_output(self.proj(x.float()))
+        return confidence.squeeze(-1)
+
+
+class DeepSeekV4DSparkLayer(DeepseekV4DecoderLayer):
+    """One DSpark stage.
+
+    It intentionally keeps the normal DeepSeek V4 decoder-layer parameter names
+    for attention/MoE/HC weights, then adds the DSpark-only stage-0 and final
+    stage heads with names matching the checkpoint.
+    """
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        *,
+        stage_id: int,
+        num_dspark_layers: int,
+        prefix: str,
+        topk_indices_buffer: torch.Tensor,
+        aux_stream_list: list[torch.cuda.Stream] | None,
+    ) -> None:
+        super().__init__(
+            vllm_config,
+            prefix=prefix,
+            topk_indices_buffer=topk_indices_buffer,
+            aux_stream_list=aux_stream_list,
+        )
+        self.prefix = prefix
+        config = vllm_config.model_config.hf_config
+        self._dspark_use_reference_fp8_linears = bool(
+            int(os.getenv("VLLM_DSPARK_REFERENCE_FP8_LINEARS", "0")))
+        self._dspark_use_separate_qkv = bool(
+            int(os.getenv("VLLM_DSPARK_SEPARATE_QKV", "0"))
+        ) or self._dspark_use_reference_fp8_linears
+        if self._dspark_use_separate_qkv:
+            self.attn.wq_a = ReplicatedLinear(
+                config.hidden_size,
+                config.q_lora_rank,
+                bias=False,
+                quant_config=vllm_config.quant_config,
+                prefix=f"{prefix}.attn.wq_a",
+                return_bias=False,
+            )
+            self.attn.wkv = ReplicatedLinear(
+                config.hidden_size,
+                config.head_dim,
+                bias=False,
+                quant_config=vllm_config.quant_config,
+                prefix=f"{prefix}.attn.wkv",
+                return_bias=False,
+            )
+        if stage_id == 0:
+            target_layer_ids = tuple(
+                int(i) for i in getattr(config, "dspark_target_layer_ids", ())
+            )
+            if not target_layer_ids:
+                raise ValueError("DSpark requires dspark_target_layer_ids.")
+            self.main_proj = ReplicatedLinear(
+                config.hidden_size * len(target_layer_ids),
+                config.hidden_size,
+                bias=False,
+                quant_config=None,
+                prefix=f"{prefix}.main_proj",
+            )
+            self.main_norm = RMSNorm(config.hidden_size, config.rms_norm_eps)
+
+        if stage_id == num_dspark_layers - 1:
+            self.norm = RMSNorm(config.hidden_size, config.rms_norm_eps)
+            self.markov_head = DSparkMarkovHead(
+                vllm_config,
+                prefix=f"{prefix}.markov_head",
+            )
+            self.confidence_head = DSparkConfidenceHead(
+                vllm_config,
+                prefix=f"{prefix}.confidence_head",
+            )
+            self.hc_head_fn = nn.Parameter(
+                torch.empty(config.hc_mult, config.hc_mult * config.hidden_size,
+                            dtype=torch.float32),
+                requires_grad=False,
+            )
+            self.hc_head_base = nn.Parameter(
+                torch.empty(config.hc_mult, dtype=torch.float32),
+                requires_grad=False,
+            )
+            self.hc_head_scale = nn.Parameter(
+                torch.empty(1, dtype=torch.float32),
+                requires_grad=False,
+            )
+
+        self.dspark_block_size = int(getattr(config, "dspark_block_size", 0) or 0)
+        self.dspark_noise_token_id = int(
+            getattr(config, "dspark_noise_token_id", -1)
+        )
+        if self.dspark_block_size <= 0:
+            raise ValueError("DSpark requires dspark_block_size in the config.")
+        if self.dspark_noise_token_id < 0:
+            raise ValueError("DSpark requires dspark_noise_token_id in the config.")
+        self.register_buffer(
+            "dspark_kv_cache",
+            torch.zeros(
+                vllm_config.scheduler_config.max_num_seqs,
+                config.sliding_window,
+                config.head_dim,
+                dtype=vllm_config.model_config.dtype,
+            ),
+            persistent=False,
+        )
+        # DSpark reuses the DeepSeek V4 attention linears/output projection, but
+        # not the normal vLLM paged MLA/SWA cache path.  Remove those attention
+        # layers from static_forward_context so DraftModelSpeculator.set_attn()
+        # does not allocate/build unused draft attention metadata for them.
+        static_forward_context = vllm_config.compilation_config.static_forward_context
+        static_forward_context.pop(self.attn.prefix, None)
+        static_forward_context.pop(self.attn.swa_cache_layer.prefix, None)
+
+    def _compute_main_kv(
+        self,
+        main_x: torch.Tensor,
+        positions: torch.Tensor,
+    ) -> torch.Tensor:
+        batch_size = main_x.shape[0]
+        if self._dspark_use_reference_fp8_linears:
+            kv = self._apply_reference_fp8_linear(
+                "wkv", main_x.view(batch_size, -1))
+        elif self._dspark_use_separate_qkv:
+            kv = _linear_output(self.attn.wkv(main_x.view(batch_size, -1)))
+        else:
+            qr_kv = _linear_output(
+                self.attn.fused_wqa_wkv(main_x.view(batch_size, -1)))
+            _, kv = qr_kv.split([self.attn.q_lora_rank, self.attn.head_dim],
+                                dim=-1)
+        if _dspark_dump_layer_parts_enabled():
+            _maybe_save_tensor_debug(
+                "dspark_main_kv_linear",
+                {
+                    "main_x": main_x.clone(),
+                    "main_kv_linear": kv.clone(),
+                },
+                {"layer": self.prefix},
+            )
+        kv_normed = self.attn.kv_norm(kv)
+        if _dspark_dump_layer_parts_enabled():
+            _maybe_save_tensor_debug(
+                "dspark_main_kv_norm",
+                {
+                    "main_kv_linear": kv.clone(),
+                    "main_kv_norm": kv_normed.clone(),
+                    "kv_norm_weight": self.attn.kv_norm.weight.clone(),
+                },
+                {"layer": self.prefix},
+            )
+        kv = _apply_dspark_rope_hf(
+            kv_normed.view(batch_size, 1, self.attn.head_dim),
+            positions.view(-1),
+            self.attn.rotary_emb.cos_sin_cache,
+            self.attn.rope_head_dim,
+        )
+        _apply_dspark_kv_qat_(kv, self.attn.rope_head_dim)
+        return kv.view(batch_size, self.attn.head_dim)
+
+    def precompute_dspark_context_kv(
+        self,
+        main_x: torch.Tensor,
+        positions: torch.Tensor,
+        cache_start: int = 0,
+    ) -> None:
+        """Populate this stage's rolling target-KV window from target hidden states."""
+        batch_size, seq_len, _ = main_x.shape
+        window_size = self.attn.window_size
+        cache = self.dspark_kv_cache[cache_start : cache_start + batch_size]
+        main_kv = self._compute_main_kv(main_x.reshape(-1, main_x.shape[-1]),
+                                        positions.reshape(-1))
+        main_kv = main_kv.view(batch_size, seq_len, self.attn.head_dim)
+        tail_len = min(seq_len, window_size)
+        tail_kv = main_kv[:, -tail_len:]
+        tail_positions = positions[:, -tail_len:]
+        slots = tail_positions.remainder(window_size).long()
+        batch_indices = torch.arange(
+            batch_size,
+            dtype=torch.long,
+            device=main_x.device,
+        ).view(batch_size, 1)
+        cache[batch_indices, slots] = tail_kv
+
+    def cache_dspark_wo_a_bf16(self) -> None:
+        """Preserve DSpark's HF-style BF16 WO-A before FP8 kernel repacking.
+
+        DSpark attention uses the public reference path:
+        inverse-RoPE -> BF16 WO-A einsum -> WO-B.  The target DeepSeek V4
+        linears are repacked by process_weights_after_loading for DeepGEMM, so
+        after that point wo_a.weight_scale_inv no longer has checkpoint block
+        layout. Cache the canonical BF16 WO-A while the loaded params still
+        match the checkpoint layout.
+        """
+        if hasattr(self.attn.wo_a, "weight_scale_inv"):
+            flat_weight = self.attn.wo_a.weight.reshape(
+                self.attn.n_local_groups * self.attn.o_lora_rank,
+                -1,
+            )
+            scale = _decode_e8m0_scales(
+                self.attn.wo_a.weight_scale_inv
+            ).reshape(-1, self.attn.wo_a.weight_scale_inv.shape[-1])
+            cached = (
+                flat_weight.unflatten(0, (-1, 128))
+                .unflatten(-1, (-1, 128))
+                .to(torch.float32)
+                * scale[:, None, :, None].to(torch.float32)
+            )
+            cached = (
+                cached.flatten(2, 3)
+                .flatten(0, 1)
+                .to(torch.bfloat16)
+                .view(
+                    self.attn.n_local_groups,
+                    self.attn.o_lora_rank,
+                    flat_weight.shape[-1],
+                )
+            )
+        else:
+            cached = self.attn.wo_a.weight.view(
+                self.attn.n_local_groups,
+                self.attn.o_lora_rank,
+                -1,
+            ).to(torch.bfloat16)
+
+        if "_dsv4_wo_a_bf16" in self.attn.wo_a._buffers:
+            self.attn.wo_a._buffers["_dsv4_wo_a_bf16"] = cached
+        else:
+            self.attn.wo_a.register_buffer(
+                "_dsv4_wo_a_bf16",
+                cached,
+                persistent=False,
+            )
+
+    def cache_dspark_reference_fp8_linears(self) -> None:
+        if not self._dspark_use_reference_fp8_linears:
+            return
+        for attr in ("wq_a", "wkv", "wq_b"):
+            layer = getattr(self.attn, attr)
+            if not hasattr(layer, "weight_scale_inv"):
+                raise ValueError(
+                    f"DSpark reference FP8 linear {attr} has no block scale.")
+            weight = layer.weight.detach().clone()
+            scale = layer.weight_scale_inv.detach().clone()
+            for name, tensor in (
+                (f"_dspark_{attr}_weight_fp8", weight),
+                (f"_dspark_{attr}_scale_e8m0", scale),
+            ):
+                if name in self.attn._buffers:
+                    self.attn._buffers[name] = tensor
+                else:
+                    self.attn.register_buffer(name, tensor, persistent=False)
+
+    def _apply_reference_fp8_linear(
+        self,
+        attr: str,
+        x: torch.Tensor,
+    ) -> torch.Tensor:
+        weight = getattr(self.attn, f"_dspark_{attr}_weight_fp8")
+        scale = getattr(self.attn, f"_dspark_{attr}_scale_e8m0")
+        return _fp8_block_linear_reference(x, weight, scale)
+
+    def _dspark_attention(
+        self,
+        positions: torch.Tensor,
+        x: torch.Tensor,
+        main_x: torch.Tensor,
+        start_pos: int,
+    ) -> torch.Tensor:
+        batch_size, block_size, hidden_size = x.shape
+        if block_size != self.dspark_block_size:
+            raise ValueError(
+                "DSpark draft block size mismatch: "
+                f"expected {self.dspark_block_size}, got {block_size}."
+            )
+        if main_x.shape[1] != 1:
+            raise ValueError(
+                "DSpark decode currently expects one target hidden state per request."
+            )
+
+        main_positions = positions.view(batch_size)
+        main_kv = self._compute_main_kv(main_x[:, 0], main_positions)
+
+        flat_x = x.reshape(batch_size * block_size, hidden_size)
+        if self._dspark_use_reference_fp8_linears:
+            qr = self._apply_reference_fp8_linear("wq_a", flat_x)
+            kv = self._apply_reference_fp8_linear("wkv", flat_x)
+        elif self._dspark_use_separate_qkv:
+            qr = _linear_output(self.attn.wq_a(flat_x))
+            kv = _linear_output(self.attn.wkv(flat_x))
+        else:
+            qr_kv = _linear_output(self.attn.fused_wqa_wkv(flat_x))
+            qr, kv = qr_kv.split([self.attn.q_lora_rank, self.attn.head_dim],
+                                 dim=-1)
+        q_normed = self.attn.q_norm(qr)
+        if self._dspark_use_reference_fp8_linears:
+            q = self._apply_reference_fp8_linear("wq_b", q_normed)
+        else:
+            q = _linear_output(self.attn.wq_b(q_normed))
+        kv_normed = self.attn.kv_norm(kv)
+        if _dspark_dump_layer_parts_enabled():
+            _maybe_save_tensor_debug(
+                "dspark_attention_linear_outputs",
+                {
+                    "flat_x": flat_x.clone(),
+                    "qr_linear": qr.clone(),
+                    "q_norm": q_normed.clone(),
+                    "kv_linear": kv.clone(),
+                    "kv_norm": kv_normed.clone(),
+                    "q_after_wqb_linear": q.clone(),
+                    "q_norm_weight": self.attn.q_norm.weight.clone(),
+                    "kv_norm_weight": self.attn.kv_norm.weight.clone(),
+                },
+                {"layer": self.prefix, "start_pos": start_pos},
+            )
+        q = q.view(batch_size * block_size, self.attn.n_local_heads,
+                   self.attn.head_dim)
+        q *= torch.rsqrt(q.square().mean(-1, keepdim=True) + self.attn.eps)
+        q_after_scale_debug = q.clone() if _dspark_dump_layer_parts_enabled() else None
+        kv = kv_normed.view(batch_size * block_size, 1, self.attn.head_dim)
+
+        draft_positions = (
+            positions.view(batch_size, 1)
+            + torch.arange(
+                1,
+                block_size + 1,
+                dtype=positions.dtype,
+                device=positions.device,
+            ).view(1, block_size)
+        )
+        q = _apply_dspark_rope_hf(
+            q,
+            draft_positions.reshape(-1),
+            self.attn.rotary_emb.cos_sin_cache,
+            self.attn.rope_head_dim,
+        )
+        kv = _apply_dspark_rope_hf(
+            kv,
+            draft_positions.reshape(-1),
+            self.attn.rotary_emb.cos_sin_cache,
+            self.attn.rope_head_dim,
+        )
+        q_after_rope_debug = q.clone() if _dspark_dump_layer_parts_enabled() else None
+        kv_after_rope_debug = kv.clone() if _dspark_dump_layer_parts_enabled() else None
+        _apply_dspark_kv_qat_(kv, self.attn.rope_head_dim)
+        if _dspark_dump_layer_parts_enabled():
+            _maybe_save_tensor_debug(
+                "dspark_attention_post_rope",
+                {
+                    "q_after_scale": q_after_scale_debug,
+                    "q_after_rope": q_after_rope_debug,
+                    "kv_after_rope": kv_after_rope_debug,
+                    "kv_after_qat": kv.clone(),
+                },
+                {"layer": self.prefix, "start_pos": start_pos},
+            )
+        q = q.view(batch_size, block_size, self.attn.n_local_heads,
+                   self.attn.head_dim)
+        kv = kv.view(batch_size, block_size, self.attn.head_dim)
+
+        window_size = self.attn.window_size
+        self.dspark_kv_cache[:batch_size, start_pos % window_size].copy_(main_kv)
+        all_kv = torch.cat([self.dspark_kv_cache[:batch_size], kv], dim=1)
+        topk_idxs = _build_dspark_topk_idxs(
+            window_size=window_size,
+            batch_size=batch_size,
+            block_size=block_size,
+            start_pos=start_pos,
+            device=x.device,
+        )
+        if _dspark_dump_layer_parts_enabled():
+            _maybe_save_tensor_debug(
+                "dspark_attention_inputs",
+                {
+                    "positions": positions,
+                    "main_x": main_x,
+                    "main_kv": main_kv,
+                    "q": q,
+                    "kv": kv,
+                    "cache_window": self.dspark_kv_cache[:batch_size],
+                    "topk_idxs": topk_idxs,
+                },
+                {"layer": self.prefix, "start_pos": start_pos},
+            )
+        sparse_attn_fn = (
+            dspark_sparse_attn_reference
+            if os.getenv("VLLM_DSPARK_REFERENCE_ATTN") == "1"
+            else dspark_sparse_attn
+        )
+        out = sparse_attn_fn(
+            q,
+            all_kv,
+            self.attn.attn_sink[: self.attn.n_local_heads],
+            topk_idxs,
+            self.attn.scale,
+        )
+        out = out.reshape(
+            batch_size * block_size,
+            self.attn.n_local_heads,
+            self.attn.head_dim,
+        )
+        if _dspark_dump_layer_parts_enabled():
+            _maybe_save_tensor_debug(
+                "dspark_attention_sparse_out",
+                {"out": out},
+                {"layer": self.prefix, "start_pos": start_pos},
+            )
+        # DSpark's public reference uses a BF16 inverse-RoPE + WO-A/WO-B path
+        # here.  The target DeepSeek V4 CUDA path uses a fused FP8 _o_proj that
+        # assumes target-layer RoPE/cache invariants and corrupts DSpark draft
+        # numerics for compress_ratio=0.
+        if os.getenv("VLLM_DSPARK_REFERENCE_WO") == "1":
+            inverse_rope = (
+                _apply_dspark_inverse_rope_hf
+                if os.getenv("VLLM_DSPARK_HF_INVERSE_ROPE") == "1"
+                else _fused_inverse_rope_gptj
+            )
+            out_ref = inverse_rope(out, draft_positions.reshape(-1),
+                                   self.attn.rotary_emb.cos_sin_cache,
+                                   self.attn.rope_head_dim)
+            out_ref = out_ref.view(
+                batch_size * block_size,
+                self.attn.n_local_groups,
+                -1,
+            )
+            if not getattr(self, "_dspark_reference_wo_shape_logged", False):
+                logger.warning(
+                    "DSpark reference WO shapes: weight=%s scale=%s "
+                    "groups=%s rank=%s out_width=%s",
+                    tuple(self.attn.wo_a.weight.shape),
+                    tuple(getattr(self.attn.wo_a, "weight_scale_inv", ()).shape),
+                    self.attn.n_local_groups,
+                    self.attn.o_lora_rank,
+                    out_ref.shape[-1],
+                )
+                self._dspark_reference_wo_shape_logged = True
+            wo_a = _get_cached_wo_a_bf16(
+                self.attn.wo_a,
+                self.attn.n_local_groups,
+                self.attn.o_lora_rank,
+                out_ref.shape[-1],
+            )
+            z = torch.einsum("tgd,grd->tgr", out_ref, wo_a)
+            if _dspark_dump_layer_parts_enabled():
+                _maybe_save_tensor_debug(
+                    "dspark_attention_reference_wo",
+                    {
+                        "out_ref": out_ref,
+                        "wo_a": wo_a,
+                        "z": z,
+                    },
+                    {"layer": self.prefix, "start_pos": start_pos},
+                )
+        else:
+            z = rocm_inv_rope_einsum(
+                self.attn.rotary_emb,
+                out,
+                draft_positions.reshape(-1),
+                self.attn.rope_head_dim,
+                self.attn.n_local_groups,
+                self.attn.o_lora_rank,
+                self.attn.wo_a,
+            )
+        out_final = self.attn.wo_b(z.flatten(1)).view(
+            batch_size,
+            block_size,
+            hidden_size,
+        )
+        if _dspark_dump_layer_parts_enabled():
+            _maybe_save_tensor_debug(
+                "dspark_attention_final",
+                {"out": out_final},
+                {"layer": self.prefix, "start_pos": start_pos},
+            )
+        return out_final
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        positions: torch.Tensor,
+        input_ids: torch.Tensor,
+        main_x: torch.Tensor,
+        start_pos: int,
+        post_mix: torch.Tensor | None = None,
+        res_mix: torch.Tensor | None = None,
+        residual: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        batch_size, block_size = input_ids.shape
+        hidden_size = self.hidden_size
+        if residual is None:
+            if x.ndim != 4:
+                raise ValueError(
+                    "First DSpark stage expects [batch, block, hc, hidden] input."
+                )
+            hc_mult = x.shape[2]
+            x_current = x.reshape(batch_size * block_size, hc_mult, hidden_size)
+        else:
+            if x.ndim != 3:
+                raise ValueError(
+                    "Subsequent DSpark stages expect [batch, block, hidden] input."
+                )
+            x_current = x.reshape(batch_size * block_size, hidden_size)
+        input_ids_flat = input_ids.reshape(-1)
+
+        attn_norm_weight = self.attn_norm.weight.data
+        attn_norm_eps = self.attn_norm.variance_epsilon
+        if residual is None:
+            residual = x_current
+            x_attn, post_mix, res_mix = self.hc_pre(
+                residual,
+                self.hc_attn_fn,
+                self.hc_attn_scale,
+                self.hc_attn_base,
+                norm_weight=attn_norm_weight,
+                norm_eps=attn_norm_eps,
+            )
+        else:
+            assert post_mix is not None
+            assert res_mix is not None
+            residual, post_mix, res_mix, x_attn = self.hc_post_pre(
+                x_current,
+                residual,
+                post_mix,
+                res_mix,
+                self.hc_attn_fn,
+                self.hc_attn_scale,
+                self.hc_attn_base,
+                norm_weight=attn_norm_weight,
+                norm_eps=attn_norm_eps,
+            )
+
+        x_attn = self._dspark_attention(
+            positions,
+            x_attn.view(batch_size, block_size, hidden_size),
+            main_x,
+            start_pos,
+        ).reshape(batch_size * block_size, hidden_size)
+
+        ffn_norm_weight = self.ffn_norm.weight.data
+        ffn_norm_eps = self.ffn_norm.variance_epsilon
+        residual, post_mix, res_mix, x_ffn = self.hc_post_pre(
+            x_attn,
+            residual,
+            post_mix,
+            res_mix,
+            self.hc_ffn_fn,
+            self.hc_ffn_scale,
+            self.hc_ffn_base,
+            norm_weight=ffn_norm_weight,
+            norm_eps=ffn_norm_eps,
+            hc_fn_bf16=self.hc_ffn_fn_bf16,
+        )
+        x_ffn = self.ffn(x_ffn, input_ids_flat)
+        return x_ffn.view(batch_size, block_size, hidden_size), residual, post_mix, res_mix
+
+    def forward_reference_hc(
+        self,
+        x: torch.Tensor,
+        positions: torch.Tensor,
+        input_ids: torch.Tensor,
+        main_x: torch.Tensor,
+        start_pos: int,
+    ) -> torch.Tensor:
+        """DSpark-only HF-style HC reference path.
+
+        This intentionally materializes the full HC state after each post-mix
+        instead of using the production fused post-pre chaining. It is guarded
+        by an env flag and exists to isolate DSpark numerical mismatches.
+        """
+        batch_size, block_size = input_ids.shape
+        hidden_size = self.hidden_size
+        if x.ndim != 4:
+            raise ValueError("DSpark reference HC expects [batch, block, hc, hidden].")
+        x_current = x.reshape(batch_size * block_size, x.shape[2], hidden_size)
+        input_ids_flat = input_ids.reshape(-1)
+
+        post_mix, res_mix, x_attn = mhc_pre_torch(
+            x_current,
+            self.hc_attn_fn,
+            self.hc_attn_scale,
+            self.hc_attn_base,
+            self.rms_norm_eps,
+            self.hc_eps,
+            self.hc_eps,
+            self.hc_post_alpha,
+            self.hc_sinkhorn_iters,
+        )
+        if _dspark_dump_layer_parts_enabled():
+            _maybe_save_tensor_debug(
+                "dspark_layer_attn_pre",
+                {
+                    "x_current": x_current,
+                    "post_mix": post_mix,
+                    "res_mix": res_mix,
+                    "x_attn_pre_norm": x_attn,
+                },
+                {"layer": self.prefix, "start_pos": start_pos},
+            )
+        x_attn = self.attn_norm(x_attn)
+        if _dspark_dump_layer_parts_enabled():
+            _maybe_save_tensor_debug(
+                "dspark_layer_attn_norm",
+                {"x_attn": x_attn},
+                {"layer": self.prefix, "start_pos": start_pos},
+            )
+        x_attn = self._dspark_attention(
+            positions,
+            x_attn.view(batch_size, block_size, hidden_size),
+            main_x,
+            start_pos,
+        ).reshape(batch_size * block_size, hidden_size)
+        if _dspark_dump_layer_parts_enabled():
+            _maybe_save_tensor_debug(
+                "dspark_layer_attn_out",
+                {"x_attn": x_attn},
+                {"layer": self.prefix, "start_pos": start_pos},
+            )
+        x_current = mhc_post_torch(x_attn, x_current, post_mix, res_mix)
+        if _dspark_dump_layer_parts_enabled():
+            _maybe_save_tensor_debug(
+                "dspark_layer_after_attn_post",
+                {"x_current": x_current},
+                {"layer": self.prefix, "start_pos": start_pos},
+            )
+
+        post_mix, res_mix, x_ffn = mhc_pre_torch(
+            x_current,
+            self.hc_ffn_fn,
+            self.hc_ffn_scale,
+            self.hc_ffn_base,
+            self.rms_norm_eps,
+            self.hc_eps,
+            self.hc_eps,
+            self.hc_post_alpha,
+            self.hc_sinkhorn_iters,
+        )
+        if _dspark_dump_layer_parts_enabled():
+            _maybe_save_tensor_debug(
+                "dspark_layer_ffn_pre",
+                {
+                    "post_mix": post_mix,
+                    "res_mix": res_mix,
+                    "x_ffn_pre_norm": x_ffn,
+                },
+                {"layer": self.prefix, "start_pos": start_pos},
+            )
+        x_ffn = self.ffn_norm(x_ffn)
+        if _dspark_dump_layer_parts_enabled():
+            _maybe_save_tensor_debug(
+                "dspark_layer_ffn_norm",
+                {"x_ffn": x_ffn},
+                {"layer": self.prefix, "start_pos": start_pos},
+            )
+        x_ffn = self.ffn(x_ffn, input_ids_flat)
+        if _dspark_dump_layer_parts_enabled():
+            _maybe_save_tensor_debug(
+                "dspark_layer_ffn_out",
+                {"x_ffn": x_ffn},
+                {"layer": self.prefix, "start_pos": start_pos},
+            )
+        x_current = mhc_post_torch(x_ffn, x_current, post_mix, res_mix)
+        if _dspark_dump_layer_parts_enabled():
+            _maybe_save_tensor_debug(
+                "dspark_layer_after_ffn_post",
+                {"x_current": x_current},
+                {"layer": self.prefix, "start_pos": start_pos},
+            )
+        return x_current.view(batch_size, block_size, x.shape[2], hidden_size)
+
+
+class DeepSeekV4DSparkDraft(nn.Module):
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        super().__init__()
+        self.config = vllm_config.model_config.hf_config
+        self.model_path = vllm_config.model_config.model
+        self.num_dspark_layers = _read_dspark_num_layers(
+            self.model_path,
+            getattr(self.config, "num_nextn_predict_layers", 1),
+        )
+        self.dspark_start_layer_idx = self.config.num_hidden_layers
+        self.checkpoint_weight_name_prefixes = tuple(
+            f"mtp.{idx}." for idx in range(self.num_dspark_layers)
+        )
+
+        self.topk_indices_buffer = torch.empty(
+            vllm_config.scheduler_config.max_num_batched_tokens,
+            self.config.index_topk,
+            dtype=torch.int32,
+        )
+        aux_stream_list = [torch.cuda.Stream() for _ in range(3)]
+
+        self.layers = nn.ModuleDict()
+        for idx in range(self.num_dspark_layers):
+            layer_idx = self.dspark_start_layer_idx + idx
+            layer_prefix = (
+                f"{prefix}.layers.{layer_idx}" if prefix else f"layers.{layer_idx}"
+            )
+            self.layers[str(layer_idx)] = DeepSeekV4DSparkLayer(
+                vllm_config,
+                stage_id=idx,
+                num_dspark_layers=self.num_dspark_layers,
+                prefix=layer_prefix,
+                topk_indices_buffer=self.topk_indices_buffer,
+                aux_stream_list=aux_stream_list,
+            )
+        self.embed_tokens: VocabParallelEmbedding | None = None
+        self.lm_head: ParallelLMHead | None = None
+        self.logits_processor = LogitsProcessor(self.config.vocab_size)
+
+    def attach_target_modules(
+        self,
+        embed_tokens: VocabParallelEmbedding,
+        lm_head: ParallelLMHead,
+    ) -> None:
+        self.embed_tokens = embed_tokens
+        self.lm_head = lm_head
+        if os.getenv("VLLM_DSPARK_FP32_LM_HEAD") == "1":
+            self.register_buffer(
+                "lm_head_fp32_weight",
+                lm_head.weight.detach().to(torch.float32).clone(),
+                persistent=False,
+            )
+            logger.info_once(
+                "DSpark draft logits use a local FP32 copy of target lm_head."
+            )
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        if self.embed_tokens is None:
+            raise RuntimeError("DSpark draft has no shared target embedding.")
+        return self.embed_tokens(input_ids)
+
+    def compute_logits(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        if self.lm_head is None:
+            raise RuntimeError("DSpark draft has no shared target lm_head.")
+        lm_head_fp32_weight = getattr(self, "lm_head_fp32_weight", None)
+        if lm_head_fp32_weight is not None:
+            logits = F.linear(hidden_states.float(), lm_head_fp32_weight)
+            logits = self.logits_processor._gather_logits(logits)
+            if logits is not None:
+                logits = logits[..., : self.config.vocab_size]
+            return logits
+        return self.logits_processor(
+            self.lm_head,
+            hidden_states.view(-1, hidden_states.shape[-1]),
+        ).view(*hidden_states.shape[:-1], -1)
+
+    def forward_embed(
+        self,
+        main_hidden: torch.Tensor,
+        input_ids: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        first_layer = self.layers[str(self.dspark_start_layer_idx)]
+        assert isinstance(first_layer, DeepSeekV4DSparkLayer)
+        main_x = _linear_output(
+            first_layer.main_proj(_maybe_fake_fp8_main_proj_input(main_hidden)))
+        main_x = first_layer.main_norm(main_x)
+        batch_size = input_ids.shape[0]
+        draft_input_ids = input_ids.new_full(
+            (batch_size, first_layer.dspark_block_size),
+            first_layer.dspark_noise_token_id,
+        )
+        draft_input_ids[:, 0] = input_ids
+        x = self.embed_input_ids(draft_input_ids.reshape(-1))
+        x = x.view(batch_size, first_layer.dspark_block_size, self.config.hidden_size)
+        x = x.unsqueeze(2).repeat(1, 1, self.config.hc_mult, 1)
+        return x, main_x.unsqueeze(1), draft_input_ids
+
+    def precompute_context_kv(
+        self,
+        main_hidden: torch.Tensor,
+        positions: torch.Tensor,
+        context_ranges: list[tuple[int, int]],
+    ) -> None:
+        """Populate DSpark rolling target-KV caches for scheduled target tokens."""
+        if not context_ranges:
+            return
+        first_layer = self.layers[str(self.dspark_start_layer_idx)]
+        assert isinstance(first_layer, DeepSeekV4DSparkLayer)
+        main_x = _linear_output(
+            first_layer.main_proj(_maybe_fake_fp8_main_proj_input(main_hidden)))
+        main_x = first_layer.main_norm(main_x)
+
+        for req_idx, (start, end) in enumerate(context_ranges):
+            if end <= start:
+                continue
+            req_main_x = main_x[start:end].unsqueeze(0)
+            req_positions = positions[start:end].unsqueeze(0)
+            for layer in self.layers.values():
+                assert isinstance(layer, DeepSeekV4DSparkLayer)
+                layer.precompute_dspark_context_kv(
+                    req_main_x,
+                    req_positions,
+                    cache_start=req_idx,
+                )
+
+    def reset_dspark_kv_cache(self) -> None:
+        for layer in self.layers.values():
+            assert isinstance(layer, DeepSeekV4DSparkLayer)
+            layer.dspark_kv_cache.zero_()
+
+    def forward_head(
+        self,
+        x: torch.Tensor,
+        input_ids: torch.Tensor,
+        *,
+        idx_mapping: torch.Tensor | None = None,
+        temperature: torch.Tensor | None = None,
+        seeds: torch.Tensor | None = None,
+        positions: torch.Tensor | None = None,
+        draft_logits: torch.Tensor | None = None,
+        draft_step_cols: torch.Tensor | None = None,
+        active_num_reqs: torch.Tensor | None = None,
+        use_fp64_gumbel: bool = False,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        final_layer = self.layers[
+            str(self.dspark_start_layer_idx + self.num_dspark_layers - 1)
+        ]
+        assert isinstance(final_layer, DeepSeekV4DSparkLayer)
+        batch_size, block_size, hc_mult, hidden_size = x.shape
+        x_flat = x.reshape(batch_size * block_size, hc_mult, hidden_size)
+        if os.getenv("VLLM_DSPARK_REFERENCE_HC_HEAD") == "1":
+            hidden = _hc_head_reference(
+                x_flat,
+                final_layer.hc_head_fn,
+                final_layer.hc_head_scale,
+                final_layer.hc_head_base,
+                final_layer.rms_norm_eps,
+                final_layer.hc_eps,
+            ).view(batch_size, block_size, hidden_size)
+        else:
+            hidden = hc_head_fused_kernel_tilelang(
+                x_flat,
+                final_layer.hc_head_fn,
+                final_layer.hc_head_scale,
+                final_layer.hc_head_base,
+                final_layer.rms_norm_eps,
+                final_layer.hc_eps,
+            ).view(batch_size, block_size, hidden_size)
+        logits_hidden = final_layer.norm(hidden)
+        logits = self.compute_logits(logits_hidden)
+        if os.getenv("VLLM_DSPARK_TENSOR_DEBUG_HEAD_PARTS") == "1":
+            _maybe_save_tensor_debug(
+                "head_base_logits",
+                {
+                    "input_ids": input_ids,
+                    "positions": positions,
+                    "hidden": hidden,
+                    "logits_hidden": logits_hidden,
+                    "base_logits": logits,
+                },
+                {
+                    "start_pos": (int(positions[0].item())
+                                  if positions is not None
+                                  and positions.numel() else None),
+                },
+            )
+
+        output_ids = input_ids.new_empty(batch_size, block_size + 1)
+        output_ids[:, 0] = input_ids
+        markov_embeds = []
+        disable_markov_bias = os.getenv("VLLM_DSPARK_DISABLE_MARKOV_BIAS") == "1"
+        for idx in range(block_size):
+            logits_bias, markov_embed = final_layer.markov_head(output_ids[:, idx])
+            if os.getenv("VLLM_DSPARK_TENSOR_DEBUG_HEAD_PARTS") == "1":
+                _maybe_save_tensor_debug(
+                    f"head_markov_{idx}",
+                    {
+                        "step_input_ids": output_ids[:, idx],
+                        "logits_bias": logits_bias,
+                        "base_logits_step": logits[:, idx],
+                    },
+                    {
+                        "step": idx,
+                        "start_pos": (int(positions[0].item())
+                                      if positions is not None
+                                      and positions.numel() else None),
+                    },
+                )
+            if not disable_markov_bias:
+                logits[:, idx].add_(logits_bias)
+            markov_embeds.append(markov_embed)
+            if draft_logits is not None:
+                assert idx_mapping is not None
+                assert temperature is not None
+                assert seeds is not None
+                assert positions is not None
+                assert draft_step_cols is not None
+                output_ids[:, idx + 1] = gumbel_sample(
+                    logits[:, idx],
+                    idx_mapping,
+                    temperature,
+                    seeds,
+                    positions + idx + 1,
+                    apply_temperature=True,
+                    output_processed_logits=draft_logits,
+                    output_processed_logits_col=draft_step_cols[idx],
+                    output_processed_logits_active_rows=active_num_reqs,
+                    use_fp64=use_fp64_gumbel,
+                )
+            else:
+                output_ids[:, idx + 1] = logits[:, idx].argmax(dim=-1)
+        confidence = final_layer.confidence_head(
+            hidden,
+            torch.stack(markov_embeds, dim=1),
+        )
+        return output_ids, logits, confidence
+
+    def forward_spec(
+        self,
+        input_ids: torch.Tensor,
+        main_hidden: torch.Tensor,
+        positions: torch.Tensor,
+        *,
+        idx_mapping: torch.Tensor | None = None,
+        temperature: torch.Tensor | None = None,
+        seeds: torch.Tensor | None = None,
+        draft_logits: torch.Tensor | None = None,
+        draft_step_cols: torch.Tensor | None = None,
+        active_num_reqs: torch.Tensor | None = None,
+        use_fp64_gumbel: bool = False,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        if positions.numel() == 0:
+            raise ValueError("DSpark forward_spec requires at least one position.")
+        # Initial version only supports uniform decode positions.  The speculator
+        # can relax this later with fully tensorized rolling-cache writes.
+        if not torch.all(positions == positions[0]):
+            raise NotImplementedError(
+                "DSpark forward_spec currently requires uniform decode positions."
+            )
+        start_pos = int(positions[0].item())
+        x, main_x, draft_input_ids = self.forward_embed(main_hidden, input_ids)
+        _maybe_dump_stage_debug(
+            "forward_embed",
+            {
+                "main_hidden": main_hidden,
+                "main_x": main_x,
+                "x": x,
+            },
+            {
+                "start_pos": start_pos,
+                "input_ids": [
+                    int(v) for v in input_ids.detach().cpu().tolist()[:8]
+                ],
+                "positions": [
+                    int(v) for v in positions.detach().cpu().tolist()[:8]
+                ],
+            },
+        )
+        _maybe_save_tensor_debug(
+            "forward_embed",
+            {
+                "input_ids": input_ids,
+                "positions": positions,
+                "main_hidden": main_hidden,
+                "main_x": main_x,
+                "draft_input_ids": draft_input_ids,
+                "x": x,
+            },
+            {
+                "start_pos": start_pos,
+            },
+        )
+        if start_pos == 0:
+            main_positions = positions.view(-1, 1)
+            for layer in self.layers.values():
+                assert isinstance(layer, DeepSeekV4DSparkLayer)
+                layer.precompute_dspark_context_kv(main_x, main_positions)
+            raise RuntimeError("DSpark context prefill does not produce draft tokens.")
+
+        final_layer = self.layers[
+            str(self.dspark_start_layer_idx + self.num_dspark_layers - 1)
+        ]
+        assert isinstance(final_layer, DeepSeekV4DSparkLayer)
+        if os.getenv("VLLM_DSPARK_REFERENCE_HC") == "1":
+            for layer in self.layers.values():
+                assert isinstance(layer, DeepSeekV4DSparkLayer)
+                x = layer.forward_reference_hc(
+                    x,
+                    positions,
+                    draft_input_ids,
+                    main_x,
+                    start_pos,
+                )
+                _maybe_dump_stage_debug(
+                    "layer_reference_hc",
+                    {"x": x},
+                    {"layer": layer.prefix, "start_pos": start_pos},
+                )
+                _maybe_save_tensor_debug(
+                    "layer_reference_hc",
+                    {"x": x},
+                    {"layer": layer.prefix, "start_pos": start_pos},
+                )
+        else:
+            residual, post_mix, res_mix = None, None, None
+            for layer in self.layers.values():
+                assert isinstance(layer, DeepSeekV4DSparkLayer)
+                x, residual, post_mix, res_mix = layer(
+                    x,
+                    positions,
+                    draft_input_ids,
+                    main_x,
+                    start_pos,
+                    post_mix,
+                    res_mix,
+                    residual,
+                )
+                _maybe_dump_stage_debug(
+                    "layer_fused_hc",
+                    {
+                        "x": x,
+                        "residual": residual,
+                        "post_mix": post_mix,
+                        "res_mix": res_mix,
+                    },
+                    {"layer": layer.prefix, "start_pos": start_pos},
+                )
+                _maybe_save_tensor_debug(
+                    "layer_fused_hc",
+                    {
+                        "x": x,
+                        "residual": residual,
+                        "post_mix": post_mix,
+                        "res_mix": res_mix,
+                    },
+                    {"layer": layer.prefix, "start_pos": start_pos},
+                )
+            assert residual is not None
+            assert post_mix is not None
+            assert res_mix is not None
+            if final_layer._should_run_b12x_mhc(int(x.shape[0] * x.shape[1])):
+                from b12x.integration.residual import b12x_mhc_post
+
+                x_flat = b12x_mhc_post(
+                    x.reshape(-1, self.config.hidden_size),
+                    residual,
+                    post_mix,
+                    res_mix,
+                )
+            else:
+                x_flat = mhc_post_tilelang(
+                    x.reshape(-1, self.config.hidden_size),
+                    residual,
+                    post_mix,
+                    res_mix,
+                )
+            x = x_flat.view(
+                input_ids.shape[0],
+                draft_input_ids.shape[1],
+                self.config.hc_mult,
+                self.config.hidden_size,
+            )
+            _maybe_dump_stage_debug(
+                "final_mhc_post",
+                {"x": x},
+                {"start_pos": start_pos},
+            )
+            _maybe_save_tensor_debug(
+                "final_mhc_post",
+                {"x": x},
+                {"start_pos": start_pos},
+            )
+        output_ids, logits, confidence = self.forward_head(
+            x,
+            input_ids,
+            idx_mapping=idx_mapping,
+            temperature=temperature,
+            seeds=seeds,
+            positions=positions,
+            draft_logits=draft_logits,
+            draft_step_cols=draft_step_cols,
+            active_num_reqs=active_num_reqs,
+            use_fp64_gumbel=use_fp64_gumbel,
+        )
+        _maybe_dump_stage_debug(
+            "forward_head",
+            {
+                "logits": logits,
+                "confidence": confidence,
+            },
+            {
+                "start_pos": start_pos,
+                "output_ids": [
+                    [int(v) for v in row]
+                    for row in output_ids.detach().cpu().tolist()[:2]
+                ],
+            },
+        )
+        _maybe_save_tensor_debug(
+            "forward_head",
+            {
+                "input_ids": input_ids,
+                "positions": positions,
+                "output_ids": output_ids,
+                "logits": logits,
+                "confidence": confidence,
+            },
+            {
+                "start_pos": start_pos,
+            },
+        )
+        return output_ids, logits, confidence
+
+    def _get_dspark_layer_idx_from_weight_name(self, name: str) -> int | None:
+        for idx in range(self.num_dspark_layers):
+            layer_idx = self.dspark_start_layer_idx + idx
+            if name.startswith(f"layers.{layer_idx}.") or name.startswith(
+                f"model.layers.{layer_idx}."
+            ):
+                return layer_idx
+        return None
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        stacked_params_mapping = [
+            ("gate_up_proj", "w1", 0),
+            ("gate_up_proj", "w3", 1),
+            ("attn.fused_wqa_wkv", "attn.wq_a", 0),
+            ("attn.fused_wqa_wkv", "attn.wkv", 1),
+        ]
+        params_dict = dict(self.named_parameters())
+        loaded_params: set[str] = set()
+
+        tp_size = get_tensor_model_parallel_world_size()
+        tp_rank = get_tensor_model_parallel_rank()
+        n_local_head = self.config.num_attention_heads // tp_size
+        head_rank_start = n_local_head * tp_rank
+        head_rank_end = n_local_head * (tp_rank + 1)
+
+        first_layer = next(iter(self.layers.values()))
+        if first_layer.ffn.use_mega_moe:
+            expert_mapping = make_deepseek_v4_expert_params_mapping(
+                self.config.n_routed_experts
+            )
+        else:
+            expert_mapping = fused_moe_make_expert_params_mapping(
+                self,
+                ckpt_gate_proj_name="w1",
+                ckpt_down_proj_name="w2",
+                ckpt_up_proj_name="w3",
+                num_experts=self.config.n_routed_experts,
+            )
+
+        expert_scale_suffix = (
+            ".weight_scale"
+            if getattr(self.config, "expert_dtype", "fp4") == "fp4"
+            else ".weight_scale_inv"
+        )
+
+        pending_main_proj: dict[str, dict[str, torch.Tensor]] = {}
+
+        def maybe_load_main_proj(
+            name: str,
+            loaded_weight: torch.Tensor,
+        ) -> bool:
+            if ".main_proj." not in name:
+                return False
+            base_name, suffix = name.rsplit(".", 1)
+            if suffix not in ("weight", "scale"):
+                return False
+            entry = pending_main_proj.setdefault(base_name, {})
+            entry[suffix] = loaded_weight
+            if "weight" not in entry or "scale" not in entry:
+                return True
+            param_name = f"{base_name}.weight"
+            param = params_dict[param_name]
+            dequant_weight = _dequantize_e4m3_e8m0_block_weight(
+                entry["weight"],
+                entry["scale"],
+                out_dtype=param.dtype,
+            )
+            dequant_weight = dequant_weight.to(
+                device=param.device, dtype=param.dtype)
+            with torch.no_grad():
+                param.data.copy_(dequant_weight)
+            loaded_params.add(param_name)
+            del pending_main_proj[base_name]
+            return True
+
+        for name, loaded_weight in weights:
+            if not name.startswith("mtp."):
+                continue
+            mtp_layer_idx = int(name.split(".", 2)[1])
+            name = name.replace(
+                f"mtp.{mtp_layer_idx}.",
+                f"layers.{self.dspark_start_layer_idx + mtp_layer_idx}.",
+            )
+            spec_layer = self._get_dspark_layer_idx_from_weight_name(name)
+            if spec_layer is None:
+                continue
+
+            if maybe_load_main_proj(name, loaded_weight):
+                continue
+
+            if name.endswith(".scale"):
+                suffix = (
+                    expert_scale_suffix
+                    if _EXPERT_SCALE_RE.search(name)
+                    else ".weight_scale_inv"
+                )
+                name = name.removesuffix(".scale") + suffix
+
+            for param_name, weight_name, shard_id in stacked_params_mapping:
+                if ".experts." in name:
+                    continue
+                if (
+                    self.layers[str(spec_layer)]._dspark_use_separate_qkv
+                    and weight_name in ("attn.wq_a", "attn.wkv")
+                ):
+                    continue
+                if weight_name in ("w1", "w3") and ".shared_experts." not in name:
+                    continue
+                if weight_name not in name:
+                    continue
+                mapped_name = name.replace(weight_name, param_name)
+                param = params_dict[mapped_name]
+                param.weight_loader(param, loaded_weight, shard_id)
+                loaded_params.add(mapped_name)
+                break
+            else:
+                if ".experts." in name:
+                    # E8M0 expert scales are stored as float8_e8m0fnu in the
+                    # checkpoint, but MXFP4 MoE scale params keep raw exponent
+                    # bytes. Non-expert FP8 linears use float8 scale params, so
+                    # keep this conversion scoped to experts only.
+                    if (
+                        "weight_scale" in name
+                        and loaded_weight.dtype == torch.float8_e8m0fnu
+                    ):
+                        loaded_weight = loaded_weight.view(torch.uint8)
+                    for mapping in expert_mapping:
+                        param_name, weight_name, expert_id, expert_shard_id = mapping
+                        if weight_name not in name:
+                            continue
+                        mapped_name = name.replace(weight_name, param_name)
+                        param = params_dict[mapped_name]
+                        weight_loader = typing.cast(
+                            Callable[..., bool], param.weight_loader
+                        )
+                        if weight_loader(
+                            param,
+                            loaded_weight,
+                            mapped_name,
+                            shard_id=expert_shard_id,
+                            expert_id=expert_id,
+                            return_success=True,
+                        ):
+                            loaded_params.add(mapped_name)
+                            break
+                    continue
+                if "attn_sink" in name:
+                    narrow_weight = loaded_weight[head_rank_start:head_rank_end]
+                    n = narrow_weight.shape[0]
+                    params_dict[name][:n].copy_(narrow_weight)
+                    loaded_params.add(name)
+                    continue
+                if ".shared_experts.w2" in name:
+                    name = name.replace(".shared_experts.w2",
+                                        ".shared_experts.down_proj")
+                if name.endswith(".ffn.gate.bias"):
+                    name = name.replace(
+                        ".ffn.gate.bias",
+                        ".ffn.gate.e_score_correction_bias",
+                    )
+                param = params_dict[name]
+                weight_loader = getattr(param, "weight_loader",
+                                        default_weight_loader)
+                weight_loader(param, loaded_weight)
+                loaded_params.add(name)
+
+        if pending_main_proj:
+            raise ValueError(
+                "Incomplete DSpark main_proj FP8 block weights: "
+                f"{sorted(pending_main_proj)}"
+            )
+
+        expected_layers = set(
+            range(
+                self.dspark_start_layer_idx,
+                self.dspark_start_layer_idx + self.num_dspark_layers,
+            )
+        )
+        loaded_layers = {
+            layer
+            for param_name in loaded_params
+            if (layer := self._get_dspark_layer_idx_from_weight_name(param_name))
+            is not None
+        }
+        missing_layers = expected_layers - loaded_layers
+        if missing_layers:
+            raise ValueError(
+                "DSpark draft layer weights missing from checkpoint: "
+                f"{sorted(missing_layers)}"
+            )
+
+        for layer in self.layers.values():
+            layer.cache_dspark_reference_fp8_linears()
+            layer.cache_dspark_wo_a_bf16()
+            layer.refresh_b12x_mhc_bf16_weights()
+            layer.ffn.finalize_mega_moe_weights()
+
+        logger.info_once(
+            "DSpark draft weights loaded: %d params across %d stages",
+            len(loaded_params),
+            self.num_dspark_layers,
+        )
+        return loaded_params
+
+
+def load_dspark_model(vllm_config: VllmConfig) -> DeepSeekV4DSparkDraft:
+    target_device = vllm_config.device_config.device
+    with set_default_torch_dtype(vllm_config.model_config.dtype):
+        model = DeepSeekV4DSparkDraft(vllm_config=vllm_config)
+    model.load_weights(_iter_mtp_safetensors(vllm_config.model_config.model))
+    process_weights_after_loading(
+        model,
+        vllm_config.model_config,
+        target_device,
+    )
+    model.to(target_device)
+    return model

--- a/vllm/models/deepseek_v4/nvidia/dspark.py
+++ b/vllm/models/deepseek_v4/nvidia/dspark.py
@@ -851,6 +851,110 @@ class DeepSeekV4DSparkLayer(DeepseekV4DecoderLayer):
         scale = getattr(self.attn, f"_dspark_{attr}_scale_e8m0")
         return _fp8_block_linear_reference(x, weight, scale)
 
+    def _dspark_output_projection(
+        self,
+        out: torch.Tensor,
+        draft_positions: torch.Tensor,
+        batch_size: int,
+        block_size: int,
+        hidden_size: int,
+        start_pos: int | None,
+    ) -> torch.Tensor:
+        flat_positions = draft_positions.reshape(-1)
+        if getattr(self.attn, "_use_b12x_wo", False):
+            # B12X owns WO-A/WO-B through a fused helper and marks the generic
+            # FP8 linears as unavailable.  DSpark attention layers are removed
+            # from the no-compile context, so call the helper directly instead
+            # of the target attention custom op that looks layers up by name.
+            out_final = self.attn._apply_b12x_wo_projection(
+                out,
+                flat_positions,
+                o_storage=out,
+                o_storage_offset=out.storage_offset(),
+                o_stride_0=out.stride(0),
+                o_stride_1=out.stride(1),
+                o_stride_2=out.stride(2),
+            ).view(batch_size, block_size, hidden_size)
+            if _dspark_dump_layer_parts_enabled():
+                _maybe_save_tensor_debug(
+                    "dspark_attention_final",
+                    {"out": out_final},
+                    {"layer": self.prefix, "start_pos": start_pos},
+                )
+            return out_final
+
+        # DSpark's public reference uses a BF16 inverse-RoPE + WO-A/WO-B path
+        # here.  The target DeepSeek V4 CUDA path uses a fused FP8 _o_proj that
+        # assumes target-layer RoPE/cache invariants and corrupts DSpark draft
+        # numerics for compress_ratio=0.
+        if os.getenv("VLLM_DSPARK_REFERENCE_WO") == "1":
+            inverse_rope = (
+                _apply_dspark_inverse_rope_hf
+                if os.getenv("VLLM_DSPARK_HF_INVERSE_ROPE") == "1"
+                else _fused_inverse_rope_gptj
+            )
+            out_ref = inverse_rope(
+                out,
+                flat_positions,
+                self.attn.rotary_emb.cos_sin_cache,
+                self.attn.rope_head_dim,
+            )
+            out_ref = out_ref.view(
+                batch_size * block_size,
+                self.attn.n_local_groups,
+                -1,
+            )
+            if not getattr(self, "_dspark_reference_wo_shape_logged", False):
+                logger.warning(
+                    "DSpark reference WO shapes: weight=%s scale=%s "
+                    "groups=%s rank=%s out_width=%s",
+                    tuple(self.attn.wo_a.weight.shape),
+                    tuple(getattr(self.attn.wo_a, "weight_scale_inv", ()).shape),
+                    self.attn.n_local_groups,
+                    self.attn.o_lora_rank,
+                    out_ref.shape[-1],
+                )
+                self._dspark_reference_wo_shape_logged = True
+            wo_a = _get_cached_wo_a_bf16(
+                self.attn.wo_a,
+                self.attn.n_local_groups,
+                self.attn.o_lora_rank,
+                out_ref.shape[-1],
+            )
+            z = torch.einsum("tgd,grd->tgr", out_ref, wo_a)
+            if _dspark_dump_layer_parts_enabled():
+                _maybe_save_tensor_debug(
+                    "dspark_attention_reference_wo",
+                    {
+                        "out_ref": out_ref,
+                        "wo_a": wo_a,
+                        "z": z,
+                    },
+                    {"layer": self.prefix, "start_pos": start_pos},
+                )
+        else:
+            z = rocm_inv_rope_einsum(
+                self.attn.rotary_emb,
+                out,
+                flat_positions,
+                self.attn.rope_head_dim,
+                self.attn.n_local_groups,
+                self.attn.o_lora_rank,
+                self.attn.wo_a,
+            )
+        out_final = self.attn.wo_b(z.flatten(1)).view(
+            batch_size,
+            block_size,
+            hidden_size,
+        )
+        if _dspark_dump_layer_parts_enabled():
+            _maybe_save_tensor_debug(
+                "dspark_attention_final",
+                {"out": out_final},
+                {"layer": self.prefix, "start_pos": start_pos},
+            )
+        return out_final
+
     def _dspark_attention(
         self,
         positions: torch.Tensor,
@@ -994,77 +1098,14 @@ class DeepSeekV4DSparkLayer(DeepseekV4DecoderLayer):
                 {"out": out},
                 {"layer": self.prefix, "start_pos": start_pos},
             )
-        # DSpark's public reference uses a BF16 inverse-RoPE + WO-A/WO-B path
-        # here.  The target DeepSeek V4 CUDA path uses a fused FP8 _o_proj that
-        # assumes target-layer RoPE/cache invariants and corrupts DSpark draft
-        # numerics for compress_ratio=0.
-        if os.getenv("VLLM_DSPARK_REFERENCE_WO") == "1":
-            inverse_rope = (
-                _apply_dspark_inverse_rope_hf
-                if os.getenv("VLLM_DSPARK_HF_INVERSE_ROPE") == "1"
-                else _fused_inverse_rope_gptj
-            )
-            out_ref = inverse_rope(
-                out,
-                draft_positions.reshape(-1),
-                self.attn.rotary_emb.cos_sin_cache,
-                self.attn.rope_head_dim,
-            )
-            out_ref = out_ref.view(
-                batch_size * block_size,
-                self.attn.n_local_groups,
-                -1,
-            )
-            if not getattr(self, "_dspark_reference_wo_shape_logged", False):
-                logger.warning(
-                    "DSpark reference WO shapes: weight=%s scale=%s "
-                    "groups=%s rank=%s out_width=%s",
-                    tuple(self.attn.wo_a.weight.shape),
-                    tuple(getattr(self.attn.wo_a, "weight_scale_inv", ()).shape),
-                    self.attn.n_local_groups,
-                    self.attn.o_lora_rank,
-                    out_ref.shape[-1],
-                )
-                self._dspark_reference_wo_shape_logged = True
-            wo_a = _get_cached_wo_a_bf16(
-                self.attn.wo_a,
-                self.attn.n_local_groups,
-                self.attn.o_lora_rank,
-                out_ref.shape[-1],
-            )
-            z = torch.einsum("tgd,grd->tgr", out_ref, wo_a)
-            if _dspark_dump_layer_parts_enabled():
-                _maybe_save_tensor_debug(
-                    "dspark_attention_reference_wo",
-                    {
-                        "out_ref": out_ref,
-                        "wo_a": wo_a,
-                        "z": z,
-                    },
-                    {"layer": self.prefix, "start_pos": start_pos},
-                )
-        else:
-            z = rocm_inv_rope_einsum(
-                self.attn.rotary_emb,
-                out,
-                draft_positions.reshape(-1),
-                self.attn.rope_head_dim,
-                self.attn.n_local_groups,
-                self.attn.o_lora_rank,
-                self.attn.wo_a,
-            )
-        out_final = self.attn.wo_b(z.flatten(1)).view(
+        return self._dspark_output_projection(
+            out,
+            draft_positions,
             batch_size,
             block_size,
             hidden_size,
+            start_pos,
         )
-        if _dspark_dump_layer_parts_enabled():
-            _maybe_save_tensor_debug(
-                "dspark_attention_final",
-                {"out": out_final},
-                {"layer": self.prefix, "start_pos": start_pos},
-            )
-        return out_final
 
     def forward(
         self,

--- a/vllm/models/deepseek_v4/nvidia/dspark.py
+++ b/vllm/models/deepseek_v4/nvidia/dspark.py
@@ -9,6 +9,7 @@ the runtime can be implemented incrementally without accidentally falling back
 to serial MTP.
 """
 
+import contextlib
 import json
 import os
 import re
@@ -39,14 +40,15 @@ from vllm.model_executor.layers.fused_moe import (
     fused_moe_make_expert_params_mapping,
 )
 from vllm.model_executor.layers.layernorm import RMSNorm
-from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.linear import ReplicatedLinear
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
     VocabParallelEmbedding,
 )
 from vllm.model_executor.model_loader.utils import process_weights_after_loading
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+from vllm.triton_utils import tl, triton
 from vllm.utils.torch_utils import set_default_torch_dtype
 from vllm.v1.attention.ops.rocm_aiter_mla_sparse import (
     _decode_e8m0_scales,
@@ -137,7 +139,8 @@ def _maybe_save_tensor_debug(
     os.makedirs(debug_dir, exist_ok=True)
     rank = get_tensor_model_parallel_rank()
     existing = sorted(
-        name for name in os.listdir(debug_dir)
+        name
+        for name in os.listdir(debug_dir)
         if name.startswith(f"rank{rank:02d}_") and name.endswith(".pt")
     )
     if len(existing) >= max_dumps:
@@ -167,7 +170,7 @@ def _build_dspark_topk_idxs(
     window_size: int,
     batch_size: int,
     block_size: int,
-    start_pos: int,
+    positions: torch.Tensor,
     device: torch.device,
 ) -> torch.Tensor:
     """Build DSpark's rolling-window+draft attention index tensor.
@@ -175,16 +178,75 @@ def _build_dspark_topk_idxs(
     The public DSpark reference uses exactly this dense gather contract: all
     available target-window positions followed by the local draft block rows.
     """
-    if start_pos <= 0:
-        raise ValueError("DSpark decode top-k indices require start_pos > 0.")
-    target_rows = min(window_size, start_pos + 1)
-    matrix = torch.cat(
-        [
-            torch.arange(target_rows, device=device, dtype=torch.int32),
-            window_size + torch.arange(block_size, device=device, dtype=torch.int32),
-        ]
+    target = torch.arange(window_size, device=device, dtype=torch.int32)
+    valid_target = target.view(1, 1, window_size) <= positions.to(torch.int32).view(
+        batch_size, 1, 1
     )
-    return matrix.view(1, 1, -1).expand(batch_size, block_size, -1).contiguous()
+    target_idxs = torch.where(
+        valid_target,
+        target.view(1, 1, window_size),
+        target.new_full((1, 1, window_size), -1),
+    )
+    target_idxs = target_idxs.expand(batch_size, block_size, window_size)
+    draft_idxs = (
+        window_size + torch.arange(block_size, device=device, dtype=torch.int32)
+    ).view(1, 1, block_size)
+    draft_idxs = draft_idxs.expand(batch_size, block_size, block_size)
+    return torch.cat([target_idxs, draft_idxs], dim=-1).contiguous()
+
+
+@triton.jit
+def _store_dspark_context_kv_kernel(
+    cache_ptr,
+    main_kv_ptr,
+    positions_ptr,
+    query_start_loc_ptr,
+    num_rejected_ptr,
+    cache_indices_ptr,
+    cache_stride_batch: tl.constexpr,
+    cache_stride_window: tl.constexpr,
+    cache_stride_dim: tl.constexpr,
+    main_kv_stride_tokens: tl.constexpr,
+    main_kv_stride_dim: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    WINDOW_SIZE: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    req_idx = tl.program_id(0)
+    tail_idx = tl.program_id(1)
+    dim_block = tl.program_id(2)
+    cache_idx = tl.load(cache_indices_ptr + req_idx).to(tl.int64)
+
+    start = tl.load(query_start_loc_ptr + req_idx)
+    end = tl.load(query_start_loc_ptr + req_idx + 1)
+    rejected = tl.load(num_rejected_ptr + req_idx)
+    valid_end = end - rejected
+    valid_len = tl.maximum(valid_end - start, 0)
+    tail_len = tl.minimum(valid_len, WINDOW_SIZE)
+    token_idx = valid_end - tail_len + tail_idx
+    safe_token_idx = tl.maximum(token_idx, 0)
+
+    dims = dim_block * BLOCK_D + tl.arange(0, BLOCK_D)
+    dim_mask = dims < HEAD_DIM
+    valid = tail_idx < tail_len
+
+    pos = tl.load(positions_ptr + safe_token_idx, mask=valid, other=0)
+    slot = pos % WINDOW_SIZE
+    values = tl.load(
+        main_kv_ptr
+        + safe_token_idx * main_kv_stride_tokens
+        + dims * main_kv_stride_dim,
+        mask=valid & dim_mask,
+        other=0.0,
+    )
+    tl.store(
+        cache_ptr
+        + cache_idx * cache_stride_batch
+        + slot * cache_stride_window
+        + dims * cache_stride_dim,
+        values,
+        mask=valid & dim_mask,
+    )
 
 
 def _fake_fp8_e4m3_mxfp_inplace(x: torch.Tensor, block_size: int = 64) -> None:
@@ -338,8 +400,11 @@ def _dequantize_e4m3_e8m0_block_weight(
             "DSpark FP8 block scale shape mismatch: "
             f"expected {expected_scale_shape}, got {tuple(scale.shape)}."
         )
-    expanded_scale = scale.to(torch.float32).repeat_interleave(
-        block_size, dim=0).repeat_interleave(block_size, dim=1)
+    expanded_scale = (
+        scale.to(torch.float32)
+        .repeat_interleave(block_size, dim=0)
+        .repeat_interleave(block_size, dim=1)
+    )
     expanded_scale = expanded_scale[:out_features, :in_features]
     return (weight.to(torch.float32) * expanded_scale).to(out_dtype)
 
@@ -353,7 +418,8 @@ def _fp8_activation_quant_dequant_reference(
     if x.shape[-1] % block_size != 0:
         raise ValueError(
             "DSpark FP8 activation reference requires block-aligned K, got "
-            f"{x.shape[-1]} with block={block_size}.")
+            f"{x.shape[-1]} with block={block_size}."
+        )
     original_shape = x.shape
     xf = x.reshape(-1, x.shape[-1]).float()
     xb = xf.view(xf.shape[0], xf.shape[1] // block_size, block_size)
@@ -379,8 +445,7 @@ def _fp8_block_linear_reference(
         out_dtype=torch.bfloat16,
     )
     x_dq = _fp8_activation_quant_dequant_reference(x)
-    out = x_dq.reshape(-1, x.shape[-1]).float().matmul(
-        weight_bf16.float().t())
+    out = x_dq.reshape(-1, x.shape[-1]).float().matmul(weight_bf16.float().t())
     return out.to(torch.bfloat16).view(*x.shape[:-1], weight.shape[0])
 
 
@@ -407,10 +472,8 @@ def _read_dspark_num_layers(model_path: str, default: int) -> int:
         for name in weight_map:
             parts = name.split(".")
             if len(parts) > 2 and parts[0] == "mtp":
-                try:
+                with contextlib.suppress(ValueError):
                     stage_ids.add(int(parts[1]))
-                except ValueError:
-                    pass
         if stage_ids:
             return max(stage_ids) + 1
     return int(default)
@@ -427,15 +490,16 @@ def _iter_mtp_safetensors(model_path: str) -> Iterable[tuple[str, torch.Tensor]]
     with open(index_path, encoding="utf-8") as f:
         weight_map = json.load(f)["weight_map"]
 
-    files = sorted({filename for name, filename in weight_map.items()
-                    if name.startswith("mtp.")})
+    files = sorted(
+        {filename for name, filename in weight_map.items() if name.startswith("mtp.")}
+    )
     if not files:
         raise ValueError(f"No mtp.* DSpark weights found in {index_path!r}.")
 
     for filename in files:
         path = os.path.join(model_path, filename)
         with safe_open(path, framework="pt", device="cpu") as f:
-            for name in f.keys():
+            for name in f.keys():  # noqa: SIM118
                 if name.startswith("mtp."):
                     yield name, f.get_tensor(name)
 
@@ -519,10 +583,12 @@ class DeepSeekV4DSparkLayer(DeepseekV4DecoderLayer):
         self.prefix = prefix
         config = vllm_config.model_config.hf_config
         self._dspark_use_reference_fp8_linears = bool(
-            int(os.getenv("VLLM_DSPARK_REFERENCE_FP8_LINEARS", "0")))
-        self._dspark_use_separate_qkv = bool(
-            int(os.getenv("VLLM_DSPARK_SEPARATE_QKV", "0"))
-        ) or self._dspark_use_reference_fp8_linears
+            int(os.getenv("VLLM_DSPARK_REFERENCE_FP8_LINEARS", "0"))
+        )
+        self._dspark_use_separate_qkv = (
+            bool(int(os.getenv("VLLM_DSPARK_SEPARATE_QKV", "0")))
+            or self._dspark_use_reference_fp8_linears
+        )
         if self._dspark_use_separate_qkv:
             self.attn.wq_a = ReplicatedLinear(
                 config.hidden_size,
@@ -566,8 +632,11 @@ class DeepSeekV4DSparkLayer(DeepseekV4DecoderLayer):
                 prefix=f"{prefix}.confidence_head",
             )
             self.hc_head_fn = nn.Parameter(
-                torch.empty(config.hc_mult, config.hc_mult * config.hidden_size,
-                            dtype=torch.float32),
+                torch.empty(
+                    config.hc_mult,
+                    config.hc_mult * config.hidden_size,
+                    dtype=torch.float32,
+                ),
                 requires_grad=False,
             )
             self.hc_head_base = nn.Parameter(
@@ -580,9 +649,7 @@ class DeepSeekV4DSparkLayer(DeepseekV4DecoderLayer):
             )
 
         self.dspark_block_size = int(getattr(config, "dspark_block_size", 0) or 0)
-        self.dspark_noise_token_id = int(
-            getattr(config, "dspark_noise_token_id", -1)
-        )
+        self.dspark_noise_token_id = int(getattr(config, "dspark_noise_token_id", -1))
         if self.dspark_block_size <= 0:
             raise ValueError("DSpark requires dspark_block_size in the config.")
         if self.dspark_noise_token_id < 0:
@@ -612,15 +679,12 @@ class DeepSeekV4DSparkLayer(DeepseekV4DecoderLayer):
     ) -> torch.Tensor:
         batch_size = main_x.shape[0]
         if self._dspark_use_reference_fp8_linears:
-            kv = self._apply_reference_fp8_linear(
-                "wkv", main_x.view(batch_size, -1))
+            kv = self._apply_reference_fp8_linear("wkv", main_x.view(batch_size, -1))
         elif self._dspark_use_separate_qkv:
             kv = _linear_output(self.attn.wkv(main_x.view(batch_size, -1)))
         else:
-            qr_kv = _linear_output(
-                self.attn.fused_wqa_wkv(main_x.view(batch_size, -1)))
-            _, kv = qr_kv.split([self.attn.q_lora_rank, self.attn.head_dim],
-                                dim=-1)
+            qr_kv = _linear_output(self.attn.fused_wqa_wkv(main_x.view(batch_size, -1)))
+            _, kv = qr_kv.split([self.attn.q_lora_rank, self.attn.head_dim], dim=-1)
         if _dspark_dump_layer_parts_enabled():
             _maybe_save_tensor_debug(
                 "dspark_main_kv_linear",
@@ -660,8 +724,9 @@ class DeepSeekV4DSparkLayer(DeepseekV4DecoderLayer):
         batch_size, seq_len, _ = main_x.shape
         window_size = self.attn.window_size
         cache = self.dspark_kv_cache[cache_start : cache_start + batch_size]
-        main_kv = self._compute_main_kv(main_x.reshape(-1, main_x.shape[-1]),
-                                        positions.reshape(-1))
+        main_kv = self._compute_main_kv(
+            main_x.reshape(-1, main_x.shape[-1]), positions.reshape(-1)
+        )
         main_kv = main_kv.view(batch_size, seq_len, self.attn.head_dim)
         tail_len = min(seq_len, window_size)
         tail_kv = main_kv[:, -tail_len:]
@@ -673,6 +738,42 @@ class DeepSeekV4DSparkLayer(DeepseekV4DecoderLayer):
             device=main_x.device,
         ).view(batch_size, 1)
         cache[batch_indices, slots] = tail_kv
+
+    def precompute_dspark_context_kv_flat(
+        self,
+        main_x: torch.Tensor,
+        positions: torch.Tensor,
+        query_start_loc: torch.Tensor,
+        num_rejected: torch.Tensor,
+        cache_indices: torch.Tensor,
+        num_reqs: int,
+    ) -> None:
+        """Populate this stage's rolling target-KV window from flat target rows."""
+        if num_reqs <= 0:
+            return
+        main_kv = self._compute_main_kv(main_x, positions).contiguous()
+        block_d = 64
+        grid = (
+            num_reqs,
+            self.attn.window_size,
+            triton.cdiv(self.attn.head_dim, block_d),
+        )
+        _store_dspark_context_kv_kernel[grid](
+            self.dspark_kv_cache,
+            main_kv,
+            positions,
+            query_start_loc,
+            num_rejected,
+            cache_indices,
+            self.dspark_kv_cache.stride(0),
+            self.dspark_kv_cache.stride(1),
+            self.dspark_kv_cache.stride(2),
+            main_kv.stride(0),
+            main_kv.stride(1),
+            HEAD_DIM=self.attn.head_dim,
+            WINDOW_SIZE=self.attn.window_size,
+            BLOCK_D=block_d,
+        )
 
     def cache_dspark_wo_a_bf16(self) -> None:
         """Preserve DSpark's HF-style BF16 WO-A before FP8 kernel repacking.
@@ -689,15 +790,12 @@ class DeepSeekV4DSparkLayer(DeepseekV4DecoderLayer):
                 self.attn.n_local_groups * self.attn.o_lora_rank,
                 -1,
             )
-            scale = _decode_e8m0_scales(
-                self.attn.wo_a.weight_scale_inv
-            ).reshape(-1, self.attn.wo_a.weight_scale_inv.shape[-1])
-            cached = (
-                flat_weight.unflatten(0, (-1, 128))
-                .unflatten(-1, (-1, 128))
-                .to(torch.float32)
-                * scale[:, None, :, None].to(torch.float32)
+            scale = _decode_e8m0_scales(self.attn.wo_a.weight_scale_inv).reshape(
+                -1, self.attn.wo_a.weight_scale_inv.shape[-1]
             )
+            cached = flat_weight.unflatten(0, (-1, 128)).unflatten(-1, (-1, 128)).to(
+                torch.float32
+            ) * scale[:, None, :, None].to(torch.float32)
             cached = (
                 cached.flatten(2, 3)
                 .flatten(0, 1)
@@ -731,7 +829,8 @@ class DeepSeekV4DSparkLayer(DeepseekV4DecoderLayer):
             layer = getattr(self.attn, attr)
             if not hasattr(layer, "weight_scale_inv"):
                 raise ValueError(
-                    f"DSpark reference FP8 linear {attr} has no block scale.")
+                    f"DSpark reference FP8 linear {attr} has no block scale."
+                )
             weight = layer.weight.detach().clone()
             scale = layer.weight_scale_inv.detach().clone()
             for name, tensor in (
@@ -757,7 +856,8 @@ class DeepSeekV4DSparkLayer(DeepseekV4DecoderLayer):
         positions: torch.Tensor,
         x: torch.Tensor,
         main_x: torch.Tensor,
-        start_pos: int,
+        cache_indices: torch.Tensor,
+        start_pos: int | None = None,
     ) -> torch.Tensor:
         batch_size, block_size, hidden_size = x.shape
         if block_size != self.dspark_block_size:
@@ -782,8 +882,7 @@ class DeepSeekV4DSparkLayer(DeepseekV4DecoderLayer):
             kv = _linear_output(self.attn.wkv(flat_x))
         else:
             qr_kv = _linear_output(self.attn.fused_wqa_wkv(flat_x))
-            qr, kv = qr_kv.split([self.attn.q_lora_rank, self.attn.head_dim],
-                                 dim=-1)
+            qr, kv = qr_kv.split([self.attn.q_lora_rank, self.attn.head_dim], dim=-1)
         q_normed = self.attn.q_norm(qr)
         if self._dspark_use_reference_fp8_linears:
             q = self._apply_reference_fp8_linear("wq_b", q_normed)
@@ -805,21 +904,17 @@ class DeepSeekV4DSparkLayer(DeepseekV4DecoderLayer):
                 },
                 {"layer": self.prefix, "start_pos": start_pos},
             )
-        q = q.view(batch_size * block_size, self.attn.n_local_heads,
-                   self.attn.head_dim)
+        q = q.view(batch_size * block_size, self.attn.n_local_heads, self.attn.head_dim)
         q *= torch.rsqrt(q.square().mean(-1, keepdim=True) + self.attn.eps)
         q_after_scale_debug = q.clone() if _dspark_dump_layer_parts_enabled() else None
         kv = kv_normed.view(batch_size * block_size, 1, self.attn.head_dim)
 
-        draft_positions = (
-            positions.view(batch_size, 1)
-            + torch.arange(
-                1,
-                block_size + 1,
-                dtype=positions.dtype,
-                device=positions.device,
-            ).view(1, block_size)
-        )
+        draft_positions = positions.view(batch_size, 1) + torch.arange(
+            1,
+            block_size + 1,
+            dtype=positions.dtype,
+            device=positions.device,
+        ).view(1, block_size)
         q = _apply_dspark_rope_hf(
             q,
             draft_positions.reshape(-1),
@@ -846,18 +941,20 @@ class DeepSeekV4DSparkLayer(DeepseekV4DecoderLayer):
                 },
                 {"layer": self.prefix, "start_pos": start_pos},
             )
-        q = q.view(batch_size, block_size, self.attn.n_local_heads,
-                   self.attn.head_dim)
+        q = q.view(batch_size, block_size, self.attn.n_local_heads, self.attn.head_dim)
         kv = kv.view(batch_size, block_size, self.attn.head_dim)
 
         window_size = self.attn.window_size
-        self.dspark_kv_cache[:batch_size, start_pos % window_size].copy_(main_kv)
-        all_kv = torch.cat([self.dspark_kv_cache[:batch_size], kv], dim=1)
+        cache_rows = cache_indices.view(batch_size).long()
+        cache_slots = positions.view(batch_size).remainder(window_size).long()
+        self.dspark_kv_cache[cache_rows, cache_slots].copy_(main_kv)
+        cache_window = self.dspark_kv_cache[cache_rows]
+        all_kv = torch.cat([cache_window, kv], dim=1)
         topk_idxs = _build_dspark_topk_idxs(
             window_size=window_size,
             batch_size=batch_size,
             block_size=block_size,
-            start_pos=start_pos,
+            positions=positions.view(batch_size),
             device=x.device,
         )
         if _dspark_dump_layer_parts_enabled():
@@ -869,7 +966,7 @@ class DeepSeekV4DSparkLayer(DeepseekV4DecoderLayer):
                     "main_kv": main_kv,
                     "q": q,
                     "kv": kv,
-                    "cache_window": self.dspark_kv_cache[:batch_size],
+                    "cache_window": cache_window,
                     "topk_idxs": topk_idxs,
                 },
                 {"layer": self.prefix, "start_pos": start_pos},
@@ -907,9 +1004,12 @@ class DeepSeekV4DSparkLayer(DeepseekV4DecoderLayer):
                 if os.getenv("VLLM_DSPARK_HF_INVERSE_ROPE") == "1"
                 else _fused_inverse_rope_gptj
             )
-            out_ref = inverse_rope(out, draft_positions.reshape(-1),
-                                   self.attn.rotary_emb.cos_sin_cache,
-                                   self.attn.rope_head_dim)
+            out_ref = inverse_rope(
+                out,
+                draft_positions.reshape(-1),
+                self.attn.rotary_emb.cos_sin_cache,
+                self.attn.rope_head_dim,
+            )
             out_ref = out_ref.view(
                 batch_size * block_size,
                 self.attn.n_local_groups,
@@ -972,7 +1072,8 @@ class DeepSeekV4DSparkLayer(DeepseekV4DecoderLayer):
         positions: torch.Tensor,
         input_ids: torch.Tensor,
         main_x: torch.Tensor,
-        start_pos: int,
+        cache_indices: torch.Tensor,
+        start_pos: int | None = None,
         post_mix: torch.Tensor | None = None,
         res_mix: torch.Tensor | None = None,
         residual: torch.Tensor | None = None,
@@ -1025,6 +1126,7 @@ class DeepSeekV4DSparkLayer(DeepseekV4DecoderLayer):
             positions,
             x_attn.view(batch_size, block_size, hidden_size),
             main_x,
+            cache_indices,
             start_pos,
         ).reshape(batch_size * block_size, hidden_size)
 
@@ -1043,7 +1145,12 @@ class DeepSeekV4DSparkLayer(DeepseekV4DecoderLayer):
             hc_fn_bf16=self.hc_ffn_fn_bf16,
         )
         x_ffn = self.ffn(x_ffn, input_ids_flat)
-        return x_ffn.view(batch_size, block_size, hidden_size), residual, post_mix, res_mix
+        return (
+            x_ffn.view(batch_size, block_size, hidden_size),
+            residual,
+            post_mix,
+            res_mix,
+        )
 
     def forward_reference_hc(
         self,
@@ -1051,7 +1158,8 @@ class DeepSeekV4DSparkLayer(DeepseekV4DecoderLayer):
         positions: torch.Tensor,
         input_ids: torch.Tensor,
         main_x: torch.Tensor,
-        start_pos: int,
+        cache_indices: torch.Tensor,
+        start_pos: int | None = None,
     ) -> torch.Tensor:
         """DSpark-only HF-style HC reference path.
 
@@ -1099,6 +1207,7 @@ class DeepSeekV4DSparkLayer(DeepseekV4DecoderLayer):
             positions,
             x_attn.view(batch_size, block_size, hidden_size),
             main_x,
+            cache_indices,
             start_pos,
         ).reshape(batch_size * block_size, hidden_size)
         if _dspark_dump_layer_parts_enabled():
@@ -1244,7 +1353,8 @@ class DeepSeekV4DSparkDraft(nn.Module):
         first_layer = self.layers[str(self.dspark_start_layer_idx)]
         assert isinstance(first_layer, DeepSeekV4DSparkLayer)
         main_x = _linear_output(
-            first_layer.main_proj(_maybe_fake_fp8_main_proj_input(main_hidden)))
+            first_layer.main_proj(_maybe_fake_fp8_main_proj_input(main_hidden))
+        )
         main_x = first_layer.main_norm(main_x)
         batch_size = input_ids.shape[0]
         draft_input_ids = input_ids.new_full(
@@ -1269,7 +1379,8 @@ class DeepSeekV4DSparkDraft(nn.Module):
         first_layer = self.layers[str(self.dspark_start_layer_idx)]
         assert isinstance(first_layer, DeepSeekV4DSparkLayer)
         main_x = _linear_output(
-            first_layer.main_proj(_maybe_fake_fp8_main_proj_input(main_hidden)))
+            first_layer.main_proj(_maybe_fake_fp8_main_proj_input(main_hidden))
+        )
         main_x = first_layer.main_norm(main_x)
 
         for req_idx, (start, end) in enumerate(context_ranges):
@@ -1284,6 +1395,36 @@ class DeepSeekV4DSparkDraft(nn.Module):
                     req_positions,
                     cache_start=req_idx,
                 )
+
+    def precompute_context_kv_flat(
+        self,
+        main_hidden: torch.Tensor,
+        positions: torch.Tensor,
+        query_start_loc: torch.Tensor,
+        num_rejected: torch.Tensor,
+        cache_indices: torch.Tensor,
+        num_reqs: int,
+    ) -> None:
+        """Populate DSpark rolling target-KV caches from flat target rows."""
+        if num_reqs <= 0 or main_hidden.numel() == 0:
+            return
+        first_layer = self.layers[str(self.dspark_start_layer_idx)]
+        assert isinstance(first_layer, DeepSeekV4DSparkLayer)
+        main_x = _linear_output(
+            first_layer.main_proj(_maybe_fake_fp8_main_proj_input(main_hidden))
+        )
+        main_x = first_layer.main_norm(main_x)
+
+        for layer in self.layers.values():
+            assert isinstance(layer, DeepSeekV4DSparkLayer)
+            layer.precompute_dspark_context_kv_flat(
+                main_x,
+                positions,
+                query_start_loc,
+                num_rejected,
+                cache_indices,
+                num_reqs,
+            )
 
     def reset_dspark_kv_cache(self) -> None:
         for layer in self.layers.values():
@@ -1341,9 +1482,11 @@ class DeepSeekV4DSparkDraft(nn.Module):
                     "base_logits": logits,
                 },
                 {
-                    "start_pos": (int(positions[0].item())
-                                  if positions is not None
-                                  and positions.numel() else None),
+                    "start_pos": (
+                        int(positions[0].item())
+                        if positions is not None and positions.numel()
+                        else None
+                    ),
                 },
             )
 
@@ -1363,9 +1506,11 @@ class DeepSeekV4DSparkDraft(nn.Module):
                     },
                     {
                         "step": idx,
-                        "start_pos": (int(positions[0].item())
-                                      if positions is not None
-                                      and positions.numel() else None),
+                        "start_pos": (
+                            int(positions[0].item())
+                            if positions is not None and positions.numel()
+                            else None
+                        ),
                     },
                 )
             if not disable_markov_bias:
@@ -1413,31 +1558,32 @@ class DeepSeekV4DSparkDraft(nn.Module):
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         if positions.numel() == 0:
             raise ValueError("DSpark forward_spec requires at least one position.")
-        # Initial version only supports uniform decode positions.  The speculator
-        # can relax this later with fully tensorized rolling-cache writes.
-        if not torch.all(positions == positions[0]):
-            raise NotImplementedError(
-                "DSpark forward_spec currently requires uniform decode positions."
-            )
-        start_pos = int(positions[0].item())
+        if idx_mapping is None:
+            raise ValueError("DSpark forward_spec requires idx_mapping.")
+        debug_start_pos = None
+        if os.getenv("VLLM_DSPARK_DEBUG_DIR") or os.getenv(
+            "VLLM_DSPARK_TENSOR_DEBUG_DIR"
+        ):
+            debug_start_pos = int(positions[0].detach().cpu())
         x, main_x, draft_input_ids = self.forward_embed(main_hidden, input_ids)
-        _maybe_dump_stage_debug(
-            "forward_embed",
-            {
-                "main_hidden": main_hidden,
-                "main_x": main_x,
-                "x": x,
-            },
-            {
-                "start_pos": start_pos,
-                "input_ids": [
-                    int(v) for v in input_ids.detach().cpu().tolist()[:8]
-                ],
-                "positions": [
-                    int(v) for v in positions.detach().cpu().tolist()[:8]
-                ],
-            },
-        )
+        if os.getenv("VLLM_DSPARK_DEBUG_DIR"):
+            _maybe_dump_stage_debug(
+                "forward_embed",
+                {
+                    "main_hidden": main_hidden,
+                    "main_x": main_x,
+                    "x": x,
+                },
+                {
+                    "start_pos": debug_start_pos,
+                    "input_ids": [
+                        int(v) for v in input_ids.detach().cpu().tolist()[:8]
+                    ],
+                    "positions": [
+                        int(v) for v in positions.detach().cpu().tolist()[:8]
+                    ],
+                },
+            )
         _maybe_save_tensor_debug(
             "forward_embed",
             {
@@ -1449,15 +1595,9 @@ class DeepSeekV4DSparkDraft(nn.Module):
                 "x": x,
             },
             {
-                "start_pos": start_pos,
+                "start_pos": debug_start_pos,
             },
         )
-        if start_pos == 0:
-            main_positions = positions.view(-1, 1)
-            for layer in self.layers.values():
-                assert isinstance(layer, DeepSeekV4DSparkLayer)
-                layer.precompute_dspark_context_kv(main_x, main_positions)
-            raise RuntimeError("DSpark context prefill does not produce draft tokens.")
 
         final_layer = self.layers[
             str(self.dspark_start_layer_idx + self.num_dspark_layers - 1)
@@ -1471,17 +1611,18 @@ class DeepSeekV4DSparkDraft(nn.Module):
                     positions,
                     draft_input_ids,
                     main_x,
-                    start_pos,
+                    idx_mapping,
+                    debug_start_pos,
                 )
                 _maybe_dump_stage_debug(
                     "layer_reference_hc",
                     {"x": x},
-                    {"layer": layer.prefix, "start_pos": start_pos},
+                    {"layer": layer.prefix, "start_pos": debug_start_pos},
                 )
                 _maybe_save_tensor_debug(
                     "layer_reference_hc",
                     {"x": x},
-                    {"layer": layer.prefix, "start_pos": start_pos},
+                    {"layer": layer.prefix, "start_pos": debug_start_pos},
                 )
         else:
             residual, post_mix, res_mix = None, None, None
@@ -1492,7 +1633,8 @@ class DeepSeekV4DSparkDraft(nn.Module):
                     positions,
                     draft_input_ids,
                     main_x,
-                    start_pos,
+                    idx_mapping,
+                    debug_start_pos,
                     post_mix,
                     res_mix,
                     residual,
@@ -1505,7 +1647,7 @@ class DeepSeekV4DSparkDraft(nn.Module):
                         "post_mix": post_mix,
                         "res_mix": res_mix,
                     },
-                    {"layer": layer.prefix, "start_pos": start_pos},
+                    {"layer": layer.prefix, "start_pos": debug_start_pos},
                 )
                 _maybe_save_tensor_debug(
                     "layer_fused_hc",
@@ -1515,7 +1657,7 @@ class DeepSeekV4DSparkDraft(nn.Module):
                         "post_mix": post_mix,
                         "res_mix": res_mix,
                     },
-                    {"layer": layer.prefix, "start_pos": start_pos},
+                    {"layer": layer.prefix, "start_pos": debug_start_pos},
                 )
             assert residual is not None
             assert post_mix is not None
@@ -1545,12 +1687,12 @@ class DeepSeekV4DSparkDraft(nn.Module):
             _maybe_dump_stage_debug(
                 "final_mhc_post",
                 {"x": x},
-                {"start_pos": start_pos},
+                {"start_pos": debug_start_pos},
             )
             _maybe_save_tensor_debug(
                 "final_mhc_post",
                 {"x": x},
-                {"start_pos": start_pos},
+                {"start_pos": debug_start_pos},
             )
         output_ids, logits, confidence = self.forward_head(
             x,
@@ -1564,20 +1706,21 @@ class DeepSeekV4DSparkDraft(nn.Module):
             active_num_reqs=active_num_reqs,
             use_fp64_gumbel=use_fp64_gumbel,
         )
-        _maybe_dump_stage_debug(
-            "forward_head",
-            {
-                "logits": logits,
-                "confidence": confidence,
-            },
-            {
-                "start_pos": start_pos,
-                "output_ids": [
-                    [int(v) for v in row]
-                    for row in output_ids.detach().cpu().tolist()[:2]
-                ],
-            },
-        )
+        if os.getenv("VLLM_DSPARK_DEBUG_DIR"):
+            _maybe_dump_stage_debug(
+                "forward_head",
+                {
+                    "logits": logits,
+                    "confidence": confidence,
+                },
+                {
+                    "start_pos": debug_start_pos,
+                    "output_ids": [
+                        [int(v) for v in row]
+                        for row in output_ids.detach().cpu().tolist()[:2]
+                    ],
+                },
+            )
         _maybe_save_tensor_debug(
             "forward_head",
             {
@@ -1588,7 +1731,7 @@ class DeepSeekV4DSparkDraft(nn.Module):
                 "confidence": confidence,
             },
             {
-                "start_pos": start_pos,
+                "start_pos": debug_start_pos,
             },
         )
         return output_ids, logits, confidence
@@ -1660,8 +1803,7 @@ class DeepSeekV4DSparkDraft(nn.Module):
                 entry["scale"],
                 out_dtype=param.dtype,
             )
-            dequant_weight = dequant_weight.to(
-                device=param.device, dtype=param.dtype)
+            dequant_weight = dequant_weight.to(device=param.device, dtype=param.dtype)
             with torch.no_grad():
                 param.data.copy_(dequant_weight)
             loaded_params.add(param_name)
@@ -1694,10 +1836,9 @@ class DeepSeekV4DSparkDraft(nn.Module):
             for param_name, weight_name, shard_id in stacked_params_mapping:
                 if ".experts." in name:
                     continue
-                if (
-                    self.layers[str(spec_layer)]._dspark_use_separate_qkv
-                    and weight_name in ("attn.wq_a", "attn.wkv")
-                ):
+                if self.layers[
+                    str(spec_layer)
+                ]._dspark_use_separate_qkv and weight_name in ("attn.wq_a", "attn.wkv"):
                     continue
                 if weight_name in ("w1", "w3") and ".shared_experts." not in name:
                     continue
@@ -1746,16 +1887,16 @@ class DeepSeekV4DSparkDraft(nn.Module):
                     loaded_params.add(name)
                     continue
                 if ".shared_experts.w2" in name:
-                    name = name.replace(".shared_experts.w2",
-                                        ".shared_experts.down_proj")
+                    name = name.replace(
+                        ".shared_experts.w2", ".shared_experts.down_proj"
+                    )
                 if name.endswith(".ffn.gate.bias"):
                     name = name.replace(
                         ".ffn.gate.bias",
                         ".ffn.gate.e_score_correction_bias",
                     )
                 param = params_dict[name]
-                weight_loader = getattr(param, "weight_loader",
-                                        default_weight_loader)
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)
                 loaded_params.add(name)
 

--- a/vllm/models/deepseek_v4/nvidia/model.py
+++ b/vllm/models/deepseek_v4/nvidia/model.py
@@ -80,6 +80,7 @@ from vllm.v1.worker.workspace import current_workspace_manager
 
 logger = init_logger(__name__)
 
+
 def _get_virtual_tp_axis_padded_size(config, axis_name: str, default: int) -> int:
     plan = getattr(config, VIRTUAL_TP_PLAN_ATTR, None)
     if not isinstance(plan, dict):
@@ -1562,28 +1563,27 @@ class DeepseekV4Model(nn.Module):
                         if use_dspark_reference_hc:
                             tokens, hc_mult, _ = residual.shape
                             post_ref = post_mix
-                            if (
-                                post_ref.ndim == 2
-                                and post_ref.shape == (hc_mult, tokens)
+                            if post_ref.ndim == 2 and post_ref.shape == (
+                                hc_mult,
+                                tokens,
                             ):
                                 post_ref = post_ref.t().contiguous()
                             comb_ref = res_mix
-                            if (
-                                comb_ref.ndim == 3
-                                and comb_ref.shape == (hc_mult, hc_mult, tokens)
+                            if comb_ref.ndim == 3 and comb_ref.shape == (
+                                hc_mult,
+                                hc_mult,
+                                tokens,
                             ):
                                 comb_ref = comb_ref.permute(2, 0, 1).contiguous()
-                            use_dspark_reference_hc = (
-                                post_ref.shape == (tokens, hc_mult)
-                                and comb_ref.shape == (tokens, hc_mult, hc_mult)
-                            )
+                            use_dspark_reference_hc = post_ref.shape == (
+                                tokens,
+                                hc_mult,
+                            ) and comb_ref.shape == (tokens, hc_mult, hc_mult)
                         if use_dspark_reference_hc:
                             aux_hc_states = (
-                                post_ref.unsqueeze(-1)
-                                * hidden_states.unsqueeze(-2)
+                                post_ref.unsqueeze(-1) * hidden_states.unsqueeze(-2)
                                 + torch.sum(
-                                    comb_ref.unsqueeze(-1)
-                                    * residual.unsqueeze(-2),
+                                    comb_ref.unsqueeze(-1) * residual.unsqueeze(-2),
                                     dim=2,
                                 )
                             ).type_as(hidden_states)

--- a/vllm/models/deepseek_v4/nvidia/model.py
+++ b/vllm/models/deepseek_v4/nvidia/model.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import os
 import typing
 from collections.abc import Callable, Iterable, MutableSequence, Sequence
 from itertools import islice
@@ -1482,6 +1483,12 @@ class DeepseekV4Model(nn.Module):
             )
         else:
             self._mtp_hidden_buffer = None
+        self.aux_hidden_state_layers: tuple[int, ...] = ()
+        self.aux_hidden_state_capture_mode: str | None = None
+
+    def set_dspark_aux_hidden_state_layers(self, layers: tuple[int, ...]) -> None:
+        self.aux_hidden_state_layers = layers
+        self.aux_hidden_state_capture_mode = "dspark_post_layer_mean"
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.embed_tokens(input_ids)
@@ -1512,7 +1519,7 @@ class DeepseekV4Model(nn.Module):
         positions: torch.Tensor,
         intermediate_tensors: IntermediateTensors | None,
         inputs_embeds: torch.Tensor | None = None,
-    ) -> torch.Tensor | IntermediateTensors:
+    ) -> torch.Tensor | tuple[torch.Tensor, list[torch.Tensor]] | IntermediateTensors:
         if get_pp_group().is_first_rank:
             if inputs_embeds is not None:
                 hidden_states = inputs_embeds
@@ -1526,8 +1533,13 @@ class DeepseekV4Model(nn.Module):
         if self.use_mega_moe:
             input_ids = input_ids.to(torch.int64)
 
+        aux_hidden_states: list[torch.Tensor] = []
         residual, post_mix, res_mix = None, None, None
-        for layer in islice(self.layers, self.start_layer, self.end_layer):
+        layer = None
+        for idx, layer in enumerate(
+            islice(self.layers, self.start_layer, self.end_layer),
+            start=self.start_layer,
+        ):
             hidden_states, residual, post_mix, res_mix = layer(
                 hidden_states,
                 positions,
@@ -1536,6 +1548,64 @@ class DeepseekV4Model(nn.Module):
                 res_mix,
                 residual,
             )
+            if idx in self.aux_hidden_state_layers:
+                if self.aux_hidden_state_capture_mode == "dspark_post_layer_mean":
+                    if hidden_states.dim() == 3:
+                        aux_hidden_states.append(hidden_states.mean(dim=1))
+                    else:
+                        assert residual is not None
+                        assert post_mix is not None
+                        assert res_mix is not None
+                        use_dspark_reference_hc = (
+                            os.getenv("VLLM_DSPARK_REFERENCE_HC") == "1"
+                        )
+                        if use_dspark_reference_hc:
+                            tokens, hc_mult, _ = residual.shape
+                            post_ref = post_mix
+                            if (
+                                post_ref.ndim == 2
+                                and post_ref.shape == (hc_mult, tokens)
+                            ):
+                                post_ref = post_ref.t().contiguous()
+                            comb_ref = res_mix
+                            if (
+                                comb_ref.ndim == 3
+                                and comb_ref.shape == (hc_mult, hc_mult, tokens)
+                            ):
+                                comb_ref = comb_ref.permute(2, 0, 1).contiguous()
+                            use_dspark_reference_hc = (
+                                post_ref.shape == (tokens, hc_mult)
+                                and comb_ref.shape == (tokens, hc_mult, hc_mult)
+                            )
+                        if use_dspark_reference_hc:
+                            aux_hc_states = (
+                                post_ref.unsqueeze(-1)
+                                * hidden_states.unsqueeze(-2)
+                                + torch.sum(
+                                    comb_ref.unsqueeze(-1)
+                                    * residual.unsqueeze(-2),
+                                    dim=2,
+                                )
+                            ).type_as(hidden_states)
+                        elif layer._should_run_b12x_mhc(int(hidden_states.shape[0])):
+                            from b12x.integration.residual import b12x_mhc_post
+
+                            aux_hc_states = b12x_mhc_post(
+                                hidden_states,
+                                residual,
+                                post_mix,
+                                res_mix,
+                            )
+                        else:
+                            aux_hc_states = mhc_post_tilelang(
+                                hidden_states,
+                                residual,
+                                post_mix,
+                                res_mix,
+                            )
+                        aux_hidden_states.append(aux_hc_states.mean(dim=1))
+                else:
+                    aux_hidden_states.append(hidden_states.flatten(1))
         if layer is not None:
             assert residual is not None
             assert post_mix is not None
@@ -1570,6 +1640,8 @@ class DeepseekV4Model(nn.Module):
             self.hc_eps,
         )
         hidden_states = self.norm(hidden_states)
+        if aux_hidden_states:
+            return hidden_states, aux_hidden_states
         return hidden_states
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
@@ -1877,7 +1949,7 @@ class DeepseekV4ForCausalLM(nn.Module, SupportsPP, DeepseekV4MixtureOfExperts):
         positions: torch.Tensor,
         intermediate_tensors: IntermediateTensors | None = None,
         inputs_embeds: torch.Tensor | None = None,
-    ) -> torch.Tensor | IntermediateTensors:
+    ) -> torch.Tensor | tuple[torch.Tensor, list[torch.Tensor]] | IntermediateTensors:
         hidden_states = self.model(
             input_ids, positions, intermediate_tensors, inputs_embeds
         )

--- a/vllm/models/deepseek_v4/nvidia/ops/dspark_sparse_attn_tilelang.py
+++ b/vllm/models/deepseek_v4/nvidia/ops/dspark_sparse_attn_tilelang.py
@@ -1,0 +1,211 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""TileLang sparse attention used by DeepSeek V4 DSpark draft blocks.
+
+This is intentionally separate from the normal DeepSeek V4 sparse-MLA path:
+DSpark attends a block of draft queries over a small rolling target-KV window
+plus the draft block KV, indexed by a dense ``topk_idxs`` tensor.  It does not
+consume vLLM paged MLA metadata.
+"""
+
+from functools import cache
+from typing import Any
+
+import torch
+
+
+@cache
+def _build_dspark_sparse_attn_kernel(num_heads: int, head_dim: int, scale: float):
+    import tilelang
+    import tilelang.language as T
+
+    pass_configs: dict[tilelang.PassConfigKey, Any] = {
+        tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
+        tilelang.PassConfigKey.TL_DISABLE_TMA_LOWER: True,
+    }
+
+    bf16 = "bfloat16"
+    fp32 = "float32"
+    int32 = "int32"
+
+    @tilelang.jit(pass_configs=pass_configs)
+    def kernel(h: int, d: int, softmax_scale: float):
+        b = T.symbolic("b")
+        m = T.symbolic("m")
+        n = T.symbolic("n")
+        topk = T.symbolic("topk")
+
+        num_stages = 2
+        threads = 256
+        # The upstream DSpark reference uses 64, which asks for ~104 KiB
+        # dynamic shared memory on DeepSeek V4 head dims and is rejected on
+        # this sm120 stack. 32 keeps the same online-softmax algorithm while
+        # fitting under the per-block shared-memory limit.
+        block = 32
+        num_blocks = tilelang.cdiv(topk, block)
+
+        @T.prim_func
+        def sparse_attn_kernel_(
+            q: T.Tensor[(b, m, h, d), bf16],
+            kv: T.Tensor[(b, n, d), bf16],
+            out: T.Tensor[(b, m, h, d), bf16],
+            attn_sink: T.Tensor[(h,), fp32],
+            topk_idxs: T.Tensor[(b, m, topk), int32],
+        ):
+            with T.Kernel(m, b, threads=threads) as (bx, by):
+                q_shared = T.alloc_shared((h, d), bf16)
+                kv_shared = T.alloc_shared((block, d), bf16)
+                out_shared = T.alloc_shared((h, d), bf16)
+                acc_s_cast = T.alloc_shared((h, block), bf16)
+
+                idxs = T.alloc_fragment(block, int32)
+                acc_s = T.alloc_fragment((h, block), fp32)
+                acc_o = T.alloc_fragment((h, d), fp32)
+                scores_max = T.alloc_fragment(h, fp32)
+                scores_max_prev = T.alloc_fragment(h, fp32)
+                scores_scale = T.alloc_fragment(h, fp32)
+                scores_sum = T.alloc_fragment(h, fp32)
+                sum_exp = T.alloc_fragment(h, fp32)
+
+                T.clear(acc_o)
+                T.clear(sum_exp)
+                T.fill(scores_max, -T.infinity(fp32))
+                T.copy(q[by, bx, :, :], q_shared)
+
+                for t in T.Pipelined(num_blocks, num_stages=num_stages):
+                    for i in T.Parallel(block):
+                        idxs[i] = T.if_then_else(
+                            t * block + i < topk,
+                            topk_idxs[by, bx, t * block + i],
+                            -1,
+                        )
+                    for i, j in T.Parallel(block, d):
+                        kv_shared[i, j] = T.if_then_else(
+                            idxs[i] != -1,
+                            kv[by, idxs[i], j],
+                            0,
+                        )
+                    for i, j in T.Parallel(h, block):
+                        acc_s[i, j] = T.if_then_else(
+                            idxs[j] != -1,
+                            0,
+                            -T.infinity(fp32),
+                        )
+                    T.gemm(
+                        q_shared,
+                        kv_shared,
+                        acc_s,
+                        transpose_B=True,
+                        policy=T.GemmWarpPolicy.FullRow,
+                    )
+                    for i, j in T.Parallel(h, block):
+                        acc_s[i, j] *= softmax_scale
+                    T.copy(scores_max, scores_max_prev)
+                    T.reduce_max(acc_s, scores_max, dim=1, clear=False)
+                    for i in T.Parallel(h):
+                        scores_scale[i] = T.exp(scores_max_prev[i] - scores_max[i])
+                    for i, j in T.Parallel(h, block):
+                        acc_s[i, j] = T.exp(acc_s[i, j] - scores_max[i])
+                    T.reduce_sum(acc_s, scores_sum, dim=1)
+                    for i in T.Parallel(h):
+                        sum_exp[i] = sum_exp[i] * scores_scale[i] + scores_sum[i]
+                    T.copy(acc_s, acc_s_cast)
+                    for i, j in T.Parallel(h, d):
+                        acc_o[i, j] *= scores_scale[i]
+                    T.gemm(
+                        acc_s_cast,
+                        kv_shared,
+                        acc_o,
+                        policy=T.GemmWarpPolicy.FullRow,
+                    )
+
+                for i in T.Parallel(h):
+                    sum_exp[i] += T.exp(attn_sink[i] - scores_max[i])
+                for i, j in T.Parallel(h, d):
+                    acc_o[i, j] /= sum_exp[i]
+                T.copy(acc_o, out_shared)
+                T.copy(out_shared, out[by, bx, :, :])
+
+        return sparse_attn_kernel_
+
+    return kernel(num_heads, head_dim, scale)
+
+
+def dspark_sparse_attn(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    attn_sink: torch.Tensor,
+    topk_idxs: torch.Tensor,
+    softmax_scale: float,
+) -> torch.Tensor:
+    """Run DSpark sparse attention.
+
+    Args:
+        q: ``[batch, draft_tokens, heads, head_dim]`` bf16.
+        kv: ``[batch, rolling_window + draft_tokens, head_dim]`` bf16.
+        attn_sink: ``[heads]`` fp32.
+        topk_idxs: ``[batch, draft_tokens, topk]`` int32 indices into ``kv``.
+    """
+    if q.dtype != torch.bfloat16 or kv.dtype != torch.bfloat16:
+        raise TypeError("DSpark sparse attention currently expects bf16 q/kv")
+    if topk_idxs.dtype != torch.int32:
+        topk_idxs = topk_idxs.to(torch.int32)
+
+    batch, draft_tokens, heads, head_dim = q.shape
+    padded_heads = heads
+    if heads < 16:
+        padded_heads = 16
+        q = torch.cat(
+            [q, q.new_zeros(batch, draft_tokens, padded_heads - heads, head_dim)],
+            dim=2,
+        )
+        attn_sink = torch.cat(
+            [attn_sink, attn_sink.new_zeros(padded_heads - heads)],
+        )
+
+    out = torch.empty_like(q)
+    kernel = _build_dspark_sparse_attn_kernel(padded_heads, head_dim, softmax_scale)
+    kernel(q.contiguous(), kv.contiguous(), out, attn_sink.contiguous(), topk_idxs)
+    if heads < 16:
+        return out.narrow(2, 0, heads).contiguous()
+    return out
+
+
+def dspark_sparse_attn_reference(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    attn_sink: torch.Tensor,
+    topk_idxs: torch.Tensor,
+    softmax_scale: float,
+) -> torch.Tensor:
+    """Slow PyTorch reference for DSpark sparse attention debugging.
+
+    This mirrors the public HF DSpark sparse-attention contract and the
+    TileLang kernel above: attend over gathered KV rows plus a learned
+    denominator-only sink term.
+    """
+    if q.dtype != torch.bfloat16 or kv.dtype != torch.bfloat16:
+        raise TypeError("DSpark sparse attention reference expects bf16 q/kv")
+
+    valid = topk_idxs >= 0
+    gather_idxs = topk_idxs.clamp_min(0).long()
+    batch = torch.arange(kv.shape[0], device=kv.device).view(-1, 1, 1)
+    gathered_kv = kv[batch, gather_idxs]
+
+    scores = torch.einsum(
+        "bmhd,bmkd->bmhk",
+        q.float(),
+        gathered_kv.float(),
+    )
+    scores.mul_(softmax_scale)
+    scores.masked_fill_(~valid.unsqueeze(2), -torch.inf)
+
+    scores_max = scores.amax(dim=-1)
+    weights = torch.exp(scores - scores_max.unsqueeze(-1))
+    weights.masked_fill_(~valid.unsqueeze(2), 0.0)
+    denom = weights.sum(dim=-1)
+    denom.add_(torch.exp(attn_sink.float().view(1, 1, -1) - scores_max))
+
+    out = torch.einsum("bmhk,bmkd->bmhd", weights, gathered_kv.float())
+    out.div_(denom.unsqueeze(-1))
+    return out.to(q.dtype)

--- a/vllm/models/deepseek_v4/sparse_mla.py
+++ b/vllm/models/deepseek_v4/sparse_mla.py
@@ -150,6 +150,18 @@ class DeepseekV4FlashMLAMetadataBuilder(
         # Classify single-token queries (plus num_speculative_tokens via
         # supports_spec_as_decode=True) as decodes; longer queries go to prefill.
         self._init_reorder_batch_threshold(1, supports_spec_as_decode=True)
+        speculative_config = self.vllm_config.speculative_config
+        num_speculative_tokens = (
+            speculative_config.num_speculative_tokens
+            if speculative_config is not None
+            and speculative_config.num_speculative_tokens is not None
+            else 0
+        )
+        # DeepSeek V4 SWA and indexer metadata treat MTP/parallel-drafting rows
+        # as decode rows up to 1 + num_speculative_tokens. Do not use the generic
+        # parallel_drafting threshold (1 + 2N) here, otherwise C128A metadata can
+        # classify a short prefill as decode while SWA classifies it as prefill.
+        self.deepseek_v4_decode_threshold = 1 + num_speculative_tokens
         self.topk_tokens = self.model_config.hf_config.index_topk
 
         max_num_batched_tokens = vllm_config.scheduler_config.max_num_batched_tokens
@@ -263,7 +275,7 @@ class DeepseekV4FlashMLAMetadataBuilder(
         (num_decodes, _, num_decode_tokens, num_prefill_tokens) = (
             split_decodes_and_prefills(
                 cm,
-                decode_threshold=self.reorder_batch_threshold or 1,
+                decode_threshold=self.deepseek_v4_decode_threshold,
             )
         )
 

--- a/vllm/v1/attention/backends/mla/sparse_swa.py
+++ b/vllm/v1/attention/backends/mla/sparse_swa.py
@@ -685,6 +685,64 @@ def _compute_prefill_metadata_kernel(
     tl.store(prefill_gather_lens_ptr + offset, gather_len, mask=mask)
 
 
+def warmup_deepseek_v4_prefill_metadata_kernel(
+    device: torch.device,
+    *,
+    max_num_prefills: int,
+    window_size: int,
+) -> int:
+    """Precompile the Triton prefill metadata kernel used by DSv4 SWA.
+
+    Mixed sparse-MLA warmup can miss the pure-prefill first-request shape on a
+    fresh Triton cache. Warm both pure prefill and mixed decode+prefill cases
+    across the small power-of-two BLOCK_SIZE specializations used by the
+    metadata builder.
+    """
+    if not torch.cuda.is_available():
+        return 0
+
+    max_num_prefills = max(1, int(max_num_prefills))
+    cases: set[int] = {1, max_num_prefills}
+    block_size = 1
+    while block_size < max_num_prefills:
+        block_size *= 2
+        cases.add(min(block_size, max_num_prefills))
+
+    launches = 0
+    for num_prefills in sorted(cases):
+        for num_decodes in (0, 1):
+            query_lens = torch.tensor(
+                [1] * num_decodes + [16] * num_prefills,
+                dtype=torch.int32,
+                device=device,
+            )
+            seq_lens = query_lens.clone()
+            query_start_loc = torch.empty(
+                query_lens.numel() + 1,
+                dtype=torch.int32,
+                device=device,
+            )
+            query_start_loc[0].zero_()
+            torch.cumsum(query_lens, dim=0, out=query_start_loc[1:])
+            prefill_gather_lens = torch.empty(
+                num_prefills,
+                dtype=torch.int32,
+                device=device,
+            )
+            _compute_prefill_metadata_kernel[(1,)](
+                prefill_gather_lens,
+                seq_lens,
+                query_start_loc,
+                num_prefills,
+                num_decodes,
+                window_size,
+                BLOCK_SIZE=triton.next_power_of_2(num_prefills),
+            )
+            launches += 1
+    torch.cuda.synchronize(device)
+    return launches
+
+
 @triton.jit(do_not_specialize=["token_offset"])
 def _compute_swa_indices_and_lens_kernel(
     swa_indices_ptr,

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -104,6 +104,9 @@ from vllm.v1.worker.gpu.sample.prompt_logprob import PromptLogprobsWorker
 from vllm.v1.worker.gpu.sample.sampler import Sampler
 from vllm.v1.worker.gpu.shutdown import free_before_shutdown
 from vllm.v1.worker.gpu.spec_decode import init_speculator
+from vllm.v1.worker.gpu.spec_decode.dspark.utils import (
+    set_dspark_aux_hidden_state_layers,
+)
 from vllm.v1.worker.gpu.spec_decode.eagle.eagle3_utils import (
     set_eagle3_aux_hidden_state_layers,
 )
@@ -221,8 +224,8 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             if self.is_last_pp_rank:
                 self.speculator = init_speculator(self.vllm_config, self.device)
 
-            if self.speculative_config.method in ("eagle3", "dflash"):
-                # EAGLE3/DFlash require auxiliary hidden states from target
+            if self.speculative_config.method in ("eagle3", "dflash", "dspark"):
+                # EAGLE3/DFlash/DSpark require auxiliary hidden states from target
                 # model outputs.
                 self.use_aux_hidden_state_outputs = True
                 if self.use_pp:
@@ -320,7 +323,14 @@ class GPUModelRunner(LoRAModelRunnerMixin):
 
             if self.use_aux_hidden_state_outputs:
                 assert self.speculative_config is not None
-                set_eagle3_aux_hidden_state_layers(self.model, self.speculative_config)
+                if self.speculative_config.method == "dspark":
+                    set_dspark_aux_hidden_state_layers(
+                        self.model, self.speculative_config
+                    )
+                else:
+                    set_eagle3_aux_hidden_state_layers(
+                        self.model, self.speculative_config
+                    )
             if isinstance(self.speculator, DraftModelSpeculator):
                 self.speculator.load_model(self.model)
                 eplb_models_added = self.eplb.maybe_register_speculator(
@@ -507,6 +517,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             decode_query_len=self.decode_query_len,
             lora_capture_cases=self.lora_capture_cases,
         )
+        draft_tokens_for_next_step = None
         if self.speculator is not None:
             self.speculator.init_cudagraph_manager(cudagraph_mode)
 
@@ -1575,7 +1586,24 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             with record_function_or_nullcontext(
                 f"vllm:v2/speculator/{phase}/store_draft_tokens"
             ):
-                self.req_states.draft_tokens[input_batch.idx_mapping] = draft_tokens
+                if draft_tokens.shape[1] == self.num_speculative_steps:
+                    self.req_states.draft_tokens[input_batch.idx_mapping] = draft_tokens
+                    draft_tokens_for_next_step = self.req_states.draft_tokens[
+                        input_batch.idx_mapping
+                    ]
+                elif draft_tokens.shape[1] == 0:
+                    # Some block speculators can intentionally decline to draft
+                    # on the next step (for example after a full rejection while
+                    # their private KV state is being realigned). Keep the
+                    # persistent fixed-width buffer untouched, but report an
+                    # empty draft list to the scheduler for the next iteration.
+                    draft_tokens_for_next_step = draft_tokens
+                else:
+                    raise RuntimeError(
+                        "Speculator returned unsupported draft shape "
+                        f"{tuple(draft_tokens.shape)}; expected "
+                        f"(*, {self.num_speculative_steps}) or (*, 0)."
+                    )
 
         if self.num_speculative_steps > 0:
             # Spec-decode and diffusion LLMs both use draft tokens but the latter does
@@ -1585,7 +1613,9 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             ):
                 self.draft_tokens_handler.set_draft_tokens(
                     input_batch,
-                    self.req_states.draft_tokens[input_batch.idx_mapping],
+                    draft_tokens_for_next_step
+                    if draft_tokens_for_next_step is not None
+                    else self.req_states.draft_tokens[input_batch.idx_mapping],
                 )
 
         # Post-step KV connector related operations.

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -517,7 +517,6 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             decode_query_len=self.decode_query_len,
             lora_capture_cases=self.lora_capture_cases,
         )
-        draft_tokens_for_next_step = None
         if self.speculator is not None:
             self.speculator.init_cudagraph_manager(cudagraph_mode)
 
@@ -1110,9 +1109,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         if grammar_output is not None:
             # Apply grammar bitmask to the logits in-place.
             assert self.structured_outputs_worker is not None
-            with record_function_or_nullcontext(
-                f"vllm:v2/target/{phase}/grammar"
-            ):
+            with record_function_or_nullcontext(f"vllm:v2/target/{phase}/grammar"):
                 self.structured_outputs_worker.apply_grammar_bitmask(
                     logits,
                     input_batch,
@@ -1122,9 +1119,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
 
         if input_batch.num_draft_tokens == 0 or self.rejection_sampler is None:
             assert self.sampler is not None
-            with record_function_or_nullcontext(
-                f"vllm:v2/target/{phase}/sample"
-            ):
+            with record_function_or_nullcontext(f"vllm:v2/target/{phase}/sample"):
                 sampler_output = self.sampler(logits, input_batch)
         else:
             # Rejection sampling for spec decoding.
@@ -1246,9 +1241,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
 
             if self.lora_config:
                 # Activate LoRA adapters.
-                with record_function_or_nullcontext(
-                    f"vllm:v2/target/{phase}/lora"
-                ):
+                with record_function_or_nullcontext(f"vllm:v2/target/{phase}/lora"):
                     lora_inputs = self.lora_state.make_lora_inputs(
                         input_batch.req_ids,
                         input_batch.idx_mapping_np,
@@ -1477,9 +1470,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
 
         if self.pp_handler is not None:
             # Broadcast to non-last PP ranks (handles spec decode multi-token).
-            with record_function_or_nullcontext(
-                f"vllm:v2/target/{phase}/pp_broadcast"
-            ):
+            with record_function_or_nullcontext(f"vllm:v2/target/{phase}/pp_broadcast"):
                 self.pp_handler.broadcast(
                     sampler_output.sampled_token_ids,
                     num_sampled,
@@ -1488,9 +1479,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 )
 
         assert self.prompt_logprobs_worker is not None
-        with record_function_or_nullcontext(
-            f"vllm:v2/target/{phase}/prompt_logprobs"
-        ):
+        with record_function_or_nullcontext(f"vllm:v2/target/{phase}/prompt_logprobs"):
             prompt_logprobs_dict = self.prompt_logprobs_worker.compute_prompt_logprobs(
                 self.model.compute_logits,
                 hidden_states,
@@ -1510,9 +1499,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             prompt_logprobs_dict=prompt_logprobs_dict,  # type: ignore[arg-type]
         )
         # Start async output copy here so that it can overlap with speculator proposal.
-        with record_function_or_nullcontext(
-            f"vllm:v2/target/{phase}/async_output"
-        ):
+        with record_function_or_nullcontext(f"vllm:v2/target/{phase}/async_output"):
             async_output = AsyncOutput(
                 model_runner_output=model_runner_output,
                 sampler_output=sampler_output,
@@ -1566,9 +1553,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             if hasattr(self.model, "get_mtp_target_hidden_states"):
                 pre_hc_hidden_states = self.model.get_mtp_target_hidden_states()
                 spec_hidden_states = pre_hc_hidden_states[: hidden_states.shape[0]]  # type: ignore[union-attr]
-            with record_function_or_nullcontext(
-                f"vllm:v2/speculator/{phase}/propose"
-            ):
+            with record_function_or_nullcontext(f"vllm:v2/speculator/{phase}/propose"):
                 draft_tokens = self.speculator.propose(
                     input_batch,
                     attn_metadata,
@@ -1619,9 +1604,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 )
 
         # Post-step KV connector related operations.
-        with record_function_or_nullcontext(
-            f"vllm:v2/target/{phase}/kv_post_forward"
-        ):
+        with record_function_or_nullcontext(f"vllm:v2/target/{phase}/kv_post_forward"):
             kv_connector_output = self.kv_connector.post_forward(finished_req_ids)
         model_runner_output.kv_connector_output = kv_connector_output
 

--- a/vllm/v1/worker/gpu/spec_decode/__init__.py
+++ b/vllm/v1/worker/gpu/spec_decode/__init__.py
@@ -14,6 +14,12 @@ def init_speculator(vllm_config: VllmConfig, device: torch.device):
         )
 
         return DFlashSpeculator(vllm_config, device)
+    elif speculative_config.method == "dspark":
+        from vllm.v1.worker.gpu.spec_decode.dspark.speculator import (
+            DSparkSpeculator,
+        )
+
+        return DSparkSpeculator(vllm_config, device)
     elif speculative_config.use_gemma4_mtp():
         from vllm.v1.worker.gpu.spec_decode.gemma4.speculator import (
             Gemma4Speculator,

--- a/vllm/v1/worker/gpu/spec_decode/dspark/__init__.py
+++ b/vllm/v1/worker/gpu/spec_decode/dspark/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/vllm/v1/worker/gpu/spec_decode/dspark/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dspark/speculator.py
@@ -1,0 +1,510 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""DeepSeek V4 DSpark speculator.
+
+DSpark is a block speculative decoder stored under the DeepSeek V4 checkpoint's
+``mtp.*`` namespace, but it is not the serial DeepSeek MTP architecture. The
+draft consumes target hidden states from configured target layers and predicts a
+noise-token block through DSpark attention, Markov logits and a confidence head.
+
+This file intentionally refuses to fall back to serial MTP. A wrong fallback
+would load cleanly but silently measure the wrong algorithm.
+"""
+
+import contextlib
+import json
+import os
+import time
+
+import torch
+import torch.nn as nn
+
+from vllm.forward_context import BatchDescriptor, set_forward_context
+from vllm.logger import init_logger
+from vllm.utils.flashinfer import autotune as flashinfer_autotune
+from vllm.v1.utils import record_function_or_nullcontext
+from vllm.v1.worker.gpu.input_batch import InputBatch
+from vllm.v1.worker.gpu.spec_decode.autoregressive.speculator import (
+    prepare_prefill_inputs,
+)
+from vllm.v1.worker.gpu.spec_decode.dspark.utils import (
+    load_deepseek_v4_dspark_model,
+)
+from vllm.v1.worker.gpu.spec_decode.speculator import DraftModelSpeculator
+
+logger = init_logger(__name__)
+
+
+def _maybe_dump_propose_debug(
+    *,
+    input_ids: torch.Tensor,
+    positions: torch.Tensor,
+    output_ids: torch.Tensor,
+    logits: torch.Tensor,
+    confidence: torch.Tensor | None,
+) -> None:
+    debug_dir = os.getenv("VLLM_DSPARK_DEBUG_DIR")
+    if not debug_dir:
+        return
+    max_dumps = int(os.getenv("VLLM_DSPARK_DEBUG_MAX_DUMPS", "8"))
+    path = os.path.join(debug_dir, "propose_debug.jsonl")
+    existing = 0
+    if os.path.exists(path):
+        with open(path, encoding="utf-8") as f:
+            existing = sum(1 for _ in f)
+    if existing >= max_dumps:
+        return
+
+    top_values, top_indices = torch.topk(logits, k=8, dim=-1)
+    rows = []
+    for req_idx in range(min(int(output_ids.shape[0]), 2)):
+        req_rows = []
+        for step in range(int(logits.shape[1])):
+            req_rows.append({
+                "step": step,
+                "top_ids": [
+                    int(x) for x in top_indices[req_idx, step].detach().cpu()
+                ],
+                "top_logits": [
+                    float(x) for x in top_values[req_idx, step].detach().cpu()
+                ],
+            })
+        rows.append({
+            "req": req_idx,
+            "input_id": int(input_ids[req_idx].detach().cpu()),
+            "position": int(positions[req_idx].detach().cpu()),
+            "output_ids": [
+                int(x) for x in output_ids[req_idx].detach().cpu().tolist()
+            ],
+            "logits_top": req_rows,
+            "confidence_logits": (
+                [
+                    float(x)
+                    for x in confidence[req_idx].detach().float().cpu().tolist()
+                ]
+                if confidence is not None
+                else None
+            ),
+            "confidence_probs": (
+                [
+                    float(x)
+                    for x in confidence[req_idx].detach().float().sigmoid().cpu().tolist()
+                ]
+                if confidence is not None
+                else None
+            ),
+        })
+    os.makedirs(debug_dir, exist_ok=True)
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(json.dumps({"time": time.time(), "rows": rows}) + "\n")
+
+
+def _maybe_dump_context_debug(
+    *,
+    input_batch: InputBatch,
+    last_token_indices: torch.Tensor,
+    input_ids: torch.Tensor,
+    positions: torch.Tensor,
+    num_sampled: torch.Tensor,
+    num_rejected_cpu: list[int],
+    last_sampled: torch.Tensor,
+    next_prefill_tokens: torch.Tensor,
+    context_ranges: list[tuple[int, int]],
+) -> None:
+    debug_dir = os.getenv("VLLM_DSPARK_DEBUG_DIR")
+    if not debug_dir:
+        return
+    max_dumps = int(os.getenv("VLLM_DSPARK_DEBUG_MAX_DUMPS", "8"))
+    path = os.path.join(debug_dir, "context_debug.jsonl")
+    existing = 0
+    if os.path.exists(path):
+        with open(path, encoding="utf-8") as f:
+            existing = sum(1 for _ in f)
+    if existing >= max_dumps:
+        return
+
+    rows = []
+    num_reqs = min(int(input_ids.shape[0]), 2)
+    host_input_ids = input_batch.input_ids[:input_batch.num_tokens].detach().cpu()
+    host_positions = input_batch.positions[:input_batch.num_tokens].detach().cpu()
+    for req_idx in range(num_reqs):
+        start, end = context_ranges[req_idx]
+        req_state_idx = int(input_batch.idx_mapping[req_idx].detach().cpu())
+        rows.append({
+            "req": req_idx,
+            "req_state_idx": req_state_idx,
+            "last_token_index": int(last_token_indices[req_idx].detach().cpu()),
+            "current_input_id": int(input_ids[req_idx].detach().cpu()),
+            "current_position": int(positions[req_idx].detach().cpu()),
+            "num_sampled": int(num_sampled[req_idx].detach().cpu()),
+            "num_rejected": int(num_rejected_cpu[req_idx]),
+            "last_sampled": int(last_sampled[req_state_idx].detach().cpu()),
+            "next_prefill_token": int(
+                next_prefill_tokens[req_state_idx].detach().cpu()
+            ),
+            "query_start": int(input_batch.query_start_loc_np[req_idx]),
+            "query_end": int(input_batch.query_start_loc_np[req_idx + 1]),
+            "context_start": int(start),
+            "context_end": int(end),
+            "context_input_ids": [
+                int(x) for x in host_input_ids[start:end].tolist()
+            ],
+            "context_positions": [
+                int(x) for x in host_positions[start:end].tolist()
+            ],
+        })
+
+    os.makedirs(debug_dir, exist_ok=True)
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(json.dumps({"time": time.time(), "rows": rows}) + "\n")
+
+
+def _maybe_dump_context_tensor_debug(
+    *,
+    input_batch: InputBatch,
+    main_hidden_all: torch.Tensor,
+    input_ids: torch.Tensor,
+    positions: torch.Tensor,
+    context_ranges: list[tuple[int, int]],
+) -> None:
+    debug_dir = os.getenv("VLLM_DSPARK_CONTEXT_TENSOR_DEBUG_DIR")
+    if not debug_dir:
+        return
+    max_dumps = int(os.getenv("VLLM_DSPARK_CONTEXT_TENSOR_DEBUG_MAX_DUMPS", "4"))
+    os.makedirs(debug_dir, exist_ok=True)
+    existing = len([
+        name for name in os.listdir(debug_dir) if name.endswith(".pt")
+    ])
+    if existing >= max_dumps:
+        return
+    path = os.path.join(debug_dir, f"context_{existing:04d}.pt")
+    torch.save(
+        {
+            "time": time.time(),
+            "main_hidden_all": main_hidden_all.detach().cpu(),
+            "input_batch_input_ids": input_batch.input_ids[
+                : input_batch.num_tokens
+            ].detach().cpu(),
+            "input_batch_positions": input_batch.positions[
+                : input_batch.num_tokens
+            ].detach().cpu(),
+            "input_ids": input_ids.detach().cpu(),
+            "positions": positions.detach().cpu(),
+            "context_ranges": list(context_ranges),
+        },
+        path,
+    )
+
+
+class DSparkSpeculator(DraftModelSpeculator):
+    def __init__(self, vllm_config, device: torch.device):
+        super().__init__(vllm_config, device)
+        self.supports_mm_inputs = False
+        parallel_config = vllm_config.parallel_config
+        cache_config = vllm_config.cache_config
+        if parallel_config.pipeline_parallel_size > 1:
+            raise NotImplementedError("DSpark currently requires pipeline parallel size 1.")
+        if parallel_config.prefill_context_parallel_size > 1:
+            raise NotImplementedError("DSpark currently requires prefill context parallel size 1.")
+        if parallel_config.decode_context_parallel_size > 1:
+            raise NotImplementedError("DSpark currently requires decode context parallel size 1.")
+        if cache_config.enable_prefix_caching:
+            raise NotImplementedError(
+                "DSpark currently cannot run with prefix caching because its "
+                "private rolling draft KV cache is not prefix-cache aware yet."
+            )
+        hf_config = self.draft_model_config.hf_config
+        self.block_size = int(getattr(hf_config, "dspark_block_size", 0) or 0)
+        self.noise_token_id = int(getattr(hf_config, "dspark_noise_token_id", -1))
+        self.target_layer_ids = tuple(
+            int(i) for i in getattr(hf_config, "dspark_target_layer_ids", ())
+        )
+        if self.block_size <= 0:
+            raise ValueError("DSpark requires dspark_block_size in the model config.")
+        if self.noise_token_id < 0:
+            raise ValueError("DSpark requires dspark_noise_token_id in the model config.")
+        if not self.target_layer_ids:
+            raise ValueError(
+                "DSpark requires dspark_target_layer_ids in the model config."
+            )
+        if self.num_speculative_steps > self.block_size:
+            raise ValueError(
+                "DSpark num_speculative_tokens must be <= dspark_block_size "
+                f"({self.num_speculative_steps} > {self.block_size})."
+            )
+        self.last_token_indices = torch.zeros(
+            self.max_num_reqs,
+            dtype=torch.int64,
+            device=device,
+        )
+        self.current_draft_step = torch.tensor(0, dtype=torch.int64, device=device)
+        self.active_num_reqs = torch.tensor(0, dtype=torch.int32, device=device)
+        self.draft_step_cols = torch.arange(
+            self.block_size,
+            dtype=torch.int64,
+            device=device,
+        )
+
+    def load_draft_model(
+        self,
+        target_model: nn.Module,
+        target_attn_layer_names: set[str],
+    ) -> nn.Module:
+        del target_attn_layer_names
+        return load_deepseek_v4_dspark_model(target_model, self.vllm_config)
+
+    def capture(self, attn_states: dict | None = None) -> None:
+        del attn_states
+        logger.warning_once(
+            "DSpark speculator currently runs eager; CUDA graph capture is skipped."
+        )
+        if os.getenv("VLLM_DSPARK_SKIP_WARMUP") == "1":
+            return
+
+        hf_config = self.draft_model_config.hf_config
+        main_hidden_size = hf_config.hidden_size * len(self.target_layer_ids)
+        input_ids = torch.full(
+            (1,),
+            self.noise_token_id,
+            dtype=torch.long,
+            device=self.device,
+        )
+        context_hidden = torch.zeros(
+            (1, main_hidden_size),
+            dtype=self.dtype,
+            device=self.device,
+        )
+        context_positions = torch.zeros(
+            (1,),
+            dtype=torch.long,
+            device=self.device,
+        )
+        decode_positions = torch.ones(
+            (1,),
+            dtype=torch.long,
+            device=self.device,
+        )
+
+        self.idx_mapping[:1].zero_()
+        self.temperature[:1].fill_(1.0)
+        self.seeds[:1].zero_()
+        self.active_num_reqs.fill_(1)
+
+        batch_descriptor = BatchDescriptor(num_tokens=self.block_size)
+        tune_ctx = contextlib.nullcontext()
+        if self.vllm_config.kernel_config.enable_flashinfer_autotune:
+            # DSpark draft MoE runs with M=block_size (5 for the published
+            # checkpoint). FlashInfer's default mapper rounds this to bucket 8,
+            # so tune that bucket to make the later non-tuning forward hit cache.
+            tune_ctx = flashinfer_autotune(
+                True,
+                tuning_buckets=(8,),
+                round_up=True,
+            )
+        try:
+            with tune_ctx, set_forward_context(
+                None,
+                self.vllm_config,
+                num_tokens=self.block_size,
+                batch_descriptor=batch_descriptor,
+                slot_mapping=None,
+            ):
+                self.model.precompute_context_kv(
+                    context_hidden,
+                    context_positions,
+                    [(0, 1)],
+                )
+                self.model.forward_spec(
+                    input_ids,
+                    context_hidden,
+                    decode_positions,
+                    idx_mapping=self.idx_mapping[:1],
+                    temperature=self.temperature,
+                    seeds=self.seeds,
+                    draft_logits=self.draft_logits,
+                    draft_step_cols=self.draft_step_cols,
+                    active_num_reqs=self.active_num_reqs,
+                    use_fp64_gumbel=self.use_fp64_gumbel,
+                )
+            torch.cuda.synchronize(self.device)
+        finally:
+            self.model.reset_dspark_kv_cache()
+            self.draft_tokens.zero_()
+            if self.draft_logits is not None:
+                self.draft_logits.zero_()
+        logger.info_once("DSpark eager warmup completed.")
+
+    def init_cudagraph_manager(self, cudagraph_mode) -> None:
+        return None
+
+    @torch.inference_mode()
+    def propose(
+        self,
+        input_batch: InputBatch,
+        attn_metadata: dict,
+        slot_mappings: dict[str, torch.Tensor],
+        # [num_tokens, hidden_size]
+        last_hidden_states: torch.Tensor,
+        # num_layers x [num_tokens, hidden_size]
+        aux_hidden_states: list[torch.Tensor] | None,
+        # [num_reqs]
+        num_sampled: torch.Tensor,
+        # [num_reqs]
+        num_rejected: torch.Tensor,
+        # [max_num_reqs]
+        last_sampled: torch.Tensor,
+        # [max_num_reqs]
+        next_prefill_tokens: torch.Tensor,
+        # [max_num_reqs]
+        temperature: torch.Tensor,
+        # [max_num_reqs]
+        seeds: torch.Tensor,
+        num_tokens_across_dp: torch.Tensor | None = None,
+        dummy_run: bool = False,
+        skip_attn_for_dummy_run: bool = False,
+        mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None,
+        is_profile: bool = False,
+    ) -> torch.Tensor:
+        del (
+            attn_metadata,
+            last_hidden_states,
+            mm_inputs,
+            is_profile,
+        )
+        num_reqs = input_batch.num_reqs
+        if any(
+            req_id.startswith(
+                ("_warmup_", "_v2_mixed_warmup", "_sparse_mla_v2_warmup")
+            )
+            for req_id in input_batch.req_ids[:num_reqs]
+        ):
+            self.draft_tokens[:num_reqs].zero_()
+            return self.draft_tokens[:num_reqs]
+        if dummy_run and skip_attn_for_dummy_run:
+            self.draft_tokens[:num_reqs].zero_()
+            return self.draft_tokens[:num_reqs]
+        if not aux_hidden_states:
+            raise RuntimeError("DSpark requires target auxiliary hidden states.")
+        if len(aux_hidden_states) != len(self.target_layer_ids):
+            raise RuntimeError(
+                "DSpark auxiliary hidden-state count mismatch: "
+                f"expected {len(self.target_layer_ids)}, got {len(aux_hidden_states)}."
+            )
+
+        with record_function_or_nullcontext("vllm:v2/speculator/dspark/prepare"):
+            prepare_prefill_inputs(
+                self.last_token_indices,
+                self.current_draft_step,
+                self.input_buffers,
+                input_batch,
+                num_sampled,
+                num_rejected,
+                last_sampled,
+                next_prefill_tokens,
+                self.max_num_reqs,
+            )
+            self._copy_request_inputs(
+                num_reqs,
+                input_batch.idx_mapping,
+                temperature,
+                seeds,
+            )
+            self.active_num_reqs.fill_(num_reqs)
+            last_token_indices = self.last_token_indices[:num_reqs]
+            # prepare_prefill_inputs writes the fresh target token at each
+            # request's last_token_index. DSpark must use that same token and
+            # position together with the corresponding aux hidden state.
+            input_ids = self.input_buffers.input_ids[last_token_indices]
+            positions = self.input_buffers.positions[last_token_indices]
+            if dummy_run:
+                self.draft_tokens[:num_reqs].zero_()
+                return self.draft_tokens[:num_reqs]
+            main_hidden_all = torch.cat(aux_hidden_states, dim=-1)
+            num_rejected_cpu = num_rejected[:num_reqs].detach().cpu().tolist()
+            skip_after_rejection = (
+                os.getenv("VLLM_DSPARK_SKIP_AFTER_REJECTION") == "1"
+            )
+            context_ranges = [
+                (
+                    int(input_batch.query_start_loc_np[req_idx]),
+                    int(input_batch.query_start_loc_np[req_idx + 1])
+                    - int(num_rejected_cpu[req_idx]),
+                )
+                for req_idx in range(num_reqs)
+            ]
+            if skip_after_rejection:
+                for req_idx, num_rejected_i in enumerate(num_rejected_cpu):
+                    if num_rejected_i > 0:
+                        stale_row = int(last_token_indices[req_idx].detach().cpu())
+                        start, end = context_ranges[req_idx]
+                        context_ranges[req_idx] = (start, min(end, stale_row))
+            _maybe_dump_context_debug(
+                input_batch=input_batch,
+                last_token_indices=last_token_indices,
+                input_ids=input_ids,
+                positions=positions,
+                num_sampled=num_sampled,
+                num_rejected_cpu=num_rejected_cpu,
+                last_sampled=last_sampled,
+                next_prefill_tokens=next_prefill_tokens,
+                context_ranges=context_ranges,
+            )
+            _maybe_dump_context_tensor_debug(
+                input_batch=input_batch,
+                main_hidden_all=main_hidden_all[: input_batch.num_tokens],
+                input_ids=input_ids,
+                positions=positions,
+                context_ranges=context_ranges,
+            )
+            self.model.precompute_context_kv(
+                main_hidden_all[: input_batch.num_tokens],
+                input_batch.positions[: input_batch.num_tokens],
+                context_ranges,
+            )
+            # The initial target prefill only initializes DSpark's rolling
+            # context KV.  The public DSpark algorithm starts proposing once a
+            # real decode token exists, so position 0 must not run the draft
+            # block model.
+            if torch.any(positions <= 0).item():
+                self.draft_tokens[:num_reqs].zero_()
+                return self.draft_tokens[:num_reqs]
+            if skip_after_rejection and any(n > 0 for n in num_rejected_cpu):
+                return self.draft_tokens[:num_reqs, :0]
+            main_hidden = main_hidden_all[last_token_indices]
+
+        with record_function_or_nullcontext("vllm:v2/speculator/dspark/forward"):
+            # DSpark uses its own TileLang attention path, but the inherited
+            # DeepSeek MoE layers still read vLLM's forward context to resolve
+            # static layer state.
+            batch_descriptor = BatchDescriptor(num_tokens=num_reqs * self.block_size)
+            with set_forward_context(
+                None,
+                self.vllm_config,
+                num_tokens=num_reqs * self.block_size,
+                num_tokens_across_dp=num_tokens_across_dp,
+                slot_mapping=slot_mappings,
+                batch_descriptor=batch_descriptor,
+            ):
+                output_ids, logits, _confidence = self.model.forward_spec(
+                    input_ids,
+                    main_hidden,
+                    positions,
+                    idx_mapping=self.idx_mapping[:num_reqs],
+                    temperature=self.temperature,
+                    seeds=self.seeds,
+                    draft_logits=self.draft_logits,
+                    draft_step_cols=self.draft_step_cols,
+                    active_num_reqs=self.active_num_reqs,
+                    use_fp64_gumbel=self.use_fp64_gumbel,
+                )
+                _maybe_dump_propose_debug(
+                    input_ids=input_ids,
+                    positions=positions,
+                    output_ids=output_ids,
+                    logits=logits,
+                    confidence=_confidence,
+                )
+
+        steps = self.num_speculative_steps
+        self.draft_tokens[:num_reqs, :steps].copy_(output_ids[:, 1 : 1 + steps])
+        return self.draft_tokens[:num_reqs]

--- a/vllm/v1/worker/gpu/spec_decode/dspark/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dspark/speculator.py
@@ -12,17 +12,23 @@ would load cleanly but silently measure the wrong algorithm.
 """
 
 import contextlib
-import json
 import os
-import time
+from collections.abc import Callable
 
 import torch
 import torch.nn as nn
 
+from vllm.config.compilation import CUDAGraphMode
 from vllm.forward_context import BatchDescriptor, set_forward_context
 from vllm.logger import init_logger
 from vllm.utils.flashinfer import autotune as flashinfer_autotune
 from vllm.v1.utils import record_function_or_nullcontext
+from vllm.v1.worker.gpu.cudagraph_utils import (
+    AttentionState,
+    BatchExecutionDescriptor,
+    CudaGraphManager,
+)
+from vllm.v1.worker.gpu.dp_utils import dispatch_cg_and_sync_dp
 from vllm.v1.worker.gpu.input_batch import InputBatch
 from vllm.v1.worker.gpu.spec_decode.autoregressive.speculator import (
     prepare_prefill_inputs,
@@ -35,167 +41,6 @@ from vllm.v1.worker.gpu.spec_decode.speculator import DraftModelSpeculator
 logger = init_logger(__name__)
 
 
-def _maybe_dump_propose_debug(
-    *,
-    input_ids: torch.Tensor,
-    positions: torch.Tensor,
-    output_ids: torch.Tensor,
-    logits: torch.Tensor,
-    confidence: torch.Tensor | None,
-) -> None:
-    debug_dir = os.getenv("VLLM_DSPARK_DEBUG_DIR")
-    if not debug_dir:
-        return
-    max_dumps = int(os.getenv("VLLM_DSPARK_DEBUG_MAX_DUMPS", "8"))
-    path = os.path.join(debug_dir, "propose_debug.jsonl")
-    existing = 0
-    if os.path.exists(path):
-        with open(path, encoding="utf-8") as f:
-            existing = sum(1 for _ in f)
-    if existing >= max_dumps:
-        return
-
-    top_values, top_indices = torch.topk(logits, k=8, dim=-1)
-    rows = []
-    for req_idx in range(min(int(output_ids.shape[0]), 2)):
-        req_rows = []
-        for step in range(int(logits.shape[1])):
-            req_rows.append({
-                "step": step,
-                "top_ids": [
-                    int(x) for x in top_indices[req_idx, step].detach().cpu()
-                ],
-                "top_logits": [
-                    float(x) for x in top_values[req_idx, step].detach().cpu()
-                ],
-            })
-        rows.append({
-            "req": req_idx,
-            "input_id": int(input_ids[req_idx].detach().cpu()),
-            "position": int(positions[req_idx].detach().cpu()),
-            "output_ids": [
-                int(x) for x in output_ids[req_idx].detach().cpu().tolist()
-            ],
-            "logits_top": req_rows,
-            "confidence_logits": (
-                [
-                    float(x)
-                    for x in confidence[req_idx].detach().float().cpu().tolist()
-                ]
-                if confidence is not None
-                else None
-            ),
-            "confidence_probs": (
-                [
-                    float(x)
-                    for x in confidence[req_idx].detach().float().sigmoid().cpu().tolist()
-                ]
-                if confidence is not None
-                else None
-            ),
-        })
-    os.makedirs(debug_dir, exist_ok=True)
-    with open(path, "a", encoding="utf-8") as f:
-        f.write(json.dumps({"time": time.time(), "rows": rows}) + "\n")
-
-
-def _maybe_dump_context_debug(
-    *,
-    input_batch: InputBatch,
-    last_token_indices: torch.Tensor,
-    input_ids: torch.Tensor,
-    positions: torch.Tensor,
-    num_sampled: torch.Tensor,
-    num_rejected_cpu: list[int],
-    last_sampled: torch.Tensor,
-    next_prefill_tokens: torch.Tensor,
-    context_ranges: list[tuple[int, int]],
-) -> None:
-    debug_dir = os.getenv("VLLM_DSPARK_DEBUG_DIR")
-    if not debug_dir:
-        return
-    max_dumps = int(os.getenv("VLLM_DSPARK_DEBUG_MAX_DUMPS", "8"))
-    path = os.path.join(debug_dir, "context_debug.jsonl")
-    existing = 0
-    if os.path.exists(path):
-        with open(path, encoding="utf-8") as f:
-            existing = sum(1 for _ in f)
-    if existing >= max_dumps:
-        return
-
-    rows = []
-    num_reqs = min(int(input_ids.shape[0]), 2)
-    host_input_ids = input_batch.input_ids[:input_batch.num_tokens].detach().cpu()
-    host_positions = input_batch.positions[:input_batch.num_tokens].detach().cpu()
-    for req_idx in range(num_reqs):
-        start, end = context_ranges[req_idx]
-        req_state_idx = int(input_batch.idx_mapping[req_idx].detach().cpu())
-        rows.append({
-            "req": req_idx,
-            "req_state_idx": req_state_idx,
-            "last_token_index": int(last_token_indices[req_idx].detach().cpu()),
-            "current_input_id": int(input_ids[req_idx].detach().cpu()),
-            "current_position": int(positions[req_idx].detach().cpu()),
-            "num_sampled": int(num_sampled[req_idx].detach().cpu()),
-            "num_rejected": int(num_rejected_cpu[req_idx]),
-            "last_sampled": int(last_sampled[req_state_idx].detach().cpu()),
-            "next_prefill_token": int(
-                next_prefill_tokens[req_state_idx].detach().cpu()
-            ),
-            "query_start": int(input_batch.query_start_loc_np[req_idx]),
-            "query_end": int(input_batch.query_start_loc_np[req_idx + 1]),
-            "context_start": int(start),
-            "context_end": int(end),
-            "context_input_ids": [
-                int(x) for x in host_input_ids[start:end].tolist()
-            ],
-            "context_positions": [
-                int(x) for x in host_positions[start:end].tolist()
-            ],
-        })
-
-    os.makedirs(debug_dir, exist_ok=True)
-    with open(path, "a", encoding="utf-8") as f:
-        f.write(json.dumps({"time": time.time(), "rows": rows}) + "\n")
-
-
-def _maybe_dump_context_tensor_debug(
-    *,
-    input_batch: InputBatch,
-    main_hidden_all: torch.Tensor,
-    input_ids: torch.Tensor,
-    positions: torch.Tensor,
-    context_ranges: list[tuple[int, int]],
-) -> None:
-    debug_dir = os.getenv("VLLM_DSPARK_CONTEXT_TENSOR_DEBUG_DIR")
-    if not debug_dir:
-        return
-    max_dumps = int(os.getenv("VLLM_DSPARK_CONTEXT_TENSOR_DEBUG_MAX_DUMPS", "4"))
-    os.makedirs(debug_dir, exist_ok=True)
-    existing = len([
-        name for name in os.listdir(debug_dir) if name.endswith(".pt")
-    ])
-    if existing >= max_dumps:
-        return
-    path = os.path.join(debug_dir, f"context_{existing:04d}.pt")
-    torch.save(
-        {
-            "time": time.time(),
-            "main_hidden_all": main_hidden_all.detach().cpu(),
-            "input_batch_input_ids": input_batch.input_ids[
-                : input_batch.num_tokens
-            ].detach().cpu(),
-            "input_batch_positions": input_batch.positions[
-                : input_batch.num_tokens
-            ].detach().cpu(),
-            "input_ids": input_ids.detach().cpu(),
-            "positions": positions.detach().cpu(),
-            "context_ranges": list(context_ranges),
-        },
-        path,
-    )
-
-
 class DSparkSpeculator(DraftModelSpeculator):
     def __init__(self, vllm_config, device: torch.device):
         super().__init__(vllm_config, device)
@@ -203,26 +48,33 @@ class DSparkSpeculator(DraftModelSpeculator):
         parallel_config = vllm_config.parallel_config
         cache_config = vllm_config.cache_config
         if parallel_config.pipeline_parallel_size > 1:
-            raise NotImplementedError("DSpark currently requires pipeline parallel size 1.")
-        if parallel_config.prefill_context_parallel_size > 1:
-            raise NotImplementedError("DSpark currently requires prefill context parallel size 1.")
-        if parallel_config.decode_context_parallel_size > 1:
-            raise NotImplementedError("DSpark currently requires decode context parallel size 1.")
-        if cache_config.enable_prefix_caching:
             raise NotImplementedError(
-                "DSpark currently cannot run with prefix caching because its "
-                "private rolling draft KV cache is not prefix-cache aware yet."
+                "DSpark currently requires pipeline parallel size 1."
+            )
+        if parallel_config.prefill_context_parallel_size > 1:
+            raise NotImplementedError(
+                "DSpark currently requires prefill context parallel size 1."
+            )
+        if parallel_config.decode_context_parallel_size > 1:
+            raise NotImplementedError(
+                "DSpark currently requires decode context parallel size 1."
             )
         hf_config = self.draft_model_config.hf_config
         self.block_size = int(getattr(hf_config, "dspark_block_size", 0) or 0)
         self.noise_token_id = int(getattr(hf_config, "dspark_noise_token_id", -1))
+        self.context_window_size = int(getattr(hf_config, "sliding_window", 0) or 0)
         self.target_layer_ids = tuple(
             int(i) for i in getattr(hf_config, "dspark_target_layer_ids", ())
         )
+        self.main_hidden_size = hf_config.hidden_size * len(self.target_layer_ids)
         if self.block_size <= 0:
             raise ValueError("DSpark requires dspark_block_size in the model config.")
         if self.noise_token_id < 0:
-            raise ValueError("DSpark requires dspark_noise_token_id in the model config.")
+            raise ValueError(
+                "DSpark requires dspark_noise_token_id in the model config."
+            )
+        if self.context_window_size <= 0:
+            raise ValueError("DSpark requires sliding_window in the model config.")
         if not self.target_layer_ids:
             raise ValueError(
                 "DSpark requires dspark_target_layer_ids in the model config."
@@ -244,6 +96,34 @@ class DSparkSpeculator(DraftModelSpeculator):
             dtype=torch.int64,
             device=device,
         )
+        self.graph_input_ids = torch.zeros(
+            self.max_num_reqs,
+            dtype=torch.int32,
+            device=device,
+        )
+        self.graph_main_hidden = torch.zeros(
+            self.max_num_reqs,
+            self.main_hidden_size,
+            dtype=self.dtype,
+            device=device,
+        )
+        self.graph_positions = torch.zeros(
+            self.max_num_reqs,
+            dtype=torch.int64,
+            device=device,
+        )
+        self.forward_cudagraph_manager: CudaGraphManager | None = None
+        self.enable_prefix_caching = cache_config.enable_prefix_caching
+        self._cache_req_ids: list[str | None] = [None] * self.max_num_reqs
+        self._cache_trusted_start = [0] * self.max_num_reqs
+        self._cache_trusted_end = [0] * self.max_num_reqs
+        self._cache_ready = [False] * self.max_num_reqs
+        if self.enable_prefix_caching:
+            logger.info(
+                "DSpark prefix cache support enabled; draft proposals are "
+                "deferred after a prefix-cache hit until the private rolling "
+                "KV window is rebuilt from fresh target rows."
+            )
 
     def load_draft_model(
         self,
@@ -255,28 +135,33 @@ class DSparkSpeculator(DraftModelSpeculator):
 
     def capture(self, attn_states: dict | None = None) -> None:
         del attn_states
-        logger.warning_once(
-            "DSpark speculator currently runs eager; CUDA graph capture is skipped."
-        )
         if os.getenv("VLLM_DSPARK_SKIP_WARMUP") == "1":
             return
 
-        hf_config = self.draft_model_config.hf_config
-        main_hidden_size = hf_config.hidden_size * len(self.target_layer_ids)
         input_ids = torch.full(
             (1,),
             self.noise_token_id,
-            dtype=torch.long,
+            dtype=torch.int32,
             device=self.device,
         )
         context_hidden = torch.zeros(
-            (1, main_hidden_size),
+            (1, self.main_hidden_size),
             dtype=self.dtype,
             device=self.device,
         )
         context_positions = torch.zeros(
             (1,),
             dtype=torch.long,
+            device=self.device,
+        )
+        context_query_start_loc = torch.tensor(
+            [0, 1],
+            dtype=torch.int32,
+            device=self.device,
+        )
+        context_num_rejected = torch.zeros(
+            (1,),
+            dtype=torch.int32,
             device=self.device,
         )
         decode_positions = torch.ones(
@@ -302,17 +187,23 @@ class DSparkSpeculator(DraftModelSpeculator):
                 round_up=True,
             )
         try:
-            with tune_ctx, set_forward_context(
-                None,
-                self.vllm_config,
-                num_tokens=self.block_size,
-                batch_descriptor=batch_descriptor,
-                slot_mapping=None,
+            with (
+                tune_ctx,
+                set_forward_context(
+                    None,
+                    self.vllm_config,
+                    num_tokens=self.block_size,
+                    batch_descriptor=batch_descriptor,
+                    slot_mapping=None,
+                ),
             ):
-                self.model.precompute_context_kv(
+                self.model.precompute_context_kv_flat(
                     context_hidden,
                     context_positions,
-                    [(0, 1)],
+                    context_query_start_loc,
+                    context_num_rejected,
+                    self.idx_mapping[:1],
+                    1,
                 )
                 self.model.forward_spec(
                     input_ids,
@@ -334,8 +225,165 @@ class DSparkSpeculator(DraftModelSpeculator):
                 self.draft_logits.zero_()
         logger.info_once("DSpark eager warmup completed.")
 
-    def init_cudagraph_manager(self, cudagraph_mode) -> None:
-        return None
+        if self.forward_cudagraph_manager is None:
+            return
+        if not self.forward_cudagraph_manager.needs_capture():
+            return
+        logger.info("Capturing DSpark block-forward CUDA graphs...")
+        try:
+            self.forward_cudagraph_manager.capture(
+                self._create_forward_graph_fn,
+                progress_bar_desc="Capturing DSpark CUDA graphs",
+            )
+        except Exception:
+            logger.exception(
+                "DSpark CUDA graph capture failed; falling back to eager draft forward."
+            )
+            self.forward_cudagraph_manager = None
+
+    def init_cudagraph_manager(self, cudagraph_mode: CUDAGraphMode) -> None:
+        if os.getenv("VLLM_DSPARK_DISABLE_FORWARD_CUDAGRAPH") == "1":
+            self.forward_cudagraph_manager = None
+            logger.info("DSpark block-forward CUDA graph capture disabled by env.")
+            return
+        if cudagraph_mode.decode_mode() == CUDAGraphMode.FULL:
+            cudagraph_mode = CUDAGraphMode.FULL_DECODE_ONLY
+        else:
+            cudagraph_mode = CUDAGraphMode.NONE
+        self.forward_cudagraph_manager = CudaGraphManager(
+            self.vllm_config,
+            self.device,
+            cudagraph_mode,
+            decode_query_len=self.block_size,
+        )
+
+    def _prepare_forward_graph_inputs(self, num_reqs: int) -> None:
+        self.graph_input_ids[:num_reqs].fill_(self.noise_token_id)
+        self.graph_main_hidden[:num_reqs].zero_()
+        self.graph_positions[:num_reqs].fill_(1)
+        self.idx_mapping[:num_reqs].copy_(
+            torch.arange(num_reqs, dtype=torch.int32, device=self.device)
+        )
+        self.temperature.fill_(1.0)
+        self.seeds.zero_()
+        self.active_num_reqs.fill_(num_reqs)
+        self.draft_tokens.zero_()
+        if self.draft_logits is not None:
+            self.draft_logits.zero_()
+
+    def _generate_draft_graph(
+        self,
+        num_reqs: int,
+        num_tokens_across_dp: torch.Tensor | None,
+        cudagraph_runtime_mode: CUDAGraphMode,
+    ) -> None:
+        num_tokens = num_reqs * self.block_size
+        batch_descriptor = BatchDescriptor(num_tokens=num_tokens)
+        with set_forward_context(
+            None,
+            self.vllm_config,
+            num_tokens=num_tokens,
+            cudagraph_runtime_mode=cudagraph_runtime_mode,
+            num_tokens_across_dp=num_tokens_across_dp,
+            slot_mapping=None,
+            batch_descriptor=batch_descriptor,
+        ):
+            output_ids, _, _ = self.model.forward_spec(
+                self.graph_input_ids[:num_reqs],
+                self.graph_main_hidden[:num_reqs],
+                self.graph_positions[:num_reqs],
+                idx_mapping=self.idx_mapping[:num_reqs],
+                temperature=self.temperature,
+                seeds=self.seeds,
+                draft_logits=self.draft_logits,
+                draft_step_cols=self.draft_step_cols,
+                active_num_reqs=self.active_num_reqs,
+                use_fp64_gumbel=self.use_fp64_gumbel,
+            )
+        steps = self.num_speculative_steps
+        self.draft_tokens[:num_reqs, :steps].copy_(output_ids[:, 1 : 1 + steps])
+
+    def _create_forward_graph_fn(
+        self,
+        desc: BatchExecutionDescriptor,
+        warmup: bool,
+    ) -> tuple[Callable[[CUDAGraphMode], None], AttentionState]:
+        del warmup
+        num_reqs = desc.num_reqs or max(1, desc.num_tokens // self.block_size)
+        num_tokens_across_dp = (
+            torch.full(
+                (self.dp_size,),
+                desc.num_tokens,
+                dtype=torch.int32,
+                device="cpu",
+            )
+            if self.dp_size > 1
+            else None
+        )
+        self._prepare_forward_graph_inputs(num_reqs)
+        fwd = lambda cg_mode: self._generate_draft_graph(
+            num_reqs,
+            num_tokens_across_dp,
+            cg_mode,
+        )
+        return fwd, AttentionState(None, {})
+
+    def _update_context_cache_state(self, input_batch: InputBatch) -> bool:
+        """Track whether DSpark's private rolling-KV rows are complete.
+
+        vLLM prefix cache can start a request with target KV already available
+        while DSpark's private target-KV window is empty for those cached
+        tokens.  We index the DSpark cache by persistent request-state index and
+        only allow proposals once fresh target forwards have repopulated the
+        whole rolling window needed by the current anchor position.
+        """
+        all_ready = True
+        for req_idx in range(input_batch.num_reqs):
+            state_idx = int(input_batch.idx_mapping_np[req_idx])
+            req_id = input_batch.req_ids[req_idx]
+            computed_start = int(input_batch.num_computed_tokens_np[req_idx])
+            scheduled = int(input_batch.num_scheduled_tokens[req_idx])
+            computed_end = computed_start + scheduled
+
+            if self._cache_req_ids[state_idx] != req_id:
+                self._cache_req_ids[state_idx] = req_id
+                self._cache_trusted_start[state_idx] = computed_start
+                self._cache_trusted_end[state_idx] = computed_start
+                self._cache_ready[state_idx] = computed_start == 0
+
+            if computed_start > self._cache_trusted_end[state_idx]:
+                # A discontinuity means target KV came from vLLM's cache or a
+                # resumed request, not from DSpark's private cache population.
+                self._cache_trusted_start[state_idx] = computed_start
+                self._cache_trusted_end[state_idx] = computed_start
+                self._cache_ready[state_idx] = False
+            elif computed_start < self._cache_trusted_start[state_idx]:
+                # Request state was rewound. Treat the current row as a fresh
+                # contiguous region.
+                self._cache_trusted_start[state_idx] = computed_start
+                self._cache_trusted_end[state_idx] = computed_start
+                self._cache_ready[state_idx] = computed_start == 0
+
+            self._cache_trusted_end[state_idx] = max(
+                self._cache_trusted_end[state_idx],
+                computed_end,
+            )
+            if scheduled <= 0:
+                all_ready = False
+                continue
+
+            anchor_pos = computed_end - 1
+            needed_start = max(0, anchor_pos - self.context_window_size + 1)
+            if (
+                self._cache_trusted_start[state_idx] <= needed_start
+                and self._cache_trusted_end[state_idx] > anchor_pos
+            ):
+                self._cache_ready[state_idx] = True
+
+            if not self._cache_ready[state_idx]:
+                all_ready = False
+
+        return all_ready
 
     @torch.inference_mode()
     def propose(
@@ -369,13 +417,10 @@ class DSparkSpeculator(DraftModelSpeculator):
             attn_metadata,
             last_hidden_states,
             mm_inputs,
-            is_profile,
         )
         num_reqs = input_batch.num_reqs
         if any(
-            req_id.startswith(
-                ("_warmup_", "_v2_mixed_warmup", "_sparse_mla_v2_warmup")
-            )
+            req_id.startswith(("_warmup_", "_v2_mixed_warmup", "_sparse_mla_v2_warmup"))
             for req_id in input_batch.req_ids[:num_reqs]
         ):
             self.draft_tokens[:num_reqs].zero_()
@@ -420,67 +465,67 @@ class DSparkSpeculator(DraftModelSpeculator):
                 self.draft_tokens[:num_reqs].zero_()
                 return self.draft_tokens[:num_reqs]
             main_hidden_all = torch.cat(aux_hidden_states, dim=-1)
-            num_rejected_cpu = num_rejected[:num_reqs].detach().cpu().tolist()
-            skip_after_rejection = (
-                os.getenv("VLLM_DSPARK_SKIP_AFTER_REJECTION") == "1"
-            )
-            context_ranges = [
-                (
-                    int(input_batch.query_start_loc_np[req_idx]),
-                    int(input_batch.query_start_loc_np[req_idx + 1])
-                    - int(num_rejected_cpu[req_idx]),
-                )
-                for req_idx in range(num_reqs)
-            ]
-            if skip_after_rejection:
-                for req_idx, num_rejected_i in enumerate(num_rejected_cpu):
-                    if num_rejected_i > 0:
-                        stale_row = int(last_token_indices[req_idx].detach().cpu())
-                        start, end = context_ranges[req_idx]
-                        context_ranges[req_idx] = (start, min(end, stale_row))
-            _maybe_dump_context_debug(
-                input_batch=input_batch,
-                last_token_indices=last_token_indices,
-                input_ids=input_ids,
-                positions=positions,
-                num_sampled=num_sampled,
-                num_rejected_cpu=num_rejected_cpu,
-                last_sampled=last_sampled,
-                next_prefill_tokens=next_prefill_tokens,
-                context_ranges=context_ranges,
-            )
-            _maybe_dump_context_tensor_debug(
-                input_batch=input_batch,
-                main_hidden_all=main_hidden_all[: input_batch.num_tokens],
-                input_ids=input_ids,
-                positions=positions,
-                context_ranges=context_ranges,
-            )
-            self.model.precompute_context_kv(
+            self.model.precompute_context_kv_flat(
                 main_hidden_all[: input_batch.num_tokens],
                 input_batch.positions[: input_batch.num_tokens],
-                context_ranges,
+                input_batch.query_start_loc,
+                num_rejected[:num_reqs],
+                input_batch.idx_mapping,
+                num_reqs,
             )
+            context_cache_ready = self._update_context_cache_state(input_batch)
             # The initial target prefill only initializes DSpark's rolling
             # context KV.  The public DSpark algorithm starts proposing once a
             # real decode token exists, so position 0 must not run the draft
             # block model.
-            if torch.any(positions <= 0).item():
+            anchor_lengths = (
+                input_batch.num_computed_tokens_np[:num_reqs]
+                + input_batch.num_scheduled_tokens[:num_reqs]
+            )
+            if int(anchor_lengths.min()) <= 1:
                 self.draft_tokens[:num_reqs].zero_()
                 return self.draft_tokens[:num_reqs]
-            if skip_after_rejection and any(n > 0 for n in num_rejected_cpu):
+            if not context_cache_ready:
                 return self.draft_tokens[:num_reqs, :0]
             main_hidden = main_hidden_all[last_token_indices]
+
+        num_query_tokens = num_reqs * self.block_size
+        batch_desc = None
+        if self.forward_cudagraph_manager is not None:
+            batch_desc, num_tokens_across_dp = dispatch_cg_and_sync_dp(
+                self.forward_cudagraph_manager,
+                num_reqs,
+                num_query_tokens,
+                uniform_token_count=self.block_size,
+                dp_size=self.dp_size,
+                dp_rank=self.dp_rank,
+                need_eager=is_profile,
+            )
+        if batch_desc is not None and batch_desc.cg_mode == CUDAGraphMode.FULL:
+            num_reqs_padded = batch_desc.num_reqs or num_reqs
+            self.graph_input_ids[:num_reqs].copy_(input_ids)
+            self.graph_main_hidden[:num_reqs].copy_(main_hidden)
+            self.graph_positions[:num_reqs].copy_(positions)
+            if num_reqs_padded > num_reqs:
+                self.graph_input_ids[num_reqs:num_reqs_padded].fill_(
+                    self.noise_token_id
+                )
+                self.graph_main_hidden[num_reqs:num_reqs_padded].zero_()
+                self.graph_positions[num_reqs:num_reqs_padded].fill_(1)
+                self.idx_mapping[num_reqs:num_reqs_padded].zero_()
+            self.active_num_reqs.fill_(num_reqs)
+            self.forward_cudagraph_manager.run_fullgraph(batch_desc)
+            return self.draft_tokens[:num_reqs]
 
         with record_function_or_nullcontext("vllm:v2/speculator/dspark/forward"):
             # DSpark uses its own TileLang attention path, but the inherited
             # DeepSeek MoE layers still read vLLM's forward context to resolve
             # static layer state.
-            batch_descriptor = BatchDescriptor(num_tokens=num_reqs * self.block_size)
+            batch_descriptor = BatchDescriptor(num_tokens=num_query_tokens)
             with set_forward_context(
                 None,
                 self.vllm_config,
-                num_tokens=num_reqs * self.block_size,
+                num_tokens=num_query_tokens,
                 num_tokens_across_dp=num_tokens_across_dp,
                 slot_mapping=slot_mappings,
                 batch_descriptor=batch_descriptor,
@@ -497,14 +542,6 @@ class DSparkSpeculator(DraftModelSpeculator):
                     active_num_reqs=self.active_num_reqs,
                     use_fp64_gumbel=self.use_fp64_gumbel,
                 )
-                _maybe_dump_propose_debug(
-                    input_ids=input_ids,
-                    positions=positions,
-                    output_ids=output_ids,
-                    logits=logits,
-                    confidence=_confidence,
-                )
-
         steps = self.num_speculative_steps
         self.draft_tokens[:num_reqs, :steps].copy_(output_ids[:, 1 : 1 + steps])
         return self.draft_tokens[:num_reqs]

--- a/vllm/v1/worker/gpu/spec_decode/dspark/utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/dspark/utils.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import os
+from collections.abc import Sequence
+
+import torch.nn as nn
+
+from vllm.config import SpeculativeConfig
+from vllm.logger import init_logger
+from vllm.models.deepseek_v4.nvidia.dspark import load_dspark_model
+
+logger = init_logger(__name__)
+
+
+def _get_target_layer_ids(spec_config: SpeculativeConfig) -> tuple[int, ...]:
+    override = os.getenv("VLLM_DSPARK_TARGET_LAYER_IDS")
+    if override:
+        try:
+            result = tuple(int(part.strip()) for part in override.split(","))
+        except ValueError as err:
+            raise RuntimeError(
+                "VLLM_DSPARK_TARGET_LAYER_IDS must be comma-separated integers, "
+                f"got {override!r}."
+            ) from err
+        if not result:
+            raise RuntimeError("VLLM_DSPARK_TARGET_LAYER_IDS must not be empty.")
+        return result
+
+    if not (spec_config and spec_config.draft_model_config):
+        raise RuntimeError("DSpark requires a draft model config.")
+    layer_ids = getattr(
+        spec_config.draft_model_config.hf_config,
+        "dspark_target_layer_ids",
+        None,
+    )
+    if not isinstance(layer_ids, Sequence) or isinstance(layer_ids, str):
+        raise RuntimeError("DSpark model config must define dspark_target_layer_ids.")
+    result = tuple(int(i) for i in layer_ids)
+    if not result:
+        raise RuntimeError("DSpark target layer list must not be empty.")
+    return result
+
+
+def set_dspark_aux_hidden_state_layers(
+    model: nn.Module,
+    spec_config: SpeculativeConfig,
+) -> None:
+    """Configure target-model auxiliary hidden-state capture for DSpark.
+
+    DeepSeek's reference DSpark code concatenates mean(HC-stream) hidden states
+    after the configured target layers. This is not EAGLE3's pre-layer residual
+    capture, so keep it as a separate mode.
+    """
+    layer_ids = _get_target_layer_ids(spec_config)
+    parent_ref = (
+        model.get_language_model() if hasattr(model, "get_language_model") else model
+    )
+    if not hasattr(parent_ref, "model"):
+        raise RuntimeError("DSpark target model must expose a .model module.")
+    inner = parent_ref.model
+    if not hasattr(inner, "set_dspark_aux_hidden_state_layers"):
+        raise RuntimeError(
+            "Target model does not support DSpark auxiliary hidden-state capture."
+        )
+    inner.set_dspark_aux_hidden_state_layers(layer_ids)
+    logger.info("Using DSpark auxiliary target layers: %s", layer_ids)
+
+
+def load_deepseek_v4_dspark_model(target_model: nn.Module, vllm_config):
+    """Load the DeepSeek V4 DSpark draft module from the target checkpoint.
+
+    DSpark shares the target embedding table and lm_head, but its ``mtp.*``
+    tensors are a draft-only block model rather than serial MTP layers.
+    """
+    dspark_model = load_dspark_model(vllm_config)
+    target_language_model = (
+        target_model.get_language_model()
+        if hasattr(target_model, "get_language_model")
+        else target_model
+    )
+    target_inner = target_language_model.model
+    target_embed = getattr(target_inner, "embed_tokens", None) or getattr(
+        target_inner, "embedding", None
+    )
+    target_lm_head = getattr(target_language_model, "lm_head", None)
+    if target_embed is None:
+        raise RuntimeError("DSpark target model does not expose embed_tokens.")
+    if target_lm_head is None:
+        raise RuntimeError("DSpark target model does not expose lm_head.")
+    dspark_model.attach_target_modules(target_embed, target_lm_head)
+    return dspark_model

--- a/vllm/v1/worker/gpu/spec_decode/rejection_sampler.py
+++ b/vllm/v1/worker/gpu/spec_decode/rejection_sampler.py
@@ -1,9 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-import json
-import os
-import time
-
 import torch
 
 from vllm.config import SpeculativeConfig
@@ -77,109 +73,6 @@ class RejectionSampler:
                 dtype=torch.float32,
                 device=device,
             )
-        self._dspark_debug_dumped = 0
-
-    def _maybe_dump_dspark_debug(
-        self,
-        input_batch: InputBatch,
-        target_logits: torch.Tensor,
-        draft_logits: torch.Tensor | None,
-        draft_sampled: torch.Tensor,
-    ) -> None:
-        debug_dir = os.getenv("VLLM_DSPARK_DEBUG_DIR")
-        if not debug_dir:
-            return
-        max_dumps = int(os.getenv("VLLM_DSPARK_DEBUG_MAX_DUMPS", "8"))
-        if self._dspark_debug_dumped >= max_dumps:
-            return
-        num_reqs = int(input_batch.num_reqs)
-        if num_reqs <= 0 or target_logits.numel() == 0:
-            return
-
-        # Keep this intentionally tiny and opt-in: it is a GPU->CPU sync used
-        # only to inspect DSpark draft/target alignment during bring-up.
-        req = 0
-        start = int(input_batch.cu_num_logits[req].item())
-        end = int(input_batch.cu_num_logits[req + 1].item())
-        if end <= start:
-            return
-        idx_mapping = int(input_batch.idx_mapping[req].item())
-        rows = []
-        local_pos = input_batch.expanded_local_pos[start:end].detach().cpu()
-        positions = input_batch.positions[input_batch.logits_indices][
-            start:end
-        ].detach().cpu()
-        sampled = draft_sampled[start:end].detach().cpu()
-        for offset, row_idx in enumerate(range(start, end)):
-            target_row = target_logits[row_idx]
-            target_topv, target_topi = torch.topk(target_row, k=8)
-            row = {
-                "row": int(row_idx),
-                "local_pos": int(local_pos[offset]),
-                "position": int(positions[offset]),
-                "input_token": int(sampled[offset]),
-                "target_top_ids": [int(x) for x in target_topi.detach().cpu()],
-                "target_top_logits": [
-                    float(x) for x in target_topv.detach().cpu()
-                ],
-            }
-            if (
-                draft_logits is not None
-                and row["local_pos"] < self.num_speculative_steps
-            ):
-                draft_row = draft_logits[idx_mapping, row["local_pos"]]
-                draft_topv, draft_topi = torch.topk(draft_row, k=8)
-                row["draft_top_ids"] = [
-                    int(x) for x in draft_topi.detach().cpu()
-                ]
-                row["draft_top_logits"] = [
-                    float(x) for x in draft_topv.detach().cpu()
-                ]
-                if offset + 1 < sampled.numel():
-                    draft_token = int(sampled[offset + 1])
-                    row["draft_token_from_input"] = draft_token
-                    # Opt-in DSpark bring-up diagnostics. Full log-softmax is
-                    # intentionally restricted to this debug path.
-                    if draft_token >= 0:
-                        target_log_probs = torch.log_softmax(
-                            target_row.float(), dim=-1)
-                        draft_log_probs = torch.log_softmax(
-                            draft_row.float(), dim=-1)
-                        target_lp = float(
-                            target_log_probs[draft_token].detach().cpu())
-                        draft_lp = float(
-                            draft_log_probs[draft_token].detach().cpu())
-                        row["draft_token_target_logprob"] = target_lp
-                        row["draft_token_draft_logprob"] = draft_lp
-                        row["draft_token_accept_prob"] = min(
-                            1.0, float(torch.exp(
-                                torch.tensor(target_lp - draft_lp)).item()))
-            rows.append(row)
-
-        os.makedirs(debug_dir, exist_ok=True)
-        path = os.path.join(debug_dir, "rejection_debug.jsonl")
-        with open(path, "a", encoding="utf-8") as f:
-            f.write(
-                json.dumps(
-                    {
-                        "time": time.time(),
-                        "dump_index": self._dspark_debug_dumped,
-                        "num_reqs": num_reqs,
-                        "cu_num_logits": [
-                            int(x)
-                            for x in input_batch.cu_num_logits.detach()
-                            .cpu()
-                            .tolist()
-                        ],
-                        "req_index": req,
-                        "req_state_index": idx_mapping,
-                        "rows": rows,
-                    },
-                    ensure_ascii=False,
-                )
-                + "\n"
-            )
-        self._dspark_debug_dumped += 1
 
     def _get_logprobs_tensors(
         self,
@@ -236,12 +129,6 @@ class RejectionSampler:
             pos,
             draft_sampled,
             input_batch.expanded_local_pos,
-        )
-        self._maybe_dump_dspark_debug(
-            input_batch,
-            processed_logits,
-            draft_logits,
-            draft_sampled,
         )
         sampled, num_sampled = rejection_sample(
             processed_logits,

--- a/vllm/v1/worker/gpu/spec_decode/rejection_sampler.py
+++ b/vllm/v1/worker/gpu/spec_decode/rejection_sampler.py
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import json
+import os
+import time
+
 import torch
 
 from vllm.config import SpeculativeConfig
@@ -73,6 +77,109 @@ class RejectionSampler:
                 dtype=torch.float32,
                 device=device,
             )
+        self._dspark_debug_dumped = 0
+
+    def _maybe_dump_dspark_debug(
+        self,
+        input_batch: InputBatch,
+        target_logits: torch.Tensor,
+        draft_logits: torch.Tensor | None,
+        draft_sampled: torch.Tensor,
+    ) -> None:
+        debug_dir = os.getenv("VLLM_DSPARK_DEBUG_DIR")
+        if not debug_dir:
+            return
+        max_dumps = int(os.getenv("VLLM_DSPARK_DEBUG_MAX_DUMPS", "8"))
+        if self._dspark_debug_dumped >= max_dumps:
+            return
+        num_reqs = int(input_batch.num_reqs)
+        if num_reqs <= 0 or target_logits.numel() == 0:
+            return
+
+        # Keep this intentionally tiny and opt-in: it is a GPU->CPU sync used
+        # only to inspect DSpark draft/target alignment during bring-up.
+        req = 0
+        start = int(input_batch.cu_num_logits[req].item())
+        end = int(input_batch.cu_num_logits[req + 1].item())
+        if end <= start:
+            return
+        idx_mapping = int(input_batch.idx_mapping[req].item())
+        rows = []
+        local_pos = input_batch.expanded_local_pos[start:end].detach().cpu()
+        positions = input_batch.positions[input_batch.logits_indices][
+            start:end
+        ].detach().cpu()
+        sampled = draft_sampled[start:end].detach().cpu()
+        for offset, row_idx in enumerate(range(start, end)):
+            target_row = target_logits[row_idx]
+            target_topv, target_topi = torch.topk(target_row, k=8)
+            row = {
+                "row": int(row_idx),
+                "local_pos": int(local_pos[offset]),
+                "position": int(positions[offset]),
+                "input_token": int(sampled[offset]),
+                "target_top_ids": [int(x) for x in target_topi.detach().cpu()],
+                "target_top_logits": [
+                    float(x) for x in target_topv.detach().cpu()
+                ],
+            }
+            if (
+                draft_logits is not None
+                and row["local_pos"] < self.num_speculative_steps
+            ):
+                draft_row = draft_logits[idx_mapping, row["local_pos"]]
+                draft_topv, draft_topi = torch.topk(draft_row, k=8)
+                row["draft_top_ids"] = [
+                    int(x) for x in draft_topi.detach().cpu()
+                ]
+                row["draft_top_logits"] = [
+                    float(x) for x in draft_topv.detach().cpu()
+                ]
+                if offset + 1 < sampled.numel():
+                    draft_token = int(sampled[offset + 1])
+                    row["draft_token_from_input"] = draft_token
+                    # Opt-in DSpark bring-up diagnostics. Full log-softmax is
+                    # intentionally restricted to this debug path.
+                    if draft_token >= 0:
+                        target_log_probs = torch.log_softmax(
+                            target_row.float(), dim=-1)
+                        draft_log_probs = torch.log_softmax(
+                            draft_row.float(), dim=-1)
+                        target_lp = float(
+                            target_log_probs[draft_token].detach().cpu())
+                        draft_lp = float(
+                            draft_log_probs[draft_token].detach().cpu())
+                        row["draft_token_target_logprob"] = target_lp
+                        row["draft_token_draft_logprob"] = draft_lp
+                        row["draft_token_accept_prob"] = min(
+                            1.0, float(torch.exp(
+                                torch.tensor(target_lp - draft_lp)).item()))
+            rows.append(row)
+
+        os.makedirs(debug_dir, exist_ok=True)
+        path = os.path.join(debug_dir, "rejection_debug.jsonl")
+        with open(path, "a", encoding="utf-8") as f:
+            f.write(
+                json.dumps(
+                    {
+                        "time": time.time(),
+                        "dump_index": self._dspark_debug_dumped,
+                        "num_reqs": num_reqs,
+                        "cu_num_logits": [
+                            int(x)
+                            for x in input_batch.cu_num_logits.detach()
+                            .cpu()
+                            .tolist()
+                        ],
+                        "req_index": req,
+                        "req_state_index": idx_mapping,
+                        "rows": rows,
+                    },
+                    ensure_ascii=False,
+                )
+                + "\n"
+            )
+        self._dspark_debug_dumped += 1
 
     def _get_logprobs_tensors(
         self,
@@ -129,6 +236,12 @@ class RejectionSampler:
             pos,
             draft_sampled,
             input_batch.expanded_local_pos,
+        )
+        self._maybe_dump_dspark_debug(
+            input_batch,
+            processed_logits,
+            draft_logits,
+            draft_sampled,
         )
         sampled, num_sampled = rejection_sample(
             processed_logits,


### PR DESCRIPTION
## Summary

Adds DeepSeek V4 DSpark speculative decoding support on top of the eldritch enlightenment release branch. This includes the draft-only DSpark model, DSpark speculator wiring, warmup/CUDA graph support, conservative prefix-cache handling, probabilistic draft sampling support, and focused CPU unit coverage.

## Validation

- `ruff check vllm/config/speculative.py vllm/config/vllm.py vllm/models/deepseek_v4/nvidia/dspark.py vllm/models/deepseek_v4/nvidia/model.py vllm/v1/worker/gpu/model_runner.py vllm/v1/worker/gpu/spec_decode/dspark/speculator.py vllm/v1/worker/gpu/spec_decode/rejection_sampler.py tests/v1/spec_decode/test_dspark.py`
- `pytest -q tests/v1/spec_decode/test_dspark.py` -> 9 passed
- `git diff --check`

## Follow-up in progress

Next step is an integration Docker image that combines this PR with local-inference-lab/vllm#60, then DS4 DSpark runtime/performance validation before any upstream vLLM PR.