### PR TITLE
fix(spec decode): harden DSpark and DFlash edge paths

### DIFF
--- a/tests/v1/attention/test_deepseek_v4_dspark_metadata.py
+++ b/tests/v1/attention/test_deepseek_v4_dspark_metadata.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import torch
+
+from vllm.v1.attention.backends.mla.sparse_swa import (
+    DeepseekSparseSWAMetadataBuilder,
+)
+from vllm.v1.kv_cache_interface import MLAAttentionSpec
+
+
+def test_dspark_swa_decode_threshold_matches_target_verification() -> None:
+    """DSpark verifies 1 + K target tokens, not the generic 1 + 2K."""
+    speculative_config = SimpleNamespace(
+        num_speculative_tokens=5,
+        parallel_drafting=True,
+        use_dspark=lambda: True,
+    )
+    hf_config = SimpleNamespace(sliding_window=128, compress_ratios=[1, 4, 128])
+    vllm_config = SimpleNamespace(
+        model_config=SimpleNamespace(max_model_len=4096, hf_config=hf_config),
+        scheduler_config=SimpleNamespace(max_num_batched_tokens=16),
+        speculative_config=speculative_config,
+        parallel_config=SimpleNamespace(
+            decode_context_parallel_size=1,
+            prefill_context_parallel_size=1,
+            cp_kv_cache_interleave_size=1,
+        ),
+    )
+    kv_cache_spec = MLAAttentionSpec(
+        block_size=256,
+        num_kv_heads=1,
+        head_size=512,
+        dtype=torch.bfloat16,
+    )
+
+    builder = DeepseekSparseSWAMetadataBuilder(
+        kv_cache_spec,
+        ["placeholder"],
+        vllm_config,
+        torch.device("cpu"),
+    )
+
+    assert builder.decode_threshold == 6

--- a/tests/v1/spec_decode/test_acceptance_length_controller.py
+++ b/tests/v1/spec_decode/test_acceptance_length_controller.py
@@ -268,6 +268,9 @@ def test_synthetic_scheduler_output_uses_default_speculative_depth():
     output.num_spec_tokens_to_schedule = 2
     assert output.resolve_num_spec_tokens_to_schedule(default=5) == 2
 
+    output.num_spec_tokens_to_schedule = 0
+    assert output.resolve_num_spec_tokens_to_schedule(default=5) == 0
+
 
 def test_runner_v2_autoregressive_drafter_stops_at_adaptive_depth(monkeypatch):
     monkeypatch.setattr(AutoRegressiveSpeculator, "__abstractmethods__", frozenset())

--- a/tests/v1/spec_decode/test_dflash_cudagraph_lifetime.py
+++ b/tests/v1/spec_decode/test_dflash_cudagraph_lifetime.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import torch
+
+from vllm.config.compilation import CUDAGraphMode
+from vllm.v1.worker.gpu.spec_decode.dflash.speculator import DFlashSpeculator
+
+
+def _make_speculator() -> SimpleNamespace:
+    hidden_states = torch.randn(2, 8)
+    return SimpleNamespace(
+        _run_model=Mock(return_value=hidden_states),
+        _captured_backbone_outputs=[],
+        num_speculative_steps=2,
+        sample_indices=torch.tensor([0, 1]),
+        sample_pos=torch.tensor([1, 2]),
+        sample_idx_mapping=torch.tensor([0, 0]),
+        temperature=torch.ones(1),
+        seeds=torch.zeros(1, dtype=torch.int64),
+        sample_col=torch.tensor([0, 1]),
+        draft_logits=None,
+        sample_draft=Mock(return_value=torch.tensor([11, 12])),
+        draft_tokens=torch.zeros(1, 2, dtype=torch.int64),
+    )
+
+
+def test_dflash_retains_backbone_output_during_cudagraph_capture(monkeypatch):
+    speculator = _make_speculator()
+    monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: True)
+
+    DFlashSpeculator._generate_draft(
+        speculator,
+        num_reqs=1,
+        num_tokens_padded=2,
+        attn_metadata=None,
+        slot_mappings=None,
+        num_tokens_across_dp=None,
+        cudagraph_runtime_mode=CUDAGraphMode.NONE,
+    )
+
+    assert len(speculator._captured_backbone_outputs) == 1
+    assert (
+        speculator._captured_backbone_outputs[0]
+        is speculator._run_model.return_value
+    )
+
+
+def test_dflash_does_not_retain_eager_backbone_output(monkeypatch):
+    speculator = _make_speculator()
+    monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: False)
+
+    DFlashSpeculator._generate_draft(
+        speculator,
+        num_reqs=1,
+        num_tokens_padded=2,
+        attn_metadata=None,
+        slot_mappings=None,
+        num_tokens_across_dp=None,
+        cudagraph_runtime_mode=CUDAGraphMode.NONE,
+    )
+
+    assert speculator._captured_backbone_outputs == []

--- a/tests/v1/spec_decode/test_dflash_cudagraph_lifetime.py
+++ b/tests/v1/spec_decode/test_dflash_cudagraph_lifetime.py
@@ -44,8 +44,7 @@ def test_dflash_retains_backbone_output_during_cudagraph_capture(monkeypatch):
 
     assert len(speculator._captured_backbone_outputs) == 1
     assert (
-        speculator._captured_backbone_outputs[0]
-        is speculator._run_model.return_value
+        speculator._captured_backbone_outputs[0] is speculator._run_model.return_value
     )
 
 

