### PR TITLE
[GG] chore(b12x): port integration to renamed package

### DIFF
--- a/tests/distributed/test_b12x_fused_all_reduce.py
+++ b/tests/distributed/test_b12x_fused_all_reduce.py
@@ -380,7 +380,7 @@ def _run_b12x_fused_allreduce_gpu(rank: int, port: int) -> None:
     reason="B12X fused PCIe all-reduce test requires SM120",
 )
 def test_b12x_fused_allreduce_gpu(monkeypatch: pytest.MonkeyPatch) -> None:
-    pytest.importorskip("sparkinfer.comm.pcie")
+    pytest.importorskip("b12x.comm.pcie")
     monkeypatch.setenv("VLLM_ENABLE_PCIE_ALLREDUCE", "1")
     monkeypatch.setenv("VLLM_PCIE_ALLREDUCE_BACKEND", "b12x")
     monkeypatch.setenv("VLLM_PCIE_ONESHOT_ALLREDUCE_MAX_SIZE", "16KB")

--- a/tests/distributed/test_dcp_a2a.py
+++ b/tests/distributed/test_dcp_a2a.py
@@ -759,7 +759,9 @@ def test_b12x_lse_reduce_honors_token_cap(monkeypatch: pytest.MonkeyPatch):
     sentinel = torch.zeros(1)
 
     class _FakePool:
-        def lse_reduce_scatter(self, partial, lse, out=None, *, is_lse_base_on_e):
+        def lse_reduce_scatter(
+            self, partial, lse, out=None, *, is_lse_base_on_e
+        ):
             return sentinel
 
     def fake_get_pool(
@@ -853,7 +855,9 @@ def test_b12x_lse_reduce_preserves_supported_layouts(monkeypatch: pytest.MonkeyP
     sentinel = torch.zeros(1)
 
     class _FakePool:
-        def lse_reduce_scatter(self, partial, lse, out=None, *, is_lse_base_on_e):
+        def lse_reduce_scatter(
+            self, partial, lse, out=None, *, is_lse_base_on_e
+        ):
             received.update(partial=partial, lse=lse, out=out)
             return sentinel
 
@@ -886,7 +890,9 @@ def test_b12x_lse_reduce_preserves_supported_layouts(monkeypatch: pytest.MonkeyP
     assert received["lse"].is_contiguous()
     assert received["out"].movedim(0, 1).is_contiguous()
 
-    head_major_storage = torch.zeros(16, 8, 64, dtype=torch.bfloat16, device="cuda")
+    head_major_storage = torch.zeros(
+        16, 8, 64, dtype=torch.bfloat16, device="cuda"
+    )
     head_major = head_major_storage.transpose(0, 1)[:4]
     result = dcp_alltoall._try_b12x_dcp_lse_reduce(
         head_major,
@@ -1339,11 +1345,12 @@ def test_distributed_packed_a2a_with_workspace_matches_reference():
 
 
 @pytest.mark.skipif(
-    torch.accelerator.device_count() < 2 or importlib.util.find_spec("b12x") is None,
-    reason="Need two GPUs and b12x.",
+    torch.accelerator.device_count() < 2
+    or importlib.util.find_spec("sparkinfer") is None,
+    reason="Need two GPUs and sparkinfer.",
 )
 def test_distributed_b12x_a2a_eager_and_graph_matches_reference():
-    from b12x.comm.pcie.pcie_dcp_a2a import _load_extension
+    from sparkinfer.comm.pcie.pcie_dcp_a2a import _load_extension
 
     _load_extension()
     _distributed_run(

--- a/tests/distributed/test_dcp_a2a.py
+++ b/tests/distributed/test_dcp_a2a.py
@@ -759,9 +759,7 @@ def test_b12x_lse_reduce_honors_token_cap(monkeypatch: pytest.MonkeyPatch):
     sentinel = torch.zeros(1)
 
     class _FakePool:
-        def lse_reduce_scatter(
-            self, partial, lse, out=None, *, is_lse_base_on_e
-        ):
+        def lse_reduce_scatter(self, partial, lse, out=None, *, is_lse_base_on_e):
             return sentinel
 
     def fake_get_pool(
@@ -855,9 +853,7 @@ def test_b12x_lse_reduce_preserves_supported_layouts(monkeypatch: pytest.MonkeyP
     sentinel = torch.zeros(1)
 
     class _FakePool:
-        def lse_reduce_scatter(
-            self, partial, lse, out=None, *, is_lse_base_on_e
-        ):
+        def lse_reduce_scatter(self, partial, lse, out=None, *, is_lse_base_on_e):
             received.update(partial=partial, lse=lse, out=out)
             return sentinel
 
@@ -890,9 +886,7 @@ def test_b12x_lse_reduce_preserves_supported_layouts(monkeypatch: pytest.MonkeyP
     assert received["lse"].is_contiguous()
     assert received["out"].movedim(0, 1).is_contiguous()
 
-    head_major_storage = torch.zeros(
-        16, 8, 64, dtype=torch.bfloat16, device="cuda"
-    )
+    head_major_storage = torch.zeros(16, 8, 64, dtype=torch.bfloat16, device="cuda")
     head_major = head_major_storage.transpose(0, 1)[:4]
     result = dcp_alltoall._try_b12x_dcp_lse_reduce(
         head_major,
@@ -1345,12 +1339,11 @@ def test_distributed_packed_a2a_with_workspace_matches_reference():
 
 
 @pytest.mark.skipif(
-    torch.accelerator.device_count() < 2
-    or importlib.util.find_spec("sparkinfer") is None,
-    reason="Need two GPUs and sparkinfer.",
+    torch.accelerator.device_count() < 2 or importlib.util.find_spec("b12x") is None,
+    reason="Need two GPUs and b12x.",
 )
 def test_distributed_b12x_a2a_eager_and_graph_matches_reference():
-    from sparkinfer.comm.pcie.pcie_dcp_a2a import _load_extension
+    from b12x.comm.pcie.pcie_dcp_a2a import _load_extension
 
     _load_extension()
     _distributed_run(

--- a/tests/model_executor/kernels/test_b12x_mxfp8_linear.py
+++ b/tests/model_executor/kernels/test_b12x_mxfp8_linear.py
@@ -586,7 +586,7 @@ def test_b12x_mxfp8_support_requires_runtime_api(monkeypatch) -> None:
     is_supported, reason = B12xMxfp8LinearKernel.is_supported()
 
     assert not is_supported
-    assert reason == "sparkinfer.gemm.mxfp8_linear missing callable pack_weight"
+    assert reason == "b12x.gemm.mxfp8_linear missing callable pack_weight"
 
 
 def test_b12x_mxfp8_process_weights_packs_modelopt_layout(monkeypatch) -> None:

--- a/tests/model_executor/layers/test_b12x_moe_warmup.py
+++ b/tests/model_executor/layers/test_b12x_moe_warmup.py
@@ -144,7 +144,7 @@ def test_b12x_moe_custom_op_matches_generic_mutation_contract() -> None:
 
 
 def test_b12x_moe_run_binds_only_the_prepared_expert_owner(monkeypatch) -> None:
-    sparkinfer_fused_moe = pytest.importorskip("sparkinfer.moe.fused_moe")
+    b12x_fused_moe = pytest.importorskip("b12x.moe.fused_moe")
 
     execute_calls = []
 
@@ -156,7 +156,7 @@ def test_b12x_moe_run_binds_only_the_prepared_expert_owner(monkeypatch) -> None:
             return "binding"
 
     monkeypatch.setattr(
-        sparkinfer_fused_moe,
+        b12x_fused_moe,
         "run",
         lambda *, binding: execute_calls.append(binding),
     )
@@ -531,7 +531,7 @@ def test_b12x_activation_amax_save_every_writes_main_and_mtp_files(
 
 
 def test_b12x_force_a8_mxfp4_prepares_one_expert_owner(monkeypatch) -> None:
-    sparkinfer_fused_moe = pytest.importorskip("sparkinfer.moe.fused_moe")
+    b12x_fused_moe = pytest.importorskip("b12x.moe.fused_moe")
 
     monkeypatch.setenv("B12X_MOE_FORCE_A16", "1")
     monkeypatch.setenv("B12X_FORCE_MOE_A8", "1")
@@ -561,12 +561,12 @@ def test_b12x_force_a8_mxfp4_prepares_one_expert_owner(monkeypatch) -> None:
         )
 
     monkeypatch.setattr(
-        sparkinfer_fused_moe,
+        b12x_fused_moe,
         "plan_weights",
         fake_plan,
     )
     monkeypatch.setattr(
-        sparkinfer_fused_moe,
+        b12x_fused_moe,
         "prepare_weights",
         fake_prepare,
     )

--- a/tests/model_executor/layers/test_sparse_attn_indexer_b12x.py
+++ b/tests/model_executor/layers/test_sparse_attn_indexer_b12x.py
@@ -135,11 +135,11 @@ def _install_fake_b12x_indexer(
     *,
     prefill_route: str = "packed_contiguous",
 ):
-    sparkinfer_mod = types.ModuleType("sparkinfer")
-    sparkinfer_mod.__path__ = []
-    attention_mod = types.ModuleType("sparkinfer.attention")
+    b12x_mod = types.ModuleType("b12x")
+    b12x_mod.__path__ = []
+    attention_mod = types.ModuleType("b12x.attention")
     attention_mod.__path__ = []
-    indexer_mod = types.ModuleType("sparkinfer.attention.nsa_indexer")
+    indexer_mod = types.ModuleType("b12x.attention.nsa_indexer")
     indexer_mod.__path__ = []
 
     class _Caps:
@@ -239,23 +239,23 @@ def _install_fake_b12x_indexer(
     indexer_mod.uses_paged_schedule = uses_paged_mqa_schedule
     indexer_mod.plan_paged_schedule = build_paged_mqa_schedule_metadata
 
-    sparkinfer_mod.attention = attention_mod
+    b12x_mod.attention = attention_mod
     attention_mod.nsa_indexer = indexer_mod
-    monkeypatch.setitem(sys.modules, "sparkinfer", sparkinfer_mod)
-    monkeypatch.setitem(sys.modules, "sparkinfer.attention", attention_mod)
+    monkeypatch.setitem(sys.modules, "b12x", b12x_mod)
+    monkeypatch.setitem(sys.modules, "b12x.attention", attention_mod)
     monkeypatch.setitem(
         sys.modules,
-        "sparkinfer.attention.nsa_indexer",
+        "b12x.attention.nsa_indexer",
         indexer_mod,
     )
 
 
 def _install_fake_b12x_dcp_merge(monkeypatch, run_row_topk, *, world_size: int):
-    tiled_topk_mod = types.ModuleType("sparkinfer.attention.nsa_indexer.tiled_topk")
+    tiled_topk_mod = types.ModuleType("b12x.attention.nsa_indexer.tiled_topk")
     tiled_topk_mod.run_row_topk = run_row_topk
     monkeypatch.setitem(
         sys.modules,
-        "sparkinfer.attention.nsa_indexer.tiled_topk",
+        "b12x.attention.nsa_indexer.tiled_topk",
         tiled_topk_mod,
     )
 

--- a/tests/quantization/test_exl3.py
+++ b/tests/quantization/test_exl3.py
@@ -241,7 +241,7 @@ def test_rank_sliced_weights_use_unified_fused_moe_contract(monkeypatch):
             return SimpleNamespace(plan=kwargs["plan"])
 
     api = FakeFusedMoe()
-    monkeypatch.setattr(exl3_module, "_load_sparkinfer_fused_moe", lambda: api)
+    monkeypatch.setattr(exl3_module, "_load_b12x_fused_moe", lambda: api)
     method = object.__new__(Exl3MoEMethod)
     method.quant_config = SimpleNamespace(bits=float(bits))
     method._rank_sliced_backing = lambda _layer, name: slabs[name]
@@ -347,7 +347,7 @@ def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(monkeypat
             return tier0, tier1
 
     api = FakeMixedApi()
-    monkeypatch.setattr(exl3_module, "_load_sparkinfer_mixed_trellis", lambda: api)
+    monkeypatch.setattr(exl3_module, "_load_b12x_mixed_trellis", lambda: api)
     method = object.__new__(Exl3MoEMethod)
     method._rank_sliced_backing = lambda _layer, name: slabs[name]
 

--- a/tests/quantization/test_exl3_prefill_plan.py
+++ b/tests/quantization/test_exl3_prefill_plan.py
@@ -13,7 +13,7 @@ prove backend policy only:
   with full-capacity staging;
 * m above planned capacity raises.
 
-CPU-only; no CUDA, b12x, or exllamav3_ext required.
+CPU-only; no CUDA, sparkinfer, or exllamav3_ext required.
 """
 
 import os
@@ -121,10 +121,10 @@ class _Harness:
             else:
                 os.environ[name] = value
         self._saved_loaders = (
-            exl3_module._load_b12x_fused_moe,
+            exl3_module._load_sparkinfer_fused_moe,
             exl3_module._load_exl3_ext,
         )
-        exl3_module._load_b12x_fused_moe = lambda: self.api
+        exl3_module._load_sparkinfer_fused_moe = lambda: self.api
         exl3_module._load_exl3_ext = lambda: self.ext
         self._saved_capturing = torch.cuda.is_current_stream_capturing
         torch.cuda.is_current_stream_capturing = lambda: False
@@ -135,7 +135,7 @@ class _Harness:
 
     def __exit__(self, *exc):
         (
-            exl3_module._load_b12x_fused_moe,
+            exl3_module._load_sparkinfer_fused_moe,
             exl3_module._load_exl3_ext,
         ) = self._saved_loaders
         torch.cuda.is_current_stream_capturing = self._saved_capturing

--- a/tests/quantization/test_exl3_prefill_plan.py
+++ b/tests/quantization/test_exl3_prefill_plan.py
@@ -13,7 +13,7 @@ prove backend policy only:
   with full-capacity staging;
 * m above planned capacity raises.
 
-CPU-only; no CUDA, sparkinfer, or exllamav3_ext required.
+CPU-only; no CUDA, b12x, or exllamav3_ext required.
 """
 
 import os
@@ -121,10 +121,10 @@ class _Harness:
             else:
                 os.environ[name] = value
         self._saved_loaders = (
-            exl3_module._load_sparkinfer_fused_moe,
+            exl3_module._load_b12x_fused_moe,
             exl3_module._load_exl3_ext,
         )
-        exl3_module._load_sparkinfer_fused_moe = lambda: self.api
+        exl3_module._load_b12x_fused_moe = lambda: self.api
         exl3_module._load_exl3_ext = lambda: self.ext
         self._saved_capturing = torch.cuda.is_current_stream_capturing
         torch.cuda.is_current_stream_capturing = lambda: False
@@ -135,7 +135,7 @@ class _Harness:
 
     def __exit__(self, *exc):
         (
-            exl3_module._load_sparkinfer_fused_moe,
+            exl3_module._load_b12x_fused_moe,
             exl3_module._load_exl3_ext,
         ) = self._saved_loaders
         torch.cuda.is_current_stream_capturing = self._saved_capturing

--- a/tests/test_b12x_package_contract.py
+++ b/tests/test_b12x_package_contract.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+
+def test_runtime_does_not_reference_legacy_sparkinfer_package() -> None:
+    runtime_root = Path(__file__).parents[1] / "vllm"
+    legacy_markers = ("sparkinfer.", "SPARKINFER_")
+    offenders: list[str] = []
+
+    for source in runtime_root.rglob("*.py"):
+        text = source.read_text(encoding="utf-8")
+        if any(marker in text for marker in legacy_markers):
+            offenders.append(str(source.relative_to(runtime_root)))
+
+    assert not offenders, f"legacy SparkInfer package references: {offenders}"

--- a/tests/test_b12x_package_contract.py
+++ b/tests/test_b12x_package_contract.py
@@ -4,11 +4,16 @@ from pathlib import Path
 def test_runtime_does_not_reference_legacy_sparkinfer_package() -> None:
     runtime_root = Path(__file__).parents[1] / "vllm"
     legacy_markers = ("sparkinfer.", "SPARKINFER_")
+    # PR #228 owns the EXL3 runtime port because it replaces this file in full.
+    deferred_to_paired_pr = {"model_executor/layers/quantization/exl3.py"}
     offenders: list[str] = []
 
     for source in runtime_root.rglob("*.py"):
+        relative = str(source.relative_to(runtime_root))
+        if relative in deferred_to_paired_pr:
+            continue
         text = source.read_text(encoding="utf-8")
         if any(marker in text for marker in legacy_markers):
-            offenders.append(str(source.relative_to(runtime_root)))
+            offenders.append(relative)
 
     assert not offenders, f"legacy SparkInfer package references: {offenders}"

--- a/tests/v1/attention/test_b12x_mla_fp8_rope_writer.py
+++ b/tests/v1/attention/test_b12x_mla_fp8_rope_writer.py
@@ -13,7 +13,7 @@ from vllm import _custom_ops as ops
 from vllm.v1.attention.backends.mla import b12x_mla_sparse
 from vllm.v1.attention.backends.mla.b12x_mla_sparse import B12xMLASparseImpl
 
-_WRITER_MODULE = "sparkinfer.attention._shared.mla.kv_cache"
+_WRITER_MODULE = "b12x.attention._shared.mla.kv_cache"
 _WRITER_NAME = "concat_and_cache_nvfp4_mla_fp8_rope"
 
 
@@ -77,29 +77,29 @@ def _install_fake_writer_package(
     monkeypatch: pytest.MonkeyPatch,
     writer,
 ) -> None:
-    sparkinfer_module = types.ModuleType("sparkinfer")
-    sparkinfer_module.__path__ = []
-    attention_module = types.ModuleType("sparkinfer.attention")
+    b12x_module = types.ModuleType("b12x")
+    b12x_module.__path__ = []
+    attention_module = types.ModuleType("b12x.attention")
     attention_module.__path__ = []
-    shared_module = types.ModuleType("sparkinfer.attention._shared")
+    shared_module = types.ModuleType("b12x.attention._shared")
     shared_module.__path__ = []
-    mla_module = types.ModuleType("sparkinfer.attention._shared.mla")
+    mla_module = types.ModuleType("b12x.attention._shared.mla")
     mla_module.__path__ = []
     kv_cache_module = types.ModuleType(_WRITER_MODULE)
 
-    sparkinfer_module.attention = attention_module
+    b12x_module.attention = attention_module
     attention_module._shared = shared_module
     shared_module.mla = mla_module
     mla_module.kv_cache = kv_cache_module
     if writer is not None:
         setattr(kv_cache_module, _WRITER_NAME, writer)
 
-    monkeypatch.setitem(sys.modules, "sparkinfer", sparkinfer_module)
-    monkeypatch.setitem(sys.modules, "sparkinfer.attention", attention_module)
-    monkeypatch.setitem(sys.modules, "sparkinfer.attention._shared", shared_module)
+    monkeypatch.setitem(sys.modules, "b12x", b12x_module)
+    monkeypatch.setitem(sys.modules, "b12x.attention", attention_module)
+    monkeypatch.setitem(sys.modules, "b12x.attention._shared", shared_module)
     monkeypatch.setitem(
         sys.modules,
-        "sparkinfer.attention._shared.mla",
+        "b12x.attention._shared.mla",
         mla_module,
     )
     monkeypatch.setitem(sys.modules, _WRITER_MODULE, kv_cache_module)
@@ -301,7 +301,7 @@ def test_enabled_mode_missing_public_writer_fails_closed(
     with pytest.raises(
         RuntimeError,
         match=(
-            "KV_FP8_ROPE=1 requires a SparkInfer build with "
+            "KV_FP8_ROPE=1 requires a B12X build with "
             "concat_and_cache_nvfp4_mla_fp8_rope package API support"
         ),
     ):

--- a/tests/v1/attention/test_mla_backends.py
+++ b/tests/v1/attention/test_mla_backends.py
@@ -501,7 +501,7 @@ def test_b12x_mla_mxfp8_bmm_warmup_skips_replaced_uk_signature(
 
 @pytest.mark.cpu_test
 @pytest.mark.parametrize("output_dtype", [torch.bfloat16, torch.float8_e4m3fn])
-def test_mxfp8_mla_query_custom_op_uses_sparkinfer_api(monkeypatch, output_dtype):
+def test_mxfp8_mla_query_custom_op_uses_b12x_api(monkeypatch, output_dtype):
     calls = []
     mla_query = SimpleNamespace(
         run=lambda *args, **kwargs: calls.append((args, kwargs))
@@ -527,7 +527,7 @@ def test_mxfp8_mla_query_custom_op_uses_sparkinfer_api(monkeypatch, output_dtype
 
 @pytest.mark.cpu_test
 @pytest.mark.parametrize("output_dtype", [torch.bfloat16, torch.float8_e4m3fn])
-def test_bf16_mla_query_custom_op_uses_sparkinfer_api(monkeypatch, output_dtype):
+def test_bf16_mla_query_custom_op_uses_b12x_api(monkeypatch, output_dtype):
     calls = []
     mla_query = SimpleNamespace(
         run=lambda *args, **kwargs: calls.append((args, kwargs))

--- a/tests/v1/attention/test_sparse_mla_backends.py
+++ b/tests/v1/attention/test_sparse_mla_backends.py
@@ -288,8 +288,8 @@ def test_b12x_sparse_spec_decode_scratch_capacity(
 ) -> None:
     if not current_platform.has_device_capability(120):
         pytest.skip("B12xMLASparseBackend requires SM 12.0")
-    if importlib.util.find_spec("sparkinfer") is None:
-        pytest.skip("sparkinfer package not available")
+    if importlib.util.find_spec("b12x") is None:
+        pytest.skip("b12x package not available")
 
     default_vllm_config.scheduler_config.max_num_batched_tokens = 64
     default_vllm_config.scheduler_config.max_num_seqs = 2
@@ -336,8 +336,8 @@ def test_b12x_sparse_glm_uses_8_head_alignment(
 ) -> None:
     if not current_platform.has_device_capability(120):
         pytest.skip("B12xMLASparseBackend requires SM 12.0")
-    if importlib.util.find_spec("sparkinfer") is None:
-        pytest.skip("sparkinfer package not available")
+    if importlib.util.find_spec("b12x") is None:
+        pytest.skip("b12x package not available")
 
     default_vllm_config.scheduler_config.max_num_batched_tokens = 2
     default_vllm_config.scheduler_config.max_num_seqs = 2
@@ -407,7 +407,7 @@ def test_b12x_sparse_glm_uses_8_head_alignment(
     assert lse is None
 
     if num_heads == 8:
-        import sparkinfer.attention._shared.mla.kernel as b12x_mla_kernel
+        import b12x.attention._shared.mla.kernel as b12x_mla_kernel
 
         torch.accelerator.synchronize()
         assert torch.isfinite(output).all()
@@ -437,8 +437,8 @@ def test_b12x_sparse_nvfp4_uses_kernel_format_not_scratch_caps(
 ) -> None:
     if not current_platform.has_device_capability(120):
         pytest.skip("B12xMLASparseBackend requires SM 12.0")
-    if importlib.util.find_spec("sparkinfer") is None:
-        pytest.skip("sparkinfer package not available")
+    if importlib.util.find_spec("b12x") is None:
+        pytest.skip("b12x package not available")
 
     default_vllm_config.scheduler_config.max_num_batched_tokens = 2
     default_vllm_config.scheduler_config.max_num_seqs = 2
@@ -485,8 +485,8 @@ def test_b12x_sparse_glm_dcp_expands_heads_and_converts_topk(
 ) -> None:
     if not current_platform.has_device_capability(120):
         pytest.skip("B12xMLASparseBackend requires SM 12.0")
-    if importlib.util.find_spec("sparkinfer") is None:
-        pytest.skip("sparkinfer package not available")
+    if importlib.util.find_spec("b12x") is None:
+        pytest.skip("b12x package not available")
 
     from vllm.distributed import parallel_state
 
@@ -576,8 +576,8 @@ def test_b12x_sparse_glm_dcp_matches_unsharded_gpu(
 ) -> None:
     if not current_platform.has_device_capability(120):
         pytest.skip("B12xMLASparseBackend requires SM 12.0")
-    if importlib.util.find_spec("sparkinfer") is None:
-        pytest.skip("sparkinfer package not available")
+    if importlib.util.find_spec("b12x") is None:
+        pytest.skip("b12x package not available")
 
     from vllm.distributed import parallel_state
 
@@ -853,9 +853,9 @@ def test_sparse_backend_decode_correctness(
             pytest.skip(f"{backend_cls.get_name()} requires SM 12.0")
         if (
             backend_cls is B12xMLASparseBackend
-            and importlib.util.find_spec("sparkinfer") is None
+            and importlib.util.find_spec("b12x") is None
         ):
-            pytest.skip("sparkinfer package not available")
+            pytest.skip("b12x package not available")
         if kv_cache_dtype != "fp8_ds_mla":
             pytest.skip("SM120 sparse MLA is validated with the fp8_ds_mla cache")
 
@@ -1007,7 +1007,7 @@ def test_sparse_backend_decode_correctness(
 
         if use_fp8_ds_mla_quantization:
             # The SM100 FlashInfer/FlashMLA kernels read ue8m0 (power-of-2) block
-            # scales, so the reference truncates scales to match. SparkInfer's
+            # scales, so the reference truncates scales to match. B12X's
             # GLM_NSA
             # kernel instead keeps the raw e4m3 K with the inline arbitrary-FP32
             # group scale (it is incompatible with ue8m0 block-scaling), so for
@@ -1248,7 +1248,7 @@ def test_b12x_sparse_spec_decode_causality(
     if not current_platform.has_device_capability(120):
         pytest.skip("B12xMLASparseBackend requires SM 12.0 (consumer Blackwell)")
 
-    sparse_mla = pytest.importorskip("sparkinfer.attention.sparse_mla")
+    sparse_mla = pytest.importorskip("b12x.attention.sparse_mla")
     calls = {"decode": 0, "extend": 0}
 
     def track_path(name, fn):

--- a/vllm/compilation/b12x_capture.py
+++ b/vllm/compilation/b12x_capture.py
@@ -33,7 +33,7 @@ def guard_b12x_kernel_resolution(reason: str) -> Iterator[None]:
         return
 
     try:
-        from sparkinfer import (
+        from b12x import (
             freeze_kernel_resolution,
             kernel_resolution_frozen,
             unfreeze_kernel_resolution,

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -102,7 +102,7 @@ def _b12x_pcie_dma_min_bytes() -> int | None:
 @lru_cache(maxsize=1)
 def _load_b12x_pcie_oneshot_pool() -> Any | None:
     try:
-        from sparkinfer.comm.pcie import (
+        from b12x.comm.pcie import (
             OneshotAllReducePool as PCIeOneshotAllReducePool,
         )
     except Exception:
@@ -113,7 +113,7 @@ def _load_b12x_pcie_oneshot_pool() -> Any | None:
 @lru_cache(maxsize=1)
 def _load_b12x_pcie_dma() -> Any | None:
     try:
-        from sparkinfer.comm.pcie import DmaAllReduce as PCIeDmaAllReduce
+        from b12x.comm.pcie import DmaAllReduce as PCIeDmaAllReduce
     except Exception:
         return None
     return PCIeDmaAllReduce
@@ -440,7 +440,7 @@ class CustomAllreduce:
             if pool_cls is None:
                 logger.warning(
                     "PCIe custom allreduce was requested, but "
-                    "sparkinfer.comm.pcie.OneshotAllReducePool is unavailable."
+                    "b12x.comm.pcie.OneshotAllReducePool is unavailable."
                 )
                 return
             # DMA must accommodate the largest scheduled prefill tensor. The
@@ -528,7 +528,7 @@ class CustomAllreduce:
             elif dma_cls is None:
                 logger.warning(
                     "b12x PCIe DMA allreduce unavailable "
-                    "(sparkinfer.comm.pcie.DmaAllReduce not importable); "
+                    "(b12x.comm.pcie.DmaAllReduce not importable); "
                     "large allreduces stay on PyNCCL."
                 )
             else:
@@ -658,7 +658,7 @@ class CustomAllreduce:
     def capture(self, stream: torch.cuda.Stream | None = None):
         """Bind communicator resources to the enclosing CUDA graph capture.
 
-        Legacy custom all-reduce registers graph buffers on exit. SparkInfer
+        Legacy custom all-reduce registers graph buffers on exit. B12X
         PCIe channels are instead created on the graph's owning stream and
         remain valid for the graph lifetime.
         """
@@ -678,7 +678,7 @@ class CustomAllreduce:
                 self.register_graph_buffers()
 
     def checkpoint_pcie_channels(self) -> Any | None:
-        """Snapshot SparkInfer PCIe channels before a disposable capture.
+        """Snapshot B12X PCIe channels before a disposable capture.
 
         Returns:
             An opaque runtime checkpoint, or ``None`` when PCIe all-reduce is
@@ -691,18 +691,18 @@ class CustomAllreduce:
         return checkpoint()
 
     def rollback_pcie_channels(self, checkpoint: Any) -> None:
-        """Release SparkInfer PCIe channels created after ``checkpoint``.
+        """Release B12X PCIe channels created after ``checkpoint``.
 
         Args:
             checkpoint: Opaque state returned by ``checkpoint_pcie_channels``.
 
         Raises:
-            RuntimeError: If the SparkInfer PCIe runtime is unavailable.
+            RuntimeError: If the B12X PCIe runtime is unavailable.
         """
         runtime = self._pcie_runtime
         rollback = getattr(runtime, "rollback_channels", None)
         if rollback is None:
-            raise RuntimeError("SparkInfer PCIe all-reduce runtime is unavailable")
+            raise RuntimeError("B12X PCIe all-reduce runtime is unavailable")
         rollback(checkpoint)
 
     def _pcie_runtime_stream(self) -> torch.cuda.Stream | None:

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -1559,7 +1559,7 @@ def get_pp_group() -> GroupCoordinator:
 
 
 def checkpoint_b12x_graph_channels() -> tuple[tuple[Callable[[Any], None], Any], ...]:
-    """Snapshot SparkInfer channels used by disposable graph captures."""
+    """Snapshot B12X channels used by disposable graph captures."""
     checkpoints: list[tuple[Callable[[Any], None], Any]] = []
     seen_communicators: set[int] = set()
     for group in (_TP, _DCP, _PP):
@@ -1594,7 +1594,7 @@ def checkpoint_b12x_graph_channels() -> tuple[tuple[Callable[[Any], None], Any],
 def rollback_b12x_graph_channels(
     checkpoints: tuple[tuple[Callable[[Any], None], Any], ...],
 ) -> None:
-    """Roll back SparkInfer channels after disposable graphs are destroyed."""
+    """Roll back B12X channels after disposable graphs are destroyed."""
     for rollback, checkpoint in reversed(checkpoints):
         rollback(checkpoint)
 
@@ -1671,7 +1671,7 @@ def graph_capture(
     if _DCP is not None and get_dcp_group().world_size > 1:
         # Import locally to avoid making distributed initialization depend on
         # attention modules. The helper is a no-op until DCP warmup creates a
-        # SparkInfer pool for this process group.
+        # B12X pool for this process group.
         from vllm.v1.attention.ops.dcp_alltoall import capture_b12x_dcp_a2a
 
         maybe_b12x_dcp_capture = capture_b12x_dcp_a2a(get_dcp_group(), context.stream)

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -1863,7 +1863,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_PCIE_ONESHOT_FUSED_ADD_RMS_NORM_MAX_SIZE": lambda: os.getenv(
         "VLLM_PCIE_ONESHOT_FUSED_ADD_RMS_NORM_MAX_SIZE", "84KB"
     ),
-    # Minimum input size for uncompressed SparkInfer DMA allreduce dispatch;
+    # Minimum input size for uncompressed B12X DMA allreduce dispatch;
     # defaults to 6 MiB. Accepts raw bytes or a case-insensitive KB/MB suffix.
     # Whitespace is ignored. "off", "disabled", and "none" disable DMA.
     # A deployment preflight may override this with a measured crossover.
@@ -2292,7 +2292,6 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Prebuilt exllamav3 extension location and torch-ABI compatibility shim.
     "VLLM_EXL3_EXT_PATH": lambda: os.getenv("VLLM_EXL3_EXT_PATH"),
     "VLLM_EXL3_ABI_SHIM": lambda: os.getenv("VLLM_EXL3_ABI_SHIM"),
-
 }
 
 

--- a/vllm/model_executor/kernels/attention/b12x_mxfp8_bmm.py
+++ b/vllm/model_executor/kernels/attention/b12x_mxfp8_bmm.py
@@ -31,7 +31,7 @@ def _import_b12x_bmm() -> Any | None:
     if _B12X_BMM_MISSING:
         return None
     try:
-        gemm = importlib.import_module("sparkinfer.gemm")
+        gemm = importlib.import_module("b12x.gemm")
     except ImportError:
         _B12X_BMM_MISSING = True
         return None
@@ -50,7 +50,7 @@ def _import_fused_mla_query() -> Any | None:
     if _FUSED_MLA_QUERY_MISSING:
         return None
     try:
-        mla_query = importlib.import_module("sparkinfer.gemm.mla_query_projection")
+        mla_query = importlib.import_module("b12x.gemm.mla_query_projection")
     except ImportError:
         _FUSED_MLA_QUERY_MISSING = True
         return None
@@ -163,7 +163,7 @@ def _b12x_mxfp8_bmm_impl(
 ) -> None:
     gemm = _import_b12x_bmm()
     if gemm is None:
-        raise ImportError("sparkinfer.gemm.bmm is not available")
+        raise ImportError("b12x.gemm.bmm is not available")
     major = "k" if b_major == 0 else "n"
     gemm.bmm(
         lhs,
@@ -204,7 +204,7 @@ def _mxfp8_mla_query_impl(
 ) -> None:
     mla_query = _import_fused_mla_query()
     if mla_query is None:
-        raise ImportError("sparkinfer.gemm.mla_query_projection is not available")
+        raise ImportError("b12x.gemm.mla_query_projection is not available")
     mla_query.run(
         lhs,
         (b_values, b_scales),
@@ -243,7 +243,7 @@ def _bf16_mla_query_impl(
 ) -> None:
     mla_query = _import_fused_mla_query()
     if mla_query is None:
-        raise ImportError("sparkinfer.gemm.mla_query_projection is not available")
+        raise ImportError("b12x.gemm.mla_query_projection is not available")
     mla_query.run(
         lhs,
         weight,

--- a/vllm/model_executor/kernels/linear/mxfp4/b12x.py
+++ b/vllm/model_executor/kernels/linear/mxfp4/b12x.py
@@ -37,7 +37,7 @@ def _import_b12x_blockscaled() -> Any | None:
     global _B12X_BLOCKSCALED
     if _B12X_BLOCKSCALED is None:
         try:
-            _B12X_BLOCKSCALED = importlib.import_module("sparkinfer.gemm.blockscaled")
+            _B12X_BLOCKSCALED = importlib.import_module("b12x.gemm.blockscaled")
         except ImportError:
             return None
     return _B12X_BLOCKSCALED
@@ -47,7 +47,7 @@ def _import_b12x_intrinsics() -> Any | None:
     global _B12X_INTRINSICS
     if _B12X_INTRINSICS is None:
         try:
-            _B12X_INTRINSICS = importlib.import_module("sparkinfer._lib.intrinsics")
+            _B12X_INTRINSICS = importlib.import_module("b12x._lib.intrinsics")
         except ImportError:
             return None
     return _B12X_INTRINSICS
@@ -95,7 +95,7 @@ def _apply_b12x_mxfp4_linear(
     blockscaled = _import_b12x_blockscaled()
     intrinsics = _import_b12x_intrinsics()
     if blockscaled is None or intrinsics is None:
-        raise ImportError("sparkinfer native MXFP4 GEMM is not importable")
+        raise ImportError("b12x native MXFP4 GEMM is not importable")
 
     output_size = int(layer.output_size_per_partition)
     output_shape = [*x.shape[:-1], output_size]
@@ -166,9 +166,9 @@ class B12xMxFp4LinearKernel(MxFp4LinearKernel):
             return False, "B12X MXFP4 kernels require a Blackwell 12x device"
         blockscaled = _import_b12x_blockscaled()
         if blockscaled is None or _import_b12x_intrinsics() is None:
-            return False, "sparkinfer native MXFP4 GEMM is not importable"
+            return False, "b12x native MXFP4 GEMM is not importable"
         if not blockscaled.is_supported():
-            return False, "sparkinfer native MXFP4 GEMM is not supported"
+            return False, "b12x native MXFP4 GEMM is not supported"
         return True, None
 
     @classmethod
@@ -181,7 +181,7 @@ class B12xMxFp4LinearKernel(MxFp4LinearKernel):
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         intrinsics = _import_b12x_intrinsics()
         if intrinsics is None:
-            raise ImportError("sparkinfer native MXFP4 GEMM is not importable")
+            raise ImportError("b12x native MXFP4 GEMM is not importable")
         layer.weight_scale = torch.nn.Parameter(
             intrinsics.swizzle_block_scale(layer.weight_scale.data),
             requires_grad=False,

--- a/vllm/model_executor/kernels/linear/mxfp8/b12x.py
+++ b/vllm/model_executor/kernels/linear/mxfp8/b12x.py
@@ -46,7 +46,7 @@ def _import_b12x_mxfp8() -> Any | None:
     if _B12X_MXFP8_MISSING:
         return None
     try:
-        _B12X_MXFP8 = importlib.import_module("sparkinfer.gemm.mxfp8_linear")
+        _B12X_MXFP8 = importlib.import_module("b12x.gemm.mxfp8_linear")
     except ImportError:
         _B12X_MXFP8_MISSING = True
         return None
@@ -84,7 +84,7 @@ def _b12x_mxfp8_warmup_token_counts(
 def _missing_b12x_mxfp8_api(mxfp8: Any) -> str | None:
     for name in ("pack_weight", "mm"):
         if not callable(getattr(mxfp8, name, None)):
-            return f"sparkinfer.gemm.mxfp8_linear missing callable {name}"
+            return f"b12x.gemm.mxfp8_linear missing callable {name}"
     return None
 
 
@@ -130,7 +130,7 @@ def _apply_b12x_mxfp8_packed_linear(
 
     mxfp8 = _import_b12x_mxfp8()
     if mxfp8 is None:
-        raise ImportError("sparkinfer.gemm.mxfp8_linear is not importable")
+        raise ImportError("b12x.gemm.mxfp8_linear is not importable")
     output = mxfp8.mm(
         input_2d,
         packed_weight,
@@ -258,13 +258,13 @@ class B12xMxfp8LinearKernel(Mxfp8LinearKernel):
             return False, "b12x MXFP8 GEMM is not enabled"
         mxfp8 = _import_b12x_mxfp8()
         if mxfp8 is None:
-            return False, "sparkinfer.gemm.mxfp8_linear is not importable"
+            return False, "b12x.gemm.mxfp8_linear is not importable"
         missing_api = _missing_b12x_mxfp8_api(mxfp8)
         if missing_api is not None:
             return False, missing_api
         support_probe = getattr(mxfp8, "is_supported", None)
         if callable(support_probe) and not support_probe():
-            return False, "sparkinfer.gemm.mxfp8_linear is not supported"
+            return False, "b12x.gemm.mxfp8_linear is not supported"
         return True, None
 
     @classmethod
@@ -304,7 +304,7 @@ class B12xMxfp8LinearKernel(Mxfp8LinearKernel):
 
         mxfp8 = _import_b12x_mxfp8()
         if mxfp8 is None:
-            raise ImportError("sparkinfer.gemm.mxfp8_linear is not importable")
+            raise ImportError("b12x.gemm.mxfp8_linear is not importable")
         scale_k = in_features // MXFP8_BLOCK_SIZE
         layer.b12x_mxfp8_packed_weight = mxfp8.pack_weight(
             weight[:out_features, :in_features].detach(),

--- a/vllm/model_executor/kernels/linear/nvfp4/b12x.py
+++ b/vllm/model_executor/kernels/linear/nvfp4/b12x.py
@@ -41,7 +41,7 @@ def _import_b12x_blockscaled() -> Any | None:
     if _B12X_MISSING:
         return None
     try:
-        _B12X_BLOCKSCALED = importlib.import_module("sparkinfer.gemm.blockscaled")
+        _B12X_BLOCKSCALED = importlib.import_module("b12x.gemm.blockscaled")
     except ImportError:
         _B12X_MISSING = True
         return None
@@ -55,7 +55,7 @@ def _import_b12x_intrinsics() -> Any | None:
     if _B12X_MISSING:
         return None
     try:
-        _B12X_INTRINSICS = importlib.import_module("sparkinfer._lib.intrinsics")
+        _B12X_INTRINSICS = importlib.import_module("b12x._lib.intrinsics")
     except ImportError:
         _B12X_MISSING = True
         return None
@@ -102,7 +102,7 @@ def _apply_b12x_nvfp4_linear(
     blockscaled = _import_b12x_blockscaled()
     intrinsics = _import_b12x_intrinsics()
     if blockscaled is None or intrinsics is None:
-        raise ImportError("sparkinfer native NVFP4 GEMM is not importable")
+        raise ImportError("b12x native NVFP4 GEMM is not importable")
 
     output_size = int(layer.output_size_per_partition)
     output_shape = [*x.shape[:-1], output_size]
@@ -180,9 +180,9 @@ class B12xNvFp4LinearKernel(NvFp4LinearKernel):
             return False, "B12X NVFP4 kernels require a Blackwell 12x device"
         blockscaled = _import_b12x_blockscaled()
         if blockscaled is None or _import_b12x_intrinsics() is None:
-            return False, "sparkinfer native NVFP4 GEMM is not importable"
+            return False, "b12x native NVFP4 GEMM is not importable"
         if not blockscaled.is_supported():
-            return False, "sparkinfer native NVFP4 GEMM is not supported"
+            return False, "b12x native NVFP4 GEMM is not supported"
         return True, None
 
     @classmethod
@@ -195,7 +195,7 @@ class B12xNvFp4LinearKernel(NvFp4LinearKernel):
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         intrinsics = _import_b12x_intrinsics()
         if intrinsics is None:
-            raise ImportError("sparkinfer native NVFP4 GEMM is not importable")
+            raise ImportError("b12x native NVFP4 GEMM is not importable")
         layer.weight_scale = torch.nn.Parameter(
             intrinsics.swizzle_block_scale(layer.weight_scale.data),
             requires_grad=False,

--- a/vllm/model_executor/kernels/linear/scaled_mm/b12x.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/b12x.py
@@ -44,7 +44,7 @@ def _import_b12x_block_fp8() -> Any | None:
     if _B12X_BLOCK_FP8_MISSING:
         return None
     try:
-        _B12X_BLOCK_FP8 = importlib.import_module("sparkinfer.gemm.block_fp8_linear")
+        _B12X_BLOCK_FP8 = importlib.import_module("b12x.gemm.block_fp8_linear")
     except ImportError:
         _B12X_BLOCK_FP8_MISSING = True
         return None
@@ -90,7 +90,7 @@ def _run_b12x_fp8_block_scaled_linear(
 ) -> torch.Tensor:
     block_fp8 = _import_b12x_block_fp8()
     if block_fp8 is None:
-        raise ImportError("sparkinfer.gemm.block_fp8_linear is not importable")
+        raise ImportError("b12x.gemm.block_fp8_linear is not importable")
 
     tokens = int(input_2d.shape[0])
     out_features = int(packed_weight.out_features)
@@ -180,7 +180,7 @@ class B12xFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
         if not current_platform.is_device_capability_family(120):
             return False, "b12x FP8 kernels require a Blackwell 12x device"
         if _import_b12x_block_fp8() is None:
-            return False, "sparkinfer.gemm.block_fp8_linear is not importable"
+            return False, "b12x.gemm.block_fp8_linear is not importable"
         return True, None
 
     @classmethod
@@ -232,7 +232,7 @@ class B12xFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
 
         block_fp8 = _import_b12x_block_fp8()
         if block_fp8 is None:
-            raise ImportError("sparkinfer.gemm.block_fp8_linear is not importable")
+            raise ImportError("b12x.gemm.block_fp8_linear is not importable")
         layer.b12x_packed_weight = block_fp8.pack_weight(
             params.weight.detach(),
             weight_scale.detach(),

--- a/vllm/model_executor/kernels/linear/scaled_mm/b12x_tensor.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/b12x_tensor.py
@@ -44,7 +44,7 @@ def _import_b12x_tensor_fp8() -> Any | None:
     if _B12X_TENSOR_FP8_MISSING:
         return None
     try:
-        _B12X_TENSOR_FP8 = importlib.import_module("sparkinfer.gemm.tensor_fp8_linear")
+        _B12X_TENSOR_FP8 = importlib.import_module("b12x.gemm.tensor_fp8_linear")
     except ImportError:
         _B12X_TENSOR_FP8_MISSING = True
         return None
@@ -65,7 +65,7 @@ def _b12x_tensor_fp8_enabled() -> bool:
 def _missing_b12x_tensor_fp8_api(tensor_fp8: Any) -> str | None:
     for name in ("pack_weight", "mm", "prewarm"):
         if not callable(getattr(tensor_fp8, name, None)):
-            return f"sparkinfer.gemm.tensor_fp8_linear missing callable {name}"
+            return f"b12x.gemm.tensor_fp8_linear missing callable {name}"
     return None
 
 
@@ -109,7 +109,7 @@ def _apply_b12x_tensor_fp8_packed_linear(
 
     tensor_fp8 = _import_b12x_tensor_fp8()
     if tensor_fp8 is None:
-        raise ImportError("sparkinfer.gemm.tensor_fp8_linear is not importable")
+        raise ImportError("b12x.gemm.tensor_fp8_linear is not importable")
 
     input_2d = x_q.reshape(-1, x_q.shape[-1]).contiguous()
     output_shape = [*x_q.shape[:-1], int(packed_weight.out_features)]
@@ -250,13 +250,13 @@ class B12xTensorFP8ScaledMMLinearKernel(FP8ScaledMMLinearKernel):
             return False, "b12x tensor FP8 GEMM is not enabled"
         tensor_fp8 = _import_b12x_tensor_fp8()
         if tensor_fp8 is None:
-            return False, "sparkinfer.gemm.tensor_fp8_linear is not importable"
+            return False, "b12x.gemm.tensor_fp8_linear is not importable"
         missing_api = _missing_b12x_tensor_fp8_api(tensor_fp8)
         if missing_api is not None:
             return False, missing_api
         support_probe = getattr(tensor_fp8, "is_supported", None)
         if callable(support_probe) and not support_probe():
-            return False, "sparkinfer.gemm.tensor_fp8_linear is not supported"
+            return False, "b12x.gemm.tensor_fp8_linear is not supported"
         return True, None
 
     @classmethod
@@ -304,7 +304,7 @@ class B12xTensorFP8ScaledMMLinearKernel(FP8ScaledMMLinearKernel):
 
         tensor_fp8 = _import_b12x_tensor_fp8()
         if tensor_fp8 is None:
-            raise ImportError("sparkinfer.gemm.tensor_fp8_linear is not importable")
+            raise ImportError("b12x.gemm.tensor_fp8_linear is not importable")
         output_scale = (
             input_scale.detach().to(torch.float32).reshape(1)
             * weight_scale.detach().to(torch.float32).reshape(1)

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -1731,7 +1731,7 @@ class MLAAttention(nn.Module, AttentionLayerBase):
         if not (uk_supported and uv_supported):
             logger.warning_once(
                 "VLLM_B12X_ABSORB_BMM=1 but the MLA geometry is outside the "
-                "sparkinfer.gemm.bmm envelope; falling back to the materialized "
+                "b12x.gemm.bmm envelope; falling back to the materialized "
                 "absorbed weights."
             )
             return False

--- a/vllm/model_executor/layers/fused_moe/b12x_ep_moe.py
+++ b/vllm/model_executor/layers/fused_moe/b12x_ep_moe.py
@@ -38,8 +38,8 @@ def _plan_b12x_ep_moe_fp4_scratch(
     swiglu_alpha: float | None = None,
     swiglu_beta: float | None = None,
 ):
-    from sparkinfer.moe.ep_moe import Caps as EPMoEScratchCaps
-    from sparkinfer.moe.ep_moe import plan as plan_ep_moe_scratch
+    from b12x.moe.ep_moe import Caps as EPMoEScratchCaps
+    from b12x.moe.ep_moe import plan as plan_ep_moe_scratch
 
     return plan_ep_moe_scratch(
         EPMoEScratchCaps(
@@ -67,7 +67,7 @@ def _run_b12x_ep_moe_fp4(
     plan: Any,
     scratch: torch.Tensor,
 ) -> None:
-    from sparkinfer.moe.ep_moe import run as b12x_ep_moe_fp4
+    from b12x.moe.ep_moe import run as b12x_ep_moe_fp4
 
     binding = plan.bind(
         scratch=scratch,
@@ -129,7 +129,7 @@ class B12xEPExperts(B12xExperts):
         if not B12xExperts._supports_current_device():
             return False
         try:
-            from sparkinfer.moe.ep_moe import run as b12x_ep_moe_fp4  # noqa: F401
+            from b12x.moe.ep_moe import run as b12x_ep_moe_fp4  # noqa: F401
 
             return True
         except ImportError:
@@ -186,7 +186,7 @@ class B12xEPExperts(B12xExperts):
                     "B12X EP expert_map changed before/during CUDA graph capture"
                 )
 
-        from sparkinfer.moe.ep_moe import prepare_expert_map as prepare_ep_expert_map
+        from b12x.moe.ep_moe import prepare_expert_map as prepare_ep_expert_map
 
         prepared = prepare_ep_expert_map(
             expert_map,

--- a/vllm/model_executor/layers/fused_moe/b12x_moe.py
+++ b/vllm/model_executor/layers/fused_moe/b12x_moe.py
@@ -403,8 +403,8 @@ def _plan_b12x_moe_fp4_scratch(
     swiglu_beta: float | None = None,
     collect_activation_amax: bool = False,
 ):
-    from sparkinfer.moe.fused_moe import Caps as TPMoEScratchCaps
-    from sparkinfer.moe.fused_moe import plan as plan_tp_moe_scratch
+    from b12x.moe.fused_moe import Caps as TPMoEScratchCaps
+    from b12x.moe.fused_moe import plan as plan_tp_moe_scratch
 
     return plan_tp_moe_scratch(
         TPMoEScratchCaps(
@@ -437,7 +437,7 @@ def _plan_b12x_moe_execution(
     swiglu_alpha: float | None = None,
     swiglu_beta: float | None = None,
 ):
-    from sparkinfer.moe.fused_moe import plan_execution as plan_tp_moe_execution
+    from b12x.moe.fused_moe import plan_execution as plan_tp_moe_execution
 
     return plan_tp_moe_execution(
         num_tokens=max(int(tokens), 1),
@@ -453,7 +453,7 @@ def _plan_b12x_moe_execution(
 
 
 def _b12x_moe_plan_supports_aux_stream_overlap(plan: Any) -> bool:
-    # Namespaced SparkInfer does not yet publish a plan capability predicate.
+    # Namespaced B12X does not yet publish a plan capability predicate.
     # Some resident-grid plans use device-wide barriers, so lack of an explicit
     # guarantee must conservatively disable auxiliary-stream overlap.
     return False
@@ -478,7 +478,7 @@ def _dynamic_moe_warmup_tokens(
     """Return a small token count that selects b12x's dynamic MoE backend."""
     # This warmup-only policy probe is not exposed by the public facade. Actual
     # planning, binding, and execution below all use the public API.
-    from sparkinfer.moe.fused_moe._impl import select_tp_moe_backend
+    from b12x.moe.fused_moe._impl import select_tp_moe_backend
 
     tokens = max(int(requested_tokens), 1)
     topk = max(int(topk), 1)
@@ -560,7 +560,7 @@ def _run_b12x_moe_fp4(
     layer_idx: int | None = None,
 ) -> None:
     """Call b12x MoE with caller-owned live scratch."""
-    from sparkinfer.moe.fused_moe import run as b12x_moe_fp4
+    from b12x.moe.fused_moe import run as b12x_moe_fp4
 
     if _moe_zero_scratch_enabled():
         if _is_current_stream_capturing():
@@ -773,7 +773,7 @@ def _normalize_modelopt_expert_scale(scale: torch.Tensor) -> torch.Tensor:
 
 def _has_b12x() -> bool:
     try:
-        from sparkinfer.moe.fused_moe import run as b12x_moe_fp4  # noqa: F401
+        from b12x.moe.fused_moe import run as b12x_moe_fp4  # noqa: F401
 
         return True
     except ImportError:
@@ -1143,11 +1143,11 @@ class B12xExperts(mk.FusedMoEExpertsModular):
             a1_gscale = unit_scale
             a2_gscale = unit_scale
 
-        from sparkinfer.moe._shared.execution import PreparedWeightLayout
-        from sparkinfer.moe.fused_moe import (
+        from b12x.moe._shared.execution import PreparedWeightLayout
+        from b12x.moe.fused_moe import (
             plan_weights as plan_b12x_fp4_moe_weights,
         )
-        from sparkinfer.moe.fused_moe import (
+        from b12x.moe.fused_moe import (
             prepare_weights as prepare_b12x_fp4_moe_weights,
         )
 

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -3,7 +3,7 @@
 
 """EXL3 (ExLlamaV3 trellis) quantization support.
 
-Rank-sliced routed-expert checkpoints use B12X's unified planned
+Rank-sliced routed-expert checkpoints use Sparkinfer's unified planned
 ``fused_moe`` API for the Trellis decode/prefill windows and the ExLlamaV3
 extension for the small eager parity window. Generic dense and non-rank-sliced
 MoE checkpoints use the
@@ -68,8 +68,8 @@ _MCG_SENTINEL = 0xCBAC1FED
 _MUL1_SENTINEL = 0x83DCD12D
 _HADAMARD_BLOCK = 128
 _EXL3_EXT: Any | None = None
-_B12X_FUSED_MOE_API: Any | None = None
-_B12X_MIXED_TRELLIS_API: Any | None = None
+_SPARKINFER_FUSED_MOE_API: Any | None = None
+_SPARKINFER_MIXED_TRELLIS_API: Any | None = None
 _RANK_SLICED_RUNTIMES: dict[tuple[Any, ...], dict[str, Any]] = {}
 _MIXED_TRELLIS_RUNTIMES: dict[tuple[Any, ...], dict[str, Any]] = {}
 _NEXT_RUNTIME_SCOPE_ID = 0
@@ -198,36 +198,40 @@ def _load_exl3_ext() -> Any:
     return ext
 
 
-def _load_b12x_fused_moe() -> Any:
+def _load_sparkinfer_fused_moe() -> Any:
     """Resolve the public unified MoE API lazily."""
 
-    global _B12X_FUSED_MOE_API
-    if _B12X_FUSED_MOE_API is not None:
-        return _B12X_FUSED_MOE_API
+    global _SPARKINFER_FUSED_MOE_API
+    if _SPARKINFER_FUSED_MOE_API is not None:
+        return _SPARKINFER_FUSED_MOE_API
     try:
-        from b12x.moe import fused_moe
+        from sparkinfer.moe import fused_moe
     except Exception as exc:
         raise RuntimeError(
             "Rank-sliced EXL3 requires the exl3_trellis_mcg source in "
-            "b12x.moe.fused_moe. Install a matching B12X build."
+            "sparkinfer.moe.fused_moe. Install a matching Sparkinfer build."
         ) from exc
-    _B12X_FUSED_MOE_API = fused_moe
+    _SPARKINFER_FUSED_MOE_API = fused_moe
     return fused_moe
 
 
-def _load_b12x_mixed_trellis() -> Any:
+def _load_sparkinfer_mixed_trellis() -> Any:
     """Resolve the one-grid mixed-bitrate Trellis API lazily."""
 
-    global _B12X_MIXED_TRELLIS_API
-    if _B12X_MIXED_TRELLIS_API is not None:
-        return _B12X_MIXED_TRELLIS_API
+    global _SPARKINFER_MIXED_TRELLIS_API
+    if _SPARKINFER_MIXED_TRELLIS_API is not None:
+        return _SPARKINFER_MIXED_TRELLIS_API
     try:
-        module = importlib.import_module("b12x.moe._shared.kernels.w4a16.mixed_trellis")
-        prepare = importlib.import_module("b12x.moe._shared.kernels.w4a16.prepare")
-        host = importlib.import_module("b12x.moe._shared.kernels.w4a16.host")
+        module = importlib.import_module(
+            "sparkinfer.moe._shared.kernels.w4a16.mixed_trellis"
+        )
+        prepare = importlib.import_module(
+            "sparkinfer.moe._shared.kernels.w4a16.prepare"
+        )
+        host = importlib.import_module("sparkinfer.moe._shared.kernels.w4a16.host")
     except Exception as exc:
         raise RuntimeError(
-            "Mixed-bitrate rank-sliced EXL3 requires the matching B12X "
+            "Mixed-bitrate rank-sliced EXL3 requires the matching SparkInfer "
             "mixed_trellis implementation."
         ) from exc
     api = SimpleNamespace(
@@ -239,7 +243,7 @@ def _load_b12x_mixed_trellis() -> Any:
         prepare_weights=prepare.prepare_trellis256_moe_weights,
         run_mixed_trellis=module.run_mixed_trellis,
     )
-    _B12X_MIXED_TRELLIS_API = api
+    _SPARKINFER_MIXED_TRELLIS_API = api
     return api
 
 
@@ -1566,7 +1570,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         return (128, 128, 128, 128)
 
     def _prepare_mixed_rank_sliced_weights(self, layer: RoutedExperts) -> None:
-        api = _load_b12x_mixed_trellis()
+        api = _load_sparkinfer_mixed_trellis()
         num_experts = int(layer.local_num_experts)
         hidden_size = int(layer.exl3_hidden_size)
         intermediate_size = int(layer.exl3_intermediate_size_per_partition)
@@ -1714,7 +1718,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         if getattr(layer, "exl3_mixed_bitrate", False):
             self._prepare_mixed_rank_sliced_weights(layer)
             return
-        api = _load_b12x_fused_moe()
+        api = _load_sparkinfer_fused_moe()
         num_experts = int(layer.local_num_experts)
         hidden_size = int(layer.exl3_hidden_size)
         intermediate_size = int(layer.exl3_intermediate_size_per_partition)
@@ -1864,7 +1868,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 f"{topk_ids.dtype}"
             )
 
-        api = _load_b12x_mixed_trellis()
+        api = _load_sparkinfer_mixed_trellis()
         device = x.device
         props = torch.cuda.get_device_properties(device)
         total_experts = sum(experts for _, experts in tier_signature)
@@ -2042,7 +2046,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 "profile pass before CUDA graph capture"
             )
 
-        api = _load_b12x_fused_moe()
+        api = _load_sparkinfer_fused_moe()
 
         def _plan_with_scratch(plan_max_tokens: int, plan_block_m: int):
             caps = api.Caps(

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -3,7 +3,7 @@
 
 """EXL3 (ExLlamaV3 trellis) quantization support.
 
-Rank-sliced routed-expert checkpoints use Sparkinfer's unified planned
+Rank-sliced routed-expert checkpoints use B12X's unified planned
 ``fused_moe`` API for the Trellis decode/prefill windows and the ExLlamaV3
 extension for the small eager parity window. Generic dense and non-rank-sliced
 MoE checkpoints use the
@@ -68,8 +68,8 @@ _MCG_SENTINEL = 0xCBAC1FED
 _MUL1_SENTINEL = 0x83DCD12D
 _HADAMARD_BLOCK = 128
 _EXL3_EXT: Any | None = None
-_SPARKINFER_FUSED_MOE_API: Any | None = None
-_SPARKINFER_MIXED_TRELLIS_API: Any | None = None
+_B12X_FUSED_MOE_API: Any | None = None
+_B12X_MIXED_TRELLIS_API: Any | None = None
 _RANK_SLICED_RUNTIMES: dict[tuple[Any, ...], dict[str, Any]] = {}
 _MIXED_TRELLIS_RUNTIMES: dict[tuple[Any, ...], dict[str, Any]] = {}
 _NEXT_RUNTIME_SCOPE_ID = 0
@@ -198,40 +198,36 @@ def _load_exl3_ext() -> Any:
     return ext
 
 
-def _load_sparkinfer_fused_moe() -> Any:
+def _load_b12x_fused_moe() -> Any:
     """Resolve the public unified MoE API lazily."""
 
-    global _SPARKINFER_FUSED_MOE_API
-    if _SPARKINFER_FUSED_MOE_API is not None:
-        return _SPARKINFER_FUSED_MOE_API
+    global _B12X_FUSED_MOE_API
+    if _B12X_FUSED_MOE_API is not None:
+        return _B12X_FUSED_MOE_API
     try:
-        from sparkinfer.moe import fused_moe
+        from b12x.moe import fused_moe
     except Exception as exc:
         raise RuntimeError(
             "Rank-sliced EXL3 requires the exl3_trellis_mcg source in "
-            "sparkinfer.moe.fused_moe. Install a matching Sparkinfer build."
+            "b12x.moe.fused_moe. Install a matching B12X build."
         ) from exc
-    _SPARKINFER_FUSED_MOE_API = fused_moe
+    _B12X_FUSED_MOE_API = fused_moe
     return fused_moe
 
 
-def _load_sparkinfer_mixed_trellis() -> Any:
+def _load_b12x_mixed_trellis() -> Any:
     """Resolve the one-grid mixed-bitrate Trellis API lazily."""
 
-    global _SPARKINFER_MIXED_TRELLIS_API
-    if _SPARKINFER_MIXED_TRELLIS_API is not None:
-        return _SPARKINFER_MIXED_TRELLIS_API
+    global _B12X_MIXED_TRELLIS_API
+    if _B12X_MIXED_TRELLIS_API is not None:
+        return _B12X_MIXED_TRELLIS_API
     try:
-        module = importlib.import_module(
-            "sparkinfer.moe._shared.kernels.w4a16.mixed_trellis"
-        )
-        prepare = importlib.import_module(
-            "sparkinfer.moe._shared.kernels.w4a16.prepare"
-        )
-        host = importlib.import_module("sparkinfer.moe._shared.kernels.w4a16.host")
+        module = importlib.import_module("b12x.moe._shared.kernels.w4a16.mixed_trellis")
+        prepare = importlib.import_module("b12x.moe._shared.kernels.w4a16.prepare")
+        host = importlib.import_module("b12x.moe._shared.kernels.w4a16.host")
     except Exception as exc:
         raise RuntimeError(
-            "Mixed-bitrate rank-sliced EXL3 requires the matching SparkInfer "
+            "Mixed-bitrate rank-sliced EXL3 requires the matching B12X "
             "mixed_trellis implementation."
         ) from exc
     api = SimpleNamespace(
@@ -243,7 +239,7 @@ def _load_sparkinfer_mixed_trellis() -> Any:
         prepare_weights=prepare.prepare_trellis256_moe_weights,
         run_mixed_trellis=module.run_mixed_trellis,
     )
-    _SPARKINFER_MIXED_TRELLIS_API = api
+    _B12X_MIXED_TRELLIS_API = api
     return api
 
 
@@ -1570,7 +1566,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         return (128, 128, 128, 128)
 
     def _prepare_mixed_rank_sliced_weights(self, layer: RoutedExperts) -> None:
-        api = _load_sparkinfer_mixed_trellis()
+        api = _load_b12x_mixed_trellis()
         num_experts = int(layer.local_num_experts)
         hidden_size = int(layer.exl3_hidden_size)
         intermediate_size = int(layer.exl3_intermediate_size_per_partition)
@@ -1718,7 +1714,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         if getattr(layer, "exl3_mixed_bitrate", False):
             self._prepare_mixed_rank_sliced_weights(layer)
             return
-        api = _load_sparkinfer_fused_moe()
+        api = _load_b12x_fused_moe()
         num_experts = int(layer.local_num_experts)
         hidden_size = int(layer.exl3_hidden_size)
         intermediate_size = int(layer.exl3_intermediate_size_per_partition)
@@ -1868,7 +1864,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 f"{topk_ids.dtype}"
             )
 
-        api = _load_sparkinfer_mixed_trellis()
+        api = _load_b12x_mixed_trellis()
         device = x.device
         props = torch.cuda.get_device_properties(device)
         total_experts = sum(experts for _, experts in tier_signature)
@@ -2046,7 +2042,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 "profile pass before CUDA graph capture"
             )
 
-        api = _load_sparkinfer_fused_moe()
+        api = _load_b12x_fused_moe()
 
         def _plan_with_scratch(plan_max_tokens: int, plan_block_m: int):
             caps = api.Caps(

--- a/vllm/model_executor/layers/quantization/nvfp4_nf3_hybrid.py
+++ b/vllm/model_executor/layers/quantization/nvfp4_nf3_hybrid.py
@@ -593,7 +593,7 @@ class NvFp4Nf3HybridMoEMethod(FusedMoEMethodBase):
         are known there, and the first forward is vLLM's eager profile run,
         so nothing compiles inside CUDA-graph capture).
         """
-        from sparkinfer.moe._shared.kernels.w4a16.prepare import (
+        from b12x.moe._shared.kernels.w4a16.prepare import (
             PreparedNF3MoeWeights,
             W4A16PackedWeights,
             _make_workspace,
@@ -738,10 +738,10 @@ class NvFp4Nf3HybridMoEMethod(FusedMoEMethodBase):
         routing and a fused top-k sum; if that compile is unavailable the
         packed launch also serves decode.
         """
-        from sparkinfer.moe._shared.kernels.w4a16.host import (
+        from b12x.moe._shared.kernels.w4a16.host import (
             max_packed_route_slots,
         )
-        from sparkinfer.moe._shared.kernels.w4a16.kernel import (
+        from b12x.moe._shared.kernels.w4a16.kernel import (
             compile_w4a16_fused_moe,
         )
 
@@ -918,10 +918,10 @@ class NvFp4Nf3HybridMoEMethod(FusedMoEMethodBase):
                 getattr(props, "shared_memory_per_block_optin", 101_376)
             )
             if runtime.grid188_launch is None:
-                from sparkinfer.moe._shared.kernels.w4a16.host import (
+                from b12x.moe._shared.kernels.w4a16.host import (
                     packed_gemm_scratch_elements,
                 )
-                from sparkinfer.moe._shared.kernels.w4a16.kernel import (
+                from b12x.moe._shared.kernels.w4a16.kernel import (
                     compile_w4a16_fused_moe_hybrid,
                 )
 
@@ -953,7 +953,7 @@ class NvFp4Nf3HybridMoEMethod(FusedMoEMethodBase):
                 ):
                     raise RuntimeError("compiled hybrid launch failed admission")
                 if not hasattr(
-                    torch.ops.sparkinfer,
+                    torch.ops.b12x,
                     "w4a16_fused_moe_hybrid_launch",
                 ):
                     raise RuntimeError("hybrid one-grid custom op is unavailable")
@@ -1020,7 +1020,7 @@ class NvFp4Nf3HybridMoEMethod(FusedMoEMethodBase):
         assert state.grid188_tier_map is not None
         assert state.grid188_output is not None
         m = int(x.shape[0])
-        torch.ops.sparkinfer.w4a16_fused_moe_hybrid_launch(
+        torch.ops.b12x.w4a16_fused_moe_hybrid_launch(
             x,
             *state.grid188_weight_views,
             topk_ids.view(-1),
@@ -1066,7 +1066,7 @@ class NvFp4Nf3HybridMoEMethod(FusedMoEMethodBase):
         scratch/buffer set. The first apply is vLLM's eager profile run at
         max_num_batched_tokens, so max_m sizes itself to the serving
         ceiling and nothing compiles during CUDA-graph capture."""
-        from sparkinfer.moe._shared.kernels.w4a16.host import (
+        from b12x.moe._shared.kernels.w4a16.host import (
             make_w4a16_packed_buffers,
             max_packed_route_slots,
         )
@@ -1140,7 +1140,7 @@ class NvFp4Nf3HybridMoEMethod(FusedMoEMethodBase):
         decode: bool,
     ) -> torch.Tensor:
         """Run one tier through its preplanned b12x launch."""
-        from sparkinfer.moe._shared.kernels.w4a16.kernel import run_w4a16_moe
+        from b12x.moe._shared.kernels.w4a16.kernel import run_w4a16_moe
 
         runtime = self.quant_config.shared_runtime
         use_decode = decode and launch_pair[0] is not launch_pair[1]

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -1063,17 +1063,17 @@ def _run_b12x_paged_topk(
     live K-row window (a metadata tensor, not an in-kernel reduction); when
     None, b12x falls back to the capacity cap.
     """
-    from sparkinfer.attention.nsa_indexer import (
+    from b12x.attention.nsa_indexer import (
         PAGED_INDEX_PAGE_SIZE,
         index_topk_fp8,
     )
-    from sparkinfer.attention.nsa_indexer import (
+    from b12x.attention.nsa_indexer import (
         SOURCE_LAYOUT_PAGED as INDEXER_SOURCE_LAYOUT_PAGED,
     )
-    from sparkinfer.attention.nsa_indexer import (
+    from b12x.attention.nsa_indexer import (
         Caps as B12XIndexerScratchCaps,
     )
-    from sparkinfer.attention.nsa_indexer import (
+    from b12x.attention.nsa_indexer import (
         plan as plan_indexer_scratch,
     )
 
@@ -1142,7 +1142,7 @@ def _merge_b12x_dcp_topk(
             "cross-rank candidate merge."
         )
 
-    from sparkinfer.attention.nsa_indexer.tiled_topk import run_row_topk
+    from b12x.attention.nsa_indexer.tiled_topk import run_row_topk
 
     from vllm.distributed.parallel_state import get_indexer_dcp_group
     from vllm.v1.attention.backends.mla.sparse_utils import (
@@ -1296,7 +1296,7 @@ def _merge_b12x_dcp_topk_by_owner(
             "DCP owner top-k local rows must alias their TP query partition"
         )
 
-    from sparkinfer.attention.nsa_indexer.tiled_topk import run_row_topk
+    from b12x.attention.nsa_indexer.tiled_topk import run_row_topk
 
     from vllm.v1.attention.backends.mla.sparse_utils import (
         triton_convert_dcp_local_topk_to_global,
@@ -1518,10 +1518,10 @@ def _prewarm_b12x_contiguous_prefill_variants(
         return
 
     try:
-        from sparkinfer.attention.nsa_indexer.contiguous_kernel import (
+        from b12x.attention.nsa_indexer.contiguous_kernel import (
             run_contiguous_logits_kernel,
         )
-        from sparkinfer.attention.nsa_indexer.tiled_topk import run_tiled_topk
+        from b12x.attention.nsa_indexer.tiled_topk import run_tiled_topk
     except (AttributeError, ImportError, ModuleNotFoundError):
         return
 
@@ -1618,16 +1618,16 @@ def _reserve_b12x_paged_indexer_scratch(
     device: torch.device,
     shared_page_table: bool = False,
 ) -> None:
-    from sparkinfer.attention.nsa_indexer import (
+    from b12x.attention.nsa_indexer import (
         PAGED_INDEX_PAGE_SIZE,
     )
-    from sparkinfer.attention.nsa_indexer import (
+    from b12x.attention.nsa_indexer import (
         SOURCE_LAYOUT_PAGED as INDEXER_SOURCE_LAYOUT_PAGED,
     )
-    from sparkinfer.attention.nsa_indexer import (
+    from b12x.attention.nsa_indexer import (
         Caps as B12XIndexerScratchCaps,
     )
-    from sparkinfer.attention.nsa_indexer import (
+    from b12x.attention.nsa_indexer import (
         plan as plan_indexer_scratch,
     )
 

--- a/vllm/model_executor/warmup/b12x_sparse_indexer_warmup.py
+++ b/vllm/model_executor/warmup/b12x_sparse_indexer_warmup.py
@@ -52,7 +52,7 @@ def _fused_decode_warmup_rows(
     max_pages: int,
     device: torch.device,
 ) -> tuple[int, ...]:
-    from sparkinfer.attention.nsa_indexer.fused_indexer import (
+    from b12x.attention.nsa_indexer.fused_indexer import (
         fused_indexer_decode_warmup_rows,
     )
 

--- a/vllm/models/deepseek_v4/attention.py
+++ b/vllm/models/deepseek_v4/attention.py
@@ -441,7 +441,7 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
 
         groups, group_width, rank, hidden = self._validate_wo_projection_tensors()
 
-        from sparkinfer.gemm.wo_projection import (
+        from b12x.gemm.wo_projection import (
             pack_weights as pack_wo_projection_fp8_block_scaled_weights_mxfp8,
         )
 
@@ -484,7 +484,7 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
         if weights is None:
             raise RuntimeError("DeepSeek V4 b12x WO weights were not packed")
 
-        from sparkinfer.gemm.wo_projection import (
+        from b12x.gemm.wo_projection import (
             run_inv_rope as wo_projection_inv_rope_mxfp8,
         )
 

--- a/vllm/models/deepseek_v4/nvidia/b12x.py
+++ b/vllm/models/deepseek_v4/nvidia/b12x.py
@@ -248,16 +248,16 @@ def _run_compressed_mla(
     {16,32,64,128} by the outer wrapper). Indices are global slot ids, so no
     indexed page table is needed.
     """
-    from sparkinfer.attention.compressed_mla import (
+    from b12x.attention.compressed_mla import (
         Caps as B12XCompressedMLAScratchCaps,
     )
-    from sparkinfer.attention.compressed_mla import (
+    from b12x.attention.compressed_mla import (
         plan as plan_compressed_mla_scratch,
     )
-    from sparkinfer.attention.compressed_mla import (
+    from b12x.attention.compressed_mla import (
         run as compressed_mla_decode_forward,
     )
-    from sparkinfer.attention.compressed_mla import (
+    from b12x.attention.compressed_mla import (
         split_chunks_for_contract as compressed_mla_split_chunks_for_contract,
     )
 
@@ -476,13 +476,13 @@ class DeepseekV4B12xMLAAttention(DeepseekV4FlashMLAAttention):
         return view
 
     def _reserve_dummy_compressed_mla_scratch(self, q: torch.Tensor) -> None:
-        from sparkinfer.attention.compressed_mla import (
+        from b12x.attention.compressed_mla import (
             Caps as B12XCompressedMLAScratchCaps,
         )
-        from sparkinfer.attention.compressed_mla import (
+        from b12x.attention.compressed_mla import (
             plan as plan_compressed_mla_scratch,
         )
-        from sparkinfer.attention.compressed_mla import (
+        from b12x.attention.compressed_mla import (
             split_chunks_for_contract as compressed_mla_split_chunks_for_contract,
         )
 

--- a/vllm/models/deepseek_v4/nvidia/model.py
+++ b/vllm/models/deepseek_v4/nvidia/model.py
@@ -967,13 +967,13 @@ class DeepseekV4DecoderLayer(nn.Module):
         )
 
         if self._use_b12x_mhc:
-            from sparkinfer.norm.mhc import (
+            from b12x.norm.mhc import (
                 DEFAULT_BLOCK_K as MHC_DEFAULT_BLOCK_K,
             )
-            from sparkinfer.norm.mhc import (
+            from b12x.norm.mhc import (
                 MULT as MHC_MULT,
             )
-            from sparkinfer.norm.mhc._impl import (
+            from b12x.norm.mhc._impl import (
                 MHC_GRAM_BLOCK_H,
                 MHC_SOURCE_TILE_H,
                 MHC_SUPPORTED_HIDDEN_SIZES,
@@ -1042,10 +1042,10 @@ class DeepseekV4DecoderLayer(nn.Module):
         comb: torch.Tensor | None = None,
         out: torch.Tensor | None = None,
     ) -> object:
-        from sparkinfer.norm.mhc import (
+        from b12x.norm.mhc import (
             Caps as B12XMHCScratchCaps,
         )
-        from sparkinfer.norm.mhc import (
+        from b12x.norm.mhc import (
             plan as plan_mhc_scratch,
         )
 
@@ -1080,7 +1080,7 @@ class DeepseekV4DecoderLayer(nn.Module):
         norm_weight: torch.Tensor,
         norm_eps: float,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-        from sparkinfer.norm.mhc import run_pre as b12x_mhc_pre
+        from b12x.norm.mhc import run_pre as b12x_mhc_pre
 
         norm_weight = self._require_b12x_mhc_norm_weight(norm_weight)
         if torch.compiler.is_compiling():
@@ -1152,7 +1152,7 @@ class DeepseekV4DecoderLayer(nn.Module):
         norm_eps: float,
         hc_fn_bf16: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-        from sparkinfer.norm.mhc import run_post_pre as b12x_mhc_post_pre
+        from b12x.norm.mhc import run_post_pre as b12x_mhc_post_pre
 
         norm_weight = self._require_b12x_mhc_norm_weight(norm_weight)
         expected_m = int(residual.shape[0])
@@ -1621,7 +1621,7 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
             if idx + 1 in self.aux_hidden_state_layers:
                 # Reconstruct the aux hidden state for draft models
                 if layer._should_run_b12x_mhc(int(hidden_states.shape[0])):
-                    from sparkinfer.norm.mhc import run_post as b12x_mhc_post
+                    from b12x.norm.mhc import run_post as b12x_mhc_post
 
                     aux_recon = b12x_mhc_post(
                         hidden_states,
@@ -1640,7 +1640,7 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
             if self.end_layer in self.aux_hidden_state_layers:
                 hidden_states = final_aux_recon
             elif layer._should_run_b12x_mhc(int(hidden_states.shape[0])):
-                from sparkinfer.norm.mhc import run_post as b12x_mhc_post
+                from b12x.norm.mhc import run_post as b12x_mhc_post
 
                 hidden_states = b12x_mhc_post(
                     hidden_states,

--- a/vllm/models/deepseek_v4/nvidia/mtp.py
+++ b/vllm/models/deepseek_v4/nvidia/mtp.py
@@ -161,7 +161,7 @@ class DeepSeekV4MultiTokenPredictorLayer(nn.Module):
             positions=positions, x=hidden_states, input_ids=None
         )
         if self.mtp_block._should_run_b12x_mhc(int(hidden_states.shape[0])):
-            from sparkinfer.norm.mhc import run_post as b12x_mhc_post
+            from b12x.norm.mhc import run_post as b12x_mhc_post
 
             hidden_states = b12x_mhc_post(
                 hidden_states,

--- a/vllm/models/minimax_m3/nvidia/sparse_attention_b12x.py
+++ b/vllm/models/minimax_m3/nvidia/sparse_attention_b12x.py
@@ -239,13 +239,13 @@ class MiniMaxM3SparseB12XImpl(MiniMaxM3SparseImpl):
 
         _disable_cutlass_memory_debug_snapshot_if_off()
 
-        from sparkinfer.attention.paged import (
+        from b12x.attention.paged import (
             Caps as B12XPagedAttentionScratchCaps,
         )
-        from sparkinfer.attention.paged import (
+        from b12x.attention.paged import (
             plan as plan_paged_attention_scratch,
         )
-        from sparkinfer.attention.paged import (
+        from b12x.attention.paged import (
             run as paged_attention_forward,
         )
 

--- a/vllm/v1/attention/backends/b12x_attn.py
+++ b/vllm/v1/attention/backends/b12x_attn.py
@@ -270,7 +270,7 @@ def _env_optional_storage_limit(name: str, *, allow_zero: bool) -> int | None:
         parsed = int(value)
     except ValueError:
         logger.warning(
-            "Ignoring invalid %s=%r; using Sparkinfer's planned capacity",
+            "Ignoring invalid %s=%r; using B12X's planned capacity",
             name,
             value,
         )
@@ -278,7 +278,7 @@ def _env_optional_storage_limit(name: str, *, allow_zero: bool) -> int | None:
     minimum = 0 if allow_zero else 1
     if parsed < minimum:
         logger.warning(
-            "Ignoring %s=%r below the minimum %d; using Sparkinfer's planned capacity",
+            "Ignoring %s=%r below the minimum %d; using B12X's planned capacity",
             name,
             value,
             minimum,
@@ -753,28 +753,28 @@ class B12XPagedAttentionImpl(AttentionImpl[B12XPagedMetadata]):
 
         _disable_cutlass_memory_debug_snapshot_if_off()
 
-        from sparkinfer.attention.paged import (
+        from b12x.attention.paged import (
             Caps as B12XPagedAttentionScratchCaps,
         )
-        from sparkinfer.attention.paged import (
+        from b12x.attention.paged import (
             compile as compile_paged_attention,
         )
-        from sparkinfer.attention.paged import (
+        from b12x.attention.paged import (
             decode_graph_capacity as plan_decode_graph_capacity,
         )
-        from sparkinfer.attention.paged import (
+        from b12x.attention.paged import (
             decode_graph_scratch_envelope as plan_decode_graph_scratch_envelope,
         )
-        from sparkinfer.attention.paged import (
+        from b12x.attention.paged import (
             extend_graph_capacity as plan_extend_graph_capacity,
         )
-        from sparkinfer.attention.paged import (
+        from b12x.attention.paged import (
             plan as plan_paged_attention_scratch,
         )
-        from sparkinfer.attention.paged import (
+        from b12x.attention.paged import (
             run as paged_attention_forward,
         )
-        from sparkinfer.attention.paged import (
+        from b12x.attention.paged import (
             verify_graph_capacity as plan_verify_graph_capacity,
         )
 
@@ -824,7 +824,7 @@ class B12XPagedAttentionImpl(AttentionImpl[B12XPagedMetadata]):
         if os.getenv("VLLM_B12X_PAGED_DECODE_MAX_CHUNKS_PER_REQ"):
             logger.warning_once(
                 "VLLM_B12X_PAGED_DECODE_MAX_CHUNKS_PER_REQ is ignored; "
-                "Sparkinfer owns decode graph chunk policy. Use the fixed "
+                "B12X owns decode graph chunk policy. Use the fixed "
                 "work/partial capacity controls only to constrain storage."
             )
         decode_work_items_limit = _env_optional_storage_limit(
@@ -1088,13 +1088,13 @@ class B12XPagedAttentionImpl(AttentionImpl[B12XPagedMetadata]):
             ) = current_workspace_manager().get_simultaneous(
                 *self._contig_workspace_specs(include_scratch=False)
             )
-            from sparkinfer.attention.varlen import (
+            from b12x.attention.varlen import (
                 create_plan as create_varlen_attention_plan,
             )
-            from sparkinfer.attention.varlen import (
+            from b12x.attention.varlen import (
                 plan as plan_varlen_attention_scratch,
             )
-            from sparkinfer.attention.varlen import (
+            from b12x.attention.varlen import (
                 run as b12x_varlen_attention_forward,
             )
 

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -5,11 +5,11 @@
 Counterpart to ``SparseMLASm120Backend`` (FlashInfer V32 v2). Same envelope --
 ``fp8_ds_mla`` KV cache (656 B/token), head_size = 576, paged block_size = 64,
 V32-family models with an ``index_topk`` config (DeepSeek V3.2, GLM-5.1, Kimi
-K2.5) -- but the decode/extend kernels come from SparkInfer's unified SM120
-backend via the ``sparkinfer.attention.sparse_mla`` front door (``run_decode`` /
-``run_extend``). On SM120+ CUDA those front-door functions route to SparkInfer's
+K2.5) -- but the decode/extend kernels come from B12X's unified SM120
+backend via the ``b12x.attention.sparse_mla`` front door (``run_decode`` /
+``run_extend``). On SM120+ CUDA those front-door functions route to B12X's
 unified MLA implementation automatically (GLM_NSA q_head_dim==576 contract).
-Selecting this backend also selects SparkInfer's sparse indexer/top-k path.
+Selecting this backend also selects B12X's sparse indexer/top-k path.
 
 Scratch philosophy (eager PLAN -> BIND -> KERNEL; no workspace/arena, ever):
 b12x workspaces/arenas are sglang-only and forbidden here. We build a caller-
@@ -133,7 +133,7 @@ def _kv_fp8_rope_enabled() -> bool:
 # Inline-scale two-level NVFP4 records: the writer derives a per-token
 # second-level scale (fp32 at record bytes [292, 296)) and the readers consume
 # it from the record instead of a per-layer launch scalar.  Requires the
-# 368-byte KV_FP8_ROPE=1 record and a SparkInfer build with the matching
+# 368-byte KV_FP8_ROPE=1 record and a B12X build with the matching
 # writer/reader mode.  Mutually exclusive with VLLM_NVFP4_MLA_SCALES_FILE.
 _NVFP4_DYNAMIC_SCALE_REQUESTED = NVFP4_MLA_CACHE_FORMAT.dynamic_scale
 
@@ -150,7 +150,7 @@ def _require_callable_parameters(
     ]
     if unsupported:
         raise RuntimeError(
-            f"{feature} requires SparkInfer callables accepting "
+            f"{feature} requires B12X callables accepting "
             f"{sorted(required)!r}; unsupported: {', '.join(unsupported)}"
         )
 
@@ -1301,12 +1301,12 @@ class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
             )
         if self._kv_fp8_rope:
             try:
-                from sparkinfer.attention._shared.mla.kv_cache import (
+                from b12x.attention._shared.mla.kv_cache import (
                     concat_and_cache_nvfp4_mla_fp8_rope,
                 )
             except ImportError as exc:
                 raise RuntimeError(
-                    "KV_FP8_ROPE=1 requires a SparkInfer build with "
+                    "KV_FP8_ROPE=1 requires a B12X build with "
                     "concat_and_cache_nvfp4_mla_fp8_rope package API support"
                 ) from exc
             self._concat_and_cache_nvfp4_mla_fp8_rope = (
@@ -1457,17 +1457,17 @@ class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
 
         self._max_batched = int(max_batched)
 
-        # Lazily import SparkInfer only on this opt-in path.
-        from sparkinfer.attention.sparse_mla import (
+        # Lazily import B12X only on this opt-in path.
+        from b12x.attention.sparse_mla import (
             Caps as B12XSparseMLAScratchCaps,
         )
-        from sparkinfer.attention.sparse_mla import (
+        from b12x.attention.sparse_mla import (
             plan as plan_sparse_mla_scratch,
         )
-        from sparkinfer.attention.sparse_mla import (
+        from b12x.attention.sparse_mla import (
             run_decode as sparse_mla_decode_forward,
         )
-        from sparkinfer.attention.sparse_mla import (
+        from b12x.attention.sparse_mla import (
             run_extend as sparse_mla_extend_forward,
         )
 
@@ -1757,7 +1757,7 @@ class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
                 per_token_scale=True,
             )
         else:
-            # Keyword omitted so pre-two-level SparkInfer builds keep working
+            # Keyword omitted so pre-two-level B12X builds keep working
             # when the mode is off.
             self._concat_and_cache_nvfp4_mla_fp8_rope(
                 kv_c_normed,
@@ -2011,7 +2011,7 @@ class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
         """Project DCP partials from 512 to 256 in borrowed MLA storage."""
         num_tokens = int(attn_out.shape[0])
         self._validate_dcp_prefill_workspace_contract(num_tokens)
-        # SparkInfer's head-major extend output is planned for the configured
+        # B12X's head-major extend output is planned for the configured
         # token capacity, even when the gathered head count needs no padding.
         # A shorter prefill chunk is therefore a pitched view of that allocation.
         # It is safe here because the input is compacted before entering cuBLAS.

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -434,7 +434,7 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
         # caches). Outside the SM100 family the FP8
         # paged MQA logits kernel only supports next_n in (1, 2)
         # (deepgemm smxx_fp8_fp4_paged_mqa_logits.hpp:233), so flatten there.
-        # The B12X / sparkinfer sparse indexer handles native next_n>2 on SM120
+        # The B12X / b12x sparse indexer handles native next_n>2 on SM120
         # directly (see sparse_attn_indexer warmup q_rows 1, 2, 4), so it must
         # NOT be forced onto the DeepGEMM next_n<=2 flatten fallback. Flattening
         # MTP-2/MTP-3 verification into rank-1 rows produced subtly wrong accepted
@@ -848,10 +848,10 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
         if schedule_seq_lens.dim() != 1:
             return None
 
-        from sparkinfer.attention.nsa_indexer import (
+        from b12x.attention.nsa_indexer import (
             plan_paged_schedule as build_paged_mqa_schedule_metadata,
         )
-        from sparkinfer.attention.nsa_indexer import (
+        from b12x.attention.nsa_indexer import (
             uses_paged_schedule as uses_paged_mqa_schedule,
         )
 

--- a/vllm/v1/attention/ops/dcp_alltoall.py
+++ b/vllm/v1/attention/ops/dcp_alltoall.py
@@ -53,9 +53,7 @@ def _is_supported_bhd_layout(tensor: torch.Tensor) -> bool:
         return False
     batch, heads, head_dim = (int(value) for value in tensor.shape)
     stride_batch, stride_head, _ = (int(value) for value in tensor.stride())
-    packed_token_major = (
-        stride_batch == heads * head_dim and stride_head == head_dim
-    )
+    packed_token_major = stride_batch == heads * head_dim and stride_head == head_dim
     capacity_strided_head_major = (
         stride_batch == head_dim and stride_head >= batch * head_dim
     )
@@ -65,7 +63,7 @@ def _is_supported_bhd_layout(tensor: torch.Tensor) -> bool:
 @lru_cache(maxsize=1)
 def _load_b12x_dcp_a2a_pool() -> Any | None:
     try:
-        from sparkinfer.comm.pcie import DcpAllToAllPool as PCIeDCPA2APool
+        from b12x.comm.pcie import DcpAllToAllPool as PCIeDCPA2APool
     except Exception:
         return None
     return PCIeDCPA2APool
@@ -172,7 +170,7 @@ def capture_b12x_dcp_a2a(
     cp_group: GroupCoordinator,
     stream: torch.cuda.Stream | None = None,
 ):
-    """Bind registered SparkInfer DCP pools to the graph's owning stream.
+    """Bind registered B12X DCP pools to the graph's owning stream.
 
     Each graph capture receives independent channels; reusing channels across
     target and draft graphs would make one graph depend on another's lifetime.
@@ -199,7 +197,7 @@ def capture_b12x_dcp_a2a(
 def checkpoint_b12x_dcp_a2a_channels(
     cp_group: GroupCoordinator,
 ) -> tuple[int, dict[Any, tuple[Any, Any]]]:
-    """Snapshot SparkInfer DCP pools before a disposable graph capture."""
+    """Snapshot B12X DCP pools before a disposable graph capture."""
     group_id = id(cp_group.device_group)
     checkpoints = {
         key: (pool, pool.checkpoint_channels())

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -952,7 +952,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         start_free_gpu_memory = torch.accelerator.get_memory_info()[0]
         graph_channel_checkpoints: tuple[tuple[Callable[[Any], None], Any], ...] = ()
         try:
-            # Snapshot graph-owned SparkInfer channels before this profiling
+            # Snapshot graph-owned B12X channels before this profiling
             # capture so profiling cannot leave stale channels behind.
             graph_channel_checkpoints = checkpoint_b12x_graph_channels()
             with self.maybe_setup_dummy_loras(self.lora_config):

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -965,7 +965,7 @@ class Worker(WorkerBase):
         # Keep vLLM's stable B12X diagnostics while notifying the renamed
         # external package that post-start kernel compilation is unexpected.
         os.environ["B12X_VLLM_ENGINE_STARTED"] = "1"
-        os.environ["SPARKINFER_ENGINE_STARTED"] = "1"
+        os.environ["B12X_ENGINE_STARTED"] = "1"
 
         activate_jit_monitor(
             mode=self.observability_config.jit_monitor_mode,


### PR DESCRIPTION
## Summary

B12X 1.1.0 renamed its Python package from `sparkinfer` back to `b12x` and moved its public environment prefix from `SPARKINFER_` to `B12X_`. Port the GG runtime and tests to that API so a clean composition with current `local-inference-lab/b12x` boots without a compatibility alias or source overlay.

The change is deliberately mechanical:

- update runtime imports and dynamic module paths to `b12x.*`;
- update B12X-owned environment names to `B12X_*`;
- update existing mocks and GPU tests to exercise the renamed package;
- add a source-contract test that prevents legacy runtime imports or env prefixes from returning.

This PR does not change algorithms, launch policy, tensor layouts, or numerical behavior.

## Paired ownership

Two functional PRs replace files too extensively for a duplicate mechanical edit here:

- #228 owns `vllm/model_executor/layers/quantization/exl3.py` and its EXL3 tests.
- #247 owns the semantic PCIe channel lifecycle and `tests/distributed/test_dcp_a2a.py`.
- #229 owns its compressed-MLA workspace additions and now tests them through `b12x.attention.compressed_mla`.

The release composition applies those PRs explicitly and performs a final source scan across both `vllm/` and `tests/`. This keeps ownership visible while guaranteeing that the composed image contains no active `sparkinfer.*` import or `SPARKINFER_*` runtime setting.

## Validation

Tested against current B12X master plus PR #125 in the CUDA 13.2 release environment:

- Ruff and `git diff --check`;
- package source-contract test;
- 50 EXL3/MXFP8/linear API tests;
- 44 sparse-indexer and B12X MoE warmup tests;
- 5 MLA query-projection API tests;
- renamed sparse-MLA scratch/capacity cases on SM120;
- composed GG source scan: no legacy package references in runtime or tests.

Multi-GPU channel and DSpark concurrency validation is performed on the full declared release composition.