### PR TITLE
perf(spec decode): return variable draft ids through async output

### DIFF
--- a/tests/v1/spec_decode/test_async_draft_output.py
+++ b/tests/v1/spec_decode/test_async_draft_output.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import numpy as np
+
+from vllm.v1.outputs import ModelRunnerOutput
+from vllm.v1.worker.gpu.async_utils import AsyncOutput
+
+
+def test_async_output_returns_draft_ids_on_same_event() -> None:
+    output = object.__new__(AsyncOutput)
+    output.copy_event_recorded = True
+    output.copy_event = SimpleNamespace(synchronize=lambda: None)
+    output.sampled_token_ids = np.array([[7, -1]], dtype=np.int32)
+    output.num_sampled_tokens_np = np.array([1], dtype=np.int32)
+    output.num_nans = None
+    output.logprobs_tensors = None
+    output.prompt_logprobs_dict = {}
+    output.model_runner_output = ModelRunnerOutput(
+        req_ids=["req-0"], req_id_to_index={"req-0": 0}
+    )
+    output.draft_req_ids = ["req-0"]
+    output.draft_token_ids_np = np.array([[11, 12, -1]], dtype=np.int32)
+
+    model_output = output.get_output()
+
+    assert model_output.sampled_token_ids == [[7]]
+    assert model_output.draft_token_ids is not None
+    assert model_output.draft_token_ids.req_ids == ["req-0"]
+    assert model_output.draft_token_ids.draft_token_ids == [[11, 12]]

--- a/tests/v1/spec_decode/test_draft_tokens_handler.py
+++ b/tests/v1/spec_decode/test_draft_tokens_handler.py
@@ -33,6 +33,17 @@ def test_fixed_width_drafts_skip_host_copy() -> None:
     assert output.draft_token_ids == [[-1, -1], [-1, -1]]
 
 
+def test_host_copy_requirement() -> None:
+    fixed = _handler(needs_real_draft_tokens=False)
+    variable = _handler(needs_real_draft_tokens=True)
+    plain_batch = SimpleNamespace(has_structured_output_reqs=False)
+    structured_batch = SimpleNamespace(has_structured_output_reqs=True)
+
+    assert not fixed.needs_host_copy(plain_batch)  # type: ignore[arg-type]
+    assert fixed.needs_host_copy(structured_batch)  # type: ignore[arg-type]
+    assert variable.needs_host_copy(plain_batch)  # type: ignore[arg-type]
+
+
 def test_host_draft_ids_trim_negative_suffix() -> None:
     handler = _handler(needs_real_draft_tokens=True)
     handler.req_ids = ["req-0", "req-1"]

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -514,7 +514,7 @@ class EngineCore:
             and self.async_scheduling
             and scheduler_output.total_num_scheduled_tokens > 0
         ):
-            self._update_draft_token_ids_from_executor()
+            self._update_draft_token_ids_from_output(model_output)
 
         return engine_core_outputs, scheduler_output.total_num_scheduled_tokens > 0
 
@@ -522,6 +522,16 @@ class EngineCore:
         draft_token_ids = self.model_executor.take_draft_token_ids()
         if draft_token_ids is not None:
             self.scheduler.update_draft_token_ids(draft_token_ids)
+
+    def _update_draft_token_ids_from_output(
+        self, model_output: ModelRunnerOutput
+    ) -> None:
+        draft_token_ids = model_output.draft_token_ids
+        if draft_token_ids is None:
+            raise RuntimeError(
+                "Async variable-length speculation did not return draft token ids"
+            )
+        self.scheduler.update_draft_token_ids(draft_token_ids)
 
     def post_step(self, model_executed: bool) -> None:
         if self.check_for_draft_tokens and not self.async_scheduling and model_executed:
@@ -621,7 +631,7 @@ class EngineCore:
             and self.async_scheduling
             and scheduler_output.total_num_scheduled_tokens > 0
         ):
-            self._update_draft_token_ids_from_executor()
+            self._update_draft_token_ids_from_output(model_output)
 
         # NOTE(nick): We can either handle the deferred tasks here or save
         # in a field and do it immediately once step_with_batch_queue is
@@ -630,7 +640,9 @@ class EngineCore:
             # When draft tokens are used with structured output, validate them
             # before computing the grammar bitmask for the deferred request.
             if self.check_for_draft_tokens:
