### PR TITLE
MiniMax M3: fp8 (e4m3) index-K side cache (+61% long-context decode)

### DIFF
--- a/tests/kernels/attention/test_minimax_m3_fp8_indexer.py
+++ b/tests/kernels/attention/test_minimax_m3_fp8_indexer.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""fp8 index-K side cache: top-k block selection must agree with bf16.
+
+The MiniMax M3 lightning-indexer scores only feed a top-k block ranking (the
+attention itself reads the main KV cache), so an fp8 (e4m3) side cache trades
+~2% relative score error for half the per-step index-K read bandwidth -- the
+dominant linear-in-context decode cost at long context. This test checks that
+the decode top-k selection from an fp8 cache matches the bf16 reference,
+including strongly-matching planted blocks.
+"""
+import pytest
+import torch
+
+from vllm.models.minimax_m3.common.ops.index_topk import (
+    SPARSE_BLOCK_SIZE,
+    minimax_m3_index_decode,
+)
+from vllm.platforms import current_platform
+
+
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="CUDA only")
+@torch.inference_mode()
+def test_fp8_index_cache_topk_matches_bf16() -> None:
+    torch.manual_seed(3)
+    dev = "cuda"
+    page, head_dim, heads, topk = SPARSE_BLOCK_SIZE, 128, 1, 16
+    num_pages = 100
+    seq_len = 96 * page + 37
+
+    keys = torch.randn(num_pages * page, head_dim, dtype=torch.bfloat16, device=dev)
+    # RMS-normalize like the real (post index_k_norm) keys.
+    keys = keys * keys.float().pow(2).mean(-1, keepdim=True).add(1e-6).rsqrt().to(
+        torch.bfloat16
+    )
+    q = torch.randn(1, heads, head_dim, dtype=torch.bfloat16, device=dev)
+    planted = (7, 40, 88)
+    for b in planted:
+        keys[b * page + 5] = (q[0, 0] * 3).to(torch.bfloat16)
+
+    block_table = torch.arange(num_pages, dtype=torch.int32, device=dev).unsqueeze(0)
+    seq_lens = torch.tensor([seq_len], dtype=torch.int32, device=dev)
+
+    def select(cache: torch.Tensor) -> set[int]:
+        idx = minimax_m3_index_decode(
+            q,
+            cache.view(num_pages, page, head_dim).contiguous(),
+            block_table,
+            seq_lens,
+            seq_len,
+            topk,
+            0,
+            0,
+            heads,
+            1,
+            1,
+        )
+        return {int(b) for b in idx[0, 0].tolist() if b >= 0}
+
+    top_bf16 = select(keys)
+    top_fp8 = select(keys.to(torch.float8_e4m3fn))
+
+    # Planted (clearly relevant) blocks must never be lost.
+    assert all(b in top_fp8 for b in planted)
+    # Selection may differ only at the noise floor (near-tied filler blocks).
+    assert len(top_bf16 & top_fp8) >= topk - 2

--- a/vllm/models/minimax_m3/common/indexer.py
+++ b/vllm/models/minimax_m3/common/indexer.py
@@ -120,16 +120,22 @@ class MiniMaxM3IndexerCache(nn.Module, AttentionLayerBase):
         backend_cls: type[AttentionBackend] = MiniMaxM3IndexerBackend,
     ) -> None:
         super().__init__()
-        if indexer_kv_dtype != "bf16":
+        if indexer_kv_dtype not in ("bf16", "fp8"):
             raise NotImplementedError(
                 f"indexer_kv_dtype={indexer_kv_dtype!r} is not supported yet "
-                "for the MiniMax M3 indexer cache (only 'bf16')."
+                "for the MiniMax M3 indexer cache (only 'bf16' or 'fp8')."
             )
         self.kv_cache = torch.tensor([])
         self.head_dim = head_dim
         self.indexer_kv_dtype = indexer_kv_dtype
-        # Storage dtype for the side cache (bf16 today; quantized layouts later).
-        self.dtype = torch.bfloat16
+        # Storage dtype for the side cache. fp8 (e4m3) halves the per-step
+        # index-K read of the decode scorer -- the dominant linear-in-context
+        # decode cost at long context -- and halves the side cache's KV-pool
+        # footprint. The scores only feed a top-k block ranking, and the keys
+        # are RMS-normed (O(1) magnitudes), so a direct cast is sufficient.
+        self.dtype = (
+            torch.float8_e4m3fn if indexer_kv_dtype == "fp8" else torch.bfloat16
+        )
         self.prefix = prefix
         self.cache_config = cache_config
         # Impl-chosen backend -> each impl gets its own builder (get_attn_backend).
@@ -450,7 +456,7 @@ def select_indexer_impl_cls(
             f"indexer_kv_dtype={indexer_kv_dtype!r} needs the (not-yet-added) "
             "CuteDSL indexer impl."
         )
-    if indexer_kv_dtype != "bf16":
+    if indexer_kv_dtype not in ("bf16", "fp8"):
         raise NotImplementedError(
             f"indexer_kv_dtype={indexer_kv_dtype!r} is not supported by the "
             "Triton indexer impl."

--- a/vllm/models/minimax_m3/common/ops/index_topk.py
+++ b/vllm/models/minimax_m3/common/ops/index_topk.py
@@ -145,7 +145,7 @@ def _index_block_score_kernel(
             + page * stride_ik_blk
             + off_k[None, :] * stride_ik_pos
             + off_d[:, None] * stride_ik_d,
-        )
+        ).to(q.dtype)  # upcast: the index cache may be fp8
         qk = tl.dot(q, k)
         # apply causal mask as needed
         if q_start < i + BLOCK_SIZE_K:
@@ -372,7 +372,7 @@ def _decode_index_score_kernel(
             + page * stride_ik_blk
             + off_k[:, None] * stride_ik_pos
             + off_d * stride_ik_d,
-        )  # [N,D]
+        ).to(q.dtype)  # [N,D] (upcast: the index cache may be fp8)
         kq = tl.dot(k, q)  # [N,HQ]
         kq = tl.where(pos_mask & q_mask[None, :], kq, float("-inf"))
         score = tl.max(kq, axis=0)  # [HQ]


### PR DESCRIPTION
# MiniMax M3: fp8 (e4m3) index-K side cache

## Summary

Implements the `"fp8"` arm of the existing `indexer_kv_dtype` config knob (currently stubbed to bf16-only) for the MiniMax M3 lightning-indexer side cache. Opt-in via `--attention-config '{"indexer_kv_dtype": "fp8"}'`; default behavior is unchanged.

## Motivation

At decode, M3's dominant *linear-in-context* cost isn't attention — it's the indexer scan: 57 sparse layers each re-read their full per-token index-K side cache every step. At 769K tokens that's 5.6 GB per step in bf16, and `_decode_index_score_kernel` is DRAM-bandwidth-bound (verified with an L2-resident microbench: the kernel hits 4.2 TB/s when data fits in L2, so bytes are the only lever). fp8 halves the read and also halves the side cache's share of the KV pool.

Why it's safe: the scores only feed a **top-k block ranking** (the attention itself reads the main KV cache at full fidelity), the scorer takes a max over 128 tokens per block (noise-robust), and index keys are RMS-normed to O(1) magnitudes so a direct e4m3 cast needs no scale factors. DeepSeek V3.2's DSA — the same indexer design lineage — ships fp8 indexer keys natively.

## Changes

- `common/indexer.py`: accept `"fp8"`; side cache allocates as `float8_e4m3fn`.
- `common/ops/index_topk.py`: both scorer kernels upcast K loads with `.to(q.dtype)` — a no-op for bf16 caches (Triton folds it), so existing users are bit-identical.
- No writer change: the insert paths already cast via `.to(idx_cache.dtype)` on both the eager and compiled (`minimax_m3_sparse_kv_cache_update`) paths.
- New regression test `tests/kernels/attention/test_minimax_m3_fp8_indexer.py`: fp8-vs-bf16 decode top-k agreement with planted strongly-matching blocks (passes on SM120; block-score correlation vs bf16 measured at 1.0000, top-16 selection differing only on noise-floor ties among random filler blocks).

## Measured (4x RTX PRO 6000 Blackwell / SM120, TP4, fp8 main KV, B12X_ATTN, MiniMax-M3-NVFP4, batch 1)

| | bf16 indexer | fp8 indexer |
|---|---|---|
| decode @ 6K | 12.6 ms/step | 12.7 ms/step |
| decode @ 96K | 15.0 ms | 14.7 ms |
| decode @ 384K | 25.8 ms (38.8 tok/s) | **19.5 ms (51.2 tok/s)** |
| decode @ 769K | 42.5 ms (23.5 tok/s) | **26.4 ms (37.8 tok/s, +61%)** |
| KV pool @ 1M-token config | 1,240K tokens | **1,430K tokens** |

Quality checks on the live server: exact needle retrieval at **751K tokens**, coherent generation, vision path unaffected.

## Trade-off (stated plainly)

e4m3 adds ~2% relative error to block scores. Since scores only rank blocks, the worst case is an occasional swap at the top-k boundary between blocks whose relevance was already statistically indistinguishable; strongly relevant blocks are unaffected (regression-tested). Not yet covered: task-level long-doc QA benchmarks and spec-decode query lengths > 1 (structurally the same kernels, measured at qlen=1 only). Being opt-in and default-off, users who don't set the flag see zero change.

Context: follow-up to lukealonso/b12x#24 (dense split-KV decode fix) — together they take M3 long-context decode on this hardware from ~14 tok/s to ~38 tok/s at 769K tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for fp8 index-cache storage and selection alongside bf16.
  * Index-scoring now consistently handles cached values in the query’s dtype.

* **Tests**
  * Added coverage to verify fp8 top-k block selection closely matches the bf16 reference, including key planted matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->