### PR TITLE
[GG] fix(kv-offload): harden shared CPU region allocation

### DIFF
--- a/tests/v1/kv_offload/cpu/test_gpu_worker.py
+++ b/tests/v1/kv_offload/cpu/test_gpu_worker.py
@@ -3,6 +3,8 @@
 import random
 import time
 import uuid
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 import torch
@@ -16,8 +18,9 @@ from vllm.v1.kv_offload.base import (
     CanonicalKVCacheTensor,
     GPULoadStoreSpec,
 )
+from vllm.v1.kv_offload.cpu import gpu_worker
 from vllm.v1.kv_offload.cpu.common import CPULoadStoreSpec
-from vllm.v1.kv_offload.cpu.gpu_worker import CPUOffloadingWorker
+from vllm.v1.kv_offload.cpu.gpu_worker import CPUOffloadingWorker, pin_mmap_region
 from vllm.v1.kv_offload.cpu.shared_offload_region import SharedOffloadRegion
 
 NUM_GPU_BLOCKS = [64]
@@ -30,6 +33,52 @@ DEVICE_TYPE = current_platform.device_type
 DEVICES = [f"{DEVICE_TYPE}:0"]
 NUM_MAPPINGS = [3]
 NUM_MAPPINGS_PER_GROUP = [2]
+
+
+class _CudaResult(int):
+    @property
+    def value(self) -> int:
+        return int(self)
+
+
+def _mock_mmap_region() -> SimpleNamespace:
+    return SimpleNamespace(
+        rank=2,
+        total_size_bytes=4096,
+        _base=SimpleNamespace(data_ptr=lambda: 0x1000),
+        is_pinned=False,
+    )
+
+
+def test_pin_mmap_region_clears_failed_registration_error(monkeypatch) -> None:
+    region = _mock_mmap_region()
+    cudart = MagicMock()
+    cudart.cudaHostRegister.return_value = _CudaResult(1)
+    runtime = MagicMock()
+    monkeypatch.setattr(gpu_worker.current_platform, "is_cuda_alike", lambda: True)
+    monkeypatch.setattr(torch.cuda, "cudart", lambda: cudart)
+    monkeypatch.setattr(gpu_worker, "CudaRTLibrary", lambda: runtime)
+
+    pin_mmap_region(region)
+
+    cudart.cudaHostRegister.assert_called_once_with(0x1000, 4096, 0)
+    runtime.cudaGetLastError.assert_called_once_with()
+    assert region.is_pinned is False
+
+
+def test_pin_mmap_region_keeps_successful_registration(monkeypatch) -> None:
+    region = _mock_mmap_region()
+    cudart = MagicMock()
+    cudart.cudaHostRegister.return_value = _CudaResult(0)
+    runtime_factory = MagicMock()
+    monkeypatch.setattr(gpu_worker.current_platform, "is_cuda_alike", lambda: True)
+    monkeypatch.setattr(torch.cuda, "cudart", lambda: cudart)
+    monkeypatch.setattr(gpu_worker, "CudaRTLibrary", runtime_factory)
+
+    pin_mmap_region(region)
+
+    runtime_factory.assert_not_called()
+    assert region.is_pinned is True
 
 
 @pytest.mark.parametrize("gpu_to_cpu", [True, False])

--- a/tests/v1/kv_offload/cpu/test_gpu_worker.py
+++ b/tests/v1/kv_offload/cpu/test_gpu_worker.py
@@ -6,6 +6,7 @@ import uuid
 from types import SimpleNamespace
 from unittest.mock import MagicMock, call
 
+import numpy as np
 import pytest
 import torch
 
@@ -21,8 +22,10 @@ from vllm.v1.kv_offload.base import (
 from vllm.v1.kv_offload.cpu import gpu_worker
 from vllm.v1.kv_offload.cpu.common import CPULoadStoreSpec
 from vllm.v1.kv_offload.cpu.gpu_worker import (
+    HOST_REGISTER_ALIGNMENT_BYTES,
     HOST_REGISTER_SEGMENT_BYTES,
     CPUOffloadingWorker,
+    _split_copy_descriptors_at_host_boundaries,
     pin_mmap_region,
 )
 from vllm.v1.kv_offload.cpu.shared_offload_region import SharedOffloadRegion
@@ -39,12 +42,16 @@ NUM_MAPPINGS = [3]
 NUM_MAPPINGS_PER_GROUP = [2]
 
 
-def _mock_mmap_region(total_size_bytes: int = 4096) -> SimpleNamespace:
+def _mock_mmap_region(
+    total_size_bytes: int = 4096, row_stride: int = 4096
+) -> SimpleNamespace:
     return SimpleNamespace(
         rank=2,
         total_size_bytes=total_size_bytes,
+        _row_stride=row_stride,
         _base=SimpleNamespace(data_ptr=lambda: 0x1000),
         _registered_host_ptrs=[],
+        _host_register_segment_bytes=None,
         is_pinned=False,
     )
 
@@ -99,6 +106,33 @@ def test_pin_mmap_region_retries_large_mapping_as_segments(monkeypatch) -> None:
         0x1000 + HOST_REGISTER_SEGMENT_BYTES,
         0x1000 + 2 * HOST_REGISTER_SEGMENT_BYTES,
     ]
