### PR TITLE
[GG] perf(attention): restore B12X MTP decode fast path

### DIFF
--- a/tests/v1/attention/test_sparse_mla_backends.py
+++ b/tests/v1/attention/test_sparse_mla_backends.py
@@ -43,6 +43,7 @@ from vllm.v1.attention.backends.mla.b12x_mla_sparse import (
     _global_causal_lens_for_ckv_gather,
 )
 from vllm.v1.attention.backends.mla.flashinfer_mla_sparse import (
+    FlashInferMLASparseSM120Backend,
     FlashInferMLASparseTRTLLMBackend,
 )
 from vllm.v1.attention.backends.mla.flashmla_sparse import (
@@ -272,6 +273,55 @@ def test_b12x_sparse_rejects_incompatible_indexer_output(
             qk_rope_head_dim=64,
             v_head_dim=512,
         )
+
+
+@pytest.mark.parametrize(
+    ("mode", "expected_rows"),
+    [("0", 2), ("auto", 8), ("1", 16)],
+)
+def test_b12x_sparse_spec_decode_scratch_capacity(
+    default_vllm_config,
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_init,
+    mode: str,
+    expected_rows: int,
+) -> None:
+    if not current_platform.has_device_capability(120):
+        pytest.skip("B12xMLASparseBackend requires SM 12.0")
+    if importlib.util.find_spec("sparkinfer") is None:
+        pytest.skip("sparkinfer package not available")
+
+    default_vllm_config.scheduler_config.max_num_batched_tokens = 64
+    default_vllm_config.scheduler_config.max_num_seqs = 2
+    default_vllm_config.speculative_config = SimpleNamespace(num_speculative_tokens=3)
+    monkeypatch.setenv("VLLM_B12X_MLA_SPEC_EXTEND_AS_DECODE", mode)
+    monkeypatch.setattr(
+        B12xMLASparseImpl,
+        "_prewarm_extend_kernels_once",
+        lambda self, max_batched: None,
+    )
+
+    impl = B12xMLASparseImpl(
+        num_heads=8,
+        head_size=576,
+        scale=1.0 / math.sqrt(576),
+        num_kv_heads=1,
+        alibi_slopes=None,
+        sliding_window=None,
+        kv_cache_dtype="fp8_ds_mla",
+        logits_soft_cap=None,
+        attn_type="decoder",
+        kv_sharing_target_layer_name=None,
+        topk_indices_buffer=torch.zeros(
+            (64, 2048), dtype=torch.int32, device=DEVICE_TYPE
+        ),
+        kv_lora_rank=512,
+        qk_nope_head_dim=512,
+        qk_rope_head_dim=64,
+        v_head_dim=512,
+    )
+
+    assert impl._decode_max_rows == expected_rows
 
 
 @pytest.mark.parametrize(
@@ -798,16 +848,16 @@ def test_sparse_backend_decode_correctness(
             device_capability
         ):
             pytest.skip("FlashInferMLASparseTRTLLMBackend requires SM 10.x capability")
-    elif backend_cls == B12xMLASparseBackend:
+    elif backend_cls in (B12xMLASparseBackend, FlashInferMLASparseSM120Backend):
         if not current_platform.has_device_capability(120):
-            pytest.skip("B12xMLASparseBackend requires SM 12.0 (consumer Blackwell)")
-        if importlib.util.find_spec("sparkinfer") is None:
+            pytest.skip(f"{backend_cls.get_name()} requires SM 12.0")
+        if (
+            backend_cls is B12xMLASparseBackend
+            and importlib.util.find_spec("sparkinfer") is None
+        ):
             pytest.skip("sparkinfer package not available")
         if kv_cache_dtype != "fp8_ds_mla":
-            # SparkInfer's GLM_NSA kernel consumes the fp8_ds_mla 656 B/token
-            # record (raw e4m3 + inline FP32 scales). The other cache dtypes are
-            # advertised for the serving alias path but not exercised here.
-            pytest.skip("b12x sparse MLA is validated with the fp8_ds_mla cache")
+            pytest.skip("SM120 sparse MLA is validated with the fp8_ds_mla cache")
 
     batch_spec = SPARSE_BACKEND_BATCH_SPECS[batch_name]
     use_fp8_ds_mla_quantization = kv_cache_dtype == "fp8_ds_mla"
@@ -828,7 +878,11 @@ def test_sparse_backend_decode_correctness(
     # GLM 5.2 selects 2048 rows. Keep the shared backend test small for other
     # implementations, but validate b12x at the model's real contract instead of
     # relying on a smaller kernel-supported regime.
-    topk_tokens = 2048 if backend_cls is B12xMLASparseBackend else 128
+    topk_tokens = (
+        2048
+        if backend_cls in (B12xMLASparseBackend, FlashInferMLASparseSM120Backend)
+        else 128
+    )
 
     max_seqlen = max(batch_spec.seq_lens)
     total_cache_tokens = sum(batch_spec.seq_lens)
@@ -853,7 +907,11 @@ def test_sparse_backend_decode_correctness(
         qk_nope_head_dim=qk_nope_head_dim,
         qk_rope_head_dim=qk_rope_head_dim,
         v_head_dim=v_head_dim,
-        model_type="deepseek_v2",
+        model_type=(
+            "glm4_moe"
+            if backend_cls in (B12xMLASparseBackend, FlashInferMLASparseSM120Backend)
+            else "deepseek_v2"
+        ),
     )
     model_config.dtype = dtype
     model_config.get_num_attention_heads = MethodType(
@@ -954,16 +1012,18 @@ def test_sparse_backend_decode_correctness(
             # kernel instead keeps the raw e4m3 K with the inline arbitrary-FP32
             # group scale (it is incompatible with ue8m0 block-scaling), so for
             # B12x the reference must dequantize with the true FP32 scales.
-            is_sm100 = (
-                torch.cuda.get_device_capability()[0] >= 10
-                and backend_cls is not B12xMLASparseBackend
+            uses_pow2_scales = torch.cuda.get_device_capability()[
+                0
+            ] >= 10 and backend_cls not in (
+                B12xMLASparseBackend,
+                FlashInferMLASparseSM120Backend,
             )
             kv_c_full, k_pe_squeezed = _quantize_dequantize_fp8_ds_mla(
                 kv_c_full,
                 k_pe_full.squeeze(1),
                 block_size=block_size,
                 scale=kv_cache_scale,
-                simulate_sm100_e8m0_scales=is_sm100,
+                simulate_sm100_e8m0_scales=uses_pow2_scales,
             )
             k_pe_full = k_pe_squeezed.unsqueeze(1)
 
@@ -1162,6 +1222,140 @@ def test_sparse_backend_decode_correctness(
         )
     else:
         torch.testing.assert_close(backend_output, sdpa_reference, rtol=0.01, atol=0.01)
+
+
+@pytest.mark.parametrize(
+    ("batch_name", "mode", "is_prefilling", "expected_path"),
+    [
+        ("spec_decode_small", "0", False, "extend"),
+        ("spec_decode_small", "auto", False, "decode"),
+        ("spec_decode_medium", "auto", False, "decode"),
+        ("spec_decode_small", "auto", True, "extend"),
+        ("spec_decode_small", "1", True, "decode"),
+    ],
+)
+def test_b12x_sparse_spec_decode_causality(
+    default_vllm_config,
+    dist_init,
+    workspace_init,
+    monkeypatch: pytest.MonkeyPatch,
+    batch_name: str,
+    mode: str,
+    is_prefilling: bool,
+    expected_path: str,
+) -> None:
+    """Both verifier paths must match token-wise causal SDPA."""
+    if not current_platform.has_device_capability(120):
+        pytest.skip("B12xMLASparseBackend requires SM 12.0 (consumer Blackwell)")
+
+    sparse_mla = pytest.importorskip("sparkinfer.attention.sparse_mla")
+    calls = {"decode": 0, "extend": 0}
+
+    def track_path(name, fn):
+        def wrapped(*args, **kwargs):
+            calls[name] += 1
+            return fn(*args, **kwargs)
+
+        return wrapped
+
+    monkeypatch.setattr(
+        sparse_mla,
+        "run_decode",
+        track_path("decode", sparse_mla.run_decode),
+    )
+    monkeypatch.setattr(
+        sparse_mla,
+        "run_extend",
+        track_path("extend", sparse_mla.run_extend),
+    )
+    monkeypatch.setenv("VLLM_B12X_MLA_SPEC_EXTEND_AS_DECODE", mode)
+    monkeypatch.setitem(SPARSE_BACKEND_BATCH_SPECS, batch_name, BATCH_SPECS[batch_name])
+
+    batch_spec = BATCH_SPECS[batch_name]
+    original_create_vllm_config = create_vllm_config
+    original_create_common_attn_metadata = create_common_attn_metadata
+
+    def create_spec_vllm_config(*args, **kwargs):
+        config = original_create_vllm_config(*args, **kwargs)
+        config.speculative_config = SimpleNamespace(
+            num_speculative_tokens=max(batch_spec.query_lens) - 1
+        )
+        return config
+
+    def create_spec_common_attn_metadata(*args, **kwargs):
+        metadata = original_create_common_attn_metadata(*args, **kwargs)
+        metadata.is_prefilling = torch.full(
+            (metadata.num_reqs,), is_prefilling, dtype=torch.bool
+        )
+        return metadata
+
+    monkeypatch.setitem(globals(), "create_vllm_config", create_spec_vllm_config)
+    monkeypatch.setitem(
+        globals(), "create_common_attn_metadata", create_spec_common_attn_metadata
+    )
+
+    test_sparse_backend_decode_correctness(
+        default_vllm_config=default_vllm_config,
+        dist_init=dist_init,
+        backend_cls=B12xMLASparseBackend,
+        batch_name=batch_name,
+        kv_cache_dtype="fp8_ds_mla",
+        tensor_parallel_size=8,
+        block_size=64,
+        workspace_init=workspace_init,
+        q_scale=1.0,
+        k_scale=1.0,
+    )
+
+    assert calls[expected_path] > 0
+    assert calls["decode" if expected_path == "extend" else "extend"] == 0
+
+
+@pytest.mark.parametrize("batch_name", ["spec_decode_small", "spec_decode_medium"])
+def test_flashinfer_sm120_sparse_spec_decode_causality(
+    default_vllm_config,
+    dist_init,
+    workspace_init,
+    monkeypatch: pytest.MonkeyPatch,
+    batch_name: str,
+) -> None:
+    """FlashInfer's flattened verifier rows must remain token-wise causal."""
+    if not current_platform.has_device_capability(120):
+        pytest.skip("FlashInferMLASparseSM120Backend requires SM 12.0")
+
+    from vllm.utils import flashinfer as flashinfer_utils
+
+    calls = []
+    original_decode = flashinfer_utils.flashinfer_trtllm_batch_decode_with_kv_cache_mla
+
+    def track_decode(*args, **kwargs):
+        calls.append(kwargs)
+        return original_decode(*args, **kwargs)
+
+    monkeypatch.setattr(
+        flashinfer_utils,
+        "flashinfer_trtllm_batch_decode_with_kv_cache_mla",
+        track_decode,
+    )
+    monkeypatch.setitem(SPARSE_BACKEND_BATCH_SPECS, batch_name, BATCH_SPECS[batch_name])
+
+    test_sparse_backend_decode_correctness(
+        default_vllm_config=default_vllm_config,
+        dist_init=dist_init,
+        backend_cls=FlashInferMLASparseSM120Backend,
+        batch_name=batch_name,
+        kv_cache_dtype="fp8_ds_mla",
+        tensor_parallel_size=8,
+        block_size=64,
+        workspace_init=workspace_init,
+        q_scale=1.0,
+        k_scale=1.0,
+    )
+
+    assert len(calls) == 1
+    assert calls[0]["query"].shape[1] == 1
+    assert calls[0]["block_tables"].shape[1] == 1
+    assert calls[0]["seq_lens"] is None
 
 
 def _triton_convert_reference_impl(

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -504,6 +504,9 @@ class B12xMLASparseMetadata(AttentionMetadata):
     num_decodes: int
     num_prefills: int
     prefill_max_seq_len: int
+    # True only for a multi-token speculative-verification batch. Unlike a
+    # short chunked prefill, every request has completed its prompt.
+    is_spec_decode: bool
 
     query_start_loc: torch.Tensor
     slot_mapping: torch.Tensor
@@ -565,6 +568,10 @@ class B12xMLASparseMetadataBuilder(AttentionMetadataBuilder[B12xMLASparseMetadat
 
             self.dcp_rank = get_dcp_group().rank_in_group
         self.cp_kv_cache_interleave_size = parallel_config.cp_kv_cache_interleave_size
+        spec_config = getattr(vllm_config, "speculative_config", None)
+        self.num_speculative_tokens = int(
+            getattr(spec_config, "num_speculative_tokens", 0) or 0
+        )
 
         max_tokens = vllm_config.scheduler_config.max_num_batched_tokens
         max_seqs = vllm_config.scheduler_config.max_num_seqs
@@ -655,6 +662,14 @@ class B12xMLASparseMetadataBuilder(AttentionMetadataBuilder[B12xMLASparseMetadat
                 )
             )
         assert num_decode_tokens + num_prefill_tokens == num_tokens
+
+        is_spec_decode = False
+        if (
+            self.num_speculative_tokens > 0
+            and 1 < cm.max_query_len <= self.num_speculative_tokens + 1
+            and cm.is_prefilling is not None
+        ):
+            is_spec_decode = not bool(torch.any(cm.is_prefilling[: cm.num_reqs]))
 
         use_dcp = self.dcp_world_size > 1
         seq_lens_for_req = (
@@ -854,6 +869,7 @@ class B12xMLASparseMetadataBuilder(AttentionMetadataBuilder[B12xMLASparseMetadat
             num_decodes=num_decodes,
             num_prefills=num_prefills,
             prefill_max_seq_len=cm.max_seq_len if num_prefills > 0 else 0,
+            is_spec_decode=is_spec_decode,
             query_start_loc=cm.query_start_loc,
             slot_mapping=cm.slot_mapping,
             block_table=cm.block_table_tensor,
@@ -1054,20 +1070,33 @@ class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
         self._pad_heads = self._kernel_num_heads != self._input_num_heads
 
         self.spec_decode_max_q = _env_int("VLLM_B12X_MLA_SPEC_DECODE_MAX_Q", 8)
-        # The decode kernel handles independent one-token query rows. MTP
-        # verification has multiple query rows per request, and later rows must
-        # attend to earlier draft rows in the same verifier batch. Route those
-        # batches through the extend path unless explicitly overridden.
-        self.spec_extend_as_decode = (
-            os.getenv("VLLM_B12X_MLA_SPEC_EXTEND_AS_DECODE", "0") != "0"
+        spec_decode_mode = (
+            os.getenv("VLLM_B12X_MLA_SPEC_EXTEND_AS_DECODE", "auto").strip().lower()
         )
+        disabled_modes = {"0", "false", "off", "no"}
+        forced_modes = {"1", "true", "on", "yes"}
+        if spec_decode_mode not in {"auto", *disabled_modes, *forced_modes}:
+            raise ValueError(
+                "VLLM_B12X_MLA_SPEC_EXTEND_AS_DECODE must be auto, 0, or 1 "
+                f"(got {spec_decode_mode!r})"
+            )
+        self.spec_extend_as_decode = spec_decode_mode not in disabled_modes
+        self.spec_extend_as_decode_force = spec_decode_mode in forced_modes
 
         # Decode query rows per request (1, plus speculative draft tokens).
         q_per_req = 1
         spec = getattr(vllm_config, "speculative_config", None)
-        if spec is not None and getattr(spec, "num_speculative_tokens", None):
+        if (
+            self.spec_extend_as_decode
+            and spec is not None
+            and getattr(spec, "num_speculative_tokens", None)
+        ):
             q_per_req = 1 + int(spec.num_speculative_tokens)
-        if self.spec_extend_as_decode:
+        # Auto mode only dispatches genuine verifier batches, whose maximum
+        # row count is fixed by speculative_config. The explicit force mode
+        # may also route arbitrary short extends and therefore reserves the
+        # full operator limit.
+        if self.spec_extend_as_decode_force:
             q_per_req = max(q_per_req, self.spec_decode_max_q)
         self._decode_max_rows = min(max_num_seqs * q_per_req, max_batched)
         if self._decode_max_rows < max_num_seqs:
@@ -2189,8 +2218,11 @@ class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
                 B12xMLASparseImpl._shared_gather_event.record(self._ckv_gather_stream)
                 B12xMLASparseImpl._shared_gather_buf_idx = next_buf_idx
 
+        use_spec_decode_kernel = self.spec_extend_as_decode and (
+            self.spec_extend_as_decode_force or attn_metadata.is_spec_decode
+        )
         use_decode_kernel = attn_metadata.max_query_len <= 1 or (
-            self.spec_extend_as_decode
+            use_spec_decode_kernel
             and attn_metadata.max_query_len <= self.spec_decode_max_q
             and num_actual_toks <= attn_metadata.num_reqs * self.spec_decode_max_q
             and num_actual_toks <= self._decode_max_rows


### PR DESCRIPTION
## Summary

- route genuine multi-token MTP verifier batches through the B12X sparse decode kernel by default
- distinguish verifier batches from equally short chunked-prefill batches using scheduler metadata
- size decode scratch storage from the configured MTP width instead of the generic operator limit
- retain `0` as a kill switch and `1` as an explicit legacy force mode

## Root cause

`VLLM_B12X_MLA_SPEC_EXTEND_AS_DECODE` defaulted to disabled because the decode kernel was assumed to treat verifier rows as independent one-token queries. That assumption does not match the current path: candidate KV rows are already present and B12X receives a causal cache length for every verifier token, so each later token can attend to earlier candidates from the same verification step.

As a result, MTP verification unnecessarily used the substantially slower sparse extend kernel. This accounted for the observed v20 B12X MTP decode gap against FlashInfer.

## Behavior

The setting now accepts three modes:

- `auto` (default): use decode only for a genuine speculative-verification batch
- `0`: always keep multi-token batches on extend
- `1`: force the old opt-in behavior for every eligible short extend

Auto classification requires a configured speculative width, `1 < max_query_len <= 1 + num_speculative_tokens`, and no real request still in prompt prefill. Short chunked prefills therefore stay on the extend path.

Scratch capacity is exact in the normal modes: one row/request when disabled and `1 + num_speculative_tokens` rows/request in auto mode. Only explicit force mode reserves up to `VLLM_B12X_MLA_SPEC_DECODE_MAX_Q`.

## Validation

SM120 targeted tests on the v20 CUDA 13.2 stack: **10 passed**.

- B12X causal output and dispatch: disabled, auto Q4, auto Q8, short-prefill auto fallback, and force mode
- FlashInfer Q4/Q8 verifier causality as an independent reference path
- scratch capacity for disabled, auto MTP3, and force modes
- `ruff check`, `ruff format --check`, and `git diff --check`

Additional full-model differential validation over 16 verifier rows:

- mean KL: `0.001490835`
- median KL: `0.000001507`
- standard deviation: `0.004936891`
- minimum KL: `0.000000032`
- maximum KL: `0.019946607`
- top-1 token: identical on all 16 rows
- top-10 overlap: `80-100%`

The distribution is strongly skewed: most rows are effectively identical, while
the maximum came from the fourth position of one MTP3 verifier batch. Later
candidate positions generally show more floating-point divergence because they
include more candidate KV rows. Across 632 layer/rank comparisons, maximum
absolute error was `0.0078125` and maximum relative L2 error was `0.00057`.

This is not bitwise equivalence between the sparse extend and decode kernels,
but it rules out the original causality concern: both paths independently match
token-wise causal SDPA, and no tested full-model row changed its top-1 token.
A conventional checkpoint-versus-BF16 KLD run would not exercise this branch,
because it does not create a multi-token MTP target-verification batch. A larger
paired verifier-logit corpus would still be required to claim zero statistical
quality impact beyond this targeted validation.

DCP2, DCP4, and DCP8 MTP verification completed coherently with no CUDA/Xid fault. Acceptance was `66/93`, `66/93`, and `67/90`, respectively.

## Controlled performance

GLM-5.2 NVFP4, TP8/DCP1/MTP3, A16 + online MXFP8, CC1. B12X runs used the same v20 image and launch parameters; only this module was overlaid.

| Path | ctx0 active decode | 64k active decode | 64k standalone prefill |
|---|---:|---:|---:|
| v20 B12X, old extend verifier | 129.52-133.77 tok/s | - | - |
| B12X, auto decode verifier | 161.36-161.45 tok/s | 153.25 tok/s | 7,001 tok/s |
| FlashInfer SM120 | 150.28-152.40 tok/s | 146.57 tok/s | 5,917 tok/s |

The optimized B12X path is about 6-7% faster than the locally reproduced FlashInfer ctx0 result, 4.6% faster at 64k context, and retains an 18.3% prefill advantage.
