### PR TITLE
fix(scheduler): skip lookahead allocation for running prefill chunks

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import dataclasses
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 import torch
@@ -1301,6 +1301,48 @@ def test_no_spec_tokens_scheduled_for_prefill_chunks():
     assert output.num_scheduled_tokens[req.request_id] == 4
     assert req.request_id in output.scheduled_spec_decode_tokens
     assert len(output.scheduled_spec_decode_tokens[req.request_id]) == num_spec_tokens
+
+
+def test_running_chunked_prefill_uses_zero_lookahead_tokens():
+    scheduler = create_scheduler(
+        num_speculative_tokens=3,
+        max_num_batched_tokens=50,
+        enable_chunked_prefill=True,
+    )
+    request = create_requests(num_requests=1, num_tokens=80)[0]
+    scheduler.add_request(request)
+
+    output = scheduler.schedule()
+    assert output.num_scheduled_tokens[request.request_id] == 50
+
+    scheduler.update_from_output(
+        output,
+        ModelRunnerOutput(
+            req_ids=[request.request_id],
+            req_id_to_index={request.request_id: 0},
+            sampled_token_ids=[[]],
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[],
+        ),
+    )
+
+    observed_lookahead_tokens: list[int] = []
+    allocate_slots = scheduler.kv_cache_manager.allocate_slots
+
+    def recording_allocate_slots(*args, **kwargs):
+        observed_lookahead_tokens.append(kwargs["num_lookahead_tokens"])
+        return allocate_slots(*args, **kwargs)
+
+    with patch.object(
+        scheduler.kv_cache_manager,
+        "allocate_slots",
+        side_effect=recording_allocate_slots,
+    ):
+        scheduler.schedule()
+
+    assert observed_lookahead_tokens
+    assert observed_lookahead_tokens[0] == 0
 
 
 def _model_output(scheduler, output, sampled):

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -544,11 +544,14 @@ class Scheduler(SchedulerInterface):
 
             # Schedule newly needed KV blocks for the request.
             with record_function_or_nullcontext("schedule: allocate_slots"):
+                effective_lookahead_tokens = (
+                    0 if request.is_prefill_chunk else self.num_lookahead_tokens
+                )
                 while True:
                     new_blocks = self.kv_cache_manager.allocate_slots(
                         request,
                         num_new_tokens,
-                        num_lookahead_tokens=self.num_lookahead_tokens,
+                        num_lookahead_tokens=effective_lookahead_tokens,
                     )
 
                     if new_blocks is not None:


### PR DESCRIPTION
## Problem

The scheduler allocated speculative lookahead slots to requests that were still executing a running/chunked prefill. Those slots cannot be consumed by speculative decode in that iteration and reduce usable KV capacity.

## Fix

Allocate lookahead only once the scheduled request is actually in decode. New requests retain the existing behavior.

This is a standalone current-FF extraction of the scheduler fix previously carried inside #88.

## Validation

- Targeted running chunked-prefill scheduler test: 1 passed
- Existing scheduler assertions extended to cover zero lookahead during running prefill
- `ruff check` and `ruff format --check` on changed files
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chunked prefill scheduling by ensuring no lookahead tokens are allocated during prefill steps.
  * Preserved lookahead token allocation for other scheduling operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->