### PR TITLE
[GG] fix(api): accept empty tools arrays in chat completions

### DIFF
--- a/tests/entrypoints/openai/chat_completion/test_empty_tools_validation.py
+++ b/tests/entrypoints/openai/chat_completion/test_empty_tools_validation.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""An empty tools array must validate like an omitted field (OpenAI parity);
+a tool_choice that forces a call with zero tools must still be rejected."""
+
+import pydantic
+import pytest
+
+from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+
+pytestmark = pytest.mark.cpu_test
+
+MESSAGES = [{"role": "user", "content": "hello"}]
+
+TOOL = {
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "parameters": {"type": "object", "properties": {}},
+    },
+}
+
+NAMED_CHOICE = {"type": "function", "function": {"name": "get_weather"}}
+
+
+@pytest.mark.parametrize(
+    "tool_choice",
+    [
+        pytest.param("absent", id="tool_choice-absent"),
+        pytest.param("auto", id="tool_choice-auto"),
+        pytest.param("none", id="tool_choice-none"),
+        pytest.param(None, id="tool_choice-null"),
+    ],
+)
+def test_empty_tools_accepted_like_omitted(tool_choice):
+    """tools=[] with a non-forcing tool_choice validates like a request
+    that sent neither field."""
+    data = {"messages": MESSAGES, "model": "x", "tools": []}
+    if tool_choice != "absent":
+        data["tool_choice"] = tool_choice
+
+    request = ChatCompletionRequest.model_validate(data)
+
+    assert request.tools is None
+    assert request.tool_choice == "none"
+
+
+@pytest.mark.parametrize(
+    "tool_choice",
+    [
+        pytest.param(NAMED_CHOICE, id="tool_choice-named"),
+        pytest.param("required", id="tool_choice-required"),
+    ],
+)
+def test_empty_tools_with_forcing_tool_choice_rejected(tool_choice):
+    """A forced tool call with zero tools is a genuinely invalid request."""
+    data = {
+        "messages": MESSAGES,
+        "model": "x",
+        "tools": [],
+        "tool_choice": tool_choice,
+    }
+
+    with pytest.raises(pydantic.ValidationError, match="`tools` must be set"):
+        ChatCompletionRequest.model_validate(data)
+
+
+def test_null_tools_accepted():
+    request = ChatCompletionRequest.model_validate(
+        {"messages": MESSAGES, "model": "x", "tools": None}
+    )
+
+    assert request.tools is None
+    assert request.tool_choice == "none"
+
+
+def test_tools_default_tool_choice_auto():
+    """Existing behavior: providing tools defaults tool_choice to auto."""
+    request = ChatCompletionRequest.model_validate(
+        {"messages": MESSAGES, "model": "x", "tools": [TOOL]}
+    )
+
+    assert request.tools is not None
+    assert request.tool_choice == "auto"
+
+
+def test_tool_choice_without_tools_rejected():
+    """Existing behavior: tool_choice=auto without any tools field."""
+    with pytest.raises(pydantic.ValidationError, match="`tools` must be set"):
+        ChatCompletionRequest.model_validate(
+            {"messages": MESSAGES, "model": "x", "tool_choice": "auto"}
+        )

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -863,12 +863,18 @@ class ChatCompletionRequest(OpenAIBaseModel):
         if not isinstance(data, dict):
             return data
 
-        # Reject empty tools array, matching OpenAI API behavior
+        # Treat an empty tools array like an omitted field, matching OpenAI
+        # API behavior; some clients (e.g. Xcode AI assistants) send
+        # tools=[] unconditionally.
         if data.get("tools") == []:
-            raise ValueError(
-                "`tools` must not be an empty array. "
-                "Either provide at least one tool or omit the field entirely."
-            )
+            data.pop("tools")
+            # A dangling tool_choice of "auto"/"none"/explicit null composes
+            # with no-tools by omitting it as well. A named tool or
+            # "required" is left in place so the "When using `tool_choice`,
+            # `tools` must be set" validation below rejects the genuinely
+            # invalid forced call.
+            if data.get("tool_choice") in ("auto", "none", None):
+                data.pop("tool_choice", None)
 
         # if "tool_choice" is not specified but tools are provided,
         # default to "auto" tool_choice


### PR DESCRIPTION
## Summary

- normalize `tools: []` to an omitted tools field for OpenAI API compatibility
- also remove non-forcing `tool_choice` values (`auto`, `none`, or null)
- continue rejecting `required` and named tool choices when no tools exist

This replaces #193 after its source branch was deleted and preserves Florian Bernd's original commit.

## Tests

`python3 -m pytest -q tests/entrypoints/openai/chat_completion/test_empty_tools_validation.py`

Result: 9 passed.