### PR TITLE
[GG] Bound EXL3 Trellis prefill arena capacity

### DIFF
--- a/tests/quantization/test_exl3_prefill_plan.py
+++ b/tests/quantization/test_exl3_prefill_plan.py
@@ -7,7 +7,8 @@ The planned Trellis API and the ExLlamaV3 extension are mocked; these tests
 prove backend policy only:
 
 * decode window m in [min, max] binds the decode plan;
-* max < m <= capacity binds the prefill plan (block_size_m=64 by default);
+* max < m <= scheduler capacity binds capacity-bounded prefill slices;
+* the opt-in prefill capacity defaults to the scheduler capacity;
 * m < min stays on the parity path with chunk-capped staging buffers;
 * VLLM_EXL3_PREFILL_TRELLIS=0 restores the single-plan parity behavior
   with full-capacity staging;
@@ -50,6 +51,7 @@ class _FakeFusedMoeApi:
     def __init__(self):
         self.planned = []
         self.bound = []
+        self.routed = []
 
     def Caps(self, **kwargs):
         return kwargs
@@ -60,12 +62,37 @@ class _FakeFusedMoeApi:
         return plan
 
     def bind(self, plan, *, scratch, a, experts, topk_weights, topk_ids):
-        del scratch, experts, topk_weights, topk_ids
+        del scratch, experts
         self.bound.append((plan, int(a.shape[0])))
-        return SimpleNamespace(plan=plan, m=int(a.shape[0]))
+        self.routed.append((topk_weights.clone(), topk_ids.clone()))
+        return SimpleNamespace(plan=plan, a=a)
 
     def run(self, *, binding):
-        return torch.zeros((binding.m, HIDDEN), dtype=torch.float32)
+        return binding.a.to(torch.float32)
+
+
+class _FakeMixedTrellisApi:
+    def __init__(self):
+        self.compiled = []
+        self.routed = []
+
+    def max_packed_route_slots(self, routed_rows, block_size, experts):
+        del block_size, experts
+        return routed_rows
+
+    def compile_mixed_trellis(self, **kwargs):
+        launch = SimpleNamespace(**kwargs)
+        self.compiled.append(launch)
+        return launch
+
+    def make_mixed_trellis_buffers(self, launch, **kwargs):
+        del kwargs
+        return SimpleNamespace(scratch=torch.empty(launch.size_m, dtype=torch.uint8))
+
+    def run_mixed_trellis(self, *args):
+        x, topk_weights, topk_ids = args[0], args[3], args[4]
+        self.routed.append((topk_weights.clone(), topk_ids.clone()))
+        return x.to(torch.float32)
 
 
 class _FakeExt:
@@ -96,6 +123,21 @@ def _make_layer():
     )
 
 
