### PR TITLE
[GG] feat(kv-offload): bound filesystem tier capacity

### DIFF
--- a/docs/features/kv_offloading_usage.md
+++ b/docs/features/kv_offloading_usage.md
@@ -83,6 +83,13 @@ Each entry in `secondary_tiers` is a dict with a required `type` field plus tier
 
 The filesystem and object-store tiers can publish hash-only `BlockStored` KV events for blocks they successfully store, tagged with a stable per-tier `medium` (`FS` for the filesystem tier, `OBJ` for the object-store tier). Set `enable_kv_events: true` in the tier's entry to opt in; events are published only when KV cache events are also enabled globally via `--kv-events-config`.
 
+`BlockRemoved` is an idempotent state invalidation. It may appear without a
+preceding `BlockStored` in the current event stream, for example when a
+persistent block is trimmed at startup or a completed asynchronous store is
+evicted before the scheduler polls its result. Consumers must ignore removals
+for blocks they do not currently track. The filesystem tier suppresses a
+pending `BlockStored` event when the block is no longer resident.
+
 Set the optional `locality` tier field to `LOCAL` or `REMOTE` to describe the tier's storage location relative to the publishing vLLM instance. `LOCAL` marks storage local to that instance, while `REMOTE` marks storage that is not local to it. When the setting is omitted, locality is unspecified. vLLM does not infer it from the tier type, so an OBJ tier is not implicitly `REMOTE`. A KV event includes `locality` only when the tier explicitly configures it. This metadata describes the tier property without implying that a consumer can already route requests to its blocks.
 
 ### Filesystem (FS)
@@ -110,10 +117,12 @@ pinned until they are safe to reclaim. If every resident block is pinned, a new
 store job fails with `ENOSPC`; the tier never exceeds the configured limit or
 evicts an in-use load source.
 
-The limit applies to the current `<model>_<digest>_r<rank>` block namespace. It
-does not include `config.json`, stale temporary files, or namespaces belonging
-to other model/configuration digests under the same `root_dir`. Values that are
-not an exact multiple of the offload block size leave the remainder unused.
+The limit applies to the current `<model>_<digest>_r<rank>` block namespace.
+Bounded-mode startup removes stale temporary files created by interrupted
+FileMapper writes before indexing completed blocks. It does not include
+`config.json`, unrelated files, or namespaces belonging to other
+model/configuration digests under the same `root_dir`. Values that are not an
+exact multiple of the offload block size leave the remainder unused.
 
 !!! warning
     Capacity tracking is process-local. Use `max_cache_size_bytes` only when one

