### PR TITLE
[GG] Add EXL3 Trellis backend for rank-sliced MoE checkpoints

### DIFF
--- a/tests/model_executor/layers/test_mla_cache_format.py
+++ b/tests/model_executor/layers/test_mla_cache_format.py
@@ -14,9 +14,16 @@ from vllm.model_executor.layers.mla_cache_format import (
 )
 
 
-def test_cache_format_envs_are_registered():
+def test_cache_format_envs_are_registered(monkeypatch):
     assert NVFP4_MLA_DYNAMIC_SCALE_ENV in envs.environment_variables
     assert NVFP4_MLA_SCALES_ENV in envs.environment_variables
+
+    scales_file = envs.environment_variables[NVFP4_MLA_SCALES_ENV]
+    monkeypatch.delenv(NVFP4_MLA_SCALES_ENV, raising=False)
+    assert scales_file() == ""
+
+    monkeypatch.setenv(NVFP4_MLA_SCALES_ENV, "  /tmp/static-scales.json  ")
+    assert scales_file() == "/tmp/static-scales.json"
 
 
 def test_from_env_captures_one_server_static_mode(monkeypatch):

--- a/tests/model_executor/layers/test_sparse_attn_indexer_b12x.py
+++ b/tests/model_executor/layers/test_sparse_attn_indexer_b12x.py
@@ -1434,9 +1434,12 @@ def test_b12x_schedule_metadata_uses_canonical_indexer_import(monkeypatch):
     monkeypatch.setattr(
         mla_indexer_mod.envs,
         "VLLM_USE_B12X_SPARSE_INDEXER",
-        True,
+        False,
     )
     builder = object.__new__(mla_indexer_mod.DeepseekV32IndexerMetadataBuilder)
+    # Backend selection is resolved once in __init__. The metadata path must
+    # use that result even when the legacy environment flag is unset.
+    builder.use_b12x_sparse_indexer = True
     builder.scheduler_metadata_buffer = torch.zeros((5, 2), dtype=torch.int32)
     builder.kv_cache_spec = types.SimpleNamespace(storage_block_size=64)
     builder.num_sms = 4
@@ -1457,6 +1460,27 @@ def test_b12x_schedule_metadata_uses_canonical_indexer_import(monkeypatch):
         ("uses_schedule", 2, 3),
         ("build_schedule", (64, 128), 64, 4, True),
     ]
+
+
+def test_b12x_schedule_metadata_respects_cached_backend_choice(monkeypatch):
+    from vllm.v1.attention.backends.mla import indexer as mla_indexer_mod
+
+    monkeypatch.setattr(
+        mla_indexer_mod.envs,
+        "VLLM_USE_B12X_SPARSE_INDEXER",
+        True,
+    )
+    builder = object.__new__(mla_indexer_mod.DeepseekV32IndexerMetadataBuilder)
+    builder.use_b12x_sparse_indexer = False
+
+    result = builder._maybe_build_b12x_schedule_metadata(
+        seq_lens=torch.tensor([64], dtype=torch.int32),
+        block_table=torch.zeros((1, 1), dtype=torch.int32),
+        num_decode_tokens=1,
+        requires_padding=False,
+    )
+
+    assert result is None
 
 
 def test_mtp_variable_decode_preserves_block_table_alignment_padding():

--- a/tests/model_executor/test_eagle_quantization.py
+++ b/tests/model_executor/test_eagle_quantization.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 import pytest
@@ -52,6 +53,49 @@ def test_get_draft_quant_config_without_draft_model():
     result = get_draft_quant_config(mock_vllm_config)
 
     assert result is None
+
+
+def test_dense_exl3_draft_skips_rank_sliced_hydration():
+    quant_config = Mock()
+    quant_config.get_name.return_value = "exl3"
+    draft_model_config = SimpleNamespace(
+        model="dense-exl3-draft",
+        hf_config=SimpleNamespace(),
+    )
+    vllm_config = SimpleNamespace(
+        speculative_config=SimpleNamespace(draft_model_config=draft_model_config),
+        load_config=object(),
+        model_config=SimpleNamespace(hf_config=SimpleNamespace()),
+    )
+
+    with patch.object(VllmConfig, "get_quantization_config", return_value=quant_config):
+        result = get_draft_quant_config(vllm_config)
+
+    assert result is quant_config
+    quant_config.maybe_update_config.assert_not_called()
+
+
+def test_rank_sliced_exl3_draft_hydrates_from_target_metadata():
+    quant_config = Mock()
+    quant_config.get_name.return_value = "exl3"
+    target_hf = SimpleNamespace(hybrid_tr3_tail={"tp": 4})
+    draft_model_config = SimpleNamespace(
+        model="rank-sliced-draft",
+        hf_config=SimpleNamespace(),
+    )
+    vllm_config = SimpleNamespace(
+        speculative_config=SimpleNamespace(draft_model_config=draft_model_config),
+        load_config=object(),
+        model_config=SimpleNamespace(hf_config=target_hf),
+    )
+
+    with patch.object(VllmConfig, "get_quantization_config", return_value=quant_config):
+        result = get_draft_quant_config(vllm_config)
+
+    assert result is quant_config
+    quant_config.maybe_update_config.assert_called_once_with(
+        "rank-sliced-draft", hf_config=target_hf
+    )
 
 
 @torch.inference_mode()

--- a/tests/quantization/test_exl3.py
+++ b/tests/quantization/test_exl3.py
@@ -8,11 +8,13 @@ import torch
 
 import vllm.model_executor.layers.quantization.exl3 as exl3_module
 import vllm.model_executor.parameter as parameter_module
+from vllm.config import CompilationMode
 from vllm.model_executor.layers.quantization import get_quantization_config
 from vllm.model_executor.layers.quantization.exl3 import (
     Exl3Config,
     Exl3MoEParameter,
 )
+from vllm.model_executor.models import glm4_moe
 
 
 def _rank_sliced_metadata(**overrides):
@@ -47,6 +49,39 @@ def test_rank_sliced_checkpoint_selects_exl3_override():
         )
         is None
     )
+
+
+def test_glm_model_retains_quant_config_for_weight_loading(monkeypatch):
+    pp_group = SimpleNamespace(is_first_rank=False, is_last_rank=False)
+    monkeypatch.setattr(glm4_moe, "get_pp_group", lambda: pp_group)
+    monkeypatch.setattr(
+        glm4_moe,
+        "make_layers",
+        lambda *args, **kwargs: (0, 0, torch.nn.ModuleList()),
+    )
+    monkeypatch.setattr(
+        glm4_moe,
+        "make_empty_intermediate_tensors_factory",
+        lambda *args, **kwargs: object(),
+    )
+    quant_config = object()
+    vllm_config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            hf_config=SimpleNamespace(
+                vocab_size=1,
+                hidden_size=8,
+                num_hidden_layers=0,
+            )
+        ),
+        cache_config=object(),
+        quant_config=quant_config,
+        parallel_config=SimpleNamespace(enable_eplb=False),
+        compilation_config=SimpleNamespace(mode=CompilationMode.NONE),
+    )
+
+    model = glm4_moe.Glm4MoeModel(vllm_config=vllm_config)
+
+    assert model.quant_config is quant_config
 
 
 @pytest.mark.parametrize(

--- a/tests/quantization/test_exl3.py
+++ b/tests/quantization/test_exl3.py
@@ -128,3 +128,58 @@ def test_rank_sliced_parameter_preallocates_projection_major_slab(monkeypatch):
     )
     torch.testing.assert_close(param.exl3_tensors[(1, "w1")], w1)
     torch.testing.assert_close(param.exl3_tensors[(2, "w3")], w3)
+
+
+def test_rank_sliced_runtime_scope_is_per_owning_model():
+    """Target and rank-sliced MTP draft layers must not share a cached runtime.
+
+    The rank-sliced runtime cache stores mutable Trellis/prefill scratch and
+    parity staging buffers. A target MoE layer and an MTP draft layer of the same
+    model have identical shapes, topk and planner settings, so a shape-only key
+    would hand the draft the target's scratch and break the target/draft
+    isolation their independently captured CUDA graphs depend on.
+    """
+    target_config = SimpleNamespace()
+    draft_config = SimpleNamespace()
+
+    target_scope = exl3_module._runtime_scope_id(target_config)
+    draft_scope = exl3_module._runtime_scope_id(draft_config)
+
+    # Distinct owning configs must never collide...
+    assert target_scope != draft_scope
+    # ...and the scope must be stable, so every layer of one model keeps sharing
+    # a single runtime (the prefill arena is ~1 GiB; per-layer runtimes would not
+    # fit on a 75+ layer model).
+    assert exl3_module._runtime_scope_id(target_config) == target_scope
+    assert exl3_module._runtime_scope_id(draft_config) == draft_scope
+
+
+def test_rank_sliced_runtime_key_differs_across_models_with_same_shape():
+    """Two same-shape layers owned by different models get different cache keys."""
+
+    def _key(quant_config):
+        # Mirrors the scope-prefixed key built in Exl3MoEMethod._rank_sliced_runtime
+        # for two layers whose shape/planner components are byte-for-byte equal.
+        return (
+            exl3_module._runtime_scope_id(quant_config),
+            0,  # device index
+            torch.bfloat16,
+            5120,  # hidden size
+            768,  # intermediate size per partition
+            64,  # local experts
+            8,  # topk
+            3072,  # max batched tokens
+        )
+
+    target_config = SimpleNamespace()
+    draft_config = SimpleNamespace()
+
+    target_key = _key(target_config)
+    draft_key = _key(draft_config)
+
+    assert target_key != draft_key
+    # Everything except the leading scope is identical, proving the scope is the
+    # only thing preventing the collision.
+    assert target_key[1:] == draft_key[1:]
+    # Same owner -> same key, so target layers still share one runtime.
+    assert _key(target_config) == target_key

--- a/tests/quantization/test_exl3.py
+++ b/tests/quantization/test_exl3.py
@@ -183,3 +183,49 @@ def test_rank_sliced_runtime_key_differs_across_models_with_same_shape():
     assert target_key[1:] == draft_key[1:]
     # Same owner -> same key, so target layers still share one runtime.
     assert _key(target_config) == target_key
+
+
+def test_draft_layer_window_defaults_to_min_capturable_m(monkeypatch) -> None:
+    """A rank-sliced draft layer must be capturable without an env workaround.
+
+    Regression test for the boot failure reported in vLLM #183: with the Trellis
+    window left at its historical default of 4, CUDA-graph capture of an EXL3
+    rank-sliced MTP draft reaches the eager parity path at m=1,2,3 and the engine
+    cannot start:
+
+        RuntimeError: EXL3 eager parity path entered during CUDA graph capture
+        (m=3); capture sizes must lie inside the Trellis window [4, 32]
+
+    It was invariant to num_speculative_tokens and to cudagraph_capture_sizes,
+    because m here is the draft's row count per step, not a target batch size.
+    The backend now declares MIN_CAPTURABLE_TRELLIS_M and defaults draft layers to
+    it, so no operator has to set VLLM_EXL3_TRELLIS_MIN_M by hand.
+    """
+    from types import SimpleNamespace
+
+    from vllm.model_executor.layers.quantization import exl3 as exl3_mod
+
+    monkeypatch.delenv("VLLM_EXL3_TRELLIS_MIN_M", raising=False)
+
+    draft = SimpleNamespace(layer_name="model.layers.78.mtp.mlp.experts")
+    target = SimpleNamespace(layer_name="model.layers.30.mlp.experts")
+
+    assert exl3_mod._is_draft_layer(draft)
+    assert not exl3_mod._is_draft_layer(target)
+
+    def resolved(layer):
+        default = (
+            exl3_mod.MIN_CAPTURABLE_TRELLIS_M
+            if exl3_mod._is_draft_layer(layer)
+            else exl3_mod._DEFAULT_TRELLIS_MIN_M
+        )
+        return exl3_mod._positive_env_int("VLLM_EXL3_TRELLIS_MIN_M", default)
+
+    # The draft must admit m=1 so capture at m=1,2,3 stays on the Trellis path.
+    assert resolved(draft) <= exl3_mod.MIN_CAPTURABLE_TRELLIS_M == 1
+    # The target keeps its historical default.
+    assert resolved(target) == exl3_mod._DEFAULT_TRELLIS_MIN_M == 4
+
+    # An explicit value remains authoritative in both directions (kill switch).
+    monkeypatch.setenv("VLLM_EXL3_TRELLIS_MIN_M", "4")
+    assert resolved(draft) == 4

--- a/tests/quantization/test_exl3.py
+++ b/tests/quantization/test_exl3.py
@@ -9,9 +9,11 @@ import torch
 import vllm.model_executor.layers.quantization.exl3 as exl3_module
 import vllm.model_executor.parameter as parameter_module
 from vllm.config import CompilationMode
+from vllm.model_executor.layers.fused_moe import MoEActivation
 from vllm.model_executor.layers.quantization import get_quantization_config
 from vllm.model_executor.layers.quantization.exl3 import (
     Exl3Config,
+    Exl3MoEMethod,
     Exl3MoEParameter,
 )
 from vllm.model_executor.models import glm4_moe
@@ -163,6 +165,74 @@ def test_rank_sliced_parameter_preallocates_projection_major_slab(monkeypatch):
     )
     torch.testing.assert_close(param.exl3_tensors[(1, "w1")], w1)
     torch.testing.assert_close(param.exl3_tensors[(2, "w3")], w3)
