### PR TITLE
[GG] Support heterogeneous per-layer routed-expert widths (deepseek_v2 + EXL3)

### DIFF
--- a/tests/models/test_deepseek_v2_heterogeneous_experts.py
+++ b/tests/models/test_deepseek_v2_heterogeneous_experts.py
@@ -1,0 +1,221 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU-only tests for heterogeneous per-layer routed-expert widths.
+
+These tests exercise the pure helpers that ``DeepseekV2MoE`` and
+``DeepseekV2Model.load_weights`` use to resolve a layer's routed-expert
+count and to map ROCm AITER fused shared-expert weights. Importing
+``deepseek_v2`` itself works on a CPU-only host (it only lazy-loads CUDA
+extensions), so we import the helpers directly rather than constructing the
+full model, which would require CUDA/ROCm and a real checkpoint.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm.model_executor.layers.quantization.exl3 import _experts_per_layer
+from vllm.model_executor.models.deepseek_v2 import _layer_routed_expert_count
+from vllm.model_executor.models.utils import _parse_layer_index
+
+
+# ---------------------------------------------------------------------------
+# Config fixtures
+# ---------------------------------------------------------------------------
+
+def _hetero_config():
+    """A heterogeneous config: layer 2 is wide (256), the rest narrow (4).
+
+    The global scalar ``n_routed_experts`` is deliberately set to the wide
+    value (256) so that any code path that falls back to it for a NARROW
+    layer would produce the wrong width -- this is exactly the B5 hazard.
+    """
+    return SimpleNamespace(
+        n_routed_experts=256,
+        n_routed_experts_per_layer=[4, 4, 256, 4],
+        n_shared_experts=1,
+    )
+
+
+def _uniform_config():
+    """A uniform (non-list) config: every layer has the same expert count."""
+    return SimpleNamespace(n_routed_experts=8, n_shared_experts=1)
+
+
+def _shared_expert_slot_name(name, config, j):
+    """Mirror the mapping performed in ``DeepseekV2Model.load_weights``:
+
+    the fused shared-expert chunk ``j`` is routed to expert slot
+    ``mlp.experts.{<this layer's routed-expert count> + j}``.
+    """
+    offset = _layer_routed_expert_count(name, config)
+    return name.replace("mlp.shared_experts", f"mlp.experts.{offset + j}")
+
+
+# ---------------------------------------------------------------------------
+# C11: the unified layer-index parser
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "prefix,expected",
+    [
+        ("model.layers.3", 3),                 # prefix ending at layers.<N>
+        ("model.layers.3.mlp.experts", 3),     # trailing components
+        ("model.layers.77.mlp.shared_experts.gate_proj.weight", 77),
+        ("layers.0", 0),                       # bare prefix
+    ],
+)
+def test_parse_layer_index_matches(prefix, expected):
+    assert _parse_layer_index(prefix) == expected
+
+
+@pytest.mark.parametrize(
+    "prefix",
+    [
+        "model.sublayers.3",   # 'layers' must be preceded by ^ or '.'
+        "model.foo.bar",       # no layer index at all
+        "model.layers",        # no digit
+        "",
+    ],
+)
+def test_parse_layer_index_rejects(prefix):
+    assert _parse_layer_index(prefix) is None
+
+
+# ---------------------------------------------------------------------------
+# Per-layer width selection (B5 / C10 / C15)
+# ---------------------------------------------------------------------------
+
+def test_per_layer_width_narrow_layer():
+    cfg = _hetero_config()
+    # Layer 0 is narrow even though the global scalar is 256.
+    assert _layer_routed_expert_count(
+        "model.layers.0.mlp.experts", cfg) == 4
+
+
+def test_per_layer_width_wide_layer():
+    cfg = _hetero_config()
+    assert _layer_routed_expert_count(
+        "model.layers.2.mlp.experts", cfg) == 256
+
+
+def test_per_layer_width_uses_global_scalar_name_not_list_index():
+    """The list is indexed by the GLOBAL model layer number parsed from the
+    prefix, not by the position of 'experts' in the string."""
+    cfg = _hetero_config()
+    # An expert weight name still resolves to the owning layer's width.
+    assert _layer_routed_expert_count(
+        "model.layers.3.mlp.experts.5.gate_proj.weight", cfg) == 4
+
+
+# ---------------------------------------------------------------------------
+# B5 regression: ROCm AITER fused shared-expert name mapping
+# ---------------------------------------------------------------------------
+
+def test_shared_expert_mapping_narrow_layer():
+    """B5: a NARROW layer's shared expert must land at slot <narrow width>+j,
+    NOT at the global scalar ``n_routed_experts`` (256). The per-layer
+    FusedMoE is built with num_experts=<layer width>, so the global offset
+    would point at a non-existent / wrong slot."""
+    cfg = _hetero_config()
+    name = "model.layers.0.mlp.shared_experts.gate_proj.weight"
+    # The fix's offset for this layer...
+    assert _layer_routed_expert_count(name, cfg) == 4
+    # ...must differ from the pre-fix global-scalar offset.
+    assert cfg.n_routed_experts == 256
+    assert _shared_expert_slot_name(name, cfg, 0) == \
+        "model.layers.0.mlp.experts.4.gate_proj.weight"
+
+
+def test_shared_expert_mapping_wide_layer():
+    cfg = _hetero_config()
+    name = "model.layers.2.mlp.shared_experts.gate_proj.weight"
+    assert _layer_routed_expert_count(name, cfg) == 256
+    assert _shared_expert_slot_name(name, cfg, 0) == \
+        "model.layers.2.mlp.experts.256.gate_proj.weight"
+
+
+def test_shared_expert_mapping_multiple_shared_experts():
+    """With n_shared_experts > 1, each chunk j maps to <width>+j."""
+    cfg = SimpleNamespace(
+        n_routed_experts=256,
+        n_routed_experts_per_layer=[4, 4, 256, 4],
+        n_shared_experts=2,
+    )
+    name = "model.layers.0.mlp.shared_experts.down_proj.weight"
+    assert _shared_expert_slot_name(name, cfg, 0) == \
+        "model.layers.0.mlp.experts.4.down_proj.weight"
+    assert _shared_expert_slot_name(name, cfg, 1) == \
+        "model.layers.0.mlp.experts.5.down_proj.weight"
+
+
+def test_mapping_table_size_bounds_all_layer_offsets():
+    """The name-mapping table is sized at max(widths)+n_shared; every layer's
+    shared-expert slot (width+j) must fall within that range so the table has
+    an entry for it. This is the 'consistency' half of the B5 fix."""
+    cfg = _hetero_config()
+    widths = cfg.n_routed_experts_per_layer
+    table_size = max(widths) + cfg.n_shared_experts
+    for layer_idx, width in enumerate(widths):
+        for j in range(cfg.n_shared_experts):
+            assert width + j < table_size, (layer_idx, j)
+
+
+# ---------------------------------------------------------------------------
+# C10: unparseable prefix raises (no silent fallback to global scalar)
+# ---------------------------------------------------------------------------
+
+def test_unparseable_prefix_raises():
+    cfg = _hetero_config()
+    with pytest.raises(ValueError, match="layer index cannot be parsed"):
+        _layer_routed_expert_count("model.attention.dense", cfg)
+
+
+# ---------------------------------------------------------------------------
+# C15: out-of-range index raises
+# ---------------------------------------------------------------------------
+
+def test_out_of_range_layer_index_raises():
+    cfg = _hetero_config()  # 4 entries -> valid indices 0..3
+    with pytest.raises(ValueError, match="requires one"):
+        _layer_routed_expert_count("model.layers.99.mlp.experts", cfg)
+
+
+def test_experts_per_layer_bounds_check():
+    metadata = {"experts_per_layer": [4, 4, 256, 4]}
+    with pytest.raises(ValueError, match="out of range"):
+        _experts_per_layer(metadata, 99)
+    # valid index works
+    assert _experts_per_layer(metadata, 2) == 256
+
+
+def test_experts_per_layer_scalar_unchanged():
+    metadata = {"experts_per_layer": 8}
+    assert _experts_per_layer(metadata, 0) == 8
+    assert _experts_per_layer(metadata, 99) == 8  # scalar ignores index
+
+
+def test_experts_per_layer_none_index_returns_widest():
+    metadata = {"experts_per_layer": [4, 4, 256, 4]}
+    assert _experts_per_layer(metadata, None) == 256
+
+
+# ---------------------------------------------------------------------------
+# Uniform (non-list) config is unchanged
+# ---------------------------------------------------------------------------
+
+def test_uniform_config_returns_scalar_for_any_layer():
+    cfg = _uniform_config()
+    for prefix in (
+        "model.layers.0.mlp.experts",
+        "model.layers.42.mlp.shared_experts.gate_proj.weight",
+        "model.layers.0",
+    ):
+        assert _layer_routed_expert_count(prefix, cfg) == 8
+
+
+def test_uniform_config_shared_expert_mapping():
+    cfg = _uniform_config()
+    name = "model.layers.0.mlp.shared_experts.gate_proj.weight"
+    assert _shared_expert_slot_name(name, cfg, 0) == \
+        "model.layers.0.mlp.experts.8.gate_proj.weight"

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -53,6 +53,7 @@ from vllm.model_executor.layers.quantization.base_config import (
     QuantizationConfig,
     QuantizeMethodBase,
 )
