### PR TITLE
[GG] Measure repeatable activation peak after kernel warmup

### DIFF
--- a/tests/v1/worker/test_gpu_worker.py
+++ b/tests/v1/worker/test_gpu_worker.py
@@ -111,6 +111,7 @@ def test_memory_profile_replays_model_after_kernel_warmup(
 ):
     worker = object.__new__(Worker)
     calls = []
+    worker.device = "cuda:0"
     worker.model_runner = SimpleNamespace(
         profile_run=lambda: calls.append("profile"),
     )
@@ -127,10 +128,21 @@ def test_memory_profile_replays_model_after_kernel_warmup(
         "_warmup_kernels_once",
         lambda: calls.append("kernel_warmup"),
     )
+    monkeypatch.setattr(
+        gpu_worker_module.torch.accelerator,
+        "reset_peak_memory_stats",
+        lambda device: calls.append(("reset_peak", device)),
+    )
 
     worker._profile_model_with_kernel_warmup()
 
-    assert calls == ["profile", "compressor", "kernel_warmup", "profile"]
+    assert calls == [
+        "profile",
+        "compressor",
+        "kernel_warmup",
+        ("reset_peak", "cuda:0"),
+        "profile",
+    ]
 
 
 @pytest.mark.parametrize("video_backend", [None, "opencv"])

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -486,6 +486,12 @@ class Worker(WorkerBase):
         )
         self._warmup_kernels_once()
 
+        # The first pass may include one-time compiler or loader temporaries.
+        # Keep every persistent allocation initialized above, but exclude that
+        # startup-only high-water mark from the activation measurement. The
+        # second pass below establishes the repeatable serving peak.
+        torch.accelerator.reset_peak_memory_stats(self.device)
+
         # Kernel warmup can create persistent modules and communication pools.
         # A second pass is required so the measured peak contains both those
         # allocations and the model's transient activation workspace.


### PR DESCRIPTION
## Problem

`determine_available_memory()` profiles a warmup pass and a second serving pass inside one peak-memory window. The first pass can include one-time compiler or loader temporaries. A transient on one rank then permanently reduces the distributed KV-cache allocation even though that memory is freed before serving.

This was reproduced with the TP4/DCP4 EXL3 path: identical cold starts varied from 834,560 down to 778,496 KV tokens, with one rank reporting 2.10 GiB peak activation while all ranks had identical live memory before the second pass.

## Fix

Reset only the accelerator peak counter after persistent kernel warmup and before the second profile pass. Live allocations are not freed or hidden; persistent buffers remain counted relative to the original baseline. The second pass establishes the repeatable serving activation peak.

A regression test locks the ordering: initial profile, compressor warmup, kernel warmup, peak reset, measured profile.

## Validation

- Targeted worker tests: 3 passed
- TP4/DCP4/MTP0, three complete cold starts: 834,560 KV tokens every time; 1.62 GiB activation peak on every rank
- MTP0 decode: 48.00 and 48.58 tok/s, no errors
- TP4/DCP4/MTP3: 485,888 KV tokens; 101.02 tok/s; acceptance 0.6847; no errors
- `git diff --check` and `py_compile`: clean

Paired EXL3 consumer: #190