+def _make_mixed_layer():
+    layer = _make_layer()
+    layer.exl3_mixed_bitrate = True
+    layer.exl3_mixed_trellis = {
+        "tiers": (object(), object()),
+        "tier_ids": ((0, 1, 2, 3), (4, 5, 6, 7)),
+        "tier_bits": (3, 4),
+        "global_to_combined": object(),
+        "descriptor_map": object(),
+        "rotations": object(),
+        "tile_config": (64, 128, 64, 128),
+    }
+    return layer
+
+
 def _make_method():
     method = object.__new__(Exl3MoEMethod)
     method.quant_config = SimpleNamespace(
@@ -112,6 +154,7 @@ class _Harness:
         self._saved_capturing = None
         self.api = _FakeFusedMoeApi()
         self.ext = _FakeExt()
+        self.mixed_api = _FakeMixedTrellisApi()
 
     def __enter__(self):
         for name, value in self._env.items():
@@ -122,30 +165,41 @@ class _Harness:
                 os.environ[name] = value
         self._saved_loaders = (
             exl3_module._load_sparkinfer_fused_moe,
+            exl3_module._load_sparkinfer_mixed_trellis,
             exl3_module._load_exl3_ext,
         )
         exl3_module._load_sparkinfer_fused_moe = lambda: self.api
+        exl3_module._load_sparkinfer_mixed_trellis = lambda: self.mixed_api
         exl3_module._load_exl3_ext = lambda: self.ext
         self._saved_capturing = torch.cuda.is_current_stream_capturing
         torch.cuda.is_current_stream_capturing = lambda: False
         self._saved_current_device = torch.cuda.current_device
         torch.cuda.current_device = lambda: 0
+        self._saved_device_properties = torch.cuda.get_device_properties
+        torch.cuda.get_device_properties = lambda device: SimpleNamespace(
+            multi_processor_count=1,
+            shared_memory_per_block_optin=1,
+        )
         exl3_module._RANK_SLICED_RUNTIMES.clear()
+        exl3_module._MIXED_TRELLIS_RUNTIMES.clear()
         return self
 
     def __exit__(self, *exc):
         (
             exl3_module._load_sparkinfer_fused_moe,
+            exl3_module._load_sparkinfer_mixed_trellis,
             exl3_module._load_exl3_ext,
         ) = self._saved_loaders
         torch.cuda.is_current_stream_capturing = self._saved_capturing
         torch.cuda.current_device = self._saved_current_device
+        torch.cuda.get_device_properties = self._saved_device_properties
         for name, value in self._saved_env.items():
             if value is None:
                 os.environ.pop(name, None)
             else:
                 os.environ[name] = value
         exl3_module._RANK_SLICED_RUNTIMES.clear()
+        exl3_module._MIXED_TRELLIS_RUNTIMES.clear()
         return False
 
     def planned_caps(self):
@@ -159,24 +213,26 @@ def _apply(method, layer, m):
     return method._apply_rank_sliced(layer, x, weights, ids)
 
 
-def test_dual_plan_construction_and_dispatch():
-    with _Harness() as h:
+def test_opt_in_prefill_capacity_slices_dispatch():
+    with _Harness(env={"VLLM_EXL3_PREFILL_CAPACITY": "128"}) as h:
         method = _make_method()
         layer = _make_layer()
 
         out = _apply(method, layer, 16)
         assert out.dtype == torch.bfloat16 and out.shape == (16, HIDDEN)
-        # Two plans: decode (32, block 8) then prefill (capacity, block 64).
+        # Two plans: decode (32, block 8), then bounded prefill (block 64).
         assert [
             (caps["max_tokens"], caps["w4a16_block_size_m"])
             for caps in h.planned_caps()
-        ] == [(32, 8), (MAX_BATCHED, 64)]
+        ] == [(32, 8), (128, 64)]
         assert all(caps["route_num_experts"] == 0 for caps in h.planned_caps())
         assert h.api.bound[-1][0].caps["max_tokens"] == 32
 
         _apply(method, layer, 200)
-        assert h.api.bound[-1][0].caps["max_tokens"] == MAX_BATCHED
-        assert h.api.bound[-1][1] == 200
+        assert all(
+            bound[0].caps["max_tokens"] == 128 for bound in h.api.bound[-2:]
+        )
+        assert [bound[1] for bound in h.api.bound[-2:]] == [128, 72]
         assert not h.ext.moe_calls
 
         _apply(method, layer, 2)
@@ -188,6 +244,7 @@ def test_dual_plan_construction_and_dispatch():
         assert runtime["parity_rows"] == 128
         assert runtime["xh"].shape[0] == 128
         assert runtime["token_sorted"].numel() == 128 * TOPK
+        assert runtime["prefill_capacity"] == 128
 
         # Batches above the scheduler contract must fail before allocating a
         # replacement runtime or a larger Trellis arena during serving.
@@ -202,6 +259,86 @@ def test_dual_plan_construction_and_dispatch():
         assert tuple(exl3_module._RANK_SLICED_RUNTIMES) == runtime_keys
         assert len(exl3_module._RANK_SLICED_RUNTIMES) == runtime_count
         assert len(h.planned_caps()) == plan_count
