### PR TITLE
[GG] fix(mla): preserve aligned block-table width during MTP expansion

### DIFF
--- a/tests/model_executor/layers/test_sparse_attn_indexer_b12x.py
+++ b/tests/model_executor/layers/test_sparse_attn_indexer_b12x.py
@@ -1090,3 +1090,49 @@ def test_b12x_schedule_metadata_uses_canonical_indexer_import(monkeypatch):
         ("uses_schedule", 2, 3),
         ("build_schedule", (64, 128), 64, 4, True),
     ]
+
+
+def test_mtp_variable_decode_drops_block_table_alignment_padding():
+    from vllm.v1.attention.backends.mla import indexer as mla_indexer_mod
+
+    builder = object.__new__(mla_indexer_mod.DeepseekV32IndexerMetadataBuilder)
+    # max_model_len=480000, block_size=64, DCP=4 requires 1875 logical
+    # blocks. The model runner aligns that row to 1876 entries.
+    logical_width = 1875
+    aligned_width = 1876
+    buffer_rows = 16
+    builder.decode_seq_lens_buffer = torch.zeros(buffer_rows, dtype=torch.int32)
+    builder.expanded_block_table_buffer = torch.zeros(
+        (buffer_rows, logical_width), dtype=torch.int32
+    )
+    builder.decode_lens_buffer = torch.zeros(buffer_rows, dtype=torch.int32)
+    builder.arange_buffer = torch.arange(buffer_rows, dtype=torch.int32)
+    builder.compress_ratio = 1
+
+    block_table = torch.arange(3 * aligned_width, dtype=torch.int32).view(
+        3, aligned_width
+    )
+    seq_lens = torch.tensor([100, 200, 300], dtype=torch.int32)
+    decode_lens = torch.tensor([3, 1, 3], dtype=torch.int32)
+    query_start_loc = torch.tensor([0, 3, 4], dtype=torch.int32)
+
+    _, expanded, _, batch_size, requires_padding = builder._prepare_decode_tensors(
+        seq_lens=seq_lens,
+        block_table=block_table,
+        decode_lens=decode_lens,
+        decode_lens_cpu=decode_lens,
+        query_start_loc=query_start_loc,
+        num_decodes=3,
+        num_decode_tokens=7,
+        use_native=False,
+        next_n=4,
+        max_decode_len=3,
+    )
+
+    expected = torch.repeat_interleave(
+        block_table[:, :logical_width], decode_lens, dim=0, output_size=7
+    )
+    assert expanded.shape == (7, logical_width)
+    torch.testing.assert_close(expanded, expected)
+    assert batch_size == 7
+    assert not requires_padding

--- a/tests/model_executor/layers/test_sparse_attn_indexer_b12x.py
+++ b/tests/model_executor/layers/test_sparse_attn_indexer_b12x.py
@@ -1092,18 +1092,20 @@ def test_b12x_schedule_metadata_uses_canonical_indexer_import(monkeypatch):
     ]
 
 
-def test_mtp_variable_decode_drops_block_table_alignment_padding():
+def test_mtp_variable_decode_preserves_block_table_alignment_padding():
     from vllm.v1.attention.backends.mla import indexer as mla_indexer_mod
+
+    assert mla_indexer_mod._align_block_table_width(1875, 64) == 1876
+    assert mla_indexer_mod._align_block_table_width(1874, 64) == 1874
 
     builder = object.__new__(mla_indexer_mod.DeepseekV32IndexerMetadataBuilder)
     # max_model_len=480000, block_size=64, DCP=4 requires 1875 logical
     # blocks. The model runner aligns that row to 1876 entries.
-    logical_width = 1875
     aligned_width = 1876
     buffer_rows = 16
     builder.decode_seq_lens_buffer = torch.zeros(buffer_rows, dtype=torch.int32)
     builder.expanded_block_table_buffer = torch.zeros(
-        (buffer_rows, logical_width), dtype=torch.int32
+        (buffer_rows, aligned_width), dtype=torch.int32
     )
     builder.decode_lens_buffer = torch.zeros(buffer_rows, dtype=torch.int32)
     builder.arange_buffer = torch.arange(buffer_rows, dtype=torch.int32)
@@ -1129,10 +1131,27 @@ def test_mtp_variable_decode_drops_block_table_alignment_padding():
         max_decode_len=3,
     )
 
