### PR TITLE
[HH] Serve full Kimi K3 MXFP4 with dense MLA and DCP8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,14 @@ endif()
 
 # CUDA by default, can be overridden by using -DVLLM_TARGET_DEVICE=... (used by setup.py)
 set(VLLM_TARGET_DEVICE "cuda" CACHE STRING "Target device backend for vLLM")
+option(VLLM_KIMI_K3_CACHE_OPS_ONLY
+  "Build only the HH Kimi-K3 cache-op compatibility extension" OFF)
+option(VLLM_KIMI_K3_KDA_OPS_ONLY
+  "Build only the HH Kimi-K3 fused-decode compatibility extension" OFF)
+option(VLLM_KIMI_K3_ACTIVATION_OPS_ONLY
+  "Build only the HH Kimi-K3 SiTU compatibility extension" OFF)
+option(VLLM_FLASHKDA_ONLY
+  "Build only the FlashKDA prefill extension" OFF)
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 message(STATUS "Target device: ${VLLM_TARGET_DEVICE}")
 
@@ -281,6 +289,118 @@ if(VLLM_GPU_LANG STREQUAL "CUDA")
   endif()
 endif()
 
+# Keep this tiny target available independently of the rest of vLLM's CUDA
+# extensions.  It is used to run HH Python sources in a preserved image whose
+# full _C_stable_libtorch predates the six Kimi-K3 cache epilogue ops.  The
+# early return deliberately avoids configuring CUTLASS and FlashAttention.
+function(define_kimi_k3_cache_ops_target)
+  set(KIMI_K3_CACHE_OPS_SRC
+    "csrc/libtorch_stable/kimi_k3_cache_ops_bindings.cpp"
+    "csrc/libtorch_stable/fused_kimi_k3_mla_key_concat_kv_cache_kernel.cu")
+  set(KIMI_K3_CACHE_OPS_ARCHS)
+  foreach(_ARCH ${CUDA_ARCHS})
+    string(REPLACE "." "" _CMAKE_ARCH "${_ARCH}")
+    list(APPEND KIMI_K3_CACHE_OPS_ARCHS "${_CMAKE_ARCH}-real")
+  endforeach()
+  define_extension_target(
+    _kimi_k3_cache_ops
+    DESTINATION vllm
+    LANGUAGE CUDA
+    SOURCES ${KIMI_K3_CACHE_OPS_SRC}
+    COMPILE_FLAGS ${VLLM_GPU_FLAGS}
+    ARCHITECTURES ${KIMI_K3_CACHE_OPS_ARCHS}
+    USE_SABI 3
+    WITH_SOABI)
+  target_compile_definitions(_kimi_k3_cache_ops PRIVATE
+    TORCH_TARGET_VERSION=0x020B000000000000ULL
+    USE_CUDA)
+endfunction()
+
+# The preserved GG image predates HH's fused KDA decode kernel.  Keep this
+# independent from the full stable-libtorch extension so updating the Python
+# checkout does not require rebuilding every vLLM CUDA op.
+function(define_kimi_k3_kda_ops_target)
+  if(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 13.0)
+    message(FATAL_ERROR "HH fused KDA decode requires CUDA >= 13.0")
+  endif()
+  cuda_archs_loose_intersection(KIMI_K3_KDA_OPS_ARCHS
+    "9.0a;10.0f;12.0f" "${CUDA_ARCHS}")
+  if(NOT KIMI_K3_KDA_OPS_ARCHS)
+    message(FATAL_ERROR
+      "No compatible architecture for HH fused KDA decode: ${CUDA_ARCHS}")
+  endif()
+  set(KIMI_K3_KDA_OPS_SRC
+    "csrc/libtorch_stable/kimi_k3_kda_ops_bindings.cpp"
+    "csrc/libtorch_stable/kimi_k3/fused_kda_decode_kernel.cu")
+  set_gencode_flags_for_srcs(
+    SRCS "${KIMI_K3_KDA_OPS_SRC}"
+    CUDA_ARCHS "${KIMI_K3_KDA_OPS_ARCHS}")
+  set_property(SOURCE ${KIMI_K3_KDA_OPS_SRC} APPEND PROPERTY
+    COMPILE_OPTIONS "$<$<COMPILE_LANGUAGE:CUDA>:--use_fast_math>")
+  set(KIMI_K3_KDA_OPS_CMAKE_ARCHS)
+  foreach(_ARCH ${CUDA_ARCHS})
+    string(REPLACE "." "" _CMAKE_ARCH "${_ARCH}")
+    list(APPEND KIMI_K3_KDA_OPS_CMAKE_ARCHS "${_CMAKE_ARCH}-real")
+  endforeach()
+  define_extension_target(
+    _kimi_k3_kda_ops
+    DESTINATION vllm
+    LANGUAGE CUDA
+    SOURCES ${KIMI_K3_KDA_OPS_SRC}
+    COMPILE_FLAGS ${VLLM_GPU_FLAGS}
+    ARCHITECTURES ${KIMI_K3_KDA_OPS_CMAKE_ARCHS}
+    USE_SABI 3
+    WITH_SOABI)
+  target_compile_definitions(_kimi_k3_kda_ops PRIVATE
+    TORCH_TARGET_VERSION=0x020B000000000000ULL
+    VLLM_ENABLE_FUSED_KDA_DECODE=1
+    USE_CUDA)
+endfunction()
+
+function(define_kimi_k3_activation_ops_target)
+  set(KIMI_K3_ACTIVATION_OPS_SRC
+    "csrc/libtorch_stable/kimi_k3_activation_ops_bindings.cpp"
+    "csrc/libtorch_stable/activation_kernels.cu")
+  set(KIMI_K3_ACTIVATION_OPS_ARCHS)
+  foreach(_ARCH ${CUDA_ARCHS})
+    string(REPLACE "." "" _CMAKE_ARCH "${_ARCH}")
+    list(APPEND KIMI_K3_ACTIVATION_OPS_ARCHS "${_CMAKE_ARCH}-real")
+  endforeach()
+  define_extension_target(
+    _kimi_k3_activation_ops
+    DESTINATION vllm
+    LANGUAGE CUDA
+    SOURCES ${KIMI_K3_ACTIVATION_OPS_SRC}
+    COMPILE_FLAGS ${VLLM_GPU_FLAGS}
+    ARCHITECTURES ${KIMI_K3_ACTIVATION_OPS_ARCHS}
+    USE_SABI 3
+    WITH_SOABI)
+  target_compile_definitions(_kimi_k3_activation_ops PRIVATE
+    TORCH_TARGET_VERSION=0x020B000000000000ULL
+    USE_CUDA)
+endfunction()
+
+if((VLLM_KIMI_K3_CACHE_OPS_ONLY AND VLLM_KIMI_K3_KDA_OPS_ONLY) OR
+   (VLLM_KIMI_K3_CACHE_OPS_ONLY AND VLLM_KIMI_K3_ACTIVATION_OPS_ONLY) OR
+   (VLLM_KIMI_K3_KDA_OPS_ONLY AND VLLM_KIMI_K3_ACTIVATION_OPS_ONLY))
+  message(FATAL_ERROR "Select only one Kimi-K3 compatibility-only target")
+endif()
+
+if(VLLM_KIMI_K3_CACHE_OPS_ONLY OR VLLM_KIMI_K3_KDA_OPS_ONLY OR
+   VLLM_KIMI_K3_ACTIVATION_OPS_ONLY)
+  if(NOT VLLM_GPU_LANG STREQUAL "CUDA")
+    message(FATAL_ERROR "Kimi-K3 compatibility targets require CUDA")
+  endif()
+  if(VLLM_KIMI_K3_CACHE_OPS_ONLY)
+    define_kimi_k3_cache_ops_target()
+  elseif(VLLM_KIMI_K3_KDA_OPS_ONLY)
+    define_kimi_k3_kda_ops_target()
+  else()
+    define_kimi_k3_activation_ops_target()
+  endif()
+  return()
+endif()
+
 #
 # Use FetchContent for C++ dependencies that are compiled as part of vLLM's build process.
 # setup.py will override FETCHCONTENT_BASE_DIR to play nicely with sccache.
@@ -290,6 +410,14 @@ endif()
 include(FetchContent)
 file(MAKE_DIRECTORY ${FETCHCONTENT_BASE_DIR}) # Ensure the directory exists
 message(STATUS "FetchContent base directory: ${FETCHCONTENT_BASE_DIR}")
+
+if(VLLM_FLASHKDA_ONLY)
+  if(NOT VLLM_GPU_LANG STREQUAL "CUDA")
+    message(FATAL_ERROR "FlashKDA compatibility target requires CUDA")
+  endif()
+  include(cmake/external_projects/flashkda.cmake)
+  return()
+endif()
 
 if(VLLM_GPU_LANG STREQUAL "HIP")
   #
@@ -1200,6 +1328,15 @@ if(VLLM_GPU_LANG STREQUAL "CUDA" OR VLLM_GPU_LANG STREQUAL "HIP")
       target_link_libraries(_C_stable_libtorch PRIVATE ${_STABLE_TORCH_AMDHIP64})
     endif()
   endif()
+endif()
+
+# Small compatibility fragment for HH Kimi-K3 cache epilogues. This lets a
+# preserved image reuse its existing full _C_stable_libtorch and compile only
+# the K3 ops added by HH instead of rebuilding the entire vLLM CUDA extension.
+if(VLLM_GPU_LANG STREQUAL "CUDA")
+  define_kimi_k3_cache_ops_target()
+  define_kimi_k3_kda_ops_target()
+  define_kimi_k3_activation_ops_target()
 endif()
 
 #

--- a/csrc/libtorch_stable/kimi_k3_activation_ops_bindings.cpp
+++ b/csrc/libtorch_stable/kimi_k3_activation_ops_bindings.cpp
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+// Companion registration fragment for the SiTU activations introduced with
+// Kimi K3.  The implementation is compiled from activation_kernels.cu while
+// the preserved GG image continues to provide every older activation op.
+
+#include "ops.h"
+#include "core/registration.h"
+
+#include <torch/csrc/stable/library.h>
+
+STABLE_TORCH_LIBRARY_FRAGMENT(_C, ops) {
+  ops.def(
+      "situ_and_mul(Tensor! out, Tensor input, float beta=1.0, float "
+      "linear_beta=-1.0) -> ()");
+  ops.def(
+      "masked_situ_and_mul(Tensor! out, Tensor input, Tensor "
+      "expert_num_tokens, float beta=1.0, float linear_beta=-1.0) -> ()");
+}
+
+STABLE_TORCH_LIBRARY_IMPL(_C, CUDA, ops) {
+  ops.impl("situ_and_mul", TORCH_BOX(&situ_and_mul));
+  ops.impl("masked_situ_and_mul", TORCH_BOX(&masked_situ_and_mul));
+}
+
+REGISTER_EXTENSION(_kimi_k3_activation_ops)

--- a/csrc/libtorch_stable/kimi_k3_cache_ops_bindings.cpp
+++ b/csrc/libtorch_stable/kimi_k3_cache_ops_bindings.cpp
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+// Companion registration fragment for running HH Python against an older
+// _C_stable_libtorch image. A current full vLLM build already carries these
+// schemas in torch_bindings.cpp; Python loads this fragment only when they are
+// absent from the main extension.
+
+#include "ops.h"
+#include "core/registration.h"
+
+#include <torch/csrc/stable/library.h>
+
+STABLE_TORCH_LIBRARY_FRAGMENT(_C, ops) {
+  ops.def(
+      "fused_kimi_k3_mla_key_concat_kv_cache_insert("
+      "Tensor! q, Tensor k_nope, Tensor k_pe, Tensor kv_c_normed, "
+      "Tensor! k_out, Tensor! k_cache, Tensor slot_mapping, "
+      "int cache_block_size, Tensor? position_ids=None, "
+      "Tensor? cos_sin_cache=None) -> ()");
+  ops.def(
+      "fused_kimi_k3_mla_key_concat_ds_mla_insert("
+      "Tensor! q, Tensor k_nope, Tensor k_pe, Tensor kv_c_normed, "
+      "Tensor! k_out, Tensor! k_cache, Tensor slot_mapping, "
+      "int cache_block_size, Tensor? position_ids=None, "
+      "Tensor? cos_sin_cache=None) -> ()");
+  ops.def(
+      "fused_kimi_k3_mla_qkv_quant_kv_cache_fp8_insert("
+      "Tensor q, Tensor k_nope, Tensor k_pe, Tensor kv_c_normed, Tensor v, "
+      "Tensor! q_fp8, Tensor! k_fp8, Tensor! v_fp8, Tensor! k_cache, "
+      "Tensor slot_mapping, Tensor q_scale_inv, Tensor k_scale_inv, "
+      "Tensor v_scale_inv, Tensor cache_scale_inv, int cache_block_size, "
+      "Tensor? position_ids=None, Tensor? cos_sin_cache=None) -> ()");
+  ops.def(
+      "fused_kimi_k3_mla_decode_q_concat_kv_cache_insert("
+      "Tensor ql_nope, Tensor q_pe, Tensor kv_c_normed, Tensor k_pe, "
+      "Tensor! mqa_q, Tensor! k_cache, Tensor slot_mapping, "
+      "int cache_block_size, Tensor? position_ids=None, "
+      "Tensor? cos_sin_cache=None) -> ()");
+  ops.def(
+      "fused_kimi_k3_mla_decode_q_concat_kv_cache_fp8_insert("
+      "Tensor ql_nope, Tensor q_pe, Tensor kv_c_normed, Tensor k_pe, "
+      "Tensor! mqa_q, Tensor! k_cache, Tensor slot_mapping, "
+      "Tensor q_scale_inv, Tensor cache_scale_inv, int cache_block_size, "
+      "Tensor? position_ids=None, Tensor? cos_sin_cache=None) -> ()");
+  ops.def(
+      "fused_kimi_k3_mla_decode_q_concat_ds_mla_insert("
+      "Tensor ql_nope, Tensor q_pe, Tensor kv_c_normed, Tensor k_pe, "
+      "Tensor! mqa_q, Tensor! k_cache, Tensor slot_mapping, "
+      "int cache_block_size, Tensor? position_ids=None, "
+      "Tensor? cos_sin_cache=None) -> ()");
+}
+
+STABLE_TORCH_LIBRARY_IMPL(_C, CUDA, ops) {
+  ops.impl("fused_kimi_k3_mla_key_concat_kv_cache_insert",
+           TORCH_BOX(&fused_kimi_k3_mla_key_concat_kv_cache_insert));
+  ops.impl("fused_kimi_k3_mla_key_concat_ds_mla_insert",
+           TORCH_BOX(&fused_kimi_k3_mla_key_concat_ds_mla_insert));
+  ops.impl("fused_kimi_k3_mla_qkv_quant_kv_cache_fp8_insert",
+           TORCH_BOX(&fused_kimi_k3_mla_qkv_quant_kv_cache_fp8_insert));
+  ops.impl("fused_kimi_k3_mla_decode_q_concat_kv_cache_insert",
+           TORCH_BOX(&fused_kimi_k3_mla_decode_q_concat_kv_cache_insert));
+  ops.impl("fused_kimi_k3_mla_decode_q_concat_kv_cache_fp8_insert",
+           TORCH_BOX(&fused_kimi_k3_mla_decode_q_concat_kv_cache_fp8_insert));
+  ops.impl("fused_kimi_k3_mla_decode_q_concat_ds_mla_insert",
+           TORCH_BOX(&fused_kimi_k3_mla_decode_q_concat_ds_mla_insert));
+}
+
+REGISTER_EXTENSION(_kimi_k3_cache_ops)

--- a/csrc/libtorch_stable/kimi_k3_kda_ops_bindings.cpp
+++ b/csrc/libtorch_stable/kimi_k3_kda_ops_bindings.cpp
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+// Companion registration fragment for HH's fused KDA decode kernel.  It lets
+// HH Python sources run against a preserved image whose full stable-libtorch
+// extension was built before this operator was added.
+
+#include "ops.h"
+#include "core/registration.h"
+
+#include <torch/csrc/stable/library.h>
+
+STABLE_TORCH_LIBRARY_FRAGMENT(_C, ops) {
+  ops.def(
+      "fused_kda_decode("
+      "Tensor x, Tensor weight, Tensor? bias, Tensor! conv_state, "
+      "Tensor raw_g, Tensor raw_beta, Tensor A_log, Tensor dt_bias, "
+      "Tensor state_indices, Tensor! state, Tensor! out, "
+      "float? lower_bound=None, Tensor? output_gate=None, "
+      "Tensor? norm_weight=None, float norm_eps=1e-5) -> ()");
+}
+
+STABLE_TORCH_LIBRARY_IMPL(_C, CUDA, ops) {
+  ops.impl("fused_kda_decode", TORCH_BOX(&fused_kda_decode));
+}
+
+REGISTER_EXTENSION(_kimi_k3_kda_ops)

--- a/serve-kimi-k3-full-mxfp4-dcp8-1m.sh
+++ b/serve-kimi-k3-full-mxfp4-dcp8-1m.sh
@@ -127,6 +127,10 @@ export VLLM_B12X_MLA_DCP_GATHER_IN_WORKSPACE="${VLLM_B12X_MLA_DCP_GATHER_IN_WORK
 export VLLM_MEMORY_PROFILE_INCLUDE_ATTN="${KIMI_MEMORY_PROFILE_INCLUDE_ATTN:-0}"
 export VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS="${KIMI_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS:-0}"
 
+# Bound context-gather and expanded Q/K/V transients while retaining the full
+# physical 1M cache. Long contexts are merged from additional exact chunks.
+export VLLM_MLA_CHUNKED_PREFILL_WORKSPACE_SIZE="${VLLM_MLA_CHUNKED_PREFILL_WORKSPACE_SIZE:-32768}"
+
 # The 24 dense MLA q_a/kv_a projections are BF16 in the checkpoint. Shard
 # their output rows across TP16 and gather the 2112-element latent result,
 # saving about 0.63 GiB/rank without changing checkpoint precision.

