### PR TITLE
fix(ds4): correct reasoning effort prefix mapping (high unreachable, max rendered high)

### DIFF
--- a/vllm/tokenizers/deepseek_v4_encoding.py
+++ b/vllm/tokenizers/deepseek_v4_encoding.py
@@ -269,7 +269,7 @@ def render_message(index: int, messages: List[Dict[str, Any]], thinking_mode: st
     if tool_calls:
         tool_calls = tool_calls_from_openai_format(tool_calls)
 
-    # Reasoning effort prefix (only at index 0 in thinking mode with max effort)
+    # Reasoning effort prefix (only at index 0 in thinking mode, for high/max effort)
     assert reasoning_effort in ['max', None, 'high'], f"Invalid reasoning effort: {reasoning_effort}"
     if index == 0 and thinking_mode == "thinking" and reasoning_effort in ("high", "max"):
         prompt += REASONING_EFFORT_HIGH if reasoning_effort == "high" else REASONING_EFFORT_MAX

--- a/vllm/tokenizers/deepseek_v4_encoding.py
+++ b/vllm/tokenizers/deepseek_v4_encoding.py
@@ -67,10 +67,16 @@ tool_output_template: str = (
     "<tool_result>{content}</tool_result>"
 )
 
-REASONING_EFFORT_MAX = (
+REASONING_EFFORT_HIGH = (
     "Reasoning Effort: Absolute maximum with no shortcuts permitted.\n"
     "You MUST be very thorough in your thinking and comprehensively decompose the problem to resolve the root cause, rigorously stress-testing your logic against all potential paths, edge cases, and adversarial scenarios.\n"
     "Explicitly write out your entire deliberation process, documenting every intermediate step, considered alternative, and rejected hypothesis to ensure absolutely no assumption is left unchecked.\n\n"
+)
+
+REASONING_EFFORT_MAX = (
+    "Reasoning Effort: Beyond maximum \u2014 exhaustive, relentless, and uncompromising.\n"
+    "You MUST reason with the utmost depth and rigor, leaving absolutely nothing to chance: exhaustively decompose the problem into its most fundamental components, trace every causal chain to its root, and resolve the underlying cause rather than any surface symptom.\n"
+    "Do not stop reasoning until you have independently verified the solution from multiple angles and are certain that no assumption remains unchecked and no error remains undiscovered.\n\n"
 )
 
 TOOLS_TEMPLATE = """## Tools
@@ -265,8 +271,8 @@ def render_message(index: int, messages: List[Dict[str, Any]], thinking_mode: st
 
     # Reasoning effort prefix (only at index 0 in thinking mode with max effort)
     assert reasoning_effort in ['max', None, 'high'], f"Invalid reasoning effort: {reasoning_effort}"
-    if index == 0 and thinking_mode == "thinking" and reasoning_effort == 'max':
-        prompt += REASONING_EFFORT_MAX
+    if index == 0 and thinking_mode == "thinking" and reasoning_effort in ("high", "max"):
+        prompt += REASONING_EFFORT_HIGH if reasoning_effort == "high" else REASONING_EFFORT_MAX
 
     if role == "system":
         prompt += system_msg_template.format(content=content or "")


### PR DESCRIPTION
## Problem

`REASONING_EFFORT_MAX` in `vllm/tokenizers/deepseek_v4_encoding.py` holds the **HIGH** prefix text from the checkpoint's reference encoder (`encoding/encoding_dsv4.py`), and a prefix is injected only when `reasoning_effort == 'max'`. Result on current main:

- `reasoning_effort=high` → **no prefix at all** (renders identically to unset/low)
- `reasoning_effort=max` → renders the **HIGH** prefix ("Absolute maximum with no shortcuts permitted…") instead of the true max prefix ("Beyond maximum — exhaustive, relentless, and uncompromising…")

So every request runs one effort level below what was requested. Agentic workloads asking for `max` have actually been getting `high` since the 0731 checkpoint introduced the third effort level.

Measured via `/tokenize` on a live server (r16 image line): `low=5, high=5, max=84` tokens. Expected per the reference encoder: `low`=empty, `high`=84, `max`≈97.

Independently reported against stock vLLM: https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731/discussions/26 (byte-identical comparison against `encoding/encoding_dsv4.py`; notes the same high/max finding in stock `tokenizer_mode=deepseek_v4`, so upstream vLLM likely wants the equivalent fix).

## Fix

- Rename the existing constant to `REASONING_EFFORT_HIGH` (its text is the reference encoder's `high` prompt verbatim).
- Add `REASONING_EFFORT_MAX` with the reference encoder's true `max` prompt, verbatim from `encoding/encoding_dsv4.py` in `deepseek-ai/DeepSeek-V4-Flash-0731`.
- Inject the prefix for both `high` and `max`.

## Validation

Patched file bind-mounted over a running production server:

- `reasoning_effort=high` → 84 tokens, ends "…no assumption is left unchecked." ✓
- `reasoning_effort=max` → 97 tokens, ends "…no error remains undiscovered." ✓
- unset effort → 84 (server default `high`) — unchanged ✓
- `none` → chat mode — unchanged ✓

Note: `tokenizers/deepseek_v4.py` maps `low` → `high` via its else-branch. That mapping looks intentional (the fork exposes none/high/max) and is left untouched, but flagging it: the reference encoder has a distinct `low` tier (thinking mode, empty prefix) that the fork currently doesn't expose.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a dedicated **high reasoning effort** mode.
  * Updated thinking-mode rendering to apply distinct prompts for **high** and **maximum** reasoning effort settings.

* **Bug Fixes**
  * Improved maximum reasoning effort prompt wording for more consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->