### PR TITLE
[GG] fix DCP packed A2A buffer lifetime during graph prewarm

### DIFF
--- a/tests/distributed/test_dcp_a2a.py
+++ b/tests/distributed/test_dcp_a2a.py
@@ -411,6 +411,39 @@ def test_packed_a2a_capture_buffers_stay_live_per_shape(
     dcp_alltoall._DCP_A2A_GRAPH_BUFFERS.clear()
 
 
+def test_packed_a2a_prewarm_buffers_are_retained_before_cuda_capture(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from vllm.v1.attention.ops import dcp_alltoall
+
+    created: list[object] = []
+
+    def fake_empty(*args, **kwargs):
+        value = object()
+        created.append(value)
+        return value
+
+    dcp_alltoall._DCP_A2A_GRAPH_BUFFERS.clear()
+    monkeypatch.setattr(torch, "empty", fake_empty)
+    monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: False)
+    monkeypatch.setattr(
+        dcp_alltoall, "is_vllm_cudagraph_capture_active", lambda: True
+    )
+    device = torch.device("cuda:0")
+
+    prewarm = dcp_alltoall._dcp_a2a_send_recv_buffers(
+        (3, 16, 11, 514), device, torch.bfloat16
+    )
+    capture = dcp_alltoall._dcp_a2a_send_recv_buffers(
+        (3, 16, 11, 514), device, torch.bfloat16
+    )
+
+    assert capture is prewarm
+    assert len(created) == 2
+    assert len(dcp_alltoall._DCP_A2A_GRAPH_BUFFERS) == 1
+    dcp_alltoall._DCP_A2A_GRAPH_BUFFERS.clear()
+
+
 def test_packed_a2a_eager_buffers_are_not_retained(
     monkeypatch: pytest.MonkeyPatch,
 ):
@@ -426,6 +459,9 @@ def test_packed_a2a_eager_buffers_are_not_retained(
     dcp_alltoall._DCP_A2A_GRAPH_BUFFERS.clear()
     monkeypatch.setattr(torch, "empty", fake_empty)
     monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: False)
+    monkeypatch.setattr(
+        dcp_alltoall, "is_vllm_cudagraph_capture_active", lambda: False
+    )
     device = torch.device("cuda:0")
 
     first = dcp_alltoall._dcp_a2a_send_recv_buffers(

--- a/vllm/v1/attention/ops/dcp_alltoall.py
+++ b/vllm/v1/attention/ops/dcp_alltoall.py
@@ -29,6 +29,7 @@ import torch.distributed as dist
 import vllm.envs as envs
 from vllm.logger import init_logger
 from vllm.triton_utils import tl, triton
+from vllm.utils.multi_stream_utils import is_vllm_cudagraph_capture_active
 
 if TYPE_CHECKING:
     from vllm.distributed.parallel_state import GroupCoordinator
@@ -538,13 +539,19 @@ def _dcp_a2a_send_recv_buffers(
     # buffer address at capture, but a larger eager batch can grow that workspace
     # and free the captured address. Eager calls therefore use ordinary temporary
     # tensors, while captured calls retain fixed-size owners below.
-    if device.type == "cuda" and torch.cuda.is_current_stream_capturing():
+    if device.type == "cuda" and (
+        is_vllm_cudagraph_capture_active()
+        or torch.cuda.is_current_stream_capturing()
+    ):
         # FULL graphs share a global graph pool. Without a live Python owner,
         # a larger descriptor's staging allocation can be recycled while a
         # smaller descriptor is captured, leaving both NCCL graph nodes bound
-        # to the same address. Keep one exact-shape pair alive per device so
-        # descriptors cannot alias each other's A2A staging storage. Layers of
-        # one graph may reuse the pair because all operations are stream-ordered.
+        # to the same address. The vLLM capture scope starts before each eager
+        # graph prewarm, so this also allocates the retained pair before CUDA
+        # capture begins instead of from the shared graph pool. Keep one
+        # exact-shape pair alive per device so descriptors cannot alias each
+        # other's A2A staging storage. Layers of one graph may reuse the pair
+        # because all operations are stream-ordered.
         key = (shape, device, dtype)
         buffers = _DCP_A2A_GRAPH_BUFFERS.get(key)
         if buffers is None:


### PR DESCRIPTION
## Summary

- Allocate retained packed NCCL A2A staging buffers during the outer vLLM CUDA graph prewarm scope.
- Reuse the same exact-shape owners when the corresponding FULL graph is captured.
- Keep ordinary eager calls outside graph setup temporary, as before.

## Root cause

The existing graph-buffer fix retains exact-shape tensors only when `torch.cuda.is_current_stream_capturing()` is true. vLLM performs an eager descriptor prewarm before entering the inner `torch.cuda.graph` context, so the first retained allocation still comes from the shared graph pool during capture.

For DCP sizes unsupported by the B12X PCIe pool, notably virtual TP6 with DCP3 or DCP6, NCCL graph nodes retain these staging addresses. The shared pool can recycle an address while later FULL descriptors are captured, producing intermittent Xid 31 illegal reads. Two preserved failures occurred at FULL graph 12/16 for MTP0 on rank 0 and 15/16 for MTP3 on rank 4; the Python frame where the asynchronous fault surfaced differed, but both NCCL watchdogs reported the same illegal-access class.

The outer `vllm_cudagraph_capture_scope` already spans descriptor prewarm and capture. Treating that scope as graph setup allocates each exact-shape pair before the inner CUDA graph pool is active.

## Scope

This does not change transport selection, tensor contents, CUDA graph sizes, or steady-state execution. It only advances allocation and extends the lifetime of buffers that were already intended to remain graph-owned.

Measured overhead on TP6/DCP3 was about 10-20 MiB per GPU of graph memory. KV capacity was unchanged.

## Validation

- `3 passed, 38 deselected` for the packed A2A capture/prewarm/eager ownership tests.
- Fresh-cache E2E startup passed with the patched file for TP6/DCP3/MTP0 and TP6/DCP3/MTP3.
- Three dual baseline/patch startup rounds completed; the baseline also passed those retries, consistent with the original fault being nondeterministic.
- Exact v19 production image, InstantTensor BUFFERED, 16 FULL graph descriptors, no backend or KV dtype changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CUDA graph capture handling for distributed attention operations.
  * Ensured prewarmed buffers are retained and reused during capture, helping prevent buffer address conflicts and improving reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->