### PR TITLE
[GG] fix(moe): serialize hybrid resident-grid launches

### DIFF
--- a/tests/quantization/test_nvfp4_nf3_hybrid.py
+++ b/tests/quantization/test_nvfp4_nf3_hybrid.py
@@ -8,6 +8,7 @@ from vllm.config.quantization import resolve_quantization_config
 from vllm.model_executor.layers.quantization import get_quantization_config
 from vllm.model_executor.layers.quantization.nvfp4_nf3_hybrid import (
     NvFp4Nf3HybridConfig,
+    NvFp4Nf3HybridMoEMethod,
     _combined_tier_local_descriptors,
     _read_hybrid_keys,
     _unpack_nf3_codes,
@@ -109,3 +110,10 @@ def test_grid188_tier_descriptors_encode_exact_partition():
 def test_grid188_tier_descriptors_reject_incomplete_partition():
     with pytest.raises(ValueError, match="does not cover all 256"):
         _combined_tier_local_descriptors({0: (0, 0)})
+
+
+@pytest.mark.parametrize("num_tokens", [1, 8, 256, 3072])
+def test_hybrid_moe_rejects_shared_expert_aux_stream(num_tokens):
+    method = object.__new__(NvFp4Nf3HybridMoEMethod)
+
+    assert not method.supports_shared_experts_aux_stream(num_tokens)

--- a/vllm/model_executor/layers/quantization/nvfp4_nf3_hybrid.py
+++ b/vllm/model_executor/layers/quantization/nvfp4_nf3_hybrid.py
@@ -333,6 +333,16 @@ class NvFp4Nf3HybridMoEMethod(FusedMoEMethodBase):
         super().__init__(moe_config)
         self.quant_config = quant_config
 
+    def supports_shared_experts_aux_stream(self, num_tokens: int) -> bool:
+        """The hybrid B12X launches must own the device while they run.
+
+        Both the unified Grid188 decode and the per-tier fused fallback use
+        resident-grid software barriers. Concurrent shared-expert work can
+        occupy an SM needed by a barrier participant and deadlock the grid;
+        the resulting asynchronous fault may surface in a later CUDA op.
+        """
+        return False
+
     def maybe_make_prepare_finalize(
         self,
         routing_tables: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None = None,


### PR DESCRIPTION
## Summary

- mark `nvfp4_nf3_hybrid` MoE execution as unsafe for shared-expert
  auxiliary-stream overlap
- keep the shared-expert GEMM on the main stream while either hybrid
  resident-grid implementation is active
- add regression coverage across decode and prefill token counts

## Why

local-inference-lab/vllm#132 adds a per-kernel capability gate before shared
experts are scheduled on an auxiliary CUDA stream. That gate correctly handles
the generic B12X MoE method, paired with lukealonso/b12x#47, but the custom
`NvFp4Nf3HybridMoEMethod` does not use the generic B12X launch plan. It therefore
inherits the base fallback, which permits overlap when no generic `moe_kernel`
is attached.

Both hybrid paths require exclusive resident-grid progress:

- unified Grid188 decode uses a software grid barrier
- the per-tier fused fallback also uses resident-grid barriers

Concurrent shared-expert work can occupy an SM needed by a barrier participant,
prevent the grid from making progress, and leave an asynchronous CUDA failure
that surfaces later in an unrelated operation. One observed incident surfaced
as `CUBLAS_STATUS_INTERNAL_ERROR` in an MLA BF16 projection; the incident was
non-reproducible, so this PR is intentionally a draft pending the GPU gates
below.

## Scope and dependencies

This is a one-commit dependent follow-up to local-inference-lab/vllm#132. It is
based directly on `dev/gilded-gnosis` so the diff does not duplicate that PR's
graph-channel, workspace-lane, or generic B12X capability changes. The override
becomes active when #132's scheduler hook is present. It also does not replace
lukealonso/b12x#47; it supplies the missing conservative capability decision
for the separate hybrid quantizer.

## Validation

Completed locally:

- Python compilation
- `git diff --check`
- regression test covers token counts 1, 8, 256, and 3072

Pending target-GPU validation:

- focused shared-expert, B12X MoE, and hybrid quantization tests
- three uninterrupted cycles of the original needle/decode workload
- unchanged container ID, `StartedAt`, and `RestartCount`
- clean CUBLAS/Xid/illegal-access/watchdog/EngineDead/OOM/5xx audit
- decode-throughput and KV-pool comparison

## Files changed

- `vllm/model_executor/layers/quantization/nvfp4_nf3_hybrid.py`
- `tests/quantization/test_nvfp4_nf3_hybrid.py`
