### PR TITLE
fix(flashinfer): only reuse persistent decode wrappers at the planned q_len

### DIFF
--- a/tests/v1/attention/test_flashinfer_decode_qlen_guard.py
+++ b/tests/v1/attention/test_flashinfer_decode_qlen_guard.py
@@ -1,0 +1,101 @@
+"""Persistent FlashInfer decode wrappers may only be reused when the runtime
+q_len_per_req equals the value frozen during wrapper planning (1 + K).
+
+The decode-classification ceiling (reorder_batch_threshold = 1 + 2K under
+parallel drafting) deliberately admits reduced-depth lone steps as decodes —
+spec truncation near max_tokens, short chunked-prefill tails fused with the
+spec step. Those steps must take the dynamic wrapper; routing them to a
+captured wrapper raises inside flashinfer's fast_decode_plan ("q_len_per_req
+is part of the frozen cudagraph shape: this wrapper was planned with 6,
+got 8|5") and kills the engine.
+
+These tests pin the invariant and, deliberately, the distinction between the
+classification ceiling (1 + 2K) and the planned shape (1 + K): substituting
+reorder_batch_threshold for the planned length reintroduces the crash.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.v1.attention.backend import AttentionMetadataBuilder
+from vllm.v1.attention.backends.flashinfer import (
+    persistent_decode_wrapper_eligible,
+)
+from vllm.v1.attention.backends.utils import split_decodes_and_prefills
+
+K = 5
+PLANNED = 1 + K
+CEILING = 1 + 2 * K
+MAX_BS = 96
+
+
+def _threshold_for(parallel_drafting: bool) -> int:
+    stub = SimpleNamespace(
+        vllm_config=SimpleNamespace(
+            speculative_config=SimpleNamespace(
+                num_speculative_tokens=K,
+                parallel_drafting=parallel_drafting,
+            ),
+            parallel_config=SimpleNamespace(decode_context_parallel_size=1),
+        )
+    )
+    AttentionMetadataBuilder._init_reorder_batch_threshold(
+        stub, 1, supports_spec_as_decode=True
+    )
+    return stub.reorder_batch_threshold
+
+
+def _eligible(q_len, *, num_reqs=1, pure_decode=True, max_bs=MAX_BS,
+              planned=PLANNED):
+    return persistent_decode_wrapper_eligible(
+        pure_decode=pure_decode,
+        num_decode_tokens=q_len * num_reqs,
+        decode_cudagraph_max_bs=max_bs,
+        decode_q_len=q_len,
+        planned_decode_q_len=planned,
+    )
+
+
+def test_classification_ceiling_is_not_planned_shape():
+    assert _threshold_for(parallel_drafting=True) == CEILING
+    assert _threshold_for(parallel_drafting=False) == PLANNED
+    assert CEILING != PLANNED
+
+
+def test_planned_shape_selects_persistent_wrapper():
+    assert _eligible(PLANNED)
+    assert _eligible(PLANNED, num_reqs=8)
+
+
+@pytest.mark.parametrize(
+    "q_len", [q for q in range(1, CEILING + 1) if q != PLANNED]
+)
+def test_reduced_or_extended_depth_falls_back_to_dynamic(q_len):
+    # Covers both observed crash signatures: q_len=5 (spec truncation near
+    # max_tokens) and q_len=8 (chunked-prefill tail fused with spec step).
+    assert not _eligible(q_len)
+
+
+def test_above_ceiling_classifies_as_prefill():
+    meta = SimpleNamespace(
+        max_query_len=CEILING + 1,
+        num_reqs=1,
+        num_actual_tokens=CEILING + 1,
+        query_start_loc_cpu=torch.tensor([0, CEILING + 1], dtype=torch.int32),
+    )
+    nd, npf, ndt, npt = split_decodes_and_prefills(
+        meta, decode_threshold=CEILING, require_uniform=True
+    )
+    assert (nd, npf, ndt, npt) == (0, 1, 0, CEILING + 1)
+
+
+def test_other_predicate_terms_still_gate():
+    assert not _eligible(PLANNED, pure_decode=False)
+    assert not _eligible(PLANNED, num_reqs=32)  # over capacity
+
+
+def test_no_spec_planned_length_is_one():
+    assert _eligible(1, planned=1)
+    assert not _eligible(2, planned=1)

--- a/tests/v1/attention/test_flashinfer_decode_qlen_guard.py
+++ b/tests/v1/attention/test_flashinfer_decode_qlen_guard.py
@@ -21,6 +21,7 @@ import torch
 
 from vllm.v1.attention.backend import AttentionMetadataBuilder
 from vllm.v1.attention.backends.flashinfer import (
+    decode_q_len_from_indptr,
     persistent_decode_wrapper_eligible,
 )
 from vllm.v1.attention.backends.utils import split_decodes_and_prefills
@@ -99,3 +100,40 @@ def test_other_predicate_terms_still_gate():
 def test_no_spec_planned_length_is_one():
     assert _eligible(1, planned=1)
     assert not _eligible(2, planned=1)
+
+
+def _indptr(*lens):
+    out = [0]
+    for n in lens:
+        out.append(out[-1] + n)
+    return torch.tensor(out, dtype=torch.int32)
+
+
+@pytest.mark.parametrize(
+    ("lens", "expected"),
+    [
+        ((PLANNED,), PLANNED),
+        ((PLANNED, 0), PLANNED),          # one active + one padding row
+        ((PLANNED, PLANNED, 0), PLANNED),
+        ((PLANNED,) * 3 + (0,), PLANNED), # total not divisible by num rows
+        ((0, 0), 0),                      # all-padding
+        ((5,), 5),                        # reduced-depth lone step
+    ],
+)
+def test_decode_q_len_ignores_zero_padding(lens, expected):
+    assert decode_q_len_from_indptr(_indptr(*lens), len(lens)) == expected
+
+
+def test_zero_padded_planned_batch_keeps_persistent_wrapper():
+    # Regression: uniform CUDA-graph batches may carry zero-length padding
+    # rows; averaging tokens over rows understated the active q_len and
+    # demoted a planned-shape batch to the dynamic wrapper.
+    lens = (PLANNED, 0)
+    q_len = decode_q_len_from_indptr(_indptr(*lens), len(lens))
+    assert persistent_decode_wrapper_eligible(
+        pure_decode=True,
+        num_decode_tokens=sum(lens),
+        decode_cudagraph_max_bs=MAX_BS,
+        decode_q_len=q_len,
+        planned_decode_q_len=PLANNED,
+    )

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -617,6 +617,38 @@ class FlashInferMetadata:
     cascade_wrapper: MultiLevelCascadeAttentionWrapper | None
 
 
+def persistent_decode_wrapper_eligible(
+    *,
+    pure_decode: bool,
+    num_decode_tokens: int,
+    decode_cudagraph_max_bs: int,
+    decode_q_len: int,
+    planned_decode_q_len: int,
+) -> bool:
+    """Whether a decode-classified batch may reuse a persistent (CUDA-graph)
+    FlashInfer decode wrapper.
+
+    Persistent wrappers are planned once, during graph capture, with a frozen
+    ``q_len_per_req`` of exactly ``planned_decode_q_len`` (1 + num_spec_tokens;
+    1 without speculative decoding). Reuse is only sound when the runtime
+    per-request query length matches that frozen shape — FlashInfer's
+    ``fast_decode_plan`` hard-errors otherwise ("q_len_per_req is part of the
+    frozen cudagraph shape").
+
+    WARNING: ``planned_decode_q_len`` is NOT ``reorder_batch_threshold``. With
+    parallel drafting the decode-classification ceiling is
+    ``1 + 2 * num_spec_tokens``, which deliberately admits reduced-depth steps
+    (spec truncation near ``max_tokens``, short chunked-prefill tails fused
+    with the spec step). Those are valid decode batches, but they must take
+    the dynamic wrapper, which replans for the current shape on every call.
+    """
+    return (
+        pure_decode
+        and num_decode_tokens <= decode_cudagraph_max_bs
+        and decode_q_len == planned_decode_q_len
+    )
+
+
 class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
     reorder_batch_threshold: int = 1
 
@@ -664,6 +696,10 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             if speculative_config is not None
             else 0
         )
+        # The frozen per-request query length persistent decode wrappers are
+        # planned with during capture. See persistent_decode_wrapper_eligible
+        # for why this must never be conflated with reorder_batch_threshold.
+        self._planned_decode_q_len = 1 + num_spec_tokens
         self.enable_cuda_graph = (
             self.compilation_config.cudagraph_mode.decode_mode() == CUDAGraphMode.FULL
         )
@@ -1507,16 +1543,21 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             else:
                 assert seq_lens_cpu is not None
                 pure_decode = num_prefills == 0
-                use_cudagraph = (
-                    self.enable_cuda_graph
-                    and pure_decode
-                    and num_decode_tokens <= self._decode_cudagraph_max_bs
-                )
                 # Spec-as-decode verify batches carry a uniform
                 # num_decode_tokens // num_decodes tokens per request; the
                 # wrapper's batch size and kv metadata are per request.
                 assert num_decode_tokens % num_decodes == 0
                 decode_q_len = num_decode_tokens // num_decodes
+                use_cudagraph = (
+                    self.enable_cuda_graph
+                    and persistent_decode_wrapper_eligible(
+                        pure_decode=pure_decode,
+                        num_decode_tokens=num_decode_tokens,
+                        decode_cudagraph_max_bs=self._decode_cudagraph_max_bs,
+                        decode_q_len=decode_q_len,
+                        planned_decode_q_len=self._planned_decode_q_len,
+                    )
+                )
 
                 decode_wrapper = self._get_decode_wrapper(num_decodes, use_cudagraph)
                 # Use the persistent buffer with padding length,

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -641,12 +641,51 @@ def persistent_decode_wrapper_eligible(
     (spec truncation near ``max_tokens``, short chunked-prefill tails fused
     with the spec step). Those are valid decode batches, but they must take
     the dynamic wrapper, which replans for the current shape on every call.
+
+    Args:
+        pure_decode: True when the batch contains no prefill requests.
+        num_decode_tokens: Total scheduled tokens across the decode requests.
+        decode_cudagraph_max_bs: Token capacity the persistent wrappers were
+            sized for ((1 + num_spec_tokens) * max_num_reqs, capped by
+            ``max_cudagraph_capture_size``).
+        decode_q_len: Runtime per-request query length of the active
+            (non-padding) decode requests.
+        planned_decode_q_len: Frozen per-request query length the persistent
+            wrappers were planned with (1 + num_spec_tokens).
+
+    Returns:
+        True when the batch may be routed to the persistent (CUDA-graph)
+        decode wrapper; False when it must use the dynamic wrapper.
     """
     return (
         pure_decode
         and num_decode_tokens <= decode_cudagraph_max_bs
         and decode_q_len == planned_decode_q_len
     )
+
+
+def decode_q_len_from_indptr(qo_indptr_cpu: torch.Tensor, num_decodes: int) -> int:
+    """Per-request query length of the active decode requests in a batch.
+
+    Uniform CUDA-graph decode batches may carry zero-length padding rows
+    (``split_decodes_and_prefills`` classifies ``q_len == 0`` padding as
+    decode so ``num_decodes`` matches the captured size). Averaging
+    ``num_decode_tokens`` over ``num_decodes`` would understate the active
+    query length for such batches and wrongly demote them to the dynamic
+    wrapper, so the length is taken as the maximum per-request span instead
+    (decode rows are uniform-or-zero by construction).
+
+    Args:
+        qo_indptr_cpu: CPU query-start-loc tensor for the batch.
+        num_decodes: Number of decode-classified requests, including any
+            zero-length padding rows.
+
+    Returns:
+        The uniform query length of the active decode requests, or 0 when
+        every row is padding.
+    """
+    lens = qo_indptr_cpu[1 : num_decodes + 1] - qo_indptr_cpu[:num_decodes]
+    return int(lens.max().item()) if num_decodes > 0 else 0
 
 
 class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
@@ -1543,11 +1582,11 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             else:
                 assert seq_lens_cpu is not None
                 pure_decode = num_prefills == 0
-                # Spec-as-decode verify batches carry a uniform
-                # num_decode_tokens // num_decodes tokens per request; the
-                # wrapper's batch size and kv metadata are per request.
-                assert num_decode_tokens % num_decodes == 0
-                decode_q_len = num_decode_tokens // num_decodes
+                # Spec-as-decode verify batches carry a uniform per-request
+                # query length; uniform CUDA-graph batches may additionally
+                # carry zero-length padding rows, so the active length comes
+                # from the per-request spans, not an average.
+                decode_q_len = decode_q_len_from_indptr(qo_indptr_cpu, num_decodes)
                 use_cudagraph = (
                     self.enable_cuda_graph
                     and persistent_decode_wrapper_eligible(


### PR DESCRIPTION
Fixes #233.

Persistent FlashInfer decode wrappers are planned during capture with a
frozen `q_len_per_req` of `1 + num_spec_tokens`, but the builder's
`use_cudagraph` predicate only checked capacity. Reduced-depth lone steps
the scheduler legitimately produces - spec truncation near `max_tokens`,
short chunked-prefill tails fused with the spec step - are
decode-classified (the reorder threshold under parallel drafting is
`1 + 2K`), reach the frozen wrapper, and die in `fast_decode_plan`
("planned with 6, got 8|5" → `EngineDeadError`). Reachable by any
length-capped request whose budget isn't a multiple of K+1; full trace and
scheduler dump in the issue.

This completes the predicate at the site that owns the decision:

- `_planned_decode_q_len = 1 + num_spec_tokens` stored in the builder
  (the same quantity that already sizes `_decode_cudagraph_max_bs`);
- eligibility factored into a pure function,
  `persistent_decode_wrapper_eligible`, whose docstring pins the invariant - including that the classification ceiling (`1 + 2K`) must never be
  substituted for the planned shape (`1 + K`);
- mismatched steps take the existing dynamic wrapper, which replans per
  call. Steady-state verification keeps FULL graphs.

Tests: threshold(1+2K)/planned(1+K) derivation, planned shape → persistent
wrapper, every `q_len ∈ {1..1+2K}\{1+K}` → dynamic fallback (covers both
observed signatures), above-ceiling → prefill classification, capacity and
no-spec terms.

Validated in production on a GB10 TP2 pair (Laguna-S-2.1-FP8 + DFlash-FP8
K=5): both deterministic reproducers complete with the engine alive,
outputs token-exact vs piecewise at temperature 0, replay logging confirms
the persistent FULL path stays active, and the previously-crashing bench
sweep survives. FULL (capture 96) vs piecewise at equal sampling: +28.8%
15-cell decode geomean, +49% coding-peak.

Longer-term follow-ups suggested in the issue: per-q_len wrapper families
so reduced-depth steps can also replay FULL graphs; making the dispatcher's
batch descriptor the single source of truth for graph eligibility; renaming
`_decode_cudagraph_max_bs` (it is a token count).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved decode processing to reuse optimized execution only when query lengths match the captured configuration.
  * Added safer fallback handling for mismatched lengths, oversized batches, and non-decode requests.
  * Preserved correct behavior for speculative decoding and no-speculation scenarios.
* **Tests**
  * Added coverage for query-length thresholds, routing decisions, batch limits, and prefill classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->