### PR TITLE
[GG] feat(dcp): support partial replicated sparse-indexer topology

### DIFF
--- a/tests/distributed/test_indexer_parallel_groups.py
+++ b/tests/distributed/test_indexer_parallel_groups.py
@@ -6,7 +6,10 @@ from types import SimpleNamespace
 import pytest
 
 from vllm.distributed import parallel_state
-from vllm.distributed.parallel_state import _build_indexer_replica_group_ranks
+from vllm.distributed.parallel_state import (
+    _build_indexer_replica_group_ranks,
+    _validate_indexer_shard_count,
+)
 
 
 def test_build_indexer_two_by_four_groups_for_tp8():
@@ -44,6 +47,17 @@ def test_build_indexer_replica_groups_stay_inside_each_tp_group():
 def test_build_indexer_replica_groups_rejects_non_divisor():
     with pytest.raises(ValueError, match="must divide"):
         _build_indexer_replica_group_ranks([list(range(8))], 3)
+
+
+@pytest.mark.parametrize("indexer_shards", [0, 1, 2, 4])
+def test_validate_indexer_shard_count_accepts_supported_dcp4_layouts(indexer_shards):
+    _validate_indexer_shard_count(indexer_shards, 4)
+
+
+@pytest.mark.parametrize("indexer_shards", [-1, 3, 5, 8])
+def test_validate_indexer_shard_count_rejects_invalid_dcp4_layouts(indexer_shards):
+    with pytest.raises(ValueError, match=r"shards=.*DCP=4"):
+        _validate_indexer_shard_count(indexer_shards, 4)
 
 
 def test_indexer_group_selector_supports_partial_target_and_full_draft(monkeypatch):

--- a/tests/distributed/test_indexer_parallel_groups.py
+++ b/tests/distributed/test_indexer_parallel_groups.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm.distributed.parallel_state import _build_indexer_replica_group_ranks
+
+
+def test_build_indexer_two_by_four_groups_for_tp8():
+    dcp_groups, query_split_groups = _build_indexer_replica_group_ranks(
+        [[0, 1, 2, 3, 4, 5, 6, 7]], 4
+    )
+
+    assert dcp_groups == [[0, 1, 2, 3], [4, 5, 6, 7]]
+    assert query_split_groups == [[0, 4], [1, 5], [2, 6], [3, 7]]
+
+
+def test_build_indexer_replica_groups_stay_inside_each_tp_group():
+    dcp_groups, query_split_groups = _build_indexer_replica_group_ranks(
+        [list(range(8)), list(range(8, 16))], 4
+    )
+
+    assert dcp_groups == [
+        [0, 1, 2, 3],
+        [4, 5, 6, 7],
+        [8, 9, 10, 11],
+        [12, 13, 14, 15],
+    ]
+    assert query_split_groups == [
+        [0, 4],
+        [1, 5],
+        [2, 6],
+        [3, 7],
+        [8, 12],
+        [9, 13],
+        [10, 14],
+        [11, 15],
+    ]
+
+
+def test_build_indexer_replica_groups_rejects_non_divisor():
+    with pytest.raises(ValueError, match="must divide"):
+        _build_indexer_replica_group_ranks([list(range(8))], 3)

--- a/tests/distributed/test_indexer_parallel_groups.py
+++ b/tests/distributed/test_indexer_parallel_groups.py
@@ -1,8 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from types import SimpleNamespace
+
 import pytest
 
+from vllm.distributed import parallel_state
 from vllm.distributed.parallel_state import _build_indexer_replica_group_ranks
 
 
@@ -41,3 +44,29 @@ def test_build_indexer_replica_groups_stay_inside_each_tp_group():
 def test_build_indexer_replica_groups_rejects_non_divisor():
     with pytest.raises(ValueError, match="must divide"):
         _build_indexer_replica_group_ranks([list(range(8))], 3)
+
+
+def test_indexer_group_selector_supports_partial_target_and_full_draft(monkeypatch):
+    partial_dcp = SimpleNamespace(world_size=2)
+    full_dcp = SimpleNamespace(world_size=4)
+    partial_query_split = SimpleNamespace(world_size=4)
+    full_query_split = SimpleNamespace(world_size=2)
+    monkeypatch.setattr(parallel_state, "_INDEXER_DCP", partial_dcp)
+    monkeypatch.setattr(parallel_state, "_DCP", full_dcp)
+    monkeypatch.setattr(parallel_state, "_INDEXER_QUERY_SPLIT", partial_query_split)
+    monkeypatch.setattr(parallel_state, "_QUERY_SPLIT", full_query_split)
+
+    assert parallel_state.get_indexer_dcp_group(2) is partial_dcp
+    assert parallel_state.get_indexer_dcp_group(4) is full_dcp
+    assert parallel_state.get_indexer_query_split_group(2) is partial_query_split
+    assert parallel_state.get_indexer_query_split_group(4) is full_query_split
+
+
+def test_indexer_group_selector_rejects_unknown_shard_count(monkeypatch):
+    monkeypatch.setattr(parallel_state, "_INDEXER_DCP", SimpleNamespace(world_size=2))
+    monkeypatch.setattr(parallel_state, "_DCP", SimpleNamespace(world_size=4))
+
+    with pytest.raises(RuntimeError, match="requested=3, partial=2, configured=4"):
+        parallel_state.get_indexer_dcp_group(3)
+    with pytest.raises(RuntimeError, match="requested=3, partial=2, configured=4"):
+        parallel_state.get_indexer_query_split_group(3)

--- a/tests/model_executor/layers/test_sparse_attn_indexer_b12x.py
+++ b/tests/model_executor/layers/test_sparse_attn_indexer_b12x.py
@@ -40,7 +40,7 @@ def test_replicated_constructor_uses_single_rank_without_dcp_group(monkeypatch):
     def init_module(self):
         torch.nn.Module.__init__(self)
 
-    def fail_dcp_group():
+    def fail_dcp_group(*_args):
         pytest.fail("replicated indexer construction must not query the DCP group")
 
     monkeypatch.setattr(indexer_mod.CustomOp, "__init__", init_module)
@@ -72,6 +72,48 @@ def test_replicated_constructor_uses_single_rank_without_dcp_group(monkeypatch):
     assert indexer.dcp_replicated is True
     assert indexer.dcp_world_size == 1
     assert indexer.dcp_rank == 0
+
+
+@pytest.mark.parametrize("kv_shards", [2, 4])
+def test_sharded_constructor_requests_group_matching_kv_shards(monkeypatch, kv_shards):
+    def init_module(self):
+        torch.nn.Module.__init__(self)
+
+    requested_sizes: list[int] = []
+
+    def get_group(expected_world_size):
+        requested_sizes.append(expected_world_size)
+        return types.SimpleNamespace(world_size=expected_world_size, rank_in_group=1)
+
+    monkeypatch.setattr(indexer_mod.CustomOp, "__init__", init_module)
+    monkeypatch.setattr(
+        indexer_mod,
+        "get_current_vllm_config",
+        lambda: types.SimpleNamespace(
+            parallel_config=types.SimpleNamespace(
+                decode_context_parallel_size=4,
+                cp_kv_cache_interleave_size=1,
+            )
+        ),
+    )
+    monkeypatch.setattr(indexer_mod, "get_indexer_dcp_group", get_group)
+    monkeypatch.setattr(indexer_mod, "use_b12x_sparse_indexer", lambda: True)
+
+    indexer = indexer_mod.SparseAttnIndexer(
+        k_cache=torch.nn.Identity(),
+        quant_block_size=128,
+        scale_fmt="ue8m0",
+        topk_tokens=4,
+        head_dim=128,
+        max_model_len=4096,
+        max_total_seq_len=4096,
+        topk_indices_buffer=torch.empty((2, 4), dtype=torch.int32),
+        dcp_kv_shard_count=kv_shards,
+    )
+
+    assert requested_sizes == [kv_shards]
+    assert indexer.dcp_world_size == kv_shards
+    assert indexer.dcp_rank == 1
 
 
 def _install_fake_b12x_indexer(
@@ -1267,7 +1309,7 @@ def test_b12x_dcp_profile_uses_planner_page_table_width(monkeypatch):
         raising=False,
     )
     monkeypatch.setattr(indexer_mod.envs, "VLLM_SPARSE_INDEXER_MAX_LOGITS_MB", 512)
-    monkeypatch.setattr(indexer_mod, "_get_dcp_warmup_params", lambda: (2, 0, 1))
+    monkeypatch.setattr(indexer_mod, "_get_dcp_warmup_params", lambda *_: (2, 0, 1))
     monkeypatch.setattr(indexer_mod, "_prewarm_b12x_dcp_topk_merge", lambda **_: None)
 
     q_rows = 8192

--- a/tests/model_executor/layers/test_sparse_attn_indexer_b12x.py
+++ b/tests/model_executor/layers/test_sparse_attn_indexer_b12x.py
@@ -54,7 +54,7 @@ def test_replicated_constructor_uses_single_rank_without_dcp_group(monkeypatch):
             )
         ),
     )
