### PR TITLE
[GG] Fix MRV2 high-utilization startup memory profiling

### DIFF
--- a/tests/model_executor/test_flashinfer_autotune_cache.py
+++ b/tests/model_executor/test_flashinfer_autotune_cache.py
@@ -91,7 +91,10 @@ def _flashinfer_autotune_worker(model, *, attn_groups=None):
                 cudagraph_capture_sizes=[],
                 compile_sizes=[],
             ),
-            kernel_config=SimpleNamespace(enable_flashinfer_autotune=True),
+            kernel_config=SimpleNamespace(
+                enable_flashinfer_autotune=True,
+                enable_cutedsl_warmup=False,
+            ),
         ),
         model_config=SimpleNamespace(dtype=torch.bfloat16),
     )
@@ -149,6 +152,8 @@ def test_b12x_dcp_warmup_finds_generic_mla_attention(monkeypatch) -> None:
     )
     worker = SimpleNamespace(
         get_model=lambda: model,
+        use_v2_model_runner=True,
+        model_runner=SimpleNamespace(is_pooling_model=True),
         model_config=SimpleNamespace(dtype=torch.bfloat16),
         scheduler_config=SimpleNamespace(max_num_batched_tokens=4096),
         vllm_config=SimpleNamespace(
@@ -157,6 +162,7 @@ def test_b12x_dcp_warmup_finds_generic_mla_attention(monkeypatch) -> None:
                 dcp_comm_backend="a2a",
             ),
             compilation_config=compilation_config,
+            model_config=SimpleNamespace(),
         ),
     )
     group = object()
@@ -265,6 +271,12 @@ def test_kernel_warmup_limits_fused_mla_query_to_graph_sizes(monkeypatch) -> Non
     kernel_warmup.kernel_warmup(worker)
 
     assert calls == [((model,), {"m_values": [1, 2, 4, 32]})]
+
+
+def test_flashinfer_attention_gate_accepts_pre_kv_runner() -> None:
+    runner = SimpleNamespace()
+
+    assert kernel_warmup._uses_flashinfer_attention(runner) is False
 
 
 def test_kernel_warmup_runs_b12x_moe_warmup(monkeypatch) -> None:

--- a/tests/v1/attention/test_b12x_mla_dcp_workspace.py
+++ b/tests/v1/attention/test_b12x_mla_dcp_workspace.py
@@ -5,11 +5,14 @@ import pytest
 import torch
 
 from vllm import envs
+from vllm.model_executor.layers.attention import mla_attention
 from vllm.model_executor.layers.attention.mla_attention import (
     MLAAttention,
     _can_use_b12x_dcp_prefill_workspace,
     _estimate_dcp_ag_rs_transient_bytes,
+    _should_allocate_sparse_profile_workspace,
 )
+from vllm.utils.multi_stream_utils import vllm_cudagraph_capture_scope
 from vllm.v1.attention.backends.mla.b12x_mla_sparse import B12xMLASparseImpl
 from vllm.v1.attention.ops import common
 
