### PR TITLE
[gg-rebased] fix: preserve packed DCP A2A buffers across FULL CUDA graphs

### DIFF
--- a/tests/distributed/test_dcp_a2a.py
+++ b/tests/distributed/test_dcp_a2a.py
@@ -377,6 +377,69 @@ def test_b12x_dispatch_bypasses_packed_nccl(monkeypatch: pytest.MonkeyPatch):
     }
 
 
+def test_packed_a2a_capture_buffers_stay_live_per_shape(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from vllm.v1.attention.ops import dcp_alltoall
+
+    created: list[object] = []
+
+    def fake_empty(*args, **kwargs):
+        value = object()
+        created.append(value)
+        return value
+
+    dcp_alltoall._DCP_A2A_GRAPH_BUFFERS.clear()
+    monkeypatch.setattr(torch, "empty", fake_empty)
+    monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: True)
+    device = torch.device("cuda:0")
+
+    first = dcp_alltoall._dcp_a2a_send_recv_buffers(
+        (3, 4, 11, 514), device, torch.bfloat16
+    )
+    same_shape = dcp_alltoall._dcp_a2a_send_recv_buffers(
+        (3, 4, 11, 514), device, torch.bfloat16
+    )
+    larger = dcp_alltoall._dcp_a2a_send_recv_buffers(
+        (3, 8, 11, 514), device, torch.bfloat16
+    )
+
+    assert same_shape is first
+    assert larger is not first
+    assert len(created) == 4
+    assert len(dcp_alltoall._DCP_A2A_GRAPH_BUFFERS) == 2
+    dcp_alltoall._DCP_A2A_GRAPH_BUFFERS.clear()
+
+
+def test_packed_a2a_eager_buffers_are_not_retained(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from vllm.v1.attention.ops import dcp_alltoall
+
+    created: list[object] = []
+
+    def fake_empty(*args, **kwargs):
+        value = object()
+        created.append(value)
+        return value
+
+    dcp_alltoall._DCP_A2A_GRAPH_BUFFERS.clear()
+    monkeypatch.setattr(torch, "empty", fake_empty)
+    monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: False)
+    device = torch.device("cuda:0")
+
+    first = dcp_alltoall._dcp_a2a_send_recv_buffers(
+        (3, 4, 11, 514), device, torch.bfloat16
+    )
+    second = dcp_alltoall._dcp_a2a_send_recv_buffers(
+        (3, 4, 11, 514), device, torch.bfloat16
+    )
+
+    assert first is not second
+    assert len(created) == 4
+    assert not dcp_alltoall._DCP_A2A_GRAPH_BUFFERS
+
+
 def test_b12x_query_gather_dispatch_bypasses_group(monkeypatch: pytest.MonkeyPatch):
     from vllm.v1.attention.ops import dcp_alltoall
 

--- a/vllm/v1/attention/ops/dcp_alltoall.py
+++ b/vllm/v1/attention/ops/dcp_alltoall.py
@@ -39,6 +39,10 @@ logger = init_logger(__name__)
 
 _B12X_DCP_A2A_POOLS: dict[tuple[int, int, int, int, int, int], Any] = {}
 _B12X_DCP_A2A_DISABLED: set[tuple[int, int, int, int, int, int]] = set()
+_DCP_A2A_GRAPH_BUFFERS: dict[
+    tuple[tuple[int, ...], torch.device, torch.dtype],
+    tuple[torch.Tensor, torch.Tensor],
+] = {}
 
 
 @lru_cache(maxsize=1)
@@ -531,15 +535,26 @@ def _dcp_a2a_send_recv_buffers(
     dtype: torch.dtype,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     # Don't use the shared WorkspaceManager here. A FULL cudagraph bakes in the
-    # buffer address at capture, but the workspace is growable and sized only to
-    # the largest *captured* batch (the cudagraph capture cap). Any eager a2a
-    # with a bigger batch regrows it, freeing that address and poisoning every
-    # captured graph -> illegal memory access on replay. This bites the very
-    # first request: the post-capture warmup runs an eager decode at
-    # max_num_seqs (> the cap), so the graphs are already dangling before the
-    # server is ready. torch.empty buffers instead live in the graph's private
-    # pool and stay valid for its lifetime (as _dcp_a2a_unpack_combine and the
-    # AG+RS combine path already rely on).
+    # buffer address at capture, but a larger eager batch can grow that workspace
+    # and free the captured address. Eager calls therefore use ordinary temporary
+    # tensors, while captured calls retain fixed-size owners below.
+    if device.type == "cuda" and torch.cuda.is_current_stream_capturing():
+        # FULL graphs share a global graph pool. Without a live Python owner,
+        # a larger descriptor's staging allocation can be recycled while a
+        # smaller descriptor is captured, leaving both NCCL graph nodes bound
+        # to the same address. Keep one exact-shape pair alive per device so
+        # descriptors cannot alias each other's A2A staging storage. Layers of
+        # one graph may reuse the pair because all operations are stream-ordered.
+        key = (shape, device, dtype)
+        buffers = _DCP_A2A_GRAPH_BUFFERS.get(key)
+        if buffers is None:
+            buffers = (
+                torch.empty(shape, device=device, dtype=dtype),
+                torch.empty(shape, device=device, dtype=dtype),
+            )
+            _DCP_A2A_GRAPH_BUFFERS[key] = buffers
+        return buffers
+
     return (
         torch.empty(shape, device=device, dtype=dtype),
         torch.empty(shape, device=device, dtype=dtype),


### PR DESCRIPTION
## Summary

Forward-port #117 onto `dev/gilded-gnosis-rebase` at `533b037f35`.

Retain exact-shape packed DCP A2A staging buffers while FULL CUDA graphs are alive so different graph descriptors cannot bind NCCL nodes to recycled graph-pool addresses. Eager allocations remain temporary.

This fixes the reproduced TP6/DCP3/MTP3 corruption where `GRAPH=8` captured multiple verifier descriptors, produced garbled output, and collapsed speculative acceptance; `GRAPH=4` remained correct.

## Port validation

- patch applied cleanly
- `ruff check`: pass
- `ruff format --check`: pass
- `git diff --check`: pass
- six-rank graph replay and GLM E2E are tracked with the v19 image

Supersedes #117 for the upstream-rebased GG line.