### PR TITLE
[GG] fix(kv-offload): align SWA/MTP retention and shared-prefix tails

### DIFF
--- a/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
@@ -2020,6 +2020,51 @@ def test_swa_alignment_retention_interval(
     )
 
 
+def test_swa_alignment_retains_shared_prefix_boundary(request_runner, monkeypatch):
+    """Native offload retains the same sparse shared-prefix tail as APC."""
+    monkeypatch.setenv("VLLM_PREFIX_CACHE_RETENTION_INTERVAL", "64")
+
+    kv_cache_groups = [
+        KVCacheGroupSpec(
+            ["layer0"],
+            FullAttentionSpec(
+                block_size=16,
+                num_kv_heads=1,
+                head_size=1,
+                dtype=torch.float32,
+            ),
+        ),
+        KVCacheGroupSpec(
+            ["layer1"],
+            SlidingWindowSpec(
+                block_size=4,
+                num_kv_heads=1,
+                head_size=1,
+                dtype=torch.float32,
+                sliding_window=8,
+            ),
+        ),
+    ]
+    runner = request_runner(
+        block_size=4,
+        num_gpu_blocks=200,
+        async_scheduling=False,
+        kv_cache_groups=kv_cache_groups,
+    )
+
+    runner.new_request(token_ids=[0] * 56)
+    request = runner.scheduler.requests[str(runner.req_id)]
+    request.shared_prefix_boundary = 32
+
+    group_config = runner.connector_scheduler.config.kv_group_configs[1]
+    assert runner.connector_scheduler._reachable_tail_end_chunks(
+        group_config, request, shift=0
+    ) == (
+        12,  # Latest replay boundary: floor((56 - 1) / 16) * 16 / 4.
+        8,  # Shared-prefix junction: 32 / 4.
+    )
+
+
 @pytest.mark.parametrize("async_scheduling", [True, False])
 def test_stale_sliding_window_block_after_prepare_store_failure(
     request_runner, async_scheduling: bool

--- a/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
@@ -1784,6 +1784,243 @@ def test_swa_alignment_skip(request_runner, async_scheduling: bool):
 
 
 @pytest.mark.parametrize("async_scheduling", [True, False])
+def test_swa_alignment_skip_eagle(request_runner, async_scheduling: bool):
+    """EAGLE/MTP SWA groups store their per-segment tail run shifted one
+    block past the segment boundary.
+
+    _lookup requires sliding_window_size_in_chunks + 1 consecutive stored
+    blocks for eagle groups (the "+1 peek" block, dropped after matching).
+    Mirroring SlidingWindowManager.reachable_block_mask (shift=1), the store
+    path retains a run of tail + 1 blocks ending one block PAST each segment
+    boundary, so the post-drop hit lands exactly on the boundary.
+
+    Setup:
+      - Group 0: full attention, block_size=16
+      - Group 1: SWA + eagle, block_size=4, sliding_window=8
+
+    alignment_chunk_count = 16 / 4 = 4, tail = 2, need = 3 (incl. peek).
+    Reachable block positions: {2, 3, 4} and {6, 7, 8} (shifted by one).
+
+    With a 36-token prompt (2 full full-attn blocks, 9 SWA blocks):
+      - Group 0 stores: blocks 0, 1
+      - Group 1 stores: blocks 2, 3, 4, 6, 7, 8
+
+    A replay then hits exactly 32 tokens (the second segment boundary): the
+    eagle lookup matches the run [6, 7, 8], drops peek block 8, and the
+    load fetches window blocks [6, 7].
+    """
+    full_attn_block_size = 16
+    swa_block_size = 4
+    sliding_window = 8
+    num_gpu_blocks = 200
+
+    kv_cache_groups = [
+        KVCacheGroupSpec(
+            ["layer0"],
+            FullAttentionSpec(
+                block_size=full_attn_block_size,
+                num_kv_heads=1,
+                head_size=1,
+                dtype=torch.float32,
+            ),
+        ),
+        KVCacheGroupSpec(
+            ["layer1"],
+            SlidingWindowSpec(
+                block_size=swa_block_size,
+                num_kv_heads=1,
+                head_size=1,
+                dtype=torch.float32,
+                sliding_window=sliding_window,
+            ),
+            is_eagle_group=True,
+        ),
+    ]
+
+    runner = request_runner(
+        block_size=swa_block_size,
+        num_gpu_blocks=num_gpu_blocks,
+        async_scheduling=async_scheduling,
+        kv_cache_groups=kv_cache_groups,
+    )
+
+    kv_group_configs = runner.connector_scheduler.config.kv_group_configs
+    assert kv_group_configs[1].is_eagle_group
+    assert kv_group_configs[1].alignment_chunk_count == 4
+    assert kv_group_configs[1].sliding_window_size_in_chunks == 2
+    # No sparse retention -> no per-request replay tail.
+    assert runner.connector_scheduler.config.replay_alignment_tokens is None
+
+    # Track stored keys so lookups reflect the actual store-side filtering.
+    stored_keys: set = set()
+
+    def _prepare_store(keys, req_context):
+        keys = list(keys)
+        stored_keys.update(keys)
+        return generate_store_output(keys)
+
+    runner.manager.prepare_store.side_effect = _prepare_store
+    runner.manager.lookup.side_effect = lambda key, req_context: (
+        LookupResult.HIT if key in stored_keys else LookupResult.MISS
+    )
+
+    num_tokens = 36
+    runner.new_request(token_ids=[0] * num_tokens)
+    runner.run(decoded_tokens=[0])
+    runner.run(
+        decoded_tokens=[EOS_TOKEN_ID],
+        expected_stored=(
+            (0, 0),
+            (0, 1),
+            (1, 2),
+            (1, 3),
+            (1, 4),
+            (1, 6),
+            (1, 7),
+            (1, 8),
+        ),
+    )
+
+    # Replay the same prompt; the eagle group must hit exactly at the
+    # 32-token segment boundary via the shifted run [6, 7, 8].
+    runner.scheduler.reset_prefix_cache()
+    # Avoid re-storing the (unloaded) peek block during the replay.
+    runner.manager.prepare_store.side_effect = lambda keys, req_context: (
+        generate_store_output([])
+    )
+    runner.new_request(token_ids=[0] * num_tokens)
+    runner.run(
+        decoded_tokens=[EOS_TOKEN_ID],
+        expected_loaded=(
+            (0, 0),
+            (0, 1),
+            (1, 6),
+            (1, 7),
+        ),
+    )
+
+
+@pytest.mark.parametrize("async_scheduling", [True, False])
+def test_swa_alignment_retention_interval(
+    request_runner, monkeypatch, async_scheduling: bool
+):
+    """VLLM_PREFIX_CACHE_RETENTION_INTERVAL sets the sparsity segment size,
+    and a per-request replay-boundary tail keeps exact replays servable.
+
+    Mirrors SlidingWindowManager.reachable_block_mask: with sparse retention
+    the local GPU cache keeps SWA tails once per retention interval (not at
+    every full-attention block boundary), plus one tail run at the latest
+    full-attention-aligned boundary of the prompt (the "replay boundary") so
+    a replay of the same prompt does not fall back a whole retention segment.
+
+    Setup:
+      - retention interval = 32 tokens
+      - Group 0: full attention, block_size=16
+      - Group 1: SWA, block_size=4, sliding_window=8
+
+    alignment_chunk_count = 32 / 4 = 8 (retention-based, not 16 / 4 = 4).
+
+    With a 56-token prompt (3 full full-attn blocks, 14 SWA blocks):
+      - segment tails: blocks {6, 7} (the second segment is incomplete:
+        blocks 14, 15 never fill)
+      - replay boundary: (56 - 1) // 16 * 16 = 48 -> tail run {10, 11}
+      - Group 1 stores: blocks 6, 7, 10, 11
+
+    A replay of the prompt hits 48 tokens via the replay tail {10, 11};
+    without it, the hit would fall back to 32 (the only segment boundary).
+    """
+    monkeypatch.setenv("VLLM_PREFIX_CACHE_RETENTION_INTERVAL", "32")
+
+    full_attn_block_size = 16
+    swa_block_size = 4
+    sliding_window = 8
+    num_gpu_blocks = 200
+
+    kv_cache_groups = [
+        KVCacheGroupSpec(
+            ["layer0"],
+            FullAttentionSpec(
+                block_size=full_attn_block_size,
+                num_kv_heads=1,
+                head_size=1,
+                dtype=torch.float32,
+            ),
+        ),
+        KVCacheGroupSpec(
+            ["layer1"],
+            SlidingWindowSpec(
+                block_size=swa_block_size,
+                num_kv_heads=1,
+                head_size=1,
+                dtype=torch.float32,
+                sliding_window=sliding_window,
+            ),
+        ),
+    ]
+
+    runner = request_runner(
+        block_size=swa_block_size,
+        num_gpu_blocks=num_gpu_blocks,
+        async_scheduling=async_scheduling,
+        kv_cache_groups=kv_cache_groups,
+    )
+
+    config = runner.connector_scheduler.config
+    # Segment granularity comes from the retention interval.
+    assert config.kv_group_configs[1].alignment_chunk_count == 8
+    assert config.kv_group_configs[1].sliding_window_size_in_chunks == 2
+    # Replay tails align to the full-attention block size.
+    assert config.replay_alignment_tokens == full_attn_block_size
+
+    # Track stored keys so lookups reflect the actual store-side filtering.
+    stored_keys: set = set()
+
+    def _prepare_store(keys, req_context):
+        keys = list(keys)
+        stored_keys.update(keys)
+        return generate_store_output(keys)
+
+    runner.manager.prepare_store.side_effect = _prepare_store
+    runner.manager.lookup.side_effect = lambda key, req_context: (
+        LookupResult.HIT if key in stored_keys else LookupResult.MISS
+    )
+
+    num_tokens = 56
+    runner.new_request(token_ids=[0] * num_tokens)
+    runner.run(decoded_tokens=[0])
+    runner.run(
+        decoded_tokens=[EOS_TOKEN_ID],
+        expected_stored=(
+            (0, 0),
+            (0, 1),
+            (0, 2),
+            (1, 6),
+            (1, 7),
+            (1, 10),
+            (1, 11),
+        ),
+    )
+
+    # Replay the same prompt; the hit must reach the 48-token replay
+    # boundary served by the replay tail run {10, 11}.
+    runner.scheduler.reset_prefix_cache()
+    runner.manager.prepare_store.side_effect = lambda keys, req_context: (
+        generate_store_output([])
+    )
+    runner.new_request(token_ids=[0] * num_tokens)
+    runner.run(
+        decoded_tokens=[EOS_TOKEN_ID],
+        expected_loaded=(
+            (0, 0),
+            (0, 1),
+            (0, 2),
+            (1, 10),
+            (1, 11),
+        ),
+    )
+
+
+@pytest.mark.parametrize("async_scheduling", [True, False])
 def test_stale_sliding_window_block_after_prepare_store_failure(
     request_runner, async_scheduling: bool
 ):

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 from itertools import chain, islice
 from typing import Any, NamedTuple
 
+import vllm.envs as envs
 from vllm.config import VllmConfig
 from vllm.distributed.kv_events import KVCacheEvent
 from vllm.distributed.kv_transfer.kv_connector.utils import yield_req_data
@@ -84,10 +85,11 @@ class GroupOffloadConfig(NamedTuple):
     kv_event_group_spec: OffloadingEventGroupSpec
     # None below means full attention
     sliding_window_size_in_chunks: int | None
-    # Number of this group's offloaded chunks per full-attention alignment
-    # segment. Used to skip storing SWA chunks that can never serve a load
-    # hit (e.g. DeepSeek V4 where SWA groups have much smaller block sizes
-    # than the MLA full-attention group).
+    # Number of this group's offloaded chunks per sparsity segment (the
+    # full-attention alignment size, or VLLM_PREFIX_CACHE_RETENTION_INTERVAL
+    # when sparse retention is configured). Used to skip storing SWA chunks
+    # that can never serve a load hit (e.g. DeepSeek V4 where SWA groups have
+    # much smaller block sizes than the MLA full-attention group).
     # None for full-attention groups or when the optimization doesn't apply.
     alignment_chunk_count: int | None = None
     # True for EAGLE/MTP draft-model attention groups. The trailing chunk
@@ -136,6 +138,11 @@ class SchedulerOffloadConfig(NamedTuple):
     blocks_per_chunk: int
     num_workers: int
     offload_prompt_only: bool
+    # Token alignment of the per-request "replay boundary" tail (see
+    # OffloadingConnectorScheduler._replay_tail_end_chunk). Set to the
+    # full-attention alignment size when sparse retention
+    # (VLLM_PREFIX_CACHE_RETENTION_INTERVAL) is enabled, else None.
+    replay_alignment_tokens: int | None = None
 
     @classmethod
     def from_spec(
@@ -164,16 +171,34 @@ class SchedulerOffloadConfig(NamedTuple):
         if len(full_attn_tokens_per_chunk) == 1:
             alignment_tokens = full_attn_tokens_per_chunk.pop()
 
+        # Mirror SlidingWindowManager.reachable_block_mask's segment-size
+        # choice: with sparse retention (VLLM_PREFIX_CACHE_RETENTION_INTERVAL)
+        # the local GPU prefix cache keeps SWA tails once per retention
+        # segment rather than at every full-attention block boundary. Use the
+        # same granularity so stored tails sit exactly where lookups converge.
+        # An interval of 0 (latest-boundary-only retention) disables the
+        # store-side skip entirely (conservative: store all chunks).
+        retention_interval = envs.VLLM_PREFIX_CACHE_RETENTION_INTERVAL
+        segment_tokens: int | None = (
+            alignment_tokens
+            if retention_interval is None
+            else (None if retention_interval == 0 else retention_interval)
+        )
+
         def _alignment_chunk_count(
             tokens_per_chunk: int,
             sliding_window_size_in_chunks: int | None,
+            is_eagle_group: bool,
         ) -> int | None:
-            if alignment_tokens is None or sliding_window_size_in_chunks is None:
+            if segment_tokens is None or sliding_window_size_in_chunks is None:
                 return None
-            if alignment_tokens <= tokens_per_chunk:
+            if segment_tokens <= tokens_per_chunk:
                 return None
-            per_segment = alignment_tokens // tokens_per_chunk
-            if sliding_window_size_in_chunks >= per_segment:
+            per_segment = segment_tokens // tokens_per_chunk
+            # Contiguous chunks a hit needs at a segment boundary, including
+            # the "+1 peek" chunk for EAGLE/MTP groups (see _lookup).
+            need = sliding_window_size_in_chunks + (1 if is_eagle_group else 0)
+            if need >= per_segment:
                 return None
             return per_segment
 
@@ -216,7 +241,9 @@ class SchedulerOffloadConfig(NamedTuple):
                         )
                     ),
                     alignment_chunk_count=_alignment_chunk_count(
-                        tokens_per_block * spec.blocks_per_chunk, sw
+                        tokens_per_block * spec.blocks_per_chunk,
+                        sw,
+                        idx in eagle_groups,
                     ),
                     kv_event_group_spec=get_offloading_event_group_spec(
                         kv_cache_config.kv_cache_groups[idx]
@@ -227,6 +254,9 @@ class SchedulerOffloadConfig(NamedTuple):
             ),
             blocks_per_chunk=spec.blocks_per_chunk,
             offload_prompt_only=spec.offload_prompt_only,
