### PR TITLE
[GG] fix: align B12X NVFP4 sparse-MLA scratch API

### DIFF
--- a/tests/v1/attention/test_sparse_mla_backends.py
+++ b/tests/v1/attention/test_sparse_mla_backends.py
@@ -348,6 +348,54 @@ def test_b12x_sparse_glm_uses_8_head_alignment(
         assert lse is None
 
 
+def test_b12x_sparse_nvfp4_uses_kernel_format_not_scratch_caps(
+    default_vllm_config,
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_init,
+) -> None:
+    if not current_platform.has_device_capability(120):
+        pytest.skip("B12xMLASparseBackend requires SM 12.0")
+    if importlib.util.find_spec("b12x") is None:
+        pytest.skip("b12x package not available")
+
+    default_vllm_config.scheduler_config.max_num_batched_tokens = 2
+    default_vllm_config.scheduler_config.max_num_seqs = 2
+    monkeypatch.setattr(
+        B12xMLASparseImpl,
+        "_prewarm_extend_kernels_once",
+        lambda self, max_batched: None,
+    )
+
+    impl = B12xMLASparseImpl(
+        num_heads=8,
+        head_size=576,
+        scale=1.0 / math.sqrt(576),
+        num_kv_heads=1,
+        alibi_slopes=None,
+        sliding_window=None,
+        kv_cache_dtype="nvfp4_ds_mla",
+        logits_soft_cap=None,
+        attn_type="decoder",
+        kv_sharing_target_layer_name=None,
+        topk_indices_buffer=torch.zeros(
+            (2, 2048), dtype=torch.int32, device=DEVICE_TYPE
+        ),
+        kv_lora_rank=512,
+        qk_nope_head_dim=512,
+        qk_rope_head_dim=64,
+        v_head_dim=512,
+    )
+
+    # Scratch shape depends on query/output geometry, not the packed KV record.
+    # NVFP4 specialization belongs on every kernel call instead.
+    assert not hasattr(impl._decode_plan.caps, "kv_cache_dtype")
+    assert not hasattr(impl._extend_plan.caps, "kv_cache_dtype")
+    assert impl._b12x_kernel_format_kwargs(0.75) == {
+        "latent_scale": 0.75,
+        "scale_format": 2,
+    }
+
+
 def test_b12x_sparse_glm_dcp_expands_heads_and_converts_topk(
     default_vllm_config,
     monkeypatch: pytest.MonkeyPatch,

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -784,12 +784,6 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
         # graph and the merge specializes on that count, so no device-side control
         # scalar initialization is needed. final_lse is pre-materialized as a view
         # so the legacy lazy torch.empty(final_lse) never fires during capture.
-        scratch_format_kwargs: dict[str, Any] = (
-            {"kv_cache_dtype": self.kv_cache_dtype}
-            if self._b12x_scale_format is not None
-            else {}
-        )
-
         def _make_plan(
             mode: str, max_q_rows: int, num_q_heads: int, max_batch: int
         ) -> Any:
@@ -807,7 +801,6 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
                     max_batch=int(max_batch),
                     max_chunks_per_row=self._num_splits_cap,
                     page_size=self.block_size,
-                    **scratch_format_kwargs,
                 )
             )
 


### PR DESCRIPTION
## Summary

- stop passing `kv_cache_dtype` to `B12XSparseMLAScratchCaps`
- keep NVFP4 specialization explicit on every decode/extend kernel call through `latent_scale` and `scale_format=2`
- add an SM120 regression test that constructs the NVFP4 backend against the current B12X scratch API

## Root cause

The consolidated GG backend passed an NVFP4-only `kv_cache_dtype` keyword into the format-neutral B12X scratch planner. Current B12X does not expose that keyword, so `--kv-cache-dtype nvfp4_ds_mla` failed during model construction with:

```text
TypeError: B12XSparseMLAScratchCaps.__init__() got an unexpected keyword argument 'kv_cache_dtype'
```

The scratch layout depends on query/output geometry, not the packed KV record. The actual B12X decode and extend launches already receive `latent_scale` and `scale_format=2`, so removing the scratch keyword preserves the intended NVFP4 kernel specialization.

## Validation

- `ruff check` and `ruff format --check`: pass
- targeted SM120 test against B12X `66dff47`: pass
- failure reproduced with the final GG v18 image before this patch during TP4/DCP4/MTP3 NF3 startup