### PR TITLE
feat(dcp): add native depth-N CKV prefetch

### DIFF
--- a/tests/model_executor/layers/test_sparse_attn_indexer_b12x.py
+++ b/tests/model_executor/layers/test_sparse_attn_indexer_b12x.py
@@ -36,6 +36,44 @@ class _FakeWorkspaceManager:
         return tensors
 
 
+def test_replicated_constructor_uses_single_rank_without_dcp_group(monkeypatch):
+    def init_module(self):
+        torch.nn.Module.__init__(self)
+
+    def fail_dcp_group():
+        pytest.fail("replicated indexer construction must not query the DCP group")
+
+    monkeypatch.setattr(indexer_mod.CustomOp, "__init__", init_module)
+    monkeypatch.setattr(
+        indexer_mod,
+        "get_current_vllm_config",
+        lambda: types.SimpleNamespace(
+            parallel_config=types.SimpleNamespace(
+                decode_context_parallel_size=4,
+                cp_kv_cache_interleave_size=1,
+            )
+        ),
+    )
+    monkeypatch.setattr(indexer_mod, "get_dcp_group", fail_dcp_group)
+    monkeypatch.setattr(indexer_mod, "use_b12x_sparse_indexer", lambda: True)
+
+    indexer = indexer_mod.SparseAttnIndexer(
+        k_cache=torch.nn.Identity(),
+        quant_block_size=128,
+        scale_fmt="ue8m0",
+        topk_tokens=4,
+        head_dim=128,
+        max_model_len=4096,
+        max_total_seq_len=4096,
+        topk_indices_buffer=torch.empty((2, 4), dtype=torch.int32),
+        dcp_replicated=True,
+    )
+
+    assert indexer.dcp_replicated is True
+    assert indexer.dcp_world_size == 1
+    assert indexer.dcp_rank == 0
+
+
 def _install_fake_b12x_indexer(
     monkeypatch,
     calls: list[tuple],
@@ -411,7 +449,7 @@ def test_b12x_prefill_indexer_requires_packed_contiguous_route(monkeypatch):
         64 * 576,
     ],
 )