--- a/serve-kimi-k3-full-mxfp4-dcp8-1m.sh
+++ b/serve-kimi-k3-full-mxfp4-dcp8-1m.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# Full stock Kimi K3 MXFP4 on HH, TP16/DCP8, native SparkInfer dense MLA,
+# and a physical 1M-token FP8 KV cache.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+PYTHON_BIN="${PYTHON_BIN:-${SCRIPT_DIR}/.venv/bin/python}"
+
+# This wrapper runs its compatibility preflight before serve-kimi-k3.sh gets a
+# chance to prepend the checkout. Make that preflight use the same HH sources.
+if [[ -e "${SCRIPT_DIR}/vllm/_C_stable_libtorch.abi3.so" ]]; then
+  export PYTHONPATH="${SCRIPT_DIR}${PYTHONPATH:+:${PYTHONPATH}}"
+fi
+
+TP_SIZE="${TP_SIZE:-16}"
+DCP_SIZE="${DCP_SIZE:-8}"
+MAX_MODEL_LEN="${MAX_MODEL_LEN:-1048576}"
+MAX_NUM_SEQS="${MAX_NUM_SEQS:-1}"
+MAX_NUM_BATCHED_TOKENS="${MAX_NUM_BATCHED_TOKENS:-256}"
+KV_CACHE_MEMORY_BYTES="${KV_CACHE_MEMORY_BYTES:-1860000000}"
+
+DCP_COMM_BACKEND="${DCP_COMM_BACKEND:-a2a}"
+# This profile serves one sequence at a time.  Sizing SparkInfer's two
+# graph/eager PCIe staging channels for 64 rows wastes about 13 MiB/rank at
+# the tight 1M-cache fit without accelerating a size-1 decode.
+DCP_A2A_MAX_TOKENS="${DCP_A2A_MAX_TOKENS:-1}"
+DCP_A2A_LARGE_BACKEND="${DCP_A2A_LARGE_BACKEND:-ag_rs}"
+KDA_PREFILL_BACKEND="${KDA_PREFILL_BACKEND:-triton}"
+
+if (( TP_SIZE != 16 )); then
+  echo "This profile is validated only for TP_SIZE=16, got ${TP_SIZE}" >&2
+  exit 2
+fi
+if (( DCP_SIZE != 8 )); then
+  echo "This profile is validated only for DCP_SIZE=8, got ${DCP_SIZE}" >&2
+  exit 2
+fi
+if (( TP_SIZE % DCP_SIZE != 0 )); then
+  echo "TP_SIZE (${TP_SIZE}) must be divisible by DCP_SIZE (${DCP_SIZE})" >&2
+  exit 2
+fi
+if [[ "${DCP_COMM_BACKEND}" != "a2a" ]]; then
+  echo "This profile requires DCP_COMM_BACKEND=a2a" >&2
+  exit 2
+fi
+case "${DCP_A2A_LARGE_BACKEND}" in
+  ag_rs | a2a) ;;
+  *)
+    echo "DCP_A2A_LARGE_BACKEND must be ag_rs or a2a" >&2
+    exit 2
+    ;;
+esac
+if [[ ! "${DCP_A2A_MAX_TOKENS}" =~ ^[0-9]+$ ]]; then
+  echo "DCP_A2A_MAX_TOKENS must be a non-negative integer" >&2
+  exit 2
+fi
+case "${KDA_PREFILL_BACKEND}" in
+  triton | flashkda) ;;
+  *)
+    echo "KDA_PREFILL_BACKEND must be triton or flashkda" >&2
+    exit 2
+    ;;
+esac
+if [[ ! -x "${PYTHON_BIN}" ]]; then
+  echo "Python interpreter not found or not executable: ${PYTHON_BIN}" >&2
+  exit 1
+fi
+
+# Fail before loading 1.4 TiB of weights when the requested Luke/SparkInfer
+# dense MLA package is missing from PYTHONPATH.
+export KDA_PREFILL_BACKEND
+"${PYTHON_BIN}" - <<'PY'
+import os
+
+from sparkinfer.attention import dense_mla
+from vllm.model_executor.layers.activation import ensure_kimi_k3_activation_ops
+from vllm.models.kimi_k3.nvidia.kda import ensure_fused_kda_decode_op
+from vllm.models.kimi_k3.nvidia.ops.fused_mla_key_concat_kv_cache import (
+    ensure_kimi_k3_cache_ops,
+)
+
+required = ("Caps", "plan", "bind", "compile", "run")
+missing = [name for name in required if not hasattr(dense_mla, name)]
+if missing:
+    raise RuntimeError(f"incomplete sparkinfer.attention.dense_mla: {missing}")
+print(f"SparkInfer dense MLA preflight: {dense_mla.__file__}", flush=True)
+ensure_kimi_k3_cache_ops()
+print("HH Kimi-K3 fused cache-op preflight: OK", flush=True)
+if not ensure_fused_kda_decode_op():
+    raise RuntimeError("HH Kimi-K3 fused KDA decode op is unavailable")
+print("HH Kimi-K3 fused KDA decode preflight: OK", flush=True)
+if os.environ["KDA_PREFILL_BACKEND"] == "flashkda":
+    import vllm._flashkda_C  # noqa: F401, E402
+
+    print("HH FlashKDA prefill preflight: OK", flush=True)
+else:
+    print("HH Triton KDA prefill selected: OK", flush=True)
+if not ensure_kimi_k3_activation_ops():
+    raise RuntimeError("HH Kimi-K3 fused SiTU activation ops are unavailable")
+print("HH Kimi-K3 fused SiTU activation preflight: OK", flush=True)
+PY
+
+# Native dense MLA gathers the six local TP16 query heads over DCP8, executes
+# 48 effective heads against the local 1/8 KV shard, and LSE-reduces the eight
+# partial outputs. Decode/small batches use SparkInfer's PCIe A2A path.
+export VLLM_USE_B12X_DCP_A2A="${VLLM_USE_B12X_DCP_A2A:-1}"
+export VLLM_B12X_CUDAGRAPH_COMPILE_ONLY_PREWARM="${VLLM_B12X_CUDAGRAPH_COMPILE_ONLY_PREWARM:-1}"
+export VLLM_DCP_A2A_MAX_TOKENS="${VLLM_DCP_A2A_MAX_TOKENS:-${DCP_A2A_MAX_TOKENS}}"
+export VLLM_DCP_A2A_LARGE_BACKEND="${VLLM_DCP_A2A_LARGE_BACKEND:-${DCP_A2A_LARGE_BACKEND}}"
+
+# K3 has no sparse indexer. Keep all GLM sparse/CKV policies disabled.
+export VLLM_DCP_INDEXER_SHARDS="${VLLM_DCP_INDEXER_SHARDS:-0}"
+export VLLM_DCP_QUERY_SPLIT="${VLLM_DCP_QUERY_SPLIT:-0}"
+export VLLM_DCP_GLOBAL_TOPK="${VLLM_DCP_GLOBAL_TOPK:-0}"
+export VLLM_DCP_PROJECT_BEFORE_MERGE="${VLLM_DCP_PROJECT_BEFORE_MERGE:-0}"
+export VLLM_B12X_MLA_DCP_GATHER_IN_WORKSPACE="${VLLM_B12X_MLA_DCP_GATHER_IN_WORKSPACE:-0}"
+
+# FlashKDA's first SM120 launch commits about 3.74 GiB of non-PyTorch CUDA
+# module state. The full stock checkpoint plus a physical 1M cache has only
+# about 0.45 GiB free after graph capture. Triton KDA prefill commits about
+# 0.12 GiB for the same 69-layer warmup, while decode still uses the separate
+# fused conv+KDA+norm companion. FlashKDA remains an explicit override for
+# smaller-cache experiments, but it cannot fit this profile as currently built.
+
+# Manual KV sizing and a measured size-1 graph make both conservative memory
+# reservations unnecessary on this very tight full-MXFP4 fit.
+export VLLM_MEMORY_PROFILE_INCLUDE_ATTN="${KIMI_MEMORY_PROFILE_INCLUDE_ATTN:-0}"
+export VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS="${KIMI_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS:-0}"
+
+# The 24 dense MLA q_a/kv_a projections are BF16 in the checkpoint. Shard
+# their output rows across TP16 and gather the 2112-element latent result,
+# saving about 0.63 GiB/rank without changing checkpoint precision.
+export VLLM_KIMI_SHARD_QKV_A="${VLLM_KIMI_SHARD_QKV_A:-1}"
+
+# Keep HH's replicated routed up-projection and fused latent-MoE tail, but
+# TP-shard the 49-MiB BF16 routed down-projection in each of 92 MoE layers.
+# Gathering the 3584-element latent output saves about 4.13 GiB/rank.
+export VLLM_KIMI_SHARD_ROUTED_DOWN_PROJ="${VLLM_KIMI_SHARD_ROUTED_DOWN_PROJ:-1}"
+
+# HH otherwise replicates another 49-MiB BF16 up projection in every MoE
+# layer. Row-shard it and reduce the routed+shared hidden partial together.
+# This saves another 4.13 GiB/rank and makes the full 93-layer model fit.
+export VLLM_KIMI_SHARD_ROUTED_UP_PROJ="${VLLM_KIMI_SHARD_ROUTED_UP_PROJ:-1}"
+
+# The 896x7168 BF16 router is otherwise replicated in all 92 MoE layers.
+# Shard it and gather the 896 FP32 logits, saving about 1.03 GiB/rank.
+export VLLM_KIMI_SHARD_ROUTER="${VLLM_KIMI_SHARD_ROUTER:-1}"
+
+export VLLM_ENABLE_PCIE_ALLREDUCE="${VLLM_ENABLE_PCIE_ALLREDUCE:-1}"
+export VLLM_PCIE_ALLREDUCE_BACKEND="${KIMI_PCIE_ALLREDUCE_BACKEND:-b12x}"
+export VLLM_PCIE_ONESHOT_SINGLE_CHANNEL="${KIMI_PCIE_ONESHOT_SINGLE_CHANNEL:-1}"
+
+if [[ -z "${COMPILATION_CONFIG:-}" ]]; then
+  export COMPILATION_CONFIG='{"mode":0,"cudagraph_mode":"PIECEWISE","cudagraph_capture_sizes":[1],"pass_config":{"fuse_allreduce_rms":true}}'
+fi
+
+export MODEL="${MODEL:-/root/.cache/huggingface/hub/models--moonshotai--Kimi-K3/snapshots/2496450e92e425c886db095102a52a6682ca3970}"
+export SERVED_MODEL_NAME="${SERVED_MODEL_NAME:-Kimi-K3-MXFP4-HH-DenseMLA-DCP8-1M}"
+export TP_SIZE DCP_SIZE MAX_MODEL_LEN MAX_NUM_SEQS MAX_NUM_BATCHED_TOKENS
+export GPU_MEMORY_UTILIZATION="${GPU_MEMORY_UTILIZATION:-0.985}"
+
+unset NCCL_GRAPH_FILE NCCL_GRAPH_DUMP_FILE
+
+exec "${SCRIPT_DIR}/serve-kimi-k3-instanttensor.sh" \
+  --language-model-only \
+  --attention-backend B12X_MLA \
+  --decode-context-parallel-size "${DCP_SIZE}" \
+  --dcp-comm-backend "${DCP_COMM_BACKEND}" \
+  --dcp-kv-cache-interleave-size 1 \
+  --kda-prefill-backend "${KDA_PREFILL_BACKEND}" \
+  --kv-cache-dtype fp8 \
+  --kv-cache-memory-bytes "${KV_CACHE_MEMORY_BYTES}" \
+  --no-enable-prefix-caching \
+  "$@"

--- a/serve-kimi-k3-instanttensor.sh
+++ b/serve-kimi-k3-instanttensor.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Fast-loading stock Kimi K3 profile. Requires the consumer-stream-safe
+# InstantTensor wheel from voipmonitor/InstantTensor:dev/gg-k3-consumer-event.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+# The stock checkpoint contains two 2.19-GiB BF16 tensors. InstantTensor
+# streams all smaller weights through this ring and sends only those two
+# through the CPU safetensors fallback, avoiding a loader-time GPU OOM.
+export INSTANTTENSOR_BUFFER_SIZE="${INSTANTTENSOR_BUFFER_SIZE:-536870912}"
+
+exec "${SCRIPT_DIR}/serve-kimi-k3.sh" --load-format instanttensor "$@"

--- a/serve-kimi-k3.sh
+++ b/serve-kimi-k3.sh
@@ -51,7 +51,9 @@ MAX_NUM_SEQS="${MAX_NUM_SEQS:-2}"
 MAX_NUM_BATCHED_TOKENS="${MAX_NUM_BATCHED_TOKENS:-512}"
 # Decode-only size-1 graphs: capture memory competes with the last GiB of
 # weights; batch sizes above the capture list run eagerly.
-COMPILATION_CONFIG="${COMPILATION_CONFIG:-{\"mode\": 0, \"cudagraph_mode\": \"PIECEWISE\", \"cudagraph_capture_sizes\": [1]}}"
+if [[ -z "${COMPILATION_CONFIG:-}" ]]; then
+  COMPILATION_CONFIG='{"mode": 0, "cudagraph_mode": "PIECEWISE", "cudagraph_capture_sizes": [1]}'
+fi
 
 exec "${PYTHON_BIN}" -m vllm.entrypoints.cli.main serve "${MODEL}" \
   --served-model-name "${SERVED_MODEL_NAME}" \

--- a/setup.py
+++ b/setup.py
@@ -784,6 +784,9 @@ class precompiled_wheel_utils:
                             "vllm/_flashmla_C.abi3.so",
                             "vllm/_flashmla_extension_C.abi3.so",
                             "vllm/_flashkda_C.abi3.so",
+                            "vllm/_kimi_k3_cache_ops.abi3.so",
+                            "vllm/_kimi_k3_kda_ops.abi3.so",
+                            "vllm/_kimi_k3_activation_ops.abi3.so",
                             "vllm/_sparse_flashmla_C.abi3.so",
                             "vllm/vllm_flash_attn/_vllm_fa2_C.abi3.so",
                             "vllm/vllm_flash_attn/_vllm_fa3_C.abi3.so",
@@ -1183,6 +1186,10 @@ if _build_custom_ops():
     if _is_cuda() or _is_hip():
         ext_modules.append(CMakeExtension(name="vllm._C_stable_libtorch"))
         ext_modules.append(CMakeExtension(name="vllm._moe_C_stable_libtorch"))
