### PR TITLE
[KV Offload] Align SWA store sparsity with local-cache retention semantics

### DIFF
--- a/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
@@ -1640,6 +1640,243 @@ def test_swa_alignment_skip(request_runner, async_scheduling: bool):
 
 
 @pytest.mark.parametrize("async_scheduling", [True, False])
+def test_swa_alignment_skip_eagle(request_runner, async_scheduling: bool):
+    """EAGLE/MTP SWA groups store their per-segment tail run shifted one
+    block past the segment boundary.
+
+    _lookup requires sliding_window_size_in_blocks + 1 consecutive stored
+    blocks for eagle groups (the "+1 peek" block, dropped after matching).
+    Mirroring SlidingWindowManager.reachable_block_mask (shift=1), the store
+    path retains a run of tail + 1 blocks ending one block PAST each segment
+    boundary, so the post-drop hit lands exactly on the boundary.
+
+    Setup:
+      - Group 0: full attention, block_size=16
+      - Group 1: SWA + eagle, block_size=4, sliding_window=8
+
+    alignment_block_count = 16 / 4 = 4, tail = 2, need = 3 (incl. peek).
+    Reachable block positions: {2, 3, 4} and {6, 7, 8} (shifted by one).
+
+    With a 36-token prompt (2 full full-attn blocks, 9 SWA blocks):
+      - Group 0 stores: blocks 0, 1
+      - Group 1 stores: blocks 2, 3, 4, 6, 7, 8
+
+    A replay then hits exactly 32 tokens (the second segment boundary): the
+    eagle lookup matches the run [6, 7, 8], drops peek block 8, and the
+    load fetches window blocks [6, 7].
+    """
+    full_attn_block_size = 16
+    swa_block_size = 4
+    sliding_window = 8
+    num_gpu_blocks = 200
+
+    kv_cache_groups = [
+        KVCacheGroupSpec(
+            ["layer0"],
+            FullAttentionSpec(
+                block_size=full_attn_block_size,
+                num_kv_heads=1,
+                head_size=1,
+                dtype=torch.float32,
+            ),
+        ),
+        KVCacheGroupSpec(
+            ["layer1"],
+            SlidingWindowSpec(
+                block_size=swa_block_size,
+                num_kv_heads=1,
+                head_size=1,
+                dtype=torch.float32,
+                sliding_window=sliding_window,
+            ),
+            is_eagle_group=True,
+        ),
+    ]
+
+    runner = request_runner(
+        block_size=swa_block_size,
+        num_gpu_blocks=num_gpu_blocks,
+        async_scheduling=async_scheduling,
+        kv_cache_groups=kv_cache_groups,
+    )
+
+    kv_group_configs = runner.connector_scheduler.config.kv_group_configs
+    assert kv_group_configs[1].is_eagle_group
+    assert kv_group_configs[1].alignment_block_count == 4
+    assert kv_group_configs[1].sliding_window_size_in_blocks == 2
+    # No sparse retention -> no per-request replay tail.
+    assert runner.connector_scheduler.config.replay_alignment_tokens is None
+
+    # Track stored keys so lookups reflect the actual store-side filtering.
+    stored_keys: set = set()
+
+    def _prepare_store(keys, req_context):
+        keys = list(keys)
+        stored_keys.update(keys)
+        return generate_store_output(keys)
+
+    runner.manager.prepare_store.side_effect = _prepare_store
+    runner.manager.lookup.side_effect = lambda key, req_context: (
+        LookupResult.HIT if key in stored_keys else LookupResult.MISS
+    )
+
+    num_tokens = 36
+    runner.new_request(token_ids=[0] * num_tokens)
+    runner.run(decoded_tokens=[0])
+    runner.run(
+        decoded_tokens=[EOS_TOKEN_ID],
+        expected_stored=(
+            (0, 0),
+            (0, 1),
+            (1, 2),
+            (1, 3),
+            (1, 4),
+            (1, 6),
+            (1, 7),
+            (1, 8),
+        ),
+    )
+
+    # Replay the same prompt; the eagle group must hit exactly at the
+    # 32-token segment boundary via the shifted run [6, 7, 8].
+    runner.scheduler.reset_prefix_cache()
+    # Avoid re-storing the (unloaded) peek block during the replay.
+    runner.manager.prepare_store.side_effect = lambda keys, req_context: (
+        generate_store_output([])
+    )
+    runner.new_request(token_ids=[0] * num_tokens)
+    runner.run(
+        decoded_tokens=[EOS_TOKEN_ID],
+        expected_loaded=(
+            (0, 0),
+            (0, 1),
+            (1, 6),
+            (1, 7),
+        ),
+    )
+
+
+@pytest.mark.parametrize("async_scheduling", [True, False])
+def test_swa_alignment_retention_interval(
+    request_runner, monkeypatch, async_scheduling: bool
+):
+    """VLLM_PREFIX_CACHE_RETENTION_INTERVAL sets the sparsity segment size,
+    and a per-request replay-boundary tail keeps exact replays servable.
+
+    Mirrors SlidingWindowManager.reachable_block_mask: with sparse retention
+    the local GPU cache keeps SWA tails once per retention interval (not at
+    every full-attention block boundary), plus one tail run at the latest
+    full-attention-aligned boundary of the prompt (the "replay boundary") so
+    a replay of the same prompt does not fall back a whole retention segment.
+
+    Setup:
+      - retention interval = 32 tokens
+      - Group 0: full attention, block_size=16
+      - Group 1: SWA, block_size=4, sliding_window=8
+
+    alignment_block_count = 32 / 4 = 8 (retention-based, not 16 / 4 = 4).
+
+    With a 56-token prompt (3 full full-attn blocks, 14 SWA blocks):
+      - segment tails: blocks {6, 7} (the second segment is incomplete:
+        blocks 14, 15 never fill)
+      - replay boundary: (56 - 1) // 16 * 16 = 48 -> tail run {10, 11}
+      - Group 1 stores: blocks 6, 7, 10, 11
+
+    A replay of the prompt hits 48 tokens via the replay tail {10, 11};
+    without it, the hit would fall back to 32 (the only segment boundary).
+    """
+    monkeypatch.setenv("VLLM_PREFIX_CACHE_RETENTION_INTERVAL", "32")
+
+    full_attn_block_size = 16
+    swa_block_size = 4
+    sliding_window = 8
+    num_gpu_blocks = 200
+
+    kv_cache_groups = [
+        KVCacheGroupSpec(
+            ["layer0"],
+            FullAttentionSpec(
+                block_size=full_attn_block_size,
+                num_kv_heads=1,
+                head_size=1,
+                dtype=torch.float32,
+            ),
+        ),
+        KVCacheGroupSpec(
+            ["layer1"],
+            SlidingWindowSpec(
+                block_size=swa_block_size,
+                num_kv_heads=1,
+                head_size=1,
+                dtype=torch.float32,
+                sliding_window=sliding_window,
+            ),
+        ),
+    ]
+
+    runner = request_runner(
+        block_size=swa_block_size,
+        num_gpu_blocks=num_gpu_blocks,
+        async_scheduling=async_scheduling,
+        kv_cache_groups=kv_cache_groups,
+    )
+
+    config = runner.connector_scheduler.config
+    # Segment granularity comes from the retention interval.
+    assert config.kv_group_configs[1].alignment_block_count == 8
+    assert config.kv_group_configs[1].sliding_window_size_in_blocks == 2
+    # Replay tails align to the full-attention block size.
+    assert config.replay_alignment_tokens == full_attn_block_size
+
+    # Track stored keys so lookups reflect the actual store-side filtering.
+    stored_keys: set = set()
+
+    def _prepare_store(keys, req_context):
+        keys = list(keys)
+        stored_keys.update(keys)
+        return generate_store_output(keys)
+
+    runner.manager.prepare_store.side_effect = _prepare_store
+    runner.manager.lookup.side_effect = lambda key, req_context: (
+        LookupResult.HIT if key in stored_keys else LookupResult.MISS
+    )
+
+    num_tokens = 56
+    runner.new_request(token_ids=[0] * num_tokens)
+    runner.run(decoded_tokens=[0])
+    runner.run(
+        decoded_tokens=[EOS_TOKEN_ID],
+        expected_stored=(
+            (0, 0),
+            (0, 1),
+            (0, 2),
+            (1, 6),
+            (1, 7),
+            (1, 10),
+            (1, 11),
+        ),
+    )
+
+    # Replay the same prompt; the hit must reach the 48-token replay
+    # boundary served by the replay tail run {10, 11}.
+    runner.scheduler.reset_prefix_cache()
+    runner.manager.prepare_store.side_effect = lambda keys, req_context: (
+        generate_store_output([])
+    )
+    runner.new_request(token_ids=[0] * num_tokens)
+    runner.run(
+        decoded_tokens=[EOS_TOKEN_ID],
+        expected_loaded=(
+            (0, 0),
+            (0, 1),
+            (0, 2),
+            (1, 10),
+            (1, 11),
+        ),
+    )
+
+
+@pytest.mark.parametrize("async_scheduling", [True, False])
 def test_stale_sliding_window_block_after_prepare_store_failure(
     request_runner, async_scheduling: bool
 ):

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 from itertools import islice
 from typing import Any, NamedTuple
 
