### PR TITLE
[GG] fix(dcp): build one-shard indexer query-split topology

### DIFF
--- a/tests/distributed/test_indexer_parallel_groups.py
+++ b/tests/distributed/test_indexer_parallel_groups.py
@@ -8,6 +8,7 @@ import pytest
 from vllm.distributed import parallel_state
 from vllm.distributed.parallel_state import (
     _build_indexer_replica_group_ranks,
+    _needs_indexer_replica_groups,
     _validate_indexer_shard_count,
 )
 
@@ -52,6 +53,14 @@ def test_build_indexer_groups_cover_dcp1_partial_and_full(
 
     assert dcp_groups == expected_dcp
     assert query_split_groups == expected_query_split
+
+
+@pytest.mark.parametrize(
+    ("indexer_shards", "expected"),
+    [(0, False), (1, True), (2, True), (4, True), (8, False)],
+)
+def test_indexer_replica_group_gate_for_dcp8(indexer_shards, expected):
+    assert _needs_indexer_replica_groups(indexer_shards, 8) is expected
 
 
 def test_build_indexer_replica_groups_stay_inside_each_tp_group():

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -1542,6 +1542,11 @@ def _validate_indexer_shard_count(indexer_shards: int, dcp_size: int) -> None:
         )
 
 
+def _needs_indexer_replica_groups(indexer_shards: int, dcp_size: int) -> bool:
+    """Return whether the indexer needs replica-specific process groups."""
+    return 1 <= indexer_shards < dcp_size
+
+
 _DCP_CKV_PREFETCH: GroupCoordinator | None = None
 
 
@@ -2101,7 +2106,9 @@ def initialize_model_parallel(
     )
     indexer_shards = int(envs.VLLM_DCP_INDEXER_SHARDS)
     _validate_indexer_shard_count(indexer_shards, decode_context_model_parallel_size)
-    if 1 <= indexer_shards < decode_context_model_parallel_size:
+    if _needs_indexer_replica_groups(
+        indexer_shards, decode_context_model_parallel_size
+    ):
         indexer_dcp_ranks, indexer_query_split_ranks = (
             _build_indexer_replica_group_ranks(tp_group_ranks, indexer_shards)
         )

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -2101,7 +2101,7 @@ def initialize_model_parallel(
     )
     indexer_shards = int(envs.VLLM_DCP_INDEXER_SHARDS)
     _validate_indexer_shard_count(indexer_shards, decode_context_model_parallel_size)
-    if 1 < indexer_shards < decode_context_model_parallel_size:
+    if 1 <= indexer_shards < decode_context_model_parallel_size:
         indexer_dcp_ranks, indexer_query_split_ranks = (
             _build_indexer_replica_group_ranks(tp_group_ranks, indexer_shards)
         )


### PR DESCRIPTION
Supersedes #244. This keeps Koush's functional commit unchanged and adds focused regression coverage. A replacement PR was necessary because GitHub denied direct maintainer writes to the fork head branch even though `maintainer_can_modify` is enabled.

## Purpose

`VLLM_DCP_INDEXER_SHARDS=1` fully replicates the sparse-indexer K cache on every DCP rank. The process-group initialization gate previously excluded this valid layout, so the dedicated singleton owner groups and DCP-wide query-split group were never created.

That had two consequences:

- without query split, every rank redundantly scored every query row against the full replicated cache;
- with `VLLM_DCP_QUERY_SPLIT=1`, lookup of the missing one-shard query-split group failed.

The existing `_build_indexer_replica_group_ranks` implementation already produces the correct topology for one shard. This PR lets that path run for `1 <= indexer_shards < DCP`. It also extracts the gate into a pure helper so the boundary behavior is covered without initializing distributed backends.

There is no behavior change for disabled replication (`0`), existing partial layouts, or `indexer_shards == DCP`.

## Test plan

```bash
python -m pytest -q tests/distributed/test_indexer_parallel_groups.py
ruff check vllm/distributed/parallel_state.py tests/distributed/test_indexer_parallel_groups.py
ruff format --check vllm/distributed/parallel_state.py tests/distributed/test_indexer_parallel_groups.py
```

The parametrized regression test covers shard counts `0, 1, 2, 4, 8` at DCP8. In particular, it fails if the one-shard boundary is changed back to `1 < indexer_shards`.

The runtime path was also validated with a model-free TP4/DCP4 process-group test and an E2E GLM-5.2 prefill A-B-A comparison.

## Test results

### Unit and static checks

- `22 passed`
- Ruff lint passed
- Ruff format check passed
- `git diff --check` passed

### TP4/DCP4 topology

With `VLLM_DCP_INDEXER_SHARDS=1` and `VLLM_DCP_QUERY_SPLIT=1`:

- initialization completed;
- `indexer_query_split:0` was created;
- the runtime reported one sparse-indexer KV shard across DCP4;
- API correctness sanity completed without a worker failure.

### E2E prefill A-B-A

Test profile: TP4/DCP4, MTP off, `MAX_NUM_SEQS=1`, graph cap 6, CKV gather enabled, owner merge disabled, unique uncached prompts, three samples per point. The available GLM-5.2 EXL3 3.25bpw checkpoint was used because the validation host did not contain the release NVFP4 checkpoint. Absolute throughput is therefore not an NVFP4 release claim.

| Variant | Prefill ~8K | Prefill ~64K |
|---|---:|---:|
| r28 baseline, query split off | 3,695 tok/s | 3,433 tok/s |
| This PR, run A1 | 3,682 tok/s | 3,488 tok/s |
| This PR, run A2 | 3,673 tok/s | 3,497 tok/s |
| This PR, mean | 3,678 tok/s | 3,493 tok/s |
| Delta | -0.5% | +1.7% |

The short-context difference is measurement noise. The 64K result was repeatably faster with the now-functional replicated query-split topology.

The root-port validation host required both variants to use the same Torch-NCCL fallback because its custom-AR/PyNCCL startup path has an unrelated environment-specific failure. This does not affect the process-group boundary fixed here and was held constant across the comparison.

## Checklist

- [x] Purpose and affected configuration described
- [x] Focused regression test added
- [x] Unit and formatting checks passed
- [x] TP4/DCP4 topology and E2E behavior validated
- [x] No documentation change required


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected distributed indexer setup for partial shard layouts, including single-shard configurations.
  * Ensured replica groups are created only when the shard count is positive and smaller than the data parallel size.
  * Improved initialization behavior across supported shard counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->