+    if _is_cuda():
+        ext_modules.append(CMakeExtension(name="vllm._kimi_k3_cache_ops"))
+        ext_modules.append(CMakeExtension(name="vllm._kimi_k3_kda_ops"))
+        ext_modules.append(CMakeExtension(name="vllm._kimi_k3_activation_ops"))
 
 package_data = {
     "vllm": [

--- a/tests/distributed/test_dcp_a2a.py
+++ b/tests/distributed/test_dcp_a2a.py
@@ -10,13 +10,18 @@ Tests cover:
 
 import importlib.util
 import math
+import os
 from contextlib import contextmanager
 from typing import Any
 
-import multiprocess as mp
 import pytest
 import torch
 import torch.distributed as dist
+
+try:
+    import multiprocess as mp
+except ModuleNotFoundError:
+    import multiprocessing as mp
 
 import vllm.envs as envs
 from vllm.config.parallel import ParallelConfig
@@ -552,8 +557,11 @@ def test_b12x_pool_uses_independent_stream_channels(
             captured.update(kwargs)
             return cls()
 
-        def for_stream(self):
-            captured["warmed"] = True
+        def prepare_channels(self, channel_ids):
+            captured["prepared"] = tuple(channel_ids)
+
+        def for_stream(self, *, channel_id):
+            captured["warmed"] = channel_id
 
     group = _FakeCPGroup(2, object())  # type: ignore[arg-type]
     monkeypatch.setattr(dcp_alltoall, "_B12X_DCP_A2A_POOLS", {})
@@ -577,7 +585,8 @@ def test_b12x_pool_uses_independent_stream_channels(
 
     assert pool is not None
     assert captured["single_channel"] is False
-    assert captured["warmed"] is True
+    assert captured["prepared"] == ("vllm:eager:dcp",)
+    assert captured["warmed"] == "vllm:eager:dcp"
 
 
 def test_b12x_dcp_capture_selects_only_current_group_pools(monkeypatch):
@@ -590,12 +599,12 @@ def test_b12x_dcp_capture_selects_only_current_group_pools(monkeypatch):
             self.name = name
 
         @contextmanager
-        def capture(self, *, stream):
-            events.append(("enter", self.name, stream))
+        def capture(self, *, stream, channel_id):
+            events.append(("enter", self.name, stream, channel_id))
             try:
                 yield
             finally:
-                events.append(("exit", self.name, stream))
+                events.append(("exit", self.name, stream, channel_id))
 
     device_group = object()
     group = _FakeCPGroup(2, device_group)  # type: ignore[arg-type]
@@ -606,16 +615,17 @@ def test_b12x_dcp_capture_selects_only_current_group_pools(monkeypatch):
         (id(object()), 0, 64, 512, 576, 64): _FakePool("foreign"),
     }
     monkeypatch.setattr(dcp_alltoall, "_B12X_DCP_A2A_POOLS", pools)
+    monkeypatch.setattr(dcp_alltoall, "_B12X_DCP_CAPTURE_SEQUENCES", {})
 
     with dcp_alltoall.capture_b12x_dcp_a2a(group, stream):  # type: ignore[arg-type]
         events.append(("body", None, stream))
 
     assert events == [
-        ("enter", "output", stream),
-        ("enter", "query", stream),
+        ("enter", "output", stream, "vllm:graph:0"),
+        ("enter", "query", stream, "vllm:graph:0"),
         ("body", None, stream),
-        ("exit", "query", stream),
-        ("exit", "output", stream),
+        ("exit", "query", stream, "vllm:graph:0"),
+        ("exit", "output", stream, "vllm:graph:0"),
     ]
 
 
@@ -760,8 +770,9 @@ def test_b12x_lse_reduce_honors_token_cap(monkeypatch: pytest.MonkeyPatch):
 
     class _FakePool:
         def lse_reduce_scatter(
-            self, partial, lse, out=None, *, is_lse_base_on_e
+            self, partial, lse, out=None, *, is_lse_base_on_e, channel_id
         ):
+            assert channel_id == "vllm:eager:dcp"
             return sentinel
 
     def fake_get_pool(
@@ -813,7 +824,8 @@ def test_b12x_query_gather_honors_token_cap(monkeypatch: pytest.MonkeyPatch):
     sentinel = torch.zeros(1)
 
     class _FakePool:
-        def all_gather_heads(self, local_input):
+        def all_gather_heads(self, local_input, *, channel_id):
+            assert channel_id == "vllm:eager:dcp"
             return sentinel
 
     def fake_get_pool(
@@ -856,8 +868,9 @@ def test_b12x_lse_reduce_preserves_supported_layouts(monkeypatch: pytest.MonkeyP
 
     class _FakePool:
         def lse_reduce_scatter(
-            self, partial, lse, out=None, *, is_lse_base_on_e
+            self, partial, lse, out=None, *, is_lse_base_on_e, channel_id
         ):
+            assert channel_id == "vllm:eager:dcp"
             received.update(partial=partial, lse=lse, out=out)
             return sentinel
 
@@ -1151,8 +1164,9 @@ def _distributed_b12x_a2a_worker(env: dict[str, str]) -> None:
 
         rank = dist.get_rank()
         world_size = dist.get_world_size()
-        batch, h_per_rank, head_dim, query_head_dim = 3, 8, 512, 576
-        total_heads = world_size * h_per_rank
+        batch = int(os.getenv("VLLM_TEST_B12X_BATCH", "3"))
+        total_heads, head_dim, query_head_dim = 48, 512, 576
+        h_per_rank = total_heads // world_size
         group = _FakeCPGroup(world_size, dist.group.WORLD)
 
         def make_inputs(step: int):
@@ -1267,7 +1281,10 @@ def _distributed_b12x_a2a_worker(env: dict[str, str]) -> None:
         dcp_alltoall._dcp_a2a_send_recv_buffers = fail_packed_nccl
         group.all_gather = fail_query_nccl  # type: ignore[attr-defined]
         graph = torch.cuda.CUDAGraph()
-        with torch.cuda.graph(graph):
+        with (
+            dcp_alltoall.capture_b12x_dcp_a2a(group),  # type: ignore[arg-type]
+            torch.cuda.graph(graph),
+        ):
             graph_query = dcp_alltoall.dcp_b12x_all_gather_heads(
                 static_query,
                 group,  # type: ignore[arg-type]
@@ -1352,10 +1369,15 @@ def test_distributed_packed_a2a_with_workspace_matches_reference():
 def test_distributed_b12x_a2a_eager_and_graph_matches_reference():
     from sparkinfer.comm.pcie.pcie_dcp_a2a import _load_extension
 
+    world_size = int(os.getenv("VLLM_TEST_B12X_WORLD_SIZE", "2"))
+    if world_size not in (2, 4, 8):
+        pytest.skip("B12X DCP A2A supports world sizes 2, 4, and 8")
+    if torch.accelerator.device_count() < world_size:
+        pytest.skip(f"Need {world_size} GPUs")
     _load_extension()
     _distributed_run(
         _distributed_b12x_a2a_worker,
-        world_size=2,
+        world_size=world_size,
         extra_env={"VLLM_USE_B12X_DCP_A2A": "1"},
     )
 

--- a/tests/kernels/core/test_activation.py
+++ b/tests/kernels/core/test_activation.py
@@ -18,6 +18,7 @@ from vllm.model_executor.layers.activation import (
     ReLUSquaredActivation,
     SiluAndMul,
     SiluAndMulWithClamp,
+    SituAndMul,
     SwigluOAIAndMul,
     SwigluStepAndMul,
     swiglustep_and_mul_triton,
@@ -31,6 +32,41 @@ SEEDS = [0]
 CUDA_DEVICES = [
     f"cuda:{i}" for i in range(1 if torch.accelerator.device_count() == 1 else 2)
 ]
+
+
+@pytest.mark.parametrize("linear_beta", [None, 25.0])
+@torch.inference_mode()
+def test_situ_and_mul_cuda_companion(
+    default_vllm_config,
+    linear_beta: float | None,
+) -> None:
+    """The fused SiTU op is available from the main or companion extension."""
+    device = CUDA_DEVICES[0]
+    x = torch.randn(7, 1024, dtype=torch.bfloat16, device=device)
+    layer = SituAndMul(beta=4.0, linear_beta=linear_beta, compile_native=False)
+
+    assert layer.op is not None
+    actual = layer.forward_cuda(x)
+    expected = layer.forward_native(x)
+    torch.testing.assert_close(actual, expected, rtol=2e-2, atol=2e-2)
+
+
+@pytest.mark.parametrize("linear_beta", [None, 25.0])
+@torch.inference_mode()
+def test_situ_and_mul_cuda_extension_fallback(
+    default_vllm_config,
+    linear_beta: float | None,
+) -> None:
+    """The source overlay remains usable with a pre-SiTU vLLM binary."""
+    device = CUDA_DEVICES[0]
+    x = torch.randn(7, 1024, dtype=torch.bfloat16, device=device)
+    layer = SituAndMul(beta=4.0, linear_beta=linear_beta, compile_native=False)
+    layer.op = None
+
+    actual = layer.forward_cuda(x)
+    expected = layer.forward_native(x)
+
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
 
 
 @pytest.mark.parametrize(

--- a/tests/model_executor/layers/test_b12x_moe_warmup.py
+++ b/tests/model_executor/layers/test_b12x_moe_warmup.py
@@ -420,6 +420,56 @@ def test_b12x_moe_warmup_runs_one_launch_per_planner_regime(monkeypatch) -> None
     assert run_tokens == [3, 8]
 
 
+def test_b12x_moe_warmup_preserves_exact_graph_decode_shape(monkeypatch) -> None:
+    planned_tokens = []
+    run_tokens = []
+
+    def fake_execution_plan(**kwargs):
+        tokens = kwargs["tokens"]
+        planned_tokens.append(tokens)
+        execution = f"w4a16-m{tokens}" if tokens <= 8 else "dynamic"
+        return _FakePlan(execution).launch_plan
+
+    monkeypatch.setattr(
+        b12x_moe,
+        "_plan_b12x_moe_execution",
+        fake_execution_plan,
+    )
+    monkeypatch.setattr(
+        b12x_moe,
+        "_plan_b12x_moe_fp4_scratch",
+        lambda **kwargs: _FakePlan(),
+    )
+    monkeypatch.setattr(
+        b12x_moe,
+        "_run_b12x_moe_fp4",
+        lambda **kwargs: run_tokens.append(kwargs["a"].shape[0]),
+    )
+    monkeypatch.setattr(
+        b12x_moe,
+        "_dynamic_moe_warmup_tokens",
+        lambda *, topk, quant_mode, requested_tokens: 16,
+    )
+
+    experts = _make_fake_b12x_experts()
+    layer = SimpleNamespace(
+        w13_weight=torch.empty(8, 32, 32, dtype=torch.uint8),
+        w2_weight=torch.empty(8, 64, 8, dtype=torch.uint8),
+        activation=MoEActivation.SWIGLUOAI_UNINTERLEAVE,
+        apply_router_weight_on_input=False,
+    )
+
+    warmed = experts.warmup_dynamic_launches(
+        layer,
+        token_counts=(1, 4, 16),
+        direct_token_counts=(1,),
+    )
+
+    assert warmed == 2
+    assert planned_tokens == [1, 16, 16, 16]
+    assert run_tokens == [1, 16]
+
+
 def test_b12x_force_a16_nvfp4_selects_w4a16(monkeypatch) -> None:
     monkeypatch.setenv("B12X_MOE_FORCE_A16", "1")
 
@@ -666,8 +716,8 @@ def test_warmup_b12x_moe_dynamic_dedupes_signatures(monkeypatch) -> None:
     def fake_signature(self, layer):
         return ("same-signature",)
 
-    def fake_warmup(self, layer, *, token_counts):
-        calls.append((self, layer, token_counts))
+    def fake_warmup(self, layer, *, token_counts, direct_token_counts=()):
+        calls.append((self, layer, token_counts, direct_token_counts))
         return 3
 
     monkeypatch.setattr(
@@ -710,6 +760,10 @@ def test_warmup_b12x_moe_dynamic_dedupes_signatures(monkeypatch) -> None:
     assert warmed == 3
     assert len(calls) == 1
     assert calls[0][2] == (1, 2, 3, 4, 5)
+
+
+def test_b12x_supports_situ_activation() -> None:
+    assert b12x_moe.B12xExperts._supports_activation(MoEActivation.SITU)
 
 
 def test_b12x_moe_warmup_token_counts_cover_serving_range() -> None:

--- a/tests/model_executor/model_loader/instanttensor_loader/test_weight_utils.py
+++ b/tests/model_executor/model_loader/instanttensor_loader/test_weight_utils.py
@@ -5,6 +5,7 @@ import glob
 
 import pytest
 import torch
+from safetensors.torch import save_file
 
 from vllm.model_executor.model_loader.weight_utils import (
     download_weights_from_hf,
@@ -40,6 +41,67 @@ def test_instanttensor_model_loader():
         assert instanttensor_tensor.dtype == hf_safetensors_tensors[name].dtype
         assert instanttensor_tensor.shape == hf_safetensors_tensors[name].shape
         assert torch.all(instanttensor_tensor.eq(hf_safetensors_tensors[name]))
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda(),
+    reason="InstantTensor requires NVIDIA GPUs",
+)
+def test_instanttensor_honors_tensor_to_shard_index(tmp_path):
+    base_shard = tmp_path / "model-00001-of-00002.safetensors"
+    overlay_shard = tmp_path / "model-00002-of-00002.safetensors"
+    save_file(
+        {
+            "model.dense.weight": torch.tensor([2.0]),
+            "model.expert.weight": torch.tensor([1.0, 1.0]),
+        },
+        base_shard,
+    )
+    save_file(
+        {"model.expert.weight": torch.tensor([3.0, 3.0, 3.0])},
+        overlay_shard,
+    )
+    indexed_tensor_files = {
+        "model.dense.weight": str(base_shard.resolve()),
+        "model.expert.weight": str(overlay_shard.resolve()),
+    }
+
+    weights = {
+        name: tensor.cpu()
+        for name, tensor in instanttensor_weights_iterator(
+            [str(base_shard), str(overlay_shard)],
+            use_tqdm_on_load=False,
+            indexed_tensor_files=indexed_tensor_files,
+        )
+    }
+
+    assert set(weights) == {"model.dense.weight", "model.expert.weight"}
+    assert weights["model.dense.weight"].tolist() == [2.0]
+    assert weights["model.expert.weight"].tolist() == [3.0, 3.0, 3.0]
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda(),
+    reason="InstantTensor requires NVIDIA GPUs",
+)
+def test_instanttensor_falls_back_for_tensor_larger_than_ring(
+    tmp_path, monkeypatch
+):
+    shard = tmp_path / "model.safetensors"
+    small = torch.arange(256 * 1024, dtype=torch.float32)
+    large = torch.arange(9 * 256 * 1024, dtype=torch.float32)
+    save_file({"model.small": small, "model.large": large}, shard)
+    monkeypatch.setenv("INSTANTTENSOR_BUFFER_SIZE", str(8 * 1024 * 1024))
+
+    weights = {
+        name: tensor.cpu()
+        for name, tensor in instanttensor_weights_iterator(
+            [str(shard)], use_tqdm_on_load=False
+        )
+    }
+
+    torch.testing.assert_close(weights["model.small"], small)
+    torch.testing.assert_close(weights["model.large"], large)
 
 
 if __name__ == "__main__":

--- a/tests/models/kimi_k3/test_moe_padding.py
+++ b/tests/models/kimi_k3/test_moe_padding.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import vllm.models.kimi_k3.nvidia.model as kimi_model
+from vllm.models.kimi_k3.nvidia.model import (
+    KimiShardedGate,
+    _shard_routed_down_projection,
+    _shard_router,
+    _uses_native_b12x_mxfp4_intermediate_size,
+)
+
+
+@pytest.mark.parametrize(
+    ("quantization", "backend", "use_b12x_env", "expected"),
+    [
+        ("mxfp4", "auto", "1", True),
+        ("mxfp4", "b12x", "0", True),
+        ("mxfp4", "auto", "0", False),
+        ("mxfp4", "triton", "1", False),
+        (None, "b12x", "1", False),
+    ],
+)
+def test_native_b12x_mxfp4_intermediate_selection(
+    monkeypatch,
+    quantization: str | None,
+    backend: str,
+    use_b12x_env: str,
+    expected: bool,
+) -> None:
+    monkeypatch.setenv("VLLM_USE_B12X_MOE", use_b12x_env)
+    vllm_config = SimpleNamespace(
+        model_config=SimpleNamespace(quantization=quantization),
+        kernel_config=SimpleNamespace(moe_backend=backend),
+    )
+
+    assert _uses_native_b12x_mxfp4_intermediate_size(vllm_config) is expected
+
+
+@pytest.mark.parametrize(
+    ("tp_size", "enabled", "expected"),
+    [(16, "1", True), (16, "0", False), (1, "1", False)],
+)
+def test_shard_routed_down_projection_selection(
+    monkeypatch,
+    tp_size: int,
+    enabled: str,
+    expected: bool,
+) -> None:
+    monkeypatch.setenv("VLLM_KIMI_SHARD_ROUTED_DOWN_PROJ", enabled)
+
+    assert _shard_routed_down_projection(tp_size) is expected
+
+
+@pytest.mark.parametrize(
+    ("tp_size", "enabled", "expected"),
+    [(16, "1", True), (16, "0", False), (1, "1", False)],
+)
+def test_shard_router_selection(
+    monkeypatch,
+    tp_size: int,
+    enabled: str,
+    expected: bool,
+) -> None:
+    monkeypatch.setenv("VLLM_KIMI_SHARD_ROUTER", enabled)
+
+    assert _shard_router(tp_size) is expected
+
+
+def test_sharded_router_gathers_rank_ordered_fp32_logits(monkeypatch) -> None:
+    gate = object.__new__(KimiShardedGate)
+    torch.nn.Module.__init__(gate)
+    gate.weight = torch.nn.Parameter(
+        torch.tensor([[1.0, 2.0], [3.0, 4.0]], dtype=torch.bfloat16),
+        requires_grad=False,
+    )
+    gate.tp_size = 2
+    x = torch.tensor([[2.0, 1.0]], dtype=torch.bfloat16)
+    expected_local = torch.nn.functional.linear(x, gate.weight).float()
+    monkeypatch.setattr(
+        kimi_model,
+        "tensor_model_parallel_all_gather",
+        lambda local: torch.cat((local, local + 10), dim=-1),
+    )
+
+    output, bias = gate(x)
+
+    torch.testing.assert_close(
+        output, torch.cat((expected_local, expected_local + 10), dim=-1)
+    )
+    assert output.dtype == torch.float32
+    assert bias is None

--- a/tests/models/kimi_k3/test_tp_projection.py
+++ b/tests/models/kimi_k3/test_tp_projection.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.fused_moe.runner import latent_moe_runner
+from vllm.model_executor.layers.fused_moe.runner.latent_moe_runner import (
+    _project_sharded_up_and_reduce,
+)
+from vllm.models.kimi_k3.nvidia.mla import _restore_merged_output_order
+
+
+def test_restore_merged_output_order() -> None:
+    tp_size = 4
+    output_sizes = [8, 12]
+    per_rank = []
+    expected_q = []
+    expected_kv = []
+    for rank in range(tp_size):
+        q = torch.full((2, output_sizes[0] // tp_size), rank + 1)
+        kv = torch.full((2, output_sizes[1] // tp_size), 10 + rank)
+        per_rank.append(torch.cat((q, kv), dim=-1))
+        expected_q.append(q)
+        expected_kv.append(kv)
+
+    rank_major = torch.cat(per_rank, dim=-1)
+    expected = torch.cat((*expected_q, *expected_kv), dim=-1)
+
+    actual = _restore_merged_output_order(rank_major, output_sizes, tp_size)
+
+    torch.testing.assert_close(actual, expected)
+
+
+def test_restore_merged_output_order_rejects_invalid_width() -> None:
+    with pytest.raises(ValueError, match="Unexpected gathered"):
+        _restore_merged_output_order(torch.empty(2, 79), [32, 48], 4)
+
+
+def test_project_sharded_up_reduces_after_shared_add(monkeypatch) -> None:
+    fused_latent = torch.tensor([[1.0, 2.0]])
+    shared_partial = torch.tensor([[3.0, 4.0]])
+    weight = torch.tensor([[2.0, 0.0], [0.0, 3.0]])
+
+    class FakeRowParallelProjection(torch.nn.Module):
+        def forward(self, x: torch.Tensor):
+            return x @ weight.T, None
+
+    reduced_inputs: list[torch.Tensor] = []
+
+    def fake_all_reduce(x: torch.Tensor) -> torch.Tensor:
+        reduced_inputs.append(x.clone())
+        return x + 10.0
+
+    monkeypatch.setattr(
+        latent_moe_runner,
+        "tensor_model_parallel_all_reduce",
+        fake_all_reduce,
+    )
+    actual = _project_sharded_up_and_reduce(
+        fused_latent,
+        shared_partial.clone(),
+        FakeRowParallelProjection(),
+    )
+
+    expected_partial = torch.tensor([[5.0, 10.0]])
+    torch.testing.assert_close(reduced_inputs[0], expected_partial)
+    torch.testing.assert_close(actual, expected_partial + 10.0)

--- a/tests/v1/attention/test_b12x_mla.py
+++ b/tests/v1/attention/test_b12x_mla.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 
 import torch
 
+from vllm.compilation.b12x_capture import b12x_compile_only_warmup
 from vllm.platforms.interface import DeviceCapability
 from vllm.v1.attention.backends.mla import b12x_mla
 from vllm.v1.attention.backends.mla.b12x_mla import (
@@ -33,6 +34,7 @@ class _FakeDenseMLA:
     def __init__(self) -> None:
         self.bindings: list[SimpleNamespace] = []
         self.compile_count = 0
+        self.run_count = 0
 
     def bind(self, plan, **kwargs):
         binding = SimpleNamespace(plan=plan, **kwargs)
@@ -43,6 +45,7 @@ class _FakeDenseMLA:
         self.compile_count += 1
 
     def run(self, *, binding):
+        self.run_count += 1
         lse = torch.zeros(
             binding.output.shape[:2], dtype=torch.float32, device=binding.output.device
         )
@@ -50,16 +53,80 @@ class _FakeDenseMLA:
 
 
 def _fake_impl(monkeypatch) -> tuple[B12xMLAImpl, _FakeDenseMLA]:
-    monkeypatch.setattr(b12x_mla, "is_workspace_manager_initialized", lambda: False)
     impl = object.__new__(B12xMLAImpl)
     impl.num_heads = 8
     impl.kv_lora_rank = 512
     impl.scale = 192**-0.5
+    impl.dcp_world_size = 1
+    impl._dcp_comm_backend = "a2a"
+    impl._dcp_max_batch_size = 64
     impl._compiled_bindings = set()
-    impl._fallback_scratch = {}
+    impl._scratch_by_plan = {}
     dense_mla = _FakeDenseMLA()
     impl._dense_mla = dense_mla
     return impl, dense_mla
+
+
+def test_b12x_mla_impl_keeps_configured_dcp_world_size(monkeypatch) -> None:
+    def fake_common_init(
+        self,
+        num_heads,
+        head_size,
+        scale,
+        num_kv_heads,
+        alibi_slopes,
+        sliding_window,
+        kv_cache_dtype,
+        logits_soft_cap,
+        attn_type,
+        kv_sharing_target_layer_name,
+        **mla_args,
+    ) -> None:
+        self.num_heads = num_heads
+        self.kv_lora_rank = mla_args["kv_lora_rank"]
+        self.qk_nope_head_dim = mla_args["qk_nope_head_dim"]
+        self.qk_rope_head_dim = mla_args["qk_rope_head_dim"]
+        self.qk_head_dim = mla_args["qk_head_dim"]
+        self.v_head_dim = mla_args["v_head_dim"]
+        self.scale = scale
+        self.dcp_world_size = -1
+
+    monkeypatch.setattr(b12x_mla.MLACommonImpl, "__init__", fake_common_init)
+    monkeypatch.setattr(b12x_mla, "_load_dense_mla", _FakeDenseMLA)
+    monkeypatch.setattr(
+        b12x_mla,
+        "get_current_vllm_config",
+        lambda: SimpleNamespace(
+            parallel_config=SimpleNamespace(
+                decode_context_parallel_size=8,
+                prefill_context_parallel_size=1,
+                dcp_comm_backend="a2a",
+            ),
+            scheduler_config=SimpleNamespace(max_num_batched_tokens=256),
+        ),
+    )
+
+    impl = B12xMLAImpl(
+        num_heads=6,
+        head_size=576,
+        scale=192**-0.5,
+        num_kv_heads=1,
+        alibi_slopes=None,
+        sliding_window=None,
+        kv_cache_dtype="fp8",
+        logits_soft_cap=None,
+        attn_type="decoder",
+        kv_sharing_target_layer_name=None,
+        q_lora_rank=2048,
+        kv_lora_rank=512,
+        qk_nope_head_dim=128,
+        qk_rope_head_dim=64,
+        qk_head_dim=192,
+        v_head_dim=128,
+        kv_b_proj=None,
+    )
+
+    assert impl.dcp_world_size == 8
 
 
 def test_b12x_mla_adapter_binds_common_decode_metadata(monkeypatch) -> None:
@@ -122,3 +189,94 @@ def test_b12x_mla_adapter_passes_fp8_scales(monkeypatch) -> None:
     binding = dense_mla.bindings[0]
     assert binding.q_scale is layer._q_scale
     assert binding.kv_scale is layer._k_scale
+
+
+def test_b12x_mla_compile_only_warmup_resolves_without_launch(monkeypatch) -> None:
+    impl, dense_mla = _fake_impl(monkeypatch)
+    q = torch.randn(1, 8, 576, dtype=torch.bfloat16)
+    cache = torch.randn(2, 16, 576, dtype=torch.bfloat16)
+    metadata = SimpleNamespace(
+        dense_mla_plan=_FakePlan(),
+        query_start_loc=torch.tensor([0, 1], dtype=torch.int32),
+        decode=SimpleNamespace(
+            block_table=torch.tensor([[0, 1]], dtype=torch.int32),
+            seq_lens=torch.tensor([17], dtype=torch.int32),
+        ),
+    )
+    layer = SimpleNamespace(
+        _q_scale=torch.tensor(0.25),
+        _k_scale=torch.tensor(0.5),
+    )
+
+    with b12x_compile_only_warmup():
+        output, lse = impl.forward_mqa(q, cache, metadata, layer)
+
+    assert output.shape == (1, 8, 512)
+    assert torch.count_nonzero(output) == 0
+    assert lse is None
+    assert dense_mla.compile_count == 1
+    assert dense_mla.run_count == 0
+
+
+def test_b12x_mla_adapter_gathers_and_reduces_dcp_heads(monkeypatch) -> None:
+    impl, dense_mla = _fake_impl(monkeypatch)
+    impl.num_heads = 6
+    impl.dcp_world_size = 8
+    group = SimpleNamespace(world_size=8)
+    monkeypatch.setattr("vllm.distributed.parallel_state.get_dcp_group", lambda: group)
+
+    gather_calls = []
+
+    def fake_gather(q, actual_group, **kwargs):
+        gather_calls.append((q.shape, actual_group, kwargs))
+        return torch.cat([q] * 8, dim=1)
+
+    reduce_calls = []
+
+    def fake_reduce(output, lse, actual_group, **kwargs):
+        reduce_calls.append((output.shape, lse.shape, actual_group, kwargs))
+        return output[:, :6]
+
+    monkeypatch.setattr(b12x_mla, "dcp_b12x_all_gather_heads", fake_gather)
+    monkeypatch.setattr(b12x_mla, "dcp_a2a_lse_reduce", fake_reduce)
+
+    q = torch.randn(1, 6, 576, dtype=torch.bfloat16)
+    cache = torch.randn(2, 16, 576, dtype=torch.bfloat16)
+    metadata = SimpleNamespace(
+        dense_mla_plan=_FakePlan(),
+        query_start_loc=torch.tensor([0, 1], dtype=torch.int32),
+        decode=SimpleNamespace(
+            block_table=torch.tensor([[0, 1]], dtype=torch.int32),
+            seq_lens=torch.tensor([17], dtype=torch.int32),
+        ),
+    )
+    layer = SimpleNamespace(
+        _q_scale=torch.tensor(0.25),
+        _k_scale=torch.tensor(0.5),
+    )
+
+    output, lse = impl.forward_mqa(q, cache, metadata, layer)
+
+    assert output.shape == (1, 6, 512)
+    assert lse is None
+    assert dense_mla.bindings[0].q.shape == (1, 48, 576)
+    assert gather_calls[0][0] == (1, 6, 576)
+    assert gather_calls[0][2]["output_head_dim"] == 512
+    assert reduce_calls[0][0] == (1, 48, 512)
+    assert reduce_calls[0][1] == (1, 48)
+    assert reduce_calls[0][3]["use_b12x"] is True
+
+
+def test_max_dcp_local_cache_tokens_respects_interleave() -> None:
+    config = SimpleNamespace(
+        model_config=SimpleNamespace(max_model_len=1_048_576),
+        parallel_config=SimpleNamespace(
+            decode_context_parallel_size=8,
+            cp_kv_cache_interleave_size=1,
+        ),
+    )
+    assert b12x_mla._max_dcp_local_cache_tokens(config) == 131_072
+
+    config.model_config.max_model_len = 1_048_577
+    config.parallel_config.cp_kv_cache_interleave_size = 4
+    assert b12x_mla._max_dcp_local_cache_tokens(config) == 131_076

--- a/tests/v1/attention/test_mla_backends.py
+++ b/tests/v1/attention/test_mla_backends.py
@@ -28,6 +28,7 @@ from vllm.model_executor.kernels.attention import (
 from vllm.model_executor.layers.attention import mla_attention as mla_attention_module
 from vllm.model_executor.layers.attention.mla_attention import (
     MLAAttention,
+    MLACommonMetadataBuilder,
     QueryLenSupport,
     _DecodeConcatQuantFP8,
 )
@@ -68,6 +69,26 @@ BACKENDS_TO_TEST = [
 ]
 
 DEVICE_TYPE = current_platform.device_type
+
+
+@pytest.mark.cpu_test
+def test_mla_chunked_prefill_workspace_limit(monkeypatch):
+    config = SimpleNamespace(
+        scheduler_config=SimpleNamespace(max_num_seqs=1),
+        cache_config=SimpleNamespace(block_size=16),
+        model_config=SimpleNamespace(max_model_len=1_048_576),
+    )
+    monkeypatch.setattr(
+        mla_attention_module.envs,
+        "VLLM_MLA_CHUNKED_PREFILL_WORKSPACE_SIZE",
+        32 * 1024,
+    )
+
+    workspace_size = MLACommonMetadataBuilder.determine_chunked_prefill_workspace_size(
+        config
+    )
+
+    assert workspace_size == 32 * 1024
 
 
 @pytest.mark.cpu_test

--- a/tests/v1/cudagraph/test_breakable_cudagraph.py
+++ b/tests/v1/cudagraph/test_breakable_cudagraph.py
@@ -401,6 +401,51 @@ def test_piecewise_capture_builds_fresh_metadata_for_both_passes():
     assert create_calls[0][1] is not create_calls[1][1]
 
 
+def test_compile_only_prewarm_skips_manager_full_forward(monkeypatch):
+    import vllm.envs as envs
+    from vllm.config import CUDAGraphMode
+    from vllm.v1.worker.gpu.cudagraph_utils import (
+        BatchExecutionDescriptor,
+        CudaGraphManager,
+    )
+
+    monkeypatch.setenv("VLLM_B12X_CUDAGRAPH_COMPILE_ONLY_PREWARM", "1")
+    envs.disable_envs_cache()
+    manager = CudaGraphManager.__new__(CudaGraphManager)
+    desc = BatchExecutionDescriptor(CUDAGraphMode.PIECEWISE, 1, None)
+    manager.device = torch.device("cpu")
+    manager._capture_descs = {CUDAGraphMode.PIECEWISE: [desc]}
+    manager._graphs_captured = False
+    manager.use_breakable_cg = True
+
+    create_calls = []
+    forward_calls = []
+
+    def create_forward_fn(desc_arg, warmup):
+        assert desc_arg == desc
+        create_calls.append(warmup)
+
+        def forward_fn(cg_mode):
+            forward_calls.append((warmup, cg_mode))
+
+        return forward_fn
+
+    with (
+        patch(
+            "vllm.v1.worker.gpu.cudagraph_utils.graph_capture",
+            return_value=nullcontext(),
+        ),
+        patch(
+            "vllm.v1.worker.gpu.cudagraph_utils.is_global_first_rank",
+            return_value=False,
+        ),
+    ):
+        manager.capture(create_forward_fn)
+
+    assert create_calls == [True, False]
+    assert forward_calls == [(False, CUDAGraphMode.PIECEWISE)]
+
+
 @pytest.fixture(autouse=True)
 def _reset_breakable_tls():
     """Defensively clear thread-local capture state between tests so a

--- a/tests/v1/test_kv_cache_spec_registry.py
+++ b/tests/v1/test_kv_cache_spec_registry.py
@@ -171,6 +171,10 @@ def are_uniform_specs(*specs: KVCacheSpec) -> bool:
     )
 
 
+def test_mamba_state_is_replicated_across_context_parallel_ranks():
+    assert make_spec(MambaSpec).dcp_replicated
+
+
 class TestKVCacheSpecRegistry:
     """Test the core registry functionality."""
 

--- a/tools/kimi_k3/benchmark_latent_up_projection.py
+++ b/tools/kimi_k3/benchmark_latent_up_projection.py
@@ -1,0 +1,225 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Model-free Kimi-K3 latent up-projection TP correctness/latency harness.
+
+Run on the target 16-GPU node:
+
+    torchrun --standalone --nproc-per-node=16 \
+      tools/kimi_k3/benchmark_latent_up_projection.py
+
+This allocates only one BF16 projection, not the Kimi-K3 checkpoint. It checks
+that a row-sharded up projection plus one combined routed/shared all-reduce is
+equivalent to the original replicated projection. The latency result uses NCCL
+as a structural microbenchmark; the final gate remains the full vLLM decode.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import statistics
+
+import torch
+import torch.distributed as dist
+
+
+def rms_norm(x: torch.Tensor, weight: torch.Tensor, eps: float) -> torch.Tensor:
+    variance = x.float().square().mean(dim=-1, keepdim=True)
+    return x * torch.rsqrt(variance + eps).to(x.dtype) * weight
+
+
+def replicated_step(
+    latent_partial: torch.Tensor,
+    shared_partial: torch.Tensor,
+    norm_weight: torch.Tensor,
+    full_weight: torch.Tensor,
+    aux_stream: torch.cuda.Stream,
+    eps: float,
+) -> torch.Tensor:
+    latent = latent_partial.clone()
+    dist.all_reduce(latent)
+    latent = rms_norm(latent, norm_weight, eps)
+
+    shared = shared_partial.clone()
+    main_stream = torch.cuda.current_stream()
+    shared.record_stream(aux_stream)
+    aux_stream.wait_stream(main_stream)
+    with torch.cuda.stream(aux_stream):
+        dist.all_reduce(shared)
+    routed = latent @ full_weight.T
+    main_stream.wait_stream(aux_stream)
+    return routed + shared
+
+
+def sharded_step(
+    latent_partial: torch.Tensor,
+    shared_partial: torch.Tensor,
+    norm_weight: torch.Tensor,
+    weight_shard: torch.Tensor,
+    rank: int,
+    world_size: int,
+    eps: float,
+) -> torch.Tensor:
+    latent = latent_partial.clone()
+    dist.all_reduce(latent)
+    latent = rms_norm(latent, norm_weight, eps)
+    latent_shard = latent.chunk(world_size, dim=-1)[rank]
+    result = latent_shard @ weight_shard.T
+    result.add_(shared_partial)
+    dist.all_reduce(result)
+    return result
+
+
+def benchmark(fn, warmup: int, iterations: int) -> list[float]:
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+
+    samples = []
+    for _ in range(iterations):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        fn()
+        end.record()
+        end.synchronize()
+        samples.append(start.elapsed_time(end))
+    return samples
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--tokens", type=int, default=1)
+    parser.add_argument("--latent-size", type=int, default=3584)
+    parser.add_argument("--hidden-size", type=int, default=7168)
+    parser.add_argument("--warmup", type=int, default=20)
+    parser.add_argument("--iterations", type=int, default=100)
+    args = parser.parse_args()
+
+    dist.init_process_group("nccl")
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    local_rank = int(os.environ["LOCAL_RANK"])
+    torch.cuda.set_device(local_rank)
+    device = torch.device("cuda", local_rank)
+    if args.latent_size % world_size:
+        raise ValueError("latent size must be divisible by world size")
+
+    generator = torch.Generator(device=device).manual_seed(20260803)
+    full_weight = torch.randn(
+        args.hidden_size,
+        args.latent_size,
+        dtype=torch.bfloat16,
+        device=device,
+        generator=generator,
+    )
+    shard_size = args.latent_size // world_size
+    weight_shard = full_weight[
+        :, rank * shard_size : (rank + 1) * shard_size
+    ].contiguous()
+    norm_weight = torch.randn(
+        args.latent_size,
+        dtype=torch.bfloat16,
+        device=device,
+        generator=generator,
+    )
+    rank_generator = torch.Generator(device=device).manual_seed(1000 + rank)
+    latent_partial = torch.randn(
+        args.tokens,
+        args.latent_size,
+        dtype=torch.bfloat16,
+        device=device,
+        generator=rank_generator,
+    )
+    shared_partial = torch.randn(
+        args.tokens,
+        args.hidden_size,
+        dtype=torch.bfloat16,
+        device=device,
+        generator=rank_generator,
+    )
+    aux_stream = torch.cuda.Stream()
+    eps = 1e-6
+
+    reference = replicated_step(
+        latent_partial,
+        shared_partial,
+        norm_weight,
+        full_weight,
+        aux_stream,
+        eps,
+    )
+    actual = sharded_step(
+        latent_partial,
+        shared_partial,
+        norm_weight,
+        weight_shard,
+        rank,
+        world_size,
+        eps,
+    )
+    actual_fp32 = actual.float()
+    reference_fp32 = reference.float()
+    cosine = torch.nn.functional.cosine_similarity(
+        actual_fp32.flatten(), reference_fp32.flatten(), dim=0
+    )
+    relative_l2 = (actual_fp32 - reference_fp32).norm() / reference_fp32.norm()
+    max_abs = (actual_fp32 - reference_fp32).abs().max()
+    # BF16 changes the accumulation order: the replicated GEMM accumulates
+    # all latent channels in one kernel, while TP sums 16 partial GEMMs. The
+    # structural check therefore gates on direction and relative L2 error.
+    if cosine < 0.9999 or relative_l2 > 1e-2:
+        raise AssertionError(
+            "row-sharded projection diverged from replicated reference: "
+            f"cosine={cosine.item():.8f}, relative_l2={relative_l2.item():.8f}"
+        )
+
+    replicated_samples = benchmark(
+        lambda: replicated_step(
+            latent_partial,
+            shared_partial,
+            norm_weight,
+            full_weight,
+            aux_stream,
+            eps,
+        ),
+        args.warmup,
+        args.iterations,
+    )
+    sharded_samples = benchmark(
+        lambda: sharded_step(
+            latent_partial,
+            shared_partial,
+            norm_weight,
+            weight_shard,
+            rank,
+            world_size,
+            eps,
+        ),
+        args.warmup,
+        args.iterations,
+    )
+
+    metrics = torch.tensor(
+        [
+            statistics.median(replicated_samples),
+            statistics.median(sharded_samples),
+        ],
+        dtype=torch.float64,
+        device=device,
+    )
+    dist.all_reduce(metrics, op=dist.ReduceOp.MAX)
+    if rank == 0:
+        replicated_ms, sharded_ms = metrics.tolist()
+        print("Kimi-K3 latent up-projection model-free check: PASS")
+        print(f"world_size={world_size} tokens={args.tokens}")
+        print(f"cosine={cosine.item():.8f} relative_l2={relative_l2.item():.8f}")
+        print(f"max_abs_bf16={max_abs.item():.6f}")
+        print(f"replicated median(max-rank): {replicated_ms:.6f} ms")
+        print(f"sharded median(max-rank):   {sharded_ms:.6f} ms")
+        print(f"sharded/replicated:         {sharded_ms / replicated_ms:.4f}x")
+
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/vllm/compilation/b12x_capture.py
+++ b/vllm/compilation/b12x_capture.py
@@ -3,8 +3,29 @@
 
 from collections.abc import Iterator
 from contextlib import contextmanager
+from contextvars import ContextVar
 
 import vllm.envs as envs
+
+_b12x_compile_only_warmup: ContextVar[bool] = ContextVar(
+    "b12x_compile_only_warmup",
+    default=False,
+)
+
+
+def is_b12x_compile_only_warmup() -> bool:
+    """Whether the current forward may compile but must not launch B12X compute."""
+    return _b12x_compile_only_warmup.get()
+
+
+@contextmanager
+def b12x_compile_only_warmup() -> Iterator[None]:
+    """Traverse a model to resolve exact B12X bindings without running them."""
+    token = _b12x_compile_only_warmup.set(True)
+    try:
+        yield
+    finally:
+        _b12x_compile_only_warmup.reset(token)
 
 
 def b12x_cuda_graph_prewarm_enabled() -> bool:

--- a/vllm/compilation/breakable_cudagraph.py
+++ b/vllm/compilation/breakable_cudagraph.py
@@ -34,6 +34,7 @@ import torch
 
 import vllm.envs as envs
 from vllm.compilation.b12x_capture import (
+    b12x_compile_only_warmup,
     b12x_cuda_graph_wrapper_prewarm_enabled,
     guard_b12x_kernel_resolution,
 )
@@ -383,7 +384,19 @@ class BreakableCUDAGraphWrapper:
         # pre-capture prefetches are complete and don't leak into the graph.
         get_offloader().sync_prev_onload()
 
-        if b12x_cuda_graph_wrapper_prewarm_enabled(
+        if envs.VLLM_B12X_CUDAGRAPH_COMPILE_ONLY_PREWARM:
+            # Some B12X kernels retain exact binding specializations for
+            # capture, but a full K3 eager forward here launches the routed
+            # MoE against capture-prepared workspaces and corrupts CUDA state.
+            # Let the adapters compile their exact bindings while suppressing
+            # those compute launches; ordinary kernel warmup has already run
+            # every graph-visible MoE specialization.
+            with b12x_compile_only_warmup():
+                prewarm_output = self.runnable(*args, **kwargs)
+            get_offloader().join_after_forward()
+            del prewarm_output
+            get_offloader().sync_prev_onload()
+        elif b12x_cuda_graph_wrapper_prewarm_enabled(
             is_piecewise=(
                 get_forward_context().cudagraph_runtime_mode == CUDAGraphMode.PIECEWISE
             )

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -73,6 +73,7 @@ if TYPE_CHECKING:
     VLLM_DCP_PROJECT_BEFORE_MERGE: bool = False
     VLLM_DCP_PROJECT_BEFORE_MERGE_MIN_PREFILL_TOKENS: int = 1024
     VLLM_B12X_MLA_DCP_GATHER_IN_WORKSPACE: bool = False
+    VLLM_MLA_CHUNKED_PREFILL_WORKSPACE_SIZE: int = 64 * 1024
     VLLM_DCP_A2A_MAX_TOKENS: int = 0
     VLLM_DCP_A2A_LARGE_BACKEND: Literal["ag_rs", "a2a"] = "ag_rs"
     VLLM_DCP_SHARD_DRAFT: str | None = None
@@ -1167,6 +1168,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
                 os.getenv("B12X_MLA_DCP_GATHER_IN_WORKSPACE", "0"),
             )
         )
+    ),
+    "VLLM_MLA_CHUNKED_PREFILL_WORKSPACE_SIZE": lambda: int(
+        os.getenv("VLLM_MLA_CHUNKED_PREFILL_WORKSPACE_SIZE", str(64 * 1024))
     ),
     # Token cap for the low-latency DCP A2A exchange (0 = uncapped). Batches
     # with more tokens than this bypass the one-shot A2A/B12X path, which is

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -89,6 +89,7 @@ if TYPE_CHECKING:
     VLLM_B12X_MLA_CKV_PREFETCH_WORKSPACE_MIB: int = 1024
     VLLM_MINIMAX_M3_ENABLE_TORCH_COMPILE: bool = False
     VLLM_B12X_CUDAGRAPH_PIECEWISE_PREWARM: bool = False
+    VLLM_B12X_CUDAGRAPH_COMPILE_ONLY_PREWARM: bool = False
     VLLM_B12X_MOE_FORCE_MODELOPT_PREP: bool = False
     VLLM_USE_RAY_COMPILED_DAG_CHANNEL_TYPE: Literal["auto", "nccl", "shm"] = "auto"
     VLLM_USE_RAY_COMPILED_DAG_OVERLAP_COMM: bool = False
@@ -336,6 +337,11 @@ if TYPE_CHECKING:
     VLLM_ELASTIC_EP_DRAIN_REQUESTS: bool = False
     VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS: bool = True
     VLLM_MEMORY_PROFILE_INCLUDE_ATTN: bool = False
+    VLLM_KIMI_SHARD_QKV_A: bool = False
+    VLLM_KIMI_SHARD_ROUTED_DOWN_PROJ: bool = False
+    VLLM_KIMI_SHARD_ROUTED_UP_PROJ: bool = False
+    VLLM_KIMI_SHARD_ROUTER: bool = False
+    VLLM_KIMI_LOG_CONSTRUCTION_MEMORY: bool = False
     VLLM_NIXL_EP_MAX_NUM_RANKS: int = 32
     VLLM_XPU_ENABLE_XPU_GRAPH: bool = False
     VLLM_XPU_USE_SAMPLER_KERNEL: bool = True
@@ -1239,6 +1245,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # capture, so this remains opt-in for debugging kernels that still need it.
     "VLLM_B12X_CUDAGRAPH_PIECEWISE_PREWARM": lambda: bool(
         int(os.getenv("VLLM_B12X_CUDAGRAPH_PIECEWISE_PREWARM", "0"))
+    ),
+    # Resolve exact B12X graph bindings without launching a full eager model
+    # forward. Required by K3's breakable graph path, where that eager forward
+    # uses capture-prepared workspaces and can corrupt CUDA state.
+    "VLLM_B12X_CUDAGRAPH_COMPILE_ONLY_PREWARM": lambda: bool(
+        int(os.getenv("VLLM_B12X_CUDAGRAPH_COMPILE_ONLY_PREWARM", "0"))
     ),
     # Force DeepSeek V4 native MXFP4/E8M0 MoE weights through b12x's
     # native/modelopt-layout W4A16 prep path.
@@ -2259,6 +2271,28 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_MEMORY_PROFILE_INCLUDE_ATTN": lambda: bool(
         int(os.getenv("VLLM_MEMORY_PROFILE_INCLUDE_ATTN", "0"))
     ),
+    # TP-shard Kimi's merged MLA q_a/kv_a projection and reconstruct its two
+    # logical outputs after one small all-gather per dense MLA layer.
+    "VLLM_KIMI_SHARD_QKV_A": lambda: bool(int(os.getenv("VLLM_KIMI_SHARD_QKV_A", "0"))),
+    # TP-shard Kimi-K3's BF16 latent-MoE down projection and gather its small
+    # latent output. This preserves the replicated-up-projection fast tail.
+    "VLLM_KIMI_SHARD_ROUTED_DOWN_PROJ": lambda: bool(
+        int(os.getenv("VLLM_KIMI_SHARD_ROUTED_DOWN_PROJ", "0"))
+    ),
+    # TP-shard Kimi-K3's BF16 latent-MoE up projection. The latent runner
+    # reduces the latent state, projects a local input shard, adds the shared
+    # expert partial, then reduces the combined hidden state once.
+    "VLLM_KIMI_SHARD_ROUTED_UP_PROJ": lambda: bool(
+        int(os.getenv("VLLM_KIMI_SHARD_ROUTED_UP_PROJ", "0"))
+    ),
+    "VLLM_KIMI_SHARD_ROUTER": lambda: bool(
+        int(os.getenv("VLLM_KIMI_SHARD_ROUTER", "0"))
+    ),
+    # Log per-layer CUDA allocation while constructing Kimi-K3. This is a
+    # model-free diagnostic: it runs before any checkpoint weight is read.
+    "VLLM_KIMI_LOG_CONSTRUCTION_MEMORY": lambda: bool(
+        int(os.getenv("VLLM_KIMI_LOG_CONSTRUCTION_MEMORY", "0"))
+    ),
     # NIXL EP environment variables
     "VLLM_NIXL_EP_MAX_NUM_RANKS": lambda: int(
         os.getenv("VLLM_NIXL_EP_MAX_NUM_RANKS", "32")
@@ -2305,7 +2339,6 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Prebuilt exllamav3 extension location and torch-ABI compatibility shim.
     "VLLM_EXL3_EXT_PATH": lambda: os.getenv("VLLM_EXL3_EXT_PATH"),
     "VLLM_EXL3_ABI_SHIM": lambda: os.getenv("VLLM_EXL3_ABI_SHIM"),
-
 }
 
 

--- a/vllm/model_executor/layers/activation.py
+++ b/vllm/model_executor/layers/activation.py
@@ -3,6 +3,7 @@
 """Custom activation functions."""
 
 import math
+from contextlib import suppress
 
 import torch
 import torch.nn as nn
@@ -21,6 +22,14 @@ from vllm.triton_utils import tl, triton
 from vllm.utils.collection_utils import LazyDict
 
 logger = init_logger(__name__)
+
+
+def ensure_kimi_k3_activation_ops() -> bool:
+    """Load the SiTU companion when the preserved main extension is old."""
+    if not hasattr(torch.ops._C, "situ_and_mul"):
+        with suppress(ImportError):
+            import vllm._kimi_k3_activation_ops  # noqa: F401
+    return hasattr(torch.ops._C, "situ_and_mul")
 
 
 @triton.jit
@@ -178,7 +187,13 @@ class SituAndMul(CustomOp):
         self.beta = float(beta)
         self.linear_beta = None if linear_beta is None else float(linear_beta)
         if current_platform.is_cuda_alike():
-            self.op = torch.ops._C.situ_and_mul
+            ensure_kimi_k3_activation_ops()
+            self.op = getattr(torch.ops._C, "situ_and_mul", None)
+            if self.op is None:
+                logger.warning_once(
+                    "The loaded vLLM extension predates _C.situ_and_mul; "
+                    "using the numerically equivalent PyTorch SiTU fallback."
+                )
 
     def forward_native(self, x: torch.Tensor) -> torch.Tensor:
         d = x.shape[-1] // 2
@@ -190,6 +205,8 @@ class SituAndMul(CustomOp):
         return (gate * up).to(x.dtype)
 
     def forward_cuda(self, x: torch.Tensor) -> torch.Tensor:
+        if self.op is None:
+            return self.forward_native(x)
         # Fused CUDA kernel: writes straight to `out`, no fp32 temporaries.
         # linear_beta<=0 signals "unset" to the kernel (up passed through).
         d = x.shape[-1] // 2

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -2834,6 +2834,12 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
         scheduler_config = vllm_config.scheduler_config
         cache_config = vllm_config.cache_config
         model_config = vllm_config.model_config
+        workspace_limit = envs.VLLM_MLA_CHUNKED_PREFILL_WORKSPACE_SIZE
+        if workspace_limit <= 0:
+            raise ValueError(
+                "VLLM_MLA_CHUNKED_PREFILL_WORKSPACE_SIZE must be positive, "
+                f"got {workspace_limit}"
+            )
 
         chunked_prefill_workspace_size = min(
             # Try for 8 full length request or at least 4 pages per-request
@@ -2841,15 +2847,15 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
                 8 * model_config.max_model_len,
                 4 * scheduler_config.max_num_seqs * cache_config.block_size,
             ),
-            # For long-context models try not to over-allocate limiting
-            # kv-cache space, limiting it to 64k tokens,
+            # For long-context models avoid over-allocating KV-cache space by
+            # applying the configured workspace limit (64k tokens by default),
             # which would result in the workspace being:
             #   2*(576)*(64*1024) = 144mb
             # (assuming 576 MLA head dim, and fp16)
             # which would result in up-projected context being
             #   2*(192*128)*(64*1024) = 3gb
             # (assuming 192 QK head dim, 128 heads, and fp16)
-            64 * 1024,
+            workspace_limit,
         )
 
         # Enforce that we enough for at least 1 page per request

--- a/vllm/model_executor/layers/fused_moe/b12x_moe.py
+++ b/vllm/model_executor/layers/fused_moe/b12x_moe.py
@@ -13,6 +13,7 @@ import torch
 
 import vllm.envs as envs
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
+from vllm.compilation.b12x_capture import is_b12x_compile_only_warmup
 from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 from vllm.model_executor.layers.fused_moe.config import (
@@ -1029,6 +1030,7 @@ class B12xExperts(mk.FusedMoEExpertsModular):
     def _supports_activation(activation: MoEActivation) -> bool:
         return activation in (
             MoEActivation.SILU,
+            MoEActivation.SITU,
             MoEActivation.SWIGLUOAI,
             MoEActivation.SWIGLUOAI_UNINTERLEAVE,
         )
@@ -1309,8 +1311,15 @@ class B12xExperts(mk.FusedMoEExpertsModular):
         layer: torch.nn.Module,
         *,
         token_counts: Iterable[int],
+        direct_token_counts: Iterable[int] = (),
     ) -> int:
-        """Compile one representative of every planned dynamic MoE regime."""
+        """Compile every serving and graph-visible B12X MoE regime.
+
+        ``token_counts`` probes the larger dynamic regimes.  Small W4A16
+        decode launches need their exact M specialization, so graph-visible
+        token counts are supplied separately instead of being promoted to a
+        dynamic warmup size.
+        """
         meta = self._warmup_metadata(layer)
         if meta is None:
             return 0
@@ -1337,6 +1346,24 @@ class B12xExperts(mk.FusedMoEExpertsModular):
         # execution plan so large prefill regimes are compiled without
         # allocating max-batch inputs.
         launch_tokens: dict[tuple[Any, ...], int] = {}
+        for tokens in sorted(set(int(count) for count in direct_token_counts)):
+            if tokens <= 0:
+                continue
+            launch_plan = _plan_b12x_moe_execution(
+                tokens=tokens,
+                topk=meta.topk,
+                device=meta.device,
+                quant_mode=meta.quant_mode,
+                experts=prepared,
+                apply_router_weight_on_input=meta.apply_router_weight_on_input,
+                swiglu_limit=meta.swiglu_limit,
+                swiglu_alpha=meta.swiglu_alpha,
+                swiglu_beta=meta.swiglu_beta,
+            )
+            launch_tokens.setdefault(
+                _b12x_moe_warmup_plan_signature(launch_plan),
+                tokens,
+            )
         for requested_tokens in sorted(set(int(count) for count in token_counts)):
             tokens = _dynamic_moe_warmup_tokens(
                 topk=meta.topk,
@@ -1557,6 +1584,30 @@ class B12xExperts(mk.FusedMoEExpertsModular):
             swiglu_limit = None
         topk_ids = _normalize_b12x_moe_topk_ids(topk_ids)
         topk_weights = _normalize_b12x_moe_topk_weights(topk_weights)
+        if is_b12x_compile_only_warmup():
+            # Exact graph-visible MoE kernels are compiled by
+            # warmup_dynamic_launches. Do not launch them again while walking
+            # the model solely to resolve attention bindings.
+            output.zero_()
+            return
+        if os.environ.get("VLLM_KIMI_DEBUG_FINITE") == "1":
+            torch.cuda.synchronize()
+            ids_min = int(topk_ids.min().item())
+            ids_max = int(topk_ids.max().item())
+            inputs_ok = bool(torch.isfinite(hidden_states).all().item())
+            weights_ok = bool(torch.isfinite(topk_weights).all().item())
+            if (
+                not inputs_ok
+                or not weights_ok
+                or ids_min < 0
+                or ids_max >= num_experts
+            ):
+                raise RuntimeError(
+                    "B12X MoE received invalid routed inputs: "
+                    f"hidden_finite={inputs_ok}, weights_finite={weights_ok}, "
+                    f"expert_id_range=[{ids_min}, {ids_max}], "
+                    f"num_experts={num_experts}"
+                )
         plan = _plan_b12x_moe_fp4_scratch(
             tokens=int(hidden_states.shape[0]),
             topk=int(topk_ids.shape[1]),
@@ -1610,8 +1661,9 @@ def warmup_b12x_moe_dynamic(
     *,
     max_tokens: int,
     token_counts: Iterable[int] = (),
+    direct_token_counts: Iterable[int] = (),
 ) -> int:
-    """Warm unique b12x dynamic MoE planner regimes in a loaded model."""
+    """Warm unique B12X MoE planner regimes in a loaded model."""
     candidates = _b12x_moe_warmup_token_counts(
         max_tokens=max_tokens,
         token_counts=token_counts,
@@ -1635,6 +1687,7 @@ def warmup_b12x_moe_dynamic(
         warmed += fused_experts.warmup_dynamic_launches(
             routed_experts,
             token_counts=candidates,
+            direct_token_counts=direct_token_counts,
         )
 
     if warmed:

--- a/vllm/model_executor/layers/fused_moe/runner/latent_moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/latent_moe_runner.py
@@ -14,8 +14,20 @@ from .moe_runner import MoERunner, _unpack
 logger = init_logger(__name__)
 
 
+def _project_sharded_up_and_reduce(
+    fused_latent: torch.Tensor,
+    shared_output: torch.Tensor,
+    up_proj: torch.nn.Module,
+) -> torch.Tensor:
+    """Project a TP latent slice and reduce routed+shared partials together."""
+    routed_output = up_proj(fused_latent)
+    if isinstance(routed_output, tuple):
+        routed_output = routed_output[0]
+    return tensor_model_parallel_all_reduce(routed_output.add_(shared_output))
+
+
 class LatentMoERunner(MoERunner):
-    """MoE runner for latent MoE with a replicated routed up-projection.
+    """MoE runner for latent MoE routed output projections.
 
     Fused path (tp>1, un-reduced combine output, shared expert, no SP):
     concatenates the un-reduced latent partial (dim d) and the un-reduced
@@ -33,11 +45,21 @@ class LatentMoERunner(MoERunner):
         self,
         *args,
         enable_k3_latent_moe_tail_fusion: bool = False,
+        up_projection_is_sharded: bool = False,
         **kwargs,
     ) -> None:
         super().__init__(*args, **kwargs)
+        self.up_projection_is_sharded = up_projection_is_sharded
         self.enable_k3_latent_moe_tail_fusion = enable_k3_latent_moe_tail_fusion
         use_fused_path = self._use_fused_path()
+        if self.up_projection_is_sharded and not use_fused_path:
+            raise ValueError(
+                "A TP-sharded latent up projection requires the fused latent "
+                "MoE path (TP>1, shared experts, and no sequence parallelism)."
+            )
+        if self.up_projection_is_sharded:
+            # The tail op consumes a full replicated up-projection weight.
+            self.enable_k3_latent_moe_tail_fusion = False
         if (
             self.enable_k3_latent_moe_tail_fusion
             and use_fused_path
@@ -170,6 +192,26 @@ class LatentMoERunner(MoERunner):
         transform = self.routed_output_transform
         assert transform is not None
 
+        if self.up_projection_is_sharded:
+            fused_latent = None
+            if transform.norm is not None:
+                fused_latent = self.allreduce_norm_latent_out(
+                    fused_output, transform.norm
+                )
+            else:
+                fused_latent = tensor_model_parallel_all_reduce(fused_output)
+
+            # RowParallelLinear slices the reconstructed latent input and
+            # emits an unreduced hidden-width partial. Shared experts already
+            # emit the matching TP partial, so reduce their sum only once.
+            result = _project_sharded_up_and_reduce(
+                fused_latent, shared_output, transform.up_proj
+            )
+            result = self._maybe_reduce_final_output(
+                result, og_hidden_dim_post_xform, output_is_reduced=True
+            )
+            return self._maybe_add_zero_expert_output(result)
+
         if self.enable_k3_latent_moe_tail_fusion:
             op = self._k3_latent_moe_tail_op
             if 0 < fused_output.shape[0] <= op.contract.max_num_tokens:
@@ -222,7 +264,7 @@ class LatentMoERunner(MoERunner):
         self,
         hidden_states: torch.Tensor,
         norm: RMSNorm,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
+    ) -> torch.Tensor:
         """All-reduce + add residual + (standard) RMSNorm, fused via flashinfer."""
         from vllm.model_executor.layers.fused_allreduce_gemma_rms_norm import (
             _AR_RESIDUAL_RMS_NORM,

--- a/vllm/model_executor/layers/mamba/abstract.py
+++ b/vllm/model_executor/layers/mamba/abstract.py
@@ -68,6 +68,9 @@ class MambaBase(AttentionLayerBase):
             shapes=tuple(self.get_state_shape()),
             dtypes=self.get_state_dtype(),
             block_size=mamba_block_size,
+            # Recurrent state is TP-sharded by heads, but every DCP rank must
+            # advance its local head state for every token.
+            dcp_replicated=True,
             page_size_padded=page_size_padded,
             mamba_type=self.mamba_type,
             mamba_cache_mode=vllm_config.cache_config.mamba_cache_mode,

--- a/vllm/model_executor/model_loader/default_loader.py
+++ b/vllm/model_executor/model_loader/default_loader.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import dataclasses
 import glob
+import json
 import os
 import time
 from collections.abc import Generator, Iterable
@@ -266,6 +267,16 @@ class DefaultModelLoader(BaseModelLoader):
             source.allow_patterns_overrides,
             source.weight_name_prefixes,
         )
+        indexed_tensor_files: dict[str, str] | None = None
+        if use_safetensors:
+            index_path = os.path.join(hf_folder, SAFE_WEIGHTS_INDEX_NAME)
+            if os.path.isfile(index_path):
+                with open(index_path, encoding="utf-8") as index_handle:
+                    weight_map = json.load(index_handle)["weight_map"]
+                indexed_tensor_files = {
+                    name: os.path.abspath(os.path.join(hf_folder, filename))
+                    for name, filename in weight_map.items()
+                }
         if self.load_config.load_format == "npcache":
             # Currently np_cache only support *.bin checkpoints
             assert use_safetensors is False
@@ -288,6 +299,7 @@ class DefaultModelLoader(BaseModelLoader):
                     hf_weights_files,
                     self.load_config.use_tqdm_on_load,
                     weight_name_prefixes=source.weight_name_prefixes,
+                    indexed_tensor_files=indexed_tensor_files,
                 )
             else:
                 if extra_config.get("enable_multithread_load"):

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -1205,9 +1205,21 @@ def instanttensor_weights_iterator(
     hf_weights_files: list[str],
     use_tqdm_on_load: bool,
     weight_name_prefixes: Sequence[str] | None = None,
+    *,
+    indexed_tensor_files: dict[str, str] | None = None,
 ) -> Generator[tuple[str, torch.Tensor], None, None]:
     """Iterate over the weights in the model safetensor files
-    using instanttensor library."""
+    using instanttensor library.
+
+    ``InstantTensor.safe_open`` normally streams every physical tensor in its
+    input files. That is incorrect and unnecessarily expensive for composed
+    checkpoints, where the final safetensors index may remap a tensor to an
+    overlay shard while leaving a stale copy in a base shard. When an index
+    is available, restrict InstantTensor's ordered metadata and C++ I/O layout
+    to the indexed byte ranges before opening the loader. Consecutive selected
+    tensors are coalesced into one range; disjoint ranges reuse the same file
+    as independent loader inputs, so skipped payload bytes are never read.
+    """
     try:
         import instanttensor
     except ImportError as e:
@@ -1228,37 +1240,222 @@ def instanttensor_weights_iterator(
 
     device = current_platform.current_device()
 
-    # copy=True yields tensors that own their memory, staying valid after the
-    # context exits or InstantTensor reuses its buffer.
-    with instanttensor.safe_open(
-        hf_weights_files,
+    configured_buffer_size = os.environ.get("INSTANTTENSOR_BUFFER_SIZE")
+    max_gpu_tensor_size = None
+    if configured_buffer_size is not None:
+        try:
+            max_gpu_tensor_size = int(configured_buffer_size)
+        except ValueError as e:
+            raise ValueError(
+                "INSTANTTENSOR_BUFFER_SIZE must be an integer number of bytes"
+            ) from e
+        if max_gpu_tensor_size <= 0:
+            raise ValueError("INSTANTTENSOR_BUFFER_SIZE must be greater than zero")
+
+    restrict_before_io = (
+        indexed_tensor_files is not None
+        or bool(weight_name_prefixes)
+        or max_gpu_tensor_size is not None
+    )
+    instant_open = instanttensor.safe_open(
+        list(hf_weights_files),
         framework="pt",
         device=device,
         process_group=process_group,
-        copy=True,
-    ) as f:
-        # Track bytes so the bar reports load throughput (GB/s).
-        pbar = tqdm(
-            total=f.total_tensor_size,
-            desc="Loading safetensors using InstantTensor loader",
-            disable=not enable_tqdm(use_tqdm_on_load),
-            bar_format=_BAR_FORMAT,
-            position=tqdm._get_free_pos(),
-            unit="B",
-            unit_scale=True,
-            unit_divisor=1024,
-            mininterval=1.0,
+        load_now=not restrict_before_io,
+        # Model weight loaders consume and copy every yielded tensor before
+        # requesting the next one. A second owning clone here only doubles
+        # device traffic and transient memory. Our InstantTensor build records
+        # a consumer-stream event before reusing its ring-buffer storage.
+        copy=False,
+    )
+    cpu_fallback_weights: list[tuple[str, str]] = []
+    if restrict_before_io:
+        cpu_fallback_weights = _restrict_instanttensor_to_selected_ranges(
+            instant_open,
+            indexed_tensor_files=indexed_tensor_files,
+            weight_name_prefixes=weight_name_prefixes,
+            max_tensor_size=max_gpu_tensor_size,
         )
-        try:
-            for name, tensor in f.tensors():
-                pbar.update(tensor.numel() * tensor.element_size())
+
+    if instant_open.ordered_tensor_metadatas:
+        with instant_open as f:
+            for name, tensor in tqdm(
+                f.tensors(),
+                desc="Loading safetensors using InstantTensor loader",
+                disable=not enable_tqdm(use_tqdm_on_load),
+                bar_format=_BAR_FORMAT,
+                position=tqdm._get_free_pos(),
+                total=len(f.keys()),
+                mininterval=1.0,
+            ):
                 if weight_name_prefixes and not _matches_weight_name_prefixes(
                     name, weight_name_prefixes
                 ):
                     continue
                 yield name, tensor
-        finally:
-            pbar.close()
+            # A generator frame retains its last loop value. Drop the final
+            # DLPack view before closing InstantTensor so the ring-buffer
+            # allocation cannot outlive the streaming phase.
+            del tensor
+
+    if cpu_fallback_weights:
+        assert max_gpu_tensor_size is not None
+        logger.info_once(
+            "Loading %d tensors larger than the %d-byte InstantTensor ring "
+            "through CPU safetensors",
+            len(cpu_fallback_weights),
+            max_gpu_tensor_size,
+        )
+        fallback_by_file: dict[str, list[str]] = defaultdict(list)
+        for name, filename in cpu_fallback_weights:
+            fallback_by_file[filename].append(name)
+        for filename, names in fallback_by_file.items():
+            with safe_open(filename, framework="pt", device="cpu") as fallback_file:
+                for name in names:
+                    yield name, fallback_file.get_tensor(name)
+
+
+def _restrict_instanttensor_to_selected_ranges(
+    instant_open: Any,
+    *,
+    indexed_tensor_files: dict[str, str] | None,
+    weight_name_prefixes: Sequence[str] | None,
+    max_tensor_size: int | None = None,
+) -> list[tuple[str, str]]:
+    """Replace an unopened InstantTensor layout with selected physical ranges.
+
+    InstantTensor 0.1.9 exposes the metadata and offset arrays used by its C++
+    loader. The C++ API accepts repeated filenames, which lets each contiguous
+    selected run become a separate logical input without copying or repacking
+    the checkpoint. Keep this adapter strict so an upstream API/layout change
+    fails before any weight I/O instead of silently loading the wrong tensor.
+    """
+    required_attrs = (
+        "filename",
+        "ordered_tensor_metadatas",
+        "tensor_offsets",
+        "tensor_sizes",
+        "total_tensor_size",
+        "tensor_name_to_index",
+        "loader_handle",
+        "_determine_buffer_size",
+    )
+    missing = [name for name in required_attrs if not hasattr(instant_open, name)]
+    if missing:
+        raise RuntimeError(
+            "Installed InstantTensor does not expose the metadata layout needed "
+            f"for index-aware loading (missing: {', '.join(missing)})"
+        )
+    if instant_open.loader_handle is not None:
+        raise RuntimeError("InstantTensor selection must be applied before opening I/O")
+
+    filenames = list(instant_open.filename)
+    metadata = list(instant_open.ordered_tensor_metadatas)
+    offsets = list(instant_open.tensor_offsets)
+    selected_filenames: list[str] = []
+    selected_metadata: list[tuple[str, dict[str, object]]] = []
+    selected_offsets: list[tuple[int, int]] = []
+    cpu_fallback_weights: list[tuple[str, str]] = []
+    metadata_pos = 0
+    offset_pos = 0
+
+    for filename in filenames:
+        filename_abs = os.path.abspath(filename)
+        with safe_open(filename, framework="pt") as physical_file:
+            physical_names = list(physical_file.offset_keys())
+        tensor_count = len(physical_names)
+        file_metadata = metadata[metadata_pos : metadata_pos + tensor_count]
+        file_offsets = offsets[offset_pos : offset_pos + tensor_count + 1]
+        if len(file_metadata) != tensor_count or len(file_offsets) != tensor_count + 1:
+            raise RuntimeError(
+                "InstantTensor metadata/offset count does not match safetensors "
+                f"header for {filename}"
+            )
+        metadata_names = [name for name, _ in file_metadata]
+        if metadata_names != physical_names:
+            raise RuntimeError(
+                "InstantTensor tensor order does not match safetensors offset order "
+                f"for {filename}"
+            )
+
+        keep = []
+        for item_index, name in enumerate(physical_names):
+            indexed_here = indexed_tensor_files is None or (
+                indexed_tensor_files.get(name) == filename_abs
+            )
+            prefix_matches = not weight_name_prefixes or _matches_weight_name_prefixes(
+                name, weight_name_prefixes
+            )
+            selected_here = indexed_here and prefix_matches
+            tensor_size = int(file_offsets[item_index + 1][1]) - int(
+                file_offsets[item_index][1]
+            )
+            use_cpu_fallback = (
+                selected_here
+                and max_tensor_size is not None
+                and tensor_size > max_tensor_size
+            )
+            keep.append(selected_here and not use_cpu_fallback)
+            if use_cpu_fallback:
+                cpu_fallback_weights.append((name, filename))
+
+        run_start = 0
+        while run_start < tensor_count:
+            while run_start < tensor_count and not keep[run_start]:
+                run_start += 1
+            if run_start == tensor_count:
+                break
+            run_end = run_start + 1
+            while run_end < tensor_count and keep[run_end]:
+                run_end += 1
+
+            logical_file_index = len(selected_filenames)
+            selected_filenames.append(filename)
+            selected_metadata.extend(file_metadata[run_start:run_end])
+            selected_offsets.extend(
+                (logical_file_index, int(file_offsets[idx][1]))
+                for idx in range(run_start, run_end)
+            )
+            selected_offsets.append((logical_file_index, int(file_offsets[run_end][1])))
+            run_start = run_end
+
+        metadata_pos += tensor_count
+        offset_pos += tensor_count + 1
+
+    if metadata_pos != len(metadata) or offset_pos != len(offsets):
+        raise RuntimeError(
+            "InstantTensor layout contains unaccounted metadata or offsets"
+        )
+    selected_names = [name for name, _ in selected_metadata]
+    if len(selected_names) != len(set(selected_names)):
+        raise RuntimeError(
+            "InstantTensor index-aware selection still contains duplicate tensor names"
+        )
+    selected_sizes = [
+        int(item["data_offsets"][1]) - int(item["data_offsets"][0])
+        for _, item in selected_metadata
+    ]
+    fallback_names = [name for name, _ in cpu_fallback_weights]
+    if len(fallback_names) != len(set(fallback_names)):
+        raise RuntimeError(
+            "InstantTensor CPU fallback selection contains duplicate tensor names"
+        )
+
+    instant_open.filename = selected_filenames
+    instant_open.ordered_tensor_metadatas = selected_metadata
+    instant_open.tensor_name_to_index = {
+        name: idx for idx, name in enumerate(selected_names)
+    }
+    instant_open.tensor_offsets = selected_offsets
+    instant_open.tensor_sizes = selected_sizes
+    instant_open.total_tensor_size = sum(selected_sizes)
+    # Recompute the ring buffer against selected tensors and their I/O layout.
+    if selected_metadata:
+        instant_open._determine_buffer_size(None)
+    elif not cpu_fallback_weights:
+        raise RuntimeError("InstantTensor index/prefix selection matched no tensors")
+    return cpu_fallback_weights
 
 
 def pt_weights_iterator(

--- a/vllm/model_executor/warmup/kernel_warmup.py
+++ b/vllm/model_executor/warmup/kernel_warmup.py
@@ -210,6 +210,9 @@ def _warmup_b12x_dcp_a2a(worker: "Worker") -> int:
     from vllm.models.deepseek_v4.nvidia.b12x import (
         DeepseekV4B12xMLAAttention,
     )
+    from vllm.models.kimi_k3.nvidia.mla import (
+        MultiHeadLatentAttention as KimiK3MLAAttention,
+    )
     from vllm.v1.attention.ops.dcp_alltoall import warmup_b12x_dcp_a2a
 
     model = worker.get_model()
@@ -234,6 +237,14 @@ def _warmup_b12x_dcp_a2a(worker: "Worker") -> int:
             device = next(module.parameters()).device
             total_heads = int(module.num_heads) * dcp_world_size
             query_head_dim = int(module.kv_lora_rank + module.qk_rope_head_dim)
+            output_head_dim = int(module.kv_lora_rank)
+        elif (
+            isinstance(module, KimiK3MLAAttention)
+            and module.attn_backend.get_name() == "B12X_MLA"
+        ):
+            device = next(module.parameters()).device
+            total_heads = int(module.num_local_heads) * dcp_world_size
+            query_head_dim = int(module.head_size)
             output_head_dim = int(module.kv_lora_rank)
         else:
             continue
@@ -412,6 +423,7 @@ def kernel_warmup(worker: "Worker", *, process_local_only: bool = False) -> bool
         worker.get_model(),
         max_tokens=max(moe_token_counts),
         token_counts=moe_token_counts,
+        direct_token_counts=(1, *cudagraph_capture_sizes),
     )
 
     minimax_m3_msa_warmup(worker)

--- a/vllm/models/kimi_k3/nvidia/kda.py
+++ b/vllm/models/kimi_k3/nvidia/kda.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from collections.abc import Callable
+from contextlib import suppress
 
 import torch
 from einops import rearrange
@@ -50,6 +51,20 @@ from vllm.v1.attention.backend import AttentionBackend
 logger = init_logger(__name__)
 
 _KDA_GATE_LOGBOUND_MIN = -5.0
+_KIMI_K3_KDA_OPS_LOAD_ATTEMPTED = False
+
+
+def ensure_fused_kda_decode_op() -> bool:
+    """Load HH's small decode companion when the main image predates it."""
+    global _KIMI_K3_KDA_OPS_LOAD_ATTEMPTED
+    if hasattr(torch.ops._C, "fused_kda_decode"):
+        return True
+    if not _KIMI_K3_KDA_OPS_LOAD_ATTEMPTED:
+        _KIMI_K3_KDA_OPS_LOAD_ATTEMPTED = True
+        # Keep the upstream fallback usable on unsupported platforms.
+        with suppress(ImportError):
+            import vllm._kimi_k3_kda_ops  # noqa: F401
+    return hasattr(torch.ops._C, "fused_kda_decode")
 
 
 def a_log_weight_loader(
@@ -140,6 +155,7 @@ def is_fused_kda_decode_supported(
     input_dtype: torch.dtype,
     conv_state_dtype: torch.dtype,
 ) -> bool:
+    fused_op_available = ensure_fused_kda_decode_op()
     if (
         num_heads not in (12, 24, 48, 96)
         or head_dim != 128
@@ -148,7 +164,7 @@ def is_fused_kda_decode_supported(
         or input_dtype != torch.bfloat16
         or conv_state_dtype != torch.bfloat16
         or is_conv_state_dim_first()
-        or not hasattr(torch.ops._C, "fused_kda_decode")
+        or not fused_op_available
     ):
         return False
     # SM90 is architecture-specific; SM10x and SM12x use family binaries.

--- a/vllm/models/kimi_k3/nvidia/mla.py
+++ b/vllm/models/kimi_k3/nvidia/mla.py
@@ -24,8 +24,9 @@ KV cache, and absorbs ``kv_b_proj`` into ``W_UK_T`` / ``W_UV`` -- mirroring the
 K3 specifics: optional rotary embedding (disabled for the target model's NoPE
 layers, enabled for DSpark) and an optional sigmoid output gate (``g_proj``).
 
-Out of scope (extension points, not wired here): context parallelism (DCP/PCP),
-sparse/indexer MLA, and the ROCm/aiter fp8/fp4 BMM fast paths.
+Out of scope (extension points, not wired here): prefill context parallelism
+(PCP), sparse/indexer MLA, and the ROCm/aiter fp8/fp4 BMM fast paths. Decode
+context parallelism is implemented by the native B12X dense MLA backend.
 """
 
 import math
@@ -34,9 +35,13 @@ from typing import TYPE_CHECKING, cast
 import torch
 from torch import nn
 
+import vllm.envs as envs
 from vllm.compilation.breakable_cudagraph import eager_break_during_capture
 from vllm.config import CacheConfig, VllmConfig, get_current_vllm_config
-from vllm.distributed import get_tensor_model_parallel_world_size
+from vllm.distributed import (
+    get_tensor_model_parallel_world_size,
+    tensor_model_parallel_all_gather,
+)
 from vllm.forward_context import get_forward_context
 from vllm.logger import init_logger
 from vllm.model_executor.layers.attention.attention import (
@@ -97,6 +102,67 @@ _GATE_MULTI_STREAM_TOKEN_THRESHOLD = 512
 def _gate_sigmoid_mul(attn_out: torch.Tensor, gate: torch.Tensor) -> torch.Tensor:
     """Apply the sigmoid output gate to a precomputed ``g_proj`` projection."""
     return attn_out * gate.sigmoid()
+
+
+def _restore_merged_output_order(
+    rank_major_output: torch.Tensor,
+    output_sizes: list[int],
+    tp_size: int,
+) -> torch.Tensor:
+    """Convert ``[rank0(a,b), rank1(a,b), ...]`` to ``[all_a, all_b]``."""
+    if tp_size == 1:
+        return rank_major_output
+    if any(size % tp_size for size in output_sizes):
+        raise ValueError(
+            f"Merged output sizes {output_sizes} must be divisible by TP={tp_size}"
+        )
+    local_sizes = [size // tp_size for size in output_sizes]
+    local_total = sum(local_sizes)
+    expected_width = local_total * tp_size
+    if rank_major_output.shape[-1] != expected_width:
+        raise ValueError(
+            "Unexpected gathered merged projection width: "
+            f"got {rank_major_output.shape[-1]}, expected {expected_width}"
+        )
+    rank_major = rank_major_output.unflatten(-1, (tp_size, local_total))
+    logical_local_shards = rank_major.split(local_sizes, dim=-1)
+    return torch.cat(
+        [shards.flatten(-2) for shards in logical_local_shards],
+        dim=-1,
+    )
+
+
+class KimiShardedMergedColumnParallelLinear(MergedColumnParallelLinear):
+    """Merged column projection with one gather and logical-shard reorder."""
+
+    def __init__(
+        self,
+        input_size: int,
+        output_sizes: list[int],
+        *,
+        quant_config: QuantizationConfig | None,
+        prefix: str,
+    ) -> None:
+        super().__init__(
+            input_size,
+            output_sizes,
+            bias=False,
+            gather_output=False,
+            quant_config=quant_config,
+            prefix=prefix,
+        )
+
+    def forward(self, x: torch.Tensor):
+        output_parallel, output_bias = super().forward(x)
+        if self.tp_size == 1:
+            return output_parallel, output_bias
+        rank_major_output = tensor_model_parallel_all_gather(output_parallel)
+        output = _restore_merged_output_order(
+            rank_major_output,
+            self.output_sizes,
+            self.tp_size,
+        )
+        return output, output_bias
 
 
 class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
@@ -184,14 +250,26 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
             # the low-rank latents are shared across TP ranks; TP splitting
             # happens at q_b_proj / kv_b_proj. Checkpoint weights ``q_a_proj``
             # and ``kv_a_proj_with_mqa`` map onto shards 0 and 1 respectively.
-            self.fused_qkv_a_proj = MergedColumnParallelLinear(
-                self.hidden_size,
-                [self.q_lora_rank, self.kv_lora_rank + self.qk_rope_head_dim],
-                bias=False,
-                quant_config=quant_config,
-                prefix=f"{prefix}.fused_qkv_a_proj",
-                disable_tp=True,
-            )
+            qkv_a_output_sizes = [
+                self.q_lora_rank,
+                self.kv_lora_rank + self.qk_rope_head_dim,
+            ]
+            if envs.VLLM_KIMI_SHARD_QKV_A and tp_size > 1:
+                self.fused_qkv_a_proj = KimiShardedMergedColumnParallelLinear(
+                    self.hidden_size,
+                    qkv_a_output_sizes,
+                    quant_config=quant_config,
+                    prefix=f"{prefix}.fused_qkv_a_proj",
+                )
+            else:
+                self.fused_qkv_a_proj = MergedColumnParallelLinear(
+                    self.hidden_size,
+                    qkv_a_output_sizes,
+                    bias=False,
+                    quant_config=quant_config,
+                    prefix=f"{prefix}.fused_qkv_a_proj",
+                    disable_tp=True,
+                )
             self.q_a_layernorm = RMSNorm(self.q_lora_rank, eps=config.rms_norm_eps)
             self.q_b_proj = ColumnParallelLinear(
                 self.q_lora_rank,
@@ -305,10 +383,15 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
 
         vllm_config = get_current_vllm_config()
         parallel_config = vllm_config.parallel_config
-        assert (
-            parallel_config.decode_context_parallel_size <= 1
-            and parallel_config.prefill_context_parallel_size <= 1
-        ), "Kimi-K3 MultiHeadLatentAttention does not support context parallelism."
+        assert parallel_config.prefill_context_parallel_size <= 1, (
+            "Kimi-K3 MultiHeadLatentAttention does not support prefill "
+            "context parallelism."
+        )
+        if parallel_config.decode_context_parallel_size > 1:
+            assert self.attn_backend.get_name() == "B12X_MLA", (
+                "Kimi-K3 decode context parallelism requires the native "
+                f"B12X_MLA backend, got {self.attn_backend.get_name()}."
+            )
         self.prefill_backend = get_mla_prefill_backend(vllm_config)(
             num_heads=self.num_local_heads,
             scale=self.scale,
@@ -693,30 +776,55 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
                 cos_sin_cache,
             )
         elif is_quantized_kv_cache(self.kv_cache_dtype):
-            assert fp8_prefill, (
-                "Kimi-K3 fp8 KV cache requires an fp8 prefill query; enable "
-                "--attention-config '{\"use_prefill_query_quantization\": true}'."
-            )
-            # Plain per-tensor fp8: quant q/k/v (unscaled, matching forward_mha's
-            # unscaled `.to(fp8)`) and insert the fp8 latent (scaled by _k_scale).
-            kv_cache = self.kv_cache
-            if kv_cache.dtype != torch.float8_e4m3fn:
-                kv_cache = kv_cache.view(torch.float8_e4m3fn)
-            q, k, v = fused_mla_qkv_quant_kv_cache_fp8_insert(
-                q,
-                k_nope,
-                k_pe,
-                kv_c_normed,
-                v,
-                kv_cache,
-                slot_mapping,
-                self._one_scale,
-                self._one_scale,
-                self._one_scale,
-                self._k_scale_inv,
-                positions,
-                cos_sin_cache,
-            )
+            if fp8_prefill:
+                # Plain per-tensor fp8: quant q/k/v (unscaled, matching
+                # forward_mha's unscaled `.to(fp8)`) and insert the fp8 latent
+                # (scaled by _k_scale).
+                kv_cache = self.kv_cache
+                if kv_cache.dtype != torch.float8_e4m3fn:
+                    kv_cache = kv_cache.view(torch.float8_e4m3fn)
+                q, k, v = fused_mla_qkv_quant_kv_cache_fp8_insert(
+                    q,
+                    k_nope,
+                    k_pe,
+                    kv_c_normed,
+                    v,
+                    kv_cache,
+                    slot_mapping,
+                    self._one_scale,
+                    self._one_scale,
+                    self._one_scale,
+                    self._k_scale_inv,
+                    positions,
+                    cos_sin_cache,
+                )
+            else:
+                # SM120 prefill backends consume bf16 Q/K/V even when the
+                # latent cache is fp8.  Keep the attention operands in bf16
+                # and quantize only [kv_c_normed | k_pe] on cache insertion.
+                # Kimi-K3 is NoPE-only, so no rotary update is needed here.
+                assert positions is None and cos_sin_cache is None, (
+                    "BF16 Kimi-K3 prefill with an FP8 cache currently "
+                    "supports NoPE layers only."
+                )
+                from vllm import _custom_ops as ops
+
+                k_pe = k_pe.reshape(k_pe.shape[0], -1)
+                k = torch.cat(
+                    (
+                        k_nope,
+                        k_pe.unsqueeze(1).expand(-1, self.num_local_heads, -1),
+                    ),
+                    dim=-1,
+                )
+                ops.concat_and_cache_mla(
+                    kv_c_normed,
+                    k_pe,
+                    self.kv_cache,
+                    slot_mapping,
+                    kv_cache_dtype=self.kv_cache_dtype,
+                    scale=self._k_scale,
+                )
         else:
             # Concat full K = [k_nope | k_pe] and insert [kv_c_normed | k_pe]
             # into the paged cache for these prefill tokens, in one launch.

--- a/vllm/models/kimi_k3/nvidia/mla.py
+++ b/vllm/models/kimi_k3/nvidia/mla.py
@@ -855,9 +855,20 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
         )
 
         if has_context:
-            context_output, context_lse = self.impl._compute_prefill_context(  # type: ignore[attr-defined]
-                q, self._attn_read_kv_cache(), attn_metadata, self._k_scale
-            )
+            if self.impl.dcp_world_size > 1:
+                context_output, context_lse = (  # type: ignore[attr-defined]
+                    self.impl._context_parallel_compute_prefill_context(
+                        q,
+                        self._attn_read_kv_cache(),
+                        attn_metadata,
+                        k_scale=self._k_scale,
+                        dcp_world_size=self.impl.dcp_world_size,
+                    )
+                )
+            else:
+                context_output, context_lse = self.impl._compute_prefill_context(  # type: ignore[attr-defined]
+                    q, self._attn_read_kv_cache(), attn_metadata, self._k_scale
+                )
             suffix_output, suffix_lse = output_prefill
             out = out.view(-1, self.num_local_heads, self.v_head_dim)
             merge_attn_states(

--- a/vllm/models/kimi_k3/nvidia/model.py
+++ b/vllm/models/kimi_k3/nvidia/model.py
@@ -15,7 +15,9 @@ from vllm.config import VllmConfig
 from vllm.distributed import (
     get_ep_group,
     get_pp_group,
+    get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
+    tensor_model_parallel_all_gather,
 )
 from vllm.forward_context import get_forward_context, is_forward_context_available
 from vllm.logger import init_logger
@@ -36,6 +38,7 @@ from vllm.model_executor.layers.fused_moe.runner.latent_moe_runner import (
 )
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import (
+    ColumnParallelLinear,
     MergedColumnParallelLinear,
     ReplicatedLinear,
     RowParallelLinear,
@@ -130,6 +133,80 @@ logger = init_logger(__name__)
 _ROUTED_DOWN_PROJ_STREAM_TOKEN_THRESHOLD = 256
 
 
+def _uses_native_b12x_mxfp4_intermediate_size(
+    vllm_config: VllmConfig,
+) -> bool:
+    """Whether B12X consumes the checkpoint's unpadded MoE shard.
+
+    SparkInfer's native E8M0 W4A16 path supports logical intermediate tails,
+    including Kimi-K3's 3072 / TP16 = 192 shard.  The generic Kimi minimum of
+    256 channels per rank would otherwise inflate every routed-expert layer by
+    one third before the quant backend gets a chance to preserve its shape.
+    """
+    if vllm_config.model_config.quantization != "mxfp4":
+        return False
+    moe_backend = vllm_config.kernel_config.moe_backend
+    return moe_backend == "b12x" or (
+        moe_backend == "auto" and envs.VLLM_USE_B12X_MOE
+    )
+
+
+def _shard_routed_down_projection(tp_size: int) -> bool:
+    return tp_size > 1 and envs.VLLM_KIMI_SHARD_ROUTED_DOWN_PROJ
+
+
+def _shard_routed_up_projection(tp_size: int) -> bool:
+    return tp_size > 1 and envs.VLLM_KIMI_SHARD_ROUTED_UP_PROJ
+
+
+def _shard_router(tp_size: int) -> bool:
+    return tp_size > 1 and envs.VLLM_KIMI_SHARD_ROUTER
+
+
+def _log_construction_memory(stage: str, prefix: str) -> None:
+    if (
+        not envs.VLLM_KIMI_LOG_CONSTRUCTION_MEMORY
+        or get_tensor_model_parallel_rank() != 0
+    ):
+        return
+    gib = 1024**3
+    logger.info(
+        "Kimi-K3 construction %s %s: allocated=%.3f GiB, "
+        "reserved=%.3f GiB",
+        stage,
+        prefix,
+        torch.cuda.memory_allocated() / gib,
+        torch.cuda.memory_reserved() / gib,
+    )
+
+
+class KimiShardedGate(ColumnParallelLinear):
+    """TP-sharded K3 router that returns globally ordered FP32 logits."""
+
+    def __init__(self, input_size: int, output_size: int, prefix: str) -> None:
+        super().__init__(
+            input_size,
+            output_size,
+            bias=False,
+            gather_output=False,
+            quant_config=None,
+            prefix=prefix,
+        )
+
+    def forward(self, x: torch.Tensor):
+        if x.is_cuda and x.dtype == self.weight.dtype == torch.bfloat16:
+            output_parallel = torch.mm(x, self.weight.T, out_dtype=torch.float32)
+        else:
+            output_parallel = torch.nn.functional.linear(
+                x.to(self.weight.dtype), self.weight
+            ).float()
+        if self.tp_size > 1:
+            output = tensor_model_parallel_all_gather(output_parallel)
+        else:
+            output = output_parallel
+        return output, None
+
+
 class KimiMLP(nn.Module):
     def __init__(
         self,
@@ -186,7 +263,7 @@ class KimiRoutedOutputTransform(nn.Module):
     def __init__(
         self,
         norm: RMSNorm | None,
-        up_proj: ReplicatedLinear,
+        up_proj: ReplicatedLinear | RowParallelLinear,
     ) -> None:
         super().__init__()
         self.norm = norm
@@ -397,6 +474,7 @@ class KimiMoE(nn.Module):
         use_sequence_parallel: bool = False,
     ):
         super().__init__()
+        _log_construction_memory("starting", prefix)
         hidden_size = config.hidden_size
         moe_intermediate_size = config.moe_intermediate_size
         num_experts = config.num_experts
@@ -444,12 +522,24 @@ class KimiMoE(nn.Module):
         min_moe_intermediate_per_partition = getattr(
             config, "min_moe_intermediate_per_partition", 256
         )
-        if self.tp_size > 1:
+        use_native_b12x_intermediate = (
+            not self.use_mega_moe
+            and _uses_native_b12x_mxfp4_intermediate_size(vllm_config)
+        )
+        if self.tp_size > 1 and not use_native_b12x_intermediate:
             moe_intermediate_per_partition = moe_intermediate_size // self.tp_size
             if moe_intermediate_per_partition < min_moe_intermediate_per_partition:
                 self.padded_moe_intermediate_size = (
                     min_moe_intermediate_per_partition * self.tp_size
                 )
+        elif use_native_b12x_intermediate:
+            logger.info_once(
+                "Kimi-K3 B12X MXFP4 is keeping the native MoE intermediate "
+                "shard (%d / TP%d = %d); no model-level padding is required.",
+                moe_intermediate_size,
+                self.tp_size,
+                moe_intermediate_size // self.tp_size,
+            )
         activation_situ_beta = (
             config.activation_situ_beta if config.hidden_act == "situ" else None
         )
@@ -458,13 +548,26 @@ class KimiMoE(nn.Module):
         )
 
         # Route with fp32 logits for numerically stable expert selection.
-        self.gate = GateLinear(
-            input_size=hidden_size,
-            output_size=num_experts,
-            bias=False,
-            out_dtype=torch.float32,
-            prefix=f"{prefix}.gate",
-        )
+        self.shard_router = _shard_router(self.tp_size)
+        if self.shard_router:
+            self.gate = KimiShardedGate(
+                input_size=hidden_size,
+                output_size=num_experts,
+                prefix=f"{prefix}.gate",
+            )
+            logger.info_once(
+                "Kimi-K3 is TP-sharding the BF16 router and gathering FP32 "
+                "logits (TP%d).",
+                self.tp_size,
+            )
+        else:
+            self.gate = GateLinear(
+                input_size=hidden_size,
+                output_size=num_experts,
+                bias=False,
+                out_dtype=torch.float32,
+                prefix=f"{prefix}.gate",
+            )
 
         self.gate.e_score_correction_bias = nn.Parameter(
             torch.empty(num_experts, dtype=torch.float32)
@@ -486,35 +589,64 @@ class KimiMoE(nn.Module):
         else:
             self.shared_experts = None
 
-        self.routed_expert_down_proj: ReplicatedLinear | None
+        self.routed_expert_down_proj: (
+            ColumnParallelLinear | ReplicatedLinear | None
+        )
         self.routed_expert_norm: RMSNorm | None
-        self.routed_expert_up_proj: ReplicatedLinear | None
+        self.routed_expert_up_proj: ReplicatedLinear | RowParallelLinear | None
         self.routed_output_transform: KimiRoutedOutputTransform | None
         if self.use_latent_moe:
-            self.routed_expert_down_proj = ReplicatedLinear(
+            shard_routed_down = _shard_routed_down_projection(self.tp_size)
+            routed_down_cls = (
+                ColumnParallelLinear if shard_routed_down else ReplicatedLinear
+            )
+            routed_down_kwargs = {"gather_output": True} if shard_routed_down else {}
+            self.routed_expert_down_proj = routed_down_cls(
                 hidden_size,
                 self.moe_hidden_size,
                 bias=False,
                 quant_config=None,
                 prefix=f"{prefix}.routed_expert_down_proj",
+                **routed_down_kwargs,
             )
+            if shard_routed_down:
+                logger.info_once(
+                    "Kimi-K3 is TP-sharding the routed-expert down projection "
+                    "and gathering its latent output (TP%d).",
+                    self.tp_size,
+                )
             self.routed_expert_norm = (
                 RMSNorm(self.moe_hidden_size, eps=config.rms_norm_eps)
                 if self.latent_moe_use_norm
                 else None
             )
-            # Replicated up-proj: the full weight lives on every rank and
-            # produces the full hidden dim locally. This lets LatentMoERunner
-            # fuse the latent and shared reductions into a single all-reduce
-            # (concat the two partials, reduce once), then run the up-proj and
-            # shared add locally with no further collective.
-            self.routed_expert_up_proj = ReplicatedLinear(
-                self.moe_hidden_size,
-                hidden_size,
-                bias=False,
-                quant_config=None,
-                prefix=f"{prefix}.routed_expert_up_proj",
-            )
+            shard_routed_up = _shard_routed_up_projection(self.tp_size)
+            if shard_routed_up:
+                self.routed_expert_up_proj = RowParallelLinear(
+                    self.moe_hidden_size,
+                    hidden_size,
+                    bias=False,
+                    input_is_parallel=False,
+                    reduce_results=False,
+                    quant_config=None,
+                    prefix=f"{prefix}.routed_expert_up_proj",
+                )
+                logger.info_once(
+                    "Kimi-K3 is TP-sharding the routed-expert up projection "
+                    "and reducing its sum with the shared-expert partial "
+                    "(TP%d).",
+                    self.tp_size,
+                )
+            else:
+                # A full local projection lets LatentMoERunner use HH's
+                # replicated-up tail path when enough memory is available.
+                self.routed_expert_up_proj = ReplicatedLinear(
+                    self.moe_hidden_size,
+                    hidden_size,
+                    bias=False,
+                    quant_config=None,
+                    prefix=f"{prefix}.routed_expert_up_proj",
+                )
 
             self.routed_output_transform = KimiRoutedOutputTransform(
                 self.routed_expert_norm, self.routed_expert_up_proj
@@ -588,7 +720,10 @@ class KimiMoE(nn.Module):
                 is_sequence_parallel=use_sequence_parallel,
                 runner_cls=LatentMoERunner if self.use_latent_moe else None,
                 runner_args=(
-                    {"enable_k3_latent_moe_tail_fusion": enable_tail_fusion}
+                    {
+                        "enable_k3_latent_moe_tail_fusion": enable_tail_fusion,
+                        "up_projection_is_sharded": shard_routed_up,
+                    }
                     if self.use_latent_moe
                     else None
                 ),
@@ -607,6 +742,7 @@ class KimiMoE(nn.Module):
             self.experts.moe_config.intermediate_size_per_partition_unpadded = (
                 moe_intermediate_size // self.tp_size
             )
+        _log_construction_memory("finished", prefix)
 
     def _maybe_overlap_router_and_down_proj(
         self, hidden_states: torch.Tensor
@@ -658,9 +794,15 @@ class KimiMoE(nn.Module):
                 lambda: down_proj(hidden_states),
                 self._down_proj_events[0],
                 self._down_proj_events[1],
-                self._down_proj_stream
-                if num_tokens <= _ROUTED_DOWN_PROJ_STREAM_TOKEN_THRESHOLD
-                else None,
+                (
+                    self._down_proj_stream
+                    if num_tokens <= _ROUTED_DOWN_PROJ_STREAM_TOKEN_THRESHOLD
+                    and not (
+                        self.shard_router
+                        and isinstance(down_proj, ColumnParallelLinear)
+                    )
+                    else None
+                ),
             )
         )
         return routed_hidden_states, router_output, topk_ids

--- a/vllm/models/kimi_k3/nvidia/ops/fused_mla_key_concat_kv_cache.py
+++ b/vllm/models/kimi_k3/nvidia/ops/fused_mla_key_concat_kv_cache.py
@@ -21,6 +21,29 @@ sm_90+.
 
 import torch
 
+_KIMI_K3_CACHE_OPS_LOADED = False
+_KIMI_K3_CACHE_OP_SENTINEL = (
+    "fused_kimi_k3_mla_decode_q_concat_kv_cache_fp8_insert"
+)
+
+
+def ensure_kimi_k3_cache_ops() -> None:
+    """Load the small HH compatibility fragment when the main image is old."""
+    global _KIMI_K3_CACHE_OPS_LOADED
+    if _KIMI_K3_CACHE_OPS_LOADED:
+        return
+    if not hasattr(torch.ops._C, _KIMI_K3_CACHE_OP_SENTINEL):
+        try:
+            import vllm._kimi_k3_cache_ops  # noqa: F401
+        except ImportError as exc:
+            raise RuntimeError(
+                "HH Kimi-K3 cache ops are absent from _C_stable_libtorch and "
+                "the companion vllm._kimi_k3_cache_ops extension is missing"
+            ) from exc
+    if not hasattr(torch.ops._C, _KIMI_K3_CACHE_OP_SENTINEL):
+        raise RuntimeError("Kimi-K3 cache op companion failed to register")
+    _KIMI_K3_CACHE_OPS_LOADED = True
+
 
 def fused_mla_key_concat_kv_cache_insert(
     q: torch.Tensor,  # [Tp, H, qk_head_dim], RoPE is applied in place
@@ -45,6 +68,7 @@ def fused_mla_key_concat_kv_cache_insert(
     )
     if tp == 0:
         return k_out
+    ensure_kimi_k3_cache_ops()
     torch.ops._C.fused_kimi_k3_mla_key_concat_kv_cache_insert(
         q,
         k_nope,
@@ -85,6 +109,7 @@ def fused_mla_key_concat_ds_mla_insert(
     )
     if tp == 0:
         return k_out
+    ensure_kimi_k3_cache_ops()
     torch.ops._C.fused_kimi_k3_mla_key_concat_ds_mla_insert(
         q,
         k_nope,
@@ -134,6 +159,7 @@ def fused_mla_qkv_quant_kv_cache_fp8_insert(
     v_fp8 = torch.empty((tp, num_heads, v_head_dim), dtype=fp8, device=q.device)
     if tp == 0:
         return q_fp8, k_fp8, v_fp8
+    ensure_kimi_k3_cache_ops()
     torch.ops._C.fused_kimi_k3_mla_qkv_quant_kv_cache_fp8_insert(
         q,
         k_nope,
@@ -190,6 +216,7 @@ def fused_mla_decode_q_concat_kv_cache_insert(
     mqa_q = torch.empty((b, num_heads, entry), dtype=out_dtype, device=ql_nope.device)
     if b == 0:
         return mqa_q
+    ensure_kimi_k3_cache_ops()
 
     if ds_mla:
         cache = (

--- a/vllm/v1/attention/backends/mla/b12x_mla.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla.py
@@ -4,11 +4,13 @@
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from typing import Any, ClassVar, cast
 
 import torch
 
+from vllm.compilation.b12x_capture import is_b12x_compile_only_warmup
 from vllm.config import VllmConfig, get_current_vllm_config
 from vllm.config.cache import CacheDType
 from vllm.logger import init_logger
@@ -27,11 +29,12 @@ from vllm.v1.attention.backend import (
     CommonAttentionMetadata,
     MultipleOf,
 )
-from vllm.v1.kv_cache_interface import AttentionSpec
-from vllm.v1.worker.workspace import (
-    current_workspace_manager,
-    is_workspace_manager_initialized,
+from vllm.v1.attention.ops.common import cp_lse_ag_out_rs
+from vllm.v1.attention.ops.dcp_alltoall import (
+    dcp_a2a_lse_reduce,
+    dcp_b12x_all_gather_heads,
 )
+from vllm.v1.kv_cache_interface import AttentionSpec
 
 logger = init_logger(__name__)
 
@@ -59,6 +62,16 @@ def _page_table_width(max_cache_tokens: int, page_size: int) -> int:
         alignment = 128 // page_size
         width = ((width + alignment - 1) // alignment) * alignment
     return width
+
+
+def _max_dcp_local_cache_tokens(vllm_config: VllmConfig) -> int:
+    """Return the largest token shard held by one decode-context rank."""
+    parallel_config = vllm_config.parallel_config
+    dcp_size = int(parallel_config.decode_context_parallel_size)
+    interleave = int(parallel_config.cp_kv_cache_interleave_size)
+    max_model_len = int(vllm_config.model_config.max_model_len)
+    partitions = dcp_size * interleave
+    return ((max_model_len + partitions - 1) // partitions) * interleave
 
 
 def _planned_kv_dtype(vllm_config: VllmConfig) -> torch.dtype:
@@ -89,7 +102,7 @@ def _create_dense_mla_plan(
 ) -> Any:
     dense_mla = _load_dense_mla()
     max_total_q = int(vllm_config.scheduler_config.max_num_seqs)
-    max_cache_tokens = int(vllm_config.model_config.max_model_len)
+    max_cache_tokens = _max_dcp_local_cache_tokens(vllm_config)
     if max_total_q > _MAX_B12X_QUERY_ROWS:
         raise ValueError(
             "B12X_MLA supports at most "
@@ -154,18 +167,18 @@ class B12xMLAMetadataBuilder(MLACommonMetadataBuilder[B12xMLAMetadata]):
             vllm_config,
             device,
             page_size=self.page_size,
-            num_q_heads=self.num_heads,
+            num_q_heads=self.num_heads * self.dcp_world_size,
         )
         self._workspace_specs = self._dense_mla_plan.shapes_and_dtypes()
-        if is_workspace_manager_initialized():
-            current_workspace_manager().get_simultaneous(*self._workspace_specs)
         logger.info_once(
-            "B12X dense K3 MLA plan: heads=%d, page_size=%d, "
+            "B12X dense K3 MLA plan: local_heads=%d, effective_heads=%d, "
+            "page_size=%d, "
             "max_decode_rows=%d, max_cache_tokens=%d, splits=%d",
             self.num_heads,
+            self.num_heads * self.dcp_world_size,
             self.page_size,
             vllm_config.scheduler_config.max_num_seqs,
-            vllm_config.model_config.max_model_len,
+            _max_dcp_local_cache_tokens(vllm_config),
             self._dense_mla_plan.num_splits,
         )
 
@@ -277,29 +290,34 @@ class B12xMLABackend(MLACommonBackend):
             )
 
         parallel_config = vllm_config.parallel_config
-        if parallel_config.decode_context_parallel_size != 1:
-            return "B12X_MLA does not yet support decode context parallelism"
+        if parallel_config.prefill_context_parallel_size != 1:
+            return "B12X_MLA does not support prefill context parallelism"
+        dcp_size = int(parallel_config.decode_context_parallel_size)
         local_heads = model_config.get_num_attention_heads(parallel_config)
-        if local_heads <= 0 or local_heads % 8:
+        effective_heads = local_heads * dcp_size
+        if local_heads <= 0 or effective_heads % 8:
             return (
-                "B12X_MLA requires a positive multiple of 8 query heads per "
-                f"rank, got {local_heads}"
+                "B12X_MLA requires a positive multiple of 8 query heads after "
+                f"DCP gather, got local={local_heads}, DCP={dcp_size}, "
+                f"effective={effective_heads}"
             )
         if vllm_config.scheduler_config.max_num_seqs > _MAX_B12X_QUERY_ROWS:
             return (
                 "B12X_MLA max_num_seqs exceeds its 1024-row decode capacity: "
                 f"{vllm_config.scheduler_config.max_num_seqs}"
             )
-        if model_config.max_model_len > _MAX_B12X_CACHE_TOKENS:
+        local_cache_tokens = _max_dcp_local_cache_tokens(vllm_config)
+        if local_cache_tokens > _MAX_B12X_CACHE_TOKENS:
             return (
-                "B12X_MLA max_model_len exceeds its 1048576-token capacity: "
-                f"{model_config.max_model_len}"
+                "B12X_MLA local DCP cache exceeds its 1048576-token capacity: "
+                f"{local_cache_tokens}"
             )
         return None
 
 
 class B12xMLAImpl(MLACommonImpl[B12xMLAMetadata]):
     can_return_lse_for_decode: bool = True
+    supports_quant_query_input: bool = True
 
     def __init__(
         self,
@@ -363,36 +381,51 @@ class B12xMLAImpl(MLACommonImpl[B12xMLAMetadata]):
                 f"B12xMLAImpl received non-K3 MLA dimensions {actual_dims}; "
                 f"required {required_dims}."
             )
-        if num_heads <= 0 or num_heads % 8:
+        vllm_config = get_current_vllm_config()
+        dcp_world_size = int(vllm_config.parallel_config.decode_context_parallel_size)
+        # KimiK3Attention calls this implementation directly instead of going
+        # through MLAAttention.forward(), where the common MLA path normally
+        # replaces the sentinel value (-1) with the initialized DCP group size.
+        # Keep the configured value here so TP16/DCP8 gathers 6 local heads to
+        # the 48-head shape used by the SparkInfer plan.
+        self.dcp_world_size = dcp_world_size
+        effective_heads = num_heads * dcp_world_size
+        if num_heads <= 0 or effective_heads % 8:
             raise ValueError(
-                "B12xMLAImpl requires a positive multiple of 8 query heads, "
-                f"got {num_heads}."
+                "B12xMLAImpl requires a positive multiple of 8 query heads "
+                "after DCP gather, "
+                f"got local={num_heads}, DCP={dcp_world_size}, "
+                f"effective={effective_heads}."
             )
-        if get_current_vllm_config().parallel_config.decode_context_parallel_size != 1:
+        if vllm_config.parallel_config.prefill_context_parallel_size != 1:
             raise NotImplementedError(
-                "B12xMLAImpl does not yet support decode context parallelism."
+                "B12xMLAImpl does not support prefill context parallelism."
             )
 
         self._dense_mla = _load_dense_mla()
+        self._dcp_comm_backend = vllm_config.parallel_config.dcp_comm_backend
+        self._dcp_max_batch_size = vllm_config.scheduler_config.max_num_batched_tokens
         self._compiled_bindings: set[tuple[object, ...]] = set()
-        self._fallback_scratch: dict[int, torch.Tensor] = {}
+        self._scratch_by_plan: dict[int, torch.Tensor] = {}
 
     def _borrow_scratch(self, plan: Any, device: torch.device) -> torch.Tensor:
-        specs = plan.shapes_and_dtypes()
-        if is_workspace_manager_initialized():
-            (scratch,) = current_workspace_manager().get_simultaneous(*specs)
-            return scratch
+        """Return storage whose address is stable for this backend instance.
 
-        # Unit-test/minimal-runner fallback. Production initializes and
-        # pre-sizes WorkspaceManager before metadata construction.
+        The general vLLM workspace is reused by MoE and other kernels.  A
+        dense-MLA CUDA graph retains this tensor's address, so borrowing that
+        shared allocation lets a later workspace resize invalidate the graph
+        and lets unrelated kernels overwrite split partials.  Keep the small
+        attention scratch allocation private instead.
+        """
+        specs = plan.shapes_and_dtypes()
         key = id(plan)
-        scratch = self._fallback_scratch.get(key)
+        scratch = self._scratch_by_plan.get(key)
         if scratch is None:
             if len(specs) != 1:
                 raise RuntimeError("B12X_MLA expected exactly one scratch buffer.")
             shape, dtype = specs[0]
             scratch = torch.empty(shape, dtype=dtype, device=device)
-            self._fallback_scratch[key] = scratch
+            self._scratch_by_plan[key] = scratch
         return scratch
 
     def forward_mqa(
@@ -426,8 +459,20 @@ class B12xMLAImpl(MLACommonImpl[B12xMLAMetadata]):
                 f"B12X_MLA expected {self.num_heads} query heads, got {q.shape[1]}."
             )
 
+        dcp_group = None
+        if self.dcp_world_size > 1:
+            from vllm.distributed.parallel_state import get_dcp_group
+
+            dcp_group = get_dcp_group()
+            q = dcp_b12x_all_gather_heads(
+                q,
+                dcp_group,
+                max_batch_size=self._dcp_max_batch_size,
+                output_head_dim=self.kv_lora_rank,
+            )
+
         output = torch.empty(
-            (batch, self.num_heads, self.kv_lora_rank),
+            (batch, int(q.shape[1]), self.kv_lora_rank),
             dtype=torch.bfloat16,
             device=q.device,
         )
@@ -464,7 +509,49 @@ class B12xMLAImpl(MLACommonImpl[B12xMLAMetadata]):
             self._dense_mla.compile(binding=binding)
             self._compiled_bindings.add(compile_key)
 
-        return self._dense_mla.run(binding=binding)
+        if is_b12x_compile_only_warmup():
+            # The binding above carries the exact FP8/BF16 strides retained by
+            # capture. Compilation is sufficient here: launching the complete
+            # K3 warmup forward against capture-prepared workspaces is unsafe.
+            local_output = output[:, : self.num_heads]
+            local_output.zero_()
+            return local_output, None
+
+        output, lse = self._dense_mla.run(binding=binding)
+        if os.environ.get("VLLM_KIMI_DEBUG_FINITE") == "1":
+            torch.cuda.synchronize()
+            output_ok = bool(torch.isfinite(output).all().item())
+            lse_ok = bool((~torch.isnan(lse) & ~torch.isposinf(lse)).all().item())
+            if not output_ok or not lse_ok:
+                raise RuntimeError(
+                    "B12X_MLA produced invalid local output/LSE: "
+                    f"output_finite={output_ok}, lse_valid={lse_ok}"
+                )
+        if dcp_group is None:
+            return output, lse
+
+        if self._dcp_comm_backend == "a2a":
+            reduced = dcp_a2a_lse_reduce(
+                output,
+                lse,
+                dcp_group,
+                is_lse_base_on_e=True,
+                use_b12x=True,
+                b12x_max_batch_size=self._dcp_max_batch_size,
+                b12x_query_head_dim=_K3_ABSORBED_HEAD_DIM,
+            )
+        else:
+            reduced = cp_lse_ag_out_rs(
+                output,
+                lse,
+                dcp_group,
+                is_lse_base_on_e=True,
+            )
+        if os.environ.get("VLLM_KIMI_DEBUG_FINITE") == "1":
+            torch.cuda.synchronize()
+            if not bool(torch.isfinite(reduced).all().item()):
+                raise RuntimeError("B12X_MLA DCP reduction produced nonfinite output")
+        return reduced, None
 
 
 __all__ = [

--- a/vllm/v1/attention/ops/dcp_alltoall.py
+++ b/vllm/v1/attention/ops/dcp_alltoall.py
@@ -41,6 +41,8 @@ logger = init_logger(__name__)
 
 _B12X_DCP_A2A_POOLS: dict[tuple[int, int, int, int, int, int], Any] = {}
 _B12X_DCP_A2A_DISABLED: set[tuple[int, int, int, int, int, int]] = set()
+_B12X_DCP_EAGER_CHANNEL_ID = "vllm:eager:dcp"
+_B12X_DCP_CAPTURE_SEQUENCES: dict[int, int] = {}
 _DCP_A2A_GRAPH_BUFFERS: dict[
     tuple[tuple[int, ...], torch.device, torch.dtype],
     tuple[torch.Tensor, torch.Tensor],
@@ -53,9 +55,7 @@ def _is_supported_bhd_layout(tensor: torch.Tensor) -> bool:
         return False
     batch, heads, head_dim = (int(value) for value in tensor.shape)
     stride_batch, stride_head, _ = (int(value) for value in tensor.stride())
-    packed_token_major = (
-        stride_batch == heads * head_dim and stride_head == head_dim
-    )
+    packed_token_major = stride_batch == heads * head_dim and stride_head == head_dim
     capacity_strided_head_major = (
         stride_batch == head_dim and stride_head >= batch * head_dim
     )
@@ -131,7 +131,11 @@ def _get_b12x_dcp_a2a_pool(
             query_head_dim=query_head_dim,
             single_channel=False,
         )
-        pool.for_stream()
+        # SparkInfer identifies independently replayable channels by a stable
+        # semantic name. Stream handles are process-local and can be recycled,
+        # so they are not a valid distributed identity.
+        pool.prepare_channels((_B12X_DCP_EAGER_CHANNEL_ID,))
+        pool.for_stream(channel_id=_B12X_DCP_EAGER_CHANNEL_ID)
     except Exception as exc:
         init_error = exc
 
@@ -182,6 +186,9 @@ def capture_b12x_dcp_a2a(
         stream: CUDA stream owned by the enclosing graph capture.
     """
     group_id = id(cp_group.device_group)
+    sequence = _B12X_DCP_CAPTURE_SEQUENCES.get(group_id, 0)
+    _B12X_DCP_CAPTURE_SEQUENCES[group_id] = sequence + 1
+    channel_id = f"vllm:graph:{sequence}"
     matching_pools = sorted(
         (
             (key, pool)
@@ -192,7 +199,7 @@ def capture_b12x_dcp_a2a(
     )
     with ExitStack() as stack:
         for _, pool in matching_pools:
-            stack.enter_context(pool.capture(stream=stream))
+            stack.enter_context(pool.capture(stream=stream, channel_id=channel_id))
         yield
 
 
@@ -313,6 +320,7 @@ def _try_b12x_dcp_lse_reduce(
         cp_attn_lse,
         out=reduced,
         is_lse_base_on_e=is_lse_base_on_e,
+        channel_id=_B12X_DCP_EAGER_CHANNEL_ID,
     )
 
 
@@ -327,7 +335,7 @@ def _try_b12x_dcp_all_gather_heads(
     world_size = cp_group.world_size
     if (
         not local_input.is_cuda
-        or local_input.dtype not in (torch.float16, torch.bfloat16)
+        or local_input.dtype not in (torch.float16, torch.bfloat16, torch.float8_e4m3fn)
         or world_size not in (2, 4, 8)
         or local_input.ndim != 3
         or not local_input.is_contiguous()
@@ -363,7 +371,10 @@ def _try_b12x_dcp_all_gather_heads(
     )
     if pool is None:
         return None
-    return pool.all_gather_heads(local_input)
+    return pool.all_gather_heads(
+        local_input,
+        channel_id=_B12X_DCP_EAGER_CHANNEL_ID,
+    )
 
 
 def dcp_b12x_all_gather_heads(

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -852,6 +852,8 @@ class SlidingWindowMLASpec(SlidingWindowSpec):
 class MambaSpec(KVCacheSpec):
     shapes: tuple[tuple[int, ...], ...]
     dtypes: tuple[torch.dtype]
+    dcp_replicated: bool = True
+    """Recurrent state is advanced on every context-parallel rank."""
     page_size_padded: int | None = None
     mamba_type: MambaAttentionBackendEnum = MambaAttentionBackendEnum.MAMBA2
     mamba_cache_mode: str = "none"

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -477,8 +477,16 @@ class CudaGraphManager:
                     # Prepare inputs and get forward function
                     forward_fn = create_forward_fn(desc, warmup=True)
 
-                    # Warmup
-                    forward_fn(CUDAGraphMode.NONE)
+                    # Warmup. Breakable capture owns its runtime lifecycle and
+                    # can execute attention as eager segments; its direct-model
+                    # warmup is optional because it uses different workspace
+                    # dispatch from the graph wrapper itself.
+                    skip_breakable_warmup = (
+                        self.use_breakable_cg
+                        and envs.VLLM_B12X_CUDAGRAPH_COMPILE_ONLY_PREWARM
+                    )
+                    if not skip_breakable_warmup:
+                        forward_fn(CUDAGraphMode.NONE)
 
                     # Capture
                     logger.debug(


### PR DESCRIPTION
## Summary

- serve the original Kimi K3 compressed-tensors MXFP4 checkpoint on TP16/DCP8 with SparkInfer native dense MLA and PCIe DCP A2A
- preserve the checkpoint's native 3072-wide MoE intermediate instead of applying generic TP16 padding to 4096
- TP-shard the otherwise replicated BF16 QKV-A, routed-down, routed-up, and router projections so the full checkpoint and a physical 1M FP8 KV cache fit
- make the Kimi cache, KDA decode, SiTU activation, dense-MLA, and breakable-CUDA-graph paths capture safe
- use the DCP-aware context path for Kimi chunked prefill
- bound the MLA chunked-context workspace to 32k rows in the full-cache profile so 64k prefill fits without changing attention backends or reducing KV capacity
- support the validated InstantTensor load path and add a complete TP16/DCP8/1M launch profile

## Why

The HH Kimi K3 implementation had the model architecture but could not serve the unmodified full checkpoint with TP16, DCP8, native dense MLA, and a physical one-million-token cache as one working configuration. Replicated BF16 projections exhausted memory, and the generic minimum MoE shard padded every expert layer by 33.33%.

Kimi's fused prefill entry point also called the non-DCP context routine under DCP8. The second scheduler chunk then treated rank-local KV as complete and failed. Dispatching to `_context_parallel_compute_prefill_context` fixes that correctness bug.

With DCP dispatch fixed, the original 64k MLA context workspace left insufficient transient memory beside the 1,054,602-token cache. FlashAttention failed allocating an 84 MiB padded-V tensor with 81.25 MiB free. A configurable 32k workspace keeps exact online-softmax chunk merging while halving the context operand envelope. Decode remains SparkInfer `B12X_MLA`; prefill remains vLLM FlashAttention FA2.

This PR is paired with the SparkInfer correctness/runtime dependency in local-inference-lab/sparkinfer#116.

## Not a duplicate

No open PR in this fork implements this Kimi full-checkpoint runtime. Upstream vllm-project/vllm#50613 is a broader per-request context scheduler redesign, while vllm-project/vllm#41229 only fixes DCP divisibility. Neither provides this profile's explicit workspace bound or the Kimi fused-entry DCP dispatch.

## Validation

- selected vLLM integration suite from the initial runtime work: 151 passed
- new workspace-limit unit test: 1 passed
- `ruff check`, `ruff format --check` on the changed focused files, `bash -n`, and `shellcheck`: passed
- full original `moonshotai/Kimi-K3` MXFP4 snapshot loaded with InstantTensor: 164.84 s checkpoint traversal; 188.69-189.02 s complete model construction
- model allocation: 90.93 GiB/rank on 16 RTX PRO 6000 Blackwell GPUs
- physical KV cache unchanged: 1,054,602 tokens; 1.01x concurrency at a 1,048,576-token request
- direct-token-ID 65,536-token E2E prefill completed: 81.3695 s TTFT, 805.413 tok/s, no OOM/CUDA/nonfinite error
- post-prefill 1,024-token decode: 38.3467 tok/s, coherent output
- SparkInfer dense-MLA plan: 6 local heads, 48 effective DCP heads, 94 static splits

`PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` is already the launcher default. Repeating the failed 64k run with it confirmed the old failure was real headroom, not allocator fragmentation.

This is full checkpoint-native MXFP4. It does not use EXL3/NF3, expert parallelism, pipeline parallelism, or model-level MoE padding.

Full reproduction, immutable Docker digest, benchmark JSON, profiling, and rollback instructions: https://github.com/local-inference-lab/rtx6kpro/blob/docs/kimi-k3-hh-dense-mla-dcp8-20260803/models/kimi-k3/hh-dense-mla-full-mxfp4-dcp8-2026-08-03.md

AI assistance from OpenAI Codex was used for implementation, testing, and documentation. The human submitter must review every changed line and validate the claims before merge.