-    expected = torch.repeat_interleave(
-        block_table[:, :logical_width], decode_lens, dim=0, output_size=7
-    )
-    assert expanded.shape == (7, logical_width)
+    expected = torch.repeat_interleave(block_table, decode_lens, dim=0, output_size=7)
+    assert expanded.shape == (7, aligned_width)
     torch.testing.assert_close(expanded, expected)
     assert batch_size == 7
     assert not requires_padding
+
+    # Future allocation drift must fail before either the Triton copy or a
+    # paged indexer kernel can consume mismatched row strides.
+    builder.expanded_block_table_buffer = torch.zeros(
+        (buffer_rows, 1875), dtype=torch.int32
+    )
+    with pytest.raises(ValueError, match="block-table row width"):
+        builder._prepare_decode_tensors(
+            seq_lens=seq_lens,
+            block_table=block_table,
+            decode_lens=decode_lens,
+            decode_lens_cpu=decode_lens,
+            query_start_loc=query_start_loc,
+            num_decodes=3,
+            num_decode_tokens=7,
+            use_native=False,
+            next_n=4,
+            max_decode_len=3,
+        )

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -36,6 +36,14 @@ from vllm.v1.worker.cp_utils import get_total_cp_world_size
 logger = init_logger(__name__)
 
 
+def _align_block_table_width(num_blocks: int, block_size: int) -> int:
+    """Match the model runner's backend-facing block-table row alignment."""
+    if block_size > 128:
+        return num_blocks
+    alignment = 128 // block_size
+    return cdiv(num_blocks, alignment) * alignment
+
+
 @triton.jit
 def _prepare_uniform_decode_kernel(
     seq_lens_ptr,
@@ -448,6 +456,17 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
             self.vllm_config.model_config.max_model_len,
             self.kv_cache_spec.block_size * get_total_cp_world_size(),
         )
