### PR TITLE
quant(fp8): bridge MXFP8 dense and NVFP4 experts

### DIFF
--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -96,6 +96,43 @@ ACTIVATION_SCHEMES = ["static", "dynamic"]
 logger = init_logger(__name__)
 
 
+class Mxfp8SerializedLinearMethod(LinearMethodBase):
+    """Thin adapter serving MXFP8-serialized dense weights (e4m3 values +
+    per-32 ue8m0 scales) inside an FP8-checkpoint config, delegating to the
+    compressed-tensors MXFP8 scheme (weight [n,k] fp8 + weight_scale u8)."""
+
+    def __init__(self):
+        from vllm.model_executor.layers.quantization.compressed_tensors.schemes.compressed_tensors_w8a8_mxfp8 import (  # noqa: E501
+            CompressedTensorsW8A8Mxfp8,
+        )
+
+        self.scheme = CompressedTensorsW8A8Mxfp8()
+
+    def create_weights(
+        self,
+        layer,
+        input_size_per_partition,
+        output_partition_sizes,
+        input_size,
+        output_size,
+        params_dtype,
+        **extra_weight_attrs,
+    ):
+        self.scheme.create_weights(
+            layer=layer,
+            output_partition_sizes=output_partition_sizes,
+            input_size_per_partition=input_size_per_partition,
+            params_dtype=params_dtype,
+            weight_loader=extra_weight_attrs.get("weight_loader"),
+        )
+
+    def process_weights_after_loading(self, layer):
+        self.scheme.process_weights_after_loading(layer)
+
+    def apply(self, layer, x, bias=None):
+        return self.scheme.apply_weights(layer, x, bias=bias)
+
+
 class Fp8Config(QuantizationConfig):
     """Config class for FP8."""
 
@@ -106,6 +143,7 @@ class Fp8Config(QuantizationConfig):
         ignored_layers: list[str] | None = None,
         weight_block_size: list[int] | None = None,
         store_dtype: str | None = None,
+        dense_format: str | None = None,
     ) -> None:
         super().__init__()
 
@@ -116,6 +154,7 @@ class Fp8Config(QuantizationConfig):
         self.activation_scheme = activation_scheme
         self.ignored_layers = ignored_layers or []
         self.store_dtype = store_dtype
+        self.dense_format = dense_format
         if weight_block_size is not None:
             if not is_checkpoint_fp8_serialized:
                 raise ValueError(
@@ -134,7 +173,6 @@ class Fp8Config(QuantizationConfig):
                     f"{activation_scheme} activation scheme."
                 )
         self.weight_block_size = weight_block_size
-        self.store_dtype = store_dtype
         self.use_deep_gemm: bool | None = None
 
     @classmethod
@@ -165,6 +203,7 @@ class Fp8Config(QuantizationConfig):
         ignored_layers = cls.get_from_keys_or(config, ["ignored_layers"], None)
         weight_block_size = cls.get_from_keys_or(config, ["weight_block_size"], None)
         store_dtype = cls.get_from_keys_or(config, ["store_dtype"], None)
+        dense_format = cls.get_from_keys_or(config, ["dense_format"], None)
         if not ignored_layers:
             ignored_layers = cls.get_from_keys_or(
                 config, ["modules_to_not_convert"], None
@@ -175,12 +214,23 @@ class Fp8Config(QuantizationConfig):
             ignored_layers=ignored_layers,
             weight_block_size=weight_block_size,
             store_dtype=store_dtype,
+            dense_format=dense_format,
         )
 
     def get_quant_method(
         self, layer: torch.nn.Module, prefix: str
     ) -> "QuantizeMethodBase | None":
         if isinstance(layer, LinearBase):
+            if self.dense_format == "mxfp8" and not is_layer_skipped(
+                prefix=prefix,
+                ignored_layers=self.ignored_layers,
+                fused_mapping=self.packed_modules_mapping,
+            ):
+                logger.info_once(
+                    "Using serialized-MXFP8 dense linear method for FP8 "
+                    "checkpoint with dense_format=mxfp8."
+                )
+                return Mxfp8SerializedLinearMethod()
             if is_layer_skipped(
                 prefix=prefix,
                 ignored_layers=self.ignored_layers,
@@ -206,6 +256,24 @@ class Fp8Config(QuantizationConfig):
                 fused_mapping=self.packed_modules_mapping,
             ):
                 return UnquantizedFusedMoEMethod(layer.moe_config)
+            if self.store_dtype == "nvfp4":
+                from vllm.model_executor.layers.quantization.modelopt import (
+                    ModelOptNvFp4Config,
+                    ModelOptNvFp4FusedMoE,
+                )
+
+                logger.info_once(
+                    "Using ModelOpt NVFP4 MoE method for FP8 checkpoint "
+                    "with store_dtype=nvfp4."
+                )
+                nv_cfg = ModelOptNvFp4Config(
+                    quant_method="NVFP4",
+                    is_checkpoint_nvfp4_serialized=True,
+                    kv_cache_quant_algo=None,
+                    exclude_modules=[],
+                    group_size=16,
+                )
+                return ModelOptNvFp4FusedMoE(nv_cfg, layer.moe_config)
             if self.store_dtype == "mxfp4":
                 from vllm.model_executor.layers.quantization.mxfp4 import (
                     GptOssMxfp4MoEMethod,


### PR DESCRIPTION
## Summary

Adds the missing FP8 checkpoint bridge for GLM-style hybrid checkpoints:

- `dense_format=mxfp8` routes dense LinearBase weights through the serialized MXFP8 compressed-tensors method.
- `store_dtype=nvfp4` routes MoE experts through the ModelOpt NVFP4 fused MoE method instead of the generic FP8 MoE path.

This is the runtime patch already present in the GLM 5.2 sweep image and is required for offline checkpoints such as `GLM-5.2-MXFP8dense-NVFP4experts` / `GLM-5.2-FP8-NVFP4experts`.

## Validation

- `python3 -m py_compile vllm/model_executor/layers/quantization/fp8.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for serialized MXFP8 dense linear layers, enabling this format to be selected through configuration.
  * Added support for NVFP4-based Mixture-of-Experts models when using the matching serialized format.
  * Introduced a new configuration option to choose the dense weight format.

* **Bug Fixes**
  * Improved quantization method selection so supported layer types now route to the appropriate quantized implementation automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->