### PR TITLE
[Bugfix][KV Offloading] Defer stores until block IDs are tracked

### DIFF
--- a/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
@@ -19,6 +19,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.offloading.scheduler import (
     OffloadingConnectorScheduler,
     RequestOffloadState,
 )
+from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheGroupSpec,
@@ -62,6 +63,39 @@ def test_scheduler_reports_allocation_failure(request_runner):
 
     reduced = _reduce_kv_connector_stats(runner)
     assert reduced[_ConnectorMetricName.ALLOCATION_FAILURE] == 1
+
+
+def test_store_defers_chunk_until_block_id_is_tracked(request_runner):
+    """Store the ready prefix, then retry a chunk once its GPU block ID arrives."""
+    runner = request_runner(
+        block_size=4,
+        num_gpu_blocks=10,
+        async_scheduling=True,
+    )
+    runner.new_request(token_ids=[0] * 12)
+    runner.manager.prepare_store.side_effect = lambda keys, req_context: (
+        generate_store_output(keys)
+    )
+
+    req_status = runner.connector_scheduler._req_status["0"]
+    req_status.update_offload_keys()
+    group_state = req_status.group_states[0]
+    group_state.block_ids.extend([1, 2])
+
+    scheduler_output = SchedulerOutput.make_empty()
+    scheduler_output.num_scheduled_tokens = {"0": 12}
+    first_jobs = runner.connector_scheduler._build_store_jobs(scheduler_output)
+
+    assert len(first_jobs) == 1
+    assert next(iter(first_jobs.values())).src_spec.block_ids.tolist() == [1, 2]
+    assert group_state.next_stored_chunk_idx == 2
+
+    group_state.block_ids.append(3)
+    second_jobs = runner.connector_scheduler._build_store_jobs(scheduler_output)
+
+    assert len(second_jobs) == 1
+    assert next(iter(second_jobs.values())).src_spec.block_ids.tolist() == [3]
+    assert group_state.next_stored_chunk_idx == 3
 
 
 @pytest.mark.parametrize("async_scheduling", [True, False])

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -327,16 +327,15 @@ class RequestOffloadState:
             num_chunks = max(0, num_chunks - 1)
         return num_chunks
 
