### PR TITLE
spec_decode: propagate DCP size to V1 draft config (fixes MTP collapse under DCP)

### DIFF
--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -1982,6 +1982,19 @@ class SparseAttnIndexer(CustomOp):
         self.max_model_len = max_model_len
         self.max_total_seq_len = max_total_seq_len
         self.topk_indices_buffer = topk_indices_buffer
+        if topk_scores_buffer is None and topk_indices_buffer is not None:
+            try:
+                from vllm.distributed.parallel_state import get_dcp_group
+
+                dcp_world_size = get_dcp_group().world_size
+            except Exception:
+                dcp_world_size = 1
+            if dcp_world_size > 1 and use_b12x_sparse_indexer():
+                topk_scores_buffer = torch.empty(
+                    topk_indices_buffer.shape,
+                    dtype=torch.float32,
+                    device=topk_indices_buffer.device,
+                )
         self.topk_scores_buffer = topk_scores_buffer
         self.skip_k_cache_insert = skip_k_cache_insert
         self.use_fp4_cache = use_fp4_cache

--- a/vllm/model_executor/models/deepseek_mtp.py
+++ b/vllm/model_executor/models/deepseek_mtp.py
@@ -346,10 +346,7 @@ class DeepSeekMultiTokenPredictorLayer(nn.Module):
                 device=self.device,
             )
             topk_scores_buffer = None
-            if (
-                vllm_config.parallel_config.decode_context_parallel_size > 1
-                and use_b12x_sparse_indexer()
-            ):
+            if vllm_config.parallel_config.decode_context_parallel_size > 1:
                 topk_scores_buffer = torch.empty(
                     vllm_config.scheduler_config.max_num_batched_tokens,
                     topk_tokens,

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 import numpy as np
 import torch
@@ -695,6 +695,7 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
         use_dcp_local_kv = (
             self.dcp_world_size > 1
             and common_attn_metadata.dcp_local_seq_lens is not None
+            and not getattr(self.kv_cache_spec, "dcp_replicated", False)
         )
         effective_dcp_world_size = self.dcp_world_size if use_dcp_local_kv else 1
         effective_dcp_rank = self.dcp_rank if use_dcp_local_kv else 0
@@ -1020,6 +1021,49 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
         )
 
         return attn_metadata
