### PR TITLE
[GG][EXL3] keep bounded mixed-K prefill on one grid

### DIFF
--- a/tests/quantization/test_exl3.py
+++ b/tests/quantization/test_exl3.py
@@ -702,9 +702,9 @@ def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(
         )
     assert [entry["tile_config"] for entry in api.prepared] == [
         (128, 128, 128, 128),
-        (128, 64, 64, 128),
         (128, 128, 128, 128),
-        (128, 64, 64, 128),
+        (128, 128, 128, 128),
+        (128, 128, 128, 128),
     ]
     assert layer.exl3_mixed_trellis["tier_ids"] == ((0, 2), (1, 3))
     assert layer.exl3_mixed_trellis["tier_bits"] == (3, 4)

--- a/tests/quantization/test_exl3.py
+++ b/tests/quantization/test_exl3.py
@@ -655,9 +655,6 @@ def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(
             name = f"{prefix}_{suffix}"
             backing = slabs.get(name)
             setattr(layer, name, parameter(shards, backing=backing))
-    marker = torch.tensor(0xCBAC1FED - (1 << 32), dtype=torch.int32)
-    layer.w13_mcg.exl3_tensors[(0, "w1")] = marker
-
     class FakeMixedApi:
         def __init__(self):
             self.prepared = []
@@ -679,30 +676,15 @@ def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(
         def combine_trellis_rotations(tier0, tier1):
             return tier0, tier1
 
-    class FakeFusedApi:
-        def __init__(self):
-            self.plans = []
-            self.prepared = []
-
-        def plan_weights(self, **kwargs):
-            self.plans.append(kwargs)
-            return SimpleNamespace(**kwargs)
-
-        def prepare_weights(self, **kwargs):
-            self.prepared.append(kwargs)
-            return SimpleNamespace(plan=kwargs["plan"])
-
     api = FakeMixedApi()
-    fused_api = FakeFusedApi()
     monkeypatch.setattr(exl3_module, "_load_sparkinfer_mixed_trellis", lambda: api)
-    monkeypatch.setattr(exl3_module, "_load_sparkinfer_fused_moe", lambda: fused_api)
     method = object.__new__(Exl3MoEMethod)
     method._rank_sliced_backing = lambda _layer, name: slabs[name]
 
     method._prepare_mixed_rank_sliced_weights(layer)
 
-    assert [entry["trellis_bits"] for entry in api.prepared] == [3, 4]
-    assert [entry["num_experts"] for entry in api.prepared] == [2, 2]
+    assert [entry["trellis_bits"] for entry in api.prepared] == [3, 3, 4, 4]
+    assert [entry["num_experts"] for entry in api.prepared] == [2] * 4
     for entry in api.prepared:
         bits = entry["trellis_bits"]
         assert tuple(entry["w13"].shape) == (
@@ -720,33 +702,26 @@ def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(
         )
     assert [entry["tile_config"] for entry in api.prepared] == [
         (128, 128, 128, 128),
+        (128, 64, 64, 128),
         (128, 128, 128, 128),
+        (128, 64, 64, 128),
     ]
     assert layer.exl3_mixed_trellis["tier_ids"] == ((0, 2), (1, 3))
     assert layer.exl3_mixed_trellis["tier_bits"] == (3, 4)
-    assert [entry["trellis_bits"] for entry in fused_api.plans] == [3, 4]
-    assert [entry["trellis_tile_config"] for entry in fused_api.plans] == [
-        (64, 128, 64, 128),
-        (64, 128, 64, 128),
-    ]
-    assert all(entry["trellis_mcg"] is marker for entry in fused_api.prepared)
-    assert len(layer.exl3_mixed_trellis["serial_tiers"]) == 2
+    assert len(layer.exl3_mixed_trellis["tiers"]) == 2
+    assert len(layer.exl3_mixed_trellis["prefill_tiers"]) == 2
     rotations = layer.exl3_mixed_trellis["rotations"]
     expected_h_rows = 1 if shared_h else experts
     assert rotations.gate_suh.shape[0] == expected_h_rows
     assert rotations.up_suh.shape[0] == expected_h_rows
     assert rotations.down_svh.shape[0] == expected_h_rows
-    for mixed_entry, serial_entry in zip(api.prepared, fused_api.prepared, strict=True):
+    for entry in api.prepared:
         expected_tier_rows = 1 if shared_h else 2
-        assert mixed_entry["gate_suh"].shape[0] == expected_tier_rows
-        assert mixed_entry["up_suh"].shape[0] == expected_tier_rows
-        assert mixed_entry["down_svh"].shape[0] == expected_tier_rows
+        assert entry["gate_suh"].shape[0] == expected_tier_rows
+        assert entry["up_suh"].shape[0] == expected_tier_rows
+        assert entry["down_svh"].shape[0] == expected_tier_rows
         assert (
-            mixed_entry["gate_suh"].untyped_storage().data_ptr()
-            == rotations.gate_suh.untyped_storage().data_ptr()
-        )
-        assert (
-            serial_entry["gate_suh"].untyped_storage().data_ptr()
+            entry["gate_suh"].untyped_storage().data_ptr()
             == rotations.gate_suh.untyped_storage().data_ptr()
         )
     assert layer.w13_trellis.exl3_tensors == {}
@@ -763,57 +738,36 @@ def test_mixed_trellis_buffer_accounting_ignores_metadata() -> None:
     assert exl3_module._unique_tensor_storage_bytes(first, second) == 8
 
 
-def test_mixed_trellis_dispatches_decode_and_serial_prefill(monkeypatch):
+def test_mixed_trellis_dispatches_decode_and_one_grid_prefill(monkeypatch):
     class FakeMixedApi:
-        calls = 0
+        calls = []
 
         def run_mixed_trellis(self, x, *args):
-            self.calls += 1
-            return torch.ones_like(x)
-
-    class FakeFusedApi:
-        def __init__(self):
-            self.bindings = []
-
-        def bind(self, plan, **kwargs):
-            del plan
-            self.bindings.append(kwargs)
-            return kwargs
-
-        @staticmethod
-        def run(*, binding):
-            output = binding["output"]
-            if output is not None:
-                output.fill_(1)
-                return output
-            return torch.full_like(binding["a"], 2, dtype=torch.float32)
-
-    class FakePlan:
-        @staticmethod
-        def scratch_specs():
-            return [SimpleNamespace(shape=(16,), dtype=torch.uint8)]
+            launch = args[7]
+            self.calls.append((int(x.shape[0]), args[0], args[1], launch))
+            return torch.full_like(x, launch.value)
 
     mixed_api = FakeMixedApi()
-    fused_api = FakeFusedApi()
+    decode_tiers = (object(), object())
+    prefill_tiers = (object(), object())
     runtime = {
         "mixed_api": mixed_api,
-        "fused_api": fused_api,
-        "decode": {"launch": object(), "buffers": object()},
-        "prefill_plans": (FakePlan(), FakePlan()),
-        "prefill_arena": torch.empty(16, dtype=torch.uint8),
-        "prefill_accum": torch.empty((8, 4), dtype=torch.float32),
+        "decode": {
+            "launch": SimpleNamespace(value=1),
+            "buffers": object(),
+        },
+        "prefill": {
+            "launch": SimpleNamespace(value=3),
+            "buffers": object(),
+        },
         "max_decode_m": 8,
         "max_batched_tokens": 16,
         "prefill_capacity": 8,
     }
-    tiers = (
-        {"weights": object(), "route_expert_map": torch.tensor([0, -1])},
-        {"weights": object(), "route_expert_map": torch.tensor([-1, 0])},
-    )
     layer = SimpleNamespace(
         exl3_mixed_trellis={
-            "tiers": (object(), object()),
-            "serial_tiers": tiers,
+            "tiers": decode_tiers,
+            "prefill_tiers": prefill_tiers,
             "global_to_combined": object(),
             "descriptor_map": object(),
             "rotations": object(),
@@ -833,33 +787,9 @@ def test_mixed_trellis_dispatches_decode_and_serial_prefill(monkeypatch):
 
     torch.testing.assert_close(decode, torch.ones_like(decode))
     torch.testing.assert_close(prefill, torch.full_like(prefill, 3))
-    assert mixed_api.calls == 1
-    assert len(fused_api.bindings) == 4
-    assert [binding["a"].shape[0] for binding in fused_api.bindings] == [8] * 4
-    assert all(
-        torch.equal(binding["topk_weights"], weights[:8])
-        for binding in fused_api.bindings[:2]
-    )
-    assert all(
-        torch.equal(binding["topk_weights"], weights[8:])
-        for binding in fused_api.bindings[2:]
-    )
-    assert all(
-        torch.equal(binding["topk_ids"], ids[:8]) for binding in fused_api.bindings[:2]
-    )
-    assert all(
-        torch.equal(binding["topk_ids"], ids[8:]) for binding in fused_api.bindings[2:]
-    )
-    assert (
-        fused_api.bindings[0]["output"].data_ptr()
-        == runtime["prefill_accum"].data_ptr()
-    )
-    assert fused_api.bindings[1]["output"] is None
-    assert (
-        fused_api.bindings[2]["output"].data_ptr()
-        == runtime["prefill_accum"].data_ptr()
-    )
-    assert fused_api.bindings[3]["output"] is None
+    assert [call[0] for call in mixed_api.calls] == [4, 8, 8]
+    assert mixed_api.calls[0][1:3] == decode_tiers
+    assert all(call[1:3] == prefill_tiers for call in mixed_api.calls[1:])
 
 
 @pytest.mark.parametrize(

--- a/tests/quantization/test_exl3_prefill_plan.py
+++ b/tests/quantization/test_exl3_prefill_plan.py
@@ -118,7 +118,6 @@ class _FakeMixedTrellisApi:
         self.routed.append((topk_weights.clone(), topk_ids.clone()))
         return x.to(torch.float32)
 
-
 class _FakeExt:
     """Parity extension without exl3_moe_fused: chunk loop only."""
 
@@ -152,23 +151,14 @@ def _make_mixed_layer():
     layer.exl3_mixed_bitrate = True
     layer.exl3_mixed_trellis = {
         "tiers": (object(), object()),
+        "prefill_tiers": (object(), object()),
         "tier_ids": ((0, 1, 2, 3), (4, 5, 6, 7)),
         "tier_bits": (3, 4),
         "global_to_combined": object(),
         "descriptor_map": object(),
         "rotations": object(),
         "tile_config": (64, 128, 64, 128),
-        "serial_tile_config": (64, 128, 64, 128),
-        "serial_tiers": (
-            {
-                "weights": SimpleNamespace(plan=object()),
-                "route_expert_map": torch.tensor([0, 1, 2, 3, -1, -1, -1, -1]),
-            },
-            {
-                "weights": SimpleNamespace(plan=object()),
-                "route_expert_map": torch.tensor([-1, -1, -1, -1, 0, 1, 2, 3]),
-            },
-        ),
+        "prefill_tile_config": (128, 64, 64, 128),
     }
     return layer
 
@@ -339,18 +329,16 @@ def test_mixed_prefill_capacity_slices_rows_and_routing():
 
         out = method._apply_rank_sliced(layer, x, weights, ids)
 
-        assert [launch.size_m for launch in h.mixed_api.compiled] == [32]
-        assert [caps["max_tokens"] for caps in h.planned_caps()] == [128, 128]
-        assert [bound[1] for bound in h.api.bound] == [128, 128, 72, 72]
+        assert [launch.size_m for launch in h.mixed_api.compiled] == [32, 128]
+        assert [launch.moe_block_size for launch in h.mixed_api.compiled] == [8, 64]
+        assert h.mixed_api.compiled[1].force_tile_config == (128, 64, 64, 128)
+        assert not h.planned_caps()
+        assert not h.api.bound
         assert torch.equal(out, x)
         assert torch.equal(
-            torch.cat([route[0] for route in h.api.routed[::2]]), weights
+            torch.cat([route[0] for route in h.mixed_api.routed]), weights
         )
-        assert torch.equal(torch.cat([route[1] for route in h.api.routed[::2]]), ids)
-        assert all(
-            torch.equal(left[0], right[0]) and torch.equal(left[1], right[1])
-            for left, right in zip(h.api.routed[::2], h.api.routed[1::2], strict=True)
-        )
+        assert torch.equal(torch.cat([route[1] for route in h.mixed_api.routed]), ids)
 
 
 def test_prefill_capacity_cannot_exceed_scheduler_bound():

--- a/tests/quantization/test_exl3_prefill_plan.py
+++ b/tests/quantization/test_exl3_prefill_plan.py
@@ -158,7 +158,7 @@ def _make_mixed_layer():
         "descriptor_map": object(),
         "rotations": object(),
         "tile_config": (64, 128, 64, 128),
-        "prefill_tile_config": (128, 64, 64, 128),
+        "prefill_tile_config": (128, 128, 128, 128),
     }
     return layer
 
@@ -331,7 +331,7 @@ def test_mixed_prefill_capacity_slices_rows_and_routing():
 
         assert [launch.size_m for launch in h.mixed_api.compiled] == [32, 128]
         assert [launch.moe_block_size for launch in h.mixed_api.compiled] == [8, 64]
-        assert h.mixed_api.compiled[1].force_tile_config == (128, 64, 64, 128)
+        assert h.mixed_api.compiled[1].force_tile_config == (128, 128, 128, 128)
         assert not h.planned_caps()
         assert not h.api.bound
         assert torch.equal(out, x)

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -1799,12 +1799,13 @@ class Exl3MoEMethod(FusedMoEMethodBase):
     def _mixed_trellis_prefill_tile_config(
         hidden_size: int, intermediate_size: int
     ):
-        if hidden_size % 128 or intermediate_size % 128:
-            raise ValueError(
-                "mixed rank-sliced EXL3 prefill requires hidden and "
-                "intermediate dimensions divisible by 128"
-            )
-        return (128, 64, 64, 128)
+        # Route packing stays block-64, while SparkInfer's mixed-kernel ABI v2
+        # executes FC2 as arithmetic-equivalent 8-row subtiles.  Reuse the
+        # checkpoint's original one-grid tile geometry so prefill has the same
+        # reduction order as the stock-r16 quality reference.
+        return Exl3MoEMethod._mixed_trellis_tile_config(
+            hidden_size, intermediate_size
+        )
 
     def _prepare_mixed_rank_sliced_weights(self, layer: RoutedExperts) -> None:
         mixed_api = _load_sparkinfer_mixed_trellis()

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -1795,9 +1795,19 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             return (128, 128, 64, 256)
         return (128, 128, 128, 128)
 
+    @staticmethod
+    def _mixed_trellis_prefill_tile_config(
+        hidden_size: int, intermediate_size: int
+    ):
+        if hidden_size % 128 or intermediate_size % 128:
+            raise ValueError(
+                "mixed rank-sliced EXL3 prefill requires hidden and "
+                "intermediate dimensions divisible by 128"
+            )
+        return (128, 64, 64, 128)
+
     def _prepare_mixed_rank_sliced_weights(self, layer: RoutedExperts) -> None:
         mixed_api = _load_sparkinfer_mixed_trellis()
-        fused_api = _load_sparkinfer_fused_moe()
         num_experts = int(layer.local_num_experts)
         hidden_size = int(layer.exl3_hidden_size)
         intermediate_size = int(layer.exl3_intermediate_size_per_partition)
@@ -1839,8 +1849,9 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         mixed_tile_config = self._mixed_trellis_tile_config(
             hidden_size, intermediate_size
         )
-        serial_tile_config = self._trellis_tile_config(hidden_size, intermediate_size)
-        marker = layer.w13_mcg.exl3_tensors[(0, "w1")]
+        prefill_tile_config = self._mixed_trellis_prefill_tile_config(
+            hidden_size, intermediate_size
+        )
         tier_order = tuple(
             expert_id for expert_ids in tiers.values() for expert_id in expert_ids
         )
@@ -1863,7 +1874,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             down_svh=combined_down_svh,
         )
         prepared_tiers = []
-        serial_tiers = []
+        prefill_tiers = []
         tier_ids = []
         tier_offset = 0
         for bits, expert_ids in tiers.items():
@@ -1904,7 +1915,6 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                     f"expected={expected_w13}/{expected_w2}"
                 )
 
-            index = torch.tensor(expert_ids, dtype=torch.long, device=device)
             tier_slice = slice(tier_offset, tier_offset + len(expert_ids))
             tier_gate_suh = (
                 combined_gate_suh
@@ -1922,16 +1932,17 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 if int(combined_down_svh.shape[0]) == 1
                 else combined_down_svh[tier_slice]
             )
-            prepared_tiers.append(
-                mixed_api.prepare_weights(
+
+            def prepare_tier(tile_config: tuple[int, int, int, int]):
+                return mixed_api.prepare_weights(
                     w13=w13,
                     w2=w2,
                     hidden_size=hidden_size,
                     intermediate_size=intermediate_size,
                     num_experts=len(expert_ids),
                     activation=layer.activation.value,
-                    fc1_tile_n=mixed_tile_config[1],
-                    fc2_tile_n=mixed_tile_config[3],
+                    fc1_tile_n=tile_config[1],
+                    fc2_tile_n=tile_config[3],
                     params_dtype=torch.float16,
                     w13_layout="trellis3_t256_proj",
                     trellis_bits=bits,
@@ -1940,46 +1951,12 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                     up_suh=tier_up_suh,
                     intermediate_rotations=intermediate_rotations,
                     down_svh=tier_down_svh,
-                    tile_config=mixed_tile_config,
+                    tile_config=tile_config,
                     workspace=w13.view(torch.int32).reshape(-1)[:1],
                 )
-            )
-            serial_weight_plan = fused_api.plan_weights(
-                quant_modes="w4a16",
-                source_format="exl3_trellis_mcg",
-                activation=layer.activation.value,
-                params_dtype=layer.exl3_params_dtype,
-                num_experts=len(expert_ids),
-                hidden_size=hidden_size,
-                intermediate_size=intermediate_size,
-                w13_layout="w13",
-                trellis_bits=bits,
-                trellis_tile_config=serial_tile_config,
-            )
-            serial_weights = fused_api.prepare_weights(
-                plan=serial_weight_plan,
-                params_dtype=layer.exl3_params_dtype,
-                w1_fp4=w13,
-                w2_fp4=w2,
-                gate_suh=tier_gate_suh,
-                up_suh=tier_up_suh,
-                intermediate_rotations=intermediate_rotations,
-                down_svh=tier_down_svh,
-                trellis_mcg=marker,
-            )
-            route_expert_map = torch.full(
-                (num_experts,), -1, dtype=torch.int32, device=device
-            )
-            route_expert_map[index] = torch.arange(
-                len(expert_ids), dtype=torch.int32, device=device
-            )
-            serial_tiers.append(
-                {
-                    "bits": bits,
-                    "weights": serial_weights,
-                    "route_expert_map": route_expert_map,
-                }
-            )
+
+            prepared_tiers.append(prepare_tier(mixed_tile_config))
+            prefill_tiers.append(prepare_tier(prefill_tile_config))
             tier_ids.append(expert_ids)
             tier_offset += len(expert_ids)
 
@@ -1988,16 +1965,16 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         )
         layer.exl3_mixed_trellis = {
             "tiers": tuple(prepared_tiers),
-            "serial_tiers": tuple(serial_tiers),
+            "prefill_tiers": tuple(prefill_tiers),
             "tier_ids": tuple(tier_ids),
             "tier_bits": tuple(tiers),
             "global_to_combined": global_to_combined,
             "descriptor_map": descriptor_map,
             "rotations": combined_rotations,
             "tile_config": mixed_tile_config,
-            "serial_tile_config": serial_tile_config,
+            "prefill_tile_config": prefill_tile_config,
         }
-        layer.exl3_trellis_tile_config = serial_tile_config
+        layer.exl3_trellis_tile_config = mixed_tile_config
 
         # The prepared tier objects own compact, tier-ordered copies. Release
         # per-expert source tensors and the original rotation slabs now rather
@@ -2164,7 +2141,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             max_batched_tokens,
             prefill_capacity,
             mixed["tile_config"],
-            mixed["serial_tile_config"],
+            mixed["prefill_tile_config"],
             prefill_block_m,
         )
         runtime = _MIXED_TRELLIS_RUNTIMES.get(key)
@@ -2182,15 +2159,18 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             )
 
         mixed_api = _load_sparkinfer_mixed_trellis()
-        fused_api = _load_sparkinfer_fused_moe()
         device = x.device
         props = torch.cuda.get_device_properties(device)
         total_experts = sum(experts for _, experts in tier_signature)
 
-        def make_decode_state(capacity: int) -> dict[str, Any]:
+        def make_state(
+            capacity: int,
+            block_size_m: int,
+            tile_config: tuple[int, int, int, int],
+        ) -> dict[str, Any]:
             route_slots = mixed_api.max_packed_route_slots(
                 capacity * topk,
-                _MIXED_TRELLIS_ROUTE_BLOCK_SIZE,
+                block_size_m,
                 total_experts,
             )
             launch = mixed_api.compile_mixed_trellis(
@@ -2202,12 +2182,11 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 tier0_bits=tier_signature[0][0],
                 tier1_bits=tier_signature[1][0],
                 top_k=topk,
-                max_m_blocks=(route_slots + _MIXED_TRELLIS_ROUTE_BLOCK_SIZE - 1)
-                // _MIXED_TRELLIS_ROUTE_BLOCK_SIZE,
-                moe_block_size=_MIXED_TRELLIS_ROUTE_BLOCK_SIZE,
+                max_m_blocks=(route_slots + block_size_m - 1) // block_size_m,
+                moe_block_size=block_size_m,
                 sms=int(props.multi_processor_count),
                 max_shared_mem=int(props.shared_memory_per_block_optin),
-                force_tile_config=mixed["tile_config"],
+                force_tile_config=tile_config,
                 rotation_input_dtype=("bf16" if x.dtype == torch.bfloat16 else "fp16"),
                 route_ids_dtype=topk_ids.dtype,
             )
@@ -2221,58 +2200,38 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 ),
             }
 
