### PR TITLE
[eldritch] Fix DSpark TP4 TileLang warp policy

### DIFF
--- a/vllm/models/deepseek_v4/nvidia/ops/dspark_sparse_attn_tilelang.py
+++ b/vllm/models/deepseek_v4/nvidia/ops/dspark_sparse_attn_tilelang.py
@@ -36,7 +36,11 @@ def _build_dspark_sparse_attn_kernel(num_heads: int, head_dim: int, scale: float
         topk = T.symbolic("topk")
 
         num_stages = 2
-        threads = 256
+        # TP4 has 16 DSpark heads per rank. With 8 warps, TileLang's FullRow
+        # repartition leaves too few warp-column tiles for this MMA layout.
+        # Use 4 warps for that native-head path; TP2 keeps the measured faster
+        # 8-warps path.
+        threads = 128 if num_heads <= 16 else 256
         # The upstream DSpark reference uses 64, which asks for ~104 KiB
         # dynamic shared memory on DeepSeek V4 head dims and is rejected on
         # this sm120 stack. 32 keeps the same online-softmax algorithm while


### PR DESCRIPTION
## Summary

This is a narrow DSpark TileLang sparse-attention fix for DeepSeek V4 Flash DSpark on TP4.

TP4 has 16 DSpark heads per rank. With the current 256-thread / 8-warp FullRow kernel, TileLang's warp repartition leaves too few warp-column tiles for this MMA layout. The fix uses 128 threads only for `num_heads <= 16`, keeping TP2 and wider-head cases on the existing 256-thread path.

## Why this shape

I compared three options:

- current 256-thread native TP4 path: compile/runtime issue for the 16-head layout
- Brandon PR-style native TP4: `h=16, block=32, threads=128, FullRow/FullRow`
- microbench-best native TP4: `h=16, block=64, threads=256, FullRow/FullCol`

The block64/FullCol variant wins the isolated TileLang kernel microbench, but loses end-to-end under the actual DSpark server path. The runtime patch therefore uses the e2e-proven PR-style TP4 shape, not the microbench-only winner.

TP2 remains unchanged because both microbench and e2e showed 256 threads is still better than forcing 128 threads for 32 heads.

## Validation

Static checks:

- `python3 -m py_compile vllm/models/deepseek_v4/nvidia/ops/dspark_sparse_attn_tilelang.py`
- `git diff --check`

Controlled DSpark-on A/B, same GPUs `8-11`, same image/runtime config:

- image: `voipmonitor/vllm:eldritch-enlightenment-v8722ac7-b12x15cd38c-cu132-20260629`
- config: TP4, `lucifer-cutlass`, DSpark enabled, `num_speculative_tokens=5`, `max_num_seqs=1`, graph/capture sizes `[1,2,4,8]`, prefix cache off
- PR-style TP4 (`h=16/block=32/threads=128/FullRow`): `/mnt/test.py -L` 60 iterations, CJK `0`, average generation-only `376.59 tok/s`
- block64/FullCol candidate: `/mnt/test.py -L` 54 iterations, CJK `0`, average generation-only `350.45 tok/s`

Earlier TP2 A/B on the same stack showed no benefit from changing TP2 to 128 threads, so TP2 is intentionally left on 256 threads.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved kernel thread selection for sparse attention based on the number of heads, helping better match execution settings to workload size.
  * Small-head configurations now use fewer threads, while larger configurations keep the higher thread count for performance balance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->