### PR TITLE
[GG] perf(dcp): merge sparse prefill top-k by row owner

### DIFF
--- a/tests/model_executor/layers/test_sparse_attn_indexer_b12x.py
+++ b/tests/model_executor/layers/test_sparse_attn_indexer_b12x.py
@@ -703,6 +703,242 @@ def test_b12x_dcp_merge_passes_contiguous_scores_to_topk(monkeypatch):
     assert run_row_topk_calls == [(True, (2, 8))]
 
 
+def test_b12x_dcp_owner_merge_exact_query_split_rows(monkeypatch):
+    topk = 2
+    dcp_size = 2
+    tp_size = 4
+    tp_rank = 1
+    rows = 4
+    owner_rows = rows // dcp_size
+
+    source_ids = torch.tensor(
+        [
+            [[10, 11], [20, 21]],
+            [[12, 13], [22, 23]],
+        ],
+        dtype=torch.int32,
+    )
+    source_scores = torch.tensor(
+        [
+            [[0.10, 0.90], [0.80, 0.20]],
+            [[0.70, 0.30], [0.40, 0.60]],
+        ],
+        dtype=torch.float32,
+    )
+    received = torch.empty((dcp_size, owner_rows, 2, topk), dtype=torch.int32)
+    received[:, :, 0, :].copy_(source_ids)
+    received[:, :, 1, :].copy_(source_scores.view(torch.int32))
+
+    class FakeDCPGroup:
+        world_size = dcp_size
+
+        @staticmethod
+        def all_to_all_single(output, input_):
+            assert tuple(input_.shape) == (rows, 2, topk)
+            output.copy_(received.reshape_as(output))
+
+    class FakeTPGroup:
+        world_size = tp_size
+        rank_in_group = tp_rank
+
+        @staticmethod
+        def all_gather(input_, dim):
+            assert dim == 0
+            assert input_.tolist() == [[11, 12], [20, 23]]
+            shards = [
+                torch.tensor([[0, 1], [2, 3]], dtype=torch.int32),
+                input_.clone(),
+                torch.tensor([[40, 41], [42, 43]], dtype=torch.int32),
+                torch.tensor([[60, 61], [62, 63]], dtype=torch.int32),
+            ]
+            return torch.cat(shards, dim=0)
+
+    def run_row_topk(*, row_logits, lengths, topk, output_values, output_indices):
+        assert lengths.tolist() == [4, 4]
+        values, positions = torch.topk(row_logits, k=topk, dim=1)
+        output_values.copy_(values)
+        output_indices.copy_(positions.to(torch.int32))
+
+    _install_fake_b12x_dcp_merge(monkeypatch, run_row_topk, world_size=dcp_size)
+    monkeypatch.setattr(indexer_mod, "get_dcp_group", lambda: FakeDCPGroup())
+    monkeypatch.setattr(indexer_mod, "get_tp_group", lambda: FakeTPGroup())
+    monkeypatch.setattr(indexer_mod, "_use_triton_dcp_remap", lambda _: False)
+    workspace_manager = _FakeWorkspaceManager()
+    monkeypatch.setattr(
+        indexer_mod, "current_workspace_manager", lambda: workspace_manager
+    )
+
+    gathered_indices = torch.full((8, topk), -1, dtype=torch.int32)
+    local_indices = gathered_indices[:rows]
+    local_indices.copy_(torch.arange(rows * topk, dtype=torch.int32).view(rows, topk))
+    local_scores = torch.zeros((rows, topk), dtype=torch.float32)
+
+    used = indexer_mod._merge_b12x_dcp_topk_by_owner(
+        topk_indices=local_indices,
+        topk_scores=local_scores,
+        gathered_topk_indices=gathered_indices,
+        topk_tokens=topk,
+        dcp_world_size=dcp_size,
+        dcp_rank=1,
+        cp_kv_cache_interleave_size=16,
+    )
+
+    assert used
+    assert gathered_indices.tolist() == [
+        [0, 1],
+        [2, 3],
+        [11, 12],
+        [20, 23],
+        [40, 41],
+        [42, 43],
+        [60, 61],
+        [62, 63],
+    ]
+    assert workspace_manager.specs == (
+        ((4, 2, 2), torch.int32),
+        ((4, 2, 2), torch.int32),
+        ((2, 4), torch.int32),
+        ((2, 4), torch.int32),
+        ((2,), torch.int32),
+        ((2, 2), torch.float32),
+        ((2, 2), torch.int32),
+        ((2, 2), torch.int32),
+    )
+
+
+def test_b12x_dcp_owner_merge_supports_tp_equal_dcp(monkeypatch):
+    topk = 2
+    dcp_size = 4
+    rows = 4
+    received_ids = torch.tensor([10, 20, 30, 40], dtype=torch.int32)
+    received_scores = torch.tensor([0.1, 0.9, 0.7, 0.3], dtype=torch.float32)
+
+    class FakeDCPGroup:
+        world_size = dcp_size
+
+        @staticmethod
+        def all_to_all_single(output, input_):
+            output_view = output.view(dcp_size, 1, 2, topk)
+            output_view[:, 0, 0, 0].copy_(received_ids)
+            output_view[:, 0, 0, 1].fill_(-1)
+            output_view[:, 0, 1, 0].copy_(received_scores.view(torch.int32))
+            output_view[:, 0, 1, 1].fill_(
+                torch.tensor(-float("inf"), dtype=torch.float32).view(torch.int32)
+            )
+
+    class FakeTPGroup:
+        world_size = dcp_size
+        rank_in_group = 2
+
+        @staticmethod
+        def all_gather(input_, dim):
+            assert dim == 0
+            assert input_.tolist() == [[20, 30]]
+            return torch.tensor(
+                [[0, 1], [10, 11], [20, 30], [40, 41]], dtype=torch.int32
+            )
+
+    def run_row_topk(*, row_logits, lengths, topk, output_values, output_indices):
+        values, positions = torch.topk(row_logits, k=topk, dim=1)
+        output_values.copy_(values)
+        output_indices.copy_(positions.to(torch.int32))
+
+    _install_fake_b12x_dcp_merge(monkeypatch, run_row_topk, world_size=dcp_size)
+    monkeypatch.setattr(indexer_mod, "get_dcp_group", lambda: FakeDCPGroup())
+    monkeypatch.setattr(indexer_mod, "get_tp_group", lambda: FakeTPGroup())
+    monkeypatch.setattr(indexer_mod, "_use_triton_dcp_remap", lambda _: False)
+    monkeypatch.setattr(
+        indexer_mod,
+        "current_workspace_manager",
+        lambda: _FakeWorkspaceManager(),
+    )
+
+    indices = torch.arange(rows * topk, dtype=torch.int32).view(rows, topk)
+    scores = torch.zeros((rows, topk), dtype=torch.float32)
+    used = indexer_mod._merge_b12x_dcp_topk_by_owner(
+        topk_indices=indices,
+        topk_scores=scores,
+        gathered_topk_indices=indices,
+        topk_tokens=topk,
+        dcp_world_size=dcp_size,
+        dcp_rank=2,
+        cp_kv_cache_interleave_size=16,
+    )
+
+    assert used
+    assert indices.tolist() == [[0, 1], [10, 11], [20, 30], [40, 41]]
+
+
+def test_b12x_dcp_owner_merge_falls_back_for_tail(monkeypatch):
+    monkeypatch.setattr(
+        indexer_mod,
+        "get_tp_group",
+        lambda: pytest.fail("tail fallback must not initialize a TP collective"),
+    )
+    topk_indices = torch.zeros((3, 2), dtype=torch.int32)
+    topk_scores = torch.zeros((3, 2), dtype=torch.float32)
+
+    assert not indexer_mod._merge_b12x_dcp_topk_by_owner(
+        topk_indices=topk_indices,
+        topk_scores=topk_scores,
+        gathered_topk_indices=torch.empty((6, 2), dtype=torch.int32),
+        topk_tokens=2,
+        dcp_world_size=2,
+        dcp_rank=0,
+        cp_kv_cache_interleave_size=16,
+    )
+
+
+@pytest.mark.parametrize(
+    ("enabled", "owner_result", "expected_owner_calls", "expected_oracle_calls"),
+    [
+        (False, True, 0, 1),
+        (True, False, 1, 1),
+        (True, True, 1, 0),
+    ],
+)
+def test_b12x_prefill_dcp_topk_routes_owner_or_oracle(
+    monkeypatch,
+    enabled,
+    owner_result,
+    expected_owner_calls,
+    expected_oracle_calls,
+):
+    owner_calls = []
+    oracle_calls = []
+
+    def fake_owner(**kwargs):
+        owner_calls.append(kwargs)
+        return owner_result
+
+    def fake_oracle(**kwargs):
+        oracle_calls.append(kwargs)
+
+    monkeypatch.setattr(
+        indexer_mod.envs,
+        "VLLM_DCP_TOPK_OWNER_MERGE",
+        enabled,
+    )
+    monkeypatch.setattr(indexer_mod, "_merge_b12x_dcp_topk_by_owner", fake_owner)
+    monkeypatch.setattr(indexer_mod, "_merge_b12x_dcp_topk", fake_oracle)
+
+    indices = torch.empty((4, 2), dtype=torch.int32)
+    scores = torch.empty((4, 2), dtype=torch.float32)
+    used = indexer_mod._merge_b12x_prefill_dcp_topk(
+        topk_indices=indices,
+        topk_scores=scores,
+        gathered_topk_indices=indices,
+        topk_tokens=2,
+        dcp_world_size=2,
+        dcp_rank=0,
+        cp_kv_cache_interleave_size=16,
+    )
+
+    assert used is (enabled and owner_result)
+    assert len(owner_calls) == expected_owner_calls
+    assert len(oracle_calls) == expected_oracle_calls
+
+
 def test_b12x_dcp_merge_warmup_reserves_workspace(monkeypatch):
     def run_row_topk(*, row_logits, lengths, topk, output_values, output_indices):
         positions = torch.arange(topk, dtype=output_indices.dtype).expand_as(

--- a/tests/model_executor/layers/test_sparse_attn_indexer_b12x.py
+++ b/tests/model_executor/layers/test_sparse_attn_indexer_b12x.py
@@ -760,7 +760,29 @@ def test_b12x_dcp_owner_merge_exact_query_split_rows(monkeypatch):
         output_indices.copy_(positions.to(torch.int32))
 
     _install_fake_b12x_dcp_merge(monkeypatch, run_row_topk, world_size=dcp_size)
-    monkeypatch.setattr(indexer_mod, "get_dcp_group", lambda: FakeDCPGroup())
+
+    class ConfiguredDCPGroup:
+        world_size = tp_size
+
+        @staticmethod
+        def all_to_all_single(*args, **kwargs):
+            raise AssertionError("owner merge must use the indexer shard group")
+
+    selected_world_sizes = []
+
+    def get_indexer_dcp_group(expected_world_size):
+        selected_world_sizes.append(expected_world_size)
+        return FakeDCPGroup()
+
+    from vllm.distributed import parallel_state
+
+    monkeypatch.setattr(
+        parallel_state,
+        "get_indexer_dcp_group",
+        get_indexer_dcp_group,
+        raising=False,
+    )
+    monkeypatch.setattr(indexer_mod, "get_dcp_group", lambda: ConfiguredDCPGroup())
     monkeypatch.setattr(indexer_mod, "get_tp_group", lambda: FakeTPGroup())
     monkeypatch.setattr(indexer_mod, "_use_triton_dcp_remap", lambda _: False)
     workspace_manager = _FakeWorkspaceManager()
@@ -784,6 +806,7 @@ def test_b12x_dcp_owner_merge_exact_query_split_rows(monkeypatch):
     )
 
     assert used
