### PR TITLE
fix(mla): use packaged compact KV cache writer

### DIFF
--- a/tests/v1/attention/test_b12x_mla_fp8_rope_writer.py
+++ b/tests/v1/attention/test_b12x_mla_fp8_rope_writer.py
@@ -1,0 +1,326 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import sys
+import types
+
+import pytest
+import torch
+import vllm.config as config_module
+from vllm import _custom_ops as ops
+from vllm.v1.attention.backends.mla import b12x_mla_sparse
+from vllm.v1.attention.backends.mla.b12x_mla_sparse import B12xMLASparseImpl
+
+_WRITER_MODULE = "b12x.attention.mla.kv_cache"
+_WRITER_NAME = "concat_and_cache_nvfp4_mla_fp8_rope"
+
+
+class _StopAfterWriterBinding(Exception):
+    pass
+
+
+class _WriterInitializationFailure(RuntimeError):
+    pass
+
+
+def _initialize_writer_seam(
+    impl: B12xMLASparseImpl,
+    *,
+    kv_cache_dtype: str = "nvfp4_ds_mla",
+) -> None:
+    B12xMLASparseImpl.__init__(
+        impl,
+        num_heads=8,
+        head_size=576,
+        scale=1.0,
+        num_kv_heads=1,
+        alibi_slopes=None,
+        sliding_window=None,
+        kv_cache_dtype=kv_cache_dtype,
+        logits_soft_cap=None,
+        attn_type=b12x_mla_sparse.AttentionType.DECODER,
+        kv_sharing_target_layer_name=None,
+        topk_indices_buffer=torch.empty((1, 1), dtype=torch.int32),
+        kv_lora_rank=512,
+        qk_nope_head_dim=512,
+        qk_rope_head_dim=64,
+        v_head_dim=512,
+    )
+
+
+def _construct_through_writer_binding(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    enabled: bool,
+) -> B12xMLASparseImpl:
+    monkeypatch.setattr(b12x_mla_sparse, "_KV_FP8_ROPE_REQUESTED", enabled)
+    monkeypatch.setattr(b12x_mla_sparse, "_IS_GLM_MOE_DSA_CACHE", True)
+
+    def stop_after_writer_binding():
+        raise _StopAfterWriterBinding
+
+    monkeypatch.setattr(
+        config_module,
+        "get_current_vllm_config",
+        stop_after_writer_binding,
+    )
+    impl = object.__new__(B12xMLASparseImpl)
+    with pytest.raises(_StopAfterWriterBinding):
+        _initialize_writer_seam(impl)
+    return impl
+
+
+def _install_fake_writer_package(
+    monkeypatch: pytest.MonkeyPatch,
+    writer,
+) -> None:
+    b12x_module = types.ModuleType("b12x")
+    b12x_module.__path__ = []
+    attention_module = types.ModuleType("b12x.attention")
+    attention_module.__path__ = []
+    mla_module = types.ModuleType("b12x.attention.mla")
+    mla_module.__path__ = []
+    kv_cache_module = types.ModuleType(_WRITER_MODULE)
+
+    b12x_module.attention = attention_module
+    attention_module.mla = mla_module
+    mla_module.kv_cache = kv_cache_module
+    if writer is not None:
+        setattr(kv_cache_module, _WRITER_NAME, writer)
+
+    monkeypatch.setitem(sys.modules, "b12x", b12x_module)
+    monkeypatch.setitem(sys.modules, "b12x.attention", attention_module)
+    monkeypatch.setitem(sys.modules, "b12x.attention.mla", mla_module)
+    monkeypatch.setitem(sys.modules, _WRITER_MODULE, kv_cache_module)
+
+
+def _enabled_impl(writer) -> B12xMLASparseImpl:
+    impl = object.__new__(B12xMLASparseImpl)
+    impl._kv_fp8_rope = True
+    impl._concat_and_cache_nvfp4_mla_fp8_rope = writer
+    return impl
+
+
+def test_disabled_mode_uses_stock_writer_without_loading_compact_writer(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    compact_imports = []
+    compact_calls = []
+    stock_calls = []
+    real_import = __import__
+
+    def guard_compact_writer_import(name, *args, **kwargs):
+        if name == _WRITER_MODULE:
+            compact_imports.append(name)
+            raise AssertionError("disabled mode must not import the compact writer")
+        return real_import(name, *args, **kwargs)
+
+    def compact_writer(*args, **kwargs):
+        compact_calls.append((args, kwargs))
+
+    def stock_writer(
+        kv_c_arg,
+        k_pe_arg,
+        kv_cache_arg,
+        slot_mapping_arg,
+        *,
+        kv_cache_dtype,
+        scale,
+    ):
+        stock_calls.append(
+            (
+                kv_c_arg,
+                k_pe_arg,
+                kv_cache_arg,
+                slot_mapping_arg,
+                kv_cache_dtype,
+                scale,
+            )
+        )
+
+    monkeypatch.setattr("builtins.__import__", guard_compact_writer_import)
+    monkeypatch.setattr(
+        B12xMLASparseImpl,
+        "_concat_and_cache_nvfp4_mla_fp8_rope",
+        compact_writer,
+        raising=False,
+    )
+    impl = _construct_through_writer_binding(monkeypatch, enabled=False)
+    monkeypatch.setattr(ops, "concat_and_cache_mla", stock_writer)
+
+    kv_c = torch.zeros((2, 512), dtype=torch.bfloat16)
+    k_pe = torch.arange(128).to(torch.bfloat16).reshape(2, 1, 64)
+    kv_cache = torch.empty((1, 2, 432), dtype=torch.uint8)
+    slot_mapping = torch.tensor([[11], [7]], dtype=torch.int64)
+    k_scale = torch.tensor(0.25)
+
+    impl.do_kv_cache_update(
+        kv_c,
+        k_pe,
+        kv_cache,
+        slot_mapping,
+        "nvfp4_ds_mla",
+        k_scale,
+    )
+
+    assert compact_imports == []
+    assert compact_calls == []
+    assert len(stock_calls) == 1
+    (
+        actual_kv_c,
+        actual_k_pe,
+        actual_kv_cache,
+        actual_slots,
+        actual_dtype,
+        actual_scale,
+    ) = stock_calls[0]
+    assert actual_kv_c is kv_c
+    assert torch.equal(actual_k_pe, k_pe.squeeze(1))
+    assert actual_kv_cache is kv_cache
+    assert torch.equal(actual_slots, slot_mapping.flatten())
+    assert actual_dtype == "nvfp4_ds_mla"
+    assert actual_scale is k_scale
+
+
+def test_enabled_mode_calls_bound_public_writer_with_flattened_slots_and_scale(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    writer_calls = []
+
+    def public_writer(kv_c_arg, k_pe_arg, kv_cache_arg, slot_mapping_arg, scale_arg):
+        writer_calls.append(
+            (kv_c_arg, k_pe_arg, kv_cache_arg, slot_mapping_arg, scale_arg)
+        )
+
+    def reject_stock_writer(*args, **kwargs):
+        pytest.fail("enabled mode fell back to the stock MLA writer")
+
+    _install_fake_writer_package(monkeypatch, public_writer)
+    monkeypatch.setattr(ops, "concat_and_cache_mla", reject_stock_writer)
+    impl = _construct_through_writer_binding(monkeypatch, enabled=True)
+
+    kv_c = torch.zeros((2, 512), dtype=torch.bfloat16)
+    k_pe = torch.arange(128).to(torch.bfloat16).reshape(2, 1, 64)
+    kv_cache = torch.empty((1, 2, 368), dtype=torch.uint8)
+    slot_mapping = torch.tensor([[9, 3]], dtype=torch.int64)
+    k_scale = torch.tensor(0.125)
+
+    impl.do_kv_cache_update(
+        kv_c,
+        k_pe,
+        kv_cache,
+        slot_mapping,
+        "nvfp4_ds_mla",
+        k_scale,
+    )
+
+    assert len(writer_calls) == 1
+    actual_kv_c, actual_k_pe, actual_kv_cache, actual_slots, actual_scale = (
+        writer_calls[0]
+    )
+    assert actual_kv_c is kv_c
+    assert actual_k_pe.shape == (2, 64)
+    assert torch.equal(actual_k_pe, k_pe.squeeze(1))
+    assert actual_kv_cache is kv_cache
+    assert actual_slots.shape == (2,)
+    assert torch.equal(actual_slots, slot_mapping.flatten())
+    assert actual_scale is k_scale
+
+
+def test_enabled_mode_rejects_wrong_cache_dtype_before_calling_writer():
+    writer_calls = []
+
+    def writer(*args):
+        writer_calls.append(args)
+
+    impl = _enabled_impl(writer)
+
+    with pytest.raises(
+        RuntimeError,
+        match="KV_FP8_ROPE writer reached a non-NVFP4 cache: 'fp8_ds_mla'",
+    ):
+        impl.do_kv_cache_update(
+            torch.empty((1, 512)),
+            torch.empty((1, 1, 64)),
+            torch.empty((1, 1, 368), dtype=torch.uint8),
+            torch.tensor([[4]], dtype=torch.int64),
+            "fp8_ds_mla",
+            torch.tensor(1.0),
+        )
+
+    assert writer_calls == []
+
+
+def test_enabled_mode_empty_cache_is_noop_before_dtype_validation():
+    writer_calls = []
+
+    def writer(*args):
+        writer_calls.append(args)
+
+    impl = _enabled_impl(writer)
+    impl.do_kv_cache_update(
+        torch.empty((0, 512)),
+        torch.empty((0, 1, 64)),
+        torch.empty((0, 368), dtype=torch.uint8),
+        torch.empty((0, 1), dtype=torch.int64),
+        "not-a-supported-cache-dtype",
+        torch.tensor(1.0),
+    )
+
+    assert writer_calls == []
+
+
+def test_enabled_mode_missing_public_writer_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _install_fake_writer_package(monkeypatch, writer=None)
+    monkeypatch.setattr(b12x_mla_sparse, "_KV_FP8_ROPE_REQUESTED", True)
+    monkeypatch.setattr(b12x_mla_sparse, "_IS_GLM_MOE_DSA_CACHE", True)
+
+    def reject_fallback_initialization():
+        raise _StopAfterWriterBinding
+
+    monkeypatch.setattr(
+        config_module,
+        "get_current_vllm_config",
+        reject_fallback_initialization,
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            "KV_FP8_ROPE=1 requires a b12x build with "
+            "concat_and_cache_nvfp4_mla_fp8_rope package API support"
+        ),
+    ):
+        _initialize_writer_seam(object.__new__(B12xMLASparseImpl))
+
+
+def test_enabled_mode_writer_initialization_failure_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    real_import = __import__
+
+    def fail_writer_initialization(name, *args, **kwargs):
+        if name == _WRITER_MODULE:
+            raise _WriterInitializationFailure("compact writer initialization failed")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.__import__", fail_writer_initialization)
+    monkeypatch.setattr(b12x_mla_sparse, "_KV_FP8_ROPE_REQUESTED", True)
+    monkeypatch.setattr(b12x_mla_sparse, "_IS_GLM_MOE_DSA_CACHE", True)
+
+    def reject_fallback_initialization():
+        raise _StopAfterWriterBinding
+
+    monkeypatch.setattr(
+        config_module,
+        "get_current_vllm_config",
+        reject_fallback_initialization,
+    )
+
+    with pytest.raises(
+        _WriterInitializationFailure,
+        match="compact writer initialization failed",
+    ):
+        _initialize_writer_seam(object.__new__(B12xMLASparseImpl))

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -33,7 +33,6 @@ from typing import TYPE_CHECKING, Any, ClassVar, cast
 import numpy as np
 import torch
 import torch.distributed as dist
-
 from vllm import _custom_ops as ops
 from vllm.config import VllmConfig
 from vllm.config.cache import CacheDType
@@ -77,7 +76,6 @@ _BF16_BYTES = 2
 _EXTEND_PREWARM_DONE: set[
     tuple[int | None, int, int, int, int, int, bool, str, bool]
 ] = set()
-_FP8_ROPE_WRITER_LOADED = False
 _KV_FP8_ROPE_REQUESTED = os.getenv("KV_FP8_ROPE", "0") == "1"
 
 
@@ -125,28 +123,6 @@ def _is_glm_moe_dsa_model() -> bool:
 def _kv_fp8_rope_enabled() -> bool:
     """Strict public gate plus literal GLM architecture selection."""
     return _KV_FP8_ROPE_REQUESTED and _is_glm_moe_dsa_model()
-
-
-def _load_fp8_rope_writer() -> None:
-    """Load the private 368-byte writer without modifying the stock writer."""
-    global _FP8_ROPE_WRITER_LOADED
-    if _FP8_ROPE_WRITER_LOADED:
-        return
-    library = os.getenv("KV_FP8_ROPE_WRITER_LIB", "/opt/fp8rope/_C_fp8_rope.so")
-    if not os.path.isfile(library):
-        raise RuntimeError(
-            "KV_FP8_ROPE=1 requires the standalone writer library at "
-            f"{library!r} (override with KV_FP8_ROPE_WRITER_LIB)"
-        )
-    torch.ops.load_library(library)
-    namespace = getattr(torch.ops, "_C_fp8_rope_ops", None)
-    if namespace is None or not hasattr(
-        namespace, "concat_and_cache_nvfp4_mla_fp8_rope"
-    ):
-        raise RuntimeError(
-            f"FP8-RoPE writer library {library!r} did not register the expected op"
-        )
-    _FP8_ROPE_WRITER_LOADED = True
 
 
 def _cdiv(x: int, y: int) -> int:
@@ -634,7 +610,18 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
                 self.kv_cache_dtype,
             )
         if self._kv_fp8_rope:
