### PR TITLE
Generalize B12X sparse-prefill workspace reuse across DCP topologies

### DIFF
--- a/tests/distributed/test_dcp_a2a.py
+++ b/tests/distributed/test_dcp_a2a.py
@@ -415,6 +415,34 @@ def test_b12x_query_gather_dispatch_bypasses_group(monkeypatch: pytest.MonkeyPat
     }
 
 
+def test_b12x_pool_init_consensus_uses_exchange_group(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from vllm.v1.attention.ops import dcp_alltoall
+
+    device_group = object()
+    cpu_group = object()
+    group = _FakeCPGroup(4, device_group, cpu_group)  # type: ignore[arg-type]
+    device = torch.device("cuda:0")
+    captured: dict[str, Any] = {}
+    original_tensor = torch.tensor
+
+    def fake_tensor(data, *, dtype, device):
+        captured["tensor_device"] = device
+        return original_tensor(data, dtype=dtype)
+
+    def fake_all_reduce(tensor, *, op, group):
+        captured.update(tensor=tensor, op=op, group=group)
+
+    monkeypatch.setattr(dcp_alltoall.torch, "tensor", fake_tensor)
+    monkeypatch.setattr(dcp_alltoall.dist, "all_reduce", fake_all_reduce)
+
+    assert not dcp_alltoall._b12x_dcp_init_failed(group, device, None)
+    assert captured["tensor_device"] == device
+    assert captured["group"] is device_group
+    assert captured["op"] == dist.ReduceOp.MAX
+
+
 @pytest.mark.skipif(torch.accelerator.device_count() < 1, reason="CUDA is required.")
 def test_b12x_lse_reduce_honors_token_cap(monkeypatch: pytest.MonkeyPatch):
     from vllm.v1.attention.ops import dcp_alltoall

--- a/tests/v1/attention/test_b12x_mla_dcp_workspace.py
+++ b/tests/v1/attention/test_b12x_mla_dcp_workspace.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.attention.mla_attention import (
+    _can_use_b12x_dcp_prefill_workspace,
+)
+from vllm.v1.attention.ops import common
+
+
+@pytest.mark.parametrize(
+    ("override", "value"),
+    [
+        ("enabled", False),
+        ("project_before_merge", False),
+        ("dcp_use_b12x", True),
+        ("num_tokens", 1024),
+        ("num_tokens", 3073),
+        ("non_dbo_workspace", False),
+        ("is_sparse_impl", False),
+        ("backend_name", "FLASHINFER_MLA"),
+        ("is_capturing", True),
+    ],
+)
+def test_dcp_workspace_gate_rejects_unsupported_profiles(override, value):
+    profile = {
+        "enabled": True,
+        "project_before_merge": True,
+        "dcp_use_b12x": False,
+        "num_tokens": 1025,
+        "non_dbo_workspace": True,
+        "is_sparse_impl": True,
+        "backend_name": "B12X_MLA_SPARSE",
+        "is_capturing": False,
+    }
+    profile[override] = value
+
+    assert not _can_use_b12x_dcp_prefill_workspace(**profile)
+
+
+@pytest.mark.parametrize("num_tokens", [1025, 2048, 3072])
+def test_dcp_workspace_gate_accepts_valid_rows(num_tokens):
+    assert _can_use_b12x_dcp_prefill_workspace(
+        enabled=True,
+        project_before_merge=True,
+        dcp_use_b12x=False,
+        num_tokens=num_tokens,
+        non_dbo_workspace=True,
+        is_sparse_impl=True,
+        backend_name="B12X_MLA_SPARSE",
+        is_capturing=False,
+    )
+
+
+def test_cp_lse_ag_out_rs_into_preserves_borrowed_output(monkeypatch):
+    corrected = torch.arange(64, dtype=torch.bfloat16).view(1, 4, 16)
+    corrected_lse = torch.arange(4, dtype=torch.float32).view(1, 4)
+    borrowed = torch.empty((1, 1, 16), dtype=torch.bfloat16)
+
+    monkeypatch.setattr(
+        common,
+        "_cp_lse_common",
+        lambda *args, **kwargs: (corrected, corrected_lse),
+    )
+
+    class FakeGroup:
+        world_size = 4
+        rank_in_group = 2
+
+        def reduce_scatter_into(self, input_, output, dim):
+            assert input_ is corrected
+            assert output is borrowed
+            assert dim == 1
+            output.copy_(input_[:, 2:3])
+            return output
+
+    output, lse = common.cp_lse_ag_out_rs_into(
+        torch.empty_like(corrected),
+        torch.empty_like(corrected_lse),
+        FakeGroup(),
+        output_provider=lambda value: borrowed,
+        return_lse=True,
+    )
+
+    assert output is borrowed
+    assert torch.equal(output, corrected[:, 2:3])
+    assert torch.equal(lse, corrected_lse[:, 2:3])

--- a/tests/v1/attention/test_b12x_mla_dcp_workspace.py
+++ b/tests/v1/attention/test_b12x_mla_dcp_workspace.py
@@ -7,6 +7,7 @@ import torch
 from vllm.model_executor.layers.attention.mla_attention import (
     _can_use_b12x_dcp_prefill_workspace,
 )
+from vllm.v1.attention.backends.mla.b12x_mla_sparse import B12xMLASparseImpl
 from vllm.v1.attention.ops import common
 
 
@@ -17,7 +18,7 @@ from vllm.v1.attention.ops import common
         ("project_before_merge", False),
         ("dcp_use_b12x", True),
         ("num_tokens", 1024),
-        ("num_tokens", 3073),
+        ("max_num_tokens", 1024),
         ("non_dbo_workspace", False),
         ("is_sparse_impl", False),
         ("backend_name", "FLASHINFER_MLA"),
@@ -30,6 +31,7 @@ def test_dcp_workspace_gate_rejects_unsupported_profiles(override, value):
         "project_before_merge": True,
         "dcp_use_b12x": False,
         "num_tokens": 1025,
+        "max_num_tokens": 3072,
         "non_dbo_workspace": True,
         "is_sparse_impl": True,
         "backend_name": "B12X_MLA_SPARSE",
@@ -40,13 +42,17 @@ def test_dcp_workspace_gate_rejects_unsupported_profiles(override, value):
     assert not _can_use_b12x_dcp_prefill_workspace(**profile)
 
 
-@pytest.mark.parametrize("num_tokens", [1025, 2048, 3072])
-def test_dcp_workspace_gate_accepts_valid_rows(num_tokens):
+@pytest.mark.parametrize(
+    ("num_tokens", "max_num_tokens"),
+    [(1025, 2048), (2048, 2048), (3072, 8192), (8192, 8192)],
+)
+def test_dcp_workspace_gate_accepts_valid_rows(num_tokens, max_num_tokens):
     assert _can_use_b12x_dcp_prefill_workspace(
         enabled=True,
         project_before_merge=True,
         dcp_use_b12x=False,
         num_tokens=num_tokens,
+        max_num_tokens=max_num_tokens,
         non_dbo_workspace=True,
         is_sparse_impl=True,
         backend_name="B12X_MLA_SPARSE",
@@ -54,9 +60,13 @@ def test_dcp_workspace_gate_accepts_valid_rows(num_tokens):
     )
 
 
-def test_cp_lse_ag_out_rs_into_preserves_borrowed_output(monkeypatch):
-    corrected = torch.arange(64, dtype=torch.bfloat16).view(1, 4, 16)
-    corrected_lse = torch.arange(4, dtype=torch.float32).view(1, 4)
+@pytest.mark.parametrize("world_size", [2, 3, 4, 6, 8])
+def test_cp_lse_ag_out_rs_into_preserves_borrowed_output(monkeypatch, world_size):
+    rank = world_size - 1
+    corrected = torch.arange(world_size * 16, dtype=torch.bfloat16).view(
+        1, world_size, 16
+    )
+    corrected_lse = torch.arange(world_size, dtype=torch.float32).view(1, world_size)
     borrowed = torch.empty((1, 1, 16), dtype=torch.bfloat16)
 
     monkeypatch.setattr(
@@ -64,26 +74,84 @@ def test_cp_lse_ag_out_rs_into_preserves_borrowed_output(monkeypatch):
         "_cp_lse_common",
         lambda *args, **kwargs: (corrected, corrected_lse),
     )
+    monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: False)
 
     class FakeGroup:
-        world_size = 4
-        rank_in_group = 2
+        rank_in_group = rank
 
         def reduce_scatter_into(self, input_, output, dim):
             assert input_ is corrected
             assert output is borrowed
             assert dim == 1
-            output.copy_(input_[:, 2:3])
+            output.copy_(input_[:, rank : rank + 1])
             return output
 
+    group = FakeGroup()
+    group.world_size = world_size
     output, lse = common.cp_lse_ag_out_rs_into(
         torch.empty_like(corrected),
         torch.empty_like(corrected_lse),
-        FakeGroup(),
+        group,
         output_provider=lambda value: borrowed,
         return_lse=True,
     )
 
     assert output is borrowed
-    assert torch.equal(output, corrected[:, 2:3])
-    assert torch.equal(lse, corrected_lse[:, 2:3])
+    assert torch.equal(output, corrected[:, rank : rank + 1])
+    assert torch.equal(lse, corrected_lse[:, rank : rank + 1])
+
+
+@pytest.mark.parametrize(
+    ("tp_size", "dcp_size", "local_heads", "input_heads", "kernel_heads"),
+    [
+        (4, 4, 16, 64, 64),
+        (6, 2, 11, 22, 24),
+        (6, 3, 11, 33, 40),
+        (6, 6, 11, 66, 72),
+        (8, 2, 8, 16, 16),
+        (8, 4, 8, 32, 32),
+        (8, 8, 8, 64, 64),
+    ],
+)
+def test_dcp_workspace_contract_accepts_validated_topologies(
+    monkeypatch,
+    tp_size,
+    dcp_size,
+    local_heads,
+    input_heads,
+    kernel_heads,
+):
+    impl = object.__new__(B12xMLASparseImpl)
+    impl._max_batched = 8192
+    impl.dcp_workspace_non_dbo = True
+    impl.tp_world_size = tp_size
+    impl.dcp_world_size = dcp_size
+    impl.num_heads = local_heads
+    impl._input_num_heads = input_heads
+    impl._kernel_num_heads = kernel_heads
+    impl._pad_heads = kernel_heads != input_heads
+    impl.q_head_dim = 576
+    impl.kv_lora_rank = 512
+    impl.v_head_dim = 256
+    monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: False)
+
+    impl._validate_dcp_prefill_workspace_contract(2048)
+
+
+def test_dcp_workspace_contract_rejects_unvalidated_topology(monkeypatch):
+    impl = object.__new__(B12xMLASparseImpl)
+    impl._max_batched = 8192
+    impl.dcp_workspace_non_dbo = True
+    impl.tp_world_size = 6
+    impl.dcp_world_size = 4
+    impl.num_heads = 11
+    impl._input_num_heads = 44
+    impl._kernel_num_heads = 48
+    impl._pad_heads = True
+    impl.q_head_dim = 576
+    impl.kv_lora_rank = 512
+    impl.v_head_dim = 256
+    monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: False)
+
+    with pytest.raises(RuntimeError, match="unsupported topology or geometry"):
+        impl._validate_dcp_prefill_workspace_contract(2048)

--- a/vllm/distributed/device_communicators/cuda_communicator.py
+++ b/vllm/distributed/device_communicators/cuda_communicator.py
@@ -384,6 +384,60 @@ class CudaCommunicator(DeviceCommunicatorBase):
         # Reshape before returning
         return output.movedim(0, dim).contiguous()
 
