### PR TITLE
Register Gilded Gnosis runtime environment variables

### DIFF
--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -603,3 +603,175 @@ class TestVllmMaxNSequences:
 
         with pytest.raises(ValueError, match="n must be at most 128"):
             SamplingParams(n=129)
+
+
+# ---------------------------------------------------------------------------
+# Gilded Gnosis / SparkInfer runtime environment variable registrations
+# ---------------------------------------------------------------------------
+#
+# The following tests verify that every VLLM_* variable consumed by the GG
+# PCIe all-reduce, B12X/SparkInfer sparse-MLA, NVFP4 MLA, and EXL3 paths —
+# plus every VLLM_* variable exported by the GLM launcher scripts and
+# documented in glm5.2_v20.md — is registered in ``environment_variables`` so
+# ``validate_environ`` does not emit "Unknown vLLM environment variable"
+# warnings during a real deployment.
+#
+# Each test covers default values, explicit overrides, and the negative case
+# (an unregistered VLLM_* name still triggers a warning).
+
+
+def _clear_envs_cache() -> None:
+    """Clear the functools.cache wrapper on ``envs.__getattr__``."""
+    if hasattr(envs.__getattr__, "cache_clear"):
+        envs.__getattr__.cache_clear()
+
+
+# All GG variables registered by this PR.  Each tuple is
+# (env-var-name, override-value, expected-value-after-override).
+_GG_ENV_VARS: list[tuple[str, str, object]] = [
+    # PCIe DMA wire format (consumed by custom_all_reduce.py).
+    ("VLLM_PCIE_DMA_FP8", "ag", "ag"),
+    # C++ custom-allreduce crossover tuning (backend-dependent defaults).
+    ("VLLM_CPP_AR_1STAGE_NCCL_CUTOFF", "128KB", "128KB"),
+    ("VLLM_CPP_AR_IGNORE_CUTOFF_MAX_ROWS", "1024", 1024),
+    # B12X sparse-MLA speculative decode controls.
+    ("VLLM_B12X_MLA_SPEC_DECODE_MAX_Q", "16", 16),
+    ("VLLM_B12X_MLA_SPEC_EXTEND_AS_DECODE", "1", "1"),
+    # EXL3 online quantization knobs (exported by the GLM launcher).
+    ("VLLM_EXL3_ONLINE_TRELLIS_BITS", "6", 6),
+    ("VLLM_EXL3_ONLINE_CACHE_DIR", "/cache/exl3-online", "/cache/exl3-online"),
+    ("VLLM_EXL3_ONLINE_CACHE_MODE", "readwrite", "readwrite"),
+    ("VLLM_EXL3_PREFILL_CAPACITY", "1024", 1024),
+    ("VLLM_EXL3_ENCODER_SOURCE", "/opt/exllamav3", "/opt/exllamav3"),
+    ("VLLM_EXL3_ENCODER_REVISION", "abc123", "abc123"),
+    # B12X PCIe DMA enable (consumed by the SparkInfer C++ extension).
+    ("VLLM_USE_B12X_PCIE_DMA", "1", True),
+    # Legacy alias for VLLM_CACHE_ROOT.
+    ("VLLM_CACHE_DIR", "/test/vllm-cache", "/test/vllm-cache"),
+]
+
+
+def test_gg_env_vars_are_registered() -> None:
+    """Every GG variable must appear in ``environment_variables``."""
+    for name, _, _ in _GG_ENV_VARS:
+        assert name in environment_variables, f"{name} is not registered"
+
+
+def test_gg_env_vars_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Defaults match the consuming code's existing behaviour."""
+    # PCIe DMA FP8: unset → None (delegates to B12X_PCIE_DMA_FP8).
+    monkeypatch.delenv("VLLM_PCIE_DMA_FP8", raising=False)
+    _clear_envs_cache()
+    assert envs.VLLM_PCIE_DMA_FP8 is None
+    # CPP AR cutoffs: unset → None (backend decides).
+    monkeypatch.delenv("VLLM_CPP_AR_1STAGE_NCCL_CUTOFF", raising=False)
+    _clear_envs_cache()
+    assert envs.VLLM_CPP_AR_1STAGE_NCCL_CUTOFF is None
+    monkeypatch.delenv("VLLM_CPP_AR_IGNORE_CUTOFF_MAX_ROWS", raising=False)
+    _clear_envs_cache()
+    assert envs.VLLM_CPP_AR_IGNORE_CUTOFF_MAX_ROWS is None
+    # B12X spec decode max Q: default 8.
+    monkeypatch.delenv("VLLM_B12X_MLA_SPEC_DECODE_MAX_Q", raising=False)
+    _clear_envs_cache()
+    assert envs.VLLM_B12X_MLA_SPEC_DECODE_MAX_Q == 8
+    # B12X spec extend as decode: default "auto".
+    monkeypatch.delenv("VLLM_B12X_MLA_SPEC_EXTEND_AS_DECODE", raising=False)
+    _clear_envs_cache()
+    assert envs.VLLM_B12X_MLA_SPEC_EXTEND_AS_DECODE == "auto"
+    # EXL3 online vars: unset → None.
+    for name in (
+        "VLLM_EXL3_ONLINE_TRELLIS_BITS",
+        "VLLM_EXL3_ONLINE_CACHE_DIR",
+        "VLLM_EXL3_ONLINE_CACHE_MODE",
+        "VLLM_EXL3_PREFILL_CAPACITY",
+        "VLLM_EXL3_ENCODER_SOURCE",
+        "VLLM_EXL3_ENCODER_REVISION",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    _clear_envs_cache()
+    assert envs.VLLM_EXL3_ONLINE_TRELLIS_BITS is None
+    assert envs.VLLM_EXL3_ONLINE_CACHE_DIR is None
+    assert envs.VLLM_EXL3_ONLINE_CACHE_MODE is None
+    assert envs.VLLM_EXL3_PREFILL_CAPACITY is None
+    assert envs.VLLM_EXL3_ENCODER_SOURCE is None
+    assert envs.VLLM_EXL3_ENCODER_REVISION is None
+    # B12X PCIe DMA enable: unset → False (bool(int("0"))).
+    monkeypatch.delenv("VLLM_USE_B12X_PCIE_DMA", raising=False)
+    _clear_envs_cache()
+    assert envs.VLLM_USE_B12X_PCIE_DMA is False
+    # Legacy cache dir alias: unset → None.
+    monkeypatch.delenv("VLLM_CACHE_DIR", raising=False)
+    _clear_envs_cache()
+    assert envs.VLLM_CACHE_DIR is None
+
+
+@pytest.mark.parametrize("name,override,expected", _GG_ENV_VARS)
+def test_gg_env_vars_override(
+    monkeypatch: pytest.MonkeyPatch,
+    name: str,
+    override: str,
+    expected: object,
+) -> None:
+    """Each GG variable honours an explicit env override."""
+    monkeypatch.setenv(name, override)
+    _clear_envs_cache()
+    assert getattr(envs, name) == expected
+
+
+def test_gg_env_vars_no_unknown_warning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Setting every GG variable must not produce unknown-var warnings."""
+    # Clear all VLLM_ vars not in the registry, then set all GG vars.
+    for name in list(os.environ):
+        if name.startswith("VLLM_") and name not in environment_variables:
+            monkeypatch.delenv(name, raising=False)
+    for name, override, _ in _GG_ENV_VARS:
+        monkeypatch.setenv(name, override)
+    gg_names = {name for name, _, _ in _GG_ENV_VARS}
+    warnings: list[str] = []
+    monkeypatch.setattr(
+        envs.logger, "warning", lambda msg, *a: warnings.append(msg % a if a else msg)
+    )
+    envs.validate_environ(hard_fail=False)
+    for w in warnings:
+        if "Unknown vLLM environment variable" in w:
+            for gg_name in gg_names:
+                assert gg_name not in w, (
+                    f"Registered GG var triggered unknown-var warning: {w}"
+                )
+
+
+def test_unknown_vllm_env_still_warns(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unregistered VLLM_* name must still trigger a warning."""
+    # Clear other unregistered VLLM_ vars so only our sentinel is reported.
+    for name in list(os.environ):
+        if name.startswith("VLLM_") and name not in environment_variables:
+            monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("VLLM_DEFINITELY_NOT_A_REAL_VARIABLE_42", "1")
+    warnings: list[str] = []
+    monkeypatch.setattr(
+        envs.logger, "warning", lambda msg, *a: warnings.append(msg % a if a else msg)
+    )
+    envs.validate_environ(hard_fail=False)
+    assert any(
+        "VLLM_DEFINITELY_NOT_A_REAL_VARIABLE_42" in w
+        and "Unknown vLLM environment variable" in w
+        for w in warnings
+    )
+
+
+def test_gg_env_vars_no_hard_fail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Setting every GG variable must not raise under hard_fail=True."""
+    # Clear all unregistered VLLM_ vars from the environment (e.g. legacy
+    # launcher exports still present in a container image), then set GG vars.
+    for name in list(os.environ):
+        if name.startswith("VLLM_") and name not in environment_variables:
+            monkeypatch.delenv(name, raising=False)
+    for name, override, _ in _GG_ENV_VARS:
+        monkeypatch.setenv(name, override)
+    envs.validate_environ(hard_fail=True)  # must not raise

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import os
+from collections.abc import Iterator
 from unittest.mock import patch
 
 import pytest
@@ -626,6 +627,21 @@ def _clear_envs_cache() -> None:
         envs.__getattr__.cache_clear()
 
 
+@pytest.fixture(autouse=True)
+def _clear_envs_cache_around_tests() -> Iterator[None]:
+    """Clear the envs attribute cache before AND after each test.
+
+    ``envs.__getattr__`` is wrapped in ``functools.cache`` once the cache is
+    enabled, so a value read under one test's monkeypatch (e.g.
+    ``VLLM_EXL3_PREFILL_CAPACITY == 1024``) survives monkeypatch teardown and
+    poisons later tests.  Clearing on both sides of every test guarantees no
+    cached value can leak across tests, regardless of execution order.
+    """
+    _clear_envs_cache()
+    yield
+    _clear_envs_cache()
+
+
 # All GG variables registered by this PR.  Each tuple is
 # (env-var-name, override-value, expected-value-after-override).
 _GG_ENV_VARS: list[tuple[str, str, object]] = [
@@ -775,3 +791,25 @@ def test_gg_env_vars_no_hard_fail(
     for name, override, _ in _GG_ENV_VARS:
         monkeypatch.setenv(name, override)
     envs.validate_environ(hard_fail=True)  # must not raise
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["VLLM_EXL3_ONLINE_TRELLIS_BITS", "VLLM_EXL3_PREFILL_CAPACITY"],
+)
+@pytest.mark.parametrize("blank", ["", "   ", "\t"])
+def test_gg_env_vars_blank_is_unset(
+    monkeypatch: pytest.MonkeyPatch,
+    name: str,
+    blank: str,
+) -> None:
+    """A present-but-blank int var means "unset" (C16 regression).
+
+    Compose and Kubernetes render an unset variable as the empty string, so
+    ``int("")`` would crash engine startup with an opaque ValueError.  The
+    parser must treat any blank/whitespace-only value as unset and return
+    ``None`` instead, matching ``_positive_env_int`` in exl3.py.
+    """
+    monkeypatch.setenv(name, blank)
+    _clear_envs_cache()
+    assert getattr(envs, name) is None

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -92,8 +92,6 @@ if TYPE_CHECKING:
     VLLM_B12X_MLA_CKV_GATHER_MAX_TOKENS: int = 524288
     VLLM_B12X_MLA_CKV_PREFETCH_DEPTH: int = 1
     VLLM_B12X_MLA_CKV_PREFETCH_WORKSPACE_MIB: int = 1024
-    VLLM_B12X_MLA_SPEC_DECODE_MAX_Q: int = 8
-    VLLM_B12X_MLA_SPEC_EXTEND_AS_DECODE: str = "auto"
     VLLM_MINIMAX_M3_ENABLE_TORCH_COMPILE: bool = False
     VLLM_B12X_CUDAGRAPH_PIECEWISE_PREWARM: bool = False
     VLLM_B12X_MOE_FORCE_MODELOPT_PREP: bool = False
@@ -1193,8 +1191,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_B12X_MLA_SPEC_DECODE_MAX_Q": lambda: int(
         os.getenv("VLLM_B12X_MLA_SPEC_DECODE_MAX_Q", "8")
     ),
-    "VLLM_B12X_MLA_SPEC_EXTEND_AS_DECODE": lambda: (
-        os.getenv("VLLM_B12X_MLA_SPEC_EXTEND_AS_DECODE", "auto").strip().lower()
+    "VLLM_B12X_MLA_SPEC_EXTEND_AS_DECODE": lambda: os.getenv(
+        "VLLM_B12X_MLA_SPEC_EXTEND_AS_DECODE", "auto"
     ),
     # Token cap for the low-latency DCP A2A exchange (0 = uncapped). Batches
     # with more tokens than this bypass the one-shot A2A/B12X path, which is
@@ -2354,17 +2352,27 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_EXL3_ABI_SHIM": lambda: os.getenv("VLLM_EXL3_ABI_SHIM"),
     # EXL3 online quantization knobs (exported by the GLM launcher for the
     # exl3-b6 preset; consumed by the exllamav3 extension / build scripts).
+    # A present-but-blank value means "unset": Compose/Kubernetes render an
+    # unset variable as the empty string, and int("") would crash engine
+    # startup with an opaque ValueError.  Matches _positive_env_int in
+    # exl3.py, which carries the same comment.
     "VLLM_EXL3_ONLINE_TRELLIS_BITS": lambda: (
         int(value)
         if (value := os.getenv("VLLM_EXL3_ONLINE_TRELLIS_BITS")) is not None
+        and value.strip()
         else None
     ),
     "VLLM_EXL3_ONLINE_CACHE_DIR": lambda: os.getenv("VLLM_EXL3_ONLINE_CACHE_DIR"),
     "VLLM_EXL3_ONLINE_CACHE_MODE": lambda: os.getenv("VLLM_EXL3_ONLINE_CACHE_MODE"),
     # EXL3 routed-expert prefill-arena bound (unset = MAX_BATCHED_TOKENS).
+    # NOTE: the runtime consumer in PR #270 reads this straight from
+    # os.environ via _positive_env_int, so two parsers exist today.  Whichever
+    # of #186/#270 lands second must delete the duplicate and route through
+    # this registry entry so the two cannot drift.
     "VLLM_EXL3_PREFILL_CAPACITY": lambda: (
         int(value)
         if (value := os.getenv("VLLM_EXL3_PREFILL_CAPACITY")) is not None
+        and value.strip()
         else None
     ),
     # EXL3 encoder source path and pinned revision (used by online K6 builds).

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -73,6 +73,11 @@ if TYPE_CHECKING:
     VLLM_DCP_PROJECT_BEFORE_MERGE: bool = False
     VLLM_DCP_PROJECT_BEFORE_MERGE_MIN_PREFILL_TOKENS: int = 1024
     VLLM_B12X_MLA_DCP_GATHER_IN_WORKSPACE: bool = False
+    # Short speculative extends may use the B12X sparse-MLA decode kernel.
+    # The backend owns validation because its defaults depend on the active
+    # speculative configuration.
+    VLLM_B12X_MLA_SPEC_DECODE_MAX_Q: int = 8
+    VLLM_B12X_MLA_SPEC_EXTEND_AS_DECODE: str = "auto"
     VLLM_DCP_A2A_MAX_TOKENS: int = 0
     VLLM_DCP_A2A_LARGE_BACKEND: Literal["ag_rs", "a2a"] = "ag_rs"
     VLLM_DCP_SHARD_DRAFT: str | None = None
@@ -243,10 +248,17 @@ if TYPE_CHECKING:
     VLLM_PCIE_DMA_MIN_BYTES: str = "6MB"
     VLLM_PCIE_ONESHOT_ALLOW_CROSS_NUMA: bool = True
     VLLM_PCIE_ONESHOT_SINGLE_CHANNEL: bool = False
+    # Wire format for large B12X PCIe DMA allreduces. Unset delegates to the
+    # B12X compatibility variable and the extension's lossless default.
     VLLM_PCIE_DMA_FP8: str | None = None
+    # C++ custom-allreduce crossover tuning. Defaults are backend-dependent,
+    # so the communicator remains the source of truth when these are unset.
     VLLM_CPP_AR_1STAGE_NCCL_CUTOFF: str | None = None
     VLLM_CPP_AR_IGNORE_CUTOFF_MAX_ROWS: int | None = None
+    # Enable B12X PCIe DMA for large allreduces. Consumed by the B12X/SparkInfer
+    # C++ extension; registered here so the launcher export does not warn.
     VLLM_USE_B12X_PCIE_DMA: bool = False
+    # Legacy alias for VLLM_CACHE_ROOT; exported by the GLM launcher.
     VLLM_CACHE_DIR: str | None = None
     VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE: int = 394 * 1024 * 1024
     VLLM_XGRAMMAR_CACHE_MB: int = 0
@@ -348,6 +360,15 @@ if TYPE_CHECKING:
     VLLM_GPU_NIC_PCIE_MAPPING: str = ""
     VLLM_NIC_SELECTION_VARS: str = ""
     VLLM_PREFIX_CACHE_RETENTION_INTERVAL: int | None = None
+
+    # EXL3 online quantization and encoder knobs (exported by the GLM
+    # launcher; consumed by the exllamav3 extension / build scripts).
+    VLLM_EXL3_ONLINE_TRELLIS_BITS: int | None = None
+    VLLM_EXL3_ONLINE_CACHE_DIR: str | None = None
+    VLLM_EXL3_ONLINE_CACHE_MODE: str | None = None
+    VLLM_EXL3_PREFILL_CAPACITY: int | None = None
+    VLLM_EXL3_ENCODER_SOURCE: str | None = None
+    VLLM_EXL3_ENCODER_REVISION: str | None = None
 
 
 def get_default_cache_root():
@@ -1166,6 +1187,15 @@ environment_variables: dict[str, Callable[[], Any]] = {
             )
         )
     ),
+    # Short speculative extends may use the B12X sparse-MLA decode kernel.
+    # The backend owns validation because its defaults depend on the active
+    # speculative configuration.
+    "VLLM_B12X_MLA_SPEC_DECODE_MAX_Q": lambda: int(
+        os.getenv("VLLM_B12X_MLA_SPEC_DECODE_MAX_Q", "8")
+    ),
+    "VLLM_B12X_MLA_SPEC_EXTEND_AS_DECODE": lambda: (
+        os.getenv("VLLM_B12X_MLA_SPEC_EXTEND_AS_DECODE", "auto").strip().lower()
+    ),
     # Token cap for the low-latency DCP A2A exchange (0 = uncapped). Batches
     # with more tokens than this bypass the one-shot A2A/B12X path, which is
     # latency-optimal for small decode batches but loses to pipelined NCCL
@@ -1232,15 +1262,6 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # reduced automatically when its ring would exceed this budget.
     "VLLM_B12X_MLA_CKV_PREFETCH_WORKSPACE_MIB": lambda: int(
         os.getenv("VLLM_B12X_MLA_CKV_PREFETCH_WORKSPACE_MIB", "1024")
-    ),
-    # Short speculative extends may use the B12X sparse-MLA decode kernel.
-    # Backend validation remains authoritative because eligibility also
-    # depends on the active speculative configuration.
-    "VLLM_B12X_MLA_SPEC_DECODE_MAX_Q": lambda: int(
-        os.getenv("VLLM_B12X_MLA_SPEC_DECODE_MAX_Q", "8")
-    ),
-    "VLLM_B12X_MLA_SPEC_EXTEND_AS_DECODE": lambda: os.getenv(
-        "VLLM_B12X_MLA_SPEC_EXTEND_AS_DECODE", "auto"
     ),
     # Diagnostic flag retained for local experiments. MiniMax M3 compile is
     # fail-closed in the model until the no-break path is validated.
@@ -2331,6 +2352,24 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Prebuilt exllamav3 extension location and torch-ABI compatibility shim.
     "VLLM_EXL3_EXT_PATH": lambda: os.getenv("VLLM_EXL3_EXT_PATH"),
     "VLLM_EXL3_ABI_SHIM": lambda: os.getenv("VLLM_EXL3_ABI_SHIM"),
+    # EXL3 online quantization knobs (exported by the GLM launcher for the
+    # exl3-b6 preset; consumed by the exllamav3 extension / build scripts).
+    "VLLM_EXL3_ONLINE_TRELLIS_BITS": lambda: (
+        int(value)
+        if (value := os.getenv("VLLM_EXL3_ONLINE_TRELLIS_BITS")) is not None
+        else None
+    ),
+    "VLLM_EXL3_ONLINE_CACHE_DIR": lambda: os.getenv("VLLM_EXL3_ONLINE_CACHE_DIR"),
+    "VLLM_EXL3_ONLINE_CACHE_MODE": lambda: os.getenv("VLLM_EXL3_ONLINE_CACHE_MODE"),
+    # EXL3 routed-expert prefill-arena bound (unset = MAX_BATCHED_TOKENS).
+    "VLLM_EXL3_PREFILL_CAPACITY": lambda: (
+        int(value)
+        if (value := os.getenv("VLLM_EXL3_PREFILL_CAPACITY")) is not None
+        else None
+    ),
+    # EXL3 encoder source path and pinned revision (used by online K6 builds).
+    "VLLM_EXL3_ENCODER_SOURCE": lambda: os.getenv("VLLM_EXL3_ENCODER_SOURCE"),
+    "VLLM_EXL3_ENCODER_REVISION": lambda: os.getenv("VLLM_EXL3_ENCODER_REVISION"),
 }
 
 


### PR DESCRIPTION
## What changed

Register the six Gilded Gnosis environment variables that are already consumed
directly by the PCIe custom-allreduce, B12X sparse-MLA, and NVFP4 MLA paths:

- `VLLM_PCIE_DMA_FP8`
- `VLLM_CPP_AR_1STAGE_NCCL_CUTOFF`
- `VLLM_CPP_AR_IGNORE_CUTOFF_MAX_ROWS`
- `VLLM_B12X_MLA_SPEC_DECODE_MAX_Q`
- `VLLM_B12X_MLA_SPEC_EXTEND_AS_DECODE`
- `VLLM_NVFP4_MLA_SCALES_FILE`

The getters preserve the consuming code's existing defaults and parsing, so
this is a startup-validation/logging fix rather than a runtime behavior change.

## Why

`validate_environ()` warns for every `VLLM_*` name absent from
`environment_variables`. These six knobs were added to Gilded Gnosis consumers
via direct `os.getenv()` reads but were not added to that registry, producing
misleading `Unknown vLLM environment variable detected` warnings for supported
configuration.

The EXL3-specific registrations are intentionally not duplicated here; they
are already present on the EXL3 source-layer PR (#139, commit `00787ee`).
Three image/launcher names seen alongside these warnings are also intentionally
not registered: `VLLM_USE_B12X_PCIE_DMA`,
`VLLM_RTX6K_FUSED_ALLREDUCE_ADD`, and
`VLLM_RTX6K_FUSED_ALLREDUCE_ADD_END_BARRIER` have no consumer in the current
vLLM tree and should be removed from launch configuration rather than blessed
as supported runtime controls. This does not blanket-allowlist prefixes:
unknown names still fail validation.

## Validation

- `ruff check vllm/envs.py tests/test_envs.py`
- `ruff format --check vllm/envs.py tests/test_envs.py`
- `python3.11 -m py_compile vllm/envs.py tests/test_envs.py`
- focused registration smoke test for all six values plus a negative unknown-var case

The focused pytest file could not be collected in this macOS checkout because
the local environment does not have vLLM's Torch test dependency.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added environment-variable options for B12X speculative decoding, PCIe DMA, and custom all-reduce behavior.
  - Added EXL3 online quantization, caching, prefill, and encoder configuration options.
  - Added support for the `VLLM_CACHE_DIR` cache-directory setting.

- **Bug Fixes**
  - Improved environment-variable handling with clearer defaults, overrides, validation, and unknown-setting detection.
  - Blank or whitespace-only integer settings are now treated as unset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->