### PR TITLE
[GG] build: restore CUTLASS DSL 4.6.0 after B12X migration

### DIFF
--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -24,9 +24,7 @@ nvtx==0.2.15
 fastsafetensors >= 0.3.2
 
 # QuACK and Cutlass DSL for FA4 (cute-DSL implementation)
-# 4.6.0 spills the SM120 B12X W4A16 prefill kernel (255 registers and a
-# 256-byte stack per thread); 4.5.3 restores spill-free code generation.
-nvidia-cutlass-dsl[cu13]==4.5.3
+nvidia-cutlass-dsl[cu13]==4.6.0
 quack-kernels>=0.4.0  # Required for tml-fa4
 
 # Tokenspeed_MLA for faster mla with spec decode


### PR DESCRIPTION
## Summary

- Revert #128's CUTLASS DSL 4.5.3 pin.
- Restore `nvidia-cutlass-dsl[cu13]==4.6.0` on `dev/gilded-gnosis`.
- Remove the now-stale spill warning added by #128.

## Why

#128 was correct for the pre-migration B12X W4A16 kernel: CUTLASS DSL 4.6.0 produced a 255-register kernel with a 256-byte per-thread stack and reduced TP8 A16 64k prefill throughput to about 5,052 tok/s.

Current B12X master contains the explicit CUTLASS DSL 4.6 migration (`6627d34`). The tested B12X release commit `bd494bc` contains current master `957b9fd`; its additional commits do not touch W4A16 or CUTLASS dependencies.

## Validation

Exact stack:

- vLLM: `30680faf5cc1fa3122b08749f8a35eab19f63576`
- B12X: `bd494bce8eb7505d0955e8139ecc200093017d9f`
- CUTLASS DSL: `4.6.0`
- GLM-5.2 Luke NVFP4, TP8/DCP1/MTP0, force-A16
- clean JIT cache

64k standalone prefill after warmup:

| Run | tok/s |
|---:|---:|
| 1 | 5,916 |
| 2 | 5,906 |
| 3 | 5,904 |
| **Median** | **5,906** |

The previous 4.5.3 median was 5,909 tok/s, so the difference is measurement noise. The old regressed 4.6.0 result was 5,052 tok/s.

All 40 compiled `W4A16FusedMoeKernel` objects reported `STACK:0 LOCAL:0`. Register counts were 124, 128, 184, 220, or 247; the old `REG:255 STACK:256` artifact was not reproduced.

## Checks

- `git diff --check`
- exact one-file revert verified
- clean-cache TP8 A16 E2E benchmark
- direct `cuobjdump --dump-resource-usage` inspection of all generated W4A16 objects

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the CUDA tooling dependency to version 4.6.0.
  * Removed outdated version-specific dependency notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->