### PR TITLE
[GG] perf(indexer): shard DCP1 prefill queries across TP

### DIFF
--- a/tests/distributed/test_query_split_groups.py
+++ b/tests/distributed/test_query_split_groups.py
@@ -38,6 +38,11 @@ from vllm.distributed.parallel_state import _get_query_split_group_ranks
             8,
             [[0], [1], [2], [3], [4], [5], [6], [7]],
         ),
+        (
+            [list(range(8))],
+            1,
+            [list(range(8))],
+        ),
     ],
 )
 def test_get_query_split_group_ranks(tp_groups, dcp_size, expected):

--- a/tests/distributed/test_query_split_groups.py
+++ b/tests/distributed/test_query_split_groups.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm.distributed.parallel_state import _get_query_split_group_ranks
+
+
+@pytest.mark.parametrize(
+    ("tp_groups", "dcp_size", "expected"),
+    [
+        (
+            [list(range(8))],
+            4,
+            [[0, 4], [1, 5], [2, 6], [3, 7]],
+        ),
+        (
+            [list(range(8))],
+            2,
+            [[0, 2, 4, 6], [1, 3, 5, 7]],
+        ),
+        (
+            [list(range(8)), list(range(8, 16))],
+            4,
+            [
+                [0, 4],
+                [1, 5],
+                [2, 6],
+                [3, 7],
+                [8, 12],
+                [9, 13],
+                [10, 14],
+                [11, 15],
+            ],
+        ),
+        (
+            [list(range(8))],
+            8,
+            [[0], [1], [2], [3], [4], [5], [6], [7]],
+        ),
+    ],
+)
+def test_get_query_split_group_ranks(tp_groups, dcp_size, expected):
+    assert _get_query_split_group_ranks(tp_groups, dcp_size) == expected
+
+
+@pytest.mark.parametrize("dcp_size", [0, -1])
+def test_get_query_split_group_ranks_rejects_nonpositive_dcp(dcp_size):
+    with pytest.raises(ValueError, match="must be positive"):
+        _get_query_split_group_ranks([[0, 1]], dcp_size)
+
+
+def test_get_query_split_group_ranks_rejects_partial_dcp_group():
+    with pytest.raises(ValueError, match="must be divisible"):
+        _get_query_split_group_ranks([[0, 1, 2]], 2)

--- a/tests/model_executor/layers/test_sparse_attn_indexer_b12x.py
+++ b/tests/model_executor/layers/test_sparse_attn_indexer_b12x.py
@@ -195,6 +195,47 @@ def _install_fake_b12x_dcp_merge(monkeypatch, run_row_topk, *, world_size: int):
     )
 
 
