### PR TITLE
qwen3_5: load rank-sliced EXL3 (Trellis) expert checkpoints

### DIFF
--- a/tests/models/test_qwen3_5_rank_sliced_loading.py
+++ b/tests/models/test_qwen3_5_rank_sliced_loading.py
@@ -1,0 +1,392 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU-only tests for rank-sliced EXL3 weight loading in Qwen3.5.
+
+These tests exercise the shared ``normalize_rank_sliced_weights`` helper and
+verify the ordering contract in both ``Qwen3_5Model.load_weights`` and
+``Qwen3_5MTP.load_weights``:
+
+* rank normalization happens *before* the ``WeightsMapper`` (main model) /
+  ``mtp.``→``model.`` remap (MTP draft);
+* local TP-rank payloads are retained and have the ``.rank{r}`` segment
+  stripped;
+* non-local ranks are dropped;
+* ordinary (non-rank-sliced) weights pass through unchanged.
+
+No real checkpoint or CUDA is required — ``AutoWeightsLoader`` is replaced
+with a capture stub and ``quant_config`` is a lightweight stand-in.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.quantization.exl3 import (
+    _RANK_SLICED_WEIGHT_RE,
+    normalize_rank_sliced_weights,
+)
+from vllm.model_executor.models.qwen3_5 import Qwen3_5Model
+from vllm.model_executor.models.qwen3_5_mtp import Qwen3_5MTP
+from vllm.model_executor.models.utils import WeightsMapper
+
+# ---------------------------------------------------------------------------
+# Stubs
+# ---------------------------------------------------------------------------
+
+_LOCAL_RANK = 0
+
+
+class StubExl3QuantConfig:
+    """Mimics ``Exl3Config.normalize_rank_sliced_weight_name`` for rank 0.
+
+    The real method delegates to ``get_tensor_model_parallel_rank()`` which
+    needs an initialized TP group; the stub hard-codes ``_LOCAL_RANK`` so the
+    tests are self-contained and deterministic on CPU.
+    """
+
+    def normalize_rank_sliced_weight_name(self, name: str) -> str | None:
+        match = _RANK_SLICED_WEIGHT_RE.match(name)
+        if match is None:
+            return name
+        if int(match.group("rank")) != _LOCAL_RANK:
+            return None
+        return f"{match.group('prefix')}.{match.group('field')}"
+
+
+class PlainQuantConfig:
+    """A quant_config without ``normalize_rank_sliced_weight_name``."""
+
+
+class _CapturedLoader:
+    """Drop-in for ``AutoWeightsLoader`` that records what it received."""
+
+    def __init__(self, model):
+        self.model = model
+        self.captured_weights: list[tuple[str, torch.Tensor]] | None = None
+        self.captured_mapper: object | None = None
+
+    def load_weights(
+        self,
+        weights: Iterable[tuple[str, torch.Tensor]],
+        *,
+        mapper: object | None = None,
+    ) -> set[str]:
+        self.captured_weights = list(weights)
+        self.captured_mapper = mapper
+        return set()
+
+
+def _w(name: str) -> tuple[str, torch.Tensor]:
+    """Build a trivial (name, tensor) pair — tensor identity is irrelevant."""
+    return name, torch.empty(1)
+
+
+# ---------------------------------------------------------------------------
+# Helper-level tests (covers the deduplicated primitive for both models)
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeRankSlicedWeights:
+    quant_config = StubExl3QuantConfig()
+
+    def test_local_rank_retained_and_normalized(self):
+        weights = [
+            _w("mlp.experts.0.w13.rank0.trellis"),
+            _w("mlp.experts.0.w2.rank0.suh"),
+        ]
+        out = list(normalize_rank_sliced_weights(weights, self.quant_config))
+        names = [n for n, _ in out]
+        assert names == [
+            "mlp.experts.0.w13.trellis",
+            "mlp.experts.0.w2.suh",
+        ]
+
+    def test_nonlocal_rank_dropped(self):
+        weights = [
+            _w("mlp.experts.0.w13.rank1.trellis"),
+            _w("mlp.experts.0.w13.rank0.trellis"),
+            _w("mlp.experts.0.w2.rank2.mcg"),
+        ]
+        out = list(normalize_rank_sliced_weights(weights, self.quant_config))
+        names = [n for n, _ in out]
+        assert names == ["mlp.experts.0.w13.trellis"]
+
+    def test_ordinary_weight_passes_through(self):
+        weights = [
+            _w("layers.0.self_attn.q_proj.weight"),
+            _w("mlp.experts.0.w13.trellis"),  # already normalized form
+        ]
+        out = list(normalize_rank_sliced_weights(weights, self.quant_config))
+        names = [n for n, _ in out]
+        assert names == [
+            "layers.0.self_attn.q_proj.weight",
+            "mlp.experts.0.w13.trellis",
+        ]
+
+    def test_plain_quant_config_passthrough(self):
+        weights = [
+            _w("mlp.experts.0.w13.rank0.trellis"),
+            _w("layers.0.self_attn.q_proj.weight"),
+        ]
+        out = list(normalize_rank_sliced_weights(weights, PlainQuantConfig()))
+        names = [n for n, _ in out]
+        # No normalize_rank_sliced_weight_name => identity passthrough.
+        assert names == [
+            "mlp.experts.0.w13.rank0.trellis",
+            "layers.0.self_attn.q_proj.weight",
+        ]
+
+    def test_returns_iterable_not_list(self):
+        """Helper returns a lazy generator (or the original iterable)."""
+        weights = [_w("mlp.experts.0.w13.rank0.trellis")]
+        result = normalize_rank_sliced_weights(weights, self.quant_config)
+        assert not isinstance(result, list)
+        # Consume to verify it works.
+        assert list(result)
+
+
+# ---------------------------------------------------------------------------
+# Qwen3_5Model.load_weights — composition with WeightsMapper
+# ---------------------------------------------------------------------------
+
+
+def _make_model_instance() -> Qwen3_5Model:
+    """Bare Qwen3_5Model without __init__ (avoids CUDA / full model build)."""
+    instance = Qwen3_5Model.__new__(Qwen3_5Model)
+    instance.quant_config = StubExl3QuantConfig()
+    # hf_to_vllm_mapper is a class attribute; no need to set it.
+    return instance
+
+
+class TestQwen3_5ModelLoadWeights:
+    def test_local_rank_normalized_before_loader(self, monkeypatch):
+        instance = _make_model_instance()
+        captured: list[_CapturedLoader] = []
+        original_cls = _CapturedLoader
+
+        def _factory(model):
+            c = original_cls(model)
+            captured.append(c)
+            return c
+
+        monkeypatch.setattr(
+            "vllm.model_executor.models.qwen3_5.AutoWeightsLoader", _factory
+        )
+        weights = [_w("mlp.experts.0.w13.rank0.trellis")]
+        instance.load_weights(weights)
+
+        assert len(captured) == 1
+        names = [n for n, _ in captured[0].captured_weights]
+        assert names == ["mlp.experts.0.w13.trellis"]
+
+    def test_nonlocal_rank_dropped_before_loader(self, monkeypatch):
+        instance = _make_model_instance()
+        captured: list[_CapturedLoader] = []
+
+        def _factory(model):
+            c = _CapturedLoader(model)
+            captured.append(c)
+            return c
+
+        monkeypatch.setattr(
+            "vllm.model_executor.models.qwen3_5.AutoWeightsLoader", _factory
+        )
+        weights = [
+            _w("mlp.experts.0.w13.rank1.trellis"),
+            _w("mlp.experts.0.w2.rank0.suh"),
+        ]
+        instance.load_weights(weights)
+
+        names = [n for n, _ in captured[0].captured_weights]
+        assert names == ["mlp.experts.0.w2.suh"]
+
+    def test_ordinary_weight_passes_to_loader(self, monkeypatch):
+        instance = _make_model_instance()
+        captured: list[_CapturedLoader] = []
+
+        def _factory(model):
+            c = _CapturedLoader(model)
+            captured.append(c)
+            return c
+
+        monkeypatch.setattr(
+            "vllm.model_executor.models.qwen3_5.AutoWeightsLoader", _factory
+        )
+        weights = [_w("layers.0.self_attn.q_proj.weight")]
+        instance.load_weights(weights)
+
+        names = [n for n, _ in captured[0].captured_weights]
+        assert names == ["layers.0.self_attn.q_proj.weight"]
+
+    def test_weights_mapper_preserved(self, monkeypatch):
+        """The mapper is still forwarded to the loader after normalization."""
+        instance = _make_model_instance()
+        captured: list[_CapturedLoader] = []
+
+        def _factory(model):
+            c = _CapturedLoader(model)
+            captured.append(c)
+            return c
+
+        monkeypatch.setattr(
+            "vllm.model_executor.models.qwen3_5.AutoWeightsLoader", _factory
+        )
+        instance.load_weights([_w("layers.0.self_attn.q_proj.weight")])
+
+        # The class-level hf_to_vllm_mapper must reach loader.load_weights.
+        assert captured[0].captured_mapper is Qwen3_5Model.hf_to_vllm_mapper
+
+    def test_mapper_receives_normalized_names(self, monkeypatch):
+        """Normalization runs *before* the mapper sees the names."""
+        instance = _make_model_instance()
+        # Inject a custom mapper that would *fail* if it saw a .rankN segment,
+        # proving the rank was already stripped upstream.
+        sentinel_mapper = WeightsMapper(
+            orig_to_new_substr={".w13.trellis": ".w13_trellis"}
+        )
+        instance.hf_to_vllm_mapper = sentinel_mapper
+        captured: list[_CapturedLoader] = []
+
+        def _factory(model):
+            c = _CapturedLoader(model)
+            captured.append(c)
+            return c
+
+        monkeypatch.setattr(
+            "vllm.model_executor.models.qwen3_5.AutoWeightsLoader", _factory
+        )
+        instance.load_weights([_w("mlp.experts.0.w13.rank0.trellis")])
+
+        names = [n for n, _ in captured[0].captured_weights]
+        # The loader receives the normalized name (mapper applied inside the
+        # real loader; here we only capture pre-mapper names, which must
+        # already have the rank stripped).
+        assert names == ["mlp.experts.0.w13.trellis"]
+        assert captured[0].captured_mapper is sentinel_mapper
+
+
+# ---------------------------------------------------------------------------
+# Qwen3_5MTP.load_weights — mtp.→model. remap AFTER normalization
+# ---------------------------------------------------------------------------
+
+
+def _make_mtp_instance() -> Qwen3_5MTP:
+    """Bare Qwen3_5MTP without __init__."""
+    instance = Qwen3_5MTP.__new__(Qwen3_5MTP)
+    instance.quant_config = StubExl3QuantConfig()
+    return instance
+
+
+class TestQwen3_5MTPLoadWeights:
+    def test_rank_normalized_then_mtp_remapped(self, monkeypatch):
+        """Ordering contract: normalization first, then mtp.→model. rewrite."""
+        instance = _make_mtp_instance()
+        captured: list[_CapturedLoader] = []
+
+        def _factory(model):
+            c = _CapturedLoader(model)
+            captured.append(c)
+            return c
+
+        monkeypatch.setattr(
+            "vllm.model_executor.models.qwen3_5_mtp.AutoWeightsLoader", _factory
+        )
+        weights = [_w("mtp.layers.0.mlp.experts.0.w13.rank0.trellis")]
+        instance.load_weights(weights)
+
+        names = [n for n, _ in captured[0].captured_weights]
+        # rank0 stripped => mtp.layers.0.mlp.experts.0.w13.trellis
+        # then mtp. => model. => model.layers.0.mlp.experts.0.w13.trellis
+        assert names == ["model.layers.0.mlp.experts.0.w13.trellis"]
+
+    def test_nonlocal_rank_dropped_before_remap(self, monkeypatch):
+        instance = _make_mtp_instance()
+        captured: list[_CapturedLoader] = []
+
+        def _factory(model):
+            c = _CapturedLoader(model)
+            captured.append(c)
+            return c
+
+        monkeypatch.setattr(
+            "vllm.model_executor.models.qwen3_5_mtp.AutoWeightsLoader", _factory
+        )
+        weights = [
+            _w("mtp.layers.0.mlp.experts.0.w13.rank1.trellis"),
+            _w("mtp.layers.0.mlp.experts.0.w2.rank0.suh"),
+        ]
+        instance.load_weights(weights)
+
+        names = [n for n, _ in captured[0].captured_weights]
+        # rank1 dropped; rank0 normalized then remapped.
+        assert names == ["model.layers.0.mlp.experts.0.w2.suh"]
+
+    def test_ordinary_mtp_weight_remapped(self, monkeypatch):
+        instance = _make_mtp_instance()
+        captured: list[_CapturedLoader] = []
+
+        def _factory(model):
+            c = _CapturedLoader(model)
+            captured.append(c)
+            return c
+
+        monkeypatch.setattr(
+            "vllm.model_executor.models.qwen3_5_mtp.AutoWeightsLoader", _factory
+        )
+        weights = [_w("mtp.layers.0.self_attn.q_proj.weight")]
+        instance.load_weights(weights)
+
+        names = [n for n, _ in captured[0].captured_weights]
+        assert names == ["model.layers.0.self_attn.q_proj.weight"]
+
+    def test_embed_tokens_language_model_prefix_stripped(self, monkeypatch):
+        instance = _make_mtp_instance()
+        captured: list[_CapturedLoader] = []
+
+        def _factory(model):
+            c = _CapturedLoader(model)
+            captured.append(c)
+            return c
+
+        monkeypatch.setattr(
+            "vllm.model_executor.models.qwen3_5_mtp.AutoWeightsLoader", _factory
+        )
+        weights = [_w("language_model.embed_tokens.weight")]
+        instance.load_weights(weights)
+
+        names = [n for n, _ in captured[0].captured_weights]
+        assert names == ["embed_tokens.weight"]
+
+    def test_ordering_rank_then_remap_no_collision(self, monkeypatch):
+        """A rank-sliced mtp. weight is normalized before the prefix rewrite.
+
+        This is the ordering contract: if the remap ran first it would turn
+        ``mtp.…rank0.trellis`` into ``model.…rank0.trellis`` and the
+        subsequent normalization would still strip the rank — but the point
+        is that the *final* name has both transforms applied correctly.
+        Verifying the exact output ``model.…w13.trellis`` proves the two
+        rewrites compose without colliding.
+        """
+        instance = _make_mtp_instance()
+        captured: list[_CapturedLoader] = []
+
+        def _factory(model):
+            c = _CapturedLoader(model)
+            captured.append(c)
+            return c
+
+        monkeypatch.setattr(
+            "vllm.model_executor.models.qwen3_5_mtp.AutoWeightsLoader", _factory
+        )
+        weights = [_w("mtp.experts.7.w13.rank0.mul1")]
+        instance.load_weights(weights)
+
+        names = [n for n, _ in captured[0].captured_weights]
+        assert names == ["model.experts.7.w13.mul1"]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "--noconftest"])

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -24,6 +24,7 @@ import importlib
 import os
 import re
 import sys
