### PR TITLE
[GG] Fuse MXFP8 and BF16 MLA query assembly

### DIFF
--- a/tests/model_executor/test_flashinfer_autotune_cache.py
+++ b/tests/model_executor/test_flashinfer_autotune_cache.py
@@ -235,6 +235,7 @@ def test_kernel_warmup_limits_fused_mla_query_to_graph_sizes(monkeypatch) -> Non
     worker = _flashinfer_autotune_worker(model)
     worker.vllm_config.compilation_config.cudagraph_capture_sizes = [2, 4, 32, 64]
     worker.vllm_config.kernel_config.enable_flashinfer_autotune = False
+    worker.vllm_config.kernel_config.enable_cutedsl_warmup = False
 
     monkeypatch.setattr(kernel_warmup, "deepseek_v4_mhc_warmup", lambda *a, **k: None)
     monkeypatch.setattr(
@@ -257,7 +258,7 @@ def test_kernel_warmup_limits_fused_mla_query_to_graph_sizes(monkeypatch) -> Non
 
     monkeypatch.setattr(
         kernel_warmup,
-        "warmup_mxfp8_mla_query",
+        "warmup_fused_mla_query",
         fake_mla_query_warmup,
     )
 

--- a/tests/model_executor/test_flashinfer_autotune_cache.py
+++ b/tests/model_executor/test_flashinfer_autotune_cache.py
@@ -229,6 +229,43 @@ def test_kernel_warmup_runs_b12x_mxfp8_linear_warmup(monkeypatch) -> None:
     }
 
 
+def test_kernel_warmup_limits_fused_mla_query_to_graph_sizes(monkeypatch) -> None:
+    calls = []
+    model = torch.nn.Linear(2, 2)
+    worker = _flashinfer_autotune_worker(model)
+    worker.vllm_config.compilation_config.cudagraph_capture_sizes = [2, 4, 32, 64]
+    worker.vllm_config.kernel_config.enable_flashinfer_autotune = False
+
+    monkeypatch.setattr(kernel_warmup, "deepseek_v4_mhc_warmup", lambda *a, **k: None)
+    monkeypatch.setattr(
+        kernel_warmup,
+        "flashinfer_sparse_mla_decode_autotune_warmup",
+        lambda *a, **k: None,
+    )
+    monkeypatch.setattr(
+        kernel_warmup,
+        "deepseek_v4_sparse_mla_attention_warmup",
+        lambda *a, **k: None,
+    )
+    monkeypatch.setattr(kernel_warmup, "minimax_m3_msa_warmup", lambda *a, **k: None)
+    monkeypatch.setattr(kernel_warmup, "warmup_b12x_mxfp8_linear", lambda *a, **k: 0)
+    monkeypatch.setattr(kernel_warmup, "warmup_b12x_moe_dynamic", lambda *a, **k: 0)
+
+    def fake_mla_query_warmup(*args, **kwargs):
+        calls.append((args, kwargs))
+        return 4
+
+    monkeypatch.setattr(
+        kernel_warmup,
+        "warmup_mxfp8_mla_query",
+        fake_mla_query_warmup,
+    )
+
+    kernel_warmup.kernel_warmup(worker)
+
+    assert calls == [((model,), {"m_values": [1, 2, 4, 32]})]
+
+
 def test_kernel_warmup_runs_b12x_moe_warmup(monkeypatch) -> None:
     calls = []
     model = torch.nn.Linear(2, 2)

--- a/tests/v1/attention/test_mla_backends.py
+++ b/tests/v1/attention/test_mla_backends.py
@@ -248,6 +248,8 @@ def _make_b12x_absorb_bmm_layer() -> MLAAttention:
     )
     layer.is_aiter_triton_fp4_bmm_enabled = False
     layer.is_aiter_triton_fp8_bmm_enabled = False
+    layer.kv_cache_dtype = "fp8"
+    layer.impl = SimpleNamespace(supports_quant_query_input=False)
     layer.quant_config = None
     layer.layer_name = "test"
     return layer
@@ -384,6 +386,163 @@ def test_b12x_mla_mxfp8_bmm_warmup_deduplicates_signatures(monkeypatch):
         ((1, 2, 3), "n"),
         ((1, 2, 3), "k"),
     ]
+
+
+@pytest.mark.cpu_test
+def test_mxfp8_mla_query_custom_op_uses_sparkinfer_api(monkeypatch):
+    calls = []
+    mla_query = SimpleNamespace(
+        run=lambda *args, **kwargs: calls.append((args, kwargs))
+    )
+    monkeypatch.setattr(b12x_mxfp8_bmm_module, "_MXFP8_MLA_QUERY", mla_query)
+    monkeypatch.setattr(
+        b12x_mxfp8_bmm_module, "_MXFP8_MLA_QUERY_MISSING", False
+    )
+    lhs = torch.empty((8, 2, 192), dtype=torch.bfloat16)
+    b_values = torch.empty((8, 192, 512), dtype=torch.float8_e4m3fn)
+    b_scales = torch.empty((8, 192, 16), dtype=torch.uint8)
+    q_pe = torch.empty((2, 8, 64), dtype=torch.bfloat16)
+    q_scale = torch.ones(1, dtype=torch.float32)
+    out = torch.empty((2, 8, 576), dtype=torch.bfloat16)
+
+    b12x_mxfp8_bmm_module._mxfp8_mla_query_impl(
+        lhs, b_values, b_scales, q_pe, q_scale, out
+    )
+
+    args, kwargs = calls[0]
+    assert args == (lhs, (b_values, b_scales), q_pe, q_scale, out)
+    assert kwargs == {}
+
+
+@pytest.mark.cpu_test
+def test_mxfp8_mla_query_warmup_deduplicates_dtype_signatures(monkeypatch):
+    calls = []
+
+    def prewarm(rhs, m_values, **kwargs):
+        calls.append((rhs, tuple(m_values), kwargs))
+        return len(tuple(m_values))
+
+    monkeypatch.setattr(
+        b12x_mxfp8_bmm_module,
+        "_MXFP8_MLA_QUERY",
+        SimpleNamespace(prewarm=prewarm),
+    )
+    monkeypatch.setattr(
+        b12x_mxfp8_bmm_module, "_MXFP8_MLA_QUERY_MISSING", False
+    )
+    model = torch.nn.Sequential(
+        torch.nn.Module(), torch.nn.Module(), torch.nn.Module()
+    )
+    for index, module in enumerate(model):
+        module._b12x_absorb_uk_rhs = (
+            torch.empty((8, 192, 512), dtype=torch.float8_e4m3fn),
+            torch.empty((8, 192, 16), dtype=torch.uint8),
+        )
+        module._mxfp8_mla_query_output_dtype = (
+            torch.bfloat16 if index < 2 else torch.float8_e4m3fn
+        )
+
+    warmed = b12x_mxfp8_bmm_module.warmup_mxfp8_mla_query(
+        model, m_values=(1, 2, 2, 3)
+    )
+
+    assert warmed == 6
+    assert len(calls) == 2
+    assert [call[1] for call in calls] == [(1, 2, 3), (1, 2, 3)]
+    assert [call[2]["output_dtype"] for call in calls] == [
+        torch.bfloat16,
+        torch.float8_e4m3fn,
+    ]
+
+
+@pytest.mark.cpu_test
+def test_mxfp8_mla_query_dispatch_uses_backend_workspace(monkeypatch):
+    layer = MLAAttention.__new__(MLAAttention)
+    layer._use_b12x_absorb_bmm = True
+    layer.is_aiter_triton_fp4_bmm_enabled = False
+    layer.is_aiter_triton_fp8_bmm_enabled = False
+    layer._mxfp8_mla_query_output_dtype = torch.bfloat16
+    layer.kv_lora_rank = 512
+    layer.qk_rope_head_dim = 64
+    layer._q_scale = torch.ones(1, dtype=torch.float32)
+    layer._b12x_absorb_uk_rhs = (
+        torch.empty((8, 192, 512), dtype=torch.float8_e4m3fn),
+        torch.empty((8, 192, 16), dtype=torch.uint8),
+    )
+    workspace = torch.empty((2, 8, 576), dtype=torch.bfloat16)
+    workspace_calls = []
+    layer.impl = SimpleNamespace(
+        get_mxfp8_mla_query_output=lambda *args: (
+            workspace_calls.append(args) or workspace
+        )
+    )
+    kernel_calls = []
+    monkeypatch.setattr(
+        mla_attention_module, "can_implement_mxfp8_mla_query", lambda **_: True
+    )
+    monkeypatch.setattr(
+        mla_attention_module,
+        "run_mxfp8_mla_query",
+        lambda *args: kernel_calls.append(args),
+    )
+    q_nope = torch.empty((8, 2, 192), dtype=torch.bfloat16)
+    q_pe = torch.empty((2, 8, 64), dtype=torch.bfloat16)
+
+    result = layer._try_mxfp8_mla_query(q_nope, q_pe)
+
+    assert result is workspace
+    assert workspace_calls == [(2, 8, torch.bfloat16)]
+    assert kernel_calls == [
+        (q_nope, layer._b12x_absorb_uk_rhs, q_pe, layer._q_scale, workspace)
+    ]
+
+
+@pytest.mark.cpu_test
+def test_mxfp8_mla_query_dispatch_preserves_unsupported_fallback(monkeypatch):
+    layer = MLAAttention.__new__(MLAAttention)
+    layer._use_b12x_absorb_bmm = True
+    layer.is_aiter_triton_fp4_bmm_enabled = False
+    layer.is_aiter_triton_fp8_bmm_enabled = False
+    layer._mxfp8_mla_query_output_dtype = torch.bfloat16
+    layer.kv_lora_rank = 512
+    layer.impl = SimpleNamespace()
+    monkeypatch.setattr(
+        mla_attention_module, "can_implement_mxfp8_mla_query", lambda **_: False
+    )
+    q_nope = torch.empty((11, 2, 192), dtype=torch.bfloat16)
+    q_pe = torch.empty((2, 11, 64), dtype=torch.bfloat16)
+
+    assert layer._try_mxfp8_mla_query(q_nope, q_pe) is None
+
+
+@pytest.mark.cpu_test
+def test_b12x_mxfp8_mla_query_workspace_is_zero_copy_and_dcp1_only():
+    from vllm.v1.attention.backends.mla.b12x_mla_sparse import B12xMLASparseImpl
+
+    workspace = torch.empty((4, 8, 576), dtype=torch.bfloat16)
+    impl = SimpleNamespace(
+        dcp_world_size=1,
+        _max_batched=4,
+        _input_num_heads=8,
+        _kernel_num_heads=8,
+        q_head_dim=576,
+        _borrow_workspace_parts=lambda: (workspace, None, torch.empty(1)),
+    )
+
+    output = B12xMLASparseImpl.get_mxfp8_mla_query_output(
+        impl, 2, 8, torch.bfloat16
+    )
+
+    assert output is not None
+    assert tuple(output.shape) == (2, 8, 576)
+    assert output.data_ptr() == workspace.data_ptr()
+    impl.dcp_world_size = 2
+    assert (
+        B12xMLASparseImpl.get_mxfp8_mla_query_output(
+            impl, 2, 8, torch.bfloat16
+        )
+        is None
+    )
 
 
 # Filtered per-test via validate_configuration (capability/deps/dims).

