### PR TITLE
Fix TP6 virtual padding for GLM MTP drafts

### DIFF
--- a/tests/config/test_virtual_tp.py
+++ b/tests/config/test_virtual_tp.py
@@ -45,6 +45,7 @@ class FakeModelConfig:
 
 class FakeGlmDsaModelConfig:
     def __init__(self):
+        self.verified_attention_heads = None
         self.hf_text_config = SimpleNamespace(
             model_type="glm_moe_dsa",
             architectures=["GlmMoeDsaForCausalLM"],
@@ -66,6 +67,10 @@ class FakeGlmDsaModelConfig:
         return SimpleNamespace(
             total_num_attention_heads=self.hf_text_config.num_attention_heads,
         )
+
+    def verify_with_parallel_config(self, parallel_config):
+        self.verified_attention_heads = self.hf_text_config.num_attention_heads
+        assert self.verified_attention_heads % parallel_config.tensor_parallel_size == 0
 
 
 class FakeWrappedGlmDsaModelConfig(FakeGlmDsaModelConfig):
@@ -332,6 +337,23 @@ def test_b12x_virtual_tp_padding_glm_dsa_draft_tp6():
     assert text_config.num_attention_heads == 66
     assert text_config.moe_intermediate_size == 2112
     assert draft_model_config.model_arch_config.total_num_attention_heads == 66
+
+
+def test_b12x_virtual_tp_padding_glm_dsa_draft_precedes_validation():
+    target_model_config = FakeGlmDsaModelConfig()
+    draft_model_config = FakeGlmDsaModelConfig()
+    spec_config = SpeculativeConfig(
+        method="ngram",
+        num_speculative_tokens=1,
+    )
+    spec_config.method = "mtp"
+    spec_config.target_model_config = target_model_config
+    spec_config.draft_model_config = draft_model_config
+    spec_config.draft_parallel_config = ParallelConfig(tensor_parallel_size=6)
+
+    spec_config._verify_args()
+
+    assert draft_model_config.verified_attention_heads == 66
 
 
 def test_b12x_virtual_tp_padding_minimax_m3_tp3_only():

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -1184,6 +1184,24 @@ class SpeculativeConfig:
 
         return draft_parallel_config
 
+    def _maybe_apply_virtual_tp_to_draft(self) -> None:
+        if (
+            self.method != "mtp"
+            or self.draft_model_config is None
+            or self.draft_parallel_config is None
+            or self.draft_model_config is self.target_model_config
+        ):
+            return
+
+        from vllm.config.virtual_tp import (
+            apply_b12x_virtual_tp_padding_to_model_config,
+        )
+
+        apply_b12x_virtual_tp_padding_to_model_config(
+            self.draft_model_config,
+            self.draft_parallel_config,
+        )
+
     @field_validator("draft_attention_backend", mode="before")
     @classmethod
     def _parse_draft_attention_backend(cls, value: Any) -> Any:
@@ -1244,6 +1262,7 @@ class SpeculativeConfig:
             )
 
         if self.draft_model_config:
+            self._maybe_apply_virtual_tp_to_draft()
             self.draft_model_config.verify_with_parallel_config(
                 self.draft_parallel_config
             )


### PR DESCRIPTION
## Summary

- restore virtual-TP padding for independently constructed MTP draft model configs
- apply the draft padding plan before draft parallel-config validation
- add a regression test that verifies padding precedes the divisibility check

## Root cause

The GLM target config was padded from 64 to 66 attention heads in `VllmConfig.__post_init__`, but `SpeculativeConfig` validates the independently constructed `DeepSeekMTPModel` first. The v17 stack contained the draft-padding test but omitted the corresponding helper and validator call, so TP6 worked with MTP off and failed with MTP enabled.

## Validation

- `19 passed` in `tests/config/test_virtual_tp.py`
- Ruff check and format check passed
- exact config-only reproduction now passes for TP6, DCP6, MTP3 with both target and draft at 66 heads / 2112 MoE intermediate size