--- a/docs/features/kv_offloading_usage.md
+++ b/docs/features/kv_offloading_usage.md
@@ -95,10 +95,33 @@ The filesystem tier (`type: "fs"`) writes blocks to a filesystem directory.
 | `root_dir` | yes | — | Base directory; vLLM creates subdirectories beneath it (see [On-Disk Layout](#on-disk-layout)). |
 | `n_read_threads` | no | `16` | Read-priority I/O threads (load path). |
 | `n_write_threads` | no | `16` | Write-priority I/O threads (store path). |
+| `max_cache_size_bytes` | no | unlimited | Maximum bytes of completed block files retained in this model/configuration namespace. Enables local LRU eviction when set. Must fit at least one offload block. |
 | `enable_kv_events` | no | `false` | Publish `BlockStored` KV events (medium `FS`) for successfully stored blocks. Requires KV cache events to be enabled globally. |
 | `locality` | no | unspecified | `LOCAL` or `REMOTE` relative to the publishing vLLM instance. Included in the tier's KV events only when explicitly configured. |
 
 Each thread group prefers its own queue but pulls from the other when its primary queue is empty, so a write-heavy or read-heavy burst won't leave the off-priority queue waiting. Size the totals to your storage's effective concurrency.
+
+Set `max_cache_size_bytes` to bound a local filesystem or NVMe cache. The
+filesystem tier indexes existing block files at startup, orders them by
+modification time, and removes the oldest files until the configured limit is
+met. During the run, successful lookups and `touch` calls maintain exact LRU
+order. Blocks selected by an active request and sources of queued load jobs are
+pinned until they are safe to reclaim. If every resident block is pinned, a new
+store job fails with `ENOSPC`; the tier never exceeds the configured limit or
+evicts an in-use load source.
+
+The limit applies to the current `<model>_<digest>_r<rank>` block namespace. It
+does not include `config.json`, stale temporary files, or namespaces belonging
+to other model/configuration digests under the same `root_dir`. Values that are
+not an exact multiple of the offload block size leave the remainder unused.
+
+!!! warning
+    Capacity tracking is process-local. Use `max_cache_size_bytes` only when one
+    live vLLM instance has exclusive ownership of the generated block
+    namespace. Do not enable it for a shared PVC or a `root_dir` concurrently
+    used by multiple instances; one process cannot honor another process's
+    in-flight pins or LRU state. Leave the option unset for cross-process
+    sharing and manage shared-storage retention externally.
 
 #### On-Disk Layout
 
@@ -181,6 +204,7 @@ Rather than embedding `host`/`port` in each `secondary_tiers` entry, set them on
 - For single-tier (CPU-only) setups, set `cpu_bytes_to_use` larger than the aggregate GPU KV cache. Because offloading is immediate, a smaller CPU tier just mirrors what the GPU already holds and adds no hit rate.
 - `block_size`: larger offloaded blocks reduce per-block bookkeeping overhead but increase the granularity of lookups. Must be a multiple of the GPU block size.
 - FS thread counts: tune `n_read_threads` and `n_write_threads` to the parallelism your storage can sustain. Reads are latency-sensitive on the prefill path, so prefer more read threads when prefill hit rates are high.
+- Local FS/NVMe capacity: set `max_cache_size_bytes` below the device's usable capacity, leaving headroom for filesystem metadata and any other data on the volume. The limit covers the active model/configuration namespace, not the entire `root_dir` or filesystem.
 - Sharing `root_dir` across runs: runs with the same model, `block_size`, parallelism layout, and dtype share files under the same `<digest>` subdirectory. Changing any of these produces a new subdirectory; old ones are orphaned but harmless. Delete them to reclaim disk.
 
 ## Per-Request Selective Offload

--- a/tests/v1/kv_offload/tiering/test_fs_tier.py
+++ b/tests/v1/kv_offload/tiering/test_fs_tier.py
@@ -93,6 +93,7 @@ def make_job(
     keys: list[OffloadKey],
     block_ids: list[int] | None = None,
     is_promotion: bool = False,
+    req_context: ReqContext = _CTX,
 ) -> JobMetadata:
     if block_ids is None:
         block_ids = list(range(len(keys)))
@@ -101,7 +102,7 @@ def make_job(
         keys=keys,
         block_ids=np.array(block_ids, dtype=np.int64),
         is_promotion=is_promotion,
-        req_context=_CTX,
+        req_context=req_context,
     )
 
 
@@ -192,6 +193,32 @@ def fs_tier_with_events(tmp_path):
     )
     yield tier
     tier.shutdown()
+
+
+def _make_bounded_fs_tier(
+    tmp_path,
+    max_blocks: int,
+    *,
+    enable_events: bool = False,
+    n_read_threads: int = 4,
+    n_write_threads: int = 4,
+):
+    tensor = _page_aligned_zero_tensor(4, _BLOCK_ELEMENTS)
+    view = memoryview(tensor.numpy())
+    assert view.strides is not None
+    block_size = view.strides[0]
+    tier = FileSystemTierManager(
+        offloading_spec=_make_offloading_spec(enable_kv_cache_events=enable_events),
+        primary_kv_view=view,
+        tier_type="fs",
+        root_dir=str(tmp_path),
+        n_read_threads=n_read_threads,
+        n_write_threads=n_write_threads,
+        enable_kv_events=enable_events,
+        locality="LOCAL" if enable_events else None,
+        max_cache_size_bytes=max_blocks * block_size,
+    )
+    return tier, tensor, block_size
 
 
 # ---------------------------------------------------------------------------
@@ -286,6 +313,231 @@ def test_factory_forwards_locality_to_fs_tier(tmp_path):
         assert tier.locality is Locality.LOCAL
     finally:
         tier.shutdown()
+
+
+def test_factory_forwards_fs_capacity(tmp_path):
+    tensor = _page_aligned_zero_tensor(4, _BLOCK_ELEMENTS)
+    view = memoryview(tensor.numpy())
+    assert view.strides is not None
+    max_cache_size_bytes = 2 * view.strides[0]
+    tier = SecondaryTierFactory.create_secondary_tier(
+        {
+            "type": "fs",
+            "root_dir": str(tmp_path),
+            "n_read_threads": 1,
+            "n_write_threads": 1,
+            "max_cache_size_bytes": max_cache_size_bytes,
+        },
+        view,
+        _MOCK_OFFLOADING_SPEC,
+    )
+    try:
+        assert isinstance(tier, FileSystemTierManager)
+        assert tier._max_cache_size_bytes == max_cache_size_bytes
+    finally:
+        tier.shutdown()
+
+
+def test_fs_capacity_validation(tmp_path):
+    tensor = _page_aligned_zero_tensor(4, _BLOCK_ELEMENTS)
+    view = memoryview(tensor.numpy())
+    assert view.strides is not None
+
+    for invalid in (True, 1.5, "1024"):
+        with pytest.raises(TypeError, match="max_cache_size_bytes"):
+            FileSystemTierManager(
+                offloading_spec=_MOCK_OFFLOADING_SPEC,
+                primary_kv_view=view,
+                tier_type="fs",
+                root_dir=str(tmp_path),
+                max_cache_size_bytes=invalid,
+            )
+
+    with pytest.raises(ValueError, match="at least one"):
+        FileSystemTierManager(
+            offloading_spec=_MOCK_OFFLOADING_SPEC,
+            primary_kv_view=view,
+            tier_type="fs",
+            root_dir=str(tmp_path),
+            max_cache_size_bytes=view.strides[0] - 1,
+        )
+
+
+def test_bounded_fs_tier_evicts_lru_block(tmp_path):
+    tier, _, block_size = _make_bounded_fs_tier(tmp_path, max_blocks=2)
+    try:
+        tier.submit_store(make_job(1, [key(1)], [0]))
+        assert all(result.success for result in drain(tier))
+        tier.submit_store(make_job(2, [key(2)], [1]))
+        assert all(result.success for result in drain(tier))
+
+        tier.touch([key(1)], _CTX)
+        tier.submit_store(make_job(3, [key(3)], [2]))
+        assert all(result.success for result in drain(tier))
+
+        assert os.path.exists(tier.file_mapper.get_file_name(key(1)))
+        assert not os.path.exists(tier.file_mapper.get_file_name(key(2)))
+        assert os.path.exists(tier.file_mapper.get_file_name(key(3)))
+        assert tier._cache_size_bytes == 2 * block_size
+    finally:
+        tier.shutdown()
+
+
+def test_lookup_hit_is_pinned_until_request_finishes(tmp_path):
+    tier, _, _ = _make_bounded_fs_tier(tmp_path, max_blocks=1)
+    ctx = ReqContext(req_id="pinned-request")
+    try:
+        tier.submit_store(make_job(1, [key(1)], [0]))
+        assert all(result.success for result in drain(tier))
+        assert lookup_and_wait(tier, [key(1)], ctx) == [LookupResult.HIT]
+
+        tier.submit_store(make_job(2, [key(2)], [1]))
+        results = drain(tier)
+        assert len(results) == 1
+        assert not results[0].success
+        assert os.path.exists(tier.file_mapper.get_file_name(key(1)))
+
+        tier.on_request_finished(ctx)
+        tier.submit_store(make_job(3, [key(2)], [1]))
+        assert all(result.success for result in drain(tier))
+        assert not os.path.exists(tier.file_mapper.get_file_name(key(1)))
+        assert os.path.exists(tier.file_mapper.get_file_name(key(2)))
+    finally:
+        tier.shutdown()
+
+
+def test_lookup_pin_transfers_to_load_job(tmp_path):
+    tier, _, _ = _make_bounded_fs_tier(tmp_path, max_blocks=1)
+    ctx = ReqContext(req_id="promoted-request")
+    try:
+        tier.submit_store(make_job(1, [key(1)], [0]))
+        assert all(result.success for result in drain(tier))
+        assert lookup_and_wait(tier, [key(1)], ctx) == [LookupResult.HIT]
+        assert tier._request_pins[ctx.req_id] == {key(1)}
+
+        tier.submit_load(make_job(2, [key(1)], [1], is_promotion=True, req_context=ctx))
+        assert ctx.req_id not in tier._request_pins
+        assert tier._load_job_keys[2] == [key(1)]
+        assert tier._pin_counts[key(1)] == 1
+
+        assert all(result.success for result in drain(tier))
+        assert tier._load_job_keys == {}
+        assert tier._pin_counts == {}
+        tier.on_request_finished(ctx)
+    finally:
+        tier.shutdown()
+
+
+def test_queued_load_source_is_pinned(tmp_path, monkeypatch):
+    import vllm.v1.kv_offload.tiering.fs.manager as mgr_mod
+
+    tier, _, _ = _make_bounded_fs_tier(tmp_path, max_blocks=1)
+    load_started = threading.Event()
+    release_load = threading.Event()
+    original_load_block = mgr_mod.load_block
+
+    def blocked_load(*args, **kwargs):
+        load_started.set()
+        assert release_load.wait(timeout=5.0)
+        return original_load_block(*args, **kwargs)
+
+    monkeypatch.setattr(mgr_mod, "load_block", blocked_load)
+    try:
+        tier.submit_store(make_job(1, [key(1)], [0]))
+        assert all(result.success for result in drain(tier))
+
+        tier.submit_load(make_job(2, [key(1)], [1], is_promotion=True))
+        assert load_started.wait(timeout=5.0)
+        tier.submit_store(make_job(3, [key(2)], [0]))
+        release_load.set()
+
+        results = {result.job_id: result for result in drain(tier)}
+        assert results[2].success
+        assert not results[3].success
+        assert os.path.exists(tier.file_mapper.get_file_name(key(1)))
+    finally:
+        release_load.set()
+        tier.shutdown()
+
+
+def test_concurrent_stores_reserve_capacity(tmp_path, monkeypatch):
+    import vllm.v1.kv_offload.tiering.fs.manager as mgr_mod
+
+    tier, _, block_size = _make_bounded_fs_tier(
+        tmp_path, max_blocks=2, n_write_threads=4
+    )
+    release_stores = threading.Event()
+    entered = 0
+    entered_cv = threading.Condition()
+    original_store_block = mgr_mod.store_block
+
+    def blocked_store(*args, **kwargs):
+        nonlocal entered
+        with entered_cv:
+            entered += 1
+            entered_cv.notify_all()
+        assert release_stores.wait(timeout=5.0)
+        return original_store_block(*args, **kwargs)
+
+    monkeypatch.setattr(mgr_mod, "store_block", blocked_store)
+    try:
+        tier.submit_store(make_job(1, [key(1), key(2), key(3)], [0, 1, 2]))
+        with entered_cv:
+            assert entered_cv.wait_for(lambda: entered == 2, timeout=5.0)
+        time.sleep(0.1)
+        assert entered == 2
+        assert tier._pending_store_bytes == 2 * block_size
+
+        release_stores.set()
+        results = drain(tier)
+        assert len(results) == 1
+        assert results[0].success
+        assert tier._cache_size_bytes == 2 * block_size
+    finally:
+        release_stores.set()
+        tier.shutdown()
+
+
+def test_capacity_index_trims_existing_namespace_on_startup(tmp_path):
+    tensor = _page_aligned_zero_tensor(4, _BLOCK_ELEMENTS)
+    view = memoryview(tensor.numpy())
+    assert view.strides is not None
+    block_size = view.strides[0]
+    tier = FileSystemTierManager(
+        offloading_spec=_MOCK_OFFLOADING_SPEC,
+        primary_kv_view=view,
+        tier_type="fs",
+        root_dir=str(tmp_path),
+        n_read_threads=1,
+        n_write_threads=1,
+    )
+    paths: list[str] = []
+    try:
+        for job_id in (1, 2, 3):
+            tier.submit_store(make_job(job_id, [key(job_id)], [job_id - 1]))
+            assert all(result.success for result in drain(tier))
+            path = tier.file_mapper.get_file_name(key(job_id))
+            paths.append(path)
+            os.utime(path, ns=(job_id, job_id))
+    finally:
+        tier.shutdown()
+
+    bounded = FileSystemTierManager(
+        offloading_spec=_MOCK_OFFLOADING_SPEC,
+        primary_kv_view=view,
+        tier_type="fs",
+        root_dir=str(tmp_path),
+        n_read_threads=1,
+        n_write_threads=1,
+        max_cache_size_bytes=2 * block_size,
+    )
+    try:
+        assert not os.path.exists(paths[0])
+        assert os.path.exists(paths[1])
+        assert os.path.exists(paths[2])
+        assert bounded._cache_size_bytes == 2 * block_size
+    finally:
+        bounded.shutdown()
 
 
 def test_failed_load_missing_file(fs_tier):
@@ -465,6 +717,31 @@ def test_batch_lookup_dispatch(fs_tier, monkeypatch, use_c_ext):
 # ---------------------------------------------------------------------------
 # KV events
 # ---------------------------------------------------------------------------
+
+
+def test_capacity_eviction_event_precedes_replacement_store(tmp_path):
+    tier, _, _ = _make_bounded_fs_tier(tmp_path, max_blocks=2, enable_events=True)
+    try:
+        tier.submit_store(make_job(1, [key(1)], [0]))
+        assert all(result.success for result in drain(tier))
+        tier.submit_store(make_job(2, [key(2)], [1]))
+        assert all(result.success for result in drain(tier))
+        list(tier.take_events())
+
+        tier.touch([key(1)], _CTX)
+        tier.submit_store(make_job(3, [key(3)], [2]))
+        assert all(result.success for result in drain(tier))
+
+        events = list(tier.take_events())
+        assert len(events) == 2
+        assert events[0].removed
+        assert events[0].keys == [key(2)]
+        assert not events[1].removed
+        assert events[1].keys == [key(3)]
+        assert all(event.medium == "FS" for event in events)
+        assert all(event.locality is Locality.LOCAL for event in events)
+    finally:
+        tier.shutdown()
 
 
 def test_successful_store_emits_stored_event(fs_tier_with_events):

--- a/tests/v1/kv_offload/tiering/test_fs_tier.py
+++ b/tests/v1/kv_offload/tiering/test_fs_tier.py
@@ -540,6 +540,124 @@ def test_capacity_index_trims_existing_namespace_on_startup(tmp_path):
         bounded.shutdown()
 
 
+def test_capacity_eviction_scans_each_candidate_once(tmp_path, monkeypatch):
+    import vllm.v1.kv_offload.tiering.fs.manager as mgr_mod
+
+    tier, _, block_size = _make_bounded_fs_tier(tmp_path, max_blocks=2)
+    paths = [tier.file_mapper.get_file_name(key(i)) for i in range(1, 5)]
+    for path in paths:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "wb"):
+            pass
+
+    with tier._capacity_cv:
+        for i in range(1, 5):
+            tier._cache_lru[key(i)] = block_size
+        tier._cache_size_bytes = 4 * block_size
+        tier._pin_counts[key(1)] = 1
+
+    remove_attempts: list[str] = []
+    original_remove = mgr_mod.os.remove
+
+    def tracked_remove(path):
+        remove_attempts.append(path)
+        if path == paths[1]:
+            raise PermissionError("injected eviction failure")
+        original_remove(path)
+
+    monkeypatch.setattr(mgr_mod.os, "remove", tracked_remove)
+    try:
+        with tier._capacity_cv:
+            assert tier._evict_until_fits_locked(0)
+        assert list(tier._cache_lru) == [key(1), key(2)]
+        assert tier._cache_size_bytes == 2 * block_size
+        assert paths[0] not in remove_attempts
+        assert remove_attempts.count(paths[1]) == 1
+        assert remove_attempts == paths[1:]
+    finally:
+        tier.shutdown()
+
+
+def test_capacity_index_removes_only_owned_stale_temp_files(tmp_path):
+    tensor = _page_aligned_zero_tensor(1, _BLOCK_ELEMENTS)
+    view = memoryview(tensor.numpy())
+    assert view.strides is not None
+    tier = FileSystemTierManager(
+        offloading_spec=_MOCK_OFFLOADING_SPEC,
+        primary_kv_view=view,
+        tier_type="fs",
+        root_dir=str(tmp_path),
+        n_read_threads=1,
+        n_write_threads=1,
+    )
+    block_path = tier.file_mapper.get_file_name(key(1))
+    tier.shutdown()
+
+    os.makedirs(os.path.dirname(block_path), exist_ok=True)
+    stale_temp_path = f"{block_path}_123.tmp"
+    unrelated_temp_path = f"{block_path}_writer.tmp"
+    for path in (stale_temp_path, unrelated_temp_path):
+        with open(path, "wb") as file:
+            file.write(b"stale")
+
+    bounded = FileSystemTierManager(
+        offloading_spec=_MOCK_OFFLOADING_SPEC,
+        primary_kv_view=view,
+        tier_type="fs",
+        root_dir=str(tmp_path),
+        n_read_threads=1,
+        n_write_threads=1,
+        max_cache_size_bytes=view.strides[0],
+    )
+    try:
+        assert not os.path.exists(stale_temp_path)
+        assert os.path.exists(unrelated_temp_path)
+    finally:
+        bounded.shutdown()
+
+
+def test_capacity_index_fails_if_stale_temp_cannot_be_removed(tmp_path, monkeypatch):
+    import vllm.v1.kv_offload.tiering.fs.manager as mgr_mod
+
+    tensor = _page_aligned_zero_tensor(1, _BLOCK_ELEMENTS)
+    view = memoryview(tensor.numpy())
+    assert view.strides is not None
+    tier = FileSystemTierManager(
+        offloading_spec=_MOCK_OFFLOADING_SPEC,
+        primary_kv_view=view,
+        tier_type="fs",
+        root_dir=str(tmp_path),
+        n_read_threads=1,
+        n_write_threads=1,
+    )
+    block_path = tier.file_mapper.get_file_name(key(1))
+    tier.shutdown()
+
+    os.makedirs(os.path.dirname(block_path), exist_ok=True)
+    stale_temp_path = f"{block_path}_123.tmp"
+    with open(stale_temp_path, "wb") as file:
+        file.write(b"stale")
+
+    original_remove = mgr_mod.os.remove
+
+    def fail_stale_temp_remove(path):
+        if path == stale_temp_path:
+            raise PermissionError("injected cleanup failure")
+        original_remove(path)
+
+    monkeypatch.setattr(mgr_mod.os, "remove", fail_stale_temp_remove)
+    with pytest.raises(OSError, match="Unable to remove stale filesystem KV temp"):
+        FileSystemTierManager(
+            offloading_spec=_MOCK_OFFLOADING_SPEC,
+            primary_kv_view=view,
+            tier_type="fs",
+            root_dir=str(tmp_path),
+            n_read_threads=1,
+            n_write_threads=1,
+            max_cache_size_bytes=view.strides[0],
+        )
+
+
 def test_failed_load_missing_file(fs_tier):
     """Test that loading a block whose file does not exist results in a failed job."""
     tier, _ = fs_tier