+
+
+@pytest.mark.parametrize(
+    ("rows", "expected_slice_rows"),
+    ((127, [127]), (128, [128]), (129, [128, 1])),
+)
+def test_prefill_capacity_boundaries_preserve_rows_and_routing(
+    rows, expected_slice_rows
+):
+    with _Harness(env={"VLLM_EXL3_PREFILL_CAPACITY": "128"}) as h:
+        method = _make_method()
+        layer = _make_layer()
+        x = (
+            torch.arange(rows, dtype=torch.bfloat16)
+            .unsqueeze(1)
+            .expand(-1, HIDDEN)
+        )
+        weights = torch.arange(rows * TOPK, dtype=torch.float32).reshape(
+            rows, TOPK
+        )
+        ids = torch.arange(rows * TOPK, dtype=torch.int64).reshape(rows, TOPK)
+        ids = ids.remainder(EXPERTS)
+
+        out = method._apply_rank_sliced(layer, x, weights, ids)
+
+        assert [bound[1] for bound in h.api.bound] == expected_slice_rows
+        assert torch.equal(out, x)
+        assert torch.equal(
+            torch.cat([route[0] for route in h.api.routed]), weights
+        )
+        assert torch.equal(torch.cat([route[1] for route in h.api.routed]), ids)
+        assert all(bound[0] is h.api.bound[0][0] for bound in h.api.bound)
+
+
+def test_default_prefill_capacity_keeps_single_dispatch():
+    with _Harness() as h:
+        out = _apply(_make_method(), _make_layer(), 200)
+
+        assert h.planned_caps()[-1]["max_tokens"] == MAX_BATCHED
+        assert [bound[1] for bound in h.api.bound] == [200]
+        assert out.shape == (200, HIDDEN)
+
+
+def test_mixed_prefill_capacity_slices_rows_and_routing():
+    with _Harness(env={"VLLM_EXL3_PREFILL_CAPACITY": "128"}) as h:
+        method = _make_method()
+        layer = _make_mixed_layer()
+        rows = 200
+        x = (
+            torch.arange(rows, dtype=torch.bfloat16)
+            .unsqueeze(1)
+            .expand(-1, HIDDEN)
+        )
+        weights = torch.arange(rows * TOPK, dtype=torch.float32).reshape(
+            rows, TOPK
+        )
+        ids = torch.arange(rows * TOPK, dtype=torch.int64).reshape(rows, TOPK)
+        ids = ids.remainder(EXPERTS)
+
+        out = method._apply_rank_sliced(layer, x, weights, ids)
+
+        assert [launch.size_m for launch in h.mixed_api.compiled] == [32, 128]
+        assert [route[0].shape[0] for route in h.mixed_api.routed] == [128, 72]
+        assert torch.equal(out, x)
+        assert torch.equal(
+            torch.cat([route[0] for route in h.mixed_api.routed]), weights
+        )
+        assert torch.equal(
+            torch.cat([route[1] for route in h.mixed_api.routed]), ids
+        )
+
+
+def test_prefill_capacity_cannot_exceed_scheduler_bound():
+    env = {"VLLM_EXL3_PREFILL_CAPACITY": str(MAX_BATCHED + 1)}
+    with _Harness(env=env) as h:
+        with pytest.raises(
+            ValueError, match="cannot exceed max_num_batched_tokens"
+        ):
+            _apply(_make_method(), _make_layer(), 16)
+        assert not h.planned_caps()
 
 
 def test_prefill_trellis_disabled_restores_parity():
@@ -221,16 +358,19 @@ def test_prefill_trellis_disabled_restores_parity():
         runtime = next(iter(exl3_module._RANK_SLICED_RUNTIMES.values()))
         assert runtime["prefill_plan"] is None
         assert runtime["parity_rows"] == MAX_BATCHED
-        assert runtime["xh"].shape[0] == MAX_BATCHED
 
 
 def test_prefill_block_m_env_override():
-    with _Harness(env={"VLLM_EXL3_PREFILL_BLOCK_M": "48"}) as h:
+    env = {
+        "VLLM_EXL3_PREFILL_BLOCK_M": "48",
+        "VLLM_EXL3_PREFILL_CAPACITY": "128",
+    }
+    with _Harness(env=env) as h:
         method = _make_method()
         layer = _make_layer()
         _apply(method, layer, 40)
         assert h.planned_caps()[-1]["w4a16_block_size_m"] == 48
