### PR TITLE
[eldritch] sparse indexer: size B12X paged workspace from runtime tok…

### DIFF
--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -1337,9 +1337,18 @@ def sparse_attn_indexer(
         )
         if _b12x_sparse_indexer_requested(use_b12x_sparse_indexer):
             _ensure_b12x_sparse_indexer_supported()
-            profile_q_rows = _get_b12x_paged_indexer_profile_q_rows(
-                int(q_quant.shape[0])
+
+            # Profile B12X scratch for the runtime token capacity. The
+            # workspace is locked after warmup, so a smaller warmup q shape can
+            # under-size long-context sparse prefill.
+            profile_q_capacity = max(
+                int(q_quant.shape[0]),
+                int(topk_indices_buffer.shape[0]),
             )
+            profile_q_rows = _get_b12x_paged_indexer_profile_q_rows(
+                profile_q_capacity
+            )
+            
             profile_k_rows = _get_b12x_paged_indexer_profile_k_rows(
                 max_model_len=max_model_len,
                 total_seq_lens=total_seq_lens,


### PR DESCRIPTION
## Purpose

Fix a B12X sparse indexer workspace sizing issue in the Eldritch DeepSeek-V4 sparse MLA path.

`B12X_MLA_SPARSE` can under-size the B12X paged sparse-indexer workspace during warmup/profiling. In a DeepSeek-V4-Flash TP2 run with:

```text
--attention-backend B12X_MLA_SPARSE
--max-num-seqs 1
--max-num-batched-tokens 8192
--max-model-len 262144
--kv-cache-dtype fp8
```

the engine starts successfully, but the first long-context prefill can fail after the workspace has already been locked:

```text
Workspace is locked but allocation from
'sparse_attn_indexer.py:923:_run_b12x_paged_topk'
requires 1124.19 MB, current size is 772.00 MB.
Workspace growth is not allowed after locking.
```

This does not look like a general CUDA OOM. The failure is specific to the B12X sparse indexer workspace being locked smaller than the later long-context request requires.

The B12X paged sparse-indexer profiling path currently sizes the q-row profile from the current warmup q shape:

```python
int(q_quant.shape[0])
```

However, the available runtime token capacity for this path is reflected by the shared top-k indices buffer. For DeepSeek-V4 and MTP, this buffer is allocated from `scheduler_config.max_num_batched_tokens`, so its leading dimension represents the maximum token capacity that the sparse indexer may later process.

This PR profiles B12X sparse-indexer scratch from the available top-k buffer capacity, not only from the current warmup q rows:

```python
profile_q_capacity = max(
    int(q_quant.shape[0]),
    int(topk_indices_buffer.shape[0]),
)
profile_q_rows = _get_b12x_paged_indexer_profile_q_rows(
    profile_q_capacity
)
```

This keeps the current q shape as a lower bound while ensuring that warmup reserves enough workspace for the top-k buffer capacity used at runtime.

Scope:

- B12X paged sparse-indexer workspace/profile sizing only.
- Non-B12X sparse indexer paths are unchanged.

Risk:

- This may reserve a larger B12X sparse-indexer workspace during warmup when the runtime top-k buffer capacity is larger than the current warmup q shape.
- The intended tradeoff is to reserve the required workspace before locking, rather than failing later when a long-context sparse prefill needs a larger scratch allocation.

## Test Plan

Code-level validation:

```bash
python3 -m py_compile vllm/model_executor/layers/sparse_attn_indexer.py
git diff --check
```

Runtime validation on B12X hardware was not run in this PR.

Suggested follow-up runtime repro for a B12X/Blackwell environment:

```bash
python -m vllm.entrypoints.cli.main serve deepseek-ai/DeepSeek-V4-Flash \
  --served-model-name deepseek-v4-flash \
  --tensor-parallel-size 2 \
  --kv-cache-dtype fp8 \
  --block-size 256 \
  --load-format safetensors \
  --attention-backend B12X_MLA_SPARSE \
  --moe-backend b12x \
  --linear-backend b12x \
  --max-model-len 262144 \
  --max-num-seqs 1 \
  --max-num-batched-tokens 8192 \
  --enable-chunked-prefill \
  --no-enable-prefix-caching \
  --tokenizer-mode deepseek_v4 \
  --tool-call-parser deepseek_v4 \
  --enable-auto-tool-choice \
  --reasoning-parser deepseek_v4 \
  --speculative-config '{"method":"mtp","num_speculative_tokens":2,"draft_sample_method":"probabilistic","moe_backend":"b12x"}'
```

Then run a long-context request or benchmark, for example 64k input / 128 output tokens.

## Test Result

Code-level validation passed:

```text
python3 -m py_compile vllm/model_executor/layers/sparse_attn_indexer.py: OK
git diff --check: OK
```

Runtime validation on B12X hardware was not run in this PR.