### PR TITLE
[GG] serve(ds4): add 0731 profile and native L1/L2 offload

### DIFF
--- a/serve-ds4-flash.sh
+++ b/serve-ds4-flash.sh
@@ -387,8 +387,9 @@ fi
 
 if [[ -z "${gpu_memory_utilization}" ]]; then
   # The 0731 DSpark draft head is larger than the historical MTP head. Its
-  # B12X TP2 profile needs 0.97 to retain the default 131k serving limit after
-  # attention and FULL-graph allocations are accounted for.
+  # B12X TP2 profile needs 0.975 to retain the default 131k serving limit after
+  # attention and FULL-graph allocations are accounted for. At 0.97 the r15
+  # stack exposed 7.11 GiB of KV storage while this profile needs 7.37 GiB.
   if [[ "${mode}" == "dspark" ]]; then
     if [[ "${backend}" == "lucifer-default" ]]; then
       # The default DeepGEMM MoE path retains more model/runtime memory than
@@ -406,7 +407,7 @@ if [[ -z "${gpu_memory_utilization}" ]]; then
     elif [[ "${backend}" == lucifer-* ]]; then
       gpu_memory_utilization=0.9465
     else
-      gpu_memory_utilization=0.97
+      gpu_memory_utilization=0.975
     fi
   elif [[ "${backend}" == lucifer-* \
     && ( "${mode}" == "mtp2" || "${mode}" == "mtp3" ) ]]; then

--- a/serve-ds4-flash.sh
+++ b/serve-ds4-flash.sh
@@ -102,6 +102,8 @@ gpu_memory_utilization=${GPU_MEMORY_UTILIZATION:-}
 block_size=${BLOCK_SIZE:-256}
 load_format=${LOAD_FORMAT:-instanttensor}
 kv_offloading_size=${KV_OFFLOADING_SIZE:-}
+native_l2_path=${NATIVE_L2_PATH:-}
+native_l2_size=${NATIVE_L2_GB:-}
 prefix_cache=$(bool_value PREFIX_CACHE "${PREFIX_CACHE:-1}")
 enable_flashinfer_autotune=$(bool_value ENABLE_FLASHINFER_AUTOTUNE "${ENABLE_FLASHINFER_AUTOTUNE:-1}")
 draft_sample_method=${DRAFT_SAMPLE_METHOD:-probabilistic}
@@ -116,6 +118,28 @@ if [[ -n "${kv_offloading_size}" \
   && ! "${kv_offloading_size}" =~ ^([0-9]+([.][0-9]*)?|[.][0-9]+)$ ]]; then
   echo "KV_OFFLOADING_SIZE must be a non-negative GiB value; got '${kv_offloading_size}'" >&2
   exit 2
