### PR TITLE
[KV Offload] Deduplicate lockstep MLA pending job cleanup

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -458,7 +458,10 @@ class OffloadingConnectorScheduler:
         return job_id
 
     def _remove_pending_job(self, job_id: int, block_ids: list[int] | None) -> None:
-        for bid in block_ids or ():
+        # Lockstep MLA groups share physical block IDs, so a transfer job may
+        # contain the same ID once per logical group. The pending-job index is
+        # set-backed and therefore registers each (block, job) pair only once.
+        for bid in set(block_ids or ()):
             pending = self._block_id_to_pending_jobs[bid]
             pending.remove(job_id)
             if not pending:


### PR DESCRIPTION
This fixes another bug with native KV offload (now superseded by LMCache, for completeness)

Lockstep MLA groups share physical block IDs, so a transfer job may contain the same block ID once per logical group. Iterate the deduplicated set of block IDs in _remove_pending_job() so each (block, job) pair is only removed once from the set-backed pending-job index, instead of crashing with KeyError on the second occurrence.

Fixes a KeyError in _remove_pending_job() observed when KV cache offloading (--kv-offloading-size) is enabled while serving GLM-5.2 (MLA + decode context parallelism), reproduced by
offload-fix-glm52/probe_gpu_cache.py.




## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transfer-job cleanup when duplicate block identifiers are present.
  * Prevented repeated removals and incorrect pending-job tracking during offloading operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->