### PR TITLE
[GG] spec-decode: cap same-model draft position limit

### DIFF
--- a/tests/config/test_speculative_draft_hf_overrides.py
+++ b/tests/config/test_speculative_draft_hf_overrides.py
@@ -173,3 +173,58 @@ def test_mtp_explicit_draft_revisions_are_preserved():
 
     assert spec.revision == "draft-weights"
     assert spec.code_revision == "draft-code"
+
+
+@pytest.mark.cpu_test
+def test_same_model_draft_inherits_smaller_target_position_limit():
+    target_text = SimpleNamespace(max_position_embeddings=600_000)
+    draft_text = SimpleNamespace(max_position_embeddings=1_000_000)
+    spec = SimpleNamespace(
+        model="org/model",
+        target_model_config=SimpleNamespace(
+            model="org/model",
+            hf_config=SimpleNamespace(),
+            hf_text_config=target_text,
+        ),
+        draft_model_config=SimpleNamespace(
+            model="org/model",
+            hf_config=SimpleNamespace(),
+            hf_text_config=draft_text,
+        ),
+    )
+
+    changed = SpeculativeConfig._cap_same_model_draft_position_embeddings(spec)
+
+    assert changed is True
+    assert draft_text.max_position_embeddings == 600_000
+
+
+@pytest.mark.cpu_test
+@pytest.mark.parametrize(
+    ("draft_model", "draft_max"),
+    [
+        ("org/other-draft", 1_000_000),
+        ("org/model", 500_000),
+    ],
+)
+def test_draft_position_limit_is_not_increased_or_applied_cross_model(
+    draft_model: str,
+    draft_max: int,
+):
+    draft_text = SimpleNamespace(max_position_embeddings=draft_max)
+    spec = SimpleNamespace(
+        model=draft_model,
+        target_model_config=SimpleNamespace(
+            model="org/model",
+            hf_text_config=SimpleNamespace(max_position_embeddings=600_000),
+        ),
+        draft_model_config=SimpleNamespace(
+            model=draft_model,
+            hf_text_config=draft_text,
+        ),
+    )
+
+    changed = SpeculativeConfig._cap_same_model_draft_position_embeddings(spec)
+
+    assert changed is False
+    assert draft_text.max_position_embeddings == draft_max

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -743,6 +743,28 @@ class SpeculativeConfig:
         if self.code_revision is None:
             self.code_revision = target.code_revision
 
+    def _cap_same_model_draft_position_embeddings(self) -> bool:
+        """Cap an in-checkpoint draft to the target's effective RoPE table."""
+        target = self.target_model_config
+        draft = self.draft_model_config
+        if target is None or draft is None or draft.model != target.model:
+            return False
+
+        target_hf = target.hf_text_config
+        draft_hf = draft.hf_text_config
+        target_max = getattr(target_hf, "max_position_embeddings", None)
+        draft_max = getattr(draft_hf, "max_position_embeddings", None)
+        if target_max is None or draft_max is None or target_max >= draft_max:
+            return False
+
+        draft_hf.max_position_embeddings = target_max
+        logger.info(
+            "Capped same-model draft max_position_embeddings from %d to %d.",
+            draft_max,
+            target_max,
+        )
+        return True
+
     def __post_init__(self):
         # Note: "method" is a new parameter that helps to extend the
         # configuration of non-model-based proposers, and the "model" parameter
@@ -955,6 +977,8 @@ class SpeculativeConfig:
                     hf_overrides=draft_hf_overrides,
                     config_format=self.target_model_config.config_format,
                 )
+
+                self._cap_same_model_draft_position_embeddings()
 
                 # Old-format Medusa checkpoints (e.g. FasterDecoding/medusa-*)
                 # omit vocab_size in config.json, so MedusaConfig falls back to


### PR DESCRIPTION
## Summary

When a target model uses a dict `hf_overrides` to reduce
`max_position_embeddings`, that dict intentionally remains target-only. A
same-checkpoint speculative draft could therefore allocate RoPE tables for the
checkpoint default even though the scheduler cannot reach those positions.

After constructing the draft `ModelConfig`, this change lowers the draft text
config limit when, and only when:

- the target and draft resolve to the same model;
- both `hf_text_config` objects expose `max_position_embeddings`; and
- the target limit is smaller.

External draft checkpoints are untouched, and an already-smaller draft limit is
never increased.

## Scope and prior work

This supersedes only the draft-context half of #146. It is an independent commit
directly on the current `dev/gilded-gnosis` head. Compared with #146, it uses
`hf_text_config` (including nested text configs), verifies same-model identity,
and includes regression tests. Searches of open upstream and local PRs found no
other implementation; #146 is the intentional predecessor being split.
PR #148 contains #146 in its stacked history, but its unique tip changes MLA
allocation order and is orthogonal to this configuration fix; it will need a
clean rebase after the predecessor replacement.

The original GLM-5.2 TP4 validation in #146 reported about 128 MiB/GPU reclaimed
when capping a 1M checkpoint default to a 600k target, with unchanged throughput,
KLD, and MTP acceptance. This patch does not alter any position the target can
schedule.

## Validation

```text
pytest tests/config/test_speculative_draft_hf_overrides.py -q
11 passed

ruff check vllm/config/speculative.py tests/config/test_speculative_draft_hf_overrides.py
ruff format --check vllm/config/speculative.py tests/config/test_speculative_draft_hf_overrides.py
git diff --check
all passed
```

AI assistance was used. This PR must not be merged until the human submitter has
reviewed every changed line and can defend the behavior end to end.
