### PR TITLE
[GG] perf: preload CUDA-clean forkserver for local GPU workers

### DIFF
--- a/tests/entrypoints/test_cli_main.py
+++ b/tests/entrypoints/test_cli_main.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from vllm.entrypoints.cli import main as cli_main
+from vllm.utils import system_utils
+
+
+def test_serve_bootstraps_forkserver_before_command_imports(monkeypatch):
+    calls: list[tuple[list[str], bool]] = []
+    monkeypatch.setenv("VLLM_WORKER_MULTIPROC_METHOD", "forkserver")
+    monkeypatch.setattr("sys.argv", ["vllm", "serve", "model"])
+    monkeypatch.setattr(
+        system_utils,
+        "ensure_cuda_clean_forkserver",
+        lambda modules, *, set_start_method=False: calls.append(
+            (modules, set_start_method)
+        ),
+    )
+
+    cli_main._bootstrap_cuda_clean_forkserver()
+
+    assert calls == [
+        (
+            [
+                "vllm.v1.engine.async_llm",
+                "vllm.v1.executor.multiproc_executor",
+                "vllm.v1.worker.gpu_worker",
+            ],
+            True,
+        )
+    ]
+
+
+def test_non_serve_command_does_not_bootstrap_forkserver(monkeypatch):
+    monkeypatch.setenv("VLLM_WORKER_MULTIPROC_METHOD", "forkserver")
+    monkeypatch.setattr("sys.argv", ["vllm", "bench"])
+    monkeypatch.setattr(
+        system_utils,
+        "ensure_cuda_clean_forkserver",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("non-serve command must not start a forkserver")
+        ),
+    )
+
+    cli_main._bootstrap_cuda_clean_forkserver()

--- a/tests/utils_/test_system_utils.py
+++ b/tests/utils_/test_system_utils.py
@@ -1,11 +1,21 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import multiprocessing
+import multiprocessing.forkserver as forkserver
 import os
 import tempfile
 from pathlib import Path
 
-from vllm.utils.system_utils import _maybe_force_spawn, unique_filepath
+import pytest
+
+import vllm.envs as envs
+from vllm.utils import system_utils
+from vllm.utils.system_utils import (
+    _maybe_force_spawn,
+    ensure_cuda_clean_forkserver,
+    unique_filepath,
+)
 
 
 def test_unique_filepath():
@@ -25,3 +35,58 @@ def test_numa_bind_forces_spawn(monkeypatch):
     monkeypatch.setattr("sys.argv", ["vllm", "serve", "--numa-bind"])
     _maybe_force_spawn()
     assert os.environ["VLLM_WORKER_MULTIPROC_METHOD"] == "spawn"
+
+
+def test_worker_multiproc_method_accepts_forkserver(monkeypatch):
+    monkeypatch.setenv("VLLM_WORKER_MULTIPROC_METHOD", "forkserver")
+
+    assert envs.environment_variables["VLLM_WORKER_MULTIPROC_METHOD"]() == "forkserver"
+
+
+def test_ensure_cuda_clean_forkserver_starts_with_deduplicated_preload(
+    monkeypatch,
+):
+    calls: dict[str, object] = {}
+    monkeypatch.setattr(system_utils, "cuda_is_initialized", lambda: False)
+    monkeypatch.setattr(system_utils, "xpu_is_initialized", lambda: False)
+    monkeypatch.setattr(
+        multiprocessing,
+        "set_start_method",
+        lambda method, force=False: calls.update(method=(method, force)),
+    )
+    monkeypatch.setattr(
+        multiprocessing,
+        "set_forkserver_preload",
+        lambda modules: calls.update(preload=modules),
+    )
+    monkeypatch.setattr(
+        forkserver,
+        "ensure_running",
+        lambda: calls.update(running=True),
+    )
+
+    ensure_cuda_clean_forkserver(
+        ["vllm.worker", "vllm.executor", "vllm.worker"],
+        set_start_method=True,
+    )
+
+    assert calls == {
+        "method": ("forkserver", True),
+        "preload": ["vllm.worker", "vllm.executor"],
+        "running": True,
+    }
+
+
+@pytest.mark.parametrize("initialized", ["cuda", "xpu"])
+def test_ensure_cuda_clean_forkserver_rejects_initialized_parent(
+    monkeypatch, initialized
+):
+    monkeypatch.setattr(
+        system_utils, "cuda_is_initialized", lambda: initialized == "cuda"
+    )
+    monkeypatch.setattr(
+        system_utils, "xpu_is_initialized", lambda: initialized == "xpu"
+    )
+
+    with pytest.raises(RuntimeError, match="after CUDA/XPU initialization"):
+        ensure_cuda_clean_forkserver(["vllm.worker"])

