### PR TITLE
perf(dspark): add opt-in rowwise FP8 draft head

### DIFF
--- a/tests/v1/spec_decode/test_dspark_fp8_draft_head.py
+++ b/tests/v1/spec_decode/test_dspark_fp8_draft_head.py
@@ -1,0 +1,150 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for the rowwise-fp8 DSpark draft lm_head (VLLM_DSPARK_FP8_DRAFT_HEAD).
+
+CPU tests cover the quantize helper (roundtrip error bound) and draft argmax
+agreement between the bf16 reference path and the fp8 path, using a float32
+emulation of torch._scaled_mm. The GPU test additionally checks the real
+_scaled_mm kernel against the emulation and the bf16 reference.
+"""
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.fp8_draft_head import (
+    _FP8_MAX,
+    Fp8DraftHead,
+    fp8_draft_head_logits,
+    fp8_draft_head_supported,
+    quantize_draft_head,
+)
+
+VOCAB = 2048
+HIDDEN = 256
+NUM_TOKENS = 64
+
+# float8_e4m3fn has a 3-bit mantissa: worst-case relative rounding error of a
+# representable-range value is 2^-4 of its binade, i.e. <= (1/16) * value and
+# <= (32/448) * rowmax absolute (half ulp of the top binade after rowwise
+# scaling to [-448, 448]).
+_ROUNDTRIP_REL_BOUND = 32.0 / 448.0 / 2.0  # half ulp at the top binade
+
+
+def _dequant(head: Fp8DraftHead) -> torch.Tensor:
+    # row_scale is [1, num_rows] laid out for the GEMM epilogue; transpose to
+    # dequantize the [num_rows, hidden] weight.
+    return head.weight_fp8.float() * head.row_scale.float().t()
+
+
+def _emulated_fp8_logits(x: torch.Tensor, head: Fp8DraftHead) -> torch.Tensor:
+    """Float32 emulation of fp8_draft_head_logits (no _scaled_mm needed)."""
+    act_max = x.abs().amax(dim=-1, keepdim=True).clamp(min=1e-6)
+    act_fp8 = (x * (_FP8_MAX / act_max)).to(torch.float8_e4m3fn)
+    out = act_fp8.float() @ head.weight_fp8.float().t()
+    out = out.to(x.dtype)
+    out = out * head.row_scale
+    out = out * (act_max / _FP8_MAX).to(x.dtype)
+    return out
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
+def test_rowwise_quant_roundtrip_error_bound(dtype: torch.dtype):
+    torch.manual_seed(0)
+    weight = torch.randn(VOCAB, HIDDEN, dtype=dtype) * 0.05
+    # Give rows wildly different magnitudes to exercise the rowwise scales.
+    weight *= torch.logspace(-3, 1, VOCAB, dtype=dtype).unsqueeze(1)
+
+    head = quantize_draft_head(weight)
+    assert head.weight_fp8.dtype == torch.float8_e4m3fn
+    assert head.weight_fp8.shape == weight.shape
+    assert head.row_scale.shape == (1, VOCAB)
+
+    err = (weight.float() - _dequant(head)).abs()
+    row_max = weight.float().abs().amax(dim=1, keepdim=True)
+    # Small slack over the analytic half-ulp bound for the two roundings
+    # (scale multiply in fp32, then fp8 cast).
+    bound = row_max * (_ROUNDTRIP_REL_BOUND * 1.25) + 1e-8
+    assert (err <= bound).all(), (
+        f"rowwise fp8 roundtrip error {err.max().item()} exceeds bound"
+    )
+
+
+def test_draft_argmax_agreement_bf16_vs_fp8_emulated():
+    """The fp8 draft head must (almost) always agree with bf16 on argmax.
+
+    Uses the float32 emulation of _scaled_mm; disagreements are only
+    acceptable when the bf16 top-2 margin is within the fp8 error scale.
+    """
+    torch.manual_seed(1234)
+    weight = torch.randn(VOCAB, HIDDEN, dtype=torch.bfloat16) * 0.02
+    hidden = torch.randn(NUM_TOKENS, HIDDEN, dtype=torch.bfloat16)
+
+    ref_logits = hidden.float() @ weight.float().t()
+    ref_argmax = ref_logits.argmax(dim=-1)
+
+    head = quantize_draft_head(weight)
+    fp8_logits = _emulated_fp8_logits(hidden, head)
+    fp8_argmax = fp8_logits.argmax(dim=-1)
+
+    # Primary correctness property: any disagreement must be a near-tie in
+    # the reference logits, i.e. the kind of flip that costs at most one
+    # rejected draft token during verification, never a wrong output.
+    top2 = ref_logits.topk(2, dim=-1).values
+    margin = (top2[:, 0] - top2[:, 1]).abs()
+    err_scale = (
+        ref_logits.abs().amax(dim=-1) * 2.0 * _ROUNDTRIP_REL_BOUND * 2.0
+    )
+    disagree = ref_argmax != fp8_argmax
+    assert (margin[disagree] <= err_scale[disagree]).all(), (
+        "fp8 draft head flipped an argmax with a large top-2 margin"
+    )
+
+    # I.i.d. Gaussian logits are the worst case for argmax stability (the
+    # top-2 gap of 2048 i.i.d. samples is tiny); real LM logits have much
+    # larger top-1 margins, where the fp8 head measured argmax-identical.
+    # Even in this adversarial regime agreement must stay high.
+    agree = (ref_argmax == fp8_argmax).float().mean().item()
+    assert agree >= 0.90, f"draft argmax agreement too low: {agree:.4f}"
+
+
+def test_emulated_logits_close_to_reference():
+    torch.manual_seed(7)
+    weight = torch.randn(VOCAB, HIDDEN, dtype=torch.bfloat16) * 0.02
+    hidden = torch.randn(NUM_TOKENS, HIDDEN, dtype=torch.bfloat16)
+
+    ref = (hidden.float() @ weight.float().t()).float()
+    head = quantize_draft_head(weight)
+    fp8 = _emulated_fp8_logits(hidden, head).float()
+
+    scale = ref.abs().amax()
+    assert (fp8 - ref).abs().max() <= 0.05 * scale
+
+
+@pytest.mark.skipif(
+    not fp8_draft_head_supported(),
+    reason="requires a CUDA device with fp8 support (SM89+)",
+)
+def test_fp8_draft_head_logits_cuda_matches_emulation():
+    torch.manual_seed(42)
+    device = torch.device("cuda")
+    weight = torch.randn(VOCAB, HIDDEN, dtype=torch.bfloat16, device=device)
+    weight *= 0.02
+    hidden = torch.randn(
+        NUM_TOKENS, HIDDEN, dtype=torch.bfloat16, device=device
+    )
+
+    head = quantize_draft_head(weight)
+    real = fp8_draft_head_logits(hidden, head).float()
+    emulated = _emulated_fp8_logits(hidden, head).float()
+
+    # _scaled_mm accumulates in fp32 like the emulation; only the final
+    # bf16 rounding differs.
+    scale = emulated.abs().amax()
+    assert (real - emulated).abs().max() <= 0.01 * scale
+
+    # And the real kernel's argmax agrees with the bf16 reference head
+    # (i.i.d. Gaussian logits are the worst case for argmax stability; see
+    # test_draft_argmax_agreement_bf16_vs_fp8_emulated).
+    ref_argmax = (hidden.float() @ weight.float().t()).argmax(dim=-1)
+    agree = (real.argmax(dim=-1) == ref_argmax).float().mean().item()
+    assert agree >= 0.90

--- a/tests/v1/spec_decode/test_dspark_fp8_draft_head.py
+++ b/tests/v1/spec_decode/test_dspark_fp8_draft_head.py
@@ -91,9 +91,7 @@ def test_draft_argmax_agreement_bf16_vs_fp8_emulated():
     # rejected draft token during verification, never a wrong output.
     top2 = ref_logits.topk(2, dim=-1).values
     margin = (top2[:, 0] - top2[:, 1]).abs()
-    err_scale = (
-        ref_logits.abs().amax(dim=-1) * 2.0 * _ROUNDTRIP_REL_BOUND * 2.0
-    )
+    err_scale = ref_logits.abs().amax(dim=-1) * 2.0 * _ROUNDTRIP_REL_BOUND * 2.0
     disagree = ref_argmax != fp8_argmax
     assert (margin[disagree] <= err_scale[disagree]).all(), (
         "fp8 draft head flipped an argmax with a large top-2 margin"
@@ -129,9 +127,7 @@ def test_fp8_draft_head_logits_cuda_matches_emulation():
     device = torch.device("cuda")
     weight = torch.randn(VOCAB, HIDDEN, dtype=torch.bfloat16, device=device)
     weight *= 0.02
-    hidden = torch.randn(
-        NUM_TOKENS, HIDDEN, dtype=torch.bfloat16, device=device
-    )
+    hidden = torch.randn(NUM_TOKENS, HIDDEN, dtype=torch.bfloat16, device=device)
 
     head = quantize_draft_head(weight)
     real = fp8_draft_head_logits(hidden, head).float()
@@ -142,9 +138,7 @@ def test_fp8_draft_head_logits_cuda_matches_emulation():
     scale = emulated.abs().amax()
     assert (real - emulated).abs().max() <= 0.01 * scale
 
-    # And the real kernel's argmax agrees with the bf16 reference head
-    # (i.i.d. Gaussian logits are the worst case for argmax stability; see
-    # test_draft_argmax_agreement_bf16_vs_fp8_emulated).
-    ref_argmax = (hidden.float() @ weight.float().t()).argmax(dim=-1)
-    agree = (real.argmax(dim=-1) == ref_argmax).float().mean().item()
-    assert agree >= 0.90
+    # The CUDA path must make exactly the same draft choice as the emulation.
+    # Quantization-induced flips against BF16 are covered separately by the
+    # top-2 margin bound in test_draft_argmax_agreement_bf16_vs_fp8_emulated.
+    torch.testing.assert_close(real.argmax(dim=-1), emulated.argmax(dim=-1))

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -61,6 +61,7 @@ if TYPE_CHECKING:
     VLLM_USE_B12X_SPARSE_INDEXER: bool = False
     VLLM_USE_B12X_MHC: bool = False
     VLLM_USE_B12X_FP8_GEMM: bool = False
+    VLLM_DSPARK_FP8_DRAFT_HEAD: bool = False
     VLLM_USE_B12X_WO_PROJECTION: bool = False
     VLLM_USE_B12X_MOE: bool = False
     VLLM_USE_B12X_MINIMAX_M3_MSA: bool = False
@@ -173,7 +174,6 @@ if TYPE_CHECKING:
     VLLM_SERVER_DEV_MODE: bool = False
     VLLM_V1_OUTPUT_PROC_CHUNK_SIZE: int = 128
     VLLM_MLA_DISABLE: bool = False
-    VLLM_DSPARK_FP8_DRAFT_HEAD: bool = False
     VLLM_RAY_PER_WORKER_GPUS: float = 1.0
     VLLM_RAY_BUNDLE_INDICES: str = ""
     VLLM_CUDART_SO_PATH: str | None = None
@@ -1063,6 +1063,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_USE_B12X_FP8_GEMM": lambda: bool(
         int(os.getenv("VLLM_USE_B12X_FP8_GEMM", "0"))
     ),
+    # Compute DSpark draft-proposal logits with a rowwise-fp8 copy of the
+    # shared target lm_head. Verification is unchanged, so accepted outputs
+    # retain target-model semantics. Requires fp8 tensor cores (SM89+).
+    "VLLM_DSPARK_FP8_DRAFT_HEAD": lambda: bool(
+        int(os.getenv("VLLM_DSPARK_FP8_DRAFT_HEAD", "0"))
+    ),
     # Use b12x for the DeepSeek V4 WO-A/WO-B fused projection.
     # This is separate from the generic FP8 linear switch for perf isolation.
     "VLLM_USE_B12X_WO_PROJECTION": lambda: bool(
@@ -1453,14 +1459,6 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     # If set, vLLM will disable the MLA attention optimizations.
     "VLLM_MLA_DISABLE": lambda: bool(int(os.getenv("VLLM_MLA_DISABLE", "0"))),
-    # If set, DSpark speculative decoding computes its draft-proposal logits
-    # with a rowwise-fp8 copy of the shared target lm_head (draft-time only;
-    # the verify pass is untouched, so accepted outputs are unchanged).
-    # Halves draft lm_head weight traffic; largest wins on bandwidth-bound
-    # GPUs. Requires fp8 tensor cores (SM89+).
-    "VLLM_DSPARK_FP8_DRAFT_HEAD": lambda: bool(
-        int(os.getenv("VLLM_DSPARK_FP8_DRAFT_HEAD", "0"))
-    ),
     # If set, vLLM will pick up the provided Flash Attention MLA
     # Number of GPUs per worker in Ray, if it is set to be a fraction,
     # it allows ray to schedule multiple actors on a single GPU,

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -173,6 +173,7 @@ if TYPE_CHECKING:
     VLLM_SERVER_DEV_MODE: bool = False
     VLLM_V1_OUTPUT_PROC_CHUNK_SIZE: int = 128
     VLLM_MLA_DISABLE: bool = False
+    VLLM_DSPARK_FP8_DRAFT_HEAD: bool = False
     VLLM_RAY_PER_WORKER_GPUS: float = 1.0
     VLLM_RAY_BUNDLE_INDICES: str = ""
     VLLM_CUDART_SO_PATH: str | None = None
@@ -1452,6 +1453,14 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     # If set, vLLM will disable the MLA attention optimizations.
     "VLLM_MLA_DISABLE": lambda: bool(int(os.getenv("VLLM_MLA_DISABLE", "0"))),
+    # If set, DSpark speculative decoding computes its draft-proposal logits
+    # with a rowwise-fp8 copy of the shared target lm_head (draft-time only;
+    # the verify pass is untouched, so accepted outputs are unchanged).
+    # Halves draft lm_head weight traffic; largest wins on bandwidth-bound
+    # GPUs. Requires fp8 tensor cores (SM89+).
+    "VLLM_DSPARK_FP8_DRAFT_HEAD": lambda: bool(
+        int(os.getenv("VLLM_DSPARK_FP8_DRAFT_HEAD", "0"))
+    ),
     # If set, vLLM will pick up the provided Flash Attention MLA
     # Number of GPUs per worker in Ray, if it is set to be a fraction,
     # it allows ray to schedule multiple actors on a single GPU,

--- a/vllm/model_executor/layers/fp8_draft_head.py
+++ b/vllm/model_executor/layers/fp8_draft_head.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Rowwise FP8 (e4m3) quantization of a speculative-decoding draft LM head.
+
+Drafters that share the target model's LM head (e.g. DSpark,
+``has_own_lm_head=False``) pay a full ``[hidden, vocab]`` bf16 GEMM per draft
+step just to propose tokens. On bandwidth-bound GPUs that weight read
+dominates the draft loop. These helpers build a one-time rowwise-fp8 copy of
+the (vocab-sharded) head and compute draft logits with a dynamic per-token
+fp8 GEMM, halving the weight traffic.
+
+This is draft-time only by construction: the verify pass never sees the fp8
+weights, so accepted outputs are bitwise unchanged. The quantized logits are
+used for the draft argmax/top-k proposal; a rare argmax flip only costs a
+rejected draft token, never an incorrect sample.
+"""
+
+from typing import NamedTuple
+
+import torch
+
+# Finite max of float8_e4m3fn.
+_FP8_MAX = 448.0
+
+
+class Fp8DraftHead(NamedTuple):
+    """Rowwise-quantized copy of a (possibly vocab-sharded) LM head."""
+
+    # [num_local_vocab, hidden] fp8_e4m3, each row scaled to [-448, 448].
+    weight_fp8: torch.Tensor
+    # [1, num_local_vocab] dequant scale per output row (rowmax / 448),
+    # kept in the activation dtype so the epilogue multiplies stay cheap.
+    row_scale: torch.Tensor
+    # fp32 scalar 1.0 for torch._scaled_mm (scaling is applied manually in
+    # the epilogue because both operands use dynamic per-row scales).
+    unit_scale: torch.Tensor
+
+
+def fp8_draft_head_supported(device: torch.device | None = None) -> bool:
+    """torch._scaled_mm needs fp8 tensor cores (SM89+) on CUDA devices."""
+    if not torch.cuda.is_available():
+        return False
+    major, minor = torch.cuda.get_device_capability(device)
+    return (major, minor) >= (8, 9)
+
+
+def quantize_draft_head(weight: torch.Tensor) -> Fp8DraftHead:
+    """Quantize a ``[num_local_vocab, hidden]`` head weight rowwise to fp8.
+
+    Per-row (per vocab entry) symmetric scaling: ``w8 = w * (448 / rowmax)``
+    stored as fp8_e4m3, ``row_scale = rowmax / 448`` for the epilogue. For a
+    vocab-parallel (sharded) head, pass the local shard; row scales are
+    per-local-row, so gather/argmax semantics downstream are unchanged.
+    """
+    with torch.no_grad():
+        w = weight.detach()
+        row_max = w.abs().amax(dim=1, keepdim=True).float().clamp(min=1e-6)
+        weight_fp8 = (w.float() * (_FP8_MAX / row_max)).to(torch.float8_e4m3fn)
+        row_scale = (row_max / _FP8_MAX).to(w.dtype).reshape(1, -1)
+        unit_scale = torch.ones(1, dtype=torch.float32, device=w.device)
+    return Fp8DraftHead(weight_fp8, row_scale, unit_scale)
+
+
+def fp8_draft_head_logits(
+    hidden_states: torch.Tensor,
+    head: Fp8DraftHead,
+) -> torch.Tensor:
+    """Local (shard) draft logits via dynamic-fp8 x rowwise-fp8 GEMM.
+
+    Activations are quantized with a per-token amax scale, then
+    ``logits = _scaled_mm(a8, w8.T) * row_scale * (amax / 448)``. Output
+    dtype and shape match ``lm_head.quant_method.apply``: the caller is
+    responsible for the same TP gather / vocab-padding slice it would apply
+    to the unquantized local logits. Contains no data-dependent control
+    flow or allocations beyond the GEMM output, so it is safe to run inside
+    a captured CUDA graph as long as ``head`` was materialized beforehand.
+    """
+    act_max = hidden_states.abs().amax(dim=-1, keepdim=True).clamp(min=1e-6)
+    act_fp8 = (hidden_states * (_FP8_MAX / act_max)).to(torch.float8_e4m3fn)
+    logits = torch._scaled_mm(
+        act_fp8,
+        head.weight_fp8.t(),
+        scale_a=head.unit_scale,
+        scale_b=head.unit_scale,
+        out_dtype=hidden_states.dtype,
+    )
+    logits = logits * head.row_scale
+    logits = logits * (act_max / _FP8_MAX).to(hidden_states.dtype)
+    return logits

