### PR TITLE
quant(modelopt): online MXFP8 overlay for checkpoint-excluded dense linears

### DIFF
--- a/docs/features/quantization/online.md
+++ b/docs/features/quantization/online.md
@@ -98,6 +98,49 @@ vllm serve <glm-5.2-modelopt-checkpoint> \
 Serialized checkpoint-quantized shared experts are preserved; only excluded
 BF16 projection weights are converted at load time.
 
+### MXFP8 dense linears on ModelOpt checkpoints
+
+The `linear` field overlays online MXFP8 the same way onto every other
+BF16 dense linear the ModelOpt checkpoint excludes: attention projections,
+dense (non-expert) MLPs, and indexer projections. Shared-expert projections
+are never selected by `linear` — they remain governed exclusively by
+`shared_experts` — and modules matched by `ignore` (exact names or `re:`
+regexes against unfused shard names) stay BF16. Routers, `lm_head`,
+embeddings, and plain `nn.Linear` modules (e.g. GLM's MTP `eh_proj`) are
+never touched.
+
+This reproduces a fully offline-requantized "MXFP8 dense" checkpoint
+bit-exactly from the original BF16-dense checkpoint at load time. For a
+GLM 5.2 ModelOpt NVFP4 checkpoint there are two supported recipes:
+
+MXFP8 dense + MXFP8 shared experts + NVFP4 routed experts:
+
+```bash
+vllm serve lukealonso/GLM-5.2-NVFP4 \
+  --quantization modelopt_fp4 \
+  --quantization-config '{"linear":{"weight":"mxfp8"},"shared_experts":{"weight":"mxfp8"}}'
+```
+
+MXFP8 dense + BF16 shared experts + NVFP4 routed experts:
+
+```bash
+vllm serve lukealonso/GLM-5.2-NVFP4 \
+  --quantization modelopt_fp4 \
+  --quantization-config.linear.weight mxfp8
+```
+
+Recommended GLM 5.2 recipe — additionally keep `kv_b_proj` in BF16. MLA
+attention dequantizes `kv_b_proj` at load time to build its absorbed
+`W_UK`/`W_UV` matrices, so quantizing it buys no speed and only adds
+rounding noise to every attention read; excluding it measured the smallest
+per-token deviation from the BF16-dense reference at identical throughput:
+
+```bash
+vllm serve lukealonso/GLM-5.2-NVFP4 \
+  --quantization modelopt_fp4 \
+  --quantization-config '{"linear":{"weight":"mxfp8"},"ignore":["re:.*kv_b_proj"]}'
+```
+
 ### Activation overrides on already-quantized checkpoints
 
 For checkpoint-quantized models, `quantization_config` lets you pick an

--- a/tests/quantization/test_modelopt.py
+++ b/tests/quantization/test_modelopt.py
@@ -107,6 +107,128 @@ def test_modelopt_nvfp4_quantizes_parallel_lm_head():
     assert isinstance(method, ModelOptNvFp4LinearMethod)
 
 
+def test_modelopt_nvfp4_online_quantizes_bf16_dense_linears():
+    config = ModelOptNvFp4Config(
+        is_checkpoint_nvfp4_serialized=True,
+        kv_cache_quant_algo=None,
+        exclude_modules=[
+            "model.layers.*.self_attn*",
+            "*shared_experts*",
+            "lm_head",
+        ],
+    )
+    current_config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            quantization_config=QuantizationConfigArgs(linear="mxfp8")
+        )
+    )
+    sentinel = MagicMock()
+
+    with (
+        patch(
+            "vllm.model_executor.layers.quantization.modelopt."
+            "get_current_vllm_config_or_none",
+            return_value=current_config,
+        ),
+        patch(
+            "vllm.model_executor.layers.quantization.modelopt.Mxfp8OnlineLinearMethod",
+            return_value=sentinel,
+        ),
+    ):
+        attn_method = config.get_quant_method(
+            _mock_linear(), "model.layers.3.self_attn.kv_b_proj"
+        )
+        indexer_method = config.get_quant_method(
+            _mock_linear(), "model.layers.0.self_attn.indexer.wq_b"
+        )
+        # shared experts are governed solely by the shared_experts spec
+        shared_method = config.get_quant_method(
+            _mock_linear(), "model.layers.3.mlp.shared_experts.down_proj"
+        )
+        lm_head_method = config.get_quant_method(_mock_lm_head(), "lm_head")
+
+    assert attn_method is sentinel
+    assert indexer_method is sentinel
+    assert isinstance(shared_method, UnquantizedLinearMethod)
+    assert isinstance(lm_head_method, UnquantizedLinearMethod)
+
+
+def test_modelopt_nvfp4_dense_overlay_honors_ignore():
+    config = ModelOptNvFp4Config(
+        is_checkpoint_nvfp4_serialized=True,
+        kv_cache_quant_algo=None,
+        exclude_modules=["model.layers.*.self_attn*"],
+    )
+    current_config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            quantization_config=QuantizationConfigArgs(
+                linear="mxfp8",
+                ignore=["re:.*o_proj"],
+            )
+        )
+    )
+    sentinel = MagicMock()
+
+    with (
+        patch(
+            "vllm.model_executor.layers.quantization.modelopt."
+            "get_current_vllm_config_or_none",
+            return_value=current_config,
+        ),
+        patch(
+            "vllm.model_executor.layers.quantization.modelopt.Mxfp8OnlineLinearMethod",
+            return_value=sentinel,
+        ),
+    ):
+        kv_b_method = config.get_quant_method(
+            _mock_linear(), "model.layers.3.self_attn.kv_b_proj"
+        )
+        o_proj_method = config.get_quant_method(
+            _mock_linear(), "model.layers.3.self_attn.o_proj"
+        )
+
+    assert kv_b_method is sentinel
+    assert isinstance(o_proj_method, UnquantizedLinearMethod)
+
+
+def test_modelopt_nvfp4_dense_overlay_composes_with_shared_experts():
+    config = ModelOptNvFp4Config(
+        is_checkpoint_nvfp4_serialized=True,
+        kv_cache_quant_algo=None,
+        exclude_modules=["model.layers.*.self_attn*", "*shared_experts*"],
+    )
+    current_config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            quantization_config=QuantizationConfigArgs(
+                linear="mxfp8",
+                shared_experts="mxfp8",
+            )
+        )
+    )
+    dense_sentinel = MagicMock()
+
+    with (
+        patch(
+            "vllm.model_executor.layers.quantization.modelopt."
+            "get_current_vllm_config_or_none",
+            return_value=current_config,
+        ),
+        patch(
+            "vllm.model_executor.layers.quantization.modelopt.Mxfp8OnlineLinearMethod",
+            return_value=dense_sentinel,
+        ),
+    ):
+        attn_method = config.get_quant_method(
+            _mock_linear(), "model.layers.3.self_attn.kv_b_proj"
+        )
+        shared_method = config.get_quant_method(
+            _mock_linear(), "model.layers.3.mlp.shared_experts.gate_up_proj"
+        )
+
+    assert attn_method is dense_sentinel
+    assert shared_method is dense_sentinel
+
+
 def test_modelopt_nvfp4_online_quantizes_bf16_shared_experts():
     config = ModelOptNvFp4Config(
         is_checkpoint_nvfp4_serialized=True,

--- a/tests/quantization/test_quantization_config_args.py
+++ b/tests/quantization/test_quantization_config_args.py
@@ -129,6 +129,44 @@ def test_resolve_allows_modelopt_shared_expert_overlay():
     assert args == QuantizationConfigArgs(shared_experts="mxfp8")
 
 
+def test_resolve_allows_modelopt_dense_linear_overlay():
+    args = resolve_quantization_config(
+        "modelopt_fp4",
+        {"linear": {"weight": "mxfp8"}},
+    )
+    assert args == QuantizationConfigArgs(linear={"weight": "mxfp8"})
+
+
+def test_resolve_allows_modelopt_combined_overlay_with_ignore():
+    args = resolve_quantization_config(
+        "modelopt_fp4",
+        {
+            "linear": {"weight": "mxfp8"},
+            "shared_experts": "mxfp8",
+            "ignore": ["re:.*o_proj"],
+        },
+    )
+    assert args.linear == QuantSpec(weight=kMxfp8Dynamic)
+    assert args.shared_experts == QuantSpec(weight=kMxfp8Dynamic)
+    assert args.ignore == ["re:.*o_proj"]
+
+
+def test_resolve_rejects_modelopt_ignore_without_linear():
+    with pytest.raises(ValueError, match="MXFP8 overlay"):
+        resolve_quantization_config(
+            "modelopt_fp4",
+            {"shared_experts": "mxfp8", "ignore": ["re:.*o_proj"]},
+        )
+
+
+def test_resolve_rejects_modelopt_moe_override():
+    with pytest.raises(ValueError, match="MXFP8 overlay"):
+        resolve_quantization_config(
+            "modelopt_fp4",
+            {"linear": {"weight": "mxfp8"}, "moe": "mxfp8"},
+        )
+
+
 def test_resolve_rejects_quantization_config_with_non_shorthand_quant():
     # If --quantization names something other than an online shorthand,
     # quantization_config is not allowed via this path (checkpoint quant

--- a/vllm/config/quantization.py
+++ b/vllm/config/quantization.py
@@ -147,25 +147,27 @@ ONLINE_QUANT_SHORTHAND_NAMES: tuple[str, ...] = (
 )
 
 
-# Checkpoint formats that support overlaying online MXFP8 on BF16 shared-expert
-# projections which the checkpoint explicitly leaves unquantized.
-_MODELOPT_SHARED_EXPERT_OVERLAY_NAMES = frozenset(
+# Checkpoint formats that support overlaying online MXFP8 on BF16 projections
+# which the checkpoint explicitly leaves unquantized (shared experts via
+# `shared_experts`, other dense linears via `linear`).
+_MODELOPT_MXFP8_OVERLAY_NAMES = frozenset(
     {"modelopt", "modelopt_fp4", "modelopt_mxfp8", "modelopt_mixed"}
 )
 
 
-def _is_modelopt_shared_expert_overlay(
+def _is_modelopt_mxfp8_overlay(
     quantization: str | None, args: QuantizationConfigArgs
 ) -> bool:
-    spec = args.shared_experts
-    return (
-        quantization in _MODELOPT_SHARED_EXPERT_OVERLAY_NAMES
-        and args.linear is None
-        and args.moe is None
-        and spec is not None
-        and spec.weight == kMxfp8Dynamic
-        and spec.activation is None
-        and not args.ignore
+    if quantization not in _MODELOPT_MXFP8_OVERLAY_NAMES or args.moe is not None:
+        return False
+    specs = [s for s in (args.linear, args.shared_experts) if s is not None]
+    if not specs:
+        return False
+    if args.ignore and args.linear is None:
+        # `ignore` only filters the dense-linear overlay.
+        return False
+    return all(
+        spec.weight == kMxfp8Dynamic and spec.activation is None for spec in specs
     )
 
 
@@ -186,13 +188,14 @@ def resolve_quantization_config(
         quantization_config = QuantizationConfigArgs(**quantization_config)
 
     if quantization is not None and quantization not in ONLINE_QUANT_SHORTHAND_NAMES:
-        if quantization_config is not None and not _is_modelopt_shared_expert_overlay(
+        if quantization_config is not None and not _is_modelopt_mxfp8_overlay(
             quantization, quantization_config
         ):
             raise ValueError(
                 f"quantization_config is only supported when quantization is "
                 f"one of {sorted(ONLINE_QUANT_SHORTHAND_NAMES)}, or when "
-                f"using the ModelOpt MXFP8 shared-expert overlay, "
+                f"using the ModelOpt MXFP8 overlay (weight='mxfp8' on "
+                f"'shared_experts' and/or 'linear', optional 'ignore'), "
                 f"got quantization={quantization!r}"
             )
         return quantization_config

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -59,6 +59,9 @@ from vllm.model_executor.layers.quantization.base_config import (
     QuantizeMethodBase,
 )
 from vllm.model_executor.layers.quantization.kv_cache import BaseKVCacheMethod
+from vllm.model_executor.layers.quantization.compressed_tensors.utils import (
+    should_ignore_layer,
+)
 from vllm.model_executor.layers.quantization.online.mxfp8 import (
     Mxfp8OnlineLinearMethod,
     is_shared_expert_projection,
@@ -208,6 +211,48 @@ class ModelOptQuantConfigBase(QuantizationConfig):
             )
         return Mxfp8OnlineLinearMethod()
 
+    def _get_dense_linear_online_method(
+        self, layer: torch.nn.Module, prefix: str
+    ) -> "QuantizeMethodBase | None":
+        """Overlay online MXFP8 on BF16 dense linears the checkpoint excludes.
+
+        Shared-expert projections are governed exclusively by the
+        ``shared_experts`` spec (see ``_get_shared_expert_online_method``), so
+        they are never selected here; ``quantization_config.ignore`` entries
+        (exact names or ``re:`` regexes, matched on unfused shard names) keep
+        individual modules on the unquantized BF16 path.
+        """
+        if not isinstance(layer, LinearBase) or is_shared_expert_projection(prefix):
+            return None
+
+        vllm_config = get_current_vllm_config_or_none()
+        if vllm_config is None:
+            return None
+        args = vllm_config.model_config.quantization_config
+        if not isinstance(args, QuantizationConfigArgs):
+            return None
+        spec = args.linear
+        if spec is None:
+            return None
+        if args.ignore and should_ignore_layer(
+            prefix,
+            ignore=args.ignore,
+            fused_mapping=self.packed_modules_mapping,
+        ):
+            return None
+        if spec.weight != kMxfp8Dynamic or spec.activation is not None:
+            raise ValueError(
+                "ModelOpt dense-linear overlay only supports "
+                "weight='mxfp8' with no activation override."
+            )
+        logger.info_once(
+            "ModelOpt dense-linear overlay: quantizing checkpoint-excluded "
+            "BF16 linears to MXFP8 at load time (module example: %s).",
+            prefix,
+        )
+        logger.debug("MXFP8 dense-linear overlay applied to %s", prefix)
+        return Mxfp8OnlineLinearMethod()
+
     def get_quant_method(
         self, layer: torch.nn.Module, prefix: str
     ) -> "QuantizeMethodBase | None":
@@ -219,6 +264,9 @@ class ModelOptQuantConfigBase(QuantizationConfig):
         if self.is_layer_excluded(prefix):
             if method := self._get_shared_expert_online_method(layer, prefix):
                 return method
+            if not isinstance(layer, ParallelLMHead):
+                if method := self._get_dense_linear_online_method(layer, prefix):
+                    return method
             if isinstance(layer, (LinearBase, ParallelLMHead)):
                 return UnquantizedLinearMethod()
             return None


### PR DESCRIPTION
## What

Extends the ModelOpt MXFP8 shared-expert overlay (c6902b1b2e) to the rest of the dense linears: with `--quantization-config.linear.weight mxfp8`, every BF16 `LinearBase` the checkpoint's exclude list leaves unquantized (attention projections, dense MLPs, indexer projections) is quantized to MXFP8 at load time. This makes both of our offline "MXFP8 dense" checkpoint variants reproducible **from the original NVFP4 checkpoint purely via switches** — no offline requantization step.

Composition rules:
- shared-expert projections are never selected by `linear` — they stay governed exclusively by `shared_experts`
- `quantization_config.ignore` (exact names or `re:` regexes, unfused shard names) keeps individual modules BF16
- routers, `lm_head`, embeddings and plain `nn.Linear` modules (GLM MTP `eh_proj`) are untouched by construction
- validation gate widened accordingly (`linear` and/or `shared_experts`, weight=`mxfp8`, no activation override, `ignore` allowed with `linear`)

## Recipes (GLM 5.2, from `lukealonso/GLM-5.2-NVFP4`)

```bash
# ≡ offline GLM-5.2-MXFP8dense-NVFP4experts (full MXFP8 dense incl. shared)
vllm serve lukealonso/GLM-5.2-NVFP4 --quantization modelopt_fp4 \
  --quantization-config '{"linear":{"weight":"mxfp8"},"shared_experts":{"weight":"mxfp8"}}'

# ≡ offline GLM-5.2-MXFP8dense-NVFP4experts-BF16shared
vllm serve lukealonso/GLM-5.2-NVFP4 --quantization modelopt_fp4 \
  --quantization-config.linear.weight mxfp8

# RECOMMENDED: additionally keep kv_b_proj BF16 (see "Findings")
vllm serve lukealonso/GLM-5.2-NVFP4 --quantization modelopt_fp4 \
  --quantization-config '{"linear":{"weight":"mxfp8"},"ignore":["re:.*kv_b_proj"]}'
```

## Bit-parity with the offline checkpoints

`mxfp8_e4m3_quantize` over the checkpoint's BF16 tensors produces **byte-identical** weights and scales to the offline-requantized checkpoint for every projection type sampled (kv_b, o_proj, q_b, fused kv_a, dense-MLP, shared, indexer wq_b), and TP8 shard-wise quantization equals full-tensor quantization (k stays divisible by 32 under row-parallel sharding). The BF16 dense payload of the NVFP4 checkpoint is byte-identical to the original BF16 release, so load-time quantization reproduces the offline artifacts exactly.

One deliberate divergence: `indexer.wk` (fused `wk_weights_proj`, `quant_config=None`) always runs BF16 at runtime; the offline checkpoints needlessly round-trip it through MXFP8 while this path keeps it pristine.

## Findings / measurements (TP8, RTX PRO 6000, seqs1/graph4/mtp0, MoE A4 default)

Teacher-forced per-token logprob deviation vs the pure BF16-dense baseline (3502 tokens; signed dNLL is inside noise for all variants — the paired deviation columns are the informative ones):

| variant | c0 tok/s | c3000 tok/s | mean\|Δlogprob\| | max\|Δlogprob\| |
|---|---:|---:|---:|---:|
| baseline (pure NVFP4 ckpt) | 88.6 | 87.0 | 0 | 0 |
| full MXFP8 dense (incl. shared) | 94.8 | 90.1 | 0.156 | 6.58 |
| MXFP8 dense, BF16 shared | 94.4 | 92.5 | 0.152 | 5.50 |
| **+ ignore kv_b_proj (recommended)** | **94.6** | **92.6** | **0.144** | **4.45** |

- MXFP8 dense carries the +6 tok/s decode win; shared-expert MXFP8 adds deviation and no speed (consistent with the earlier per-group KLD sweep).
- `kv_b_proj`: MLA `process_weights_after_loading` dequantizes it (`get_and_maybe_dequant_weights`) to build `W_UK`/`W_UV`, so its quantization contributes zero speed and only noise — excluding it is a free fidelity win (same tok/s, lowest deviation, mildest worst case).

## Tests

- 3 new unit tests for the overlay hook (selection, `ignore`, composition with `shared_experts`)
- 5 new gate tests for `resolve_quantization_config` (dense overlay accepted, combined + ignore accepted, ignore-without-linear rejected, moe override rejected)
- all pass; pre-existing test↔image version-skew failures unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for applying an online MXFP8 overlay to eligible dense linear layers at load time.
  * Expanded quantization configuration options to support dense-linears, shared-experts, and ignore rules together.

* **Bug Fixes**
  * Improved validation so unsupported quantization combinations are rejected with clearer errors.
  * Preserved BF16 for modules matched by ignore patterns and for excluded projections.

* **Tests**
  * Added coverage for dense overlay routing, ignore handling, shared-experts composition, and config validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->