### PR TITLE
[GG] perf(dcp): split prefill queries and gather selected CKV

### DIFF
--- a/tests/v1/attention/test_sparse_mla_backends.py
+++ b/tests/v1/attention/test_sparse_mla_backends.py
@@ -40,6 +40,7 @@ from vllm.v1.attention.backends.mla.b12x_mla_sparse import (
     B12xMLASparseBackend,
     B12xMLASparseImpl,
     B12xMLASparseMetadataBuilder,
+    _global_causal_lens_for_ckv_gather,
 )
 from vllm.v1.attention.backends.mla.flashinfer_mla_sparse import (
     FlashInferMLASparseTRTLLMBackend,
@@ -71,6 +72,31 @@ SPARSE_BACKEND_BATCH_SPECS["large_q_pure_prefill"] = BatchSpec(
 )
 
 DEVICE_TYPE = current_platform.device_type
+
+
+@pytest.mark.parametrize(
+    ("global_seq_lens", "query_start_loc", "req_ids", "expected"),
+    [
+        ([8], [0, 4], [0, 0, 0, 0], [5, 6, 7, 8]),
+        ([5, 10], [0, 2, 5], [0, 0, 1, 1, 1], [4, 5, 8, 9, 10]),
+    ],
+)
+def test_ckv_gather_uses_global_per_token_causal_lens(
+    global_seq_lens: list[int],
+    query_start_loc: list[int],
+    req_ids: list[int],
+    expected: list[int],
+) -> None:
+    device = torch.device(DEVICE_TYPE)
+    result = _global_causal_lens_for_ckv_gather(
+        torch.tensor(global_seq_lens, dtype=torch.int32, device=device),
+        torch.tensor(query_start_loc, dtype=torch.int32, device=device),
+        torch.tensor(req_ids, dtype=torch.int32, device=device),
+        len(req_ids),
+    )
+
+    assert result.dtype == torch.int32
+    assert result.tolist() == expected
 
 
 @pytest.mark.parametrize(

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -1415,6 +1415,14 @@ def get_dcp_group() -> GroupCoordinator:
     return _DCP
 
 
+_QUERY_SPLIT: GroupCoordinator | None = None
+
+
+def get_query_split_group() -> GroupCoordinator:
+    assert _QUERY_SPLIT is not None, "query split group is not initialized"
+    return _QUERY_SPLIT
+
+
 _PP: GroupCoordinator | None = None
 
 
@@ -1878,6 +1886,26 @@ def initialize_model_parallel(
         group_name="dcp",
     )
 
+    # Build the query-split groups for the indexer query split (Fix A).
+    # Ranks sharing the same dcp_rank (position within their DCP group)
+    # form a query-split group.  At TP=8/DCP=2 the DCP groups are
+    # {0,1},{2,3},{4,5},{6,7} and the query-split groups are
+    # {0,2,4,6} (dcp_rank=0) and {1,3,5,7} (dcp_rank=1).
+    global _QUERY_SPLIT
+    assert _QUERY_SPLIT is None, "query split group is already initialized"
+    if decode_context_model_parallel_size > 1:
+        query_split_ranks: list[list[int]] = []
+        for dcp_rank_idx in range(decode_context_model_parallel_size):
+            query_split_ranks.append(
+                [grp[dcp_rank_idx] for grp in group_ranks]
+            )
+        _QUERY_SPLIT = init_model_parallel_group(
+            query_split_ranks,
+            get_world_group().local_rank,
+            backend,
+            group_name="query_split",
+        )
+
     global _PCP
     assert _PCP is None, "prefill context parallel group is already initialized"
     group_ranks = (
@@ -2102,6 +2130,11 @@ def destroy_model_parallel():
     if _DCP:
         _DCP.destroy()
     _DCP = None
+
+    global _QUERY_SPLIT
+    if _QUERY_SPLIT:
+        _QUERY_SPLIT.destroy()
+    _QUERY_SPLIT = None
 
     global _PCP
     if _PCP:

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -1423,6 +1423,16 @@ def get_query_split_group() -> GroupCoordinator:
     return _QUERY_SPLIT
 
 
+_DCP_CKV_PREFETCH: GroupCoordinator | None = None
+
+
+def get_dcp_ckv_prefetch_group() -> GroupCoordinator:
+    assert _DCP_CKV_PREFETCH is not None, (
+        "DCP ckv prefetch group is not initialized"
+    )
+    return _DCP_CKV_PREFETCH
+
+
 _PP: GroupCoordinator | None = None
 
 
@@ -1906,6 +1916,23 @@ def initialize_model_parallel(
             group_name="query_split",
         )
 
+    # A dedicated communicator over the DCP ranks for the transient ckv
+    # prefetch gather (Fix B). The prefetch runs on a side stream and would
+    # otherwise share the DCP communicator with the indexer's DCP top-k
+    # merge on the default stream; concurrent collectives on one NCCL
+    # communicator from two streams is unsupported. Same ranks as ``_DCP``.
+    global _DCP_CKV_PREFETCH
+    assert _DCP_CKV_PREFETCH is None, (
+        "DCP ckv prefetch group is already initialized"
+    )
+    if decode_context_model_parallel_size > 1:
+        _DCP_CKV_PREFETCH = init_model_parallel_group(
+            group_ranks,
+            get_world_group().local_rank,
+            backend,
+            group_name="dcp_ckv_prefetch",
+        )
+
     global _PCP
     assert _PCP is None, "prefill context parallel group is already initialized"
     group_ranks = (
@@ -2135,6 +2162,11 @@ def destroy_model_parallel():
     if _QUERY_SPLIT:
         _QUERY_SPLIT.destroy()
     _QUERY_SPLIT = None
+
+    global _DCP_CKV_PREFETCH
+    if _DCP_CKV_PREFETCH:
+        _DCP_CKV_PREFETCH.destroy()
+    _DCP_CKV_PREFETCH = None
 
     global _PCP
     if _PCP:

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -1427,9 +1427,7 @@ _DCP_CKV_PREFETCH: GroupCoordinator | None = None
 
 
 def get_dcp_ckv_prefetch_group() -> GroupCoordinator:
-    assert _DCP_CKV_PREFETCH is not None, (
-        "DCP ckv prefetch group is not initialized"
-    )
+    assert _DCP_CKV_PREFETCH is not None, "DCP ckv prefetch group is not initialized"
     return _DCP_CKV_PREFETCH
 
 
@@ -1903,12 +1901,10 @@ def initialize_model_parallel(
     # {0,2,4,6} (dcp_rank=0) and {1,3,5,7} (dcp_rank=1).
     global _QUERY_SPLIT
     assert _QUERY_SPLIT is None, "query split group is already initialized"
-    if decode_context_model_parallel_size > 1:
+    if decode_context_model_parallel_size > 1 and envs.VLLM_DCP_QUERY_SPLIT:
         query_split_ranks: list[list[int]] = []
         for dcp_rank_idx in range(decode_context_model_parallel_size):
-            query_split_ranks.append(
-                [grp[dcp_rank_idx] for grp in group_ranks]
-            )
+            query_split_ranks.append([grp[dcp_rank_idx] for grp in group_ranks])
         _QUERY_SPLIT = init_model_parallel_group(
             query_split_ranks,
             get_world_group().local_rank,
@@ -1922,10 +1918,8 @@ def initialize_model_parallel(
     # merge on the default stream; concurrent collectives on one NCCL
     # communicator from two streams is unsupported. Same ranks as ``_DCP``.
     global _DCP_CKV_PREFETCH
-    assert _DCP_CKV_PREFETCH is None, (
-        "DCP ckv prefetch group is already initialized"
-    )
-    if decode_context_model_parallel_size > 1:
+    assert _DCP_CKV_PREFETCH is None, "DCP ckv prefetch group is already initialized"
+    if decode_context_model_parallel_size > 1 and envs.VLLM_B12X_MLA_CKV_GATHER:
         _DCP_CKV_PREFETCH = init_model_parallel_group(
             group_ranks,
             get_world_group().local_rank,

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -72,6 +72,10 @@ if TYPE_CHECKING:
     VLLM_DCP_A2A_LARGE_BACKEND: Literal["ag_rs", "a2a"] = "ag_rs"
     VLLM_DCP_SHARD_DRAFT: str | None = None
     VLLM_DCP_GLOBAL_TOPK: bool = True
+    VLLM_DCP_QUERY_SPLIT: bool = False
+    VLLM_B12X_MLA_CKV_GATHER: bool = False
+    VLLM_B12X_MLA_CKV_GATHER_MIN_TOKENS: int = 16
+    VLLM_B12X_MLA_CKV_GATHER_MAX_TOKENS: int = 524288
     VLLM_MINIMAX_M3_ENABLE_TORCH_COMPILE: bool = False
     VLLM_B12X_CUDAGRAPH_PIECEWISE_PREWARM: bool = False
     VLLM_B12X_MOE_FORCE_MODELOPT_PREP: bool = False
@@ -1118,6 +1122,18 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # top-k instead of a per-rank local top-k.
     "VLLM_DCP_GLOBAL_TOPK": lambda: (
         os.getenv("VLLM_DCP_GLOBAL_TOPK", "1").lower() in ("1", "true", "yes", "on")
+    ),
+    "VLLM_DCP_QUERY_SPLIT": lambda: (
+        os.getenv("VLLM_DCP_QUERY_SPLIT", "0").lower() in ("1", "true", "yes", "on")
+    ),
+    "VLLM_B12X_MLA_CKV_GATHER": lambda: (
+        os.getenv("VLLM_B12X_MLA_CKV_GATHER", "0").lower() in ("1", "true", "yes", "on")
+    ),
+    "VLLM_B12X_MLA_CKV_GATHER_MIN_TOKENS": lambda: int(
+        os.getenv("VLLM_B12X_MLA_CKV_GATHER_MIN_TOKENS", "16")
+    ),
+    "VLLM_B12X_MLA_CKV_GATHER_MAX_TOKENS": lambda: int(
+        os.getenv("VLLM_B12X_MLA_CKV_GATHER_MAX_TOKENS", "524288")
     ),
     # Diagnostic flag retained for local experiments. MiniMax M3 compile is
     # fail-closed in the model until the no-break path is validated.

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -187,8 +187,8 @@ for chunk_idx in range(cdiv(C, MCC)):
 return curr_o @ W_O
 """
 
-import os
 import functools
+import os
 from abc import abstractmethod
 from dataclasses import dataclass
 from enum import Enum
@@ -1046,9 +1046,7 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             if not is_sparse_impl:
                 assert attn_metadata.decode is not None
             if ckv_gather_used:
-                ckv_setter = getattr(
-                    self.impl, "set_ckv_current_chunk_kv", None
-                )
+                ckv_setter = getattr(self.impl, "set_ckv_current_chunk_kv", None)
                 if callable(ckv_setter):
                     ckv_setter(k_c_normed, k_pe)
             attn_out, lse = self.impl.forward_mqa(mqa_q, kv_cache, attn_metadata, self)  # type: ignore[attr-defined]
@@ -1379,13 +1377,9 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             and num_hidden_layers is not None
             and layer_id >= int(num_hidden_layers)
         )
-        model_type = getattr(
-            vllm_config.model_config.hf_config, "model_type", None
-        )
+        model_type = getattr(vllm_config.model_config.hf_config, "model_type", None)
         speculative_config = getattr(vllm_config, "speculative_config", None)
-        target_model_config = getattr(
-            speculative_config, "target_model_config", None
-        )
+        target_model_config = getattr(speculative_config, "target_model_config", None)
         target_model_type = (
             getattr(target_model_config.hf_config, "model_type", None)
             if target_model_config is not None
@@ -1393,10 +1387,7 @@ class MLAAttention(nn.Module, AttentionLayerBase):
         )
         glm_model_or_mtp = bool(
             model_type == "glm_moe_dsa"
-            or (
-                model_type == "deepseek_mtp"
-                and target_model_type == "glm_moe_dsa"
-            )
+            or (model_type == "deepseek_mtp" and target_model_type == "glm_moe_dsa")
         )
         glm_fp8_rope = bool(
             os.environ.get("KV_FP8_ROPE", "0") == "1"
@@ -1512,8 +1503,6 @@ class MLAAttention(nn.Module, AttentionLayerBase):
         for start in range(0, num_tokens, max_chunk_tokens):
             end = min(start + max_chunk_tokens, num_tokens)
             self._v_up_proj_bmm(x[start:end], out[start:end], w_uv)
-
-
 
 
 def unified_mla_kv_cache_update(

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -943,13 +943,22 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             dcp_use_a2a = False
             project_before_merge = False
             workspace_gather_used = False
+            ckv_gather_used = False
             if self.impl.dcp_world_size > 1:
-                if not self.impl.can_return_lse_for_decode:
-                    raise NotImplementedError(
-                        f"{type(self.impl).__name__} cannot use DCP because it "
-                        "does not return decode softmax LSE."
-                    )
-                self.impl.need_to_return_lse_for_decode = True
+                ckv_gather_selector = getattr(
+                    self.impl, "dcp_prefill_ckv_gather_eligible", None
+                )
+                ckv_gather_used = bool(
+                    callable(ckv_gather_selector)
+                    and ckv_gather_selector(attn_metadata, num_mqa_tokens)
+                )
+                if not ckv_gather_used:
+                    if not self.impl.can_return_lse_for_decode:
+                        raise NotImplementedError(
+                            f"{type(self.impl).__name__} cannot use DCP because it "
+                            "does not return decode softmax LSE."
+                        )
+                    self.impl.need_to_return_lse_for_decode = True
                 if (
                     fp8_attention
                     and isinstance(mqa_q, torch.Tensor)
@@ -974,7 +983,9 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 )
                 # The project-before path currently targets eager AG/RS
                 # prefill. A2A retains its established merge-then-project path.
-                project_before_merge = use_ondemand_w_uv and not dcp_use_a2a
+                project_before_merge = (
+                    use_ondemand_w_uv and not dcp_use_a2a and not ckv_gather_used
+                )
                 workspace_gather_eligible = _can_use_b12x_dcp_prefill_workspace(
                     enabled=envs.VLLM_B12X_MLA_DCP_GATHER_IN_WORKSPACE,
                     project_before_merge=project_before_merge,
@@ -988,11 +999,18 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                     backend_name=self.attn_backend.get_name(),
                     is_capturing=torch.cuda.is_current_stream_capturing(),
                 )
-                if isinstance(mqa_q, tuple) and not workspace_gather_eligible:
-                    # Ordinary communicators require one contiguous query.
+                if (
+                    isinstance(mqa_q, tuple)
+                    and not workspace_gather_eligible
+                    and not ckv_gather_used
+                ):
                     mqa_q = torch.cat(mqa_q, dim=-1)
-                # mqa_q do allgather in head dim.
-                if dcp_use_b12x:
+                if ckv_gather_used:
+                    logger.info_once(
+                        "Keeping local query heads for transient full-CKV "
+                        "B12X sparse MLA prefill"
+                    )
+                elif dcp_use_b12x:
                     mqa_q = dcp_b12x_all_gather_heads(
                         mqa_q,
                         get_dcp_group(),
@@ -1027,10 +1045,16 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             # call decode attn
             if not is_sparse_impl:
                 assert attn_metadata.decode is not None
+            if ckv_gather_used:
+                ckv_setter = getattr(
+                    self.impl, "set_ckv_current_chunk_kv", None
+                )
+                if callable(ckv_setter):
+                    ckv_setter(k_c_normed, k_pe)
             attn_out, lse = self.impl.forward_mqa(mqa_q, kv_cache, attn_metadata, self)  # type: ignore[attr-defined]
 
             # correct dcp attn_out with lse.
-            if self.impl.dcp_world_size > 1:
+            if self.impl.dcp_world_size > 1 and not ckv_gather_used:
                 if lse is None:
                     raise RuntimeError(
                         f"{type(self.impl).__name__} did not return decode "

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -1604,11 +1604,7 @@ def sparse_attn_indexer(
             qs_active = False
             qs_row_start = chunk.token_start
             qs_row_end = chunk.token_end
-            if (
-                qs_world_size > 1
-                and use_b12x_indexer
-                and chunk.total_seq_lens > 0
-            ):
+            if qs_world_size > 1 and use_b12x_indexer and chunk.total_seq_lens > 0:
                 chunk_tokens = chunk.token_end - chunk.token_start
                 if chunk_tokens % qs_world_size == 0:
                     slice_tokens = chunk_tokens // qs_world_size
@@ -1691,7 +1687,7 @@ def sparse_attn_indexer(
                             "B12X sparse indexer DCP requires topk_scores_buffer."
                         )
                     topk_scores = topk_scores_buffer[
-                        qs_row_start : qs_row_end, :topk_tokens
+                        qs_row_start:qs_row_end, :topk_tokens
                     ]
                 _run_b12x_paged_topk(
                     q_fp8=q_slice.contiguous(),

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -10,7 +10,7 @@ import vllm.envs as envs
 from vllm import _custom_ops as ops
 from vllm._aiter_ops import rocm_aiter_ops
 from vllm.config import CUDAGraphMode, get_current_vllm_config
-from vllm.distributed import get_dcp_group
+from vllm.distributed import get_dcp_group, get_query_split_group
 from vllm.forward_context import get_forward_context
 from vllm.model_executor.custom_op import CustomOp
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
@@ -1510,6 +1510,18 @@ def sparse_attn_indexer(
     # DCP scalars arrive as op arguments (resolved once at layer construction),
     # not through per-step metadata.
     dcp_global_topk = _dcp_global_topk_requested() and dcp_world_size > 1
+    qs_group = None
+    qs_world_size = 1
+    qs_rank = 0
+    if envs.VLLM_DCP_QUERY_SPLIT and dcp_world_size > 1:
+        try:
+            _qs = get_query_split_group()
+            if int(_qs.world_size) > 1:
+                qs_group = _qs
+                qs_world_size = int(_qs.world_size)
+                qs_rank = int(_qs.rank_in_group)
+        except Exception:
+            pass
     if output_physical_slots:
         if not _use_b12x_sparse_indexer(use_b12x_sparse_indexer):
             raise RuntimeError(
@@ -1589,6 +1601,30 @@ def sparse_attn_indexer(
             topk_indices = topk_indices_buffer[
                 chunk.token_start : chunk.token_end, :topk_tokens
             ]
+            qs_active = False
+            qs_row_start = chunk.token_start
+            qs_row_end = chunk.token_end
+            if (
+                qs_world_size > 1
+                and use_b12x_indexer
+                and chunk.total_seq_lens > 0
+            ):
+                chunk_tokens = chunk.token_end - chunk.token_start
+                if chunk_tokens % qs_world_size == 0:
+                    slice_tokens = chunk_tokens // qs_world_size
+                    qs_row_start = chunk.token_start + qs_rank * slice_tokens
+                    qs_row_end = qs_row_start + slice_tokens
+                    q_slice = q_quant[qs_row_start:qs_row_end]
+                    q_scale_slice = (
+                        q_scale[qs_row_start:qs_row_end]
+                        if q_scale is not None
+                        else None
+                    )
+                    weights_slice = weights[qs_row_start:qs_row_end]
+                    topk_indices = topk_indices_buffer[
+                        qs_row_start:qs_row_end, :topk_tokens
+                    ]
+                    qs_active = True
             if use_b12x_indexer and chunk.total_seq_lens <= 0:
                 topk_indices.fill_(-1)
                 if dcp_global_topk:
@@ -1617,15 +1653,36 @@ def sparse_attn_indexer(
                         "B12X sparse prefill requires single-request chunks so "
                         "the page table can be row-shared without packing."
                     )
-                row_has_no_kv = chunk.cu_seqlen_ke <= chunk.cu_seqlen_ks
+                if qs_active:
+                    rel_start = qs_row_start - chunk.token_start
+                    rel_end = qs_row_end - chunk.token_start
+                    cu_seqlen_ks = chunk.cu_seqlen_ks[rel_start:rel_end]
+                    cu_seqlen_ke = chunk.cu_seqlen_ke[rel_start:rel_end]
+                else:
+                    cu_seqlen_ks = chunk.cu_seqlen_ks
+                    cu_seqlen_ke = chunk.cu_seqlen_ke
+                row_has_no_kv = cu_seqlen_ke <= cu_seqlen_ks
                 seq_lens = torch.where(
                     row_has_no_kv,
-                    torch.zeros_like(chunk.cu_seqlen_ks),
-                    chunk.cu_seqlen_ke - chunk.cu_seqlen_ks,
+                    torch.zeros_like(cu_seqlen_ks),
+                    cu_seqlen_ke - cu_seqlen_ks,
                 )
-                block_table = chunk.block_table[:1].expand(
+                local_k_rows = (
+                    int(chunk.local_total_seq_lens)
+                    if dcp_world_size > 1
+                    else int(chunk.total_seq_lens)
+                )
+                active_page_width = max(
+                    1,
+                    (local_k_rows + _B12X_PAGED_INDEX_PAGE_SIZE - 1)
+                    // _B12X_PAGED_INDEX_PAGE_SIZE,
+                )
+                active_page_width = min(
+                    active_page_width, int(chunk.block_table.shape[1])
+                )
+                block_table = chunk.block_table[:1, :active_page_width].expand(
                     int(q_slice.shape[0]),
-                    int(chunk.block_table.shape[1]),
+                    active_page_width,
                 )
                 topk_scores = None
                 if dcp_world_size > 1:
@@ -1634,7 +1691,7 @@ def sparse_attn_indexer(
                             "B12X sparse indexer DCP requires topk_scores_buffer."
                         )
                     topk_scores = topk_scores_buffer[
-                        chunk.token_start : chunk.token_end, :topk_tokens
+                        qs_row_start : qs_row_end, :topk_tokens
                     ]
                 _run_b12x_paged_topk(
                     q_fp8=q_slice.contiguous(),
@@ -1666,6 +1723,20 @@ def sparse_attn_indexer(
                         dcp_rank=dcp_rank,
                         cp_kv_cache_interleave_size=cp_kv_cache_interleave_size,
                     )
+                if qs_active:
+                    gathered_indices = qs_group.all_gather(
+                        topk_indices.contiguous(), dim=0
+                    )
+                    topk_indices_buffer[
+                        chunk.token_start : chunk.token_end, :topk_tokens
+                    ].copy_(gathered_indices)
+                    if topk_scores is not None:
+                        gathered_scores = qs_group.all_gather(
+                            topk_scores.contiguous(), dim=0
+                        )
+                        topk_scores_buffer[
+                            chunk.token_start : chunk.token_end, :topk_tokens
+                        ].copy_(gathered_scores)
                 continue
 
             cu_seqlen_ks = chunk.cu_seqlen_ks

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -2001,9 +2001,36 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
                 cp_kv_cache_interleave_size=self.cp_kv_cache_interleave_size,
                 padded_rank_tokens=attn_metadata.dcp_padded_total_tokens,
             )
+            # The gathered buffer holds the *global* sequence and the extend
+            # kernel attends it in full (cache_seqlens = global lengths), so
+            # the count of selected entries must be capped by the global
+            # per-token causal length. ``per_token_cache`` is the *local*
+            # per-rank length (~global/dcp); using it drops the other ranks'
+            # selected tokens whenever it is the smaller bound
+            # (local_len < min(topk, global_len)) -- i.e. for short contexts,
+            # which shows up as small-context-only garbage.
+            assert attn_metadata.global_cache_seq_lens_per_req is not None
+            g_num_reqs = attn_metadata.num_reqs
+            g_qsl = attn_metadata.query_start_loc[: g_num_reqs + 1].to(
+                torch.int32
+            )
+            g_req_ids = attn_metadata.req_id_per_token[:num_actual_toks].to(
+                torch.int64
+            )
+            g_chunk_start = g_qsl[:-1][g_req_ids]
+            g_chunk_len = (g_qsl[1:] - g_qsl[:-1])[g_req_ids]
+            g_full_seq = attn_metadata.global_cache_seq_lens_per_req[
+                g_req_ids
+            ].to(torch.int32)
+            g_t = torch.arange(
+                num_actual_toks, device=self.device, dtype=torch.int32
+            )
+            global_causal_len = (
+                g_full_seq - g_chunk_len + (g_t - g_chunk_start) + 1
+            )
             torch.minimum(
                 nsa_cache_seqlens,
-                per_token_cache,
+                global_causal_len,
                 out=nsa_cache_seqlens,
             )
             _mask_page_table_after_nsa_len(selected_indices, nsa_cache_seqlens)

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -563,6 +563,9 @@ class B12xMLASparseMetadataBuilder(AttentionMetadataBuilder[B12xMLASparseMetadat
 
         max_tokens = vllm_config.scheduler_config.max_num_batched_tokens
         max_seqs = vllm_config.scheduler_config.max_num_seqs
+        from vllm import envs as envs_mod
+
+        ckv_gather_requested = envs_mod.VLLM_B12X_MLA_CKV_GATHER
         # Max-batched-token scratch buffers so cudagraph capture sees stable
         # allocations (sliced per build()).
         self.cache_seq_lens_per_token_buffer = torch.empty(
@@ -584,21 +587,28 @@ class B12xMLASparseMetadataBuilder(AttentionMetadataBuilder[B12xMLASparseMetadat
             self.req_ids_arange = torch.arange(
                 max_tokens, dtype=torch.int32, device=device
             )
-            self.ckv_page_table_1_buffer = torch.empty(
-                (max_tokens, self.topk_tokens), dtype=torch.int32, device=device
-            )
-            self.ckv_nsa_cache_seqlens_buffer = torch.empty(
-                (max_tokens,), dtype=torch.int32, device=device
-            )
-            self.dcp_rank_req_lens_buffer = torch.empty(
-                (self.dcp_world_size, max_seqs), dtype=torch.int32, device=device
-            )
-            self.dcp_rank_req_starts_buffer = torch.empty(
-                (self.dcp_world_size, max_seqs), dtype=torch.int32, device=device
-            )
-            self.dcp_local_cu_seq_lens_buffer = torch.empty(
-                (max_seqs + 1,), dtype=torch.int32, device=device
-            )
+            if ckv_gather_requested:
+                self.ckv_page_table_1_buffer = torch.empty(
+                    (max_tokens, self.topk_tokens), dtype=torch.int32, device=device
+                )
+                self.ckv_nsa_cache_seqlens_buffer = torch.empty(
+                    (max_tokens,), dtype=torch.int32, device=device
+                )
+                self.dcp_rank_req_lens_buffer = torch.empty(
+                    (self.dcp_world_size, max_seqs), dtype=torch.int32, device=device
+                )
+                self.dcp_rank_req_starts_buffer = torch.empty(
+                    (self.dcp_world_size, max_seqs), dtype=torch.int32, device=device
+                )
+                self.dcp_local_cu_seq_lens_buffer = torch.empty(
+                    (max_seqs + 1,), dtype=torch.int32, device=device
+                )
+            else:
+                self.ckv_page_table_1_buffer = None
+                self.ckv_nsa_cache_seqlens_buffer = None
+                self.dcp_rank_req_lens_buffer = None
+                self.dcp_rank_req_starts_buffer = None
+                self.dcp_local_cu_seq_lens_buffer = None
         else:
             self.req_id_per_token_buffer = None
             self.page_table_1_buffer = None
@@ -863,7 +873,9 @@ class B12xMLASparseMetadataBuilder(AttentionMetadataBuilder[B12xMLASparseMetadat
             dcp_rank_req_lens=dcp_rank_req_lens,
             dcp_local_cu_seq_lens=dcp_local_cu_seq_lens,
             global_cache_seq_lens_per_req=(
-                cm.seq_lens[: cm.num_reqs] if use_dcp else None
+                cm.seq_lens[: cm.num_reqs]
+                if use_dcp and envs_mod.VLLM_B12X_MLA_CKV_GATHER
+                else None
             ),
             dcp_local_total_tokens=dcp_local_total_tokens,
             dcp_padded_total_tokens=dcp_padded_total_tokens,

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -169,7 +169,6 @@ def _env_int(name: str, default: int) -> int:
     return parsed
 
 
-
 def _get_ckv_gather_workspace(
     device: torch.device, nbytes: int
 ) -> torch.Tensor:
@@ -317,6 +316,9 @@ def _map_global_topk_to_gathered_ckv_kernel(
     valid_i32 = valid.to(tl.int32)
     local_offset = tl.cumsum(valid_i32) - valid_i32
     tile_valid_count = tl.sum(valid_i32)
+    # Tiles race to reserve output ranges via atomic_add, so the surviving
+    # slots land in an unspecified order within a row. Attention is a softmax
+    # over the selected set, so order does not affect the result.
     output_base = tl.atomic_add(valid_count_ptr + row, tile_valid_count)
     output_col = output_base + local_offset
     tl.store(
@@ -654,6 +656,17 @@ class B12xMLASparseMetadataBuilder(AttentionMetadataBuilder[B12xMLASparseMetadat
         dcp_ckv_gather_eligible = False
 
         from vllm import envs as envs_mod
+
+        if envs_mod.VLLM_B12X_MLA_CKV_GATHER:
+            # Reset the cross-layer prefetch pipeline once per step so the
+            # first layer always sync-gathers. The event/buf-idx are class
+            # state that would otherwise leak across chunks (the last layer
+            # of a chunk consumes but never re-arms), mis-scheduling layer 0
+            # of subsequent chunks onto a stale gathered buffer. The
+            # layer->cache registry is intentionally left intact (stable
+            # cache pointers across chunks).
+            B12xMLASparseImpl._shared_gather_event = None
+            B12xMLASparseImpl._shared_gather_buf_idx = 0
 
         if (
             use_dcp
@@ -1637,6 +1650,12 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
             + self._ckv_local_capacity * (self.dcp_world_size + 1)
         ]
         if stream is not None:
+            # The side stream must observe the default stream's prior writes
+            # to the paged KV cache (this and earlier steps' do_kv_cache_update)
+            # before gathering history off it; there is otherwise no ordering
+            # between the two streams in this direction. Enqueued before L's
+            # attention/MLP, so the prefetch still overlaps that compute.
+            stream.wait_stream(torch.cuda.current_stream())
             stream_ctx = torch.cuda.stream(stream)
         else:
             stream_ctx = torch.cuda.stream(torch.cuda.current_stream())
@@ -1652,9 +1671,20 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
             if local_tokens < padded_tokens:
                 local_buffer[local_tokens:padded_tokens].zero_()
 
-            from vllm.distributed.parallel_state import get_dcp_group
+            from vllm.distributed.parallel_state import (
+                get_dcp_ckv_prefetch_group,
+                get_dcp_group,
+            )
 
-            dcp_group = get_dcp_group()
+            # The prefetch (side stream) uses a dedicated communicator so it
+            # cannot collide with the indexer's DCP merge on the default
+            # stream; the synchronous path shares the default stream with the
+            # merge and is safe on the main DCP communicator.
+            dcp_group = (
+                get_dcp_ckv_prefetch_group()
+                if stream is not None
+                else get_dcp_group()
+            )
             _dcp_all_gather_current_stream(
                 dcp_group,
                 local_buffer[:padded_tokens].view(-1),
@@ -1678,6 +1708,29 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
     ) -> None:
         self._ckv_current_chunk_kv_c = kv_c_normed
         self._ckv_current_chunk_kpe = k_pe
+
+    def _resolve_layer_index(self, layer) -> int | None:
+        """Global layer index used to key the cross-layer prefetch registry.
+
+        ``MLAAttention`` exposes ``layer_name`` (a dotted prefix), not
+        ``layer_idx``; without this fallback the prefetch pipeline never
+        engages and every layer gathers synchronously on the critical path.
+        """
+        layer_idx = getattr(layer, "layer_idx", None)
+        if layer_idx is not None:
+            try:
+                return int(layer_idx)
+            except (TypeError, ValueError):
+                return None
+        layer_name = getattr(layer, "layer_name", None)
+        if not layer_name:
+            return None
+        from vllm.model_executor.models.utils import extract_layer_index
+
+        try:
+            return extract_layer_index(layer_name)
+        except (ValueError, AssertionError, IndexError):
+            return None
 
     def _append_current_chunk_to_gathered(
         self,
@@ -1716,10 +1769,22 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
         )
         global_seq_per_token = global_seq_lens[req_ids].to(torch.int32)
 
+        # Map each current-chunk token to its absolute position within its
+        # own sequence. ``num_actual_toks`` spans the whole batch, so the
+        # position must be computed per request: the current chunk holds the
+        # last ``chunk_len_r`` positions of request r, and this token is the
+        # ``(t - query_start_loc[r])``-th of them. Using the batch-global
+        # ``t``/``num_actual_toks`` is only correct for a single request and
+        # otherwise misplaces every request but the last.
+        query_start_loc = attn_metadata.query_start_loc[: num_reqs + 1].to(
+            torch.int32
+        )
+        req_chunk_start = query_start_loc[:-1][req_ids]
+        req_chunk_len = (query_start_loc[1:] - query_start_loc[:-1])[req_ids]
         t = torch.arange(
             num_actual_toks, device=self.device, dtype=torch.int32
         )
-        global_pos = global_seq_per_token - num_actual_toks + t
+        global_pos = global_seq_per_token - req_chunk_len + (t - req_chunk_start)
         owner = (
             (global_pos // interleave) % self.dcp_world_size
         ).to(torch.int64)
@@ -1730,7 +1795,11 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
 
         rank_req_starts = attn_metadata.dcp_rank_req_starts
         flat_idx = owner * num_reqs + req_ids
-        rank_start = rank_req_starts.view(-1)[flat_idx].to(torch.int64)
+        # ``dcp_rank_req_starts`` is a ``[dcp, :num_reqs]`` slice of a
+        # ``[dcp, max_seqs]`` buffer, so it is non-contiguous whenever
+        # ``num_reqs < max_seqs``; ``reshape`` compacts to row-length
+        # ``num_reqs`` to match ``flat_idx``. ``view`` would raise here.
+        rank_start = rank_req_starts.reshape(-1)[flat_idx].to(torch.int64)
 
         padded_tokens = attn_metadata.dcp_padded_total_tokens
         slots = (
@@ -2038,7 +2107,7 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
         if use_ckv_gather:
             if ckv_workspace is None:
                 raise RuntimeError("CKV gather workspace was not borrowed")
-            layer_idx = getattr(layer, "layer_idx", None)
+            layer_idx = self._resolve_layer_index(layer)
             if layer_idx is not None:
                 while len(B12xMLASparseImpl._all_layer_kv_caches) <= layer_idx:
                     B12xMLASparseImpl._all_layer_kv_caches.append(None)

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -78,6 +78,7 @@ _EXTEND_PREWARM_DONE: set[
     tuple[int | None, int, int, int, int, int, bool, str, bool]
 ] = set()
 _FP8_ROPE_WRITER_LOADED = False
+_CKV_GATHER_WORKSPACES: dict[tuple[str, int | None], torch.Tensor] = {}
 _KV_FP8_ROPE_REQUESTED = os.getenv("KV_FP8_ROPE", "0") == "1"
 
 
@@ -168,6 +169,64 @@ def _env_int(name: str, default: int) -> int:
     return parsed
 
 
+def _env_flag(name: str, default: bool = False) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.strip().lower() not in {"", "0", "false", "no", "off"}
+
+
+def _get_ckv_gather_workspace(
+    device: torch.device, nbytes: int
+) -> torch.Tensor:
+    key = (device.type, device.index)
+    workspace = _CKV_GATHER_WORKSPACES.get(key)
+    if workspace is None:
+        workspace = torch.empty((nbytes,), dtype=torch.uint8, device=device)
+        _CKV_GATHER_WORKSPACES[key] = workspace
+    elif workspace.numel() < nbytes:
+        raise RuntimeError(
+            "CKV gather workspace cannot grow after attention layers retain "
+            f"aliases: existing={workspace.numel()} requested={nbytes}"
+        )
+    return workspace[:nbytes]
+
+
+def _dcp_all_gather_current_stream(
+    group,
+    input_tensor: torch.Tensor,
+    output_tensor: torch.Tensor,
+) -> None:
+    if not input_tensor.is_contiguous() or not output_tensor.is_contiguous():
+        raise ValueError("CKV all-gather tensors must be contiguous")
+    if (
+        output_tensor.shape[0] != input_tensor.shape[0] * group.world_size
+        or output_tensor.shape[1:] != input_tensor.shape[1:]
+    ):
+        raise ValueError("CKV all-gather tensors have incompatible shapes")
+
+    communicator = getattr(group, "device_communicator", None)
+    pynccl_comm = getattr(communicator, "pynccl_comm", None)
+    if pynccl_comm is not None and not getattr(pynccl_comm, "disabled", False):
+        pynccl_comm.all_gather(output_tensor, input_tensor)
+        return
+
+    device_group = getattr(group, "device_group", None)
+    if device_group is None:
+        device_group = getattr(communicator, "device_group", None)
+    if device_group is not None:
+        dist.all_gather_into_tensor(
+            output_tensor,
+            input_tensor,
+            group=device_group,
+            async_op=False,
+        )
+        return
+
+    gathered = group.all_gather(input_tensor, dim=0)
+    output_tensor.copy_(gathered)
+
+
 @triton.jit
 def _mask_page_table_after_nsa_len_kernel(
     page_table_ptr,
@@ -206,6 +265,130 @@ def _mask_page_table_after_nsa_len(
         page_table.stride(1),
         width,
         BLOCK_N=block_n,
+    )
+
+
+@triton.jit
+def _map_global_topk_to_gathered_ckv_kernel(
+    req_id_ptr,
+    token_indices_ptr,
+    rank_req_starts_ptr,
+    rank_req_lens_ptr,
+    out_ptr,
+    valid_count_ptr,
+    starts_stride0,
+    starts_stride1,
+    lens_stride0,
+    lens_stride1,
+    ti_stride0,
+    ti_stride1,
+    out_stride0,
+    out_stride1,
+    padded_rank_tokens,
+    DCP_SIZE: tl.constexpr,
+    DCP_INTERLEAVE: tl.constexpr,
+    NUM_TOPK_TOKENS: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    row = tl.program_id(0)
+    tile = tl.program_id(1)
+    cols = tile * BLOCK_N + tl.arange(0, BLOCK_N)
+    col_mask = cols < NUM_TOPK_TOKENS
+
+    req = tl.load(req_id_ptr + row)
+    tok = tl.load(
+        token_indices_ptr + row * ti_stride0 + cols * ti_stride1,
+        mask=col_mask,
+        other=-1,
+    )
+    owner = (tok // DCP_INTERLEAVE) % DCP_SIZE
+    local_idx = (
+        tok // (DCP_SIZE * DCP_INTERLEAVE)
+    ) * DCP_INTERLEAVE + tok % DCP_INTERLEAVE
+    req_start = tl.load(
+        rank_req_starts_ptr
+        + owner * starts_stride0
+        + req * starts_stride1,
+        mask=col_mask & (tok >= 0),
+        other=0,
+    )
+    req_len = tl.load(
+        rank_req_lens_ptr + owner * lens_stride0 + req * lens_stride1,
+        mask=col_mask & (tok >= 0),
+        other=0,
+    )
+    valid = col_mask & (tok >= 0) & (local_idx >= 0) & (local_idx < req_len)
+    gathered_slot = owner * padded_rank_tokens + req_start + local_idx
+
+    valid_i32 = valid.to(tl.int32)
+    local_offset = tl.cumsum(valid_i32) - valid_i32
+    tile_valid_count = tl.sum(valid_i32)
+    output_base = tl.atomic_add(valid_count_ptr + row, tile_valid_count)
+    output_col = output_base + local_offset
+    tl.store(
+        out_ptr + row * out_stride0 + output_col * out_stride1,
+        gathered_slot,
+        mask=valid,
+    )
+
+
+def _map_global_topk_to_gathered_ckv(
+    req_ids: torch.Tensor,
+    token_indices: torch.Tensor,
+    rank_req_starts: torch.Tensor,
+    rank_req_lens: torch.Tensor,
+    out: torch.Tensor,
+    valid_counts: torch.Tensor,
+    *,
+    dcp_size: int,
+    cp_kv_cache_interleave_size: int,
+    padded_rank_tokens: int,
+) -> None:
+    if token_indices.shape != out.shape:
+        raise ValueError("CKV gather index output shape does not match top-k input")
+    if rank_req_starts.shape != rank_req_lens.shape:
+        raise ValueError("CKV gather request starts/lens shapes do not match")
+    if rank_req_starts.shape[0] != dcp_size:
+        raise ValueError("CKV gather request metadata does not match DCP size")
+    if any(
+        tensor.dtype != torch.int32
+        for tensor in (
+            req_ids,
+            token_indices,
+            rank_req_starts,
+            rank_req_lens,
+            out,
+            valid_counts,
+        )
+    ):
+        raise TypeError("CKV gather index metadata must be int32")
+    if token_indices.shape[1] % 128 != 0:
+        raise ValueError("CKV gather top-k width must be divisible by 128")
+
+    out.fill_(-1)
+    valid_counts.zero_()
+    _map_global_topk_to_gathered_ckv_kernel[
+        (token_indices.shape[0], token_indices.shape[1] // 128)
+    ](
+        req_ids,
+        token_indices,
+        rank_req_starts,
+        rank_req_lens,
+        out,
+        valid_counts,
+        rank_req_starts.stride(0),
+        rank_req_starts.stride(1),
+        rank_req_lens.stride(0),
+        rank_req_lens.stride(1),
+        token_indices.stride(0),
+        token_indices.stride(1),
+        out.stride(0),
+        out.stride(1),
+        padded_rank_tokens,
+        DCP_SIZE=dcp_size,
+        DCP_INTERLEAVE=cp_kv_cache_interleave_size,
+        NUM_TOPK_TOKENS=token_indices.shape[1],
+        BLOCK_N=128,
     )
 
 
@@ -341,6 +524,17 @@ class B12xMLASparseMetadata(AttentionMetadata):
     # For pure decode this equals ``seq_lens`` (one token per request).
     cache_seq_lens_per_token: torch.Tensor
 
+    # Transient full-CKV prefill gather metadata.
+    ckv_page_table_1: torch.Tensor | None = None
+    ckv_nsa_cache_seqlens: torch.Tensor | None = None
+    dcp_rank_req_starts: torch.Tensor | None = None
+    dcp_rank_req_lens: torch.Tensor | None = None
+    dcp_local_cu_seq_lens: torch.Tensor | None = None
+    global_cache_seq_lens_per_req: torch.Tensor | None = None
+    dcp_local_total_tokens: int = 0
+    dcp_padded_total_tokens: int = 0
+    dcp_ckv_gather_eligible: bool = False
+
     block_size: int = 64
     topk_tokens: int = 2048
 
@@ -398,11 +592,31 @@ class B12xMLASparseMetadataBuilder(AttentionMetadataBuilder[B12xMLASparseMetadat
             self.req_ids_arange = torch.arange(
                 max_tokens, dtype=torch.int32, device=device
             )
+            self.ckv_page_table_1_buffer = torch.empty(
+                (max_tokens, self.topk_tokens), dtype=torch.int32, device=device
+            )
+            self.ckv_nsa_cache_seqlens_buffer = torch.empty(
+                (max_tokens,), dtype=torch.int32, device=device
+            )
+            self.dcp_rank_req_lens_buffer = torch.empty(
+                (self.dcp_world_size, max_seqs), dtype=torch.int32, device=device
+            )
+            self.dcp_rank_req_starts_buffer = torch.empty(
+                (self.dcp_world_size, max_seqs), dtype=torch.int32, device=device
+            )
+            self.dcp_local_cu_seq_lens_buffer = torch.empty(
+                (max_seqs + 1,), dtype=torch.int32, device=device
+            )
         else:
             self.req_id_per_token_buffer = None
             self.page_table_1_buffer = None
             self.nsa_cache_seqlens_buffer = None
             self.req_ids_arange = None
+            self.ckv_page_table_1_buffer = None
+            self.ckv_nsa_cache_seqlens_buffer = None
+            self.dcp_rank_req_lens_buffer = None
+            self.dcp_rank_req_starts_buffer = None
+            self.dcp_local_cu_seq_lens_buffer = None
 
     def build(
         self,
@@ -438,6 +652,67 @@ class B12xMLASparseMetadataBuilder(AttentionMetadataBuilder[B12xMLASparseMetadat
             else cm.seq_lens
         )
         req_id_per_token_tensor = None
+        dcp_rank_req_lens = None
+        dcp_rank_req_starts = None
+        dcp_local_cu_seq_lens = None
+        dcp_local_total_tokens = 0
+        dcp_padded_total_tokens = 0
+        dcp_ckv_gather_eligible = False
+
+        from vllm import envs as envs_mod
+
+        if (
+            use_dcp
+            and envs_mod.VLLM_B12X_MLA_CKV_GATHER
+            and num_decode_tokens == 0
+            and num_prefill_tokens == num_tokens
+            and cm.max_query_len
+            > envs_mod.VLLM_B12X_MLA_CKV_GATHER_MIN_TOKENS
+        ):
+            assert self.dcp_rank_req_lens_buffer is not None
+            assert self.dcp_rank_req_starts_buffer is not None
+            assert self.dcp_local_cu_seq_lens_buffer is not None
+            global_seq_lens = cm.seq_lens[: cm.num_reqs]
+            all_rank_lens = get_dcp_local_seq_lens(
+                global_seq_lens,
+                self.dcp_world_size,
+                dcp_rank=None,
+                cp_kv_cache_interleave_size=self.cp_kv_cache_interleave_size,
+            ).transpose(0, 1)
+            dcp_rank_req_lens = self.dcp_rank_req_lens_buffer[
+                : self.dcp_world_size, : cm.num_reqs
+            ]
+            dcp_rank_req_lens.copy_(all_rank_lens)
+            dcp_rank_req_starts = self.dcp_rank_req_starts_buffer[
+                : self.dcp_world_size, : cm.num_reqs
+            ]
+            dcp_rank_req_starts[:, 0].zero_()
+            if cm.num_reqs > 1:
+                torch.cumsum(
+                    dcp_rank_req_lens[:, :-1],
+                    dim=1,
+                    out=dcp_rank_req_starts[:, 1:],
+                )
+
+            dcp_local_cu_seq_lens = self.dcp_local_cu_seq_lens_buffer[
+                : cm.num_reqs + 1
+            ]
+            dcp_local_cu_seq_lens[0].zero_()
+            torch.cumsum(
+                dcp_rank_req_lens[self.dcp_rank],
+                dim=0,
+                out=dcp_local_cu_seq_lens[1:],
+            )
+            rank_totals = dcp_rank_req_lens.sum(dim=1).tolist()
+            dcp_local_total_tokens = int(rank_totals[self.dcp_rank])
+            dcp_padded_total_tokens = (
+                _cdiv(
+                    max(int(total) for total in rank_totals),
+                    self.kv_cache_spec.block_size,
+                )
+                * self.kv_cache_spec.block_size
+            )
+            dcp_ckv_gather_eligible = dcp_padded_total_tokens > 0
 
         # Per-token causal KV length. In pure decode the common metadata already
         # has exactly the graph-stable tensor both b12x consumers need, so bind it
@@ -574,6 +849,25 @@ class B12xMLASparseMetadataBuilder(AttentionMetadataBuilder[B12xMLASparseMetadat
             seq_lens=cache_seq_lens_per_req,
             cache_seq_lens_per_req=cache_seq_lens_per_req,
             cache_seq_lens_per_token=cache_seq_lens_per_token,
+            ckv_page_table_1=(
+                self.ckv_page_table_1_buffer[:num_tokens]
+                if self.ckv_page_table_1_buffer is not None
+                else None
+            ),
+            ckv_nsa_cache_seqlens=(
+                self.ckv_nsa_cache_seqlens_buffer[:num_tokens]
+                if self.ckv_nsa_cache_seqlens_buffer is not None
+                else None
+            ),
+            dcp_rank_req_starts=dcp_rank_req_starts,
+            dcp_rank_req_lens=dcp_rank_req_lens,
+            dcp_local_cu_seq_lens=dcp_local_cu_seq_lens,
+            global_cache_seq_lens_per_req=(
+                cm.seq_lens[: cm.num_reqs] if use_dcp else None
+            ),
+            dcp_local_total_tokens=dcp_local_total_tokens,
+            dcp_padded_total_tokens=dcp_padded_total_tokens,
+            dcp_ckv_gather_eligible=dcp_ckv_gather_eligible,
             block_size=self.kv_cache_spec.block_size,
             topk_tokens=self.topk_tokens,
         )
@@ -850,6 +1144,90 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
         self._workspace_specs = tuple(workspace_specs)
         self._borrow_workspaces()
         self._prewarm_extend_kernels_once(max_batched)
+
+        # CKV gather setup (Fix B).
+        from vllm import envs as envs_mod
+
+        ckv_gather_requested = envs_mod.VLLM_B12X_MLA_CKV_GATHER
+        self._ckv_gather_enabled = ckv_gather_requested and (
+            self.dcp_world_size > 1
+            and self.num_heads % _HEAD_ALIGNMENT == 0
+            and self.dcp_workspace_non_dbo
+        )
+        if ckv_gather_requested and not self._ckv_gather_enabled:
+            logger.warning_once(
+                "Ignoring VLLM_B12X_MLA_CKV_GATHER on unsupported "
+                "topology: dcp=%d local_heads=%d DBO=%s",
+                self.dcp_world_size,
+                self.num_heads,
+                not self.dcp_workspace_non_dbo,
+            )
+        self._ckv_kernel_num_heads = self.num_heads
+        self._ckv_gather_max_tokens = envs_mod.VLLM_B12X_MLA_CKV_GATHER_MAX_TOKENS
+        self._ckv_gather_min_tokens = envs_mod.VLLM_B12X_MLA_CKV_GATHER_MIN_TOKENS
+        self._ckv_local_capacity = (
+            _cdiv(
+                _cdiv(self._ckv_gather_max_tokens, max(1, self.dcp_world_size))
+                + max_num_seqs * self.cp_kv_cache_interleave_size,
+                self.block_size,
+            )
+            * self.block_size
+        )
+        self._ckv_workspace_nbytes = (
+            2
+            * (self.dcp_world_size + 1)
+            * self._ckv_local_capacity
+            * self._kv_record_bytes
+            if self._ckv_gather_enabled
+            else 0
+        )
+        self._ckv_workspace = (
+            _get_ckv_gather_workspace(self.device, self._ckv_workspace_nbytes)
+            if self._ckv_gather_enabled
+            else None
+        )
+
+        # Separate extend plan for the gathered-cache path: full local heads
+        # (no head all-gather), global seq lens.
+        if self._ckv_gather_enabled:
+            self._ckv_extend_plan = _make_plan(
+                "extend", max_batched, self._ckv_kernel_num_heads, max_num_seqs
+            )
+            self._scratch_nbytes = max(
+                self._scratch_nbytes,
+                int(self._ckv_extend_plan.layout.nbytes),
+            )
+        else:
+            self._ckv_extend_plan = None
+
+        # Layer prefetch (side stream + events + ping-pong).
+        # _shared_* are class-level: layer L kicks off the prefetch for
+        # layer L+1, and layer L+1 (a different impl instance) consumes it.
+        self._ckv_prefetch_supported = self._ckv_gather_enabled and (
+            self.kv_cache_dtype == "fp8_ds_mla" or self._kv_fp8_rope
+        )
+        if self._ckv_gather_enabled:
+            self._ckv_gather_stream = torch.cuda.Stream(device=self.device)
+            self._ckv_current_chunk_kv_c: torch.Tensor | None = None
+            self._ckv_current_chunk_kpe: torch.Tensor | None = None
+            B12xMLASparseImpl._all_layer_kv_caches: list[
+                torch.Tensor | None
+            ] = []
+            B12xMLASparseImpl._shared_gather_event: (
+                torch.cuda.Event | None
+            ) = None
+            B12xMLASparseImpl._shared_gather_buf_idx = 0
+            if not self._ckv_prefetch_supported:
+                logger.warning_once(
+                    "CKV gather prefetch disabled for kv_cache_dtype=%s "
+                    "(KV_FP8_ROPE=%s); falling back to synchronous gather.",
+                    self.kv_cache_dtype,
+                    int(self._kv_fp8_rope),
+                )
+        else:
+            self._ckv_gather_stream = None
+            self._ckv_current_chunk_kv_c = None
+            self._ckv_current_chunk_kpe = None
 
         # Q arrives BF16; the unified kernel quantizes inside.
         self.supports_quant_query_input = False
@@ -1183,6 +1561,207 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
             raise RuntimeError("DCP reduce-scatter output is not contiguous")
         return output
 
+    def _validate_ckv_workspace(self, ckv_workspace: torch.Tensor) -> None:
+        if not self._ckv_gather_enabled:
+            raise RuntimeError("CKV gather workspace requested while disabled")
+        if (
+            tuple(ckv_workspace.shape) != (self._ckv_workspace_nbytes,)
+            or ckv_workspace.dtype != torch.uint8
+            or ckv_workspace.device != self.device
+            or not ckv_workspace.is_contiguous()
+        ):
+            raise RuntimeError("B12X CKV gather borrowed an invalid workspace")
+
+    def dcp_prefill_ckv_gather_eligible(
+        self,
+        attn_metadata: B12xMLASparseMetadata,
+        num_tokens: int,
+    ) -> bool:
+        if not self._ckv_gather_enabled:
+            return False
+        if torch.cuda.is_current_stream_capturing():
+            return False
+        if (
+            not attn_metadata.dcp_ckv_gather_eligible
+            or attn_metadata.num_decode_tokens != 0
+            or attn_metadata.num_prefill_tokens != attn_metadata.num_actual_tokens
+            or int(num_tokens) != attn_metadata.num_actual_tokens
+            or int(num_tokens) <= self._ckv_gather_min_tokens
+            or attn_metadata.dcp_padded_total_tokens > self._ckv_local_capacity
+            or attn_metadata.dcp_local_total_tokens
+            > attn_metadata.dcp_padded_total_tokens
+        ):
+            return False
+        return all(
+            tensor is not None
+            for tensor in (
+                attn_metadata.req_id_per_token,
+                attn_metadata.ckv_page_table_1,
+                attn_metadata.ckv_nsa_cache_seqlens,
+                attn_metadata.dcp_rank_req_starts,
+                attn_metadata.dcp_rank_req_lens,
+                attn_metadata.dcp_local_cu_seq_lens,
+            )
+        )
+
+    def _dcp_gather_ckv(
+        self,
+        kv_cache: torch.Tensor,
+        attn_metadata: B12xMLASparseMetadata,
+        ckv_workspace: torch.Tensor,
+        buf_idx: int = 0,
+        stream: torch.cuda.Stream | None = None,
+    ) -> torch.Tensor:
+        if not self.dcp_prefill_ckv_gather_eligible(
+            attn_metadata, attn_metadata.num_actual_tokens
+        ):
+            raise RuntimeError("CKV gather called for an ineligible attention batch")
+        if (
+            kv_cache.dtype != torch.uint8
+            or kv_cache.ndim != 3
+            or tuple(kv_cache.shape[1:]) != (self.block_size, self._kv_record_bytes)
+            or not kv_cache.is_contiguous()
+        ):
+            raise ValueError(
+                "CKV gather requires contiguous native paged KV cache pages"
+            )
+
+        assert attn_metadata.dcp_local_cu_seq_lens is not None
+        padded_tokens = attn_metadata.dcp_padded_total_tokens
+        local_tokens = attn_metadata.dcp_local_total_tokens
+        self._validate_ckv_workspace(ckv_workspace)
+        half_nbytes = (
+            (self.dcp_world_size + 1)
+            * self._ckv_local_capacity
+            * self._kv_record_bytes
+        )
+        ws_half = ckv_workspace.view(-1, self._kv_record_bytes)
+        base = buf_idx * (half_nbytes // self._kv_record_bytes)
+        local_buffer = ws_half[base : base + self._ckv_local_capacity]
+        gathered_buffer = ws_half[
+            base + self._ckv_local_capacity : base
+            + self._ckv_local_capacity * (self.dcp_world_size + 1)
+        ]
+        if stream is not None:
+            stream_ctx = torch.cuda.stream(stream)
+        else:
+            stream_ctx = torch.cuda.stream(torch.cuda.current_stream())
+        with stream_ctx:
+            if local_tokens:
+                ops.cp_gather_cache(
+                    src_cache=kv_cache,
+                    dst=local_buffer[:local_tokens],
+                    block_table=attn_metadata.block_table,
+                    cu_seq_lens=attn_metadata.dcp_local_cu_seq_lens,
+                    batch_size=attn_metadata.num_reqs,
+                )
+            if local_tokens < padded_tokens:
+                local_buffer[local_tokens:padded_tokens].zero_()
+
+            from vllm.distributed.parallel_state import get_dcp_group
+
+            dcp_group = get_dcp_group()
+            _dcp_all_gather_current_stream(
+                dcp_group,
+                local_buffer[:padded_tokens].view(-1),
+                gathered_buffer[: self.dcp_world_size * padded_tokens].view(-1),
+            )
+        gathered_tokens = gathered_buffer[
+            : self.dcp_world_size * self._ckv_local_capacity
+        ]
+        return gathered_tokens.view(
+            -1, self.block_size, self._kv_record_bytes
+        )
+
+    def set_ckv_current_chunk_kv(
+        self, kv_c_normed: torch.Tensor, k_pe: torch.Tensor
+    ) -> None:
+        self._ckv_current_chunk_kv_c = kv_c_normed
+        self._ckv_current_chunk_kpe = k_pe
+
+    def _append_current_chunk_to_gathered(
+        self,
+        gathered_buffer: torch.Tensor,
+        attn_metadata: "B12xMLASparseMetadata",
+        layer,
+        num_actual_toks: int,
+    ) -> None:
+        """Write the current chunk's BF16 KV into the gathered buffer for
+        all DCP ranks.  Every rank already holds the full BF16 latent; the
+        normal ``do_kv_cache_update`` only writes this rank's interleaved
+        subset to the paged cache.  The prefetch gathered history from the
+        next layer's cache *before* that layer's ``do_kv_cache_update``
+        ran, so the current chunk is missing.  This method writes all
+        tokens — not just the local rank's share — into the correct slots
+        of the rank-ordered gathered buffer.
+        """
+        if (
+            self._ckv_current_chunk_kv_c is None
+            or num_actual_toks == 0
+        ):
+            return
+        kv_c = self._ckv_current_chunk_kv_c[:num_actual_toks]
+        k_pe_flat = self._ckv_current_chunk_kpe[:num_actual_toks]
+        if k_pe_flat.ndim == 3:
+            k_pe_flat = k_pe_flat.squeeze(1)
+
+        num_reqs = attn_metadata.num_reqs
+        interleave = self.cp_kv_cache_interleave_size
+        global_seq_lens = attn_metadata.global_cache_seq_lens_per_req
+        if global_seq_lens is None:
+            return
+        global_seq_lens = global_seq_lens[:num_reqs]
+        req_ids = attn_metadata.req_id_per_token[:num_actual_toks].to(
+            torch.int64
+        )
+        global_seq_per_token = global_seq_lens[req_ids].to(torch.int32)
+
+        t = torch.arange(
+            num_actual_toks, device=self.device, dtype=torch.int32
+        )
+        global_pos = global_seq_per_token - num_actual_toks + t
+        owner = (
+            (global_pos // interleave) % self.dcp_world_size
+        ).to(torch.int64)
+        local_pos = (
+            global_pos // (self.dcp_world_size * interleave) * interleave
+            + global_pos % interleave
+        ).to(torch.int64)
+
+        rank_req_starts = attn_metadata.dcp_rank_req_starts
+        flat_idx = owner * num_reqs + req_ids
+        rank_start = rank_req_starts.view(-1)[flat_idx].to(torch.int64)
+
+        padded_tokens = attn_metadata.dcp_padded_total_tokens
+        slots = (
+            owner * int(padded_tokens) + rank_start + local_pos
+        )
+
+        k_scale = getattr(layer, "_k_scale", None)
+        if self._kv_fp8_rope:
+            torch.ops._C_fp8_rope_ops.concat_and_cache_nvfp4_mla_fp8_rope(
+                kv_c,
+                k_pe_flat,
+                gathered_buffer,
+                slots,
+                k_scale,
+            )
+        elif self.kv_cache_dtype == "fp8_ds_mla":
+            ops.concat_and_cache_mla(
+                kv_c,
+                k_pe_flat,
+                gathered_buffer,
+                slots,
+                self.kv_cache_dtype,
+                k_scale,
+            )
+        else:
+            raise RuntimeError(
+                "CKV gather prefetch append is not yet supported for "
+                f"kv_cache_dtype={self.kv_cache_dtype!r}; disable prefetch "
+                "or use fp8_ds_mla / KV_FP8_ROPE."
+            )
+
     def _sync_warmup(self) -> None:
         if self.device.type == "cuda":
             torch.accelerator.synchronize(self.device)
@@ -1303,38 +1882,50 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
         # launch receives this as a runtime scalar.
         latent_scale = float(getattr(layer, "_nvfp4_mla_outer_scale", 1.0))
         kernel_format_kwargs = self._b12x_kernel_format_kwargs(latent_scale)
-        # q arrives as (mqa_ql_nope[T, H, kv_lora_rank], mqa_q_pe[T, H, rope]);
-        # b12x's GLM_NSA contract wants a single contiguous [T, H, 576] tensor.
-        # Co-allocate the q-concat buffer and the per-call attention scratch in ONE
-        # get_simultaneous call so they receive distinct, non-overlapping offsets:
-        # the kernel reads q while writing the scratch (tmp_output/output), and the
-        # manager packs every call from offset 0, so separate calls would alias q
-        # with the scratch and corrupt the result.
+        query_rows = q[0].shape[0] if isinstance(q, tuple) else q.shape[0]
+        use_ckv_gather = self.dcp_prefill_ckv_gather_eligible(
+            attn_metadata, int(query_rows)
+        )
         workspace_tensors = self._borrow_workspaces()
         q_workspace = workspace_tensors[0]
         dense_out_workspace = workspace_tensors[1] if self._pad_heads else None
+        ckv_workspace = self._ckv_workspace
         scratch_storage = workspace_tensors[-1]
+        expected_input_heads = (
+            self.num_heads if use_ckv_gather else self._input_num_heads
+        )
+        if use_ckv_gather:
+            local_q_numel = (
+                self._max_batched * self._ckv_kernel_num_heads * self.q_head_dim
+            )
+            q_buffer = q_workspace.view(-1)[:local_q_numel].view(
+                self._max_batched,
+                self._ckv_kernel_num_heads,
+                self.q_head_dim,
+            )
+        else:
+            q_buffer = q_workspace
         if isinstance(q, tuple):
             ql_nope, q_pe = q
             num_actual_toks = ql_nope.shape[0]
             num_input_heads = ql_nope.shape[1]
-            if num_input_heads != self._input_num_heads:
+            if num_input_heads != expected_input_heads:
                 raise ValueError(
                     "B12X_MLA_SPARSE query heads do not match the planned "
-                    f"head count: {num_input_heads} != {self._input_num_heads}."
+                    f"head count: {num_input_heads} != {expected_input_heads}."
                 )
-            q_buffer = q_workspace[:num_actual_toks]
+            q_buffer = q_buffer[:num_actual_toks]
             q_all = q_buffer[:, :num_input_heads]
             ops.concat_mla_q(ql_nope, q_pe, q_all)
         else:
             num_actual_toks = q.shape[0]
             num_input_heads = q.shape[1]
-            if num_input_heads != self._input_num_heads:
+            if num_input_heads != expected_input_heads:
                 raise ValueError(
                     "B12X_MLA_SPARSE query heads do not match the planned "
-                    f"head count: {num_input_heads} != {self._input_num_heads}."
+                    f"head count: {num_input_heads} != {expected_input_heads}."
                 )
-            q_buffer = q_workspace[:num_actual_toks]
+            q_buffer = q_buffer[:num_actual_toks]
             q_all = q_buffer[:, :num_input_heads]
             exact_workspace_alias = (
                 tuple(q.shape) == tuple(q_all.shape)
@@ -1350,7 +1941,36 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
         assert self.topk_indices_buffer is not None
         topk_indices = self.topk_indices_buffer[:num_actual_toks]
         per_token_cache = attn_metadata.cache_seq_lens_per_token[:num_actual_toks]
-        if self.dcp_world_size > 1:
+        if use_ckv_gather:
+            assert attn_metadata.req_id_per_token is not None
+            assert attn_metadata.ckv_page_table_1 is not None
+            assert attn_metadata.ckv_nsa_cache_seqlens is not None
+            assert attn_metadata.dcp_rank_req_starts is not None
+            assert attn_metadata.dcp_rank_req_lens is not None
+            selected_indices = attn_metadata.ckv_page_table_1[
+                :num_actual_toks, : topk_indices.shape[1]
+            ]
+            nsa_cache_seqlens = attn_metadata.ckv_nsa_cache_seqlens[
+                :num_actual_toks
+            ]
+            _map_global_topk_to_gathered_ckv(
+                attn_metadata.req_id_per_token[:num_actual_toks],
+                topk_indices,
+                attn_metadata.dcp_rank_req_starts,
+                attn_metadata.dcp_rank_req_lens,
+                selected_indices,
+                nsa_cache_seqlens,
+                dcp_size=self.dcp_world_size,
+                cp_kv_cache_interleave_size=self.cp_kv_cache_interleave_size,
+                padded_rank_tokens=attn_metadata.dcp_padded_total_tokens,
+            )
+            torch.minimum(
+                nsa_cache_seqlens,
+                per_token_cache,
+                out=nsa_cache_seqlens,
+            )
+            _mask_page_table_after_nsa_len(selected_indices, nsa_cache_seqlens)
+        elif self.dcp_world_size > 1:
             # The indexer globally merges logical top-k ids across DCP ranks.
             # Compact just this rank's winners into local physical cache slots;
             # the outer MLA layer combines the rank-local outputs using LSE.
@@ -1415,6 +2035,69 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
                 "B12X_MLA_SPARSE requires a contiguous native paged KV cache; "
                 f"got stride={tuple(kv_cache.stride())}"
             )
+        if use_ckv_gather:
+            if ckv_workspace is None:
+                raise RuntimeError("CKV gather workspace was not borrowed")
+            layer_idx = getattr(layer, "layer_idx", None)
+            if layer_idx is not None:
+                while len(B12xMLASparseImpl._all_layer_kv_caches) <= layer_idx:
+                    B12xMLASparseImpl._all_layer_kv_caches.append(None)
+                B12xMLASparseImpl._all_layer_kv_caches[layer_idx] = kv_cache
+            if B12xMLASparseImpl._shared_gather_event is not None:
+                B12xMLASparseImpl._shared_gather_event.wait()
+                half_nbytes = (
+                    (self.dcp_world_size + 1)
+                    * self._ckv_local_capacity
+                    * self._kv_record_bytes
+                )
+                ws_half = ckv_workspace.view(-1, self._kv_record_bytes)
+                base = B12xMLASparseImpl._shared_gather_buf_idx * (
+                    half_nbytes // self._kv_record_bytes
+                )
+                gathered_buffer = ws_half[
+                    base
+                    + self._ckv_local_capacity : base
+                    + self._ckv_local_capacity
+                    * (self.dcp_world_size + 1)
+                ]
+                kv_cache = gathered_buffer[
+                    : self.dcp_world_size * self._ckv_local_capacity
+                ].view(-1, self.block_size, self._kv_record_bytes)
+                self._append_current_chunk_to_gathered(
+                    kv_cache, attn_metadata, layer, num_actual_toks
+                )
+            else:
+                kv_cache = self._dcp_gather_ckv(
+                    kv_cache, attn_metadata, ckv_workspace
+                )
+            logger.info_once(
+                "Using transient full-CKV gather for B12X sparse MLA prefill "
+                "(capacity=%d logical tokens)",
+                self._ckv_gather_max_tokens,
+            )
+            if (
+                self._ckv_prefetch_supported
+                and layer_idx is not None
+                and layer_idx + 1 < len(B12xMLASparseImpl._all_layer_kv_caches)
+                and B12xMLASparseImpl._all_layer_kv_caches[layer_idx + 1]
+                is not None
+            ):
+                next_kv = B12xMLASparseImpl._all_layer_kv_caches[layer_idx + 1]
+                next_buf_idx = 1 - B12xMLASparseImpl._shared_gather_buf_idx
+                self._dcp_gather_ckv(
+                    next_kv,
+                    attn_metadata,
+                    ckv_workspace,
+                    buf_idx=next_buf_idx,
+                    stream=self._ckv_gather_stream,
+                )
+                B12xMLASparseImpl._shared_gather_event = torch.cuda.Event(
+                    blocking=False
+                )
+                B12xMLASparseImpl._shared_gather_event.record(
+                    self._ckv_gather_stream
+                )
+                B12xMLASparseImpl._shared_gather_buf_idx = next_buf_idx
 
         use_decode_kernel = attn_metadata.max_query_len <= 1 or (
             self.spec_extend_as_decode
@@ -1484,15 +2167,25 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
             # Extend / prefill -> single-pass unified prefill (no split-K
             # scratch needed; only output_buffer is read). b12x supports 8-head
             # granularity, so only a non-aligned local tail is padded here.
-            cache_seqlens = attn_metadata.cache_seq_lens_per_req
+            if use_ckv_gather:
+                if attn_metadata.global_cache_seq_lens_per_req is None:
+                    raise RuntimeError(
+                        "CKV gather is missing global sequence lengths"
+                    )
+                cache_seqlens = attn_metadata.global_cache_seq_lens_per_req
+            else:
+                cache_seqlens = attn_metadata.cache_seq_lens_per_req
             prefill_q = q_all
-            if self._pad_heads:
+            if self._pad_heads and not use_ckv_gather:
                 prefill_q = q_buffer[:, : self._kernel_num_heads]
                 prefill_q[:, self._input_num_heads :, :].zero_()
 
-            # Eager bind into the extend views container (single-pass prefill;
-            # no split-K, output_buffer is the only scratch the kernel writes).
-            binding = self._extend_plan.bind(
+            extend_plan = (
+                self._ckv_extend_plan if use_ckv_gather else self._extend_plan
+            )
+            if extend_plan is None:
+                raise RuntimeError("CKV gather extend plan was not initialized")
+            binding = extend_plan.bind(
                 scratch=scratch_storage,
                 q=prefill_q,
                 selected_indices=selected_indices,
@@ -1500,7 +2193,7 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
                 nsa_cache_seqlens_int32=nsa_cache_seqlens,
             )
             lse = None
-            if self.need_to_return_lse_for_decode:
+            if self.need_to_return_lse_for_decode and not use_ckv_gather:
                 out, lse = cast(
                     tuple[torch.Tensor, torch.Tensor],
                     self._sparse_mla_extend_forward(
@@ -1524,7 +2217,7 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
                         **kernel_format_kwargs,
                     ),
                 )
-            if self._pad_heads:
+            if self._pad_heads and not use_ckv_gather:
                 assert dense_out_workspace is not None
                 dense_out = dense_out_workspace[:num_actual_toks]
                 dense_out.copy_(out[:, : self._input_num_heads, :])

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -169,12 +169,6 @@ def _env_int(name: str, default: int) -> int:
     return parsed
 
 
-def _env_flag(name: str, default: bool = False) -> bool:
-    value = os.getenv(name)
-    if value is None:
-        return default
-    return value.strip().lower() not in {"", "0", "false", "no", "off"}
-
 
 def _get_ckv_gather_workspace(
     device: torch.device, nbytes: int
@@ -1666,6 +1660,12 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
                 local_buffer[:padded_tokens].view(-1),
                 gathered_buffer[: self.dcp_world_size * padded_tokens].view(-1),
             )
+        # Keep the cache geometry stable across requests. CuTe/B12X caches the
+        # compiled prefill launch, while ``padded_tokens`` grows with context;
+        # exposing a differently sized first dimension on every request can
+        # reuse a launch specialized for an earlier, smaller cache. The live
+        # records remain packed in the prefix and selected indices are still
+        # based on ``padded_tokens``, so the unused capacity is unreachable.
         gathered_tokens = gathered_buffer[
             : self.dcp_world_size * self._ckv_local_capacity
         ]

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -259,6 +259,27 @@ def _mask_page_table_after_nsa_len(
     )
 
 
+def _global_causal_lens_for_ckv_gather(
+    global_seq_lens: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    req_id_per_token: torch.Tensor,
+    num_actual_toks: int,
+) -> torch.Tensor:
+    """Return each query token's causal length in the gathered global cache."""
+    num_reqs = global_seq_lens.shape[0]
+    qsl = query_start_loc[: num_reqs + 1].to(torch.int32)
+    req_ids = req_id_per_token[:num_actual_toks].to(torch.int64)
+    chunk_start = qsl[:-1][req_ids]
+    chunk_len = (qsl[1:] - qsl[:-1])[req_ids]
+    full_seq = global_seq_lens[req_ids].to(torch.int32)
+    token_idx = torch.arange(
+        num_actual_toks,
+        device=global_seq_lens.device,
+        dtype=torch.int32,
+    )
+    return full_seq - chunk_len + (token_idx - chunk_start) + 1
+
+
 @triton.jit
 def _map_global_topk_to_gathered_ckv_kernel(
     req_id_ptr,
@@ -2022,23 +2043,11 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
             # (local_len < min(topk, global_len)) -- i.e. for short contexts,
             # which shows up as small-context-only garbage.
             assert attn_metadata.global_cache_seq_lens_per_req is not None
-            g_num_reqs = attn_metadata.num_reqs
-            g_qsl = attn_metadata.query_start_loc[: g_num_reqs + 1].to(
-                torch.int32
-            )
-            g_req_ids = attn_metadata.req_id_per_token[:num_actual_toks].to(
-                torch.int64
-            )
-            g_chunk_start = g_qsl[:-1][g_req_ids]
-            g_chunk_len = (g_qsl[1:] - g_qsl[:-1])[g_req_ids]
-            g_full_seq = attn_metadata.global_cache_seq_lens_per_req[
-                g_req_ids
-            ].to(torch.int32)
-            g_t = torch.arange(
-                num_actual_toks, device=self.device, dtype=torch.int32
-            )
-            global_causal_len = (
-                g_full_seq - g_chunk_len + (g_t - g_chunk_start) + 1
+            global_causal_len = _global_causal_lens_for_ckv_gather(
+                attn_metadata.global_cache_seq_lens_per_req,
+                attn_metadata.query_start_loc,
+                attn_metadata.req_id_per_token,
+                num_actual_toks,
             )
             torch.minimum(
                 nsa_cache_seqlens,

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -169,9 +169,7 @@ def _env_int(name: str, default: int) -> int:
     return parsed
 
 
-def _get_ckv_gather_workspace(
-    device: torch.device, nbytes: int
-) -> torch.Tensor:
+def _get_ckv_gather_workspace(device: torch.device, nbytes: int) -> torch.Tensor:
     key = (device.type, device.index)
     workspace = _CKV_GATHER_WORKSPACES.get(key)
     if workspace is None:
@@ -299,9 +297,7 @@ def _map_global_topk_to_gathered_ckv_kernel(
         tok // (DCP_SIZE * DCP_INTERLEAVE)
     ) * DCP_INTERLEAVE + tok % DCP_INTERLEAVE
     req_start = tl.load(
-        rank_req_starts_ptr
-        + owner * starts_stride0
-        + req * starts_stride1,
+        rank_req_starts_ptr + owner * starts_stride0 + req * starts_stride1,
         mask=col_mask & (tok >= 0),
         other=0,
     )
@@ -673,8 +669,7 @@ class B12xMLASparseMetadataBuilder(AttentionMetadataBuilder[B12xMLASparseMetadat
             and envs_mod.VLLM_B12X_MLA_CKV_GATHER
             and num_decode_tokens == 0
             and num_prefill_tokens == num_tokens
-            and cm.max_query_len
-            > envs_mod.VLLM_B12X_MLA_CKV_GATHER_MIN_TOKENS
+            and cm.max_query_len > envs_mod.VLLM_B12X_MLA_CKV_GATHER_MIN_TOKENS
         ):
             assert self.dcp_rank_req_lens_buffer is not None
             assert self.dcp_rank_req_starts_buffer is not None
@@ -701,9 +696,7 @@ class B12xMLASparseMetadataBuilder(AttentionMetadataBuilder[B12xMLASparseMetadat
                     out=dcp_rank_req_starts[:, 1:],
                 )
 
-            dcp_local_cu_seq_lens = self.dcp_local_cu_seq_lens_buffer[
-                : cm.num_reqs + 1
-            ]
+            dcp_local_cu_seq_lens = self.dcp_local_cu_seq_lens_buffer[: cm.num_reqs + 1]
             dcp_local_cu_seq_lens[0].zero_()
             torch.cumsum(
                 dcp_rank_req_lens[self.dcp_rank],
@@ -1217,12 +1210,8 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
             self._ckv_gather_stream = torch.cuda.Stream(device=self.device)
             self._ckv_current_chunk_kv_c: torch.Tensor | None = None
             self._ckv_current_chunk_kpe: torch.Tensor | None = None
-            B12xMLASparseImpl._all_layer_kv_caches: list[
-                torch.Tensor | None
-            ] = []
-            B12xMLASparseImpl._shared_gather_event: (
-                torch.cuda.Event | None
-            ) = None
+            B12xMLASparseImpl._all_layer_kv_caches: list[torch.Tensor | None] = []
+            B12xMLASparseImpl._shared_gather_event: torch.cuda.Event | None = None
             B12xMLASparseImpl._shared_gather_buf_idx = 0
             if not self._ckv_prefetch_supported:
                 logger.warning_once(
@@ -1638,9 +1627,7 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
         local_tokens = attn_metadata.dcp_local_total_tokens
         self._validate_ckv_workspace(ckv_workspace)
         half_nbytes = (
-            (self.dcp_world_size + 1)
-            * self._ckv_local_capacity
-            * self._kv_record_bytes
+            (self.dcp_world_size + 1) * self._ckv_local_capacity * self._kv_record_bytes
         )
         ws_half = ckv_workspace.view(-1, self._kv_record_bytes)
         base = buf_idx * (half_nbytes // self._kv_record_bytes)
@@ -1681,9 +1668,7 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
             # stream; the synchronous path shares the default stream with the
             # merge and is safe on the main DCP communicator.
             dcp_group = (
-                get_dcp_ckv_prefetch_group()
-                if stream is not None
-                else get_dcp_group()
+                get_dcp_ckv_prefetch_group() if stream is not None else get_dcp_group()
             )
             _dcp_all_gather_current_stream(
                 dcp_group,
@@ -1699,9 +1684,7 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
         gathered_tokens = gathered_buffer[
             : self.dcp_world_size * self._ckv_local_capacity
         ]
-        return gathered_tokens.view(
-            -1, self.block_size, self._kv_record_bytes
-        )
+        return gathered_tokens.view(-1, self.block_size, self._kv_record_bytes)
 
     def set_ckv_current_chunk_kv(
         self, kv_c_normed: torch.Tensor, k_pe: torch.Tensor
@@ -1748,10 +1731,7 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
         tokens — not just the local rank's share — into the correct slots
         of the rank-ordered gathered buffer.
         """
-        if (
-            self._ckv_current_chunk_kv_c is None
-            or num_actual_toks == 0
-        ):
+        if self._ckv_current_chunk_kv_c is None or num_actual_toks == 0:
             return
         kv_c = self._ckv_current_chunk_kv_c[:num_actual_toks]
         k_pe_flat = self._ckv_current_chunk_kpe[:num_actual_toks]
@@ -1764,9 +1744,7 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
         if global_seq_lens is None:
             return
         global_seq_lens = global_seq_lens[:num_reqs]
-        req_ids = attn_metadata.req_id_per_token[:num_actual_toks].to(
-            torch.int64
-        )
+        req_ids = attn_metadata.req_id_per_token[:num_actual_toks].to(torch.int64)
         global_seq_per_token = global_seq_lens[req_ids].to(torch.int32)
 
         # Map each current-chunk token to its absolute position within its
@@ -1776,18 +1754,12 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
         # ``(t - query_start_loc[r])``-th of them. Using the batch-global
         # ``t``/``num_actual_toks`` is only correct for a single request and
         # otherwise misplaces every request but the last.
-        query_start_loc = attn_metadata.query_start_loc[: num_reqs + 1].to(
-            torch.int32
-        )
+        query_start_loc = attn_metadata.query_start_loc[: num_reqs + 1].to(torch.int32)
         req_chunk_start = query_start_loc[:-1][req_ids]
         req_chunk_len = (query_start_loc[1:] - query_start_loc[:-1])[req_ids]
-        t = torch.arange(
-            num_actual_toks, device=self.device, dtype=torch.int32
-        )
+        t = torch.arange(num_actual_toks, device=self.device, dtype=torch.int32)
         global_pos = global_seq_per_token - req_chunk_len + (t - req_chunk_start)
-        owner = (
-            (global_pos // interleave) % self.dcp_world_size
-        ).to(torch.int64)
+        owner = ((global_pos // interleave) % self.dcp_world_size).to(torch.int64)
         local_pos = (
             global_pos // (self.dcp_world_size * interleave) * interleave
             + global_pos % interleave
@@ -1802,9 +1774,7 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
         rank_start = rank_req_starts.reshape(-1)[flat_idx].to(torch.int64)
 
         padded_tokens = attn_metadata.dcp_padded_total_tokens
-        slots = (
-            owner * int(padded_tokens) + rank_start + local_pos
-        )
+        slots = owner * int(padded_tokens) + rank_start + local_pos
 
         k_scale = getattr(layer, "_k_scale", None)
         if self._kv_fp8_rope:
@@ -2019,9 +1989,7 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
             selected_indices = attn_metadata.ckv_page_table_1[
                 :num_actual_toks, : topk_indices.shape[1]
             ]
-            nsa_cache_seqlens = attn_metadata.ckv_nsa_cache_seqlens[
-                :num_actual_toks
-            ]
+            nsa_cache_seqlens = attn_metadata.ckv_nsa_cache_seqlens[:num_actual_toks]
             _map_global_topk_to_gathered_ckv(
                 attn_metadata.req_id_per_token[:num_actual_toks],
                 topk_indices,
@@ -2124,10 +2092,8 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
                     half_nbytes // self._kv_record_bytes
                 )
                 gathered_buffer = ws_half[
-                    base
-                    + self._ckv_local_capacity : base
-                    + self._ckv_local_capacity
-                    * (self.dcp_world_size + 1)
+                    base + self._ckv_local_capacity : base
+                    + self._ckv_local_capacity * (self.dcp_world_size + 1)
                 ]
                 kv_cache = gathered_buffer[
                     : self.dcp_world_size * self._ckv_local_capacity
@@ -2136,9 +2102,7 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
                     kv_cache, attn_metadata, layer, num_actual_toks
                 )
             else:
-                kv_cache = self._dcp_gather_ckv(
-                    kv_cache, attn_metadata, ckv_workspace
-                )
+                kv_cache = self._dcp_gather_ckv(kv_cache, attn_metadata, ckv_workspace)
             logger.info_once(
                 "Using transient full-CKV gather for B12X sparse MLA prefill "
                 "(capacity=%d logical tokens)",
@@ -2148,8 +2112,7 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
                 self._ckv_prefetch_supported
                 and layer_idx is not None
                 and layer_idx + 1 < len(B12xMLASparseImpl._all_layer_kv_caches)
-                and B12xMLASparseImpl._all_layer_kv_caches[layer_idx + 1]
-                is not None
+                and B12xMLASparseImpl._all_layer_kv_caches[layer_idx + 1] is not None
             ):
                 next_kv = B12xMLASparseImpl._all_layer_kv_caches[layer_idx + 1]
                 next_buf_idx = 1 - B12xMLASparseImpl._shared_gather_buf_idx
@@ -2163,9 +2126,7 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
                 B12xMLASparseImpl._shared_gather_event = torch.cuda.Event(
                     blocking=False
                 )
-                B12xMLASparseImpl._shared_gather_event.record(
-                    self._ckv_gather_stream
-                )
+                B12xMLASparseImpl._shared_gather_event.record(self._ckv_gather_stream)
                 B12xMLASparseImpl._shared_gather_buf_idx = next_buf_idx
 
         use_decode_kernel = attn_metadata.max_query_len <= 1 or (
@@ -2238,9 +2199,7 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
             # granularity, so only a non-aligned local tail is padded here.
             if use_ckv_gather:
                 if attn_metadata.global_cache_seq_lens_per_req is None:
-                    raise RuntimeError(
-                        "CKV gather is missing global sequence lengths"
-                    )
+                    raise RuntimeError("CKV gather is missing global sequence lengths")
                 cache_seqlens = attn_metadata.global_cache_seq_lens_per_req
             else:
                 cache_seqlens = attn_metadata.cache_seq_lens_per_req
@@ -2249,9 +2208,7 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
                 prefill_q = q_buffer[:, : self._kernel_num_heads]
                 prefill_q[:, self._input_num_heads :, :].zero_()
 
-            extend_plan = (
-                self._ckv_extend_plan if use_ckv_gather else self._extend_plan
-            )
+            extend_plan = self._ckv_extend_plan if use_ckv_gather else self._extend_plan
             if extend_plan is None:
                 raise RuntimeError("CKV gather extend plan was not initialized")
             binding = extend_plan.bind(


### PR DESCRIPTION
## Summary

This ports the already validated DCP prefill optimization stack to the consolidated `dev/gilded-gnosis` branch. It adds two independent, opt-in B12X sparse-MLA paths:

- `VLLM_DCP_QUERY_SPLIT=1` splits the replicated prefill query across DCP ranks before sparse MLA and restores the expected output layout afterward.
- `VLLM_B12X_MLA_CKV_GATHER=1` gathers only the selected compressed-KV rows needed by sparse MLA instead of running attention over each rank's full local CKV contribution.

The seven commits preserve the original authorship and applied cleanly to GG. Both paths remain disabled by default and preserve the existing implementation as fallback.

## Implementation

- Adds caller-provided collective output support needed by query split.
- Keeps CKV communicators and metadata buffers unallocated unless enabled.
- Maps global sparse top-k indices into the gathered CKV layout.
- Caps selected entries with each token's global causal length, including short and mixed-request batches.
- Prefetches the next layer's selected CKV while retaining stable CUDA graph addresses.
- Allows query split and CKV gather to be enabled independently for attribution.

For TP8/DCP8, `TP/DCP == 1`, so query split is intentionally a no-op; the measured gain there comes from selected-CKV gather.

## Performance

GLM-5.2 Luke NVFP4, A16, MTP off, TP8, identical v18 integration base on 8x RTX PRO 6000 Blackwell. Each value is the median of three runs and passed first-token checks.

| Profile | Baseline 8k | Optimized 8k | Delta | Baseline 64k | Optimized 64k | Delta |
|---|---:|---:|---:|---:|---:|---:|
| DCP4, query split only | 3,579 | 3,645 | +1.90% | 3,599 | 3,685 | +2.36% |
| DCP4, CKV gather only | 3,579 | 5,156 | +44.14% | 3,599 | 5,088 | +41.37% |
| DCP4, both | 3,579 | 5,311 | +48.39% | 3,599 | 5,291 | +47.01% |
| DCP8, both | 2,397 | 4,459 | +86.02% | 2,405 | 4,441 | +84.66% |

With both flags disabled, the candidate differed from baseline by -0.11% at 8k and -0.36% at 64k. DCP8 KV capacity changed from 4,581,888 to 4,553,216 tokens (-0.63%).

## Verification

- DCP4 baseline, query-only, CKV-only, and combined runs passed first-token checks at 8k and 64k.
- DCP8 baseline and combined runs passed first-token checks at 8k and 64k.
- The focused global-causal-length regression test is included.
- `ruff check`, `ruff format --check`, `git diff --check`, and Python compilation pass on GG.

Supersedes #110, which contains the same stack against the retired FF integration base.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional CKV gathering for distributed prefill and decode workloads.
  * Added query-split parallelism to improve sparse attention processing.
  * Added configuration options for enabling these optimizations and tuning token limits.
  * Added distributed coordination for CKV prefetch and query-split operations.

* **Bug Fixes**
  * Improved global causal-length handling and gathered-cache index mapping.
  * Added coverage validating causal-length calculations on CUDA.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->