### PR TITLE
dcp: make head-sliced attention views contiguous for the B12X PCIe pool (fathomless-firmament)

### DIFF
--- a/tests/distributed/test_dcp_a2a.py
+++ b/tests/distributed/test_dcp_a2a.py
@@ -509,6 +509,49 @@ def test_b12x_query_gather_honors_token_cap(monkeypatch: pytest.MonkeyPatch):
     assert result is None
 
 
+@pytest.mark.skipif(torch.accelerator.device_count() < 1, reason="CUDA is required.")
+def test_b12x_lse_reduce_makes_views_contiguous(monkeypatch: pytest.MonkeyPatch):
+    """Head-sliced attention views must reach the PCIe pool contiguous."""
+    from vllm.v1.attention.ops import dcp_alltoall
+
+    monkeypatch.setenv("VLLM_USE_B12X_DCP_A2A", "1")
+    received: dict[str, Any] = {}
+    sentinel = torch.zeros(1)
+
+    class _FakePool:
+        def lse_reduce_scatter(self, out, lse, *, is_lse_base_on_e):
+            received.update(out=out, lse=lse)
+            return sentinel
+
+    monkeypatch.setattr(
+        dcp_alltoall,
+        "_get_b12x_dcp_a2a_pool",
+        lambda *a, **k: _FakePool(),
+    )
+    group = _FakeCPGroup(4, None)  # type: ignore[arg-type]
+
+    # Simulate the GLM TP6 head66 pattern: kernel-padded buffers sliced back
+    # in the head dim produce non-contiguous views.
+    out_padded = torch.zeros(4, 24, 64, dtype=torch.bfloat16, device="cuda")
+    lse_padded = torch.zeros(4, 24, dtype=torch.float32, device="cuda")
+    out_view = out_padded[:, :16]
+    lse_view = lse_padded[:, :16]
+    assert not out_view.is_contiguous() and not lse_view.is_contiguous()
+
+    result = dcp_alltoall._try_b12x_dcp_lse_reduce(
+        out_view,
+        lse_view,
+        group,  # type: ignore[arg-type]
+        return_lse=False,
+        is_lse_base_on_e=True,
+        max_batch_size=8192,
+        query_head_dim=64,
+    )
+    assert result is sentinel
+    assert received["out"].is_contiguous()
+    assert received["lse"].is_contiguous()
+
+
 def test_b12x_query_gather_requires_env(monkeypatch: pytest.MonkeyPatch):
     from vllm.v1.attention.ops import dcp_alltoall
 

--- a/vllm/v1/attention/ops/dcp_alltoall.py
+++ b/vllm/v1/attention/ops/dcp_alltoall.py
@@ -201,6 +201,16 @@ def _try_b12x_dcp_lse_reduce(
         )
         return None
 
+    # Sparse MLA backends can return head-sliced views (e.g. GLM TP6 pads
+    # 64 -> 66 heads and slices the kernel output back), and the PCIe pool
+    # requires contiguous operands. The NCCL packers take explicit strides,
+    # so only this fast path needs the copy; LSE is tiny and the output is
+    # already contiguous on unpadded head counts.
+    if not cp_attn_out.is_contiguous():
+        cp_attn_out = cp_attn_out.contiguous()
+    if not cp_attn_lse.is_contiguous():
+        cp_attn_lse = cp_attn_lse.contiguous()
+
     return pool.lse_reduce_scatter(
         cp_attn_out,
         cp_attn_lse,


### PR DESCRIPTION
Same single commit as #81, retargeted at `dev/fathomless-firmament` (which already carries the #78/#79 re-picks but not this fix — `_try_b12x_dcp_lse_reduce` still passes head-sliced views straight to the pool).

## Problem

Sparse MLA backends can return head-sliced views: GLM TP6 pads 64 → 66 attention heads and slices the kernel output back (`lse = lse[:, :input_num_heads]`), producing non-contiguous `cp_attn_out`/`cp_attn_lse`. The B12X PCIe DCP pool validates contiguity, so TP6 × DCP≥2 dies at CUDA-graph capture with `ValueError: partial_lse must be contiguous`. TP8 never hits it (kernel head count == input head count); the NCCL packers take explicit strides and are unaffected — only this fast path needs the copy.

## Fix

Guarded `.contiguous()` on both operands in `_try_b12x_dcp_lse_reduce`, after the cheap reject checks and before the pool call. LSE is a tiny [B, H] fp32 tensor and the output copy only happens on padded head counts; capture-time allocations go to the graph pool like the existing send/recv buffers.

## Verification

- Unit test simulates the head66 slicing pattern (padded buffers sliced to `[:, :16]`, asserts the pool receives contiguous tensors). Suite on the v6 image with this file mounted: 31 passed + 1 pre-existing environment-bound failure (`TestDCPCommBackendConfig::test_a2a_with_dcp_valid`, identical on the unpatched branch in the same container).
- E2E on the eldritch lineage (v6 image, GLM-5.2 AMD MXFP4, TP6/A8/online-MXFP8/**DCP2**, GMU 0.95): previously died at capture; with the fix boots (KV 639,616), c0 67.1 / c3000 66.9 tok/s, 0 CJK.
- Content-equivalent to the build patch `blackwell-llm-docker/patches/vllm-dcp-b12x-contiguous-lse-20260707.patch` — merging retires it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)