+fi
+native_l2_enabled=0
+if [[ -n "${native_l2_path}" || -n "${native_l2_size}" ]]; then
+  if [[ -z "${native_l2_path}" || -z "${native_l2_size}" ]]; then
+    echo "NATIVE_L2_PATH and NATIVE_L2_GB must be set together" >&2
+    exit 2
+  fi
+  if [[ "${native_l2_path}" != /* ]]; then
+    echo "NATIVE_L2_PATH must be an absolute container path" >&2
+    exit 2
+  fi
+  if [[ ! "${native_l2_size}" =~ ^([0-9]+([.][0-9]*)?|[.][0-9]+)$ \
+    || "${native_l2_size}" =~ ^0*([.]0*)?$ ]]; then
+    echo "NATIVE_L2_GB must be a positive GiB value; got '${native_l2_size}'" >&2
+    exit 2
+  fi
+  if [[ -z "${kv_offloading_size}" \
+    || "${kv_offloading_size}" =~ ^0*([.]0*)?$ ]]; then
+    echo "NATIVE_L2 requires a positive KV_OFFLOADING_SIZE for its L1 tier" >&2
+    exit 2
+  fi
+  native_l2_enabled=1
 fi
 if [[ "${mode}" == "dspark" && "${dcp_size}" != "1" ]]; then
   echo "DSpark non-causal attention currently requires DCP_SIZE=1" >&2
@@ -452,6 +476,34 @@ if [[ -n "${kv_offloading_size}" \
     --kv-offloading-size "${kv_offloading_size}"
     --kv-offloading-backend native
   )
+  if [[ "${native_l2_enabled}" == "1" ]]; then
+    export PYTHONHASHSEED=${PYTHONHASHSEED:-0}
+    native_l2_config=$(python3 - "${native_l2_path}" "${native_l2_size}" <<'PY'
+import json
+import sys
+
+root_dir, max_size_gb = sys.argv[1:]
+config = {
+    "kv_connector": "OffloadingConnector",
+    "kv_role": "kv_both",
+    "kv_connector_extra_config": {
+        "spec_name": "TieringOffloadingSpec",
+        "secondary_tiers": [
+            {
+                "type": "fs",
+                "root_dir": root_dir,
+                "n_read_threads": 32,
+                "n_write_threads": 16,
+                "gc_max_size_gb": float(max_size_gb),
+            }
+        ],
+    },
+}
+print(json.dumps(config, separators=(",", ":")))
+PY
+    )
+    offloading_args+=(--kv-transfer-config "${native_l2_config}")
+  fi
 fi
 
 capture_args=()
@@ -535,11 +587,12 @@ if [[ -n "${EXTRA_VLLM_ARGS:-}" ]]; then
 fi
 command+=("$@")
 
-printf 'DS4 launch: mode=%s depth=%s backend=%s allreduce=%s b12x_dma=%s indexer=%s tp=%s dcp=%s max_seqs=%s graph=%s load_format=%s instanttensor_backend=%s allocator=%s model=%s\n' \
+printf 'DS4 launch: mode=%s depth=%s backend=%s allreduce=%s b12x_dma=%s indexer=%s tp=%s dcp=%s max_seqs=%s graph=%s load_format=%s instanttensor_backend=%s native_l2=%s allocator=%s model=%s\n' \
   "${mode}" "${dspark_depth_mode}" \
   "${backend}" "${allreduce_mode}" "${b12x_pcie_dma}" \
   "${indexer_backend}" "${tp_size}" "${dcp_size}" "${max_num_seqs}" \
   "${graph_cap}" "${load_format}" "${INSTANTTENSOR_BACKEND}" \
+  "${native_l2_enabled}" \
   "${PYTORCH_CUDA_ALLOC_CONF:-<unset>}" "${model}" >&2
 printf 'Command:' >&2
 printf ' %q' "${command[@]}" >&2

--- a/serve-ds4-flash.sh
+++ b/serve-ds4-flash.sh
@@ -40,9 +40,10 @@ case "${mode}" in
   off|mtp0|standard-mtp0) mode=mtp0 ;;
   mtp2|standard-mtp2) mode=mtp2 ;;
   mtp3|standard-mtp3) mode=mtp3 ;;
+  dspark-off|dspark-mtp0) mode=dspark-mtp0 ;;
   dspark) ;;
   *)
-    echo "MODE must be mtp0, mtp2, mtp3, or dspark; got '${mode}'" >&2
+    echo "MODE must be mtp0, mtp2, mtp3, dspark-mtp0, or dspark; got '${mode}'" >&2
     exit 2
     ;;
 esac
@@ -59,13 +60,13 @@ case "${backend}" in
 esac
 
 standard_model=${STANDARD_MODEL:-deepseek-ai/DeepSeek-V4-Flash}
-dspark_model=${DSPARK_MODEL:-deepseek-ai/DeepSeek-V4-Flash-DSpark}
+dspark_model=${DSPARK_MODEL:-deepseek-ai/DeepSeek-V4-Flash-0731}
 standard_model_revision=${STANDARD_MODEL_REVISION:-60d8d70770c6776ff598c94bb586a859a38244f1}
-dspark_model_revision=${DSPARK_MODEL_REVISION:-62af8fffb2f7030cac4de2f0169f5b8d1101b646}
-if [[ "${mode}" == "dspark" ]]; then
+dspark_model_revision=${DSPARK_MODEL_REVISION:-9e165c30e2704aec5d9d593cce3eebd58bbef1cb}
+if [[ "${mode}" == "dspark" || "${mode}" == "dspark-mtp0" ]]; then
   model=${MODEL_PATH:-${MODEL:-${dspark_model}}}
   spec_model=${SPEC_MODEL_PATH:-${model}}
-  served_model_name=${SERVED_MODEL_NAME:-DeepSeek-V4-Flash-DSpark}
+  served_model_name=${SERVED_MODEL_NAME:-DeepSeek-V4-Flash-0731}
   default_model_revision=${dspark_model_revision}
 else
   model=${MODEL_PATH:-${MODEL:-${standard_model}}}
@@ -88,9 +89,14 @@ fi
 host=${HOST:-0.0.0.0}
 port=${PORT:-8000}
 tp_size=${TP_SIZE:-${TP:-2}}
-dcp_size=${DCP_SIZE:-1}
-max_num_seqs=${MAX_NUM_SEQS:-64}
-max_model_len=${MAX_MODEL_LEN:-262144}
+dcp_size=${DCP_SIZE:-${DCP:-1}}
+if [[ "${mode}" == "dspark" || "${mode}" == "dspark-mtp0" ]]; then
+  max_num_seqs=${MAX_NUM_SEQS:-16}
+  max_model_len=${MAX_MODEL_LEN:-131072}
+else
+  max_num_seqs=${MAX_NUM_SEQS:-64}
+  max_model_len=${MAX_MODEL_LEN:-262144}
+fi
 max_num_batched_tokens=${MAX_NUM_BATCHED_TOKENS:-8192}
 gpu_memory_utilization=${GPU_MEMORY_UTILIZATION:-}
 block_size=${BLOCK_SIZE:-256}
@@ -246,6 +252,7 @@ esac
 spec_args=()
 spec_tokens=0
 graph_multiplier=4
+dspark_depth_mode=disabled
 if [[ "${mode}" == "mtp2" || "${mode}" == "mtp3" ]]; then
   if [[ "${mode}" == "mtp2" ]]; then spec_tokens=2; else spec_tokens=3; fi
   mtp_moe_json=
@@ -259,7 +266,7 @@ if [[ "${mode}" == "mtp2" || "${mode}" == "mtp3" ]]; then
   spec_args=(--speculative-config "${spec_json}")
   graph_multiplier=8
 elif [[ "${mode}" == "dspark" ]]; then
-  spec_tokens=${DSPARK_TOKENS:-5}
+  spec_tokens=${DSPARK_TOKENS:-${NUM_SPECULATIVE_TOKENS:-7}}
   require_positive_int DSPARK_TOKENS "${spec_tokens}"
   # Target verification schedules at most one sampled token plus K drafts per
   # request. Capturing beyond that physical row count only consumes graph
@@ -280,7 +287,25 @@ elif [[ "${mode}" == "dspark" ]]; then
     draft_attention_json=$(printf \
       ',"draft_attention_backend":"%s"' "${draft_attention_backend}")
   fi
-  dspark_capacity=$(bool_value DSPARK_CAPACITY "${DSPARK_CAPACITY:-0}")
+  dspark_depth_mode=${DSPARK_DEPTH_MODE:-fixed}
+  case "${dspark_depth_mode}" in
+    fixed)
+      default_dspark_capacity=0
+      default_dynamic_depth=0
+      default_activation_batch_size=0
+      ;;
+    dynamic)
+      default_dspark_capacity=1
+      default_dynamic_depth=1
+      default_activation_batch_size=1
+      ;;
+    *)
+      echo "DSPARK_DEPTH_MODE must be fixed or dynamic" >&2
+      exit 2
+      ;;
+  esac
+  dspark_capacity=$(bool_value DSPARK_CAPACITY \
+    "${DSPARK_CAPACITY:-${default_dspark_capacity}}")
   capacity_json=
   if [[ "${dspark_capacity}" == "1" ]]; then
     capacity_mode=${DSPARK_CAPACITY_VERIFICATION_MODE:-}
@@ -319,11 +344,14 @@ elif [[ "${mode}" == "dspark" ]]; then
     "${rejection_sample_method}" "${draft_attention_json}" "${capacity_json}")
   spec_args=(--speculative-config "${spec_json}")
   export VLLM_DSPARK_FP8_DRAFT_HEAD=$(bool_value DSPARK_FP8_DRAFT_HEAD "${DSPARK_FP8_DRAFT_HEAD:-0}")
-  export VLLM_DSPARK_DYNAMIC_DRAFT_DEPTH=$(bool_value DSPARK_DYNAMIC_DRAFT_DEPTH "${DSPARK_DYNAMIC_DRAFT_DEPTH:-0}")
+  dynamic_depth=${DSPARK_DYNAMIC_DRAFT_DEPTH:-${VLLM_DSPARK_DYNAMIC_DRAFT_DEPTH:-${default_dynamic_depth}}}
+  export VLLM_DSPARK_DYNAMIC_DRAFT_DEPTH=$(bool_value \
+    DSPARK_DYNAMIC_DRAFT_DEPTH "${dynamic_depth}")
   export VLLM_DSPARK_DYNAMIC_DRAFT_DEPTH_WINDOW=${DSPARK_DYNAMIC_DRAFT_DEPTH_WINDOW:-8}
   require_positive_int DSPARK_DYNAMIC_DRAFT_DEPTH_WINDOW \
     "${VLLM_DSPARK_DYNAMIC_DRAFT_DEPTH_WINDOW}"
-  export VLLM_DSPARK_CAPACITY_ACTIVATION_BATCH_SIZE=${DSPARK_CAPACITY_ACTIVATION_BATCH_SIZE:-0}
+  activation_batch_size=${DSPARK_CAPACITY_ACTIVATION_BATCH_SIZE:-${VLLM_DSPARK_CAPACITY_ACTIVATION_BATCH_SIZE:-${default_activation_batch_size}}}
+  export VLLM_DSPARK_CAPACITY_ACTIVATION_BATCH_SIZE=${activation_batch_size}
   require_nonnegative_int DSPARK_CAPACITY_ACTIVATION_BATCH_SIZE \
     "${VLLM_DSPARK_CAPACITY_ACTIVATION_BATCH_SIZE}"
   export VLLM_DSPARK_CAPACITY_LOG_INTERVAL=${DSPARK_CAPACITY_LOG_INTERVAL:-0}
@@ -358,8 +386,9 @@ if [[ "${sp_async_tp}" == "1" ]]; then
 fi
 
 if [[ -z "${gpu_memory_utilization}" ]]; then
-  # The v10 profiler includes attention and FULL-graph allocations. These
-  # defaults preserve the 262k serving limit used by v9 after that accounting.
+  # The 0731 DSpark draft head is larger than the historical MTP head. Its
+  # B12X TP2 profile needs 0.97 to retain the default 131k serving limit after
+  # attention and FULL-graph allocations are accounted for.
   if [[ "${mode}" == "dspark" ]]; then
     if [[ "${backend}" == "lucifer-default" ]]; then
       # The default DeepGEMM MoE path retains more model/runtime memory than
@@ -377,7 +406,7 @@ if [[ -z "${gpu_memory_utilization}" ]]; then
     elif [[ "${backend}" == lucifer-* ]]; then
       gpu_memory_utilization=0.9465
     else
-      gpu_memory_utilization=0.95
+      gpu_memory_utilization=0.97
     fi
   elif [[ "${backend}" == lucifer-* \
     && ( "${mode}" == "mtp2" || "${mode}" == "mtp3" ) ]]; then
@@ -478,8 +507,9 @@ if [[ -n "${EXTRA_VLLM_ARGS:-}" ]]; then
 fi
 command+=("$@")
 
-printf 'DS4 launch: mode=%s backend=%s allreduce=%s b12x_dma=%s indexer=%s tp=%s dcp=%s max_seqs=%s graph=%s load_format=%s instanttensor_backend=%s model=%s\n' \
-  "${mode}" "${backend}" "${allreduce_mode}" "${b12x_pcie_dma}" \
+printf 'DS4 launch: mode=%s depth=%s backend=%s allreduce=%s b12x_dma=%s indexer=%s tp=%s dcp=%s max_seqs=%s graph=%s load_format=%s instanttensor_backend=%s model=%s\n' \
+  "${mode}" "${dspark_depth_mode}" \
+  "${backend}" "${allreduce_mode}" "${b12x_pcie_dma}" \
   "${indexer_backend}" "${tp_size}" "${dcp_size}" "${max_num_seqs}" \
   "${graph_cap}" "${load_format}" "${INSTANTTENSOR_BACKEND}" "${model}" >&2
 printf 'Command:' >&2

--- a/serve-ds4-flash.sh
+++ b/serve-ds4-flash.sh
@@ -101,6 +101,7 @@ max_num_batched_tokens=${MAX_NUM_BATCHED_TOKENS:-8192}
 gpu_memory_utilization=${GPU_MEMORY_UTILIZATION:-}
 block_size=${BLOCK_SIZE:-256}
 load_format=${LOAD_FORMAT:-instanttensor}
+kv_offloading_size=${KV_OFFLOADING_SIZE:-}
 prefix_cache=$(bool_value PREFIX_CACHE "${PREFIX_CACHE:-1}")
 enable_flashinfer_autotune=$(bool_value ENABLE_FLASHINFER_AUTOTUNE "${ENABLE_FLASHINFER_AUTOTUNE:-1}")
 draft_sample_method=${DRAFT_SAMPLE_METHOD:-probabilistic}
@@ -111,6 +112,11 @@ require_positive_int DCP_SIZE "${dcp_size}"
 require_positive_int MAX_NUM_SEQS "${max_num_seqs}"
 require_positive_int MAX_NUM_BATCHED_TOKENS "${max_num_batched_tokens}"
 require_positive_int BLOCK_SIZE "${block_size}"
+if [[ -n "${kv_offloading_size}" \
+  && ! "${kv_offloading_size}" =~ ^([0-9]+([.][0-9]*)?|[.][0-9]+)$ ]]; then
+  echo "KV_OFFLOADING_SIZE must be a non-negative GiB value; got '${kv_offloading_size}'" >&2
+  exit 2
+fi
 if [[ "${mode}" == "dspark" && "${dcp_size}" != "1" ]]; then
   echo "DSpark non-causal attention currently requires DCP_SIZE=1" >&2
   exit 2
@@ -428,6 +434,17 @@ if [[ "${enable_flashinfer_autotune}" == "0" ]]; then
   autotune_args=(--no-enable-flashinfer-autotune)
 fi
 
+offloading_args=()
+if [[ -n "${kv_offloading_size}" \
+  && ! "${kv_offloading_size}" =~ ^0*([.]0*)?$ ]]; then
+  # This is the total host-cache capacity across all TP ranks, matching the
+  # vLLM CLI contract. LMCache remains a separate deployment mode.
+  offloading_args=(
+    --kv-offloading-size "${kv_offloading_size}"
+    --kv-offloading-backend native
+  )
+fi
+
 capture_args=()
 capture_sizes=${CUDAGRAPH_CAPTURE_SIZES:-default}
 if [[ "${capture_sizes}" == "auto" ]]; then
@@ -495,6 +512,7 @@ command=(
   "${autotune_args[@]}"
   "${prefix_args[@]}"
   "${capture_args[@]}"
+  "${offloading_args[@]}"
   "${spec_args[@]}"
   "${backend_args[@]}"
   "${allreduce_args[@]}"

--- a/serve-ds4-flash.sh
+++ b/serve-ds4-flash.sh
@@ -315,7 +315,7 @@ elif [[ "${mode}" == "dspark" ]]; then
         ;;
     esac
     draft_attention_json=$(printf \
-      ',"draft_attention_backend":"%s"' "${draft_attention_backend}")
+      ',"attention_backend":"%s"' "${draft_attention_backend}")
   fi
   dspark_depth_mode=${DSPARK_DEPTH_MODE:-fixed}
   case "${dspark_depth_mode}" in

--- a/serve-ds4-flash.sh
+++ b/serve-ds4-flash.sh
@@ -438,7 +438,16 @@ offloading_args=()
 if [[ -n "${kv_offloading_size}" \
   && ! "${kv_offloading_size}" =~ ^0*([.]0*)?$ ]]; then
   # This is the total host-cache capacity across all TP ranks, matching the
-  # vLLM CLI contract. LMCache remains a separate deployment mode.
+  # vLLM CLI contract. LMCache remains a separate deployment mode. Native KV
+  # offload pins/registers GPU cache allocations, so PyTorch's remappable VMM
+  # segments must be disabled while preserving any other allocator settings.
+  allocator_config=${PYTORCH_CUDA_ALLOC_CONF:-}
+  if [[ -z "${allocator_config}" ]]; then
+    allocator_config=expandable_segments:False
+  elif [[ "${allocator_config}" =~ (^|,)expandable_segments:True(,|$) ]]; then
+    allocator_config=${allocator_config//expandable_segments:True/expandable_segments:False}
+  fi
+  export PYTORCH_CUDA_ALLOC_CONF=${allocator_config}
   offloading_args=(
     --kv-offloading-size "${kv_offloading_size}"
     --kv-offloading-backend native
@@ -526,11 +535,12 @@ if [[ -n "${EXTRA_VLLM_ARGS:-}" ]]; then
 fi
 command+=("$@")
 
-printf 'DS4 launch: mode=%s depth=%s backend=%s allreduce=%s b12x_dma=%s indexer=%s tp=%s dcp=%s max_seqs=%s graph=%s load_format=%s instanttensor_backend=%s model=%s\n' \
+printf 'DS4 launch: mode=%s depth=%s backend=%s allreduce=%s b12x_dma=%s indexer=%s tp=%s dcp=%s max_seqs=%s graph=%s load_format=%s instanttensor_backend=%s allocator=%s model=%s\n' \
   "${mode}" "${dspark_depth_mode}" \
   "${backend}" "${allreduce_mode}" "${b12x_pcie_dma}" \
   "${indexer_backend}" "${tp_size}" "${dcp_size}" "${max_num_seqs}" \
-  "${graph_cap}" "${load_format}" "${INSTANTTENSOR_BACKEND}" "${model}" >&2
+  "${graph_cap}" "${load_format}" "${INSTANTTENSOR_BACKEND}" \
+  "${PYTORCH_CUDA_ALLOC_CONF:-<unset>}" "${model}" >&2
 printf 'Command:' >&2
 printf ' %q' "${command[@]}" >&2
 printf '\n' >&2

--- a/serve-ds4-flash.sh
+++ b/serve-ds4-flash.sh
@@ -43,7 +43,7 @@ case "${mode}" in
   dspark-off|dspark-mtp0) mode=dspark-mtp0 ;;
   dspark) ;;
   *)
-    echo "MODE must be mtp0, mtp2, mtp3, dspark-mtp0, or dspark; got '${mode}'" >&2
+    echo "MODE must be mtp0, mtp2, mtp3, dspark-off, dspark-mtp0, or dspark; got '${mode}'" >&2
     exit 2
     ;;
 esac

--- a/tests/entrypoints/test_ds4_flash_launcher.py
+++ b/tests/entrypoints/test_ds4_flash_launcher.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import os
+import subprocess
+from pathlib import Path
+
+
+_REPO_ROOT = Path(__file__).parents[2]
+_LAUNCHER = _REPO_ROOT / "serve-ds4-flash.sh"
+
+
+def _dry_run(tmp_path: Path, **overrides: str) -> str:
+    env = {
+        "PATH": os.environ["PATH"],
+        "HOME": str(tmp_path),
+        "XDG_CACHE_HOME": str(tmp_path / "cache"),
+        "DRY_RUN": "1",
+        **overrides,
+    }
+    result = subprocess.run(
+        ["bash", str(_LAUNCHER)],
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stderr
+
+
+def test_ds4_launcher_defaults_to_0731_fixed_k7(tmp_path: Path) -> None:
+    output = _dry_run(tmp_path)
+
+    assert "mode=dspark depth=fixed" in output
+    assert "model=deepseek-ai/DeepSeek-V4-Flash-0731" in output
+    assert "9e165c30e2704aec5d9d593cce3eebd58bbef1cb" in output
+    assert "num_speculative_tokens\\\":7" in output
+    assert "max_seqs=16 graph=128" in output
+    assert "--max-model-len 131072" in output
+    assert "--gpu-memory-utilization 0.97" in output
+
+
+def test_ds4_launcher_dynamic_depth_enables_capacity_mode(tmp_path: Path) -> None:
+    output = _dry_run(tmp_path, DSPARK_DEPTH_MODE="dynamic")
+
+    assert "mode=dspark depth=dynamic" in output
+    assert "dspark_capacity_verification_mode\\\":\\\"varlen" in output
+    assert "dspark_sps_curve\\\":\\\"auto" in output
+
+
+def test_ds4_launcher_accepts_cluster_style_aliases(tmp_path: Path) -> None:
+    output = _dry_run(
+        tmp_path,
+        DCP="1",
+        NUM_SPECULATIVE_TOKENS="5",
+    )
+
+    assert "dcp=1" in output
+    assert "num_speculative_tokens\\\":5" in output
+
+
+def test_ds4_launcher_standard_mtp_uses_standard_checkpoint(tmp_path: Path) -> None:
+    output = _dry_run(tmp_path, MODE="mtp2")
+
+    assert "mode=mtp2 depth=disabled" in output
+    assert "model=deepseek-ai/DeepSeek-V4-Flash" in output
+    assert "DeepSeek-V4-Flash-0731" not in output
+    assert "method\\\":\\\"mtp" in output
+    assert "num_speculative_tokens\\\":2" in output
+
+
+def test_ds4_launcher_can_disable_dspark_on_0731(tmp_path: Path) -> None:
+    output = _dry_run(tmp_path, MODE="dspark-mtp0")
+
+    assert "mode=dspark-mtp0 depth=disabled" in output
+    assert "model=deepseek-ai/DeepSeek-V4-Flash-0731" in output
+    assert "--speculative-config" not in output

--- a/tests/entrypoints/test_ds4_flash_launcher.py
+++ b/tests/entrypoints/test_ds4_flash_launcher.py
@@ -84,20 +84,74 @@ def test_ds4_launcher_enables_native_kv_offload(tmp_path: Path) -> None:
     assert "allocator=expandable_segments:False" in output
 
 
+def test_ds4_launcher_builds_bounded_native_l2_config(tmp_path: Path) -> None:
+    output = _dry_run(
+        tmp_path,
+        KV_OFFLOADING_SIZE="32",
+        NATIVE_L2_PATH="/cache/native-l2",
+        NATIVE_L2_GB="128",
+    )
+
+    assert "native_l2=1" in output
+    assert "--kv-transfer-config" in output
+    assert "OffloadingConnector" in output
+    assert "TieringOffloadingSpec" in output
+    assert "cache/native-l2" in output
+    assert 'gc_max_size_gb\\":128.0' in output
+
+
+def test_ds4_launcher_native_l2_requires_l1(tmp_path: Path) -> None:
+    env = {
+        "PATH": os.environ["PATH"],
+        "HOME": str(tmp_path),
+        "XDG_CACHE_HOME": str(tmp_path / "cache"),
+        "DRY_RUN": "1",
+        "NATIVE_L2_PATH": "/cache/native-l2",
+        "NATIVE_L2_GB": "128",
+    }
+    result = subprocess.run(
+        ["bash", str(_LAUNCHER)],
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "NATIVE_L2 requires a positive KV_OFFLOADING_SIZE" in result.stderr
+
+
+def test_ds4_launcher_native_l2_requires_complete_pair(tmp_path: Path) -> None:
+    env = {
+        "PATH": os.environ["PATH"],
+        "HOME": str(tmp_path),
+        "XDG_CACHE_HOME": str(tmp_path / "cache"),
+        "DRY_RUN": "1",
+        "KV_OFFLOADING_SIZE": "32",
+        "NATIVE_L2_PATH": "/cache/native-l2",
+    }
+    result = subprocess.run(
+        ["bash", str(_LAUNCHER)],
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "NATIVE_L2_PATH and NATIVE_L2_GB must be set together" in result.stderr
+
+
 def test_ds4_launcher_native_offload_preserves_other_allocator_settings(
     tmp_path: Path,
 ) -> None:
     output = _dry_run(
         tmp_path,
         KV_OFFLOADING_SIZE="5.5",
-        PYTORCH_CUDA_ALLOC_CONF=(
-            "max_split_size_mb:256,expandable_segments:True"
-        ),
+        PYTORCH_CUDA_ALLOC_CONF=("max_split_size_mb:256,expandable_segments:True"),
     )
 
-    assert (
-        "allocator=max_split_size_mb:256,expandable_segments:False" in output
-    )
+    assert "allocator=max_split_size_mb:256,expandable_segments:False" in output
 
 
 def test_ds4_launcher_without_offload_keeps_expandable_segments(

--- a/tests/entrypoints/test_ds4_flash_launcher.py
+++ b/tests/entrypoints/test_ds4_flash_launcher.py
@@ -37,7 +37,7 @@ def test_ds4_launcher_defaults_to_0731_fixed_k7(tmp_path: Path) -> None:
     assert "num_speculative_tokens\\\":7" in output
     assert "max_seqs=16 graph=128" in output
     assert "--max-model-len 131072" in output
-    assert "--gpu-memory-utilization 0.97" in output
+    assert "--gpu-memory-utilization 0.975" in output
 
 
 def test_ds4_launcher_dynamic_depth_enables_capacity_mode(tmp_path: Path) -> None:

--- a/tests/entrypoints/test_ds4_flash_launcher.py
+++ b/tests/entrypoints/test_ds4_flash_launcher.py
@@ -10,6 +10,15 @@ _LAUNCHER = _REPO_ROOT / "serve-ds4-flash.sh"
 
 
 def _dry_run(tmp_path: Path, **overrides: str) -> str:
+    """Run the DS4 launcher in dry-run mode.
+
+    Args:
+        tmp_path: Temporary home and cache root.
+        **overrides: Environment variables that override launcher defaults.
+
+    Returns:
+        The launcher's standard-error output.
+    """
     env = {
         "PATH": os.environ["PATH"],
         "HOME": str(tmp_path),
@@ -28,6 +37,11 @@ def _dry_run(tmp_path: Path, **overrides: str) -> str:
 
 
 def test_ds4_launcher_defaults_to_0731_fixed_k7(tmp_path: Path) -> None:
+    """Verify the default 0731 fixed-K7 launch profile.
+
+    Args:
+        tmp_path: Temporary home and cache root.
+    """
     output = _dry_run(tmp_path)
 
     assert "mode=dspark depth=fixed" in output
@@ -40,6 +54,11 @@ def test_ds4_launcher_defaults_to_0731_fixed_k7(tmp_path: Path) -> None:
 
 
 def test_ds4_launcher_dynamic_depth_enables_capacity_mode(tmp_path: Path) -> None:
+    """Verify that dynamic depth selects variable-capacity verification.
+
+    Args:
+        tmp_path: Temporary home and cache root.
+    """
     output = _dry_run(tmp_path, DSPARK_DEPTH_MODE="dynamic")
 
     assert "mode=dspark depth=dynamic" in output
@@ -48,6 +67,11 @@ def test_ds4_launcher_dynamic_depth_enables_capacity_mode(tmp_path: Path) -> Non
 
 
 def test_ds4_launcher_accepts_cluster_style_aliases(tmp_path: Path) -> None:
+    """Verify compatibility with cluster-style environment aliases.
+
+    Args:
+        tmp_path: Temporary home and cache root.
+    """
     output = _dry_run(
         tmp_path,
         DCP="1",
@@ -59,6 +83,11 @@ def test_ds4_launcher_accepts_cluster_style_aliases(tmp_path: Path) -> None:
 
 
 def test_ds4_launcher_standard_mtp_uses_standard_checkpoint(tmp_path: Path) -> None:
+    """Verify that standard MTP selects the non-DSpark checkpoint.
+
+    Args:
+        tmp_path: Temporary home and cache root.
+    """
     output = _dry_run(tmp_path, MODE="mtp2")
 
     assert "mode=mtp2 depth=disabled" in output
@@ -69,6 +98,11 @@ def test_ds4_launcher_standard_mtp_uses_standard_checkpoint(tmp_path: Path) -> N
 
 
 def test_ds4_launcher_can_disable_dspark_on_0731(tmp_path: Path) -> None:
+    """Verify target-only serving with the 0731 checkpoint.
+
+    Args:
+        tmp_path: Temporary home and cache root.
+    """
     output = _dry_run(tmp_path, MODE="dspark-mtp0")
 
     assert "mode=dspark-mtp0 depth=disabled" in output
@@ -77,6 +111,11 @@ def test_ds4_launcher_can_disable_dspark_on_0731(tmp_path: Path) -> None:
 
 
 def test_ds4_launcher_enables_native_kv_offload(tmp_path: Path) -> None:
+    """Verify native host-memory KV offload arguments.
+
+    Args:
+        tmp_path: Temporary home and cache root.
+    """
     output = _dry_run(tmp_path, KV_OFFLOADING_SIZE="5.5")
 
     assert "--kv-offloading-size 5.5" in output
@@ -85,6 +124,11 @@ def test_ds4_launcher_enables_native_kv_offload(tmp_path: Path) -> None:
 
 
 def test_ds4_launcher_builds_bounded_native_l2_config(tmp_path: Path) -> None:
+    """Verify bounded filesystem L2 configuration generation.
+
+    Args:
+        tmp_path: Temporary home and cache root.
+    """
     output = _dry_run(
         tmp_path,
         KV_OFFLOADING_SIZE="32",
@@ -101,6 +145,11 @@ def test_ds4_launcher_builds_bounded_native_l2_config(tmp_path: Path) -> None:
 
 
 def test_ds4_launcher_native_l2_requires_l1(tmp_path: Path) -> None:
+    """Verify that filesystem L2 requires native host-memory L1.
+
+    Args:
+        tmp_path: Temporary home and cache root.
+    """
     env = {
         "PATH": os.environ["PATH"],
         "HOME": str(tmp_path),
@@ -122,6 +171,11 @@ def test_ds4_launcher_native_l2_requires_l1(tmp_path: Path) -> None:
 
 
 def test_ds4_launcher_native_l2_requires_complete_pair(tmp_path: Path) -> None:
+    """Verify that both filesystem L2 settings are required.
+
+    Args:
+        tmp_path: Temporary home and cache root.
+    """
     env = {
         "PATH": os.environ["PATH"],
         "HOME": str(tmp_path),
@@ -145,6 +199,11 @@ def test_ds4_launcher_native_l2_requires_complete_pair(tmp_path: Path) -> None:
 def test_ds4_launcher_native_offload_preserves_other_allocator_settings(
     tmp_path: Path,
 ) -> None:
+    """Verify allocator normalization preserves unrelated settings.
+
+    Args:
+        tmp_path: Temporary home and cache root.
+    """
     output = _dry_run(
         tmp_path,
         KV_OFFLOADING_SIZE="5.5",
@@ -157,18 +216,33 @@ def test_ds4_launcher_native_offload_preserves_other_allocator_settings(
 def test_ds4_launcher_without_offload_keeps_expandable_segments(
     tmp_path: Path,
 ) -> None:
+    """Verify the default allocator when native offload is disabled.
+
+    Args:
+        tmp_path: Temporary home and cache root.
+    """
     output = _dry_run(tmp_path)
 
     assert "allocator=expandable_segments:True" in output
 
 
 def test_ds4_launcher_zero_kv_offload_stays_disabled(tmp_path: Path) -> None:
+    """Verify that a zero offload size does not enable native offload.
+
+    Args:
+        tmp_path: Temporary home and cache root.
+    """
     output = _dry_run(tmp_path, KV_OFFLOADING_SIZE="0.0")
 
     assert "--kv-offloading-size" not in output
 
 
 def test_ds4_launcher_rejects_invalid_kv_offload_size(tmp_path: Path) -> None:
+    """Verify rejection of a nonnumeric native-offload size.
+
+    Args:
+        tmp_path: Temporary home and cache root.
+    """
     env = {
         "PATH": os.environ["PATH"],
         "HOME": str(tmp_path),

--- a/tests/entrypoints/test_ds4_flash_launcher.py
+++ b/tests/entrypoints/test_ds4_flash_launcher.py
@@ -5,7 +5,6 @@ import os
 import subprocess
 from pathlib import Path
 
-
 _REPO_ROOT = Path(__file__).parents[2]
 _LAUNCHER = _REPO_ROOT / "serve-ds4-flash.sh"
 
@@ -34,7 +33,7 @@ def test_ds4_launcher_defaults_to_0731_fixed_k7(tmp_path: Path) -> None:
     assert "mode=dspark depth=fixed" in output
     assert "model=deepseek-ai/DeepSeek-V4-Flash-0731" in output
     assert "9e165c30e2704aec5d9d593cce3eebd58bbef1cb" in output
-    assert "num_speculative_tokens\\\":7" in output
+    assert 'num_speculative_tokens\\":7' in output
     assert "max_seqs=16 graph=128" in output
     assert "--max-model-len 131072" in output
     assert "--gpu-memory-utilization 0.975" in output
@@ -44,8 +43,8 @@ def test_ds4_launcher_dynamic_depth_enables_capacity_mode(tmp_path: Path) -> Non
     output = _dry_run(tmp_path, DSPARK_DEPTH_MODE="dynamic")
 
     assert "mode=dspark depth=dynamic" in output
-    assert "dspark_capacity_verification_mode\\\":\\\"varlen" in output
-    assert "dspark_sps_curve\\\":\\\"auto" in output
+    assert 'dspark_capacity_verification_mode\\":\\"varlen' in output
+    assert 'dspark_sps_curve\\":\\"auto' in output
 
 
 def test_ds4_launcher_accepts_cluster_style_aliases(tmp_path: Path) -> None:
@@ -56,7 +55,7 @@ def test_ds4_launcher_accepts_cluster_style_aliases(tmp_path: Path) -> None:
     )
 
     assert "dcp=1" in output
-    assert "num_speculative_tokens\\\":5" in output
+    assert 'num_speculative_tokens\\":5' in output
 
 
 def test_ds4_launcher_standard_mtp_uses_standard_checkpoint(tmp_path: Path) -> None:
@@ -65,8 +64,8 @@ def test_ds4_launcher_standard_mtp_uses_standard_checkpoint(tmp_path: Path) -> N
     assert "mode=mtp2 depth=disabled" in output
     assert "model=deepseek-ai/DeepSeek-V4-Flash" in output
     assert "DeepSeek-V4-Flash-0731" not in output
-    assert "method\\\":\\\"mtp" in output
-    assert "num_speculative_tokens\\\":2" in output
+    assert 'method\\":\\"mtp' in output
+    assert 'num_speculative_tokens\\":2' in output
 
 
 def test_ds4_launcher_can_disable_dspark_on_0731(tmp_path: Path) -> None:
@@ -75,3 +74,36 @@ def test_ds4_launcher_can_disable_dspark_on_0731(tmp_path: Path) -> None:
     assert "mode=dspark-mtp0 depth=disabled" in output
     assert "model=deepseek-ai/DeepSeek-V4-Flash-0731" in output
     assert "--speculative-config" not in output
+
+
+def test_ds4_launcher_enables_native_kv_offload(tmp_path: Path) -> None:
+    output = _dry_run(tmp_path, KV_OFFLOADING_SIZE="5.5")
+
+    assert "--kv-offloading-size 5.5" in output
+    assert "--kv-offloading-backend native" in output
+
+
+def test_ds4_launcher_zero_kv_offload_stays_disabled(tmp_path: Path) -> None:
+    output = _dry_run(tmp_path, KV_OFFLOADING_SIZE="0.0")
+
+    assert "--kv-offloading-size" not in output
+
+
+def test_ds4_launcher_rejects_invalid_kv_offload_size(tmp_path: Path) -> None:
+    env = {
+        "PATH": os.environ["PATH"],
+        "HOME": str(tmp_path),
+        "XDG_CACHE_HOME": str(tmp_path / "cache"),
+        "DRY_RUN": "1",
+        "KV_OFFLOADING_SIZE": "five",
+    }
+    result = subprocess.run(
+        ["bash", str(_LAUNCHER)],
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "KV_OFFLOADING_SIZE must be a non-negative GiB value" in result.stderr

--- a/tests/entrypoints/test_ds4_flash_launcher.py
+++ b/tests/entrypoints/test_ds4_flash_launcher.py
@@ -66,6 +66,23 @@ def test_ds4_launcher_dynamic_depth_enables_capacity_mode(tmp_path: Path) -> Non
     assert 'dspark_sps_curve\\":\\"auto' in output
 
 
+def test_ds4_launcher_uses_speculative_attention_backend_field(
+    tmp_path: Path,
+) -> None:
+    """Verify the draft backend uses SpeculativeConfig's canonical field.
+
+    Args:
+        tmp_path: Temporary home and cache root.
+    """
+    output = _dry_run(
+        tmp_path,
+        DSPARK_DRAFT_ATTENTION_BACKEND="FLASHINFER_MLA_SPARSE_DSV4",
+    )
+
+    assert 'attention_backend\\":\\"FLASHINFER_MLA_SPARSE_DSV4' in output
+    assert 'draft_attention_backend\\"' not in output
+
+
 def test_ds4_launcher_accepts_cluster_style_aliases(tmp_path: Path) -> None:
     """Verify compatibility with cluster-style environment aliases.
 

--- a/tests/entrypoints/test_ds4_flash_launcher.py
+++ b/tests/entrypoints/test_ds4_flash_launcher.py
@@ -81,6 +81,31 @@ def test_ds4_launcher_enables_native_kv_offload(tmp_path: Path) -> None:
 
     assert "--kv-offloading-size 5.5" in output
     assert "--kv-offloading-backend native" in output
+    assert "allocator=expandable_segments:False" in output
+
+
+def test_ds4_launcher_native_offload_preserves_other_allocator_settings(
+    tmp_path: Path,
+) -> None:
+    output = _dry_run(
+        tmp_path,
+        KV_OFFLOADING_SIZE="5.5",
+        PYTORCH_CUDA_ALLOC_CONF=(
+            "max_split_size_mb:256,expandable_segments:True"
+        ),
+    )
+
+    assert (
+        "allocator=max_split_size_mb:256,expandable_segments:False" in output
+    )
+
+
+def test_ds4_launcher_without_offload_keeps_expandable_segments(
+    tmp_path: Path,
+) -> None:
+    output = _dry_run(tmp_path)
+
+    assert "allocator=expandable_segments:True" in output
 
 
 def test_ds4_launcher_zero_kv_offload_stays_disabled(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Update the environment-only DS4 launcher for `deepseek-ai/DeepSeek-V4-Flash-0731` while preserving the historical standard-checkpoint MTP modes, and expose bounded native L1/L2 KV offload without requiring users to construct `--kv-transfer-config` JSON.

## Runtime Contract

- `MODE=dspark` selects the 0731 checkpoint; `MODE=dspark-mtp0` runs the same target without speculation.
- `MODE=mtp0|mtp2|mtp3` continues to select `deepseek-ai/DeepSeek-V4-Flash`.
- `DSPARK_DEPTH_MODE=dynamic` enables variable-length, confidence-driven verification.
- `KV_OFFLOADING_SIZE=<GiB>` enables the native CPU L1 tier. Decimal and non-power-of-two values are accepted; unset or zero keeps offload disabled.
- Setting `NATIVE_L2_PATH=<absolute container path>` and `NATIVE_L2_GB=<GiB>` together adds a bounded filesystem L2 tier. The helper builds a `TieringOffloadingSpec` with 32 read threads, 16 write threads, and `gc_max_size_gb`.
- L2 requires a positive L1 size and defaults `PYTHONHASHSEED=0` so persisted block keys remain reusable across restarts.
- Native offload disables only `expandable_segments`, retaining unrelated allocator settings.
- `DCP` and `NUM_SPECULATIVE_TOKENS` remain compatibility aliases for cluster launchers.

The launcher keeps K7 as its neutral source default. Release Compose profiles explicitly select the qualified production depth.

## Validation

- Launcher dry-run tests: 13 passed
- `bash -n serve-ds4-flash.sh`: pass
- Ruff check, format check, and `git diff --check`: pass
- Tests cover L1 decimal enablement, zero disablement, invalid input, allocator normalization, generated L2 connector configuration, incomplete L2 configuration, and L2-without-L1 rejection
- Qualified 0731 target/DSpark E2E results remain unchanged because L1/L2 are opt-in

Native storage lifecycle support remains separated by ownership: vLLM #217/#218 provide shared-region and retention behavior, while vLLM #254 adds bounded filesystem eviction and stale-load recovery.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added DSpark launcher aliases and updated default model, revision, sequence, context-length, token, and GPU memory settings.
  - Added configurable native KV and L2 offloading, including allocator behavior and optional filesystem tiering.
  - Added fixed and dynamic DSpark depth options with expanded launch diagnostics.

- **Bug Fixes**
  - Added validation for incompatible or incomplete offloading settings and invalid input values.

- **Tests**
  - Added coverage for launcher profiles, offloading configurations, aliases, speculative attention, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->