### PR TITLE
[GG] fix(ds4): harden compressed MLA cache and workspace contracts

### DIFF
--- a/tests/kernels/test_compressor_kv_cache.py
+++ b/tests/kernels/test_compressor_kv_cache.py
@@ -21,6 +21,7 @@ from vllm import _custom_ops as ops
 from vllm.models.deepseek_v4.common.ops import (
     dequantize_and_gather_k_cache,
     quantize_and_insert_k_cache,
+    save_partial_states,
 )
 from vllm.models.deepseek_v4.common.ops.fused_compress_quant_cache import (
     _fused_kv_compress_norm_rope_insert_indexer_attn,
@@ -59,6 +60,77 @@ def _ue8m0_reference(x: torch.Tensor, block_size: int, fp8_max: float):
 
 
 # ── Test A: DeepseekV4 Attention path ──────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("draft_tokens", [5, 7])
+def test_save_partial_states_writes_every_verifier_row(draft_tokens: int) -> None:
+    """The compressor state write covers all target rows for each request."""
+    device = "cuda"
+    verifier_width = draft_tokens + 1
+    num_reqs = 2
+    num_actual = num_reqs * verifier_width
+    head_size = 16
+    block_size = 16
+    compress_ratio = 4
+
+    kv = (
+        torch.arange(
+            (num_actual + 1) * head_size,
+            dtype=torch.float32,
+            device=device,
+        )
+        .view(num_actual + 1, head_size)
+        .to(torch.bfloat16)
+    )
+    score = (kv + 1000).to(torch.bfloat16)
+    ape = (
+        torch.arange(
+            compress_ratio * head_size,
+            dtype=torch.float32,
+            device=device,
+        )
+        .view(compress_ratio, head_size)
+        .to(torch.bfloat16)
+    )
+    positions = torch.arange(num_actual + 1, dtype=torch.int64, device=device)
+    slot_mapping = torch.cat(
+        (
+            torch.arange(verifier_width, dtype=torch.int64, device=device),
+            torch.arange(
+                block_size,
+                block_size + verifier_width,
+                dtype=torch.int64,
+                device=device,
+            ),
+            torch.tensor([-1], dtype=torch.int64, device=device),
+        )
+    )
+    state_cache = torch.full(
+        (2, block_size, 2 * head_size),
+        fill_value=-1,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+
+    save_partial_states(
+        kv=kv,
+        score=score,
+        ape=ape,
+        positions=positions,
+        state_cache=state_cache,
+        slot_mapping=slot_mapping,
+        block_size=block_size,
+        state_width=head_size,
+        compress_ratio=compress_ratio,
+    )
+    torch.cuda.synchronize()
+
+    actual_slots = slot_mapping[:num_actual]
+    actual = state_cache.view(-1, 2 * head_size)[actual_slots]
+    torch.testing.assert_close(actual[:, :head_size], kv[:num_actual])
+    expected_score = score[:num_actual] + ape[positions[:num_actual] % compress_ratio]
+    torch.testing.assert_close(actual[:, head_size:], expected_score)
+    assert torch.all(state_cache.view(-1, 2 * head_size)[verifier_width] == -1)
 
 
 @pytest.mark.parametrize("num_tokens", [1, 4, 8, 17])

--- a/tests/models/deepseek_v4/test_b12x_cache_page_view.py
+++ b/tests/models/deepseek_v4/test_b12x_cache_page_view.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+from vllm.models.deepseek_v4.nvidia.b12x import _b12x_cache_page_view
+
+_PAGE_SIZE = 64
+_PAYLOAD_BYTES = _PAGE_SIZE * 584
+_PADDED_PAGE_BYTES = 37_440
+
+
+def test_b12x_cache_page_view_accepts_contiguous_payload_pages() -> None:
+    cache = torch.empty((3, _PAGE_SIZE, 584), dtype=torch.uint8)
+
+    view = _b12x_cache_page_view(cache, _PAGE_SIZE, "cache")
+
+    assert view.shape == (3, _PAYLOAD_BYTES)
+    assert view.stride() == (_PAYLOAD_BYTES, 1)
+
+
+def test_b12x_cache_page_view_preserves_padded_physical_stride() -> None:
+    storage = torch.empty(3 * _PADDED_PAGE_BYTES, dtype=torch.uint8)
+    cache = torch.as_strided(
+        storage,
+        size=(3, _PAGE_SIZE, 584),
+        stride=(_PADDED_PAGE_BYTES, 584, 1),
+    )
+
+    view = _b12x_cache_page_view(cache, _PAGE_SIZE, "cache")
+
+    assert view.shape == (3, _PAYLOAD_BYTES)
+    assert view.stride() == (_PADDED_PAGE_BYTES, 1)
+
+
+def test_b12x_cache_page_view_rejects_short_physical_stride() -> None:
+    storage = torch.empty(2 * _PAYLOAD_BYTES, dtype=torch.uint8)
+    cache = torch.as_strided(
+        storage,
+        size=(2, _PAGE_SIZE, 584),
+        stride=(_PAYLOAD_BYTES - 1, 584, 1),
+    )
+
+    with pytest.raises(RuntimeError, match=r"page stride .* is smaller"):
+        _b12x_cache_page_view(cache, _PAGE_SIZE, "cache")
+
+
+def test_b12x_cache_page_view_rejects_overlapping_2d_pages() -> None:
+    storage = torch.empty(2 * _PAYLOAD_BYTES, dtype=torch.uint8)
+    cache = torch.as_strided(
+        storage,
+        size=(2, _PAYLOAD_BYTES),
+        stride=(_PAYLOAD_BYTES - 1, 1),
+    )
+
+    with pytest.raises(RuntimeError, match=r"page stride .* is smaller"):
+        _b12x_cache_page_view(cache, _PAGE_SIZE, "cache")
+
+
+def test_b12x_cache_page_view_rejects_gapped_page_payload() -> None:
+    storage = torch.empty(2 * _PAYLOAD_BYTES + _PAGE_SIZE, dtype=torch.uint8)
+    cache = torch.as_strided(
+        storage,
+        size=(2, _PAGE_SIZE, 584),
+        stride=(_PAYLOAD_BYTES, 585, 1),
+    )
+
+    with pytest.raises(RuntimeError, match=r"page payload must be contiguous"):
+        _b12x_cache_page_view(cache, _PAGE_SIZE, "cache")

--- a/tests/models/deepseek_v4/test_b12x_compressed_mla_workspace.py
+++ b/tests/models/deepseek_v4/test_b12x_compressed_mla_workspace.py
@@ -9,8 +9,10 @@ from types import SimpleNamespace
 import pytest
 import torch
 
+from vllm.models.deepseek_v4 import compressor as compressor_mod
 from vllm.models.deepseek_v4.nvidia import b12x as b12x_mod
 from vllm.utils.math_utils import round_up
+from vllm.v1.attention.backend import CommonAttentionMetadata
 from vllm.v1.attention.backends.mla.compressor_utils import (
     get_c128a_topk_width,
     get_compressed_mla_max_q_chunks,
@@ -52,9 +54,16 @@ def _install_recording_sparkinfer(monkeypatch, caps_calls: list[SimpleNamespace]
             shapes_and_dtypes=lambda: (((1,), torch.uint8),),
         )
 
-    def split_chunks_for_contract(*, rows: int, width: int, max_chunks: int) -> int:
+    def split_chunks_for_contract(
+        *,
+        rows: int,
+        width: int,
+        max_chunks: int,
+        decode_row_capacity: int | None = None,
+    ) -> int:
         del width
-        return min(max_chunks, 8 if rows <= 256 else 1)
+        decode_split_max_rows = max(256, int(decode_row_capacity or 0))
+        return min(max_chunks, 8 if rows <= decode_split_max_rows else 1)
 
     compressed_mla.Caps = caps  # type: ignore[attr-defined]
     compressed_mla.plan = plan  # type: ignore[attr-defined]
@@ -76,6 +85,8 @@ def _make_layer(
     compress_ratio: int,
     dspark: bool,
     dcp_world_size: int = 1,
+    max_num_batched_tokens: int = _MAX_ROWS,
+    max_num_seqs: int = 64,
 ):
     layer = object.__new__(b12x_mod.DeepseekV4B12xMLAAttention)
     torch.nn.Module.__init__(layer)
@@ -88,7 +99,7 @@ def _make_layer(
     layer.indexer = None
     layer.max_model_len = 524288
     layer.window_size = _WINDOW_SIZE
-    layer.max_num_batched_tokens = _MAX_ROWS
+    layer.max_num_batched_tokens = max_num_batched_tokens
     layer.swa_cache_layer = SimpleNamespace(block_size=_PAGE_SIZE)
     speculative_config = (
         SimpleNamespace(
@@ -100,6 +111,10 @@ def _make_layer(
     )
     layer.vllm_config = SimpleNamespace(
         speculative_config=speculative_config,
+        scheduler_config=SimpleNamespace(
+            max_num_seqs=max_num_seqs,
+            max_num_batched_tokens=max_num_batched_tokens,
+        ),
         parallel_config=SimpleNamespace(
             decode_context_parallel_size=dcp_world_size,
         ),
@@ -136,13 +151,16 @@ def test_reserve_uses_full_runtime_width(
 
     caps = caps_calls[-1]
     split_cap = get_compressed_mla_split_cap(expected_width)
+    decode_row_capacity = 64 * (1 + 5) if dspark else None
     assert caps.max_width == expected_width
     assert caps.max_q_rows == _MAX_ROWS
+    assert caps.decode_row_capacity == decode_row_capacity
     assert caps.max_q_chunks == get_compressed_mla_max_q_chunks(
         _MAX_ROWS,
         expected_width,
         split_cap,
         split_chunks,
+        decode_row_capacity=decode_row_capacity,
     )
     assert workspace.specs is not None
 
@@ -170,6 +188,105 @@ def test_workspace_width_helpers_match_reporter_geometry() -> None:
     assert get_dspark_swa_index_width(512, 5) == 1024
 
 
+@pytest.mark.parametrize(
+    ("max_num_seqs", "num_speculative_tokens", "expected"),
+    [
+        pytest.param(24, 5, 144, id="mns24-k5"),
+        pytest.param(64, 5, 384, id="mns64-k5"),
+        pytest.param(128, 5, 768, id="mns128-k5"),
+        pytest.param(64, 7, 512, id="mns64-k7"),
+    ],
+)
+def test_dspark_decode_row_capacity_comes_from_scheduler_contract(
+    max_num_seqs: int,
+    num_speculative_tokens: int,
+    expected: int,
+) -> None:
+    vllm_config = SimpleNamespace(
+        speculative_config=SimpleNamespace(
+            use_dspark=lambda: True,
+            num_speculative_tokens=num_speculative_tokens,
+        ),
+        scheduler_config=SimpleNamespace(
+            max_num_seqs=max_num_seqs,
+            max_num_batched_tokens=8192,
+        ),
+    )
+    assert b12x_mod._get_dspark_decode_row_capacity(vllm_config) == expected
+
+
+def test_non_dspark_has_no_declared_decode_row_capacity() -> None:
+    vllm_config = SimpleNamespace(
+        speculative_config=SimpleNamespace(use_dspark=lambda: False),
+        scheduler_config=SimpleNamespace(
+            max_num_seqs=128,
+            max_num_batched_tokens=8192,
+        ),
+    )
+    assert b12x_mod._get_dspark_decode_row_capacity(vllm_config) is None
+
+
+def test_dspark_decode_row_capacity_fails_closed() -> None:
+    b12x_mod._validate_compressed_mla_decode_row_capacity(
+        rows=384,
+        mode="decode",
+        decode_row_capacity=384,
+    )
+    b12x_mod._validate_compressed_mla_decode_row_capacity(
+        rows=8192,
+        mode="extend",
+        decode_row_capacity=384,
+    )
+    with pytest.raises(ValueError, match="rows 385 exceed.*capacity 384"):
+        b12x_mod._validate_compressed_mla_decode_row_capacity(
+            rows=385,
+            mode="decode",
+            decode_row_capacity=384,
+        )
+
+
+@pytest.mark.parametrize("draft_tokens", [5, 7])
+def test_compressor_metadata_keeps_every_verifier_row(
+    monkeypatch,
+    draft_tokens: int,
+) -> None:
+    verifier_width = draft_tokens + 1
+    num_reqs = 2
+    num_tokens = num_reqs * verifier_width
+    builder = object.__new__(compressor_mod.CompressorMetadataBuilder)
+    builder.block_size = 16
+    builder.token_to_req_indices = torch.empty(num_tokens, dtype=torch.int32)
+    common = CommonAttentionMetadata(
+        query_start_loc=torch.tensor(
+            [0, verifier_width, num_tokens], dtype=torch.int32
+        ),
+        query_start_loc_cpu=torch.tensor(
+            [0, verifier_width, num_tokens], dtype=torch.int32
+        ),
+        seq_lens=torch.tensor([100, 200], dtype=torch.int32),
+        num_reqs=num_reqs,
+        num_actual_tokens=num_tokens,
+        max_query_len=verifier_width,
+        max_seq_len=200,
+        block_table_tensor=torch.zeros((num_reqs, 1), dtype=torch.int32),
+        slot_mapping=torch.arange(num_tokens, dtype=torch.int64),
+        causal=False,
+    )
+    monkeypatch.setattr(compressor_mod, "_prefer_two_stage_compressor", lambda: False)
+
+    metadata = builder.build(0, common)
+
+    assert metadata.slot_mapping.shape == (num_tokens,)
+    assert metadata.token_to_req_indices is not None
+    torch.testing.assert_close(
+        metadata.token_to_req_indices,
+        torch.repeat_interleave(
+            torch.arange(num_reqs, dtype=torch.int32),
+            verifier_width,
+        ),
+    )
+
+
 def test_q_chunk_envelope_is_cached() -> None:
     call_count = 0
 
@@ -191,6 +308,57 @@ def test_q_chunk_envelope_is_cached() -> None:
             == _MAX_ROWS
         )
     assert call_count == _MAX_ROWS
+
+
+def test_production_q_chunk_envelope_only_reserves_declared_capacity() -> None:
+    def split_chunks_for_contract(
+        *,
+        rows: int,
+        width: int,
+        max_chunks: int,
+        decode_row_capacity: int | None = None,
+    ) -> int:
+        decode_split_max_rows = max(256, int(decode_row_capacity or 0))
+        chunk_size = 64 if rows <= decode_split_max_rows else 1024
+        return min(max_chunks, math.ceil(width / chunk_size))
+
+    max_rows = 8192
+    width = 4608
+    split_cap = get_compressed_mla_split_cap(width)
+    get_compressed_mla_max_q_chunks.cache_clear()
+
+    legacy = get_compressed_mla_max_q_chunks(
+        max_rows,
+        width,
+        split_cap,
+        split_chunks_for_contract,
+    )
+    mns24 = get_compressed_mla_max_q_chunks(
+        max_rows,
+        width,
+        split_cap,
+        split_chunks_for_contract,
+        decode_row_capacity=144,
+    )
+    mns64 = get_compressed_mla_max_q_chunks(
+        max_rows,
+        width,
+        split_cap,
+        split_chunks_for_contract,
+        decode_row_capacity=384,
+    )
+    mns128 = get_compressed_mla_max_q_chunks(
+        max_rows,
+        width,
+        split_cap,
+        split_chunks_for_contract,
+        decode_row_capacity=768,
+    )
+
+    assert legacy == 40960
+    assert mns24 == legacy
+    assert mns64 == legacy
+    assert mns128 == 55296
 
 
 def _aligned_nbytes(
@@ -233,14 +401,14 @@ def _runtime_plan_nbytes(compressed_mla, *, rows: int, width: int, heads: int) -
     ),
     [
         pytest.param(1, False, 1, (128,), 64.502929688, id="swa-causal"),
-        pytest.param(1, True, 1, (128, 512), 64.502929688, id="swa-dspark"),
+        pytest.param(1, True, 1, (128, 512), 96.627929688, id="swa-dspark"),
         pytest.param(4, False, 1, (2176,), 273.315429688, id="c4-causal"),
         pytest.param(
             4,
             True,
             1,
             (2176, 2560),
-            321.502929688,
+            482.127929688,
             id="c4-dspark",
         ),
         pytest.param(128, False, 1, (4224,), 530.315429688, id="c128-causal"),
@@ -249,7 +417,7 @@ def _runtime_plan_nbytes(compressed_mla, *, rows: int, width: int, heads: int) -
             True,
             1,
             (4224, 4608),
-            578.502929688,
+            867.627929688,
             id="c128-dspark",
         ),
         pytest.param(128, False, 2, (4224,), 1060.627929688, id="c128-dcp2"),
@@ -291,3 +459,53 @@ def test_real_sparkinfer_reserve_dominates_runtime_envelope(
         for rows in range(1, _MAX_ROWS + 1)
     )
     assert reserve_bytes >= runtime_bytes
+
+
+def test_mns64_contract_does_not_grow_production_mnb8192_scratch(
+    monkeypatch,
+) -> None:
+    compressed_mla = pytest.importorskip("sparkinfer.attention.compressed_mla")
+    workspace = _RecordingWorkspaceManager()
+    monkeypatch.setattr(b12x_mod, "current_workspace_manager", lambda: workspace)
+    max_rows = 8192
+    layer = _make_layer(
+        compress_ratio=128,
+        dspark=True,
+        max_num_batched_tokens=max_rows,
+        max_num_seqs=64,
+    )
+
+    layer._reserve_dummy_compressed_mla_scratch(
+        torch.empty((1, _LOCAL_HEADS, 512), dtype=torch.bfloat16)
+    )
+
+    assert workspace.specs is not None
+    candidate_bytes = _aligned_nbytes(workspace.specs)
+    width = 4608
+    split_cap = get_compressed_mla_split_cap(width)
+    max_q_chunks = get_compressed_mla_max_q_chunks(
+        max_rows,
+        width,
+        split_cap,
+        compressed_mla.split_chunks_for_contract,
+    )
+    splits = compressed_mla.split_chunks_for_contract(
+        rows=max_rows,
+        width=width,
+        max_chunks=split_cap,
+    )
+    legacy_plan = compressed_mla.plan(
+        compressed_mla.Caps(
+            device="cpu",
+            num_q_heads=_LOCAL_HEADS,
+            max_q_rows=max_rows,
+            max_width=width,
+            head_dim=512,
+            v_head_dim=512,
+            page_size=_PAGE_SIZE,
+            max_chunks_per_row=splits,
+            max_q_chunks=max_q_chunks,
+        )
+    )
+
+    assert candidate_bytes == _aligned_nbytes(legacy_plan.shapes_and_dtypes())

--- a/tests/models/deepseek_v4/test_b12x_compressed_mla_workspace.py
+++ b/tests/models/deepseek_v4/test_b12x_compressed_mla_workspace.py
@@ -38,12 +38,12 @@ class _RecordingWorkspaceManager:
         return []
 
 
-def _install_recording_sparkinfer(monkeypatch, caps_calls: list[SimpleNamespace]):
-    sparkinfer = types.ModuleType("sparkinfer")
-    sparkinfer.__path__ = []
-    attention = types.ModuleType("sparkinfer.attention")
+def _install_recording_b12x(monkeypatch, caps_calls: list[SimpleNamespace]):
+    b12x = types.ModuleType("b12x")
+    b12x.__path__ = []
+    attention = types.ModuleType("b12x.attention")
     attention.__path__ = []
-    compressed_mla = types.ModuleType("sparkinfer.attention.compressed_mla")
+    compressed_mla = types.ModuleType("b12x.attention.compressed_mla")
 
     def caps(**kwargs) -> SimpleNamespace:
         return SimpleNamespace(**kwargs)
@@ -70,11 +70,11 @@ def _install_recording_sparkinfer(monkeypatch, caps_calls: list[SimpleNamespace]
     compressed_mla.split_chunks_for_contract = (  # type: ignore[attr-defined]
         split_chunks_for_contract
     )
-    monkeypatch.setitem(sys.modules, "sparkinfer", sparkinfer)
-    monkeypatch.setitem(sys.modules, "sparkinfer.attention", attention)
+    monkeypatch.setitem(sys.modules, "b12x", b12x)
+    monkeypatch.setitem(sys.modules, "b12x.attention", attention)
     monkeypatch.setitem(
         sys.modules,
-        "sparkinfer.attention.compressed_mla",
+        "b12x.attention.compressed_mla",
         compressed_mla,
     )
     return split_chunks_for_contract
@@ -140,7 +140,7 @@ def test_reserve_uses_full_runtime_width(
     expected_width: int,
 ) -> None:
     caps_calls: list[SimpleNamespace] = []
-    split_chunks = _install_recording_sparkinfer(monkeypatch, caps_calls)
+    split_chunks = _install_recording_b12x(monkeypatch, caps_calls)
     workspace = _RecordingWorkspaceManager()
     monkeypatch.setattr(b12x_mod, "current_workspace_manager", lambda: workspace)
     layer = _make_layer(compress_ratio=compress_ratio, dspark=dspark)
@@ -167,7 +167,7 @@ def test_reserve_uses_full_runtime_width(
 
 def test_reserve_uses_dcp_gathered_heads(monkeypatch) -> None:
     caps_calls: list[SimpleNamespace] = []
-    _install_recording_sparkinfer(monkeypatch, caps_calls)
+    _install_recording_b12x(monkeypatch, caps_calls)
     monkeypatch.setattr(
         b12x_mod,
         "current_workspace_manager",
@@ -423,7 +423,7 @@ def _runtime_plan_nbytes(compressed_mla, *, rows: int, width: int, heads: int) -
         pytest.param(128, False, 2, (4224,), 1060.627929688, id="c128-dcp2"),
     ],
 )
-def test_real_sparkinfer_reserve_dominates_runtime_envelope(
+def test_real_b12x_reserve_dominates_runtime_envelope(
     monkeypatch,
     compress_ratio: int,
     dspark: bool,
@@ -431,7 +431,7 @@ def test_real_sparkinfer_reserve_dominates_runtime_envelope(
     runtime_widths: tuple[int, ...],
     expected_reserve_mib: float,
 ) -> None:
-    compressed_mla = pytest.importorskip("sparkinfer.attention.compressed_mla")
+    compressed_mla = pytest.importorskip("b12x.attention.compressed_mla")
     workspace = _RecordingWorkspaceManager()
     monkeypatch.setattr(b12x_mod, "current_workspace_manager", lambda: workspace)
     layer = _make_layer(
@@ -464,7 +464,7 @@ def test_real_sparkinfer_reserve_dominates_runtime_envelope(
 def test_mns64_contract_does_not_grow_production_mnb8192_scratch(
     monkeypatch,
 ) -> None:
-    compressed_mla = pytest.importorskip("sparkinfer.attention.compressed_mla")
+    compressed_mla = pytest.importorskip("b12x.attention.compressed_mla")
     workspace = _RecordingWorkspaceManager()
     monkeypatch.setattr(b12x_mod, "current_workspace_manager", lambda: workspace)
     max_rows = 8192

--- a/tests/models/deepseek_v4/test_b12x_compressed_mla_workspace.py
+++ b/tests/models/deepseek_v4/test_b12x_compressed_mla_workspace.py
@@ -1,0 +1,293 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import math
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.models.deepseek_v4.nvidia import b12x as b12x_mod
+from vllm.utils.math_utils import round_up
+from vllm.v1.attention.backends.mla.compressor_utils import (
+    get_c128a_topk_width,
+    get_compressed_mla_max_q_chunks,
+    get_compressed_mla_split_cap,
+    get_dspark_swa_index_width,
+)
+
+_MAX_ROWS = 2048
+_LOCAL_HEADS = 32
+_PAGE_SIZE = 64
+_WINDOW_SIZE = 128
+_INDEX_TOPK = 2048
+
+
+class _RecordingWorkspaceManager:
+    def __init__(self) -> None:
+        self.specs: tuple[tuple[tuple[int, ...], torch.dtype], ...] | None = None
+
+    def get_simultaneous(
+        self, *specs: tuple[tuple[int, ...], torch.dtype]
+    ) -> list[torch.Tensor]:
+        self.specs = specs
+        return []
+
+
+def _install_recording_sparkinfer(monkeypatch, caps_calls: list[SimpleNamespace]):
+    sparkinfer = types.ModuleType("sparkinfer")
+    sparkinfer.__path__ = []
+    attention = types.ModuleType("sparkinfer.attention")
+    attention.__path__ = []
+    compressed_mla = types.ModuleType("sparkinfer.attention.compressed_mla")
+
+    def caps(**kwargs) -> SimpleNamespace:
+        return SimpleNamespace(**kwargs)
+
+    def plan(caps_value):
+        caps_calls.append(caps_value)
+        return SimpleNamespace(
+            shapes_and_dtypes=lambda: (((1,), torch.uint8),),
+        )
+
+    def split_chunks_for_contract(*, rows: int, width: int, max_chunks: int) -> int:
+        del width
+        return min(max_chunks, 8 if rows <= 256 else 1)
+
+    compressed_mla.Caps = caps  # type: ignore[attr-defined]
+    compressed_mla.plan = plan  # type: ignore[attr-defined]
+    compressed_mla.split_chunks_for_contract = (  # type: ignore[attr-defined]
+        split_chunks_for_contract
+    )
+    monkeypatch.setitem(sys.modules, "sparkinfer", sparkinfer)
+    monkeypatch.setitem(sys.modules, "sparkinfer.attention", attention)
+    monkeypatch.setitem(
+        sys.modules,
+        "sparkinfer.attention.compressed_mla",
+        compressed_mla,
+    )
+    return split_chunks_for_contract
+
+
+def _make_layer(
+    *,
+    compress_ratio: int,
+    dspark: bool,
+    dcp_world_size: int = 1,
+):
+    layer = object.__new__(b12x_mod.DeepseekV4B12xMLAAttention)
+    torch.nn.Module.__init__(layer)
+    layer.compress_ratio = compress_ratio
+    layer.topk_indices_buffer = (
+        torch.empty((1, _INDEX_TOPK), dtype=torch.int32)
+        if compress_ratio == 4
+        else None
+    )
+    layer.indexer = None
+    layer.max_model_len = 524288
+    layer.window_size = _WINDOW_SIZE
+    layer.max_num_batched_tokens = _MAX_ROWS
+    layer.swa_cache_layer = SimpleNamespace(block_size=_PAGE_SIZE)
+    speculative_config = (
+        SimpleNamespace(
+            use_dspark=lambda: True,
+            num_speculative_tokens=5,
+        )
+        if dspark
+        else None
+    )
+    layer.vllm_config = SimpleNamespace(
+        speculative_config=speculative_config,
+        parallel_config=SimpleNamespace(
+            decode_context_parallel_size=dcp_world_size,
+        ),
+    )
+    return layer
+
+
+@pytest.mark.parametrize(
+    ("compress_ratio", "dspark", "expected_width"),
+    [
+        pytest.param(1, False, 128, id="swa-causal"),
+        pytest.param(1, True, 512, id="swa-dspark"),
+        pytest.param(4, False, 2176, id="c4-causal"),
+        pytest.param(4, True, 2560, id="c4-dspark"),
+        pytest.param(128, False, 4224, id="c128-causal"),
+        pytest.param(128, True, 4608, id="c128-dspark"),
+    ],
+)
+def test_reserve_uses_full_runtime_width(
+    monkeypatch,
+    compress_ratio: int,
+    dspark: bool,
+    expected_width: int,
+) -> None:
+    caps_calls: list[SimpleNamespace] = []
+    split_chunks = _install_recording_sparkinfer(monkeypatch, caps_calls)
+    workspace = _RecordingWorkspaceManager()
+    monkeypatch.setattr(b12x_mod, "current_workspace_manager", lambda: workspace)
+    layer = _make_layer(compress_ratio=compress_ratio, dspark=dspark)
+
+    layer._reserve_dummy_compressed_mla_scratch(
+        torch.empty((1, _LOCAL_HEADS, 512), dtype=torch.bfloat16)
+    )
+
+    caps = caps_calls[-1]
+    split_cap = get_compressed_mla_split_cap(expected_width)
+    assert caps.max_width == expected_width
+    assert caps.max_q_rows == _MAX_ROWS
+    assert caps.max_q_chunks == get_compressed_mla_max_q_chunks(
+        _MAX_ROWS,
+        expected_width,
+        split_cap,
+        split_chunks,
+    )
+    assert workspace.specs is not None
+
+
+def test_reserve_uses_dcp_gathered_heads(monkeypatch) -> None:
+    caps_calls: list[SimpleNamespace] = []
+    _install_recording_sparkinfer(monkeypatch, caps_calls)
+    monkeypatch.setattr(
+        b12x_mod,
+        "current_workspace_manager",
+        lambda: _RecordingWorkspaceManager(),
+    )
+    layer = _make_layer(compress_ratio=128, dspark=False, dcp_world_size=2)
+
+    layer._reserve_dummy_compressed_mla_scratch(
+        torch.empty((1, _LOCAL_HEADS, 512), dtype=torch.bfloat16)
+    )
+
+    assert caps_calls[-1].num_q_heads == _LOCAL_HEADS * 2
+
+
+def test_workspace_width_helpers_match_reporter_geometry() -> None:
+    assert get_c128a_topk_width(524288, 128) == 4096
+    assert get_dspark_swa_index_width(128, 5) == 512
+    assert get_dspark_swa_index_width(512, 5) == 1024
+
+
+def test_q_chunk_envelope_is_cached() -> None:
+    call_count = 0
+
+    def split_chunks_for_contract(**kwargs) -> int:
+        nonlocal call_count
+        call_count += 1
+        return min(kwargs["max_chunks"], 8 if kwargs["rows"] <= 256 else 1)
+
+    get_compressed_mla_max_q_chunks.cache_clear()
+    split_cap = get_compressed_mla_split_cap(4608)
+    for _ in range(2):
+        assert (
+            get_compressed_mla_max_q_chunks(
+                _MAX_ROWS,
+                4608,
+                split_cap,
+                split_chunks_for_contract,
+            )
+            == _MAX_ROWS
+        )
+    assert call_count == _MAX_ROWS
+
+
+def _aligned_nbytes(
+    specs: tuple[tuple[tuple[int, ...], torch.dtype], ...],
+) -> int:
+    return sum(
+        round_up(math.prod(shape) * dtype.itemsize, 256) for shape, dtype in specs
+    )
+
+
+def _runtime_plan_nbytes(compressed_mla, *, rows: int, width: int, heads: int) -> int:
+    split_cap = get_compressed_mla_split_cap(width)
+    splits = compressed_mla.split_chunks_for_contract(
+        rows=rows,
+        width=width,
+        max_chunks=split_cap,
+    )
+    runtime_plan = compressed_mla.plan(
+        compressed_mla.Caps(
+            device="cpu",
+            num_q_heads=heads,
+            max_q_rows=rows,
+            max_width=width,
+            head_dim=512,
+            v_head_dim=512,
+            page_size=_PAGE_SIZE,
+            max_chunks_per_row=splits,
+        )
+    )
+    return _aligned_nbytes(runtime_plan.shapes_and_dtypes())
+
+
+@pytest.mark.parametrize(
+    (
+        "compress_ratio",
+        "dspark",
+        "dcp_world_size",
+        "runtime_widths",
+        "expected_reserve_mib",
+    ),
+    [
+        pytest.param(1, False, 1, (128,), 64.502929688, id="swa-causal"),
+        pytest.param(1, True, 1, (128, 512), 64.502929688, id="swa-dspark"),
+        pytest.param(4, False, 1, (2176,), 273.315429688, id="c4-causal"),
+        pytest.param(
+            4,
+            True,
+            1,
+            (2176, 2560),
+            321.502929688,
+            id="c4-dspark",
+        ),
+        pytest.param(128, False, 1, (4224,), 530.315429688, id="c128-causal"),
+        pytest.param(
+            128,
+            True,
+            1,
+            (4224, 4608),
+            578.502929688,
+            id="c128-dspark",
+        ),
+        pytest.param(128, False, 2, (4224,), 1060.627929688, id="c128-dcp2"),
+    ],
+)
+def test_real_sparkinfer_reserve_dominates_runtime_envelope(
+    monkeypatch,
+    compress_ratio: int,
+    dspark: bool,
+    dcp_world_size: int,
+    runtime_widths: tuple[int, ...],
+    expected_reserve_mib: float,
+) -> None:
+    compressed_mla = pytest.importorskip("sparkinfer.attention.compressed_mla")
+    workspace = _RecordingWorkspaceManager()
+    monkeypatch.setattr(b12x_mod, "current_workspace_manager", lambda: workspace)
+    layer = _make_layer(
+        compress_ratio=compress_ratio,
+        dspark=dspark,
+        dcp_world_size=dcp_world_size,
+    )
+
+    layer._reserve_dummy_compressed_mla_scratch(
+        torch.empty((1, _LOCAL_HEADS, 512), dtype=torch.bfloat16)
+    )
+
+    assert workspace.specs is not None
+    reserve_bytes = _aligned_nbytes(workspace.specs)
+    assert reserve_bytes / (1 << 20) == pytest.approx(expected_reserve_mib)
+    runtime_heads = _LOCAL_HEADS * dcp_world_size
+    runtime_bytes = max(
+        _runtime_plan_nbytes(
+            compressed_mla,
+            rows=rows,
+            width=runtime_width,
+            heads=runtime_heads,
+        )
+        for runtime_width in runtime_widths
+        for rows in range(1, _MAX_ROWS + 1)
+    )
+    assert reserve_bytes >= runtime_bytes

--- a/vllm/models/deepseek_v4/nvidia/b12x.py
+++ b/vllm/models/deepseek_v4/nvidia/b12x.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, ClassVar, Literal, cast
 
 import torch
 
+from vllm.config import VllmConfig
 from vllm.forward_context import get_forward_context
 from vllm.models.deepseek_v4.common.ops import (
     compute_dcp_global_topk_indices_and_lens,
@@ -51,6 +52,36 @@ _DSV4_HEAD_DIM = 512
 _DSV4_V_HEAD_DIM = 512
 _DSV4_CACHE_BYTES_PER_TOKEN = 584
 _VALIDATE_DCP_INDICES_ENV = "VLLM_DSV4_DCP_VALIDATE_INDICES"
+
+
+def _get_dspark_decode_row_capacity(vllm_config: VllmConfig) -> int | None:
+    """Return the largest target-verifier row count the scheduler can emit."""
+    speculative_config = vllm_config.speculative_config
+    if speculative_config is None or not speculative_config.use_dspark():
+        return None
+    num_speculative_tokens = int(speculative_config.num_speculative_tokens or 0)
+    if num_speculative_tokens <= 0:
+        return None
+    scheduler_config = vllm_config.scheduler_config
+    return min(
+        int(scheduler_config.max_num_batched_tokens),
+        int(scheduler_config.max_num_seqs) * (1 + num_speculative_tokens),
+    )
+
+
+def _validate_compressed_mla_decode_row_capacity(
+    *,
+    rows: int,
+    mode: Literal["decode", "extend"],
+    decode_row_capacity: int | None,
+) -> None:
+    if mode != "decode" or decode_row_capacity is None:
+        return
+    if int(rows) > int(decode_row_capacity):
+        raise ValueError(
+            f"compressed MLA decode rows {rows} exceed the declared "
+            f"capacity {decode_row_capacity}"
+        )
 
 
 def _cdiv(x: int, y: int) -> int:
@@ -286,6 +317,7 @@ def _run_compressed_mla(
     indexed_lens: torch.Tensor | None,
     indexed_page_size: int | None,
     mode: Literal["decode", "extend"] = "decode",
+    decode_row_capacity: int | None = None,
     return_lse: bool = False,
     lse_scale: Literal["natural", "base2"] = "natural",
 ) -> torch.Tensor | None:
@@ -309,6 +341,11 @@ def _run_compressed_mla(
     )
 
     rows, heads = int(q.shape[0]), int(q.shape[1])
+    _validate_compressed_mla_decode_row_capacity(
+        rows=rows,
+        mode=mode,
+        decode_row_capacity=decode_row_capacity,
+    )
     q = q.contiguous()
     swa_indices = swa_indices.contiguous()
     swa_lens = swa_lens.contiguous()
@@ -341,6 +378,7 @@ def _run_compressed_mla(
         rows=max(1, rows),
         width=width,
         max_chunks=decode_split_cap,
+        decode_row_capacity=decode_row_capacity,
     )
 
     plan = plan_compressed_mla_scratch(
@@ -353,6 +391,7 @@ def _run_compressed_mla(
             v_head_dim=_DSV4_V_HEAD_DIM,
             page_size=int(swa_page_size),
             max_chunks_per_row=num_splits_cap,
+            decode_row_capacity=decode_row_capacity,
         )
     )
     scratch = current_workspace_manager().get_simultaneous(*plan.shapes_and_dtypes())
@@ -411,6 +450,7 @@ def _run_dcp_compressed_mla(
     indexed_lens: torch.Tensor | None,
     indexed_page_size: int | None,
     mode: Literal["decode", "extend"] = "decode",
+    decode_row_capacity: int | None = None,
 ) -> None:
     from vllm.distributed.parallel_state import get_dcp_group
 
@@ -443,6 +483,7 @@ def _run_dcp_compressed_mla(
         indexed_lens=indexed_lens,
         indexed_page_size=indexed_page_size,
         mode=mode,
+        decode_row_capacity=decode_row_capacity,
         return_lse=True,
         lse_scale="natural",
     )
@@ -547,6 +588,7 @@ class DeepseekV4B12xMLAAttention(DeepseekV4FlashMLAAttention):
 
         swa_width = int(self.window_size)
         speculative_config = self.vllm_config.speculative_config
+        decode_row_capacity = _get_dspark_decode_row_capacity(self.vllm_config)
         if speculative_config is not None and speculative_config.use_dspark():
             swa_width = max(
                 swa_width,
@@ -563,12 +605,14 @@ class DeepseekV4B12xMLAAttention(DeepseekV4FlashMLAAttention):
             rows=rows,
             width=width,
             max_chunks=decode_split_cap,
+            decode_row_capacity=decode_row_capacity,
         )
         max_q_chunks = get_compressed_mla_max_q_chunks(
             rows,
             width,
             decode_split_cap,
             compressed_mla_split_chunks_for_contract,
+            decode_row_capacity=decode_row_capacity,
         )
         dcp_world_size = max(
             int(self.vllm_config.parallel_config.decode_context_parallel_size),
@@ -587,6 +631,7 @@ class DeepseekV4B12xMLAAttention(DeepseekV4FlashMLAAttention):
                 page_size=int(self.swa_cache_layer.block_size),
                 max_chunks_per_row=num_splits_cap,
                 max_q_chunks=max_q_chunks,
+                decode_row_capacity=decode_row_capacity,
             )
         )
         current_workspace_manager().get_simultaneous(*plan.shapes_and_dtypes())
@@ -693,6 +738,7 @@ class DeepseekV4B12xMLAAttention(DeepseekV4FlashMLAAttention):
         num_decodes = swa_metadata.num_decodes
         num_decode_tokens = swa_metadata.num_decode_tokens
         dcp_world_size = vllm_config.parallel_config.decode_context_parallel_size
+        decode_row_capacity = _get_dspark_decode_row_capacity(vllm_config)
         dcp_rank = 0
         if dcp_world_size > 1:
             from vllm.distributed.parallel_state import get_dcp_group
@@ -770,6 +816,7 @@ class DeepseekV4B12xMLAAttention(DeepseekV4FlashMLAAttention):
                 indexed_lens=topk_lens,
                 indexed_page_size=indexed_page_size,
                 mode="decode",
+                decode_row_capacity=decode_row_capacity,
             )
         else:
             _run_compressed_mla(
@@ -786,6 +833,7 @@ class DeepseekV4B12xMLAAttention(DeepseekV4FlashMLAAttention):
                 indexed_lens=topk_lens,
                 indexed_page_size=indexed_page_size,
                 mode="decode",
+                decode_row_capacity=decode_row_capacity,
             )
 
     def _forward_b12x_prefill(

--- a/vllm/models/deepseek_v4/nvidia/b12x.py
+++ b/vllm/models/deepseek_v4/nvidia/b12x.py
@@ -30,6 +30,12 @@ from vllm.models.deepseek_v4.nvidia.flashmla import (
     DeepseekV4FlashMLABackend,
 )
 from vllm.models.deepseek_v4.sparse_mla import DeepseekV4FlashMLAMetadata
+from vllm.v1.attention.backends.mla.compressor_utils import (
+    get_c128a_topk_width,
+    get_compressed_mla_max_q_chunks,
+    get_compressed_mla_split_cap,
+    get_dspark_swa_index_width,
+)
 from vllm.v1.attention.ops.common import cp_lse_ag_out_rs
 from vllm.v1.attention.ops.dcp_alltoall import (
     dcp_a2a_lse_reduce,
@@ -44,9 +50,6 @@ if TYPE_CHECKING:
 _DSV4_HEAD_DIM = 512
 _DSV4_V_HEAD_DIM = 512
 _DSV4_CACHE_BYTES_PER_TOKEN = 584
-_DSV4_CACHE_PAD_ALIGNMENT_BYTES = 576
-_DECODE_SPLIT_TILE = 64
-_C128A_TOPK_ALIGNMENT = 128
 _VALIDATE_DCP_INDICES_ENV = "VLLM_DSV4_DCP_VALIDATE_INDICES"
 
 
@@ -55,11 +58,20 @@ def _cdiv(x: int, y: int) -> int:
 
 
 def _dsv4_b12x_page_nbytes(page_size: int) -> int:
-    payload_nbytes = int(page_size) * _DSV4_CACHE_BYTES_PER_TOKEN
-    return (
-        _cdiv(payload_nbytes, _DSV4_CACHE_PAD_ALIGNMENT_BYTES)
-        * _DSV4_CACHE_PAD_ALIGNMENT_BYTES
-    )
+    """Return the logical DSV4 payload bytes in one cache page.
+
+    vLLM may place padding between physical pages, but the padding is not part
+    of the compressed-MLA payload.  Keeping it out of the exported view also
+    supports standalone contiguous allocations, whose physical page stride is
+    exactly ``page_size * 584`` bytes.
+
+    Args:
+        page_size: Number of tokens stored in one cache page.
+
+    Returns:
+        The logical compressed-MLA payload size in bytes.
+    """
+    return int(page_size) * _DSV4_CACHE_BYTES_PER_TOKEN
 
 
 def _b12x_cache_page_view(
@@ -67,7 +79,25 @@ def _b12x_cache_page_view(
     page_size: int,
     name: str,
 ) -> torch.Tensor:
-    """Return a uint8 ``[pages, padded_page_bytes]`` view for b12x kernels."""
+    """Return a uint8 ``[pages, payload_bytes]`` view for SparkInfer kernels.
+
+    Preserve the physical page stride so both padded packed allocations and
+    contiguous per-layer allocations follow the same runtime contract.
+
+    Args:
+        cache: Source paged cache tensor.
+        page_size: Number of tokens stored in one cache page.
+        name: Cache name used in validation errors.
+
+    Returns:
+        A logical byte view that preserves the source physical page stride.
+
+    Raises:
+        ValueError: If ``page_size`` is not positive.
+        RuntimeError: If the cache is not paged, a page cannot contain the
+            logical payload, pages overlap, or the payload within a page is
+            not contiguous.
+    """
     page_nbytes = _dsv4_b12x_page_nbytes(page_size)
     if page_nbytes <= 0:
         raise ValueError(f"{name} page_size must be positive, got {page_size}")
@@ -77,11 +107,19 @@ def _b12x_cache_page_view(
         if int(byte_cache.shape[1]) < page_nbytes:
             raise RuntimeError(
                 f"{name} page width {int(byte_cache.shape[1])} is smaller than "
-                f"DSV4 padded page width {page_nbytes}"
+                f"DSV4 payload width {page_nbytes}"
             )
-        if not byte_cache.is_contiguous():
-            raise RuntimeError(f"{name} page cache must be contiguous")
-        return byte_cache
+        if int(byte_cache.stride(1)) != 1:
+            raise RuntimeError(
+                f"{name} page payload must be contiguous, got stride "
+                f"{tuple(byte_cache.stride())}"
+            )
+        if int(byte_cache.stride(0)) < page_nbytes:
+            raise RuntimeError(
+                f"{name} page stride {int(byte_cache.stride(0))} is smaller than "
+                f"DSV4 page payload {page_nbytes}"
+            )
+        return byte_cache[:, :page_nbytes]
 
     if byte_cache.ndim < 2:
         raise RuntimeError(
@@ -93,13 +131,22 @@ def _b12x_cache_page_view(
     if page_stride_nbytes < page_nbytes:
         raise RuntimeError(
             f"{name} page stride {page_stride_nbytes} is smaller than DSV4 page "
-            f"width {page_nbytes}"
+            f"payload {page_nbytes}"
         )
 
+    expected_stride = 1
+    for dim in range(byte_cache.ndim - 1, 0, -1):
+        if int(byte_cache.stride(dim)) != expected_stride:
+            raise RuntimeError(
+                f"{name} page payload must be contiguous, got stride "
+                f"{tuple(byte_cache.stride())}"
+            )
+        expected_stride *= int(byte_cache.shape[dim])
+
     # Packed DS4 KV cache views have a storage offset for this layer and a
-    # larger per-block stride for the whole packed block. Expose only this
-    # layer's page payload while preserving stride(0), so B12X can use the
-    # packed block stride without materializing/copying.
+    # larger per-block stride for the whole packed block. Expose only the
+    # logical payload while preserving stride(0), so SparkInfer can use the
+    # physical block stride without materializing/copying.
     page_view = torch.as_strided(
         byte_cache,
         size=(pages, page_nbytes),
@@ -287,7 +334,7 @@ def _run_compressed_mla(
     width = int(swa_indices.shape[-1])
     if indexed_indices is not None:
         width += int(indexed_indices.shape[-1])
-    decode_split_cap = max(1, _cdiv(width, _DECODE_SPLIT_TILE))
+    decode_split_cap = get_compressed_mla_split_cap(width)
     # Keep the legacy 64-wide split cap for decode, but let the b12x contract
     # select the smaller batched-prefill split count when rows > decode max.
     num_splits_cap = compressed_mla_split_chunks_for_contract(
@@ -493,28 +540,53 @@ class DeepseekV4B12xMLAAttention(DeepseekV4FlashMLAAttention):
             elif self.indexer is not None:
                 indexed_width = int(self.indexer.topk_tokens)
         elif self.compress_ratio > 1:
-            indexed_width = _cdiv(self.max_model_len, self.compress_ratio)
-            indexed_width = _cdiv(indexed_width, _C128A_TOPK_ALIGNMENT)
-            indexed_width *= _C128A_TOPK_ALIGNMENT
+            indexed_width = get_c128a_topk_width(
+                self.max_model_len,
+                self.compress_ratio,
+            )
 
-        width = max(int(self.window_size) + indexed_width, 1)
+        swa_width = int(self.window_size)
+        speculative_config = self.vllm_config.speculative_config
+        if speculative_config is not None and speculative_config.use_dspark():
+            swa_width = max(
+                swa_width,
+                get_dspark_swa_index_width(
+                    swa_width,
+                    speculative_config.num_speculative_tokens or 0,
+                ),
+            )
+
+        width = max(swa_width + indexed_width, 1)
         rows = max(int(self.max_num_batched_tokens), 1)
-        decode_split_cap = max(1, _cdiv(width, _DECODE_SPLIT_TILE))
+        decode_split_cap = get_compressed_mla_split_cap(width)
         num_splits_cap = compressed_mla_split_chunks_for_contract(
             rows=rows,
             width=width,
             max_chunks=decode_split_cap,
         )
+        max_q_chunks = get_compressed_mla_max_q_chunks(
+            rows,
+            width,
+            decode_split_cap,
+            compressed_mla_split_chunks_for_contract,
+        )
+        dcp_world_size = max(
+            int(self.vllm_config.parallel_config.decode_context_parallel_size),
+            1,
+        )
+        # max_q_rows covers final row-sized buffers; max_q_chunks covers split
+        # intermediates whose peak can occur below max_q_rows.
         plan = plan_compressed_mla_scratch(
             B12XCompressedMLAScratchCaps(
                 device=q.device,
-                num_q_heads=int(q.shape[1]),
+                num_q_heads=int(q.shape[1]) * dcp_world_size,
                 max_q_rows=rows,
                 max_width=width,
                 head_dim=_DSV4_HEAD_DIM,
                 v_head_dim=_DSV4_V_HEAD_DIM,
                 page_size=int(self.swa_cache_layer.block_size),
                 max_chunks_per_row=num_splits_cap,
+                max_q_chunks=max_q_chunks,
             )
         )
         current_workspace_manager().get_simultaneous(*plan.shapes_and_dtypes())
@@ -549,6 +621,7 @@ class DeepseekV4B12xMLAAttention(DeepseekV4FlashMLAAttention):
         if attn_metadata is None:
             # Warmup dummy run: no metadata, so reserve the largest compressed
             # MLA scratch this layer can request before vLLM locks workspace.
+            # Its config-derived geometry is identical on later dummy calls.
             output.zero_()
             self._reserve_dummy_compressed_mla_scratch(q)
             return

--- a/vllm/models/deepseek_v4/sparse_mla.py
+++ b/vllm/models/deepseek_v4/sparse_mla.py
@@ -11,7 +11,6 @@ from vllm.config import VllmConfig
 from vllm.config.cache import CacheDType
 from vllm.platforms.interface import DeviceCapability
 from vllm.triton_utils import tl, triton
-from vllm.utils.math_utils import cdiv
 from vllm.v1.attention.backend import (
     AttentionBackend,
     AttentionCGSupport,
@@ -20,16 +19,12 @@ from vllm.v1.attention.backend import (
     CommonAttentionMetadata,
     MultipleOf,
 )
-from vllm.v1.attention.backends.mla.compressor_utils import get_compressed_slot_mapping
+from vllm.v1.attention.backends.mla.compressor_utils import (
+    get_c128a_topk_width,
+    get_compressed_slot_mapping,
+)
 from vllm.v1.attention.backends.utils import split_decodes_and_prefills
 from vllm.v1.kv_cache_interface import AttentionSpec
-
-# Pad C128A topk width to this alignment. 128 covers both h_q=64 (B_TOPK=64) and
-# h_q=128 (B_TOPK=128). FlashMLA decode asserts extra_topk % B_TOPK == 0;
-# unaligned widths (e.g. 17 = ceil(2136/128)) crash the sm100 head64 kernel.
-# Padded slots stay -1 and decode_lens caps them via topk_length, so the pad is a
-# no-op at kernel level. Mirrors _SPARSE_PREFILL_TOPK_ALIGNMENT in cache_utils.py.
-_C128A_TOPK_ALIGNMENT = 128
 
 
 class DeepseekV4FlashMLABackend(AttentionBackend):
@@ -191,12 +186,9 @@ class DeepseekV4FlashMLAMetadataBuilder(
 
         # Pre-allocate C128A topk buffers for CUDA graph address stability.
         if self.compress_ratio == 128:
-            c128a_max_compressed = cdiv(
-                self.model_config.max_model_len, self.compress_ratio
-            )
-            c128a_max_compressed = (
-                cdiv(c128a_max_compressed, _C128A_TOPK_ALIGNMENT)
-                * _C128A_TOPK_ALIGNMENT
+            c128a_max_compressed = get_c128a_topk_width(
+                self.model_config.max_model_len,
+                self.compress_ratio,
             )
             # Stored so _build_c128a_metadata passes it as the kernel's
             # max_compressed_tokens, matching the buffer stride. Otherwise the

--- a/vllm/v1/attention/backends/mla/compressor_utils.py
+++ b/vllm/v1/attention/backends/mla/compressor_utils.py
@@ -62,6 +62,7 @@ def get_compressed_mla_max_q_chunks(
     width: int,
     max_chunks: int,
     split_chunks_for_contract: Callable[..., int],
+    decode_row_capacity: int | None = None,
 ) -> int:
     """Return the q-chunk cap over every reachable row count.
 
@@ -70,6 +71,7 @@ def get_compressed_mla_max_q_chunks(
         width: Combined SWA and indexed width.
         max_chunks: Maximum chunks allowed for each row.
         split_chunks_for_contract: Kernel contract split-count function.
+        decode_row_capacity: Integration-declared decode/verifier row capacity.
 
     Returns:
         The largest reachable product of rows and chunks per row.
@@ -83,6 +85,7 @@ def get_compressed_mla_max_q_chunks(
             rows=rows,
             width=width,
             max_chunks=max_chunks,
+            decode_row_capacity=decode_row_capacity,
         )
         for rows in range(1, max_rows + 1)
     )

--- a/vllm/v1/attention/backends/mla/compressor_utils.py
+++ b/vllm/v1/attention/backends/mla/compressor_utils.py
@@ -1,8 +1,91 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from collections.abc import Callable
+from functools import cache
+
 import torch
 
 from vllm.triton_utils import tl, triton
+from vllm.utils.math_utils import cdiv
+
+_C128A_TOPK_ALIGNMENT = 128
+_COMPRESSED_MLA_SPLIT_ALIGNMENT = 64
+_DSPARK_SWA_INDEX_ALIGNMENT = 512
+
+
+def get_c128a_topk_width(max_model_len: int, compress_ratio: int) -> int:
+    """Return C128 indexed width padded for FlashMLA B_TOPK divisibility.
+
+    Args:
+        max_model_len: Maximum model context length in tokens.
+        compress_ratio: Ratio used to compress the indexed KV cache.
+
+    Returns:
+        The aligned compressed top-k width.
+    """
+    compressed_width = cdiv(max_model_len, compress_ratio)
+    return cdiv(compressed_width, _C128A_TOPK_ALIGNMENT) * _C128A_TOPK_ALIGNMENT
+
+
+def get_dspark_swa_index_width(
+    window_size: int,
+    num_speculative_tokens: int,
+) -> int:
+    """Return the padded width of non-causal DSpark SWA indices.
+
+    Args:
+        window_size: Sliding-window attention width.
+        num_speculative_tokens: Number of DSpark draft tokens.
+
+    Returns:
+        The aligned non-causal index width.
+    """
+    width = max(int(window_size), 0) + max(int(num_speculative_tokens), 0)
+    return cdiv(width, _DSPARK_SWA_INDEX_ALIGNMENT) * _DSPARK_SWA_INDEX_ALIGNMENT
+
+
+def get_compressed_mla_split_cap(width: int) -> int:
+    """Return the maximum compressed-MLA split count for ``width``.
+
+    Args:
+        width: Combined SWA and indexed width.
+
+    Returns:
+        The split count capped by the kernel tile width.
+    """
+    return max(1, cdiv(max(int(width), 1), _COMPRESSED_MLA_SPLIT_ALIGNMENT))
+
+
+@cache
+def get_compressed_mla_max_q_chunks(
+    max_rows: int,
+    width: int,
+    max_chunks: int,
+    split_chunks_for_contract: Callable[..., int],
+) -> int:
+    """Return the q-chunk cap over every reachable row count.
+
+    Args:
+        max_rows: Maximum number of query rows in one scheduler step.
+        width: Combined SWA and indexed width.
+        max_chunks: Maximum chunks allowed for each row.
+        split_chunks_for_contract: Kernel contract split-count function.
+
+    Returns:
+        The largest reachable product of rows and chunks per row.
+    """
+    max_rows = max(int(max_rows), 1)
+    width = max(int(width), 1)
+    max_chunks = max(int(max_chunks), 1)
+    return max(
+        rows
+        * split_chunks_for_contract(
+            rows=rows,
+            width=width,
+            max_chunks=max_chunks,
+        )
+        for rows in range(1, max_rows + 1)
+    )
 
 
 @triton.jit
@@ -48,15 +131,12 @@ def _compressed_slot_mapping_kernel(
         else:
             virtual_block_size = block_size * DCP_WORLD_SIZE
             block_ids = pos_after_compress // virtual_block_size
-            virtual_block_offsets = (
-                pos_after_compress - block_ids * virtual_block_size
-            )
+            virtual_block_offsets = pos_after_compress - block_ids * virtual_block_size
             is_local = (
                 virtual_block_offsets // CP_KV_CACHE_INTERLEAVE_SIZE
             ) % DCP_WORLD_SIZE == DCP_RANK
             block_offsets = (
-                virtual_block_offsets
-                // (DCP_WORLD_SIZE * CP_KV_CACHE_INTERLEAVE_SIZE)
+                virtual_block_offsets // (DCP_WORLD_SIZE * CP_KV_CACHE_INTERLEAVE_SIZE)
             ) * CP_KV_CACHE_INTERLEAVE_SIZE + (
                 virtual_block_offsets % CP_KV_CACHE_INTERLEAVE_SIZE
             )

--- a/vllm/v1/attention/backends/mla/sparse_swa.py
+++ b/vllm/v1/attention/backends/mla/sparse_swa.py
@@ -17,6 +17,9 @@ from vllm.v1.attention.backend import (
     CommonAttentionMetadata,
     MultipleOf,
 )
+from vllm.v1.attention.backends.mla.compressor_utils import (
+    get_dspark_swa_index_width,
+)
 from vllm.v1.attention.ops.flashmla import FlashMLASchedMeta, get_mla_metadata
 from vllm.v1.kv_cache_interface import (
     KVCacheSpec,
@@ -416,7 +419,10 @@ class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
         # width. decode_swa_lens keeps the padding out of the attention result.
         self.is_dspark = spec_config is not None and spec_config.use_dspark()
         self.noncausal_index_width = (
-            cdiv(self.window_size + self.num_speculative_tokens, 512) * 512
+            get_dspark_swa_index_width(
+                self.window_size,
+                self.num_speculative_tokens,
+            )
             if self.is_dspark
             else 0
         )


### PR DESCRIPTION
## Summary

- preserve the physical compressed-MLA page stride while exposing only the logical 584-byte/token payload to B12X;
- reserve the full compressed-MLA scratch envelope across runtime row counts, DSpark SWA geometry, DCP gathered heads, and planner split caps;
- centralize the shared geometry contract used by the model and attention backends;
- declare the verifier's maximum decode-row capacity from `max_num_seqs * (1 + num_speculative_tokens)` and fail closed if live rows exceed it.

## Why

The page-stride and workspace fixes previously lived in PRs #212 and #227 and both changed `vllm/models/deepseek_v4/nvidia/b12x.py`, so the clean GG release composer could not apply them together.

The workspace bug is not a simple `max_num_batched_tokens` sizing error. Scratch use scales with `rows * split_chunks(rows, width)`, and the split count can peak at a smaller runtime row count. The reported TP2/DCP1/K5 case is reproduced exactly: the old planner reserves 321.50 MiB at 2,048 rows, while 232 runtime rows require 480.40 MiB with 66 splits.

The added verifier-capacity contract fixes the separate high-concurrency failure reported above C24. A `max_num_seqs=64` graph may verify 384 rows at K5 or 512 rows at K7. The previous fixed 256-row decode envelope allowed the B12X split planner to address beyond graph-owned control storage, corrupting later replays. vLLM now derives and passes the real envelope, and B12X PR #125 allocates for it.

This PR combines these contracts against current `dev/gilded-gnosis` and supersedes #212, #227, and the stacked voipmonitor/vllm#12 without a release-only conflict resolution.

## Validation

- 21 compressed-cache page-view and workspace-envelope unit tests;
- 12 verifier-row/capacity/workspace tests against current B12X;
- SM120 graph-contract tests at 384, 512, and 768 rows, each in a fresh process;
- Ruff check, Ruff format check, and `git diff --check`;
- TP2/DCP1/K5, `max_num_batched_tokens=2048`, six uncached 120,325-token prompts: all requests completed without a workspace assertion;
- corrected reservation changed the tested 327k profile from 906,955 to 896,256 KV tokens (about 0.10 GiB/GPU), matching the intended scratch-for-KV tradeoff.

The final C1-C64 K5/K7 serving matrix is validated in the release candidate composed with B12X PR #125.

Supersedes #212 and #227.