### PR TITLE
[GG] fix(distributed): isolate semantic PCIe graph channels

### DIFF
--- a/tests/distributed/test_b12x_fused_all_reduce.py
+++ b/tests/distributed/test_b12x_fused_all_reduce.py
@@ -84,6 +84,42 @@ def make_b12x_custom_allreduce(
     return custom_allreduce, runtime
 
 
+def test_b12x_destructor_quarantines_live_runtime_without_close() -> None:
+    custom_allreduce, runtime = make_b12x_custom_allreduce(
+        allreduce_max_size=64,
+        fused_max_size=64,
+    )
+    dma = MagicMock()
+    custom_allreduce._pcie_dma = dma
+    quarantine: dict[int, object] = {}
+
+    custom_allreduce.__del__(quarantine)
+
+    dma.close.assert_not_called()
+    runtime.close.assert_not_called()
+    assert quarantine == {id(custom_allreduce): custom_allreduce}
+
+    custom_allreduce._pcie_dma = None
+    custom_allreduce._pcie_runtime = None
+    quarantine.clear()
+
+
+def test_b12x_explicit_close_remains_coordinated() -> None:
+    custom_allreduce, runtime = make_b12x_custom_allreduce(
+        allreduce_max_size=64,
+        fused_max_size=64,
+    )
+    dma = MagicMock()
+    custom_allreduce._pcie_dma = dma
+
+    custom_allreduce.close()
+
+    dma.close.assert_called_once_with()
+    runtime.close.assert_called_once_with()
+    assert custom_allreduce._pcie_dma is None
+    assert custom_allreduce._pcie_runtime is None
+
+
 def test_b12x_fused_allreduce_uses_independent_cutoff() -> None:
     custom_allreduce, runtime = make_b12x_custom_allreduce(
         allreduce_max_size=16,

--- a/tests/distributed/test_b12x_fused_all_reduce.py
+++ b/tests/distributed/test_b12x_fused_all_reduce.py
@@ -84,42 +84,6 @@ def make_b12x_custom_allreduce(
     return custom_allreduce, runtime
 
 
-def test_b12x_destructor_quarantines_live_runtime_without_close() -> None:
-    custom_allreduce, runtime = make_b12x_custom_allreduce(
-        allreduce_max_size=64,
-        fused_max_size=64,
-    )
-    dma = MagicMock()
-    custom_allreduce._pcie_dma = dma
-    quarantine: dict[int, object] = {}
-
-    custom_allreduce.__del__(quarantine)
-
-    dma.close.assert_not_called()
-    runtime.close.assert_not_called()
-    assert quarantine == {id(custom_allreduce): custom_allreduce}
-
-    custom_allreduce._pcie_dma = None
-    custom_allreduce._pcie_runtime = None
-    quarantine.clear()
-
-
-def test_b12x_explicit_close_remains_coordinated() -> None:
-    custom_allreduce, runtime = make_b12x_custom_allreduce(
-        allreduce_max_size=64,
-        fused_max_size=64,
-    )
-    dma = MagicMock()
-    custom_allreduce._pcie_dma = dma
-
-    custom_allreduce.close()
-
-    dma.close.assert_called_once_with()
-    runtime.close.assert_called_once_with()
-    assert custom_allreduce._pcie_dma is None
-    assert custom_allreduce._pcie_runtime is None
-
-
 def test_b12x_fused_allreduce_uses_independent_cutoff() -> None:
     custom_allreduce, runtime = make_b12x_custom_allreduce(
         allreduce_max_size=16,

--- a/tests/distributed/test_b12x_fused_all_reduce.py
+++ b/tests/distributed/test_b12x_fused_all_reduce.py
@@ -157,6 +157,40 @@ def test_b12x_channel_checkpoint_delegates_to_runtime() -> None:
     runtime.rollback_channels.assert_called_once_with(checkpoint)
 
 
+def test_b12x_capture_forwards_semantic_channel_id() -> None:
+    custom_allreduce, runtime = make_b12x_custom_allreduce(
+        allreduce_max_size=64,
+        fused_max_size=64,
+    )
+    stream = object()
+
+    with custom_allreduce.capture(  # type: ignore[arg-type]
+        stream,
+        channel_id="vllm:target:profile",
+    ):
+        pass
+
+    runtime.capture.assert_called_once_with(
+        stream=stream,
+        channel_id="vllm:target:profile",
+    )
+
+
+def test_b12x_capture_rejects_missing_semantic_channel_id() -> None:
+    custom_allreduce, runtime = make_b12x_custom_allreduce(
+        allreduce_max_size=64,
+        fused_max_size=64,
+    )
+
+    with (
+        pytest.raises(RuntimeError, match="semantic channel_id"),
+        custom_allreduce.capture(),
+    ):
+        pass
+
+    runtime.capture.assert_not_called()
+
+
 def test_b12x_oneshot_buffer_tracks_dispatch_limits(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -357,7 +391,10 @@ def _run_b12x_fused_allreduce_gpu(rank: int, port: int) -> None:
     )
     inp.copy_(original_inp)
     residual.copy_(original_residual)
-    with graph_capture(device=device) as capture_context:
+    with graph_capture(
+        device=device,
+        channel_id="vllm:test:b12x-fused",
+    ) as capture_context:
         graph = torch.cuda.CUDAGraph()
         with torch.cuda.graph(graph, stream=capture_context.stream):
             torch.ops.vllm.b12x_fused_allreduce_add_rms_norm.default(

--- a/tests/distributed/test_b12x_fused_all_reduce.py
+++ b/tests/distributed/test_b12x_fused_all_reduce.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -25,6 +26,7 @@ from vllm.config import (
     set_current_vllm_config,
 )
 from vllm.distributed import tensor_model_parallel_all_reduce
+from vllm.distributed.device_communicators import custom_all_reduce
 from vllm.distributed.device_communicators.custom_all_reduce import (
     CustomAllreduce,
     _b12x_pcie_dma_min_bytes,
@@ -106,7 +108,66 @@ def test_b12x_fused_allreduce_uses_independent_cutoff() -> None:
         out=inp,
         residual_out=residual,
         stream=None,
+        channel_id="vllm:eager:allreduce",
     )
+    runtime.for_stream.assert_called_with(
+        None,
+        channel_id="vllm:eager:allreduce",
+    )
+
+
+def test_b12x_eager_allreduce_forwards_stable_semantic_channel() -> None:
+    custom_allreduce, runtime = make_b12x_custom_allreduce(
+        allreduce_max_size=64,
+        fused_max_size=64,
+    )
+    inp = torch.randn(2, 4)
+    expected = torch.empty_like(inp)
+    runtime.all_reduce.return_value = expected
+
+    actual = custom_allreduce.all_reduce(inp)
+
+    assert actual is expected
+    runtime.all_reduce.assert_called_once_with(
+        inp,
+        out=None,
+        stream=None,
+        channel_id="vllm:eager:allreduce",
+    )
+
+
+def test_b12x_eager_owner_fails_closed_on_second_stream_bind() -> None:
+    custom_allreduce, runtime = make_b12x_custom_allreduce(
+        allreduce_max_size=64,
+        fused_max_size=64,
+    )
+    first_stream = object()
+    second_stream = object()
+    custom_allreduce._pcie_runtime_stream = MagicMock(  # type: ignore[method-assign]
+        side_effect=(first_stream, second_stream)
+    )
+    bound_stream = None
+
+    def for_stream(stream, *, channel_id):
+        nonlocal bound_stream
+        assert channel_id == "vllm:eager:allreduce"
+        if bound_stream is None:
+            bound_stream = stream
+        elif stream is not bound_stream:
+            raise RuntimeError("stream-affine logical owner rebound")
+        channel = MagicMock()
+        channel.should_allreduce.return_value = True
+        return channel
+
+    runtime.for_stream.side_effect = for_stream
+    inp = torch.randn(2, 4)
+
+    assert custom_allreduce.should_custom_ar(inp)
+    with pytest.raises(RuntimeError, match="stream-affine"):
+        custom_allreduce.should_custom_ar(inp)
+    assert [
+        call.kwargs["channel_id"] for call in runtime.for_stream.call_args_list
+    ] == ["vllm:eager:allreduce", "vllm:eager:allreduce"]
 
 
 def test_b12x_fused_allreduce_falls_back_above_its_cutoff() -> None:
@@ -140,6 +201,121 @@ def test_b12x_oneshot_defaults_to_stream_isolation(
     monkeypatch.delenv("VLLM_PCIE_ONESHOT_SINGLE_CHANNEL", raising=False)
 
     assert not envs.environment_variables["VLLM_PCIE_ONESHOT_SINGLE_CHANNEL"]()
+
+
+def test_b12x_pool_prepares_single_stable_eager_owner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured = {}
+    runtime = MagicMock()
+
+    class FakePool:
+        @classmethod
+        def from_exchange_group(cls, **kwargs):
+            captured.update(kwargs)
+            return runtime
+
+    def fake_all_gather(gather_list, tensor, *, group):
+        for index, slot in enumerate(gather_list):
+            slot.fill_(index)
+
+    fake_config = SimpleNamespace(
+        model_config=SimpleNamespace(get_hidden_size=lambda: 4),
+        scheduler_config=SimpleNamespace(max_num_batched_tokens=8),
+    )
+    monkeypatch.setattr(custom_all_reduce, "custom_ar", True)
+    monkeypatch.setattr(custom_all_reduce.dist, "get_backend", lambda group: "gloo")
+    monkeypatch.setattr(
+        custom_all_reduce,
+        "in_the_same_node_as",
+        lambda group, source_rank=0: [True, True],
+    )
+    monkeypatch.setattr(custom_all_reduce.dist, "get_rank", lambda group=None: 0)
+    monkeypatch.setattr(custom_all_reduce.dist, "get_world_size", lambda group=None: 2)
+    monkeypatch.setattr(custom_all_reduce.dist, "all_gather", fake_all_gather)
+    monkeypatch.setattr(
+        custom_all_reduce.dist, "all_reduce", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        custom_all_reduce,
+        "_b12x_pcie_allreduce_requested",
+        lambda: True,
+    )
+    monkeypatch.setattr(custom_all_reduce, "_can_p2p", lambda *args: True)
+    monkeypatch.setattr(
+        custom_all_reduce,
+        "_is_cross_numa_topology",
+        lambda ids: False,
+    )
+    monkeypatch.setattr(
+        custom_all_reduce,
+        "_load_b12x_pcie_oneshot_pool",
+        lambda: FakePool,
+    )
+    monkeypatch.setattr(
+        custom_all_reduce,
+        "_b12x_pcie_dma_min_bytes",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        custom_all_reduce.current_platform,
+        "get_device_capability",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        custom_all_reduce.current_platform,
+        "visible_device_id_to_physical_device_id",
+        lambda index: index,
+    )
+    monkeypatch.setattr(
+        custom_all_reduce.current_platform,
+        "is_cuda_alike",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        custom_all_reduce.current_platform,
+        "is_fully_connected",
+        lambda ids: False,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        custom_all_reduce.current_platform,
+        "is_cuda",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        custom_all_reduce.current_platform,
+        "is_rocm",
+        lambda: False,
+    )
+    monkeypatch.setattr(
+        "vllm.config.get_current_vllm_config",
+        lambda: fake_config,
+    )
+    monkeypatch.setattr(
+        custom_all_reduce.envs,
+        "VLLM_PCIE_ONESHOT_SINGLE_CHANNEL",
+        False,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        custom_all_reduce.envs,
+        "VLLM_ALLOW_CUSTOM_ALLREDUCE_PCIE",
+        False,
+        raising=False,
+    )
+
+    built = CustomAllreduce(
+        object(),  # type: ignore[arg-type]
+        torch.device("cuda:0"),
+        nccl_group=object(),  # type: ignore[arg-type]
+    )
+
+    assert not built.disabled
+    assert captured["single_channel"] is False
+    assert captured["max_concurrent_channels"] == 2
+    runtime.prepare_channels.assert_called_once_with(("vllm:eager:allreduce",))
+    runtime.for_stream.assert_called_once_with(channel_id="vllm:eager:allreduce")
 
 
 def test_b12x_channel_checkpoint_delegates_to_runtime() -> None:

--- a/tests/distributed/test_custom_allreduce_lifecycle.py
+++ b/tests/distributed/test_custom_allreduce_lifecycle.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import gc
+import weakref
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from vllm.distributed.device_communicators.cuda_communicator import CudaCommunicator
+from vllm.distributed.device_communicators.custom_all_reduce import CustomAllreduce
+from vllm.distributed.parallel_state import GroupCoordinator
+
+
+def make_b12x_custom_allreduce() -> tuple[CustomAllreduce, MagicMock]:
+    runtime = MagicMock()
+    custom_allreduce = object.__new__(CustomAllreduce)
+    custom_allreduce.disabled = False
+    custom_allreduce._pcie_runtime = runtime
+    custom_allreduce._pcie_dma = None
+    custom_allreduce._ptr = 0
+    return custom_allreduce, runtime
+
+
+def test_b12x_destructor_skips_collective_close_without_retention() -> None:
+    custom_allreduce, runtime = make_b12x_custom_allreduce()
+    dma = MagicMock()
+    custom_allreduce._pcie_dma = dma
+    custom_allreduce_ref = weakref.ref(custom_allreduce)
+
+    del custom_allreduce
+    gc.collect()
+
+    dma.close.assert_not_called()
+    runtime.close.assert_not_called()
+    assert custom_allreduce_ref() is None
+
+
+def test_b12x_explicit_close_remains_coordinated() -> None:
+    custom_allreduce, runtime = make_b12x_custom_allreduce()
+    dma = MagicMock()
+    custom_allreduce._pcie_dma = dma
+    close_order = []
+    runtime.close.side_effect = lambda: close_order.append("runtime")
+    dma.close.side_effect = lambda: close_order.append("dma")
+
+    custom_allreduce.close()
+
+    assert close_order == ["runtime", "dma"]
+    dma.close.assert_called_once_with()
+    runtime.close.assert_called_once_with()
+    assert custom_allreduce._pcie_dma is None
+    assert custom_allreduce._pcie_runtime is None
+
+
+def test_b12x_close_retains_owners_when_runtime_close_fails() -> None:
+    custom_allreduce, runtime = make_b12x_custom_allreduce()
+    dma = MagicMock()
+    runtime.close.side_effect = RuntimeError("close failed")
+    custom_allreduce._pcie_dma = dma
+
+    with pytest.raises(RuntimeError, match="close failed"):
+        custom_allreduce.close()
+
+    assert custom_allreduce._pcie_runtime is runtime
+    assert custom_allreduce._pcie_dma is dma
+    dma.close.assert_not_called()
+
+
+def test_cuda_communicator_closes_custom_allreduce_before_nccl() -> None:
+    communicator = object.__new__(CudaCommunicator)
+    communicator.ca_comm = MagicMock()
+    communicator.pynccl_comm = MagicMock()
+    communicator.aiter_ar_comm = None
+    communicator.fi_ar_comm = None
+    communicator.all2all_manager = None
+    close_order = []
+    communicator.ca_comm.close.side_effect = lambda: close_order.append("custom")
+    communicator.pynccl_comm.destroy.side_effect = lambda: close_order.append("nccl")
+
+    communicator.destroy()
+
+    assert close_order == ["custom", "nccl"]
+    assert communicator.ca_comm is None
+    assert communicator.pynccl_comm is None
+
+
+def test_cuda_communicator_retains_owners_when_custom_close_fails() -> None:
+    communicator = object.__new__(CudaCommunicator)
+    custom_allreduce = MagicMock()
+    custom_allreduce.close.side_effect = RuntimeError("close failed")
+    communicator.ca_comm = custom_allreduce
+    communicator.pynccl_comm = MagicMock()
+    communicator.aiter_ar_comm = None
+    communicator.fi_ar_comm = None
+    communicator.all2all_manager = None
+
+    with pytest.raises(RuntimeError, match="close failed"):
+        communicator.destroy()
+
+    assert communicator.ca_comm is custom_allreduce
+    communicator.pynccl_comm.destroy.assert_not_called()
+
+
+def test_group_destroy_keeps_process_groups_live_for_communicator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    coordinator = object.__new__(GroupCoordinator)
+    coordinator.device_group = object()
+    coordinator.cpu_group = object()
+    coordinator.device_communicator = MagicMock()
+    coordinator.mq_broadcaster = None
+    device_group = coordinator.device_group
+    destroy_order = []
+    coordinator.device_communicator.destroy.side_effect = lambda: destroy_order.append(
+        "communicator"
+    )
+    monkeypatch.setattr(
+        torch.distributed,
+        "destroy_process_group",
+        lambda group: destroy_order.append(
+            "device" if group is device_group else "cpu"
+        ),
+    )
+
+    coordinator.destroy()
+
+    assert destroy_order == ["communicator", "device", "cpu"]
+
+
+def test_group_destroy_retains_process_groups_when_communicator_close_fails() -> None:
+    coordinator = object.__new__(GroupCoordinator)
+    coordinator.device_group = object()
+    coordinator.cpu_group = object()
+    coordinator.device_communicator = MagicMock()
+    coordinator.device_communicator.destroy.side_effect = RuntimeError("close failed")
+    coordinator.mq_broadcaster = None
+
+    with pytest.raises(RuntimeError, match="close failed"):
+        coordinator.destroy()
+
+    assert hasattr(coordinator, "device_group")
+    assert hasattr(coordinator, "cpu_group")

--- a/tests/distributed/test_dcp_a2a.py
+++ b/tests/distributed/test_dcp_a2a.py
@@ -552,8 +552,11 @@ def test_b12x_pool_uses_independent_stream_channels(
             captured.update(kwargs)
             return cls()
 
-        def for_stream(self):
-            captured["warmed"] = True
+        def prepare_channels(self, channel_ids):
+            captured["prepared"] = tuple(channel_ids)
+
+        def for_stream(self, *, channel_id):
+            captured["warmed"] = channel_id
 
     group = _FakeCPGroup(2, object())  # type: ignore[arg-type]
     monkeypatch.setattr(dcp_alltoall, "_B12X_DCP_A2A_POOLS", {})
@@ -577,7 +580,9 @@ def test_b12x_pool_uses_independent_stream_channels(
 
     assert pool is not None
     assert captured["single_channel"] is False
-    assert captured["warmed"] is True
+    assert captured["max_concurrent_channels"] == 2
+    assert captured["prepared"] == ("vllm:eager:dcp",)
+    assert captured["warmed"] == "vllm:eager:dcp"
 
 
 def test_b12x_dcp_capture_selects_only_current_group_pools(monkeypatch):
@@ -868,7 +873,16 @@ def test_b12x_lse_reduce_honors_token_cap(monkeypatch: pytest.MonkeyPatch):
     sentinel = torch.zeros(1)
 
     class _FakePool:
-        def lse_reduce_scatter(self, partial, lse, out=None, *, is_lse_base_on_e):
+        def lse_reduce_scatter(
+            self,
+            partial,
+            lse,
+            out=None,
+            *,
+            is_lse_base_on_e,
+            channel_id,
+        ):
+            created["channel_id"] = channel_id
             return sentinel
 
     def fake_get_pool(
@@ -894,6 +908,7 @@ def test_b12x_lse_reduce_honors_token_cap(monkeypatch: pytest.MonkeyPatch):
     # Batch within the cap uses B12X, with the staging pool capped too.
     assert result is sentinel
     assert created["max_batch_size"] == 4
+    assert created["channel_id"] == "vllm:eager:dcp"
 
     out_large = torch.zeros(8, 16, 64, dtype=torch.bfloat16, device="cuda")
     lse_large = torch.zeros(8, 16, dtype=torch.float32, device="cuda")
@@ -920,7 +935,8 @@ def test_b12x_query_gather_honors_token_cap(monkeypatch: pytest.MonkeyPatch):
     sentinel = torch.zeros(1)
 
     class _FakePool:
-        def all_gather_heads(self, local_input):
+        def all_gather_heads(self, local_input, *, channel_id):
+            created["channel_id"] = channel_id
             return sentinel
 
     def fake_get_pool(
@@ -941,6 +957,7 @@ def test_b12x_query_gather_honors_token_cap(monkeypatch: pytest.MonkeyPatch):
     )
     assert result is sentinel
     assert created["max_batch_size"] == 4
+    assert created["channel_id"] == "vllm:eager:dcp"
 
     large = torch.zeros(8, 8, 64, dtype=torch.bfloat16, device="cuda")
     result = dcp_alltoall._try_b12x_dcp_all_gather_heads(
@@ -962,8 +979,21 @@ def test_b12x_lse_reduce_preserves_supported_layouts(monkeypatch: pytest.MonkeyP
     sentinel = torch.zeros(1)
 
     class _FakePool:
-        def lse_reduce_scatter(self, partial, lse, out=None, *, is_lse_base_on_e):
-            received.update(partial=partial, lse=lse, out=out)
+        def lse_reduce_scatter(
+            self,
+            partial,
+            lse,
+            out=None,
+            *,
+            is_lse_base_on_e,
+            channel_id,
+        ):
+            received.update(
+                partial=partial,
+                lse=lse,
+                out=out,
+                channel_id=channel_id,
+            )
             return sentinel
 
     monkeypatch.setattr(
@@ -994,6 +1024,7 @@ def test_b12x_lse_reduce_preserves_supported_layouts(monkeypatch: pytest.MonkeyP
     assert received["partial"].is_contiguous()
     assert received["lse"].is_contiguous()
     assert received["out"].movedim(0, 1).is_contiguous()
+    assert received["channel_id"] == "vllm:eager:dcp"
 
     head_major_storage = torch.zeros(16, 8, 64, dtype=torch.bfloat16, device="cuda")
     head_major = head_major_storage.transpose(0, 1)[:4]

--- a/tests/distributed/test_dcp_a2a.py
+++ b/tests/distributed/test_dcp_a2a.py
@@ -10,7 +10,7 @@ Tests cover:
 
 import importlib.util
 import math
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 from typing import Any
 
 import multiprocess as mp
@@ -583,19 +583,19 @@ def test_b12x_pool_uses_independent_stream_channels(
 def test_b12x_dcp_capture_selects_only_current_group_pools(monkeypatch):
     from vllm.v1.attention.ops import dcp_alltoall
 
-    events = []
+    events: list[Any] = []
 
     class _FakePool:
         def __init__(self, name):
             self.name = name
 
         @contextmanager
-        def capture(self, *, stream):
-            events.append(("enter", self.name, stream))
+        def capture(self, *, stream, channel_id):
+            events.append(("enter", self.name, stream, channel_id))
             try:
                 yield
             finally:
-                events.append(("exit", self.name, stream))
+                events.append(("exit", self.name, stream, channel_id))
 
     device_group = object()
     group = _FakeCPGroup(2, device_group)  # type: ignore[arg-type]
@@ -607,16 +607,39 @@ def test_b12x_dcp_capture_selects_only_current_group_pools(monkeypatch):
     }
     monkeypatch.setattr(dcp_alltoall, "_B12X_DCP_A2A_POOLS", pools)
 
-    with dcp_alltoall.capture_b12x_dcp_a2a(group, stream):  # type: ignore[arg-type]
-        events.append(("body", None, stream))
+    with dcp_alltoall.capture_b12x_dcp_a2a(  # type: ignore[arg-type]
+        group,
+        stream,
+        channel_id="vllm:target:profile",
+    ):
+        events.append(("body", None, stream, "vllm:target:profile"))
 
     assert events == [
-        ("enter", "output", stream),
-        ("enter", "query", stream),
-        ("body", None, stream),
-        ("exit", "query", stream),
-        ("exit", "output", stream),
+        ("enter", "output", stream, "vllm:target:profile"),
+        ("enter", "query", stream, "vllm:target:profile"),
+        ("body", None, stream, "vllm:target:profile"),
+        ("exit", "query", stream, "vllm:target:profile"),
+        ("exit", "output", stream, "vllm:target:profile"),
     ]
+
+
+def test_b12x_dcp_capture_rejects_missing_semantic_id(monkeypatch):
+    from vllm.v1.attention.ops import dcp_alltoall
+
+    device_group = object()
+    group = _FakeCPGroup(2, device_group)  # type: ignore[arg-type]
+    key = (id(device_group), 0, 64, 512, 576, 64)
+    monkeypatch.setattr(
+        dcp_alltoall,
+        "_B12X_DCP_A2A_POOLS",
+        {key: object()},
+    )
+
+    with (
+        pytest.raises(RuntimeError, match="semantic channel_id"),
+        dcp_alltoall.capture_b12x_dcp_a2a(group),
+    ):
+        pass
 
 
 def test_b12x_dcp_channel_rollback_restores_existing_and_closes_new_pools(
@@ -624,7 +647,7 @@ def test_b12x_dcp_channel_rollback_restores_existing_and_closes_new_pools(
 ):
     from vllm.v1.attention.ops import dcp_alltoall
 
-    events = []
+    events: list[Any] = []
 
     class _FakePool:
         def __init__(self, name):
@@ -667,7 +690,7 @@ def test_profile_channel_checkpoint_rolls_back_all_b12x_transports(monkeypatch):
     from vllm.distributed import parallel_state
     from vllm.v1.attention.ops import dcp_alltoall
 
-    events = []
+    events: list[Any] = []
 
     class _FakeCommunicator:
         def checkpoint_pcie_channels(self):
@@ -691,10 +714,15 @@ def test_profile_channel_checkpoint_rolls_back_all_b12x_transports(monkeypatch):
     monkeypatch.setattr(parallel_state, "_TP", tp_group)
     monkeypatch.setattr(parallel_state, "_PP", pp_group)
     monkeypatch.setattr(parallel_state, "_DCP", dcp_group)
+
+    def checkpoint_dcp(group):
+        events.append("checkpoint-dcp")
+        return "dcp-checkpoint"
+
     monkeypatch.setattr(
         dcp_alltoall,
         "checkpoint_b12x_dcp_a2a_channels",
-        lambda group: events.append("checkpoint-dcp") or "dcp-checkpoint",
+        checkpoint_dcp,
     )
     monkeypatch.setattr(
         dcp_alltoall,
@@ -717,25 +745,38 @@ def test_global_graph_capture_enters_b12x_dcp_pool(monkeypatch):
     from vllm.distributed import parallel_state
     from vllm.v1.attention.ops import dcp_alltoall
 
-    events = []
+    events: list[Any] = []
 
     class _FakeGroup:
         world_size = 2
 
+        def __init__(self, name):
+            self.name = name
+
         @contextmanager
         def graph_capture(self, context):
-            yield context
+            events.append(("enter-group", self.name, context.channel_id))
+            try:
+                yield context
+            finally:
+                events.append(("exit-group", self.name, context.channel_id))
 
-    tp_group = _FakeGroup()
-    pp_group = _FakeGroup()
-    dcp_group = _FakeGroup()
+    tp_group = _FakeGroup("tp")
+    pp_group = _FakeGroup("pp")
+    dcp_group = _FakeGroup("dcp")
     stream = object()
-    context = parallel_state.GraphCaptureContext(stream)  # type: ignore[arg-type]
+    context = parallel_state.GraphCaptureContext(  # type: ignore[arg-type]
+        stream,
+        channel_id="vllm:target:profile",
+    )
 
     @contextmanager
-    def fake_b12x_capture(group, selected_stream):
-        events.append((group, selected_stream))
-        yield
+    def fake_b12x_capture(group, selected_stream, *, channel_id):
+        events.append(("enter-b12x", group, selected_stream, channel_id))
+        try:
+            yield
+        finally:
+            events.append(("exit-b12x", group, selected_stream, channel_id))
 
     monkeypatch.setattr(parallel_state, "_DCP", dcp_group)
     monkeypatch.setattr(parallel_state, "get_tp_group", lambda: tp_group)
@@ -746,7 +787,75 @@ def test_global_graph_capture_enters_b12x_dcp_pool(monkeypatch):
     with parallel_state.graph_capture(torch.device("cpu"), context) as actual:
         assert actual is context
 
-    assert events == [(dcp_group, stream)]
+    assert events == [
+        ("enter-group", "tp", "vllm:target:profile"),
+        ("enter-group", "pp", "vllm:target:profile"),
+        ("enter-group", "dcp", "vllm:target:profile"),
+        (
+            "enter-b12x",
+            dcp_group,
+            stream,
+            "vllm:target:profile",
+        ),
+        (
+            "exit-b12x",
+            dcp_group,
+            stream,
+            "vllm:target:profile",
+        ),
+        ("exit-group", "dcp", "vllm:target:profile"),
+        ("exit-group", "pp", "vllm:target:profile"),
+        ("exit-group", "tp", "vllm:target:profile"),
+    ]
+
+
+def test_group_capture_forwards_semantic_id_to_custom_allreduce(monkeypatch):
+    from vllm._aiter_ops import rocm_aiter_ops
+    from vllm.distributed import parallel_state
+    from vllm.distributed.device_communicators.cuda_communicator import (
+        CudaCommunicator,
+    )
+
+    events: list[Any] = []
+
+    class FakeCustomAllreduce:
+        @contextmanager
+        def capture(self, *, stream, channel_id):
+            events.append(("enter", stream, channel_id))
+            try:
+                yield
+            finally:
+                events.append(("exit", stream, channel_id))
+
+    communicator = object.__new__(CudaCommunicator)
+    communicator.ca_comm = FakeCustomAllreduce()
+    group = object.__new__(parallel_state.GroupCoordinator)
+    group.device_communicator = communicator
+    stream = object()
+    context = parallel_state.GraphCaptureContext(  # type: ignore[arg-type]
+        stream,
+        channel_id="vllm:draft:decode:production",
+    )
+
+    monkeypatch.setattr(rocm_aiter_ops, "is_enabled", lambda: False)
+    monkeypatch.setattr(
+        parallel_state.torch.cuda,
+        "current_stream",
+        lambda: stream,
+    )
+    monkeypatch.setattr(
+        parallel_state.torch.cuda,
+        "stream",
+        lambda selected: nullcontext(),
+    )
+
+    with parallel_state.GroupCoordinator.graph_capture(group, context) as actual:
+        assert actual is context
+
+    assert events == [
+        ("enter", stream, "vllm:draft:decode:production"),
+        ("exit", stream, "vllm:draft:decode:production"),
+    ]
 
 
 @pytest.mark.skipif(torch.accelerator.device_count() < 1, reason="CUDA is required.")
@@ -759,9 +868,7 @@ def test_b12x_lse_reduce_honors_token_cap(monkeypatch: pytest.MonkeyPatch):
     sentinel = torch.zeros(1)
 
     class _FakePool:
-        def lse_reduce_scatter(
-            self, partial, lse, out=None, *, is_lse_base_on_e
-        ):
+        def lse_reduce_scatter(self, partial, lse, out=None, *, is_lse_base_on_e):
             return sentinel
 
     def fake_get_pool(
@@ -855,9 +962,7 @@ def test_b12x_lse_reduce_preserves_supported_layouts(monkeypatch: pytest.MonkeyP
     sentinel = torch.zeros(1)
 
     class _FakePool:
-        def lse_reduce_scatter(
-            self, partial, lse, out=None, *, is_lse_base_on_e
-        ):
+        def lse_reduce_scatter(self, partial, lse, out=None, *, is_lse_base_on_e):
             received.update(partial=partial, lse=lse, out=out)
             return sentinel
 
@@ -890,9 +995,7 @@ def test_b12x_lse_reduce_preserves_supported_layouts(monkeypatch: pytest.MonkeyP
     assert received["lse"].is_contiguous()
     assert received["out"].movedim(0, 1).is_contiguous()
 
-    head_major_storage = torch.zeros(
-        16, 8, 64, dtype=torch.bfloat16, device="cuda"
-    )
+    head_major_storage = torch.zeros(16, 8, 64, dtype=torch.bfloat16, device="cuda")
     head_major = head_major_storage.transpose(0, 1)[:4]
     result = dcp_alltoall._try_b12x_dcp_lse_reduce(
         head_major,

--- a/tests/distributed/test_dcp_a2a.py
+++ b/tests/distributed/test_dcp_a2a.py
@@ -1401,7 +1401,15 @@ def _distributed_b12x_a2a_worker(env: dict[str, str]) -> None:
         dcp_alltoall._dcp_a2a_send_recv_buffers = fail_packed_nccl
         group.all_gather = fail_query_nccl  # type: ignore[attr-defined]
         graph = torch.cuda.CUDAGraph()
-        with torch.cuda.graph(graph):
+        capture_stream = torch.cuda.Stream(device=f"cuda:{local_rank}")
+        with (
+            dcp_alltoall.capture_b12x_dcp_a2a(
+                group,  # type: ignore[arg-type]
+                capture_stream,
+                channel_id="test:dcp:graph",
+            ),
+            torch.cuda.graph(graph, stream=capture_stream),
+        ):
             graph_query = dcp_alltoall.dcp_b12x_all_gather_heads(
                 static_query,
                 group,  # type: ignore[arg-type]

--- a/tests/v1/cudagraph/test_breakable_cudagraph.py
+++ b/tests/v1/cudagraph/test_breakable_cudagraph.py
@@ -99,6 +99,7 @@ def test_memory_profile_reuses_production_pool_and_destroys_graphs(monkeypatch):
         def capture(self, *args, **kwargs):
             assert self.pool is production_pool
             assert wrapper.graph_pool is production_pool
+            assert kwargs["channel_id"] == "vllm:target:profile"
             lazy_wrapper = FakeWrapper()
             lazy_wrapper.graph_pool = self.pool
             lazy_wrappers.append(lazy_wrapper)
@@ -112,8 +113,9 @@ def test_memory_profile_reuses_production_pool_and_destroys_graphs(monkeypatch):
         def get_cudagraph_managers(self):
             return []
 
-        def capture(self):
+        def capture(self, *, capture_phase):
             assert workspace_module._workspace_lane.get() == 1
+            assert capture_phase == "profile"
             events.append("spec_capture")
 
     manager = FakeManager()
@@ -235,6 +237,7 @@ def test_production_capture_releases_pool_anchor_on_failure(monkeypatch):
 
         @staticmethod
         def capture(*args, **kwargs):
+            assert kwargs["channel_id"] == "vllm:target:production"
             events.append("capture")
             raise RuntimeError("capture failed")
 
@@ -267,6 +270,60 @@ def test_production_capture_releases_pool_anchor_on_failure(monkeypatch):
 
     assert runner._cudagraph_pool_anchor is None
     assert events == ["capture", "anchor_reset"]
+
+
+def test_production_capture_assigns_target_and_draft_phase_ids(monkeypatch):
+    from vllm.v1.worker.gpu import model_runner as model_runner_module
+
+    events = []
+
+    class FakeManager:
+        @staticmethod
+        def needs_capture():
+            return True
+
+        @staticmethod
+        def capture(*args, **kwargs):
+            events.append(("target", kwargs["channel_id"]))
+
+    class FakeSpeculator:
+        @staticmethod
+        def capture(*, capture_phase):
+            events.append(("draft", capture_phase))
+
+    runner = model_runner_module.GPUModelRunner.__new__(
+        model_runner_module.GPUModelRunner
+    )
+    runner.cudagraph_manager = FakeManager()
+    runner._cudagraph_pool_anchor = None
+    runner.lora_config = None
+    runner.model = object()
+    runner.model_state = object()
+    runner.input_buffers = object()
+    runner.intermediate_tensors = object()
+    runner.block_tables = object()
+    runner.attn_groups = object()
+    runner.kv_cache_config = object()
+    runner.use_aux_hidden_state_outputs = False
+    runner.speculator = FakeSpeculator()
+    runner.maybe_setup_dummy_loras = lambda _: nullcontext()
+    runner._zero_cudagraph_capture_kv_blocks = lambda: None
+
+    monkeypatch.setattr(model_runner_module.gc, "collect", lambda: None)
+    monkeypatch.setattr(torch.accelerator, "empty_cache", lambda: None)
+    monkeypatch.setattr(
+        torch.accelerator,
+        "get_memory_info",
+        lambda: (1000, 0),
+    )
+    monkeypatch.setattr(model_runner_module, "lock_workspace", lambda: None)
+
+    runner.capture_model()
+
+    assert events == [
+        ("target", "vllm:target:production"),
+        ("draft", "production"),
+    ]
 
 
 def test_skipped_production_capture_releases_pool_anchor():
@@ -372,13 +429,21 @@ def test_piecewise_capture_builds_fresh_metadata_for_both_passes():
         patch(
             "vllm.v1.worker.gpu.cudagraph_utils.graph_capture",
             return_value=nullcontext(),
-        ),
+        ) as graph_capture_mock,
         patch(
             "vllm.v1.worker.gpu.cudagraph_utils.is_global_first_rank",
             return_value=False,
         ),
     ):
-        manager.capture(create_forward_fn)
+        manager.capture(
+            create_forward_fn,
+            channel_id="vllm:target:profile",
+        )
+
+    graph_capture_mock.assert_called_once_with(
+        device=torch.device("cpu"),
+        channel_id="vllm:target:profile",
+    )
 
     assert [warmup for warmup, _ in create_calls] == [True, False]
     assert [mode for _, mode, _ in forward_calls] == [

--- a/tests/v1/spec_decode/test_dflash_cudagraph_lifetime.py
+++ b/tests/v1/spec_decode/test_dflash_cudagraph_lifetime.py
@@ -63,3 +63,34 @@ def test_dflash_does_not_retain_eager_backbone_output(monkeypatch):
     )
 
     assert speculator._captured_backbone_outputs == []
+
+
+def test_dflash_capture_uses_phase_specific_draft_channel_ids():
+    events = []
+
+    class FakeManager:
+        def capture(self, *args, **kwargs):
+            events.append(kwargs["channel_id"])
+
+    speculator = SimpleNamespace(
+        _speculator_name="DFlash",
+        sample_indices=torch.zeros(1),
+        sample_pos=torch.zeros(1),
+        sample_idx_mapping=torch.zeros(1),
+        query_cudagraph_manager=FakeManager(),
+        _generate_draft=object(),
+        input_buffers=object(),
+        block_tables=object(),
+        attn_groups=object(),
+        kv_cache_config=object(),
+        max_model_len=1,
+        _group_causal=True,
+    )
+
+    DFlashSpeculator.capture(speculator, capture_phase="profile")
+    DFlashSpeculator.capture(speculator, capture_phase="production")
+
+    assert events == [
+        "vllm:draft:dflash:profile",
+        "vllm:draft:dflash:production",
+    ]

--- a/tests/v1/worker/test_gpu_autoregressive_speculator.py
+++ b/tests/v1/worker/test_gpu_autoregressive_speculator.py
@@ -168,8 +168,8 @@ def test_ar_probabilistic_draft_uses_shared_sampler(monkeypatch):
     assert captured["active_rows"] is speculator.active_num_reqs
 
 
-def test_autoregressive_capture_ids_are_cross_rank_symmetric_and_separated():
-    def capture_for_rank() -> list[str]:
+def test_autoregressive_capture_ids_are_deterministic_and_phase_separated():
+    def capture_channel_ids() -> list[str]:
         events = []
 
         class FakeManager:
@@ -204,4 +204,4 @@ def test_autoregressive_capture_ids_are_cross_rank_symmetric_and_separated():
         "vllm:draft:prefill:production",
         "vllm:draft:decode:production",
     ]
-    assert capture_for_rank() == capture_for_rank() == expected
+    assert capture_channel_ids() == capture_channel_ids() == expected

--- a/tests/v1/worker/test_gpu_autoregressive_speculator.py
+++ b/tests/v1/worker/test_gpu_autoregressive_speculator.py
@@ -166,3 +166,42 @@ def test_ar_probabilistic_draft_uses_shared_sampler(monkeypatch):
 
     assert captured["positions"] is positions
     assert captured["active_rows"] is speculator.active_num_reqs
+
+
+def test_autoregressive_capture_ids_are_cross_rank_symmetric_and_separated():
+    def capture_for_rank() -> list[str]:
+        events = []
+
+        class FakeManager:
+            use_breakable_cg = False
+
+            def capture(self, *args, **kwargs):
+                events.append(kwargs["channel_id"])
+
+        speculator = object.__new__(_TestSpeculator)
+        speculator.last_token_indices = torch.zeros(1)
+        speculator.prefill_cudagraph_manager = FakeManager()
+        speculator.decode_cudagraph_manager = FakeManager()
+        speculator.model = object()
+        speculator._prefill = object()
+        speculator._generate_draft = object()
+        speculator.model_state = object()
+        speculator.target_input_buffers = object()
+        speculator.input_buffers = object()
+        speculator.block_tables = object()
+        speculator.target_attn_groups = object()
+        speculator.attn_groups = object()
+        speculator.kv_cache_config = object()
+        speculator.num_speculative_steps = 3
+
+        speculator.capture(capture_phase="profile")
+        speculator.capture(capture_phase="production")
+        return events
+
+    expected = [
+        "vllm:draft:prefill:profile",
+        "vllm:draft:decode:profile",
+        "vllm:draft:prefill:production",
+        "vllm:draft:decode:production",
+    ]
+    assert capture_for_rank() == capture_for_rank() == expected

--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -1793,7 +1793,10 @@ def test_v1_capture_separates_target_and_draft_semantic_channels(monkeypatch):
         uses_extract_hidden_states=lambda: False,
     )
     runner.cudagraph_dispatcher = SimpleNamespace(
-        get_capture_descs=lambda: [(CUDAGraphMode.PIECEWISE, [object()])]
+        get_capture_descs=lambda: [
+            (CUDAGraphMode.FULL, []),
+            (CUDAGraphMode.PIECEWISE, [object()]),
+        ]
     )
     runner.encoder_cudagraph_manager = None
     runner.device = torch.device("cpu")
@@ -1920,7 +1923,10 @@ def test_v1_profile_rolls_back_distinct_target_and_draft_channels(monkeypatch):
     )
     desc = SimpleNamespace(num_tokens=32)
     runner.cudagraph_dispatcher = SimpleNamespace(
-        get_capture_descs=lambda: [(CUDAGraphMode.PIECEWISE, [desc])],
+        get_capture_descs=lambda: [
+            (CUDAGraphMode.FULL, []),
+            (CUDAGraphMode.PIECEWISE, [desc]),
+        ],
         cudagraph_keys={},
         keys_initialized=True,
     )
@@ -2032,7 +2038,11 @@ def test_v1_profile_rolls_back_distinct_target_and_draft_channels(monkeypatch):
     assert events[-1] == ("rollback", checkpoint)
 
 
-def test_v1_profile_rolls_back_channels_when_capture_fails(monkeypatch):
+@pytest.mark.parametrize("cleanup_fails", [False, True])
+def test_v1_profile_restores_state_when_capture_or_cleanup_fails(
+    monkeypatch,
+    cleanup_fails,
+):
     runner = GPUModelRunner.__new__(GPUModelRunner)
     runner.vllm_config = object()
     runner.device = torch.device("cpu")
@@ -2093,20 +2103,28 @@ def test_v1_profile_rolls_back_channels_when_capture_fails(monkeypatch):
         "set_cudagraph_capturing_enabled",
         lambda enabled: events.append(("capture-enabled", enabled)),
     )
+    original_pool = object()
+    wrapper = SimpleNamespace(graph_pool=original_pool)
     monkeypatch.setattr(
         gpu_model_runner_module.CUDAGraphWrapper,
         "_all_instances",
-        [],
+        [wrapper],
     )
     monkeypatch.setattr(
         gpu_model_runner_module.BreakableCUDAGraphWrapper,
         "_all_instances",
         [],
     )
+
+    def clear_target_graphs():
+        events.append("clear-target")
+        if cleanup_fails:
+            raise RuntimeError("expected cleanup failure")
+
     monkeypatch.setattr(
         gpu_model_runner_module.CUDAGraphWrapper,
         "clear_all_graphs",
-        lambda: events.append("clear-target"),
+        clear_target_graphs,
     )
     monkeypatch.setattr(
         gpu_model_runner_module.BreakableCUDAGraphWrapper,
@@ -2117,10 +2135,13 @@ def test_v1_profile_rolls_back_channels_when_capture_fails(monkeypatch):
     monkeypatch.setattr(torch.accelerator, "empty_cache", lambda: None)
     monkeypatch.setattr(torch.accelerator, "get_memory_info", lambda: (1000, 0))
 
-    with pytest.raises(RuntimeError, match="expected capture failure"):
+    expected_error = "expected cleanup failure" if cleanup_fails else "capture failure"
+    with pytest.raises(RuntimeError, match=expected_error):
         runner.profile_cudagraph_memory()
 
-    assert events.index("clear-target") < events.index("cleanup")
-    assert events.index("cleanup-sync") < events.index("cleanup")
-    assert events.index("cleanup") < events.index(("rollback", checkpoint))
+    assert wrapper.graph_pool is original_pool
+    if not cleanup_fails:
+        assert events.index("clear-target") < events.index("cleanup")
+        assert events.index("cleanup-sync") < events.index("cleanup")
+        assert events.index("cleanup") < events.index(("rollback", checkpoint))
     assert events[-1] == ("rollback", checkpoint)

--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from contextlib import contextmanager, nullcontext
 from types import SimpleNamespace
 from unittest.mock import Mock
 
@@ -12,6 +13,7 @@ import vllm.v1.worker.gpu_model_runner as gpu_model_runner_module
 from vllm.config import (
     AttentionConfig,
     CacheConfig,
+    CUDAGraphMode,
     ModelConfig,
     ParallelConfig,
     SchedulerConfig,
@@ -1779,3 +1781,346 @@ def test_mamba_cache_raises_when_max_num_seqs_exceeds_blocks():
 
         with pytest.raises(ValueError, match="max_num_seqs"):
             runner.initialize_kv_cache(kv_cache_config)
+
+
+def test_v1_capture_separates_target_and_draft_semantic_channels(monkeypatch):
+    runner = GPUModelRunner.__new__(GPUModelRunner)
+    runner.compilation_config = SimpleNamespace(cudagraph_mode=CUDAGraphMode.PIECEWISE)
+    runner.speculative_config = SimpleNamespace(
+        enforce_eager=False,
+        use_eagle=lambda: False,
+        uses_draft_model=lambda: True,
+        uses_extract_hidden_states=lambda: False,
+    )
+    runner.cudagraph_dispatcher = SimpleNamespace(
+        get_capture_descs=lambda: [(CUDAGraphMode.PIECEWISE, [object()])]
+    )
+    runner.encoder_cudagraph_manager = None
+    runner.device = torch.device("cpu")
+    runner._maybe_init_encoder_cudagraph_manager = lambda: None
+    runner._freeze_gc = nullcontext
+
+    active_channel: list[str] = []
+    channel_entries: list[str] = []
+    captures: list[tuple[str, bool]] = []
+
+    @contextmanager
+    def fake_graph_capture(*, device, channel_id, **kwargs):
+        assert device == runner.device
+        active_channel.append(channel_id)
+        channel_entries.append(channel_id)
+        try:
+            yield SimpleNamespace(channel_id=channel_id)
+        finally:
+            assert active_channel.pop() == channel_id
+
+    def fake_capture_cudagraphs(*, run_drafter, **kwargs):
+        assert len(active_channel) == 1
+        captures.append((active_channel[0], run_drafter))
+
+    runner._capture_cudagraphs = fake_capture_cudagraphs
+    runner.encoder_cudagraph_manager = SimpleNamespace(
+        capture=lambda **_: captures.append((active_channel[0], True))
+    )
+    memory_info = iter(((1000, 0), (900, 0)))
+    monkeypatch.setattr(gpu_model_runner_module, "graph_capture", fake_graph_capture)
+    monkeypatch.setattr(
+        gpu_model_runner_module,
+        "set_cudagraph_capturing_enabled",
+        lambda _: None,
+    )
+    monkeypatch.setattr(gpu_model_runner_module, "lock_workspace", lambda: None)
+    monkeypatch.setattr(
+        gpu_model_runner_module,
+        "current_platform",
+        SimpleNamespace(graph_pool_handle=object),
+    )
+    monkeypatch.setattr(
+        torch.accelerator,
+        "synchronize",
+        lambda: None,
+    )
+    monkeypatch.setattr(torch.accelerator, "empty_cache", lambda: None)
+    monkeypatch.setattr(
+        torch.accelerator,
+        "get_memory_info",
+        lambda: next(memory_info),
+    )
+
+    assert runner.capture_model() == 100
+    assert captures == [
+        ("vllm:target:production", False),
+        ("vllm:draft:production", True),
+        ("vllm:encoder:production", True),
+    ]
+    assert channel_entries == [
+        "vllm:target:production",
+        "vllm:draft:production",
+        "vllm:encoder:production",
+    ]
+
+
+def test_v1_full_capture_without_speculation_is_target_only(monkeypatch):
+    runner = GPUModelRunner.__new__(GPUModelRunner)
+    runner.compilation_config = SimpleNamespace(cudagraph_mode=CUDAGraphMode.FULL)
+    runner.speculative_config = None
+    runner.cudagraph_dispatcher = SimpleNamespace(
+        get_capture_descs=lambda: [(CUDAGraphMode.FULL, [object()])]
+    )
+    runner.encoder_cudagraph_manager = None
+    runner.device = torch.device("cpu")
+    runner._maybe_init_encoder_cudagraph_manager = lambda: None
+    runner._freeze_gc = nullcontext
+
+    channels: list[str] = []
+    captures: list[bool] = []
+
+    @contextmanager
+    def fake_graph_capture(*, channel_id, **kwargs):
+        channels.append(channel_id)
+        yield SimpleNamespace(channel_id=channel_id)
+
+    runner._capture_cudagraphs = lambda *, run_drafter, **_: captures.append(
+        run_drafter
+    )
+    memory_info = iter(((1000, 0), (900, 0)))
+    monkeypatch.setattr(gpu_model_runner_module, "graph_capture", fake_graph_capture)
+    monkeypatch.setattr(
+        gpu_model_runner_module,
+        "set_cudagraph_capturing_enabled",
+        lambda _: None,
+    )
+    monkeypatch.setattr(gpu_model_runner_module, "lock_workspace", lambda: None)
+    monkeypatch.setattr(
+        torch.accelerator,
+        "synchronize",
+        lambda: None,
+    )
+    monkeypatch.setattr(torch.accelerator, "empty_cache", lambda: None)
+    monkeypatch.setattr(
+        torch.accelerator,
+        "get_memory_info",
+        lambda: next(memory_info),
+    )
+
+    assert runner.capture_model() == 100
+    assert channels == ["vllm:target:production"]
+    assert captures == [True]
+
+
+def test_v1_profile_rolls_back_distinct_target_and_draft_channels(monkeypatch):
+    runner = GPUModelRunner.__new__(GPUModelRunner)
+    runner.vllm_config = object()
+    runner.device = torch.device("cpu")
+    runner.speculative_config = SimpleNamespace(
+        enforce_eager=False,
+        use_eagle=lambda: False,
+        uses_draft_model=lambda: True,
+        uses_extract_hidden_states=lambda: False,
+    )
+    desc = SimpleNamespace(num_tokens=32)
+    runner.cudagraph_dispatcher = SimpleNamespace(
+        get_capture_descs=lambda: [(CUDAGraphMode.PIECEWISE, [desc])],
+        cudagraph_keys={},
+        keys_initialized=True,
+    )
+    runner.max_model_len = 4096
+    runner.max_num_tokens = 256
+    runner.lora_config = None
+    runner._freeze_gc = nullcontext
+    runner._init_minimal_kv_cache_for_profiling = lambda: None
+    runner._create_encoder_cudagraph_manager = lambda: None
+    runner.maybe_remove_all_loras = lambda _: None
+
+    events: list[object] = []
+    active_channel: list[str] = []
+
+    @contextmanager
+    def fake_graph_capture(*, device, channel_id, **kwargs):
+        assert device == runner.device
+        active_channel.append(channel_id)
+        events.append(("enter", channel_id))
+        try:
+            yield SimpleNamespace(channel_id=channel_id)
+        finally:
+            assert active_channel.pop() == channel_id
+            events.append(("exit", channel_id))
+
+    def fake_warmup_and_capture(*args, run_drafter, **kwargs):
+        assert len(active_channel) == 1
+        events.append(("capture", active_channel[0], run_drafter))
+
+    runner._warmup_and_capture = fake_warmup_and_capture
+    runner._cleanup_profiling_kv_cache = lambda: events.extend(
+        ("cleanup-sync", "cleanup")
+    )
+
+    checkpoint = ((lambda _: None, "checkpoint"),)
+
+    def checkpoint_graph_channels():
+        events.append("checkpoint")
+        return checkpoint
+
+    monkeypatch.setattr(
+        gpu_model_runner_module,
+        "checkpoint_b12x_graph_channels",
+        checkpoint_graph_channels,
+    )
+    monkeypatch.setattr(
+        gpu_model_runner_module,
+        "rollback_b12x_graph_channels",
+        lambda value: events.append(("rollback", value)),
+    )
+    monkeypatch.setattr(gpu_model_runner_module, "graph_capture", fake_graph_capture)
+    monkeypatch.setattr(
+        gpu_model_runner_module,
+        "set_current_vllm_config",
+        lambda _: nullcontext(),
+    )
+    monkeypatch.setattr(
+        gpu_model_runner_module,
+        "current_platform",
+        SimpleNamespace(
+            graph_pool_handle=object,
+            is_rocm=lambda: False,
+        ),
+    )
+    monkeypatch.setattr(
+        gpu_model_runner_module,
+        "set_cudagraph_capturing_enabled",
+        lambda enabled: events.append(("capture-enabled", enabled)),
+    )
+    monkeypatch.setattr(
+        gpu_model_runner_module.CUDAGraphWrapper,
+        "_all_instances",
+        [],
+    )
+    monkeypatch.setattr(
+        gpu_model_runner_module.BreakableCUDAGraphWrapper,
+        "_all_instances",
+        [],
+    )
+    monkeypatch.setattr(
+        gpu_model_runner_module.CUDAGraphWrapper,
+        "clear_all_graphs",
+        lambda: events.append("clear-target"),
+    )
+    monkeypatch.setattr(
+        gpu_model_runner_module.BreakableCUDAGraphWrapper,
+        "clear_all_graphs",
+        lambda: events.append("clear-breakable"),
+    )
+    memory_info = iter(((1000, 0), (900, 0), (900, 0), (800, 0)))
+    monkeypatch.setattr(
+        torch.accelerator,
+        "synchronize",
+        lambda: events.append("sync"),
+    )
+    monkeypatch.setattr(torch.accelerator, "empty_cache", lambda: None)
+    monkeypatch.setattr(
+        torch.accelerator,
+        "get_memory_info",
+        lambda: next(memory_info),
+    )
+
+    assert runner.profile_cudagraph_memory() == 200
+    assert ("capture", "vllm:target:profile", False) in events
+    assert ("capture", "vllm:draft:profile", True) in events
+    assert events.index("clear-target") < events.index("cleanup")
+    assert events.index("cleanup-sync") < events.index("cleanup")
+    assert events.index("cleanup") < events.index(("rollback", checkpoint))
+    assert events[-1] == ("rollback", checkpoint)
+
+
+def test_v1_profile_rolls_back_channels_when_capture_fails(monkeypatch):
+    runner = GPUModelRunner.__new__(GPUModelRunner)
+    runner.vllm_config = object()
+    runner.device = torch.device("cpu")
+    runner.speculative_config = None
+    desc = SimpleNamespace(num_tokens=32)
+    runner.cudagraph_dispatcher = SimpleNamespace(
+        get_capture_descs=lambda: [(CUDAGraphMode.FULL, [desc])],
+        cudagraph_keys={},
+        keys_initialized=True,
+    )
+    runner.max_model_len = 4096
+    runner.max_num_tokens = 256
+    runner.lora_config = None
+    runner._freeze_gc = nullcontext
+    runner._init_minimal_kv_cache_for_profiling = lambda: None
+    runner._create_encoder_cudagraph_manager = lambda: None
+    runner.maybe_remove_all_loras = lambda _: None
+
+    events: list[object] = []
+
+    @contextmanager
+    def fake_graph_capture(**kwargs):
+        yield SimpleNamespace(channel_id=kwargs["channel_id"])
+
+    def fail_capture(*args, **kwargs):
+        events.append("capture-failed")
+        raise RuntimeError("expected capture failure")
+
+    runner._warmup_and_capture = fail_capture
+    runner._cleanup_profiling_kv_cache = lambda: events.extend(
+        ("cleanup-sync", "cleanup")
+    )
+    checkpoint = ((lambda _: None, "checkpoint"),)
+
+    monkeypatch.setattr(
+        gpu_model_runner_module,
+        "checkpoint_b12x_graph_channels",
+        lambda: checkpoint,
+    )
+    monkeypatch.setattr(
+        gpu_model_runner_module,
+        "rollback_b12x_graph_channels",
+        lambda value: events.append(("rollback", value)),
+    )
+    monkeypatch.setattr(gpu_model_runner_module, "graph_capture", fake_graph_capture)
+    monkeypatch.setattr(
+        gpu_model_runner_module,
+        "set_current_vllm_config",
+        lambda _: nullcontext(),
+    )
+    monkeypatch.setattr(
+        gpu_model_runner_module,
+        "current_platform",
+        SimpleNamespace(graph_pool_handle=object, is_rocm=lambda: False),
+    )
+    monkeypatch.setattr(
+        gpu_model_runner_module,
+        "set_cudagraph_capturing_enabled",
+        lambda enabled: events.append(("capture-enabled", enabled)),
+    )
+    monkeypatch.setattr(
+        gpu_model_runner_module.CUDAGraphWrapper,
+        "_all_instances",
+        [],
+    )
+    monkeypatch.setattr(
+        gpu_model_runner_module.BreakableCUDAGraphWrapper,
+        "_all_instances",
+        [],
+    )
+    monkeypatch.setattr(
+        gpu_model_runner_module.CUDAGraphWrapper,
+        "clear_all_graphs",
+        lambda: events.append("clear-target"),
+    )
+    monkeypatch.setattr(
+        gpu_model_runner_module.BreakableCUDAGraphWrapper,
+        "clear_all_graphs",
+        lambda: events.append("clear-breakable"),
+    )
+    monkeypatch.setattr(torch.accelerator, "synchronize", lambda: None)
+    monkeypatch.setattr(torch.accelerator, "empty_cache", lambda: None)
+    monkeypatch.setattr(torch.accelerator, "get_memory_info", lambda: (1000, 0))
+
+    with pytest.raises(RuntimeError, match="expected capture failure"):
+        runner.profile_cudagraph_memory()
+
+    assert events.index("clear-target") < events.index("cleanup")
+    assert events.index("cleanup-sync") < events.index("cleanup")
+    assert events.index("cleanup") < events.index(("rollback", checkpoint))
+    assert events[-1] == ("rollback", checkpoint)

--- a/vllm/distributed/device_communicators/cuda_communicator.py
+++ b/vllm/distributed/device_communicators/cuda_communicator.py
@@ -662,11 +662,14 @@ class CudaCommunicator(DeviceCommunicatorBase):
             raise ValueError("No PyNCCL communicator found")
 
     def destroy(self):
+        if self.ca_comm is not None:
+            # SparkInfer close is coordinated across ranks and must run before
+            # its NCCL exchange group is destroyed.
+            self.ca_comm.close()
+            self.ca_comm = None
         if self.pynccl_comm is not None:
             self.pynccl_comm.destroy()
             self.pynccl_comm = None
-        if self.ca_comm is not None:
-            self.ca_comm = None
         if self.aiter_ar_comm is not None:
             self.aiter_ar_comm.close()
             self.aiter_ar_comm = None

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -36,7 +36,6 @@ logger = init_logger(__name__)
 # fails closed if the same logical owner is rebound to a second eager stream.
 _B12X_PCIE_EAGER_CHANNEL_ID = "vllm:eager:allreduce"
 _B12X_PCIE_MAX_CONCURRENT_CHANNELS = 2
-_ABANDONED_B12X_PCIE_ALLREDUCE_QUARANTINE: dict[int, object] = {}
 
 
 def _get_pcie_allreduce_backend() -> str:
@@ -680,6 +679,15 @@ class CustomAllreduce:
         Legacy custom all-reduce registers graph buffers on exit. SparkInfer
         PCIe channels are instead created on the graph's owning stream and
         remain valid for the graph lifetime.
+
+        Args:
+            stream: CUDA stream owned by the enclosing graph capture.
+            channel_id: Stable identity shared by every rank for this graph
+                owner. Required when the SparkInfer PCIe runtime is active.
+
+        Raises:
+            RuntimeError: If the PCIe runtime is active and ``channel_id`` is
+                ``None``.
         """
         old_pcie_capture_stream = self._pcie_capture_stream
         try:
@@ -966,12 +974,12 @@ class CustomAllreduce:
             return self.all_reduce(input, registered=False)
 
     def close(self):
-        if self._pcie_dma is not None:
-            self._pcie_dma.close()
-            self._pcie_dma = None
         if self._pcie_runtime is not None:
             self._pcie_runtime.close()
             self._pcie_runtime = None
+        if self._pcie_dma is not None:
+            self._pcie_dma.close()
+            self._pcie_dma = None
         if not self.disabled and self._ptr:
             if ops is not None:
                 ops.dispose(self._ptr)
@@ -979,18 +987,15 @@ class CustomAllreduce:
             self.free_shared_buffer(self.meta_ptrs, rank=self.rank)
             self.free_shared_buffer(self.buffer_ptrs, rank=self.rank)
 
-    def __del__(
-        self,
-        _quarantine: dict[int, object] = _ABANDONED_B12X_PCIE_ALLREDUCE_QUARANTINE,
-    ) -> None:
+    def __del__(self) -> None:
         # A finalizer cannot collectively close SparkInfer after another rank
-        # has exited or vLLM has destroyed the process group. Keep the complete
-        # owner alive; explicit close() remains the coordinated cleanup path.
+        # has exited or vLLM has destroyed the process group. The backend owns
+        # abnormal resource finalization; explicit close() is coordinated by
+        # CudaCommunicator.destroy() while both process groups are still live.
         if (
             getattr(self, "_pcie_runtime", None) is not None
             or getattr(self, "_pcie_dma", None) is not None
         ):
-            _quarantine[id(self)] = self
             return
         self.close()
 

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -31,6 +31,12 @@ except Exception:
 
 logger = init_logger(__name__)
 
+# The eager scheduler has one stable all-reduce stream owner.  Never derive
+# this identity from a process-local CUDA stream handle; SparkInfer deliberately
+# fails closed if the same logical owner is rebound to a second eager stream.
+_B12X_PCIE_EAGER_CHANNEL_ID = "vllm:eager:allreduce"
+_B12X_PCIE_MAX_CONCURRENT_CHANNELS = 2
+
 
 def _get_pcie_allreduce_backend() -> str:
     backend = envs.VLLM_PCIE_ALLREDUCE_BACKEND.lower()
@@ -488,8 +494,15 @@ class CustomAllreduce:
                     eager_buffer_bytes=pcie_oneshot_buffer_size,
                     max_size=pcie_oneshot_buffer_size,
                     single_channel=pcie_single_channel,
+                    max_concurrent_channels=_B12X_PCIE_MAX_CONCURRENT_CHANNELS,
                 )
-                pcie_runtime.for_stream()
+                if not pcie_single_channel:
+                    pcie_runtime.prepare_channels((_B12X_PCIE_EAGER_CHANNEL_ID,))
+                pcie_runtime.for_stream(
+                    channel_id=(
+                        None if pcie_single_channel else _B12X_PCIE_EAGER_CHANNEL_ID
+                    )
+                )
             except Exception as exc:
                 pcie_init_error = exc
 
@@ -740,7 +753,8 @@ class CustomAllreduce:
     def register_graph_buffers(self):
         if self._pcie_runtime is not None:
             self._pcie_runtime.for_stream(
-                self._pcie_runtime_stream()
+                self._pcie_runtime_stream(),
+                channel_id=_B12X_PCIE_EAGER_CHANNEL_ID,
             ).register_graph_buffers()
             return
         handle, offset = ops.get_graph_buffer_ipc_meta(self._ptr)
@@ -770,7 +784,8 @@ class CustomAllreduce:
                 self._pcie_allreduce_max_size is not None
                 and inp_size <= self._pcie_allreduce_max_size
                 and self._pcie_runtime.for_stream(
-                    self._pcie_runtime_stream()
+                    self._pcie_runtime_stream(),
+                    channel_id=_B12X_PCIE_EAGER_CHANNEL_ID,
                 ).should_allreduce(inp)
             )
             if (
@@ -849,7 +864,10 @@ class CustomAllreduce:
                     self._pcie_runtime_stream() is not None,
                 )
             return self._pcie_runtime.all_reduce(
-                inp, out=out, stream=self._pcie_runtime_stream()
+                inp,
+                out=out,
+                stream=self._pcie_runtime_stream(),
+                channel_id=_B12X_PCIE_EAGER_CHANNEL_ID,
             )
         if out is None:
             out = torch.empty_like(inp)
@@ -891,7 +909,8 @@ class CustomAllreduce:
             return False
         assert self._pcie_runtime is not None
         if not self._pcie_runtime.for_stream(
-            self._pcie_runtime_stream()
+            self._pcie_runtime_stream(),
+            channel_id=_B12X_PCIE_EAGER_CHANNEL_ID,
         ).should_allreduce(inp):
             return False
         if (
@@ -918,6 +937,7 @@ class CustomAllreduce:
             out=inp,
             residual_out=residual,
             stream=self._pcie_runtime_stream(),
+            channel_id=_B12X_PCIE_EAGER_CHANNEL_ID,
         )
         return True
 

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -36,6 +36,7 @@ logger = init_logger(__name__)
 # fails closed if the same logical owner is rebound to a second eager stream.
 _B12X_PCIE_EAGER_CHANNEL_ID = "vllm:eager:allreduce"
 _B12X_PCIE_MAX_CONCURRENT_CHANNELS = 2
+_ABANDONED_B12X_PCIE_ALLREDUCE_QUARANTINE: dict[int, object] = {}
 
 
 def _get_pcie_allreduce_backend() -> str:
@@ -978,7 +979,19 @@ class CustomAllreduce:
             self.free_shared_buffer(self.meta_ptrs, rank=self.rank)
             self.free_shared_buffer(self.buffer_ptrs, rank=self.rank)
 
-    def __del__(self):
+    def __del__(
+        self,
+        _quarantine: dict[int, object] = _ABANDONED_B12X_PCIE_ALLREDUCE_QUARANTINE,
+    ) -> None:
+        # A finalizer cannot collectively close SparkInfer after another rank
+        # has exited or vLLM has destroyed the process group. Keep the complete
+        # owner alive; explicit close() remains the coordinated cleanup path.
+        if (
+            getattr(self, "_pcie_runtime", None) is not None
+            or getattr(self, "_pcie_dma", None) is not None
+        ):
+            _quarantine[id(self)] = self
+            return
         self.close()
 
     @staticmethod

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -655,7 +655,12 @@ class CustomAllreduce:
         ops.register_buffer(self._ptr, self.buffer_ptrs)
 
     @contextmanager
-    def capture(self, stream: torch.cuda.Stream | None = None):
+    def capture(
+        self,
+        stream: torch.cuda.Stream | None = None,
+        *,
+        channel_id: str | None = None,
+    ):
         """Bind communicator resources to the enclosing CUDA graph capture.
 
         Legacy custom all-reduce registers graph buffers on exit. SparkInfer
@@ -668,8 +673,16 @@ class CustomAllreduce:
             if self._pcie_runtime is None:
                 yield
             else:
+                if channel_id is None:
+                    raise RuntimeError(
+                        "distributed PCIe graph capture requires an explicit "
+                        "semantic channel_id"
+                    )
                 self._pcie_capture_stream = stream
-                with self._pcie_runtime.capture(stream=stream):
+                with self._pcie_runtime.capture(
+                    stream=stream,
+                    channel_id=channel_id,
+                ):
                     yield
         finally:
             self._pcie_capture_stream = old_pcie_capture_stream

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -1265,14 +1265,14 @@ class GroupCoordinator:
         return self.device_communicator.recv(size, dtype, src)
 
     def destroy(self):
+        if self.device_communicator is not None:
+            self.device_communicator.destroy()
         if hasattr(self, "device_group"):
             torch.distributed.destroy_process_group(self.device_group)
             del self.device_group
         if hasattr(self, "cpu_group"):
             torch.distributed.destroy_process_group(self.cpu_group)
             del self.cpu_group
-        if self.device_communicator is not None:
-            self.device_communicator.destroy()
         if self.mq_broadcaster is not None:
             self.mq_broadcaster = None
 
@@ -1664,6 +1664,15 @@ def graph_capture(
 
     A caller may pass an explicit ``graph_capture_context`` to control the
     stream used (e.g. to capture on the default stream).
+
+    Args:
+        device: Device that owns a newly created capture stream.
+        graph_capture_context: Existing capture context to reuse.
+        channel_id: Stable distributed identity for this graph owner.
+
+    Raises:
+        ValueError: If ``channel_id`` conflicts with the identity stored on
+            ``graph_capture_context``.
     """
     if graph_capture_context is None:
         context = GraphCaptureContext(

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -65,6 +65,7 @@ if TYPE_CHECKING:
 @dataclass
 class GraphCaptureContext:
     stream: torch.cuda.Stream
+    channel_id: str | None = None
 
 
 TensorMetadata = namedtuple("TensorMetadata", ["device", "dtype", "size"])
@@ -620,7 +621,10 @@ class GroupCoordinator:
             )
             ca_comm = self.device_communicator.ca_comm
             if ca_comm is not None:
-                maybe_ca_context = ca_comm.capture(stream=stream)  # type: ignore
+                maybe_ca_context = ca_comm.capture(  # type: ignore
+                    stream=stream,
+                    channel_id=graph_capture_context.channel_id,
+                )
 
             from vllm._aiter_ops import rocm_aiter_ops
 
@@ -1643,14 +1647,15 @@ def get_pcp_group() -> GroupCoordinator:
 def graph_capture(
     device: torch.device,
     graph_capture_context: GraphCaptureContext | None = None,
+    channel_id: str | None = None,
 ):
     """
     `graph_capture` is a context manager which should surround the code that
     is capturing the CUDA graph. Its main purpose is to ensure that some
     operations will be run after the graph is captured, before the graph
     is replayed. It returns a `GraphCaptureContext` object which contains the
-    necessary data for the graph capture. Currently, it only contains the
-    stream that the graph capture is running on. This stream is set to the
+    necessary data for the graph capture: its stream and an optional semantic
+    channel identity for distributed capture resources. The stream is set to the
     current CUDA stream when the context manager is entered and reset to the
     default stream when the context manager is exited. This is to ensure that
     the graph capture is running on a separate stream from the default stream,
@@ -1660,21 +1665,37 @@ def graph_capture(
     A caller may pass an explicit ``graph_capture_context`` to control the
     stream used (e.g. to capture on the default stream).
     """
-    context = graph_capture_context or GraphCaptureContext(
-        torch.cuda.Stream(device=device)
-    )
+    if graph_capture_context is None:
+        context = GraphCaptureContext(
+            torch.cuda.Stream(device=device),
+            channel_id=channel_id,
+        )
+    else:
+        context = graph_capture_context
+        if channel_id is not None:
+            if context.channel_id is not None and context.channel_id != channel_id:
+                raise ValueError(
+                    "graph capture channel_id conflicts with GraphCaptureContext"
+                )
+            if context.channel_id is None:
+                context = GraphCaptureContext(context.stream, channel_id=channel_id)
     maybe_dcp_capture = (
         get_dcp_group().graph_capture(context)
         if _DCP is not None and get_dcp_group().world_size > 1
         else nullcontext()
     )
+    maybe_b12x_dcp_capture: contextlib.AbstractContextManager[Any]
     if _DCP is not None and get_dcp_group().world_size > 1:
         # Import locally to avoid making distributed initialization depend on
         # attention modules. The helper is a no-op until DCP warmup creates a
         # SparkInfer pool for this process group.
         from vllm.v1.attention.ops.dcp_alltoall import capture_b12x_dcp_a2a
 
-        maybe_b12x_dcp_capture = capture_b12x_dcp_a2a(get_dcp_group(), context.stream)
+        maybe_b12x_dcp_capture = capture_b12x_dcp_a2a(
+            get_dcp_group(),
+            context.stream,
+            channel_id=context.channel_id,
+        )
     else:
         maybe_b12x_dcp_capture = nullcontext()
     with (

--- a/vllm/v1/attention/ops/dcp_alltoall.py
+++ b/vllm/v1/attention/ops/dcp_alltoall.py
@@ -41,6 +41,10 @@ logger = init_logger(__name__)
 
 _B12X_DCP_A2A_POOLS: dict[tuple[int, int, int, int, int, int], Any] = {}
 _B12X_DCP_A2A_DISABLED: set[tuple[int, int, int, int, int, int]] = set()
+# DCP likewise has one stable eager scheduler owner.  Graph target/draft/encoder
+# identities are supplied separately by their GraphCaptureContext.
+_B12X_DCP_EAGER_CHANNEL_ID = "vllm:eager:dcp"
+_B12X_DCP_MAX_CONCURRENT_CHANNELS = 2
 _DCP_A2A_GRAPH_BUFFERS: dict[
     tuple[tuple[int, ...], torch.device, torch.dtype],
     tuple[torch.Tensor, torch.Tensor],
@@ -128,8 +132,10 @@ def _get_b12x_dcp_a2a_pool(
             head_dim=head_dim,
             query_head_dim=query_head_dim,
             single_channel=False,
+            max_concurrent_channels=_B12X_DCP_MAX_CONCURRENT_CHANNELS,
         )
-        pool.for_stream()
+        pool.prepare_channels((_B12X_DCP_EAGER_CHANNEL_ID,))
+        pool.for_stream(channel_id=_B12X_DCP_EAGER_CHANNEL_ID)
     except Exception as exc:
         init_error = exc
 
@@ -319,6 +325,7 @@ def _try_b12x_dcp_lse_reduce(
         cp_attn_lse,
         out=reduced,
         is_lse_base_on_e=is_lse_base_on_e,
+        channel_id=_B12X_DCP_EAGER_CHANNEL_ID,
     )
 
 
@@ -369,7 +376,10 @@ def _try_b12x_dcp_all_gather_heads(
     )
     if pool is None:
         return None
-    return pool.all_gather_heads(local_input)
+    return pool.all_gather_heads(
+        local_input,
+        channel_id=_B12X_DCP_EAGER_CHANNEL_ID,
+    )
 
 
 def dcp_b12x_all_gather_heads(

--- a/vllm/v1/attention/ops/dcp_alltoall.py
+++ b/vllm/v1/attention/ops/dcp_alltoall.py
@@ -53,9 +53,7 @@ def _is_supported_bhd_layout(tensor: torch.Tensor) -> bool:
         return False
     batch, heads, head_dim = (int(value) for value in tensor.shape)
     stride_batch, stride_head, _ = (int(value) for value in tensor.stride())
-    packed_token_major = (
-        stride_batch == heads * head_dim and stride_head == head_dim
-    )
+    packed_token_major = stride_batch == heads * head_dim and stride_head == head_dim
     capacity_strided_head_major = (
         stride_batch == head_dim and stride_head >= batch * head_dim
     )
@@ -171,6 +169,8 @@ def _get_b12x_dcp_a2a_pool(
 def capture_b12x_dcp_a2a(
     cp_group: GroupCoordinator,
     stream: torch.cuda.Stream | None = None,
+    *,
+    channel_id: str | None = None,
 ):
     """Bind registered SparkInfer DCP pools to the graph's owning stream.
 
@@ -180,6 +180,7 @@ def capture_b12x_dcp_a2a(
     Args:
         cp_group: DCP group whose registered pools should enter capture.
         stream: CUDA stream owned by the enclosing graph capture.
+        channel_id: Stable identity shared by every rank for this graph owner.
     """
     group_id = id(cp_group.device_group)
     matching_pools = sorted(
@@ -190,9 +191,14 @@ def capture_b12x_dcp_a2a(
         ),
         key=lambda item: item[0][1:],
     )
+    if matching_pools and channel_id is None:
+        raise RuntimeError(
+            "distributed PCIe DCP graph capture requires an explicit semantic "
+            "channel_id"
+        )
     with ExitStack() as stack:
         for _, pool in matching_pools:
-            stack.enter_context(pool.capture(stream=stream))
+            stack.enter_context(pool.capture(stream=stream, channel_id=channel_id))
         yield
 
 

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -446,6 +446,8 @@ class CudaGraphManager:
     def capture(
         self,
         create_forward_fn: CreateForwardFn,
+        *,
+        channel_id: str,
         progress_bar_desc: str = "Capturing CUDA graphs",
     ) -> None:
         """Capture CUDA graphs.
@@ -456,12 +458,16 @@ class CudaGraphManager:
                 it is invoked once with warmup=True and again with warmup=False
                 because attention backends may mutate or lazily initialize
                 metadata during warmup.
+            channel_id: Stable distributed identity for this graph owner.
         """
         # Keep event handles created by descriptor warmups alive together with
         # the graph artifacts captured below. Some multi-stream custom ops run
         # on joined auxiliary streams where CUDA's per-current-stream capture
         # query is false even though later graph nodes retain those handles.
-        with graph_capture(device=self.device), vllm_cudagraph_capture_scope():
+        with (
+            graph_capture(device=self.device, channel_id=channel_id),
+            vllm_cudagraph_capture_scope(),
+        ):
             # Capture in order: PIECEWISE first, then FULL. PIECEWISE has larger
             # activations so FULL activations should fit in already allocated
             # buffers in the graph pool.
@@ -638,6 +644,8 @@ class ModelCudaGraphManager(CudaGraphManager):
         has_lora: bool = False,
         use_aux_hidden_state_outputs: bool = False,
         lora_capture_hook: Callable[[int, int, int], None] | None = None,
+        *,
+        channel_id: str,
         progress_bar_desc: str = "Capturing CUDA graphs",
     ) -> None:
         """Capture CUDA graphs for model forward pass."""
@@ -752,7 +760,11 @@ class ModelCudaGraphManager(CudaGraphManager):
 
             return forward_fn
 
-        super().capture(create_forward_fn, progress_bar_desc)
+        super().capture(
+            create_forward_fn,
+            channel_id=channel_id,
+            progress_bar_desc=progress_bar_desc,
+        )
 
     def clear(self) -> None:
         super().clear()

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -967,11 +967,12 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                     has_lora=self.lora_config is not None,
                     use_aux_hidden_state_outputs=self.use_aux_hidden_state_outputs,
                     lora_capture_hook=create_lora_capture_hook(self.lora_config, self),
+                    channel_id="vllm:target:profile",
                     progress_bar_desc="Profiling CUDA graph memory",
                 )
                 if self.speculator is not None:
                     with use_workspace_lane(1):
-                        self.speculator.capture()
+                        self.speculator.capture(capture_phase="profile")
                 self._zero_cudagraph_capture_kv_blocks()
             end_free_gpu_memory = torch.accelerator.get_memory_info()[0]
             gross_cuda_graph_size = max(start_free_gpu_memory - end_free_gpu_memory, 0)
@@ -1050,10 +1051,11 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                     has_lora=self.lora_config is not None,
                     use_aux_hidden_state_outputs=self.use_aux_hidden_state_outputs,
                     lora_capture_hook=create_lora_capture_hook(self.lora_config, self),
+                    channel_id="vllm:target:production",
                 )
                 if self.speculator is not None:
                     with use_workspace_lane(1):
-                        self.speculator.capture()
+                        self.speculator.capture(capture_phase="production")
                 self._zero_cudagraph_capture_kv_blocks()
         finally:
             self._release_cudagraph_pool_anchor()

--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/cudagraph_utils.py
@@ -35,6 +35,8 @@ class SpeculatorCudaGraphManager(CudaGraphManager):
         block_tables: BlockTables,
         attn_groups: list[list[AttentionGroup]],
         kv_cache_config: KVCacheConfig,
+        *,
+        channel_id: str,
         progress_bar_desc: str = "Capturing CUDA graphs",
     ) -> None:
         def create_forward_fn(
@@ -71,4 +73,8 @@ class SpeculatorCudaGraphManager(CudaGraphManager):
                 cg_mode,
             )
 
-        super().capture(create_forward_fn, progress_bar_desc)
+        super().capture(
+            create_forward_fn,
+            channel_id=channel_id,
+            progress_bar_desc=progress_bar_desc,
+        )

--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
@@ -21,7 +21,10 @@ from vllm.v1.worker.gpu.input_batch import InputBatch, InputBuffers
 from vllm.v1.worker.gpu.spec_decode.autoregressive.cudagraph_utils import (
     SpeculatorCudaGraphManager,
 )
-from vllm.v1.worker.gpu.spec_decode.speculator import DraftModelSpeculator
+from vllm.v1.worker.gpu.spec_decode.speculator import (
+    CUDAGraphCapturePhase,
+    DraftModelSpeculator,
+)
 
 logger = init_logger(__name__)
 
@@ -87,7 +90,7 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
             decode_query_len=1,
         )
 
-    def capture(self) -> None:
+    def capture(self, *, capture_phase: CUDAGraphCapturePhase) -> None:
         logger.info("Capturing model for speculator...")
         # Reset indices to zeros to prevent stale values from prior
         # dummy runs to cause out-of-bounds indexing during capture.
@@ -111,6 +114,7 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
             self.block_tables,
             self.target_attn_groups,
             self.kv_cache_config,
+            channel_id=f"vllm:draft:prefill:{capture_phase}",
             progress_bar_desc="Capturing prefill CUDA graphs",
         )
 
@@ -128,6 +132,7 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
             self.block_tables,
             self.attn_groups,
             self.kv_cache_config,
+            channel_id=f"vllm:draft:decode:{capture_phase}",
             progress_bar_desc="Capturing decode CUDA graphs",
         )
 

--- a/vllm/v1/worker/gpu/spec_decode/dflash/cudagraph.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/cudagraph.py
@@ -72,6 +72,8 @@ class DFlashCudaGraphManager(CudaGraphManager):
         kv_cache_config: KVCacheConfig,
         max_model_len: int,
         causal: bool | Mapping[int, bool],
+        *,
+        channel_id: str,
         progress_bar_desc: str = "Capturing CUDA graphs",
     ) -> None:
         def create_forward_fn(
@@ -108,4 +110,8 @@ class DFlashCudaGraphManager(CudaGraphManager):
                 num_query_per_req=desc.uniform_token_count,
             )
 
-        super().capture(create_forward_fn, progress_bar_desc)
+        super().capture(
+            create_forward_fn,
+            channel_id=channel_id,
+            progress_bar_desc=progress_bar_desc,
+        )

--- a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
@@ -35,7 +35,10 @@ from vllm.v1.worker.gpu.spec_decode.dflash.utils import (
     load_dflash_model,
     maybe_load_mask_embedding,
 )
-from vllm.v1.worker.gpu.spec_decode.speculator import DraftModelSpeculator
+from vllm.v1.worker.gpu.spec_decode.speculator import (
+    CUDAGraphCapturePhase,
+    DraftModelSpeculator,
+)
 from vllm.v1.worker.gpu.spec_decode.utils import get_parallel_drafting_token_id
 from vllm.v1.worker.utils import AttentionGroup
 
@@ -184,7 +187,7 @@ class DFlashSpeculator(DraftModelSpeculator):
             decode_query_len=self.num_query_per_req,
         )
 
-    def capture(self) -> None:
+    def capture(self, *, capture_phase: CUDAGraphCapturePhase) -> None:
         logger.info("Capturing model for %s speculator...", self._speculator_name)
         # Reset sampling indices to prevent stale values from prior dummy runs
         # from being baked into the captured graph. Mapping rows stay inert.
@@ -200,6 +203,7 @@ class DFlashSpeculator(DraftModelSpeculator):
             self.kv_cache_config,
             self.max_model_len,
             causal=self._group_causal,
+            channel_id=f"vllm:draft:dflash:{capture_phase}",
             progress_bar_desc=f"Capturing {self._speculator_name.lower()} CUDA graphs",
         )
 

--- a/vllm/v1/worker/gpu/spec_decode/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/speculator.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 import torch
 import torch.nn as nn
@@ -32,6 +32,8 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
+CUDAGraphCapturePhase = Literal["profile", "production"]
+
 
 class BaseSpeculator(ABC):
     # Draft-token capacity surface, implemented by speculators with a
@@ -51,7 +53,7 @@ class BaseSpeculator(ABC):
         pass
 
     @abstractmethod
-    def capture(self) -> None:
+    def capture(self, *, capture_phase: CUDAGraphCapturePhase) -> None:
         pass
 
     def get_cudagraph_managers(self) -> tuple["CudaGraphManager", ...]:

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4645,11 +4645,7 @@ class GPUModelRunner(
             )
             # Whether the drafter runs a GPU model forward (and thus carries
             # TP/EP/DP collectives), independent of padded-batch timing.
-            drafter_runs_model_forward = (
-                spec_config.use_eagle()
-                or spec_config.uses_draft_model()
-                or spec_config.uses_extract_hidden_states()
-            )
+            drafter_runs_model_forward = self._drafter_runs_model_forward()
             use_gpu_toks = (
                 drafter_runs_model_forward
                 and not spec_config.disable_padded_drafter_batch
@@ -6181,15 +6177,7 @@ class GPUModelRunner(
             else:
                 hidden_states = outputs
 
-            if (
-                run_drafter
-                and self.speculative_config
-                and (
-                    self.speculative_config.use_eagle()
-                    or self.speculative_config.uses_draft_model()
-                    or self.speculative_config.uses_extract_hidden_states()
-                )
-            ):
+            if run_drafter and self._drafter_runs_model_forward():
                 assert isinstance(
                     self.drafter,
                     EagleProposer
@@ -6741,8 +6729,11 @@ class GPUModelRunner(
                     component_descs = [
                         (mode, descs)
                         for mode, descs in capture_descs
-                        if component == "target"
-                        or self._captures_independent_drafter_graphs(mode)
+                        if descs
+                        and (
+                            component == "target"
+                            or self._captures_independent_drafter_graphs(mode)
+                        )
                     ]
                     if not component_descs:
                         continue
@@ -6806,7 +6797,7 @@ class GPUModelRunner(
 
                             logger.debug(
                                 "Estimated %s %s CUDA graph memory: "
-                                "%.2f MiB first-capture + (%d-1) × %.2f MiB "
+                                "%.2f MiB first-capture + (%d-1) x %.2f MiB "
                                 "per-graph",
                                 component,
                                 mode.name,
@@ -6842,16 +6833,14 @@ class GPUModelRunner(
                     )
         finally:
             try:
-                set_cudagraph_capturing_enabled(False)
-                CUDAGraphWrapper.clear_all_graphs()
-                BreakableCUDAGraphWrapper.clear_all_graphs()
-                if encoder_cudagraph_manager is not None:
-                    encoder_cudagraph_manager.clear()
-                all_wrappers = list(CUDAGraphWrapper._all_instances) + list(
-                    BreakableCUDAGraphWrapper._all_instances
-                )
-                for instance in all_wrappers:
-                    if id(instance) in original_pools:
+                try:
+                    set_cudagraph_capturing_enabled(False)
+                    CUDAGraphWrapper.clear_all_graphs()
+                    BreakableCUDAGraphWrapper.clear_all_graphs()
+                    if encoder_cudagraph_manager is not None:
+                        encoder_cudagraph_manager.clear()
+                finally:
+                    for instance in all_wrappers:
                         instance.graph_pool = original_pools[id(instance)]
                 for key_set in self.cudagraph_dispatcher.cudagraph_keys.values():
                     key_set.clear()
@@ -6914,8 +6903,11 @@ class GPUModelRunner(
                     component_descs = [
                         (mode, descs)
                         for mode, descs in capture_descs
-                        if component == "target"
-                        or self._captures_independent_drafter_graphs(mode)
+                        if descs
+                        and (
+                            component == "target"
+                            or self._captures_independent_drafter_graphs(mode)
+                        )
                     ]
                     if not component_descs:
                         continue
@@ -6971,16 +6963,29 @@ class GPUModelRunner(
         self,
         cudagraph_runtime_mode: CUDAGraphMode,
     ) -> bool:
+        """Return whether PIECEWISE capture needs a separate drafter pass.
+
+        Args:
+            cudagraph_runtime_mode: CUDA graph mode being captured.
+
+        Returns:
+            Whether the mode owns independently replayable drafter graphs.
+        """
         spec_config = self.speculative_config
         return (
             cudagraph_runtime_mode == CUDAGraphMode.PIECEWISE
             and spec_config is not None
             and not spec_config.enforce_eager
-            and (
-                spec_config.use_eagle()
-                or spec_config.uses_draft_model()
-                or spec_config.uses_extract_hidden_states()
-            )
+            and self._drafter_runs_model_forward()
+        )
+
+    def _drafter_runs_model_forward(self) -> bool:
+        """Return whether the configured drafter executes a model forward."""
+        spec_config = self.speculative_config
+        return spec_config is not None and (
+            spec_config.use_eagle()
+            or spec_config.uses_draft_model()
+            or spec_config.uses_extract_hidden_states()
         )
 
     def _warmup_and_capture(

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -44,12 +44,14 @@ from vllm.distributed.kv_transfer import get_kv_transfer_group, has_kv_transfer_
 from vllm.distributed.kv_transfer.kv_connector.utils import copy_kv_blocks
 from vllm.distributed.parallel_state import (
     GraphCaptureContext,
+    checkpoint_b12x_graph_channels,
     get_dcp_group,
     get_pp_group,
     get_tp_group,
     graph_capture,
     is_global_first_rank,
     prepare_communication_buffer_for_model,
+    rollback_b12x_graph_channels,
 )
 from vllm.forward_context import (
     BatchDescriptor,
@@ -5845,6 +5847,7 @@ class GPUModelRunner(
         profile_seq_lens: int | None = None,
         include_mm_inputs: bool = True,
         single_request_prefill: bool = False,
+        run_drafter: bool = True,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """
         Run a dummy forward pass to warm up/profile run or capture the
@@ -5878,6 +5881,7 @@ class GPUModelRunner(
             single_request_prefill: If True, create one prefill request with
                 `num_tokens` tokens. This covers text-only single-request
                 prefill kernels without keying warmup on a live prompt length.
+            run_drafter: Whether to execute the draft-model portion of the run.
         """
         mm_config = self.vllm_config.model_config.multimodal_config
         if mm_config and mm_config.mm_encoder_only:
@@ -6177,10 +6181,14 @@ class GPUModelRunner(
             else:
                 hidden_states = outputs
 
-            if self.speculative_config and (
-                self.speculative_config.use_eagle()
-                or self.speculative_config.uses_draft_model()
-                or self.speculative_config.uses_extract_hidden_states()
+            if (
+                run_drafter
+                and self.speculative_config
+                and (
+                    self.speculative_config.use_eagle()
+                    or self.speculative_config.uses_draft_model()
+                    or self.speculative_config.uses_extract_hidden_states()
+                )
             ):
                 assert isinstance(
                     self.drafter,
@@ -6672,7 +6680,7 @@ class GPUModelRunner(
 
         saved_num_cudagraph_captured = compilation_counter.num_cudagraph_captured
 
-        capture_descs = self.cudagraph_dispatcher.get_capture_descs()
+        capture_descs = list(self.cudagraph_dispatcher.get_capture_descs())
         # Use a temporary manager for memory profiling. The persistent manager
         # is initialized later so it does not keep profiling-only graph state.
         encoder_cudagraph_manager = self._create_encoder_cudagraph_manager()
@@ -6715,81 +6723,114 @@ class GPUModelRunner(
             original_pools[id(instance)] = instance.graph_pool
             instance.graph_pool = profiling_pool
 
-        shared_memory_estimate = {}
-        per_graph_estimate = {}
+        shared_memory_estimate: dict[CUDAGraphMode, int] = {}
+        per_graph_estimate: dict[CUDAGraphMode, int] = {}
         encoder_memory_estimate = 0
-
-        # On ROCm, capture these throwaway profiling graphs on vLLM's dedicated
-        # compute stream instead of the fresh side stream graph_capture()
-        # allocates by default. torch's allocator pools free blocks per stream,
-        # so a side-stream forward strands a persistent aiter scratch buffer in
-        # a separate pool, shifting the physical placement of the real KV cache
-        # allocated afterward and slowing bandwidth-bound decode ~20%. The
-        # graphs are discarded, so a side stream is unnecessary here.
-        # Use current_stream(), not torch.cuda.current_stream(): before vLLM
-        # initializes its dedicated stream, torch returns the per-thread default
-        # stream (cuda_stream=0), which cannot be used for cudagraph capture.
-        # cap_ctx=None keeps the side-stream path on CUDA.
-        cap_ctx = (
-            GraphCaptureContext(current_stream())
-            if current_platform.is_rocm()
-            else None
-        )
 
         # Cleanup-only guard: CUDA graph capture errors should still propagate
         # because encoder graph capture is opt-in.
+        graph_channel_checkpoints: tuple[tuple[Callable[[Any], None], Any], ...] = ()
         try:
+            graph_channel_checkpoints = checkpoint_b12x_graph_channels()
             set_cudagraph_capturing_enabled(True)
-            with (
-                self._freeze_gc(),
-                graph_capture(device=self.device, graph_capture_context=cap_ctx),
-            ):
-                torch.accelerator.synchronize()
-                torch.accelerator.empty_cache()
+            with self._freeze_gc():
+                for component, channel_id in (
+                    ("target", "vllm:target:profile"),
+                    ("draft", "vllm:draft:profile"),
+                ):
+                    component_descs = [
+                        (mode, descs)
+                        for mode, descs in capture_descs
+                        if component == "target"
+                        or self._captures_independent_drafter_graphs(mode)
+                    ]
+                    if not component_descs:
+                        continue
 
-                for mode, descs in capture_descs:
-                    profile_descs = descs[:2]
-                    mem_samples: list[int] = []
-
-                    for i, desc in enumerate(profile_descs):
-                        mem_before = torch.accelerator.get_memory_info()[0]
-                        self._warmup_and_capture(
-                            desc,
-                            cudagraph_runtime_mode=mode,
-                            profile_seq_lens=(
-                                min(
-                                    self.max_model_len,
-                                    self.max_num_tokens // desc.num_tokens,
-                                )
-                                if mode == CUDAGraphMode.FULL and i == 0
-                                else None
-                            ),
-                        )
+                    # ROCm profiles on vLLM's dedicated compute stream to avoid
+                    # stranding allocator pages in a disposable side stream.
+                    cap_ctx = (
+                        GraphCaptureContext(current_stream(), channel_id=channel_id)
+                        if current_platform.is_rocm()
+                        else None
+                    )
+                    with graph_capture(
+                        device=self.device,
+                        graph_capture_context=cap_ctx,
+                        channel_id=channel_id,
+                    ):
                         torch.accelerator.synchronize()
-                        free_after = torch.accelerator.get_memory_info()[0]
-                        mem_samples.append(mem_before - free_after)
+                        torch.accelerator.empty_cache()
 
-                    first_capture = mem_samples[0]
-                    # Use at least 1 MiB per graph for driver overhead
-                    per_graph = max(
-                        mem_samples[1] if len(mem_samples) > 1 else 0, 1 << 20
-                    )
+                        for mode, descs in component_descs:
+                            profile_descs = descs[:2]
+                            mem_samples: list[int] = []
+                            captures_drafter = (
+                                self._captures_independent_drafter_graphs(mode)
+                            )
 
-                    shared_memory_estimate[mode] = first_capture
-                    per_graph_estimate[mode] = per_graph * (len(descs) - 1)
+                            for i, desc in enumerate(profile_descs):
+                                mem_before = torch.accelerator.get_memory_info()[0]
+                                self._warmup_and_capture(
+                                    desc,
+                                    cudagraph_runtime_mode=mode,
+                                    profile_seq_lens=(
+                                        min(
+                                            self.max_model_len,
+                                            self.max_num_tokens // desc.num_tokens,
+                                        )
+                                        if mode == CUDAGraphMode.FULL and i == 0
+                                        else None
+                                    ),
+                                    run_drafter=(
+                                        component == "draft" or not captures_drafter
+                                    ),
+                                )
+                                torch.accelerator.synchronize()
+                                free_after = torch.accelerator.get_memory_info()[0]
+                                mem_samples.append(max(mem_before - free_after, 0))
 
-                    logger.debug(
-                        "Estimated %s CUDA graph memory: "
-                        "%.2f MiB first-capture + (%d-1) × %.2f MiB per-graph",
-                        mode.name,
-                        first_capture / (1 << 20),
-                        len(descs),
-                        per_graph / (1 << 20),
-                    )
+                            first_capture = mem_samples[0]
+                            # Use at least 1 MiB per graph for driver overhead.
+                            per_graph = max(
+                                mem_samples[1] if len(mem_samples) > 1 else 0,
+                                1 << 20,
+                            )
+
+                            shared_memory_estimate[mode] = (
+                                shared_memory_estimate.get(mode, 0) + first_capture
+                            )
+                            per_graph_estimate[mode] = per_graph_estimate.get(
+                                mode, 0
+                            ) + per_graph * (len(descs) - 1)
+
+                            logger.debug(
+                                "Estimated %s %s CUDA graph memory: "
+                                "%.2f MiB first-capture + (%d-1) × %.2f MiB "
+                                "per-graph",
+                                component,
+                                mode.name,
+                                first_capture / (1 << 20),
+                                len(descs),
+                                per_graph / (1 << 20),
+                            )
 
                 if encoder_cudagraph_manager is not None:
+                    channel_id = "vllm:encoder:profile"
+                    cap_ctx = (
+                        GraphCaptureContext(current_stream(), channel_id=channel_id)
+                        if current_platform.is_rocm()
+                        else None
+                    )
                     mem_before = torch.accelerator.get_memory_info()[0]
-                    encoder_cudagraph_manager.capture(graph_pool=encoder_profiling_pool)
+                    with graph_capture(
+                        device=self.device,
+                        graph_capture_context=cap_ctx,
+                        channel_id=channel_id,
+                    ):
+                        encoder_cudagraph_manager.capture(
+                            graph_pool=encoder_profiling_pool
+                        )
                     torch.accelerator.synchronize()
                     free_after = torch.accelerator.get_memory_info()[0]
                     encoder_memory_estimate = max(mem_before - free_after, 0)
@@ -6800,23 +6841,28 @@ class GPUModelRunner(
                         encoder_graphs,
                     )
         finally:
-            set_cudagraph_capturing_enabled(False)
-            CUDAGraphWrapper.clear_all_graphs()
-            BreakableCUDAGraphWrapper.clear_all_graphs()
-            if encoder_cudagraph_manager is not None:
-                encoder_cudagraph_manager.clear()
-            all_wrappers = list(CUDAGraphWrapper._all_instances) + list(
-                BreakableCUDAGraphWrapper._all_instances
-            )
-            for instance in all_wrappers:
-                if id(instance) in original_pools:
-                    instance.graph_pool = original_pools[id(instance)]
-            for key_set in self.cudagraph_dispatcher.cudagraph_keys.values():
-                key_set.clear()
-            self.cudagraph_dispatcher.keys_initialized = False
-            self.maybe_remove_all_loras(self.lora_config)
-            self._cleanup_profiling_kv_cache()
-            compilation_counter.num_cudagraph_captured = saved_num_cudagraph_captured
+            try:
+                set_cudagraph_capturing_enabled(False)
+                CUDAGraphWrapper.clear_all_graphs()
+                BreakableCUDAGraphWrapper.clear_all_graphs()
+                if encoder_cudagraph_manager is not None:
+                    encoder_cudagraph_manager.clear()
+                all_wrappers = list(CUDAGraphWrapper._all_instances) + list(
+                    BreakableCUDAGraphWrapper._all_instances
+                )
+                for instance in all_wrappers:
+                    if id(instance) in original_pools:
+                        instance.graph_pool = original_pools[id(instance)]
+                for key_set in self.cudagraph_dispatcher.cudagraph_keys.values():
+                    key_set.clear()
+                self.cudagraph_dispatcher.keys_initialized = False
+                self.maybe_remove_all_loras(self.lora_config)
+                self._cleanup_profiling_kv_cache()
+                compilation_counter.num_cudagraph_captured = (
+                    saved_num_cudagraph_captured
+                )
+            finally:
+                rollback_b12x_graph_channels(graph_channel_checkpoints)
 
         # FULL and PIECEWISE graphs share the global pool at runtime and are
         # never replayed concurrently, so the pool overlays their memory.
@@ -6853,36 +6899,55 @@ class GPUModelRunner(
         # Trigger CUDA graph capture for specific shapes.
         # Capture the large shapes first so that the smaller shapes
         # can reuse the memory pool allocated for the large shapes.
+        capture_descs = list(self.cudagraph_dispatcher.get_capture_descs())
         set_cudagraph_capturing_enabled(True)
-        with self._freeze_gc(), graph_capture(device=self.device):
-            torch.accelerator.synchronize()
-            torch.accelerator.empty_cache()
-            start_free_gpu_memory = torch.accelerator.get_memory_info()[0]
-
-            for (
-                runtime_mode,
-                batch_descs,
-            ) in self.cudagraph_dispatcher.get_capture_descs():
-                self._capture_cudagraphs(
-                    batch_descriptors=batch_descs,
-                    cudagraph_runtime_mode=runtime_mode,
-                )
+        try:
+            with self._freeze_gc():
                 torch.accelerator.synchronize()
+                torch.accelerator.empty_cache()
+                start_free_gpu_memory = torch.accelerator.get_memory_info()[0]
 
-            # Capture encoder CUDA graphs if enabled
-            if self.encoder_cudagraph_manager is not None:
-                encoder_graph_pool = current_platform.graph_pool_handle()
-                self.encoder_cudagraph_manager.capture(graph_pool=encoder_graph_pool)
+                for component, channel_id in (
+                    ("target", "vllm:target:production"),
+                    ("draft", "vllm:draft:production"),
+                ):
+                    component_descs = [
+                        (mode, descs)
+                        for mode, descs in capture_descs
+                        if component == "target"
+                        or self._captures_independent_drafter_graphs(mode)
+                    ]
+                    if not component_descs:
+                        continue
+                    with graph_capture(device=self.device, channel_id=channel_id):
+                        for runtime_mode, batch_descs in component_descs:
+                            captures_drafter = (
+                                self._captures_independent_drafter_graphs(runtime_mode)
+                            )
+                            self._capture_cudagraphs(
+                                batch_descriptors=batch_descs,
+                                cudagraph_runtime_mode=runtime_mode,
+                                run_drafter=(
+                                    component == "draft" or not captures_drafter
+                                ),
+                            )
+                            torch.accelerator.synchronize()
 
-            torch.accelerator.synchronize()
-            end_free_gpu_memory = torch.accelerator.get_memory_info()[0]
+                if self.encoder_cudagraph_manager is not None:
+                    encoder_graph_pool = current_platform.graph_pool_handle()
+                    with graph_capture(
+                        device=self.device,
+                        channel_id="vllm:encoder:production",
+                    ):
+                        self.encoder_cudagraph_manager.capture(
+                            graph_pool=encoder_graph_pool
+                        )
 
-        # Disable cudagraph capturing globally, so any unexpected cudagraph
-        # capturing will be detected and raise an error after here.
-        # Note: We don't put it into graph_capture context manager because
-        # we may do lazy capturing in future that still allows capturing
-        # after here.
-        set_cudagraph_capturing_enabled(False)
+                torch.accelerator.synchronize()
+                end_free_gpu_memory = torch.accelerator.get_memory_info()[0]
+        finally:
+            # Leave capture mode disabled even when one graph owner fails.
+            set_cudagraph_capturing_enabled(False)
 
         torch.accelerator.synchronize()
         torch.accelerator.empty_cache()
@@ -6902,6 +6967,22 @@ class GPUModelRunner(
         )
         return cuda_graph_size
 
+    def _captures_independent_drafter_graphs(
+        self,
+        cudagraph_runtime_mode: CUDAGraphMode,
+    ) -> bool:
+        spec_config = self.speculative_config
+        return (
+            cudagraph_runtime_mode == CUDAGraphMode.PIECEWISE
+            and spec_config is not None
+            and not spec_config.enforce_eager
+            and (
+                spec_config.use_eagle()
+                or spec_config.uses_draft_model()
+                or spec_config.uses_extract_hidden_states()
+            )
+        )
+
     def _warmup_and_capture(
         self,
         desc: BatchDescriptor,
@@ -6909,6 +6990,7 @@ class GPUModelRunner(
         profile_seq_lens: int | None = None,
         allow_microbatching: bool = False,
         num_warmups: int | None = None,
+        run_drafter: bool = True,
     ):
         if num_warmups is None:
             num_warmups = self.compilation_config.cudagraph_num_of_warmups
@@ -6924,6 +7006,7 @@ class GPUModelRunner(
                 remove_lora=False,
                 num_active_loras=desc.num_active_loras,
                 profile_seq_lens=profile_seq_lens,
+                run_drafter=run_drafter,
             )
         self._dummy_run(
             desc.num_tokens,
@@ -6935,12 +7018,15 @@ class GPUModelRunner(
             num_active_loras=desc.num_active_loras,
             is_graph_capturing=True,
             profile_seq_lens=profile_seq_lens,
+            run_drafter=run_drafter,
         )
 
     def _capture_cudagraphs(
         self,
         batch_descriptors: list[BatchDescriptor],
         cudagraph_runtime_mode: CUDAGraphMode,
+        *,
+        run_drafter: bool = True,
     ):
         assert (
             cudagraph_runtime_mode != CUDAGraphMode.NONE
@@ -6983,6 +7069,7 @@ class GPUModelRunner(
                 batch_desc,
                 cudagraph_runtime_mode=cudagraph_runtime_mode,
                 allow_microbatching=allow_microbatching,
+                run_drafter=run_drafter,
             )
             torch.accelerator.synchronize()
         self.maybe_remove_all_loras(self.lora_config)


### PR DESCRIPTION
## Purpose

Pair vLLM CUDA-graph callers with the semantic multi-channel PCIe ownership contract in [SparkInfer #105](https://github.com/local-inference-lab/sparkinfer/pull/105), and ensure normal teardown closes those collective owners while their process groups are still live.

A process-local CUDA stream handle is not a sufficient identity for transport resources owned by independently captured/replayed target, draft, encoder, profiling, production, and eager paths. This series:

- threads stable semantic `channel_id` values through V1/V2 graph capture, custom all-reduce, and DCP A2A;
- separates target/draft/encoder and profile/production owners;
- gives eager communication stable identities;
- rolls disposable profiling graphs, pools, keys, and channel state back on success or failure;
- explicitly closes custom all-reduce before PyNCCL and before device/CPU process groups;
- retains ownership if coordinated close fails; and
- keeps `__del__` non-collective without an unbounded vLLM wrapper quarantine.

Distributed PCIe graph capture fails closed when a caller omits its semantic identity. Related defects remain tracked by [#208](https://github.com/local-inference-lab/vllm/issues/208) and [#215](https://github.com/local-inference-lab/vllm/issues/215) until this draft is reviewed and merged.

## Status and exact provenance

> **Exact GPU-run field head:** `f99e1e7b8636ca3811ab6d23084ac6da63420dc3`.
>
> **Patch-identical clean GPU evidence boundary:** `d344da368da4496eeb308a75faf314cb6376dc62`, based on `dev/gilded-gnosis@30038602b71395f481ef4a6edfe4fcf8551d9c15`.
>
> **Current review head:** `52201611719edf67f18bc0cbec17802880a4afb7`. This is a post-qualification review successor. It addresses eight valid CodeRabbit findings and has focused portable qualification, but it is not being mislabeled as the literal GPU-run commit.
>
> **Paired SparkInfer:** exact GPU head `bc62980543b3ca59a9bee971df1b19ce6181964c`; current post-review head `caa643c8546121214493d052221f16c62f69f719`.

The first four clean commits are patch-identical to the field lineage; stable patch IDs and `git range-diff` report `=`:

| Field commit | Clean commit | Purpose |
|---|---|---|
| `a89816a3` | `fc186b0b` | Name graph owners and thread IDs through V1/V2. |
| `bd093827` | `52cfe40d` | Name stable eager all-reduce and DCP owners. |
| `be1e289a` | `7dbe5a27` | Complete the DCP graph-channel regression contract. |
| `f99e1e7b` | `d344da36` | Keep abnormal finalization non-collective. |
| — | `52201611` | Post-review explicit teardown and profiling-cleanup hardening; not GPU-run. |

Do not combine this with rejected SparkInfer #101/#103 heads or intermediate `31fa6a4`. That pair passed focused tests but failed full GLM startup when descriptor warmup inside `vllm:target:profile` collided with the static eager identity. SparkInfer `bc629805` repaired that owner-stream handoff without weakening side-stream collision checks.

## Review follow-up at `52201611`

All eight CodeRabbit findings were valid and addressed:

- remove the unbounded vLLM finalizer quarantine;
- coordinate `CustomAllreduce` close before NCCL/process-group destruction;
- retain owners when close fails;
- filter mixed empty graph descriptor lists in profiling and production capture;
- always restore persistent graph pools when cleanup raises;
- centralize the duplicated drafter-forward predicate;
- add both requested Google-style API docstrings;
- rename the misleading rank-symmetry test and replace the ambiguous Unicode multiplication sign.

Validation:

- focused new/changed behavior: **12/12 passed**;
- exact Ruff 0.15.12 lint and format across all 18 PR Python files: **pass**;
- Python byte-compilation and `git diff --check`: **pass**;
- all applicable pre-commit hooks: **pass**;
- direct mypy reached four pre-existing errors in untouched `parallel_state.py` lines 2115/2133/2134/2159; those are outside this diff;
- broader local CPU selection: **46 passed / 2 skipped**, with four unrelated baseline macOS CPU-backend failures.

## Exact GPU qualification at `f99e1e7` / `d344da36`

Paired with SparkInfer `bc629805` on 4x RTX PRO 6000 Blackwell:

- vLLM focused semantic/finalizer selection: **16/16 passed**;
- SparkInfer focused/static: **88/88 passed**;
- SparkInfer communication suite: **241 passed / 21 expected skips**;
- four-rank one-shot and DCP semantic prewarm/capture/replay gates: **pass**;
- full GLM startup and target/draft PIECEWISE plus FULL capture: **pass**;
- **251,392 logical KV tokens**, **1.87 GiB/rank** available;
- API/structured-output gate: **13/13 twice**;
- retrieval: **5/5 at 32K**, **20/20 across cold 65K/126K**;
- two bounded C1/C2/C4/C8 matrices: **64/64 requests**, no error/preemption;
- GSM8K **96/100**; GPQA **44/50**, every normal stop correct and six 32K reasoning-ceiling truncations;
- wrapper exit within 2 seconds and every worker/GPU allocation released within 19 seconds.

This closes the 131K text-only/offload-disabled repair-attribution profile. It does not by itself qualify 512K, vision, or live LMCache. Healthy serve/shutdown proves normal-path compatibility; the abnormal finalizer and new explicit-close ordering are covered by focused tests, not by claiming that ordinary shutdown exercised Python GC at exactly that boundary.

## Claim boundary and evidence

This is correctness and lifecycle work. No direct VRAM, PP, TG, or acceptance-length gain is claimed. The approximately 1.1 GiB/rank full-model recovery belongs to vLLM #210.

- [Immutable counter-validation guide](https://github.com/malaiwah/glm52-exl3-vast/blob/d821001f97dd15f0ae6ace626cc1f334a2069553/docs/field-review-results/2026-07-30-vast-46335896/COUNTER-VALIDATION.md)
- [Repair campaign ledger](https://github.com/malaiwah/glm52-exl3-vast/blob/d821001f97dd15f0ae6ace626cc1f334a2069553/docs/field-review-results/2026-07-30-vast-46335896/UPSTREAM-REPAIR-CAMPAIGN.md)
- [Raw artifacts](https://github.com/malaiwah/glm52-exl3-vast/tree/5c76a2536e7fc9a5f1cb6bf182531889f5385e65/docs/field-review-results/2026-07-30-vast-46335896/artifacts)

## Contribution disclosure

This series was developed with OpenAI Codex assistance; assisted commits carry the trailer. Duplicate checks covered #208, #215, #210, and open semantic-channel/finalizer PRs; no duplicate caller implementation was found. SparkInfer #105 is the required backend half, not a duplicate.

Per repository policy, this PR remains a **draft** until the human submitter has reviewed every changed line and can defend the current `52201611` successor end-to-end. Human maintainer review and independent counter-validation are requested.