-        assert h.api.bound[-1][0].caps["max_tokens"] == MAX_BATCHED
+        assert h.api.bound[-1][0].caps["max_tokens"] == 128
 
 
 def test_parity_window_capacity_is_validated_before_planning():
@@ -259,7 +399,11 @@ def test_disabled_prefill_plan_keeps_full_parity_capacity():
 
 
 def test_explicit_parity_path_guarded_against_capture():
-    with _Harness(env={"VLLM_EXL3_TRELLIS_MIN_M": "4"}) as h:
+    env = {
+        "VLLM_EXL3_TRELLIS_MIN_M": "4",
+        "VLLM_EXL3_PREFILL_CAPACITY": "128",
+    }
+    with _Harness(env=env) as h:
         method = _make_method()
         layer = _make_layer()
         # Plan eagerly, then flip into "capturing" state.
@@ -268,18 +412,14 @@ def test_explicit_parity_path_guarded_against_capture():
         # Both trellis plans stay capture-safe.
         _apply(method, layer, 16)
         _apply(method, layer, 200)
-        assert h.api.bound[-1][1] == 200
+        assert [bound[1] for bound in h.api.bound[-2:]] == [128, 72]
         # The eager parity path must refuse to be recorded.
-        try:
+        with pytest.raises(RuntimeError, match="capture"):
             _apply(method, layer, 2)
-        except RuntimeError as err:
-            assert "capture" in str(err)
-        else:
-            raise AssertionError("parity path must raise during capture")
 
 
 if __name__ == "__main__":
-    test_dual_plan_construction_and_dispatch()
+    test_opt_in_prefill_capacity_slices_dispatch()
     test_prefill_trellis_disabled_restores_parity()
     test_prefill_block_m_env_override()
     test_explicit_parity_path_guarded_against_capture()

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -2287,6 +2287,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_EXL3_TRELLIS_MAX_M": lambda: os.getenv("VLLM_EXL3_TRELLIS_MAX_M"),
     "VLLM_EXL3_TRELLIS_BLOCK_M": lambda: os.getenv("VLLM_EXL3_TRELLIS_BLOCK_M"),
     "VLLM_EXL3_PREFILL_CHUNK": lambda: os.getenv("VLLM_EXL3_PREFILL_CHUNK"),
+    "VLLM_EXL3_PREFILL_CAPACITY": lambda: os.getenv(
+        "VLLM_EXL3_PREFILL_CAPACITY"
+    ),
     "VLLM_EXL3_PREFILL_TRELLIS": lambda: os.getenv("VLLM_EXL3_PREFILL_TRELLIS"),
     "VLLM_EXL3_PREFILL_BLOCK_M": lambda: os.getenv("VLLM_EXL3_PREFILL_BLOCK_M"),
     # Prebuilt exllamav3 extension location and torch-ABI compatibility shim.

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -283,6 +283,18 @@ def _positive_env_int(name: str, default: int) -> int:
         raise ValueError(f"{name} must be positive, got {value}")
     return value
 