+from collections.abc import Iterable
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 
@@ -158,6 +159,33 @@ _RANK_SLICED_WEIGHT_RE = re.compile(
     r"^(?P<prefix>.+)\.rank(?P<rank>\d+)\."
     r"(?P<field>trellis|suh|svh|mcg|mul1)$"
 )
+
+
+def normalize_rank_sliced_weights(
+    weights: Iterable[tuple[str, torch.Tensor]],
+    quant_config: Any,
+) -> Iterable[tuple[str, torch.Tensor]]:
+    """Drop non-local TP payloads and strip the serialized ``.rank{r}`` segment.
+
+    Thin generator wrapper around
+    ``quant_config.normalize_rank_sliced_weight_name`` that handles the
+    ``getattr`` fallback: when ``quant_config`` has no such method (e.g. a
+    non-EXL3 checkpoint) the weights are yielded unchanged. Weights whose name
+    normalizes to ``None`` (a non-local TP rank) are dropped.
+
+    This deduplicates the per-model loader boilerplate that previously appeared
+    as inline copies in ``qwen3_5.py`` and ``qwen3_5_mtp.py``.
+    """
+    rank_sliced_name = getattr(
+        quant_config, "normalize_rank_sliced_weight_name", None
+    )
+    if rank_sliced_name is None:
+        return weights
+    return (
+        (new_name, loaded_weight)
+        for name, loaded_weight in weights
+        if (new_name := rank_sliced_name(name)) is not None
+    )
 
 ShardId = str | int | tuple[int, ...] | None
 

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -279,6 +279,29 @@ class Qwen3_5Model(Qwen3NextModel):
             mapper = mapper | WeightsMapper(
                 orig_to_new_substr={"mlp.shared_expert.": f"mlp.experts.{num_routed}."}
             )
