### PR TITLE
[GG] Fix MRV2 profiled CUDA graph pool lifecycle

### DIFF
--- a/tests/v1/cudagraph/test_breakable_cudagraph.py
+++ b/tests/v1/cudagraph/test_breakable_cudagraph.py
@@ -44,9 +44,7 @@ def test_memory_profile_cleanup_resets_backend_cache_bindings(monkeypatch):
     runner.kv_block_zeroer = object()
     runner.verification_capacity_manager = object()
     runner.cache_config = SimpleNamespace(num_gpu_blocks=1)
-    runner.compilation_config = SimpleNamespace(
-        static_forward_context={"layer": layer}
-    )
+    runner.compilation_config = SimpleNamespace(static_forward_context={"layer": layer})
 
     monkeypatch.setattr(torch.accelerator, "synchronize", lambda: None)
     monkeypatch.setattr(torch.accelerator, "empty_cache", lambda: None)
@@ -81,13 +79,14 @@ def test_cudagraph_manager_clear_releases_capture_state():
     assert manager.intermediate_tensors is None
 
 
-def test_memory_profile_destroys_graphs_before_restoring_pools(monkeypatch):
+def test_memory_profile_reuses_production_pool_and_destroys_graphs(monkeypatch):
     from vllm.v1.worker import workspace as workspace_module
     from vllm.v1.worker.gpu import model_runner as model_runner_module
 
-    profile_pool = object()
-    production_pool = object()
     events: list[str] = []
+    production_pool = object()
+    anchor_graph = SimpleNamespace(reset=lambda: events.append("anchor_reset"))
+    anchor_token = object()
     lazy_wrappers: list[FakeWrapper] = []
 
     class FakeManager:
@@ -98,8 +97,8 @@ def test_memory_profile_destroys_graphs_before_restoring_pools(monkeypatch):
             return True
 
         def capture(self, *args, **kwargs):
-            assert self.pool is profile_pool
-            assert wrapper.graph_pool is profile_pool
+            assert self.pool is production_pool
+            assert wrapper.graph_pool is production_pool
             lazy_wrapper = FakeWrapper()
             lazy_wrapper.graph_pool = self.pool
             lazy_wrappers.append(lazy_wrapper)
@@ -123,6 +122,7 @@ def test_memory_profile_destroys_graphs_before_restoring_pools(monkeypatch):
         model_runner_module.GPUModelRunner
     )
     runner.vllm_config = object()
+    runner.device = torch.device("cuda")
     runner.cudagraph_manager = manager
     runner.speculator = FakeSpeculator()
     runner.lora_config = None
@@ -137,12 +137,13 @@ def test_memory_profile_destroys_graphs_before_restoring_pools(monkeypatch):
     runner._init_minimal_kv_cache_for_profiling = lambda: None
     runner.maybe_setup_dummy_loras = lambda _: nullcontext()
     runner._zero_cudagraph_capture_kv_blocks = lambda: None
+    runner._cudagraph_pool_anchor = None
 
     def cleanup():
         events.append("cleanup")
-        assert manager.pool is profile_pool
-        assert wrapper.graph_pool is profile_pool
-        assert lazy_wrappers[0].graph_pool is profile_pool
+        assert manager.pool is production_pool
+        assert wrapper.graph_pool is production_pool
+        assert lazy_wrappers[0].graph_pool is production_pool
 
     runner._cleanup_cudagraph_memory_profile = cleanup
 
@@ -154,12 +155,24 @@ def test_memory_profile_destroys_graphs_before_restoring_pools(monkeypatch):
         model_runner_module,
         "current_platform",
         SimpleNamespace(
-            graph_pool_handle=lambda: profile_pool,
+            graph_pool_handle=lambda: pytest.fail(
+                "memory profiling must not allocate a disposable graph pool"
+            ),
             get_global_graph_pool=lambda: production_pool,
         ),
     )
     monkeypatch.setattr(
         model_runner_module.CUDAGraphWrapper, "_all_instances", [wrapper]
+    )
+
+    def create_anchor(pool, device):
+        events.append("anchor_create")
+        return anchor_graph, anchor_token
+
+    monkeypatch.setattr(
+        model_runner_module,
+        "_create_cudagraph_pool_anchor",
+        create_anchor,
     )
     monkeypatch.setattr(
         model_runner_module.BreakableCUDAGraphWrapper,
@@ -170,10 +183,15 @@ def test_memory_profile_destroys_graphs_before_restoring_pools(monkeypatch):
     monkeypatch.setattr(torch.accelerator, "empty_cache", lambda: None)
     monkeypatch.setattr(torch.accelerator, "synchronize", lambda: None)
     monkeypatch.setattr(torch.accelerator, "get_memory_info", lambda: next(memory_info))
+
+    def checkpoint_graph_channels():
+        events.append("checkpoint")
+        return ("channel-checkpoint",)
+
     monkeypatch.setattr(
         model_runner_module,
         "checkpoint_b12x_graph_channels",
-        lambda: events.append("checkpoint") or ("channel-checkpoint",),
+        checkpoint_graph_channels,
     )
     monkeypatch.setattr(
         model_runner_module,
@@ -185,11 +203,12 @@ def test_memory_profile_destroys_graphs_before_restoring_pools(monkeypatch):
         ),
     )
 
