### PR TITLE
[EXL3] Route prefill batches through the planned Trellis MoE (+58-64% prefill, stacked on #139)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -794,9 +794,12 @@ RUN --mount=type=cache,target=/opt/uv/cache \
 # https://docs.flashinfer.ai/installation.html
 # From versions.json: .flashinfer.version
 ARG FLASHINFER_VERSION=0.6.14
+ARG INSTALL_FLASHINFER_JIT_CACHE=true
 RUN --mount=type=cache,target=/opt/uv/cache \
-    uv pip install --system flashinfer-jit-cache==${FLASHINFER_VERSION} \
-        --index-url https://flashinfer.ai/whl/cu$(echo $CUDA_VERSION | cut -d. -f1,2 | tr -d '.')
+    if [ "${INSTALL_FLASHINFER_JIT_CACHE}" = "true" ]; then \
+        uv pip install --system flashinfer-jit-cache==${FLASHINFER_VERSION} \
+            --index-url https://flashinfer.ai/whl/cu$(echo $CUDA_VERSION | cut -d. -f1,2 | tr -d '.'); \
+    fi
 
 # ============================================================
 # OPENAI API SERVER DEPENDENCIES

--- a/tests/distributed/test_b12x_fused_all_reduce.py
+++ b/tests/distributed/test_b12x_fused_all_reduce.py
@@ -7,6 +7,7 @@ import pytest
 import torch
 import torch.distributed as dist
 
+import vllm.envs as envs
 import vllm.ir.ops
 from tests.compile.backend import TestBackend
 from vllm.compilation.passes.fusion import allreduce_rms_fusion
@@ -26,6 +27,7 @@ from vllm.config import (
 from vllm.distributed import tensor_model_parallel_all_reduce
 from vllm.distributed.device_communicators.custom_all_reduce import (
     CustomAllreduce,
+    _b12x_pcie_oneshot_limits,
     get_b12x_pcie_allreduce,
 )
 from vllm.distributed.parallel_state import get_tp_group, graph_capture
@@ -129,6 +131,30 @@ def test_b12x_fused_allreduce_zero_cutoff_disables_support() -> None:
     )
 
     assert not custom_allreduce.supports_fused_add_rms_norm()
+
+
+def test_b12x_oneshot_defaults_to_stream_isolation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("VLLM_PCIE_ONESHOT_SINGLE_CHANNEL", raising=False)
+
+    assert not envs.environment_variables["VLLM_PCIE_ONESHOT_SINGLE_CHANNEL"]()
+
+
+def test_b12x_oneshot_buffer_tracks_dispatch_limits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VLLM_PCIE_ONESHOT_ALLREDUCE_MAX_SIZE", "64KB")
+    monkeypatch.setenv(
+        "VLLM_PCIE_ONESHOT_FUSED_ADD_RMS_NORM_MAX_SIZE",
+        "84KB",
+    )
+
+    assert _b12x_pcie_oneshot_limits() == (
+        64 * 1024,
+        84 * 1024,
+        84 * 1024,
+    )
 
 
 def test_b12x_fused_custom_op_dispatch(monkeypatch) -> None:

--- a/tests/distributed/test_dcp_a2a.py
+++ b/tests/distributed/test_dcp_a2a.py
@@ -10,6 +10,7 @@ Tests cover:
 
 import importlib.util
 import math
+from contextlib import contextmanager
 from typing import Any
 
 import multiprocess as mp
@@ -536,6 +537,122 @@ def test_b12x_pool_init_consensus_uses_exchange_group(
     assert captured["tensor_device"] == device
     assert captured["group"] is device_group
     assert captured["op"] == dist.ReduceOp.MAX
+
+
+def test_b12x_pool_uses_independent_stream_channels(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from vllm.v1.attention.ops import dcp_alltoall
+
+    captured: dict[str, Any] = {}
+
+    class _FakePool:
+        @classmethod
+        def from_exchange_group(cls, **kwargs):
+            captured.update(kwargs)
+            return cls()
+
+        def for_stream(self):
+            captured["warmed"] = True
+
+    group = _FakeCPGroup(2, object())  # type: ignore[arg-type]
+    monkeypatch.setattr(dcp_alltoall, "_B12X_DCP_A2A_POOLS", {})
+    monkeypatch.setattr(dcp_alltoall, "_B12X_DCP_A2A_DISABLED", set())
+    monkeypatch.setattr(dcp_alltoall, "_load_b12x_dcp_a2a_pool", lambda: _FakePool)
+    monkeypatch.setattr(dcp_alltoall, "_b12x_dcp_init_failed", lambda *args: False)
+    monkeypatch.setattr(
+        dcp_alltoall.torch.cuda,
+        "is_current_stream_capturing",
+        lambda: False,
+    )
+
+    pool = dcp_alltoall._get_b12x_dcp_a2a_pool(
+        group,  # type: ignore[arg-type]
+        device=torch.device("cuda:0"),
+        total_heads=64,
+        head_dim=512,
+        query_head_dim=576,
+        max_batch_size=64,
+    )
+
+    assert pool is not None
+    assert captured["single_channel"] is False
+    assert captured["warmed"] is True
+
+
+def test_b12x_dcp_capture_selects_only_current_group_pools(monkeypatch):
+    from vllm.v1.attention.ops import dcp_alltoall
+
+    events = []
+
+    class _FakePool:
+        def __init__(self, name):
+            self.name = name
+
+        @contextmanager
+        def capture(self, *, stream):
+            events.append(("enter", self.name, stream))
+            try:
+                yield
+            finally:
+                events.append(("exit", self.name, stream))
+
+    device_group = object()
+    group = _FakeCPGroup(2, device_group)  # type: ignore[arg-type]
+    stream = object()
+    pools = {
+        (id(device_group), 0, 64, 512, 576, 64): _FakePool("output"),
+        (id(device_group), 0, 64, 576, 576, 64): _FakePool("query"),
+        (id(object()), 0, 64, 512, 576, 64): _FakePool("foreign"),
+    }
+    monkeypatch.setattr(dcp_alltoall, "_B12X_DCP_A2A_POOLS", pools)
+
+    with dcp_alltoall.capture_b12x_dcp_a2a(group, stream):  # type: ignore[arg-type]
+        events.append(("body", None, stream))
+
+    assert events == [
+        ("enter", "output", stream),
+        ("enter", "query", stream),
+        ("body", None, stream),
+        ("exit", "query", stream),
+        ("exit", "output", stream),
+    ]
+
+
+def test_global_graph_capture_enters_b12x_dcp_pool(monkeypatch):
+    from vllm.distributed import parallel_state
+    from vllm.v1.attention.ops import dcp_alltoall
+
+    events = []
+
+    class _FakeGroup:
+        world_size = 2
+
+        @contextmanager
+        def graph_capture(self, context):
+            yield context
+
+    tp_group = _FakeGroup()
+    pp_group = _FakeGroup()
+    dcp_group = _FakeGroup()
+    stream = object()
+    context = parallel_state.GraphCaptureContext(stream)  # type: ignore[arg-type]
+
+    @contextmanager
+    def fake_b12x_capture(group, selected_stream):
+        events.append((group, selected_stream))
+        yield
+
+    monkeypatch.setattr(parallel_state, "_DCP", dcp_group)
+    monkeypatch.setattr(parallel_state, "get_tp_group", lambda: tp_group)
+    monkeypatch.setattr(parallel_state, "get_pp_group", lambda: pp_group)
+    monkeypatch.setattr(parallel_state, "get_dcp_group", lambda: dcp_group)
+    monkeypatch.setattr(dcp_alltoall, "capture_b12x_dcp_a2a", fake_b12x_capture)
+
+    with parallel_state.graph_capture(torch.device("cpu"), context) as actual:
+        assert actual is context
+
+    assert events == [(dcp_group, stream)]
 
 
 @pytest.mark.skipif(torch.accelerator.device_count() < 1, reason="CUDA is required.")

--- a/tests/quantization/test_exl3.py
+++ b/tests/quantization/test_exl3.py
@@ -1,0 +1,130 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import vllm.model_executor.layers.quantization.exl3 as exl3_module
+import vllm.model_executor.parameter as parameter_module
+from vllm.model_executor.layers.quantization import get_quantization_config
+from vllm.model_executor.layers.quantization.exl3 import (
+    Exl3Config,
+    Exl3MoEParameter,
+)
+
+
+def _rank_sliced_metadata(**overrides):
+    metadata = {
+        "format": "exl3-trellis",
+        "bits": 3.0,
+        "codebook": "mcg",
+        "experts_per_layer": 256,
+        "moe_layers": [3, 77],
+        "tensor_schema": (
+            "model.layers.{L}.mlp.experts.{E}.{proj}.rank{r}.{trellis|suh|svh|mcg}"
+        ),
+        "tp": 4,
+    }
+    metadata.update(overrides)
+    return metadata
+
+
+def test_rank_sliced_checkpoint_selects_exl3_override():
+    hf_config = SimpleNamespace(hybrid_tr3_tail=_rank_sliced_metadata())
+
+    assert get_quantization_config("exl3") is Exl3Config
+    assert (
+        Exl3Config.override_quantization_method(
+            {"quant_method": "modelopt"}, None, hf_config
+        )
+        == "exl3"
+    )
+    assert (
+        Exl3Config.override_quantization_method(
+            {"quant_method": "modelopt"}, "fp8", hf_config
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"codebook": "mul1"}, "MCG codebook"),
+        ({"moe_layers": [77, 3]}, "moe_layers"),
+        ({"tensor_schema": "unsupported"}, "tensor schema"),
+    ],
+)
+def test_rank_sliced_metadata_fails_closed(overrides, message):
+    config = Exl3Config()
+    hf_config = SimpleNamespace(hybrid_tr3_tail=_rank_sliced_metadata(**overrides))
+
+    with pytest.raises(ValueError, match=message):
+        config.maybe_update_config("unused", hf_config)
+
+
+def test_rank_sliced_metadata_admits_only_declared_moe_layers():
+    config = Exl3Config()
+    config.maybe_update_config(
+        "unused",
+        SimpleNamespace(hybrid_tr3_tail=_rank_sliced_metadata()),
+    )
+
+    assert config._moe_prefix_is_exl3("model.layers.3.mlp.experts")
+    assert config._moe_prefix_is_exl3("model.layers.77.mlp.experts")
+    assert not config._moe_prefix_is_exl3("model.layers.2.mlp.experts")
+    assert not config._moe_prefix_is_exl3("model.layers.78.mlp.experts")
+    assert (
+        config.codebook_for_prefix("model.layers.10.mlp.experts.0.gate_proj") == "mcg"
+    )
+
+
+def test_rank_sliced_weight_name_keeps_only_local_tp_rank(monkeypatch):
+    config = Exl3Config()
+    config.maybe_update_config(
+        "unused",
+        SimpleNamespace(hybrid_tr3_tail=_rank_sliced_metadata()),
+    )
+    monkeypatch.setattr(exl3_module, "get_tensor_model_parallel_rank", lambda: 2)
+    prefix = "model.layers.3.mlp.experts.17.gate_proj"
+
+    assert (
+        config.normalize_rank_sliced_weight_name(f"{prefix}.rank2.trellis")
+        == f"{prefix}.trellis"
+    )
+    assert config.normalize_rank_sliced_weight_name(f"{prefix}.rank1.trellis") is None
+    assert (
+        config.normalize_rank_sliced_weight_name("model.embed_tokens.weight")
+        == "model.embed_tokens.weight"
+    )
+
+
+def test_rank_sliced_parameter_preallocates_projection_major_slab(monkeypatch):
+    monkeypatch.setattr(parameter_module, "get_tensor_model_parallel_rank", lambda: 0)
+    monkeypatch.setattr(
+        parameter_module, "get_tensor_model_parallel_world_size", lambda: 1
+    )
+    param = Exl3MoEParameter(
+        weight_loader=lambda *args, **kwargs: None,
+        num_experts=3,
+        shard_ids=("w1", "w3"),
+        preallocate=True,
+    )
+    w1 = torch.arange(8, dtype=torch.int16).reshape(2, 2, 2)
+    w3 = w1 + 20
+
+    param.load_exl3_weight(w1, expert_id=1, shard_id="w1")
+    param.load_exl3_weight(w3, expert_id=2, shard_id="w3")
+
+    assert param.exl3_backing is not None
+    assert tuple(param.exl3_backing.shape) == (2, 3, 2, 2, 2)
+    assert (
+        param.exl3_tensors[(1, "w1")].data_ptr() == param.exl3_backing[0, 1].data_ptr()
+    )
+    assert (
+        param.exl3_tensors[(2, "w3")].data_ptr() == param.exl3_backing[1, 2].data_ptr()
+    )
+    torch.testing.assert_close(param.exl3_tensors[(1, "w1")], w1)
+    torch.testing.assert_close(param.exl3_tensors[(2, "w3")], w3)

--- a/tests/quantization/test_exl3_prefill_plan.py
+++ b/tests/quantization/test_exl3_prefill_plan.py
@@ -1,0 +1,254 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Dispatch-contract tests for the dual-plan rank-sliced EXL3 MoE runtime.
+
+The planned Trellis API and the ExLlamaV3 extension are mocked; these tests
+prove backend policy only:
+
+* decode window m in [min, max] binds the decode plan;
+* max < m <= capacity binds the prefill plan (block_size_m=64 by default);
+* m < min stays on the parity path with chunk-capped staging buffers;
+* VLLM_EXL3_PREFILL_TRELLIS=0 restores the single-plan parity behavior
+  with full-capacity staging;
+* m above planned capacity raises.
+
+CPU-only; no CUDA, sparkinfer, or exllamav3_ext required.
+"""
+
+import os
+from types import SimpleNamespace
+
+import torch
+
+import vllm.model_executor.layers.quantization.exl3 as exl3_module
+from vllm.model_executor.layers.quantization.exl3 import Exl3MoEMethod
+
+HIDDEN = 128
+INTERMEDIATE = 128
+EXPERTS = 8
+TOPK = 4
+MAX_BATCHED = 256
+
+
+class _FakePlan:
+    def __init__(self, caps):
+        self.caps = caps
+
+    def scratch_specs(self):
+        return (
+            SimpleNamespace(
+                shape=(64,),
+                dtype=torch.uint8,
+                device=self.caps["device"],
+            ),
+        )
+
+
+class _FakeTrellisApi:
+    def __init__(self):
+        self.planned = []
+        self.bound = []
+
+    def Caps(self, **kwargs):
+        return kwargs
+
+    def plan(self, caps):
+        plan = _FakePlan(caps)
+        self.planned.append(caps)
+        return plan
+
+    def bind(self, plan, *, scratch, a, weights, topk_weights, topk_ids):
+        del scratch, weights, topk_weights, topk_ids
+        self.bound.append((plan, int(a.shape[0])))
+        return SimpleNamespace(plan=plan, m=int(a.shape[0]))
+
+    def run(self, *, binding):
+        return torch.zeros((binding.m, HIDDEN), dtype=torch.float32)
+
+
+class _FakeExt:
+    """Parity extension without exl3_moe_fused: chunk loop only."""
+
+    def __init__(self):
+        self.moe_calls = []
+
+    def exl3_moe_max_concurrency(self, device):
+        del device
+        return 2
+
+    def exl3_moe(self, xh, out32, *args):
+        del args
+        self.moe_calls.append((int(xh.shape[0]), int(out32.shape[0])))
+
+
+def _make_layer():
+    return SimpleNamespace(
+        exl3_max_num_batched_tokens=MAX_BATCHED,
+        exl3_hidden_size=HIDDEN,
+        exl3_intermediate_size_per_partition=INTERMEDIATE,
+        local_num_experts=EXPERTS,
+        exl3_trellis_tile_config=(64, 128, 64, 128),
+        exl3_trellis_weights=object(),
+        exl3_pointer_tables=(),
+        exl3_expert_map=torch.arange(EXPERTS, dtype=torch.int64),
+    )
+
+
+def _make_method():
+    method = object.__new__(Exl3MoEMethod)
+    method.quant_config = SimpleNamespace(
+        bits=3.0,
+        rank_sliced_metadata={"tp": 4},
+    )
+    return method
+
+
+class _Harness:
+    def __init__(self, env=None):
+        self._env = dict(env or {})
+        self._saved_env = {}
+        self._saved_capturing = None
+        self.api = _FakeTrellisApi()
+        self.ext = _FakeExt()
+
+    def __enter__(self):
+        for name, value in self._env.items():
+            self._saved_env[name] = os.environ.get(name)
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+        self._saved_loaders = (
+            exl3_module._load_sparkinfer_trellis,
+            exl3_module._load_exl3_ext,
+        )
+        exl3_module._load_sparkinfer_trellis = lambda: self.api
+        exl3_module._load_exl3_ext = lambda: self.ext
+        self._saved_capturing = torch.cuda.is_current_stream_capturing
+        torch.cuda.is_current_stream_capturing = lambda: False
+        self._saved_current_device = torch.cuda.current_device
+        torch.cuda.current_device = lambda: 0
+        exl3_module._RANK_SLICED_RUNTIMES.clear()
+        return self
+
+    def __exit__(self, *exc):
+        (
+            exl3_module._load_sparkinfer_trellis,
+            exl3_module._load_exl3_ext,
+        ) = self._saved_loaders
+        torch.cuda.is_current_stream_capturing = self._saved_capturing
+        torch.cuda.current_device = self._saved_current_device
+        for name, value in self._saved_env.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+        exl3_module._RANK_SLICED_RUNTIMES.clear()
+        return False
+
+
+def _apply(method, layer, m):
+    x = torch.zeros((m, HIDDEN), dtype=torch.bfloat16)
+    weights = torch.zeros((m, TOPK), dtype=torch.float32)
+    ids = torch.zeros((m, TOPK), dtype=torch.int64)
+    return method._apply_rank_sliced(layer, x, weights, ids)
+
+
+def test_dual_plan_construction_and_dispatch():
+    with _Harness() as h:
+        method = _make_method()
+        layer = _make_layer()
+
+        out = _apply(method, layer, 16)
+        assert out.dtype == torch.bfloat16 and out.shape == (16, HIDDEN)
+        # Two plans: decode (32, block 8) then prefill (capacity, block 64).
+        assert [
+            (caps["max_tokens"], caps["block_size_m"]) for caps in h.planned_caps()
+        ] == [(32, 8), (MAX_BATCHED, 64)]
+        assert h.api.bound[-1][0].caps["max_tokens"] == 32
+
+        _apply(method, layer, 200)
+        assert h.api.bound[-1][0].caps["max_tokens"] == MAX_BATCHED
+        assert h.api.bound[-1][1] == 200
+        assert not h.ext.moe_calls
+
+        _apply(method, layer, 2)
+        assert h.ext.moe_calls == [(2, 2)]
+
+        runtime = next(iter(exl3_module._RANK_SLICED_RUNTIMES.values()))
+        assert runtime["parity_rows"] == 128
+        assert runtime["xh"].shape[0] == 128
+        assert runtime["token_sorted"].numel() == 128 * TOPK
+
+        # m above the scheduler capacity re-keys the runtime and re-plans
+        # at the larger capacity (eager-only; capture remains guarded).
+        _apply(method, layer, MAX_BATCHED + 1)
+        assert h.api.bound[-1][0].caps["max_tokens"] == MAX_BATCHED + 1
+        assert h.planned_caps()[-1]["max_tokens"] == MAX_BATCHED + 1
+
+
+def test_prefill_trellis_disabled_restores_parity():
+    with _Harness(env={"VLLM_EXL3_PREFILL_TRELLIS": "0"}) as h:
+        method = _make_method()
+        layer = _make_layer()
+
+        _apply(method, layer, 200)
+        # Single decode plan only; large m runs the parity chunk loop.
+        assert [
+            (caps["max_tokens"], caps["block_size_m"]) for caps in h.planned_caps()
+        ] == [(32, 8)]
+        assert not h.api.bound
+        assert h.ext.moe_calls == [(128, 128), (72, 72)]
+
+        runtime = next(iter(exl3_module._RANK_SLICED_RUNTIMES.values()))
+        assert runtime["prefill_plan"] is None
+        assert runtime["parity_rows"] == MAX_BATCHED
+        assert runtime["xh"].shape[0] == MAX_BATCHED
+
+
+def test_prefill_block_m_env_override():
+    with _Harness(env={"VLLM_EXL3_PREFILL_BLOCK_M": "48"}) as h:
+        method = _make_method()
+        layer = _make_layer()
+        _apply(method, layer, 40)
+        assert h.planned_caps()[-1]["block_size_m"] == 48
+        assert h.api.bound[-1][0].caps["max_tokens"] == MAX_BATCHED
+
+
+def test_parity_path_guarded_against_capture():
+    with _Harness() as h:
+        method = _make_method()
+        layer = _make_layer()
+        # Plan eagerly, then flip into "capturing" state.
+        _apply(method, layer, 16)
+        torch.cuda.is_current_stream_capturing = lambda: True
+        # Both trellis plans stay capture-safe.
+        _apply(method, layer, 16)
+        _apply(method, layer, 200)
+        assert h.api.bound[-1][1] == 200
+        # The eager parity path must refuse to be recorded.
+        try:
+            _apply(method, layer, 2)
+        except RuntimeError as err:
+            assert "capture" in str(err)
+        else:
+            raise AssertionError("parity path must raise during capture")
+
+
+def _install_planned_caps_helper():
+    def planned_caps(self):
+        return self.api.planned
+
+    _Harness.planned_caps = planned_caps
+
+
+_install_planned_caps_helper()
+
+
+if __name__ == "__main__":
+    test_dual_plan_construction_and_dispatch()
+    test_prefill_trellis_disabled_restores_parity()
+    test_prefill_block_m_env_override()
+    test_parity_path_guarded_against_capture()
+    print("EXL3_PREFILL_PLAN_TESTS_OK")

--- a/tests/v1/attention/test_sparse_mla_backends.py
+++ b/tests/v1/attention/test_sparse_mla_backends.py
@@ -224,6 +224,60 @@ def test_b12x_sparse_dcp1_metadata_uses_exact_gpu_positions() -> None:
     assert result.nsa_cache_seqlens is None
 
 
+def test_b12x_sparse_dcp_metadata_uses_exact_gpu_positions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from vllm.distributed import parallel_state
+
+    class FakeDCPGroup:
+        rank_in_group = 1
+
+    monkeypatch.setattr(parallel_state, "get_dcp_group", lambda: FakeDCPGroup())
+
+    batch_spec = BatchSpec(seq_lens=[5], query_lens=[2])
+    hf_config = SimpleNamespace(
+        index_topk=512,
+        kv_lora_rank=512,
+        qk_nope_head_dim=512,
+        qk_rope_head_dim=64,
+        v_head_dim=512,
+    )
+    model_config = SimpleNamespace(
+        hf_config=hf_config,
+        hf_text_config=hf_config,
+    )
+    vllm_config = SimpleNamespace(
+        model_config=model_config,
+        parallel_config=SimpleNamespace(
+            decode_context_parallel_size=2,
+            cp_kv_cache_interleave_size=1,
+        ),
+        scheduler_config=SimpleNamespace(
+            max_num_batched_tokens=4,
+            max_num_seqs=1,
+        ),
+    )
+    metadata = create_common_attn_metadata(
+        batch_spec,
+        block_size=64,
+        device=torch.device(DEVICE_TYPE),
+    )
+    metadata.positions = torch.tensor([3, 4], dtype=torch.int64, device=DEVICE_TYPE)
+    metadata.seq_lens_cpu_upper_bound = torch.tensor([500], dtype=torch.int32)
+    builder = B12xMLASparseMetadataBuilder(
+        SimpleNamespace(block_size=64),
+        ["placeholder"],
+        vllm_config,
+        torch.device(DEVICE_TYPE),
+    )
+
+    result = builder.build(0, metadata)
+
+    assert result.cache_seq_lens_per_token.tolist() == [2, 2]
+    assert result.req_id_per_token is not None
+    assert result.req_id_per_token.tolist() == [0, 0]
+
+
 @pytest.mark.parametrize(
     ("dcp_world_size", "output_physical_slots", "expected_output"),
     [
@@ -296,6 +350,7 @@ def test_b12x_sparse_glm_uses_8_head_alignment(
         "_prewarm_extend_kernels_once",
         lambda self, max_batched: None,
     )
+    monkeypatch.setenv("VLLM_B12X_MLA_SPEC_EXTEND_AS_DECODE", "1")
 
     topk_indices = torch.zeros((2, 2048), dtype=torch.int32, device=DEVICE_TYPE)
     impl = B12xMLASparseImpl(
@@ -324,9 +379,12 @@ def test_b12x_sparse_glm_uses_8_head_alignment(
     assert impl._extend_plan.caps.num_q_heads == kernel_num_heads
 
     captured: dict[str, tuple[int, ...]] = {}
+    decode_calls = 0
     real_decode_forward = impl._sparse_mla_decode_forward
 
     def fake_decode_forward(*, binding, **kwargs):
+        nonlocal decode_calls
+        decode_calls += 1
         captured["q_shape"] = tuple(binding.q.shape)
         if num_heads == 8:
             return real_decode_forward(binding=binding, **kwargs)
@@ -353,6 +411,7 @@ def test_b12x_sparse_glm_uses_8_head_alignment(
 
     output, lse = impl.forward_mqa((q_nope, q_rope), kv_cache, metadata, layer=None)
     assert captured["q_shape"] == (1, kernel_num_heads, 576)
+    assert decode_calls == 1
     assert output.shape == (1, num_heads, 512)
     assert lse is None
 
@@ -378,6 +437,7 @@ def test_b12x_sparse_glm_uses_8_head_alignment(
         assert output.shape == (2, 8, 512)
         assert torch.isfinite(output).all()
         assert lse is None
+        assert decode_calls == 1
 
 
 def test_b12x_sparse_nvfp4_uses_kernel_format_not_scratch_caps(

--- a/tests/v1/core/test_contiguous_kv_packing.py
+++ b/tests/v1/core/test_contiguous_kv_packing.py
@@ -31,25 +31,28 @@ def _make_mla_spec(page_size: int, block_size: int = 256) -> MLAAttentionSpec:
         cache_dtype_str="fp8_ds_mla",
         model_version="deepseek_v4",
         alignment=576,
+        indexes_kv_by_block_stride=True,
     )
 
 
-def _make_full_spec() -> FullAttentionSpec:
+def _make_full_spec(*, indexes_kv_by_block_stride: bool = True) -> FullAttentionSpec:
     return FullAttentionSpec(
         block_size=16,
         num_kv_heads=2,
         head_size=64,
         dtype=torch.float16,
+        indexes_kv_by_block_stride=indexes_kv_by_block_stride,
     )
 
 
-def _make_sw_spec() -> SlidingWindowSpec:
+def _make_sw_spec(*, indexes_kv_by_block_stride: bool = True) -> SlidingWindowSpec:
     return SlidingWindowSpec(
         block_size=16,
         num_kv_heads=2,
         head_size=64,
         dtype=torch.float16,
         sliding_window=128,
+        indexes_kv_by_block_stride=indexes_kv_by_block_stride,
     )
 
 
@@ -212,6 +215,45 @@ class TestInterleavedPacking:
                 block_stride=page_size * 2,
             ),
         ]
+
+    def test_enable_cross_layers_falls_back_for_native_layout_backend(self):
+        full = _make_full_spec()
+        sw = _make_sw_spec(indexes_kv_by_block_stride=False)
+        page_size = full.page_size_bytes
+        groups = [
+            KVCacheGroupSpec(["full.0", "full.1"], full),
+            KVCacheGroupSpec(["sw.0", "sw.1"], sw),
+        ]
+
+        config = get_kv_cache_config_from_groups(
+            _mock_vllm_config({"enable_cross_layers_blocks": "True"}),
+            groups,
+            available_memory=page_size * 2 * 32,
+        )
+
+        assert config.num_blocks == 32
+        assert [tensor.block_stride for tensor in config.kv_cache_tensors] == [0, 0]
+        assert sum(tensor.size for tensor in config.kv_cache_tensors) == (
+            page_size * 2 * 32
+        )
+
+    def test_native_layout_backend_rejects_padded_pages(self):
+        full = _make_full_spec(indexes_kv_by_block_stride=False)
+        padded = FullAttentionSpec(
+            block_size=full.block_size,
+            num_kv_heads=full.num_kv_heads,
+            head_size=full.head_size,
+            dtype=full.dtype,
+            page_size_padded=full.page_size_bytes * 2,
+            indexes_kv_by_block_stride=False,
+        )
+
+        with pytest.raises(ValueError, match="requires native contiguous KV pages"):
+            get_kv_cache_config_from_groups(
+                _mock_vllm_config(),
+                [KVCacheGroupSpec(["full.0"], padded)],
+                available_memory=padded.page_size_bytes * 32,
+            )
 
     def test_single_group_attention_keeps_unpacked_layout(self):
         spec = _make_full_spec()

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -4,7 +4,7 @@ import hashlib
 import importlib
 from collections.abc import Callable
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 
 import pytest
 import torch
@@ -1683,6 +1683,26 @@ def test_resolve_kv_cache_block_sizes_mixed_dcp_replicated_groups():
     assert hash_block_size == 64
 
 
+def test_attention_block_table_width_respects_dcp_replication():
+    vllm_config = SimpleNamespace(
+        parallel_config=SimpleNamespace(
+            decode_context_parallel_size=4,
+            prefill_context_parallel_size=1,
+        )
+    )
+    common = dict(
+        block_size=64,
+        num_kv_heads=1,
+        head_size=128,
+        dtype=torch.float32,
+    )
+    sharded = MLAAttentionSpec(**common)
+    replicated = MLAAttentionSpec(**common, dcp_replicated=True)
+
+    assert sharded.max_num_blocks_per_req(vllm_config, 135_500) == 530
+    assert replicated.max_num_blocks_per_req(vllm_config, 135_500) == 2_118
+
+
 def test_dsv4_engine_capacity_uses_worker_kv_cache_config():
     from vllm.v1.engine.core import EngineCore
 
@@ -2259,6 +2279,94 @@ def test_group_and_unify_kv_cache_specs_mixed_page_size_groups():
     assert len(grouped) == 2
     layer_names = {name for g in grouped for name in g.kv_cache_specs}
     assert layer_names == {"mla.0", "mla.1", "swa.0"}
+
+
+def test_group_and_unify_kv_cache_specs_replicated_mla_draft():
+    target_mla = new_mla_spec()
+    target_indexer = MLAAttentionSpec(
+        block_size=16,
+        num_kv_heads=1,
+        head_size=128,
+        dtype=torch.float32,
+    )
+    draft_mla = MLAAttentionSpec(
+        block_size=16,
+        num_kv_heads=1,
+        head_size=320,
+        dtype=torch.float32,
+        dcp_replicated=True,
+    )
+    draft_indexer = MLAAttentionSpec(
+        block_size=16,
+        num_kv_heads=1,
+        head_size=96,
+        dtype=torch.float32,
+        dcp_replicated=True,
+    )
+    specs = {
+        "model.layers.0.self_attn": target_mla,
+        "model.layers.0.self_attn.indexer.k_cache": target_indexer,
+        "model.layers.79.self_attn": draft_mla,
+        "model.layers.79.self_attn.indexer.k_cache": draft_indexer,
+    }
+
+    grouped = group_and_unify_kv_cache_specs(specs)
+
+    assert grouped is not None
+    assert len(grouped) == 2
+    assert set(grouped[0].kv_cache_specs) == {
+        "model.layers.0.self_attn",
+        "model.layers.0.self_attn.indexer.k_cache",
+    }
+    assert set(grouped[1].kv_cache_specs) == {
+        "model.layers.79.self_attn",
+        "model.layers.79.self_attn.indexer.k_cache",
+    }
+    assert all(not spec.dcp_replicated for spec in grouped[0].kv_cache_specs.values())
+    assert all(spec.dcp_replicated for spec in grouped[1].kv_cache_specs.values())
+
+    cache_groups = kv_cache_utils._get_kv_cache_groups_uniform_groups(grouped)
+    assert len(cache_groups) == 2
+
+    draft_group_spec = cache_groups[1].kv_cache_spec
+    assert isinstance(draft_group_spec, UniformTypeKVCacheSpecs)
+    assert all(
+        spec.page_size_padded is None
+        for spec in draft_group_spec.kv_cache_specs.values()
+    )
+
+    buckets = kv_cache_utils._bucket_layers_by_page_size(cache_groups)
+    bytes_per_block = sum(ps * len(slots) for ps, slots in buckets.items())
+    vllm_config = cast(
+        VllmConfig,
+        SimpleNamespace(
+            cache_config=SimpleNamespace(num_gpu_blocks_override=None),
+            kv_transfer_config=None,
+            model_config=SimpleNamespace(max_model_len=16),
+            parallel_config=SimpleNamespace(
+                decode_context_parallel_size=1,
+                prefill_context_parallel_size=1,
+            ),
+        ),
+    )
+    cache_config = kv_cache_utils.get_kv_cache_config_from_groups(
+        vllm_config,
+        cache_groups,
+        available_memory=bytes_per_block * 8,
+    )
+    assert cache_config.num_blocks == 8
+    assert all(tensor.block_stride == 0 for tensor in cache_config.kv_cache_tensors)
+    assert sum(tensor.size for tensor in cache_config.kv_cache_tensors) == (
+        bytes_per_block * 8
+    )
+    request_blocks = sum(
+        group.kv_cache_spec.max_memory_usage_pages(vllm_config)
+        for group in cache_groups
+        if isinstance(group.kv_cache_spec, UniformTypeKVCacheSpecs)
+    )
+    assert kv_cache_utils._max_memory_usage_bytes_from_groups(
+        vllm_config, cache_groups
+    ) == (bytes_per_block * request_blocks)
 
 
 def test_get_kv_cache_spec_kind_prefers_specific_attention_subclasses():

--- a/tests/v1/structured_output/test_reasoning_structured_output.py
+++ b/tests/v1/structured_output/test_reasoning_structured_output.py
@@ -241,6 +241,116 @@ class TestReasoningStructuredOutput:
         assert structured_req.reasoning_ended is True
         assert result is True
 
+    def test_should_advance_reasoning_just_ended_with_spec_decode_json(
+        self,
+        manager_with_reasoner,
+        mock_request_with_structured_output,
+    ):
+        """When reasoning ends this step under speculative decoding, advance
+        immediately for every structured type, not just structural tags: the
+        step may already contain accepted post-marker content, and deferring
+        leaves the grammar one token behind the sampled stream (#48228)."""
+        structured_req = mock_request_with_structured_output.structured_output_request
+        structured_req.reasoning_ended = False
+        structured_req.structured_output_key = (
+            StructuredOutputOptions.JSON,
+            '{"type": "object"}',
+        )
+        reasoner = MockReasoner(tokenizer=Mock())
+        reasoner.is_reasoning_end_streaming.return_value = True
+        structured_req.reasoner = reasoner
+
+        manager_with_reasoner.vllm_config.speculative_config = Mock()
+
+        result = manager_with_reasoner.should_advance(
+            mock_request_with_structured_output
+        )
+
+        assert structured_req.reasoning_ended is True
+        assert result is True
+        assert isinstance(structured_req.reasoning_end_token_index, int)
+
+    def test_should_advance_detects_end_from_new_token_ids(
+        self,
+        manager_with_reasoner,
+        mock_request_with_structured_output,
+    ):
+        """new_token_ids is the authoritative step delta: with speculative
+        decoding, num_computed_tokens is pre-incremented past accepted draft
+        tokens, so the counter-derived window misses the end marker (#34650)."""
+        end_token_id, content_token_id = 42, 99
+        request = mock_request_with_structured_output
+        structured_req = request.structured_output_request
+        structured_req.reasoning_ended = False
+        reasoner = MockReasoner(tokenizer=Mock())
+        reasoner.is_reasoning_end_streaming.side_effect = (
+            lambda input_ids, delta_ids: end_token_id in list(delta_ids)
+        )
+        structured_req.reasoner = reasoner
+
+        request.all_token_ids = request.prompt_token_ids + [
+            7,
+            end_token_id,
+            content_token_id,
+        ]
+        # Spec decode pre-incremented past the accepted tokens: the
+        # counter-derived window all_token_ids[num_computed_tokens:] is empty.
+        request.num_computed_tokens = len(request.all_token_ids)
+        request.num_output_placeholders = 0
+
+        # The counter fallback misses the marker...
+        assert manager_with_reasoner.should_advance(request) is False
+        assert structured_req.reasoning_ended is False
+
+        # ...the explicit step delta does not (no spec config here, so the
+        # advance itself is still deferred to the next step).
+        result = manager_with_reasoner.should_advance(
+            request, [end_token_id, content_token_id]
+        )
+        assert structured_req.reasoning_ended is True
+        assert result is False
+
+    def test_should_advance_straddle_step_trims_and_advances_same_step(
+        self,
+        manager_with_reasoner,
+        mock_request_with_structured_output,
+    ):
+        """A speculative step accepting [</think>, "{"] must advance the
+        grammar with exactly the post-marker content in the same step;
+        otherwise the next bitmask is computed from the un-advanced grammar
+        and re-forces the content token, doubling it in the output (#48228)."""
+        end_token_id, content_token_id = 42, 99
+        request = mock_request_with_structured_output
+        structured_req = request.structured_output_request
+        structured_req.reasoning_ended = False
+        structured_req.structured_output_key = (
+            StructuredOutputOptions.JSON,
+            '{"type": "object"}',
+        )
+        reasoner = MockReasoner(tokenizer=Mock())
+        reasoner.is_reasoning_end_streaming.side_effect = (
+            lambda input_ids, delta_ids: end_token_id in list(delta_ids)
+        )
+        structured_req.reasoner = reasoner
+        manager_with_reasoner.vllm_config.speculative_config = Mock()
+
+        new_token_ids = [end_token_id, content_token_id]
+        request.all_token_ids = request.prompt_token_ids + [
+            7,
+            end_token_id,
+            content_token_id,
+        ]
+        request.num_computed_tokens = len(request.all_token_ids)
+        request.num_output_placeholders = 0
+
+        assert manager_with_reasoner.should_advance(request, new_token_ids) is True
+        assert structured_req.reasoning_end_token_index == (
+            len(request.all_token_ids) - 2
+        )
+        assert manager_with_reasoner.trim_reasoning_for_advance(
+            request, new_token_ids
+        ) == [content_token_id]
+
     def test_should_advance_reasoning_already_ended(
         self,
         manager_with_reasoner,

--- a/tests/v1/worker/test_workspace.py
+++ b/tests/v1/worker/test_workspace.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+import vllm.v1.worker.workspace as workspace
+
+
+def test_workspace_lanes_do_not_alias_and_restore_context(monkeypatch) -> None:
+    ubatch_id = 0
+    monkeypatch.setattr(workspace, "dbo_current_ubatch_id", lambda: ubatch_id)
+    manager = workspace.WorkspaceManager(
+        torch.device("cpu"), num_ubatches=2, num_lanes=2
+    )
+
+    (target,) = manager.get_simultaneous(((16,), torch.uint8))
+    with workspace.use_workspace_lane(1):
+        (draft,) = manager.get_simultaneous(((16,), torch.uint8))
+        (draft_reused,) = manager.get_simultaneous(((8,), torch.uint8))
+
+    (target_reused,) = manager.get_simultaneous(((8,), torch.uint8))
+
+    assert target.data_ptr() != draft.data_ptr()
+    assert draft.data_ptr() == draft_reused.data_ptr()
+    assert target.data_ptr() == target_reused.data_ptr()
+
+
+def test_workspace_lanes_compose_with_ubatches(monkeypatch) -> None:
+    active_ubatch = [0]
+    monkeypatch.setattr(workspace, "dbo_current_ubatch_id", lambda: active_ubatch[0])
+    manager = workspace.WorkspaceManager(
+        torch.device("cpu"), num_ubatches=2, num_lanes=2
+    )
+
+    pointers = set()
+    for ubatch_id in range(2):
+        active_ubatch[0] = ubatch_id
+        for lane in range(2):
+            with workspace.use_workspace_lane(lane):
+                (buffer,) = manager.get_simultaneous(((16,), torch.uint8))
+                pointers.add(buffer.data_ptr())
+
+    assert len(pointers) == 4
+
+
+def test_workspace_lane_validation() -> None:
+    manager = workspace.WorkspaceManager(torch.device("cpu"), num_lanes=1)
+
+    with (
+        pytest.raises(ValueError, match="non-negative"),
+        workspace.use_workspace_lane(-1),
+    ):
+        pass
+
+    with (
+        workspace.use_workspace_lane(1),
+        pytest.raises(RuntimeError, match="is not configured"),
+    ):
+        manager.get_simultaneous(((1,), torch.uint8))
+
+    with pytest.raises(ValueError, match="at least one"):
+        workspace.WorkspaceManager(torch.device("cpu"), num_lanes=0)

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -1052,6 +1052,10 @@ class ModelConfig:
                 "awq_marlin",
                 "inc",
                 "moe_wna16",
+                # Rank-sliced EXL3 checkpoints retain a ModelOpt dispatch tag
+                # for backward compatibility, so EXL3 must inspect metadata
+                # before the ModelOpt overrides claim them.
+                "exl3",
                 # Must precede modelopt_fp4: hybrid checkpoints are
                 # modelopt-tagged NVFP4 plus a hybrid_bit_map.
                 "nvfp4_nf3_hybrid",

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -80,6 +80,20 @@ def _parse_byte_size(value: str) -> int:
     return int(value)
 
 
+def _b12x_pcie_oneshot_limits() -> tuple[int, int, int]:
+    allreduce_max_size = _parse_byte_size(envs.VLLM_PCIE_ONESHOT_ALLREDUCE_MAX_SIZE)
+    fused_max_size = _parse_byte_size(
+        envs.VLLM_PCIE_ONESHOT_FUSED_ADD_RMS_NORM_MAX_SIZE
+    )
+    if allreduce_max_size < 0 or fused_max_size < 0:
+        raise ValueError("b12x PCIe oneshot size limits must be non-negative")
+    # The pool only dispatches tensors within these limits. Reserving the
+    # scheduler's full prefill tensor capacity per stream wastes hundreds of
+    # MiB once target and draft graphs use independent channels.
+    buffer_size = max(allreduce_max_size, fused_max_size, 16)
+    return allreduce_max_size, fused_max_size, buffer_size
+
+
 @lru_cache(maxsize=1)
 def _load_b12x_pcie_oneshot_pool() -> Any | None:
     try:
@@ -424,9 +438,8 @@ class CustomAllreduce:
                     "sparkinfer.comm.pcie.OneshotAllReducePool is unavailable."
                 )
                 return
-            # The largest allreduce the model can issue (prefill chunk x
-            # hidden) determines buffer capacity. Dispatch crossovers come
-            # from envs below so startup does not benchmark the serving GPUs.
+            # DMA must accommodate the largest scheduled prefill tensor. The
+            # oneshot pool only needs its much smaller dispatch cutoffs.
             try:
                 from vllm.config import get_current_vllm_config
 
@@ -446,6 +459,11 @@ class CustomAllreduce:
                 )
             pcie_buffer_size = max_num_batched_tokens * model_hidden_size * 2
             pcie_single_channel = envs.VLLM_PCIE_ONESHOT_SINGLE_CHANNEL
+            (
+                self._pcie_allreduce_max_size,
+                self._pcie_fused_add_rms_norm_max_size,
+                pcie_oneshot_buffer_size,
+            ) = _b12x_pcie_oneshot_limits()
             if self.nccl_group is None:
                 logger.warning(
                     "Custom allreduce is disabled because b12x PCIe oneshot "
@@ -453,8 +471,6 @@ class CustomAllreduce:
                 )
                 return
             self.max_size = pcie_buffer_size
-            self._pcie_allreduce_max_size = 0
-            self._pcie_fused_add_rms_norm_max_size = 0
             self.rank = rank
             self.world_size = world_size
             self.fully_connected = False
@@ -464,8 +480,8 @@ class CustomAllreduce:
                 pcie_runtime = pool_cls.from_exchange_group(
                     exchange_group=self.nccl_group,
                     device=self.device,
-                    eager_buffer_bytes=pcie_buffer_size,
-                    max_size=pcie_buffer_size,
+                    eager_buffer_bytes=pcie_oneshot_buffer_size,
+                    max_size=pcie_oneshot_buffer_size,
                     single_channel=pcie_single_channel,
                 )
                 pcie_runtime.for_stream()
@@ -544,12 +560,6 @@ class CustomAllreduce:
                     self._pcie_dma = dma
                     logger.debug("b12x PCIe DMA allreduce wire mode: %s", dma.wire_mode)
 
-            self._pcie_allreduce_max_size = _parse_byte_size(
-                envs.VLLM_PCIE_ONESHOT_ALLREDUCE_MAX_SIZE
-            )
-            self._pcie_fused_add_rms_norm_max_size = _parse_byte_size(
-                envs.VLLM_PCIE_ONESHOT_FUSED_ADD_RMS_NORM_MAX_SIZE
-            )
             if rank == 0:
                 logger.info(
                     "Configured b12x PCIe crossovers: "
@@ -562,12 +572,14 @@ class CustomAllreduce:
             logger.debug(
                 "Using b12x PCIe oneshot allreduce backend "
                 "(world_size=%d, allreduce_max_size=%d, "
-                "fused_add_rms_norm_max_size=%d, buffer_size=%d, "
+                "fused_add_rms_norm_max_size=%d, oneshot_buffer_size=%d, "
+                "dma_buffer_size=%d, "
                 "single_channel=%s).",
                 world_size,
                 self._pcie_allreduce_max_size,
                 self._pcie_fused_add_rms_norm_max_size,
-                self.max_size,
+                pcie_oneshot_buffer_size,
+                pcie_buffer_size,
                 pcie_single_channel,
             )
             return

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -1532,10 +1532,20 @@ def graph_capture(
         if _DCP is not None and get_dcp_group().world_size > 1
         else nullcontext()
     )
+    if _DCP is not None and get_dcp_group().world_size > 1:
+        # Import locally to avoid making distributed initialization depend on
+        # attention modules. The helper is a no-op until DCP warmup creates a
+        # B12X pool for this process group.
+        from vllm.v1.attention.ops.dcp_alltoall import capture_b12x_dcp_a2a
+
+        maybe_b12x_dcp_capture = capture_b12x_dcp_a2a(get_dcp_group(), context.stream)
+    else:
+        maybe_b12x_dcp_capture = nullcontext()
     with (
         get_tp_group().graph_capture(context),
         get_pp_group().graph_capture(context),
         maybe_dcp_capture,
+        maybe_b12x_dcp_capture,
     ):
         yield context
 

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -230,7 +230,7 @@ if TYPE_CHECKING:
     VLLM_PCIE_ONESHOT_ALLREDUCE_MAX_SIZE: str = "84KB"
     VLLM_PCIE_ONESHOT_FUSED_ADD_RMS_NORM_MAX_SIZE: str = "84KB"
     VLLM_PCIE_ONESHOT_ALLOW_CROSS_NUMA: bool = True
-    VLLM_PCIE_ONESHOT_SINGLE_CHANNEL: bool = True
+    VLLM_PCIE_ONESHOT_SINGLE_CHANNEL: bool = False
     VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE: int = 394 * 1024 * 1024
     VLLM_XGRAMMAR_CACHE_MB: int = 0
     VLLM_REGEX_COMPILATION_TIMEOUT_S: int = 5
@@ -1818,9 +1818,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_PCIE_ONESHOT_ALLOW_CROSS_NUMA": lambda: (
         os.getenv("VLLM_PCIE_ONESHOT_ALLOW_CROSS_NUMA", "1") != "0"
     ),
-    # Use a single channel for the b12x PCIe oneshot allreduce.
+    # Reuse one b12x PCIe oneshot channel across CUDA streams. This saves
+    # buffers but is unsafe when target and draft graphs replay concurrently.
     "VLLM_PCIE_ONESHOT_SINGLE_CHANNEL": lambda: (
-        os.getenv("VLLM_PCIE_ONESHOT_SINGLE_CHANNEL", "1").strip().lower()
+        os.getenv("VLLM_PCIE_ONESHOT_SINGLE_CHANNEL", "0").strip().lower()
         not in ("", "0", "false", "no", "off")
     ),
     # Control the workspace buffer size for the FlashInfer backend.

--- a/vllm/model_executor/layers/fused_moe/routed_experts.py
+++ b/vllm/model_executor/layers/fused_moe/routed_experts.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import re
 from collections.abc import Callable, Iterable
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Literal, cast, overload
@@ -36,6 +37,10 @@ if TYPE_CHECKING:
 
 
 logger = init_logger(__name__)
+
+# Per-expert checkpoint names carry an explicit expert index ("experts.{i}.");
+# fused pre-fused-checkpoint entries never do (see build_expert_params_mapping).
+_PER_EXPERT_IDX_RE = re.compile(r"experts\.\d+\.")
 
 
 class FusedMoeWeightScaleSupported(Enum):
@@ -943,14 +948,24 @@ class RoutedExperts(PluggableLayer):
         unpadded_hidden = self.moe_config.hidden_dim_unpadded
         for expert_name, loaded_weight in weights:
             qual_name = f"{self.layer_name}.{expert_name}"
-            # Fused expert weights can be identified by their 3D tensors
-            is_fused = loaded_weight.dim() == 3
+            # Fused expert weights are 3D tensors matched against a *fused*
+            # mapping entry. Rank alone is not decisive: per-expert tensors of
+            # some quantized formats (e.g. EXL3 trellis [K/16, N/16, 16*bpw])
+            # are also rank-3 and must not be routed down the fused
+            # transpose/chunk path. Fused entries are exactly those whose
+            # weight_name carries no per-expert index.
+            is_fused_rank = loaded_weight.dim() == 3
+            is_fused = False
             matched = False
             for param_name, weight_name, expert_id, shard_id in expert_mapping:
                 if weight_name not in qual_name:
                     if matched and is_fused:
                         break
                     continue
+                is_fused = (
+                    is_fused_rank
+                    and _PER_EXPERT_IDX_RE.search(weight_name) is None
+                )
                 matched = True
                 weight_name = qual_name.replace(weight_name, param_name)
                 param_name = weight_name.removeprefix(f"{self.layer_name}.")

--- a/vllm/model_executor/layers/quantization/__init__.py
+++ b/vllm/model_executor/layers/quantization/__init__.py
@@ -14,6 +14,7 @@ QuantizationMethods = Literal[
     "auto_awq",
     "fp8",
     "fbgemm_fp8",
+    "exl3",
     "fp_quant",
     "modelopt",
     "modelopt_fp4",
@@ -123,6 +124,7 @@ def get_quantization_config(quantization: str) -> type[QuantizationConfig]:
         CompressedTensorsConfig,
     )
     from .experts_int8 import ExpertsInt8Config
+    from .exl3 import Exl3Config
     from .fbgemm_fp8 import FBGEMMFp8Config
     from .fp8 import Fp8Config
     from .fp_quant import FPQuantConfig
@@ -146,6 +148,7 @@ def get_quantization_config(quantization: str) -> type[QuantizationConfig]:
         "auto_awq": AutoAWQConfig,
         "fp8": Fp8Config,
         "fbgemm_fp8": FBGEMMFp8Config,
+        "exl3": Exl3Config,
         "fp_quant": FPQuantConfig,
         "modelopt": ModelOptFp8Config,
         "modelopt_fp4": ModelOptNvFp4Config,

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -1,0 +1,1090 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""EXL3 (ExLlamaV3 trellis) quantization support.
+
+This is deliberately the correctness backend.  Every logical checkpoint
+matrix is dispatched independently through ``exllamav3_ext.exl3_gemm``.  In
+particular, vLLM's packed QKV and gate/up modules are *not* treated as one EXL3
+matrix: each source matrix owns its own Hadamard vectors and codebook marker.
+
+The extension is imported lazily on the first CUDA execution.  Importing this
+module, parsing checkpoint metadata, or compiling it with ``py_compile`` does
+not load the extension or initialize CUDA.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import importlib
+import os
+import sys
+from typing import TYPE_CHECKING, Any
+
+import torch
+from transformers import PretrainedConfig
+
+from vllm.distributed import (
+    get_tensor_model_parallel_rank,
+    get_tensor_model_parallel_world_size,
+)
+from vllm.config import get_current_vllm_config_or_none
+from vllm.logger import init_logger
+from vllm.model_executor.layers.fused_moe import (
+    FusedMoEMethodBase,
+    FusedMoEQuantConfig,
+    MoEActivation,
+    RoutedExperts,
+)
+from vllm.model_executor.layers.linear import (
+    LinearBase,
+    LinearMethodBase,
+    QKVParallelLinear,
+    ReplicatedLinear,
+    UnquantizedLinearMethod,
+)
+from vllm.model_executor.layers.quantization.base_config import (
+    QuantizationConfig,
+    QuantizeMethodBase,
+)
+from vllm.model_executor.parameter import BasevLLMParameter
+from vllm.transformers_utils.repo_utils import get_hf_file_to_dict
+
+if TYPE_CHECKING:
+    from vllm.model_executor.layers.fused_moe.runner.shared_experts import (
+        SharedExperts,
+    )
+    from vllm.model_executor.models.utils import WeightsMapper
+
+logger = init_logger(__name__)
+
+_MCG_SENTINEL = 0xCBAC1FED
+_MUL1_SENTINEL = 0x83DCD12D
+_HADAMARD_BLOCK = 128
+_EXL3_EXT: Any | None = None
+
+ShardId = str | int | tuple[int, ...] | None
+
+
+def _load_exl3_ext() -> Any:
+    """Load the existing ExLlamaV3 extension only from an actual CUDA call."""
+
+    global _EXL3_EXT
+    if _EXL3_EXT is not None:
+        return _EXL3_EXT
+
+    shim = os.environ.get("VLLM_EXL3_ABI_SHIM")
+    if shim:
+        ctypes.CDLL(shim, mode=ctypes.RTLD_GLOBAL)
+
+    ext_path = os.environ.get("VLLM_EXL3_EXT_PATH")
+    if ext_path:
+        search_dir = ext_path if os.path.isdir(ext_path) else os.path.dirname(ext_path)
+        if search_dir and search_dir not in sys.path:
+            sys.path.insert(0, search_dir)
+
+    try:
+        ext = importlib.import_module("exllamav3_ext")
+    except Exception as exc:
+        hint = (
+            "Set VLLM_EXL3_EXT_PATH to the directory containing "
+            "exllamav3_ext*.so (and VLLM_EXL3_ABI_SHIM when the local "
+            "PyTorch ABI shim is required)."
+        )
+        raise RuntimeError(f"Unable to import exllamav3_ext. {hint}") from exc
+
+    if not hasattr(ext, "exl3_gemm"):
+        raise RuntimeError(
+            "The imported exllamav3_ext does not export exl3_gemm; rebuild the "
+            "track_a_retile extension used by this overlay."
+        )
+    _EXL3_EXT = ext
+    return ext
+
+
+@torch.library.custom_op(
+    "vllm::exl3_gemm",
+    mutates_args=(),
+    device_types="cuda",
+)
+def _exl3_gemm(
+    x: torch.Tensor,
+    trellis: torch.Tensor,
+    suh: torch.Tensor,
+    svh: torch.Tensor,
+    mcg: bool,
+    mul1: bool,
+) -> torch.Tensor:
+    """Opaque torch op around the bit-faithful ExLlamaV3 dense call."""
+
+    ext = _load_exl3_ext()
+    output = torch.empty(
+        (x.shape[0], trellis.shape[1] * 16),
+        dtype=torch.float16,
+        device=x.device,
+    )
+    x_had = torch.empty_like(x)
+    ext.exl3_gemm(
+        x,
+        trellis,
+        output,
+        suh,
+        x_had,
+        svh,
+        -1,
+        mcg,
+        mul1,
+        0,
+    )
+    return output
+
+
+@_exl3_gemm.register_fake
+def _exl3_gemm_fake(
+    x: torch.Tensor,
+    trellis: torch.Tensor,
+    suh: torch.Tensor,
+    svh: torch.Tensor,
+    mcg: bool,
+    mul1: bool,
+) -> torch.Tensor:
+    del suh, svh, mcg, mul1
+    return torch.empty(
+        (x.shape[0], trellis.shape[1] * 16),
+        dtype=torch.float16,
+        device=x.device,
+    )
+
+
+class Exl3Config(QuantizationConfig):
+    """Configuration for modern and legacy EXL3 trellis checkpoints."""
+
+    def __init__(
+        self,
+        bits: float | None = None,
+        head_bits: float | None = None,
+        codebook: str | None = None,
+        version: str | None = None,
+        tensor_storage: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__()
+        self.bits = bits
+        self.head_bits = head_bits
+        self.codebook = codebook
+        self.version = version
+        self.tensor_storage = tensor_storage or {}
+        self._eager_checked = False
+
+    def get_name(self) -> str:
+        return "exl3"
+
+    def get_supported_act_dtypes(self) -> list[torch.dtype]:
+        # The kernel boundary is always fp16.  BF16 model activations are cast
+        # in apply() and converted back after the fp16 bias addition.
+        return [torch.float16, torch.bfloat16]
+
+    @classmethod
+    def get_min_capability(cls) -> int:
+        return 80
+
+    @staticmethod
+    def get_config_filenames() -> list[str]:
+        return ["quantization_config.json"]
+
+    @classmethod
+    def from_config(cls, config: dict[str, Any]) -> "Exl3Config":
+        return cls(
+            bits=config.get("bits"),
+            head_bits=config.get("head_bits"),
+            codebook=config.get("codebook"),
+            version=config.get("version"),
+            tensor_storage=config.get("tensor_storage"),
+        )
+
+    def maybe_update_config(
+        self,
+        model_name: str,
+        hf_config: PretrainedConfig | None = None,
+        revision: str | None = None,
+    ) -> None:
+        # vLLM returns the summary embedded in config.json without consulting
+        # get_config_filenames().  Hydrate the per-module records explicitly.
+        if not self.tensor_storage:
+            resolved_revision = revision
+            if resolved_revision is None and hf_config is not None:
+                resolved_revision = getattr(hf_config, "_commit_hash", None)
+            config = get_hf_file_to_dict(
+                "quantization_config.json",
+                model_name,
+                revision=resolved_revision,
+            )
+            if not config or not config.get("tensor_storage"):
+                raise ValueError(
+                    "EXL3 requires quantization_config.json with a non-empty "
+                    "tensor_storage map. For branch-indexed Hugging Face repos, "
+                    "download/serve an actual bpw revision rather than main."
+                )
+            self.bits = config.get("bits", self.bits)
+            self.head_bits = config.get("head_bits", self.head_bits)
+            self.codebook = config.get("codebook", self.codebook)
+            self.version = config.get("version", self.version)
+            self.tensor_storage = config["tensor_storage"]
+
+        self._validate_storage_metadata()
+        self._force_independent_lm_head(hf_config)
+
+    def apply_vllm_mapper(self, hf_to_vllm_mapper: "WeightsMapper") -> None:
+        # Keep both spellings: loader prefixes use vLLM names, while packed
+        # source-matrix discovery intentionally refers to the unstacked HF name.
+        mapped = hf_to_vllm_mapper.apply_dict(self.tensor_storage)
+        self.tensor_storage = {**self.tensor_storage, **mapped}
+
+    def _validate_storage_metadata(self) -> None:
+        bad: list[str] = []
+        exl3_count = 0
+        for prefix, entry in self.tensor_storage.items():
+            if entry.get("quant_format") != "exl3":
+                continue
+            exl3_count += 1
+            stored = entry.get("stored_tensors", {})
+            suffixes = {name.rsplit(".", 1)[-1] for name in stored}
+            required = {"trellis"}
+            if not ({"suh", "su"} & suffixes):
+                required.add("suh|su")
+            if not ({"svh", "sv"} & suffixes):
+                required.add("svh|sv")
+            missing = [name for name in required if name not in suffixes]
+            if missing:
+                bad.append(f"{prefix}: missing {','.join(sorted(missing))}")
+            if {"mcg", "mul1"} <= suffixes:
+                bad.append(f"{prefix}: both mcg and mul1 are present")
+        if not exl3_count:
+            raise ValueError("quantization_config.json has no EXL3 tensor records")
+        if bad:
+            raise ValueError("Invalid EXL3 tensor metadata: " + "; ".join(bad[:16]))
+
+    def _force_independent_lm_head(self, hf_config: PretrainedConfig | None) -> None:
+        if hf_config is None or not self.has_quantized_lm_head():
+            return
+        configs: list[Any] = [hf_config]
+        try:
+            text_config = hf_config.get_text_config()
+        except (AttributeError, TypeError):
+            text_config = None
+        if text_config is not None and text_config is not hf_config:
+            configs.append(text_config)
+        changed = False
+        for config in configs:
+            if getattr(config, "tie_word_embeddings", False):
+                config.tie_word_embeddings = False
+                changed = True
+        if changed:
+            logger.warning_once(
+                "EXL3 metadata contains an independently quantized lm_head; "
+                "overriding tie_word_embeddings so vLLM instantiates it."
+            )
+
+    def _require_enforce_eager(self) -> None:
+        # exllamav3_ext's exl3_gemm autotunes with timing launches on the first
+        # call per (m-bucket, k, n, K) shape hash; under CUDA-graph capture
+        # those launches fault, and m-bucketing means a warmup pass cannot
+        # reliably cover every bucket. Fail fast at build time instead of
+        # faulting mid-capture.
+        if self._eager_checked:
+            return
+        self._eager_checked = True
+        vllm_config = get_current_vllm_config_or_none()
+        if vllm_config is None:
+            return
+        if not vllm_config.model_config.enforce_eager:
+            raise ValueError(
+                "The EXL3 quantization backend requires eager execution: "
+                "pass --enforce-eager (enforce_eager=True). exl3_gemm "
+                "autotunes with timing launches on first use per shape "
+                "bucket, which is incompatible with CUDA-graph capture."
+            )
+
+    def get_quant_method(
+        self, layer: torch.nn.Module, prefix: str
+    ) -> QuantizeMethodBase | None:
+        self._require_enforce_eager()
+        is_lm_head = layer.__class__.__name__ == "ParallelLMHead"
+        if is_lm_head and not prefix:
+            prefix = "lm_head"
+        if isinstance(layer, LinearBase) or is_lm_head:
+            if not self._linear_prefix_is_exl3(prefix):
+                return UnquantizedLinearMethod()
+            return Exl3LinearMethod(self)
+        if isinstance(layer, RoutedExperts):
+            if not self._moe_prefix_is_exl3(prefix):
+                return None
+            return Exl3MoEMethod(self, layer.moe_config)
+        return None
+
+    def _storage_entry(self, prefix: str) -> dict[str, Any] | None:
+        candidates = [prefix]
+        if prefix.startswith("model."):
+            candidates.append(prefix.removeprefix("model."))
+        else:
+            candidates.append(f"model.{prefix}")
+
+        # Multimodal wrappers often add an extra `.model` or
+        # `.language_model` segment relative to vLLM's text-only module.
+        parts = prefix.split(".")
+        for removable in ("model", "language_model"):
+            for idx in range(1, len(parts) - 1):
+                if parts[idx] != removable:
+                    continue
+                collapsed = ".".join(parts[:idx] + parts[idx + 1 :])
+                candidates.extend((collapsed, f"model.{collapsed}"))
+                if collapsed.startswith("model."):
+                    candidates.append(collapsed.removeprefix("model."))
+
+        for candidate in dict.fromkeys(candidates):
+            entry = self.tensor_storage.get(candidate)
+            if entry is not None:
+                return entry
+        return None
+
+    def _is_exl3_prefix(self, prefix: str) -> bool:
+        entry = self._storage_entry(prefix)
+        return entry is not None and entry.get("quant_format") == "exl3"
+
+    def _linear_prefix_is_exl3(self, prefix: str) -> bool:
+        if self._is_exl3_prefix(prefix):
+            return True
+        leaf = prefix.rsplit(".", 1)[-1]
+        source_leaves = self.packed_modules_mapping.get(leaf)
+        if not source_leaves:
+            return False
+        base = prefix.rsplit(".", 1)[0] if "." in prefix else ""
+        return all(
+            self._is_exl3_prefix(f"{base}.{source}" if base else source)
+            for source in source_leaves
+        )
+
+    def _moe_prefix_is_exl3(self, prefix: str) -> bool:
+        expert_prefixes = (f"{prefix}.0", f"{prefix}.experts.0")
+        return any(
+            all(
+                self._is_exl3_prefix(f"{expert}.{projection}")
+                for projection in ("gate_proj", "up_proj", "down_proj")
+            )
+            for expert in expert_prefixes
+        )
+
+    def codebook_for_prefix(self, prefix: str) -> str | None:
+        entry = self._storage_entry(prefix)
+        if entry is None:
+            return None
+        suffixes = {name.rsplit(".", 1)[-1] for name in entry.get("stored_tensors", {})}
+        if "mcg" in suffixes:
+            return "mcg"
+        if "mul1" in suffixes:
+            return "mul1"
+        return None
+
+    def has_quantized_lm_head(self) -> bool:
+        return self._is_exl3_prefix("lm_head")
+
+
+class Exl3Parameter(BasevLLMParameter):
+    """Zero-sized parameter holding independently shaped EXL3 components."""
+
+    def __new__(cls, *, weight_loader):
+        data = torch.empty(0, dtype=torch.uint8)
+        return super().__new__(cls, data=data, weight_loader=weight_loader)
+
+    def __init__(self, *, weight_loader):
+        self.exl3_tensors: dict[ShardId, torch.Tensor] = {}
+        super().__init__(data=self.data, weight_loader=weight_loader)
+
+    def load_exl3_weight(
+        self,
+        loaded_weight: torch.Tensor,
+        shard_id: ShardId = None,
+    ) -> None:
+        self.exl3_tensors[shard_id] = loaded_weight.contiguous()
+
+
+def _exl3_weight_loader(
+    param: Exl3Parameter,
+    loaded_weight: torch.Tensor,
+    loaded_shard_id: ShardId = None,
+) -> None:
+    param.load_exl3_weight(loaded_weight, loaded_shard_id)
+
+
+class Exl3LinearMethod(LinearMethodBase):
+    def __init__(self, quant_config: Exl3Config) -> None:
+        self.quant_config = quant_config
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: list[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ) -> None:
+        del params_dtype, extra_weight_attrs
+        if layer.__class__.__name__ == "ParallelLMHead":
+            org = getattr(layer, "org_vocab_size", None)
+            total = getattr(layer, "num_embeddings", None)
+            if org is not None and total is not None and org != total:
+                raise NotImplementedError(
+                    "EXL3 lm_head with added vocabulary is unsupported: the "
+                    f"trellis tensor covers the original {org} rows but the "
+                    f"layer allocates {total}; TP slicing would silently "
+                    "misalign. Strip --lora-extra-vocab-size / added tokens "
+                    "or leave lm_head unquantized."
+                )
+        # Respect the layer's effective topology. disable_tp linears set their
+        # own tp_size=1, while ReplicatedLinear carries full weights even when
+        # the process-wide tensor group is larger than one.
+        if isinstance(layer, ReplicatedLinear):
+            layer.exl3_tp_rank = 0
+            layer.exl3_tp_size = 1
+        else:
+            layer.exl3_tp_rank = getattr(
+                layer, "tp_rank", get_tensor_model_parallel_rank()
+            )
+            layer.exl3_tp_size = getattr(
+                layer, "tp_size", get_tensor_model_parallel_world_size()
+            )
+        layer.exl3_input_size = input_size
+        layer.exl3_input_size_per_partition = input_size_per_partition
+        layer.exl3_output_size = output_size
+        layer.exl3_output_partition_sizes = output_partition_sizes
+        layer.exl3_shard_ids = self._shard_ids_for_layer(layer, output_partition_sizes)
+        layer.exl3_parallel_mode = (
+            "row" if input_size_per_partition != input_size else "column"
+        )
+        source_prefixes = self._source_prefixes_for_layer(layer, layer.exl3_shard_ids)
+        layer.exl3_expected_codebooks = {
+            shard_id: self.quant_config.codebook_for_prefix(source_prefix)
+            for shard_id, source_prefix in zip(
+                layer.exl3_shard_ids, source_prefixes, strict=True
+            )
+        }
+
+        # su/sv are legacy packed sign bitfields.  Modern checkpoints load
+        # suh/svh directly.
+        for name in ("suh", "svh", "su", "sv", "trellis", "mcg", "mul1"):
+            layer.register_parameter(
+                name,
+                Exl3Parameter(weight_loader=_exl3_weight_loader),
+            )
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        self._materialize_legacy_hadamard(layer)
+        missing: list[str] = []
+        for attr in ("suh", "svh", "trellis"):
+            param = getattr(layer, attr)
+            for shard_id in layer.exl3_shard_ids:
+                if shard_id not in param.exl3_tensors:
+                    missing.append(f"{attr}[{shard_id!r}]")
+        for shard_id in layer.exl3_shard_ids:
+            expected = layer.exl3_expected_codebooks[shard_id]
+            has_mcg = shard_id in layer.mcg.exl3_tensors
+            has_mul1 = shard_id in layer.mul1.exl3_tensors
+            if has_mcg and has_mul1:
+                missing.append(f"codebook[{shard_id!r}]=both mcg and mul1")
+            elif expected == "mcg" and not has_mcg:
+                missing.append(f"mcg[{shard_id!r}]")
+            elif expected == "mul1" and not has_mul1:
+                missing.append(f"mul1[{shard_id!r}]")
+            elif expected is None and (has_mcg or has_mul1):
+                missing.append(f"unexpected codebook[{shard_id!r}]")
+        if missing:
+            prefix = getattr(layer, "prefix", layer.__class__.__name__)
+            raise ValueError(
+                f"Missing or inconsistent EXL3 tensors for {prefix}: "
+                + ", ".join(missing)
+            )
+
+        self._validate_loaded_tensors(layer)
+        self._shard_tensors_for_tensor_parallel(layer)
+        self._validate_loaded_tensors(layer)
+
+        # device_loading_context has moved the zero-sized registered parameter
+        # to the model target device.  Its device is the safest destination for
+        # the tensors kept in the side dictionaries.
+        device = layer.trellis.device
+        for attr in ("suh", "svh", "trellis", "mcg", "mul1"):
+            param = getattr(layer, attr)
+            for shard_id, tensor in list(param.exl3_tensors.items()):
+                param.exl3_tensors[shard_id] = tensor.to(
+                    device=device, non_blocking=True
+                ).contiguous()
+
+    def apply(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        original_shape = x.shape[:-1]
+        original_dtype = x.dtype
+        x_2d = x.reshape(-1, x.shape[-1]).to(torch.float16).contiguous()
+        outputs = [
+            self._apply_one(layer, x_2d, shard_id) for shard_id in layer.exl3_shard_ids
+        ]
+        output = outputs[0] if len(outputs) == 1 else torch.cat(outputs, dim=-1)
+        if bias is not None:
+            output = output + bias.to(dtype=output.dtype)
+        output = output.reshape(*original_shape, output.shape[-1])
+        return output if output.dtype == original_dtype else output.to(original_dtype)
+
+    @staticmethod
+    def _unpack_signs(bitfield: torch.Tensor) -> torch.Tensor:
+        words = bitfield.contiguous().view(torch.uint16).to(torch.int32)
+        masks = 1 << torch.arange(16, device=words.device, dtype=torch.int32)
+        negative = (words.unsqueeze(-1) & masks) != 0
+        return (
+            torch.where(
+                negative,
+                torch.tensor(-1.0, device=words.device, dtype=torch.float16),
+                torch.tensor(1.0, device=words.device, dtype=torch.float16),
+            )
+            .flatten()
+            .contiguous()
+        )
+
+    @classmethod
+    def _materialize_legacy_hadamard(cls, layer: torch.nn.Module) -> None:
+        for packed_name, half_name in (("su", "suh"), ("sv", "svh")):
+            packed = getattr(layer, packed_name).exl3_tensors
+            half = getattr(layer, half_name).exl3_tensors
+            for shard_id in layer.exl3_shard_ids:
+                if shard_id not in half and shard_id in packed:
+                    half[shard_id] = cls._unpack_signs(packed[shard_id])
+
+    @staticmethod
+    def _validate_marker(tensor: torch.Tensor, expected: int, name: str) -> None:
+        if tensor.dtype != torch.int32 or tensor.numel() != 1:
+            raise ValueError(f"EXL3 {name} must be a scalar int32 sentinel")
+        value = int(tensor.reshape(()).item()) & 0xFFFFFFFF
+        if value != expected:
+            raise ValueError(
+                f"Invalid EXL3 {name} sentinel 0x{value:08x}; expected 0x{expected:08x}"
+            )
+
+    @classmethod
+    def _validate_loaded_tensors(cls, layer: torch.nn.Module) -> None:
+        for shard_id in layer.exl3_shard_ids:
+            trellis = layer.trellis.exl3_tensors[shard_id]
+            suh = layer.suh.exl3_tensors[shard_id]
+            svh = layer.svh.exl3_tensors[shard_id]
+            if trellis.dtype != torch.int16 or trellis.ndim != 3:
+                raise ValueError("EXL3 trellis must be rank-3 int16")
+            if trellis.shape[2] % 16 or not 1 <= trellis.shape[2] // 16 <= 8:
+                raise ValueError(
+                    f"Invalid EXL3 trellis bit width {trellis.shape[2]} / 16"
+                )
+            if suh.dtype != torch.float16 or suh.ndim != 1:
+                raise ValueError("EXL3 suh must be rank-1 float16")
+            if svh.dtype != torch.float16 or svh.ndim != 1:
+                raise ValueError("EXL3 svh must be rank-1 float16")
+            k = trellis.shape[0] * 16
+            n = trellis.shape[1] * 16
+            if suh.numel() != k or svh.numel() != n:
+                raise ValueError(
+                    "EXL3 dimensions disagree: "
+                    f"trellis={tuple(trellis.shape)}, suh={suh.numel()}, "
+                    f"svh={svh.numel()}"
+                )
+            if k % _HADAMARD_BLOCK or n % _HADAMARD_BLOCK:
+                raise ValueError(
+                    f"EXL3 kernel dimensions must be {_HADAMARD_BLOCK}-aligned, "
+                    f"got K={k}, N={n}"
+                )
+            if shard_id in layer.mcg.exl3_tensors:
+                cls._validate_marker(
+                    layer.mcg.exl3_tensors[shard_id], _MCG_SENTINEL, "mcg"
+                )
+            if shard_id in layer.mul1.exl3_tensors:
+                cls._validate_marker(
+                    layer.mul1.exl3_tensors[shard_id], _MUL1_SENTINEL, "mul1"
+                )
+
+    @staticmethod
+    def _slice_exl3_tensor(
+        tensor: torch.Tensor,
+        *,
+        dim: int,
+        start: int,
+        size: int,
+    ) -> torch.Tensor:
+        if start % _HADAMARD_BLOCK or size % _HADAMARD_BLOCK:
+            axis = "output" if dim == 1 else "input"
+            raise ValueError(
+                f"EXL3 TP {axis} slice must be {_HADAMARD_BLOCK}-aligned, "
+                f"got start={start}, size={size}"
+            )
+        return tensor.narrow(dim, start // 16, size // 16).contiguous()
+
+    @staticmethod
+    def _output_shard_size(layer: torch.nn.Module, shard_id: ShardId) -> int:
+        if shard_id is None:
+            return layer.exl3_output_partition_sizes[0]
+        if isinstance(shard_id, str) and shard_id in ("q", "k", "v"):
+            return layer.exl3_output_partition_sizes[{"q": 0, "k": 1, "v": 2}[shard_id]]
+        if isinstance(shard_id, tuple):
+            return sum(layer.exl3_output_partition_sizes[idx] for idx in shard_id)
+        if isinstance(shard_id, int):
+            return layer.exl3_output_partition_sizes[shard_id]
+        return layer.exl3_output_partition_sizes[layer.exl3_shard_ids.index(shard_id)]
+
+    @staticmethod
+    def _qkv_output_start(
+        layer: torch.nn.Module, shard_id: ShardId, shard_size: int
+    ) -> int:
+        if shard_id in ("k", "v"):
+            shard_rank = layer.exl3_tp_rank // layer.num_kv_head_replicas
+        else:
+            shard_rank = layer.exl3_tp_rank
+        return shard_rank * shard_size
+
+    @classmethod
+    def _shard_tensors_for_tensor_parallel(cls, layer: torch.nn.Module) -> None:
+        if layer.exl3_tp_size == 1:
+            return
+        if layer.exl3_parallel_mode == "row":
+            start = layer.exl3_tp_rank * layer.exl3_input_size_per_partition
+            size = layer.exl3_input_size_per_partition
+            for shard_id in layer.exl3_shard_ids:
+                layer.suh.exl3_tensors[shard_id] = (
+                    layer.suh.exl3_tensors[shard_id].narrow(0, start, size).contiguous()
+                )
+                layer.trellis.exl3_tensors[shard_id] = cls._slice_exl3_tensor(
+                    layer.trellis.exl3_tensors[shard_id],
+                    dim=0,
+                    start=start,
+                    size=size,
+                )
+            return
+
+        already_sharded = cls._expand_tuple_output_shards(layer)
+        for shard_id in layer.exl3_shard_ids:
+            if shard_id in already_sharded:
+                continue
+            size = cls._output_shard_size(layer, shard_id)
+            start = cls._qkv_output_start(layer, shard_id, size)
+            layer.svh.exl3_tensors[shard_id] = (
+                layer.svh.exl3_tensors[shard_id].narrow(0, start, size).contiguous()
+            )
+            layer.trellis.exl3_tensors[shard_id] = cls._slice_exl3_tensor(
+                layer.trellis.exl3_tensors[shard_id],
+                dim=1,
+                start=start,
+                size=size,
+            )
+
+    @classmethod
+    def _expand_tuple_output_shards(cls, layer: torch.nn.Module) -> set[int]:
+        tuples = [sid for sid in layer.exl3_shard_ids if isinstance(sid, tuple)]
+        if not tuples:
+            return set()
+
+        expanded_ids: list[ShardId] = []
+        component_ids: set[int] = set()
+        for shard_id in layer.exl3_shard_ids:
+            if isinstance(shard_id, tuple):
+                expanded_ids.extend(shard_id)
+                component_ids.update(shard_id)
+            else:
+                expanded_ids.append(shard_id)
+
+        for tuple_id in tuples:
+            full_offsets: dict[int, int] = {}
+            offset = 0
+            for idx in tuple_id:
+                full_offsets[idx] = offset
+                offset += layer.exl3_output_partition_sizes[idx] * layer.exl3_tp_size
+            for idx in tuple_id:
+                size = layer.exl3_output_partition_sizes[idx]
+                start = full_offsets[idx] + layer.exl3_tp_rank * size
+                layer.suh.exl3_tensors[idx] = layer.suh.exl3_tensors[tuple_id]
+                layer.svh.exl3_tensors[idx] = (
+                    layer.svh.exl3_tensors[tuple_id].narrow(0, start, size).contiguous()
+                )
+                layer.trellis.exl3_tensors[idx] = cls._slice_exl3_tensor(
+                    layer.trellis.exl3_tensors[tuple_id],
+                    dim=1,
+                    start=start,
+                    size=size,
+                )
+                layer.exl3_expected_codebooks[idx] = layer.exl3_expected_codebooks[
+                    tuple_id
+                ]
+                for marker in ("mcg", "mul1"):
+                    tensors = getattr(layer, marker).exl3_tensors
+                    if tuple_id in tensors:
+                        tensors[idx] = tensors[tuple_id]
+            for attr in ("suh", "svh", "trellis", "mcg", "mul1"):
+                getattr(layer, attr).exl3_tensors.pop(tuple_id, None)
+            layer.exl3_expected_codebooks.pop(tuple_id, None)
+
+        layer.exl3_shard_ids = expanded_ids
+        return component_ids
+
+    @staticmethod
+    def _shard_ids_for_layer(
+        layer: torch.nn.Module,
+        output_partition_sizes: list[int],
+    ) -> list[ShardId]:
+        if len(output_partition_sizes) == 1:
+            return [None]
+        prefix = getattr(layer, "prefix", "")
+        if isinstance(layer, QKVParallelLinear) and len(output_partition_sizes) == 3:
+            return ["q", "k", "v"]
+        if prefix.endswith("in_proj_qkvz"):
+            return [(0, 1, 2), 3]
+        return list(range(len(output_partition_sizes)))
+
+    def _source_prefixes_for_layer(
+        self, layer: torch.nn.Module, shard_ids: list[ShardId]
+    ) -> list[str]:
+        prefix = getattr(layer, "prefix", "")
+        if len(shard_ids) == 1:
+            return [prefix or "lm_head"]
+        leaf = prefix.rsplit(".", 1)[-1]
+        base = prefix.rsplit(".", 1)[0] if "." in prefix else ""
+        sources = self.quant_config.packed_modules_mapping.get(leaf)
+        if sources and len(sources) == len(shard_ids):
+            return [f"{base}.{source}" if base else source for source in sources]
+        raise ValueError(
+            f"EXL3 does not know the source matrices for packed layer {prefix}; "
+            "add it to the model's packed_modules_mapping."
+        )
+
+    @staticmethod
+    def _apply_one(
+        layer: torch.nn.Module, x: torch.Tensor, shard_id: ShardId
+    ) -> torch.Tensor:
+        trellis = layer.trellis.exl3_tensors[shard_id]
+        packed_k = trellis.shape[0] * 16
+        if x.shape[-1] > packed_k:
+            raise ValueError(
+                f"EXL3 input width {x.shape[-1]} exceeds packed K={packed_k}"
+            )
+        if x.shape[-1] < packed_k:
+            x = torch.nn.functional.pad(x, (0, packed_k - x.shape[-1]))
+        output = _exl3_gemm(
+            x,
+            trellis,
+            layer.suh.exl3_tensors[shard_id],
+            layer.svh.exl3_tensors[shard_id],
+            shard_id in layer.mcg.exl3_tensors,
+            shard_id in layer.mul1.exl3_tensors,
+        )
+        logical_n = Exl3LinearMethod._output_shard_size(layer, shard_id)
+        if output.shape[-1] < logical_n:
+            raise ValueError(
+                f"EXL3 packed N={output.shape[-1]} is below logical N={logical_n}"
+            )
+        return output[..., :logical_n]
+
+
+class Exl3MoEParameter(BasevLLMParameter):
+    """Zero-sized parameter holding EXL3 tensors by expert and projection."""
+
+    def __new__(cls, *, weight_loader):
+        data = torch.empty(0, dtype=torch.uint8)
+        return super().__new__(cls, data=data, weight_loader=weight_loader)
+
+    def __init__(self, *, weight_loader):
+        self.exl3_tensors: dict[tuple[int, str], torch.Tensor] = {}
+        super().__init__(data=self.data, weight_loader=weight_loader)
+
+
+def _exl3_moe_weight_loader(
+    param: Exl3MoEParameter,
+    loaded_weight: torch.Tensor,
+    weight_name: str,
+    shard_id: str,
+    expert_id: int,
+    return_success: bool = False,
+) -> bool | None:
+    del weight_name
+    param.exl3_tensors[(expert_id, shard_id)] = loaded_weight.contiguous()
+    return True if return_success else None
+
+
+# Model loaders (e.g. llama4-style paths) check this attribute before routing
+# expert tensors through a param's weight_loader with MoE kwargs.
+_exl3_moe_weight_loader.supports_moe_loading = True  # type: ignore[attr-defined]
+
+
+class Exl3MoEMethod(FusedMoEMethodBase):
+    """Correctness MoE path: route, then use three dense EXL3 GEMMs/expert."""
+
+    def __init__(self, quant_config: Exl3Config, moe) -> None:
+        super().__init__(moe)
+        self.quant_config = quant_config
+
+    def create_weights(
+        self,
+        layer: RoutedExperts,
+        num_experts: int,
+        hidden_size: int,
+        intermediate_size_per_partition: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ) -> None:
+        del num_experts, params_dtype, extra_weight_attrs
+        if self.moe.moe_parallel_config.use_ep:
+            raise NotImplementedError(
+                "EXL3 correctness MoE currently supports TP but not expert parallelism"
+            )
+        if self.moe.has_bias:
+            raise NotImplementedError(
+                "EXL3 correctness MoE does not yet support expert biases"
+            )
+        layer.exl3_tp_rank = self.moe.moe_parallel_config.tp_rank
+        layer.exl3_tp_size = self.moe.moe_parallel_config.tp_size
+        layer.exl3_hidden_size = hidden_size
+        layer.exl3_intermediate_size_per_partition = intermediate_size_per_partition
+        for prefix in ("w13", "w2"):
+            for suffix in ("suh", "svh", "trellis", "mcg", "mul1"):
+                layer.register_parameter(
+                    f"{prefix}_{suffix}",
+                    Exl3MoEParameter(weight_loader=_exl3_moe_weight_loader),
+                )
+
+    def process_weights_after_loading(self, layer: RoutedExperts) -> None:
+        required = {"w13": ("w1", "w3"), "w2": ("w2",)}
+        missing: list[str] = []
+        for prefix, shard_ids in required.items():
+            for attr in ("suh", "svh", "trellis"):
+                tensors = getattr(layer, f"{prefix}_{attr}").exl3_tensors
+                for expert_id in range(layer.local_num_experts):
+                    for shard_id in shard_ids:
+                        if (expert_id, shard_id) not in tensors:
+                            missing.append(f"{prefix}_{attr}[{expert_id},{shard_id}]")
+        if missing:
+            raise ValueError(
+                f"Missing EXL3 MoE tensors for {layer.layer_name}: "
+                + ", ".join(missing[:32])
+                + (" ..." if len(missing) > 32 else "")
+            )
+        self._validate_codebooks(layer)
+        self._shard_tensors_for_tensor_parallel(layer)
+        device = layer.w13_trellis.device
+        for prefix in ("w13", "w2"):
+            for attr in ("suh", "svh", "trellis", "mcg", "mul1"):
+                param = getattr(layer, f"{prefix}_{attr}")
+                for key, tensor in list(param.exl3_tensors.items()):
+                    param.exl3_tensors[key] = tensor.to(
+                        device=device, non_blocking=True
+                    ).contiguous()
+        self._validate_moe_shapes(layer)
+
+    def _validate_codebooks(self, layer: RoutedExperts) -> None:
+        projections = {
+            "w1": layer.ckpt_gate_proj_name,
+            "w2": layer.ckpt_down_proj_name,
+            "w3": layer.ckpt_up_proj_name,
+        }
+        for expert_id in range(layer.local_num_experts):
+            for shard_id, projection in projections.items():
+                prefix = f"{layer.layer_name}.{expert_id}.{projection}"
+                expected = self.quant_config.codebook_for_prefix(prefix)
+                group = "w2" if shard_id == "w2" else "w13"
+                key = (expert_id, shard_id)
+                has_mcg = key in getattr(layer, f"{group}_mcg").exl3_tensors
+                has_mul1 = key in getattr(layer, f"{group}_mul1").exl3_tensors
+                if has_mcg and has_mul1:
+                    raise ValueError(f"EXL3 MoE {prefix} has both codebooks")
+                if expected == "mcg" and not has_mcg:
+                    raise ValueError(f"EXL3 MoE {prefix} is missing mcg")
+                if expected == "mul1" and not has_mul1:
+                    raise ValueError(f"EXL3 MoE {prefix} is missing mul1")
+                if expected is None and (has_mcg or has_mul1):
+                    raise ValueError(
+                        f"EXL3 MoE {prefix} has an unexpected codebook marker"
+                    )
+                if has_mcg:
+                    Exl3LinearMethod._validate_marker(
+                        getattr(layer, f"{group}_mcg").exl3_tensors[key],
+                        _MCG_SENTINEL,
+                        "mcg",
+                    )
+                if has_mul1:
+                    Exl3LinearMethod._validate_marker(
+                        getattr(layer, f"{group}_mul1").exl3_tensors[key],
+                        _MUL1_SENTINEL,
+                        "mul1",
+                    )
+
+    @classmethod
+    def _shard_tensors_for_tensor_parallel(cls, layer: RoutedExperts) -> None:
+        if layer.exl3_tp_size == 1:
+            return
+        start = layer.exl3_tp_rank * layer.exl3_intermediate_size_per_partition
+        size = layer.exl3_intermediate_size_per_partition
+        for expert_id in range(layer.local_num_experts):
+            for shard_id in ("w1", "w3"):
+                key = (expert_id, shard_id)
+                layer.w13_svh.exl3_tensors[key] = (
+                    layer.w13_svh.exl3_tensors[key].narrow(0, start, size).contiguous()
+                )
+                layer.w13_trellis.exl3_tensors[key] = (
+                    Exl3LinearMethod._slice_exl3_tensor(
+                        layer.w13_trellis.exl3_tensors[key],
+                        dim=1,
+                        start=start,
+                        size=size,
+                    )
+                )
+            key = (expert_id, "w2")
+            layer.w2_suh.exl3_tensors[key] = (
+                layer.w2_suh.exl3_tensors[key].narrow(0, start, size).contiguous()
+            )
+            layer.w2_trellis.exl3_tensors[key] = Exl3LinearMethod._slice_exl3_tensor(
+                layer.w2_trellis.exl3_tensors[key],
+                dim=0,
+                start=start,
+                size=size,
+            )
+
+    @staticmethod
+    def _validate_moe_shapes(layer: RoutedExperts) -> None:
+        for expert_id in range(layer.local_num_experts):
+            for group, shard_ids in (("w13", ("w1", "w3")), ("w2", ("w2",))):
+                for shard_id in shard_ids:
+                    key = (expert_id, shard_id)
+                    trellis = getattr(layer, f"{group}_trellis").exl3_tensors[key]
+                    suh = getattr(layer, f"{group}_suh").exl3_tensors[key]
+                    svh = getattr(layer, f"{group}_svh").exl3_tensors[key]
+                    if (
+                        trellis.dtype != torch.int16
+                        or trellis.ndim != 3
+                        or trellis.shape[2] % 16
+                        or not 1 <= trellis.shape[2] // 16 <= 8
+                        or suh.dtype != torch.float16
+                        or suh.ndim != 1
+                        or svh.dtype != torch.float16
+                        or svh.ndim != 1
+                        or suh.numel() != trellis.shape[0] * 16
+                        or svh.numel() != trellis.shape[1] * 16
+                        or (trellis.shape[0] * 16) % _HADAMARD_BLOCK
+                        or (trellis.shape[1] * 16) % _HADAMARD_BLOCK
+                    ):
+                        raise ValueError(
+                            f"Invalid EXL3 MoE tensors for expert={expert_id}, "
+                            f"projection={shard_id}"
+                        )
+
+    def get_fused_moe_quant_config(
+        self, layer: RoutedExperts
+    ) -> FusedMoEQuantConfig | None:
+        del layer
+        return None
+
+    @property
+    def topk_indices_dtype(self) -> torch.dtype | None:
+        return torch.long
+
+    def apply(
+        self,
+        layer: RoutedExperts,
+        x: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        shared_experts: "SharedExperts | None",
+        shared_experts_input: torch.Tensor | None,
+    ) -> torch.Tensor:
+        del shared_experts, shared_experts_input
+        if layer.activation != MoEActivation.SILU:
+            raise NotImplementedError(
+                f"EXL3 correctness MoE supports SiLU only, got {layer.activation}"
+            )
+        if layer.expert_map is not None:
+            raise NotImplementedError("EXL3 MoE expert maps/EPLB are not supported")
+        if layer.apply_router_weight_on_input:
+            raise NotImplementedError(
+                "EXL3 MoE does not support router weights applied on input"
+            )
+
+        original_shape = x.shape[:-1]
+        original_dtype = x.dtype
+        x_2d = x.reshape(-1, x.shape[-1]).to(torch.float16).contiguous()
+        ids = topk_ids.reshape(x_2d.shape[0], -1).to(torch.long)
+        weights = topk_weights.reshape_as(ids).to(torch.float16)
+        output = torch.zeros(
+            (x_2d.shape[0], layer.hidden_size),
+            dtype=torch.float32,
+            device=x.device,
+        )
+        for expert_id in range(layer.local_num_experts):
+            positions = (ids == expert_id).nonzero(as_tuple=False)
+            if positions.shape[0] == 0:
+                continue
+            token_ids = positions[:, 0]
+            route_ids = positions[:, 1]
+            expert_input = x_2d.index_select(0, token_ids)
+            gate = self._apply_expert(layer, "w13", expert_input, expert_id, "w1")
+            up = self._apply_expert(layer, "w13", expert_input, expert_id, "w3")
+            hidden = torch.nn.functional.silu(gate) * up
+            expert_output = self._apply_expert(layer, "w2", hidden, expert_id, "w2")
+            route_weight = weights[token_ids, route_ids].unsqueeze(-1)
+            output.index_add_(
+                0,
+                token_ids,
+                (expert_output * route_weight).to(torch.float32),
+            )
+        output = output.reshape(*original_shape, output.shape[-1])
+        return output if output.dtype == original_dtype else output.to(original_dtype)
+
+    def apply_monolithic(
+        self,
+        layer: RoutedExperts,
+        x: torch.Tensor,
+        router_logits: torch.Tensor,
+        input_ids: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        del layer, x, router_logits, input_ids
+        raise NotImplementedError("EXL3 MoE uses vLLM's external router")
+
+    @staticmethod
+    def _apply_expert(
+        layer: RoutedExperts,
+        group: str,
+        x: torch.Tensor,
+        expert_id: int,
+        shard_id: str,
+    ) -> torch.Tensor:
+        key = (expert_id, shard_id)
+        trellis = getattr(layer, f"{group}_trellis").exl3_tensors[key]
+        packed_k = trellis.shape[0] * 16
+        if x.shape[-1] > packed_k:
+            raise ValueError(
+                f"EXL3 MoE input width {x.shape[-1]} exceeds packed K={packed_k}"
+            )
+        if x.shape[-1] < packed_k:
+            x = torch.nn.functional.pad(x, (0, packed_k - x.shape[-1]))
+        output = _exl3_gemm(
+            x,
+            trellis,
+            getattr(layer, f"{group}_suh").exl3_tensors[key],
+            getattr(layer, f"{group}_svh").exl3_tensors[key],
+            key in getattr(layer, f"{group}_mcg").exl3_tensors,
+            key in getattr(layer, f"{group}_mul1").exl3_tensors,
+        )
+        logical_n = (
+            layer.hidden_size
+            if shard_id == "w2"
+            else layer.exl3_intermediate_size_per_partition
+        )
+        if output.shape[-1] < logical_n:
+            raise ValueError(
+                f"EXL3 MoE packed N={output.shape[-1]} is below logical N={logical_n}"
+            )
+        return output[..., :logical_n]
+
+
+__all__ = ["Exl3Config", "Exl3LinearMethod", "Exl3MoEMethod"]

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -417,11 +417,13 @@ class Exl3Config(QuantizationConfig):
         else:
             candidates.append(f"model.{prefix}")
 
-        # Multimodal wrappers often add an extra `.model` or
-        # `.language_model` segment relative to vLLM's text-only module.
+        # Multimodal wrappers often add an extra `model` or `language_model`
+        # segment relative to vLLM's text-only module — interior
+        # (`model.language_model.layers...`) or leading
+        # (`language_model.lm_head`), so leading segments collapse too.
         parts = prefix.split(".")
         for removable in ("model", "language_model"):
-            for idx in range(1, len(parts) - 1):
+            for idx in range(0, len(parts) - 1):
                 if parts[idx] != removable:
                     continue
                 collapsed = ".".join(parts[:idx] + parts[idx + 1 :])

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -3,14 +3,29 @@
 
 """EXL3 (ExLlamaV3 trellis) quantization support.
 
-This is deliberately the correctness backend.  Every logical checkpoint
-matrix is dispatched independently through ``exllamav3_ext.exl3_gemm``.  In
-particular, vLLM's packed QKV and gate/up modules are *not* treated as one EXL3
-matrix: each source matrix owns its own Hadamard vectors and codebook marker.
+Compute paths, in selection order:
 
-The extension is imported lazily on the first CUDA execution.  Importing this
+1. **Fused path (primary).** Modules whose checkpoint carries the MCG codebook
+   marker run through the b12x fused CuTeDSL trellis kernel
+   (``b12x.moe.fused.w4a16.run_trellis256_dense``): native EXL3 storage is
+   consumed zero-copy at 3/4/5/6 bpw, the full input-rotation -> GEMM ->
+   output-rotation chain executes as one compiled artifact, and the output is
+   byte-identical across batch size m — a property the split upstream
+   GEMV/GEMM/reconstruct ladder does not have. Selection happens once per
+   shard at weight-processing time; ineligible shards (legacy ``default`` or
+   MUL1 codebooks, or shapes the kernel rejects) fall back per-shard.
+2. **Parity path (fallback + oracle).** The bit-faithful wrapper around
+   ``exllamav3_ext.exl3_gemm``. Every logical checkpoint matrix is dispatched
+   independently: vLLM's packed QKV and gate/up modules are *not* treated as
+   one EXL3 matrix — each source matrix owns its own Hadamard vectors and
+   codebook marker.
+
+``VLLM_EXL3_FUSED=0`` forces the parity path everywhere (A/B switch).
+``VLLM_EXL3_LOG_PATH_SELECTION=1`` logs the chosen path per shard.
+
+Both the extension and the b12x package are imported lazily.  Importing this
 module, parsing checkpoint metadata, or compiling it with ``py_compile`` does
-not load the extension or initialize CUDA.
+not load either one or initialize CUDA.
 """
 
 from __future__ import annotations
@@ -154,6 +169,80 @@ def _exl3_gemm_fake(
         dtype=torch.float16,
         device=x.device,
     )
+
+
+_B12X_UNAVAILABLE = object()
+_B12X_DENSE_API: Any = None
+
+
+def _fused_mode_enabled() -> bool:
+    return os.environ.get("VLLM_EXL3_FUSED", "1") == "1"
+
+
+def _load_b12x_dense() -> Any:
+    """Resolve the b12x fused dense entry points once, without hard-failing.
+
+    Returns a ``(prepare_trellis256_dense_weight, run_trellis256_dense)``
+    tuple, or None when the fused path is disabled or the b12x package is not
+    importable.  The parity path through exllamav3_ext remains the fallback
+    either way.  This backend requires eager execution (see
+    ``_require_enforce_eager``), so the fused call does not need an opaque
+    torch.library wrapper.
+    """
+    global _B12X_DENSE_API
+    if _B12X_DENSE_API is _B12X_UNAVAILABLE:
+        return None
+    if _B12X_DENSE_API is not None:
+        return _B12X_DENSE_API
+    if not _fused_mode_enabled():
+        _B12X_DENSE_API = _B12X_UNAVAILABLE
+        return None
+    try:
+        from b12x.moe.fused.w4a16 import (
+            prepare_trellis256_dense_weight,
+            run_trellis256_dense,
+        )
+    except Exception:
+        logger.warning(
+            "EXL3: the b12x fused trellis kernel is not importable; every "
+            "module will use the bit-faithful exllamav3_ext parity path."
+        )
+        _B12X_DENSE_API = _B12X_UNAVAILABLE
+        return None
+    _B12X_DENSE_API = (prepare_trellis256_dense_weight, run_trellis256_dense)
+    return _B12X_DENSE_API
+
+
+def _log_path_selection(prefix: str, chosen: str, reason: str) -> None:
+    if os.environ.get("VLLM_EXL3_LOG_PATH_SELECTION") == "1":
+        logger.info("EXL3 path %s -> %s (%s)", prefix, chosen, reason)
+
+
+def _try_prepare_fused(
+    prefix: str,
+    trellis: torch.Tensor,
+    suh: torch.Tensor,
+    svh: torch.Tensor,
+    mcg: torch.Tensor | None,
+    mul1: torch.Tensor | None,
+) -> Any | None:
+    """Prepare one shard for the fused kernel; None selects the parity path."""
+    api = _load_b12x_dense()
+    if api is None:
+        return None
+    if mcg is None or mul1 is not None:
+        # The fused t256 decoder implements the MCG codebook only.  Legacy
+        # "default"-codebook and MUL1 checkpoints stay on the parity path.
+        _log_path_selection(prefix, "parity", "non-MCG codebook")
+        return None
+    prepare, _ = api
+    try:
+        prepared = prepare(trellis, suh, svh, mcg=mcg)
+    except Exception as exc:
+        _log_path_selection(prefix, "parity", f"prepare rejected: {exc}")
+        return None
+    _log_path_selection(prefix, "fused", "mcg")
+    return prepared
 
 
 class Exl3Config(QuantizationConfig):
@@ -520,6 +609,22 @@ class Exl3LinearMethod(LinearMethodBase):
                     device=device, non_blocking=True
                 ).contiguous()
 
+        fused: dict[ShardId, Any] = {}
+        if _fused_mode_enabled():
+            prefix = getattr(layer, "prefix", layer.__class__.__name__)
+            for shard_id in layer.exl3_shard_ids:
+                prepared = _try_prepare_fused(
+                    f"{prefix}[{shard_id!r}]",
+                    layer.trellis.exl3_tensors[shard_id],
+                    layer.suh.exl3_tensors[shard_id],
+                    layer.svh.exl3_tensors[shard_id],
+                    layer.mcg.exl3_tensors.get(shard_id),
+                    layer.mul1.exl3_tensors.get(shard_id),
+                )
+                if prepared is not None:
+                    fused[shard_id] = prepared
+        layer.exl3_fused_prepared = fused
+
     def apply(
         self,
         layer: torch.nn.Module,
@@ -773,14 +878,20 @@ class Exl3LinearMethod(LinearMethodBase):
             )
         if x.shape[-1] < packed_k:
             x = torch.nn.functional.pad(x, (0, packed_k - x.shape[-1]))
-        output = _exl3_gemm(
-            x,
-            trellis,
-            layer.suh.exl3_tensors[shard_id],
-            layer.svh.exl3_tensors[shard_id],
-            shard_id in layer.mcg.exl3_tensors,
-            shard_id in layer.mul1.exl3_tensors,
-        )
+        prepared = getattr(layer, "exl3_fused_prepared", {}).get(shard_id)
+        if prepared is not None:
+            api = _load_b12x_dense()
+            assert api is not None
+            output = api[1](x, prepared)
+        else:
+            output = _exl3_gemm(
+                x,
+                trellis,
+                layer.suh.exl3_tensors[shard_id],
+                layer.svh.exl3_tensors[shard_id],
+                shard_id in layer.mcg.exl3_tensors,
+                shard_id in layer.mul1.exl3_tensors,
+            )
         logical_n = Exl3LinearMethod._output_shard_size(layer, shard_id)
         if output.shape[-1] < logical_n:
             raise ValueError(
@@ -882,6 +993,29 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                         device=device, non_blocking=True
                     ).contiguous()
         self._validate_moe_shapes(layer)
+
+        fused: dict[tuple[str, int, str], Any] = {}
+        if _fused_mode_enabled():
+            for group, shard_ids in (("w13", ("w1", "w3")), ("w2", ("w2",))):
+                trellis_map = getattr(layer, f"{group}_trellis").exl3_tensors
+                suh_map = getattr(layer, f"{group}_suh").exl3_tensors
+                svh_map = getattr(layer, f"{group}_svh").exl3_tensors
+                mcg_map = getattr(layer, f"{group}_mcg").exl3_tensors
+                mul1_map = getattr(layer, f"{group}_mul1").exl3_tensors
+                for expert_id in range(layer.local_num_experts):
+                    for shard_id in shard_ids:
+                        key = (expert_id, shard_id)
+                        prepared = _try_prepare_fused(
+                            f"{layer.layer_name}.{expert_id}.{shard_id}",
+                            trellis_map[key],
+                            suh_map[key],
+                            svh_map[key],
+                            mcg_map.get(key),
+                            mul1_map.get(key),
+                        )
+                        if prepared is not None:
+                            fused[(group,) + key] = prepared
+        layer.exl3_moe_fused_prepared = fused
 
     def _validate_codebooks(self, layer: RoutedExperts) -> None:
         projections = {
@@ -1067,14 +1201,22 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             )
         if x.shape[-1] < packed_k:
             x = torch.nn.functional.pad(x, (0, packed_k - x.shape[-1]))
-        output = _exl3_gemm(
-            x,
-            trellis,
-            getattr(layer, f"{group}_suh").exl3_tensors[key],
-            getattr(layer, f"{group}_svh").exl3_tensors[key],
-            key in getattr(layer, f"{group}_mcg").exl3_tensors,
-            key in getattr(layer, f"{group}_mul1").exl3_tensors,
+        prepared = getattr(layer, "exl3_moe_fused_prepared", {}).get(
+            (group,) + key
         )
+        if prepared is not None:
+            api = _load_b12x_dense()
+            assert api is not None
+            output = api[1](x, prepared)
+        else:
+            output = _exl3_gemm(
+                x,
+                trellis,
+                getattr(layer, f"{group}_suh").exl3_tensors[key],
+                getattr(layer, f"{group}_svh").exl3_tensors[key],
+                key in getattr(layer, f"{group}_mcg").exl3_tensors,
+                key in getattr(layer, f"{group}_mul1").exl3_tensors,
+            )
         logical_n = (
             layer.hidden_size
             if shard_id == "w2"

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -412,7 +412,7 @@ class Exl3Config(QuantizationConfig):
                 return UnquantizedLinearMethod()
             return Exl3LinearMethod(self)
         if isinstance(layer, RoutedExperts):
-            if not self._moe_prefix_is_exl3(prefix):
+            if not self._moe_prefix_is_exl3(prefix, layer):
                 return None
             return Exl3MoEMethod(self, layer.moe_config)
         return None
@@ -461,12 +461,26 @@ class Exl3Config(QuantizationConfig):
             for source in source_leaves
         )
 
-    def _moe_prefix_is_exl3(self, prefix: str) -> bool:
+    def _moe_prefix_is_exl3(
+        self, prefix: str, layer: torch.nn.Module | None = None
+    ) -> bool:
+        # Use the layer's checkpoint projection names (the same fields
+        # _validate_codebooks keys off) so remapped-projection MoE
+        # checkpoints are still detected; fall back to the defaults when the
+        # layer variant does not carry them.
+        projections = tuple(
+            getattr(layer, attr, default)
+            for attr, default in (
+                ("ckpt_gate_proj_name", "gate_proj"),
+                ("ckpt_up_proj_name", "up_proj"),
+                ("ckpt_down_proj_name", "down_proj"),
+            )
+        )
         expert_prefixes = (f"{prefix}.0", f"{prefix}.experts.0")
         return any(
             all(
                 self._is_exl3_prefix(f"{expert}.{projection}")
-                for projection in ("gate_proj", "up_proj", "down_proj")
+                for projection in projections
             )
             for expert in expert_prefixes
         )

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -198,6 +198,13 @@ def _load_b12x_dense() -> Any:
         _B12X_DENSE_API = _B12X_UNAVAILABLE
         return None
     try:
+        # The fused dense entry performs its outer rotations through
+        # exllamav3_ext.had_r_128, and b12x imports that extension by module
+        # name. Resolve it here through the same VLLM_EXL3_ABI_SHIM /
+        # VLLM_EXL3_EXT_PATH contract as the parity path so b12x sees the
+        # shimmed, correctly-located extension instead of whatever an
+        # unshimmed site-packages import would find.
+        _load_exl3_ext()
         from b12x.moe.fused.w4a16 import (
             prepare_trellis256_dense_weight,
             run_trellis256_dense,

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -1546,7 +1546,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 topk_ids=topk_ids,
             )
             output = runtime["api"].run(binding=binding)
-            return output.to(x.dtype).clone()
+            return output.to(x.dtype)
 
         if m > runtime["max_batched_tokens"]:
             raise ValueError(
@@ -1589,7 +1589,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 0.0,
                 0,
             )
-            return out32.to(x.dtype).clone()
+            return out32.to(x.dtype)
 
         local_ids = layer.exl3_expert_map[topk_ids.long()]
         half_weights = topk_weights.to(torch.float16)
@@ -1631,7 +1631,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 False,
                 0.0,
             )
-        return out32.to(x.dtype).clone()
+        return out32.to(x.dtype)
 
     def apply(
         self,

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -3,29 +3,17 @@
 
 """EXL3 (ExLlamaV3 trellis) quantization support.
 
-Compute paths, in selection order:
+Rank-sliced routed-expert checkpoints use Sparkinfer's planned full-rotation
+Trellis MoE API for the decode window and the ExLlamaV3 extension for larger
+prefill batches. Generic dense and non-rank-sliced MoE checkpoints use the
+bit-faithful ``exllamav3_ext.exl3_gemm`` parity path. Every logical checkpoint
+matrix is dispatched independently: vLLM's packed QKV and gate/up modules are
+not treated as one EXL3 matrix because each source matrix owns its Hadamard
+vectors and codebook marker.
 
-1. **Fused path (primary).** Modules whose checkpoint carries the MCG codebook
-   marker run through the b12x fused CuTeDSL trellis kernel
-   (``b12x.moe.fused.w4a16.run_trellis256_dense``): native EXL3 storage is
-   consumed zero-copy at 3/4/5/6 bpw, the full input-rotation -> GEMM ->
-   output-rotation chain executes as one compiled artifact, and the output is
-   byte-identical across batch size m — a property the split upstream
-   GEMV/GEMM/reconstruct ladder does not have. Selection happens once per
-   shard at weight-processing time; ineligible shards (legacy ``default`` or
-   MUL1 codebooks, or shapes the kernel rejects) fall back per-shard.
-2. **Parity path (fallback + oracle).** The bit-faithful wrapper around
-   ``exllamav3_ext.exl3_gemm``. Every logical checkpoint matrix is dispatched
-   independently: vLLM's packed QKV and gate/up modules are *not* treated as
-   one EXL3 matrix — each source matrix owns its own Hadamard vectors and
-   codebook marker.
-
-``VLLM_EXL3_FUSED=0`` forces the parity path everywhere (A/B switch).
-``VLLM_EXL3_LOG_PATH_SELECTION=1`` logs the chosen path per shard.
-
-Both the extension and the b12x package are imported lazily.  Importing this
-module, parsing checkpoint metadata, or compiling it with ``py_compile`` does
-not load either one or initialize CUDA.
+Both dependencies are imported lazily. Importing this module, parsing
+checkpoint metadata, or compiling it with ``py_compile`` does not load either
+one or initialize CUDA.
 """
 
 from __future__ import annotations
@@ -33,17 +21,18 @@ from __future__ import annotations
 import ctypes
 import importlib
 import os
+import re
 import sys
 from typing import TYPE_CHECKING, Any
 
 import torch
 from transformers import PretrainedConfig
 
+from vllm.config import get_current_vllm_config_or_none
 from vllm.distributed import (
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
 )
-from vllm.config import get_current_vllm_config_or_none
 from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe import (
     FusedMoEMethodBase,
@@ -77,6 +66,13 @@ _MCG_SENTINEL = 0xCBAC1FED
 _MUL1_SENTINEL = 0x83DCD12D
 _HADAMARD_BLOCK = 128
 _EXL3_EXT: Any | None = None
+_SPARKINFER_TRELLIS_API: Any | None = None
+_RANK_SLICED_RUNTIMES: dict[tuple[Any, ...], dict[str, Any]] = {}
+_RANK_SLICED_FORMAT = "exl3-trellis"
+_RANK_SLICED_WEIGHT_RE = re.compile(
+    r"^(?P<prefix>.+)\.rank(?P<rank>\d+)\."
+    r"(?P<field>trellis|suh|svh|mcg|mul1)$"
+)
 
 ShardId = str | int | tuple[int, ...] | None
 
@@ -115,6 +111,30 @@ def _load_exl3_ext() -> Any:
         )
     _EXL3_EXT = ext
     return ext
+
+
+def _load_sparkinfer_trellis() -> Any:
+    """Resolve the public planned Trellis MoE API lazily."""
+
+    global _SPARKINFER_TRELLIS_API
+    if _SPARKINFER_TRELLIS_API is not None:
+        return _SPARKINFER_TRELLIS_API
+    try:
+        from sparkinfer.moe import trellis_moe
+    except Exception as exc:
+        raise RuntimeError(
+            "Rank-sliced EXL3 requires sparkinfer.moe.trellis_moe. Install "
+            "a Sparkinfer build containing the planned full-rotation API."
+        ) from exc
+    _SPARKINFER_TRELLIS_API = trellis_moe
+    return trellis_moe
+
+
+def _positive_env_int(name: str, default: int) -> int:
+    value = int(os.environ.get(name, default))
+    if value <= 0:
+        raise ValueError(f"{name} must be positive, got {value}")
+    return value
 
 
 @torch.library.custom_op(
@@ -171,87 +191,6 @@ def _exl3_gemm_fake(
     )
 
 
-_B12X_UNAVAILABLE = object()
-_B12X_DENSE_API: Any = None
-
-
-def _fused_mode_enabled() -> bool:
-    return os.environ.get("VLLM_EXL3_FUSED", "1") == "1"
-
-
-def _load_b12x_dense() -> Any:
-    """Resolve the b12x fused dense entry points once, without hard-failing.
-
-    Returns a ``(prepare_trellis256_dense_weight, run_trellis256_dense)``
-    tuple, or None when the fused path is disabled or the b12x package is not
-    importable.  The parity path through exllamav3_ext remains the fallback
-    either way.  This backend requires eager execution (see
-    ``_require_enforce_eager``), so the fused call does not need an opaque
-    torch.library wrapper.
-    """
-    global _B12X_DENSE_API
-    if _B12X_DENSE_API is _B12X_UNAVAILABLE:
-        return None
-    if _B12X_DENSE_API is not None:
-        return _B12X_DENSE_API
-    if not _fused_mode_enabled():
-        _B12X_DENSE_API = _B12X_UNAVAILABLE
-        return None
-    try:
-        # The fused dense entry performs its outer rotations through
-        # exllamav3_ext.had_r_128, and b12x imports that extension by module
-        # name. Resolve it here through the same VLLM_EXL3_ABI_SHIM /
-        # VLLM_EXL3_EXT_PATH contract as the parity path so b12x sees the
-        # shimmed, correctly-located extension instead of whatever an
-        # unshimmed site-packages import would find.
-        _load_exl3_ext()
-        from b12x.moe.fused.w4a16 import (
-            prepare_trellis256_dense_weight,
-            run_trellis256_dense,
-        )
-    except Exception:
-        logger.warning(
-            "EXL3: the b12x fused trellis kernel is not importable; every "
-            "module will use the bit-faithful exllamav3_ext parity path."
-        )
-        _B12X_DENSE_API = _B12X_UNAVAILABLE
-        return None
-    _B12X_DENSE_API = (prepare_trellis256_dense_weight, run_trellis256_dense)
-    return _B12X_DENSE_API
-
-
-def _log_path_selection(prefix: str, chosen: str, reason: str) -> None:
-    if os.environ.get("VLLM_EXL3_LOG_PATH_SELECTION") == "1":
-        logger.info("EXL3 path %s -> %s (%s)", prefix, chosen, reason)
-
-
-def _try_prepare_fused(
-    prefix: str,
-    trellis: torch.Tensor,
-    suh: torch.Tensor,
-    svh: torch.Tensor,
-    mcg: torch.Tensor | None,
-    mul1: torch.Tensor | None,
-) -> Any | None:
-    """Prepare one shard for the fused kernel; None selects the parity path."""
-    api = _load_b12x_dense()
-    if api is None:
-        return None
-    if mcg is None or mul1 is not None:
-        # The fused t256 decoder implements the MCG codebook only.  Legacy
-        # "default"-codebook and MUL1 checkpoints stay on the parity path.
-        _log_path_selection(prefix, "parity", "non-MCG codebook")
-        return None
-    prepare, _ = api
-    try:
-        prepared = prepare(trellis, suh, svh, mcg=mcg)
-    except Exception as exc:
-        _log_path_selection(prefix, "parity", f"prepare rejected: {exc}")
-        return None
-    _log_path_selection(prefix, "fused", "mcg")
-    return prepared
-
-
 class Exl3Config(QuantizationConfig):
     """Configuration for modern and legacy EXL3 trellis checkpoints."""
 
@@ -270,6 +209,7 @@ class Exl3Config(QuantizationConfig):
         self.version = version
         self.tensor_storage = tensor_storage or {}
         self._eager_checked = False
+        self.rank_sliced_metadata: dict[str, Any] | None = None
 
     def get_name(self) -> str:
         return "exl3"
@@ -288,7 +228,7 @@ class Exl3Config(QuantizationConfig):
         return ["quantization_config.json"]
 
     @classmethod
-    def from_config(cls, config: dict[str, Any]) -> "Exl3Config":
+    def from_config(cls, config: dict[str, Any]) -> Exl3Config:
         return cls(
             bits=config.get("bits"),
             head_bits=config.get("head_bits"),
@@ -297,12 +237,35 @@ class Exl3Config(QuantizationConfig):
             tensor_storage=config.get("tensor_storage"),
         )
 
+    @classmethod
+    def override_quantization_method(
+        cls,
+        hf_quant_cfg: dict[str, Any],
+        user_quant: str | None,
+        hf_config: PretrainedConfig | None = None,
+    ) -> str | None:
+        del hf_quant_cfg
+        if user_quant is not None and user_quant != "exl3":
+            return None
+        metadata = getattr(hf_config, "hybrid_tr3_tail", None)
+        if isinstance(metadata, dict) and metadata.get("format") == _RANK_SLICED_FORMAT:
+            return "exl3"
+        return None
+
     def maybe_update_config(
         self,
         model_name: str,
         hf_config: PretrainedConfig | None = None,
         revision: str | None = None,
     ) -> None:
+        rank_sliced = getattr(hf_config, "hybrid_tr3_tail", None)
+        if (
+            isinstance(rank_sliced, dict)
+            and rank_sliced.get("format") == _RANK_SLICED_FORMAT
+        ):
+            self._configure_rank_sliced(rank_sliced)
+            return
+
         # vLLM returns the summary embedded in config.json without consulting
         # get_config_filenames().  Hydrate the per-module records explicitly.
         if not self.tensor_storage:
@@ -329,7 +292,47 @@ class Exl3Config(QuantizationConfig):
         self._validate_storage_metadata()
         self._force_independent_lm_head(hf_config)
 
-    def apply_vllm_mapper(self, hf_to_vllm_mapper: "WeightsMapper") -> None:
+    def _configure_rank_sliced(self, metadata: dict[str, Any]) -> None:
+        required = {
+            "bits",
+            "codebook",
+            "experts_per_layer",
+            "moe_layers",
+            "tensor_schema",
+            "tp",
+        }
+        missing = sorted(required.difference(metadata))
+        if missing:
+            raise ValueError(
+                "rank-sliced EXL3 metadata is missing: " + ", ".join(missing)
+            )
+        if metadata["codebook"] != "mcg":
+            raise ValueError(
+                "rank-sliced EXL3 currently requires the MCG codebook, got "
+                f"{metadata['codebook']!r}"
+            )
+        layers = metadata["moe_layers"]
+        if (
+            not isinstance(layers, list)
+            or len(layers) != 2
+            or int(layers[0]) < 0
+            or int(layers[1]) < int(layers[0])
+        ):
+            raise ValueError("rank-sliced EXL3 moe_layers must be [first, last]")
+        expected_schema = (
+            "model.layers.{L}.mlp.experts.{E}.{proj}.rank{r}.{trellis|suh|svh|mcg}"
+        )
+        if metadata["tensor_schema"] != expected_schema:
+            raise ValueError(
+                "unsupported rank-sliced EXL3 tensor schema: "
+                f"{metadata['tensor_schema']!r}"
+            )
+        self.rank_sliced_metadata = dict(metadata)
+        self.bits = float(metadata["bits"])
+        self.codebook = str(metadata["codebook"])
+        self.version = str(metadata.get("exllamav3_version", "rank-sliced"))
+
+    def apply_vllm_mapper(self, hf_to_vllm_mapper: WeightsMapper) -> None:
         # Keep both spellings: loader prefixes use vLLM names, while packed
         # source-matrix discovery intentionally refers to the unstacked HF name.
         mapped = hf_to_vllm_mapper.apply_dict(self.tensor_storage)
@@ -381,6 +384,10 @@ class Exl3Config(QuantizationConfig):
             )
 
     def _require_enforce_eager(self) -> None:
+        if self.rank_sliced_metadata is not None:
+            # The routed-expert fast path is eagerly planned before graph
+            # capture. Only its large-M parity fallback remains eager.
+            return
         # exllamav3_ext's exl3_gemm autotunes with timing launches on the first
         # call per (m-bucket, k, n, K) shape hash; under CUDA-graph capture
         # those launches fault, and m-bucketing means a warmup pass cannot
@@ -464,6 +471,12 @@ class Exl3Config(QuantizationConfig):
     def _moe_prefix_is_exl3(
         self, prefix: str, layer: torch.nn.Module | None = None
     ) -> bool:
+        if self.rank_sliced_metadata is not None:
+            match = re.search(r"layers\.(\d+)\b", prefix)
+            if match is None:
+                return False
+            first, last = (int(v) for v in self.rank_sliced_metadata["moe_layers"])
+            return first <= int(match.group(1)) <= last
         # Use the layer's checkpoint projection names (the same fields
         # _validate_codebooks keys off) so remapped-projection MoE
         # checkpoints are still detected; fall back to the defaults when the
@@ -486,6 +499,12 @@ class Exl3Config(QuantizationConfig):
         )
 
     def codebook_for_prefix(self, prefix: str) -> str | None:
+        if self.rank_sliced_metadata is not None:
+            match = re.search(r"layers\.(\d+)\b", prefix)
+            if match is None:
+                return None
+            first, last = (int(v) for v in self.rank_sliced_metadata["moe_layers"])
+            return "mcg" if first <= int(match.group(1)) <= last else None
         entry = self._storage_entry(prefix)
         if entry is None:
             return None
@@ -498,6 +517,17 @@ class Exl3Config(QuantizationConfig):
 
     def has_quantized_lm_head(self) -> bool:
         return self._is_exl3_prefix("lm_head")
+
+    def normalize_rank_sliced_weight_name(self, name: str) -> str | None:
+        """Drop non-local TP payloads and remove the serialized rank segment."""
+        if self.rank_sliced_metadata is None:
+            return name
+        match = _RANK_SLICED_WEIGHT_RE.match(name)
+        if match is None:
+            return name
+        if int(match.group("rank")) != get_tensor_model_parallel_rank():
+            return None
+        return f"{match.group('prefix')}.{match.group('field')}"
 
 
 class Exl3Parameter(BasevLLMParameter):
@@ -631,22 +661,6 @@ class Exl3LinearMethod(LinearMethodBase):
                 param.exl3_tensors[shard_id] = tensor.to(
                     device=device, non_blocking=True
                 ).contiguous()
-
-        fused: dict[ShardId, Any] = {}
-        if _fused_mode_enabled():
-            prefix = getattr(layer, "prefix", layer.__class__.__name__)
-            for shard_id in layer.exl3_shard_ids:
-                prepared = _try_prepare_fused(
-                    f"{prefix}[{shard_id!r}]",
-                    layer.trellis.exl3_tensors[shard_id],
-                    layer.suh.exl3_tensors[shard_id],
-                    layer.svh.exl3_tensors[shard_id],
-                    layer.mcg.exl3_tensors.get(shard_id),
-                    layer.mul1.exl3_tensors.get(shard_id),
-                )
-                if prepared is not None:
-                    fused[shard_id] = prepared
-        layer.exl3_fused_prepared = fused
 
     def apply(
         self,
@@ -901,20 +915,14 @@ class Exl3LinearMethod(LinearMethodBase):
             )
         if x.shape[-1] < packed_k:
             x = torch.nn.functional.pad(x, (0, packed_k - x.shape[-1]))
-        prepared = getattr(layer, "exl3_fused_prepared", {}).get(shard_id)
-        if prepared is not None:
-            api = _load_b12x_dense()
-            assert api is not None
-            output = api[1](x, prepared)
-        else:
-            output = _exl3_gemm(
-                x,
-                trellis,
-                layer.suh.exl3_tensors[shard_id],
-                layer.svh.exl3_tensors[shard_id],
-                shard_id in layer.mcg.exl3_tensors,
-                shard_id in layer.mul1.exl3_tensors,
-            )
+        output = _exl3_gemm(
+            x,
+            trellis,
+            layer.suh.exl3_tensors[shard_id],
+            layer.svh.exl3_tensors[shard_id],
+            shard_id in layer.mcg.exl3_tensors,
+            shard_id in layer.mul1.exl3_tensors,
+        )
         logical_n = Exl3LinearMethod._output_shard_size(layer, shard_id)
         if output.shape[-1] < logical_n:
             raise ValueError(
@@ -924,15 +932,80 @@ class Exl3LinearMethod(LinearMethodBase):
 
 
 class Exl3MoEParameter(BasevLLMParameter):
-    """Zero-sized parameter holding EXL3 tensors by expert and projection."""
+    """EXL3 tensors keyed by expert/projection, optionally in one GPU slab."""
 
-    def __new__(cls, *, weight_loader):
+    def __new__(
+        cls,
+        *,
+        weight_loader,
+        num_experts: int = 0,
+        shard_ids: tuple[str, ...] = (),
+        preallocate: bool = False,
+    ):
+        del num_experts, shard_ids, preallocate
         data = torch.empty(0, dtype=torch.uint8)
         return super().__new__(cls, data=data, weight_loader=weight_loader)
 
-    def __init__(self, *, weight_loader):
+    def __init__(
+        self,
+        *,
+        weight_loader,
+        num_experts: int = 0,
+        shard_ids: tuple[str, ...] = (),
+        preallocate: bool = False,
+    ):
         self.exl3_tensors: dict[tuple[int, str], torch.Tensor] = {}
+        self.exl3_backing: torch.Tensor | None = None
+        self.exl3_num_experts = int(num_experts)
+        self.exl3_shard_ids = tuple(shard_ids)
+        self.exl3_preallocate = bool(preallocate)
         super().__init__(data=self.data, weight_loader=weight_loader)
+
+    def load_exl3_weight(
+        self,
+        loaded_weight: torch.Tensor,
+        *,
+        expert_id: int,
+        shard_id: str,
+    ) -> None:
+        key = (int(expert_id), str(shard_id))
+        if not self.exl3_preallocate:
+            self.exl3_tensors[key] = loaded_weight.contiguous()
+            return
+        if self.exl3_num_experts <= 0 or shard_id not in self.exl3_shard_ids:
+            raise ValueError(
+                f"invalid EXL3 slab key expert={expert_id}, shard={shard_id!r}"
+            )
+        if not 0 <= int(expert_id) < self.exl3_num_experts:
+            raise ValueError(
+                f"EXL3 expert {expert_id} is outside [0, {self.exl3_num_experts})"
+            )
+        if self.device.type == "meta":
+            raise RuntimeError("rank-sliced EXL3 slabs cannot be allocated on meta")
+        if self.exl3_backing is None:
+            prefix = (
+                (len(self.exl3_shard_ids), self.exl3_num_experts)
+                if len(self.exl3_shard_ids) > 1
+                else (self.exl3_num_experts,)
+            )
+            self.exl3_backing = torch.empty(
+                prefix + tuple(loaded_weight.shape),
+                dtype=loaded_weight.dtype,
+                device=self.device,
+            )
+        shard_index = self.exl3_shard_ids.index(shard_id)
+        target = (
+            self.exl3_backing[shard_index, expert_id]
+            if len(self.exl3_shard_ids) > 1
+            else self.exl3_backing[expert_id]
+        )
+        if tuple(target.shape) != tuple(loaded_weight.shape):
+            raise ValueError(
+                "rank-sliced EXL3 tensor shape changed within one slab: "
+                f"expected={tuple(target.shape)}, got={tuple(loaded_weight.shape)}"
+            )
+        target.copy_(loaded_weight, non_blocking=True)
+        self.exl3_tensors[key] = target
 
 
 def _exl3_moe_weight_loader(
@@ -944,7 +1017,11 @@ def _exl3_moe_weight_loader(
     return_success: bool = False,
 ) -> bool | None:
     del weight_name
-    param.exl3_tensors[(expert_id, shard_id)] = loaded_weight.contiguous()
+    param.load_exl3_weight(
+        loaded_weight,
+        expert_id=expert_id,
+        shard_id=shard_id,
+    )
     return True if return_success else None
 
 
@@ -969,7 +1046,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         params_dtype: torch.dtype,
         **extra_weight_attrs,
     ) -> None:
-        del num_experts, params_dtype, extra_weight_attrs
+        del params_dtype, extra_weight_attrs
         if self.moe.moe_parallel_config.use_ep:
             raise NotImplementedError(
                 "EXL3 correctness MoE currently supports TP but not expert parallelism"
@@ -982,11 +1059,39 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         layer.exl3_tp_size = self.moe.moe_parallel_config.tp_size
         layer.exl3_hidden_size = hidden_size
         layer.exl3_intermediate_size_per_partition = intermediate_size_per_partition
-        for prefix in ("w13", "w2"):
+        rank_sliced = self.quant_config.rank_sliced_metadata is not None
+        if rank_sliced:
+            checkpoint_tp = int(self.quant_config.rank_sliced_metadata["tp"])
+            if checkpoint_tp != layer.exl3_tp_size:
+                raise ValueError(
+                    "rank-sliced EXL3 checkpoint TP does not match runtime: "
+                    f"checkpoint={checkpoint_tp}, runtime={layer.exl3_tp_size}"
+                )
+            expected_experts = int(
+                self.quant_config.rank_sliced_metadata["experts_per_layer"]
+            )
+            if expected_experts != num_experts:
+                raise ValueError(
+                    "rank-sliced EXL3 expert count does not match the model: "
+                    f"checkpoint={expected_experts}, model={num_experts}"
+                )
+            vllm_config = get_current_vllm_config_or_none()
+            scheduler_config = (
+                vllm_config.scheduler_config if vllm_config is not None else None
+            )
+            layer.exl3_max_num_batched_tokens = int(
+                getattr(scheduler_config, "max_num_batched_tokens", 4096)
+            )
+        for prefix, shard_ids in (("w13", ("w1", "w3")), ("w2", ("w2",))):
             for suffix in ("suh", "svh", "trellis", "mcg", "mul1"):
                 layer.register_parameter(
                     f"{prefix}_{suffix}",
-                    Exl3MoEParameter(weight_loader=_exl3_moe_weight_loader),
+                    Exl3MoEParameter(
+                        weight_loader=_exl3_moe_weight_loader,
+                        num_experts=num_experts,
+                        shard_ids=shard_ids,
+                        preallocate=rank_sliced and suffix in {"suh", "svh", "trellis"},
+                    ),
                 )
 
     def process_weights_after_loading(self, layer: RoutedExperts) -> None:
@@ -1006,7 +1111,8 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 + (" ..." if len(missing) > 32 else "")
             )
         self._validate_codebooks(layer)
-        self._shard_tensors_for_tensor_parallel(layer)
+        if self.quant_config.rank_sliced_metadata is None:
+            self._shard_tensors_for_tensor_parallel(layer)
         device = layer.w13_trellis.device
         for prefix in ("w13", "w2"):
             for attr in ("suh", "svh", "trellis", "mcg", "mul1"):
@@ -1017,28 +1123,9 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                     ).contiguous()
         self._validate_moe_shapes(layer)
 
-        fused: dict[tuple[str, int, str], Any] = {}
-        if _fused_mode_enabled():
-            for group, shard_ids in (("w13", ("w1", "w3")), ("w2", ("w2",))):
-                trellis_map = getattr(layer, f"{group}_trellis").exl3_tensors
-                suh_map = getattr(layer, f"{group}_suh").exl3_tensors
-                svh_map = getattr(layer, f"{group}_svh").exl3_tensors
-                mcg_map = getattr(layer, f"{group}_mcg").exl3_tensors
-                mul1_map = getattr(layer, f"{group}_mul1").exl3_tensors
-                for expert_id in range(layer.local_num_experts):
-                    for shard_id in shard_ids:
-                        key = (expert_id, shard_id)
-                        prepared = _try_prepare_fused(
-                            f"{layer.layer_name}.{expert_id}.{shard_id}",
-                            trellis_map[key],
-                            suh_map[key],
-                            svh_map[key],
-                            mcg_map.get(key),
-                            mul1_map.get(key),
-                        )
-                        if prepared is not None:
-                            fused[(group,) + key] = prepared
-        layer.exl3_moe_fused_prepared = fused
+        if self.quant_config.rank_sliced_metadata is not None:
+            self._prepare_rank_sliced_weights(layer)
+            return
 
     def _validate_codebooks(self, layer: RoutedExperts) -> None:
         projections = {
@@ -1136,6 +1223,135 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                             f"projection={shard_id}"
                         )
 
+    @staticmethod
+    def _rank_sliced_backing(
+        layer: RoutedExperts,
+        param_name: str,
+    ) -> torch.Tensor:
+        param = getattr(layer, param_name)
+        backing = param.exl3_backing
+        if backing is None or not backing.is_contiguous():
+            raise RuntimeError(
+                f"rank-sliced EXL3 parameter {param_name} has no contiguous slab"
+            )
+        for (expert_id, shard_id), tensor in param.exl3_tensors.items():
+            shard_index = param.exl3_shard_ids.index(shard_id)
+            expected = (
+                backing[shard_index, expert_id]
+                if len(param.exl3_shard_ids) > 1
+                else backing[expert_id]
+            )
+            if tensor.data_ptr() != expected.data_ptr():
+                raise RuntimeError(
+                    "rank-sliced EXL3 expert payload lost its slab alias: "
+                    f"{param_name}[{expert_id},{shard_id}]"
+                )
+        return backing
+
+    @staticmethod
+    def _pointer_table(slab: torch.Tensor) -> torch.Tensor:
+        if slab.ndim < 2 or not slab[0].is_contiguous():
+            raise RuntimeError("EXL3 pointer-table rows must be contiguous")
+        step = slab.stride(0) * slab.element_size()
+        base = slab.data_ptr()
+        return torch.tensor(
+            [base + expert_id * step for expert_id in range(slab.shape[0])],
+            dtype=torch.int64,
+            device=slab.device,
+        )
+
+    @staticmethod
+    def _trellis_tile_config(hidden_size: int, intermediate_size: int):
+        if hidden_size % 128 or intermediate_size % 128:
+            raise ValueError(
+                "rank-sliced EXL3 full rotations require hidden and "
+                "intermediate dimensions divisible by 128"
+            )
+        if hidden_size % 256 == 0 and intermediate_size % 256 == 0:
+            return (64, 256, 64, 256)
+        return (64, 128, 64, 128)
+
+    def _prepare_rank_sliced_weights(self, layer: RoutedExperts) -> None:
+        api = _load_sparkinfer_trellis()
+        num_experts = int(layer.local_num_experts)
+        hidden_size = int(layer.exl3_hidden_size)
+        intermediate_size = int(layer.exl3_intermediate_size_per_partition)
+        bits = int(self.quant_config.bits or 0)
+        if float(bits) != self.quant_config.bits or bits not in (3, 4, 5, 6):
+            raise ValueError(
+                "rank-sliced EXL3 requires an integral 3/4/5/6 bitrate, got "
+                f"{self.quant_config.bits!r}"
+            )
+
+        w13 = self._rank_sliced_backing(layer, "w13_trellis")
+        w2 = self._rank_sliced_backing(layer, "w2_trellis")
+        gate_suh, up_suh = self._rank_sliced_backing(layer, "w13_suh")
+        gate_svh, up_svh = self._rank_sliced_backing(layer, "w13_svh")
+        down_suh = self._rank_sliced_backing(layer, "w2_suh")
+        down_svh = self._rank_sliced_backing(layer, "w2_svh")
+        expected_w13 = (
+            2,
+            num_experts,
+            hidden_size // 16,
+            intermediate_size // 16,
+            16 * bits,
+        )
+        expected_w2 = (
+            num_experts,
+            intermediate_size // 16,
+            hidden_size // 16,
+            16 * bits,
+        )
+        if tuple(w13.shape) != expected_w13 or tuple(w2.shape) != expected_w2:
+            raise ValueError(
+                "rank-sliced EXL3 slab geometry mismatch: "
+                f"w13={tuple(w13.shape)}, w2={tuple(w2.shape)}, "
+                f"expected={expected_w13}/{expected_w2}"
+            )
+
+        intermediate_rotations = torch.empty(
+            (num_experts, 3 * intermediate_size),
+            dtype=torch.float16,
+            device=w13.device,
+        )
+        intermediate_rotations[:, :intermediate_size].copy_(gate_svh)
+        intermediate_rotations[:, intermediate_size : 2 * intermediate_size].copy_(
+            up_svh
+        )
+        intermediate_rotations[:, 2 * intermediate_size :].copy_(down_suh)
+        tile_config = self._trellis_tile_config(hidden_size, intermediate_size)
+        marker = layer.w13_mcg.exl3_tensors[(0, "w1")]
+        layer.exl3_trellis_weights = api.prepare_weights(
+            w13,
+            w2,
+            gate_suh=gate_suh,
+            up_suh=up_suh,
+            intermediate_rotations=intermediate_rotations,
+            down_svh=down_svh,
+            codebook="mcg",
+            mcg=marker,
+            tile_config=tile_config,
+        )
+
+        slabs = (
+            w13[0],
+            gate_suh,
+            gate_svh,
+            w13[1],
+            up_suh,
+            up_svh,
+            w2,
+            down_suh,
+            down_svh,
+        )
+        layer.exl3_pointer_tables = tuple(self._pointer_table(slab) for slab in slabs)
+        layer.exl3_expert_map = torch.arange(
+            num_experts,
+            dtype=torch.int64,
+            device=w13.device,
+        )
+        layer.exl3_trellis_tile_config = tile_config
+
     def get_fused_moe_quant_config(
         self, layer: RoutedExperts
     ) -> FusedMoEQuantConfig | None:
@@ -1146,13 +1362,284 @@ class Exl3MoEMethod(FusedMoEMethodBase):
     def topk_indices_dtype(self) -> torch.dtype | None:
         return torch.long
 
+    def _rank_sliced_runtime(
+        self,
+        layer: RoutedExperts,
+        x: torch.Tensor,
+        topk_ids: torch.Tensor,
+    ) -> dict[str, Any]:
+        min_trellis_m = _positive_env_int("VLLM_EXL3_TRELLIS_MIN_M", 4)
+        max_trellis_m = _positive_env_int("VLLM_EXL3_TRELLIS_MAX_M", 32)
+        block_m = _positive_env_int("VLLM_EXL3_TRELLIS_BLOCK_M", 8)
+        chunk = _positive_env_int("VLLM_EXL3_PREFILL_CHUNK", 128)
+        if min_trellis_m > max_trellis_m:
+            raise ValueError(
+                "VLLM_EXL3_TRELLIS_MIN_M cannot exceed VLLM_EXL3_TRELLIS_MAX_M"
+            )
+        max_batched_tokens = max(
+            int(layer.exl3_max_num_batched_tokens),
+            int(x.shape[0]),
+        )
+        topk = int(topk_ids.shape[1])
+        device_index = x.device.index
+        key = (
+            device_index,
+            x.dtype,
+            int(layer.exl3_hidden_size),
+            int(layer.exl3_intermediate_size_per_partition),
+            int(layer.local_num_experts),
+            topk,
+            max_batched_tokens,
+            min_trellis_m,
+            max_trellis_m,
+            block_m,
+            chunk,
+            layer.exl3_trellis_tile_config,
+        )
+        runtime = _RANK_SLICED_RUNTIMES.get(key)
+        if runtime is not None:
+            return runtime
+        if torch.cuda.is_current_stream_capturing():
+            raise RuntimeError(
+                "Rank-sliced EXL3 runtime must be planned during the eager "
+                "profile pass before CUDA graph capture"
+            )
+
+        api = _load_sparkinfer_trellis()
+        caps = api.Caps(
+            max_tokens=max_trellis_m,
+            num_topk=topk,
+            num_experts=int(layer.local_num_experts),
+            hidden_size=int(layer.exl3_hidden_size),
+            intermediate_size=int(layer.exl3_intermediate_size_per_partition),
+            route_num_experts=int(layer.local_num_experts),
+            block_size_m=block_m,
+            trellis_bits=int(self.quant_config.bits),
+            tile_config=layer.exl3_trellis_tile_config,
+            input_dtype=x.dtype,
+            device=x.device,
+        )
+        trellis_plan = api.plan(caps)
+        scratch_spec = trellis_plan.scratch_specs()[0]
+        trellis_scratch = torch.empty(
+            scratch_spec.shape,
+            dtype=scratch_spec.dtype,
+            device=scratch_spec.device,
+        )
+
+        ext = _load_exl3_ext()
+        required_ext = {
+            "exl3_moe",
+            "exl3_moe_max_concurrency",
+        }
+        missing_ext = sorted(name for name in required_ext if not hasattr(ext, name))
+        if missing_ext:
+            raise RuntimeError(
+                "The EXL3 extension lacks routed-expert entry points: "
+                + ", ".join(missing_ext)
+            )
+        concurrency = int(ext.exl3_moe_max_concurrency(torch.cuda.current_device()))
+        hidden_size = int(layer.exl3_hidden_size)
+        intermediate_size = int(layer.exl3_intermediate_size_per_partition)
+        num_experts = int(layer.local_num_experts)
+        device = x.device
+        runtime = {
+            "api": api,
+            "trellis_plan": trellis_plan,
+            "trellis_scratch": trellis_scratch,
+            "ext": ext,
+            "min_trellis_m": min_trellis_m,
+            "max_trellis_m": max_trellis_m,
+            "max_batched_tokens": max_batched_tokens,
+            "topk": topk,
+            "chunk": chunk,
+            "xh": torch.empty(
+                (max_batched_tokens, hidden_size),
+                dtype=torch.float16,
+                device=device,
+            ),
+            "out32": torch.empty(
+                (max_batched_tokens, hidden_size),
+                dtype=torch.float32,
+                device=device,
+            ),
+            "tg": torch.empty(
+                (concurrency, chunk, hidden_size),
+                dtype=torch.float16,
+                device=device,
+            ),
+            "tu": torch.empty(
+                (concurrency, chunk, hidden_size),
+                dtype=torch.float16,
+                device=device,
+            ),
+            "ig": torch.empty(
+                (concurrency, chunk, intermediate_size),
+                dtype=torch.float16,
+                device=device,
+            ),
+            "iu": torch.empty(
+                (concurrency, chunk, intermediate_size),
+                dtype=torch.float16,
+                device=device,
+            ),
+            "expert_count": torch.empty(
+                num_experts + 1,
+                dtype=torch.int64,
+                device=device,
+            ),
+            "expert_offsets": torch.empty(
+                num_experts + 1,
+                dtype=torch.int64,
+                device=device,
+            ),
+            "token_sorted": torch.empty(
+                max_batched_tokens * topk,
+                dtype=torch.int64,
+                device=device,
+            ),
+            "weight_sorted": torch.empty(
+                max_batched_tokens * topk,
+                dtype=torch.float16,
+                device=device,
+            ),
+            "flat_token": torch.arange(
+                chunk,
+                dtype=torch.int64,
+                device=device,
+            ).repeat_interleave(topk),
+            "ones": torch.ones(
+                chunk * topk,
+                dtype=torch.int64,
+                device=device,
+            ),
+        }
+        _RANK_SLICED_RUNTIMES[key] = runtime
+        logger.info_once(
+            "EXL3 rank-sliced runtime planned: Trellis m=%d..%d block_m=%d, "
+            "prefill capacity=%d chunk=%d topk=%d",
+            min_trellis_m,
+            max_trellis_m,
+            block_m,
+            max_batched_tokens,
+            chunk,
+            topk,
+        )
+        return runtime
+
+    def _apply_rank_sliced(
+        self,
+        layer: RoutedExperts,
+        x: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+    ) -> torch.Tensor:
+        runtime = self._rank_sliced_runtime(layer, x, topk_ids)
+        m = int(x.shape[0])
+        if runtime["min_trellis_m"] <= m <= runtime["max_trellis_m"]:
+            binding = runtime["api"].bind(
+                runtime["trellis_plan"],
+                scratch=runtime["trellis_scratch"],
+                a=x,
+                weights=layer.exl3_trellis_weights,
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
+            )
+            output = runtime["api"].run(binding=binding)
+            return output.to(x.dtype).clone()
+
+        if m > runtime["max_batched_tokens"]:
+            raise ValueError(
+                "EXL3 batch exceeds its planned capacity: "
+                f"m={m}, capacity={runtime['max_batched_tokens']}"
+            )
+        ext = runtime["ext"]
+        xh = runtime["xh"][:m]
+        xh.copy_(x)
+        out32 = runtime["out32"][:m]
+        out32.zero_()
+        chunk = int(runtime["chunk"])
+        pointer_args = layer.exl3_pointer_tables
+        if m > chunk and hasattr(ext, "exl3_moe_fused"):
+            ext.exl3_moe_fused(
+                xh,
+                out32,
+                topk_ids,
+                topk_weights,
+                layer.exl3_expert_map,
+                runtime["expert_count"],
+                runtime["expert_offsets"],
+                runtime["token_sorted"],
+                runtime["weight_sorted"],
+                runtime["tg"],
+                runtime["tu"],
+                runtime["ig"],
+                runtime["iu"],
+                0,
+                3,
+                3,
+                3,
+                *pointer_args,
+                True,
+                False,
+                True,
+                False,
+                True,
+                False,
+                0.0,
+                0,
+            )
+            return out32.to(x.dtype).clone()
+
+        local_ids = layer.exl3_expert_map[topk_ids.long()]
+        half_weights = topk_weights.to(torch.float16)
+        topk = int(runtime["topk"])
+        for start in range(0, m, chunk):
+            current_m = min(chunk, m - start)
+            flat = local_ids[start : start + current_m].reshape(-1)
+            order = torch.argsort(flat)
+            route_count = current_m * topk
+            token_ids = runtime["flat_token"][:route_count].index_select(0, order)
+            route_weights = (
+                half_weights[start : start + current_m]
+                .reshape(-1)
+                .index_select(0, order)
+            )
+            counts = runtime["expert_count"]
+            counts.zero_()
+            counts.scatter_add_(0, flat, runtime["ones"][:route_count])
+            ext.exl3_moe(
+                xh[start : start + current_m],
+                out32[start : start + current_m],
+                counts,
+                token_ids,
+                route_weights,
+                runtime["tg"],
+                runtime["tu"],
+                runtime["ig"],
+                runtime["iu"],
+                0,
+                3,
+                3,
+                3,
+                *pointer_args,
+                True,
+                False,
+                True,
+                False,
+                True,
+                False,
+                0.0,
+            )
+        return out32.to(x.dtype).clone()
+
     def apply(
         self,
         layer: RoutedExperts,
         x: torch.Tensor,
         topk_weights: torch.Tensor,
         topk_ids: torch.Tensor,
-        shared_experts: "SharedExperts | None",
+        shared_experts: SharedExperts | None,
         shared_experts_input: torch.Tensor | None,
     ) -> torch.Tensor:
         del shared_experts, shared_experts_input
@@ -1169,9 +1656,16 @@ class Exl3MoEMethod(FusedMoEMethodBase):
 
         original_shape = x.shape[:-1]
         original_dtype = x.dtype
-        x_2d = x.reshape(-1, x.shape[-1]).to(torch.float16).contiguous()
-        ids = topk_ids.reshape(x_2d.shape[0], -1).to(torch.long)
-        weights = topk_weights.reshape_as(ids).to(torch.float16)
+        x_2d = x.reshape(-1, x.shape[-1]).contiguous()
+        ids = topk_ids.reshape(x_2d.shape[0], -1).contiguous()
+        weights = topk_weights.reshape_as(ids).to(torch.float32).contiguous()
+        if self.quant_config.rank_sliced_metadata is not None:
+            output = self._apply_rank_sliced(layer, x_2d, weights, ids)
+            return output.reshape(*original_shape, output.shape[-1])
+
+        x_2d = x_2d.to(torch.float16)
+        ids = ids.to(torch.long)
+        weights = weights.to(torch.float16)
         output = torch.zeros(
             (x_2d.shape[0], layer.hidden_size),
             dtype=torch.float32,
@@ -1224,22 +1718,14 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             )
         if x.shape[-1] < packed_k:
             x = torch.nn.functional.pad(x, (0, packed_k - x.shape[-1]))
-        prepared = getattr(layer, "exl3_moe_fused_prepared", {}).get(
-            (group,) + key
+        output = _exl3_gemm(
+            x,
+            trellis,
+            getattr(layer, f"{group}_suh").exl3_tensors[key],
+            getattr(layer, f"{group}_svh").exl3_tensors[key],
+            key in getattr(layer, f"{group}_mcg").exl3_tensors,
+            key in getattr(layer, f"{group}_mul1").exl3_tensors,
         )
-        if prepared is not None:
-            api = _load_b12x_dense()
-            assert api is not None
-            output = api[1](x, prepared)
-        else:
-            output = _exl3_gemm(
-                x,
-                trellis,
-                getattr(layer, f"{group}_suh").exl3_tensors[key],
-                getattr(layer, f"{group}_svh").exl3_tensors[key],
-                key in getattr(layer, f"{group}_mcg").exl3_tensors,
-                key in getattr(layer, f"{group}_mul1").exl3_tensors,
-            )
         logical_n = (
             layer.hidden_size
             if shard_id == "w2"

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -1372,6 +1372,8 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         max_trellis_m = _positive_env_int("VLLM_EXL3_TRELLIS_MAX_M", 32)
         block_m = _positive_env_int("VLLM_EXL3_TRELLIS_BLOCK_M", 8)
         chunk = _positive_env_int("VLLM_EXL3_PREFILL_CHUNK", 128)
+        prefill_trellis = os.environ.get("VLLM_EXL3_PREFILL_TRELLIS", "1") == "1"
+        prefill_block_m = _positive_env_int("VLLM_EXL3_PREFILL_BLOCK_M", 64)
         if min_trellis_m > max_trellis_m:
             raise ValueError(
                 "VLLM_EXL3_TRELLIS_MIN_M cannot exceed VLLM_EXL3_TRELLIS_MAX_M"
@@ -1394,6 +1396,8 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             max_trellis_m,
             block_m,
             chunk,
+            prefill_trellis,
+            prefill_block_m,
             layer.exl3_trellis_tile_config,
         )
         runtime = _RANK_SLICED_RUNTIMES.get(key)
@@ -1406,26 +1410,41 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             )
 
         api = _load_sparkinfer_trellis()
-        caps = api.Caps(
-            max_tokens=max_trellis_m,
-            num_topk=topk,
-            num_experts=int(layer.local_num_experts),
-            hidden_size=int(layer.exl3_hidden_size),
-            intermediate_size=int(layer.exl3_intermediate_size_per_partition),
-            route_num_experts=int(layer.local_num_experts),
-            block_size_m=block_m,
-            trellis_bits=int(self.quant_config.bits),
-            tile_config=layer.exl3_trellis_tile_config,
-            input_dtype=x.dtype,
-            device=x.device,
-        )
-        trellis_plan = api.plan(caps)
-        scratch_spec = trellis_plan.scratch_specs()[0]
-        trellis_scratch = torch.empty(
-            scratch_spec.shape,
-            dtype=scratch_spec.dtype,
-            device=scratch_spec.device,
-        )
+
+        def _plan_with_scratch(plan_max_tokens: int, plan_block_m: int):
+            caps = api.Caps(
+                max_tokens=plan_max_tokens,
+                num_topk=topk,
+                num_experts=int(layer.local_num_experts),
+                hidden_size=int(layer.exl3_hidden_size),
+                intermediate_size=int(layer.exl3_intermediate_size_per_partition),
+                route_num_experts=int(layer.local_num_experts),
+                block_size_m=plan_block_m,
+                trellis_bits=int(self.quant_config.bits),
+                tile_config=layer.exl3_trellis_tile_config,
+                input_dtype=x.dtype,
+                device=x.device,
+            )
+            plan = api.plan(caps)
+            scratch_spec = plan.scratch_specs()[0]
+            scratch = torch.empty(
+                scratch_spec.shape,
+                dtype=scratch_spec.dtype,
+                device=scratch_spec.device,
+            )
+            return plan, scratch
+
+        trellis_plan, trellis_scratch = _plan_with_scratch(max_trellis_m, block_m)
+        # Prefill batches (m > max_trellis_m) run through a second planned
+        # Trellis capacity instead of the eager ExLlamaV3 parity path. The
+        # large block keeps expert tiles streamed once per block of routed
+        # rows rather than once per 8-row block.
+        prefill_plan = None
+        prefill_scratch = None
+        if prefill_trellis and max_batched_tokens > max_trellis_m:
+            prefill_plan, prefill_scratch = _plan_with_scratch(
+                max_batched_tokens, prefill_block_m
+            )
 
         ext = _load_exl3_ext()
         required_ext = {
@@ -1443,23 +1462,33 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         intermediate_size = int(layer.exl3_intermediate_size_per_partition)
         num_experts = int(layer.local_num_experts)
         device = x.device
+        # With the prefill plan live, the parity path only ever serves
+        # m < min_trellis_m, so its persistent staging shrinks to one chunk.
+        parity_rows = (
+            max_batched_tokens
+            if prefill_plan is None
+            else min(chunk, max_batched_tokens)
+        )
         runtime = {
             "api": api,
             "trellis_plan": trellis_plan,
             "trellis_scratch": trellis_scratch,
+            "prefill_plan": prefill_plan,
+            "prefill_scratch": prefill_scratch,
             "ext": ext,
             "min_trellis_m": min_trellis_m,
             "max_trellis_m": max_trellis_m,
             "max_batched_tokens": max_batched_tokens,
+            "parity_rows": parity_rows,
             "topk": topk,
             "chunk": chunk,
             "xh": torch.empty(
-                (max_batched_tokens, hidden_size),
+                (parity_rows, hidden_size),
                 dtype=torch.float16,
                 device=device,
             ),
             "out32": torch.empty(
-                (max_batched_tokens, hidden_size),
+                (parity_rows, hidden_size),
                 dtype=torch.float32,
                 device=device,
             ),
@@ -1494,12 +1523,12 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 device=device,
             ),
             "token_sorted": torch.empty(
-                max_batched_tokens * topk,
+                parity_rows * topk,
                 dtype=torch.int64,
                 device=device,
             ),
             "weight_sorted": torch.empty(
-                max_batched_tokens * topk,
+                parity_rows * topk,
                 dtype=torch.float16,
                 device=device,
             ),
@@ -1515,12 +1544,23 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             ),
         }
         _RANK_SLICED_RUNTIMES[key] = runtime
+        prefill_arena_mib = (
+            0.0
+            if prefill_scratch is None
+            else prefill_scratch.numel() * prefill_scratch.element_size() / (1 << 20)
+        )
         logger.info_once(
             "EXL3 rank-sliced runtime planned: Trellis m=%d..%d block_m=%d, "
-            "prefill capacity=%d chunk=%d topk=%d",
+            "prefill %s capacity=%d chunk=%d topk=%d",
             min_trellis_m,
             max_trellis_m,
             block_m,
+            (
+                f"trellis block_m={prefill_block_m} "
+                f"arena={prefill_arena_mib:.1f}MiB"
+                if prefill_plan is not None
+                else "parity"
+            ),
             max_batched_tokens,
             chunk,
             topk,
@@ -1548,10 +1588,33 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             output = runtime["api"].run(binding=binding)
             return output.to(x.dtype)
 
-        if m > runtime["max_batched_tokens"]:
+        if runtime["prefill_plan"] is not None and m > runtime["max_trellis_m"]:
+            if m > runtime["max_batched_tokens"]:
+                raise ValueError(
+                    "EXL3 batch exceeds its planned capacity: "
+                    f"m={m}, capacity={runtime['max_batched_tokens']}"
+                )
+            binding = runtime["api"].bind(
+                runtime["prefill_plan"],
+                scratch=runtime["prefill_scratch"],
+                a=x,
+                weights=layer.exl3_trellis_weights,
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
+            )
+            output = runtime["api"].run(binding=binding)
+            return output.to(x.dtype)
+
+        if torch.cuda.is_current_stream_capturing():
+            raise RuntimeError(
+                "EXL3 eager parity path entered during CUDA graph capture "
+                f"(m={m}); capture sizes must lie inside the Trellis window "
+                f"[{runtime['min_trellis_m']}, {runtime['max_trellis_m']}]"
+            )
+        if m > runtime["parity_rows"]:
             raise ValueError(
-                "EXL3 batch exceeds its planned capacity: "
-                f"m={m}, capacity={runtime['max_batched_tokens']}"
+                "EXL3 batch exceeds its planned parity capacity: "
+                f"m={m}, capacity={runtime['parity_rows']}"
             )
         ext = runtime["ext"]
         xh = runtime["xh"][:m]

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -1481,6 +1481,7 @@ class DeepseekV2Model(nn.Module):
         config = vllm_config.model_config.hf_config
         quant_config = vllm_config.quant_config
         self.config = config
+        self.quant_config = quant_config
         self.device = current_platform.device_type
         self.hidden_size = config.hidden_size
         self.vocab_size = config.vocab_size
@@ -1699,12 +1700,21 @@ class DeepseekV2Model(nn.Module):
         pp_missing_layer_names = get_pp_missing_layer_names(self)
         params_dict = dict(self.named_parameters())
         loaded_params: set[str] = set()
+        rank_sliced_name = getattr(
+            self.quant_config,
+            "normalize_rank_sliced_weight_name",
+            None,
+        )
         # With index_topk_freq>1 only some layers build an indexer, yet the
         # checkpoint ships indexer weights for all of them; track the built ones.
         indexer_present_prefixes = {
             n.rsplit(".indexer.", 1)[0] for n in params_dict if ".indexer." in n
         }
         for name, loaded_weight in weights:
+            if rank_sliced_name is not None:
+                name = rank_sliced_name(name)
+                if name is None:
+                    continue
             if "rotary_emb.inv_freq" in name:
                 continue
 

--- a/vllm/model_executor/models/glm4_moe.py
+++ b/vllm/model_executor/models/glm4_moe.py
@@ -522,7 +522,16 @@ class Glm4MoeModel(nn.Module):
         params_dict = dict(self.named_parameters())
         loaded_params: set[str] = set()
         expert_params_mapping = self.get_expert_mapping()
+        rank_sliced_name = getattr(
+            self.quant_config,
+            "normalize_rank_sliced_weight_name",
+            None,
+        )
         for name, loaded_weight in weights:
+            if rank_sliced_name is not None:
+                name = rank_sliced_name(name)
+                if name is None:
+                    continue
             spec_layer = get_spec_layer_idx_from_weight_name(self.config, name)
             if spec_layer is not None:
                 continue

--- a/vllm/models/deepseek_v32/nvidia/attention.py
+++ b/vllm/models/deepseek_v32/nvidia/attention.py
@@ -398,7 +398,10 @@ class DeepseekV32Attention(MLAAttention):
         assert isinstance(slot_mapping, dict)
         mla_slot = slot_mapping.get(self.layer_name)
 
-        if self.indexer is not None:
+        # index_k is None when skip_topk (MTP draft steps 1+ under
+        # index_share_for_mtp_iteration): treat this forward as a shared
+        # layer so the step-0 top-k is reused instead of cleared/recomputed.
+        if self.indexer is not None and index_k is not None:
             has_indexer = True
             indexer_k_norm_w = self.indexer.k_norm.weight
             indexer_k_norm_bias = self.indexer.k_norm.bias
@@ -456,7 +459,7 @@ class DeepseekV32Attention(MLAAttention):
         q_nope = q_nope.transpose(0, 1)
         ql_nope = torch.bmm(q_nope, self.W_UK_T).transpose(0, 1)
 
-        if self.indexer is not None:
+        if self.indexer is not None and has_indexer:
             index_q = self.indexer.wq_b(q_c)[0]
             index_q = index_q.view(-1, self.indexer.n_head, self.indexer.head_dim)
         else:
@@ -478,7 +481,7 @@ class DeepseekV32Attention(MLAAttention):
             quantize_mqa=self._fp8_query,
         )
 
-        if self.indexer is not None:
+        if self.indexer is not None and has_indexer:
             sparse_attn_indexer(
                 q_c,
                 self.indexer.k_cache.prefix,

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -780,13 +780,21 @@ class B12xMLASparseMetadataBuilder(AttentionMetadataBuilder[B12xMLASparseMetadat
                 if num_query_tokens:
                     req_ids[:num_query_tokens] = req_id_per_token_np
 
-            if not use_dcp and cm.positions is not None and cm.positions.ndim == 1:
+            if cm.positions is not None and cm.positions.ndim == 1:
                 # Async scheduling intentionally exposes only an optimistic CPU
                 # sequence-length bound. That bound can lag when a finished slot is
                 # recycled for a shorter request, so it is not a valid causal mask
                 # for multi-token verification. Positions are authoritative on the
-                # GPU and give the exact per-token KV length for DCP1.
+                # GPU and give the exact global per-token KV length. DCP consumers
+                # need the corresponding rank-local lengths.
                 per_token_lens_t = cm.positions[:num_tokens].to(torch.int32) + 1
+                if use_dcp:
+                    per_token_lens_t = get_dcp_local_seq_lens(
+                        per_token_lens_t,
+                        self.dcp_world_size,
+                        self.dcp_rank,
+                        self.cp_kv_cache_interleave_size,
+                    )
             else:
                 # DCP needs rank-local lengths rather than global positions. Avoid
                 # the blocking lazy seq_lens D2H copy and convert the scheduler's
@@ -1056,11 +1064,15 @@ class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
         self.spec_decode_max_q = _env_int("VLLM_B12X_MLA_SPEC_DECODE_MAX_Q", 8)
         # The decode kernel handles independent one-token query rows. MTP
         # verification has multiple query rows per request, and later rows must
-        # attend to earlier draft rows in the same verifier batch. Route those
-        # batches through the extend path unless explicitly overridden.
-        self.spec_extend_as_decode = (
-            os.getenv("VLLM_B12X_MLA_SPEC_EXTEND_AS_DECODE", "0") != "0"
-        )
+        # attend to earlier draft rows in the same verifier batch. The old
+        # override was not causally correct, so keep multi-row verification on
+        # the extend path even when a stale deployment still enables it.
+        self.spec_extend_as_decode = False
+        if os.getenv("VLLM_B12X_MLA_SPEC_EXTEND_AS_DECODE", "0") != "0":
+            logger.warning_once(
+                "Ignoring VLLM_B12X_MLA_SPEC_EXTEND_AS_DECODE=1 because the "
+                "decode kernel cannot causally verify multi-row MTP batches."
+            )
 
         # Decode query rows per request (1, plus speculative draft tokens).
         q_per_req = 1
@@ -2177,12 +2189,7 @@ class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
                 B12xMLASparseImpl._shared_gather_event.record(self._ckv_gather_stream)
                 B12xMLASparseImpl._shared_gather_buf_idx = next_buf_idx
 
-        use_decode_kernel = attn_metadata.max_query_len <= 1 or (
-            self.spec_extend_as_decode
-            and attn_metadata.max_query_len <= self.spec_decode_max_q
-            and num_actual_toks <= attn_metadata.num_reqs * self.spec_decode_max_q
-            and num_actual_toks <= self._decode_max_rows
-        )
+        use_decode_kernel = attn_metadata.max_query_len <= 1
         if use_decode_kernel:
             cache_seqlens = (
                 attn_metadata.cache_seq_lens_per_req

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -16,7 +16,6 @@ from vllm.utils.deep_gemm import (
     get_paged_mqa_logits_metadata,
     has_deep_gemm,
 )
-from vllm.utils.math_utils import cdiv
 from vllm.utils.platform_utils import num_compute_units
 from vllm.v1.attention.backend import (
     AttentionBackend,
@@ -31,7 +30,6 @@ from vllm.v1.attention.backends.utils import (
     split_decodes_and_prefills,
 )
 from vllm.v1.kv_cache_interface import AttentionSpec, MLAAttentionSpec
-from vllm.v1.worker.cp_utils import get_total_cp_world_size
 
 logger = init_logger(__name__)
 
@@ -444,9 +442,9 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
             dtype=torch.int32,
             device=self.device,
         )
-        max_num_blocks_per_req = cdiv(
+        max_num_blocks_per_req = self.kv_cache_spec.max_num_blocks_per_req(
+            self.vllm_config,
             self.vllm_config.model_config.max_model_len,
-            self.kv_cache_spec.block_size * get_total_cp_world_size(),
         )
         self.expanded_block_table_buffer = torch.zeros(
             (

--- a/vllm/v1/attention/ops/dcp_alltoall.py
+++ b/vllm/v1/attention/ops/dcp_alltoall.py
@@ -20,6 +20,7 @@ Reference: https://arxiv.org/abs/2507.07120
 
 from __future__ import annotations
 
+from contextlib import ExitStack, contextmanager
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any
 
@@ -128,7 +129,7 @@ def _get_b12x_dcp_a2a_pool(
             total_heads=total_heads,
             head_dim=head_dim,
             query_head_dim=query_head_dim,
-            single_channel=True,
+            single_channel=False,
         )
         pool.for_stream()
     except Exception as exc:
@@ -164,6 +165,27 @@ def _get_b12x_dcp_a2a_pool(
         head_dim,
     )
     return pool
+
+
+@contextmanager
+def capture_b12x_dcp_a2a(
+    cp_group: GroupCoordinator,
+    stream: object = None,
+):
+    """Bind each CUDA graph manager to independent B12X DCP channels."""
+    group_id = id(cp_group.device_group)
+    matching_pools = sorted(
+        (
+            (key, pool)
+            for key, pool in _B12X_DCP_A2A_POOLS.items()
+            if key[0] == group_id
+        ),
+        key=lambda item: item[0][1:],
+    )
+    with ExitStack() as stack:
+        for _, pool in matching_pools:
+            stack.enter_context(pool.capture(stream=stream))
+        yield
 
 
 def _try_b12x_dcp_lse_reduce(

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1373,6 +1373,74 @@ def _get_kv_cache_config_packed(
     return num_blocks, kv_cache_tensors
 
 
+def _kv_cache_groups_support_block_stride(
+    kv_cache_groups: list[KVCacheGroupSpec],
+) -> bool:
+    """Whether every layer can consume an interleaved per-block backing."""
+    for group in kv_cache_groups:
+        group_spec = group.kv_cache_spec
+        layer_specs = (
+            (group_spec.kv_cache_specs[name] for name in group.layer_names)
+            if isinstance(group_spec, UniformTypeKVCacheSpecs)
+            else (group_spec,)
+        )
+        if any(
+            not isinstance(spec, AttentionSpec) or not spec.indexes_kv_by_block_stride
+            for spec in layer_specs
+        ):
+            return False
+    return True
+
+
+def _validate_kv_cache_page_layouts(
+    kv_cache_groups: list[KVCacheGroupSpec],
+) -> None:
+    """Reject padded pages for backends that require native contiguous pages."""
+    for group in kv_cache_groups:
+        group_spec = group.kv_cache_spec
+        layer_specs = (
+            ((name, group_spec.kv_cache_specs[name]) for name in group.layer_names)
+            if isinstance(group_spec, UniformTypeKVCacheSpecs)
+            else ((name, group_spec) for name in group.layer_names)
+        )
+        for layer_name, spec in layer_specs:
+            if (
+                isinstance(spec, AttentionSpec)
+                and not spec.indexes_kv_by_block_stride
+                and spec.page_size_bytes != spec.real_page_size_bytes
+            ):
+                raise ValueError(
+                    f"Layer {layer_name} requires native contiguous KV pages, "
+                    f"but its real page size {spec.real_page_size_bytes} was "
+                    f"padded to {spec.page_size_bytes}."
+                )
+
+
+def _get_kv_cache_config_unpacked_buckets(
+    vllm_config: VllmConfig,
+    kv_cache_groups: list[KVCacheGroupSpec],
+    available_memory: int,
+) -> tuple[int, list[KVCacheTensor]]:
+    """Plan contiguous tensors for a multi-page-size KV cache layout.
+
+    This uses the same block accounting and cross-group ``shared_by`` slots as
+    the packed planner, but gives each slot its own allocation. Backends that
+    require native contiguous pages can therefore use the DeepSeek-v4
+    multi-group scheduler without receiving an interleaved strided view.
+    """
+    buckets = _bucket_layers_by_page_size(kv_cache_groups)
+    total_num_bytes_per_block = sum(ps * len(slots) for ps, slots in buckets.items())
+
+    num_blocks = available_memory // total_num_bytes_per_block
+    num_blocks = may_override_num_blocks(vllm_config, num_blocks)
+    kv_cache_tensors = [
+        KVCacheTensor(size=ps * num_blocks, shared_by=slot)
+        for ps, slots in buckets.items()
+        for slot in slots
+    ]
+    return num_blocks, kv_cache_tensors
+
+
 def get_kv_cache_config_from_groups(
     vllm_config: VllmConfig,
     kv_cache_groups: list[KVCacheGroupSpec],
@@ -1398,6 +1466,8 @@ def get_kv_cache_config_from_groups(
             kv_cache_groups=kv_cache_groups,
         )
 
+    _validate_kv_cache_page_layouts(kv_cache_groups)
+
     # Determine how model runners should initialize the KV cache tensors.
     if len(kv_cache_groups) == 1 and isinstance(
         kv_cache_groups[0].kv_cache_spec, UniformTypeKVCacheSpecs
@@ -1420,9 +1490,18 @@ def get_kv_cache_config_from_groups(
     elif _use_packed_kv_cache_config(vllm_config, kv_cache_groups):
         # DeepSeek V4 uses the packed layout by default. Other multi-group
         # layouts can opt in with --enable-cross-layers.
-        num_blocks, kv_cache_tensors = _get_kv_cache_config_packed(
-            vllm_config, kv_cache_groups, available_memory
-        )
+        if _kv_cache_groups_support_block_stride(kv_cache_groups):
+            num_blocks, kv_cache_tensors = _get_kv_cache_config_packed(
+                vllm_config, kv_cache_groups, available_memory
+            )
+        else:
+            logger.info(
+                "Using contiguous KV cache tensors because at least one "
+                "attention backend does not support block-stride indexing."
+            )
+            num_blocks, kv_cache_tensors = _get_kv_cache_config_unpacked_buckets(
+                vllm_config, kv_cache_groups, available_memory
+            )
     else:
         # General case:
         # We will have group_size memory pools, each is shared by one layer from
@@ -1565,14 +1644,10 @@ def group_and_unify_kv_cache_specs(
     has_swa = any(
         isinstance(spec, SlidingWindowMLASpec) for spec in kv_cache_spec.values()
     )
-    # DFlash-under-DCP draft: full-attention layers replicated on every DCP
-    # rank. They have a different page size than the MLA target and need their
-    # own group, but the DeepseekV4 multi-group allocator (with page-size
-    # padding) handles exactly that, so route them through here too.
+    # Draft attention replicated on every DCP rank needs a separate group from
+    # the sharded target. This includes both DFlash and native MLA MTP drafts.
     has_repl = any(
-        getattr(spec, "dcp_replicated", False)
-        and not isinstance(spec, MLAAttentionSpec)
-        for spec in kv_cache_spec.values()
+        getattr(spec, "dcp_replicated", False) for spec in kv_cache_spec.values()
     )
     if not (has_swa or has_repl):
         return None
@@ -1601,7 +1676,7 @@ def group_and_unify_kv_cache_specs(
                     spec.dcp_sharded,
                 )
             ][name] = spec
-        elif isinstance(spec, MLAAttentionSpec):
+        elif isinstance(spec, MLAAttentionSpec) and not spec.dcp_replicated:
             mla_specs[name] = spec
         elif getattr(spec, "dcp_replicated", False):
             grouped_repl_specs[(spec.block_size,)][name] = spec
@@ -1718,16 +1793,19 @@ def _get_kv_cache_groups_uniform_groups(
         layers_per_size: dict[int, list[str]] = defaultdict(list)
         assert max(sm_page_sizes) <= max(all_page_sizes)
 
-        # Unify page size by padding layers' page_size to the nearest larger page_size.
-        # Compute candidate (nearest larger page_size) for each unique page size.
-        size_to_candidate: dict[int, int] = {}
-        for ps in sm_page_sizes:
-            size_to_candidate[ps] = min(x for x in all_page_sizes if x >= ps)
-        # Pad and collect layer names per page size.
+        # Backends that index by the runtime block stride can pad to a target
+        # MLA page bucket. Native-layout backends retain their real page size;
+        # the allocator gives those buckets separate contiguous tensors.
         for layer_name, layer_spec in sm_spec.kv_cache_specs.items():
             current_size = layer_spec.page_size_bytes
-            candidate = size_to_candidate[current_size]
-            if current_size < candidate:
+            larger_target_sizes = [x for x in all_page_sizes if x >= current_size]
+            can_pad = (
+                isinstance(layer_spec, AttentionSpec)
+                and layer_spec.indexes_kv_by_block_stride
+                and larger_target_sizes
+            )
+            candidate = min(larger_target_sizes) if can_pad else current_size
+            if candidate != current_size:
                 object.__setattr__(layer_spec, "page_size_padded", candidate)
             layers_per_size[candidate].append(layer_name)
         # NOTE(yifan): for now, inside a UniformKV group, each page_size should
@@ -1916,27 +1994,18 @@ def _max_memory_usage_bytes_from_groups(
         isinstance(group.kv_cache_spec, UniformTypeKVCacheSpecs)
         for group in kv_cache_groups
     ):
-        # Special case (only DeepseekV4 for now): all groups are
-        # UniformTypeKVCacheSpecs.
-        # They must already be page_size aligned and share a common padded
-        # layer-tuple layout. Even groups with fewer actual tuples still reserve
-        # the global number of tuple slots in the shared tensor layout.
-        full_mla_spec = cast(UniformTypeKVCacheSpecs, kv_cache_groups[0].kv_cache_spec)
-        layer_tuple_bytes = sum(full_mla_spec.get_page_sizes())
-        num_layer_tuples = max(
-            cast(UniformTypeKVCacheSpecs, group.kv_cache_spec).get_num_layer_tuples()
+        # All groups draw block IDs from one global pool. Every live block ID
+        # occupies one slot in every physical page-size bucket, while a request
+        # consumes the sum of its per-group page counts. This formula applies
+        # to both interleaved and separate-contiguous bucket layouts.
+        pool_bytes_per_block = _pool_bytes_per_block(vllm_config, kv_cache_groups)
+        request_blocks = sum(
+            cast(UniformTypeKVCacheSpecs, group.kv_cache_spec).max_memory_usage_pages(
+                vllm_config
+            )
             for group in kv_cache_groups
         )
-
-        total_max_mem_usage_bytes = 0
-        for group in kv_cache_groups:
-            group_spec = cast(UniformTypeKVCacheSpecs, group.kv_cache_spec)
-            g_max_mem_usage_pages = group_spec.max_memory_usage_pages(vllm_config)
-            g_max_mem_usage_page_bytes = (
-                num_layer_tuples * g_max_mem_usage_pages * layer_tuple_bytes
-            )
-            total_max_mem_usage_bytes += g_max_mem_usage_page_bytes
-        return total_max_mem_usage_bytes
+        return pool_bytes_per_block * request_blocks
 
     # General case: group_size pools, each shared by one layer per group
     # Memory = group_size * page_size * blocks_for_max_len

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1756,7 +1756,9 @@ class Scheduler(SchedulerInterface):
                 request.status = RequestStatus.FINISHED_STOPPED
                 stopped = True
 
-            if new_token_ids and self.structured_output_manager.should_advance(request):
+            if new_token_ids and self.structured_output_manager.should_advance(
+                request, new_token_ids
+            ):
                 struct_output_request = request.structured_output_request
                 assert struct_output_request is not None
                 grammar = struct_output_request.grammar

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -225,11 +225,16 @@ class AttentionSpec(KVCacheSpec):
 
     def max_num_blocks_per_req(self, vllm_config: VllmConfig, max_len: int) -> int:
         # Attention KV is token-interleaved across DCP/PCP ranks, so each rank
-        # only stores max_len // (dcp * pcp) tokens per request.
+        # only stores max_len // (dcp * pcp) tokens per request. Replicated
+        # draft groups retain the full global block table on every rank.
         parallel_config = vllm_config.parallel_config
         total_cp_size = (
-            parallel_config.decode_context_parallel_size
-            * parallel_config.prefill_context_parallel_size
+            1
+            if self.dcp_replicated
+            else (
+                parallel_config.decode_context_parallel_size
+                * parallel_config.prefill_context_parallel_size
+            )
         )
         return cdiv(max_len, self.block_size * total_cp_size)
 

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -362,9 +362,7 @@ class StructuredOutputManager:
                 # After unifying the `openai_gptoss` and non-`openai_gptoss` styles,
                 # it can be removed.
                 request.structured_output_request.reasoning_ended = (
-                    reasoner.is_reasoning_end_for_prompt(
-                        request.prompt_token_ids or []
-                    )
+                    reasoner.is_reasoning_end_for_prompt(request.prompt_token_ids or [])
                 )
             return request.structured_output_request.reasoning_ended
         return True

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -15,7 +15,6 @@ from vllm.v1.structured_output.backend_guidance import GuidanceBackend
 from vllm.v1.structured_output.backend_types import (
     StructuredOutputBackend,
     StructuredOutputGrammar,
-    StructuredOutputOptions,
 )
 from vllm.v1.structured_output.backend_xgrammar import XgrammarBackend
 
@@ -370,7 +369,9 @@ class StructuredOutputManager:
             return request.structured_output_request.reasoning_ended
         return True
 
-    def should_advance(self, request: "Request") -> bool:
+    def should_advance(
+        self, request: "Request", new_token_ids: Sequence[int] | None = None
+    ) -> bool:
         if not request.use_structured_output:
             return False
 
@@ -393,33 +394,38 @@ class StructuredOutputManager:
         if structured_req.reasoning_ended:
             return True
 
-        # Check if reasoning ends in *this* step
-        delta_from = request.num_computed_tokens - request.num_output_placeholders
+        # Check if reasoning ends in *this* step. Prefer the caller's actual
+        # new_token_ids over reconstructing the step window from scheduler
+        # counters: with speculative decoding, num_computed_tokens is already
+        # advanced past the accepted draft tokens when this runs, so the
+        # counter-derived window can miss the reasoning-end marker.
         all_token_ids = request.all_token_ids
-        start = (
-            delta_from if delta_from >= 0 else max(len(all_token_ids) + delta_from, 0)
-        )
-        if reasoner.is_reasoning_end_streaming(
-            all_token_ids, itertools.islice(all_token_ids, start, None)
-        ):
+        if new_token_ids is not None:
+            start = max(len(all_token_ids) - len(new_token_ids), 0)
+            delta: Iterable[int] = new_token_ids
+        else:
+            delta_from = request.num_computed_tokens - request.num_output_placeholders
+            start = (
+                delta_from
+                if delta_from >= 0
+                else max(len(all_token_ids) + delta_from, 0)
+            )
+            delta = itertools.islice(all_token_ids, start, None)
+        if reasoner.is_reasoning_end_streaming(all_token_ids, delta):
             structured_req.reasoning_ended = True
 
-            # Reasoning just ended this step. Defer FSM advance until the next
-            # pass (see reasoning_ended check above) for JSON/regex/choice/grammar:
-            # advancing on the closing boundary token can accept tokens that still
-            # belong to the reasoning stream. Structural tags are the only safe
-            # same-step exception: they model phased output (e.g. thinking tag ->
-            # answer tag), and speculative decoding must run grammar.validate_tokens
-            # on draft tokens produced immediately after that transition.
-            if (
-                self.vllm_config.speculative_config is not None
-                and structured_req.structured_output_key[0]
-                == StructuredOutputOptions.STRUCTURAL_TAG
-            ):
-                # The scheduler will advance the grammar with this step's
-                # tokens right away, but the step still contains reasoning
-                # content up to and including the end marker. Record where
-                # it ends so trim_reasoning_for_advance() can drop it.
+            # Reasoning just ended this step. Without speculative decoding the
+            # boundary step ends at the marker, so deferring the FSM advance to
+            # the next pass (see reasoning_ended check above) is safe. With
+            # speculative decoding the same step can already contain accepted
+            # post-marker content (e.g. a drafted "{" verified right after the
+            # end marker); deferring would leave the grammar permanently one
+            # token behind the sampled stream, and the next bitmask would then
+            # force a duplicate of a token the model already emitted. Advance
+            # same-step for every structured type: trim_reasoning_for_advance()
+            # drops everything up to and including the marker, so the grammar
+            # never sees reasoning content.
+            if self.vllm_config.speculative_config is not None:
                 structured_req.reasoning_end_token_index = (
                     self._find_reasoning_end_index(reasoner, all_token_ids, start)
                 )

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -124,7 +124,7 @@ from vllm.v1.worker.gpu.states import RequestState
 from vllm.v1.worker.gpu.structured_outputs import StructuredOutputsWorker
 from vllm.v1.worker.lora_model_runner_mixin import LoRAModelRunnerMixin
 from vllm.v1.worker.utils import KVBlockZeroer, copy_kv_cache_blocks_inplace
-from vllm.v1.worker.workspace import lock_workspace
+from vllm.v1.worker.workspace import lock_workspace, use_workspace_lane
 
 logger = init_logger(__name__)
 
@@ -345,10 +345,11 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 assert self.speculative_config is not None
                 set_eagle3_aux_hidden_state_layers(self.model, self.speculative_config)
             if isinstance(self.speculator, DraftModelSpeculator):
-                self.speculator.load_model(self.model)
-                eplb_models_added = self.eplb.maybe_register_speculator(
-                    self.speculator, self.speculative_config, load_dummy_weights
-                )
+                with use_workspace_lane(1):
+                    self.speculator.load_model(self.model)
+                    eplb_models_added = self.eplb.maybe_register_speculator(
+                        self.speculator, self.speculative_config, load_dummy_weights
+                    )
         time_after_load = time.perf_counter()
 
         self.model_memory_usage = m.consumed_memory
@@ -550,25 +551,27 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         )
         check_attention_cp_compatibility(self.vllm_config)
         if isinstance(self.speculator, DraftModelSpeculator):
-            # HACK(woosuk)
-            self.speculator.set_attn(
-                self.model_state,
-                self.kv_cache_config,
-                self.block_tables,
-                self.input_buffers,
-                self.attn_groups,
-            )
-            if hasattr(self.speculator, "set_num_cached_tokens"):
-                # DFlash/DSpark mask cache-restored tokens out of the draft's
-                # context (their draft context KV was never computed).
-                self.speculator.set_num_cached_tokens(
-                    self.req_states.num_cached_tokens.gpu,
-                    self.req_states.num_cached_tokens_np,
+            with use_workspace_lane(1):
+                # HACK(woosuk)
+                self.speculator.set_attn(
+                    self.model_state,
+                    self.kv_cache_config,
+                    self.block_tables,
+                    self.input_buffers,
+                    self.attn_groups,
                 )
+                if hasattr(self.speculator, "set_num_cached_tokens"):
+                    # DFlash/DSpark mask cache-restored tokens out of the draft's
+                    # context (their draft context KV was never computed).
+                    self.speculator.set_num_cached_tokens(
+                        self.req_states.num_cached_tokens.gpu,
+                        self.req_states.num_cached_tokens_np,
+                    )
         if self.speculator is not None:
             # After set_attn, so the speculator can size its cudagraph mode
             # to its own attention support.
-            self.speculator.init_cudagraph_manager(cudagraph_mode)
+            with use_workspace_lane(1):
+                self.speculator.init_cudagraph_manager(cudagraph_mode)
 
         self.kv_caches: list[torch.Tensor] = []
         kv_caches_dict = init_kv_cache(
@@ -710,27 +713,28 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             if hasattr(self.model, "get_mtp_target_hidden_states"):
                 pre_hc_hidden_states = self.model.get_mtp_target_hidden_states()
                 spec_hidden_states = pre_hc_hidden_states[: hidden_states.shape[0]]  # type: ignore[union-attr]
-            self.speculator.propose(
-                input_batch=input_batch,
-                attn_metadata=attn_metadata,
-                slot_mappings=slot_mappings_by_layer,
-                last_hidden_states=spec_hidden_states,
-                aux_hidden_states=aux_hidden_states,
-                num_sampled=torch.ones(
-                    input_batch.num_reqs, dtype=torch.int32, device=self.device
-                ),
-                num_rejected=torch.zeros(
-                    input_batch.num_reqs, dtype=torch.int32, device=self.device
-                ),
-                last_sampled=self.req_states.last_sampled_tokens,
-                next_prefill_tokens=self.req_states.next_prefill_tokens,
-                temperature=self.sampler.sampling_states.temperature.gpu,
-                seeds=self.sampler.sampling_states.seeds.gpu,
-                dummy_run=True,
-                skip_attn_for_dummy_run=skip_attn,
-                mm_inputs=mm_inputs,
-                is_profile=is_profile,
-            )
+            with use_workspace_lane(1):
+                self.speculator.propose(
+                    input_batch=input_batch,
+                    attn_metadata=attn_metadata,
+                    slot_mappings=slot_mappings_by_layer,
+                    last_hidden_states=spec_hidden_states,
+                    aux_hidden_states=aux_hidden_states,
+                    num_sampled=torch.ones(
+                        input_batch.num_reqs, dtype=torch.int32, device=self.device
+                    ),
+                    num_rejected=torch.zeros(
+                        input_batch.num_reqs, dtype=torch.int32, device=self.device
+                    ),
+                    last_sampled=self.req_states.last_sampled_tokens,
+                    next_prefill_tokens=self.req_states.next_prefill_tokens,
+                    temperature=self.sampler.sampling_states.temperature.gpu,
+                    seeds=self.sampler.sampling_states.seeds.gpu,
+                    dummy_run=True,
+                    skip_attn_for_dummy_run=skip_attn,
+                    mm_inputs=mm_inputs,
+                    is_profile=is_profile,
+                )
             if sps_debug is not None:
                 ev[2].record()
                 sps_debug.append(ev)
@@ -826,7 +830,8 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 lora_capture_hook=create_lora_capture_hook(self.lora_config, self),
             )
             if self.speculator is not None:
-                self.speculator.capture()
+                with use_workspace_lane(1):
+                    self.speculator.capture()
             self._zero_cudagraph_capture_kv_blocks()
 
         end_time = time.perf_counter()
@@ -1786,7 +1791,10 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             if hasattr(self.model, "get_mtp_target_hidden_states"):
                 pre_hc_hidden_states = self.model.get_mtp_target_hidden_states()
                 spec_hidden_states = pre_hc_hidden_states[: hidden_states.shape[0]]  # type: ignore[union-attr]
-            with record_function_or_nullcontext(f"vllm:v2/speculator/{phase}/propose"):
+            with (
+                use_workspace_lane(1),
+                record_function_or_nullcontext(f"vllm:v2/speculator/{phase}/propose"),
+            ):
                 draft_tokens = self.speculator.propose(
                     input_batch,
                     attn_metadata,
@@ -1829,7 +1837,10 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 self.verification_capacity_manager is not None
                 and not self.verification_capacity_manager.capacity_bypassed
             ):
-                draft_token_capacity = self.speculator.compute_capacities(input_batch)
+                with use_workspace_lane(1):
+                    draft_token_capacity = self.speculator.compute_capacities(
+                        input_batch
+                    )
                 assert draft_token_capacity is not None
                 self.verification_capacity_manager.update_capacities(
                     draft_token_capacity

--- a/vllm/v1/worker/gpu/spec_decode/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/speculator.py
@@ -315,6 +315,7 @@ class DraftModelSpeculator(BaseSpeculator):
                 kv_cache_config=self.kv_cache_config,
                 causal=causal,
                 dcp_local_seq_lens=dcp_local_seq_lens,
+                positions=self.input_buffers.positions[:num_tokens_padded],
                 seq_lens_cpu_upper_bound=seq_lens_cpu_upper_bound,
                 max_seq_len_upper_bound=max_seq_len_upper_bound,
             )

--- a/vllm/v1/worker/gpu/warmup.py
+++ b/vllm/v1/worker/gpu/warmup.py
@@ -21,6 +21,7 @@ from vllm.v1.core.sched.output import (
 from vllm.v1.kv_cache_interface import CrossAttentionSpec, MambaSpec
 from vllm.v1.request import Request
 from vllm.v1.worker.gpu.model_runner import GPUModelRunner
+from vllm.v1.worker.workspace import use_workspace_lane
 
 logger = init_logger(__name__)
 
@@ -348,7 +349,8 @@ def warmup_kernels(
                 model_runner.input_buffers
             )
             assert model_runner.speculator is not None
-            model_runner.speculator.warmup_capacity_kernels()
+            with use_workspace_lane(1):
+                model_runner.speculator.warmup_capacity_kernels()
             if model_runner.speculator.wants_auto_sps_curve:
                 _profile_sps_curve(model_runner)
                 model_runner.kv_connector.set_disabled(True)

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -397,9 +397,16 @@ class Worker(WorkerBase):
         else:
             raise RuntimeError(f"Unsupported device type: {self.device_config.device}")
 
-        # Initialize workspace manager
+        # Target and speculative captures retain workspace views concurrently,
+        # so speculative V2 execution needs a separate ownership lane.
         num_ubatches = 2 if self.vllm_config.parallel_config.enable_dbo else 1
-        init_workspace_manager(self.device, num_ubatches)
+        num_workspace_lanes = (
+            2
+            if self.use_v2_model_runner
+            and self.vllm_config.speculative_config is not None
+            else 1
+        )
+        init_workspace_manager(self.device, num_ubatches, num_workspace_lanes)
 
         # Construct the model runner
         if self.use_v2_model_runner:

--- a/vllm/v1/worker/workspace.py
+++ b/vllm/v1/worker/workspace.py
@@ -3,6 +3,9 @@
 
 import inspect
 import os
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
 from itertools import accumulate
 from math import prod
 
@@ -26,22 +29,48 @@ _GiB = 1024**3
 
 # Global workspace manager instance
 _manager: "WorkspaceManager | None" = None
+_workspace_lane: ContextVar[int] = ContextVar("vllm_workspace_lane", default=0)
+
+
+@contextmanager
+def use_workspace_lane(lane: int) -> Iterator[None]:
+    """Select the workspace owner for this execution context.
+
+    Target execution uses lane 0; speculative execution uses lane 1 so a
+    captured graph cannot retain views into the target graph's buffer.
+    """
+    if lane < 0:
+        raise ValueError(f"Workspace lane must be non-negative, got {lane}.")
+    token = _workspace_lane.set(lane)
+    try:
+        yield
+    finally:
+        _workspace_lane.reset(token)
 
 
 class WorkspaceManager:
     """Manager for workspace allocation.
 
-    Manages one workspace buffer per active ubatch slot.
-    Can be locked to prevent further growth during execution.
+    Owns one reusable buffer per ``(ubatch, lane)``. Separate lanes prevent
+    target and draft graphs from retaining views into the same allocation.
+    The manager can be locked to prevent growth during execution.
     """
 
-    def __init__(self, device: torch.device, num_ubatches: int | None = None):
+    def __init__(
+        self,
+        device: torch.device,
+        num_ubatches: int | None = None,
+        num_lanes: int = 1,
+    ):
         self._device = device
         # Cache num ubatches at init based on configuration (default to 1)
         self._num_ubatches = num_ubatches if num_ubatches is not None else 1
-        self._current_workspaces: list[torch.Tensor | None] = [
-            None
-        ] * self._num_ubatches
+        if num_lanes < 1:
+            raise ValueError(f"num_lanes must be at least one, got {num_lanes}.")
+        self._num_lanes = num_lanes
+        self._current_workspaces: list[torch.Tensor | None] = [None] * (
+            self._num_ubatches * self._num_lanes
+        )
         self._locked: bool = False
 
     @staticmethod
@@ -126,7 +155,14 @@ class WorkspaceManager:
             The current workspace tensor.
         """
         ubatch_id = dbo_current_ubatch_id()
-        current_workspace = self._current_workspaces[ubatch_id]
+        lane = _workspace_lane.get()
+        if lane >= self._num_lanes:
+            raise RuntimeError(
+                f"Workspace lane {lane} is not configured; manager has "
+                f"{self._num_lanes} lane(s)."
+            )
+        workspace_id = ubatch_id * self._num_lanes + lane
+        current_workspace = self._current_workspaces[workspace_id]
         current_size = self._workspace_size_bytes(current_workspace)
 
         if current_size < required_bytes:
@@ -161,11 +197,10 @@ class WorkspaceManager:
                     "Workspace growth is not allowed after locking."
                 )
 
-            # Only resize the requesting ubatch's workspace.  Other
-            # ubatches resize lazily on their next get_simultaneous call.
-            # Resizing all ubatches here would orphan the other ubatch's
-            # old tensor when it still holds views into it (DBO leak).
-            self._current_workspaces[ubatch_id] = None
+            # Only resize the requesting ubatch/lane workspace. Other slots
+            # resize lazily on their next get_simultaneous call. Resizing all
+            # slots here would orphan a tensor that still has live views.
+            self._current_workspaces[workspace_id] = None
             del current_workspace
             # Release the freed segment back to CUDA so the caching
             # allocator can reuse the GPU memory for the larger
@@ -173,19 +208,20 @@ class WorkspaceManager:
             # dead segment in reserved memory which can cause higher peak
             # memory usage.
             torch.accelerator.empty_cache()
-            self._current_workspaces[ubatch_id] = torch.empty(
+            self._current_workspaces[workspace_id] = torch.empty(
                 (required_bytes,), dtype=torch.uint8, device=self._device
             )
-            current_workspace = self._current_workspaces[ubatch_id]
+            current_workspace = self._current_workspaces[workspace_id]
 
             if envs.VLLM_DEBUG_WORKSPACE:
                 logger.info(
                     "[WORKSPACE DEBUG] Resized workspace from '%s': %.2f MB -> "
-                    "%.2f MB (ubatch %d)",
+                    "%.2f MB (ubatch %d, lane %d)",
                     get_caller_info(),
                     current_size / _MB,
                     required_bytes / _MB,
                     ubatch_id,
+                    lane,
                 )
 
         return current_workspace
@@ -214,7 +250,9 @@ def current_workspace_manager() -> "WorkspaceManager":
 
 
 def init_workspace_manager(
-    device: torch.device, num_ubatches: int | None = None
+    device: torch.device,
+    num_ubatches: int | None = None,
+    num_lanes: int = 1,
 ) -> None:
     """Initialize the workspace manager with a device.
 
@@ -224,6 +262,7 @@ def init_workspace_manager(
     Args:
         device: The device to allocate workspace on.
         num_ubatches: Number of workspace ubatch slots. Defaults to 1.
+        num_lanes: Number of independent execution lanes per ubatch. Defaults to 1.
     """
     global _manager
     if _manager is not None:
@@ -233,7 +272,7 @@ def init_workspace_manager(
             _manager._device,
             device,
         )
-    _manager = WorkspaceManager(device, num_ubatches)
+    _manager = WorkspaceManager(device, num_ubatches, num_lanes)
 
 
 def lock_workspace() -> None:

--- a/vllm/v1/worker/workspace.py
+++ b/vllm/v1/worker/workspace.py
@@ -38,6 +38,13 @@ def use_workspace_lane(lane: int) -> Iterator[None]:
 
     Target execution uses lane 0; speculative execution uses lane 1 so a
     captured graph cannot retain views into the target graph's buffer.
+
+    Args:
+        lane: Workspace owner index for this context. Must be non-negative;
+            target execution uses ``0`` and speculative execution uses ``1``.
+
+    Raises:
+        ValueError: If ``lane`` is negative.
     """
     if lane < 0:
         raise ValueError(f"Workspace lane must be non-negative, got {lane}.")


### PR DESCRIPTION
> **Status (2026-07-22): incorporated into #139 (commits `a59770430`/`f83fc162f`, byte-identical, authorship preserved) as of its v20 rebase. Review #139; this PR is the isolated pre-rebase review scope and closes when #139 merges.**

> **Stacked on #139** (@brandonmusic's rank-sliced EXL3 backend); this branch is based on the #139 head (`2fdc6d3676`), so the Files-changed tab includes its commits until #139 merges. **Review scope — exactly this PR's changes:** [compare `2fdc6d3676...exl3-prefill-trellis-plan`](https://github.com/davidsyoung/vllm/compare/2fdc6d3676...exl3-prefill-trellis-plan) · commit [`d57d77534` (the fix, `exl3.py` only, +91/−28)](https://github.com/local-inference-lab/vllm/pull/163/commits/d57d77534) · commit [`f80a56df1` (optional CPU tests — happy to drop)](https://github.com/local-inference-lab/vllm/pull/163/commits/f80a56df1). Will rebase after #139 lands so the PR contains only its own commits.

Stacked on your `exl3-backend` branch (local-inference-lab/vllm#139) — merging here lands the commits inside #139 with no history rewrite. No change to weight loading, formats, or the decode path; this only extends the rank-sliced batch dispatch.

## Problem

`_apply_rank_sliced` serves every batch with `m > 32` through the eager `exllamav3_ext` parity path: fp16-in/fp32-out staging (~25 GB extra HBM traffic per 4096-token step at GLM-5.2 geometry), python chunk loops, and one expert re-stream per 128-row chunk. That covers 100% of prefill, capping prefill at ~2.0–2.3k tok/s while the same weights decode at full speed through the planned Trellis window.

## Change

Build a second `trellis_moe` plan at `max_tokens=max_num_batched_tokens` with `block_size_m=64` (`VLLM_EXL3_PREFILL_BLOCK_M`, allowed {8,16,32,48,64}) beside the decode plan (32/8), and dispatch three ways:

- `m ∈ [min, max]` → decode plan (unchanged)
- `max < m ≤ capacity` → prefill plan — sparkinfer `bind` already accepts any `tokens ∈ [1, max_tokens]`, so zero kernel changes are needed
- `m < min` → parity path, whose persistent staging (`xh/out32/token_sorted/weight_sorted`) shrinks from capacity rows to one chunk while the prefill plan is live (~110 MiB/GPU returned)

`VLLM_EXL3_PREFILL_TRELLIS=0` restores the exact single-plan parity behavior (one-variable serving A/B lever). The parity branch now raises during CUDA graph capture instead of silently recording eager ext calls. The prefill arena (~1.05 GiB/GPU at capacity 3072) allocates during the profile pass, so the memory profiler sees it and the KV pool auto-shrinks instead of risking request-time OOM.

## Measured

Matched A/B serving `brandonmusic/GLM-5.2-EXL3-TR3-3.0bpw` on your published `verdictai/glm52-exl3-sparkinfer` runtime image (4× RTX PRO 6000 Blackwell, TP4/DCP4/MTP3, identical boot geometry, only the kill-switch flipped, fresh JIT cache both arms; llm_decode_bench prefill-only, exact `/tokenize`, C1, 60 s/context):

| ctx | parity | trellis | delta |
|---|---:|---:|---:|
| 8k | 2,287 | 3,742 | +63.6% |
| 32k | 2,218 | 3,557 | +60.4% |
| 64k | 2,078 | 3,381 | +62.7% |
| 128k | 1,920 | 3,032 | +57.9% |

Decode C1 unchanged-to-better (99.7→101.8 aggregate across our runs); 57k-token needle retrieval exact; zero request errors.

Second commit adds CPU contract tests (mocked plan/ext APIs, no GPU/sparkinfer/ext needed) following the `test_exl3.py` pattern — happy to drop it if you'd rather keep the branch minimal.

Related build-compat PR on the sparkinfer side (independent, for PyPI DSL 4.6.0 users): see the companion PR on `exl3-trellis-fused`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for EXL3-quantized models, including rank-sliced MoE checkpoints.
  * Improved KV-cache handling for contiguous layouts and replicated attention workloads.
  * Added safer workspace separation for speculative decoding.

* **Bug Fixes**
  * Improved structured-output reasoning boundary handling during speculative decoding.
  * Corrected sparse attention metadata and DeepSeek shared-layer behavior.
  * Refined PCIe communication buffer sizing and defaults for improved reliability.

* **Tests**
  * Expanded coverage for quantization, attention, KV-cache layouts, distributed execution, structured output, and workspace management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