-    monkeypatch.setattr(indexer_mod, "get_dcp_group", fail_dcp_group)
+    monkeypatch.setattr(indexer_mod, "get_indexer_dcp_group", fail_dcp_group)
     monkeypatch.setattr(indexer_mod, "use_b12x_sparse_indexer", lambda: True)
 
     indexer = indexer_mod.SparseAttnIndexer(

--- a/tests/models/test_dcp_shard_draft_defaults.py
+++ b/tests/models/test_dcp_shard_draft_defaults.py
@@ -9,6 +9,7 @@ import torch
 import vllm.model_executor.models.deepseek_v2 as deepseek_v2
 from vllm.model_executor.models.deepseek_v2 import (
     DeepseekV32IndexerCache,
+    _indexer_cache_dcp_shard_count,
     _replicate_indexer_cache_under_dcp,
 )
 
@@ -45,7 +46,15 @@ def _indexer_cache(layer_id: int = 78):
 
 def _get_indexer_spec(layer_id: int, config):
     cache = _indexer_cache(layer_id)
-    cache.dcp_replicated = _replicate_indexer_cache_under_dcp(cache.prefix, config)
+    configured_cp = (
+        config.parallel_config.decode_context_parallel_size
+        * config.parallel_config.prefill_context_parallel_size
+    )
+    cache.dcp_shard_count = _indexer_cache_dcp_shard_count(cache.prefix, config)
+    cache.dcp_replicated = configured_cp > 1 and cache.dcp_shard_count == 1
+    cache.dcp_kv_shard_count = (
+        cache.dcp_shard_count if 1 < cache.dcp_shard_count < configured_cp else None
+    )
     return cache, cache.get_kv_cache_spec(config)
 
 
@@ -90,6 +99,35 @@ def test_target_indexer_replication_equalizes_global_block_coverage(
 
     assert spec.dcp_replicated is True
     assert spec.block_size == dcp_size * cache.cache_config.block_size
+
+
+def test_target_indexer_partial_replication_uses_four_shards_under_dcp8(
+    monkeypatch,
+):
+    monkeypatch.delenv("VLLM_DCP_REPLICATE_INDEXER_CACHE", raising=False)
+    monkeypatch.setenv("VLLM_DCP_INDEXER_SHARDS", "4")
+    monkeypatch.setattr(deepseek_v2, "use_b12x_sparse_indexer", lambda: True)
+
+    cache, spec = _get_indexer_spec(12, _vllm_config(dcp_size=8))
+
+    assert cache.dcp_shard_count == 4
+    assert spec.dcp_replicated is False
+    assert spec.dcp_kv_shard_count == 4
+    assert spec.block_size == 2 * cache.cache_config.block_size
+    assert spec.block_size * spec.dcp_kv_shard_count == 8 * 256
+
+
+@pytest.mark.parametrize("shards", [3, 5, 6, 7, 9])
+def test_target_indexer_partial_replication_requires_dcp_divisor(
+    monkeypatch, shards: int
+):
+    monkeypatch.setenv("VLLM_DCP_INDEXER_SHARDS", str(shards))
+    monkeypatch.setattr(deepseek_v2, "use_b12x_sparse_indexer", lambda: True)
+
+    with pytest.raises(ValueError, match="positive divisor"):
+        _indexer_cache_dcp_shard_count(
+            "model.layers.12.indexer.k_cache", _vllm_config(dcp_size=8)
+        )
 
 
 def test_target_indexer_replication_rejects_pcp(monkeypatch):
@@ -148,6 +186,7 @@ def test_indexer_constructor_forwards_cache_replication(monkeypatch):
         def __init__(self, *args, **kwargs):
             super().__init__()
             self.dcp_replicated = True
+            self.dcp_kv_shard_count = None
 
     def fake_sparse_attn_indexer(*args, **kwargs):
         captured["args"] = args
@@ -197,3 +236,4 @@ def test_indexer_constructor_forwards_cache_replication(monkeypatch):
     assert isinstance(sparse_kwargs, dict)
     assert sparse_args[0] is indexer.k_cache
     assert sparse_kwargs["dcp_replicated"] is True
+    assert sparse_kwargs["dcp_kv_shard_count"] is None

--- a/tests/v1/attention/test_indexer_dcp_localize.py
+++ b/tests/v1/attention/test_indexer_dcp_localize.py
@@ -347,8 +347,8 @@ def _merge_local_topks_global_with_fake_dcp(
         )
 
     fake_group = _FakeDCPGroup(torch.cat(packed_per_rank, dim=1).contiguous())
-    original_get_dcp_group = sparse_indexer.get_dcp_group
-    sparse_indexer.get_dcp_group = lambda: fake_group
+    original_get_indexer_dcp_group = sparse_indexer.get_indexer_dcp_group
+    sparse_indexer.get_indexer_dcp_group = lambda expected_world_size=None: fake_group
     try:
         merged = []
         for rank, (logits, indices) in enumerate(zip(local_logits, local_topks)):
@@ -366,7 +366,7 @@ def _merge_local_topks_global_with_fake_dcp(
             merged.append(rank_indices)
         return merged
     finally:
-        sparse_indexer.get_dcp_group = original_get_dcp_group
+        sparse_indexer.get_indexer_dcp_group = original_get_indexer_dcp_group
 
 
 @pytest.mark.parametrize("world", [1, 2, 4, 6, 8])

--- a/tests/v1/attention/test_indexer_dcp_localize.py
+++ b/tests/v1/attention/test_indexer_dcp_localize.py
@@ -56,7 +56,7 @@ def test_replicated_builder_uses_global_lengths_without_dcp_localization(monkeyp
     def fail_dcp_path(*args, **kwargs):
         pytest.fail("replicated indexer metadata must not enter DCP localization")
 
-    monkeypatch.setattr(indexer_backend, "get_dcp_group", fail_dcp_path)
+    monkeypatch.setattr(indexer_backend, "get_indexer_dcp_group", fail_dcp_path)
     monkeypatch.setattr(indexer_backend, "num_compute_units", lambda device: 4)
     monkeypatch.setattr(indexer_backend.envs, "VLLM_USE_B12X_SPARSE_INDEXER", True)
 

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -1747,6 +1747,39 @@ def test_replicated_mla_uses_lockstep_pool_capacity_and_contiguous_tensors():
     ) == pytest.approx(2.0)
 
 
+def test_partial_replicated_mla_uses_lockstep_dcp8_layout():
+    target = MLAAttentionSpec(
+        block_size=64,
+        num_kv_heads=1,
+        head_size=576,
+        dtype=torch.uint8,
+        cache_dtype_str="nvfp4_ds_mla",
+    )
+    indexer = MLAAttentionSpec(
+        block_size=128,
+        num_kv_heads=1,
+        head_size=132,
+        dtype=torch.uint8,
+        dcp_kv_shard_count=4,
+    )
+    groups = [
+        KVCacheGroupSpec(["target"], target),
+        KVCacheGroupSpec(["indexer"], indexer),
+    ]
+
+    assert kv_cache_utils._use_lockstep_mla_allocation(groups, 8, 1)
+    assert target.block_size * 8 == indexer.block_size * 4 == 512
+
+    grouped_specs = kv_cache_utils.group_and_unify_kv_cache_specs(
+        {"target": target, "indexer": indexer}, 8, 1
+    )
+    assert grouped_specs is not None
+    grouped = kv_cache_utils._get_kv_cache_groups_uniform_groups(grouped_specs)
+    assert len(grouped) == 2
+    assert kv_cache_utils._use_lockstep_mla_allocation(grouped, 8, 1)
+    assert grouped[1].kv_cache_spec.page_size_bytes == indexer.page_size_bytes
+
+
 def test_lockstep_mla_predicate_rejects_nonmatching_layouts():
     sharded = MLAAttentionSpec(
         block_size=64,

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -1874,6 +1874,47 @@ def test_lockstep_mla_equal_page_sizes_use_distinct_tensors():
     ]
 
 
+def test_custom_cp_specs_with_same_block_size_stay_in_type_specific_groups():
+    target = MLAAttentionSpec(
+        block_size=64,
+        num_kv_heads=1,
+        head_size=128,
+        dtype=torch.float32,
+    )
+    replicated_full = FullAttentionSpec(
+        block_size=256,
+        num_kv_heads=1,
+        head_size=128,
+        dtype=torch.float32,
+        dcp_replicated=True,
+    )
+    replicated_sink = SinkFullAttentionSpec(
+        block_size=256,
+        num_kv_heads=1,
+        head_size=128,
+        dtype=torch.float32,
+        dcp_replicated=True,
+        sink_len=4,
+    )
+
+    grouped = group_and_unify_kv_cache_specs(
+        {
+            "target": target,
+            "full": replicated_full,
+            "sink": replicated_sink,
+        },
+        dcp_world_size=4,
+    )
+
+    assert grouped is not None
+    assert len(grouped) == 3
+    assert [set(group.kv_cache_specs) for group in grouped] == [
+        {"target"},
+        {"full"},
+        {"sink"},
+    ]
+
+
 def test_dsv4_engine_capacity_uses_worker_kv_cache_config():
     from vllm.v1.engine.core import EngineCore
 

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -1800,6 +1800,10 @@ def test_partial_replicated_uniform_groups_use_global_block_size():
     )
     assert grouped_specs is not None
     groups = kv_cache_utils._get_kv_cache_groups_uniform_groups(grouped_specs)
+    assert len(groups) == 2
+    assert {
+        name for group in groups for name in group.kv_cache_spec.kv_cache_specs
+    } == {"target", "indexer"}
     assert all(
         isinstance(group.kv_cache_spec, UniformTypeKVCacheSpecs) for group in groups
     )

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -1780,6 +1780,97 @@ def test_partial_replicated_mla_uses_lockstep_dcp8_layout():
     assert grouped[1].kv_cache_spec.page_size_bytes == indexer.page_size_bytes
 
 
+def test_partial_replicated_uniform_groups_use_global_block_size():
+    target = MLAAttentionSpec(
+        block_size=64,
+        num_kv_heads=1,
+        head_size=576,
+        dtype=torch.uint8,
+        cache_dtype_str="nvfp4_ds_mla",
+    )
+    indexer = MLAAttentionSpec(
+        block_size=128,
+        num_kv_heads=1,
+        head_size=132,
+        dtype=torch.uint8,
+        dcp_kv_shard_count=4,
+    )
+    grouped_specs = kv_cache_utils.group_and_unify_kv_cache_specs(
+        {"target": target, "indexer": indexer}, 8, 1
+    )
+    assert grouped_specs is not None
+    groups = kv_cache_utils._get_kv_cache_groups_uniform_groups(grouped_specs)
+    assert all(
+        isinstance(group.kv_cache_spec, UniformTypeKVCacheSpecs) for group in groups
+    )
+
+    vllm_config = SimpleNamespace(
+        cache_config=SimpleNamespace(
+            block_size=64,
+            enable_prefix_caching=True,
+            prefix_match_unit=None,
+        ),
+        parallel_config=SimpleNamespace(
+            decode_context_parallel_size=8,
+            prefill_context_parallel_size=1,
+        ),
+        kv_transfer_config=None,
+    )
+    kv_cache_config = KVCacheConfig(
+        num_blocks=128,
+        kv_cache_tensors=[],
+        kv_cache_groups=groups,
+    )
+
+    single_group_config = KVCacheConfig(
+        num_blocks=128,
+        kv_cache_tensors=[],
+        kv_cache_groups=[groups[0]],
+    )
+    assert kv_cache_utils.resolve_kv_cache_block_sizes(
+        single_group_config, vllm_config
+    ) == (512, 512)
+    assert kv_cache_utils.resolve_kv_cache_block_sizes(
+        kv_cache_config, vllm_config
+    ) == (512, 512)
+
+
+def test_partial_replicated_mla_groups_with_sliding_window_mla():
+    target = MLAAttentionSpec(
+        block_size=64,
+        num_kv_heads=1,
+        head_size=576,
+        dtype=torch.uint8,
+        cache_dtype_str="nvfp4_ds_mla",
+    )
+    indexer = MLAAttentionSpec(
+        block_size=128,
+        num_kv_heads=1,
+        head_size=132,
+        dtype=torch.uint8,
+        dcp_kv_shard_count=4,
+    )
+    sliding = SlidingWindowMLASpec(
+        block_size=64,
+        num_kv_heads=1,
+        head_size=128,
+        dtype=torch.uint8,
+        sliding_window=4096,
+        dcp_sharded=True,
+    )
+
+    grouped = kv_cache_utils.group_and_unify_kv_cache_specs(
+        {"target": target, "indexer": indexer, "sliding": sliding}, 8, 1
+    )
+
+    assert grouped is not None
+    assert [set(group.kv_cache_specs) for group in grouped] == [
+        {"target"},
+        {"sliding"},
+        {"indexer"},
+    ]
+
+
 def test_lockstep_mla_predicate_rejects_nonmatching_layouts():
     sharded = MLAAttentionSpec(
         block_size=64,

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -177,7 +177,9 @@ def make_kv_cache_config_hybrid_model(
     )
 
 
-def make_lockstep_mla_manager(num_blocks: int = 5) -> KVCacheManager:
+def make_lockstep_mla_manager(
+    num_blocks: int = 5, hash_block_size: int = 256
+) -> KVCacheManager:
     global_block_size = 256
     kv_cache_config = KVCacheConfig(
         num_blocks=num_blocks,
@@ -208,7 +210,7 @@ def make_lockstep_mla_manager(num_blocks: int = 5) -> KVCacheManager:
         kv_cache_config=kv_cache_config,
         max_model_len=4 * global_block_size,
         scheduler_block_size=global_block_size,
-        hash_block_size=global_block_size,
+        hash_block_size=hash_block_size,
         enable_caching=True,
         dcp_world_size=4,
     )
@@ -293,6 +295,65 @@ def test_mixed_mla_groups_share_block_ids_hashes_and_eviction_order():
     assert evicted.block_id == target_ids[-1]
     assert manager.block_pool.get_cached_block(request.block_hashes[-1], [0]) is None
     assert manager.block_pool.get_cached_block(request.block_hashes[-1], [1]) is None
+
+
+def test_lockstep_mla_partial_prefix_hit_mirrors_single_cow_block():
+    hash_block_size = 64
+    manager = make_lockstep_mla_manager(num_blocks=6, hash_block_size=hash_block_size)
+    # Exercise the fine-grained lookup contract directly. Production DCP
+    # currently keeps this policy disabled, but lockstep allocation must still
+    # preserve group identity when such a hit is supplied.
+    manager.coordinator.enable_partial_hash_hits = True
+    owner = make_request(
+        "owner",
+        list(range(6 * hash_block_size)),
+        hash_block_size,
+        sha256,
+    )
+    assert manager.allocate_slots(owner, 6 * hash_block_size) is not None
+    owner_ids = manager.get_block_ids(owner.request_id)
+    assert owner_ids[0] == owner_ids[1]
+    source_block_id = owner_ids[0][1]
+    manager.free(owner)
+    manager.new_step_starts()
+
+    replay = make_request(
+        "replay",
+        list(range(8 * hash_block_size)),
+        hash_block_size,
+        sha256,
+    )
+    computed_blocks, num_computed_tokens, _ = manager.get_computed_blocks(replay)
+    assert num_computed_tokens == 6 * hash_block_size
+    assert computed_blocks.get_block_ids() == (
+        list(owner_ids[0]),
+        list(owner_ids[1]),
+    )
+
+    new_blocks = manager.allocate_slots(
+        replay,
+        num_new_tokens=2 * hash_block_size,
+        num_new_computed_tokens=num_computed_tokens,
+        new_computed_blocks=computed_blocks,
+    )
+    assert new_blocks is not None
+    replay_ids = manager.get_block_ids(replay.request_id)
+    assert replay_ids[0] == replay_ids[1]
+    assert len(replay_ids[0]) == 2
+    cow_block_id = replay_ids[0][1]
+    assert cow_block_id != source_block_id
+    assert new_blocks.get_block_ids() == ([cow_block_id], [cow_block_id])
+
+    copies, retained = manager.take_kv_cache_block_copies()
+    assert [(copy.src_block_id, copy.dst_block_id) for copy in copies] == [
+        (source_block_id, cow_block_id)
+    ]
+    assert [block.block_id for block in retained] == [source_block_id, cow_block_id]
+    assert manager.block_pool.blocks[source_block_id].ref_cnt == 1
+    assert manager.block_pool.blocks[cow_block_id].ref_cnt == 3
+    manager.block_pool.free_blocks(retained)
+    assert manager.block_pool.blocks[source_block_id].ref_cnt == 0
+    assert manager.block_pool.blocks[cow_block_id].ref_cnt == 2
 
 
 def test_lockstep_mla_allocates_external_computed_blocks_once():

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -239,7 +239,7 @@ def test_mixed_mla_groups_share_block_ids_hashes_and_eviction_order():
         manager.block_pool.blocks[block_id].ref_cnt == 2 for block_id in target_ids
     )
 
-    for block_hash, block_id in zip(request.block_hashes, target_ids):
+    for block_hash, block_id in zip(request.block_hashes, target_ids, strict=True):
         group_keys = [
             make_block_hash_with_group_id(block_hash, group_id) for group_id in range(2)
         ]

--- a/tests/v1/worker/test_gpu_block_table.py
+++ b/tests/v1/worker/test_gpu_block_table.py
@@ -223,3 +223,56 @@ def test_compute_slot_mappings_mixed_sharded_and_replicated_groups():
         ],
         list(range(1280, 1288)),
     ]