@@ -255,9 +258,7 @@ def test_cp_lse_ag_out_rs_into_preserves_borrowed_output(monkeypatch, world_size
 
 
 def test_cp_lse_ag_out_rs_requests_head_major_output(monkeypatch):
-    corrected_storage = torch.arange(8 * 3 * 16, dtype=torch.bfloat16).view(
-        8, 3, 16
-    )
+    corrected_storage = torch.arange(8 * 3 * 16, dtype=torch.bfloat16).view(8, 3, 16)
     corrected = corrected_storage.movedim(0, 1)
     corrected_lse = torch.zeros(3, 8, dtype=torch.float32)
 
@@ -446,3 +447,11 @@ def test_dcp_workspace_projection_accepts_aligned_head_capacity_pitch(monkeypatc
     assert attn_out.stride() == (kv_lora_rank, max_batched * kv_lora_rank, 1)
     assert actual.movedim(0, 1).is_contiguous()
     torch.testing.assert_close(actual, expected)
+
+
+def test_sparse_profile_workspace_skips_cudagraph_capture_scope() -> None:
+    assert _should_allocate_sparse_profile_workspace(1)
+    assert not _should_allocate_sparse_profile_workspace(0)
+    with vllm_cudagraph_capture_scope():
+        assert mla_attention.is_vllm_cudagraph_capture_active()
+        assert not _should_allocate_sparse_profile_workspace(1)

--- a/tests/v1/worker/test_gpu_worker.py
+++ b/tests/v1/worker/test_gpu_worker.py
@@ -52,6 +52,69 @@ def _pynvvideocodec_decoder_budget(api_process_count: int = 1) -> int:
     )
 
 
+def test_kernel_warmup_runs_once(monkeypatch: pytest.MonkeyPatch):
+    worker = object.__new__(Worker)
+    calls = []
+    monkeypatch.setattr(
+        gpu_worker_module,
+        "kernel_warmup",
+        lambda warmed_worker: calls.append(warmed_worker),
+    )
+
+    worker._warmup_kernels_once()
+    worker._warmup_kernels_once()
+
+    assert calls == [worker]
+    assert worker._kernel_warmup_complete is True
+
+
+def test_failed_kernel_warmup_is_retryable(monkeypatch: pytest.MonkeyPatch):
+    worker = object.__new__(Worker)
+    calls = 0
+
+    def fail_once(_worker):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise RuntimeError("warmup failed")
+
+    monkeypatch.setattr(gpu_worker_module, "kernel_warmup", fail_once)
+
+    with pytest.raises(RuntimeError, match="warmup failed"):
+        worker._warmup_kernels_once()
+    worker._warmup_kernels_once()
+
+    assert calls == 2
+    assert worker._kernel_warmup_complete is True
+
+
+def test_memory_profile_replays_model_after_kernel_warmup(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    worker = object.__new__(Worker)
+    calls = []
+    worker.model_runner = SimpleNamespace(
+        profile_run=lambda: calls.append("profile"),
+    )
+    worker.vllm_config = SimpleNamespace()
+    worker.get_model = lambda: object()
+    worker.get_kv_cache_spec = lambda: object()
+    monkeypatch.setattr(
+        gpu_worker_module,
+        "deepseek_v4_compressor_triton_warmup",
+        lambda *args: calls.append("compressor"),
+    )
+    monkeypatch.setattr(
+        worker,
+        "_warmup_kernels_once",
+        lambda: calls.append("kernel_warmup"),
+    )
+
+    worker._profile_model_with_kernel_warmup()
+
+    assert calls == ["profile", "compressor", "kernel_warmup", "profile"]
+
+
 @pytest.mark.parametrize("video_backend", [None, "opencv"])
 def test_reserve_mm_ipc_gpu_memory_raw_frame_budget_only(
     monkeypatch: pytest.MonkeyPatch,

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -253,6 +253,7 @@ from vllm.model_executor.utils import replace_parameter
 from vllm.platforms import current_platform
 from vllm.utils.flashinfer import has_flashinfer
 from vllm.utils.math_utils import cdiv, round_down
+from vllm.utils.multi_stream_utils import is_vllm_cudagraph_capture_active
 from vllm.utils.torch_utils import (
     LayerNameType,
     _encode_layer_name,
@@ -486,6 +487,10 @@ def _estimate_dcp_ag_rs_transient_bytes(
         + gathered_lse
         + gathered_w_uv
     )
+
+
+def _should_allocate_sparse_profile_workspace(workspace_bytes: int) -> bool:
+    return workspace_bytes > 0 and not is_vllm_cudagraph_capture_active()
 
 
 def _extract_single_layer_index(layer_name: str) -> int | None:
@@ -1146,7 +1151,11 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 )
             else:
                 profile_workspace_bytes = self._get_sparse_memory_profile_bytes()
-                if profile_workspace_bytes > 0:
+                # This synthetic allocation models eager runtime workspace for
+                # KV sizing. attn_metadata is also None during CUDA graph
+                # capture, where allocating it again only consumes capture-time
+                # memory and can OOM after KV cache allocation.
+                if _should_allocate_sparse_profile_workspace(profile_workspace_bytes):
                     _ = torch.empty(
                         (profile_workspace_bytes,),
                         device=k_c_normed.device,

--- a/vllm/model_executor/warmup/kernel_warmup.py
+++ b/vllm/model_executor/warmup/kernel_warmup.py
@@ -135,11 +135,12 @@ def _contains_flashinfer_object(
 
 
 def _uses_flashinfer_attention(runner: "GPUModelRunner") -> bool:
+    attn_groups = getattr(runner, "attn_groups", None)
     return bool(
-        runner.attn_groups
+        attn_groups
         and any(
             _is_flashinfer_backend(group.backend)
-            for groups in runner.attn_groups
+            for groups in attn_groups
             for group in groups
         )
     )
@@ -375,15 +376,16 @@ def kernel_warmup(worker: "Worker"):
     # FlashInfer attention warmup
     # Only warmup if the model has FlashInfer attention groups
     # and is not a pooling model
+    attn_groups = getattr(worker.model_runner, "attn_groups", None)
     if (
         not worker.model_runner.is_pooling_model
-        and worker.model_runner.attn_groups
+        and attn_groups
         # NOTE: This should be `any` instead of `all` but other hybrid attention
         # backends don't support this dummy run. Once we remove
         # `build_for_cudagraph_capture`, we can change it to `any`.
         and all(
             _is_flashinfer_backend(group.backend)
-            for groups in worker.model_runner.attn_groups
+            for groups in attn_groups
             for group in groups
         )
     ):

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -454,6 +454,27 @@ class Worker(WorkerBase):
     def reload_weights(self, *args, **kwargs) -> None:
         self.model_runner.reload_weights(*args, **kwargs)
 
+    def _warmup_kernels_once(self) -> None:
+        """Materialize persistent kernel resources before KV cache sizing."""
+        if getattr(self, "_kernel_warmup_complete", False):
+            return
+        kernel_warmup(self)
+        self._kernel_warmup_complete = True
+
+    def _profile_model_with_kernel_warmup(self) -> None:
+        """Profile activations on top of persistent kernel allocations."""
+        # The first pass initializes runner state required by some warmups.
+        self.model_runner.profile_run()
+        deepseek_v4_compressor_triton_warmup(
+            self.get_model(), self.get_kv_cache_spec(), self.vllm_config
+        )
+        self._warmup_kernels_once()
+
+        # Kernel warmup can create persistent modules and communication pools.
+        # A second pass is required so the measured peak contains both those
+        # allocations and the model's transient activation workspace.
+        self.model_runner.profile_run()
+
     @torch.inference_mode()
     def determine_available_memory(self) -> int:
         """Profiles the peak memory usage of the model to determine how much
@@ -476,6 +497,7 @@ class Worker(WorkerBase):
             deepseek_v4_compressor_triton_warmup(
                 self.get_model(), self.get_kv_cache_spec(), self.vllm_config
             )
+            self._warmup_kernels_once()
 
             msg = (
                 f"Initial free memory {format_gib(self.init_snapshot.free_memory)} "
@@ -498,10 +520,7 @@ class Worker(WorkerBase):
             self.init_snapshot,
             weights_memory=int(self.model_runner.model_memory_usage),
         ) as profile_result:
-            self.model_runner.profile_run()
-            deepseek_v4_compressor_triton_warmup(
-                self.get_model(), self.get_kv_cache_spec(), self.vllm_config
-            )
+            self._profile_model_with_kernel_warmup()
 
             profile_torch_peak = torch.accelerator.memory_stats(self.device).get(
                 "allocated_bytes.all.peak", 0
@@ -797,7 +816,7 @@ class Worker(WorkerBase):
 
         # Warmup and tune the kernels used during model execution before
         # cuda graph capture.
-        kernel_warmup(self)
+        self._warmup_kernels_once()
 
         cuda_graph_memory_bytes = 0
         if not self.model_config.enforce_eager:


### PR DESCRIPTION
## Problem

MRV2 can size KV cache before persistent DCP/JIT kernel resources exist. At
high GPU utilization this can over-allocate KV and fail later during kernel
warmup or CUDA graph capture.

A single model profile is insufficient after warmup moves earlier: it observes
either the transient activation peak or newly persistent resources, not their
simultaneous high-water mark.

## Fix

- materialize persistent kernel resources once during automatic memory
  profiling, before KV allocation;
- replay the model profile after warmup so activation workspace is measured on
  top of the persistent baseline;
- keep kernel warmup idempotent and retryable after a failed warmup;
- allow pre-KV runners that have not created optional `attn_groups` yet;
- avoid creating the synthetic sparse-DCP profile workspace inside CUDA graph
  capture while retaining it during ordinary memory profiling.

This PR does not change the inference hot path, backend selection, or requested
GPU utilization.

## Related fixes

This PR addresses persistent-resource ordering only. The full high-utilization
startup fix also needs:

- vLLM #180 for the profiled CUDA graph pool lifecycle and full graph
  high-water accounting;
- SparkInfer #76 for an exact-capacity, profile-visible persistent PCIe DMA
  default-output workspace.

Those responsibilities remain separate so kernel warmup, graph-pool lifecycle,
and communication-buffer ownership can be reviewed independently.

## Validation

- focused unit suites for worker ordering, sparse workspace capture behavior,
  and FlashInfer pre-KV warmup: passed;
- retry after a failed kernel warmup: covered by unit test;
- isolated full stack on 4x RTX PRO 6000 Blackwell:
  TP4/DCP4/MTP3 NF3, MNS 16, graph 64, max model length 350,208, batched tokens
  2,048, GMU 0.98 reached READY with 563,712 KV tokens and completed a
  300,017-token prefill plus decode; health remained OK;
- isolated TP8/DCP2/MTP3 A4 online-MXFP8 ring-DMA gate completed a
  300,066-token prefill plus 512 decode in 65.924 seconds and remained healthy.

The tested graph-pool profile measured 1.00 GiB total, with 0.72 GiB already
retained in the reusable pool. vLLM #180 intentionally reserves that full
high-water mark; the older `gross - retained` result omitted live
PyTorch-reserved pages and could overstate KV capacity.

## Capacity interpretation

This change makes persistent memory visible rather than reclaiming it. A lower
reported KV capacity can therefore be the correct result. The helper's logged
GMU adjustment can recover capacity only when physical headroom exists; it
cannot compensate for genuinely persistent model or DCP allocations.

The earlier 480k/GMU 0.98 failure was not rerun with the complete #180/#76
stack. Only the 350,208-token profile above is validated here, so this PR does
not claim 480k is safe.

## AI assistance disclosure

The implementation review, tests, hardware validation, and this write-up were
prepared with OpenAI Codex assistance and reviewed by the human submitter.