### PR TITLE
[Core] Allow verified copy-based KV connectors with expandable segments

### DIFF
--- a/tests/v1/kv_connector/unit/test_config.py
+++ b/tests/v1/kv_connector/unit/test_config.py
@@ -103,13 +103,20 @@ def _build_config(
     kv_connector: str | None,
     enable_sleep_mode: bool = False,
     enable_cumem_allocator: bool = False,
+    kv_connector_supports_expandable_segments: bool = False,
 ) -> VllmConfig:
     """Build a VllmConfig that exercises _verify_kv_transfer_compat without
     requiring a real model (avoids HF downloads in CI)."""
     from types import SimpleNamespace
 
     kv_transfer_config = (
-        KVTransferConfig(kv_connector=kv_connector, kv_role="kv_both")
+        KVTransferConfig(
+            kv_connector=kv_connector,
+            kv_role="kv_both",
+            kv_connector_supports_expandable_segments=(
+                kv_connector_supports_expandable_segments
+            ),
+        )
         if kv_connector is not None
         else None
     )
@@ -150,6 +157,32 @@ def test_kv_connector_allows_expandable_segments_with_cumem_allocator(
     """Manual CuMem allocation must also bypass expandable_segments."""
     monkeypatch.setenv("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
     _build_config(kv_connector="NixlConnector", enable_cumem_allocator=True)
+
+
+@pytest.mark.parametrize("kv_connector", ["LMCacheMPConnector", "LMCacheConnectorV1"])
+def test_kv_connector_allows_expandable_segments_with_operator_opt_in(
+    monkeypatch, kv_connector
+):
+    """Copy-based connectors (CUDA kernels / cudaMemcpy at transfer time, no
+    pinned/registered KV memory) dereference virtual addresses on every
+    transfer, so VMM physical remaps are transparent to them. The operator
+    can assert that via kv_connector_supports_expandable_segments to skip
+    the conservative rejection."""
+    monkeypatch.setenv("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+    _build_config(
+        kv_connector=kv_connector,
+        kv_connector_supports_expandable_segments=True,
+    )
+
+
+def test_kv_connector_opt_in_defaults_off(monkeypatch):
+    """Without the explicit operator opt-in the rejection must still fire."""
+    monkeypatch.setenv("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+    with pytest.raises(ValueError, match="expandable_segments"):
+        _build_config(
+            kv_connector="LMCacheMPConnector",
+            kv_connector_supports_expandable_segments=False,
+        )
 
 
 def test_kv_connector_allows_other_alloc_conf(monkeypatch):

--- a/vllm/config/kv_transfer.py
+++ b/vllm/config/kv_transfer.py
@@ -71,6 +71,19 @@ class KVTransferConfig:
     'recompute': reschedule the request to recompute failed blocks
     'fail': immediately fail the request with an error finish reason (default)"""
 
+    kv_connector_supports_expandable_segments: bool = False
+    """Operator assertion that the configured KV connector never pins or
+    registers KV cache device memory (no RDMA memory regions, no GDS/cuFile
+    registration, no CUDA IPC handles held across steps) and instead moves KV
+    with CUDA kernels or cudaMemcpy at transfer time. Such copy-based
+    connectors dereference virtual addresses on every transfer, so they are
+    unaffected when PyTorch's expandable_segments allocator remaps physical
+    pages, and the conservative expandable_segments incompatibility check can
+    be skipped. Leave False (default) unless you have verified this for your
+    connector: enabling it with a connector that does register KV memory (e.g.
+    NixlConnector, MooncakeConnector) leads to silent KV corruption or RDMA
+    failures after a remap."""
+
     def compute_hash(self) -> str:
         """
         WARNING: Whenever a new field is added to this config,

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -899,6 +899,17 @@ class VllmConfig:
             return
         if self.model_config is not None and (self.model_config.enable_cumem_allocator):
             return
+        # Copy-based connectors (CUDA kernels / cudaMemcpy at transfer time,
+        # no pinned/registered KV memory) dereference virtual addresses on
+        # every transfer, so VMM physical remaps are transparent to them. The
+        # operator can assert that property to skip the conservative check.
+        if self.kv_transfer_config.kv_connector_supports_expandable_segments:
+            logger.info_once(
+                "Allowing KV connector %s with expandable_segments:True "
+                "because kv_connector_supports_expandable_segments is set.",
+                self.kv_transfer_config.kv_connector,
+            )
+            return
 
         raise ValueError(
             f"KV connector {self.kv_transfer_config.kv_connector} is "
@@ -907,10 +918,13 @@ class VllmConfig:
             "allocator can remap KV cache virtual addresses to different "
             "physical pages, invalidating any pinned/registered KV memory "
             "(e.g. IB memory regions registered by NIXL or Mooncake). Either "
-            "unset expandable_segments:True or enable the cumem allocator "
+            "unset expandable_segments:True, enable the cumem allocator "
             "(sleep mode does this automatically and also "
             "routes KV allocations through CuMemAllocator's pool, where "
-            "expandable_segments is automatically disabled)."
+            "expandable_segments is automatically disabled), or — only if your "
+            "connector never pins/registers KV cache memory and is purely "
+            "copy-based — set "
+            "kv_transfer_config.kv_connector_supports_expandable_segments."
         )
 
     def __post_init__(self):


### PR DESCRIPTION
## Summary

Backports vLLM PR #48243 / commit `81866d82` into the local inference lab fork.

- Adds an explicit, default-off `kv_connector_supports_expandable_segments` assertion.
- Allows verified copy-based connectors such as `LMCacheConnectorV1` to run with `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`.
- Preserves the existing rejection for connectors that pin or register KV memory.
- Documents the corruption/RDMA risk of opting in an incompatible connector.

## Scope

This PR intentionally contains only the vLLM-owned configuration change. The DCP gather/scatter, heterogeneous KV packing, DCP-local token validation, and LMCache allocator logging changes belong to the external LMCache package and are not duplicated in vLLM.

## Duplicate-work check

No open PR in `local-inference-lab/vllm` covers this change. The corresponding upstream work remains open as vllm-project/vllm#48243; this PR is a direct backport for the fork rather than a competing upstream implementation.

## Validation

- `.venv/bin/python -m pytest tests/v1/kv_connector/unit/test_config.py -v` — 16 passed
- `.venv/bin/pre-commit run --files tests/v1/kv_connector/unit/test_config.py vllm/config/kv_transfer.py vllm/config/vllm.py` — all applicable hooks passed, including ruff and mypy
- `.venv/bin/python -m compileall -q tests/v1/kv_connector/unit/test_config.py vllm/config/kv_transfer.py vllm/config/vllm.py` — passed
- `git diff main...HEAD --check` — passed

Model evaluation is not applicable because this changes startup configuration validation only and does not alter model execution or outputs.

## Assistance disclosure

AI assistance was used to review repository ownership, transplant the existing upstream commit, and run validation. The substantive patch is the unchanged upstream commit authored by Carlos Molina.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in KV transfer configuration for connectors that support PyTorch’s `expandable_segments` memory allocator.
  * Copy-based LMCache connectors can now be used with `expandable_segments:True` when explicitly enabled.

* **Bug Fixes**
  * Valid compatible configurations are no longer rejected.
  * Improved configuration guidance explains available alternatives when compatibility is not enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->