### PR TITLE
[GG] fix(ds4): align 0731 reasoning and tool prompt contract

### DIFF
--- a/rust/src/chat/src/renderer/deepseek_v4/encoding.rs
+++ b/rust/src/chat/src/renderer/deepseek_v4/encoding.rs
@@ -24,10 +24,15 @@ const THINKING_END_TOKEN: &str = "</think>";
 const DSML_TOKEN: &str = "｜DSML｜";
 const USER_SP_TOKEN: &str = "<｜User｜>";
 const ASSISTANT_SP_TOKEN: &str = "<｜Assistant｜>";
-const REASONING_EFFORT_MAX: &str = concat!(
+const REASONING_EFFORT_HIGH: &str = concat!(
     "Reasoning Effort: Absolute maximum with no shortcuts permitted.\n",
     "You MUST be very thorough in your thinking and comprehensively decompose the problem to resolve the root cause, rigorously stress-testing your logic against all potential paths, edge cases, and adversarial scenarios.\n",
     "Explicitly write out your entire deliberation process, documenting every intermediate step, considered alternative, and rejected hypothesis to ensure absolutely no assumption is left unchecked.\n\n",
+);
+const REASONING_EFFORT_MAX: &str = concat!(
+    "Reasoning Effort: Beyond maximum — exhaustive, relentless, and uncompromising.\n",
+    "You MUST reason with the utmost depth and rigor, leaving absolutely nothing to chance: exhaustively decompose the problem into its most fundamental components, trace every causal chain to its root, and resolve the underlying cause rather than any surface symptom.\n",
+    "Do not stop reasoning until you have independently verified the solution from multiple angles and are certain that no assumption remains unchecked and no error remains undiscovered.\n\n",
 );
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -47,7 +52,7 @@ struct RenderedToolSchema<'a> {
 
 /// Render one chat request into the final prompt string.
 pub(super) fn render_request(request: &ChatRequest) -> Result<String> {
-    let (thinking_mode, max_reasoning_effort) = resolve_thinking_options(request)?;
+    let (thinking_mode, reasoning_effort_prompt) = resolve_thinking_options(request)?;
     let request_tools = request_tools(request);
     let synthetic_tool_system = needs_synthetic_tool_system(request, request_tools);
     let drop_thinking = request.parse_template_bool("drop_thinking")?.unwrap_or(true)
@@ -55,8 +60,8 @@ pub(super) fn render_request(request: &ChatRequest) -> Result<String> {
     let last_user_render_index =
         find_last_user_render_index(request.messages.as_slice(), synthetic_tool_system);
     let mut out = String::from(BOS_TOKEN);
-    if thinking_mode == ThinkingMode::Thinking && max_reasoning_effort {
-        out.push_str(REASONING_EFFORT_MAX);
+    if thinking_mode == ThinkingMode::Thinking {
+        out.push_str(reasoning_effort_prompt);
     }
 
     let mut request_tools_attached = false;
@@ -124,20 +129,25 @@ pub(super) fn render_request(request: &ChatRequest) -> Result<String> {
 /// wrapper, the Rust renderer only consumes the typed top-level
 /// `reasoning_effort`; the generic template-kwargs map is left for HF
 /// templates.
-fn resolve_thinking_options(request: &ChatRequest) -> Result<(ThinkingMode, bool)> {
+fn resolve_thinking_options(request: &ChatRequest) -> Result<(ThinkingMode, &'static str)> {
     let mut thinking_mode = match request.enable_thinking()?.unwrap_or(false) {
         true => ThinkingMode::Thinking,
         false => ThinkingMode::Chat,
     };
-    let mut max_reasoning_effort = false;
+    let mut reasoning_effort_prompt = "";
 
     match request.chat_options.reasoning_effort {
         Some(ReasoningEffort::None) => thinking_mode = ThinkingMode::Chat,
-        Some(ReasoningEffort::Max | ReasoningEffort::XHigh) => max_reasoning_effort = true,
+        Some(ReasoningEffort::Max | ReasoningEffort::XHigh) => {
+            reasoning_effort_prompt = REASONING_EFFORT_MAX;
+        }
+        Some(ReasoningEffort::Minimal | ReasoningEffort::Medium | ReasoningEffort::High) => {
+            reasoning_effort_prompt = REASONING_EFFORT_HIGH;
+        }
         Some(_) | None => {}
     }
 
-    Ok((thinking_mode, max_reasoning_effort))
+    Ok((thinking_mode, reasoning_effort_prompt))
 }
 
 /// Return request-level tools only when native tool parsing is enabled.

--- a/rust/src/chat/src/renderer/deepseek_v4/tests.rs
+++ b/rust/src/chat/src/renderer/deepseek_v4/tests.rs
@@ -10,7 +10,9 @@ use super::DeepSeekV4ChatRenderer;
 use crate::ChatRenderer;
 use crate::event::{AssistantContentBlock, AssistantToolCall};
 use crate::renderer::test_utils::{FixtureRequestOptions, fixture_chat_request};
-use crate::request::{ChatMessage, ChatRequest, GenerationPromptMode, ReasoningEffort};
+use crate::request::{
+    ChatMessage, ChatRequest, ChatTool, ChatToolChoice, GenerationPromptMode, ReasoningEffort,
+};
 
 fn render_request(request: &ChatRequest) -> String {
     DeepSeekV4ChatRenderer::new()
@@ -76,12 +78,86 @@ fn reasoning_effort_max_adds_prefix_when_thinking_is_enabled() {
     let rendered = render_request(&request);
 
     expect![[r#"
+        <｜begin▁of▁sentence｜>Reasoning Effort: Beyond maximum — exhaustive, relentless, and uncompromising.
+        You MUST reason with the utmost depth and rigor, leaving absolutely nothing to chance: exhaustively decompose the problem into its most fundamental components, trace every causal chain to its root, and resolve the underlying cause rather than any surface symptom.
+        Do not stop reasoning until you have independently verified the solution from multiple angles and are certain that no assumption remains unchecked and no error remains undiscovered.
+
+        <｜User｜>solve it<｜Assistant｜><think>"#]]
+    .assert_eq(&rendered);
+}
+
+#[test]
+fn reasoning_effort_high_adds_0731_high_prefix() {
+    let mut request = ChatRequest {
+        messages: vec![ChatMessage::user("solve it")],
+        ..ChatRequest::for_test()
+    };
+    request
+        .chat_options
+        .template_kwargs
+        .insert("thinking".to_string(), Value::Bool(true));
+    request.chat_options.reasoning_effort = Some(ReasoningEffort::High);
+
+    let rendered = render_request(&request);
+
+    expect![[r#"
         <｜begin▁of▁sentence｜>Reasoning Effort: Absolute maximum with no shortcuts permitted.
         You MUST be very thorough in your thinking and comprehensively decompose the problem to resolve the root cause, rigorously stress-testing your logic against all potential paths, edge cases, and adversarial scenarios.
         Explicitly write out your entire deliberation process, documenting every intermediate step, considered alternative, and rejected hypothesis to ensure absolutely no assumption is left unchecked.
 
         <｜User｜>solve it<｜Assistant｜><think>"#]]
     .assert_eq(&rendered);
+}
+
+#[test]
+fn reasoning_effort_low_keeps_the_default_prompt() {
+    let mut request = ChatRequest {
+        messages: vec![ChatMessage::user("solve it")],
+        ..ChatRequest::for_test()
+    };
+    request
+        .chat_options
+        .template_kwargs
+        .insert("thinking".to_string(), Value::Bool(true));
+    request.chat_options.reasoning_effort = Some(ReasoningEffort::Low);
+
+    let rendered = render_request(&request);
+
+    expect!["<｜begin▁of▁sentence｜><｜User｜>solve it<｜Assistant｜><think>"].assert_eq(&rendered);
+}
+
+#[test]
+fn request_tools_follow_existing_system_prompt() {
+    let mut request = ChatRequest {
+        messages: vec![
+            ChatMessage::system("Follow policy."),
+            ChatMessage::user("Find it."),
+        ],
+        tools: vec![ChatTool {
+            name: "lookup".to_string(),
+            description: Some("Look things up".to_string()),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {},
+            }),
+            strict: None,
+        }],
+        tool_choice: ChatToolChoice::Auto,
+        ..ChatRequest::for_test()
+    };
+    request
+        .chat_options
+        .template_kwargs
+        .insert("thinking".to_string(), Value::Bool(true));
+    request.chat_options.reasoning_effort = Some(ReasoningEffort::Max);
+
+    let rendered = render_request(&request);
+
+    let prefix = rendered.find("Reasoning Effort: Beyond maximum").unwrap();
+    let system = rendered.find("Follow policy.").unwrap();
+    let tools = rendered.find("## Tools").unwrap();
+    let user = rendered.find("<｜User｜>Find it.").unwrap();
+    assert!(prefix < system && system < tools && tools < user);
 }
 
 #[test]

--- a/tests/entrypoints/unit_tests/test_chat_utils.py
+++ b/tests/entrypoints/unit_tests/test_chat_utils.py
@@ -708,6 +708,30 @@ def test_parse_chat_messages_empty_system(
     ]
 
 
+@pytest.mark.parametrize("role", ["system", "developer"])
+def test_parse_chat_messages_preserves_message_level_tools(
+    mistral_model_config,
+    role,
+):
+    # Message-level `tools` (as opposed to the request-level `tools`
+    # parameter) must be preserved on both "system" and "developer" role
+    # messages: chat template/encoders such as DeepSeek-V4 and DeepSeek-V3.2
+    # read message-level tools for either role.
+    tools = [{"type": "function", "function": {"name": "get_weather"}}]
+    conversation, _, _ = parse_chat_messages(
+        [
+            {"role": role, "content": "you have tools", "tools": tools},
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": "Hi"}],
+            },
+        ],
+        mistral_model_config,
+        content_format="string",
+    )
+    assert conversation[0]["tools"] == tools
+
+
 @pytest.mark.asyncio
 async def test_parse_chat_messages_single_image_async(
     phi3v_model_config,

--- a/tests/tokenizers_/fixtures/deepseek_v4/test_output_1.txt
+++ b/tests/tokenizers_/fixtures/deepseek_v4/test_output_1.txt
@@ -1,4 +1,4 @@
-<｜begin▁of▁sentence｜>
+<｜begin▁of▁sentence｜>You are a helpful assistant.
 
 ## Tools
 
@@ -26,7 +26,7 @@ Otherwise, output directly after </think> with tool calls or final response.
 {"name": "search", "description": "Search the web for information", "parameters": {"type": "object", "properties": {"query": {"type": "string", "description": "Search query"}, "num_results": {"type": "integer", "description": "Number of results to return"}}, "required": ["query"]}}
 
 You MUST strictly follow the above defined tool name and parameter schemas to invoke tool calls.
-You are a helpful assistant.<｜User｜>What's the weather in Beijing?<｜Assistant｜><think>The user wants to know the weather in Beijing. I should use the get_weather tool.</think>
+<｜User｜>What's the weather in Beijing?<｜Assistant｜><think>The user wants to know the weather in Beijing. I should use the get_weather tool.</think>
 
 <｜DSML｜tool_calls>
 <｜DSML｜invoke name="get_weather">

--- a/tests/tokenizers_/test_deepseek_v4.py
+++ b/tests/tokenizers_/test_deepseek_v4.py
@@ -158,6 +158,102 @@ def test_deepseek_v4_attaches_request_tools_after_existing_system_prompt():
     assert prompt.index(tool_block) < prompt.index(user)
 
 
+def test_deepseek_v4_attaches_request_tools_to_existing_developer_prompt():
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "lookup",
+                "description": "Look things up",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+
+    prompt = _tokenizer().apply_chat_template(
+        [
+            {"role": "developer", "content": "Follow policy."},
+            {"role": "user", "content": "Find it."},
+        ],
+        tools=tools,
+        tokenize=False,
+    )
+
+    assert prompt.index("Follow policy.") < prompt.index("## Tools")
+    assert prompt.index("## Tools") < prompt.index("<｜User｜>Find it.")
+    assert prompt.count("## Tools") == 1
+
+
+def test_deepseek_v4_merges_message_and_request_tools_into_one_block():
+    message_tools = [
+        {
+            "type": "function",
+            "function": {"name": "old_tool", "parameters": {"type": "object"}},
+        }
+    ]
+    request_tools = [
+        {
+            "type": "function",
+            "function": {"name": "new_tool", "parameters": {"type": "object"}},
+        }
+    ]
+
+    prompt = _tokenizer().apply_chat_template(
+        [
+            {
+                "role": "system",
+                "content": "Follow policy.",
+                "tools": message_tools,
+            },
+            {"role": "user", "content": "Find it."},
+        ],
+        tools=request_tools,
+        tokenize=False,
+    )
+
+    assert prompt.count("## Tools") == 1
+    assert '"name": "new_tool"' in prompt
+    assert '"name": "old_tool"' in prompt
+
+
+def test_deepseek_v4_request_tool_replaces_same_named_message_tool():
+    prompt = _tokenizer().apply_chat_template(
+        [
+            {
+                "role": "system",
+                "content": "Follow policy.",
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "lookup",
+                            "description": "old definition",
+                            "parameters": {"type": "object"},
+                        },
+                    }
+                ],
+            },
+            {"role": "user", "content": "Find it."},
+        ],
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "lookup",
+                    "description": "new definition",
+                    "parameters": {"type": "object"},
+                },
+            }
+        ],
+        tokenize=False,
+    )
+
+    assert prompt.count("## Tools") == 1
+    assert prompt.count('"name": "lookup"') == 1
+    assert "new definition" in prompt
+    assert "old definition" not in prompt
+
+
 def test_deepseek_v4_renders_message_level_system_tools():
     tools = [
         {
@@ -244,6 +340,45 @@ def test_deepseek_v4_renders_parsed_history_tool_arguments():
     assert '<｜DSML｜parameter name="command" string="true">view' in prompt
     assert '<｜DSML｜parameter name="path" string="true">/testbed' in prompt
     assert 'parameter name="arguments"' not in prompt
+
+
+@pytest.mark.parametrize(
+    ("arguments", "expected_value", "is_string"),
+    [
+        ("", "", True),
+        ("not json", "not json", True),
+        ('{"unterminated": 1', '{"unterminated": 1', True),
+        (None, "null", False),
+        ([1, 2], "[1, 2]", False),
+        ("[1, 2]", "[1, 2]", False),
+    ],
+)
+def test_deepseek_v4_renders_non_object_history_tool_arguments(
+    arguments,
+    expected_value,
+    is_string,
+):
+    prompt = _tokenizer().apply_chat_template(
+        [
+            {"role": "user", "content": "Run it"},
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "type": "function",
+                        "function": {"name": "run", "arguments": arguments},
+                    }
+                ],
+            },
+        ],
+        tokenize=False,
+    )
+
+    parameter = (
+        f'<｜DSML｜parameter name="arguments" '
+        f'string="{str(is_string).lower()}">{expected_value}'
+    )
+    assert parameter in prompt
 
 
 @pytest.mark.parametrize(

--- a/tests/tokenizers_/test_deepseek_v4.py
+++ b/tests/tokenizers_/test_deepseek_v4.py
@@ -126,6 +126,69 @@ def test_deepseek_v4_uses_v4_tool_prompt_from_request_tools():
     assert prompt.endswith("<｜User｜>Weather?<｜Assistant｜></think>")
 
 
+def test_deepseek_v4_attaches_request_tools_after_existing_system_prompt():
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "lookup",
+                "description": "Look things up",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+
+    prompt = _tokenizer().apply_chat_template(
+        [
+            {"role": "system", "content": "Follow policy."},
+            {"role": "user", "content": "Find it."},
+        ],
+        tools=tools,
+        tokenize=False,
+        enable_thinking=True,
+        reasoning_effort="max",
+    )
+
+    max_prefix = "Reasoning Effort: Beyond maximum"
+    system = "Follow policy."
+    tool_block = "## Tools"
+    user = "<｜User｜>Find it."
+    assert prompt.index(max_prefix) < prompt.index(system)
+    assert prompt.index(system) < prompt.index(tool_block)
+    assert prompt.index(tool_block) < prompt.index(user)
+
+
+def test_deepseek_v4_renders_message_level_system_tools():
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "lookup",
+                "description": "Look things up",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+    messages = [
+        {"role": "system", "content": "Follow policy.", "tools": tools},
+        {"role": "user", "content": "Find it."},
+    ]
+    conversation, _, _ = parse_chat_messages(
+        messages,
+        _model_config(),
+        content_format="string",
+    )
+
+    prompt = _tokenizer().apply_chat_template(
+        conversation=conversation,
+        messages=messages,
+        tokenize=False,
+    )
+
+    assert prompt.index("Follow policy.") < prompt.index("## Tools")
+    assert prompt.index("## Tools") < prompt.index("<｜User｜>Find it.")
+
+
 def test_deepseek_v4_renders_parsed_history_tool_arguments():
     messages = [
         {"role": "user", "content": "List the repo"},
@@ -183,8 +246,17 @@ def test_deepseek_v4_renders_parsed_history_tool_arguments():
     assert 'parameter name="arguments"' not in prompt
 
 
-@pytest.mark.parametrize("reasoning_effort", ["minimal", "low", "medium", "high"])
-def test_deepseek_v4_accepts_openai_reasoning_effort_values(reasoning_effort):
+@pytest.mark.parametrize(
+    ("reasoning_effort", "expected_prefix"),
+    [
+        ("low", "<｜begin▁of▁sentence｜><｜User｜>Hello"),
+        ("high", "<｜begin▁of▁sentence｜>Reasoning Effort: Absolute maximum"),
+        ("max", "<｜begin▁of▁sentence｜>Reasoning Effort: Beyond maximum"),
+    ],
+)
+def test_deepseek_v4_renders_0731_reasoning_effort_prompts(
+    reasoning_effort, expected_prefix
+):
     prompt = _tokenizer().apply_chat_template(
         [{"role": "user", "content": "Hello"}],
         tokenize=False,
@@ -193,7 +265,7 @@ def test_deepseek_v4_accepts_openai_reasoning_effort_values(reasoning_effort):
     )
 
     assert prompt.endswith("<｜Assistant｜><think>")
-    assert "Reasoning Effort: Absolute maximum" not in prompt
+    assert prompt.startswith(expected_prefix)
 
 
 def test_deepseek_v4_none_reasoning_effort_disables_thinking():
@@ -212,7 +284,7 @@ def test_deepseek_v4_none_reasoning_effort_disables_thinking():
     [
         ("none", "chat", None),
         ("minimal", "thinking", "high"),
-        ("low", "thinking", "high"),
+        ("low", "thinking", "low"),
         ("medium", "thinking", "high"),
         ("high", "thinking", "high"),
         ("xhigh", "thinking", "max"),
@@ -248,7 +320,7 @@ def test_deepseek_v4_maps_compatible_thinking_reasoning_effort_values(
     assert captured_kwargs[-1]["reasoning_effort"] == expected_effort
 
 
-def test_deepseek_v4_preserves_reference_max_reasoning_effort():
+def test_deepseek_v4_renders_0731_max_reasoning_effort():
     prompt = _tokenizer().apply_chat_template(
         [{"role": "user", "content": "Hello"}],
         tokenize=False,
@@ -256,12 +328,10 @@ def test_deepseek_v4_preserves_reference_max_reasoning_effort():
         reasoning_effort="max",
     )
 
-    assert prompt.startswith(
-        "<｜begin▁of▁sentence｜>Reasoning Effort: Absolute maximum"
-    )
+    assert prompt.startswith("<｜begin▁of▁sentence｜>Reasoning Effort: Beyond maximum")
 
 
-def test_deepseek_v4_maps_xhigh_to_reference_max_reasoning_effort():
+def test_deepseek_v4_maps_xhigh_to_0731_max_reasoning_effort():
     prompt = _tokenizer().apply_chat_template(
         [{"role": "user", "content": "Hello"}],
         tokenize=False,
@@ -269,9 +339,7 @@ def test_deepseek_v4_maps_xhigh_to_reference_max_reasoning_effort():
         reasoning_effort="xhigh",
     )
 
-    assert prompt.startswith(
-        "<｜begin▁of▁sentence｜>Reasoning Effort: Absolute maximum"
-    )
+    assert prompt.startswith("<｜begin▁of▁sentence｜>Reasoning Effort: Beyond maximum")
 
 
 @pytest.mark.parametrize(

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -1867,8 +1867,8 @@ def _parse_chat_message_content(
         if "task" in message and isinstance(message["task"], str):
             result_msg["task"] = message["task"]
 
-        if role in ("system", "developer"):
-            result_msg["tools"] = message.get("tools", None)
+        if role in ("system", "developer") and message.get("tools") is not None:
+            result_msg["tools"] = message["tools"]
     return result
 
 

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -359,7 +359,12 @@ class CustomChatCompletionMessageParam(TypedDict, total=False):
     """The reasoning content for interleaved thinking."""
 
     tools: list[ChatCompletionFunctionToolParam] | None
-    """The tools for developer role."""
+    """Message-level tools, preserved for "system" and "developer" roles.
+
+    Used by chat templates/encoders (e.g. DeepSeek-V4, DeepSeek-V3.2) that
+    accept tools attached directly to a system or developer message, as
+    opposed to (or in addition to) the request-level `tools` parameter.
+    """
 
     task: str | None
     """Model-specific task marker. Currently passed through for DeepSeek V4."""
@@ -396,7 +401,12 @@ class ConversationMessage(TypedDict, total=False):
     """Deprecated: The reasoning content for interleaved thinking."""
 
     tools: list[ChatCompletionFunctionToolParam] | None
-    """The tools for developer role."""
+    """Message-level tools, preserved for "system" and "developer" roles.
+
+    Used by chat templates/encoders (e.g. DeepSeek-V4, DeepSeek-V3.2) that
+    accept tools attached directly to a system or developer message, as
+    opposed to (or in addition to) the request-level `tools` parameter.
+    """
 
     task: str | None
     """Model-specific task marker. Currently passed through for DeepSeek V4."""
@@ -1857,7 +1867,7 @@ def _parse_chat_message_content(
         if "task" in message and isinstance(message["task"], str):
             result_msg["task"] = message["task"]
 
-        if role == "developer":
+        if role in ("system", "developer"):
             result_msg["tools"] = message.get("tools", None)
     return result
 

--- a/vllm/tokenizers/deepseek_v4.py
+++ b/vllm/tokenizers/deepseek_v4.py
@@ -37,8 +37,15 @@ def get_deepseek_v4_tokenizer(tokenizer: HfTokenizer) -> HfTokenizer:
             conversation = kwargs.get("conversation", messages)
             messages = conversation.copy()
             if tools is not None and len(tools) > 0:
-                messages.insert(0, {"role": "system"})
-                messages[0]["tools"] = tools  # type: ignore[typeddict-unknown-key]
+                for index, message in enumerate(messages):
+                    if message.get("role") == "system":
+                        system_message = message.copy()
+                        system_message["tools"] = tools  # type: ignore[typeddict-unknown-key]
+                        messages[index] = system_message
+                        break
+                else:
+                    messages.insert(0, {"role": "system"})
+                    messages[0]["tools"] = tools  # type: ignore[typeddict-unknown-key]
 
             reasoning_effort = kwargs.get("reasoning_effort")
             if not isinstance(reasoning_effort, str):
@@ -48,6 +55,8 @@ def get_deepseek_v4_tokenizer(tokenizer: HfTokenizer) -> HfTokenizer:
                 reasoning_effort = None
             elif reasoning_effort in ("max", "xhigh"):
                 reasoning_effort = "max"
+            elif reasoning_effort == "low":
+                reasoning_effort = "low"
             else:
                 reasoning_effort = "high"
 

--- a/vllm/tokenizers/deepseek_v4.py
+++ b/vllm/tokenizers/deepseek_v4.py
@@ -38,10 +38,21 @@ def get_deepseek_v4_tokenizer(tokenizer: HfTokenizer) -> HfTokenizer:
             messages = conversation.copy()
             if tools is not None and len(tools) > 0:
                 for index, message in enumerate(messages):
-                    if message.get("role") == "system":
-                        system_message = message.copy()
-                        system_message["tools"] = tools  # type: ignore[typeddict-unknown-key]
-                        messages[index] = system_message
+                    if message.get("role") in ("system", "developer"):
+                        prompt_message = message.copy()
+                        message_tools = prompt_message.get("tools")
+                        request_tool_names = {
+                            tool.get("function", {}).get("name") for tool in tools
+                        }
+                        merged_tools = [
+                            tool
+                            for tool in message_tools or []
+                            if tool.get("function", {}).get("name")
+                            not in request_tool_names
+                        ]
+                        merged_tools.extend(tools)
+                        prompt_message["tools"] = merged_tools  # type: ignore[typeddict-unknown-key]
+                        messages[index] = prompt_message
                         break
                 else:
                     messages.insert(0, {"role": "system"})

--- a/vllm/tokenizers/deepseek_v4_encoding.py
+++ b/vllm/tokenizers/deepseek_v4_encoding.py
@@ -65,11 +65,20 @@ tool_output_template: str = (
     "<tool_result>{content}</tool_result>"
 )
 
-REASONING_EFFORT_MAX = (
-    "Reasoning Effort: Absolute maximum with no shortcuts permitted.\n"
-    "You MUST be very thorough in your thinking and comprehensively decompose the problem to resolve the root cause, rigorously stress-testing your logic against all potential paths, edge cases, and adversarial scenarios.\n"
-    "Explicitly write out your entire deliberation process, documenting every intermediate step, considered alternative, and rejected hypothesis to ensure absolutely no assumption is left unchecked.\n\n"
-)
+REASONING_EFFORT_PROMPTS: Dict[str, str] = {
+    "low": "",
+    "high": (
+        "Reasoning Effort: Absolute maximum with no shortcuts permitted.\n"
+        "You MUST be very thorough in your thinking and comprehensively decompose the problem to resolve the root cause, rigorously stress-testing your logic against all potential paths, edge cases, and adversarial scenarios.\n"
+        "Explicitly write out your entire deliberation process, documenting every intermediate step, considered alternative, and rejected hypothesis to ensure absolutely no assumption is left unchecked.\n\n"
+    ),
+    "max": (
+        "Reasoning Effort: Beyond maximum — exhaustive, relentless, and uncompromising.\n"
+        "You MUST reason with the utmost depth and rigor, leaving absolutely nothing to chance: exhaustively decompose the problem into its most fundamental components, trace every causal chain to its root, and resolve the underlying cause rather than any surface symptom.\n"
+        "Do not stop reasoning until you have independently verified the solution from multiple angles and are certain that no assumption remains unchecked and no error remains undiscovered.\n\n"
+    ),
+}
+DEFAULT_REASONING_EFFORT = "low"
 
 TOOLS_TEMPLATE = """## Tools
 
@@ -202,7 +211,8 @@ def render_message(index: int, messages: List[Dict[str, Any]], thinking_mode: st
         messages: Full list of messages in the conversation.
         thinking_mode: Either "chat" or "thinking".
         drop_thinking: Whether to drop reasoning content from earlier turns.
-        reasoning_effort: Optional reasoning effort level ("max", "high", or None).
+        reasoning_effort: Reasoning effort level, one of "low", "high", "max".
+            None is treated as "low".
 
     Returns:
         Encoded string for this message.
@@ -227,10 +237,13 @@ def render_message(index: int, messages: List[Dict[str, Any]], thinking_mode: st
     if tool_calls:
         tool_calls = tool_calls_from_openai_format(tool_calls)
 
-    # Reasoning effort prefix (only at index 0 in thinking mode with max effort)
-    assert reasoning_effort in ['max', None, 'high'], f"Invalid reasoning effort: {reasoning_effort}"
-    if index == 0 and thinking_mode == "thinking" and reasoning_effort == 'max':
-        prompt += REASONING_EFFORT_MAX
+    reasoning_effort = reasoning_effort or DEFAULT_REASONING_EFFORT
+    assert reasoning_effort in REASONING_EFFORT_PROMPTS, (
+        f"Invalid reasoning effort: {reasoning_effort}, expected one of "
+        f"{list(REASONING_EFFORT_PROMPTS)}"
+    )
+    if index == 0 and thinking_mode == "thinking":
+        prompt += REASONING_EFFORT_PROMPTS[reasoning_effort]
 
     if role == "system":
         prompt += system_msg_template.format(content=content or "")
@@ -497,7 +510,8 @@ def encode_messages(
         drop_thinking: If True, drop reasoning from earlier assistant turns
                       (only keep reasoning for messages after the last user message).
         add_default_bos_token: Whether to prepend BOS token at conversation start.
-        reasoning_effort: Optional reasoning effort level ("max", "high", or None).
+        reasoning_effort: Reasoning effort level, one of "low", "high", "max".
+            Only takes effect in thinking mode. None is treated as "low".
 
     Returns:
         The encoded prompt string.

--- a/vllm/tokenizers/deepseek_v4_encoding.py
+++ b/vllm/tokenizers/deepseek_v4_encoding.py
@@ -69,13 +69,24 @@ REASONING_EFFORT_PROMPTS: Dict[str, str] = {
     "low": "",
     "high": (
         "Reasoning Effort: Absolute maximum with no shortcuts permitted.\n"
-        "You MUST be very thorough in your thinking and comprehensively decompose the problem to resolve the root cause, rigorously stress-testing your logic against all potential paths, edge cases, and adversarial scenarios.\n"
-        "Explicitly write out your entire deliberation process, documenting every intermediate step, considered alternative, and rejected hypothesis to ensure absolutely no assumption is left unchecked.\n\n"
+        "You MUST be very thorough in your thinking and comprehensively "
+        "decompose the problem to resolve the root cause, rigorously "
+        "stress-testing your logic against all potential paths, edge cases, "
+        "and adversarial scenarios.\n"
+        "Explicitly write out your entire deliberation process, documenting "
+        "every intermediate step, considered alternative, and rejected "
+        "hypothesis to ensure absolutely no assumption is left unchecked.\n\n"
     ),
     "max": (
-        "Reasoning Effort: Beyond maximum — exhaustive, relentless, and uncompromising.\n"
-        "You MUST reason with the utmost depth and rigor, leaving absolutely nothing to chance: exhaustively decompose the problem into its most fundamental components, trace every causal chain to its root, and resolve the underlying cause rather than any surface symptom.\n"
-        "Do not stop reasoning until you have independently verified the solution from multiple angles and are certain that no assumption remains unchecked and no error remains undiscovered.\n\n"
+        "Reasoning Effort: Beyond maximum — exhaustive, relentless, and "
+        "uncompromising.\n"
+        "You MUST reason with the utmost depth and rigor, leaving absolutely "
+        "nothing to chance: exhaustively decompose the problem into its most "
+        "fundamental components, trace every causal chain to its root, and "
+        "resolve the underlying cause rather than any surface symptom.\n"
+        "Do not stop reasoning until you have independently verified the "
+        "solution from multiple angles and are certain that no assumption "
+        "remains unchecked and no error remains undiscovered.\n\n"
     ),
 }
 DEFAULT_REASONING_EFFORT = "low"
@@ -148,10 +159,19 @@ def encode_arguments_to_dsml(tool_call: Dict[str, Any]) -> str:
     p_dsml_template = '<{dsml_token}parameter name="{key}" string="{is_str}">{value}</{dsml_token}parameter>'
     P_dsml_strs = []
 
-    if isinstance(tool_call["arguments"], str):
-        arguments = json.loads(tool_call["arguments"])
+    raw_arguments = tool_call.get("arguments")
+    if isinstance(raw_arguments, str):
+        try:
+            arguments = json.loads(raw_arguments)
+        except (TypeError, ValueError):
+            arguments = {"arguments": raw_arguments}
     else:
-        arguments = tool_call["arguments"]
+        arguments = raw_arguments
+
+    # Historical tool calls are not always normalized to an object. Preserve
+    # those values as one explicit parameter instead of failing prompt render.
+    if not isinstance(arguments, dict):
+        arguments = {"arguments": arguments}
 
     for k, v in arguments.items():
         p_dsml_str = p_dsml_template.format(


### PR DESCRIPTION
## Summary

DeepSeek-V4-Flash-0731 changed the reasoning-effort contract and required tool-schema placement. GG still carried preview-era behavior.

This PR:

- ports the official 0731 low, high, and max prefixes to the Python and Rust renderers;
- keeps minimal/medium as compatibility aliases for high and xhigh as an alias for max;
- preserves tools attached to system and developer messages;
- attaches request tools to the first existing system or developer message, creating a synthetic system message only when neither exists;
- merges message-level and request-level schemas into one Tools section, with the request definition winning on duplicate names;
- renders malformed historical tool arguments through the existing fallback parameter instead of failing prompt construction;
- preserves exact prompt bytes while splitting overlong source literals for reviewability.

## Root cause

The old encoder exposed high as a no-op, labeled the official high prefix as max, and lacked the true 0731 max prefix. Request tools could also be placed before the real system message, while system/developer tools were dropped or duplicated. Those defects changed the prompt seen by reasoning and tool-heavy requests.

## Provenance

The reasoning update is based on upstream vLLM PR #50580. Message-level tool preservation is based on upstream PR #50684. The ordering, deterministic merge, malformed-history fallback, and Python/Rust parity coverage are GG additions checked against the published DeepSeek 0731 encoder:

- https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731/blob/main/encoding/encoding_dsv4.py
- https://github.com/vllm-project/vllm/pull/50580
- https://github.com/vllm-project/vllm/pull/50684

## Validation

- Current Python tokenizer and focused chat-parser suite: 38 passed.
- Rust DeepSeek-V4 renderer suite: 11 passed.
- Ruff check, Ruff format check, Cargo format check, and git diff check passed.
- Golden prompt ordering matches the published 0731 encoder.