--- a/tests/v1/attention/test_mla_backends.py
+++ b/tests/v1/attention/test_mla_backends.py
@@ -1142,9 +1142,16 @@ def test_fp8_dcp_sparse_mla_uses_lse_gather_path(monkeypatch):
             lse = torch.zeros((q.shape[0], q.shape[1]), dtype=torch.float32)
             return out, lse
 
-    def fake_lse_reduce(attn_out, lse, group, is_lse_base_on_e=True):
+    def fake_lse_reduce(
+        attn_out,
+        lse,
+        group,
+        is_lse_base_on_e=True,
+        head_major_output=False,
+    ):
         assert group.world_size == 2
         assert lse is not None
+        assert head_major_output
         return attn_out[:, :2, :]
 
     monkeypatch.setattr(mla_attention, "get_dcp_group", lambda: FakeDCPGroup())
@@ -1170,6 +1177,16 @@ def test_fp8_dcp_sparse_mla_uses_lse_gather_path(monkeypatch):
     layer.is_aiter_triton_fp4_bmm_enabled = False
     layer.is_aiter_triton_fp8_bmm_enabled = False
     layer.W_UK_T = torch.ones((2, 4, 3), dtype=torch.bfloat16)
+    layer._try_fused_mla_query = lambda q_nope, q_pe: torch.cat(
+        (
+            torch.ones(
+                (q_pe.shape[0], q_pe.shape[1], layer.kv_lora_rank),
+                dtype=q_pe.dtype,
+            ),
+            q_pe,
+        ),
+        dim=-1,
+    )
 
     def fake_v_up_proj(x, out):
         out.copy_(x.reshape(out.shape))
@@ -1242,6 +1259,7 @@ def test_fp8_dcp_quantized_query_requires_backend_opt_in(monkeypatch):
     layer.is_aiter_triton_fp4_bmm_enabled = False
     layer.is_aiter_triton_fp8_bmm_enabled = False
     layer.W_UK_T = torch.ones((2, 4, 3), dtype=torch.bfloat16)
