### PR TITLE
Pad B12X DCP A2A outputs to avoid cuBLAS read-ahead fault

### DIFF
--- a/vllm/v1/attention/ops/dcp_alltoall.py
+++ b/vllm/v1/attention/ops/dcp_alltoall.py
@@ -20,6 +20,7 @@ Reference: https://arxiv.org/abs/2507.07120
 
 from __future__ import annotations
 
+import math
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any
 
@@ -36,6 +37,29 @@ if TYPE_CHECKING:
 
 
 logger = init_logger(__name__)
+
+# cuBLAS selects TMA-tiled kernels for the strided/overlapping-batch view of
+# the DCP reduce-scatter output in MLA `_v_up_proj`. Those kernels perform a
+# bounded read-ahead (observed up to base + 64 KB) past the operand's logical
+# extent, relying on the caching allocator's natural segment padding. A tight
+# `torch.empty` output can land at a 2 MB segment tail with an unmapped VA page
+# after it, so the read-ahead faults (Xid 31 / FAULT_PDE) on all ranks at once.
+# Padding the output allocation keeps >= 64 KB past the logical end mapped
+# inside the same allocator block, regardless of segment layout.
+_CUBLAS_TAIL_PAD_BYTES = 65536
+
+
+def _tail_padded_empty(
+    shape: tuple[int, ...], device: torch.device, dtype: torch.dtype
+) -> torch.Tensor:
+    """Allocate a contiguous tensor of ``shape`` with >= 64 KB of live tail
+    padding inside the same allocator block, so downstream cuBLAS read-ahead
+    cannot cross into unmapped memory."""
+    numel = math.prod(shape)
+    pad = -(-_CUBLAS_TAIL_PAD_BYTES // dtype.itemsize)
+    flat = torch.empty(numel + pad, device=device, dtype=dtype)
+    return flat[:numel].view(shape)
+
 
 _B12X_DCP_A2A_POOLS: dict[tuple[int, int, int, int, int, int], Any] = {}
 _B12X_DCP_A2A_DISABLED: set[tuple[int, int, int, int, int, int]] = set()
@@ -225,9 +249,17 @@ def _try_b12x_dcp_lse_reduce(
     if not cp_attn_lse.is_contiguous():
         cp_attn_lse = cp_attn_lse.contiguous()
 
+    # Pass a tail-padded output so the reduce kernel writes directly into a
+    # buffer that is safe for the downstream `_v_up_proj` cuBLAS read-ahead.
+    out = _tail_padded_empty(
+        (batch, total_heads // world_size, head_dim),
+        cp_attn_out.device,
+        cp_attn_out.dtype,
+    )
     return pool.lse_reduce_scatter(
         cp_attn_out,
         cp_attn_lse,
+        out=out,
         is_lse_base_on_e=is_lse_base_on_e,
     )
 
@@ -279,7 +311,14 @@ def _try_b12x_dcp_all_gather_heads(
     )
     if pool is None:
         return None
-    return pool.all_gather_heads(local_input)
+    # Pad the gathered output for the same cuBLAS read-ahead safety reason as
+    # the reduce-scatter path (see `_tail_padded_empty`).
+    out = _tail_padded_empty(
+        (batch, local_heads * world_size, head_dim),
+        local_input.device,
+        local_input.dtype,
+    )
+    return pool.all_gather_heads(local_input, out=out)
 
 
 def dcp_b12x_all_gather_heads(


### PR DESCRIPTION
Here is Fable RCA, I doubt it is correct though. Will test this patch in prod a couple of days and update 

# GLM-5.2 v17/v19 Xid 31 during DCP decode: root cause analysis and fix options

Analyzed at the exact commits the v19 image was built from:

- `vllm @ 7ea567a24` (`dev/gilded-gnosis` lineage)
- `b12x @ c7dc733` (master)

## Summary

With `B12X_PCIE_DMA=1`, TP=8, DCP=2, MTP=3, the server crashes with a GPU MMU
page fault (Xid 31, FAULT_PDE, ACCESS_TYPE_VIRT_READ) on the first decode step
after a long chunked prefill. The fault surfaces as
`CUBLAS_STATUS_INTERNAL_ERROR` in `torch.bmm` inside the MLA V up-projection.

The faulting operand is the output of the B12X DCP `lse_reduce_scatter`
collective. cuBLAS performs a bounded read-ahead (up to `base + 64 KB`) on the
transposed, strided view of this tensor. The tensor's storage is 49,152 bytes
(exactly 12 × 4 KB pages), and when its allocation block happens to end at the
tail of a mapped region with an unmapped VA page after it, the read-ahead
crosses into unmapped memory and faults on all ranks simultaneously.

## Faulting path

1. `vllm/model_executor/layers/attention/mla_attention.py:1169` — decode path
   calls `dcp_a2a_lse_reduce(..., use_b12x=dcp_use_b12x, ...)`.
2. `vllm/v1/attention/ops/dcp_alltoall.py:228` — `_try_b12x_dcp_lse_reduce`
   returns `pool.lse_reduce_scatter(cp_attn_out, cp_attn_lse, ...)` directly,
   without passing `out=`.
3. `mla_attention.py:1237` → `_v_up_proj(attn_out, out=mqa_output_slice)` →
   line 1477: `torch.bmm(x, self.W_UV, out=out.transpose(0, 1))` where
   `x = attn_out.view(-1, num_heads, kv_lora_rank).transpose(0, 1)`.

## Evidence and arithmetic

- The reduce-scatter output is `[6, 8, 512]` bf16 = 49,152 bytes = exactly
  12 × 4 KB pages, no remainder.
- The transpose yields shape `(8, 6, 512)` with strides `(512, 4096, 1)` — a
  legal strided-batched layout that PyTorch dispatches to
  `cublasGemmStridedBatchedEx` without a contiguous copy. The batch stride
  (512 elems) is smaller than the per-matrix span, i.e. the batch matrices
  **overlap** in memory; this is legal for cuBLAS inputs (stride-0 broadcast
  is explicitly supported).
- Debug instrumentation shows the dmesg fault address is exactly
  `x.data_ptr() + 0x10000` on every rank — consistent with a bounded (~64 KB)
  TMA tile read-ahead past a tightly-mapped region. Identical deltas across
  ranks are expected, since allocation sequences are symmetric across ranks.
- `CUDA_LAUNCH_BLOCKING=1` pins the fault to this exact `bmm` call and rules
  out a race; the crash also reproduces with `--enforce-eager`,
  `VLLM_DCP_QUERY_SPLIT=0`, and `VLLM_B12X_MLA_CKV_GATHER=0`, ruling out
  torch.compile, CUDA graphs, and CKV gather.

## Where the tensor actually lives

At `b12x/b12x/distributed/pcie_dcp_a2a.py:389-396`, when the caller passes no
`out`, `PCIeDCPA2A.lse_reduce_scatter` allocates the result with
`torch.empty(...)` — the standard PyTorch caching allocator. The CUDA
extension (`pcie_dcp_a2a.cu`, `lse_reduce_scatter` binding →
`runtime->run(...)`) uses the IPC slab **only for internal staging**; the
kernel writes the final reduced result into `output.data_ptr()`, i.e. the
`torch.empty` buffer. `all_gather_heads` has the same structure. The IPC slab
itself is capacity-sized (`max_batch_size * total_heads *
max(head_dim, query_head_dim)`), not sized to the current batch.

So the tight allocation that cuBLAS over-reads is a **caching-allocator
block**, not IPC memory: a 48 KB `torch.empty` block landing at the tail of a
2 MB caching-allocator segment (no `expandable_segments`, which is
incompatible with native KV offloading), with an unmapped VA hole immediately
after the segment.

This explains every observation:

- **Why `B12X_PCIE_DMA=1` matters**: it selects the b12x pool path, whose
  allocation sequence differs entirely from the NCCL path
  (`_dcp_a2a_send_recv_buffers` + `_dcp_a2a_unpack_combine`), changing which
  block the output lands in.
- **Why the long chunked prefill triggers it**: an 8k–13k token prefill
  reshapes allocator segment state (potentially releasing segments under
  pressure, creating unmapped VA holes), after which the small decode-step
  output lands at a segment tail.
- **Why the first short request works**: different allocator layout; the
  output block has mapped memory after it.
- **Why all ranks fault at identical offsets**: symmetric allocation streams.
- **Why a `.clone()` of the pool output avoids the crash**: it hands cuBLAS a
  different block. This is a layout perturbation, not a guarantee — the clone
  is the same size from the same allocator, and a future allocation pattern
  could put it at a segment tail and re-trigger the crash.

**Conclusive verification** (not yet done): at the faulting step, capture
`torch.cuda.memory_snapshot()` and check whether the `x` tensor's block sits
within 16 KB of its segment end, and whether the VA immediately after the
segment is unmapped.

## Fix options, ranked

### 1. Recommended: padded `out=` allocation in the vLLM wrapper

Allocate the output with tail padding and pass it as `out=` to the pool
(b12x's `_validate` only requires shape/dtype/contiguity, which a sliced flat
view satisfies):

```python
_CUBLAS_TAIL_PAD_BYTES = 65536  # observed cuBLAS TMA tile read-ahead bound

def _tail_padded_empty(shape, device, dtype):
    numel = math.prod(shape)
    pad = -(-_CUBLAS_TAIL_PAD_BYTES // dtype.itemsize)
    flat = torch.empty(numel + pad, device=device, dtype=dtype)
    return flat[:numel].view(shape)
```

In `_try_b12x_dcp_lse_reduce`:

```python
out = _tail_padded_empty(
    (batch, total_heads // world_size, head_dim),
    cp_attn_out.device, cp_attn_out.dtype,
)
return pool.lse_reduce_scatter(cp_attn_out, cp_attn_lse, out=out, ...)
```

and the same for `_try_b12x_dcp_all_gather_heads`.

Properties:

- Zero extra copies/kernels — the reduce kernel writes directly into the
  padded buffer.
- Deterministic safety — the padding lives inside the same allocator block, so
  ≥ 64 KB past the logical end is guaranteed mapped, regardless of allocator
  layout.

### 2. Defense in depth: same padding for b12x's internal defaults

Apply the padded-flat-then-slice pattern to the `out is None` defaults in
`PCIeDCPA2A.lse_reduce_scatter` (`pcie_dcp_a2a.py:389`) and
`all_gather_heads` (`:440`), so every consumer is safe regardless of caller
behavior. Note the IPC staging slab needs no change — the returned tensor
never lives in the slab, and the slab is already capacity-sized.

### 3. Upstream bug report (cuBLAS / PyTorch)

A TMA-tiled cuBLAS kernel reading ~16 KB past the storage extent of a legal
(overlapping-batch, strided) operand is a library bug — either in cuBLAS or in
PyTorch's kernel selection for `torch.bmm` on such views. A standalone repro
is provided in `repro_cublas_oob_read.py`: it maps exactly N bytes via CUDA
VMM (`cuMemAddressReserve`/`cuMemCreate`/`cuMemMap`) with the following pages
reserved but unmapped, places the `[6, 8, 512]` bf16 operand so its storage
ends at the mapping boundary, and runs the exact `_v_up_proj` bmm; `front`
and `clone` control modes prove the layout itself is legal. Options 1–2
remain workarounds for it.

**Preconditions audit (no documented contract is violated).** Verified against
PyTorch `v2.11.0` sources (tag matches the installed build,
`git_version 70d99e99`) and the official cuBLAS 13.x documentation for
`cublasGemmStridedBatchedEx` (installed: cuBLAS 13.1.0.3):

- **Dispatch path**: `aten/src/ATen/native/cuda/Blas.cpp`
  (`baddbmm_out_cuda_impl` → `prepare_batch_matrix_for_cublas`) accepts the
  `(8, 6, 512)` / strides `(512, 4096, 1)` view without a copy: the
  `stride[2] == 1 && stride[1] >= k` branch matches, yielding `ld = 4096`,
  batch stride `= 512`. PyTorch deliberately does not require the batch
  stride to cover the per-matrix span, so the overlapping-batch input is a
  supported layout. `aten/src/ATen/cuda/CUDABlas.cpp` then calls
  `cublasGemmStridedBatchedEx` with `CUDA_R_16BF` operands and `CUDA_R_32F`
  compute (the cuBLASLt path is only used with a non-default
  `blasPreferredBackend`).
- **Stride contract**: cuBLAS defines `strideA`/`strideB` only as "offset in
  number of elements between `A[i]` and `A[i+1]`" that "must not be zero".
  There is no lower bound and no non-overlap requirement for *input*
  matrices (stride-0-style broadcast overlap is legal). Ours is 512 ≠ 0.
- **Output overlap**: the only overlap clause applies to `C`: "matrices must
  not overlap, i.e. the individual gemm operations must be computable
  independently." The output view (batch stride 128, ld 1024) interleaves
  address ranges but writes element-disjoint sets, satisfying the stated
  criterion — and it is the layout PyTorch produces for every transposed bmm
  output. (This is the one mildly ambiguous clause, but it governs writes;
  the observed fault is a read at `x + 0x10000`.)
- **Leading dimensions**: `ld = 4096 ≥ k = 512`, enforced by PyTorch before
  dispatch.
- **Alignment**: the docs ask for 16-byte pointer alignment when
  `k % 8 == 0`; PyTorch allocations are ≥256-byte aligned. The Tensor Core
  section states there are no further dimension/alignment restrictions for
  non-FP8 types since cuBLAS 11.
- **No padding license**: nothing in the documentation permits cuBLAS to
  read beyond the extents implied by dims/ld/strides, and there is no
  "allocations must be padded" precondition.

Since every documented precondition is satisfied, the bounded read-ahead past
the operand's storage is outside the documented contract and reportable as an
upstream defect.

### Follow-up: the NCCL path has the same theoretical exposure

`_dcp_a2a_unpack_combine` returns a tight `torch.empty` of identical shape
that flows into the same `bmm`. Configurations without `B12X_PCIE_DMA` survive
by allocator luck, not by construction. Using `_tail_padded_empty` there too
costs nothing.

Sizing note: keep the pad at 64 KB rather than 2 MB — it is per-call transient
memory, and the observed read bound is exactly `base + 0x10000`.
