### PR TITLE
[Bugfix][MLA] Treat int32 packed weights like uint8 in the kv_b dtype guard

### DIFF
--- a/tests/kernels/attention/test_mla_kv_b_dtype_guard.py
+++ b/tests/kernels/attention/test_mla_kv_b_dtype_guard.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Packed-quantized kv_b_proj weights must not drive a kv_c_normed upcast.
+
+NVFP4 packs into uint8 and compressed-tensors int4/int8 packs into int32.
+Both are containers, not real activation dtypes -- casting kv_c_normed to
+either corrupts chunked prefill past ~4K prompts.
+"""
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.attention.mla_attention import (
+    is_packed_quantized_dtype,
+)
+
+
+@pytest.mark.parametrize(
+    "dtype,expected",
+    [
+        (torch.uint8, True),  # NVFP4
+        (torch.int32, True),  # compressed-tensors int4/int8
+        (torch.bfloat16, False),
+        (torch.float16, False),
+        (torch.float8_e4m3fn, False),
+    ],
+)
+def test_is_packed_quantized_dtype(dtype: torch.dtype, expected: bool):
+    assert is_packed_quantized_dtype(dtype) is expected

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -332,6 +332,16 @@ def _run_mla_query_bmm(
     torch.bmm(query.contiguous() if use_safe_op else query, weight, out=output)
 
 
+def is_packed_quantized_dtype(dtype: torch.dtype) -> bool:
+    """True if ``dtype`` is a container for packed quantized weights.
+
+    NVFP4 packs into ``uint8``; compressed-tensors int4/int8 packs into
+    ``int32``. Neither is a real activation dtype, so ``kv_c_normed`` must not
+    be cast to them -- the linear layer unpacks and quantizes internally.
+    """
+    return dtype in (torch.uint8, torch.int32)
+
+
 @functools.cache
 def _b12x_absorb_bmm_enabled() -> bool:
     return envs.VLLM_B12X_ABSORB_BMM
@@ -3169,12 +3179,13 @@ class MLACommonBaseImpl(MLAAttentionImpl[A], Generic[A]):
                 if hasattr(self.kv_b_proj, "weight")
                 else self.kv_b_proj.params_dtype
             )
-            # For NVFP4, weights are packed uint8 — keep input in model dtype
-            # since the NVFP4 linear layer quantizes internally.
+            # Packed quantized weights (NVFP4 → uint8, compressed-tensors
+            # int4/int8 → int32) are containers, not activation dtypes — keep
+            # the input in model dtype; the linear layer quantizes internally.
             if (
                 use_fp8_prefill or _kv_b_proj_w_dtype != current_platform.fp8_dtype()
-            ) and _kv_b_proj_w_dtype != torch.uint8:
-                kv_c_normed = kv_c_normed.to(self.kv_b_proj.weight.dtype)
+            ) and not is_packed_quantized_dtype(_kv_b_proj_w_dtype):
+                kv_c_normed = kv_c_normed.to(_kv_b_proj_w_dtype)
 
             k_pe = workspace[:toks][..., self.kv_lora_rank :].unsqueeze(1)
             kv_nope = self.kv_b_proj(kv_c_normed)[0].view(
@@ -3325,9 +3336,11 @@ class MLACommonBaseImpl(MLAAttentionImpl[A], Generic[A]):
                 if hasattr(self.kv_b_proj, "weight")
                 else self.kv_b_proj.params_dtype
             )
+            # Same packed-container rule as _compute_prefill_context above; this
+            # is the branch forward_mha takes when dcp_world_size > 1.
             if (
                 use_fp8_prefill or kv_b_proj_w_dtype != current_platform.fp8_dtype()
-            ) and kv_b_proj_w_dtype != torch.uint8:
+            ) and not is_packed_quantized_dtype(kv_b_proj_w_dtype):
                 kv_c_normed = kv_c_normed.to(kv_b_proj_w_dtype)
 
             kv_nope = self.kv_b_proj(kv_c_normed)[0].view(


### PR DESCRIPTION
## The bug

`MLACommonBaseImpl` resolves the kv_b projection weight dtype and then skips the `kv_c_normed` cast when those weights are packed — but it only recognises NVFP4's `uint8` container:

```python
) and _kv_b_proj_w_dtype != torch.uint8:
    kv_c_normed = kv_c_normed.to(self.kv_b_proj.weight.dtype)
```

compressed-tensors int4/int8 packs into **`int32`**, which that check misses. So on an int-quantized checkpoint `kv_c_normed` is cast to the packed *container* dtype rather than left in model dtype, and chunked prefill produces garbage beyond ~4K prompts. The linear layer unpacks and quantizes internally, so the input must stay in model dtype for both containers.

Reproduced on GLM-5.2-Int4-Int8Mix (`QuantTrio/GLM-5.2-Int4-Int8Mix`) across 4x DGX Spark at 610K context, TP=4 + DCP=4. Short prompts look fine, which is what makes it easy to miss.

## The fix

Extract the predicate as `is_packed_quantized_dtype()` covering `uint8` and `int32`, and use it in the guard.

## A second, adjacent fix

The cast now targets `_kv_b_proj_w_dtype` instead of `self.kv_b_proj.weight.dtype`. That dtype is resolved a few lines above with a `hasattr` fallback:

```python
_kv_b_proj_w_dtype = (
    self.kv_b_proj.weight.dtype
    if hasattr(self.kv_b_proj, "weight")
    else self.kv_b_proj.params_dtype
)
```

The existing comment says the fallback is there "for quantized layers (AWQ/GPTQ) that lack a `.weight` attribute" — but the cast then dereferenced `.weight` unconditionally, so that path raised `AttributeError` rather than using the dtype just computed for it. Where `.weight` exists the two expressions are the same value, so this is a no-op for every path that works today.

Happy to split this into its own PR if you'd prefer it separate.

## Test

`tests/kernels/attention/test_mla_kv_b_dtype_guard.py` — parametrized over both packed containers and three real activation dtypes. Pure predicate test, no GPU required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of quantized attention weights using packed data formats.
  * Prevented incorrect dtype conversions during attention processing, improving compatibility with supported quantized configurations.

* **Tests**
  * Added coverage for packed quantized and standard numeric data types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->