### PR TITLE
[GG] Calibrate lossless PCIe DMA dispatch crossover

### DIFF
--- a/tests/distributed/test_b12x_fused_all_reduce.py
+++ b/tests/distributed/test_b12x_fused_all_reduce.py
@@ -27,6 +27,7 @@ from vllm.config import (
 from vllm.distributed import tensor_model_parallel_all_reduce
 from vllm.distributed.device_communicators.custom_all_reduce import (
     CustomAllreduce,
+    _b12x_pcie_dma_min_bytes,
     _b12x_pcie_oneshot_limits,
     get_b12x_pcie_allreduce,
 )
@@ -170,6 +171,23 @@ def test_b12x_oneshot_buffer_tracks_dispatch_limits(
         84 * 1024,
         84 * 1024,
     )
+
+
+def test_b12x_dma_min_bytes_is_configurable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("VLLM_PCIE_DMA_MIN_BYTES", raising=False)
+    assert _b12x_pcie_dma_min_bytes() == 6 * 1024 * 1024
+
+    monkeypatch.setenv("VLLM_PCIE_DMA_MIN_BYTES", "24MB")
+    assert _b12x_pcie_dma_min_bytes() == 24 * 1024 * 1024
+
+    monkeypatch.setenv("VLLM_PCIE_DMA_MIN_BYTES", "off")
+    assert _b12x_pcie_dma_min_bytes() is None
+
+    monkeypatch.setenv("VLLM_PCIE_DMA_MIN_BYTES", "-1")
+    with pytest.raises(ValueError, match="must be non-negative"):
+        _b12x_pcie_dma_min_bytes()
 
 
 def test_b12x_fused_custom_op_dispatch(monkeypatch) -> None:

--- a/tests/distributed/test_b12x_fused_all_reduce.py
+++ b/tests/distributed/test_b12x_fused_all_reduce.py
@@ -179,11 +179,12 @@ def test_b12x_dma_min_bytes_is_configurable(
     monkeypatch.delenv("VLLM_PCIE_DMA_MIN_BYTES", raising=False)
     assert _b12x_pcie_dma_min_bytes() == 6 * 1024 * 1024
 
-    monkeypatch.setenv("VLLM_PCIE_DMA_MIN_BYTES", "24MB")
+    monkeypatch.setenv("VLLM_PCIE_DMA_MIN_BYTES", " 24mB ")
     assert _b12x_pcie_dma_min_bytes() == 24 * 1024 * 1024
 
-    monkeypatch.setenv("VLLM_PCIE_DMA_MIN_BYTES", "off")
-    assert _b12x_pcie_dma_min_bytes() is None
+    for disabled in ("off", " DISABLED ", "NoNe"):
+        monkeypatch.setenv("VLLM_PCIE_DMA_MIN_BYTES", disabled)
+        assert _b12x_pcie_dma_min_bytes() is None
 
     monkeypatch.setenv("VLLM_PCIE_DMA_MIN_BYTES", "-1")
     with pytest.raises(ValueError, match="must be non-negative"):

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -31,11 +31,6 @@ except Exception:
 
 logger = init_logger(__name__)
 
-# Fixed DMA crossover for the 8x PCIe GLM serving path: 512 BF16 rows at
-# hidden size 6144. The oneshot crossovers come from the
-# VLLM_PCIE_ONESHOT_*_MAX_SIZE envs (default 84KB, seven such rows).
-_B12X_PCIE_DMA_MIN_BYTES = 6 * 1024 * 1024
-
 
 def _get_pcie_allreduce_backend() -> str:
     backend = envs.VLLM_PCIE_ALLREDUCE_BACKEND.lower()
@@ -92,6 +87,16 @@ def _b12x_pcie_oneshot_limits() -> tuple[int, int, int]:
     # MiB once target and draft graphs use independent channels.
     buffer_size = max(allreduce_max_size, fused_max_size, 16)
     return allreduce_max_size, fused_max_size, buffer_size
+
+
+def _b12x_pcie_dma_min_bytes() -> int | None:
+    configured = envs.VLLM_PCIE_DMA_MIN_BYTES.strip().lower()
+    if configured in {"off", "disabled", "none"}:
+        return None
+    min_bytes = _parse_byte_size(configured)
+    if min_bytes < 0:
+        raise ValueError("b12x PCIe DMA minimum size must be non-negative")
+    return min_bytes
 
 
 @lru_cache(maxsize=1)
@@ -510,10 +515,17 @@ class CustomAllreduce:
                 return
             assert pcie_runtime is not None
             self._pcie_runtime = pcie_runtime
-            # Prefill-size DMA allreduce alongside the oneshot. Its fixed
-            # lower bound is applied after every rank initializes cleanly.
-            dma_cls = _load_b12x_pcie_dma()
-            if dma_cls is None:
+            # Prefill-size DMA allreduce alongside the oneshot. A deployment
+            # preflight can tune its crossover or disable it when lossless DMA
+            # never beats NCCL on the selected PCIe topology.
+            dma_min_bytes = _b12x_pcie_dma_min_bytes()
+            dma_cls = None if dma_min_bytes is None else _load_b12x_pcie_dma()
+            if dma_min_bytes is None:
+                logger.info(
+                    "b12x PCIe DMA allreduce disabled by "
+                    "VLLM_PCIE_DMA_MIN_BYTES=off; large allreduces stay on PyNCCL."
+                )
+            elif dma_cls is None:
                 logger.warning(
                     "b12x PCIe DMA allreduce unavailable "
                     "(sparkinfer.comm.pcie.DmaAllReduce not importable); "
@@ -556,17 +568,17 @@ class CustomAllreduce:
                     )
                 else:
                     assert dma is not None
-                    dma.min_bytes = _B12X_PCIE_DMA_MIN_BYTES
+                    dma.min_bytes = dma_min_bytes
                     self._pcie_dma = dma
                     logger.debug("b12x PCIe DMA allreduce wire mode: %s", dma.wire_mode)
 
             if rank == 0:
                 logger.info(
                     "Configured b12x PCIe crossovers: "
-                    "oneshot max=%d, fused max=%d, DMA min=%d.",
+                    "oneshot max=%d, fused max=%d, DMA min=%s.",
                     self._pcie_allreduce_max_size,
                     self._pcie_fused_add_rms_norm_max_size,
-                    _B12X_PCIE_DMA_MIN_BYTES,
+                    dma_min_bytes if dma_min_bytes is not None else "off",
                 )
             self.disabled = False
             logger.debug(

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -229,6 +229,7 @@ if TYPE_CHECKING:
     VLLM_PCIE_ALLREDUCE_BACKEND: Literal["b12x", "cpp"] = "cpp"
     VLLM_PCIE_ONESHOT_ALLREDUCE_MAX_SIZE: str = "84KB"
     VLLM_PCIE_ONESHOT_FUSED_ADD_RMS_NORM_MAX_SIZE: str = "84KB"
+    VLLM_PCIE_DMA_MIN_BYTES: str = "6MB"
     VLLM_PCIE_ONESHOT_ALLOW_CROSS_NUMA: bool = True
     VLLM_PCIE_ONESHOT_SINGLE_CHANNEL: bool = False
     VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE: int = 394 * 1024 * 1024
@@ -1815,6 +1816,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_PCIE_ONESHOT_FUSED_ADD_RMS_NORM_MAX_SIZE": lambda: os.getenv(
         "VLLM_PCIE_ONESHOT_FUSED_ADD_RMS_NORM_MAX_SIZE", "84KB"
     ),
+    # Minimum input size for uncompressed SparkInfer DMA allreduce dispatch.
+    # A deployment preflight may override this with a measured crossover.
+    "VLLM_PCIE_DMA_MIN_BYTES": lambda: os.getenv("VLLM_PCIE_DMA_MIN_BYTES", "6MB"),
     # Allow the b12x PCIe oneshot allreduce on cross-NUMA PCIe topologies.
     "VLLM_PCIE_ONESHOT_ALLOW_CROSS_NUMA": lambda: (
         os.getenv("VLLM_PCIE_ONESHOT_ALLOW_CROSS_NUMA", "1") != "0"

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -1816,7 +1816,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_PCIE_ONESHOT_FUSED_ADD_RMS_NORM_MAX_SIZE": lambda: os.getenv(
         "VLLM_PCIE_ONESHOT_FUSED_ADD_RMS_NORM_MAX_SIZE", "84KB"
     ),
-    # Minimum input size for uncompressed SparkInfer DMA allreduce dispatch.
+    # Minimum input size for uncompressed SparkInfer DMA allreduce dispatch;
+    # defaults to 6 MiB. Accepts raw bytes or a case-insensitive KB/MB suffix.
+    # Whitespace is ignored. "off", "disabled", and "none" disable DMA.
     # A deployment preflight may override this with a measured crossover.
     "VLLM_PCIE_DMA_MIN_BYTES": lambda: os.getenv("VLLM_PCIE_DMA_MIN_BYTES", "6MB"),
     # Allow the b12x PCIe oneshot allreduce on cross-NUMA PCIe topologies.


### PR DESCRIPTION
## Summary

- replace the fixed 6 MiB SparkInfer DMA crossover with `VLLM_PCIE_DMA_MIN_BYTES`
- accept byte-size values and an explicit `off` state
- avoid constructing the DMA collective when calibration determines that lossless DMA never beats NCCL
- preserve the existing 6 MiB behavior when the variable is unset

## Why

The crossover depends on GPU order, PCIe/root-complex topology, CPU/NUMA placement, and collective configuration. A fixed threshold can route large all-reduces to a slower path on cross-root or PCIe Gen4 systems. A pre-model probe can now provide the measured threshold without changing compressed wire modes.

## Validation

- `git diff --check dev/gilded-gnosis...HEAD`
- runtime contract exercised in the pinned v20 CUDA 13.2 image for default, `24MB`, `off`, `disabled`, and invalid negative values
- focused unit coverage added in `test_b12x_fused_all_reduce.py`

This PR does not select FP8/INT8/MXFP8 DMA modes. Those remain explicit quality choices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configuration for the minimum PCIe DMA transfer size via `VLLM_PCIE_DMA_MIN_BYTES` (default `6MB`).
  * Accepts raw byte values or KB/MB suffixes (whitespace ignored) and can disable DMA using `off`, `disabled`, or `none` (case-insensitive).
  * When disabled, large all-reduce operations continue on the standard communication path.
* **Bug Fixes**
  * Negative DMA threshold values are now rejected with a clear error.
* **Tests**
  * Added unit coverage for defaults, custom values, disabled modes, and invalid negatives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->