-        decode = make_decode_state(max_decode_m)
-        prefill_plans = []
-        prefill_arena = None
-        prefill_accum = None
+        decode = make_state(
+            max_decode_m,
+            _MIXED_TRELLIS_ROUTE_BLOCK_SIZE,
+            mixed["tile_config"],
+        )
+        prefill = None
         if max_batched_tokens > max_decode_m:
             if os.environ.get("VLLM_EXL3_PREFILL_TRELLIS", "1") != "1":
                 raise ValueError("mixed-K EXL3 requires VLLM_EXL3_PREFILL_TRELLIS=1")
-            scratch_bytes = 0
-            for tier in mixed["serial_tiers"]:
-                caps = fused_api.Caps(
-                    max_tokens=prefill_capacity,
-                    num_topk=topk,
-                    route_num_experts=total_experts,
-                    device=device,
-                    weight_plan=tier["weights"].plan,
-                    quant_mode="w4a16",
-                    w4a16_block_size_m=prefill_block_m,
-                )
-                plan = fused_api.plan(caps)
-                prefill_plans.append(plan)
-                spec = plan.scratch_specs()[0]
-                size = int(spec.dtype.itemsize)
-                for dim in spec.shape:
-                    size *= int(dim)
-                scratch_bytes = max(scratch_bytes, size)
-            prefill_arena = torch.empty(scratch_bytes, dtype=torch.uint8, device=device)
-            prefill_accum = torch.empty(
-                (prefill_capacity, int(layer.exl3_hidden_size)),
-                dtype=torch.float32,
-                device=device,
+            prefill = make_state(
+                prefill_capacity,
+                prefill_block_m,
+                mixed["prefill_tile_config"],
             )
         runtime = {
             "mixed_api": mixed_api,
-            "fused_api": fused_api,
             "decode": decode,
-            "prefill_plans": tuple(prefill_plans),
-            "prefill_arena": prefill_arena,
-            "prefill_accum": prefill_accum,
+            "prefill": prefill,
             "max_decode_m": max_decode_m,
             "max_batched_tokens": max_batched_tokens,
             "prefill_capacity": prefill_capacity,
         }
         _MIXED_TRELLIS_RUNTIMES[key] = runtime
         decode_bytes = _unique_tensor_storage_bytes(decode["buffers"])
-        prefill_bytes = sum(
-            tensor.numel() * tensor.element_size()
-            for tensor in (prefill_arena, prefill_accum)
-            if tensor is not None
+        prefill_bytes = (
+            0
+            if prefill is None
+            else _unique_tensor_storage_bytes(prefill["buffers"])
         )
         logger.info_once(
             "EXL3 mixed Trellis runtime planned: tiers=%s one-grid decode=%d "
-            "serial prefill=%d/%d block_m=%d buffers=%.1f+%.1f MiB",
+            "one-grid prefill=%d/%d block_m=%d buffers=%.1f+%.1f MiB",
             tier_signature,
             max_decode_m,
             prefill_capacity,
@@ -2298,71 +2257,56 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 f"m={m}, capacity={runtime['max_batched_tokens']}"
             )
         mixed = layer.exl3_mixed_trellis
-        # The cooperative mixed-K grid wins at small M, but its SM120 path is
-        # currently limited to route block 8.  Homogeneous tier plans support
-        # block 64 and are substantially faster for prefill, so keep the
-        # one-grid launch for decode and dispatch large M through the two
-        # serial tiers until the mixed kernel gains an efficient large block.
-        if m <= runtime["max_decode_m"]:
-            state = runtime["decode"]
-            output = runtime["mixed_api"].run_mixed_trellis(
-                x,
-                mixed["tiers"][0],
-                mixed["tiers"][1],
-                topk_weights,
-                topk_ids,
+        def run_state(
+            slice_x: torch.Tensor,
+            slice_weights: torch.Tensor,
+            slice_ids: torch.Tensor,
+            state: dict[str, Any],
+            tiers: tuple[Any, Any],
+        ) -> torch.Tensor:
+            return runtime["mixed_api"].run_mixed_trellis(
+                slice_x,
+                tiers[0],
+                tiers[1],
+                slice_weights,
+                slice_ids,
                 mixed["global_to_combined"],
                 mixed["descriptor_map"],
                 mixed["rotations"],
                 state["launch"],
                 state["buffers"],
+            ).to(slice_x.dtype)
+
+        if m <= runtime["max_decode_m"]:
+            return run_state(
+                x,
+                topk_weights,
+                topk_ids,
+                runtime["decode"],
+                mixed["tiers"],
             )
-            return output.to(x.dtype)
 
-        if runtime["prefill_arena"] is None or runtime["prefill_accum"] is None:
-            raise RuntimeError("mixed-K EXL3 serial prefill plan is unavailable")
+        if runtime["prefill"] is None:
+            raise RuntimeError("mixed-K EXL3 one-grid prefill plan is unavailable")
         prefill_capacity = int(runtime["prefill_capacity"])
-
-        def run_serial_slice(
-            slice_x: torch.Tensor,
-            slice_weights: torch.Tensor,
-            slice_ids: torch.Tensor,
-        ) -> torch.Tensor:
-            slice_m = int(slice_x.shape[0])
-            accum = runtime["prefill_accum"][:slice_m]
-            first = True
-            for plan, tier in zip(
-                runtime["prefill_plans"], mixed["serial_tiers"], strict=True
-            ):
-                binding = runtime["fused_api"].bind(
-                    plan,
-                    scratch=_scratch_view(
-                        runtime["prefill_arena"], plan.scratch_specs()[0]
-                    ),
-                    a=slice_x,
-                    experts=tier["weights"],
-                    topk_weights=slice_weights,
-                    topk_ids=slice_ids,
-                    route_expert_map=tier["route_expert_map"],
-                    output_expert_map=tier["route_expert_map"],
-                    output=accum if first else None,
-                )
-                tier_output = runtime["fused_api"].run(binding=binding)
-                if not first:
-                    accum.add_(tier_output)
-                first = False
-            return accum.to(slice_x.dtype)
-
         if m <= prefill_capacity:
-            return run_serial_slice(x, topk_weights, topk_ids)
+            return run_state(
+                x,
+                topk_weights,
+                topk_ids,
+                runtime["prefill"],
+                mixed["prefill_tiers"],
+            )
 
         output = torch.empty_like(x)
         for start in range(0, m, prefill_capacity):
             stop = min(start + prefill_capacity, m)
-            slice_output = run_serial_slice(
+            slice_output = run_state(
                 x[start:stop],
                 topk_weights[start:stop],
                 topk_ids[start:stop],
+                runtime["prefill"],
+                mixed["prefill_tiers"],
             )
             output[start:stop].copy_(slice_output)
         return output


### PR DESCRIPTION
## What

Changes the EXL3 mixed-K prefill planner to keep K3/K4 work in one bounded
mixed grid rather than launching serial homogeneous tier kernels.

- preserves the 3,072-row capacity limit and block-64 route packing;
- restores the checkpoint's original one-grid mixed-Trellis tile geometry;
- prepares both K3 and K4 tiers for SparkInfer's paired-M8 FC2 path;
- retains PR #225's shared hidden-side rotation loading;
- leaves decode and small-M routing unchanged.

## Why

Serial homogeneous prefill avoids the prior mixed-grid reduction-order issue
but gives up the one-grid execution model. The companion SparkInfer change
provides deterministic reference-aligned FC2 arithmetic inside a bounded
mixed grid, so vLLM can retain one-grid prefill without the measured KLD
regression.

## Validation

Component-specific gates:

- all three changed files are byte-identical to the qualified Gilded Gnosis
  r19 overlay;
- 47 focused vLLM EXL3 planner tests passed on the qualified source;
- Python compilation and `git diff --check` pass on this clean branch;
- production M=3072 mixed-K versus serial phase comparison is bit exact.

The combined r19 qualification (TR3-3.36, TP4/DCP4, dynamic NVFP4 MLA KV,
exact selector, paired-M8 SparkInfer, `i8_hier`) measured:

- one-grid prefill planned at 3,072/3,072 rows with block M=64;
- 609,024 GPU KV tokens at MTP0/480k;
- 38.9868 tok/s at MTP0/C1;
- 1,705 server tok/s on randomized cold 64k prefill after one-time JIT,
  `cached_tokens=0`;
- cold 350k retrieval returned exact `738216`, `cached_tokens=0`.

The paired-M8 implementation previously restored prescribed KLD to
`0.07776700789368204` over 2,047 positions, exact reference parity. No
separate r19 KLD run is claimed; the r19 qualification re-ran the
production-width exact operator and long-context behavioral gates against the
same qualified planner/kernel bytes.

## Dependencies

This PR is stacked on local-inference-lab/vllm#225 so the review diff contains
only the one-grid planner change and preserves the shared-rotation work.
Retarget to `dev/gilded-gnosis` after #225 merges.

Companion SparkInfer paired-M8 PR:
https://github.com/local-inference-lab/sparkinfer/pull/111
