### PR TITLE
[GG] perf(indexer): shard sparse prefill queries and halve result traffic

### DIFF
--- a/tests/distributed/test_indexer_parallel_groups.py
+++ b/tests/distributed/test_indexer_parallel_groups.py
@@ -21,6 +21,39 @@ def test_build_indexer_two_by_four_groups_for_tp8():
     assert query_split_groups == [[0, 4], [1, 5], [2, 6], [3, 7]]
 
 
+@pytest.mark.parametrize(
+    ("indexer_shards", "expected_dcp", "expected_query_split"),
+    [
+        (
+            1,
+            [[0], [1], [2], [3], [4], [5], [6], [7]],
+            [list(range(8))],
+        ),
+        (
+            2,
+            [[0, 1], [2, 3], [4, 5], [6, 7]],
+            [[0, 2, 4, 6], [1, 3, 5, 7]],
+        ),
+        (
+            8,
+            [list(range(8))],
+            [[0], [1], [2], [3], [4], [5], [6], [7]],
+        ),
+    ],
+)
+def test_build_indexer_groups_cover_dcp1_partial_and_full(
+    indexer_shards,
+    expected_dcp,
+    expected_query_split,
+):
+    dcp_groups, query_split_groups = _build_indexer_replica_group_ranks(
+        [list(range(8))], indexer_shards
+    )
+
+    assert dcp_groups == expected_dcp
+    assert query_split_groups == expected_query_split
+
+
 def test_build_indexer_replica_groups_stay_inside_each_tp_group():
     dcp_groups, query_split_groups = _build_indexer_replica_group_ranks(
         [list(range(8)), list(range(8, 16))], 4
@@ -74,6 +107,18 @@ def test_indexer_group_selector_supports_partial_target_and_full_draft(monkeypat
     assert parallel_state.get_indexer_dcp_group(4) is full_dcp
     assert parallel_state.get_indexer_query_split_group(2) is partial_query_split
     assert parallel_state.get_indexer_query_split_group(4) is full_query_split
+
+
+def test_indexer_group_selector_uses_tp_query_split_for_dcp1(monkeypatch):
+    dcp = SimpleNamespace(world_size=1)
+    query_split = SimpleNamespace(world_size=8)
+    monkeypatch.setattr(parallel_state, "_INDEXER_DCP", None)
+    monkeypatch.setattr(parallel_state, "_INDEXER_QUERY_SPLIT", None)
+    monkeypatch.setattr(parallel_state, "_DCP", dcp)
+    monkeypatch.setattr(parallel_state, "_QUERY_SPLIT", query_split)
+
+    assert parallel_state.get_indexer_dcp_group(1) is dcp
+    assert parallel_state.get_indexer_query_split_group(1) is query_split
 
 
 def test_indexer_group_selector_rejects_unknown_shard_count(monkeypatch):

--- a/tests/model_executor/layers/test_sparse_attn_indexer_b12x.py
+++ b/tests/model_executor/layers/test_sparse_attn_indexer_b12x.py
@@ -288,6 +288,94 @@ def _install_fake_b12x_dcp_merge(monkeypatch, run_row_topk, *, world_size: int):
     )
 
 
+def test_query_split_gathers_indices_in_place_without_scores():
+    calls: list[tuple[int, int]] = []
+
+    class FakePyNccl:
+        disabled = False
+
+        def all_gather(self, output, input_):
+            calls.append((output.data_ptr(), input_.data_ptr()))
+            rows = input_.shape[0]
+            output[:rows].fill_(10)
+            output[rows:].fill_(20)
+
+    group = types.SimpleNamespace(
+        world_size=2,
+        rank_in_group=1,
+        device_communicator=types.SimpleNamespace(pynccl_comm=FakePyNccl()),
+    )
+    gathered_indices = torch.full((4, 3), -1, dtype=torch.int32)
+    local_indices = gathered_indices[2:]
+    local_indices.fill_(20)
+    scores = torch.arange(12, dtype=torch.float32).reshape(4, 3)
+    scores_before = scores.clone()
+
+    indexer_mod._query_split_all_gather_indices(
+        group,
+        local_indices,
+        gathered_indices,
+    )
+
+    assert calls == [(gathered_indices.data_ptr(), local_indices.data_ptr())]
+    assert gathered_indices.tolist() == [[10] * 3, [10] * 3, [20] * 3, [20] * 3]
+    assert torch.equal(scores, scores_before)
+
+
+def test_query_split_copies_aliased_input_for_torch_distributed_fallback(
+    monkeypatch,
+):
+    calls: list[tuple[int, int]] = []
+
+    def fake_all_gather_into_tensor(output, input_, *, group):
+        assert group == "device-group"
+        calls.append((output.data_ptr(), input_.data_ptr()))
+        rows = input_.shape[0]
+        output[:rows].fill_(10)
+        output[rows:].copy_(input_)
+
+    monkeypatch.setattr(
+        torch.distributed,
+        "all_gather_into_tensor",
+        fake_all_gather_into_tensor,
+    )
+    group = types.SimpleNamespace(
+        world_size=2,
+        rank_in_group=1,
+        device_group="device-group",
+        device_communicator=types.SimpleNamespace(
+            pynccl_comm=types.SimpleNamespace(disabled=True),
+        ),
+    )
+    gathered_indices = torch.full((4, 3), -1, dtype=torch.int32)
+    local_indices = gathered_indices[2:]
+    local_indices.fill_(20)
+    local_ptr = local_indices.data_ptr()
+
+    indexer_mod._query_split_all_gather_indices(
+        group,
+        local_indices,
+        gathered_indices,
+    )
+
+    assert calls[0][0] == gathered_indices.data_ptr()
+    assert calls[0][1] != local_ptr
+    assert gathered_indices.tolist() == [[10] * 3, [10] * 3, [20] * 3, [20] * 3]
+
+
+def test_query_split_rejects_non_aliasing_local_indices():
+    group = types.SimpleNamespace(world_size=2, rank_in_group=0)
+    gathered_indices = torch.empty((4, 3), dtype=torch.int32)
+    local_indices = torch.empty((2, 3), dtype=torch.int32)
+
+    with pytest.raises(RuntimeError, match="must alias"):
+        indexer_mod._query_split_all_gather_indices(
+            group,
+            local_indices,
+            gathered_indices,
+        )
+
+
 @pytest.mark.parametrize(
     "page_stride0",
     [

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -2073,17 +2073,17 @@ def initialize_model_parallel(
         group_name="dcp",
     )
 
-    # Build the query-split groups for the indexer query split (Fix A).
-    # Ranks sharing the same dcp_rank (position within their DCP group)
-    # form a query-split group.  At TP=8/DCP=2 the DCP groups are
-    # {0,1},{2,3},{4,5},{6,7} and the query-split groups are
-    # {0,2,4,6} (dcp_rank=0) and {1,3,5,7} (dcp_rank=1).
+    # Build the full-indexer query-split groups from the same topology helper
+    # used by partially replicated indexers below. At TP8/DCP2 this produces
+    # {0,2,4,6}/{1,3,5,7}. DCP1 intentionally produces one TP-wide group:
+    # every rank has the replicated indexer inputs and can process a query-row
+    # shard before restoring the exact int32 top-k indices.
     global _QUERY_SPLIT
     assert _QUERY_SPLIT is None, "query split group is already initialized"
-    if decode_context_model_parallel_size > 1 and envs.VLLM_DCP_QUERY_SPLIT:
-        query_split_ranks: list[list[int]] = []
-        for dcp_rank_idx in range(decode_context_model_parallel_size):
-            query_split_ranks.append([grp[dcp_rank_idx] for grp in group_ranks])
+    if envs.VLLM_DCP_QUERY_SPLIT:
+        _, query_split_ranks = _build_indexer_replica_group_ranks(
+            tp_group_ranks, decode_context_model_parallel_size
+        )
         _QUERY_SPLIT = init_model_parallel_group(
             query_split_ranks,
             get_world_group().local_rank,

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -407,15 +407,66 @@ def _dcp_all_gather_first_dim_into(
         pynccl_comm.all_gather(output_tensor, input_tensor)
         return
 
-    device_group = getattr(communicator, "device_group", None)
+    device_group = getattr(group, "device_group", None)
+    if device_group is None:
+        device_group = getattr(communicator, "device_group", None)
     if device_group is not None:
         import torch.distributed as dist
 
-        dist.all_gather_into_tensor(output_tensor, input_tensor, group=device_group)
+        gather_input = input_tensor
+        input_start = input_tensor.data_ptr()
+        input_end = input_start + input_tensor.numel() * input_tensor.element_size()
+        output_start = output_tensor.data_ptr()
+        output_end = output_start + output_tensor.numel() * output_tensor.element_size()
+        if input_start < output_end and output_start < input_end:
+            # PyTorch does not expose NCCL's in-place all-gather contract.
+            # Keep the generic fallback portable; the deployed PyNCCL path
+            # above retains the rank-local zero-copy layout.
+            gather_input = input_tensor.clone()
+        dist.all_gather_into_tensor(output_tensor, gather_input, group=device_group)
         return
 
     gathered = group.all_gather(input_tensor, dim=0)
     output_tensor.copy_(gathered)
+
+
+def _query_split_all_gather_indices(
+    group,
+    local_indices: torch.Tensor,
+    gathered_indices: torch.Tensor,
+) -> None:
+    """Restore query-split rows directly into their shared index buffer.
+
+    Args:
+        group: Query-split process group and rank metadata.
+        local_indices: Contiguous rank-local rows aliasing their output slot.
+        gathered_indices: Contiguous output containing every rank's rows.
+
+    Raises:
+        RuntimeError: If the buffers are noncontiguous, have incompatible
+            shapes, or do not satisfy the rank-local alias contract.
+    """
+    if group.world_size <= 1:
+        return
+    if not local_indices.is_contiguous() or not gathered_indices.is_contiguous():
+        raise RuntimeError("query-split top-k buffers must be contiguous")
+    if gathered_indices.shape[0] != local_indices.shape[0] * group.world_size:
+        raise RuntimeError("query-split output has an invalid row count")
+    if gathered_indices.shape[1:] != local_indices.shape[1:]:
+        raise RuntimeError("query-split output has an invalid trailing shape")
+
+    rank = int(group.rank_in_group)
+    expected_local = gathered_indices.narrow(
+        0, rank * local_indices.shape[0], local_indices.shape[0]
+    )
+    if expected_local.data_ptr() != local_indices.data_ptr():
+        raise RuntimeError(
+            "query-split local indices must alias their rank slot in the output"
+        )
+
+    # NCCL supports in-place all-gather when the send buffer aliases the
+    # rank-local receive slice. The generic fallback copies only that slice.
+    _dcp_all_gather_first_dim_into(group, local_indices, gathered_indices)
 
 
 def _unpack_b12x_dcp_gathered_candidates(
@@ -1994,19 +2045,17 @@ def sparse_attn_indexer(
                 if used_owner_merge:
                     continue
                 if qs_active:
-                    gathered_indices = qs_group.all_gather(
-                        topk_indices.contiguous(), dim=0
-                    )
-                    topk_indices_buffer[
+                    gathered_indices = topk_indices_buffer[
                         chunk.token_start : chunk.token_end, :topk_tokens
-                    ].copy_(gathered_indices)
-                    if topk_scores is not None:
-                        gathered_scores = qs_group.all_gather(
-                            topk_scores.contiguous(), dim=0
-                        )
-                        topk_scores_buffer[
-                            chunk.token_start : chunk.token_end, :topk_tokens
-                        ].copy_(gathered_scores)
+                    ]
+                    _query_split_all_gather_indices(
+                        qs_group,
+                        topk_indices,
+                        gathered_indices,
+                    )
+                    # Scores are consumed only by the DCP-local candidate
+                    # merge above. Sparse attention needs the restored indices,
+                    # so gathering scores here would double result traffic.
                 continue
 
             cu_seqlen_ks = chunk.cu_seqlen_ks


### PR DESCRIPTION
## Summary

- shard sparse-indexer query rows across the query-split group;
- gather only the final contiguous `int32` top-k indices directly into the caller-owned buffer;
- stop gathering FP32 scores after the DCP-local candidate merge, because sparse attention does not consume them;
- support the same exact query sharding at DCP1, where TP ranks otherwise repeat identical indexer work;
- keep the PyNCCL path in-place while giving generic `torch.distributed` backends a safe copied send slice.

The feature remains gated by `VLLM_DCP_QUERY_SPLIT`. This PR does not globally enable it; deployment policy retains an explicit kill switch and excludes unqualified virtual-TP6 layouts.

## Current GG integration

The PR was reconstructed on 2026-07-30 from current `dev/gilded-gnosis@2d9c9801094842960b94c053539d62892e35a0bc`.

The earlier branch carried its own query-split topology helper. Current GG now has canonical full and partially replicated indexer topology through `_build_indexer_replica_group_ranks`, `get_indexer_dcp_group`, and `get_indexer_query_split_group`. This refresh removes the duplicate implementation and uses that canonical builder for DCP1, partial DCP, and full DCP.

The remaining diff is therefore limited to the still-missing communication optimization, DCP1 group initialization, and focused regression coverage. It composes with current GG's partial-indexer groups and context-crossover policy instead of replacing either one.

## Why this is exact

Each query-split rank computes a disjoint row slice with the existing sparse top-k kernel, then all-gathers the resulting `int32` indices. It does not compress scores, indices, CKV, weights, or activations. A deterministic unique 64k prompt produced the same winning token; baseline-vs-query logprob delta was `7.15e-7` versus `9.54e-7` baseline repeat spread.

## Communication impact

For TP8/DCP4, 8192 rows, top-k 2048, and query-split size 2, eliminating the FP32 score collective reduces result traffic per GPU/layer/direction from 64 MiB to 32 MiB. The isolated collective median fell from 2.726 ms to 1.412 ms per active layer and 8k chunk.

## Qualified E2E results

GLM-5.2, MTP off, exact raw prefill, no concurrent model loading or benchmark traffic:

| Topology | Context | Before | After | Delta |
|---|---:|---:|---:|---:|
| TP8/DCP1 NVFP4 A16 | 400k | 4,403 | 5,805 tok/s | +31.8% |
| TP8/DCP1 NVFP4 A16 | 64k | ~5,860 | ~6,148 tok/s | +4.9% |
| TP4/DCP1 NF3 hybrid, same GPUs 0-3 | 64k | 4,125 | 4,226 tok/s | +2.4% |
| TP8/DCP4 NVFP4 A16 | 64k | 5,362.5 | 5,484.5 tok/s | +2.28% |

The immutable v20 r14 image contains the earlier, E2E-qualified implementation at `2c14a58a21c724f08d01d988b9972d10c77ed4c0`. This refresh preserves that transport behavior while replacing obsolete topology code with current GG's implementation.

Virtual TP6 has 11 padded heads per rank and remains excluded from auto-enable:

| TP6 topology | Context | Disabled | Enabled | Delta |
|---|---:|---:|---:|---:|
| DCP1 | 64k | 5,014 | 4,959 | -1.1% |
| DCP2 | 64k | 3,851 | 3,830 | -0.6% |
| DCP3 | 64k / 400k | 3,354 / 3,123 | 2,822 / 2,663 | -15.9% / -14.7% |
| DCP6 | 64k / 400k | 2,306 / 2,238.8 | 2,288 / 2,236.7 | -0.8% / -0.1% |

## Validation

Current-GG refresh:

- `47/47` focused tests pass;
- DCP1, partial-DCP, full-DCP, selector, PyNCCL in-place, generic fallback, alias, and score-preservation contracts are covered;
- Ruff check and format pass;
- `git diff --check` passes;
- the branch is one commit over current GG.

Earlier E2E qualification retained by the unchanged transport core:

- TP8/DCP1 64k and 400k;
- TP4/DCP1 64k same-GPU A/B;
- TP6 DCP1/2/3/6 64k and long-context ON/OFF;
- TP8/DCP4 two-run A/B.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for partially replicated sparse-indexer decode-context and query-split configurations.
  * Improved sparse-indexer data gathering and merging across distributed layouts.
  * Added configurable replication and KV shard-count options for sparse-indexer initialization.

* **Bug Fixes**
  * Improved handling of overlapping buffers during distributed gathers.
  * Added validation for index buffer aliasing and compatible shard configurations.

* **Tests**
  * Expanded coverage for distributed group layouts, in-place gathering, fallback behavior, and invalid configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->