### PR TITLE
exl3: use shape-aware mixed decode and serial prefill

### DIFF
--- a/tests/quantization/test_exl3.py
+++ b/tests/quantization/test_exl3.py
@@ -313,6 +313,7 @@ def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(monkeypat
         local_num_experts=experts,
         exl3_hidden_size=hidden,
         exl3_intermediate_size_per_partition=intermediate,
+        exl3_params_dtype=torch.float16,
         exl3_layer_bitrates=bitrates,
         activation=MoEActivation.SILU,
         layer_name="model.layers.3.mlp.experts",
@@ -324,6 +325,8 @@ def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(monkeypat
             name = f"{prefix}_{suffix}"
             backing = slabs.get(name)
             setattr(layer, name, parameter(shards, backing=backing))
+    marker = torch.tensor(0xCBAC1FED - (1 << 32), dtype=torch.int32)
+    layer.w13_mcg.exl3_tensors[(0, "w1")] = marker
 
     class FakeMixedApi:
         def __init__(self):
@@ -346,8 +349,23 @@ def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(monkeypat
         def combine_trellis_rotations(tier0, tier1):
             return tier0, tier1
 
+    class FakeFusedApi:
+        def __init__(self):
+            self.plans = []
+            self.prepared = []
+
+        def plan_weights(self, **kwargs):
+            self.plans.append(kwargs)
+            return SimpleNamespace(**kwargs)
+
+        def prepare_weights(self, **kwargs):
+            self.prepared.append(kwargs)
+            return SimpleNamespace(plan=kwargs["plan"])
+
     api = FakeMixedApi()
+    fused_api = FakeFusedApi()
     monkeypatch.setattr(exl3_module, "_load_sparkinfer_mixed_trellis", lambda: api)
+    monkeypatch.setattr(exl3_module, "_load_sparkinfer_fused_moe", lambda: fused_api)
     method = object.__new__(Exl3MoEMethod)
     method._rank_sliced_backing = lambda _layer, name: slabs[name]
 
@@ -376,6 +394,23 @@ def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(monkeypat
     ]
     assert layer.exl3_mixed_trellis["tier_ids"] == ((0, 2), (1, 3))
     assert layer.exl3_mixed_trellis["tier_bits"] == (3, 4)
+    assert [entry["trellis_bits"] for entry in fused_api.plans] == [3, 4]
+    assert [entry["trellis_tile_config"] for entry in fused_api.plans] == [
+        (64, 128, 64, 128),
+        (64, 128, 64, 128),
+    ]
+    assert all(entry["trellis_mcg"] is marker for entry in fused_api.prepared)
+    assert len(layer.exl3_mixed_trellis["serial_tiers"]) == 2
+    rotations = layer.exl3_mixed_trellis["rotations"]
+    for mixed_entry, serial_entry in zip(api.prepared, fused_api.prepared, strict=True):
+        assert (
+            mixed_entry["gate_suh"].untyped_storage().data_ptr()
+            == rotations.gate_suh.untyped_storage().data_ptr()
+        )
+        assert (
+            serial_entry["gate_suh"].untyped_storage().data_ptr()
+            == rotations.gate_suh.untyped_storage().data_ptr()
+        )
     assert layer.w13_trellis.exl3_tensors == {}
     assert layer.w2_trellis.exl3_tensors == {}
     assert layer.w13_suh.exl3_backing is None
@@ -388,6 +423,84 @@ def test_mixed_trellis_buffer_accounting_ignores_metadata() -> None:
     second = SimpleNamespace(alias=shared.view(2, 4), label="prefill")
 
     assert exl3_module._unique_tensor_storage_bytes(first, second) == 8
+
+
+def test_mixed_trellis_dispatches_decode_and_serial_prefill(monkeypatch):
+    class FakeMixedApi:
+        calls = 0
+
+        def run_mixed_trellis(self, x, *args):
+            self.calls += 1
+            return torch.ones_like(x)
+
+    class FakeFusedApi:
+        def __init__(self):
+            self.bindings = []
+
+        def bind(self, plan, **kwargs):
+            del plan
+            self.bindings.append(kwargs)
+            return kwargs
+
+        @staticmethod
+        def run(*, binding):
+            output = binding["output"]
+            if output is not None:
+                output.fill_(1)
+                return output
+            return torch.full_like(binding["a"], 2, dtype=torch.float32)
+
+    class FakePlan:
+        @staticmethod
+        def scratch_specs():
+            return [SimpleNamespace(shape=(16,), dtype=torch.uint8)]
+
+    mixed_api = FakeMixedApi()
+    fused_api = FakeFusedApi()
+    runtime = {
+        "mixed_api": mixed_api,
+        "fused_api": fused_api,
+        "decode": {"launch": object(), "buffers": object()},
+        "prefill_plans": (FakePlan(), FakePlan()),
+        "prefill_arena": torch.empty(16, dtype=torch.uint8),
+        "prefill_accum": torch.empty((16, 4), dtype=torch.float32),
+        "max_decode_m": 8,
+        "max_batched_tokens": 16,
+    }
+    tiers = (
+        {"weights": object(), "route_expert_map": torch.tensor([0, -1])},
+        {"weights": object(), "route_expert_map": torch.tensor([-1, 0])},
+    )
+    layer = SimpleNamespace(
+        exl3_mixed_trellis={
+            "tiers": (object(), object()),
+            "serial_tiers": tiers,
+            "global_to_combined": object(),
+            "descriptor_map": object(),
+            "rotations": object(),
+        }
+    )
+    method = object.__new__(Exl3MoEMethod)
+    monkeypatch.setattr(
+        method, "_mixed_rank_sliced_runtime", lambda layer, x, ids: runtime
+    )
+    weights = torch.ones((16, 2), dtype=torch.float32)
+    ids = torch.zeros((16, 2), dtype=torch.int64)
+
+    decode = method._apply_mixed_rank_sliced(
+        layer, torch.zeros((4, 4)), weights[:4], ids[:4]
+    )
+    prefill = method._apply_mixed_rank_sliced(layer, torch.zeros((16, 4)), weights, ids)
+
+    torch.testing.assert_close(decode, torch.ones_like(decode))
+    torch.testing.assert_close(prefill, torch.full_like(prefill, 3))
+    assert mixed_api.calls == 1
+    assert len(fused_api.bindings) == 2
+    assert (
+        fused_api.bindings[0]["output"].data_ptr()
+        == runtime["prefill_accum"].data_ptr()
+    )
+    assert fused_api.bindings[1]["output"] is None
 
 
 @pytest.mark.parametrize(

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -264,6 +264,15 @@ def _unique_tensor_storage_bytes(*buffers: Any) -> int:
     return total
 
 
+def _scratch_view(backing: torch.Tensor, spec: Any) -> torch.Tensor:
+    """Return a typed plan-scratch view over a shared byte arena."""
+
+    nbytes = int(spec.dtype.itemsize)
+    for dim in spec.shape:
+        nbytes *= int(dim)
+    return backing.narrow(0, 0, nbytes).view(spec.dtype).view(tuple(spec.shape))
+
+
 def _positive_env_int(name: str, default: int) -> int:
     # An env var that is present but blank means "unset". Compose and Kubernetes
     # both render an unset variable as the empty string, so int("") would abort
@@ -1570,7 +1579,8 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         return (128, 128, 128, 128)
 
     def _prepare_mixed_rank_sliced_weights(self, layer: RoutedExperts) -> None:
-        api = _load_sparkinfer_mixed_trellis()
+        mixed_api = _load_sparkinfer_mixed_trellis()
+        fused_api = _load_sparkinfer_fused_moe()
         num_experts = int(layer.local_num_experts)
         hidden_size = int(layer.exl3_hidden_size)
         intermediate_size = int(layer.exl3_intermediate_size_per_partition)
@@ -1609,9 +1619,36 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         down_suh = self._rank_sliced_backing(layer, "w2_suh")
         down_svh = self._rank_sliced_backing(layer, "w2_svh")
         device = gate_suh.device
-        tile_config = self._mixed_trellis_tile_config(hidden_size, intermediate_size)
+        mixed_tile_config = self._mixed_trellis_tile_config(
+            hidden_size, intermediate_size
+        )
+        serial_tile_config = self._trellis_tile_config(hidden_size, intermediate_size)
+        marker = layer.w13_mcg.exl3_tensors[(0, "w1")]
+        tier_order = tuple(
+            expert_id for expert_ids in tiers.values() for expert_id in expert_ids
+        )
+        tier_index = torch.tensor(tier_order, dtype=torch.long, device=device)
+        combined_gate_suh = gate_suh.index_select(0, tier_index).contiguous()
+        combined_up_suh = up_suh.index_select(0, tier_index).contiguous()
+        combined_intermediate_rotations = torch.cat(
+            (
+                gate_svh.index_select(0, tier_index),
+                up_svh.index_select(0, tier_index),
+                down_suh.index_select(0, tier_index),
+            ),
+            dim=1,
+        ).contiguous()
+        combined_down_svh = down_svh.index_select(0, tier_index).contiguous()
+        combined_rotations = SimpleNamespace(
+            intermediate=combined_intermediate_rotations,
+            gate_suh=combined_gate_suh,
+            up_suh=combined_up_suh,
+            down_svh=combined_down_svh,
+        )
         prepared_tiers = []
+        serial_tiers = []
         tier_ids = []
+        tier_offset = 0
         for bits, expert_ids in tiers.items():
             expected_last = 16 * bits
             w13 = torch.stack(
@@ -1651,27 +1688,21 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 )
 
             index = torch.tensor(expert_ids, dtype=torch.long, device=device)
-            tier_gate_suh = gate_suh.index_select(0, index).contiguous()
-            tier_up_suh = up_suh.index_select(0, index).contiguous()
-            intermediate_rotations = torch.cat(
-                (
-                    gate_svh.index_select(0, index),
-                    up_svh.index_select(0, index),
-                    down_suh.index_select(0, index),
-                ),
-                dim=1,
-            ).contiguous()
-            tier_down_svh = down_svh.index_select(0, index).contiguous()
+            tier_slice = slice(tier_offset, tier_offset + len(expert_ids))
+            tier_gate_suh = combined_gate_suh[tier_slice]
+            tier_up_suh = combined_up_suh[tier_slice]
+            intermediate_rotations = combined_intermediate_rotations[tier_slice]
+            tier_down_svh = combined_down_svh[tier_slice]
             prepared_tiers.append(
-                api.prepare_weights(
+                mixed_api.prepare_weights(
                     w13=w13,
                     w2=w2,
                     hidden_size=hidden_size,
                     intermediate_size=intermediate_size,
                     num_experts=len(expert_ids),
                     activation=layer.activation.value,
-                    fc1_tile_n=tile_config[1],
-                    fc2_tile_n=tile_config[3],
+                    fc1_tile_n=mixed_tile_config[1],
+                    fc2_tile_n=mixed_tile_config[3],
                     params_dtype=torch.float16,
                     w13_layout="trellis3_t256_proj",
                     trellis_bits=bits,
@@ -1680,25 +1711,64 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                     up_suh=tier_up_suh,
                     intermediate_rotations=intermediate_rotations,
                     down_svh=tier_down_svh,
-                    tile_config=tile_config,
+                    tile_config=mixed_tile_config,
                     workspace=w13.view(torch.int32).reshape(-1)[:1],
                 )
             )
+            serial_weight_plan = fused_api.plan_weights(
+                quant_modes="w4a16",
+                source_format="exl3_trellis_mcg",
+                activation=layer.activation.value,
+                params_dtype=layer.exl3_params_dtype,
+                num_experts=len(expert_ids),
+                hidden_size=hidden_size,
+                intermediate_size=intermediate_size,
+                w13_layout="w13",
+                trellis_bits=bits,
+                trellis_tile_config=serial_tile_config,
+            )
+            serial_weights = fused_api.prepare_weights(
+                plan=serial_weight_plan,
+                params_dtype=layer.exl3_params_dtype,
+                w1_fp4=w13,
+                w2_fp4=w2,
+                gate_suh=tier_gate_suh,
+                up_suh=tier_up_suh,
+                intermediate_rotations=intermediate_rotations,
+                down_svh=tier_down_svh,
+                trellis_mcg=marker,
+            )
+            route_expert_map = torch.full(
+                (num_experts,), -1, dtype=torch.int32, device=device
+            )
+            route_expert_map[index] = torch.arange(
+                len(expert_ids), dtype=torch.int32, device=device
+            )
+            serial_tiers.append(
+                {
+                    "bits": bits,
+                    "weights": serial_weights,
+                    "route_expert_map": route_expert_map,
+                }
+            )
             tier_ids.append(expert_ids)
+            tier_offset += len(expert_ids)
 
-        global_to_combined, descriptor_map = api.build_tiered_maps(
+        global_to_combined, descriptor_map = mixed_api.build_tiered_maps(
             tier_ids[0], tier_ids[1], device=device
         )
         layer.exl3_mixed_trellis = {
             "tiers": tuple(prepared_tiers),
+            "serial_tiers": tuple(serial_tiers),
             "tier_ids": tuple(tier_ids),
             "tier_bits": tuple(tiers),
             "global_to_combined": global_to_combined,
             "descriptor_map": descriptor_map,
-            "rotations": api.combine_trellis_rotations(*prepared_tiers),
-            "tile_config": tile_config,
+            "rotations": combined_rotations,
+            "tile_config": mixed_tile_config,
+            "serial_tile_config": serial_tile_config,
         }
-        layer.exl3_trellis_tile_config = tile_config
+        layer.exl3_trellis_tile_config = serial_tile_config
 
         # The prepared tier objects own compact, tier-ordered copies. Release
         # per-expert source tensors and the original rotation slabs now rather
@@ -1834,6 +1904,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         mixed = layer.exl3_mixed_trellis
         max_decode_m = _positive_env_int("VLLM_EXL3_TRELLIS_MAX_M", 32)
         max_batched_tokens = int(layer.exl3_max_num_batched_tokens)
+        prefill_block_m = _positive_env_int("VLLM_EXL3_PREFILL_BLOCK_M", 64)
         if max_decode_m > max_batched_tokens:
             max_decode_m = max_batched_tokens
         topk = int(topk_ids.shape[1])
@@ -1853,6 +1924,8 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             max_decode_m,
             max_batched_tokens,
             mixed["tile_config"],
+            mixed["serial_tile_config"],
+            prefill_block_m,
         )
         runtime = _MIXED_TRELLIS_RUNTIMES.get(key)
         if runtime is not None:
@@ -1868,18 +1941,19 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 f"{topk_ids.dtype}"
             )
 
-        api = _load_sparkinfer_mixed_trellis()
+        mixed_api = _load_sparkinfer_mixed_trellis()
+        fused_api = _load_sparkinfer_fused_moe()
         device = x.device
         props = torch.cuda.get_device_properties(device)
         total_experts = sum(experts for _, experts in tier_signature)
 
-        def make_state(capacity: int) -> dict[str, Any]:
-            route_slots = api.max_packed_route_slots(
+        def make_decode_state(capacity: int) -> dict[str, Any]:
+            route_slots = mixed_api.max_packed_route_slots(
                 capacity * topk,
                 _MIXED_TRELLIS_ROUTE_BLOCK_SIZE,
                 total_experts,
             )
-            launch = api.compile_mixed_trellis(
+            launch = mixed_api.compile_mixed_trellis(
                 size_m=capacity,
                 hidden_size=int(layer.exl3_hidden_size),
                 intermediate_size=int(layer.exl3_intermediate_size_per_partition),
@@ -1900,37 +1974,70 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             return {
                 "capacity": capacity,
                 "launch": launch,
-                "buffers": api.make_mixed_trellis_buffers(
+                "buffers": mixed_api.make_mixed_trellis_buffers(
                     launch,
                     device=device,
                     sms=int(props.multi_processor_count),
                 ),
             }
 
-        decode = make_state(max_decode_m)
-        prefill = (
-            make_state(max_batched_tokens)
-            if max_batched_tokens > max_decode_m
-            else decode
-        )
+        decode = make_decode_state(max_decode_m)
+        prefill_plans = []
+        prefill_arena = None
+        prefill_accum = None
+        if max_batched_tokens > max_decode_m:
+            if os.environ.get("VLLM_EXL3_PREFILL_TRELLIS", "1") != "1":
+                raise ValueError("mixed-K EXL3 requires VLLM_EXL3_PREFILL_TRELLIS=1")
+            scratch_bytes = 0
+            for tier in mixed["serial_tiers"]:
+                caps = fused_api.Caps(
+                    max_tokens=max_batched_tokens,
+                    num_topk=topk,
+                    route_num_experts=total_experts,
+                    device=device,
+                    weight_plan=tier["weights"].plan,
+                    quant_mode="w4a16",
+                    w4a16_block_size_m=prefill_block_m,
+                )
+                plan = fused_api.plan(caps)
+                prefill_plans.append(plan)
+                spec = plan.scratch_specs()[0]
+                size = int(spec.dtype.itemsize)
+                for dim in spec.shape:
+                    size *= int(dim)
+                scratch_bytes = max(scratch_bytes, size)
+            prefill_arena = torch.empty(scratch_bytes, dtype=torch.uint8, device=device)
+            prefill_accum = torch.empty(
+                (max_batched_tokens, int(layer.exl3_hidden_size)),
+                dtype=torch.float32,
+                device=device,
+            )
         runtime = {
-            "api": api,
+            "mixed_api": mixed_api,
+            "fused_api": fused_api,
             "decode": decode,
-            "prefill": prefill,
+            "prefill_plans": tuple(prefill_plans),
+            "prefill_arena": prefill_arena,
+            "prefill_accum": prefill_accum,
             "max_decode_m": max_decode_m,
             "max_batched_tokens": max_batched_tokens,
         }
         _MIXED_TRELLIS_RUNTIMES[key] = runtime
-        buffer_bytes = _unique_tensor_storage_bytes(
-            decode["buffers"], prefill["buffers"]
+        decode_bytes = _unique_tensor_storage_bytes(decode["buffers"])
+        prefill_bytes = sum(
+            tensor.numel() * tensor.element_size()
+            for tensor in (prefill_arena, prefill_accum)
+            if tensor is not None
         )
         logger.info_once(
-            "EXL3 mixed Trellis runtime planned: tiers=%s decode_capacity=%d "
-            "prefill_capacity=%d buffers=%.1f MiB",
+            "EXL3 mixed Trellis runtime planned: tiers=%s one-grid decode=%d "
+            "serial prefill=%d block_m=%d buffers=%.1f+%.1f MiB",
             tier_signature,
             max_decode_m,
             max_batched_tokens,
-            buffer_bytes / (1 << 20),
+            prefill_block_m,
+            decode_bytes / (1 << 20),
+            prefill_bytes / (1 << 20),
         )
         return runtime
 
@@ -1948,23 +2055,53 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 "mixed-bitrate EXL3 batch exceeds planned capacity: "
                 f"m={m}, capacity={runtime['max_batched_tokens']}"
             )
-        state = (
-            runtime["decode"] if m <= runtime["max_decode_m"] else runtime["prefill"]
-        )
         mixed = layer.exl3_mixed_trellis
-        output = runtime["api"].run_mixed_trellis(
-            x,
-            mixed["tiers"][0],
-            mixed["tiers"][1],
-            topk_weights,
-            topk_ids,
-            mixed["global_to_combined"],
-            mixed["descriptor_map"],
-            mixed["rotations"],
-            state["launch"],
-            state["buffers"],
-        )
-        return output.to(x.dtype)
+        # The cooperative mixed-K grid wins at small M, but its SM120 path is
+        # currently limited to route block 8.  Homogeneous tier plans support
+        # block 64 and are substantially faster for prefill, so keep the
+        # one-grid launch for decode and dispatch large M through the two
+        # serial tiers until the mixed kernel gains an efficient large block.
+        if m <= runtime["max_decode_m"]:
+            state = runtime["decode"]
+            output = runtime["mixed_api"].run_mixed_trellis(
+                x,
+                mixed["tiers"][0],
+                mixed["tiers"][1],
+                topk_weights,
+                topk_ids,
+                mixed["global_to_combined"],
+                mixed["descriptor_map"],
+                mixed["rotations"],
+                state["launch"],
+                state["buffers"],
+            )
+            return output.to(x.dtype)
+
+        if runtime["prefill_arena"] is None or runtime["prefill_accum"] is None:
+            raise RuntimeError("mixed-K EXL3 serial prefill plan is unavailable")
+        accum = runtime["prefill_accum"][:m]
+        first = True
+        for plan, tier in zip(
+            runtime["prefill_plans"], mixed["serial_tiers"], strict=True
+        ):
+            binding = runtime["fused_api"].bind(
+                plan,
+                scratch=_scratch_view(
+                    runtime["prefill_arena"], plan.scratch_specs()[0]
+                ),
+                a=x,
+                experts=tier["weights"],
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
+                route_expert_map=tier["route_expert_map"],
+                output_expert_map=tier["route_expert_map"],
+                output=accum if first else None,
+            )
+            output = runtime["fused_api"].run(binding=binding)
+            if not first:
+                accum.add_(output)
+            first = False
+        return accum.to(x.dtype)
 
     def _rank_sliced_runtime(
         self,


### PR DESCRIPTION
## Summary

Make mixed-bitrate EXL3 execution shape-aware:

- retain SparkInfer's one-grid mixed K3/K4 path for decode and small row counts;
- dispatch larger prefill shapes through serial homogeneous K3/K4 fused-MoE plans with route block 64;
- share the tier-ordered rotations between both paths and share one prefill scratch arena between the serial tiers;
- preserve the r14 validation and launch-contract hardening.

This fixes the approximately 23% GLM-5.2 prefill regression introduced when r14 replaced r13's serial block-64 prefill path with a mixed one-grid block-8 launch.

Kernel-side report and corrected microbenchmark: local-inference-lab/sparkinfer#107.

## Contribution and duplicate-work disclosure

OpenAI Codex assisted with the bisect, implementation, tests, and this draft. The commit carries an `Assisted-by` trailer. This PR will remain draft until the human submitter has reviewed every changed line and is prepared to defend the change end-to-end.

Duplicate checks were run against both `vllm-project/vllm` and `local-inference-lab/vllm` for `EXL3 mixed K3 K4 prefill` and `mixed Trellis serial prefill`; no other open implementation of this dispatcher fix was found.

Two related efforts touch this area:

- #210 changes this same upstream file, but it bounds/slices the prefill arena to make an explicit PP-for-memory trade. This PR fixes the default r14 execution geometry and does not include #210. The changes are conceptually compatible but are expected to text-conflict; whichever merges second should rebase and rerun the full-model gate.
- Issue #203 and malaiwah/glm52-exl3-vast#15 concern sharing an arena between serialized target/draft owners, dead eager-parity staging, and retained raw rotation slabs. The turnkey PR correctly changes the appliance overlay script rather than this upstream source. This PR is different: it restores large-M serial execution while retaining one-grid decode, and shares storage only between the two APIs/tier plans introduced by that shape-aware dispatcher.

## Attribution

The paired feature boundary is vLLM `2258b4e0f0f5` plus SparkInfer `f27c41d25667`. The later hardening commits are not reverted.

Both published release arms already contained the same vLLM #145, #175, and #198 revisions and the same consolidated SparkInfer #92 API. A hybrid retaining the complete r14 image and replacing only the EXL3 mixed executor recovered the prefill loss. All matched server arms forced exactly 524,288 active KV tokens, ruling out KV assignment as the cause.

On SM120, the current mixed path supports route block 8 for this shape. Route block 64 fails to compile because the register-count table has no `(256, 4, 8, 8, False)` specialization. The serial homogeneous plans support block 64 and remain substantially faster at large M; the one-grid path remains faster at decode-sized M.

## Matched full-server result

Hardware: 4x RTX PRO 6000 Blackwell, TP4/DCP4, 280 W/card, driver 595.71.05, CUDA 13.2.

Software/model contract: published r14 image, `willfalco/GLM-5.2-EXL3-TR3-3.25bpw` at `d7d79c2d14599dfce7a5d12b85f7ad73f40e623d`, MTP5, dynamic NVFP4 MLA KV, fixed 524,288 active KV tokens, 2,048 batched tokens, 8 sequences, CKV gather 140,000, vision off, and fresh compile/LMCache namespaces.

Every shape was warmed before the common measured corpus.

| Prompt | r13 control | Pristine r14 | This change | vs r14 | vs r13 |
|---:|---:|---:|---:|---:|---:|
| 3,072 | 2,322.7 tok/s | 1,772.9 tok/s | 2,283.2 tok/s | +28.78% | -1.70% |
| 32,768 | 2,180.2 tok/s | 1,660.2 tok/s | 2,146.6 tok/s | +29.30% | -1.54% |
| 131,072 | 2,057.5 tok/s | 1,583.1 tok/s | 2,033.1 tok/s | +28.43% | -1.18% |

The independent prime corpus measured 2,343.1 / 2,235.2 / 2,096.3 tok/s.

The common C1/C2/C4/C8 decode results were 98.45 / 165.25 / 198.76 / 248.07 aggregate tok/s, with mean acceptance lengths 3.518 / 4.164 / 3.926 / 3.836. Decode acceptance is stochastic; the one-grid decode path itself is unchanged.

The complete 35-request matrix had zero failures and zero preemptions.

## Memory and correctness

- Model-load memory fell from 83.53 GiB/GPU in pristine r14 to 82.81 GiB/GPU because the one-grid and serial paths share tier-ordered rotations.
- The serial K3/K4 plans share one scratch arena because they execute sequentially.
- The server exposed the full 524,288-token KV target and retained 1.5 GiB/GPU after the full matrix.
- A 509,022-token exact prompt recovered all three needles at 10%, 50%, and 90% depth in 295 seconds, with no degeneration.
- A separate 128K three-depth retrieval gate also passed.

## Tests

- `python -m pytest tests/quantization/test_exl3.py`: 20 passed in the exact r14 runtime image.
- `ruff format --check` and `ruff check` pass for both changed files.
- `py_compile` and `git diff --check` pass.
- Full GLM-5.2 TP4/DCP4 startup, eager warmup, CUDA-graph capture, HTTP inference, concurrency matrix, and maximum-context retrieval passed.

`pre-commit run --files ...` was also run from the required `uv` environment. Ruff, SPDX, configuration, filename, Docker dependency, and suggestion hooks passed. The whole-file hooks still report the release branch's existing EXL3 findings: technical identifier `suh` in typos (including this patch's uses of that existing tensor name), six source/five test mypy findings at unchanged lines, the existing `import re`, and an existing `torch.cuda` call. This patch introduces no new failure category.

The unit tests cover preparation of both APIs, shared rotation storage, and decode/prefill dispatch with serial accumulation.

## Review notes

The default threshold remains `VLLM_EXL3_TRELLIS_MAX_M`; the existing `VLLM_EXL3_PREFILL_BLOCK_M` controls the serial prefill geometry and defaults to 64. No new environment variables are introduced.

The intended long-term replacement is a competitive SM120 mixed large-block specialization. Until then, this preserves the one-grid decode win without paying its large-M prefill cost.
