### PR TITLE
dcp: make head-sliced attention views contiguous for the B12X PCIe pool

### DIFF
--- a/tests/distributed/test_dcp_a2a.py
+++ b/tests/distributed/test_dcp_a2a.py
@@ -507,6 +507,49 @@ def test_b12x_query_gather_honors_token_cap(monkeypatch: pytest.MonkeyPatch):
     assert result is None
 
 
+@pytest.mark.skipif(torch.accelerator.device_count() < 1, reason="CUDA is required.")
+def test_b12x_lse_reduce_makes_views_contiguous(monkeypatch: pytest.MonkeyPatch):
+    """Head-sliced attention views must reach the PCIe pool contiguous."""
+    from vllm.v1.attention.ops import dcp_alltoall
+
+    monkeypatch.setenv("VLLM_USE_B12X_DCP_A2A", "1")
+    received: dict[str, Any] = {}
+    sentinel = torch.zeros(1)
+
+    class _FakePool:
+        def lse_reduce_scatter(self, out, lse, *, is_lse_base_on_e):
+            received.update(out=out, lse=lse)
+            return sentinel
+
+    monkeypatch.setattr(
+        dcp_alltoall,
+        "_get_b12x_dcp_a2a_pool",
+        lambda *a, **k: _FakePool(),
+    )
+    group = _FakeCPGroup(4, None)  # type: ignore[arg-type]
+
+    # Simulate the GLM TP6 head66 pattern: kernel-padded buffers sliced back
+    # in the head dim produce non-contiguous views.
+    out_padded = torch.zeros(4, 24, 64, dtype=torch.bfloat16, device="cuda")
+    lse_padded = torch.zeros(4, 24, dtype=torch.float32, device="cuda")
+    out_view = out_padded[:, :16]
+    lse_view = lse_padded[:, :16]
+    assert not out_view.is_contiguous() and not lse_view.is_contiguous()
+
+    result = dcp_alltoall._try_b12x_dcp_lse_reduce(
+        out_view,
+        lse_view,
+        group,  # type: ignore[arg-type]
+        return_lse=False,
+        is_lse_base_on_e=True,
+        max_batch_size=8192,
+        query_head_dim=64,
+    )
+    assert result is sentinel
+    assert received["out"].is_contiguous()
+    assert received["lse"].is_contiguous()
+
+
 def test_b12x_query_gather_requires_env(monkeypatch: pytest.MonkeyPatch):
     from vllm.v1.attention.ops import dcp_alltoall
 

--- a/vllm/v1/attention/ops/dcp_alltoall.py
+++ b/vllm/v1/attention/ops/dcp_alltoall.py
@@ -201,6 +201,16 @@ def _try_b12x_dcp_lse_reduce(
         )
         return None
 
+    # Sparse MLA backends can return head-sliced views (e.g. GLM TP6 pads
+    # 64 -> 66 heads and slices the kernel output back), and the PCIe pool
+    # requires contiguous operands. The NCCL packers take explicit strides,
+    # so only this fast path needs the copy; LSE is tiny and the output is
+    # already contiguous on unpadded head counts.
+    if not cp_attn_out.is_contiguous():
+        cp_attn_out = cp_attn_out.contiguous()
+    if not cp_attn_lse.is_contiguous():
+        cp_attn_lse = cp_attn_lse.contiguous()
+
     return pool.lse_reduce_scatter(
         cp_attn_out,
         cp_attn_lse,


### PR DESCRIPTION
## Problem

TP6 + DCP>1 with the B12X A2A fast path dies at CUDA graph capture:

```text
ValueError: partial_lse must be contiguous
  pool.lse_reduce_scatter(cp_attn_out, cp_attn_lse, ...)   # pcie_dcp_a2a._validate
```

Root cause: GLM TP6 virtual-TP pads attention heads 64 → 66, and the B12X sparse MLA kernel pads its head dim further, returning the decode output/LSE as **head-sliced views** (`b12x_mla_sparse.py: lse = lse[:, :input_num_heads]`) — non-contiguous whenever kernel head count > input head count. TP8 shapes never hit this (counts match), which is why all DCP2/DCP4 runs to date were fine. The NCCL packers take explicit stride arguments and the query all-gather wrapper already calls `.contiguous()`; only the PCIe pool's lse-reduce entry lacked the fix-up.

## Fix

Copy the operands to contiguous in `_try_b12x_dcp_lse_reduce`, placed after the cheap reject checks so NCCL fallback paths pay nothing. The LSE copy is a tiny [B, H] fp32; the output copy only happens on padded head counts. Graph-capture safe (same in-graph allocation pattern as the packed A2A send/recv buffers).

Matches the minimal patch Martin drafted (`blackwell-llm-docker/patches/vllm-dcp-b12x-contiguous-lse-20260707.patch`) — this PR adds the placement inside the try-helper plus a unit test that simulates the sliced-view pattern and asserts the pool receives contiguous tensors (31/31 in `test_dcp_a2a.py` on the v6 image, distributed cases deselected).

## Verification

Diagnosed on TP6/MXFP4/A8/DCP2, v6 image (`vllm49bed029-b12x26144c0`): previously died at capture; E2E with this file mounted boots and serves (numbers in comment below).

Stacked on `fable/w4a8mx-qmma-pad-20260707` (#80) — the v6 image pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved distributed attention processing for head-sliced tensors.
  * Ensured partial attention outputs and LSE data are contiguous before reduction, preventing failures with non-contiguous inputs.
* **Tests**
  * Added CUDA coverage validating correct handling of non-contiguous attention tensor views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->