-                draft_token_ids = self.model_executor.take_draft_token_ids()
+                draft_token_ids = model_output.draft_token_ids
+                if draft_token_ids is None:
+                    draft_token_ids = self.model_executor.take_draft_token_ids()
                 if draft_token_ids is not None:
                     # Update the draft token ids in the scheduler output to
                     # filter out the invalid spec tokens, which will be padded

--- a/vllm/v1/outputs.py
+++ b/vllm/v1/outputs.py
@@ -243,6 +243,11 @@ class ModelRunnerOutput:
     # each request due to speculative/jump decoding.
     sampled_token_ids: list[list[int]] = field(default_factory=list)
 
+    # Draft token ids generated for the next scheduler step. Async block
+    # speculators attach these to the normal model output so their D2H transfer
+    # shares the sampled-output event instead of requiring a second worker RPC.
+    draft_token_ids: "DraftTokenIds | None" = None
+
     # [num_reqs, max_num_logprobs + 1]
     # [num_reqs, max_num_logprobs + 1]
     # [num_reqs]

--- a/vllm/v1/worker/gpu/async_utils.py
+++ b/vllm/v1/worker/gpu/async_utils.py
@@ -5,7 +5,12 @@ import contextlib
 import numpy as np
 import torch
 
-from vllm.v1.outputs import AsyncModelRunnerOutput, LogprobsTensors, ModelRunnerOutput
+from vllm.v1.outputs import (
+    AsyncModelRunnerOutput,
+    DraftTokenIds,
+    LogprobsTensors,
+    ModelRunnerOutput,
+)
 from vllm.v1.worker.gpu.sample.output import SamplerOutput
 
 
@@ -17,6 +22,7 @@ class AsyncOutput(AsyncModelRunnerOutput):
         num_sampled_tokens: torch.Tensor,
         main_stream: torch.cuda.Stream,
         copy_stream: torch.cuda.Stream,
+        defer_copy_event: bool = False,
     ):
         # NOTE(woosuk): We must retain references to the GPU tensors,
         # as the copy operations are performed on a different CUDA stream than
@@ -24,8 +30,13 @@ class AsyncOutput(AsyncModelRunnerOutput):
         self.model_runner_output = model_runner_output
         self.sampler_output = sampler_output
         self.num_sampled_tokens = num_sampled_tokens
+        self.main_stream = main_stream
+        self.copy_stream = copy_stream
+        self.draft_req_ids: list[str] | None = None
+        self.draft_token_ids_np: np.ndarray | None = None
         # Blocking (sleep) event to avoid busy-polling the CUDA driver lock.
         self.copy_event = torch.cuda.Event(blocking=True)
+        self.copy_event_recorded = False
 
         with stream(copy_stream, main_stream):
             copy_stream.wait_stream(main_stream)
@@ -44,9 +55,30 @@ class AsyncOutput(AsyncModelRunnerOutput):
                 k: v.to_cpu_nonblocking() if v is not None else None
                 for k, v in self.model_runner_output.prompt_logprobs_dict.items()
             }
-            self.copy_event.record(copy_stream)
+            if not defer_copy_event:
+                self.copy_event.record(copy_stream)
+                self.copy_event_recorded = True
+
+    def add_draft_token_ids(
+        self, req_ids: list[str], draft_token_ids: torch.Tensor
+    ) -> None:
+        """Append draft D2H to this output's copy stream and final event."""
+        assert not self.copy_event_recorded
+        self.draft_req_ids = list(req_ids)
+
+        # Draft state lives in a persistent worker buffer that the next step can
+        # overwrite. Snapshot it on the main stream before handing it to the
+        # asynchronous copy stream.
+        draft_token_ids_snapshot = draft_token_ids.clone()
+        with stream(self.copy_stream, self.main_stream):
+            self.copy_stream.wait_stream(self.main_stream)
+            self.draft_token_ids_np = async_copy_to_np(draft_token_ids_snapshot)
+            draft_token_ids_snapshot.record_stream(self.copy_stream)
+            self.copy_event.record(self.copy_stream)
+            self.copy_event_recorded = True
 
     def get_output(self) -> ModelRunnerOutput:
+        assert self.copy_event_recorded
         self.copy_event.synchronize()
 
         # NOTE(woosuk): The following code is to ensure compatibility with
@@ -62,6 +94,18 @@ class AsyncOutput(AsyncModelRunnerOutput):
                     del token_ids[i:]
                     break
         self.model_runner_output.sampled_token_ids = sampled_token_ids
