### PR TITLE
perf: avoid fixed-width MTP draft host synchronization

### DIFF
--- a/tests/v1/spec_decode/test_draft_tokens_handler.py
+++ b/tests/v1/spec_decode/test_draft_tokens_handler.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import numpy as np
+
+from vllm.v1.worker.gpu.spec_decode.utils import DraftTokensHandler
+
+
+def _handler(*, needs_real_draft_tokens: bool) -> DraftTokensHandler:
+    handler = object.__new__(DraftTokensHandler)
+    handler.needs_real_draft_tokens = needs_real_draft_tokens
+    handler.req_ids = []
+    handler.draft_tokens_np = None
+    handler.num_draft_tokens = 0
+    return handler
+
+
+def test_fixed_width_drafts_skip_host_copy() -> None:
+    handler = _handler(needs_real_draft_tokens=False)
+    input_batch = SimpleNamespace(
+        req_ids=["req-0", "req-1"], has_structured_output_reqs=False
+    )
+    draft_tokens = np.zeros((2, 2), dtype=np.int32)
+
+    handler.set_draft_tokens(input_batch, draft_tokens)  # type: ignore[arg-type]
+    output = handler.get_draft_tokens()
+
+    assert handler.draft_tokens_np is None
+    assert output is not None
+    assert output.req_ids == ["req-0", "req-1"]
+    assert output.draft_token_ids == [[-1, -1], [-1, -1]]
+
+
+def test_host_draft_ids_trim_negative_suffix() -> None:
+    handler = _handler(needs_real_draft_tokens=True)
+    handler.req_ids = ["req-0", "req-1"]
+    handler.draft_tokens_np = np.array([[11, 12], [21, -1]], dtype=np.int32)
+    handler.copy_event = SimpleNamespace(synchronize=lambda: None)
+
+    output = handler.get_draft_tokens()
+
+    assert output is not None
+    assert output.draft_token_ids == [[11, 12], [21]]

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -1360,6 +1360,15 @@ class SpeculativeConfig:
     def use_causal_cascade(self) -> bool:
         return self.method == "causal_cascade"
 
+    def requires_host_draft_token_ids(self) -> bool:
+        """Whether async scheduling needs the actual draft ids on the host.
+
+        Fixed-width speculators can use scheduler placeholders and keep draft
+        ids on the worker. Block speculators may return a shorter prefix using
+        ``-1`` sentinels, so the scheduler must receive their real draft ids.
+        """
+        return self.method in ("dflash", "dspark", "causal_cascade")
+
     def uses_batch_size_dynamic_speculative_decoding(self) -> bool:
         return self.num_speculative_tokens_per_batch_size is not None
 

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -160,6 +160,11 @@ class EngineCore:
         self.check_for_draft_tokens = (
             self.use_spec_decode or vllm_config.model_config.is_diffusion
         )
+        speculative_config = vllm_config.speculative_config
+        self.requires_host_draft_token_ids = (
+            speculative_config is not None
+            and speculative_config.requires_host_draft_token_ids()
+        )
         if self.scheduler.connector is not None:  # type: ignore
             self.model_executor.init_kv_output_aggregator(self.scheduler.connector)  # type: ignore
 
@@ -505,7 +510,7 @@ class EngineCore:
             scheduler_output, model_output
         )
         if (
-            self.check_for_draft_tokens
+            self.requires_host_draft_token_ids
             and self.async_scheduling
             and scheduler_output.total_num_scheduled_tokens > 0
         ):
@@ -612,7 +617,7 @@ class EngineCore:
             scheduler_output, model_output
         )
         if (
-            self.check_for_draft_tokens
+            self.requires_host_draft_token_ids
             and self.async_scheduling
             and scheduler_output.total_num_scheduled_tokens > 0
         ):

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -240,8 +240,15 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                         "parallel is not supported."
                     )
 
-        # Draft tokens propagation - for spec-dec + struct outputs.
-        self.draft_tokens_handler = DraftTokensHandler(self.device)
+        # Draft token propagation for structured outputs and block speculators
+        # whose returned draft prefix can be shorter than the configured width.
+        self.draft_tokens_handler = DraftTokensHandler(
+            self.device,
+            needs_real_draft_tokens=(
+                self.speculative_config is not None
+                and self.speculative_config.requires_host_draft_token_ids()
+            ),
+        )
 
         # Pooling models.
         self.is_pooling_model = self.model_config.runner_type == "pooling"

