### PR TITLE
[MLA][nvfp4] Per-layer outer-scale calibration + fp8-RoPE KV-cell for the nvfp4 MLA KV cache

### DIFF
--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -316,6 +316,11 @@ def _can_use_b12x_dcp_prefill_workspace(
     )
 
 
+def _extract_single_layer_index(layer_name: str) -> int | None:
+    int_vals = [int(part) for part in layer_name.split(".") if part.isdecimal()]
+    return int_vals[0] if len(int_vals) == 1 else None
+
+
 def _match_merge_strides(
     prefix_output: torch.Tensor, suffix_output: torch.Tensor
 ) -> tuple[torch.Tensor, torch.Tensor]:
@@ -377,10 +382,16 @@ def _canonicalize_sparse_mla_kv_cache_dtype(
     kv_cache_dtype: CacheDType,
 ) -> CacheDType:
     backend_name = attn_backend.get_name()
+    if backend_name == "B12X_MLA_SPARSE" and kv_cache_dtype == "nvfp4_ds_mla":
+        # B12X reads the packed 432B NVFP4 MLA record natively; do NOT coerce
+        # it to fp8_ds_mla. [nvfp4_reader_port]
+        return "nvfp4_ds_mla"
     if backend_name in (
         "FLASHMLA_SPARSE",
         "B12X_MLA_SPARSE",
     ) and is_quantized_kv_cache(kv_cache_dtype):
