### PR TITLE
[GG] fix(mla): restore safe query BMM layouts

### DIFF
--- a/tests/v1/attention/test_mla_backends.py
+++ b/tests/v1/attention/test_mla_backends.py
@@ -139,6 +139,29 @@ def test_mla_absorbed_weight_preallocation_reuses_compatible_storage():
     assert pre_w_uk_t is None
 
 
+@pytest.mark.cpu_test
+def test_mla_absorbed_weight_preallocation_replaces_strided_storage():
+    layer = SimpleNamespace(
+        kv_lora_rank=2,
+        num_heads=2,
+        qk_nope_head_dim=3,
+        v_head_dim=4,
+        kv_b_proj=torch.nn.Module(),
+        W_UV=torch.empty((2, 4, 2), dtype=torch.float32).transpose(1, 2),
+        W_UK_T=torch.empty((2, 2, 3), dtype=torch.float32).transpose(1, 2),
+        force_contiguous_mla_bmm_weight=True,
+    )
+    assert not layer.W_UV.is_contiguous()
+    assert not layer.W_UK_T.is_contiguous()
+
+    pre_w_uv, pre_w_uk_t = mla_attention_module._preallocate_absorbed_mla_weights(
+        layer, torch.float32
+    )
+
+    assert pre_w_uv is not None and pre_w_uv.is_contiguous()
+    assert pre_w_uk_t is not None and pre_w_uk_t.is_contiguous()
+
+
 @pytest.mark.parametrize(
     ("cache_dtype", "expected_quant_mode"),
     [
@@ -161,6 +184,79 @@ def test_mla_kv_cache_spec_uses_layer_cache_dtype(
     assert spec.kv_quant_mode == expected_quant_mode
     if cache_dtype == "fp8_ds_mla":
         assert spec.page_size_bytes == 64 * 656
+
+
+@pytest.mark.cpu_test
+def test_mla_init_propagates_query_bmm_contiguity_contract(monkeypatch):
+    class FakeImpl:
+        is_sparse = True
+        supports_mha_prefill = False
+
+        def __init__(self, **kwargs):
+            self.force_contiguous_mla_bmm_input = True
+            self.force_contiguous_mla_bmm_weight = True
+
+    class FakeBackend:
+        @staticmethod
+        def is_mla():
+            return True
+
+        @staticmethod
+        def get_name():
+            return "TEST_MLA"
+
+        @staticmethod
+        def get_impl_cls():
+            return FakeImpl
+
+    config = SimpleNamespace(
+        compilation_config=SimpleNamespace(
+            static_forward_context={}, cudagraph_capture_sizes=[]
+        ),
+        attention_config=SimpleNamespace(mla_prefill_backend=None),
+        parallel_config=SimpleNamespace(
+            decode_context_parallel_size=1,
+            dcp_comm_backend="a2a",
+        ),
+        scheduler_config=SimpleNamespace(max_num_batched_tokens=128),
+    )
+    monkeypatch.setattr(
+        mla_attention_module, "get_current_vllm_config", lambda: config
+    )
+    monkeypatch.setattr(
+        mla_attention_module, "get_current_vllm_config_or_none", lambda: config
+    )
+    monkeypatch.setattr(mla_attention_module, "_init_kv_cache_quant", lambda *a: None)
+    monkeypatch.setattr(
+        mla_attention_module,
+        "get_mla_prefill_backend",
+        lambda _: (_ for _ in ()).throw(ValueError),
+    )
+    monkeypatch.setattr(mla_attention_module, "_DecodeConcatQuantFP8", lambda **_: None)
+    monkeypatch.setattr(mla_attention_module, "QuantFP8", lambda **_: None)
+    monkeypatch.setattr(
+        mla_attention_module.rocm_aiter_ops, "is_fp8bmm_enabled", lambda: False
+    )
+    monkeypatch.setattr(
+        mla_attention_module.rocm_aiter_ops, "is_fp4bmm_enabled", lambda: False
+    )
+
+    layer = MLAAttention(
+        num_heads=8,
+        scale=1.0,
+        qk_nope_head_dim=4,
+        qk_rope_head_dim=2,
+        v_head_dim=3,
+        q_lora_rank=None,
+        kv_lora_rank=4,
+        kv_b_proj=SimpleNamespace(),
+        prefix="test",
+        attn_backend=FakeBackend,
+        use_sparse=True,
+    )
+
+    assert layer.force_contiguous_mla_bmm_input
+    assert layer.force_contiguous_mla_bmm_weight
 
 
 # Remove sm100 backends from the list if not using sm100
@@ -222,6 +318,48 @@ def test_mla_post_load_preserves_runtime_weight_addresses(monkeypatch):
     assert layer.W_UK_T.data_ptr() == w_uk_t_ptr
     torch.testing.assert_close(layer.W_UV, old_w_uv + 100)
     torch.testing.assert_close(layer.W_UK_T, old_w_uk_t + 100)
+
+
+@pytest.mark.cpu_test
+def test_mla_post_load_replaces_strided_absorbed_weights(monkeypatch):
+    layer = MLAAttention.__new__(MLAAttention)
+    torch.nn.Module.__init__(layer)
+    layer.kv_lora_rank = 2
+    layer.num_heads = 2
+    layer.qk_nope_head_dim = 3
+    layer.v_head_dim = 4
+    layer.kv_b_proj = torch.nn.Module()
+    layer.kv_b_proj.weight = torch.nn.Parameter(
+        torch.arange(28.0, dtype=torch.float32).reshape(14, 2)
+    )
+    layer.kv_b_proj.quant_method = None
+    layer.is_aiter_triton_fp4_bmm_enabled = False
+    layer.is_aiter_triton_fp8_bmm_enabled = False
+    layer.force_contiguous_mla_bmm_weight = True
+    layer.quant_config = None
+    layer.layer_name = "test"
+    layer.W_UV = torch.nn.Parameter(
+        torch.empty((2, 4, 2), dtype=torch.float32).transpose(1, 2)
+    )
+    layer.W_UK_T = torch.nn.Parameter(
+        torch.empty((2, 2, 3), dtype=torch.float32).transpose(1, 2)
+    )
+    old_w_uv_ptr = layer.W_UV.data_ptr()
+    old_w_uk_t_ptr = layer.W_UK_T.data_ptr()
+    assert not layer.W_UV.is_contiguous()
+    assert not layer.W_UK_T.is_contiguous()
+
+    monkeypatch.setattr(
+        mla_attention_module, "set_default_quant_scales", lambda *_, **__: None
+    )
+
+    with torch.no_grad():
+        layer.process_weights_after_loading(torch.float32)
+
+    assert layer.W_UV.is_contiguous()
+    assert layer.W_UK_T.is_contiguous()
+    assert layer.W_UV.data_ptr() != old_w_uv_ptr
+    assert layer.W_UK_T.data_ptr() != old_w_uk_t_ptr
 
 
 def _make_b12x_absorb_bmm_layer() -> MLAAttention:
@@ -776,6 +914,81 @@ def test_sparse_mla_profile_skips_dense_prefill_workspace(monkeypatch):
 
     assert result is output
     assert torch.equal(output, torch.zeros_like(output))
+
+
+@pytest.mark.cpu_test
+def test_mla_query_absorb_materializes_bmm_input(monkeypatch):
+    class FakeSparseImpl(SparseMLACommonImpl):
+        supports_quant_query_input = False
+
+        def __init__(self):
+            self.dcp_world_size = 1
+
+        def forward_mqa(self, q, kv_cache, attn_metadata, layer):
+            assert isinstance(q, tuple)
+            out = torch.ones(
+                (q[0].shape[0], q[0].shape[1], layer.kv_lora_rank),
+                dtype=q[0].dtype,
+            )
+            return out, None
+
+    layer = object.__new__(MLAAttention)
+    layer.impl = FakeSparseImpl()
+    layer.kv_cache_dtype = "auto"
+    layer.num_heads = 2
+    layer.qk_nope_head_dim = 4
+    layer.qk_rope_head_dim = 2
+    layer.kv_lora_rank = 3
+    layer.v_head_dim = 3
+    layer.q_pad_num_heads = None
+    layer.force_contiguous_mla_bmm_input = True
+    layer.is_aiter_triton_fp4_bmm_enabled = False
+    layer.is_aiter_triton_fp8_bmm_enabled = False
+    layer.W_UK_T = torch.ones((2, 4, 3), dtype=torch.bfloat16)
+
+    def fake_v_up_proj(x, out):
+        out.copy_(x.reshape(out.shape))
+
+    layer._v_up_proj = fake_v_up_proj
+
+    real_bmm = torch.bmm
+    seen_input_layouts = []
+
+    def checked_bmm(input_tensor, mat2, *, out=None):
+        if mat2 is layer.W_UK_T:
+            seen_input_layouts.append(input_tensor.is_contiguous())
+        return real_bmm(input_tensor, mat2, out=out)
+
+    monkeypatch.setattr(torch, "bmm", checked_bmm)
+
+    num_tokens = 3
+    q = torch.ones((num_tokens, 2, 6), dtype=torch.bfloat16)
+    q_nope, _ = q.split((4, 2), dim=-1)
+    assert not q_nope.transpose(0, 1).is_contiguous()
+    kv_c = torch.empty((num_tokens, 3), dtype=torch.bfloat16)
+    k_pe = torch.empty((num_tokens, 1, 2), dtype=torch.bfloat16)
+    kv_cache = torch.empty((0,), dtype=torch.uint8)
+    output = torch.empty((num_tokens, 6), dtype=torch.bfloat16)
+    attn_metadata = SimpleNamespace(
+        num_actual_tokens=num_tokens,
+        num_decodes=num_tokens,
+        num_prefills=0,
+        num_decode_tokens=num_tokens,
+        max_query_len=1,
+    )
+
+    result = MLAAttention.forward_impl(
+        layer,
+        q,
+        kv_c,
+        k_pe,
+        kv_cache,
+        attn_metadata,
+        output,
+    )
+
+    assert result is output
+    assert seen_input_layouts == [True]
 
 
 def test_fp8_dcp_sparse_mla_uses_lse_gather_path(monkeypatch):

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -373,6 +373,10 @@ def _preallocate_absorbed_mla_weights(
             and weight.shape == shape
             and weight.dtype == act_dtype
             and weight.device == device
+            and (
+                not getattr(layer, "force_contiguous_mla_bmm_weight", False)
+                or weight.is_contiguous()
+            )
         )
 
     pre_w_uv = (
@@ -699,6 +703,12 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             **extra_impl_args,
         )
         self.q_pad_num_heads = getattr(self.impl, "q_pad_num_heads", None)
+        self.force_contiguous_mla_bmm_input = getattr(
+            self.impl, "force_contiguous_mla_bmm_input", False
+        )
+        self.force_contiguous_mla_bmm_weight = getattr(
+            self.impl, "force_contiguous_mla_bmm_weight", False
+        )
         self.use_direct_call = not current_platform.opaque_attention_op()
 
         vllm_config = get_current_vllm_config()
@@ -1188,6 +1198,9 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                     L = self.kv_lora_rank
                 else:
                     _, _, L = self.W_UK_T.shape
+
+                if self.force_contiguous_mla_bmm_input:
+                    mqa_q_nope = mqa_q_nope.contiguous()
 
                 if self.q_pad_num_heads is not None:
                     mqa_ql_nope = mqa_q_nope.new_empty((self.q_pad_num_heads, B, L))
@@ -1727,13 +1740,17 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             if pre_w_uv is not None:
                 pre_w_uv.copy_(w_uv)
                 w_uv = pre_w_uv
-            replace_parameter(self, "W_UV", w_uv, prefer_copy=True)
+            replace_parameter(
+                self, "W_UV", w_uv, prefer_copy=pre_w_uv is None
+            )
             # Convert from (L, N, P) to (N, P, L)
             w_uk_t = W_UK.permute(1, 2, 0)
             if pre_w_uk_t is not None:
                 pre_w_uk_t.copy_(w_uk_t)
                 w_uk_t = pre_w_uk_t
-            replace_parameter(self, "W_UK_T", w_uk_t, prefer_copy=True)
+            replace_parameter(
+                self, "W_UK_T", w_uk_t, prefer_copy=pre_w_uk_t is None
+            )
 
         # If we should not load quant weights, we initialize the scales to 1.0
         # as the default value. See [Note: Register q/k/v/prob scales in state dict]

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -976,6 +976,16 @@ class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
         self.v_head_dim: int = mla_args.get("v_head_dim", 512)
         # GLM_NSA contract: q_head_dim = kv_lora_rank (512) + qk_rope (64) = 576.
         self.q_head_dim = self.kv_lora_rank + self.qk_rope_head_dim
+        # Query absorption splits Q and transposes it to head-major order,
+        # producing a non-contiguous view. Some cuBLAS BMM algorithms read a
+        # complete tile beyond that view's logical row bounds. B12X buffers can
+        # be tightly mapped, so materialize the query operand and keep the
+        # absorbed weights contiguous before entering torch.bmm.
+        #
+        # DCP attention outputs are already kept head-major for the V-up BMM;
+        # this contract is specifically for the independent query-absorb BMM.
+        self.force_contiguous_mla_bmm_input = True
+        self.force_contiguous_mla_bmm_weight = True
         # The indexer carries the shared buffer for normal layers and tests;
         # the explicitly-passed buffer covers backbone skip layers, whose
         # indexer is not constructed (see deepseek_v2.py).


### PR DESCRIPTION
## Summary

Restore the B12X MLA query-absorption layout contract that was removed when
DCP attention outputs moved to a head-major layout.

The head-major DCP change correctly made the old V-up output copy unnecessary,
but query absorption is a separate BMM:

```python
mqa_q_nope = mqa_q_nope.transpose(0, 1)
torch.bmm(mqa_q_nope, self.W_UK_T, out=mqa_ql_nope)
```

`mqa_q_nope` is a non-contiguous split-and-transpose view. On the v20
TP4/DCP4/MTP3 stack, production decode-graph warmup reproducibly raised a CUDA
illegal-address error at this BMM, while the profiling capture of the same
descriptors succeeded.

This patch:

- lets B12X request contiguous query-BMM input and absorbed weights;
- materializes the query operand immediately before the affected BMM;
- prevents compatible-but-strided absorbed-weight storage from being reused;
  and
- preserves weight addresses when the existing storage already satisfies the
  contract.

It deliberately does not restore the old V-up output temporary. The newer
head-major DCP output path remains unchanged.

## Root cause

`b3ea2e8f` / #136 originally added backend-selected contiguous MLA BMM
operands after a cuBLAS read-ahead failure. `6a2edcf1` subsequently kept DCP
attention outputs head-major and removed all three B12X contiguity flags.

That removal was valid for the superseded V-up output layout, but it also
removed protection from the independent query-absorption BMM. The v20 source
still constructs its first operand with `split(...).transpose(0, 1)` and
passed that view directly to `torch.bmm`.

With `CUDA_LAUNCH_BLOCKING=1`, the previously asynchronous boot failure
localized to that exact launch:

```text
speculator capture
  -> deepseek_mtp.py: forward
  -> mla_attention.py: forward_impl
  -> torch.bmm(mqa_q_nope, self.W_UK_T, out=mqa_ql_nope)
  -> CUDA error: an illegal memory access was encountered
```

## Validation

### Unit tests

```bash
python -m pytest -q tests/v1/attention/test_mla_backends.py -m cpu_test
# 11 passed
```

The same suite passed twice:

1. on the v20 image source; and
2. after applying the formatted patch to the later CKV-reset candidate source.

New coverage verifies backend flag propagation, materialization of the exact
split-and-transpose query operand, compatible contiguous-weight reuse, and
replacement of strided absorbed-weight storage.

### TP4/DCP4/MTP3 runtime proof

Configuration:

```text
GLM-5.2, TP4 / DCP4 / MTP3
max_model_len=480000
max_num_seqs=16
max_cudagraph_capture_size=64
gpu_memory_utilization=0.980
B12X_MLA_SPARSE
nvfp4_ds_mla + KV_FP8_ROPE=1
i8_ring
DRAM + bounded NVMe KV offload enabled
```

Before the patch, the production decode-speculator capture failed
reproducibly across the configuration and memory-control runs. Descriptor
M=9 was the first diagnostic failure; a launch-blocking run named the BMM
above as the first failing CUDA operation.

Patched result:

```text
profiling decode capture:   sizes 16 -> 1 PASS
production decode capture:  sizes 16 -> 1 PASS
CG_DIAG boundaries:         624 PASS / 0 FAIL
M=9:                        all five stages PASS in both rounds
API/liveness:               PASS
MTP acceptance:             46/48 draft tokens (95.8%)
GPU KV pool:                557,824 tokens (1.16x at 480k)
RestartCount:               0
illegal access/cuBLAS/OOM/
Xid/EngineDead/assertion:    0
```

The image byte-verified both patched output files. The separate experimental
MoE overlap patch was not present, isolating this fix as the change that
cleared the boot failure.

Extended throughput, long-context needle and offload qualification is running
on the same live process and will be added when complete.

## Scope and tradeoff

The added copy is limited to the query-absorption operand selected by the
B12X backend. At the reproduced M=9 descriptor it is a small
head-major query tensor; it does not copy KV state or DCP attention output.

This patch does not change MTP, graph sizes, A2A/AG-RS routing, INT8 wire mode,
CKV prefetch, MoE scheduling, GPU-memory accounting, or KV offloading.
