### PR TITLE
[GG] Fix MLA BMM layout contract for cuBLAS read-ahead

### DIFF
--- a/tests/v1/attention/test_mla_backends.py
+++ b/tests/v1/attention/test_mla_backends.py
@@ -265,10 +265,10 @@ def test_mla_v_up_proj_honors_bmm_contiguity(monkeypatch):
     real_bmm = torch.bmm
     seen_layouts = []
 
-    def checked_bmm(input, mat2, *, out=None):
+    def checked_bmm(input_tensor, mat2, *, out=None):
         assert out is not None
-        seen_layouts.append((input.is_contiguous(), out.is_contiguous()))
-        return real_bmm(input, mat2, out=out)
+        seen_layouts.append((input_tensor.is_contiguous(), out.is_contiguous()))
+        return real_bmm(input_tensor, mat2, out=out)
 
     monkeypatch.setattr(torch, "bmm", checked_bmm)
 

--- a/tests/v1/attention/test_mla_backends.py
+++ b/tests/v1/attention/test_mla_backends.py
@@ -86,6 +86,77 @@ def test_mla_kv_cache_spec_uses_layer_cache_dtype(
         assert spec.page_size_bytes == 64 * 656
 
 
+def test_mla_init_propagates_backend_bmm_contiguity_contract(monkeypatch):
+    class FakeImpl:
+        is_sparse = True
+        supports_mha_prefill = False
+
+        def __init__(self, **kwargs):
+            self.force_contiguous_mla_bmm_input = True
+            self.force_contiguous_mla_bmm_weight = True
+            self.force_contiguous_mla_bmm_output = True
+
+    class FakeBackend:
+        @staticmethod
+        def is_mla():
+            return True
+
+        @staticmethod
+        def get_name():
+            return "TEST_MLA"
+
+        @staticmethod
+        def get_impl_cls():
+            return FakeImpl
+
+    config = SimpleNamespace(
+        compilation_config=SimpleNamespace(
+            static_forward_context={}, cudagraph_capture_sizes=[]
+        ),
+        attention_config=SimpleNamespace(mla_prefill_backend=None),
+        parallel_config=SimpleNamespace(decode_context_parallel_size=1),
+        scheduler_config=SimpleNamespace(max_num_batched_tokens=128),
+    )
+    monkeypatch.setattr(
+        mla_attention_module, "get_current_vllm_config", lambda: config
+    )
+    monkeypatch.setattr(
+        mla_attention_module, "get_current_vllm_config_or_none", lambda: config
+    )
+    monkeypatch.setattr(mla_attention_module, "_init_kv_cache_quant", lambda *a: None)
+    monkeypatch.setattr(
+        mla_attention_module,
+        "get_mla_prefill_backend",
+        lambda _: (_ for _ in ()).throw(ValueError),
+    )
+    monkeypatch.setattr(mla_attention_module, "_DecodeConcatQuantFP8", lambda **_: None)
+    monkeypatch.setattr(mla_attention_module, "QuantFP8", lambda **_: None)
+    monkeypatch.setattr(
+        mla_attention_module.rocm_aiter_ops, "is_fp8bmm_enabled", lambda: False
+    )
+    monkeypatch.setattr(
+        mla_attention_module.rocm_aiter_ops, "is_fp4bmm_enabled", lambda: False
+    )
+
+    layer = MLAAttention(
+        num_heads=8,
+        scale=1.0,
+        qk_nope_head_dim=4,
+        qk_rope_head_dim=2,
+        v_head_dim=3,
+        q_lora_rank=None,
+        kv_lora_rank=4,
+        kv_b_proj=SimpleNamespace(),
+        prefix="test",
+        attn_backend=FakeBackend,
+        use_sparse=True,
+    )
+
+    assert layer.force_contiguous_mla_bmm_input
+    assert layer.force_contiguous_mla_bmm_weight
+    assert layer.force_contiguous_mla_bmm_output
+
+
 # Remove sm100 backends from the list if not using sm100
 if not torch.cuda.is_available() or torch.cuda.get_device_properties(0).major < 10:
     BACKENDS_TO_TEST.remove(AttentionBackendEnum.CUTLASS_MLA)
@@ -122,6 +193,7 @@ def test_mla_post_load_preserves_runtime_weight_addresses(monkeypatch):
     layer.kv_b_proj.quant_method = None
     layer.is_aiter_triton_fp4_bmm_enabled = False
     layer.is_aiter_triton_fp8_bmm_enabled = False
+    layer.force_contiguous_mla_bmm_weight = False
     layer.quant_config = None
     layer.layer_name = "test"
 
@@ -145,6 +217,65 @@ def test_mla_post_load_preserves_runtime_weight_addresses(monkeypatch):
     assert layer.W_UK_T.data_ptr() == w_uk_t_ptr
     torch.testing.assert_close(layer.W_UV, old_w_uv + 100)
     torch.testing.assert_close(layer.W_UK_T, old_w_uk_t + 100)
+
+
+def test_mla_post_load_honors_bmm_weight_contiguity(monkeypatch):
+    layer = MLAAttention.__new__(MLAAttention)
+    torch.nn.Module.__init__(layer)
+    layer.kv_lora_rank = 2
+    layer.num_heads = 2
+    layer.qk_nope_head_dim = 3
+    layer.v_head_dim = 4
+    layer.kv_b_proj = torch.nn.Module()
+    layer.kv_b_proj.weight = torch.nn.Parameter(
+        torch.arange(28.0, dtype=torch.float32).reshape(14, 2)
+    )
+    layer.kv_b_proj.quant_method = None
+    layer.is_aiter_triton_fp4_bmm_enabled = False
+    layer.is_aiter_triton_fp8_bmm_enabled = False
+    layer.force_contiguous_mla_bmm_weight = True
+    layer.quant_config = None
+    layer.layer_name = "test"
+
+    monkeypatch.setattr(
+        mla_attention_module, "set_default_quant_scales", lambda *_, **__: None
+    )
+
+    with torch.no_grad():
+        layer.process_weights_after_loading(torch.float32)
+
+    assert layer.W_UV.is_contiguous()
+    assert layer.W_UK_T.is_contiguous()
+
+
+def test_mla_v_up_proj_honors_bmm_contiguity(monkeypatch):
+    layer = object.__new__(MLAAttention)
+    layer.num_heads = 8
+    layer.kv_lora_rank = 4
+    layer.v_head_dim = 3
+    layer.is_aiter_triton_fp4_bmm_enabled = False
+    layer.is_aiter_triton_fp8_bmm_enabled = False
+    layer.force_contiguous_mla_bmm_input = True
+    layer.force_contiguous_mla_bmm_output = True
+    layer.W_UV = torch.randn((8, 4, 3), dtype=torch.bfloat16)
+
+    x = torch.randn((6, 8, 4), dtype=torch.bfloat16)
+    out = torch.empty((6, 8, 3), dtype=torch.bfloat16)
+    expected = torch.einsum("bnl,nlv->bnv", x, layer.W_UV)
+    real_bmm = torch.bmm
+    seen_layouts = []
+
+    def checked_bmm(input, mat2, *, out=None):
+        assert out is not None
+        seen_layouts.append((input.is_contiguous(), out.is_contiguous()))
+        return real_bmm(input, mat2, out=out)
+
+    monkeypatch.setattr(torch, "bmm", checked_bmm)
+
+    MLAAttention._v_up_proj(layer, x, out)
+
+    assert seen_layouts == [(True, True)]
+    torch.testing.assert_close(out, expected)
 
 
 # Filtered per-test via validate_configuration (capability/deps/dims).

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -563,6 +563,15 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             **extra_impl_args,
         )
         self.q_pad_num_heads = getattr(self.impl, "q_pad_num_heads", None)
