### PR TITLE
[GG] Prewarm CuTe PCIe one-shot all-reduce before graph capture

### DIFF
--- a/tests/distributed/test_b12x_custom_all_reduce_warmup.py
+++ b/tests/distributed/test_b12x_custom_all_reduce_warmup.py
@@ -12,6 +12,14 @@ from vllm.distributed.device_communicators.custom_all_reduce import CustomAllred
 def _make_custom_allreduce(
     *, allreduce_max_size: int
 ) -> tuple[CustomAllreduce, MagicMock]:
+    """Build a minimal custom all-reduce with a mocked PCIe runtime.
+
+    Args:
+        allreduce_max_size: Largest input eligible for one-shot all-reduce.
+
+    Returns:
+        The custom all-reduce instance and its mocked PCIe runtime.
+    """
     runtime = MagicMock()
     runtime.for_stream.return_value.should_allreduce.return_value = True
 
@@ -32,6 +40,15 @@ def _mock_capture_warmup(
     monkeypatch: pytest.MonkeyPatch,
     custom_allreduce: CustomAllreduce,
 ) -> object:
+    """Place a custom all-reduce in the non-capturing graph warmup phase.
+
+    Args:
+        monkeypatch: Pytest fixture used to replace capture state helpers.
+        custom_allreduce: Instance whose PCIe stream should be mocked.
+
+    Returns:
+        The mocked PCIe capture stream.
+    """
     capture_stream = object()
     monkeypatch.setattr(
         custom_allreduce,
@@ -50,6 +67,7 @@ def _mock_capture_warmup(
 def test_capture_warmup_prepares_plain_graph_allreduce(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Verify that plain one-shot warmup prepares without communication."""
     custom_allreduce, runtime = _make_custom_allreduce(allreduce_max_size=64)
     capture_stream = _mock_capture_warmup(monkeypatch, custom_allreduce)
     inp = torch.randn(2, 4)
@@ -68,6 +86,7 @@ def test_capture_warmup_prepares_plain_graph_allreduce(
 def test_capture_warmup_does_not_prepare_dma_only_input(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Verify that DMA-only warmup keeps the communication-free placeholder."""
     custom_allreduce, runtime = _make_custom_allreduce(allreduce_max_size=16)
     custom_allreduce._pcie_dma = MagicMock()
     custom_allreduce._pcie_dma.should_allreduce.return_value = True
@@ -77,4 +96,7 @@ def test_capture_warmup_does_not_prepare_dma_only_input(
     output = custom_allreduce.custom_all_reduce(inp)
 
     assert output is not None
+    assert output.shape == inp.shape
     runtime.prepare_graph_all_reduce.assert_not_called()
+    runtime.all_reduce.assert_not_called()
+    custom_allreduce._pcie_dma.all_reduce.assert_not_called()

--- a/tests/distributed/test_b12x_custom_all_reduce_warmup.py
+++ b/tests/distributed/test_b12x_custom_all_reduce_warmup.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from vllm.distributed.device_communicators.custom_all_reduce import CustomAllreduce
+
+
+def _make_custom_allreduce(
+    *, allreduce_max_size: int
+) -> tuple[CustomAllreduce, MagicMock]:
+    runtime = MagicMock()
+    runtime.for_stream.return_value.should_allreduce.return_value = True
+
+    custom_allreduce = object.__new__(CustomAllreduce)
+    custom_allreduce.disabled = False
+    custom_allreduce._pcie_runtime = runtime
+    custom_allreduce._pcie_dma = None
+    custom_allreduce._pcie_capture_stream = None
+    custom_allreduce._pcie_allreduce_max_size = allreduce_max_size
+    custom_allreduce._pcie_logged_first_allreduce = False
+    custom_allreduce._IS_CAPTURING = True
+    custom_allreduce._ptr = 0
+    custom_allreduce.max_size = allreduce_max_size
+    return custom_allreduce, runtime
+
+
+def _mock_capture_warmup(
+    monkeypatch: pytest.MonkeyPatch,
+    custom_allreduce: CustomAllreduce,
+) -> object:
+    capture_stream = object()
+    monkeypatch.setattr(
+        custom_allreduce,
+        "_pcie_runtime_stream",
+        lambda: capture_stream,
+    )
+    monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: False)
+    monkeypatch.setattr(
+        "vllm.distributed.device_communicators.custom_all_reduce."
+        "_is_piecewise_cudagraph_runtime",
+        lambda: False,
+    )
+    return capture_stream
+
+
+def test_capture_warmup_prepares_plain_graph_allreduce(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    custom_allreduce, runtime = _make_custom_allreduce(allreduce_max_size=64)
+    capture_stream = _mock_capture_warmup(monkeypatch, custom_allreduce)
+    inp = torch.randn(2, 4)
+
+    output = custom_allreduce.custom_all_reduce(inp)
+
+    assert output is not None
+    assert output.shape == inp.shape
+    runtime.prepare_graph_all_reduce.assert_called_once_with(
+        inp,
+        stream=capture_stream,
+    )
+    runtime.all_reduce.assert_not_called()
+
+
+def test_capture_warmup_does_not_prepare_dma_only_input(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    custom_allreduce, runtime = _make_custom_allreduce(allreduce_max_size=16)
+    custom_allreduce._pcie_dma = MagicMock()
+    custom_allreduce._pcie_dma.should_allreduce.return_value = True
+    _mock_capture_warmup(monkeypatch, custom_allreduce)
+    inp = torch.randn(4, 4)
+
+    output = custom_allreduce.custom_all_reduce(inp)
+
+    assert output is not None
+    runtime.prepare_graph_all_reduce.assert_not_called()

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -922,6 +922,24 @@ class CustomAllreduce:
                 # all-reduce; returning a placeholder is only valid for warmup.
                 if _is_piecewise_cudagraph_runtime():
                     return self.all_reduce(input, registered=False)
+                # The warmup intentionally skips communication, but CuTe-based
+                # PCIe launchers still need their graph specialization loaded
+                # before the nested Inductor capture starts.
+                inp_size = input.numel() * input.element_size()
+                prepare_graph_all_reduce = getattr(
+                    self._pcie_runtime,
+                    "prepare_graph_all_reduce",
+                    None,
+                )
+                if (
+                    prepare_graph_all_reduce is not None
+                    and self._pcie_allreduce_max_size is not None
+                    and inp_size <= self._pcie_allreduce_max_size
+                ):
+                    prepare_graph_all_reduce(
+                        input,
+                        stream=self._pcie_runtime_stream(),
+                    )
                 # If warm up, mimic the allocation pattern since custom
                 # allreduce is out-of-place.
                 return torch.empty_like(input)


### PR DESCRIPTION
## Summary

Prewarm the B12X CuTe one-shot all-reduce specialization during vLLM's CUDA graph warmup, before the nested Inductor capture begins.

B12X commit `680d819` migrated the PCIe communication kernels to CuTe DSL and correctly rejects a cold one-shot launch during CUDA graph capture. vLLM's existing graph-warmup branch intentionally skipped the collective and returned `empty_like`; that preserved communication semantics, but it also meant the new CuTe specialization was never prepared. A cold GLM TP4/DCP4 boot then failed in the first PIECEWISE graph capture with:

```
cold PCIe oneshot CUDA graph capture is not allowed;
call prepare_graph_all_reduce() before capture
```

## Change

When vLLM is in the non-capturing warmup branch:

- prepare the CuTe graph specialization only for inputs eligible for the one-shot path;
- keep returning the same out-of-place placeholder;
- do not launch communication;
- leave DMA-only inputs and the runtime hot path unchanged;
- retain B12X's cold-capture guard.

## Validation

- Focused unit tests: `2 passed`
  - one-shot warmup prepares once without calling `all_reduce`;
  - DMA-only input does not prepare the one-shot path.
- Ruff check and format: pass.
- Before fix: clean GLM-5.2 EXL3 TP4/DCP4 cold boot failed deterministically during the first PIECEWISE graph capture.
- After fix: the same image/config completed profiling and production CUDA graph capture and became healthy.
- API coherence: `42/42` exact responses passed.
- Prefill remained within run variance against the pre-CuTe candidate:

| Context | Pre-CuTe candidate | Fixed CuTe path |
|---|---:|---:|
| 8k | 3,352 tok/s | 3,342 tok/s |
| 64k | 3,393 tok/s | 3,438 tok/s |

Runtime gate used current GG plus current B12X master and the GLM TP4/DCP4 one-shard query-split profile.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved CUDA graph warmup for eligible custom all-reduce operations.
  * Prepares supported PCIe graph specializations during warmup to improve subsequent execution.
  * Skips preparation for unsupported or DMA-only inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->