+def _resolve_prefill_capacity(max_batched_tokens: int) -> int:
+    prefill_capacity = _positive_env_int(
+        "VLLM_EXL3_PREFILL_CAPACITY", max_batched_tokens
+    )
+    if prefill_capacity > max_batched_tokens:
+        raise ValueError(
+            "VLLM_EXL3_PREFILL_CAPACITY cannot exceed "
+            "max_num_batched_tokens: "
+            f"capacity={prefill_capacity}, max={max_batched_tokens}"
+        )
+    return prefill_capacity
+
 
 @torch.library.custom_op(
     "vllm::exl3_gemm",
@@ -1834,15 +1846,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         mixed = layer.exl3_mixed_trellis
         max_decode_m = _positive_env_int("VLLM_EXL3_TRELLIS_MAX_M", 32)
         max_batched_tokens = int(layer.exl3_max_num_batched_tokens)
-        prefill_capacity = _positive_env_int(
-            "VLLM_EXL3_PREFILL_CAPACITY", max_batched_tokens
-        )
-        if prefill_capacity > max_batched_tokens:
-            raise ValueError(
-                "VLLM_EXL3_PREFILL_CAPACITY cannot exceed "
-                "max_num_batched_tokens: "
-                f"capacity={prefill_capacity}, max={max_batched_tokens}"
-            )
+        prefill_capacity = _resolve_prefill_capacity(max_batched_tokens)
         if max_decode_m > max_batched_tokens:
             max_decode_m = max_batched_tokens
         topk = int(topk_ids.shape[1])
@@ -2032,15 +2036,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         # bound remains fail-closed while a smaller opt-in Trellis capacity is
         # handled by slicing at dispatch.
         max_batched_tokens = int(layer.exl3_max_num_batched_tokens)
-        prefill_capacity = _positive_env_int(
-            "VLLM_EXL3_PREFILL_CAPACITY", max_batched_tokens
-        )
-        if prefill_capacity > max_batched_tokens:
-            raise ValueError(
-                "VLLM_EXL3_PREFILL_CAPACITY cannot exceed "
-                "max_num_batched_tokens: "
-                f"capacity={prefill_capacity}, max={max_batched_tokens}"
-            )
+        prefill_capacity = _resolve_prefill_capacity(max_batched_tokens)
         prefill_plan_enabled = prefill_trellis and max_batched_tokens > max_trellis_m
         parity_rows = (
             min(chunk, max_batched_tokens)

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -1834,6 +1834,15 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         mixed = layer.exl3_mixed_trellis
         max_decode_m = _positive_env_int("VLLM_EXL3_TRELLIS_MAX_M", 32)
         max_batched_tokens = int(layer.exl3_max_num_batched_tokens)
+        prefill_capacity = _positive_env_int(
+            "VLLM_EXL3_PREFILL_CAPACITY", max_batched_tokens
+        )
+        if prefill_capacity > max_batched_tokens:
+            raise ValueError(
+                "VLLM_EXL3_PREFILL_CAPACITY cannot exceed "
+                "max_num_batched_tokens: "
+                f"capacity={prefill_capacity}, max={max_batched_tokens}"
+            )
         if max_decode_m > max_batched_tokens:
             max_decode_m = max_batched_tokens
         topk = int(topk_ids.shape[1])
@@ -1852,6 +1861,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             topk,
             max_decode_m,
             max_batched_tokens,
+            prefill_capacity,
             mixed["tile_config"],
         )
         runtime = _MIXED_TRELLIS_RUNTIMES.get(key)
@@ -1909,7 +1919,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
 
         decode = make_state(max_decode_m)
         prefill = (
-            make_state(max_batched_tokens)
+            make_state(prefill_capacity)
             if max_batched_tokens > max_decode_m
             else decode
         )
@@ -1919,6 +1929,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             "prefill": prefill,
             "max_decode_m": max_decode_m,
             "max_batched_tokens": max_batched_tokens,
+            "prefill_capacity": prefill_capacity,
         }
         _MIXED_TRELLIS_RUNTIMES[key] = runtime
         buffer_bytes = _unique_tensor_storage_bytes(
@@ -1926,9 +1937,10 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         )
         logger.info_once(
             "EXL3 mixed Trellis runtime planned: tiers=%s decode_capacity=%d "
-            "prefill_capacity=%d buffers=%.1f MiB",
+            "prefill_capacity=%d scheduler_capacity=%d buffers=%.1f MiB",
             tier_signature,
             max_decode_m,
+            prefill_capacity,
             max_batched_tokens,
             buffer_bytes / (1 << 20),
         )
@@ -1952,19 +1964,39 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             runtime["decode"] if m <= runtime["max_decode_m"] else runtime["prefill"]
         )
         mixed = layer.exl3_mixed_trellis