+            replay_alignment_tokens=(
+                alignment_tokens if retention_interval is not None else None
+            ),
         )
 
 
@@ -411,6 +441,20 @@ class OffloadingConnectorScheduler:
         self._lookup_groups = tuple(full_attention_groups) + self._sliding_window_groups
         self._mamba_align_size: int | None = resolve_mamba_align_size(
             spec, kv_cache_config
+        )
+
+        # Tokens that must remain past a replay boundary for it to be
+        # servable: the last prompt token is always recomputed (hence the
+        # default of 1), and each EAGLE/MTP group must be able to match one
+        # complete chunk past the boundary (its "+1 peek", dropped after
+        # verification in _lookup).
+        self._replay_reserve_tokens: int = max(
+            (
+                group_config.tokens_per_chunk
+                for group_config in self.config.kv_group_configs
+                if group_config.is_eagle_group
+            ),
+            default=1,
         )
 
         self._req_status: dict[ReqId, RequestOffloadState] = {}
@@ -943,6 +987,32 @@ class OffloadingConnectorScheduler:
                         ):
                             group_state.block_ids[j] = 0
 
+    def _replay_tail_end_chunk(
+        self, group_config: GroupOffloadConfig, num_prompt_tokens: int, shift: int
+    ) -> int | None:
+        """End chunk index (exclusive) of this group's replay-boundary tail.
+
+        Mirrors the replay-boundary handling of
+        SlidingWindowManager.reachable_block_mask: with sparse retention,
+        segment tails exist only once per retention interval, so a replay of
+        the same prompt would otherwise fall back a whole segment. Retain one
+        extra tail run per request, ending at the latest
+        full-attention-aligned boundary that every group can service (i.e.
+        far enough from the prompt end that each EAGLE/MTP group's "+1 peek"
+        chunk is still a complete prompt chunk).
+        """
+        alignment_tokens = self.config.replay_alignment_tokens
+        if alignment_tokens is None:
+            return None
+        latest = (
+            (num_prompt_tokens - self._replay_reserve_tokens)
+            // alignment_tokens
+            * alignment_tokens
+        )
+        if latest <= 0 or latest % group_config.tokens_per_chunk != 0:
+            return None
+        return latest // group_config.tokens_per_chunk + shift
+
     def _build_store_jobs(
         self,
         scheduler_output: SchedulerOutput,
@@ -995,22 +1065,46 @@ class OffloadingConnectorScheduler:
 
                 alignment_chunk_count = group_config.alignment_chunk_count
                 tail = group_config.sliding_window_size_in_chunks
+                # Chunks reachable by _sliding_window_lookup, mirroring
+                # SlidingWindowManager.reachable_block_mask: a hit needs
+                # `need` contiguous chunks ending at a segment boundary. For
+                # EAGLE/MTP groups the run includes the "+1 peek" chunk and
+                # is shifted one chunk past the boundary, so that after
+                # _lookup drops the peek the hit lands exactly on it.
+                need = shift = 0
+                replay_end_chunk: int | None = None
+                if alignment_chunk_count is not None:
+                    assert tail is not None
+                    shift = 1 if group_config.is_eagle_group else 0
+                    need = tail + shift
+                    replay_end_chunk = self._replay_tail_end_chunk(
+                        group_config, req.num_prompt_tokens, shift
+                    )
 
                 for key_idx, (offload_key, block_id) in enumerate(
                     zip(offload_keys, offload_block_ids)
                 ):
                     if block_id == 0:
                         continue
-                    # Skip SWA chunks that can never serve a load hit:
-                    # within each full-attention alignment segment, only the
-                    # trailing `tail` chunks are reachable by
+                    # Skip SWA chunks that can never serve a load hit: only
+                    # the trailing `need` chunks of each alignment segment
+                    # (plus the replay-boundary tail) are reachable by
                     # _sliding_window_lookup. For DeepSeek V4 with 100K
                     # tokens this reduces SWA stores by ~78%.
                     if alignment_chunk_count is not None:
-                        assert tail is not None
                         abs_chunk_idx = start_chunk_idx + key_idx
-                        pos_in_segment = abs_chunk_idx % alignment_chunk_count
-                        if pos_in_segment < alignment_chunk_count - tail:
+                        reachable = (
+                            abs_chunk_idx >= shift
+                            and (abs_chunk_idx - shift) % alignment_chunk_count
+                            >= alignment_chunk_count - need
+                        )
+                        if not reachable and replay_end_chunk is not None:
+                            reachable = (
+                                replay_end_chunk - need
+                                <= abs_chunk_idx
+                                < replay_end_chunk
+                            )
+                        if not reachable:
                             continue
                     new_offload_keys.append(offload_key)
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -987,31 +987,36 @@ class OffloadingConnectorScheduler:
                         ):
                             group_state.block_ids[j] = 0
 
