### PR TITLE
[GG] Gate DCP query split by measured context crossover

### DIFF
--- a/tests/model_executor/layers/test_sparse_attn_indexer_b12x.py
+++ b/tests/model_executor/layers/test_sparse_attn_indexer_b12x.py
@@ -10,6 +10,19 @@ import torch
 from vllm.model_executor.layers import sparse_attn_indexer as indexer_mod
 
 
+def test_query_split_context_crossover_env(monkeypatch):
+    monkeypatch.delenv("VLLM_DCP_QUERY_SPLIT_MIN_CONTEXT_TOKENS", raising=False)
+    assert indexer_mod._dcp_query_split_context_eligible(1)
+
+    monkeypatch.setenv("VLLM_DCP_QUERY_SPLIT_MIN_CONTEXT_TOKENS", "65536")
+    assert not indexer_mod._dcp_query_split_context_eligible(8192)
+    assert indexer_mod._dcp_query_split_context_eligible(65536)
+
+    monkeypatch.setenv("VLLM_DCP_QUERY_SPLIT_MIN_CONTEXT_TOKENS", "-1")
+    with pytest.raises(ValueError, match="must be non-negative"):
+        indexer_mod._dcp_query_split_context_eligible(65536)
+
+
 def _profile_forward_context():
     return types.SimpleNamespace(
         attn_metadata=None,

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -77,6 +77,7 @@ if TYPE_CHECKING:
     VLLM_DCP_REPLICATE_INDEXER_CACHE: bool = False
     VLLM_DCP_GLOBAL_TOPK: bool = True
     VLLM_DCP_QUERY_SPLIT: bool = False
+    VLLM_DCP_QUERY_SPLIT_MIN_CONTEXT_TOKENS: int = 0
     VLLM_DCP_TOPK_OWNER_MERGE: bool = False
     VLLM_B12X_MLA_CKV_GATHER: bool = False
     VLLM_B12X_MLA_CKV_GATHER_MIN_TOKENS: int = 16
@@ -1176,6 +1177,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     "VLLM_DCP_QUERY_SPLIT": lambda: (
         os.getenv("VLLM_DCP_QUERY_SPLIT", "0").lower() in ("1", "true", "yes", "on")
+    ),
+    # Keep query-split process groups initialized while selecting the faster
+    # full-query path below a deployment-calibrated context crossover.
+    "VLLM_DCP_QUERY_SPLIT_MIN_CONTEXT_TOKENS": lambda: int(
+        os.getenv("VLLM_DCP_QUERY_SPLIT_MIN_CONTEXT_TOKENS", "0")
     ),
     # Send each query row's exact FP32 top-k candidates to one DCP owner, merge
     # once there, then gather only the final indices over TP. This is an

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -59,6 +59,13 @@ def _dcp_global_topk_requested() -> bool:
     return envs.VLLM_DCP_GLOBAL_TOPK
 
 
+def _dcp_query_split_context_eligible(context_tokens: int) -> bool:
+    min_context = envs.VLLM_DCP_QUERY_SPLIT_MIN_CONTEXT_TOKENS
+    if min_context < 0:
+        raise ValueError("VLLM_DCP_QUERY_SPLIT_MIN_CONTEXT_TOKENS must be non-negative")
+    return context_tokens > 0 and context_tokens >= min_context
+
+
 def _use_persistent_topk_decode(topk_tokens: int) -> bool:
     return current_platform.is_cuda() and topk_tokens in (512, 1024, 2048)
 
@@ -1847,7 +1854,11 @@ def sparse_attn_indexer(
             qs_active = False
             qs_row_start = chunk.token_start
             qs_row_end = chunk.token_end
-            if qs_world_size > 1 and use_b12x_indexer and chunk.total_seq_lens > 0:
+            if (
+                qs_world_size > 1
+                and use_b12x_indexer
+                and _dcp_query_split_context_eligible(chunk.total_seq_lens)
+            ):
                 chunk_tokens = chunk.token_end - chunk.token_start
                 if chunk_tokens % qs_world_size == 0:
                     slice_tokens = chunk_tokens // qs_world_size


### PR DESCRIPTION
## Summary

- add `VLLM_DCP_QUERY_SPLIT_MIN_CONTEXT_TOKENS`
- keep query-split process groups initialized while using the full-query path below the configured context threshold
- gate each sparse-indexer prefill chunk by its total sequence length
- preserve existing behavior with the default threshold of zero

## Why

Query split is strongly beneficial at long context, but its extra collective and launch overhead can regress short prefill. The crossover is machine-dependent. This small runtime gate lets the deployment preflight select the first measured context where split wins without restarting with a different process-group layout.

## Validation

- `git diff --check dev/gilded-gnosis...HEAD`
- runtime contract exercised in the pinned v20 CUDA 13.2 image at 8k and 64k thresholds plus invalid input
- focused unit coverage added in `test_sparse_attn_indexer_b12x.py`

The change does not alter top-k results or compressed communication formats.
