### PR TITLE
fix(indexer): remove duplicate RoPE quant helper

### DIFF
--- a/tests/model_executor/layers/test_sparse_attn_indexer_b12x.py
+++ b/tests/model_executor/layers/test_sparse_attn_indexer_b12x.py
@@ -153,6 +153,44 @@ def _install_fake_b12x_indexer(
     monkeypatch.setitem(sys.modules, "b12x.integration", integration_mod)
 
 
+def _install_fake_b12x_dcp_merge(monkeypatch, run_row_topk, *, world_size: int):
+    tiled_topk_mod = types.ModuleType("b12x.attention.indexer.tiled_topk")
+    tiled_topk_mod.run_row_topk = run_row_topk
+    monkeypatch.setitem(
+        sys.modules,
+        "b12x.attention.indexer.tiled_topk",
+        tiled_topk_mod,
+    )
+
+    class FakeDCPGroup:
+        def __init__(self) -> None:
+            self.world_size = world_size
+
+        def all_gather(self, tensor, dim):
+            assert dim == 0
+            return torch.cat([tensor.clone() for _ in range(world_size)], dim=dim)
+
+    import vllm.distributed.parallel_state as parallel_state
+    import vllm.v1.attention.backends.mla.sparse_utils as sparse_utils
+
+    monkeypatch.setattr(parallel_state, "get_dcp_group", lambda: FakeDCPGroup())
+    monkeypatch.setattr(
+        sparse_utils,
+        "triton_convert_dcp_local_topk_to_global",
+        lambda *args, **kwargs: None,
+    )
+
+    def gather_topk_ids_by_position(candidate_ids, positions, out):
+        gathered = torch.gather(candidate_ids, 1, positions.to(torch.int64))
+        out.copy_(gathered.to(out.dtype))
+
+    monkeypatch.setattr(
+        sparse_utils,
+        "triton_gather_topk_ids_by_position",
+        gather_topk_ids_by_position,
+    )
+
+
 @pytest.mark.parametrize(
     "page_stride0",
     [
@@ -560,9 +598,6 @@ def test_b12x_dcp_decode_requests_score_output(monkeypatch):
             schedule_metadata=None,
             active_width=None,
         ),
-        dcp_world_size=2,
-        dcp_rank=1,
-        cp_interleave_size=16,
     )
     layer_name = "layers.0.attn"
     metadata_key = indexer_mod._resolve_layer_name(layer_name)
@@ -599,6 +634,9 @@ def test_b12x_dcp_decode_requests_score_output(monkeypatch):
         use_fp4_cache=False,
         use_b12x_sparse_indexer=True,
         topk_scores_buffer=topk_scores_buffer,
+        dcp_world_size=2,
+        dcp_rank=1,
+        cp_kv_cache_interleave_size=16,
     )
 
     assert result is topk_indices_buffer
@@ -625,7 +663,6 @@ def test_b12x_dcp_decode_requests_score_output(monkeypatch):
 
 
 def test_b12x_dcp_merge_passes_contiguous_scores_to_topk(monkeypatch):
-    tiled_topk_mod = types.ModuleType("b12x.attention.indexer.tiled_topk")
     run_row_topk_calls: list[tuple[bool, tuple[int, ...]]] = []
 
     def run_row_topk(*, row_logits, lengths, topk, output_values, output_indices):
@@ -638,39 +675,7 @@ def test_b12x_dcp_merge_passes_contiguous_scores_to_topk(monkeypatch):
         output_indices.copy_(positions)
         output_values.copy_(row_logits[:, :topk])
 