+    def reduce_scatter_into(
+        self,
+        input_: torch.Tensor,
+        output: torch.Tensor,
+        dim: int = -1,
+    ) -> torch.Tensor:
+        """Run the validated eager DCP4 reduce-scatter without allocating."""
+        if self.world_size != 4 or dim != 1:
+            raise RuntimeError("reduce_scatter_into is restricted to DCP4 heads")
+        if input_.ndim != 3 or output.ndim != 3:
+            raise ValueError("reduce_scatter_into requires rank-3 tensors")
+        num_tokens = int(input_.shape[0])
+        expected_input = (num_tokens, 64, 256)
+        expected_output = (num_tokens, 16, 256)
+        if (
+            not 1025 <= num_tokens <= 3072
+            or tuple(input_.shape) != expected_input
+            or tuple(output.shape) != expected_output
+            or input_.dtype != torch.bfloat16
+            or output.dtype != torch.bfloat16
+            or input_.device != output.device
+            or input_.device != self.device
+        ):
+            raise ValueError(
+                "reduce_scatter_into requires BF16 [T,64,256] -> "
+                "[T,16,256] on the communicator device"
+            )
+        if torch.cuda.is_current_stream_capturing():
+            raise RuntimeError("reduce_scatter_into is eager-only")
+
+        input_tensor = input_.movedim(0, dim)
+        output_tensor = output.movedim(0, dim)
+        if not input_tensor.is_contiguous() or not output_tensor.is_contiguous():
+            raise ValueError("reduce_scatter_into requires head-major storage")
+        if input_tensor.numel() != self.world_size * output_tensor.numel():
+            raise ValueError("reduce_scatter_into element-count mismatch")
+
+        input_begin = input_tensor.data_ptr()
+        input_end = input_begin + input_tensor.numel() * input_tensor.element_size()
+        output_begin = output_tensor.data_ptr()
+        output_end = output_begin + output_tensor.numel() * output_tensor.element_size()
+        if input_begin < output_end and output_begin < input_end:
+            raise ValueError("reduce_scatter_into input and output overlap")
+
+        pynccl_comm = self.pynccl_comm
+        if pynccl_comm is None or pynccl_comm.disabled:
+            raise RuntimeError("reduce_scatter_into requires PyNccl")
+        pynccl_comm.reduce_scatter(
+            output_tensor,
+            input_tensor,
+            stream=torch.cuda.current_stream(self.device),
+        )
+        return output
+
     def reduce_scatterv(
         self, input_: torch.Tensor, dim: int = -1, sizes: list[int] | None = None
     ):

--- a/vllm/distributed/device_communicators/cuda_communicator.py
+++ b/vllm/distributed/device_communicators/cuda_communicator.py
@@ -390,16 +390,20 @@ class CudaCommunicator(DeviceCommunicatorBase):
         output: torch.Tensor,
         dim: int = -1,
     ) -> torch.Tensor:
-        """Run the validated eager DCP4 reduce-scatter without allocating."""
-        if self.world_size != 4 or dim != 1:
-            raise RuntimeError("reduce_scatter_into is restricted to DCP4 heads")
+        """Run eager DCP reduce-scatter without allocating."""
+        if self.world_size <= 1 or dim != 1:
+            raise RuntimeError("reduce_scatter_into requires DCP heads on dim 1")
         if input_.ndim != 3 or output.ndim != 3:
             raise ValueError("reduce_scatter_into requires rank-3 tensors")
         num_tokens = int(input_.shape[0])
-        expected_input = (num_tokens, 64, 256)
-        expected_output = (num_tokens, 16, 256)
+        input_heads = int(input_.shape[1])
+        if input_heads % self.world_size != 0:
+            raise ValueError("reduce_scatter_into head count is not DCP-divisible")
+        output_heads = input_heads // self.world_size
+        expected_input = (num_tokens, input_heads, 256)
+        expected_output = (num_tokens, output_heads, 256)
         if (
-            not 1025 <= num_tokens <= 3072
+            num_tokens < 1025
             or tuple(input_.shape) != expected_input
             or tuple(output.shape) != expected_output
             or input_.dtype != torch.bfloat16
@@ -408,8 +412,8 @@ class CudaCommunicator(DeviceCommunicatorBase):
             or input_.device != self.device
         ):
             raise ValueError(
-                "reduce_scatter_into requires BF16 [T,64,256] -> "
-                "[T,16,256] on the communicator device"
+                "reduce_scatter_into requires DCP-divisible BF16 "
+                "[T,H,256] -> [T,H/DCP,256] on the communicator device"
             )
         if torch.cuda.is_current_stream_capturing():
             raise RuntimeError("reduce_scatter_into is eager-only")

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -714,6 +714,37 @@ class GroupCoordinator:
         else:
             return self._reduce_scatter_out_place(input_, dim)
 
+    def reduce_scatter_into(
+        self,
+        input_: torch.Tensor,
+        output: torch.Tensor,
+        dim: int = -1,
+    ) -> torch.Tensor:
+        """Run eager reduce-scatter into caller-provided CUDA storage."""
+        if self.world_size != 4 or dim != 1:
+            raise RuntimeError("reduce_scatter_into is restricted to DCP4 heads")
+        if input_.ndim != 3 or output.ndim != 3:
+            raise ValueError("reduce_scatter_into requires rank-3 tensors")
+        if input_.device != output.device or input_.device.type != "cuda":
+            raise ValueError("reduce_scatter_into requires one CUDA device")
+        if torch.cuda.is_current_stream_capturing():
+            raise RuntimeError("reduce_scatter_into is eager-only")
+        if self.device_communicator is None:
+            raise RuntimeError("reduce_scatter_into requires a device communicator")
+
+        reduce_scatter_into = getattr(
+            self.device_communicator, "reduce_scatter_into", None
+        )
+        if not callable(reduce_scatter_into):
+            raise RuntimeError(
+                f"{type(self.device_communicator).__name__} does not support "
+                "reduce_scatter_into"
+            )
+        result = reduce_scatter_into(input_, output, dim)
+        if result is not output:
+            raise RuntimeError("reduce_scatter_into did not preserve output identity")
+        return output
+
     def reduce_scatterv(
         self, input_: torch.Tensor, dim: int = -1, sizes: list[int] | None = None
     ) -> torch.Tensor:

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -721,12 +721,18 @@ class GroupCoordinator:
         dim: int = -1,
     ) -> torch.Tensor:
         """Run eager reduce-scatter into caller-provided CUDA storage."""
-        if self.world_size != 4 or dim != 1:
-            raise RuntimeError("reduce_scatter_into is restricted to DCP4 heads")
+        if self.world_size <= 1 or dim != 1:
+            raise RuntimeError("reduce_scatter_into requires DCP heads on dim 1")
         if input_.ndim != 3 or output.ndim != 3:
             raise ValueError("reduce_scatter_into requires rank-3 tensors")
         if input_.device != output.device or input_.device.type != "cuda":
             raise ValueError("reduce_scatter_into requires one CUDA device")
+        if (
+            input_.shape[0] != output.shape[0]
+            or input_.shape[1] != self.world_size * output.shape[1]
+            or input_.shape[2:] != output.shape[2:]
+        ):
+            raise ValueError("reduce_scatter_into shape mismatch")
         if torch.cuda.is_current_stream_capturing():
             raise RuntimeError("reduce_scatter_into is eager-only")
         if self.device_communicator is None:

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -65,6 +65,8 @@ if TYPE_CHECKING:
     VLLM_USE_B12X_MOE: bool = False
     VLLM_USE_B12X_MINIMAX_M3_MSA: bool = False
     VLLM_USE_B12X_DCP_A2A: bool = False
+    VLLM_DCP_PROJECT_BEFORE_MERGE: bool = False
+    VLLM_DCP_PROJECT_BEFORE_MERGE_MIN_PREFILL_TOKENS: int = 1024
     VLLM_DCP_A2A_MAX_TOKENS: int = 0
     VLLM_DCP_A2A_LARGE_BACKEND: Literal["ag_rs", "a2a"] = "ag_rs"
     VLLM_DCP_SHARD_DRAFT: str | None = None
@@ -1081,6 +1083,16 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     # Use b12x PCIe collectives for DCP query gather and output reduction.
     "VLLM_USE_B12X_DCP_A2A": lambda: bool(int(os.getenv("VLLM_USE_B12X_DCP_A2A", "0"))),
+    # Project rank-local sparse MLA partials before their DCP merge. This is
+    # opt-in until the guarded TP4 path has been benchmarked against baseline.
+    "VLLM_DCP_PROJECT_BEFORE_MERGE": lambda: bool(
+        int(os.getenv("VLLM_DCP_PROJECT_BEFORE_MERGE", "0"))
+    ),
+    # Strict lower bound on actual prefill/extend rows. Keep it above every
+    # CUDA graph capture size so the weight gather remains eager-only.
+    "VLLM_DCP_PROJECT_BEFORE_MERGE_MIN_PREFILL_TOKENS": lambda: int(
+        os.getenv("VLLM_DCP_PROJECT_BEFORE_MERGE_MIN_PREFILL_TOKENS", "1024")
+    ),
     # Token cap for the low-latency DCP A2A exchange (0 = uncapped). Batches
     # with more tokens than this bypass the one-shot A2A/B12X path, which is
     # latency-optimal for small decode batches but loses to pipelined NCCL

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -67,6 +67,7 @@ if TYPE_CHECKING:
     VLLM_USE_B12X_DCP_A2A: bool = False
     VLLM_DCP_PROJECT_BEFORE_MERGE: bool = False
     VLLM_DCP_PROJECT_BEFORE_MERGE_MIN_PREFILL_TOKENS: int = 1024
+    VLLM_B12X_MLA_DCP_GATHER_IN_WORKSPACE: bool = False
     VLLM_DCP_A2A_MAX_TOKENS: int = 0
     VLLM_DCP_A2A_LARGE_BACKEND: Literal["ag_rs", "a2a"] = "ag_rs"
     VLLM_DCP_SHARD_DRAFT: str | None = None
@@ -1092,6 +1093,16 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # CUDA graph capture size so the weight gather remains eager-only.
     "VLLM_DCP_PROJECT_BEFORE_MERGE_MIN_PREFILL_TOKENS": lambda: int(
         os.getenv("VLLM_DCP_PROJECT_BEFORE_MERGE_MIN_PREFILL_TOKENS", "1024")
+    ),
+    # Reuse the B12X sparse-MLA query/scratch buffers for the guarded TP4/DCP4
+    # eager prefill path. The old name is retained for v1.3 compatibility.
+    "VLLM_B12X_MLA_DCP_GATHER_IN_WORKSPACE": lambda: bool(
+        int(
+            os.getenv(
+                "VLLM_B12X_MLA_DCP_GATHER_IN_WORKSPACE",
+                os.getenv("B12X_MLA_DCP_GATHER_IN_WORKSPACE", "0"),
+            )
+        )
     ),
     # Token cap for the low-latency DCP A2A exchange (0 = uncapped). Batches
     # with more tokens than this bypass the one-shot A2A/B12X path, which is

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -273,6 +273,7 @@ from vllm.v1.attention.ops.common import cp_lse_ag_out_rs
 from vllm.v1.attention.ops.dcp_alltoall import (
     dcp_a2a_lse_reduce,
     dcp_b12x_all_gather_heads,
+    sanitize_dcp_attn_empty_rows,
 )
 from vllm.v1.attention.ops.merge_attn_states import merge_attn_states
 from vllm.v1.attention.selector import get_attn_backend
@@ -551,6 +552,37 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             and _vllm_config is not None
             and _vllm_config.parallel_config.decode_context_parallel_size in (2, 4, 8)
         )
