### PR TITLE
dcp: hybrid A2A dispatch — cap the one-shot B12X exchange by batch tokens

### DIFF
--- a/tests/distributed/test_dcp_a2a.py
+++ b/tests/distributed/test_dcp_a2a.py
@@ -415,6 +415,98 @@ def test_b12x_query_gather_dispatch_bypasses_group(monkeypatch: pytest.MonkeyPat
     }
 
 
+@pytest.mark.skipif(torch.accelerator.device_count() < 1, reason="CUDA is required.")
+def test_b12x_lse_reduce_honors_token_cap(monkeypatch: pytest.MonkeyPatch):
+    from vllm.v1.attention.ops import dcp_alltoall
+
+    monkeypatch.setenv("VLLM_USE_B12X_DCP_A2A", "1")
+    monkeypatch.setenv("VLLM_DCP_A2A_MAX_TOKENS", "4")
+    created: dict[str, Any] = {}
+    sentinel = torch.zeros(1)
+
+    class _FakePool:
+        def lse_reduce_scatter(self, out, lse, *, is_lse_base_on_e):
+            return sentinel
+
+    def fake_get_pool(cp_group, *, device, total_heads, head_dim, query_head_dim,
+                      max_batch_size):
+        created["max_batch_size"] = max_batch_size
+        return _FakePool()
+
+    monkeypatch.setattr(dcp_alltoall, "_get_b12x_dcp_a2a_pool", fake_get_pool)
+    group = _FakeCPGroup(4, None)  # type: ignore[arg-type]
+
+    out = torch.zeros(4, 16, 64, dtype=torch.bfloat16, device="cuda")
+    lse = torch.zeros(4, 16, dtype=torch.float32, device="cuda")
+    result = dcp_alltoall._try_b12x_dcp_lse_reduce(
+        out,
+        lse,
+        group,  # type: ignore[arg-type]
+        return_lse=False,
+        is_lse_base_on_e=True,
+        max_batch_size=8192,
+        query_head_dim=64,
+    )
+    # Batch within the cap uses B12X, with the staging pool capped too.
+    assert result is sentinel
+    assert created["max_batch_size"] == 4
+
+    out_large = torch.zeros(8, 16, 64, dtype=torch.bfloat16, device="cuda")
+    lse_large = torch.zeros(8, 16, dtype=torch.float32, device="cuda")
+    result = dcp_alltoall._try_b12x_dcp_lse_reduce(
+        out_large,
+        lse_large,
+        group,  # type: ignore[arg-type]
+        return_lse=False,
+        is_lse_base_on_e=True,
+        max_batch_size=8192,
+        query_head_dim=64,
+    )
+    # Batch above the cap declines B12X so the caller picks an NCCL path.
+    assert result is None
+
+
+@pytest.mark.skipif(torch.accelerator.device_count() < 1, reason="CUDA is required.")
+def test_b12x_query_gather_honors_token_cap(monkeypatch: pytest.MonkeyPatch):
+    from vllm.v1.attention.ops import dcp_alltoall
+
+    monkeypatch.setenv("VLLM_USE_B12X_DCP_A2A", "1")
+    monkeypatch.setenv("VLLM_DCP_A2A_MAX_TOKENS", "4")
+    created: dict[str, Any] = {}
+    sentinel = torch.zeros(1)
+
+    class _FakePool:
+        def all_gather_heads(self, local_input):
+            return sentinel
+
+    def fake_get_pool(cp_group, *, device, total_heads, head_dim, query_head_dim,
+                      max_batch_size):
+        created["max_batch_size"] = max_batch_size
+        return _FakePool()
+
+    monkeypatch.setattr(dcp_alltoall, "_get_b12x_dcp_a2a_pool", fake_get_pool)
+    group = _FakeCPGroup(4, None)  # type: ignore[arg-type]
+
+    small = torch.zeros(4, 8, 64, dtype=torch.bfloat16, device="cuda")
+    result = dcp_alltoall._try_b12x_dcp_all_gather_heads(
+        small,
+        group,  # type: ignore[arg-type]
+        max_batch_size=8192,
+        output_head_dim=64,
+    )
+    assert result is sentinel
+    assert created["max_batch_size"] == 4
+
+    large = torch.zeros(8, 8, 64, dtype=torch.bfloat16, device="cuda")
+    result = dcp_alltoall._try_b12x_dcp_all_gather_heads(
+        large,
+        group,  # type: ignore[arg-type]
+        max_batch_size=8192,
+        output_head_dim=64,
+    )
+    assert result is None
+
+
 def test_b12x_query_gather_requires_env(monkeypatch: pytest.MonkeyPatch):
     from vllm.v1.attention.ops import dcp_alltoall
 

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -65,6 +65,8 @@ if TYPE_CHECKING:
     VLLM_USE_B12X_MOE: bool = False
     VLLM_USE_B12X_MINIMAX_M3_MSA: bool = False
     VLLM_USE_B12X_DCP_A2A: bool = False
