### PR TITLE
[codex] quant(mxfp4): allow online dense FP8 overlays

### DIFF
--- a/tests/quantization/test_mxfp4_online_overlay.py
+++ b/tests/quantization/test_mxfp4_online_overlay.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Selection tests for the online dense overlay on MXFP4 checkpoints."""
+
+import contextlib
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import torch
+
+from vllm.config.quantization import QuantizationConfigArgs
+from vllm.model_executor.layers.linear import LinearBase, UnquantizedLinearMethod
+from vllm.model_executor.layers.quantization.mxfp4 import Mxfp4Config
+
+
+def _mock_linear() -> Mock:
+    return Mock(spec=LinearBase)
+
+
+@contextlib.contextmanager
+def _patched_current_config(args: QuantizationConfigArgs):
+    current = SimpleNamespace(
+        model_config=SimpleNamespace(
+            quantization_config=args, dtype=torch.bfloat16
+        )
+    )
+    with (
+        patch(
+            "vllm.model_executor.layers.quantization.mxfp4."
+            "get_current_vllm_config",
+            return_value=current,
+        ),
+        patch(
+            "vllm.model_executor.layers.quantization.online.fp8."
+            "get_current_vllm_config",
+            return_value=current,
+        ),
+    ):
+        yield
+
+
+def test_mxfp4_linear_overlay_skips_shared_experts_without_spec():
+    """`linear` alone must not touch shared experts (ModelOpt semantics)."""
+    config = Mxfp4Config()
+    args = QuantizationConfigArgs(linear="mxfp8")
+
+    with _patched_current_config(args):
+        dense = config.get_quant_method(
+            _mock_linear(), "model.layers.3.self_attn.kv_b_proj"
+        )
+        shared = config.get_quant_method(
+            _mock_linear(), "model.layers.3.mlp.shared_experts.down_proj"
+        )
+
+    assert type(dense).__name__ == "Mxfp8OnlineLinearMethod"
+    assert isinstance(shared, UnquantizedLinearMethod)
+
+
+def test_mxfp4_linear_overlay_quantizes_shared_experts_with_spec():
+    config = Mxfp4Config()
+    args = QuantizationConfigArgs(linear="mxfp8", shared_experts="mxfp8")
+
+    with _patched_current_config(args):
+        shared = config.get_quant_method(
+            _mock_linear(), "model.layers.3.mlp.shared_experts.down_proj"
+        )
+
+    assert type(shared).__name__ == "Mxfp8OnlineLinearMethod"
+
+
+def test_mxfp4_linear_overlay_honors_ignore():
+    config = Mxfp4Config()
+    args = QuantizationConfigArgs(
+        linear="mxfp8", ignore=["re:.*kv_b_proj"]
+    )
+
+    with _patched_current_config(args):
+        ignored = config.get_quant_method(
+            _mock_linear(), "model.layers.3.self_attn.kv_b_proj"
+        )
+        kept = config.get_quant_method(
+            _mock_linear(), "model.layers.3.self_attn.q_b_proj"
+        )
+
+    assert isinstance(ignored, UnquantizedLinearMethod)
+    assert type(kept).__name__ == "Mxfp8OnlineLinearMethod"

--- a/tests/quantization/test_quantization_config_args.py
+++ b/tests/quantization/test_quantization_config_args.py
@@ -137,6 +137,26 @@ def test_resolve_allows_modelopt_dense_linear_overlay():
     assert args == QuantizationConfigArgs(linear={"weight": "mxfp8"})
 
 
+def test_resolve_allows_mxfp4_dense_linear_mxfp8_overlay():
+    args = resolve_quantization_config(
+        "mxfp4",
+        {"linear": {"weight": "mxfp8"}},
+    )
+    assert args == QuantizationConfigArgs(linear={"weight": "mxfp8"})
+
+
+def test_resolve_allows_mxfp4_dense_linear_fp8_overlay():
+    args = resolve_quantization_config(
+        "mxfp4",
+        {
+            "linear": {"weight": "fp8_per_block_static"},
+            "ignore": ["re:.*indexer\\.weights_proj"],
+        },
+    )
+    assert args.linear == QuantSpec(weight=kFp8Static128BlockSym)
+    assert args.ignore == ["re:.*indexer\\.weights_proj"]
+
+
 def test_resolve_allows_modelopt_combined_overlay_with_ignore():
     args = resolve_quantization_config(
         "modelopt_fp4",
@@ -152,7 +172,7 @@ def test_resolve_allows_modelopt_combined_overlay_with_ignore():
 
 
 def test_resolve_rejects_modelopt_ignore_without_linear():
-    with pytest.raises(ValueError, match="MXFP8 overlay"):
+    with pytest.raises(ValueError, match="online overlay"):
         resolve_quantization_config(
             "modelopt_fp4",
             {"shared_experts": "mxfp8", "ignore": ["re:.*o_proj"]},
@@ -160,7 +180,7 @@ def test_resolve_rejects_modelopt_ignore_without_linear():
 
 
 def test_resolve_rejects_modelopt_moe_override():
-    with pytest.raises(ValueError, match="MXFP8 overlay"):
+    with pytest.raises(ValueError, match="online overlay"):
         resolve_quantization_config(
             "modelopt_fp4",
             {"linear": {"weight": "mxfp8"}, "moe": "mxfp8"},

--- a/vllm/config/quantization.py
+++ b/vllm/config/quantization.py
@@ -147,18 +147,23 @@ ONLINE_QUANT_SHORTHAND_NAMES: tuple[str, ...] = (
 )
 
 
-# Checkpoint formats that support overlaying online MXFP8 on BF16 projections
+# Checkpoint formats that support overlaying online quantization on BF16 projections
 # which the checkpoint explicitly leaves unquantized (shared experts via
 # `shared_experts`, other dense linears via `linear`).
-_MODELOPT_MXFP8_OVERLAY_NAMES = frozenset(
-    {"modelopt", "modelopt_fp4", "modelopt_mxfp8", "modelopt_mixed"}
+_MODELOPT_ONLINE_OVERLAY_NAMES = frozenset(
+    {"modelopt", "modelopt_fp4", "modelopt_mxfp8", "modelopt_mixed", "mxfp4"}
 )
 
 
-def _is_modelopt_mxfp8_overlay(
+_MODELOPT_ONLINE_OVERLAY_WEIGHTS = frozenset(
+    {kMxfp8Dynamic, kFp8Static128BlockSym}
+)
+
+
+def _is_modelopt_online_overlay(
     quantization: str | None, args: QuantizationConfigArgs
 ) -> bool:
-    if quantization not in _MODELOPT_MXFP8_OVERLAY_NAMES or args.moe is not None:
+    if quantization not in _MODELOPT_ONLINE_OVERLAY_NAMES or args.moe is not None:
         return False
     specs = [s for s in (args.linear, args.shared_experts) if s is not None]
     if not specs:
@@ -167,7 +172,9 @@ def _is_modelopt_mxfp8_overlay(
         # `ignore` only filters the dense-linear overlay.
         return False
     return all(
-        spec.weight == kMxfp8Dynamic and spec.activation is None for spec in specs
+        spec.weight in _MODELOPT_ONLINE_OVERLAY_WEIGHTS
+        and spec.activation is None
+        for spec in specs
     )
 
 
@@ -181,21 +188,22 @@ def resolve_quantization_config(
     `quantization` may be a CLI shorthand that desugars into a base config via
     `_ONLINE_SHORTHANDS`. `quantization_config` is a dict or pre-built args
     object. When both are online settings, fields explicitly set in
-    `quantization_config` take precedence over the shorthand. ModelOpt also
-    accepts the MXFP8 shared-expert overlay.
+    `quantization_config` take precedence over the shorthand. ModelOpt accepts
+    online overlays for BF16 dense/shared-expert projections.
     """
     if isinstance(quantization_config, dict):
         quantization_config = QuantizationConfigArgs(**quantization_config)
 
     if quantization is not None and quantization not in ONLINE_QUANT_SHORTHAND_NAMES:
-        if quantization_config is not None and not _is_modelopt_mxfp8_overlay(
+        if quantization_config is not None and not _is_modelopt_online_overlay(
             quantization, quantization_config
         ):
             raise ValueError(
                 f"quantization_config is only supported when quantization is "
                 f"one of {sorted(ONLINE_QUANT_SHORTHAND_NAMES)}, or when "
-                f"using the ModelOpt MXFP8 overlay (weight='mxfp8' on "
-                f"'shared_experts' and/or 'linear', optional 'ignore'), "
+                f"using the ModelOpt online overlay (weight='mxfp8' or "
+                f"weight='fp8_per_block_static' on 'shared_experts' and/or "
+                f"'linear', optional 'ignore'), "
                 f"got quantization={quantization!r}"
             )
         return quantization_config

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -96,6 +96,43 @@ ACTIVATION_SCHEMES = ["static", "dynamic"]
 logger = init_logger(__name__)
 
 
+class Mxfp8SerializedLinearMethod(LinearMethodBase):
+    """Thin adapter serving MXFP8-serialized dense weights (e4m3 values +
+    per-32 ue8m0 scales) inside an FP8-checkpoint config, delegating to the
+    compressed-tensors MXFP8 scheme (weight [n,k] fp8 + weight_scale u8)."""
+
+    def __init__(self):
+        from vllm.model_executor.layers.quantization.compressed_tensors.schemes.compressed_tensors_w8a8_mxfp8 import (  # noqa: E501
+            CompressedTensorsW8A8Mxfp8,
+        )
+
+        self.scheme = CompressedTensorsW8A8Mxfp8()
+
+    def create_weights(
+        self,
+        layer,
+        input_size_per_partition,
+        output_partition_sizes,
+        input_size,
+        output_size,
+        params_dtype,
+        **extra_weight_attrs,
+    ):
+        self.scheme.create_weights(
+            layer=layer,
+            output_partition_sizes=output_partition_sizes,
+            input_size_per_partition=input_size_per_partition,
+            params_dtype=params_dtype,
+            weight_loader=extra_weight_attrs.get("weight_loader"),
+        )
+
+    def process_weights_after_loading(self, layer):
+        self.scheme.process_weights_after_loading(layer)
+
+    def apply(self, layer, x, bias=None):
+        return self.scheme.apply_weights(layer, x, bias=bias)
+
+
 class Fp8Config(QuantizationConfig):
     """Config class for FP8."""
 
@@ -106,6 +143,7 @@ class Fp8Config(QuantizationConfig):
         ignored_layers: list[str] | None = None,
         weight_block_size: list[int] | None = None,
         store_dtype: str | None = None,
+        dense_format: str | None = None,
     ) -> None:
         super().__init__()
 
