### PR TITLE
[GG] EXL3: consolidate mixed execution, MXFP8 overlay, and shared rotations

### DIFF
--- a/docs/features/quantization/online.md
+++ b/docs/features/quantization/online.md
@@ -100,7 +100,7 @@ vllm serve <glm-5.2-modelopt-checkpoint> \
 Serialized checkpoint-quantized shared experts are preserved; only excluded
 BF16 projection weights are converted at load time.
 
-### MXFP8 dense linears on ModelOpt checkpoints
+### MXFP8 dense linears on quantized checkpoints
 
 The `linear` field overlays online MXFP8 the same way onto every other
 BF16 dense linear the ModelOpt checkpoint excludes: attention projections,
@@ -142,6 +142,22 @@ vllm serve lukealonso/GLM-5.2-NVFP4 \
   --quantization modelopt_fp4 \
   --quantization-config '{"linear":{"weight":"mxfp8"},"ignore":["re:.*kv_b_proj"]}'
 ```
+
+EXL3 checkpoints can use the same overlay for dense and shared-expert
+projections that are absent from the EXL3 tensor metadata. Serialized EXL3
+dense matrices and routed experts always retain their checkpoint format;
+`moe` overlays are rejected. `lm_head` also remains in its checkpoint format
+or BF16. For example:
+
+```bash
+vllm serve <exl3-checkpoint> \
+  --quantization exl3 \
+  --quantization-config '{"linear":{"weight":"mxfp8"},"shared_experts":{"weight":"mxfp8"},"ignore":["re:.*\\.q_a_proj$","re:.*kv_a_proj_with_mqa","lm_head"]}'
+```
+
+As with ModelOpt, `linear` does not select shared experts. Add the
+`shared_experts` field explicitly when those BF16 projections should also be
+converted. Ignore patterns are matched against unfused checkpoint names.
 
 ### Activation overrides on already-quantized checkpoints
 

--- a/tests/quantization/test_exl3.py
+++ b/tests/quantization/test_exl3.py
@@ -463,9 +463,10 @@ def test_mixed_trellis_dispatches_decode_and_serial_prefill(monkeypatch):
         "decode": {"launch": object(), "buffers": object()},
         "prefill_plans": (FakePlan(), FakePlan()),
         "prefill_arena": torch.empty(16, dtype=torch.uint8),
-        "prefill_accum": torch.empty((16, 4), dtype=torch.float32),
+        "prefill_accum": torch.empty((8, 4), dtype=torch.float32),
         "max_decode_m": 8,
         "max_batched_tokens": 16,
+        "prefill_capacity": 8,
     }
     tiers = (
         {"weights": object(), "route_expert_map": torch.tensor([0, -1])},
@@ -495,12 +496,32 @@ def test_mixed_trellis_dispatches_decode_and_serial_prefill(monkeypatch):
     torch.testing.assert_close(decode, torch.ones_like(decode))
     torch.testing.assert_close(prefill, torch.full_like(prefill, 3))
     assert mixed_api.calls == 1
-    assert len(fused_api.bindings) == 2
+    assert len(fused_api.bindings) == 4
+    assert [binding["a"].shape[0] for binding in fused_api.bindings] == [8] * 4
+    assert all(
+        torch.equal(binding["topk_weights"], weights[:8])
+        for binding in fused_api.bindings[:2]
+    )
+    assert all(
+        torch.equal(binding["topk_weights"], weights[8:])
+        for binding in fused_api.bindings[2:]
+    )
+    assert all(
+        torch.equal(binding["topk_ids"], ids[:8]) for binding in fused_api.bindings[:2]
+    )
+    assert all(
+        torch.equal(binding["topk_ids"], ids[8:]) for binding in fused_api.bindings[2:]
+    )
     assert (
         fused_api.bindings[0]["output"].data_ptr()
         == runtime["prefill_accum"].data_ptr()
     )
     assert fused_api.bindings[1]["output"] is None
+    assert (
+        fused_api.bindings[2]["output"].data_ptr()
+        == runtime["prefill_accum"].data_ptr()
+    )
+    assert fused_api.bindings[3]["output"] is None
 
 
 @pytest.mark.parametrize(

--- a/tests/quantization/test_exl3.py
+++ b/tests/quantization/test_exl3.py
@@ -313,6 +313,7 @@ def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(monkeypat
         local_num_experts=experts,
         exl3_hidden_size=hidden,
         exl3_intermediate_size_per_partition=intermediate,
+        exl3_params_dtype=torch.float16,
         exl3_layer_bitrates=bitrates,
         activation=MoEActivation.SILU,
         layer_name="model.layers.3.mlp.experts",
@@ -324,6 +325,8 @@ def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(monkeypat
             name = f"{prefix}_{suffix}"
             backing = slabs.get(name)
             setattr(layer, name, parameter(shards, backing=backing))
+    marker = torch.tensor(0xCBAC1FED - (1 << 32), dtype=torch.int32)
+    layer.w13_mcg.exl3_tensors[(0, "w1")] = marker
 
     class FakeMixedApi:
         def __init__(self):
@@ -346,8 +349,23 @@ def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(monkeypat
         def combine_trellis_rotations(tier0, tier1):
             return tier0, tier1
 
+    class FakeFusedApi:
+        def __init__(self):
+            self.plans = []
+            self.prepared = []
+
+        def plan_weights(self, **kwargs):
+            self.plans.append(kwargs)
+            return SimpleNamespace(**kwargs)
+
+        def prepare_weights(self, **kwargs):
+            self.prepared.append(kwargs)
+            return SimpleNamespace(plan=kwargs["plan"])
+
     api = FakeMixedApi()
+    fused_api = FakeFusedApi()
     monkeypatch.setattr(exl3_module, "_load_sparkinfer_mixed_trellis", lambda: api)
+    monkeypatch.setattr(exl3_module, "_load_sparkinfer_fused_moe", lambda: fused_api)
     method = object.__new__(Exl3MoEMethod)
     method._rank_sliced_backing = lambda _layer, name: slabs[name]
 
@@ -376,6 +394,23 @@ def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(monkeypat
     ]
     assert layer.exl3_mixed_trellis["tier_ids"] == ((0, 2), (1, 3))
     assert layer.exl3_mixed_trellis["tier_bits"] == (3, 4)
+    assert [entry["trellis_bits"] for entry in fused_api.plans] == [3, 4]
+    assert [entry["trellis_tile_config"] for entry in fused_api.plans] == [
+        (64, 128, 64, 128),
+        (64, 128, 64, 128),
+    ]
+    assert all(entry["trellis_mcg"] is marker for entry in fused_api.prepared)
+    assert len(layer.exl3_mixed_trellis["serial_tiers"]) == 2
+    rotations = layer.exl3_mixed_trellis["rotations"]
+    for mixed_entry, serial_entry in zip(api.prepared, fused_api.prepared, strict=True):
+        assert (
+            mixed_entry["gate_suh"].untyped_storage().data_ptr()
+            == rotations.gate_suh.untyped_storage().data_ptr()
+        )
+        assert (
+            serial_entry["gate_suh"].untyped_storage().data_ptr()
+            == rotations.gate_suh.untyped_storage().data_ptr()
+        )
     assert layer.w13_trellis.exl3_tensors == {}
     assert layer.w2_trellis.exl3_tensors == {}
     assert layer.w13_suh.exl3_backing is None
@@ -388,6 +423,84 @@ def test_mixed_trellis_buffer_accounting_ignores_metadata() -> None:
     second = SimpleNamespace(alias=shared.view(2, 4), label="prefill")
 
     assert exl3_module._unique_tensor_storage_bytes(first, second) == 8
+
+
+def test_mixed_trellis_dispatches_decode_and_serial_prefill(monkeypatch):
+    class FakeMixedApi:
+        calls = 0
+
+        def run_mixed_trellis(self, x, *args):
+            self.calls += 1
+            return torch.ones_like(x)
+
+    class FakeFusedApi:
+        def __init__(self):
+            self.bindings = []
+
+        def bind(self, plan, **kwargs):
+            del plan
+            self.bindings.append(kwargs)
+            return kwargs
+
+        @staticmethod
+        def run(*, binding):
+            output = binding["output"]
+            if output is not None:
+                output.fill_(1)
+                return output
+            return torch.full_like(binding["a"], 2, dtype=torch.float32)
+
+    class FakePlan:
+        @staticmethod
+        def scratch_specs():
+            return [SimpleNamespace(shape=(16,), dtype=torch.uint8)]
+
+    mixed_api = FakeMixedApi()
+    fused_api = FakeFusedApi()
+    runtime = {
+        "mixed_api": mixed_api,
+        "fused_api": fused_api,
+        "decode": {"launch": object(), "buffers": object()},
+        "prefill_plans": (FakePlan(), FakePlan()),
+        "prefill_arena": torch.empty(16, dtype=torch.uint8),
+        "prefill_accum": torch.empty((16, 4), dtype=torch.float32),
+        "max_decode_m": 8,
+        "max_batched_tokens": 16,
+    }
+    tiers = (
+        {"weights": object(), "route_expert_map": torch.tensor([0, -1])},
+        {"weights": object(), "route_expert_map": torch.tensor([-1, 0])},
+    )
+    layer = SimpleNamespace(
+        exl3_mixed_trellis={
+            "tiers": (object(), object()),
+            "serial_tiers": tiers,
+            "global_to_combined": object(),
+            "descriptor_map": object(),
+            "rotations": object(),
+        }
+    )
+    method = object.__new__(Exl3MoEMethod)
+    monkeypatch.setattr(
+        method, "_mixed_rank_sliced_runtime", lambda layer, x, ids: runtime
+    )
+    weights = torch.ones((16, 2), dtype=torch.float32)
+    ids = torch.zeros((16, 2), dtype=torch.int64)
+
+    decode = method._apply_mixed_rank_sliced(
+        layer, torch.zeros((4, 4)), weights[:4], ids[:4]
+    )
+    prefill = method._apply_mixed_rank_sliced(layer, torch.zeros((16, 4)), weights, ids)
+
+    torch.testing.assert_close(decode, torch.ones_like(decode))
+    torch.testing.assert_close(prefill, torch.full_like(prefill, 3))
+    assert mixed_api.calls == 1
+    assert len(fused_api.bindings) == 2
+    assert (
+        fused_api.bindings[0]["output"].data_ptr()
+        == runtime["prefill_accum"].data_ptr()
+    )
+    assert fused_api.bindings[1]["output"] is None
 
 
 @pytest.mark.parametrize(

--- a/tests/quantization/test_exl3.py
+++ b/tests/quantization/test_exl3.py
@@ -603,7 +603,10 @@ def test_rank_sliced_weights_pass_shared_h_rows_without_expansion(monkeypatch):
     assert all(tuple(table.shape) == (experts,) for table in layer.exl3_pointer_tables)
 
 
-def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(monkeypatch):
+@pytest.mark.parametrize("shared_h", [False, True])
+def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(
+    monkeypatch, shared_h
+):
     experts = 4
     hidden = intermediate = 128
     bitrates = (3, 4, 3, 4)
@@ -629,10 +632,12 @@ def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(monkeypat
         )
 
     slabs = {
-        "w13_suh": torch.ones((2, experts, hidden), dtype=torch.float16),
+        "w13_suh": torch.ones(
+            (2, 1 if shared_h else experts, hidden), dtype=torch.float16
+        ),
         "w13_svh": torch.ones((2, experts, intermediate), dtype=torch.float16),
         "w2_suh": torch.ones((experts, intermediate), dtype=torch.float16),
-        "w2_svh": torch.ones((experts, hidden), dtype=torch.float16),
+        "w2_svh": torch.ones((1 if shared_h else experts, hidden), dtype=torch.float16),
     }
     layer = SimpleNamespace(
         local_num_experts=experts,
@@ -727,7 +732,15 @@ def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(monkeypat
     assert all(entry["trellis_mcg"] is marker for entry in fused_api.prepared)
     assert len(layer.exl3_mixed_trellis["serial_tiers"]) == 2
     rotations = layer.exl3_mixed_trellis["rotations"]
+    expected_h_rows = 1 if shared_h else experts
+    assert rotations.gate_suh.shape[0] == expected_h_rows
+    assert rotations.up_suh.shape[0] == expected_h_rows
+    assert rotations.down_svh.shape[0] == expected_h_rows
     for mixed_entry, serial_entry in zip(api.prepared, fused_api.prepared, strict=True):
+        expected_tier_rows = 1 if shared_h else 2
+        assert mixed_entry["gate_suh"].shape[0] == expected_tier_rows
+        assert mixed_entry["up_suh"].shape[0] == expected_tier_rows
+        assert mixed_entry["down_svh"].shape[0] == expected_tier_rows
         assert (
             mixed_entry["gate_suh"].untyped_storage().data_ptr()
             == rotations.gate_suh.untyped_storage().data_ptr()

--- a/tests/quantization/test_exl3.py
+++ b/tests/quantization/test_exl3.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pytest
 import torch
@@ -9,10 +10,13 @@ import torch
 import vllm.model_executor.layers.quantization.exl3 as exl3_module
 import vllm.model_executor.parameter as parameter_module
 from vllm.config import CompilationMode
-from vllm.model_executor.layers.fused_moe import MoEActivation
+from vllm.config.quantization import QuantizationConfigArgs
+from vllm.model_executor.layers.fused_moe import MoEActivation, RoutedExperts
+from vllm.model_executor.layers.linear import LinearBase, UnquantizedLinearMethod
 from vllm.model_executor.layers.quantization import get_quantization_config
 from vllm.model_executor.layers.quantization.exl3 import (
     Exl3Config,
+    Exl3LinearMethod,
     Exl3MoEMethod,
     Exl3MoEParameter,
 )
@@ -33,6 +37,125 @@ def _rank_sliced_metadata(**overrides):
     }
     metadata.update(overrides)
     return metadata
+
+
+def _set_online_overlay(monkeypatch, args: QuantizationConfigArgs) -> object:
+    current = SimpleNamespace(
+        model_config=SimpleNamespace(
+            quantization_config=args,
+            enforce_eager=True,
+        )
+    )
+    sentinel = object()
+    monkeypatch.setattr(exl3_module, "get_current_vllm_config_or_none", lambda: current)
+    monkeypatch.setattr(exl3_module, "Mxfp8OnlineLinearMethod", lambda: sentinel)
+    return sentinel
+
+
+def _mock_linear() -> Mock:
+    return Mock(spec=LinearBase)
+
+
+def test_exl3_online_overlay_quantizes_only_bf16_dense_and_shared(monkeypatch):
+    config = Exl3Config(
+        tensor_storage={"model.layers.3.self_attn.q_b_proj": {"quant_format": "exl3"}}
+    )
+    sentinel = _set_online_overlay(
+        monkeypatch,
+        QuantizationConfigArgs(linear="mxfp8", shared_experts="mxfp8"),
+    )
+
+    serialized = config.get_quant_method(
+        _mock_linear(), "model.layers.3.self_attn.q_b_proj"
+    )
+    dense_bf16 = config.get_quant_method(
+        _mock_linear(), "model.layers.3.self_attn.kv_b_proj"
+    )
+    shared_bf16 = config.get_quant_method(
+        _mock_linear(), "model.layers.3.mlp.shared_experts.down_proj"
+    )
+
+    assert isinstance(serialized, Exl3LinearMethod)
+    assert dense_bf16 is sentinel
+    assert shared_bf16 is sentinel
+
+
+def test_exl3_linear_overlay_does_not_select_shared_experts(monkeypatch):
+    config = Exl3Config()
+    sentinel = _set_online_overlay(monkeypatch, QuantizationConfigArgs(linear="mxfp8"))
+
+    dense = config.get_quant_method(
+        _mock_linear(), "model.layers.3.self_attn.kv_b_proj"
+    )
+    shared = config.get_quant_method(
+        _mock_linear(), "model.layers.3.mlp.shared_experts.down_proj"
+    )
+
+    assert dense is sentinel
+    assert isinstance(shared, UnquantizedLinearMethod)
+
+
+def test_exl3_online_overlay_honors_unfused_ignore_names(monkeypatch):
+    config = Exl3Config()
+    config.packed_modules_mapping = {
+        "fused_qkv_a_proj": ["q_a_proj", "kv_a_proj_with_mqa"]
+    }
+    sentinel = _set_online_overlay(
+        monkeypatch,
+        QuantizationConfigArgs(
+            linear="mxfp8",
+            ignore=["re:.*\\.q_a_proj$", "re:.*kv_a_proj_with_mqa"],
+        ),
+    )
+
+    ignored = config.get_quant_method(
+        _mock_linear(), "model.layers.3.self_attn.fused_qkv_a_proj"
+    )
+    kept = config.get_quant_method(_mock_linear(), "model.layers.3.self_attn.kv_b_proj")
+
+    assert isinstance(ignored, UnquantizedLinearMethod)
+    assert kept is sentinel
+
+
+def test_exl3_online_overlay_rejects_split_packed_quantization(monkeypatch):
+    config = Exl3Config()
+    config.packed_modules_mapping = {
+        "fused_qkv_a_proj": ["q_a_proj", "kv_a_proj_with_mqa"]
+    }
+    _set_online_overlay(
+        monkeypatch,
+        QuantizationConfigArgs(linear="mxfp8", ignore=["re:.*\\.q_a_proj$"]),
+    )
+
+    with pytest.raises(ValueError, match="different quantization schemes"):
+        config.get_quant_method(
+            _mock_linear(), "model.layers.3.self_attn.fused_qkv_a_proj"
+        )
+
+
+def test_exl3_online_overlay_never_quantizes_bf16_lm_head(monkeypatch):
+    config = Exl3Config()
+    _set_online_overlay(monkeypatch, QuantizationConfigArgs(linear="mxfp8"))
+    lm_head = type("ParallelLMHead", (torch.nn.Module,), {})()
+
+    method = config.get_quant_method(lm_head, "lm_head")
+
+    assert isinstance(method, UnquantizedLinearMethod)
+
+
+def test_exl3_online_overlay_preserves_rank_sliced_routed_experts(monkeypatch):
+    config = Exl3Config()
+    config.rank_sliced_metadata = _rank_sliced_metadata()
+    _set_online_overlay(
+        monkeypatch,
+        QuantizationConfigArgs(linear="mxfp8", shared_experts="mxfp8"),
+    )
+    routed = Mock(spec=RoutedExperts)
+    routed.moe_config = object()
+
+    method = config.get_quant_method(routed, "model.layers.3.mlp.experts")
+
+    assert isinstance(method, Exl3MoEMethod)
 
 
 def test_rank_sliced_checkpoint_selects_exl3_override():

--- a/tests/quantization/test_exl3.py
+++ b/tests/quantization/test_exl3.py
@@ -133,6 +133,21 @@ def test_exl3_online_overlay_rejects_split_packed_quantization(monkeypatch):
         )
 
 
+def test_exl3_online_overlay_rejects_mixed_packed_storage(monkeypatch):
+    config = Exl3Config(
+        tensor_storage={"model.layers.3.self_attn.q_a_proj": {"quant_format": "exl3"}}
+    )
+    config.packed_modules_mapping = {
+        "fused_qkv_a_proj": ["q_a_proj", "kv_a_proj_with_mqa"]
+    }
+    _set_online_overlay(monkeypatch, QuantizationConfigArgs(linear="mxfp8"))
+
+    with pytest.raises(ValueError, match="mixes EXL3 and BF16 source shards"):
+        config.get_quant_method(
+            _mock_linear(), "model.layers.3.self_attn.fused_qkv_a_proj"
+        )
+
+
 def test_exl3_online_overlay_never_quantizes_bf16_lm_head(monkeypatch):
     config = Exl3Config()
     _set_online_overlay(monkeypatch, QuantizationConfigArgs(linear="mxfp8"))

--- a/tests/quantization/test_exl3.py
+++ b/tests/quantization/test_exl3.py
@@ -230,6 +230,8 @@ def test_glm_model_retains_quant_config_for_weight_loading(monkeypatch):
         ({"codebook": "mul1"}, "MCG codebook"),
         ({"moe_layers": [77, 3]}, "moe_layers"),
         ({"tensor_schema": "unsupported"}, "tensor schema"),
+        ({"rotation_layout": "implicit_magic"}, "rotation_layout"),
+        ({"rotation_layout": "shared_h_v1"}, "shared_h_tensor_schema"),
     ],
 )
 def test_rank_sliced_metadata_fails_closed(overrides, message):
@@ -254,6 +256,28 @@ def test_rank_sliced_metadata_admits_only_declared_moe_layers():
     assert (
         config.codebook_for_prefix("model.layers.10.mlp.experts.0.gate_proj") == "mcg"
     )
+
+
+def test_rank_sliced_shared_h_metadata_is_explicit_and_legacy_defaults_unchanged():
+    legacy = Exl3Config()
+    legacy.maybe_update_config(
+        "unused", SimpleNamespace(hybrid_tr3_tail=_rank_sliced_metadata())
+    )
+    shared = Exl3Config()
+    shared.maybe_update_config(
+        "unused",
+        SimpleNamespace(
+            hybrid_tr3_tail=_rank_sliced_metadata(
+                rotation_layout="shared_h_v1",
+                shared_h_tensor_schema=(
+                    "model.layers.{L}.mlp.experts.shared_h.{proj}.rank{r}.{suh|svh}"
+                ),
+            )
+        ),
+    )
+
+    assert legacy.rank_sliced_rotation_layout == "per_expert_v1"
+    assert shared.rank_sliced_rotation_layout == "shared_h_v1"
 
 
 def test_mixed_rank_sliced_metadata_hydrates_per_layer_bitrates(monkeypatch):
@@ -317,6 +341,49 @@ def test_rank_sliced_weight_name_keeps_only_local_tp_rank(monkeypatch):
     )
 
 
+def test_rank_sliced_shared_h_names_map_once_and_fail_closed(monkeypatch):
+    config = Exl3Config()
+    config.maybe_update_config(
+        "unused",
+        SimpleNamespace(
+            hybrid_tr3_tail=_rank_sliced_metadata(
+                rotation_layout="shared_h_v1",
+                shared_h_tensor_schema=(
+                    "model.layers.{L}.mlp.experts.shared_h.{proj}.rank{r}.{suh|svh}"
+                ),
+            )
+        ),
+    )
+    monkeypatch.setattr(exl3_module, "get_tensor_model_parallel_rank", lambda: 2)
+    prefix = "model.layers.3.mlp.experts"
+
+    assert (
+        config.normalize_rank_sliced_weight_name(
+            f"{prefix}.shared_h.gate_proj.rank2.suh"
+        )
+        == f"{prefix}.0.gate_proj.suh"
+    )
+    assert (
+        config.normalize_rank_sliced_weight_name(
+            f"{prefix}.shared_h.down_proj.rank1.svh"
+        )
+        is None
+    )
+    with pytest.raises(ValueError, match="requires suh"):
+        config.normalize_rank_sliced_weight_name(
+            f"{prefix}.shared_h.gate_proj.rank2.svh"
+        )
+    with pytest.raises(ValueError, match="must store H-side rotations"):
+        config.normalize_rank_sliced_weight_name(f"{prefix}.7.down_proj.rank2.svh")
+
+    legacy = Exl3Config()
+    legacy.maybe_update_config(
+        "unused", SimpleNamespace(hybrid_tr3_tail=_rank_sliced_metadata())
+    )
+    with pytest.raises(ValueError, match="does not declare"):
+        legacy.normalize_rank_sliced_weight_name(f"{prefix}.shared_h.up_proj.rank2.suh")
+
+
 def test_rank_sliced_parameter_preallocates_projection_major_slab(monkeypatch):
     monkeypatch.setattr(parameter_module, "get_tensor_model_parallel_rank", lambda: 0)
     monkeypatch.setattr(
@@ -344,6 +411,70 @@ def test_rank_sliced_parameter_preallocates_projection_major_slab(monkeypatch):
     )
     torch.testing.assert_close(param.exl3_tensors[(1, "w1")], w1)
     torch.testing.assert_close(param.exl3_tensors[(2, "w3")], w3)
+
+
+def test_rank_sliced_broadcast_pointer_table_repeats_one_physical_row():
+    slab = torch.ones((1, 128), dtype=torch.float16)
+
+    table = Exl3MoEMethod._pointer_table(slab, num_experts=4)
+
+    assert table.tolist() == [slab.data_ptr()] * 4
+    with pytest.raises(RuntimeError, match="per-expert or broadcast"):
+        Exl3MoEMethod._pointer_table(
+            torch.ones((2, 128), dtype=torch.float16), num_experts=4
+        )
+
+
+def test_rank_sliced_shared_h_create_weights_allocates_one_physical_row(
+    monkeypatch,
+):
+    monkeypatch.setattr(parameter_module, "get_tensor_model_parallel_rank", lambda: 0)
+    monkeypatch.setattr(
+        parameter_module, "get_tensor_model_parallel_world_size", lambda: 4
+    )
+    config = Exl3Config()
+    config.maybe_update_config(
+        "unused",
+        SimpleNamespace(
+            hybrid_tr3_tail=_rank_sliced_metadata(
+                rotation_layout="shared_h_v1",
+                shared_h_tensor_schema=(
+                    "model.layers.{L}.mlp.experts.shared_h.{proj}.rank{r}.{suh|svh}"
+                ),
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        exl3_module,
+        "get_current_vllm_config_or_none",
+        lambda: SimpleNamespace(
+            scheduler_config=SimpleNamespace(max_num_batched_tokens=8192),
+            model_config=SimpleNamespace(runner_type="generate"),
+        ),
+    )
+    layer = torch.nn.Module()
+    layer.layer_name = "model.layers.3.mlp.experts"
+    moe = SimpleNamespace(
+        moe_parallel_config=SimpleNamespace(use_ep=False, tp_rank=0, tp_size=4),
+        has_bias=False,
+    )
+    method = Exl3MoEMethod(config, moe)
+
+    method.create_weights(
+        layer,
+        num_experts=256,
+        hidden_size=6144,
+        intermediate_size_per_partition=512,
+        params_dtype=torch.bfloat16,
+    )
+
+    assert layer.exl3_shared_h_rotations
+    assert layer.w13_suh.exl3_num_experts == 1
+    assert layer.w2_svh.exl3_num_experts == 1
+    assert layer.w13_svh.exl3_num_experts == 256
+    assert layer.w2_suh.exl3_num_experts == 256
+    assert layer.w13_trellis.exl3_num_experts == 256
+    assert layer.w2_trellis.exl3_num_experts == 256
 
 
 def test_rank_sliced_weights_use_unified_fused_moe_contract(monkeypatch):
@@ -414,6 +545,62 @@ def test_rank_sliced_weights_use_unified_fused_moe_contract(monkeypatch):
     assert api.prepare_kwargs["w1_fp4"] is slabs["w13_trellis"]
     assert api.prepare_kwargs["w2_fp4"] is slabs["w2_trellis"]
     assert api.prepare_kwargs["trellis_mcg"] is marker
+
+
+def test_rank_sliced_weights_pass_shared_h_rows_without_expansion(monkeypatch):
+    experts = 3
+    hidden = intermediate = 128
+    bits = 3
+    slabs = {
+        "w13_trellis": torch.zeros(
+            (2, experts, hidden // 16, intermediate // 16, 16 * bits),
+            dtype=torch.int16,
+        ),
+        "w2_trellis": torch.zeros(
+            (experts, intermediate // 16, hidden // 16, 16 * bits),
+            dtype=torch.int16,
+        ),
+        "w13_suh": torch.ones((2, 1, hidden), dtype=torch.float16),
+        "w13_svh": torch.ones((2, experts, intermediate), dtype=torch.float16),
+        "w2_suh": torch.ones((experts, intermediate), dtype=torch.float16),
+        "w2_svh": torch.ones((1, hidden), dtype=torch.float16),
+    }
+
+    class FakeFusedMoe:
+        @staticmethod
+        def plan_weights(**kwargs):
+            return SimpleNamespace(source_format=kwargs["source_format"])
+
+        @staticmethod
+        def prepare_weights(**kwargs):
+            return SimpleNamespace(**kwargs)
+
+    monkeypatch.setattr(
+        exl3_module, "_load_sparkinfer_fused_moe", lambda: FakeFusedMoe()
+    )
+    method = object.__new__(Exl3MoEMethod)
+    method.quant_config = SimpleNamespace(bits=float(bits))
+    method._rank_sliced_backing = lambda _layer, name: slabs[name]
+    marker = torch.tensor(0xCBAC1FED - (1 << 32), dtype=torch.int32)
+    layer = SimpleNamespace(
+        local_num_experts=experts,
+        exl3_hidden_size=hidden,
+        exl3_intermediate_size_per_partition=intermediate,
+        exl3_params_dtype=torch.float16,
+        exl3_layer_bitrates=(bits,) * experts,
+        exl3_mixed_bitrate=False,
+        exl3_shared_h_rotations=True,
+        activation=MoEActivation.SILU,
+        w13_mcg=SimpleNamespace(exl3_tensors={(0, "w1"): marker}),
+    )
+
+    method._prepare_rank_sliced_weights(layer)
+
+    prepared = layer.exl3_trellis_weights
+    assert tuple(prepared.gate_suh.shape) == (1, hidden)
+    assert tuple(prepared.up_suh.shape) == (1, hidden)
+    assert tuple(prepared.down_svh.shape) == (1, hidden)
+    assert all(tuple(table.shape) == (experts,) for table in layer.exl3_pointer_tables)
 
 
 def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(monkeypatch):

--- a/tests/quantization/test_exl3_prefill_plan.py
+++ b/tests/quantization/test_exl3_prefill_plan.py
@@ -7,7 +7,8 @@ The planned Trellis API and the ExLlamaV3 extension are mocked; these tests
 prove backend policy only:
 
 * decode window m in [min, max] binds the decode plan;
-* max < m <= capacity binds the prefill plan (block_size_m=64 by default);
+* max < m <= scheduler capacity binds capacity-bounded prefill slices;
+* the opt-in prefill capacity defaults to the scheduler capacity;
 * m < min stays on the parity path with chunk-capped staging buffers;
 * VLLM_EXL3_PREFILL_TRELLIS=0 restores the single-plan parity behavior
   with full-capacity staging;
@@ -50,6 +51,7 @@ class _FakeFusedMoeApi:
     def __init__(self):
         self.planned = []
         self.bound = []
+        self.routed = []
 
     def Caps(self, **kwargs):
         return kwargs
@@ -60,12 +62,37 @@ class _FakeFusedMoeApi:
         return plan
 
     def bind(self, plan, *, scratch, a, experts, topk_weights, topk_ids):
-        del scratch, experts, topk_weights, topk_ids
+        del scratch, experts
         self.bound.append((plan, int(a.shape[0])))
-        return SimpleNamespace(plan=plan, m=int(a.shape[0]))
+        self.routed.append((topk_weights.clone(), topk_ids.clone()))
+        return SimpleNamespace(plan=plan, a=a)
 
     def run(self, *, binding):
-        return torch.zeros((binding.m, HIDDEN), dtype=torch.float32)
+        return binding.a.to(torch.float32)
+
+
+class _FakeMixedTrellisApi:
+    def __init__(self):
+        self.compiled = []
+        self.routed = []
+
+    def max_packed_route_slots(self, routed_rows, block_size, experts):
+        del block_size, experts
+        return routed_rows
+
+    def compile_mixed_trellis(self, **kwargs):
+        launch = SimpleNamespace(**kwargs)
+        self.compiled.append(launch)
+        return launch
+
+    def make_mixed_trellis_buffers(self, launch, **kwargs):
+        del kwargs
+        return SimpleNamespace(scratch=torch.empty(launch.size_m, dtype=torch.uint8))
+
+    def run_mixed_trellis(self, *args):
+        x, topk_weights, topk_ids = args[0], args[3], args[4]
+        self.routed.append((topk_weights.clone(), topk_ids.clone()))
+        return x.to(torch.float32)
 
 
 class _FakeExt:
@@ -96,6 +123,21 @@ def _make_layer():
     )
 
 
+def _make_mixed_layer():
+    layer = _make_layer()
+    layer.exl3_mixed_bitrate = True
+    layer.exl3_mixed_trellis = {
+        "tiers": (object(), object()),
+        "tier_ids": ((0, 1, 2, 3), (4, 5, 6, 7)),
+        "tier_bits": (3, 4),
+        "global_to_combined": object(),
+        "descriptor_map": object(),
+        "rotations": object(),
+        "tile_config": (64, 128, 64, 128),
+    }
+    return layer
+
+
 def _make_method():
     method = object.__new__(Exl3MoEMethod)
     method.quant_config = SimpleNamespace(
@@ -112,6 +154,7 @@ class _Harness:
         self._saved_capturing = None
         self.api = _FakeFusedMoeApi()
         self.ext = _FakeExt()
+        self.mixed_api = _FakeMixedTrellisApi()
 
     def __enter__(self):
         for name, value in self._env.items():
@@ -122,30 +165,41 @@ class _Harness:
                 os.environ[name] = value
         self._saved_loaders = (
             exl3_module._load_sparkinfer_fused_moe,
+            exl3_module._load_sparkinfer_mixed_trellis,
             exl3_module._load_exl3_ext,
         )
         exl3_module._load_sparkinfer_fused_moe = lambda: self.api
+        exl3_module._load_sparkinfer_mixed_trellis = lambda: self.mixed_api
         exl3_module._load_exl3_ext = lambda: self.ext
         self._saved_capturing = torch.cuda.is_current_stream_capturing
         torch.cuda.is_current_stream_capturing = lambda: False
         self._saved_current_device = torch.cuda.current_device
         torch.cuda.current_device = lambda: 0
+        self._saved_device_properties = torch.cuda.get_device_properties
+        torch.cuda.get_device_properties = lambda device: SimpleNamespace(
+            multi_processor_count=1,
+            shared_memory_per_block_optin=1,
+        )
         exl3_module._RANK_SLICED_RUNTIMES.clear()
+        exl3_module._MIXED_TRELLIS_RUNTIMES.clear()
         return self
 
     def __exit__(self, *exc):
         (
             exl3_module._load_sparkinfer_fused_moe,
+            exl3_module._load_sparkinfer_mixed_trellis,
             exl3_module._load_exl3_ext,
         ) = self._saved_loaders
         torch.cuda.is_current_stream_capturing = self._saved_capturing
         torch.cuda.current_device = self._saved_current_device
+        torch.cuda.get_device_properties = self._saved_device_properties
         for name, value in self._saved_env.items():
             if value is None:
                 os.environ.pop(name, None)
             else:
                 os.environ[name] = value
         exl3_module._RANK_SLICED_RUNTIMES.clear()
+        exl3_module._MIXED_TRELLIS_RUNTIMES.clear()
         return False
 
     def planned_caps(self):
@@ -159,24 +213,26 @@ def _apply(method, layer, m):
     return method._apply_rank_sliced(layer, x, weights, ids)
 
 
-def test_dual_plan_construction_and_dispatch():
-    with _Harness() as h:
+def test_opt_in_prefill_capacity_slices_dispatch():
+    with _Harness(env={"VLLM_EXL3_PREFILL_CAPACITY": "128"}) as h:
         method = _make_method()
         layer = _make_layer()
 
         out = _apply(method, layer, 16)
         assert out.dtype == torch.bfloat16 and out.shape == (16, HIDDEN)
-        # Two plans: decode (32, block 8) then prefill (capacity, block 64).
+        # Two plans: decode (32, block 8), then bounded prefill (block 64).
         assert [
             (caps["max_tokens"], caps["w4a16_block_size_m"])
             for caps in h.planned_caps()
-        ] == [(32, 8), (MAX_BATCHED, 64)]
+        ] == [(32, 8), (128, 64)]
         assert all(caps["route_num_experts"] == 0 for caps in h.planned_caps())
         assert h.api.bound[-1][0].caps["max_tokens"] == 32
 
         _apply(method, layer, 200)
-        assert h.api.bound[-1][0].caps["max_tokens"] == MAX_BATCHED
-        assert h.api.bound[-1][1] == 200
+        assert all(
+            bound[0].caps["max_tokens"] == 128 for bound in h.api.bound[-2:]
+        )
+        assert [bound[1] for bound in h.api.bound[-2:]] == [128, 72]
         assert not h.ext.moe_calls
 
         _apply(method, layer, 2)
@@ -188,6 +244,7 @@ def test_dual_plan_construction_and_dispatch():
         assert runtime["parity_rows"] == 128
         assert runtime["xh"].shape[0] == 128
         assert runtime["token_sorted"].numel() == 128 * TOPK
+        assert runtime["prefill_capacity"] == 128
 
         # Batches above the scheduler contract must fail before allocating a
         # replacement runtime or a larger Trellis arena during serving.
@@ -202,6 +259,86 @@ def test_dual_plan_construction_and_dispatch():
         assert tuple(exl3_module._RANK_SLICED_RUNTIMES) == runtime_keys
         assert len(exl3_module._RANK_SLICED_RUNTIMES) == runtime_count
         assert len(h.planned_caps()) == plan_count
+
+
+@pytest.mark.parametrize(
+    ("rows", "expected_slice_rows"),
+    ((127, [127]), (128, [128]), (129, [128, 1])),
+)
+def test_prefill_capacity_boundaries_preserve_rows_and_routing(
+    rows, expected_slice_rows
+):
+    with _Harness(env={"VLLM_EXL3_PREFILL_CAPACITY": "128"}) as h:
+        method = _make_method()
+        layer = _make_layer()
+        x = (
+            torch.arange(rows, dtype=torch.bfloat16)
+            .unsqueeze(1)
+            .expand(-1, HIDDEN)
+        )
+        weights = torch.arange(rows * TOPK, dtype=torch.float32).reshape(
+            rows, TOPK
+        )
+        ids = torch.arange(rows * TOPK, dtype=torch.int64).reshape(rows, TOPK)
+        ids = ids.remainder(EXPERTS)
+
+        out = method._apply_rank_sliced(layer, x, weights, ids)
+
+        assert [bound[1] for bound in h.api.bound] == expected_slice_rows
+        assert torch.equal(out, x)
+        assert torch.equal(
+            torch.cat([route[0] for route in h.api.routed]), weights
+        )
+        assert torch.equal(torch.cat([route[1] for route in h.api.routed]), ids)
+        assert all(bound[0] is h.api.bound[0][0] for bound in h.api.bound)
+
+
+def test_default_prefill_capacity_keeps_single_dispatch():
+    with _Harness() as h:
+        out = _apply(_make_method(), _make_layer(), 200)
+
+        assert h.planned_caps()[-1]["max_tokens"] == MAX_BATCHED
+        assert [bound[1] for bound in h.api.bound] == [200]
+        assert out.shape == (200, HIDDEN)
+
+
+def test_mixed_prefill_capacity_slices_rows_and_routing():
+    with _Harness(env={"VLLM_EXL3_PREFILL_CAPACITY": "128"}) as h:
+        method = _make_method()
+        layer = _make_mixed_layer()
+        rows = 200
+        x = (
+            torch.arange(rows, dtype=torch.bfloat16)
+            .unsqueeze(1)
+            .expand(-1, HIDDEN)
+        )
+        weights = torch.arange(rows * TOPK, dtype=torch.float32).reshape(
+            rows, TOPK
+        )
+        ids = torch.arange(rows * TOPK, dtype=torch.int64).reshape(rows, TOPK)
+        ids = ids.remainder(EXPERTS)
+
+        out = method._apply_rank_sliced(layer, x, weights, ids)
+
+        assert [launch.size_m for launch in h.mixed_api.compiled] == [32, 128]
+        assert [route[0].shape[0] for route in h.mixed_api.routed] == [128, 72]
+        assert torch.equal(out, x)
+        assert torch.equal(
+            torch.cat([route[0] for route in h.mixed_api.routed]), weights
+        )
+        assert torch.equal(
+            torch.cat([route[1] for route in h.mixed_api.routed]), ids
+        )
+
+
+def test_prefill_capacity_cannot_exceed_scheduler_bound():
+    env = {"VLLM_EXL3_PREFILL_CAPACITY": str(MAX_BATCHED + 1)}
+    with _Harness(env=env) as h:
+        with pytest.raises(
+            ValueError, match="cannot exceed max_num_batched_tokens"
+        ):
+            _apply(_make_method(), _make_layer(), 16)
+        assert not h.planned_caps()
 
 
 def test_prefill_trellis_disabled_restores_parity():
@@ -221,16 +358,19 @@ def test_prefill_trellis_disabled_restores_parity():
         runtime = next(iter(exl3_module._RANK_SLICED_RUNTIMES.values()))
         assert runtime["prefill_plan"] is None
         assert runtime["parity_rows"] == MAX_BATCHED
-        assert runtime["xh"].shape[0] == MAX_BATCHED
 
 
 def test_prefill_block_m_env_override():
-    with _Harness(env={"VLLM_EXL3_PREFILL_BLOCK_M": "48"}) as h:
+    env = {
+        "VLLM_EXL3_PREFILL_BLOCK_M": "48",
+        "VLLM_EXL3_PREFILL_CAPACITY": "128",
+    }
+    with _Harness(env=env) as h:
         method = _make_method()
         layer = _make_layer()
         _apply(method, layer, 40)
         assert h.planned_caps()[-1]["w4a16_block_size_m"] == 48
-        assert h.api.bound[-1][0].caps["max_tokens"] == MAX_BATCHED
+        assert h.api.bound[-1][0].caps["max_tokens"] == 128
 
 
 def test_parity_window_capacity_is_validated_before_planning():
@@ -259,7 +399,11 @@ def test_disabled_prefill_plan_keeps_full_parity_capacity():
 
 
 def test_explicit_parity_path_guarded_against_capture():
-    with _Harness(env={"VLLM_EXL3_TRELLIS_MIN_M": "4"}) as h:
+    env = {
+        "VLLM_EXL3_TRELLIS_MIN_M": "4",
+        "VLLM_EXL3_PREFILL_CAPACITY": "128",
+    }
+    with _Harness(env=env) as h:
         method = _make_method()
         layer = _make_layer()
         # Plan eagerly, then flip into "capturing" state.
@@ -268,18 +412,14 @@ def test_explicit_parity_path_guarded_against_capture():
         # Both trellis plans stay capture-safe.
         _apply(method, layer, 16)
         _apply(method, layer, 200)
-        assert h.api.bound[-1][1] == 200
+        assert [bound[1] for bound in h.api.bound[-2:]] == [128, 72]
         # The eager parity path must refuse to be recorded.
-        try:
+        with pytest.raises(RuntimeError, match="capture"):
             _apply(method, layer, 2)
-        except RuntimeError as err:
-            assert "capture" in str(err)
-        else:
-            raise AssertionError("parity path must raise during capture")
 
 
 if __name__ == "__main__":
-    test_dual_plan_construction_and_dispatch()
+    test_opt_in_prefill_capacity_slices_dispatch()
     test_prefill_trellis_disabled_restores_parity()
     test_prefill_block_m_env_override()
     test_explicit_parity_path_guarded_against_capture()

--- a/tests/quantization/test_exl3_prefill_plan.py
+++ b/tests/quantization/test_exl3_prefill_plan.py
@@ -61,13 +61,37 @@ class _FakeFusedMoeApi:
         self.planned.append(caps)
         return plan
 
-    def bind(self, plan, *, scratch, a, experts, topk_weights, topk_ids):
+    def bind(
+        self,
+        plan,
+        *,
+        scratch,
+        a,
+        experts,
+        topk_weights,
+        topk_ids,
+        route_expert_map=None,
+        output_expert_map=None,
+        output=None,
+    ):
         del scratch, experts
         self.bound.append((plan, int(a.shape[0])))
         self.routed.append((topk_weights.clone(), topk_ids.clone()))
-        return SimpleNamespace(plan=plan, a=a)
+        return SimpleNamespace(
+            plan=plan,
+            a=a,
+            route_expert_map=route_expert_map,
+            output_expert_map=output_expert_map,
+            output=output,
+        )
 
     def run(self, *, binding):
+        if binding.route_expert_map is not None:
+            tier_output = binding.a.to(torch.float32).mul(0.5)
+            if binding.output is not None:
+                binding.output.copy_(tier_output)
+                return binding.output
+            return tier_output
         return binding.a.to(torch.float32)
 
 
@@ -134,6 +158,17 @@ def _make_mixed_layer():
         "descriptor_map": object(),
         "rotations": object(),
         "tile_config": (64, 128, 64, 128),
+        "serial_tile_config": (64, 128, 64, 128),
+        "serial_tiers": (
+            {
+                "weights": SimpleNamespace(plan=object()),
+                "route_expert_map": torch.tensor([0, 1, 2, 3, -1, -1, -1, -1]),
+            },
+            {
+                "weights": SimpleNamespace(plan=object()),
+                "route_expert_map": torch.tensor([-1, -1, -1, -1, 0, 1, 2, 3]),
+            },
+        ),
     }
     return layer
 
@@ -229,9 +264,7 @@ def test_opt_in_prefill_capacity_slices_dispatch():
         assert h.api.bound[-1][0].caps["max_tokens"] == 32
 
         _apply(method, layer, 200)
-        assert all(
-            bound[0].caps["max_tokens"] == 128 for bound in h.api.bound[-2:]
-        )
+        assert all(bound[0].caps["max_tokens"] == 128 for bound in h.api.bound[-2:])
         assert [bound[1] for bound in h.api.bound[-2:]] == [128, 72]
         assert not h.ext.moe_calls
 
@@ -271,14 +304,8 @@ def test_prefill_capacity_boundaries_preserve_rows_and_routing(
     with _Harness(env={"VLLM_EXL3_PREFILL_CAPACITY": "128"}) as h:
         method = _make_method()
         layer = _make_layer()
-        x = (
-            torch.arange(rows, dtype=torch.bfloat16)
-            .unsqueeze(1)
-            .expand(-1, HIDDEN)
-        )
-        weights = torch.arange(rows * TOPK, dtype=torch.float32).reshape(
-            rows, TOPK
-        )
+        x = torch.arange(rows, dtype=torch.bfloat16).unsqueeze(1).expand(-1, HIDDEN)
+        weights = torch.arange(rows * TOPK, dtype=torch.float32).reshape(rows, TOPK)
         ids = torch.arange(rows * TOPK, dtype=torch.int64).reshape(rows, TOPK)
         ids = ids.remainder(EXPERTS)
 
@@ -286,9 +313,7 @@ def test_prefill_capacity_boundaries_preserve_rows_and_routing(
 
         assert [bound[1] for bound in h.api.bound] == expected_slice_rows
         assert torch.equal(out, x)
-        assert torch.equal(
-            torch.cat([route[0] for route in h.api.routed]), weights
-        )
+        assert torch.equal(torch.cat([route[0] for route in h.api.routed]), weights)
         assert torch.equal(torch.cat([route[1] for route in h.api.routed]), ids)
         assert all(bound[0] is h.api.bound[0][0] for bound in h.api.bound)
 
@@ -307,36 +332,31 @@ def test_mixed_prefill_capacity_slices_rows_and_routing():
         method = _make_method()
         layer = _make_mixed_layer()
         rows = 200
-        x = (
-            torch.arange(rows, dtype=torch.bfloat16)
-            .unsqueeze(1)
-            .expand(-1, HIDDEN)
-        )
-        weights = torch.arange(rows * TOPK, dtype=torch.float32).reshape(
-            rows, TOPK
-        )
+        x = torch.arange(rows, dtype=torch.bfloat16).unsqueeze(1).expand(-1, HIDDEN)
+        weights = torch.arange(rows * TOPK, dtype=torch.float32).reshape(rows, TOPK)
         ids = torch.arange(rows * TOPK, dtype=torch.int64).reshape(rows, TOPK)
         ids = ids.remainder(EXPERTS)
 
         out = method._apply_rank_sliced(layer, x, weights, ids)
 
-        assert [launch.size_m for launch in h.mixed_api.compiled] == [32, 128]
-        assert [route[0].shape[0] for route in h.mixed_api.routed] == [128, 72]
+        assert [launch.size_m for launch in h.mixed_api.compiled] == [32]
+        assert [caps["max_tokens"] for caps in h.planned_caps()] == [128, 128]
+        assert [bound[1] for bound in h.api.bound] == [128, 128, 72, 72]
         assert torch.equal(out, x)
         assert torch.equal(
-            torch.cat([route[0] for route in h.mixed_api.routed]), weights
+            torch.cat([route[0] for route in h.api.routed[::2]]), weights
         )
-        assert torch.equal(
-            torch.cat([route[1] for route in h.mixed_api.routed]), ids
+        assert torch.equal(torch.cat([route[1] for route in h.api.routed[::2]]), ids)
+        assert all(
+            torch.equal(left[0], right[0]) and torch.equal(left[1], right[1])
+            for left, right in zip(h.api.routed[::2], h.api.routed[1::2], strict=True)
         )
 
 
 def test_prefill_capacity_cannot_exceed_scheduler_bound():
     env = {"VLLM_EXL3_PREFILL_CAPACITY": str(MAX_BATCHED + 1)}
     with _Harness(env=env) as h:
-        with pytest.raises(
-            ValueError, match="cannot exceed max_num_batched_tokens"
-        ):
+        with pytest.raises(ValueError, match="cannot exceed max_num_batched_tokens"):
             _apply(_make_method(), _make_layer(), 16)
         assert not h.planned_caps()
 

--- a/tests/quantization/test_quantization_config_args.py
+++ b/tests/quantization/test_quantization_config_args.py
@@ -187,6 +187,35 @@ def test_resolve_rejects_modelopt_moe_override():
         )
 
 
+def test_resolve_allows_exl3_bf16_mxfp8_overlay():
+    args = resolve_quantization_config(
+        "exl3",
+        {
+            "linear": {"weight": "mxfp8"},
+            "shared_experts": "mxfp8",
+            "ignore": ["re:.*q_a_proj$", "lm_head"],
+        },
+    )
+
+    assert args.linear == QuantSpec(weight=kMxfp8Dynamic)
+    assert args.shared_experts == QuantSpec(weight=kMxfp8Dynamic)
+    assert args.ignore == ["re:.*q_a_proj$", "lm_head"]
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        {"linear": {"weight": "fp8_per_block_static"}},
+        {"linear": {"weight": "mxfp8", "activation": "mxfp8"}},
+        {"linear": {"weight": "mxfp8"}, "moe": "mxfp8"},
+        {"shared_experts": "mxfp8", "ignore": ["lm_head"]},
+    ],
+)
+def test_resolve_rejects_unsupported_exl3_overlay(config):
+    with pytest.raises(ValueError, match="checkpoint online overlay"):
+        resolve_quantization_config("exl3", config)
+
+
 def test_resolve_rejects_quantization_config_with_non_shorthand_quant():
     # If --quantization names something other than an online shorthand,
     # quantization_config is not allowed via this path (checkpoint quant

--- a/vllm/config/quantization.py
+++ b/vllm/config/quantization.py
@@ -193,8 +193,7 @@ def resolve_quantization_config(
     quantization: str | None,
     quantization_config: dict[str, Any] | QuantizationConfigArgs | None,
 ) -> QuantizationConfigArgs | None:
-    """Resolve `--quantization` shorthand and `--quantization-config` into a
-    QuantizationConfigArgs.
+    """Resolve quantization CLI settings into structured arguments.
 
     `quantization` may be a CLI shorthand that desugars into a base config via
     `_ONLINE_SHORTHANDS`. `quantization_config` is a dict or pre-built args
@@ -202,6 +201,18 @@ def resolve_quantization_config(
     `quantization_config` take precedence over the shorthand. Selected
     checkpoint formats accept online overlays for BF16 dense/shared-expert
     projections.
+
+    Args:
+        quantization: Quantization method name or online shorthand.
+        quantization_config: Explicit online quantization fields, if any.
+
+    Returns:
+        The resolved quantization arguments, or ``None`` when no online
+        configuration was requested.
+
+    Raises:
+        ValueError: If an explicit configuration cannot overlay the selected
+            checkpoint quantization method.
     """
     if isinstance(quantization_config, dict):
         quantization_config = QuantizationConfigArgs(**quantization_config)

--- a/vllm/config/quantization.py
+++ b/vllm/config/quantization.py
@@ -153,11 +153,14 @@ ONLINE_QUANT_SHORTHAND_NAMES: tuple[str, ...] = (
 )
 
 
-# Checkpoint formats that support overlaying online quantization on BF16 projections
-# which the checkpoint explicitly leaves unquantized (shared experts via
-# `shared_experts`, other dense linears via `linear`).
-_MODELOPT_ONLINE_OVERLAY_NAMES = frozenset(
-    {
+# Checkpoint formats that support overlaying online quantization on projections
+# which the checkpoint explicitly leaves in BF16 (shared experts via
+# `shared_experts`, other dense linears via `linear`). Each checkpoint backend
+# still owns the layer-level dispatch, so serialized weights always take
+# precedence over this overlay.
+_CHECKPOINT_ONLINE_OVERLAY_WEIGHTS = {
+    name: frozenset({kMxfp8Dynamic, kFp8Static128BlockSym})
+    for name in {
         "modelopt",
         "modelopt_fp4",
         "modelopt_mxfp8",
@@ -165,16 +168,15 @@ _MODELOPT_ONLINE_OVERLAY_NAMES = frozenset(
         "mxfp4",
         "nvfp4_nf3_hybrid",
     }
-)
+}
+_CHECKPOINT_ONLINE_OVERLAY_WEIGHTS["exl3"] = frozenset({kMxfp8Dynamic})
 
 
-_MODELOPT_ONLINE_OVERLAY_WEIGHTS = frozenset({kMxfp8Dynamic, kFp8Static128BlockSym})
-
-
-def _is_modelopt_online_overlay(
+def _is_checkpoint_online_overlay(
     quantization: str | None, args: QuantizationConfigArgs
 ) -> bool:
-    if quantization not in _MODELOPT_ONLINE_OVERLAY_NAMES or args.moe is not None:
+    supported_weights = _CHECKPOINT_ONLINE_OVERLAY_WEIGHTS.get(quantization)
+    if supported_weights is None or args.moe is not None:
         return False
     specs = [s for s in (args.linear, args.shared_experts) if s is not None]
     if not specs:
@@ -183,8 +185,7 @@ def _is_modelopt_online_overlay(
         # `ignore` only filters the dense-linear overlay.
         return False
     return all(
-        spec.weight in _MODELOPT_ONLINE_OVERLAY_WEIGHTS and spec.activation is None
-        for spec in specs
+        spec.weight in supported_weights and spec.activation is None for spec in specs
     )
 
 
@@ -198,22 +199,22 @@ def resolve_quantization_config(
     `quantization` may be a CLI shorthand that desugars into a base config via
     `_ONLINE_SHORTHANDS`. `quantization_config` is a dict or pre-built args
     object. When both are online settings, fields explicitly set in
-    `quantization_config` take precedence over the shorthand. ModelOpt accepts
-    online overlays for BF16 dense/shared-expert projections.
+    `quantization_config` take precedence over the shorthand. Selected
+    checkpoint formats accept online overlays for BF16 dense/shared-expert
+    projections.
     """
     if isinstance(quantization_config, dict):
         quantization_config = QuantizationConfigArgs(**quantization_config)
 
     if quantization is not None and quantization not in ONLINE_QUANT_SHORTHAND_NAMES:
-        if quantization_config is not None and not _is_modelopt_online_overlay(
+        if quantization_config is not None and not _is_checkpoint_online_overlay(
             quantization, quantization_config
         ):
             raise ValueError(
                 f"quantization_config is only supported when quantization is "
                 f"one of {sorted(ONLINE_QUANT_SHORTHAND_NAMES)}, or when "
-                f"using the ModelOpt online overlay (weight='mxfp8' or "
-                f"weight='fp8_per_block_static' on 'shared_experts' and/or "
-                f"'linear', optional 'ignore'), "
+                f"using a supported checkpoint online overlay on "
+                f"'shared_experts' and/or 'linear' (optional 'ignore'), "
                 f"got quantization={quantization!r}"
             )
         return quantization_config

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -2287,6 +2287,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_EXL3_TRELLIS_MAX_M": lambda: os.getenv("VLLM_EXL3_TRELLIS_MAX_M"),
     "VLLM_EXL3_TRELLIS_BLOCK_M": lambda: os.getenv("VLLM_EXL3_TRELLIS_BLOCK_M"),
     "VLLM_EXL3_PREFILL_CHUNK": lambda: os.getenv("VLLM_EXL3_PREFILL_CHUNK"),
+    "VLLM_EXL3_PREFILL_CAPACITY": lambda: os.getenv(
+        "VLLM_EXL3_PREFILL_CAPACITY"
+    ),
     "VLLM_EXL3_PREFILL_TRELLIS": lambda: os.getenv("VLLM_EXL3_PREFILL_TRELLIS"),
     "VLLM_EXL3_PREFILL_BLOCK_M": lambda: os.getenv("VLLM_EXL3_PREFILL_BLOCK_M"),
     # Prebuilt exllamav3 extension location and torch-ABI compatibility shim.

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -2287,15 +2287,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_EXL3_TRELLIS_MAX_M": lambda: os.getenv("VLLM_EXL3_TRELLIS_MAX_M"),
     "VLLM_EXL3_TRELLIS_BLOCK_M": lambda: os.getenv("VLLM_EXL3_TRELLIS_BLOCK_M"),
     "VLLM_EXL3_PREFILL_CHUNK": lambda: os.getenv("VLLM_EXL3_PREFILL_CHUNK"),
-    "VLLM_EXL3_PREFILL_CAPACITY": lambda: os.getenv(
-        "VLLM_EXL3_PREFILL_CAPACITY"
-    ),
+    "VLLM_EXL3_PREFILL_CAPACITY": lambda: os.getenv("VLLM_EXL3_PREFILL_CAPACITY"),
     "VLLM_EXL3_PREFILL_TRELLIS": lambda: os.getenv("VLLM_EXL3_PREFILL_TRELLIS"),
     "VLLM_EXL3_PREFILL_BLOCK_M": lambda: os.getenv("VLLM_EXL3_PREFILL_BLOCK_M"),
     # Prebuilt exllamav3 extension location and torch-ABI compatibility shim.
     "VLLM_EXL3_EXT_PATH": lambda: os.getenv("VLLM_EXL3_EXT_PATH"),
     "VLLM_EXL3_ABI_SHIM": lambda: os.getenv("VLLM_EXL3_ABI_SHIM"),
-
 }
 
 

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -292,6 +292,7 @@ def _positive_env_int(name: str, default: int) -> int:
         raise ValueError(f"{name} must be positive, got {value}")
     return value
 
+
 def _resolve_prefill_capacity(max_batched_tokens: int) -> int:
     """Resolve the optional EXL3 arena bound within the scheduler contract."""
 

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -264,6 +264,15 @@ def _unique_tensor_storage_bytes(*buffers: Any) -> int:
     return total
 
 
+def _scratch_view(backing: torch.Tensor, spec: Any) -> torch.Tensor:
+    """Return a typed plan-scratch view over a shared byte arena."""
+
+    nbytes = int(spec.dtype.itemsize)
+    for dim in spec.shape:
+        nbytes *= int(dim)
+    return backing.narrow(0, 0, nbytes).view(spec.dtype).view(tuple(spec.shape))
+
+
 def _positive_env_int(name: str, default: int) -> int:
     # An env var that is present but blank means "unset". Compose and Kubernetes
     # both render an unset variable as the empty string, so int("") would abort
@@ -1570,7 +1579,8 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         return (128, 128, 128, 128)
 
     def _prepare_mixed_rank_sliced_weights(self, layer: RoutedExperts) -> None:
-        api = _load_sparkinfer_mixed_trellis()
+        mixed_api = _load_sparkinfer_mixed_trellis()
+        fused_api = _load_sparkinfer_fused_moe()
         num_experts = int(layer.local_num_experts)
         hidden_size = int(layer.exl3_hidden_size)
         intermediate_size = int(layer.exl3_intermediate_size_per_partition)
@@ -1609,9 +1619,36 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         down_suh = self._rank_sliced_backing(layer, "w2_suh")
         down_svh = self._rank_sliced_backing(layer, "w2_svh")
         device = gate_suh.device
-        tile_config = self._mixed_trellis_tile_config(hidden_size, intermediate_size)
+        mixed_tile_config = self._mixed_trellis_tile_config(
+            hidden_size, intermediate_size
+        )
+        serial_tile_config = self._trellis_tile_config(hidden_size, intermediate_size)
+        marker = layer.w13_mcg.exl3_tensors[(0, "w1")]
+        tier_order = tuple(
+            expert_id for expert_ids in tiers.values() for expert_id in expert_ids
+        )
+        tier_index = torch.tensor(tier_order, dtype=torch.long, device=device)
+        combined_gate_suh = gate_suh.index_select(0, tier_index).contiguous()
+        combined_up_suh = up_suh.index_select(0, tier_index).contiguous()
+        combined_intermediate_rotations = torch.cat(
+            (
+                gate_svh.index_select(0, tier_index),
+                up_svh.index_select(0, tier_index),
+                down_suh.index_select(0, tier_index),
+            ),
+            dim=1,
+        ).contiguous()
+        combined_down_svh = down_svh.index_select(0, tier_index).contiguous()
+        combined_rotations = SimpleNamespace(
+            intermediate=combined_intermediate_rotations,
+            gate_suh=combined_gate_suh,
+            up_suh=combined_up_suh,
+            down_svh=combined_down_svh,
+        )
         prepared_tiers = []
+        serial_tiers = []
         tier_ids = []
+        tier_offset = 0
         for bits, expert_ids in tiers.items():
             expected_last = 16 * bits
             w13 = torch.stack(
@@ -1651,27 +1688,21 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 )
 
             index = torch.tensor(expert_ids, dtype=torch.long, device=device)
-            tier_gate_suh = gate_suh.index_select(0, index).contiguous()
-            tier_up_suh = up_suh.index_select(0, index).contiguous()
-            intermediate_rotations = torch.cat(
-                (
-                    gate_svh.index_select(0, index),
-                    up_svh.index_select(0, index),
-                    down_suh.index_select(0, index),
-                ),
-                dim=1,
-            ).contiguous()
-            tier_down_svh = down_svh.index_select(0, index).contiguous()
+            tier_slice = slice(tier_offset, tier_offset + len(expert_ids))
+            tier_gate_suh = combined_gate_suh[tier_slice]
+            tier_up_suh = combined_up_suh[tier_slice]
+            intermediate_rotations = combined_intermediate_rotations[tier_slice]
+            tier_down_svh = combined_down_svh[tier_slice]
             prepared_tiers.append(
-                api.prepare_weights(
+                mixed_api.prepare_weights(
                     w13=w13,
                     w2=w2,
                     hidden_size=hidden_size,
                     intermediate_size=intermediate_size,
                     num_experts=len(expert_ids),
                     activation=layer.activation.value,
-                    fc1_tile_n=tile_config[1],
-                    fc2_tile_n=tile_config[3],
+                    fc1_tile_n=mixed_tile_config[1],
+                    fc2_tile_n=mixed_tile_config[3],
                     params_dtype=torch.float16,
                     w13_layout="trellis3_t256_proj",
                     trellis_bits=bits,
@@ -1680,25 +1711,64 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                     up_suh=tier_up_suh,
                     intermediate_rotations=intermediate_rotations,
                     down_svh=tier_down_svh,
-                    tile_config=tile_config,
+                    tile_config=mixed_tile_config,
                     workspace=w13.view(torch.int32).reshape(-1)[:1],
                 )
             )
+            serial_weight_plan = fused_api.plan_weights(
+                quant_modes="w4a16",
+                source_format="exl3_trellis_mcg",
+                activation=layer.activation.value,
+                params_dtype=layer.exl3_params_dtype,
+                num_experts=len(expert_ids),
+                hidden_size=hidden_size,
+                intermediate_size=intermediate_size,
+                w13_layout="w13",
+                trellis_bits=bits,
+                trellis_tile_config=serial_tile_config,
+            )
+            serial_weights = fused_api.prepare_weights(
+                plan=serial_weight_plan,
+                params_dtype=layer.exl3_params_dtype,
+                w1_fp4=w13,
+                w2_fp4=w2,
+                gate_suh=tier_gate_suh,
+                up_suh=tier_up_suh,
+                intermediate_rotations=intermediate_rotations,
+                down_svh=tier_down_svh,
+                trellis_mcg=marker,
+            )
+            route_expert_map = torch.full(
+                (num_experts,), -1, dtype=torch.int32, device=device
+            )
+            route_expert_map[index] = torch.arange(
+                len(expert_ids), dtype=torch.int32, device=device
+            )
+            serial_tiers.append(
+                {
+                    "bits": bits,
+                    "weights": serial_weights,
+                    "route_expert_map": route_expert_map,
+                }
+            )
             tier_ids.append(expert_ids)
+            tier_offset += len(expert_ids)
 
-        global_to_combined, descriptor_map = api.build_tiered_maps(
+        global_to_combined, descriptor_map = mixed_api.build_tiered_maps(
             tier_ids[0], tier_ids[1], device=device
         )
         layer.exl3_mixed_trellis = {
             "tiers": tuple(prepared_tiers),
+            "serial_tiers": tuple(serial_tiers),
             "tier_ids": tuple(tier_ids),
             "tier_bits": tuple(tiers),
             "global_to_combined": global_to_combined,
             "descriptor_map": descriptor_map,
-            "rotations": api.combine_trellis_rotations(*prepared_tiers),
-            "tile_config": tile_config,
+            "rotations": combined_rotations,
+            "tile_config": mixed_tile_config,
+            "serial_tile_config": serial_tile_config,
         }
-        layer.exl3_trellis_tile_config = tile_config
+        layer.exl3_trellis_tile_config = serial_tile_config
 
         # The prepared tier objects own compact, tier-ordered copies. Release
         # per-expert source tensors and the original rotation slabs now rather
@@ -1834,6 +1904,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         mixed = layer.exl3_mixed_trellis
         max_decode_m = _positive_env_int("VLLM_EXL3_TRELLIS_MAX_M", 32)
         max_batched_tokens = int(layer.exl3_max_num_batched_tokens)
+        prefill_block_m = _positive_env_int("VLLM_EXL3_PREFILL_BLOCK_M", 64)
         if max_decode_m > max_batched_tokens:
             max_decode_m = max_batched_tokens
         topk = int(topk_ids.shape[1])
@@ -1853,6 +1924,8 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             max_decode_m,
             max_batched_tokens,
             mixed["tile_config"],
+            mixed["serial_tile_config"],
+            prefill_block_m,
         )
         runtime = _MIXED_TRELLIS_RUNTIMES.get(key)
         if runtime is not None:
@@ -1868,18 +1941,19 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 f"{topk_ids.dtype}"
             )
 
-        api = _load_sparkinfer_mixed_trellis()
+        mixed_api = _load_sparkinfer_mixed_trellis()
+        fused_api = _load_sparkinfer_fused_moe()
         device = x.device
         props = torch.cuda.get_device_properties(device)
         total_experts = sum(experts for _, experts in tier_signature)
 
-        def make_state(capacity: int) -> dict[str, Any]:
-            route_slots = api.max_packed_route_slots(
+        def make_decode_state(capacity: int) -> dict[str, Any]:
+            route_slots = mixed_api.max_packed_route_slots(
                 capacity * topk,
                 _MIXED_TRELLIS_ROUTE_BLOCK_SIZE,
                 total_experts,
             )
-            launch = api.compile_mixed_trellis(
+            launch = mixed_api.compile_mixed_trellis(
                 size_m=capacity,
                 hidden_size=int(layer.exl3_hidden_size),
                 intermediate_size=int(layer.exl3_intermediate_size_per_partition),
@@ -1900,37 +1974,70 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             return {
                 "capacity": capacity,
                 "launch": launch,
-                "buffers": api.make_mixed_trellis_buffers(
+                "buffers": mixed_api.make_mixed_trellis_buffers(
                     launch,
                     device=device,
                     sms=int(props.multi_processor_count),
                 ),
             }
 
-        decode = make_state(max_decode_m)
-        prefill = (
-            make_state(max_batched_tokens)
-            if max_batched_tokens > max_decode_m
-            else decode
-        )
+        decode = make_decode_state(max_decode_m)
+        prefill_plans = []
+        prefill_arena = None
+        prefill_accum = None
+        if max_batched_tokens > max_decode_m:
+            if os.environ.get("VLLM_EXL3_PREFILL_TRELLIS", "1") != "1":
+                raise ValueError("mixed-K EXL3 requires VLLM_EXL3_PREFILL_TRELLIS=1")
+            scratch_bytes = 0
+            for tier in mixed["serial_tiers"]:
+                caps = fused_api.Caps(
+                    max_tokens=max_batched_tokens,
+                    num_topk=topk,
+                    route_num_experts=total_experts,
+                    device=device,
+                    weight_plan=tier["weights"].plan,
+                    quant_mode="w4a16",
+                    w4a16_block_size_m=prefill_block_m,
+                )
+                plan = fused_api.plan(caps)
+                prefill_plans.append(plan)
+                spec = plan.scratch_specs()[0]
+                size = int(spec.dtype.itemsize)
+                for dim in spec.shape:
+                    size *= int(dim)
+                scratch_bytes = max(scratch_bytes, size)
+            prefill_arena = torch.empty(scratch_bytes, dtype=torch.uint8, device=device)
+            prefill_accum = torch.empty(
+                (max_batched_tokens, int(layer.exl3_hidden_size)),
+                dtype=torch.float32,
+                device=device,
+            )
         runtime = {
-            "api": api,
+            "mixed_api": mixed_api,
+            "fused_api": fused_api,
             "decode": decode,
-            "prefill": prefill,
+            "prefill_plans": tuple(prefill_plans),
+            "prefill_arena": prefill_arena,
+            "prefill_accum": prefill_accum,
             "max_decode_m": max_decode_m,
             "max_batched_tokens": max_batched_tokens,
         }
         _MIXED_TRELLIS_RUNTIMES[key] = runtime
-        buffer_bytes = _unique_tensor_storage_bytes(
-            decode["buffers"], prefill["buffers"]
+        decode_bytes = _unique_tensor_storage_bytes(decode["buffers"])
+        prefill_bytes = sum(
+            tensor.numel() * tensor.element_size()
+            for tensor in (prefill_arena, prefill_accum)
+            if tensor is not None
         )
         logger.info_once(
-            "EXL3 mixed Trellis runtime planned: tiers=%s decode_capacity=%d "
-            "prefill_capacity=%d buffers=%.1f MiB",
+            "EXL3 mixed Trellis runtime planned: tiers=%s one-grid decode=%d "
+            "serial prefill=%d block_m=%d buffers=%.1f+%.1f MiB",
             tier_signature,
             max_decode_m,
             max_batched_tokens,
-            buffer_bytes / (1 << 20),
+            prefill_block_m,
+            decode_bytes / (1 << 20),
+            prefill_bytes / (1 << 20),
         )
         return runtime
 
@@ -1948,23 +2055,53 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 "mixed-bitrate EXL3 batch exceeds planned capacity: "
                 f"m={m}, capacity={runtime['max_batched_tokens']}"
             )
-        state = (
-            runtime["decode"] if m <= runtime["max_decode_m"] else runtime["prefill"]
-        )
         mixed = layer.exl3_mixed_trellis
-        output = runtime["api"].run_mixed_trellis(
-            x,
-            mixed["tiers"][0],
-            mixed["tiers"][1],
-            topk_weights,
-            topk_ids,
-            mixed["global_to_combined"],
-            mixed["descriptor_map"],
-            mixed["rotations"],
-            state["launch"],
-            state["buffers"],
-        )
-        return output.to(x.dtype)
+        # The cooperative mixed-K grid wins at small M, but its SM120 path is
+        # currently limited to route block 8.  Homogeneous tier plans support
+        # block 64 and are substantially faster for prefill, so keep the
+        # one-grid launch for decode and dispatch large M through the two
+        # serial tiers until the mixed kernel gains an efficient large block.
+        if m <= runtime["max_decode_m"]:
+            state = runtime["decode"]
+            output = runtime["mixed_api"].run_mixed_trellis(
+                x,
+                mixed["tiers"][0],
+                mixed["tiers"][1],
+                topk_weights,
+                topk_ids,
+                mixed["global_to_combined"],
+                mixed["descriptor_map"],
+                mixed["rotations"],
+                state["launch"],
+                state["buffers"],
+            )
+            return output.to(x.dtype)
+
+        if runtime["prefill_arena"] is None or runtime["prefill_accum"] is None:
+            raise RuntimeError("mixed-K EXL3 serial prefill plan is unavailable")
+        accum = runtime["prefill_accum"][:m]
+        first = True
+        for plan, tier in zip(
+            runtime["prefill_plans"], mixed["serial_tiers"], strict=True
+        ):
+            binding = runtime["fused_api"].bind(
+                plan,
+                scratch=_scratch_view(
+                    runtime["prefill_arena"], plan.scratch_specs()[0]
+                ),
+                a=x,
+                experts=tier["weights"],
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
+                route_expert_map=tier["route_expert_map"],
+                output_expert_map=tier["route_expert_map"],
+                output=accum if first else None,
+            )
+            output = runtime["fused_api"].run(binding=binding)
+            if not first:
+                accum.add_(output)
+            first = False
+        return accum.to(x.dtype)
 
     def _rank_sliced_runtime(
         self,

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -293,6 +293,21 @@ def _positive_env_int(name: str, default: int) -> int:
     return value
 
 
+def _resolve_prefill_capacity(max_batched_tokens: int) -> int:
+    """Resolve the optional EXL3 arena bound within the scheduler contract."""
+
+    prefill_capacity = _positive_env_int(
+        "VLLM_EXL3_PREFILL_CAPACITY", max_batched_tokens
+    )
+    if prefill_capacity > max_batched_tokens:
+        raise ValueError(
+            "VLLM_EXL3_PREFILL_CAPACITY cannot exceed "
+            "max_num_batched_tokens: "
+            f"capacity={prefill_capacity}, max={max_batched_tokens}"
+        )
+    return prefill_capacity
+
+
 @torch.library.custom_op(
     "vllm::exl3_gemm",
     mutates_args=(),
@@ -1904,6 +1919,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         mixed = layer.exl3_mixed_trellis
         max_decode_m = _positive_env_int("VLLM_EXL3_TRELLIS_MAX_M", 32)
         max_batched_tokens = int(layer.exl3_max_num_batched_tokens)
+        prefill_capacity = _resolve_prefill_capacity(max_batched_tokens)
         prefill_block_m = _positive_env_int("VLLM_EXL3_PREFILL_BLOCK_M", 64)
         if max_decode_m > max_batched_tokens:
             max_decode_m = max_batched_tokens
@@ -1923,6 +1939,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             topk,
             max_decode_m,
             max_batched_tokens,
+            prefill_capacity,
             mixed["tile_config"],
             mixed["serial_tile_config"],
             prefill_block_m,
@@ -1991,7 +2008,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             scratch_bytes = 0
             for tier in mixed["serial_tiers"]:
                 caps = fused_api.Caps(
-                    max_tokens=max_batched_tokens,
+                    max_tokens=prefill_capacity,
                     num_topk=topk,
                     route_num_experts=total_experts,
                     device=device,
@@ -2008,7 +2025,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 scratch_bytes = max(scratch_bytes, size)
             prefill_arena = torch.empty(scratch_bytes, dtype=torch.uint8, device=device)
             prefill_accum = torch.empty(
-                (max_batched_tokens, int(layer.exl3_hidden_size)),
+                (prefill_capacity, int(layer.exl3_hidden_size)),
                 dtype=torch.float32,
                 device=device,
             )
@@ -2021,6 +2038,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             "prefill_accum": prefill_accum,
             "max_decode_m": max_decode_m,
             "max_batched_tokens": max_batched_tokens,
+            "prefill_capacity": prefill_capacity,
         }
         _MIXED_TRELLIS_RUNTIMES[key] = runtime
         decode_bytes = _unique_tensor_storage_bytes(decode["buffers"])
@@ -2031,9 +2049,10 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         )
         logger.info_once(
             "EXL3 mixed Trellis runtime planned: tiers=%s one-grid decode=%d "
-            "serial prefill=%d block_m=%d buffers=%.1f+%.1f MiB",
+            "serial prefill=%d/%d block_m=%d buffers=%.1f+%.1f MiB",
             tier_signature,
             max_decode_m,
+            prefill_capacity,
             max_batched_tokens,
             prefill_block_m,
             decode_bytes / (1 << 20),
@@ -2079,29 +2098,51 @@ class Exl3MoEMethod(FusedMoEMethodBase):
 
         if runtime["prefill_arena"] is None or runtime["prefill_accum"] is None:
             raise RuntimeError("mixed-K EXL3 serial prefill plan is unavailable")
-        accum = runtime["prefill_accum"][:m]
-        first = True
-        for plan, tier in zip(
-            runtime["prefill_plans"], mixed["serial_tiers"], strict=True
-        ):
-            binding = runtime["fused_api"].bind(
-                plan,
-                scratch=_scratch_view(
-                    runtime["prefill_arena"], plan.scratch_specs()[0]
-                ),
-                a=x,
-                experts=tier["weights"],
-                topk_weights=topk_weights,
-                topk_ids=topk_ids,
-                route_expert_map=tier["route_expert_map"],
-                output_expert_map=tier["route_expert_map"],
-                output=accum if first else None,
+        prefill_capacity = int(runtime["prefill_capacity"])
+
+        def run_serial_slice(
+            slice_x: torch.Tensor,
+            slice_weights: torch.Tensor,
+            slice_ids: torch.Tensor,
+        ) -> torch.Tensor:
+            slice_m = int(slice_x.shape[0])
+            accum = runtime["prefill_accum"][:slice_m]
+            first = True
+            for plan, tier in zip(
+                runtime["prefill_plans"], mixed["serial_tiers"], strict=True
+            ):
+                binding = runtime["fused_api"].bind(
+                    plan,
+                    scratch=_scratch_view(
+                        runtime["prefill_arena"], plan.scratch_specs()[0]
+                    ),
+                    a=slice_x,
+                    experts=tier["weights"],
+                    topk_weights=slice_weights,
+                    topk_ids=slice_ids,
+                    route_expert_map=tier["route_expert_map"],
+                    output_expert_map=tier["route_expert_map"],
+                    output=accum if first else None,
+                )
+                tier_output = runtime["fused_api"].run(binding=binding)
+                if not first:
+                    accum.add_(tier_output)
+                first = False
+            return accum.to(slice_x.dtype)
+
+        if m <= prefill_capacity:
+            return run_serial_slice(x, topk_weights, topk_ids)
+
+        output = torch.empty_like(x)
+        for start in range(0, m, prefill_capacity):
+            stop = min(start + prefill_capacity, m)
+            slice_output = run_serial_slice(
+                x[start:stop],
+                topk_weights[start:stop],
+                topk_ids[start:stop],
             )
-            output = runtime["fused_api"].run(binding=binding)
-            if not first:
-                accum.add_(output)
-            first = False
-        return accum.to(x.dtype)
+            output[start:stop].copy_(slice_output)
+        return output
 
     def _rank_sliced_runtime(
         self,
@@ -2133,12 +2174,19 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             raise ValueError(
                 "VLLM_EXL3_TRELLIS_MIN_M cannot exceed VLLM_EXL3_TRELLIS_MAX_M"
             )
-        # Batch-INVARIANT capacity. Including x.shape[0] here made the runtime
-        # cache key depend on the live batch, so any m above the planned capacity
-        # produced a cache MISS -- silently planning a fresh ~1 GiB arena mid-serve
-        # and making the capacity guard in _apply_rank_sliced unreachable. The
-        # planned capacity is a property of the layer, not of one forward pass.
+        # Both capacities are batch-invariant runtime properties. The scheduler
+        # bound remains fail-closed while a smaller opt-in Trellis capacity is
+        # handled by slicing at dispatch.
         max_batched_tokens = int(layer.exl3_max_num_batched_tokens)
+        prefill_capacity = _positive_env_int(
+            "VLLM_EXL3_PREFILL_CAPACITY", max_batched_tokens
+        )
+        if prefill_capacity > max_batched_tokens:
+            raise ValueError(
+                "VLLM_EXL3_PREFILL_CAPACITY cannot exceed "
+                "max_num_batched_tokens: "
+                f"capacity={prefill_capacity}, max={max_batched_tokens}"
+            )
         prefill_plan_enabled = prefill_trellis and max_batched_tokens > max_trellis_m
         parity_rows = (
             min(chunk, max_batched_tokens)
@@ -2173,6 +2221,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             prefill_trellis,
             prefill_block_m,
             layer.exl3_trellis_tile_config,
+            prefill_capacity,
         )
         runtime = _RANK_SLICED_RUNTIMES.get(key)
         if runtime is not None:
@@ -2216,7 +2265,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         prefill_scratch = None
         if prefill_plan_enabled:
             prefill_plan, prefill_scratch = _plan_with_scratch(
-                max_batched_tokens, prefill_block_m
+                prefill_capacity, prefill_block_m
             )
 
         ext = _load_exl3_ext()
@@ -2247,6 +2296,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             "min_trellis_m": min_trellis_m,
             "max_trellis_m": max_trellis_m,
             "max_batched_tokens": max_batched_tokens,
+            "prefill_capacity": prefill_capacity,
             "parity_rows": parity_rows,
             "topk": topk,
             "chunk": chunk,
@@ -2319,12 +2369,13 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         )
         logger.info_once(
             "EXL3 rank-sliced runtime planned: Trellis m=%d..%d block_m=%d, "
-            "prefill %s capacity=%d chunk=%d topk=%d",
+            "prefill %s scheduler_capacity=%d chunk=%d topk=%d",
             min_trellis_m,
             max_trellis_m,
             block_m,
             (
-                f"trellis block_m={prefill_block_m} arena={prefill_arena_mib:.1f}MiB"
+                f"trellis block_m={prefill_block_m} "
+                f"capacity={prefill_capacity} arena={prefill_arena_mib:.1f}MiB"
                 if prefill_plan is not None
                 else "parity"
             ),
@@ -2368,16 +2419,33 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                     "EXL3 batch exceeds its planned capacity: "
                     f"m={m}, capacity={runtime['max_batched_tokens']}"
                 )
-            binding = runtime["api"].bind(
-                runtime["prefill_plan"],
-                scratch=runtime["prefill_scratch"],
-                a=x,
-                experts=layer.exl3_trellis_weights,
-                topk_weights=topk_weights,
-                topk_ids=topk_ids,
-            )
-            output = runtime["api"].run(binding=binding)
-            return output.to(x.dtype)
+            prefill_capacity = int(runtime["prefill_capacity"])
+            if m <= prefill_capacity:
+                binding = runtime["api"].bind(
+                    runtime["prefill_plan"],
+                    scratch=runtime["prefill_scratch"],
+                    a=x,
+                    experts=layer.exl3_trellis_weights,
+                    topk_weights=topk_weights,
+                    topk_ids=topk_ids,
+                )
+                output = runtime["api"].run(binding=binding)
+                return output.to(x.dtype)
+
+            output = torch.empty_like(x)
+            for start in range(0, m, prefill_capacity):
+                stop = min(start + prefill_capacity, m)
+                binding = runtime["api"].bind(
+                    runtime["prefill_plan"],
+                    scratch=runtime["prefill_scratch"],
+                    a=x[start:stop],
+                    experts=layer.exl3_trellis_weights,
+                    topk_weights=topk_weights[start:stop],
+                    topk_ids=topk_ids[start:stop],
+                )
+                slice_output = runtime["api"].run(binding=binding)
+                output[start:stop].copy_(slice_output)
+            return output
 
         if torch.cuda.is_current_stream_capturing():
             raise RuntimeError(

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -712,6 +712,18 @@ class Exl3Config(QuantizationConfig):
         EXL3-owned dense matrices are selected before this method and routed
         experts never enter it. Shared-expert projections have an independent
         spec so a broad ``linear`` overlay cannot quantize them accidentally.
+
+        Args:
+            layer: Candidate module for the online overlay.
+            prefix: Fully qualified checkpoint module name.
+
+        Returns:
+            An MXFP8 method for an eligible BF16 projection, otherwise
+            ``None``.
+
+        Raises:
+            ValueError: If the EXL3 overlay requests an unsupported weight or
+                activation format.
         """
         if not isinstance(layer, LinearBase):
             return None
@@ -791,10 +803,17 @@ class Exl3Config(QuantizationConfig):
         if not source_leaves:
             return False
         base = prefix.rsplit(".", 1)[0] if "." in prefix else ""
-        return all(
+        source_is_exl3 = [
             self._is_exl3_prefix(f"{base}.{source}" if base else source)
             for source in source_leaves
-        )
+        ]
+        if any(source_is_exl3) and not all(source_is_exl3):
+            raise ValueError(
+                f"Packed EXL3 projection {prefix!r} mixes EXL3 and BF16 "
+                "source shards; a fused module must use one quantization "
+                "scheme."
+            )
+        return all(source_is_exl3)
 
     def _moe_prefix_is_exl3(
         self, prefix: str, layer: torch.nn.Module | None = None

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -292,7 +292,6 @@ def _positive_env_int(name: str, default: int) -> int:
         raise ValueError(f"{name} must be positive, got {value}")
     return value
 
-
 def _resolve_prefill_capacity(max_batched_tokens: int) -> int:
     """Resolve the optional EXL3 arena bound within the scheduler contract."""
 
@@ -2178,15 +2177,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         # bound remains fail-closed while a smaller opt-in Trellis capacity is
         # handled by slicing at dispatch.
         max_batched_tokens = int(layer.exl3_max_num_batched_tokens)
-        prefill_capacity = _positive_env_int(
-            "VLLM_EXL3_PREFILL_CAPACITY", max_batched_tokens
-        )
-        if prefill_capacity > max_batched_tokens:
-            raise ValueError(
-                "VLLM_EXL3_PREFILL_CAPACITY cannot exceed "
-                "max_num_batched_tokens: "
-                f"capacity={prefill_capacity}, max={max_batched_tokens}"
-            )
+        prefill_capacity = _resolve_prefill_capacity(max_batched_tokens)
         prefill_plan_enabled = prefill_trellis and max_batched_tokens > max_trellis_m
         parity_rows = (
             min(chunk, max_batched_tokens)

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -163,9 +163,22 @@ def _runtime_scope_id(quant_config: Any) -> int:
 
 
 _RANK_SLICED_FORMAT = "exl3-trellis"
+_PER_EXPERT_ROTATION_LAYOUT = "per_expert_v1"
+_SHARED_H_ROTATION_LAYOUT = "shared_h_v1"
+_SHARED_H_TENSOR_SCHEMA = (
+    "model.layers.{L}.mlp.experts.shared_h.{proj}.rank{r}.{suh|svh}"
+)
 _RANK_SLICED_WEIGHT_RE = re.compile(
     r"^(?P<prefix>.+)\.rank(?P<rank>\d+)\."
     r"(?P<field>trellis|suh|svh|mcg|mul1)$"
+)
+_SHARED_H_WEIGHT_RE = re.compile(
+    r"^(?P<experts_prefix>.+\.experts)\.shared_h\."
+    r"(?P<projection>gate_proj|up_proj|down_proj)\.rank(?P<rank>\d+)\."
+    r"(?P<field>suh|svh)$"
+)
+_EXPERT_PROJECTION_RE = re.compile(
+    r"^.+\.experts\.\d+\.(?P<projection>gate_proj|up_proj|down_proj)$"
 )
 
 ShardId = str | int | tuple[int, ...] | None
@@ -390,6 +403,7 @@ class Exl3Config(QuantizationConfig):
         self.tensor_storage = tensor_storage or {}
         self._eager_checked = False
         self.rank_sliced_metadata: dict[str, Any] | None = None
+        self.rank_sliced_rotation_layout = _PER_EXPERT_ROTATION_LAYOUT
         self.rank_sliced_k_values: tuple[int, ...] | None = None
         self.rank_sliced_bits_by_layer: dict[int, tuple[int, ...]] = {}
 
@@ -517,7 +531,30 @@ class Exl3Config(QuantizationConfig):
                 "unsupported rank-sliced EXL3 tensor schema: "
                 f"{metadata['tensor_schema']!r}"
             )
+        rotation_layout = str(
+            metadata.get("rotation_layout", _PER_EXPERT_ROTATION_LAYOUT)
+        )
+        if rotation_layout not in {
+            _PER_EXPERT_ROTATION_LAYOUT,
+            _SHARED_H_ROTATION_LAYOUT,
+        }:
+            raise ValueError(
+                f"unsupported rank-sliced EXL3 rotation_layout: {rotation_layout!r}"
+            )
+        shared_schema = metadata.get("shared_h_tensor_schema")
+        if rotation_layout == _SHARED_H_ROTATION_LAYOUT:
+            if shared_schema != _SHARED_H_TENSOR_SCHEMA:
+                raise ValueError(
+                    "shared_h_v1 rank-sliced EXL3 requires "
+                    f"shared_h_tensor_schema={_SHARED_H_TENSOR_SCHEMA!r}"
+                )
+        elif shared_schema is not None:
+            raise ValueError(
+                "shared_h_tensor_schema is only valid with "
+                "rotation_layout='shared_h_v1'"
+            )
         self.rank_sliced_metadata = dict(metadata)
+        self.rank_sliced_rotation_layout = rotation_layout
         bits_field = metadata["bits"]
         if isinstance(bits_field, str) and bits_field.strip().lower() == "mixed":
             k_values = tuple(
@@ -869,9 +906,40 @@ class Exl3Config(QuantizationConfig):
         """Drop non-local TP payloads and remove the serialized rank segment."""
         if self.rank_sliced_metadata is None:
             return name
+        shared_match = _SHARED_H_WEIGHT_RE.match(name)
+        if shared_match is not None:
+            if self.rank_sliced_rotation_layout != _SHARED_H_ROTATION_LAYOUT:
+                raise ValueError(
+                    "rank-sliced EXL3 contains shared-H tensors but metadata "
+                    "does not declare rotation_layout='shared_h_v1'"
+                )
+            projection = shared_match.group("projection")
+            field = shared_match.group("field")
+            expected_field = "svh" if projection == "down_proj" else "suh"
+            if field != expected_field:
+                raise ValueError(
+                    "invalid shared-H EXL3 tensor: "
+                    f"projection={projection!r} requires {expected_field}, got {field}"
+                )
+            if int(shared_match.group("rank")) != get_tensor_model_parallel_rank():
+                return None
+            return f"{shared_match.group('experts_prefix')}.0.{projection}.{field}"
         match = _RANK_SLICED_WEIGHT_RE.match(name)
         if match is None:
             return name
+        if self.rank_sliced_rotation_layout == _SHARED_H_ROTATION_LAYOUT:
+            projection_match = _EXPERT_PROJECTION_RE.match(match.group("prefix"))
+            if projection_match is not None:
+                projection = projection_match.group("projection")
+                field = match.group("field")
+                is_h_side = (
+                    projection in {"gate_proj", "up_proj"} and field == "suh"
+                ) or (projection == "down_proj" and field == "svh")
+                if is_h_side:
+                    raise ValueError(
+                        "shared_h_v1 must store H-side rotations under "
+                        "experts.shared_h, not under an expert id"
+                    )
         if int(match.group("rank")) != get_tensor_model_parallel_rank():
             return None
         return f"{match.group('prefix')}.{match.group('field')}"
@@ -1412,6 +1480,12 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         layer.exl3_intermediate_size_per_partition = intermediate_size_per_partition
         layer.exl3_params_dtype = params_dtype
         rank_sliced = self.quant_config.rank_sliced_metadata is not None
+        shared_h = (
+            rank_sliced
+            and self.quant_config.rank_sliced_rotation_layout
+            == _SHARED_H_ROTATION_LAYOUT
+        )
+        layer.exl3_shared_h_rotations = shared_h
         if rank_sliced:
             checkpoint_tp = int(self.quant_config.rank_sliced_metadata["tp"])
             if checkpoint_tp != layer.exl3_tp_size:
@@ -1464,11 +1538,15 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             layer.exl3_mixed_bitrate = len(set(layer.exl3_layer_bitrates)) > 1
         for prefix, shard_ids in (("w13", ("w1", "w3")), ("w2", ("w2",))):
             for suffix in ("suh", "svh", "trellis", "mcg", "mul1"):
+                shared_parameter = shared_h and (
+                    (prefix == "w13" and suffix == "suh")
+                    or (prefix == "w2" and suffix == "svh")
+                )
                 layer.register_parameter(
                     f"{prefix}_{suffix}",
                     Exl3MoEParameter(
                         weight_loader=_exl3_moe_weight_loader,
-                        num_experts=num_experts,
+                        num_experts=1 if shared_parameter else num_experts,
                         shard_ids=shard_ids,
                         preallocate=rank_sliced
                         and suffix
@@ -1486,7 +1564,16 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         for prefix, shard_ids in required.items():
             for attr in ("suh", "svh", "trellis"):
                 tensors = getattr(layer, f"{prefix}_{attr}").exl3_tensors
-                for expert_id in range(layer.local_num_experts):
+                shared_parameter = getattr(
+                    layer, "exl3_shared_h_rotations", False
+                ) and (
+                    (prefix == "w13" and attr == "suh")
+                    or (prefix == "w2" and attr == "svh")
+                )
+                expert_ids = (
+                    (0,) if shared_parameter else range(layer.local_num_experts)
+                )
+                for expert_id in expert_ids:
                     for shard_id in shard_ids:
                         if (expert_id, shard_id) not in tensors:
                             missing.append(f"{prefix}_{attr}[{expert_id},{shard_id}]")
@@ -1588,8 +1675,20 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 for shard_id in shard_ids:
                     key = (expert_id, shard_id)
                     trellis = getattr(layer, f"{group}_trellis").exl3_tensors[key]
-                    suh = getattr(layer, f"{group}_suh").exl3_tensors[key]
-                    svh = getattr(layer, f"{group}_svh").exl3_tensors[key]
+                    suh_key = (
+                        (0, shard_id)
+                        if getattr(layer, "exl3_shared_h_rotations", False)
+                        and group == "w13"
+                        else key
+                    )
+                    svh_key = (
+                        (0, shard_id)
+                        if getattr(layer, "exl3_shared_h_rotations", False)
+                        and group == "w2"
+                        else key
+                    )
+                    suh = getattr(layer, f"{group}_suh").exl3_tensors[suh_key]
+                    svh = getattr(layer, f"{group}_svh").exl3_tensors[svh_key]
                     if (
                         trellis.dtype != torch.int16
                         or trellis.ndim != 3
@@ -1635,16 +1734,39 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         return backing
 
     @staticmethod
-    def _pointer_table(slab: torch.Tensor) -> torch.Tensor:
+    def _pointer_table(
+        slab: torch.Tensor,
+        *,
+        num_experts: int | None = None,
+    ) -> torch.Tensor:
         if slab.ndim < 2 or not slab[0].is_contiguous():
             raise RuntimeError("EXL3 pointer-table rows must be contiguous")
+        rows = int(slab.shape[0])
+        entries = rows if num_experts is None else int(num_experts)
+        if rows not in {1, entries}:
+            raise RuntimeError(
+                "EXL3 pointer-table rows must be per-expert or broadcast: "
+                f"rows={rows}, experts={entries}"
+            )
         step = slab.stride(0) * slab.element_size()
         base = slab.data_ptr()
         return torch.tensor(
-            [base + expert_id * step for expert_id in range(slab.shape[0])],
+            [
+                base + (0 if rows == 1 else expert_id) * step
+                for expert_id in range(entries)
+            ],
             dtype=torch.int64,
             device=slab.device,
         )
+
+    @staticmethod
+    def _select_rotation_rows(
+        rotations: torch.Tensor,
+        expert_ids: torch.Tensor,
+    ) -> torch.Tensor:
+        if int(rotations.shape[0]) == 1:
+            return rotations
+        return rotations.index_select(0, expert_ids).contiguous()
 
     @staticmethod
     def _trellis_tile_config(hidden_size: int, intermediate_size: int):
@@ -1723,8 +1845,8 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             expert_id for expert_ids in tiers.values() for expert_id in expert_ids
         )
         tier_index = torch.tensor(tier_order, dtype=torch.long, device=device)
-        combined_gate_suh = gate_suh.index_select(0, tier_index).contiguous()
-        combined_up_suh = up_suh.index_select(0, tier_index).contiguous()
+        combined_gate_suh = self._select_rotation_rows(gate_suh, tier_index)
+        combined_up_suh = self._select_rotation_rows(up_suh, tier_index)
         combined_intermediate_rotations = torch.cat(
             (
                 gate_svh.index_select(0, tier_index),
@@ -1733,7 +1855,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             ),
             dim=1,
         ).contiguous()
-        combined_down_svh = down_svh.index_select(0, tier_index).contiguous()
+        combined_down_svh = self._select_rotation_rows(down_svh, tier_index)
         combined_rotations = SimpleNamespace(
             intermediate=combined_intermediate_rotations,
             gate_suh=combined_gate_suh,
@@ -1784,10 +1906,22 @@ class Exl3MoEMethod(FusedMoEMethodBase):
 
             index = torch.tensor(expert_ids, dtype=torch.long, device=device)
             tier_slice = slice(tier_offset, tier_offset + len(expert_ids))
-            tier_gate_suh = combined_gate_suh[tier_slice]
-            tier_up_suh = combined_up_suh[tier_slice]
+            tier_gate_suh = (
+                combined_gate_suh
+                if int(combined_gate_suh.shape[0]) == 1
+                else combined_gate_suh[tier_slice]
+            )
+            tier_up_suh = (
+                combined_up_suh
+                if int(combined_up_suh.shape[0]) == 1
+                else combined_up_suh[tier_slice]
+            )
             intermediate_rotations = combined_intermediate_rotations[tier_slice]
-            tier_down_svh = combined_down_svh[tier_slice]
+            tier_down_svh = (
+                combined_down_svh
+                if int(combined_down_svh.shape[0]) == 1
+                else combined_down_svh[tier_slice]
+            )
             prepared_tiers.append(
                 mixed_api.prepare_weights(
                     w13=w13,
@@ -1972,13 +2106,22 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             down_suh,
             down_svh,
         )
-        layer.exl3_pointer_tables = tuple(self._pointer_table(slab) for slab in slabs)
+        layer.exl3_pointer_tables = tuple(
+            self._pointer_table(slab, num_experts=num_experts) for slab in slabs
+        )
         layer.exl3_expert_map = torch.arange(
             num_experts,
             dtype=torch.int64,
             device=w13.device,
         )
         layer.exl3_trellis_tile_config = tile_config
+        if getattr(layer, "exl3_shared_h_rotations", False):
+            saved_bytes = (num_experts - 1) * 3 * hidden_size * 2
+            logger.info_once(
+                "EXL3 shared-H rotation layout active; saving %.2f MiB per "
+                "routed-expert layer and TP rank",
+                saved_bytes / (1024 * 1024),
+            )
 
     def get_fused_moe_quant_config(
         self, layer: RoutedExperts

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -31,6 +31,7 @@ import torch
 from transformers import PretrainedConfig
 
 from vllm.config import get_current_vllm_config_or_none
+from vllm.config.quantization import QuantizationConfigArgs
 from vllm.distributed import (
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
@@ -53,6 +54,14 @@ from vllm.model_executor.layers.quantization.base_config import (
     QuantizationConfig,
     QuantizeMethodBase,
 )
+from vllm.model_executor.layers.quantization.compressed_tensors.utils import (
+    should_ignore_layer,
+)
+from vllm.model_executor.layers.quantization.online.mxfp8 import (
+    Mxfp8OnlineLinearMethod,
+    is_shared_expert_projection,
+)
+from vllm.model_executor.layers.quantization.utils.quant_utils import kMxfp8Dynamic
 from vllm.model_executor.parameter import BasevLLMParameter
 from vllm.transformers_utils.repo_utils import get_hf_file_to_dict
 
@@ -682,14 +691,66 @@ class Exl3Config(QuantizationConfig):
         if is_lm_head and not prefix:
             prefix = "lm_head"
         if isinstance(layer, LinearBase) or is_lm_head:
-            if not self._linear_prefix_is_exl3(prefix):
-                return UnquantizedLinearMethod()
-            return Exl3LinearMethod(self)
+            if self._linear_prefix_is_exl3(prefix):
+                return Exl3LinearMethod(self)
+            if not is_lm_head and (
+                method := self._get_bf16_online_linear_method(layer, prefix)
+            ):
+                return method
+            return UnquantizedLinearMethod()
         if isinstance(layer, RoutedExperts):
             if not self._moe_prefix_is_exl3(prefix, layer):
                 return None
             return Exl3MoEMethod(self, layer.moe_config)
         return None
+
+    def _get_bf16_online_linear_method(
+        self, layer: torch.nn.Module, prefix: str
+    ) -> QuantizeMethodBase | None:
+        """Overlay MXFP8 only on linears absent from EXL3 tensor storage.
+
+        EXL3-owned dense matrices are selected before this method and routed
+        experts never enter it. Shared-expert projections have an independent
+        spec so a broad ``linear`` overlay cannot quantize them accidentally.
+        """
+        if not isinstance(layer, LinearBase):
+            return None
+
+        vllm_config = get_current_vllm_config_or_none()
+        if vllm_config is None:
+            return None
+        args = vllm_config.model_config.quantization_config
+        if not isinstance(args, QuantizationConfigArgs):
+            return None
+
+        shared_expert = is_shared_expert_projection(prefix)
+        spec = args.shared_experts if shared_expert else args.linear
+        if spec is None:
+            return None
+        if (
+            not shared_expert
+            and args.ignore
+            and should_ignore_layer(
+                prefix,
+                ignore=args.ignore,
+                fused_mapping=self.packed_modules_mapping,
+            )
+        ):
+            return None
+        if spec.weight != kMxfp8Dynamic or spec.activation is not None:
+            raise ValueError(
+                "EXL3 BF16 online overlay only supports weight='mxfp8' "
+                "with no activation override."
+            )
+
+        logger.info_once(
+            "EXL3 BF16 online overlay: quantizing non-EXL3 %s projections "
+            "to MXFP8 at load time (module example: %s).",
+            "shared-expert" if shared_expert else "dense-linear",
+            prefix,
+        )
+        logger.debug("EXL3 BF16 MXFP8 overlay applied to %s", prefix)
+        return Mxfp8OnlineLinearMethod()
 
     def _storage_entry(self, prefix: str) -> dict[str, Any] | None:
         candidates = [prefix]


### PR DESCRIPTION
## Summary

Consolidate the three EXL3 changes that touched the same loader and planning code into one reviewable GG PR:

- retain the shape-aware mixed K3/K4 decode path and serial block-64 prefill path from #222;
- retain the explicit MXFP8 overlay for BF16 linear/shared-expert weights from #223;
- add the backward-compatible `shared_h_v1` artifact layout from the original #225.

Keeping one PR avoids merge-order conflicts and makes the combined memory, dispatch, and quantization contracts testable together.

## Runtime contracts

### Mixed K3/K4 execution

- Decode and small M use the one-grid mixed Trellis path.
- Larger prefills use homogeneous serial K3/K4 plans.
- `VLLM_EXL3_PREFILL_CAPACITY` optionally bounds persistent prefill scratch.
- Route weights, route IDs, output views, and CUDA graph behavior are preserved.

### Online MXFP8 overlay

- EXL3 tensor-storage records remain controlled by `Exl3LinearMethod`/`Exl3MoEMethod`.
- Only BF16 dense/shared-expert weights are eligible for the MXFP8 overlay.
- Routed EXL3 experts reject incompatible MoE overlays.
- Existing ModelOpt/MXFP4 overlay behavior is unchanged.

### Shared-H artifacts

- Missing `rotation_layout` remains legacy `per_expert_v1`.
- `shared_h_v1` requires the exact `shared_h_tensor_schema` metadata.
- Gate/up SU and down SV are allocated as one physical `[1,H]` row and broadcast by stride/pointer contract without expansion.
- Mixed K3/K4 tiers retain the same single physical row in both one-grid decode and serial prefill.
- Invalid mixed legacy/shared tensor names fail closed.

For GLM-5.2, the shared-H layout removes 672.36 MiB/GPU of duplicated persistent rotations across 75 MoE layers.

## Validation

- `47 passed`: `tests/quantization/test_exl3.py` and `tests/quantization/test_exl3_prefill_plan.py`
- Includes an integration regression test for mixed K3/K4 + `shared_h_v1` + serial prefill.
- Ruff check/format, `py_compile`, and `git diff --check` pass.
- The earlier matched TP4/DCP4 EXL3 validation from #222 remains applicable:
  - 3k: 3,012 -> 3,792 tok/s
  - 32k: 2,855 -> 3,690 tok/s
  - 128k: 2,363 -> 3,324 tok/s
  - KV capacity: 804,864 -> 856,320 tokens

The shared-H loader is explicit and backward compatible. A complete newly encoded shared-H checkpoint still requires its own KLD and E2E release validation.

Supersedes #222 and #223.