--- a/tests/v1/spec_decode/test_dflash_prefix_cache_masking.py
+++ b/tests/v1/spec_decode/test_dflash_prefix_cache_masking.py
@@ -1,0 +1,155 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""DFlash/DSpark draft context masking under prefix caching.
+
+Cache-restored tokens never flow through the target forward, so the draft's
+context KV is never written for them. shift_draft_block_tables hides those
+slots from the draft's attention by left-shifting each request's block-table
+row by the restored whole blocks (seq_lens is shortened to match by
+_prepare_dflash_inputs_kernel).
+"""
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+from vllm.v1.worker.gpu.spec_decode.dflash.speculator import (
+    shift_draft_block_tables,
+)
+
+pytestmark = pytest.mark.skipif(
+    not current_platform.is_cuda(), reason="Requires CUDA"
+)
+
+DEVICE = "cuda"
+BLOCK_SIZE = 16
+MAX_BLOCKS = 64
+MAX_NUM_REQS = 8
+
+
+def _make_block_table(num_reqs: int) -> torch.Tensor:
+    # Distinct block ids per (request, slot) so shifts are detectable.
+    table = torch.arange(
+        MAX_NUM_REQS * MAX_BLOCKS, dtype=torch.int32, device=DEVICE
+    ).view(MAX_NUM_REQS, MAX_BLOCKS)
+    return table[:num_reqs].contiguous()
+
+
+@pytest.mark.parametrize(
+    "num_cached,expected_shift",
+    [
+        (0, 0),  # no cache hit: no-op
+        (BLOCK_SIZE * 3, 3),  # block-aligned hit (the common APC case)
+        (BLOCK_SIZE * 3 + 5, 3),  # unaligned: floor to whole blocks
+        (BLOCK_SIZE - 1, 0),  # less than one block: no-op
+    ],
+)
+def test_shift_single_request(num_cached: int, expected_shift: int):
+    block_table = _make_block_table(1)
+    original = block_table.clone()
+    idx_mapping = torch.zeros(1, dtype=torch.int32, device=DEVICE)
+    num_cached_tokens = torch.full(
+        (MAX_NUM_REQS,), num_cached, dtype=torch.int32, device=DEVICE
+    )
+
+    seq_lens = torch.full(
+        (idx_mapping.shape[0],),
+        MAX_BLOCKS * BLOCK_SIZE,
+        dtype=torch.int32,
+        device=DEVICE,
+    )
+    shift_draft_block_tables(
+        block_table, idx_mapping, num_cached_tokens, seq_lens, BLOCK_SIZE
+    )
+
+    kept = MAX_BLOCKS - expected_shift
+    torch.testing.assert_close(
+        block_table[0, :kept], original[0, expected_shift:]
+    )
+
+
+def test_shift_per_request_and_idx_mapping():
+    # Requests in batch order 0..3 map to request-state slots 3..0, with a
+    # different cached count per slot. Each row must shift by its own count.
+    num_reqs = 4
+    block_table = _make_block_table(num_reqs)
+    original = block_table.clone()
+    idx_mapping = torch.tensor([3, 2, 1, 0], dtype=torch.int32, device=DEVICE)
+    # Slot i has i whole cached blocks.
+    num_cached_tokens = torch.zeros(
+        MAX_NUM_REQS, dtype=torch.int32, device=DEVICE
+    )
+    num_cached_tokens[:4] = (
+        torch.arange(4, dtype=torch.int32, device=DEVICE) * BLOCK_SIZE
+    )
+
+    seq_lens = torch.full(
+        (idx_mapping.shape[0],),
+        MAX_BLOCKS * BLOCK_SIZE,
+        dtype=torch.int32,
+        device=DEVICE,
+    )
+    shift_draft_block_tables(
+        block_table, idx_mapping, num_cached_tokens, seq_lens, BLOCK_SIZE
+    )
+
+    for batch_idx in range(num_reqs):
+        shift = int(idx_mapping[batch_idx])  # slot id == cached blocks
+        kept = MAX_BLOCKS - shift
+        torch.testing.assert_close(
+            block_table[batch_idx, :kept],
+            original[batch_idx, shift:],
+            msg=f"batch row {batch_idx} (slot {shift})",
+        )
+
+
+def test_shift_large_row_in_place_overlap():
+    # Shift smaller than the copy chunk (1024) exercises the overlapping
+    # in-place load-before-store path on a long row.
+    max_blocks = 4096
+    block_table = (
+        torch.arange(max_blocks, dtype=torch.int32, device=DEVICE)
+        .unsqueeze(0)
+        .contiguous()
+    )
+    original = block_table.clone()
+    idx_mapping = torch.zeros(1, dtype=torch.int32, device=DEVICE)
+    num_cached_tokens = torch.full(
+        (1,), 7 * BLOCK_SIZE, dtype=torch.int32, device=DEVICE
+    )
+
+    seq_lens = torch.full(
+        (idx_mapping.shape[0],),
+        max_blocks * BLOCK_SIZE,
+        dtype=torch.int32,
+        device=DEVICE,
+    )
+    shift_draft_block_tables(
+        block_table, idx_mapping, num_cached_tokens, seq_lens, BLOCK_SIZE
+    )
+
+    torch.testing.assert_close(
+        block_table[0, : max_blocks - 7], original[0, 7:]
+    )
+
+
+def test_shift_copy_bounded_by_seq_len():
+    # Only the blocks referenced by the shifted sequence move; the tail of the
+    # row must stay untouched (perf guard for long-context block tables).
+    block_table = _make_block_table(1)
+    original = block_table.clone()
+    idx_mapping = torch.zeros(1, dtype=torch.int32, device=DEVICE)
+    num_cached_tokens = torch.full(
+        (MAX_NUM_REQS,), 4 * BLOCK_SIZE, dtype=torch.int32, device=DEVICE
+    )
+    # Shifted draft length of 3.5 blocks -> exactly 4 blocks copied.
+    seq_lens = torch.full(
+        (1,), 3 * BLOCK_SIZE + BLOCK_SIZE // 2, dtype=torch.int32, device=DEVICE
+    )
+
+    shift_draft_block_tables(
+        block_table, idx_mapping, num_cached_tokens, seq_lens, BLOCK_SIZE
+    )
+
+    torch.testing.assert_close(block_table[0, :4], original[0, 4:8])
+    torch.testing.assert_close(block_table[0, 4:], original[0, 4:])

--- a/tests/v1/spec_decode/test_dflash_prefix_cache_masking.py
+++ b/tests/v1/spec_decode/test_dflash_prefix_cache_masking.py
@@ -17,9 +17,7 @@ from vllm.v1.worker.gpu.spec_decode.dflash.speculator import (
     shift_draft_block_tables,
 )
 
-pytestmark = pytest.mark.skipif(
-    not current_platform.is_cuda(), reason="Requires CUDA"
-)
+pytestmark = pytest.mark.skipif(not current_platform.is_cuda(), reason="Requires CUDA")
 
 DEVICE = "cuda"
 BLOCK_SIZE = 16
@@ -63,9 +61,7 @@ def test_shift_single_request(num_cached: int, expected_shift: int):
     )
 
     kept = MAX_BLOCKS - expected_shift
-    torch.testing.assert_close(
-        block_table[0, :kept], original[0, expected_shift:]
-    )
+    torch.testing.assert_close(block_table[0, :kept], original[0, expected_shift:])
 
 
 def test_shift_per_request_and_idx_mapping():
@@ -76,9 +72,7 @@ def test_shift_per_request_and_idx_mapping():
     original = block_table.clone()
     idx_mapping = torch.tensor([3, 2, 1, 0], dtype=torch.int32, device=DEVICE)
     # Slot i has i whole cached blocks.
-    num_cached_tokens = torch.zeros(
-        MAX_NUM_REQS, dtype=torch.int32, device=DEVICE
-    )
+    num_cached_tokens = torch.zeros(MAX_NUM_REQS, dtype=torch.int32, device=DEVICE)
     num_cached_tokens[:4] = (
         torch.arange(4, dtype=torch.int32, device=DEVICE) * BLOCK_SIZE
     )
@@ -128,9 +122,7 @@ def test_shift_large_row_in_place_overlap():
         block_table, idx_mapping, num_cached_tokens, seq_lens, BLOCK_SIZE
     )
 
-    torch.testing.assert_close(
-        block_table[0, : max_blocks - 7], original[0, 7:]
-    )
+    torch.testing.assert_close(block_table[0, : max_blocks - 7], original[0, 7:])
 
 
 def test_shift_copy_bounded_by_seq_len():

--- a/tests/v1/spec_decode/test_dflash_prefix_cache_masking.py
+++ b/tests/v1/spec_decode/test_dflash_prefix_cache_masking.py
@@ -9,11 +9,15 @@ row by the restored whole blocks (seq_lens is shortened to match by
 _prepare_dflash_inputs_kernel).
 """
 
+from types import SimpleNamespace
+
+import numpy as np
 import pytest
 import torch
 
 from vllm.platforms import current_platform
 from vllm.v1.worker.gpu.spec_decode.dflash.speculator import (
+    DFlashSpeculator,
     shift_draft_block_tables,
 )
 