-        output = runtime["api"].run_mixed_trellis(
-            x,
-            mixed["tiers"][0],
-            mixed["tiers"][1],
-            topk_weights,
-            topk_ids,
-            mixed["global_to_combined"],
-            mixed["descriptor_map"],
-            mixed["rotations"],
-            state["launch"],
-            state["buffers"],
-        )
-        return output.to(x.dtype)
+
+        def run_slice(
+            slice_x: torch.Tensor,
+            slice_weights: torch.Tensor,
+            slice_ids: torch.Tensor,
+        ) -> torch.Tensor:
+            return runtime["api"].run_mixed_trellis(
+                slice_x,
+                mixed["tiers"][0],
+                mixed["tiers"][1],
+                slice_weights,
+                slice_ids,
+                mixed["global_to_combined"],
+                mixed["descriptor_map"],
+                mixed["rotations"],
+                state["launch"],
+                state["buffers"],
+            )
+
+        prefill_capacity = int(runtime["prefill_capacity"])
+        if m <= runtime["max_decode_m"] or m <= prefill_capacity:
+            return run_slice(x, topk_weights, topk_ids).to(x.dtype)
+
+        output = torch.empty_like(x)
+        for start in range(0, m, prefill_capacity):
+            stop = min(start + prefill_capacity, m)
+            slice_output = run_slice(
+                x[start:stop],
+                topk_weights[start:stop],
+                topk_ids[start:stop],
+            )
+            output[start:stop].copy_(slice_output)
+        return output
 
     def _rank_sliced_runtime(
         self,
@@ -1996,12 +2028,19 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             raise ValueError(
                 "VLLM_EXL3_TRELLIS_MIN_M cannot exceed VLLM_EXL3_TRELLIS_MAX_M"
             )
-        # Batch-INVARIANT capacity. Including x.shape[0] here made the runtime
-        # cache key depend on the live batch, so any m above the planned capacity
-        # produced a cache MISS -- silently planning a fresh ~1 GiB arena mid-serve
-        # and making the capacity guard in _apply_rank_sliced unreachable. The
-        # planned capacity is a property of the layer, not of one forward pass.
+        # Both capacities are batch-invariant runtime properties. The scheduler
+        # bound remains fail-closed while a smaller opt-in Trellis capacity is
+        # handled by slicing at dispatch.
         max_batched_tokens = int(layer.exl3_max_num_batched_tokens)
+        prefill_capacity = _positive_env_int(
+            "VLLM_EXL3_PREFILL_CAPACITY", max_batched_tokens
+        )
+        if prefill_capacity > max_batched_tokens:
+            raise ValueError(
+                "VLLM_EXL3_PREFILL_CAPACITY cannot exceed "
+                "max_num_batched_tokens: "
+                f"capacity={prefill_capacity}, max={max_batched_tokens}"
+            )
         prefill_plan_enabled = prefill_trellis and max_batched_tokens > max_trellis_m
         parity_rows = (
             min(chunk, max_batched_tokens)
@@ -2036,6 +2075,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             prefill_trellis,
             prefill_block_m,
             layer.exl3_trellis_tile_config,
+            prefill_capacity,
         )
         runtime = _RANK_SLICED_RUNTIMES.get(key)
         if runtime is not None:
@@ -2079,7 +2119,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         prefill_scratch = None
         if prefill_plan_enabled:
             prefill_plan, prefill_scratch = _plan_with_scratch(
-                max_batched_tokens, prefill_block_m
+                prefill_capacity, prefill_block_m
             )
 
         ext = _load_exl3_ext()
@@ -2110,6 +2150,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             "min_trellis_m": min_trellis_m,
             "max_trellis_m": max_trellis_m,
             "max_batched_tokens": max_batched_tokens,
+            "prefill_capacity": prefill_capacity,
             "parity_rows": parity_rows,
             "topk": topk,
             "chunk": chunk,
@@ -2182,12 +2223,13 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         )
         logger.info_once(
             "EXL3 rank-sliced runtime planned: Trellis m=%d..%d block_m=%d, "
-            "prefill %s capacity=%d chunk=%d topk=%d",
+            "prefill %s scheduler_capacity=%d chunk=%d topk=%d",
             min_trellis_m,
             max_trellis_m,
             block_m,
             (
-                f"trellis block_m={prefill_block_m} arena={prefill_arena_mib:.1f}MiB"
+                f"trellis block_m={prefill_block_m} "
+                f"capacity={prefill_capacity} arena={prefill_arena_mib:.1f}MiB"
                 if prefill_plan is not None
                 else "parity"
             ),
@@ -2231,16 +2273,33 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                     "EXL3 batch exceeds its planned capacity: "
                     f"m={m}, capacity={runtime['max_batched_tokens']}"
                 )