@@ -740,6 +858,25 @@ def test_capacity_eviction_event_precedes_replacement_store(tmp_path):
         assert events[1].keys == [key(3)]
         assert all(event.medium == "FS" for event in events)
         assert all(event.locality is Locality.LOCAL for event in events)
+    finally:
+        tier.shutdown()
+
+
+def test_eviction_before_store_poll_emits_invalidation_only(tmp_path):
+    tier, _, _ = _make_bounded_fs_tier(tmp_path, max_blocks=1, enable_events=True)
+    try:
+        tier.submit_store(make_job(1, [key(1)], [0]))
+        tier.drain_jobs()
+
+        tier.submit_store(make_job(2, [key(2)], [1]))
+        results = drain(tier)
+        assert all(result.success for result in results)
+
+        events = list(tier.take_events())
+        assert [(event.removed, event.keys) for event in events] == [
+            (True, [key(1)]),
+            (False, [key(2)]),
+        ]
     finally:
         tier.shutdown()
 

--- a/vllm/v1/kv_offload/base.py
+++ b/vllm/v1/kv_offload/base.py
@@ -106,6 +106,12 @@ class Locality(Enum):
 
 @dataclass
 class OffloadingEvent:
+    """Storage-state update emitted by an offloading tier.
+
+    Removal is an idempotent invalidation and need not have a preceding store
+    in the current event stream.
+    """
+
     keys: list[OffloadKey]
     medium: str
     # True if blocks are removed, False if stored

