### PR TITLE
fix(spec-decode): separate AR draft Philox stream

### DIFF
--- a/tests/v1/worker/test_gpu_autoregressive_speculator.py
+++ b/tests/v1/worker/test_gpu_autoregressive_speculator.py
@@ -80,3 +80,46 @@ def test_run_model_reuses_tensor_return_for_mtp(monkeypatch):
 
     assert actual_logits_hidden is hidden
     assert actual_feedback_hidden is hidden
+
+
+def test_probabilistic_draft_uses_disjoint_philox_offsets(monkeypatch):
+    captured_positions = None
+
+    def fake_gumbel_sample(
+        logits,
+        idx_mapping,
+        temperature,
+        seeds,
+        positions,
+        **kwargs,
+    ):
+        nonlocal captured_positions
+        captured_positions = positions
+        return torch.zeros(logits.shape[0], dtype=torch.int64)
+
+    monkeypatch.setattr(spec_module, "gumbel_sample", fake_gumbel_sample)
+    speculator = object.__new__(_TestSpeculator)
+    speculator.model = SimpleNamespace(
+        compute_logits=lambda hidden_states: torch.zeros(hidden_states.shape[0], 5)
+    )
+    speculator.active_num_reqs = torch.tensor(2, dtype=torch.int32)
+    speculator.use_fp64_gumbel = False
+    positions = torch.tensor([12, 99], dtype=torch.int64)
+
+    speculator.sample_draft(
+        hidden_states=torch.zeros(2, 3),
+        positions=positions,
+        idx_mapping=torch.arange(2),
+        temperature=torch.ones(2),
+        seeds=torch.tensor([7, 11], dtype=torch.int64),
+        draft_step=torch.tensor(0, dtype=torch.int64),
+        draft_logits=torch.empty(2, 5),
+    )
+
+    assert captured_positions is not None
+    torch.testing.assert_close(
+        captured_positions,
+        positions + 1 + (1 << 30),
+        rtol=0,
+        atol=0,
+    )

--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
@@ -23,6 +23,7 @@ from vllm.v1.worker.gpu.spec_decode.autoregressive.cudagraph_utils import (
     SpeculatorCudaGraphManager,
 )
 from vllm.v1.worker.gpu.spec_decode.speculator import DraftModelSpeculator
+from vllm.v1.worker.gpu.spec_decode.utils import draft_gumbel_pos
 
 logger = init_logger(__name__)
 
@@ -369,14 +370,14 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
     ) -> torch.Tensor:
         logits = self.model.compute_logits(hidden_states)
         if draft_logits is not None:
-            # NOTE(woosuk): We must add 1 to the positions to match the Gumbel noise
-            # used for draft and target sampling.
+            # Draft proposal noise must not reuse the rejection sampler's
+            # acceptance and recovery Philox offsets.
             return gumbel_sample(
                 logits,
                 idx_mapping,
                 temperature,
                 seeds,
-                positions + 1,
+                draft_gumbel_pos(positions),
                 apply_temperature=True,
                 output_processed_logits=draft_logits,
                 output_processed_logits_col=draft_step,


### PR DESCRIPTION
## Summary

Move probabilistic proposal noise in the V2 autoregressive speculator onto the documented salted draft Philox range, so rejection recovery cannot reuse the exact Gumbel field that selected the rejected draft token.

Fixes #205.

## Corrected scope

The issue's re-review established the exact live surface:

- affected: V2 `AutoRegressiveSpeculator` with probabilistic drafts and sampled requests;
- unaffected: greedy drafts, the V1 proposer, DFlash/DSpark, and the all-accepted bonus draw;
- shipped live preset: plain `glm52` / `glm52-hybrid` with `MTP>0`, V2, default probabilistic draft sampling;
- r12 EXL3 release gate is greedy and the production turnkey uses V1, so neither executes this line.

The first-order defect is recovery after rejection. The verifier reuses the rejected draft token's unsalted `(seed, offset)` and therefore the exact per-vocabulary Gumbel vector conditioned on that draft having won. Acceptance-word correlation is negligible; the bonus offset is already disjoint.

## Change

Replace:

```python
positions + 1
```

with:

```python
draft_gumbel_pos(positions)
```

in `AutoRegressiveSpeculator.sample_draft`.

The override remains intact. In particular, it still forwards `output_processed_logits_active_rows=self.active_num_reqs`, which prevents padded FULL-graph rows from overwriting real request state.

## Invariants

- Draft proposal offsets become `positions + 1 + 2**30`, exactly disjoint from verifier offsets.
- The existing int64 tensor shape and one elementwise add are unchanged; only the immediate changes.
- FULL-graph active-row protection is unchanged.
- Greedy behavior, bonus offsets, acceptance logic, capture operation count, allocations, public ABI, and non-AR speculators are unchanged.
- Output tokens can change bit-for-bit on the affected probabilistic path; distributionally this restores the rejection sampler's independence contract.

## Verification

CPU-isolated r12 container:

```text
3 passed
```

The new regression constructs the real AR override with probabilistic draft logits, intercepts `gumbel_sample`, and asserts the exact passed position tensor is:

```text
positions + 1 + 2**30
```

Additional checks:

- Ruff lint and format: pass
- `git diff --check`: pass
- independent adversarial review: APPROVE, confidence 0.99, no findings

The reviewer re-derived the draft/rejection offset algebra and confirmed the rejected-token collision is removed while bonus range, FULL-graph safeguards, dtype/shape, and greedy behavior remain unchanged.

No acceptance-rate or user-visible distribution magnitude claim is made without the optional statistical A/B. Production was not rebuilt or restarted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved speculative decoding’s probabilistic draft sampling to use separate random-number generator offsets, preventing overlap with acceptance and recovery sampling.
  * Deterministic draft sampling behavior remains unchanged.

* **Tests**
  * Added coverage verifying that probabilistic draft sampling uses disjoint random-number generator offsets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->