### PR TITLE
Fix GLM sparse indexer MTP guard after FF rebase

### DIFF
--- a/tests/models/test_deepseek_v2_index_topk.py
+++ b/tests/models/test_deepseek_v2_index_topk.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+from vllm.model_executor.models.deepseek_v2 import _should_skip_index_topk
+
+
+def test_index_topk_pattern_only_skips_backbone_layers() -> None:
+    config = SimpleNamespace(
+        num_hidden_layers=4,
+        index_topk_pattern="FSSF",
+    )
+
+    assert not _should_skip_index_topk(config, 0)
+    assert _should_skip_index_topk(config, 1)
+    assert _should_skip_index_topk(config, 2)
+    assert not _should_skip_index_topk(config, 3)
+    assert not _should_skip_index_topk(config, 4)
+    assert not _should_skip_index_topk(config, 5)
+
+
+def test_index_topk_frequency_does_not_skip_nextn_layer() -> None:
+    config = SimpleNamespace(
+        num_hidden_layers=4,
+        index_topk_pattern=None,
+        index_topk_freq=3,
+        index_skip_topk_offset=2,
+    )
+
+    assert _should_skip_index_topk(config, 2)
+    assert not _should_skip_index_topk(config, 4)

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -1273,12 +1273,9 @@ class DeepseekV2MLAAttention(nn.Module):
             cache_config,
             quant_config,
             prefix,
-            # MTP layers must never start with skip_topk=True: their indexer
-            # computes indices at draft step 0, and the runtime toggle
-            # (set_skip_topk, index_share_for_mtp_iteration) only exists in
-            # the V1 proposer. A frozen True would leave the draft reading a
-            # never-written topk buffer.
-            skip_topk=_skip_topk and not is_mtp_layer,
+            # _should_skip_index_topk already returns False for MTP/NextN
+            # layer ids, so they always start with a populated indexer.
+            skip_topk=_skip_topk,
         )
 
     def forward(


### PR DESCRIPTION
## Summary

Fix a startup NameError in DeepseekV2MLAAttention after the latest Fathomless Firmament rebase.

Upstream PR #47381 guarded skip_topk with is_mtp_layer. A later fork integration replaced the old inline skip calculation with _should_skip_index_topk, which already excludes MTP/NextN layer ids, and removed the local is_mtp_layer variable. The stale reference remained and crashes every sparse GLM/DeepSeek model during construction, including MTP-off serving.

## Fix

Pass _skip_topk directly. _should_skip_index_topk returns False for every layer id at or above num_hidden_layers, preserving the intended MTP behavior without duplicate state.

## Validation

- ruff check and format checks on the changed model and test
- focused backbone-pattern and frequency tests, including NextN ids
- full GLM-5.2 TP8/DCP2/A16/online-MXFP8 startup with InstantTensor
- B12X global-top-k request completed successfully
- decode cc1: 76.3 tok/s versus the v15 baseline 76.28 tok/s

This PR is ready for review.
