### PR TITLE
fix(dcp): build the indexer query-split topology for a single shard

### DIFF
--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -2101,7 +2101,7 @@ def initialize_model_parallel(
     )
     indexer_shards = int(envs.VLLM_DCP_INDEXER_SHARDS)
     _validate_indexer_shard_count(indexer_shards, decode_context_model_parallel_size)
-    if 1 < indexer_shards < decode_context_model_parallel_size:
+    if 1 <= indexer_shards < decode_context_model_parallel_size:
         indexer_dcp_ranks, indexer_query_split_ranks = (
             _build_indexer_replica_group_ranks(tp_group_ranks, indexer_shards)
         )


### PR DESCRIPTION
VLLM_DCP_INDEXER_SHARDS=1 replicates the sparse-indexer K cache on every DCP rank, but the indexer topology was only built for 1 < shards < DCP, so one-shard runs fell back to _QUERY_SPLIT, which is singleton at TP == DCP. Every rank then scored every query row against the full indexer cache during prefill: DCP-wide redundant compute (~8x at DCP8, measurable as a long-context prefill throughput loss). With VLLM_DCP_QUERY_SPLIT=1 it was worse than redundant, since get_indexer_query_split_group(1) had no group to return and raised "No indexer query-split group matches the requested KV shard count".

_build_indexer_replica_group_ranks already yields the correct layout for shards=1 -- single-rank owner groups and one TP-wide query-split group -- so let it run. Each rank scores totalQ/TP rows against the full replicated cache, and the existing indices-only all-gather restores the shared top-k buffer. No merge is needed or attempted: dcp_world_size stays 1 for a replicated cache, so every candidate-merge path still early-returns.


Claude-Session: https://claude.ai/code/session_01J4BQPVrK6LdTUbXudyPkga

<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved distributed processing initialization for configurations using a single indexer shard with multiple decode-context parallel partitions.
  * Ensures these configurations now initialize correctly and operate as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->