-    assert runner.profile_cudagraph_memory() == 50
+    assert runner.profile_cudagraph_memory() == 100
     assert events == [
         "checkpoint",
         "capture",
         "spec_capture",
+        "anchor_create",
         "cleanup",
         "rollback",
     ]
@@ -197,6 +216,101 @@ def test_memory_profile_destroys_graphs_before_restoring_pools(monkeypatch):
     assert manager.pool is production_pool
     assert wrapper.graph_pool is production_pool
     assert lazy_wrappers[0].graph_pool is production_pool
+    assert runner._cudagraph_pool_anchor == (anchor_graph, anchor_token)
+
+    runner._release_cudagraph_pool_anchor()
+    assert runner._cudagraph_pool_anchor is None
+    assert events[-1] == "anchor_reset"
+
+
+def test_production_capture_releases_pool_anchor_on_failure(monkeypatch):
+    from vllm.v1.worker.gpu import model_runner as model_runner_module
+
+    events: list[str] = []
+
+    class FakeManager:
+        @staticmethod
+        def needs_capture():
+            return True
+
+        @staticmethod
+        def capture(*args, **kwargs):
+            events.append("capture")
+            raise RuntimeError("capture failed")
+
+    runner = model_runner_module.GPUModelRunner.__new__(
+        model_runner_module.GPUModelRunner
+    )
+    runner.cudagraph_manager = FakeManager()
+    runner._cudagraph_pool_anchor = (
+        SimpleNamespace(reset=lambda: events.append("anchor_reset")),
+        object(),
+    )
+    runner.lora_config = None
+    runner.model = object()
+    runner.model_state = object()
+    runner.input_buffers = object()
+    runner.intermediate_tensors = object()
+    runner.block_tables = object()
+    runner.attn_groups = object()
+    runner.kv_cache_config = object()
+    runner.use_aux_hidden_state_outputs = False
+    runner.speculator = None
+    runner.maybe_setup_dummy_loras = lambda _: nullcontext()
+
+    monkeypatch.setattr(model_runner_module.gc, "collect", lambda: None)
+    monkeypatch.setattr(torch.accelerator, "empty_cache", lambda: None)
+    monkeypatch.setattr(torch.accelerator, "get_memory_info", lambda: (1000, 0))
+
+    with pytest.raises(RuntimeError, match="capture failed"):
+        runner.capture_model()
+
+    assert runner._cudagraph_pool_anchor is None
+    assert events == ["capture", "anchor_reset"]
+
+
+def test_skipped_production_capture_releases_pool_anchor():
+    from vllm.v1.worker.gpu import model_runner as model_runner_module
+
+    events: list[str] = []
+    runner = model_runner_module.GPUModelRunner.__new__(
+        model_runner_module.GPUModelRunner
+    )
+    runner.cudagraph_manager = SimpleNamespace(needs_capture=lambda: False)
+    runner._cudagraph_pool_anchor = (
+        SimpleNamespace(reset=lambda: events.append("anchor_reset")),
+        object(),
+    )
+
+    assert runner.capture_model() == 0
+    assert runner._cudagraph_pool_anchor is None
+    assert events == ["anchor_reset"]
+
+
+def test_shutdown_releases_pool_anchor(monkeypatch):
+    from vllm.v1.worker.gpu import model_runner as model_runner_module
+
+    events: list[str] = []
+    runner = model_runner_module.GPUModelRunner.__new__(
+        model_runner_module.GPUModelRunner
+    )
+    runner.vllm_config = object()
+    runner._cudagraph_pool_anchor = (
+        SimpleNamespace(reset=lambda: events.append("anchor_reset")),
+        object(),
+    )
+
+    monkeypatch.setattr(
+        torch.accelerator, "synchronize", lambda: events.append("synchronize")
+    )
+    monkeypatch.setattr(torch.accelerator, "empty_cache", lambda: None)
+    monkeypatch.setattr(model_runner_module.gc, "collect", lambda: None)
+    monkeypatch.setattr(model_runner_module, "free_before_shutdown", lambda _: None)
+
+    runner.shutdown()
+
+    assert runner._cudagraph_pool_anchor is None
+    assert events == ["synchronize", "anchor_reset"]
 
 
 def test_breakable_runner_inherits_active_manager_pool(monkeypatch):

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -21,6 +21,7 @@ import functools
 import gc
 import sys
 import time
