### PR TITLE
[GG] build: pin CUTLASS DSL 4.5.3 for SM120 W4A16

### DIFF
--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -24,7 +24,9 @@ nvtx==0.2.15
 fastsafetensors >= 0.3.2
 
 # QuACK and Cutlass DSL for FA4 (cute-DSL implementation)
-nvidia-cutlass-dsl[cu13]==4.6.0
+# 4.6.0 spills the SM120 B12X W4A16 prefill kernel (255 registers and a
+# 256-byte stack per thread); 4.5.3 restores spill-free code generation.
+nvidia-cutlass-dsl[cu13]==4.5.3
 quack-kernels>=0.4.0  # Required for tml-fa4
 
 # Tokenspeed_MLA for faster mla with spec decode


### PR DESCRIPTION
## Summary

- pin the CUDA CuTe DSL dependency to 4.5.3 on the Gilded Gnosis SM120 stack
- preserve a source-level package requirement that matches the release image
- document the concrete B12X W4A16 code-generation regression seen with 4.6.0

## Why

CUTLASS DSL 4.6.0 regresses the B12X W4A16 fused-MoE prefill signature on
SM120. With the same vLLM source, B12X source, model, launcher, and benchmark:

| Runtime DSL | A16 decode CC1 | A16 prefill 64k median |
|---|---:|---:|
| 4.6.0 | 87.36 tok/s | 5,052 tok/s |
| 4.5.3 | 87.18 tok/s | 5,909 tok/s |

The generated kernel changes from `REG:242 STACK:0` under 4.5.3 to
`REG:255 STACK:256` under 4.6.0. A rank-0 Torch trace attributes the prefill
delta to `W4A16FusedMoeKernel`; attention and indexer timings do not show the
same regression. Decode remains within measurement noise.

The 4.5.3 package is API-compatible with this branch and restores the previous
4.5.2 performance. The Docker build separately guarantees that the CUDA 13
wheel is installed after the overlapping base wheel.

Keeping this pin in `requirements/cuda.txt`, rather than overriding only the
container, is necessary because the generated vLLM wheel otherwise declares
an exact 4.6.0 requirement and fails `pip check` with the validated runtime.

## Validation

- package availability and import on Python 3.12 / CUDA 13
- `cutlass.cute.nvgpu.warp.MmaMXF8Op` present
- TP8/DCP1/MTP0 Luke GLM-5.2 NVFP4 A16 original:
  - decode `87.18 tok/s`
  - 64k prefill `5912 / 5909 / 5906`, median `5909 tok/s`
- TP8/DCP1/MTP0 A16 online MXFP8:
  - decode `92.18 tok/s`
  - 64k prefill `5915 / 5909 / 5907`, median `5909 tok/s`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CUDA compatibility by updating the CUTLASS DSL dependency to a version that avoids register and stack spilling in supported prefill workloads.
  * Restored spill-free code generation for SM120 GPU kernels to improve performance consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->