### PR TITLE
[gg-rebased] perf(nf3): integrate Grid188 hybrid decode

### DIFF
--- a/tests/quantization/test_nvfp4_nf3_hybrid.py
+++ b/tests/quantization/test_nvfp4_nf3_hybrid.py
@@ -4,12 +4,15 @@
 import pytest
 import torch
 
+from vllm.config.quantization import resolve_quantization_config
 from vllm.model_executor.layers.quantization import get_quantization_config
 from vllm.model_executor.layers.quantization.nvfp4_nf3_hybrid import (
     NvFp4Nf3HybridConfig,
+    _combined_tier_local_descriptors,
     _read_hybrid_keys,
     _unpack_nf3_codes,
 )
+from vllm.model_executor.layers.quantization.utils.quant_utils import kMxfp8Dynamic
 
 
 @pytest.mark.parametrize(
@@ -65,6 +68,21 @@ def test_config_rejects_missing_hybrid_bit_map():
         )
 
 
+def test_config_accepts_dense_mxfp8_online_overlay():
+    resolved = resolve_quantization_config(
+        "nvfp4_nf3_hybrid",
+        {
+            "linear": {"weight": "mxfp8"},
+            "ignore": ["re:.*kv_b_proj"],
+        },
+    )
+
+    assert resolved is not None
+    assert resolved.linear is not None
+    assert resolved.linear.weight == kMxfp8Dynamic
+    assert resolved.ignore == ["re:.*kv_b_proj"]
+
+
 def test_unpack_nf3_codes():
     expected = torch.tensor([[[0, 1, 2, 3, 4, 5, 6, 7]]], dtype=torch.int32)
     word = sum(int(code) << (index * 3) for index, code in enumerate(expected[0, 0]))
@@ -74,3 +92,20 @@ def test_unpack_nf3_codes():
     )
 
     torch.testing.assert_close(_unpack_nf3_codes(packed, size_k=8), expected)
+
+
+def test_grid188_tier_descriptors_encode_exact_partition():
+    remap = {
+        **{global_id: (0, global_id) for global_id in range(64)},
+        **{global_id: (1, global_id - 64) for global_id in range(64, 256)},
+    }
+
+    descriptors = _combined_tier_local_descriptors(remap)
+
+    assert descriptors[:64] == list(range(64))
+    assert descriptors[64:] == [0x100 | local_id for local_id in range(192)]
+
+
+def test_grid188_tier_descriptors_reject_incomplete_partition():
+    with pytest.raises(ValueError, match="does not cover all 256"):
+        _combined_tier_local_descriptors({0: (0, 0)})

--- a/tests/v1/attention/test_indexer_dcp_localize.py
+++ b/tests/v1/attention/test_indexer_dcp_localize.py
@@ -306,6 +306,19 @@ def test_get_dcp_local_seq_lens_preserves_mtp_bounds_shape():
     torch.testing.assert_close(actual, expected)
 
 
+def test_get_dcp_local_seq_lens_rank_does_not_allocate_cuda_scalar(monkeypatch):
+    seq_lens = torch.tensor([17, 33, 65], dtype=torch.int32)
+
+    def fail_tensor_allocation(*args, **kwargs):
+        raise AssertionError("rank localization must not allocate a scalar tensor")
+
+    monkeypatch.setattr(torch, "tensor", fail_tensor_allocation)
+
+    actual = get_dcp_local_seq_lens(seq_lens, dcp_size=4, dcp_rank=2)
+
+    assert actual.tolist() == [4, 8, 16]
+
+
 def test_get_dcp_local_seq_lens_must_run_after_decode_expansion():
     world = 2
     rank = 1

