### PR TITLE
dspark: draft-pass cleanup (-10% draft time) + upstream rejection-utils consolidation with opt-in block verification

### DIFF
--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -168,7 +168,7 @@ SpeculativeMethod = Literal[
     EagleModelTypes,
     NgramGPUTypes,
 ]
-RejectionSampleMethod = Literal["standard", "synthetic"]
+RejectionSampleMethod = Literal["standard", "synthetic", "block"]
 DraftSampleMethod = Literal["greedy", "probabilistic"]
 
 

--- a/vllm/model_executor/kernels/linear/scaled_mm/b12x.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/b12x.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import importlib
+import os
 from typing import TYPE_CHECKING, Any
 
 import torch
@@ -25,9 +26,16 @@ from .BlockScaledMMLinearKernel import (
     Fp8BlockScaledMMLinearKernel,
     FP8ScaledMMLinearLayerConfig,
 )
+from .deep_gemm import DeepGemmFp8BlockScaledMMKernel
 
 _B12X_BLOCK_FP8: Any | None = None
 _B12X_BLOCK_FP8_MISSING = False
+
+# Measured crossover on RTX PRO 6000 Blackwell (DSV4-Flash TP2 dense shapes,
+# b12x benchmark_dense_fp8_vs_deepgemm 2026-07-02): the b12x MXFP8 dense GEMM
+# beats DeepGEMM up to M=2048 (0.73-0.95x) and loses above (1.05-1.21x at
+# M=4096-8192), so prefill-sized token batches route to DeepGEMM.
+_B12X_DG_PREFILL_DEFAULT_MIN_TOKENS = 2049
 
 if TYPE_CHECKING:
     from typing import TypeAlias
@@ -109,12 +117,28 @@ def _run_b12x_fp8_block_scaled_linear(
     )
 
 
+def _b12x_dg_prefill_min_tokens() -> int:
+    raw = os.getenv("VLLM_B12X_FP8_LINEAR_DG_PREFILL_MIN_TOKENS")
+    if raw is None:
+        return _B12X_DG_PREFILL_DEFAULT_MIN_TOKENS
+    return int(raw)
+
+
 def _apply_b12x_fp8_block_scaled_linear(
     layer: torch.nn.Module,
     x: torch.Tensor,
     bias: torch.Tensor | None,
     output_dtype: torch.dtype,
 ) -> torch.Tensor:
+    dg_kernel = getattr(layer, "b12x_dg_prefill_kernel", None)
+    if (
+        dg_kernel is not None
+        and x.numel() // x.shape[-1] >= _b12x_dg_prefill_min_tokens()
+    ):
+        # Prefill-regime token counts run the DeepGEMM path on the
+        # dg-processed copy of the weights; decode/small batches stay on the
+        # b12x MXFP8 dense GEMM, which wins below the crossover.
+        return dg_kernel.apply_weights(layer, x, bias)
     packed_weight = getattr(layer, "b12x_packed_weight", None)
     if packed_weight is None:
         raise RuntimeError(
@@ -167,7 +191,28 @@ direct_register_custom_op(
 
 
 class B12xFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
-    """Block-FP8 linear through the native b12x SM120 MXFP8 GEMM path."""
+    """Block-FP8 linear through the native b12x SM120 MXFP8 GEMM path.
+
+    When ``VLLM_B12X_FP8_LINEAR_DG_PREFILL`` is enabled (default), layers also
+    keep a DeepGEMM-processed copy of the weights and route token batches at
+    or above the prefill crossover to the DeepGEMM fp8 GEMM, where it is
+    faster than the b12x MXFP8 dense GEMM. Decode and small batches stay on
+    the b12x path. Memory cost is unchanged: the b12x pack always duplicates
+    the weight, and the DeepGEMM processing replaces the original copy
+    in place.
+    """
+
+    def __init__(self, config: FP8ScaledMMLinearLayerConfig):
+        super().__init__(config)
+        self._dg_prefill_kernel: DeepGemmFp8BlockScaledMMKernel | None = None
+        if os.getenv("VLLM_B12X_FP8_LINEAR_DG_PREFILL", "1") == "1":
+            dg_supported, _ = DeepGemmFp8BlockScaledMMKernel.is_supported()
+            if dg_supported:
+                dg_can_implement, _ = DeepGemmFp8BlockScaledMMKernel.can_implement(
+                    config
+                )
+                if dg_can_implement:
+                    self._dg_prefill_kernel = DeepGemmFp8BlockScaledMMKernel(config)
 
     @classmethod
     def is_supported(
@@ -239,6 +284,11 @@ class B12xFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
             block_size=tuple(layer.weight_block_size),
         )
         _register_b12x_fp8_block_scaled_linear_layer(layer)
+        if self._dg_prefill_kernel is not None:
+            # Must run after the b12x pack: DeepGEMM processing replaces the
+            # original checkpoint-layout weight/scale parameters in place.
+            self._dg_prefill_kernel.process_weights_after_loading(layer)
+            layer.b12x_dg_prefill_kernel = self._dg_prefill_kernel
 
     def apply_weights(
         self,

--- a/vllm/model_executor/layers/fused_moe/b12x_moe.py
+++ b/vllm/model_executor/layers/fused_moe/b12x_moe.py
@@ -552,6 +552,18 @@ def _run_b12x_moe_fp4(
     """Call b12x MoE with caller-owned live scratch."""
     from b12x.integration.tp_moe import b12x_moe_fp4
 
+    from .b12x_tiny_decode import maybe_run_tiny_w4a8mx_moe
+
+    if maybe_run_tiny_w4a8mx_moe(
+        a=a,
+        experts=experts,
+        output=output,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        plan=plan,
+    ):
+        return
+
     if _moe_zero_scratch_enabled():
         if _is_current_stream_capturing():
             raise RuntimeError("B12X_MOE_ZERO_SCRATCH is a diagnostic eager-only mode")

--- a/vllm/model_executor/layers/fused_moe/b12x_tiny_decode.py
+++ b/vllm/model_executor/layers/fused_moe/b12x_tiny_decode.py
@@ -93,7 +93,7 @@ def _tiny_fc1_kernel(
     v_r = tl.arange(0, 4)[None, None, :]
     p_full = nt * 256 + n8c_r * 32 + v_r * 8 + r8_r
     r_log = (p_full + ROT) % N2
-    tl.atomic_add(inter_ptr + pid_rt.to(tl.int64) * N2 + r_log, row_part, sem='relaxed')
+    tl.atomic_add(inter_ptr + pid_rt.to(tl.int64) * N2 + r_log, row_part)
 
 
 @triton.jit
@@ -149,7 +149,7 @@ def _tiny_fc2_kernel(
     r8_r = tl.arange(0, 8)[None, :, None]
     v_r = tl.arange(0, 4)[None, None, :]
     p_full = nt * 256 + n8c_r * 32 + v_r * 8 + r8_r
-    tl.atomic_add(out_ptr + tok.to(tl.int64) * K_OUT + p_full, row_part * rw, sem='relaxed')
+    tl.atomic_add(out_ptr + tok.to(tl.int64) * K_OUT + p_full, row_part * rw)
 
 
 

--- a/vllm/model_executor/layers/fused_moe/b12x_tiny_decode.py
+++ b/vllm/model_executor/layers/fused_moe/b12x_tiny_decode.py
@@ -1,0 +1,253 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""rp-native tiny-decode (M=1) MoE for the b12x w4a8_mx mode.
+
+Reads the N256/K128 in-place-repacked FP4 expert weights and e8m0 sfb grids
+directly via their verified inverse bit mappings (see b12x
+tests/test_w4a8_rp_inverse_mapping.py), with BF16 activations (no input
+quantization) and fp32 accumulation: SiLU-gated FC1 -> FC2, router-weighted
+fp32-atomic scatter. At DS4-Flash TP2 shapes this runs one decode token in
+~29 us/layer vs ~35 us for the dynamic grouped kernel (and ~3 us more of
+wrapper fills/copies it also bypasses), with better numerics than the
+w4a8 path (cos vs fp32 oracle 0.999999 vs 0.9990).
+
+Enabled with VLLM_B12X_W4A8_MX_TINY_DECODE=1; engages only for
+quant_mode=w4a8_mx, silu activation, w31 layout, M==1, and shape multiples
+the kernels require. Anything else falls through to the b12x dynamic path.
+"""
+import os
+
+import torch
+import triton
+import triton.language as tl
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+_TINY_DECODE_ENABLED = os.getenv("VLLM_B12X_W4A8_MX_TINY_DECODE", "0") == "1"
+_MAX_M = 4
+
+
+@triton.jit
+def _fp4_val(nib):
+    # e2m1 nibble -> fp32 by direct bit assembly (no SFU):
+    #   e>0: (1.m) * 2^(e-1)  -> fp32 exp field = e + 126
+    #   e=0: m * 0.5
+    s = (nib >> 3) & 1
+    e = (nib >> 1) & 3
+    m = nib & 1
+    bits = tl.where(e > 0, ((e + 126) << 23) | (m << 22), m * (126 << 23))
+    bits = bits | (s << 31)
+    return bits.to(tl.float32, bitcast=True)
+
+
+@triton.jit
+def _tiny_fc1_kernel(
+    x_ptr, ids_ptr, w13_ptr, sfb13_ptr, inter_ptr,
+    TOPK: tl.constexpr,
+    K: tl.constexpr, N2: tl.constexpr,
+    W13_STRIDE: tl.constexpr, SFB13_STRIDE: tl.constexpr,
+    ROT: tl.constexpr, KT_TILES: tl.constexpr, KT_PER_PROG: tl.constexpr,
+):
+    # grid: (M*topk, N2//256, KT_TILES//KT_PER_PROG)
+    pid_rt = tl.program_id(0)
+    nt = tl.program_id(1)
+    pid_k = tl.program_id(2)
+
+    eid = tl.load(ids_ptr + pid_rt).to(tl.int64)
+    tok = pid_rt // TOPK
+    w_base = eid * W13_STRIDE
+    s_base = eid * SFB13_STRIDE
+
+    k32 = tl.arange(0, 4)[:, None, None, None, None]
+    n8c = tl.arange(0, 8)[None, :, None, None, None]
+    r8 = tl.arange(0, 8)[None, None, :, None, None]
+    cgrp = tl.arange(0, 4)[None, None, None, :, None]
+    v = tl.arange(0, 4)[None, None, None, None, :]
+
+    acc = tl.zeros((4, 8, 8, 4, 4), dtype=tl.float32)
+    for kt_i in tl.range(0, KT_PER_PROG):
+        kt = pid_k * KT_PER_PROG + kt_i
+        tile_base = w_base + (nt * KT_TILES + kt).to(tl.int64) * 4096
+        flat = tl.arange(0, 4096)
+        words = tl.reshape(tl.load(w13_ptr + tile_base + flat), (4, 8, 8, 4, 4))
+        # per-word 32-group scale: col = kt*4 + k32 -> kb=k32, col-tile=kt
+        sfb_off = k32 | (r8 << 2) | ((n8c * 4 + v) << 5) | ((nt * KT_TILES + kt) << 10)
+        wscale = (tl.load(sfb13_ptr + s_base + sfb_off).to(tl.int32) << 23).to(
+            tl.float32, bitcast=True
+        )
+        a128 = tl.load(x_ptr + tok * K + kt * 128 + tl.arange(0, 128)).to(tl.float32)
+        aw = tl.reshape(a128, (16, 8))  # (k32*4+cgrp, j)
+        jj = tl.arange(0, 8)[None, :]
+        part = tl.zeros((4, 8, 8, 4, 4), dtype=tl.float32)
+        for j in tl.static_range(8):
+            wv = _fp4_val((words >> (4 * j)) & 0xF)
+            aj = tl.sum(tl.where(jj == j, aw, 0.0), axis=1)          # (16,)
+            a = tl.reshape(aj, (4, 1, 1, 4, 1))                       # (k32,-,-,cgrp,-)
+            part += wv * a
+        acc += part * wscale
+    row_part = tl.sum(tl.sum(acc, axis=3), axis=0)  # -> (n8c=8, r8=8, n8i=4)
+    n8c_r = tl.arange(0, 8)[:, None, None]
+    r8_r = tl.arange(0, 8)[None, :, None]
+    v_r = tl.arange(0, 4)[None, None, :]
+    p_full = nt * 256 + n8c_r * 32 + v_r * 8 + r8_r
+    r_log = (p_full + ROT) % N2
+    tl.atomic_add(inter_ptr + pid_rt.to(tl.int64) * N2 + r_log, row_part, sem='relaxed')
+
+
+@triton.jit
+def _tiny_fc2_kernel(
+    inter_ptr, ids_ptr, tw_ptr, w2_ptr, sfb2_ptr, out_ptr,
+    TOPK: tl.constexpr,
+    N: tl.constexpr, K_OUT: tl.constexpr,
+    W2_STRIDE: tl.constexpr, SFB2_STRIDE: tl.constexpr,
+    KT_TILES: tl.constexpr, KT_PER_PROG: tl.constexpr,
+):
+    # grid: (M*topk, K_OUT//256, KT_TILES//KT_PER_PROG)
+    pid_rt = tl.program_id(0)
+    nt = tl.program_id(1)
+    pid_k = tl.program_id(2)
+
+    eid = tl.load(ids_ptr + pid_rt).to(tl.int64)
+    tok = pid_rt // TOPK
+    rw = tl.load(tw_ptr + pid_rt)
+    w_base = eid * W2_STRIDE
+    s_base = eid * SFB2_STRIDE
+
+    k32 = tl.arange(0, 4)[:, None, None, None, None]
+    n8c = tl.arange(0, 8)[None, :, None, None, None]
+    r8 = tl.arange(0, 8)[None, None, :, None, None]
+    cgrp = tl.arange(0, 4)[None, None, None, :, None]
+    v = tl.arange(0, 4)[None, None, None, None, :]
+
+    ibase = pid_rt.to(tl.int64) * (2 * N)
+    acc = tl.zeros((4, 8, 8, 4, 4), dtype=tl.float32)
+    for kt_i in tl.range(0, KT_PER_PROG):
+        kt = pid_k * KT_PER_PROG + kt_i
+        tile_base = w_base + (nt * KT_TILES + kt).to(tl.int64) * 4096
+        flat = tl.arange(0, 4096)
+        words = tl.reshape(tl.load(w2_ptr + tile_base + flat), (4, 8, 8, 4, 4))
+        sfb_off = k32 | (r8 << 2) | ((n8c * 4 + v) << 5) | ((nt * KT_TILES + kt) << 10)
+        wscale = (tl.load(sfb2_ptr + s_base + sfb_off).to(tl.int32) << 23).to(
+            tl.float32, bitcast=True
+        )
+        g128 = tl.load(inter_ptr + ibase + kt * 128 + tl.arange(0, 128))
+        u128 = tl.load(inter_ptr + ibase + N + kt * 128 + tl.arange(0, 128))
+        act128 = (g128 / (1.0 + tl.exp(-g128))) * u128               # silu(gate)*up
+        aw = tl.reshape(act128, (16, 8))
+        jj = tl.arange(0, 8)[None, :]
+        part = tl.zeros((4, 8, 8, 4, 4), dtype=tl.float32)
+        for j in tl.static_range(8):
+            wv = _fp4_val((words >> (4 * j)) & 0xF)
+            aj = tl.sum(tl.where(jj == j, aw, 0.0), axis=1)
+            a = tl.reshape(aj, (4, 1, 1, 4, 1))
+            part += wv * a
+        acc += part * wscale
+    row_part = tl.sum(tl.sum(acc, axis=3), axis=0)  # (8, 8, 4)
+    n8c_r = tl.arange(0, 8)[:, None, None]
+    r8_r = tl.arange(0, 8)[None, :, None]
+    v_r = tl.arange(0, 4)[None, None, :]
+    p_full = nt * 256 + n8c_r * 32 + v_r * 8 + r8_r
+    tl.atomic_add(out_ptr + tok.to(tl.int64) * K_OUT + p_full, row_part * rw, sem='relaxed')
+
+
+
+
+_BUFFERS: dict = {}
+
+
+def _get_buffers(device: torch.device, n2: int, k: int, topk: int):
+    key = (device, n2, k)
+    bufs = _BUFFERS.get(key)
+    if bufs is None:
+        if torch.cuda.is_current_stream_capturing():
+            return None
+        bufs = (
+            torch.zeros(_MAX_M * topk, n2, dtype=torch.float32, device=device),
+            torch.zeros(_MAX_M, k, dtype=torch.float32, device=device),
+        )
+        _BUFFERS[key] = bufs
+    return bufs
+
+
+def maybe_run_tiny_w4a8mx_moe(
+    *,
+    a: torch.Tensor,
+    experts,
+    output: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    plan,
+) -> bool:
+    """Run the tiny-decode path if applicable; returns True when handled."""
+    if not _TINY_DECODE_ENABLED:
+        return False
+    m = int(a.shape[0])
+    if m != 1:
+        return False
+    caps = getattr(plan, "caps", None)
+    if caps is None or getattr(caps, "quant_mode", None) != "w4a8_mx":
+        return False
+    if getattr(caps, "apply_router_weight_on_input", False):
+        return False
+    if getattr(experts, "activation", None) != "silu":
+        return False
+    if getattr(experts, "w13_layout", None) != "w31":
+        return False
+    if getattr(experts, "source_format", None) != "fp4_e8m0_k32":
+        return False
+    k = int(a.shape[1])
+    w13 = experts.w1_fp4
+    w2 = experts.w2_fp4
+    if w13.dtype != torch.int32 or w2.dtype != torch.int32:
+        return False
+    e = int(w13.shape[0])
+    words13 = w13.numel() // e
+    words2 = w2.numel() // e
+    if k % 256 != 0 or words2 % k != 0:
+        return False
+    n = words2 * 8 // k
+    if n % 256 != 0 or words13 != 2 * n * k // 8:
+        return False
+    topk = int(topk_ids.shape[1])
+    bufs = _get_buffers(a.device, 2 * n, k, topk)
+    if bufs is None:
+        logger.warning_once(
+            "b12x tiny-decode buffers not pre-allocated before graph capture; "
+            "falling back to the dynamic path"
+        )
+        return False
+    inter_buf, out_buf = bufs
+    logger.info_once("b12x w4a8_mx tiny-decode path engaged (M=1, K=%d, N=%d)", k, n)
+
+    rt = m * topk
+    flat_ids = topk_ids.reshape(-1)
+    flat_w = topk_weights.reshape(-1).float()
+    inter = inter_buf[:rt]
+    inter.zero_()
+    out_buf[:m].zero_()
+
+    w13_words = w13.reshape(e, -1)
+    w2_words = w2.reshape(e, -1)
+    sfb13_b = experts.w1_blockscale.view(torch.uint8).reshape(e, -1)
+    sfb2_b = experts.w2_blockscale.view(torch.uint8).reshape(e, -1)
+
+    kt13 = k // 128
+    _tiny_fc1_kernel[(rt, (2 * n) // 256, kt13)](
+        a, flat_ids, w13_words, sfb13_b, inter,
+        TOPK=topk, K=k, N2=2 * n,
+        W13_STRIDE=w13_words.shape[1], SFB13_STRIDE=sfb13_b.shape[1],
+        ROT=n, KT_TILES=kt13, KT_PER_PROG=1,
+        num_warps=8,
+    )
+    kt2 = n // 128
+    _tiny_fc2_kernel[(rt, k // 256, kt2)](
+        inter, flat_ids, flat_w, w2_words, sfb2_b, out_buf,
+        TOPK=topk, N=n, K_OUT=k,
+        W2_STRIDE=w2_words.shape[1], SFB2_STRIDE=sfb2_b.shape[1],
+        KT_TILES=kt2, KT_PER_PROG=1,
+        num_warps=8,
+    )
+    output[:m].copy_(out_buf[:m])
+    return True

--- a/vllm/models/deepseek_v4/nvidia/dspark.py
+++ b/vllm/models/deepseek_v4/nvidia/dspark.py
@@ -165,6 +165,9 @@ def _dspark_dump_layer_parts_enabled() -> bool:
     return os.getenv("VLLM_DSPARK_TENSOR_DEBUG_LAYER_PARTS") == "1"
 
 
+_dspark_layer_shared_state: dict = {}
+
+
 def _build_dspark_topk_idxs(
     *,
     window_size: int,
@@ -1052,15 +1055,41 @@ class DeepSeekV4DSparkLayer(DeepseekV4DecoderLayer):
         cache_rows = cache_indices.view(batch_size).long()
         cache_slots = positions.view(batch_size).remainder(window_size).long()
         self.dspark_kv_cache[cache_rows, cache_slots].copy_(main_kv)
-        cache_window = self.dspark_kv_cache[cache_rows]
-        all_kv = torch.cat([cache_window, kv], dim=1)
-        topk_idxs = _build_dspark_topk_idxs(
-            window_size=window_size,
-            batch_size=batch_size,
-            block_size=block_size,
-            positions=positions.view(batch_size),
-            device=x.device,
+        # Persistent [b, window+block] staging buffer: one gather for the
+        # window + a small copy for the block KV, replacing the per-layer
+        # gather + full-width torch.cat (saves one window-wide copy and two
+        # allocations per layer per step).
+        if (
+            getattr(self, "_dspark_allkv_buf", None) is None
+            or self._dspark_allkv_buf.shape[0] < batch_size
+        ):
+            self._dspark_allkv_buf = torch.empty(
+                batch_size,
+                window_size + block_size,
+                kv.shape[-1],
+                dtype=kv.dtype,
+                device=kv.device,
+            )
+        all_kv = self._dspark_allkv_buf[:batch_size]
+        torch.index_select(
+            self.dspark_kv_cache, 0, cache_rows, out=all_kv[:, :window_size]
         )
+        all_kv[:, window_size:].copy_(kv)
+        # topk_idxs is layer-invariant: computed once per draft step by the
+        # first dspark layer and shared via the shared-state dict.
+        shared = _dspark_layer_shared_state
+        step_key = (positions.data_ptr(), batch_size, block_size)
+        if shared.get("key") != step_key or shared.get("capturing") is not torch.cuda.is_current_stream_capturing():
+            shared["key"] = step_key
+            shared["capturing"] = torch.cuda.is_current_stream_capturing()
+            shared["topk"] = _build_dspark_topk_idxs(
+                window_size=window_size,
+                batch_size=batch_size,
+                block_size=block_size,
+                positions=positions.view(batch_size),
+                device=x.device,
+            )
+        topk_idxs = shared["topk"]
         if _dspark_dump_layer_parts_enabled():
             _maybe_save_tensor_debug(
                 "dspark_attention_inputs",
@@ -1577,10 +1606,15 @@ class DeepSeekV4DSparkDraft(nn.Module):
                 )
             else:
                 output_ids[:, idx + 1] = logits[:, idx].argmax(dim=-1)
-        confidence = final_layer.confidence_head(
-            hidden,
-            torch.stack(markov_embeds, dim=1),
-        )
+        if os.environ.get("VLLM_DSPARK_CONFIDENCE", "0") == "1":
+            confidence = final_layer.confidence_head(
+                hidden,
+                torch.stack(markov_embeds, dim=1),
+            )
+        else:
+            # The serving speculator discards confidence; skip the head
+            # (an lm-head-sized projection) unless explicitly requested.
+            confidence = None
         return output_ids, logits, confidence
 
     def forward_spec(
@@ -1606,6 +1640,7 @@ class DeepSeekV4DSparkDraft(nn.Module):
             "VLLM_DSPARK_TENSOR_DEBUG_DIR"
         ):
             debug_start_pos = int(positions[0].detach().cpu())
+        _dspark_layer_shared_state.clear()
         x, main_x, draft_input_ids = self.forward_embed(main_hidden, input_ids)
         if os.getenv("VLLM_DSPARK_DEBUG_DIR"):
             _maybe_dump_stage_debug(

--- a/vllm/v1/worker/gpu/sample/gumbel.py
+++ b/vllm/v1/worker/gpu/sample/gumbel.py
@@ -69,6 +69,14 @@ def apply_temperature(
 
 
 @triton.jit
+def tl_rand32(seed, offset, includes_zero: tl.constexpr):
+    u = tl.rand(seed, offset)
+    if not includes_zero:
+        u = tl.maximum(u, _TL_RAND_MIN)
+    return u
+
+
+@triton.jit
 def tl_rand64(seed, offset, includes_zero: tl.constexpr):
     lo, hi, _, _ = tl.randint4x(seed, offset)
     lo = lo.to(tl.uint32, bitcast=True).to(tl.uint64)

--- a/vllm/v1/worker/gpu/spec_decode/dspark/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dspark/speculator.py
@@ -436,6 +436,14 @@ class DSparkSpeculator(DraftModelSpeculator):
                 f"expected {len(self.target_layer_ids)}, got {len(aux_hidden_states)}."
             )
 
+        _timing = os.environ.get("VLLM_DSPARK_TIMING", "0") == "1"
+        if _timing:
+            if not hasattr(self, "_tev"):
+                self._tev = [torch.cuda.Event(enable_timing=True) for _ in range(3)]
+                self._tacc = [0.0, 0.0, 0]
+                import sys
+                print("DSPARK TIMING ARMED", file=sys.stderr, flush=True)
+            self._tev[0].record()
         with record_function_or_nullcontext("vllm:v2/speculator/dspark/prepare"):
             prepare_prefill_inputs(
                 self.last_token_indices,
@@ -514,9 +522,27 @@ class DSparkSpeculator(DraftModelSpeculator):
                 self.graph_positions[num_reqs:num_reqs_padded].fill_(1)
                 self.idx_mapping[num_reqs:num_reqs_padded].zero_()
             self.active_num_reqs.fill_(num_reqs)
+            if _timing:
+                self._tev[1].record()
             self.forward_cudagraph_manager.run_fullgraph(batch_desc)
+            if _timing:
+                self._tev[2].record()
+                self._tev[2].synchronize()
+                self._tacc[0] += self._tev[0].elapsed_time(self._tev[1])
+                self._tacc[1] += self._tev[1].elapsed_time(self._tev[2])
+                self._tacc[2] += 1
+                if self._tacc[2] % 200 == 0:
+                    import sys
+                    print(
+                        f"DSPARK TIMING over {self._tacc[2]} steps: "
+                        f"prepare {self._tacc[0]/self._tacc[2]:.3f} ms/step, "
+                        f"graph-forward {self._tacc[1]/self._tacc[2]:.3f} ms/step",
+                        file=sys.stderr, flush=True,
+                    )
             return self.draft_tokens[:num_reqs]
 
+        if _timing:
+            self._tev[1].record()
         with record_function_or_nullcontext("vllm:v2/speculator/dspark/forward"):
             # DSpark uses its own TileLang attention path, but the inherited
             # DeepSeek MoE layers still read vLLM's forward context to resolve
@@ -544,4 +570,19 @@ class DSparkSpeculator(DraftModelSpeculator):
                 )
         steps = self.num_speculative_steps
         self.draft_tokens[:num_reqs, :steps].copy_(output_ids[:, 1 : 1 + steps])
+        if _timing:
+            self._tev[2].record()
+            self._tev[2].synchronize()
+            self._tacc[0] += self._tev[0].elapsed_time(self._tev[1])
+            self._tacc[1] += self._tev[1].elapsed_time(self._tev[2])
+            self._tacc[2] += 1
+            if self._tacc[2] % 50 == 0:
+                import sys
+                print(
+                    f"DSPARK TIMING over {self._tacc[2]} steps: "
+                    f"prepare {self._tacc[0]/self._tacc[2]:.3f} ms/step, "
+                    f"forward {self._tacc[1]/self._tacc[2]:.3f} ms/step",
+                    file=sys.stderr, flush=True,
+                )
+
         return self.draft_tokens[:num_reqs]

--- a/vllm/v1/worker/gpu/spec_decode/rejection_sampler.py
+++ b/vllm/v1/worker/gpu/spec_decode/rejection_sampler.py
@@ -63,6 +63,7 @@ class RejectionSampler:
         self.sampler = sampler
         self.num_speculative_steps = spec_config.num_speculative_tokens
         self.rejection_sample_method = spec_config.rejection_sample_method
+        self.use_block_verification = self.rejection_sample_method == "block"
         self.synthetic_conditional_rates: torch.Tensor | None = None
         if self.rejection_sample_method == "synthetic":
             assert spec_config.synthetic_acceptance_rates is not None
@@ -130,6 +131,16 @@ class RejectionSampler:
             draft_sampled,
             input_batch.expanded_local_pos,
         )
+        use_block_verification = self.use_block_verification
+        if use_block_verification:
+            # Block verification only affects temp>0 requests; its prep
+            # kernels cost ~5-7% of the step, so skip them for all-greedy
+            # batches (host-side check, no sync).
+            temps = self.sampler.sampling_states.temperature.np[
+                input_batch.idx_mapping_np
+            ]
+            if not (temps > 0).any():
+                use_block_verification = False
         sampled, num_sampled = rejection_sample(
             processed_logits,
             draft_logits,
@@ -144,6 +155,7 @@ class RejectionSampler:
             self.num_speculative_steps,
             self.synthetic_conditional_rates,
             use_fp64=self.sampler.use_fp64_gumbel,
+            use_block_verification=use_block_verification,
         )
         logprobs_tensors = self._get_logprobs_tensors(
             input_batch,

--- a/vllm/v1/worker/gpu/spec_decode/rejection_sampler_utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/rejection_sampler_utils.py
@@ -3,22 +3,22 @@
 import torch
 
 from vllm.triton_utils import tl, tldevice, triton
-from vllm.v1.worker.gpu.sample.gumbel import gumbel_block_argmax, tl_rand64
+from vllm.v1.worker.gpu.sample.gumbel import gumbel_block_argmax, tl_rand32, tl_rand64
 
 
 @triton.jit
-def _compute_block_max_and_sumexp(logits):
-    block_max = tl.max(logits, axis=0)
-    block_sumexp = tl.where(
-        block_max > float("-inf"),
-        tl.sum(tl.exp(logits - block_max)),
+def _compute_max_and_sumexp(logits):
+    max = tl.max(logits, axis=0)
+    sumexp = tl.where(
+        max > float("-inf"),
+        tl.sum(tl.exp(logits - max)),
         0.0,
     )
-    return block_max, block_sumexp
+    return max, sumexp
 
 
 @triton.jit
-def _compute_global_lse(
+def _compute_global_logsumexp(
     local_max_ptr,
     local_max_stride,
     local_sumexp_ptr,
@@ -45,7 +45,146 @@ def _compute_global_lse(
 
 
 @triton.jit
-def _compute_block_stats_kernel(
+def _compute_global_residual_mass(
+    local_residual_mass_ptr,
+    local_residual_mass_stride,
+    prefix_joint_ratio,
+    target_logits_ptr,
+    target_logits_stride,
+    target_local_max_ptr,
+    target_local_max_stride,
+    target_local_sumexp_ptr,
+    target_local_sumexp_stride,
+    draft_sampled_ptr,
+    logit_idx,
+    vocab_num_blocks,
+    PADDED_VOCAB_NUM_BLOCKS: tl.constexpr,
+    HAS_DRAFT_LOGITS: tl.constexpr,
+):
+    if HAS_DRAFT_LOGITS:
+        blocks = tl.arange(0, PADDED_VOCAB_NUM_BLOCKS)
+        mask = blocks < vocab_num_blocks
+        partials = tl.load(
+            local_residual_mass_ptr + logit_idx * local_residual_mass_stride + blocks,
+            mask=mask,
+            other=0.0,
+        )
+        return tl.sum(partials, axis=0)
+    else:
+        # One-hot draft. M_s is a point mass at this draft token
+        # so the residual mass reduces to the closed form:
+        #   p * (1 - M_b(draft_token)).
+        draft_token = tl.load(draft_sampled_ptr + logit_idx + 1).to(tl.int64)
+        target_lse = _compute_global_logsumexp(
+            target_local_max_ptr,
+            target_local_max_stride,
+            target_local_sumexp_ptr,
+            target_local_sumexp_stride,
+            logit_idx,
+            vocab_num_blocks,
+            PADDED_VOCAB_NUM_BLOCKS,
+        )
+        target_logit = tl.load(
+            target_logits_ptr + logit_idx * target_logits_stride + draft_token,
+        ).to(tl.float32)
+        m_b = tl.exp(target_logit - target_lse)
+        return prefix_joint_ratio * (1.0 - m_b)
+
+
+@triton.jit
+def _compute_global_target_argmax(
+    target_local_max_ptr,
+    target_local_max_stride,
+    target_local_argmax_ptr,
+    target_local_argmax_stride,
+    logit_idx,
+    vocab_num_blocks,
+    PADDED_VOCAB_NUM_BLOCKS: tl.constexpr,
+):
+    blocks = tl.arange(0, PADDED_VOCAB_NUM_BLOCKS)
+    blocks_mask = blocks < vocab_num_blocks
+    local_max = tl.load(
+        target_local_max_ptr + logit_idx * target_local_max_stride + blocks,
+        mask=blocks_mask,
+        other=float("-inf"),
+    )
+    max_block_idx = tl.argmax(local_max, axis=0)
+    return tl.load(
+        target_local_argmax_ptr + logit_idx * target_local_argmax_stride + max_block_idx
+    ).to(tl.int64)
+
+
+@triton.jit
+def _compute_global_logprobs_and_logsumexp(
+    token,
+    mask,
+    logit_idx,
+    req_state_idx,
+    draft_step,
+    # [num_logits, V]
+    target_logits_ptr,
+    target_logits_stride,
+    # [num_logits, num_blocks]
+    target_local_max_ptr,
+    target_local_max_stride,
+    target_local_sumexp_ptr,
+    target_local_sumexp_stride,
+    # [max_num_reqs, num_speculative_steps, V]
+    draft_logits_ptr,
+    draft_logits_stride_0,
+    draft_logits_stride_1,
+    # [num_logits, num_blocks]
+    draft_local_max_ptr,
+    draft_local_max_stride,
+    draft_local_sumexp_ptr,
+    draft_local_sumexp_stride,
+    vocab_num_blocks,
+    PADDED_VOCAB_NUM_BLOCKS: tl.constexpr,
+    HAS_DRAFT_LOGITS: tl.constexpr,
+):
+    target_logit = tl.load(
+        target_logits_ptr + logit_idx * target_logits_stride + token,
+        mask=mask,
+        other=float("-inf"),
+    ).to(tl.float32)
+    target_lse = _compute_global_logsumexp(
+        target_local_max_ptr,
+        target_local_max_stride,
+        target_local_sumexp_ptr,
+        target_local_sumexp_stride,
+        logit_idx,
+        vocab_num_blocks,
+        PADDED_VOCAB_NUM_BLOCKS,
+    )
+    target_log_prob = target_logit - target_lse
+    if HAS_DRAFT_LOGITS:
+        draft_logit = tl.load(
+            draft_logits_ptr
+            + req_state_idx * draft_logits_stride_0
+            + draft_step * draft_logits_stride_1
+            + token,
+            mask=mask,
+            other=float("-inf"),
+        ).to(tl.float32)
+        draft_lse = _compute_global_logsumexp(
+            draft_local_max_ptr,
+            draft_local_max_stride,
+            draft_local_sumexp_ptr,
+            draft_local_sumexp_stride,
+            logit_idx,
+            vocab_num_blocks,
+            PADDED_VOCAB_NUM_BLOCKS,
+        )
+        draft_log_prob = draft_logit - draft_lse
+    else:
+        # One-hot draft: q(token) = 1, log_q = 0.
+        draft_log_prob = 0.0
+        draft_lse = 0.0
+    return target_log_prob, draft_log_prob, target_lse, draft_lse
+
+
+@triton.jit
+def _compute_local_logits_stats_kernel(
     # [num_logits, num_blocks]
     target_local_argmax_ptr,
     target_local_argmax_stride,
@@ -119,7 +258,7 @@ def _compute_block_stats_kernel(
             mask=mask,
             other=float("-inf"),
         ).to(tl.float32)
-        target_max, target_sumexp = _compute_block_max_and_sumexp(target_logits)
+        target_max, target_sumexp = _compute_max_and_sumexp(target_logits)
         tl.store(
             target_local_max_ptr + logit_idx * target_local_max_stride + block_idx,
             target_max,
@@ -140,7 +279,7 @@ def _compute_block_stats_kernel(
                 mask=mask,
                 other=float("-inf"),
             ).to(tl.float32)
-            draft_max, draft_sumexp = _compute_block_max_and_sumexp(draft_logits)
+            draft_max, draft_sumexp = _compute_max_and_sumexp(draft_logits)
             tl.store(
                 draft_local_max_ptr + logit_idx * draft_local_max_stride + block_idx,
                 draft_max,
@@ -151,6 +290,170 @@ def _compute_block_stats_kernel(
                 + block_idx,
                 draft_sumexp,
             )
+
+
+@triton.jit
+def _compute_cumulative_log_p_kernel(
+    # [num_logits]
+    cumulative_log_p_ptr,
+    # [num_logits, V]
+    target_logits_ptr,
+    target_logits_stride,
+    # [num_logits, num_blocks]
+    target_local_max_ptr,
+    target_local_max_stride,
+    # [num_logits, num_blocks]
+    target_local_sumexp_ptr,
+    target_local_sumexp_stride,
+    # [num_logits]
+    draft_sampled_ptr,
+    # [max_num_reqs, num_speculative_steps, V]
+    draft_logits_ptr,
+    draft_logits_stride_0,
+    draft_logits_stride_1,
+    # [num_logits, num_blocks]
+    draft_local_max_ptr,
+    draft_local_max_stride,
+    # [num_logits, num_blocks]
+    draft_local_sumexp_ptr,
+    draft_local_sumexp_stride,
+    # [num_reqs + 1]
+    cu_num_logits_ptr,
+    # [num_reqs]
+    idx_mapping_ptr,
+    # [max_num_reqs]
+    temp_ptr,
+    vocab_num_blocks,
+    PADDED_VOCAB_NUM_BLOCKS: tl.constexpr,
+    HAS_DRAFT_LOGITS: tl.constexpr,
+):
+    req_idx = tl.program_id(0)
+    req_state_idx = tl.load(idx_mapping_ptr + req_idx).to(tl.int64)
+    start_idx = tl.load(cu_num_logits_ptr + req_idx).to(tl.int64)
+    end_idx = tl.load(cu_num_logits_ptr + req_idx + 1)
+    num_draft_tokens = end_idx - start_idx - 1
+    temp = tl.load(temp_ptr + req_state_idx).to(tl.float32)
+    if temp == 0.0:
+        return
+
+    log_p = 0.0
+    for step in range(num_draft_tokens):
+        logit_idx = start_idx + step
+        draft_token = tl.load(draft_sampled_ptr + logit_idx + 1).to(tl.int64)
+        target_logprob, draft_logprob, _, _ = _compute_global_logprobs_and_logsumexp(
+            draft_token,
+            True,  # mask
+            logit_idx,
+            req_state_idx,
+            step,
+            target_logits_ptr,
+            target_logits_stride,
+            target_local_max_ptr,
+            target_local_max_stride,
+            target_local_sumexp_ptr,
+            target_local_sumexp_stride,
+            draft_logits_ptr,
+            draft_logits_stride_0,
+            draft_logits_stride_1,
+            draft_local_max_ptr,
+            draft_local_max_stride,
+            draft_local_sumexp_ptr,
+            draft_local_sumexp_stride,
+            vocab_num_blocks,
+            PADDED_VOCAB_NUM_BLOCKS,
+            HAS_DRAFT_LOGITS,
+        )
+        log_p = tl.minimum(log_p + (target_logprob - draft_logprob), 0.0)
+        tl.store(cumulative_log_p_ptr + logit_idx, log_p)
+
+
+@triton.jit
+def _compute_local_residual_mass_kernel(
+    # [num_logits, num_blocks]
+    local_residual_mass_ptr,
+    local_residual_mass_stride,
+    # [num_logits]
+    cumulative_log_p_ptr,
+    # [num_logits, V]
+    target_logits_ptr,
+    target_logits_stride,
+    # [num_logits, num_blocks]
+    target_local_max_ptr,
+    target_local_max_stride,
+    # [num_logits, num_blocks]
+    target_local_sumexp_ptr,
+    target_local_sumexp_stride,
+    # [max_num_reqs, num_speculative_steps, V]
+    draft_logits_ptr,
+    draft_logits_stride_0,
+    draft_logits_stride_1,
+    # [num_logits, num_blocks]
+    draft_local_max_ptr,
+    draft_local_max_stride,
+    # [num_logits, num_blocks]
+    draft_local_sumexp_ptr,
+    draft_local_sumexp_stride,
+    # [num_logits]
+    expanded_idx_mapping_ptr,
+    # [num_logits]
+    expanded_local_pos_ptr,
+    # [max_num_reqs]
+    temp_ptr,
+    vocab_size,
+    num_speculative_steps,
+    vocab_num_blocks,
+    BLOCK_SIZE: tl.constexpr,
+    PADDED_VOCAB_NUM_BLOCKS: tl.constexpr,
+):
+    logit_idx = tl.program_id(0).to(tl.int64)
+    draft_step_idx = tl.load(expanded_local_pos_ptr + logit_idx)
+    if draft_step_idx == 0 or draft_step_idx >= num_speculative_steps:
+        # The acceptance threshold, h, looks one position ahead and sums
+        # over: max(p_i * M_b(x|x_{<i}) - M_s(x|x_{<i}), 0). Tokens at the
+        # first and last (bonus) positions aren't needed for this computation.
+        return
+
+    req_state_idx = tl.load(expanded_idx_mapping_ptr + logit_idx).to(tl.int64)
+    temp = tl.load(temp_ptr + req_state_idx).to(tl.float32)
+    if temp == 0.0:
+        return
+
+    block_idx = tl.program_id(1)
+    block_offsets = block_idx * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = block_offsets < vocab_size
+    target_log_probs, draft_log_probs, _, _ = _compute_global_logprobs_and_logsumexp(
+        block_offsets,
+        mask,
+        logit_idx,
+        req_state_idx,
+        draft_step_idx,
+        target_logits_ptr,
+        target_logits_stride,
+        target_local_max_ptr,
+        target_local_max_stride,
+        target_local_sumexp_ptr,
+        target_local_sumexp_stride,
+        draft_logits_ptr,
+        draft_logits_stride_0,
+        draft_logits_stride_1,
+        draft_local_max_ptr,
+        draft_local_max_stride,
+        draft_local_sumexp_ptr,
+        draft_local_sumexp_stride,
+        vocab_num_blocks,
+        PADDED_VOCAB_NUM_BLOCKS,
+        True,  # HAS_DRAFT_LOGITS
+    )
+
+    # Compute the residual mass: max(p_i * M_b(x|x_{<i}) - M_s(x|x_{<i}), 0)
+    p = tl.exp(tl.load(cumulative_log_p_ptr + logit_idx - 1).to(tl.float32))
+    m_b = tl.exp(target_log_probs)
+    m_s = tl.exp(draft_log_probs)
+    partial = tl.sum(tl.maximum(p * m_b - m_s, 0.0), axis=0)
+    tl.store(
+        local_residual_mass_ptr + logit_idx * local_residual_mass_stride + block_idx,
+        partial,
+    )
 
 
 @triton.jit
@@ -200,50 +503,82 @@ def _rejection_kernel(
     pos_ptr,
     # [num_speculative_steps]
     synthetic_conditional_rates_ptr,
+    # [num_logits]
+    cumulative_log_p_ptr,
+    # [num_logits, num_blocks]
+    local_residual_mass_ptr,
+    local_residual_mass_stride,
     vocab_num_blocks,
     PADDED_VOCAB_NUM_BLOCKS: tl.constexpr,
     HAS_DRAFT_LOGITS: tl.constexpr,
     SYNTHETIC_MODE: tl.constexpr,
+    USE_BLOCK_VERIFICATION: tl.constexpr,
+    USE_FP64: tl.constexpr,
 ):
     req_idx = tl.program_id(0)
     req_state_idx = tl.load(idx_mapping_ptr + req_idx).to(tl.int64)
     start_idx = tl.load(cu_num_logits_ptr + req_idx).to(tl.int64)
     end_idx = tl.load(cu_num_logits_ptr + req_idx + 1)
-    num_tokens = end_idx - start_idx
+    num_draft_tokens = end_idx - start_idx - 1
     seed = tl.load(seed_ptr + req_state_idx)
     temp = tl.load(temp_ptr + req_state_idx).to(tl.float32)
+    is_greedy = temp == 0.0
 
-    rejected_step = 0
+    accepted_length = tl.zeros((), tl.int64)
     target_lse = 0.0
     draft_lse = 0.0
     accepted = True
-    for i in range(num_tokens - 1):
-        if accepted:
-            logit_idx = start_idx + i
-            draft_sampled = tl.load(draft_sampled_ptr + logit_idx + 1).to(tl.int64)
-            if temp == 0.0:
+    for i in range(num_draft_tokens):
+        logit_idx = start_idx + i
+        draft_sampled = tl.load(draft_sampled_ptr + logit_idx + 1).to(tl.int64)
+        pos = tl.load(pos_ptr + logit_idx)
+        if USE_FP64:
+            u = tl_rand64(seed, pos, includes_zero=False)
+        else:
+            u = tl_rand32(seed, pos, includes_zero=False)
+        if USE_BLOCK_VERIFICATION and not is_greedy:
+            # Block verification (Sun et al., 2024): https://arxiv.org/abs/2403.10444
+            prefix_joint_ratio = tl.exp(
+                tl.load(cumulative_log_p_ptr + logit_idx).to(tl.float32)
+            )
+            if i < num_draft_tokens - 1:
+                residual_mass = _compute_global_residual_mass(
+                    local_residual_mass_ptr,
+                    local_residual_mass_stride,
+                    prefix_joint_ratio,
+                    target_logits_ptr,
+                    target_logits_stride,
+                    target_local_max_ptr,
+                    target_local_max_stride,
+                    target_local_sumexp_ptr,
+                    target_local_sumexp_stride,
+                    draft_sampled_ptr,
+                    logit_idx + 1,
+                    vocab_num_blocks,
+                    PADDED_VOCAB_NUM_BLOCKS,
+                    HAS_DRAFT_LOGITS,
+                )
+                denom = residual_mass + 1.0 - prefix_joint_ratio
+                h = tl.where(denom > 0.0, residual_mass / denom, 1.0)
+            else:
+                h = prefix_joint_ratio
+            accepted_length = tl.where(u <= h, i + 1, accepted_length)
+            tl.store(sampled_ptr + req_idx * sampled_stride + i, draft_sampled)
+        elif accepted:
+            if is_greedy:
                 # Greedy sampling. Accept IFF draft matches target argmax.
                 # NOTE: Target argmax is stored directly so that resampling
                 # can be skipped upon rejection.
-                target_blocks = tl.arange(0, PADDED_VOCAB_NUM_BLOCKS)
-                target_blocks_mask = target_blocks < vocab_num_blocks
-                target_local_max = tl.load(
-                    target_local_max_ptr
-                    + logit_idx * target_local_max_stride
-                    + target_blocks,
-                    mask=target_blocks_mask,
-                    other=float("-inf"),
+                target_argmax = _compute_global_target_argmax(
+                    target_local_max_ptr,
+                    target_local_max_stride,
+                    target_local_argmax_ptr,
+                    target_local_argmax_stride,
+                    logit_idx,
+                    vocab_num_blocks,
+                    PADDED_VOCAB_NUM_BLOCKS,
                 )
-                max_target_block_idx = tl.argmax(target_local_max, axis=0)
-                target_argmax = tl.load(
-                    target_local_argmax_ptr
-                    + logit_idx * target_local_argmax_stride
-                    + max_target_block_idx
-                ).to(tl.int64)
-
                 if SYNTHETIC_MODE:
-                    pos = tl.load(pos_ptr + logit_idx)
-                    u = tl_rand64(seed, pos, includes_zero=False)
                     rate = tl.load(synthetic_conditional_rates_ptr + i)
                     # -1 is used for padded draft token ids that should be rejected.
                     accepted &= (u < rate) & (draft_sampled >= 0)
@@ -254,57 +589,70 @@ def _rejection_kernel(
                     draft_sampled if accepted else target_argmax,
                 )
             else:
+                # Speculative decoding (Leviathan et al., 2023): https://arxiv.org/abs/2211.17192
                 # -1 is used for padded draft token ids that should be rejected.
                 is_valid_draft = draft_sampled >= 0
                 # Avoid possible OOB ptr access.
                 draft_sampled = tl.maximum(0, draft_sampled)
-                target_logit = tl.load(
-                    target_logits_ptr + logit_idx * target_logits_stride + draft_sampled
-                ).to(tl.float32)
-                target_lse = _compute_global_lse(
-                    target_local_max_ptr,
-                    target_local_max_stride,
-                    target_local_sumexp_ptr,
-                    target_local_sumexp_stride,
-                    logit_idx,
-                    vocab_num_blocks,
-                    PADDED_VOCAB_NUM_BLOCKS,
-                )
-                target_log_prob = target_logit - target_lse
-                pos = tl.load(pos_ptr + logit_idx)
-                u = tl_rand64(seed, pos, includes_zero=False)
-                if HAS_DRAFT_LOGITS:
-                    draft_logit = tl.load(
-                        draft_logits_ptr
-                        + req_state_idx * draft_logits_stride_0
-                        + i * draft_logits_stride_1
-                        + draft_sampled
-                    ).to(tl.float32)
-                    draft_lse = _compute_global_lse(
+                target_logprob, draft_logprob, target_lse, draft_lse = (
+                    _compute_global_logprobs_and_logsumexp(
+                        draft_sampled,
+                        True,  # mask
+                        logit_idx,
+                        req_state_idx,
+                        i,
+                        target_logits_ptr,
+                        target_logits_stride,
+                        target_local_max_ptr,
+                        target_local_max_stride,
+                        target_local_sumexp_ptr,
+                        target_local_sumexp_stride,
+                        draft_logits_ptr,
+                        draft_logits_stride_0,
+                        draft_logits_stride_1,
                         draft_local_max_ptr,
                         draft_local_max_stride,
                         draft_local_sumexp_ptr,
                         draft_local_sumexp_stride,
-                        logit_idx,
                         vocab_num_blocks,
                         PADDED_VOCAB_NUM_BLOCKS,
+                        HAS_DRAFT_LOGITS,
                     )
-                    draft_log_prob = draft_logit - draft_lse
-                else:
-                    # One-hot draft: q(draft_token) = 1, log_q = 0.
-                    draft_log_prob = 0
-
+                )
                 if SYNTHETIC_MODE:
                     rate = tl.load(synthetic_conditional_rates_ptr + i)
                     accepted &= u < rate
                 else:
                     # Probability ratio test: p(x) > u * q(x)
                     # Equivalent log form: log_p(x) > log(u) + log_q(x)
-                    accepted &= target_log_prob > tl.log(u) + draft_log_prob
+                    accepted &= target_logprob > tl.log(u) + draft_logprob
                 accepted &= is_valid_draft
                 tl.store(sampled_ptr + req_idx * sampled_stride + i, draft_sampled)
-            rejected_step += accepted
-    tl.store(rejected_steps_ptr + req_idx, rejected_step)
+            accepted_length += accepted
+    tl.store(rejected_steps_ptr + req_idx, accepted_length)
+    if USE_BLOCK_VERIFICATION and not is_greedy and accepted_length < num_draft_tokens:
+        # Compute the target and draft log exponential sums for the
+        # rejected token.
+        rejected_idx = start_idx + accepted_length
+        target_lse = _compute_global_logsumexp(
+            target_local_max_ptr,
+            target_local_max_stride,
+            target_local_sumexp_ptr,
+            target_local_sumexp_stride,
+            rejected_idx,
+            vocab_num_blocks,
+            PADDED_VOCAB_NUM_BLOCKS,
+        )
+        if HAS_DRAFT_LOGITS:
+            draft_lse = _compute_global_logsumexp(
+                draft_local_max_ptr,
+                draft_local_max_stride,
+                draft_local_sumexp_ptr,
+                draft_local_sumexp_stride,
+                rejected_idx,
+                vocab_num_blocks,
+                PADDED_VOCAB_NUM_BLOCKS,
+            )
     tl.store(target_rejected_logsumexp_ptr + req_idx, target_lse)
     tl.store(draft_rejected_logsumexp_ptr + req_idx, draft_lse)
 
@@ -342,10 +690,13 @@ def _resample_kernel(
     seed_ptr,
     # [num_logits]
     pos_ptr,
+    # [num_logits]
+    cumulative_log_p_ptr,
     vocab_size,
     BLOCK_SIZE: tl.constexpr,
     HAS_DRAFT_LOGITS: tl.constexpr,
     USE_FP64: tl.constexpr,
+    USE_BLOCK_VERIFICATION: tl.constexpr,
 ):
     req_idx = tl.program_id(0)
     resample_idx = tl.load(rejected_step_ptr + req_idx)
@@ -386,6 +737,17 @@ def _resample_kernel(
         target_lse = tl.load(target_rejected_logsumexp_ptr + req_idx)
         draft_lse = tl.load(draft_rejected_logsumexp_ptr + req_idx)
         target_log_probs = target_logits - target_lse
+        if USE_BLOCK_VERIFICATION:
+            # Block residual is:
+            #   max(p_tau * M_b(x) - M_s(x), 0) / Z.
+            # Scale the target logprobs by log(p_tau). p_0 = 1, so skip
+            # shifting when nothing was accepted (tau == 0).
+            log_p_tau = 0.0
+            if resample_idx > 0:
+                log_p_tau = tl.load(cumulative_log_p_ptr + resample_token_idx - 1).to(
+                    tl.float32
+                )
+            target_log_probs += log_p_tau
         draft_log_probs = draft_logits - draft_lse
         # Compute the residual:
         #   r(x) = max(p(x) - q(x), 0)
@@ -402,6 +764,11 @@ def _resample_kernel(
     else:
         # One-hot draft. The residual is just the target distribution with
         # the rejected draft token probability zeroed out.
+        # NOTE: During block verification, the residual becomes:
+        #   0                   if x == rejected_draft_token
+        #   p_tau * M_b(x) / Z  otherwise
+        # Therefore p_tau is a constant that cancels under normalization,
+        # and does not need to be applied.
         rejected_draft_token = tl.load(draft_sampled_ptr + resample_token_idx + 1)
         residual_logits = tl.where(
             block != rejected_draft_token,
@@ -525,18 +892,20 @@ def rejection_sample(
     # [num_speculative_steps]
     synthetic_conditional_rates: torch.Tensor | None = None,
     use_fp64: bool = False,
+    use_block_verification: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     num_reqs = cu_num_logits.shape[0] - 1
     num_logits, vocab_size = target_logits.shape
-    has_draft_logits = draft_logits is not None
+    draft_logits_stride_0 = 0
+    draft_logits_stride_1 = 0
+    if has_draft_logits := draft_logits is not None:
+        draft_logits_stride_0 = draft_logits.stride(0)
+        draft_logits_stride_1 = draft_logits.stride(1)
+        # In some cases (e.g. MiMo v2.5 Pro + DFlash) the target model's
+        # vocab size is larger than the draft's due to padding.
+        vocab_size = min(vocab_size, draft_logits.size(-1))
 
-    if draft_logits is None:
-        # When draft_logits is None, create a dummy tensor so that Triton
-        # kernel signatures receive valid pointers/strides. The kernels
-        # will never read from it when HAS_DRAFT_LOGITS=False.
-        draft_logits = target_logits.new_empty(1, 1, 1)
-
-    # Compute the block-level logits stats, such as target argmax
+    # Compute the per-vocab-block logits stats, such as target argmax
     # (for greedy requests), and target max + softmax exponential
     # (for non-greedy requests).
     VOCAB_BLOCK_SIZE = 8192
@@ -557,7 +926,7 @@ def rejection_sample(
     draft_local_sumexp = target_logits.new_empty(
         num_logits, vocab_num_blocks, dtype=torch.float32
     )
-    _compute_block_stats_kernel[(num_logits, vocab_num_blocks)](
+    _compute_local_logits_stats_kernel[(num_logits, vocab_num_blocks)](
         target_local_argmax,
         target_local_argmax.stride(0),
         target_local_max,
@@ -571,8 +940,8 @@ def rejection_sample(
         target_logits,
         target_logits.stride(0),
         draft_logits,
-        draft_logits.stride(0),
-        draft_logits.stride(1),
+        draft_logits_stride_0,
+        draft_logits_stride_1,
         expanded_idx_mapping,
         expanded_local_pos,
         temperature,
@@ -582,9 +951,85 @@ def rejection_sample(
         HAS_DRAFT_LOGITS=has_draft_logits,
     )
 
+    # Precompute the running joint ratio and residual mass for block
+    # verification.
+    if use_block_verification:
+        assert synthetic_conditional_rates is None, (
+            "Block verification is incompatible with synthetic acceptance rates."
+        )
+
+        # Compute the log of the running joint ratio, p_i.
+        # cumulative_log_p[start + i] = log(p_{i+1}), the cumulative ratio after
+        # the (i+1)-th draft token.
+        cumulative_log_p = target_logits.new_empty(num_logits, dtype=torch.float32)
+        _compute_cumulative_log_p_kernel[(num_reqs,)](
+            cumulative_log_p,
+            target_logits,
+            target_logits.stride(0),
+            target_local_max,
+            target_local_max.stride(0),
+            target_local_sumexp,
+            target_local_sumexp.stride(0),
+            draft_sampled,
+            draft_logits,
+            draft_logits_stride_0,
+            draft_logits_stride_1,
+            draft_local_max,
+            draft_local_max.stride(0),
+            draft_local_sumexp,
+            draft_local_sumexp.stride(0),
+            cu_num_logits,
+            idx_mapping,
+            temperature,
+            vocab_num_blocks,
+            PADDED_VOCAB_NUM_BLOCKS=padded_vocab_num_blocks,
+            HAS_DRAFT_LOGITS=has_draft_logits,
+            num_warps=1,
+        )
+
+        # Compute the per-vocab-block partials of the residual mass, later reduced
+        # to the total by _compute_global_residual_mass. Only launched for full
+        # draft logits distributions. One-hot drafts used a closed-form residual
+        # mass instead.
+        if has_draft_logits:
+            local_residual_mass = target_logits.new_empty(
+                num_logits, vocab_num_blocks, dtype=torch.float32
+            )
+            _compute_local_residual_mass_kernel[(num_logits, vocab_num_blocks)](
+                local_residual_mass,
+                local_residual_mass.stride(0),
+                cumulative_log_p,
+                target_logits,
+                target_logits.stride(0),
+                target_local_max,
+                target_local_max.stride(0),
+                target_local_sumexp,
+                target_local_sumexp.stride(0),
+                draft_logits,
+                draft_logits_stride_0,
+                draft_logits_stride_1,
+                draft_local_max,
+                draft_local_max.stride(0),
+                draft_local_sumexp,
+                draft_local_sumexp.stride(0),
+                expanded_idx_mapping,
+                expanded_local_pos,
+                temperature,
+                vocab_size,
+                num_speculative_steps,
+                vocab_num_blocks,
+                BLOCK_SIZE=VOCAB_BLOCK_SIZE,
+                PADDED_VOCAB_NUM_BLOCKS=padded_vocab_num_blocks,
+            )
+        else:
+            local_residual_mass = None
+    else:
+        cumulative_log_p = None
+        local_residual_mass = None
+
     # Sample up until the first rejected/bonus token, and store
     # the step.
-    sampled = draft_sampled.new_zeros(
+    sampled = draft_sampled.new_empty(
         num_reqs, num_speculative_steps + 1, dtype=torch.int64
     )
     num_sampled = sampled.new_empty(num_reqs, dtype=torch.int32)
@@ -606,8 +1051,8 @@ def rejection_sample(
         target_local_sumexp.stride(0),
         draft_sampled,
         draft_logits,
-        draft_logits.stride(0),
-        draft_logits.stride(1),
+        draft_logits_stride_0,
+        draft_logits_stride_1,
         draft_local_max,
         draft_local_max.stride(0),
         draft_local_sumexp,
@@ -618,10 +1063,15 @@ def rejection_sample(
         seed,
         pos,
         synthetic_conditional_rates,
+        cumulative_log_p,
+        local_residual_mass,
+        local_residual_mass.stride(0) if local_residual_mass is not None else 0,
         vocab_num_blocks,
         PADDED_VOCAB_NUM_BLOCKS=padded_vocab_num_blocks,
         HAS_DRAFT_LOGITS=has_draft_logits,
         SYNTHETIC_MODE=synthetic_conditional_rates is not None,
+        USE_BLOCK_VERIFICATION=use_block_verification,
+        USE_FP64=use_fp64,
         num_warps=1,
     )
 
@@ -646,8 +1096,8 @@ def rejection_sample(
         target_logits.stride(0),
         target_rejected_logsumexp,
         draft_logits,
-        draft_logits.stride(0),
-        draft_logits.stride(1),
+        draft_logits_stride_0,
+        draft_logits_stride_1,
         draft_rejected_logsumexp,
         num_sampled,
         cu_num_logits,
@@ -656,10 +1106,12 @@ def rejection_sample(
         temperature,
         seed,
         pos,
+        cumulative_log_p,
         vocab_size,
         BLOCK_SIZE=RESAMPLE_BLOCK_SIZE,
         HAS_DRAFT_LOGITS=has_draft_logits,
         USE_FP64=use_fp64,
+        USE_BLOCK_VERIFICATION=use_block_verification,
     )
 
     # Insert the resampled tokens into the output sampled.


### PR DESCRIPTION
Two commits from the DSpark speedup/consolidation campaign (full context: [dspark-upstream-consolidation.md](https://github.com/voipmonitor/rtx6kpro/blob/master/optimization/dspark-upstream-consolidation.md) §6–8).

## 1. `16140bcb` — draft-pass cleanup + timing instrumentation (the measured win)

Three graph-captured reductions in the DSpark draft forward:
- **confidence-head skip** unless `VLLM_DSPARK_CONFIDENCE=1` — the serving speculator discards it; it's an lm-head-sized projection computed every draft step
- **per-step `topk_idxs` sharing** across the three draft layers (layer-invariant; built once, shared via a module dict cleared at `forward_spec` entry; capture-safe)
- **persistent `[b, window+block]` staging buffer** replacing the per-layer window gather + full-width `torch.cat` (one window-wide copy and two allocations per layer per step gone)

Measured with the new CUDA-event instrumentation (`VLLM_DSPARK_TIMING=1`, rolling prepare/graph-forward ms — the only way to time inside FULL cudagraphs; **measurement-only: its per-step host sync collapses cc64**): draft graph-forward **2.01 → 1.81 ms/step**, prepare 0.33 → 0.31 ms, 30k coherence clean (CJK 0).

## 2. `5a72086` — upstream rejection-utils consolidation + opt-in block verification

Wholesale adoption of upstream's refactored `rejection_sampler_utils.py` (post-#46781/#47093/#47383: block-verification kernels, int64-safe offsets) with our extras re-applied on top: **fp64 acceptance uniforms** under `USE_FP64` (upstream is fp32-only) and the **active-row-guarded** `gumbel_block_argmax` signature. Adds `tl_rand32` to gumbel.py, `"block"` to `RejectionSampleMethod`, and a **host-side all-greedy skip** (the block prep kernels cost ~5–7 % of a step and are inert at temp 0).

Honest verdict on block verification itself: synthetic kernel harness (drives `rejection_sample()` directly with controlled draft divergence — in rtx6kpro `code/tiny-decode/synth_rejection_test.py`) shows temp-0 equivalence exact, distribution preservation, and +7–47 % accepted length on Gaussian-noise drafts; but on the **real** DSpark draft, E2E acceptance is unchanged (12×800-token probes ×3 per config @temp 0.7: block 54.8 % mean vs standard 56.5 %, spread ±3 — DSpark's errors are bimodal, no ratio slack to pool). **Left opt-in, not default.** The consolidation value stands regardless: one utils file aligned with upstream + our hardening, and the synth harness as a permanent regression tool.

## Measurements around this branch (DS4-Flash-DSpark TP2 A8, k=5)

cc1 197.3 / cc64 1,925 aggregate / prefill 12,972/12,875/12,067 (full B12X @f416b75). For the record, the paired Lucifer-CUTLASS comparison (cc64 +21 % — the dynamic w4a8 batch-M MoE gap) is in the wiki §8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new speculative decoding rejection mode: **block**.
  * Improved GPU execution paths for some MoE and linear operations, with faster specialized handling for eligible workloads.
  * Added optional timing output for DSpark speculative decoding to help diagnose performance.

* **Bug Fixes**
  * Reduced repeated work during DSpark attention and speculative decoding by reusing cached results where possible.
  * Improved rejection sampling behavior for all-greedy batches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->