### PR TITLE
[GG] fix(speculation): isolate graph resources and profile MRV2 memory

### DIFF
--- a/tests/distributed/test_b12x_fused_all_reduce.py
+++ b/tests/distributed/test_b12x_fused_all_reduce.py
@@ -141,6 +141,21 @@ def test_b12x_oneshot_defaults_to_stream_isolation(
     assert not envs.environment_variables["VLLM_PCIE_ONESHOT_SINGLE_CHANNEL"]()
 
 
+def test_b12x_channel_checkpoint_delegates_to_runtime() -> None:
+    custom_allreduce, runtime = make_b12x_custom_allreduce(
+        allreduce_max_size=64,
+        fused_max_size=64,
+    )
+    checkpoint = object()
+    runtime.checkpoint_channels.return_value = checkpoint
+
+    assert custom_allreduce.checkpoint_pcie_channels() is checkpoint
+    custom_allreduce.rollback_pcie_channels(checkpoint)
+
+    runtime.checkpoint_channels.assert_called_once_with()
+    runtime.rollback_channels.assert_called_once_with(checkpoint)
+
+
 def test_b12x_oneshot_buffer_tracks_dispatch_limits(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/distributed/test_b12x_fused_all_reduce.py
+++ b/tests/distributed/test_b12x_fused_all_reduce.py
@@ -7,6 +7,7 @@ import pytest
 import torch
 import torch.distributed as dist
 
+import vllm.envs as envs
 import vllm.ir.ops
 from tests.compile.backend import TestBackend
 from vllm.compilation.passes.fusion import allreduce_rms_fusion
@@ -26,6 +27,7 @@ from vllm.config import (
 from vllm.distributed import tensor_model_parallel_all_reduce
 from vllm.distributed.device_communicators.custom_all_reduce import (
     CustomAllreduce,
+    _b12x_pcie_oneshot_limits,
     get_b12x_pcie_allreduce,
 )
 from vllm.distributed.parallel_state import get_tp_group, graph_capture
@@ -129,6 +131,30 @@ def test_b12x_fused_allreduce_zero_cutoff_disables_support() -> None:
     )
 
     assert not custom_allreduce.supports_fused_add_rms_norm()
+
+
+def test_b12x_oneshot_defaults_to_stream_isolation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("VLLM_PCIE_ONESHOT_SINGLE_CHANNEL", raising=False)
+
+    assert not envs.environment_variables["VLLM_PCIE_ONESHOT_SINGLE_CHANNEL"]()
+
+
+def test_b12x_oneshot_buffer_tracks_dispatch_limits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VLLM_PCIE_ONESHOT_ALLREDUCE_MAX_SIZE", "64KB")
+    monkeypatch.setenv(
+        "VLLM_PCIE_ONESHOT_FUSED_ADD_RMS_NORM_MAX_SIZE",
+        "84KB",
+    )
+
+    assert _b12x_pcie_oneshot_limits() == (
+        64 * 1024,
+        84 * 1024,
+        84 * 1024,
+    )
 
 
 def test_b12x_fused_custom_op_dispatch(monkeypatch) -> None:

--- a/tests/distributed/test_dcp_a2a.py
+++ b/tests/distributed/test_dcp_a2a.py
@@ -10,6 +10,7 @@ Tests cover:
 
 import importlib.util
 import math
+from contextlib import contextmanager
 from typing import Any
 
 import multiprocess as mp
@@ -536,6 +537,122 @@ def test_b12x_pool_init_consensus_uses_exchange_group(
     assert captured["tensor_device"] == device
     assert captured["group"] is device_group
     assert captured["op"] == dist.ReduceOp.MAX
+
+
+def test_b12x_pool_uses_independent_stream_channels(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from vllm.v1.attention.ops import dcp_alltoall
+
+    captured: dict[str, Any] = {}
+
+    class _FakePool:
+        @classmethod
+        def from_exchange_group(cls, **kwargs):
+            captured.update(kwargs)
+            return cls()
+
+        def for_stream(self):
+            captured["warmed"] = True
+
+    group = _FakeCPGroup(2, object())  # type: ignore[arg-type]
+    monkeypatch.setattr(dcp_alltoall, "_B12X_DCP_A2A_POOLS", {})
+    monkeypatch.setattr(dcp_alltoall, "_B12X_DCP_A2A_DISABLED", set())
+    monkeypatch.setattr(dcp_alltoall, "_load_b12x_dcp_a2a_pool", lambda: _FakePool)
+    monkeypatch.setattr(dcp_alltoall, "_b12x_dcp_init_failed", lambda *args: False)
+    monkeypatch.setattr(
+        dcp_alltoall.torch.cuda,
+        "is_current_stream_capturing",
+        lambda: False,
+    )
+
+    pool = dcp_alltoall._get_b12x_dcp_a2a_pool(
+        group,  # type: ignore[arg-type]
+        device=torch.device("cuda:0"),
+        total_heads=64,
+        head_dim=512,
+        query_head_dim=576,
+        max_batch_size=64,
+    )
+
+    assert pool is not None
+    assert captured["single_channel"] is False
+    assert captured["warmed"] is True
+
+
+def test_b12x_dcp_capture_selects_only_current_group_pools(monkeypatch):
+    from vllm.v1.attention.ops import dcp_alltoall
+
+    events = []
+
+    class _FakePool:
+        def __init__(self, name):
+            self.name = name
+
+        @contextmanager
+        def capture(self, *, stream):
+            events.append(("enter", self.name, stream))
+            try:
+                yield
+            finally:
+                events.append(("exit", self.name, stream))
+
+    device_group = object()
+    group = _FakeCPGroup(2, device_group)  # type: ignore[arg-type]
+    stream = object()
+    pools = {
+        (id(device_group), 0, 64, 512, 576, 64): _FakePool("output"),
+        (id(device_group), 0, 64, 576, 576, 64): _FakePool("query"),
+        (id(object()), 0, 64, 512, 576, 64): _FakePool("foreign"),
+    }
+    monkeypatch.setattr(dcp_alltoall, "_B12X_DCP_A2A_POOLS", pools)
+
+    with dcp_alltoall.capture_b12x_dcp_a2a(group, stream):  # type: ignore[arg-type]
+        events.append(("body", None, stream))
+
+    assert events == [
+        ("enter", "output", stream),
+        ("enter", "query", stream),
+        ("body", None, stream),
+        ("exit", "query", stream),
+        ("exit", "output", stream),
+    ]
+
+
+def test_global_graph_capture_enters_b12x_dcp_pool(monkeypatch):
+    from vllm.distributed import parallel_state
+    from vllm.v1.attention.ops import dcp_alltoall
+
+    events = []
+
+    class _FakeGroup:
+        world_size = 2
+
+        @contextmanager
+        def graph_capture(self, context):
+            yield context
+
+    tp_group = _FakeGroup()
+    pp_group = _FakeGroup()
+    dcp_group = _FakeGroup()
+    stream = object()
+    context = parallel_state.GraphCaptureContext(stream)  # type: ignore[arg-type]
+
+    @contextmanager
+    def fake_b12x_capture(group, selected_stream):
+        events.append((group, selected_stream))
+        yield
+
+    monkeypatch.setattr(parallel_state, "_DCP", dcp_group)
+    monkeypatch.setattr(parallel_state, "get_tp_group", lambda: tp_group)
+    monkeypatch.setattr(parallel_state, "get_pp_group", lambda: pp_group)
+    monkeypatch.setattr(parallel_state, "get_dcp_group", lambda: dcp_group)
+    monkeypatch.setattr(dcp_alltoall, "capture_b12x_dcp_a2a", fake_b12x_capture)
+
+    with parallel_state.graph_capture(torch.device("cpu"), context) as actual:
+        assert actual is context
+
+    assert events == [(dcp_group, stream)]
 
 
 @pytest.mark.skipif(torch.accelerator.device_count() < 1, reason="CUDA is required.")

--- a/tests/distributed/test_dcp_a2a.py
+++ b/tests/distributed/test_dcp_a2a.py
@@ -619,6 +619,100 @@ def test_b12x_dcp_capture_selects_only_current_group_pools(monkeypatch):
     ]
 
 
+def test_b12x_dcp_channel_rollback_restores_existing_and_closes_new_pools(
+    monkeypatch,
+):
+    from vllm.v1.attention.ops import dcp_alltoall
+
+    events = []
+
+    class _FakePool:
+        def __init__(self, name):
+            self.name = name
+
+        def checkpoint_channels(self):
+            events.append(("checkpoint", self.name))
+            return f"{self.name}-checkpoint"
+
+        def rollback_channels(self, checkpoint):
+            events.append(("rollback", self.name, checkpoint))
+
+        def close(self):
+            events.append(("close", self.name))
+
+    device_group = object()
+    group = _FakeCPGroup(2, device_group)  # type: ignore[arg-type]
+    existing_key = (id(device_group), 0, 64, 512, 576, 64)
+    new_key = (id(device_group), 0, 64, 576, 576, 64)
+    foreign_key = (id(object()), 0, 64, 512, 576, 64)
+    existing = _FakePool("existing")
+    foreign = _FakePool("foreign")
+    pools = {existing_key: existing, foreign_key: foreign}
+    monkeypatch.setattr(dcp_alltoall, "_B12X_DCP_A2A_POOLS", pools)
+
+    checkpoint = dcp_alltoall.checkpoint_b12x_dcp_a2a_channels(group)
+    transient = _FakePool("transient")
+    pools[new_key] = transient
+    dcp_alltoall.rollback_b12x_dcp_a2a_channels(checkpoint)
+
+    assert pools == {existing_key: existing, foreign_key: foreign}
+    assert events == [
+        ("checkpoint", "existing"),
+        ("rollback", "existing", "existing-checkpoint"),
+        ("close", "transient"),
+    ]
+
+
+def test_profile_channel_checkpoint_rolls_back_all_b12x_transports(monkeypatch):
+    from vllm.distributed import parallel_state
+    from vllm.v1.attention.ops import dcp_alltoall
+
+    events = []
+
+    class _FakeCommunicator:
+        def checkpoint_pcie_channels(self):
+            events.append("checkpoint-tp")
+            return "tp-checkpoint"
+
+        def rollback_pcie_channels(self, checkpoint):
+            events.append(("rollback-tp", checkpoint))
+
+    class _FakeGroup:
+        def __init__(self, *, world_size, communicator=None):
+            self.world_size = world_size
+            self.device_communicator = type(
+                "DeviceCommunicator", (), {"ca_comm": communicator}
+            )()
+
+    communicator = _FakeCommunicator()
+    tp_group = _FakeGroup(world_size=8, communicator=communicator)
+    pp_group = _FakeGroup(world_size=1, communicator=communicator)
+    dcp_group = _FakeGroup(world_size=2)
+    monkeypatch.setattr(parallel_state, "_TP", tp_group)
+    monkeypatch.setattr(parallel_state, "_PP", pp_group)
+    monkeypatch.setattr(parallel_state, "_DCP", dcp_group)
+    monkeypatch.setattr(
+        dcp_alltoall,
+        "checkpoint_b12x_dcp_a2a_channels",
+        lambda group: events.append("checkpoint-dcp") or "dcp-checkpoint",
+    )
+    monkeypatch.setattr(
+        dcp_alltoall,
+        "rollback_b12x_dcp_a2a_channels",
+        lambda checkpoint: events.append(("rollback-dcp", checkpoint)),
+    )
+
+    checkpoint = parallel_state.checkpoint_b12x_graph_channels()
+    parallel_state.rollback_b12x_graph_channels(checkpoint)
+
+    assert events == [
+        "checkpoint-tp",
+        "checkpoint-dcp",
+        ("rollback-dcp", "dcp-checkpoint"),
+        ("rollback-tp", "tp-checkpoint"),
+    ]
+
+
 def test_global_graph_capture_enters_b12x_dcp_pool(monkeypatch):
     from vllm.distributed import parallel_state
     from vllm.v1.attention.ops import dcp_alltoall

--- a/tests/v1/attention/test_b12x_mla_dcp_workspace.py
+++ b/tests/v1/attention/test_b12x_mla_dcp_workspace.py
@@ -110,6 +110,37 @@ def test_sparse_profile_reserves_largest_non_workspace_ag_rs_batch(monkeypatch):
     assert attn._get_sparse_memory_profile_bytes() == expected
 
 
+def test_sparse_profile_accounts_for_projected_fallback_before_workspace(monkeypatch):
+    attn, workspace_enabled = _make_profile_attention(workspace_enabled=True)
+    attn.dcp_project_before_merge_min_prefill_tokens = 512
+    monkeypatch.setattr(envs, "VLLM_MEMORY_PROFILE_INCLUDE_ATTN", True)
+    monkeypatch.setattr(
+        envs, "VLLM_B12X_MLA_DCP_GATHER_IN_WORKSPACE", workspace_enabled
+    )
+
+    unprojected = _estimate_dcp_ag_rs_transient_bytes(
+        num_tokens=512,
+        local_heads=11,
+        dcp_world_size=6,
+        q_head_dim=576,
+        output_head_dim=512,
+        kv_lora_rank=512,
+        v_head_dim=256,
+        project_before_merge=False,
+    )
+    projected = _estimate_dcp_ag_rs_transient_bytes(
+        num_tokens=1024,
+        local_heads=11,
+        dcp_world_size=6,
+        q_head_dim=576,
+        output_head_dim=256,
+        kv_lora_rank=512,
+        v_head_dim=256,
+        project_before_merge=True,
+    )
+    assert attn._get_sparse_memory_profile_bytes() == max(unprojected, projected)
+
+
 def test_sparse_profile_accounts_for_projected_fallback_without_workspace(monkeypatch):
     attn, workspace_enabled = _make_profile_attention(workspace_enabled=False)
     monkeypatch.setattr(envs, "VLLM_MEMORY_PROFILE_INCLUDE_ATTN", True)

--- a/tests/v1/attention/test_b12x_mla_dcp_workspace.py
+++ b/tests/v1/attention/test_b12x_mla_dcp_workspace.py
@@ -4,8 +4,11 @@
 import pytest
 import torch
 
+from vllm import envs
 from vllm.model_executor.layers.attention.mla_attention import (
+    MLAAttention,
     _can_use_b12x_dcp_prefill_workspace,
+    _estimate_dcp_ag_rs_transient_bytes,
 )
 from vllm.v1.attention.backends.mla.b12x_mla_sparse import B12xMLASparseImpl
 from vllm.v1.attention.ops import common
@@ -58,6 +61,110 @@ def test_dcp_workspace_gate_accepts_valid_rows(num_tokens, max_num_tokens):
         backend_name="B12X_MLA_SPARSE",
         is_capturing=False,
     )
+
+
+def _make_profile_attention(*, workspace_enabled: bool, pure_a2a: bool = False):
+    class Backend:
+        @staticmethod
+        def get_name():
+            return "B12X_MLA_SPARSE"
+
+    class Impl:
+        dcp_world_size = 6
+        dcp_workspace_non_dbo = True
+        is_sparse = True
+        _max_batched = 4096
+
+    attn = object.__new__(MLAAttention)
+    attn.attn_backend = Backend
+    attn.impl = Impl()
+    attn.num_heads = 11
+    attn.kv_lora_rank = 512
+    attn.qk_rope_head_dim = 64
+    attn.v_head_dim = 256
+    attn.dcp_project_before_merge = True
+    attn.dcp_project_before_merge_min_prefill_tokens = 1024
+    attn.dcp_a2a = True
+    attn.dcp_a2a_max_tokens = 0 if pure_a2a else 256
+    attn.dcp_a2a_large_backend = "ag_rs"
+    return attn, workspace_enabled
+
+
+def test_sparse_profile_reserves_largest_non_workspace_ag_rs_batch(monkeypatch):
+    attn, workspace_enabled = _make_profile_attention(workspace_enabled=True)
+    monkeypatch.setattr(envs, "VLLM_MEMORY_PROFILE_INCLUDE_ATTN", True)
+    monkeypatch.setattr(
+        envs, "VLLM_B12X_MLA_DCP_GATHER_IN_WORKSPACE", workspace_enabled
+    )
+
+    expected = _estimate_dcp_ag_rs_transient_bytes(
+        num_tokens=1024,
+        local_heads=11,
+        dcp_world_size=6,
+        q_head_dim=576,
+        output_head_dim=512,
+        kv_lora_rank=512,
+        v_head_dim=256,
+        project_before_merge=False,
+    )
+    assert attn._get_sparse_memory_profile_bytes() == expected
+
+
+def test_sparse_profile_accounts_for_projected_fallback_without_workspace(monkeypatch):
+    attn, workspace_enabled = _make_profile_attention(workspace_enabled=False)
+    monkeypatch.setattr(envs, "VLLM_MEMORY_PROFILE_INCLUDE_ATTN", True)
+    monkeypatch.setattr(
+        envs, "VLLM_B12X_MLA_DCP_GATHER_IN_WORKSPACE", workspace_enabled
+    )
+
+    unprojected = _estimate_dcp_ag_rs_transient_bytes(
+        num_tokens=1024,
+        local_heads=11,
+        dcp_world_size=6,
+        q_head_dim=576,
+        output_head_dim=512,
+        kv_lora_rank=512,
+        v_head_dim=256,
+        project_before_merge=False,
+    )
+    projected = _estimate_dcp_ag_rs_transient_bytes(
+        num_tokens=4096,
+        local_heads=11,
+        dcp_world_size=6,
+        q_head_dim=576,
+        output_head_dim=256,
+        kv_lora_rank=512,
+        v_head_dim=256,
+        project_before_merge=True,
+    )
+    assert attn._get_sparse_memory_profile_bytes() == max(unprojected, projected)
+
+
+def test_sparse_profile_accounts_for_unprojected_full_batch(monkeypatch):
+    attn, _ = _make_profile_attention(workspace_enabled=False)
+    attn.dcp_project_before_merge = False
+    monkeypatch.setattr(envs, "VLLM_MEMORY_PROFILE_INCLUDE_ATTN", True)
+    monkeypatch.setattr(envs, "VLLM_B12X_MLA_DCP_GATHER_IN_WORKSPACE", False)
+
+    expected = _estimate_dcp_ag_rs_transient_bytes(
+        num_tokens=4096,
+        local_heads=11,
+        dcp_world_size=6,
+        q_head_dim=576,
+        output_head_dim=512,
+        kv_lora_rank=512,
+        v_head_dim=256,
+        project_before_merge=False,
+    )
+    assert attn._get_sparse_memory_profile_bytes() == expected
+
+
+def test_sparse_profile_skips_pure_a2a(monkeypatch):
+    attn, _ = _make_profile_attention(workspace_enabled=True, pure_a2a=True)
+    monkeypatch.setattr(envs, "VLLM_MEMORY_PROFILE_INCLUDE_ATTN", True)
+    monkeypatch.setattr(envs, "VLLM_B12X_MLA_DCP_GATHER_IN_WORKSPACE", True)
+
+    assert attn._get_sparse_memory_profile_bytes() == 0
 
 
 @pytest.mark.parametrize("world_size", [2, 3, 4, 6, 8])

--- a/tests/v1/cudagraph/test_breakable_cudagraph.py
+++ b/tests/v1/cudagraph/test_breakable_cudagraph.py
@@ -46,6 +46,7 @@ def test_memory_profile_destroys_graphs_before_restoring_pools(monkeypatch):
     profile_pool = object()
     production_pool = object()
     events: list[str] = []
+    lazy_wrappers: list[FakeWrapper] = []
 
     class FakeManager:
         def __init__(self):
@@ -57,6 +58,9 @@ def test_memory_profile_destroys_graphs_before_restoring_pools(monkeypatch):
         def capture(self, *args, **kwargs):
             assert self.pool is profile_pool
             assert wrapper.graph_pool is profile_pool
+            lazy_wrapper = FakeWrapper()
+            lazy_wrapper.graph_pool = self.pool
+            lazy_wrappers.append(lazy_wrapper)
             events.append("capture")
 
     class FakeWrapper:
@@ -96,6 +100,7 @@ def test_memory_profile_destroys_graphs_before_restoring_pools(monkeypatch):
         events.append("cleanup")
         assert manager.pool is profile_pool
         assert wrapper.graph_pool is profile_pool
+        assert lazy_wrappers[0].graph_pool is profile_pool
 
     runner._cleanup_cudagraph_memory_profile = cleanup
 
@@ -115,7 +120,9 @@ def test_memory_profile_destroys_graphs_before_restoring_pools(monkeypatch):
         model_runner_module.CUDAGraphWrapper, "_all_instances", [wrapper]
     )
     monkeypatch.setattr(
-        model_runner_module.BreakableCUDAGraphWrapper, "_all_instances", []
+        model_runner_module.BreakableCUDAGraphWrapper,
+        "_all_instances",
+        lazy_wrappers,
     )
     monkeypatch.setattr(model_runner_module.gc, "collect", lambda: None)
     monkeypatch.setattr(torch.accelerator, "empty_cache", lambda: None)
@@ -147,6 +154,34 @@ def test_memory_profile_destroys_graphs_before_restoring_pools(monkeypatch):
     assert workspace_module._workspace_lane.get() == 0
     assert manager.pool is production_pool
     assert wrapper.graph_pool is production_pool
+    assert lazy_wrappers[0].graph_pool is production_pool
+
+
+def test_breakable_runner_inherits_active_manager_pool(monkeypatch):
+    from vllm.v1.worker.gpu import cudagraph_utils
+
+    active_pool = object()
+
+    class FakeBreakableWrapper:
+        def __init__(self, model, vllm_config):
+            self.model = model
+            self.vllm_config = vllm_config
+            self.graph_pool = object()
+
+    monkeypatch.setattr(
+        cudagraph_utils, "BreakableCUDAGraphWrapper", FakeBreakableWrapper
+    )
+    manager = cudagraph_utils.CudaGraphManager.__new__(cudagraph_utils.CudaGraphManager)
+    manager.breakable_cg_runner = None
+    manager.vllm_config = object()
+    manager.pool = active_pool
+    model = object()
+
+    manager.init_breakable_cg_runner(model)
+
+    assert manager.breakable_cg_runner is not None
+    assert manager.breakable_cg_runner.model is model
+    assert manager.breakable_cg_runner.graph_pool is active_pool
 
 
 def test_piecewise_capture_builds_fresh_metadata_for_both_passes():

--- a/tests/v1/cudagraph/test_breakable_cudagraph.py
+++ b/tests/v1/cudagraph/test_breakable_cudagraph.py
@@ -9,12 +9,144 @@ from __future__ import annotations
 import os
 import threading
 from contextlib import nullcontext
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
 import torch
 
 os.environ["VLLM_USE_BREAKABLE_CUDAGRAPH"] = "1"
+
+
+def test_cudagraph_manager_clear_releases_capture_state():
+    from vllm.v1.worker.gpu.cudagraph_utils import ModelCudaGraphManager
+
+    manager = ModelCudaGraphManager.__new__(ModelCudaGraphManager)
+    manager.graphs = {object(): object()}
+    manager._graphs_captured = True
+    manager.breakable_cg_runner = object()
+    manager.hidden_states = object()
+    manager.aux_hidden_states = [object()]
+    manager.intermediate_tensors = object()
+
+    manager.clear()
+
+    assert manager.graphs == {}
+    assert not manager._graphs_captured
+    assert manager.breakable_cg_runner is None
+    assert manager.hidden_states is None
+    assert manager.aux_hidden_states == []
+    assert manager.intermediate_tensors is None
+
+
+def test_memory_profile_destroys_graphs_before_restoring_pools(monkeypatch):
+    from vllm.v1.worker import workspace as workspace_module
+    from vllm.v1.worker.gpu import model_runner as model_runner_module
+
+    profile_pool = object()
+    production_pool = object()
+    events: list[str] = []
+
+    class FakeManager:
+        def __init__(self):
+            self.pool = production_pool
+
+        def needs_capture(self):
+            return True
+
+        def capture(self, *args, **kwargs):
+            assert self.pool is profile_pool
+            assert wrapper.graph_pool is profile_pool
+            events.append("capture")
+
+    class FakeWrapper:
+        def __init__(self):
+            self.graph_pool = production_pool
+
+    class FakeSpeculator:
+        def get_cudagraph_managers(self):
+            return []
+
+        def capture(self):
+            assert workspace_module._workspace_lane.get() == 1
+            events.append("spec_capture")
+
+    manager = FakeManager()
+    wrapper = FakeWrapper()
+    runner = model_runner_module.GPUModelRunner.__new__(
+        model_runner_module.GPUModelRunner
+    )
+    runner.vllm_config = object()
+    runner.cudagraph_manager = manager
+    runner.speculator = FakeSpeculator()
+    runner.lora_config = None
+    runner.model = object()
+    runner.model_state = object()
+    runner.input_buffers = object()
+    runner.intermediate_tensors = object()
+    runner.block_tables = object()
+    runner.attn_groups = object()
+    runner.kv_cache_config = object()
+    runner.use_aux_hidden_state_outputs = False
+    runner._init_minimal_kv_cache_for_profiling = lambda: None
+    runner.maybe_setup_dummy_loras = lambda _: nullcontext()
+    runner._zero_cudagraph_capture_kv_blocks = lambda: None
+
+    def cleanup():
+        events.append("cleanup")
+        assert manager.pool is profile_pool
+        assert wrapper.graph_pool is profile_pool
+
+    runner._cleanup_cudagraph_memory_profile = cleanup
+
+    memory_info = iter(((1000, 0), (900, 0), (950, 0)))
+    monkeypatch.setattr(
+        model_runner_module, "set_current_vllm_config", lambda _: nullcontext()
+    )
+    monkeypatch.setattr(
+        model_runner_module,
+        "current_platform",
+        SimpleNamespace(
+            graph_pool_handle=lambda: profile_pool,
+            get_global_graph_pool=lambda: production_pool,
+        ),
+    )
+    monkeypatch.setattr(
+        model_runner_module.CUDAGraphWrapper, "_all_instances", [wrapper]
+    )
+    monkeypatch.setattr(
+        model_runner_module.BreakableCUDAGraphWrapper, "_all_instances", []
+    )
+    monkeypatch.setattr(model_runner_module.gc, "collect", lambda: None)
+    monkeypatch.setattr(torch.accelerator, "empty_cache", lambda: None)
+    monkeypatch.setattr(torch.accelerator, "synchronize", lambda: None)
+    monkeypatch.setattr(torch.accelerator, "get_memory_info", lambda: next(memory_info))
+    monkeypatch.setattr(
+        model_runner_module,
+        "checkpoint_b12x_graph_channels",
+        lambda: events.append("checkpoint") or ("channel-checkpoint",),
+    )
+    monkeypatch.setattr(
+        model_runner_module,
+        "rollback_b12x_graph_channels",
+        lambda checkpoint: (
+            events.append("rollback")
+            if checkpoint == ("channel-checkpoint",)
+            else pytest.fail("rollback received the wrong channel checkpoint")
+        ),
+    )
+
+    assert runner.profile_cudagraph_memory() == 50
+    assert events == [
+        "checkpoint",
+        "capture",
+        "spec_capture",
+        "cleanup",
+        "rollback",
+    ]
+    assert workspace_module._workspace_lane.get() == 0
+    assert manager.pool is production_pool
+    assert wrapper.graph_pool is production_pool
 
 
 def test_piecewise_capture_builds_fresh_metadata_for_both_passes():

--- a/tests/v1/worker/test_workspace.py
+++ b/tests/v1/worker/test_workspace.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+import vllm.v1.worker.workspace as workspace
+
+
+def test_workspace_lanes_do_not_alias_and_restore_context(monkeypatch) -> None:
+    ubatch_id = 0
+    monkeypatch.setattr(workspace, "dbo_current_ubatch_id", lambda: ubatch_id)
+    manager = workspace.WorkspaceManager(
+        torch.device("cpu"), num_ubatches=2, num_lanes=2
+    )
+
+    (target,) = manager.get_simultaneous(((16,), torch.uint8))
+    with workspace.use_workspace_lane(1):
+        (draft,) = manager.get_simultaneous(((16,), torch.uint8))
+        (draft_reused,) = manager.get_simultaneous(((8,), torch.uint8))
+
+    (target_reused,) = manager.get_simultaneous(((8,), torch.uint8))
+
+    assert target.data_ptr() != draft.data_ptr()
+    assert draft.data_ptr() == draft_reused.data_ptr()
+    assert target.data_ptr() == target_reused.data_ptr()
+
+
+def test_workspace_lanes_compose_with_ubatches(monkeypatch) -> None:
+    active_ubatch = [0]
+    monkeypatch.setattr(workspace, "dbo_current_ubatch_id", lambda: active_ubatch[0])
+    manager = workspace.WorkspaceManager(
+        torch.device("cpu"), num_ubatches=2, num_lanes=2
+    )
+
+    pointers = set()
+    for ubatch_id in range(2):
+        active_ubatch[0] = ubatch_id
+        for lane in range(2):
+            with workspace.use_workspace_lane(lane):
+                (buffer,) = manager.get_simultaneous(((16,), torch.uint8))
+                pointers.add(buffer.data_ptr())
+
+    assert len(pointers) == 4
+
+
+def test_workspace_lane_validation() -> None:
+    manager = workspace.WorkspaceManager(torch.device("cpu"), num_lanes=1)
+
+    with (
+        pytest.raises(ValueError, match="non-negative"),
+        workspace.use_workspace_lane(-1),
+    ):
+        pass
+
+    with (
+        workspace.use_workspace_lane(1),
+        pytest.raises(RuntimeError, match="is not configured"),
+    ):
+        manager.get_simultaneous(((1,), torch.uint8))
+
+    with pytest.raises(ValueError, match="at least one"):
+        workspace.WorkspaceManager(torch.device("cpu"), num_lanes=0)

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -644,10 +644,11 @@ class CustomAllreduce:
 
     @contextmanager
     def capture(self, stream: torch.cuda.Stream | None = None):
-        """
-        The main responsibility of this context manager is the
-        `register_graph_buffers` call at the end of the context.
-        It records all the buffer addresses used in the CUDA graph.
+        """Bind communicator resources to the enclosing CUDA graph capture.
+
+        Legacy custom all-reduce registers graph buffers on exit. SparkInfer
+        PCIe channels are instead created on the graph's owning stream and
+        remain valid for the graph lifetime.
         """
         old_pcie_capture_stream = self._pcie_capture_stream
         try:
@@ -663,6 +664,34 @@ class CustomAllreduce:
             self._IS_CAPTURING = False
             if not self.disabled and self._pcie_runtime is None:
                 self.register_graph_buffers()
+
+    def checkpoint_pcie_channels(self) -> Any | None:
+        """Snapshot SparkInfer PCIe channels before a disposable capture.
+
+        Returns:
+            An opaque runtime checkpoint, or ``None`` when PCIe all-reduce is
+            unavailable.
+        """
+        runtime = self._pcie_runtime
+        checkpoint = getattr(runtime, "checkpoint_channels", None)
+        if checkpoint is None:
+            return None
+        return checkpoint()
+
+    def rollback_pcie_channels(self, checkpoint: Any) -> None:
+        """Release SparkInfer PCIe channels created after ``checkpoint``.
+
+        Args:
+            checkpoint: Opaque state returned by ``checkpoint_pcie_channels``.
+
+        Raises:
+            RuntimeError: If the SparkInfer PCIe runtime is unavailable.
+        """
+        runtime = self._pcie_runtime
+        rollback = getattr(runtime, "rollback_channels", None)
+        if rollback is None:
+            raise RuntimeError("SparkInfer PCIe all-reduce runtime is unavailable")
+        rollback(checkpoint)
 
     def _pcie_runtime_stream(self) -> torch.cuda.Stream | None:
         pinned = self._pcie_capture_stream

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -80,6 +80,20 @@ def _parse_byte_size(value: str) -> int:
     return int(value)
 
 
+def _b12x_pcie_oneshot_limits() -> tuple[int, int, int]:
+    allreduce_max_size = _parse_byte_size(envs.VLLM_PCIE_ONESHOT_ALLREDUCE_MAX_SIZE)
+    fused_max_size = _parse_byte_size(
+        envs.VLLM_PCIE_ONESHOT_FUSED_ADD_RMS_NORM_MAX_SIZE
+    )
+    if allreduce_max_size < 0 or fused_max_size < 0:
+        raise ValueError("b12x PCIe oneshot size limits must be non-negative")
+    # The pool only dispatches tensors within these limits. Reserving the
+    # scheduler's full prefill tensor capacity per stream wastes hundreds of
+    # MiB once target and draft graphs use independent channels.
+    buffer_size = max(allreduce_max_size, fused_max_size, 16)
+    return allreduce_max_size, fused_max_size, buffer_size
+
+
 @lru_cache(maxsize=1)
 def _load_b12x_pcie_oneshot_pool() -> Any | None:
     try:
@@ -424,9 +438,8 @@ class CustomAllreduce:
                     "sparkinfer.comm.pcie.OneshotAllReducePool is unavailable."
                 )
                 return
-            # The largest allreduce the model can issue (prefill chunk x
-            # hidden) determines buffer capacity. Dispatch crossovers come
-            # from envs below so startup does not benchmark the serving GPUs.
+            # DMA must accommodate the largest scheduled prefill tensor. The
+            # oneshot pool only needs its much smaller dispatch cutoffs.
             try:
                 from vllm.config import get_current_vllm_config
 
@@ -446,6 +459,11 @@ class CustomAllreduce:
                 )
             pcie_buffer_size = max_num_batched_tokens * model_hidden_size * 2
             pcie_single_channel = envs.VLLM_PCIE_ONESHOT_SINGLE_CHANNEL
+            (
+                self._pcie_allreduce_max_size,
+                self._pcie_fused_add_rms_norm_max_size,
+                pcie_oneshot_buffer_size,
+            ) = _b12x_pcie_oneshot_limits()
             if self.nccl_group is None:
                 logger.warning(
                     "Custom allreduce is disabled because b12x PCIe oneshot "
@@ -453,8 +471,6 @@ class CustomAllreduce:
                 )
                 return
             self.max_size = pcie_buffer_size
-            self._pcie_allreduce_max_size = 0
-            self._pcie_fused_add_rms_norm_max_size = 0
             self.rank = rank
             self.world_size = world_size
             self.fully_connected = False
@@ -464,8 +480,8 @@ class CustomAllreduce:
                 pcie_runtime = pool_cls.from_exchange_group(
                     exchange_group=self.nccl_group,
                     device=self.device,
-                    eager_buffer_bytes=pcie_buffer_size,
-                    max_size=pcie_buffer_size,
+                    eager_buffer_bytes=pcie_oneshot_buffer_size,
+                    max_size=pcie_oneshot_buffer_size,
                     single_channel=pcie_single_channel,
                 )
                 pcie_runtime.for_stream()
@@ -544,12 +560,6 @@ class CustomAllreduce:
                     self._pcie_dma = dma
                     logger.debug("b12x PCIe DMA allreduce wire mode: %s", dma.wire_mode)
 
-            self._pcie_allreduce_max_size = _parse_byte_size(
-                envs.VLLM_PCIE_ONESHOT_ALLREDUCE_MAX_SIZE
-            )
-            self._pcie_fused_add_rms_norm_max_size = _parse_byte_size(
-                envs.VLLM_PCIE_ONESHOT_FUSED_ADD_RMS_NORM_MAX_SIZE
-            )
             if rank == 0:
                 logger.info(
                     "Configured b12x PCIe crossovers: "
@@ -562,12 +572,14 @@ class CustomAllreduce:
             logger.debug(
                 "Using b12x PCIe oneshot allreduce backend "
                 "(world_size=%d, allreduce_max_size=%d, "
-                "fused_add_rms_norm_max_size=%d, buffer_size=%d, "
+                "fused_add_rms_norm_max_size=%d, oneshot_buffer_size=%d, "
+                "dma_buffer_size=%d, "
                 "single_channel=%s).",
                 world_size,
                 self._pcie_allreduce_max_size,
                 self._pcie_fused_add_rms_norm_max_size,
-                self.max_size,
+                pcie_oneshot_buffer_size,
+                pcie_buffer_size,
                 pcie_single_channel,
             )
             return

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -1508,10 +1508,20 @@ def graph_capture(
         if _DCP is not None and get_dcp_group().world_size > 1
         else nullcontext()
     )
+    if _DCP is not None and get_dcp_group().world_size > 1:
+        # Import locally to avoid making distributed initialization depend on
+        # attention modules. The helper is a no-op until DCP warmup creates a
+        # B12X pool for this process group.
+        from vllm.v1.attention.ops.dcp_alltoall import capture_b12x_dcp_a2a
+
+        maybe_b12x_dcp_capture = capture_b12x_dcp_a2a(get_dcp_group(), context.stream)
+    else:
+        maybe_b12x_dcp_capture = nullcontext()
     with (
         get_tp_group().graph_capture(context),
         get_pp_group().graph_capture(context),
         maybe_dcp_capture,
+        maybe_b12x_dcp_capture,
     ):
         yield context
 

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -1439,6 +1439,47 @@ def get_pp_group() -> GroupCoordinator:
     return _PP
 
 
+def checkpoint_b12x_graph_channels() -> tuple[tuple[Callable[[Any], None], Any], ...]:
+    """Snapshot SparkInfer channels used by disposable graph captures."""
+    checkpoints: list[tuple[Callable[[Any], None], Any]] = []
+    seen_communicators: set[int] = set()
+    for group in (_TP, _DCP, _PP):
+        device_communicator = None if group is None else group.device_communicator
+        communicator = getattr(device_communicator, "ca_comm", None)
+        if communicator is None or id(communicator) in seen_communicators:
+            continue
+        seen_communicators.add(id(communicator))
+        checkpoint_fn = getattr(communicator, "checkpoint_pcie_channels", None)
+        rollback_fn = getattr(communicator, "rollback_pcie_channels", None)
+        if checkpoint_fn is None or rollback_fn is None:
+            continue
+        checkpoint = checkpoint_fn()
+        if checkpoint is not None:
+            checkpoints.append((rollback_fn, checkpoint))
+
+    if _DCP is not None and _DCP.world_size > 1:
+        from vllm.v1.attention.ops.dcp_alltoall import (
+            checkpoint_b12x_dcp_a2a_channels,
+            rollback_b12x_dcp_a2a_channels,
+        )
+
+        checkpoints.append(
+            (
+                rollback_b12x_dcp_a2a_channels,
+                checkpoint_b12x_dcp_a2a_channels(_DCP),
+            )
+        )
+    return tuple(checkpoints)
+
+
+def rollback_b12x_graph_channels(
+    checkpoints: tuple[tuple[Callable[[Any], None], Any], ...],
+) -> None:
+    """Roll back SparkInfer channels after disposable graphs are destroyed."""
+    for rollback, checkpoint in reversed(checkpoints):
+        rollback(checkpoint)
+
+
 _DP: GroupCoordinator | None = None
 
 
@@ -1511,7 +1552,7 @@ def graph_capture(
     if _DCP is not None and get_dcp_group().world_size > 1:
         # Import locally to avoid making distributed initialization depend on
         # attention modules. The helper is a no-op until DCP warmup creates a
-        # B12X pool for this process group.
+        # SparkInfer pool for this process group.
         from vllm.v1.attention.ops.dcp_alltoall import capture_b12x_dcp_a2a
 
         maybe_b12x_dcp_capture = capture_b12x_dcp_a2a(get_dcp_group(), context.stream)

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -322,6 +322,7 @@ if TYPE_CHECKING:
     VLLM_ELASTIC_EP_SCALE_UP_LAUNCH: bool = False
     VLLM_ELASTIC_EP_DRAIN_REQUESTS: bool = False
     VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS: bool = True
+    VLLM_MEMORY_PROFILE_INCLUDE_ATTN: bool = False
     VLLM_NIXL_EP_MAX_NUM_RANKS: int = 32
     VLLM_XPU_ENABLE_XPU_GRAPH: bool = False
     VLLM_XPU_USE_SAMPLER_KERNEL: bool = True
@@ -2184,6 +2185,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # memory allocation. Enabled by default as of v0.21.0
     "VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS": lambda: bool(
         int(os.getenv("VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS", "1"))
+    ),
+    # Include backend-declared transient attention buffers in the profile peak.
+    "VLLM_MEMORY_PROFILE_INCLUDE_ATTN": lambda: bool(
+        int(os.getenv("VLLM_MEMORY_PROFILE_INCLUDE_ATTN", "0"))
     ),
     # NIXL EP environment variables
     "VLLM_NIXL_EP_MAX_NUM_RANKS": lambda: int(

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -229,7 +229,7 @@ if TYPE_CHECKING:
     VLLM_PCIE_ONESHOT_ALLREDUCE_MAX_SIZE: str = "84KB"
     VLLM_PCIE_ONESHOT_FUSED_ADD_RMS_NORM_MAX_SIZE: str = "84KB"
     VLLM_PCIE_ONESHOT_ALLOW_CROSS_NUMA: bool = True
-    VLLM_PCIE_ONESHOT_SINGLE_CHANNEL: bool = True
+    VLLM_PCIE_ONESHOT_SINGLE_CHANNEL: bool = False
     VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE: int = 394 * 1024 * 1024
     VLLM_XGRAMMAR_CACHE_MB: int = 0
     VLLM_REGEX_COMPILATION_TIMEOUT_S: int = 5
@@ -1815,9 +1815,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_PCIE_ONESHOT_ALLOW_CROSS_NUMA": lambda: (
         os.getenv("VLLM_PCIE_ONESHOT_ALLOW_CROSS_NUMA", "1") != "0"
     ),
-    # Use a single channel for the b12x PCIe oneshot allreduce.
+    # Reuse one b12x PCIe oneshot channel across CUDA streams. This saves
+    # buffers but is unsafe when target and draft graphs replay concurrently.
     "VLLM_PCIE_ONESHOT_SINGLE_CHANNEL": lambda: (
-        os.getenv("VLLM_PCIE_ONESHOT_SINGLE_CHANNEL", "1").strip().lower()
+        os.getenv("VLLM_PCIE_ONESHOT_SINGLE_CHANNEL", "0").strip().lower()
         not in ("", "0", "false", "no", "off")
     ),
     # Control the workspace buffer size for the FlashInfer backend.

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -318,6 +318,47 @@ def _can_use_b12x_dcp_prefill_workspace(
     )
 
 
+def _estimate_dcp_ag_rs_transient_bytes(
+    *,
+    num_tokens: int,
+    local_heads: int,
+    dcp_world_size: int,
+    q_head_dim: int,
+    output_head_dim: int,
+    kv_lora_rank: int,
+    v_head_dim: int,
+    project_before_merge: bool,
+) -> int:
+    """Upper-bound simultaneously live eager DCP AG/RS attention tensors."""
+    if num_tokens <= 0 or local_heads <= 0 or dcp_world_size <= 1:
+        return 0
+
+    bf16_bytes = 2
+    fp32_bytes = 4
+    global_heads = local_heads * dcp_world_size
+
+    gathered_query = num_tokens * global_heads * q_head_dim * bf16_bytes
+    attention_output = num_tokens * global_heads * output_head_dim * bf16_bytes
+    # CUDA communicator materializes a head-major contiguous RS input, then an
+    # output and its token-major contiguous return while attention_output lives.
+    reduce_scatter = attention_output + (
+        2 * num_tokens * local_heads * output_head_dim * bf16_bytes
+    )
+    gathered_lse = (dcp_world_size + 1) * num_tokens * global_heads * fp32_bytes
+    gathered_w_uv = (
+        global_heads * kv_lora_rank * v_head_dim * bf16_bytes
+        if project_before_merge
+        else 0
+    )
+    return (
+        gathered_query
+        + attention_output
+        + reduce_scatter
+        + gathered_lse
+        + gathered_w_uv
+    )
+
+
 def _extract_single_layer_index(layer_name: str) -> int | None:
     int_vals = [int(part) for part in layer_name.split(".") if part.isdecimal()]
     return int_vals[0] if len(int_vals) == 1 else None
@@ -697,6 +738,78 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             compile_native=True,
         )
 
+    def _get_sparse_memory_profile_bytes(self) -> int:
+        if (
+            not envs.VLLM_MEMORY_PROFILE_INCLUDE_ATTN
+            or self.attn_backend.get_name() != "B12X_MLA_SPARSE"
+            or self.impl.dcp_world_size <= 1
+        ):
+            return 0
+
+        max_tokens = int(getattr(self.impl, "_max_batched", 0))
+        if max_tokens <= 0:
+            return 0
+
+        # Pure A2A does not enter the allocating NCCL AG/RS path. Hybrid A2A
+        # enters it immediately above the configured small-batch cap.
+        if self.dcp_a2a:
+            if self.dcp_a2a_max_tokens <= 0 or self.dcp_a2a_large_backend == "a2a":
+                return 0
+            first_ag_rs_row = self.dcp_a2a_max_tokens + 1
+        else:
+            first_ag_rs_row = 1
+
+        project_threshold = self.dcp_project_before_merge_min_prefill_tokens
+        workspace_start = max(1025, project_threshold + 1)
+        workspace_eligible = (
+            workspace_start <= max_tokens
+            and _can_use_b12x_dcp_prefill_workspace(
+                enabled=envs.VLLM_B12X_MLA_DCP_GATHER_IN_WORKSPACE,
+                project_before_merge=self.dcp_project_before_merge,
+                dcp_use_b12x=False,
+                num_tokens=workspace_start,
+                max_num_tokens=max_tokens,
+                non_dbo_workspace=getattr(self.impl, "dcp_workspace_non_dbo", False),
+                is_sparse_impl=self.impl.is_sparse,
+                backend_name=self.attn_backend.get_name(),
+                is_capturing=False,
+            )
+        )
+        last_ag_rs_row = (
+            min(max_tokens, workspace_start - 1) if workspace_eligible else max_tokens
+        )
+        if first_ag_rs_row > last_ag_rs_row:
+            return 0
+
+        candidates: list[tuple[int, bool]] = []
+        if not self.dcp_project_before_merge:
+            candidates.append((last_ag_rs_row, False))
+        else:
+            unprojected_rows = min(last_ag_rs_row, project_threshold)
+            if unprojected_rows >= first_ag_rs_row:
+                candidates.append((unprojected_rows, False))
+            if not workspace_eligible and last_ag_rs_row > project_threshold:
+                candidates.append((last_ag_rs_row, True))
+
+        return max(
+            (
+                _estimate_dcp_ag_rs_transient_bytes(
+                    num_tokens=num_tokens,
+                    local_heads=self.num_heads,
+                    dcp_world_size=self.impl.dcp_world_size,
+                    q_head_dim=self.kv_lora_rank + self.qk_rope_head_dim,
+                    output_head_dim=(
+                        self.v_head_dim if projected else self.kv_lora_rank
+                    ),
+                    kv_lora_rank=self.kv_lora_rank,
+                    v_head_dim=self.v_head_dim,
+                    project_before_merge=projected,
+                )
+                for num_tokens, projected in candidates
+            ),
+            default=0,
+        )
+
     @property
     def chunked_prefill_workspace_size(self) -> int:
         if self._chunked_prefill_workspace_size is None:
@@ -828,6 +941,19 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                     device=k_c_normed.device,
                     dtype=k_c_normed.dtype,
                 )
+            else:
+                profile_workspace_bytes = self._get_sparse_memory_profile_bytes()
+                if profile_workspace_bytes > 0:
+                    _ = torch.empty(
+                        (profile_workspace_bytes,),
+                        device=k_c_normed.device,
+                        dtype=torch.uint8,
+                    )
+                    logger.info_once(
+                        "Including %.2f MiB of B12X sparse DCP transient "
+                        "memory in the profile peak",
+                        profile_workspace_bytes / (1 << 20),
+                    )
 
             # The zero fill is required when used with DP + EP
             # to ensure all ranks within a DP group compute the

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -788,7 +788,7 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             unprojected_rows = min(last_ag_rs_row, project_threshold)
             if unprojected_rows >= first_ag_rs_row:
                 candidates.append((unprojected_rows, False))
-            if not workspace_eligible and last_ag_rs_row > project_threshold:
+            if last_ag_rs_row > project_threshold:
                 candidates.append((last_ag_rs_row, True))
 
         return max(

--- a/vllm/v1/attention/ops/dcp_alltoall.py
+++ b/vllm/v1/attention/ops/dcp_alltoall.py
@@ -20,6 +20,7 @@ Reference: https://arxiv.org/abs/2507.07120
 
 from __future__ import annotations
 
+from contextlib import ExitStack, contextmanager
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any
 
@@ -113,7 +114,7 @@ def _get_b12x_dcp_a2a_pool(
             total_heads=total_heads,
             head_dim=head_dim,
             query_head_dim=query_head_dim,
-            single_channel=True,
+            single_channel=False,
         )
         pool.for_stream()
     except Exception as exc:
@@ -149,6 +150,27 @@ def _get_b12x_dcp_a2a_pool(
         head_dim,
     )
     return pool
+
+
+@contextmanager
+def capture_b12x_dcp_a2a(
+    cp_group: GroupCoordinator,
+    stream: object = None,
+):
+    """Bind each CUDA graph manager to independent B12X DCP channels."""
+    group_id = id(cp_group.device_group)
+    matching_pools = sorted(
+        (
+            (key, pool)
+            for key, pool in _B12X_DCP_A2A_POOLS.items()
+            if key[0] == group_id
+        ),
+        key=lambda item: item[0][1:],
+    )
+    with ExitStack() as stack:
+        for _, pool in matching_pools:
+            stack.enter_context(pool.capture(stream=stream))
+        yield
 
 
 def _try_b12x_dcp_lse_reduce(

--- a/vllm/v1/attention/ops/dcp_alltoall.py
+++ b/vllm/v1/attention/ops/dcp_alltoall.py
@@ -155,9 +155,17 @@ def _get_b12x_dcp_a2a_pool(
 @contextmanager
 def capture_b12x_dcp_a2a(
     cp_group: GroupCoordinator,
-    stream: object = None,
+    stream: torch.cuda.Stream | None = None,
 ):
-    """Bind each CUDA graph manager to independent B12X DCP channels."""
+    """Bind registered SparkInfer DCP pools to the graph's owning stream.
+
+    Each graph capture receives independent channels; reusing channels across
+    target and draft graphs would make one graph depend on another's lifetime.
+
+    Args:
+        cp_group: DCP group whose registered pools should enter capture.
+        stream: CUDA stream owned by the enclosing graph capture.
+    """
     group_id = id(cp_group.device_group)
     matching_pools = sorted(
         (
@@ -171,6 +179,39 @@ def capture_b12x_dcp_a2a(
         for _, pool in matching_pools:
             stack.enter_context(pool.capture(stream=stream))
         yield
+
+
+def checkpoint_b12x_dcp_a2a_channels(
+    cp_group: GroupCoordinator,
+) -> tuple[int, dict[Any, tuple[Any, Any]]]:
+    """Snapshot SparkInfer DCP pools before a disposable graph capture."""
+    group_id = id(cp_group.device_group)
+    checkpoints = {
+        key: (pool, pool.checkpoint_channels())
+        for key, pool in _B12X_DCP_A2A_POOLS.items()
+        if key[0] == group_id
+    }
+    return group_id, checkpoints
+
+
+def rollback_b12x_dcp_a2a_channels(
+    checkpoint: tuple[int, dict[Any, tuple[Any, Any]]],
+) -> None:
+    """Restore DCP pools after their disposable graphs are destroyed."""
+    group_id, checkpoints = checkpoint
+    for key, pool in list(_B12X_DCP_A2A_POOLS.items()):
+        if key[0] != group_id:
+            continue
+        saved = checkpoints.get(key)
+        if saved is None:
+            pool.close()
+            del _B12X_DCP_A2A_POOLS[key]
+            continue
+        saved_pool, channel_checkpoint = saved
+        if pool is not saved_pool:
+            pool.close()
+            _B12X_DCP_A2A_POOLS[key] = saved_pool
+        saved_pool.rollback_channels(channel_checkpoint)
 
 
 def _try_b12x_dcp_lse_reduce(

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -587,6 +587,11 @@ class CudaGraphManager:
             self.breakable_cg_runner = BreakableCUDAGraphWrapper(
                 model, self.vllm_config
             )
+            # Disposable memory profiling temporarily replaces the manager's
+            # graph pool. A runner created during that capture must allocate
+            # from the same pool so cleanup can release the profiled graphs.
+            if self.pool is not None:
+                self.breakable_cg_runner.graph_pool = self.pool
 
     def run_pw_graph(self, model: nn.Module, model_inputs: dict[str, Any]) -> Any:
         if not self.use_breakable_cg:

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -436,6 +436,12 @@ class CudaGraphManager:
     def needs_capture(self) -> bool:
         return len(self._capture_descs) > 0
 
+    def clear(self) -> None:
+        """Release captured graphs and reset this manager for a later capture."""
+        self.graphs.clear()
+        self._graphs_captured = False
+        self.breakable_cg_runner = None
+
     @torch.inference_mode()
     def capture(
         self,
@@ -742,6 +748,12 @@ class ModelCudaGraphManager(CudaGraphManager):
             return forward_fn
 
         super().capture(create_forward_fn, progress_bar_desc)
+
+    def clear(self) -> None:
+        super().clear()
+        self.hidden_states = None
+        self.aux_hidden_states.clear()
+        self.intermediate_tensors = None
 
     def run_fullgraph(
         self, desc: BatchExecutionDescriptor

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -124,7 +124,7 @@ from vllm.v1.worker.gpu.states import RequestState
 from vllm.v1.worker.gpu.structured_outputs import StructuredOutputsWorker
 from vllm.v1.worker.lora_model_runner_mixin import LoRAModelRunnerMixin
 from vllm.v1.worker.utils import KVBlockZeroer, copy_kv_cache_blocks_inplace
-from vllm.v1.worker.workspace import lock_workspace
+from vllm.v1.worker.workspace import lock_workspace, use_workspace_lane
 
 logger = init_logger(__name__)
 
@@ -345,10 +345,11 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 assert self.speculative_config is not None
                 set_eagle3_aux_hidden_state_layers(self.model, self.speculative_config)
             if isinstance(self.speculator, DraftModelSpeculator):
-                self.speculator.load_model(self.model)
-                eplb_models_added = self.eplb.maybe_register_speculator(
-                    self.speculator, self.speculative_config, load_dummy_weights
-                )
+                with use_workspace_lane(1):
+                    self.speculator.load_model(self.model)
+                    eplb_models_added = self.eplb.maybe_register_speculator(
+                        self.speculator, self.speculative_config, load_dummy_weights
+                    )
         time_after_load = time.perf_counter()
 
         self.model_memory_usage = m.consumed_memory
@@ -550,25 +551,27 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         )
         check_attention_cp_compatibility(self.vllm_config)
         if isinstance(self.speculator, DraftModelSpeculator):
-            # HACK(woosuk)
-            self.speculator.set_attn(
-                self.model_state,
-                self.kv_cache_config,
-                self.block_tables,
-                self.input_buffers,
-                self.attn_groups,
-            )
-            if hasattr(self.speculator, "set_num_cached_tokens"):
-                # DFlash/DSpark mask cache-restored tokens out of the draft's
-                # context (their draft context KV was never computed).
-                self.speculator.set_num_cached_tokens(
-                    self.req_states.num_cached_tokens.gpu,
-                    self.req_states.num_cached_tokens_np,
+            with use_workspace_lane(1):
+                # HACK(woosuk)
+                self.speculator.set_attn(
+                    self.model_state,
+                    self.kv_cache_config,
+                    self.block_tables,
+                    self.input_buffers,
+                    self.attn_groups,
                 )
+                if hasattr(self.speculator, "set_num_cached_tokens"):
+                    # DFlash/DSpark mask cache-restored tokens out of the draft's
+                    # context (their draft context KV was never computed).
+                    self.speculator.set_num_cached_tokens(
+                        self.req_states.num_cached_tokens.gpu,
+                        self.req_states.num_cached_tokens_np,
+                    )
         if self.speculator is not None:
             # After set_attn, so the speculator can size its cudagraph mode
             # to its own attention support.
-            self.speculator.init_cudagraph_manager(cudagraph_mode)
+            with use_workspace_lane(1):
+                self.speculator.init_cudagraph_manager(cudagraph_mode)
 
         self.kv_caches: list[torch.Tensor] = []
         kv_caches_dict = init_kv_cache(
@@ -710,27 +713,28 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             if hasattr(self.model, "get_mtp_target_hidden_states"):
                 pre_hc_hidden_states = self.model.get_mtp_target_hidden_states()
                 spec_hidden_states = pre_hc_hidden_states[: hidden_states.shape[0]]  # type: ignore[union-attr]
-            self.speculator.propose(
-                input_batch=input_batch,
-                attn_metadata=attn_metadata,
-                slot_mappings=slot_mappings_by_layer,
-                last_hidden_states=spec_hidden_states,
-                aux_hidden_states=aux_hidden_states,
-                num_sampled=torch.ones(
-                    input_batch.num_reqs, dtype=torch.int32, device=self.device
-                ),
-                num_rejected=torch.zeros(
-                    input_batch.num_reqs, dtype=torch.int32, device=self.device
-                ),
-                last_sampled=self.req_states.last_sampled_tokens,
-                next_prefill_tokens=self.req_states.next_prefill_tokens,
-                temperature=self.sampler.sampling_states.temperature.gpu,
-                seeds=self.sampler.sampling_states.seeds.gpu,
-                dummy_run=True,
-                skip_attn_for_dummy_run=skip_attn,
-                mm_inputs=mm_inputs,
-                is_profile=is_profile,
-            )
+            with use_workspace_lane(1):
+                self.speculator.propose(
+                    input_batch=input_batch,
+                    attn_metadata=attn_metadata,
+                    slot_mappings=slot_mappings_by_layer,
+                    last_hidden_states=spec_hidden_states,
+                    aux_hidden_states=aux_hidden_states,
+                    num_sampled=torch.ones(
+                        input_batch.num_reqs, dtype=torch.int32, device=self.device
+                    ),
+                    num_rejected=torch.zeros(
+                        input_batch.num_reqs, dtype=torch.int32, device=self.device
+                    ),
+                    last_sampled=self.req_states.last_sampled_tokens,
+                    next_prefill_tokens=self.req_states.next_prefill_tokens,
+                    temperature=self.sampler.sampling_states.temperature.gpu,
+                    seeds=self.sampler.sampling_states.seeds.gpu,
+                    dummy_run=True,
+                    skip_attn_for_dummy_run=skip_attn,
+                    mm_inputs=mm_inputs,
+                    is_profile=is_profile,
+                )
             if sps_debug is not None:
                 ev[2].record()
                 sps_debug.append(ev)
@@ -826,7 +830,8 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 lora_capture_hook=create_lora_capture_hook(self.lora_config, self),
             )
             if self.speculator is not None:
-                self.speculator.capture()
+                with use_workspace_lane(1):
+                    self.speculator.capture()
             self._zero_cudagraph_capture_kv_blocks()
 
         end_time = time.perf_counter()
@@ -1786,7 +1791,10 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             if hasattr(self.model, "get_mtp_target_hidden_states"):
                 pre_hc_hidden_states = self.model.get_mtp_target_hidden_states()
                 spec_hidden_states = pre_hc_hidden_states[: hidden_states.shape[0]]  # type: ignore[union-attr]
-            with record_function_or_nullcontext(f"vllm:v2/speculator/{phase}/propose"):
+            with (
+                use_workspace_lane(1),
+                record_function_or_nullcontext(f"vllm:v2/speculator/{phase}/propose"),
+            ):
                 draft_tokens = self.speculator.propose(
                     input_batch,
                     attn_metadata,
@@ -1829,7 +1837,10 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 self.verification_capacity_manager is not None
                 and not self.verification_capacity_manager.capacity_bypassed
             ):
-                draft_token_capacity = self.speculator.compute_capacities(input_batch)
+                with use_workspace_lane(1):
+                    draft_token_capacity = self.speculator.compute_capacities(
+                        input_batch
+                    )
                 assert draft_token_capacity is not None
                 self.verification_capacity_manager.update_capacities(
                     draft_token_capacity

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -29,13 +29,17 @@ import torch
 import torch.nn as nn
 
 import vllm.envs as envs
+from vllm.compilation.breakable_cudagraph import BreakableCUDAGraphWrapper
 from vllm.compilation.counter import compilation_counter
-from vllm.config import VllmConfig
+from vllm.compilation.cuda_graph import CUDAGraphWrapper
+from vllm.config import VllmConfig, set_current_vllm_config
 from vllm.config.compilation import CUDAGraphMode
 from vllm.distributed.parallel_state import (
+    checkpoint_b12x_graph_channels,
     get_dcp_group,
     get_pp_group,
     prepare_communication_buffer_for_model,
+    rollback_b12x_graph_channels,
 )
 from vllm.forward_context import BatchDescriptor, set_forward_context
 from vllm.logger import init_logger
@@ -44,6 +48,7 @@ from vllm.model_executor.layers.mamba.ops.ssu_dispatch import (
 )
 from vllm.model_executor.model_loader import get_model_loader
 from vllm.multimodal import MULTIMODAL_REGISTRY
+from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
 from vllm.tasks import SupportedTask
 from vllm.utils.math_utils import cdiv
@@ -51,6 +56,7 @@ from vllm.utils.mem_utils import DeviceMemoryProfiler, format_gib
 from vllm.utils.torch_utils import PIN_MEMORY, STR_DTYPE_TO_TORCH_DTYPE
 from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
 from vllm.v1.kv_cache_interface import KVCacheConfig, MambaSpec
+from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry
 from vllm.v1.outputs import DraftTokenIds, ModelRunnerOutput
 from vllm.v1.utils import record_function_or_nullcontext
 from vllm.v1.worker.cp_utils import check_attention_cp_compatibility
@@ -795,9 +801,163 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         # SP is not supported yet.
         return num_scheduled_tokens
 
+    def _init_minimal_kv_cache_for_profiling(self) -> None:
+        from vllm.v1.core.kv_cache_utils import (
+            get_kv_cache_config_from_groups,
+            get_kv_cache_groups,
+        )
+
+        kv_cache_spec = self.get_kv_cache_spec()
+        KVCacheSpecRegistry.check_kv_cache_spec_registry(kv_cache_spec)
+        kv_cache_groups = get_kv_cache_groups(self.vllm_config, kv_cache_spec)
+        min_blocks = (
+            min(self.max_num_reqs, self.compilation_config.max_cudagraph_capture_size)
+            or 1
+        )
+
+        saved_override = self.cache_config.num_gpu_blocks_override
+        self.cache_config.num_gpu_blocks_override = min_blocks
+        try:
+            minimal_config = get_kv_cache_config_from_groups(
+                self.vllm_config, kv_cache_groups, available_memory=0
+            )
+        finally:
+            self.cache_config.num_gpu_blocks_override = saved_override
+
+        self.initialize_kv_cache(minimal_config)
+        self.cache_config.num_gpu_blocks = minimal_config.num_blocks
+
+    def _cleanup_cudagraph_memory_profile(self) -> None:
+        torch.accelerator.synchronize()
+        if self.cudagraph_manager is not None:
+            self.cudagraph_manager.clear()
+        if self.speculator is not None:
+            self.speculator.clear_cudagraphs()
+        CUDAGraphWrapper.clear_all_graphs()
+        BreakableCUDAGraphWrapper.clear_all_graphs()
+
+        if hasattr(self, "kv_caches"):
+            self.kv_caches.clear()
+        if hasattr(self, "attn_groups"):
+            self.attn_groups.clear()
+        if hasattr(self, "kv_cache_config"):
+            del self.kv_cache_config
+        for attr in ("block_tables", "kernel_block_sizes"):
+            if hasattr(self, attr):
+                delattr(self, attr)
+
+        self.kv_connector = NO_OP_KV_CONNECTOR
+        self.kv_block_zeroer = None
+        self.cudagraph_manager = None
+        self.verification_capacity_manager = None
+        self.cache_config.num_gpu_blocks = None
+
+        for layer in self.compilation_config.static_forward_context.values():
+            if hasattr(layer, "kv_cache"):
+                kv_cache = layer.kv_cache
+                layer.kv_cache = (
+                    torch.tensor([]) if isinstance(kv_cache, torch.Tensor) else []
+                )
+
+        gc.collect()
+        torch.accelerator.empty_cache()
+        torch.accelerator.synchronize()
+
     def profile_cudagraph_memory(self) -> int:
-        # NOTE(woosuk): It is TBD whether we keep this API or not.
-        return 0
+        with set_current_vllm_config(self.vllm_config):
+            self._init_minimal_kv_cache_for_profiling()
+
+        assert self.cudagraph_manager is not None
+        if not self.cudagraph_manager.needs_capture():
+            self._cleanup_cudagraph_memory_profile()
+            return 0
+
+        saved_num_cudagraph_captured = compilation_counter.num_cudagraph_captured
+        profiling_pool = current_platform.graph_pool_handle()
+        managers = [self.cudagraph_manager]
+        if self.speculator is not None:
+            managers.extend(self.speculator.get_cudagraph_managers())
+        original_manager_pools = {id(manager): manager.pool for manager in managers}
+        for manager in managers:
+            manager.pool = profiling_pool
+
+        wrappers = list(CUDAGraphWrapper._all_instances) + list(
+            BreakableCUDAGraphWrapper._all_instances
+        )
+        original_wrapper_pools = {
+            id(wrapper): wrapper.graph_pool for wrapper in wrappers
+        }
+        for wrapper in wrappers:
+            wrapper.graph_pool = profiling_pool
+
+        gc.collect()
+        torch.accelerator.empty_cache()
+        torch.accelerator.synchronize()
+        start_free_gpu_memory = torch.accelerator.get_memory_info()[0]
+        graph_channel_checkpoints = ()
+        try:
+            # Snapshot graph-owned SparkInfer channels before this disposable
+            # capture so profiling cannot leave stale channels behind.
+            graph_channel_checkpoints = checkpoint_b12x_graph_channels()
+            with self.maybe_setup_dummy_loras(self.lora_config):
+                self.cudagraph_manager.capture(
+                    self.model,
+                    self.model_state,
+                    self.input_buffers,
+                    self.intermediate_tensors,
+                    self.block_tables,
+                    self.attn_groups,
+                    self.kv_cache_config,
+                    has_lora=self.lora_config is not None,
+                    use_aux_hidden_state_outputs=self.use_aux_hidden_state_outputs,
+                    lora_capture_hook=create_lora_capture_hook(self.lora_config, self),
+                    progress_bar_desc="Profiling CUDA graph memory",
+                )
+                if self.speculator is not None:
+                    with use_workspace_lane(1):
+                        self.speculator.capture()
+                self._zero_cudagraph_capture_kv_blocks()
+            end_free_gpu_memory = torch.accelerator.get_memory_info()[0]
+            gross_cuda_graph_size = max(start_free_gpu_memory - end_free_gpu_memory, 0)
+        finally:
+            try:
+                # Destroy disposable graphs while every manager and wrapper still
+                # points at the private pool that owns their allocations.
+                try:
+                    self._cleanup_cudagraph_memory_profile()
+                finally:
+                    rollback_b12x_graph_channels(graph_channel_checkpoints)
+            finally:
+                for manager in managers:
+                    manager.pool = original_manager_pools[id(manager)]
+                wrappers = list(CUDAGraphWrapper._all_instances) + list(
+                    BreakableCUDAGraphWrapper._all_instances
+                )
+                for wrapper in wrappers:
+                    original_pool = original_wrapper_pools.get(id(wrapper))
+                    if id(wrapper) in original_wrapper_pools:
+                        wrapper.graph_pool = original_pool
+                    else:
+                        wrapper.graph_pool = current_platform.get_global_graph_pool()
+                del profiling_pool
+                compilation_counter.num_cudagraph_captured = (
+                    saved_num_cudagraph_captured
+                )
+
+        free_after_cleanup = torch.accelerator.get_memory_info()[0]
+        retained_pool_size = max(start_free_gpu_memory - free_after_cleanup, 0)
+        # A CUDA graph private pool can retain physical pages after its graph
+        # objects are destroyed. memory_profiling observes those pages as
+        # non-torch memory, so only return the remaining capture cost here.
+        cuda_graph_size = max(gross_cuda_graph_size - retained_pool_size, 0)
+        logger.info(
+            "Estimated MRV2 CUDA graph memory: %.2f GiB additional "
+            "(%.2f GiB captured, %.2f GiB retained and counted as non-torch)",
+            cuda_graph_size / (1 << 30),
+            gross_cuda_graph_size / (1 << 30),
+            retained_pool_size / (1 << 30),
+        )
+        return int(cuda_graph_size)
 
     @torch.inference_mode()
     def capture_model(self) -> int:

--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
@@ -132,6 +132,16 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
             progress_bar_desc="Capturing decode CUDA graphs",
         )
 
+    def get_cudagraph_managers(self) -> tuple[SpeculatorCudaGraphManager, ...]:
+        return tuple(
+            manager
+            for manager in (
+                self.prefill_cudagraph_manager,
+                self.decode_cudagraph_manager,
+            )
+            if manager is not None
+        )
+
     @torch.inference_mode()
     def propose(
         self,

--- a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
@@ -203,6 +203,15 @@ class DFlashSpeculator(DraftModelSpeculator):
             progress_bar_desc=f"Capturing {self._speculator_name.lower()} CUDA graphs",
         )
 
+    def get_cudagraph_managers(self) -> tuple[DFlashCudaGraphManager, ...]:
+        if self.query_cudagraph_manager is None:
+            return ()
+        return (self.query_cudagraph_manager,)
+
+    def clear_cudagraphs(self) -> None:
+        super().clear_cudagraphs()
+        self._captured_backbone_outputs.clear()
+
     def _warmup_prepare_inputs_kernel(self) -> None:
         if self.draft_kv_cache_group_id < 0:
             return

--- a/vllm/v1/worker/gpu/spec_decode/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/speculator.py
@@ -27,6 +27,7 @@ from vllm.v1.worker.gpu.spec_decode.utils import draft_gumbel_pos
 from vllm.v1.worker.utils import AttentionGroup
 
 if TYPE_CHECKING:
+    from vllm.v1.worker.gpu.cudagraph_utils import CudaGraphManager
     from vllm.v1.worker.gpu.spec_decode.dspark.online_sts import DSparkOnlineSTS
 
 logger = init_logger(__name__)
@@ -52,6 +53,13 @@ class BaseSpeculator(ABC):
     @abstractmethod
     def capture(self) -> None:
         pass
+
+    def get_cudagraph_managers(self) -> tuple["CudaGraphManager", ...]:
+        return ()
+
+    def clear_cudagraphs(self) -> None:
+        for manager in self.get_cudagraph_managers():
+            manager.clear()
 
     @abstractmethod
     def propose(

--- a/vllm/v1/worker/gpu/warmup.py
+++ b/vllm/v1/worker/gpu/warmup.py
@@ -21,6 +21,7 @@ from vllm.v1.core.sched.output import (
 from vllm.v1.kv_cache_interface import CrossAttentionSpec, MambaSpec
 from vllm.v1.request import Request
 from vllm.v1.worker.gpu.model_runner import GPUModelRunner
+from vllm.v1.worker.workspace import use_workspace_lane
 
 logger = init_logger(__name__)
 
@@ -348,7 +349,8 @@ def warmup_kernels(
                 model_runner.input_buffers
             )
             assert model_runner.speculator is not None
-            model_runner.speculator.warmup_capacity_kernels()
+            with use_workspace_lane(1):
+                model_runner.speculator.warmup_capacity_kernels()
             if model_runner.speculator.wants_auto_sps_curve:
                 _profile_sps_curve(model_runner)
                 model_runner.kv_connector.set_disabled(True)

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -397,9 +397,16 @@ class Worker(WorkerBase):
         else:
             raise RuntimeError(f"Unsupported device type: {self.device_config.device}")
 
-        # Initialize workspace manager
+        # Target and speculative captures retain workspace views concurrently,
+        # so speculative V2 execution needs a separate ownership lane.
         num_ubatches = 2 if self.vllm_config.parallel_config.enable_dbo else 1
-        init_workspace_manager(self.device, num_ubatches)
+        num_workspace_lanes = (
+            2
+            if self.use_v2_model_runner
+            and self.vllm_config.speculative_config is not None
+            else 1
+        )
+        init_workspace_manager(self.device, num_ubatches, num_workspace_lanes)
 
         # Construct the model runner
         if self.use_v2_model_runner:

--- a/vllm/v1/worker/workspace.py
+++ b/vllm/v1/worker/workspace.py
@@ -3,6 +3,9 @@
 
 import inspect
 import os
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
 from itertools import accumulate
 from math import prod
 
@@ -26,22 +29,48 @@ _GiB = 1024**3
 
 # Global workspace manager instance
 _manager: "WorkspaceManager | None" = None
+_workspace_lane: ContextVar[int] = ContextVar("vllm_workspace_lane", default=0)
+
+
+@contextmanager
+def use_workspace_lane(lane: int) -> Iterator[None]:
+    """Select the workspace owner for this execution context.
+
+    Target execution uses lane 0; speculative execution uses lane 1 so a
+    captured graph cannot retain views into the target graph's buffer.
+    """
+    if lane < 0:
+        raise ValueError(f"Workspace lane must be non-negative, got {lane}.")
+    token = _workspace_lane.set(lane)
+    try:
+        yield
+    finally:
+        _workspace_lane.reset(token)
 
 
 class WorkspaceManager:
     """Manager for workspace allocation.
 
-    Manages one workspace buffer per active ubatch slot.
-    Can be locked to prevent further growth during execution.
+    Owns one reusable buffer per ``(ubatch, lane)``. Separate lanes prevent
+    target and draft graphs from retaining views into the same allocation.
+    The manager can be locked to prevent growth during execution.
     """
 
-    def __init__(self, device: torch.device, num_ubatches: int | None = None):
+    def __init__(
+        self,
+        device: torch.device,
+        num_ubatches: int | None = None,
+        num_lanes: int = 1,
+    ):
         self._device = device
         # Cache num ubatches at init based on configuration (default to 1)
         self._num_ubatches = num_ubatches if num_ubatches is not None else 1
-        self._current_workspaces: list[torch.Tensor | None] = [
-            None
-        ] * self._num_ubatches
+        if num_lanes < 1:
+            raise ValueError(f"num_lanes must be at least one, got {num_lanes}.")
+        self._num_lanes = num_lanes
+        self._current_workspaces: list[torch.Tensor | None] = [None] * (
+            self._num_ubatches * self._num_lanes
+        )
         self._locked: bool = False
 
     @staticmethod
@@ -126,7 +155,14 @@ class WorkspaceManager:
             The current workspace tensor.
         """
         ubatch_id = dbo_current_ubatch_id()
-        current_workspace = self._current_workspaces[ubatch_id]
+        lane = _workspace_lane.get()
+        if lane >= self._num_lanes:
+            raise RuntimeError(
+                f"Workspace lane {lane} is not configured; manager has "
+                f"{self._num_lanes} lane(s)."
+            )
+        workspace_id = ubatch_id * self._num_lanes + lane
+        current_workspace = self._current_workspaces[workspace_id]
         current_size = self._workspace_size_bytes(current_workspace)
 
         if current_size < required_bytes:
@@ -161,11 +197,10 @@ class WorkspaceManager:
                     "Workspace growth is not allowed after locking."
                 )
 