+        # Rank-sliced EXL3 checkpoints ship one tensor per TP rank
+        # (`...experts.{E}.{proj}.rank{r}.{trellis|suh|svh|mcg}`) while
+        # Exl3MoEMethod registers fused per-projection params (w13_trellis,
+        # ...). Strip the `.rank{r}` segment / drop non-local ranks BEFORE
+        # AutoWeightsLoader descends into RoutedExperts.load_weights, exactly
+        # as deepseek_v2.load_weights does; otherwise the expert-mapping
+        # string surgery produces `...experts.w13_rank0.trellis` and the
+        # parameter lookup fails.
+        rank_sliced_name = getattr(
+            self.quant_config,
+            "normalize_rank_sliced_weight_name",
+            None,
+        )
+        if rank_sliced_name is not None:
+
+            def _normalize_rank_sliced(weights):
+                for name, loaded_weight in weights:
+                    name = rank_sliced_name(name)
+                    if name is None:
+                        continue
+                    yield name, loaded_weight
+
+            weights = _normalize_rank_sliced(weights)
         loader = AutoWeightsLoader(self)
         return loader.load_weights(weights, mapper=mapper)
 

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -38,6 +38,9 @@ from vllm.distributed import (
 from vllm.logger import init_logger
 from vllm.model_executor.layers.layernorm import GemmaRMSNorm as Qwen3_5RMSNorm
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.quantization.exl3 import (
+    normalize_rank_sliced_weights,
+)
 from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import (
     QwenGatedDeltaNetAttention,
 )
@@ -287,21 +290,7 @@ class Qwen3_5Model(Qwen3NextModel):
         # as deepseek_v2.load_weights does; otherwise the expert-mapping
         # string surgery produces `...experts.w13_rank0.trellis` and the
         # parameter lookup fails.
-        rank_sliced_name = getattr(
-            self.quant_config,
-            "normalize_rank_sliced_weight_name",
-            None,
-        )
-        if rank_sliced_name is not None:
-
-            def _normalize_rank_sliced(weights):
-                for name, loaded_weight in weights:
-                    name = rank_sliced_name(name)
-                    if name is None:
-                        continue
-                    yield name, loaded_weight
-
-            weights = _normalize_rank_sliced(weights)
+        weights = normalize_rank_sliced_weights(weights, self.quant_config)
         loader = AutoWeightsLoader(self)
         return loader.load_weights(weights, mapper=mapper)
 

--- a/vllm/model_executor/models/qwen3_5_mtp.py
+++ b/vllm/model_executor/models/qwen3_5_mtp.py
@@ -14,6 +14,9 @@ from vllm.distributed.parallel_state import get_pp_group
 from vllm.logger import init_logger
 from vllm.model_executor.layers.linear import ColumnParallelLinear
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.quantization.exl3 import (
+    normalize_rank_sliced_weights,
+)
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
     VocabParallelEmbedding,
@@ -300,17 +303,7 @@ class Qwen3_5MTP(LocalArgmaxMixin, nn.Module, SupportsMultiModal):
         # `.rank{r}` segment / drop non-local ranks before the mtp.->model.
         # prefix remap, mirroring Qwen3_5Model.load_weights; the rank segment
         # is a name suffix, so the two rewrites cannot collide.
-        rank_sliced_name = getattr(
-            self.quant_config,
-            "normalize_rank_sliced_weight_name",
-            None,
-        )
-        if rank_sliced_name is not None:
-            weights = (
-                (new_name, weight)
-                for name, weight in weights
-                if (new_name := rank_sliced_name(name)) is not None
-            )
+        weights = normalize_rank_sliced_weights(weights, self.quant_config)
 
         def remap_weight_names(weights):
             for name, weight in weights:

--- a/vllm/model_executor/models/qwen3_5_mtp.py
+++ b/vllm/model_executor/models/qwen3_5_mtp.py
@@ -295,6 +295,23 @@ class Qwen3_5MTP(LocalArgmaxMixin, nn.Module, SupportsMultiModal):
         return self.logits_processor(self.lm_head, hidden_states)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        # Rank-sliced EXL3 drafts reuse the target's hydrated quant config
+        # (the proposer copies it into the draft VllmConfig). Strip the
+        # `.rank{r}` segment / drop non-local ranks before the mtp.->model.
+        # prefix remap, mirroring Qwen3_5Model.load_weights; the rank segment
+        # is a name suffix, so the two rewrites cannot collide.
+        rank_sliced_name = getattr(
+            self.quant_config,
+            "normalize_rank_sliced_weight_name",
+            None,
+        )
+        if rank_sliced_name is not None:
+            weights = (
+                (new_name, weight)
+                for name, weight in weights
+                if (new_name := rank_sliced_name(name)) is not None
+            )
+
         def remap_weight_names(weights):
             for name, weight in weights:
                 if name.startswith("mtp."):


### PR DESCRIPTION
## What

Two small insertions (40 lines, no behavior change for non-EXL3 configs) that let the qwen3_5 family load rank-sliced EXL3 ("SIQ") expert checkpoints — the same format the DeepSeek/GLM families already load:

- `Qwen3_5Model.load_weights`: normalize `...experts.{E}.{proj}.rank{r}.{field}` names via `Exl3Config.normalize_rank_sliced_weight_name` before AutoWeightsLoader descends into `RoutedExperts.load_weights` (mirrors `deepseek_v2.py` / `glm4_moe.py`). Covers both `Qwen3_5MoeForCausalLM` and the VL wrapper.
- `Qwen3_5MTP.load_weights`: same normalization for the draft path (the proposer hands the draft the target's hydrated `Exl3Config`).

Everything downstream already works unchanged: `RoutedExperts.load_weights` routes per-expert EXL3 tensors, `Exl3MoEMethod` claims the layers, and SparkInfer #117's runtime-dynamic tier counts execute a second geometry with the same compiled kernels.

## Why

A 32 GB single-GPU dev proxy for the GLM-5.2 SIQ stack: Qwen3.6-35B-A3B has the identical expert tier space (256 routed, top-8, 1 shared), so a mixed-K3/K4 checkpoint with GLM's exact per-layer partitions (206/50 + 160/96) exercises the loader/kernel/runtime contract at 20 GB and ~10-second loads. Artifact + full reproduction toolchain: https://huggingface.co/malaiwah/Qwen-3.6-35B-A3B-SIQ-K6-K4K3

## Tested (RTX 5090 / SM120, r25 image, TP1)

- exl3 auto-override selected from `hybrid_tr3_tail`; 40/40 MoE layers on `Exl3MoEMethod`, runtime tiers `((3,206),(4,50))` / `((3,160),(4,96))`
- Warm load 10.1 s; KV 711,243 tok @ 262k native (fp8 KV); CC1 158.7 tok/s, CC8 873 tok/s; prefill 13.5k tok/s @ 31k / 4.5k @ 249k
- Text (qwen3 reasoning parser), tool calls (qwen3_coder), and vision (`image_url`) smokes pass
- Truncated-KLD vs BF16 data point: 0.0105 (vs 0.0186 for the NVFP4 build of the same model)

Operator note (worth a docs line somewhere): Qwen's GDN micro-projections (`in_proj_ba` N=64, `shared_expert_gate` N=1) must be ignore-listed from the online MXFP8/K6 overlay (`mm_mxfp8` needs N≥128), and fused-module ignores match against unfused shard names — a blanket `re:.*linear_attn.*` is the practical form.

Relationship: consumes the runtime contract from sparkinfer#117 (which supersedes sparkinfer#114) — this PR makes a second model family exercise it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DmTegASpyEG2T8zB5BZYTw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading of rank-sliced EXL3 checkpoints for Qwen3.5 models.
  * Correctly filters unsupported weight entries and aligns fused expert parameters during model initialization.
  * Applied the same checkpoint compatibility improvements to Qwen3.5 multi-token prediction models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->