### PR TITLE
dspark: rowwise-fp8 draft lm_head (`VLLM_DSPARK_FP8_DRAFT_HEAD`, opt-in)

### DIFF
--- a/vllm/models/deepseek_v4/nvidia/dspark.py
+++ b/vllm/models/deepseek_v4/nvidia/dspark.py
@@ -1365,6 +1365,37 @@ class DeepSeekV4DSparkDraft(nn.Module):
             logger.info_once(
                 "DSpark draft logits use a local FP32 copy of target lm_head."
             )
+        elif os.getenv("VLLM_DSPARK_FP8_DRAFT_HEAD") == "1":
+            # Rowwise-fp8 copy of the (vocab-sharded local) target lm_head,
+            # used ONLY for draft base logits: w8 = w * (448 / rowmax) stored
+            # e4m3, row_scale = rowmax / 448 for the epilogue. Materialized
+            # eagerly here, before CUDA graph capture of the draft step.
+            # Verify pass never sees it, so accepted outputs are unchanged;
+            # a rare draft argmax flip only costs a rejected token.
+            with torch.no_grad():
+                weight = lm_head.weight.detach()
+                row_max = (
+                    weight.abs().amax(dim=1, keepdim=True).float().clamp(min=1e-6)
+                )
+                self.register_buffer(
+                    "lm_head_fp8_weight",
+                    (weight.float() * (448.0 / row_max)).to(torch.float8_e4m3fn),
+                    persistent=False,
+                )
+                self.register_buffer(
+                    "lm_head_fp8_row_scale",
+                    (row_max / 448.0).to(weight.dtype).reshape(1, -1),
+                    persistent=False,
+                )
+                self.register_buffer(
+                    "lm_head_fp8_unit_scale",
+                    torch.ones(1, dtype=torch.float32, device=weight.device),
+                    persistent=False,
+                )
+            logger.info_once(
+                "DSpark draft logits use a rowwise-FP8 copy of target lm_head "
+                "(draft-time only; verify pass untouched)."
+            )
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         if self.embed_tokens is None:
@@ -1380,6 +1411,29 @@ class DeepSeekV4DSparkDraft(nn.Module):
             logits = self.logits_processor._gather_logits(logits)
             if logits is not None:
                 logits = logits[..., : self.config.vocab_size]
+            return logits
+        lm_head_fp8_weight = getattr(self, "lm_head_fp8_weight", None)
+        if lm_head_fp8_weight is not None:
+            # Dynamic per-token activation quant + fp8 GEMM; the epilogue
+            # applies both dynamic scales. Same gather/slice as the FP32
+            # branch, so TP argmax semantics are unchanged. No allocations
+            # or data-dependent control flow beyond the GEMM: capture-safe.
+            hidden_2d = hidden_states.reshape(-1, hidden_states.shape[-1])
+            act_max = hidden_2d.abs().amax(dim=-1, keepdim=True).clamp(min=1e-6)
+            act_fp8 = (hidden_2d * (448.0 / act_max)).to(torch.float8_e4m3fn)
+            logits = torch._scaled_mm(
+                act_fp8,
+                lm_head_fp8_weight.t(),
+                scale_a=self.lm_head_fp8_unit_scale,
+                scale_b=self.lm_head_fp8_unit_scale,
+                out_dtype=hidden_2d.dtype,
+            )
+            logits = logits * self.lm_head_fp8_row_scale
+            logits = logits * (act_max / 448.0).to(hidden_2d.dtype)
+            logits = self.logits_processor._gather_logits(logits)
+            if logits is not None:
+                logits = logits[..., : self.config.vocab_size]
+                logits = logits.view(*hidden_states.shape[:-1], -1)
             return logits
         return self.logits_processor(
             self.lm_head,


### PR DESCRIPTION

## Summary

DSpark's draft base logits are a full `[hidden, vocab]` bf16 GEMM through the
shared target lm_head (4096 x 64640 for DS4-Flash), computed once per draft
step purely to propose tokens. On bandwidth-bound GPUs the weight read
dominates the draft loop.

With `VLLM_DSPARK_FP8_DRAFT_HEAD=1`, `attach_target_modules` materializes a
one-time rowwise-fp8 (e4m3) copy of the local lm_head shard — `w8 = w *
(448 / rowmax)` stored fp8, `row_scale = rowmax / 448` — and
`compute_logits` runs dynamic per-token activation quant +
`torch._scaled_mm`, scales applied in the epilogue:

```
logits = _scaled_mm(a8, w8.T, out_dtype=bf16) * row_scale * (amax / 448)
```

Halves lm_head weight traffic in the draft step. Env unset: zero behavior
change. Mirrors the existing `VLLM_DSPARK_FP32_LM_HEAD` pattern (eager copy
at attach, branch in `compute_logits`); FP32 takes precedence if both are
set.

## Numbers

Production A/B, DeepSeek-V4-Flash-DSpark on DGX Spark (GB10, ~235 GB/s):

- draft-head GEMM **2.73 -> 1.45 ms** per draft step
- **+3–5%** end-to-end single-stream decode
- draft argmax-identical to the bf16 head on our eval set; per-position
  acceptance unchanged

Win scales with how bandwidth-bound the part is; GB10 is the extreme case,
expect less on B300/RTX 6000 Pro — hence opt-in.

## Why it's safe

- Draft-time only: `compute_logits` lives on the draft model; the verify
  pass never sees the fp8 copy, so accepted outputs are bit-identical.
- Rowwise scaling bounds per-logit error to ~e4m3 half-ulp of each row's
  max; a rare near-tie argmax flip costs one rejected draft token, never a
  wrong output.
- TP: quantizes the local vocab shard with per-local-row scales, then the
  same `_gather_logits` + `vocab_size` slice as the FP32 branch — argmax
  semantics unchanged.
- Capture-safe: materialized eagerly at attach (before draft-step FULL
  graph capture); the fp8 branch has no data-dependent control flow and no
  allocations beyond the GEMM output.

## Scope

One file, `vllm/models/deepseek_v4/nvidia/dspark.py` (+54): fp8 buffers in
`attach_target_modules`, fp8 branch in `compute_logits`. No collision with
#71 — its dspark.py hunks touch `_dspark_attention`, the `forward_head`
confidence skip, and `forward_spec`, not `attach_target_modules` /
`compute_logits`; the two compose (this removes half the head GEMM cost,
#71's confidence skip removes the other lm-head-sized projection).

## Validation

- `python3 -m py_compile vllm/models/deepseek_v4/nvidia/dspark.py`
- `git diff --check lil/dev/eldritch-enlightenment..HEAD`
- Kernel math validated on GB10 (torch 2.11 cu130 container): real
  `torch._scaled_mm` path matches a float32 emulation bitwise; rowwise
  quant roundtrip within the analytic half-ulp bound; bf16-vs-fp8 argmax
  flips occur only on near-ties (top-2 margin within fp8 error scale) on
  i.i.d.-Gaussian worst-case logits.
- E2E: same patch (V1-lineage overlay) in production on our 2x DGX Spark
  cluster since 2026-06; A/B numbers above, 30k-token coherence clean.

Upstream port of the same change: vllm-project/vllm#47584

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional FP8 draft-time path for generating logits, enabled through an environment setting.
  * When turned on, the model can use a quantized weight format for the final projection step during draft generation.

* **Performance**
  * Improves draft-time inference efficiency while preserving the existing default behavior when the option is not enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->