### PR TITLE
[GG] fix(warmup): skip pre-KV V2 attention during autotune

### DIFF
--- a/tests/model_executor/test_flashinfer_autotune_cache.py
+++ b/tests/model_executor/test_flashinfer_autotune_cache.py
@@ -128,6 +128,53 @@ def _patch_flashinfer_autotune_deps(monkeypatch):
     return calls
 
 
+def test_flashinfer_autotune_dummy_run_skips_pre_kv_v2_attention() -> None:
+    runner = SimpleNamespace(
+        scheduler_config=SimpleNamespace(max_num_batched_tokens=8192),
+        vllm_config=SimpleNamespace(use_v2_model_runner=True),
+    )
+
+    kwargs = kernel_warmup._flashinfer_autotune_dummy_run_kwargs(runner)
+
+    assert kwargs == {
+        "num_tokens": 8192,
+        "skip_eplb": True,
+        "is_profile": True,
+        "skip_attn": True,
+    }
+
+
+def test_flashinfer_autotune_dummy_run_keeps_attention_after_kv_init() -> None:
+    runner = SimpleNamespace(
+        scheduler_config=SimpleNamespace(max_num_batched_tokens=8192),
+        vllm_config=SimpleNamespace(use_v2_model_runner=True),
+        block_tables=object(),
+    )
+
+    kwargs = kernel_warmup._flashinfer_autotune_dummy_run_kwargs(runner)
+
+    assert kwargs == {
+        "num_tokens": 8192,
+        "skip_eplb": True,
+        "is_profile": True,
+    }
+
+
+def test_flashinfer_autotune_dummy_run_keeps_v1_signature() -> None:
+    runner = SimpleNamespace(
+        scheduler_config=SimpleNamespace(max_num_batched_tokens=8192),
+        vllm_config=SimpleNamespace(use_v2_model_runner=False),
+    )
+
+    kwargs = kernel_warmup._flashinfer_autotune_dummy_run_kwargs(runner)
+
+    assert kwargs == {
+        "num_tokens": 8192,
+        "skip_eplb": True,
+        "is_profile": True,
+    }
+
+
 def test_b12x_dcp_warmup_finds_generic_mla_attention(monkeypatch) -> None:
     from vllm.distributed import parallel_state
     from vllm.model_executor.layers.attention.mla_attention import MLAAttention

--- a/vllm/model_executor/warmup/kernel_warmup.py
+++ b/vllm/model_executor/warmup/kernel_warmup.py
@@ -442,6 +442,28 @@ def _flashinfer_autotune_skip_ops(runner: "GPUModelRunner") -> set[str] | None:
     return None
 
 
+def _flashinfer_autotune_dummy_run_kwargs(
+    runner: "GPUModelRunner",
+) -> dict[str, object]:
+    kwargs = dict(
+        num_tokens=runner.scheduler_config.max_num_batched_tokens,
+        skip_eplb=True,
+        is_profile=True,
+    )
+
+    # V2 initializes attention backends and block tables only after the initial
+    # memory profile.  Kernel autotuning runs during that profile, so execute
+    # the model kernels without attention until those tables exist.  Attention
+    # backends have their own warmup after KV-cache initialization.
+    if (
+        getattr(runner.vllm_config, "use_v2_model_runner", False)
+        and not hasattr(runner, "block_tables")
+    ):
+        kwargs["skip_attn"] = True
+
+    return kwargs
+
+
 def flashinfer_autotune(runner: "GPUModelRunner") -> None:
     """
     Autotune FlashInfer operations.
@@ -475,11 +497,7 @@ def flashinfer_autotune(runner: "GPUModelRunner") -> None:
 
     if not use_persistent_cache:
         with torch.inference_mode(), fi_utils.autotune(**autotune_kwargs):
-            runner._dummy_run(
-                num_tokens=runner.scheduler_config.max_num_batched_tokens,
-                skip_eplb=True,
-                is_profile=True,
-            )
+            runner._dummy_run(**_flashinfer_autotune_dummy_run_kwargs(runner))
         get_world_group().barrier()
         return
 
@@ -494,11 +512,7 @@ def flashinfer_autotune(runner: "GPUModelRunner") -> None:
     # When autotuning with number of tokens m, flashinfer will autotune
     # operations for all number of tokens up to m, so we only need to
     # run with the max number of tokens.
-    dummy_run_kwargs = dict(
-        num_tokens=runner.scheduler_config.max_num_batched_tokens,
-        skip_eplb=True,
-        is_profile=True,
-    )
+    dummy_run_kwargs = _flashinfer_autotune_dummy_run_kwargs(runner)
 
     with torch.inference_mode():
         if is_leader:


### PR DESCRIPTION
## Summary

Keep FlashInfer kernel autotuning enabled for V2 models whose first memory profile runs before KV-cache initialization.

## Root cause

DSpark requires the V2 model runner. During the initial memory profile, FlashInfer autotune calls `_dummy_run()` before V2 has created `block_tables`. Preparing attention metadata at that point raises `AttributeError` and prevents startup.

## Fix

Build the autotune dummy-run arguments in one helper and add `skip_attn=True` only when both conditions hold:

- the runner is V2
- `block_tables` has not been initialized yet

V1 keeps its existing signature. A post-KV V2 run also keeps attention enabled. Attention backends still receive their dedicated warmup after KV-cache initialization; linear and MoE FlashInfer autotuning remains active during the initial profile.

## Validation

- `tests/model_executor/test_flashinfer_autotune_cache.py`: 14 passed
- TP2 0731 DSpark K7 with autotune enabled completed model load, KV initialization, piecewise/full graph capture, and inference
- sustained CC1: 196.33 tok/s
- coding median: 285.39 tok/s, 0/5 CJK
- prior autotune-disabled run: 199.47 sustained / 282.36 coding; difference is measurement noise, with no systematic regression