+        # Keep the expanded decode table layout identical to the model
+        # runner's block table. The runner right-pads rows to a 128-token
+        # boundary for attention backends; sizing this buffer to only the
+        # logical page count can therefore produce a different row stride
+        # (for example 1875 here versus 1876 in the runner at 480k,
+        # block_size=64, DCP=4). Besides breaking variable-width MTP's
+        # repeat_interleave, that divergent stride is passed to the paged
+        # indexer kernels during flattened decode.
+        max_num_blocks_per_req = _align_block_table_width(
+            max_num_blocks_per_req, self.kv_cache_spec.block_size
+        )
         self.expanded_block_table_buffer = torch.zeros(
             (
                 scheduler_config.max_num_batched_tokens,
@@ -566,6 +585,12 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
         min_decode_len = int(decode_lens_cpu.min().item())
         if not use_native and (max_decode_len > 1 or force_flatten):
             assert self.decode_seq_lens_buffer.dim() == 1
+            if block_table.shape[1] != self.expanded_block_table_buffer.shape[1]:
+                raise ValueError(
+                    "MTP block-table row width does not match its expanded buffer: "
+                    f"{block_table.shape[1]} != "
+                    f"{self.expanded_block_table_buffer.shape[1]}"
+                )
             if (
                 min_decode_len == max_decode_len
                 and num_decodes * max_decode_len == num_decode_tokens
@@ -630,15 +655,11 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                 seq_lens = self.decode_seq_lens_buffer[:num_decode_tokens]
 
                 # Give each of the flattened entries the same block table row as the
-                # original request. The model runner may right-pad block-table rows
-                # for backend alignment (for example, 1875 logical blocks becomes
-                # 1876 at block_size=64), while this indexer buffer is sized to the
-                # logical page count. Match the uniform Triton path above, which
-                # copies only expanded_bt_stride entries and drops that unused tail.
-                expanded_block_table_width = self.expanded_block_table_buffer.shape[1]
+                # original request. The expanded buffer uses the same backend-aligned
+                # row width as the model runner's source table.
                 self.expanded_block_table_buffer[:actual_expanded] = (
                     torch.repeat_interleave(
-                        block_table[:, :expanded_block_table_width],
+                        block_table,
                         decode_lens,
                         dim=0,
                         output_size=actual_expanded,

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -630,10 +630,18 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                 seq_lens = self.decode_seq_lens_buffer[:num_decode_tokens]
 
                 # Give each of the flattened entries the same block table row as the
-                # original request.
+                # original request. The model runner may right-pad block-table rows
+                # for backend alignment (for example, 1875 logical blocks becomes
+                # 1876 at block_size=64), while this indexer buffer is sized to the
+                # logical page count. Match the uniform Triton path above, which
+                # copies only expanded_bt_stride entries and drops that unused tail.
+                expanded_block_table_width = self.expanded_block_table_buffer.shape[1]
                 self.expanded_block_table_buffer[:actual_expanded] = (
                     torch.repeat_interleave(
-                        block_table, decode_lens, dim=0, output_size=actual_expanded
+                        block_table[:, :expanded_block_table_width],
+                        decode_lens,
+                        dim=0,
+                        output_size=actual_expanded,
                     )
                 )
                 if actual_expanded < num_decode_tokens:


### PR DESCRIPTION
## Purpose

Keep the MLA indexer's flattened-MTP block table on the same backend-aligned
row layout as the model runner.

At `max_model_len=480000`, block size 64, and DCP4, a request needs 1,875
logical local pages. The model runner aligns its block-table row to a multiple
of `128 / block_size`, producing 1,876 entries. The indexer previously
allocated its expansion buffer at the unaligned logical width.

That first caused a synchronous variable-width MTP error:

```text
Target sizes: [7, 1875]. Tensor sizes: [7, 1876]
```

The first revision of this PR avoided the exception by trimming the runner's
table to 1,875 columns. Runtime validation showed that was incomplete: four
boots carrying the trim passed the Python assignment and then hit the same
asynchronous CUDA illegal access during production speculator capture. The
failure was invariant across graph caps, memory budgets, MRV2 pool reuse, and
the DCP A2A/AG-RS route.

This revision fixes the contract at its source:

- align the indexer's expanded buffer with the same 128-token rule used by the
  model runner;
- preserve the complete aligned row during uniform and variable MTP expansion;
- fail before a GPU kernel launch if source and expanded row widths ever drift
  again.

For the reported case, both source and destination are now `[*, 1876]`. The
extra page remains inert: localized live sequence lengths expose at most 1,875
real pages at 480k, so the alignment-only column is not attended.

## Evidence

CN3 boot ledger for the incomplete trim revision:

| Boot | Distinguishing setting | KV pool | Result |
|---|---|---:|---|
| 2 | GMU .980, MNS16, graph 64 | 544,000 | illegal access |
| 3 | GMU .978, MNS8, graph 32 | 592,640 | identical illegal access |
| 4 | MRV2 pool-reuse fix | 555,520 | identical illegal access |
| 5 | A2A cap 16, large route AG/RS | 562,432 | identical illegal access |
| 6 | aligned 1,876-column buffer (this revision) | 554,496 | identical illegal access |

In every failing boot the profiling speculator capture succeeded, target graph
capture completed, and the production speculator capture surfaced the pending
fault two seconds later at an H2D copy. There was no
`cudaErrorMemoryAllocation`.

Boot 6 byte-verified this revision (`indexer.py` SHA-256 `d419af9e...`) and
forced a fresh 26-kernel SparkInfer compile round for the new 1,876-column
shape. The original `Target sizes` exception remained fixed, but the later
illegal access was byte-identical and invariant. This proves the row-alignment
change is not the CUDA-crash fix. It remains a valid correction for the
original synchronous expansion mismatch; the PR stays draft while that
separate asynchronous fault is localized.

Supporting boundary evidence: a separate stock-v20 TP4/DCP4/MTP3 deployment
reports successful load and benchmark at `max_model_len=479744`. That length
requires 1,874 local pages, which is already aligned; it does not exercise the
1,875-to-1,876 seam. This observation is supportive, not a controlled proof.

## Test result

- `pytest -q tests/model_executor/layers/test_sparse_attn_indexer_b12x.py`:
  **16 passed**.
- Exact regression checks `1875 -> 1876` at block size 64 and keeps an already
  aligned width of 1874 unchanged.
- Variable-width MTP expands an aligned `[3, 1876]` source to `[7, 1876]` and
  preserves every column.
- A deliberately mismatched 1876/1875 source-buffer pair now fails before the
  Triton copy or paged indexer launch.
- `git diff --check`: passed.

## Runtime result and remaining gate

The exact v20 TP4/DCP4/MTP3 proof boot at `max_model_len=480000` did not reach
serving because of the invariant asynchronous CUDA fault described above. A
descriptor-boundary synchronization build is now being used to attribute that
fault. Do not treat this PR as its fix.

This change is independent of INT8 wire encoding and KV offload behavior.