--- a/tests/utils_/test_system_utils.py
+++ b/tests/utils_/test_system_utils.py
@@ -47,6 +47,7 @@ def test_ensure_cuda_clean_forkserver_starts_with_deduplicated_preload(
     monkeypatch,
 ):
     calls: dict[str, object] = {}
+    monkeypatch.setattr(system_utils, "_cuda_clean_forkserver_owner_pid", None)
     monkeypatch.setattr(system_utils, "cuda_is_initialized", lambda: False)
     monkeypatch.setattr(system_utils, "xpu_is_initialized", lambda: False)
     monkeypatch.setattr(
@@ -75,12 +76,49 @@ def test_ensure_cuda_clean_forkserver_starts_with_deduplicated_preload(
         "preload": ["vllm.worker", "vllm.executor"],
         "running": True,
     }
+    assert system_utils._cuda_clean_forkserver_owner_pid == os.getpid()
+
+
+def test_ensure_cuda_clean_forkserver_is_idempotent(monkeypatch):
+    monkeypatch.setattr(system_utils, "_cuda_clean_forkserver_owner_pid", os.getpid())
+    monkeypatch.setattr(
+        system_utils,
+        "cuda_is_initialized",
+        lambda: pytest.fail("idempotent call must not recheck CUDA"),
+    )
+
+    ensure_cuda_clean_forkserver(["vllm.worker"])
+
+
+def test_active_cuda_clean_forkserver_is_not_replaced(monkeypatch):
+    monkeypatch.setenv("VLLM_WORKER_MULTIPROC_METHOD", "forkserver")
+    monkeypatch.setattr(system_utils, "_cuda_clean_forkserver_owner_pid", os.getpid())
+    monkeypatch.setattr(system_utils, "cuda_is_initialized", lambda: True)
+
+    _maybe_force_spawn()
+
+    assert os.environ["VLLM_WORKER_MULTIPROC_METHOD"] == "forkserver"
+
+
+def test_unstarted_forkserver_is_replaced_after_cuda_init(monkeypatch):
+    monkeypatch.setenv("VLLM_WORKER_MULTIPROC_METHOD", "forkserver")
+    monkeypatch.setattr(system_utils, "_cuda_clean_forkserver_owner_pid", None)
+    monkeypatch.setattr(system_utils, "cuda_is_initialized", lambda: True)
+    monkeypatch.setattr(system_utils, "xpu_is_initialized", lambda: False)
+    monkeypatch.setattr(system_utils, "is_in_ray_actor", lambda: False)
+    monkeypatch.setattr(system_utils, "in_wsl", lambda: False)
+    monkeypatch.setattr("sys.argv", ["vllm", "serve"])
+
+    _maybe_force_spawn()
+
+    assert os.environ["VLLM_WORKER_MULTIPROC_METHOD"] == "spawn"
 
 
 @pytest.mark.parametrize("initialized", ["cuda", "xpu"])
 def test_ensure_cuda_clean_forkserver_rejects_initialized_parent(
     monkeypatch, initialized
 ):
+    monkeypatch.setattr(system_utils, "_cuda_clean_forkserver_owner_pid", None)
     monkeypatch.setattr(
         system_utils, "cuda_is_initialized", lambda: initialized == "cuda"
     )

--- a/tests/v1/worker/test_gpu_worker.py
+++ b/tests/v1/worker/test_gpu_worker.py
@@ -1,8 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import sys
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -20,6 +21,23 @@ from vllm.v1.worker.startup_plan import (
     maybe_apply_startup_plan,
     maybe_save_startup_plan,
 )
+
+
+def test_gpu_worker_keeps_cuda_warmup_import_lazy(monkeypatch: pytest.MonkeyPatch):
+    # Forkserver preloads this module. Binding kernel_warmup at module scope
+    # imports CUDA-initializing warmup dependencies into the server snapshot.
+    assert gpu_worker_module.kernel_warmup.__module__ == gpu_worker_module.__name__
+
+    run_kernel_warmup = Mock()
+    monkeypatch.setitem(
+        sys.modules,
+        "vllm.model_executor.warmup.kernel_warmup",
+        SimpleNamespace(kernel_warmup=run_kernel_warmup),
+    )
+    worker = object()
+    gpu_worker_module.kernel_warmup(worker)
+
+    run_kernel_warmup.assert_called_once_with(worker)
 
 
 def _worker_with_mm_config(

--- a/vllm/entrypoints/cli/main.py
+++ b/vllm/entrypoints/cli/main.py
@@ -6,6 +6,7 @@ Note that all future modules must be lazily loaded within main
 to avoid certain eager import breakage."""
 
 import importlib.metadata
+import os
 import sys
 from importlib.util import find_spec
 
@@ -14,7 +15,28 @@ from vllm.logger import init_logger
 logger = init_logger(__name__)
 
 
+def _bootstrap_cuda_clean_forkserver() -> None:
+    """Start the serving forkserver before CLI imports can initialize CUDA."""
+    if len(sys.argv) < 2 or sys.argv[1] != "serve":
+        return
+    if os.environ.get("VLLM_WORKER_MULTIPROC_METHOD") != "forkserver":
+        return
+
+    from vllm.utils.system_utils import ensure_cuda_clean_forkserver
+
+    ensure_cuda_clean_forkserver(
+        [
+            "vllm.v1.engine.async_llm",
+            "vllm.v1.executor.multiproc_executor",
+            "vllm.v1.worker.gpu_worker",
+        ],
+        set_start_method=True,
+    )
+
+
 def main():
+    _bootstrap_cuda_clean_forkserver()
+
     import vllm.entrypoints.cli.benchmark.main
     import vllm.entrypoints.cli.collect_env
     import vllm.entrypoints.cli.launch

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -3,9 +3,6 @@
 import asyncio
 import importlib
 import inspect
-import multiprocessing
-import multiprocessing.forkserver as forkserver
-import os
 import signal
 import socket
 import tempfile
@@ -66,7 +63,11 @@ from vllm.tracing import instrument
 from vllm.usage.usage_lib import UsageContext
 from vllm.utils.argparse_utils import FlexibleArgumentParser
 from vllm.utils.network_utils import is_valid_ipv6_address
-from vllm.utils.system_utils import decorate_logs, set_ulimit
+from vllm.utils.system_utils import (
+    decorate_logs,
+    ensure_cuda_clean_forkserver,
+    set_ulimit,
+)
 from vllm.v1.engine.exceptions import EngineDeadError, EngineGenerateError
 from vllm.version import __version__ as VLLM_VERSION
 
@@ -120,13 +121,19 @@ async def build_async_engine_client(
     usage_context: UsageContext = UsageContext.OPENAI_API_SERVER,
     client_config: dict[str, Any] | None = None,
 ) -> AsyncIterator[EngineClient]:
-    if os.getenv("VLLM_WORKER_MULTIPROC_METHOD") == "forkserver":
-        # The executor is expected to be mp.
-        # Pre-import heavy modules in the forkserver process
-        logger.debug("Setup forkserver with pre-imports")
-        multiprocessing.set_start_method("forkserver")
-        multiprocessing.set_forkserver_preload(["vllm.v1.engine.async_llm"])
-        forkserver.ensure_running()
+    if envs.VLLM_WORKER_MULTIPROC_METHOD == "forkserver":
+        # EngineCore is forked from this CUDA-clean server. Preloading the
+        # executor and worker stack lets its pages be shared instead of imported
+        # independently by every local rank.
+        logger.debug("Setup CUDA-clean API forkserver with worker preloads")
+        ensure_cuda_clean_forkserver(
+            [
+                "vllm.v1.engine.async_llm",
+                "vllm.v1.executor.multiproc_executor",
+                "vllm.v1.worker.gpu_worker",
+            ],
+            set_start_method=True,
+        )
         logger.debug("Forkserver setup complete!")
 
     # Context manager to handle engine_client lifecycle

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -92,7 +92,7 @@ if TYPE_CHECKING:
     VLLM_USE_RAY_V2_EXECUTOR_BACKEND: bool = False
     VLLM_DISTRIBUTED_USE_SPLIT_GROUP: bool = False
     VLLM_XLA_USE_SPMD: bool = False
-    VLLM_WORKER_MULTIPROC_METHOD: Literal["fork", "spawn"] = "fork"
+    VLLM_WORKER_MULTIPROC_METHOD: Literal["fork", "spawn", "forkserver"] = "fork"
     VLLM_ASSETS_CACHE: str = os.path.join(VLLM_CACHE_ROOT, "assets")
     VLLM_ASSETS_CACHE_MODEL_CLEAN: bool = False
     VLLM_IMAGE_FETCH_TIMEOUT: int = 5
@@ -949,9 +949,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
         int(os.getenv("VLLM_DISTRIBUTED_USE_SPLIT_GROUP", "0"))
     ),
     # Use dedicated multiprocess context for workers.
-    # Both spawn and fork work
+    # spawn, fork, and an explicitly configured forkserver are supported.
     "VLLM_WORKER_MULTIPROC_METHOD": env_with_choices(
-        "VLLM_WORKER_MULTIPROC_METHOD", "fork", ["spawn", "fork"]
+        "VLLM_WORKER_MULTIPROC_METHOD", "fork", ["spawn", "fork", "forkserver"]
     ),
     # Path to the cache for storing downloaded assets
     "VLLM_ASSETS_CACHE": lambda: os.path.expanduser(

--- a/vllm/utils/system_utils.py
+++ b/vllm/utils/system_utils.py
@@ -112,6 +112,35 @@ def unique_filepath(fn: Callable[[int], Path]) -> Path:
 # Process management utilities
 
 
+def ensure_cuda_clean_forkserver(
+    preload_modules: list[str],
+    *,
+    set_start_method: bool = False,
+) -> None:
+    """Start a forkserver before this process initializes an accelerator.
+
+    A forkserver child inherits the server's runtime state. Starting that
+    server after CUDA/XPU initialization would reproduce the same unsafe state
+    inheritance as a direct fork, so fail closed instead of creating workers
+    that can fail later during device initialization.
+    """
+    if cuda_is_initialized() or xpu_is_initialized():
+        raise RuntimeError(
+            "Cannot start the vLLM forkserver after CUDA/XPU initialization. "
+            "Use VLLM_WORKER_MULTIPROC_METHOD=spawn instead."
+        )
+    if not preload_modules:
+        raise ValueError("forkserver preload_modules must not be empty")
+
+    if set_start_method:
+        multiprocessing.set_start_method("forkserver", force=True)
+    multiprocessing.set_forkserver_preload(list(dict.fromkeys(preload_modules)))
+
+    import multiprocessing.forkserver as forkserver
+
+    forkserver.ensure_running()
+
+
 def _sync_visible_devices_env_vars():
     """Sync HIP/CUDA visibility env vars before spawning (ROCm only)."""
 

--- a/vllm/utils/system_utils.py
+++ b/vllm/utils/system_utils.py
@@ -112,6 +112,13 @@ def unique_filepath(fn: Callable[[int], Path]) -> Path:
 # Process management utilities
 
 
+_cuda_clean_forkserver_owner_pid: int | None = None
+
+
+def _cuda_clean_forkserver_is_running() -> bool:
+    return _cuda_clean_forkserver_owner_pid == os.getpid()
+
+
 def ensure_cuda_clean_forkserver(
     preload_modules: list[str],
     *,
@@ -124,6 +131,10 @@ def ensure_cuda_clean_forkserver(
     inheritance as a direct fork, so fail closed instead of creating workers
     that can fail later during device initialization.
     """
+    global _cuda_clean_forkserver_owner_pid
+
+    if _cuda_clean_forkserver_is_running():
+        return
     if cuda_is_initialized() or xpu_is_initialized():
         raise RuntimeError(
             "Cannot start the vLLM forkserver after CUDA/XPU initialization. "
@@ -139,6 +150,7 @@ def ensure_cuda_clean_forkserver(
     import multiprocessing.forkserver as forkserver
 
     forkserver.ensure_running()
+    _cuda_clean_forkserver_owner_pid = os.getpid()
 
 
 def _sync_visible_devices_env_vars():
@@ -156,7 +168,10 @@ def _maybe_force_spawn():
     """Check if we need to force the use of the `spawn` multiprocessing start
     method.
     """
-    if os.environ.get("VLLM_WORKER_MULTIPROC_METHOD") == "spawn":
+    method = os.environ.get("VLLM_WORKER_MULTIPROC_METHOD")
+    if method == "spawn" or (
+        method == "forkserver" and _cuda_clean_forkserver_is_running()
+    ):
         return
 
     reasons = []

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -55,6 +55,7 @@ from vllm.utils.ompmultiprocessing import OMPProcessManager
 from vllm.utils.system_utils import (
     _maybe_force_spawn,
     decorate_logs,
+    ensure_cuda_clean_forkserver,
     get_mp_context,
     set_process_title,
 )
@@ -114,6 +115,21 @@ class MultiprocExecutor(Executor):
         self.is_failed = False
         self.failure_callback: FailureCallback | None = None
 
+        if envs.VLLM_WORKER_MULTIPROC_METHOD == "forkserver":
+            # EngineCore owns a separate forkserver for its GPU workers. Start
+            # it before message-queue setup can touch CUDA and preload the stack
+            # each local rank would otherwise import independently.
+            ensure_cuda_clean_forkserver(
+                [
+                    "vllm.v1.executor.multiproc_executor",
+                    "vllm.v1.worker.gpu_worker",
+                ]
+            )
+
+        # Resolve the context immediately after the clean forkserver starts.
+        # Existing NUMA/Ray/WSL guards in get_mp_context remain authoritative.
+        context = get_mp_context()
+
         tp_size, pp_size, pcp_size = self._get_parallel_sizes()
         assert self.world_size == tp_size * pp_size * pcp_size, (
             f"world_size ({self.world_size}) must be equal to the "
@@ -156,7 +172,6 @@ class MultiprocExecutor(Executor):
             )
             scheduler_output_handle = self.rpc_broadcast_mq.export_handle()
         # Create workers
-        context = get_mp_context()
         shared_worker_lock = context.Lock()
         unready_workers: list[UnreadyWorkerProcHandle] = []
         success = False

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -53,7 +53,6 @@ from vllm.lora.request import LoRARequest
 from vllm.model_executor.warmup.deepseek_v4_compressor_warmup import (
     deepseek_v4_compressor_triton_warmup,
 )
-from vllm.model_executor.warmup.kernel_warmup import kernel_warmup
 from vllm.multimodal.video import (
     PYNVVIDEOCODEC_CUDA_CONTEXT_BYTES,
     PYNVVIDEOCODEC_DECODER_GPU_MEMORY_BYTES,
@@ -91,6 +90,16 @@ from .gpu.warmup import warmup_kernels
 from .utils import request_memory
 
 logger = init_logger(__name__)
+
+
+def kernel_warmup(worker: "Worker") -> None:
+    """Run kernel warmup without importing its CUDA dependencies on preload."""
+    from vllm.model_executor.warmup.kernel_warmup import (
+        kernel_warmup as run_kernel_warmup,
+    )
+
+    run_kernel_warmup(worker)
+
 
 if TYPE_CHECKING:
     from vllm.device_allocator.sleep_mode_backend import SleepModeBackend

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -93,7 +93,14 @@ logger = init_logger(__name__)
 
 
 def kernel_warmup(worker: "Worker") -> None:
-    """Run kernel warmup without importing its CUDA dependencies on preload."""
+    """Run kernel warmup without importing its CUDA dependencies on preload.
+
+    Args:
+        worker: Worker whose kernels should be warmed up.
+
+    Returns:
+        None.
+    """
     from vllm.model_executor.warmup.kernel_warmup import (
         kernel_warmup as run_kernel_warmup,
     )


### PR DESCRIPTION
## Summary

Add an opt-in, CUDA-clean `forkserver` path for local multi-GPU workers. This is a clean extraction of the startup optimization validated on Kimi K3 TP16; it contains none of the Kimi loader or release-overlay changes from the experimental branch.

When `VLLM_WORKER_MULTIPROC_METHOD=forkserver`:

- the OpenAI process starts its EngineCore forkserver before accelerator initialization and preloads the async engine, multiprocess executor, and GPU worker stack;
- EngineCore starts its own worker forkserver before message-queue setup and preloads the executor/worker modules;
- `gpu_worker` imports `kernel_warmup` only at warmup time, keeping forkserver preload CUDA-clean;
- startup fails closed if CUDA or XPU is already initialized instead of creating poisoned children;
- existing NUMA/Ray/WSL force-spawn policy remains in place. The default method is unchanged.

This extends upstream vllm-project/vllm#45483. That PR makes the surviving forkserver path reachable but intentionally avoids preload. Preloading the second, EngineCore-owned worker forkserver is the part that removes repeated per-rank imports at high TP. The previous preload regression is addressed here by moving the identified CUDA-initializing import out of module scope and testing that contract.

## Measured result

Matched Kimi K3 TP16 startup, `Initializing a V1 LLM engine` to `Starting to load model`:

| Method | Time |
|---|---:|
| `spawn` | 167 s |
| CUDA-clean `forkserver` | 39 s |

All 16 ranks entered distributed initialization within one second. Full EngineCore-to-ready time decreased from 407 s to 271 s. A repeat run completed model loading, CUDA graph capture, `/health`, and a correctness request.

## Validation

- `tests/utils_/test_system_utils.py`
- `tests/v1/worker/test_gpu_worker.py`
- Result: `14 passed`
- GPU import probe:
  - before imports: `torch.cuda.is_initialized() == False`
  - after `multiproc_executor`: `False`
  - after `gpu_worker`: `False`

The release helper should keep this opt-in until GLM TP8 and the canonical image complete matched spawn/forkserver E2E validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the `forkserver` multiprocessing method via `VLLM_WORKER_MULTIPROC_METHOD`.
  * Improved server/executor startup to initialize a clean forkserver before accelerator-related imports.
  * Added safeguards to prevent forkserver changes after CUDA/XPU initialization.
  * Kept GPU warmup dependencies lazily loaded to avoid premature accelerator initialization.

* **Tests**
  * Added/expanded coverage for CLI serve bootstrapping, forkserver lifecycle behavior, multiprocessing configuration, and lazy GPU warmup imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->