### PR TITLE
[GG] fix(kv-offload): defer finalization until final store

### DIFF
--- a/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
@@ -37,6 +37,10 @@ from vllm.v1.kv_offload.base import (
     get_offload_block_hash,
     make_offload_key,
 )
+from vllm.v1.kv_offload.tiering.manager import (
+    CPUPrimaryTierOffloadingManager,
+    TieringOffloadingManager,
+)
 from vllm.v1.request import RequestStatus
 
 
@@ -65,7 +69,8 @@ def test_scheduler_reports_allocation_failure(request_runner):
     runner.run(decoded_tokens=[EOS_TOKEN_ID])
 
     reduced = _reduce_kv_connector_stats(runner)
-    assert reduced[_ConnectorMetricName.ALLOCATION_FAILURE] == 1
+    # The final scheduler step retries the failed store before finalization.
+    assert reduced[_ConnectorMetricName.ALLOCATION_FAILURE] == 2
 
 
 @pytest.mark.parametrize("missing_metadata", ["block_ids", "offload_keys"])
@@ -166,7 +171,7 @@ def test_abort_queued_request_does_not_build_store_job(
 def test_last_block_offloaded_at_request_finish(
     request_runner, async_scheduling: bool, prompt_offset: int
 ):
-    """EOS fills the last block at request finish — verify req_status is kept alive.
+    """EOS fills the last block at request finish and stores it before cleanup.
 
     prompt = block_size + prompt_offset tokens → not a full block at schedule time,
     so _build_store_jobs creates no store job. After EOS, request_finished
@@ -188,18 +193,49 @@ def test_last_block_offloaded_at_request_finish(
         generate_store_output(list(keys))
     )
 
-    # Run with one step (EOS)
-    runner.run(
-        decoded_tokens=[EOS_TOKEN_ID],
-    )
+    if prompt_offset == -1:
+        runner.run(decoded_tokens=[EOS_TOKEN_ID], expected_stored=(0,))
+    else:
+        runner.run(decoded_tokens=[EOS_TOKEN_ID])
 
     cs = runner.connector_scheduler
-    # Verify req_status is kept alive for _build_store_jobs to process
-    # regardless of whether there are storable blocks
-    assert "0" in cs._req_status, (
-        "req_status was deleted but should be kept alive "
-        "for _build_store_jobs to process finished_req_ids."
+    assert "0" not in cs._req_status
+
+
+@pytest.mark.parametrize("async_scheduling", [True, False])
+def test_tiering_manager_final_store_precedes_request_finish(
+    request_runner, async_scheduling: bool
+):
+    """Regression for a final-store KeyError in TieringOffloadingManager."""
+    runner = request_runner(
+        block_size=4,
+        num_gpu_blocks=10,
+        async_scheduling=async_scheduling,
     )
+
+    manager_events: list[str] = []
+    primary = MagicMock(spec=CPUPrimaryTierOffloadingManager)
+    primary.lookup.return_value = LookupResult.MISS
+    primary.get_stats.return_value = None
+    primary.take_events.return_value = []
+
+    def prepare_store(keys, req_context):
+        manager_events.append("prepare_store")
+        return generate_store_output(keys)
+
+    primary.prepare_store.side_effect = prepare_store
+    primary.on_request_finished.side_effect = lambda req_context: manager_events.append(
+        "on_request_finished"
+    )
+
+    tiering_manager = TieringOffloadingManager(primary_tier=primary)
+    runner.connector_scheduler.manager = tiering_manager
+
+    runner.new_request(token_ids=[0, 0, 0])
+    runner.run(decoded_tokens=[EOS_TOKEN_ID], expected_stored=(0,))
+
+    assert manager_events == ["prepare_store", "on_request_finished"]
+    assert tiering_manager._req_state == {}
 
 
 def test_scheduler_reports_lookup_sync_delay(request_runner):
@@ -423,10 +459,10 @@ def test_request_preemption(request_runner, async_scheduling: bool):
 
 
 @pytest.mark.parametrize("async_scheduling", [True, False])
-def test_on_request_finished_is_not_deferred_until_store_completion(
+def test_on_request_finished_not_deferred_until_store_completion(
     request_runner, async_scheduling: bool
 ):
-    """on_request_finished fires when no more stores will be submitted.
+    """on_request_finished fires after the last prepare_store is submitted.
 
     A request can finish while its GPU->primary store is still in flight. The
     manager-level hook should not wait for that completion; complete_store may
@@ -467,8 +503,8 @@ def test_on_request_finished_is_not_deferred_until_store_completion(
         complete_transfers=False,
     )
 
-    # Finish the request while its stores are still in flight. The hook should
-    # fire immediately even though no complete_store has arrived yet.
+    # The following scheduler step submits the final store and fires the hook,
+    # without waiting for any complete_store callback.
     runner.run(
         decoded_tokens=[EOS_TOKEN_ID],
         complete_transfers=False,
@@ -685,7 +721,7 @@ def test_two_groups_full_and_sliding_window(request_runner, async_scheduling: bo
     touch_calls = runner.manager.touch.call_args_list
     assert len(touch_calls) == 6
 
-    runner.run(decoded_tokens=[EOS_TOKEN_ID])
+    runner.run(decoded_tokens=[EOS_TOKEN_ID], expected_stored=(6,))
 
     runner.scheduler.reset_prefix_cache()
 
@@ -698,19 +734,11 @@ def test_two_groups_full_and_sliding_window(request_runner, async_scheduling: bo
         # Group 1 (sliding window, window=2): only the last 2 blocks
         #   are within the window → loads blocks 1,2
         expected_loaded=((0, 0), (0, 1), (0, 2), (1, 1), (1, 2)),
-        # The deferred store from the previous request's last block
-        # completes during this step, and its blocks are flushed because
-        # they were reallocated to the new request.
-        # Only block 1 (sliding window group) is stored — block 0's
-        # deferred store is flushed because it was reallocated.
-        expected_stored=((0, 1),),
-        expected_flushed=((0, 1),),
     )
 
-    # 4 touch calls: 2 from get_num_new_matched_tokens (2 groups)
-    # + 2 from _get_reqs_to_store (2 groups)
+    # 2 touch calls from get_num_new_matched_tokens (2 groups).
     touch_calls = runner.manager.touch.call_args_list
-    assert len(touch_calls) == 4
+    assert len(touch_calls) == 2
     # full attention group touched all 3 blocks
     assert len(touch_calls[0].args[0]) == 3
     # sliding window group touched just the last 2 blocks
@@ -1553,16 +1581,13 @@ def test_reset_cache_finalizes_finished_request_with_pending_store(
     assert req_status.transfer_jobs, "expected an in-flight store before finish"
     assert any(job.is_store for job in cs._jobs.values())
 
-    # Finish the request while its store is still in flight. request_finished
-    # fires the hook eagerly, but the entry stays tracked so later completions
-    # can still call complete_store().
+    # Finalization is deferred because the final store decision has not run.
     req_status.req.status = RequestStatus.FINISHED_STOPPED
     cs.request_finished(req_status.req)
-    assert finalized == [req_id]
+    assert finalized == []
     assert req_id in cs._req_status
 
-    # reset_cache discards the in-flight store and drops the state without a
-    # duplicate on_request_finished call.
+    # reset_cache discards pending work, signals finalization, and drops state.
     cs.reset_cache()
     assert finalized == [req_id]
     assert req_id not in cs._req_status

--- a/tests/v1/kv_connector/unit/offloading_connector/utils.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/utils.py
@@ -482,8 +482,13 @@ class RequestRunner:
             # Strict-always-False frees the request immediately on EOS, but
             # the worker may still have a deferred store queued. In production
             # the next request's step drains it; in single-request tests we
-            # must keep stepping until the scheduler sees no in-flight jobs.
-            if not self.scheduler.requests and not self.connector_scheduler._jobs:
+            # must keep stepping until the scheduler sees no in-flight jobs
+            # and no finished request awaiting final-store construction.
+            if (
+                not self.scheduler.requests
+                and not self.connector_scheduler._jobs
+                and not self.scheduler.finished_req_ids
+            ):
                 break
 
             scheduler_output = self.scheduler.schedule()
@@ -544,19 +549,30 @@ class RequestRunner:
             if (
                 prev_token_id == EOS_TOKEN_ID
                 and prev_token_id != token_id
-                and (self.scheduler.requests or self.connector_scheduler._jobs)
+                and (
+                    self.scheduler.requests
+                    or self.connector_scheduler._jobs
+                    or self.scheduler.finished_req_ids
+                )
             ):
                 # continue for one more step to allow offloading to kick off
                 continue
 
             if token_id is None:
                 if self.async_scheduling:
-                    # sample last token
+                    # Flush the previous step's output.
                     engine_outputs = self.scheduler.update_from_output(
                         prev_scheduler_output, prev_model_runner_output
                     )
                     self._record_kv_connector_stats(engine_outputs)
-                break
+                    prev_model_runner_output = None
+                if self.scheduler.requests:
+                    # The request is still running; decoded_tokens is exhausted.
+                    break
+                if not self.scheduler.finished_req_ids and (
+                    not complete_transfers or not self.connector_scheduler._jobs
+                ):
+                    break
 
         self._parse_transfers()
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -258,6 +258,8 @@ class RequestOffloadState:
     # time.monotonic() of this request's first deferred offload lookup;
     # None once consumed (observed) or while no lookup is pending.
     deferred_lookup_start_time: float | None = None
+    # True once on_request_finished has been signaled to the manager.
+    finished_signaled: bool = False
 
     def __post_init__(self) -> None:
         self.group_states = tuple(
@@ -474,13 +476,6 @@ class OffloadingConnectorScheduler:
         if self.config.offload_prompt_only:
             num = min(num, req_status.req.num_prompt_tokens)
         return num
-
-    def _maybe_cleanup_finished_req(
-        self, req_id: str, req_status: RequestOffloadState
-    ) -> None:
-        """Clean up req_status if finished and no in-flight jobs."""
-        if req_status.req.is_finished() and not req_status.transfer_jobs:
-            del self._req_status[req_id]
 
     def _maximal_prefix_lookup(
         self, keys: Iterable[OffloadKey], req_context: ReqContext
@@ -1016,7 +1011,6 @@ class OffloadingConnectorScheduler:
 
             if not new_offload_keys:
                 req_status.advance_stored_idx(num_offloadable_tokens)
-                self._maybe_cleanup_finished_req(req_id, req_status)
                 continue
 
             store_output = self.manager.prepare_store(
@@ -1027,12 +1021,10 @@ class OffloadingConnectorScheduler:
                     _ConnectorMetricName.ALLOCATION_FAILURE
                 )
                 logger.warning("Request %s: cannot store chunks", req_id)
-                self._maybe_cleanup_finished_req(req_id, req_status)
                 continue
 
             if not store_output.keys_to_store:
                 req_status.advance_stored_idx(num_offloadable_tokens)
-                self._maybe_cleanup_finished_req(req_id, req_status)
                 continue
 
             self._touch(req_status)
@@ -1176,6 +1168,17 @@ class OffloadingConnectorScheduler:
             store_jobs=self._build_store_jobs(scheduler_output),
             jobs_to_flush=self._current_batch_jobs_to_flush,
         )
+
+        # prepare_store must remain valid until every final store has been
+        # submitted. Tiering managers may release per-request state here.
+        for req_id in scheduler_output.finished_req_ids or ():
+            req_status = self._req_status.get(req_id)
+            if req_status is None:
+                continue
+            req_status.finished_signaled = True
+            self.manager.on_request_finished(req_status.req_context)
+            if not req_status.transfer_jobs:
+                del self._req_status[req_id]
         self._current_batch_load_jobs = {}
         self._current_batch_jobs_to_flush = set()
         self._current_batch_allocated_block_ids = set()
@@ -1266,7 +1269,7 @@ class OffloadingConnectorScheduler:
 
             del self._jobs[job_id]
             req_status.transfer_jobs.remove(job_id)
-            if not req_status.transfer_jobs and req_status.req.is_finished():
+            if req_status.finished_signaled and not req_status.transfer_jobs:
                 del self._req_status[job_status.req_id]
 
     def get_stats(self) -> OffloadingConnectorStats | None:
@@ -1308,7 +1311,6 @@ class OffloadingConnectorScheduler:
             self.manager.on_request_finished(req_context)
             return False, None
 
-        self.manager.on_request_finished(req_status.req_context)
         self._maybe_observe_lookup_async_delay(req_status)
 
         # Update offload keys with final block hash so _build_store_jobs can
@@ -1352,6 +1354,8 @@ class OffloadingConnectorScheduler:
 
         for req_id, status in list(self._req_status.items()):
             if status.req.is_finished():
+                if not status.finished_signaled:
+                    self.manager.on_request_finished(status.req_context)
                 del self._req_status[req_id]
 
         # Reset offloading manager cache


### PR DESCRIPTION
## Summary

Port the final-store lifecycle fix from upstream vLLM [#49671](https://github.com/vllm-project/vllm/pull/49671) to current Gilded Gnosis.

This fixes the native tiered KV-offload crash reported in [rtx6kpro#60](https://github.com/local-inference-lab/rtx6kpro/issues/60): `TieringOffloadingManager.prepare_store()` could receive a request after its `_req_state` entry had already been finalized, causing `KeyError` and terminating EngineCore.

## Root cause

`OffloadingConnectorScheduler.request_finished()` notified the manager immediately, but the request's final block hash is only available after finish and its store is built from `finished_req_ids` on the next scheduler step.

For a tiering request with no earlier primary store in flight, `on_request_finished()` legitimately removed the manager state. The next step then called `prepare_store()` for the EOS-completed block against that removed state. This is a deterministic lifecycle ordering bug, not a concurrent dictionary race.

## Fix

- Build all deferred final-store jobs before calling `manager.on_request_finished()`.
- Keep scheduler request state until both finalization has been signaled and submitted transfers have completed.
- Finalize unfinished lifecycle state during `reset_cache()` when the pending final-store step is intentionally discarded.
- Make the unit runner drain `finished_req_ids`, matching the production scheduler lifecycle.
- Add sync and async regression coverage with a real `TieringOffloadingManager`.

Untracked requests still finalize immediately because they cannot have deferred store work.

## Reproduction and validation

The regression test uses the actual tiering manager and an EOS that completes a partial KV block:

- Unpatched GG, synchronous scheduler: `KeyError('0')`
- Unpatched GG, asynchronous scheduler: `KeyError('0')`
- Patched GG: final `prepare_store` precedes `on_request_finished`, the block is stored, and tiering state is released normally in both modes.

Validation:

- Offloading scheduler and tiering suites: **151 passed, 2 skipped**
- Focused lifecycle matrix: **10 passed**
- `ruff check`: passed
- `ruff format --check`: passed
- `git diff --check`: passed

The full 500k/C200 model workload was not repeated because all local GPUs were occupied; the deterministic test reproduces the exact manager, call path, and exception from the report without requiring model weights.

## Provenance

Adapted from upstream vLLM #49671 while preserving GG's local offload scheduler behavior and tests. Original authors are retained as commit co-authors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request completion handling to ensure final data is stored before a request is marked finished.
  * Prevented premature cleanup while background transfers or storage operations are still pending.
  * Improved cache reset behavior to avoid duplicate completion notifications.
  * Updated scheduling behavior for sliding-window and CPU-primary tiering scenarios.
  * Enhanced handling of end-of-stream and token-exhaustion cases when asynchronous work remains active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->