+from collections.abc import Callable
 from copy import deepcopy
 from typing import Any, NamedTuple
 
@@ -146,6 +147,30 @@ def _maybe_save_b12x_moe_activation_amax() -> None:
 
 def _profile_cg_mode(cg_mode: CUDAGraphMode) -> str:
     return cg_mode.name.lower()
+
+
+def _create_cudagraph_pool_anchor(
+    pool: Any, device: torch.device
+) -> tuple[torch.cuda.CUDAGraph, torch.Tensor]:
+    """Keep a graph-private pool live between profiling and real capture.
+
+    PyTorch cannot reopen a pool whose last graph was reset while allocations
+    remain. This tiny graph holds the pool reference until production capture.
+
+    Args:
+        pool: CUDA graph pool to retain.
+        device: CUDA device on which to create the anchor.
+
+    Returns:
+        The anchor graph and its retained token tensor.
+    """
+    token = torch.zeros(1, device=device)
+    token.add_(0)
+    torch.accelerator.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, pool=pool):
+        token.add_(0)
+    return graph, token
 
 
 def _profile_batch_phase(input_batch: InputBatch, dummy_run: bool = False) -> str:
@@ -296,6 +321,9 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         self.prompt_logprobs_worker: PromptLogprobsWorker | None = None
         self.structured_outputs_worker: StructuredOutputsWorker | None = None
         self.cudagraph_manager: ModelCudaGraphManager | None = None
+        self._cudagraph_pool_anchor: (
+            tuple[torch.cuda.CUDAGraph, torch.Tensor] | None
+        ) = None
 
         # LoRA-related workers.
         self.lora_state = LoraState(max_num_reqs=self.max_num_reqs)
@@ -859,9 +887,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             # production cache. Keep the hook optional so backends without
             # cache-generation state pay no cost.
             impl = getattr(layer, "impl", None)
-            reset_binding_state = getattr(
-                impl, "reset_kv_cache_binding_state", None
-            )
+            reset_binding_state = getattr(impl, "reset_kv_cache_binding_state", None)
             if reset_binding_state is not None:
                 reset_binding_state()
             if hasattr(layer, "kv_cache"):
@@ -874,6 +900,15 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         torch.accelerator.empty_cache()
         torch.accelerator.synchronize()
 
+    def _release_cudagraph_pool_anchor(self) -> None:
+        anchor = getattr(self, "_cudagraph_pool_anchor", None)
+        if anchor is None:
+            return
+        self._cudagraph_pool_anchor = None
+        graph, token = anchor
+        graph.reset()
+        del token
+
     def profile_cudagraph_memory(self) -> int:
         with set_current_vllm_config(self.vllm_config):
             self._init_minimal_kv_cache_for_profiling()
@@ -884,7 +919,11 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             return 0
 
         saved_num_cudagraph_captured = compilation_counter.num_cudagraph_captured
-        profiling_pool = current_platform.graph_pool_handle()
+        # Profile into the same pool used by the production capture. Destroying
+        # graphs can leave physical pages retained by their pool; a different
+        # disposable pool strands those pages. Reusing the global pool lets the
+        # production capture consume its retained capacity.
+        profiling_pool = current_platform.get_global_graph_pool()
         managers = [self.cudagraph_manager]
         if self.speculator is not None:
             managers.extend(self.speculator.get_cudagraph_managers())
@@ -905,9 +944,9 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         torch.accelerator.empty_cache()
         torch.accelerator.synchronize()
         start_free_gpu_memory = torch.accelerator.get_memory_info()[0]
-        graph_channel_checkpoints = ()
+        graph_channel_checkpoints: tuple[tuple[Callable[[Any], None], Any], ...] = ()
         try:
