### PR TITLE
[GG] quant: add EXL3 BF16 MXFP8 online overlay

### DIFF
--- a/docs/features/quantization/online.md
+++ b/docs/features/quantization/online.md
@@ -100,7 +100,7 @@ vllm serve <glm-5.2-modelopt-checkpoint> \
 Serialized checkpoint-quantized shared experts are preserved; only excluded
 BF16 projection weights are converted at load time.
 
-### MXFP8 dense linears on ModelOpt checkpoints
+### MXFP8 dense linears on quantized checkpoints
 
 The `linear` field overlays online MXFP8 the same way onto every other
 BF16 dense linear the ModelOpt checkpoint excludes: attention projections,
@@ -142,6 +142,22 @@ vllm serve lukealonso/GLM-5.2-NVFP4 \
   --quantization modelopt_fp4 \
   --quantization-config '{"linear":{"weight":"mxfp8"},"ignore":["re:.*kv_b_proj"]}'
 ```
+
+EXL3 checkpoints can use the same overlay for dense and shared-expert
+projections that are absent from the EXL3 tensor metadata. Serialized EXL3
+dense matrices and routed experts always retain their checkpoint format;
+`moe` overlays are rejected. `lm_head` also remains in its checkpoint format
+or BF16. For example:
+
+```bash
+vllm serve <exl3-checkpoint> \
+  --quantization exl3 \
+  --quantization-config '{"linear":{"weight":"mxfp8"},"shared_experts":{"weight":"mxfp8"},"ignore":["re:.*\\.q_a_proj$","re:.*kv_a_proj_with_mqa","lm_head"]}'
+```
+
+As with ModelOpt, `linear` does not select shared experts. Add the
+`shared_experts` field explicitly when those BF16 projections should also be
+converted. Ignore patterns are matched against unfused checkpoint names.
 
 ### Activation overrides on already-quantized checkpoints
 

--- a/tests/quantization/test_exl3.py
+++ b/tests/quantization/test_exl3.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pytest
 import torch
@@ -9,10 +10,13 @@ import torch
 import vllm.model_executor.layers.quantization.exl3 as exl3_module
 import vllm.model_executor.parameter as parameter_module
 from vllm.config import CompilationMode
-from vllm.model_executor.layers.fused_moe import MoEActivation
+from vllm.config.quantization import QuantizationConfigArgs
+from vllm.model_executor.layers.fused_moe import MoEActivation, RoutedExperts
+from vllm.model_executor.layers.linear import LinearBase, UnquantizedLinearMethod
 from vllm.model_executor.layers.quantization import get_quantization_config
 from vllm.model_executor.layers.quantization.exl3 import (
     Exl3Config,
+    Exl3LinearMethod,
     Exl3MoEMethod,
     Exl3MoEParameter,
 )
@@ -33,6 +37,125 @@ def _rank_sliced_metadata(**overrides):
     }
     metadata.update(overrides)
     return metadata
+
+
+def _set_online_overlay(monkeypatch, args: QuantizationConfigArgs) -> object:
+    current = SimpleNamespace(
+        model_config=SimpleNamespace(
+            quantization_config=args,
+            enforce_eager=True,
+        )
+    )
+    sentinel = object()
+    monkeypatch.setattr(exl3_module, "get_current_vllm_config_or_none", lambda: current)
+    monkeypatch.setattr(exl3_module, "Mxfp8OnlineLinearMethod", lambda: sentinel)
+    return sentinel
+
+
+def _mock_linear() -> Mock:
+    return Mock(spec=LinearBase)
+
+
+def test_exl3_online_overlay_quantizes_only_bf16_dense_and_shared(monkeypatch):
+    config = Exl3Config(
+        tensor_storage={"model.layers.3.self_attn.q_b_proj": {"quant_format": "exl3"}}
+    )
+    sentinel = _set_online_overlay(
+        monkeypatch,
+        QuantizationConfigArgs(linear="mxfp8", shared_experts="mxfp8"),
+    )
+
+    serialized = config.get_quant_method(
+        _mock_linear(), "model.layers.3.self_attn.q_b_proj"
+    )
+    dense_bf16 = config.get_quant_method(
+        _mock_linear(), "model.layers.3.self_attn.kv_b_proj"
+    )
+    shared_bf16 = config.get_quant_method(
+        _mock_linear(), "model.layers.3.mlp.shared_experts.down_proj"
+    )
+
+    assert isinstance(serialized, Exl3LinearMethod)
+    assert dense_bf16 is sentinel
+    assert shared_bf16 is sentinel
+
+
+def test_exl3_linear_overlay_does_not_select_shared_experts(monkeypatch):
+    config = Exl3Config()
+    sentinel = _set_online_overlay(monkeypatch, QuantizationConfigArgs(linear="mxfp8"))
+
+    dense = config.get_quant_method(
+        _mock_linear(), "model.layers.3.self_attn.kv_b_proj"
+    )
+    shared = config.get_quant_method(
+        _mock_linear(), "model.layers.3.mlp.shared_experts.down_proj"
+    )
+
+    assert dense is sentinel
+    assert isinstance(shared, UnquantizedLinearMethod)
+
+
+def test_exl3_online_overlay_honors_unfused_ignore_names(monkeypatch):
+    config = Exl3Config()
+    config.packed_modules_mapping = {
+        "fused_qkv_a_proj": ["q_a_proj", "kv_a_proj_with_mqa"]
+    }
+    sentinel = _set_online_overlay(
+        monkeypatch,
+        QuantizationConfigArgs(
+            linear="mxfp8",
+            ignore=["re:.*\\.q_a_proj$", "re:.*kv_a_proj_with_mqa"],
+        ),
+    )
+
+    ignored = config.get_quant_method(
+        _mock_linear(), "model.layers.3.self_attn.fused_qkv_a_proj"
+    )
+    kept = config.get_quant_method(_mock_linear(), "model.layers.3.self_attn.kv_b_proj")
+
+    assert isinstance(ignored, UnquantizedLinearMethod)
+    assert kept is sentinel
+
+
+def test_exl3_online_overlay_rejects_split_packed_quantization(monkeypatch):
+    config = Exl3Config()
+    config.packed_modules_mapping = {
+        "fused_qkv_a_proj": ["q_a_proj", "kv_a_proj_with_mqa"]
+    }
+    _set_online_overlay(
+        monkeypatch,
+        QuantizationConfigArgs(linear="mxfp8", ignore=["re:.*\\.q_a_proj$"]),
+    )
+
+    with pytest.raises(ValueError, match="different quantization schemes"):
+        config.get_quant_method(
+            _mock_linear(), "model.layers.3.self_attn.fused_qkv_a_proj"
+        )
+
+
+def test_exl3_online_overlay_never_quantizes_bf16_lm_head(monkeypatch):
+    config = Exl3Config()
+    _set_online_overlay(monkeypatch, QuantizationConfigArgs(linear="mxfp8"))
+    lm_head = type("ParallelLMHead", (torch.nn.Module,), {})()
+
+    method = config.get_quant_method(lm_head, "lm_head")
+
+    assert isinstance(method, UnquantizedLinearMethod)
+
+
+def test_exl3_online_overlay_preserves_rank_sliced_routed_experts(monkeypatch):
+    config = Exl3Config()
+    config.rank_sliced_metadata = _rank_sliced_metadata()
+    _set_online_overlay(
+        monkeypatch,
+        QuantizationConfigArgs(linear="mxfp8", shared_experts="mxfp8"),
+    )
+    routed = Mock(spec=RoutedExperts)
+    routed.moe_config = object()
+
+    method = config.get_quant_method(routed, "model.layers.3.mlp.experts")
+
+    assert isinstance(method, Exl3MoEMethod)
 
 
 def test_rank_sliced_checkpoint_selects_exl3_override():

--- a/tests/quantization/test_exl3.py
+++ b/tests/quantization/test_exl3.py
@@ -133,6 +133,21 @@ def test_exl3_online_overlay_rejects_split_packed_quantization(monkeypatch):
         )
 
 
+def test_exl3_online_overlay_rejects_mixed_packed_storage(monkeypatch):
+    config = Exl3Config(
+        tensor_storage={"model.layers.3.self_attn.q_a_proj": {"quant_format": "exl3"}}
+    )
+    config.packed_modules_mapping = {
+        "fused_qkv_a_proj": ["q_a_proj", "kv_a_proj_with_mqa"]
+    }
+    _set_online_overlay(monkeypatch, QuantizationConfigArgs(linear="mxfp8"))
+
+    with pytest.raises(ValueError, match="mixes EXL3 and BF16 source shards"):
+        config.get_quant_method(
+            _mock_linear(), "model.layers.3.self_attn.fused_qkv_a_proj"
+        )
+
+
 def test_exl3_online_overlay_never_quantizes_bf16_lm_head(monkeypatch):
     config = Exl3Config()
     _set_online_overlay(monkeypatch, QuantizationConfigArgs(linear="mxfp8"))

--- a/tests/quantization/test_quantization_config_args.py
+++ b/tests/quantization/test_quantization_config_args.py
@@ -187,6 +187,35 @@ def test_resolve_rejects_modelopt_moe_override():
         )
 
 
+def test_resolve_allows_exl3_bf16_mxfp8_overlay():
+    args = resolve_quantization_config(
+        "exl3",
+        {
+            "linear": {"weight": "mxfp8"},
+            "shared_experts": "mxfp8",
+            "ignore": ["re:.*q_a_proj$", "lm_head"],
+        },
+    )
+
+    assert args.linear == QuantSpec(weight=kMxfp8Dynamic)
+    assert args.shared_experts == QuantSpec(weight=kMxfp8Dynamic)
+    assert args.ignore == ["re:.*q_a_proj$", "lm_head"]
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        {"linear": {"weight": "fp8_per_block_static"}},
+        {"linear": {"weight": "mxfp8", "activation": "mxfp8"}},
+        {"linear": {"weight": "mxfp8"}, "moe": "mxfp8"},
+        {"shared_experts": "mxfp8", "ignore": ["lm_head"]},
+    ],
+)
+def test_resolve_rejects_unsupported_exl3_overlay(config):
+    with pytest.raises(ValueError, match="checkpoint online overlay"):
+        resolve_quantization_config("exl3", config)
+
+
 def test_resolve_rejects_quantization_config_with_non_shorthand_quant():
     # If --quantization names something other than an online shorthand,
     # quantization_config is not allowed via this path (checkpoint quant

--- a/vllm/config/quantization.py
+++ b/vllm/config/quantization.py
@@ -193,8 +193,7 @@ def resolve_quantization_config(
     quantization: str | None,
     quantization_config: dict[str, Any] | QuantizationConfigArgs | None,
 ) -> QuantizationConfigArgs | None:
-    """Resolve `--quantization` shorthand and `--quantization-config` into a
-    QuantizationConfigArgs.
+    """Resolve quantization CLI settings into structured arguments.
 
     `quantization` may be a CLI shorthand that desugars into a base config via
     `_ONLINE_SHORTHANDS`. `quantization_config` is a dict or pre-built args
@@ -202,6 +201,18 @@ def resolve_quantization_config(
     `quantization_config` take precedence over the shorthand. Selected
     checkpoint formats accept online overlays for BF16 dense/shared-expert
     projections.
+
+    Args:
+        quantization: Quantization method name or online shorthand.
+        quantization_config: Explicit online quantization fields, if any.
+
+    Returns:
+        The resolved quantization arguments, or ``None`` when no online
+        configuration was requested.
+
+    Raises:
+        ValueError: If an explicit configuration cannot overlay the selected
+            checkpoint quantization method.
     """
     if isinstance(quantization_config, dict):
         quantization_config = QuantizationConfigArgs(**quantization_config)

--- a/vllm/config/quantization.py
+++ b/vllm/config/quantization.py
@@ -153,11 +153,14 @@ ONLINE_QUANT_SHORTHAND_NAMES: tuple[str, ...] = (
 )
 
 
-# Checkpoint formats that support overlaying online quantization on BF16 projections
-# which the checkpoint explicitly leaves unquantized (shared experts via
-# `shared_experts`, other dense linears via `linear`).
-_MODELOPT_ONLINE_OVERLAY_NAMES = frozenset(
-    {
+# Checkpoint formats that support overlaying online quantization on projections
+# which the checkpoint explicitly leaves in BF16 (shared experts via
+# `shared_experts`, other dense linears via `linear`). Each checkpoint backend
+# still owns the layer-level dispatch, so serialized weights always take
+# precedence over this overlay.
+_CHECKPOINT_ONLINE_OVERLAY_WEIGHTS = {
+    name: frozenset({kMxfp8Dynamic, kFp8Static128BlockSym})
+    for name in {
         "modelopt",
         "modelopt_fp4",
         "modelopt_mxfp8",
@@ -165,16 +168,15 @@ _MODELOPT_ONLINE_OVERLAY_NAMES = frozenset(
         "mxfp4",
         "nvfp4_nf3_hybrid",
     }
-)
+}
+_CHECKPOINT_ONLINE_OVERLAY_WEIGHTS["exl3"] = frozenset({kMxfp8Dynamic})
 
 
-_MODELOPT_ONLINE_OVERLAY_WEIGHTS = frozenset({kMxfp8Dynamic, kFp8Static128BlockSym})
-
-
-def _is_modelopt_online_overlay(
+def _is_checkpoint_online_overlay(
     quantization: str | None, args: QuantizationConfigArgs
 ) -> bool:
-    if quantization not in _MODELOPT_ONLINE_OVERLAY_NAMES or args.moe is not None:
+    supported_weights = _CHECKPOINT_ONLINE_OVERLAY_WEIGHTS.get(quantization)
+    if supported_weights is None or args.moe is not None:
         return False
     specs = [s for s in (args.linear, args.shared_experts) if s is not None]
     if not specs:
@@ -183,8 +185,7 @@ def _is_modelopt_online_overlay(
         # `ignore` only filters the dense-linear overlay.
         return False
     return all(
-        spec.weight in _MODELOPT_ONLINE_OVERLAY_WEIGHTS and spec.activation is None
-        for spec in specs
+        spec.weight in supported_weights and spec.activation is None for spec in specs
     )
 
 
@@ -198,22 +199,22 @@ def resolve_quantization_config(
     `quantization` may be a CLI shorthand that desugars into a base config via
     `_ONLINE_SHORTHANDS`. `quantization_config` is a dict or pre-built args
     object. When both are online settings, fields explicitly set in
-    `quantization_config` take precedence over the shorthand. ModelOpt accepts
-    online overlays for BF16 dense/shared-expert projections.
+    `quantization_config` take precedence over the shorthand. Selected
+    checkpoint formats accept online overlays for BF16 dense/shared-expert
+    projections.
     """
     if isinstance(quantization_config, dict):
         quantization_config = QuantizationConfigArgs(**quantization_config)
 
     if quantization is not None and quantization not in ONLINE_QUANT_SHORTHAND_NAMES:
-        if quantization_config is not None and not _is_modelopt_online_overlay(
+        if quantization_config is not None and not _is_checkpoint_online_overlay(
             quantization, quantization_config
         ):
             raise ValueError(
                 f"quantization_config is only supported when quantization is "
                 f"one of {sorted(ONLINE_QUANT_SHORTHAND_NAMES)}, or when "
-                f"using the ModelOpt online overlay (weight='mxfp8' or "
-                f"weight='fp8_per_block_static' on 'shared_experts' and/or "
-                f"'linear', optional 'ignore'), "
+                f"using a supported checkpoint online overlay on "
+                f"'shared_experts' and/or 'linear' (optional 'ignore'), "
                 f"got quantization={quantization!r}"
             )
         return quantization_config

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -31,6 +31,7 @@ import torch
 from transformers import PretrainedConfig
 
 from vllm.config import get_current_vllm_config_or_none
+from vllm.config.quantization import QuantizationConfigArgs
 from vllm.distributed import (
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
@@ -53,6 +54,14 @@ from vllm.model_executor.layers.quantization.base_config import (
     QuantizationConfig,
     QuantizeMethodBase,
 )
+from vllm.model_executor.layers.quantization.compressed_tensors.utils import (
+    should_ignore_layer,
+)
+from vllm.model_executor.layers.quantization.online.mxfp8 import (
+    Mxfp8OnlineLinearMethod,
+    is_shared_expert_projection,
+)
+from vllm.model_executor.layers.quantization.utils.quant_utils import kMxfp8Dynamic
 from vllm.model_executor.parameter import BasevLLMParameter
 from vllm.transformers_utils.repo_utils import get_hf_file_to_dict
 
@@ -658,14 +667,66 @@ class Exl3Config(QuantizationConfig):
         if is_lm_head and not prefix:
             prefix = "lm_head"
         if isinstance(layer, LinearBase) or is_lm_head:
-            if not self._linear_prefix_is_exl3(prefix):
-                return UnquantizedLinearMethod()
-            return Exl3LinearMethod(self)
+            if self._linear_prefix_is_exl3(prefix):
+                return Exl3LinearMethod(self)
+            if not is_lm_head and (
+                method := self._get_bf16_online_linear_method(layer, prefix)
+            ):
+                return method
+            return UnquantizedLinearMethod()
         if isinstance(layer, RoutedExperts):
             if not self._moe_prefix_is_exl3(prefix, layer):
                 return None
             return Exl3MoEMethod(self, layer.moe_config)
         return None
+
+    def _get_bf16_online_linear_method(
+        self, layer: torch.nn.Module, prefix: str
+    ) -> QuantizeMethodBase | None:
+        """Overlay MXFP8 only on linears absent from EXL3 tensor storage.
+
+        EXL3-owned dense matrices are selected before this method and routed
+        experts never enter it. Shared-expert projections have an independent
+        spec so a broad ``linear`` overlay cannot quantize them accidentally.
+        """
+        if not isinstance(layer, LinearBase):
+            return None
+
+        vllm_config = get_current_vllm_config_or_none()
+        if vllm_config is None:
+            return None
+        args = vllm_config.model_config.quantization_config
+        if not isinstance(args, QuantizationConfigArgs):
+            return None
+
+        shared_expert = is_shared_expert_projection(prefix)
+        spec = args.shared_experts if shared_expert else args.linear
+        if spec is None:
+            return None
+        if (
+            not shared_expert
+            and args.ignore
+            and should_ignore_layer(
+                prefix,
+                ignore=args.ignore,
+                fused_mapping=self.packed_modules_mapping,
+            )
+        ):
+            return None
+        if spec.weight != kMxfp8Dynamic or spec.activation is not None:
+            raise ValueError(
+                "EXL3 BF16 online overlay only supports weight='mxfp8' "
+                "with no activation override."
+            )
+
+        logger.info_once(
+            "EXL3 BF16 online overlay: quantizing non-EXL3 %s projections "
+            "to MXFP8 at load time (module example: %s).",
+            "shared-expert" if shared_expert else "dense-linear",
+            prefix,
+        )
+        logger.debug("EXL3 BF16 MXFP8 overlay applied to %s", prefix)
+        return Mxfp8OnlineLinearMethod()
 
     def _storage_entry(self, prefix: str) -> dict[str, Any] | None:
         candidates = [prefix]

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -688,6 +688,18 @@ class Exl3Config(QuantizationConfig):
         EXL3-owned dense matrices are selected before this method and routed
         experts never enter it. Shared-expert projections have an independent
         spec so a broad ``linear`` overlay cannot quantize them accidentally.
+
+        Args:
+            layer: Candidate module for the online overlay.
+            prefix: Fully qualified checkpoint module name.
+
+        Returns:
+            An MXFP8 method for an eligible BF16 projection, otherwise
+            ``None``.
+
+        Raises:
+            ValueError: If the EXL3 overlay requests an unsupported weight or
+                activation format.
         """
         if not isinstance(layer, LinearBase):
             return None
@@ -767,10 +779,17 @@ class Exl3Config(QuantizationConfig):
         if not source_leaves:
             return False
         base = prefix.rsplit(".", 1)[0] if "." in prefix else ""
-        return all(
+        source_is_exl3 = [
             self._is_exl3_prefix(f"{base}.{source}" if base else source)
             for source in source_leaves
-        )
+        ]
+        if any(source_is_exl3) and not all(source_is_exl3):
+            raise ValueError(
+                f"Packed EXL3 projection {prefix!r} mixes EXL3 and BF16 "
+                "source shards; a fused module must use one quantization "
+                "scheme."
+            )
+        return all(source_is_exl3)
 
     def _moe_prefix_is_exl3(
         self, prefix: str, layer: torch.nn.Module | None = None


### PR DESCRIPTION
## Summary

Add an explicit online MXFP8 overlay for BF16 linear weights in EXL3 checkpoints.

- EXL3 tensor-storage records always retain `Exl3LinearMethod`.
- Rank-sliced and regular routed experts always retain `Exl3MoEMethod`; `moe` overlays are rejected.
- Only non-EXL3 `LinearBase` weights may use online MXFP8.
- Dense and shared-expert projections are controlled independently by `linear` and `shared_experts`.
- `lm_head` remains EXL3 or BF16.
- Dense `ignore` rules use unfused checkpoint names and reject inconsistent policies across packed shards.

This keeps one checkpoint quantization provider in control instead of trying to compose EXL3 with a second model-level `OnlineQuantizationConfig`.

## Usage

```bash
vllm serve <exl3-checkpoint> \
  --quantization exl3 \
  --quantization-config '{"linear":{"weight":"mxfp8"},"shared_experts":{"weight":"mxfp8"},"ignore":["re:.*\\.q_a_proj$","re:.*kv_a_proj_with_mqa","lm_head"]}'
```

EXL3 overlays currently accept MXFP8 weights only, with no activation override. Existing ModelOpt/MXFP4 overlay capabilities are unchanged.

## Validation

- `53 passed`: EXL3 and quantization resolver focused suites.
- `72 passed, 7 skipped`: EXL3, resolver, generic online, and NVFP4/NF3 hybrid regression suites.
- Ruff lint and format pass.
- `py_compile` and `git diff --check` pass.

GPU E2E validation is intentionally left for the release candidate: boot the target EXL3 checkpoint, verify selected module methods in logs, compare per-rank VRAM/KV capacity, and run matched logprob/KLD plus prefill/decode tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added online MXFP8 overlay support for EXL3 checkpoints.
  * Supports selective quantization of dense and shared-expert layers, with configurable ignore patterns.
  * Preserves EXL3-compressed tensors and routed-expert handling.
  * Excludes the language-model head by default.

* **Bug Fixes**
  * Improved validation and error messages for unsupported overlay configurations, including activation quantization and split packed schemes.

* **Documentation**
  * Expanded quantization guidance with EXL3 overlay examples and configuration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->