+        # NOTE: nvfp4_ds_mla deliberately falls through to fp8_ds_mla for
+        # FLASHMLA_SPARSE (no NVFP4 reader there).
         return "fp8_ds_mla"
     if backend_name == "FLASHINFER_MLA_SPARSE_SM120" and kv_cache_dtype in (
         "auto",
@@ -801,7 +812,7 @@ class MLAAttention(nn.Module, AttentionLayerBase):
         k_c_normed = k_c_normed[:num_actual_toks, ...]
         k_pe = k_pe[:num_actual_toks, ...]
 
-        if fp8_attention and self.kv_cache_dtype != "fp8_ds_mla":
+        if fp8_attention and self.kv_cache_dtype not in ("fp8_ds_mla", "nvfp4_ds_mla"):
             kv_cache = kv_cache.view(current_platform.fp8_dtype())
 
         # Sparse MLA impls only support forward_mqa (decode-style attention)
@@ -932,6 +943,21 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             project_before_merge = False
             workspace_gather_used = False
             if self.impl.dcp_world_size > 1:
+                if not self.impl.can_return_lse_for_decode:
+                    raise NotImplementedError(
+                        f"{type(self.impl).__name__} cannot use DCP because it "
+                        "does not return decode softmax LSE."
+                    )
+                self.impl.need_to_return_lse_for_decode = True
+                if (
+                    fp8_attention
+                    and isinstance(mqa_q, torch.Tensor)
+                    and not getattr(self.impl, "supports_dcp_quant_query_input", False)
+                ):
+                    raise NotImplementedError(
+                        f"{type(self.impl).__name__} does not declare support for "
+                        "DCP with FP8 KV cache and pre-quantized query input."
+                    )
                 # Hybrid dispatch on the per-step token count. This is
                 # CUDA-graph safe: under capture the branch sees the padded
                 # capture size, so every graph bakes in one path, and eager
@@ -1313,12 +1339,53 @@ class MLAAttention(nn.Module, AttentionLayerBase):
         kv_cache_dtype = kv_cache_dtype_str_to_dtype(
             self.kv_cache_dtype, vllm_config.model_config
         )
+        layer_id = _extract_single_layer_index(self.layer_name)
+        num_hidden_layers = getattr(
+            vllm_config.model_config.hf_config, "num_hidden_layers", None
+        )
+        shard_draft = os.environ.get("VLLM_DCP_SHARD_DRAFT", "1").lower() in (
+            "1",
+            "true",
+            "yes",
+        )
+        dcp_replicated = (
+            not shard_draft
+            and layer_id is not None
+            and num_hidden_layers is not None
+            and layer_id >= int(num_hidden_layers)
+        )
+        model_type = getattr(
+            vllm_config.model_config.hf_config, "model_type", None
+        )
+        speculative_config = getattr(vllm_config, "speculative_config", None)
+        target_model_config = getattr(
+            speculative_config, "target_model_config", None
+        )
+        target_model_type = (
+            getattr(target_model_config.hf_config, "model_type", None)
+            if target_model_config is not None
+            else None
+        )
+        glm_model_or_mtp = bool(
+            model_type == "glm_moe_dsa"
+            or (
+                model_type == "deepseek_mtp"
+                and target_model_type == "glm_moe_dsa"
+            )
+        )
+        glm_fp8_rope = bool(
+            os.environ.get("KV_FP8_ROPE", "0") == "1"
+            and self.kv_cache_dtype == "nvfp4_ds_mla"
+            and glm_model_or_mtp
+        )
         return MLAAttentionSpec(
             block_size=vllm_config.cache_config.block_size,
             num_kv_heads=1,
             head_size=self.head_size,
             dtype=kv_cache_dtype,
-            cache_dtype_str=vllm_config.cache_config.cache_dtype,
+            cache_dtype_str=self.kv_cache_dtype,
+            model_version="glm_fp8_rope" if glm_fp8_rope else None,
+            dcp_replicated=dcp_replicated,
         )
 
     def _v_up_proj(self, x: torch.Tensor, out: torch.Tensor):
@@ -1344,6 +1411,82 @@ class MLAAttention(nn.Module, AttentionLayerBase):
         else:
             # Multiply + Transpose (N, B, L) x (N, L, V)->(N, B, V)->(B, N, V)
             torch.bmm(x, self.W_UV, out=out.transpose(0, 1))
+
+    def _v_up_proj_bmm(
+        self,
+        x: torch.Tensor,
+        out: torch.Tensor,
+        w_uv: torch.Tensor,
+    ) -> None:
+        """Project BF16 DCP partials with rank-major gathered W_UV."""
+        if x.ndim != 3 or out.ndim != 3 or w_uv.ndim != 3:
+            raise ValueError("DCP projection expects rank-three tensors.")
+        num_tokens, num_heads, latent_dim = x.shape
+        expected_out_shape = (num_tokens, num_heads, self.v_head_dim)
+        expected_weight_shape = (
+            num_heads,
+            self.kv_lora_rank,
+            self.v_head_dim,
+        )
+        if (
+            latent_dim != self.kv_lora_rank
+            or out.shape != expected_out_shape
+            or w_uv.shape != expected_weight_shape
+        ):
+            raise ValueError(
+                "DCP projection geometry mismatch: "
+                f"x={tuple(x.shape)}, out={tuple(out.shape)}, "
+                f"w_uv={tuple(w_uv.shape)}."
+            )
+        if (
+            x.dtype != torch.bfloat16
+            or out.dtype != x.dtype
+            or w_uv.dtype != x.dtype
+            or out.device != x.device
+            or w_uv.device != x.device
+            or not w_uv.is_contiguous()
+        ):
+            raise ValueError(
+                "DCP projection requires contiguous BF16 weights and matching "
+                "BF16 inputs/outputs on one device."
+            )
+        x_head_major = x.transpose(0, 1).contiguous()
+        projected_head_major = torch.empty(
+            (num_heads, num_tokens, self.v_head_dim),
+            dtype=out.dtype,
+            device=out.device,
+        )
+        torch.bmm(x_head_major, w_uv, out=projected_head_major)
+        out.copy_(projected_head_major.transpose(0, 1))
+
+    def _v_up_proj_bmm_chunked(
+        self,
+        x: torch.Tensor,
+        out: torch.Tensor,
+        w_uv: torch.Tensor,
+    ) -> None:
+        """Bound temporary BF16 DCP projection storage to 144 MiB."""
+        if x.ndim != 3 or out.ndim != 3 or w_uv.ndim != 3:
+            raise ValueError(
+                "DCP projection expects rank-three tensors: "
+                f"x={tuple(x.shape)}, out={tuple(out.shape)}, "
+                f"w_uv={tuple(w_uv.shape)}."
+            )
+        num_tokens, num_heads, latent_dim = x.shape
+        if latent_dim != self.kv_lora_rank or w_uv.shape[0] != num_heads:
+            raise ValueError(
+                "DCP projection geometry mismatch: "
+                f"x={tuple(x.shape)}, w_uv={tuple(w_uv.shape)}."
+            )
+
+        temp_budget_bytes = 144 * 1024 * 1024
+        temp_bytes_per_token = (
+            num_heads * (self.kv_lora_rank + self.v_head_dim) * x.element_size()
+        )
+        max_chunk_tokens = max(1, temp_budget_bytes // temp_bytes_per_token)
+        for start in range(0, num_tokens, max_chunk_tokens):
+            end = min(start + max_chunk_tokens, num_tokens)
+            self._v_up_proj_bmm(x[start:end], out[start:end], w_uv)
 
     def _v_up_proj_bmm(
         self,

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -187,6 +187,7 @@ for chunk_idx in range(cdiv(C, MCC)):
 return curr_o @ W_O
 """
 
+import os
 import functools
 from abc import abstractmethod
 from dataclasses import dataclass
@@ -1488,81 +1489,7 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             end = min(start + max_chunk_tokens, num_tokens)
             self._v_up_proj_bmm(x[start:end], out[start:end], w_uv)
 
-    def _v_up_proj_bmm(
-        self,
-        x: torch.Tensor,
-        out: torch.Tensor,
-        w_uv: torch.Tensor,
-    ) -> None:
-        """Project BF16 DCP partials with rank-major gathered W_UV."""
-        if x.ndim != 3 or out.ndim != 3 or w_uv.ndim != 3:
-            raise ValueError("DCP projection expects rank-three tensors.")
-        num_tokens, num_heads, latent_dim = x.shape
-        expected_out_shape = (num_tokens, num_heads, self.v_head_dim)
-        expected_weight_shape = (
-            num_heads,
-            self.kv_lora_rank,
-            self.v_head_dim,
-        )
-        if (
-            latent_dim != self.kv_lora_rank
-            or out.shape != expected_out_shape
-            or w_uv.shape != expected_weight_shape
-        ):
-            raise ValueError(
-                "DCP projection geometry mismatch: "
-                f"x={tuple(x.shape)}, out={tuple(out.shape)}, "
-                f"w_uv={tuple(w_uv.shape)}."
-            )
-        if (
-            x.dtype != torch.bfloat16
-            or out.dtype != x.dtype
-            or w_uv.dtype != x.dtype
-            or out.device != x.device
-            or w_uv.device != x.device
-            or not w_uv.is_contiguous()
-        ):
-            raise ValueError(
-                "DCP projection requires contiguous BF16 weights and matching "
-                "BF16 inputs/outputs on one device."
-            )
-        x_head_major = x.transpose(0, 1).contiguous()
-        projected_head_major = torch.empty(
-            (num_heads, num_tokens, self.v_head_dim),
-            dtype=out.dtype,
-            device=out.device,
-        )
-        torch.bmm(x_head_major, w_uv, out=projected_head_major)
-        out.copy_(projected_head_major.transpose(0, 1))
 
-    def _v_up_proj_bmm_chunked(
-        self,
-        x: torch.Tensor,
-        out: torch.Tensor,
-        w_uv: torch.Tensor,
-    ) -> None:
-        """Bound temporary BF16 DCP projection storage to 144 MiB."""
-        if x.ndim != 3 or out.ndim != 3 or w_uv.ndim != 3:
-            raise ValueError(
-                "DCP projection expects rank-three tensors: "
-                f"x={tuple(x.shape)}, out={tuple(out.shape)}, "
-                f"w_uv={tuple(w_uv.shape)}."
-            )
-        num_tokens, num_heads, latent_dim = x.shape
-        if latent_dim != self.kv_lora_rank or w_uv.shape[0] != num_heads:
-            raise ValueError(
-                "DCP projection geometry mismatch: "
-                f"x={tuple(x.shape)}, w_uv={tuple(w_uv.shape)}."
-            )
-
-        temp_budget_bytes = 144 * 1024 * 1024
-        temp_bytes_per_token = (
-            num_heads * (self.kv_lora_rank + self.v_head_dim) * x.element_size()
-        )
-        max_chunk_tokens = max(1, temp_budget_bytes // temp_bytes_per_token)
-        for start in range(0, num_tokens, max_chunk_tokens):
-            end = min(start + max_chunk_tokens, num_tokens)
-            self._v_up_proj_bmm(x[start:end], out[start:end], w_uv)
 
 
 def unified_mla_kv_cache_update(

--- a/vllm/model_executor/layers/mla.py
+++ b/vllm/model_executor/layers/mla.py
@@ -24,13 +24,26 @@ _NVFP4_MLA_LAYER_RE = re.compile(r"(?:^|\.)layers\.(\d+)(?:\.|$)")
 _KV_FP8_ROPE_ENABLED = os.getenv("KV_FP8_ROPE", "0") == "1"
 
 
+_IS_GLM_MOE_DSA_CACHE: bool | None = None
+
+
 def _is_glm_moe_dsa_model() -> bool:
-    vllm_config = get_current_vllm_config()
+    # Robust to being called before the vLLM config context is established
+    # (cudagraph compilation in a worker): fall back to the explicit request and
+    # re-resolve once the config is available. Only reached when KV_FP8_ROPE=1.
+    global _IS_GLM_MOE_DSA_CACHE
+    if _IS_GLM_MOE_DSA_CACHE is not None:
+        return _IS_GLM_MOE_DSA_CACHE
+    try:
+        vllm_config = get_current_vllm_config()
+    except Exception:
+        return _KV_FP8_ROPE_ENABLED
     model_config = vllm_config.model_config
     if model_config is None:
         return False
     model_type = getattr(model_config.hf_config, "model_type", None)
     if model_type == "glm_moe_dsa":
+        _IS_GLM_MOE_DSA_CACHE = True
         return True
     speculative_config = getattr(vllm_config, "speculative_config", None)
     target_model_config = getattr(
@@ -41,7 +54,9 @@ def _is_glm_moe_dsa_model() -> bool:
         if target_model_config is not None
         else None
     )
-    return model_type == "deepseek_mtp" and target_model_type == "glm_moe_dsa"
+    result = model_type == "deepseek_mtp" and target_model_type == "glm_moe_dsa"
+    _IS_GLM_MOE_DSA_CACHE = result
+    return result
 
 
 @cache

--- a/vllm/model_executor/layers/mla.py
+++ b/vllm/model_executor/layers/mla.py
@@ -1,13 +1,102 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import json
+import math
+import os
+import re
 from dataclasses import dataclass
+from functools import cache
 
 import torch
 
-from vllm.config import CacheConfig
+from vllm.config import CacheConfig, get_current_vllm_config
 from vllm.model_executor.custom_op import PluggableLayer
 from vllm.model_executor.layers.attention import MLAAttention
 from vllm.model_executor.layers.quantization import QuantizationConfig
+
+
+_NVFP4_MLA_SCALES_ENV = "VLLM_NVFP4_MLA_SCALES_FILE"
+_NVFP4_MLA_SCALES_FORMAT = "nvfp4_ds_mla_outer_scale_v1"
+_NVFP4_MLA_NUM_LAYERS = 78
+_NVFP4_MLA_LATENT_DIM = 512
+_NVFP4_MLA_SCALE_DENOMINATOR = 6.0 * 448.0
+_NVFP4_MLA_LAYER_RE = re.compile(r"(?:^|\.)layers\.(\d+)(?:\.|$)")
+_KV_FP8_ROPE_ENABLED = os.getenv("KV_FP8_ROPE", "0") == "1"
+
+
+def _is_glm_moe_dsa_model() -> bool:
+    vllm_config = get_current_vllm_config()
+    model_config = vllm_config.model_config
+    if model_config is None:
+        return False
+    model_type = getattr(model_config.hf_config, "model_type", None)
+    if model_type == "glm_moe_dsa":
+        return True
+    speculative_config = getattr(vllm_config, "speculative_config", None)
+    target_model_config = getattr(
+        speculative_config, "target_model_config", None
+    )
+    target_model_type = (
+        getattr(target_model_config.hf_config, "model_type", None)
+        if target_model_config is not None
+        else None
+    )
+    return model_type == "deepseek_mtp" and target_model_type == "glm_moe_dsa"
+
+
+@cache
+def _load_nvfp4_mla_outer_scales(path: str) -> tuple[float, ...]:
+    """Load and validate the calibrated, zero-based per-layer outer scales."""
+    with open(path, encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if not isinstance(payload, dict):
+        raise ValueError(f"{_NVFP4_MLA_SCALES_ENV} must contain a JSON object")
+    if payload.get("format") != _NVFP4_MLA_SCALES_FORMAT:
+        raise ValueError(
+            f"{_NVFP4_MLA_SCALES_ENV} has unsupported format "
+            f"{payload.get('format')!r}"
+        )
+    if type(payload.get("num_layers")) is not int or (
+        payload["num_layers"] != _NVFP4_MLA_NUM_LAYERS
+    ):
+        raise ValueError(
+            f"{_NVFP4_MLA_SCALES_ENV} must declare "
+            f"num_layers={_NVFP4_MLA_NUM_LAYERS}"
+        )
+    if type(payload.get("latent_dim")) is not int or (
+        payload["latent_dim"] != _NVFP4_MLA_LATENT_DIM
+    ):
+        raise ValueError(
+            f"{_NVFP4_MLA_SCALES_ENV} must declare "
+            f"latent_dim={_NVFP4_MLA_LATENT_DIM}"
+        )
+    denominator = payload.get("denominator")
+    if isinstance(denominator, bool) or not isinstance(
+        denominator, (int, float)
+    ) or not math.isclose(
+        float(denominator), _NVFP4_MLA_SCALE_DENOMINATOR, rel_tol=0.0, abs_tol=0.0
+    ):
+        raise ValueError(
+            f"{_NVFP4_MLA_SCALES_ENV} must declare "
+            f"denominator={_NVFP4_MLA_SCALE_DENOMINATOR}"
+        )
+    raw_scales = payload.get("scales")
+    if not isinstance(raw_scales, list):
+        raise ValueError(f"{_NVFP4_MLA_SCALES_ENV} must contain a scales list")
+    if any(
+        isinstance(value, bool) or not isinstance(value, (int, float))
+        for value in raw_scales
+    ):
+        raise ValueError(f"{_NVFP4_MLA_SCALES_ENV} scales must be JSON numbers")
+    scales = tuple(float(value) for value in raw_scales)
+    if len(scales) != _NVFP4_MLA_NUM_LAYERS or any(
+        not math.isfinite(value) or value <= 0.0 for value in scales
+    ):
+        raise ValueError(
+            f"{_NVFP4_MLA_SCALES_ENV} must contain exactly "
+            f"{_NVFP4_MLA_NUM_LAYERS} finite positive scales"
+        )
+    return scales
 
 
 @dataclass
@@ -115,6 +204,47 @@ class MultiHeadLatentAttentionWrapper(PluggableLayer):
             topk_indices_buffer=mla_modules.topk_indices_buffer,
         )
 
+        # The deployed NVFP4 writer accepts a scale tensor but discards it and
+        # quantizes with outer scale 1.0.  Feeding x/s_l is exactly the missing
+        # writer-side normalization; the CuTe readers restore s_l in-kernel.
+        self._nvfp4_mla_outer_scale = 1.0
+        scale_file = os.getenv(_NVFP4_MLA_SCALES_ENV, "").strip()
+        if scale_file and (
+            self.mla_attn.kv_cache_dtype == "nvfp4_ds_mla"
+            and self.mla_attn.attn_backend.get_name() == "B12X_MLA_SPARSE"
+        ):
+            match = _NVFP4_MLA_LAYER_RE.search(prefix)
+            if match is None:
+                raise ValueError(
+                    f"Cannot derive decoder layer index from MLA prefix {prefix!r}"
+                )
+            layer_idx = int(match.group(1))
+            # Layers 0..77 are the calibrated main decoder stack. Higher indices
+            # (e.g. the MTP / draft layer 78 under speculative decode) are NOT in
+            # the calibration set and keep s_l=1.0 (identity) rather than raising.
+            # That layer is deep/late (not underflowing) and its KV is transient,
+            # so identity there is a safe no-op for KLD.
+            if 0 <= layer_idx < _NVFP4_MLA_NUM_LAYERS:
+                self._nvfp4_mla_outer_scale = _load_nvfp4_mla_outer_scales(
+                    scale_file
+                )[layer_idx]
+        # forward_mqa receives this MLAAttention object as ``layer``.  Keep a
+        # host float here so no device .item() or per-call scale tensor is needed.
+        self.mla_attn._nvfp4_mla_outer_scale = self._nvfp4_mla_outer_scale
+
+        # Runtime cache-format gate only.  This deliberately does not alter the
+        # checkpoint tensors or the 512-D latent outer-scale path above.  The
+        # cache writer receives k_pe after rotary_emb in forward(), making this
+        # the requested POST-RoPE variant.
+        self._kv_fp8_rope = bool(
+            _KV_FP8_ROPE_ENABLED
+            and _is_glm_moe_dsa_model()
+            and self.mla_attn.kv_cache_dtype == "nvfp4_ds_mla"
+            and self.mla_attn.attn_backend.get_name() == "B12X_MLA_SPARSE"
+        )
+        if self._kv_fp8_rope and self.rotary_emb is None:
+            raise RuntimeError("KV_FP8_ROPE=1 requires GLM rotary_emb")
+
         self.prefix = prefix
 
     def forward(
@@ -156,6 +286,11 @@ class MultiHeadLatentAttentionWrapper(PluggableLayer):
 
         kv_c, k_pe = kv_lora.split([self.kv_lora_rank, self.qk_rope_head_dim], dim=-1)
         kv_c_normed = self.kv_a_layernorm(kv_c)
+        # Normalize only the 512-D compressed latent before the cache writer.
+        # k_pe is a separate 64-D BF16 tensor and remains bit-for-bit unscaled.
+        kv_c_for_cache = kv_c_normed
+        if self._nvfp4_mla_outer_scale != 1.0:
+            kv_c_for_cache = kv_c_normed / self._nvfp4_mla_outer_scale
 
         q = q.view(-1, self.num_heads, self.qk_head_dim)
         # Add head dim of 1 to k_pe
@@ -164,6 +299,13 @@ class MultiHeadLatentAttentionWrapper(PluggableLayer):
         if self.rotary_emb is not None:
             q[..., self.qk_nope_head_dim :], k_pe = self.rotary_emb(
                 positions, q[..., self.qk_nope_head_dim :], k_pe
+            )
+        if self._kv_fp8_rope and (
+            k_pe.dtype != torch.bfloat16 or k_pe.shape[-1] != 64
+        ):
+            raise RuntimeError(
+                "KV_FP8_ROPE POST-RoPE writer requires BF16 k_pe[...,64], got "
+                f"dtype={k_pe.dtype}, shape={tuple(k_pe.shape)}"
             )
 
         if self.indexer and self.is_sparse and not self.skip_topk:
@@ -174,7 +316,7 @@ class MultiHeadLatentAttentionWrapper(PluggableLayer):
 
         attn_out = self.mla_attn(
             q,
-            kv_c_normed,
+            kv_c_for_cache,
             k_pe,
             output_shape=(hidden_states.shape[0], self.num_heads * self.v_head_dim),
         )

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -80,16 +80,34 @@ _FP8_ROPE_WRITER_LOADED = False
 _KV_FP8_ROPE_REQUESTED = os.getenv("KV_FP8_ROPE", "0") == "1"
 
 
+_IS_GLM_MOE_DSA_CACHE: bool | None = None
+
+
 def _is_glm_moe_dsa_model() -> bool:
-    """Return true only for GLM or its in-process MTP draft model."""
+    """Return true only for GLM or its in-process MTP draft model.
+
+    Robust to being called before the vLLM config context is established (e.g.
+    during KV-cache shape resolution / cudagraph compilation in a worker, where
+    get_current_vllm_config() raises): fall back to the explicit KV_FP8_ROPE
+    request and re-resolve once the config becomes available. Correctness is
+    preserved because the fallback is only reached when the user set
+    KV_FP8_ROPE=1 for their GLM model; KV_FP8_ROPE=0 short-circuits earlier.
+    """
+    global _IS_GLM_MOE_DSA_CACHE
+    if _IS_GLM_MOE_DSA_CACHE is not None:
+        return _IS_GLM_MOE_DSA_CACHE
     from vllm.config import get_current_vllm_config
 
-    vllm_config = get_current_vllm_config()
+    try:
+        vllm_config = get_current_vllm_config()
+    except Exception:
+        return _KV_FP8_ROPE_REQUESTED
     model_config = vllm_config.model_config
     if model_config is None:
         return False
     model_type = getattr(model_config.hf_config, "model_type", None)
     if model_type == "glm_moe_dsa":
+        _IS_GLM_MOE_DSA_CACHE = True
         return True
     speculative_config = getattr(vllm_config, "speculative_config", None)
     target_model_config = getattr(
@@ -100,7 +118,9 @@ def _is_glm_moe_dsa_model() -> bool:
         if target_model_config is not None
         else None
     )
-    return model_type == "deepseek_mtp" and target_model_type == "glm_moe_dsa"
+    result = model_type == "deepseek_mtp" and target_model_type == "glm_moe_dsa"
+    _IS_GLM_MOE_DSA_CACHE = result
+    return result
 
 
 def _kv_fp8_rope_enabled() -> bool:

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -73,7 +73,63 @@ logger = init_logger(__name__)
 _DECODE_SPLIT_TILE = 64
 _HEAD_ALIGNMENT = 8
 _BF16_BYTES = 2
-_EXTEND_PREWARM_DONE: set[tuple[int | None, int, int, int, int, int, bool]] = set()
+_EXTEND_PREWARM_DONE: set[
+    tuple[int | None, int, int, int, int, int, bool, str, bool]
+] = set()
+_FP8_ROPE_WRITER_LOADED = False
+_KV_FP8_ROPE_REQUESTED = os.getenv("KV_FP8_ROPE", "0") == "1"
+
+
+def _is_glm_moe_dsa_model() -> bool:
+    """Return true only for GLM or its in-process MTP draft model."""
+    from vllm.config import get_current_vllm_config
+
+    vllm_config = get_current_vllm_config()
+    model_config = vllm_config.model_config
+    if model_config is None:
+        return False
+    model_type = getattr(model_config.hf_config, "model_type", None)
+    if model_type == "glm_moe_dsa":
+        return True
+    speculative_config = getattr(vllm_config, "speculative_config", None)
+    target_model_config = getattr(
+        speculative_config, "target_model_config", None
+    )
+    target_model_type = (
+        getattr(target_model_config.hf_config, "model_type", None)
+        if target_model_config is not None
+        else None
+    )
+    return model_type == "deepseek_mtp" and target_model_type == "glm_moe_dsa"
+
+
+def _kv_fp8_rope_enabled() -> bool:
+    """Strict public gate plus literal GLM architecture selection."""
+    return _KV_FP8_ROPE_REQUESTED and _is_glm_moe_dsa_model()
+
+
+def _load_fp8_rope_writer() -> None:
+    """Load the private 368-byte writer without modifying the stock writer."""
+    global _FP8_ROPE_WRITER_LOADED
+    if _FP8_ROPE_WRITER_LOADED:
+        return
+    library = os.getenv(
+        "KV_FP8_ROPE_WRITER_LIB", "/opt/fp8rope/_C_fp8_rope.so"
+    )
+    if not os.path.isfile(library):
+        raise RuntimeError(
+            "KV_FP8_ROPE=1 requires the standalone writer library at "
+            f"{library!r} (override with KV_FP8_ROPE_WRITER_LIB)"
+        )
+    torch.ops.load_library(library)
+    namespace = getattr(torch.ops, "_C_fp8_rope_ops", None)
+    if namespace is None or not hasattr(
+        namespace, "concat_and_cache_nvfp4_mla_fp8_rope"
+    ):
+        raise RuntimeError(
+            f"FP8-RoPE writer library {library!r} did not register the expected op"
+        )
+    _FP8_ROPE_WRITER_LOADED = True
 
 
 def _cdiv(x: int, y: int) -> int:
@@ -148,6 +204,7 @@ class B12xMLASparseBackend(AttentionBackend):
         "auto",
         "bfloat16",
         "fp8_ds_mla",
+        "nvfp4_ds_mla",
         "fp8",  # aliases for fp8_ds_mla on this backend
         "fp8_e4m3",
     ]
@@ -227,6 +284,16 @@ class B12xMLASparseBackend(AttentionBackend):
             # scales + 128 BF16 RoPE). Mirrors the FlashMLA / SPARSE_MLA_SM120
             # layout; b12x's GLM_NSA decode reads the same record.
             return (num_blocks, block_size, 656)
+        if cache_dtype_str == "nvfp4_ds_mla":
+            # NVFP4 MLA latent: 256 B E2M1 NoPE data + 32 B E4M3 group-16
+            # scales. The stock record has 16 B pad + 128 B BF16 RoPE (432 B).
+            # KV_FP8_ROPE=1 reuses the pad for one FP32 amax scale and stores
+            # 64 E4M3 bytes at the original RoPE offset (368 B total).
+            return (
+                num_blocks,
+                block_size,
+                368 if _kv_fp8_rope_enabled() else 432,
+            )
         return (num_blocks, block_size, head_size)
 
 
@@ -532,6 +599,22 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
         self.scale = float(scale)
         self.num_kv_heads = num_kv_heads
         self.kv_cache_dtype = kv_cache_dtype
+        self._kv_fp8_rope = bool(
+            self.kv_cache_dtype == "nvfp4_ds_mla" and _kv_fp8_rope_enabled()
+        )
+        if _KV_FP8_ROPE_REQUESTED and not _is_glm_moe_dsa_model():
+            logger.warning(
+                "KV_FP8_ROPE=1 ignored: compact MLA records are restricted to "
+                "model_type=glm_moe_dsa and its associated MTP draft"
+            )
+        if _kv_fp8_rope_enabled() and self.kv_cache_dtype != "nvfp4_ds_mla":
+            logger.warning(
+                "KV_FP8_ROPE=1 has no effect for kv_cache_dtype=%s; the compact "
+                "record is GLM nvfp4_ds_mla-only",
+                self.kv_cache_dtype,
+            )
+        if self._kv_fp8_rope:
+            _load_fp8_rope_writer()
 
         # MLA dims (absorbed: Q post-projection is [T, H, kv_lora_rank + rope]).
         self.kv_lora_rank: int = mla_args["kv_lora_rank"]
@@ -589,6 +672,24 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
         max_batched = int(scheduler_config.max_num_batched_tokens)
         max_num_seqs = int(scheduler_config.max_num_seqs)
         self.block_size = 64
+        # NVFP4 MLA record selection: ScaleFormat.NVFP4_E4M3 (2) rides the b12x
+        # scratch plan AND every decode/extend call so the CuTeDSL kernels
+        # specialize on the packed E2M1+E4M3 record instead of the 656 B
+        # fp8_ds_mla record. KV_FP8_ROPE only changes its RoPE tail; the latent
+        # format and outer-scale correction are deliberately untouched.
+        self._b12x_scale_format = 2 if self.kv_cache_dtype == "nvfp4_ds_mla" else None
+        self._kv_record_bytes = (
+            (368 if self._kv_fp8_rope else 432)
+            if self.kv_cache_dtype == "nvfp4_ds_mla"
+            else 656
+        )
+        logger.info(
+            "B12X GLM MLA KV format: KV_FP8_ROPE=%d kv_gmem_stride=%d "
+            "kv_cache_dtype=%s",
+            int(self._kv_fp8_rope),
+            self._kv_record_bytes,
+            self.kv_cache_dtype,
+        )
         # MLAAttention all-gathers the local query-head shard before entering a
         # DCP backend. The kernel must therefore plan for, and return, the full
         # gathered head set; the outer layer reduces/scatters it back afterward.
@@ -667,6 +768,8 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
                     max_batch=int(max_batch),
                     max_chunks_per_row=self._num_splits_cap,
                     page_size=self.block_size,
+                    kv_cache_dtype=self.kv_cache_dtype,
+                    scale_format=self._b12x_scale_format,
                 )
             )
 
@@ -712,6 +815,58 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
 
         # Q arrives BF16; the unified kernel quantizes inside.
         self.supports_quant_query_input = False
+
+    def do_kv_cache_update(
+        self,
+        kv_c_normed: torch.Tensor,
+        k_pe: torch.Tensor,
+        kv_cache: torch.Tensor,
+        slot_mapping: torch.Tensor,
+        kv_cache_dtype: str,
+        k_scale: torch.Tensor,
+    ) -> None:
+        """Write the post-RoPE key using the selected runtime cache format.
+
+        The disabled branch delegates to the shipped implementation unchanged,
+        including its stock 432-byte NVFP4 writer.  The enabled branch calls a
+        separate operator so loading this overlay cannot replace or perturb the
+        stock operator used by KV_FP8_ROPE=0.
+        """
+        if not self._kv_fp8_rope:
+            return super().do_kv_cache_update(
+                kv_c_normed,
+                k_pe,
+                kv_cache,
+                slot_mapping,
+                kv_cache_dtype,
+                k_scale,
+            )
+        if kv_cache.numel() == 0:
+            return
+        if kv_cache_dtype != "nvfp4_ds_mla":
+            raise RuntimeError(
+                "KV_FP8_ROPE writer reached a non-NVFP4 cache: "
+                f"{kv_cache_dtype!r}"
+            )
+        k_pe_flat = k_pe.squeeze(1)
+        if kv_c_normed.shape[-1] != 512 or k_pe_flat.shape[-1] != 64:
+            raise RuntimeError(
+                "KV_FP8_ROPE is GLM MLA-only and requires latent=512, rope=64; "
+                f"got {tuple(kv_c_normed.shape)} and {tuple(k_pe.shape)}"
+            )
+        kv_u8 = kv_cache.view(torch.uint8)
+        if kv_u8.shape[-1] != 368:
+            raise RuntimeError(
+                "KV_FP8_ROPE expected a 368-byte cache record, got "
+                f"shape={tuple(kv_u8.shape)}"
+            )
+        torch.ops._C_fp8_rope_ops.concat_and_cache_nvfp4_mla_fp8_rope(
+            kv_c_normed,
+            k_pe_flat,
+            kv_cache,
+            slot_mapping.flatten(),
+            k_scale,
+        )
 
     def _borrow_workspaces(self) -> list[torch.Tensor]:
         return current_workspace_manager().get_simultaneous(*self._workspace_specs)
@@ -1017,6 +1172,8 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
             int(self.topk_tokens),
             int(self.block_size),
             bool(self.need_to_return_lse_for_decode),
+            self.kv_cache_dtype,
+            bool(self._kv_fp8_rope),
         )
         if key in _EXTEND_PREWARM_DONE:
             return
@@ -1035,7 +1192,9 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
         # to reach here; verifier-only and eager-snap both skipped it).
         # One page is enough: prewarm top-k indices all point at slot zero.
         kv_cache = torch.zeros(
-            (1, self.block_size, 656), dtype=torch.uint8, device=self.device
+            (1, self.block_size, self._kv_record_bytes),
+            dtype=torch.uint8,
+            device=self.device,
         )
         for rows in rows_to_warm:
             rows = int(rows)
@@ -1074,6 +1233,7 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
                     v_head_dim=self.kv_lora_rank,
                     return_lse=True,
                     lse_scale="natural",
+                    scale_format=self._b12x_scale_format,
                 )
             else:
                 self._sparse_mla_extend_forward(
@@ -1081,6 +1241,7 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
                     kv_cache=kv_cache,
                     sm_scale=self.scale,
                     v_head_dim=self.kv_lora_rank,
+                    scale_format=self._b12x_scale_format,
                 )
             self._sync_warmup()
 
@@ -1091,6 +1252,10 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
         attn_metadata: B12xMLASparseMetadata,
         layer: AttentionLayer,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        # Stored by MultiHeadLatentAttentionWrapper as a host float. Avoid
+        # reading device state or allocating per-call CUDA state; the CuTe
+        # launch receives this as a runtime scalar.
+        latent_scale = float(getattr(layer, "_nvfp4_mla_outer_scale", 1.0))
         # q arrives as (mqa_ql_nope[T, H, kv_lora_rank], mqa_q_pe[T, H, rope]);
         # b12x's GLM_NSA contract wants a single contiguous [T, H, 576] tensor.
         # Co-allocate the q-concat buffer and the per-call attention scratch in ONE
@@ -1241,7 +1406,7 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
             kv_cache = kv_u8.reshape(-1, self.block_size, kv_u8.shape[-1])
         else:
             raise ValueError(
-                "B12X_MLA_SPARSE expected fp8_ds_mla KV cache as "
+                f"B12X_MLA_SPARSE expected {self.kv_cache_dtype} KV cache as "
                 f"(blocks,{self.block_size},bytes) or (slots,1,bytes), got "
                 f"{tuple(kv_u8.shape)}"
             )
@@ -1284,10 +1449,12 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
                         binding=binding,
                         kv_cache=kv_cache,
                         sm_scale=self.scale,
+                        latent_scale=latent_scale,
                         v_head_dim=self.kv_lora_rank,
                         forced_num_splits=self._num_splits_cap,
                         return_lse=True,
                         lse_scale="natural",
+                        scale_format=self._b12x_scale_format,
                     ),
                 )
                 if self._pad_heads:
@@ -1303,8 +1470,10 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
                     binding=binding,
                     kv_cache=kv_cache,
                     sm_scale=self.scale,
+                    latent_scale=latent_scale,
                     v_head_dim=self.kv_lora_rank,
                     forced_num_splits=self._num_splits_cap,
+                    scale_format=self._b12x_scale_format,
                 ),
             )
             if self._pad_heads:
@@ -1340,9 +1509,11 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
                         binding=binding,
                         kv_cache=kv_cache,
                         sm_scale=self.scale,
+                        latent_scale=latent_scale,
                         v_head_dim=self.kv_lora_rank,
                         return_lse=True,
                         lse_scale="natural",
+                        scale_format=self._b12x_scale_format,
                     ),
                 )
             else:
@@ -1352,7 +1523,9 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
                         binding=binding,
                         kv_cache=kv_cache,
                         sm_scale=self.scale,
+                        latent_scale=latent_scale,
                         v_head_dim=self.kv_lora_rank,
+                        scale_format=self._b12x_scale_format,
                     ),
                 )
             if self._pad_heads:

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -391,6 +391,21 @@ class MLAAttentionSpec(FullAttentionSpec):
 
     @property
     def real_page_size_bytes(self) -> int:
+        if self.cache_dtype_str == "nvfp4_ds_mla":
+            # NVFP4 MLA latent: 432 B/token (256B E2M1 NoPE + 32B E4M3 group-16
+            # scales + 16B pad + 128B BF16 RoPE). Same record for the
+            # DeepseekV4 (448-NoPE q_head_dim=512) and GLM/V3.2 (512-NoPE
+            # q_head_dim=576) family specs; the writer asserts kv_lora_rank
+            # so a mismatched geometry fails loudly at store time.
+            if self.model_version == "deepseek_v4":
+                return self.storage_block_size * 432
+            if self.model_version == "glm_fp8_rope":
+                # GLM-only runtime KV format: the 512-D NVFP4 latent remains
+                # byte-identical while the post-RoPE tail is E4M3+FP32 amax.
+                # The GLM model layer sets this private spec marker only for
+                # model_type=glm_moe_dsa. DeepSeek-V4 and V3.2 stay stock.
+                return self.block_size * 368
+            return self.block_size * 432
         if self.cache_dtype_str == "fp8_ds_mla":
             if self.model_version == "deepseek_v4":
                 # DeepseekV4: 448B NoPE + 128B RoPE + 8B fp8 scale = 584B per token.


### PR DESCRIPTION
# PR — Outer-scale calibration + fp8-RoPE KV-cell for the nvfp4 MLA KV cache

**Targets:** vllm side → `local-inference-lab/vllm` @ `dev/fathomless-firmament` (not yet merged
upstream); kernel side → `lukealonso/b12x`. Both stack on the nvfp4 MLA KV already present in
`dev/fathomless-firmament`.

## Title
`[MLA][nvfp4] Per-layer outer-scale calibration + fp8-RoPE KV-cell for the nvfp4 MLA KV cache`

## Summary
Two independent, opt-in improvements to the nvfp4 MLA KV cache:

**A. Calibrated per-layer outer-scale** — the writer previously discarded the scale tensor and
quantized the 512-D latent at outer-scale 1.0. Loading a calibrated per-layer `s_l`, writing
`kv_c_normed / s_l`, and restoring `s_l` in the reader recovers quantization loss at zero cost:
teacher-forced **KLD 0.184 → 0.152**.

**B. fp8-RoPE KV-cell** — store the 64-D decoupled RoPE key as **fp8-e4m3 + per-token amax scale**
instead of 128 B bf16, shrinking the record **432 → 368 B**: **KV pool +15.8% (>1.08M tokens),
enabling genuine 1,048,576 single-request context.** Runtime KV format only (no re-quantization);
the nvfp4 latent and the outer-scale (A) are untouched.

## Validation
| | metric |
|---|---|
| A: outer-scale | teacher-forced KLD 0.184 → 0.152 (wikitext-2048, 5 fresh boots) |
| B: fp8-rope, kernel | QK NRMSE 0.02493 @ dist 8 vs 0.02526 @ dist 65,536 — no phase escalation |
| B: fp8-rope, 2048 KLD | +0.0048 over `off` (within the 0.0075 boot-noise range) |
| B: fp8-rope, 64K retrieval | **OFF 15/15 = ON 15/15**, zero fp8-only misses, needle to ~59K tokens |
| B: fp8-rope, 64K divergence | KL(on‖off) 0.0493 nats — **below** the 0.056–0.061 self-noise floor |

Shipped in `verdictai/vllm-glm52-tr3-hybrid:v4-fp8rope`.

## The change
**vllm** (`local-inference-lab/vllm` @ `dev/fathomless-firmament`):
- `model_executor/layers/mla.py` — (A) outer-scale loader + `kv_c_normed / s_l` (+103/−2); (B) the fp8-rope write hook (+42/−1).
- `v1/attention/backends/mla/b12x_mla_sparse.py` — (B) the 368 B record layout + `scale_format` (+149/−6).
- `v1/kv_cache_interface.py` + `model_executor/layers/attention/mla_attention.py` — (B) the 368 B allocator ABI so page accounting / cache shape / writer / readers agree.

**b12x** (`lukealonso/b12x`):
- `attention/mla/{api,decode_math,kernel,prefill,prefill_mg}.py` — (A) in-kernel `s_l` restore (`scale_format==2`); (B) the fp8-rope pack on write + dequant on read (~200 lines).
- `attention/mla/traits.py` — (B) the gated 368 B GLM record variant.
- a small torch custom op `concat_and_cache_nvfp4_mla_fp8_rope` (the fp8 rope writer).

## Opt-in / no default change
- (A) no scales file → `s_l = 1.0` = prior behavior. The shipped per-layer scales are calibrated
  offline (per-layer max-abs of `kv_c_normed` ÷ 6·448) — `nvfp4_ds_mla_outer_scale_v1` JSON,
  loaded via `VLLM_NVFP4_MLA_SCALES_FILE`.
- (B) `KV_FP8_ROPE` unset/`0` → byte-identical 432 B record; `=1` selects 368 B. GLM path only
  (V3.2 + DSV4 records untouched).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for NVFP4 MLA KV-cache formats, including optimized storage layouts.
  * Added optional FP8 RoPE KV-cache writing for supported model and backend configurations.
  * Added calibrated per-layer scaling for compatible NVFP4 MLA models.
  * Improved distributed decode support with capability checks and quantized query handling.

* **Bug Fixes**
  * Prevented incorrect dtype conversions for NVFP4 KV caches.
  * Added validation and clearer errors for unsupported cache layouts, data types, and FP8 RoPE configurations.
  * Improved cache sizing and execution behavior across supported model variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->