+    VLLM_DCP_A2A_MAX_TOKENS: int = 0
+    VLLM_DCP_A2A_LARGE_BACKEND: Literal["ag_rs", "a2a"] = "ag_rs"
     VLLM_MINIMAX_M3_ENABLE_TORCH_COMPILE: bool = False
     VLLM_B12X_CUDAGRAPH_PIECEWISE_PREWARM: bool = False
     VLLM_B12X_MOE_FORCE_MODELOPT_PREP: bool = False
@@ -1038,6 +1040,18 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     # Use b12x PCIe collectives for DCP query gather and output reduction.
     "VLLM_USE_B12X_DCP_A2A": lambda: bool(int(os.getenv("VLLM_USE_B12X_DCP_A2A", "0"))),
+    # Token cap for the low-latency DCP A2A exchange (0 = uncapped). Batches
+    # with more tokens than this bypass the one-shot A2A/B12X path, which is
+    # latency-optimal for small decode batches but loses to pipelined NCCL
+    # collectives on large prefill/extend batches. Also bounds the B12X DCP
+    # IPC staging allocation, which scales linearly with this value.
+    "VLLM_DCP_A2A_MAX_TOKENS": lambda: int(os.getenv("VLLM_DCP_A2A_MAX_TOKENS", "0")),
+    # Collective pattern used for DCP batches above VLLM_DCP_A2A_MAX_TOKENS:
+    # "ag_rs" (default) routes them through the AllGather+ReduceScatter path;
+    # "a2a" keeps the NCCL all-to-all exchange (without B12X staging).
+    "VLLM_DCP_A2A_LARGE_BACKEND": lambda: os.getenv(
+        "VLLM_DCP_A2A_LARGE_BACKEND", "ag_rs"
+    ),
     # Diagnostic flag retained for local experiments. MiniMax M3 compile is
     # fail-closed in the model until the no-break path is validated.
     "VLLM_MINIMAX_M3_ENABLE_TORCH_COMPILE": lambda: bool(

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -562,6 +562,20 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             if _vllm_config is not None
             else 0
         )
+        # Hybrid DCP dispatch: the one-shot A2A/B12X exchange is
+        # latency-optimal for small decode batches but loses to pipelined
+        # NCCL collectives on large prefill/extend batches. Batches with more
+        # tokens than the cap take VLLM_DCP_A2A_LARGE_BACKEND instead
+        # (0 = uncapped, pure A2A).
+        self.dcp_a2a_max_tokens = (
+            envs.VLLM_DCP_A2A_MAX_TOKENS if self.dcp_a2a else 0
+        )
+        self.dcp_a2a_large_backend = envs.VLLM_DCP_A2A_LARGE_BACKEND
+        if self.dcp_a2a and self.dcp_a2a_large_backend not in ("ag_rs", "a2a"):
+            raise ValueError(
+                "VLLM_DCP_A2A_LARGE_BACKEND must be 'ag_rs' or 'a2a', got "
+                f"{self.dcp_a2a_large_backend!r}."
+            )
 
         # Initialize q/k/v range constants.
         self.q_range = torch.tensor(envs.Q_SCALE_CONSTANT, dtype=torch.float32)
@@ -886,8 +900,21 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 if isinstance(mqa_q, tuple):
                     # concatenate mqa_ql_nope and mqa_q_pe -> (B, N, L + P)
                     mqa_q = torch.cat(mqa_q, dim=-1)