-            # Only resize the requesting ubatch's workspace.  Other
-            # ubatches resize lazily on their next get_simultaneous call.
-            # Resizing all ubatches here would orphan the other ubatch's
-            # old tensor when it still holds views into it (DBO leak).
-            self._current_workspaces[ubatch_id] = None
+            # Only resize the requesting ubatch/lane workspace. Other slots
+            # resize lazily on their next get_simultaneous call. Resizing all
+            # slots here would orphan a tensor that still has live views.
+            self._current_workspaces[workspace_id] = None
             del current_workspace
             # Release the freed segment back to CUDA so the caching
             # allocator can reuse the GPU memory for the larger
@@ -173,19 +208,20 @@ class WorkspaceManager:
             # dead segment in reserved memory which can cause higher peak
             # memory usage.
             torch.accelerator.empty_cache()
-            self._current_workspaces[ubatch_id] = torch.empty(
+            self._current_workspaces[workspace_id] = torch.empty(
                 (required_bytes,), dtype=torch.uint8, device=self._device
             )
-            current_workspace = self._current_workspaces[ubatch_id]
+            current_workspace = self._current_workspaces[workspace_id]
 
             if envs.VLLM_DEBUG_WORKSPACE:
                 logger.info(
                     "[WORKSPACE DEBUG] Resized workspace from '%s': %.2f MB -> "
-                    "%.2f MB (ubatch %d)",
+                    "%.2f MB (ubatch %d, lane %d)",
                     get_caller_info(),
                     current_size / _MB,
                     required_bytes / _MB,
                     ubatch_id,
+                    lane,
                 )
 
         return current_workspace
@@ -214,7 +250,9 @@ def current_workspace_manager() -> "WorkspaceManager":
 
 
 def init_workspace_manager(
-    device: torch.device, num_ubatches: int | None = None
+    device: torch.device,
+    num_ubatches: int | None = None,
+    num_lanes: int = 1,
 ) -> None:
     """Initialize the workspace manager with a device.
 
@@ -224,6 +262,7 @@ def init_workspace_manager(
     Args:
         device: The device to allocate workspace on.
         num_ubatches: Number of workspace ubatch slots. Defaults to 1.
+        num_lanes: Number of independent execution lanes per ubatch. Defaults to 1.
     """
     global _manager
     if _manager is not None:
@@ -233,7 +272,7 @@ def init_workspace_manager(
             _manager._device,
             device,
         )
-    _manager = WorkspaceManager(device, num_ubatches)
+    _manager = WorkspaceManager(device, num_ubatches, num_lanes)
 
 
 def lock_workspace() -> None:


### PR DESCRIPTION
## Summary

Establish one ownership contract for target and draft CUDA-graph resources, then use it to make MRV2 memory profiling accurate and disposable.

This is intentionally one atomic PR: MRV2 profiling captures both target and speculator graphs. That capture is only safe when their workspace views and SparkInfer communication channels have independent owners. MoE scheduling is unrelated and remains in #150.

## What changes

- `workspace.py` gives each `(ubatch, execution owner)` an independent reusable buffer. Target uses lane 0; speculative execution uses lane 1.
- The model runner applies lane 1 to every speculator phase, including the temporary MRV2 profiling capture.
- SparkInfer PCIe all-reduce and DCP A2A bind channels to the enclosing graph capture instead of sharing target/draft channel lifetime.
- Oneshot buffers are sized to their dispatch limits; the larger DMA buffer remains sized for scheduled prefill traffic.
- MRV2 profiling captures target and draft graphs in a private pool, includes sparse-DCP transient memory, then destroys graphs and rolls back channels before restoring production pools.

## Root causes and lifecycle

Previously, graph-retained workspace views could alias, communication channels could outlive the graph that created them, and MRV2 reserved no production graph footprint. Sparse MLA transient buffers were also absent from the dummy profile.

A disposable profile now follows this order:

1. checkpoint production communication channels
2. capture target and draft graphs in a private pool
3. measure graph and sparse-DCP transient memory
4. synchronize and destroy every disposable graph while its pool is still owned
5. roll back transient channels and restore production pool references

Tests assert lane separation and restoration, independent graph channels, cleanup ordering, retained-pool accounting, and sparse-DCP workspace accounting.

## Scope and dependencies

- Directly based on `dev/gilded-gnosis`; no Docker-only overlay.
- Replaces the separately opened #151 and #152, removing their merge-order dependency.
- Runtime channel checkpoint/capture support is provided by [SparkInfer #59](https://github.com/local-inference-lab/sparkinfer/pull/59).
- Shared-expert/MoE scheduling remains isolated in #150 with [SparkInfer #60](https://github.com/local-inference-lab/sparkinfer/pull/60).

## Validation

Release CUDA image with four visible GPUs:

- `tests/v1/worker/test_workspace.py`
- `tests/distributed/test_b12x_fused_all_reduce.py`
- `tests/distributed/test_dcp_a2a.py`
- `tests/v1/attention/test_b12x_mla_dcp_workspace.py`
- `tests/v1/cudagraph/test_breakable_cudagraph.py`
- **103 passed**
- Ruff lint and format checks passed
- `git diff --check` passed