+from vllm.model_executor.models.utils import _parse_layer_index
 from vllm.model_executor.parameter import BasevLLMParameter
 from vllm.transformers_utils.repo_utils import get_hf_file_to_dict
 
@@ -162,13 +163,27 @@ _RANK_SLICED_WEIGHT_RE = re.compile(
 
 def _experts_per_layer(metadata, layer_index=None):
     """Resolve ``experts_per_layer``, which may be a scalar or a per-layer
-    list indexed by model layer (heterogeneous expert widths). Scalar
-    checkpoints behave exactly as before; with a list and no layer context
-    the widest layer is returned."""
+    list indexed by the GLOBAL model layer number (dense layers included) for
+    heterogeneous expert widths. Scalar checkpoints behave exactly as before;
+    with a list and no layer context the widest layer is returned.
+
+    Args:
+        metadata: rank-sliced EXL3 metadata dict carrying ``experts_per_layer``.
+        layer_index: global model layer index. ``None`` is only valid for the
+            scalar case or when the caller explicitly wants the widest layer.
+
+    Raises:
+        ValueError: ``layer_index`` is out of range for the per-layer list.
+    """
     value = metadata["experts_per_layer"]
     if isinstance(value, (list, tuple)):
         if layer_index is None:
             return max(int(v) for v in value)
+        if layer_index < 0 or layer_index >= len(value):
+            raise ValueError(
+                f"experts_per_layer has {len(value)} entries but layer index "
+                f"{layer_index} is out of range"
+            )
         return int(value[layer_index])
     return int(value)
 
@@ -571,12 +586,11 @@ class Exl3Config(QuantizationConfig):
         self.rank_sliced_bits_by_layer = by_layer
 
     def rank_sliced_layer_bitrates(self, layer_name: str) -> tuple[int, ...]:
-        match = re.search(r"(?:^|\.)layers\.(\d+)(?:\.|$)", layer_name)
-        if match is None:
+        layer_index = _parse_layer_index(layer_name)
+        if layer_index is None:
             raise ValueError(
                 f"cannot resolve rank-sliced EXL3 layer index from {layer_name!r}"
             )
-        layer_index = int(match.group(1))
         if self.rank_sliced_k_values is None:
             if self.bits is None or float(self.bits) != int(self.bits):
                 raise ValueError(f"invalid uniform EXL3 bitrate {self.bits!r}")
@@ -729,11 +743,11 @@ class Exl3Config(QuantizationConfig):
         self, prefix: str, layer: torch.nn.Module | None = None
     ) -> bool:
         if self.rank_sliced_metadata is not None:
-            match = re.search(r"layers\.(\d+)\b", prefix)
-            if match is None:
+            layer_index = _parse_layer_index(prefix)
+            if layer_index is None:
                 return False
             first, last = (int(v) for v in self.rank_sliced_metadata["moe_layers"])
-            return first <= int(match.group(1)) <= last
+            return first <= layer_index <= last
         # Use the layer's checkpoint projection names (the same fields
         # _validate_codebooks keys off) so remapped-projection MoE
         # checkpoints are still detected; fall back to the defaults when the
@@ -757,11 +771,11 @@ class Exl3Config(QuantizationConfig):
 
     def codebook_for_prefix(self, prefix: str) -> str | None:
         if self.rank_sliced_metadata is not None:
-            match = re.search(r"layers\.(\d+)\b", prefix)
-            if match is None:
+            layer_index = _parse_layer_index(prefix)
+            if layer_index is None:
                 return None
             first, last = (int(v) for v in self.rank_sliced_metadata["moe_layers"])
-            return "mcg" if first <= int(match.group(1)) <= last else None
+            return "mcg" if first <= layer_index <= last else None
         entry = self._storage_entry(prefix)
         if entry is None:
             return None
@@ -1336,17 +1350,19 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 name = str(
                     getattr(layer, "layer_name", "") or getattr(layer, "prefix", "")
                 )
-                match = re.search(r"(?:^|\.)layers\.(\d+)(?:\.|$)", name)
-                if match is not None:
-                    expected_experts = int(metadata_experts[int(match.group(1))])
-                else:
-                    # No layer identity on this module: accept any declared
-                    # width rather than misvalidating against the widest.
-                    expected_experts = (
-                        num_experts
-                        if num_experts in {int(v) for v in metadata_experts}
-                        else -1
+                layer_index = _parse_layer_index(name)
+                if layer_index is None:
+                    # No layer identity on this module: refuse to guess.
+                    # Silently accepting any declared width (or a -1 sentinel)
+                    # lets a mismatched checkpoint load unchecked.
+                    raise ValueError(
+                        "cannot determine layer index for "
+                        f"{name!r}; rank-sliced EXL3 with per-layer expert "
+                        "widths requires a 'layers.<N>' module name."
                     )
+                expected_experts = _experts_per_layer(
+                    self.quant_config.rank_sliced_metadata, layer_index
+                )
             else:
                 expected_experts = int(metadata_experts)
             if expected_experts != num_experts:

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -159,6 +159,20 @@ _RANK_SLICED_WEIGHT_RE = re.compile(
     r"(?P<field>trellis|suh|svh|mcg|mul1)$"
 )
 
+
+def _experts_per_layer(metadata, layer_index=None):
+    """Resolve ``experts_per_layer``, which may be a scalar or a per-layer
+    list indexed by model layer (heterogeneous expert widths). Scalar
+    checkpoints behave exactly as before; with a list and no layer context
+    the widest layer is returned."""
+    value = metadata["experts_per_layer"]
+    if isinstance(value, (list, tuple)):
+        if layer_index is None:
+            return max(int(v) for v in value)
+        return int(value[layer_index])
+    return int(value)
+
+
 ShardId = str | int | tuple[int, ...] | None
 
 
@@ -526,7 +540,6 @@ class Exl3Config(QuantizationConfig):
         if not isinstance(payload, dict):
             raise ValueError(f"rank-sliced EXL3 could not load {filename!r}")
 
-        experts = int(self.rank_sliced_metadata["experts_per_layer"])
         first, last = (int(value) for value in self.rank_sliced_metadata["moe_layers"])
         allowed = set(self.rank_sliced_k_values or ())
         by_layer: dict[int, tuple[int, ...]] = {}
@@ -536,6 +549,7 @@ class Exl3Config(QuantizationConfig):
                 raise ValueError(
                     f"rank-sliced EXL3 bitrate map is missing layer {layer_index}"
                 )
+            experts = _experts_per_layer(self.rank_sliced_metadata, layer_index)
             raw = entry.get(field)
             # The GLM-5.2 MTP overlay records all routed experts under tail_tr3
             # instead of repeating a 256-entry K3 vector.
@@ -566,7 +580,7 @@ class Exl3Config(QuantizationConfig):
         if self.rank_sliced_k_values is None:
             if self.bits is None or float(self.bits) != int(self.bits):
                 raise ValueError(f"invalid uniform EXL3 bitrate {self.bits!r}")
-            experts = int(self.rank_sliced_metadata["experts_per_layer"])
+            experts = _experts_per_layer(self.rank_sliced_metadata, layer_index)
             return (int(self.bits),) * experts
         try:
             return self.rank_sliced_bits_by_layer[layer_index]
@@ -1315,9 +1329,26 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                     "rank-sliced EXL3 checkpoint TP does not match runtime: "
                     f"checkpoint={checkpoint_tp}, runtime={layer.exl3_tp_size}"
                 )
-            expected_experts = int(
-                self.quant_config.rank_sliced_metadata["experts_per_layer"]
-            )
+            metadata_experts = self.quant_config.rank_sliced_metadata[
+                "experts_per_layer"
+            ]
+            if isinstance(metadata_experts, (list, tuple)):
+                name = str(
+                    getattr(layer, "layer_name", "") or getattr(layer, "prefix", "")
+                )
+                match = re.search(r"(?:^|\.)layers\.(\d+)(?:\.|$)", name)
+                if match is not None:
+                    expected_experts = int(metadata_experts[int(match.group(1))])
+                else:
+                    # No layer identity on this module: accept any declared
+                    # width rather than misvalidating against the widest.
+                    expected_experts = (
+                        num_experts
+                        if num_experts in {int(v) for v in metadata_experts}
+                        else -1
+                    )
+            else:
+                expected_experts = int(metadata_experts)
             if expected_experts != num_experts:
                 raise ValueError(
                     "rank-sliced EXL3 expert count does not match the model: "

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -24,6 +24,8 @@
 # limitations under the License.
 """Inference-only DeepseekV2/DeepseekV3 model."""
 
+import copy
+import re
 import typing
 from collections.abc import Callable, Iterable
 from itertools import islice
@@ -291,6 +293,24 @@ class DeepseekV2MoE(nn.Module):
         self.tp_rank = get_tensor_model_parallel_rank()
 
         self.routed_scaling_factor = getattr(config, "routed_scaling_factor", 1.0)
+
+        # Heterogeneous expert widths: when the HF config carries
+        # n_routed_experts_per_layer (a per-layer list), override the scalar
+        # for THIS layer (index parsed from prefix) on a shallow config copy,
+        # so every config.n_routed_experts read below sees this layer's width.
+        per_layer_experts = getattr(config, "n_routed_experts_per_layer", None)
+        if per_layer_experts is not None:
+            match = re.search(r"layers\.(\d+)\.", prefix)
+            if match is not None:
+                layer_idx = int(match.group(1))
+                if layer_idx >= len(per_layer_experts):
+                    raise ValueError(
+                        "n_routed_experts_per_layer has "
+                        f"{len(per_layer_experts)} entries but layer "
+                        f"{layer_idx} ({prefix!r}) requires one."
+                    )
+                config = copy.copy(config)
+                config.n_routed_experts = per_layer_experts[layer_idx]
 
         self.ep_group = get_ep_group().device_group
         self.ep_rank = get_ep_group().rank_in_group
@@ -1785,7 +1805,14 @@ class DeepseekV2Model(nn.Module):
             ckpt_gate_proj_name="gate_proj",
             ckpt_down_proj_name="down_proj",
             ckpt_up_proj_name="up_proj",
-            num_experts=self.config.n_routed_experts
+            num_experts=(
+                # Heterogeneous widths: the widest layer bounds the
+                # name-mapping table; narrower layers simply never match
+                # the higher expert ids.
+                max(self.config.n_routed_experts_per_layer)
+                if getattr(self.config, "n_routed_experts_per_layer", None)
+                else self.config.n_routed_experts
+            )
             + (
                 self.config.n_shared_experts
                 if rocm_aiter_moe_shared_expert_enabled

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -25,7 +25,6 @@
 """Inference-only DeepseekV2/DeepseekV3 model."""
 
 import copy
-import re
 import typing
 from collections.abc import Callable, Iterable
 from itertools import islice
@@ -89,6 +88,7 @@ from vllm.model_executor.model_loader.weight_utils import (
     maybe_remap_kv_scale_name,
 )
 from vllm.model_executor.models.utils import (
+    _parse_layer_index,
     AutoWeightsLoader,
     extract_layer_index,
     sequence_parallel_chunk,
@@ -278,6 +278,36 @@ class DeepseekV2MLP(nn.Module):
         return x
 
 
+def _layer_routed_expert_count(prefix: str, config) -> int:
+    """Return the routed-expert count for the model layer in ``prefix``.
+
+    Honors ``n_routed_experts_per_layer`` (a per-layer list indexed by the
+    GLOBAL model layer number, dense layers included) for heterogeneous
+    expert widths; uniform configs fall back to the scalar
+    ``n_routed_experts`` unchanged.
+
+    Raises:
+        ValueError: ``n_routed_experts_per_layer`` is set but no layer index
+            can be parsed from ``prefix``, or the index is out of range.
+    """
+    per_layer = getattr(config, "n_routed_experts_per_layer", None)
+    if per_layer is None:
+        return config.n_routed_experts
+    layer_idx = _parse_layer_index(prefix)
+    if layer_idx is None:
+        raise ValueError(
+            "n_routed_experts_per_layer is set but the layer index cannot "
+            f"be parsed from prefix {prefix!r}"
+        )
+    if layer_idx >= len(per_layer):
+        raise ValueError(
+            "n_routed_experts_per_layer has "
+            f"{len(per_layer)} entries but layer {layer_idx} ({prefix!r}) "
+            "requires one."
+        )
+    return int(per_layer[layer_idx])
+
+
 class DeepseekV2MoE(nn.Module):
     def __init__(
         self,
@@ -298,19 +328,13 @@ class DeepseekV2MoE(nn.Module):
         # n_routed_experts_per_layer (a per-layer list), override the scalar
         # for THIS layer (index parsed from prefix) on a shallow config copy,
         # so every config.n_routed_experts read below sees this layer's width.
-        per_layer_experts = getattr(config, "n_routed_experts_per_layer", None)
-        if per_layer_experts is not None:
-            match = re.search(r"layers\.(\d+)\.", prefix)
-            if match is not None:
-                layer_idx = int(match.group(1))
-                if layer_idx >= len(per_layer_experts):
-                    raise ValueError(
-                        "n_routed_experts_per_layer has "
-                        f"{len(per_layer_experts)} entries but layer "
-                        f"{layer_idx} ({prefix!r}) requires one."
-                    )
-                config = copy.copy(config)
-                config.n_routed_experts = per_layer_experts[layer_idx]
+        # _layer_routed_expert_count raises loudly for an unparseable prefix
+        # or out-of-range index rather than silently falling back to the
+        # global scalar (which would build the layer with the wrong width).
+        if getattr(config, "n_routed_experts_per_layer", None) is not None:
+            layer_count = _layer_routed_expert_count(prefix, config)
+            config = copy.copy(config)
+            config.n_routed_experts = layer_count
 
         self.ep_group = get_ep_group().device_group
         self.ep_rank = get_ep_group().rank_in_group
@@ -1937,6 +1961,15 @@ class DeepseekV2Model(nn.Module):
                         f"not divisible by num_chunks {num_chunks}"
                     )
                     chunk_size = total // num_chunks
+                    # B5: the fused shared-expert slot for THIS layer sits at
+                    # <this layer's routed-expert count> + j, NOT the global
+                    # scalar. The per-layer FusedMoE is built with
+                    # num_experts=<layer width>, so using the global scalar
+                    # would map shared-expert weights into the wrong slot (or
+                    # a non-existent one) on heterogeneous checkpoints.
+                    shared_expert_offset = _layer_routed_expert_count(
+                        name, self.config
+                    )
 
                 for j in range(num_chunks):
                     chunk_name = name
@@ -1954,7 +1987,7 @@ class DeepseekV2Model(nn.Module):
                         # can route it
                         chunk_name = name.replace(
                             "mlp.shared_experts",
-                            f"mlp.experts.{self.config.n_routed_experts + j}",
+                            f"mlp.experts.{shared_expert_offset + j}",
                         )
 
                     # Use expert_params_mapping to locate the destination

--- a/vllm/model_executor/models/utils.py
+++ b/vllm/model_executor/models/utils.py
@@ -830,6 +830,20 @@ def get_draft_quant_config(vllm_config: VllmConfig) -> "QuantizationConfig | Non
     return quant_config
 
 
+_LAYER_INDEX_RE = re.compile(r"(?:^|\.)layers\.(\d+)(?:\.|$)")
+
+
+def _parse_layer_index(prefix: str) -> int | None:
+    """Parse the global model layer index from a weight or module prefix.
+
+    Matches ``layers.<N>`` where ``layers`` is preceded by start-of-string or
+    a dot (so ``sublayers.3`` is rejected) and ``<N>`` is followed by a dot or
+    end-of-string, so a prefix that ends at ``layers.3`` still parses. Returns
+    the index, or ``None`` when no layer index is present.
+    """
+    match = _LAYER_INDEX_RE.search(prefix)
+    return int(match.group(1)) if match is not None else None
+
 def extract_layer_index(layer_name: str, num_attn_module: int = 1) -> int:
     """
     Extract the layer index from the module name.


### PR DESCRIPTION
## Purpose

Support MoE checkpoints with a **different number of routed experts per layer** (asymmetric-width MoE) on the DeepseekV2/GLM family. Pruning/frankenmodel pipelines naturally produce layers of different widths, but the stack currently assumes one scalar `n_routed_experts` for every layer.

- `deepseek_v2.py`: an optional `n_routed_experts_per_layer` list in the HF config overrides the scalar per layer on a shallow config copy inside `DeepseekV2MoE` (index parsed from the module prefix); the expert-name mapping table is sized by the widest layer (narrower layers simply never match the higher expert ids).
- `exl3.py`: the rank-sliced EXL3 loader resolves `experts_per_layer` per layer when the checkpoint metadata carries a list (bitrate-map validation, uniform-bitrate expansion, and the MoE `create_weights` expert-count check).

Checkpoints without `n_routed_experts_per_layer` / with scalar `experts_per_layer` metadata behave exactly as before.

## Test Plan

Functional evidence checkpoint: [`malaiwah/GLM-5.2-Legume-v3`](https://huggingface.co/malaiwah/GLM-5.2-Legume-v3) — a 20-layer, 724-expert GLM-5.2 franken with per-layer widths 56..28 (`n_routed_experts_per_layer` in its config, per-layer `experts_per_layer` list in its EXL3 metadata; ships these patches in `patches/`).

On RTX 5090 (SM120), gilded-gnosis r25 image with exactly these two files swapped in:
1. Negative control (stock files): boot must fail on the expert-count mismatch.
2. Patched: boot + small-prompt battery (1/2/5/8/9-token prefills) + greedy generations.

## Test Result

Negative control (stock r25, list config) fails as expected in the EXL3 metadata parse:

```
    experts = int(self.rank_sliced_metadata["experts_per_layer"])
TypeError: int() argument must be a string, a bytes-like object or a real number, not 'list'
```

Patched (these two files swapped into the same image):

```
[config] n_routed_experts_per_layer=[0, 0, 0, 56, 52, 52, 48, 40, 48, 56, 48, 48, 36, 36, 36, 36, 28, 32, 36, 36]
[config] layers=20 distinct_widths=[0, 28, 32, 36, 40, 48, 52, 56] total_experts=724
[battery] 1-token prefill OK
[battery] 2-token prefill OK
[battery] 5-token prefill OK
[battery] 8-token prefill OK
[battery] 9-token prefill OK
LEGUME-V3-BOOT-OK
```

All 17 MoE layers (widths 28..56) landed on `Exl3MoEMethod` with per-layer runtime tiers (`EXL3 mixed Trellis runtime planned: tiers=((3, 51), (4, 1))` etc. in the boot log), prefill + decode both exercised. Generation *quality* is a property of the zero-training franken (documented on the model card), not of this patch; held-out Apache-2.0 logprob for this exact checkpoint is on the model card (−11.70, beats the uniform-width baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DmTegASpyEG2T8zB5BZYTw

## Notes

- MTP/NextN draft layers are unaffected (Legume-v3 carries no MTP overlay; the per-layer override only triggers when the config list is present).
- Complements #240 (rank-sliced EXL3 loading for qwen3_5); this PR is the deepseek_v2-family analog for asymmetric widths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Added support for models with different numbers of routed experts across layers.
  * Improved loading and processing of quantized mixture-of-experts weights for layer-specific configurations.
  * Added validation to detect incompatible expert layouts and invalid layer settings.
  * Preserved compatibility with configurations that use a single expert count across all layers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->