### PR TITLE
Restore B12X DCP global top-k helper kernels

### DIFF
--- a/tests/v1/attention/test_sparse_utils_dcp_topk.py
+++ b/tests/v1/attention/test_sparse_utils_dcp_topk.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+from vllm.v1.attention.backends.mla.sparse_utils import (
+    triton_convert_dcp_local_topk_to_global,
+    triton_gather_topk_ids_by_position,
+)
+
+pytestmark = pytest.mark.skipif(
+    not current_platform.is_cuda(), reason="DCP top-k helpers require CUDA"
+)
+
+
+def test_convert_dcp_local_topk_to_global() -> None:
+    token_indices = torch.tensor(
+        [[0, 1, 3, 4, 7, 8, 15, -1]], dtype=torch.int32, device="cuda"
+    )
+    scores = torch.arange(8, dtype=torch.float32, device="cuda").reshape(1, 8)
+
+    triton_convert_dcp_local_topk_to_global(
+        token_indices,
+        scores,
+        dcp_world_size=3,
+        dcp_rank=1,
+        cp_kv_cache_interleave_size=4,
+        BLOCK_N=8,
+    )
+
+    expected = torch.tensor(
+        [[4, 5, 7, 16, 19, 28, 43, -1]], dtype=torch.int32, device="cuda"
+    )
+    torch.testing.assert_close(token_indices, expected)
+    torch.testing.assert_close(
+        scores[:, :-1],
+        torch.arange(7, dtype=torch.float32, device="cuda").reshape(1, 7),
+    )
+    assert torch.isneginf(scores[0, -1])
+
+
+def test_gather_topk_ids_by_position_handles_invalid_positions() -> None:
+    candidate_ids = torch.tensor(
+        [[10, 11, 12, 13, 14, 15], [20, 21, 22, 23, 24, 25]],
+        dtype=torch.int32,
+        device="cuda",
+    )
+    positions = torch.tensor(
+        [[5, 0, -1, 6], [1, 4, 3, 0]], dtype=torch.int32, device="cuda"
+    )
+    out = torch.empty_like(positions)
+
+    triton_gather_topk_ids_by_position(
+        candidate_ids,
+        positions,
+        out,
+        BLOCK_N=4,
+    )
+
+    expected = torch.tensor(
+        [[15, 10, -1, -1], [21, 24, 23, 20]], dtype=torch.int32, device="cuda"
+    )
+    torch.testing.assert_close(out, expected)

--- a/vllm/v1/attention/backends/mla/sparse_utils.py
+++ b/vllm/v1/attention/backends/mla/sparse_utils.py
@@ -7,6 +7,77 @@ import torch
 from vllm.triton_utils import tl, triton
 
 
