### PR TITLE
[GG] fix(moe): safely overlap shared experts before resident grids

### DIFF
--- a/tests/model_executor/layers/fused_moe/test_shared_experts_stream.py
+++ b/tests/model_executor/layers/fused_moe/test_shared_experts_stream.py
@@ -2,12 +2,53 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from contextlib import contextmanager
-from unittest.mock import Mock
+from types import SimpleNamespace
+from unittest.mock import Mock, call
 
 import torch
 
 import vllm.model_executor.layers.fused_moe.runner.shared_experts as shared_module
-from vllm.model_executor.layers.fused_moe.runner.shared_experts import SharedExperts
+from vllm.model_executor.layers.fused_moe.runner.moe_runner import MoERunner
+from vllm.model_executor.layers.fused_moe.runner.shared_experts import (
+    SharedExperts,
+    SharedExpertsOrder,
+)
+
+
+def test_aux_stream_respects_expert_kernel_capability(monkeypatch) -> None:
+    stream = Mock()
+    supports_aux_stream = Mock(side_effect=lambda num_tokens: num_tokens <= 8)
+    monkeypatch.setattr(shared_module, "aux_stream", Mock(return_value=stream))
+    monkeypatch.setattr(shared_module.envs, "VLLM_DISABLE_SHARED_EXPERTS_STREAM", False)
+    monkeypatch.setattr(
+        shared_module,
+        "current_platform",
+        SimpleNamespace(is_cuda=lambda: True),
+    )
+    moe_config = SimpleNamespace(
+        moe_parallel_config=SimpleNamespace(
+            enable_eplb=False,
+            all2all_backend="allgather_reducescatter",
+            use_fi_nvl_two_sided_kernels=False,
+        )
+    )
+    shared_experts = SharedExperts(
+        layer=Mock(),
+        moe_config=moe_config,
+        enable_dbo=False,
+        mk_can_overlap_shared_experts=Mock(return_value=False),
+        experts_support_aux_stream=supports_aux_stream,
+    )
+
+    assert (
+        shared_experts._determine_shared_experts_order(torch.empty(8, 16))
+        == SharedExpertsOrder.MULTI_STREAM_OVERLAPPED
+    )
+    assert (
+        shared_experts._determine_shared_experts_order(torch.empty(16, 16))
+        == SharedExpertsOrder.NO_OVERLAP
+    )
+    assert supports_aux_stream.call_args_list == [call(8), call(16)]
 
 
 def test_aux_stream_output_lifetime_extends_to_consumer(monkeypatch) -> None:
@@ -15,21 +56,97 @@ def test_aux_stream_output_lifetime_extends_to_consumer(monkeypatch) -> None:
     aux_stream = Mock()
     consumer_stream = Mock()
     output = Mock()
-    shared_experts_input = Mock()
+    shared_experts.enable_dbo = False
+    shared_experts._output = [output, None]
     shared_experts._stream = aux_stream
-    shared_experts._layer = Mock(return_value=output)
+    monkeypatch.setattr(shared_module, "current_stream", lambda: consumer_stream)
+
+    shared_experts._join_aux_stream()
+
+    consumer_stream.wait_stream.assert_called_once_with(aux_stream)
+    output.record_stream.assert_called_once_with(consumer_stream)
+
+
+def test_aux_shared_experts_are_enqueued_before_resident_moe() -> None:
+    runner = object.__new__(MoERunner)
+    events: list[object] = []
+    fused_out = object()
+    shared_out = object()
+
+    runner._maybe_apply_shared_experts = lambda _input, order: events.append(order)
+    runner.routed_experts = SimpleNamespace(
+        quant_method=SimpleNamespace(is_monolithic=True),
+        forward_monolithic=lambda **_kwargs: events.append("routed") or fused_out,
+    )
+    runner._shared_experts = SimpleNamespace(output=shared_out)
+
+    result = runner._apply_quant_method(
+        hidden_states=Mock(),
+        router_logits=Mock(),
+        shared_experts_input=Mock(),
+    )
+
+    assert events == [
+        SharedExpertsOrder.NO_OVERLAP,
+        SharedExpertsOrder.MULTI_STREAM_OVERLAPPED,
+        "routed",
+    ]
+    assert result == (shared_out, fused_out)
+
+
+def test_aux_stream_is_joined_before_resident_moe(monkeypatch) -> None:
+    events: list[str] = []
+    aux = Mock()
+    consumer = Mock()
+    output = Mock()
+
+    aux.wait_stream.side_effect = lambda _stream: events.append("input-ready")
+    consumer.wait_stream.side_effect = lambda _stream: events.append("join-aux")
+    monkeypatch.setattr(shared_module, "aux_stream", Mock(return_value=aux))
+    monkeypatch.setattr(shared_module, "current_stream", lambda: consumer)
+    monkeypatch.setattr(shared_module.envs, "VLLM_DISABLE_SHARED_EXPERTS_STREAM", False)
+    monkeypatch.setattr(
+        shared_module,
+        "current_platform",
+        SimpleNamespace(is_cuda=lambda: True),
+    )
 
     @contextmanager
     def use_stream(stream):
