### PR TITLE
[eldritch] Keep DeepSeek V4 RoPE cache in FP32 for MTP

### DIFF
--- a/vllm/models/deepseek_v4/common/rope.py
+++ b/vllm/models/deepseek_v4/common/rope.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """DeepseekV4 rotary embedding initialization."""
 
+import torch
+
 from vllm.model_executor.layers.rotary_embedding import get_rope
 from vllm.model_executor.layers.rotary_embedding.base import RotaryEmbedding
 
@@ -35,4 +37,8 @@ def build_deepseek_v4_rope(
         max_position=max_position_embeddings,
         rope_parameters=rope_parameters,
         is_neox_style=False,
+        # DeepSeek V4 kernels consume the cached cos/sin table directly and
+        # require FP32 even when the draft/MTP model is initialized under a
+        # lower default dtype.
+        dtype=torch.float32,
     )


### PR DESCRIPTION
## Summary

Keep the DeepSeek V4 RoPE cache in FP32 by passing `dtype=torch.float32` when constructing the model RoPE table.

## Why

DeepSeek V4 MTP draft initialization can happen under a lower default dtype. The fused DeepSeek V4 qnorm/rope/KV insert path consumes `rotary_emb.cos_sin_cache` directly and requires that table to be FP32. When the cache is created as BF16, DS4 MTP2 fails during draft warmup or graph capture with:

```text
fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert ... cos_sin_cache must be float32
```

This was reproduced both with and without `B12X_MLA_SPARSE`, and both with and without CUDA graphs, so the fix is intentionally placed at RoPE construction rather than in a B12X-specific path or via a runtime cast.

## Scope

- DeepSeek V4 RoPE construction only.
- No runtime `.float()` conversion in the forward path.
- No B12X workspace or binding changes.

## Validation

- `python3 -m py_compile vllm/models/deepseek_v4/common/rope.py vllm/models/deepseek_v4/attention.py`
- `git diff --check lil/dev/eldritch-enlightenment..HEAD`
- Runtime overlay smoke on DeepSeek-V4-Flash TP2/MTP2 with B12X attention/MoE/linear and `max_num_batched_tokens=8192`: server reached API-ready, target and speculator capture completed, a short `/v1/chat/completions` request returned HTTP 200, and logs showed spec-decoding metrics with no `cos_sin_cache`, `RuntimeError`, or traceback.