+        configured_dcp_world_size = (
+            _vllm_config.parallel_config.decode_context_parallel_size
+            if _vllm_config is not None
+            else 1
+        )
+        self.dcp_project_before_merge = (
+            configured_dcp_world_size > 1
+            and envs.VLLM_DCP_PROJECT_BEFORE_MERGE
+            and getattr(self.impl, "supports_dcp_project_before_merge", False)
+        )
+        self.W_UV_dcp: torch.Tensor | None = None
+        self.dcp_project_before_merge_min_prefill_tokens = (
+            envs.VLLM_DCP_PROJECT_BEFORE_MERGE_MIN_PREFILL_TOKENS
+        )
+        if self.dcp_project_before_merge_min_prefill_tokens < 0:
+            raise ValueError(
+                "VLLM_DCP_PROJECT_BEFORE_MERGE_MIN_PREFILL_TOKENS must be "
+                "non-negative, got "
+                f"{self.dcp_project_before_merge_min_prefill_tokens}."
+            )
+        max_capture_size = max(compilation_config.cudagraph_capture_sizes, default=0)
+        if (
+            self.dcp_project_before_merge
+            and self.dcp_project_before_merge_min_prefill_tokens < max_capture_size
+        ):
+            raise ValueError(
+                "VLLM_DCP_PROJECT_BEFORE_MERGE_MIN_PREFILL_TOKENS "
+                f"({self.dcp_project_before_merge_min_prefill_tokens}) must "
+                "be at least the maximum cudagraph capture size "
+                f"({max_capture_size})."
+            )
         self.dcp_max_batch_size = (
             int(_vllm_config.scheduler_config.max_num_batched_tokens)
             if _vllm_config is not None
@@ -765,6 +797,36 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             num_mqa_tokens = attn_metadata.num_decode_tokens
             num_mha_tokens = q.size(0) - num_mqa_tokens
 
+        persistent_w_uv_capable = (
+            self.dcp_project_before_merge
+            and self.impl.dcp_world_size > 1
+            and is_sparse_impl
+            and getattr(self.impl, "supports_dcp_project_before_merge", False)
+            and self.W_UV_dcp is not None
+            and self.W_UV_dcp.dtype == torch.bfloat16
+            and self.W_UV_dcp.is_contiguous()
+            and self.W_UV.dtype == torch.bfloat16
+            and self.W_UV.is_contiguous()
+            and self.W_UV.device == self.W_UV_dcp.device
+        )
+        num_prefill_tokens = (
+            getattr(attn_metadata, "num_prefill_tokens", None)
+            if persistent_w_uv_capable
+            else None
+        )
+        if num_prefill_tokens is None:
+            if persistent_w_uv_capable:
+                raise RuntimeError(
+                    f"{type(self.impl).__name__} enables DCP "
+                    "project-before-merge without num_prefill_tokens metadata."
+                )
+            num_prefill_tokens = 0
+        use_persistent_w_uv = (
+            persistent_w_uv_capable
+            and attn_metadata.max_query_len > 1
+            and num_prefill_tokens > self.dcp_project_before_merge_min_prefill_tokens
+        )
+
         mha_use_quant_output = (
             quant_key is not None
             and self.prefill_backend.supports_quant_output(quant_key)
@@ -856,6 +918,8 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 )
             else:
                 mqa_q = (mqa_ql_nope, mqa_q_pe)
+            dcp_use_a2a = False
+            project_before_merge = False
             if self.impl.dcp_world_size > 1:
                 if isinstance(mqa_q, tuple):
                     # concatenate mqa_ql_nope and mqa_q_pe -> (B, N, L + P)
@@ -873,13 +937,20 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 dcp_use_a2a = self.dcp_a2a and (
                     dcp_small_batch or self.dcp_a2a_large_backend != "ag_rs"
                 )
+                # The project-before path currently targets eager AG/RS
+                # prefill. A2A retains its established merge-then-project path.
+                project_before_merge = use_persistent_w_uv and not dcp_use_a2a
                 # mqa_q do allgather in head dim.
                 if dcp_use_b12x:
                     mqa_q = dcp_b12x_all_gather_heads(
                         mqa_q,
                         get_dcp_group(),
                         max_batch_size=self.dcp_max_batch_size,
-                        output_head_dim=self.kv_lora_rank,
+                        output_head_dim=(
+                            self.v_head_dim
+                            if project_before_merge
+                            else self.kv_lora_rank
+                        ),
                     )
                 else:
                     mqa_q = get_dcp_group().all_gather(mqa_q, dim=1)
@@ -896,6 +967,38 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                         f"{type(self.impl).__name__} did not return decode "
                         "softmax LSE required by DCP."
                     )
+                valid_counts = None
+                if project_before_merge:
+                    valid_counts_tensor = getattr(
+                        attn_metadata, "nsa_cache_seqlens", None
+                    )
+                    if (
+                        not isinstance(valid_counts_tensor, torch.Tensor)
+                        or valid_counts_tensor.ndim != 1
+                        or valid_counts_tensor.numel() < num_mqa_tokens
+                        or valid_counts_tensor.dtype != torch.int32
+                        or valid_counts_tensor.device != attn_out.device
+                    ):
+                        raise RuntimeError(
+                            "Projected DCP merge requires a one-dimensional "
+                            f"int32 nsa_cache_seqlens tensor with at least "
+                            f"{num_mqa_tokens} rows on {attn_out.device}."
+                        )
+                    valid_counts = valid_counts_tensor[:num_mqa_tokens]
+                    if not valid_counts.is_contiguous():
+                        raise RuntimeError(
+                            "Projected DCP valid counts must be contiguous."
+                        )
+                    w_uv_dcp = self.W_UV_dcp
+                    if w_uv_dcp is None:
+                        raise RuntimeError(
+                            "Persistent DCP W_UV is unavailable for projection."
+                        )
+                    projected = attn_out.new_empty(
+                        attn_out.shape[0], attn_out.shape[1], self.v_head_dim
+                    )
+                    self._v_up_proj_bmm(attn_out, projected, w_uv_dcp)
+                    attn_out = projected
                 if dcp_use_a2a:
                     attn_out = dcp_a2a_lse_reduce(
                         attn_out,
@@ -907,6 +1010,8 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                         b12x_query_head_dim=(self.kv_lora_rank + self.qk_rope_head_dim),
                     )
                 else:
+                    if project_before_merge:
+                        sanitize_dcp_attn_empty_rows(attn_out, lse, valid_counts)
                     attn_out = cp_lse_ag_out_rs(
                         attn_out,
                         lse,
@@ -914,8 +1019,10 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                         is_lse_base_on_e=self.impl.lse_base_on_e,
                     )
 
-            # v_up projection
-            self._v_up_proj(attn_out, out=mqa_output_slice)
+            if project_before_merge:
+                mqa_output_slice.copy_(attn_out.reshape(mqa_output_slice.shape))
+            else:
+                self._v_up_proj(attn_out, out=mqa_output_slice)
 
         if quant_key is not None:
             quant_idx = num_mqa_tokens if mha_use_quant_output else num_actual_toks
@@ -1046,6 +1153,36 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             self.W_UV = W_UV.transpose(0, 1)
             # Convert from (L, N, P) to (N, P, L)
             self.W_UK_T = W_UK.permute(1, 2, 0)
+            if self.dcp_project_before_merge and self.W_UV.dtype == torch.bfloat16:
+                dcp_group = get_dcp_group()
+                local_w_uv = self.W_UV.contiguous()
+                expected_shape = (
+                    dcp_group.world_size * self.num_heads,
+                    self.kv_lora_rank,
+                    self.v_head_dim,
+                )
+                w_uv_dcp = dcp_group.all_gather(local_w_uv, dim=0)
+                if (
+                    w_uv_dcp.shape != expected_shape
+                    or w_uv_dcp.dtype != torch.bfloat16
+                    or w_uv_dcp.device != local_w_uv.device
+                    or not w_uv_dcp.is_contiguous()
+                ):
+                    raise RuntimeError(
+                        "Invalid persistent rank-major DCP W_UV gather: expected "
+                        f"contiguous {expected_shape} on {local_w_uv.device}, got "
+                        f"{tuple(w_uv_dcp.shape)} on {w_uv_dcp.device}/"
+                        f"{w_uv_dcp.dtype}."
+                    )
+                rank_start = dcp_group.rank_in_group * self.num_heads
+                gathered_local_w_uv = w_uv_dcp.narrow(0, rank_start, self.num_heads)
+                if not torch.equal(
+                    gathered_local_w_uv.view(torch.int16),
+                    local_w_uv.view(torch.int16),
+                ):
+                    raise RuntimeError("Persistent DCP W_UV gather is not rank-major.")
+                self.W_UV_dcp = w_uv_dcp
+                self.W_UV = gathered_local_w_uv
 
         # If we should not load quant weights, we initialize the scales to 1.0
         # as the default value. See [Note: Register q/k/v/prob scales in state dict]
@@ -1118,6 +1255,53 @@ class MLAAttention(nn.Module, AttentionLayerBase):
         else:
             # Multiply + Transpose (N, B, L) x (N, L, V)->(N, B, V)->(B, N, V)
             torch.bmm(x, self.W_UV, out=out.transpose(0, 1))