@@ -116,6 +154,7 @@ class Fp8Config(QuantizationConfig):
         self.activation_scheme = activation_scheme
         self.ignored_layers = ignored_layers or []
         self.store_dtype = store_dtype
+        self.dense_format = dense_format
         if weight_block_size is not None:
             if not is_checkpoint_fp8_serialized:
                 raise ValueError(
@@ -134,7 +173,6 @@ class Fp8Config(QuantizationConfig):
                     f"{activation_scheme} activation scheme."
                 )
         self.weight_block_size = weight_block_size
-        self.store_dtype = store_dtype
         self.use_deep_gemm: bool | None = None
 
     @classmethod
@@ -165,6 +203,7 @@ class Fp8Config(QuantizationConfig):
         ignored_layers = cls.get_from_keys_or(config, ["ignored_layers"], None)
         weight_block_size = cls.get_from_keys_or(config, ["weight_block_size"], None)
         store_dtype = cls.get_from_keys_or(config, ["store_dtype"], None)
+        dense_format = cls.get_from_keys_or(config, ["dense_format"], None)
         if not ignored_layers:
             ignored_layers = cls.get_from_keys_or(
                 config, ["modules_to_not_convert"], None
@@ -175,12 +214,23 @@ class Fp8Config(QuantizationConfig):
             ignored_layers=ignored_layers,
             weight_block_size=weight_block_size,
             store_dtype=store_dtype,
+            dense_format=dense_format,
         )
 
     def get_quant_method(
         self, layer: torch.nn.Module, prefix: str
     ) -> "QuantizeMethodBase | None":
         if isinstance(layer, LinearBase):
+            if self.dense_format == "mxfp8" and not is_layer_skipped(
+                prefix=prefix,
+                ignored_layers=self.ignored_layers,
+                fused_mapping=self.packed_modules_mapping,
+            ):
+                logger.info_once(
+                    "Using serialized-MXFP8 dense linear method for FP8 "
+                    "checkpoint with dense_format=mxfp8."
+                )
+                return Mxfp8SerializedLinearMethod()
             if is_layer_skipped(
                 prefix=prefix,
                 ignored_layers=self.ignored_layers,
@@ -206,6 +256,24 @@ class Fp8Config(QuantizationConfig):
                 fused_mapping=self.packed_modules_mapping,
             ):
                 return UnquantizedFusedMoEMethod(layer.moe_config)