-        assert stream is aux_stream
+        assert stream is aux
         yield
 
     monkeypatch.setattr(torch.cuda, "stream", use_stream)
-    monkeypatch.setattr(shared_module, "current_stream", lambda: consumer_stream)
+    shared = SharedExperts(
+        layer=Mock(side_effect=lambda _input: events.append("shared") or output),
+        moe_config=SimpleNamespace(
+            moe_parallel_config=SimpleNamespace(
+                enable_eplb=False,
+                all2all_backend="allgather_reducescatter",
+                use_fi_nvl_two_sided_kernels=False,
+            )
+        ),
+        enable_dbo=False,
+        mk_can_overlap_shared_experts=Mock(return_value=False),
+        experts_support_aux_stream=Mock(return_value=True),
+    )
+    shared_input = Mock()
+    shared_input.shape = (1, 16)
+    shared.maybe_sync_shared_experts_stream(shared_input)
+    events.append("gate")
 
-    result = shared_experts._run_in_aux_stream(shared_experts_input)
+    runner = object.__new__(MoERunner)
+    torch.nn.Module.__init__(runner)
+    runner._shared_experts = shared
+    runner.routed_experts = SimpleNamespace(
+        quant_method=SimpleNamespace(is_monolithic=True),
+        forward_monolithic=lambda **_kwargs: events.append("routed") or object(),
+    )
+    runner._apply_quant_method(
+        hidden_states=Mock(),
+        router_logits=Mock(),
+        shared_experts_input=shared_input,
+    )
 
-    assert result is output
-    shared_experts._layer.assert_called_once_with(shared_experts_input)
-    consumer_stream.wait_stream.assert_called_once_with(aux_stream)
-    output.record_stream.assert_called_once_with(consumer_stream)
+    assert events == ["input-ready", "shared", "gate", "join-aux", "routed"]
+    shared_input.record_stream.assert_called_once_with(aux)

--- a/tests/model_executor/layers/test_b12x_moe_warmup.py
+++ b/tests/model_executor/layers/test_b12x_moe_warmup.py
@@ -89,6 +89,7 @@ def _make_fake_b12x_experts() -> b12x_moe.B12xExperts:
     experts._activation_amax_base_num_layers = None
     experts._activation_amax_state_key = None
     experts._activation_amax_layer_idx = None
+    experts._aux_stream_overlap_by_tokens = {}
     return experts
 
 
@@ -129,6 +130,39 @@ def test_non_b12x_moe_runner_keeps_generic_custom_op(monkeypatch) -> None:
     forward_entry = runner._select_forward()
 
     assert forward_entry._qualified_op_name == "vllm::moe_forward"
