### PR TITLE
config: register the 'mxfp8' checkpoint alias in the override list

### DIFF
--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -993,6 +993,9 @@ class ModelConfig:
                 "modelopt",
                 "modelopt_fp4",
                 "modelopt_mxfp8",
+                # "mxfp8" aliases ModelOptMxFp8Config for MiniMax-style
+                # checkpoints, so it participates in override detection too.
+                "mxfp8",
                 "modelopt_mixed",
                 # Ensure heavy backends are probed last to avoid unnecessary
                 # imports during override detection (e.g., MXFP4 imports Triton)


### PR DESCRIPTION
## Problem

Every serialized ModelOpt MXFP8 checkpoint (`quant_method: modelopt` + `quant_algo: MXFP8`, or MiniMax-style `quant_method: mxfp8`) crashes quantization auto-detection:

```text
ValueError: Quantization method mxfp8 is an override but is has not been added to the `overrides` list above.
```

The `mxfp8` method name aliases `ModelOptMxFp8Config` (added for MiniMax-style checkpoints), so its `override_quantization_method` matches MXFP8 checkpoints — but the alias was never added to `ModelConfig`'s `overrides` list, and the detection loop hard-fails on any such checkpoint regardless of the user-passed `--quantization` value.

## Fix

One line: register `"mxfp8"` in the overrides list next to `modelopt_mxfp8` (both names resolve to the same config class, so relative order between them is irrelevant).

## Verification

GLM-5.2 BF16-dense + MXFP8-experts checkpoint (built from lukealonso/GLM-5.2-NVFP4 base with experts re-quantized BF16→MXFP8): previously died at ModelConfig validation; with this fix detection logs `Detected ModelOpt MXFP8 checkpoint` and resolves to `modelopt_mxfp8` (TP16 boot verification in comment below).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for MXFP8 and FP8 “online overlay” quantization during model loading.
  * Added new DCP tuning options to control token-cap behavior and collective routing.

* **Bug Fixes**
  * B12X DCP paths now automatically fall back when batch sizes exceed the configured token cap.
  * Improved handling of non-contiguous attention buffers and unsupported DCP world sizes.
  * Tightened MXFP4 overlay selection so shared-expert and ignored layers are handled correctly.
  * Added support for padded FP4 expert layouts when model dimensions don’t align with hardware constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->