+
+    def build_for_drafting(
+        self,
+        common_attn_metadata: CommonAttentionMetadata,
+        draft_index: int,
+    ) -> DeepseekV32IndexerMetadata:
+        if draft_index > 0:
+            num_tokens = common_attn_metadata.num_actual_tokens
+            num_reqs = min(common_attn_metadata.num_reqs, num_tokens)
+            if num_tokens > 0 and num_reqs > 0:
+                needs_unpadded_decode_view = (
+                    common_attn_metadata.batch_topology is not None
+                    or common_attn_metadata.max_query_len > 1
+                    or common_attn_metadata.num_reqs != num_reqs
+                    or int(common_attn_metadata.query_start_loc_cpu[num_reqs])
+                    != num_tokens
+                )
+                if needs_unpadded_decode_view:
+                    query_start_loc = torch.arange(
+                        num_reqs + 1,
+                        dtype=common_attn_metadata.query_start_loc.dtype,
+                        device=common_attn_metadata.query_start_loc.device,
+                    )
+                    query_start_loc_cpu = torch.arange(
+                        num_reqs + 1,
+                        dtype=common_attn_metadata.query_start_loc_cpu.dtype,
+                        device=common_attn_metadata.query_start_loc_cpu.device,
+                    )
+                    common_attn_metadata = replace(
+                        common_attn_metadata.unpadded(
+                            num_actual_tokens=num_tokens,
+                            num_actual_reqs=num_reqs,
+                        ),
+                        query_start_loc=query_start_loc,
+                        query_start_loc_cpu=query_start_loc_cpu,
+                        max_query_len=1,
+                    )
+
+        return self.build(
+            common_prefix_len=0,
+            common_attn_metadata=common_attn_metadata,
+            fast_build=True,
+        )
 
 
 def build_prefill_chunk_metadata(

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -1332,10 +1332,29 @@ class SpecDecodeBaseProposer:
         Subclasses may override to apply additional config changes.
         """
         spec_cfg = self.speculative_config
+        draft_parallel_config = spec_cfg.draft_parallel_config
+        # create_draft_parallel_config() does not copy
+        # decode_context_parallel_size from the target, so the draft
+        # attention silently runs with dcp=1 (no q-allgather, no LSE merge)
+        # while its KV/metadata use DCP-local sharded semantics. The V2
+        # runner path (gpu/spec_decode/eagle/utils.py) restores the target
+        # DCP for native MTP drafts; mirror that here for the V1 path.
+        import os as _os
+
+        default_shard_draft = "1" if spec_cfg.method == "mtp" else "0"
+        if _os.environ.get(
+            "VLLM_DCP_SHARD_DRAFT", default_shard_draft
+        ).lower() in ("1", "true", "yes"):
+            draft_parallel_config = replace(
+                draft_parallel_config,
+                decode_context_parallel_size=(
+                    self.vllm_config.parallel_config.decode_context_parallel_size
+                ),
+            )
         config = replace(
             self.vllm_config,
             parallel_config=replace(
-                spec_cfg.draft_parallel_config,
+                draft_parallel_config,
                 rank=self.vllm_config.parallel_config.rank,
             ),
             model_config=spec_cfg.draft_model_config,


### PR DESCRIPTION
## Problem

Drafts built via the **V1 proposer path** (`vllm/v1/spec_decode/llm_base_proposer.py`) run their attention with `dcp_world_size=1` while their KV cache, metadata, and sparse-indexer state are DCP-sharded.

Root cause: `SpeculativeConfig.create_draft_parallel_config()` builds the draft `ParallelConfig` by copying selected fields from the target — and `decode_context_parallel_size` is not among them, so it silently defaults to 1. `_create_draft_vllm_config()` then uses it verbatim. The V2 runner path (`gpu/spec_decode/eagle/utils.py`) already restores the target DCP size for native MTP drafts; the V1 path has no equivalent.

The result for native MTP under DCP>1 on V1: no q-allgather, no LSE merge (`merged_out == partial_out`), global top-k indices consumed with replicated-cache addressing against a sharded cache, and draft forwards where 3 of 4 DCP ranks see an all-`-1` top-k row and emit **all-zero attention output** for their head groups. `o_proj`'s TP all-reduce then blends the inconsistent per-rank results into one identical-everywhere (wrong) hidden state — which makes the failure invisible to cross-rank divergence checks and immune to every runtime knob (interleave size, `ag_rs` vs `a2a`, global vs local top-k, eager vs CUDA graphs were all tested; none changed the signature).

Because the corruption compounds each recursive draft step, MTP1 mostly survives on the hidden-state pathway while MTP2/MTP3 collapse — and the damage scales with `dcp_world_size` (step-1 conditional acceptance ≈ 0.80 / 0.68 / 0.42 at DCP 1/2/4).

## Fix

Commit 1 mirrors the V2 logic into the V1 `_create_draft_vllm_config`: when `VLLM_DCP_SHARD_DRAFT` is enabled (default for `method=="mtp"`, same gating as V2), replace the draft parallel config's `decode_context_parallel_size` with the target's.

Commit 2 carries three companion fixes needed before that path is reachable for GLM checkpoints routed through `glm4_moe` (which don't pass a `topk_scores_buffer` at construction):
- lazy `topk_scores_buffer` allocation in `SparseAttnIndexer` at DCP>1 with the B12X sparse indexer (otherwise the first decode step raises `B12X sparse indexer DCP requires topk_scores_buffer`);
- MTP-layer scores buffer allocated whenever DCP>1 in `deepseek_mtp`;
- `build_for_drafting()` on `DeepseekV32IndexerMetadataBuilder` with an unpadded decode view for `draft_index>0` (otherwise iterative draft steps fail `num_decode_tokens + num_prefill_tokens == num_tokens`), plus skipping dcp-local KV addressing for `dcp_replicated` specs.

An alternative (possibly preferable) form of the core fix is to copy `decode_context_parallel_size` inside `create_draft_parallel_config()` itself so every consumer inherits it; I kept the change local to the V1 MTP path to match the existing V2 gating and avoid changing behavior for external Eagle/DFlash drafts.

## Validation

4× DGX Spark (GB10/SM121, unified memory), GLM-5.2 NVFP4 + MTP overlay, TP4/DCP4, 131072 max len, fp8 KV, `B12X_MLA_SPARSE`, MTP3, greedy 512-token codegen bench:

| | before | after |
|---|---|---|
| per-position acceptance | 0.72 / 0.30 / 0.07 | **0.90 / 0.79 / 0.67** |
| mean acceptance ratio | 0.34–0.40 | **0.775–0.794** |
| decode tok/s (hot) | 14.6 | **22.0–23.0** |

DCP1 on the same checkpoint gives 0.85 / 0.68 / 0.59, so the fixed DCP4 path now matches/exceeds the no-DCP baseline, in line with the numbers this repo reports on SM120 rigs (which run the V2 path).

Diagnosed with a tensor-level tap on the draft layer's `forward_mqa`/merge site: at DCP1 a fp64 reference attention over the dequantized `fp8_ds_mla` cache reproduces the kernel partials at cos ≥ 0.9999; the DCP4 dumps show `impl.dcp_world_size==1`, no merge, per-rank zero partials, and DCP-local seq lens (6/6/5/5 for a global 22) feeding a non-DCP attention. Happy to share the dumps/harness if useful.
