### PR TITLE
[GG] fix(sched): tolerate late KV-transfer completions

### DIFF
--- a/tests/v1/kv_connector/unit/test_late_kv_xfer_completions.py
+++ b/tests/v1/kv_connector/unit/test_late_kv_xfer_completions.py
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Late or duplicate KV-transfer completions must not kill the engine core.
+
+A worker-side connector can report finished_recving/finished_sending for a
+request the scheduler no longer tracks (abort racing an async KV load, or the
+same request reported twice) or tracks in an unexpected status. The scheduler
+must ignore such completions instead of raising AssertionError.
+"""
+
+import copy
+
+import pytest
+
+from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.core.sched.scheduler import Scheduler
+from vllm.v1.outputs import EMPTY_MODEL_RUNNER_OUTPUT, KVConnectorOutput
+from vllm.v1.request import RequestStatus
+
+from .utils import (
+    assert_scheduler_empty,
+    create_model_runner_output,
+    create_request,
+    create_scheduler,
+    create_vllm_config,
+)
+
+pytestmark = pytest.mark.cpu_test
+
+
+def _deliver_kv_connector_output(
+    scheduler: Scheduler, scheduler_output: SchedulerOutput, **kwargs
+) -> None:
+    model_runner_output = copy.deepcopy(EMPTY_MODEL_RUNNER_OUTPUT)
+    model_runner_output.kv_connector_output = KVConnectorOutput(**kwargs)
+    scheduler.update_from_output(scheduler_output, model_runner_output)
+
+
+def test_finished_sending_for_untracked_request_ignored():
+    """finished_sending for an unknown request id is a no-op."""
+    vllm_config = create_vllm_config()
+    scheduler = create_scheduler(vllm_config)
+
+    scheduler_output = scheduler.schedule()
+    _deliver_kv_connector_output(
+        scheduler, scheduler_output, finished_sending={"id-unknown"}
+    )
+
+    assert_scheduler_empty(scheduler)
+
+
+def test_finished_recving_for_untracked_request_ignored():
+    """finished_recving for an unknown request id is a no-op."""
+    vllm_config = create_vllm_config()
+    scheduler = create_scheduler(vllm_config)
+
+    scheduler_output = scheduler.schedule()
+    _deliver_kv_connector_output(
+        scheduler, scheduler_output, finished_recving={"id-unknown"}
+    )
+
+    assert_scheduler_empty(scheduler)
+
+
+def test_finished_recving_for_running_request_keeps_blocks():
+    """A completion for a live request that is not waiting for remote KVs
+    must not free its blocks; the request keeps running and finishes
+    normally."""
+    vllm_config = create_vllm_config()
+    scheduler = create_scheduler(vllm_config)
+    request = create_request(max_tokens=4)
+    scheduler.add_request(request)
+
+    scheduler_output = scheduler.schedule()
+    model_runner_output = create_model_runner_output(
+        reqs=[request], finished_recving={request.request_id}
+    )
+    scheduler.update_from_output(scheduler_output, model_runner_output)
+
+    assert request.status == RequestStatus.RUNNING
+    assert request.request_id not in scheduler.finished_recving_kv_req_ids
+
+    # The request still finishes cleanly and releases everything.
+    scheduler_output = scheduler.schedule()
+    model_runner_output = create_model_runner_output(reqs=[request], use_eos=True)
+    scheduler.update_from_output(scheduler_output, model_runner_output)
+    assert request.is_finished()
+
+    scheduler.schedule()
+    assert_scheduler_empty(scheduler)
+
+
+def test_duplicate_finished_sending_after_free_ignored():
+    """A second finished_sending for a request whose blocks were already
+    freed by the first completion is ignored."""
+    vllm_config = create_vllm_config()
+    scheduler = create_scheduler(vllm_config)
+    request = create_request(do_remote_decode=True)
+    scheduler.add_request(request)
+    request_id = request.request_id
+
+    scheduler_output = scheduler.schedule()
+    model_runner_output = create_model_runner_output(reqs=[request])
+    scheduler.update_from_output(scheduler_output, model_runner_output)
+    assert request.is_finished()
+
+    # Pass the finished request to the persistent batch.
+    scheduler_output = scheduler.schedule()
+    scheduler.update_from_output(scheduler_output, EMPTY_MODEL_RUNNER_OUTPUT)
+
+    # The first completion frees the blocks.
+    scheduler_output = scheduler.schedule()
+    _deliver_kv_connector_output(
+        scheduler, scheduler_output, finished_sending={request_id}
+    )
+    assert_scheduler_empty(scheduler)
+
+    # The duplicate completion is ignored.
+    scheduler_output = scheduler.schedule()
+    _deliver_kv_connector_output(
+        scheduler, scheduler_output, finished_sending={request_id}
+    )
+    assert_scheduler_empty(scheduler)

--- a/tests/v1/kv_connector/unit/test_late_kv_xfer_completions.py
+++ b/tests/v1/kv_connector/unit/test_late_kv_xfer_completions.py
@@ -90,6 +90,30 @@ def test_finished_recving_for_running_request_keeps_blocks():
     assert_scheduler_empty(scheduler)
 
 
+def test_finished_sending_for_running_request_keeps_blocks():
+    vllm_config = create_vllm_config()
+    scheduler = create_scheduler(vllm_config)
+    request = create_request(max_tokens=4)
+    scheduler.add_request(request)
+
+    scheduler_output = scheduler.schedule()
+    model_runner_output = create_model_runner_output(
+        reqs=[request], finished_sending={request.request_id}
+    )
+    scheduler.update_from_output(scheduler_output, model_runner_output)
+
+    assert request.status == RequestStatus.RUNNING
+
+    # The request still owns its blocks and can finish normally.
+    scheduler_output = scheduler.schedule()
+    model_runner_output = create_model_runner_output(reqs=[request], use_eos=True)
+    scheduler.update_from_output(scheduler_output, model_runner_output)
+    assert request.is_finished()
+
+    scheduler.schedule()
+    assert_scheduler_empty(scheduler)
+
+
 def test_duplicate_finished_sending_after_free_ignored():
     """A second finished_sending for a request whose blocks were already
     freed by the first completion is ignored."""

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -2686,19 +2686,47 @@ class Scheduler(SchedulerInterface):
             self.connector.update_connector_output(kv_connector_output)
 
         # KV Connector:: update recv and send status from last step.
+        # Late or duplicate completions can arrive for requests that are no
+        # longer tracked (e.g. an abort racing an async KV load, or a
+        # connector reporting the same request twice); tolerate them instead
+        # of asserting, which would kill the engine core.
         for req_id in kv_connector_output.finished_recving or ():
             logger.debug("Finished recving KV transfer for request %s", req_id)
-            assert req_id in self.requests
-            req = self.requests[req_id]
+            req = self.requests.get(req_id)
+            if req is None:
+                logger.warning(
+                    "Finished recving KV transfer for request %s, but the "
+                    "request is no longer tracked; ignoring late/duplicate "
+                    "completion.",
+                    req_id,
+                )
+                continue
             if req.status == RequestStatus.WAITING_FOR_REMOTE_KVS:
                 self.finished_recving_kv_req_ids.add(req_id)
+            elif RequestStatus.is_finished(req.status):
+                self._free_blocks(req)
             else:
-                assert RequestStatus.is_finished(req.status)
-                self._free_blocks(self.requests[req_id])
+                # Freeing the blocks of a live request would corrupt
+                # scheduler state, so leave the request alone.
+                logger.warning(
+                    "Finished recving KV transfer for request %s in "
+                    "unexpected status %s; ignoring late/duplicate "
+                    "completion.",
+                    req_id,
+                    req.status,
+                )
         for req_id in kv_connector_output.finished_sending or ():
             logger.debug("Finished sending KV transfer for request %s", req_id)
-            assert req_id in self.requests
-            self._free_blocks(self.requests[req_id])
+            req = self.requests.get(req_id)
+            if req is None:
+                logger.warning(
+                    "Finished sending KV transfer for request %s, but the "
+                    "request is no longer tracked; ignoring late/duplicate "
+                    "completion.",
+                    req_id,
+                )
+                continue
+            self._free_blocks(req)
 
     def _update_requests_with_invalid_blocks(
         self,

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -2726,7 +2726,18 @@ class Scheduler(SchedulerInterface):
                     req_id,
                 )
                 continue
-            self._free_blocks(req)
+            if RequestStatus.is_finished(req.status):
+                self._free_blocks(req)
+            else:
+                # A stale completion must never release blocks still owned by
+                # a live request.
+                logger.warning(
+                    "Finished sending KV transfer for request %s in "
+                    "unexpected status %s; ignoring late/duplicate "
+                    "completion.",
+                    req_id,
+                    req.status,
+                )
 
     def _update_requests_with_invalid_blocks(
         self,


### PR DESCRIPTION
## Summary

- tolerate late or duplicate KV receive/send completions for requests that are no longer tracked
- preserve live request ownership when a stale completion arrives in an unexpected status
- retain normal cleanup for completed requests

This replaces #192 after its source branch was deleted. It preserves Florian Bernd's original commit and adds the send-side live-request guard requested in review.

## Why

LMCache MP with async scheduling can deliver a completion after abort cleanup or report a completion twice. Assertions in the scheduler then terminate EngineCore. A stale send completion must also never free blocks still owned by a running request.

## Tests

`python3 -m pytest -q tests/v1/kv_connector/unit/test_late_kv_xfer_completions.py`

Result: 5 passed.