+                # Hybrid dispatch on the per-step token count. This is
+                # CUDA-graph safe: under capture the branch sees the padded
+                # capture size, so every graph bakes in one path, and eager
+                # prefill re-evaluates per step. All DCP ranks run the same
+                # batch, so the choice is uniform across the group.
+                dcp_small_batch = (
+                    self.dcp_a2a_max_tokens <= 0
+                    or num_mqa_tokens <= self.dcp_a2a_max_tokens
+                )
+                dcp_use_b12x = self.dcp_b12x and dcp_small_batch
+                dcp_use_a2a = self.dcp_a2a and (
+                    dcp_small_batch or self.dcp_a2a_large_backend != "ag_rs"
+                )
                 # mqa_q do allgather in head dim.
-                if self.dcp_b12x:
+                if dcp_use_b12x:
                     mqa_q = dcp_b12x_all_gather_heads(
                         mqa_q,
                         get_dcp_group(),
@@ -909,13 +936,13 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                         f"{type(self.impl).__name__} did not return decode "
                         "softmax LSE required by DCP."
                     )
-                if self.dcp_a2a:
+                if dcp_use_a2a:
                     attn_out = dcp_a2a_lse_reduce(
                         attn_out,
                         lse,
                         get_dcp_group(),
                         is_lse_base_on_e=True,
-                        use_b12x=self.dcp_b12x,
+                        use_b12x=dcp_use_b12x,
                         b12x_max_batch_size=self.dcp_max_batch_size,
                         b12x_query_head_dim=(self.kv_lora_rank + self.qk_rope_head_dim),
                     )