-def test_sparse_attn_indexer_decode_uses_non_shared_b12x_binding(
+def test_replicated_decode_skips_dcp_merge_and_keeps_global_topk_ids(
     monkeypatch,
     page_stride0,
 ):
@@ -437,6 +475,12 @@ def test_sparse_attn_indexer_decode_uses_non_shared_b12x_binding(
         lambda: torch.uint8,
         raising=False,
     )
+    monkeypatch.setattr(indexer_mod, "_dcp_global_topk_requested", lambda: True)
+
+    def fail_dcp_merge(**kwargs):
+        pytest.fail("replicated indexer must not all-gather top-k candidates")
+
+    monkeypatch.setattr(indexer_mod, "_merge_b12x_dcp_topk", fail_dcp_merge)
 
     q_rows = 2
     num_heads = 1
@@ -505,6 +549,7 @@ def test_sparse_attn_indexer_decode_uses_non_shared_b12x_binding(
     )
 
     assert result is topk_indices_buffer
+    # B12X indexes the full replicated cache, so its logical IDs are already global.
     assert topk_indices_buffer.tolist() == [[123] * topk, [123] * topk]
     assert calls == [
         (

--- a/tests/models/test_dcp_shard_draft_defaults.py
+++ b/tests/models/test_dcp_shard_draft_defaults.py
@@ -3,16 +3,33 @@
 
 from types import SimpleNamespace
 
+import pytest
 import torch
 
-from vllm.model_executor.models.deepseek_v2 import DeepseekV32IndexerCache
+import vllm.model_executor.models.deepseek_v2 as deepseek_v2
+from vllm.model_executor.models.deepseek_v2 import (
+    DeepseekV32IndexerCache,
+    _replicate_indexer_cache_under_dcp,
+)
 
 
-def _vllm_config(num_hidden_layers: int = 78):
+def _vllm_config(
+    num_hidden_layers: int = 78,
+    dcp_size: int = 4,
+    pcp_size: int = 1,
+):
     return SimpleNamespace(
+        use_v2_model_runner=True,
         cache_config=SimpleNamespace(block_size=256),
+        compilation_config=SimpleNamespace(static_forward_context={}),
+        attention_config=SimpleNamespace(backend="B12X_MLA_SPARSE"),
         model_config=SimpleNamespace(
-            hf_config=SimpleNamespace(num_hidden_layers=num_hidden_layers)
+            hf_config=SimpleNamespace(num_hidden_layers=num_hidden_layers),
+            max_model_len=4096,
+        ),
+        parallel_config=SimpleNamespace(
+            decode_context_parallel_size=dcp_size,
+            prefill_context_parallel_size=pcp_size,
         ),
     )
 
@@ -26,17 +43,157 @@ def _indexer_cache(layer_id: int = 78):
     return cache
 
 
-def test_dcp_shard_draft_defaults_to_sharded(monkeypatch):
-    monkeypatch.delenv("VLLM_DCP_SHARD_DRAFT", raising=False)
+def _get_indexer_spec(layer_id: int, config):
+    cache = _indexer_cache(layer_id)
+    cache.dcp_replicated = _replicate_indexer_cache_under_dcp(cache.prefix, config)
+    return cache, cache.get_kv_cache_spec(config)
 
-    spec = _indexer_cache().get_kv_cache_spec(_vllm_config())
+
+def test_target_indexer_replication_defaults_off(monkeypatch):
+    monkeypatch.delenv("VLLM_DCP_REPLICATE_INDEXER_CACHE", raising=False)
+
+    cache, spec = _get_indexer_spec(12, _vllm_config())
 
     assert spec.dcp_replicated is False
+    assert spec.block_size == cache.cache_config.block_size
+
+
+def test_dcp_shard_draft_defaults_to_sharded(monkeypatch):
+    monkeypatch.delenv("VLLM_DCP_SHARD_DRAFT", raising=False)
+    monkeypatch.setenv("VLLM_DCP_REPLICATE_INDEXER_CACHE", "1")
+
+    cache, spec = _get_indexer_spec(78, _vllm_config())
+
+    assert spec.dcp_replicated is False
+    assert spec.block_size == cache.cache_config.block_size
 
 
 def test_dcp_shard_draft_can_restore_replicated_legacy_mode(monkeypatch):
     monkeypatch.setenv("VLLM_DCP_SHARD_DRAFT", "0")
+    monkeypatch.setenv("VLLM_DCP_REPLICATE_INDEXER_CACHE", "1")
 
-    spec = _indexer_cache().get_kv_cache_spec(_vllm_config())
+    cache, spec = _get_indexer_spec(78, _vllm_config())
 
     assert spec.dcp_replicated is True
+    assert spec.block_size == cache.cache_config.block_size
+
+
+@pytest.mark.parametrize("dcp_size", [2, 4, 6, 8])
+def test_target_indexer_replication_equalizes_global_block_coverage(
+    monkeypatch, dcp_size: int
+):
+    monkeypatch.setenv("VLLM_DCP_REPLICATE_INDEXER_CACHE", "1")
+    monkeypatch.setattr(deepseek_v2, "use_b12x_sparse_indexer", lambda: True)
+
+    config = _vllm_config(dcp_size=dcp_size)
+    cache, spec = _get_indexer_spec(12, config)
+
+    assert spec.dcp_replicated is True
+    assert spec.block_size == dcp_size * cache.cache_config.block_size
+
+
+def test_target_indexer_replication_rejects_pcp(monkeypatch):
+    monkeypatch.setenv("VLLM_DCP_REPLICATE_INDEXER_CACHE", "1")
+    monkeypatch.setattr(deepseek_v2, "use_b12x_sparse_indexer", lambda: True)
+
+    config = _vllm_config(dcp_size=4, pcp_size=2)
+    with pytest.raises(NotImplementedError, match="DCP2 through DCP8 with PCP1"):
+        _replicate_indexer_cache_under_dcp("model.layers.12.indexer.k_cache", config)
+
+
+def test_target_indexer_replication_requires_v2_model_runner(monkeypatch):
+    monkeypatch.setenv("VLLM_DCP_REPLICATE_INDEXER_CACHE", "1")
+
+    config = _vllm_config()
+    config.use_v2_model_runner = False
+    with pytest.raises(NotImplementedError, match="V2 model runner"):
+        _replicate_indexer_cache_under_dcp("model.layers.12.indexer.k_cache", config)
+
+
+def test_real_cache_construction_replicates_target_but_not_draft(monkeypatch):
+    monkeypatch.setenv("VLLM_DCP_REPLICATE_INDEXER_CACHE", "1")
+    monkeypatch.delenv("VLLM_DCP_SHARD_DRAFT", raising=False)
+    monkeypatch.setattr(deepseek_v2, "use_b12x_sparse_indexer", lambda: True)
+
+    config = _vllm_config()
+    monkeypatch.setattr(deepseek_v2, "get_current_vllm_config", lambda: config)
+
+    target = DeepseekV32IndexerCache(
+        head_dim=132,
+        dtype=torch.uint8,
+        prefix="model.layers.12.self_attn.indexer.k_cache",
+        cache_config=config.cache_config,
+    )
+    draft = DeepseekV32IndexerCache(
+        head_dim=132,
+        dtype=torch.uint8,
+        prefix="model.layers.78.self_attn.indexer.k_cache",
+        cache_config=config.cache_config,
+    )
+
+    assert target.dcp_replicated is True
+    assert target.get_kv_cache_spec(config).dcp_replicated is True
+    assert draft.dcp_replicated is False
+    assert draft.get_kv_cache_spec(config).dcp_replicated is False
+    assert config.compilation_config.static_forward_context == {
+        target.prefix: target,
+        draft.prefix: draft,
+    }
+
+
+def test_indexer_constructor_forwards_cache_replication(monkeypatch):
+    captured: dict[str, object] = {}
+
+    class FakeCache(torch.nn.Module):
+        def __init__(self, *args, **kwargs):
+            super().__init__()
+            self.dcp_replicated = True
+
+    def fake_sparse_attn_indexer(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return torch.nn.Identity()
+
+    monkeypatch.setattr(deepseek_v2, "DeepseekV32IndexerCache", FakeCache)
+    monkeypatch.setattr(deepseek_v2, "SparseAttnIndexer", fake_sparse_attn_indexer)
+    monkeypatch.setattr(
+        deepseek_v2,
+        "ReplicatedLinear",
+        lambda *args, **kwargs: torch.nn.Identity(),
+    )
+    monkeypatch.setattr(
+        deepseek_v2,
+        "MergedColumnParallelLinear",
+        lambda *args, **kwargs: torch.nn.Identity(),
+    )
+    monkeypatch.setattr(
+        deepseek_v2,
+        "LayerNorm",
+        lambda *args, **kwargs: torch.nn.Identity(),
+    )
+    monkeypatch.setattr(deepseek_v2.current_platform, "is_cuda", lambda: False)
+
+    vllm_config = _vllm_config()
+    model_config = SimpleNamespace(
+        index_topk=4,
+        index_n_heads=1,
+        index_head_dim=128,
+        qk_rope_head_dim=64,
+    )
+    indexer = deepseek_v2.Indexer(
+        vllm_config=vllm_config,
+        config=model_config,
+        hidden_size=256,
+        q_lora_rank=128,
+        quant_config=None,
+        cache_config=vllm_config.cache_config,
+        topk_indices_buffer=torch.empty((2, 4), dtype=torch.int32),
+        prefix="model.layers.12.self_attn.indexer",
+    )
+
+    sparse_args = captured["args"]
+    sparse_kwargs = captured["kwargs"]
+    assert isinstance(sparse_args, tuple)
+    assert isinstance(sparse_kwargs, dict)
+    assert sparse_args[0] is indexer.k_cache
+    assert sparse_kwargs["dcp_replicated"] is True

--- a/tests/v1/attention/test_b12x_ckv_prefetch_policy.py
+++ b/tests/v1/attention/test_b12x_ckv_prefetch_policy.py
@@ -48,12 +48,13 @@ def test_ckv_prefetch_targets_stop_at_first_unregistered_layer():
     assert _ckv_prefetch_target_indices(1, 3, caches, pending) == []
 
 
-def test_ckv_workspace_reuses_local_staging_across_ring_slots():
+@pytest.mark.parametrize("record_bytes", [368, 432])
+def test_ckv_workspace_reuses_local_staging_across_ring_slots(record_bytes):
     impl = object.__new__(B12xMLASparseImpl)
     impl._ckv_gather_enabled = True
     impl._ckv_workspace_slots = 4
     impl._ckv_local_capacity = 8
-    impl._kv_record_bytes = 432
+    impl._kv_record_bytes = record_bytes
     impl.dcp_world_size = 4
     impl.device = torch.device("cpu")
     impl._ckv_workspace_nbytes = (
@@ -67,7 +68,7 @@ def test_ckv_workspace_reuses_local_staging_across_ring_slots():
     local_3, gathered_3 = impl._ckv_workspace_views(workspace, 3)
 
     assert local_0.data_ptr() == local_3.data_ptr()
-    assert gathered_0.shape == gathered_3.shape == (32, 432)
+    assert gathered_0.shape == gathered_3.shape == (32, record_bytes)
     assert gathered_0.data_ptr() != gathered_3.data_ptr()
 
 

--- a/tests/v1/attention/test_b12x_ckv_prefetch_policy.py
+++ b/tests/v1/attention/test_b12x_ckv_prefetch_policy.py
@@ -1,0 +1,310 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import gc
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import vllm.v1.worker.workspace as workspace
+from vllm.v1.attention.backends.mla.b12x_mla_sparse import (
+    B12xMLASparseImpl,
+    _ckv_prefetch_ring_slots,
+    _ckv_prefetch_supports_format,
+    _ckv_prefetch_target_indices,
+    _ckv_workspace_identity,
+    _CKVPrefetchStateRegistry,
+)
+
+
+@pytest.mark.parametrize(
+    ("depth", "expected_slots", "expected_targets"),
+    [
+        (0, 1, []),
+        (1, 2, [2]),
+        (3, 4, [2, 3, 4]),
+    ],
+)
+def test_ckv_prefetch_depth_controls_ring_and_targets(
+    depth, expected_slots, expected_targets
+):
+    caches = [torch.empty(0) for _ in range(6)]
+
+    assert _ckv_prefetch_ring_slots(depth) == expected_slots
+    assert _ckv_prefetch_target_indices(1, depth, caches, {}) == expected_targets
+
+
+def test_ckv_prefetch_supports_native_full_record_formats():
+    assert _ckv_prefetch_supports_format("nvfp4_ds_mla")
+    assert _ckv_prefetch_supports_format("fp8_ds_mla")
+    assert not _ckv_prefetch_supports_format("auto")
+
+
+def test_ckv_prefetch_targets_stop_at_first_unregistered_layer():
+    caches = [torch.empty(0), torch.empty(0), torch.empty(0), None, torch.empty(0)]
+    pending = {2: (object(), 0)}
+
+    assert _ckv_prefetch_target_indices(1, 3, caches, pending) == []
+
+
+def test_ckv_workspace_reuses_local_staging_across_ring_slots():
+    impl = object.__new__(B12xMLASparseImpl)
+    impl._ckv_gather_enabled = True
+    impl._ckv_workspace_slots = 4
+    impl._ckv_local_capacity = 8
+    impl._kv_record_bytes = 432
+    impl.dcp_world_size = 4
+    impl.device = torch.device("cpu")
+    impl._ckv_workspace_nbytes = (
+        (1 + impl._ckv_workspace_slots * impl.dcp_world_size)
+        * impl._ckv_local_capacity
+        * impl._kv_record_bytes
+    )
+    workspace = torch.empty(impl._ckv_workspace_nbytes, dtype=torch.uint8)
+
+    local_0, gathered_0 = impl._ckv_workspace_views(workspace, 0)
+    local_3, gathered_3 = impl._ckv_workspace_views(workspace, 3)
+
+    assert local_0.data_ptr() == local_3.data_ptr()
+    assert gathered_0.shape == gathered_3.shape == (32, 432)
+    assert gathered_0.data_ptr() != gathered_3.data_ptr()
+
+
+def test_ckv_workspace_rejects_ring_slot_outside_depth():
+    impl = object.__new__(B12xMLASparseImpl)
+    impl._ckv_gather_enabled = True
+    impl._ckv_workspace_slots = 2
+    impl._ckv_local_capacity = 1
+    impl._kv_record_bytes = 432
+    impl.dcp_world_size = 2
+    impl.device = torch.device("cpu")
+    impl._ckv_workspace_nbytes = 5 * impl._kv_record_bytes
+    workspace = torch.empty(impl._ckv_workspace_nbytes, dtype=torch.uint8)
+
+    with pytest.raises(ValueError, match="outside"):
+        impl._ckv_workspace_views(workspace, 2)
+
+
+class _FakeEvent:
+    def __init__(self):
+        self.wait_calls = 0
+
+    def wait(self):
+        self.wait_calls += 1
+
+
+def test_ckv_prefetch_incomplete_step_recovers_with_stream_wait():
+    registry = _CKVPrefetchStateRegistry()
+    state = registry.for_workspace(torch.empty(16, dtype=torch.uint8))
+    cache = torch.empty(0)
+    event = _FakeEvent()
+    state.register_cache(3, cache)
+    state.pending_layers[3] = (event, 0)
+    state.last_layer_idx = 2
+
+    state.enter_layer(0)
+
+    assert event.wait_calls == 1
+    assert state.pending_layers == {}
+    assert state.layer_caches[3] is cache
+    assert state.last_layer_idx == 0
+
+
+def test_ckv_prefetch_first_request_discovers_caches_without_lookahead():
+    registry = _CKVPrefetchStateRegistry()
+    state = registry.for_workspace(torch.empty(16, dtype=torch.uint8))
+    caches = [torch.empty(0) for _ in range(4)]
+
+    for layer_idx, cache in enumerate(caches):
+        state.enter_layer(layer_idx)
+        state.register_cache(layer_idx, cache)
+
+        assert (
+            _ckv_prefetch_target_indices(
+                layer_idx, 3, state.layer_caches, state.pending_layers
+            )
+            == []
+        )
+        assert state.gather_stream is None
+
+    state.enter_layer(0)
+
+    assert _ckv_prefetch_target_indices(0, 3, state.layer_caches, {}) == [1, 2, 3]
+
+
+def test_ckv_prefetch_target_and_draft_lifecycles_are_isolated(monkeypatch):
+    monkeypatch.setattr(workspace, "dbo_current_ubatch_id", lambda: 0)
+    monkeypatch.setattr(torch.accelerator, "empty_cache", lambda: None)
+    manager = workspace.WorkspaceManager(torch.device("cpu"), num_lanes=2)
+    (target_workspace,) = manager.get_simultaneous(((16,), torch.uint8))
+    with workspace.use_workspace_lane(1):
+        (draft_workspace,) = manager.get_simultaneous(((16,), torch.uint8))
+
+    registry = _CKVPrefetchStateRegistry()
+    target_state = registry.for_workspace(target_workspace)
+    draft_state = registry.for_workspace(draft_workspace)
+    target_cache = torch.empty(0)
+    draft_cache = torch.empty(0)
+    target_event = _FakeEvent()
+    target_ring = target_state.get_ckv_workspace(64)
+    draft_ring = draft_state.get_ckv_workspace(64)
+
+    target_state.register_cache(1, target_cache)
+    target_state.pending_layers[1] = (target_event, 1)
+    draft_state.register_cache(1, draft_cache)
+
+    assert target_state is not draft_state
+    assert target_ring.untyped_storage().data_ptr() != (
+        draft_ring.untyped_storage().data_ptr()
+    )
+    assert target_state.layer_caches[1] is target_cache
+    assert target_state.pending_layers[1] == (target_event, 1)
+    assert draft_state.layer_caches[1] is draft_cache
+    assert draft_state.pending_layers == {}
+
+
+def test_ckv_prefetch_lazily_owns_one_stream_per_workspace_lane(monkeypatch):
+    monkeypatch.setattr(workspace, "dbo_current_ubatch_id", lambda: 0)
+    monkeypatch.setattr(torch.accelerator, "empty_cache", lambda: None)
+    manager = workspace.WorkspaceManager(torch.device("cpu"), num_lanes=2)
+    (target_workspace,) = manager.get_simultaneous(((16,), torch.uint8))
+    (target_workspace_reused,) = manager.get_simultaneous(((16,), torch.uint8))
+    with workspace.use_workspace_lane(1):
+        (draft_workspace,) = manager.get_simultaneous(((16,), torch.uint8))
+
+    created_streams = []
+
+    def create_stream(*, device):
+        stream = SimpleNamespace(device=device)
+        created_streams.append(stream)
+        return stream
+
+    monkeypatch.setattr(torch.cuda, "Stream", create_stream)
+    registry = _CKVPrefetchStateRegistry()
+    target_state = registry.for_workspace(target_workspace)
+    target_state_reused = registry.for_workspace(target_workspace_reused)
+    draft_state = registry.for_workspace(draft_workspace)
+
+    assert created_streams == []
+    assert target_state_reused is target_state
+    assert target_state.get_gather_stream() is target_state.get_gather_stream()
+    assert draft_state.get_gather_stream() is draft_state.get_gather_stream()
+    assert target_state.gather_stream is not draft_state.gather_stream
+    assert len(created_streams) == 2
+
+
+def test_ckv_prefetch_ring_survives_intervening_workspace_borrow(monkeypatch):
+    monkeypatch.setattr(workspace, "dbo_current_ubatch_id", lambda: 0)
+    monkeypatch.setattr(torch.accelerator, "empty_cache", lambda: None)
+    manager = workspace.WorkspaceManager(torch.device("cpu"), num_lanes=1)
+    (lane_workspace,) = manager.get_simultaneous(((256,), torch.uint8))
+    registry = _CKVPrefetchStateRegistry()
+    state = registry.for_workspace(lane_workspace)
+
+    assert state.ckv_workspace is None
+    ring = state.get_ckv_workspace(64)
+    ring.fill_(0xA5)
+
+    # WorkspaceManager callers all borrow from offset zero. An intervening
+    # indexer/MoE scratch allocation must not alias cross-layer CKV state.
+    (intervening_workspace,) = manager.get_simultaneous(((128,), torch.uint8))
+    intervening_workspace.zero_()
+
+    assert ring.untyped_storage().data_ptr() != (
+        intervening_workspace.untyped_storage().data_ptr()
+    )
+    assert torch.all(ring == 0xA5)
+
+
+def test_ckv_prefetch_ring_resize_drains_pending_generation():
+    registry = _CKVPrefetchStateRegistry()
+    state = registry.for_workspace(torch.empty(16, dtype=torch.uint8))
+
+    first_ring = state.get_ckv_workspace(64)
+    assert state.get_ckv_workspace(64) is first_ring
+    assert state.ckv_workspace_generation == 1
+
+    event = _FakeEvent()
+    state.pending_layers[1] = (event, 0)
+    resized_ring = state.get_ckv_workspace(128)
+
+    assert resized_ring is not first_ring
+    assert resized_ring.numel() == 128
+    assert state.ckv_workspace_generation == 2
+    assert event.wait_calls == 1
+    assert state.pending_layers == {}
+
+
+def test_ckv_prefetch_workspace_identity_invalidates_changed_geometry():
+    registry = _CKVPrefetchStateRegistry()
+    workspace_buffer = torch.empty(16, dtype=torch.uint8)
+    same_geometry = workspace_buffer.view_as(workspace_buffer)
+    changed_geometry = workspace_buffer[:8]
+    old_state = registry.for_workspace(workspace_buffer)
+    event = _FakeEvent()
+    old_state.pending_layers[1] = (event, 0)
+
+    assert registry.for_workspace(same_geometry) is old_state
+
+    resized_state = registry.for_workspace(changed_geometry)
+
+    assert resized_state is not old_state
+    assert event.wait_calls == 1
+    assert len(registry.states) == 1
+
+
+def test_ckv_prefetch_workspace_identity_tracks_manager_resize(monkeypatch):
+    monkeypatch.setattr(workspace, "dbo_current_ubatch_id", lambda: 0)
+    monkeypatch.setattr(torch.accelerator, "empty_cache", lambda: None)
+    manager = workspace.WorkspaceManager(torch.device("cpu"), num_lanes=2)
+    (first_workspace,) = manager.get_simultaneous(((16,), torch.uint8))
+    with workspace.use_workspace_lane(1):
+        (draft_workspace,) = manager.get_simultaneous(((16,), torch.uint8))
+    registry = _CKVPrefetchStateRegistry()
+    cache = torch.empty(0)
+    first_state = registry.for_workspace(first_workspace, 0, cache)
+    first_state.register_cache(0, cache)
+    draft_cache = torch.empty(0)
+    draft_state = registry.for_workspace(draft_workspace, 0, draft_cache)
+    draft_state.register_cache(0, draft_cache)
+    event = _FakeEvent()
+    first_state.pending_layers[1] = (event, 0)
+
+    (resized_workspace,) = manager.get_simultaneous(((257,), torch.uint8))
+    resized_state = registry.for_workspace(resized_workspace, 0, cache)
+
+    assert (
+        _ckv_workspace_identity(first_workspace).storage_generation
+        != _ckv_workspace_identity(resized_workspace).storage_generation
+    )
+    assert resized_state is not first_state
+    assert resized_state.layer_caches == []
+    assert event.wait_calls == 1
+    assert registry.for_workspace(draft_workspace) is draft_state
+    assert len(registry.states) == 2
+
+
+def test_ckv_prefetch_registry_retires_released_profile_workspace():
+    registry = _CKVPrefetchStateRegistry()
+    profile_workspace = torch.empty(16, dtype=torch.uint8)
+    state = registry.for_workspace(profile_workspace)
+    event = _FakeEvent()
+    state.pending_layers[1] = (event, 0)
+
+    del profile_workspace
+    gc.collect()
+    registry.begin_step()
+
+    assert event.wait_calls == 1
+    assert registry.states == {}
+
+
+def test_ckv_gather_uses_capture_fallback_without_reading_prefetch_state(
+    monkeypatch,
+):
+    impl = object.__new__(B12xMLASparseImpl)
+    impl._ckv_gather_enabled = True
+    monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: True)
+
+    assert not impl.dcp_prefill_ckv_gather_eligible(SimpleNamespace(), 128)

--- a/tests/v1/attention/test_b12x_mla_dcp_workspace.py
+++ b/tests/v1/attention/test_b12x_mla_dcp_workspace.py
@@ -103,9 +103,7 @@ def test_cp_lse_ag_out_rs_into_preserves_borrowed_output(monkeypatch, world_size
 
 
 def test_cp_lse_ag_out_rs_requests_head_major_output(monkeypatch):
-    corrected_storage = torch.arange(8 * 3 * 16, dtype=torch.bfloat16).view(
-        8, 3, 16
-    )
+    corrected_storage = torch.arange(8 * 3 * 16, dtype=torch.bfloat16).view(8, 3, 16)
     corrected = corrected_storage.movedim(0, 1)
     corrected_lse = torch.zeros(3, 8, dtype=torch.float32)
 
@@ -192,3 +190,49 @@ def test_dcp_workspace_contract_rejects_unvalidated_topology(monkeypatch):
 
     with pytest.raises(RuntimeError, match="unsupported topology or geometry"):
         impl._validate_dcp_prefill_workspace_contract(2048)
+
+
+@pytest.mark.parametrize("num_tokens", [1025, 1640, 3072])
+def test_dcp_projection_accepts_b12x_output_layouts(monkeypatch, num_tokens):
+    impl = object.__new__(B12xMLASparseImpl)
+    impl._max_batched = 3072
+    impl.dcp_workspace_non_dbo = True
+    impl.tp_world_size = 4
+    impl.dcp_world_size = 4
+    impl.num_heads = 1
+    impl._input_num_heads = 4
+    impl._kernel_num_heads = 8
+    impl._pad_heads = False
+    impl.q_head_dim = 576
+    impl.kv_lora_rank = 2
+    impl.v_head_dim = 1
+    monkeypatch.setattr(
+        impl, "_validate_dcp_prefill_workspace_contract", lambda _: None
+    )
+
+    q_workspace = torch.empty(num_tokens, 8, 576, dtype=torch.bfloat16)
+    scratch = torch.empty(8 * num_tokens * 2, dtype=torch.uint8)
+    monkeypatch.setattr(
+        impl,
+        "_borrow_workspace_parts",
+        lambda: (q_workspace, None, scratch),
+    )
+
+    lse = torch.zeros(num_tokens, 4, dtype=torch.float32)
+    w_uv = torch.ones(4, 2, 1, dtype=torch.bfloat16)
+    token_major = (
+        scratch[: num_tokens * 4 * 2 * 2].view(torch.bfloat16).view(num_tokens, 4, 2)
+    )
+    token_major.fill_(1)
+    result = impl.dcp_project_before_merge_in_workspace(token_major, lse, w_uv)
+    torch.testing.assert_close(result, torch.full_like(result, 2))
+
+    head_major = (
+        scratch[: num_tokens * 4 * 2 * 2]
+        .view(torch.bfloat16)
+        .view(4, num_tokens, 2)
+        .transpose(0, 1)
+    )
+    head_major.fill_(1)
+    result = impl.dcp_project_before_merge_in_workspace(head_major, lse, w_uv)
+    torch.testing.assert_close(result, torch.full_like(result, 2))

--- a/tests/v1/attention/test_b12x_mla_dcp_workspace.py
+++ b/tests/v1/attention/test_b12x_mla_dcp_workspace.py
@@ -192,7 +192,7 @@ def test_dcp_workspace_contract_rejects_unvalidated_topology(monkeypatch):
         impl._validate_dcp_prefill_workspace_contract(2048)
 
 
-@pytest.mark.parametrize("num_tokens", [1025, 1640, 3072])
+@pytest.mark.parametrize("num_tokens", [1025, 1640, 2139, 3072])
 def test_dcp_projection_accepts_b12x_output_layouts(monkeypatch, num_tokens):
     impl = object.__new__(B12xMLASparseImpl)
     impl._max_batched = 3072
@@ -211,7 +211,7 @@ def test_dcp_projection_accepts_b12x_output_layouts(monkeypatch, num_tokens):
     )
 
     q_workspace = torch.empty(num_tokens, 8, 576, dtype=torch.bfloat16)
-    scratch = torch.empty(8 * num_tokens * 2, dtype=torch.uint8)
+    scratch = torch.empty(4 * impl._max_batched * 2 * 2, dtype=torch.uint8)
     monkeypatch.setattr(
         impl,
         "_borrow_workspace_parts",
@@ -235,4 +235,17 @@ def test_dcp_projection_accepts_b12x_output_layouts(monkeypatch, num_tokens):
     )
     head_major.fill_(1)
     result = impl.dcp_project_before_merge_in_workspace(head_major, lse, w_uv)
+    torch.testing.assert_close(result, torch.full_like(result, 2))
+
+    padded_head_major = (
+        scratch.view(torch.bfloat16)
+        .view(4, impl._max_batched, 2)
+        .transpose(0, 1)[:num_tokens]
+    )
+    padded_head_major.fill_(1)
+    result = impl.dcp_project_before_merge_in_workspace(
+        padded_head_major,
+        lse,
+        w_uv,
+    )
     torch.testing.assert_close(result, torch.full_like(result, 2))

--- a/tests/v1/attention/test_indexer_dcp_localize.py
+++ b/tests/v1/attention/test_indexer_dcp_localize.py
@@ -1,22 +1,128 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 
 import vllm.model_executor.layers.sparse_attn_indexer as sparse_indexer
+import vllm.v1.attention.backends.mla.indexer as indexer_backend
 from vllm.platforms import current_platform
 from vllm.utils.import_utils import has_cutedsl
-from vllm.v1.attention.backends.mla.indexer import build_prefill_chunk_metadata
+from vllm.v1.attention.backend import CommonAttentionMetadata
+from vllm.v1.attention.backends.mla.indexer import (
+    DeepseekV32IndexerMetadataBuilder,
+    build_prefill_chunk_metadata,
+    get_indexer_max_num_blocks_per_req,
+)
 from vllm.v1.attention.backends.mla.sparse_utils import (
     triton_filter_and_convert_dcp_index,
 )
 from vllm.v1.attention.backends.utils import get_dcp_local_seq_lens
 from vllm.v1.attention.ops.common import CPTritonContext, correct_attn_out
+from vllm.v1.kv_cache_interface import MLAAttentionSpec
 
 
 def _local_count(length: int, rank: int, world: int, interleave: int) -> int:
     return sum(1 for pos in range(length) if (pos // interleave) % world == rank)
+
+
+@pytest.mark.parametrize("dcp_size", [2, 4, 6, 8])
+def test_replicated_indexer_metadata_covers_full_context(dcp_size: int):
+    max_model_len = 131_071
+    storage_block_size = 64
+    manager_block_size = storage_block_size * dcp_size
+
+    sharded_blocks = get_indexer_max_num_blocks_per_req(
+        max_model_len=max_model_len,
+        block_size=storage_block_size,
+        configured_cp_world_size=dcp_size,
+        dcp_replicated=False,
+    )
+    replicated_blocks = get_indexer_max_num_blocks_per_req(
+        max_model_len=max_model_len,
+        block_size=manager_block_size,
+        configured_cp_world_size=dcp_size,
+        dcp_replicated=True,
+    )
+    expected_blocks = (max_model_len + manager_block_size - 1) // manager_block_size
+
+    assert sharded_blocks == expected_blocks
+    assert replicated_blocks == expected_blocks
+
+
+def test_replicated_builder_uses_global_lengths_without_dcp_localization(monkeypatch):
+    def fail_dcp_path(*args, **kwargs):
+        pytest.fail("replicated indexer metadata must not enter DCP localization")
+
+    monkeypatch.setattr(indexer_backend, "get_dcp_group", fail_dcp_path)
+    monkeypatch.setattr(indexer_backend, "num_compute_units", lambda device: 4)
+    monkeypatch.setattr(indexer_backend.envs, "VLLM_USE_B12X_SPARSE_INDEXER", True)
+
+    spec = MLAAttentionSpec(
+        block_size=1024,
+        num_kv_heads=1,
+        head_size=132,
+        dtype=torch.uint8,
+        dcp_replicated=True,
+    )
+    config = SimpleNamespace(
+        scheduler_config=SimpleNamespace(
+            max_num_batched_tokens=8,
+            max_num_seqs=4,
+        ),
+        parallel_config=SimpleNamespace(
+            decode_context_parallel_size=4,
+            prefill_context_parallel_size=1,
+            cp_kv_cache_interleave_size=1,
+        ),
+        speculative_config=None,
+        attention_config=SimpleNamespace(use_fp4_indexer_cache=False),
+        model_config=SimpleNamespace(max_model_len=4096),
+    )
+    builder = DeepseekV32IndexerMetadataBuilder(
+        kv_cache_spec=spec,
+        layer_names=["model.layers.12.self_attn.indexer.k_cache"],
+        vllm_config=config,
+        device=torch.device("cpu"),
+    )
+    monkeypatch.setattr(builder, "_dcp_localize_decode_seq_lens", fail_dcp_path)
+    monkeypatch.setattr(
+        builder,
+        "_maybe_build_b12x_schedule_metadata",
+        lambda *args, **kwargs: None,
+    )
+
+    global_seq_lens = torch.tensor([9], dtype=torch.int32)
+    local_seq_lens = torch.tensor([3], dtype=torch.int32)
+    common_metadata = CommonAttentionMetadata(
+        query_start_loc=torch.tensor([0, 1], dtype=torch.int32),
+        query_start_loc_cpu=torch.tensor([0, 1], dtype=torch.int32),
+        seq_lens=global_seq_lens,
+        num_reqs=1,
+        num_actual_tokens=1,
+        max_query_len=1,
+        max_seq_len=9,
+        block_table_tensor=torch.zeros((1, 1), dtype=torch.int32),
+        slot_mapping=torch.tensor([8], dtype=torch.int64),
+        dcp_local_seq_lens=local_seq_lens,
+        dcp_local_seq_lens_cpu=local_seq_lens.clone(),
+        seq_lens_cpu_upper_bound=global_seq_lens.clone(),
+        _seq_lens_cpu=global_seq_lens.clone(),
+    )
+
+    metadata = builder.build(0, common_metadata)
+
+    assert builder.dcp_world_size == 1
+    assert builder.dcp_rank == 0
+    assert metadata.seq_lens.tolist() == [9]
+    assert metadata.slot_mapping.tolist() == [8]
+    assert metadata.decode is not None
+    assert metadata.decode.seq_lens.tolist() == [[9]]
+    assert metadata.decode.max_seq_len == 9
+    assert metadata.decode.active_width.tolist() == [9]
+    assert metadata.decode.global_seq_lens is None
 
 
 def _global_to_local_indices(
@@ -89,6 +195,16 @@ def _attention_from_indices(
     v: torch.Tensor,
     indices: torch.Tensor,
 ) -> tuple[torch.Tensor, torch.Tensor]:
+    if k.shape[0] == 0:
+        return (
+            torch.zeros_like(q),
+            torch.full(
+                (q.shape[0],),
+                float("-inf"),
+                dtype=q.dtype,
+                device=q.device,
+            ),
+        )
     valid = indices >= 0
     safe_indices = indices.clamp_min(0)
     selected_k = k[safe_indices]
@@ -253,7 +369,7 @@ def _merge_local_topks_global_with_fake_dcp(
         sparse_indexer.get_dcp_group = original_get_dcp_group
 
 
-@pytest.mark.parametrize("world", [1, 2, 4])
+@pytest.mark.parametrize("world", [1, 2, 4, 6, 8])
 @pytest.mark.parametrize("interleave", [1, 2, 4])
 def test_get_dcp_local_seq_lens_matches_naive(world: int, interleave: int):
     seq_lens = torch.arange(0, 33, dtype=torch.int32)
@@ -341,9 +457,11 @@ def test_get_dcp_local_seq_lens_must_run_after_decode_expansion():
 
 
 @pytest.mark.parametrize("interleave", [1, 2])
-def test_sparse_dcp_attention_matches_global_topk_attention(interleave: int):
+@pytest.mark.parametrize("world", [2, 4, 6, 8])
+def test_sparse_dcp_attention_matches_global_topk_attention(
+    interleave: int, world: int
+):
     torch.manual_seed(0)
-    world = 2
     topk = 3
     num_queries = 4
     max_seq_len = 13

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -1683,7 +1683,12 @@ def test_resolve_kv_cache_block_sizes_mixed_dcp_replicated_groups():
     assert hash_block_size == 64
 
 
-def test_replicated_mla_uses_lockstep_pool_capacity_and_contiguous_tensors():
+@pytest.mark.parametrize(
+    ("model_version", "record_bytes"), [(None, 432), ("glm_fp8_rope", 368)]
+)
+def test_replicated_mla_uses_lockstep_pool_capacity_and_contiguous_tensors(
+    model_version, record_bytes
+):
     vllm_config = SimpleNamespace(
         model_config=SimpleNamespace(max_model_len=262144),
         parallel_config=SimpleNamespace(
@@ -1700,6 +1705,7 @@ def test_replicated_mla_uses_lockstep_pool_capacity_and_contiguous_tensors():
             head_size=576,
             dtype=torch.uint8,
             cache_dtype_str="nvfp4_ds_mla",
+            model_version=model_version,
         )
         for i in range(3)
     }
@@ -1724,7 +1730,7 @@ def test_replicated_mla_uses_lockstep_pool_capacity_and_contiguous_tensors():
     )
     assert kv_cache_utils._use_lockstep_mla_allocation(groups, 4, 1)
 
-    bytes_per_pool_block = 3 * (64 * 432) + 2 * (256 * 132)
+    bytes_per_pool_block = 3 * (64 * record_bytes) + 2 * (256 * 132)
     request_blocks = 262144 // 256
     required_memory = bytes_per_pool_block * request_blocks
     kv_cache_config = kv_cache_utils.get_kv_cache_config_from_groups(

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -1683,6 +1683,164 @@ def test_resolve_kv_cache_block_sizes_mixed_dcp_replicated_groups():
     assert hash_block_size == 64
 
 
+def test_replicated_mla_uses_lockstep_pool_capacity_and_contiguous_tensors():
+    vllm_config = SimpleNamespace(
+        model_config=SimpleNamespace(max_model_len=262144),
+        parallel_config=SimpleNamespace(
+            decode_context_parallel_size=4,
+            prefill_context_parallel_size=1,
+        ),
+        cache_config=SimpleNamespace(num_gpu_blocks_override=None),
+        kv_transfer_config=None,
+    )
+    specs: dict[str, KVCacheSpec] = {
+        f"target.{i}": MLAAttentionSpec(
+            block_size=64,
+            num_kv_heads=1,
+            head_size=576,
+            dtype=torch.uint8,
+            cache_dtype_str="nvfp4_ds_mla",
+        )
+        for i in range(3)
+    }
+    specs.update(
+        {
+            f"indexer.{i}": MLAAttentionSpec(
+                block_size=256,
+                num_kv_heads=1,
+                head_size=132,
+                dtype=torch.uint8,
+                dcp_replicated=True,
+            )
+            for i in range(2)
+        }
+    )
+
+    grouped_specs = kv_cache_utils.group_and_unify_kv_cache_specs(specs, 4, 1)
+    assert grouped_specs is not None
+    groups = kv_cache_utils._get_kv_cache_groups_uniform_groups(grouped_specs)
+    assert all(
+        isinstance(group.kv_cache_spec, UniformTypeKVCacheSpecs) for group in groups
+    )
+    assert kv_cache_utils._use_lockstep_mla_allocation(groups, 4, 1)
+
+    bytes_per_pool_block = 3 * (64 * 432) + 2 * (256 * 132)
+    request_blocks = 262144 // 256
+    required_memory = bytes_per_pool_block * request_blocks
+    kv_cache_config = kv_cache_utils.get_kv_cache_config_from_groups(
+        vllm_config,
+        groups,
+        available_memory=required_memory * 2,
+    )
+
+    assert kv_cache_config.num_blocks == request_blocks * 2
+    assert all(tensor.block_stride == 0 for tensor in kv_cache_config.kv_cache_tensors)
+    assert sum(tensor.size for tensor in kv_cache_config.kv_cache_tensors) == (
+        required_memory * 2
+    )
+    assert (
+        kv_cache_utils._max_memory_usage_bytes_from_groups(vllm_config, groups)
+        == required_memory
+    )
+    assert get_max_concurrency_for_kv_cache_config(
+        vllm_config, kv_cache_config
+    ) == pytest.approx(2.0)
+
+
+def test_lockstep_mla_predicate_rejects_nonmatching_layouts():
+    sharded = MLAAttentionSpec(
+        block_size=64,
+        num_kv_heads=1,
+        head_size=128,
+        dtype=torch.float32,
+    )
+    replicated = MLAAttentionSpec(
+        block_size=256,
+        num_kv_heads=1,
+        head_size=128,
+        dtype=torch.float32,
+        dcp_replicated=True,
+    )
+    groups = [
+        KVCacheGroupSpec(["target"], sharded),
+        KVCacheGroupSpec(["indexer"], replicated),
+    ]
+    assert not kv_cache_utils._use_lockstep_mla_allocation(groups, 1, 1)
+
+    mismatched = MLAAttentionSpec(
+        block_size=64,
+        num_kv_heads=1,
+        head_size=128,
+        dtype=torch.float32,
+        dcp_replicated=True,
+    )
+    mismatched_groups = [groups[0], KVCacheGroupSpec(["indexer"], mismatched)]
+    assert not kv_cache_utils._use_lockstep_mla_allocation(mismatched_groups, 4, 1)
+    assert (
+        kv_cache_utils.group_and_unify_kv_cache_specs(
+            {"target": sharded, "indexer": mismatched}, 4, 1
+        )
+        is None
+    )
+
+    non_mla = FullAttentionSpec(
+        block_size=256,
+        num_kv_heads=1,
+        head_size=128,
+        dtype=torch.float32,
+        dcp_replicated=True,
+    )
+    assert not kv_cache_utils._use_lockstep_mla_allocation(
+        [groups[0], KVCacheGroupSpec(["draft"], non_mla)], 4, 1
+    )
+
+
+def test_lockstep_mla_equal_page_sizes_use_distinct_tensors():
+    sharded = MLAAttentionSpec(
+        block_size=64,
+        num_kv_heads=1,
+        head_size=128,
+        dtype=torch.bfloat16,
+    )
+    replicated = MLAAttentionSpec(
+        block_size=256,
+        num_kv_heads=1,
+        head_size=32,
+        dtype=torch.bfloat16,
+        dcp_replicated=True,
+    )
+    assert sharded.page_size_bytes == replicated.page_size_bytes
+    groups = [
+        KVCacheGroupSpec(["target"], sharded),
+        KVCacheGroupSpec(["indexer"], replicated),
+    ]
+    vllm_config = SimpleNamespace(
+        cache_config=SimpleNamespace(num_gpu_blocks_override=None),
+        parallel_config=SimpleNamespace(
+            decode_context_parallel_size=4,
+            prefill_context_parallel_size=1,
+        ),
+        kv_transfer_config=None,
+    )
+    bytes_per_pool_block = sharded.page_size_bytes + replicated.page_size_bytes
+
+    kv_cache_config = kv_cache_utils.get_kv_cache_config_from_groups(
+        vllm_config,
+        groups,
+        available_memory=3 * bytes_per_pool_block,
+    )
+
+    assert kv_cache_config.num_blocks == 3
+    assert [tensor.shared_by for tensor in kv_cache_config.kv_cache_tensors] == [
+        ["target"],
+        ["indexer"],
+    ]
+    assert [tensor.size for tensor in kv_cache_config.kv_cache_tensors] == [
+        3 * sharded.page_size_bytes,
+        3 * replicated.page_size_bytes,
+    ]
+
+
 def test_dsv4_engine_capacity_uses_worker_kv_cache_config():
     from vllm.v1.engine.core import EngineCore
 

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -177,6 +177,183 @@ def make_kv_cache_config_hybrid_model(
     )
 
 
+def make_lockstep_mla_manager(num_blocks: int = 5) -> KVCacheManager:
+    global_block_size = 256
+    kv_cache_config = KVCacheConfig(
+        num_blocks=num_blocks,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["target"],
+                MLAAttentionSpec(
+                    block_size=global_block_size // 4,
+                    num_kv_heads=1,
+                    head_size=432,
+                    dtype=torch.uint8,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["indexer"],
+                MLAAttentionSpec(
+                    block_size=global_block_size,
+                    num_kv_heads=1,
+                    head_size=132,
+                    dtype=torch.uint8,
+                    dcp_replicated=True,
+                ),
+            ),
+        ],
+    )
+    return KVCacheManager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=4 * global_block_size,
+        scheduler_block_size=global_block_size,
+        hash_block_size=global_block_size,
+        enable_caching=True,
+        dcp_world_size=4,
+    )
+
+
+def test_mixed_mla_groups_share_block_ids_hashes_and_eviction_order():
+    block_size = 256
+    manager = make_lockstep_mla_manager()
+    assert manager.coordinator.lockstep_mla_allocations
+    request = make_request(
+        "lockstep",
+        list(range(4 * block_size)),
+        block_size,
+        sha256,
+    )
+
+    new_blocks = manager.allocate_slots(
+        request,
+        num_new_tokens=4 * block_size,
+        full_sequence_must_fit=True,
+    )
+    assert new_blocks is not None
+    target_ids, indexer_ids = manager.get_block_ids(request.request_id)
+    assert target_ids == indexer_ids
+    assert new_blocks.get_block_ids() == (target_ids, target_ids)
+    assert manager.block_pool.get_num_free_blocks() == 0
+    assert all(
+        manager.block_pool.blocks[block_id].ref_cnt == 2 for block_id in target_ids
+    )
+
+    for block_hash, block_id in zip(request.block_hashes, target_ids):
+        group_keys = [
+            make_block_hash_with_group_id(block_hash, group_id) for group_id in range(2)
+        ]
+        assert group_keys[0] != group_keys[1]
+        cached = manager.block_pool.get_cached_block(block_hash, [0, 1])
+        assert cached is not None
+        assert [block.block_id for block in cached] == [block_id, block_id]
+
+    manager.free(request)
+    assert manager.block_pool.get_num_free_blocks() == 4
+    assert all(
+        manager.block_pool.blocks[block_id].ref_cnt == 0 for block_id in target_ids
+    )
+    free_ids = [
+        block.block_id
+        for block in manager.block_pool.free_block_queue.get_all_free_blocks()
+    ]
+    assert free_ids == target_ids[::-1]
+
+    replay = make_request(
+        "lockstep-replay",
+        list(range(4 * block_size)),
+        block_size,
+        sha256,
+    )
+    computed_blocks, num_computed_tokens, _ = manager.get_computed_blocks(replay)
+    assert num_computed_tokens == 3 * block_size
+    assert computed_blocks.get_block_ids() == (
+        target_ids[:3],
+        target_ids[:3],
+    )
+
+    replay_new_blocks = manager.allocate_slots(
+        replay,
+        num_new_tokens=block_size,
+        num_new_computed_tokens=num_computed_tokens,
+        new_computed_blocks=computed_blocks,
+    )
+    assert replay_new_blocks is not None
+    assert manager.get_block_ids(replay.request_id) == (target_ids, target_ids)
+    assert all(
+        manager.block_pool.blocks[block_id].ref_cnt == 2 for block_id in target_ids
+    )
+    manager.free(replay)
+    assert [
+        block.block_id
+        for block in manager.block_pool.free_block_queue.get_all_free_blocks()
+    ] == target_ids[::-1]
+
+    evicted = manager.block_pool.get_new_blocks(1)[0]
+    assert evicted.block_id == target_ids[-1]
+    assert manager.block_pool.get_cached_block(request.block_hashes[-1], [0]) is None
+    assert manager.block_pool.get_cached_block(request.block_hashes[-1], [1]) is None
+
+
+def test_lockstep_mla_rejects_external_computed_blocks():
+    manager = make_lockstep_mla_manager()
+
+    with pytest.raises(NotImplementedError, match="External KV loads"):
+        manager.coordinator.allocate_new_computed_blocks(
+            "external",
+            ([], []),
+            num_local_computed_tokens=0,
+            num_external_computed_tokens=256,
+        )
+
+    assert manager.get_block_ids("external") == ([], [])
+
+
+def test_lockstep_group_hashes_promote_partial_block_together():
+    hash_block_size = 64
+    block_size = 4 * hash_block_size
+    pool = BlockPool(
+        num_gpu_blocks=2,
+        enable_caching=True,
+        hash_block_size=hash_block_size,
+    )
+    block = pool.get_new_blocks(1)[0]
+    request = make_request(
+        "promotion",
+        list(range(block_size)),
+        hash_block_size,
+        sha256,
+    )
+
+    for group_id in range(2):
+        pool.cache_partial_block(
+            request=request,
+            block=block,
+            num_tokens=2 * hash_block_size,
+            kv_cache_group_id=group_id,
+            block_size=block_size,
+        )
+    partial_hash = request.block_hashes[1]
+    partial_cached = pool.get_cached_block(partial_hash, [0, 1])
+    assert partial_cached == [block, block]
+
+    for group_id in range(2):
+        pool.cache_full_blocks(
+            request=request,
+            blocks=[block],
+            num_cached_blocks=0,
+            num_full_blocks=1,
+            block_size=block_size,
+            kv_cache_group_id=group_id,
+        )
+
+    assert pool.get_cached_block(partial_hash, [0]) is None
+    assert pool.get_cached_block(partial_hash, [1]) is None
+    full_hash = request.block_hashes[-1]
+    assert pool.get_cached_block(full_hash, [0, 1]) == [block, block]
+    assert block.block_hash_num_tokens == block_size
+
+
 def make_kv_cache_config_three_types(
     block_size: int, num_blocks: int, third_spec_type: str = "mamba"
 ) -> KVCacheConfig:

--- a/tests/v1/worker/test_attn_utils.py
+++ b/tests/v1/worker/test_attn_utils.py
@@ -1,10 +1,20 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from types import SimpleNamespace
+
 import torch
 
-from vllm.v1.kv_cache_interface import FullAttentionSpec, KVQuantMode
-from vllm.v1.worker.gpu.attn_utils import _reshape_kv_cache
+from vllm.v1.core.kv_cache_utils import _get_kv_cache_config_packed
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+    KVQuantMode,
+    MLAAttentionSpec,
+    UniformTypeKVCacheSpecs,
+)
+from vllm.v1.worker.gpu.attn_utils import _allocate_kv_cache, _reshape_kv_cache
 from vllm.v1.worker.utils import AttentionGroup
 
 
@@ -147,6 +157,104 @@ class FakeDiffKVBackend:
     ) -> tuple[int, ...]:
         assert not include_num_layers_dimension
         return (0, 1, 2, 3)
+
+
+class FakeSingleKVBackend:
+    @staticmethod
+    def get_kv_cache_shape(
+        num_blocks: int,
+        block_size: int,
+        num_kv_heads: int,
+        head_size: int,
+        cache_dtype_str: str = "auto",
+    ) -> tuple[int, ...]:
+        assert num_kv_heads == 1
+        return (num_blocks, block_size, head_size)
+
+    @staticmethod
+    def get_kv_cache_stride_order(
+        include_num_layers_dimension: bool = False,
+    ) -> tuple[int, ...]:
+        assert not include_num_layers_dimension
+        return (0, 1, 2)
+
+    @staticmethod
+    def get_kv_cache_block_dim(
+        block_size: int,
+        num_kv_heads: int,
+        head_size: int,
+        cache_dtype_str: str = "auto",
+    ) -> int:
+        return 0
+
+
+def test_lockstep_manager_pages_reshape_to_contiguous_kernel_pages():
+    manager_blocks = 3
+    kernel_block_size = 64
+    main_layer = MLAAttentionSpec(
+        block_size=kernel_block_size,
+        num_kv_heads=1,
+        head_size=328,
+        dtype=torch.bfloat16,
+    )
+    indexer_layer = MLAAttentionSpec(
+        block_size=kernel_block_size * 4,
+        num_kv_heads=1,
+        head_size=132,
+        dtype=torch.bfloat16,
+        dcp_replicated=True,
+    )
+    main_spec = UniformTypeKVCacheSpecs(
+        block_size=main_layer.block_size,
+        kv_cache_specs={"main": main_layer},
+    )
+    indexer_spec = UniformTypeKVCacheSpecs(
+        block_size=indexer_layer.block_size,
+        kv_cache_specs={"indexer": indexer_layer},
+    )
+    groups = [
+        KVCacheGroupSpec(["main"], main_spec),
+        KVCacheGroupSpec(["indexer"], indexer_spec),
+    ]
+    config = SimpleNamespace(
+        cache_config=SimpleNamespace(num_gpu_blocks_override=None),
+        parallel_config=SimpleNamespace(
+            decode_context_parallel_size=4,
+            prefill_context_parallel_size=1,
+        ),
+        kv_transfer_config=None,
+    )
+    bytes_per_manager_block = main_layer.page_size_bytes + indexer_layer.page_size_bytes
+    num_blocks, tensors = _get_kv_cache_config_packed(
+        config,
+        groups,
+        available_memory=bytes_per_manager_block * manager_blocks,
+    )
+    kv_cache_config = KVCacheConfig(
+        num_blocks=num_blocks,
+        kv_cache_tensors=tensors,
+        kv_cache_groups=groups,
+    )
+    raw_tensors = _allocate_kv_cache(kv_cache_config, {}, torch.device("cpu"))
+    attn_groups = [
+        AttentionGroup(FakeSingleKVBackend, ["main"], main_layer, 0),
+        AttentionGroup(FakeSingleKVBackend, ["indexer"], indexer_layer, 1),
+    ]
+
+    kv_caches = _reshape_kv_cache(
+        attn_groups,
+        raw_tensors,
+        "auto",
+        [kernel_block_size, kernel_block_size],
+        {},
+        kv_cache_config,
+    )
+
+    assert kv_caches["main"].shape == (manager_blocks, 64, 328)
+    assert kv_caches["indexer"].shape == (manager_blocks * 4, 64, 132)
+    assert kv_caches["main"].is_contiguous()
+    assert kv_caches["indexer"].is_contiguous()
+    assert all(tensor.block_stride == 0 for tensor in tensors)
 
 
 def test_reshape_padded_diff_kv_cache_does_not_infer_kv_dim():

--- a/tests/v1/worker/test_gpu_block_table.py
+++ b/tests/v1/worker/test_gpu_block_table.py
@@ -177,3 +177,49 @@ def test_compute_slot_mappings_applies_padding_mask():
     assert slot_mappings.cpu().tolist() == [
         [32, PAD_SLOT_ID, 34, 48, PAD_SLOT_ID, PAD_SLOT_ID, PAD_SLOT_ID, PAD_SLOT_ID]
     ]
+
+
+def test_compute_slot_mappings_mixed_sharded_and_replicated_groups():
+    device = torch.device("cuda")
+    block_tables = BlockTables(
+        block_sizes=[64, 256],
+        max_num_reqs=1,
+        max_num_batched_tokens=8,
+        max_num_blocks_per_group=[1, 1],
+        device=device,
+        kernel_block_sizes=[64, 64],
+        cp_size=4,
+        cp_rank=2,
+        group_cp_sizes=[4, 1],
+    )
+    block_tables.append_block_ids(
+        req_index=0,
+        new_block_ids=([5], [5]),
+        overwrite=True,
+    )
+    block_tables.apply_staged_writes()
+
+    idx_mapping = torch.tensor([0], dtype=torch.int32, device=device)
+    query_start_loc = torch.tensor([0, 8], dtype=torch.int32, device=device)
+    positions = torch.arange(8, dtype=torch.int64, device=device)
+    slot_mappings = block_tables.compute_slot_mappings(
+        idx_mapping,
+        query_start_loc,
+        positions,
+        num_tokens_padded=8,
+    )
+    torch.accelerator.synchronize()
+
+    assert slot_mappings.cpu().tolist() == [
+        [
+            PAD_SLOT_ID,
+            PAD_SLOT_ID,
+            320,
+            PAD_SLOT_ID,
+            PAD_SLOT_ID,
+            PAD_SLOT_ID,
+            321,
+            PAD_SLOT_ID,
+        ],
+        list(range(1280, 1288)),
+    ]

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -79,6 +79,7 @@ if TYPE_CHECKING:
     VLLM_B12X_MLA_CKV_GATHER: bool = False
     VLLM_B12X_MLA_CKV_GATHER_MIN_TOKENS: int = 16
     VLLM_B12X_MLA_CKV_GATHER_MAX_TOKENS: int = 524288
+    VLLM_B12X_MLA_CKV_PREFETCH_DEPTH: int = 1
     VLLM_MINIMAX_M3_ENABLE_TORCH_COMPILE: bool = False
     VLLM_B12X_CUDAGRAPH_PIECEWISE_PREWARM: bool = False
     VLLM_B12X_MOE_FORCE_MODELOPT_PREP: bool = False
@@ -1178,6 +1179,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     "VLLM_B12X_MLA_CKV_GATHER_MAX_TOKENS": lambda: int(
         os.getenv("VLLM_B12X_MLA_CKV_GATHER_MAX_TOKENS", "524288")
+    ),
+    # Number of future full-CKV layer gathers to queue. Zero keeps the
+    # synchronous gather path without allocating lookahead ring slots.
+    "VLLM_B12X_MLA_CKV_PREFETCH_DEPTH": lambda: int(
+        os.getenv("VLLM_B12X_MLA_CKV_PREFETCH_DEPTH", "1")
     ),
     # Diagnostic flag retained for local experiments. MiniMax M3 compile is
     # fail-closed in the model until the no-break path is validated.

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -73,6 +73,7 @@ if TYPE_CHECKING:
     VLLM_DCP_A2A_MAX_TOKENS: int = 0
     VLLM_DCP_A2A_LARGE_BACKEND: Literal["ag_rs", "a2a"] = "ag_rs"
     VLLM_DCP_SHARD_DRAFT: str | None = None
+    VLLM_DCP_REPLICATE_INDEXER_CACHE: bool = False
     VLLM_DCP_GLOBAL_TOPK: bool = True
     VLLM_DCP_QUERY_SPLIT: bool = False
     VLLM_B12X_MLA_CKV_GATHER: bool = False
@@ -1156,6 +1157,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # target indexer cache and native MTP drafts, replicated for external
     # (Eagle-style) drafts.
     "VLLM_DCP_SHARD_DRAFT": lambda: os.getenv("VLLM_DCP_SHARD_DRAFT", None),
+    # Replicate the target model's sparse-indexer K cache on every DCP rank.
+    "VLLM_DCP_REPLICATE_INDEXER_CACHE": lambda: (
+        os.getenv("VLLM_DCP_REPLICATE_INDEXER_CACHE", "0").lower()
+        in ("1", "true", "yes", "on")
+    ),
     # Under DCP, gather sparse-indexer logits across ranks and select a global
     # top-k instead of a per-rank local top-k.
     "VLLM_DCP_GLOBAL_TOPK": lambda: (

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -2155,6 +2155,7 @@ class SparseAttnIndexer(CustomOp):
         topk_scores_buffer: torch.Tensor | None = None,
         output_physical_slots: bool = False,
         num_q_heads: int | None = None,
+        dcp_replicated: bool = False,
     ):
         super().__init__()
         self.k_cache = k_cache
@@ -2174,7 +2175,9 @@ class SparseAttnIndexer(CustomOp):
         # during model construction) and pass them into the custom op, rather
         # than threading them through per-step metadata.
         parallel_config = get_current_vllm_config().parallel_config
-        self.dcp_world_size = parallel_config.decode_context_parallel_size
+        self.dcp_replicated = bool(dcp_replicated)
+        configured_dcp_world_size = parallel_config.decode_context_parallel_size
+        self.dcp_world_size = 1 if self.dcp_replicated else configured_dcp_world_size
         self.dcp_rank = get_dcp_group().rank_in_group if self.dcp_world_size > 1 else 0
         self.cp_kv_cache_interleave_size = parallel_config.cp_kv_cache_interleave_size
         self.use_b12x_sparse_indexer = use_b12x_sparse_indexer()

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -617,6 +617,41 @@ class DeepseekV2Attention(nn.Module):
         return output
 
 
+def _replicate_indexer_cache_under_dcp(prefix: str, vllm_config: VllmConfig) -> bool:
+    layer_id = extract_layer_index(prefix)
+    num_hidden_layers = getattr(
+        vllm_config.model_config.hf_config, "num_hidden_layers", None
+    )
+    if layer_id is None or num_hidden_layers is None:
+        return False
+
+    parallel_config = vllm_config.parallel_config
+    dcp_size = parallel_config.decode_context_parallel_size
+    pcp_size = parallel_config.prefill_context_parallel_size
+    if dcp_size * pcp_size <= 1:
+        return False
+
+    if int(layer_id) >= int(num_hidden_layers):
+        return False
+
+    requested = envs.VLLM_DCP_REPLICATE_INDEXER_CACHE
+    if requested and not vllm_config.use_v2_model_runner:
+        raise NotImplementedError(
+            "Replicated sparse-indexer KV requires the V2 model runner's "
+            "per-group context-parallel block tables."
+        )
+    if requested and (not 2 <= dcp_size <= 8 or pcp_size != 1):
+        raise NotImplementedError(
+            "Replicated sparse-indexer KV currently supports DCP2 through "
+            "DCP8 with PCP1."
+        )
+    if requested and not use_b12x_sparse_indexer():
+        raise RuntimeError(
+            "VLLM_DCP_REPLICATE_INDEXER_CACHE requires the B12X sparse indexer."
+        )
+    return requested
+
+
 class DeepseekV32IndexerCache(torch.nn.Module, AttentionLayerBase):
     def __init__(
         self, head_dim: int, dtype: torch.dtype, prefix: str, cache_config: CacheConfig
@@ -627,30 +662,44 @@ class DeepseekV32IndexerCache(torch.nn.Module, AttentionLayerBase):
         self.prefix = prefix
         self.cache_config = cache_config
         self.dtype = dtype
-        compilation_config = get_current_vllm_config().compilation_config
+        vllm_config = get_current_vllm_config()
+        self.dcp_replicated = _replicate_indexer_cache_under_dcp(prefix, vllm_config)
+        compilation_config = vllm_config.compilation_config
         if prefix in compilation_config.static_forward_context:
             raise ValueError(f"Duplicate layer name: {prefix}")
         compilation_config.static_forward_context[prefix] = self
 
     def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
+        block_size = self.cache_config.block_size
+        if self.dcp_replicated:
+            parallel_config = vllm_config.parallel_config
+            block_size *= (
+                parallel_config.decode_context_parallel_size
+                * parallel_config.prefill_context_parallel_size
+            )
+            logger.info_once(
+                "Using a DCP-replicated sparse-indexer K cache with %d-token "
+                "manager pages.",
+                block_size,
+            )
         layer_id = extract_layer_index(self.prefix)
         num_hidden_layers = getattr(
             vllm_config.model_config.hf_config, "num_hidden_layers", None
         )
         raw = envs.VLLM_DCP_SHARD_DRAFT
         shard_draft = ("1" if raw is None else raw).lower() in ("1", "true", "yes")
-        dcp_replicated = (
+        draft_replicated = (
             not shard_draft
             and layer_id is not None
             and num_hidden_layers is not None
             and int(layer_id) >= int(num_hidden_layers)
         )
         return MLAAttentionSpec(  # Only has one vector instead of K + V
-            block_size=self.cache_config.block_size,
+            block_size=block_size,
             num_kv_heads=1,
             head_size=self.head_dim,
             dtype=self.dtype,
-            dcp_replicated=dcp_replicated,
+            dcp_replicated=self.dcp_replicated or draft_replicated,
         )
 
     def forward(self): ...
@@ -751,6 +800,7 @@ class Indexer(nn.Module):
             topk_scores_buffer=self.topk_scores_buffer,
             output_physical_slots=self.output_physical_slots,
             num_q_heads=self.n_head,
+            dcp_replicated=self.k_cache.dcp_replicated,
         )
 
         self.is_inplace_rope = is_inplace_rope

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -27,6 +27,7 @@ ONE ``get_simultaneous`` call so they never alias.
 
 import inspect
 import os
+import weakref
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
@@ -77,7 +78,6 @@ _BF16_BYTES = 2
 _EXTEND_PREWARM_DONE: set[
     tuple[int | None, int, int, int, int, int, bool, str, bool]
 ] = set()
-_CKV_GATHER_WORKSPACES: dict[tuple[str, int | None], torch.Tensor] = {}
 _KV_FP8_ROPE_REQUESTED = os.getenv("KV_FP8_ROPE", "0") == "1"
 
 
@@ -146,18 +146,173 @@ def _env_int(name: str, default: int) -> int:
     return parsed
 
 
-def _get_ckv_gather_workspace(device: torch.device, nbytes: int) -> torch.Tensor:
-    key = (device.type, device.index)
-    workspace = _CKV_GATHER_WORKSPACES.get(key)
-    if workspace is None:
-        workspace = torch.empty((nbytes,), dtype=torch.uint8, device=device)
-        _CKV_GATHER_WORKSPACES[key] = workspace
-    elif workspace.numel() < nbytes:
-        raise RuntimeError(
-            "CKV gather workspace cannot grow after attention layers retain "
-            f"aliases: existing={workspace.numel()} requested={nbytes}"
+def _ckv_prefetch_supports_format(kv_cache_dtype: str) -> bool:
+    return kv_cache_dtype in ("fp8_ds_mla", "nvfp4_ds_mla")
+
+
+def _ckv_prefetch_ring_slots(depth: int) -> int:
+    return max(0, int(depth)) + 1
+
+
+def _ckv_prefetch_target_indices(
+    layer_idx: int,
+    depth: int,
+    layer_caches: list[torch.Tensor | None],
+    pending_layers: dict[int, tuple[Any, int]],
+) -> list[int]:
+    targets: list[int] = []
+    for distance in range(1, max(0, int(depth)) + 1):
+        target_idx = layer_idx + distance
+        if target_idx in pending_layers:
+            continue
+        if target_idx >= len(layer_caches) or layer_caches[target_idx] is None:
+            break
+        targets.append(target_idx)
+    return targets
+
+
+@dataclass(frozen=True)
+class _CKVWorkspaceIdentity:
+    device: torch.device
+    storage_generation: int
+    data_ptr: int
+    storage_offset: int
+    shape: tuple[int, ...]
+    stride: tuple[int, ...]
+    dtype: torch.dtype
+
+
+def _ckv_workspace_identity(workspace: torch.Tensor) -> _CKVWorkspaceIdentity:
+    storage = workspace.untyped_storage()
+    return _CKVWorkspaceIdentity(
+        device=workspace.device,
+        # WorkspaceManager does not expose its allocation generation. PyTorch's
+        # storage handle changes when MRV2 replaces the backing allocation.
+        storage_generation=int(storage._cdata),
+        data_ptr=workspace.data_ptr(),
+        storage_offset=workspace.storage_offset(),
+        shape=tuple(workspace.shape),
+        stride=tuple(workspace.stride()),
+        dtype=workspace.dtype,
+    )
+
+
+class _CKVPrefetchState:
+    """Cross-layer state for one workspace allocation and execution lane."""
+
+    def __init__(
+        self,
+        workspace_identity: _CKVWorkspaceIdentity,
+        workspace: torch.Tensor,
+    ) -> None:
+        self.workspace_identity = workspace_identity
+        self.workspace_storage_ref = weakref.ref(workspace.untyped_storage())
+        self.layer_caches: list[torch.Tensor | None] = []
+        self.pending_layers: dict[int, tuple[Any, int]] = {}
+        self.gather_stream: torch.cuda.Stream | None = None
+        self.ckv_workspace: torch.Tensor | None = None
+        self.ckv_workspace_generation = 0
+        self.last_layer_idx: int | None = None
+
+    def begin_step(self) -> None:
+        for event, _ in self.pending_layers.values():
+            # Preserve ring ordering without blocking the host indefinitely.
+            # The next main-stream gather is enqueued after these dependencies.
+            event.wait()
+        self.pending_layers.clear()
+        self.last_layer_idx = None
+
+    def enter_layer(self, layer_idx: int) -> None:
+        if self.last_layer_idx is not None and layer_idx <= self.last_layer_idx:
+            self.begin_step()
+        self.last_layer_idx = layer_idx
+
+    def register_cache(self, layer_idx: int, kv_cache: torch.Tensor) -> None:
+        while len(self.layer_caches) <= layer_idx:
+            self.layer_caches.append(None)
+        self.layer_caches[layer_idx] = kv_cache
+
+    def get_gather_stream(self) -> torch.cuda.Stream:
+        if self.gather_stream is None:
+            self.gather_stream = torch.cuda.Stream(
+                device=self.workspace_identity.device
+            )
+        return self.gather_stream
+
+    def get_ckv_workspace(self, nbytes: int) -> torch.Tensor:
+        if nbytes <= 0:
+            raise ValueError(f"CKV workspace size must be positive, got {nbytes}")
+        workspace = self.ckv_workspace
+        if workspace is None or workspace.numel() != nbytes:
+            # Pending side-stream writes must be ordered before replacing their
+            # backing allocation. record_stream() in _dcp_gather_ckv keeps the
+            # old storage alive until those writes complete.
+            self.begin_step()
+            workspace = torch.empty(
+                (nbytes,),
+                dtype=torch.uint8,
+                device=self.workspace_identity.device,
+            )
+            self.ckv_workspace = workspace
+            self.ckv_workspace_generation += 1
+        return workspace
+
+
+class _CKVPrefetchStateRegistry:
+    """Builder-owned states partitioned by lane-scoped CKV workspace."""
+
+    def __init__(self) -> None:
+        self.states: dict[_CKVWorkspaceIdentity, _CKVPrefetchState] = {}
+
+    def _retire(self, identities: list[_CKVWorkspaceIdentity]) -> None:
+        for identity in identities:
+            self.states.pop(identity).begin_step()
+
+    def _prune_released_workspaces(self) -> None:
+        self._retire(
+            [
+                identity
+                for identity, state in self.states.items()
+                if state.workspace_storage_ref() is None
+            ]
         )
-    return workspace[:nbytes]
+
+    def begin_step(self) -> None:
+        self._prune_released_workspaces()
+        for state in self.states.values():
+            state.begin_step()
+
+    def for_workspace(
+        self,
+        workspace: torch.Tensor,
+        layer_idx: int | None = None,
+        kv_cache: torch.Tensor | None = None,
+    ) -> _CKVPrefetchState:
+        self._prune_released_workspaces()
+        identity = _ckv_workspace_identity(workspace)
+        state = self.states.get(identity)
+        if state is None:
+            # A resized view may retain its address, while an allocation
+            # replacement changes it. A known layer cache identifies the same
+            # execution lane across the latter without merging target/draft.
+            stale_identities = [
+                existing
+                for existing, existing_state in self.states.items()
+                if (
+                    existing.device == identity.device
+                    and existing.data_ptr == identity.data_ptr
+                )
+                or (
+                    layer_idx is not None
+                    and kv_cache is not None
+                    and layer_idx < len(existing_state.layer_caches)
+                    and existing_state.layer_caches[layer_idx] is kv_cache
+                )
+            ]
+            self._retire(stale_identities)
+            state = _CKVPrefetchState(identity, workspace)
+            self.states[identity] = state
+        return state
 
 
 def _dcp_all_gather_current_stream(
@@ -531,6 +686,7 @@ class B12xMLASparseMetadata(AttentionMetadata):
     dcp_local_total_tokens: int = 0
     dcp_padded_total_tokens: int = 0
     dcp_ckv_gather_eligible: bool = False
+    ckv_prefetch_registry: _CKVPrefetchStateRegistry | None = None
 
     block_size: int = 64
     topk_tokens: int = 2048
@@ -571,6 +727,9 @@ class B12xMLASparseMetadataBuilder(AttentionMetadataBuilder[B12xMLASparseMetadat
         from vllm import envs as envs_mod
 
         ckv_gather_requested = envs_mod.VLLM_B12X_MLA_CKV_GATHER
+        self.ckv_prefetch_registry = (
+            _CKVPrefetchStateRegistry() if ckv_gather_requested else None
+        )
         # Max-batched-token scratch buffers so cudagraph capture sees stable
         # allocations (sliced per build()).
         self.cache_seq_lens_per_token_buffer = torch.empty(
@@ -672,16 +831,8 @@ class B12xMLASparseMetadataBuilder(AttentionMetadataBuilder[B12xMLASparseMetadat
 
         from vllm import envs as envs_mod
 
-        if envs_mod.VLLM_B12X_MLA_CKV_GATHER:
-            # Reset the cross-layer prefetch pipeline once per step so the
-            # first layer always sync-gathers. The event/buf-idx are class
-            # state that would otherwise leak across chunks (the last layer
-            # of a chunk consumes but never re-arms), scheduling layer 0
-            # of subsequent chunks onto a stale gathered buffer. The
-            # layer->cache registry is intentionally left intact (stable
-            # cache pointers across chunks).
-            B12xMLASparseImpl._shared_gather_event = None
-            B12xMLASparseImpl._shared_gather_buf_idx = 0
+        if self.ckv_prefetch_registry is not None:
+            self.ckv_prefetch_registry.begin_step()
 
         if (
             use_dcp
@@ -892,6 +1043,7 @@ class B12xMLASparseMetadataBuilder(AttentionMetadataBuilder[B12xMLASparseMetadat
             dcp_local_total_tokens=dcp_local_total_tokens,
             dcp_padded_total_tokens=dcp_padded_total_tokens,
             dcp_ckv_gather_eligible=dcp_ckv_gather_eligible,
+            ckv_prefetch_registry=self.ckv_prefetch_registry,
             block_size=self.kv_cache_spec.block_size,
             topk_tokens=self.topk_tokens,
         )
@@ -1155,30 +1307,6 @@ class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
             int(self._extend_plan.layout.nbytes),
         )
 
-        # Pre-touch q-concat + the attention scratch TOGETHER so the workspace
-        # manager grows during warmup (before lock_workspace() runs
-        # post-cudagraph-capture) and so the two always come from ONE
-        # get_simultaneous call -> distinct, non-overlapping offsets. The manager
-        # packs every call from offset 0, so borrowing q and the scratch the kernel
-        # writes in separate calls would alias them.
-        workspace_specs: list[tuple[tuple[int, ...], torch.dtype]] = [
-            (
-                (max_batched, self._kernel_num_heads, self.q_head_dim),
-                torch.bfloat16,
-            )
-        ]
-        if self._pad_heads:
-            workspace_specs.append(
-                (
-                    (max_batched, self._input_num_heads, self.kv_lora_rank),
-                    torch.bfloat16,
-                )
-            )
-        workspace_specs.append(((self._scratch_nbytes,), torch.uint8))
-        self._workspace_specs = tuple(workspace_specs)
-        self._borrow_workspaces()
-        self._prewarm_extend_kernels_once(max_batched)
-
         # CKV gather setup (Fix B).
         from vllm import envs as envs_mod
 
@@ -1199,6 +1327,20 @@ class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
         self._ckv_kernel_num_heads = self.num_heads
         self._ckv_gather_max_tokens = envs_mod.VLLM_B12X_MLA_CKV_GATHER_MAX_TOKENS
         self._ckv_gather_min_tokens = envs_mod.VLLM_B12X_MLA_CKV_GATHER_MIN_TOKENS
+        configured_prefetch_depth = int(envs_mod.VLLM_B12X_MLA_CKV_PREFETCH_DEPTH)
+        if configured_prefetch_depth < 0:
+            logger.warning_once(
+                "Ignoring negative VLLM_B12X_MLA_CKV_PREFETCH_DEPTH=%d; using 0",
+                configured_prefetch_depth,
+            )
+        self._ckv_prefetch_supported = (
+            self._ckv_gather_enabled
+            and _ckv_prefetch_supports_format(self.kv_cache_dtype)
+        )
+        self._ckv_prefetch_depth = (
+            max(0, configured_prefetch_depth) if self._ckv_prefetch_supported else 0
+        )
+        self._ckv_workspace_slots = _ckv_prefetch_ring_slots(self._ckv_prefetch_depth)
         self._ckv_local_capacity = (
             _cdiv(
                 _cdiv(self._ckv_gather_max_tokens, max(1, self.dcp_world_size))
@@ -1208,17 +1350,11 @@ class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
             * self.block_size
         )
         self._ckv_workspace_nbytes = (
-            2
-            * (self.dcp_world_size + 1)
+            (1 + self._ckv_workspace_slots * self.dcp_world_size)
             * self._ckv_local_capacity
             * self._kv_record_bytes
             if self._ckv_gather_enabled
             else 0
-        )
-        self._ckv_workspace = (
-            _get_ckv_gather_workspace(self.device, self._ckv_workspace_nbytes)
-            if self._ckv_gather_enabled
-            else None
         )
 
         # Separate extend plan for the gathered-cache path: full local heads
@@ -1234,19 +1370,34 @@ class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
         else:
             self._ckv_extend_plan = None
 
-        # Layer prefetch (side stream + events + ping-pong).
-        # _shared_* are class-level: layer L kicks off the prefetch for
-        # layer L+1, and layer L+1 (a different impl instance) consumes it.
-        self._ckv_prefetch_supported = self._ckv_gather_enabled and (
-            self.kv_cache_dtype == "fp8_ds_mla" or self._kv_fp8_rope
-        )
+        # Pre-touch q-concat and attention scratch together. Cross-layer CKV
+        # data cannot live in WorkspaceManager: every caller borrows from
+        # offset zero, so intervening indexer/MoE scratch would alias it. The
+        # builder-owned state allocates a dedicated ring per workspace lane.
+        workspace_specs: list[tuple[tuple[int, ...], torch.dtype]] = [
+            (
+                (max_batched, self._kernel_num_heads, self.q_head_dim),
+                torch.bfloat16,
+            )
+        ]
+        if self._pad_heads:
+            workspace_specs.append(
+                (
+                    (max_batched, self._input_num_heads, self.kv_lora_rank),
+                    torch.bfloat16,
+                )
+            )
+        workspace_specs.append(((self._scratch_nbytes,), torch.uint8))
+        self._workspace_specs = tuple(workspace_specs)
+        self._borrow_workspaces()
+        self._prewarm_extend_kernels_once(max_batched)
+
+        # The builder-owned registry lazily creates one stream per workspace
+        # lane after cache discovery finds the first lookahead target. CUDA
+        # capture keeps the existing non-CKV fallback.
         if self._ckv_gather_enabled:
-            self._ckv_gather_stream = torch.cuda.Stream(device=self.device)
             self._ckv_current_chunk_kv_c: torch.Tensor | None = None
             self._ckv_current_chunk_kpe: torch.Tensor | None = None
-            B12xMLASparseImpl._all_layer_kv_caches: list[torch.Tensor | None] = []
-            B12xMLASparseImpl._shared_gather_event: torch.cuda.Event | None = None
-            B12xMLASparseImpl._shared_gather_buf_idx = 0
             if not self._ckv_prefetch_supported:
                 logger.warning_once(
                     "CKV gather prefetch disabled for kv_cache_dtype=%s "
@@ -1254,8 +1405,14 @@ class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
                     self.kv_cache_dtype,
                     int(self._kv_fp8_rope),
                 )
+            elif self._ckv_prefetch_depth > 0:
+                logger.info_once(
+                    "Using native CKV layer prefetch with depth=%d and "
+                    "%d workspace slots.",
+                    self._ckv_prefetch_depth,
+                    self._ckv_workspace_slots,
+                )
         else:
-            self._ckv_gather_stream = None
             self._ckv_current_chunk_kv_c = None
             self._ckv_current_chunk_kpe = None
 
@@ -1601,6 +1758,27 @@ class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
         ):
             raise RuntimeError("B12X CKV gather borrowed an invalid workspace")
 
+    def _ckv_workspace_views(
+        self, ckv_workspace: torch.Tensor, buf_idx: int
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        self._validate_ckv_workspace(ckv_workspace)
+        if not 0 <= int(buf_idx) < self._ckv_workspace_slots:
+            raise ValueError(
+                f"CKV gather buffer index {buf_idx} is outside "
+                f"[0, {self._ckv_workspace_slots})"
+            )
+        records = ckv_workspace.view(-1, self._kv_record_bytes)
+        local_buffer = records[: self._ckv_local_capacity]
+        gathered_base = (
+            self._ckv_local_capacity
+            + buf_idx * self.dcp_world_size * self._ckv_local_capacity
+        )
+        gathered_buffer = records[
+            gathered_base : gathered_base
+            + self.dcp_world_size * self._ckv_local_capacity
+        ]
+        return local_buffer, gathered_buffer
+
     def dcp_prefill_ckv_gather_eligible(
         self,
         attn_metadata: B12xMLASparseMetadata,
@@ -1658,18 +1836,11 @@ class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
         assert attn_metadata.dcp_local_cu_seq_lens is not None
         padded_tokens = attn_metadata.dcp_padded_total_tokens
         local_tokens = attn_metadata.dcp_local_total_tokens
-        self._validate_ckv_workspace(ckv_workspace)
-        half_nbytes = (
-            (self.dcp_world_size + 1) * self._ckv_local_capacity * self._kv_record_bytes
+        local_buffer, gathered_buffer = self._ckv_workspace_views(
+            ckv_workspace, buf_idx
         )
-        ws_half = ckv_workspace.view(-1, self._kv_record_bytes)
-        base = buf_idx * (half_nbytes // self._kv_record_bytes)
-        local_buffer = ws_half[base : base + self._ckv_local_capacity]
-        gathered_buffer = ws_half[
-            base + self._ckv_local_capacity : base
-            + self._ckv_local_capacity * (self.dcp_world_size + 1)
-        ]
         if stream is not None:
+            ckv_workspace.record_stream(stream)
             # The side stream must observe the default stream's prior writes
             # to the paged KV cache (this and earlier steps' do_kv_cache_update)
             # before gathering history off it; there is otherwise no ordering
@@ -1818,7 +1989,7 @@ class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
                 slots,
                 k_scale,
             )
-        elif self.kv_cache_dtype == "fp8_ds_mla":
+        elif self.kv_cache_dtype in ("fp8_ds_mla", "nvfp4_ds_mla"):
             ops.concat_and_cache_mla(
                 kv_c,
                 k_pe_flat,
@@ -1831,7 +2002,7 @@ class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
             raise RuntimeError(
                 "CKV gather prefetch append is not yet supported for "
                 f"kv_cache_dtype={self.kv_cache_dtype!r}; disable prefetch "
-                "or use fp8_ds_mla / KV_FP8_ROPE."
+                "or use fp8_ds_mla / nvfp4_ds_mla."
             )
 
     def _sync_warmup(self) -> None:
@@ -1961,7 +2132,6 @@ class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
         workspace_tensors = self._borrow_workspaces()
         q_workspace = workspace_tensors[0]
         dense_out_workspace = workspace_tensors[1] if self._pad_heads else None
-        ckv_workspace = self._ckv_workspace
         scratch_storage = workspace_tensors[-1]
         expected_input_heads = (
             self.num_heads if use_ckv_gather else self._input_num_heads
@@ -2121,28 +2291,28 @@ class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
                 f"got stride={tuple(kv_cache.stride())}"
             )
         if use_ckv_gather:
-            if ckv_workspace is None:
-                raise RuntimeError("CKV gather workspace was not borrowed")
             layer_idx = self._resolve_layer_index(layer)
-            if layer_idx is not None:
-                while len(B12xMLASparseImpl._all_layer_kv_caches) <= layer_idx:
-                    B12xMLASparseImpl._all_layer_kv_caches.append(None)
-                B12xMLASparseImpl._all_layer_kv_caches[layer_idx] = kv_cache
-            if B12xMLASparseImpl._shared_gather_event is not None:
-                B12xMLASparseImpl._shared_gather_event.wait()
-                half_nbytes = (
-                    (self.dcp_world_size + 1)
-                    * self._ckv_local_capacity
-                    * self._kv_record_bytes
+            prefetch_registry = attn_metadata.ckv_prefetch_registry
+            if prefetch_registry is None:
+                raise RuntimeError("CKV gather requires a prefetch state registry")
+            prefetch_state = prefetch_registry.for_workspace(
+                q_workspace, layer_idx, kv_cache
+            )
+            ckv_workspace = prefetch_state.get_ckv_workspace(self._ckv_workspace_nbytes)
+            if layer_idx is not None and self._ckv_prefetch_depth > 0:
+                prefetch_state.enter_layer(layer_idx)
+                prefetch_state.register_cache(layer_idx, kv_cache)
+            pending = (
+                prefetch_state.pending_layers.pop(layer_idx, None)
+                if layer_idx is not None and self._ckv_prefetch_depth > 0
+                else None
+            )
+            if pending is not None:
+                gather_event, current_buf_idx = pending
+                gather_event.wait()
+                _, gathered_buffer = self._ckv_workspace_views(
+                    ckv_workspace, current_buf_idx
                 )
-                ws_half = ckv_workspace.view(-1, self._kv_record_bytes)
-                base = B12xMLASparseImpl._shared_gather_buf_idx * (
-                    half_nbytes // self._kv_record_bytes
-                )
-                gathered_buffer = ws_half[
-                    base + self._ckv_local_capacity : base
-                    + self._ckv_local_capacity * (self.dcp_world_size + 1)
-                ]
                 kv_cache = gathered_buffer[
                     : self.dcp_world_size * self._ckv_local_capacity
                 ].view(-1, self.block_size, self._kv_record_bytes)
@@ -2150,7 +2320,17 @@ class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
                     kv_cache, attn_metadata, layer, num_actual_toks
                 )
             else:
-                kv_cache = self._dcp_gather_ckv(kv_cache, attn_metadata, ckv_workspace)
+                current_buf_idx = (
+                    layer_idx % self._ckv_workspace_slots
+                    if layer_idx is not None
+                    else 0
+                )
+                kv_cache = self._dcp_gather_ckv(
+                    kv_cache,
+                    attn_metadata,
+                    ckv_workspace,
+                    buf_idx=current_buf_idx,
+                )
             logger.info_once(
                 "Using transient full-CKV gather for B12X sparse MLA prefill "
                 "(capacity=%d logical tokens)",
@@ -2158,24 +2338,39 @@ class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
             )
             if (
                 self._ckv_prefetch_supported
+                and self._ckv_prefetch_depth > 0
                 and layer_idx is not None
-                and layer_idx + 1 < len(B12xMLASparseImpl._all_layer_kv_caches)
-                and B12xMLASparseImpl._all_layer_kv_caches[layer_idx + 1] is not None
             ):
-                next_kv = B12xMLASparseImpl._all_layer_kv_caches[layer_idx + 1]
-                next_buf_idx = 1 - B12xMLASparseImpl._shared_gather_buf_idx
-                self._dcp_gather_ckv(
-                    next_kv,
-                    attn_metadata,
-                    ckv_workspace,
-                    buf_idx=next_buf_idx,
-                    stream=self._ckv_gather_stream,
+                # The first eligible request only discovers one layer cache at
+                # a time. It intentionally has no lookahead and primes the
+                # cache registry for subsequent requests.
+                targets = _ckv_prefetch_target_indices(
+                    layer_idx,
+                    self._ckv_prefetch_depth,
+                    prefetch_state.layer_caches,
+                    prefetch_state.pending_layers,
                 )
-                B12xMLASparseImpl._shared_gather_event = torch.cuda.Event(
-                    blocking=False
+                prefetch_stream = (
+                    prefetch_state.get_gather_stream() if targets else None
                 )
-                B12xMLASparseImpl._shared_gather_event.record(self._ckv_gather_stream)
-                B12xMLASparseImpl._shared_gather_buf_idx = next_buf_idx
+                for target_idx in targets:
+                    assert prefetch_stream is not None
+                    target_kv = prefetch_state.layer_caches[target_idx]
+                    assert target_kv is not None
+                    target_buf_idx = target_idx % self._ckv_workspace_slots
+                    self._dcp_gather_ckv(
+                        target_kv,
+                        attn_metadata,
+                        ckv_workspace,
+                        buf_idx=target_buf_idx,
+                        stream=prefetch_stream,
+                    )
+                    target_event = torch.cuda.Event(blocking=False)
+                    target_event.record(prefetch_stream)
+                    prefetch_state.pending_layers[target_idx] = (
+                        target_event,
+                        target_buf_idx,
+                    )
 
         use_decode_kernel = attn_metadata.max_query_len <= 1 or (
             self.spec_extend_as_decode

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -1664,8 +1664,17 @@ class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
         """Project DCP partials from 512 to 256 in borrowed MLA storage."""
         num_tokens = int(attn_out.shape[0])
         self._validate_dcp_prefill_workspace_contract(num_tokens)
+        padded_head_major = (
+            attn_out.ndim == 3
+            and attn_out.stride(2) == 1
+            and attn_out.stride(0) == attn_out.shape[2]
+            and attn_out.stride(1) >= attn_out.shape[0] * attn_out.shape[2]
+            and attn_out.stride(1) % attn_out.shape[2] == 0
+        )
         attn_out_has_supported_layout = (
-            attn_out.is_contiguous() or attn_out.movedim(0, 1).is_contiguous()
+            attn_out.is_contiguous()
+            or attn_out.movedim(0, 1).is_contiguous()
+            or padded_head_major
         )
         if (
             tuple(attn_out.shape)

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -1664,10 +1664,13 @@ class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
         """Project DCP partials from 512 to 256 in borrowed MLA storage."""
         num_tokens = int(attn_out.shape[0])
         self._validate_dcp_prefill_workspace_contract(num_tokens)
+        attn_out_has_supported_layout = (
+            attn_out.is_contiguous() or attn_out.movedim(0, 1).is_contiguous()
+        )
         if (
             tuple(attn_out.shape)
             != (num_tokens, self._input_num_heads, self.kv_lora_rank)
-            or not attn_out.movedim(0, 1).is_contiguous()
+            or not attn_out_has_supported_layout
             or attn_out.dtype != torch.bfloat16
             or tuple(w_uv.shape)
             != (self._input_num_heads, self.kv_lora_rank, self.v_head_dim)
@@ -1677,7 +1680,11 @@ class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
             or lse.dtype != torch.float32
         ):
             raise ValueError(
-                "DCP workspace projection received an invalid tensor layout"
+                "DCP workspace projection received an invalid tensor layout: "
+                f"attn_out={tuple(attn_out.shape)}/{tuple(attn_out.stride())}/"
+                f"{attn_out.dtype}, lse={tuple(lse.shape)}/{tuple(lse.stride())}/"
+                f"{lse.dtype}, w_uv={tuple(w_uv.shape)}/{tuple(w_uv.stride())}/"
+                f"{w_uv.dtype}"
             )
 
         q_workspace, dense_out_workspace, scratch_storage = (

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -31,7 +31,6 @@ from vllm.v1.attention.backends.utils import (
     split_decodes_and_prefills,
 )
 from vllm.v1.kv_cache_interface import AttentionSpec, MLAAttentionSpec
-from vllm.v1.worker.cp_utils import get_total_cp_world_size
 
 logger = init_logger(__name__)
 
@@ -272,6 +271,17 @@ def get_max_prefill_buffer_size(vllm_config: VllmConfig):
     return max_model_len * 40
 
 
+def get_indexer_max_num_blocks_per_req(
+    max_model_len: int,
+    block_size: int,
+    configured_cp_world_size: int,
+    dcp_replicated: bool,
+) -> int:
+    """Size indexer metadata for the cache group's effective DCP layout."""
+    effective_cp_world_size = 1 if dcp_replicated else configured_cp_world_size
+    return cdiv(max_model_len, block_size * effective_cp_world_size)
+
+
 def _supports_varlen_paged_mqa_logits() -> bool:
     if (
         envs.VLLM_USE_B12X_SPARSE_INDEXER
@@ -347,7 +357,12 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
         super().__init__(*args, **kwargs)
         scheduler_config = self.vllm_config.scheduler_config
         parallel_config = self.vllm_config.parallel_config
-        self.dcp_world_size = parallel_config.decode_context_parallel_size
+        self.dcp_replicated = bool(getattr(self.kv_cache_spec, "dcp_replicated", False))
+        configured_dcp_world_size = parallel_config.decode_context_parallel_size
+        configured_cp_world_size = (
+            configured_dcp_world_size * parallel_config.prefill_context_parallel_size
+        )
+        self.dcp_world_size = 1 if self.dcp_replicated else configured_dcp_world_size
         self.dcp_rank = get_dcp_group().rank_in_group if self.dcp_world_size > 1 else 0
         self.cp_kv_cache_interleave_size = parallel_config.cp_kv_cache_interleave_size
         # The DCP sparse-indexer code is parameterized by interleave size, but
@@ -444,9 +459,11 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
             dtype=torch.int32,
             device=self.device,
         )
-        max_num_blocks_per_req = cdiv(
+        max_num_blocks_per_req = get_indexer_max_num_blocks_per_req(
             self.vllm_config.model_config.max_model_len,
-            self.kv_cache_spec.block_size * get_total_cp_world_size(),
+            self.kv_cache_spec.block_size,
+            configured_cp_world_size,
+            self.dcp_replicated,
         )
         self.expanded_block_table_buffer = torch.zeros(
             (
@@ -986,7 +1003,7 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
             # range and miss valid tokens. Keep the global seq_lens here and
             # localize the expanded bounds further down.
             global_seq_lens_for_decode: torch.Tensor | None = None
-            if dcp_local_seq_lens is not None:
+            if use_dcp_local_kv:
                 global_seq_lens_for_decode = common_attn_metadata.seq_lens[:num_decodes]
             seq_lens = common_attn_metadata.seq_lens[:num_decodes]
             block_table = common_attn_metadata.block_table_tensor[:num_decodes, ...]
@@ -1050,7 +1067,7 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
             # Uncompressed DCP localizes after per-token expansion. Compressed
             # DCP must first convert global logical lengths to compressed-token
             # lengths and only then shard those retained tokens across ranks.
-            if dcp_local_seq_lens is not None and self.compress_ratio == 1:
+            if use_dcp_local_kv and self.compress_ratio == 1:
                 seq_lens = self._dcp_localize_decode_seq_lens(
                     seq_lens, num_decodes, seq_lens_is_buffer_view
                 )
@@ -1060,7 +1077,7 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
             if self.compress_ratio > 1:
                 if seq_lens_is_buffer_view:
                     seq_lens //= self.compress_ratio
-                    if dcp_local_seq_lens is not None:
+                    if use_dcp_local_kv:
                         seq_lens.copy_(
                             get_dcp_local_seq_lens(
                                 seq_lens,
@@ -1072,7 +1089,7 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                 else:
                     # Copy to avoid mutating shared state; keeps CG address stable.
                     compressed_decode_seq_lens = seq_lens // self.compress_ratio
-                    if dcp_local_seq_lens is not None:
+                    if use_dcp_local_kv:
                         compressed_decode_seq_lens = get_dcp_local_seq_lens(
                             compressed_decode_seq_lens,
                             self.dcp_world_size,
@@ -1123,7 +1140,7 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                         use_native,
                         (
                             common_attn_metadata.dcp_local_seq_lens_cpu[:num_decodes]
-                            if dcp_local_seq_lens is not None
+                            if use_dcp_local_kv
                             and common_attn_metadata.dcp_local_seq_lens_cpu is not None
                             else None
                         ),

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -282,14 +282,16 @@ class BlockPool:
                 block_hash, kv_cache_group_id
             )
             if blk.block_hash is not None:
-                # The only valid case where a "new full block" already has a
-                # hash is partial->full promotion of the same cache block.
-                assert (
-                    blk.block_hash_num_tokens is not None
-                    and blk.block_hash_num_tokens < num_hash_tokens
-                )
-                removed_hashes = self._remove_cached_block_hashes(blk)
-                self._emit_block_removed_events(removed_hashes)
+                assert blk.block_hash_num_tokens is not None
+                if blk.block_hash_num_tokens < num_hash_tokens:
+                    removed_hashes = self._remove_cached_block_hashes(blk)
+                    self._emit_block_removed_events(removed_hashes)
+                else:
+                    # Lockstep groups attach group-specific keys to one block
+                    # at the same token boundary.
+                    assert blk.block_hash_num_tokens == num_hash_tokens
+                    assert get_block_hash(blk.block_hash) == block_hash
+                    assert get_group_id(blk.block_hash) != kv_cache_group_id
             self._insert_block_hash(
                 block_hash_with_group_id,
                 blk,

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -11,6 +11,7 @@ from vllm.v1.core.kv_cache_metrics import KVCacheMetricsCollector
 from vllm.v1.core.kv_cache_utils import (
     BlockHash,
     KVCacheBlock,
+    _use_lockstep_mla_allocation,
     is_deepseek_v4_hybrid_kv_cache_config,
 )
 from vllm.v1.core.single_type_kv_cache_manager import (
@@ -119,6 +120,11 @@ class KVCacheCoordinator(ABC):
             )
             for i, kv_cache_group in enumerate(self.kv_cache_config.kv_cache_groups)
         )
+        self.lockstep_mla_allocations = _use_lockstep_mla_allocation(
+            kv_cache_config.kv_cache_groups,
+            dcp_world_size,
+            pcp_world_size,
+        )
 
         # A positive retention interval must be a multiple of the base hit granularity
         # (``scheduler_block_size``) to land on real cache-hit boundaries.
@@ -164,31 +170,37 @@ class KVCacheCoordinator(ABC):
         Returns:
             The number of blocks to allocate.
         """
-        num_blocks_to_allocate = 0
+        blocks_by_group: list[int] = []
         for i, manager in enumerate(self.single_type_managers):
             if isinstance(manager, CrossAttentionManager):
                 # For cross-attention, we issue a single static allocation
                 # of blocks based on the number of encoder input tokens.
-                num_blocks_to_allocate += manager.get_num_blocks_to_allocate(
-                    request_id,
-                    num_encoder_tokens,
-                    [],
-                    0,
-                    0,
-                    num_encoder_tokens,
-                    apply_admission_cap=apply_admission_cap,
+                blocks_by_group.append(
+                    manager.get_num_blocks_to_allocate(
+                        request_id,
+                        num_encoder_tokens,
+                        [],
+                        0,
+                        0,
+                        num_encoder_tokens,
+                        apply_admission_cap=apply_admission_cap,
+                    )
                 )
             else:
-                num_blocks_to_allocate += manager.get_num_blocks_to_allocate(
-                    request_id,
-                    num_tokens,
-                    new_computed_blocks[i],
-                    total_computed_tokens,
-                    num_local_computed_tokens,
-                    num_tokens_main_model,
-                    apply_admission_cap=apply_admission_cap,
+                blocks_by_group.append(
+                    manager.get_num_blocks_to_allocate(
+                        request_id,
+                        num_tokens,
+                        new_computed_blocks[i],
+                        total_computed_tokens,
+                        num_local_computed_tokens,
+                        num_tokens_main_model,
+                        apply_admission_cap=apply_admission_cap,
+                    )
                 )
-        return num_blocks_to_allocate
+        if self.lockstep_mla_allocations:
+            return max(blocks_by_group, default=0)
+        return sum(blocks_by_group)
 
     def allocate_new_computed_blocks(
         self,
@@ -208,6 +220,11 @@ class KVCacheCoordinator(ABC):
             num_local_computed_tokens: The number of local computed tokens.
             num_external_computed_tokens: The number of external computed tokens.
         """
+        if self.lockstep_mla_allocations and num_external_computed_tokens:
+            raise NotImplementedError(
+                "External KV loads are not supported with lockstep MLA allocations."
+            )
+
         # A running request is already tracked in num_cached_block and won't
         # have new prefix-cache hits, so this is a no-op for it.
         if any(
@@ -236,6 +253,17 @@ class KVCacheCoordinator(ABC):
                     num_external_computed_tokens,
                 )
 
+        if self.lockstep_mla_allocations:
+            group_blocks = [
+                manager.req_to_blocks[request_id]
+                for manager in self.single_type_managers
+            ]
+            block_ids = [block.block_id for block in group_blocks[0]]
+            assert all(
+                [block.block_id for block in blocks] == block_ids
+                for blocks in group_blocks[1:]
+            )
+
     def allocate_new_blocks(
         self,
         request_id: str,
@@ -260,16 +288,38 @@ class KVCacheCoordinator(ABC):
         Returns:
             The new allocated blocks.
         """
-        return tuple(
-            manager.allocate_new_blocks(
-                request_id,
-                num_encoder_tokens
-                if isinstance(manager, CrossAttentionManager)
-                else num_tokens,
-                num_tokens_main_model,
+        if not self.lockstep_mla_allocations:
+            return tuple(
+                manager.allocate_new_blocks(
+                    request_id,
+                    num_encoder_tokens
+                    if isinstance(manager, CrossAttentionManager)
+                    else num_tokens,
+                    num_tokens_main_model,
+                )
+                for manager in self.single_type_managers
             )
-            for manager in self.single_type_managers
+
+        managers = self.single_type_managers
+        primary_ids = [
+            block.block_id for block in managers[0].req_to_blocks[request_id]
+        ]
+        assert all(
+            [block.block_id for block in manager.req_to_blocks[request_id]]
+            == primary_ids
+            for manager in managers[1:]
         )
+
+        new_blocks = managers[0].allocate_new_blocks(
+            request_id,
+            num_tokens,
+            num_tokens_main_model,
+        )
+        for manager in managers[1:]:
+            if new_blocks:
+                self.block_pool.touch(new_blocks)
+                manager.req_to_blocks[request_id].extend(new_blocks)
+        return tuple(list(new_blocks) for _ in managers)
 
     def cache_blocks(self, request: Request, num_computed_tokens: int) -> None:
         """

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1002,6 +1002,16 @@ def _pool_bytes_per_block(
     `available_memory` into `num_blocks`. Used to compute the effective KV cache
     capacity once `num_gpu_blocks_override` is applied.
     """
+    parallel_config = vllm_config.parallel_config
+    if _use_lockstep_mla_allocation(
+        kv_cache_groups,
+        parallel_config.decode_context_parallel_size,
+        parallel_config.prefill_context_parallel_size,
+    ):
+        return sum(
+            page_size
+            for page_size, _ in _get_lockstep_mla_tensor_slots(kv_cache_groups)
+        )
     if len(kv_cache_groups) == 1 and isinstance(
         kv_cache_groups[0].kv_cache_spec, UniformTypeKVCacheSpecs
     ):
@@ -1313,10 +1323,91 @@ def _bucket_layers_by_page_size(
     return buckets
 
 
+def _is_lockstep_mla_spec_layout(
+    kv_cache_specs: Iterable[KVCacheSpec],
+    dcp_world_size: int,
+    pcp_world_size: int,
+) -> bool:
+    specs = list(kv_cache_specs)
+    if (
+        len(specs) < 2
+        or not isinstance(dcp_world_size, int)
+        or not isinstance(pcp_world_size, int)
+    ):
+        return False
+    cp_world_size = dcp_world_size * pcp_world_size
+    if cp_world_size <= 1:
+        return False
+    if not all(isinstance(spec, MLAAttentionSpec) for spec in specs):
+        return False
+
+    replication_modes = {bool(getattr(spec, "dcp_replicated", False)) for spec in specs}
+    global_block_sizes = {
+        spec.block_size
+        if getattr(spec, "dcp_replicated", False)
+        else spec.block_size * cp_world_size
+        for spec in specs
+    }
+    return replication_modes == {False, True} and len(global_block_sizes) == 1
+
+
+def _use_lockstep_mla_allocation(
+    kv_cache_groups: list[KVCacheGroupSpec],
+    dcp_world_size: int,
+    pcp_world_size: int,
+) -> bool:
+    """Return whether mixed MLA groups can share one block-ID namespace."""
+    if len(kv_cache_groups) < 2:
+        return False
+
+    layer_specs: list[KVCacheSpec] = []
+    for group in kv_cache_groups:
+        group_spec = group.kv_cache_spec
+        group_layer_specs = (
+            list(group_spec.kv_cache_specs.values())
+            if isinstance(group_spec, UniformTypeKVCacheSpecs)
+            else [group_spec]
+        )
+        group_modes = {
+            bool(getattr(spec, "dcp_replicated", False)) for spec in group_layer_specs
+        }
+        if len(group_modes) != 1:
+            return False
+        layer_specs.extend(group_layer_specs)
+
+    return _is_lockstep_mla_spec_layout(layer_specs, dcp_world_size, pcp_world_size)
+
+
+def _get_lockstep_mla_tensor_slots(
+    kv_cache_groups: list[KVCacheGroupSpec],
+) -> list[tuple[int, list[str]]]:
+    slots: list[tuple[int, list[str]]] = []
+    for group in kv_cache_groups:
+        group_spec = group.kv_cache_spec
+        if isinstance(group_spec, UniformTypeKVCacheSpecs):
+            slots.extend(
+                (group_spec.kv_cache_specs[layer_name].page_size_bytes, [layer_name])
+                for layer_name in group.layer_names
+            )
+        else:
+            slots.extend(
+                (group_spec.page_size_bytes, [layer_name])
+                for layer_name in group.layer_names
+            )
+    return slots
+
+
 def _use_packed_kv_cache_config(
     vllm_config: VllmConfig,
     kv_cache_groups: list[KVCacheGroupSpec],
 ) -> bool:
+    parallel_config = vllm_config.parallel_config
+    if _use_lockstep_mla_allocation(
+        kv_cache_groups,
+        parallel_config.decode_context_parallel_size,
+        parallel_config.prefill_context_parallel_size,
+    ):
+        return True
     is_dsv4 = all(
         isinstance(group.kv_cache_spec, UniformTypeKVCacheSpecs)
         for group in kv_cache_groups
@@ -1346,11 +1437,27 @@ def _get_kv_cache_config_packed(
     groups at the same slot share a tensor (they have independent block
     tables so block-id namespaces never collide). Each emitted tensor aliases
     one physical backing allocation, with per-block data laid out contiguously.
+    Lockstep MLA groups instead get distinct contiguous tensors because their
+    block IDs intentionally coincide.
     """
+    parallel_config = vllm_config.parallel_config
+    if _use_lockstep_mla_allocation(
+        kv_cache_groups,
+        parallel_config.decode_context_parallel_size,
+        parallel_config.prefill_context_parallel_size,
+    ):
+        tensor_slots = _get_lockstep_mla_tensor_slots(kv_cache_groups)
+        total_num_bytes_per_block = sum(page_size for page_size, _ in tensor_slots)
+        num_blocks = available_memory // total_num_bytes_per_block
+        num_blocks = may_override_num_blocks(vllm_config, num_blocks)
+        return num_blocks, [
+            KVCacheTensor(size=page_size * num_blocks, shared_by=slot)
+            for page_size, slot in tensor_slots
+        ]
+
     # buckets = {page_size: [[layer_names], [layer_names], ...]}
     buckets = _bucket_layers_by_page_size(kv_cache_groups)
     total_num_bytes_per_block = sum(ps * len(slots) for ps, slots in buckets.items())
-
     num_blocks = available_memory // total_num_bytes_per_block
     num_blocks = may_override_num_blocks(vllm_config, num_blocks)
 
@@ -1557,6 +1664,8 @@ def unify_hybrid_kv_cache_specs(kv_cache_spec: dict[str, KVCacheSpec]):
 
 def group_and_unify_kv_cache_specs(
     kv_cache_spec: dict[str, KVCacheSpec],
+    dcp_world_size: int = 1,
+    pcp_world_size: int = 1,
 ) -> list[UniformTypeKVCacheSpecs] | None:
     """
     Group the KV cache specs and unify each group into one UniformTypeKVCacheSpecs.
@@ -1565,29 +1674,33 @@ def group_and_unify_kv_cache_specs(
     has_swa = any(
         isinstance(spec, SlidingWindowMLASpec) for spec in kv_cache_spec.values()
     )
-    # DFlash-under-DCP draft: full-attention layers replicated on every DCP
-    # rank. They have a different page size than the MLA target and need their
-    # own group, but the DeepseekV4 multi-group allocator (with page-size
-    # padding) handles exactly that, so route them through here too.
+    lockstep_mla_layout = _is_lockstep_mla_spec_layout(
+        kv_cache_spec.values(), dcp_world_size, pcp_world_size
+    )
+    # Replicated layers need a group separate from sharded layers because they
+    # have different token ownership and block-table semantics.
     has_repl = any(
         getattr(spec, "dcp_replicated", False)
-        and not isinstance(spec, MLAAttentionSpec)
+        and (not isinstance(spec, MLAAttentionSpec) or lockstep_mla_layout)
         for spec in kv_cache_spec.values()
     )
     if not (has_swa or has_repl):
         return None
 
-    # SlidingWindowMLASpec models with uniform page sizes don't need tuple packing.
+    # Other uniform page layouts do not need tuple packing.
     page_sizes = {spec.page_size_bytes for spec in kv_cache_spec.values()}
-    if len(page_sizes) <= 1:
+    if len(page_sizes) <= 1 and not lockstep_mla_layout:
         return None
 
     mla_specs: dict[str, KVCacheSpec] = {}
     grouped_swa_mla_specs: dict[tuple[int, int, bool, bool], dict[str, KVCacheSpec]] = (
         defaultdict(dict)
     )
-    # dcp_replicated non-MLA groups (e.g. the DFlash draft), keyed by block_size.
-    grouped_repl_specs: dict[tuple[int], dict[str, KVCacheSpec]] = defaultdict(dict)
+    # Keep incompatible replicated types and page layouts separate. This
+    # includes DFlash drafts and replicated MLA indexer caches.
+    grouped_repl_specs: dict[
+        tuple[int] | tuple[str, int, int], dict[str, KVCacheSpec]
+    ] = defaultdict(dict)
     # NOTE: Here we group SWA layers by (block_size, sliding_window,
     # dcp_replicated, dcp_sharded), which separates SWA layers, C4I+C4A
     # layers, C128A layers, and replicated compressor-state groups.
@@ -1601,10 +1714,17 @@ def group_and_unify_kv_cache_specs(
                     spec.dcp_sharded,
                 )
             ][name] = spec
+        elif getattr(spec, "dcp_replicated", False) and (
+            not isinstance(spec, MLAAttentionSpec) or lockstep_mla_layout
+        ):
+            key = (
+                (type(spec).__name__, spec.block_size, spec.page_size_bytes)
+                if isinstance(spec, MLAAttentionSpec)
+                else (spec.block_size,)
+            )
+            grouped_repl_specs[key][name] = spec
         elif isinstance(spec, MLAAttentionSpec):
             mla_specs[name] = spec
-        elif getattr(spec, "dcp_replicated", False):
-            grouped_repl_specs[(spec.block_size,)][name] = spec
 
     if len(mla_specs) == 0:
         # No full-MLA group to anchor the DeepseekV4 layout; let the generic
@@ -1698,11 +1818,17 @@ def _get_kv_cache_groups_uniform_groups(
     ]
 
     swa_mla_specs = grouped_specs[1:]
-    # Non-first groups are SWA-MLA, full-attention dcp_replicated drafts, or
-    # sliding-window dcp_replicated drafts. All are padded to MLA buckets
-    # identically.
+    # Non-first groups are SWA-MLA or DCP-replicated caches.
     assert all(
-        isinstance(spec, (SlidingWindowMLASpec, FullAttentionSpec, SlidingWindowSpec))
+        isinstance(
+            spec,
+            (
+                MLAAttentionSpec,
+                SlidingWindowMLASpec,
+                FullAttentionSpec,
+                SlidingWindowSpec,
+            ),
+        )
         for group in swa_mla_specs
         for spec in group.kv_cache_specs.values()
     )
@@ -1716,19 +1842,30 @@ def _get_kv_cache_groups_uniform_groups(
     for sm_spec in swa_mla_specs:
         sm_page_sizes = sm_spec.get_page_sizes()
         layers_per_size: dict[int, list[str]] = defaultdict(list)
-        assert max(sm_page_sizes) <= max(all_page_sizes)
+        is_replicated_mla = all(
+            isinstance(spec, MLAAttentionSpec)
+            and getattr(spec, "dcp_replicated", False)
+            for spec in sm_spec.kv_cache_specs.values()
+        )
+        if not is_replicated_mla:
+            assert max(sm_page_sizes) <= max(all_page_sizes)
 
         # Unify page size by padding layers' page_size to the nearest larger page_size.
         # Compute candidate (nearest larger page_size) for each unique page size.
         size_to_candidate: dict[int, int] = {}
         for ps in sm_page_sizes:
-            size_to_candidate[ps] = min(x for x in all_page_sizes if x >= ps)
+            if ps <= max(all_page_sizes):
+                size_to_candidate[ps] = min(x for x in all_page_sizes if x >= ps)
         # Pad and collect layer names per page size.
         for layer_name, layer_spec in sm_spec.kv_cache_specs.items():
             current_size = layer_spec.page_size_bytes
-            candidate = size_to_candidate[current_size]
-            if current_size < candidate:
-                object.__setattr__(layer_spec, "page_size_padded", candidate)
+            if is_replicated_mla:
+                candidate = current_size
+            else:
+                assert current_size <= max(all_page_sizes)
+                candidate = size_to_candidate[current_size]
+                if current_size < candidate:
+                    object.__setattr__(layer_spec, "page_size_padded", candidate)
             layers_per_size[candidate].append(layer_name)
         # NOTE(yifan): for now, inside a UniformKV group, each page_size should
         # have the same number of layers. This also means we don't need to pad layers
@@ -1816,7 +1953,11 @@ def get_kv_cache_groups(
         # full attention, or all layers are sliding window attention with the
         # same window size). Put all layers into one group.
         return _get_kv_cache_groups_uniform_type(uniform_spec)
-    elif grouped_specs := group_and_unify_kv_cache_specs(kv_cache_spec):
+    elif grouped_specs := group_and_unify_kv_cache_specs(
+        kv_cache_spec,
+        vllm_config.parallel_config.decode_context_parallel_size,
+        vllm_config.parallel_config.prefill_context_parallel_size,
+    ):
         # DeepseekV4 case: All layers need the same number of token slots,
         # yet some layers are full attention while others are sliding window
         # attention in different sizes. Need to group layers into multiple
@@ -1902,6 +2043,21 @@ def _max_memory_usage_bytes_from_groups(
     """
     if not kv_cache_groups:
         return 0
+
+    parallel_config = vllm_config.parallel_config
+    if _use_lockstep_mla_allocation(
+        kv_cache_groups,
+        parallel_config.decode_context_parallel_size,
+        parallel_config.prefill_context_parallel_size,
+    ):
+        request_blocks = max(
+            cdiv(
+                group.kv_cache_spec.max_memory_usage_bytes(vllm_config),
+                group.kv_cache_spec.page_size_bytes,
+            )
+            for group in kv_cache_groups
+        )
+        return request_blocks * _pool_bytes_per_block(vllm_config, kv_cache_groups)
 
     if len(kv_cache_groups) == 1 and isinstance(
         kv_cache_groups[0].kv_cache_spec, UniformTypeKVCacheSpecs


### PR DESCRIPTION
## Summary

Add feature-gated full-CKV DCP prefill gather with native depth-N cross-layer lookahead.

For eligible pure-prefill steps, each rank gathers native paged CKV history on a dedicated communicator and runs its local query heads over global CKV. A dedicated ring and side stream can queue future layers; the destination layer patches current-chunk records written after prefetch began before attention consumes the workspace.

## Scope

- `VLLM_B12X_MLA_CKV_GATHER`
- configurable min/max token eligibility
- `VLLM_B12X_MLA_CKV_PREFETCH_DEPTH`
- dedicated DCP CKV process group
- depth + 1 workspace ring
- current-chunk append/fixup
- target/draft execution-lane isolation
- stock DCP fallback for capture, mixed batches, missing metadata, or unsupported formats

Lookahead supports `fp8_ds_mla` and `nvfp4_ds_mla`. All new behavior defaults off.

## Stack note

This PR is stacked on [#159](https://github.com/local-inference-lab/vllm/pull/159), so GitHub temporarily shows the allocator/indexer prerequisite commits too. The new review unit in this PR is `d6545696ff` (`feat(dcp): add depth-N native CKV prefetch`).

## Validation

On the final TP4/DCP4/MTP3 integration:

- cold prefill: 3,326 / 3,139 / 2,966 / 2,719 / 2,356 tok/s at 8K / 32K / 64K / 128K / 256K
- deterministic output matched twice near 8K, 64K, and 128K
- vLLM policy/workspace suite: 160 passed, 18 skipped
- target and MTP CUDA graph capture passed

Those figures include the complete integration stack and are evidence of compatibility, not an isolated claim for this commit alone.

Compact-record validation:

- workspace and lockstep-allocation tests cover native 368-byte FP8-RoPE and 432-byte BF16-RoPE records
- the final TP4/DCP4/MTP3 FP8-RoPE integration completed cold prefill through 291,822 prompt tokens
- the same integration reported 304,863 KV tokens at a 300,000-token model limit

## Design

[GLM-5.2 Sparse CKV under Decode Context Parallelism](https://github.com/FujitsuPolycom/vllm/blob/codex/glm52-sparse-ckv-upstream-ready-20260721/docs/design/glm52_sparse_ckv.md)

## Credits

The lookahead design originates from Koush's CKV gather and shared-layer prefetch work and builds on Luke Alonso's B12X/Sparkinfer infrastructure.

Implementation, tests, and documentation were developed with OpenAI Codex assistance and manually reviewed and GPU-validated.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional replication of sparse indexer caches across decode-context parallel ranks.
  * Added configurable B12X CKV prefetching to improve attention cache access.
  * Added lockstep allocation for mixed MLA KV-cache groups, improving aligned block management and memory planning.
  * Added environment settings for indexer-cache replication and CKV prefetch depth.

* **Bug Fixes**
  * Improved DCP handling for replicated caches, including projection layouts, localization, metadata sizing, and cache allocation.
  * Improved prefix-cache promotion and eviction consistency across related MLA groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->