+        self.force_contiguous_mla_bmm_input = getattr(
+            self.impl, "force_contiguous_mla_bmm_input", False
+        )
+        self.force_contiguous_mla_bmm_weight = getattr(
+            self.impl, "force_contiguous_mla_bmm_weight", False
+        )
+        self.force_contiguous_mla_bmm_output = getattr(
+            self.impl, "force_contiguous_mla_bmm_output", False
+        )
         self.use_direct_call = not current_platform.opaque_attention_op()
 
         vllm_config = get_current_vllm_config()
@@ -963,6 +972,9 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 N, B, P = mqa_q_nope.shape
                 _, _, L = self.W_UK_T.shape
 
+                if self.force_contiguous_mla_bmm_input:
+                    mqa_q_nope = mqa_q_nope.contiguous()
+
                 if self.q_pad_num_heads is not None:
                     mqa_ql_nope = mqa_q_nope.new_empty((self.q_pad_num_heads, B, L))
                     mqa_ql_nope.resize_((N, B, L))
@@ -1362,9 +1374,14 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 )
         else:
             # Convert from (L, N, V) to (N, L, V)
-            replace_parameter(self, "W_UV", W_UV.transpose(0, 1), prefer_copy=True)
+            W_UV = W_UV.transpose(0, 1)
             # Convert from (L, N, P) to (N, P, L)
-            replace_parameter(self, "W_UK_T", W_UK.permute(1, 2, 0), prefer_copy=True)
+            W_UK_T = W_UK.permute(1, 2, 0)
+            if self.force_contiguous_mla_bmm_weight:
+                W_UV = W_UV.contiguous()
+                W_UK_T = W_UK_T.contiguous()
+            replace_parameter(self, "W_UV", W_UV, prefer_copy=True)
+            replace_parameter(self, "W_UK_T", W_UK_T, prefer_copy=True)
 
         # If we should not load quant weights, we initialize the scales to 1.0
         # as the default value. See [Note: Register q/k/v/prob scales in state dict]
