### PR TITLE
[GG] fix: restore consolidated runtime invariants

### DIFF
--- a/tests/v1/attention/test_flashinfer_sparse_mla_sm120_api.py
+++ b/tests/v1/attention/test_flashinfer_sparse_mla_sm120_api.py
@@ -9,6 +9,7 @@ import torch
 from vllm.config import set_current_vllm_config
 from vllm.platforms.interface import DeviceCapability
 from vllm.utils import flashinfer as fi_utils
+from vllm.v1.attention.backends.mla import flashinfer_mla_sparse
 from vllm.v1.attention.backends.mla.flashinfer_mla_sparse import (
     FlashInferMLASparseSM120Backend,
 )
@@ -52,3 +53,26 @@ def test_v32_glm_sm120_backend_accepts_glm_block_size(
         )
 
     assert invalid_reasons == []
+
+
+def test_sparse_workspace_is_cached_per_cuda_device(monkeypatch) -> None:
+    allocations = []
+
+    def fake_zeros(size, *, dtype, device):
+        workspace = SimpleNamespace(size=size, dtype=dtype, device=device)
+        allocations.append(workspace)
+        return workspace
+
+    monkeypatch.setattr(torch, "zeros", fake_zeros)
+    flashinfer_mla_sparse._fi_sparse_workspace_by_device.clear()
+
+    cuda0_first = flashinfer_mla_sparse._get_workspace_buffer(torch.device("cuda:0"))
+    cuda1 = flashinfer_mla_sparse._get_workspace_buffer(torch.device("cuda:1"))
+    cuda0_second = flashinfer_mla_sparse._get_workspace_buffer(torch.device("cuda:0"))
+
+    assert cuda0_first is cuda0_second
+    assert cuda0_first is not cuda1
+    assert [workspace.device for workspace in allocations] == [
+        torch.device("cuda:0"),
+        torch.device("cuda:1"),
+    ]

--- a/tests/v1/spec_decode/test_mtp.py
+++ b/tests/v1/spec_decode/test_mtp.py
@@ -23,6 +23,7 @@ from vllm.config import (
     VllmConfig,
 )
 from vllm.config.load import LoadConfig
+from vllm.model_executor.models.deepseek_mtp import DeepSeekMTP
 from vllm.model_executor.models.llama import LlamaForCausalLM
 from vllm.platforms import current_platform
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
@@ -79,6 +80,19 @@ def test_autoregressive_mtp_tuple_return_detection(architectures, expected):
     )
 
     assert speculator.model_returns_tuple is expected
+
+
+def test_deepseek_mtp_local_argmax_delegates_spec_step():
+    expected = torch.tensor([7], dtype=torch.int64)
+    inner = mock.Mock()
+    inner.get_top_tokens.return_value = expected
+    wrapper = SimpleNamespace(model=inner)
+    hidden_states = torch.zeros((1, 8), dtype=torch.bfloat16)
+
+    actual = DeepSeekMTP.get_top_tokens(wrapper, hidden_states, spec_step_idx=2)
+
+    assert actual is expected
+    inner.get_top_tokens.assert_called_once_with(hidden_states, 2)
 
 
 @mock.patch("vllm.v1.spec_decode.llm_base_proposer.get_pp_group")

--- a/vllm/model_executor/models/deepseek_mtp.py
+++ b/vllm/model_executor/models/deepseek_mtp.py
@@ -526,6 +526,21 @@ class DeepSeekMultiTokenPredictor(nn.Module):
         )
         return logits
 
+    def get_top_tokens(
+        self,
+        hidden_states: torch.Tensor,
+        spec_step_idx: int = 0,
+    ) -> torch.Tensor:
+        """Return the vocab-parallel argmax without gathering full logits."""
+        current_step_idx = spec_step_idx % self.num_mtp_layers
+        mtp_layer = self.layers[str(self.mtp_start_layer_idx + current_step_idx)]
+        if mtp_layer.shared_head.head is None:
+            raise RuntimeError("MTP shared LM head has not been attached")
+        return self.logits_processor.get_top_tokens(
+            mtp_layer.shared_head.head,
+            mtp_layer.shared_head(hidden_states),
+        )
+
 
 @support_torch_compile
 class DeepSeekMTP(nn.Module, DeepseekV2MixtureOfExperts):
@@ -625,6 +640,13 @@ class DeepSeekMTP(nn.Module, DeepseekV2MixtureOfExperts):
         spec_step_idx: int = 0,
     ) -> torch.Tensor | None:
         return self.model.compute_logits(hidden_states, spec_step_idx)