+
+
+def test_b12x_shared_expert_overlap_follows_launch_plan_capability(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for name in (
+        "B12X_MOE_FORCE_A8",
+        "B12X_FORCE_MOE_A8",
+        "B12X_MOE_FORCE_A16",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    plans = []
+    plan = object()
+
+    def fake_plan(**kwargs):
+        plans.append(kwargs)
+        return plan
+
+    monkeypatch.setattr(b12x_moe, "_plan_b12x_moe_execution", fake_plan)
+    monkeypatch.setattr(
+        b12x_moe,
+        "_b12x_moe_plan_supports_aux_stream_overlap",
+        lambda candidate: candidate is plan,
+    )
+    experts = _make_fake_b12x_experts()
+
+    assert experts.supports_shared_experts_aux_stream(8)
+    assert experts.supports_shared_experts_aux_stream(8)
+
+    assert len(plans) == 1
+    assert plans[0]["tokens"] == 8
+    assert plans[0]["topk"] == 4
+    assert plans[0]["quant_mode"] == "nvfp4"
 
 
 def test_b12x_moe_custom_op_matches_generic_mutation_contract() -> None:

--- a/tests/quantization/test_nvfp4_nf3_hybrid.py
+++ b/tests/quantization/test_nvfp4_nf3_hybrid.py
@@ -8,6 +8,7 @@ from vllm.config.quantization import resolve_quantization_config
 from vllm.model_executor.layers.quantization import get_quantization_config
 from vllm.model_executor.layers.quantization.nvfp4_nf3_hybrid import (
     NvFp4Nf3HybridConfig,
+    NvFp4Nf3HybridMoEMethod,
     _combined_tier_local_descriptors,
     _read_hybrid_keys,
     _unpack_nf3_codes,
@@ -109,3 +110,10 @@ def test_grid188_tier_descriptors_encode_exact_partition():
 def test_grid188_tier_descriptors_reject_incomplete_partition():
     with pytest.raises(ValueError, match="does not cover all 256"):
         _combined_tier_local_descriptors({0: (0, 0)})
+
+
+@pytest.mark.parametrize("num_tokens", [1, 8, 256, 3072])
+def test_hybrid_moe_rejects_shared_expert_aux_stream(num_tokens):
+    method = object.__new__(NvFp4Nf3HybridMoEMethod)
+
+    assert not method.supports_shared_experts_aux_stream(num_tokens)

--- a/vllm/model_executor/layers/fused_moe/b12x_moe.py
+++ b/vllm/model_executor/layers/fused_moe/b12x_moe.py
@@ -453,10 +453,9 @@ def _plan_b12x_moe_execution(
 
 
 def _b12x_moe_plan_supports_aux_stream_overlap(plan: Any) -> bool:
-    # Namespaced SparkInfer does not yet publish a plan capability predicate.
-    # Some resident-grid plans use device-wide barriers, so lack of an explicit
-    # guarantee must conservatively disable auxiliary-stream overlap.
-    return False
+    from sparkinfer.moe.fused_moe import plan_supports_aux_stream_overlap
+
+    return bool(plan_supports_aux_stream_overlap(plan))
 
 
 def _b12x_scratch_nbytes(plan: Any) -> int:
@@ -802,6 +801,7 @@ class B12xExperts(mk.FusedMoEExpertsModular):
         self._activation_amax_base_num_layers = _current_config_num_hidden_layers()
         self._activation_amax_state_key: tuple[str, str, int] | None = None
         self._activation_amax_layer_idx: int | None = None
+        self._aux_stream_overlap_by_tokens: dict[int, bool] = {}
 
     def _quant_mode(self) -> str:
         source_format = self._source_format()
@@ -825,6 +825,38 @@ class B12xExperts(mk.FusedMoEExpertsModular):
             logger.warning_once("B12X MoE force-A16 enabled: using quant_mode=w4a16.")
             return "w4a16"
         return "nvfp4" if self.quant_config.quant_dtype == "nvfp4" else "w4a16"
+
+    def supports_shared_experts_aux_stream(self, num_tokens: int) -> bool:
+        """Allow overlap only when B12X selected a barrier-free launch."""
+        num_tokens = max(int(num_tokens), 1)
+        cached = self._aux_stream_overlap_by_tokens.get(num_tokens)
+        if cached is not None:
+            return cached
+
+        prepared = self._lookup_prepared_experts()
+        if prepared is None:
+            return False
+        activation = self.moe_config.activation
+        swiglu_limit, swiglu_alpha, swiglu_beta = self._b12x_swiglu_params(activation)
+        quant_mode = self._quant_mode()
+        if (
+            not _supports_swiglu_limit(quant_mode)
+            and activation != MoEActivation.SWIGLUOAI_UNINTERLEAVE
+        ):
+            swiglu_limit = None
+        plan = _plan_b12x_moe_execution(
+            tokens=num_tokens,
+            topk=int(self.moe_config.experts_per_token),
+            device=prepared.w1_fp4.device,
+            quant_mode=quant_mode,
+            experts=prepared,
+            swiglu_limit=swiglu_limit,
+            swiglu_alpha=swiglu_alpha,
+            swiglu_beta=swiglu_beta,
+        )
+        supports_overlap = _b12x_moe_plan_supports_aux_stream_overlap(plan)
+        self._aux_stream_overlap_by_tokens[num_tokens] = supports_overlap
+        return supports_overlap
 
     def _source_format(self) -> str:
         if self.quant_config.weight_quant_dtype == "nvfp4":

--- a/vllm/model_executor/layers/fused_moe/fused_moe_method_base.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe_method_base.py
@@ -49,6 +49,20 @@ class FusedMoEMethodBase(QuantizeMethodBase):
             self.moe_kernel is not None and self.moe_kernel.can_overlap_shared_experts
         )
 
+    def supports_shared_experts_aux_stream(self, num_tokens: int) -> bool:
+        """Whether the selected expert kernel can overlap another CUDA stream."""
+        if self.moe_kernel is None:
+            return True
+        experts = getattr(self.moe_kernel, "fused_experts", None)
+        supports_overlap = getattr(
+            experts,
+            "supports_shared_experts_aux_stream",
+            None,
+        )
+        if supports_overlap is None:
+            return True
+        return bool(supports_overlap(int(num_tokens)))
+
     @abstractmethod
     def create_weights(
         self,

--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -296,11 +296,16 @@ class MoERunner(MoERunnerInterface):
         self._shared_experts: SharedExperts | None = None
         if shared_experts is not None:
             can_overlap = lambda: self._quant_method.mk_can_overlap_shared_experts
+
+            def supports_aux_stream(num_tokens: int) -> bool:
+                return self._quant_method.supports_shared_experts_aux_stream(num_tokens)
+
             self._shared_experts = SharedExperts(
                 shared_experts,
                 moe_config=moe_config,
                 enable_dbo=enable_dbo,
                 mk_can_overlap_shared_experts=can_overlap,
+                experts_support_aux_stream=supports_aux_stream,
             )
 
         # Needed for string -> MoERunner layer lookup in custom ops.
@@ -600,6 +605,10 @@ class MoERunner(MoERunnerInterface):
 
         if self.routed_experts.quant_method.is_monolithic:
             # Monolithic kernels: pass router_logits to routed_experts
+            self._maybe_apply_shared_experts(
+                shared_experts_input,
+                SharedExpertsOrder.MULTI_STREAM_OVERLAPPED,
+            )
             fused_out = self.routed_experts.forward_monolithic(
                 x=hidden_states,
                 router_logits=router_logits,
@@ -614,6 +623,14 @@ class MoERunner(MoERunnerInterface):
                 input_ids=input_ids,
             )
 
+            # The auxiliary launch was queued before gate/router work. Join it
+            # only after routing, immediately before the routed kernel, to keep
+            # resident-grid plans isolated without serializing independent work.
+            self._maybe_apply_shared_experts(
+                shared_experts_input,
+                SharedExpertsOrder.MULTI_STREAM_OVERLAPPED,
+            )
+
             fused_out = self.routed_experts.forward_modular(
                 x=hidden_states,
                 topk_weights=topk_weights,
@@ -621,11 +638,6 @@ class MoERunner(MoERunnerInterface):
                 shared_experts=self._shared_experts,
                 shared_experts_input=shared_experts_input,
             )
-
-        self._maybe_apply_shared_experts(
-            shared_experts_input,
-            SharedExpertsOrder.MULTI_STREAM_OVERLAPPED,
-        )
 
         return (
             self._shared_experts.output if self._shared_experts is not None else None,

--- a/vllm/model_executor/layers/fused_moe/runner/shared_experts.py
+++ b/vllm/model_executor/layers/fused_moe/runner/shared_experts.py
@@ -43,6 +43,7 @@ class SharedExperts(torch.nn.Module):
         moe_config: FusedMoEConfig,
         enable_dbo: bool,
         mk_can_overlap_shared_experts: Callable[[], bool],
+        experts_support_aux_stream: Callable[[int], bool],
     ):
         super().__init__()
 
@@ -56,6 +57,7 @@ class SharedExperts(torch.nn.Module):
         self._moe_config = moe_config
 
         self._mk_can_overlap_shared_experts = mk_can_overlap_shared_experts
+        self._experts_support_aux_stream = experts_support_aux_stream
 
         # Allow disabling of the separate shared experts stream for
         # debug purposes.
@@ -99,6 +101,7 @@ class SharedExperts(torch.nn.Module):
         should_run_shared_in_aux_stream = (
             current_platform.is_cuda()
             and self._stream is not None
+            and self._experts_support_aux_stream(int(hidden_states.shape[0]))
             and hidden_states.shape[0]
             <= envs.VLLM_SHARED_EXPERTS_STREAM_TOKEN_THRESHOLD
         )
@@ -116,6 +119,7 @@ class SharedExperts(torch.nn.Module):
 
         if experts_order == SharedExpertsOrder.MULTI_STREAM_OVERLAPPED:
             assert self._stream is not None
+            assert self._output[self._output_idx] is None
 
             # Record that the clone will be used by shared_experts_stream
             # to avoid gc issue from deallocation of hidden_states_clone
@@ -126,15 +130,15 @@ class SharedExperts(torch.nn.Module):
             # run in parallel with router/gate.
             self._stream.wait_stream(current_stream())
 
-    def _run_in_aux_stream(
-        self,
-        shared_experts_input: torch.Tensor,
-    ) -> torch.Tensor:
-        # TODO: assert that maybe_sync_shared_experts_stream has been called.
+            # Submit the shared expert before gate/router work. The consumer
+            # stream is joined later, immediately before the routed kernel, so
+            # resident-grid kernels never execute concurrently with this work.
+            with torch.cuda.stream(self._stream):
+                self._output[self._output_idx] = self._layer(shared_experts_input)
 
-        # Run shared experts in parallel on a separate stream.
-        with torch.cuda.stream(self._stream):
-            output = self._layer(shared_experts_input)
+    def _join_aux_stream(self) -> None:
+        output = self._output[self._output_idx]
+        assert output is not None
         consumer_stream = current_stream()
         consumer_stream.wait_stream(self._stream)
 
@@ -143,8 +147,6 @@ class SharedExperts(torch.nn.Module):
         # orders producer before consumer; record_stream keeps the allocation
         # alive until the consumer has finished using it.
         output.record_stream(consumer_stream)
-
-        return output
 
     @property
     def _output_idx(self) -> int:
@@ -167,13 +169,10 @@ class SharedExperts(torch.nn.Module):
         if order != experts_order:
             return None
 
-        assert self._output[self._output_idx] is None
-
         if order == SharedExpertsOrder.MULTI_STREAM_OVERLAPPED:
-            self._output[self._output_idx] = self._run_in_aux_stream(
-                shared_experts_input
-            )
+            self._join_aux_stream()
         else:
+            assert self._output[self._output_idx] is None
             self._output[self._output_idx] = self._layer(shared_experts_input)
 
         assert self._output[self._output_idx] is not None

--- a/vllm/model_executor/layers/quantization/nvfp4_nf3_hybrid.py
+++ b/vllm/model_executor/layers/quantization/nvfp4_nf3_hybrid.py
@@ -333,6 +333,16 @@ class NvFp4Nf3HybridMoEMethod(FusedMoEMethodBase):
         super().__init__(moe_config)
         self.quant_config = quant_config
 
+    def supports_shared_experts_aux_stream(self, num_tokens: int) -> bool:
+        """The hybrid B12X launches must own the device while they run.
+
+        Both the unified Grid188 decode and the per-tier fused fallback use
+        resident-grid software barriers. Concurrent shared-expert work can
+        occupy an SM needed by a barrier participant and deadlock the grid;
+        the resulting asynchronous fault may surface in a later CUDA op.
+        """
+        return False
+
     def maybe_make_prepare_finalize(
         self,
         routing_tables: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None = None,


### PR DESCRIPTION
## Summary

- query the selected SparkInfer MoE plan before using the shared-expert auxiliary stream
- submit eligible shared-expert work before gate/router work
- join the auxiliary stream immediately before a resident routed-MoE launch
- reject overlap for the NVFP4/NF3 hybrid resident-grid path
- keep all CUDA graph, DCP channel, and workspace lifecycle changes out of this PR

## Root cause and ordering contract

A resident-grid MoE kernel can deadlock if it is submitted while auxiliary work occupies an SM needed by its grid-wide barrier. Blanket serialization avoids the deadlock but creates a measurable DCP1 A16 decode regression.

The safe order is:

1. establish the input dependency and submit shared experts on the auxiliary stream
2. execute gate/router work on the consumer stream
3. join the auxiliary stream
4. submit the resident routed-MoE grid

This preserves gate/router overlap without allowing shared experts and the resident grid to execute concurrently.

## Dependency

Requires local-inference-lab/sparkinfer#60.

This branch is based directly on `dev/gilded-gnosis`; it is not stacked. It contains the MoE portion split out of #149 plus the profiler-guided no-regression ordering correction.

## Validation

- focused vLLM MoE/quantization suite: **29 passed, 2 skipped**
- Ruff lint and format checks passed
- `git diff --check` passed
- TP8/DCP1/MTP0/A16 CC1:
  - v17 baseline mean: **87.745 tok/s**
  - previous #149 ordering mean: **86.929 tok/s**
  - corrected ordering median: **87.643 tok/s**
  - remaining delta vs v17: **-0.12%**
- KV capacity unchanged at **578,368 tokens**
- profiler: auxiliary idle gap reduced from **162 us** to **79 us**; v17 was **71 us**