+import vllm.envs as envs
 from vllm.distributed.kv_events import KVCacheEvent
 from vllm.distributed.kv_transfer.kv_connector.utils import yield_req_data
 from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorMetadata
@@ -82,10 +83,11 @@ class GroupOffloadConfig(NamedTuple):
     kv_event_group_spec: OffloadingEventGroupSpec
     # None below means full attention
     sliding_window_size_in_blocks: int | None
-    # Number of this group's offloaded blocks per full-attention alignment
-    # segment. Used to skip storing SWA blocks that can never serve a load
-    # hit (e.g. DeepSeek V4 where SWA groups have much smaller block sizes
-    # than the MLA full-attention group).
+    # Number of this group's offloaded blocks per sparsity segment (the
+    # full-attention alignment size, or VLLM_PREFIX_CACHE_RETENTION_INTERVAL
+    # when sparse retention is configured). Used to skip storing SWA blocks
+    # that can never serve a load hit (e.g. DeepSeek V4 where SWA groups have
+    # much smaller block sizes than the MLA full-attention group).
     # None for full-attention groups or when the optimization doesn't apply.
     alignment_block_count: int | None = None
     # True for EAGLE/MTP draft-model attention groups. The trailing block
@@ -132,6 +134,11 @@ class SchedulerOffloadConfig(NamedTuple):
     block_size_factor: int
     num_workers: int
     offload_prompt_only: bool