+
+    def get_top_tokens(
+        self,
+        hidden_states: torch.Tensor,
+        spec_step_idx: int = 0,
+    ) -> torch.Tensor:
+        return self.model.get_top_tokens(hidden_states, spec_step_idx)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         rocm_aiter_moe_shared_expert_enabled = (

--- a/vllm/transformers_utils/configs/speculators/algos.py
+++ b/vllm/transformers_utils/configs/speculators/algos.py
@@ -101,24 +101,34 @@ def update_dflash(config_dict: dict, pre_trained_config: dict) -> None:
     - target_hidden_size: Hidden size of the target model
     - mask_token_id (required): Token ID used for parallel drafting mask
         placeholders
-    - aux_hidden_state_layer_ids (required): Layer indices from the target
-        model whose intermediate hidden states are used as context for the
-        DFlash drafter. Mapped to both eagle_aux_hidden_state_layer_ids
-        (for gpu_model_runner) and dflash_config.target_layer_ids (for the
-        DFlash model).
+    - aux_hidden_state_layer_ids (required): DFlash target layer indices whose
+        intermediate hidden states are used as context for the DFlash drafter.
+        Mapped to dflash_config.target_layer_ids for the DFlash model. The
+        runner-facing eagle_aux_hidden_state_layer_ids are shifted by one to
+        match vLLM's hidden-state extraction semantics.
     """
     pre_trained_config["architectures"] = ["DFlashDraftModel"]
     pre_trained_config["draft_vocab_size"] = config_dict.get("draft_vocab_size")
     if config_dict.get("target_hidden_size") is not None:
         pre_trained_config["target_hidden_size"] = config_dict["target_hidden_size"]
+    for key in (
+        "layer_types",
+        "use_sliding_window",
+        "sliding_window",
+        "max_window_layers",
+    ):
+        if key in config_dict:
+            pre_trained_config[key] = config_dict[key]
 
+    # Checkpoints store zero-based target layer ids. Hidden-state extraction
+    # indexes the embedding output first, so its ids need a one-based shift.
     aux_layer_ids = config_dict["aux_hidden_state_layer_ids"]
-    pre_trained_config["eagle_aux_hidden_state_layer_ids"] = aux_layer_ids
-
-    # DFlash configs use different indexing for the target layers, see #40727
+    pre_trained_config["eagle_aux_hidden_state_layer_ids"] = [
+        i + 1 for i in aux_layer_ids
+    ]
     pre_trained_config["dflash_config"] = {
         "mask_token_id": config_dict["mask_token_id"],
-        "target_layer_ids": [i - 1 for i in aux_layer_ids],
+        "target_layer_ids": list(aux_layer_ids),
     }
     # Enable causal masking in SWA for vllm-project/speculators models
     pre_trained_config["dflash_config"]["causal"] = not config_dict.get(

--- a/vllm/v1/attention/backends/mla/flashinfer_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/flashinfer_mla_sparse.py
@@ -348,21 +348,31 @@ class FlashInferMLASparseMetadataBuilder(
         )
 
 
-# Global workspace buffer (lazily initialized)
-_fi_sparse_workspace: torch.Tensor | None = None
+# Tests and warmup helpers can construct backends for several CUDA devices in
+# one process, so a process-global singleton can return storage on the wrong GPU.
+_fi_sparse_workspace_by_device: dict[torch.device, torch.Tensor] = {}
+
+
+def _normalize_workspace_device(device: torch.device) -> torch.device:
+    device = torch.device(device)
+    if device.type == "cuda" and device.index is None:
+        device = torch.device("cuda", torch.accelerator.current_device_index())
+    return device
 
 
 def _get_workspace_buffer(device: torch.device) -> torch.Tensor:
-    global _fi_sparse_workspace
-    if _fi_sparse_workspace is None:
+    device = _normalize_workspace_device(device)
+    workspace = _fi_sparse_workspace_by_device.get(device)
+    if workspace is None:
         # FlashInfer's CuteDSL MLA-decode tactic requires an int8 workspace;
         # the trtllm-gen path views it as uint8, so int8 is safe for all backends.
-        _fi_sparse_workspace = torch.zeros(
+        workspace = torch.zeros(
             envs.VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE,
             dtype=torch.int8,
             device=device,
         )
-    return _fi_sparse_workspace
+        _fi_sparse_workspace_by_device[device] = workspace
+    return workspace
 
 
 class FlashInferMLASparseImpl(SparseMLAAttentionImpl[FlashInferMLASparseMetadata]):


### PR DESCRIPTION
## Summary

Restore three production runtime invariants that were present on `dev/fathomless-firmament` but were unintentionally omitted from the consolidated `dev/gilded-gnosis` tree.

## Fixes

1. **DeepSeek MTP local argmax**
   - Restores `DeepSeekMTP.get_top_tokens()` and its inner-model implementation.
   - This is required by launch profiles that set `use_local_argmax_reduction=true`; without it the configured fast path has no model API to call.

2. **DFlash sliding-window configuration**
   - Propagates `layer_types`, `use_sliding_window`, `sliding_window`, and `max_window_layers` into the draft config.
   - Restores the intended indexing contract: checkpoint target layer IDs remain zero-based for DFlash, while runner hidden-state extraction receives the one-based IDs it expects.
   - The existing GG DFlash regression test already encoded this behavior but the consolidated implementation did not satisfy it.

3. **Per-device FlashInfer sparse-MLA workspace**
   - Replaces the process-global singleton with a cache keyed by normalized CUDA device.
   - Prevents tests, warmup helpers, or multi-device construction in one process from receiving workspace storage allocated on another GPU.

## Scope

The FF-only Causal Cascade and generic LL-BF16 router experiments are intentionally not restored. This PR contains only independent runtime correctness fixes required by configurations and tests already retained in GG.

## Verification

- `tests/v1/spec_decode/test_mtp.py`
- `tests/v1/spec_decode/test_dflash_swa.py`
- `tests/v1/attention/test_flashinfer_sparse_mla_sm120_api.py`
- 15 focused tests pass in the v18 CUDA runtime image.
- `ruff check`, `ruff format --check`, and `git diff --check` pass.
