### PR TITLE
fix(sched): tolerate late or duplicate KV-xfer completions

### DIFF
--- a/tests/v1/kv_connector/unit/test_late_kv_xfer_completions.py
+++ b/tests/v1/kv_connector/unit/test_late_kv_xfer_completions.py
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Late or duplicate KV-transfer completions must not kill the engine core.
+
+A worker-side connector can report finished_recving/finished_sending for a
+request the scheduler no longer tracks (abort racing an async KV load, or the
+same request reported twice) or tracks in an unexpected status. The scheduler
+must ignore such completions instead of raising AssertionError.
+"""
+
+import copy
+
+import pytest
+
+from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.core.sched.scheduler import Scheduler
+from vllm.v1.outputs import EMPTY_MODEL_RUNNER_OUTPUT, KVConnectorOutput
+from vllm.v1.request import RequestStatus
+
+from .utils import (
+    assert_scheduler_empty,
+    create_model_runner_output,
+    create_request,
+    create_scheduler,
+    create_vllm_config,
+)
+
+pytestmark = pytest.mark.cpu_test
+
+
+def _deliver_kv_connector_output(
+    scheduler: Scheduler, scheduler_output: SchedulerOutput, **kwargs
+) -> None:
+    model_runner_output = copy.deepcopy(EMPTY_MODEL_RUNNER_OUTPUT)
+    model_runner_output.kv_connector_output = KVConnectorOutput(**kwargs)
+    scheduler.update_from_output(scheduler_output, model_runner_output)
+
+
+def test_finished_sending_for_untracked_request_ignored():
+    """finished_sending for an unknown request id is a no-op."""
+    vllm_config = create_vllm_config()
+    scheduler = create_scheduler(vllm_config)
+
+    scheduler_output = scheduler.schedule()
+    _deliver_kv_connector_output(
+        scheduler, scheduler_output, finished_sending={"id-unknown"}
+    )
+
+    assert_scheduler_empty(scheduler)
+
+
+def test_finished_recving_for_untracked_request_ignored():
+    """finished_recving for an unknown request id is a no-op."""
+    vllm_config = create_vllm_config()
+    scheduler = create_scheduler(vllm_config)
+
+    scheduler_output = scheduler.schedule()
+    _deliver_kv_connector_output(
+        scheduler, scheduler_output, finished_recving={"id-unknown"}
+    )
+
+    assert_scheduler_empty(scheduler)
+
+
+def test_finished_recving_for_running_request_keeps_blocks():
+    """A completion for a live request that is not waiting for remote KVs
+    must not free its blocks; the request keeps running and finishes
+    normally."""
+    vllm_config = create_vllm_config()
+    scheduler = create_scheduler(vllm_config)
+    request = create_request(max_tokens=4)
+    scheduler.add_request(request)
+
+    scheduler_output = scheduler.schedule()
+    model_runner_output = create_model_runner_output(
+        reqs=[request], finished_recving={request.request_id}
+    )
+    scheduler.update_from_output(scheduler_output, model_runner_output)
+
+    assert request.status == RequestStatus.RUNNING
+    assert request.request_id not in scheduler.finished_recving_kv_req_ids
+
+    # The request still finishes cleanly and releases everything.
+    scheduler_output = scheduler.schedule()
+    model_runner_output = create_model_runner_output(reqs=[request], use_eos=True)
+    scheduler.update_from_output(scheduler_output, model_runner_output)
+    assert request.is_finished()
+
+    scheduler.schedule()
+    assert_scheduler_empty(scheduler)
+
+
+def test_duplicate_finished_sending_after_free_ignored():
+    """A second finished_sending for a request whose blocks were already
+    freed by the first completion is ignored."""
+    vllm_config = create_vllm_config()
+    scheduler = create_scheduler(vllm_config)
+    request = create_request(do_remote_decode=True)
+    scheduler.add_request(request)
+    request_id = request.request_id
+
+    scheduler_output = scheduler.schedule()
+    model_runner_output = create_model_runner_output(reqs=[request])
+    scheduler.update_from_output(scheduler_output, model_runner_output)
+    assert request.is_finished()
+
+    # Pass the finished request to the persistent batch.
+    scheduler_output = scheduler.schedule()
+    scheduler.update_from_output(scheduler_output, EMPTY_MODEL_RUNNER_OUTPUT)
+
+    # The first completion frees the blocks.
+    scheduler_output = scheduler.schedule()
+    _deliver_kv_connector_output(
+        scheduler, scheduler_output, finished_sending={request_id}
+    )
+    assert_scheduler_empty(scheduler)
+
+    # The duplicate completion is ignored.
+    scheduler_output = scheduler.schedule()
+    _deliver_kv_connector_output(
+        scheduler, scheduler_output, finished_sending={request_id}
+    )
+    assert_scheduler_empty(scheduler)

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -2686,19 +2686,47 @@ class Scheduler(SchedulerInterface):
             self.connector.update_connector_output(kv_connector_output)
 
         # KV Connector:: update recv and send status from last step.
+        # Late or duplicate completions can arrive for requests that are no
+        # longer tracked (e.g. an abort racing an async KV load, or a
+        # connector reporting the same request twice); tolerate them instead
+        # of asserting, which would kill the engine core.
         for req_id in kv_connector_output.finished_recving or ():
             logger.debug("Finished recving KV transfer for request %s", req_id)
-            assert req_id in self.requests
-            req = self.requests[req_id]
+            req = self.requests.get(req_id)
+            if req is None:
+                logger.warning(
+                    "Finished recving KV transfer for request %s, but the "
+                    "request is no longer tracked; ignoring late/duplicate "
+                    "completion.",
+                    req_id,
+                )
+                continue
             if req.status == RequestStatus.WAITING_FOR_REMOTE_KVS:
                 self.finished_recving_kv_req_ids.add(req_id)
+            elif RequestStatus.is_finished(req.status):
+                self._free_blocks(req)
             else:
-                assert RequestStatus.is_finished(req.status)
-                self._free_blocks(self.requests[req_id])
+                # Freeing the blocks of a live request would corrupt
+                # scheduler state, so leave the request alone.
+                logger.warning(
+                    "Finished recving KV transfer for request %s in "
+                    "unexpected status %s; ignoring late/duplicate "
+                    "completion.",
+                    req_id,
+                    req.status,
+                )
         for req_id in kv_connector_output.finished_sending or ():
             logger.debug("Finished sending KV transfer for request %s", req_id)
-            assert req_id in self.requests
-            self._free_blocks(self.requests[req_id])
+            req = self.requests.get(req_id)
+            if req is None:
+                logger.warning(
+                    "Finished sending KV transfer for request %s, but the "
+                    "request is no longer tracked; ignoring late/duplicate "
+                    "completion.",
+                    req_id,
+                )
+                continue
+            self._free_blocks(req)
 
     def _update_requests_with_invalid_blocks(
         self,


### PR DESCRIPTION
## Summary

`Scheduler._update_from_kv_xfer_finished` asserted that every `finished_recving` / `finished_sending` request id is
still tracked and in an expected status. Late or duplicate KV-transfer completions violate both assumptions and each
occurrence killed EngineCore with an `AssertionError`. The asserts become warn-and-skip guards:

- unknown request id in `finished_recving` or `finished_sending`: log a warning and skip
- known request that is neither `WAITING_FOR_REMOTE_KVS` nor finished: log a warning and skip the block free, since
  freeing the blocks of a live request would corrupt scheduler state

## Intention

A worker-side connector can legitimately produce these completions: a client abort can race an async KV load so the
completion arrives after the request was freed, and a connector can report the same request id twice. Both were
observed with the LMCache MP connector under `kv_role=kv_both` with async scheduling (upstream reports in
LMCache/LMCache#2356; LMCache/LMCache#4136 fixes one producer of the duplicates on the LMCache side, this guard stays
as defense in depth for any other producer). Upstream vLLM main still has the bare asserts, so this is a fork-side
hardening, not a backport.

## Validation

Run in the r8 image against this branch:

- new `tests/v1/kv_connector/unit/test_late_kv_xfer_completions.py`: 4 passed; the same 4 tests fail with
  `AssertionError` when the guard commit is reverted
- neighboring `tests/v1/kv_connector/unit/test_remote_decode_lifecycle.py`: 4 passed
- Ruff lint and format checks passed

The guarded code has additionally been running in production as a startup source patch on the GLM-5.2 TP8 + DCP4
deployment since 2026-07-25 (v10/v11 of the runtime patch) with no assertion deaths since.

## Related

- local-inference-lab/vllm#191 documents a separate KV-load-failure wakeup issue observed in the same deployment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience to late or duplicate KV-transfer completion signals.
  * Prevented invalid completion events from incorrectly changing request state or freeing resources.
  * Ensured completed requests release KV blocks safely while active requests remain unaffected.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->