--- a/vllm/v1/worker/gpu/spec_decode/utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/utils.py
@@ -37,8 +37,13 @@ def limit_draft_tokens(
 
 
 class DraftTokensHandler:
-    def __init__(self, device: torch.device | None = None):
+    def __init__(
+        self,
+        device: torch.device | None = None,
+        needs_real_draft_tokens: bool = False,
+    ):
         self.device = device
+        self.needs_real_draft_tokens = needs_real_draft_tokens
         self.copy_stream = torch.cuda.Stream(device)
         # Blocking (sleep) event to avoid busy-polling the CUDA driver lock.
         self.copy_event = torch.cuda.Event(blocking=True)
@@ -52,6 +57,14 @@ class DraftTokensHandler:
     ) -> None:
         self.req_ids = input_batch.req_ids
         self.num_draft_tokens = draft_tokens.shape[1]
+        if (
+            not self.needs_real_draft_tokens
+            and not input_batch.has_structured_output_reqs
+        ):
+            # Fixed-width speculators use scheduler placeholders. Avoid a D2H
+            # copy and per-step event synchronization on their decode path.
+            self.draft_tokens_np = None
+            return
 
         # The scheduler needs the real draft lengths. Some speculators use
         # -1 as a sentinel for fallback/no-draft slots; sending placeholder
@@ -71,14 +84,15 @@ class DraftTokensHandler:
         if self.draft_tokens_np is not None:
             self.copy_event.synchronize()
             draft_token_ids = self.draft_tokens_np.tolist()
+            for token_ids in draft_token_ids:
+                for i, token_id in enumerate(token_ids):
+                    if token_id < 0:
+                        del token_ids[i:]
+                        break
         else:
-            # This case only happens when async scheduling is disabled.
+            # Fixed-width async scheduling only needs the draft count. The
+            # worker retains the actual token ids for verification.
             draft_token_ids = [[-1] * self.num_draft_tokens for _ in self.req_ids]
-        for token_ids in draft_token_ids:
-            for i, token_id in enumerate(token_ids):
-                if token_id < 0:
-                    del token_ids[i:]
-                    break
         return DraftTokenIds(self.req_ids, draft_token_ids)
 
 


### PR DESCRIPTION
## Summary

- classify speculative methods by whether the scheduler needs their real draft token IDs on the host
- keep fixed-width MTP draft IDs on the worker and give the scheduler fixed-width placeholders
- avoid the per-target-step draft D2H copy and `copy_event.synchronize()` for standard MTP
- preserve real host draft IDs for variable-width DFlash, DSpark, and CausalCascade methods
- preserve the existing host-copy path for structured-output requests

## Root cause

With async scheduling enabled, `DraftTokensHandler` copied draft token IDs to the host and `EngineCore` consumed them after every target decode step. This is required for variable-width block speculators because a `-1` suffix communicates their actual draft length, but standard MTP always has the configured fixed draft width. Its scheduler does not need the token values; verification continues to use the real IDs retained on the worker.

The unnecessary CUDA-event synchronization reduced GLM-5.2 MTP:3 target-step rate while MTP:0 remained unchanged.

## Performance validation

Configuration: GLM-5.2 NVFP4, A16, TP8, DCP1, MTP:3, F8 DMA disabled, CC1, temperature 0. Each result uses four runs of three complete 2,048-token requests. Baseline and patched images were swapped between GPU 0-7 and GPU 8-15, and both servers were fully loaded and settled before measurement.

| Metric | GPU 0-7 | GPU 8-15 | Balanced effect |
|---|---:|---:|---:|
| Decode throughput | 135.81 -> 142.56 tok/s (+4.97%) | 133.02 -> 139.08 tok/s (+4.55%) | **+4.758%** |
| Target steps/s | 47.04 -> 49.16 (+4.52%) | 46.33 -> 48.41 (+4.48%) | **+4.496%** |

Bootstrap 95% CI for the balanced throughput effect: **+3.588% to +5.877%**.

Acceptance and mean accepted length did not change significantly:

- acceptance: +0.337%, 95% CI -1.290% to +1.929%
- mean accepted length: +0.252%, 95% CI -0.816% to +1.286%

This isolates the gain to target-step execution rather than a favorable acceptance sample.

## Checks

- `pytest --noconftest -q tests/v1/spec_decode/test_draft_tokens_handler.py` (`2 passed`)
- `ruff check` on all changed Python files
- `ruff format --check` on all changed Python files
- full GLM-5.2 TP8 MTP:3 crossover benchmark on 16 GPUs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved speculative decoding support for methods that can return shorter draft-token prefixes.
  - Draft token IDs are now correctly trimmed at negative sentinel values when needed.
  - Fixed handling of fixed-width draft tokens by avoiding unnecessary host-side transfers and providing consistent placeholder values.
  - Updated scheduling and GPU execution paths to use the appropriate draft-token handling behavior.
- **Tests**
  - Added coverage for host-copy behavior and negative draft-token suffix trimming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->