### PR TITLE
[GG] MLA: preallocate absorbed projection weights before dequant scratch

### DIFF
--- a/tests/v1/attention/test_mla_backends.py
+++ b/tests/v1/attention/test_mla_backends.py
@@ -65,6 +65,80 @@ BACKENDS_TO_TEST = [
 DEVICE_TYPE = current_platform.device_type
 
 
+@pytest.mark.cpu_test
+def test_mla_post_load_preallocates_quantized_absorbed_weights(monkeypatch):
+    layer = MLAAttention.__new__(MLAAttention)
+    torch.nn.Module.__init__(layer)
+    layer.kv_lora_rank = 2
+    layer.num_heads = 2
+    layer.qk_nope_head_dim = 3
+    layer.v_head_dim = 4
+    layer.kv_b_proj = torch.nn.Module()
+    layer.kv_b_proj.qweight = torch.nn.Parameter(
+        torch.ones((14, 2), dtype=torch.int8), requires_grad=False
+    )
+    layer.kv_b_proj.quant_method = object()
+    layer.is_aiter_triton_fp4_bmm_enabled = False
+    layer.is_aiter_triton_fp8_bmm_enabled = False
+    layer.quant_config = None
+    layer.layer_name = "test"
+    dequantized = torch.arange(28.0, dtype=torch.float32).reshape(14, 2)
+    events = []
+    preallocated = []
+    preallocate = mla_attention_module._preallocate_absorbed_mla_weights
+
+    def track_preallocation(*args, **kwargs):
+        events.append("preallocate")
+        weights = preallocate(*args, **kwargs)
+        preallocated.extend(weights)
+        return weights
+
+    def fake_dequant(*args, **kwargs):
+        events.append("dequantize")
+        return dequantized
+
+    monkeypatch.setattr(
+        mla_attention_module,
+        "_preallocate_absorbed_mla_weights",
+        track_preallocation,
+    )
+    monkeypatch.setattr(
+        mla_attention_module, "get_and_maybe_dequant_weights", fake_dequant
+    )
+    monkeypatch.setattr(
+        mla_attention_module, "set_default_quant_scales", lambda *_, **__: None
+    )
+
+    with torch.no_grad():
+        layer.process_weights_after_loading(torch.float32)
+
+    assert events == ["preallocate", "dequantize"]
+    assert layer.W_UV.data_ptr() == preallocated[0].data_ptr()
+    assert layer.W_UK_T.data_ptr() == preallocated[1].data_ptr()
+    assert layer.W_UV.device == layer.kv_b_proj.qweight.device
+    assert layer.W_UK_T.device == layer.kv_b_proj.qweight.device
+
+
+@pytest.mark.cpu_test
+def test_mla_absorbed_weight_preallocation_reuses_compatible_storage():
+    layer = SimpleNamespace(
+        kv_lora_rank=2,
+        num_heads=2,
+        qk_nope_head_dim=3,
+        v_head_dim=4,
+        kv_b_proj=torch.nn.Module(),
+        W_UV=torch.empty((2, 2, 4), dtype=torch.float32),
+        W_UK_T=torch.empty((2, 3, 2), dtype=torch.float32),
+    )
+
+    pre_w_uv, pre_w_uk_t = mla_attention_module._preallocate_absorbed_mla_weights(
+        layer, torch.float32
+    )
+
+    assert pre_w_uv is None
+    assert pre_w_uk_t is None
+
+
 @pytest.mark.parametrize(
     ("cache_dtype", "expected_quant_mode"),
     [

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -303,6 +303,91 @@ def _b12x_absorb_bmm_enabled() -> bool:
     return envs.VLLM_B12X_ABSORB_BMM
 
 
+def _find_linear_weight_device(layer: torch.nn.Module) -> torch.device | None:
+    """Find the device that owns a linear layer's loaded weights.
+
+    Args:
+        layer: Linear layer or a wrapper around one.
+
+    Returns:
+        The loaded weight device, or ``None`` when the layer owns no tensors.
+    """
+    while hasattr(layer, "base_layer") and hasattr(layer.base_layer, "quant_method"):
+        layer = layer.base_layer
+
+    for name in ("weight", "qweight", "weight_packed"):
+        weight = getattr(layer, name, None)
+        if isinstance(weight, torch.Tensor):
+            return weight.device
+    for parameter in layer.parameters(recurse=False):
+        return parameter.device
+    for buffer in layer.buffers(recurse=False):
+        return buffer.device
+    return None
+
+
+def _preallocate_absorbed_mla_weights(
+    layer: "MLAAttention", act_dtype: torch.dtype
+) -> tuple[torch.Tensor | None, torch.Tensor | None]:
+    """Allocate persistent MLA weights before temporary dequantization storage.
+
+    Compatible weights from an earlier load are reused in place, preserving
+    their addresses for CUDA graphs.
+
+    Args:
+        layer: MLA attention layer whose KV projection will be absorbed.
+        act_dtype: Data type used by the absorbed projection weights.
+
+    Returns:
+        Optional new storage for ``W_UV`` and ``W_UK_T``, respectively.
+
+    Raises:
+        RuntimeError: If neither the source projection nor reusable absorbed
+            weights identify the target device.
+    """
+    w_uv_shape = (layer.num_heads, layer.kv_lora_rank, layer.v_head_dim)
+    w_uk_t_shape = (
+        layer.num_heads,
+        layer.qk_nope_head_dim,
+        layer.kv_lora_rank,
+    )
+    current_w_uv = getattr(layer, "W_UV", None)
+    current_w_uk_t = getattr(layer, "W_UK_T", None)
+
+    device = _find_linear_weight_device(layer.kv_b_proj)
+    if device is None:
+        current_devices = {
+            weight.device
+            for weight in (current_w_uv, current_w_uk_t)
+            if isinstance(weight, torch.Tensor)
+        }
+        if len(current_devices) != 1:
+            raise RuntimeError(
+                "Cannot determine the device for absorbed MLA projection weights."
+            )
+        device = current_devices.pop()
+
+    def needs_storage(weight: object, shape: tuple[int, ...]) -> bool:
+        return not (
+            isinstance(weight, torch.Tensor)
+            and weight.shape == shape
+            and weight.dtype == act_dtype
+            and weight.device == device
+        )
+
+    pre_w_uv = (
+        torch.empty(w_uv_shape, dtype=act_dtype, device=device)
+        if needs_storage(current_w_uv, w_uv_shape)
+        else None
+    )
+    pre_w_uk_t = (
+        torch.empty(w_uk_t_shape, dtype=act_dtype, device=device)
+        if needs_storage(current_w_uk_t, w_uk_t_shape)
+        else None
+    )
+    return pre_w_uv, pre_w_uk_t
+
+
 def _can_use_b12x_dcp_prefill_workspace(
     *,
     enabled: bool,
@@ -1421,6 +1506,13 @@ class MLAAttention(nn.Module, AttentionLayerBase):
         return w_uk.permute(1, 2, 0), w_uv.transpose(0, 1)
 
     def _process_materialized_absorbed_weights(self, act_dtype: torch.dtype):
+        pre_w_uv = pre_w_uk_t = None
+        if not (
+            self.is_aiter_triton_fp4_bmm_enabled or self.is_aiter_triton_fp8_bmm_enabled
+        ):
+            # Seat persistent weights before the transient dequantization scratch.
+            pre_w_uv, pre_w_uk_t = _preallocate_absorbed_mla_weights(self, act_dtype)
+
         # we currently do not have quantized bmm's which are needed for
         # `W_UV` and `W_UK_T`, we just store fp16/bf16 copies and perform
         # the bmm's in 16-bit, the extra memory overhead of this is fairly low
@@ -1505,9 +1597,17 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 )
         else:
             # Convert from (L, N, V) to (N, L, V)
-            replace_parameter(self, "W_UV", W_UV.transpose(0, 1), prefer_copy=True)
+            w_uv = W_UV.transpose(0, 1)
+            if pre_w_uv is not None:
+                pre_w_uv.copy_(w_uv)
+                w_uv = pre_w_uv
+            replace_parameter(self, "W_UV", w_uv, prefer_copy=True)
             # Convert from (L, N, P) to (N, P, L)
-            replace_parameter(self, "W_UK_T", W_UK.permute(1, 2, 0), prefer_copy=True)
+            w_uk_t = W_UK.permute(1, 2, 0)
+            if pre_w_uk_t is not None:
+                pre_w_uk_t.copy_(w_uk_t)
+                w_uk_t = pre_w_uk_t
+            replace_parameter(self, "W_UK_T", w_uk_t, prefer_copy=True)
 
         # If we should not load quant weights, we initialize the scales to 1.0
         # as the default value. See [Note: Register q/k/v/prob scales in state dict]


### PR DESCRIPTION
## Summary

Allocate the persistent MLA absorbed projection pair (`W_UV` and `W_UK_T`) before materializing temporary dequantization storage. This keeps long-lived tensors out of the allocator holes created by per-layer dequant scratch.

Compared with #148, this clean replacement also:

- limits preallocation to the generic 16-bit absorbed path, so Aiter FP4/FP8 BMM paths do not allocate unused tensors;
- resolves the device from `weight`, `qweight`, `weight_packed`, wrapped base layers, parameters, or buffers instead of assuming `kv_b_proj.weight`;
- reuses compatible absorbed tensors on reload and keeps `prefer_copy=True`, preserving CUDA-graph-visible `data_ptr` values;
- adds focused CPU coverage for quantized layers without `.weight`, allocation-before-dequant ordering, first-load storage adoption, and reload pointer stability.

## Why

The original allocation order materializes each persistent absorbed pair after the dequant scratch has churned the CUDA allocator. The validation attached to #148 measured reserved-but-unallocated memory falling from 0.577 to 0.225 GiB per GPU at GLM-5.2 TP4 geometry when the persistent pair is allocated first.

This PR intentionally supersedes #148 instead of building on it: #148 is stacked on unrelated #145/#146 changes. No upstream open PR matched searches for `W_UK_T W_UV preallocate` or `MLA dequant scratch fragmentation`. #154 is related but not a duplicate: it releases B12X-owned source storage after absorption, while this PR controls allocation order. The two branches apply without a source conflict.

## CodeRabbit feedback from #148

Accepted and strengthened:

- safe device lookup for quantized modules without `.weight`;
- `prefer_copy=True` and reload-safe pointer preservation.

Not ported:

- the KLD table edit in `kv-scales/README.md`, because that file belongs to the unrelated #145 stack and is outside this clean PR.

## Validation

```text
ruff check vllm/model_executor/layers/attention/mla_attention.py tests/v1/attention/test_mla_backends.py
ruff format --check vllm/model_executor/layers/attention/mla_attention.py tests/v1/attention/test_mla_backends.py
git diff --check
```

```text
python -m pytest tests/v1/attention/test_mla_backends.py -q \
  -k 'post_load_preserves_runtime_weight_addresses or post_load_preallocates_quantized_absorbed_weights or absorbed_weight_preallocation_reuses_compatible_storage'
3 passed
```

Compatibility validation with #154's focused tests: `6 passed`.

The predecessor's GLM-5.2 TP4/DCP4 model validation for the same allocation-order change reported:

- reserved-but-unallocated: 0.577 -> 0.225 GiB/GPU;
- 740,255-token KV pool;
- prefill ladder through 157,932 tokens passed;
- decode 106.7 tok/s and MTP acceptance 92.8%, unchanged;
- teacher-forced prefill KLD 0.1366 +/- 0.0042 over 15 runs.

No numerical operation or runtime weight layout changes in this replacement.

## AI assistance

OpenAI Codex assisted with implementation and validation. The human submitter must review every changed line and be able to explain and defend the allocator, reload, and device-selection contracts before merge.