+@triton.jit
+def _convert_dcp_local_topk_to_global_kernel(
+    token_indices_ptr,
+    scores_ptr,
+    ti_stride0,
+    ti_stride1,
+    scores_stride0,
+    scores_stride1,
+    width: tl.constexpr,
+    DCP_WORLD_SIZE: tl.constexpr,
+    DCP_RANK: tl.constexpr,
+    CP_KV_CACHE_INTERLEAVE_SIZE: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    row = tl.program_id(0)
+    tile = tl.program_id(1)
+    offs = tile * BLOCK_N + tl.arange(0, BLOCK_N)
+    mask = offs < width
+    idx_ptrs = token_indices_ptr + row * ti_stride0 + offs * ti_stride1
+    local_idx = tl.load(idx_ptrs, mask=mask, other=-1)
+    valid = local_idx >= 0
+
+    interleave_block = local_idx // CP_KV_CACHE_INTERLEAVE_SIZE
+    interleave_offset = local_idx % CP_KV_CACHE_INTERLEAVE_SIZE
+    global_idx = (
+        (interleave_block * DCP_WORLD_SIZE + DCP_RANK)
+        * CP_KV_CACHE_INTERLEAVE_SIZE
+        + interleave_offset
+    )
+    tl.store(idx_ptrs, tl.where(valid, global_idx, -1), mask=mask)
+
+    score_ptrs = scores_ptr + row * scores_stride0 + offs * scores_stride1
+    scores = tl.load(score_ptrs, mask=mask, other=-float("inf"))
+    tl.store(score_ptrs, tl.where(valid, scores, -float("inf")), mask=mask)
+
+
+def triton_convert_dcp_local_topk_to_global(
+    token_indices: torch.Tensor,
+    scores: torch.Tensor,
+    *,
+    dcp_world_size: int,
+    dcp_rank: int,
+    cp_kv_cache_interleave_size: int,
+    BLOCK_N: int = 128,
+) -> None:
+    """Convert local DCP top-k ids in-place to global logical token ids."""
+    assert token_indices.dtype == torch.int32
+    assert scores.dtype == torch.float32
+    assert token_indices.shape == scores.shape
+    assert token_indices.is_contiguous()
+    assert scores.is_contiguous()
+    width = token_indices.shape[1]
+    assert width % BLOCK_N == 0, (
+        f"top-k width ({width}) must be divisible by BLOCK_N ({BLOCK_N})"
+    )
+    grid = (token_indices.shape[0], width // BLOCK_N)
+    _convert_dcp_local_topk_to_global_kernel[grid](
+        token_indices,
+        scores,
+        token_indices.stride(0),
+        token_indices.stride(1),
+        scores.stride(0),
+        scores.stride(1),
+        width,
+        DCP_WORLD_SIZE=dcp_world_size,
+        DCP_RANK=dcp_rank,
+        CP_KV_CACHE_INTERLEAVE_SIZE=cp_kv_cache_interleave_size,
+        BLOCK_N=BLOCK_N,
+    )
+
+
 # Kernel with prefill workspace support and valid count tracking
 @triton.jit
 def _convert_req_index_to_global_index_kernel(

--- a/vllm/v1/attention/backends/mla/sparse_utils.py
+++ b/vllm/v1/attention/backends/mla/sparse_utils.py
@@ -32,10 +32,8 @@ def _convert_dcp_local_topk_to_global_kernel(
     interleave_block = local_idx // CP_KV_CACHE_INTERLEAVE_SIZE
     interleave_offset = local_idx % CP_KV_CACHE_INTERLEAVE_SIZE
     global_idx = (
-        (interleave_block * DCP_WORLD_SIZE + DCP_RANK)
-        * CP_KV_CACHE_INTERLEAVE_SIZE
-        + interleave_offset
-    )
+        interleave_block * DCP_WORLD_SIZE + DCP_RANK
+    ) * CP_KV_CACHE_INTERLEAVE_SIZE + interleave_offset
     tl.store(idx_ptrs, tl.where(valid, global_idx, -1), mask=mask)
 
     score_ptrs = scores_ptr + row * scores_stride0 + offs * scores_stride1

--- a/vllm/v1/attention/backends/mla/sparse_utils.py
+++ b/vllm/v1/attention/backends/mla/sparse_utils.py
@@ -78,6 +78,78 @@ def triton_convert_dcp_local_topk_to_global(
     )
 
 
+@triton.jit
+def _gather_topk_ids_by_position_kernel(
+    candidate_ids_ptr,
+    positions_ptr,
+    out_ptr,
+    cand_stride0,
+    cand_stride1,
+    pos_stride0,
+    pos_stride1,
+    out_stride0,
+    out_stride1,
+    topk: tl.constexpr,
+    candidate_width: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    row = tl.program_id(0)
+    tile = tl.program_id(1)
+    offs = tile * BLOCK_N + tl.arange(0, BLOCK_N)
+    mask = offs < topk
+    pos = tl.load(
+        positions_ptr + row * pos_stride0 + offs * pos_stride1,
+        mask=mask,
+        other=-1,
+    )
+    valid = (pos >= 0) & (pos < candidate_width)
+    gathered = tl.load(
+        candidate_ids_ptr + row * cand_stride0 + pos * cand_stride1,
+        mask=mask & valid,
+        other=-1,
+    )
+    tl.store(
+        out_ptr + row * out_stride0 + offs * out_stride1,
+        tl.where(valid, gathered, -1),
+        mask=mask,
+    )
+
+
+def triton_gather_topk_ids_by_position(
+    candidate_ids: torch.Tensor,
+    positions: torch.Tensor,
+    out: torch.Tensor,
+    *,
+    BLOCK_N: int = 128,
+) -> None:
+    """Gather final ids from flattened candidate ids using int32 top-k positions."""
+    assert candidate_ids.dtype == torch.int32
+    assert positions.dtype == torch.int32
+    assert out.dtype == torch.int32
+    assert candidate_ids.ndim == 2
+    assert positions.ndim == 2
+    assert out.shape == positions.shape
+    assert candidate_ids.shape[0] == positions.shape[0]
+    assert positions.shape[1] % BLOCK_N == 0, (
+        f"top-k width ({positions.shape[1]}) must be divisible by BLOCK_N ({BLOCK_N})"
+    )
+    grid = (positions.shape[0], positions.shape[1] // BLOCK_N)
+    _gather_topk_ids_by_position_kernel[grid](
+        candidate_ids,
+        positions,
+        out,
+        candidate_ids.stride(0),
+        candidate_ids.stride(1),
+        positions.stride(0),
+        positions.stride(1),
+        out.stride(0),
+        out.stride(1),
+        positions.shape[1],
+        candidate_ids.shape[1],
+        BLOCK_N=BLOCK_N,
+    )
+
+
 # Kernel with prefill workspace support and valid count tracking
 @triton.jit
 def _convert_req_index_to_global_index_kernel(


### PR DESCRIPTION
## Summary

Restore the two Triton helpers required by the B12X sparse-indexer DCP global-top-k path:

- convert rank-local top-k token IDs to global interleaved DCP IDs
- gather final global token IDs from the merged candidate positions

The current dev/fathomless-firmament branch still imports both helpers from sparse_attn_indexer.py, but their definitions were lost during the latest rebase. DCP1 does not enter this path; GLM-5.2 DCP2/4/8 with VLLM_USE_B12X_SPARSE_INDEXER=1 and VLLM_DCP_GLOBAL_TOPK=1 does.

## Root cause

The B12X DCP merge implementation survived the rebase, while these source helpers did not. That leaves a lazy runtime import failure only once a multi-rank global-top-k request reaches _merge_b12x_dcp_topk, so ordinary imports and DCP1 smoke tests do not expose it.

## Validation

- ruff check and ruff format --check
- focused SM120/CUDA 13.2 GPU execution for both kernels
- tests cover DCP interleave mapping, invalid local IDs/scores, positional gathering, and invalid positions

Upstream vLLM PR #47381 is already an ancestor of the current branch and is unrelated to this restore.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GPU-accelerated utilities for converting distributed sparse top-k token indices into global IDs.
  * Added support for gathering top-k candidate IDs by position, with safe handling of invalid selections.

* **Tests**
  * Added CUDA-specific coverage validating index conversion, score masking, candidate gathering, and invalid-position behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->