+
+    def _v_up_proj_bmm(
+        self,
+        x: torch.Tensor,
+        out: torch.Tensor,
+        w_uv: torch.Tensor,
+    ) -> None:
+        """Project BF16 DCP partials with rank-major gathered W_UV."""
+        if x.ndim != 3 or out.ndim != 3 or w_uv.ndim != 3:
+            raise ValueError("DCP projection expects rank-three tensors.")
+        num_tokens, num_heads, latent_dim = x.shape
+        expected_out_shape = (num_tokens, num_heads, self.v_head_dim)
+        expected_weight_shape = (
+            num_heads,
+            self.kv_lora_rank,
+            self.v_head_dim,
+        )
+        if (
+            latent_dim != self.kv_lora_rank
+            or out.shape != expected_out_shape
+            or w_uv.shape != expected_weight_shape
+        ):
+            raise ValueError(
+                "DCP projection geometry mismatch: "
+                f"x={tuple(x.shape)}, out={tuple(out.shape)}, "
+                f"w_uv={tuple(w_uv.shape)}."
+            )
+        if (
+            x.dtype != torch.bfloat16
+            or out.dtype != x.dtype
+            or w_uv.dtype != x.dtype
+            or out.device != x.device
+            or w_uv.device != x.device
+            or not w_uv.is_contiguous()
+        ):
+            raise ValueError(
+                "DCP projection requires contiguous BF16 weights and matching "
+                "BF16 inputs/outputs on one device."
+            )
+        x_head_major = x.transpose(0, 1).contiguous()
+        projected_head_major = torch.empty(
+            (num_heads, num_tokens, self.v_head_dim),
+            dtype=out.dtype,
+            device=out.device,
+        )
+        torch.bmm(x_head_major, w_uv, out=projected_head_major)
+        out.copy_(projected_head_major.transpose(0, 1))
 
 
 def unified_mla_kv_cache_update(

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -269,7 +269,10 @@ from vllm.v1.attention.backends.utils import (
     get_dcp_local_seq_lens,
     split_decodes_and_prefills,
 )
-from vllm.v1.attention.ops.common import cp_lse_ag_out_rs
+from vllm.v1.attention.ops.common import (
+    cp_lse_ag_out_rs,
+    cp_lse_ag_out_rs_into,
+)
 from vllm.v1.attention.ops.dcp_alltoall import (
     dcp_a2a_lse_reduce,
     dcp_b12x_all_gather_heads,
@@ -286,6 +289,30 @@ from vllm.v1.kv_cache_interface import (
 logger = init_logger(__name__)
 
 _FP8_DTYPE = current_platform.fp8_dtype()
+
+
+def _can_use_b12x_dcp_prefill_workspace(
+    *,
+    enabled: bool,
+    project_before_merge: bool,
+    dcp_use_b12x: bool,
+    num_tokens: int,
+    non_dbo_workspace: bool,
+    is_sparse_impl: bool,
+    backend_name: str,
+    is_capturing: bool,
+) -> bool:
+    """Gate the exact B12X TP4/DCP4 eager-prefill workspace contract."""
+    return (
+        enabled
+        and project_before_merge
+        and not dcp_use_b12x
+        and 1025 <= num_tokens <= 3072
+        and non_dbo_workspace
+        and is_sparse_impl
+        and backend_name == "B12X_MLA_SPARSE"
+        and not is_capturing
+    )
 
 
 def _match_merge_strides(
@@ -797,32 +824,23 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             num_mha_tokens = q.size(0) - num_mqa_tokens
 
         ondemand_w_uv_capable = (
-            self.dcp_project_before_merge
+            getattr(self, "dcp_project_before_merge", False)
             and self.impl.dcp_world_size > 1
             and is_sparse_impl
             and getattr(self.impl, "supports_dcp_project_before_merge", False)
             and hasattr(self, "W_UV")
             and self.W_UV.dtype == torch.bfloat16
-            and self.W_UV.is_contiguous()
         )
-        num_prefill_tokens = (
-            getattr(attn_metadata, "num_prefill_tokens", None)
-            if ondemand_w_uv_capable
-            else None
+        project_before_merge_min_tokens = getattr(
+            self,
+            "dcp_project_before_merge_min_prefill_tokens",
+            1024,
         )
-        if num_prefill_tokens is None:
-            if ondemand_w_uv_capable:
-                raise RuntimeError(
-                    f"{type(self.impl).__name__} enables DCP "
-                    "project-before-merge without num_prefill_tokens metadata."
-                )
-            num_prefill_tokens = 0
         use_ondemand_w_uv = (
             ondemand_w_uv_capable
             and attn_metadata.max_query_len > 1
-            and num_prefill_tokens > self.dcp_project_before_merge_min_prefill_tokens
+            and num_mqa_tokens > project_before_merge_min_tokens
         )
-
         mha_use_quant_output = (
             quant_key is not None
             and self.prefill_backend.supports_quant_output(quant_key)
@@ -916,10 +934,8 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 mqa_q = (mqa_ql_nope, mqa_q_pe)
             dcp_use_a2a = False
             project_before_merge = False
+            workspace_gather_used = False
             if self.impl.dcp_world_size > 1:
-                if isinstance(mqa_q, tuple):
-                    # concatenate mqa_ql_nope and mqa_q_pe -> (B, N, L + P)
-                    mqa_q = torch.cat(mqa_q, dim=-1)
                 # Hybrid dispatch on the per-step token count. This is
                 # CUDA-graph safe: under capture the branch sees the padded
                 # capture size, so every graph bakes in one path, and eager
@@ -936,6 +952,21 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 # The project-before path currently targets eager AG/RS
                 # prefill. A2A retains its established merge-then-project path.
                 project_before_merge = use_ondemand_w_uv and not dcp_use_a2a
+                workspace_gather_eligible = _can_use_b12x_dcp_prefill_workspace(
+                    enabled=envs.VLLM_B12X_MLA_DCP_GATHER_IN_WORKSPACE,
+                    project_before_merge=project_before_merge,
+                    dcp_use_b12x=dcp_use_b12x,
+                    num_tokens=num_mqa_tokens,
+                    non_dbo_workspace=getattr(
+                        self.impl, "dcp_workspace_non_dbo", False
+                    ),
+                    is_sparse_impl=is_sparse_impl,
+                    backend_name=self.attn_backend.get_name(),
+                    is_capturing=torch.cuda.is_current_stream_capturing(),
+                )
+                if isinstance(mqa_q, tuple) and not workspace_gather_eligible:
+                    # Ordinary communicators require one contiguous query.
+                    mqa_q = torch.cat(mqa_q, dim=-1)
                 # mqa_q do allgather in head dim.
                 if dcp_use_b12x:
                     mqa_q = dcp_b12x_all_gather_heads(
@@ -947,6 +978,24 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                             if project_before_merge
                             else self.kv_lora_rank
                         ),
+                    )
+                elif workspace_gather_eligible:
+                    workspace_gather = getattr(
+                        self.impl, "dcp_all_gather_query_in_workspace", None
+                    )
+                    if not getattr(
+                        self.impl,
+                        "supports_dcp_gather_query_in_workspace",
+                        False,
+                    ) or not callable(workspace_gather):
+                        raise RuntimeError(
+                            f"{type(self.impl).__name__} does not support the "
+                            "enabled workspace DCP query gather"
+                        )
+                    mqa_q = workspace_gather(mqa_q)
+                    workspace_gather_used = True
+                    logger.info_once(
+                        "Using borrowed B12X workspaces for TP4/DCP4 sparse MLA prefill"
                     )
                 else:
                     mqa_q = get_dcp_group().all_gather(mqa_q, dim=1)
@@ -985,7 +1034,7 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                         raise RuntimeError(
                             "Projected DCP valid counts must be contiguous."
                         )
-                    local_w_uv = self.W_UV
+                    local_w_uv = self.W_UV.contiguous()
                     w_uv_dcp = get_dcp_group().all_gather(local_w_uv, dim=0)
                     expected_shape = (
                         self.num_heads * get_dcp_group().world_size,
@@ -1005,11 +1054,28 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                             f"{tuple(w_uv_dcp.shape)} on "
                             f"{w_uv_dcp.device}/{w_uv_dcp.dtype}."
                         )
-                    projected = attn_out.new_empty(
-                        attn_out.shape[0], attn_out.shape[1], self.v_head_dim
-                    )
-                    self._v_up_proj_bmm_chunked(attn_out, projected, w_uv_dcp)
-                    attn_out = projected
+                    if workspace_gather_used:
+                        workspace_project = getattr(
+                            self.impl,
+                            "dcp_project_before_merge_in_workspace",
+                            None,
+                        )
+                        if not getattr(
+                            self.impl,
+                            "supports_dcp_project_before_merge_in_workspace",
+                            False,
+                        ) or not callable(workspace_project):
+                            raise RuntimeError(
+                                f"{type(self.impl).__name__} does not support "
+                                "workspace DCP projection"
+                            )
+                        attn_out = workspace_project(attn_out, lse, w_uv_dcp)
+                    else:
+                        projected = attn_out.new_empty(
+                            attn_out.shape[0], attn_out.shape[1], self.v_head_dim
+                        )
+                        self._v_up_proj_bmm_chunked(attn_out, projected, w_uv_dcp)
+                        attn_out = projected
                 if dcp_use_a2a:
                     attn_out = dcp_a2a_lse_reduce(
                         attn_out,
@@ -1023,15 +1089,61 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 else:
                     if project_before_merge:
                         sanitize_dcp_attn_empty_rows(attn_out, lse, valid_counts)
-                    attn_out = cp_lse_ag_out_rs(
-                        attn_out,
-                        lse,
-                        get_dcp_group(),
-                        is_lse_base_on_e=self.impl.lse_base_on_e,
-                    )
+                    if workspace_gather_used:
+                        workspace_output = getattr(
+                            self.impl,
+                            "dcp_reduce_scatter_output_in_workspace",
+                            None,
+                        )
+                        if not getattr(
+                            self.impl,
+                            "supports_dcp_reduce_scatter_output_in_workspace",
+                            False,
+                        ) or not callable(workspace_output):
+                            raise RuntimeError(
+                                f"{type(self.impl).__name__} does not support "
+                                "workspace DCP reduce-scatter output"
+                            )
+                        attn_out = cp_lse_ag_out_rs_into(
+                            attn_out,
+                            lse,
+                            get_dcp_group(),
+                            output_provider=workspace_output,
+                            is_lse_base_on_e=self.impl.lse_base_on_e,
+                        )
+                    else:
+                        attn_out = cp_lse_ag_out_rs(
+                            attn_out,
+                            lse,
+                            get_dcp_group(),
+                            is_lse_base_on_e=self.impl.lse_base_on_e,
+                        )
 
             if project_before_merge:
-                mqa_output_slice.copy_(attn_out.reshape(mqa_output_slice.shape))
+                if workspace_gather_used:
+                    expected_shape = (
+                        num_mqa_tokens,
+                        self.num_heads,
+                        self.v_head_dim,
+                    )
+                    expected_stride = (
+                        self.v_head_dim,
+                        num_mqa_tokens * self.v_head_dim,
+                        1,
+                    )
+                    if (
+                        tuple(attn_out.shape) != expected_shape
+                        or tuple(attn_out.stride()) != expected_stride
+                        or not attn_out.movedim(0, 1).is_contiguous()
+                    ):
+                        raise RuntimeError(
+                            "Workspace DCP reduce-scatter returned an invalid "
+                            f"layout: shape={tuple(attn_out.shape)}, "
+                            f"stride={tuple(attn_out.stride())}"
+                        )
+                    mqa_output_slice.view(expected_shape).copy_(attn_out)
+                else:
+                    mqa_output_slice.copy_(attn_out.reshape(mqa_output_slice.shape))
             else:
                 self._v_up_proj(attn_out, out=mqa_output_slice)
 

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -297,17 +297,18 @@ def _can_use_b12x_dcp_prefill_workspace(
     project_before_merge: bool,
     dcp_use_b12x: bool,
     num_tokens: int,
+    max_num_tokens: int,
     non_dbo_workspace: bool,
     is_sparse_impl: bool,
     backend_name: str,
     is_capturing: bool,
 ) -> bool:
-    """Gate the exact B12X TP4/DCP4 eager-prefill workspace contract."""
+    """Gate the B12X eager-prefill workspace contract."""
     return (
         enabled
         and project_before_merge
         and not dcp_use_b12x
-        and 1025 <= num_tokens <= 3072
+        and 1025 <= num_tokens <= max_num_tokens
         and non_dbo_workspace
         and is_sparse_impl
         and backend_name == "B12X_MLA_SPARSE"
@@ -957,6 +958,7 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                     project_before_merge=project_before_merge,
                     dcp_use_b12x=dcp_use_b12x,
                     num_tokens=num_mqa_tokens,
+                    max_num_tokens=getattr(self.impl, "_max_batched", 0),
                     non_dbo_workspace=getattr(
                         self.impl, "dcp_workspace_non_dbo", False
                     ),
@@ -995,7 +997,7 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                     mqa_q = workspace_gather(mqa_q)
                     workspace_gather_used = True
                     logger.info_once(
-                        "Using borrowed B12X workspaces for TP4/DCP4 sparse MLA prefill"
+                        "Using borrowed B12X workspaces for sparse MLA DCP prefill"
                     )
                 else:
                     mqa_q = get_dcp_group().all_gather(mqa_q, dim=1)

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -562,7 +562,6 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             and envs.VLLM_DCP_PROJECT_BEFORE_MERGE
             and getattr(self.impl, "supports_dcp_project_before_merge", False)
         )
-        self.W_UV_dcp: torch.Tensor | None = None
         self.dcp_project_before_merge_min_prefill_tokens = (
             envs.VLLM_DCP_PROJECT_BEFORE_MERGE_MIN_PREFILL_TOKENS
         )
@@ -797,32 +796,29 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             num_mqa_tokens = attn_metadata.num_decode_tokens
             num_mha_tokens = q.size(0) - num_mqa_tokens
 
-        persistent_w_uv_capable = (
+        ondemand_w_uv_capable = (
             self.dcp_project_before_merge
             and self.impl.dcp_world_size > 1
             and is_sparse_impl
             and getattr(self.impl, "supports_dcp_project_before_merge", False)
-            and self.W_UV_dcp is not None
-            and self.W_UV_dcp.dtype == torch.bfloat16
-            and self.W_UV_dcp.is_contiguous()
+            and hasattr(self, "W_UV")
             and self.W_UV.dtype == torch.bfloat16
             and self.W_UV.is_contiguous()
-            and self.W_UV.device == self.W_UV_dcp.device
         )
         num_prefill_tokens = (
             getattr(attn_metadata, "num_prefill_tokens", None)
-            if persistent_w_uv_capable
+            if ondemand_w_uv_capable
             else None
         )
         if num_prefill_tokens is None:
-            if persistent_w_uv_capable:
+            if ondemand_w_uv_capable:
                 raise RuntimeError(
                     f"{type(self.impl).__name__} enables DCP "
                     "project-before-merge without num_prefill_tokens metadata."
                 )
             num_prefill_tokens = 0
-        use_persistent_w_uv = (
-            persistent_w_uv_capable
+        use_ondemand_w_uv = (
+            ondemand_w_uv_capable
             and attn_metadata.max_query_len > 1
             and num_prefill_tokens > self.dcp_project_before_merge_min_prefill_tokens
         )
@@ -939,7 +935,7 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 )
                 # The project-before path currently targets eager AG/RS
                 # prefill. A2A retains its established merge-then-project path.
-                project_before_merge = use_persistent_w_uv and not dcp_use_a2a
+                project_before_merge = use_ondemand_w_uv and not dcp_use_a2a
                 # mqa_q do allgather in head dim.
                 if dcp_use_b12x:
                     mqa_q = dcp_b12x_all_gather_heads(
@@ -989,15 +985,30 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                         raise RuntimeError(
                             "Projected DCP valid counts must be contiguous."
                         )
-                    w_uv_dcp = self.W_UV_dcp
-                    if w_uv_dcp is None:
+                    local_w_uv = self.W_UV
+                    w_uv_dcp = get_dcp_group().all_gather(local_w_uv, dim=0)
+                    expected_shape = (
+                        self.num_heads * get_dcp_group().world_size,
+                        self.kv_lora_rank,
+                        self.v_head_dim,
+                    )
+                    if (
+                        w_uv_dcp.shape != expected_shape
+                        or w_uv_dcp.dtype != local_w_uv.dtype
+                        or w_uv_dcp.device != local_w_uv.device
+                        or not w_uv_dcp.is_contiguous()
+                    ):
                         raise RuntimeError(
-                            "Persistent DCP W_UV is unavailable for projection."
+                            "Invalid rank-major DCP W_UV gather: expected "
+                            f"contiguous {expected_shape} on "
+                            f"{local_w_uv.device}/{local_w_uv.dtype}, got "
+                            f"{tuple(w_uv_dcp.shape)} on "
+                            f"{w_uv_dcp.device}/{w_uv_dcp.dtype}."
                         )
                     projected = attn_out.new_empty(
                         attn_out.shape[0], attn_out.shape[1], self.v_head_dim
                     )
-                    self._v_up_proj_bmm(attn_out, projected, w_uv_dcp)
+                    self._v_up_proj_bmm_chunked(attn_out, projected, w_uv_dcp)
                     attn_out = projected
                 if dcp_use_a2a:
                     attn_out = dcp_a2a_lse_reduce(
@@ -1153,37 +1164,6 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             self.W_UV = W_UV.transpose(0, 1)
             # Convert from (L, N, P) to (N, P, L)
             self.W_UK_T = W_UK.permute(1, 2, 0)
-            if self.dcp_project_before_merge and self.W_UV.dtype == torch.bfloat16:
-                dcp_group = get_dcp_group()
-                local_w_uv = self.W_UV.contiguous()
-                expected_shape = (
-                    dcp_group.world_size * self.num_heads,
-                    self.kv_lora_rank,
-                    self.v_head_dim,
-                )
-                w_uv_dcp = dcp_group.all_gather(local_w_uv, dim=0)
-                if (
-                    w_uv_dcp.shape != expected_shape
-                    or w_uv_dcp.dtype != torch.bfloat16
-                    or w_uv_dcp.device != local_w_uv.device
-                    or not w_uv_dcp.is_contiguous()
-                ):
-                    raise RuntimeError(
-                        "Invalid persistent rank-major DCP W_UV gather: expected "
-                        f"contiguous {expected_shape} on {local_w_uv.device}, got "
-                        f"{tuple(w_uv_dcp.shape)} on {w_uv_dcp.device}/"
-                        f"{w_uv_dcp.dtype}."
-                    )
-                rank_start = dcp_group.rank_in_group * self.num_heads
-                gathered_local_w_uv = w_uv_dcp.narrow(0, rank_start, self.num_heads)
-                if not torch.equal(
-                    gathered_local_w_uv.view(torch.int16),
-                    local_w_uv.view(torch.int16),
-                ):
-                    raise RuntimeError("Persistent DCP W_UV gather is not rank-major.")
-                self.W_UV_dcp = w_uv_dcp
-                self.W_UV = gathered_local_w_uv
-
         # If we should not load quant weights, we initialize the scales to 1.0
         # as the default value. See [Note: Register q/k/v/prob scales in state dict]
         # for more details.
@@ -1302,6 +1282,35 @@ class MLAAttention(nn.Module, AttentionLayerBase):
         )
         torch.bmm(x_head_major, w_uv, out=projected_head_major)
         out.copy_(projected_head_major.transpose(0, 1))
+
+    def _v_up_proj_bmm_chunked(
+        self,
+        x: torch.Tensor,
+        out: torch.Tensor,
+        w_uv: torch.Tensor,
+    ) -> None:
+        """Bound temporary BF16 DCP projection storage to 144 MiB."""
+        if x.ndim != 3 or out.ndim != 3 or w_uv.ndim != 3:
+            raise ValueError(
+                "DCP projection expects rank-three tensors: "
+                f"x={tuple(x.shape)}, out={tuple(out.shape)}, "
+                f"w_uv={tuple(w_uv.shape)}."
+            )
+        num_tokens, num_heads, latent_dim = x.shape
+        if latent_dim != self.kv_lora_rank or w_uv.shape[0] != num_heads:
+            raise ValueError(
+                "DCP projection geometry mismatch: "
+                f"x={tuple(x.shape)}, w_uv={tuple(w_uv.shape)}."
+            )
+
+        temp_budget_bytes = 144 * 1024 * 1024
+        temp_bytes_per_token = (
+            num_heads * (self.kv_lora_rank + self.v_head_dim) * x.element_size()
+        )
+        max_chunk_tokens = max(1, temp_budget_bytes // temp_bytes_per_token)
+        for start in range(0, num_tokens, max_chunk_tokens):
+            end = min(start + max_chunk_tokens, num_tokens)
+            self._v_up_proj_bmm(x[start:end], out[start:end], w_uv)
 
 
 def unified_mla_kv_cache_update(

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -53,7 +53,10 @@ from vllm.v1.attention.backend import (
 from vllm.v1.attention.backends.mla.sparse_utils import (
     triton_filter_and_convert_dcp_index,
 )
-from vllm.v1.attention.backends.utils import get_dcp_local_seq_lens
+from vllm.v1.attention.backends.utils import (
+    get_dcp_local_seq_lens,
+    split_decodes_and_prefills,
+)
 from vllm.v1.kv_cache_interface import AttentionSpec
 from vllm.v1.worker.workspace import current_workspace_manager
 
@@ -240,6 +243,8 @@ class B12xMLASparseMetadata(AttentionMetadata):
     max_query_len: int
     max_seq_len: int
     num_actual_tokens: int
+    num_decode_tokens: int
+    num_prefill_tokens: int
 
     query_start_loc: torch.Tensor
     slot_mapping: torch.Tensor
@@ -328,6 +333,24 @@ class B12xMLASparseMetadataBuilder(AttentionMetadataBuilder[B12xMLASparseMetadat
     ) -> B12xMLASparseMetadata:
         cm = common_attn_metadata
         num_tokens = cm.num_actual_tokens
+        if cm.max_query_len <= 1 and num_tokens == cm.num_reqs:
+            num_decode_tokens = num_tokens
+            num_prefill_tokens = 0
+        elif cm.batch_topology is not None:
+            _, _, num_decode_tokens, num_prefill_tokens = (
+                cm.batch_topology.split_decodes_and_prefills(
+                    cm,
+                    decode_threshold=1,
+                    treat_short_extends_as_decodes=True,
+                )
+            )
+        else:
+            _, _, num_decode_tokens, num_prefill_tokens = split_decodes_and_prefills(
+                cm,
+                decode_threshold=1,
+                treat_short_extends_as_decodes=True,
+            )
+        assert num_decode_tokens + num_prefill_tokens == num_tokens
 
         use_dcp = self.dcp_world_size > 1
         seq_lens_for_req = (
@@ -453,6 +476,8 @@ class B12xMLASparseMetadataBuilder(AttentionMetadataBuilder[B12xMLASparseMetadat
             max_query_len=cm.max_query_len,
             max_seq_len=cm.max_seq_len,
             num_actual_tokens=num_tokens,
+            num_decode_tokens=num_decode_tokens,
+            num_prefill_tokens=num_prefill_tokens,
             query_start_loc=cm.query_start_loc,
             slot_mapping=cm.slot_mapping,
             block_table=cm.block_table_tensor,
@@ -479,6 +504,7 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
     """b12x unified sparse-MLA implementation (decode + extend/prefill)."""
 
     can_return_lse_for_decode: bool = True
+    supports_dcp_project_before_merge: bool = True
 
     def __init__(
         self,

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -753,25 +753,84 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
     def _borrow_workspaces(self) -> list[torch.Tensor]:
         return current_workspace_manager().get_simultaneous(*self._workspace_specs)
 
-    def _validate_dcp_prefill_workspace_contract(self, num_tokens: int) -> None:
+    def _borrow_workspace_parts(
+        self,
+    ) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor]:
+        workspace_tensors = self._borrow_workspaces()
+        expected_count = 3 if self._pad_heads else 2
+        if len(workspace_tensors) != expected_count:
+            raise RuntimeError(
+                "B12X DCP prefill borrowed an unexpected workspace count: "
+                f"{len(workspace_tensors)} != {expected_count}"
+            )
+        q_workspace = workspace_tensors[0]
+        dense_out_workspace = workspace_tensors[1] if self._pad_heads else None
+        scratch_storage = workspace_tensors[-1]
+        expected_q_shape = (
+            self._max_batched,
+            self._kernel_num_heads,
+            self.q_head_dim,
+        )
         if (
-            self._max_batched != 3072
-            or not 1025 <= num_tokens <= 3072
+            tuple(q_workspace.shape) != expected_q_shape
+            or q_workspace.dtype != torch.bfloat16
+            or q_workspace.device != self.device
+            or not q_workspace.is_contiguous()
+        ):
+            raise RuntimeError(
+                "B12X DCP prefill borrowed an invalid query workspace: "
+                f"shape={tuple(q_workspace.shape)}, dtype={q_workspace.dtype}, "
+                f"device={q_workspace.device}"
+            )
+        if dense_out_workspace is not None and (
+            tuple(dense_out_workspace.shape)
+            != (self._max_batched, self._input_num_heads, self.kv_lora_rank)
+            or dense_out_workspace.dtype != torch.bfloat16
+            or dense_out_workspace.device != self.device
+            or not dense_out_workspace.is_contiguous()
+        ):
+            raise RuntimeError("B12X DCP prefill borrowed an invalid dense output")
+        if (
+            tuple(scratch_storage.shape) != (self._scratch_nbytes,)
+            or scratch_storage.dtype != torch.uint8
+            or scratch_storage.device != self.device
+            or not scratch_storage.is_contiguous()
+        ):
+            raise RuntimeError("B12X DCP prefill borrowed an invalid raw scratch")
+        return q_workspace, dense_out_workspace, scratch_storage
+
+    def _validate_dcp_prefill_workspace_contract(self, num_tokens: int) -> None:
+        supported_topologies = {
+            (4, 4),
+            (6, 2),
+            (6, 3),
+            (6, 6),
+            (8, 2),
+            (8, 4),
+            (8, 8),
+        }
+        if (
+            not 1025 <= num_tokens <= self._max_batched
             or not self.dcp_workspace_non_dbo
-            or self.tp_world_size != 4
-            or self.dcp_world_size != 4
-            or self.num_heads != 16
-            or self._input_num_heads != 64
-            or self._kernel_num_heads != 64
-            or self._pad_heads
+            or (self.tp_world_size, self.dcp_world_size) not in supported_topologies
+            or self.dcp_world_size <= 1
+            or self.num_heads <= 0
+            or self._input_num_heads != self.num_heads * self.dcp_world_size
+            or self._kernel_num_heads < self._input_num_heads
+            or self._kernel_num_heads % _HEAD_ALIGNMENT != 0
             or self.q_head_dim != 576
             or self.kv_lora_rank != 512
             or self.v_head_dim != 256
         ):
             raise RuntimeError(
-                "The DCP prefill workspace path requires TP4/DCP4, "
-                "MNBT=3072, 1025..3072 rows, "
-                "16/64 heads and MLA dimensions 576/512/256"
+                "The DCP prefill workspace path received an unsupported "
+                "topology or geometry: "
+                f"tokens={num_tokens}/{self._max_batched}, "
+                f"TP/DCP={self.tp_world_size}/{self.dcp_world_size}, "
+                f"local/input/kernel heads={self.num_heads}/"
+                f"{self._input_num_heads}/{self._kernel_num_heads}, "
+                f"pad_heads={self._pad_heads}, dimensions="
+                f"{self.q_head_dim}/{self.kv_lora_rank}/{self.v_head_dim}"
             )
         if torch.cuda.is_current_stream_capturing():
             raise RuntimeError("The DCP prefill workspace path is eager-only")
@@ -802,26 +861,20 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
             query_device = q.device
 
         self._validate_dcp_prefill_workspace_contract(int(num_tokens))
-        if local_heads != 16 or query_device != self.device:
-            raise ValueError(
-                "DCP workspace requires 16 local heads on the planned device"
-            )
+        if local_heads != self.num_heads or query_device != self.device:
+            raise ValueError("DCP workspace query does not match the MLA plan")
 
         from vllm.distributed.parallel_state import get_dcp_group
 
         dcp_group = get_dcp_group()
         process_group = dcp_group.device_group
-        if dcp_group.world_size != 4 or dcp_group.rank_in_group != self.dcp_rank:
+        if (
+            dcp_group.world_size != self.dcp_world_size
+            or dcp_group.rank_in_group != self.dcp_rank
+        ):
             raise RuntimeError("DCP workspace group does not match the MLA plan")
 
-        q_workspace, scratch_storage = self._borrow_workspaces()
-        if (
-            tuple(q_workspace.shape) != (3072, 64, 576)
-            or q_workspace.dtype != torch.bfloat16
-            or tuple(scratch_storage.shape) != (self._scratch_nbytes,)
-            or scratch_storage.dtype != torch.uint8
-        ):
-            raise RuntimeError("DCP prefill borrowed an unexpected workspace layout")
+        q_workspace, _, scratch_storage = self._borrow_workspace_parts()
         q_begin = q_workspace.data_ptr()
         q_end = q_begin + q_workspace.numel() * q_workspace.element_size()
         scratch_begin = scratch_storage.data_ptr()
@@ -829,22 +882,19 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
         if q_begin < scratch_end and scratch_begin < q_end:
             raise RuntimeError("DCP query and scratch workspaces overlap")
 
-        world_size = 4
-        head_dim = 576
-        gather_scratch_nbytes = 3072 * 64 * 512 * _BF16_BYTES
-        if gather_scratch_nbytes > scratch_storage.numel():
-            raise RuntimeError("DCP scratch cannot hold the gather staging area")
+        world_size = self.dcp_world_size
+        head_dim = self.q_head_dim
         bytes_per_chunk_row = world_size * local_heads * head_dim * _BF16_BYTES
-        chunk_capacity = gather_scratch_nbytes // bytes_per_chunk_row
-        if chunk_capacity != 2730:
-            raise RuntimeError("Unexpected DCP workspace gather chunk capacity")
+        chunk_capacity = scratch_storage.numel() // bytes_per_chunk_row
+        if chunk_capacity <= 0:
+            raise RuntimeError("DCP scratch cannot hold one gathered query row")
 
         q_workspace_flat = q_workspace.view(-1)
         chunk_start = 0
         while chunk_start < num_tokens:
             chunk_rows = min(chunk_capacity, num_tokens - chunk_start)
             if tuple_input:
-                local_offset = chunk_start * 64 * head_dim
+                local_offset = chunk_start * self._kernel_num_heads * head_dim
                 local_numel = chunk_rows * local_heads * head_dim
                 local_chunk = q_workspace_flat.narrow(
                     0, local_offset, local_numel
@@ -877,9 +927,13 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
                 )
             chunk_start += chunk_rows
 
-        global_query = q_workspace[:num_tokens]
-        if not global_query.is_contiguous():
-            raise RuntimeError("DCP workspace did not produce a contiguous query")
+        global_query = q_workspace[:num_tokens, : self._input_num_heads]
+        expected_stride = (self._kernel_num_heads * head_dim, head_dim, 1)
+        if (
+            tuple(global_query.shape) != (num_tokens, self._input_num_heads, head_dim)
+            or tuple(global_query.stride()) != expected_stride
+        ):
+            raise RuntimeError("DCP workspace produced an invalid query view")
         return global_query
 
     def dcp_project_before_merge_in_workspace(
@@ -892,41 +946,50 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
         num_tokens = int(attn_out.shape[0])
         self._validate_dcp_prefill_workspace_contract(num_tokens)
         if (
-            tuple(attn_out.shape) != (num_tokens, 64, 512)
+            tuple(attn_out.shape)
+            != (num_tokens, self._input_num_heads, self.kv_lora_rank)
             or not attn_out.is_contiguous()
             or attn_out.dtype != torch.bfloat16
-            or tuple(w_uv.shape) != (64, 512, 256)
+            or tuple(w_uv.shape)
+            != (self._input_num_heads, self.kv_lora_rank, self.v_head_dim)
             or not w_uv.is_contiguous()
             or w_uv.dtype != torch.bfloat16
-            or tuple(lse.shape) != (num_tokens, 64)
+            or tuple(lse.shape) != (num_tokens, self._input_num_heads)
             or lse.dtype != torch.float32
         ):
             raise ValueError(
                 "DCP workspace projection received an invalid tensor layout"
             )
 
-        q_workspace, scratch_storage = self._borrow_workspaces()
-        input_numel = 64 * num_tokens * 512
-        projected_numel = 64 * num_tokens * 256
+        q_workspace, dense_out_workspace, scratch_storage = (
+            self._borrow_workspace_parts()
+        )
+        input_numel = self._input_num_heads * num_tokens * self.kv_lora_rank
+        projected_numel = self._input_num_heads * num_tokens * self.v_head_dim
         projected_nbytes = projected_numel * _BF16_BYTES
         if (
             q_workspace.numel() < input_numel
             or scratch_storage.numel() < projected_nbytes
         ):
             raise RuntimeError("DCP projection workspace is too small")
-        if (
-            attn_out.untyped_storage().data_ptr()
-            != scratch_storage.untyped_storage().data_ptr()
+        expected_attn_storage = (
+            dense_out_workspace if self._pad_heads else scratch_storage
+        )
+        assert expected_attn_storage is not None
+        if attn_out.untyped_storage().data_ptr() != (
+            expected_attn_storage.untyped_storage().data_ptr()
         ):
             raise RuntimeError(
-                "DCP attention output is not backed by the MLA scratch workspace"
+                "DCP attention output is not backed by the expected MLA workspace"
             )
 
-        projection_input = q_workspace.view(-1)[:input_numel].view(64, num_tokens, 512)
+        projection_input = q_workspace.view(-1)[:input_numel].view(
+            self._input_num_heads, num_tokens, self.kv_lora_rank
+        )
         projected_head_major = (
             scratch_storage[:projected_nbytes]
             .view(torch.bfloat16)
-            .view(64, num_tokens, 256)
+            .view(self._input_num_heads, num_tokens, self.v_head_dim)
         )
         projection_input.copy_(attn_out.transpose(0, 1))
         torch.bmm(projection_input, w_uv, out=projected_head_major)
@@ -936,18 +999,19 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
         self,
         corrected_attn_out: torch.Tensor,
     ) -> torch.Tensor:
-        """Expose the dead query prefix as DCP4 reduce-scatter output."""
+        """Expose the dead query prefix as DCP reduce-scatter output."""
         num_tokens = int(corrected_attn_out.shape[0])
         self._validate_dcp_prefill_workspace_contract(num_tokens)
         input_head_major = corrected_attn_out.movedim(0, 1)
         if (
-            tuple(corrected_attn_out.shape) != (num_tokens, 64, 256)
+            tuple(corrected_attn_out.shape)
+            != (num_tokens, self._input_num_heads, self.v_head_dim)
             or corrected_attn_out.dtype != torch.bfloat16
             or not input_head_major.is_contiguous()
         ):
             raise ValueError("DCP reduce-scatter input has an invalid layout")
 
-        q_workspace, scratch_storage = self._borrow_workspaces()
+        q_workspace, _, scratch_storage = self._borrow_workspace_parts()
         if (
             corrected_attn_out.untyped_storage().data_ptr()
             != scratch_storage.untyped_storage().data_ptr()
@@ -955,9 +1019,9 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
             raise RuntimeError(
                 "DCP corrected input is not backed by the MLA scratch workspace"
             )
-        output_numel = 16 * num_tokens * 256
+        output_numel = self.num_heads * num_tokens * self.v_head_dim
         output_head_major = q_workspace.view(-1)[:output_numel].view(
-            16, num_tokens, 256
+            self.num_heads, num_tokens, self.v_head_dim
         )
         output = output_head_major.transpose(0, 1)
         if not output_head_major.is_contiguous():

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -31,6 +31,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 import numpy as np
 import torch
+import torch.distributed as dist
 
 from vllm import _custom_ops as ops
 from vllm.config import VllmConfig
@@ -71,6 +72,7 @@ logger = init_logger(__name__)
 # wave-balanced planner picks num_splits <= this cap.
 _DECODE_SPLIT_TILE = 64
 _HEAD_ALIGNMENT = 8
+_BF16_BYTES = 2
 _EXTEND_PREWARM_DONE: set[
     tuple[int | None, int, int, int, int, int, bool, str, int | None]
 ] = set()
@@ -505,6 +507,9 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
 
     can_return_lse_for_decode: bool = True
     supports_dcp_project_before_merge: bool = True
+    supports_dcp_gather_query_in_workspace: bool = True
+    supports_dcp_project_before_merge_in_workspace: bool = True
+    supports_dcp_reduce_scatter_output_in_workspace: bool = True
 
     def __init__(
         self,
@@ -565,7 +570,9 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
 
         vllm_config = get_current_vllm_config()
         parallel_config = vllm_config.parallel_config
+        self.dcp_workspace_non_dbo = not bool(parallel_config.enable_dbo)
         self.dcp_world_size = parallel_config.decode_context_parallel_size
+        self.tp_world_size = int(parallel_config.tensor_parallel_size)
         self.dcp_rank = 0
         if self.dcp_world_size > 1:
             from vllm.distributed.parallel_state import get_dcp_group
@@ -736,11 +743,226 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
                 )
             )
         workspace_specs.append(((self._scratch_nbytes,), torch.uint8))
-        current_workspace_manager().get_simultaneous(*workspace_specs)
+        self._workspace_specs = tuple(workspace_specs)
+        self._borrow_workspaces()
         self._prewarm_extend_kernels_once(max_batched)
 
         # Q arrives BF16; the unified kernel quantizes inside.
         self.supports_quant_query_input = False
+
+    def _borrow_workspaces(self) -> list[torch.Tensor]:
+        return current_workspace_manager().get_simultaneous(*self._workspace_specs)
+
+    def _validate_dcp_prefill_workspace_contract(self, num_tokens: int) -> None:
+        if (
+            self._max_batched != 3072
+            or not 1025 <= num_tokens <= 3072
+            or not self.dcp_workspace_non_dbo
+            or self.tp_world_size != 4
+            or self.dcp_world_size != 4
+            or self.num_heads != 16
+            or self._input_num_heads != 64
+            or self._kernel_num_heads != 64
+            or self._pad_heads
+            or self.q_head_dim != 576
+            or self.kv_lora_rank != 512
+            or self.v_head_dim != 256
+        ):
+            raise RuntimeError(
+                "The DCP prefill workspace path requires TP4/DCP4, "
+                "MNBT=3072, 1025..3072 rows, "
+                "16/64 heads and MLA dimensions 576/512/256"
+            )
+        if torch.cuda.is_current_stream_capturing():
+            raise RuntimeError("The DCP prefill workspace path is eager-only")
+
+    def dcp_all_gather_query_in_workspace(
+        self,
+        q: torch.Tensor | tuple[torch.Tensor, torch.Tensor],
+    ) -> torch.Tensor:
+        """Gather local DCP query heads through the borrowed MLA workspaces."""
+        if isinstance(q, tuple):
+            ql_nope, q_pe = q
+            if ql_nope.ndim != 3 or q_pe.ndim != 3:
+                raise ValueError("DCP workspace tuple queries must be rank-3")
+            num_tokens, local_heads, nope_dim = ql_nope.shape
+            if tuple(q_pe.shape) != (num_tokens, local_heads, 64) or nope_dim != 512:
+                raise ValueError("DCP workspace requires noPE/RoPE dimensions 512/64")
+            if ql_nope.dtype != torch.bfloat16 or q_pe.dtype != torch.bfloat16:
+                raise TypeError("DCP workspace queries must be BF16")
+            tuple_input = True
+            query_device = ql_nope.device
+        else:
+            if q.ndim != 3:
+                raise ValueError("DCP workspace query must be rank-3")
+            num_tokens, local_heads, head_dim = q.shape
+            if head_dim != self.q_head_dim or not q.is_contiguous():
+                raise ValueError("DCP workspace tensor query has invalid layout")
+            tuple_input = False
+            query_device = q.device
+
+        self._validate_dcp_prefill_workspace_contract(int(num_tokens))
+        if local_heads != 16 or query_device != self.device:
+            raise ValueError(
+                "DCP workspace requires 16 local heads on the planned device"
+            )
+
+        from vllm.distributed.parallel_state import get_dcp_group
+
+        dcp_group = get_dcp_group()
+        process_group = dcp_group.device_group
+        if dcp_group.world_size != 4 or dcp_group.rank_in_group != self.dcp_rank:
+            raise RuntimeError("DCP workspace group does not match the MLA plan")
+
+        q_workspace, scratch_storage = self._borrow_workspaces()
+        if (
+            tuple(q_workspace.shape) != (3072, 64, 576)
+            or q_workspace.dtype != torch.bfloat16
+            or tuple(scratch_storage.shape) != (self._scratch_nbytes,)
+            or scratch_storage.dtype != torch.uint8
+        ):
+            raise RuntimeError("DCP prefill borrowed an unexpected workspace layout")
+        q_begin = q_workspace.data_ptr()
+        q_end = q_begin + q_workspace.numel() * q_workspace.element_size()
+        scratch_begin = scratch_storage.data_ptr()
+        scratch_end = scratch_begin + scratch_storage.numel()
+        if q_begin < scratch_end and scratch_begin < q_end:
+            raise RuntimeError("DCP query and scratch workspaces overlap")
+
+        world_size = 4
+        head_dim = 576
+        gather_scratch_nbytes = 3072 * 64 * 512 * _BF16_BYTES
+        if gather_scratch_nbytes > scratch_storage.numel():
+            raise RuntimeError("DCP scratch cannot hold the gather staging area")
+        bytes_per_chunk_row = world_size * local_heads * head_dim * _BF16_BYTES
+        chunk_capacity = gather_scratch_nbytes // bytes_per_chunk_row
+        if chunk_capacity != 2730:
+            raise RuntimeError("Unexpected DCP workspace gather chunk capacity")
+
+        q_workspace_flat = q_workspace.view(-1)
+        chunk_start = 0
+        while chunk_start < num_tokens:
+            chunk_rows = min(chunk_capacity, num_tokens - chunk_start)
+            if tuple_input:
+                local_offset = chunk_start * 64 * head_dim
+                local_numel = chunk_rows * local_heads * head_dim
+                local_chunk = q_workspace_flat.narrow(
+                    0, local_offset, local_numel
+                ).view(chunk_rows, local_heads, head_dim)
+                ops.concat_mla_q(
+                    ql_nope.narrow(0, chunk_start, chunk_rows),
+                    q_pe.narrow(0, chunk_start, chunk_rows),
+                    local_chunk,
+                )
+            else:
+                local_chunk = q.narrow(0, chunk_start, chunk_rows)
+
+            gather_numel = world_size * chunk_rows * local_heads * head_dim
+            gathered = (
+                scratch_storage.narrow(0, 0, gather_numel * _BF16_BYTES)
+                .view(torch.bfloat16)
+                .view(world_size * chunk_rows, local_heads, head_dim)
+            )
+            dist.all_gather_into_tensor(
+                gathered,
+                local_chunk,
+                group=process_group,
+                async_op=False,
+            )
+            rank_major = gathered.view(world_size, chunk_rows, local_heads, head_dim)
+            destination = q_workspace.narrow(0, chunk_start, chunk_rows)
+            for source_rank in range(world_size):
+                destination.narrow(1, source_rank * local_heads, local_heads).copy_(
+                    rank_major[source_rank]
+                )
+            chunk_start += chunk_rows
+
+        global_query = q_workspace[:num_tokens]
+        if not global_query.is_contiguous():
+            raise RuntimeError("DCP workspace did not produce a contiguous query")
+        return global_query
+
+    def dcp_project_before_merge_in_workspace(
+        self,
+        attn_out: torch.Tensor,
+        lse: torch.Tensor,
+        w_uv: torch.Tensor,
+    ) -> torch.Tensor:
+        """Project DCP partials from 512 to 256 in borrowed MLA storage."""
+        num_tokens = int(attn_out.shape[0])
+        self._validate_dcp_prefill_workspace_contract(num_tokens)
+        if (
+            tuple(attn_out.shape) != (num_tokens, 64, 512)
+            or not attn_out.is_contiguous()
+            or attn_out.dtype != torch.bfloat16
+            or tuple(w_uv.shape) != (64, 512, 256)
+            or not w_uv.is_contiguous()
+            or w_uv.dtype != torch.bfloat16
+            or tuple(lse.shape) != (num_tokens, 64)
+            or lse.dtype != torch.float32
+        ):
+            raise ValueError(
+                "DCP workspace projection received an invalid tensor layout"
+            )
+
+        q_workspace, scratch_storage = self._borrow_workspaces()
+        input_numel = 64 * num_tokens * 512
+        projected_numel = 64 * num_tokens * 256
+        projected_nbytes = projected_numel * _BF16_BYTES
+        if (
+            q_workspace.numel() < input_numel
+            or scratch_storage.numel() < projected_nbytes
+        ):
+            raise RuntimeError("DCP projection workspace is too small")
+        if (
+            attn_out.untyped_storage().data_ptr()
+            != scratch_storage.untyped_storage().data_ptr()
+        ):
+            raise RuntimeError(
+                "DCP attention output is not backed by the MLA scratch workspace"
+            )
+
+        projection_input = q_workspace.view(-1)[:input_numel].view(64, num_tokens, 512)
+        projected_head_major = (
+            scratch_storage[:projected_nbytes]
+            .view(torch.bfloat16)
+            .view(64, num_tokens, 256)
+        )
+        projection_input.copy_(attn_out.transpose(0, 1))
+        torch.bmm(projection_input, w_uv, out=projected_head_major)
+        return projected_head_major.transpose(0, 1)
+
+    def dcp_reduce_scatter_output_in_workspace(
+        self,
+        corrected_attn_out: torch.Tensor,
+    ) -> torch.Tensor:
+        """Expose the dead query prefix as DCP4 reduce-scatter output."""
+        num_tokens = int(corrected_attn_out.shape[0])
+        self._validate_dcp_prefill_workspace_contract(num_tokens)
+        input_head_major = corrected_attn_out.movedim(0, 1)
+        if (
+            tuple(corrected_attn_out.shape) != (num_tokens, 64, 256)
+            or corrected_attn_out.dtype != torch.bfloat16
+            or not input_head_major.is_contiguous()
+        ):
+            raise ValueError("DCP reduce-scatter input has an invalid layout")
+
+        q_workspace, scratch_storage = self._borrow_workspaces()
+        if (
+            corrected_attn_out.untyped_storage().data_ptr()
+            != scratch_storage.untyped_storage().data_ptr()
+        ):
+            raise RuntimeError(
+                "DCP corrected input is not backed by the MLA scratch workspace"
+            )
+        output_numel = 16 * num_tokens * 256
+        output_head_major = q_workspace.view(-1)[:output_numel].view(
+            16, num_tokens, 256
+        )
+        output = output_head_major.transpose(0, 1)
+        if not output_head_major.is_contiguous():
+            raise RuntimeError("DCP reduce-scatter output is not contiguous")
+        return output
 
     def _sync_warmup(self) -> None:
         if self.device.type == "cuda":
@@ -859,26 +1081,7 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
         # the kernel reads q while writing the scratch (tmp_output/output), and the
         # manager packs every call from offset 0, so separate calls would alias q
         # with the scratch and corrupt the result.
-        manager = current_workspace_manager()
-        workspace_specs: list[tuple[tuple[int, ...], torch.dtype]] = [
-            (
-                (self._max_batched, self._kernel_num_heads, self.q_head_dim),
-                torch.bfloat16,
-            )
-        ]
-        if self._pad_heads:
-            workspace_specs.append(
-                (
-                    (
-                        self._max_batched,
-                        self._input_num_heads,
-                        self.kv_lora_rank,
-                    ),
-                    torch.bfloat16,
-                )
-            )
-        workspace_specs.append(((self._scratch_nbytes,), torch.uint8))
-        workspace_tensors = manager.get_simultaneous(*workspace_specs)
+        workspace_tensors = self._borrow_workspaces()
         q_workspace = workspace_tensors[0]
         dense_out_workspace = workspace_tensors[1] if self._pad_heads else None
         scratch_storage = workspace_tensors[-1]
@@ -895,9 +1098,8 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
             q_all = q_buffer[:, :num_input_heads]
             ops.concat_mla_q(ql_nope, q_pe, q_all)
         else:
-            q_input = q.contiguous()
-            num_actual_toks = q_input.shape[0]
-            num_input_heads = q_input.shape[1]
+            num_actual_toks = q.shape[0]
+            num_input_heads = q.shape[1]
             if num_input_heads != self._input_num_heads:
                 raise ValueError(
                     "B12X_MLA_SPARSE query heads do not match the planned "
@@ -905,7 +1107,16 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
                 )
             q_buffer = q_workspace[:num_actual_toks]
             q_all = q_buffer[:, :num_input_heads]
-            q_all.copy_(q_input)
+            exact_workspace_alias = (
+                tuple(q.shape) == tuple(q_all.shape)
+                and tuple(q.stride()) == tuple(q_all.stride())
+                and q.dtype == q_all.dtype
+                and q.device == q_all.device
+                and q.untyped_storage().data_ptr() == q_all.untyped_storage().data_ptr()
+                and q.storage_offset() == q_all.storage_offset()
+            )
+            if not exact_workspace_alias:
+                q_all.copy_(q.contiguous())
 
         assert self.topk_indices_buffer is not None
         topk_indices = self.topk_indices_buffer[:num_actual_toks]

--- a/vllm/v1/attention/ops/common.py
+++ b/vllm/v1/attention/ops/common.py
@@ -259,10 +259,8 @@ def cp_lse_ag_out_rs_into(
     is_lse_base_on_e: bool = True,
 ):
     """Correct DCP partials and reduce-scatter into borrowed output storage."""
-    if cp_group.world_size != 4:
-        raise RuntimeError(
-            "cp_lse_ag_out_rs_into is restricted to the validated DCP4 path"
-        )
+    if cp_group.world_size <= 1:
+        raise RuntimeError("cp_lse_ag_out_rs_into requires DCP world size > 1")
     if torch.cuda.is_current_stream_capturing():
         raise RuntimeError("cp_lse_ag_out_rs_into is eager-only")
 

--- a/vllm/v1/attention/ops/common.py
+++ b/vllm/v1/attention/ops/common.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from collections.abc import Callable
+
 import torch
 
 from vllm.distributed.parallel_state import GroupCoordinator
@@ -238,6 +240,43 @@ def cp_lse_ag_out_rs(
         cp_attn_out, cp_attn_lse, cp_group, ctx=ctx, is_lse_base_on_e=is_lse_base_on_e
     )
     out = cp_group.reduce_scatter(out, dim=1)
+
+    if return_lse:
+        cp_num_heads = lse.shape[1] // cp_group.world_size
+        cp_rank = cp_group.rank_in_group
+        lse = lse[:, cp_num_heads * cp_rank : cp_num_heads * (cp_rank + 1)]
+        return out, lse
+    return out
+
+
+def cp_lse_ag_out_rs_into(
+    cp_attn_out: torch.Tensor,
+    cp_attn_lse: torch.Tensor,
+    cp_group: GroupCoordinator,
+    output_provider: Callable[[torch.Tensor], torch.Tensor],
+    ctx: CPTritonContext | None = None,
+    return_lse: bool = False,
+    is_lse_base_on_e: bool = True,
+):
+    """Correct DCP partials and reduce-scatter into borrowed output storage."""
+    if cp_group.world_size != 4:
+        raise RuntimeError(
+            "cp_lse_ag_out_rs_into is restricted to the validated DCP4 path"
+        )
+    if torch.cuda.is_current_stream_capturing():
+        raise RuntimeError("cp_lse_ag_out_rs_into is eager-only")
+
+    out, lse = _cp_lse_common(
+        cp_attn_out,
+        cp_attn_lse,
+        cp_group,
+        ctx=ctx,
+        is_lse_base_on_e=is_lse_base_on_e,
+    )
+    output = output_provider(out)
+    if not isinstance(output, torch.Tensor):
+        raise TypeError("DCP output provider must return a tensor")
+    out = cp_group.reduce_scatter_into(out, output, dim=1)
 
     if return_lse:
         cp_num_heads = lse.shape[1] // cp_group.world_size

--- a/vllm/v1/attention/ops/dcp_alltoall.py
+++ b/vllm/v1/attention/ops/dcp_alltoall.py
@@ -50,6 +50,19 @@ def _load_b12x_dcp_a2a_pool() -> Any | None:
     return PCIeDCPA2APool
 
 
+def _b12x_dcp_init_failed(
+    cp_group: GroupCoordinator,
+    device: torch.device,
+    init_error: Exception | None,
+) -> bool:
+    """Reach consensus on pool initialization through its exchange group."""
+    failed = torch.tensor(
+        [int(init_error is not None)], dtype=torch.int32, device=device
+    )
+    dist.all_reduce(failed, op=dist.ReduceOp.MAX, group=cp_group.device_group)
+    return bool(failed.item())
+
+
 def _get_b12x_dcp_a2a_pool(
     cp_group: GroupCoordinator,
     *,
@@ -101,13 +114,10 @@ def _get_b12x_dcp_a2a_pool(
     except Exception as exc:
         init_error = exc
 
-    cpu_group = getattr(cp_group, "cpu_group", None)
-    if cpu_group is not None:
-        failed = torch.tensor([int(init_error is not None)], dtype=torch.int32)
-        dist.all_reduce(failed, op=dist.ReduceOp.MAX, group=cpu_group)
-        any_failed = bool(failed.item())
-    else:
-        any_failed = init_error is not None
+    # Keep the status collective ordered with the NCCL group used above for
+    # IPC-handle exchange. A separate Gloo group can be at a different startup
+    # sequence when vLLM initializes overlapping TP/DCP coordinators.
+    any_failed = _b12x_dcp_init_failed(cp_group, device, init_error)
 
     if any_failed:
         if pool is not None:

--- a/vllm/v1/attention/ops/dcp_alltoall.py
+++ b/vllm/v1/attention/ops/dcp_alltoall.py
@@ -432,6 +432,89 @@ def _dcp_a2a_lse_pack_dim(output_dtype: torch.dtype) -> int:
     raise ValueError(f"Cannot pack fp32 LSE into output dtype {output_dtype}.")
 
 
+def _validate_dcp_valid_counts(
+    valid_counts: torch.Tensor | None,
+    cp_attn_out: torch.Tensor,
+) -> None:
+    if valid_counts is None:
+        return
+    expected_shape = (cp_attn_out.shape[0],)
+    if valid_counts.shape != expected_shape:
+        raise ValueError(
+            f"valid_counts must have shape {expected_shape}, got "
+            f"{tuple(valid_counts.shape)}."
+        )
+    if valid_counts.dtype != torch.int32:
+        raise TypeError(
+            f"valid_counts must have dtype torch.int32, got {valid_counts.dtype}."
+        )
+    if valid_counts.device != cp_attn_out.device:
+        raise ValueError(
+            "valid_counts and attention output must be on the same device, got "
+            f"{valid_counts.device} and {cp_attn_out.device}."
+        )
+
+
+@triton.jit
+def _sanitize_dcp_empty_rows_kernel(
+    out_ptr,
+    lse_ptr,
+    valid_counts_ptr,
+    out_stride_B,
+    out_stride_H,
+    out_stride_D,
+    lse_stride_B,
+    lse_stride_H,
+    valid_counts_stride_B,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    batch_idx = tl.program_id(0).to(tl.int64)
+    head_idx = tl.program_id(1).to(tl.int64)
+    d_offsets = tl.arange(0, BLOCK_D)
+    d_mask = d_offsets < HEAD_DIM
+    row_is_valid = tl.load(valid_counts_ptr + batch_idx * valid_counts_stride_B) > 0
+    out_offsets = (
+        batch_idx * out_stride_B + head_idx * out_stride_H + d_offsets * out_stride_D
+    )
+    values = tl.load(out_ptr + out_offsets, mask=d_mask)
+    tl.store(out_ptr + out_offsets, tl.where(row_is_valid, values, 0.0), mask=d_mask)
+    lse_offset = batch_idx * lse_stride_B + head_idx * lse_stride_H
+    lse = tl.load(lse_ptr + lse_offset)
+    tl.store(lse_ptr + lse_offset, tl.where(row_is_valid, lse, -float("inf")))
+
+
+def sanitize_dcp_attn_empty_rows(
+    cp_attn_out: torch.Tensor,
+    cp_attn_lse: torch.Tensor,
+    valid_counts: torch.Tensor | None,
+) -> None:
+    """Force locally empty DCP rows to the neutral ``(0, -inf)`` state."""
+    _validate_dcp_valid_counts(valid_counts, cp_attn_out)
+    if valid_counts is None or cp_attn_out.shape[0] == 0:
+        return
+    if cp_attn_out.ndim != 3 or cp_attn_lse.shape != cp_attn_out.shape[:2]:
+        raise ValueError(
+            "Expected attention output [B,H,D] and LSE [B,H], got "
+            f"{tuple(cp_attn_out.shape)} and {tuple(cp_attn_lse.shape)}."
+        )
+    head_dim = cp_attn_out.shape[2]
+    grid = (cp_attn_out.shape[0], cp_attn_out.shape[1], 1)
+    _sanitize_dcp_empty_rows_kernel[grid](
+        cp_attn_out,
+        cp_attn_lse,
+        valid_counts,
+        cp_attn_out.stride(0),
+        cp_attn_out.stride(1),
+        cp_attn_out.stride(2),
+        cp_attn_lse.stride(0),
+        cp_attn_lse.stride(1),
+        valid_counts.stride(0),
+        HEAD_DIM=head_dim,
+        BLOCK_D=triton.next_power_of_2(head_dim),
+    )
+
+
 def _dcp_a2a_send_recv_buffers(
     shape: tuple[int, ...],
     device: torch.device,


### PR DESCRIPTION
## Summary

- Projects DCP sparse-MLA partial outputs from 512 to 256 before the LSE-corrected reduce-scatter.
- Borrows existing B12X query, padded-output, and scratch workspaces for query gather, projection, and caller-owned reduce-scatter output.
- Generalizes the original TP4/DCP4 path to the E2E-validated TP6 and TP8 DCP topologies, including TP6 padded-head layouts.
- Keeps BF16 `W_UV` call-scoped, so KV capacity is unchanged.
- Keeps B12X DCP pool initialization consensus on the NCCL exchange group, avoiding the previously found startup deadlock.
- Adds focused gate, topology, and borrowed-output tests.

The borrowed-workspace design is adapted from the fast647 implementation in [davidsyoung/vllm-glm52 v1.3](https://github.com/davidsyoung/vllm-glm52/tree/v1.3). Its older loader, compact KV layout, deployment tuning, and unrelated decode transport changes remain excluded.

## Guarded Scope

The eager workspace path activates only for B12X sparse MLA, AG/RS prefill, more than 1024 active rows, no CUDA graph capture, and a non-DBO workspace. It is explicitly restricted to:

- TP4/DCP4
- TP6/DCP2, TP6/DCP3, TP6/DCP6
- TP8/DCP2, TP8/DCP4, TP8/DCP8

TP6 uses virtual-TP head padding: 22->24, 33->40, and 66->72 kernel heads. Only logical heads participate in projection and reduce-scatter.

## Measured Results

All rows are MTP off, `F8_DMA=0`, InstantTensor `BUFFERED`, hybrid DCP (`a2a` small rows, `ag_rs` large rows), exact 8,192/65,536 token targeting, and two runs per A/B side. No model loaded while a benchmark client was active.

TP8 uses `lukealonso/GLM-5.2-NVFP4`, A16, `MAX_BATCHED_TOKENS=8192`, `MAX_NUM_SEQS=32`, graph 128.

| Topology | Baseline 8k | PR 8k | Delta | Baseline 64k | PR 64k | Delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| TP8/DCP2 | 4,476 | 4,633 | +3.51% | 4,481.5 | 4,641.5 | +3.57% |
| TP8/DCP4 | 3,312 | 3,551.5 | +7.23% | 3,328.5 | 3,576 | +7.44% |
| TP8/DCP8 | 2,150.5 | 2,378.5 | +10.60% | 2,157.5 | 2,388 | +10.68% |

TP6 uses `GLM-5.2-BF16-AMDMXFP4experts`, forced A8, `MAX_BATCHED_TOKENS=2048`, `MAX_NUM_SEQS=16`, graph 64.

| Topology | Baseline 8k | PR 8k | Delta | Baseline 64k | PR 64k | Delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| TP6/DCP2 | 3,912 | 3,975.5 | +1.62% | 3,912.5 | 3,966.5 | +1.38% |
| TP6/DCP3 | 3,172.5 | 3,299 | +3.99% | 3,200.5 | 3,326.5 | +3.94% |
| TP6/DCP6 | 2,119 | 2,275 | +7.36% | 2,132.5 | 2,293 | +7.53% |

The fixed GPU halves understate the smallest-topology gain because the lower GPU group is faster. Cross-over A/B on each identical group measured:

| Topology/group | 8k delta | 64k delta |
| --- | ---: | ---: |
| TP8/DCP2 lower | +4.80% | +4.79% |
| TP8/DCP2 upper | +4.56% | +4.68% |
| TP6/DCP2 lower | +3.12% | +3.21% |
| TP6/DCP2 upper | +3.31% | +2.92% |

The original madeby561 hybrid TP4/DCP4 profile remains +9.5% at 8k and +9.2% at 64k, with unchanged 768k KV capacity and decode within noise.

## Implementation Notes

1. Query gather is chunked through existing raw scratch and writes rank-major logical heads into the B12X query workspace.
2. TP6 preserves the padded row stride and zeros padded query heads before the sparse kernel.
3. Padded sparse output is copied into the existing dense-output workspace; unpadded output remains in raw scratch.
4. Projection reuses dead query storage for the head-major BF16 input and raw scratch for the 256-wide projected output.
5. Generic caller-owned reduce-scatter accepts DCP-divisible `[T,H,256] -> [T,H/DCP,256]` head-major tensors for world sizes exercised by the guarded topology list.
6. Shape, stride, dtype, storage identity, overlap, communicator, capture state, and topology are checked before collectives.

## Investigation History

- The first project-before-merge path did not activate because sparse metadata reported zero prefill tokens; the final gate uses actual sparse query rows plus `max_query_len`.
- Persisting globally gathered BF16 `W_UV` reduced KV capacity; the final path gathers it per call.
- Project-before-merge without workspace reuse remained allocation/copy heavy.
- The initial implementation hard-coded TP4/DCP4 `[T,64,256] -> [T,16,256]`; TP8 activation exposed this immediately and led to the generic communicator contract.
- TP6 required preserving padded query stride and using its separate dense-output workspace.
- Two first cold TP6 optimized starts hit Xid31 during FULL CUDA-graph capture at <=64 rows. The eager workspace gate cannot activate under capture and emitted no activation log. Identical restarts from the completed cache became healthy; all reported benchmark requests then activated the workspace path and completed normally.

## Validation

- 26 focused tests pass in the final runtime image.
- Ruff check, format, and `git diff --check` pass.
- Every listed topology booted and served exact 8k/64k prefill requests.
- Server logs confirm borrowed-workspace activation for every optimized topology.
- A deterministic long-prompt generation comparison produced identical baseline and optimized output.
- Decode remains on the existing CUDA-graph path; this PR changes eager prefill only.