+
+
+def test_compute_slot_mappings_partial_replica_pairs_share_four_way_shard():
+    device = torch.device("cuda")
+
+    def compute_for_rank(cp_rank: int) -> list[int]:
+        block_tables = BlockTables(
+            block_sizes=[128],
+            max_num_reqs=1,
+            max_num_batched_tokens=16,
+            max_num_blocks_per_group=[1],
+            device=device,
+            kernel_block_sizes=[64],
+            cp_size=8,
+            cp_rank=cp_rank,
+            group_cp_sizes=[4],
+        )
+        block_tables.append_block_ids(
+            req_index=0,
+            new_block_ids=([5],),
+            overwrite=True,
+        )
+        block_tables.apply_staged_writes()
+        result = block_tables.compute_slot_mappings(
+            torch.tensor([0], dtype=torch.int32, device=device),
+            torch.tensor([0, 16], dtype=torch.int32, device=device),
+            torch.arange(16, dtype=torch.int64, device=device),
+            num_tokens_padded=16,
+        )
+        torch.accelerator.synchronize()
+        return result[0].cpu().tolist()
+
+    rank0 = compute_for_rank(0)
+    rank4 = compute_for_rank(4)
+    assert rank0 == rank4
+    assert rank0 == [
+        640,
+        PAD_SLOT_ID,
+        PAD_SLOT_ID,
+        PAD_SLOT_ID,
+        641,
+        PAD_SLOT_ID,
+        PAD_SLOT_ID,
+        PAD_SLOT_ID,
+        642,
+        PAD_SLOT_ID,
+        PAD_SLOT_ID,
+        PAD_SLOT_ID,
+        643,
+        PAD_SLOT_ID,
+        PAD_SLOT_ID,
+        PAD_SLOT_ID,
+    ]

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -1531,6 +1531,17 @@ def _build_indexer_replica_group_ranks(
     return dcp_groups, query_split_groups
 
 
+def _validate_indexer_shard_count(indexer_shards: int, dcp_size: int) -> None:
+    """Reject partial-indexer layouts that cannot form equal replica groups."""
+    if indexer_shards in (0, 1, dcp_size):
+        return
+    if indexer_shards < 1 or indexer_shards > dcp_size or dcp_size % indexer_shards:
+        raise ValueError(
+            "VLLM_DCP_INDEXER_SHARDS must be 0, 1, or a positive divisor of "
+            f"the configured DCP size; got shards={indexer_shards}, DCP={dcp_size}"
+        )
+
+
 _DCP_CKV_PREFETCH: GroupCoordinator | None = None
 
 
@@ -2089,10 +2100,8 @@ def initialize_model_parallel(
         "indexer query split group is already initialized"
     )
     indexer_shards = int(envs.VLLM_DCP_INDEXER_SHARDS)
-    if (
-        1 < indexer_shards < decode_context_model_parallel_size
-        and decode_context_model_parallel_size % indexer_shards == 0
-    ):
+    _validate_indexer_shard_count(indexer_shards, decode_context_model_parallel_size)
+    if 1 < indexer_shards < decode_context_model_parallel_size:
         indexer_dcp_ranks, indexer_query_split_ranks = (
             _build_indexer_replica_group_ranks(tp_group_ranks, indexer_shards)
         )

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -1448,18 +1448,64 @@ def get_query_split_group() -> GroupCoordinator:
 _INDEXER_DCP: GroupCoordinator | None = None
 
 
-def get_indexer_dcp_group() -> GroupCoordinator:
-    """Return the sparse-indexer shard group, or the configured DCP group."""
-    return _INDEXER_DCP if _INDEXER_DCP is not None else get_dcp_group()
+def get_indexer_dcp_group(
+    expected_world_size: int | None = None,
+) -> GroupCoordinator:
+    """Return the group matching an indexer's actual KV shard count.
+
+    A partially replicated target indexer and a fully sharded speculative
+    indexer can coexist in the same model. Callers that know their shard count
+    must provide it so the speculative indexer does not inherit the target's
+    smaller process group.
+    """
+    if expected_world_size is None:
+        return _INDEXER_DCP if _INDEXER_DCP is not None else get_dcp_group()
+
+    if _INDEXER_DCP is not None and int(_INDEXER_DCP.world_size) == expected_world_size:
+        return _INDEXER_DCP
+
+    dcp_group = get_dcp_group()
+    if int(dcp_group.world_size) == expected_world_size:
+        return dcp_group
+
+    partial_size = int(_INDEXER_DCP.world_size) if _INDEXER_DCP is not None else None
+    raise RuntimeError(
+        "No sparse-indexer DCP group matches the requested KV shard count: "
+        f"requested={expected_world_size}, partial={partial_size}, "
+        f"configured={dcp_group.world_size}"
+    )
 
 
 _INDEXER_QUERY_SPLIT: GroupCoordinator | None = None
 
 
-def get_indexer_query_split_group() -> GroupCoordinator:
-    if _INDEXER_QUERY_SPLIT is not None:
+def get_indexer_query_split_group(
+    indexer_dcp_world_size: int | None = None,
+) -> GroupCoordinator:
+    """Return the query-split group paired with an indexer's shard group."""
+    if indexer_dcp_world_size is None:
+        if _INDEXER_QUERY_SPLIT is not None:
+            return _INDEXER_QUERY_SPLIT
+        return get_query_split_group()
+
+    if (
+        _INDEXER_DCP is not None
+        and int(_INDEXER_DCP.world_size) == indexer_dcp_world_size
+    ):
+        if _INDEXER_QUERY_SPLIT is None:
+            raise RuntimeError("Partial indexer DCP group has no query-split group")
         return _INDEXER_QUERY_SPLIT
-    return get_query_split_group()
+
+    dcp_group = get_dcp_group()
+    if int(dcp_group.world_size) == indexer_dcp_world_size:
+        return get_query_split_group()
+
+    partial_size = int(_INDEXER_DCP.world_size) if _INDEXER_DCP is not None else None
+    raise RuntimeError(
+        "No indexer query-split group matches the requested KV shard count: "
+        f"requested={indexer_dcp_world_size}, partial={partial_size}, "
+        f"configured={dcp_group.world_size}"
+    )
 
 
 def _build_indexer_replica_group_ranks(

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -758,9 +758,7 @@ class GroupCoordinator:
     ) -> torch.Tensor:
         """Reduce-scatter and preserve a physically head-major output view."""
         if self.world_size <= 1 or dim != 1:
-            raise RuntimeError(
-                "reduce_scatter_head_major requires DCP heads on dim 1"
-            )
+            raise RuntimeError("reduce_scatter_head_major requires DCP heads on dim 1")
         if self.device_communicator is None:
             raise RuntimeError(
                 "reduce_scatter_head_major requires a device communicator"
@@ -1447,6 +1445,46 @@ def get_query_split_group() -> GroupCoordinator:
     return _QUERY_SPLIT
 
 
+_INDEXER_DCP: GroupCoordinator | None = None
+
+
+def get_indexer_dcp_group() -> GroupCoordinator:
+    """Return the sparse-indexer shard group, or the configured DCP group."""
+    return _INDEXER_DCP if _INDEXER_DCP is not None else get_dcp_group()
+
+
+_INDEXER_QUERY_SPLIT: GroupCoordinator | None = None
+
+
+def get_indexer_query_split_group() -> GroupCoordinator:
+    if _INDEXER_QUERY_SPLIT is not None:
+        return _INDEXER_QUERY_SPLIT
+    return get_query_split_group()
+
+
+def _build_indexer_replica_group_ranks(
+    tp_group_ranks: list[list[int]], indexer_shards: int
+) -> tuple[list[list[int]], list[list[int]]]:
+    """Build shard-owner groups and cross-replica query-split groups."""
+    dcp_groups: list[list[int]] = []
+    query_split_groups: list[list[int]] = []
+    for tp_ranks in tp_group_ranks:
+        if indexer_shards <= 0 or len(tp_ranks) % indexer_shards != 0:
+            raise ValueError(
+                f"Indexer shards={indexer_shards} must divide TP={len(tp_ranks)}"
+            )
+        replicas = [
+            tp_ranks[start : start + indexer_shards]
+            for start in range(0, len(tp_ranks), indexer_shards)
+        ]
+        dcp_groups.extend(replicas)
+        query_split_groups.extend(
+            [replica[shard_rank] for replica in replicas]
+            for shard_rank in range(indexer_shards)
+        )
+    return dcp_groups, query_split_groups
+
+
 _DCP_CKV_PREFETCH: GroupCoordinator | None = None
 
 
@@ -1946,6 +1984,7 @@ def initialize_model_parallel(
     if enable_elastic_ep:
         group_ranks = local_all_ranks.view(-1, tensor_model_parallel_size).unbind(0)
         group_ranks = [x.tolist() for x in group_ranks]
+    tp_group_ranks = group_ranks
     # message queue broadcaster is only used in tensor model parallel group
     _TP = init_model_parallel_group(
         group_ranks,
@@ -1994,6 +2033,36 @@ def initialize_model_parallel(
             backend,
             group_name="query_split",
         )
+
+    # A partially replicated sparse-indexer cache has its own shard topology.
+    # With TP8/DCP8 and four indexer shards, these are {0,1,2,3}/{4,5,6,7};
+    # ranks at the same position form two-way query-split groups.
+    global _INDEXER_DCP, _INDEXER_QUERY_SPLIT
+    assert _INDEXER_DCP is None, "indexer DCP group is already initialized"
+    assert _INDEXER_QUERY_SPLIT is None, (
+        "indexer query split group is already initialized"
+    )
+    indexer_shards = int(envs.VLLM_DCP_INDEXER_SHARDS)
+    if (
+        1 < indexer_shards < decode_context_model_parallel_size
+        and decode_context_model_parallel_size % indexer_shards == 0
+    ):
+        indexer_dcp_ranks, indexer_query_split_ranks = (
+            _build_indexer_replica_group_ranks(tp_group_ranks, indexer_shards)
+        )
+        _INDEXER_DCP = init_model_parallel_group(
+            indexer_dcp_ranks,
+            get_world_group().local_rank,
+            backend,
+            group_name="indexer_dcp",
+        )
+        if envs.VLLM_DCP_QUERY_SPLIT:
+            _INDEXER_QUERY_SPLIT = init_model_parallel_group(
+                indexer_query_split_ranks,
+                get_world_group().local_rank,
+                backend,
+                group_name="indexer_query_split",
+            )
 
     # A dedicated communicator over the DCP ranks for the transient ckv
     # prefetch gather (Fix B). The prefetch runs on a side stream and would
@@ -2239,6 +2308,16 @@ def destroy_model_parallel():
     if _QUERY_SPLIT:
         _QUERY_SPLIT.destroy()
     _QUERY_SPLIT = None
+
+    global _INDEXER_DCP
+    if _INDEXER_DCP:
+        _INDEXER_DCP.destroy()
+    _INDEXER_DCP = None
+
+    global _INDEXER_QUERY_SPLIT
+    if _INDEXER_QUERY_SPLIT:
+        _INDEXER_QUERY_SPLIT.destroy()
+    _INDEXER_QUERY_SPLIT = None
 
     global _DCP_CKV_PREFETCH
     if _DCP_CKV_PREFETCH:

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -75,6 +75,7 @@ if TYPE_CHECKING:
     VLLM_DCP_A2A_LARGE_BACKEND: Literal["ag_rs", "a2a"] = "ag_rs"
     VLLM_DCP_SHARD_DRAFT: str | None = None
     VLLM_DCP_REPLICATE_INDEXER_CACHE: bool = False
+    VLLM_DCP_INDEXER_SHARDS: int = 0
     VLLM_DCP_GLOBAL_TOPK: bool = True
     VLLM_DCP_QUERY_SPLIT: bool = False
     VLLM_DCP_TOPK_OWNER_MERGE: bool = False
@@ -1169,6 +1170,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
         os.getenv("VLLM_DCP_REPLICATE_INDEXER_CACHE", "0").lower()
         in ("1", "true", "yes", "on")
     ),
+    # Number of unique sparse-indexer KV shards inside each configured DCP
+    # group. Zero keeps the configured DCP size; one fully replicates the
+    # cache. Intermediate divisors create replicated shard groups (for
+    # example, 4 under DCP8 creates two replicas of four shards).
+    "VLLM_DCP_INDEXER_SHARDS": lambda: int(os.getenv("VLLM_DCP_INDEXER_SHARDS", "0")),
     # Under DCP, gather sparse-indexer logits across ranks and select a global
     # top-k instead of a per-rank local top-k.
     "VLLM_DCP_GLOBAL_TOPK": lambda: (

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -10,7 +10,10 @@ import vllm.envs as envs
 from vllm import _custom_ops as ops
 from vllm._aiter_ops import rocm_aiter_ops
 from vllm.config import CUDAGraphMode, get_current_vllm_config
-from vllm.distributed import get_dcp_group, get_query_split_group
+from vllm.distributed import (
+    get_indexer_dcp_group,
+    get_indexer_query_split_group,
+)
 from vllm.forward_context import get_forward_context
 from vllm.model_executor.custom_op import CustomOp
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
@@ -458,9 +461,9 @@ def _get_dcp_warmup_params() -> tuple[int, int, int]:
         pass
 
     try:
-        from vllm.distributed.parallel_state import get_dcp_group
+        from vllm.distributed.parallel_state import get_indexer_dcp_group
 
-        dcp_group = get_dcp_group()
+        dcp_group = get_indexer_dcp_group()
         if int(dcp_group.world_size) > 1:
             dcp_world_size = int(dcp_group.world_size)
             dcp_rank = int(dcp_group.rank_in_group)
@@ -476,9 +479,9 @@ def _sync_dcp_warmup() -> None:
         torch.accelerator.synchronize()
 
     try:
-        from vllm.distributed.parallel_state import get_dcp_group
+        from vllm.distributed.parallel_state import get_indexer_dcp_group
 
-        dcp_group = get_dcp_group()
+        dcp_group = get_indexer_dcp_group()
         if int(dcp_group.world_size) <= 1:
             return
         dcp_group.barrier()
@@ -540,7 +543,7 @@ def _dcp_global_topk_remap(
     if world_size <= 1 or topk_indices.numel() == 0:
         return
 
-    from vllm.distributed.parallel_state import get_dcp_group
+    from vllm.distributed.parallel_state import get_indexer_dcp_group
 
     candidates = _dcp_pack_topk_candidates(
         topk_indices,
@@ -551,7 +554,7 @@ def _dcp_global_topk_remap(
         interleave,
         row_starts=row_starts,
     )
-    all_candidates = get_dcp_group().all_gather(candidates.contiguous(), dim=2)
+    all_candidates = get_indexer_dcp_group().all_gather(candidates.contiguous(), dim=2)
     all_scores = all_candidates[:, 1, :].view(torch.float32)
     _, selected = torch.topk(all_scores, topk_tokens, dim=1)
     _dcp_finalize_topk_remap(
@@ -767,7 +770,7 @@ def _merge_dcp_topk_global(
         cp_interleave,
         row_starts,
     )
-    gathered = get_dcp_group().all_gather(packed, dim=1)
+    gathered = get_indexer_dcp_group().all_gather(packed, dim=1)
     stable_topk_from_gathered_candidates_cutedsl(
         gathered, topk_tokens, out=topk_indices
     )
@@ -1076,7 +1079,7 @@ def _merge_b12x_dcp_topk(
 
     from sparkinfer.attention.nsa_indexer.tiled_topk import run_row_topk
 
-    from vllm.distributed.parallel_state import get_dcp_group
+    from vllm.distributed.parallel_state import get_indexer_dcp_group
     from vllm.v1.attention.backends.mla.sparse_utils import (
         triton_convert_dcp_local_topk_to_global,
         triton_gather_topk_ids_by_position,
@@ -1111,7 +1114,7 @@ def _merge_b12x_dcp_topk(
     candidates[:, 0, :].copy_(topk_indices)
     candidates[:, 1, :].copy_(topk_scores.view(torch.int32))
 
-    dcp_group = get_dcp_group()
+    dcp_group = get_indexer_dcp_group()
     _dcp_all_gather_first_dim_into(
         dcp_group,
         candidates,
@@ -1758,7 +1761,7 @@ def sparse_attn_indexer(
     qs_rank = 0
     if envs.VLLM_DCP_QUERY_SPLIT and dcp_world_size > 1:
         try:
-            _qs = get_query_split_group()
+            _qs = get_indexer_query_split_group()
             if int(_qs.world_size) > 1:
                 qs_group = _qs
                 qs_world_size = int(_qs.world_size)
@@ -2393,6 +2396,7 @@ class SparseAttnIndexer(CustomOp):
         output_physical_slots: bool = False,
         num_q_heads: int | None = None,
         dcp_replicated: bool = False,
+        dcp_kv_shard_count: int | None = None,
     ):
         super().__init__()
         self.k_cache = k_cache
@@ -2414,8 +2418,21 @@ class SparseAttnIndexer(CustomOp):
         parallel_config = get_current_vllm_config().parallel_config
         self.dcp_replicated = bool(dcp_replicated)
         configured_dcp_world_size = parallel_config.decode_context_parallel_size
-        self.dcp_world_size = 1 if self.dcp_replicated else configured_dcp_world_size
-        self.dcp_rank = get_dcp_group().rank_in_group if self.dcp_world_size > 1 else 0
+        self.dcp_world_size = (
+            1
+            if self.dcp_replicated
+            else int(dcp_kv_shard_count or configured_dcp_world_size)
+        )
+        if self.dcp_world_size > 1:
+            indexer_group = get_indexer_dcp_group()
+            if int(indexer_group.world_size) != self.dcp_world_size:
+                raise RuntimeError(
+                    "Sparse-indexer DCP group does not match its KV shard count: "
+                    f"group={indexer_group.world_size}, shards={self.dcp_world_size}"
+                )
+            self.dcp_rank = int(indexer_group.rank_in_group)
+        else:
+            self.dcp_rank = 0
         self.cp_kv_cache_interleave_size = parallel_config.cp_kv_cache_interleave_size
         self.use_b12x_sparse_indexer = use_b12x_sparse_indexer()
         if self.output_physical_slots and not self.use_b12x_sparse_indexer:

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -12,7 +12,7 @@ from vllm._aiter_ops import rocm_aiter_ops
 from vllm.config import CUDAGraphMode, get_current_vllm_config
 from vllm.distributed import (
     get_indexer_dcp_group,
-    get_indexer_query_split_group,
+    get_query_split_group,
 )
 from vllm.forward_context import get_forward_context
 from vllm.model_executor.custom_op import CustomOp
@@ -1766,15 +1766,19 @@ def sparse_attn_indexer(
     qs_group = None
     qs_world_size = 1
     qs_rank = 0
-    if envs.VLLM_DCP_QUERY_SPLIT and dcp_world_size > 1:
-        try:
-            _qs = get_indexer_query_split_group(dcp_world_size)
-            if int(_qs.world_size) > 1:
-                qs_group = _qs
-                qs_world_size = int(_qs.world_size)
-                qs_rank = int(_qs.rank_in_group)
-        except Exception:
-            pass
+    if envs.VLLM_DCP_QUERY_SPLIT:
+        from vllm.distributed import parallel_state
+
+        selector = getattr(parallel_state, "get_indexer_query_split_group", None)
+        _qs = (
+            selector(dcp_world_size)
+            if selector is not None
+            else get_query_split_group()
+        )
+        if int(_qs.world_size) > 1:
+            qs_group = _qs
+            qs_world_size = int(_qs.world_size)
+            qs_rank = int(_qs.rank_in_group)
     if output_physical_slots:
         if not _use_b12x_sparse_indexer(use_b12x_sparse_indexer):
             raise RuntimeError(

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -443,8 +443,11 @@ def _unpack_b12x_dcp_gathered_candidates(
         candidate_score_bits[:, start:end].copy_(gathered_view[rank, :, 1, :])
 
 
-def _get_dcp_warmup_params() -> tuple[int, int, int]:
-    dcp_world_size = 1
+def _get_dcp_warmup_params(
+    expected_dcp_world_size: int | None = None,
+) -> tuple[int, int, int]:
+    dcp_world_size = int(expected_dcp_world_size or 1)
+    group_world_size = expected_dcp_world_size
     dcp_rank = 0
     cp_kv_cache_interleave_size = 1
     try:
@@ -453,7 +456,9 @@ def _get_dcp_warmup_params() -> tuple[int, int, int]:
         vllm_config = get_current_vllm_config_or_none()
         if vllm_config is not None:
             parallel_config = vllm_config.parallel_config
-            dcp_world_size = int(parallel_config.decode_context_parallel_size)
+            if expected_dcp_world_size is None:
+                dcp_world_size = int(parallel_config.decode_context_parallel_size)
+                group_world_size = dcp_world_size
             cp_kv_cache_interleave_size = int(
                 parallel_config.cp_kv_cache_interleave_size
             )
@@ -463,7 +468,7 @@ def _get_dcp_warmup_params() -> tuple[int, int, int]:
     try:
         from vllm.distributed.parallel_state import get_indexer_dcp_group
 
-        dcp_group = get_indexer_dcp_group()
+        dcp_group = get_indexer_dcp_group(group_world_size)
         if int(dcp_group.world_size) > 1:
             dcp_world_size = int(dcp_group.world_size)
             dcp_rank = int(dcp_group.rank_in_group)
@@ -473,7 +478,7 @@ def _get_dcp_warmup_params() -> tuple[int, int, int]:
     return dcp_world_size, dcp_rank, cp_kv_cache_interleave_size
 
 
-def _sync_dcp_warmup() -> None:
+def _sync_dcp_warmup(dcp_world_size: int) -> None:
     """Finish one-time DCP warmup on every rank before graph warmup proceeds."""
     if current_platform.is_cuda():
         torch.accelerator.synchronize()
@@ -481,7 +486,7 @@ def _sync_dcp_warmup() -> None:
     try:
         from vllm.distributed.parallel_state import get_indexer_dcp_group
 
-        dcp_group = get_indexer_dcp_group()
+        dcp_group = get_indexer_dcp_group(dcp_world_size)
         if int(dcp_group.world_size) <= 1:
             return
         dcp_group.barrier()
@@ -527,7 +532,7 @@ def _prewarm_b12x_dcp_topk_merge(
             dcp_rank=int(dcp_rank),
             cp_kv_cache_interleave_size=int(cp_kv_cache_interleave_size),
         )
-        _sync_dcp_warmup()
+        _sync_dcp_warmup(dcp_world_size)
 
 
 def _dcp_global_topk_remap(
@@ -554,7 +559,9 @@ def _dcp_global_topk_remap(
         interleave,
         row_starts=row_starts,
     )
-    all_candidates = get_indexer_dcp_group().all_gather(candidates.contiguous(), dim=2)
+    all_candidates = get_indexer_dcp_group(world_size).all_gather(
+        candidates.contiguous(), dim=2
+    )
     all_scores = all_candidates[:, 1, :].view(torch.float32)
     _, selected = torch.topk(all_scores, topk_tokens, dim=1)
     _dcp_finalize_topk_remap(
@@ -770,7 +777,7 @@ def _merge_dcp_topk_global(
         cp_interleave,
         row_starts,
     )
-    gathered = get_indexer_dcp_group().all_gather(packed, dim=1)
+    gathered = get_indexer_dcp_group(dcp_world_size).all_gather(packed, dim=1)
     stable_topk_from_gathered_candidates_cutedsl(
         gathered, topk_tokens, out=topk_indices
     )
@@ -1114,7 +1121,7 @@ def _merge_b12x_dcp_topk(
     candidates[:, 0, :].copy_(topk_indices)
     candidates[:, 1, :].copy_(topk_scores.view(torch.int32))
 
-    dcp_group = get_indexer_dcp_group()
+    dcp_group = get_indexer_dcp_group(dcp_world_size)
     _dcp_all_gather_first_dim_into(
         dcp_group,
         candidates,
@@ -1682,7 +1689,7 @@ def sparse_attn_indexer(
                 dcp_world_size,
                 dcp_rank,
                 cp_kv_cache_interleave_size,
-            ) = _get_dcp_warmup_params()
+            ) = _get_dcp_warmup_params(dcp_world_size)
             _prewarm_b12x_paged_indexer_prefill(
                 q_quant=q_quant,
                 weights=weights,
@@ -1761,7 +1768,7 @@ def sparse_attn_indexer(
     qs_rank = 0
     if envs.VLLM_DCP_QUERY_SPLIT and dcp_world_size > 1:
         try:
-            _qs = get_indexer_query_split_group()
+            _qs = get_indexer_query_split_group(dcp_world_size)
             if int(_qs.world_size) > 1:
                 qs_group = _qs
                 qs_world_size = int(_qs.world_size)
@@ -2424,7 +2431,7 @@ class SparseAttnIndexer(CustomOp):
             else int(dcp_kv_shard_count or configured_dcp_world_size)
         )
         if self.dcp_world_size > 1:
-            indexer_group = get_indexer_dcp_group()
+            indexer_group = get_indexer_dcp_group(self.dcp_world_size)
             if int(indexer_group.world_size) != self.dcp_world_size:
                 raise RuntimeError(
                     "Sparse-indexer DCP group does not match its KV shard count: "

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -617,39 +617,71 @@ class DeepseekV2Attention(nn.Module):
         return output
 
 
-def _replicate_indexer_cache_under_dcp(prefix: str, vllm_config: VllmConfig) -> bool:
+def _indexer_cache_dcp_shard_count(prefix: str, vllm_config: VllmConfig) -> int:
+    parallel_config = vllm_config.parallel_config
+    dcp_size = parallel_config.decode_context_parallel_size
+    pcp_size = parallel_config.prefill_context_parallel_size
+    configured_cp_size = dcp_size * pcp_size
     layer_id = extract_layer_index(prefix)
     num_hidden_layers = getattr(
         vllm_config.model_config.hf_config, "num_hidden_layers", None
     )
     if layer_id is None or num_hidden_layers is None:
-        return False
-
-    parallel_config = vllm_config.parallel_config
-    dcp_size = parallel_config.decode_context_parallel_size
-    pcp_size = parallel_config.prefill_context_parallel_size
-    if dcp_size * pcp_size <= 1:
-        return False
+        return configured_cp_size
+    if configured_cp_size <= 1:
+        return configured_cp_size
 
     if int(layer_id) >= int(num_hidden_layers):
-        return False
+        return configured_cp_size
 
-    requested = envs.VLLM_DCP_REPLICATE_INDEXER_CACHE
-    if requested and not vllm_config.use_v2_model_runner:
+    requested_shards = envs.VLLM_DCP_INDEXER_SHARDS
+    requested_replicated = envs.VLLM_DCP_REPLICATE_INDEXER_CACHE
+    if requested_replicated and requested_shards not in (0, 1):
+        raise ValueError(
+            "VLLM_DCP_REPLICATE_INDEXER_CACHE conflicts with "
+            f"VLLM_DCP_INDEXER_SHARDS={requested_shards}"
+        )
+    if requested_replicated:
+        requested_shards = 1
+    if requested_shards == 0:
+        return configured_cp_size
+
+    if not vllm_config.use_v2_model_runner:
         raise NotImplementedError(
-            "Replicated sparse-indexer KV requires the V2 model runner's "
+            "Partially replicated sparse-indexer KV requires the V2 model runner's "
             "per-group context-parallel block tables."
         )
-    if requested and (not 2 <= dcp_size <= 8 or pcp_size != 1):
+    if not 2 <= dcp_size <= 8 or pcp_size != 1:
         raise NotImplementedError(
-            "Replicated sparse-indexer KV currently supports DCP2 through "
+            "Partially replicated sparse-indexer KV currently supports DCP2 through "
             "DCP8 with PCP1."
         )
-    if requested and not use_b12x_sparse_indexer():
-        raise RuntimeError(
-            "VLLM_DCP_REPLICATE_INDEXER_CACHE requires the B12X sparse indexer."
+    if (
+        requested_shards < 1
+        or requested_shards > dcp_size
+        or dcp_size % requested_shards != 0
+    ):
+        raise ValueError(
+            "VLLM_DCP_INDEXER_SHARDS must be a positive divisor of DCP, "
+            f"got shards={requested_shards}, DCP={dcp_size}."
         )
-    return requested
+    if not use_b12x_sparse_indexer():
+        raise RuntimeError(
+            "Partial sparse-indexer KV replication requires the B12X sparse indexer."
+        )
+    return requested_shards
+
+
+def _replicate_indexer_cache_under_dcp(prefix: str, vllm_config: VllmConfig) -> bool:
+    parallel_config = vllm_config.parallel_config
+    configured_cp_size = (
+        parallel_config.decode_context_parallel_size
+        * parallel_config.prefill_context_parallel_size
+    )
+    return (
+        configured_cp_size > 1
+        and _indexer_cache_dcp_shard_count(prefix, vllm_config) == 1
+    )
 
 
 class DeepseekV32IndexerCache(torch.nn.Module, AttentionLayerBase):
@@ -663,7 +695,17 @@ class DeepseekV32IndexerCache(torch.nn.Module, AttentionLayerBase):
         self.cache_config = cache_config
         self.dtype = dtype
         vllm_config = get_current_vllm_config()
-        self.dcp_replicated = _replicate_indexer_cache_under_dcp(prefix, vllm_config)
+        configured_cp_size = (
+            vllm_config.parallel_config.decode_context_parallel_size
+            * vllm_config.parallel_config.prefill_context_parallel_size
+        )
+        self.dcp_shard_count = _indexer_cache_dcp_shard_count(prefix, vllm_config)
+        self.dcp_replicated = configured_cp_size > 1 and self.dcp_shard_count == 1
+        self.dcp_kv_shard_count = (
+            self.dcp_shard_count
+            if 1 < self.dcp_shard_count < configured_cp_size
+            else None
+        )
         compilation_config = vllm_config.compilation_config
         if prefix in compilation_config.static_forward_context:
             raise ValueError(f"Duplicate layer name: {prefix}")
@@ -671,15 +713,18 @@ class DeepseekV32IndexerCache(torch.nn.Module, AttentionLayerBase):
 
     def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
         block_size = self.cache_config.block_size
-        if self.dcp_replicated:
+        if self.dcp_replicated or self.dcp_kv_shard_count is not None:
             parallel_config = vllm_config.parallel_config
-            block_size *= (
+            configured_cp_size = (
                 parallel_config.decode_context_parallel_size
                 * parallel_config.prefill_context_parallel_size
             )
+            block_size *= configured_cp_size // self.dcp_shard_count
             logger.info_once(
-                "Using a DCP-replicated sparse-indexer K cache with %d-token "
-                "manager pages.",
+                "Using %d sparse-indexer KV shards across DCP%d with "
+                "%d-token manager pages.",
+                self.dcp_shard_count,
+                configured_cp_size,
                 block_size,
             )
         layer_id = extract_layer_index(self.prefix)
@@ -700,6 +745,7 @@ class DeepseekV32IndexerCache(torch.nn.Module, AttentionLayerBase):
             head_size=self.head_dim,
             dtype=self.dtype,
             dcp_replicated=self.dcp_replicated or draft_replicated,
+            dcp_kv_shard_count=self.dcp_kv_shard_count,
         )
 
     def forward(self): ...
@@ -801,6 +847,7 @@ class Indexer(nn.Module):
             output_physical_slots=self.output_physical_slots,
             num_q_heads=self.n_head,
             dcp_replicated=self.k_cache.dcp_replicated,
+            dcp_kv_shard_count=self.k_cache.dcp_kv_shard_count,
         )
 
         self.is_inplace_rope = is_inplace_rope

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -383,7 +383,7 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
             parallel_config.prefill_context_parallel_size,
         )
         if self.dcp_world_size > 1:
-            indexer_group = get_indexer_dcp_group()
+            indexer_group = get_indexer_dcp_group(self.dcp_world_size)
             if int(indexer_group.world_size) != self.dcp_world_size:
                 raise RuntimeError(
                     "Indexer metadata DCP group does not match its KV shard count: "

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -8,7 +8,7 @@ import torch
 
 import vllm.envs as envs
 from vllm.config import VllmConfig
-from vllm.distributed import get_dcp_group
+from vllm.distributed import get_indexer_dcp_group
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
@@ -30,7 +30,11 @@ from vllm.v1.attention.backends.utils import (
     get_dcp_local_seq_lens,
     split_decodes_and_prefills,
 )
-from vllm.v1.kv_cache_interface import AttentionSpec, MLAAttentionSpec
+from vllm.v1.kv_cache_interface import (
+    AttentionSpec,
+    MLAAttentionSpec,
+    get_kv_cache_cp_shard_count,
+)
 
 logger = init_logger(__name__)
 
@@ -284,9 +288,12 @@ def get_indexer_max_num_blocks_per_req(
     block_size: int,
     configured_cp_world_size: int,
     dcp_replicated: bool,
+    dcp_kv_shard_count: int | None = None,
 ) -> int:
     """Size indexer metadata for the cache group's effective DCP layout."""
-    effective_cp_world_size = 1 if dcp_replicated else configured_cp_world_size
+    effective_cp_world_size = (
+        1 if dcp_replicated else int(dcp_kv_shard_count or configured_cp_world_size)
+    )
     return cdiv(max_model_len, block_size * effective_cp_world_size)
 
 
@@ -370,8 +377,21 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
         configured_cp_world_size = (
             configured_dcp_world_size * parallel_config.prefill_context_parallel_size
         )
-        self.dcp_world_size = 1 if self.dcp_replicated else configured_dcp_world_size
-        self.dcp_rank = get_dcp_group().rank_in_group if self.dcp_world_size > 1 else 0
+        self.dcp_world_size = get_kv_cache_cp_shard_count(
+            self.kv_cache_spec,
+            configured_dcp_world_size,
+            parallel_config.prefill_context_parallel_size,
+        )
+        if self.dcp_world_size > 1:
+            indexer_group = get_indexer_dcp_group()
+            if int(indexer_group.world_size) != self.dcp_world_size:
+                raise RuntimeError(
+                    "Indexer metadata DCP group does not match its KV shard count: "
+                    f"group={indexer_group.world_size}, shards={self.dcp_world_size}"
+                )
+            self.dcp_rank = int(indexer_group.rank_in_group)
+        else:
+            self.dcp_rank = 0
         self.cp_kv_cache_interleave_size = parallel_config.cp_kv_cache_interleave_size
         # The DCP sparse-indexer code is parameterized by interleave size, but
         # interleave > 1 is not yet validated end-to-end (gsm8k parity fails),
@@ -472,6 +492,7 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
             self.kv_cache_spec.block_size,
             configured_cp_world_size,
             self.dcp_replicated,
+            getattr(self.kv_cache_spec, "dcp_kv_shard_count", None),
         )
         # Keep the expanded decode table layout identical to the model
         # runner's block table. The runner right-pads rows to a 128-token

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -331,15 +331,34 @@ class KVCacheCoordinator(ABC):
             for manager in managers[1:]
         )
 
+        cow_block_idx = managers[0].pending_cow_block_index(request_id)
         new_blocks = managers[0].allocate_new_blocks(
             request_id,
             num_tokens,
             num_tokens_main_model,
         )
+        blocks_to_append = new_blocks
+        cow_block = None
+        if cow_block_idx is not None:
+            cow_block = managers[0].req_to_blocks[request_id][cow_block_idx]
+            assert new_blocks and new_blocks[0] is cow_block
+            blocks_to_append = new_blocks[1:]
+
         for manager in managers[1:]:
-            if new_blocks:
-                self.block_pool.touch(new_blocks)
-                manager.req_to_blocks[request_id].extend(new_blocks)
+            peer_cow_idx = manager.pending_cow_block_index(request_id)
+            assert peer_cow_idx == cow_block_idx
+            if cow_block_idx is not None:
+                assert cow_block is not None
+                manager.apply_lockstep_cow(request_id, cow_block_idx, cow_block)
+            if blocks_to_append:
+                self.block_pool.touch(blocks_to_append)
+                manager.req_to_blocks[request_id].extend(blocks_to_append)
+
+        final_ids = [block.block_id for block in managers[0].req_to_blocks[request_id]]
+        assert all(
+            [block.block_id for block in manager.req_to_blocks[request_id]] == final_ids
+            for manager in managers[1:]
+        )
         return tuple(list(new_blocks) for _ in managers)
 
     def cache_blocks(self, request: Request, num_computed_tokens: int) -> None:

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -625,6 +625,26 @@ def hash_block_tokens(
     )
 
 
+def _effective_kv_cache_block_size(
+    spec: KVCacheSpec,
+    dcp_world_size: int,
+    pcp_world_size: int,
+) -> int:
+    is_attention_group = isinstance(spec, AttentionSpec) or (
+        isinstance(spec, UniformTypeKVCacheSpecs)
+        and bool(spec.kv_cache_specs)
+        and all(
+            isinstance(inner_spec, AttentionSpec)
+            for inner_spec in spec.kv_cache_specs.values()
+        )
+    )
+    if not is_attention_group:
+        return spec.block_size
+    return spec.block_size * get_kv_cache_cp_shard_count(
+        spec, dcp_world_size, pcp_world_size
+    )
+
+
 def resolve_kv_cache_block_sizes(
     kv_cache_config: KVCacheConfig,
     vllm_config: VllmConfig,
@@ -651,19 +671,11 @@ def resolve_kv_cache_block_sizes(
 
     if len(groups) <= 1:
         spec = groups[0].kv_cache_spec
-        bs = (
-            spec.block_size * get_kv_cache_cp_shard_count(spec, dcp, pcp)
-            if isinstance(spec, AttentionSpec)
-            else spec.block_size
-        )
+        bs = _effective_kv_cache_block_size(spec, dcp, pcp)
         return bs, bs
 
     group_block_sizes = [
-        g.kv_cache_spec.block_size
-        * get_kv_cache_cp_shard_count(g.kv_cache_spec, dcp, pcp)
-        if isinstance(g.kv_cache_spec, AttentionSpec)
-        else g.kv_cache_spec.block_size
-        for g in groups
+        _effective_kv_cache_block_size(g.kv_cache_spec, dcp, pcp) for g in groups
     ]
     scheduler_block_size = math.lcm(*group_block_sizes)
 
@@ -1684,8 +1696,13 @@ def group_and_unify_kv_cache_specs(
     has_swa = any(
         isinstance(spec, SlidingWindowMLASpec) for spec in kv_cache_spec.values()
     )
+    # Sliding-window and other cache types are grouped independently below.
+    # Detect lockstep only across full MLA/indexer specs so those unrelated
+    # groups cannot hide a valid partial-replication layout.
     lockstep_mla_layout = _is_lockstep_mla_spec_layout(
-        kv_cache_spec.values(), dcp_world_size, pcp_world_size
+        (spec for spec in kv_cache_spec.values() if isinstance(spec, MLAAttentionSpec)),
+        dcp_world_size,
+        pcp_world_size,
     )
     # Any non-default CP layout needs a group separate from normally sharded
     # layers because token ownership and block-table semantics differ.

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1735,7 +1735,7 @@ def group_and_unify_kv_cache_specs(
                     get_kv_cache_cp_shard_count(spec, dcp_world_size, pcp_world_size),
                 )
                 if isinstance(spec, MLAAttentionSpec)
-                else (spec.block_size,)
+                else (type(spec).__name__, spec.block_size)
             )
             grouped_repl_specs[key][name] = spec
         elif isinstance(spec, MLAAttentionSpec):

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -33,6 +33,8 @@ from vllm.v1.kv_cache_interface import (
     SlidingWindowMLASpec,
     SlidingWindowSpec,
     UniformTypeKVCacheSpecs,
+    get_kv_cache_cp_shard_count,
+    has_nondefault_kv_cp_layout,
 )
 from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry
 from vllm.v1.request import Request
@@ -647,14 +649,19 @@ def resolve_kv_cache_block_sizes(
     pcp = vllm_config.parallel_config.prefill_context_parallel_size
     groups = kv_cache_config.kv_cache_groups
 
-    if len(groups) <= 1:  # Single group: block_size * dcp * pcp
-        bs = cache_config.block_size * dcp * pcp
+    if len(groups) <= 1:
+        spec = groups[0].kv_cache_spec
+        bs = (
+            spec.block_size * get_kv_cache_cp_shard_count(spec, dcp, pcp)
+            if isinstance(spec, AttentionSpec)
+            else spec.block_size
+        )
         return bs, bs
 
     group_block_sizes = [
-        g.kv_cache_spec.block_size * dcp * pcp
+        g.kv_cache_spec.block_size
+        * get_kv_cache_cp_shard_count(g.kv_cache_spec, dcp, pcp)
         if isinstance(g.kv_cache_spec, AttentionSpec)
-        and not getattr(g.kv_cache_spec, "dcp_replicated", False)
         else g.kv_cache_spec.block_size
         for g in groups
     ]
@@ -1341,14 +1348,16 @@ def _is_lockstep_mla_spec_layout(
     if not all(isinstance(spec, MLAAttentionSpec) for spec in specs):
         return False
 
-    replication_modes = {bool(getattr(spec, "dcp_replicated", False)) for spec in specs}
-    global_block_sizes = {
-        spec.block_size
-        if getattr(spec, "dcp_replicated", False)
-        else spec.block_size * cp_world_size
+    shard_counts = {
+        get_kv_cache_cp_shard_count(spec, dcp_world_size, pcp_world_size)
         for spec in specs
     }
-    return replication_modes == {False, True} and len(global_block_sizes) == 1
+    global_block_sizes = {
+        spec.block_size
+        * get_kv_cache_cp_shard_count(spec, dcp_world_size, pcp_world_size)
+        for spec in specs
+    }
+    return len(shard_counts) > 1 and len(global_block_sizes) == 1
 
 
 def _use_lockstep_mla_allocation(
@@ -1368,10 +1377,11 @@ def _use_lockstep_mla_allocation(
             if isinstance(group_spec, UniformTypeKVCacheSpecs)
             else [group_spec]
         )
-        group_modes = {
-            bool(getattr(spec, "dcp_replicated", False)) for spec in group_layer_specs
+        group_layouts = {
+            get_kv_cache_cp_shard_count(spec, dcp_world_size, pcp_world_size)
+            for spec in group_layer_specs
         }
-        if len(group_modes) != 1:
+        if len(group_layouts) != 1:
             return False
         layer_specs.extend(group_layer_specs)
 
@@ -1677,14 +1687,14 @@ def group_and_unify_kv_cache_specs(
     lockstep_mla_layout = _is_lockstep_mla_spec_layout(
         kv_cache_spec.values(), dcp_world_size, pcp_world_size
     )
-    # Replicated layers need a group separate from sharded layers because they
-    # have different token ownership and block-table semantics.
-    has_repl = any(
-        getattr(spec, "dcp_replicated", False)
+    # Any non-default CP layout needs a group separate from normally sharded
+    # layers because token ownership and block-table semantics differ.
+    has_custom_cp = any(
+        has_nondefault_kv_cp_layout(spec, dcp_world_size, pcp_world_size)
         and (not isinstance(spec, MLAAttentionSpec) or lockstep_mla_layout)
         for spec in kv_cache_spec.values()
     )
-    if not (has_swa or has_repl):
+    if not (has_swa or has_custom_cp):
         return None
 
     # Other uniform page layouts do not need tuple packing.
@@ -1696,11 +1706,11 @@ def group_and_unify_kv_cache_specs(
     grouped_swa_mla_specs: dict[tuple[int, int, bool, bool], dict[str, KVCacheSpec]] = (
         defaultdict(dict)
     )
-    # Keep incompatible replicated types and page layouts separate. This
-    # includes DFlash drafts and replicated MLA indexer caches.
-    grouped_repl_specs: dict[
-        tuple[int] | tuple[str, int, int], dict[str, KVCacheSpec]
-    ] = defaultdict(dict)
+    # Keep incompatible custom-CP types and page layouts separate. This
+    # includes DFlash drafts and partially/fully replicated MLA indexer caches.
+    grouped_repl_specs: dict[tuple[Any, ...], dict[str, KVCacheSpec]] = defaultdict(
+        dict
+    )
     # NOTE: Here we group SWA layers by (block_size, sliding_window,
     # dcp_replicated, dcp_sharded), which separates SWA layers, C4I+C4A
     # layers, C128A layers, and replicated compressor-state groups.
@@ -1714,11 +1724,16 @@ def group_and_unify_kv_cache_specs(
                     spec.dcp_sharded,
                 )
             ][name] = spec
-        elif getattr(spec, "dcp_replicated", False) and (
+        elif has_nondefault_kv_cp_layout(spec, dcp_world_size, pcp_world_size) and (
             not isinstance(spec, MLAAttentionSpec) or lockstep_mla_layout
         ):
             key = (
-                (type(spec).__name__, spec.block_size, spec.page_size_bytes)
+                (
+                    type(spec).__name__,
+                    spec.block_size,
+                    spec.page_size_bytes,
+                    get_kv_cache_cp_shard_count(spec, dcp_world_size, pcp_world_size),
+                )
                 if isinstance(spec, MLAAttentionSpec)
                 else (spec.block_size,)
             )
@@ -1842,12 +1857,15 @@ def _get_kv_cache_groups_uniform_groups(
     for sm_spec in swa_mla_specs:
         sm_page_sizes = sm_spec.get_page_sizes()
         layers_per_size: dict[int, list[str]] = defaultdict(list)
-        is_replicated_mla = all(
+        is_nondefault_cp_mla = all(
             isinstance(spec, MLAAttentionSpec)
-            and getattr(spec, "dcp_replicated", False)
+            and (
+                getattr(spec, "dcp_replicated", False)
+                or getattr(spec, "dcp_kv_shard_count", None) is not None
+            )
             for spec in sm_spec.kv_cache_specs.values()
         )
-        if not is_replicated_mla:
+        if not is_nondefault_cp_mla:
             assert max(sm_page_sizes) <= max(all_page_sizes)
 
         # Unify page size by padding layers' page_size to the nearest larger page_size.
@@ -1859,7 +1877,7 @@ def _get_kv_cache_groups_uniform_groups(
         # Pad and collect layer names per page size.
         for layer_name, layer_spec in sm_spec.kv_cache_specs.items():
             current_size = layer_spec.page_size_bytes
-            if is_replicated_mla:
+            if is_nondefault_cp_mla:
                 candidate = current_size
             else:
                 assert current_size <= max(all_page_sizes)

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -387,6 +387,31 @@ class SingleTypeKVCacheManager(ABC):
         self._pending_cow_copies = []
         return pending_copies
 
+    def pending_cow_block_index(self, request_id: str) -> int | None:
+        """Return the pending partial-hit CoW index without consuming it."""
+        partial_hit = self._partial_hit_reqs.get(request_id)
+        return partial_hit[0] if partial_hit is not None else None
+
+    def apply_lockstep_cow(
+        self,
+        request_id: str,
+        block_idx: int,
+        cow_block: KVCacheBlock,
+    ) -> None:
+        """Mirror a peer manager's CoW substitution using the same block ID.
+
+        The primary manager owns the physical copy operation. A lockstep peer
+        only transfers its request reference from the shared source block to
+        the already allocated destination block.
+        """
+        pending_idx, source_block = self._partial_hit_reqs.pop(request_id)
+        assert pending_idx == block_idx
+        req_blocks = self.req_to_blocks[request_id]
+        assert req_blocks[block_idx] is source_block
+        self.block_pool.touch([cow_block])
+        req_blocks[block_idx] = cow_block
+        self.block_pool.free_blocks([source_block])
+
     def _apply_cow(
         self,
         request_id: str,

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -28,6 +28,7 @@ from vllm.v1.kv_cache_interface import (
     SlidingWindowMLASpec,
     SlidingWindowSpec,
     TQFullAttentionSpec,
+    get_kv_cache_cp_shard_count,
 )
 from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry
 from vllm.v1.request import Request
@@ -81,10 +82,10 @@ class SingleTypeKVCacheManager(ABC):
         # dcp_replicated groups (e.g. the DFlash draft) instead keep the full
         # cache on every rank, so one block covers exactly `block_size` global
         # tokens and must not be scaled.
-        if dcp_world_size * pcp_world_size > 1 and not getattr(
-            kv_cache_spec, "dcp_replicated", False
-        ):
-            self.block_size *= dcp_world_size * pcp_world_size
+        if dcp_world_size * pcp_world_size > 1:
+            self.block_size *= get_kv_cache_cp_shard_count(
+                kv_cache_spec, dcp_world_size, pcp_world_size
+            )
         self.kv_cache_spec = kv_cache_spec
         self.block_pool = block_pool
         self.enable_caching = enable_caching
@@ -682,13 +683,13 @@ class FullAttentionManager(SingleTypeKVCacheManager):
             "and chunked local attention groups"
         )
         block_size = kv_cache_spec.block_size
-        if dcp_world_size * pcp_world_size > 1 and not getattr(
-            kv_cache_spec, "dcp_replicated", False
-        ):
+        if dcp_world_size * pcp_world_size > 1:
             # DCP/PCP shard each block's KV across ranks; hashes must be
             # viewed at the sharded (scaled) block size. Replicated groups
             # keep the model block size on every rank.
-            block_size *= dcp_world_size * pcp_world_size
+            block_size *= get_kv_cache_cp_shard_count(
+                kv_cache_spec, dcp_world_size, pcp_world_size
+            )
         block_hashes = resolve_block_hashes(
             block_hashes,
             block_pool.hash_block_size,
@@ -894,12 +895,12 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
         assert isinstance(kv_cache_spec, SlidingWindowSpec), (
             "SlidingWindowManager can only be used for sliding window groups"
         )
-        assert (
-            dcp_world_size == 1 or kv_cache_spec.dcp_replicated
-        ), "DCP only supports sliding-window KV when it is dcp_replicated."
-        assert (
-            pcp_world_size == 1 or kv_cache_spec.dcp_replicated
-        ), "PCP only supports sliding-window KV when it is dcp_replicated."
+        assert dcp_world_size == 1 or kv_cache_spec.dcp_replicated, (
+            "DCP only supports sliding-window KV when it is dcp_replicated."
+        )
+        assert pcp_world_size == 1 or kv_cache_spec.dcp_replicated, (
+            "PCP only supports sliding-window KV when it is dcp_replicated."
+        )
         # Fine-grained partial hits are not supported for sliding window now
         assert alignment_tokens % kv_cache_spec.block_size == 0, (
             "SlidingWindowManager does not support fine-grained (partial) cache hits"
@@ -1831,9 +1832,9 @@ def get_manager_for_kv_cache_spec(
                 kv_cache_spec.sliding_window - 1 + max_in_flight_tokens,
                 max_model_len,
             )
-            kwargs["max_admission_blocks_per_request"] = cdiv(
-                num_tokens, block_size
-            ) + 1
+            kwargs["max_admission_blocks_per_request"] = (
+                cdiv(num_tokens, block_size) + 1
+            )
         else:
             kwargs["max_admission_blocks_per_request"] = (
                 kv_cache_spec.max_admission_blocks_per_request(

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -170,10 +170,17 @@ class KVCacheSpec:
         # Keep DCP-replicated layers (DFlash draft) out of a shared group with
         # DCP-sharded layers (MLA target): one group carries a single cp_size.
         # group_and_unify_kv_cache_specs then routes them as separate groups.
-        self_repl = getattr(self, "dcp_replicated", False)
+        self_layout = (
+            getattr(self, "dcp_replicated", False),
+            getattr(self, "dcp_kv_shard_count", None),
+        )
         return all(
             isinstance(spec, uniform_type_base_spec)
-            and getattr(spec, "dcp_replicated", False) == self_repl
+            and (
+                getattr(spec, "dcp_replicated", False),
+                getattr(spec, "dcp_kv_shard_count", None),
+            )
+            == self_layout
             for spec in kv_cache_specs.values()
         )
 
@@ -268,6 +275,15 @@ class FullAttentionSpec(AttentionSpec):
     backend cannot reduce across DCP ranks (e.g. the DFlash draft); every
     rank then stores and attends over the full context."""
 
+    dcp_kv_shard_count: int | None = None
+    """Optional number of unique KV shards inside the configured DCP group.
+
+    ``None`` uses every configured DCP/PCP rank. A proper divisor creates
+    replicated shard groups; for example, four shards under DCP8 stores the
+    same shard on ranks ``r`` and ``r + 4``. Full replication continues to use
+    ``dcp_replicated=True``.
+    """
+
     def __post_init__(self):
         if self.head_size_v is None:
             object.__setattr__(self, "head_size_v", self.head_size)
@@ -276,10 +292,9 @@ class FullAttentionSpec(AttentionSpec):
         max_model_len = vllm_config.model_config.max_model_len
         dcp_world_size = vllm_config.parallel_config.decode_context_parallel_size
         pcp_world_size = vllm_config.parallel_config.prefill_context_parallel_size
-        # Note(hc): each dcp rank only need save
-        # (max_model_len//dcp_world_size) tokens locally.
-        if dcp_world_size * pcp_world_size > 1 and not self.dcp_replicated:
-            max_model_len = cdiv(max_model_len, dcp_world_size * pcp_world_size)
+        cp_shards = get_kv_cache_cp_shard_count(self, dcp_world_size, pcp_world_size)
+        if cp_shards > 1:
+            max_model_len = cdiv(max_model_len, cp_shards)
         return cdiv(max_model_len, self.block_size) * self.page_size_bytes
 
     @classmethod
@@ -330,6 +345,7 @@ class FullAttentionSpec(AttentionSpec):
             # non-causal so the engine core disables incompatible scheduling.
             non_causal=any(spec.non_causal for spec in specs),
             dcp_replicated=specs[0].dcp_replicated,
+            dcp_kv_shard_count=specs[0].dcp_kv_shard_count,
         )
         for spec in specs:
             for f in fields(AttentionSpec):
@@ -361,6 +377,48 @@ class FullAttentionSpec(AttentionSpec):
         return (
             self.block_size * self.num_kv_heads * last_dim * get_dtype_size(self.dtype)
         )
+
+
+def get_kv_cache_cp_shard_count(
+    spec: KVCacheSpec,
+    dcp_world_size: int,
+    pcp_world_size: int = 1,
+) -> int:
+    """Return the number of unique token-position shards for a cache group."""
+    configured_cp = int(dcp_world_size) * int(pcp_world_size)
+    if configured_cp < 1:
+        raise ValueError(
+            f"Configured context-parallel size must be positive: {configured_cp}"
+        )
+    replicated = bool(getattr(spec, "dcp_replicated", False))
+    override = getattr(spec, "dcp_kv_shard_count", None)
+    if replicated:
+        if override not in (None, 1):
+            raise ValueError(
+                f"dcp_replicated cannot be combined with dcp_kv_shard_count={override}"
+            )
+        return 1
+    if override is None:
+        return configured_cp
+    override = int(override)
+    if pcp_world_size != 1:
+        raise ValueError("Partial KV replication currently requires PCP1")
+    if override < 1 or override > configured_cp or configured_cp % override != 0:
+        raise ValueError(
+            "dcp_kv_shard_count must be a positive divisor of the configured "
+            f"DCP size, got shards={override}, DCP={configured_cp}"
+        )
+    return override
+
+
+def has_nondefault_kv_cp_layout(
+    spec: KVCacheSpec,
+    dcp_world_size: int,
+    pcp_world_size: int = 1,
+) -> bool:
+    return get_kv_cache_cp_shard_count(spec, dcp_world_size, pcp_world_size) != int(
+        dcp_world_size
+    ) * int(pcp_world_size)
 
 
 def _apply_alignment_padding(spec: MLAAttentionSpec | SlidingWindowMLASpec):
@@ -463,6 +521,7 @@ class MLAAttentionSpec(FullAttentionSpec):
         model_version_set = set(spec.model_version for spec in specs)
         block_stride_set = set(spec.indexes_kv_by_block_stride for spec in specs)
         dcp_replicated_set = set(spec.dcp_replicated for spec in specs)
+        dcp_kv_shard_count_set = set(spec.dcp_kv_shard_count for spec in specs)
         assert (
             len(cache_dtype_str_set) == 1
             and len(dtype_set) == 1
@@ -471,6 +530,7 @@ class MLAAttentionSpec(FullAttentionSpec):
             and len(model_version_set) == 1
             and len(block_stride_set) == 1
             and len(dcp_replicated_set) == 1
+            and len(dcp_kv_shard_count_set) == 1
         ), (
             "All attention layers in the same KV cache group must use the same "
             "dtype, quantization method, compress ratio, model version, and "
@@ -488,6 +548,7 @@ class MLAAttentionSpec(FullAttentionSpec):
             compress_ratio=compress_ratio_set.pop(),
             model_version=model_version_set.pop(),
             dcp_replicated=dcp_replicated_set.pop(),
+            dcp_kv_shard_count=dcp_kv_shard_count_set.pop(),
         )
 
 
@@ -920,6 +981,18 @@ class UniformTypeKVCacheSpecs(KVCacheSpec):
             getattr(spec, "dcp_replicated", False)
             for spec in self.kv_cache_specs.values()
         )
+
+    @property
+    def dcp_kv_shard_count(self) -> int | None:
+        shard_counts = {
+            getattr(spec, "dcp_kv_shard_count", None)
+            for spec in self.kv_cache_specs.values()
+        }
+        if len(shard_counts) != 1:
+            raise ValueError(
+                f"A uniform KV cache group cannot mix DCP shard counts: {shard_counts}"
+            )
+        return shard_counts.pop()
 
     def max_memory_usage_bytes(self, vllm_config: VllmConfig) -> int:
         max_num_pages = max(

--- a/vllm/v1/worker/gpu/block_table.py
+++ b/vllm/v1/worker/gpu/block_table.py
@@ -332,8 +332,11 @@ def _compute_slot_mappings_kernel(
             if group_cp_size == 1:
                 slot_ids = block_numbers * block_size + block_offsets
             else:
-                is_local = block_offsets // CP_INTERLEAVE % CP_SIZE == cp_rank
-                rounds = block_offsets // (CP_INTERLEAVE * CP_SIZE)
+                group_cp_rank = cp_rank % group_cp_size
+                is_local = (
+                    block_offsets // CP_INTERLEAVE % group_cp_size == group_cp_rank
+                )
+                rounds = block_offsets // (CP_INTERLEAVE * group_cp_size)
                 remainder = block_offsets % CP_INTERLEAVE
                 local_offsets = rounds * CP_INTERLEAVE + remainder
                 slot_ids = block_numbers * block_size + local_offsets

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -56,7 +56,11 @@ from vllm.utils.math_utils import cdiv
 from vllm.utils.mem_utils import DeviceMemoryProfiler, format_gib
 from vllm.utils.torch_utils import PIN_MEMORY, STR_DTYPE_TO_TORCH_DTYPE
 from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
-from vllm.v1.kv_cache_interface import KVCacheConfig, MambaSpec
+from vllm.v1.kv_cache_interface import (
+    KVCacheConfig,
+    MambaSpec,
+    get_kv_cache_cp_shard_count,
+)
 from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry
 from vllm.v1.outputs import DraftTokenIds, ModelRunnerOutput
 from vllm.v1.utils import record_function_or_nullcontext
@@ -515,8 +519,10 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             # As a result, one block on the current rank covers `block_size * cp_size`
             # tokens in the full, global (unsharded) sequence. dcp_replicated
             # groups keep the full cache on every rank instead.
-            group_cp_size = (
-                1 if getattr(spec, "dcp_replicated", False) else self.dcp_size
+            group_cp_size = get_kv_cache_cp_shard_count(
+                spec,
+                self.dcp_size,
+                self.parallel_config.prefill_context_parallel_size,
             )
             group_cp_sizes.append(group_cp_size)
             max_num_blocks = cdiv(


### PR DESCRIPTION
## Summary

Add an opt-in partial-replication topology for the GLM sparse-indexer cache.
This PR now builds directly on `dev/gilded-gnosis` after #159 was merged as
`4247d676`; it no longer contains or duplicates any #159 commits.

## Design

- `VLLM_DCP_INDEXER_SHARDS=0` keeps the indexer sharded by the configured DCP.
- `VLLM_DCP_INDEXER_SHARDS=1` fully replicates the indexer cache.
- An intermediate divisor creates replicated shard groups. Under DCP8, `4`
  creates `{0,1,2,3}` and `{4,5,6,7}` indexer groups with cross-replica query
  groups `{0,4}`, `{1,5}`, `{2,6}`, and `{3,7}`.
- The main MLA CKV cache remains sharded by the configured DCP.
- Mixed MLA groups retain one logical block-ID lifecycle while using their own
  physical page geometry, block tables, and slot mapping.
- Unsupported non-divisors, PCP layouts, and non-V2 runners fail explicitly.

The legacy `VLLM_DCP_REPLICATE_INDEXER_CACHE=1` switch remains backward
compatible and maps to one indexer shard. All new behavior defaults off.

## Measured impact

GLM-5.2 NVFP4 A16, TP8, MTP0, 8x RTX PRO 6000 Blackwell. Baseline and candidate
used the same image, helper, GPU group, and serial benchmark protocol. The
measured image also contained the independent prefill PRs #177 and #178; this
PR does not include their code.

| Topology | Prefill 64k | Prefill 400k | Decode ctx0 / 64k / 400k | KV tokens |
|---|---:|---:|---:|---:|
| DCP4 sharded | 5,772 | 5,077.8 | 67.32 / 65.53 / 65.92 | 2,088,704 |
| DCP4 partial 2x2 | 5,836 +/- 23 | 5,110.2 +/- 7.0 | 73.19 / 71.50 / 70.03 | 1,984,256 |
| DCP8 sharded | 3,279 | 2,989.6 | 66.59 / 66.43 / 66.41 | 4,174,336 |
| DCP8 partial 2x4 | 5,772 +/- 6 | 5,030.5 +/- 1.3 | 68.02 / 66.06 / 66.48 | 3,964,928 |

DCP4 partial improves CC1 decode by 6.25-9.10% and prefill by 0.64-1.1% for a
5.0% KV-capacity cost. DCP8 partial improves prefill by 68.3-76.0%, keeps long
decode effectively in parity, and also costs about 5.0% KV capacity.

## Validation

- Rebased directly onto GG `4247d676`, with exactly five #179-specific commits.
- `git range-diff` confirms semantic parity with the original unique commit
  range; the only behavior adjustment keeps #159's supported external-load
  contract instead of the obsolete rejection test.
- All 18 changed Python files pass Ruff check and format check.
- Focused partial-topology suite: 16 passed, 1 GPU-only test skipped.
- Broader affected suite: 247 passed and 22 skipped; 14 unrelated cases require
  CUDA platform detection unavailable in the CPU-only test container.
- Existing E2E TP8/DCP4 partial 2x2 and TP8/DCP8 partial 2x4 startup,
  64k/400k prefill, and CC1 decode validation remains applicable because the
  production diff is semantically unchanged.

The lockstep allocator and full-replication foundation are provided by merged
#159. This PR's review unit is the partial topology, dedicated process groups,
generalized cache geometry, query-split composition, and their tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `VLLM_DCP_INDEXER_SHARDS` to control sparse-indexer KV sharding/replication within DCP groups.
  * Introduced indexer-aware DCP/query-split process group selection and exposed indexer DCP/query-split group accessors.
  * Updated sparse indexer and KV-cache planning to support replicated and partially replicated layouts.
  * Extended lockstep MLA allocation and KVCache coherence behavior.

* **Bug Fixes**
  * Improved DCP attention/indexer group rank handling and empty-key/value reference attention behavior.
  * Fixed lockstep MLA copy-on-write mirroring semantics.

* **Tests**
  * Expanded distributed, attention, KV-cache, prefix caching, and GPU slot-mapping coverage for DCP/PCP and partial replication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->