### PR TITLE
[GG] exl3: shape-aware mixed decode and bounded serial prefill

### DIFF
--- a/tests/quantization/test_exl3.py
+++ b/tests/quantization/test_exl3.py
@@ -463,9 +463,10 @@ def test_mixed_trellis_dispatches_decode_and_serial_prefill(monkeypatch):
         "decode": {"launch": object(), "buffers": object()},
         "prefill_plans": (FakePlan(), FakePlan()),
         "prefill_arena": torch.empty(16, dtype=torch.uint8),
-        "prefill_accum": torch.empty((16, 4), dtype=torch.float32),
+        "prefill_accum": torch.empty((8, 4), dtype=torch.float32),
         "max_decode_m": 8,
         "max_batched_tokens": 16,
+        "prefill_capacity": 8,
     }
     tiers = (
         {"weights": object(), "route_expert_map": torch.tensor([0, -1])},
@@ -495,12 +496,32 @@ def test_mixed_trellis_dispatches_decode_and_serial_prefill(monkeypatch):
     torch.testing.assert_close(decode, torch.ones_like(decode))
     torch.testing.assert_close(prefill, torch.full_like(prefill, 3))
     assert mixed_api.calls == 1
-    assert len(fused_api.bindings) == 2
+    assert len(fused_api.bindings) == 4
+    assert [binding["a"].shape[0] for binding in fused_api.bindings] == [8] * 4
+    assert all(
+        torch.equal(binding["topk_weights"], weights[:8])
+        for binding in fused_api.bindings[:2]
+    )
+    assert all(
+        torch.equal(binding["topk_weights"], weights[8:])
+        for binding in fused_api.bindings[2:]
+    )
+    assert all(
+        torch.equal(binding["topk_ids"], ids[:8]) for binding in fused_api.bindings[:2]
+    )
+    assert all(
+        torch.equal(binding["topk_ids"], ids[8:]) for binding in fused_api.bindings[2:]
+    )
     assert (
         fused_api.bindings[0]["output"].data_ptr()
         == runtime["prefill_accum"].data_ptr()
     )
     assert fused_api.bindings[1]["output"] is None
+    assert (
+        fused_api.bindings[2]["output"].data_ptr()
+        == runtime["prefill_accum"].data_ptr()
+    )
+    assert fused_api.bindings[3]["output"] is None
 
 
 @pytest.mark.parametrize(

--- a/tests/quantization/test_exl3.py
+++ b/tests/quantization/test_exl3.py
@@ -313,6 +313,7 @@ def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(monkeypat
         local_num_experts=experts,
         exl3_hidden_size=hidden,
         exl3_intermediate_size_per_partition=intermediate,
+        exl3_params_dtype=torch.float16,
         exl3_layer_bitrates=bitrates,
         activation=MoEActivation.SILU,
         layer_name="model.layers.3.mlp.experts",
@@ -324,6 +325,8 @@ def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(monkeypat
             name = f"{prefix}_{suffix}"
             backing = slabs.get(name)
             setattr(layer, name, parameter(shards, backing=backing))
+    marker = torch.tensor(0xCBAC1FED - (1 << 32), dtype=torch.int32)
+    layer.w13_mcg.exl3_tensors[(0, "w1")] = marker
 
     class FakeMixedApi:
         def __init__(self):
@@ -346,8 +349,23 @@ def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(monkeypat
         def combine_trellis_rotations(tier0, tier1):
             return tier0, tier1
 
+    class FakeFusedApi:
+        def __init__(self):
+            self.plans = []
+            self.prepared = []
+
+        def plan_weights(self, **kwargs):
+            self.plans.append(kwargs)
+            return SimpleNamespace(**kwargs)
+
+        def prepare_weights(self, **kwargs):
+            self.prepared.append(kwargs)
+            return SimpleNamespace(plan=kwargs["plan"])
+
     api = FakeMixedApi()
+    fused_api = FakeFusedApi()
     monkeypatch.setattr(exl3_module, "_load_sparkinfer_mixed_trellis", lambda: api)
+    monkeypatch.setattr(exl3_module, "_load_sparkinfer_fused_moe", lambda: fused_api)
     method = object.__new__(Exl3MoEMethod)
     method._rank_sliced_backing = lambda _layer, name: slabs[name]
 
@@ -376,6 +394,23 @@ def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(monkeypat
     ]
     assert layer.exl3_mixed_trellis["tier_ids"] == ((0, 2), (1, 3))
     assert layer.exl3_mixed_trellis["tier_bits"] == (3, 4)
+    assert [entry["trellis_bits"] for entry in fused_api.plans] == [3, 4]
+    assert [entry["trellis_tile_config"] for entry in fused_api.plans] == [
+        (64, 128, 64, 128),
+        (64, 128, 64, 128),
+    ]
+    assert all(entry["trellis_mcg"] is marker for entry in fused_api.prepared)
+    assert len(layer.exl3_mixed_trellis["serial_tiers"]) == 2
+    rotations = layer.exl3_mixed_trellis["rotations"]
+    for mixed_entry, serial_entry in zip(api.prepared, fused_api.prepared, strict=True):
+        assert (
+            mixed_entry["gate_suh"].untyped_storage().data_ptr()
+            == rotations.gate_suh.untyped_storage().data_ptr()
+        )
+        assert (
+            serial_entry["gate_suh"].untyped_storage().data_ptr()
+            == rotations.gate_suh.untyped_storage().data_ptr()
+        )
     assert layer.w13_trellis.exl3_tensors == {}
     assert layer.w2_trellis.exl3_tensors == {}
     assert layer.w13_suh.exl3_backing is None
@@ -388,6 +423,84 @@ def test_mixed_trellis_buffer_accounting_ignores_metadata() -> None:
     second = SimpleNamespace(alias=shared.view(2, 4), label="prefill")
 
     assert exl3_module._unique_tensor_storage_bytes(first, second) == 8
+
+
+def test_mixed_trellis_dispatches_decode_and_serial_prefill(monkeypatch):
+    class FakeMixedApi:
+        calls = 0
+
+        def run_mixed_trellis(self, x, *args):
+            self.calls += 1
+            return torch.ones_like(x)
+
+    class FakeFusedApi:
+        def __init__(self):
+            self.bindings = []
+
+        def bind(self, plan, **kwargs):
+            del plan
+            self.bindings.append(kwargs)
+            return kwargs
+
+        @staticmethod
+        def run(*, binding):
+            output = binding["output"]
+            if output is not None:
+                output.fill_(1)
+                return output
+            return torch.full_like(binding["a"], 2, dtype=torch.float32)
+
+    class FakePlan:
+        @staticmethod
+        def scratch_specs():
+            return [SimpleNamespace(shape=(16,), dtype=torch.uint8)]
+
+    mixed_api = FakeMixedApi()
+    fused_api = FakeFusedApi()
+    runtime = {
+        "mixed_api": mixed_api,
+        "fused_api": fused_api,
+        "decode": {"launch": object(), "buffers": object()},
+        "prefill_plans": (FakePlan(), FakePlan()),
+        "prefill_arena": torch.empty(16, dtype=torch.uint8),
+        "prefill_accum": torch.empty((16, 4), dtype=torch.float32),
+        "max_decode_m": 8,
+        "max_batched_tokens": 16,
+    }
+    tiers = (
+        {"weights": object(), "route_expert_map": torch.tensor([0, -1])},
+        {"weights": object(), "route_expert_map": torch.tensor([-1, 0])},
+    )
+    layer = SimpleNamespace(
+        exl3_mixed_trellis={
+            "tiers": (object(), object()),
+            "serial_tiers": tiers,
+            "global_to_combined": object(),
+            "descriptor_map": object(),
+            "rotations": object(),
+        }
+    )
+    method = object.__new__(Exl3MoEMethod)
+    monkeypatch.setattr(
+        method, "_mixed_rank_sliced_runtime", lambda layer, x, ids: runtime
+    )
+    weights = torch.ones((16, 2), dtype=torch.float32)
+    ids = torch.zeros((16, 2), dtype=torch.int64)
+
+    decode = method._apply_mixed_rank_sliced(
+        layer, torch.zeros((4, 4)), weights[:4], ids[:4]
+    )
+    prefill = method._apply_mixed_rank_sliced(layer, torch.zeros((16, 4)), weights, ids)
+
+    torch.testing.assert_close(decode, torch.ones_like(decode))
+    torch.testing.assert_close(prefill, torch.full_like(prefill, 3))
+    assert mixed_api.calls == 1
+    assert len(fused_api.bindings) == 2
+    assert (
+        fused_api.bindings[0]["output"].data_ptr()
+        == runtime["prefill_accum"].data_ptr()
+    )
+    assert fused_api.bindings[1]["output"] is None
 
 
 @pytest.mark.parametrize(

--- a/tests/quantization/test_exl3_prefill_plan.py
+++ b/tests/quantization/test_exl3_prefill_plan.py
@@ -7,7 +7,8 @@ The planned Trellis API and the ExLlamaV3 extension are mocked; these tests
 prove backend policy only:
 
 * decode window m in [min, max] binds the decode plan;
-* max < m <= capacity binds the prefill plan (block_size_m=64 by default);
+* max < m <= scheduler capacity binds capacity-bounded prefill slices;
+* the opt-in prefill capacity defaults to the scheduler capacity;
 * m < min stays on the parity path with chunk-capped staging buffers;
 * VLLM_EXL3_PREFILL_TRELLIS=0 restores the single-plan parity behavior
   with full-capacity staging;
@@ -50,6 +51,7 @@ class _FakeFusedMoeApi:
     def __init__(self):
         self.planned = []
         self.bound = []
+        self.routed = []
 
     def Caps(self, **kwargs):
         return kwargs
@@ -60,12 +62,37 @@ class _FakeFusedMoeApi:
         return plan
 
     def bind(self, plan, *, scratch, a, experts, topk_weights, topk_ids):
-        del scratch, experts, topk_weights, topk_ids
+        del scratch, experts
         self.bound.append((plan, int(a.shape[0])))
-        return SimpleNamespace(plan=plan, m=int(a.shape[0]))
+        self.routed.append((topk_weights.clone(), topk_ids.clone()))
+        return SimpleNamespace(plan=plan, a=a)
 
     def run(self, *, binding):
-        return torch.zeros((binding.m, HIDDEN), dtype=torch.float32)
+        return binding.a.to(torch.float32)
+
+
+class _FakeMixedTrellisApi:
+    def __init__(self):
+        self.compiled = []
+        self.routed = []
+
+    def max_packed_route_slots(self, routed_rows, block_size, experts):
+        del block_size, experts
+        return routed_rows
+
+    def compile_mixed_trellis(self, **kwargs):
+        launch = SimpleNamespace(**kwargs)
+        self.compiled.append(launch)
+        return launch
+
+    def make_mixed_trellis_buffers(self, launch, **kwargs):
+        del kwargs
+        return SimpleNamespace(scratch=torch.empty(launch.size_m, dtype=torch.uint8))
+
+    def run_mixed_trellis(self, *args):
+        x, topk_weights, topk_ids = args[0], args[3], args[4]
+        self.routed.append((topk_weights.clone(), topk_ids.clone()))
+        return x.to(torch.float32)
 
 
 class _FakeExt:
@@ -96,6 +123,21 @@ def _make_layer():
     )
 
 
+def _make_mixed_layer():
+    layer = _make_layer()
+    layer.exl3_mixed_bitrate = True
+    layer.exl3_mixed_trellis = {
+        "tiers": (object(), object()),
+        "tier_ids": ((0, 1, 2, 3), (4, 5, 6, 7)),
+        "tier_bits": (3, 4),
+        "global_to_combined": object(),
+        "descriptor_map": object(),
+        "rotations": object(),
+        "tile_config": (64, 128, 64, 128),
+    }
+    return layer
+
+
 def _make_method():
     method = object.__new__(Exl3MoEMethod)
     method.quant_config = SimpleNamespace(
@@ -112,6 +154,7 @@ class _Harness:
         self._saved_capturing = None
         self.api = _FakeFusedMoeApi()
         self.ext = _FakeExt()
+        self.mixed_api = _FakeMixedTrellisApi()
 
     def __enter__(self):
         for name, value in self._env.items():
@@ -122,30 +165,41 @@ class _Harness:
                 os.environ[name] = value
         self._saved_loaders = (
             exl3_module._load_sparkinfer_fused_moe,
+            exl3_module._load_sparkinfer_mixed_trellis,
             exl3_module._load_exl3_ext,
         )
         exl3_module._load_sparkinfer_fused_moe = lambda: self.api
+        exl3_module._load_sparkinfer_mixed_trellis = lambda: self.mixed_api
         exl3_module._load_exl3_ext = lambda: self.ext
         self._saved_capturing = torch.cuda.is_current_stream_capturing
         torch.cuda.is_current_stream_capturing = lambda: False
         self._saved_current_device = torch.cuda.current_device
         torch.cuda.current_device = lambda: 0
+        self._saved_device_properties = torch.cuda.get_device_properties
+        torch.cuda.get_device_properties = lambda device: SimpleNamespace(
+            multi_processor_count=1,
+            shared_memory_per_block_optin=1,
+        )
         exl3_module._RANK_SLICED_RUNTIMES.clear()
+        exl3_module._MIXED_TRELLIS_RUNTIMES.clear()
         return self
 
     def __exit__(self, *exc):
         (
             exl3_module._load_sparkinfer_fused_moe,
+            exl3_module._load_sparkinfer_mixed_trellis,
             exl3_module._load_exl3_ext,
         ) = self._saved_loaders
         torch.cuda.is_current_stream_capturing = self._saved_capturing
         torch.cuda.current_device = self._saved_current_device
+        torch.cuda.get_device_properties = self._saved_device_properties
         for name, value in self._saved_env.items():
             if value is None:
                 os.environ.pop(name, None)
             else:
                 os.environ[name] = value
         exl3_module._RANK_SLICED_RUNTIMES.clear()
+        exl3_module._MIXED_TRELLIS_RUNTIMES.clear()
         return False
 
     def planned_caps(self):
@@ -159,24 +213,26 @@ def _apply(method, layer, m):
     return method._apply_rank_sliced(layer, x, weights, ids)
 
 
-def test_dual_plan_construction_and_dispatch():
-    with _Harness() as h:
+def test_opt_in_prefill_capacity_slices_dispatch():
+    with _Harness(env={"VLLM_EXL3_PREFILL_CAPACITY": "128"}) as h:
         method = _make_method()
         layer = _make_layer()
 
         out = _apply(method, layer, 16)
         assert out.dtype == torch.bfloat16 and out.shape == (16, HIDDEN)
-        # Two plans: decode (32, block 8) then prefill (capacity, block 64).
+        # Two plans: decode (32, block 8), then bounded prefill (block 64).
         assert [
             (caps["max_tokens"], caps["w4a16_block_size_m"])
             for caps in h.planned_caps()
-        ] == [(32, 8), (MAX_BATCHED, 64)]
+        ] == [(32, 8), (128, 64)]
         assert all(caps["route_num_experts"] == 0 for caps in h.planned_caps())
         assert h.api.bound[-1][0].caps["max_tokens"] == 32
 
         _apply(method, layer, 200)
-        assert h.api.bound[-1][0].caps["max_tokens"] == MAX_BATCHED
-        assert h.api.bound[-1][1] == 200
+        assert all(
+            bound[0].caps["max_tokens"] == 128 for bound in h.api.bound[-2:]
+        )
+        assert [bound[1] for bound in h.api.bound[-2:]] == [128, 72]
         assert not h.ext.moe_calls
 
         _apply(method, layer, 2)
@@ -188,6 +244,7 @@ def test_dual_plan_construction_and_dispatch():
         assert runtime["parity_rows"] == 128
         assert runtime["xh"].shape[0] == 128
         assert runtime["token_sorted"].numel() == 128 * TOPK
+        assert runtime["prefill_capacity"] == 128
 
         # Batches above the scheduler contract must fail before allocating a
         # replacement runtime or a larger Trellis arena during serving.
@@ -202,6 +259,86 @@ def test_dual_plan_construction_and_dispatch():
         assert tuple(exl3_module._RANK_SLICED_RUNTIMES) == runtime_keys
         assert len(exl3_module._RANK_SLICED_RUNTIMES) == runtime_count
         assert len(h.planned_caps()) == plan_count
+
+
+@pytest.mark.parametrize(
+    ("rows", "expected_slice_rows"),
+    ((127, [127]), (128, [128]), (129, [128, 1])),
+)
+def test_prefill_capacity_boundaries_preserve_rows_and_routing(
+    rows, expected_slice_rows
+):
+    with _Harness(env={"VLLM_EXL3_PREFILL_CAPACITY": "128"}) as h:
+        method = _make_method()
+        layer = _make_layer()
+        x = (
+            torch.arange(rows, dtype=torch.bfloat16)
+            .unsqueeze(1)
+            .expand(-1, HIDDEN)
+        )
+        weights = torch.arange(rows * TOPK, dtype=torch.float32).reshape(
+            rows, TOPK
+        )
+        ids = torch.arange(rows * TOPK, dtype=torch.int64).reshape(rows, TOPK)
+        ids = ids.remainder(EXPERTS)
+
+        out = method._apply_rank_sliced(layer, x, weights, ids)
+
+        assert [bound[1] for bound in h.api.bound] == expected_slice_rows
+        assert torch.equal(out, x)
+        assert torch.equal(
+            torch.cat([route[0] for route in h.api.routed]), weights
+        )
+        assert torch.equal(torch.cat([route[1] for route in h.api.routed]), ids)
+        assert all(bound[0] is h.api.bound[0][0] for bound in h.api.bound)
+
+
+def test_default_prefill_capacity_keeps_single_dispatch():
+    with _Harness() as h:
+        out = _apply(_make_method(), _make_layer(), 200)
+
+        assert h.planned_caps()[-1]["max_tokens"] == MAX_BATCHED
+        assert [bound[1] for bound in h.api.bound] == [200]
+        assert out.shape == (200, HIDDEN)
+
+
+def test_mixed_prefill_capacity_slices_rows_and_routing():
+    with _Harness(env={"VLLM_EXL3_PREFILL_CAPACITY": "128"}) as h:
+        method = _make_method()
+        layer = _make_mixed_layer()
+        rows = 200
+        x = (
+            torch.arange(rows, dtype=torch.bfloat16)
+            .unsqueeze(1)
+            .expand(-1, HIDDEN)
+        )
+        weights = torch.arange(rows * TOPK, dtype=torch.float32).reshape(
+            rows, TOPK
+        )
+        ids = torch.arange(rows * TOPK, dtype=torch.int64).reshape(rows, TOPK)
+        ids = ids.remainder(EXPERTS)
+
+        out = method._apply_rank_sliced(layer, x, weights, ids)
+
+        assert [launch.size_m for launch in h.mixed_api.compiled] == [32, 128]
+        assert [route[0].shape[0] for route in h.mixed_api.routed] == [128, 72]
+        assert torch.equal(out, x)
+        assert torch.equal(
+            torch.cat([route[0] for route in h.mixed_api.routed]), weights
+        )
+        assert torch.equal(
+            torch.cat([route[1] for route in h.mixed_api.routed]), ids
+        )
+
+
+def test_prefill_capacity_cannot_exceed_scheduler_bound():
+    env = {"VLLM_EXL3_PREFILL_CAPACITY": str(MAX_BATCHED + 1)}
+    with _Harness(env=env) as h:
+        with pytest.raises(
+            ValueError, match="cannot exceed max_num_batched_tokens"
+        ):
+            _apply(_make_method(), _make_layer(), 16)
+        assert not h.planned_caps()
 
 
 def test_prefill_trellis_disabled_restores_parity():
@@ -221,16 +358,19 @@ def test_prefill_trellis_disabled_restores_parity():
         runtime = next(iter(exl3_module._RANK_SLICED_RUNTIMES.values()))
         assert runtime["prefill_plan"] is None
         assert runtime["parity_rows"] == MAX_BATCHED
-        assert runtime["xh"].shape[0] == MAX_BATCHED
 
 
 def test_prefill_block_m_env_override():
-    with _Harness(env={"VLLM_EXL3_PREFILL_BLOCK_M": "48"}) as h:
+    env = {
+        "VLLM_EXL3_PREFILL_BLOCK_M": "48",
+        "VLLM_EXL3_PREFILL_CAPACITY": "128",
+    }
+    with _Harness(env=env) as h:
         method = _make_method()
         layer = _make_layer()
         _apply(method, layer, 40)
         assert h.planned_caps()[-1]["w4a16_block_size_m"] == 48
-        assert h.api.bound[-1][0].caps["max_tokens"] == MAX_BATCHED
+        assert h.api.bound[-1][0].caps["max_tokens"] == 128
 
 
 def test_parity_window_capacity_is_validated_before_planning():
@@ -259,7 +399,11 @@ def test_disabled_prefill_plan_keeps_full_parity_capacity():
 
 
 def test_explicit_parity_path_guarded_against_capture():
-    with _Harness(env={"VLLM_EXL3_TRELLIS_MIN_M": "4"}) as h:
+    env = {
+        "VLLM_EXL3_TRELLIS_MIN_M": "4",
+        "VLLM_EXL3_PREFILL_CAPACITY": "128",
+    }
+    with _Harness(env=env) as h:
         method = _make_method()
         layer = _make_layer()
         # Plan eagerly, then flip into "capturing" state.
@@ -268,18 +412,14 @@ def test_explicit_parity_path_guarded_against_capture():
         # Both trellis plans stay capture-safe.
         _apply(method, layer, 16)
         _apply(method, layer, 200)
-        assert h.api.bound[-1][1] == 200
+        assert [bound[1] for bound in h.api.bound[-2:]] == [128, 72]
         # The eager parity path must refuse to be recorded.
-        try:
+        with pytest.raises(RuntimeError, match="capture"):
             _apply(method, layer, 2)
-        except RuntimeError as err:
-            assert "capture" in str(err)
-        else:
-            raise AssertionError("parity path must raise during capture")
 
 
 if __name__ == "__main__":
-    test_dual_plan_construction_and_dispatch()
+    test_opt_in_prefill_capacity_slices_dispatch()
     test_prefill_trellis_disabled_restores_parity()
     test_prefill_block_m_env_override()
     test_explicit_parity_path_guarded_against_capture()

--- a/tests/quantization/test_exl3_prefill_plan.py
+++ b/tests/quantization/test_exl3_prefill_plan.py
@@ -61,13 +61,37 @@ class _FakeFusedMoeApi:
         self.planned.append(caps)
         return plan
 
-    def bind(self, plan, *, scratch, a, experts, topk_weights, topk_ids):
+    def bind(
+        self,
+        plan,
+        *,
+        scratch,
+        a,
+        experts,
+        topk_weights,
+        topk_ids,
+        route_expert_map=None,
+        output_expert_map=None,
+        output=None,
+    ):
         del scratch, experts
         self.bound.append((plan, int(a.shape[0])))
         self.routed.append((topk_weights.clone(), topk_ids.clone()))
-        return SimpleNamespace(plan=plan, a=a)
+        return SimpleNamespace(
+            plan=plan,
+            a=a,
+            route_expert_map=route_expert_map,
+            output_expert_map=output_expert_map,
+            output=output,
+        )
 
     def run(self, *, binding):
+        if binding.route_expert_map is not None:
+            tier_output = binding.a.to(torch.float32).mul(0.5)
+            if binding.output is not None:
+                binding.output.copy_(tier_output)
+                return binding.output
+            return tier_output
         return binding.a.to(torch.float32)
 
 
@@ -134,6 +158,17 @@ def _make_mixed_layer():
         "descriptor_map": object(),
         "rotations": object(),
         "tile_config": (64, 128, 64, 128),
+        "serial_tile_config": (64, 128, 64, 128),
+        "serial_tiers": (
+            {
+                "weights": SimpleNamespace(plan=object()),
+                "route_expert_map": torch.tensor([0, 1, 2, 3, -1, -1, -1, -1]),
+            },
+            {
+                "weights": SimpleNamespace(plan=object()),
+                "route_expert_map": torch.tensor([-1, -1, -1, -1, 0, 1, 2, 3]),
+            },
+        ),
     }
     return layer
 
@@ -229,9 +264,7 @@ def test_opt_in_prefill_capacity_slices_dispatch():
         assert h.api.bound[-1][0].caps["max_tokens"] == 32
 
         _apply(method, layer, 200)
-        assert all(
-            bound[0].caps["max_tokens"] == 128 for bound in h.api.bound[-2:]
-        )
+        assert all(bound[0].caps["max_tokens"] == 128 for bound in h.api.bound[-2:])
         assert [bound[1] for bound in h.api.bound[-2:]] == [128, 72]
         assert not h.ext.moe_calls
 
@@ -271,14 +304,8 @@ def test_prefill_capacity_boundaries_preserve_rows_and_routing(
     with _Harness(env={"VLLM_EXL3_PREFILL_CAPACITY": "128"}) as h:
         method = _make_method()
         layer = _make_layer()
-        x = (
-            torch.arange(rows, dtype=torch.bfloat16)
-            .unsqueeze(1)
-            .expand(-1, HIDDEN)
-        )
-        weights = torch.arange(rows * TOPK, dtype=torch.float32).reshape(
-            rows, TOPK
-        )
+        x = torch.arange(rows, dtype=torch.bfloat16).unsqueeze(1).expand(-1, HIDDEN)
+        weights = torch.arange(rows * TOPK, dtype=torch.float32).reshape(rows, TOPK)
         ids = torch.arange(rows * TOPK, dtype=torch.int64).reshape(rows, TOPK)
         ids = ids.remainder(EXPERTS)
 
@@ -286,9 +313,7 @@ def test_prefill_capacity_boundaries_preserve_rows_and_routing(
 
         assert [bound[1] for bound in h.api.bound] == expected_slice_rows
         assert torch.equal(out, x)
-        assert torch.equal(
-            torch.cat([route[0] for route in h.api.routed]), weights
-        )
+        assert torch.equal(torch.cat([route[0] for route in h.api.routed]), weights)
         assert torch.equal(torch.cat([route[1] for route in h.api.routed]), ids)
         assert all(bound[0] is h.api.bound[0][0] for bound in h.api.bound)
 
@@ -307,36 +332,31 @@ def test_mixed_prefill_capacity_slices_rows_and_routing():
         method = _make_method()
         layer = _make_mixed_layer()
         rows = 200
-        x = (
-            torch.arange(rows, dtype=torch.bfloat16)
-            .unsqueeze(1)
-            .expand(-1, HIDDEN)
-        )
-        weights = torch.arange(rows * TOPK, dtype=torch.float32).reshape(
-            rows, TOPK
-        )
+        x = torch.arange(rows, dtype=torch.bfloat16).unsqueeze(1).expand(-1, HIDDEN)
+        weights = torch.arange(rows * TOPK, dtype=torch.float32).reshape(rows, TOPK)
         ids = torch.arange(rows * TOPK, dtype=torch.int64).reshape(rows, TOPK)
         ids = ids.remainder(EXPERTS)
 
         out = method._apply_rank_sliced(layer, x, weights, ids)
 
-        assert [launch.size_m for launch in h.mixed_api.compiled] == [32, 128]
-        assert [route[0].shape[0] for route in h.mixed_api.routed] == [128, 72]
+        assert [launch.size_m for launch in h.mixed_api.compiled] == [32]
+        assert [caps["max_tokens"] for caps in h.planned_caps()] == [128, 128]
+        assert [bound[1] for bound in h.api.bound] == [128, 128, 72, 72]
         assert torch.equal(out, x)
         assert torch.equal(
-            torch.cat([route[0] for route in h.mixed_api.routed]), weights
+            torch.cat([route[0] for route in h.api.routed[::2]]), weights
         )
-        assert torch.equal(
-            torch.cat([route[1] for route in h.mixed_api.routed]), ids
+        assert torch.equal(torch.cat([route[1] for route in h.api.routed[::2]]), ids)
+        assert all(
+            torch.equal(left[0], right[0]) and torch.equal(left[1], right[1])
+            for left, right in zip(h.api.routed[::2], h.api.routed[1::2], strict=True)
         )
 
 
 def test_prefill_capacity_cannot_exceed_scheduler_bound():
     env = {"VLLM_EXL3_PREFILL_CAPACITY": str(MAX_BATCHED + 1)}
     with _Harness(env=env) as h:
-        with pytest.raises(
-            ValueError, match="cannot exceed max_num_batched_tokens"
-        ):
+        with pytest.raises(ValueError, match="cannot exceed max_num_batched_tokens"):
             _apply(_make_method(), _make_layer(), 16)
         assert not h.planned_caps()
 

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -2287,6 +2287,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_EXL3_TRELLIS_MAX_M": lambda: os.getenv("VLLM_EXL3_TRELLIS_MAX_M"),
     "VLLM_EXL3_TRELLIS_BLOCK_M": lambda: os.getenv("VLLM_EXL3_TRELLIS_BLOCK_M"),
     "VLLM_EXL3_PREFILL_CHUNK": lambda: os.getenv("VLLM_EXL3_PREFILL_CHUNK"),
+    "VLLM_EXL3_PREFILL_CAPACITY": lambda: os.getenv(
+        "VLLM_EXL3_PREFILL_CAPACITY"
+    ),
     "VLLM_EXL3_PREFILL_TRELLIS": lambda: os.getenv("VLLM_EXL3_PREFILL_TRELLIS"),
     "VLLM_EXL3_PREFILL_BLOCK_M": lambda: os.getenv("VLLM_EXL3_PREFILL_BLOCK_M"),
     # Prebuilt exllamav3 extension location and torch-ABI compatibility shim.

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -2287,15 +2287,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_EXL3_TRELLIS_MAX_M": lambda: os.getenv("VLLM_EXL3_TRELLIS_MAX_M"),
     "VLLM_EXL3_TRELLIS_BLOCK_M": lambda: os.getenv("VLLM_EXL3_TRELLIS_BLOCK_M"),
     "VLLM_EXL3_PREFILL_CHUNK": lambda: os.getenv("VLLM_EXL3_PREFILL_CHUNK"),
-    "VLLM_EXL3_PREFILL_CAPACITY": lambda: os.getenv(
-        "VLLM_EXL3_PREFILL_CAPACITY"
-    ),
+    "VLLM_EXL3_PREFILL_CAPACITY": lambda: os.getenv("VLLM_EXL3_PREFILL_CAPACITY"),
     "VLLM_EXL3_PREFILL_TRELLIS": lambda: os.getenv("VLLM_EXL3_PREFILL_TRELLIS"),
     "VLLM_EXL3_PREFILL_BLOCK_M": lambda: os.getenv("VLLM_EXL3_PREFILL_BLOCK_M"),
     # Prebuilt exllamav3 extension location and torch-ABI compatibility shim.
     "VLLM_EXL3_EXT_PATH": lambda: os.getenv("VLLM_EXL3_EXT_PATH"),
     "VLLM_EXL3_ABI_SHIM": lambda: os.getenv("VLLM_EXL3_ABI_SHIM"),
-
 }
 
 

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -292,6 +292,7 @@ def _positive_env_int(name: str, default: int) -> int:
         raise ValueError(f"{name} must be positive, got {value}")
     return value
 
+
 def _resolve_prefill_capacity(max_batched_tokens: int) -> int:
     """Resolve the optional EXL3 arena bound within the scheduler contract."""
 

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -264,6 +264,15 @@ def _unique_tensor_storage_bytes(*buffers: Any) -> int:
     return total
 
 
+def _scratch_view(backing: torch.Tensor, spec: Any) -> torch.Tensor:
+    """Return a typed plan-scratch view over a shared byte arena."""
+
+    nbytes = int(spec.dtype.itemsize)
+    for dim in spec.shape:
+        nbytes *= int(dim)
+    return backing.narrow(0, 0, nbytes).view(spec.dtype).view(tuple(spec.shape))
+
+
 def _positive_env_int(name: str, default: int) -> int:
     # An env var that is present but blank means "unset". Compose and Kubernetes
     # both render an unset variable as the empty string, so int("") would abort
@@ -1570,7 +1579,8 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         return (128, 128, 128, 128)
 
     def _prepare_mixed_rank_sliced_weights(self, layer: RoutedExperts) -> None:
-        api = _load_sparkinfer_mixed_trellis()
+        mixed_api = _load_sparkinfer_mixed_trellis()
+        fused_api = _load_sparkinfer_fused_moe()
         num_experts = int(layer.local_num_experts)
         hidden_size = int(layer.exl3_hidden_size)
         intermediate_size = int(layer.exl3_intermediate_size_per_partition)
@@ -1609,9 +1619,36 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         down_suh = self._rank_sliced_backing(layer, "w2_suh")
         down_svh = self._rank_sliced_backing(layer, "w2_svh")
         device = gate_suh.device
-        tile_config = self._mixed_trellis_tile_config(hidden_size, intermediate_size)
+        mixed_tile_config = self._mixed_trellis_tile_config(
+            hidden_size, intermediate_size
+        )
+        serial_tile_config = self._trellis_tile_config(hidden_size, intermediate_size)
+        marker = layer.w13_mcg.exl3_tensors[(0, "w1")]
+        tier_order = tuple(
+            expert_id for expert_ids in tiers.values() for expert_id in expert_ids
+        )
+        tier_index = torch.tensor(tier_order, dtype=torch.long, device=device)
+        combined_gate_suh = gate_suh.index_select(0, tier_index).contiguous()
+        combined_up_suh = up_suh.index_select(0, tier_index).contiguous()
+        combined_intermediate_rotations = torch.cat(
+            (
+                gate_svh.index_select(0, tier_index),
+                up_svh.index_select(0, tier_index),
+                down_suh.index_select(0, tier_index),
+            ),
+            dim=1,
+        ).contiguous()
+        combined_down_svh = down_svh.index_select(0, tier_index).contiguous()
+        combined_rotations = SimpleNamespace(
+            intermediate=combined_intermediate_rotations,
+            gate_suh=combined_gate_suh,
+            up_suh=combined_up_suh,
+            down_svh=combined_down_svh,
+        )
         prepared_tiers = []
+        serial_tiers = []
         tier_ids = []
+        tier_offset = 0
         for bits, expert_ids in tiers.items():
             expected_last = 16 * bits
             w13 = torch.stack(
@@ -1651,27 +1688,21 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 )
 
             index = torch.tensor(expert_ids, dtype=torch.long, device=device)
-            tier_gate_suh = gate_suh.index_select(0, index).contiguous()
-            tier_up_suh = up_suh.index_select(0, index).contiguous()
-            intermediate_rotations = torch.cat(
-                (
-                    gate_svh.index_select(0, index),
-                    up_svh.index_select(0, index),
-                    down_suh.index_select(0, index),
-                ),
-                dim=1,
-            ).contiguous()
-            tier_down_svh = down_svh.index_select(0, index).contiguous()
+            tier_slice = slice(tier_offset, tier_offset + len(expert_ids))
+            tier_gate_suh = combined_gate_suh[tier_slice]
+            tier_up_suh = combined_up_suh[tier_slice]
+            intermediate_rotations = combined_intermediate_rotations[tier_slice]
+            tier_down_svh = combined_down_svh[tier_slice]
             prepared_tiers.append(
-                api.prepare_weights(
+                mixed_api.prepare_weights(
                     w13=w13,
                     w2=w2,
                     hidden_size=hidden_size,
                     intermediate_size=intermediate_size,
                     num_experts=len(expert_ids),
                     activation=layer.activation.value,
-                    fc1_tile_n=tile_config[1],
-                    fc2_tile_n=tile_config[3],
+                    fc1_tile_n=mixed_tile_config[1],
+                    fc2_tile_n=mixed_tile_config[3],
                     params_dtype=torch.float16,
                     w13_layout="trellis3_t256_proj",
                     trellis_bits=bits,
@@ -1680,25 +1711,64 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                     up_suh=tier_up_suh,
                     intermediate_rotations=intermediate_rotations,
                     down_svh=tier_down_svh,
-                    tile_config=tile_config,
+                    tile_config=mixed_tile_config,
                     workspace=w13.view(torch.int32).reshape(-1)[:1],
                 )
             )
+            serial_weight_plan = fused_api.plan_weights(
+                quant_modes="w4a16",
+                source_format="exl3_trellis_mcg",
+                activation=layer.activation.value,
+                params_dtype=layer.exl3_params_dtype,
+                num_experts=len(expert_ids),
+                hidden_size=hidden_size,
+                intermediate_size=intermediate_size,
+                w13_layout="w13",
+                trellis_bits=bits,
+                trellis_tile_config=serial_tile_config,
+            )
+            serial_weights = fused_api.prepare_weights(
+                plan=serial_weight_plan,
+                params_dtype=layer.exl3_params_dtype,
+                w1_fp4=w13,
+                w2_fp4=w2,
+                gate_suh=tier_gate_suh,
+                up_suh=tier_up_suh,
+                intermediate_rotations=intermediate_rotations,
+                down_svh=tier_down_svh,
+                trellis_mcg=marker,
+            )
+            route_expert_map = torch.full(
+                (num_experts,), -1, dtype=torch.int32, device=device
+            )
+            route_expert_map[index] = torch.arange(
+                len(expert_ids), dtype=torch.int32, device=device
+            )
+            serial_tiers.append(
+                {
+                    "bits": bits,
+                    "weights": serial_weights,
+                    "route_expert_map": route_expert_map,
+                }
+            )
             tier_ids.append(expert_ids)
+            tier_offset += len(expert_ids)
 
-        global_to_combined, descriptor_map = api.build_tiered_maps(
+        global_to_combined, descriptor_map = mixed_api.build_tiered_maps(
             tier_ids[0], tier_ids[1], device=device
         )
         layer.exl3_mixed_trellis = {
             "tiers": tuple(prepared_tiers),
+            "serial_tiers": tuple(serial_tiers),
             "tier_ids": tuple(tier_ids),
             "tier_bits": tuple(tiers),
             "global_to_combined": global_to_combined,
             "descriptor_map": descriptor_map,
-            "rotations": api.combine_trellis_rotations(*prepared_tiers),
-            "tile_config": tile_config,
+            "rotations": combined_rotations,
+            "tile_config": mixed_tile_config,
+            "serial_tile_config": serial_tile_config,
         }
-        layer.exl3_trellis_tile_config = tile_config
+        layer.exl3_trellis_tile_config = serial_tile_config
 
         # The prepared tier objects own compact, tier-ordered copies. Release
         # per-expert source tensors and the original rotation slabs now rather
@@ -1834,6 +1904,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         mixed = layer.exl3_mixed_trellis
         max_decode_m = _positive_env_int("VLLM_EXL3_TRELLIS_MAX_M", 32)
         max_batched_tokens = int(layer.exl3_max_num_batched_tokens)
+        prefill_block_m = _positive_env_int("VLLM_EXL3_PREFILL_BLOCK_M", 64)
         if max_decode_m > max_batched_tokens:
             max_decode_m = max_batched_tokens
         topk = int(topk_ids.shape[1])
@@ -1853,6 +1924,8 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             max_decode_m,
             max_batched_tokens,
             mixed["tile_config"],
+            mixed["serial_tile_config"],
+            prefill_block_m,
         )
         runtime = _MIXED_TRELLIS_RUNTIMES.get(key)
         if runtime is not None:
@@ -1868,18 +1941,19 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 f"{topk_ids.dtype}"
             )
 
-        api = _load_sparkinfer_mixed_trellis()
+        mixed_api = _load_sparkinfer_mixed_trellis()
+        fused_api = _load_sparkinfer_fused_moe()
         device = x.device
         props = torch.cuda.get_device_properties(device)
         total_experts = sum(experts for _, experts in tier_signature)
 
-        def make_state(capacity: int) -> dict[str, Any]:
-            route_slots = api.max_packed_route_slots(
+        def make_decode_state(capacity: int) -> dict[str, Any]:
+            route_slots = mixed_api.max_packed_route_slots(
                 capacity * topk,
                 _MIXED_TRELLIS_ROUTE_BLOCK_SIZE,
                 total_experts,
             )
-            launch = api.compile_mixed_trellis(
+            launch = mixed_api.compile_mixed_trellis(
                 size_m=capacity,
                 hidden_size=int(layer.exl3_hidden_size),
                 intermediate_size=int(layer.exl3_intermediate_size_per_partition),
@@ -1900,37 +1974,70 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             return {
                 "capacity": capacity,
                 "launch": launch,
-                "buffers": api.make_mixed_trellis_buffers(
+                "buffers": mixed_api.make_mixed_trellis_buffers(
                     launch,
                     device=device,
                     sms=int(props.multi_processor_count),
                 ),
             }
 
-        decode = make_state(max_decode_m)
-        prefill = (
-            make_state(max_batched_tokens)
-            if max_batched_tokens > max_decode_m
-            else decode
-        )
+        decode = make_decode_state(max_decode_m)
+        prefill_plans = []
+        prefill_arena = None
+        prefill_accum = None
+        if max_batched_tokens > max_decode_m:
+            if os.environ.get("VLLM_EXL3_PREFILL_TRELLIS", "1") != "1":
+                raise ValueError("mixed-K EXL3 requires VLLM_EXL3_PREFILL_TRELLIS=1")
+            scratch_bytes = 0
+            for tier in mixed["serial_tiers"]:
+                caps = fused_api.Caps(
+                    max_tokens=max_batched_tokens,
+                    num_topk=topk,
+                    route_num_experts=total_experts,
+                    device=device,
+                    weight_plan=tier["weights"].plan,
+                    quant_mode="w4a16",
+                    w4a16_block_size_m=prefill_block_m,
+                )
+                plan = fused_api.plan(caps)
+                prefill_plans.append(plan)
+                spec = plan.scratch_specs()[0]
+                size = int(spec.dtype.itemsize)
+                for dim in spec.shape:
+                    size *= int(dim)
+                scratch_bytes = max(scratch_bytes, size)
+            prefill_arena = torch.empty(scratch_bytes, dtype=torch.uint8, device=device)
+            prefill_accum = torch.empty(
+                (max_batched_tokens, int(layer.exl3_hidden_size)),
+                dtype=torch.float32,
+                device=device,
+            )
         runtime = {
-            "api": api,
+            "mixed_api": mixed_api,
+            "fused_api": fused_api,
             "decode": decode,
-            "prefill": prefill,
+            "prefill_plans": tuple(prefill_plans),
+            "prefill_arena": prefill_arena,
+            "prefill_accum": prefill_accum,
             "max_decode_m": max_decode_m,
             "max_batched_tokens": max_batched_tokens,
         }
         _MIXED_TRELLIS_RUNTIMES[key] = runtime
-        buffer_bytes = _unique_tensor_storage_bytes(
-            decode["buffers"], prefill["buffers"]
+        decode_bytes = _unique_tensor_storage_bytes(decode["buffers"])
+        prefill_bytes = sum(
+            tensor.numel() * tensor.element_size()
+            for tensor in (prefill_arena, prefill_accum)
+            if tensor is not None
         )
         logger.info_once(
-            "EXL3 mixed Trellis runtime planned: tiers=%s decode_capacity=%d "
-            "prefill_capacity=%d buffers=%.1f MiB",
+            "EXL3 mixed Trellis runtime planned: tiers=%s one-grid decode=%d "
+            "serial prefill=%d block_m=%d buffers=%.1f+%.1f MiB",
             tier_signature,
             max_decode_m,
             max_batched_tokens,
-            buffer_bytes / (1 << 20),
+            prefill_block_m,
+            decode_bytes / (1 << 20),
+            prefill_bytes / (1 << 20),
         )
         return runtime
 
@@ -1948,23 +2055,53 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 "mixed-bitrate EXL3 batch exceeds planned capacity: "
                 f"m={m}, capacity={runtime['max_batched_tokens']}"
             )
-        state = (
-            runtime["decode"] if m <= runtime["max_decode_m"] else runtime["prefill"]
-        )
         mixed = layer.exl3_mixed_trellis
-        output = runtime["api"].run_mixed_trellis(
-            x,
-            mixed["tiers"][0],
-            mixed["tiers"][1],
-            topk_weights,
-            topk_ids,
-            mixed["global_to_combined"],
-            mixed["descriptor_map"],
-            mixed["rotations"],
-            state["launch"],
-            state["buffers"],
-        )
-        return output.to(x.dtype)
+        # The cooperative mixed-K grid wins at small M, but its SM120 path is
+        # currently limited to route block 8.  Homogeneous tier plans support
+        # block 64 and are substantially faster for prefill, so keep the
+        # one-grid launch for decode and dispatch large M through the two
+        # serial tiers until the mixed kernel gains an efficient large block.
+        if m <= runtime["max_decode_m"]:
+            state = runtime["decode"]
+            output = runtime["mixed_api"].run_mixed_trellis(
+                x,
+                mixed["tiers"][0],
+                mixed["tiers"][1],
+                topk_weights,
+                topk_ids,
+                mixed["global_to_combined"],
+                mixed["descriptor_map"],
+                mixed["rotations"],
+                state["launch"],
+                state["buffers"],
+            )
+            return output.to(x.dtype)
+
+        if runtime["prefill_arena"] is None or runtime["prefill_accum"] is None:
+            raise RuntimeError("mixed-K EXL3 serial prefill plan is unavailable")
+        accum = runtime["prefill_accum"][:m]
+        first = True
+        for plan, tier in zip(
+            runtime["prefill_plans"], mixed["serial_tiers"], strict=True
+        ):
+            binding = runtime["fused_api"].bind(
+                plan,
+                scratch=_scratch_view(
+                    runtime["prefill_arena"], plan.scratch_specs()[0]
+                ),
+                a=x,
+                experts=tier["weights"],
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
+                route_expert_map=tier["route_expert_map"],
+                output_expert_map=tier["route_expert_map"],
+                output=accum if first else None,
+            )
+            output = runtime["fused_api"].run(binding=binding)
+            if not first:
+                accum.add_(output)
+            first = False
+        return accum.to(x.dtype)
 
     def _rank_sliced_runtime(
         self,

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -293,6 +293,21 @@ def _positive_env_int(name: str, default: int) -> int:
     return value
 
 
+def _resolve_prefill_capacity(max_batched_tokens: int) -> int:
+    """Resolve the optional EXL3 arena bound within the scheduler contract."""
+
+    prefill_capacity = _positive_env_int(
+        "VLLM_EXL3_PREFILL_CAPACITY", max_batched_tokens
+    )
+    if prefill_capacity > max_batched_tokens:
+        raise ValueError(
+            "VLLM_EXL3_PREFILL_CAPACITY cannot exceed "
+            "max_num_batched_tokens: "
+            f"capacity={prefill_capacity}, max={max_batched_tokens}"
+        )
+    return prefill_capacity
+
+
 @torch.library.custom_op(
     "vllm::exl3_gemm",
     mutates_args=(),
@@ -1904,6 +1919,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         mixed = layer.exl3_mixed_trellis
         max_decode_m = _positive_env_int("VLLM_EXL3_TRELLIS_MAX_M", 32)
         max_batched_tokens = int(layer.exl3_max_num_batched_tokens)
+        prefill_capacity = _resolve_prefill_capacity(max_batched_tokens)
         prefill_block_m = _positive_env_int("VLLM_EXL3_PREFILL_BLOCK_M", 64)
         if max_decode_m > max_batched_tokens:
             max_decode_m = max_batched_tokens
@@ -1923,6 +1939,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             topk,
             max_decode_m,
             max_batched_tokens,
+            prefill_capacity,
             mixed["tile_config"],
             mixed["serial_tile_config"],
             prefill_block_m,
@@ -1991,7 +2008,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             scratch_bytes = 0
             for tier in mixed["serial_tiers"]:
                 caps = fused_api.Caps(
-                    max_tokens=max_batched_tokens,
+                    max_tokens=prefill_capacity,
                     num_topk=topk,
                     route_num_experts=total_experts,
                     device=device,
@@ -2008,7 +2025,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 scratch_bytes = max(scratch_bytes, size)
             prefill_arena = torch.empty(scratch_bytes, dtype=torch.uint8, device=device)
             prefill_accum = torch.empty(
-                (max_batched_tokens, int(layer.exl3_hidden_size)),
+                (prefill_capacity, int(layer.exl3_hidden_size)),
                 dtype=torch.float32,
                 device=device,
             )
@@ -2021,6 +2038,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             "prefill_accum": prefill_accum,
             "max_decode_m": max_decode_m,
             "max_batched_tokens": max_batched_tokens,
+            "prefill_capacity": prefill_capacity,
         }
         _MIXED_TRELLIS_RUNTIMES[key] = runtime
         decode_bytes = _unique_tensor_storage_bytes(decode["buffers"])
@@ -2031,9 +2049,10 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         )
         logger.info_once(
             "EXL3 mixed Trellis runtime planned: tiers=%s one-grid decode=%d "
-            "serial prefill=%d block_m=%d buffers=%.1f+%.1f MiB",
+            "serial prefill=%d/%d block_m=%d buffers=%.1f+%.1f MiB",
             tier_signature,
             max_decode_m,
+            prefill_capacity,
             max_batched_tokens,
             prefill_block_m,
             decode_bytes / (1 << 20),
@@ -2079,29 +2098,51 @@ class Exl3MoEMethod(FusedMoEMethodBase):
 
         if runtime["prefill_arena"] is None or runtime["prefill_accum"] is None:
             raise RuntimeError("mixed-K EXL3 serial prefill plan is unavailable")
-        accum = runtime["prefill_accum"][:m]
-        first = True
-        for plan, tier in zip(
-            runtime["prefill_plans"], mixed["serial_tiers"], strict=True
-        ):
-            binding = runtime["fused_api"].bind(
-                plan,
-                scratch=_scratch_view(
-                    runtime["prefill_arena"], plan.scratch_specs()[0]
-                ),
-                a=x,
-                experts=tier["weights"],
-                topk_weights=topk_weights,
-                topk_ids=topk_ids,
-                route_expert_map=tier["route_expert_map"],
-                output_expert_map=tier["route_expert_map"],
-                output=accum if first else None,
+        prefill_capacity = int(runtime["prefill_capacity"])
+
+        def run_serial_slice(
+            slice_x: torch.Tensor,
+            slice_weights: torch.Tensor,
+            slice_ids: torch.Tensor,
+        ) -> torch.Tensor:
+            slice_m = int(slice_x.shape[0])
+            accum = runtime["prefill_accum"][:slice_m]
+            first = True
+            for plan, tier in zip(
+                runtime["prefill_plans"], mixed["serial_tiers"], strict=True
+            ):
+                binding = runtime["fused_api"].bind(
+                    plan,
+                    scratch=_scratch_view(
+                        runtime["prefill_arena"], plan.scratch_specs()[0]
+                    ),
+                    a=slice_x,
+                    experts=tier["weights"],
+                    topk_weights=slice_weights,
+                    topk_ids=slice_ids,
+                    route_expert_map=tier["route_expert_map"],
+                    output_expert_map=tier["route_expert_map"],
+                    output=accum if first else None,
+                )
+                tier_output = runtime["fused_api"].run(binding=binding)
+                if not first:
+                    accum.add_(tier_output)
+                first = False
+            return accum.to(slice_x.dtype)
+
+        if m <= prefill_capacity:
+            return run_serial_slice(x, topk_weights, topk_ids)
+
+        output = torch.empty_like(x)
+        for start in range(0, m, prefill_capacity):
+            stop = min(start + prefill_capacity, m)
+            slice_output = run_serial_slice(
+                x[start:stop],
+                topk_weights[start:stop],
+                topk_ids[start:stop],
             )
-            output = runtime["fused_api"].run(binding=binding)
-            if not first:
-                accum.add_(output)
-            first = False
-        return accum.to(x.dtype)
+            output[start:stop].copy_(slice_output)
+        return output
 
     def _rank_sliced_runtime(
         self,
@@ -2133,12 +2174,19 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             raise ValueError(
                 "VLLM_EXL3_TRELLIS_MIN_M cannot exceed VLLM_EXL3_TRELLIS_MAX_M"
             )
-        # Batch-INVARIANT capacity. Including x.shape[0] here made the runtime
-        # cache key depend on the live batch, so any m above the planned capacity
-        # produced a cache MISS -- silently planning a fresh ~1 GiB arena mid-serve
-        # and making the capacity guard in _apply_rank_sliced unreachable. The
-        # planned capacity is a property of the layer, not of one forward pass.
+        # Both capacities are batch-invariant runtime properties. The scheduler
+        # bound remains fail-closed while a smaller opt-in Trellis capacity is
+        # handled by slicing at dispatch.
         max_batched_tokens = int(layer.exl3_max_num_batched_tokens)
+        prefill_capacity = _positive_env_int(
+            "VLLM_EXL3_PREFILL_CAPACITY", max_batched_tokens
+        )
+        if prefill_capacity > max_batched_tokens:
+            raise ValueError(
+                "VLLM_EXL3_PREFILL_CAPACITY cannot exceed "
+                "max_num_batched_tokens: "
+                f"capacity={prefill_capacity}, max={max_batched_tokens}"
+            )
         prefill_plan_enabled = prefill_trellis and max_batched_tokens > max_trellis_m
         parity_rows = (
             min(chunk, max_batched_tokens)
@@ -2173,6 +2221,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             prefill_trellis,
             prefill_block_m,
             layer.exl3_trellis_tile_config,
+            prefill_capacity,
         )
         runtime = _RANK_SLICED_RUNTIMES.get(key)
         if runtime is not None:
@@ -2216,7 +2265,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         prefill_scratch = None
         if prefill_plan_enabled:
             prefill_plan, prefill_scratch = _plan_with_scratch(
-                max_batched_tokens, prefill_block_m
+                prefill_capacity, prefill_block_m
             )
 
         ext = _load_exl3_ext()
@@ -2247,6 +2296,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             "min_trellis_m": min_trellis_m,
             "max_trellis_m": max_trellis_m,
             "max_batched_tokens": max_batched_tokens,
+            "prefill_capacity": prefill_capacity,
             "parity_rows": parity_rows,
             "topk": topk,
             "chunk": chunk,
@@ -2319,12 +2369,13 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         )
         logger.info_once(
             "EXL3 rank-sliced runtime planned: Trellis m=%d..%d block_m=%d, "
-            "prefill %s capacity=%d chunk=%d topk=%d",
+            "prefill %s scheduler_capacity=%d chunk=%d topk=%d",
             min_trellis_m,
             max_trellis_m,
             block_m,
             (
-                f"trellis block_m={prefill_block_m} arena={prefill_arena_mib:.1f}MiB"
+                f"trellis block_m={prefill_block_m} "
+                f"capacity={prefill_capacity} arena={prefill_arena_mib:.1f}MiB"
                 if prefill_plan is not None
                 else "parity"
             ),
@@ -2368,16 +2419,33 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                     "EXL3 batch exceeds its planned capacity: "
                     f"m={m}, capacity={runtime['max_batched_tokens']}"
                 )
-            binding = runtime["api"].bind(
-                runtime["prefill_plan"],
-                scratch=runtime["prefill_scratch"],
-                a=x,
-                experts=layer.exl3_trellis_weights,
-                topk_weights=topk_weights,
-                topk_ids=topk_ids,
-            )
-            output = runtime["api"].run(binding=binding)
-            return output.to(x.dtype)
+            prefill_capacity = int(runtime["prefill_capacity"])
+            if m <= prefill_capacity:
+                binding = runtime["api"].bind(
+                    runtime["prefill_plan"],
+                    scratch=runtime["prefill_scratch"],
+                    a=x,
+                    experts=layer.exl3_trellis_weights,
+                    topk_weights=topk_weights,
+                    topk_ids=topk_ids,
+                )
+                output = runtime["api"].run(binding=binding)
+                return output.to(x.dtype)
+
+            output = torch.empty_like(x)
+            for start in range(0, m, prefill_capacity):
+                stop = min(start + prefill_capacity, m)
+                binding = runtime["api"].bind(
+                    runtime["prefill_plan"],
+                    scratch=runtime["prefill_scratch"],
+                    a=x[start:stop],
+                    experts=layer.exl3_trellis_weights,
+                    topk_weights=topk_weights[start:stop],
+                    topk_ids=topk_ids[start:stop],
+                )
+                slice_output = runtime["api"].run(binding=binding)
+                output[start:stop].copy_(slice_output)
+            return output
 
         if torch.cuda.is_current_stream_capturing():
             raise RuntimeError(

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -292,7 +292,6 @@ def _positive_env_int(name: str, default: int) -> int:
         raise ValueError(f"{name} must be positive, got {value}")
     return value
 
-
 def _resolve_prefill_capacity(max_batched_tokens: int) -> int:
     """Resolve the optional EXL3 arena bound within the scheduler contract."""
 
@@ -2178,15 +2177,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         # bound remains fail-closed while a smaller opt-in Trellis capacity is
         # handled by slicing at dispatch.
         max_batched_tokens = int(layer.exl3_max_num_batched_tokens)
-        prefill_capacity = _positive_env_int(
-            "VLLM_EXL3_PREFILL_CAPACITY", max_batched_tokens
-        )
-        if prefill_capacity > max_batched_tokens:
-            raise ValueError(
-                "VLLM_EXL3_PREFILL_CAPACITY cannot exceed "
-                "max_num_batched_tokens: "
-                f"capacity={prefill_capacity}, max={max_batched_tokens}"
-            )
+        prefill_capacity = _resolve_prefill_capacity(max_batched_tokens)
         prefill_plan_enabled = prefill_trellis and max_batched_tokens > max_trellis_m
         parity_rows = (
             min(chunk, max_batched_tokens)


### PR DESCRIPTION
## Summary

Make mixed-bitrate EXL3 execution shape-aware and add a bounded-memory prefill option:

- retain SparkInfer's one-grid mixed K3/K4 path for decode and small row counts;
- dispatch larger prefills through serial homogeneous K3/K4 block-64 plans;
- share tier-ordered rotations and one scratch arena between the serial tiers;
- optionally bound that arena with `VLLM_EXL3_PREFILL_CAPACITY` and slice larger prefills through it;
- preserve route weights, route IDs, output views, decode selection, and CUDA-capture behavior.

This supersedes #210. Keeping both changes in one PR avoids two conflicting edits to the same EXL3 planning and dispatch code. The default remains unbounded at `max_num_batched_tokens`; the capacity knob is opt-in.

## Why

The one-grid mixed K3/K4 kernel is the best path for decode-sized M, but its block-8 geometry regressed large prefill. Homogeneous serial K3/K4 plans support block 64 and are substantially faster at large M.

The serial tiers never overlap, so they can safely share rotations and scratch. Operators that prioritize KV capacity can additionally cap the serial arena; live prefills above the cap are processed as contiguous slices through the same persistent plan and accumulator.

## Matched TP4/DCP4 validation

Hardware: 4x RTX PRO 6000 Blackwell on GPUs 12-15. Model: `willfalco/GLM-5.2-EXL3-TR3-3.25bpw` at `d7d79c2d14599dfce7a5d12b85f7ad73f40e623d`. Published r16 image, MTP off, `max_num_batched_tokens=2048`, `max_num_seqs=1`, graph cap 6, identical helper configuration and JIT cache.

| Variant | KV tokens | 3k | 32k | 128k |
|---|---:|---:|---:|---:|
| r16 stock mixed one-grid | 804,864 | 3,012 | 2,855 | 2,363 |
| shape-aware, default capacity | 856,320 | 3,792 | 3,690 | 3,324 |
| shape-aware, capacity 1024 | 896,000 | 3,335 | 3,277 | 2,932 |

Default shape-aware deltas versus stock are `+25.9% / +29.2% / +40.7%`, while KV capacity grows by 6.4%. Capacity 1024 grows KV capacity by 11.3% versus stock and remains `+10.7% / +14.8% / +24.1%` faster than stock.

Startup contracts observed in the same run:

```text
default:  one-grid decode=32 serial prefill=2048/2048 block_m=64 buffers=31.0+783.3 MiB
cap 1024: one-grid decode=32 serial prefill=1024/2048 block_m=64 buffers=31.0+438.7 MiB
```

A live HTTP correctness request also completed normally after the capacity-1024 run.

## Tests

```text
32 passed
```

Suites:

- `tests/quantization/test_exl3.py`
- `tests/quantization/test_exl3_prefill_plan.py`

The tests cover both APIs, shared rotations, shape dispatch, serial accumulation, exact capacity boundaries, short tails, multi-slice route/output preservation, invalid capacity rejection, and reuse of the same persistent accumulator. Changed-file Ruff checks, formatting, and `git diff --check` pass.

## Operational contract

- Unset or blank `VLLM_EXL3_PREFILL_CAPACITY` resolves to `max_num_batched_tokens` and is the recommended throughput default.
- A positive value at or below `max_num_batched_tokens` trades additional launches for lower scratch and more KV cache.
- Invalid, non-positive, or above-scheduler values are rejected rather than silently clamped.
- The existing `VLLM_EXL3_TRELLIS_MAX_M` remains the decode/small-M threshold.
- The existing `VLLM_EXL3_PREFILL_BLOCK_M` controls serial prefill geometry and defaults to 64.

The paired SparkInfer kernel work is tracked separately; this PR changes only vLLM integration and policy.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved EXL3 quantization support for mixed-bitrate and rank-sliced models.
  - Added optimized execution paths for decode and serial prefill workloads.
  - Added configurable prefill capacity through `VLLM_EXL3_PREFILL_CAPACITY`.
  - Large prefill batches are now processed in bounded chunks to improve reliability and resource usage.

- **Bug Fixes**
  - Improved routing, output handling, and buffer reuse across mixed expert-model workloads.
  - Added validation for unsupported prefill capacity configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->