@@ -1473,7 +1490,21 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             )
         else:
             # Multiply + Transpose (N, B, L) x (N, L, V)->(N, B, V)->(B, N, V)
-            torch.bmm(x, self.W_UV, out=out.transpose(0, 1))
+            # Some CUDA BMM algorithms read a full tile beyond strided tensor
+            # bounds. Backends with tightly mapped buffers opt into contiguous
+            # operands so those accesses stay inside the logical allocation.
+            if self.force_contiguous_mla_bmm_input:
+                x = x.contiguous()
+            if self.force_contiguous_mla_bmm_output:
+                bmm_out = torch.empty(
+                    (self.num_heads, x.shape[1], self.v_head_dim),
+                    dtype=out.dtype,
+                    device=out.device,
+                )
+                torch.bmm(x, self.W_UV, out=bmm_out)
+                out.copy_(bmm_out.transpose(0, 1))
+            else:
+                torch.bmm(x, self.W_UV, out=out.transpose(0, 1))
 
     def _v_up_proj_bmm(
         self,


### PR DESCRIPTION
## Summary

- restore the MLA backend's contiguous BMM input/weight/output contract that was dropped during an upstream rebase
- honor that contract in the query projection and V up-projection BMM paths
- keep all non-opting backends on the existing strided path
- add regression tests for flag propagation, post-load weight layout, and V up-projection operand layout

## Root cause

`B12XMLASparseImpl` still advertises:

```python
force_contiguous_mla_bmm_input = True
force_contiguous_mla_bmm_weight = True
force_contiguous_mla_bmm_output = True
```

but `MLAAttention` no longer consumed those attributes after the rebase. The V up-projection therefore passed a `(8, 6, 512)` BF16 view with strides `(512, 4096, 1)` directly to `cublasGemmStridedBatchedEx`.

A CUDA VMM guard-page reproducer confirmed that the selected cuBLAS 13.4 algorithm reads through `input_base + 64 KiB`, beyond the tensor's 49,152-byte logical storage:

- tight strided operand: deterministic Xid 31 / `FAULT_PDE ACCESS_TYPE_VIRT_READ`
- same allocation with mapped tail padding: passes
- tight contiguous head-major operand, stride `(3072, 512, 1)`: 100/100 iterations pass

This is producer-independent. It affects the B12X PCIe pool path, but TP6 can hit the same unsafe consumer through the NCCL fallback. Padding only B12X pool outputs, as proposed in #135, does not cover TP6 or future producers.

## Fix

The B12X backend opts into the restored contract. `MLAAttention` then:

1. materializes query-projection BMM input when requested;
2. materializes post-load `W_UV` and `W_UK_T` layouts when requested;
3. materializes the V up-projection input in contiguous head-major order;
4. writes the BMM to a contiguous temporary and copies it to the public output layout.

This matches the behavior that existed before the rebase while preserving the default path for every backend that does not opt in.

## Verification

### Unit/regression tests

- 4/4 new and directly affected MLA layout tests passed
- 6/6 existing MLA/DCP decode contract tests passed
- `ruff check` passed
- `git diff --check` passed

### Guard-page reproducer

- strided tight allocation: reproduced Xid 31 at `data_ptr + 0x10000`
- contiguous tight allocation: 100 iterations passed with the guard beginning exactly at the logical allocation end

### GLM-5.2 E2E

Profile:

- TP6 / DCP6 / MTP3
- `GLM-5.2-BF16-AMDMXFP4experts`
- force A8 + online MXFP8
- native allocator; no `expandable_segments`
- no `CUDA_LAUNCH_BLOCKING`
- InstantTensor BUFFERED
- v19 image with only `mla_attention.py` bind-mounted from this change

Stress sequence:

- one 64k warmup
- seven consecutive `8k -> 64k -> first decode token` rounds
- all rounds passed; server remained healthy
- kernel Xid count remained exactly `543 -> 543`

Performance:

- 64k prefill median: `2365 tok/s` versus historical `2373 tok/s` (`-0.34%`)
- CC1 decode runs: `75.21 / 76.61 / 75.76 tok/s`
- patched median: `75.76 tok/s`; same unpatched v19 profile: `74.74 tok/s`

No measurable performance regression was observed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MLA attention backend compatibility by honoring contiguity requirements for BMM inputs, weights, and outputs.
  * Ensured relevant attention tensors and precomputed weights are contiguous when required, improving reliability across supported execution paths.

* **Tests**
  * Added coverage for backend contiguity settings, post-load weight handling, and MLA projection operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->