+def test_query_split_gathers_indices_in_place_without_scores():
+    calls: list[tuple[int, int]] = []
+
+    class FakePyNccl:
+        disabled = False
+
+        def all_gather(self, output, input_):
+            calls.append((output.data_ptr(), input_.data_ptr()))
+            rows = input_.shape[0]
+            output[:rows].fill_(10)
+            output[rows:].fill_(20)
+
+    group = types.SimpleNamespace(
+        world_size=2,
+        rank_in_group=1,
+        device_communicator=types.SimpleNamespace(pynccl_comm=FakePyNccl()),
+    )
+    gathered_indices = torch.full((4, 3), -1, dtype=torch.int32)
+    local_indices = gathered_indices[2:]
+    local_indices.fill_(20)
+    scores = torch.arange(12, dtype=torch.float32).reshape(4, 3)
+    scores_before = scores.clone()
+
+    indexer_mod._query_split_all_gather_indices(group, local_indices, gathered_indices)
+
+    assert calls == [(gathered_indices.data_ptr(), local_indices.data_ptr())]
+    assert gathered_indices.tolist() == [[10] * 3, [10] * 3, [20] * 3, [20] * 3]
+    assert torch.equal(scores, scores_before)
+
+
+def test_query_split_rejects_non_aliasing_local_indices():
+    group = types.SimpleNamespace(world_size=2, rank_in_group=0)
+    gathered_indices = torch.empty((4, 3), dtype=torch.int32)
+    local_indices = torch.empty((2, 3), dtype=torch.int32)
+
+    with pytest.raises(RuntimeError, match="must alias"):
+        indexer_mod._query_split_all_gather_indices(
+            group, local_indices, gathered_indices
+        )
+
+
 @pytest.mark.parametrize(
     "page_stride0",
     [

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -1447,6 +1447,29 @@ def get_query_split_group() -> GroupCoordinator:
     return _QUERY_SPLIT
 
 
+def _get_query_split_group_ranks(
+    tp_group_ranks: list[list[int]], dcp_size: int
+) -> list[list[int]]:
+    """Transpose DCP groups within each independent TP cohort."""
+    if dcp_size <= 0:
+        raise ValueError(f"dcp_size must be positive, got {dcp_size}")
+
+    query_split_ranks: list[list[int]] = []
+    for tp_ranks in tp_group_ranks:
+        if len(tp_ranks) % dcp_size != 0:
+            raise ValueError(
+                f"TP group size {len(tp_ranks)} must be divisible by "
+                f"dcp_size {dcp_size}"
+            )
+        dcp_groups = [
+            tp_ranks[start : start + dcp_size]
+            for start in range(0, len(tp_ranks), dcp_size)
+        ]
+        for dcp_rank in range(dcp_size):
+            query_split_ranks.append([group[dcp_rank] for group in dcp_groups])
+    return query_split_ranks
+
+
 _DCP_CKV_PREFETCH: GroupCoordinator | None = None
 
 
@@ -1946,6 +1969,7 @@ def initialize_model_parallel(
     if enable_elastic_ep:
         group_ranks = local_all_ranks.view(-1, tensor_model_parallel_size).unbind(0)
         group_ranks = [x.tolist() for x in group_ranks]
+    tp_group_ranks = group_ranks
     # message queue broadcaster is only used in tensor model parallel group
     _TP = init_model_parallel_group(
         group_ranks,
@@ -1985,9 +2009,9 @@ def initialize_model_parallel(
     global _QUERY_SPLIT
     assert _QUERY_SPLIT is None, "query split group is already initialized"
     if decode_context_model_parallel_size > 1 and envs.VLLM_DCP_QUERY_SPLIT:
-        query_split_ranks: list[list[int]] = []
-        for dcp_rank_idx in range(decode_context_model_parallel_size):
-            query_split_ranks.append([grp[dcp_rank_idx] for grp in group_ranks])
+        query_split_ranks = _get_query_split_group_ranks(
+            tp_group_ranks, decode_context_model_parallel_size
+        )
         _QUERY_SPLIT = init_model_parallel_group(
             query_split_ranks,
             get_world_group().local_rank,

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -2001,14 +2001,13 @@ def initialize_model_parallel(
         group_name="dcp",
     )
 
-    # Build the query-split groups for the indexer query split (Fix A).
-    # Ranks sharing the same dcp_rank (position within their DCP group)
-    # form a query-split group.  At TP=8/DCP=2 the DCP groups are
-    # {0,1},{2,3},{4,5},{6,7} and the query-split groups are
-    # {0,2,4,6} (dcp_rank=0) and {1,3,5,7} (dcp_rank=1).
+    # Build query-split groups for the sparse indexer. Ranks sharing the same
+    # dcp_rank form one group. This also applies to DCP=1: all TP ranks hold
+    # the same indexer inputs, so they can divide query rows and all-gather
+    # only the exact int32 top-k result.
     global _QUERY_SPLIT
     assert _QUERY_SPLIT is None, "query split group is already initialized"
-    if decode_context_model_parallel_size > 1 and envs.VLLM_DCP_QUERY_SPLIT:
+    if envs.VLLM_DCP_QUERY_SPLIT:
         query_split_ranks = _get_query_split_group_ranks(
             tp_group_ranks, decode_context_model_parallel_size
         )

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -372,6 +372,36 @@ def _dcp_all_gather_first_dim_into(
     output_tensor.copy_(gathered)
 
 
+def _query_split_all_gather_indices(
+    group,
+    local_indices: torch.Tensor,
+    gathered_indices: torch.Tensor,
+) -> None:
+    """Restore query-split rows directly into their shared index buffer."""
+    if group.world_size <= 1:
+        return
+    if not local_indices.is_contiguous() or not gathered_indices.is_contiguous():
+        raise RuntimeError("query-split top-k buffers must be contiguous")
+    if gathered_indices.shape[0] != local_indices.shape[0] * group.world_size:
+        raise RuntimeError("query-split output has an invalid row count")
+    if gathered_indices.shape[1:] != local_indices.shape[1:]:
+        raise RuntimeError("query-split output has an invalid trailing shape")
+
+    rank = int(group.rank_in_group)
+    expected_local = gathered_indices.narrow(
+        0, rank * local_indices.shape[0], local_indices.shape[0]
+    )
+    if expected_local.data_ptr() != local_indices.data_ptr():
+        raise RuntimeError(
+            "query-split local indices must alias their rank slot in the output"
+        )
+
+    # NCCL supports in-place all-gather when the send buffer aliases the
+    # rank-local slice of the receive buffer. The generic fallback in
+    # _dcp_all_gather_first_dim_into remains correct when PyNCCL is unavailable.
+    _dcp_all_gather_first_dim_into(group, local_indices, gathered_indices)
+
+
 def _unpack_b12x_dcp_gathered_candidates(
     gathered_candidates: torch.Tensor,
     candidate_indices: torch.Tensor,
@@ -1526,14 +1556,11 @@ def sparse_attn_indexer(
     qs_world_size = 1
     qs_rank = 0
     if envs.VLLM_DCP_QUERY_SPLIT and dcp_world_size > 1:
-        try:
-            _qs = get_query_split_group()
-            if int(_qs.world_size) > 1:
-                qs_group = _qs
-                qs_world_size = int(_qs.world_size)
-                qs_rank = int(_qs.rank_in_group)
-        except Exception:
-            pass
+        _qs = get_query_split_group()
+        if int(_qs.world_size) > 1:
+            qs_group = _qs
+            qs_world_size = int(_qs.world_size)
+            qs_rank = int(_qs.rank_in_group)
     if output_physical_slots:
         if not _use_b12x_sparse_indexer(use_b12x_sparse_indexer):
             raise RuntimeError(
@@ -1732,19 +1759,17 @@ def sparse_attn_indexer(
                         cp_kv_cache_interleave_size=cp_kv_cache_interleave_size,
                     )
                 if qs_active:
-                    gathered_indices = qs_group.all_gather(
-                        topk_indices.contiguous(), dim=0
-                    )
-                    topk_indices_buffer[
+                    gathered_indices = topk_indices_buffer[
                         chunk.token_start : chunk.token_end, :topk_tokens
-                    ].copy_(gathered_indices)
-                    if topk_scores is not None:
-                        gathered_scores = qs_group.all_gather(
-                            topk_scores.contiguous(), dim=0
-                        )
-                        topk_scores_buffer[
-                            chunk.token_start : chunk.token_end, :topk_tokens
-                        ].copy_(gathered_scores)
+                    ]
+                    _query_split_all_gather_indices(
+                        qs_group,
+                        topk_indices,
+                        gathered_indices,
+                    )
+                    # Scores are only needed for the DCP-local candidate merge
+                    # above. Sparse attention consumes the restored indices, so
+                    # gathering scores here would double query-split traffic.
                 continue
 
             cu_seqlen_ks = chunk.cu_seqlen_ks

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -1555,7 +1555,7 @@ def sparse_attn_indexer(
     qs_group = None
     qs_world_size = 1
     qs_rank = 0
-    if envs.VLLM_DCP_QUERY_SPLIT and dcp_world_size > 1:
+    if envs.VLLM_DCP_QUERY_SPLIT:
         _qs = get_query_split_group()
         if int(_qs.world_size) > 1:
             qs_group = _qs


### PR DESCRIPTION
## Summary

- allow the existing exact sparse-indexer query split when DCP=1, where all TP ranks otherwise repeat identical indexer work
- gather only the final contiguous int32 top-k indices in place; sparse attention does not consume the per-rank scores, so gathering scores doubled traffic
- retain the existing opt-in environment gate; deployment policy can keep unsupported or slower topologies disabled

## Why this is exact

Each TP rank owns a disjoint query-row slice, computes the same sparse top-k operation it computed before, and all-gathers the resulting int32 indices. No score, index, CKV, or activation compression is introduced. A deterministic unique 64k prompt produced the same winning token, with a baseline-vs-query logprob difference of 7.15e-7 versus 9.54e-7 baseline repeat spread.

## E2E results

GLM-5.2, MTP off, exact raw prefill, no concurrent model loading or benchmark traffic:

| Topology | Context | Before | After | Delta |
|---|---:|---:|---:|---:|
| TP8/DCP1 NVFP4 A16 | 400k | 4,403 | 5,805 tok/s | +31.8% |
| TP8/DCP1 NVFP4 A16 | 64k | ~5,860 | ~6,148 tok/s | +4.9% |
| TP4/DCP1 NF3 hybrid, same GPUs 0-3 | 64k | 4,125 | 4,226 tok/s | +2.4% |

Virtual TP6 has 11 padded heads per rank and did not benefit: DCP1 regressed about 1.1%, DCP3 regressed 15.9% at 64k and 14.7% at 400k, and DCP6 was neutral at 400k. The image helper therefore keeps this opt-in path auto-disabled for all TP6 modes.

## Tests

- `tests/distributed/test_query_split_groups.py`
- `tests/model_executor/layers/test_sparse_attn_indexer_b12x.py`
- 26 passed in the pinned v20 runtime
- TP8/DCP1 64k and 400k E2E
- TP4/DCP1 64k same-GPU A/B
- TP6 DCP1/2/3/6 64k and long-context ON/OFF validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved distributed query-split rank handling across different parallel configurations, including single-device context parallelism.
  * Added validation for invalid or incompatible query-split sizes with clear errors.
  * Improved sparse-attention index gathering to preserve shared buffers correctly and avoid unnecessary score transfers.
  * Added safeguards for non-contiguous or improperly aliased index buffers.

* **Tests**
  * Expanded coverage for query-split layouts, input validation, and sparse-attention gathering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->