### PR TITLE
Fix shared-expert auxiliary-stream output lifetime

### DIFF
--- a/tests/model_executor/layers/fused_moe/test_shared_experts_stream.py
+++ b/tests/model_executor/layers/fused_moe/test_shared_experts_stream.py
@@ -1,0 +1,32 @@
+from contextlib import contextmanager
+from unittest.mock import Mock
+
+import torch
+
+import vllm.model_executor.layers.fused_moe.runner.shared_experts as shared_module
+from vllm.model_executor.layers.fused_moe.runner.shared_experts import SharedExperts
+
+
+def test_aux_stream_output_lifetime_extends_to_consumer(monkeypatch) -> None:
+    shared_experts = object.__new__(SharedExperts)
+    aux_stream = Mock()
+    consumer_stream = Mock()
+    output = Mock()
+    shared_experts_input = Mock()
+    shared_experts._stream = aux_stream
+    shared_experts._layer = Mock(return_value=output)
+
+    @contextmanager
+    def use_stream(stream):
+        assert stream is aux_stream
+        yield
+
+    monkeypatch.setattr(torch.cuda, "stream", use_stream)
+    monkeypatch.setattr(shared_module, "current_stream", lambda: consumer_stream)
+
+    result = shared_experts._run_in_aux_stream(shared_experts_input)
+
+    assert result is output
+    shared_experts._layer.assert_called_once_with(shared_experts_input)
+    consumer_stream.wait_stream.assert_called_once_with(aux_stream)
+    output.record_stream.assert_called_once_with(consumer_stream)

--- a/vllm/model_executor/layers/fused_moe/runner/shared_experts.py
+++ b/vllm/model_executor/layers/fused_moe/runner/shared_experts.py
@@ -120,8 +120,6 @@ class SharedExperts(torch.nn.Module):
             # Record that the clone will be used by shared_experts_stream
             # to avoid gc issue from deallocation of hidden_states_clone
             # For more details: https://docs.pytorch.org/docs/stable/generated/torch.Tensor.record_stream.html # noqa: E501
-            # NOTE: We don't need shared_output.record_stream(current_stream())
-            # because we synch the streams before using shared_output.
             shared_experts_input.record_stream(self._stream)
 
             # Mark sync start point for the aux stream since we will

--- a/vllm/model_executor/layers/fused_moe/runner/shared_experts.py
+++ b/vllm/model_executor/layers/fused_moe/runner/shared_experts.py
@@ -137,7 +137,14 @@ class SharedExperts(torch.nn.Module):
         # Run shared experts in parallel on a separate stream.
         with torch.cuda.stream(self._stream):
             output = self._layer(shared_experts_input)
-        current_stream().wait_stream(self._stream)
+        consumer_stream = current_stream()
+        consumer_stream.wait_stream(self._stream)
+
+        # The output allocation belongs to the aux stream, but the routed and
+        # shared expert outputs are combined on the consumer stream. The wait
+        # orders producer before consumer; record_stream keeps the allocation
+        # alive until the consumer has finished using it.
+        output.record_stream(consumer_stream)
 
         return output
 


### PR DESCRIPTION
## Root cause

`SharedExperts._run_in_aux_stream` waits for the producer stream but does not record the output allocation on the consumer stream. The CUDA caching allocator can therefore recycle that allocation after the auxiliary stream finishes even while routed/shared expert fusion on the main stream still consumes it.

This lifetime edge was present before the shared-expert refactor, where `output.record_stream(consumer_stream)` existed, and was lost during the refactor.

The failure is deterministic on GLM-5.2 TP6, B12X MoE, BF16 shared experts, fused all-reduce plus RMSNorm, and CUDA graphs: graph capture terminates with illegal memory access / Xid 31. TP8 does not reliably expose the allocator timing window.

## Fix

- Record the auxiliary-stream output on the actual consumer stream after ordering it with `wait_stream`.
- Add a focused test that verifies producer/consumer ordering and allocation lifetime tracking.

No overlap, fused collective, CUDA graph, backend, or KV-cache feature is disabled.

## Validation

- Focused unit test: `1 passed`.
- Exact TP6 production configuration that failed twice before the patch completed all piecewise and full CUDA graph captures after the patch.
- B12X attention/MoE, fused all-reduce plus RMSNorm, shared-expert auxiliary overlap, InstantTensor BUFFERED, FP8 KV cache, and graph capture all remained enabled.
- Long coding output was coherent and a 64k standalone prefill completed without Xid or CUDA errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU stream coordination for shared expert outputs.
  * Ensured outputs remain available until downstream processing completes, reducing the risk of synchronization or lifetime-related issues.

* **Tests**
  * Added coverage verifying auxiliary-stream synchronization and output lifetime handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->