-            binding = runtime["api"].bind(
-                runtime["prefill_plan"],
-                scratch=runtime["prefill_scratch"],
-                a=x,
-                experts=layer.exl3_trellis_weights,
-                topk_weights=topk_weights,
-                topk_ids=topk_ids,
-            )
-            output = runtime["api"].run(binding=binding)
-            return output.to(x.dtype)
+            prefill_capacity = int(runtime["prefill_capacity"])
+            if m <= prefill_capacity:
+                binding = runtime["api"].bind(
+                    runtime["prefill_plan"],
+                    scratch=runtime["prefill_scratch"],
+                    a=x,
+                    experts=layer.exl3_trellis_weights,
+                    topk_weights=topk_weights,
+                    topk_ids=topk_ids,
+                )
+                output = runtime["api"].run(binding=binding)
+                return output.to(x.dtype)
+
+            output = torch.empty_like(x)
+            for start in range(0, m, prefill_capacity):
+                stop = min(start + prefill_capacity, m)
+                binding = runtime["api"].bind(
+                    runtime["prefill_plan"],
+                    scratch=runtime["prefill_scratch"],
+                    a=x[start:stop],
+                    experts=layer.exl3_trellis_weights,
+                    topk_weights=topk_weights[start:stop],
+                    topk_ids=topk_ids[start:stop],
+                )
+                slice_output = runtime["api"].run(binding=binding)
+                output[start:stop].copy_(slice_output)
+            return output
 
         if torch.cuda.is_current_stream_capturing():
             raise RuntimeError(


### PR DESCRIPTION
## Summary

Add an opt-in bound for EXL3 Trellis prefill arena capacity and execute larger eager prefills as contiguous slices through the same caller-owned arena.

Completes the caller-side capacity work from local-inference-lab/sparkinfer#93. SparkInfer PR #100 supplies the separate cheap sizing query and reachable-block planner correction.

## Value

The current 3072-token GLM-5.2 prefill plan reserves about 1.05 GiB/rank. A 512-row opt-in plan prices near 254 MiB/rank, potentially returning roughly 800 MiB/rank to KV capacity. This PR exposes that tradeoff without changing the shipped default; throughput/TTFT selection remains an operator measurement decision.

## Change

- Add `VLLM_EXL3_PREFILL_CAPACITY` for homogeneous and mixed rank-sliced EXL3 Trellis.
- Unset or blank resolves exactly to `max_num_batched_tokens`; existing one-shot planning and dispatch remain unchanged.
- Reject malformed, non-positive, or above-scheduler values before planning. Never clamp.
- Plan one prefill arena at the selected capacity. If live eager prefill rows exceed it, dispatch contiguous capacity-sized slices plus the exact short tail through the same plan/scratch, with matching input, route-weight, route-ID, and output views.
- Keep decode selection, scheduler overflow checks, parity staging, CUDA-capture policy, and zero-row behavior unchanged.
- Include prefill capacity in homogeneous/mixed runtime cache identity and startup logs alongside scheduler capacity and arena/buffer bytes.

## Dependency base

The feature was developed against prerequisite PR #190 head `46c36c0f89a44fade81947c1bf84faede14755ad`. After #190 squash-merged, this branch was rewritten cleanly onto current `dev/gilded-gnosis`: two commits ahead, zero behind, exactly the intended three-file delta.

## Verification

CPU-isolated against the pulled r12 image dependencies:

```text
12 passed
```

Suite: `tests/quantization/test_exl3_prefill_plan.py`.

Changed-file Ruff lint passes. Regressions cover opt-in slicing, exact capacity boundaries and short tails, route/output preservation, default one-shot dispatch, mixed-mode slicing, invalid/above-bound values, parity fallback, and capture rejection.

CodeRabbit's only finding was the duplicated homogeneous/mixed capacity validation; both now call one shared resolver without semantic change.

No live-GPU or throughput result is claimed. All four GPUs remain occupied by the unchanged production service; production was not rebuilt or restarted.