--- a/vllm/v1/kv_offload/tiering/fs/manager.py
+++ b/vllm/v1/kv_offload/tiering/fs/manager.py
@@ -15,10 +15,13 @@ File naming:  <base_path>_r<rank>/<hhh>/<hh>_g<group_idx>/<hash_hex>.bin
               (hash-based subdirectories to limit directory fan-out)
 """
 
+import errno
 import functools
 import json
 import os
-from collections.abc import Iterable
+import threading
+from collections import OrderedDict
+from collections.abc import Collection, Iterable
 from typing import TYPE_CHECKING, ClassVar
 
 try:
@@ -38,6 +41,7 @@ from vllm.v1.kv_offload.base import (
     OffloadingEvent,
     OffloadKey,
     ReqContext,
+    make_offload_key,
 )
 from vllm.v1.kv_offload.file_mapper import FileMapper
 from vllm.v1.kv_offload.tiering.async_lookup import AsyncLookupManager
@@ -112,6 +116,7 @@ class FileSystemTierManager(SecondaryTierManager):
         n_write_threads: int = 16,
         enable_kv_events: bool = False,
         locality: str | None = None,
+        max_cache_size_bytes: int | None = None,
     ):
         """
         Args:
@@ -127,10 +132,16 @@ class FileSystemTierManager(SecondaryTierManager):
                 cache events are enabled globally (kv_events_config).
             locality: Whether this tier's storage is LOCAL or REMOTE relative
                 to the publishing vLLM instance.