-    tiled_topk_mod.run_row_topk = run_row_topk
-    monkeypatch.setitem(
-        sys.modules,
-        "b12x.attention.indexer.tiled_topk",
-        tiled_topk_mod,
-    )
-
-    class FakeDCPGroup:
-        world_size = 2
-
-        def all_gather(self, tensor, dim):
-            assert dim == 0
-            return torch.cat([tensor, tensor.clone()], dim=dim)
-
-    import vllm.distributed.parallel_state as parallel_state
-    import vllm.v1.attention.backends.mla.sparse_utils as sparse_utils
-
-    monkeypatch.setattr(parallel_state, "get_dcp_group", lambda: FakeDCPGroup())
-    monkeypatch.setattr(
-        sparse_utils,
-        "triton_convert_dcp_local_topk_to_global",
-        lambda *args, **kwargs: None,
-    )
-
-    def gather_topk_ids_by_position(candidate_ids, positions, out):
-        gathered = torch.gather(candidate_ids, 1, positions.to(torch.int64))
-        out.copy_(gathered.to(out.dtype))
-
-    monkeypatch.setattr(
-        sparse_utils,
-        "triton_gather_topk_ids_by_position",
-        gather_topk_ids_by_position,
-    )
+    _install_fake_b12x_dcp_merge(monkeypatch, run_row_topk, world_size=2)
     workspace_manager = _FakeWorkspaceManager()
     monkeypatch.setattr(
         indexer_mod, "current_workspace_manager", lambda: workspace_manager
@@ -695,6 +700,14 @@ def test_b12x_dcp_merge_passes_contiguous_scores_to_topk(monkeypatch):
 
 
 def test_b12x_dcp_merge_warmup_reserves_workspace(monkeypatch):
+    def run_row_topk(*, row_logits, lengths, topk, output_values, output_indices):
+        positions = torch.arange(topk, dtype=output_indices.dtype).expand_as(
+            output_indices
+        )
+        output_indices.copy_(positions)
+        output_values.copy_(row_logits[:, :topk])
+
+    _install_fake_b12x_dcp_merge(monkeypatch, run_row_topk, world_size=4)
     workspace_manager = _FakeWorkspaceManager()
     monkeypatch.setattr(
         indexer_mod, "current_workspace_manager", lambda: workspace_manager
@@ -1054,7 +1067,7 @@ def test_b12x_schedule_metadata_uses_canonical_indexer_import(monkeypatch):
     )
     builder = object.__new__(mla_indexer_mod.DeepseekV32IndexerMetadataBuilder)
     builder.scheduler_metadata_buffer = torch.zeros((5, 2), dtype=torch.int32)
-    builder.storage_block_size = 64
+    builder.kv_cache_spec = types.SimpleNamespace(storage_block_size=64)
     builder.num_sms = 4
 
     seq_lens = torch.tensor([64, 128], dtype=torch.int32)

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -9,7 +9,6 @@ import torch
 import vllm.envs as envs
 from vllm import _custom_ops as ops
 from vllm._aiter_ops import rocm_aiter_ops
-from vllm.compilation.breakable_cudagraph import eager_break_during_capture
 from vllm.config import CUDAGraphMode, get_current_vllm_config
 from vllm.distributed import get_dcp_group
 from vllm.forward_context import get_forward_context
@@ -21,7 +20,6 @@ from vllm.platforms import current_platform
 from vllm.triton_utils import HAS_TRITON, tl, triton
 from vllm.utils.deep_gemm import (
     fp8_fp4_mqa_logits,
-    fp8_fp4_paged_mqa_logits,
     has_deep_gemm,
 )
 from vllm.utils.import_utils import has_cutedsl
@@ -658,133 +656,6 @@ def _use_b12x_sparse_indexer(enabled: bool | None = None) -> bool:
 
 def use_b12x_sparse_indexer(enabled: bool | None = None) -> bool:
     return _use_b12x_sparse_indexer(enabled)
-
-
-@triton.jit
-def _fused_indexer_q_rope_quant_kernel(
-    positions,
-    q,
-    q_s0,
-    q_s1,
-    cos_sin_cache,
-    cos_sin_s0,
-    q_fp8,
-    q_fp8_s0,
-    q_fp8_s1,
-    weights,
-    weights_s0,
-    weights_s1,
-    weights_out,
-    weights_out_s0,
-    weights_out_s1,
-    softmax_scale,
-    head_scale,
-    fp8_min: tl.constexpr,
-    fp8_max: tl.constexpr,
-    is_neox: tl.constexpr,
-):
-    token = tl.program_id(0)
-    head = tl.program_id(1)
-    offs32 = tl.arange(0, 32)
-    offs64 = tl.arange(0, 64)
-
-    pos = tl.load(positions + token)
-    cos = tl.load(cos_sin_cache + pos * cos_sin_s0 + offs32).to(tl.float32)
-    sin = tl.load(cos_sin_cache + pos * cos_sin_s0 + 32 + offs32).to(tl.float32)
-    q_base = q + token * q_s0 + head * q_s1
-    out_base = q_fp8 + token * q_fp8_s0 + head * q_fp8_s1
-
-    if is_neox:
-        # NeoX layout, x0 = q[0:32], x1 = q[32:64]
-        x0 = tl.load(q_base + offs32).to(tl.float32)
-        x1 = tl.load(q_base + 32 + offs32).to(tl.float32)
-    else:
-        # interleaved layout
-        # x0 = q[0, 2, 4, ...], x1 = q[1, 3, 5, ...]
-        x0 = tl.load(q_base + offs32 * 2).to(tl.float32)
-        x1 = tl.load(q_base + offs32 * 2 + 1).to(tl.float32)
-    r0 = (x0 * cos - x1 * sin).to(tl.bfloat16).to(tl.float32)
-    r1 = (x1 * cos + x0 * sin).to(tl.bfloat16).to(tl.float32)
-    amax = tl.maximum(tl.max(tl.abs(r0)), tl.max(tl.abs(r1)))
-
-    q_nope = tl.load(q_base + 64 + offs64).to(tl.float32)
-    amax = tl.maximum(amax, tl.max(tl.abs(q_nope)))
-    scale_raw = tl.maximum(amax, 1e-10) * (1.0 / fp8_max)
-    # e8m0 format
-    q_scale = tl.math.exp2(tl.ceil(tl.log2(scale_raw)))
-
-    if is_neox:
-        tl.store(
-            out_base + offs32,
-            tl.clamp(r0 / q_scale, fp8_min, fp8_max).to(q_fp8.dtype.element_ty),
-        )
-        tl.store(
-            out_base + 32 + offs32,
-            tl.clamp(r1 / q_scale, fp8_min, fp8_max).to(q_fp8.dtype.element_ty),
-        )
-    else:
-        tl.store(
-            out_base + offs32 * 2,
-            tl.clamp(r0 / q_scale, fp8_min, fp8_max).to(q_fp8.dtype.element_ty),
-        )
-        tl.store(
-            out_base + offs32 * 2 + 1,
-            tl.clamp(r1 / q_scale, fp8_min, fp8_max).to(q_fp8.dtype.element_ty),
-        )
-    tl.store(
-        out_base + 64 + offs64,
-        tl.clamp(q_nope / q_scale, fp8_min, fp8_max).to(q_fp8.dtype.element_ty),
-    )
-
-    weight = tl.load(weights + token * weights_s0 + head * weights_s1).to(tl.float32)
-    tl.store(
-        weights_out + token * weights_out_s0 + head * weights_out_s1,
-        weight * q_scale * softmax_scale * head_scale,
-    )
-
-
-def fused_indexer_q_rope_quant(
-    positions: torch.Tensor,
-    q: torch.Tensor,
-    cos_sin_cache: torch.Tensor,
-    weights: torch.Tensor,
-    softmax_scale: float,
-    head_scale: float,
-    is_neox: bool,
-) -> tuple[torch.Tensor, torch.Tensor]:
-    assert current_platform.is_cuda()
-    assert q.dtype == torch.bfloat16
-    assert q.shape[-1] == 128
-    assert cos_sin_cache.shape[-1] == 64
-    assert weights.shape == q.shape[:2]
-
-    q_fp8 = torch.empty_like(q, dtype=current_platform.fp8_dtype())
-    weights_out = torch.empty_like(weights, dtype=torch.float32)
-    fp8_min, fp8_max = get_fp8_min_max()
-    _fused_indexer_q_rope_quant_kernel[(q.shape[0], q.shape[1])](
-        positions,
-        q,
-        q.stride(0),
-        q.stride(1),
-        cos_sin_cache,
-        cos_sin_cache.stride(0),
-        q_fp8,
-        q_fp8.stride(0),
-        q_fp8.stride(1),
-        weights,
-        weights.stride(0),
-        weights.stride(1),
-        weights_out,
-        weights_out.stride(0),
-        weights_out.stride(1),
-        softmax_scale,
-        head_scale,
-        fp8_min=fp8_min,
-        fp8_max=fp8_max,
-        is_neox=is_neox,
-        num_warps=1,
-    )
-    return q_fp8, weights_out
 
 
 def _assert_cutedsl_dcp_merge_supported(


### PR DESCRIPTION
## Summary

- remove the first of two byte-identical `_fused_indexer_q_rope_quant_kernel` / `fused_indexer_q_rope_quant` definitions
- remove two imports that are unused in the canonical FF tree
- leave the surviving runtime implementation unchanged
- refresh stale B12X sparse-indexer fixtures to the current FF DCP and KV-cache contracts

## Why

The duplicate entered the FF branch when the B12X sparse-indexer integration and upstream sparse-indexer work converged. Python silently replaced the first wrapper with the second, so runtime behavior was unaffected, but Ruff reports `F811` plus the two stale `F401` imports. This can fail pre-commit for later PRs that touch the file.

## Validation

- the removed kernel and wrapper were byte-identical to the surviving definitions
- `ruff check vllm/model_executor/layers/sparse_attn_indexer.py`
- `ruff format --check vllm/model_executor/layers/sparse_attn_indexer.py`
- `git diff --check`
- `15 passed` in `tests/model_executor/layers/test_sparse_attn_indexer_b12x.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined sparse-attention indexing and decoding internals for more consistent execution across supported configurations.
  * Improved handling of specialized runtime paths without changing the public API.

* **Tests**
  * Expanded coverage for distributed sparse-attention merging, top-k results, score output, and schedule metadata.
  * Standardized test setup across multiple parallelism configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->