--- a/vllm/v1/attention/ops/dcp_alltoall.py
+++ b/vllm/v1/attention/ops/dcp_alltoall.py
@@ -166,6 +166,13 @@ def _try_b12x_dcp_lse_reduce(
     if max_batch_size is None:
         max_batch_size = batch
     max_batch_size = int(max_batch_size)
+    token_cap = envs.VLLM_DCP_A2A_MAX_TOKENS
+    if token_cap > 0:
+        # Deliberate hybrid dispatch: batches above the cap take a pipelined
+        # NCCL collective instead, and the staging pool shrinks to the cap.
+        if batch > token_cap:
+            return None
+        max_batch_size = min(max_batch_size, token_cap)
     if max_batch_size < 1:
         return None
     if query_head_dim is None:
@@ -225,6 +232,11 @@ def _try_b12x_dcp_all_gather_heads(
     if max_batch_size is None:
         max_batch_size = batch
     max_batch_size = int(max_batch_size)
+    token_cap = envs.VLLM_DCP_A2A_MAX_TOKENS
+    if token_cap > 0:
+        if batch > token_cap:
+            return None
+        max_batch_size = min(max_batch_size, token_cap)
     if max_batch_size < 1 or batch > max_batch_size:
         return None
     if output_head_dim is None:


### PR DESCRIPTION
## Problem

`--dcp-comm-backend a2a` + `VLLM_USE_B12X_DCP_A2A=1` is a latency-optimized,
one-barrier PCIe exchange. It wins low-concurrency decode, but for B12X sparse
MLA **every** batch (prefill included) goes through `forward_mqa`, so the same
one-shot staging path also carries 8k-token prefill batches — where it loses
~30 % to pipelined NCCL collectives (full-staging copy + single-channel,
unpipelined pulls; `pcie_dcp_a2a.cu` deliberately follows the low-latency
`pcie_oneshot` design, which is the right call only for small batches).

Neither backend wins both ends: the regime flips from latency-bound (small
decode batches: one barrier beats 3 pipelined NCCL calls) to bandwidth-bound
(large extend batches: pipelining wins).

## Fix

The same policy the PCIe allreduce already uses (deterministic size
crossovers: oneshot ≤ 84 KB / PyNCCL / DMA ring ≥ 6 MB), applied to the DCP
exchange — dispatch on the per-step token count:

- `VLLM_DCP_A2A_MAX_TOKENS` (int, default `0` = uncapped → **behavior
  unchanged unless opted in**): batches with more tokens than the cap skip
  the one-shot A2A/B12X path.
- `VLLM_DCP_A2A_LARGE_BACKEND` (`ag_rs` default | `a2a`): collective used
  above the cap — AG+RS (measured prefill winner) or the packed NCCL
  all-to-all.
- The cap also bounds the B12X IPC staging pool, which scales linearly with
  its token capacity: at `max_num_batched_tokens=8192` it reserves
  2 slots × 8192 × 32 heads × 578 × 2 B ≈ 0.6 GB per rank; at 64 tokens ≈ 5 MB.
  (Boot log: `Using B12X PCIe DCP collectives (... max_batch_size=64 ...)`.)

Implementation:

- `dcp_alltoall.py`: `_try_b12x_dcp_lse_reduce` / `_try_b12x_dcp_all_gather_heads`
  decline batches above the cap and clamp the pool `max_batch_size` to it.
  Because the clamp lives inside the `_try_*` helpers, `warmup_b12x_dcp_a2a`
  creates the pool under the same cache key with no call-site changes, and
  DSv4's direct callers inherit the cap automatically (their above-cap
  fallback is the packed NCCL A2A).
- `mla_attention.py`: forward picks per step — tokens ≤ cap → B12X A2A
  (unchanged); tokens > cap → `cp_lse_ag_out_rs` + plain `all_gather`
  (exactly the `ag_rs` code path), or NCCL A2A when
  `VLLM_DCP_A2A_LARGE_BACKEND=a2a`.

CUDA-graph safety: the branch condition is the per-step token count, so each
captured graph bakes in exactly one path (decode graphs ≤ cap capture B12X;
larger capture sizes capture AG+RS, which the `ag_rs` backend already runs
under decode graphs today), and eager/piecewise prefill re-evaluates per
step. All DCP ranks see the same batch, so the choice is uniform across the
group — no divergent-collective risk.

## Results

GLM-5.2 NVFP4, TP8/DCP4/MTP3/A16, `max_num_batched_tokens=8192`, GRAPH=128,
image `vllm02f5b41-b12xe44cb77` (2× 8 RTX PRO 6000, all runs same day,
prefill benched solo).

Standalone prefill (tok/s):

| config | 8k | 64k |
|---|---:|---:|
| pure a2a | 2466 | 2491 |
| pure ag_rs | 3202 | 3236 |
| **hybrid: a2a + cap=64** | **3225 / 3209** | **3268 / 3225** (GPU 0-7 / 8-15) |

Decode ctx0 (tok/s), CC×MTP3 → tokens/step; hybrid and ag_rs on the same
GPUs 0-7:

| tokens/step | 4 | 8 | 16 | 32 | 64 | 128 |
|---|---:|---:|---:|---:|---:|---:|
| hybrid cap=64 | **102.5** | **158.9** | **303.7** | **463.4** | 678.6 | 1025.7 |
| pure ag_rs | 94.0 | 153.2 | 286.7 | 449.0 | 678.9 | 1013.2 |
| pure a2a (GPU 8-15) | 101.2 | 164.9 | 300.8 | 456.5 | 662.5 | 957.8 |

- Prefill: +30 % vs pure a2a, equal to ag_rs → the DCP4 prefill regression is gone.
- Decode ≤ 32 tokens/step: +3-9 % over ag_rs (identical to the pure-a2a B12X path).
- The B12X advantage crosses zero **exactly at 64 tokens/step** (678.6 vs
  678.9), and at 128 the hybrid rides the AG+RS graphs (1025.7 ≈ ag_rs
  1013.2, +7 % over pure a2a). `cap=64` sits right on the measured crossover.

Correctness: `test.py` c0 / c3000 / c30000 → CJK 0 (exercises B12X decode
graphs, eager AG+RS chunked prefill, and the transition between them).

## Tests

`tests/distributed/test_dcp_a2a.py`: two new no-dist unit tests
(`test_b12x_lse_reduce_honors_token_cap`, `test_b12x_query_gather_honors_token_cap`)
— the cap declines oversized batches and clamps the staging pool size.
File status in the image container: 31 passed, 1 pre-existing environment
failure (`test_a2a_with_dcp_valid` asserts a TP4 config with 1 visible GPU),
5 distributed tests deselected.

## Suggested rollout

- Helper/compose: keep `DCP_BACKEND=a2a` and add `VLLM_DCP_A2A_MAX_TOKENS=64`
  (64 = measured crossover; anything in 32-128 is sane).
- `DCP=1` unchanged (backend n/a). Default `0` keeps current behavior for
  anyone not opted in.
- Longer term the same crossover should probably live *inside* a future
  pipelined/CE-driven B12X DCP exchange (pcie_twoshot direction); this env
  gives the policy a home until the kernel exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