-    def advance_stored_idx(self, num_offloadable_tokens: int) -> None:
-        # max(): at the prefill->decode transition of a chunk-aligned prompt,
-        # storable_chunks drops by one (the eagle exclusion kicks in), and the
-        # index must not move backwards past already-stored chunks.
-        for group_config, group_state in zip(
-            self.config.kv_group_configs, self.group_states
+    def advance_stored_idx(self, num_chunks_by_group: Sequence[int]) -> None:
+        # Keep the cursor monotonic: the EAGLE exclusion can lower a group's
+        # storable boundary at the prefill-to-decode transition.
+        for num_chunks, group_state in zip(
+            num_chunks_by_group, self.group_states, strict=True
         ):
             group_state.next_stored_chunk_idx = max(
                 group_state.next_stored_chunk_idx,
-                self.storable_chunks(group_config, num_offloadable_tokens),
+                num_chunks,
             )
 
     def update_num_hit_chunks(self, num_cached_tokens: int) -> None:
@@ -950,14 +949,38 @@ class OffloadingConnectorScheduler:
 
             # Filter out chunks skipped due to sliding window attention / SSM
             # or unreachable by the load path's alignment constraints.
-            new_offload_keys: list[OffloadKey] = []
+            group_chunk_ends: list[int] = []
             for group_config, group_state in zip(
                 self.config.kv_group_configs, req_status.group_states
             ):
-                num_chunks = req_status.storable_chunks(
+                num_storable_chunks = req_status.storable_chunks(
                     group_config, num_offloadable_tokens
                 )
+                num_tracked_chunks = len(group_state.block_ids) // blocks_per_chunk
+                num_chunks = min(
+                    num_storable_chunks,
+                    len(group_state.offload_keys),
+                    num_tracked_chunks,
+                )
+                group_chunk_ends.append(num_chunks)
+                if num_chunks < num_storable_chunks:
+                    logger.debug(
+                        "Request %s deferring group %d offload chunks: "
+                        "storable=%d keys=%d tracked_blocks=%d",
+                        req_id,
+                        group_config.group_idx,
+                        num_storable_chunks,
+                        len(group_state.offload_keys),
+                        len(group_state.block_ids),
+                    )
 
+            new_offload_keys: list[OffloadKey] = []
+            for group_config, group_state, num_chunks in zip(
+                self.config.kv_group_configs,
+                req_status.group_states,
+                group_chunk_ends,
+                strict=True,
+            ):
                 start_chunk_idx = group_state.next_stored_chunk_idx
                 if num_chunks <= start_chunk_idx:
                     continue
@@ -972,7 +995,6 @@ class OffloadingConnectorScheduler:
                     + blocks_per_chunk
                     - 1 : num_chunks * blocks_per_chunk : blocks_per_chunk
                 ]
-                assert len(offload_keys) == len(offload_block_ids)
 
                 alignment_chunk_count = group_config.alignment_chunk_count
                 tail = group_config.sliding_window_size_in_chunks
@@ -996,7 +1018,7 @@ class OffloadingConnectorScheduler:
                     new_offload_keys.append(offload_key)
 
             if not new_offload_keys:
-                req_status.advance_stored_idx(num_offloadable_tokens)
+                req_status.advance_stored_idx(group_chunk_ends)
                 self._maybe_cleanup_finished_req(req_id, req_status)
                 continue
 
@@ -1012,7 +1034,7 @@ class OffloadingConnectorScheduler:
                 continue
 
             if not store_output.keys_to_store:
-                req_status.advance_stored_idx(num_offloadable_tokens)
+                req_status.advance_stored_idx(group_chunk_ends)
                 self._maybe_cleanup_finished_req(req_id, req_status)
                 continue
 
@@ -1025,14 +1047,14 @@ class OffloadingConnectorScheduler:
             src_block_ids: list[int] = []
             sliding_window_block_ids: list[int] = []
             non_sliding_window_block_ids: list[int] = []
-            for group_config, group_state in zip(
-                self.config.kv_group_configs, req_status.group_states
+            for group_config, group_state, num_chunks in zip(
+                self.config.kv_group_configs,
+                req_status.group_states,
+                group_chunk_ends,
+                strict=True,
             ):
                 is_sliding_window = (
                     group_config.sliding_window_size_in_chunks is not None
-                )
-                num_chunks = req_status.storable_chunks(
-                    group_config, num_offloadable_tokens
                 )
                 start_chunk_idx = group_state.next_stored_chunk_idx
                 block_ids = group_state.block_ids


### PR DESCRIPTION
# `[Bugfix][KV Offloading] Defer stores until block IDs are tracked`

## Purpose

Fix a fatal `OffloadingConnector._build_store_jobs` assertion when KV pressure
causes eviction/preemption while tiered offloading and async scheduling are
active.

The store path currently derives `num_chunks` from token progress, then assumes
that two independently maintained collections have reached the same boundary:

- content-hash-derived `offload_keys`; and
- scheduler-propagated physical GPU `block_ids`.

Eviction/preemption can expose a transient state where the token-derived store
boundary is ahead of one of those collections. The resulting slices have
different lengths, and this assertion terminates `EngineCore`:

```python
assert len(offload_keys) == len(offload_block_ids)
```

This change computes a ready boundary independently for every KV group:

```python
min(
    num_storable_chunks,
    len(group_state.offload_keys),
    len(group_state.block_ids) // blocks_per_chunk,
)
```

Only that common ready prefix is offered to the offload manager. Store progress
also advances only through the capped boundary, so a lagging chunk is retried
after its key and complete set of source block IDs are tracked. This is
important: merely removing the assertion and relying on `zip()` would avoid the
crash but could advance the cursor past an unstored chunk, silently losing it.

When all three state sources are synchronized, the ready boundary equals the
existing token-derived boundary and behavior is unchanged.

## Production evidence

The failure was reproduced on a GLM-5.2 hybrid deployment using TP4/DCP4,
MTP3, async scheduling, `TieringOffloadingSpec`, and a 644,864-token GPU KV
pool:

- concurrency 16 x 50k context (~800k active tokens): fatal assertion during
  eviction;
- concurrency 32 sweep: same assertion;
- concurrency 16 x 16k and concurrency <= 8 x 50k: no assertion while active
  demand remained below the pool;
- BF16, E4M3, and block-INT8 collective modes all reproduced the failure,
  ruling out the collective wire codec.

The deployed downstream vLLM commit is `7ea567a2458a4800a6a0e3e0a6ba41fcbd00d146`.
The complete patch applies cleanly to that commit as well as current upstream
main.

## Test Plan

1. Reproduce the lag directly in the existing OffloadingConnector scheduler
   fixture: make three chunks storable while only two GPU block IDs are tracked.
2. Verify the first store job contains the two ready chunks and advances only
   to chunk two.
3. Add the third block ID and verify a second store job retries exactly chunk
   three.
4. Run the complete neighboring scheduler suite, including async/sync
   scheduling, request finish, preemption, reset, MTP/EAGLE, hybrid groups, and
   sliding-window cases.
5. Run all repository pre-commit hooks applicable to the changed files.
6. Before submission, repeat the original above-pool workload on the target
   deployment and verify zero assertion, zero `EngineDeadError`, no restart,
   and successful request completion.

## Test Result

Completed locally:

```text
pytest tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
92 passed, 15 warnings in 40.95s
```

```text
pre-commit run --files <scheduler.py> <test_scheduler.py>
all applicable hooks passed
```

- `git diff --check`: passed.
- Patch applicability against deployed v19 commit `7ea567a`: passed.
- The new regression passes and proves the deferred chunk is retried rather
  than skipped.

Target-box overflow reproduction:

- Patched image SHA-256 began with `41078d5f`; the mounted scheduler SHA-256
  began with `a68a28e5`.
- Deployment: block-INT8 wire mode, offloading enabled with 64 GB host DRAM,
  480k maximum model length, 16 maximum sequences, 0.970 GPU memory
  utilization, TP4/DCP4/MTP3, and a 611,840-token boot KV pool.
- 16/16 unique-prefix requests completed successfully with
  `finish_reason=stop`; each carried approximately 49,800 prompt tokens.
- Active demand reached approximately 797k tokens against a 611,840-token GPU
  KV pool, forcing the eviction path that crashed the unpatched connector.
- Prefix-cache metrics recorded 797,218 queries and zero hits, confirming that
  the requests were freshly prefilled rather than cache-served.
- `RestartCount` remained 0 -> 0 under a one-second watcher; container identity
  and `StartedAt` remained unchanged throughout the 11-minute run.
- No `_build_store_jobs` assertion, `EngineDeadError`, OOM, HTTP 5xx, or request
  error occurred.
- A post-load liveness request returned the expected answer `4` from the same
  engine instance. The container ID, `StartedAt`, and `RestartCount=0` remained
  unchanged.

All production acceptance criteria passed.

No model evaluation is required for this change because it does not alter model
weights, kernels, logits, sampling, or transferred KV values. It changes only
when scheduler metadata declares a store chunk ready. The target overflow gate
above remains required because it validates the production scheduler lifecycle.

## Non-duplication

Open-PR searches and fetched git-history searches for the assertion, store
boundary, and preemption/block-ID terms found no existing fix as of 2026-07-19.

PR [#48596](https://github.com/vllm-project/vllm/pull/48596) is related but not
duplicative: it fixes final-block storage and a block-reuse race at request
finish. Both the deployed commit and current upstream main include that change
while retaining the failing length assertion addressed here.

## AI assistance disclosure

OpenAI Codex assisted with failure analysis, patch preparation, and regression
test development. The commit contains an `Assisted-by` trailer. The production
overflow validation remains a merge gate and its results will be added here.