@@ -23,6 +27,25 @@ DEVICE = "cuda"
 BLOCK_SIZE = 16
 MAX_BLOCKS = 64
 MAX_NUM_REQS = 8
+
+
+def test_unaligned_cached_prefix_detection():
+    speculator = SimpleNamespace(
+        num_cached_tokens_np=np.array([32, 35, 64], dtype=np.int32),
+        block_tables=SimpleNamespace(kernel_block_sizes=[16]),
+    )
+
+    aligned = SimpleNamespace(
+        idx_mapping_np=np.array([0, 2], dtype=np.int32),
+        num_reqs=2,
+    )
+    unaligned = SimpleNamespace(
+        idx_mapping_np=np.array([0, 1], dtype=np.int32),
+        num_reqs=2,
+    )
+
+    assert not DFlashSpeculator._has_unaligned_cached_prefix(speculator, aligned)
+    assert DFlashSpeculator._has_unaligned_cached_prefix(speculator, unaligned)
 
 
 def _make_block_table(num_reqs: int) -> torch.Tensor:

--- a/tests/v1/spec_decode/test_dynamic_sd_cug.py
+++ b/tests/v1/spec_decode/test_dynamic_sd_cug.py
@@ -326,3 +326,52 @@ def test_dynamic_sd_only_captures_scheduled_query_lengths(monkeypatch):
                 assert desc.num_tokens == num_tokens
                 assert desc.num_reqs is None
             assert desc.num_active_loras == 0
+
+
+def test_dynamic_sd_skips_zero_draft_tokens_in_cudagraph_schedule(monkeypatch):
+    """K=0 in the DSD schedule must not produce decode_query_len=0.
+
+    DSpark (anchor-as-first) passes ``num_query_per_req == num_speculative_tokens``
+    to the draft CudaGraphManager, so ``num_new_sampled_tokens_per_step`` recovers
+    as 0. A schedule entry with K=0 would otherwise crash during candidate init.
+    """
+
+    max_num_seqs = 128
+    max_spec_tokens = 5
+
+    monkeypatch.setattr(
+        gpu_cudagraph_utils,
+        "get_pp_group",
+        lambda: SimpleNamespace(is_first_rank=True, is_last_rank=True),
+    )
+
+    vllm_config = _create_vllm_config_for_dsd(
+        max_num_seqs=max_num_seqs,
+        max_spec_tokens=max_spec_tokens,
+        cudagraph_mode="FULL_AND_PIECEWISE",
+        use_dynamic_sd=True,
+        num_spec_per_batch_size=[
+            (1, 32, 5),
+            (33, 64, 3),
+            (65, 96, 1),
+            (97, 128, 0),
+        ],
+    )
+    draft_decode_query_len = max_spec_tokens
+
+    manager = gpu_cudagraph_utils.CudaGraphManager(
+        vllm_config=vllm_config,
+        device=torch.device("cpu"),
+        cudagraph_mode=CUDAGraphMode.FULL_AND_PIECEWISE,
+        decode_query_len=draft_decode_query_len,
+    )
+
+    scheduled_query_lens = {5, 3, 1}
+    captured_query_lens = {
+        desc.uniform_token_count
+        for descs in manager._candidates.values()
+        for desc in descs
+        if desc.cg_mode == CUDAGraphMode.FULL
+        and desc.uniform_token_count is not None
+    }
+    assert captured_query_lens == scheduled_query_lens

--- a/tests/v1/spec_decode/test_dynamic_sd_cug.py
+++ b/tests/v1/spec_decode/test_dynamic_sd_cug.py
@@ -62,7 +62,10 @@ def _create_vllm_config_for_dsd(
     vllm_config.num_speculative_tokens = max_spec_tokens
 
     speculative_config = MagicMock()
-    speculative_config.uses_dynamic_speculative_decoding.return_value = use_dynamic_sd
+    speculative_config.uses_batch_size_dynamic_speculative_decoding.return_value = (
+        use_dynamic_sd
+    )
+    speculative_config.uses_acceptance_length_adaptation.return_value = False
     if use_dynamic_sd:
         # DSD reads the per-batch-size schedule; a schedule entry with K
         # speculative tokens maps to decode query length K + 1. By default

--- a/tests/v1/spec_decode/test_dynamic_sd_cug.py
+++ b/tests/v1/spec_decode/test_dynamic_sd_cug.py
@@ -374,7 +374,6 @@ def test_dynamic_sd_skips_zero_draft_tokens_in_cudagraph_schedule(monkeypatch):
         desc.uniform_token_count
         for descs in manager._candidates.values()
         for desc in descs
-        if desc.cg_mode == CUDAGraphMode.FULL
-        and desc.uniform_token_count is not None
+        if desc.cg_mode == CUDAGraphMode.FULL and desc.uniform_token_count is not None
     }
     assert captured_query_lens == scheduled_query_lens

--- a/tests/v1/worker/test_gpu_sampling_states_seed.py
+++ b/tests/v1/worker/test_gpu_sampling_states_seed.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import numpy as np
+import torch
+
+from vllm.sampling_params import SamplingParams
+from vllm.v1.worker.gpu.sample import states
+
+
+class _HostBackedTensor:
+    def __init__(self, size: int, dtype: torch.dtype):
+        self.cpu = torch.zeros(size, dtype=dtype)
+        self.np = self.cpu.numpy()
+        self.gpu = self.cpu
+
+    def copy_to_uva(self, n: int | None = None) -> torch.Tensor:
+        return self.gpu[:n] if n is not None else self.gpu
+
+
+def test_fallback_seeds_do_not_depend_on_global_numpy_rng(monkeypatch) -> None:
+    monkeypatch.setattr(states, "UvaBackedTensor", _HostBackedTensor)
+    rank0 = states.SamplingStates(4, 128, seed=17)
+
+    np.random.seed(1234)
+    np.random.random(1000)
+    rank1 = states.SamplingStates(4, 128, seed=17)
+
+    params = SamplingParams(seed=None)
+    for req_idx in range(4):
+        rank0.add_request(req_idx, params)
+        np.random.random(req_idx + 1)
+        rank1.add_request(req_idx, params)
+
+    np.testing.assert_array_equal(rank0.seeds.np, rank1.seeds.np)

--- a/tools/pre_commit/generate_attention_backend_docs.py
+++ b/tools/pre_commit/generate_attention_backend_docs.py
@@ -1341,7 +1341,9 @@ def _get_backends_from_return(stmts: list) -> list[str]:
 
 
 def _is_sm100_check(test: ast.expr) -> bool:
-    """Check if test is `something.major == 10`."""
+    """Check if test is `something.major == 10`, possibly inside an `and`."""
+    if isinstance(test, ast.BoolOp) and isinstance(test.op, ast.And):
+        return any(_is_sm100_check(value) for value in test.values)
     return (
         isinstance(test, ast.Compare)
         and isinstance(test.left, ast.Attribute)

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -85,6 +85,7 @@ def _get_backend_priorities(
     device_capability: DeviceCapability,
     num_heads: int | None = None,
     kv_cache_dtype: CacheDType | None = None,
+    use_non_causal: bool = False,
 ) -> list[AttentionBackendEnum]:
     """Get backend priorities with lazy import to avoid circular dependency."""
     from vllm.utils.torch_utils import is_quantized_kv_cache
@@ -141,7 +142,10 @@ def _get_backend_priorities(
                 AttentionBackendEnum.FLASHMLA_SPARSE,
             ]
     else:
-        if device_capability.major == 10:
+        # SM100f defaults to FlashInfer for TRTLLM causal attention, but its non-causal
+        # cutlass path (used for dflash attention) is known to have problems.
+        # So prefer FlashAttention when non-causal on SM100f.
+        if device_capability.major == 10 and not use_non_causal:
             return [
                 AttentionBackendEnum.FLASHINFER,
                 AttentionBackendEnum.FLASH_ATTN,
@@ -368,6 +372,7 @@ class CudaPlatformBase(Platform):
             device_capability,
             num_heads,
             attn_selector_config.kv_cache_dtype,
+            attn_selector_config.use_non_causal,
         )
         for priority, backend in enumerate(backend_priorities):
             try:

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -9,17 +9,17 @@ from typing import ClassVar
 
 import numpy as np
 import torch
+from flashinfer.decode import fast_decode_plan, trtllm_batch_decode_with_kv_cache
+from flashinfer.prefill import trtllm_batch_context_with_kv_cache
+from flashinfer.utils import FP4Tensor
+from typing_extensions import override
+
 from flashinfer import (
     BatchDecodeWithPagedKVCacheWrapper,
     BatchPrefillWithPagedKVCacheWrapper,
     BatchPrefillWithRaggedKVCacheWrapper,
     MultiLevelCascadeAttentionWrapper,
 )
-from flashinfer.decode import fast_decode_plan, trtllm_batch_decode_with_kv_cache
-from flashinfer.prefill import trtllm_batch_context_with_kv_cache
-from flashinfer.utils import FP4Tensor
-from typing_extensions import override
-
 from vllm import _custom_ops as custom_ops
 from vllm import envs
 from vllm.config import (
@@ -885,7 +885,8 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                 has_trtllm_support = False
                 break
 
-        if has_trtllm_support:
+        # trtllm-gen only supports causal attention.
+        if has_trtllm_support and not vllm_config.attention_config.use_non_causal:
             return AttentionCGSupport.UNIFORM_BATCH
         else:
             return AttentionCGSupport.UNIFORM_SINGLE_TOKEN_DECODE

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -9,17 +9,17 @@ from typing import ClassVar
 
 import numpy as np
 import torch
-from flashinfer.decode import fast_decode_plan, trtllm_batch_decode_with_kv_cache
-from flashinfer.prefill import trtllm_batch_context_with_kv_cache
-from flashinfer.utils import FP4Tensor
-from typing_extensions import override
-
 from flashinfer import (
     BatchDecodeWithPagedKVCacheWrapper,
     BatchPrefillWithPagedKVCacheWrapper,
     BatchPrefillWithRaggedKVCacheWrapper,
     MultiLevelCascadeAttentionWrapper,
 )
+from flashinfer.decode import fast_decode_plan, trtllm_batch_decode_with_kv_cache
+from flashinfer.prefill import trtllm_batch_context_with_kv_cache
+from flashinfer.utils import FP4Tensor
+from typing_extensions import override
+
 from vllm import _custom_ops as custom_ops
 from vllm import envs
 from vllm.config import (

--- a/vllm/v1/attention/backends/mla/sparse_swa.py
+++ b/vllm/v1/attention/backends/mla/sparse_swa.py
@@ -306,8 +306,10 @@ class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
             self.vllm_config.scheduler_config.max_num_batched_tokens
         )
 
-        # Keep the split aligned with target verification. DSpark verifies the
-        # sampled token plus K draft tokens, even though it drafts in parallel.
+        # Keep the decode/prefill split identical to the DeepSeek V4 C128A
+        # metadata and indexer. Target verification contains the bonus token
+        # plus N speculative tokens even for parallel drafters such as DSpark;
+        # the generic parallel-drafting threshold (1 + 2N) is not applicable.
         spec_config = self.vllm_config.speculative_config
         self.num_speculative_tokens = (
             spec_config.num_speculative_tokens if spec_config else 0

--- a/vllm/v1/core/sched/async_scheduler.py
+++ b/vllm/v1/core/sched/async_scheduler.py
@@ -20,9 +20,9 @@ class AsyncScheduler(Scheduler):
         super()._update_after_schedule(scheduler_output)
         spec_decode_tokens = scheduler_output.scheduled_spec_decode_tokens
         # Use the latest num of scheduled draft tokens in next step as placeholder.
-        self._spec_token_placeholders = [
-            -1
-        ] * scheduler_output.num_spec_tokens_to_schedule
+        self._spec_token_placeholders = [-1] * (
+            scheduler_output.resolve_num_spec_tokens_to_schedule(self.num_spec_tokens)
+        )
         for req_id in scheduler_output.num_scheduled_tokens:
             request = self.requests[req_id]
             if request.is_prefill_chunk:

--- a/vllm/v1/core/sched/output.py
+++ b/vllm/v1/core/sched/output.py
@@ -242,7 +242,7 @@ class SchedulerOutput:
 
     # Dynamic speculative decoding: optimal K chosen by scheduler.
     # Number of spec tokens to schedule for the next step.
-    num_spec_tokens_to_schedule: int = 0
+    num_spec_tokens_to_schedule: int | None = None
 
     @classmethod
     def make_empty(cls) -> "SchedulerOutput":
@@ -260,7 +260,9 @@ class SchedulerOutput:
 
     def resolve_num_spec_tokens_to_schedule(self, default: int) -> int:
         """Resolve the speculative depth for real and synthetic outputs."""
-        return self.num_spec_tokens_to_schedule or default
+        if self.num_spec_tokens_to_schedule is None:
+            return default
+        return self.num_spec_tokens_to_schedule
 
 
 @dataclass

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1816,7 +1816,9 @@ class Scheduler(SchedulerInterface):
             spec_decoding_stats.current_num_spec_tokens = (
                 self.acceptance_length_controller.num_spec_tokens
                 if self.acceptance_length_controller is not None
-                else scheduler_output.num_spec_tokens_to_schedule
+                else scheduler_output.resolve_num_spec_tokens_to_schedule(
+                    self.num_spec_tokens
+                )
             )
 
         # Remove the stopped requests from the running and waiting queues.

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -226,9 +226,15 @@ class CudaGraphManager:
                 self.decode_query_len - self.vllm_config.num_speculative_tokens
             )
             # Each entry is (range_start, range_end, num_speculative_tokens).
-            decode_query_lens = [
-                x[2] + num_new_sampled_tokens_per_step for x in num_spec_per_batch_size
-            ]
+            # K=0 disables drafting at that concurrency; no draft graph is
+            # needed, and a zero query length would break capture bucketing.
+            decode_query_lens = sorted(
+                {
+                    x[2] + num_new_sampled_tokens_per_step
+                    for x in num_spec_per_batch_size
+                    if x[2] + num_new_sampled_tokens_per_step > 0
+                }
+            )
         elif (
             speculative_config
             and speculative_config.uses_acceptance_length_adaptation()

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -534,6 +534,12 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             self.speculator.set_attn(
                 self.model_state, self.kv_cache_config, self.block_tables
             )
+            if hasattr(self.speculator, "set_num_cached_tokens"):
+                # DFlash/DSpark mask cache-restored tokens out of the draft's
+                # context (their draft context KV was never computed).
+                self.speculator.set_num_cached_tokens(
+                    self.req_states.num_cached_tokens.gpu
+                )
 
         self.kv_caches: list[torch.Tensor] = []
         kv_caches_dict = init_kv_cache(

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -525,9 +525,6 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             decode_query_len=self.decode_query_len,
             lora_capture_cases=self.lora_capture_cases,
         )
-        if self.speculator is not None:
-            self.speculator.init_cudagraph_manager(cudagraph_mode)
-
         check_attention_cp_compatibility(self.vllm_config)
         if isinstance(self.speculator, DraftModelSpeculator):
             # HACK(woosuk)
@@ -540,6 +537,10 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 self.speculator.set_num_cached_tokens(
                     self.req_states.num_cached_tokens.gpu
                 )
+        if self.speculator is not None:
+            # After set_attn, so the speculator can size its cudagraph mode
+            # to its own attention support.
+            self.speculator.init_cudagraph_manager(cudagraph_mode)
 
         self.kv_caches: list[torch.Tensor] = []
         kv_caches_dict = init_kv_cache(

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -381,6 +381,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 logprobs_mode=self.model_config.logprobs_mode,
                 num_speculative_tokens=self.decode_query_len,
                 use_fp64_gumbel=self.model_config.use_fp64_gumbel,
+                seed=self.model_config.seed,
             )
             custom = self.model_state.custom_sampler(self.sampler)
 
@@ -824,7 +825,9 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         preempted_req_ids = scheduler_output.preempted_req_ids
         if preempted_req_ids:
             finished_req_ids = finished_req_ids.union(preempted_req_ids)
-        for req_id in finished_req_ids:
+        # A set's order can differ across TP processes. Recycle slots in a
+        # deterministic order so request-to-slot state stays rank-aligned.
+        for req_id in sorted(finished_req_ids):
             self._remove_request(req_id)
 
     def free_states(self, scheduler_output: SchedulerOutput) -> None:

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -535,7 +535,8 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 # DFlash/DSpark mask cache-restored tokens out of the draft's
                 # context (their draft context KV was never computed).
                 self.speculator.set_num_cached_tokens(
-                    self.req_states.num_cached_tokens.gpu
+                    self.req_states.num_cached_tokens.gpu,
+                    self.req_states.num_cached_tokens_np,
                 )
         if self.speculator is not None:
             # After set_attn, so the speculator can size its cudagraph mode

--- a/vllm/v1/worker/gpu/sample/sampler.py
+++ b/vllm/v1/worker/gpu/sample/sampler.py
@@ -37,6 +37,7 @@ class Sampler:
         logprobs_mode: LogprobsMode = "raw_logprobs",
         num_speculative_tokens: int = 1,
         use_fp64_gumbel: bool = False,
+        seed: int | None = None,
     ):
         if logprobs_mode not in ("processed_logprobs", "raw_logprobs"):
             raise NotImplementedError(f"Unsupported logprobs_mode: {logprobs_mode}")
@@ -45,7 +46,7 @@ class Sampler:
         self.use_fp64_gumbel = use_fp64_gumbel
 
         self.req_states = req_states
-        self.sampling_states = SamplingStates(max_num_reqs, vocab_size)
+        self.sampling_states = SamplingStates(max_num_reqs, vocab_size, seed)
         self.penalties_state = PenaltiesState(req_states)
         self.logit_bias_state = LogitBiasState(max_num_reqs, device)
         self.bad_words_state = BadWordsState(req_states)

--- a/vllm/v1/worker/gpu/sample/states.py
+++ b/vllm/v1/worker/gpu/sample/states.py
@@ -15,9 +15,13 @@ _NP_INT64_MAX = np.iinfo(np.int64).max
 
 
 class SamplingStates:
-    def __init__(self, max_num_reqs: int, vocab_size: int):
+    def __init__(self, max_num_reqs: int, vocab_size: int, seed: int | None = None):
         self.max_num_reqs = max_num_reqs
         self.vocab_size = vocab_size
+
+        # Every TP rank must derive the same fallback request seeds. A private
+        # stream avoids rank-local consumers perturbing NumPy's global RNG.
+        self._fallback_seed_rng = np.random.default_rng(seed if seed is not None else 0)
 
         self.temperature = UvaBackedTensor(max_num_reqs, dtype=torch.float32)
         self.top_k = UvaBackedTensor(max_num_reqs, dtype=torch.int32)
@@ -50,7 +54,11 @@ class SamplingStates:
         seed = sampling_params.seed
         self.seeds_set[req_idx] = seed is not None
         if seed is None:
-            seed = np.random.randint(_NP_INT64_MIN, _NP_INT64_MAX)
+            seed = int(
+                self._fallback_seed_rng.integers(
+                    _NP_INT64_MIN, _NP_INT64_MAX, dtype=np.int64
+                )
+            )
         self.seeds.np[req_idx] = seed
 
         num_logprobs = sampling_params.logprobs

--- a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
@@ -114,6 +114,10 @@ class DFlashSpeculator(DraftModelSpeculator):
 
         self.query_cudagraph_manager: DFlashCudaGraphManager | None = None
         self.draft_kv_cache_group_id: int = -1
+        # Manual CUDA graphs keep raw addresses for model intermediates. Retain
+        # each captured backbone output so its storage cannot be recycled while
+        # a graph still reads it during sampling.
+        self._captured_backbone_outputs: list[torch.Tensor] = []
 
     @property
     def attn_vllm_config(self) -> VllmConfig:
@@ -291,6 +295,8 @@ class DFlashSpeculator(DraftModelSpeculator):
             num_tokens_across_dp,
             cudagraph_runtime_mode,
         )
+        if torch.cuda.is_current_stream_capturing():
+            self._captured_backbone_outputs.append(last_hidden_states)
 
         num_sample = num_reqs * self.num_speculative_steps
         sample_hidden_states = last_hidden_states[self.sample_indices[:num_sample]]

--- a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
@@ -15,11 +15,12 @@ from typing import Any
 import torch
 import torch.nn as nn
 
-from vllm.config import VllmConfig
+from vllm.config import VllmConfig, replace
 from vllm.config.compilation import CUDAGraphMode
 from vllm.forward_context import BatchDescriptor, set_forward_context
 from vllm.logger import init_logger
 from vllm.triton_utils import tl, triton
+from vllm.v1.attention.backend import AttentionCGSupport
 from vllm.v1.attention.backends.utils import PAD_SLOT_ID
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.worker.gpu.attn_utils import build_slot_mappings_by_layer
@@ -114,9 +115,32 @@ class DFlashSpeculator(DraftModelSpeculator):
         self.query_cudagraph_manager: DFlashCudaGraphManager | None = None
         self.draft_kv_cache_group_id: int = -1
 
+    @property
+    def attn_vllm_config(self) -> VllmConfig:
+        # The draft's attention differs from the target's in causality.
+        return replace(
+            self.vllm_config,
+            attention_config=replace(
+                self.vllm_config.attention_config,
+                use_non_causal=not self.dflash_causal,
+            ),
+        )
+
     def init_cudagraph_manager(self, cudagraph_mode: CUDAGraphMode) -> None:
-        # PIECEWISE cudagraphs are not supported for dflash
-        if cudagraph_mode.decode_mode() == CUDAGraphMode.FULL:
+        wants_full = cudagraph_mode.decode_mode() == CUDAGraphMode.FULL
+        supports_full = (
+            self.attn_cg_support.min_cg_support.value
+            >= AttentionCGSupport.UNIFORM_BATCH.value
+        )
+        if wants_full and not supports_full:
+            logger.warning(
+                "%s draft attention (%s) does not support full CUDA graphs; "
+                "running the draft eagerly.",
+                self._speculator_name,
+                self.attn_cg_support.min_cg_attn_backend,
+            )
+        # PIECEWISE cudagraphs are not supported for dflash.
+        if wants_full and supports_full:
             cudagraph_mode = CUDAGraphMode.FULL_DECODE_ONLY
         else:
             cudagraph_mode = CUDAGraphMode.NONE

--- a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
@@ -89,8 +89,11 @@ class DFlashSpeculator(DraftModelSpeculator):
         self.sample_pos = torch.zeros(
             max_num_sampled_tokens, dtype=torch.int64, device=device
         )
-        self.sample_idx_mapping = torch.zeros(
-            max_num_sampled_tokens, dtype=torch.int32, device=device
+        # -1 marks an inert sampling row. CUDA graph capture can execute the
+        # full buffer before a real batch has populated it, so zero would make
+        # every padding row race while scattering into request slot 0.
+        self.sample_idx_mapping = torch.full(
+            (max_num_sampled_tokens,), -1, dtype=torch.int32, device=device
         )
         # [0, 1, ..., N-1, 0, 1, ..., N-1, ...] -> the per-token column index into
         # draft_logits[req, step, :].
@@ -117,11 +120,11 @@ class DFlashSpeculator(DraftModelSpeculator):
 
     def capture(self, attn_states: dict | None = None) -> None:
         logger.info("Capturing model for %s speculator...", self._speculator_name)
-        # Reset sampling indices to zero to prevent stale values from prior
-        # dummy runs from being baked into the captured graph.
+        # Reset sampling indices to prevent stale values from prior dummy runs
+        # from being baked into the captured graph. Mapping rows stay inert.
         self.sample_indices.zero_()
         self.sample_pos.zero_()
-        self.sample_idx_mapping.zero_()
+        self.sample_idx_mapping.fill_(-1)
         assert self.query_cudagraph_manager is not None
         self.query_cudagraph_manager.capture(
             self._generate_draft,
@@ -607,6 +610,8 @@ def _prepare_dflash_inputs_kernel(
             for i in range(q_pad_start, max_num_tokens, BLOCK_SIZE):
                 block = i + tl.arange(0, BLOCK_SIZE)
                 mask = block < max_num_tokens
+                tl.store(out_input_ids_ptr + block, 0, mask=mask)
+                tl.store(out_query_positions_ptr + block, 0, mask=mask)
                 tl.store(out_query_slot_mapping_ptr + block, PAD_SLOT_ID, mask=mask)
 
 

--- a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
@@ -807,10 +807,21 @@ def _shift_draft_block_tables_kernel(
     # In-place left shift is safe: iterations run in ascending order and each
     # loads its chunk (from offset + shift) before storing (at offset), so no
     # store ever precedes a load of the same element.
-    for i in tl.range(0, num_remaining, BLOCK_SIZE):
+    # Keep iterations strictly ordered. Compiler software pipelining may start
+    # a store before a later overlapping source load has completed.
+    for i in tl.range(
+        0,
+        num_remaining,
+        BLOCK_SIZE,
+        num_stages=1,
+        loop_unroll_factor=1,
+    ):
         offset = i + tl.arange(0, BLOCK_SIZE)
         mask = offset < num_remaining
         block_ids = tl.load(row_ptr + offset + shift, mask=mask, other=0)
+        # Source and destination overlap for shifts smaller than BLOCK_SIZE.
+        # Ensure every lane has consumed its source before any lane stores.
+        tl.debug_barrier()
         tl.store(row_ptr + offset, block_ids, mask=mask)
 
 

--- a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
@@ -81,6 +81,16 @@ class DFlashSpeculator(DraftModelSpeculator):
             self.max_num_tokens, dtype=torch.int64, device=device
         )
 
+        # Per-request-slot count of tokens whose KV was restored (e.g. from the
+        # prefix cache) at the request's last (re)admission, indexed by
+        # req_state_idx. The target never ran a forward pass over them, so
+        # their draft context KV was never computed; the prep kernel and the
+        # block-table shift in propose() hide them from the draft's attention.
+        # The runner replaces this zeros fallback via set_num_cached_tokens.
+        self.num_cached_tokens = torch.zeros(
+            self.max_num_reqs, dtype=torch.int32, device=device
+        )
+
         # Per-mask-token sampling buffers. Flattened from (num_reqs, num_spec_tokens).
         max_num_sampled_tokens = self.max_num_reqs * self.num_speculative_steps
         self.sample_indices = torch.zeros(
@@ -150,6 +160,13 @@ class DFlashSpeculator(DraftModelSpeculator):
         )
         return model
 
+    def set_num_cached_tokens(self, num_cached_tokens: torch.Tensor) -> None:
+        """Register the runner's per-request-slot cache-restored token counts.
+
+        Indexed by req_state_idx; see the buffer comment in __init__.
+        """
+        self.num_cached_tokens = num_cached_tokens
+
     def set_attn(
         self,
         model_state: ModelState,
@@ -163,6 +180,17 @@ class DFlashSpeculator(DraftModelSpeculator):
         ]
         assert self.draft_kv_cache_group_ids, "No draft attention groups found."
         self.draft_kv_cache_group_id = self.draft_kv_cache_group_ids[0]
+        # The shared seq_lens buffer carries the cache-shifted draft sequence
+        # lengths (see _prepare_dflash_inputs_kernel), which only works if all
+        # draft groups shift by the same number of slots per cached block.
+        draft_block_sizes = {
+            self.block_tables.kernel_block_sizes[gid]
+            for gid in self.draft_kv_cache_group_ids
+        }
+        assert len(draft_block_sizes) == 1, (
+            "DFlash requires a uniform block size across draft KV cache "
+            f"groups, got {draft_block_sizes}."
+        )
 
         # Per-group context slot buffers for the precompute (one row per group).
         self._context_slot_mappings = torch.zeros(
@@ -373,6 +401,7 @@ class DFlashSpeculator(DraftModelSpeculator):
                 next_prefill_tokens,
                 self.block_tables.input_block_tables[gid],
                 self.block_tables.kernel_block_sizes[gid],
+                self.num_cached_tokens,
                 self.parallel_drafting_token_id,
                 self.num_query_per_req,
                 self.num_speculative_steps,
@@ -381,6 +410,27 @@ class DFlashSpeculator(DraftModelSpeculator):
                 self.max_model_len,
                 self.sample_from_anchor,
             )
+
+        # Cache-restored tokens (e.g. prefix-cache hits) never flowed through
+        # the target forward, so their draft context KV was never written and
+        # their cache slots hold garbage. Hide them from the draft's
+        # attention: shift each draft block-table row left by the restored
+        # whole blocks (the prep kernel shortened seq_lens to match). Runs
+        # after prepare_dflash_inputs because the slot mappings index the
+        # unshifted table; in-place is safe because input_block_tables are
+        # regathered from the persistent block tables every step. Up to
+        # block_size - 1 restored slots may remain visible when the restored
+        # count is not block-aligned (e.g. a full-prompt cache hit). Skipped
+        # for dummy runs, whose idx_mapping does not reference live requests.
+        if not dummy_run:
+            for gid in self.draft_kv_cache_group_ids:
+                shift_draft_block_tables(
+                    self.block_tables.input_block_tables[gid],
+                    input_batch.idx_mapping,
+                    self.num_cached_tokens,
+                    self.input_buffers.seq_lens,
+                    self.block_tables.kernel_block_sizes[gid],
+                )
 
         # Pre-insert context K/V into the cache. Runs eagerly outside the captured graph
         # because the context shape varies per step. During dummy runs the block tables
@@ -472,6 +522,8 @@ def _prepare_dflash_inputs_kernel(
     # Block table for slot mapping lookup.
     block_table_ptr,
     block_table_stride,
+    # [max_num_reqs] cache-restored token counts, indexed by req_state_idx.
+    num_cached_tokens_ptr,
     # Scalars
     parallel_drafting_token_id,
     block_size,
@@ -578,8 +630,20 @@ def _prepare_dflash_inputs_kernel(
         tl.store(out_query_start_loc_ptr + req_idx, query_base)
         # seq_lens is the absolute sequence length the draft attention
         # reads up to (context + query), not just the count of accepted
-        # tokens this step.
-        tl.store(out_seq_lens_ptr + req_idx, last_valid_pos + 1 + num_query_per_req)
+        # tokens this step — minus the cache-restored whole blocks, which
+        # hold no draft KV and are shifted out of the block table (see
+        # shift_draft_block_tables).
+        num_cached = tl.load(num_cached_tokens_ptr + req_state_idx)
+        num_shifted_slots = (num_cached // block_size) * block_size
+        # The clamp guards dummy runs, where req_state_idx may point at a
+        # stale slot whose cached count exceeds the dummy sequence length.
+        tl.store(
+            out_seq_lens_ptr + req_idx,
+            tl.maximum(
+                last_valid_pos + 1 + num_query_per_req - num_shifted_slots,
+                num_query_per_req,
+            ),
+        )
         if req_idx == num_reqs - 1:
             # Pad per-request buffers to max_num_reqs for CUDA graph safety.
             last_query_end = num_reqs * num_query_per_req
@@ -635,6 +699,8 @@ def prepare_dflash_inputs(
     # [max_num_reqs, max_num_blocks]
     block_table: torch.Tensor,
     block_size: int,
+    # [max_num_reqs]
+    num_cached_tokens: torch.Tensor,
     parallel_drafting_token_id: int,
     num_query_per_req: int,
     num_speculative_steps: int,
@@ -671,6 +737,7 @@ def prepare_dflash_inputs(
         num_rejected,
         block_table,
         block_table.stride(0),
+        num_cached_tokens,
         parallel_drafting_token_id,
         block_size,
         num_query_per_req,
@@ -681,4 +748,64 @@ def prepare_dflash_inputs(
         SAMPLE_FROM_ANCHOR=sample_from_anchor,
         PAD_SLOT_ID=PAD_SLOT_ID,
         BLOCK_SIZE=BLOCK_SIZE,
+    )
+
+
+@triton.jit
+def _shift_draft_block_tables_kernel(
+    block_table_ptr,
+    block_table_stride,
+    idx_mapping_ptr,
+    num_cached_tokens_ptr,
+    seq_lens_ptr,
+    block_size,
+    BLOCK_SIZE: tl.constexpr,
+):
+    req_idx = tl.program_id(0)
+    req_state_idx = tl.load(idx_mapping_ptr + req_idx)
+    num_cached = tl.load(num_cached_tokens_ptr + req_state_idx)
+    shift = num_cached // block_size
+    if shift == 0:
+        return
+    row_ptr = block_table_ptr + req_idx.to(tl.int64) * block_table_stride
+    # Only the blocks the shifted sequence still references need to move;
+    # seq_lens holds the cache-shifted draft length (written by
+    # _prepare_dflash_inputs_kernel, which must run first).
+    seq_len = tl.load(seq_lens_ptr + req_idx)
+    num_needed = (seq_len + block_size - 1) // block_size
+    num_remaining = tl.minimum(block_table_stride - shift, num_needed)
+    # In-place left shift is safe: iterations run in ascending order and each
+    # loads its chunk (from offset + shift) before storing (at offset), so no
+    # store ever precedes a load of the same element.
+    for i in tl.range(0, num_remaining, BLOCK_SIZE):
+        offset = i + tl.arange(0, BLOCK_SIZE)
+        mask = offset < num_remaining
+        block_ids = tl.load(row_ptr + offset + shift, mask=mask, other=0)
+        tl.store(row_ptr + offset, block_ids, mask=mask)
+
+
+def shift_draft_block_tables(
+    # [max_num_reqs, max_num_blocks]
+    block_table: torch.Tensor,
+    # [num_reqs]
+    idx_mapping: torch.Tensor,
+    # [max_num_reqs]
+    num_cached_tokens: torch.Tensor,
+    # [num_reqs] cache-shifted draft sequence lengths
+    seq_lens: torch.Tensor,
+    block_size: int,
+) -> None:
+    """Shift each request's draft block-table row left by its cache-restored
+    whole blocks, hiding slots that hold no draft context KV from the draft's
+    attention. Must run after prepare_dflash_inputs (slot mappings index the
+    unshifted table, and seq_lens must already hold the shifted lengths)."""
+    num_reqs = idx_mapping.shape[0]
+    _shift_draft_block_tables_kernel[(num_reqs,)](
+        block_table,
+        block_table.stride(0),
+        idx_mapping,
+        num_cached_tokens,
+        seq_lens,
+        block_size,
+        BLOCK_SIZE=1024,  # type: ignore
     )

--- a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
@@ -12,6 +12,7 @@ layer, and written into the draft KV cache.
 from collections.abc import Mapping
 from typing import Any
 
+import numpy as np
 import torch
 import torch.nn as nn
 
@@ -91,6 +92,7 @@ class DFlashSpeculator(DraftModelSpeculator):
         self.num_cached_tokens = torch.zeros(
             self.max_num_reqs, dtype=torch.int32, device=device
         )
+        self.num_cached_tokens_np = np.zeros(self.max_num_reqs, dtype=np.int32)
 
         # Per-mask-token sampling buffers. Flattened from (num_reqs, num_spec_tokens).
         max_num_sampled_tokens = self.max_num_reqs * self.num_speculative_steps
@@ -188,12 +190,25 @@ class DFlashSpeculator(DraftModelSpeculator):
         )
         return model
 
-    def set_num_cached_tokens(self, num_cached_tokens: torch.Tensor) -> None:
+    def set_num_cached_tokens(
+        self,
+        num_cached_tokens: torch.Tensor,
+        num_cached_tokens_np: np.ndarray,
+    ) -> None:
         """Register the runner's per-request-slot cache-restored token counts.
 
         Indexed by req_state_idx; see the buffer comment in __init__.
         """
         self.num_cached_tokens = num_cached_tokens
+        self.num_cached_tokens_np = num_cached_tokens_np
+
+    def _has_unaligned_cached_prefix(self, input_batch: InputBatch) -> bool:
+        req_state_indices = input_batch.idx_mapping_np[: input_batch.num_reqs]
+        cached = self.num_cached_tokens_np[req_state_indices]
+        return any(
+            np.any(cached % block_size != 0)
+            for block_size in self.block_tables.kernel_block_sizes
+        )
 
     def set_attn(
         self,
@@ -365,6 +380,14 @@ class DFlashSpeculator(DraftModelSpeculator):
     ) -> torch.Tensor:
         num_reqs = input_batch.num_reqs
         num_target_tokens = input_batch.num_tokens
+        if not dummy_run and self._has_unaligned_cached_prefix(input_batch):
+            logger.warning_once(
+                "DFlash/DSpark drafting is disabled for a batch containing a "
+                "block-unaligned cache-restored prefix because draft KV is "
+                "not available for the restored partial block."
+            )
+            self.draft_tokens[:num_reqs].fill_(-1)
+            return self.draft_tokens[:num_reqs]
         num_query_tokens = num_reqs * self.num_query_per_req
         max_seq_len = input_batch.seq_lens_cpu_upper_bound[:num_reqs].max().item()
         self.draft_max_seq_len = min(
@@ -449,9 +472,9 @@ class DFlashSpeculator(DraftModelSpeculator):
         # after prepare_dflash_inputs because the slot mappings index the
         # unshifted table; in-place is safe because input_block_tables are
         # regathered from the persistent block tables every step. Up to
-        # block_size - 1 restored slots may remain visible when the restored
-        # count is not block-aligned (e.g. a full-prompt cache hit). Skipped
-        # for dummy runs, whose idx_mapping does not reference live requests.
+        # Non-aligned restored prefixes fail closed before this path because a
+        # block-table shift cannot hide the residual partial block. Skipped for
+        # dummy runs, whose idx_mapping does not reference live requests.
         if not dummy_run:
             for gid in self.draft_kv_cache_group_ids:
                 shift_draft_block_tables(

--- a/vllm/v1/worker/gpu/spec_decode/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/speculator.py
@@ -185,6 +185,12 @@ class DraftModelSpeculator(BaseSpeculator):
                 num_unpadded_tokens,
             )
 
+    @property
+    def attn_vllm_config(self) -> VllmConfig:
+        """Config for the draft's attention metadata builders. Overridden by
+        speculators whose attention mode differs from the target's."""
+        return self.vllm_config
+
     def set_attn(
         self,
         model_state: ModelState,
@@ -193,9 +199,9 @@ class DraftModelSpeculator(BaseSpeculator):
     ) -> None:
         self.model_state = model_state
         self.kv_cache_config = kv_cache_config
-        self.attn_groups, _, _ = init_attn_backend(
+        self.attn_groups, self.attn_cg_support, _ = init_attn_backend(
             kv_cache_config,
-            self.vllm_config,
+            self.attn_vllm_config,
             self.device,
             active_layer_names=self.draft_attn_layer_names,
         )

--- a/vllm/v1/worker/gpu/states.py
+++ b/vllm/v1/worker/gpu/states.py
@@ -80,6 +80,15 @@ class RequestState:
             self.max_num_reqs, dtype=torch.int32, device=device
         )
 
+        # Tokens whose KV was restored (e.g. from the prefix cache) rather than
+        # computed at the request's most recent (re)admission. The target never
+        # runs a forward pass over them, so speculators that derive per-token
+        # state from target hidden states (DFlash/DSpark context KV) have
+        # nothing for these positions.
+        self.num_cached_tokens = StagedWriteTensor(
+            self.max_num_reqs, dtype=torch.int32, device=device
+        )
+
     @property
     def num_reqs(self) -> int:
         return len(self.req_id_to_index)
@@ -109,6 +118,7 @@ class RequestState:
         self.num_computed_prefill_tokens[req_idx] = num_computed_tokens
         self.num_computed_tokens_np[req_idx] = num_computed_tokens
         self.num_computed_tokens.stage_write_elem(req_idx, num_computed_tokens)
+        self.num_cached_tokens.stage_write_elem(req_idx, num_computed_tokens)
 
         self.draft_tokens[req_idx].zero_()
 
@@ -118,6 +128,7 @@ class RequestState:
         self.total_len.apply_write()
         self.all_token_ids.apply_write()
         self.num_computed_tokens.apply_write()
+        self.num_cached_tokens.apply_write()
 
     def remove_request(self, req_id: str) -> int | None:
         """Return the freed slot index, or None if the request was not found."""

--- a/vllm/v1/worker/gpu/states.py
+++ b/vllm/v1/worker/gpu/states.py
@@ -88,6 +88,7 @@ class RequestState:
         self.num_cached_tokens = StagedWriteTensor(
             self.max_num_reqs, dtype=torch.int32, device=device
         )
+        self.num_cached_tokens_np = np.zeros(self.max_num_reqs, dtype=np.int32)
 
     @property
     def num_reqs(self) -> int:
@@ -119,6 +120,7 @@ class RequestState:
         self.num_computed_tokens_np[req_idx] = num_computed_tokens
         self.num_computed_tokens.stage_write_elem(req_idx, num_computed_tokens)
         self.num_cached_tokens.stage_write_elem(req_idx, num_computed_tokens)
+        self.num_cached_tokens_np[req_idx] = num_computed_tokens
 
         self.draft_tokens[req_idx].zero_()
 


### PR DESCRIPTION
## Summary

Extract the remaining correctness fixes from the conflicting #88 onto current Fathomless Firmament, without its PCIe stack, deployment launcher, memory tuning, or capacity-controller experiment.

## Fixes

- Skip zero-width DSD CUDA-graph candidates instead of constructing an invalid query length.
- Keep DSpark target metadata, request-slot recycling, and fallback sampling seeds deterministic across TP ranks.
- Mark padded draft sampling rows inert and clear their query inputs.
- Mask prefix-cache-restored tokens whose draft KV was never computed.
- Make the overlapping in-place draft block-table shift race-free across Triton lanes.
- Prefer FlashAttention where SM100f non-causal FlashInfer is unsupported and keep non-causal FlashInfer draft attention out of FULL graphs.
- Preserve an explicit adaptive depth of zero instead of replacing it with the default K.
- Retain DFlash backbone storage referenced by captured CUDA graphs.

## Important review finding

The original #88 block-table shift had a real nondeterministic cross-lane read/write race. The long-row test reproduced corrupted block IDs. This version inserts a barrier between overlapping source loads and destination stores; 100 consecutive overlap iterations passed.

## Validation

- 30 passed across DSD graph dispatch, DSpark metadata, TP seed state, prefix-cache masking, adaptive-depth scheduling, and DFlash graph lifetime.
- Additional 100-iteration SM120 overlap stress passed.
- Ruff check and format pass on all changed Python files.
- git diff --check passes.

Capacity-aware/load-aware DSpark verification is intentionally excluded and will be proposed separately.