### PR TITLE
[GG] fix(mla): accept partial pitched TP6 workspace output

### DIFF
--- a/tests/v1/attention/test_b12x_mla_dcp_workspace.py
+++ b/tests/v1/attention/test_b12x_mla_dcp_workspace.py
@@ -192,3 +192,53 @@ def test_dcp_workspace_contract_rejects_unvalidated_topology(monkeypatch):
 
     with pytest.raises(RuntimeError, match="unsupported topology or geometry"):
         impl._validate_dcp_prefill_workspace_contract(2048)
+
+
+def test_dcp_workspace_projection_accepts_partial_pitched_head_major_output(
+    monkeypatch,
+):
+    max_batched = 8
+    num_tokens = 5
+    input_heads = 3
+    kernel_heads = 4
+    kv_lora_rank = 4
+    v_head_dim = 2
+
+    impl = object.__new__(B12xMLASparseImpl)
+    impl._max_batched = max_batched
+    impl._input_num_heads = input_heads
+    impl._kernel_num_heads = kernel_heads
+    impl._pad_heads = True
+    impl.kv_lora_rank = kv_lora_rank
+    impl.v_head_dim = v_head_dim
+
+    q_workspace = torch.empty(
+        max_batched, kernel_heads, kv_lora_rank, dtype=torch.bfloat16
+    )
+    dense_storage = torch.arange(
+        input_heads * max_batched * kv_lora_rank, dtype=torch.float32
+    ).to(torch.bfloat16)
+    dense_workspace = dense_storage.view(
+        input_heads, max_batched, kv_lora_rank
+    ).transpose(0, 1)
+    projected_nbytes = input_heads * num_tokens * v_head_dim * 2
+    scratch_storage = torch.empty(projected_nbytes, dtype=torch.uint8)
+
+    monkeypatch.setattr(
+        impl, "_validate_dcp_prefill_workspace_contract", lambda _: None
+    )
+    monkeypatch.setattr(
+        impl,
+        "_borrow_workspace_parts",
+        lambda: (q_workspace, dense_workspace, scratch_storage),
+    )
+
+    attn_out = dense_workspace[:num_tokens]
+    lse = torch.zeros(num_tokens, input_heads, dtype=torch.float32)
+    w_uv = torch.randn(input_heads, kv_lora_rank, v_head_dim, dtype=torch.bfloat16)
+    expected = torch.bmm(attn_out.transpose(0, 1).contiguous(), w_uv).transpose(0, 1)
+
+    actual = impl.dcp_project_before_merge_in_workspace(attn_out, lse, w_uv)
+
+    assert actual.movedim(0, 1).is_contiguous()
+    torch.testing.assert_close(actual, expected)

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -1507,10 +1507,19 @@ class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
         """Project DCP partials from 512 to 256 in borrowed MLA storage."""
         num_tokens = int(attn_out.shape[0])
         self._validate_dcp_prefill_workspace_contract(num_tokens)
+        # Virtual-TP head padding writes into a head-major workspace sized for
+        # the configured token capacity. A shorter final prefill chunk is a
+        # pitched, non-contiguous view of that allocation, but it is safe here:
+        # the projection input is compacted below before entering cuBLAS.
+        expected_attn_stride = (
+            self.kv_lora_rank,
+            (self._max_batched if self._pad_heads else num_tokens) * self.kv_lora_rank,
+            1,
+        )
         if (
             tuple(attn_out.shape)
             != (num_tokens, self._input_num_heads, self.kv_lora_rank)
-            or not attn_out.movedim(0, 1).is_contiguous()
+            or tuple(attn_out.stride()) != expected_attn_stride
             or attn_out.dtype != torch.bfloat16
             or tuple(w_uv.shape)
             != (self._input_num_heads, self.kv_lora_rank, self.v_head_dim)
@@ -1520,7 +1529,10 @@ class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
             or lse.dtype != torch.float32
         ):
             raise ValueError(
-                "DCP workspace projection received an invalid tensor layout"
+                "DCP workspace projection received an invalid tensor layout: "
+                f"attn shape/stride={tuple(attn_out.shape)}/"
+                f"{tuple(attn_out.stride())}, expected stride="
+                f"{expected_attn_stride}"
             )
 
         q_workspace, dense_out_workspace, scratch_storage = (


### PR DESCRIPTION
## Summary

- accept the exact pitched head-major view produced by a partially filled virtual-TP DCP prefill workspace
- keep strict shape, dtype, and stride validation instead of broadly accepting non-contiguous tensors
- compact the validated view before the cuBLAS projection, preserving its normal allocator/layout contract
- add a regression test for a short final chunk in a head-padded TP6 workspace

## Root cause

Virtual TP6 pads the per-rank head geometry. Its borrowed DCP workspace is allocated for `_max_batched` rows, so a shorter final prefill chunk is a valid pitched view: the logical shape is smaller while the head stride still reflects the full allocation. The old `movedim(...).is_contiguous()` requirement rejected that valid view even though the projection immediately compacts the input before cuBLAS.

The new check derives and requires the one exact stride allowed by the workspace contract:

```text
(kv_lora_rank, workspace_rows * kv_lora_rank, 1)
```

Unsupported geometry, shape, dtype, or stride still fails closed.

## Validation

- `ruff check vllm/v1/attention/backends/mla/b12x_mla_sparse.py tests/v1/attention/test_b12x_mla_dcp_workspace.py`
- targeted workspace tests: 28 passed
- exact GLM-5.2 MXFP4/A8 TP6+DCP3 startup and inference passed
- TP6/DCP3 MTP0 decode: 57.27 tok/s
- TP6/DCP3 KV capacity: 700,449 tokens at seq=16, batch=4096, GMU=0.95

This is the vLLM-side companion to SparkInfer PR #48; the two fixes cover independent TP6 workspace and W4A8 scratch contracts.