+    assert region._host_register_segment_bytes == HOST_REGISTER_SEGMENT_BYTES
+
+
+def test_pin_mmap_region_aligns_segments_to_kv_rows(monkeypatch) -> None:
+    row_stride = 3 * 4096
+    segment_alignment = np.lcm(row_stride, HOST_REGISTER_ALIGNMENT_BYTES)
+    segment_bytes = (
+        HOST_REGISTER_SEGMENT_BYTES // segment_alignment
+    ) * segment_alignment
+    total_bytes = 2 * segment_bytes + row_stride
+    region = _mock_mmap_region(total_bytes, row_stride)
+    register = MagicMock(side_effect=[1, 0, 0, 0])
+    monkeypatch.setattr(gpu_worker.current_platform, "is_cuda_alike", lambda: True)
+    monkeypatch.setattr(gpu_worker, "register_host_memory", register)
+
+    pin_mmap_region(region)
+
+    assert register.call_args_list == [
+        call(0x1000, total_bytes),
+        call(0x1000, segment_bytes),
+        call(0x1000 + segment_bytes, segment_bytes),
+        call(0x1000 + 2 * segment_bytes, row_stride),
+    ]
+    assert region.is_pinned is True
+    assert region._host_register_segment_bytes == segment_bytes
+    assert segment_bytes % row_stride == 0
+    assert segment_bytes % HOST_REGISTER_ALIGNMENT_BYTES == 0
 
 
 def test_pin_mmap_region_rolls_back_partial_segment_registration(
@@ -120,6 +154,65 @@ def test_pin_mmap_region_rolls_back_partial_segment_registration(
     ]
     assert region.is_pinned is False
     assert region._registered_host_ptrs == []
+
+
+@pytest.mark.parametrize("host_is_src", [False, True])
+def test_split_copy_descriptors_at_host_boundaries(host_is_src: bool) -> None:
+    host_base = 10_000
+    segment_bytes = 100
+    src = np.full(6, -1, dtype=np.int64)
+    dst = np.full(6, -1, dtype=np.int64)
+    sizes = np.full(6, -1, dtype=np.int64)
+
+    host_ptrs = [host_base + 90, host_base + 196]
+    device_ptrs = [20_000, 30_000]
+    if host_is_src:
+        src[:2], dst[:2] = host_ptrs, device_ptrs
+    else:
+        src[:2], dst[:2] = device_ptrs, host_ptrs
+    sizes[:2] = [20, 12]
+
+    count = _split_copy_descriptors_at_host_boundaries(
+        src,
+        dst,
+        sizes,
+        2,
+        host_is_src=host_is_src,
+        host_base=host_base,
+        segment_bytes=segment_bytes,
+    )
+
+    assert count == 4
+    expected_host = [host_base + 90, host_base + 100, host_base + 196, host_base + 200]
+    expected_device = [20_000, 20_010, 30_000, 30_004]
+    if host_is_src:
+        assert src[:count].tolist() == expected_host
+        assert dst[:count].tolist() == expected_device
+    else:
+        assert src[:count].tolist() == expected_device
+        assert dst[:count].tolist() == expected_host
+    assert sizes[:count].tolist() == [10, 10, 4, 8]
+
+
+def test_split_copy_descriptors_keeps_in_segment_copy() -> None:
+    src = np.array([20_000], dtype=np.int64)
+    dst = np.array([10_010], dtype=np.int64)
+    sizes = np.array([20], dtype=np.int64)
+
+    count = _split_copy_descriptors_at_host_boundaries(
+        src,
+        dst,
+        sizes,
+        1,
+        host_is_src=False,
+        host_base=10_000,
+        segment_bytes=100,
+    )
+
+    assert count == 1
+    assert src.tolist() == [20_000]
+    assert dst.tolist() == [10_010]
+    assert sizes.tolist() == [20]
 
 
 @pytest.mark.parametrize("gpu_to_cpu", [True, False])

--- a/tests/v1/kv_offload/cpu/test_gpu_worker.py
+++ b/tests/v1/kv_offload/cpu/test_gpu_worker.py
@@ -39,12 +39,6 @@ NUM_MAPPINGS = [3]
 NUM_MAPPINGS_PER_GROUP = [2]
 
 
-class _CudaResult(int):
-    @property
-    def value(self) -> int:
-        return int(self)
-
-
 def _mock_mmap_region(total_size_bytes: int = 4096) -> SimpleNamespace:
     return SimpleNamespace(
         rank=2,
@@ -55,34 +49,27 @@ def _mock_mmap_region(total_size_bytes: int = 4096) -> SimpleNamespace:
     )
 
 
-def test_pin_mmap_region_clears_failed_registration_error(monkeypatch) -> None:
+def test_pin_mmap_region_falls_back_after_failed_registration(monkeypatch) -> None:
     region = _mock_mmap_region()
-    cudart = MagicMock()
-    cudart.cudaHostRegister.return_value = _CudaResult(1)
-    runtime = MagicMock()
+    register = MagicMock(return_value=1)
     monkeypatch.setattr(gpu_worker.current_platform, "is_cuda_alike", lambda: True)
-    monkeypatch.setattr(torch.cuda, "cudart", lambda: cudart)
-    monkeypatch.setattr(gpu_worker, "CudaRTLibrary", lambda: runtime)
+    monkeypatch.setattr(gpu_worker, "register_host_memory", register)
 
     pin_mmap_region(region)
 
-    cudart.cudaHostRegister.assert_called_once_with(0x1000, 4096, 0)
-    runtime.cudaGetLastError.assert_called_once_with()
+    register.assert_called_once_with(0x1000, 4096)
     assert region.is_pinned is False
 
 
 def test_pin_mmap_region_keeps_successful_registration(monkeypatch) -> None:
     region = _mock_mmap_region()
-    cudart = MagicMock()
-    cudart.cudaHostRegister.return_value = _CudaResult(0)
-    runtime_factory = MagicMock()
+    register = MagicMock(return_value=0)
     monkeypatch.setattr(gpu_worker.current_platform, "is_cuda_alike", lambda: True)
-    monkeypatch.setattr(torch.cuda, "cudart", lambda: cudart)
-    monkeypatch.setattr(gpu_worker, "CudaRTLibrary", runtime_factory)
+    monkeypatch.setattr(gpu_worker, "register_host_memory", register)
 
     pin_mmap_region(region)
 
-    runtime_factory.assert_not_called()
+    register.assert_called_once_with(0x1000, 4096)
     assert region.is_pinned is True
     assert region._registered_host_ptrs == [0x1000]
 
@@ -91,31 +78,21 @@ def test_pin_mmap_region_retries_large_mapping_as_segments(monkeypatch) -> None:
     tail_bytes = 4096
     total_bytes = 2 * HOST_REGISTER_SEGMENT_BYTES + tail_bytes
     region = _mock_mmap_region(total_bytes)
-    cudart = MagicMock()
-    cudart.cudaHostRegister.side_effect = [
-        _CudaResult(1),
-        _CudaResult(0),
-        _CudaResult(0),
-        _CudaResult(0),
-    ]
-    runtime = MagicMock()
+    register = MagicMock(side_effect=[1, 0, 0, 0])
     monkeypatch.setattr(gpu_worker.current_platform, "is_cuda_alike", lambda: True)
-    monkeypatch.setattr(torch.cuda, "cudart", lambda: cudart)
-    monkeypatch.setattr(gpu_worker, "CudaRTLibrary", lambda: runtime)
+    monkeypatch.setattr(gpu_worker, "register_host_memory", register)
 
     pin_mmap_region(region)
 
-    assert cudart.cudaHostRegister.call_args_list == [
-        call(0x1000, total_bytes, 0),
-        call(0x1000, HOST_REGISTER_SEGMENT_BYTES, 0),
+    assert register.call_args_list == [
+        call(0x1000, total_bytes),
+        call(0x1000, HOST_REGISTER_SEGMENT_BYTES),
         call(
             0x1000 + HOST_REGISTER_SEGMENT_BYTES,
             HOST_REGISTER_SEGMENT_BYTES,
-            0,
         ),
-        call(0x1000 + 2 * HOST_REGISTER_SEGMENT_BYTES, tail_bytes, 0),
+        call(0x1000 + 2 * HOST_REGISTER_SEGMENT_BYTES, tail_bytes),
     ]
-    runtime.cudaGetLastError.assert_called_once_with()
     assert region.is_pinned is True
     assert region._registered_host_ptrs == [
         0x1000,
@@ -129,26 +106,18 @@ def test_pin_mmap_region_rolls_back_partial_segment_registration(
 ) -> None:
     total_bytes = 3 * HOST_REGISTER_SEGMENT_BYTES
     region = _mock_mmap_region(total_bytes)
-    cudart = MagicMock()
-    cudart.cudaHostRegister.side_effect = [
-        _CudaResult(1),
-        _CudaResult(0),
-        _CudaResult(0),
-        _CudaResult(2),
-    ]
-    cudart.cudaHostUnregister.return_value = _CudaResult(0)
-    runtime = MagicMock()
+    register = MagicMock(side_effect=[1, 0, 0, 2])
+    unregister = MagicMock(return_value=0)
     monkeypatch.setattr(gpu_worker.current_platform, "is_cuda_alike", lambda: True)
-    monkeypatch.setattr(torch.cuda, "cudart", lambda: cudart)
-    monkeypatch.setattr(gpu_worker, "CudaRTLibrary", lambda: runtime)
+    monkeypatch.setattr(gpu_worker, "register_host_memory", register)
+    monkeypatch.setattr(gpu_worker, "unregister_host_memory", unregister)
 
     pin_mmap_region(region)
 
-    assert cudart.cudaHostUnregister.call_args_list == [
+    assert unregister.call_args_list == [
         call(0x1000 + HOST_REGISTER_SEGMENT_BYTES),
         call(0x1000),
     ]
-    assert runtime.cudaGetLastError.call_count == 2
     assert region.is_pinned is False
     assert region._registered_host_ptrs == []
 

--- a/tests/v1/kv_offload/cpu/test_gpu_worker.py
+++ b/tests/v1/kv_offload/cpu/test_gpu_worker.py
@@ -4,7 +4,7 @@ import random
 import time
 import uuid
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 import pytest
 import torch
@@ -20,7 +20,11 @@ from vllm.v1.kv_offload.base import (
 )
 from vllm.v1.kv_offload.cpu import gpu_worker
 from vllm.v1.kv_offload.cpu.common import CPULoadStoreSpec
-from vllm.v1.kv_offload.cpu.gpu_worker import CPUOffloadingWorker, pin_mmap_region
+from vllm.v1.kv_offload.cpu.gpu_worker import (
+    HOST_REGISTER_SEGMENT_BYTES,
+    CPUOffloadingWorker,
+    pin_mmap_region,
+)
 from vllm.v1.kv_offload.cpu.shared_offload_region import SharedOffloadRegion
 
 NUM_GPU_BLOCKS = [64]
@@ -41,11 +45,12 @@ class _CudaResult(int):
         return int(self)
 
 
-def _mock_mmap_region() -> SimpleNamespace:
+def _mock_mmap_region(total_size_bytes: int = 4096) -> SimpleNamespace:
     return SimpleNamespace(
         rank=2,
-        total_size_bytes=4096,
+        total_size_bytes=total_size_bytes,
         _base=SimpleNamespace(data_ptr=lambda: 0x1000),
+        _registered_host_ptrs=[],
         is_pinned=False,
     )
 
@@ -79,6 +84,73 @@ def test_pin_mmap_region_keeps_successful_registration(monkeypatch) -> None:
 
     runtime_factory.assert_not_called()
     assert region.is_pinned is True
+    assert region._registered_host_ptrs == [0x1000]
+
+
+def test_pin_mmap_region_retries_large_mapping_as_segments(monkeypatch) -> None:
+    tail_bytes = 4096
+    total_bytes = 2 * HOST_REGISTER_SEGMENT_BYTES + tail_bytes
+    region = _mock_mmap_region(total_bytes)
+    cudart = MagicMock()
+    cudart.cudaHostRegister.side_effect = [
+        _CudaResult(1),
+        _CudaResult(0),
+        _CudaResult(0),
+        _CudaResult(0),
+    ]
+    runtime = MagicMock()
+    monkeypatch.setattr(gpu_worker.current_platform, "is_cuda_alike", lambda: True)
+    monkeypatch.setattr(torch.cuda, "cudart", lambda: cudart)
+    monkeypatch.setattr(gpu_worker, "CudaRTLibrary", lambda: runtime)
+
+    pin_mmap_region(region)
+
+    assert cudart.cudaHostRegister.call_args_list == [
+        call(0x1000, total_bytes, 0),
+        call(0x1000, HOST_REGISTER_SEGMENT_BYTES, 0),
+        call(
+            0x1000 + HOST_REGISTER_SEGMENT_BYTES,
+            HOST_REGISTER_SEGMENT_BYTES,
+            0,
+        ),
+        call(0x1000 + 2 * HOST_REGISTER_SEGMENT_BYTES, tail_bytes, 0),
+    ]
+    runtime.cudaGetLastError.assert_called_once_with()
+    assert region.is_pinned is True
+    assert region._registered_host_ptrs == [
+        0x1000,
+        0x1000 + HOST_REGISTER_SEGMENT_BYTES,
+        0x1000 + 2 * HOST_REGISTER_SEGMENT_BYTES,
+    ]
+
+
+def test_pin_mmap_region_rolls_back_partial_segment_registration(
+    monkeypatch,
+) -> None:
+    total_bytes = 3 * HOST_REGISTER_SEGMENT_BYTES
+    region = _mock_mmap_region(total_bytes)
+    cudart = MagicMock()
+    cudart.cudaHostRegister.side_effect = [
+        _CudaResult(1),
+        _CudaResult(0),
+        _CudaResult(0),
+        _CudaResult(2),
+    ]
+    cudart.cudaHostUnregister.return_value = _CudaResult(0)
+    runtime = MagicMock()
+    monkeypatch.setattr(gpu_worker.current_platform, "is_cuda_alike", lambda: True)
+    monkeypatch.setattr(torch.cuda, "cudart", lambda: cudart)
+    monkeypatch.setattr(gpu_worker, "CudaRTLibrary", lambda: runtime)
+
+    pin_mmap_region(region)
+
+    assert cudart.cudaHostUnregister.call_args_list == [
+        call(0x1000 + HOST_REGISTER_SEGMENT_BYTES),
+        call(0x1000),
+    ]
+    assert runtime.cudaGetLastError.call_count == 2
+    assert region.is_pinned is False
+    assert region._registered_host_ptrs == []
 
 
 @pytest.mark.parametrize("gpu_to_cpu", [True, False])

--- a/tests/v1/kv_offload/cpu/test_host_mem_ops.py
+++ b/tests/v1/kv_offload/cpu/test_host_mem_ops.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import torch
+
+from vllm.v1.kv_offload.cpu import host_mem_ops
+
+
+def _driver_result(code: int) -> tuple[SimpleNamespace]:
+    return (SimpleNamespace(value=code),)
+
+
+def test_cuda_registration_uses_driver_api(monkeypatch) -> None:
+    driver = MagicMock()
+    driver.cuMemHostRegister.return_value = _driver_result(2)
+    driver.cuMemHostUnregister.return_value = _driver_result(0)
+    runtime_factory = MagicMock()
+    monkeypatch.setattr(host_mem_ops.current_platform, "is_cuda", lambda: True)
+    monkeypatch.setattr(host_mem_ops, "_get_cuda_driver", lambda: driver)
+    monkeypatch.setattr(host_mem_ops, "CudaRTLibrary", runtime_factory)
+
+    assert host_mem_ops.register_host_memory(0x1000, 4096) == 2
+    assert host_mem_ops.unregister_host_memory(0x1000) == 0
+
+    driver.cuMemHostRegister.assert_called_once_with(0x1000, 4096, 0)
+    driver.cuMemHostUnregister.assert_called_once_with(0x1000)
+    runtime_factory.assert_not_called()
+
+
+def test_rocm_registration_clears_runtime_failures(monkeypatch) -> None:
+    cudart = MagicMock()
+    cudart.cudaHostRegister.return_value = SimpleNamespace(value=1)
+    cudart.cudaHostUnregister.return_value = SimpleNamespace(value=2)
+    runtime = MagicMock()
+    monkeypatch.setattr(host_mem_ops.current_platform, "is_cuda", lambda: False)
+    monkeypatch.setattr(torch.cuda, "cudart", lambda: cudart)
+    monkeypatch.setattr(host_mem_ops, "CudaRTLibrary", lambda: runtime)
+
+    assert host_mem_ops.register_host_memory(0x2000, 8192) == 1
+    assert host_mem_ops.unregister_host_memory(0x2000) == 2
+
+    assert runtime.cudaGetLastError.call_count == 2

--- a/tests/v1/kv_offload/cpu/test_shared_offload_region.py
+++ b/tests/v1/kv_offload/cpu/test_shared_offload_region.py
@@ -406,6 +406,30 @@ def test_file_has_correct_size(iid):
         assert os.path.getsize(r.mmap_path) == 4 * PAGE_SIZE
 
 
+def test_prefault_can_be_disabled_for_delayed_scheduler(iid, monkeypatch):
+    """A scheduler join must not issue MADV_POPULATE_WRITE for the full region."""
+    monkeypatch.setattr(
+        shared_offload_region.mmap,
+        "MADV_POPULATE_WRITE",
+        2**31 - 1,
+        raising=False,
+    )
+    mmap_path = f"/dev/shm/vllm_offload_{iid}.mmap"
+    region = SharedOffloadRegion(
+        engine_id=iid,
+        num_blocks=4,
+        rank=None,
+        kv_bytes_per_block=PAGE_SIZE,
+        cpu_page_size=PAGE_SIZE,
+        prefault=False,
+    )
+    try:
+        assert region.mmap_obj is not None
+    finally:
+        region.cleanup()
+        _cleanup_file(mmap_path)
+
+
 def test_unlink_after_all_workers_map_keeps_shared_mapping(iid):
     """The production mode unlinks only after every worker owns its mmap."""
     num_workers = 2
@@ -475,6 +499,74 @@ def test_unlink_after_workers_map_requires_worker_count(iid):
             cpu_page_size=PAGE_SIZE,
             unlink_after_workers_map=True,
         )
+
+
+def test_unlink_rendezvous_timeout_cleans_resources_and_markers(iid, monkeypatch):
+    """A missing worker must not leak the creator mapping or rendezvous files."""
+    mmap_path = f"/dev/shm/vllm_offload_{iid}.mmap"
+    cleanup_state: list[tuple[int | None, mmap.mmap | None]] = []
+    original_cleanup = SharedOffloadRegion.cleanup
+
+    def tracked_cleanup(region: SharedOffloadRegion) -> None:
+        original_cleanup(region)
+        cleanup_state.append((region.fd, region.mmap_obj))
+
+    monotonic = MagicMock(side_effect=[0.0, 31.0])
+    monkeypatch.setattr(shared_offload_region.time, "monotonic", monotonic)
+    monkeypatch.setattr(SharedOffloadRegion, "cleanup", tracked_cleanup)
+
+    with pytest.raises(TimeoutError, match="worker mmap markers"):
+        SharedOffloadRegion(
+            engine_id=iid,
+            num_blocks=4,
+            rank=0,
+            kv_bytes_per_block=2 * PAGE_SIZE,
+            cpu_page_size=PAGE_SIZE,
+            unlink_after_workers_map=True,
+            num_workers=2,
+        )
+
+    assert cleanup_state == [(None, None)]
+    assert not os.path.exists(mmap_path)
+    assert not os.path.exists(f"{mmap_path}.mapped.0")
+    assert not os.path.exists(f"{mmap_path}.mapped.1")
+
+
+def test_delayed_scheduler_joins_worker_backing(iid):
+    """Tiering's delayed scheduler mapping must observe the worker backing."""
+    mmap_path = f"/dev/shm/vllm_offload_{iid}.mmap"
+    regions: list[SharedOffloadRegion] = []
+    try:
+        for rank in range(2):
+            regions.append(
+                SharedOffloadRegion(
+                    engine_id=iid,
+                    num_blocks=4,
+                    rank=rank,
+                    kv_bytes_per_block=2 * PAGE_SIZE,
+                    cpu_page_size=PAGE_SIZE,
+                )
+            )
+
+        assert os.path.exists(mmap_path)
+        scheduler = SharedOffloadRegion(
+            engine_id=iid,
+            num_blocks=4,
+            rank=None,
+            kv_bytes_per_block=2 * PAGE_SIZE,
+            cpu_page_size=PAGE_SIZE,
+            prefault=False,
+        )
+        regions.append(scheduler)
+
+        regions[0].mmap_obj[0:1] = b"\x2a"
+        assert scheduler.mmap_obj[0:1] == b"\x2a"
+        scheduler.mmap_obj[PAGE_SIZE : PAGE_SIZE + 1] = b"\x3b"
+        assert regions[1].mmap_obj[PAGE_SIZE : PAGE_SIZE + 1] == b"\x3b"
+    finally:
+        for region in reversed(regions):
+            region.cleanup()
+        _cleanup_file(mmap_path)
 
 
 # ---------------------------------------------------------------------------
@@ -558,26 +650,36 @@ def test_multiprocess_race_construct_and_write(iid):
     for rank, r in results.items():
         assert r["error"] is None, f"rank {rank}: {r['error']}"
 
-    # Read the raw file while all workers still hold it open.
-    mmap_path = f"/dev/shm/vllm_offload_{iid}.mmap"
-    with open(mmap_path, "rb") as f:
-        raw = f.read()
+    # Attach through the scheduler API only after every worker has mapped and
+    # written the region. This mirrors TieringOffloadingSpec startup ordering.
+    scheduler = SharedOffloadRegion(
+        engine_id=iid,
+        num_blocks=num_blocks,
+        rank=None,
+        kv_bytes_per_block=num_workers * PAGE_SIZE,
+        cpu_page_size=PAGE_SIZE,
+        prefault=False,
+    )
+    try:
+        assert scheduler.mmap_obj is not None
+        raw = bytes(scheduler.mmap_obj)
 
-    for blk in range(num_blocks):
-        for w in range(num_workers):
-            slot_start = (blk * num_workers + w) * PAGE_SIZE
-            slot = raw[slot_start : slot_start + PAGE_SIZE]
-            expected = w + 1  # fill_value = rank + 1
-            assert all(b == expected for b in slot), (
-                f"block {blk}, worker {w}: expected {expected} but got wrong bytes"
-            )
-
-    # Unblock all workers to clean up.
-    for _ in range(num_workers):
-        cleanup_queue.put(True)
-    for p in procs:
-        p.join(timeout=10)
-        assert p.exitcode == 0
+        for blk in range(num_blocks):
+            for w in range(num_workers):
+                slot_start = (blk * num_workers + w) * PAGE_SIZE
+                slot = raw[slot_start : slot_start + PAGE_SIZE]
+                expected = w + 1  # fill_value = rank + 1
+                assert all(b == expected for b in slot), (
+                    f"block {blk}, worker {w}: expected {expected} but got wrong bytes"
+                )
+    finally:
+        scheduler.cleanup()
+        # Unblock all workers to clean up.
+        for _ in range(num_workers):
+            cleanup_queue.put(True)
+        for proc in procs:
+            proc.join(timeout=10)
+            assert proc.exitcode == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/v1/kv_offload/cpu/test_shared_offload_region.py
+++ b/tests/v1/kv_offload/cpu/test_shared_offload_region.py
@@ -406,6 +406,77 @@ def test_file_has_correct_size(iid):
         assert os.path.getsize(r.mmap_path) == 4 * PAGE_SIZE
 
 
+def test_unlink_after_all_workers_map_keeps_shared_mapping(iid):
+    """The production mode unlinks only after every worker owns its mmap."""
+    num_workers = 2
+    regions: list[SharedOffloadRegion | None] = [None, None]
+    errors: list[BaseException] = []
+    mmap_path = f"/dev/shm/vllm_offload_{iid}.mmap"
+
+    def create_rank0() -> None:
+        try:
+            regions[0] = SharedOffloadRegion(
+                engine_id=iid,
+                num_blocks=4,
+                rank=0,
+                kv_bytes_per_block=num_workers * PAGE_SIZE,
+                cpu_page_size=PAGE_SIZE,
+                unlink_after_workers_map=True,
+                num_workers=num_workers,
+            )
+        except BaseException as exc:
+            errors.append(exc)
+
+    rank0_thread = threading.Thread(target=create_rank0)
+    rank0_thread.start()
+    marker0 = f"{mmap_path}.mapped.0"
+    deadline = time.monotonic() + 5
+    while not os.path.exists(marker0):
+        assert time.monotonic() < deadline, "rank 0 did not publish its mmap marker"
+        time.sleep(0.005)
+
+    assert os.path.exists(mmap_path), "joiners still need the pathname"
+    regions[1] = SharedOffloadRegion(
+        engine_id=iid,
+        num_blocks=4,
+        rank=1,
+        kv_bytes_per_block=num_workers * PAGE_SIZE,
+        cpu_page_size=PAGE_SIZE,
+        unlink_after_workers_map=True,
+        num_workers=num_workers,
+    )
+    rank0_thread.join(timeout=5)
+
+    try:
+        assert not rank0_thread.is_alive()
+        assert not errors
+        assert regions[0] is not None
+        assert regions[1] is not None
+        assert not os.path.exists(mmap_path)
+        assert not os.path.exists(marker0)
+        assert not os.path.exists(f"{mmap_path}.mapped.1")
+
+        regions[0].mmap_obj[0:1] = b"\x2a"
+        assert regions[1].mmap_obj[0:1] == b"\x2a"
+    finally:
+        for region in regions:
+            if region is not None:
+                region.cleanup()
+        _cleanup_file(mmap_path)
+
+
+def test_unlink_after_workers_map_requires_worker_count(iid):
+    with pytest.raises(ValueError, match="num_workers must be positive"):
+        SharedOffloadRegion(
+            engine_id=iid,
+            num_blocks=4,
+            rank=0,
+            kv_bytes_per_block=PAGE_SIZE,
+            cpu_page_size=PAGE_SIZE,
+            unlink_after_workers_map=True,
+        )
+
+
 # ---------------------------------------------------------------------------
 # Multi-worker race — concurrent construction
 # ---------------------------------------------------------------------------

--- a/tests/v1/kv_offload/cpu/test_shared_offload_region.py
+++ b/tests/v1/kv_offload/cpu/test_shared_offload_region.py
@@ -8,12 +8,10 @@ import os
 import threading
 import time
 import uuid
-from types import SimpleNamespace
 from unittest.mock import MagicMock, call
 
 import pytest
 
-from vllm.distributed.device_communicators import cuda_wrapper
 from vllm.utils.system_utils import get_mp_context
 from vllm.v1.kv_offload.cpu import shared_offload_region
 from vllm.v1.kv_offload.cpu.shared_offload_region import (
@@ -575,27 +573,27 @@ def test_cleanup_after_create_next_view_releases_mmap(iid):
 def test_cleanup_unregisters_tracked_segments_in_reverse(iid, monkeypatch):
     """cleanup() must unregister the exact segments accepted during pinning."""
     r = _make_region(iid)
-    cudart = MagicMock()
-    cudart.cudaHostUnregister.return_value = SimpleNamespace(value=0)
-    runtime_factory = MagicMock()
+    unregister = MagicMock(return_value=0)
     monkeypatch.setattr(
         shared_offload_region.current_platform,
         "is_cuda_alike",
         lambda: True,
     )
-    monkeypatch.setattr(shared_offload_region.torch.cuda, "cudart", lambda: cudart)
-    monkeypatch.setattr(cuda_wrapper, "CudaRTLibrary", runtime_factory)
+    monkeypatch.setattr(
+        shared_offload_region,
+        "unregister_host_memory",
+        unregister,
+    )
     r._registered_host_ptrs = [0x1000, 0x2000, 0x3000]
     r.is_pinned = True
 
     r.cleanup()
 
-    assert cudart.cudaHostUnregister.call_args_list == [
+    assert unregister.call_args_list == [
         call(0x3000),
         call(0x2000),
         call(0x1000),
     ]
-    runtime_factory.assert_not_called()
     assert r._registered_host_ptrs == []
     assert r.is_pinned is False
 

--- a/tests/v1/kv_offload/cpu/test_shared_offload_region.py
+++ b/tests/v1/kv_offload/cpu/test_shared_offload_region.py
@@ -8,10 +8,14 @@ import os
 import threading
 import time
 import uuid
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call
 
 import pytest
 
+from vllm.distributed.device_communicators import cuda_wrapper
 from vllm.utils.system_utils import get_mp_context
+from vllm.v1.kv_offload.cpu import shared_offload_region
 from vllm.v1.kv_offload.cpu.shared_offload_region import (
     SharedOffloadRegion,
     _wait_for_file_size,
@@ -566,6 +570,34 @@ def test_cleanup_after_create_next_view_releases_mmap(iid):
     r.cleanup()
 
     assert mmap_obj.closed, "mmap should be closed after releasing the tensor"
+
+
+def test_cleanup_unregisters_tracked_segments_in_reverse(iid, monkeypatch):
+    """cleanup() must unregister the exact segments accepted during pinning."""
+    r = _make_region(iid)
+    cudart = MagicMock()
+    cudart.cudaHostUnregister.return_value = SimpleNamespace(value=0)
+    runtime_factory = MagicMock()
+    monkeypatch.setattr(
+        shared_offload_region.current_platform,
+        "is_cuda_alike",
+        lambda: True,
+    )
+    monkeypatch.setattr(shared_offload_region.torch.cuda, "cudart", lambda: cudart)
+    monkeypatch.setattr(cuda_wrapper, "CudaRTLibrary", runtime_factory)
+    r._registered_host_ptrs = [0x1000, 0x2000, 0x3000]
+    r.is_pinned = True
+
+    r.cleanup()
+
+    assert cudart.cudaHostUnregister.call_args_list == [
+        call(0x3000),
+        call(0x2000),
+        call(0x1000),
+    ]
+    runtime_factory.assert_not_called()
+    assert r._registered_host_ptrs == []
+    assert r.is_pinned is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/v1/kv_offload/test_factory.py
+++ b/tests/v1/kv_offload/test_factory.py
@@ -375,6 +375,8 @@ def test_cpu_spec_create_worker_uses_shared_region_on_cuda(monkeypatch):
         rank=1,
         kv_bytes_per_block=spec.kv_bytes_per_chunk,
         cpu_page_size=spec.cpu_page_size_per_worker,
+        unlink_after_workers_map=True,
+        num_workers=4,
     )
     worker_ctor.assert_called_once_with(
         kv_caches=kv_caches,

--- a/tests/v1/kv_offload/test_factory.py
+++ b/tests/v1/kv_offload/test_factory.py
@@ -464,6 +464,81 @@ def test_tiering_spec_aligns_row_size():
     assert spec.num_blocks == cpu_bytes_to_use // alignment
 
 
+def test_tiering_spec_keeps_region_named_for_delayed_scheduler(monkeypatch):
+    import vllm.v1.kv_offload.tiering.spec as tiering_spec_module
+
+    alignment = SharedOffloadRegion.BLOCK_SIZE_ALIGNMENT
+    config = _make_layout_vllm_config(
+        spec_name="TieringOffloadingSpec",
+        cpu_bytes_to_use=alignment * 2,
+        tensor_parallel_size=2,
+    )
+    spec = _create_spec(config, _make_sizing_kv_cache_config(packed=False))
+    assert isinstance(spec, TieringOffloadingSpec)
+
+    scheduler_region = MagicMock()
+    region_ctor = MagicMock(return_value=scheduler_region)
+    primary_tier = MagicMock()
+    primary_tier.get_kv_memoryview.return_value = memoryview(bytearray(1))
+    primary_ctor = MagicMock(return_value=primary_tier)
+    manager_ctor = MagicMock(return_value=MagicMock())
+    monkeypatch.setattr(tiering_spec_module, "SharedOffloadRegion", region_ctor)
+    monkeypatch.setattr(
+        tiering_spec_module, "CPUPrimaryTierOffloadingManager", primary_ctor
+    )
+    monkeypatch.setattr(tiering_spec_module, "TieringOffloadingManager", manager_ctor)
+
+    spec.get_manager()
+
+    region_ctor.assert_called_once_with(
+        engine_id=spec._engine_id,
+        num_blocks=spec.num_blocks,
+        rank=None,
+        kv_bytes_per_block=spec.kv_bytes_per_chunk,
+        cpu_page_size=spec.cpu_page_size_per_worker,
+        prefault=False,
+    )
+
+
+def test_tiering_worker_keeps_region_named_for_scheduler(monkeypatch):
+    import vllm.v1.kv_offload.tiering.spec as tiering_spec_module
+
+    alignment = SharedOffloadRegion.BLOCK_SIZE_ALIGNMENT
+    config = _make_layout_vllm_config(
+        spec_name="TieringOffloadingSpec",
+        cpu_bytes_to_use=alignment * 2,
+        tensor_parallel_size=2,
+    )
+    spec = _create_spec(config, _make_sizing_kv_cache_config(packed=False))
+    assert isinstance(spec, TieringOffloadingSpec)
+
+    worker_region = MagicMock()
+    region_ctor = MagicMock(return_value=worker_region)
+    worker_ctor = MagicMock(return_value=MagicMock())
+    monkeypatch.setattr(tiering_spec_module, "SharedOffloadRegion", region_ctor)
+    monkeypatch.setattr(tiering_spec_module, "CPUOffloadingWorker", worker_ctor)
+    monkeypatch.setattr(
+        tiering_spec_module.torch.accelerator, "current_device_index", lambda: 3
+    )
+
+    kv_caches = MagicMock()
+    spec.create_worker(kv_caches)
+
+    region_ctor.assert_called_once_with(
+        engine_id=spec._engine_id,
+        num_blocks=spec.num_blocks,
+        rank=1,
+        kv_bytes_per_block=spec.kv_bytes_per_chunk,
+        cpu_page_size=spec.cpu_page_size_per_worker,
+    )
+    worker_ctor.assert_called_once_with(
+        kv_caches=kv_caches,
+        blocks_per_chunk=spec.blocks_per_chunk,
+        num_cpu_blocks=spec.num_blocks,
+        mmap_region=worker_region,
+    )
+
+
 def test_offloading_spec_resolves_prefill_context_parallel_block_sizes():
     config = _make_layout_vllm_config(
         cpu_bytes_to_use=65536,

--- a/tests/v1/kv_offload/test_factory.py
+++ b/tests/v1/kv_offload/test_factory.py
@@ -328,7 +328,8 @@ def test_create_cpu_offloading_spec_end_to_end():
 
 @pytest.mark.parametrize("packed", [False, True])
 def test_cpu_spec_sizing_preserves_tensor_layout(packed: bool):
-    cpu_bytes_to_use = 1920
+    alignment = SharedOffloadRegion.BLOCK_SIZE_ALIGNMENT
+    cpu_bytes_to_use = alignment * 3
     config = _make_layout_vllm_config(
         cpu_bytes_to_use=cpu_bytes_to_use,
         extra_config={"block_size": 32},
@@ -340,8 +341,83 @@ def test_cpu_spec_sizing_preserves_tensor_layout(packed: bool):
 
     assert isinstance(spec, CPUOffloadingSpec)
     assert spec.cpu_page_size_per_worker == 32
-    assert spec.kv_bytes_per_chunk == 192
-    assert spec.num_blocks == cpu_bytes_to_use // 192
+    assert spec.kv_bytes_per_chunk == alignment
+    assert spec.num_blocks == 3
+
+
+def test_cpu_spec_create_worker_uses_shared_region_on_cuda(monkeypatch):
+    import vllm.v1.kv_offload.cpu.spec as cpu_spec_module
+
+    alignment = SharedOffloadRegion.BLOCK_SIZE_ALIGNMENT
+    config = _make_layout_vllm_config(
+        cpu_bytes_to_use=alignment * 2,
+        tensor_parallel_size=4,
+    )
+    spec = _create_spec(config, _make_sizing_kv_cache_config(packed=False))
+    assert isinstance(spec, CPUOffloadingSpec)
+
+    region = MagicMock()
+    region_ctor = MagicMock(return_value=region)
+    worker_ctor = MagicMock(return_value=MagicMock())
+    monkeypatch.setattr(cpu_spec_module.current_platform, "is_cuda_alike", lambda: True)
+    monkeypatch.setattr(cpu_spec_module, "SharedOffloadRegion", region_ctor)
+    monkeypatch.setattr(cpu_spec_module, "CPUOffloadingWorker", worker_ctor)
+    monkeypatch.setattr(
+        cpu_spec_module.torch.accelerator, "current_device_index", lambda: 5
+    )
+
+    kv_caches = MagicMock()
+    spec.create_worker(kv_caches)
+
+    region_ctor.assert_called_once_with(
+        engine_id=spec.config.engine_id,
+        num_blocks=spec.num_blocks,
+        rank=1,
+        kv_bytes_per_block=spec.kv_bytes_per_chunk,
+        cpu_page_size=spec.cpu_page_size_per_worker,
+    )
+    worker_ctor.assert_called_once_with(
+        kv_caches=kv_caches,
+        blocks_per_chunk=spec.blocks_per_chunk,
+        num_cpu_blocks=spec.num_blocks,
+        mmap_region=region,
+    )
+
+
+@pytest.mark.parametrize("num_blocks", [0, 2])
+def test_cpu_spec_create_worker_keeps_tensor_path_without_cuda_or_blocks(
+    monkeypatch, num_blocks: int
+):
+    import vllm.v1.kv_offload.cpu.spec as cpu_spec_module
+
+    alignment = SharedOffloadRegion.BLOCK_SIZE_ALIGNMENT
+    config = _make_layout_vllm_config(cpu_bytes_to_use=alignment * 2)
+    kv_cache_config = _make_sizing_kv_cache_config(packed=False)
+    if num_blocks == 0:
+        kv_cache_config.num_blocks = 0
+    spec = _create_spec(config, kv_cache_config)
+    assert isinstance(spec, CPUOffloadingSpec)
+
+    region_ctor = MagicMock()
+    worker_ctor = MagicMock(return_value=MagicMock())
+    monkeypatch.setattr(
+        cpu_spec_module.current_platform,
+        "is_cuda_alike",
+        lambda: num_blocks == 0,
+    )
+    monkeypatch.setattr(cpu_spec_module, "SharedOffloadRegion", region_ctor)
+    monkeypatch.setattr(cpu_spec_module, "CPUOffloadingWorker", worker_ctor)
+
+    kv_caches = MagicMock()
+    spec.create_worker(kv_caches)
+
+    region_ctor.assert_not_called()
+    worker_ctor.assert_called_once_with(
+        kv_caches=kv_caches,
+        blocks_per_chunk=spec.blocks_per_chunk,
+        num_cpu_blocks=spec.num_blocks,
+        mmap_region=None,
+    )
 
 
 def test_cpu_spec_rejects_partially_packed_tensor_layout():

--- a/vllm/distributed/device_communicators/cuda_wrapper.py
+++ b/vllm/distributed/device_communicators/cuda_wrapper.py
@@ -146,7 +146,11 @@ class CudaRTLibrary:
         return self.funcs["cudaGetErrorString"](error).decode("utf-8")
 
     def cudaGetLastError(self) -> int:
-        """Return and clear the calling thread's pending runtime error."""
+        """Return and clear the calling thread's pending runtime error.
+
+        Returns:
+            The CUDA or HIP runtime error code that was cleared.
+        """
         return int(self.funcs["cudaGetLastError"]())
 
     def cudaSetDevice(self, device: int) -> None:

--- a/vllm/distributed/device_communicators/cuda_wrapper.py
+++ b/vllm/distributed/device_communicators/cuda_wrapper.py
@@ -48,6 +48,8 @@ class CudaRTLibrary:
         Function("cudaDeviceReset", cudaError_t, []),
         # const char* 	cudaGetErrorString ( cudaError_t error )
         Function("cudaGetErrorString", ctypes.c_char_p, [cudaError_t]),
+        # cudaError_t cudaGetLastError ( void )
+        Function("cudaGetLastError", cudaError_t, []),
         # ​cudaError_t 	cudaMalloc ( void** devPtr, size_t size )
         Function(
             "cudaMalloc",
@@ -86,6 +88,7 @@ class CudaRTLibrary:
         "cudaDeviceSynchronize": "hipDeviceSynchronize",
         "cudaDeviceReset": "hipDeviceReset",
         "cudaGetErrorString": "hipGetErrorString",
+        "cudaGetLastError": "hipGetLastError",
         "cudaMalloc": "hipMalloc",
         "cudaFree": "hipFree",
         "cudaMemset": "hipMemset",
@@ -141,6 +144,10 @@ class CudaRTLibrary:
 
     def cudaGetErrorString(self, error: cudaError_t) -> str:
         return self.funcs["cudaGetErrorString"](error).decode("utf-8")
+
+    def cudaGetLastError(self) -> int:
+        """Return and clear the calling thread's pending runtime error."""
+        return int(self.funcs["cudaGetLastError"]())
 
     def cudaSetDevice(self, device: int) -> None:
         self.CUDART_CHECK(self.funcs["cudaSetDevice"](device))

--- a/vllm/v1/kv_offload/cpu/gpu_worker.py
+++ b/vllm/v1/kv_offload/cpu/gpu_worker.py
@@ -9,6 +9,7 @@ import numpy as np
 import torch
 
 from vllm import _custom_ops as ops
+from vllm.distributed.device_communicators.cuda_wrapper import CudaRTLibrary
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.triton_utils import HAS_TRITON, triton
@@ -141,6 +142,11 @@ def pin_mmap_region(region: SharedOffloadRegion) -> None:
             rank,
             result,
         )
+        # cudaHostRegister records its failure as the thread's pending runtime
+        # error. Consume it before continuing with the documented unpinned
+        # fallback, otherwise an unrelated subsequent CUDA call reports this
+        # stale error and aborts worker initialization.
+        CudaRTLibrary().cudaGetLastError()
     else:
         logger.debug(
             "cudaHostRegister rank=%d %.2f GB",

--- a/vllm/v1/kv_offload/cpu/gpu_worker.py
+++ b/vllm/v1/kv_offload/cpu/gpu_worker.py
@@ -32,6 +32,8 @@ from vllm.v1.kv_offload.cpu.swap_blocks_triton import (
 
 logger = init_logger(__name__)
 
+HOST_REGISTER_SEGMENT_BYTES = 256 << 20
+
 
 def _select_swap_blocks_fn(
     kv_cache_groups_data_refs: list[list[CanonicalKVCacheRef]],
@@ -122,7 +124,12 @@ def compute_sub_block_ptrs(
 
 
 def pin_mmap_region(region: SharedOffloadRegion) -> None:
-    """Register the entire mmap as CUDA pinned memory via cudaHostRegister."""
+    """Register the mmap as CUDA pinned memory.
+
+    Large virtual mappings can be rejected by ``cudaHostRegister`` even when
+    enough host memory is available. Preserve the single-registration fast
+    path, then retry large mappings as bounded, non-overlapping segments.
+    """
     if not current_platform.is_cuda_alike():
         logger.info(
             "Skipping mmap host registration on %s; cudaHostRegister is only "
@@ -134,26 +141,74 @@ def pin_mmap_region(region: SharedOffloadRegion) -> None:
     rank = region.rank
 
     base_ptr = region._base.data_ptr()
-    result = torch.cuda.cudart().cudaHostRegister(base_ptr, region.total_size_bytes, 0)
+    cudart = torch.cuda.cudart()
+    region._registered_host_ptrs.clear()
+    result = cudart.cudaHostRegister(base_ptr, region.total_size_bytes, 0)
     if result.value != 0:
-        logger.warning(
-            "cudaHostRegister failed for rank=%d (code=%d) — "
-            "transfers will still work but may be slower (unpinned DMA)",
-            rank,
-            result,
-        )
+        runtime = CudaRTLibrary()
         # cudaHostRegister records its failure as the thread's pending runtime
-        # error. Consume it before continuing with the documented unpinned
-        # fallback, otherwise an unrelated subsequent CUDA call reports this
-        # stale error and aborts worker initialization.
-        CudaRTLibrary().cudaGetLastError()
-    else:
-        logger.debug(
-            "cudaHostRegister rank=%d %.2f GB",
+        # error. Consume it before retrying or continuing unpinned.
+        runtime.cudaGetLastError()
+        if region.total_size_bytes <= HOST_REGISTER_SEGMENT_BYTES:
+            logger.warning(
+                "cudaHostRegister failed for rank=%d (code=%d); "
+                "transfers will continue with unpinned memory",
+                rank,
+                result,
+            )
+            return
+
+        registered_ptrs: list[int] = []
+        for offset in range(0, region.total_size_bytes, HOST_REGISTER_SEGMENT_BYTES):
+            ptr = base_ptr + offset
+            size = min(
+                HOST_REGISTER_SEGMENT_BYTES,
+                region.total_size_bytes - offset,
+            )
+            segment_result = cudart.cudaHostRegister(ptr, size, 0)
+            if segment_result.value == 0:
+                registered_ptrs.append(ptr)
+                continue
+
+            runtime.cudaGetLastError()
+            for registered_ptr in reversed(registered_ptrs):
+                unregister_result = cudart.cudaHostUnregister(registered_ptr)
+                if unregister_result.value != 0:
+                    runtime.cudaGetLastError()
+                    logger.warning(
+                        "cudaHostUnregister rollback failed for rank=%d "
+                        "ptr=%#x (code=%d)",
+                        rank,
+                        registered_ptr,
+                        unregister_result,
+                    )
+            logger.warning(
+                "Segmented cudaHostRegister failed for rank=%d offset=%d "
+                "size=%d (code=%d); transfers will continue with unpinned memory",
+                rank,
+                offset,
+                size,
+                segment_result,
+            )
+            return
+
+        region._registered_host_ptrs.extend(registered_ptrs)
+        region.is_pinned = True
+        logger.info(
+            "Registered rank=%d mmap as %d host-memory segments (%.2f GB)",
             rank,
+            len(registered_ptrs),
             region.total_size_bytes / 1e9,
         )
-        region.is_pinned = True
+        return
+
+    region._registered_host_ptrs.append(base_ptr)
+    region.is_pinned = True
+    logger.debug(
+        "cudaHostRegister rank=%d %.2f GB",
+        rank,
+        region.total_size_bytes / 1e9,
+    )
 
 
 def _new_descriptor_buffers(

--- a/vllm/v1/kv_offload/cpu/gpu_worker.py
+++ b/vllm/v1/kv_offload/cpu/gpu_worker.py
@@ -4,6 +4,7 @@ import functools
 import time
 from collections import deque
 from dataclasses import dataclass
+from math import lcm
 
 import numpy as np
 import torch
@@ -36,6 +37,73 @@ from vllm.v1.kv_offload.cpu.swap_blocks_triton import (
 logger = init_logger(__name__)
 
 HOST_REGISTER_SEGMENT_BYTES = 256 << 20
+HOST_REGISTER_ALIGNMENT_BYTES = 64 << 10
+
+
+def _split_copy_descriptors_at_host_boundaries(
+    src: np.ndarray,
+    dst: np.ndarray,
+    sizes: np.ndarray,
+    count: int,
+    *,
+    host_is_src: bool,
+    host_base: int,
+    segment_bytes: int,
+) -> int:
+    """Split raw copies that cross separately registered host segments.
+
+    ``cuMemcpyBatchAsync`` rejects a single descriptor spanning two adjacent
+    ``cudaHostRegister`` regions. Expand only those descriptors in place;
+    processing backwards keeps unread inputs intact.
+    """
+    assert segment_bytes > 0
+    host_ptrs = src if host_is_src else dst
+    host_offsets = host_ptrs[:count] - host_base
+    copy_sizes = sizes[:count]
+    assert np.all(host_offsets >= 0) and np.all(copy_sizes > 0)
+    part_counts = np.floor_divide(
+        np.remainder(host_offsets, segment_bytes) + copy_sizes + segment_bytes - 1,
+        segment_bytes,
+    )
+    expanded_count = int(part_counts.sum())
+
+    if expanded_count == count:
+        return count
+
+    assert expanded_count <= len(src)
+    write_idx = expanded_count
+    for read_idx in range(count - 1, -1, -1):
+        src_ptr = int(src[read_idx])
+        dst_ptr = int(dst[read_idx])
+        size = int(sizes[read_idx])
+        host_ptr = src_ptr if host_is_src else dst_ptr
+        part_count = int(part_counts[read_idx])
+        if part_count == 1:
+            write_idx -= 1
+            src[write_idx] = src_ptr
+            dst[write_idx] = dst_ptr
+            sizes[write_idx] = size
+            continue
+
+        parts: list[tuple[int, int]] = []
+        copied = 0
+        while copied < size:
+            host_offset = host_ptr + copied - host_base
+            bytes_to_boundary = segment_bytes - host_offset % segment_bytes
+            part_size = min(size - copied, bytes_to_boundary)
+            parts.append((copied, part_size))
+            copied += part_size
+
+        assert len(parts) == part_count
+        write_idx -= len(parts)
+        for part_idx, (offset, part_size) in enumerate(parts):
+            out_idx = write_idx + part_idx
+            src[out_idx] = src_ptr + offset
+            dst[out_idx] = dst_ptr + offset
+            sizes[out_idx] = part_size
+
+    assert write_idx == 0
+    return expanded_count
 
 
 def _select_swap_blocks_fn(
@@ -145,6 +213,7 @@ def pin_mmap_region(region: SharedOffloadRegion) -> None:
 
     base_ptr = region._base.data_ptr()
     region._registered_host_ptrs.clear()
+    region._host_register_segment_bytes = None
     result = register_host_memory(base_ptr, region.total_size_bytes)
     if result != 0:
         if region.total_size_bytes <= HOST_REGISTER_SEGMENT_BYTES:
@@ -156,11 +225,23 @@ def pin_mmap_region(region: SharedOffloadRegion) -> None:
             )
             return
 
+        # Keep every canonical KV row inside one registration. CUDA's batched
+        # memcpy API rejects a descriptor spanning two adjacent registrations.
+        row_stride = region._row_stride
+        # CUDA 13 rejects adjacent registrations when their split offset does
+        # not preserve its 64 KiB host-registration granularity. Align to both
+        # that boundary and a full KV row so neither registration ranges nor
+        # batch-copy descriptors straddle a split.
+        segment_alignment = lcm(row_stride, HOST_REGISTER_ALIGNMENT_BYTES)
+        alignments_per_segment = max(
+            1, HOST_REGISTER_SEGMENT_BYTES // segment_alignment
+        )
+        segment_bytes = alignments_per_segment * segment_alignment
         registered_ptrs: list[int] = []
-        for offset in range(0, region.total_size_bytes, HOST_REGISTER_SEGMENT_BYTES):
+        for offset in range(0, region.total_size_bytes, segment_bytes):
             ptr = base_ptr + offset
             size = min(
-                HOST_REGISTER_SEGMENT_BYTES,
+                segment_bytes,
                 region.total_size_bytes - offset,
             )
             segment_result = register_host_memory(ptr, size)
@@ -189,11 +270,14 @@ def pin_mmap_region(region: SharedOffloadRegion) -> None:
             return
 
         region._registered_host_ptrs.extend(registered_ptrs)
+        region._host_register_segment_bytes = segment_bytes
         region.is_pinned = True
         logger.info(
-            "Registered rank=%d mmap as %d host-memory segments (%.2f GB)",
+            "Registered rank=%d mmap as %d row-aligned host-memory segments "
+            "(segment=%d bytes, total=%.2f GB)",
             rank,
             len(registered_ptrs),
+            segment_bytes,
             region.total_size_bytes / 1e9,
         )
         return
@@ -236,6 +320,8 @@ class SingleDirectionOffloadingHandler:
         kv_cache_groups_data_refs: list[list[CanonicalKVCacheRef]],
         gpu_to_cpu: bool,
         mmap_region: SharedOffloadRegion | None = None,
+        segmented_host_base: int | None = None,
+        segmented_host_bytes: int | None = None,
     ):
         """
         Initialize a SingleDirectionOffloadingHandler.
@@ -275,6 +361,21 @@ class SingleDirectionOffloadingHandler:
         self._swap_blocks_batch = _select_swap_blocks_fn(
             kv_cache_groups_data_refs, gpu_to_cpu
         )
+        self._segmented_host_base = segmented_host_base
+        self._segmented_host_bytes = segmented_host_bytes
+        assert (segmented_host_base is None) == (segmented_host_bytes is None)
+        page_sizes = [
+            data_ref.page_size_bytes
+            for group in kv_cache_groups_data_refs
+            for data_ref in group
+        ]
+        self._descriptor_capacity_multiplier = 1
+        if segmented_host_base is not None and page_sizes:
+            assert segmented_host_bytes is not None
+            max_page_size = max(page_sizes)
+            self._descriptor_capacity_multiplier = 1 + cdiv(
+                max_page_size - 1, segmented_host_bytes
+            )
 
         # GPU blocks may be smaller
         # cpu_page_size = gpu_page_size * blocks_per_chunk.
@@ -344,13 +445,16 @@ class SingleDirectionOffloadingHandler:
             num_copy_ops += group_size * len(group_data_refs)
 
         # reuse a pooled buffer set, growing it if this transfer needs more room
+        descriptor_capacity = num_copy_ops * self._descriptor_capacity_multiplier
         batch_src, batch_dst, batch_sizes = (
             self._buffer_pool.pop()
             if self._buffer_pool
-            else _new_descriptor_buffers(num_copy_ops)
+            else _new_descriptor_buffers(descriptor_capacity)
         )
-        if batch_src.numel() < num_copy_ops:
-            batch_src, batch_dst, batch_sizes = _new_descriptor_buffers(num_copy_ops)
+        if batch_src.numel() < descriptor_capacity:
+            batch_src, batch_dst, batch_sizes = _new_descriptor_buffers(
+                descriptor_capacity
+            )
 
         src = batch_src[:num_copy_ops]
         dst = batch_dst[:num_copy_ops]
@@ -415,6 +519,21 @@ class SingleDirectionOffloadingHandler:
         assert src_offset == num_src_blocks
         assert dst_offset == num_dst_blocks
         assert op_idx == num_copy_ops
+
+        if self._segmented_host_base is not None and num_copy_ops > 0:
+            assert self._segmented_host_bytes is not None
+            num_copy_ops = _split_copy_descriptors_at_host_boundaries(
+                batch_src.numpy(),
+                batch_dst.numpy(),
+                batch_sizes.numpy(),
+                num_copy_ops,
+                host_is_src=not self.gpu_to_cpu,
+                host_base=self._segmented_host_base,
+                segment_bytes=self._segmented_host_bytes,
+            )
+            src = batch_src[:num_copy_ops]
+            dst = batch_dst[:num_copy_ops]
+            sizes = batch_sizes[:num_copy_ops]
 
         stream = (
             self._stream_pool.pop() if self._stream_pool else current_platform.Stream()
@@ -537,6 +656,8 @@ class CPUOffloadingWorker(OffloadingWorker):
         logger.info("Allocating %d CPU tensors...", len(kv_caches.tensors))
         if mmap_region is not None and pin_memory:
             pin_mmap_region(mmap_region)
+        segmented_host_base = None
+        segmented_host_bytes = None
 
         gpu_tensors: list[torch.Tensor] = []
         cpu_tensors: list[torch.Tensor] = []
@@ -568,6 +689,15 @@ class CPUOffloadingWorker(OffloadingWorker):
             gpu_tensors.append(gpu_tensor)
             cpu_tensors.append(cpu_tensor)
 
+        if mmap_region is not None and len(mmap_region._registered_host_ptrs) > 1:
+            registration_bytes = mmap_region._host_register_segment_bytes
+            assert registration_bytes is not None
+            # Row-aligned registrations are the zero-overhead fast path. Keep
+            # the descriptor splitter only for alternate layouts.
+            if any(registration_bytes % tensor.stride(0) for tensor in cpu_tensors):
+                segmented_host_base = mmap_region._base.data_ptr()
+                segmented_host_bytes = registration_bytes
+
         self._store_handler = SingleDirectionOffloadingHandler(
             gpu_tensors=gpu_tensors,
             cpu_tensors=cpu_tensors,
@@ -575,6 +705,8 @@ class CPUOffloadingWorker(OffloadingWorker):
             kv_cache_groups_data_refs=kv_caches.group_data_refs,
             gpu_to_cpu=True,
             mmap_region=mmap_region,
+            segmented_host_base=segmented_host_base,
+            segmented_host_bytes=segmented_host_bytes,
         )
 
         self._load_handler = SingleDirectionOffloadingHandler(
@@ -583,6 +715,8 @@ class CPUOffloadingWorker(OffloadingWorker):
             blocks_per_chunk=blocks_per_chunk,
             kv_cache_groups_data_refs=kv_caches.group_data_refs,
             gpu_to_cpu=False,
+            segmented_host_base=segmented_host_base,
+            segmented_host_bytes=segmented_host_bytes,
         )
 
     def submit_store(

--- a/vllm/v1/kv_offload/cpu/gpu_worker.py
+++ b/vllm/v1/kv_offload/cpu/gpu_worker.py
@@ -9,7 +9,6 @@ import numpy as np
 import torch
 
 from vllm import _custom_ops as ops
-from vllm.distributed.device_communicators.cuda_wrapper import CudaRTLibrary
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.triton_utils import HAS_TRITON, triton
@@ -23,6 +22,10 @@ from vllm.v1.kv_offload.base import (
     LoadStoreSpec,
     OffloadingWorker,
     TransferResult,
+)
+from vllm.v1.kv_offload.cpu.host_mem_ops import (
+    register_host_memory,
+    unregister_host_memory,
 )
 from vllm.v1.kv_offload.cpu.shared_offload_region import SharedOffloadRegion
 from vllm.v1.kv_offload.cpu.swap_blocks_triton import (
@@ -141,14 +144,9 @@ def pin_mmap_region(region: SharedOffloadRegion) -> None:
     rank = region.rank
 
     base_ptr = region._base.data_ptr()
-    cudart = torch.cuda.cudart()
     region._registered_host_ptrs.clear()
-    result = cudart.cudaHostRegister(base_ptr, region.total_size_bytes, 0)
-    if result.value != 0:
-        runtime = CudaRTLibrary()
-        # cudaHostRegister records its failure as the thread's pending runtime
-        # error. Consume it before retrying or continuing unpinned.
-        runtime.cudaGetLastError()
+    result = register_host_memory(base_ptr, region.total_size_bytes)
+    if result != 0:
         if region.total_size_bytes <= HOST_REGISTER_SEGMENT_BYTES:
             logger.warning(
                 "cudaHostRegister failed for rank=%d (code=%d); "
@@ -165,16 +163,14 @@ def pin_mmap_region(region: SharedOffloadRegion) -> None:
                 HOST_REGISTER_SEGMENT_BYTES,
                 region.total_size_bytes - offset,
             )
-            segment_result = cudart.cudaHostRegister(ptr, size, 0)
-            if segment_result.value == 0:
+            segment_result = register_host_memory(ptr, size)
+            if segment_result == 0:
                 registered_ptrs.append(ptr)
                 continue
 
-            runtime.cudaGetLastError()
             for registered_ptr in reversed(registered_ptrs):
-                unregister_result = cudart.cudaHostUnregister(registered_ptr)
-                if unregister_result.value != 0:
-                    runtime.cudaGetLastError()
+                unregister_result = unregister_host_memory(registered_ptr)
+                if unregister_result != 0:
                     logger.warning(
                         "cudaHostUnregister rollback failed for rank=%d "
                         "ptr=%#x (code=%d)",

--- a/vllm/v1/kv_offload/cpu/host_mem_ops.py
+++ b/vllm/v1/kv_offload/cpu/host_mem_ops.py
@@ -22,6 +22,13 @@ def register_host_memory(ptr: int, size: int) -> int:
     can make a later unrelated PyTorch operation fail even when offload falls
     back to pageable memory. Driver API failures are returned directly and do
     not contaminate that runtime state.
+
+    Args:
+        ptr: Base address of the host-memory region.
+        size: Region size in bytes.
+
+    Returns:
+        The CUDA or HIP registration error code.
     """
     if current_platform.is_cuda():
         (result,) = _get_cuda_driver().cuMemHostRegister(ptr, size, 0)
@@ -38,7 +45,14 @@ def register_host_memory(ptr: int, size: int) -> int:
 
 
 def unregister_host_memory(ptr: int) -> int:
-    """Unregister host memory and return a CUDA/HIP error code."""
+    """Unregister host memory and return a CUDA/HIP error code.
+
+    Args:
+        ptr: Base address passed to :func:`register_host_memory`.
+
+    Returns:
+        The CUDA or HIP unregistration error code.
+    """
     if current_platform.is_cuda():
         (result,) = _get_cuda_driver().cuMemHostUnregister(ptr)
         return int(result.value)

--- a/vllm/v1/kv_offload/cpu/host_mem_ops.py
+++ b/vllm/v1/kv_offload/cpu/host_mem_ops.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Low-level host-memory registration helpers for CPU KV offload."""
+
+import torch
+
+from vllm.distributed.device_communicators.cuda_wrapper import CudaRTLibrary
+from vllm.platforms import current_platform
+
+
+def _get_cuda_driver():
+    from cuda.bindings import driver
+
+    return driver
+
+
+def register_host_memory(ptr: int, size: int) -> int:
+    """Register host memory and return a CUDA/HIP error code.
+
+    CUDA uses the driver API deliberately. A failed runtime
+    ``cudaHostRegister`` updates the calling thread's last-error state, which
+    can make a later unrelated PyTorch operation fail even when offload falls
+    back to pageable memory. Driver API failures are returned directly and do
+    not contaminate that runtime state.
+    """
+    if current_platform.is_cuda():
+        (result,) = _get_cuda_driver().cuMemHostRegister(ptr, size, 0)
+        return int(result.value)
+
+    cudart = torch.cuda.cudart()
+    result = cudart.cudaHostRegister(ptr, size, 0)
+    code = int(result.value)
+    if code != 0:
+        # HIP uses the runtime API, so consume its expected registration error
+        # before the caller continues with pageable memory.
+        CudaRTLibrary().cudaGetLastError()
+    return code
+
+
+def unregister_host_memory(ptr: int) -> int:
+    """Unregister host memory and return a CUDA/HIP error code."""
+    if current_platform.is_cuda():
+        (result,) = _get_cuda_driver().cuMemHostUnregister(ptr)
+        return int(result.value)
+
+    cudart = torch.cuda.cudart()
+    result = cudart.cudaHostUnregister(ptr)
+    code = int(result.value)
+    if code != 0:
+        CudaRTLibrary().cudaGetLastError()
+    return code

--- a/vllm/v1/kv_offload/cpu/shared_offload_region.py
+++ b/vllm/v1/kv_offload/cpu/shared_offload_region.py
@@ -8,6 +8,7 @@ import torch
 
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
+from vllm.v1.kv_offload.cpu.host_mem_ops import unregister_host_memory
 
 logger = init_logger(__name__)
 
@@ -174,16 +175,10 @@ class SharedOffloadRegion:
     def cleanup(self) -> None:
         if self.is_pinned and self._base is not None:
             if current_platform.is_cuda_alike():
-                from vllm.distributed.device_communicators.cuda_wrapper import (
-                    CudaRTLibrary,
-                )
-
-                cudart = torch.cuda.cudart()
                 registered_ptrs = self._registered_host_ptrs or [self._base.data_ptr()]
                 for ptr in reversed(registered_ptrs):
-                    result = cudart.cudaHostUnregister(ptr)
-                    if result.value != 0:
-                        CudaRTLibrary().cudaGetLastError()
+                    result = unregister_host_memory(ptr)
+                    if result != 0:
                         logger.warning(
                             "cudaHostUnregister failed for rank=%d ptr=%#x (code=%d)",
                             self.rank,

--- a/vllm/v1/kv_offload/cpu/shared_offload_region.py
+++ b/vllm/v1/kv_offload/cpu/shared_offload_region.py
@@ -134,6 +134,7 @@ class SharedOffloadRegion:
         self._base = torch.frombuffer(memoryview(self.mmap_obj), dtype=torch.int8)
         self._views: list[torch.Tensor] = []
         self._registered_host_ptrs: list[int] = []
+        self._host_register_segment_bytes: int | None = None
         self.is_pinned: bool = False
 
     def _unlink_after_worker_mappings(
@@ -252,6 +253,7 @@ class SharedOffloadRegion:
                             result,
                         )
             self._registered_host_ptrs.clear()
+            self._host_register_segment_bytes = None
             self.is_pinned = False
         # Release views before _base: each view holds a _base reference and a
         # direct StorageImpl reference.  Freeing views first lets both refcounts

--- a/vllm/v1/kv_offload/cpu/shared_offload_region.py
+++ b/vllm/v1/kv_offload/cpu/shared_offload_region.py
@@ -115,6 +115,7 @@ class SharedOffloadRegion:
 
         self._base = torch.frombuffer(memoryview(self.mmap_obj), dtype=torch.int8)
         self._views: list[torch.Tensor] = []
+        self._registered_host_ptrs: list[int] = []
         self.is_pinned: bool = False
 
     def create_next_view(self, tensor_page_size: int) -> torch.Tensor:
@@ -173,14 +174,23 @@ class SharedOffloadRegion:
     def cleanup(self) -> None:
         if self.is_pinned and self._base is not None:
             if current_platform.is_cuda_alike():
-                base_ptr = self._base.data_ptr()
-                result = torch.cuda.cudart().cudaHostUnregister(base_ptr)
-                if result.value != 0:
-                    logger.warning(
-                        "cudaHostUnregister failed for rank=%d (code=%d)",
-                        self.rank,
-                        result,
-                    )
+                from vllm.distributed.device_communicators.cuda_wrapper import (
+                    CudaRTLibrary,
+                )
+
+                cudart = torch.cuda.cudart()
+                registered_ptrs = self._registered_host_ptrs or [self._base.data_ptr()]
+                for ptr in reversed(registered_ptrs):
+                    result = cudart.cudaHostUnregister(ptr)
+                    if result.value != 0:
+                        CudaRTLibrary().cudaGetLastError()
+                        logger.warning(
+                            "cudaHostUnregister failed for rank=%d ptr=%#x (code=%d)",
+                            self.rank,
+                            ptr,
+                            result,
+                        )
+            self._registered_host_ptrs.clear()
             self.is_pinned = False
         # Release views before _base: each view holds a _base reference and a
         # direct StorageImpl reference.  Freeing views first lets both refcounts

--- a/vllm/v1/kv_offload/cpu/shared_offload_region.py
+++ b/vllm/v1/kv_offload/cpu/shared_offload_region.py
@@ -50,6 +50,7 @@ class SharedOffloadRegion:
         *,
         unlink_after_workers_map: bool = False,
         num_workers: int | None = None,
+        prefault: bool = True,
     ) -> None:
         self.page_size = mmap.PAGESIZE
         assert kv_bytes_per_block % self.page_size == 0
@@ -69,6 +70,13 @@ class SharedOffloadRegion:
         self.mmap_path = f"/dev/shm/vllm_offload_{engine_id}.mmap"
         self._mapping_marker: str | None = None
         self._creator = False  # set True only if this worker creates the file
+        self.fd: int | None = None
+        self.mmap_obj: mmap.mmap | None = None
+        self._base: torch.Tensor | None = None
+        self._views: list[torch.Tensor] = []
+        self._registered_host_ptrs: list[int] = []
+        self._host_register_segment_bytes: int | None = None
+        self.is_pinned: bool = False
         self.rank = rank
         if rank is not None:
             # byte offset to this worker's first slot within each block row
@@ -76,66 +84,67 @@ class SharedOffloadRegion:
             # exclusive upper bound for this worker's area within each row
             self._worker_area_end = (rank + 1) * cpu_page_size
         try:
-            # Exclusive create — only one worker succeeds
-            self.fd: int | None = os.open(
-                self.mmap_path, os.O_CREAT | os.O_EXCL | os.O_RDWR, 0o600
-            )
-            os.ftruncate(self.fd, self.total_size_bytes)
-            self._creator = True
-            logger.info(
-                "Created mmap file %s (%.2f GB)",
-                self.mmap_path,
-                self.total_size_bytes / 1e9,
-            )
-        except FileExistsError:
-            self.fd = os.open(self.mmap_path, os.O_RDWR)
-            _wait_for_file_size(self.fd, self.total_size_bytes)
-            logger.info("Opened existing mmap file %s", self.mmap_path)
-
-        self.mmap_obj: mmap.mmap | None = mmap.mmap(
-            self.fd,
-            self.total_size_bytes,
-            flags=mmap.MAP_SHARED,
-            prot=mmap.PROT_READ | mmap.PROT_WRITE,
-        )
-
-        if unlink_after_workers_map and rank is not None:
-            assert num_workers is not None
-            self._unlink_after_worker_mappings(num_workers)
-
-        # MADV_POPULATE_WRITE was added in Linux 5.14 (value 23).
-        _MADV_POPULATE_WRITE = getattr(mmap, "MADV_POPULATE_WRITE", 23)
-        if rank is not None:
-            # Populate only this worker's pages (one slot per block row).
-            worker_offset = rank * cpu_page_size
-            _t0 = time.perf_counter()
-            page_size = self.page_size
-            for block in range(num_blocks):
-                raw_offset = block * self._row_stride + worker_offset
-                aligned_offset = (raw_offset // page_size) * page_size
-                end = raw_offset + cpu_page_size
-                aligned_length = end - aligned_offset
-                self.mmap_obj.madvise(
-                    _MADV_POPULATE_WRITE, aligned_offset, aligned_length
+            try:
+                # Exclusive create — only one worker succeeds.
+                self.fd = os.open(
+                    self.mmap_path, os.O_CREAT | os.O_EXCL | os.O_RDWR, 0o600
                 )
-            logger.debug(
-                "MADV_POPULATE_WRITE loop: %d blocks in %.3f s",
-                num_blocks,
-                time.perf_counter() - _t0,
-            )
-        else:
-            # No rank — populate the entire shared region in one call.
-            _t0 = time.perf_counter()
-            self.mmap_obj.madvise(_MADV_POPULATE_WRITE, 0, self.total_size_bytes)
-            logger.debug(
-                "MADV_POPULATE_WRITE entire region: %.3f s", time.perf_counter() - _t0
-            )
+                os.ftruncate(self.fd, self.total_size_bytes)
+                self._creator = True
+                logger.info(
+                    "Created mmap file %s (%.2f GB)",
+                    self.mmap_path,
+                    self.total_size_bytes / 1e9,
+                )
+            except FileExistsError:
+                self.fd = os.open(self.mmap_path, os.O_RDWR)
+                _wait_for_file_size(self.fd, self.total_size_bytes)
+                logger.info("Opened existing mmap file %s", self.mmap_path)
 
-        self._base = torch.frombuffer(memoryview(self.mmap_obj), dtype=torch.int8)
-        self._views: list[torch.Tensor] = []
-        self._registered_host_ptrs: list[int] = []
-        self._host_register_segment_bytes: int | None = None
-        self.is_pinned: bool = False
+            assert self.fd is not None
+            mmap_obj = mmap.mmap(
+                self.fd,
+                self.total_size_bytes,
+                flags=mmap.MAP_SHARED,
+                prot=mmap.PROT_READ | mmap.PROT_WRITE,
+            )
+            self.mmap_obj = mmap_obj
+
+            if unlink_after_workers_map and rank is not None:
+                assert num_workers is not None
+                self._unlink_after_worker_mappings(num_workers)
+
+            if prefault:
+                # MADV_POPULATE_WRITE was added in Linux 5.14 (value 23).
+                populate_write = getattr(mmap, "MADV_POPULATE_WRITE", 23)
+                if rank is not None:
+                    # Populate only this worker's pages (one slot per block row).
+                    worker_offset = rank * cpu_page_size
+                    start = time.perf_counter()
+                    page_size = self.page_size
+                    for block in range(num_blocks):
+                        raw_offset = block * self._row_stride + worker_offset
+                        aligned_offset = (raw_offset // page_size) * page_size
+                        end = raw_offset + cpu_page_size
+                        aligned_length = end - aligned_offset
+                        mmap_obj.madvise(populate_write, aligned_offset, aligned_length)
+                    logger.debug(
+                        "MADV_POPULATE_WRITE loop: %d blocks in %.3f s",
+                        num_blocks,
+                        time.perf_counter() - start,
+                    )
+                else:
+                    start = time.perf_counter()
+                    mmap_obj.madvise(populate_write, 0, self.total_size_bytes)
+                    logger.debug(
+                        "MADV_POPULATE_WRITE entire region: %.3f s",
+                        time.perf_counter() - start,
+                    )
+
+            self._base = torch.frombuffer(memoryview(mmap_obj), dtype=torch.int8)
+        except BaseException:
+            self.cleanup()
+            raise
 
     def _unlink_after_worker_mappings(
         self, num_workers: int, timeout: float = 30.0
@@ -146,6 +155,9 @@ class SharedOffloadRegion:
         Once every rank owns a mapping, unlinking is safe: POSIX keeps the
         pages alive until the last mapping closes and releases them even when
         a worker is terminated before Python cleanup runs.
+
+        Raises:
+            TimeoutError: If not every worker publishes its mapping marker.
         """
         assert self.rank is not None
         marker_prefix = f"{self.mmap_path}.mapped."
@@ -162,24 +174,28 @@ class SharedOffloadRegion:
             return
 
         marker_paths = [f"{marker_prefix}{rank}" for rank in range(num_workers)]
-        deadline = time.monotonic() + timeout
-        while not all(os.path.exists(path) for path in marker_paths):
-            if time.monotonic() > deadline:
-                missing = [path for path in marker_paths if not os.path.exists(path)]
-                raise TimeoutError(
-                    "Timed out waiting for worker mmap markers: " + ", ".join(missing)
-                )
-            time.sleep(0.005)
-
         try:
-            os.unlink(self.mmap_path)
-            logger.info(
-                "Unlinked mmap file %s after %d workers mapped it",
-                self.mmap_path,
-                num_workers,
-            )
-        except FileNotFoundError:
-            pass
+            deadline = time.monotonic() + timeout
+            while not all(os.path.exists(path) for path in marker_paths):
+                if time.monotonic() > deadline:
+                    missing = [
+                        path for path in marker_paths if not os.path.exists(path)
+                    ]
+                    raise TimeoutError(
+                        "Timed out waiting for worker mmap markers: "
+                        + ", ".join(missing)
+                    )
+                time.sleep(0.005)
+
+            try:
+                os.unlink(self.mmap_path)
+                logger.info(
+                    "Unlinked mmap file %s after %d workers mapped it",
+                    self.mmap_path,
+                    num_workers,
+                )
+            except FileNotFoundError:
+                pass
         finally:
             for path in marker_paths:
                 with contextlib.suppress(FileNotFoundError):
@@ -209,6 +225,7 @@ class SharedOffloadRegion:
             tensor_page_size: Bytes per block for this  tensor.
         """
         assert self.rank is not None
+        assert self._base is not None
         new_offset = self._worker_offset + tensor_page_size
         assert new_offset <= self._worker_area_end, (
             f"Worker offset {new_offset} exceeds worker area end "
@@ -231,6 +248,7 @@ class SharedOffloadRegion:
         Shape: (num_blocks, row_stride_bytes). Secondary tiers address
         block *b* as ``view[b]``.
         """
+        assert self._base is not None
         kv_tensor = self._base.view(self.num_blocks, self._row_stride)
         np_arr = kv_tensor.numpy()
         assert np_arr.ctypes.data == self._base.data_ptr(), (

--- a/vllm/v1/kv_offload/cpu/shared_offload_region.py
+++ b/vllm/v1/kv_offload/cpu/shared_offload_region.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import contextlib
 import mmap
 import os
 import time
@@ -46,15 +47,27 @@ class SharedOffloadRegion:
         rank: int | None,
         kv_bytes_per_block: int,
         cpu_page_size: int,
+        *,
+        unlink_after_workers_map: bool = False,
+        num_workers: int | None = None,
     ) -> None:
         self.page_size = mmap.PAGESIZE
         assert kv_bytes_per_block % self.page_size == 0
+        if unlink_after_workers_map:
+            if num_workers is None or num_workers <= 0:
+                raise ValueError(
+                    "num_workers must be positive when "
+                    "unlink_after_workers_map is enabled"
+                )
+            if rank is not None and not 0 <= rank < num_workers:
+                raise ValueError(f"rank {rank} is outside num_workers={num_workers}")
 
         self.num_blocks = num_blocks
         self._row_stride = kv_bytes_per_block
         self.total_size_bytes = self.num_blocks * self._row_stride
 
         self.mmap_path = f"/dev/shm/vllm_offload_{engine_id}.mmap"
+        self._mapping_marker: str | None = None
         self._creator = False  # set True only if this worker creates the file
         self.rank = rank
         if rank is not None:
@@ -85,6 +98,10 @@ class SharedOffloadRegion:
             flags=mmap.MAP_SHARED,
             prot=mmap.PROT_READ | mmap.PROT_WRITE,
         )
+
+        if unlink_after_workers_map and rank is not None:
+            assert num_workers is not None
+            self._unlink_after_worker_mappings(num_workers)
 
         # MADV_POPULATE_WRITE was added in Linux 5.14 (value 23).
         _MADV_POPULATE_WRITE = getattr(mmap, "MADV_POPULATE_WRITE", 23)
@@ -118,6 +135,55 @@ class SharedOffloadRegion:
         self._views: list[torch.Tensor] = []
         self._registered_host_ptrs: list[int] = []
         self.is_pinned: bool = False
+
+    def _unlink_after_worker_mappings(
+        self, num_workers: int, timeout: float = 30.0
+    ) -> None:
+        """Make the mmap anonymous after every worker has mapped the file.
+
+        The pathname is needed only while workers rendezvous during startup.
+        Once every rank owns a mapping, unlinking is safe: POSIX keeps the
+        pages alive until the last mapping closes and releases them even when
+        a worker is terminated before Python cleanup runs.
+        """
+        assert self.rank is not None
+        marker_prefix = f"{self.mmap_path}.mapped."
+        marker_path = f"{marker_prefix}{self.rank}"
+        marker_fd = os.open(marker_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+        os.close(marker_fd)
+        self._mapping_marker = marker_path
+
+        # Rank 0 is the coordinator, independent of which rank created the
+        # backing file. Other ranks can continue as soon as their mapping is
+        # established; rank 0 keeps the pathname available until all markers
+        # are visible.
+        if self.rank != 0:
+            return
+
+        marker_paths = [f"{marker_prefix}{rank}" for rank in range(num_workers)]
+        deadline = time.monotonic() + timeout
+        while not all(os.path.exists(path) for path in marker_paths):
+            if time.monotonic() > deadline:
+                missing = [path for path in marker_paths if not os.path.exists(path)]
+                raise TimeoutError(
+                    "Timed out waiting for worker mmap markers: " + ", ".join(missing)
+                )
+            time.sleep(0.005)
+
+        try:
+            os.unlink(self.mmap_path)
+            logger.info(
+                "Unlinked mmap file %s after %d workers mapped it",
+                self.mmap_path,
+                num_workers,
+            )
+        except FileNotFoundError:
+            pass
+        finally:
+            for path in marker_paths:
+                with contextlib.suppress(FileNotFoundError):
+                    os.unlink(path)
+            self._mapping_marker = None
 
     def create_next_view(self, tensor_page_size: int) -> torch.Tensor:
         """Allocate a strided int8 view for this worker, one canonical tensor.
@@ -206,10 +272,16 @@ class SharedOffloadRegion:
             except Exception:
                 logger.warning("Failed to close fd %s", self.fd, exc_info=True)
             self.fd = None
+        if self._mapping_marker is not None:
+            with contextlib.suppress(FileNotFoundError):
+                os.unlink(self._mapping_marker)
+            self._mapping_marker = None
         if self._creator and getattr(self, "mmap_path", None):
             try:
                 os.unlink(self.mmap_path)
                 logger.info("Removed mmap file %s", self.mmap_path)
+            except FileNotFoundError:
+                pass
             except Exception:
                 logger.warning(
                     "Failed to unlink path %s", self.mmap_path, exc_info=True

--- a/vllm/v1/kv_offload/cpu/spec.py
+++ b/vllm/v1/kv_offload/cpu/spec.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from typing import Any
 
+import torch
 from typing_extensions import override
 
 from vllm.platforms import current_platform
@@ -20,10 +21,11 @@ from vllm.v1.kv_offload.config import OffloadingConfig
 from vllm.v1.kv_offload.cpu.common import CPUOffloadingMetrics
 from vllm.v1.kv_offload.cpu.gpu_worker import CPUOffloadingWorker
 from vllm.v1.kv_offload.cpu.manager import CPUOffloadingManager
+from vllm.v1.kv_offload.cpu.shared_offload_region import SharedOffloadRegion
 
 
 class CPUOffloadingSpec(OffloadingSpec):
-    BLOCK_SIZE_ALIGNMENT = 1
+    BLOCK_SIZE_ALIGNMENT = SharedOffloadRegion.BLOCK_SIZE_ALIGNMENT
 
     @classmethod
     def build_metric_definitions(
@@ -133,10 +135,22 @@ class CPUOffloadingSpec(OffloadingSpec):
         return self._manager
 
     def create_worker(self, kv_caches: CanonicalKVCaches) -> CPUOffloadingWorker:
+        mmap_region: SharedOffloadRegion | None = None
+        if current_platform.is_cuda_alike() and self.num_blocks > 0:
+            world_size = self.config.parallel.world_size
+            rank = torch.accelerator.current_device_index() % world_size
+            mmap_region = SharedOffloadRegion(
+                engine_id=self.config.engine_id,
+                num_blocks=self.num_blocks,
+                rank=rank,
+                kv_bytes_per_block=self.kv_bytes_per_chunk,
+                cpu_page_size=self.cpu_page_size_per_worker,
+            )
         return CPUOffloadingWorker(
             kv_caches=kv_caches,
             blocks_per_chunk=self.blocks_per_chunk,
             num_cpu_blocks=self.num_blocks,
+            mmap_region=mmap_region,
         )
 
     @override

--- a/vllm/v1/kv_offload/cpu/spec.py
+++ b/vllm/v1/kv_offload/cpu/spec.py
@@ -145,6 +145,8 @@ class CPUOffloadingSpec(OffloadingSpec):
                 rank=rank,
                 kv_bytes_per_block=self.kv_bytes_per_chunk,
                 cpu_page_size=self.cpu_page_size_per_worker,
+                unlink_after_workers_map=True,
+                num_workers=world_size,
             )
         return CPUOffloadingWorker(
             kv_caches=kv_caches,

--- a/vllm/v1/kv_offload/tiering/spec.py
+++ b/vllm/v1/kv_offload/tiering/spec.py
@@ -179,8 +179,10 @@ class TieringOffloadingSpec(CPUOffloadingSpec):
                 rank=None,
                 kv_bytes_per_block=self.kv_bytes_per_chunk,
                 cpu_page_size=self.cpu_page_size_per_worker,
-                unlink_after_workers_map=True,
-                num_workers=self.config.parallel.world_size,
+                # Workers already prefault every row. Repeating that work over
+                # the full region can fail for very large L1 tiers and provides
+                # no benefit to the scheduler's zero-copy secondary-tier view.
+                prefault=False,
             )
             self._scheduler_mmap = scheduler_mmap
 
@@ -249,8 +251,6 @@ class TieringOffloadingSpec(CPUOffloadingSpec):
             rank=rank,
             kv_bytes_per_block=self.kv_bytes_per_chunk,
             cpu_page_size=self.cpu_page_size_per_worker,
-            unlink_after_workers_map=True,
-            num_workers=world_size,
         )
         return CPUOffloadingWorker(
             kv_caches=kv_caches,

--- a/vllm/v1/kv_offload/tiering/spec.py
+++ b/vllm/v1/kv_offload/tiering/spec.py
@@ -179,6 +179,8 @@ class TieringOffloadingSpec(CPUOffloadingSpec):
                 rank=None,
                 kv_bytes_per_block=self.kv_bytes_per_chunk,
                 cpu_page_size=self.cpu_page_size_per_worker,
+                unlink_after_workers_map=True,
+                num_workers=self.config.parallel.world_size,
             )
             self._scheduler_mmap = scheduler_mmap
 
@@ -247,6 +249,8 @@ class TieringOffloadingSpec(CPUOffloadingSpec):
             rank=rank,
             kv_bytes_per_block=self.kv_bytes_per_chunk,
             cpu_page_size=self.cpu_page_size_per_worker,
+            unlink_after_workers_map=True,
+            num_workers=world_size,
         )
         return CPUOffloadingWorker(
             kv_caches=kv_caches,


### PR DESCRIPTION
## Purpose

Backport the allocation semantics of merged upstream vLLM PR #50094 onto
`dev/gilded-gnosis`. Native `CPUOffloadingSpec` currently allocates one large
pinned PyTorch tensor per worker; PyTorch can round that allocation to a
power-of-two size, so values such as `--kv-offloading-size 40` may reserve
substantially more host memory than requested.

The CUDA/ROCm path now uses the existing page-aligned `SharedOffloadRegion`
mmap and passes its worker slot to `CPUOffloadingWorker`. Empty caches and
non-CUDA-like platforms retain the tensor path. This changes only allocation
backing; it does not add TP deduplication or change stored KV bytes.

## Host registration

Some hosts intermittently reject one large host-registration request for
native L1 regions above roughly 96-128 GiB even though smaller registrations
succeed. Calling the CUDA runtime `cudaHostRegister` for that expected failure
also updates the thread-local CUDA runtime error state. A later unrelated
PyTorch operation can then report `invalid argument`, incorrectly implicating
the operation that merely observed the stale error.

The registration contract is now:

1. On CUDA, use driver API `cuMemHostRegister`/`cuMemHostUnregister`. Driver
   failures are returned directly and do not contaminate CUDA runtime state.
2. On ROCm, retain the runtime API and explicitly consume expected failures.
3. Try the existing whole-region registration first.
4. If a large mapping is rejected, retry it as bounded segments.
5. Align every segment boundary to both a complete interleaved KV row and
   CUDA's 64 KiB host-registration granularity.
6. Track every accepted base pointer and unregister those exact ranges in
   reverse order.
7. If a segment fails, roll back accepted segments before continuing with the
   documented pageable-memory fallback.

The row alignment is required for correctness, not padding. A production
failure and an isolated CUDA reproducer showed that `cuMemcpyBatchAsync`
returns `CUDA_ERROR_INVALID_VALUE` when one descriptor crosses two adjacent,
separately registered host regions. The canonical DS4 layout now keeps each
KV row inside one registration, adding no transfer-time branch or copy. A
descriptor splitter remains as a bounded fallback for alternate layouts that
cannot satisfy the row-aligned contract.

This does not hide registration errors, add mapped tail padding, or change the
mmap size. Segmentation is used only after whole-region registration fails.

This supersedes the allocation-only approach from upstream #48436. Upstream
#50094 is based on newer code and does not cherry-pick cleanly onto GG because
the local KV layout configuration and tests have diverged.

## Validation

- Focused driver/runtime registration, row-aligned segmentation, descriptor
  splitting, rollback, and reverse-cleanup tests: **8 passed**.
- Shared-region lifecycle suite: **28 passed**.
- `tests/v1/kv_offload/test_factory.py`: **39 passed**.
- `ruff check`, `ruff format --check`, and `git diff --check`: passed.
- Real CUDA registration tests:
  - 2 GiB mapping: 8 adjacent segments registered, exercised, and
    unregistered successfully;
  - 128 GiB mapping: 512 adjacent segments registered, exercised, and
    unregistered successfully;
  - a failed driver registration was followed by a successful PyTorch CUDA
    allocation and synchronization;
  - a guarded batched-copy reproducer fails only when one descriptor crosses
    a registration boundary and passes when row alignment or the fallback
    splitter is used, in both transfer directions.
- Exact composed DS4 E2E on two GPUs:
  - TP2/DCP1, fixed K5 DSpark, MNB=2048, MNS=16, graph=96;
  - InstantTensor BUFFERED plus 5.5 GiB native offload;
  - forced segmented fallback logged 23 row-aligned registrations of
    258,539,520 bytes per rank;
  - full model load, memory profile, and CUDA graph capture completed;
  - six concurrent independent uncached prefills of about 120k tokens each all
    returned HTTP 200 (about 720k input tokens total);
  - observed DMA throughput was about **55.8 GB/s**, matching the previous
    whole-registration fast path;
  - short correctness output, health, shared-region unlinking, and runtime
    error-signature scans passed.

The composed E2E image also contained vLLM #229, so that run validates the
interaction between native offload and the corrected compressed-MLA workspace;
the focused tests above isolate this PR's behavior.

## Provenance

- Backport of vllm-project/vllm#50094.
- Host-allocation diagnosis originally documented in vllm-project/vllm#48436.
- Large-region segmentation, driver/runtime error isolation, and row-aligned
  batched-copy handling were added from production DS4 failure evidence.

AI assistance was used to adapt the upstream change and tests to the GG
configuration boundary; every changed line and the resulting test output were
reviewed.