+    assert selected_world_sizes == [dcp_size]
     assert gathered_indices.tolist() == [
         [0, 1],
         [2, 3],
@@ -844,7 +867,11 @@ def test_b12x_dcp_owner_merge_supports_tp_equal_dcp(monkeypatch):
         output_indices.copy_(positions.to(torch.int32))
 
     _install_fake_b12x_dcp_merge(monkeypatch, run_row_topk, world_size=dcp_size)
-    monkeypatch.setattr(indexer_mod, "get_dcp_group", lambda: FakeDCPGroup())
+    monkeypatch.setattr(
+        indexer_mod,
+        "_get_owner_merge_dcp_group",
+        lambda expected_world_size: FakeDCPGroup(),
+    )
     monkeypatch.setattr(indexer_mod, "get_tp_group", lambda: FakeTPGroup())
     monkeypatch.setattr(indexer_mod, "_use_triton_dcp_remap", lambda _: False)
     monkeypatch.setattr(

--- a/tests/model_executor/layers/test_sparse_attn_indexer_b12x.py
+++ b/tests/model_executor/layers/test_sparse_attn_indexer_b12x.py
@@ -782,8 +782,8 @@ def test_b12x_dcp_owner_merge_exact_query_split_rows(monkeypatch):
         get_indexer_dcp_group,
         raising=False,
     )
-    monkeypatch.setattr(indexer_mod, "get_dcp_group", lambda: ConfiguredDCPGroup())
-    monkeypatch.setattr(indexer_mod, "get_tp_group", lambda: FakeTPGroup())
+    monkeypatch.setattr(parallel_state, "get_dcp_group", lambda: ConfiguredDCPGroup())
+    monkeypatch.setattr(parallel_state, "get_tp_group", lambda: FakeTPGroup())
     monkeypatch.setattr(indexer_mod, "_use_triton_dcp_remap", lambda _: False)
     workspace_manager = _FakeWorkspaceManager()
     monkeypatch.setattr(
@@ -867,12 +867,14 @@ def test_b12x_dcp_owner_merge_supports_tp_equal_dcp(monkeypatch):
         output_indices.copy_(positions.to(torch.int32))
 
     _install_fake_b12x_dcp_merge(monkeypatch, run_row_topk, world_size=dcp_size)
+    from vllm.distributed import parallel_state
+
     monkeypatch.setattr(
         indexer_mod,
         "_get_owner_merge_dcp_group",
         lambda expected_world_size: FakeDCPGroup(),
     )
-    monkeypatch.setattr(indexer_mod, "get_tp_group", lambda: FakeTPGroup())
+    monkeypatch.setattr(parallel_state, "get_tp_group", lambda: FakeTPGroup())
     monkeypatch.setattr(indexer_mod, "_use_triton_dcp_remap", lambda _: False)
     monkeypatch.setattr(
         indexer_mod,
@@ -897,8 +899,10 @@ def test_b12x_dcp_owner_merge_supports_tp_equal_dcp(monkeypatch):
 
 
 def test_b12x_dcp_owner_merge_falls_back_for_tail(monkeypatch):
+    from vllm.distributed import parallel_state
+
     monkeypatch.setattr(
-        indexer_mod,
+        parallel_state,
         "get_tp_group",
         lambda: pytest.fail("tail fallback must not initialize a TP collective"),
     )

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -76,6 +76,7 @@ if TYPE_CHECKING:
     VLLM_DCP_SHARD_DRAFT: str | None = None
     VLLM_DCP_GLOBAL_TOPK: bool = True
     VLLM_DCP_QUERY_SPLIT: bool = False
+    VLLM_DCP_TOPK_OWNER_MERGE: bool = False
     VLLM_B12X_MLA_CKV_GATHER: bool = False
     VLLM_B12X_MLA_CKV_GATHER_MIN_TOKENS: int = 16
     VLLM_B12X_MLA_CKV_GATHER_MAX_TOKENS: int = 524288
@@ -1167,6 +1168,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     "VLLM_DCP_QUERY_SPLIT": lambda: (
         os.getenv("VLLM_DCP_QUERY_SPLIT", "0").lower() in ("1", "true", "yes", "on")
+    ),
+    # Send each query row's exact FP32 top-k candidates to one DCP owner, merge
+    # once there, then gather only the final indices over TP. This is an
+    # opt-in prefill path until the full TP/DCP validation matrix is complete.
+    "VLLM_DCP_TOPK_OWNER_MERGE": lambda: (
+        os.getenv("VLLM_DCP_TOPK_OWNER_MERGE", "0").lower()
+        in ("1", "true", "yes", "on")
     ),
     "VLLM_B12X_MLA_CKV_GATHER": lambda: (
         os.getenv("VLLM_B12X_MLA_CKV_GATHER", "0").lower() in ("1", "true", "yes", "on")

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -10,7 +10,7 @@ import vllm.envs as envs
 from vllm import _custom_ops as ops
 from vllm._aiter_ops import rocm_aiter_ops
 from vllm.config import CUDAGraphMode, get_current_vllm_config
-from vllm.distributed import get_dcp_group, get_query_split_group, get_tp_group
+from vllm.distributed import get_dcp_group, get_query_split_group
 from vllm.forward_context import get_forward_context
 from vllm.model_executor.custom_op import CustomOp
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
@@ -344,34 +344,6 @@ def _dcp_finalize_topk_remap(
     topk_indices.copy_(final.to(topk_indices.dtype))
 
 
-def _dcp_all_gather_first_dim_into(
-    group,
-    input_tensor: torch.Tensor,
-    output_tensor: torch.Tensor,
-) -> None:
-    """All-gather into caller-owned output, concatenating along dim 0."""
-    assert input_tensor.is_contiguous()
-    assert output_tensor.is_contiguous()
-    assert output_tensor.shape[0] == input_tensor.shape[0] * group.world_size
-    assert output_tensor.shape[1:] == input_tensor.shape[1:]
-
-    communicator = getattr(group, "device_communicator", None)
-    pynccl_comm = getattr(communicator, "pynccl_comm", None)
-    if pynccl_comm is not None and not getattr(pynccl_comm, "disabled", False):
-        pynccl_comm.all_gather(output_tensor, input_tensor)
-        return
-
-    device_group = getattr(communicator, "device_group", None)
-    if device_group is not None:
-        import torch.distributed as dist
-
-        dist.all_gather_into_tensor(output_tensor, input_tensor, group=device_group)
-        return
-
-    gathered = group.all_gather(input_tensor, dim=0)
-    output_tensor.copy_(gathered)
-
-
 def _dcp_all_to_all_first_dim_into(
     group,
     input_tensor: torch.Tensor,
@@ -406,6 +378,34 @@ def _dcp_all_to_all_first_dim_into(
         input_tensor.view(-1),
         group=device_group,
     )
+
+
+def _dcp_all_gather_first_dim_into(
+    group,
+    input_tensor: torch.Tensor,
+    output_tensor: torch.Tensor,
+) -> None:
+    """All-gather into caller-owned output, concatenating along dim 0."""
+    assert input_tensor.is_contiguous()
+    assert output_tensor.is_contiguous()
+    assert output_tensor.shape[0] == input_tensor.shape[0] * group.world_size
+    assert output_tensor.shape[1:] == input_tensor.shape[1:]
+
+    communicator = getattr(group, "device_communicator", None)
+    pynccl_comm = getattr(communicator, "pynccl_comm", None)
+    if pynccl_comm is not None and not getattr(pynccl_comm, "disabled", False):
+        pynccl_comm.all_gather(output_tensor, input_tensor)
+        return
+
+    device_group = getattr(communicator, "device_group", None)
+    if device_group is not None:
+        import torch.distributed as dist
+
+        dist.all_gather_into_tensor(output_tensor, input_tensor, group=device_group)
+        return
+
+    gathered = group.all_gather(input_tensor, dim=0)
+    output_tensor.copy_(gathered)
 
 
 def _unpack_b12x_dcp_gathered_candidates(
@@ -1160,7 +1160,11 @@ def _get_owner_merge_dcp_group(expected_world_size: int):
     from vllm.distributed import parallel_state
 
     selector = getattr(parallel_state, "get_indexer_dcp_group", None)
-    group = selector(expected_world_size) if selector is not None else get_dcp_group()
+    group = (
+        selector(expected_world_size)
+        if selector is not None
+        else parallel_state.get_dcp_group()
+    )
     if int(group.world_size) != int(expected_world_size):
         raise RuntimeError(
             "DCP owner top-k group does not match the indexer KV shard count: "
@@ -1200,7 +1204,9 @@ def _merge_b12x_dcp_topk_by_owner(
     if rows % int(dcp_world_size) != 0:
         return False
 
-    tp_group = get_tp_group()
+    from vllm.distributed import parallel_state
+
+    tp_group = parallel_state.get_tp_group()
     tp_world_size = int(tp_group.world_size)
     tp_rank = int(tp_group.rank_in_group)
     if tp_world_size % int(dcp_world_size) != 0:
@@ -1960,7 +1966,9 @@ def sparse_attn_indexer(
                         dcp_rank=dcp_rank,
                         cp_kv_cache_interleave_size=cp_kv_cache_interleave_size,
                     )
-                if qs_active and not used_owner_merge:
+                if used_owner_merge:
+                    continue
+                if qs_active:
                     gathered_indices = qs_group.all_gather(
                         topk_indices.contiguous(), dim=0
                     )

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -10,7 +10,7 @@ import vllm.envs as envs
 from vllm import _custom_ops as ops
 from vllm._aiter_ops import rocm_aiter_ops
 from vllm.config import CUDAGraphMode, get_current_vllm_config
-from vllm.distributed import get_dcp_group, get_query_split_group
+from vllm.distributed import get_dcp_group, get_query_split_group, get_tp_group
 from vllm.forward_context import get_forward_context
 from vllm.model_executor.custom_op import CustomOp
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
@@ -370,6 +370,42 @@ def _dcp_all_gather_first_dim_into(
 
     gathered = group.all_gather(input_tensor, dim=0)
     output_tensor.copy_(gathered)
+
+
+def _dcp_all_to_all_first_dim_into(
+    group,
+    input_tensor: torch.Tensor,
+    output_tensor: torch.Tensor,
+) -> None:
+    """Exchange equal contiguous row shards into caller-owned storage."""
+    if not input_tensor.is_contiguous() or not output_tensor.is_contiguous():
+        raise RuntimeError("DCP top-k all-to-all buffers must be contiguous")
+    if input_tensor.shape != output_tensor.shape:
+        raise RuntimeError("DCP top-k all-to-all buffers must have matching shapes")
+    if input_tensor.shape[0] % int(group.world_size) != 0:
+        raise RuntimeError("DCP top-k rows must divide the DCP world size")
+
+    # A small fake group uses this hook in unit tests. Production
+    # GroupCoordinator instances expose the NCCL process group instead.
+    all_to_all_single = getattr(group, "all_to_all_single", None)
+    if all_to_all_single is not None:
+        all_to_all_single(output_tensor, input_tensor)
+        return
+
+    device_group = getattr(group, "device_group", None)
+    if device_group is None:
+        communicator = getattr(group, "device_communicator", None)
+        device_group = getattr(communicator, "device_group", None)
+    if device_group is None:
+        raise RuntimeError("DCP group does not expose an all-to-all process group")
+
+    import torch.distributed as dist
+
+    dist.all_to_all_single(
+        output_tensor.view(-1),
+        input_tensor.view(-1),
+        group=device_group,
+    )
 
 
 def _unpack_b12x_dcp_gathered_candidates(
@@ -1104,6 +1140,166 @@ def _merge_b12x_dcp_topk(
     )
 
 
+def _merge_b12x_dcp_topk_by_owner(
+    *,
+    topk_indices: torch.Tensor,
+    topk_scores: torch.Tensor | None,
+    gathered_topk_indices: torch.Tensor,
+    topk_tokens: int,
+    dcp_world_size: int,
+    dcp_rank: int,
+    cp_kv_cache_interleave_size: int,
+) -> bool:
+    """Merge each prefill row's exact candidates on one DCP rank.
+
+    Query split partitions rows across DCP groups. Within each group, an
+    all-to-all routes contiguous row shards to their owners. Every owner runs
+    the same rank-major FP32 top-k merge as the replicated path, and a final TP
+    all-gather restores rows in query-partition/owner order. ``False`` means
+    that a tail shape cannot be partitioned exactly and must use the existing
+    replicated merge.
+    """
+    if dcp_world_size <= 1 or topk_indices.numel() == 0:
+        return False
+    if topk_scores is None:
+        raise RuntimeError(
+            "B12X sparse indexer DCP requires a topk_scores_buffer for "
+            "cross-rank candidate merge."
+        )
+
+    rows = int(topk_indices.shape[0])
+    if rows % int(dcp_world_size) != 0:
+        return False
+
+    tp_group = get_tp_group()
+    tp_world_size = int(tp_group.world_size)
+    tp_rank = int(tp_group.rank_in_group)
+    if tp_world_size % int(dcp_world_size) != 0:
+        return False
+    if tp_rank % int(dcp_world_size) != int(dcp_rank):
+        raise RuntimeError("TP and DCP rank layouts disagree for owner top-k merge")
+
+    query_partitions = tp_world_size // int(dcp_world_size)
+    expected_rows = rows * query_partitions
+    if int(gathered_topk_indices.shape[0]) != expected_rows:
+        return False
+    if gathered_topk_indices.shape[1:] != topk_indices.shape[1:]:
+        raise RuntimeError("DCP owner top-k output has an invalid trailing shape")
+
+    query_partition = tp_rank // int(dcp_world_size)
+    expected_local = gathered_topk_indices.narrow(0, query_partition * rows, rows)
+    if expected_local.data_ptr() != topk_indices.data_ptr():
+        raise RuntimeError(
+            "DCP owner top-k local rows must alias their TP query partition"
+        )
+
+    from sparkinfer.attention.nsa_indexer.tiled_topk import run_row_topk
+
+    from vllm.v1.attention.backends.mla.sparse_utils import (
+        triton_convert_dcp_local_topk_to_global,
+        triton_gather_topk_ids_by_position,
+    )
+
+    triton_convert_dcp_local_topk_to_global(
+        topk_indices,
+        topk_scores,
+        dcp_world_size=dcp_world_size,
+        dcp_rank=dcp_rank,
+        cp_kv_cache_interleave_size=cp_kv_cache_interleave_size,
+    )
+    if not topk_scores.is_contiguous():
+        raise RuntimeError("B12X sparse indexer DCP requires contiguous topk scores.")
+
+    owner_rows = rows // int(dcp_world_size)
+    candidate_width = int(dcp_world_size * topk_tokens)
+    (
+        candidates,
+        received_candidates,
+        candidate_indices,
+        candidate_score_bits,
+        candidate_lengths,
+        owner_values,
+        owner_positions,
+        owner_indices,
+    ) = current_workspace_manager().get_simultaneous(
+        ((rows, 2, int(topk_tokens)), torch.int32),
+        ((rows, 2, int(topk_tokens)), torch.int32),
+        ((owner_rows, candidate_width), torch.int32),
+        ((owner_rows, candidate_width), torch.int32),
+        ((owner_rows,), torch.int32),
+        ((owner_rows, int(topk_tokens)), torch.float32),
+        ((owner_rows, int(topk_tokens)), torch.int32),
+        ((owner_rows, int(topk_tokens)), torch.int32),
+    )
+    candidates[:, 0, :].copy_(topk_indices)
+    candidates[:, 1, :].copy_(topk_scores.view(torch.int32))
+
+    _dcp_all_to_all_first_dim_into(
+        get_dcp_group(),
+        candidates,
+        received_candidates,
+    )
+    _unpack_b12x_dcp_gathered_candidates(
+        received_candidates,
+        candidate_indices,
+        candidate_score_bits,
+        dcp_world_size=dcp_world_size,
+        topk_tokens=int(topk_tokens),
+    )
+    candidate_lengths.fill_(candidate_width)
+    run_row_topk(
+        row_logits=candidate_score_bits.view(torch.float32),
+        lengths=candidate_lengths,
+        topk=int(topk_tokens),
+        output_values=owner_values,
+        output_indices=owner_positions,
+    )
+    triton_gather_topk_ids_by_position(
+        candidate_indices,
+        owner_positions,
+        owner_indices,
+    )
+    _dcp_all_gather_first_dim_into(
+        tp_group,
+        owner_indices,
+        gathered_topk_indices,
+    )
+    return True
+
+
+def _merge_b12x_prefill_dcp_topk(
+    *,
+    topk_indices: torch.Tensor,
+    topk_scores: torch.Tensor | None,
+    gathered_topk_indices: torch.Tensor,
+    topk_tokens: int,
+    dcp_world_size: int,
+    dcp_rank: int,
+    cp_kv_cache_interleave_size: int,
+) -> bool:
+    """Select the opt-in owner merge or the established replicated oracle."""
+    if envs.VLLM_DCP_TOPK_OWNER_MERGE and _merge_b12x_dcp_topk_by_owner(
+        topk_indices=topk_indices,
+        topk_scores=topk_scores,
+        gathered_topk_indices=gathered_topk_indices,
+        topk_tokens=topk_tokens,
+        dcp_world_size=dcp_world_size,
+        dcp_rank=dcp_rank,
+        cp_kv_cache_interleave_size=cp_kv_cache_interleave_size,
+    ):
+        return True
+
+    _merge_b12x_dcp_topk(
+        topk_indices=topk_indices,
+        topk_scores=topk_scores,
+        topk_tokens=topk_tokens,
+        dcp_world_size=dcp_world_size,
+        dcp_rank=dcp_rank,
+        cp_kv_cache_interleave_size=cp_kv_cache_interleave_size,
+    )
+    return False
+
+
 def _convert_b12x_dcp_local_topk_to_global(
     *,
     topk_indices: torch.Tensor,
@@ -1715,15 +1911,19 @@ def sparse_attn_indexer(
                     output_physical_slots=output_physical_slots,
                 )
                 if dcp_global_topk:
-                    _merge_b12x_dcp_topk(
+                    used_owner_merge = _merge_b12x_prefill_dcp_topk(
                         topk_indices=topk_indices,
                         topk_scores=topk_scores,
+                        gathered_topk_indices=topk_indices_buffer[
+                            chunk.token_start : chunk.token_end, :topk_tokens
+                        ],
                         topk_tokens=topk_tokens,
                         dcp_world_size=dcp_world_size,
                         dcp_rank=dcp_rank,
                         cp_kv_cache_interleave_size=cp_kv_cache_interleave_size,
                     )
                 else:
+                    used_owner_merge = False
                     _convert_b12x_dcp_local_topk_to_global(
                         topk_indices=topk_indices,
                         topk_scores=topk_scores,
@@ -1731,7 +1931,7 @@ def sparse_attn_indexer(
                         dcp_rank=dcp_rank,
                         cp_kv_cache_interleave_size=cp_kv_cache_interleave_size,
                     )
-                if qs_active:
+                if qs_active and not used_owner_merge:
                     gathered_indices = qs_group.all_gather(
                         topk_indices.contiguous(), dim=0
                     )

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -1140,6 +1140,35 @@ def _merge_b12x_dcp_topk(
     )
 
 
+def _get_owner_merge_dcp_group(expected_world_size: int):
+    """Return the collective group that owns the indexer's KV shards.
+
+    Partial indexer replication may use fewer KV shards than the model's
+    configured DCP size. The partial-topology extension provides a dedicated
+    selector for that case; without it, the regular DCP group remains the
+    standalone owner-merge contract.
+
+    Args:
+        expected_world_size: Number of KV shards participating in the merge.
+
+    Returns:
+        The process group whose world size matches ``expected_world_size``.
+
+    Raises:
+        RuntimeError: If the selected group does not match the indexer layout.
+    """
+    from vllm.distributed import parallel_state
+
+    selector = getattr(parallel_state, "get_indexer_dcp_group", None)
+    group = selector(expected_world_size) if selector is not None else get_dcp_group()
+    if int(group.world_size) != int(expected_world_size):
+        raise RuntimeError(
+            "DCP owner top-k group does not match the indexer KV shard count: "
+            f"group={group.world_size}, shards={expected_world_size}"
+        )
+    return group
+
+
 def _merge_b12x_dcp_topk_by_owner(
     *,
     topk_indices: torch.Tensor,
@@ -1235,7 +1264,7 @@ def _merge_b12x_dcp_topk_by_owner(
     candidates[:, 1, :].copy_(topk_scores.view(torch.int32))
 
     _dcp_all_to_all_first_dim_into(
-        get_dcp_group(),
+        _get_owner_merge_dcp_group(dcp_world_size),
         candidates,
         received_candidates,
     )


### PR DESCRIPTION
## Summary

Add an opt-in exact 2D owner merge for sharded sparse-indexer top-k during DCP prefill.

Instead of replicating every rank's candidate rows to every other rank, the path:

1. routes each contiguous query-row shard to its DCP owner,
2. performs the exact row top-k over FP32 candidate scores on that owner, and
3. all-gathers only the final int32 indices to restore TP query order.

`VLLM_DCP_TOPK_OWNER_MERGE=0` remains the default. Unsupported shapes and tail rows return to the existing replicated NCCL oracle.

## Why

Query split reduces indexer compute, but the existing global top-k merge still replicates all candidate scores and indices. The owner layout preserves sharded scoring and exact FP32 selection while reducing candidate workspace and communication.

## Results

GLM-5.2 NVFP4, 8x RTX PRO 6000 Blackwell, TP8/DCP4/MTP0/A16, query split plus full-CKV gather:

| Context | Existing oracle | Owner merge | Delta |
|---:|---:|---:|---:|
| 64k | 5,353.7 +/- 4.5 tok/s | 5,766.3 +/- 10.6 tok/s | +7.71% |
| 400k | 4,670.1 tok/s | 5,047.8 +/- 8.5 tok/s | +8.09% |

At the 131k planning profile, KV capacity increased from 2,140,416 to 2,186,496 tokens (+2.15%) because the owner path reserves a smaller candidate-merge workspace.

## Correctness and fallback

- Candidate scores remain FP32; this is not a lossy transport.
- Query-split TP/DCP rank mapping is checked before dispatch.
- TP=DCP and TP>DCP layouts are covered.
- Non-divisible row tails fall back to the established oracle before initializing a new collective.
- The feature is isolated from replicated-indexer mode.

## Validation

- `22 passed` in `tests/model_executor/layers/test_sparse_attn_indexer_b12x.py` against the exact installed overlay.
- `ruff check` and `ruff format --check` pass for all modified files.
- TP8/DCP4 E2E measurements completed at 64k and 400k with no request errors.

The separate SparkInfer candidate transport is intentionally not part of this PR. This change uses standard vLLM collectives and is independently useful.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in configuration for optimized B12X prefill top-k routing across parallel processing groups.
  * Improved sparse attention routing to merge candidates at their owning shard when supported.
  * Added automatic fallback to the existing routing behavior for unsupported partition layouts.

* **Tests**
  * Added coverage for shard splitting, parallel group configurations, fallback handling, and routing selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->