### PR TITLE
[GG] fix(mrv2): reset CKV prefetch bindings after profiling

### DIFF
--- a/tests/v1/attention/test_b12x_mla_dcp_workspace.py
+++ b/tests/v1/attention/test_b12x_mla_dcp_workspace.py
@@ -14,6 +14,20 @@ from vllm.v1.attention.backends.mla.b12x_mla_sparse import B12xMLASparseImpl
 from vllm.v1.attention.ops import common
 
 
+def test_ckv_prefetch_reset_drops_old_cache_generation(monkeypatch):
+    old_cache = torch.zeros((1, 64, 368), dtype=torch.uint8)
+    old_event = object()
+    monkeypatch.setattr(B12xMLASparseImpl, "_all_layer_kv_caches", [old_cache])
+    monkeypatch.setattr(B12xMLASparseImpl, "_shared_gather_event", old_event)
+    monkeypatch.setattr(B12xMLASparseImpl, "_shared_gather_buf_idx", 1)
+
+    B12xMLASparseImpl.reset_kv_cache_binding_state()
+
+    assert B12xMLASparseImpl._all_layer_kv_caches == []
+    assert B12xMLASparseImpl._shared_gather_event is None
+    assert B12xMLASparseImpl._shared_gather_buf_idx == 0
+
+
 @pytest.mark.parametrize(
     ("override", "value"),
     [

--- a/tests/v1/cudagraph/test_breakable_cudagraph.py
+++ b/tests/v1/cudagraph/test_breakable_cudagraph.py
@@ -18,6 +18,48 @@ import torch
 os.environ["VLLM_USE_BREAKABLE_CUDAGRAPH"] = "1"
 
 
+def test_memory_profile_cleanup_resets_backend_cache_bindings(monkeypatch):
+    from vllm.v1.worker.gpu import model_runner as model_runner_module
+
+    events: list[str] = []
+    old_cache = torch.ones((1,), dtype=torch.uint8)
+
+    class Impl:
+        def reset_kv_cache_binding_state(self):
+            events.append("reset")
+            assert layer.kv_cache is old_cache
+
+    layer = SimpleNamespace(impl=Impl(), kv_cache=old_cache)
+    runner = model_runner_module.GPUModelRunner.__new__(
+        model_runner_module.GPUModelRunner
+    )
+    runner.cudagraph_manager = None
+    runner.speculator = None
+    runner.kv_caches = [old_cache]
+    runner.attn_groups = []
+    runner.kv_cache_config = object()
+    runner.block_tables = object()
+    runner.kernel_block_sizes = object()
+    runner.kv_connector = object()
+    runner.kv_block_zeroer = object()
+    runner.verification_capacity_manager = object()
+    runner.cache_config = SimpleNamespace(num_gpu_blocks=1)
+    runner.compilation_config = SimpleNamespace(
+        static_forward_context={"layer": layer}
+    )
+
+    monkeypatch.setattr(torch.accelerator, "synchronize", lambda: None)
+    monkeypatch.setattr(torch.accelerator, "empty_cache", lambda: None)
+    monkeypatch.setattr(model_runner_module.gc, "collect", lambda: None)
+
+    runner._cleanup_cudagraph_memory_profile()
+
+    assert events == ["reset"]
+    assert runner.kv_caches == []
+    assert layer.kv_cache.numel() == 0
+    assert runner.cache_config.num_gpu_blocks is None
+
+
 def test_cudagraph_manager_clear_releases_capture_state():
     from vllm.v1.worker.gpu.cudagraph_utils import ModelCudaGraphManager
 

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -1262,6 +1262,25 @@ class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
         # Q arrives BF16; the unified kernel quantizes inside.
         self.supports_quant_query_input = False
 
+    @classmethod
+    def reset_kv_cache_binding_state(cls) -> None:
+        """Drop prefetch state whose pointers belong to an old KV cache.
+
+        Layer prefetch learns each layer's cache tensor during forward and
+        deliberately keeps those tensors across ordinary scheduler steps.
+        They are not valid across a KV-cache replacement, however. In
+        particular, MRV2 CUDA-graph memory profiling binds a temporary cache,
+        destroys it, and later binds the production cache without rebuilding
+        the attention implementations.
+
+        The runner calls this hook while tearing down the temporary cache.
+        The first forward on the new cache therefore primes the registry with
+        synchronous gathers; later forwards recover normal layer prefetch.
+        """
+        cls._all_layer_kv_caches = []
+        cls._shared_gather_event = None
+        cls._shared_gather_buf_idx = 0
+
     def do_kv_cache_update(
         self,
         kv_c_normed: torch.Tensor,

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -909,6 +909,11 @@ class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
     supports_dcp_gather_query_in_workspace: bool = True
     supports_dcp_project_before_merge_in_workspace: bool = True
     supports_dcp_reduce_scatter_output_in_workspace: bool = True
+    # Cross-layer CKV prefetch state must exist before the first backend
+    # instance so profile-cache cleanup is independent of construction order.
+    _all_layer_kv_caches: list[torch.Tensor | None] = []
+    _shared_gather_event: torch.cuda.Event | None = None
+    _shared_gather_buf_idx: int = 0
 
     def __init__(
         self,

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -853,6 +853,17 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         self.cache_config.num_gpu_blocks = None
 
         for layer in self.compilation_config.static_forward_context.values():
+            # Attention implementations may retain derived state or tensor
+            # pointers across scheduler steps. Those bindings become stale
+            # when this temporary profiling cache is replaced by the
+            # production cache. Keep the hook optional so backends without
+            # cache-generation state pay no cost.
+            impl = getattr(layer, "impl", None)
+            reset_binding_state = getattr(
+                impl, "reset_kv_cache_binding_state", None
+            )
+            if reset_binding_state is not None:
+                reset_binding_state()
             if hasattr(layer, "kv_cache"):
                 kv_cache = layer.kv_cache
                 layer.kv_cache = (


### PR DESCRIPTION
## Purpose

Prevent B12X CKV layer prefetch from dereferencing profiling-cache tensors after MRV2 replaces the temporary CUDA-graph profiling KV cache with the production KV cache.

## Root cause

`B12xMLASparseImpl` keeps a class-level registry of per-layer KV-cache tensors so layer `L` can prefetch layer `L+1`. During MRV2 graph-memory profiling, the registry is populated with the temporary minimal cache. Cleanup empties the attention layers' cache tensors but previously left that registry and its shared event intact.

On the first production forward, each layer refreshes only its own entry. Layer 0 can therefore prefetch layer 1 through the stale profiling-generation tensor before layer 1 gets a chance to replace its entry. Later forwards hide the problem because every layer has then rebound itself.

## Fix

- Add an optional attention-backend cache-binding reset hook to MRV2 profiling cleanup.
- Implement the hook for B12X sparse MLA by clearing the per-layer registry, pending event, and ping-pong index.
- Let the first production forward repopulate the registry synchronously; ordinary scheduler steps retain the existing prefetch behavior.

Backends without derived cache-generation state are unchanged.

## Proof

- Regression coverage verifies that B12X reset drops the old tensor generation, event, and buffer index.
- Cleanup coverage verifies the backend hook runs before the layer's temporary `kv_cache` is emptied.
- `git diff --check`: pass.
- The complete four-file patch applies cleanly to the exact v20 image source commit `3e731bc043d23ec21277fb76d3e15fe6da91b23b` as well as the PR base.

GPU runtime validation remains pending, so this PR is intentionally draft. This is an independently valid lifecycle fix; it is not presented as the root cause of the separately localized nine-row decode-speculator crash.

## AI assistance disclosure

OpenAI Codex assisted with source tracing, implementation, and regression-test design. The submitted change was reviewed against the profiling and prefetch lifecycle described above.