-            # Snapshot graph-owned SparkInfer channels before this disposable
+            # Snapshot graph-owned SparkInfer channels before this profiling
             # capture so profiling cannot leave stale channels behind.
             graph_channel_checkpoints = checkpoint_b12x_graph_channels()
             with self.maybe_setup_dummy_loras(self.lora_config):
@@ -930,10 +969,14 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 self._zero_cudagraph_capture_kv_blocks()
             end_free_gpu_memory = torch.accelerator.get_memory_info()[0]
             gross_cuda_graph_size = max(start_free_gpu_memory - end_free_gpu_memory, 0)
+            assert getattr(self, "_cudagraph_pool_anchor", None) is None
+            self._cudagraph_pool_anchor = _create_cudagraph_pool_anchor(
+                profiling_pool, self.device
+            )
         finally:
             try:
-                # Destroy disposable graphs while every manager and wrapper still
-                # points at the private pool that owns their allocations.
+                # Destroy profiling graphs while every manager and wrapper still
+                # points at the pool that owns their allocations.
                 try:
                     self._cleanup_cudagraph_memory_profile()
                 finally:
@@ -957,15 +1000,15 @@ class GPUModelRunner(LoRAModelRunnerMixin):
 
         free_after_cleanup = torch.accelerator.get_memory_info()[0]
         retained_pool_size = max(start_free_gpu_memory - free_after_cleanup, 0)
-        # A CUDA graph private pool can retain physical pages after its graph
-        # objects are destroyed. memory_profiling observes those pages as
-        # non-torch memory, so only return the remaining capture cost here.
-        cuda_graph_size = max(gross_cuda_graph_size - retained_pool_size, 0)
+        # Retained private-pool pages are PyTorch-reserved. The outer profiler
+        # deliberately restores the pre-graph torch peak, so they are not
+        # accounted elsewhere. Reserve the complete graph high-water mark;
+        # production reuses the retained portion and allocates only the rest.
+        cuda_graph_size = gross_cuda_graph_size
         logger.info(
-            "Estimated MRV2 CUDA graph memory: %.2f GiB additional "
-            "(%.2f GiB captured, %.2f GiB retained and counted as non-torch)",
+            "Estimated MRV2 CUDA graph memory: %.2f GiB total "
+            "(%.2f GiB retained in the reusable pool)",
             cuda_graph_size / (1 << 30),
-            gross_cuda_graph_size / (1 << 30),
             retained_pool_size / (1 << 30),
         )
         return int(cuda_graph_size)
@@ -974,6 +1017,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
     def capture_model(self) -> int:
         assert self.cudagraph_manager is not None
         if not self.cudagraph_manager.needs_capture():
