### PR TITLE
[GG] fix(kv-offload): defer stores until metadata is ready

### DIFF
--- a/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
@@ -11,6 +11,9 @@ from tests.v1.kv_connector.unit.offloading_connector.utils import (
     to_keys,
 )
 from tests.v1.kv_connector.unit.utils import EOS_TOKEN_ID
+from vllm.distributed.kv_transfer.kv_connector.v1.offloading.common import (
+    OffloadingConnectorMetadata,
+)
 from vllm.distributed.kv_transfer.kv_connector.v1.offloading.metrics import (
     OffloadingConnectorStats,
     _ConnectorMetricName,
@@ -19,6 +22,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.offloading.scheduler import (
     OffloadingConnectorScheduler,
     RequestOffloadState,
 )
+from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheGroupSpec,
@@ -62,6 +66,99 @@ def test_scheduler_reports_allocation_failure(request_runner):
 
     reduced = _reduce_kv_connector_stats(runner)
     assert reduced[_ConnectorMetricName.ALLOCATION_FAILURE] == 1
+
+
+@pytest.mark.parametrize("missing_metadata", ["block_ids", "offload_keys"])
+@pytest.mark.parametrize("blocks_per_chunk", [1, 2])
+def test_store_defers_chunk_until_metadata_is_ready(
+    request_runner, missing_metadata: str, blocks_per_chunk: int
+):
+    """Store only the common key/block prefix, then retry the deferred chunk."""
+    block_size = 4
+    num_chunks = 3
+    runner = request_runner(
+        block_size=block_size,
+        num_gpu_blocks=10,
+        async_scheduling=True,
+        blocks_per_chunk=blocks_per_chunk,
+    )
+    num_tokens = block_size * blocks_per_chunk * num_chunks
+    runner.new_request(token_ids=[0] * num_tokens)
+    runner.manager.prepare_store.side_effect = lambda keys, req_context: (
+        generate_store_output(keys)
+    )
+
+    req_status = runner.connector_scheduler._req_status["0"]
+    req_status.update_offload_keys()
+    group_state = req_status.group_states[0]
+    all_block_ids = list(range(1, blocks_per_chunk * num_chunks + 1))
+    group_state.block_ids.extend(all_block_ids)
+    assert len(group_state.offload_keys) == num_chunks
+
+    pending_block_id = (
+        group_state.block_ids.pop() if missing_metadata == "block_ids" else None
+    )
+    pending_offload_key = (
+        group_state.offload_keys.pop() if missing_metadata == "offload_keys" else None
+    )
+
+    scheduler_output = SchedulerOutput.make_empty()
+    scheduler_output.num_scheduled_tokens = {"0": num_tokens}
+    first_jobs = runner.connector_scheduler._build_store_jobs(scheduler_output)
+
+    assert len(first_jobs) == 1
+    assert (
+        next(iter(first_jobs.values())).src_spec.block_ids.tolist()
+        == all_block_ids[: 2 * blocks_per_chunk]
+    )
+    assert group_state.next_stored_chunk_idx == 2
+
+    if missing_metadata == "block_ids":
+        assert pending_block_id is not None
+        group_state.block_ids.append(pending_block_id)
+    else:
+        assert pending_offload_key is not None
+        group_state.offload_keys.append(pending_offload_key)
+    second_jobs = runner.connector_scheduler._build_store_jobs(scheduler_output)
+
+    assert len(second_jobs) == 1
+    second_block_ids = next(iter(second_jobs.values())).src_spec.block_ids.tolist()
+    assert second_block_ids == all_block_ids[2 * blocks_per_chunk :]
+    assert group_state.next_stored_chunk_idx == 3
+
+
+@pytest.mark.parametrize("async_scheduling", [True, False])
+def test_abort_queued_request_does_not_build_store_job(
+    request_runner, async_scheduling: bool
+):
+    """Aborting a never-scheduled request must not store unallocated KV."""
+    block_size = 4
+    runner = request_runner(
+        block_size=block_size,
+        num_gpu_blocks=8,
+        async_scheduling=async_scheduling,
+    )
+
+    runner.new_request(token_ids=[0] * (block_size * 4))
+    runner.scheduler.schedule()
+
+    runner.new_request(token_ids=[1] * (block_size * 4))
+    queued_req_id = str(runner.req_id)
+    assert any(
+        request.request_id == queued_req_id for request in runner.scheduler.waiting
+    )
+
+    runner.scheduler.finish_requests(queued_req_id, RequestStatus.FINISHED_ABORTED)
+    req_status = runner.connector_scheduler._req_status[queued_req_id]
+    assert all(group_state.offload_keys for group_state in req_status.group_states)
+    assert all(not group_state.block_ids for group_state in req_status.group_states)
+
+    scheduler_output = runner.scheduler.schedule()
+
+    metadata = scheduler_output.kv_connector_metadata
+    assert isinstance(metadata, OffloadingConnectorMetadata)
+    assert all(job.req_id != queued_req_id for job in metadata.store_jobs.values())
+    assert queued_req_id not in runner.connector_scheduler._req_status
 
 
 @pytest.mark.parametrize("async_scheduling", [True, False])

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -306,9 +306,12 @@ class RequestOffloadState:
             group_state.block_ids.extend(new_blocks)
 
     def storable_chunks(
-        self, group_config: "GroupOffloadConfig", num_offloadable_tokens: int
+        self,
+        group_config: "GroupOffloadConfig",
+        group_state: RequestGroupState,
+        num_offloadable_tokens: int,
     ) -> int:
-        """Number of leading offloaded chunks eligible for store.
+        """Number of leading chunks whose keys and source blocks are ready.
 
         For eagle/MTP groups the volatile trailing chunk of the offloadable
         range is excluded while decoding: the draft-layer KV of the last
@@ -320,23 +323,40 @@ class RequestOffloadState:
         each step is skipped on collection but jumped over by
         ``next_stored_chunk_idx``, so it is never re-considered and a
         permanent hole breaks prefix-reuse lookup.
+
+        Async scheduling can expose token progress before either hashes or a
+        complete source-block chunk is tracked. Limit the cursor to their
+        common ready prefix so the missing chunk is retried on a later step.
         """
         num_chunks = num_offloadable_tokens // group_config.tokens_per_chunk
         is_decoding = num_offloadable_tokens > self.req.num_prompt_tokens
         if group_config.is_eagle_group and is_decoding:
             num_chunks = max(0, num_chunks - 1)
-        return num_chunks
+        num_ready_chunks = min(
+            len(group_state.offload_keys),
+            len(group_state.block_ids) // self.config.blocks_per_chunk,
+        )
+        if num_ready_chunks < num_chunks:
+            logger.debug(
+                "Request %s deferring group %d offload chunks: "
+                "storable=%d keys=%d tracked_blocks=%d",
+                self.req.request_id,
+                group_config.group_idx,
+                num_chunks,
+                len(group_state.offload_keys),
+                len(group_state.block_ids),
+            )
+        return min(num_chunks, num_ready_chunks)
 
     def advance_stored_idx(self, num_offloadable_tokens: int) -> None:
-        # max(): at the prefill->decode transition of a chunk-aligned prompt,
-        # storable_chunks drops by one (the eagle exclusion kicks in), and the
-        # index must not move backwards past already-stored chunks.
+        # Keep the cursor monotonic: the EAGLE exclusion can lower a group's
+        # storable boundary at the prefill-to-decode transition.
         for group_config, group_state in zip(
             self.config.kv_group_configs, self.group_states
         ):
             group_state.next_stored_chunk_idx = max(
                 group_state.next_stored_chunk_idx,
-                self.storable_chunks(group_config, num_offloadable_tokens),
+                self.storable_chunks(group_config, group_state, num_offloadable_tokens),
             )
 
     def update_num_hit_chunks(self, num_cached_tokens: int) -> None:
@@ -955,9 +975,8 @@ class OffloadingConnectorScheduler:
                 self.config.kv_group_configs, req_status.group_states
             ):
                 num_chunks = req_status.storable_chunks(
-                    group_config, num_offloadable_tokens
+                    group_config, group_state, num_offloadable_tokens
                 )
-
                 start_chunk_idx = group_state.next_stored_chunk_idx
                 if num_chunks <= start_chunk_idx:
                     continue
@@ -1032,7 +1051,7 @@ class OffloadingConnectorScheduler:
                     group_config.sliding_window_size_in_chunks is not None
                 )
                 num_chunks = req_status.storable_chunks(
-                    group_config, num_offloadable_tokens
+                    group_config, group_state, num_offloadable_tokens
                 )
                 start_chunk_idx = group_state.next_stored_chunk_idx
                 block_ids = group_state.block_ids


### PR DESCRIPTION
## Summary

- bound each KV group's store cursor by the common ready prefix of token eligibility, hash keys, and complete tracked GPU-block chunks
- retry a lagging chunk on a later scheduler step instead of asserting or advancing past it
- retain the key/block length assertion after the readiness bound as an internal consistency guard

## Root cause

With async scheduling, token-derived store progress can become visible before either `offload_keys` or `block_ids` reaches the same chunk boundary. The old code sliced both collections at the token-derived boundary and asserted equal lengths, which could terminate `EngineCore` during queue abort, eviction, or preemption.

Removing the assertion or relying on `zip()` is not sufficient: advancing `next_stored_chunk_idx` past the missing metadata would silently skip that chunk forever. `storable_chunks()` now owns the complete invariant and returns only the common ready prefix.

## Relation to earlier work

This replaces the closed #133, which targeted a transient CUTLASS integration branch instead of `dev/gilded-gnosis`.

The implementation was re-audited against upstream [#49146](https://github.com/vllm-project/vllm/pull/49146):

- it follows the upstream-reviewed design by keeping readiness inside `storable_chunks()`
- it includes the upstream queued-abort behavior
- it additionally gates on available hash keys, since keys and block IDs can lag independently
- it covers multi-block chunks and verifies that deferred chunks are retried

## Validation

Run in the GG release CUDA image:

- focused metadata-lag and queued-abort cases: **6 passed**
- complete `test_scheduler.py`: **97 passed**
- complete `tests/v1/kv_connector/unit/offloading_connector`: **142 passed**
- Ruff lint and format checks passed
- `git diff --check` passed

The branch is based directly on `dev/gilded-gnosis` at `73e4a8cde8`; there is no stacked base or Docker-only overlay.