+            max_cache_size_bytes: Optional byte limit for this tier's block
+                files. When set, the least-recently-used unpinned blocks are
+                removed before new blocks are stored. The limit applies only
+                to this model/configuration namespace and requires exclusive
+                ownership of that namespace by this vLLM instance.
         """
         super().__init__(offloading_spec, primary_kv_view, tier_type)
         self.locality = Locality(locality) if locality is not None else None
 
+        self._events_lock = threading.Lock()
         self.events: list[OffloadingEvent] | None = None
         if enable_kv_events:
             if offloading_spec.kv_events_config.enable_kv_cache_events:
@@ -150,6 +161,29 @@ class FileSystemTierManager(SecondaryTierManager):
             "primary_kv_view.strides cannot be None"
         )
         self._block_size: int = primary_kv_view.strides[0]
+        if max_cache_size_bytes is not None:
+            if isinstance(max_cache_size_bytes, bool) or not isinstance(
+                max_cache_size_bytes, int
+            ):
+                raise TypeError("max_cache_size_bytes must be an integer or None")
+            if max_cache_size_bytes < self._block_size:
+                raise ValueError(
+                    "max_cache_size_bytes must fit at least one filesystem "
+                    f"cache block ({self._block_size} bytes)"
+                )
+        self._max_cache_size_bytes = max_cache_size_bytes
+
+        # Capacity state is used only when max_cache_size_bytes is configured.
+        # _cache_lru is oldest-first. Pending stores reserve their final file
+        # size before I/O so concurrent writers cannot oversubscribe the limit.
+        self._capacity_cv = threading.Condition(threading.Lock())
+        self._cache_lru: OrderedDict[OffloadKey, int] = OrderedDict()
+        self._cache_size_bytes = 0
+        self._pending_store_keys: set[OffloadKey] = set()
+        self._pending_store_bytes = 0
+        self._request_pins: dict[str, set[OffloadKey]] = {}
+        self._pin_counts: dict[OffloadKey, int] = {}
+        self._load_job_keys: dict[JobId, list[OffloadKey]] = {}
 
         # Opt in; FileMapper enables it only for a parallelism-invariant block.
         self.file_mapper = FileMapper.from_offloading_spec(
@@ -168,6 +202,9 @@ class FileSystemTierManager(SecondaryTierManager):
                     self.file_mapper.get_run_config(), f, indent=2, sort_keys=True
                 )
 
+        if self._max_cache_size_bytes is not None:
+            self._initialize_capacity_index()
+
         self._pool = DualQueueThreadPool(
             n_read_threads,
             n_write_threads,
@@ -185,36 +222,79 @@ class FileSystemTierManager(SecondaryTierManager):
         result = self._lookup_manager.lookup(key, req_context)
         if result is None:
             return LookupResult.RETRY
-        return LookupResult.HIT if result else LookupResult.MISS
+        if not result:
+            return LookupResult.MISS
+        if self._max_cache_size_bytes is not None:
+            pinned = self._pin_lookup_hit(key, req_context.req_id)
+            if pinned is None:
+                # A store has published the file but has not committed its
+                # capacity reservation yet. Retry once that transition ends.
+                return LookupResult.RETRY
+            if not pinned:
+                # The async existence result raced an eviction.
+                return LookupResult.MISS
+        return LookupResult.HIT
 
     @override
     def submit_store(self, job_metadata: JobMetadata) -> None:
         if self.events is not None:
             self._store_job_keys[job_metadata.job_id] = list(job_metadata.keys)
-        tasks = (
-            functools.partial(
-                store_block,
-                self.file_mapper.get_file_name(key),
-                self._primary_kv_view,
-                int(bid) * self._block_size,
-                self._block_size,
+        if self._max_cache_size_bytes is None:
+            tasks = (
+                functools.partial(
+                    store_block,
+                    self.file_mapper.get_file_name(key),
+                    self._primary_kv_view,
+                    int(bid) * self._block_size,
+                    self._block_size,
+                )
+                for key, bid in zip(job_metadata.keys, job_metadata.block_ids)
             )
-            for key, bid in zip(job_metadata.keys, job_metadata.block_ids)
-        )
+        else:
+            tasks = (
+                functools.partial(
+                    self._store_block_bounded,
+                    key,
+                    int(bid) * self._block_size,
+                )
+                for key, bid in zip(job_metadata.keys, job_metadata.block_ids)
+            )
         self._pool.enqueue_store(job_metadata.job_id, len(job_metadata.keys), tasks)
 
     @override
     def submit_load(self, job_metadata: JobMetadata) -> None:
-        tasks = (
-            functools.partial(
-                load_block,
-                self.file_mapper.get_file_name(key),
-                self._primary_kv_view,
-                int(bid) * self._block_size,
-                self._block_size,
+        if self._max_cache_size_bytes is None:
+            tasks = (
+                functools.partial(
+                    load_block,
+                    self.file_mapper.get_file_name(key),
+                    self._primary_kv_view,
+                    int(bid) * self._block_size,
+                    self._block_size,
+                )
+                for key, bid in zip(job_metadata.keys, job_metadata.block_ids)
             )
-            for key, bid in zip(job_metadata.keys, job_metadata.block_ids)
-        )
+        else:
+            # Pin before enqueueing: load tasks can wait behind other work,
+            # and capacity must not reclaim their source files in that gap.
+            pinned_keys: list[OffloadKey] = []
+            with self._capacity_cv:
+                for key in job_metadata.keys:
+                    if key in self._cache_lru:
+                        self._pin_counts[key] = self._pin_counts.get(key, 0) + 1
+                        pinned_keys.append(key)
+                        self._release_request_pin_locked(
+                            job_metadata.req_context.req_id, key
+                        )
+                self._load_job_keys[job_metadata.job_id] = pinned_keys
+            tasks = (
+                functools.partial(
+                    self._load_block_bounded,
+                    key,
+                    int(bid) * self._block_size,
+                )
+                for key, bid in zip(job_metadata.keys, job_metadata.block_ids)
+            )
         self._pool.enqueue_load(job_metadata.job_id, len(job_metadata.keys), tasks)
 
     @override
@@ -224,25 +304,51 @@ class FileSystemTierManager(SecondaryTierManager):
         """
         results = []
         for job_id, success in self._pool.get_finished():
+            if self._max_cache_size_bytes is not None:
+                self._release_load_job_pins(job_id)
             if self.events is not None:
                 keys = self._store_job_keys.pop(job_id, None)
                 if success and keys:
-                    self.events.append(
-                        OffloadingEvent(
-                            keys=keys,
-                            medium=self.medium,
-                            removed=False,
-                            locality=self.locality,
+                    if self._max_cache_size_bytes is not None:
+                        with self._capacity_cv:
+                            keys = [key for key in keys if key in self._cache_lru]
+                            if keys:
+                                self._append_event(
+                                    OffloadingEvent(
+                                        keys=keys,
+                                        medium=self.medium,
+                                        removed=False,
+                                        locality=self.locality,
+                                    )
+                                )
+                    else:
+                        self._append_event(
+                            OffloadingEvent(
+                                keys=keys,
+                                medium=self.medium,
+                                removed=False,
+                                locality=self.locality,
+                            )
                         )
-                    )
             results.append(JobResult(job_id=job_id, success=success))
         return results
 
     @override
     def take_events(self) -> Iterable[OffloadingEvent]:
         if self.events is not None:
-            yield from self.events
-            self.events.clear()
+            with self._events_lock:
+                events = list(self.events)
+                self.events.clear()
+            yield from events
+
+    @override
+    def touch(self, keys: Collection[OffloadKey], req_context: ReqContext) -> None:
+        if self._max_cache_size_bytes is None:
+            return
+        with self._capacity_cv:
+            for key in keys:
+                if key in self._cache_lru:
+                    self._cache_lru.move_to_end(key)
 
     @override
     def drain_jobs(self) -> None:
@@ -251,6 +357,11 @@ class FileSystemTierManager(SecondaryTierManager):
 
     def on_request_finished(self, req_context: ReqContext) -> None:
         self._lookup_manager.cleanup(req_context.req_id)
+        if self._max_cache_size_bytes is not None:
+            with self._capacity_cv:
+                for key in self._request_pins.pop(req_context.req_id, ()):
+                    self._unpin_key_locked(key)
+                self._capacity_cv.notify_all()
 
     @override
     def on_schedule_end(self, context: ScheduleEndContext) -> None:
@@ -266,3 +377,262 @@ class FileSystemTierManager(SecondaryTierManager):
         """
         self._lookup_manager.shutdown()
         self._pool.shutdown(wait=True)
+        if self._max_cache_size_bytes is not None:
+            with self._capacity_cv:
+                for job_id in list(self._load_job_keys):
+                    self._release_load_job_pins_locked(job_id)
+
+    def _append_event(self, event: OffloadingEvent) -> None:
+        if self.events is not None:
+            with self._events_lock:
+                self.events.append(event)
+
+    def _key_from_cache_path(self, path: str) -> OffloadKey | None:
+        """Recover an OffloadKey from a FileMapper-owned block path."""
+        filename = os.path.basename(path)
+        if not filename.endswith(".bin"):
+            return None
+        group_dir = os.path.basename(os.path.dirname(path))
+        _, separator, group_idx = group_dir.rpartition("_g")
+        if not separator:
+            return None
+        try:
+            key = make_offload_key(
+                bytes.fromhex(filename.removesuffix(".bin")), int(group_idx)
+            )
+        except (ValueError, OverflowError):
+            return None
+        expected = os.path.normpath(self.file_mapper.get_file_name(key))
+        return key if expected == os.path.normpath(path) else None
+
+    def _initialize_capacity_index(self) -> None:
+        """Index existing block files and trim an oversized namespace."""
+        data_dir = f"{self.file_mapper.base_path}_r{self.file_mapper.rank}"
+        entries: list[tuple[int, str, OffloadKey, int]] = []
+        for dir_path, _, filenames in os.walk(data_dir):
+            for filename in filenames:
+                path = os.path.join(dir_path, filename)
+                key = self._key_from_cache_path(path)
+                if key is None:
+                    continue
+                try:
+                    stat_result = os.stat(path)
+                except OSError:
+                    continue
+                entries.append(
+                    (stat_result.st_mtime_ns, path, key, stat_result.st_size)
+                )
+
+        # mtime is the restart-safe approximation of prior recency. Runtime
+        # touches maintain exact LRU order after initialization.
+        entries.sort(key=lambda entry: (entry[0], entry[1]))
+        with self._capacity_cv:
+            for _, _, key, size in entries:
+                previous = self._cache_lru.pop(key, None)
+                if previous is not None:
+                    self._cache_size_bytes -= previous
+                self._cache_lru[key] = size
+                self._cache_size_bytes += size
+            if not self._evict_until_fits_locked(0):
+                raise OSError(
+                    "Unable to reduce filesystem KV cache to "
+                    f"max_cache_size_bytes={self._max_cache_size_bytes}"
+                )
+
+        logger.info(
+            "Filesystem KV cache capacity enabled: %d/%d bytes in %s",
+            self._cache_size_bytes,
+            self._max_cache_size_bytes,
+            data_dir,
+        )
+
+    def _evict_until_fits_locked(self, required_bytes: int) -> bool:
+        """Evict unpinned LRU entries until required_bytes can be reserved."""
+        assert self._max_cache_size_bytes is not None
+        while (
+            self._cache_size_bytes + self._pending_store_bytes + required_bytes
+            > self._max_cache_size_bytes
+        ):
+            evicted = False
+            for key, size in list(self._cache_lru.items()):
+                if self._pin_counts.get(key, 0):
+                    continue
+                path = self.file_mapper.get_file_name(key)
+                try:
+                    os.remove(path)
+                except FileNotFoundError:
+                    pass
+                except OSError as exc:
+                    logger.warning(
+                        "Failed to evict filesystem KV block %s: %s", path, exc
+                    )
+                    continue
+                del self._cache_lru[key]
+                self._cache_size_bytes -= size
+                self._append_event(
+                    OffloadingEvent(
+                        keys=[key],
+                        medium=self.medium,
+                        removed=True,
+                        locality=self.locality,
+                    )
+                )
+                evicted = True
+                break
+            if not evicted:
+                return False
+        return True
+
+    def _reserve_store(self, key: OffloadKey) -> bool:
+        """Reserve one block. Return False when it is already resident."""
+        path = self.file_mapper.get_file_name(key)
+        with self._capacity_cv:
+            while True:
+                size = self._cache_lru.get(key)
+                if size is not None:
+                    if os.path.exists(path):
+                        self._cache_lru.move_to_end(key)
+                        return False
+                    del self._cache_lru[key]
+                    self._cache_size_bytes -= size
+                    self._append_event(
+                        OffloadingEvent(
+                            keys=[key],
+                            medium=self.medium,
+                            removed=True,
+                            locality=self.locality,
+                        )
+                    )
+
+                if key in self._pending_store_keys:
+                    self._capacity_cv.wait()
+                    continue
+
+                if self._evict_until_fits_locked(self._block_size):
+                    self._pending_store_keys.add(key)
+                    self._pending_store_bytes += self._block_size
+                    return True
+
+                # A concurrent store may become an evictable resident entry.
+                if self._pending_store_bytes:
+                    self._capacity_cv.wait()
+                    continue
+
+                raise OSError(
+                    errno.ENOSPC,
+                    "Filesystem KV cache is full and every resident block is "
+                    "pinned by an active request or load job",
+                )
+
+    def _store_block_bounded(self, key: OffloadKey, offset: int) -> None:
+        if not self._reserve_store(key):
+            return
+
+        path = self.file_mapper.get_file_name(key)
+        success = False
+        try:
+            store_block(
+                path,
+                self._primary_kv_view,
+                offset,
+                self._block_size,
+            )
+            size = os.path.getsize(path)
+            if size != self._block_size:
+                try:
+                    os.remove(path)
+                except OSError as cleanup_exc:
+                    logger.warning(
+                        "Failed to remove invalid filesystem KV block %s: %s",
+                        path,
+                        cleanup_exc,
+                    )
+                raise OSError(
+                    f"Invalid filesystem KV block size: expected "
+                    f"{self._block_size} bytes, found {size} at {path}"
+                )
+            success = True
+        finally:
+            with self._capacity_cv:
+                self._pending_store_keys.remove(key)
+                self._pending_store_bytes -= self._block_size
+                if success:
+                    previous = self._cache_lru.pop(key, None)
+                    if previous is not None:
+                        self._cache_size_bytes -= previous
+                    self._cache_lru[key] = self._block_size
+                    self._cache_size_bytes += self._block_size
+                self._capacity_cv.notify_all()
+
+    def _load_block_bounded(self, key: OffloadKey, offset: int) -> None:
+        path = self.file_mapper.get_file_name(key)
+        try:
+            load_block(
+                path,
+                self._primary_kv_view,
+                offset,
+                self._block_size,
+            )
+        except Exception:
+            with self._capacity_cv:
+                size = self._cache_lru.pop(key, None)
+                if size is not None:
+                    self._cache_size_bytes -= size
+                    self._append_event(
+                        OffloadingEvent(
+                            keys=[key],
+                            medium=self.medium,
+                            removed=True,
+                            locality=self.locality,
+                        )
+                    )
+            raise
+        else:
+            with self._capacity_cv:
+                if key in self._cache_lru:
+                    self._cache_lru.move_to_end(key)
+
+    def _pin_lookup_hit(self, key: OffloadKey, req_id: str) -> bool | None:
+        """Pin a hit through request finalization to close lookup/load races."""
+        with self._capacity_cv:
+            req_keys = self._request_pins.setdefault(req_id, set())
+            if key in req_keys:
+                if key in self._cache_lru:
+                    self._cache_lru.move_to_end(key)
+                    return True
+                req_keys.remove(key)
+                self._unpin_key_locked(key)
+                return False
+            if key in self._pending_store_keys:
+                return None
+            if key not in self._cache_lru:
+                return False
+            req_keys.add(key)
+            self._pin_counts[key] = self._pin_counts.get(key, 0) + 1
+            self._cache_lru.move_to_end(key)
+            return True
+
+    def _release_load_job_pins(self, job_id: JobId) -> None:
+        with self._capacity_cv:
+            self._release_load_job_pins_locked(job_id)
+
+    def _release_load_job_pins_locked(self, job_id: JobId) -> None:
+        for key in self._load_job_keys.pop(job_id, ()):
+            self._unpin_key_locked(key)
+        self._capacity_cv.notify_all()
+
+    def _release_request_pin_locked(self, req_id: str, key: OffloadKey) -> None:
+        req_keys = self._request_pins.get(req_id)
+        if req_keys is None or key not in req_keys:
+            return
+        req_keys.remove(key)
+        if not req_keys:
+            del self._request_pins[req_id]
+        self._unpin_key_locked(key)
+
+    def _unpin_key_locked(self, key: OffloadKey) -> None:
+        pin_count = self._pin_counts[key] - 1
+        if pin_count:
+            self._pin_counts[key] = pin_count
+        else:
+            del self._pin_counts[key]

--- a/vllm/v1/kv_offload/tiering/fs/manager.py
+++ b/vllm/v1/kv_offload/tiering/fs/manager.py
@@ -311,6 +311,9 @@ class FileSystemTierManager(SecondaryTierManager):
                 if success and keys:
                     if self._max_cache_size_bytes is not None:
                         with self._capacity_cv:
+                            # Removal events are idempotent invalidations. If a
+                            # block was evicted before this completion poll,
+                            # do not publish a stale store event for it.
                             keys = [key for key in keys if key in self._cache_lru]
                             if keys:
                                 self._append_event(
@@ -405,15 +408,37 @@ class FileSystemTierManager(SecondaryTierManager):
         expected = os.path.normpath(self.file_mapper.get_file_name(key))
         return key if expected == os.path.normpath(path) else None
 
+    def _key_from_cache_temp_path(self, path: str) -> OffloadKey | None:
+        """Recover an OffloadKey from a FileMapper-owned temporary path."""
+        if not path.endswith(".tmp"):
+            return None
+        final_path, separator, suffix = path.removesuffix(".tmp").rpartition("_")
+        if not separator or not suffix.isdecimal():
+            return None
+        return self._key_from_cache_path(final_path)
+
     def _initialize_capacity_index(self) -> None:
         """Index existing block files and trim an oversized namespace."""
         data_dir = f"{self.file_mapper.base_path}_r{self.file_mapper.rank}"
         entries: list[tuple[int, str, OffloadKey, int]] = []
+        stale_temp_files_removed = 0
         for dir_path, _, filenames in os.walk(data_dir):
             for filename in filenames:
                 path = os.path.join(dir_path, filename)
                 key = self._key_from_cache_path(path)
                 if key is None:
+                    if self._key_from_cache_temp_path(path) is None:
+                        continue
+                    try:
+                        os.remove(path)
+                    except FileNotFoundError:
+                        continue
+                    except OSError as exc:
+                        raise OSError(
+                            f"Unable to remove stale filesystem KV temp file {path}: "
+                            f"{exc}"
+                        ) from exc
+                    stale_temp_files_removed += 1
                     continue
                 try:
                     stat_result = os.stat(path)
@@ -422,6 +447,13 @@ class FileSystemTierManager(SecondaryTierManager):
                 entries.append(
                     (stat_result.st_mtime_ns, path, key, stat_result.st_size)
                 )
+
+        if stale_temp_files_removed:
+            logger.info(
+                "Removed %d stale filesystem KV temp files from %s",
+                stale_temp_files_removed,
+                data_dir,
+            )
 
         # mtime is the restart-safe approximation of prior recency. Runtime
         # touches maintain exact LRU order after initialization.
@@ -449,39 +481,40 @@ class FileSystemTierManager(SecondaryTierManager):
     def _evict_until_fits_locked(self, required_bytes: int) -> bool:
         """Evict unpinned LRU entries until required_bytes can be reserved."""
         assert self._max_cache_size_bytes is not None
-        while (
+        if (
             self._cache_size_bytes + self._pending_store_bytes + required_bytes
-            > self._max_cache_size_bytes
+            <= self._max_cache_size_bytes
         ):
-            evicted = False
-            for key, size in list(self._cache_lru.items()):
-                if self._pin_counts.get(key, 0):
-                    continue
-                path = self.file_mapper.get_file_name(key)
-                try:
-                    os.remove(path)
-                except FileNotFoundError:
-                    pass
-                except OSError as exc:
-                    logger.warning(
-                        "Failed to evict filesystem KV block %s: %s", path, exc
-                    )
-                    continue
-                del self._cache_lru[key]
-                self._cache_size_bytes -= size
-                self._append_event(
-                    OffloadingEvent(
-                        keys=[key],
-                        medium=self.medium,
-                        removed=True,
-                        locality=self.locality,
-                    )
+            return True
+
+        for key in tuple(self._cache_lru):
+            if self._pin_counts.get(key, 0):
+                continue
+            size = self._cache_lru[key]
+            path = self.file_mapper.get_file_name(key)
+            try:
+                os.remove(path)
+            except FileNotFoundError:
+                pass
+            except OSError as exc:
+                logger.warning("Failed to evict filesystem KV block %s: %s", path, exc)
+                continue
+            del self._cache_lru[key]
+            self._cache_size_bytes -= size
+            self._append_event(
+                OffloadingEvent(
+                    keys=[key],
+                    medium=self.medium,
+                    removed=True,
+                    locality=self.locality,
                 )
-                evicted = True
-                break
-            if not evicted:
-                return False
-        return True
+            )
+            if (
+                self._cache_size_bytes + self._pending_store_bytes + required_bytes
+                <= self._max_cache_size_bytes
+            ):
+                return True
+        return False
 
     def _reserve_store(self, key: OffloadKey) -> bool:
         """Reserve one block. Return False when it is already resident."""


### PR DESCRIPTION
## Summary

- Add an opt-in `max_cache_size_bytes` capacity to the filesystem secondary tier.
- Index and trim existing block files at startup, then maintain runtime LRU order.
- Reserve capacity across concurrent writers so completed and pending blocks cannot oversubscribe the limit.
- Pin lookup hits and queued load sources until eviction is safe.
- Remove FileMapper-owned stale temporary files during bounded-mode startup.
- Publish removal events as idempotent state invalidations and suppress stale store events.

## Why

The filesystem tier currently grows without a configured retention bound. On a local NVMe tier, this can fill the device and turn normal KV churn into `ENOSPC` failures outside the cache policy.

Bounded mode evicts the least-recently-used unpinned block before admitting a store. If every resident block is pinned by an active request or load job, that store fails with `ENOSPC` instead of evicting an in-use source or exceeding the configured limit. Leaving `max_cache_size_bytes` unset preserves the existing path.

This does not duplicate an open downstream or upstream capacity PR. The open upstream worker-transfer and CPU-policy changes address different tiers and ownership layers; none provides a byte bound for the local filesystem tier.

## Forward-port and review history

The `dev/gilded-gnosis` versions of the original three input files were byte-for-byte identical to the v19 inputs for commit `d74c0a6c`. Commit `a1f5cc6c` was therefore an exact replay with no conflict resolution or semantic adaptation.

Follow-up commit `8cee971b` addresses all three findings from the independent review:

1. **Startup trim complexity:** `_evict_until_fits_locked` now makes one oldest-first pass over a stable key snapshot. It attempts each pinned, unremovable, or evictable entry at most once per admission call instead of rebuilding and restarting an `O(N)` item list after every eviction.
2. **Crash-leftover temporary files:** bounded-mode startup recognizes only the exact FileMapper writer shape, `<valid-final-.bin>_<decimal>.tmp`, removes those stale files before indexing, preserves unrelated files, and fails startup if an owned stale file cannot be removed.
3. **KV-event ordering:** `BlockRemoved` is now explicitly an idempotent state invalidation. A removal may have no preceding store in the current stream, including restart trimming and eviction before scheduler completion polling. The resident filter continues to suppress a stale `BlockStored` event after eviction; this behavior is documented at the raw event type and consumer-facing documentation and covered by a deterministic regression test.

## Validation

Focused tests on the repaired v20 tree:

- `VLLM_TARGET_DEVICE=empty python -m pytest -q tests/v1/kv_offload/tiering/test_fs_tier.py`: 36 passed, 2 skipped platform-extension cells
- `VLLM_TARGET_DEVICE=empty python -m pytest -q tests/v1/kv_offload/tiering/test_factory.py tests/v1/kv_offload/tiering/test_tiering_offloading.py`: 37 passed
- `pre-commit` on all four changed files: all applicable hooks passed, including Ruff, mypy, markdownlint, SPDX, forbidden-import, and configuration checks
- Python `compileall`: passed
- `git diff --check`: passed

The filesystem suite was run on ARM macOS with vLLM's `skip_global_cleanup` test marker because PyTorch 2.11's unrelated MPS allocator asserts in the global teardown fixture. All test bodies passed. The two skipped cells require the optional Linux filesystem lookup extension.

Existing target-system capacity evidence for the underlying reservation/eviction path:

- configured capacity: 8,589,934,592 bytes
- ordered inotify events observed during saturation/turnover: 41,334
- capacity violations: 0
- high-water mark: 823,296 bytes below the configured limit
- LRU turnover was observed while the serving process remained live

The ordered-event monitor tracks completed and in-flight temporary files. This replaced an earlier non-atomic directory sampler whose apparent transient overshoots were measurement artifacts.

Model-output evaluation is not applicable because this change controls filesystem cache retention, recovery, and event reporting, not model computation.

## Source pins

- PR head: `8cee971bef4f483904d86d196a39da1aa9f7c106`
- Review-fix parent: `a1f5cc6cd0bcbcedfc607f98afbd8883ea3a3d5a`

| File | MD5 | SHA-256 |
| --- | --- | --- |
| `vllm/v1/kv_offload/tiering/fs/manager.py` | `db623944a195ebb601d647f4325349bf` | `bebaec75f07b53d06a74bb55e64b7963c89f0e78287defa6b5c32d66f0417352` |
| `vllm/v1/kv_offload/base.py` | `2048bd632e66e599c48a65650694ae5e` | `7a506dc168c4b7b76a992ee81e1b1c2a2e856c49be51287ab1b8b1be6b2e5f12` |
| `tests/v1/kv_offload/tiering/test_fs_tier.py` | `adf9a247088f0ec434c076023506700e` | `4d4f458208c266ad8a143561d4e2c6807c558be659f6bc0f31d76b22a4750f48` |
| `docs/features/kv_offloading_usage.md` | `682fbaaa361f68e9191150c2d2e6be4c` | `f49137c5a260286bc31a20eada70a804f29a35291206ec4671fa7368a3326a69` |

## AI assistance

OpenAI Codex assisted with investigation, implementation, testing, and PR drafting. The human submitter will review every changed line and the recorded evidence before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional size limits for filesystem KV caching.
  * Added LRU eviction while protecting blocks in active use or pending operations.
  * Added startup cleanup of stale temporary cache files.
  * Added capacity-aware behavior for concurrent reads and writes.

* **Bug Fixes**
  * Improved KV event ordering and handling of invalidation events during eviction and failed loads.

* **Documentation**
  * Clarified cache sizing, startup cleanup, eviction behavior, and idempotent removal events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->