+    # Token alignment of the per-request "replay boundary" tail (see
+    # OffloadingConnectorScheduler._replay_tail_end_block). Set to the
+    # full-attention alignment size when sparse retention
+    # (VLLM_PREFIX_CACHE_RETENTION_INTERVAL) is enabled, else None.
+    replay_alignment_tokens: int | None = None
 
     @classmethod
     def from_spec(cls, spec: OffloadingSpec) -> "SchedulerOffloadConfig":
@@ -157,16 +164,34 @@ class SchedulerOffloadConfig(NamedTuple):
         if len(full_attn_offloaded_block_sizes) == 1:
             alignment_tokens = full_attn_offloaded_block_sizes.pop()
 
+        # Mirror SlidingWindowManager.reachable_block_mask's segment-size
+        # choice: with sparse retention (VLLM_PREFIX_CACHE_RETENTION_INTERVAL)
+        # the local GPU prefix cache keeps SWA tails once per retention
+        # segment rather than at every full-attention block boundary. Use the
+        # same granularity so stored tails sit exactly where lookups converge.
+        # An interval of 0 (latest-boundary-only retention) disables the
+        # store-side skip entirely (conservative: store all blocks).
+        retention_interval = envs.VLLM_PREFIX_CACHE_RETENTION_INTERVAL
+        segment_tokens: int | None = (
+            alignment_tokens
+            if retention_interval is None
+            else (None if retention_interval == 0 else retention_interval)
+        )
+
         def _alignment_block_count(
             offloaded_block_size: int,
             sliding_window_size_in_blocks: int | None,
+            is_eagle_group: bool,
         ) -> int | None:
-            if alignment_tokens is None or sliding_window_size_in_blocks is None:
+            if segment_tokens is None or sliding_window_size_in_blocks is None:
                 return None
-            if alignment_tokens <= offloaded_block_size:
+            if segment_tokens <= offloaded_block_size:
                 return None
-            per_segment = alignment_tokens // offloaded_block_size
-            if sliding_window_size_in_blocks >= per_segment:
+            per_segment = segment_tokens // offloaded_block_size
+            # Contiguous blocks a hit needs at a segment boundary, including
+            # the "+1 peek" block for EAGLE/MTP groups (see _lookup).
+            need = sliding_window_size_in_blocks + (1 if is_eagle_group else 0)
+            if need >= per_segment:
                 return None
             return per_segment
 
@@ -209,7 +234,9 @@ class SchedulerOffloadConfig(NamedTuple):
                         )
                     ),
                     alignment_block_count=_alignment_block_count(
-                        gpu_block_size * spec.block_size_factor, sw
+                        gpu_block_size * spec.block_size_factor,
+                        sw,
+                        idx in eagle_groups,
                     ),
                     kv_event_group_spec=get_offloading_event_group_spec(
                         spec.kv_cache_config.kv_cache_groups[idx]
@@ -220,6 +247,9 @@ class SchedulerOffloadConfig(NamedTuple):
             ),
             block_size_factor=spec.block_size_factor,
             offload_prompt_only=spec.offload_prompt_only,
+            replay_alignment_tokens=(
+                alignment_tokens if retention_interval is not None else None
+            ),
         )
 
 
@@ -379,6 +409,20 @@ class OffloadingConnectorScheduler:
         self._sliding_window_groups: tuple[int, ...] = tuple(sliding_window_groups)
         self._lookup_groups = tuple(full_attention_groups) + self._sliding_window_groups
         self._mamba_align_size: int | None = resolve_mamba_align_size(spec)
+
+        # Tokens that must remain past a replay boundary for it to be
+        # servable: the last prompt token is always recomputed (hence the
+        # default of 1), and each EAGLE/MTP group must be able to match one
+        # complete block past the boundary (its "+1 peek", dropped after
+        # verification in _lookup).
+        self._replay_reserve_tokens: int = max(
+            (
+                group_config.offloaded_block_size
+                for group_config in self.config.kv_group_configs
+                if group_config.is_eagle_group
+            ),
+            default=1,
+        )
 
         self._req_status: dict[ReqId, RequestOffloadState] = {}
         self._current_batch_load_jobs: dict[int, TransferJob] = {}
@@ -895,6 +939,32 @@ class OffloadingConnectorScheduler:
                         ):
                             group_state.block_ids[j] = 0
 