-            _load_fp8_rope_writer()
+            try:
+                from b12x.attention.mla.kv_cache import (
+                    concat_and_cache_nvfp4_mla_fp8_rope,
+                )
+            except ImportError as exc:
+                raise RuntimeError(
+                    "KV_FP8_ROPE=1 requires a b12x build with "
+                    "concat_and_cache_nvfp4_mla_fp8_rope package API support"
+                ) from exc
+            self._concat_and_cache_nvfp4_mla_fp8_rope = (
+                concat_and_cache_nvfp4_mla_fp8_rope
+            )
 
         # MLA dims (absorbed: Q post-projection is [T, H, kv_lora_rank + rope]).
         self.kv_lora_rank: int = mla_args["kv_lora_rank"]
@@ -866,9 +853,9 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
         """Write the post-RoPE key using the selected runtime cache format.
 
         The disabled branch delegates to the shipped implementation unchanged,
-        including its stock 432-byte NVFP4 writer.  The enabled branch calls a
-        separate operator so loading this overlay cannot replace or perturb the
-        stock operator used by KV_FP8_ROPE=0.
+        including its stock 432-byte NVFP4 writer. The enabled branch calls the
+        b12x package writer API, which does not replace or perturb the stock
+        writer used by KV_FP8_ROPE=0.
         """
         if not self._kv_fp8_rope:
             return super().do_kv_cache_update(
@@ -886,18 +873,7 @@ class B12xMLASparseImpl(SparseMLAAttentionImpl[B12xMLASparseMetadata]):
                 f"KV_FP8_ROPE writer reached a non-NVFP4 cache: {kv_cache_dtype!r}"
             )
         k_pe_flat = k_pe.squeeze(1)
