### PR TITLE
[GG] fix(mla): accept capacity-pitched DCP workspace output

### DIFF
--- a/tests/v1/attention/test_b12x_mla_dcp_workspace.py
+++ b/tests/v1/attention/test_b12x_mla_dcp_workspace.py
@@ -380,3 +380,55 @@ def test_dcp_workspace_projection_accepts_partial_pitched_head_major_output(
 
     assert actual.movedim(0, 1).is_contiguous()
     torch.testing.assert_close(actual, expected)
+
+
+def test_dcp_workspace_projection_accepts_aligned_head_capacity_pitch(monkeypatch):
+    max_batched = 8
+    num_tokens = 5
+    input_heads = kernel_heads = 4
+    kv_lora_rank = 4
+    v_head_dim = 2
+
+    impl = object.__new__(B12xMLASparseImpl)
+    impl._max_batched = max_batched
+    impl._input_num_heads = input_heads
+    impl._kernel_num_heads = kernel_heads
+    impl._pad_heads = False
+    impl.kv_lora_rank = kv_lora_rank
+    impl.v_head_dim = v_head_dim
+
+    q_workspace = torch.empty(
+        max_batched, kernel_heads, kv_lora_rank, dtype=torch.bfloat16
+    )
+    scratch_nbytes = input_heads * max_batched * kv_lora_rank * 2
+    scratch_storage = torch.empty(scratch_nbytes, dtype=torch.uint8)
+    full_output = (
+        scratch_storage.view(torch.bfloat16)
+        .view(input_heads, max_batched, kv_lora_rank)
+        .transpose(0, 1)
+    )
+    full_output.copy_(
+        torch.arange(full_output.numel(), dtype=torch.float32)
+        .to(torch.bfloat16)
+        .view_as(full_output)
+    )
+
+    monkeypatch.setattr(
+        impl, "_validate_dcp_prefill_workspace_contract", lambda _: None
+    )
+    monkeypatch.setattr(
+        impl,
+        "_borrow_workspace_parts",
+        lambda: (q_workspace, None, scratch_storage),
+    )
+
+    attn_out = full_output[:num_tokens]
+    lse = torch.zeros(num_tokens, input_heads, dtype=torch.float32)
+    w_uv = torch.randn(input_heads, kv_lora_rank, v_head_dim, dtype=torch.bfloat16)
+    expected = torch.bmm(attn_out.transpose(0, 1).contiguous(), w_uv).transpose(0, 1)
+
+    actual = impl.dcp_project_before_merge_in_workspace(attn_out, lse, w_uv)
+
+    assert attn_out.stride() == (kv_lora_rank, max_batched * kv_lora_rank, 1)
+    assert actual.movedim(0, 1).is_contiguous()
+    torch.testing.assert_close(actual, expected)

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -1507,13 +1507,13 @@ class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
         """Project DCP partials from 512 to 256 in borrowed MLA storage."""
         num_tokens = int(attn_out.shape[0])
         self._validate_dcp_prefill_workspace_contract(num_tokens)
-        # Virtual-TP head padding writes into a head-major workspace sized for
-        # the configured token capacity. A shorter final prefill chunk is a
-        # pitched, non-contiguous view of that allocation, but it is safe here:
-        # the projection input is compacted below before entering cuBLAS.
+        # SparkInfer's head-major extend output is planned for the configured
+        # token capacity, even when the gathered head count needs no padding.
+        # A shorter prefill chunk is therefore a pitched view of that allocation.
+        # It is safe here because the input is compacted before entering cuBLAS.
         expected_attn_stride = (
             self.kv_lora_rank,
-            (self._max_batched if self._pad_heads else num_tokens) * self.kv_lora_rank,
+            self._max_batched * self.kv_lora_rank,
             1,
         )
         if (


### PR DESCRIPTION
## Problem

SparkInfer plans head-major DCP extend output with the configured token-capacity pitch even when the head count is already aligned. vLLM only accepted that pitch when virtual-TP head padding was active.

For a reported TP8/DCP8 partial chunk, the valid tensor had shape/stride `(3532, 64, 512)/(512, 4194304, 1)`: the head stride is `8192 * 512`, while the validator incorrectly expected `3532 * 512` and rejected it before projection.

## Fix

- Validate the capacity-pitched head-major contract for both aligned and padded head counts.
- Keep the existing compact-before-cuBLAS behavior unchanged.
- Add a regression test for an aligned-head partial chunk backed by the full-capacity scratch workspace.

This is intentionally limited to the workspace contract check; it does not change CKV-gather policy or collective behavior.

## Validation

- `pytest -q tests/v1/attention/test_b12x_mla_dcp_workspace.py` (34 passed)
- `ruff check` on both changed files
- `git diff --check`