### PR TITLE
[GG] fix(ds4): keep broadcast MHC pre behind compile boundary

### DIFF
--- a/tests/kernels/test_mhc_broadcast_compile.py
+++ b/tests/kernels/test_mhc_broadcast_compile.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import torch
+
+from vllm.model_executor.kernels.mhc.tilelang import mhc_pre_broadcast_tilelang
+
+
+def _inputs(device: str = "meta") -> tuple[torch.Tensor, ...]:
+    num_tokens = 6
+    hidden_size = 128
+    hc_mult = 4
+    hc_mult3 = 2 * hc_mult + hc_mult * hc_mult
+    return (
+        torch.empty(num_tokens, hidden_size, dtype=torch.bfloat16, device=device),
+        torch.empty(
+            hc_mult3,
+            hc_mult * hidden_size,
+            dtype=torch.float32,
+            device=device,
+        ),
+        torch.empty(3, dtype=torch.float32, device=device),
+        torch.empty(hc_mult3, dtype=torch.float32, device=device),
+        torch.empty(hidden_size, dtype=torch.bfloat16, device=device),
+        torch.empty(
+            hc_mult3,
+            hidden_size,
+            dtype=torch.float32,
+            device=device,
+        ),
+    )
+
+
+def _run_broadcast_mhc(
+    residual: torch.Tensor,
+    fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    norm_weight: torch.Tensor,
+    fn_broadcast: torch.Tensor,
+) -> tuple[torch.Tensor, ...]:
+    return mhc_pre_broadcast_tilelang(
+        residual,
+        fn,
+        hc_scale,
+        hc_base,
+        1e-6,
+        1e-6,
+        1e-6,
+        2.0,
+        20,
+        norm_weight=norm_weight,
+        fn_broadcast=fn_broadcast,
+    )
+
+
+def _assert_output_contract(outputs: tuple[torch.Tensor, ...]) -> None:
+    residual, post_mix, res_mix, layer_input = outputs
+    assert residual.shape == (6, 4, 128)
+    assert residual.dtype == torch.bfloat16
+    assert post_mix.shape == (6, 4, 1)
+    assert post_mix.dtype == torch.float32
+    assert res_mix.shape == (6, 4, 4)
+    assert res_mix.dtype == torch.float32
+    assert layer_input.shape == (6, 128)
+    assert layer_input.dtype == torch.bfloat16
+
+
+def test_mhc_pre_broadcast_fake_output_contract() -> None:
+    _assert_output_contract(_run_broadcast_mhc(*_inputs()))
+
+
+def test_mhc_pre_broadcast_is_fullgraph_compile_boundary() -> None:
+    compiled = torch.compile(_run_broadcast_mhc, backend="eager", fullgraph=True)
+    _assert_output_contract(compiled(*_inputs()))

--- a/vllm/model_executor/kernels/mhc/tilelang.py
+++ b/vllm/model_executor/kernels/mhc/tilelang.py
@@ -407,6 +407,67 @@ def mhc_pre_broadcast_tilelang(
     )
 
 