+
+
+def test_rank_sliced_weights_use_unified_fused_moe_contract(monkeypatch):
+    experts = 2
+    hidden = intermediate = 128
+    bits = 3
+    slabs = {
+        "w13_trellis": torch.zeros(
+            (2, experts, hidden // 16, intermediate // 16, 16 * bits),
+            dtype=torch.int16,
+        ),
+        "w2_trellis": torch.zeros(
+            (experts, intermediate // 16, hidden // 16, 16 * bits),
+            dtype=torch.int16,
+        ),
+        "w13_suh": torch.ones((2, experts, hidden), dtype=torch.float16),
+        "w13_svh": torch.ones((2, experts, intermediate), dtype=torch.float16),
+        "w2_suh": torch.ones((experts, intermediate), dtype=torch.float16),
+        "w2_svh": torch.ones((experts, hidden), dtype=torch.float16),
+    }
+
+    class FakeFusedMoe:
+        def __init__(self):
+            self.plan_kwargs = None
+            self.prepare_kwargs = None
+
+        def plan_weights(self, **kwargs):
+            self.plan_kwargs = kwargs
+            return SimpleNamespace(source_format=kwargs["source_format"])
+
+        def prepare_weights(self, **kwargs):
+            self.prepare_kwargs = kwargs
+            return SimpleNamespace(plan=kwargs["plan"])
+
+    api = FakeFusedMoe()
+    monkeypatch.setattr(exl3_module, "_load_sparkinfer_fused_moe", lambda: api)
+    method = object.__new__(Exl3MoEMethod)
+    method.quant_config = SimpleNamespace(bits=float(bits))
+    method._rank_sliced_backing = lambda _layer, name: slabs[name]
+    marker = torch.tensor(0xCBAC1FED - (1 << 32), dtype=torch.int32)
+    layer = SimpleNamespace(
+        local_num_experts=experts,
+        exl3_hidden_size=hidden,
+        exl3_intermediate_size_per_partition=intermediate,
+        exl3_params_dtype=torch.float16,
+        activation=MoEActivation.SILU,
+        w13_mcg=SimpleNamespace(exl3_tensors={(0, "w1"): marker}),
+    )
+
+    method._prepare_rank_sliced_weights(layer)
+
+    assert api.plan_kwargs == {
+        "quant_modes": "w4a16",
+        "source_format": "exl3_trellis_mcg",
+        "activation": "silu",
+        "params_dtype": torch.float16,
+        "num_experts": experts,
+        "hidden_size": hidden,
+        "intermediate_size": intermediate,
+        "w13_layout": "w13",
+        "trellis_bits": bits,
+        "trellis_tile_config": (64, 128, 64, 128),
+    }
+    assert api.prepare_kwargs["plan"] is layer.exl3_trellis_weights.plan
+    assert api.prepare_kwargs["params_dtype"] == torch.float16
+    assert api.prepare_kwargs["w1_fp4"] is slabs["w13_trellis"]
+    assert api.prepare_kwargs["w2_fp4"] is slabs["w2_trellis"]
+    assert api.prepare_kwargs["trellis_mcg"] is marker
 
 
 def test_rank_sliced_runtime_scope_is_per_owning_model():

--- a/tests/quantization/test_exl3.py
+++ b/tests/quantization/test_exl3.py
@@ -118,6 +118,47 @@ def test_rank_sliced_metadata_admits_only_declared_moe_layers():
     )
 
 
+def test_mixed_rank_sliced_metadata_hydrates_per_layer_bitrates(monkeypatch):
+    metadata = _rank_sliced_metadata(
+        bits="mixed",
+        bits_per_expert="tier_bitmap.json:k",
+        k_values=[3, 4],
+        experts_per_layer=4,
+        moe_layers=[77, 78],
+    )
+    payload = {
+        "77": {"k": [3, 4, 3, 4]},
+        # The checkpoint's MTP overlay records a uniform K3 tail this way.
+        "78": {"tail_tr3": [0, 1, 2, 3]},
+    }
+    monkeypatch.setattr(
+        exl3_module,
+        "get_hf_file_to_dict",
+        lambda filename, model_name, revision=None: payload,
+    )
+    config = Exl3Config()
+
+    config.maybe_update_config(
+        "unused",
+        SimpleNamespace(hybrid_tr3_tail=metadata, _commit_hash="revision"),
+    )
+
+    assert config.bits is None
+    assert config.rank_sliced_k_values == (3, 4)
+    assert config.rank_sliced_layer_bitrates("model.layers.77.mlp.experts") == (
+        3,
+        4,
+        3,
+        4,
+    )
+    assert config.rank_sliced_layer_bitrates("model.layers.78.mlp.experts") == (
+        3,
+        3,
+        3,
+        3,
+    )
+
+
 def test_rank_sliced_weight_name_keeps_only_local_tp_rank(monkeypatch):
     config = Exl3Config()
     config.maybe_update_config(
@@ -210,6 +251,8 @@ def test_rank_sliced_weights_use_unified_fused_moe_contract(monkeypatch):
         exl3_hidden_size=hidden,
         exl3_intermediate_size_per_partition=intermediate,
         exl3_params_dtype=torch.float16,
+        exl3_layer_bitrates=(bits,) * experts,
+        exl3_mixed_bitrate=False,
         activation=MoEActivation.SILU,
         w13_mcg=SimpleNamespace(exl3_tensors={(0, "w1"): marker}),
     )
@@ -233,6 +276,108 @@ def test_rank_sliced_weights_use_unified_fused_moe_contract(monkeypatch):
     assert api.prepare_kwargs["w1_fp4"] is slabs["w13_trellis"]
     assert api.prepare_kwargs["w2_fp4"] is slabs["w2_trellis"]
     assert api.prepare_kwargs["trellis_mcg"] is marker
+
+
+def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(monkeypatch):
+    experts = 4
+    hidden = intermediate = 128
+    bitrates = (3, 4, 3, 4)
+
+    def parameter(shard_ids=(), tensors=None, backing=None):
+        return SimpleNamespace(
+            exl3_shard_ids=list(shard_ids),
+            exl3_tensors=dict(tensors or {}),
+            exl3_backing=backing,
+        )
+
+    w13_tensors = {}
+    w2_tensors = {}
+    for expert, bits in enumerate(bitrates):
+        for shard in ("w1", "w3"):
+            w13_tensors[(expert, shard)] = torch.zeros(
+                (hidden // 16, intermediate // 16, 16 * bits),
+                dtype=torch.int16,
+            )
+        w2_tensors[(expert, "w2")] = torch.zeros(
+            (intermediate // 16, hidden // 16, 16 * bits),
+            dtype=torch.int16,
+        )
+
+    slabs = {
+        "w13_suh": torch.ones((2, experts, hidden), dtype=torch.float16),
+        "w13_svh": torch.ones((2, experts, intermediate), dtype=torch.float16),
+        "w2_suh": torch.ones((experts, intermediate), dtype=torch.float16),
+        "w2_svh": torch.ones((experts, hidden), dtype=torch.float16),
+    }
+    layer = SimpleNamespace(
+        local_num_experts=experts,
+        exl3_hidden_size=hidden,
+        exl3_intermediate_size_per_partition=intermediate,
+        exl3_layer_bitrates=bitrates,
+        activation=MoEActivation.SILU,
+        layer_name="model.layers.3.mlp.experts",
+        w13_trellis=parameter(("w1", "w3"), w13_tensors),
+        w2_trellis=parameter(("w2",), w2_tensors),
+    )
+    for prefix, shards in (("w13", ("w1", "w3")), ("w2", ("w2",))):
+        for suffix in ("suh", "svh", "mcg", "mul1"):
+            name = f"{prefix}_{suffix}"
+            backing = slabs.get(name)
+            setattr(layer, name, parameter(shards, backing=backing))
+
+    class FakeMixedApi:
+        def __init__(self):
+            self.prepared = []
+
+        def prepare_weights(self, **kwargs):
+            self.prepared.append(kwargs)
+            return SimpleNamespace(**kwargs)
+
+        @staticmethod
+        def build_tiered_maps(tier0, tier1, *, device):
+            assert tuple(tier0) == (0, 2)
+            assert tuple(tier1) == (1, 3)
+            return (
+                torch.tensor([0, 2, 1, 3], dtype=torch.int32, device=device),
+                torch.tensor([0, 1, 256, 257], dtype=torch.int32, device=device),
+            )
+
+        @staticmethod
+        def combine_trellis_rotations(tier0, tier1):
+            return tier0, tier1
+
+    api = FakeMixedApi()
+    monkeypatch.setattr(exl3_module, "_load_sparkinfer_mixed_trellis", lambda: api)
+    method = object.__new__(Exl3MoEMethod)
+    method._rank_sliced_backing = lambda _layer, name: slabs[name]
+
+    method._prepare_mixed_rank_sliced_weights(layer)
+
+    assert [entry["trellis_bits"] for entry in api.prepared] == [3, 4]
+    assert [entry["num_experts"] for entry in api.prepared] == [2, 2]
+    assert [entry["tile_config"] for entry in api.prepared] == [
+        (128, 128, 128, 128),
+        (128, 128, 128, 128),
+    ]
+    assert layer.exl3_mixed_trellis["tier_ids"] == ((0, 2), (1, 3))
+    assert layer.w13_trellis.exl3_tensors == {}
+    assert layer.w2_trellis.exl3_tensors == {}
+    assert layer.w13_suh.exl3_backing is None
+    assert layer.w2_svh.exl3_backing is None
+
+
+@pytest.mark.parametrize(
+    ("hidden", "intermediate", "expected"),
+    [
+        (6144, 512, (128, 128, 32, 512)),
+        (256, 128, (128, 128, 64, 256)),
+        (128, 128, (128, 128, 128, 128)),
+    ],
+)
+def test_mixed_trellis_uses_large_m_safe_tile_geometry(
+    hidden, intermediate, expected
+):
+    assert Exl3MoEMethod._mixed_trellis_tile_config(hidden, intermediate) == expected
 
 
 def test_rank_sliced_runtime_scope_is_per_owning_model():

--- a/tests/quantization/test_exl3.py
+++ b/tests/quantization/test_exl3.py
@@ -355,15 +355,39 @@ def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(monkeypat
 
     assert [entry["trellis_bits"] for entry in api.prepared] == [3, 4]
     assert [entry["num_experts"] for entry in api.prepared] == [2, 2]
+    for entry in api.prepared:
+        bits = entry["trellis_bits"]
+        assert tuple(entry["w13"].shape) == (
+            2,
+            2,
+            hidden // 16,
+            intermediate // 16,
+            16 * bits,
+        )
+        assert tuple(entry["w2"].shape) == (
+            2,
+            intermediate // 16,
+            hidden // 16,
+            16 * bits,
+        )
     assert [entry["tile_config"] for entry in api.prepared] == [
         (128, 128, 128, 128),
         (128, 128, 128, 128),
     ]
     assert layer.exl3_mixed_trellis["tier_ids"] == ((0, 2), (1, 3))
+    assert layer.exl3_mixed_trellis["tier_bits"] == (3, 4)
     assert layer.w13_trellis.exl3_tensors == {}
     assert layer.w2_trellis.exl3_tensors == {}
     assert layer.w13_suh.exl3_backing is None
     assert layer.w2_svh.exl3_backing is None
+
+
+def test_mixed_trellis_buffer_accounting_ignores_metadata() -> None:
+    shared = torch.empty(8, dtype=torch.uint8)
+    first = SimpleNamespace(tensor=shared, metadata=None, block_size=8)
+    second = SimpleNamespace(alias=shared.view(2, 4), label="prefill")
+
+    assert exl3_module._unique_tensor_storage_bytes(first, second) == 8
 
 
 @pytest.mark.parametrize(
@@ -374,9 +398,7 @@ def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(monkeypat
         (128, 128, (128, 128, 128, 128)),
     ],
 )
-def test_mixed_trellis_uses_large_m_safe_tile_geometry(
-    hidden, intermediate, expected
-):
+def test_mixed_trellis_uses_large_m_safe_tile_geometry(hidden, intermediate, expected):
     assert Exl3MoEMethod._mixed_trellis_tile_config(hidden, intermediate) == expected
 
 

--- a/tests/quantization/test_exl3.py
+++ b/tests/quantization/test_exl3.py
@@ -1,0 +1,130 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import vllm.model_executor.layers.quantization.exl3 as exl3_module
+import vllm.model_executor.parameter as parameter_module
+from vllm.model_executor.layers.quantization import get_quantization_config
+from vllm.model_executor.layers.quantization.exl3 import (
+    Exl3Config,
+    Exl3MoEParameter,
+)
+
+
+def _rank_sliced_metadata(**overrides):
+    metadata = {
+        "format": "exl3-trellis",
+        "bits": 3.0,
+        "codebook": "mcg",
+        "experts_per_layer": 256,
+        "moe_layers": [3, 77],
+        "tensor_schema": (
+            "model.layers.{L}.mlp.experts.{E}.{proj}.rank{r}.{trellis|suh|svh|mcg}"
+        ),
+        "tp": 4,
+    }
+    metadata.update(overrides)
+    return metadata
+
+
+def test_rank_sliced_checkpoint_selects_exl3_override():
+    hf_config = SimpleNamespace(hybrid_tr3_tail=_rank_sliced_metadata())
+
+    assert get_quantization_config("exl3") is Exl3Config
+    assert (
+        Exl3Config.override_quantization_method(
+            {"quant_method": "modelopt"}, None, hf_config
+        )
+        == "exl3"
+    )
+    assert (
+        Exl3Config.override_quantization_method(
+            {"quant_method": "modelopt"}, "fp8", hf_config
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"codebook": "mul1"}, "MCG codebook"),
+        ({"moe_layers": [77, 3]}, "moe_layers"),
+        ({"tensor_schema": "unsupported"}, "tensor schema"),
+    ],
+)
+def test_rank_sliced_metadata_fails_closed(overrides, message):
+    config = Exl3Config()
+    hf_config = SimpleNamespace(hybrid_tr3_tail=_rank_sliced_metadata(**overrides))
+
+    with pytest.raises(ValueError, match=message):
+        config.maybe_update_config("unused", hf_config)
+
+
+def test_rank_sliced_metadata_admits_only_declared_moe_layers():
+    config = Exl3Config()
+    config.maybe_update_config(
+        "unused",
+        SimpleNamespace(hybrid_tr3_tail=_rank_sliced_metadata()),
+    )
+
+    assert config._moe_prefix_is_exl3("model.layers.3.mlp.experts")
+    assert config._moe_prefix_is_exl3("model.layers.77.mlp.experts")
+    assert not config._moe_prefix_is_exl3("model.layers.2.mlp.experts")
+    assert not config._moe_prefix_is_exl3("model.layers.78.mlp.experts")
+    assert (
+        config.codebook_for_prefix("model.layers.10.mlp.experts.0.gate_proj") == "mcg"
+    )
+
+
+def test_rank_sliced_weight_name_keeps_only_local_tp_rank(monkeypatch):
+    config = Exl3Config()
+    config.maybe_update_config(
+        "unused",
+        SimpleNamespace(hybrid_tr3_tail=_rank_sliced_metadata()),
+    )
+    monkeypatch.setattr(exl3_module, "get_tensor_model_parallel_rank", lambda: 2)
+    prefix = "model.layers.3.mlp.experts.17.gate_proj"
+
+    assert (
+        config.normalize_rank_sliced_weight_name(f"{prefix}.rank2.trellis")
+        == f"{prefix}.trellis"
+    )
+    assert config.normalize_rank_sliced_weight_name(f"{prefix}.rank1.trellis") is None
+    assert (
+        config.normalize_rank_sliced_weight_name("model.embed_tokens.weight")
+        == "model.embed_tokens.weight"
+    )
+
+
+def test_rank_sliced_parameter_preallocates_projection_major_slab(monkeypatch):
+    monkeypatch.setattr(parameter_module, "get_tensor_model_parallel_rank", lambda: 0)
+    monkeypatch.setattr(
+        parameter_module, "get_tensor_model_parallel_world_size", lambda: 1
+    )
+    param = Exl3MoEParameter(
+        weight_loader=lambda *args, **kwargs: None,
+        num_experts=3,
+        shard_ids=("w1", "w3"),
+        preallocate=True,
+    )
+    w1 = torch.arange(8, dtype=torch.int16).reshape(2, 2, 2)
+    w3 = w1 + 20
+
+    param.load_exl3_weight(w1, expert_id=1, shard_id="w1")
+    param.load_exl3_weight(w3, expert_id=2, shard_id="w3")
+
+    assert param.exl3_backing is not None
+    assert tuple(param.exl3_backing.shape) == (2, 3, 2, 2, 2)
+    assert (
+        param.exl3_tensors[(1, "w1")].data_ptr() == param.exl3_backing[0, 1].data_ptr()
+    )
+    assert (
+        param.exl3_tensors[(2, "w3")].data_ptr() == param.exl3_backing[1, 2].data_ptr()
+    )
+    torch.testing.assert_close(param.exl3_tensors[(1, "w1")], w1)
+    torch.testing.assert_close(param.exl3_tensors[(2, "w3")], w3)

--- a/tests/quantization/test_exl3.py
+++ b/tests/quantization/test_exl3.py
@@ -290,8 +290,8 @@ def test_rank_sliced_runtime_key_differs_across_models_with_same_shape():
     assert _key(target_config) == target_key
 
 
-def test_draft_layer_window_defaults_to_min_capturable_m(monkeypatch) -> None:
-    """A rank-sliced draft layer must be capturable without an env workaround.
+def test_rank_sliced_window_defaults_to_min_capturable_m(monkeypatch) -> None:
+    """Every rank-sliced layer must cover small rows without an env workaround.
 
     Regression test for the boot failure reported in vLLM #183: with the Trellis
     window left at its historical default of 4, CUDA-graph capture of an EXL3
@@ -303,8 +303,9 @@ def test_draft_layer_window_defaults_to_min_capturable_m(monkeypatch) -> None:
 
     It was invariant to num_speculative_tokens and to cudagraph_capture_sizes,
     because m here is the draft's row count per step, not a target batch size.
-    The backend now declares MIN_CAPTURABLE_TRELLIS_M and defaults draft layers to
-    it, so no operator has to set VLLM_EXL3_TRELLIS_MIN_M by hand.
+    Target profiling can also produce m=3, so role-dependent defaults merely
+    move the same failure from the draft to MTP0. The backend declares one
+    capability floor and uses it for both roles.
     """
     from types import SimpleNamespace
 
@@ -331,22 +332,17 @@ def test_draft_layer_window_defaults_to_min_capturable_m(monkeypatch) -> None:
         SimpleNamespace(layer_name="model.layers.0.mtp.experts", exl3_is_draft=False)
     )
 
-    def resolved(layer):
-        default = (
-            exl3_mod.MIN_CAPTURABLE_TRELLIS_M
-            if exl3_mod._is_draft_layer(layer)
-            else exl3_mod._DEFAULT_TRELLIS_MIN_M
+    def resolved():
+        return exl3_mod._positive_env_int(
+            "VLLM_EXL3_TRELLIS_MIN_M", exl3_mod._DEFAULT_TRELLIS_MIN_M
         )
-        return exl3_mod._positive_env_int("VLLM_EXL3_TRELLIS_MIN_M", default)
 
-    # The draft must admit m=1 so capture at m=1,2,3 stays on the Trellis path.
-    assert resolved(draft) <= exl3_mod.MIN_CAPTURABLE_TRELLIS_M == 1
-    # The target keeps its historical default.
-    assert resolved(target) == exl3_mod._DEFAULT_TRELLIS_MIN_M == 4
+    assert resolved() == exl3_mod._DEFAULT_TRELLIS_MIN_M
+    assert resolved() == exl3_mod.MIN_CAPTURABLE_TRELLIS_M == 1
 
-    # An explicit value remains authoritative in both directions (kill switch).
+    # An explicit value remains authoritative as a diagnostic kill switch.
     monkeypatch.setenv("VLLM_EXL3_TRELLIS_MIN_M", "4")
-    assert resolved(draft) == 4
+    assert resolved() == 4
 
 
 def test_draft_role_stamp_wins_over_name() -> None:

--- a/tests/quantization/test_exl3.py
+++ b/tests/quantization/test_exl3.py
@@ -207,11 +207,24 @@ def test_draft_layer_window_defaults_to_min_capturable_m(monkeypatch) -> None:
 
     monkeypatch.delenv("VLLM_EXL3_TRELLIS_MIN_M", raising=False)
 
-    draft = SimpleNamespace(layer_name="model.layers.78.mtp.mlp.experts")
+    # The GLM-5.2 MTP head is named exactly like a target layer, so the role
+    # comes from the exl3_is_draft stamp applied by load_eagle_model -- name
+    # inspection alone cannot classify it.
+    draft = SimpleNamespace(
+        layer_name="model.layers.78.mlp.experts", exl3_is_draft=True
+    )
     target = SimpleNamespace(layer_name="model.layers.30.mlp.experts")
 
     assert exl3_mod._is_draft_layer(draft)
     assert not exl3_mod._is_draft_layer(target)
+    # Unstamped draft with a distinctive prefix still classifies via fallback.
+    assert exl3_mod._is_draft_layer(
+        SimpleNamespace(layer_name="model.layers.0.mtp.mlp.experts")
+    )
+    # A stamp always wins over the name, in both directions.
+    assert not exl3_mod._is_draft_layer(
+        SimpleNamespace(layer_name="model.layers.0.mtp.experts", exl3_is_draft=False)
+    )
 
     def resolved(layer):
         default = (
@@ -229,3 +242,32 @@ def test_draft_layer_window_defaults_to_min_capturable_m(monkeypatch) -> None:
     # An explicit value remains authoritative in both directions (kill switch).
     monkeypatch.setenv("VLLM_EXL3_TRELLIS_MIN_M", "4")
     assert resolved(draft) == 4
+
+
+def test_draft_role_stamp_wins_over_name() -> None:
+    """The exl3_is_draft stamp set in create_weights is authoritative.
+
+    Forward/plan/capture time has no current vllm config, so the role cannot be
+    inferred there; create_weights stamps it from runner_type while the
+    construction context is live. Stamped values must win over any name
+    heuristic in both directions.
+    """
+    from types import SimpleNamespace
+
+    from vllm.model_executor.layers.quantization import exl3 as exl3_mod
+
+    # GLM-5.2 MTP head: named like a target, stamped draft.
+    assert exl3_mod._is_draft_layer(
+        SimpleNamespace(layer_name="model.layers.78.mlp.experts", exl3_is_draft=True)
+    )
+    # Target stamped False keeps its role even with a suspicious name.
+    assert not exl3_mod._is_draft_layer(
+        SimpleNamespace(layer_name="model.layers.0.mtp.experts", exl3_is_draft=False)
+    )
+    # Unstamped layers fall back to the name heuristic.
+    assert exl3_mod._is_draft_layer(
+        SimpleNamespace(layer_name="model.layers.0.mtp.mlp.experts")
+    )
+    assert not exl3_mod._is_draft_layer(
+        SimpleNamespace(layer_name="model.layers.30.mlp.experts")
+    )

--- a/tests/quantization/test_exl3_prefill_plan.py
+++ b/tests/quantization/test_exl3_prefill_plan.py
@@ -225,6 +225,31 @@ def test_prefill_block_m_env_override():
         assert h.api.bound[-1][0].caps["max_tokens"] == MAX_BATCHED
 
 
+def test_parity_window_capacity_is_validated_before_planning():
+    env = {
+        "VLLM_EXL3_TRELLIS_MIN_M": "160",
+        "VLLM_EXL3_TRELLIS_MAX_M": "192",
+        "VLLM_EXL3_PREFILL_CHUNK": "128",
+    }
+    with _Harness(env=env) as h:
+        with pytest.raises(ValueError, match="cannot cover the EXL3 parity window"):
+            _apply(_make_method(), _make_layer(), 16)
+        assert not h.planned_caps()
+
+
+def test_disabled_prefill_plan_keeps_full_parity_capacity():
+    env = {
+        "VLLM_EXL3_TRELLIS_MIN_M": "160",
+        "VLLM_EXL3_TRELLIS_MAX_M": "192",
+        "VLLM_EXL3_PREFILL_CHUNK": "128",
+        "VLLM_EXL3_PREFILL_TRELLIS": "0",
+    }
+    with _Harness(env=env):
+        _apply(_make_method(), _make_layer(), 159)
+        runtime = next(iter(exl3_module._RANK_SLICED_RUNTIMES.values()))
+        assert runtime["parity_rows"] == MAX_BATCHED
+
+
 def test_parity_path_guarded_against_capture():
     with _Harness() as h:
         method = _make_method()

--- a/tests/quantization/test_exl3_prefill_plan.py
+++ b/tests/quantization/test_exl3_prefill_plan.py
@@ -46,7 +46,7 @@ class _FakePlan:
         )
 
 
-class _FakeTrellisApi:
+class _FakeFusedMoeApi:
     def __init__(self):
         self.planned = []
         self.bound = []
@@ -59,8 +59,8 @@ class _FakeTrellisApi:
         self.planned.append(caps)
         return plan
 
-    def bind(self, plan, *, scratch, a, weights, topk_weights, topk_ids):
-        del scratch, weights, topk_weights, topk_ids
+    def bind(self, plan, *, scratch, a, experts, topk_weights, topk_ids):
+        del scratch, experts, topk_weights, topk_ids
         self.bound.append((plan, int(a.shape[0])))
         return SimpleNamespace(plan=plan, m=int(a.shape[0]))
 
@@ -90,7 +90,7 @@ def _make_layer():
         exl3_intermediate_size_per_partition=INTERMEDIATE,
         local_num_experts=EXPERTS,
         exl3_trellis_tile_config=(64, 128, 64, 128),
-        exl3_trellis_weights=object(),
+        exl3_trellis_weights=SimpleNamespace(plan=object()),
         exl3_pointer_tables=(),
         exl3_expert_map=torch.arange(EXPERTS, dtype=torch.int64),
     )
@@ -110,7 +110,7 @@ class _Harness:
         self._env = dict(env or {})
         self._saved_env = {}
         self._saved_capturing = None
-        self.api = _FakeTrellisApi()
+        self.api = _FakeFusedMoeApi()
         self.ext = _FakeExt()
 
     def __enter__(self):
@@ -121,10 +121,10 @@ class _Harness:
             else:
                 os.environ[name] = value
         self._saved_loaders = (
-            exl3_module._load_sparkinfer_trellis,
+            exl3_module._load_sparkinfer_fused_moe,
             exl3_module._load_exl3_ext,
         )
-        exl3_module._load_sparkinfer_trellis = lambda: self.api
+        exl3_module._load_sparkinfer_fused_moe = lambda: self.api
         exl3_module._load_exl3_ext = lambda: self.ext
         self._saved_capturing = torch.cuda.is_current_stream_capturing
         torch.cuda.is_current_stream_capturing = lambda: False
@@ -135,7 +135,7 @@ class _Harness:
 
     def __exit__(self, *exc):
         (
-            exl3_module._load_sparkinfer_trellis,
+            exl3_module._load_sparkinfer_fused_moe,
             exl3_module._load_exl3_ext,
         ) = self._saved_loaders
         torch.cuda.is_current_stream_capturing = self._saved_capturing
@@ -165,7 +165,8 @@ def test_dual_plan_construction_and_dispatch():
         assert out.dtype == torch.bfloat16 and out.shape == (16, HIDDEN)
         # Two plans: decode (32, block 8) then prefill (capacity, block 64).
         assert [
-            (caps["max_tokens"], caps["block_size_m"]) for caps in h.planned_caps()
+            (caps["max_tokens"], caps["w4a16_block_size_m"])
+            for caps in h.planned_caps()
         ] == [(32, 8), (MAX_BATCHED, 64)]
         assert h.api.bound[-1][0].caps["max_tokens"] == 32
 
@@ -205,7 +206,8 @@ def test_prefill_trellis_disabled_restores_parity():
         _apply(method, layer, 200)
         # Single decode plan only; large m runs the parity chunk loop.
         assert [
-            (caps["max_tokens"], caps["block_size_m"]) for caps in h.planned_caps()
+            (caps["max_tokens"], caps["w4a16_block_size_m"])
+            for caps in h.planned_caps()
         ] == [(32, 8)]
         assert not h.api.bound
         assert h.ext.moe_calls == [(128, 128), (72, 72)]
@@ -221,7 +223,7 @@ def test_prefill_block_m_env_override():
         method = _make_method()
         layer = _make_layer()
         _apply(method, layer, 40)
-        assert h.planned_caps()[-1]["block_size_m"] == 48
+        assert h.planned_caps()[-1]["w4a16_block_size_m"] == 48
         assert h.api.bound[-1][0].caps["max_tokens"] == MAX_BATCHED
 
 

--- a/tests/quantization/test_exl3_prefill_plan.py
+++ b/tests/quantization/test_exl3_prefill_plan.py
@@ -19,6 +19,7 @@ CPU-only; no CUDA, sparkinfer, or exllamav3_ext required.
 import os
 from types import SimpleNamespace
 
+import pytest
 import torch
 
 import vllm.model_executor.layers.quantization.exl3 as exl3_module
@@ -181,11 +182,19 @@ def test_dual_plan_construction_and_dispatch():
         assert runtime["xh"].shape[0] == 128
         assert runtime["token_sorted"].numel() == 128 * TOPK
 
-        # m above the scheduler capacity re-keys the runtime and re-plans
-        # at the larger capacity (eager-only; capture remains guarded).
-        _apply(method, layer, MAX_BATCHED + 1)
-        assert h.api.bound[-1][0].caps["max_tokens"] == MAX_BATCHED + 1
-        assert h.planned_caps()[-1]["max_tokens"] == MAX_BATCHED + 1
+        # Batches above the scheduler contract must fail before allocating a
+        # replacement runtime or a larger Trellis arena during serving.
+        runtime_keys = tuple(exl3_module._RANK_SLICED_RUNTIMES)
+        runtime_count = len(exl3_module._RANK_SLICED_RUNTIMES)
+        plan_count = len(h.planned_caps())
+        with pytest.raises(
+            ValueError,
+            match=rf"m={MAX_BATCHED + 1}, capacity={MAX_BATCHED}",
+        ):
+            _apply(method, layer, MAX_BATCHED + 1)
+        assert tuple(exl3_module._RANK_SLICED_RUNTIMES) == runtime_keys
+        assert len(exl3_module._RANK_SLICED_RUNTIMES) == runtime_count
+        assert len(h.planned_caps()) == plan_count
 
 
 def test_prefill_trellis_disabled_restores_parity():

--- a/tests/quantization/test_exl3_prefill_plan.py
+++ b/tests/quantization/test_exl3_prefill_plan.py
@@ -148,6 +148,9 @@ class _Harness:
         exl3_module._RANK_SLICED_RUNTIMES.clear()
         return False
 
+    def planned_caps(self):
+        return self.api.planned
+
 
 def _apply(method, layer, m):
     x = torch.zeros((m, HIDDEN), dtype=torch.bfloat16)
@@ -275,19 +278,9 @@ def test_explicit_parity_path_guarded_against_capture():
             raise AssertionError("parity path must raise during capture")
 
 
-def _install_planned_caps_helper():
-    def planned_caps(self):
-        return self.api.planned
-
-    _Harness.planned_caps = planned_caps
-
-
-_install_planned_caps_helper()
-
-
 if __name__ == "__main__":
     test_dual_plan_construction_and_dispatch()
     test_prefill_trellis_disabled_restores_parity()
     test_prefill_block_m_env_override()
-    test_parity_path_guarded_against_capture()
+    test_explicit_parity_path_guarded_against_capture()
     print("EXL3_PREFILL_PLAN_TESTS_OK")

--- a/tests/quantization/test_exl3_prefill_plan.py
+++ b/tests/quantization/test_exl3_prefill_plan.py
@@ -1,0 +1,254 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Dispatch-contract tests for the dual-plan rank-sliced EXL3 MoE runtime.
+
+The planned Trellis API and the ExLlamaV3 extension are mocked; these tests
+prove backend policy only:
+
+* decode window m in [min, max] binds the decode plan;
+* max < m <= capacity binds the prefill plan (block_size_m=64 by default);
+* m < min stays on the parity path with chunk-capped staging buffers;
+* VLLM_EXL3_PREFILL_TRELLIS=0 restores the single-plan parity behavior
+  with full-capacity staging;
+* m above planned capacity raises.
+
+CPU-only; no CUDA, sparkinfer, or exllamav3_ext required.
+"""
+
+import os
+from types import SimpleNamespace
+
+import torch
+
+import vllm.model_executor.layers.quantization.exl3 as exl3_module
+from vllm.model_executor.layers.quantization.exl3 import Exl3MoEMethod
+
+HIDDEN = 128
+INTERMEDIATE = 128
+EXPERTS = 8
+TOPK = 4
+MAX_BATCHED = 256
+
+
+class _FakePlan:
+    def __init__(self, caps):
+        self.caps = caps
+
+    def scratch_specs(self):
+        return (
+            SimpleNamespace(
+                shape=(64,),
+                dtype=torch.uint8,
+                device=self.caps["device"],
+            ),
+        )
+
+
+class _FakeTrellisApi:
+    def __init__(self):
+        self.planned = []
+        self.bound = []
+
+    def Caps(self, **kwargs):
+        return kwargs
+
+    def plan(self, caps):
+        plan = _FakePlan(caps)
+        self.planned.append(caps)
+        return plan
+
+    def bind(self, plan, *, scratch, a, weights, topk_weights, topk_ids):
+        del scratch, weights, topk_weights, topk_ids
+        self.bound.append((plan, int(a.shape[0])))
+        return SimpleNamespace(plan=plan, m=int(a.shape[0]))
+
+    def run(self, *, binding):
+        return torch.zeros((binding.m, HIDDEN), dtype=torch.float32)
+
+
+class _FakeExt:
+    """Parity extension without exl3_moe_fused: chunk loop only."""
+
+    def __init__(self):
+        self.moe_calls = []
+
+    def exl3_moe_max_concurrency(self, device):
+        del device
+        return 2
+
+    def exl3_moe(self, xh, out32, *args):
+        del args
+        self.moe_calls.append((int(xh.shape[0]), int(out32.shape[0])))
+
+
+def _make_layer():
+    return SimpleNamespace(
+        exl3_max_num_batched_tokens=MAX_BATCHED,
+        exl3_hidden_size=HIDDEN,
+        exl3_intermediate_size_per_partition=INTERMEDIATE,
+        local_num_experts=EXPERTS,
+        exl3_trellis_tile_config=(64, 128, 64, 128),
+        exl3_trellis_weights=object(),
+        exl3_pointer_tables=(),
+        exl3_expert_map=torch.arange(EXPERTS, dtype=torch.int64),
+    )
+
+
+def _make_method():
+    method = object.__new__(Exl3MoEMethod)
+    method.quant_config = SimpleNamespace(
+        bits=3.0,
+        rank_sliced_metadata={"tp": 4},
+    )
+    return method
+
+
+class _Harness:
+    def __init__(self, env=None):
+        self._env = dict(env or {})
+        self._saved_env = {}
+        self._saved_capturing = None
+        self.api = _FakeTrellisApi()
+        self.ext = _FakeExt()
+
+    def __enter__(self):
+        for name, value in self._env.items():
+            self._saved_env[name] = os.environ.get(name)
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+        self._saved_loaders = (
+            exl3_module._load_sparkinfer_trellis,
+            exl3_module._load_exl3_ext,
+        )
+        exl3_module._load_sparkinfer_trellis = lambda: self.api
+        exl3_module._load_exl3_ext = lambda: self.ext
+        self._saved_capturing = torch.cuda.is_current_stream_capturing
+        torch.cuda.is_current_stream_capturing = lambda: False
+        self._saved_current_device = torch.cuda.current_device
+        torch.cuda.current_device = lambda: 0
+        exl3_module._RANK_SLICED_RUNTIMES.clear()
+        return self
+
+    def __exit__(self, *exc):
+        (
+            exl3_module._load_sparkinfer_trellis,
+            exl3_module._load_exl3_ext,
+        ) = self._saved_loaders
+        torch.cuda.is_current_stream_capturing = self._saved_capturing
+        torch.cuda.current_device = self._saved_current_device
+        for name, value in self._saved_env.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+        exl3_module._RANK_SLICED_RUNTIMES.clear()
+        return False
+
+
+def _apply(method, layer, m):
+    x = torch.zeros((m, HIDDEN), dtype=torch.bfloat16)
+    weights = torch.zeros((m, TOPK), dtype=torch.float32)
+    ids = torch.zeros((m, TOPK), dtype=torch.int64)
+    return method._apply_rank_sliced(layer, x, weights, ids)
+
+
+def test_dual_plan_construction_and_dispatch():
+    with _Harness() as h:
+        method = _make_method()
+        layer = _make_layer()
+
+        out = _apply(method, layer, 16)
+        assert out.dtype == torch.bfloat16 and out.shape == (16, HIDDEN)
+        # Two plans: decode (32, block 8) then prefill (capacity, block 64).
+        assert [
+            (caps["max_tokens"], caps["block_size_m"]) for caps in h.planned_caps()
+        ] == [(32, 8), (MAX_BATCHED, 64)]
+        assert h.api.bound[-1][0].caps["max_tokens"] == 32
+
+        _apply(method, layer, 200)
+        assert h.api.bound[-1][0].caps["max_tokens"] == MAX_BATCHED
+        assert h.api.bound[-1][1] == 200
+        assert not h.ext.moe_calls
+
+        _apply(method, layer, 2)
+        assert h.ext.moe_calls == [(2, 2)]
+
+        runtime = next(iter(exl3_module._RANK_SLICED_RUNTIMES.values()))
+        assert runtime["parity_rows"] == 128
+        assert runtime["xh"].shape[0] == 128
+        assert runtime["token_sorted"].numel() == 128 * TOPK
+
+        # m above the scheduler capacity re-keys the runtime and re-plans
+        # at the larger capacity (eager-only; capture remains guarded).
+        _apply(method, layer, MAX_BATCHED + 1)
+        assert h.api.bound[-1][0].caps["max_tokens"] == MAX_BATCHED + 1
+        assert h.planned_caps()[-1]["max_tokens"] == MAX_BATCHED + 1
+
+
+def test_prefill_trellis_disabled_restores_parity():
+    with _Harness(env={"VLLM_EXL3_PREFILL_TRELLIS": "0"}) as h:
+        method = _make_method()
+        layer = _make_layer()
+
+        _apply(method, layer, 200)
+        # Single decode plan only; large m runs the parity chunk loop.
+        assert [
+            (caps["max_tokens"], caps["block_size_m"]) for caps in h.planned_caps()
+        ] == [(32, 8)]
+        assert not h.api.bound
+        assert h.ext.moe_calls == [(128, 128), (72, 72)]
+
+        runtime = next(iter(exl3_module._RANK_SLICED_RUNTIMES.values()))
+        assert runtime["prefill_plan"] is None
+        assert runtime["parity_rows"] == MAX_BATCHED
+        assert runtime["xh"].shape[0] == MAX_BATCHED
+
+
+def test_prefill_block_m_env_override():
+    with _Harness(env={"VLLM_EXL3_PREFILL_BLOCK_M": "48"}) as h:
+        method = _make_method()
+        layer = _make_layer()
+        _apply(method, layer, 40)
+        assert h.planned_caps()[-1]["block_size_m"] == 48
+        assert h.api.bound[-1][0].caps["max_tokens"] == MAX_BATCHED
+
+
+def test_parity_path_guarded_against_capture():
+    with _Harness() as h:
+        method = _make_method()
+        layer = _make_layer()
+        # Plan eagerly, then flip into "capturing" state.
+        _apply(method, layer, 16)
+        torch.cuda.is_current_stream_capturing = lambda: True
+        # Both trellis plans stay capture-safe.
+        _apply(method, layer, 16)
+        _apply(method, layer, 200)
+        assert h.api.bound[-1][1] == 200
+        # The eager parity path must refuse to be recorded.
+        try:
+            _apply(method, layer, 2)
+        except RuntimeError as err:
+            assert "capture" in str(err)
+        else:
+            raise AssertionError("parity path must raise during capture")
+
+
+def _install_planned_caps_helper():
+    def planned_caps(self):
+        return self.api.planned
+
+    _Harness.planned_caps = planned_caps
+
+
+_install_planned_caps_helper()
+
+
+if __name__ == "__main__":
+    test_dual_plan_construction_and_dispatch()
+    test_prefill_trellis_disabled_restores_parity()
+    test_prefill_block_m_env_override()
+    test_parity_path_guarded_against_capture()
+    print("EXL3_PREFILL_PLAN_TESTS_OK")

--- a/tests/quantization/test_exl3_prefill_plan.py
+++ b/tests/quantization/test_exl3_prefill_plan.py
@@ -168,6 +168,7 @@ def test_dual_plan_construction_and_dispatch():
             (caps["max_tokens"], caps["w4a16_block_size_m"])
             for caps in h.planned_caps()
         ] == [(32, 8), (MAX_BATCHED, 64)]
+        assert all(caps["route_num_experts"] == 0 for caps in h.planned_caps())
         assert h.api.bound[-1][0].caps["max_tokens"] == 32
 
         _apply(method, layer, 200)
@@ -176,7 +177,9 @@ def test_dual_plan_construction_and_dispatch():
         assert not h.ext.moe_calls
 
         _apply(method, layer, 2)
-        assert h.ext.moe_calls == [(2, 2)]
+        assert h.api.bound[-1][0].caps["max_tokens"] == 32
+        assert h.api.bound[-1][1] == 2
+        assert not h.ext.moe_calls
 
         runtime = next(iter(exl3_module._RANK_SLICED_RUNTIMES.values()))
         assert runtime["parity_rows"] == 128
@@ -252,8 +255,8 @@ def test_disabled_prefill_plan_keeps_full_parity_capacity():
         assert runtime["parity_rows"] == MAX_BATCHED
 
 
-def test_parity_path_guarded_against_capture():
-    with _Harness() as h:
+def test_explicit_parity_path_guarded_against_capture():
+    with _Harness(env={"VLLM_EXL3_TRELLIS_MIN_M": "4"}) as h:
         method = _make_method()
         layer = _make_layer()
         # Plan eagerly, then flip into "capturing" state.

--- a/tests/v1/structured_output/test_reasoning_structured_output.py
+++ b/tests/v1/structured_output/test_reasoning_structured_output.py
@@ -241,6 +241,116 @@ class TestReasoningStructuredOutput:
         assert structured_req.reasoning_ended is True
         assert result is True
 
+    def test_should_advance_reasoning_just_ended_with_spec_decode_json(
+        self,
+        manager_with_reasoner,
+        mock_request_with_structured_output,
+    ):
+        """When reasoning ends this step under speculative decoding, advance
+        immediately for every structured type, not just structural tags: the
+        step may already contain accepted post-marker content, and deferring
+        leaves the grammar one token behind the sampled stream (#48228)."""
+        structured_req = mock_request_with_structured_output.structured_output_request
+        structured_req.reasoning_ended = False
+        structured_req.structured_output_key = (
+            StructuredOutputOptions.JSON,
+            '{"type": "object"}',
+        )
+        reasoner = MockReasoner(tokenizer=Mock())
+        reasoner.is_reasoning_end_streaming.return_value = True
+        structured_req.reasoner = reasoner
+
+        manager_with_reasoner.vllm_config.speculative_config = Mock()
+
+        result = manager_with_reasoner.should_advance(
+            mock_request_with_structured_output
+        )
+
+        assert structured_req.reasoning_ended is True
+        assert result is True
+        assert isinstance(structured_req.reasoning_end_token_index, int)
+
+    def test_should_advance_detects_end_from_new_token_ids(
+        self,
+        manager_with_reasoner,
+        mock_request_with_structured_output,
+    ):
+        """new_token_ids is the authoritative step delta: with speculative
+        decoding, num_computed_tokens is pre-incremented past accepted draft
+        tokens, so the counter-derived window misses the end marker (#34650)."""
+        end_token_id, content_token_id = 42, 99
+        request = mock_request_with_structured_output
+        structured_req = request.structured_output_request
+        structured_req.reasoning_ended = False
+        reasoner = MockReasoner(tokenizer=Mock())
+        reasoner.is_reasoning_end_streaming.side_effect = (
+            lambda input_ids, delta_ids: end_token_id in list(delta_ids)
+        )
+        structured_req.reasoner = reasoner
+
+        request.all_token_ids = request.prompt_token_ids + [
+            7,
+            end_token_id,
+            content_token_id,
+        ]
+        # Spec decode pre-incremented past the accepted tokens: the
+        # counter-derived window all_token_ids[num_computed_tokens:] is empty.
+        request.num_computed_tokens = len(request.all_token_ids)
+        request.num_output_placeholders = 0
+
+        # The counter fallback misses the marker...
+        assert manager_with_reasoner.should_advance(request) is False
+        assert structured_req.reasoning_ended is False
+
+        # ...the explicit step delta does not (no spec config here, so the
+        # advance itself is still deferred to the next step).
+        result = manager_with_reasoner.should_advance(
+            request, [end_token_id, content_token_id]
+        )
+        assert structured_req.reasoning_ended is True
+        assert result is False
+
+    def test_should_advance_straddle_step_trims_and_advances_same_step(
+        self,
+        manager_with_reasoner,
+        mock_request_with_structured_output,
+    ):
+        """A speculative step accepting [</think>, "{"] must advance the
+        grammar with exactly the post-marker content in the same step;
+        otherwise the next bitmask is computed from the un-advanced grammar
+        and re-forces the content token, doubling it in the output (#48228)."""
+        end_token_id, content_token_id = 42, 99
+        request = mock_request_with_structured_output
+        structured_req = request.structured_output_request
+        structured_req.reasoning_ended = False
+        structured_req.structured_output_key = (
+            StructuredOutputOptions.JSON,
+            '{"type": "object"}',
+        )
+        reasoner = MockReasoner(tokenizer=Mock())
+        reasoner.is_reasoning_end_streaming.side_effect = (
+            lambda input_ids, delta_ids: end_token_id in list(delta_ids)
+        )
+        structured_req.reasoner = reasoner
+        manager_with_reasoner.vllm_config.speculative_config = Mock()
+
+        new_token_ids = [end_token_id, content_token_id]
+        request.all_token_ids = request.prompt_token_ids + [
+            7,
+            end_token_id,
+            content_token_id,
+        ]
+        request.num_computed_tokens = len(request.all_token_ids)
+        request.num_output_placeholders = 0
+
+        assert manager_with_reasoner.should_advance(request, new_token_ids) is True
+        assert structured_req.reasoning_end_token_index == (
+            len(request.all_token_ids) - 2
+        )
+        assert manager_with_reasoner.trim_reasoning_for_advance(
+            request, new_token_ids
+        ) == [content_token_id]
+
     def test_should_advance_reasoning_already_ended(
         self,
         manager_with_reasoner,

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -1052,6 +1052,10 @@ class ModelConfig:
                 "awq_marlin",
                 "inc",
                 "moe_wna16",
+                # Rank-sliced EXL3 checkpoints retain a ModelOpt dispatch tag
+                # for backward compatibility, so EXL3 must inspect metadata
+                # before the ModelOpt overrides claim them.
+                "exl3",
                 # Must precede modelopt_fp4: hybrid checkpoints are
                 # modelopt-tagged NVFP4 plus a hybrid_bit_map.
                 "nvfp4_nf3_hybrid",

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -2281,9 +2281,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # --- EXL3 Trellis MoE runtime knobs (read directly by
     # model_executor/layers/quantization/exl3.py; registered here so startup
     # does not flag them as unknown). All are passthrough: consuming code
-    # applies its own context-dependent defaults (e.g. the Trellis window
-    # minimum defaults to MIN_CAPTURABLE_TRELLIS_M=1 for draft layers and 4
-    # for target layers when unset).
+    # applies its own defaults (the Trellis window minimum is 1 for both target
+    # and draft layers; an explicit value is a diagnostic override).
     "VLLM_EXL3_TRELLIS_MIN_M": lambda: os.getenv("VLLM_EXL3_TRELLIS_MIN_M"),
     "VLLM_EXL3_TRELLIS_MAX_M": lambda: os.getenv("VLLM_EXL3_TRELLIS_MAX_M"),
     "VLLM_EXL3_TRELLIS_BLOCK_M": lambda: os.getenv("VLLM_EXL3_TRELLIS_BLOCK_M"),

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -2278,6 +2278,24 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Each entry is VAR_NAME or VAR_NAME:<suffix> (suffix appended to
     # RDMA device name). Must be set together with VLLM_GPU_NIC_PCIE_MAPPING.
     "VLLM_NIC_SELECTION_VARS": lambda: os.getenv("VLLM_NIC_SELECTION_VARS", ""),
+    # --- EXL3 Trellis MoE runtime knobs (read directly by
+    # model_executor/layers/quantization/exl3.py; registered here so startup
+    # does not flag them as unknown). All are passthrough: consuming code
+    # applies its own context-dependent defaults (e.g. the Trellis window
+    # minimum defaults to MIN_CAPTURABLE_TRELLIS_M=1 for draft layers and 4
+    # for target layers when unset).
+    "VLLM_EXL3_TRELLIS_MIN_M": lambda: os.getenv("VLLM_EXL3_TRELLIS_MIN_M"),
+    "VLLM_EXL3_TRELLIS_MAX_M": lambda: os.getenv("VLLM_EXL3_TRELLIS_MAX_M"),
+    "VLLM_EXL3_TRELLIS_BLOCK_M": lambda: os.getenv("VLLM_EXL3_TRELLIS_BLOCK_M"),
+    "VLLM_EXL3_PREFILL_CHUNK": lambda: os.getenv("VLLM_EXL3_PREFILL_CHUNK"),
+    "VLLM_EXL3_PREFILL_TRELLIS": lambda: os.getenv("VLLM_EXL3_PREFILL_TRELLIS"),
+    "VLLM_EXL3_PREFILL_BLOCK_M": lambda: os.getenv("VLLM_EXL3_PREFILL_BLOCK_M"),
+    # Prebuilt exllamav3 extension location and torch-ABI compatibility shim.
+    "VLLM_EXL3_EXT_PATH": lambda: os.getenv("VLLM_EXL3_EXT_PATH"),
+    "VLLM_EXL3_ABI_SHIM": lambda: os.getenv("VLLM_EXL3_ABI_SHIM"),
+    # Calibrated MLA outer scales for the nvfp4_ds_mla KV cache.
+    "VLLM_NVFP4_MLA_SCALES_FILE": lambda: os.getenv("VLLM_NVFP4_MLA_SCALES_FILE"),
+
 }
 
 

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -2293,8 +2293,6 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Prebuilt exllamav3 extension location and torch-ABI compatibility shim.
     "VLLM_EXL3_EXT_PATH": lambda: os.getenv("VLLM_EXL3_EXT_PATH"),
     "VLLM_EXL3_ABI_SHIM": lambda: os.getenv("VLLM_EXL3_ABI_SHIM"),
-    # Calibrated MLA outer scales for the nvfp4_ds_mla KV cache.
-    "VLLM_NVFP4_MLA_SCALES_FILE": lambda: os.getenv("VLLM_NVFP4_MLA_SCALES_FILE"),
 
 }
 

--- a/vllm/model_executor/layers/fused_moe/routed_experts.py
+++ b/vllm/model_executor/layers/fused_moe/routed_experts.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import re
 from collections.abc import Callable, Iterable
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Literal, cast, overload
@@ -36,6 +37,10 @@ if TYPE_CHECKING:
 
 
 logger = init_logger(__name__)
+
+# Per-expert checkpoint names carry an explicit expert index ("experts.{i}.");
+# fused pre-fused-checkpoint entries never do (see build_expert_params_mapping).
+_PER_EXPERT_IDX_RE = re.compile(r"experts\.\d+\.")
 
 
 class FusedMoeWeightScaleSupported(Enum):
@@ -943,14 +948,24 @@ class RoutedExperts(PluggableLayer):
         unpadded_hidden = self.moe_config.hidden_dim_unpadded
         for expert_name, loaded_weight in weights:
             qual_name = f"{self.layer_name}.{expert_name}"
-            # Fused expert weights can be identified by their 3D tensors
-            is_fused = loaded_weight.dim() == 3
+            # Fused expert weights are 3D tensors matched against a *fused*
+            # mapping entry. Rank alone is not decisive: per-expert tensors of
+            # some quantized formats (e.g. EXL3 trellis [K/16, N/16, 16*bpw])
+            # are also rank-3 and must not be routed down the fused
+            # transpose/chunk path. Fused entries are exactly those whose
+            # weight_name carries no per-expert index.
+            is_fused_rank = loaded_weight.dim() == 3
+            is_fused = False
             matched = False
             for param_name, weight_name, expert_id, shard_id in expert_mapping:
                 if weight_name not in qual_name:
                     if matched and is_fused:
                         break
                     continue
+                is_fused = (
+                    is_fused_rank
+                    and _PER_EXPERT_IDX_RE.search(weight_name) is None
+                )
                 matched = True
                 weight_name = qual_name.replace(weight_name, param_name)
                 param_name = weight_name.removeprefix(f"{self.layer_name}.")

--- a/vllm/model_executor/layers/quantization/__init__.py
+++ b/vllm/model_executor/layers/quantization/__init__.py
@@ -14,6 +14,7 @@ QuantizationMethods = Literal[
     "auto_awq",
     "fp8",
     "fbgemm_fp8",
+    "exl3",
     "fp_quant",
     "modelopt",
     "modelopt_fp4",
@@ -123,6 +124,7 @@ def get_quantization_config(quantization: str) -> type[QuantizationConfig]:
         CompressedTensorsConfig,
     )
     from .experts_int8 import ExpertsInt8Config
+    from .exl3 import Exl3Config
     from .fbgemm_fp8 import FBGEMMFp8Config
     from .fp8 import Fp8Config
     from .fp_quant import FPQuantConfig
@@ -146,6 +148,7 @@ def get_quantization_config(quantization: str) -> type[QuantizationConfig]:
         "auto_awq": AutoAWQConfig,
         "fp8": Fp8Config,
         "fbgemm_fp8": FBGEMMFp8Config,
+        "exl3": Exl3Config,
         "fp_quant": FPQuantConfig,
         "modelopt": ModelOptFp8Config,
         "modelopt_fp4": ModelOptNvFp4Config,

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -1,0 +1,1090 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""EXL3 (ExLlamaV3 trellis) quantization support.
+
+This is deliberately the correctness backend.  Every logical checkpoint
+matrix is dispatched independently through ``exllamav3_ext.exl3_gemm``.  In
+particular, vLLM's packed QKV and gate/up modules are *not* treated as one EXL3
+matrix: each source matrix owns its own Hadamard vectors and codebook marker.
+
+The extension is imported lazily on the first CUDA execution.  Importing this
+module, parsing checkpoint metadata, or compiling it with ``py_compile`` does
+not load the extension or initialize CUDA.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import importlib
+import os
+import sys
+from typing import TYPE_CHECKING, Any
+
+import torch
+from transformers import PretrainedConfig
+
+from vllm.distributed import (
+    get_tensor_model_parallel_rank,
+    get_tensor_model_parallel_world_size,
+)
+from vllm.config import get_current_vllm_config_or_none
+from vllm.logger import init_logger
+from vllm.model_executor.layers.fused_moe import (
+    FusedMoEMethodBase,
+    FusedMoEQuantConfig,
+    MoEActivation,
+    RoutedExperts,
+)
+from vllm.model_executor.layers.linear import (
+    LinearBase,
+    LinearMethodBase,
+    QKVParallelLinear,
+    ReplicatedLinear,
+    UnquantizedLinearMethod,
+)
+from vllm.model_executor.layers.quantization.base_config import (
+    QuantizationConfig,
+    QuantizeMethodBase,
+)
+from vllm.model_executor.parameter import BasevLLMParameter
+from vllm.transformers_utils.repo_utils import get_hf_file_to_dict
+
+if TYPE_CHECKING:
+    from vllm.model_executor.layers.fused_moe.runner.shared_experts import (
+        SharedExperts,
+    )
+    from vllm.model_executor.models.utils import WeightsMapper
+
+logger = init_logger(__name__)
+
+_MCG_SENTINEL = 0xCBAC1FED
+_MUL1_SENTINEL = 0x83DCD12D
+_HADAMARD_BLOCK = 128
+_EXL3_EXT: Any | None = None
+
+ShardId = str | int | tuple[int, ...] | None
+
+
+def _load_exl3_ext() -> Any:
+    """Load the existing ExLlamaV3 extension only from an actual CUDA call."""
+
+    global _EXL3_EXT
+    if _EXL3_EXT is not None:
+        return _EXL3_EXT
+
+    shim = os.environ.get("VLLM_EXL3_ABI_SHIM")
+    if shim:
+        ctypes.CDLL(shim, mode=ctypes.RTLD_GLOBAL)
+
+    ext_path = os.environ.get("VLLM_EXL3_EXT_PATH")
+    if ext_path:
+        search_dir = ext_path if os.path.isdir(ext_path) else os.path.dirname(ext_path)
+        if search_dir and search_dir not in sys.path:
+            sys.path.insert(0, search_dir)
+
+    try:
+        ext = importlib.import_module("exllamav3_ext")
+    except Exception as exc:
+        hint = (
+            "Set VLLM_EXL3_EXT_PATH to the directory containing "
+            "exllamav3_ext*.so (and VLLM_EXL3_ABI_SHIM when the local "
+            "PyTorch ABI shim is required)."
+        )
+        raise RuntimeError(f"Unable to import exllamav3_ext. {hint}") from exc
+
+    if not hasattr(ext, "exl3_gemm"):
+        raise RuntimeError(
+            "The imported exllamav3_ext does not export exl3_gemm; rebuild the "
+            "track_a_retile extension used by this overlay."
+        )
+    _EXL3_EXT = ext
+    return ext
+
+
+@torch.library.custom_op(
+    "vllm::exl3_gemm",
+    mutates_args=(),
+    device_types="cuda",
+)
+def _exl3_gemm(
+    x: torch.Tensor,
+    trellis: torch.Tensor,
+    suh: torch.Tensor,
+    svh: torch.Tensor,
+    mcg: bool,
+    mul1: bool,
+) -> torch.Tensor:
+    """Opaque torch op around the bit-faithful ExLlamaV3 dense call."""
+
+    ext = _load_exl3_ext()
+    output = torch.empty(
+        (x.shape[0], trellis.shape[1] * 16),
+        dtype=torch.float16,
+        device=x.device,
+    )
+    x_had = torch.empty_like(x)
+    ext.exl3_gemm(
+        x,
+        trellis,
+        output,
+        suh,
+        x_had,
+        svh,
+        -1,
+        mcg,
+        mul1,
+        0,
+    )
+    return output
+
+
+@_exl3_gemm.register_fake
+def _exl3_gemm_fake(
+    x: torch.Tensor,
+    trellis: torch.Tensor,
+    suh: torch.Tensor,
+    svh: torch.Tensor,
+    mcg: bool,
+    mul1: bool,
+) -> torch.Tensor:
+    del suh, svh, mcg, mul1
+    return torch.empty(
+        (x.shape[0], trellis.shape[1] * 16),
+        dtype=torch.float16,
+        device=x.device,
+    )
+
+
+class Exl3Config(QuantizationConfig):
+    """Configuration for modern and legacy EXL3 trellis checkpoints."""
+
+    def __init__(
+        self,
+        bits: float | None = None,
+        head_bits: float | None = None,
+        codebook: str | None = None,
+        version: str | None = None,
+        tensor_storage: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__()
+        self.bits = bits
+        self.head_bits = head_bits
+        self.codebook = codebook
+        self.version = version
+        self.tensor_storage = tensor_storage or {}
+        self._eager_checked = False
+
+    def get_name(self) -> str:
+        return "exl3"
+
+    def get_supported_act_dtypes(self) -> list[torch.dtype]:
+        # The kernel boundary is always fp16.  BF16 model activations are cast
+        # in apply() and converted back after the fp16 bias addition.
+        return [torch.float16, torch.bfloat16]
+
+    @classmethod
+    def get_min_capability(cls) -> int:
+        return 80
+
+    @staticmethod
+    def get_config_filenames() -> list[str]:
+        return ["quantization_config.json"]
+
+    @classmethod
+    def from_config(cls, config: dict[str, Any]) -> "Exl3Config":
+        return cls(
+            bits=config.get("bits"),
+            head_bits=config.get("head_bits"),
+            codebook=config.get("codebook"),
+            version=config.get("version"),
+            tensor_storage=config.get("tensor_storage"),
+        )
+
+    def maybe_update_config(
+        self,
+        model_name: str,
+        hf_config: PretrainedConfig | None = None,
+        revision: str | None = None,
+    ) -> None:
+        # vLLM returns the summary embedded in config.json without consulting
+        # get_config_filenames().  Hydrate the per-module records explicitly.
+        if not self.tensor_storage:
+            resolved_revision = revision
+            if resolved_revision is None and hf_config is not None:
+                resolved_revision = getattr(hf_config, "_commit_hash", None)
+            config = get_hf_file_to_dict(
+                "quantization_config.json",
+                model_name,
+                revision=resolved_revision,
+            )
+            if not config or not config.get("tensor_storage"):
+                raise ValueError(
+                    "EXL3 requires quantization_config.json with a non-empty "
+                    "tensor_storage map. For branch-indexed Hugging Face repos, "
+                    "download/serve an actual bpw revision rather than main."
+                )
+            self.bits = config.get("bits", self.bits)
+            self.head_bits = config.get("head_bits", self.head_bits)
+            self.codebook = config.get("codebook", self.codebook)
+            self.version = config.get("version", self.version)
+            self.tensor_storage = config["tensor_storage"]
+
+        self._validate_storage_metadata()
+        self._force_independent_lm_head(hf_config)
+
+    def apply_vllm_mapper(self, hf_to_vllm_mapper: "WeightsMapper") -> None:
+        # Keep both spellings: loader prefixes use vLLM names, while packed
+        # source-matrix discovery intentionally refers to the unstacked HF name.
+        mapped = hf_to_vllm_mapper.apply_dict(self.tensor_storage)
+        self.tensor_storage = {**self.tensor_storage, **mapped}
+
+    def _validate_storage_metadata(self) -> None:
+        bad: list[str] = []
+        exl3_count = 0
+        for prefix, entry in self.tensor_storage.items():
+            if entry.get("quant_format") != "exl3":
+                continue
+            exl3_count += 1
+            stored = entry.get("stored_tensors", {})
+            suffixes = {name.rsplit(".", 1)[-1] for name in stored}
+            required = {"trellis"}
+            if not ({"suh", "su"} & suffixes):
+                required.add("suh|su")
+            if not ({"svh", "sv"} & suffixes):
+                required.add("svh|sv")
+            missing = [name for name in required if name not in suffixes]
+            if missing:
+                bad.append(f"{prefix}: missing {','.join(sorted(missing))}")
+            if {"mcg", "mul1"} <= suffixes:
+                bad.append(f"{prefix}: both mcg and mul1 are present")
+        if not exl3_count:
+            raise ValueError("quantization_config.json has no EXL3 tensor records")
+        if bad:
+            raise ValueError("Invalid EXL3 tensor metadata: " + "; ".join(bad[:16]))
+
+    def _force_independent_lm_head(self, hf_config: PretrainedConfig | None) -> None:
+        if hf_config is None or not self.has_quantized_lm_head():
+            return
+        configs: list[Any] = [hf_config]
+        try:
+            text_config = hf_config.get_text_config()
+        except (AttributeError, TypeError):
+            text_config = None
+        if text_config is not None and text_config is not hf_config:
+            configs.append(text_config)
+        changed = False
+        for config in configs:
+            if getattr(config, "tie_word_embeddings", False):
+                config.tie_word_embeddings = False
+                changed = True
+        if changed:
+            logger.warning_once(
+                "EXL3 metadata contains an independently quantized lm_head; "
+                "overriding tie_word_embeddings so vLLM instantiates it."
+            )
+
+    def _require_enforce_eager(self) -> None:
+        # exllamav3_ext's exl3_gemm autotunes with timing launches on the first
+        # call per (m-bucket, k, n, K) shape hash; under CUDA-graph capture
+        # those launches fault, and m-bucketing means a warmup pass cannot
+        # reliably cover every bucket. Fail fast at build time instead of
+        # faulting mid-capture.
+        if self._eager_checked:
+            return
+        self._eager_checked = True
+        vllm_config = get_current_vllm_config_or_none()
+        if vllm_config is None:
+            return
+        if not vllm_config.model_config.enforce_eager:
+            raise ValueError(
+                "The EXL3 quantization backend requires eager execution: "
+                "pass --enforce-eager (enforce_eager=True). exl3_gemm "
+                "autotunes with timing launches on first use per shape "
+                "bucket, which is incompatible with CUDA-graph capture."
+            )
+
+    def get_quant_method(
+        self, layer: torch.nn.Module, prefix: str
+    ) -> QuantizeMethodBase | None:
+        self._require_enforce_eager()
+        is_lm_head = layer.__class__.__name__ == "ParallelLMHead"
+        if is_lm_head and not prefix:
+            prefix = "lm_head"
+        if isinstance(layer, LinearBase) or is_lm_head:
+            if not self._linear_prefix_is_exl3(prefix):
+                return UnquantizedLinearMethod()
+            return Exl3LinearMethod(self)
+        if isinstance(layer, RoutedExperts):
+            if not self._moe_prefix_is_exl3(prefix):
+                return None
+            return Exl3MoEMethod(self, layer.moe_config)
+        return None
+
+    def _storage_entry(self, prefix: str) -> dict[str, Any] | None:
+        candidates = [prefix]
+        if prefix.startswith("model."):
+            candidates.append(prefix.removeprefix("model."))
+        else:
+            candidates.append(f"model.{prefix}")
+
+        # Multimodal wrappers often add an extra `.model` or
+        # `.language_model` segment relative to vLLM's text-only module.
+        parts = prefix.split(".")
+        for removable in ("model", "language_model"):
+            for idx in range(1, len(parts) - 1):
+                if parts[idx] != removable:
+                    continue
+                collapsed = ".".join(parts[:idx] + parts[idx + 1 :])
+                candidates.extend((collapsed, f"model.{collapsed}"))
+                if collapsed.startswith("model."):
+                    candidates.append(collapsed.removeprefix("model."))
+
+        for candidate in dict.fromkeys(candidates):
+            entry = self.tensor_storage.get(candidate)
+            if entry is not None:
+                return entry
+        return None
+
+    def _is_exl3_prefix(self, prefix: str) -> bool:
+        entry = self._storage_entry(prefix)
+        return entry is not None and entry.get("quant_format") == "exl3"
+
+    def _linear_prefix_is_exl3(self, prefix: str) -> bool:
+        if self._is_exl3_prefix(prefix):
+            return True
+        leaf = prefix.rsplit(".", 1)[-1]
+        source_leaves = self.packed_modules_mapping.get(leaf)
+        if not source_leaves:
+            return False
+        base = prefix.rsplit(".", 1)[0] if "." in prefix else ""
+        return all(
+            self._is_exl3_prefix(f"{base}.{source}" if base else source)
+            for source in source_leaves
+        )
+
+    def _moe_prefix_is_exl3(self, prefix: str) -> bool:
+        expert_prefixes = (f"{prefix}.0", f"{prefix}.experts.0")
+        return any(
+            all(
+                self._is_exl3_prefix(f"{expert}.{projection}")
+                for projection in ("gate_proj", "up_proj", "down_proj")
+            )
+            for expert in expert_prefixes
+        )
+
+    def codebook_for_prefix(self, prefix: str) -> str | None:
+        entry = self._storage_entry(prefix)
+        if entry is None:
+            return None
+        suffixes = {name.rsplit(".", 1)[-1] for name in entry.get("stored_tensors", {})}
+        if "mcg" in suffixes:
+            return "mcg"
+        if "mul1" in suffixes:
+            return "mul1"
+        return None
+
+    def has_quantized_lm_head(self) -> bool:
+        return self._is_exl3_prefix("lm_head")
+
+
+class Exl3Parameter(BasevLLMParameter):
+    """Zero-sized parameter holding independently shaped EXL3 components."""
+
+    def __new__(cls, *, weight_loader):
+        data = torch.empty(0, dtype=torch.uint8)
+        return super().__new__(cls, data=data, weight_loader=weight_loader)
+
+    def __init__(self, *, weight_loader):
+        self.exl3_tensors: dict[ShardId, torch.Tensor] = {}
+        super().__init__(data=self.data, weight_loader=weight_loader)
+
+    def load_exl3_weight(
+        self,
+        loaded_weight: torch.Tensor,
+        shard_id: ShardId = None,
+    ) -> None:
+        self.exl3_tensors[shard_id] = loaded_weight.contiguous()
+
+
+def _exl3_weight_loader(
+    param: Exl3Parameter,
+    loaded_weight: torch.Tensor,
+    loaded_shard_id: ShardId = None,
+) -> None:
+    param.load_exl3_weight(loaded_weight, loaded_shard_id)
+
+
+class Exl3LinearMethod(LinearMethodBase):
+    def __init__(self, quant_config: Exl3Config) -> None:
+        self.quant_config = quant_config
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: list[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ) -> None:
+        del params_dtype, extra_weight_attrs
+        if layer.__class__.__name__ == "ParallelLMHead":
+            org = getattr(layer, "org_vocab_size", None)
+            total = getattr(layer, "num_embeddings", None)
+            if org is not None and total is not None and org != total:
+                raise NotImplementedError(
+                    "EXL3 lm_head with added vocabulary is unsupported: the "
+                    f"trellis tensor covers the original {org} rows but the "
+                    f"layer allocates {total}; TP slicing would silently "
+                    "misalign. Strip --lora-extra-vocab-size / added tokens "
+                    "or leave lm_head unquantized."
+                )
+        # Respect the layer's effective topology. disable_tp linears set their
+        # own tp_size=1, while ReplicatedLinear carries full weights even when
+        # the process-wide tensor group is larger than one.
+        if isinstance(layer, ReplicatedLinear):
+            layer.exl3_tp_rank = 0
+            layer.exl3_tp_size = 1
+        else:
+            layer.exl3_tp_rank = getattr(
+                layer, "tp_rank", get_tensor_model_parallel_rank()
+            )
+            layer.exl3_tp_size = getattr(
+                layer, "tp_size", get_tensor_model_parallel_world_size()
+            )
+        layer.exl3_input_size = input_size
+        layer.exl3_input_size_per_partition = input_size_per_partition
+        layer.exl3_output_size = output_size
+        layer.exl3_output_partition_sizes = output_partition_sizes
+        layer.exl3_shard_ids = self._shard_ids_for_layer(layer, output_partition_sizes)
+        layer.exl3_parallel_mode = (
+            "row" if input_size_per_partition != input_size else "column"
+        )
+        source_prefixes = self._source_prefixes_for_layer(layer, layer.exl3_shard_ids)
+        layer.exl3_expected_codebooks = {
+            shard_id: self.quant_config.codebook_for_prefix(source_prefix)
+            for shard_id, source_prefix in zip(
+                layer.exl3_shard_ids, source_prefixes, strict=True
+            )
+        }
+
+        # su/sv are legacy packed sign bitfields.  Modern checkpoints load
+        # suh/svh directly.
+        for name in ("suh", "svh", "su", "sv", "trellis", "mcg", "mul1"):
+            layer.register_parameter(
+                name,
+                Exl3Parameter(weight_loader=_exl3_weight_loader),
+            )
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        self._materialize_legacy_hadamard(layer)
+        missing: list[str] = []
+        for attr in ("suh", "svh", "trellis"):
+            param = getattr(layer, attr)
+            for shard_id in layer.exl3_shard_ids:
+                if shard_id not in param.exl3_tensors:
+                    missing.append(f"{attr}[{shard_id!r}]")
+        for shard_id in layer.exl3_shard_ids:
+            expected = layer.exl3_expected_codebooks[shard_id]
+            has_mcg = shard_id in layer.mcg.exl3_tensors
+            has_mul1 = shard_id in layer.mul1.exl3_tensors
+            if has_mcg and has_mul1:
+                missing.append(f"codebook[{shard_id!r}]=both mcg and mul1")
+            elif expected == "mcg" and not has_mcg:
+                missing.append(f"mcg[{shard_id!r}]")
+            elif expected == "mul1" and not has_mul1:
+                missing.append(f"mul1[{shard_id!r}]")
+            elif expected is None and (has_mcg or has_mul1):
+                missing.append(f"unexpected codebook[{shard_id!r}]")
+        if missing:
+            prefix = getattr(layer, "prefix", layer.__class__.__name__)
+            raise ValueError(
+                f"Missing or inconsistent EXL3 tensors for {prefix}: "
+                + ", ".join(missing)
+            )
+
+        self._validate_loaded_tensors(layer)
+        self._shard_tensors_for_tensor_parallel(layer)
+        self._validate_loaded_tensors(layer)
+
+        # device_loading_context has moved the zero-sized registered parameter
+        # to the model target device.  Its device is the safest destination for
+        # the tensors kept in the side dictionaries.
+        device = layer.trellis.device
+        for attr in ("suh", "svh", "trellis", "mcg", "mul1"):
+            param = getattr(layer, attr)
+            for shard_id, tensor in list(param.exl3_tensors.items()):
+                param.exl3_tensors[shard_id] = tensor.to(
+                    device=device, non_blocking=True
+                ).contiguous()
+
+    def apply(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        original_shape = x.shape[:-1]
+        original_dtype = x.dtype
+        x_2d = x.reshape(-1, x.shape[-1]).to(torch.float16).contiguous()
+        outputs = [
+            self._apply_one(layer, x_2d, shard_id) for shard_id in layer.exl3_shard_ids
+        ]
+        output = outputs[0] if len(outputs) == 1 else torch.cat(outputs, dim=-1)
+        if bias is not None:
+            output = output + bias.to(dtype=output.dtype)
+        output = output.reshape(*original_shape, output.shape[-1])
+        return output if output.dtype == original_dtype else output.to(original_dtype)
+
+    @staticmethod
+    def _unpack_signs(bitfield: torch.Tensor) -> torch.Tensor:
+        words = bitfield.contiguous().view(torch.uint16).to(torch.int32)
+        masks = 1 << torch.arange(16, device=words.device, dtype=torch.int32)
+        negative = (words.unsqueeze(-1) & masks) != 0
+        return (
+            torch.where(
+                negative,
+                torch.tensor(-1.0, device=words.device, dtype=torch.float16),
+                torch.tensor(1.0, device=words.device, dtype=torch.float16),
+            )
+            .flatten()
+            .contiguous()
+        )
+
+    @classmethod
+    def _materialize_legacy_hadamard(cls, layer: torch.nn.Module) -> None:
+        for packed_name, half_name in (("su", "suh"), ("sv", "svh")):
+            packed = getattr(layer, packed_name).exl3_tensors
+            half = getattr(layer, half_name).exl3_tensors
+            for shard_id in layer.exl3_shard_ids:
+                if shard_id not in half and shard_id in packed:
+                    half[shard_id] = cls._unpack_signs(packed[shard_id])
+
+    @staticmethod
+    def _validate_marker(tensor: torch.Tensor, expected: int, name: str) -> None:
+        if tensor.dtype != torch.int32 or tensor.numel() != 1:
+            raise ValueError(f"EXL3 {name} must be a scalar int32 sentinel")
+        value = int(tensor.reshape(()).item()) & 0xFFFFFFFF
+        if value != expected:
+            raise ValueError(
+                f"Invalid EXL3 {name} sentinel 0x{value:08x}; expected 0x{expected:08x}"
+            )
+
+    @classmethod
+    def _validate_loaded_tensors(cls, layer: torch.nn.Module) -> None:
+        for shard_id in layer.exl3_shard_ids:
+            trellis = layer.trellis.exl3_tensors[shard_id]
+            suh = layer.suh.exl3_tensors[shard_id]
+            svh = layer.svh.exl3_tensors[shard_id]
+            if trellis.dtype != torch.int16 or trellis.ndim != 3:
+                raise ValueError("EXL3 trellis must be rank-3 int16")
+            if trellis.shape[2] % 16 or not 1 <= trellis.shape[2] // 16 <= 8:
+                raise ValueError(
+                    f"Invalid EXL3 trellis bit width {trellis.shape[2]} / 16"
+                )
+            if suh.dtype != torch.float16 or suh.ndim != 1:
+                raise ValueError("EXL3 suh must be rank-1 float16")
+            if svh.dtype != torch.float16 or svh.ndim != 1:
+                raise ValueError("EXL3 svh must be rank-1 float16")
+            k = trellis.shape[0] * 16
+            n = trellis.shape[1] * 16
+            if suh.numel() != k or svh.numel() != n:
+                raise ValueError(
+                    "EXL3 dimensions disagree: "
+                    f"trellis={tuple(trellis.shape)}, suh={suh.numel()}, "
+                    f"svh={svh.numel()}"
+                )
+            if k % _HADAMARD_BLOCK or n % _HADAMARD_BLOCK:
+                raise ValueError(
+                    f"EXL3 kernel dimensions must be {_HADAMARD_BLOCK}-aligned, "
+                    f"got K={k}, N={n}"
+                )
+            if shard_id in layer.mcg.exl3_tensors:
+                cls._validate_marker(
+                    layer.mcg.exl3_tensors[shard_id], _MCG_SENTINEL, "mcg"
+                )
+            if shard_id in layer.mul1.exl3_tensors:
+                cls._validate_marker(
+                    layer.mul1.exl3_tensors[shard_id], _MUL1_SENTINEL, "mul1"
+                )
+
+    @staticmethod
+    def _slice_exl3_tensor(
+        tensor: torch.Tensor,
+        *,
+        dim: int,
+        start: int,
+        size: int,
+    ) -> torch.Tensor:
+        if start % _HADAMARD_BLOCK or size % _HADAMARD_BLOCK:
+            axis = "output" if dim == 1 else "input"
+            raise ValueError(
+                f"EXL3 TP {axis} slice must be {_HADAMARD_BLOCK}-aligned, "
+                f"got start={start}, size={size}"
+            )
+        return tensor.narrow(dim, start // 16, size // 16).contiguous()
+
+    @staticmethod
+    def _output_shard_size(layer: torch.nn.Module, shard_id: ShardId) -> int:
+        if shard_id is None:
+            return layer.exl3_output_partition_sizes[0]
+        if isinstance(shard_id, str) and shard_id in ("q", "k", "v"):
+            return layer.exl3_output_partition_sizes[{"q": 0, "k": 1, "v": 2}[shard_id]]
+        if isinstance(shard_id, tuple):
+            return sum(layer.exl3_output_partition_sizes[idx] for idx in shard_id)
+        if isinstance(shard_id, int):
+            return layer.exl3_output_partition_sizes[shard_id]
+        return layer.exl3_output_partition_sizes[layer.exl3_shard_ids.index(shard_id)]
+
+    @staticmethod
+    def _qkv_output_start(
+        layer: torch.nn.Module, shard_id: ShardId, shard_size: int
+    ) -> int:
+        if shard_id in ("k", "v"):
+            shard_rank = layer.exl3_tp_rank // layer.num_kv_head_replicas
+        else:
+            shard_rank = layer.exl3_tp_rank
+        return shard_rank * shard_size
+
+    @classmethod
+    def _shard_tensors_for_tensor_parallel(cls, layer: torch.nn.Module) -> None:
+        if layer.exl3_tp_size == 1:
+            return
+        if layer.exl3_parallel_mode == "row":
+            start = layer.exl3_tp_rank * layer.exl3_input_size_per_partition
+            size = layer.exl3_input_size_per_partition
+            for shard_id in layer.exl3_shard_ids:
+                layer.suh.exl3_tensors[shard_id] = (
+                    layer.suh.exl3_tensors[shard_id].narrow(0, start, size).contiguous()
+                )
+                layer.trellis.exl3_tensors[shard_id] = cls._slice_exl3_tensor(
+                    layer.trellis.exl3_tensors[shard_id],
+                    dim=0,
+                    start=start,
+                    size=size,
+                )
+            return
+
+        already_sharded = cls._expand_tuple_output_shards(layer)
+        for shard_id in layer.exl3_shard_ids:
+            if shard_id in already_sharded:
+                continue
+            size = cls._output_shard_size(layer, shard_id)
+            start = cls._qkv_output_start(layer, shard_id, size)
+            layer.svh.exl3_tensors[shard_id] = (
+                layer.svh.exl3_tensors[shard_id].narrow(0, start, size).contiguous()
+            )
+            layer.trellis.exl3_tensors[shard_id] = cls._slice_exl3_tensor(
+                layer.trellis.exl3_tensors[shard_id],
+                dim=1,
+                start=start,
+                size=size,
+            )
+
+    @classmethod
+    def _expand_tuple_output_shards(cls, layer: torch.nn.Module) -> set[int]:
+        tuples = [sid for sid in layer.exl3_shard_ids if isinstance(sid, tuple)]
+        if not tuples:
+            return set()
+
+        expanded_ids: list[ShardId] = []
+        component_ids: set[int] = set()
+        for shard_id in layer.exl3_shard_ids:
+            if isinstance(shard_id, tuple):
+                expanded_ids.extend(shard_id)
+                component_ids.update(shard_id)
+            else:
+                expanded_ids.append(shard_id)
+
+        for tuple_id in tuples:
+            full_offsets: dict[int, int] = {}
+            offset = 0
+            for idx in tuple_id:
+                full_offsets[idx] = offset
+                offset += layer.exl3_output_partition_sizes[idx] * layer.exl3_tp_size
+            for idx in tuple_id:
+                size = layer.exl3_output_partition_sizes[idx]
+                start = full_offsets[idx] + layer.exl3_tp_rank * size
+                layer.suh.exl3_tensors[idx] = layer.suh.exl3_tensors[tuple_id]
+                layer.svh.exl3_tensors[idx] = (
+                    layer.svh.exl3_tensors[tuple_id].narrow(0, start, size).contiguous()
+                )
+                layer.trellis.exl3_tensors[idx] = cls._slice_exl3_tensor(
+                    layer.trellis.exl3_tensors[tuple_id],
+                    dim=1,
+                    start=start,
+                    size=size,
+                )
+                layer.exl3_expected_codebooks[idx] = layer.exl3_expected_codebooks[
+                    tuple_id
+                ]
+                for marker in ("mcg", "mul1"):
+                    tensors = getattr(layer, marker).exl3_tensors
+                    if tuple_id in tensors:
+                        tensors[idx] = tensors[tuple_id]
+            for attr in ("suh", "svh", "trellis", "mcg", "mul1"):
+                getattr(layer, attr).exl3_tensors.pop(tuple_id, None)
+            layer.exl3_expected_codebooks.pop(tuple_id, None)
+
+        layer.exl3_shard_ids = expanded_ids
+        return component_ids
+
+    @staticmethod
+    def _shard_ids_for_layer(
+        layer: torch.nn.Module,
+        output_partition_sizes: list[int],
+    ) -> list[ShardId]:
+        if len(output_partition_sizes) == 1:
+            return [None]
+        prefix = getattr(layer, "prefix", "")
+        if isinstance(layer, QKVParallelLinear) and len(output_partition_sizes) == 3:
+            return ["q", "k", "v"]
+        if prefix.endswith("in_proj_qkvz"):
+            return [(0, 1, 2), 3]
+        return list(range(len(output_partition_sizes)))
+
+    def _source_prefixes_for_layer(
+        self, layer: torch.nn.Module, shard_ids: list[ShardId]
+    ) -> list[str]:
+        prefix = getattr(layer, "prefix", "")
+        if len(shard_ids) == 1:
+            return [prefix or "lm_head"]
+        leaf = prefix.rsplit(".", 1)[-1]
+        base = prefix.rsplit(".", 1)[0] if "." in prefix else ""
+        sources = self.quant_config.packed_modules_mapping.get(leaf)
+        if sources and len(sources) == len(shard_ids):
+            return [f"{base}.{source}" if base else source for source in sources]
+        raise ValueError(
+            f"EXL3 does not know the source matrices for packed layer {prefix}; "
+            "add it to the model's packed_modules_mapping."
+        )
+
+    @staticmethod
+    def _apply_one(
+        layer: torch.nn.Module, x: torch.Tensor, shard_id: ShardId
+    ) -> torch.Tensor:
+        trellis = layer.trellis.exl3_tensors[shard_id]
+        packed_k = trellis.shape[0] * 16
+        if x.shape[-1] > packed_k:
+            raise ValueError(
+                f"EXL3 input width {x.shape[-1]} exceeds packed K={packed_k}"
+            )
+        if x.shape[-1] < packed_k:
+            x = torch.nn.functional.pad(x, (0, packed_k - x.shape[-1]))
+        output = _exl3_gemm(
+            x,
+            trellis,
+            layer.suh.exl3_tensors[shard_id],
+            layer.svh.exl3_tensors[shard_id],
+            shard_id in layer.mcg.exl3_tensors,
+            shard_id in layer.mul1.exl3_tensors,
+        )
+        logical_n = Exl3LinearMethod._output_shard_size(layer, shard_id)
+        if output.shape[-1] < logical_n:
+            raise ValueError(
+                f"EXL3 packed N={output.shape[-1]} is below logical N={logical_n}"
+            )
+        return output[..., :logical_n]
+
+
+class Exl3MoEParameter(BasevLLMParameter):
+    """Zero-sized parameter holding EXL3 tensors by expert and projection."""
+
+    def __new__(cls, *, weight_loader):
+        data = torch.empty(0, dtype=torch.uint8)
+        return super().__new__(cls, data=data, weight_loader=weight_loader)
+
+    def __init__(self, *, weight_loader):
+        self.exl3_tensors: dict[tuple[int, str], torch.Tensor] = {}
+        super().__init__(data=self.data, weight_loader=weight_loader)
+
+
+def _exl3_moe_weight_loader(
+    param: Exl3MoEParameter,
+    loaded_weight: torch.Tensor,
+    weight_name: str,
+    shard_id: str,
+    expert_id: int,
+    return_success: bool = False,
+) -> bool | None:
+    del weight_name
+    param.exl3_tensors[(expert_id, shard_id)] = loaded_weight.contiguous()
+    return True if return_success else None
+
+
+# Model loaders (e.g. llama4-style paths) check this attribute before routing
+# expert tensors through a param's weight_loader with MoE kwargs.
+_exl3_moe_weight_loader.supports_moe_loading = True  # type: ignore[attr-defined]
+
+
+class Exl3MoEMethod(FusedMoEMethodBase):
+    """Correctness MoE path: route, then use three dense EXL3 GEMMs/expert."""
+
+    def __init__(self, quant_config: Exl3Config, moe) -> None:
+        super().__init__(moe)
+        self.quant_config = quant_config
+
+    def create_weights(
+        self,
+        layer: RoutedExperts,
+        num_experts: int,
+        hidden_size: int,
+        intermediate_size_per_partition: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ) -> None:
+        del num_experts, params_dtype, extra_weight_attrs
+        if self.moe.moe_parallel_config.use_ep:
+            raise NotImplementedError(
+                "EXL3 correctness MoE currently supports TP but not expert parallelism"
+            )
+        if self.moe.has_bias:
+            raise NotImplementedError(
+                "EXL3 correctness MoE does not yet support expert biases"
+            )
+        layer.exl3_tp_rank = self.moe.moe_parallel_config.tp_rank
+        layer.exl3_tp_size = self.moe.moe_parallel_config.tp_size
+        layer.exl3_hidden_size = hidden_size
+        layer.exl3_intermediate_size_per_partition = intermediate_size_per_partition
+        for prefix in ("w13", "w2"):
+            for suffix in ("suh", "svh", "trellis", "mcg", "mul1"):
+                layer.register_parameter(
+                    f"{prefix}_{suffix}",
+                    Exl3MoEParameter(weight_loader=_exl3_moe_weight_loader),
+                )
+
+    def process_weights_after_loading(self, layer: RoutedExperts) -> None:
+        required = {"w13": ("w1", "w3"), "w2": ("w2",)}
+        missing: list[str] = []
+        for prefix, shard_ids in required.items():
+            for attr in ("suh", "svh", "trellis"):
+                tensors = getattr(layer, f"{prefix}_{attr}").exl3_tensors
+                for expert_id in range(layer.local_num_experts):
+                    for shard_id in shard_ids:
+                        if (expert_id, shard_id) not in tensors:
+                            missing.append(f"{prefix}_{attr}[{expert_id},{shard_id}]")
+        if missing:
+            raise ValueError(
+                f"Missing EXL3 MoE tensors for {layer.layer_name}: "
+                + ", ".join(missing[:32])
+                + (" ..." if len(missing) > 32 else "")
+            )
+        self._validate_codebooks(layer)
+        self._shard_tensors_for_tensor_parallel(layer)
+        device = layer.w13_trellis.device
+        for prefix in ("w13", "w2"):
+            for attr in ("suh", "svh", "trellis", "mcg", "mul1"):
+                param = getattr(layer, f"{prefix}_{attr}")
+                for key, tensor in list(param.exl3_tensors.items()):
+                    param.exl3_tensors[key] = tensor.to(
+                        device=device, non_blocking=True
+                    ).contiguous()
+        self._validate_moe_shapes(layer)
+
+    def _validate_codebooks(self, layer: RoutedExperts) -> None:
+        projections = {
+            "w1": layer.ckpt_gate_proj_name,
+            "w2": layer.ckpt_down_proj_name,
+            "w3": layer.ckpt_up_proj_name,
+        }
+        for expert_id in range(layer.local_num_experts):
+            for shard_id, projection in projections.items():
+                prefix = f"{layer.layer_name}.{expert_id}.{projection}"
+                expected = self.quant_config.codebook_for_prefix(prefix)
+                group = "w2" if shard_id == "w2" else "w13"
+                key = (expert_id, shard_id)
+                has_mcg = key in getattr(layer, f"{group}_mcg").exl3_tensors
+                has_mul1 = key in getattr(layer, f"{group}_mul1").exl3_tensors
+                if has_mcg and has_mul1:
+                    raise ValueError(f"EXL3 MoE {prefix} has both codebooks")
+                if expected == "mcg" and not has_mcg:
+                    raise ValueError(f"EXL3 MoE {prefix} is missing mcg")
+                if expected == "mul1" and not has_mul1:
+                    raise ValueError(f"EXL3 MoE {prefix} is missing mul1")
+                if expected is None and (has_mcg or has_mul1):
+                    raise ValueError(
+                        f"EXL3 MoE {prefix} has an unexpected codebook marker"
+                    )
+                if has_mcg:
+                    Exl3LinearMethod._validate_marker(
+                        getattr(layer, f"{group}_mcg").exl3_tensors[key],
+                        _MCG_SENTINEL,
+                        "mcg",
+                    )
+                if has_mul1:
+                    Exl3LinearMethod._validate_marker(
+                        getattr(layer, f"{group}_mul1").exl3_tensors[key],
+                        _MUL1_SENTINEL,
+                        "mul1",
+                    )
+
+    @classmethod
+    def _shard_tensors_for_tensor_parallel(cls, layer: RoutedExperts) -> None:
+        if layer.exl3_tp_size == 1:
+            return
+        start = layer.exl3_tp_rank * layer.exl3_intermediate_size_per_partition
+        size = layer.exl3_intermediate_size_per_partition
+        for expert_id in range(layer.local_num_experts):
+            for shard_id in ("w1", "w3"):
+                key = (expert_id, shard_id)
+                layer.w13_svh.exl3_tensors[key] = (
+                    layer.w13_svh.exl3_tensors[key].narrow(0, start, size).contiguous()
+                )
+                layer.w13_trellis.exl3_tensors[key] = (
+                    Exl3LinearMethod._slice_exl3_tensor(
+                        layer.w13_trellis.exl3_tensors[key],
+                        dim=1,
+                        start=start,
+                        size=size,
+                    )
+                )
+            key = (expert_id, "w2")
+            layer.w2_suh.exl3_tensors[key] = (
+                layer.w2_suh.exl3_tensors[key].narrow(0, start, size).contiguous()
+            )
+            layer.w2_trellis.exl3_tensors[key] = Exl3LinearMethod._slice_exl3_tensor(
+                layer.w2_trellis.exl3_tensors[key],
+                dim=0,
+                start=start,
+                size=size,
+            )
+
+    @staticmethod
+    def _validate_moe_shapes(layer: RoutedExperts) -> None:
+        for expert_id in range(layer.local_num_experts):
+            for group, shard_ids in (("w13", ("w1", "w3")), ("w2", ("w2",))):
+                for shard_id in shard_ids:
+                    key = (expert_id, shard_id)
+                    trellis = getattr(layer, f"{group}_trellis").exl3_tensors[key]
+                    suh = getattr(layer, f"{group}_suh").exl3_tensors[key]
+                    svh = getattr(layer, f"{group}_svh").exl3_tensors[key]
+                    if (
+                        trellis.dtype != torch.int16
+                        or trellis.ndim != 3
+                        or trellis.shape[2] % 16
+                        or not 1 <= trellis.shape[2] // 16 <= 8
+                        or suh.dtype != torch.float16
+                        or suh.ndim != 1
+                        or svh.dtype != torch.float16
+                        or svh.ndim != 1
+                        or suh.numel() != trellis.shape[0] * 16
+                        or svh.numel() != trellis.shape[1] * 16
+                        or (trellis.shape[0] * 16) % _HADAMARD_BLOCK
+                        or (trellis.shape[1] * 16) % _HADAMARD_BLOCK
+                    ):
+                        raise ValueError(
+                            f"Invalid EXL3 MoE tensors for expert={expert_id}, "
+                            f"projection={shard_id}"
+                        )
+
+    def get_fused_moe_quant_config(
+        self, layer: RoutedExperts
+    ) -> FusedMoEQuantConfig | None:
+        del layer
+        return None
+
+    @property
+    def topk_indices_dtype(self) -> torch.dtype | None:
+        return torch.long
+
+    def apply(
+        self,
+        layer: RoutedExperts,
+        x: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        shared_experts: "SharedExperts | None",
+        shared_experts_input: torch.Tensor | None,
+    ) -> torch.Tensor:
+        del shared_experts, shared_experts_input
+        if layer.activation != MoEActivation.SILU:
+            raise NotImplementedError(
+                f"EXL3 correctness MoE supports SiLU only, got {layer.activation}"
+            )
+        if layer.expert_map is not None:
+            raise NotImplementedError("EXL3 MoE expert maps/EPLB are not supported")
+        if layer.apply_router_weight_on_input:
+            raise NotImplementedError(
+                "EXL3 MoE does not support router weights applied on input"
+            )
+
+        original_shape = x.shape[:-1]
+        original_dtype = x.dtype
+        x_2d = x.reshape(-1, x.shape[-1]).to(torch.float16).contiguous()
+        ids = topk_ids.reshape(x_2d.shape[0], -1).to(torch.long)
+        weights = topk_weights.reshape_as(ids).to(torch.float16)
+        output = torch.zeros(
+            (x_2d.shape[0], layer.hidden_size),
+            dtype=torch.float32,
+            device=x.device,
+        )
+        for expert_id in range(layer.local_num_experts):
+            positions = (ids == expert_id).nonzero(as_tuple=False)
+            if positions.shape[0] == 0:
+                continue
+            token_ids = positions[:, 0]
+            route_ids = positions[:, 1]
+            expert_input = x_2d.index_select(0, token_ids)
+            gate = self._apply_expert(layer, "w13", expert_input, expert_id, "w1")
+            up = self._apply_expert(layer, "w13", expert_input, expert_id, "w3")
+            hidden = torch.nn.functional.silu(gate) * up
+            expert_output = self._apply_expert(layer, "w2", hidden, expert_id, "w2")
+            route_weight = weights[token_ids, route_ids].unsqueeze(-1)
+            output.index_add_(
+                0,
+                token_ids,
+                (expert_output * route_weight).to(torch.float32),
+            )
+        output = output.reshape(*original_shape, output.shape[-1])
+        return output if output.dtype == original_dtype else output.to(original_dtype)
+
+    def apply_monolithic(
+        self,
+        layer: RoutedExperts,
+        x: torch.Tensor,
+        router_logits: torch.Tensor,
+        input_ids: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        del layer, x, router_logits, input_ids
+        raise NotImplementedError("EXL3 MoE uses vLLM's external router")
+
+    @staticmethod
+    def _apply_expert(
+        layer: RoutedExperts,
+        group: str,
+        x: torch.Tensor,
+        expert_id: int,
+        shard_id: str,
+    ) -> torch.Tensor:
+        key = (expert_id, shard_id)
+        trellis = getattr(layer, f"{group}_trellis").exl3_tensors[key]
+        packed_k = trellis.shape[0] * 16
+        if x.shape[-1] > packed_k:
+            raise ValueError(
+                f"EXL3 MoE input width {x.shape[-1]} exceeds packed K={packed_k}"
+            )
+        if x.shape[-1] < packed_k:
+            x = torch.nn.functional.pad(x, (0, packed_k - x.shape[-1]))
+        output = _exl3_gemm(
+            x,
+            trellis,
+            getattr(layer, f"{group}_suh").exl3_tensors[key],
+            getattr(layer, f"{group}_svh").exl3_tensors[key],
+            key in getattr(layer, f"{group}_mcg").exl3_tensors,
+            key in getattr(layer, f"{group}_mul1").exl3_tensors,
+        )
+        logical_n = (
+            layer.hidden_size
+            if shard_id == "w2"
+            else layer.exl3_intermediate_size_per_partition
+        )
+        if output.shape[-1] < logical_n:
+            raise ValueError(
+                f"EXL3 MoE packed N={output.shape[-1]} is below logical N={logical_n}"
+            )
+        return output[..., :logical_n]
+
+
+__all__ = ["Exl3Config", "Exl3LinearMethod", "Exl3MoEMethod"]

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -417,11 +417,13 @@ class Exl3Config(QuantizationConfig):
         else:
             candidates.append(f"model.{prefix}")
 
-        # Multimodal wrappers often add an extra `.model` or
-        # `.language_model` segment relative to vLLM's text-only module.
+        # Multimodal wrappers often add an extra `model` or `language_model`
+        # segment relative to vLLM's text-only module — interior
+        # (`model.language_model.layers...`) or leading
+        # (`language_model.lm_head`), so leading segments collapse too.
         parts = prefix.split(".")
         for removable in ("model", "language_model"):
-            for idx in range(1, len(parts) - 1):
+            for idx in range(0, len(parts) - 1):
                 if parts[idx] != removable:
                     continue
                 collapsed = ".".join(parts[:idx] + parts[idx + 1 :])

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -24,6 +24,7 @@ import importlib
 import os
 import re
 import sys
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 
 import torch
@@ -72,6 +73,7 @@ _SPARKINFER_MIXED_TRELLIS_API: Any | None = None
 _RANK_SLICED_RUNTIMES: dict[tuple[Any, ...], dict[str, Any]] = {}
 _MIXED_TRELLIS_RUNTIMES: dict[tuple[Any, ...], dict[str, Any]] = {}
 _NEXT_RUNTIME_SCOPE_ID = 0
+_MIXED_TRELLIS_ROUTE_BLOCK_SIZE = 8
 
 
 # Smallest m the Trellis kernel path can service, and therefore the smallest
@@ -232,10 +234,34 @@ def _load_sparkinfer_mixed_trellis() -> Any:
             "Mixed-bitrate rank-sliced EXL3 requires the matching SparkInfer "
             "mixed_trellis implementation."
         ) from exc
-    module.prepare_weights = prepare.prepare_trellis256_moe_weights
-    module.max_packed_route_slots = host.max_packed_route_slots
-    _SPARKINFER_MIXED_TRELLIS_API = module
-    return module
+    api = SimpleNamespace(
+        build_tiered_maps=module.build_tiered_maps,
+        combine_trellis_rotations=module.combine_trellis_rotations,
+        compile_mixed_trellis=module.compile_mixed_trellis,
+        make_mixed_trellis_buffers=module.make_mixed_trellis_buffers,
+        max_packed_route_slots=host.max_packed_route_slots,
+        prepare_weights=prepare.prepare_trellis256_moe_weights,
+        run_mixed_trellis=module.run_mixed_trellis,
+    )
+    _SPARKINFER_MIXED_TRELLIS_API = api
+    return api
+
+
+def _unique_tensor_storage_bytes(*buffers: Any) -> int:
+    """Count unique tensor storage while ignoring buffer metadata fields."""
+
+    total = 0
+    seen: set[tuple[int, int]] = set()
+    for buffers_ in buffers:
+        for value in vars(buffers_).values():
+            if not isinstance(value, torch.Tensor):
+                continue
+            storage = value.untyped_storage()
+            storage_key = (storage.data_ptr(), storage.nbytes())
+            if storage_key not in seen:
+                seen.add(storage_key)
+                total += storage.nbytes()
+    return total
 
 
 def _positive_env_int(name: str, default: int) -> int:
@@ -1331,9 +1357,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             layer.exl3_layer_bitrates = self.quant_config.rank_sliced_layer_bitrates(
                 str(layer.layer_name)
             )
-            layer.exl3_mixed_bitrate = (
-                len(set(layer.exl3_layer_bitrates)) > 1
-            )
+            layer.exl3_mixed_bitrate = len(set(layer.exl3_layer_bitrates)) > 1
         for prefix, shard_ids in (("w13", ("w1", "w3")), ("w2", ("w2",))):
             for suffix in ("suh", "svh", "trellis", "mcg", "mul1"):
                 layer.register_parameter(
@@ -1585,9 +1609,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         down_suh = self._rank_sliced_backing(layer, "w2_suh")
         down_svh = self._rank_sliced_backing(layer, "w2_svh")
         device = gate_suh.device
-        tile_config = self._mixed_trellis_tile_config(
-            hidden_size, intermediate_size
-        )
+        tile_config = self._mixed_trellis_tile_config(hidden_size, intermediate_size)
         prepared_tiers = []
         tier_ids = []
         for bits, expert_ids in tiers.items():
@@ -1605,8 +1627,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             ).contiguous()
             w2 = torch.stack(
                 tuple(
-                    w2_param.exl3_tensors[(expert_id, "w2")]
-                    for expert_id in expert_ids
+                    w2_param.exl3_tensors[(expert_id, "w2")] for expert_id in expert_ids
                 )
             ).contiguous()
             expected_w13 = (
@@ -1690,7 +1711,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         logger.info(
             "EXL3 mixed Trellis %s: tiers=%s",
             layer.layer_name,
-            tuple((bits, len(ids)) for bits, ids in zip(tiers, tier_ids)),
+            tuple((bits, len(ids)) for bits, ids in zip(tiers, tier_ids, strict=True)),
         )
 
     def _prepare_rank_sliced_weights(self, layer: RoutedExperts) -> None:
@@ -1710,8 +1731,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         bits = int(layer_bitrates[0])
         if bits not in (3, 4, 5, 6):
             raise ValueError(
-                "rank-sliced EXL3 requires an integral 3/4/5/6 bitrate, got "
-                f"{bits!r}"
+                f"rank-sliced EXL3 requires an integral 3/4/5/6 bitrate, got {bits!r}"
             )
 
         w13 = self._rank_sliced_backing(layer, "w13_trellis")
@@ -1819,7 +1839,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         topk = int(topk_ids.shape[1])
         tier_signature = tuple(
             (int(bits), len(ids))
-            for bits, ids in zip(mixed["tier_bits"], mixed["tier_ids"])
+            for bits, ids in zip(mixed["tier_bits"], mixed["tier_ids"], strict=True)
         )
         key = (
             _runtime_owner_token(self.quant_config, layer),
@@ -1854,7 +1874,11 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         total_experts = sum(experts for _, experts in tier_signature)
 
         def make_state(capacity: int) -> dict[str, Any]:
-            route_slots = api.max_packed_route_slots(capacity * topk, 8, total_experts)
+            route_slots = api.max_packed_route_slots(
+                capacity * topk,
+                _MIXED_TRELLIS_ROUTE_BLOCK_SIZE,
+                total_experts,
+            )
             launch = api.compile_mixed_trellis(
                 size_m=capacity,
                 hidden_size=int(layer.exl3_hidden_size),
@@ -1864,7 +1888,9 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 tier0_bits=tier_signature[0][0],
                 tier1_bits=tier_signature[1][0],
                 top_k=topk,
-                max_m_blocks=(route_slots + 7) // 8,
+                max_m_blocks=(route_slots + _MIXED_TRELLIS_ROUTE_BLOCK_SIZE - 1)
+                // _MIXED_TRELLIS_ROUTE_BLOCK_SIZE,
+                moe_block_size=_MIXED_TRELLIS_ROUTE_BLOCK_SIZE,
                 sms=int(props.multi_processor_count),
                 max_shared_mem=int(props.shared_memory_per_block_optin),
                 force_tile_config=mixed["tile_config"],
@@ -1895,15 +1921,9 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             "max_batched_tokens": max_batched_tokens,
         }
         _MIXED_TRELLIS_RUNTIMES[key] = runtime
-        buffer_bytes = 0
-        seen: set[tuple[int, int]] = set()
-        for state in (decode, prefill):
-            for tensor in vars(state["buffers"]).values():
-                storage = tensor.untyped_storage()
-                storage_key = (storage.data_ptr(), storage.nbytes())
-                if storage_key not in seen:
-                    seen.add(storage_key)
-                    buffer_bytes += storage.nbytes()
+        buffer_bytes = _unique_tensor_storage_bytes(
+            decode["buffers"], prefill["buffers"]
+        )
         logger.info_once(
             "EXL3 mixed Trellis runtime planned: tiers=%s decode_capacity=%d "
             "prefill_capacity=%d buffers=%.1f MiB",
@@ -1929,9 +1949,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 f"m={m}, capacity={runtime['max_batched_tokens']}"
             )
         state = (
-            runtime["decode"]
-            if m <= runtime["max_decode_m"]
-            else runtime["prefill"]
+            runtime["decode"] if m <= runtime["max_decode_m"] else runtime["prefill"]
         )
         mixed = layer.exl3_mixed_trellis
         output = runtime["api"].run_mixed_trellis(

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -71,6 +71,16 @@ _RANK_SLICED_RUNTIMES: dict[tuple[Any, ...], dict[str, Any]] = {}
 _NEXT_RUNTIME_SCOPE_ID = 0
 
 
+# Smallest m the Trellis kernel path can service, and therefore the smallest
+# row count an EXL3 rank-sliced MoE layer can be CUDA-graph captured at. A
+# capture-size selector may read this to align its sizes with the backend
+# instead of failing at capture time.
+MIN_CAPTURABLE_TRELLIS_M = 1
+
+# Historical default for non-captured (target) layers.
+_DEFAULT_TRELLIS_MIN_M = 4
+
+
 def _is_draft_layer(layer: Any) -> bool:
     """True for a rank-sliced MTP/EAGLE draft MoE layer.
 
@@ -1438,7 +1448,26 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         x: torch.Tensor,
         topk_ids: torch.Tensor,
     ) -> dict[str, Any]:
-        min_trellis_m = _positive_env_int("VLLM_EXL3_TRELLIS_MIN_M", 4)
+        # A rank-sliced draft layer is CUDA-graph captured at small row counts
+        # (m = draft rows per step, typically 1..3). If m falls outside the
+        # Trellis window the eager parity path is reached, which is illegal
+        # during capture -- the engine then cannot start at all:
+        #
+        #   RuntimeError: EXL3 eager parity path entered during CUDA graph
+        #   capture (m=3); capture sizes must lie inside the Trellis window
+        #   [4, 32]
+        #
+        # That was previously worked around by asking every operator to set
+        # VLLM_EXL3_TRELLIS_MIN_M=1 by hand. A backend should satisfy its own
+        # capture contract instead, so draft layers default the window down to
+        # MIN_CAPTURABLE_TRELLIS_M. An explicit env value still wins, and the
+        # target path keeps its original default.
+        default_min_m = (
+            MIN_CAPTURABLE_TRELLIS_M
+            if _is_draft_layer(layer)
+            else _DEFAULT_TRELLIS_MIN_M
+        )
+        min_trellis_m = _positive_env_int("VLLM_EXL3_TRELLIS_MIN_M", default_min_m)
         max_trellis_m = _positive_env_int("VLLM_EXL3_TRELLIS_MAX_M", 32)
         block_m = _positive_env_int("VLLM_EXL3_TRELLIS_BLOCK_M", 8)
         chunk = _positive_env_int("VLLM_EXL3_PREFILL_CHUNK", 128)
@@ -1685,7 +1714,13 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             raise RuntimeError(
                 "EXL3 eager parity path entered during CUDA graph capture "
                 f"(m={m}); capture sizes must lie inside the Trellis window "
-                f"[{runtime['min_trellis_m']}, {runtime['max_trellis_m']}]"
+                f"[{runtime['min_trellis_m']}, {runtime['max_trellis_m']}]. "
+                f"Layer {getattr(layer, 'layer_name', '<unknown>')!r} was "
+                f"classified as {'draft' if _is_draft_layer(layer) else 'target'}. "
+                "A rank-sliced draft layer should have had its window widened to "
+                f"MIN_CAPTURABLE_TRELLIS_M={MIN_CAPTURABLE_TRELLIS_M} "
+                "automatically; if VLLM_EXL3_TRELLIS_MIN_M is set explicitly, "
+                f"lower it to {MIN_CAPTURABLE_TRELLIS_M} or unset it."
             )
         if m > runtime["parity_rows"]:
             raise ValueError(

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -3,14 +3,29 @@
 
 """EXL3 (ExLlamaV3 trellis) quantization support.
 
-This is deliberately the correctness backend.  Every logical checkpoint
-matrix is dispatched independently through ``exllamav3_ext.exl3_gemm``.  In
-particular, vLLM's packed QKV and gate/up modules are *not* treated as one EXL3
-matrix: each source matrix owns its own Hadamard vectors and codebook marker.
+Compute paths, in selection order:
 
-The extension is imported lazily on the first CUDA execution.  Importing this
+1. **Fused path (primary).** Modules whose checkpoint carries the MCG codebook
+   marker run through the b12x fused CuTeDSL trellis kernel
+   (``b12x.moe.fused.w4a16.run_trellis256_dense``): native EXL3 storage is
+   consumed zero-copy at 3/4/5/6 bpw, the full input-rotation -> GEMM ->
+   output-rotation chain executes as one compiled artifact, and the output is
+   byte-identical across batch size m — a property the split upstream
+   GEMV/GEMM/reconstruct ladder does not have. Selection happens once per
+   shard at weight-processing time; ineligible shards (legacy ``default`` or
+   MUL1 codebooks, or shapes the kernel rejects) fall back per-shard.
+2. **Parity path (fallback + oracle).** The bit-faithful wrapper around
+   ``exllamav3_ext.exl3_gemm``. Every logical checkpoint matrix is dispatched
+   independently: vLLM's packed QKV and gate/up modules are *not* treated as
+   one EXL3 matrix — each source matrix owns its own Hadamard vectors and
+   codebook marker.
+
+``VLLM_EXL3_FUSED=0`` forces the parity path everywhere (A/B switch).
+``VLLM_EXL3_LOG_PATH_SELECTION=1`` logs the chosen path per shard.
+
+Both the extension and the b12x package are imported lazily.  Importing this
 module, parsing checkpoint metadata, or compiling it with ``py_compile`` does
-not load the extension or initialize CUDA.
+not load either one or initialize CUDA.
 """
 
 from __future__ import annotations
@@ -154,6 +169,80 @@ def _exl3_gemm_fake(
         dtype=torch.float16,
         device=x.device,
     )
+
+
+_B12X_UNAVAILABLE = object()
+_B12X_DENSE_API: Any = None
+
+
+def _fused_mode_enabled() -> bool:
+    return os.environ.get("VLLM_EXL3_FUSED", "1") == "1"
+
+
+def _load_b12x_dense() -> Any:
+    """Resolve the b12x fused dense entry points once, without hard-failing.
+
+    Returns a ``(prepare_trellis256_dense_weight, run_trellis256_dense)``
+    tuple, or None when the fused path is disabled or the b12x package is not
+    importable.  The parity path through exllamav3_ext remains the fallback
+    either way.  This backend requires eager execution (see
+    ``_require_enforce_eager``), so the fused call does not need an opaque
+    torch.library wrapper.
+    """
+    global _B12X_DENSE_API
+    if _B12X_DENSE_API is _B12X_UNAVAILABLE:
+        return None
+    if _B12X_DENSE_API is not None:
+        return _B12X_DENSE_API
+    if not _fused_mode_enabled():
+        _B12X_DENSE_API = _B12X_UNAVAILABLE
+        return None
+    try:
+        from b12x.moe.fused.w4a16 import (
+            prepare_trellis256_dense_weight,
+            run_trellis256_dense,
+        )
+    except Exception:
+        logger.warning(
+            "EXL3: the b12x fused trellis kernel is not importable; every "
+            "module will use the bit-faithful exllamav3_ext parity path."
+        )
+        _B12X_DENSE_API = _B12X_UNAVAILABLE
+        return None
+    _B12X_DENSE_API = (prepare_trellis256_dense_weight, run_trellis256_dense)
+    return _B12X_DENSE_API
+
+
+def _log_path_selection(prefix: str, chosen: str, reason: str) -> None:
+    if os.environ.get("VLLM_EXL3_LOG_PATH_SELECTION") == "1":
+        logger.info("EXL3 path %s -> %s (%s)", prefix, chosen, reason)
+
+
+def _try_prepare_fused(
+    prefix: str,
+    trellis: torch.Tensor,
+    suh: torch.Tensor,
+    svh: torch.Tensor,
+    mcg: torch.Tensor | None,
+    mul1: torch.Tensor | None,
+) -> Any | None:
+    """Prepare one shard for the fused kernel; None selects the parity path."""
+    api = _load_b12x_dense()
+    if api is None:
+        return None
+    if mcg is None or mul1 is not None:
+        # The fused t256 decoder implements the MCG codebook only.  Legacy
+        # "default"-codebook and MUL1 checkpoints stay on the parity path.
+        _log_path_selection(prefix, "parity", "non-MCG codebook")
+        return None
+    prepare, _ = api
+    try:
+        prepared = prepare(trellis, suh, svh, mcg=mcg)
+    except Exception as exc:
+        _log_path_selection(prefix, "parity", f"prepare rejected: {exc}")
+        return None
+    _log_path_selection(prefix, "fused", "mcg")
+    return prepared
 
 
 class Exl3Config(QuantizationConfig):
@@ -520,6 +609,22 @@ class Exl3LinearMethod(LinearMethodBase):
                     device=device, non_blocking=True
                 ).contiguous()
 
+        fused: dict[ShardId, Any] = {}
+        if _fused_mode_enabled():
+            prefix = getattr(layer, "prefix", layer.__class__.__name__)
+            for shard_id in layer.exl3_shard_ids:
+                prepared = _try_prepare_fused(
+                    f"{prefix}[{shard_id!r}]",
+                    layer.trellis.exl3_tensors[shard_id],
+                    layer.suh.exl3_tensors[shard_id],
+                    layer.svh.exl3_tensors[shard_id],
+                    layer.mcg.exl3_tensors.get(shard_id),
+                    layer.mul1.exl3_tensors.get(shard_id),
+                )
+                if prepared is not None:
+                    fused[shard_id] = prepared
+        layer.exl3_fused_prepared = fused
+
     def apply(
         self,
         layer: torch.nn.Module,
@@ -773,14 +878,20 @@ class Exl3LinearMethod(LinearMethodBase):
             )
         if x.shape[-1] < packed_k:
             x = torch.nn.functional.pad(x, (0, packed_k - x.shape[-1]))
-        output = _exl3_gemm(
-            x,
-            trellis,
-            layer.suh.exl3_tensors[shard_id],
-            layer.svh.exl3_tensors[shard_id],
-            shard_id in layer.mcg.exl3_tensors,
-            shard_id in layer.mul1.exl3_tensors,
-        )
+        prepared = getattr(layer, "exl3_fused_prepared", {}).get(shard_id)
+        if prepared is not None:
+            api = _load_b12x_dense()
+            assert api is not None
+            output = api[1](x, prepared)
+        else:
+            output = _exl3_gemm(
+                x,
+                trellis,
+                layer.suh.exl3_tensors[shard_id],
+                layer.svh.exl3_tensors[shard_id],
+                shard_id in layer.mcg.exl3_tensors,
+                shard_id in layer.mul1.exl3_tensors,
+            )
         logical_n = Exl3LinearMethod._output_shard_size(layer, shard_id)
         if output.shape[-1] < logical_n:
             raise ValueError(
@@ -882,6 +993,29 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                         device=device, non_blocking=True
                     ).contiguous()
         self._validate_moe_shapes(layer)
+
+        fused: dict[tuple[str, int, str], Any] = {}
+        if _fused_mode_enabled():
+            for group, shard_ids in (("w13", ("w1", "w3")), ("w2", ("w2",))):
+                trellis_map = getattr(layer, f"{group}_trellis").exl3_tensors
+                suh_map = getattr(layer, f"{group}_suh").exl3_tensors
+                svh_map = getattr(layer, f"{group}_svh").exl3_tensors
+                mcg_map = getattr(layer, f"{group}_mcg").exl3_tensors
+                mul1_map = getattr(layer, f"{group}_mul1").exl3_tensors
+                for expert_id in range(layer.local_num_experts):
+                    for shard_id in shard_ids:
+                        key = (expert_id, shard_id)
+                        prepared = _try_prepare_fused(
+                            f"{layer.layer_name}.{expert_id}.{shard_id}",
+                            trellis_map[key],
+                            suh_map[key],
+                            svh_map[key],
+                            mcg_map.get(key),
+                            mul1_map.get(key),
+                        )
+                        if prepared is not None:
+                            fused[(group,) + key] = prepared
+        layer.exl3_moe_fused_prepared = fused
 
     def _validate_codebooks(self, layer: RoutedExperts) -> None:
         projections = {
@@ -1067,14 +1201,22 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             )
         if x.shape[-1] < packed_k:
             x = torch.nn.functional.pad(x, (0, packed_k - x.shape[-1]))
-        output = _exl3_gemm(
-            x,
-            trellis,
-            getattr(layer, f"{group}_suh").exl3_tensors[key],
-            getattr(layer, f"{group}_svh").exl3_tensors[key],
-            key in getattr(layer, f"{group}_mcg").exl3_tensors,
-            key in getattr(layer, f"{group}_mul1").exl3_tensors,
+        prepared = getattr(layer, "exl3_moe_fused_prepared", {}).get(
+            (group,) + key
         )
+        if prepared is not None:
+            api = _load_b12x_dense()
+            assert api is not None
+            output = api[1](x, prepared)
+        else:
+            output = _exl3_gemm(
+                x,
+                trellis,
+                getattr(layer, f"{group}_suh").exl3_tensors[key],
+                getattr(layer, f"{group}_svh").exl3_tensors[key],
+                key in getattr(layer, f"{group}_mcg").exl3_tensors,
+                key in getattr(layer, f"{group}_mul1").exl3_tensors,
+            )
         logical_n = (
             layer.hidden_size
             if shard_id == "w2"

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -412,7 +412,7 @@ class Exl3Config(QuantizationConfig):
                 return UnquantizedLinearMethod()
             return Exl3LinearMethod(self)
         if isinstance(layer, RoutedExperts):
-            if not self._moe_prefix_is_exl3(prefix):
+            if not self._moe_prefix_is_exl3(prefix, layer):
                 return None
             return Exl3MoEMethod(self, layer.moe_config)
         return None
@@ -461,12 +461,26 @@ class Exl3Config(QuantizationConfig):
             for source in source_leaves
         )
 
-    def _moe_prefix_is_exl3(self, prefix: str) -> bool:
+    def _moe_prefix_is_exl3(
+        self, prefix: str, layer: torch.nn.Module | None = None
+    ) -> bool:
+        # Use the layer's checkpoint projection names (the same fields
+        # _validate_codebooks keys off) so remapped-projection MoE
+        # checkpoints are still detected; fall back to the defaults when the
+        # layer variant does not carry them.
+        projections = tuple(
+            getattr(layer, attr, default)
+            for attr, default in (
+                ("ckpt_gate_proj_name", "gate_proj"),
+                ("ckpt_up_proj_name", "up_proj"),
+                ("ckpt_down_proj_name", "down_proj"),
+            )
+        )
         expert_prefixes = (f"{prefix}.0", f"{prefix}.experts.0")
         return any(
             all(
                 self._is_exl3_prefix(f"{expert}.{projection}")
-                for projection in ("gate_proj", "up_proj", "down_proj")
+                for projection in projections
             )
             for expert in expert_prefixes
         )

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -71,6 +71,30 @@ _RANK_SLICED_RUNTIMES: dict[tuple[Any, ...], dict[str, Any]] = {}
 _NEXT_RUNTIME_SCOPE_ID = 0
 
 
+def _is_draft_layer(layer: Any) -> bool:
+    """True for a rank-sliced MTP/EAGLE draft MoE layer.
+
+    Derived from the layer prefix rather than the quant config, because config
+    identity is not a reliable role signal: only some MTP model files build the
+    draft a fresh ``Exl3Config``. Several (e.g. ``glm4_moe_mtp``, ``qwen3_next_mtp``,
+    ``deepseek_eagle``) pass ``vllm_config.quant_config`` straight through, which
+    makes the draft's scope identical to the target's and silently restores the
+    shared-scratch corruption this scoping exists to prevent.
+    """
+    name = str(getattr(layer, "layer_name", "") or getattr(layer, "prefix", ""))
+    return any(t in name for t in (".mtp", "mtp.", "nextn", "eagle", "draft",
+                                   "speculator"))
+
+
+def _runtime_owner_token(quant_config: Any, layer: Any) -> tuple[int, bool]:
+    """Runtime-cache owner identity: (config scope, is_draft).
+
+    Adding the role makes target/draft isolation independent of whether the model
+    file happened to mint a separate quant config.
+    """
+    return (_runtime_scope_id(quant_config), _is_draft_layer(layer))
+
+
 def _runtime_scope_id(quant_config: Any) -> int:
     """Stable identity for the model that owns a rank-sliced runtime.
 
@@ -95,7 +119,7 @@ def _runtime_scope_id(quant_config: Any) -> int:
     scope = _NEXT_RUNTIME_SCOPE_ID
     _NEXT_RUNTIME_SCOPE_ID += 1
     try:
-        quant_config._exl3_runtime_scope_id = scope
+        quant_config._exl3_runtime_scope_id = scope  # noqa: SLF001
     except AttributeError:
         # Frozen/slotted config: fall back to object identity. Configs live for
         # the process lifetime, so reuse-after-GC aliasing is not a concern here.
@@ -1114,8 +1138,19 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             scheduler_config = (
                 vllm_config.scheduler_config if vllm_config is not None else None
             )
+            # No silent fallback: a wrong capacity here puts the target and the
+            # rank-sliced MTP draft on different plans with no error, which is
+            # exactly the class of mismatch that corrupts only at scale.
+            if scheduler_config is None or getattr(
+                scheduler_config, "max_num_batched_tokens", None
+            ) is None:
+                raise ValueError(
+                    "EXL3 rank-sliced MoE requires scheduler_config."
+                    "max_num_batched_tokens to plan its Trellis arena; refusing to "
+                    "guess a capacity."
+                )
             layer.exl3_max_num_batched_tokens = int(
-                getattr(scheduler_config, "max_num_batched_tokens", 4096)
+                scheduler_config.max_num_batched_tokens
             )
         for prefix, shard_ids in (("w13", ("w1", "w3")), ("w2", ("w2",))):
             for suffix in ("suh", "svh", "trellis", "mcg", "mul1"):
@@ -1413,17 +1448,19 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             raise ValueError(
                 "VLLM_EXL3_TRELLIS_MIN_M cannot exceed VLLM_EXL3_TRELLIS_MAX_M"
             )
-        max_batched_tokens = max(
-            int(layer.exl3_max_num_batched_tokens),
-            int(x.shape[0]),
-        )
+        # Batch-INVARIANT capacity. Including x.shape[0] here made the runtime
+        # cache key depend on the live batch, so any m above the planned capacity
+        # produced a cache MISS -- silently planning a fresh ~1 GiB arena mid-serve
+        # and making the capacity guard in _apply_rank_sliced unreachable. The
+        # planned capacity is a property of the layer, not of one forward pass.
+        max_batched_tokens = int(layer.exl3_max_num_batched_tokens)
         topk = int(topk_ids.shape[1])
         device_index = x.device.index
         key = (
             # Owning model scope first: the cached runtime holds mutable scratch,
             # so a target layer and a same-shape rank-sliced MTP draft layer must
             # not share an entry (see _runtime_scope_id).
-            _runtime_scope_id(self.quant_config),
+            _runtime_owner_token(self.quant_config, layer),
             device_index,
             x.dtype,
             int(layer.exl3_hidden_size),

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -198,6 +198,13 @@ def _load_b12x_dense() -> Any:
         _B12X_DENSE_API = _B12X_UNAVAILABLE
         return None
     try:
+        # The fused dense entry performs its outer rotations through
+        # exllamav3_ext.had_r_128, and b12x imports that extension by module
+        # name. Resolve it here through the same VLLM_EXL3_ABI_SHIM /
+        # VLLM_EXL3_EXT_PATH contract as the parity path so b12x sees the
+        # shimmed, correctly-located extension instead of whatever an
+        # unshimmed site-packages import would find.
+        _load_exl3_ext()
         from b12x.moe.fused.w4a16 import (
             prepare_trellis256_dense_weight,
             run_trellis256_dense,

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -3,9 +3,10 @@
 
 """EXL3 (ExLlamaV3 trellis) quantization support.
 
-Rank-sliced routed-expert checkpoints use Sparkinfer's planned full-rotation
-Trellis MoE API for the decode window and the ExLlamaV3 extension for larger
-prefill batches. Generic dense and non-rank-sliced MoE checkpoints use the
+Rank-sliced routed-expert checkpoints use Sparkinfer's unified planned
+``fused_moe`` API for the Trellis decode/prefill windows and the ExLlamaV3
+extension for the small eager parity window. Generic dense and non-rank-sliced
+MoE checkpoints use the
 bit-faithful ``exllamav3_ext.exl3_gemm`` parity path. Every logical checkpoint
 matrix is dispatched independently: vLLM's packed QKV and gate/up modules are
 not treated as one EXL3 matrix because each source matrix owns its Hadamard
@@ -66,7 +67,7 @@ _MCG_SENTINEL = 0xCBAC1FED
 _MUL1_SENTINEL = 0x83DCD12D
 _HADAMARD_BLOCK = 128
 _EXL3_EXT: Any | None = None
-_SPARKINFER_TRELLIS_API: Any | None = None
+_SPARKINFER_FUSED_MOE_API: Any | None = None
 _RANK_SLICED_RUNTIMES: dict[tuple[Any, ...], dict[str, Any]] = {}
 _NEXT_RUNTIME_SCOPE_ID = 0
 
@@ -191,21 +192,21 @@ def _load_exl3_ext() -> Any:
     return ext
 
 
-def _load_sparkinfer_trellis() -> Any:
-    """Resolve the public planned Trellis MoE API lazily."""
+def _load_sparkinfer_fused_moe() -> Any:
+    """Resolve the public unified MoE API lazily."""
 
-    global _SPARKINFER_TRELLIS_API
-    if _SPARKINFER_TRELLIS_API is not None:
-        return _SPARKINFER_TRELLIS_API
+    global _SPARKINFER_FUSED_MOE_API
+    if _SPARKINFER_FUSED_MOE_API is not None:
+        return _SPARKINFER_FUSED_MOE_API
     try:
-        from sparkinfer.moe import trellis_moe
+        from sparkinfer.moe import fused_moe
     except Exception as exc:
         raise RuntimeError(
-            "Rank-sliced EXL3 requires sparkinfer.moe.trellis_moe. Install "
-            "a Sparkinfer build containing the planned full-rotation API."
+            "Rank-sliced EXL3 requires the exl3_trellis_mcg source in "
+            "sparkinfer.moe.fused_moe. Install a matching Sparkinfer build."
         ) from exc
-    _SPARKINFER_TRELLIS_API = trellis_moe
-    return trellis_moe
+    _SPARKINFER_FUSED_MOE_API = fused_moe
+    return fused_moe
 
 
 def _positive_env_int(name: str, default: int) -> int:
@@ -1137,7 +1138,11 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         params_dtype: torch.dtype,
         **extra_weight_attrs,
     ) -> None:
-        del params_dtype, extra_weight_attrs
+        del extra_weight_attrs
+        if params_dtype not in (torch.bfloat16, torch.float16):
+            raise ValueError(
+                f"EXL3 MoE requires BF16 or FP16 activations, got {params_dtype}"
+            )
         if self.moe.moe_parallel_config.use_ep:
             raise NotImplementedError(
                 "EXL3 correctness MoE currently supports TP but not expert parallelism"
@@ -1150,6 +1155,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         layer.exl3_tp_size = self.moe.moe_parallel_config.tp_size
         layer.exl3_hidden_size = hidden_size
         layer.exl3_intermediate_size_per_partition = intermediate_size_per_partition
+        layer.exl3_params_dtype = params_dtype
         rank_sliced = self.quant_config.rank_sliced_metadata is not None
         if rank_sliced:
             checkpoint_tp = int(self.quant_config.rank_sliced_metadata["tp"])
@@ -1387,7 +1393,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         return (64, 128, 64, 128)
 
     def _prepare_rank_sliced_weights(self, layer: RoutedExperts) -> None:
-        api = _load_sparkinfer_trellis()
+        api = _load_sparkinfer_fused_moe()
         num_experts = int(layer.local_num_experts)
         hidden_size = int(layer.exl3_hidden_size)
         intermediate_size = int(layer.exl3_intermediate_size_per_partition)
@@ -1436,16 +1442,28 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         intermediate_rotations[:, 2 * intermediate_size :].copy_(down_suh)
         tile_config = self._trellis_tile_config(hidden_size, intermediate_size)
         marker = layer.w13_mcg.exl3_tensors[(0, "w1")]
+        weight_plan = api.plan_weights(
+            quant_modes="w4a16",
+            source_format="exl3_trellis_mcg",
+            activation=layer.activation.value,
+            params_dtype=layer.exl3_params_dtype,
+            num_experts=num_experts,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            w13_layout="w13",
+            trellis_bits=bits,
+            trellis_tile_config=tile_config,
+        )
         layer.exl3_trellis_weights = api.prepare_weights(
-            w13,
-            w2,
+            plan=weight_plan,
+            params_dtype=layer.exl3_params_dtype,
+            w1_fp4=w13,
+            w2_fp4=w2,
             gate_suh=gate_suh,
             up_suh=up_suh,
             intermediate_rotations=intermediate_rotations,
             down_svh=down_svh,
-            codebook="mcg",
-            mcg=marker,
-            tile_config=tile_config,
+            trellis_mcg=marker,
         )
 
         slabs = (
@@ -1562,21 +1580,17 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 "profile pass before CUDA graph capture"
             )
 
-        api = _load_sparkinfer_trellis()
+        api = _load_sparkinfer_fused_moe()
 
         def _plan_with_scratch(plan_max_tokens: int, plan_block_m: int):
             caps = api.Caps(
                 max_tokens=plan_max_tokens,
                 num_topk=topk,
-                num_experts=int(layer.local_num_experts),
-                hidden_size=int(layer.exl3_hidden_size),
-                intermediate_size=int(layer.exl3_intermediate_size_per_partition),
                 route_num_experts=int(layer.local_num_experts),
-                block_size_m=plan_block_m,
-                trellis_bits=int(self.quant_config.bits),
-                tile_config=layer.exl3_trellis_tile_config,
-                input_dtype=x.dtype,
                 device=x.device,
+                weight_plan=layer.exl3_trellis_weights.plan,
+                quant_mode="w4a16",
+                w4a16_block_size_m=plan_block_m,
             )
             plan = api.plan(caps)
             scratch_spec = plan.scratch_specs()[0]
@@ -1728,7 +1742,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 runtime["trellis_plan"],
                 scratch=runtime["trellis_scratch"],
                 a=x,
-                weights=layer.exl3_trellis_weights,
+                experts=layer.exl3_trellis_weights,
                 topk_weights=topk_weights,
                 topk_ids=topk_ids,
             )
@@ -1745,7 +1759,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 runtime["prefill_plan"],
                 scratch=runtime["prefill_scratch"],
                 a=x,
-                weights=layer.exl3_trellis_weights,
+                experts=layer.exl3_trellis_weights,
                 topk_weights=topk_weights,
                 topk_ids=topk_ids,
             )

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -1173,9 +1173,10 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             # No silent fallback: a wrong capacity here puts the target and the
             # rank-sliced MTP draft on different plans with no error, which is
             # exactly the class of mismatch that corrupts only at scale.
-            if scheduler_config is None or getattr(
-                scheduler_config, "max_num_batched_tokens", None
-            ) is None:
+            if (
+                scheduler_config is None
+                or getattr(scheduler_config, "max_num_batched_tokens", None) is None
+            ):
                 raise ValueError(
                     "EXL3 rank-sliced MoE requires scheduler_config."
                     "max_num_batched_tokens to plan its Trellis arena; refusing to "
@@ -1517,6 +1518,19 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         # and making the capacity guard in _apply_rank_sliced unreachable. The
         # planned capacity is a property of the layer, not of one forward pass.
         max_batched_tokens = int(layer.exl3_max_num_batched_tokens)
+        prefill_plan_enabled = prefill_trellis and max_batched_tokens > max_trellis_m
+        parity_rows = (
+            min(chunk, max_batched_tokens)
+            if prefill_plan_enabled
+            else max_batched_tokens
+        )
+        max_parity_batch = min(max_batched_tokens, min_trellis_m - 1)
+        if max_parity_batch > parity_rows:
+            raise ValueError(
+                "VLLM_EXL3_PREFILL_CHUNK cannot cover the EXL3 parity window: "
+                f"chunk={chunk}, required_rows={max_parity_batch}. Increase "
+                "VLLM_EXL3_PREFILL_CHUNK or lower VLLM_EXL3_TRELLIS_MIN_M."
+            )
         topk = int(topk_ids.shape[1])
         device_index = x.device.index
         key = (
@@ -1580,7 +1594,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         # rows rather than once per 8-row block.
         prefill_plan = None
         prefill_scratch = None
-        if prefill_trellis and max_batched_tokens > max_trellis_m:
+        if prefill_plan_enabled:
             prefill_plan, prefill_scratch = _plan_with_scratch(
                 max_batched_tokens, prefill_block_m
             )
@@ -1603,11 +1617,6 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         device = x.device
         # With the prefill plan live, the parity path only ever serves
         # m < min_trellis_m, so its persistent staging shrinks to one chunk.
-        parity_rows = (
-            max_batched_tokens
-            if prefill_plan is None
-            else min(chunk, max_batched_tokens)
-        )
         runtime = {
             "api": api,
             "trellis_plan": trellis_plan,
@@ -1695,8 +1704,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             max_trellis_m,
             block_m,
             (
-                f"trellis block_m={prefill_block_m} "
-                f"arena={prefill_arena_mib:.1f}MiB"
+                f"trellis block_m={prefill_block_m} arena={prefill_arena_mib:.1f}MiB"
                 if prefill_plan is not None
                 else "parity"
             ),

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -68,7 +68,9 @@ _MUL1_SENTINEL = 0x83DCD12D
 _HADAMARD_BLOCK = 128
 _EXL3_EXT: Any | None = None
 _SPARKINFER_FUSED_MOE_API: Any | None = None
+_SPARKINFER_MIXED_TRELLIS_API: Any | None = None
 _RANK_SLICED_RUNTIMES: dict[tuple[Any, ...], dict[str, Any]] = {}
+_MIXED_TRELLIS_RUNTIMES: dict[tuple[Any, ...], dict[str, Any]] = {}
 _NEXT_RUNTIME_SCOPE_ID = 0
 
 
@@ -211,6 +213,31 @@ def _load_sparkinfer_fused_moe() -> Any:
     return fused_moe
 
 
+def _load_sparkinfer_mixed_trellis() -> Any:
+    """Resolve the one-grid mixed-bitrate Trellis API lazily."""
+
+    global _SPARKINFER_MIXED_TRELLIS_API
+    if _SPARKINFER_MIXED_TRELLIS_API is not None:
+        return _SPARKINFER_MIXED_TRELLIS_API
+    try:
+        module = importlib.import_module(
+            "sparkinfer.moe._shared.kernels.w4a16.mixed_trellis"
+        )
+        prepare = importlib.import_module(
+            "sparkinfer.moe._shared.kernels.w4a16.prepare"
+        )
+        host = importlib.import_module("sparkinfer.moe._shared.kernels.w4a16.host")
+    except Exception as exc:
+        raise RuntimeError(
+            "Mixed-bitrate rank-sliced EXL3 requires the matching SparkInfer "
+            "mixed_trellis implementation."
+        ) from exc
+    module.prepare_weights = prepare.prepare_trellis256_moe_weights
+    module.max_packed_route_slots = host.max_packed_route_slots
+    _SPARKINFER_MIXED_TRELLIS_API = module
+    return module
+
+
 def _positive_env_int(name: str, default: int) -> int:
     # An env var that is present but blank means "unset". Compose and Kubernetes
     # both render an unset variable as the empty string, so int("") would abort
@@ -304,6 +331,8 @@ class Exl3Config(QuantizationConfig):
         self.tensor_storage = tensor_storage or {}
         self._eager_checked = False
         self.rank_sliced_metadata: dict[str, Any] | None = None
+        self.rank_sliced_k_values: tuple[int, ...] | None = None
+        self.rank_sliced_bits_by_layer: dict[int, tuple[int, ...]] = {}
 
     def get_name(self) -> str:
         return "exl3"
@@ -358,6 +387,14 @@ class Exl3Config(QuantizationConfig):
             and rank_sliced.get("format") == _RANK_SLICED_FORMAT
         ):
             self._configure_rank_sliced(rank_sliced)
+            if self.rank_sliced_k_values is not None:
+                resolved_revision = revision
+                if resolved_revision is None and hf_config is not None:
+                    resolved_revision = getattr(hf_config, "_commit_hash", None)
+                self._load_rank_sliced_bitrates(
+                    model_name,
+                    revision=resolved_revision,
+                )
             return
 
         # vLLM returns the summary embedded in config.json without consulting
@@ -422,9 +459,95 @@ class Exl3Config(QuantizationConfig):
                 f"{metadata['tensor_schema']!r}"
             )
         self.rank_sliced_metadata = dict(metadata)
-        self.bits = float(metadata["bits"])
+        bits_field = metadata["bits"]
+        if isinstance(bits_field, str) and bits_field.strip().lower() == "mixed":
+            k_values = tuple(
+                sorted({int(value) for value in metadata.get("k_values", ())})
+            )
+            if not k_values or any(value not in (3, 4, 5, 6) for value in k_values):
+                raise ValueError(
+                    "mixed rank-sliced EXL3 requires k_values within 3..6, got "
+                    f"{metadata.get('k_values')!r}"
+                )
+            if not isinstance(metadata.get("bits_per_expert"), str):
+                raise ValueError(
+                    "mixed rank-sliced EXL3 requires a bits_per_expert JSON reference"
+                )
+            self.bits = None
+            self.rank_sliced_k_values = k_values
+        else:
+            self.bits = float(bits_field)
+            self.rank_sliced_k_values = None
         self.codebook = str(metadata["codebook"])
         self.version = str(metadata.get("exllamav3_version", "rank-sliced"))
+
+    def _load_rank_sliced_bitrates(
+        self,
+        model_name: str,
+        *,
+        revision: str | None,
+    ) -> None:
+        assert self.rank_sliced_metadata is not None
+        reference = str(self.rank_sliced_metadata["bits_per_expert"])
+        try:
+            filename, field = reference.rsplit(":", 1)
+        except ValueError as exc:
+            raise ValueError(
+                "rank-sliced EXL3 bits_per_expert must use 'file.json:field' syntax, "
+                f"got {reference!r}"
+            ) from exc
+        payload = get_hf_file_to_dict(filename, model_name, revision=revision)
+        if not isinstance(payload, dict):
+            raise ValueError(f"rank-sliced EXL3 could not load {filename!r}")
+
+        experts = int(self.rank_sliced_metadata["experts_per_layer"])
+        first, last = (int(value) for value in self.rank_sliced_metadata["moe_layers"])
+        allowed = set(self.rank_sliced_k_values or ())
+        by_layer: dict[int, tuple[int, ...]] = {}
+        for layer_index in range(first, last + 1):
+            entry = payload.get(str(layer_index))
+            if not isinstance(entry, dict):
+                raise ValueError(
+                    f"rank-sliced EXL3 bitrate map is missing layer {layer_index}"
+                )
+            raw = entry.get(field)
+            # The GLM-5.2 MTP overlay records all routed experts under tail_tr3
+            # instead of repeating a 256-entry K3 vector.
+            if raw is None and len(entry.get("tail_tr3", ())) == experts:
+                raw = [3] * experts
+            if not isinstance(raw, list) or len(raw) != experts:
+                raise ValueError(
+                    "rank-sliced EXL3 bitrate map must contain one entry per expert: "
+                    f"layer={layer_index}, field={field!r}, expected={experts}"
+                )
+            bitrates = tuple(int(value) for value in raw)
+            unexpected = sorted(set(bitrates).difference(allowed))
+            if unexpected:
+                raise ValueError(
+                    f"rank-sliced EXL3 layer {layer_index} uses undeclared bitrates "
+                    f"{unexpected}; declared={sorted(allowed)}"
+                )
+            by_layer[layer_index] = bitrates
+        self.rank_sliced_bits_by_layer = by_layer
+
+    def rank_sliced_layer_bitrates(self, layer_name: str) -> tuple[int, ...]:
+        match = re.search(r"(?:^|\.)layers\.(\d+)(?:\.|$)", layer_name)
+        if match is None:
+            raise ValueError(
+                f"cannot resolve rank-sliced EXL3 layer index from {layer_name!r}"
+            )
+        layer_index = int(match.group(1))
+        if self.rank_sliced_k_values is None:
+            if self.bits is None or float(self.bits) != int(self.bits):
+                raise ValueError(f"invalid uniform EXL3 bitrate {self.bits!r}")
+            experts = int(self.rank_sliced_metadata["experts_per_layer"])
+            return (int(self.bits),) * experts
+        try:
+            return self.rank_sliced_bits_by_layer[layer_index]
+        except KeyError as exc:
+            raise ValueError(
+                f"rank-sliced EXL3 bitrate map has no layer {layer_index}"
+            ) from exc
 
     def apply_vllm_mapper(self, hf_to_vllm_mapper: WeightsMapper) -> None:
         # Keep both spellings: loader prefixes use vLLM names, while packed
@@ -1205,6 +1328,12 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             layer.exl3_is_draft = (
                 getattr(vllm_config.model_config, "runner_type", None) == "draft"
             )
+            layer.exl3_layer_bitrates = self.quant_config.rank_sliced_layer_bitrates(
+                str(layer.layer_name)
+            )
+            layer.exl3_mixed_bitrate = (
+                len(set(layer.exl3_layer_bitrates)) > 1
+            )
         for prefix, shard_ids in (("w13", ("w1", "w3")), ("w2", ("w2",))):
             for suffix in ("suh", "svh", "trellis", "mcg", "mul1"):
                 layer.register_parameter(
@@ -1213,7 +1342,13 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                         weight_loader=_exl3_moe_weight_loader,
                         num_experts=num_experts,
                         shard_ids=shard_ids,
-                        preallocate=rank_sliced and suffix in {"suh", "svh", "trellis"},
+                        preallocate=rank_sliced
+                        and suffix
+                        in (
+                            {"suh", "svh"}
+                            if getattr(layer, "exl3_mixed_bitrate", False)
+                            else {"suh", "svh", "trellis"}
+                        ),
                     ),
                 )
 
@@ -1394,16 +1529,189 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             return (64, 256, 64, 256)
         return (64, 128, 64, 128)
 
+    @staticmethod
+    def _mixed_trellis_tile_config(hidden_size: int, intermediate_size: int):
+        if hidden_size % 128 or intermediate_size % 128:
+            raise ValueError(
+                "mixed rank-sliced EXL3 requires hidden and intermediate "
+                "dimensions divisible by 128"
+            )
+        # The mixed K3/K4 megakernel needs a 128-wide FC1 K tile. The older
+        # 64x256 FC1 geometry loses partial reductions at large prefill M. A
+        # 512-wide FC2 tile then removes the second persistent wave on GLM-5.2.
+        if hidden_size % 512 == 0:
+            return (128, 128, 32, 512)
+        if hidden_size % 256 == 0:
+            return (128, 128, 64, 256)
+        return (128, 128, 128, 128)
+
+    def _prepare_mixed_rank_sliced_weights(self, layer: RoutedExperts) -> None:
+        api = _load_sparkinfer_mixed_trellis()
+        num_experts = int(layer.local_num_experts)
+        hidden_size = int(layer.exl3_hidden_size)
+        intermediate_size = int(layer.exl3_intermediate_size_per_partition)
+        bitrates = tuple(int(value) for value in layer.exl3_layer_bitrates)
+        if len(bitrates) != num_experts:
+            raise ValueError(
+                "mixed rank-sliced EXL3 bitrate count does not match experts: "
+                f"bitrates={len(bitrates)}, experts={num_experts}"
+            )
+        tiers = {
+            bits: tuple(
+                expert_id
+                for expert_id, expert_bits in enumerate(bitrates)
+                if expert_bits == bits
+            )
+            for bits in sorted(set(bitrates))
+        }
+        if len(tiers) != 2:
+            raise ValueError(
+                "the one-grid mixed Trellis path currently requires exactly two "
+                f"bitrates, got {tuple(tiers)}"
+            )
+
+        w13_param = layer.w13_trellis
+        w2_param = layer.w2_trellis
+        w13_shards = tuple(w13_param.exl3_shard_ids)
+        w2_shards = tuple(w2_param.exl3_shard_ids)
+        if w13_shards != ("w1", "w3") or w2_shards != ("w2",):
+            raise ValueError(
+                "mixed rank-sliced EXL3 requires w13=(w1,w3) and w2=(w2), got "
+                f"{w13_shards}/{w2_shards}"
+            )
+
+        gate_suh, up_suh = self._rank_sliced_backing(layer, "w13_suh")
+        gate_svh, up_svh = self._rank_sliced_backing(layer, "w13_svh")
+        down_suh = self._rank_sliced_backing(layer, "w2_suh")
+        down_svh = self._rank_sliced_backing(layer, "w2_svh")
+        device = gate_suh.device
+        tile_config = self._mixed_trellis_tile_config(
+            hidden_size, intermediate_size
+        )
+        prepared_tiers = []
+        tier_ids = []
+        for bits, expert_ids in tiers.items():
+            expected_last = 16 * bits
+            w13 = torch.stack(
+                tuple(
+                    torch.stack(
+                        tuple(
+                            w13_param.exl3_tensors[(expert_id, shard_id)]
+                            for expert_id in expert_ids
+                        )
+                    )
+                    for shard_id in w13_shards
+                )
+            ).contiguous()
+            w2 = torch.stack(
+                tuple(
+                    w2_param.exl3_tensors[(expert_id, "w2")]
+                    for expert_id in expert_ids
+                )
+            ).contiguous()
+            expected_w13 = (
+                2,
+                len(expert_ids),
+                hidden_size // 16,
+                intermediate_size // 16,
+                expected_last,
+            )
+            expected_w2 = (
+                len(expert_ids),
+                intermediate_size // 16,
+                hidden_size // 16,
+                expected_last,
+            )
+            if tuple(w13.shape) != expected_w13 or tuple(w2.shape) != expected_w2:
+                raise ValueError(
+                    f"mixed EXL3 K{bits} slab geometry mismatch: "
+                    f"w13={tuple(w13.shape)}, w2={tuple(w2.shape)}, "
+                    f"expected={expected_w13}/{expected_w2}"
+                )
+
+            index = torch.tensor(expert_ids, dtype=torch.long, device=device)
+            tier_gate_suh = gate_suh.index_select(0, index).contiguous()
+            tier_up_suh = up_suh.index_select(0, index).contiguous()
+            intermediate_rotations = torch.cat(
+                (
+                    gate_svh.index_select(0, index),
+                    up_svh.index_select(0, index),
+                    down_suh.index_select(0, index),
+                ),
+                dim=1,
+            ).contiguous()
+            tier_down_svh = down_svh.index_select(0, index).contiguous()
+            prepared_tiers.append(
+                api.prepare_weights(
+                    w13=w13,
+                    w2=w2,
+                    hidden_size=hidden_size,
+                    intermediate_size=intermediate_size,
+                    num_experts=len(expert_ids),
+                    activation=layer.activation.value,
+                    fc1_tile_n=tile_config[1],
+                    fc2_tile_n=tile_config[3],
+                    params_dtype=torch.float16,
+                    w13_layout="trellis3_t256_proj",
+                    trellis_bits=bits,
+                    codebook="mcg",
+                    gate_suh=tier_gate_suh,
+                    up_suh=tier_up_suh,
+                    intermediate_rotations=intermediate_rotations,
+                    down_svh=tier_down_svh,
+                    tile_config=tile_config,
+                    workspace=w13.view(torch.int32).reshape(-1)[:1],
+                )
+            )
+            tier_ids.append(expert_ids)
+
+        global_to_combined, descriptor_map = api.build_tiered_maps(
+            tier_ids[0], tier_ids[1], device=device
+        )
+        layer.exl3_mixed_trellis = {
+            "tiers": tuple(prepared_tiers),
+            "tier_ids": tuple(tier_ids),
+            "tier_bits": tuple(tiers),
+            "global_to_combined": global_to_combined,
+            "descriptor_map": descriptor_map,
+            "rotations": api.combine_trellis_rotations(*prepared_tiers),
+            "tile_config": tile_config,
+        }
+        layer.exl3_trellis_tile_config = tile_config
+
+        # The prepared tier objects own compact, tier-ordered copies. Release
+        # per-expert source tensors and the original rotation slabs now rather
+        # than retaining both representations for every layer.
+        for prefix in ("w13", "w2"):
+            for suffix in ("suh", "svh", "trellis", "mcg", "mul1"):
+                param = getattr(layer, f"{prefix}_{suffix}")
+                param.exl3_tensors.clear()
+                param.exl3_backing = None
+        logger.info(
+            "EXL3 mixed Trellis %s: tiers=%s",
+            layer.layer_name,
+            tuple((bits, len(ids)) for bits, ids in zip(tiers, tier_ids)),
+        )
+
     def _prepare_rank_sliced_weights(self, layer: RoutedExperts) -> None:
+        if getattr(layer, "exl3_mixed_bitrate", False):
+            self._prepare_mixed_rank_sliced_weights(layer)
+            return
         api = _load_sparkinfer_fused_moe()
         num_experts = int(layer.local_num_experts)
         hidden_size = int(layer.exl3_hidden_size)
         intermediate_size = int(layer.exl3_intermediate_size_per_partition)
-        bits = int(self.quant_config.bits or 0)
-        if float(bits) != self.quant_config.bits or bits not in (3, 4, 5, 6):
+        layer_bitrates = tuple(getattr(layer, "exl3_layer_bitrates", ()))
+        if len(set(layer_bitrates)) != 1:
+            raise ValueError(
+                "uniform rank-sliced EXL3 layer has invalid bitrates "
+                f"{layer_bitrates!r}"
+            )
+        bits = int(layer_bitrates[0])
+        if bits not in (3, 4, 5, 6):
             raise ValueError(
                 "rank-sliced EXL3 requires an integral 3/4/5/6 bitrate, got "
-                f"{self.quant_config.bits!r}"
+                f"{bits!r}"
             )
 
         w13 = self._rank_sliced_backing(layer, "w13_trellis")
@@ -1496,6 +1804,149 @@ class Exl3MoEMethod(FusedMoEMethodBase):
     @property
     def topk_indices_dtype(self) -> torch.dtype | None:
         return torch.long
+
+    def _mixed_rank_sliced_runtime(
+        self,
+        layer: RoutedExperts,
+        x: torch.Tensor,
+        topk_ids: torch.Tensor,
+    ) -> dict[str, Any]:
+        mixed = layer.exl3_mixed_trellis
+        max_decode_m = _positive_env_int("VLLM_EXL3_TRELLIS_MAX_M", 32)
+        max_batched_tokens = int(layer.exl3_max_num_batched_tokens)
+        if max_decode_m > max_batched_tokens:
+            max_decode_m = max_batched_tokens
+        topk = int(topk_ids.shape[1])
+        tier_signature = tuple(
+            (int(bits), len(ids))
+            for bits, ids in zip(mixed["tier_bits"], mixed["tier_ids"])
+        )
+        key = (
+            _runtime_owner_token(self.quant_config, layer),
+            x.device.index,
+            x.dtype,
+            topk_ids.dtype,
+            int(layer.exl3_hidden_size),
+            int(layer.exl3_intermediate_size_per_partition),
+            tier_signature,
+            topk,
+            max_decode_m,
+            max_batched_tokens,
+            mixed["tile_config"],
+        )
+        runtime = _MIXED_TRELLIS_RUNTIMES.get(key)
+        if runtime is not None:
+            return runtime
+        if torch.cuda.is_current_stream_capturing():
+            raise RuntimeError(
+                "Mixed-bitrate EXL3 runtime must be compiled during the eager "
+                "profile pass before CUDA graph capture"
+            )
+        if topk_ids.dtype not in (torch.int32, torch.int64):
+            raise TypeError(
+                "mixed-bitrate EXL3 requires int32/int64 route IDs, got "
+                f"{topk_ids.dtype}"
+            )
+
+        api = _load_sparkinfer_mixed_trellis()
+        device = x.device
+        props = torch.cuda.get_device_properties(device)
+        total_experts = sum(experts for _, experts in tier_signature)
+
+        def make_state(capacity: int) -> dict[str, Any]:
+            route_slots = api.max_packed_route_slots(capacity * topk, 8, total_experts)
+            launch = api.compile_mixed_trellis(
+                size_m=capacity,
+                hidden_size=int(layer.exl3_hidden_size),
+                intermediate_size=int(layer.exl3_intermediate_size_per_partition),
+                tier0_num_experts=tier_signature[0][1],
+                tier1_num_experts=tier_signature[1][1],
+                tier0_bits=tier_signature[0][0],
+                tier1_bits=tier_signature[1][0],
+                top_k=topk,
+                max_m_blocks=(route_slots + 7) // 8,
+                sms=int(props.multi_processor_count),
+                max_shared_mem=int(props.shared_memory_per_block_optin),
+                force_tile_config=mixed["tile_config"],
+                rotation_input_dtype=("bf16" if x.dtype == torch.bfloat16 else "fp16"),
+                route_ids_dtype=topk_ids.dtype,
+            )
+            return {
+                "capacity": capacity,
+                "launch": launch,
+                "buffers": api.make_mixed_trellis_buffers(
+                    launch,
+                    device=device,
+                    sms=int(props.multi_processor_count),
+                ),
+            }
+
+        decode = make_state(max_decode_m)
+        prefill = (
+            make_state(max_batched_tokens)
+            if max_batched_tokens > max_decode_m
+            else decode
+        )
+        runtime = {
+            "api": api,
+            "decode": decode,
+            "prefill": prefill,
+            "max_decode_m": max_decode_m,
+            "max_batched_tokens": max_batched_tokens,
+        }
+        _MIXED_TRELLIS_RUNTIMES[key] = runtime
+        buffer_bytes = 0
+        seen: set[tuple[int, int]] = set()
+        for state in (decode, prefill):
+            for tensor in vars(state["buffers"]).values():
+                storage = tensor.untyped_storage()
+                storage_key = (storage.data_ptr(), storage.nbytes())
+                if storage_key not in seen:
+                    seen.add(storage_key)
+                    buffer_bytes += storage.nbytes()
+        logger.info_once(
+            "EXL3 mixed Trellis runtime planned: tiers=%s decode_capacity=%d "
+            "prefill_capacity=%d buffers=%.1f MiB",
+            tier_signature,
+            max_decode_m,
+            max_batched_tokens,
+            buffer_bytes / (1 << 20),
+        )
+        return runtime
+
+    def _apply_mixed_rank_sliced(
+        self,
+        layer: RoutedExperts,
+        x: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+    ) -> torch.Tensor:
+        runtime = self._mixed_rank_sliced_runtime(layer, x, topk_ids)
+        m = int(x.shape[0])
+        if m > runtime["max_batched_tokens"]:
+            raise ValueError(
+                "mixed-bitrate EXL3 batch exceeds planned capacity: "
+                f"m={m}, capacity={runtime['max_batched_tokens']}"
+            )
+        state = (
+            runtime["decode"]
+            if m <= runtime["max_decode_m"]
+            else runtime["prefill"]
+        )
+        mixed = layer.exl3_mixed_trellis
+        output = runtime["api"].run_mixed_trellis(
+            x,
+            mixed["tiers"][0],
+            mixed["tiers"][1],
+            topk_weights,
+            topk_ids,
+            mixed["global_to_combined"],
+            mixed["descriptor_map"],
+            mixed["rotations"],
+            state["launch"],
+            state["buffers"],
+        )
+        return output.to(x.dtype)
 
     def _rank_sliced_runtime(
         self,
@@ -1735,6 +2186,13 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         topk_weights: torch.Tensor,
         topk_ids: torch.Tensor,
     ) -> torch.Tensor:
+        if getattr(layer, "exl3_mixed_bitrate", False):
+            return self._apply_mixed_rank_sliced(
+                layer,
+                x,
+                topk_weights,
+                topk_ids,
+            )
         runtime = self._rank_sliced_runtime(layer, x, topk_ids)
         m = int(x.shape[0])
         if runtime["min_trellis_m"] <= m <= runtime["max_trellis_m"]:

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -82,18 +82,27 @@ _DEFAULT_TRELLIS_MIN_M = 4
 
 
 def _is_draft_layer(layer: Any) -> bool:
-    """True for a rank-sliced MTP/EAGLE draft MoE layer.
+    """True for a rank-sliced MTP/nextn/eagle draft MoE layer.
 
-    Derived from the layer prefix rather than the quant config, because config
-    identity is not a reliable role signal: only some MTP model files build the
-    draft a fresh ``Exl3Config``. Several (e.g. ``glm4_moe_mtp``, ``qwen3_next_mtp``,
-    ``deepseek_eagle``) pass ``vllm_config.quant_config`` straight through, which
-    makes the draft's scope identical to the target's and silently restores the
-    shared-scratch corruption this scoping exists to prevent.
+    The role is stamped (``exl3_is_draft = True``) on every draft-owned module
+    by ``load_eagle_model`` at draft construction, which is the single funnel
+    every speculator draft passes through. It is NOT inferable here: a
+    GLM-5.2-style MTP head is an extra decoder layer named exactly like a
+    target layer (``model.layers.78.*`` with ``num_hidden_layers = 78``), and
+    this function runs at plan/capture/forward time, when
+    ``set_current_vllm_config`` has already exited and
+    ``get_current_vllm_config_or_none()`` returns None -- so both name and
+    layer-index inference silently fail. The substring fallback below covers
+    drafts built outside ``load_eagle_model``.
     """
+    stamped = getattr(layer, "exl3_is_draft", None)
+    if stamped is not None:
+        return bool(stamped)
     name = str(getattr(layer, "layer_name", "") or getattr(layer, "prefix", ""))
-    return any(t in name for t in (".mtp", "mtp.", "nextn", "eagle", "draft",
-                                   "speculator"))
+    return any(
+        token in name
+        for token in (".mtp", "mtp.", "nextn", "eagle", "draft", "speculator")
+    )
 
 
 def _runtime_owner_token(quant_config: Any, layer: Any) -> tuple[int, bool]:
@@ -200,7 +209,20 @@ def _load_sparkinfer_trellis() -> Any:
 
 
 def _positive_env_int(name: str, default: int) -> int:
-    value = int(os.environ.get(name, default))
+    # An env var that is present but blank means "unset". Compose and Kubernetes
+    # both render an unset variable as the empty string, so int("") would abort
+    # engine startup with a bare
+    #   ValueError: invalid literal for int() with base 10: ''
+    # that names neither the variable nor the fix.
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        value = int(raw.strip())
+    except ValueError:
+        raise ValueError(
+            f"{name} must be a positive integer or unset, got {raw!r}"
+        ) from None
     if value <= 0:
         raise ValueError(f"{name} must be positive, got {value}")
     return value
@@ -1161,6 +1183,18 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 )
             layer.exl3_max_num_batched_tokens = int(
                 scheduler_config.max_num_batched_tokens
+            )
+            # Stamp the layer role while the model-construction config context
+            # is still active. Forward time (the profile pass and CUDA graph
+            # capture) runs with no current vllm config, so neither name- nor
+            # index-based detection can resolve the role there -- a GLM-5.2
+            # style MTP head is named exactly like a target layer
+            # (model.layers.<num_hidden_layers>.*). runner_type is minted as
+            # "draft" for every model-backed speculator draft
+            # (SpeculativeConfig.__post_init__ -> ModelConfig(runner="draft")),
+            # which also covers speculators that bypass load_eagle_model.
+            layer.exl3_is_draft = (
+                getattr(vllm_config.model_config, "runner_type", None) == "draft"
             )
         for prefix, shard_ids in (("w13", ("w1", "w3")), ("w2", ("w2",))):
             for suffix in ("suh", "svh", "trellis", "mcg", "mul1"):

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -78,8 +78,10 @@ _NEXT_RUNTIME_SCOPE_ID = 0
 # instead of failing at capture time.
 MIN_CAPTURABLE_TRELLIS_M = 1
 
-# Historical default for non-captured (target) layers.
-_DEFAULT_TRELLIS_MIN_M = 4
+# Target execution also reaches m=1..3 during profiling and small-batch decode.
+# Keep every supported row count on the native path by default; operators may
+# still raise the threshold explicitly as a diagnostic kill switch.
+_DEFAULT_TRELLIS_MIN_M = MIN_CAPTURABLE_TRELLIS_M
 
 
 def _is_draft_layer(layer: Any) -> bool:
@@ -1501,26 +1503,21 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         x: torch.Tensor,
         topk_ids: torch.Tensor,
     ) -> dict[str, Any]:
-        # A rank-sliced draft layer is CUDA-graph captured at small row counts
-        # (m = draft rows per step, typically 1..3). If m falls outside the
-        # Trellis window the eager parity path is reached, which is illegal
-        # during capture -- the engine then cannot start at all:
+        # Rank-sliced target and draft layers both reach small row counts
+        # (typically m=1..3) during profiling, decode, or CUDA-graph capture. If
+        # m falls outside the Trellis window the eager parity path is reached;
+        # under capture that is illegal and during eager execution it adds an
+        # avoidable external-extension ABI dependency:
         #
         #   RuntimeError: EXL3 eager parity path entered during CUDA graph
         #   capture (m=3); capture sizes must lie inside the Trellis window
         #   [4, 32]
         #
-        # That was previously worked around by asking every operator to set
-        # VLLM_EXL3_TRELLIS_MIN_M=1 by hand. A backend should satisfy its own
-        # capture contract instead, so draft layers default the window down to
-        # MIN_CAPTURABLE_TRELLIS_M. An explicit env value still wins, and the
-        # target path keeps its original default.
-        default_min_m = (
-            MIN_CAPTURABLE_TRELLIS_M
-            if _is_draft_layer(layer)
-            else _DEFAULT_TRELLIS_MIN_M
+        # The backend therefore owns one capability-based default for both
+        # roles. An explicit env value remains authoritative for diagnostics.
+        min_trellis_m = _positive_env_int(
+            "VLLM_EXL3_TRELLIS_MIN_M", _DEFAULT_TRELLIS_MIN_M
         )
-        min_trellis_m = _positive_env_int("VLLM_EXL3_TRELLIS_MIN_M", default_min_m)
         max_trellis_m = _positive_env_int("VLLM_EXL3_TRELLIS_MAX_M", 32)
         block_m = _positive_env_int("VLLM_EXL3_TRELLIS_BLOCK_M", 8)
         chunk = _positive_env_int("VLLM_EXL3_PREFILL_CHUNK", 128)
@@ -1586,7 +1583,10 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             caps = api.Caps(
                 max_tokens=plan_max_tokens,
                 num_topk=topk,
-                route_num_experts=int(layer.local_num_experts),
+                # vLLM supplies final top-k IDs/weights to bind(); the fused-MoE
+                # router workspace is unused. A zero route-workspace request
+                # still lets the W4A16 core derive route_E from weight_E.
+                route_num_experts=0,
                 device=x.device,
                 weight_plan=layer.exl3_trellis_weights.plan,
                 quant_mode="w4a16",

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -1546,7 +1546,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 topk_ids=topk_ids,
             )
             output = runtime["api"].run(binding=binding)
-            return output.to(x.dtype).clone()
+            return output.to(x.dtype)
 
         if m > runtime["max_batched_tokens"]:
             raise ValueError(
@@ -1589,7 +1589,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 0.0,
                 0,
             )
-            return out32.to(x.dtype).clone()
+            return out32.to(x.dtype)
 
         local_ids = layer.exl3_expert_map[topk_ids.long()]
         half_weights = topk_weights.to(torch.float16)
@@ -1631,7 +1631,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 False,
                 0.0,
             )
-        return out32.to(x.dtype).clone()
+        return out32.to(x.dtype)
 
     def apply(
         self,

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -68,6 +68,41 @@ _HADAMARD_BLOCK = 128
 _EXL3_EXT: Any | None = None
 _SPARKINFER_TRELLIS_API: Any | None = None
 _RANK_SLICED_RUNTIMES: dict[tuple[Any, ...], dict[str, Any]] = {}
+_NEXT_RUNTIME_SCOPE_ID = 0
+
+
+def _runtime_scope_id(quant_config: Any) -> int:
+    """Stable identity for the model that owns a rank-sliced runtime.
+
+    A cached runtime owns mutable Trellis/prefill scratch plus parity staging and
+    sort buffers, so an entry must never be shared across models. A target MoE
+    layer and a rank-sliced MTP draft layer have identical shapes, topk and
+    planner settings -- both read ``max_num_batched_tokens`` from the same
+    scheduler config -- so a shape-only key makes the draft reuse the target's
+    scratch. That defeats the target/draft resource isolation their
+    independently captured CUDA graphs rely on.
+
+    Scoping by the owning quant config is deliberately coarser than per-layer:
+    the draft is built with its own ``Exl3Config`` while every layer of one model
+    shares a single config, so each model gets exactly one runtime. The prefill
+    arena alone is ~1 GiB, so per-layer runtimes would cost tens of GiB per rank
+    on a 75+ layer model and are not affordable.
+    """
+    global _NEXT_RUNTIME_SCOPE_ID
+    scope = getattr(quant_config, "_exl3_runtime_scope_id", None)
+    if scope is not None:
+        return scope
+    scope = _NEXT_RUNTIME_SCOPE_ID
+    _NEXT_RUNTIME_SCOPE_ID += 1
+    try:
+        quant_config._exl3_runtime_scope_id = scope
+    except AttributeError:
+        # Frozen/slotted config: fall back to object identity. Configs live for
+        # the process lifetime, so reuse-after-GC aliasing is not a concern here.
+        return id(quant_config)
+    return scope
+
+
 _RANK_SLICED_FORMAT = "exl3-trellis"
 _RANK_SLICED_WEIGHT_RE = re.compile(
     r"^(?P<prefix>.+)\.rank(?P<rank>\d+)\."
@@ -1385,6 +1420,10 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         topk = int(topk_ids.shape[1])
         device_index = x.device.index
         key = (
+            # Owning model scope first: the cached runtime holds mutable scratch,
+            # so a target layer and a same-shape rank-sliced MTP draft layer must
+            # not share an entry (see _runtime_scope_id).
+            _runtime_scope_id(self.quant_config),
             device_index,
             x.dtype,
             int(layer.exl3_hidden_size),

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -3,29 +3,17 @@
 
 """EXL3 (ExLlamaV3 trellis) quantization support.
 
-Compute paths, in selection order:
+Rank-sliced routed-expert checkpoints use Sparkinfer's planned full-rotation
+Trellis MoE API for the decode window and the ExLlamaV3 extension for larger
+prefill batches. Generic dense and non-rank-sliced MoE checkpoints use the
+bit-faithful ``exllamav3_ext.exl3_gemm`` parity path. Every logical checkpoint
+matrix is dispatched independently: vLLM's packed QKV and gate/up modules are
+not treated as one EXL3 matrix because each source matrix owns its Hadamard
+vectors and codebook marker.
 
-1. **Fused path (primary).** Modules whose checkpoint carries the MCG codebook
-   marker run through the b12x fused CuTeDSL trellis kernel
-   (``b12x.moe.fused.w4a16.run_trellis256_dense``): native EXL3 storage is
-   consumed zero-copy at 3/4/5/6 bpw, the full input-rotation -> GEMM ->
-   output-rotation chain executes as one compiled artifact, and the output is
-   byte-identical across batch size m — a property the split upstream
-   GEMV/GEMM/reconstruct ladder does not have. Selection happens once per
-   shard at weight-processing time; ineligible shards (legacy ``default`` or
-   MUL1 codebooks, or shapes the kernel rejects) fall back per-shard.
-2. **Parity path (fallback + oracle).** The bit-faithful wrapper around
-   ``exllamav3_ext.exl3_gemm``. Every logical checkpoint matrix is dispatched
-   independently: vLLM's packed QKV and gate/up modules are *not* treated as
-   one EXL3 matrix — each source matrix owns its own Hadamard vectors and
-   codebook marker.
-
-``VLLM_EXL3_FUSED=0`` forces the parity path everywhere (A/B switch).
-``VLLM_EXL3_LOG_PATH_SELECTION=1`` logs the chosen path per shard.
-
-Both the extension and the b12x package are imported lazily.  Importing this
-module, parsing checkpoint metadata, or compiling it with ``py_compile`` does
-not load either one or initialize CUDA.
+Both dependencies are imported lazily. Importing this module, parsing
+checkpoint metadata, or compiling it with ``py_compile`` does not load either
+one or initialize CUDA.
 """
 
 from __future__ import annotations
@@ -33,17 +21,18 @@ from __future__ import annotations
 import ctypes
 import importlib
 import os
+import re
 import sys
 from typing import TYPE_CHECKING, Any
 
 import torch
 from transformers import PretrainedConfig
 
+from vllm.config import get_current_vllm_config_or_none
 from vllm.distributed import (
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
 )
-from vllm.config import get_current_vllm_config_or_none
 from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe import (
     FusedMoEMethodBase,
@@ -77,6 +66,13 @@ _MCG_SENTINEL = 0xCBAC1FED
 _MUL1_SENTINEL = 0x83DCD12D
 _HADAMARD_BLOCK = 128
 _EXL3_EXT: Any | None = None
+_SPARKINFER_TRELLIS_API: Any | None = None
+_RANK_SLICED_RUNTIMES: dict[tuple[Any, ...], dict[str, Any]] = {}
+_RANK_SLICED_FORMAT = "exl3-trellis"
+_RANK_SLICED_WEIGHT_RE = re.compile(
+    r"^(?P<prefix>.+)\.rank(?P<rank>\d+)\."
+    r"(?P<field>trellis|suh|svh|mcg|mul1)$"
+)
 
 ShardId = str | int | tuple[int, ...] | None
 
@@ -115,6 +111,30 @@ def _load_exl3_ext() -> Any:
         )
     _EXL3_EXT = ext
     return ext
+
+
+def _load_sparkinfer_trellis() -> Any:
+    """Resolve the public planned Trellis MoE API lazily."""
+
+    global _SPARKINFER_TRELLIS_API
+    if _SPARKINFER_TRELLIS_API is not None:
+        return _SPARKINFER_TRELLIS_API
+    try:
+        from sparkinfer.moe import trellis_moe
+    except Exception as exc:
+        raise RuntimeError(
+            "Rank-sliced EXL3 requires sparkinfer.moe.trellis_moe. Install "
+            "a Sparkinfer build containing the planned full-rotation API."
+        ) from exc
+    _SPARKINFER_TRELLIS_API = trellis_moe
+    return trellis_moe
+
+
+def _positive_env_int(name: str, default: int) -> int:
+    value = int(os.environ.get(name, default))
+    if value <= 0:
+        raise ValueError(f"{name} must be positive, got {value}")
+    return value
 
 
 @torch.library.custom_op(
@@ -171,87 +191,6 @@ def _exl3_gemm_fake(
     )
 
 
-_B12X_UNAVAILABLE = object()
-_B12X_DENSE_API: Any = None
-
-
-def _fused_mode_enabled() -> bool:
-    return os.environ.get("VLLM_EXL3_FUSED", "1") == "1"
-
-
-def _load_b12x_dense() -> Any:
-    """Resolve the b12x fused dense entry points once, without hard-failing.
-
-    Returns a ``(prepare_trellis256_dense_weight, run_trellis256_dense)``
-    tuple, or None when the fused path is disabled or the b12x package is not
-    importable.  The parity path through exllamav3_ext remains the fallback
-    either way.  This backend requires eager execution (see
-    ``_require_enforce_eager``), so the fused call does not need an opaque
-    torch.library wrapper.
-    """
-    global _B12X_DENSE_API
-    if _B12X_DENSE_API is _B12X_UNAVAILABLE:
-        return None
-    if _B12X_DENSE_API is not None:
-        return _B12X_DENSE_API
-    if not _fused_mode_enabled():
-        _B12X_DENSE_API = _B12X_UNAVAILABLE
-        return None
-    try:
-        # The fused dense entry performs its outer rotations through
-        # exllamav3_ext.had_r_128, and b12x imports that extension by module
-        # name. Resolve it here through the same VLLM_EXL3_ABI_SHIM /
-        # VLLM_EXL3_EXT_PATH contract as the parity path so b12x sees the
-        # shimmed, correctly-located extension instead of whatever an
-        # unshimmed site-packages import would find.
-        _load_exl3_ext()
-        from b12x.moe.fused.w4a16 import (
-            prepare_trellis256_dense_weight,
-            run_trellis256_dense,
-        )
-    except Exception:
-        logger.warning(
-            "EXL3: the b12x fused trellis kernel is not importable; every "
-            "module will use the bit-faithful exllamav3_ext parity path."
-        )
-        _B12X_DENSE_API = _B12X_UNAVAILABLE
-        return None
-    _B12X_DENSE_API = (prepare_trellis256_dense_weight, run_trellis256_dense)
-    return _B12X_DENSE_API
-
-
-def _log_path_selection(prefix: str, chosen: str, reason: str) -> None:
-    if os.environ.get("VLLM_EXL3_LOG_PATH_SELECTION") == "1":
-        logger.info("EXL3 path %s -> %s (%s)", prefix, chosen, reason)
-
-
-def _try_prepare_fused(
-    prefix: str,
-    trellis: torch.Tensor,
-    suh: torch.Tensor,
-    svh: torch.Tensor,
-    mcg: torch.Tensor | None,
-    mul1: torch.Tensor | None,
-) -> Any | None:
-    """Prepare one shard for the fused kernel; None selects the parity path."""
-    api = _load_b12x_dense()
-    if api is None:
-        return None
-    if mcg is None or mul1 is not None:
-        # The fused t256 decoder implements the MCG codebook only.  Legacy
-        # "default"-codebook and MUL1 checkpoints stay on the parity path.
-        _log_path_selection(prefix, "parity", "non-MCG codebook")
-        return None
-    prepare, _ = api
-    try:
-        prepared = prepare(trellis, suh, svh, mcg=mcg)
-    except Exception as exc:
-        _log_path_selection(prefix, "parity", f"prepare rejected: {exc}")
-        return None
-    _log_path_selection(prefix, "fused", "mcg")
-    return prepared
-
-
 class Exl3Config(QuantizationConfig):
     """Configuration for modern and legacy EXL3 trellis checkpoints."""
 
@@ -270,6 +209,7 @@ class Exl3Config(QuantizationConfig):
         self.version = version
         self.tensor_storage = tensor_storage or {}
         self._eager_checked = False
+        self.rank_sliced_metadata: dict[str, Any] | None = None
 
     def get_name(self) -> str:
         return "exl3"
@@ -288,7 +228,7 @@ class Exl3Config(QuantizationConfig):
         return ["quantization_config.json"]
 
     @classmethod
-    def from_config(cls, config: dict[str, Any]) -> "Exl3Config":
+    def from_config(cls, config: dict[str, Any]) -> Exl3Config:
         return cls(
             bits=config.get("bits"),
             head_bits=config.get("head_bits"),
@@ -297,12 +237,35 @@ class Exl3Config(QuantizationConfig):
             tensor_storage=config.get("tensor_storage"),
         )
 
+    @classmethod
+    def override_quantization_method(
+        cls,
+        hf_quant_cfg: dict[str, Any],
+        user_quant: str | None,
+        hf_config: PretrainedConfig | None = None,
+    ) -> str | None:
+        del hf_quant_cfg
+        if user_quant is not None and user_quant != "exl3":
+            return None
+        metadata = getattr(hf_config, "hybrid_tr3_tail", None)
+        if isinstance(metadata, dict) and metadata.get("format") == _RANK_SLICED_FORMAT:
+            return "exl3"
+        return None
+
     def maybe_update_config(
         self,
         model_name: str,
         hf_config: PretrainedConfig | None = None,
         revision: str | None = None,
     ) -> None:
+        rank_sliced = getattr(hf_config, "hybrid_tr3_tail", None)
+        if (
+            isinstance(rank_sliced, dict)
+            and rank_sliced.get("format") == _RANK_SLICED_FORMAT
+        ):
+            self._configure_rank_sliced(rank_sliced)
+            return
+
         # vLLM returns the summary embedded in config.json without consulting
         # get_config_filenames().  Hydrate the per-module records explicitly.
         if not self.tensor_storage:
@@ -329,7 +292,47 @@ class Exl3Config(QuantizationConfig):
         self._validate_storage_metadata()
         self._force_independent_lm_head(hf_config)
 
-    def apply_vllm_mapper(self, hf_to_vllm_mapper: "WeightsMapper") -> None:
+    def _configure_rank_sliced(self, metadata: dict[str, Any]) -> None:
+        required = {
+            "bits",
+            "codebook",
+            "experts_per_layer",
+            "moe_layers",
+            "tensor_schema",
+            "tp",
+        }
+        missing = sorted(required.difference(metadata))
+        if missing:
+            raise ValueError(
+                "rank-sliced EXL3 metadata is missing: " + ", ".join(missing)
+            )
+        if metadata["codebook"] != "mcg":
+            raise ValueError(
+                "rank-sliced EXL3 currently requires the MCG codebook, got "
+                f"{metadata['codebook']!r}"
+            )
+        layers = metadata["moe_layers"]
+        if (
+            not isinstance(layers, list)
+            or len(layers) != 2
+            or int(layers[0]) < 0
+            or int(layers[1]) < int(layers[0])
+        ):
+            raise ValueError("rank-sliced EXL3 moe_layers must be [first, last]")
+        expected_schema = (
+            "model.layers.{L}.mlp.experts.{E}.{proj}.rank{r}.{trellis|suh|svh|mcg}"
+        )
+        if metadata["tensor_schema"] != expected_schema:
+            raise ValueError(
+                "unsupported rank-sliced EXL3 tensor schema: "
+                f"{metadata['tensor_schema']!r}"
+            )
+        self.rank_sliced_metadata = dict(metadata)
+        self.bits = float(metadata["bits"])
+        self.codebook = str(metadata["codebook"])
+        self.version = str(metadata.get("exllamav3_version", "rank-sliced"))
+
+    def apply_vllm_mapper(self, hf_to_vllm_mapper: WeightsMapper) -> None:
         # Keep both spellings: loader prefixes use vLLM names, while packed
         # source-matrix discovery intentionally refers to the unstacked HF name.
         mapped = hf_to_vllm_mapper.apply_dict(self.tensor_storage)
@@ -381,6 +384,10 @@ class Exl3Config(QuantizationConfig):
             )
 
     def _require_enforce_eager(self) -> None:
+        if self.rank_sliced_metadata is not None:
+            # The routed-expert fast path is eagerly planned before graph
+            # capture. Only its large-M parity fallback remains eager.
+            return
         # exllamav3_ext's exl3_gemm autotunes with timing launches on the first
         # call per (m-bucket, k, n, K) shape hash; under CUDA-graph capture
         # those launches fault, and m-bucketing means a warmup pass cannot
@@ -464,6 +471,12 @@ class Exl3Config(QuantizationConfig):
     def _moe_prefix_is_exl3(
         self, prefix: str, layer: torch.nn.Module | None = None
     ) -> bool:
+        if self.rank_sliced_metadata is not None:
+            match = re.search(r"layers\.(\d+)\b", prefix)
+            if match is None:
+                return False
+            first, last = (int(v) for v in self.rank_sliced_metadata["moe_layers"])
+            return first <= int(match.group(1)) <= last
         # Use the layer's checkpoint projection names (the same fields
         # _validate_codebooks keys off) so remapped-projection MoE
         # checkpoints are still detected; fall back to the defaults when the
@@ -486,6 +499,12 @@ class Exl3Config(QuantizationConfig):
         )
 
     def codebook_for_prefix(self, prefix: str) -> str | None:
+        if self.rank_sliced_metadata is not None:
+            match = re.search(r"layers\.(\d+)\b", prefix)
+            if match is None:
+                return None
+            first, last = (int(v) for v in self.rank_sliced_metadata["moe_layers"])
+            return "mcg" if first <= int(match.group(1)) <= last else None
         entry = self._storage_entry(prefix)
         if entry is None:
             return None
@@ -498,6 +517,17 @@ class Exl3Config(QuantizationConfig):
 
     def has_quantized_lm_head(self) -> bool:
         return self._is_exl3_prefix("lm_head")
+
+    def normalize_rank_sliced_weight_name(self, name: str) -> str | None:
+        """Drop non-local TP payloads and remove the serialized rank segment."""
+        if self.rank_sliced_metadata is None:
+            return name
+        match = _RANK_SLICED_WEIGHT_RE.match(name)
+        if match is None:
+            return name
+        if int(match.group("rank")) != get_tensor_model_parallel_rank():
+            return None
+        return f"{match.group('prefix')}.{match.group('field')}"
 
 
 class Exl3Parameter(BasevLLMParameter):
@@ -631,22 +661,6 @@ class Exl3LinearMethod(LinearMethodBase):
                 param.exl3_tensors[shard_id] = tensor.to(
                     device=device, non_blocking=True
                 ).contiguous()
-
-        fused: dict[ShardId, Any] = {}
-        if _fused_mode_enabled():
-            prefix = getattr(layer, "prefix", layer.__class__.__name__)
-            for shard_id in layer.exl3_shard_ids:
-                prepared = _try_prepare_fused(
-                    f"{prefix}[{shard_id!r}]",
-                    layer.trellis.exl3_tensors[shard_id],
-                    layer.suh.exl3_tensors[shard_id],
-                    layer.svh.exl3_tensors[shard_id],
-                    layer.mcg.exl3_tensors.get(shard_id),
-                    layer.mul1.exl3_tensors.get(shard_id),
-                )
-                if prepared is not None:
-                    fused[shard_id] = prepared
-        layer.exl3_fused_prepared = fused
 
     def apply(
         self,
@@ -901,20 +915,14 @@ class Exl3LinearMethod(LinearMethodBase):
             )
         if x.shape[-1] < packed_k:
             x = torch.nn.functional.pad(x, (0, packed_k - x.shape[-1]))
-        prepared = getattr(layer, "exl3_fused_prepared", {}).get(shard_id)
-        if prepared is not None:
-            api = _load_b12x_dense()
-            assert api is not None
-            output = api[1](x, prepared)
-        else:
-            output = _exl3_gemm(
-                x,
-                trellis,
-                layer.suh.exl3_tensors[shard_id],
-                layer.svh.exl3_tensors[shard_id],
-                shard_id in layer.mcg.exl3_tensors,
-                shard_id in layer.mul1.exl3_tensors,
-            )
+        output = _exl3_gemm(
+            x,
+            trellis,
+            layer.suh.exl3_tensors[shard_id],
+            layer.svh.exl3_tensors[shard_id],
+            shard_id in layer.mcg.exl3_tensors,
+            shard_id in layer.mul1.exl3_tensors,
+        )
         logical_n = Exl3LinearMethod._output_shard_size(layer, shard_id)
         if output.shape[-1] < logical_n:
             raise ValueError(
@@ -924,15 +932,80 @@ class Exl3LinearMethod(LinearMethodBase):
 
 
 class Exl3MoEParameter(BasevLLMParameter):
-    """Zero-sized parameter holding EXL3 tensors by expert and projection."""
+    """EXL3 tensors keyed by expert/projection, optionally in one GPU slab."""
 
-    def __new__(cls, *, weight_loader):
+    def __new__(
+        cls,
+        *,
+        weight_loader,
+        num_experts: int = 0,
+        shard_ids: tuple[str, ...] = (),
+        preallocate: bool = False,
+    ):
+        del num_experts, shard_ids, preallocate
         data = torch.empty(0, dtype=torch.uint8)
         return super().__new__(cls, data=data, weight_loader=weight_loader)
 
-    def __init__(self, *, weight_loader):
+    def __init__(
+        self,
+        *,
+        weight_loader,
+        num_experts: int = 0,
+        shard_ids: tuple[str, ...] = (),
+        preallocate: bool = False,
+    ):
         self.exl3_tensors: dict[tuple[int, str], torch.Tensor] = {}
+        self.exl3_backing: torch.Tensor | None = None
+        self.exl3_num_experts = int(num_experts)
+        self.exl3_shard_ids = tuple(shard_ids)
+        self.exl3_preallocate = bool(preallocate)
         super().__init__(data=self.data, weight_loader=weight_loader)
+
+    def load_exl3_weight(
+        self,
+        loaded_weight: torch.Tensor,
+        *,
+        expert_id: int,
+        shard_id: str,
+    ) -> None:
+        key = (int(expert_id), str(shard_id))
+        if not self.exl3_preallocate:
+            self.exl3_tensors[key] = loaded_weight.contiguous()
+            return
+        if self.exl3_num_experts <= 0 or shard_id not in self.exl3_shard_ids:
+            raise ValueError(
+                f"invalid EXL3 slab key expert={expert_id}, shard={shard_id!r}"
+            )
+        if not 0 <= int(expert_id) < self.exl3_num_experts:
+            raise ValueError(
+                f"EXL3 expert {expert_id} is outside [0, {self.exl3_num_experts})"
+            )
+        if self.device.type == "meta":
+            raise RuntimeError("rank-sliced EXL3 slabs cannot be allocated on meta")
+        if self.exl3_backing is None:
+            prefix = (
+                (len(self.exl3_shard_ids), self.exl3_num_experts)
+                if len(self.exl3_shard_ids) > 1
+                else (self.exl3_num_experts,)
+            )
+            self.exl3_backing = torch.empty(
+                prefix + tuple(loaded_weight.shape),
+                dtype=loaded_weight.dtype,
+                device=self.device,
+            )
+        shard_index = self.exl3_shard_ids.index(shard_id)
+        target = (
+            self.exl3_backing[shard_index, expert_id]
+            if len(self.exl3_shard_ids) > 1
+            else self.exl3_backing[expert_id]
+        )
+        if tuple(target.shape) != tuple(loaded_weight.shape):
+            raise ValueError(
+                "rank-sliced EXL3 tensor shape changed within one slab: "
+                f"expected={tuple(target.shape)}, got={tuple(loaded_weight.shape)}"
+            )
+        target.copy_(loaded_weight, non_blocking=True)
+        self.exl3_tensors[key] = target
 
 
 def _exl3_moe_weight_loader(
@@ -944,7 +1017,11 @@ def _exl3_moe_weight_loader(
     return_success: bool = False,
 ) -> bool | None:
     del weight_name
-    param.exl3_tensors[(expert_id, shard_id)] = loaded_weight.contiguous()
+    param.load_exl3_weight(
+        loaded_weight,
+        expert_id=expert_id,
+        shard_id=shard_id,
+    )
     return True if return_success else None
 
 
@@ -969,7 +1046,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         params_dtype: torch.dtype,
         **extra_weight_attrs,
     ) -> None:
-        del num_experts, params_dtype, extra_weight_attrs
+        del params_dtype, extra_weight_attrs
         if self.moe.moe_parallel_config.use_ep:
             raise NotImplementedError(
                 "EXL3 correctness MoE currently supports TP but not expert parallelism"
@@ -982,11 +1059,39 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         layer.exl3_tp_size = self.moe.moe_parallel_config.tp_size
         layer.exl3_hidden_size = hidden_size
         layer.exl3_intermediate_size_per_partition = intermediate_size_per_partition
-        for prefix in ("w13", "w2"):
+        rank_sliced = self.quant_config.rank_sliced_metadata is not None
+        if rank_sliced:
+            checkpoint_tp = int(self.quant_config.rank_sliced_metadata["tp"])
+            if checkpoint_tp != layer.exl3_tp_size:
+                raise ValueError(
+                    "rank-sliced EXL3 checkpoint TP does not match runtime: "
+                    f"checkpoint={checkpoint_tp}, runtime={layer.exl3_tp_size}"
+                )
+            expected_experts = int(
+                self.quant_config.rank_sliced_metadata["experts_per_layer"]
+            )
+            if expected_experts != num_experts:
+                raise ValueError(
+                    "rank-sliced EXL3 expert count does not match the model: "
+                    f"checkpoint={expected_experts}, model={num_experts}"
+                )
+            vllm_config = get_current_vllm_config_or_none()
+            scheduler_config = (
+                vllm_config.scheduler_config if vllm_config is not None else None
+            )
+            layer.exl3_max_num_batched_tokens = int(
+                getattr(scheduler_config, "max_num_batched_tokens", 4096)
+            )
+        for prefix, shard_ids in (("w13", ("w1", "w3")), ("w2", ("w2",))):
             for suffix in ("suh", "svh", "trellis", "mcg", "mul1"):
                 layer.register_parameter(
                     f"{prefix}_{suffix}",
-                    Exl3MoEParameter(weight_loader=_exl3_moe_weight_loader),
+                    Exl3MoEParameter(
+                        weight_loader=_exl3_moe_weight_loader,
+                        num_experts=num_experts,
+                        shard_ids=shard_ids,
+                        preallocate=rank_sliced and suffix in {"suh", "svh", "trellis"},
+                    ),
                 )
 
     def process_weights_after_loading(self, layer: RoutedExperts) -> None:
@@ -1006,7 +1111,8 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 + (" ..." if len(missing) > 32 else "")
             )
         self._validate_codebooks(layer)
-        self._shard_tensors_for_tensor_parallel(layer)
+        if self.quant_config.rank_sliced_metadata is None:
+            self._shard_tensors_for_tensor_parallel(layer)
         device = layer.w13_trellis.device
         for prefix in ("w13", "w2"):
             for attr in ("suh", "svh", "trellis", "mcg", "mul1"):
@@ -1017,28 +1123,9 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                     ).contiguous()
         self._validate_moe_shapes(layer)
 
-        fused: dict[tuple[str, int, str], Any] = {}
-        if _fused_mode_enabled():
-            for group, shard_ids in (("w13", ("w1", "w3")), ("w2", ("w2",))):
-                trellis_map = getattr(layer, f"{group}_trellis").exl3_tensors
-                suh_map = getattr(layer, f"{group}_suh").exl3_tensors
-                svh_map = getattr(layer, f"{group}_svh").exl3_tensors
-                mcg_map = getattr(layer, f"{group}_mcg").exl3_tensors
-                mul1_map = getattr(layer, f"{group}_mul1").exl3_tensors
-                for expert_id in range(layer.local_num_experts):
-                    for shard_id in shard_ids:
-                        key = (expert_id, shard_id)
-                        prepared = _try_prepare_fused(
-                            f"{layer.layer_name}.{expert_id}.{shard_id}",
-                            trellis_map[key],
-                            suh_map[key],
-                            svh_map[key],
-                            mcg_map.get(key),
-                            mul1_map.get(key),
-                        )
-                        if prepared is not None:
-                            fused[(group,) + key] = prepared
-        layer.exl3_moe_fused_prepared = fused
+        if self.quant_config.rank_sliced_metadata is not None:
+            self._prepare_rank_sliced_weights(layer)
+            return
 
     def _validate_codebooks(self, layer: RoutedExperts) -> None:
         projections = {
@@ -1136,6 +1223,135 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                             f"projection={shard_id}"
                         )
 
+    @staticmethod
+    def _rank_sliced_backing(
+        layer: RoutedExperts,
+        param_name: str,
+    ) -> torch.Tensor:
+        param = getattr(layer, param_name)
+        backing = param.exl3_backing
+        if backing is None or not backing.is_contiguous():
+            raise RuntimeError(
+                f"rank-sliced EXL3 parameter {param_name} has no contiguous slab"
+            )
+        for (expert_id, shard_id), tensor in param.exl3_tensors.items():
+            shard_index = param.exl3_shard_ids.index(shard_id)
+            expected = (
+                backing[shard_index, expert_id]
+                if len(param.exl3_shard_ids) > 1
+                else backing[expert_id]
+            )
+            if tensor.data_ptr() != expected.data_ptr():
+                raise RuntimeError(
+                    "rank-sliced EXL3 expert payload lost its slab alias: "
+                    f"{param_name}[{expert_id},{shard_id}]"
+                )
+        return backing
+
+    @staticmethod
+    def _pointer_table(slab: torch.Tensor) -> torch.Tensor:
+        if slab.ndim < 2 or not slab[0].is_contiguous():
+            raise RuntimeError("EXL3 pointer-table rows must be contiguous")
+        step = slab.stride(0) * slab.element_size()
+        base = slab.data_ptr()
+        return torch.tensor(
+            [base + expert_id * step for expert_id in range(slab.shape[0])],
+            dtype=torch.int64,
+            device=slab.device,
+        )
+
+    @staticmethod
+    def _trellis_tile_config(hidden_size: int, intermediate_size: int):
+        if hidden_size % 128 or intermediate_size % 128:
+            raise ValueError(
+                "rank-sliced EXL3 full rotations require hidden and "
+                "intermediate dimensions divisible by 128"
+            )
+        if hidden_size % 256 == 0 and intermediate_size % 256 == 0:
+            return (64, 256, 64, 256)
+        return (64, 128, 64, 128)
+
+    def _prepare_rank_sliced_weights(self, layer: RoutedExperts) -> None:
+        api = _load_sparkinfer_trellis()
+        num_experts = int(layer.local_num_experts)
+        hidden_size = int(layer.exl3_hidden_size)
+        intermediate_size = int(layer.exl3_intermediate_size_per_partition)
+        bits = int(self.quant_config.bits or 0)
+        if float(bits) != self.quant_config.bits or bits not in (3, 4, 5, 6):
+            raise ValueError(
+                "rank-sliced EXL3 requires an integral 3/4/5/6 bitrate, got "
+                f"{self.quant_config.bits!r}"
+            )
+
+        w13 = self._rank_sliced_backing(layer, "w13_trellis")
+        w2 = self._rank_sliced_backing(layer, "w2_trellis")
+        gate_suh, up_suh = self._rank_sliced_backing(layer, "w13_suh")
+        gate_svh, up_svh = self._rank_sliced_backing(layer, "w13_svh")
+        down_suh = self._rank_sliced_backing(layer, "w2_suh")
+        down_svh = self._rank_sliced_backing(layer, "w2_svh")
+        expected_w13 = (
+            2,
+            num_experts,
+            hidden_size // 16,
+            intermediate_size // 16,
+            16 * bits,
+        )
+        expected_w2 = (
+            num_experts,
+            intermediate_size // 16,
+            hidden_size // 16,
+            16 * bits,
+        )
+        if tuple(w13.shape) != expected_w13 or tuple(w2.shape) != expected_w2:
+            raise ValueError(
+                "rank-sliced EXL3 slab geometry mismatch: "
+                f"w13={tuple(w13.shape)}, w2={tuple(w2.shape)}, "
+                f"expected={expected_w13}/{expected_w2}"
+            )
+
+        intermediate_rotations = torch.empty(
+            (num_experts, 3 * intermediate_size),
+            dtype=torch.float16,
+            device=w13.device,
+        )
+        intermediate_rotations[:, :intermediate_size].copy_(gate_svh)
+        intermediate_rotations[:, intermediate_size : 2 * intermediate_size].copy_(
+            up_svh
+        )
+        intermediate_rotations[:, 2 * intermediate_size :].copy_(down_suh)
+        tile_config = self._trellis_tile_config(hidden_size, intermediate_size)
+        marker = layer.w13_mcg.exl3_tensors[(0, "w1")]
+        layer.exl3_trellis_weights = api.prepare_weights(
+            w13,
+            w2,
+            gate_suh=gate_suh,
+            up_suh=up_suh,
+            intermediate_rotations=intermediate_rotations,
+            down_svh=down_svh,
+            codebook="mcg",
+            mcg=marker,
+            tile_config=tile_config,
+        )
+
+        slabs = (
+            w13[0],
+            gate_suh,
+            gate_svh,
+            w13[1],
+            up_suh,
+            up_svh,
+            w2,
+            down_suh,
+            down_svh,
+        )
+        layer.exl3_pointer_tables = tuple(self._pointer_table(slab) for slab in slabs)
+        layer.exl3_expert_map = torch.arange(
+            num_experts,
+            dtype=torch.int64,
+            device=w13.device,
+        )
+        layer.exl3_trellis_tile_config = tile_config
+
     def get_fused_moe_quant_config(
         self, layer: RoutedExperts
     ) -> FusedMoEQuantConfig | None:
@@ -1146,13 +1362,284 @@ class Exl3MoEMethod(FusedMoEMethodBase):
     def topk_indices_dtype(self) -> torch.dtype | None:
         return torch.long
 
+    def _rank_sliced_runtime(
+        self,
+        layer: RoutedExperts,
+        x: torch.Tensor,
+        topk_ids: torch.Tensor,
+    ) -> dict[str, Any]:
+        min_trellis_m = _positive_env_int("VLLM_EXL3_TRELLIS_MIN_M", 4)
+        max_trellis_m = _positive_env_int("VLLM_EXL3_TRELLIS_MAX_M", 32)
+        block_m = _positive_env_int("VLLM_EXL3_TRELLIS_BLOCK_M", 8)
+        chunk = _positive_env_int("VLLM_EXL3_PREFILL_CHUNK", 128)
+        if min_trellis_m > max_trellis_m:
+            raise ValueError(
+                "VLLM_EXL3_TRELLIS_MIN_M cannot exceed VLLM_EXL3_TRELLIS_MAX_M"
+            )
+        max_batched_tokens = max(
+            int(layer.exl3_max_num_batched_tokens),
+            int(x.shape[0]),
+        )
+        topk = int(topk_ids.shape[1])
+        device_index = x.device.index
+        key = (
+            device_index,
+            x.dtype,
+            int(layer.exl3_hidden_size),
+            int(layer.exl3_intermediate_size_per_partition),
+            int(layer.local_num_experts),
+            topk,
+            max_batched_tokens,
+            min_trellis_m,
+            max_trellis_m,
+            block_m,
+            chunk,
+            layer.exl3_trellis_tile_config,
+        )
+        runtime = _RANK_SLICED_RUNTIMES.get(key)
+        if runtime is not None:
+            return runtime
+        if torch.cuda.is_current_stream_capturing():
+            raise RuntimeError(
+                "Rank-sliced EXL3 runtime must be planned during the eager "
+                "profile pass before CUDA graph capture"
+            )
+
+        api = _load_sparkinfer_trellis()
+        caps = api.Caps(
+            max_tokens=max_trellis_m,
+            num_topk=topk,
+            num_experts=int(layer.local_num_experts),
+            hidden_size=int(layer.exl3_hidden_size),
+            intermediate_size=int(layer.exl3_intermediate_size_per_partition),
+            route_num_experts=int(layer.local_num_experts),
+            block_size_m=block_m,
+            trellis_bits=int(self.quant_config.bits),
+            tile_config=layer.exl3_trellis_tile_config,
+            input_dtype=x.dtype,
+            device=x.device,
+        )
+        trellis_plan = api.plan(caps)
+        scratch_spec = trellis_plan.scratch_specs()[0]
+        trellis_scratch = torch.empty(
+            scratch_spec.shape,
+            dtype=scratch_spec.dtype,
+            device=scratch_spec.device,
+        )
+
+        ext = _load_exl3_ext()
+        required_ext = {
+            "exl3_moe",
+            "exl3_moe_max_concurrency",
+        }
+        missing_ext = sorted(name for name in required_ext if not hasattr(ext, name))
+        if missing_ext:
+            raise RuntimeError(
+                "The EXL3 extension lacks routed-expert entry points: "
+                + ", ".join(missing_ext)
+            )
+        concurrency = int(ext.exl3_moe_max_concurrency(torch.cuda.current_device()))
+        hidden_size = int(layer.exl3_hidden_size)
+        intermediate_size = int(layer.exl3_intermediate_size_per_partition)
+        num_experts = int(layer.local_num_experts)
+        device = x.device
+        runtime = {
+            "api": api,
+            "trellis_plan": trellis_plan,
+            "trellis_scratch": trellis_scratch,
+            "ext": ext,
+            "min_trellis_m": min_trellis_m,
+            "max_trellis_m": max_trellis_m,
+            "max_batched_tokens": max_batched_tokens,
+            "topk": topk,
+            "chunk": chunk,
+            "xh": torch.empty(
+                (max_batched_tokens, hidden_size),
+                dtype=torch.float16,
+                device=device,
+            ),
+            "out32": torch.empty(
+                (max_batched_tokens, hidden_size),
+                dtype=torch.float32,
+                device=device,
+            ),
+            "tg": torch.empty(
+                (concurrency, chunk, hidden_size),
+                dtype=torch.float16,
+                device=device,
+            ),
+            "tu": torch.empty(
+                (concurrency, chunk, hidden_size),
+                dtype=torch.float16,
+                device=device,
+            ),
+            "ig": torch.empty(
+                (concurrency, chunk, intermediate_size),
+                dtype=torch.float16,
+                device=device,
+            ),
+            "iu": torch.empty(
+                (concurrency, chunk, intermediate_size),
+                dtype=torch.float16,
+                device=device,
+            ),
+            "expert_count": torch.empty(
+                num_experts + 1,
+                dtype=torch.int64,
+                device=device,
+            ),
+            "expert_offsets": torch.empty(
+                num_experts + 1,
+                dtype=torch.int64,
+                device=device,
+            ),
+            "token_sorted": torch.empty(
+                max_batched_tokens * topk,
+                dtype=torch.int64,
+                device=device,
+            ),
+            "weight_sorted": torch.empty(
+                max_batched_tokens * topk,
+                dtype=torch.float16,
+                device=device,
+            ),
+            "flat_token": torch.arange(
+                chunk,
+                dtype=torch.int64,
+                device=device,
+            ).repeat_interleave(topk),
+            "ones": torch.ones(
+                chunk * topk,
+                dtype=torch.int64,
+                device=device,
+            ),
+        }
+        _RANK_SLICED_RUNTIMES[key] = runtime
+        logger.info_once(
+            "EXL3 rank-sliced runtime planned: Trellis m=%d..%d block_m=%d, "
+            "prefill capacity=%d chunk=%d topk=%d",
+            min_trellis_m,
+            max_trellis_m,
+            block_m,
+            max_batched_tokens,
+            chunk,
+            topk,
+        )
+        return runtime
+
+    def _apply_rank_sliced(
+        self,
+        layer: RoutedExperts,
+        x: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+    ) -> torch.Tensor:
+        runtime = self._rank_sliced_runtime(layer, x, topk_ids)
+        m = int(x.shape[0])
+        if runtime["min_trellis_m"] <= m <= runtime["max_trellis_m"]:
+            binding = runtime["api"].bind(
+                runtime["trellis_plan"],
+                scratch=runtime["trellis_scratch"],
+                a=x,
+                weights=layer.exl3_trellis_weights,
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
+            )
+            output = runtime["api"].run(binding=binding)
+            return output.to(x.dtype).clone()
+
+        if m > runtime["max_batched_tokens"]:
+            raise ValueError(
+                "EXL3 batch exceeds its planned capacity: "
+                f"m={m}, capacity={runtime['max_batched_tokens']}"
+            )
+        ext = runtime["ext"]
+        xh = runtime["xh"][:m]
+        xh.copy_(x)
+        out32 = runtime["out32"][:m]
+        out32.zero_()
+        chunk = int(runtime["chunk"])
+        pointer_args = layer.exl3_pointer_tables
+        if m > chunk and hasattr(ext, "exl3_moe_fused"):
+            ext.exl3_moe_fused(
+                xh,
+                out32,
+                topk_ids,
+                topk_weights,
+                layer.exl3_expert_map,
+                runtime["expert_count"],
+                runtime["expert_offsets"],
+                runtime["token_sorted"],
+                runtime["weight_sorted"],
+                runtime["tg"],
+                runtime["tu"],
+                runtime["ig"],
+                runtime["iu"],
+                0,
+                3,
+                3,
+                3,
+                *pointer_args,
+                True,
+                False,
+                True,
+                False,
+                True,
+                False,
+                0.0,
+                0,
+            )
+            return out32.to(x.dtype).clone()
+
+        local_ids = layer.exl3_expert_map[topk_ids.long()]
+        half_weights = topk_weights.to(torch.float16)
+        topk = int(runtime["topk"])
+        for start in range(0, m, chunk):
+            current_m = min(chunk, m - start)
+            flat = local_ids[start : start + current_m].reshape(-1)
+            order = torch.argsort(flat)
+            route_count = current_m * topk
+            token_ids = runtime["flat_token"][:route_count].index_select(0, order)
+            route_weights = (
+                half_weights[start : start + current_m]
+                .reshape(-1)
+                .index_select(0, order)
+            )
+            counts = runtime["expert_count"]
+            counts.zero_()
+            counts.scatter_add_(0, flat, runtime["ones"][:route_count])
+            ext.exl3_moe(
+                xh[start : start + current_m],
+                out32[start : start + current_m],
+                counts,
+                token_ids,
+                route_weights,
+                runtime["tg"],
+                runtime["tu"],
+                runtime["ig"],
+                runtime["iu"],
+                0,
+                3,
+                3,
+                3,
+                *pointer_args,
+                True,
+                False,
+                True,
+                False,
+                True,
+                False,
+                0.0,
+            )
+        return out32.to(x.dtype).clone()
+
     def apply(
         self,
         layer: RoutedExperts,
         x: torch.Tensor,
         topk_weights: torch.Tensor,
         topk_ids: torch.Tensor,
-        shared_experts: "SharedExperts | None",
+        shared_experts: SharedExperts | None,
         shared_experts_input: torch.Tensor | None,
     ) -> torch.Tensor:
         del shared_experts, shared_experts_input
@@ -1169,9 +1656,16 @@ class Exl3MoEMethod(FusedMoEMethodBase):
 
         original_shape = x.shape[:-1]
         original_dtype = x.dtype
-        x_2d = x.reshape(-1, x.shape[-1]).to(torch.float16).contiguous()
-        ids = topk_ids.reshape(x_2d.shape[0], -1).to(torch.long)
-        weights = topk_weights.reshape_as(ids).to(torch.float16)
+        x_2d = x.reshape(-1, x.shape[-1]).contiguous()
+        ids = topk_ids.reshape(x_2d.shape[0], -1).contiguous()
+        weights = topk_weights.reshape_as(ids).to(torch.float32).contiguous()
+        if self.quant_config.rank_sliced_metadata is not None:
+            output = self._apply_rank_sliced(layer, x_2d, weights, ids)
+            return output.reshape(*original_shape, output.shape[-1])
+
+        x_2d = x_2d.to(torch.float16)
+        ids = ids.to(torch.long)
+        weights = weights.to(torch.float16)
         output = torch.zeros(
             (x_2d.shape[0], layer.hidden_size),
             dtype=torch.float32,
@@ -1224,22 +1718,14 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             )
         if x.shape[-1] < packed_k:
             x = torch.nn.functional.pad(x, (0, packed_k - x.shape[-1]))
-        prepared = getattr(layer, "exl3_moe_fused_prepared", {}).get(
-            (group,) + key
+        output = _exl3_gemm(
+            x,
+            trellis,
+            getattr(layer, f"{group}_suh").exl3_tensors[key],
+            getattr(layer, f"{group}_svh").exl3_tensors[key],
+            key in getattr(layer, f"{group}_mcg").exl3_tensors,
+            key in getattr(layer, f"{group}_mul1").exl3_tensors,
         )
-        if prepared is not None:
-            api = _load_b12x_dense()
-            assert api is not None
-            output = api[1](x, prepared)
-        else:
-            output = _exl3_gemm(
-                x,
-                trellis,
-                getattr(layer, f"{group}_suh").exl3_tensors[key],
-                getattr(layer, f"{group}_svh").exl3_tensors[key],
-                key in getattr(layer, f"{group}_mcg").exl3_tensors,
-                key in getattr(layer, f"{group}_mul1").exl3_tensors,
-            )
         logical_n = (
             layer.hidden_size
             if shard_id == "w2"

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -1372,6 +1372,8 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         max_trellis_m = _positive_env_int("VLLM_EXL3_TRELLIS_MAX_M", 32)
         block_m = _positive_env_int("VLLM_EXL3_TRELLIS_BLOCK_M", 8)
         chunk = _positive_env_int("VLLM_EXL3_PREFILL_CHUNK", 128)
+        prefill_trellis = os.environ.get("VLLM_EXL3_PREFILL_TRELLIS", "1") == "1"
+        prefill_block_m = _positive_env_int("VLLM_EXL3_PREFILL_BLOCK_M", 64)
         if min_trellis_m > max_trellis_m:
             raise ValueError(
                 "VLLM_EXL3_TRELLIS_MIN_M cannot exceed VLLM_EXL3_TRELLIS_MAX_M"
@@ -1394,6 +1396,8 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             max_trellis_m,
             block_m,
             chunk,
+            prefill_trellis,
+            prefill_block_m,
             layer.exl3_trellis_tile_config,
         )
         runtime = _RANK_SLICED_RUNTIMES.get(key)
@@ -1406,26 +1410,41 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             )
 
         api = _load_sparkinfer_trellis()
-        caps = api.Caps(
-            max_tokens=max_trellis_m,
-            num_topk=topk,
-            num_experts=int(layer.local_num_experts),
-            hidden_size=int(layer.exl3_hidden_size),
-            intermediate_size=int(layer.exl3_intermediate_size_per_partition),
-            route_num_experts=int(layer.local_num_experts),
-            block_size_m=block_m,
-            trellis_bits=int(self.quant_config.bits),
-            tile_config=layer.exl3_trellis_tile_config,
-            input_dtype=x.dtype,
-            device=x.device,
-        )
-        trellis_plan = api.plan(caps)
-        scratch_spec = trellis_plan.scratch_specs()[0]
-        trellis_scratch = torch.empty(
-            scratch_spec.shape,
-            dtype=scratch_spec.dtype,
-            device=scratch_spec.device,
-        )
+
+        def _plan_with_scratch(plan_max_tokens: int, plan_block_m: int):
+            caps = api.Caps(
+                max_tokens=plan_max_tokens,
+                num_topk=topk,
+                num_experts=int(layer.local_num_experts),
+                hidden_size=int(layer.exl3_hidden_size),
+                intermediate_size=int(layer.exl3_intermediate_size_per_partition),
+                route_num_experts=int(layer.local_num_experts),
+                block_size_m=plan_block_m,
+                trellis_bits=int(self.quant_config.bits),
+                tile_config=layer.exl3_trellis_tile_config,
+                input_dtype=x.dtype,
+                device=x.device,
+            )
+            plan = api.plan(caps)
+            scratch_spec = plan.scratch_specs()[0]
+            scratch = torch.empty(
+                scratch_spec.shape,
+                dtype=scratch_spec.dtype,
+                device=scratch_spec.device,
+            )
+            return plan, scratch
+
+        trellis_plan, trellis_scratch = _plan_with_scratch(max_trellis_m, block_m)
+        # Prefill batches (m > max_trellis_m) run through a second planned
+        # Trellis capacity instead of the eager ExLlamaV3 parity path. The
+        # large block keeps expert tiles streamed once per block of routed
+        # rows rather than once per 8-row block.
+        prefill_plan = None
+        prefill_scratch = None
+        if prefill_trellis and max_batched_tokens > max_trellis_m:
+            prefill_plan, prefill_scratch = _plan_with_scratch(
+                max_batched_tokens, prefill_block_m
+            )
 
         ext = _load_exl3_ext()
         required_ext = {
@@ -1443,23 +1462,33 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         intermediate_size = int(layer.exl3_intermediate_size_per_partition)
         num_experts = int(layer.local_num_experts)
         device = x.device
+        # With the prefill plan live, the parity path only ever serves
+        # m < min_trellis_m, so its persistent staging shrinks to one chunk.
+        parity_rows = (
+            max_batched_tokens
+            if prefill_plan is None
+            else min(chunk, max_batched_tokens)
+        )
         runtime = {
             "api": api,
             "trellis_plan": trellis_plan,
             "trellis_scratch": trellis_scratch,
+            "prefill_plan": prefill_plan,
+            "prefill_scratch": prefill_scratch,
             "ext": ext,
             "min_trellis_m": min_trellis_m,
             "max_trellis_m": max_trellis_m,
             "max_batched_tokens": max_batched_tokens,
+            "parity_rows": parity_rows,
             "topk": topk,
             "chunk": chunk,
             "xh": torch.empty(
-                (max_batched_tokens, hidden_size),
+                (parity_rows, hidden_size),
                 dtype=torch.float16,
                 device=device,
             ),
             "out32": torch.empty(
-                (max_batched_tokens, hidden_size),
+                (parity_rows, hidden_size),
                 dtype=torch.float32,
                 device=device,
             ),
@@ -1494,12 +1523,12 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 device=device,
             ),
             "token_sorted": torch.empty(
-                max_batched_tokens * topk,
+                parity_rows * topk,
                 dtype=torch.int64,
                 device=device,
             ),
             "weight_sorted": torch.empty(
-                max_batched_tokens * topk,
+                parity_rows * topk,
                 dtype=torch.float16,
                 device=device,
             ),
@@ -1515,12 +1544,23 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             ),
         }
         _RANK_SLICED_RUNTIMES[key] = runtime
+        prefill_arena_mib = (
+            0.0
+            if prefill_scratch is None
+            else prefill_scratch.numel() * prefill_scratch.element_size() / (1 << 20)
+        )
         logger.info_once(
             "EXL3 rank-sliced runtime planned: Trellis m=%d..%d block_m=%d, "
-            "prefill capacity=%d chunk=%d topk=%d",
+            "prefill %s capacity=%d chunk=%d topk=%d",
             min_trellis_m,
             max_trellis_m,
             block_m,
+            (
+                f"trellis block_m={prefill_block_m} "
+                f"arena={prefill_arena_mib:.1f}MiB"
+                if prefill_plan is not None
+                else "parity"
+            ),
             max_batched_tokens,
             chunk,
             topk,
@@ -1548,10 +1588,33 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             output = runtime["api"].run(binding=binding)
             return output.to(x.dtype)
 
-        if m > runtime["max_batched_tokens"]:
+        if runtime["prefill_plan"] is not None and m > runtime["max_trellis_m"]:
+            if m > runtime["max_batched_tokens"]:
+                raise ValueError(
+                    "EXL3 batch exceeds its planned capacity: "
+                    f"m={m}, capacity={runtime['max_batched_tokens']}"
+                )
+            binding = runtime["api"].bind(
+                runtime["prefill_plan"],
+                scratch=runtime["prefill_scratch"],
+                a=x,
+                weights=layer.exl3_trellis_weights,
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
+            )
+            output = runtime["api"].run(binding=binding)
+            return output.to(x.dtype)
+
+        if torch.cuda.is_current_stream_capturing():
+            raise RuntimeError(
+                "EXL3 eager parity path entered during CUDA graph capture "
+                f"(m={m}); capture sizes must lie inside the Trellis window "
+                f"[{runtime['min_trellis_m']}, {runtime['max_trellis_m']}]"
+            )
+        if m > runtime["parity_rows"]:
             raise ValueError(
-                "EXL3 batch exceeds its planned capacity: "
-                f"m={m}, capacity={runtime['max_batched_tokens']}"
+                "EXL3 batch exceeds its planned parity capacity: "
+                f"m={m}, capacity={runtime['parity_rows']}"
             )
         ext = runtime["ext"]
         xh = runtime["xh"][:m]

--- a/vllm/model_executor/models/deepseek_mtp.py
+++ b/vllm/model_executor/models/deepseek_mtp.py
@@ -741,7 +741,22 @@ class DeepSeekMTP(nn.Module, DeepseekV2MixtureOfExperts):
         loaded_params: set[str] = set()
         _pending_wk_fp8: dict = {}  # FP8 indexer wk dequant buffer
         _pending_fp8_linear: dict = {}
+        # Rank-sliced EXL3 checkpoints ship one tensor per TP rank
+        # (`....rank{r}.{trellis|suh|svh|mcg}`), while Exl3MoEMethod registers a
+        # single fused param per projection group (`w13_mcg`, `w2_trellis`, ...).
+        # Strip the `.rank{r}` segment before expert mapping, exactly as the
+        # target model (deepseek_v2.load_weights) does; otherwise the MTP loader
+        # looks up `...routed_experts.w2_rank0.mcg` and KeyErrors.
+        rank_sliced_name = getattr(
+            self.quant_config,
+            "normalize_rank_sliced_weight_name",
+            None,
+        )
         for name, loaded_weight in weights:
+            if rank_sliced_name is not None:
+                name = rank_sliced_name(name)
+                if name is None:
+                    continue
             if "rotary_emb.inv_freq" in name:
                 continue
             spec_layer = get_spec_layer_idx_from_weight_name(self.config, name)

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -1578,6 +1578,7 @@ class DeepseekV2Model(nn.Module):
         config = vllm_config.model_config.hf_config
         quant_config = vllm_config.quant_config
         self.config = config
+        self.quant_config = quant_config
         self.device = current_platform.device_type
         self.hidden_size = config.hidden_size
         self.vocab_size = config.vocab_size
@@ -1796,12 +1797,21 @@ class DeepseekV2Model(nn.Module):
         pp_missing_layer_names = get_pp_missing_layer_names(self)
         params_dict = dict(self.named_parameters())
         loaded_params: set[str] = set()
+        rank_sliced_name = getattr(
+            self.quant_config,
+            "normalize_rank_sliced_weight_name",
+            None,
+        )
         # With index_topk_freq>1 only some layers build an indexer, yet the
         # checkpoint ships indexer weights for all of them; track the built ones.
         indexer_present_prefixes = {
             n.rsplit(".indexer.", 1)[0] for n in params_dict if ".indexer." in n
         }
         for name, loaded_weight in weights:
+            if rank_sliced_name is not None:
+                name = rank_sliced_name(name)
+                if name is None:
+                    continue
             if "rotary_emb.inv_freq" in name:
                 continue
 

--- a/vllm/model_executor/models/glm4_moe.py
+++ b/vllm/model_executor/models/glm4_moe.py
@@ -522,7 +522,16 @@ class Glm4MoeModel(nn.Module):
         params_dict = dict(self.named_parameters())
         loaded_params: set[str] = set()
         expert_params_mapping = self.get_expert_mapping()
+        rank_sliced_name = getattr(
+            self.quant_config,
+            "normalize_rank_sliced_weight_name",
+            None,
+        )
         for name, loaded_weight in weights:
+            if rank_sliced_name is not None:
+                name = rank_sliced_name(name)
+                if name is None:
+                    continue
             spec_layer = get_spec_layer_idx_from_weight_name(self.config, name)
             if spec_layer is not None:
                 continue

--- a/vllm/model_executor/models/glm4_moe.py
+++ b/vllm/model_executor/models/glm4_moe.py
@@ -418,6 +418,7 @@ class Glm4MoeModel(nn.Module):
         quant_config = vllm_config.quant_config
         enable_eplb = vllm_config.parallel_config.enable_eplb
         self.config = config
+        self.quant_config = quant_config
 
         self.vocab_size = config.vocab_size
 

--- a/vllm/model_executor/models/utils.py
+++ b/vllm/model_executor/models/utils.py
@@ -796,11 +796,40 @@ def get_draft_quant_config(vllm_config: VllmConfig) -> "QuantizationConfig | Non
     draft_model_config = vllm_config.speculative_config.draft_model_config
     draft_load_config = vllm_config.load_config
 
-    return (
-        VllmConfig.get_quantization_config(draft_model_config, draft_load_config)
-        if draft_model_config
-        else None
+    if not draft_model_config:
+        return None
+
+    quant_config = VllmConfig.get_quantization_config(
+        draft_model_config, draft_load_config
     )
+
+    # EXL3 rank-sliced (hybrid_tr3_tail) metadata is hydrated by VllmConfig via
+    # Exl3Config.maybe_update_config() for the *target* model only. The draft/MTP
+    # quant config is built separately here, so without this call its
+    # rank_sliced_metadata stays None and a rank-sliced MTP MoE layer silently
+    # falls back to the stock (non-tr3) expert path, KeyError-ing on
+    # `...experts.routed_experts.wN_rankR.mcg`. Mirror the target-model call so
+    # the MTP layer's experts load through the tr3 path.
+    if (
+        quant_config is not None
+        and getattr(quant_config, "get_name", lambda: None)() == "exl3"
+    ):
+        draft_hf = getattr(draft_model_config, "hf_config", None)
+        target_hf = getattr(
+            getattr(vllm_config, "model_config", None), "hf_config", None
+        )
+        hf_config = draft_hf
+        if (
+            getattr(draft_hf, "hybrid_tr3_tail", None) is None
+            and getattr(target_hf, "hybrid_tr3_tail", None) is not None
+        ):
+            hf_config = target_hf
+        quant_config.maybe_update_config(
+            draft_model_config.model,
+            hf_config=hf_config,
+        )
+
+    return quant_config
 
 
 def extract_layer_index(layer_name: str, num_attn_module: int = 1) -> int:

--- a/vllm/model_executor/models/utils.py
+++ b/vllm/model_executor/models/utils.py
@@ -819,15 +819,13 @@ def get_draft_quant_config(vllm_config: VllmConfig) -> "QuantizationConfig | Non
             getattr(vllm_config, "model_config", None), "hf_config", None
         )
         hf_config = draft_hf
-        if (
-            getattr(draft_hf, "hybrid_tr3_tail", None) is None
-            and getattr(target_hf, "hybrid_tr3_tail", None) is not None
-        ):
+        if getattr(draft_hf, "hybrid_tr3_tail", None) is None:
             hf_config = target_hf
-        quant_config.maybe_update_config(
-            draft_model_config.model,
-            hf_config=hf_config,
-        )
+        if getattr(hf_config, "hybrid_tr3_tail", None) is not None:
+            quant_config.maybe_update_config(
+                draft_model_config.model,
+                hf_config=hf_config,
+            )
 
     return quant_config
 

--- a/vllm/models/deepseek_v32/nvidia/attention.py
+++ b/vllm/models/deepseek_v32/nvidia/attention.py
@@ -398,7 +398,10 @@ class DeepseekV32Attention(MLAAttention):
         assert isinstance(slot_mapping, dict)
         mla_slot = slot_mapping.get(self.layer_name)
 
-        if self.indexer is not None:
+        # index_k is None when skip_topk (MTP draft steps 1+ under
+        # index_share_for_mtp_iteration): treat this forward as a shared
+        # layer so the step-0 top-k is reused instead of cleared/recomputed.
+        if self.indexer is not None and index_k is not None:
             has_indexer = True
             indexer_k_norm_w = self.indexer.k_norm.weight
             indexer_k_norm_bias = self.indexer.k_norm.bias
@@ -456,7 +459,7 @@ class DeepseekV32Attention(MLAAttention):
         q_nope = q_nope.transpose(0, 1)
         ql_nope = torch.bmm(q_nope, self.W_UK_T).transpose(0, 1)
 
-        if self.indexer is not None:
+        if self.indexer is not None and has_indexer:
             index_q = self.indexer.wq_b(q_c)[0]
             index_q = index_q.view(-1, self.indexer.n_head, self.indexer.head_dim)
         else:
@@ -478,7 +481,7 @@ class DeepseekV32Attention(MLAAttention):
             quantize_mqa=self._fp8_query,
         )
 
-        if self.indexer is not None:
+        if self.indexer is not None and has_indexer:
             sparse_attn_indexer(
                 q_c,
                 self.indexer.k_cache.prefix,

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -430,9 +430,23 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
         # caches). Outside the SM100 family the FP8
         # paged MQA logits kernel only supports next_n in (1, 2)
         # (deepgemm smxx_fp8_fp4_paged_mqa_logits.hpp:233), so flatten there.
-        self.use_flattening = not current_platform.is_device_capability_family(
-            100
-        ) and next_n not in (1, 2)
+        # The B12X / sparkinfer sparse indexer handles native next_n>2 on SM120
+        # directly (see sparse_attn_indexer warmup q_rows 1, 2, 4), so it must
+        # NOT be forced onto the DeepGEMM next_n<=2 flatten fallback. Flattening
+        # MTP-2/MTP-3 verification into rank-1 rows produced subtly wrong accepted
+        # tokens (code-gen syntax errors); the native (B, next_n) path keeps MTP
+        # correct. Use the canonical backend-aware predicate so this also holds
+        # when B12X is selected via --attention-backend B12X_MLA_SPARSE with the
+        # VLLM_USE_B12X_SPARSE_INDEXER env var unset (it also asserts SM120).
+        from vllm.model_executor.layers.sparse_attn_indexer import (
+            use_b12x_sparse_indexer,
+        )
+
+        self.use_flattening = (
+            not current_platform.is_device_capability_family(100)
+            and next_n not in (1, 2)
+            and not use_b12x_sparse_indexer()
+        )
         # SM100 supports the varlen paged MQA logits kernel (indices-selected,
         # next_n == 1 rows). Only compact spec-decode verification batches opt
         # into it; uniform DFlash draft proposal should keep the native path.

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -297,12 +297,16 @@ def get_indexer_max_num_blocks_per_req(
     return cdiv(max_model_len, block_size * effective_cp_world_size)
 
 
-def _supports_varlen_paged_mqa_logits() -> bool:
-    if (
-        envs.VLLM_USE_B12X_SPARSE_INDEXER
-        and current_platform.is_cuda()
-        and current_platform.is_device_capability_family(120)
-    ):
+def _supports_varlen_paged_mqa_logits(
+    use_b12x_sparse_indexer: bool | None = None,
+) -> bool:
+    if use_b12x_sparse_indexer is None and current_platform.is_cuda():
+        from vllm.model_executor.layers.sparse_attn_indexer import (
+            use_b12x_sparse_indexer as resolve_b12x_sparse_indexer,
+        )
+
+        use_b12x_sparse_indexer = resolve_b12x_sparse_indexer()
+    if use_b12x_sparse_indexer:
         # B12X consumes the already-flattened rank-1 seq_lens and repeated
         # block-table rows directly, so it does not need DeepGEMM's indices.
         return True
@@ -442,18 +446,18 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
             use_b12x_sparse_indexer,
         )
 
+        self.use_b12x_sparse_indexer = use_b12x_sparse_indexer()
         self.use_flattening = (
             not current_platform.is_device_capability_family(100)
             and next_n not in (1, 2)
-            and not use_b12x_sparse_indexer()
+            and not self.use_b12x_sparse_indexer
         )
         # SM100 supports the varlen paged MQA logits kernel (indices-selected,
         # next_n == 1 rows). Only compact spec-decode verification batches opt
         # into it; uniform DFlash draft proposal should keep the native path.
-        self.use_varlen = (
-            _supports_varlen_paged_mqa_logits()
-            and _uses_varlen_dspark_capacity(self.vllm_config)
-        )
+        self.use_varlen = _supports_varlen_paged_mqa_logits(
+            self.use_b12x_sparse_indexer
+        ) and _uses_varlen_dspark_capacity(self.vllm_config)
         logger.info_once(
             "DSA indexer decode path: use_flattening=%s use_varlen=%s "
             "(next_n=%d, use_fp4_indexer_cache=%s)",
@@ -697,7 +701,7 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                 # their slot mappings stay padded and their outputs are ignored.
                 padding_seq_len = (
                     self.compress_ratio
-                    if force_flatten and envs.VLLM_USE_B12X_SPARSE_INDEXER
+                    if force_flatten and self.use_b12x_sparse_indexer
                     else 0
                 )
                 self.decode_seq_lens_buffer[actual_expanded:num_decode_tokens] = (
@@ -832,7 +836,7 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
         num_decode_tokens: int,
         requires_padding: bool,
     ) -> torch.Tensor | None:
-        if not envs.VLLM_USE_B12X_SPARSE_INDEXER or requires_padding:
+        if not self.use_b12x_sparse_indexer or requires_padding:
             return None
 
         schedule_seq_lens = seq_lens
@@ -995,7 +999,7 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
             # slice below).
             assert common_attn_metadata.seq_lens_cpu_upper_bound is not None
             seq_lens_cpu = common_attn_metadata.seq_lens_cpu_upper_bound
-            if envs.VLLM_USE_B12X_SPARSE_INDEXER:
+            if self.use_b12x_sparse_indexer:
                 # The b12x paged prefill streams one supertile at a time and
                 # row-shares the page table, which requires single-request
                 # chunks. Budget each request by the supertile K window.
@@ -1174,7 +1178,7 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
 
             active_width: torch.Tensor | None = None
             decode_topk_max_seq_len: int | None = None
-            if envs.VLLM_USE_B12X_SPARSE_INDEXER:
+            if self.use_b12x_sparse_indexer:
                 # Live scorer window in cache tokens. ceil(max_seq_len /
                 # compress_ratio) is an upper bound on the max compressed
                 # context across the batch, so windowing to it is

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1756,7 +1756,9 @@ class Scheduler(SchedulerInterface):
                 request.status = RequestStatus.FINISHED_STOPPED
                 stopped = True
 
-            if new_token_ids and self.structured_output_manager.should_advance(request):
+            if new_token_ids and self.structured_output_manager.should_advance(
+                request, new_token_ids
+            ):
                 struct_output_request = request.structured_output_request
                 assert struct_output_request is not None
                 grammar = struct_output_request.grammar

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -15,7 +15,6 @@ from vllm.v1.structured_output.backend_guidance import GuidanceBackend
 from vllm.v1.structured_output.backend_types import (
     StructuredOutputBackend,
     StructuredOutputGrammar,
-    StructuredOutputOptions,
 )
 from vllm.v1.structured_output.backend_xgrammar import XgrammarBackend
 
@@ -370,7 +369,9 @@ class StructuredOutputManager:
             return request.structured_output_request.reasoning_ended
         return True
 
-    def should_advance(self, request: "Request") -> bool:
+    def should_advance(
+        self, request: "Request", new_token_ids: Sequence[int] | None = None
+    ) -> bool:
         if not request.use_structured_output:
             return False
 
@@ -393,33 +394,38 @@ class StructuredOutputManager:
         if structured_req.reasoning_ended:
             return True
 
-        # Check if reasoning ends in *this* step
-        delta_from = request.num_computed_tokens - request.num_output_placeholders
+        # Check if reasoning ends in *this* step. Prefer the caller's actual
+        # new_token_ids over reconstructing the step window from scheduler
+        # counters: with speculative decoding, num_computed_tokens is already
+        # advanced past the accepted draft tokens when this runs, so the
+        # counter-derived window can miss the reasoning-end marker.
         all_token_ids = request.all_token_ids
-        start = (
-            delta_from if delta_from >= 0 else max(len(all_token_ids) + delta_from, 0)
-        )
-        if reasoner.is_reasoning_end_streaming(
-            all_token_ids, itertools.islice(all_token_ids, start, None)
-        ):
+        if new_token_ids is not None:
+            start = max(len(all_token_ids) - len(new_token_ids), 0)
+            delta: Iterable[int] = new_token_ids
+        else:
+            delta_from = request.num_computed_tokens - request.num_output_placeholders
+            start = (
+                delta_from
+                if delta_from >= 0
+                else max(len(all_token_ids) + delta_from, 0)
+            )
+            delta = itertools.islice(all_token_ids, start, None)
+        if reasoner.is_reasoning_end_streaming(all_token_ids, delta):
             structured_req.reasoning_ended = True
 
-            # Reasoning just ended this step. Defer FSM advance until the next
-            # pass (see reasoning_ended check above) for JSON/regex/choice/grammar:
-            # advancing on the closing boundary token can accept tokens that still
-            # belong to the reasoning stream. Structural tags are the only safe
-            # same-step exception: they model phased output (e.g. thinking tag ->
-            # answer tag), and speculative decoding must run grammar.validate_tokens
-            # on draft tokens produced immediately after that transition.
-            if (
-                self.vllm_config.speculative_config is not None
-                and structured_req.structured_output_key[0]
-                == StructuredOutputOptions.STRUCTURAL_TAG
-            ):
-                # The scheduler will advance the grammar with this step's
-                # tokens right away, but the step still contains reasoning
-                # content up to and including the end marker. Record where
-                # it ends so trim_reasoning_for_advance() can drop it.
+            # Reasoning just ended this step. Without speculative decoding the
+            # boundary step ends at the marker, so deferring the FSM advance to
+            # the next pass (see reasoning_ended check above) is safe. With
+            # speculative decoding the same step can already contain accepted
+            # post-marker content (e.g. a drafted "{" verified right after the
+            # end marker); deferring would leave the grammar permanently one
+            # token behind the sampled stream, and the next bitmask would then
+            # force a duplicate of a token the model already emitted. Advance
+            # same-step for every structured type: trim_reasoning_for_advance()
+            # drops everything up to and including the marker, so the grammar
+            # never sees reasoning content.
+            if self.vllm_config.speculative_config is not None:
                 structured_req.reasoning_end_token_index = (
                     self._find_reasoning_end_index(reasoner, all_token_ids, start)
                 )


### PR DESCRIPTION
## Summary

Add native EXL3 checkpoint loading and execution without reconstructing or requantizing routed-expert weights at load time:

- `--quantization exl3` configuration and packed tensor loading
- dense, LM-head, and rank-sliced routed-MoE execution
- planned SparkInfer Trellis decode and prefill paths with parity fallbacks
- one-grid mixed K3/K4 routed-MoE execution for two-tier checkpoints
- TP-aware GLM/DeepSeek expert and MTP draft loading
- CUDA graph/runtime ownership isolation for target and draft models
- speculative structured-output advancement fixes and focused tests

This supersedes #139 with the implementation replayed directly on the current `dev/gilded-gnosis` head. Original commit authorship is preserved.

## Unified SparkInfer API

The homogeneous consumer uses SparkInfer #90 rather than the separate `trellis_moe` API from superseded SparkInfer #49:

1. `fused_moe.plan_weights(source_format="exl3_trellis_mcg", quant_modes="w4a16", ...)`
2. `fused_moe.prepare_weights(...)`
3. standard `Caps` / `plan` / caller-owned `scratch_specs()` / `bind` / `run`

This gives EXL3 Trellis and NF3 the same prepared-weight, scratch-arena, activation-dispatch, cache, and CUDA graph lifecycle. The consumer preserves the checkpoint's BF16 or FP16 parameter dtype rather than hard-coding BF16.

Mixed K3/K4 checkpoints use the paired internal API from SparkInfer #104. vLLM interprets the checkpoint metadata and creates two native packed weight tiers; SparkInfer packs global routes once, rotates activations once, and dispatches each CTA to its native bitrate inside one cooperative FC1/activation/FC2 grid. No BF16 reconstruction or requantization is performed.

## Clean-up from #139

- Base is current `dev/gilded-gnosis`, not an integration/build branch.
- The unrelated FlashInfer Dockerfile change was dropped.
- Capacity remains fail-closed: a batch above the scheduler-planned arena raises instead of allocating a replacement serving runtime.
- Rank-sliced metadata is hydrated only for compatible EXL3 checkpoints.
- The B12X sparse-indexer capability decision is cached instead of repeatedly recomputed.
- No generated binaries or model-specific Docker overlays are included.
- The scheduler-planned Trellis route geometry is retained through the paired SparkInfer binding rather than recomputed from the live batch shape.

## Dependencies

- Required homogeneous Trellis API: local-inference-lab/sparkinfer#90
- Required mixed K3/K4 path: local-inference-lab/sparkinfer#104
- Independent compile-cache correctness fix: local-inference-lab/sparkinfer#88

## Validation

Pinned CUDA 13.2 / PyTorch 2.12 / SM120 runtime:

- vLLM EXL3 tests: `18 passed` after the mixed integration update
- SparkInfer mixed K3/K4 GPU tests: `4 passed`
- existing SparkInfer Trellis, shared execution/scratch, and registry/API tests: `89 passed`
- covers SiLU/SiTU, BF16/FP16, small-M partial blocks, below-capacity CUDA graph replay, mixed K3-only/K4-only/interleaved routes, and production-shape `M=3072`
- the full `willfalco/GLM-5.2-EXL3-TR3-3.25bpw` checkpoint passed TP4/DCP4 with MTP0 and MTP3, CUDA graph capture, eight concurrent requests, and a 65,536-token prompt plus 256 generated tokens

Mixed-checkpoint performance:

| Test | Result |
|---|---:|
| MTP0 CC1 | 48.37 tok/s |
| MTP3 CC1 | 105.23 tok/s |
| MTP3 CC4 aggregate | 260.6 tok/s |
| MTP3 CC8 aggregate | 390.9 tok/s |

Profiler validation reduced the mixed decode kernel from `82.38` to `54.11 us/layer` without adding a host synchronization or copy. The safe GLM tile geometry reduced production-shape relative L2 error from `8.32e-3` to approximately `4.1e-8`.

Ruff, `py_compile`, and `git diff --check` pass for all mixed-path changes.

## Review notes

The largest review surface is `vllm/model_executor/layers/quantization/exl3.py`. The shared GLM sparse-attention changes are replayed on current GG rather than copied from an older full-file overlay.

No canonical branch is modified by this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `exl3` quantization method, including rank-sliced EXL3 draft/target metadata handling.
  * Enabled mixed-bitrate rank-sliced MoE routing via a dedicated mixed Trellis execution path.

* **Bug Fixes**
  * Unified EXL3 Trellis minimum defaults (now consistently resolves to `1` when unset) and improved related env override behavior.
  * Improved routed-expert weight loading robustness for different checkpoint tensor layouts.
  * Fixed structured-output reasoning advancement during speculative decoding and hardened scheduler handling of late/duplicate KV-transfer completions.
  * Improved sparse indexer KV-cache sharding and tightened indexer usage when index/top-k data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->