-    def _replay_tail_end_chunk(
-        self, group_config: GroupOffloadConfig, num_prompt_tokens: int, shift: int
-    ) -> int | None:
-        """End chunk index (exclusive) of this group's replay-boundary tail.
+    def _reachable_tail_end_chunks(
+        self, group_config: GroupOffloadConfig, req: Request, shift: int
+    ) -> tuple[int, ...]:
+        """End chunk indices (exclusive) of serviceable boundary tails.
 
         Mirrors the replay-boundary handling of
         SlidingWindowManager.reachable_block_mask: with sparse retention,
-        segment tails exist only once per retention interval, so a replay of
-        the same prompt would otherwise fall back a whole segment. Retain one
-        extra tail run per request, ending at the latest
-        full-attention-aligned boundary that every group can service (i.e.
-        far enough from the prompt end that each EAGLE/MTP group's "+1 peek"
-        chunk is still a complete prompt chunk).
+        segment tails exist only once per retention interval. Retain tails at
+        the request replay boundary and at a detected shared-prefix junction.
+        Clamp each boundary to the latest point that every group can service,
+        including a complete EAGLE/MTP peek chunk.
         """
         alignment_tokens = self.config.replay_alignment_tokens
         if alignment_tokens is None:
-            return None
-        latest = (
-            (num_prompt_tokens - self._replay_reserve_tokens)
-            // alignment_tokens
-            * alignment_tokens
-        )
-        if latest <= 0 or latest % group_config.tokens_per_chunk != 0:
-            return None
-        return latest // group_config.tokens_per_chunk + shift
+            return ()
+
+        latest_serviceable = req.num_prompt_tokens - self._replay_reserve_tokens
+        boundaries = [latest_serviceable]
+        if req.shared_prefix_boundary:
+            boundaries.append(min(req.shared_prefix_boundary, latest_serviceable))
+
+        ends: list[int] = []
+        for boundary in boundaries:
+            aligned = boundary // alignment_tokens * alignment_tokens
+            if aligned <= 0 or aligned % group_config.tokens_per_chunk != 0:
+                continue
+            end = aligned // group_config.tokens_per_chunk + shift
+            if end not in ends:
+                ends.append(end)
+        return tuple(ends)
 
     def _build_store_jobs(
         self,
@@ -1072,13 +1077,13 @@ class OffloadingConnectorScheduler:
                 # is shifted one chunk past the boundary, so that after
                 # _lookup drops the peek the hit lands exactly on it.
                 need = shift = 0
-                replay_end_chunk: int | None = None
+                reachable_end_chunks: tuple[int, ...] = ()
                 if alignment_chunk_count is not None:
                     assert tail is not None
                     shift = 1 if group_config.is_eagle_group else 0
                     need = tail + shift
-                    replay_end_chunk = self._replay_tail_end_chunk(
-                        group_config, req.num_prompt_tokens, shift
+                    reachable_end_chunks = self._reachable_tail_end_chunks(
+                        group_config, req, shift
                     )
 
                 for key_idx, (offload_key, block_id) in enumerate(
@@ -1098,11 +1103,10 @@ class OffloadingConnectorScheduler:
                             and (abs_chunk_idx - shift) % alignment_chunk_count
                             >= alignment_chunk_count - need
                         )
-                        if not reachable and replay_end_chunk is not None:
-                            reachable = (
-                                replay_end_chunk - need
-                                <= abs_chunk_idx
-                                < replay_end_chunk
+                        if not reachable:
+                            reachable = any(
+                                end - need <= abs_chunk_idx < end
+                                for end in reachable_end_chunks
                             )
                         if not reachable:
                             continue


### PR DESCRIPTION
## Summary

Port the native KV-offload SWA/EAGLE retention fix to the current Gilded Gnosis branch and keep its store-side sparsity aligned with the local hybrid KV cache manager.

- Retain the EAGLE/MTP peek chunk required by offload lookup.
- Use `VLLM_PREFIX_CACHE_RETENTION_INTERVAL` as the sparse segment size.
- Retain the latest serviceable replay-boundary tail.
- Also retain a detected `Request.shared_prefix_boundary` tail, which exists in current GG but not in the original r15 patch.
- Preserve Procr's original commit and authorship, with the GG adaptation as a separate commit.

This supersedes #89 for the GG/r16 line. The old PR was based on the r15 release tree and did not account for current GG shared-prefix junction semantics.

## Validation

- `ruff format --check`: passed
- `ruff check`: passed
- `git diff --check`: passed
- Targeted scheduler tests in the r15 CUDA runtime: 7 passed
  - SWA sparse store filtering
  - EAGLE/MTP shifted peek retention
  - retention-interval replay tails
  - shared-prefix boundary tail calculation

E2E DS4 native-offload replay validation will be recorded on the release issue after the r16 image is composed.

## Provenance

The first commit is the clean port of `procr1337/vllm@65e061be82cb7c52f6152d47557636cb25b5a75b`. The second commit is the current-GG adaptation.

Assisted by OpenAI Codex.