+def _mhc_pre_broadcast_tilelang_fake(
+    residual: torch.Tensor,
+    fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    rms_eps: float,
+    hc_pre_eps: float,
+    hc_sinkhorn_eps: float,
+    hc_post_mult_value: float,
+    sinkhorn_repeat: int,
+    n_splits: int = 1,
+    norm_weight: torch.Tensor | None = None,
+    norm_eps: float = 1e-6,
+    fn_broadcast: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    del (
+        hc_scale,
+        hc_base,
+        rms_eps,
+        hc_pre_eps,
+        hc_sinkhorn_eps,
+        hc_post_mult_value,
+        sinkhorn_repeat,
+        n_splits,
+        norm_weight,
+        norm_eps,
+        fn_broadcast,
+    )
+    num_tokens, hidden_size = residual.shape
+    hc_mult = fn.shape[1] // hidden_size
+    return (
+        torch.empty(
+            num_tokens,
+            hc_mult,
+            hidden_size,
+            dtype=torch.bfloat16,
+            device=residual.device,
+        ),
+        torch.empty(
+            num_tokens,
+            hc_mult,
+            1,
+            dtype=torch.float32,
+            device=residual.device,
+        ),
+        torch.empty(
+            num_tokens,
+            hc_mult,
+            hc_mult,
+            dtype=torch.float32,
+            device=residual.device,
+        ),
+        torch.empty(
+            num_tokens,
+            hidden_size,
+            dtype=torch.bfloat16,
+            device=residual.device,
+        ),
+    )
+
+
 def mhc_post_tilelang(
     x: torch.Tensor,
     residual: torch.Tensor,
@@ -782,6 +843,7 @@ def _hc_head_fused_kernel_tilelang_fake(
 
 
 _mhc_pre_tilelang_impl = mhc_pre_tilelang
+_mhc_pre_broadcast_tilelang_impl = mhc_pre_broadcast_tilelang
 _mhc_post_tilelang_impl = mhc_post_tilelang
 _mhc_fused_post_pre_tilelang_impl = mhc_fused_post_pre_tilelang
 
@@ -790,6 +852,12 @@ direct_register_custom_op(
     op_func=_mhc_pre_tilelang_impl,
     mutates_args=[],
     fake_impl=_mhc_pre_tilelang_fake,
+)
+direct_register_custom_op(
+    op_name="mhc_pre_broadcast_tilelang",
+    op_func=_mhc_pre_broadcast_tilelang_impl,
+    mutates_args=[],
+    fake_impl=_mhc_pre_broadcast_tilelang_fake,
 )
 direct_register_custom_op(
     op_name="mhc_post_tilelang",
@@ -816,6 +884,17 @@ def mhc_pre_tilelang(*args, **kwargs):
     return torch.ops.vllm.mhc_pre_tilelang(*args, **kwargs)
 
 
+def mhc_pre_broadcast_tilelang(*args, **kwargs):
+    """Call broadcast MHC pre through the registered custom op.
+
+    The implementation invokes DeepGEMM through a pybind extension, which
+    cannot be traced by Dynamo. Keeping that call behind a custom-op boundary
+    lets full-graph compilation represent the operation without entering its
+    Python implementation.
+    """
+    return torch.ops.vllm.mhc_pre_broadcast_tilelang(*args, **kwargs)
+
+
 def mhc_post_tilelang(*args, **kwargs):
     """Call MHC post through the registered custom op."""
     return torch.ops.vllm.mhc_post_tilelang(*args, **kwargs)
@@ -824,6 +903,7 @@ def mhc_post_tilelang(*args, **kwargs):
 def mhc_fused_post_pre_tilelang(*args, **kwargs):
     """Call fused MHC post/pre through the registered custom op."""
     return torch.ops.vllm.mhc_fused_post_pre_tilelang(*args, **kwargs)
+
 
 direct_register_custom_op(
     op_name="hc_head_fused_kernel_tilelang",


### PR DESCRIPTION
## Summary

- register `mhc_pre_broadcast_tilelang` as a vLLM custom op
- provide its fake/meta output contract for full-graph compilation
- keep the existing DeepGEMM and TileLang implementation unchanged at runtime

## Root cause

The DS4 TP4 `lucifer-cutlass` profile reaches the first-layer broadcast MHC path. Unlike the adjacent MHC pre, post, and fused post/pre operations, this function was not registered as a custom op. Dynamo therefore traced into `tf32_hc_prenorm_gemm`, a pybind function it cannot represent, and startup failed during full-graph compilation with `torch._dynamo.exc.Unsupported`.

The custom-op boundary is the same contract already used by the other MHC operations; this is not a backend disable or an eager-mode workaround.

## Validation

- `ruff format --check` and `ruff check`: pass
- focused fake-contract and `torch.compile(..., fullgraph=True)` tests: 2 passed
- exact E2E profile: DS4-Flash-0731, TP4/DCP1, fixed DSpark K5, `lucifer-cutlass`, `MAX_NUM_SEQS=1`, graph cap 6
- model load, AOT full-graph compile, MRV2 memory profiling, CUDA graph capture, and API startup all completed
- live chat request returned `42`; no runtime errors were logged

The matching image without this change fails deterministically while tracing `tf32_hc_prenorm_gemm`.