--- a/vllm/config/quantization.py
+++ b/vllm/config/quantization.py
@@ -157,7 +157,14 @@ ONLINE_QUANT_SHORTHAND_NAMES: tuple[str, ...] = (
 # which the checkpoint explicitly leaves unquantized (shared experts via
 # `shared_experts`, other dense linears via `linear`).
 _MODELOPT_ONLINE_OVERLAY_NAMES = frozenset(
-    {"modelopt", "modelopt_fp4", "modelopt_mxfp8", "modelopt_mixed", "mxfp4"}
+    {
+        "modelopt",
+        "modelopt_fp4",
+        "modelopt_mxfp8",
+        "modelopt_mixed",
+        "mxfp4",
+        "nvfp4_nf3_hybrid",
+    }
 )
 
 

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -63,6 +63,7 @@ if TYPE_CHECKING:
     VLLM_USE_B12X_FP8_GEMM: bool = False
     VLLM_USE_B12X_WO_PROJECTION: bool = False
     VLLM_USE_B12X_MOE: bool = False
+    VLLM_NF3_GRID188_DECODE: bool = True
     VLLM_USE_B12X_MINIMAX_M3_MSA: bool = False
     VLLM_USE_B12X_DCP_A2A: bool = False
     VLLM_DCP_PROJECT_BEFORE_MERGE: bool = False
@@ -1091,6 +1092,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Use b12x for FP4 MoE experts.
     # This is opt-in while the b12x subsystems are brought over one at a time.
     "VLLM_USE_B12X_MOE": lambda: bool(int(os.getenv("VLLM_USE_B12X_MOE", "0"))),
+    # Exact TP4 GLM-5.2 E64-NVFP4/E192-NF3 one-grid decode specialization.
+    "VLLM_NF3_GRID188_DECODE": lambda: bool(
+        int(os.getenv("VLLM_NF3_GRID188_DECODE", "1"))
+    ),
     # Use b12x for MiniMax M3's block-sparse MSA attention.
     # This is opt-in while page-128 MSA support is integrated.
     "VLLM_USE_B12X_MINIMAX_M3_MSA": lambda: bool(

--- a/vllm/model_executor/layers/quantization/nvfp4_nf3_hybrid.py
+++ b/vllm/model_executor/layers/quantization/nvfp4_nf3_hybrid.py
@@ -31,6 +31,7 @@ from typing import TYPE_CHECKING, Any
 
 import torch
 
+from vllm import envs
 from vllm.distributed import (
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
@@ -66,6 +67,77 @@ _NF3_GLOBAL_SCALE = 2.0**116
 # Expert-chunk size for NF3 unpack/repack (bounds transient VRAM: the int32
 # code planes are ~400 MB per 16 w13 experts at GLM-5.2 shapes).
 _NF3_PACK_CHUNK = 16
+# Exact one-grid decode specialization published for the TP4 hybrid checkpoint.
+_GRID188_M = 4
+_GRID188_TOPK = 8
+_GRID188_HIDDEN = 6144
+_GRID188_INTERMEDIATE = 512
+_GRID188_NUM_KEPT = 64
+_GRID188_NUM_NF3 = 192
+
+
+def _combined_tier_local_descriptors(
+    remap: dict[int, tuple[int, int]],
+) -> list[int]:
+    """Encode an exact E64/E192 partition for the mapped Grid188 kernel."""
+    descriptors = [-1] * (_GRID188_NUM_KEPT + _GRID188_NUM_NF3)
+    seen_local = (set(), set())
+    for global_id, tier_local in remap.items():
+        try:
+            global_id_i = int(global_id)
+            tier, local_id = tier_local
+            tier_i, local_id_i = int(tier), int(local_id)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("invalid heterogeneous expert remap entry") from exc
+        if global_id_i != global_id or not 0 <= global_id_i < len(descriptors):
+            raise ValueError(f"invalid global expert ID {global_id!r}")
+        if descriptors[global_id_i] != -1:
+            raise ValueError(f"duplicate global expert ID {global_id_i}")
+        local_limit = (
+            _GRID188_NUM_KEPT if tier_i == 0 else _GRID188_NUM_NF3 if tier_i == 1 else 0
+        )
+        if (
+            tier_i != tier
+            or local_id_i != local_id
+            or local_limit == 0
+            or not 0 <= local_id_i < local_limit
+        ):
+            raise ValueError(f"invalid tier/local expert descriptor {tier_local!r}")
+        if local_id_i in seen_local[tier_i]:
+            raise ValueError(
+                f"duplicate tier/local expert descriptor {(tier_i, local_id_i)!r}"
+            )
+        seen_local[tier_i].add(local_id_i)
+        descriptors[global_id_i] = local_id_i if tier_i == 0 else 0x100 | local_id_i
+    if any(descriptor < 0 for descriptor in descriptors):
+        raise ValueError("heterogeneous remap does not cover all 256 global experts")
+    if seen_local[0] != set(range(_GRID188_NUM_KEPT)) or seen_local[1] != set(
+        range(_GRID188_NUM_NF3)
+    ):
+        raise ValueError("heterogeneous remap is not a complete E64/E192 partition")
+    return descriptors
+
+
+def _is_grid188_geometry(
+    *,
+    hidden_size: int,
+    intermediate_size: int,
+    num_experts: int,
+    num_kept: int,
+    num_nf3: int,
+    topk: int,
+    kept_mx: bool,
+) -> bool:
+    return (
+        envs.VLLM_NF3_GRID188_DECODE
+        and not kept_mx
+        and hidden_size == _GRID188_HIDDEN
+        and intermediate_size == _GRID188_INTERMEDIATE
+        and num_experts == _GRID188_NUM_KEPT + _GRID188_NUM_NF3
+        and num_kept == _GRID188_NUM_KEPT
+        and num_nf3 == _GRID188_NUM_NF3
+        and topk == _GRID188_TOPK
+    )
 
 
 def _read_hybrid_keys(config: Any) -> tuple[dict[str, list[int]] | None, str | None]:
@@ -114,6 +186,11 @@ class _HybridSharedRuntime:
         self.buffers: Any = None
         self.out_kept: torch.Tensor | None = None
         self.out_nf3: torch.Tensor | None = None
+        self.grid188_launch: Any = None
+        self.grid188_scratch: dict[str, torch.Tensor] | None = None
+        self.grid188_sms: int | None = None
+        self.grid188_max_shared_mem: int | None = None
+        self.grid188_disabled_reason: str | None = None
 
 
 class _HybridLayerState:
@@ -150,6 +227,11 @@ class _HybridLayerState:
         self.kept_kernel: Any = None
         self.kept_module: torch.nn.Module | None = None
         self.kept_remap: torch.Tensor | None = None
+        # Exact TP4 E64-NVFP4/E192-NF3 one-grid decode resources.
+        self.grid188_weight_views: tuple[torch.Tensor, ...] | None = None
+        self.grid188_tier_map: torch.Tensor | None = None
+        self.grid188_output: torch.Tensor | None = None
+        self.grid188_ready = False
         # Keeps kernel-format tensors alive: b12x prepared weights VIEW the
         # converted tensors, so dropping them would dangle the views.
         self.keepalive: Any = None
@@ -733,6 +815,221 @@ class NvFp4Nf3HybridMoEMethod(FusedMoEMethodBase):
         runtime.launches[key] = (decode, prefill)
         return runtime.launches[key]
 
+    @staticmethod
+    def _grid188_prepared_views(prepared: Any) -> tuple[torch.Tensor, ...]:
+        return (
+            prepared.w13.view(torch.int32).view(-1),
+            prepared.w2.view(torch.int32).view(-1),
+            prepared.w13_scale.view(torch.uint8).view(torch.int32).view(-1),
+            prepared.w2_scale.view(torch.uint8).view(torch.int32).view(-1),
+            prepared.w13_global_scale.view(-1),
+            prepared.w2_global_scale.view(-1),
+        )
+
+    @staticmethod
+    def _borrow_grid188_scratch(
+        buffers: Any,
+        *,
+        device: torch.device,
+        scratch_elements: int,
+        workspace_words: int,
+    ) -> dict[str, torch.Tensor]:
+        """Borrow serial-path buffers; the two decode paths never overlap."""
+        specs = (
+            ("fc1", "intermediate_cache13", torch.bfloat16, (32, 1024)),
+            ("activated", "intermediate_cache2", torch.bfloat16, (32, 512)),
+            ("fc1_c_tmp", "fc1_c_tmp", torch.float32, (scratch_elements,)),
+            ("fc2_c_tmp", "fc2_c_tmp", torch.float32, (scratch_elements,)),
+        )
+        borrowed: dict[str, torch.Tensor] = {}
+        storage_ids: set[int] = set()
+        for target_name, source_name, dtype, shape in specs:
+            source = getattr(buffers, source_name, None)
+            elements = 1
+            for extent in shape:
+                elements *= int(extent)
+            if (
+                source is None
+                or source.dtype != dtype
+                or source.device != device
+                or not source.is_contiguous()
+                or source.numel() < elements
+                or source.data_ptr() == 0
+                or source.data_ptr() % 16
+            ):
+                raise RuntimeError(
+                    f"Grid188 scratch source {source_name} failed admission"
+                )
+            storage_id = int(source.untyped_storage().data_ptr())
+            if storage_id in storage_ids:
+                raise RuntimeError("Grid188 scratch sources alias each other")
+            storage_ids.add(storage_id)
+            borrowed[target_name] = source.view(-1)[:elements].view(shape)
+        borrowed["workspace"] = torch.zeros(
+            (workspace_words,), dtype=torch.int32, device=device
+        )
+        return borrowed
+
+    def _prepare_grid188(self, layer: "RoutedExperts", topk: int) -> None:
+        """Arm the exact NF3 Grid188 path during the eager profile forward."""
+        state: _HybridLayerState = layer.hybrid_state
+        runtime = self.quant_config.shared_runtime
+        if state.grid188_ready or runtime.grid188_disabled_reason is not None:
+            return
+        if not _is_grid188_geometry(
+            hidden_size=state.hidden_size,
+            intermediate_size=state.intermediate_size,
+            num_experts=state.num_experts,
+            num_kept=state.num_kept,
+            num_nf3=state.num_nf3,
+            topk=topk,
+            kept_mx=state.kept_mx,
+        ):
+            return
+        if torch.cuda.is_current_stream_capturing():
+            runtime.grid188_disabled_reason = (
+                "resources were not prepared before capture"
+            )
+            return
+        try:
+            prep_kept, prep_nf3 = state.prep_kept, state.prep_nf3
+            if prep_kept is None or prep_nf3 is None:
+                raise RuntimeError("both prepared tiers are required")
+            prepared_contract = (
+                prep_kept.weight_layout == "packed"
+                and prep_kept.scale_format == "e4m3_k16"
+                and int(prep_kept.num_experts) == _GRID188_NUM_KEPT
+                and prep_nf3.weight_layout == "nf3_2p1"
+                and prep_nf3.scale_format == "e4m3_k32"
+                and int(prep_nf3.num_experts) == _GRID188_NUM_NF3
+            )
+            if not prepared_contract:
+                raise RuntimeError("prepared tier layouts do not match Grid188 ABI")
+
+            props = torch.cuda.get_device_properties(torch.cuda.current_device())
+            sms = int(props.multi_processor_count)
+            max_shared_mem = int(
+                getattr(props, "shared_memory_per_block_optin", 101_376)
+            )
+            if runtime.grid188_launch is None:
+                from b12x.moe.fused.w4a16.kernel import (
+                    compile_w4a16_hybrid_mapped_grid188,
+                )
+
+                launch = compile_w4a16_hybrid_mapped_grid188(
+                    size_m=_GRID188_M,
+                    hidden_size=_GRID188_HIDDEN,
+                    intermediate_size=_GRID188_INTERMEDIATE,
+                    nv_num_experts=_GRID188_NUM_KEPT,
+                    nf_num_experts=_GRID188_NUM_NF3,
+                    top_k=_GRID188_TOPK,
+                    activation="silu",
+                    element_dtype="bf16",
+                    fast_math=True,
+                    sms=sms,
+                    max_shared_mem=max_shared_mem,
+                    force_tile_config=_B12X_TILES,
+                )
+                if (
+                    int(launch.grid_x) != 188
+                    or int(launch.blocks_per_sm) != 1
+                    or int(launch.size_m) != _GRID188_M
+                    or int(launch.shared_memory_bytes) != 45_184
+                    or int(launch.route_slots) != _GRID188_M * _GRID188_TOPK
+                    or int(launch.map_slots) != _GRID188_NUM_KEPT + _GRID188_NUM_NF3
+                ):
+                    raise RuntimeError("compiled Grid188 launch failed admission")
+                if not hasattr(torch.ops.b12x, "w4a16_hybrid_mapped_grid188_launch"):
+                    raise RuntimeError("Grid188 custom op is unavailable")
+                runtime.grid188_scratch = self._borrow_grid188_scratch(
+                    runtime.buffers,
+                    device=prep_kept.w13.device,
+                    scratch_elements=int(launch.scratch_elements),
+                    workspace_words=int(launch.workspace_words),
+                )
+                runtime.grid188_sms = sms
+                runtime.grid188_max_shared_mem = max_shared_mem
+                runtime.grid188_launch = launch
+
+            weight_views = (
+                *self._grid188_prepared_views(prep_kept),
+                *self._grid188_prepared_views(prep_nf3),
+            )
+            tier_map = torch.tensor(
+                _combined_tier_local_descriptors(state.remap),
+                dtype=torch.int32,
+                device=prep_kept.w13.device,
+            ).contiguous()
+            output = torch.empty(
+                (_GRID188_M, _GRID188_HIDDEN),
+                dtype=torch.bfloat16,
+                device=prep_kept.w13.device,
+            )
+            # Publish only after every allocation and validation has succeeded.
+            state.grid188_weight_views = weight_views
+            state.grid188_tier_map = tier_map
+            state.grid188_output = output
+            state.grid188_ready = True
+            logger.info_once(
+                "nvfp4_nf3_hybrid: armed exact TP4 Grid188 one-grid decode"
+            )
+        except Exception as exc:
+            runtime.grid188_disabled_reason = f"{type(exc).__name__}: {exc}"
+            logger.warning_once(
+                "nvfp4_nf3_hybrid: Grid188 unavailable; using serial decode: %s",
+                runtime.grid188_disabled_reason,
+            )
+
+    def _run_grid188(
+        self,
+        layer: "RoutedExperts",
+        x: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+    ) -> torch.Tensor:
+        state: _HybridLayerState = layer.hybrid_state
+        runtime = self.quant_config.shared_runtime
+        launch = runtime.grid188_launch
+        scratch = runtime.grid188_scratch
+        assert launch is not None and scratch is not None
+        assert runtime.grid188_sms is not None
+        assert runtime.grid188_max_shared_mem is not None
+        assert state.grid188_weight_views is not None
+        assert state.grid188_tier_map is not None
+        assert state.grid188_output is not None
+        torch.ops.b12x.w4a16_hybrid_mapped_grid188_launch(
+            x,
+            *state.grid188_weight_views,
+            topk_ids,
+            state.grid188_tier_map,
+            scratch["fc1"],
+            scratch["activated"],
+            state.grid188_output,
+            topk_weights,
+            scratch["fc1_c_tmp"],
+            scratch["fc2_c_tmp"],
+            scratch["workspace"],
+            _GRID188_M,
+            int(launch.size_m),
+            int(launch.hidden_size),
+            int(launch.intermediate_size),
+            int(launch.nv_num_experts),
+            int(launch.nf_num_experts),
+            int(launch.top_k),
+            launch.activation,
+            launch.element_dtype,
+            bool(launch.fast_math),
+            runtime.grid188_sms,
+            runtime.grid188_max_shared_mem,
+            int(launch.fc1_tile_k),
+            int(launch.fc1_tile_n),
+            int(launch.fc2_tile_k),
+            int(launch.fc2_tile_n),
+            int(launch.grid_x),
+            int(torch.cuda.current_stream(x.device).cuda_stream),
+        )
+        return state.grid188_output
+
     def _ensure_runtime(self, layer: "RoutedExperts", m: int, topk: int) -> None:
         """First-apply init: per-tier preplanned launches plus ONE shared
         scratch/buffer set. The first apply is vLLM's eager profile run at
@@ -797,6 +1094,7 @@ class NvFp4Nf3HybridMoEMethod(FusedMoEMethodBase):
             # them, so sharing them across layers is safe.
             runtime.out_kept = buffers.output
             runtime.out_nf3 = torch.empty_like(buffers.output)
+        self._prepare_grid188(layer, topk)
         state.runtime_ready = True
 
     def _run_tier(
@@ -918,6 +1216,25 @@ class NvFp4Nf3HybridMoEMethod(FusedMoEMethodBase):
         )
         if not weights.is_contiguous():
             weights = weights.contiguous()
+        if state.grid188_ready and m == _GRID188_M:
+            grid_ids = (
+                topk_ids if topk_ids.dtype == torch.int32 else topk_ids.to(torch.int32)
+            )
+            if not grid_ids.is_contiguous():
+                grid_ids = grid_ids.contiguous()
+            if (
+                x.dtype == torch.bfloat16
+                and x.is_contiguous()
+                and grid_ids.numel() == _GRID188_M * _GRID188_TOPK
+                and grid_ids.is_cuda
+                and grid_ids.device == x.device
+                and grid_ids.data_ptr() % 16 == 0
+                and weights.numel() == _GRID188_M * _GRID188_TOPK
+            ):
+                logger.info_once(
+                    "nvfp4_nf3_hybrid: executing TP4 Grid188 one-grid decode"
+                )
+                return self._run_grid188(layer, x, weights, grid_ids)
         if state.num_nf3 == 0:
             # Uniform-NVFP4 layer (e.g. MTP head): single-tier launch.
             output = torch.empty((m, state.hidden_size), dtype=x.dtype, device=x.device)

--- a/vllm/v1/attention/backends/utils.py
+++ b/vllm/v1/attention/backends/utils.py
@@ -904,7 +904,10 @@ def get_dcp_local_seq_lens(
         )
         seq_lens_tiled = seq_lens_i32.unsqueeze(-1)
     else:
-        rank_offsets = torch.tensor(dcp_rank, dtype=torch.int32, device=seq_lens.device)
+        # Keep the rank as a host scalar. Constructing a one-element CUDA
+        # tensor here issues a pageable H2D copy on every MTP draft step and
+        # serializes CPU run-ahead with the active stream.
+        rank_offsets = dcp_rank
         seq_lens_tiled = seq_lens_i32
     base = (
         seq_lens_tiled

--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
@@ -177,6 +177,14 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
             self.draft_max_seq_len = min(
                 max_seq_len + num_speculative_tokens, self.max_model_len
             )
+            # Draft attention metadata is rebuilt once per speculative step.
+            # Keep a CPU-resident conservative bound so sparse attention
+            # builders do not fall back to a blocking seq_lens D2H copy in
+            # that loop. Every draft step advances by at most one token, so
+            # adding the full proposal depth is valid for every step.
+            self._draft_decode_seq_lens_upper_bound = (
+                input_batch.seq_lens_cpu_upper_bound + num_speculative_tokens
+            )
 
             # NOTE(woosuk): To avoid CPU-GPU synchronization without CPU knowing the
             # number of rejected tokens, we maintain the size of input_ids and
@@ -500,6 +508,9 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
                         num_reqs=num_reqs,
                         num_reqs_padded=batch_desc.num_reqs or num_reqs,
                         num_tokens_padded=batch_desc.num_tokens,
+                        seq_lens_cpu_upper_bound=(
+                            self._draft_decode_seq_lens_upper_bound
+                        ),
                     )
 
             # Update the current draft step.


### PR DESCRIPTION
## Summary

Forward-port the vLLM side of the mapped Grid188 NF3 hybrid decode path from #113 onto `dev/gilded-gnosis-rebase` at `533b037f35`.

The two commits retain:

- exact-geometry fail-closed admission for the TP4 64-NVFP4 + 192-NF3 hybrid;
- the `nvfp4_nf3_hybrid` online quantization integration;
- `VLLM_NF3_GRID188_DECODE` as the explicit runtime gate;
- the per-step host-synchronization removal.

Requires lukealonso/b12x#36 (`bc85ef3619`) until that PR is merged.

## Measured contribution

Matched TP4/DCP4/MTP3 C1 decode on the same GPUs and current v18 runtime:

| Path | Median server decode |
|---|---:|
| Grid188 disabled | 95.34 tok/s |
| Grid188 enabled | 106.28 tok/s |
| Incremental gain | **+11.47%** |

## Port validation

- `ruff check`: pass
- `ruff format --check`: pass
- `git diff --check`: pass
- Integrated CUDA/E2E validation is tracked with the v19 image.

Supersedes #113 for the upstream-rebased GG line.