+            if self.store_dtype == "nvfp4":
+                from vllm.model_executor.layers.quantization.modelopt import (
+                    ModelOptNvFp4Config,
+                    ModelOptNvFp4FusedMoE,
+                )
+
+                logger.info_once(
+                    "Using ModelOpt NVFP4 MoE method for FP8 checkpoint "
+                    "with store_dtype=nvfp4."
+                )
+                nv_cfg = ModelOptNvFp4Config(
+                    quant_method="NVFP4",
+                    is_checkpoint_nvfp4_serialized=True,
+                    kv_cache_quant_algo=None,
+                    exclude_modules=[],
+                    group_size=16,
+                )
+                return ModelOptNvFp4FusedMoE(nv_cfg, layer.moe_config)
             if self.store_dtype == "mxfp4":
                 from vllm.model_executor.layers.quantization.mxfp4 import (
                     GptOssMxfp4MoEMethod,

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -4,6 +4,7 @@
 import torch
 
 from vllm.config import get_current_vllm_config
+from vllm.config.quantization import QuantizationConfigArgs
 from vllm.logger import init_logger
 from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.fused_moe import (
@@ -31,6 +32,9 @@ from vllm.model_executor.layers.quantization import QuantizationMethods
 from vllm.model_executor.layers.quantization.base_config import (
     QuantizationConfig,
     QuantizeMethodBase,
+)
+from vllm.model_executor.layers.quantization.online.base import (
+    OnlineQuantizationConfig,
 )
 from vllm.model_executor.layers.quantization.utils.quant_utils import is_layer_skipped
 from vllm.model_executor.utils import replace_parameter, set_weight_attrs
@@ -251,6 +255,21 @@ class Mxfp4Config(QuantizationConfig):
                 fused_mapping=self.packed_modules_mapping,
             ):
                 return UnquantizedLinearMethod()
+            args = get_current_vllm_config().model_config.quantization_config
+            if isinstance(args, QuantizationConfigArgs) and (
+                args.linear is not None or args.shared_experts is not None
+            ):
+                online_config = OnlineQuantizationConfig(args)
+                online_config.packed_modules_mapping = self.packed_modules_mapping
+                method = online_config.get_quant_method(layer, prefix)
+                if not isinstance(method, UnquantizedLinearMethod):
+                    logger.info_once(
+                        "MXFP4 dense-linear online overlay: quantizing BF16 "
+                        "linear weights at load time while keeping routed "
+                        "experts on the MXFP4 MoE path (module example: %s).",
+                        prefix,
+                    )
+                return method
             logger.debug_once(
                 "MXFP4 linear layer is not implemented - falling back to "
                 "UnquantizedLinearMethod.",

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -36,6 +36,9 @@ from vllm.model_executor.layers.quantization.base_config import (
 from vllm.model_executor.layers.quantization.online.base import (
     OnlineQuantizationConfig,
 )
+from vllm.model_executor.layers.quantization.online.mxfp8 import (
+    is_shared_expert_projection,
+)
 from vllm.model_executor.layers.quantization.utils.quant_utils import is_layer_skipped
 from vllm.model_executor.utils import replace_parameter, set_weight_attrs
 
@@ -256,8 +259,16 @@ class Mxfp4Config(QuantizationConfig):
             ):
                 return UnquantizedLinearMethod()
             args = get_current_vllm_config().model_config.quantization_config
-            if isinstance(args, QuantizationConfigArgs) and (
-                args.linear is not None or args.shared_experts is not None
+            if (
+                isinstance(args, QuantizationConfigArgs)
+                and (args.linear is not None or args.shared_experts is not None)
+                # Match the ModelOpt overlay semantics: the `linear` spec never
+                # touches shared-expert projections; those are quantized only
+                # when a `shared_experts` spec is given explicitly.
+                and (
+                    args.shared_experts is not None
+                    or not is_shared_expert_projection(prefix)
+                )
             ):
                 online_config = OnlineQuantizationConfig(args)
                 online_config.packed_modules_mapping = self.packed_modules_mapping


### PR DESCRIPTION
## Summary

Adds the missing online dense-linear overlay path for MXFP4 checkpoints so a BF16+MXFP4 checkpoint can quantize its BF16 dense projections at load time with either:

- `linear.weight=mxfp8`
- `linear.weight=fp8_per_block_static`

The routed MXFP4 MoE path remains unchanged.

## Details

- Treat `mxfp4` as a ModelOpt-compatible overlay base for `quantization_config`.
- Generalize the overlay validator from MXFP8-only to supported online overlay weights.
- Route MXFP4 linear layers through `OnlineQuantizationConfig` when `linear` or `shared_experts` overlay specs are provided.
- Keep `ignore` scoped to dense-linear overlays.

## Validation

- `git diff --check`
- Direct resolver smoke test inside the vLLM CUDA image:
  - `mxfp4 + linear.weight=mxfp8`
  - `mxfp4 + linear.weight=fp8_per_block_static`
  - `modelopt_fp4 + shared_experts/linear mxfp8`
- `python -m pytest tests/quantization/test_quantization_config_args.py -q` was attempted on the host but the local environment is missing `fastapi` during test conftest import.

## Stack

This is stacked on PR #76 (`codex/fp8-modelopt-bridge-20260706`) because the FP8 bridge commit is still open against `dev/eldritch-enlightenment`.