-        if kv_c_normed.shape[-1] != 512 or k_pe_flat.shape[-1] != 64:
-            raise RuntimeError(
-                "KV_FP8_ROPE is GLM MLA-only and requires latent=512, rope=64; "
-                f"got {tuple(kv_c_normed.shape)} and {tuple(k_pe.shape)}"
-            )
-        kv_u8 = kv_cache.view(torch.uint8)
-        if kv_u8.shape[-1] != 368:
-            raise RuntimeError(
-                "KV_FP8_ROPE expected a 368-byte cache record, got "
-                f"shape={tuple(kv_u8.shape)}"
-            )
-        torch.ops._C_fp8_rope_ops.concat_and_cache_nvfp4_mla_fp8_rope(
+        self._concat_and_cache_nvfp4_mla_fp8_rope(
             kv_c_normed,
             k_pe_flat,
             kv_cache,


### PR DESCRIPTION
## Dependency

Requires https://github.com/lukealonso/b12x/pull/37, which adds the public compact-cache writer API.

## Summary

- replace the `KV_FP8_ROPE=1` external shared-library loader with `b12x.attention.mla.kv_cache.concat_and_cache_nvfp4_mla_fp8_rope`
- bind the package callable once during `B12xMLASparseImpl` construction only when the compact 368-byte cache format is enabled
- preserve the `KV_FP8_ROPE=0` stock `ops.concat_and_cache_mla` path without importing the new b12x submodule
- preserve the empty-cache no-op and the non-NVFP4 cache dtype guard
- pass the existing latent tensor, squeezed 64-d RoPE tensor, flattened slot map, cache, and identical `k_scale` object to the package API
- remove the downstream duplicate shape/record-width checks; the b12x public wrapper now owns the record ABI and input validation
- fail closed with a targeted error when the requested package API is unavailable; non-import initialization failures propagate unchanged

This removes the deployment-only `KV_FP8_ROPE_WRITER_LIB` and `torch.ops.load_library` dependency. The ordinary 432-byte writer and all `KV_FP8_ROPE=0` behavior remain unchanged.

## Compatibility and rollout

This PR must land with a b12x revision containing b12x#37. With an older b12x package, `KV_FP8_ROPE=1` raises a targeted startup error rather than silently falling back to the stock 432-byte writer. Disabled deployments do not import the new submodule and continue through the existing stock writer.

This is a package-boundary correction, not a new performance candidate; no serving-throughput claim is made. The writer bytes and both production reader families are covered in b12x#37.

## Test plan

- `pytest tests/v1/attention/test_b12x_mla_fp8_rope_writer.py -vv` — 6 passed in the gg-v18 Python 3.12 / torch environment
  - disabled construction never imports/calls the compact writer and reaches the stock writer
  - enabled construction binds/calls the public package API with exact squeeze/flatten/scale semantics
  - wrong cache dtype fails before mutation
  - empty cache remains a no-op
  - missing public API fails closed
  - non-ImportError initialization failures propagate
- `ruff check vllm/v1/attention/backends/mla/b12x_mla_sparse.py tests/v1/attention/test_b12x_mla_fp8_rope_writer.py` — passed with the repository-pinned ruff 0.14.0
- `ruff format --check vllm/v1/attention/backends/mla/b12x_mla_sparse.py tests/v1/attention/test_b12x_mla_fp8_rope_writer.py` — passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added integration with the packaged KV-cache writer for supported FP8 RoPE configurations.
  * Added validation to prevent unsupported cache formats from being processed.

* **Bug Fixes**
  * Improved handling of empty cache tensors.
  * Added fail-fast behavior when the required writer integration is unavailable or cannot initialize.

* **Tests**
  * Added comprehensive coverage for enabled and disabled writer modes, argument forwarding, validation, fallback behavior, and initialization failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->