+    layer._try_fused_mla_query = lambda q_nope, q_pe: None
     layer._q_scale = torch.tensor(1.0, dtype=torch.float32)
     layer._decode_concat_quant_fp8_op = lambda q_nope, q_pe, scale: torch.empty(
         (q_nope.shape[0], q_nope.shape[1], q_nope.shape[2] + q_pe.shape[2]),

--- a/tests/v1/attention/test_mla_backends.py
+++ b/tests/v1/attention/test_mla_backends.py
@@ -407,10 +407,10 @@ def test_b12x_mla_mxfp8_bmm_warmup_skips_replaced_uk_signature(
     monkeypatch.setattr(b12x_mxfp8_bmm_module, "_B12X_BMM_MISSING", False)
     monkeypatch.setattr(
         b12x_mxfp8_bmm_module,
-        "_MXFP8_MLA_QUERY",
-        SimpleNamespace(can_implement=lambda **_: True),
+        "_FUSED_MLA_QUERY",
+        SimpleNamespace(can_implement=lambda **_: fused_query_supported),
     )
-    monkeypatch.setattr(b12x_mxfp8_bmm_module, "_MXFP8_MLA_QUERY_MISSING", False)
+    monkeypatch.setattr(b12x_mxfp8_bmm_module, "_FUSED_MLA_QUERY_MISSING", False)
     model = torch.nn.Sequential(torch.nn.Module())
     module = model[0]
     module._b12x_absorb_uk_rhs = (
@@ -421,10 +421,7 @@ def test_b12x_mla_mxfp8_bmm_warmup_skips_replaced_uk_signature(
         torch.empty((8, 256, 512), dtype=torch.float8_e4m3fn),
         torch.empty((8, 256, 16), dtype=torch.uint8),
     )
-    module._mxfp8_mla_query_output_dtype = torch.bfloat16
-    module.impl = SimpleNamespace(
-        supports_mxfp8_mla_query_output=lambda *args: fused_query_supported
-    )
+    module._fused_mla_query_output_dtype = torch.bfloat16
 
     warmed = b12x_mxfp8_bmm_module.warmup_b12x_mla_mxfp8_bmm(model, m_values=(1, 2, 3))
 
@@ -439,8 +436,8 @@ def test_mxfp8_mla_query_custom_op_uses_sparkinfer_api(monkeypatch):
     mla_query = SimpleNamespace(
         run=lambda *args, **kwargs: calls.append((args, kwargs))
     )
-    monkeypatch.setattr(b12x_mxfp8_bmm_module, "_MXFP8_MLA_QUERY", mla_query)
-    monkeypatch.setattr(b12x_mxfp8_bmm_module, "_MXFP8_MLA_QUERY_MISSING", False)
+    monkeypatch.setattr(b12x_mxfp8_bmm_module, "_FUSED_MLA_QUERY", mla_query)
+    monkeypatch.setattr(b12x_mxfp8_bmm_module, "_FUSED_MLA_QUERY_MISSING", False)
     lhs = torch.empty((8, 2, 192), dtype=torch.bfloat16)
     b_values = torch.empty((8, 192, 512), dtype=torch.float8_e4m3fn)
     b_scales = torch.empty((8, 192, 16), dtype=torch.uint8)
@@ -458,7 +455,28 @@ def test_mxfp8_mla_query_custom_op_uses_sparkinfer_api(monkeypatch):
 
 
 @pytest.mark.cpu_test
-def test_mxfp8_mla_query_warmup_deduplicates_dtype_signatures(monkeypatch):
+def test_bf16_mla_query_custom_op_uses_sparkinfer_api(monkeypatch):
+    calls = []
+    mla_query = SimpleNamespace(
+        run=lambda *args, **kwargs: calls.append((args, kwargs))
+    )
+    monkeypatch.setattr(b12x_mxfp8_bmm_module, "_FUSED_MLA_QUERY", mla_query)
+    monkeypatch.setattr(b12x_mxfp8_bmm_module, "_FUSED_MLA_QUERY_MISSING", False)
+    lhs = torch.empty((11, 2, 192), dtype=torch.bfloat16)
+    weight = torch.empty((11, 192, 512), dtype=torch.bfloat16)
+    q_pe = torch.empty((2, 11, 64), dtype=torch.bfloat16)
+    q_scale = torch.ones(1, dtype=torch.float32)
+    out = torch.empty((2, 11, 576), dtype=torch.bfloat16)
+
+    b12x_mxfp8_bmm_module._bf16_mla_query_impl(lhs, weight, q_pe, q_scale, out)
+
+    args, kwargs = calls[0]
+    assert args == (lhs, weight, q_pe, q_scale, out)
+    assert kwargs == {}
+
+
+@pytest.mark.cpu_test
+def test_fused_mla_query_warmup_deduplicates_weight_and_dtype_signatures(monkeypatch):
     calls = []
 
     def prewarm(rhs, m_values, **kwargs):
@@ -467,21 +485,21 @@ def test_mxfp8_mla_query_warmup_deduplicates_dtype_signatures(monkeypatch):
 
     monkeypatch.setattr(
         b12x_mxfp8_bmm_module,
-        "_MXFP8_MLA_QUERY",
+        "_FUSED_MLA_QUERY",
         SimpleNamespace(prewarm=prewarm, can_implement=lambda **_: True),
     )
-    monkeypatch.setattr(b12x_mxfp8_bmm_module, "_MXFP8_MLA_QUERY_MISSING", False)
+    monkeypatch.setattr(b12x_mxfp8_bmm_module, "_FUSED_MLA_QUERY_MISSING", False)
     model = torch.nn.Sequential(torch.nn.Module(), torch.nn.Module(), torch.nn.Module())
     for index, module in enumerate(model):
         module._b12x_absorb_uk_rhs = (
             torch.empty((8, 192, 512), dtype=torch.float8_e4m3fn),
             torch.empty((8, 192, 16), dtype=torch.uint8),
         )
-        module._mxfp8_mla_query_output_dtype = (
+        module._fused_mla_query_output_dtype = (
             torch.bfloat16 if index < 2 else torch.float8_e4m3fn
         )
 
-    warmed = b12x_mxfp8_bmm_module.warmup_mxfp8_mla_query(model, m_values=(1, 2, 2, 3))
+    warmed = b12x_mxfp8_bmm_module.warmup_fused_mla_query(model, m_values=(1, 2, 2, 3))
 
     assert warmed == 6
     assert len(calls) == 2
@@ -493,12 +511,41 @@ def test_mxfp8_mla_query_warmup_deduplicates_dtype_signatures(monkeypatch):
 
 
 @pytest.mark.cpu_test
-def test_mxfp8_mla_query_dispatch_uses_backend_workspace(monkeypatch):
+def test_fused_mla_query_warmup_includes_bf16_virtual_tp_signature(monkeypatch):
+    calls = []
+
+    def prewarm(weight, m_values, **kwargs):
+        calls.append((weight, tuple(m_values), kwargs))
+        return 2
+
+    monkeypatch.setattr(
+        b12x_mxfp8_bmm_module,
+        "_FUSED_MLA_QUERY",
+        SimpleNamespace(prewarm=prewarm, can_implement=lambda **_: True),
+    )
+    monkeypatch.setattr(b12x_mxfp8_bmm_module, "_FUSED_MLA_QUERY_MISSING", False)
+    model = torch.nn.Sequential(torch.nn.Module(), torch.nn.Module())
+    for module in model:
+        module.W_UK_T = torch.nn.Parameter(
+            torch.empty((11, 192, 512), dtype=torch.bfloat16)
+        )
+        module._fused_mla_query_output_dtype = torch.bfloat16
+
+    warmed = b12x_mxfp8_bmm_module.warmup_fused_mla_query(model, m_values=(1, 6, 32))
+
+    assert warmed == 2
+    assert len(calls) == 1
+    assert calls[0][0] is model[0].W_UK_T
+    assert calls[0][1] == (1, 6, 32)
+
+
+@pytest.mark.cpu_test
+def test_fused_mla_query_dispatch_uses_backend_workspace(monkeypatch):
     layer = MLAAttention.__new__(MLAAttention)
     layer._use_b12x_absorb_bmm = True
     layer.is_aiter_triton_fp4_bmm_enabled = False
     layer.is_aiter_triton_fp8_bmm_enabled = False
-    layer._mxfp8_mla_query_output_dtype = torch.bfloat16
+    layer._fused_mla_query_output_dtype = torch.bfloat16
     layer.kv_lora_rank = 512
     layer.qk_rope_head_dim = 64
     layer._q_scale = torch.ones(1, dtype=torch.float32)
@@ -509,7 +556,7 @@ def test_mxfp8_mla_query_dispatch_uses_backend_workspace(monkeypatch):
     workspace = torch.empty((2, 8, 576), dtype=torch.bfloat16)
     workspace_calls = []
     layer.impl = SimpleNamespace(
-        get_mxfp8_mla_query_output=lambda *args: (
+        get_fused_mla_query_output=lambda *args: (
             workspace_calls.append(args) or workspace
         )
     )
@@ -525,7 +572,7 @@ def test_mxfp8_mla_query_dispatch_uses_backend_workspace(monkeypatch):
     q_nope = torch.empty((8, 2, 192), dtype=torch.bfloat16)
     q_pe = torch.empty((2, 8, 64), dtype=torch.bfloat16)
 
-    result = layer._try_mxfp8_mla_query(q_nope, q_pe)
+    result = layer._try_fused_mla_query(q_nope, q_pe)
 
     assert result is workspace
     assert workspace_calls == [(2, 8, torch.bfloat16)]
@@ -535,30 +582,36 @@ def test_mxfp8_mla_query_dispatch_uses_backend_workspace(monkeypatch):
 
 
 @pytest.mark.cpu_test
-def test_mxfp8_mla_query_dispatch_preserves_unsupported_fallback(monkeypatch):
+def test_fused_mla_query_dispatch_preserves_unsupported_fallback(monkeypatch):
     layer = MLAAttention.__new__(MLAAttention)
     layer._use_b12x_absorb_bmm = True
     layer.is_aiter_triton_fp4_bmm_enabled = False
     layer.is_aiter_triton_fp8_bmm_enabled = False
-    layer._mxfp8_mla_query_output_dtype = torch.bfloat16
+    layer._fused_mla_query_output_dtype = torch.bfloat16
     layer.kv_lora_rank = 512
     layer.impl = SimpleNamespace()
+    layer._b12x_absorb_uk_rhs = (
+        torch.empty((11, 192, 512), dtype=torch.float8_e4m3fn),
+        torch.empty((11, 192, 16), dtype=torch.uint8),
+    )
     monkeypatch.setattr(
         mla_attention_module, "can_implement_mxfp8_mla_query", lambda **_: False
     )
     q_nope = torch.empty((11, 2, 192), dtype=torch.bfloat16)
     q_pe = torch.empty((2, 11, 64), dtype=torch.bfloat16)
 
-    assert layer._try_mxfp8_mla_query(q_nope, q_pe) is None
+    assert layer._try_fused_mla_query(q_nope, q_pe) is None
 
 
 @pytest.mark.cpu_test
-def test_mxfp8_mla_query_dispatch_honors_backend_workspace_rejection(monkeypatch):
+def test_fused_mla_query_dispatch_uses_temporary_when_backend_rejects_direct_output(
+    monkeypatch,
+):
     layer = MLAAttention.__new__(MLAAttention)
     layer._use_b12x_absorb_bmm = True
     layer.is_aiter_triton_fp4_bmm_enabled = False
     layer.is_aiter_triton_fp8_bmm_enabled = False
-    layer._mxfp8_mla_query_output_dtype = torch.bfloat16
+    layer._fused_mla_query_output_dtype = torch.bfloat16
     layer.kv_lora_rank = 512
     layer.qk_rope_head_dim = 64
     layer._q_scale = torch.ones(1, dtype=torch.float32)
@@ -568,7 +621,7 @@ def test_mxfp8_mla_query_dispatch_honors_backend_workspace_rejection(monkeypatch
     )
     workspace_calls = []
     layer.impl = SimpleNamespace(
-        get_mxfp8_mla_query_output=lambda *args: workspace_calls.append(args) or None
+        get_fused_mla_query_output=lambda *args: workspace_calls.append(args) or None
     )
     kernel_calls = []
     monkeypatch.setattr(
@@ -582,13 +635,52 @@ def test_mxfp8_mla_query_dispatch_honors_backend_workspace_rejection(monkeypatch
     q_nope = torch.empty((8, 2, 192), dtype=torch.bfloat16)
     q_pe = torch.empty((2, 8, 64), dtype=torch.bfloat16)
 
-    assert layer._try_mxfp8_mla_query(q_nope, q_pe) is None
+    result = layer._try_fused_mla_query(q_nope, q_pe)
+    assert result is not None
+    assert tuple(result.shape) == (2, 8, 576)
     assert workspace_calls == [(2, 8, torch.bfloat16)]
-    assert kernel_calls == []
+    assert kernel_calls == [
+        (q_nope, layer._b12x_absorb_uk_rhs, q_pe, layer._q_scale, result)
+    ]
 
 
 @pytest.mark.cpu_test
-def test_b12x_mxfp8_mla_query_workspace_is_zero_copy_and_dcp1_only():
+def test_bf16_fused_mla_query_dispatch_supports_tp6_dcp_temporary(monkeypatch):
+    layer = MLAAttention.__new__(MLAAttention)
+    layer._use_b12x_absorb_bmm = False
+    layer.is_aiter_triton_fp4_bmm_enabled = False
+    layer.is_aiter_triton_fp8_bmm_enabled = False
+    layer._fused_mla_query_output_dtype = torch.bfloat16
+    layer.kv_lora_rank = 512
+    layer.qk_rope_head_dim = 64
+    layer._q_scale = torch.ones(1, dtype=torch.float32)
+    layer.W_UK_T = torch.empty((11, 192, 512), dtype=torch.bfloat16)
+    workspace_calls = []
+    layer.impl = SimpleNamespace(
+        get_fused_mla_query_output=lambda *args: workspace_calls.append(args) or None
+    )
+    kernel_calls = []
+    monkeypatch.setattr(
+        mla_attention_module, "can_implement_bf16_mla_query", lambda **_: True
+    )
+    monkeypatch.setattr(
+        mla_attention_module,
+        "run_bf16_mla_query",
+        lambda *args: kernel_calls.append(args),
+    )
+    q_nope = torch.empty((11, 2, 192), dtype=torch.bfloat16)
+    q_pe = torch.empty((2, 11, 64), dtype=torch.bfloat16)
+
+    result = layer._try_fused_mla_query(q_nope, q_pe)
+
+    assert result is not None
+    assert tuple(result.shape) == (2, 11, 576)
+    assert workspace_calls == [(2, 11, torch.bfloat16)]
+    assert kernel_calls == [(q_nope, layer.W_UK_T, q_pe, layer._q_scale, result)]
+
+
+@pytest.mark.cpu_test
+def test_b12x_fused_mla_query_workspace_is_zero_copy_and_dcp1_only():
     from vllm.v1.attention.backends.mla.b12x_mla_sparse import B12xMLASparseImpl
 
     workspace = torch.empty((4, 8, 576), dtype=torch.bfloat16)
@@ -600,22 +692,22 @@ def test_b12x_mxfp8_mla_query_workspace_is_zero_copy_and_dcp1_only():
         q_head_dim=576,
         _borrow_workspace_parts=lambda: (workspace, None, torch.empty(1)),
     )
-    impl.supports_mxfp8_mla_query_output = lambda num_heads, output_dtype: (
-        B12xMLASparseImpl.supports_mxfp8_mla_query_output(impl, num_heads, output_dtype)
+    impl.supports_fused_mla_query_output = lambda num_heads, output_dtype: (
+        B12xMLASparseImpl.supports_fused_mla_query_output(impl, num_heads, output_dtype)
     )
 
-    output = B12xMLASparseImpl.get_mxfp8_mla_query_output(impl, 2, 8, torch.bfloat16)
+    output = B12xMLASparseImpl.get_fused_mla_query_output(impl, 2, 8, torch.bfloat16)
 
-    assert B12xMLASparseImpl.supports_mxfp8_mla_query_output(impl, 8, torch.bfloat16)
+    assert B12xMLASparseImpl.supports_fused_mla_query_output(impl, 8, torch.bfloat16)
     assert output is not None
     assert tuple(output.shape) == (2, 8, 576)
     assert output.data_ptr() == workspace.data_ptr()
     impl.dcp_world_size = 2
-    assert not B12xMLASparseImpl.supports_mxfp8_mla_query_output(
+    assert not B12xMLASparseImpl.supports_fused_mla_query_output(
         impl, 8, torch.bfloat16
     )
     assert (
-        B12xMLASparseImpl.get_mxfp8_mla_query_output(impl, 2, 8, torch.bfloat16) is None
+        B12xMLASparseImpl.get_fused_mla_query_output(impl, 2, 8, torch.bfloat16) is None
     )
 
 

--- a/tests/v1/attention/test_mla_backends.py
+++ b/tests/v1/attention/test_mla_backends.py
@@ -600,6 +600,9 @@ def test_b12x_mxfp8_mla_query_workspace_is_zero_copy_and_dcp1_only():
         q_head_dim=576,
         _borrow_workspace_parts=lambda: (workspace, None, torch.empty(1)),
     )
+    impl.supports_mxfp8_mla_query_output = lambda num_heads, output_dtype: (
+        B12xMLASparseImpl.supports_mxfp8_mla_query_output(impl, num_heads, output_dtype)
+    )
 
     output = B12xMLASparseImpl.get_mxfp8_mla_query_output(impl, 2, 8, torch.bfloat16)
 

--- a/tests/v1/attention/test_mla_backends.py
+++ b/tests/v1/attention/test_mla_backends.py
@@ -389,15 +389,58 @@ def test_b12x_mla_mxfp8_bmm_warmup_deduplicates_signatures(monkeypatch):
 
 
 @pytest.mark.cpu_test
+@pytest.mark.parametrize("fused_query_supported", [True, False])
+def test_b12x_mla_mxfp8_bmm_warmup_skips_replaced_uk_signature(
+    monkeypatch, fused_query_supported
+):
+    calls = []
+
+    def prewarm(rhs, m_values, **kwargs):
+        calls.append((rhs, tuple(m_values), kwargs))
+        return len(tuple(m_values))
+
+    monkeypatch.setattr(
+        b12x_mxfp8_bmm_module,
+        "_B12X_BMM",
+        SimpleNamespace(prewarm_bmm=prewarm),
+    )
+    monkeypatch.setattr(b12x_mxfp8_bmm_module, "_B12X_BMM_MISSING", False)
+    monkeypatch.setattr(
+        b12x_mxfp8_bmm_module,
+        "_MXFP8_MLA_QUERY",
+        SimpleNamespace(can_implement=lambda **_: True),
+    )
+    monkeypatch.setattr(b12x_mxfp8_bmm_module, "_MXFP8_MLA_QUERY_MISSING", False)
+    model = torch.nn.Sequential(torch.nn.Module())
+    module = model[0]
+    module._b12x_absorb_uk_rhs = (
+        torch.empty((8, 192, 512), dtype=torch.float8_e4m3fn),
+        torch.empty((8, 192, 16), dtype=torch.uint8),
+    )
+    module._b12x_absorb_uv_rhs = (
+        torch.empty((8, 256, 512), dtype=torch.float8_e4m3fn),
+        torch.empty((8, 256, 16), dtype=torch.uint8),
+    )
+    module._mxfp8_mla_query_output_dtype = torch.bfloat16
+    module.impl = SimpleNamespace(
+        supports_mxfp8_mla_query_output=lambda *args: fused_query_supported
+    )
+
+    warmed = b12x_mxfp8_bmm_module.warmup_b12x_mla_mxfp8_bmm(model, m_values=(1, 2, 3))
+
+    expected_majors = ["k"] if fused_query_supported else ["n", "k"]
+    assert warmed == 3 * len(expected_majors)
+    assert [call[2]["b_major"] for call in calls] == expected_majors
+
+
+@pytest.mark.cpu_test
 def test_mxfp8_mla_query_custom_op_uses_sparkinfer_api(monkeypatch):
     calls = []
     mla_query = SimpleNamespace(
         run=lambda *args, **kwargs: calls.append((args, kwargs))
     )
     monkeypatch.setattr(b12x_mxfp8_bmm_module, "_MXFP8_MLA_QUERY", mla_query)
-    monkeypatch.setattr(
-        b12x_mxfp8_bmm_module, "_MXFP8_MLA_QUERY_MISSING", False
-    )
+    monkeypatch.setattr(b12x_mxfp8_bmm_module, "_MXFP8_MLA_QUERY_MISSING", False)
     lhs = torch.empty((8, 2, 192), dtype=torch.bfloat16)
     b_values = torch.empty((8, 192, 512), dtype=torch.float8_e4m3fn)
     b_scales = torch.empty((8, 192, 16), dtype=torch.uint8)
@@ -425,14 +468,10 @@ def test_mxfp8_mla_query_warmup_deduplicates_dtype_signatures(monkeypatch):
     monkeypatch.setattr(
         b12x_mxfp8_bmm_module,
         "_MXFP8_MLA_QUERY",
-        SimpleNamespace(prewarm=prewarm),
+        SimpleNamespace(prewarm=prewarm, can_implement=lambda **_: True),
     )
-    monkeypatch.setattr(
-        b12x_mxfp8_bmm_module, "_MXFP8_MLA_QUERY_MISSING", False
-    )
-    model = torch.nn.Sequential(
-        torch.nn.Module(), torch.nn.Module(), torch.nn.Module()
-    )
+    monkeypatch.setattr(b12x_mxfp8_bmm_module, "_MXFP8_MLA_QUERY_MISSING", False)
+    model = torch.nn.Sequential(torch.nn.Module(), torch.nn.Module(), torch.nn.Module())
     for index, module in enumerate(model):
         module._b12x_absorb_uk_rhs = (
             torch.empty((8, 192, 512), dtype=torch.float8_e4m3fn),
@@ -442,9 +481,7 @@ def test_mxfp8_mla_query_warmup_deduplicates_dtype_signatures(monkeypatch):
             torch.bfloat16 if index < 2 else torch.float8_e4m3fn
         )
 
-    warmed = b12x_mxfp8_bmm_module.warmup_mxfp8_mla_query(
-        model, m_values=(1, 2, 2, 3)
-    )
+    warmed = b12x_mxfp8_bmm_module.warmup_mxfp8_mla_query(model, m_values=(1, 2, 2, 3))
 
     assert warmed == 6
     assert len(calls) == 2
@@ -516,6 +553,41 @@ def test_mxfp8_mla_query_dispatch_preserves_unsupported_fallback(monkeypatch):
 
 
 @pytest.mark.cpu_test
+def test_mxfp8_mla_query_dispatch_honors_backend_workspace_rejection(monkeypatch):
+    layer = MLAAttention.__new__(MLAAttention)
+    layer._use_b12x_absorb_bmm = True
+    layer.is_aiter_triton_fp4_bmm_enabled = False
+    layer.is_aiter_triton_fp8_bmm_enabled = False
+    layer._mxfp8_mla_query_output_dtype = torch.bfloat16
+    layer.kv_lora_rank = 512
+    layer.qk_rope_head_dim = 64
+    layer._q_scale = torch.ones(1, dtype=torch.float32)
+    layer._b12x_absorb_uk_rhs = (
+        torch.empty((8, 192, 512), dtype=torch.float8_e4m3fn),
+        torch.empty((8, 192, 16), dtype=torch.uint8),
+    )
+    workspace_calls = []
+    layer.impl = SimpleNamespace(
+        get_mxfp8_mla_query_output=lambda *args: workspace_calls.append(args) or None
+    )
+    kernel_calls = []
+    monkeypatch.setattr(
+        mla_attention_module, "can_implement_mxfp8_mla_query", lambda **_: True
+    )
+    monkeypatch.setattr(
+        mla_attention_module,
+        "run_mxfp8_mla_query",
+        lambda *args: kernel_calls.append(args),
+    )
+    q_nope = torch.empty((8, 2, 192), dtype=torch.bfloat16)
+    q_pe = torch.empty((2, 8, 64), dtype=torch.bfloat16)
+
+    assert layer._try_mxfp8_mla_query(q_nope, q_pe) is None
+    assert workspace_calls == [(2, 8, torch.bfloat16)]
+    assert kernel_calls == []
+
+
+@pytest.mark.cpu_test
 def test_b12x_mxfp8_mla_query_workspace_is_zero_copy_and_dcp1_only():
     from vllm.v1.attention.backends.mla.b12x_mla_sparse import B12xMLASparseImpl
 
@@ -529,19 +601,18 @@ def test_b12x_mxfp8_mla_query_workspace_is_zero_copy_and_dcp1_only():
         _borrow_workspace_parts=lambda: (workspace, None, torch.empty(1)),
     )
 
-    output = B12xMLASparseImpl.get_mxfp8_mla_query_output(
-        impl, 2, 8, torch.bfloat16
-    )
+    output = B12xMLASparseImpl.get_mxfp8_mla_query_output(impl, 2, 8, torch.bfloat16)
 
+    assert B12xMLASparseImpl.supports_mxfp8_mla_query_output(impl, 8, torch.bfloat16)
     assert output is not None
     assert tuple(output.shape) == (2, 8, 576)
     assert output.data_ptr() == workspace.data_ptr()
     impl.dcp_world_size = 2
+    assert not B12xMLASparseImpl.supports_mxfp8_mla_query_output(
+        impl, 8, torch.bfloat16
+    )
     assert (
-        B12xMLASparseImpl.get_mxfp8_mla_query_output(
-            impl, 2, 8, torch.bfloat16
-        )
-        is None
+        B12xMLASparseImpl.get_mxfp8_mla_query_output(impl, 2, 8, torch.bfloat16) is None
     )
 
 

--- a/tests/v1/attention/test_mla_backends.py
+++ b/tests/v1/attention/test_mla_backends.py
@@ -431,7 +431,8 @@ def test_b12x_mla_mxfp8_bmm_warmup_skips_replaced_uk_signature(
 
 
 @pytest.mark.cpu_test
-def test_mxfp8_mla_query_custom_op_uses_sparkinfer_api(monkeypatch):
+@pytest.mark.parametrize("output_dtype", [torch.bfloat16, torch.float8_e4m3fn])
+def test_mxfp8_mla_query_custom_op_uses_sparkinfer_api(monkeypatch, output_dtype):
     calls = []
     mla_query = SimpleNamespace(
         run=lambda *args, **kwargs: calls.append((args, kwargs))
@@ -443,19 +444,21 @@ def test_mxfp8_mla_query_custom_op_uses_sparkinfer_api(monkeypatch):
     b_scales = torch.empty((8, 192, 16), dtype=torch.uint8)
     q_pe = torch.empty((2, 8, 64), dtype=torch.bfloat16)
     q_scale = torch.ones(1, dtype=torch.float32)
-    out = torch.empty((2, 8, 576), dtype=torch.bfloat16)
+    out = torch.empty((2, 8, 576), dtype=output_dtype)
 
     b12x_mxfp8_bmm_module._mxfp8_mla_query_impl(
         lhs, b_values, b_scales, q_pe, q_scale, out
     )
 
     args, kwargs = calls[0]
-    assert args == (lhs, (b_values, b_scales), q_pe, q_scale, out)
-    assert kwargs == {}
+    assert args == (lhs, (b_values, b_scales), q_pe, out)
+    expected_scale = q_scale if output_dtype == torch.float8_e4m3fn else None
+    assert kwargs == {"q_scale": expected_scale}
 
 
 @pytest.mark.cpu_test
-def test_bf16_mla_query_custom_op_uses_sparkinfer_api(monkeypatch):
+@pytest.mark.parametrize("output_dtype", [torch.bfloat16, torch.float8_e4m3fn])
+def test_bf16_mla_query_custom_op_uses_sparkinfer_api(monkeypatch, output_dtype):
     calls = []
     mla_query = SimpleNamespace(
         run=lambda *args, **kwargs: calls.append((args, kwargs))
@@ -466,13 +469,14 @@ def test_bf16_mla_query_custom_op_uses_sparkinfer_api(monkeypatch):
     weight = torch.empty((11, 192, 512), dtype=torch.bfloat16)
     q_pe = torch.empty((2, 11, 64), dtype=torch.bfloat16)
     q_scale = torch.ones(1, dtype=torch.float32)
-    out = torch.empty((2, 11, 576), dtype=torch.bfloat16)
+    out = torch.empty((2, 11, 576), dtype=output_dtype)
 
     b12x_mxfp8_bmm_module._bf16_mla_query_impl(lhs, weight, q_pe, q_scale, out)
 
     args, kwargs = calls[0]
-    assert args == (lhs, weight, q_pe, q_scale, out)
-    assert kwargs == {}
+    assert args == (lhs, weight, q_pe, out)
+    expected_scale = q_scale if output_dtype == torch.float8_e4m3fn else None
+    assert kwargs == {"q_scale": expected_scale}
 
 
 @pytest.mark.cpu_test

--- a/vllm/model_executor/kernels/attention/b12x_mxfp8_bmm.py
+++ b/vllm/model_executor/kernels/attention/b12x_mxfp8_bmm.py
@@ -223,6 +223,45 @@ def run_mxfp8_mla_query(
     return out
 
 
+def _module_uses_mxfp8_mla_query(module: torch.nn.Module) -> bool:
+    """Return whether fused query assembly replaces this module's UK BMM."""
+    mla_query = _import_mxfp8_mla_query()
+    rhs = getattr(module, "_b12x_absorb_uk_rhs", None)
+    output_dtype = getattr(module, "_mxfp8_mla_query_output_dtype", None)
+    if (
+        mla_query is None
+        or rhs is None
+        or output_dtype
+        not in (
+            torch.bfloat16,
+            torch.float8_e4m3fn,
+        )
+    ):
+        return False
+
+    b_values, _ = rhs
+    backend_gate = getattr(
+        getattr(module, "impl", None),
+        "supports_mxfp8_mla_query_output",
+        None,
+    )
+    if callable(backend_gate) and not backend_gate(
+        int(b_values.shape[0]), output_dtype
+    ):
+        return False
+
+    return bool(
+        mla_query.can_implement(
+            num_heads=int(b_values.shape[0]),
+            max_m=1,
+            nope_dim=int(b_values.shape[1]),
+            latent_dim=int(b_values.shape[2]),
+            output_dtype=output_dtype,
+            device=b_values.device,
+        )
+    )
+
+
 def warmup_b12x_mla_mxfp8_bmm(
     model: torch.nn.Module,
     *,
@@ -240,6 +279,8 @@ def warmup_b12x_mla_mxfp8_bmm(
             ("_b12x_absorb_uk_rhs", "n"),
             ("_b12x_absorb_uv_rhs", "k"),
         ):
+            if attr == "_b12x_absorb_uk_rhs" and _module_uses_mxfp8_mla_query(module):
+                continue
             rhs = getattr(module, attr, None)
             if rhs is None:
                 continue
@@ -273,11 +314,13 @@ def warmup_mxfp8_mla_query(
         return 0
 
     values = tuple(dict.fromkeys(int(m) for m in m_values if int(m) > 0))
-    seen: set[
-        tuple[tuple[int, ...], tuple[int, ...], torch.dtype, torch.device]
-    ] = set()
+    seen: set[tuple[tuple[int, ...], tuple[int, ...], torch.dtype, torch.device]] = (
+        set()
+    )
     warmed = 0
     for module in model.modules():
+        if not _module_uses_mxfp8_mla_query(module):
+            continue
         rhs = getattr(module, "_b12x_absorb_uk_rhs", None)
         output_dtype = getattr(module, "_mxfp8_mla_query_output_dtype", None)
         if rhs is None or output_dtype not in (

--- a/vllm/model_executor/kernels/attention/b12x_mxfp8_bmm.py
+++ b/vllm/model_executor/kernels/attention/b12x_mxfp8_bmm.py
@@ -20,8 +20,8 @@ _BMM_SPEC = {
 }
 _B12X_BMM: Any | None = None
 _B12X_BMM_MISSING = False
-_MXFP8_MLA_QUERY: Any | None = None
-_MXFP8_MLA_QUERY_MISSING = False
+_FUSED_MLA_QUERY: Any | None = None
+_FUSED_MLA_QUERY_MISSING = False
 
 
 def _import_b12x_bmm() -> Any | None:
@@ -43,22 +43,22 @@ def _import_b12x_bmm() -> Any | None:
     return gemm
 
 
-def _import_mxfp8_mla_query() -> Any | None:
-    global _MXFP8_MLA_QUERY, _MXFP8_MLA_QUERY_MISSING
-    if _MXFP8_MLA_QUERY is not None:
-        return _MXFP8_MLA_QUERY
-    if _MXFP8_MLA_QUERY_MISSING:
+def _import_fused_mla_query() -> Any | None:
+    global _FUSED_MLA_QUERY, _FUSED_MLA_QUERY_MISSING
+    if _FUSED_MLA_QUERY is not None:
+        return _FUSED_MLA_QUERY
+    if _FUSED_MLA_QUERY_MISSING:
         return None
     try:
         mla_query = importlib.import_module("sparkinfer.attention.mla_query")
     except ImportError:
-        _MXFP8_MLA_QUERY_MISSING = True
+        _FUSED_MLA_QUERY_MISSING = True
         return None
     required = ("run", "can_implement", "prewarm")
     if not all(callable(getattr(mla_query, name, None)) for name in required):
-        _MXFP8_MLA_QUERY_MISSING = True
+        _FUSED_MLA_QUERY_MISSING = True
         return None
-    _MXFP8_MLA_QUERY = mla_query
+    _FUSED_MLA_QUERY = mla_query
     return mla_query
 
 
@@ -97,7 +97,48 @@ def can_implement_mxfp8_mla_query(
     output_dtype: torch.dtype,
     device: torch.device,
 ) -> bool:
-    mla_query = _import_mxfp8_mla_query()
+    return can_implement_fused_mla_query(
+        num_heads=num_heads,
+        max_m=max_m,
+        nope_dim=nope_dim,
+        latent_dim=latent_dim,
+        output_dtype=output_dtype,
+        weight_format="mxfp8",
+        device=device,
+    )
+
+
+def can_implement_bf16_mla_query(
+    *,
+    num_heads: int,
+    max_m: int,
+    nope_dim: int,
+    latent_dim: int,
+    output_dtype: torch.dtype,
+    device: torch.device,
+) -> bool:
+    return can_implement_fused_mla_query(
+        num_heads=num_heads,
+        max_m=max_m,
+        nope_dim=nope_dim,
+        latent_dim=latent_dim,
+        output_dtype=output_dtype,
+        weight_format="bf16",
+        device=device,
+    )
+
+
+def can_implement_fused_mla_query(
+    *,
+    num_heads: int,
+    max_m: int,
+    nope_dim: int,
+    latent_dim: int,
+    output_dtype: torch.dtype,
+    weight_format: Literal["bf16", "mxfp8"],
+    device: torch.device,
+) -> bool:
+    mla_query = _import_fused_mla_query()
     if mla_query is None:
         return False
     return bool(
@@ -107,6 +148,7 @@ def can_implement_mxfp8_mla_query(
             nope_dim=nope_dim,
             latent_dim=latent_dim,
             output_dtype=output_dtype,
+            weight_format=weight_format,
             device=device,
         )
     )
@@ -160,7 +202,7 @@ def _mxfp8_mla_query_impl(
     q_scale: torch.Tensor,
     out: torch.Tensor,
 ) -> None:
-    mla_query = _import_mxfp8_mla_query()
+    mla_query = _import_fused_mla_query()
     if mla_query is None:
         raise ImportError("sparkinfer.attention.mla_query is not available")
     mla_query.run(lhs, (b_values, b_scales), q_pe, q_scale, out)
@@ -182,6 +224,38 @@ direct_register_custom_op(
     op_func=_mxfp8_mla_query_impl,
     mutates_args=["out"],
     fake_impl=_mxfp8_mla_query_fake,
+    tags=(torch.Tag.needs_fixed_stride_order,),
+)
+
+
+def _bf16_mla_query_impl(
+    lhs: torch.Tensor,
+    weight: torch.Tensor,
+    q_pe: torch.Tensor,
+    q_scale: torch.Tensor,
+    out: torch.Tensor,
+) -> None:
+    mla_query = _import_fused_mla_query()
+    if mla_query is None:
+        raise ImportError("sparkinfer.attention.mla_query is not available")
+    mla_query.run(lhs, weight, q_pe, q_scale, out)
+
+
+def _bf16_mla_query_fake(
+    lhs: torch.Tensor,
+    weight: torch.Tensor,
+    q_pe: torch.Tensor,
+    q_scale: torch.Tensor,
+    out: torch.Tensor,
+) -> None:
+    del lhs, weight, q_pe, q_scale, out
+
+
+direct_register_custom_op(
+    op_name="bf16_mla_query",
+    op_func=_bf16_mla_query_impl,
+    mutates_args=["out"],
+    fake_impl=_bf16_mla_query_fake,
     tags=(torch.Tag.needs_fixed_stride_order,),
 )
 
@@ -223,43 +297,69 @@ def run_mxfp8_mla_query(
     return out
 
 
-def _module_uses_mxfp8_mla_query(module: torch.nn.Module) -> bool:
-    """Return whether fused query assembly replaces this module's UK BMM."""
-    mla_query = _import_mxfp8_mla_query()
+def run_bf16_mla_query(
+    lhs: torch.Tensor,
+    weight: torch.Tensor,
+    q_pe: torch.Tensor,
+    q_scale: torch.Tensor,
+    out: torch.Tensor,
+) -> torch.Tensor:
+    torch.ops.vllm.bf16_mla_query(lhs, weight, q_pe, q_scale, out)
+    return out
+
+
+def _module_fused_mla_query_spec(
+    module: torch.nn.Module,
+) -> (
+    tuple[
+        torch.Tensor | tuple[torch.Tensor, torch.Tensor],
+        Literal["bf16", "mxfp8"],
+        torch.dtype,
+    ]
+    | None
+):
+    """Return the module's qualified fused-query weight and output format."""
+    mla_query = _import_fused_mla_query()
+    output_dtype = getattr(module, "_fused_mla_query_output_dtype", None)
+    if mla_query is None or output_dtype not in (
+        torch.bfloat16,
+        torch.float8_e4m3fn,
+    ):
+        return None
+
     rhs = getattr(module, "_b12x_absorb_uk_rhs", None)
-    output_dtype = getattr(module, "_mxfp8_mla_query_output_dtype", None)
-    if (
-        mla_query is None
-        or rhs is None
-        or output_dtype
-        not in (
-            torch.bfloat16,
-            torch.float8_e4m3fn,
-        )
-    ):
-        return False
+    if rhs is not None:
+        weight = rhs
+        weight_format: Literal["bf16", "mxfp8"] = "mxfp8"
+        b_values, _ = rhs
+        shape = tuple(b_values.shape)
+        device = b_values.device
+    else:
+        weight = getattr(module, "W_UK_T", None)
+        if not isinstance(weight, torch.Tensor) or weight.dtype != torch.bfloat16:
+            return None
+        weight_format = "bf16"
+        shape = tuple(weight.shape)
+        device = weight.device
 
-    b_values, _ = rhs
-    backend_gate = getattr(
-        getattr(module, "impl", None),
-        "supports_mxfp8_mla_query_output",
-        None,
-    )
-    if callable(backend_gate) and not backend_gate(
-        int(b_values.shape[0]), output_dtype
+    if len(shape) != 3:
+        return None
+    if not mla_query.can_implement(
+        num_heads=int(shape[0]),
+        max_m=1,
+        nope_dim=int(shape[1]),
+        latent_dim=int(shape[2]),
+        output_dtype=output_dtype,
+        weight_format=weight_format,
+        device=device,
     ):
-        return False
+        return None
+    return weight, weight_format, output_dtype
 
-    return bool(
-        mla_query.can_implement(
-            num_heads=int(b_values.shape[0]),
-            max_m=1,
-            nope_dim=int(b_values.shape[1]),
-            latent_dim=int(b_values.shape[2]),
-            output_dtype=output_dtype,
-            device=b_values.device,
-        )
-    )
+
+def _module_uses_mxfp8_mla_query(module: torch.nn.Module) -> bool:
+    spec = _module_fused_mla_query_spec(module)
+    return spec is not None and spec[1] == "mxfp8"
 
 
 def warmup_b12x_mla_mxfp8_bmm(
@@ -304,42 +404,44 @@ def warmup_b12x_mla_mxfp8_bmm(
     return warmed
 
 
-def warmup_mxfp8_mla_query(
+def warmup_fused_mla_query(
     model: torch.nn.Module,
     *,
     m_values: Iterable[int] = range(1, 33),
 ) -> int:
-    mla_query = _import_mxfp8_mla_query()
+    mla_query = _import_fused_mla_query()
     if mla_query is None:
         return 0
 
     values = tuple(dict.fromkeys(int(m) for m in m_values if int(m) > 0))
-    seen: set[tuple[tuple[int, ...], tuple[int, ...], torch.dtype, torch.device]] = (
-        set()
-    )
+    seen: set[tuple[object, ...]] = set()
     warmed = 0
     for module in model.modules():
-        if not _module_uses_mxfp8_mla_query(module):
+        spec = _module_fused_mla_query_spec(module)
+        if spec is None:
             continue
-        rhs = getattr(module, "_b12x_absorb_uk_rhs", None)
-        output_dtype = getattr(module, "_mxfp8_mla_query_output_dtype", None)
-        if rhs is None or output_dtype not in (
-            torch.bfloat16,
-            torch.float8_e4m3fn,
-        ):
-            continue
-        b_values, b_scales = rhs
-        signature = (
-            tuple(b_values.shape),
-            tuple(b_scales.shape),
-            output_dtype,
-            b_values.device,
-        )
+        weight, weight_format, output_dtype = spec
+        if isinstance(weight, torch.Tensor):
+            signature = (
+                weight_format,
+                tuple(weight.shape),
+                output_dtype,
+                weight.device,
+            )
+        else:
+            b_values, b_scales = weight
+            signature = (
+                weight_format,
+                tuple(b_values.shape),
+                tuple(b_scales.shape),
+                output_dtype,
+                b_values.device,
+            )
         if signature in seen:
             continue
         seen.add(signature)
         warmed += mla_query.prewarm(
-            rhs,
+            weight,
             values,
             output_dtype=output_dtype,
         )
@@ -348,9 +450,12 @@ def warmup_mxfp8_mla_query(
 
 __all__ = [
     "can_implement_b12x_mxfp8_bmm",
+    "can_implement_bf16_mla_query",
+    "can_implement_fused_mla_query",
     "can_implement_mxfp8_mla_query",
+    "run_bf16_mla_query",
     "run_b12x_mxfp8_bmm",
     "run_mxfp8_mla_query",
     "warmup_b12x_mla_mxfp8_bmm",
-    "warmup_mxfp8_mla_query",
+    "warmup_fused_mla_query",
 ]

--- a/vllm/model_executor/kernels/attention/b12x_mxfp8_bmm.py
+++ b/vllm/model_executor/kernels/attention/b12x_mxfp8_bmm.py
@@ -50,7 +50,7 @@ def _import_fused_mla_query() -> Any | None:
     if _FUSED_MLA_QUERY_MISSING:
         return None
     try:
-        mla_query = importlib.import_module("sparkinfer.attention.mla_query")
+        mla_query = importlib.import_module("sparkinfer.gemm.mla_query_projection")
     except ImportError:
         _FUSED_MLA_QUERY_MISSING = True
         return None
@@ -204,8 +204,14 @@ def _mxfp8_mla_query_impl(
 ) -> None:
     mla_query = _import_fused_mla_query()
     if mla_query is None:
-        raise ImportError("sparkinfer.attention.mla_query is not available")
-    mla_query.run(lhs, (b_values, b_scales), q_pe, q_scale, out)
+        raise ImportError("sparkinfer.gemm.mla_query_projection is not available")
+    mla_query.run(
+        lhs,
+        (b_values, b_scales),
+        q_pe,
+        out,
+        q_scale=q_scale if out.dtype == torch.float8_e4m3fn else None,
+    )
 
 
 def _mxfp8_mla_query_fake(
@@ -237,8 +243,14 @@ def _bf16_mla_query_impl(
 ) -> None:
     mla_query = _import_fused_mla_query()
     if mla_query is None:
-        raise ImportError("sparkinfer.attention.mla_query is not available")
-    mla_query.run(lhs, weight, q_pe, q_scale, out)
+        raise ImportError("sparkinfer.gemm.mla_query_projection is not available")
+    mla_query.run(
+        lhs,
+        weight,
+        q_pe,
+        out,
+        q_scale=q_scale if out.dtype == torch.float8_e4m3fn else None,
+    )
 
 
 def _bf16_mla_query_fake(

--- a/vllm/model_executor/kernels/attention/b12x_mxfp8_bmm.py
+++ b/vllm/model_executor/kernels/attention/b12x_mxfp8_bmm.py
@@ -20,6 +20,8 @@ _BMM_SPEC = {
 }
 _B12X_BMM: Any | None = None
 _B12X_BMM_MISSING = False
+_MXFP8_MLA_QUERY: Any | None = None
+_MXFP8_MLA_QUERY_MISSING = False
 
 
 def _import_b12x_bmm() -> Any | None:
@@ -39,6 +41,25 @@ def _import_b12x_bmm() -> Any | None:
         return None
     _B12X_BMM = gemm
     return gemm
+
+
+def _import_mxfp8_mla_query() -> Any | None:
+    global _MXFP8_MLA_QUERY, _MXFP8_MLA_QUERY_MISSING
+    if _MXFP8_MLA_QUERY is not None:
+        return _MXFP8_MLA_QUERY
+    if _MXFP8_MLA_QUERY_MISSING:
+        return None
+    try:
+        mla_query = importlib.import_module("sparkinfer.attention.mla_query")
+    except ImportError:
+        _MXFP8_MLA_QUERY_MISSING = True
+        return None
+    required = ("run", "can_implement", "prewarm")
+    if not all(callable(getattr(mla_query, name, None)) for name in required):
+        _MXFP8_MLA_QUERY_MISSING = True
+        return None
+    _MXFP8_MLA_QUERY = mla_query
+    return mla_query
 
 
 def can_implement_b12x_mxfp8_bmm(
@@ -63,6 +84,30 @@ def can_implement_b12x_mxfp8_bmm(
             sf_axis=b_major,
             device=device,
             **_BMM_SPEC,
+        )
+    )
+
+
+def can_implement_mxfp8_mla_query(
+    *,
+    num_heads: int,
+    max_m: int,
+    nope_dim: int,
+    latent_dim: int,
+    output_dtype: torch.dtype,
+    device: torch.device,
+) -> bool:
+    mla_query = _import_mxfp8_mla_query()
+    if mla_query is None:
+        return False
+    return bool(
+        mla_query.can_implement(
+            num_heads=num_heads,
+            max_m=max_m,
+            nope_dim=nope_dim,
+            latent_dim=latent_dim,
+            output_dtype=output_dtype,
+            device=device,
         )
     )
 
@@ -107,6 +152,40 @@ direct_register_custom_op(
 )
 
 
+def _mxfp8_mla_query_impl(
+    lhs: torch.Tensor,
+    b_values: torch.Tensor,
+    b_scales: torch.Tensor,
+    q_pe: torch.Tensor,
+    q_scale: torch.Tensor,
+    out: torch.Tensor,
+) -> None:
+    mla_query = _import_mxfp8_mla_query()
+    if mla_query is None:
+        raise ImportError("sparkinfer.attention.mla_query is not available")
+    mla_query.run(lhs, (b_values, b_scales), q_pe, q_scale, out)
+
+
+def _mxfp8_mla_query_fake(
+    lhs: torch.Tensor,
+    b_values: torch.Tensor,
+    b_scales: torch.Tensor,
+    q_pe: torch.Tensor,
+    q_scale: torch.Tensor,
+    out: torch.Tensor,
+) -> None:
+    del lhs, b_values, b_scales, q_pe, q_scale, out
+
+
+direct_register_custom_op(
+    op_name="mxfp8_mla_query",
+    op_func=_mxfp8_mla_query_impl,
+    mutates_args=["out"],
+    fake_impl=_mxfp8_mla_query_fake,
+    tags=(torch.Tag.needs_fixed_stride_order,),
+)
+
+
 def run_b12x_mxfp8_bmm(
     lhs: torch.Tensor,
     rhs: tuple[torch.Tensor, torch.Tensor],
@@ -121,6 +200,25 @@ def run_b12x_mxfp8_bmm(
         b_scales,
         out,
         0 if b_major == "k" else 1,
+    )
+    return out
+
+
+def run_mxfp8_mla_query(
+    lhs: torch.Tensor,
+    rhs: tuple[torch.Tensor, torch.Tensor],
+    q_pe: torch.Tensor,
+    q_scale: torch.Tensor,
+    out: torch.Tensor,
+) -> torch.Tensor:
+    b_values, b_scales = rhs
+    torch.ops.vllm.mxfp8_mla_query(
+        lhs,
+        b_values,
+        b_scales,
+        q_pe,
+        q_scale,
+        out,
     )
     return out
 
@@ -165,8 +263,51 @@ def warmup_b12x_mla_mxfp8_bmm(
     return warmed
 
 
+def warmup_mxfp8_mla_query(
+    model: torch.nn.Module,
+    *,
+    m_values: Iterable[int] = range(1, 33),
+) -> int:
+    mla_query = _import_mxfp8_mla_query()
+    if mla_query is None:
+        return 0
+
+    values = tuple(dict.fromkeys(int(m) for m in m_values if int(m) > 0))
+    seen: set[
+        tuple[tuple[int, ...], tuple[int, ...], torch.dtype, torch.device]
+    ] = set()
+    warmed = 0
+    for module in model.modules():
+        rhs = getattr(module, "_b12x_absorb_uk_rhs", None)
+        output_dtype = getattr(module, "_mxfp8_mla_query_output_dtype", None)
+        if rhs is None or output_dtype not in (
+            torch.bfloat16,
+            torch.float8_e4m3fn,
+        ):
+            continue
+        b_values, b_scales = rhs
+        signature = (
+            tuple(b_values.shape),
+            tuple(b_scales.shape),
+            output_dtype,
+            b_values.device,
+        )
+        if signature in seen:
+            continue
+        seen.add(signature)
+        warmed += mla_query.prewarm(
+            rhs,
+            values,
+            output_dtype=output_dtype,
+        )
+    return warmed
+
+
 __all__ = [
     "can_implement_b12x_mxfp8_bmm",
+    "can_implement_mxfp8_mla_query",
     "run_b12x_mxfp8_bmm",
+    "run_mxfp8_mla_query",
     "warmup_b12x_mla_mxfp8_bmm",
+    "warmup_mxfp8_mla_query",
 ]

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -1323,9 +1323,12 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                             "does not return decode softmax LSE."
                         )
                     self.impl.need_to_return_lse_for_decode = True
+                # A fused BF16 query is also a single tensor. Only an actual
+                # FP8 query requires the backend's DCP quant-input contract.
                 if (
                     fp8_attention
                     and isinstance(mqa_q, torch.Tensor)
+                    and mqa_q.dtype == _FP8_DTYPE
                     and not getattr(self.impl, "supports_dcp_quant_query_input", False)
                 ):
                     raise NotImplementedError(

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -219,7 +219,9 @@ from vllm.logger import init_logger
 from vllm.model_executor.custom_op import CustomOp
 from vllm.model_executor.kernels.attention.b12x_mxfp8_bmm import (
     can_implement_b12x_mxfp8_bmm,
+    can_implement_mxfp8_mla_query,
     run_b12x_mxfp8_bmm,
+    run_mxfp8_mla_query,
 )
 from vllm.model_executor.layers.attention.attention import (
     _init_kv_cache_quant,
@@ -986,6 +988,56 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             )
             return output
 
+    def _try_mxfp8_mla_query(
+        self,
+        q_nope: torch.Tensor,
+        q_pe: torch.Tensor,
+    ) -> torch.Tensor | None:
+        """Fuse the small-M absorbed-query BMM with query assembly."""
+        if (
+            not getattr(self, "_use_b12x_absorb_bmm", False)
+            or self.is_aiter_triton_fp4_bmm_enabled
+            or self.is_aiter_triton_fp8_bmm_enabled
+        ):
+            return None
+
+        num_heads, num_tokens, nope_dim = q_nope.shape
+        output_dtype = self._mxfp8_mla_query_output_dtype
+        if not can_implement_mxfp8_mla_query(
+            num_heads=num_heads,
+            max_m=num_tokens,
+            nope_dim=nope_dim,
+            latent_dim=self.kv_lora_rank,
+            output_dtype=output_dtype,
+            device=q_nope.device,
+        ):
+            return None
+
+        workspace_getter = getattr(self.impl, "get_mxfp8_mla_query_output", None)
+        output = (
+            workspace_getter(num_tokens, num_heads, output_dtype)
+            if callable(workspace_getter)
+            else None
+        )
+        if output is None:
+            output = torch.empty(
+                (
+                    num_tokens,
+                    num_heads,
+                    self.kv_lora_rank + self.qk_rope_head_dim,
+                ),
+                dtype=output_dtype,
+                device=q_nope.device,
+            )
+        run_mxfp8_mla_query(
+            q_nope,
+            self._b12x_absorb_uk_rhs,
+            q_pe,
+            self._q_scale,
+            output,
+        )
+        return output
+
     def forward_impl(
         self,
         q: torch.Tensor,
@@ -1161,7 +1213,11 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 mqa_pe_padded.copy_(mqa_q_pe)
                 mqa_q_pe = mqa_pe_padded
 
-            if self.is_aiter_triton_fp4_bmm_enabled:
+            fused_mqa_q = self._try_mxfp8_mla_query(mqa_q_nope, mqa_q_pe)
+
+            if fused_mqa_q is not None:
+                mqa_q = fused_mqa_q
+            elif self.is_aiter_triton_fp4_bmm_enabled:
                 from aiter.ops.triton.batched_gemm_a16wfp4 import batched_gemm_a16wfp4
 
                 mqa_ql_nope = batched_gemm_a16wfp4(
@@ -1216,14 +1272,15 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 # Convert from (N, B, L) to (B, N, L)
                 mqa_ql_nope = mqa_ql_nope.transpose(0, 1)
 
-            if fp8_attention and self.impl.supports_quant_query_input:
-                assert mqa_ql_nope.shape[0] == mqa_q_pe.shape[0]
-                assert mqa_ql_nope.shape[1] == mqa_q_pe.shape[1]
-                mqa_q = self._decode_concat_quant_fp8_op(
-                    mqa_ql_nope, mqa_q_pe, self._q_scale
-                )
-            else:
-                mqa_q = (mqa_ql_nope, mqa_q_pe)
+            if fused_mqa_q is None:
+                if fp8_attention and self.impl.supports_quant_query_input:
+                    assert mqa_ql_nope.shape[0] == mqa_q_pe.shape[0]
+                    assert mqa_ql_nope.shape[1] == mqa_q_pe.shape[1]
+                    mqa_q = self._decode_concat_quant_fp8_op(
+                        mqa_ql_nope, mqa_q_pe, self._q_scale
+                    )
+                else:
+                    mqa_q = (mqa_ql_nope, mqa_q_pe)
             dcp_use_a2a = False
             project_before_merge = False
             workspace_gather_used = False
@@ -1751,6 +1808,13 @@ class MLAAttention(nn.Module, AttentionLayerBase):
         if not self._use_b12x_absorb_bmm:
             self._process_materialized_absorbed_weights(act_dtype)
             return
+
+        self._mxfp8_mla_query_output_dtype = (
+            current_platform.fp8_dtype()
+            if is_quantized_kv_cache(self.kv_cache_dtype)
+            and self.impl.supports_quant_query_input
+            else torch.bfloat16
+        )
 
         quant_method = (
             self.quant_config.get_quant_method(self, prefix=self.layer_name)

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -1014,12 +1014,14 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             return None
 
         workspace_getter = getattr(self.impl, "get_mxfp8_mla_query_output", None)
-        output = (
-            workspace_getter(num_tokens, num_heads, output_dtype)
-            if callable(workspace_getter)
-            else None
-        )
-        if output is None:
+        if callable(workspace_getter):
+            output = workspace_getter(num_tokens, num_heads, output_dtype)
+            # A backend that exposes the workspace contract controls where it
+            # is safe to use the fused path. For example, B12X DCP and padded
+            # virtual-TP layouts require their existing gather/copy path.
+            if output is None:
+                return None
+        else:
             output = torch.empty(
                 (
                     num_tokens,

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -219,8 +219,10 @@ from vllm.logger import init_logger
 from vllm.model_executor.custom_op import CustomOp
 from vllm.model_executor.kernels.attention.b12x_mxfp8_bmm import (
     can_implement_b12x_mxfp8_bmm,
+    can_implement_bf16_mla_query,
     can_implement_mxfp8_mla_query,
     run_b12x_mxfp8_bmm,
+    run_bf16_mla_query,
     run_mxfp8_mla_query,
 )
 from vllm.model_executor.layers.attention.attention import (
@@ -988,39 +990,58 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             )
             return output
 
-    def _try_mxfp8_mla_query(
+    def _try_fused_mla_query(
         self,
         q_nope: torch.Tensor,
         q_pe: torch.Tensor,
     ) -> torch.Tensor | None:
-        """Fuse the small-M absorbed-query BMM with query assembly."""
-        if (
-            not getattr(self, "_use_b12x_absorb_bmm", False)
-            or self.is_aiter_triton_fp4_bmm_enabled
-            or self.is_aiter_triton_fp8_bmm_enabled
-        ):
+        """Fuse a qualified BF16/MXFP8 query BMM with query assembly."""
+        if self.is_aiter_triton_fp4_bmm_enabled or self.is_aiter_triton_fp8_bmm_enabled:
             return None
 
         num_heads, num_tokens, nope_dim = q_nope.shape
-        output_dtype = self._mxfp8_mla_query_output_dtype
-        if not can_implement_mxfp8_mla_query(
-            num_heads=num_heads,
-            max_m=num_tokens,
-            nope_dim=nope_dim,
-            latent_dim=self.kv_lora_rank,
-            output_dtype=output_dtype,
-            device=q_nope.device,
-        ):
-            return None
+        output_dtype = self._fused_mla_query_output_dtype
+        if getattr(self, "_use_b12x_absorb_bmm", False):
+            weight = self._b12x_absorb_uk_rhs
+            if not can_implement_mxfp8_mla_query(
+                num_heads=num_heads,
+                max_m=num_tokens,
+                nope_dim=nope_dim,
+                latent_dim=self.kv_lora_rank,
+                output_dtype=output_dtype,
+                device=q_nope.device,
+            ):
+                return None
+            runner = run_mxfp8_mla_query
+        else:
+            weight = getattr(self, "W_UK_T", None)
+            if not isinstance(weight, torch.Tensor) or not can_implement_bf16_mla_query(
+                num_heads=num_heads,
+                max_m=num_tokens,
+                nope_dim=nope_dim,
+                latent_dim=self.kv_lora_rank,
+                output_dtype=output_dtype,
+                device=q_nope.device,
+            ):
+                return None
+            runner = run_bf16_mla_query
 
-        workspace_getter = getattr(self.impl, "get_mxfp8_mla_query_output", None)
+        workspace_getter = getattr(self.impl, "get_fused_mla_query_output", None)
         if callable(workspace_getter):
             output = workspace_getter(num_tokens, num_heads, output_dtype)
-            # A backend that exposes the workspace contract controls where it
-            # is safe to use the fused path. For example, B12X DCP and padded
-            # virtual-TP layouts require their existing gather/copy path.
+            # DCP1 can return the final query workspace. DCP and padded
+            # virtual-TP layouts return None and use a graph-owned local query
+            # tensor that their established gather/copy path consumes.
             if output is None:
-                return None
+                output = torch.empty(
+                    (
+                        num_tokens,
+                        num_heads,
+                        self.kv_lora_rank + self.qk_rope_head_dim,
+                    ),
+                    dtype=output_dtype,
+                    device=q_nope.device,
+                )
         else:
             output = torch.empty(
                 (
@@ -1031,9 +1052,9 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 dtype=output_dtype,
                 device=q_nope.device,
             )
-        run_mxfp8_mla_query(
+        runner(
             q_nope,
-            self._b12x_absorb_uk_rhs,
+            weight,
             q_pe,
             self._q_scale,
             output,
@@ -1215,7 +1236,7 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 mqa_pe_padded.copy_(mqa_q_pe)
                 mqa_q_pe = mqa_pe_padded
 
-            fused_mqa_q = self._try_mxfp8_mla_query(mqa_q_nope, mqa_q_pe)
+            fused_mqa_q = self._try_fused_mla_query(mqa_q_nope, mqa_q_pe)
 
             if fused_mqa_q is not None:
                 mqa_q = fused_mqa_q
@@ -1807,16 +1828,15 @@ class MLAAttention(nn.Module, AttentionLayerBase):
 
     def process_weights_after_loading(self, act_dtype: torch.dtype):
         self._use_b12x_absorb_bmm = self._prepare_b12x_absorb_bmm(act_dtype)
-        if not self._use_b12x_absorb_bmm:
-            self._process_materialized_absorbed_weights(act_dtype)
-            return
-
-        self._mxfp8_mla_query_output_dtype = (
+        self._fused_mla_query_output_dtype = (
             current_platform.fp8_dtype()
             if is_quantized_kv_cache(self.kv_cache_dtype)
             and self.impl.supports_quant_query_input
             else torch.bfloat16
         )
+        if not self._use_b12x_absorb_bmm:
+            self._process_materialized_absorbed_weights(act_dtype)
+            return
 
         quant_method = (
             self.quant_config.get_quant_method(self, prefix=self.layer_name)

--- a/vllm/model_executor/warmup/kernel_warmup.py
+++ b/vllm/model_executor/warmup/kernel_warmup.py
@@ -310,7 +310,20 @@ def kernel_warmup(worker: "Worker"):
             warmed_mla_bmm,
         )
 
-    warmed_mla_query = warmup_mxfp8_mla_query(worker.get_model())
+    # Graph replay cannot JIT a missing specialization. Prewarm only the
+    # graph-visible token counts covered by the small-M kernel instead of
+    # retaining all 32 possible variants in every worker. M=1 also covers
+    # eager-only configurations and the ordinary single-request decode path.
+    mla_query_warmup_sizes = sorted(
+        {
+            1,
+            *(size for size in cudagraph_capture_sizes if 1 <= size <= 32),
+        }
+    )
+    warmed_mla_query = warmup_mxfp8_mla_query(
+        worker.get_model(),
+        m_values=mla_query_warmup_sizes,
+    )
     if warmed_mla_query:
         logger.info(
             "Warmed up %d fused MLA MXFP8 query variants.",

--- a/vllm/model_executor/warmup/kernel_warmup.py
+++ b/vllm/model_executor/warmup/kernel_warmup.py
@@ -16,7 +16,7 @@ import vllm.envs as envs
 from vllm.logger import init_logger
 from vllm.model_executor.kernels.attention.b12x_mxfp8_bmm import (
     warmup_b12x_mla_mxfp8_bmm,
-    warmup_mxfp8_mla_query,
+    warmup_fused_mla_query,
 )
 from vllm.model_executor.kernels.linear.mxfp8.b12x import warmup_b12x_mxfp8_linear
 from vllm.model_executor.layers.fused_moe.b12x_moe import warmup_b12x_moe_dynamic
@@ -320,13 +320,13 @@ def kernel_warmup(worker: "Worker"):
             *(size for size in cudagraph_capture_sizes if 1 <= size <= 32),
         }
     )
-    warmed_mla_query = warmup_mxfp8_mla_query(
+    warmed_mla_query = warmup_fused_mla_query(
         worker.get_model(),
         m_values=mla_query_warmup_sizes,
     )
     if warmed_mla_query:
         logger.info(
-            "Warmed up %d fused MLA MXFP8 query variants.",
+            "Warmed up %d fused MLA BF16/MXFP8 query variants.",
             warmed_mla_query,
         )
 

--- a/vllm/model_executor/warmup/kernel_warmup.py
+++ b/vllm/model_executor/warmup/kernel_warmup.py
@@ -16,6 +16,7 @@ import vllm.envs as envs
 from vllm.logger import init_logger
 from vllm.model_executor.kernels.attention.b12x_mxfp8_bmm import (
     warmup_b12x_mla_mxfp8_bmm,
+    warmup_mxfp8_mla_query,
 )
 from vllm.model_executor.kernels.linear.mxfp8.b12x import warmup_b12x_mxfp8_linear
 from vllm.model_executor.layers.fused_moe.b12x_moe import warmup_b12x_moe_dynamic
@@ -307,6 +308,13 @@ def kernel_warmup(worker: "Worker"):
         logger.info(
             "Warmed up %d B12X MLA MXFP8 BMM variants.",
             warmed_mla_bmm,
+        )
+
+    warmed_mla_query = warmup_mxfp8_mla_query(worker.get_model())
+    if warmed_mla_query:
+        logger.info(
+            "Warmed up %d fused MLA MXFP8 query variants.",
+            warmed_mla_query,
         )
 
     warmed_indexer = warmup_b12x_sparse_indexer(worker)

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -1389,9 +1389,7 @@ class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
         the query without a concat or workspace copy.
         """
         if (
-            not B12xMLASparseImpl.supports_mxfp8_mla_query_output(
-                self, num_heads, output_dtype
-            )
+            not self.supports_mxfp8_mla_query_output(num_heads, output_dtype)
             or num_tokens <= 0
             or num_tokens > self._max_batched
         ):

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -1361,6 +1361,35 @@ class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
             raise RuntimeError("B12X DCP prefill borrowed an invalid raw scratch")
         return q_workspace, dense_out_workspace, scratch_storage
 
+    def get_mxfp8_mla_query_output(
+        self,
+        num_tokens: int,
+        num_heads: int,
+        output_dtype: torch.dtype,
+    ) -> torch.Tensor | None:
+        """Return the final B12X query view for fused DCP1 assembly.
+
+        DCP query gathering needs a different local-head layout, so those
+        configurations retain the ordinary temporary query path. For DCP1,
+        writing the fused epilogue directly here lets ``forward_mqa`` consume
+        the query without a concat or workspace copy.
+        """
+        if (
+            self.dcp_world_size != 1
+            or output_dtype != torch.bfloat16
+            or num_tokens <= 0
+            or num_tokens > self._max_batched
+            or num_heads != self._input_num_heads
+            or self._kernel_num_heads != self._input_num_heads
+            or self.q_head_dim != 576
+        ):
+            return None
+        q_workspace, _, _ = self._borrow_workspace_parts()
+        output = q_workspace[:num_tokens, :num_heads]
+        if not output.is_contiguous():
+            raise RuntimeError("B12X fused MLA query output must be contiguous")
+        return output
+
     def _validate_dcp_prefill_workspace_contract(self, num_tokens: int) -> None:
         supported_topologies = {
             (4, 4),

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -1361,6 +1361,20 @@ class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
             raise RuntimeError("B12X DCP prefill borrowed an invalid raw scratch")
         return q_workspace, dense_out_workspace, scratch_storage
 
+    def supports_mxfp8_mla_query_output(
+        self,
+        num_heads: int,
+        output_dtype: torch.dtype,
+    ) -> bool:
+        """Whether fused query assembly can target the planned B12X layout."""
+        return bool(
+            self.dcp_world_size == 1
+            and output_dtype == torch.bfloat16
+            and num_heads == self._input_num_heads
+            and self._kernel_num_heads == self._input_num_heads
+            and self.q_head_dim == 576
+        )
+
     def get_mxfp8_mla_query_output(
         self,
         num_tokens: int,
@@ -1375,13 +1389,11 @@ class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
         the query without a concat or workspace copy.
         """
         if (
-            self.dcp_world_size != 1
-            or output_dtype != torch.bfloat16
+            not B12xMLASparseImpl.supports_mxfp8_mla_query_output(
+                self, num_heads, output_dtype
+            )
             or num_tokens <= 0
             or num_tokens > self._max_batched
-            or num_heads != self._input_num_heads
-            or self._kernel_num_heads != self._input_num_heads
-            or self.q_head_dim != 576
         ):
             return None
         q_workspace, _, _ = self._borrow_workspace_parts()

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -1361,7 +1361,7 @@ class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
             raise RuntimeError("B12X DCP prefill borrowed an invalid raw scratch")
         return q_workspace, dense_out_workspace, scratch_storage
 
-    def supports_mxfp8_mla_query_output(
+    def supports_fused_mla_query_output(
         self,
         num_heads: int,
         output_dtype: torch.dtype,
@@ -1375,7 +1375,7 @@ class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
             and self.q_head_dim == 576
         )
 
-    def get_mxfp8_mla_query_output(
+    def get_fused_mla_query_output(
         self,
         num_tokens: int,
         num_heads: int,
@@ -1389,7 +1389,7 @@ class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
         the query without a concat or workspace copy.
         """
         if (
-            not self.supports_mxfp8_mla_query_output(num_heads, output_dtype)
+            not self.supports_fused_mla_query_output(num_heads, output_dtype)
             or num_tokens <= 0
             or num_tokens > self._max_batched
         ):


### PR DESCRIPTION
## What

Integrates SparkInfer's fused MLA query projection into the GLM MLA path for
both native MXFP8 and materialized BF16 `W_UK_T` weights.

- Native MXFP8 uses the operation merged in
  `local-inference-lab/sparkinfer#74`.
- BF16 weights use the extension in `local-inference-lab/sparkinfer#75`.
- The fused epilogue writes `[M,H,576]` directly and appends `q_pe` without a
  separate concat kernel.
- BF16 output omits the unused scale argument; E4M3 output passes `_q_scale`.
- H=8/11/16 and M=1..32 are capability-gated. Unsupported cases keep the
  staged path.

The integration imports the final public API,
`sparkinfer.gemm.mla_query_projection`; the obsolete
`sparkinfer.attention.mla_query` path is not restored.

## Layout and topology behavior

- DCP1 B12X writes directly into its final query workspace when the backend
  confirms an unpadded BF16 layout.
- DCP>1 and padded virtual-TP layouts use a graph-owned local query tensor and
  continue through their established gather/copy path.
- TP6 is covered by the BF16 H=11 specialization.
- Existing UK BMM warmup is skipped only when fused query projection is
  qualified; UV warmup is unchanged.
- Prewarm is limited to graph-visible M regimes to avoid unnecessary retained
  allocations.
- With FP8 KV, only an actual E4M3 query tensor requires backend
  `supports_quant_query_input`; the fused BF16 query remains valid for DCP.

## Safety scope and PR 173

This PR removes the query-side `torch.bmm` from qualified H=8/11/16,
M=1..32 execution, but it does not supersede #173. Unsupported shapes,
missing SparkInfer support, or failed capability checks still use the staged
query BMM. #173 remains the no-copy cuBLAS read-ahead fix for that fallback.
Merge #173 first, then refresh this PR so its safe operation is retained only
behind the fused-path fallback.

The downstream V up-projection is a separate issue already fixed by #147 and
`local-inference-lab/sparkinfer#54`.

## Performance evidence

Exact paired TP8/DCP1/MTP0 profiling, averaged over eight ranks:

| Metric | Staged | Fused | Delta |
| --- | ---: | ---: | ---: |
| Query BMM + concat per layer | 4.047940 us | 2.880912 us | -28.8% |
| CUDA kernel events, four steps | 10,200 | 9,888 | -312 |
| GPU trace span | 50,940.968 us | 50,450.708 us | -0.96% |

No extra hot-path synchronization appeared. Final TP8/DCP1/MTP0 duration
validation on GPUs 0-7 produced aggregate 87.658/87.610 tok/s (mean 87.634)
and active per-user 88.359/88.313 tok/s (mean 88.336), with zero errors.

## E2E topology matrix

All values are aggregate CC1 output tok/s. Every 64k case includes the full
prefill-to-decode transition. Models were fully loaded before benchmarks, and
parallel instances were measured sequentially.

| Model path | TP | DCP | MTP | ctx0 | ctx64k | Errors |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| NF3 MXFP8 | 4 | 1 | 0 | 64.44 | 61.66 | 0 |
| NF3 MXFP8 | 4 | 2 | 0 | 58.11 | 57.51 | 0 |
| NF3 MXFP8 | 4 | 4 | 0 | 57.61 | 56.24 | 0 |
| Luke BF16 | 6 | 1 | 0 | 68.69 | 67.11 | 0 |
| Luke BF16 | 6 | 2 | 0 | 58.11 | 57.27 | 0 |
| Luke BF16 | 6 | 3 | 0 | 52.38 | 50.82 | 0 |
| Luke BF16 | 6 | 6 | 0 | 42.66 | 41.98 | 0 |
| Luke BF16 | 8 | 1 | 0 | 87.63 | - | 0 |
| Luke BF16 | 8 | 2 | 0 | 73.39 | 71.33 | 0 |
| Luke BF16 | 8 | 4 | 0 | 71.79 | 69.47 | 0 |
| Luke BF16 | 8 | 8 | 0 | 66.43 | 65.83 | 0 |
| NF3 MXFP8 | 4 | 4 | 3 | 111.60 | 102.13 | 0 |
| Luke BF16 | 6 | 3 | 3 | 89.15 | 79.04 | 0 |
| Luke BF16 | 8 | 4 | 3 | 124.27 | 111.77 | 0 |

All workers logged fused-query warmup. The final log audit found no traceback,
Xid, illegal-memory-access, `CUBLAS_STATUS`, `FAULT_PDE`, invalid-layout, or
engine-initialization failure.

## Validation

- SparkInfer BMM/query/registry suites: 93 passed on GPU 0.
- Focused vLLM dispatch, warmup, workspace, fallback, BF16/MXFP8, and output
  tests: 14 passed.
- Final DCP/FP8 guard regression selection: 9 passed, 2325 deselected.
- Direct H=11 custom-op smoke passed against the final SparkInfer API.
- TP4/TP6/TP8, every MTP0 DCP divisor, representative MTP3, and 64k
  prefill-to-decode transitions passed.
- Ruff, Ruff format, `compileall`, and `git diff --check` passed.

## Dependencies

- merged: `local-inference-lab/sparkinfer#74`
- required: `local-inference-lab/sparkinfer#75`
- fallback safety and merge first: #173