+    def _replay_tail_end_block(
+        self, group_config: GroupOffloadConfig, num_prompt_tokens: int, shift: int
+    ) -> int | None:
+        """End block index (exclusive) of this group's replay-boundary tail.
+
+        Mirrors the replay-boundary handling of
+        SlidingWindowManager.reachable_block_mask: with sparse retention,
+        segment tails exist only once per retention interval, so a replay of
+        the same prompt would otherwise fall back a whole segment. Retain one
+        extra tail run per request, ending at the latest
+        full-attention-aligned boundary that every group can service (i.e.
+        far enough from the prompt end that each EAGLE/MTP group's "+1 peek"
+        block is still a complete prompt block).
+        """
+        alignment_tokens = self.config.replay_alignment_tokens
+        if alignment_tokens is None:
+            return None
+        latest = (
+            (num_prompt_tokens - self._replay_reserve_tokens)
+            // alignment_tokens
+            * alignment_tokens
+        )
+        if latest <= 0 or latest % group_config.offloaded_block_size != 0:
+            return None
+        return latest // group_config.offloaded_block_size + shift
+
     def _build_store_jobs(
         self,
         scheduler_output: SchedulerOutput,
@@ -952,22 +1022,46 @@ class OffloadingConnectorScheduler:
 
                 alignment_block_count = group_config.alignment_block_count
                 tail = group_config.sliding_window_size_in_blocks
+                # Blocks reachable by _sliding_window_lookup, mirroring
+                # SlidingWindowManager.reachable_block_mask: a hit needs
+                # `need` contiguous blocks ending at a segment boundary. For
+                # EAGLE/MTP groups the run includes the "+1 peek" block and
+                # is shifted one block past the boundary, so that after
+                # _lookup drops the peek the hit lands exactly on it.
+                need = shift = 0
+                replay_end_block: int | None = None
+                if alignment_block_count is not None:
+                    assert tail is not None
+                    shift = 1 if group_config.is_eagle_group else 0
+                    need = tail + shift
+                    replay_end_block = self._replay_tail_end_block(
+                        group_config, req.num_prompt_tokens, shift
+                    )
 
                 for key_idx, (offload_key, block_id) in enumerate(
                     zip(offload_keys, offload_block_ids)
                 ):
                     if block_id == 0:
                         continue
-                    # Skip SWA blocks that can never serve a load hit:
-                    # within each full-attention alignment segment, only the
-                    # trailing `tail` blocks are reachable by
+                    # Skip SWA blocks that can never serve a load hit: only
+                    # the trailing `need` blocks of each alignment segment
+                    # (plus the replay-boundary tail) are reachable by
                     # _sliding_window_lookup. For DeepSeek V4 with 100K
                     # tokens this reduces SWA stores by ~78%.
                     if alignment_block_count is not None:
-                        assert tail is not None
                         abs_block_idx = start_block_idx + key_idx
-                        pos_in_segment = abs_block_idx % alignment_block_count
-                        if pos_in_segment < alignment_block_count - tail:
+                        reachable = (
+                            abs_block_idx >= shift
+                            and (abs_block_idx - shift) % alignment_block_count
+                            >= alignment_block_count - need
+                        )
+                        if not reachable and replay_end_block is not None:
+                            reachable = (
+                                replay_end_block - need
+                                <= abs_block_idx
+                                < replay_end_block
+                            )
+                        if not reachable:
                             continue
                     new_offload_keys.append(offload_key)
 


### PR DESCRIPTION
Superseded by https://github.com/local-inference-lab/vllm/pull/218

## Purpose

For SWA groups, the offloading connector stores only a small "tail" run of blocks per sparsity segment, because `_sliding_window_lookup` only ever needs a consecutive run of `sliding_window_size_in_blocks` stored blocks. This is the CPU-side analog of the local GPU prefix cache's sparse retention (`SlidingWindowManager.reachable_block_mask` in `vllm/v1/core/single_type_kv_cache_manager.py`).

The store-side skip had diverged from `reachable_block_mask` in three ways:

1. **EAGLE/MTP peek block was never stored.** `_lookup()` requires `sliding_window_size_in_blocks + 1` consecutive stored blocks for eagle groups (the "+1 peek" block, which is matched and then dropped), but the store path only retained `sliding_window_size_in_blocks` blocks per segment. A run long enough for an eagle lookup literally never existed, so eagle-group lookups always returned 0 — and since `_lookup()` converges over *all* groups, the overall hit was always 0.

2. **Segment size ignored the retention interval.** The connector always derived its sparsity segment from the full-attention block size (256 tokens), while the local GPU cache uses `VLLM_PREFIX_CACHE_RETENTION_INTERVAL` (4096 tokens) when configured. The local cache only retains blocks at retention boundaries, so the two sides disagreed 16× on where usable prefixes live.

3. **No replay-boundary tail.** With sparse retention, segment tails exist only once per retention interval, so replaying a prompt whose length is not near a boundary would fall back up to a whole interval (4095 tokens) of otherwise-cached prefix.

### The Fix

Make the store-side filter semantically identical to `SlidingWindowManager.reachable_block_mask`, which the local GPU cache has already proven out. Three coordinated changes, all on the **store side** — the lookup path needs no changes:

1. **Shifted eagle tail runs** (`_build_store_jobs`). For eagle groups, retain `tail + 1` blocks per segment, ending one block *past* the segment boundary (mirroring `reachable_block_mask`'s `shift = 1`). After `_lookup()` matches the run and drops the peek block, the hit lands exactly on the segment boundary. This keeps convergence boundary-aligned by construction, so every converged hit is serviceable by the sparse store and the load path can never request a never-stored block.

2. **Retention-aware segments** (`SchedulerOffloadConfig.from_spec`). Segment size now follows the exact expression used by `reachable_block_mask`: `alignment_tokens` if the interval is unset, the interval itself if positive, and no skip at all (store everything, conservative) for `0`. The eagle-aware `need` is also used for the "segment too small, store everything" degenerate check.

3. **Replay-boundary tail** (`_replay_tail_end_block`, mirroring `reachable_block_mask`'s replay-boundary handling). When sparse retention is active, each request additionally retains one tail run per SWA group ending at the latest full-attention-aligned boundary of its prompt — pulled back far enough (`_replay_reserve_tokens`) that every eagle group's peek block is still a complete prompt block. Replays of a 49k prompt then restore up to the latest 256-token boundary instead of only the latest 4096-token boundary.

## Test Plan

Tested with mtp:2, lucifer-cutlass, vllm main 5f8e73cb8b8d41f7a2a5168cddf5b772888fa991 + https://github.com/vllm-project/vllm/pull/48303 + https://github.com/vllm-project/vllm/pull/48304 + https://github.com/vllm-project/vllm/pull/48317 + flashinfer-python 0.6.14 (assumed to be minimal viable patchset for vllm main). Should also work with https://github.com/local-inference-lab/rtx6kpro/blob/master/models/ds4dspark-v10.md, but a slightly different patchset was tested there

* TODO re-test with v10 image
* TODO DSpark should work, but untested
* TODO GLM-5.2 should be unaffected, but untested

Testing this with a running vLLM is a bit annoying. What I did is run with `--kv-cache-memory-bytes 7G --max-model-len 50000` (and https://github.com/vllm-project/vllm/pull/48317 applied) to get about 1 full length request worth of GPU cache. we can then probe both cache levels with a sweep of unique or prefix-shared requests. E.g.

**make_request.py**:

```python
"""Usage: python make_request.py <N> <seed>
Sends a chat completion request with exactly N input tokens to localhost:8000.
The seed determines the prompt content (same seed = same prompt) and is also
passed to the model for reproducible sampling.
Outputs the raw JSON response.
"""

import sys
import json
import random
import urllib.request

# 26 letters, each " x" is exactly 1 token (verified via /tokenize)
_VOCAB = [" " + c for c in "abcdefghijklmnopqrstuvwxyz"]

def make_request(n_tokens: int, seed: int) -> dict:
    rng = random.Random(seed)
    # First token has no leading space; remaining tokens are drawn from _VOCAB
    first = rng.choice(_VOCAB).lstrip()
    rest = [rng.choice(_VOCAB) for _ in range(n_tokens - 1)]
    prompt = first + "".join(rest)

    payload = json.dumps({
        "model": "DeepSeek-V4-Flash",
        "messages": [{"role": "user", "content": prompt}],
        "max_completion_tokens": 5,
        "seed": seed,
    }).encode()

    req = urllib.request.Request(
        "http://localhost:8000/v1/chat/completions",
        data=payload,
        headers={"Content-Type": "application/json"},
    )
    with urllib.request.urlopen(req) as resp:
        return json.loads(resp.read())

def make_request_split(n_prefix: int, prefix_seed: int,
                       n_suffix: int, suffix_seed: int) -> dict:
    """Build a prompt with a shared prefix (keyed by prefix_seed) and a
    unique suffix (keyed by suffix_seed).  Same prefix_seed => identical
    prefix tokens, enabling prefix-cache sharing across requests."""
    rng_p = random.Random(prefix_seed)
    rng_s = random.Random(suffix_seed)

    prefix = rng_p.choice(_VOCAB).lstrip() + \
             "".join(rng_p.choice(_VOCAB) for _ in range(n_prefix - 1))
    suffix = "".join(rng_s.choice(_VOCAB) for _ in range(n_suffix))
    prompt = prefix + suffix

    # use suffix_seed as the API seed so AB/AC/AD are distinguishable
    payload = json.dumps({
        "model": "DeepSeek-V4-Flash",
        "messages": [{"role": "user", "content": prompt}],
        "max_completion_tokens": 5,
        "seed": suffix_seed,
    }).encode()

    req = urllib.request.Request(
        "http://localhost:8000/v1/chat/completions",
        data=payload,
        headers={"Content-Type": "application/json"},
    )
    with urllib.request.urlopen(req) as resp:
        return json.loads(resp.read())


if __name__ == "__main__":
    n = int(sys.argv[1])
    seed = int(sys.argv[2])
    print(json.dumps(make_request(n, seed), indent=2))
```

**probe_gpu_cache.py**:

```python
#!/usr/bin/env python3
"""Probe how many N-token requests fit in GPU vs DRAM (offload) KV cache.

Makes K requests forward then replays in reverse, timing each request and
distinguishing GPU cache hits from external (DRAM offload) hits via metrics.

Usage: python probe_gpu_cache.py [N] [K] [run_seed]

run_seed is mixed into every per-request seed so repeated runs don't
cross-contaminate each other's cache entries.
"""

import sys
import time
import urllib.request
import json
from make_request import make_request

N = int(sys.argv[1]) if len(sys.argv) > 1 else 9000
K = int(sys.argv[2]) if len(sys.argv) > 2 else 15
RUN_SEED = int(sys.argv[3]) if len(sys.argv) > 3 else int(time.time())

METRICS_URL = "http://localhost:8000/metrics"

def get_metrics():
    with urllib.request.urlopen(METRICS_URL) as resp:
        text = resp.read().decode()
    metrics = {}
    for line in text.splitlines():
        if line.startswith("#"):
            continue
        if "{" in line:
            name_part, val = line.rsplit("}", 1)
            name = name_part.split("{")[0]
        else:
            parts = line.split()
            if len(parts) != 2:
                continue
            name, val = parts
        try:
            metrics[name] = float(val)
        except ValueError:
            pass
    return metrics

def probe_request(n, seed):
    m0 = get_metrics()
    t0 = time.perf_counter()
    resp = make_request(n, seed)
    elapsed = time.perf_counter() - t0
    m1 = get_metrics()

    cached_tokens = resp["usage"]["prompt_tokens_details"]["cached_tokens"]
    ext_delta = m1.get("vllm:external_prefix_cache_hits_total", 0) - \
                m0.get("vllm:external_prefix_cache_hits_total", 0)
    gpu_hits = cached_tokens - int(ext_delta)

    return {
        "seed": seed,
        "prompt_tokens": resp["usage"]["prompt_tokens"],
        "cached_total": cached_tokens,
        "gpu_hits": gpu_hits,
        "dram_hits": int(ext_delta),
        "elapsed_s": elapsed,
    }

def fmt(r):
    source = "miss"
    if r["dram_hits"] > 0 and r["gpu_hits"] > 0:
        source = f"GPU+DRAM"
    elif r["dram_hits"] > 0:
        source = "DRAM"
    elif r["gpu_hits"] > 0:
        source = "GPU"
    local = r['seed'] % 10000  # display just the local index portion
    return (f"  seed={local:4d}  prompt_tokens={r['prompt_tokens']}  "
            f"cached={r['cached_total']:5d} (gpu={r['gpu_hits']:5d} dram={r['dram_hits']:5d})"
            f"  {r['elapsed_s']:.2f}s  [{source}]")

print(f"run_seed={RUN_SEED}")
seeds = [RUN_SEED * 10000 + 11 * (i + 1) for i in range(K)]
requests = [(N, s) for s in seeds]

print(f"=== Forward pass (N={N}, K={K}) ===")
for n, seed in requests:
    r = probe_request(n, seed)
    print(fmt(r))

print()
print(f"=== Reverse pass (N={N}, K={K}) ===")
for n, seed in reversed(requests):
    r = probe_request(n, seed)
    print(fmt(r))
```


## Test Result

With `--kv-offloading-size 64` we can fit 70 50k requests into the external cache in our test case with 7GB of GPU KV cache:

```
$ python3 probe_gpu_cache.py 49000 100
  seed=  11  prompt_tokens=49004  cached=    0 (gpu=    0 dram=    0)  4.40s  [miss]
  seed=  22  prompt_tokens=49004  cached=    0 (gpu=    0 dram=    0)  4.41s  [miss]
  seed=  33  prompt_tokens=49004  cached=    0 (gpu=    0 dram=    0)  4.41s  [miss]
...
  seed=1078  prompt_tokens=49004  cached=    0 (gpu=    0 dram=    0)  4.52s  [miss]
  seed=1089  prompt_tokens=49004  cached=    0 (gpu=    0 dram=    0)  4.52s  [miss]
  seed=1100  prompt_tokens=49004  cached=    0 (gpu=    0 dram=    0)  4.48s  [miss]

=== Reverse pass (N=49000, K=100) ===
  seed=1100  prompt_tokens=49004  cached=48896 (gpu=48896 dram=    0)  0.54s  [GPU]
  seed=1089  prompt_tokens=49004  cached=48896 (gpu=    0 dram=48896)  0.44s  [DRAM]
  seed=1078  prompt_tokens=49004  cached=48896 (gpu=    0 dram=48896)  0.44s  [DRAM]
...
  seed= 352  prompt_tokens=49004  cached=48896 (gpu=    0 dram=48896)  0.44s  [DRAM]
  seed= 341  prompt_tokens=49004  cached=48896 (gpu=    0 dram=48896)  0.46s  [DRAM]
  seed= 330  prompt_tokens=49004  cached=    0 (gpu=    0 dram=    0)  4.38s  [miss]
  seed= 319  prompt_tokens=49004  cached=    0 (gpu=    0 dram=    0)  4.46s  [miss]
  seed= 308  prompt_tokens=49004  cached=    0 (gpu=    0 dram=    0)  4.47s  [miss]
...
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved offloaded sliding-window attention cache handling at replay boundaries.
  * Preserved the correct cache blocks for EAGLE and MTP workflows, including peek blocks needed during replay.
  * Respect the configured prefix-cache retention interval when aligning and retaining offloaded blocks.
  * Improved cache-hit behavior at full-attention segment boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->