+            self._release_cudagraph_pool_anchor()
             logger.warning(
                 "Skipping CUDA graph capture. To turn on CUDA graph capture, "
                 "ensure `cudagraph_mode` was not manually set to `NONE`"
@@ -987,23 +1031,26 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         torch.accelerator.empty_cache()
         start_free_gpu_memory = torch.accelerator.get_memory_info()[0]
 
-        with self.maybe_setup_dummy_loras(self.lora_config):
-            self.cudagraph_manager.capture(
-                self.model,
-                self.model_state,
-                self.input_buffers,
-                self.intermediate_tensors,
-                self.block_tables,
-                self.attn_groups,
-                self.kv_cache_config,
-                has_lora=self.lora_config is not None,
-                use_aux_hidden_state_outputs=self.use_aux_hidden_state_outputs,
-                lora_capture_hook=create_lora_capture_hook(self.lora_config, self),
-            )
-            if self.speculator is not None:
-                with use_workspace_lane(1):
-                    self.speculator.capture()
-            self._zero_cudagraph_capture_kv_blocks()
+        try:
+            with self.maybe_setup_dummy_loras(self.lora_config):
+                self.cudagraph_manager.capture(
+                    self.model,
+                    self.model_state,
+                    self.input_buffers,
+                    self.intermediate_tensors,
+                    self.block_tables,
+                    self.attn_groups,
+                    self.kv_cache_config,
+                    has_lora=self.lora_config is not None,
+                    use_aux_hidden_state_outputs=self.use_aux_hidden_state_outputs,
+                    lora_capture_hook=create_lora_capture_hook(self.lora_config, self),
+                )
+                if self.speculator is not None:
+                    with use_workspace_lane(1):
+                        self.speculator.capture()
+                self._zero_cudagraph_capture_kv_blocks()
+        finally:
+            self._release_cudagraph_pool_anchor()
 
         end_time = time.perf_counter()
         end_free_gpu_memory = torch.accelerator.get_memory_info()[0]
@@ -2102,6 +2149,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         """Release GPU tensors (model weights, KV caches, workspace) so that
         memory is reclaimable when running in the same process."""
         torch.accelerator.synchronize()
+        self._release_cudagraph_pool_anchor()
         if hasattr(self, "kv_caches"):
             self.kv_caches.clear()
         if hasattr(self, "attn_groups"):


### PR DESCRIPTION
## Summary

Preserve the CUDA graph private-pool lifecycle across MRV2 graph-memory
profiling and production capture.

The previous implementation profiled into a graph pool, reset every graph,
kept allocations from that pool alive, and then attempted to capture new
graphs into the same pool handle. PyTorch's caching allocator rejects that
state: once the last graph reference is gone, a private pool with live
allocations has `use_count == 0` and cannot be reopened.

This change:

- profiles into the production graph pool so retained pages are reusable;
- captures one allocation-free anchor graph before profiling graphs are reset;
- keeps the anchor alive until production graphs replace it;
- releases the anchor on success, skipped capture, and capture failure;
- reserves the complete graph high-water mark because retained pool pages are
  PyTorch-reserved and the outer profiler intentionally restores the pre-graph
  Torch peak.

There is no tail padding, allocator over-read allowance, disabled graph mode,
or backend-specific workaround in this PR.

## Why a new PR

This supersedes #168. That PR is hosted on an external fork that the current
maintainer account cannot update, and its one-line pool reuse is incomplete:
it reproduces PyTorch's `use_count > 0` allocator assertion when retained
allocations outlive the last profiling graph. This PR retains the valid pool
reuse idea and adds the missing lifecycle and accounting contract.

Upstream PR vllm-project/vllm#47925 was also checked. It pre-sizes model output
staging buffers and does not address private-pool teardown/reopen semantics, so
this is not duplicate work.

## Root-cause proof

A minimal CUDA repro holds an output allocated by a private graph pool, resets
the last graph, empties the cache, and recaptures into the same pool handle.
Without a live graph it hits the same allocator assertion. A one-kernel anchor
kept alive across teardown makes recapture succeed without adding pool storage.

The unit tests cover pool identity, anchor ordering, full high-water accounting,
and anchor release when production capture throws.

## Validation

Exact PR-only image:

```text
vLLM base: dev/gilded-gnosis@89b4a98d1ffebb2dda1e1ac5e55238e3a9cfbd58
SparkInfer base: master@c39b8062ba450c030e669d898a026d10980c9470
image: local/vllm:gilded-gnosis-issue34-mrv2-pool-lifecycle-vllm89b4a98-sic39b806-20260726
```

- `git diff --check`
- Python bytecode compilation of both changed files
- `tests/v1/cudagraph/test_breakable_cudagraph.py` and
  `tests/v1/worker/test_gpu_worker.py`: **27 passed**
- minimal private-pool reset/recapture GPU repro: **passed** with a live anchor

The complete
[rtx6kpro#34](https://github.com/local-inference-lab/rtx6kpro/issues/34)
stack was then tested in an isolated image containing only current GG, #172,
this runtime change, and SparkInfer #76:

```text
local/vllm:gilded-gnosis-v20-issue34-pool-anchor-poc-vllm2d3b70c-si0c98d6b-fi801d57a-cu132-20260726
```

| Gate | Result |
|---|---|
| TP8/DCP1/MTP0, Luke NVFP4 A16 | 87.716 aggregate tok/s; prior candidate 87.744; no measurable regression |
| TP4/DCP4/MTP3 NF3, GMU 0.98, graph 64 | booted; 563,712 KV tokens; 300,017-token prefill plus 16 decode completed; server remained healthy |
| TP8/DCP2/MTP3 A4 online MXFP8, ring DMA | 300,066-token prefill plus 512 decode completed in 65.924 s; server remained healthy |

The DCP2 profile measured 1.00 GiB total graph high-water with 0.72 GiB already
retained in the reusable pool and produced 1,102,720 KV tokens. The older
`gross - retained` calculation reported more KV because it omitted those live
PyTorch-reserved pages; that was overcommit, not free capacity. Operators can
recover equivalent KV capacity by raising GMU by the logged graph-memory delta
(0.91 to approximately 0.9205 in this test).

No new GPU fault or server error appeared in either long-context gate.

## AI assistance disclosure

Root-cause analysis, implementation, tests, hardware validation, and this
write-up were prepared with OpenAI Codex assistance and reviewed by the human
submitter.