--- a/vllm/models/deepseek_v4/nvidia/dspark.py
+++ b/vllm/models/deepseek_v4/nvidia/dspark.py
@@ -15,6 +15,7 @@ import regex as re
 import torch
 import torch.nn as nn
 
+import vllm.envs as envs
 from vllm.config import VllmConfig, get_current_vllm_config
 from vllm.distributed import (
     get_tensor_model_parallel_rank,
@@ -24,6 +25,12 @@ from vllm.logger import init_logger
 from vllm.model_executor.kernels.mhc.tilelang import (
     hc_head_fused_kernel_tilelang,
     mhc_post_tilelang,
+)
+from vllm.model_executor.layers.fp8_draft_head import (
+    Fp8DraftHead,
+    fp8_draft_head_logits,
+    fp8_draft_head_supported,
+    quantize_draft_head,
 )
 from vllm.model_executor.layers.fused_moe import (
     fused_moe_make_expert_params_mapping,
@@ -287,6 +294,10 @@ class DSparkDeepseekV4ForCausalLM(nn.Module):
             prefix=maybe_prefix(prefix, "lm_head"),
         )
         self.logits_processor = LogitsProcessor(self.config.vocab_size)
+        # Optional rowwise-fp8 copy of the (shared) lm_head, used ONLY for
+        # draft-proposal logits. Materialized eagerly at load time via
+        # maybe_init_fp8_draft_head(); None means the bf16 path is used.
+        self._fp8_draft_head: Fp8DraftHead | None = None
 
     # --- Hooks used by the speculator -------------------------------------
 
@@ -324,8 +335,48 @@ class DSparkDeepseekV4ForCausalLM(nn.Module):
         """Base logits U_k = lm_head(norm(head_hidden))."""
         return self.logits_processor(self.lm_head, self.model.norm(hidden_states))
 
+    def maybe_init_fp8_draft_head(self) -> None:
+        """Materialize the rowwise-fp8 draft lm_head copy (opt-in).
+
+        Called by ``load_dspark_model`` right after the target's lm_head is
+        aliased onto this model. This must happen eagerly at load time, NOT
+        lazily on the first draft call: the whole DSpark draft step
+        (including ``compute_draft_logits``) runs inside a FULL captured
+        CUDA graph, so the quantization kernels must not fire during
+        capture/replay.
+
+        TP: the lm_head is vocab-sharded, so each rank quantizes its local
+        shard with per-local-row scales; the draft path's gather and argmax
+        semantics are unchanged.
+        """
+        if not envs.VLLM_DSPARK_FP8_DRAFT_HEAD:
+            return
+        if not fp8_draft_head_supported(self.lm_head.weight.device):
+            logger.warning(
+                "VLLM_DSPARK_FP8_DRAFT_HEAD is set but this device has no "
+                "fp8 support (SM89+ required); using the unquantized "
+                "draft lm_head."
+            )
+            return
+        self._fp8_draft_head = quantize_draft_head(self.lm_head.weight)
+        logger.info_once(
+            "DSpark draft-proposal logits use a rowwise-fp8 copy of the "
+            "target lm_head (draft-time only; verify pass untouched)."
+        )
+
     def compute_draft_logits(self, hidden_states: torch.Tensor) -> torch.Tensor:
         # Full-vocab draft: base logits, no d2t scatter.
+        if self._fp8_draft_head is not None:
+            # Draft-proposal-only fp8 path. Mirrors compute_logits ->
+            # LogitsProcessor._get_logits: local (shard) logits, then the
+            # same TP gather and vocab-padding slice.
+            local_logits = fp8_draft_head_logits(
+                self.model.norm(hidden_states), self._fp8_draft_head
+            )
+            logits = self.logits_processor._gather_logits(local_logits)
+            if logits is not None:
+                logits = logits[..., : self.logits_processor.org_vocab_size]
+            return logits
         return self.compute_logits(hidden_states)
 
     def map_draft_to_target(self, draft_ids: torch.Tensor) -> torch.Tensor:

--- a/vllm/v1/worker/gpu/spec_decode/dspark/utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/dspark/utils.py
@@ -79,9 +79,7 @@ def load_dspark_model(target_model: nn.Module, vllm_config: VllmConfig) -> nn.Mo
     # Opt-in rowwise-fp8 draft head (VLLM_DSPARK_FP8_DRAFT_HEAD). Must run
     # after the lm_head aliasing above and BEFORE CUDA graph capture: the
     # draft step is captured whole, so the fp8 copy is materialized eagerly.
-    maybe_init_fp8_draft_head = getattr(
-        draft_model, "maybe_init_fp8_draft_head", None
-    )
+    maybe_init_fp8_draft_head = getattr(draft_model, "maybe_init_fp8_draft_head", None)
     if maybe_init_fp8_draft_head is not None:
         maybe_init_fp8_draft_head()
 

--- a/vllm/v1/worker/gpu/spec_decode/dspark/utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/dspark/utils.py
@@ -76,4 +76,13 @@ def load_dspark_model(target_model: nn.Module, vllm_config: VllmConfig) -> nn.Mo
             del draft_model.lm_head
         draft_model.lm_head = target_lm_head
 
+    # Opt-in rowwise-fp8 draft head (VLLM_DSPARK_FP8_DRAFT_HEAD). Must run
+    # after the lm_head aliasing above and BEFORE CUDA graph capture: the
+    # draft step is captured whole, so the fp8 copy is materialized eagerly.
+    maybe_init_fp8_draft_head = getattr(
+        draft_model, "maybe_init_fp8_draft_head", None
+    )
+    if maybe_init_fp8_draft_head is not None:
+        maybe_init_fp8_draft_head()
+
     return draft_model


### PR DESCRIPTION
## Summary

Extract the opt-in rowwise-FP8 DSpark draft lm_head from #88 onto current Fathomless Firmament.

- VLLM_DSPARK_FP8_DRAFT_HEAD=1 creates a rowwise FP8-E4M3 copy of the vocab-sharded shared lm_head at model load.
- Draft logits use dynamic per-token activation quantization and torch._scaled_mm.
- Target verification continues to use the original weights, so accepted output semantics do not change; a draft argmax flip only reduces acceptance.
- Default behavior is unchanged.

## Prior performance result

On DGX Spark, the original implementation measured draft-head GEMM at 2.73 ms -> 1.45 ms and +3-5% end-to-end single-stream DSpark decode.

## Validation

- 5 focused tests passed on SM120.
- CUDA output is numerically identical to the FP8 emulation and produces identical draft argmax choices.
- The separate top-2 margin test bounds quantization-induced flips against BF16.
- Ruff check/format and git diff --check pass.

This is optional and independent of the correctness PRs; it is separated so Luke can review/merge it without taking the capacity-controller work.