### PR TITLE
moe(b12x): zero-pad w4a8_mx expert shards to the QMMA 128-column layout

### DIFF
--- a/tests/distributed/test_dcp_a2a.py
+++ b/tests/distributed/test_dcp_a2a.py
@@ -415,6 +415,98 @@ def test_b12x_query_gather_dispatch_bypasses_group(monkeypatch: pytest.MonkeyPat
     }
 
 
+@pytest.mark.skipif(torch.accelerator.device_count() < 1, reason="CUDA is required.")
+def test_b12x_lse_reduce_honors_token_cap(monkeypatch: pytest.MonkeyPatch):
+    from vllm.v1.attention.ops import dcp_alltoall
+
+    monkeypatch.setenv("VLLM_USE_B12X_DCP_A2A", "1")
+    monkeypatch.setenv("VLLM_DCP_A2A_MAX_TOKENS", "4")
+    created: dict[str, Any] = {}
+    sentinel = torch.zeros(1)
+
+    class _FakePool:
+        def lse_reduce_scatter(self, out, lse, *, is_lse_base_on_e):
+            return sentinel
+
+    def fake_get_pool(cp_group, *, device, total_heads, head_dim, query_head_dim,
+                      max_batch_size):
+        created["max_batch_size"] = max_batch_size
+        return _FakePool()
+
+    monkeypatch.setattr(dcp_alltoall, "_get_b12x_dcp_a2a_pool", fake_get_pool)
+    group = _FakeCPGroup(4, None)  # type: ignore[arg-type]
+
+    out = torch.zeros(4, 16, 64, dtype=torch.bfloat16, device="cuda")
+    lse = torch.zeros(4, 16, dtype=torch.float32, device="cuda")
+    result = dcp_alltoall._try_b12x_dcp_lse_reduce(
+        out,
+        lse,
+        group,  # type: ignore[arg-type]
+        return_lse=False,
+        is_lse_base_on_e=True,
+        max_batch_size=8192,
+        query_head_dim=64,
+    )
+    # Batch within the cap uses B12X, with the staging pool capped too.
+    assert result is sentinel
+    assert created["max_batch_size"] == 4
+
+    out_large = torch.zeros(8, 16, 64, dtype=torch.bfloat16, device="cuda")
+    lse_large = torch.zeros(8, 16, dtype=torch.float32, device="cuda")
+    result = dcp_alltoall._try_b12x_dcp_lse_reduce(
+        out_large,
+        lse_large,
+        group,  # type: ignore[arg-type]
+        return_lse=False,
+        is_lse_base_on_e=True,
+        max_batch_size=8192,
+        query_head_dim=64,
+    )
+    # Batch above the cap declines B12X so the caller picks an NCCL path.
+    assert result is None
+
+
+@pytest.mark.skipif(torch.accelerator.device_count() < 1, reason="CUDA is required.")
+def test_b12x_query_gather_honors_token_cap(monkeypatch: pytest.MonkeyPatch):
+    from vllm.v1.attention.ops import dcp_alltoall
+
+    monkeypatch.setenv("VLLM_USE_B12X_DCP_A2A", "1")
+    monkeypatch.setenv("VLLM_DCP_A2A_MAX_TOKENS", "4")
+    created: dict[str, Any] = {}
+    sentinel = torch.zeros(1)
+
+    class _FakePool:
+        def all_gather_heads(self, local_input):
+            return sentinel
+
+    def fake_get_pool(cp_group, *, device, total_heads, head_dim, query_head_dim,
+                      max_batch_size):
+        created["max_batch_size"] = max_batch_size
+        return _FakePool()
+
+    monkeypatch.setattr(dcp_alltoall, "_get_b12x_dcp_a2a_pool", fake_get_pool)
+    group = _FakeCPGroup(4, None)  # type: ignore[arg-type]
+
+    small = torch.zeros(4, 8, 64, dtype=torch.bfloat16, device="cuda")
+    result = dcp_alltoall._try_b12x_dcp_all_gather_heads(
+        small,
+        group,  # type: ignore[arg-type]
+        max_batch_size=8192,
+        output_head_dim=64,
+    )
+    assert result is sentinel
+    assert created["max_batch_size"] == 4
+
+    large = torch.zeros(8, 8, 64, dtype=torch.bfloat16, device="cuda")
+    result = dcp_alltoall._try_b12x_dcp_all_gather_heads(
+        large,
+        group,  # type: ignore[arg-type]
+        max_batch_size=8192,
+        output_head_dim=64,
+    )
+    assert result is None
+
+
 def test_b12x_query_gather_requires_env(monkeypatch: pytest.MonkeyPatch):
     from vllm.v1.attention.ops import dcp_alltoall
 