+
+        if self.draft_token_ids_np is not None:
+            assert self.draft_req_ids is not None
+            draft_token_ids = self.draft_token_ids_np.tolist()
+            for token_ids in draft_token_ids:
+                for i, token_id in enumerate(token_ids):
+                    if token_id < 0:
+                        del token_ids[i:]
+                        break
+            self.model_runner_output.draft_token_ids = DraftTokenIds(
+                self.draft_req_ids, draft_token_ids
+            )
 
         if self.num_nans is not None:
             self.model_runner_output.num_nans_in_logits = dict(

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -1562,6 +1562,11 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             sampled_token_ids=None,  # type: ignore
             prompt_logprobs_dict=prompt_logprobs_dict,  # type: ignore[arg-type]
         )
+        copy_draft_with_output = (
+            self.num_speculative_steps > 0
+            and self.scheduler_config.async_scheduling
+            and self.draft_tokens_handler.needs_host_copy(input_batch)
+        )
         # Start async output copy here so that it can overlap with speculator proposal.
         with record_function_or_nullcontext(f"vllm:v2/target/{phase}/async_output"):
             async_output = AsyncOutput(
@@ -1570,6 +1575,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 num_sampled_tokens=num_sampled,
                 main_stream=self.main_stream,
                 copy_stream=self.output_copy_stream,
+                defer_copy_event=copy_draft_with_output,
             )
 
         mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None
@@ -1657,12 +1663,19 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             with record_function_or_nullcontext(
                 f"vllm:v2/target/{phase}/set_draft_tokens"
             ):
-                self.draft_tokens_handler.set_draft_tokens(
-                    input_batch,
+                next_draft_tokens = (
                     draft_tokens_for_next_step
                     if draft_tokens_for_next_step is not None
-                    else self.req_states.draft_tokens[input_batch.idx_mapping],
+                    else self.req_states.draft_tokens[input_batch.idx_mapping]
                 )
+                if copy_draft_with_output:
+                    async_output.add_draft_token_ids(
+                        input_batch.req_ids, next_draft_tokens
+                    )
+                else:
+                    self.draft_tokens_handler.set_draft_tokens(
+                        input_batch, next_draft_tokens
+                    )
 
         # Post-step KV connector related operations.
         with record_function_or_nullcontext(f"vllm:v2/target/{phase}/kv_post_forward"):

--- a/vllm/v1/worker/gpu/spec_decode/utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/utils.py
@@ -67,15 +67,15 @@ class DraftTokensHandler:
         self.draft_tokens_np: np.ndarray | None = None
         self.num_draft_tokens: int = 0
 
+    def needs_host_copy(self, input_batch: InputBatch) -> bool:
+        return self.needs_real_draft_tokens or input_batch.has_structured_output_reqs
+
     def set_draft_tokens(
         self, input_batch: InputBatch, draft_tokens: torch.Tensor
     ) -> None:
         self.req_ids = input_batch.req_ids
         self.num_draft_tokens = draft_tokens.shape[1]
-        if (
-            not self.needs_real_draft_tokens
-            and not input_batch.has_structured_output_reqs
-        ):
+        if not self.needs_host_copy(input_batch):
             # Fixed-width speculators use scheduler placeholders. Avoid a D2H
             # copy and per-step event synchronization on their decode path.
             self.draft_tokens_np = None


### PR DESCRIPTION
## Context

#97 is already merged into `dev/fathomless-firmament`. This branch has been rebased onto the current FF head and now contains only the variable-length async-output extension.

## Problem

#97 removes the unconditional fixed-width draft-token host synchronization, but variable-length DSpark still needs a second device-to-host synchronization to learn the draft count and then copy IDs. That leaves one avoidable synchronization on every variable-depth step.

## Fix

Piggyback the variable-length draft IDs and their valid count on vLLM's existing asynchronous model-runner output. The engine consumes the IDs after the normal output transfer, so no separate draft-count synchronization is required. Fixed-width behavior remains unchanged from #97.

## Validation

Rebased on `dev/fathomless-firmament@b2e51d9ba3`.

- `python -m pytest -q tests/v1/spec_decode/test_draft_tokens_handler.py tests/v1/spec_decode/test_async_draft_output.py`
- Result: `4 passed`
- `ruff check`, `ruff format --check`, and `git diff --check` passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved asynchronous speculative decoding so draft token information is consistently preserved and available during subsequent processing.
  * Enhanced handling of draft tokens for structured-output requests and deferred scheduling.
  * Reduced unnecessary host transfers while maintaining correct draft-token data when required.

* **Tests**
  * Added coverage for draft token results returned on the same event.
  * Added coverage for host-copy requirements across speculative decoding scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->