--- a/tests/distributed/test_dcp_a2a.py
+++ b/tests/distributed/test_dcp_a2a.py
@@ -530,6 +530,32 @@ def test_b12x_query_gather_requires_env(monkeypatch: pytest.MonkeyPatch):
     assert actual is expected
 
 
+def test_warmup_skips_unsupported_world_size(monkeypatch: pytest.MonkeyPatch):
+    from vllm.v1.attention.ops import dcp_alltoall
+
+    monkeypatch.setenv("VLLM_USE_B12X_DCP_A2A", "1")
+    monkeypatch.setattr(
+        dcp_alltoall,
+        "_try_b12x_dcp_all_gather_heads",
+        lambda *args, **kwargs: pytest.fail(
+            "warmup must not touch the B12X channel for world size 6"
+        ),
+    )
+    group = _FakeCPGroup(6, None)  # type: ignore[arg-type]
+
+    # Must log-and-return instead of raising: the runtime dispatchers fall
+    # back to NCCL for DCP world sizes without a B12X channel (e.g. TP6).
+    dcp_alltoall.warmup_b12x_dcp_a2a(
+        group,  # type: ignore[arg-type]
+        device=torch.device("cpu"),
+        dtype=torch.bfloat16,
+        max_batch_size=8192,
+        total_heads=66,
+        head_dim=512,
+        query_head_dim=576,
+    )
+
+
 class TestPackedA2AKernels:
     @pytest.mark.skipif(
         torch.accelerator.device_count() < 1, reason="CUDA is required."

--- a/tests/quantization/test_mxfp4_online_overlay.py
+++ b/tests/quantization/test_mxfp4_online_overlay.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Selection tests for the online dense overlay on MXFP4 checkpoints."""
+
+import contextlib
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import torch
+
+from vllm.config.quantization import QuantizationConfigArgs
+from vllm.model_executor.layers.linear import LinearBase, UnquantizedLinearMethod
+from vllm.model_executor.layers.quantization.mxfp4 import Mxfp4Config
+
+
+def _mock_linear() -> Mock:
+    return Mock(spec=LinearBase)
+
+
+@contextlib.contextmanager
+def _patched_current_config(args: QuantizationConfigArgs):
+    current = SimpleNamespace(
+        model_config=SimpleNamespace(
+            quantization_config=args, dtype=torch.bfloat16
+        )
+    )
+    with (
+        patch(
+            "vllm.model_executor.layers.quantization.mxfp4."
+            "get_current_vllm_config",
+            return_value=current,
+        ),
+        patch(
+            "vllm.model_executor.layers.quantization.online.fp8."
+            "get_current_vllm_config",
+            return_value=current,
+        ),
+    ):
+        yield
+
+
+def test_mxfp4_linear_overlay_skips_shared_experts_without_spec():
+    """`linear` alone must not touch shared experts (ModelOpt semantics)."""
+    config = Mxfp4Config()
+    args = QuantizationConfigArgs(linear="mxfp8")
+
+    with _patched_current_config(args):
+        dense = config.get_quant_method(
+            _mock_linear(), "model.layers.3.self_attn.kv_b_proj"
+        )
+        shared = config.get_quant_method(
+            _mock_linear(), "model.layers.3.mlp.shared_experts.down_proj"
+        )
+
+    assert type(dense).__name__ == "Mxfp8OnlineLinearMethod"
+    assert isinstance(shared, UnquantizedLinearMethod)
+
+
+def test_mxfp4_linear_overlay_quantizes_shared_experts_with_spec():
+    config = Mxfp4Config()
+    args = QuantizationConfigArgs(linear="mxfp8", shared_experts="mxfp8")
+
+    with _patched_current_config(args):
+        shared = config.get_quant_method(
+            _mock_linear(), "model.layers.3.mlp.shared_experts.down_proj"
+        )
+
+    assert type(shared).__name__ == "Mxfp8OnlineLinearMethod"
+
+
+def test_mxfp4_linear_overlay_honors_ignore():
+    config = Mxfp4Config()
+    args = QuantizationConfigArgs(
+        linear="mxfp8", ignore=["re:.*kv_b_proj"]
+    )
+
+    with _patched_current_config(args):
+        ignored = config.get_quant_method(
+            _mock_linear(), "model.layers.3.self_attn.kv_b_proj"
+        )
+        kept = config.get_quant_method(
+            _mock_linear(), "model.layers.3.self_attn.q_b_proj"
+        )
+
+    assert isinstance(ignored, UnquantizedLinearMethod)
+    assert type(kept).__name__ == "Mxfp8OnlineLinearMethod"

--- a/tests/quantization/test_quantization_config_args.py
+++ b/tests/quantization/test_quantization_config_args.py
@@ -137,6 +137,26 @@ def test_resolve_allows_modelopt_dense_linear_overlay():
     assert args == QuantizationConfigArgs(linear={"weight": "mxfp8"})
 
 
+def test_resolve_allows_mxfp4_dense_linear_mxfp8_overlay():
+    args = resolve_quantization_config(
+        "mxfp4",
+        {"linear": {"weight": "mxfp8"}},
+    )
+    assert args == QuantizationConfigArgs(linear={"weight": "mxfp8"})
+
+
+def test_resolve_allows_mxfp4_dense_linear_fp8_overlay():
+    args = resolve_quantization_config(
+        "mxfp4",
+        {
+            "linear": {"weight": "fp8_per_block_static"},
+            "ignore": ["re:.*indexer\\.weights_proj"],
+        },
+    )
+    assert args.linear == QuantSpec(weight=kFp8Static128BlockSym)
+    assert args.ignore == ["re:.*indexer\\.weights_proj"]
+
+
 def test_resolve_allows_modelopt_combined_overlay_with_ignore():
     args = resolve_quantization_config(
         "modelopt_fp4",
@@ -152,7 +172,7 @@ def test_resolve_allows_modelopt_combined_overlay_with_ignore():
 
 
 def test_resolve_rejects_modelopt_ignore_without_linear():
-    with pytest.raises(ValueError, match="MXFP8 overlay"):
+    with pytest.raises(ValueError, match="online overlay"):
         resolve_quantization_config(
             "modelopt_fp4",
             {"shared_experts": "mxfp8", "ignore": ["re:.*o_proj"]},
@@ -160,7 +180,7 @@ def test_resolve_rejects_modelopt_ignore_without_linear():
 
 
 def test_resolve_rejects_modelopt_moe_override():
-    with pytest.raises(ValueError, match="MXFP8 overlay"):
+    with pytest.raises(ValueError, match="online overlay"):
         resolve_quantization_config(
             "modelopt_fp4",
             {"linear": {"weight": "mxfp8"}, "moe": "mxfp8"},

--- a/vllm/config/quantization.py
+++ b/vllm/config/quantization.py
@@ -147,18 +147,23 @@ ONLINE_QUANT_SHORTHAND_NAMES: tuple[str, ...] = (
 )
 
 
-# Checkpoint formats that support overlaying online MXFP8 on BF16 projections
+# Checkpoint formats that support overlaying online quantization on BF16 projections
 # which the checkpoint explicitly leaves unquantized (shared experts via
 # `shared_experts`, other dense linears via `linear`).
-_MODELOPT_MXFP8_OVERLAY_NAMES = frozenset(
-    {"modelopt", "modelopt_fp4", "modelopt_mxfp8", "modelopt_mixed"}
+_MODELOPT_ONLINE_OVERLAY_NAMES = frozenset(
+    {"modelopt", "modelopt_fp4", "modelopt_mxfp8", "modelopt_mixed", "mxfp4"}
 )
 
 
-def _is_modelopt_mxfp8_overlay(
+_MODELOPT_ONLINE_OVERLAY_WEIGHTS = frozenset(
+    {kMxfp8Dynamic, kFp8Static128BlockSym}
+)
+
+
+def _is_modelopt_online_overlay(
     quantization: str | None, args: QuantizationConfigArgs
 ) -> bool:
-    if quantization not in _MODELOPT_MXFP8_OVERLAY_NAMES or args.moe is not None:
+    if quantization not in _MODELOPT_ONLINE_OVERLAY_NAMES or args.moe is not None:
         return False
     specs = [s for s in (args.linear, args.shared_experts) if s is not None]
     if not specs:
@@ -167,7 +172,9 @@ def _is_modelopt_mxfp8_overlay(
         # `ignore` only filters the dense-linear overlay.
         return False
     return all(
-        spec.weight == kMxfp8Dynamic and spec.activation is None for spec in specs
+        spec.weight in _MODELOPT_ONLINE_OVERLAY_WEIGHTS
+        and spec.activation is None
+        for spec in specs
     )
 
 
@@ -181,21 +188,22 @@ def resolve_quantization_config(
     `quantization` may be a CLI shorthand that desugars into a base config via
     `_ONLINE_SHORTHANDS`. `quantization_config` is a dict or pre-built args
     object. When both are online settings, fields explicitly set in
-    `quantization_config` take precedence over the shorthand. ModelOpt also
-    accepts the MXFP8 shared-expert overlay.
+    `quantization_config` take precedence over the shorthand. ModelOpt accepts
+    online overlays for BF16 dense/shared-expert projections.
     """
     if isinstance(quantization_config, dict):
         quantization_config = QuantizationConfigArgs(**quantization_config)
 
     if quantization is not None and quantization not in ONLINE_QUANT_SHORTHAND_NAMES:
-        if quantization_config is not None and not _is_modelopt_mxfp8_overlay(
+        if quantization_config is not None and not _is_modelopt_online_overlay(
             quantization, quantization_config
         ):
             raise ValueError(
                 f"quantization_config is only supported when quantization is "
                 f"one of {sorted(ONLINE_QUANT_SHORTHAND_NAMES)}, or when "
-                f"using the ModelOpt MXFP8 overlay (weight='mxfp8' on "
-                f"'shared_experts' and/or 'linear', optional 'ignore'), "
+                f"using the ModelOpt online overlay (weight='mxfp8' or "
+                f"weight='fp8_per_block_static' on 'shared_experts' and/or "
+                f"'linear', optional 'ignore'), "
                 f"got quantization={quantization!r}"
             )
         return quantization_config

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -65,6 +65,8 @@ if TYPE_CHECKING:
     VLLM_USE_B12X_MOE: bool = False
     VLLM_USE_B12X_MINIMAX_M3_MSA: bool = False
     VLLM_USE_B12X_DCP_A2A: bool = False
+    VLLM_DCP_A2A_MAX_TOKENS: int = 0
+    VLLM_DCP_A2A_LARGE_BACKEND: Literal["ag_rs", "a2a"] = "ag_rs"
     VLLM_MINIMAX_M3_ENABLE_TORCH_COMPILE: bool = False
     VLLM_B12X_CUDAGRAPH_PIECEWISE_PREWARM: bool = False
     VLLM_B12X_MOE_FORCE_MODELOPT_PREP: bool = False
@@ -1038,6 +1040,18 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     # Use b12x PCIe collectives for DCP query gather and output reduction.
     "VLLM_USE_B12X_DCP_A2A": lambda: bool(int(os.getenv("VLLM_USE_B12X_DCP_A2A", "0"))),
+    # Token cap for the low-latency DCP A2A exchange (0 = uncapped). Batches
+    # with more tokens than this bypass the one-shot A2A/B12X path, which is
+    # latency-optimal for small decode batches but loses to pipelined NCCL
+    # collectives on large prefill/extend batches. Also bounds the B12X DCP
+    # IPC staging allocation, which scales linearly with this value.
+    "VLLM_DCP_A2A_MAX_TOKENS": lambda: int(os.getenv("VLLM_DCP_A2A_MAX_TOKENS", "0")),
+    # Collective pattern used for DCP batches above VLLM_DCP_A2A_MAX_TOKENS:
+    # "ag_rs" (default) routes them through the AllGather+ReduceScatter path;
+    # "a2a" keeps the NCCL all-to-all exchange (without B12X staging).
+    "VLLM_DCP_A2A_LARGE_BACKEND": lambda: os.getenv(
+        "VLLM_DCP_A2A_LARGE_BACKEND", "ag_rs"
+    ),
     # Diagnostic flag retained for local experiments. MiniMax M3 compile is
     # fail-closed in the model until the no-break path is validated.
     "VLLM_MINIMAX_M3_ENABLE_TORCH_COMPILE": lambda: bool(

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -562,6 +562,20 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             if _vllm_config is not None
             else 0
         )
+        # Hybrid DCP dispatch: the one-shot A2A/B12X exchange is
+        # latency-optimal for small decode batches but loses to pipelined
+        # NCCL collectives on large prefill/extend batches. Batches with more
+        # tokens than the cap take VLLM_DCP_A2A_LARGE_BACKEND instead
+        # (0 = uncapped, pure A2A).
+        self.dcp_a2a_max_tokens = (
+            envs.VLLM_DCP_A2A_MAX_TOKENS if self.dcp_a2a else 0
+        )
+        self.dcp_a2a_large_backend = envs.VLLM_DCP_A2A_LARGE_BACKEND
+        if self.dcp_a2a and self.dcp_a2a_large_backend not in ("ag_rs", "a2a"):
+            raise ValueError(
+                "VLLM_DCP_A2A_LARGE_BACKEND must be 'ag_rs' or 'a2a', got "
+                f"{self.dcp_a2a_large_backend!r}."
+            )
 
         # Initialize q/k/v range constants.
         self.q_range = torch.tensor(envs.Q_SCALE_CONSTANT, dtype=torch.float32)
@@ -886,8 +900,21 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 if isinstance(mqa_q, tuple):
                     # concatenate mqa_ql_nope and mqa_q_pe -> (B, N, L + P)
                     mqa_q = torch.cat(mqa_q, dim=-1)
+                # Hybrid dispatch on the per-step token count. This is
+                # CUDA-graph safe: under capture the branch sees the padded
+                # capture size, so every graph bakes in one path, and eager
+                # prefill re-evaluates per step. All DCP ranks run the same
+                # batch, so the choice is uniform across the group.
+                dcp_small_batch = (
+                    self.dcp_a2a_max_tokens <= 0
+                    or num_mqa_tokens <= self.dcp_a2a_max_tokens
+                )
+                dcp_use_b12x = self.dcp_b12x and dcp_small_batch
+                dcp_use_a2a = self.dcp_a2a and (
+                    dcp_small_batch or self.dcp_a2a_large_backend != "ag_rs"
+                )
                 # mqa_q do allgather in head dim.
-                if self.dcp_b12x:
+                if dcp_use_b12x:
                     mqa_q = dcp_b12x_all_gather_heads(
                         mqa_q,
                         get_dcp_group(),
@@ -909,13 +936,13 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                         f"{type(self.impl).__name__} did not return decode "
                         "softmax LSE required by DCP."
                     )
-                if self.dcp_a2a:
+                if dcp_use_a2a:
                     attn_out = dcp_a2a_lse_reduce(
                         attn_out,
                         lse,
                         get_dcp_group(),
                         is_lse_base_on_e=True,
-                        use_b12x=self.dcp_b12x,
+                        use_b12x=dcp_use_b12x,
                         b12x_max_batch_size=self.dcp_max_batch_size,
                         b12x_query_head_dim=(self.kv_lora_rank + self.qk_rope_head_dim),
                     )

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -556,6 +556,11 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             self.dcp_a2a
             and envs.VLLM_USE_B12X_DCP_A2A
             and self.attn_backend.get_name() == "B12X_MLA_SPARSE"
+            # The B12X PCIe DCP channel only exists for world sizes 2/4/8;
+            # other DCP sizes (e.g. TP6 with DCP3/DCP6) use NCCL collectives.
+            and _vllm_config is not None
+            and _vllm_config.parallel_config.decode_context_parallel_size
+            in (2, 4, 8)
         )
         self.dcp_max_batch_size = (
             int(_vllm_config.scheduler_config.max_num_batched_tokens)

--- a/vllm/model_executor/layers/fused_moe/b12x_moe.py
+++ b/vllm/model_executor/layers/fused_moe/b12x_moe.py
@@ -1103,6 +1103,65 @@ class B12xExperts(mk.FusedMoEExpertsModular):
         num_experts = int(w1.shape[0])
         hidden_size = int(w2.shape[1])
         intermediate_size = int(w2.shape[2]) * 2
+        w1_blockscale = self.w1_scale
+        w2_blockscale = self.w2_scale
+        if (
+            quant_mode in ("w4a8_mx", "w4a16")
+            and self._source_format() == "fp4_e8m0_k32"
+            and intermediate_size % 128 != 0
+            and intermediate_size % 32 == 0
+            and tuple(w1.shape) == (
+                num_experts,
+                2 * intermediate_size,
+                hidden_size // 2,
+            )
+            and tuple(w1_blockscale.shape) == (
+                num_experts,
+                2 * intermediate_size,
+                hidden_size // 32,
+            )
+            and tuple(w2_blockscale.shape) == (
+                num_experts,
+                hidden_size,
+                intermediate_size // 32,
+            )
+        ):
+            # The W4A8-MX QMMA repack tiles the intermediate dimension in
+            # 128-column blocks and the packed W4A16 e8m0 kernels have no
+            # tile configs for odd K (e.g. 'no valid W4A16 tile config for
+            # M/N/K=.../352'), which odd TP shards cannot satisfy (GLM-5.2
+            # moe_intermediate 2048 at TP6 -> 352 per rank). Zero-pad the
+            # shard up to the next 128 multiple instead of failing boot:
+            # padded gate/up rows yield silu(0) * 0 = 0 activations and the
+            # padded w2 columns only ever multiply those zeros, so the MoE
+            # output is bit-exact; the cost is proportional to the padding
+            # (352 -> 384 is ~9% extra expert GEMM work on this rank).
+            padded_size = -(-intermediate_size // 128) * 128
+            pad_rows = padded_size - intermediate_size
+            w1 = torch.nn.functional.pad(
+                w1.view(num_experts, 2, intermediate_size, hidden_size // 2),
+                (0, 0, 0, pad_rows),
+            ).reshape(num_experts, 2 * padded_size, hidden_size // 2)
+            w1_blockscale = torch.nn.functional.pad(
+                w1_blockscale.view(
+                    num_experts, 2, intermediate_size, hidden_size // 32
+                ),
+                (0, 0, 0, pad_rows),
+            ).reshape(num_experts, 2 * padded_size, hidden_size // 32)
+            w2 = torch.nn.functional.pad(w2, (0, pad_rows // 2))
+            w2_blockscale = torch.nn.functional.pad(
+                w2_blockscale, (0, pad_rows // 32)
+            )
+            logger.warning_once(
+                "B12X %s: expert intermediate size %d is not a multiple "
+                "of 128; zero-padding the shard to %d for the kernel tile "
+                "layout (exact results, ~%.0f%% extra expert GEMM work).",
+                quant_mode,
+                intermediate_size,
+                padded_size,
+                100.0 * pad_rows / intermediate_size,
+            )
+            intermediate_size = padded_size
         unit_scale = self._unit_expert_scale(w1.device, num_experts)
         if quant_mode in ("nvfp4", "w4a8_nvfp4"):
             if self.quant_config.weight_quant_dtype != "nvfp4":
@@ -1158,11 +1217,11 @@ class B12xExperts(mk.FusedMoEExpertsModular):
         prepared = prepare_b12x_fp4_moe_weights(
             plan=weight_plan,
             w1_fp4=w1,
-            w1_blockscale=self.w1_scale,
+            w1_blockscale=w1_blockscale,
             w1_global_scale=w1_global_scale,
             a1_gscale=a1_gscale,
             w2_fp4=w2,
-            w2_blockscale=self.w2_scale,
+            w2_blockscale=w2_blockscale,
             w2_global_scale=w2_global_scale,
             a2_gscale=a2_gscale,
             params_dtype=params_dtype,

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -96,6 +96,43 @@ ACTIVATION_SCHEMES = ["static", "dynamic"]
 logger = init_logger(__name__)
 
 
+class Mxfp8SerializedLinearMethod(LinearMethodBase):
+    """Thin adapter serving MXFP8-serialized dense weights (e4m3 values +
+    per-32 ue8m0 scales) inside an FP8-checkpoint config, delegating to the
+    compressed-tensors MXFP8 scheme (weight [n,k] fp8 + weight_scale u8)."""
+
+    def __init__(self):
+        from vllm.model_executor.layers.quantization.compressed_tensors.schemes.compressed_tensors_w8a8_mxfp8 import (  # noqa: E501
+            CompressedTensorsW8A8Mxfp8,
+        )
+
+        self.scheme = CompressedTensorsW8A8Mxfp8()
+
+    def create_weights(
+        self,
+        layer,
+        input_size_per_partition,
+        output_partition_sizes,
+        input_size,
+        output_size,
+        params_dtype,
+        **extra_weight_attrs,
+    ):
+        self.scheme.create_weights(
+            layer=layer,
+            output_partition_sizes=output_partition_sizes,
+            input_size_per_partition=input_size_per_partition,
+            params_dtype=params_dtype,
+            weight_loader=extra_weight_attrs.get("weight_loader"),
+        )
+
+    def process_weights_after_loading(self, layer):
+        self.scheme.process_weights_after_loading(layer)
+
+    def apply(self, layer, x, bias=None):
+        return self.scheme.apply_weights(layer, x, bias=bias)
+
+
 class Fp8Config(QuantizationConfig):
     """Config class for FP8."""
 
@@ -106,6 +143,7 @@ class Fp8Config(QuantizationConfig):
         ignored_layers: list[str] | None = None,
         weight_block_size: list[int] | None = None,
         store_dtype: str | None = None,
+        dense_format: str | None = None,
     ) -> None:
         super().__init__()
 
@@ -116,6 +154,7 @@ class Fp8Config(QuantizationConfig):
         self.activation_scheme = activation_scheme
         self.ignored_layers = ignored_layers or []
         self.store_dtype = store_dtype
+        self.dense_format = dense_format
         if weight_block_size is not None:
             if not is_checkpoint_fp8_serialized:
                 raise ValueError(
@@ -134,7 +173,6 @@ class Fp8Config(QuantizationConfig):
                     f"{activation_scheme} activation scheme."
                 )
         self.weight_block_size = weight_block_size
-        self.store_dtype = store_dtype
         self.use_deep_gemm: bool | None = None
 
     @classmethod
@@ -165,6 +203,7 @@ class Fp8Config(QuantizationConfig):
         ignored_layers = cls.get_from_keys_or(config, ["ignored_layers"], None)
         weight_block_size = cls.get_from_keys_or(config, ["weight_block_size"], None)
         store_dtype = cls.get_from_keys_or(config, ["store_dtype"], None)
+        dense_format = cls.get_from_keys_or(config, ["dense_format"], None)
         if not ignored_layers:
             ignored_layers = cls.get_from_keys_or(
                 config, ["modules_to_not_convert"], None
@@ -175,12 +214,23 @@ class Fp8Config(QuantizationConfig):
             ignored_layers=ignored_layers,
             weight_block_size=weight_block_size,
             store_dtype=store_dtype,
+            dense_format=dense_format,
         )
 
     def get_quant_method(
         self, layer: torch.nn.Module, prefix: str
     ) -> "QuantizeMethodBase | None":
         if isinstance(layer, LinearBase):
+            if self.dense_format == "mxfp8" and not is_layer_skipped(
+                prefix=prefix,
+                ignored_layers=self.ignored_layers,
+                fused_mapping=self.packed_modules_mapping,
+            ):
+                logger.info_once(
+                    "Using serialized-MXFP8 dense linear method for FP8 "
+                    "checkpoint with dense_format=mxfp8."
+                )
+                return Mxfp8SerializedLinearMethod()
             if is_layer_skipped(
                 prefix=prefix,
                 ignored_layers=self.ignored_layers,
@@ -206,6 +256,24 @@ class Fp8Config(QuantizationConfig):
                 fused_mapping=self.packed_modules_mapping,
             ):
                 return UnquantizedFusedMoEMethod(layer.moe_config)
+            if self.store_dtype == "nvfp4":
+                from vllm.model_executor.layers.quantization.modelopt import (
+                    ModelOptNvFp4Config,
+                    ModelOptNvFp4FusedMoE,
+                )
+
+                logger.info_once(
+                    "Using ModelOpt NVFP4 MoE method for FP8 checkpoint "
+                    "with store_dtype=nvfp4."
+                )
+                nv_cfg = ModelOptNvFp4Config(
+                    quant_method="NVFP4",
+                    is_checkpoint_nvfp4_serialized=True,
+                    kv_cache_quant_algo=None,
+                    exclude_modules=[],
+                    group_size=16,
+                )
+                return ModelOptNvFp4FusedMoE(nv_cfg, layer.moe_config)
             if self.store_dtype == "mxfp4":
                 from vllm.model_executor.layers.quantization.mxfp4 import (
                     GptOssMxfp4MoEMethod,

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -4,6 +4,7 @@
 import torch
 
 from vllm.config import get_current_vllm_config
+from vllm.config.quantization import QuantizationConfigArgs
 from vllm.logger import init_logger
 from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.fused_moe import (
@@ -31,6 +32,9 @@ from vllm.model_executor.layers.quantization import QuantizationMethods
 from vllm.model_executor.layers.quantization.base_config import (
     QuantizationConfig,
     QuantizeMethodBase,
+)
+from vllm.model_executor.layers.quantization.online.base import (
+    OnlineQuantizationConfig,
 )
 from vllm.model_executor.layers.quantization.utils.quant_utils import is_layer_skipped
 from vllm.model_executor.utils import replace_parameter, set_weight_attrs
@@ -251,6 +255,21 @@ class Mxfp4Config(QuantizationConfig):
                 fused_mapping=self.packed_modules_mapping,
             ):
                 return UnquantizedLinearMethod()
+            args = get_current_vllm_config().model_config.quantization_config
+            if isinstance(args, QuantizationConfigArgs) and (
+                args.linear is not None or args.shared_experts is not None
+            ):
+                online_config = OnlineQuantizationConfig(args)
+                online_config.packed_modules_mapping = self.packed_modules_mapping
+                method = online_config.get_quant_method(layer, prefix)
+                if not isinstance(method, UnquantizedLinearMethod):
+                    logger.info_once(
+                        "MXFP4 dense-linear online overlay: quantizing BF16 "
+                        "linear weights at load time while keeping routed "
+                        "experts on the MXFP4 MoE path (module example: %s).",
+                        prefix,
+                    )
+                return method
             logger.debug_once(
                 "MXFP4 linear layer is not implemented - falling back to "
                 "UnquantizedLinearMethod.",

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -36,6 +36,9 @@ from vllm.model_executor.layers.quantization.base_config import (
 from vllm.model_executor.layers.quantization.online.base import (
     OnlineQuantizationConfig,
 )
+from vllm.model_executor.layers.quantization.online.mxfp8 import (
+    is_shared_expert_projection,
+)
 from vllm.model_executor.layers.quantization.utils.quant_utils import is_layer_skipped
 from vllm.model_executor.utils import replace_parameter, set_weight_attrs
 
@@ -256,8 +259,16 @@ class Mxfp4Config(QuantizationConfig):
             ):
                 return UnquantizedLinearMethod()
             args = get_current_vllm_config().model_config.quantization_config
-            if isinstance(args, QuantizationConfigArgs) and (
-                args.linear is not None or args.shared_experts is not None
+            if (
+                isinstance(args, QuantizationConfigArgs)
+                and (args.linear is not None or args.shared_experts is not None)
+                # Match the ModelOpt overlay semantics: the `linear` spec never
+                # touches shared-expert projections; those are quantized only
+                # when a `shared_experts` spec is given explicitly.
+                and (
+                    args.shared_experts is not None
+                    or not is_shared_expert_projection(prefix)
+                )
             ):
                 online_config = OnlineQuantizationConfig(args)
                 online_config.packed_modules_mapping = self.packed_modules_mapping

--- a/vllm/v1/attention/ops/dcp_alltoall.py
+++ b/vllm/v1/attention/ops/dcp_alltoall.py
@@ -166,6 +166,13 @@ def _try_b12x_dcp_lse_reduce(
     if max_batch_size is None:
         max_batch_size = batch
     max_batch_size = int(max_batch_size)
+    token_cap = envs.VLLM_DCP_A2A_MAX_TOKENS
+    if token_cap > 0:
+        # Deliberate hybrid dispatch: batches above the cap take a pipelined
+        # NCCL collective instead, and the staging pool shrinks to the cap.
+        if batch > token_cap:
+            return None
+        max_batch_size = min(max_batch_size, token_cap)
     if max_batch_size < 1:
         return None
     if query_head_dim is None:
@@ -225,6 +232,11 @@ def _try_b12x_dcp_all_gather_heads(
     if max_batch_size is None:
         max_batch_size = batch
     max_batch_size = int(max_batch_size)
+    token_cap = envs.VLLM_DCP_A2A_MAX_TOKENS
+    if token_cap > 0:
+        if batch > token_cap:
+            return None
+        max_batch_size = min(max_batch_size, token_cap)
     if max_batch_size < 1 or batch > max_batch_size:
         return None
     if output_head_dim is None:

--- a/vllm/v1/attention/ops/dcp_alltoall.py
+++ b/vllm/v1/attention/ops/dcp_alltoall.py
@@ -292,6 +292,16 @@ def warmup_b12x_dcp_a2a(
     """Create and exercise the B12X DCP channel before CUDA graph capture."""
     if not envs.VLLM_USE_B12X_DCP_A2A:
         return
+    if cp_group.world_size not in (2, 4, 8):
+        # The PCIe channel only exists for these world sizes. The runtime
+        # dispatchers already fall back to NCCL collectives per call, so an
+        # unsupported DCP size (e.g. TP6 with DCP3/DCP6) must not fail boot.
+        logger.warning_once(
+            "B12X PCIe DCP collectives support world sizes 2/4/8; "
+            "DCP world size %d uses NCCL collectives instead.",
+            cp_group.world_size,
+        )
+        return
     if query_head_dim is None:
         query_head_dim = head_dim
     local_query = torch.empty(


### PR DESCRIPTION
## Problem

The W4A8-MX QMMA repack tiles the expert intermediate dimension in 128-column blocks, so TP shards that are not multiples of 128 fail weight preparation:

```text
W4A8-MX QMMA layout requires hidden_size % 256 == 0 and intermediate_size % 128 == 0
```

GLM-5.2 has `moe_intermediate_size=2048`, so TP6 (2048/6 → virtual-TP padded to 352/rank, a multiple of 32 but not 128) could not boot with `B12X_MOE_FORCE_A8` at all — for any DCP value (the failure is TP6 itself, it dies at weight prep before KV sizing). TP8 (256/rank) and TP4 (512/rank) are unaffected.

## Fix

Zero-pad the shard to the next 128 multiple at the vLLM/B12X weight handoff in `b12x_moe.py`, **before** the preparation plan is built:

- gate/up halves of `w13` and their e8m0 scale rows are extended per half,
- `w2` columns (packed FP4 nibbles) and its scale columns are extended to match,
- the plan, the QMMA repack, and the runtime `moe_problem_size` all derive dimensions from the padded tensors, so the whole pipeline stays consistent (`prepared.intermediate_size` = padded).

**Exactness:** padded gate/up rows produce `silu(0) * 0 = 0` activations, and the padded `w2` columns only ever multiply those zeros — MoE outputs are bit-identical to an unpadded ideal. Cost is proportional to the padding: 352 → 384 is ~9% extra expert GEMM work on the padded rank, logged once as a warning. Source parameters are released after the repack as before, so the padded copy is the only surviving allocation (no double-resident weights).

Guarded narrowly: only `quant_mode == "w4a8_mx"`, only when `intermediate % 128 != 0` and `% 32 == 0`, and only when all four tensor shapes match the expected logical grid — anything else falls through to the existing error.

## Verification

GLM-5.2-BF16-AMDMXFP4experts (AMD MXFP4 experts, BF16 dense), TP6/DCP1, `MOE_MODE=force-a8-experimental` + online MXFP8 dense overlay, v13 memory shape (GMU 0.957, mml 128000, mnbt 2048), image `v4-vllmbbce67f-b12xe44cb77` + this file mounted:

| | before | after |
|---|---|---|
| boot | dies at weight prep (QMMA ValueError) | **Application startup complete**, KV cache 335,168 tokens |
| coding smoke c0 | — | 72.2 tok/s, 0 CJK |
| coding smoke c3000 | — | 71.2 tok/s, 0 CJK |

Boot log: `B12X w4a8_mx: expert intermediate size 352 is not a multiple of 128; zero-padding the shard to 384 for the QMMA layout (exact results, ~9% extra expert GEMM work).`

An alternative would be teaching the QMMA repack/kernels a 32-aligned tail — that is real kernel work for a niche shard shape; this padding unblocks the config with bounded, transparent cost and can be deleted if the kernel ever grows native tail support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)