### PR TITLE
[GG] feat(distributed): add FlashInfer PCIe IPC all-reduce backend

### DIFF
--- a/serve-ds4-flash.sh
+++ b/serve-ds4-flash.sh
@@ -144,7 +144,14 @@ export VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=${VLLM_MEMORY_PROFILER_ESTIMATE_
 export VLLM_PREFIX_CACHE_RETENTION_INTERVAL=${VLLM_PREFIX_CACHE_RETENTION_INTERVAL:-4096}
 export VLLM_MULTI_STREAM_GEMM_TOKEN_THRESHOLD=${VLLM_MULTI_STREAM_GEMM_TOKEN_THRESHOLD:-1024}
 
-allreduce_mode=${ALLREDUCE_MODE:-b12x}
+allreduce_mode=${ALLREDUCE_MODE:-auto}
+if [[ "${allreduce_mode}" == "auto" ]]; then
+  if [[ "${tp_size}" == "2" ]]; then
+    allreduce_mode=flashinfer-ipc
+  else
+    allreduce_mode=b12x
+  fi
+fi
 b12x_pcie_dma=$(bool_value B12X_PCIE_DMA "${B12X_PCIE_DMA:-0}")
 export VLLM_USE_B12X_PCIE_DMA=${b12x_pcie_dma}
 allreduce_args=()
@@ -153,6 +160,15 @@ case "${allreduce_mode}" in
     export VLLM_ENABLE_PCIE_ALLREDUCE=1
     export VLLM_PCIE_ALLREDUCE_BACKEND=b12x
     export VLLM_PCIE_ONESHOT_ALLREDUCE_MAX_SIZE=${VLLM_PCIE_ONESHOT_ALLREDUCE_MAX_SIZE:-64KB}
+    export VLLM_ALLOW_CUSTOM_ALLREDUCE_PCIE=0
+    export PYTORCH_CUDA_ALLOC_CONF=${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True}
+    ;;
+  flashinfer-ipc)
+    export VLLM_ENABLE_PCIE_ALLREDUCE=1
+    export VLLM_PCIE_ALLREDUCE_BACKEND=flashinfer-ipc
+    export VLLM_PCIE_ONESHOT_ALLREDUCE_MAX_SIZE=${VLLM_PCIE_ONESHOT_ALLREDUCE_MAX_SIZE:-1MB}
+    export VLLM_PCIE_ONESHOT_FUSED_ADD_RMS_NORM_MAX_SIZE=0
+    export VLLM_PCIE_DMA_MIN_BYTES=off
     export VLLM_ALLOW_CUSTOM_ALLREDUCE_PCIE=0
     export PYTORCH_CUDA_ALLOC_CONF=${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True}
     ;;
@@ -177,8 +193,8 @@ case "${allreduce_mode}" in
     allreduce_args=(--disable-custom-all-reduce)
     ;;
   *)
-    echo "ALLREDUCE_MODE must be b12x, vllm-custom, vllm-custom-2stage," \
-      "or nccl; got '${allreduce_mode}'" >&2
+    echo "ALLREDUCE_MODE must be auto, b12x, flashinfer-ipc, vllm-custom," \
+      "vllm-custom-2stage, or nccl; got '${allreduce_mode}'" >&2
     exit 2
     ;;
 esac

--- a/tests/distributed/test_flashinfer_pcie_all_reduce.py
+++ b/tests/distributed/test_flashinfer_pcie_all_reduce.py
@@ -1,0 +1,224 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from vllm.distributed.device_communicators import custom_all_reduce
+from vllm.distributed.device_communicators import flashinfer_pcie_all_reduce as fi_pcie
+
+
+class FakeWorkspace:
+    instances: list[FakeWorkspace] = []
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+        self.destroyed = False
+        self.last_input: torch.Tensor | None = None
+        FakeWorkspace.instances.append(self)
+
+    def supports(self, inp: torch.Tensor) -> bool:
+        return inp.numel() <= self.kwargs["max_numel"]
+
+    def all_reduce(
+        self, inp: torch.Tensor, *, out: torch.Tensor | None = None
+    ) -> torch.Tensor:
+        self.last_input = inp
+        if out is None:
+            return inp.clone()
+        out.copy_(inp)
+        return out
+
+    def destroy(self) -> None:
+        self.destroyed = True
+
+
+@pytest.fixture(autouse=True)
+def fake_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    FakeWorkspace.instances.clear()
+    monkeypatch.setattr(fi_pcie, "_load_workspace_class", lambda: FakeWorkspace)
+    monkeypatch.setattr(fi_pcie.dist, "get_rank", lambda group=None: 0)
+    monkeypatch.setattr(fi_pcie.dist, "get_world_size", lambda group=None: 2)
+
+    def all_gather_object(gathered, value, *, group):
+        del group
+        gathered[:] = [value, value]
+
+    monkeypatch.setattr(fi_pcie.dist, "all_gather_object", all_gather_object)
+
+
+def make_pool() -> fi_pcie.FlashInferPcieIpcAllReducePool:
+    return fi_pcie.FlashInferPcieIpcAllReducePool(
+        exchange_group=object(),  # type: ignore[arg-type]
+        device="cpu",
+        max_size=64,
+    )
+
+
+def test_each_semantic_channel_gets_an_independent_workspace() -> None:
+    pool = make_pool()
+    assert FakeWorkspace.instances == []
+    checkpoint = pool.checkpoint_channels()
+
+    pool.prepare_channels(("vllm:target:profile",))
+    assert len(FakeWorkspace.instances) == 1
+    assert pool.for_stream(channel_id="vllm:target:profile").should_allreduce(
+        torch.ones(4)
+    )
+
+    profile_workspace = FakeWorkspace.instances[-1]
+    pool.rollback_channels(checkpoint)
+    assert profile_workspace.destroyed
+    assert pool.checkpoint_channels() == ()
+
+    inp = torch.ones(4)
+    assert torch.equal(pool.all_reduce(inp), inp)
+    eager = FakeWorkspace.instances[-1]
+    pool.close()
+    assert eager.destroyed
+
+
+def test_capture_routes_graph_calls_without_reusing_eager_state() -> None:
+    pool = make_pool()
+    inp = torch.arange(4, dtype=torch.float32)
+    out = torch.empty_like(inp)
+
+    with pool.capture(channel_id="vllm:target:production"):
+        pool.prepare_graph_all_reduce(inp)
+        actual = pool.all_reduce(
+            inp,
+            out=out,
+            channel_id="vllm:target:production",
+        )
+
+    assert actual is out
+    assert torch.equal(actual, inp)
+    assert len(FakeWorkspace.instances) == 1
+    assert FakeWorkspace.instances[0].last_input is inp
+    pool.close()
+
+
+def test_channel_creation_fails_closed_when_rank_ids_differ(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pool = make_pool()
+
+    def divergent(gathered, value, *, group):
+        del group
+        gathered[:] = [value, "different-channel"]
+
+    monkeypatch.setattr(fi_pcie.dist, "all_gather_object", divergent)
+    with pytest.raises(RuntimeError, match="rank-stable"):
+        pool.prepare_channels(("vllm:target:production",))
+    pool.close()
+
+
+def test_flashinfer_ipc_is_an_explicit_integrated_backend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VLLM_ENABLE_PCIE_ALLREDUCE", "1")
+    monkeypatch.setenv("VLLM_PCIE_ALLREDUCE_BACKEND", "flashinfer-ipc")
+
+    assert custom_all_reduce._flashinfer_pcie_allreduce_requested()
+    assert not custom_all_reduce._b12x_pcie_allreduce_requested()
+    assert custom_all_reduce._get_pcie_allreduce_backend() == "flashinfer-ipc"
+
+
+def test_custom_allreduce_constructs_flashinfer_pool(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+    runtime = MagicMock()
+
+    class FakePool:
+        @classmethod
+        def from_exchange_group(cls, **kwargs: Any) -> MagicMock:
+            captured.update(kwargs)
+            return runtime
+
+    def fake_all_gather(gather_list, tensor, *, group) -> None:
+        del tensor, group
+        for index, slot in enumerate(gather_list):
+            slot.fill_(index)
+
+    fake_config = SimpleNamespace(
+        model_config=SimpleNamespace(get_hidden_size=lambda: 4096),
+        scheduler_config=SimpleNamespace(max_num_batched_tokens=128),
+    )
+    monkeypatch.setattr(custom_all_reduce, "custom_ar", True)
+    monkeypatch.setattr(custom_all_reduce.dist, "get_backend", lambda group: "gloo")
+    monkeypatch.setattr(
+        custom_all_reduce,
+        "in_the_same_node_as",
+        lambda group, source_rank=0: [True, True],
+    )
+    monkeypatch.setattr(custom_all_reduce.dist, "get_rank", lambda group=None: 0)
+    monkeypatch.setattr(custom_all_reduce.dist, "get_world_size", lambda group=None: 2)
+    monkeypatch.setattr(custom_all_reduce.dist, "all_gather", fake_all_gather)
+    monkeypatch.setattr(
+        custom_all_reduce.dist, "all_reduce", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        custom_all_reduce, "_b12x_pcie_allreduce_requested", lambda: False
+    )
+    monkeypatch.setattr(
+        custom_all_reduce, "_flashinfer_pcie_allreduce_requested", lambda: True
+    )
+    monkeypatch.setattr(
+        custom_all_reduce, "_get_pcie_allreduce_backend", lambda: "flashinfer-ipc"
+    )
+    monkeypatch.setattr(custom_all_reduce, "_can_p2p", lambda *args: True)
+    monkeypatch.setattr(custom_all_reduce, "_is_cross_numa_topology", lambda ids: False)
+    monkeypatch.setattr(
+        custom_all_reduce, "_load_flashinfer_pcie_oneshot_pool", lambda: FakePool
+    )
+    monkeypatch.setattr(
+        custom_all_reduce.current_platform, "get_device_capability", lambda: None
+    )
+    monkeypatch.setattr(
+        custom_all_reduce.current_platform,
+        "visible_device_id_to_physical_device_id",
+        lambda index: index,
+    )
+    monkeypatch.setattr(
+        custom_all_reduce.current_platform, "is_cuda_alike", lambda: True
+    )
+    monkeypatch.setattr(
+        custom_all_reduce.current_platform,
+        "is_fully_connected",
+        lambda ids: False,
+        raising=False,
+    )
+    monkeypatch.setattr(custom_all_reduce.current_platform, "is_cuda", lambda: True)
+    monkeypatch.setattr(custom_all_reduce.current_platform, "is_rocm", lambda: False)
+    monkeypatch.setattr("vllm.config.get_current_vllm_config", lambda: fake_config)
+    monkeypatch.setattr(
+        custom_all_reduce.envs,
+        "VLLM_PCIE_ONESHOT_SINGLE_CHANNEL",
+        False,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        custom_all_reduce.envs,
+        "VLLM_ALLOW_CUSTOM_ALLREDUCE_PCIE",
+        False,
+        raising=False,
+    )
+
+    built = custom_all_reduce.CustomAllreduce(
+        object(),  # type: ignore[arg-type]
+        torch.device("cuda:0"),
+        nccl_group=object(),  # type: ignore[arg-type]
+    )
+
+    assert not built.disabled
+    assert built.backend_name() == "FLASHINFER_PCIE_IPC"
+    assert captured["max_size"] > 0
+    runtime.prepare_channels.assert_called_once()
+    runtime.for_stream.assert_called_once()

--- a/tests/entrypoints/test_ds4_allreduce_launcher.py
+++ b/tests/entrypoints/test_ds4_allreduce_launcher.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import os
+import subprocess
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).parents[2]
+_LAUNCHER = _REPO_ROOT / "serve-ds4-flash.sh"
+
+
+def _dry_run(tmp_path: Path, **overrides: str) -> str:
+    env = {
+        "PATH": os.environ["PATH"],
+        "HOME": str(tmp_path),
+        "XDG_CACHE_HOME": str(tmp_path / "cache"),
+        "DRY_RUN": "1",
+        "MODE": "mtp0",
+        **overrides,
+    }
+    result = subprocess.run(
+        ["bash", str(_LAUNCHER)],
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stderr
+
+
+def test_ds4_launcher_auto_selects_flashinfer_ipc_for_tp2(tmp_path: Path) -> None:
+    output = _dry_run(tmp_path, TP="2")
+
+    assert "allreduce=flashinfer-ipc" in output
+
+
+def test_ds4_launcher_auto_keeps_b12x_for_tp4(tmp_path: Path) -> None:
+    output = _dry_run(tmp_path, TP="4")
+
+    assert "allreduce=b12x" in output
+
+
+def test_ds4_launcher_explicit_allreduce_overrides_auto(tmp_path: Path) -> None:
+    output = _dry_run(tmp_path, TP="2", ALLREDUCE_MODE="b12x")
+
+    assert "allreduce=b12x" in output

--- a/tests/entrypoints/test_ds4_allreduce_launcher.py
+++ b/tests/entrypoints/test_ds4_allreduce_launcher.py
@@ -10,6 +10,15 @@ _LAUNCHER = _REPO_ROOT / "serve-ds4-flash.sh"
 
 
 def _dry_run(tmp_path: Path, **overrides: str) -> str:
+    """Run the DS4 launcher without starting a server.
+
+    Args:
+        tmp_path: Isolated home and cache root for the launcher.
+        **overrides: Environment values applied to the launcher defaults.
+
+    Returns:
+        The launcher's diagnostic stderr output.
+    """
     env = {
         "PATH": os.environ["PATH"],
         "HOME": str(tmp_path),
@@ -29,18 +38,21 @@ def _dry_run(tmp_path: Path, **overrides: str) -> str:
 
 
 def test_ds4_launcher_auto_selects_flashinfer_ipc_for_tp2(tmp_path: Path) -> None:
+    """Verify that automatic selection uses FlashInfer IPC at TP2."""
     output = _dry_run(tmp_path, TP="2")
 
     assert "allreduce=flashinfer-ipc" in output
 
 
 def test_ds4_launcher_auto_keeps_b12x_for_tp4(tmp_path: Path) -> None:
+    """Verify that automatic selection retains B12X at TP4."""
     output = _dry_run(tmp_path, TP="4")
 
     assert "allreduce=b12x" in output
 
 
 def test_ds4_launcher_explicit_allreduce_overrides_auto(tmp_path: Path) -> None:
+    """Verify that an explicit all-reduce mode overrides automatic selection."""
     output = _dry_run(tmp_path, TP="2", ALLREDUCE_MODE="b12x")
 
     assert "allreduce=b12x" in output

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -451,17 +451,18 @@ class CustomAllreduce:
             return
 
         if use_pcie_oneshot:
+            pcie_backend = _get_pcie_allreduce_backend()
             allow_cross_numa = envs.VLLM_PCIE_ONESHOT_ALLOW_CROSS_NUMA
             if _is_cross_numa_topology(physical_device_ids) and not allow_cross_numa:
                 logger.warning(
-                    "Custom allreduce is disabled because b12x PCIe oneshot "
+                    "Custom allreduce is disabled because %s PCIe oneshot "
                     "allreduce was requested on a cross-NUMA PCIe topology "
                     "(physical_device_ids=%s). Set "
                     "VLLM_PCIE_ONESHOT_ALLOW_CROSS_NUMA=1 or unset it to force it.",
+                    pcie_backend,
                     physical_device_ids,
                 )
                 return
-            pcie_backend = _get_pcie_allreduce_backend()
             pool_cls = (
                 _load_b12x_pcie_oneshot_pool()
                 if pcie_backend == "b12x"
@@ -489,7 +490,8 @@ class CustomAllreduce:
                 max_num_batched_tokens = 8192
                 logger.warning(
                     "vLLM config unavailable during CustomAllreduce init; "
-                    "allocating b12x PCIe buffers for hidden=%d, rows<=%d.",
+                    "allocating %s PCIe buffers for hidden=%d, rows<=%d.",
+                    pcie_backend,
                     model_hidden_size,
                     max_num_batched_tokens,
                 )
@@ -502,8 +504,9 @@ class CustomAllreduce:
             ) = _b12x_pcie_oneshot_limits()
             if self.nccl_group is None:
                 logger.warning(
-                    "Custom allreduce is disabled because b12x PCIe oneshot "
-                    "allreduce requires a CUDA/NCCL device process group."
+                    "Custom allreduce is disabled because %s PCIe oneshot "
+                    "allreduce requires a CUDA/NCCL device process group.",
+                    pcie_backend,
                 )
                 return
             self.max_size = pcie_buffer_size
@@ -535,15 +538,17 @@ class CustomAllreduce:
                     pcie_runtime.close()
                 if pcie_init_error is not None:
                     logger.warning(
-                        "b12x PCIe oneshot allreduce initialization failed on "
+                        "%s PCIe oneshot allreduce initialization failed on "
                         "rank %d: %s. Falling back to PyNCCL allreduce.",
+                        pcie_backend,
                         rank,
                         pcie_init_error,
                     )
                 else:
                     logger.warning(
-                        "b12x PCIe oneshot allreduce initialization failed on "
-                        "another TP rank. Falling back to PyNCCL allreduce."
+                        "%s PCIe oneshot allreduce initialization failed on "
+                        "another TP rank. Falling back to PyNCCL allreduce.",
+                        pcie_backend,
                     )
                 return
             assert pcie_runtime is not None

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -36,16 +36,23 @@ _B12X_PCIE_EAGER_CHANNEL_ID = "eager:vllm-tp-allreduce"
 
 def _get_pcie_allreduce_backend() -> str:
     backend = envs.VLLM_PCIE_ALLREDUCE_BACKEND.lower()
-    if backend not in {"b12x", "cpp"}:
+    if backend not in {"b12x", "cpp", "flashinfer-ipc"}:
         raise ValueError(
             "Invalid VLLM_PCIE_ALLREDUCE_BACKEND: "
-            f"{backend!r}. Valid values: b12x, cpp."
+            f"{backend!r}. Valid values: b12x, cpp, flashinfer-ipc."
         )
     return backend
 
 
 def _b12x_pcie_allreduce_requested() -> bool:
     return envs.VLLM_ENABLE_PCIE_ALLREDUCE and _get_pcie_allreduce_backend() == "b12x"
+
+
+def _flashinfer_pcie_allreduce_requested() -> bool:
+    return (
+        envs.VLLM_ENABLE_PCIE_ALLREDUCE
+        and _get_pcie_allreduce_backend() == "flashinfer-ipc"
+    )
 
 
 def _is_piecewise_cudagraph_runtime() -> bool:
@@ -119,6 +126,17 @@ def _load_b12x_pcie_dma() -> Any | None:
     except Exception:
         return None
     return PCIeDmaAllReduce
+
+
+@lru_cache(maxsize=1)
+def _load_flashinfer_pcie_oneshot_pool() -> Any | None:
+    try:
+        from vllm.distributed.device_communicators.flashinfer_pcie_all_reduce import (
+            FlashInferPcieIpcAllReducePool,
+        )
+    except Exception:
+        return None
+    return FlashInferPcieIpcAllReducePool
 
 
 def _get_physical_device_numa_node(physical_device_id: int) -> int | None:
@@ -269,6 +287,7 @@ class CustomAllreduce:
         self._cpp_ar_cutoff_size: int | None = None
         self._cpp_ar_ignore_cutoff_max_rows = 0
         self._pcie_cpp_backend = False
+        self._pcie_backend_name: str | None = None
         self._pcie_logged_first_allreduce = False
         self._ptr = 0
 
@@ -304,9 +323,11 @@ class CustomAllreduce:
             return
 
         b12x_pcie_requested = _b12x_pcie_allreduce_requested()
+        flashinfer_pcie_requested = _flashinfer_pcie_allreduce_requested()
+        integrated_pcie_requested = b12x_pcie_requested or flashinfer_pcie_requested
         if (
             world_size not in CustomAllreduce._SUPPORTED_WORLD_SIZES
-            and not b12x_pcie_requested
+            and not integrated_pcie_requested
         ):
             logger.warning(
                 "Custom allreduce is disabled due to an unsupported world"
@@ -363,16 +384,17 @@ class CustomAllreduce:
         assert current_platform.is_cuda_alike()
         fully_connected = current_platform.is_fully_connected(physical_device_ids)
         use_pcie_oneshot = False
-        if b12x_pcie_requested:
+        if integrated_pcie_requested:
             if not current_platform.is_cuda():
                 logger.warning(
-                    "Custom allreduce is disabled because b12x PCIe oneshot "
-                    "allreduce requires CUDA."
+                    "Custom allreduce is disabled because the integrated "
+                    "PCIe oneshot backend requires CUDA."
                 )
                 return
             logger.debug(
-                "b12x PCIe oneshot allreduce requested "
+                "%s PCIe oneshot allreduce requested "
                 "(world_size=%d, physical_device_ids=%s, fully_connected=%s).",
+                _get_pcie_allreduce_backend(),
                 world_size,
                 physical_device_ids,
                 fully_connected,
@@ -439,11 +461,17 @@ class CustomAllreduce:
                     physical_device_ids,
                 )
                 return
-            pool_cls = _load_b12x_pcie_oneshot_pool()
+            pcie_backend = _get_pcie_allreduce_backend()
+            pool_cls = (
+                _load_b12x_pcie_oneshot_pool()
+                if pcie_backend == "b12x"
+                else _load_flashinfer_pcie_oneshot_pool()
+            )
             if pool_cls is None:
                 logger.warning(
-                    "PCIe custom allreduce was requested, but "
-                    "b12x.comm.pcie.OneshotAllReducePool is unavailable."
+                    "%s PCIe custom allreduce was requested, but its runtime "
+                    "is unavailable.",
+                    pcie_backend,
                 )
                 return
             # DMA must accommodate the largest scheduled prefill tensor. The
@@ -520,12 +548,20 @@ class CustomAllreduce:
                 return
             assert pcie_runtime is not None
             self._pcie_runtime = pcie_runtime
+            self._pcie_backend_name = pcie_backend
             # Prefill-size DMA allreduce alongside the oneshot. A deployment
             # preflight can tune its crossover or disable it when lossless DMA
             # never beats NCCL on the selected PCIe topology.
-            dma_min_bytes = _b12x_pcie_dma_min_bytes()
+            dma_min_bytes = (
+                _b12x_pcie_dma_min_bytes() if pcie_backend == "b12x" else None
+            )
             dma_cls = None if dma_min_bytes is None else _load_b12x_pcie_dma()
-            if dma_min_bytes is None:
+            if pcie_backend != "b12x":
+                logger.info(
+                    "FlashInfer PCIe IPC handles only tuned one-shot shapes; "
+                    "larger allreduces stay on PyNCCL."
+                )
+            elif dma_min_bytes is None:
                 logger.info(
                     "b12x PCIe DMA allreduce disabled by "
                     "VLLM_PCIE_DMA_MIN_BYTES=off; large allreduces stay on PyNCCL."
@@ -579,19 +615,21 @@ class CustomAllreduce:
 
             if rank == 0:
                 logger.info(
-                    "Configured b12x PCIe crossovers: "
+                    "Configured %s PCIe crossovers: "
                     "oneshot max=%d, fused max=%d, DMA min=%s.",
+                    pcie_backend,
                     self._pcie_allreduce_max_size,
                     self._pcie_fused_add_rms_norm_max_size,
                     dma_min_bytes if dma_min_bytes is not None else "off",
                 )
             self.disabled = False
             logger.debug(
-                "Using b12x PCIe oneshot allreduce backend "
+                "Using %s PCIe oneshot allreduce backend "
                 "(world_size=%d, allreduce_max_size=%d, "
                 "fused_add_rms_norm_max_size=%d, oneshot_buffer_size=%d, "
                 "dma_buffer_size=%d, "
                 "single_channel=%s).",
+                pcie_backend,
                 world_size,
                 self._pcie_allreduce_max_size,
                 self._pcie_fused_add_rms_norm_max_size,
@@ -815,6 +853,8 @@ class CustomAllreduce:
 
     def backend_name(self) -> str:
         if self._pcie_runtime is not None:
+            if self._pcie_backend_name == "flashinfer-ipc":
+                return "FLASHINFER_PCIE_IPC"
             if self._pcie_dma is not None:
                 return "B12X_PCIE_ONESHOT_DMA"
             return "B12X_PCIE_ONESHOT"

--- a/vllm/distributed/device_communicators/flashinfer_pcie_all_reduce.py
+++ b/vllm/distributed/device_communicators/flashinfer_pcie_all_reduce.py
@@ -1,0 +1,208 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Stream-isolated adapter for FlashInfer's PCIe IPC all-reduce."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
+from functools import lru_cache
+from typing import Any
+
+import torch
+import torch.distributed as dist
+from torch.distributed import ProcessGroup
+
+
+@lru_cache(maxsize=1)
+def _load_workspace_class() -> type:
+    from flashinfer.comm import PcieIpcAllReduceWorkspace
+
+    return PcieIpcAllReduceWorkspace
+
+
+class _FlashInferPcieChannel:
+    def __init__(
+        self,
+        owner: FlashInferPcieIpcAllReducePool,
+        channel_id: str,
+    ) -> None:
+        self._owner = owner
+        self._channel_id = channel_id
+
+    def should_allreduce(self, inp: torch.Tensor) -> bool:
+        return self._owner._workspace(self._channel_id).supports(inp)
+
+    def register_graph_buffers(self) -> None:
+        # FlashInfer owns fixed IPC slabs; graph replay does not register input
+        # pointers with the legacy vLLM custom-allreduce runtime.
+        return None
+
+
+class FlashInferPcieIpcAllReducePool:
+    """Give every eager/CUDA-graph owner a distinct FlashInfer workspace.
+
+    FlashInfer's protocol state is stream-affine. vLLM may own an eager stream
+    plus independent target and draft CUDA-graph streams, so sharing one
+    workspace would permit their epochs to interleave. Semantic ``channel_id``
+    values provide a rank-stable key and one IPC workspace is allocated for
+    each live channel.
+    """
+
+    _EAGER_CHANNEL_ID = "vllm:eager:allreduce"
+
+    def __init__(
+        self,
+        *,
+        exchange_group: ProcessGroup,
+        device: torch.device | int | str,
+        max_size: int,
+        single_channel: bool = False,
+    ) -> None:
+        self.group = exchange_group
+        self.device = torch.device(device)
+        self.rank = dist.get_rank(group=exchange_group)
+        self.world_size = dist.get_world_size(group=exchange_group)
+        self.max_size = max_size
+        self.max_numel = max_size // torch.bfloat16.itemsize
+        self.single_channel = single_channel
+        self._workspaces: dict[str, Any] = {}
+        self._active_channel_id: str | None = None
+        self._closed = False
+
+        if max_size <= 0 or max_size % 16:
+            raise ValueError(
+                "FlashInfer PCIe IPC max_size must be a positive multiple "
+                f"of 16 bytes, got {max_size}"
+            )
+        # Workspace creation is collective. Keep construction allocation-free so
+        # the integration layer can prepare semantic channels at a rank-stable
+        # lifecycle point; standalone callers may still create them on first use.
+
+    @classmethod
+    def from_exchange_group(
+        cls,
+        *,
+        exchange_group: ProcessGroup,
+        device: torch.device | int | str,
+        eager_buffer_bytes: int,
+        max_size: int,
+        single_channel: bool = False,
+        max_concurrent_channels: int | None = None,
+        **_: Any,
+    ) -> FlashInferPcieIpcAllReducePool:
+        del eager_buffer_bytes, max_concurrent_channels
+        return cls(
+            exchange_group=exchange_group,
+            device=device,
+            max_size=max_size,
+            single_channel=single_channel,
+        )
+
+    def _canonical_channel_id(self, channel_id: str | None) -> str:
+        if self.single_channel or channel_id is None:
+            return self._EAGER_CHANNEL_ID
+        return channel_id
+
+    def _verify_channel_id(self, channel_id: str) -> None:
+        gathered: list[str | None] = [None] * self.world_size
+        dist.all_gather_object(gathered, channel_id, group=self.group)
+        if any(peer != channel_id for peer in gathered):
+            raise RuntimeError(
+                "FlashInfer PCIe IPC channel creation must be rank-stable; "
+                f"received {gathered}"
+            )
+
+    def _workspace(self, channel_id: str | None) -> Any:
+        if self._closed:
+            raise RuntimeError("FlashInfer PCIe IPC pool is closed")
+        key = self._canonical_channel_id(channel_id)
+        workspace = self._workspaces.get(key)
+        if workspace is None:
+            self._verify_channel_id(key)
+            workspace = _load_workspace_class()(
+                group=self.group,
+                max_numel=self.max_numel,
+                dtype=torch.bfloat16,
+            )
+            self._workspaces[key] = workspace
+        return workspace
+
+    def prepare_channels(self, channel_ids: Sequence[str]) -> None:
+        for channel_id in channel_ids:
+            self._workspace(channel_id)
+
+    def for_stream(
+        self,
+        stream: torch.cuda.Stream | None = None,
+        *,
+        channel_id: str | None = None,
+    ) -> _FlashInferPcieChannel:
+        del stream
+        key = self._canonical_channel_id(channel_id)
+        self._workspace(key)
+        return _FlashInferPcieChannel(self, key)
+
+    @contextmanager
+    def capture(
+        self,
+        stream: torch.cuda.Stream | None = None,
+        *,
+        channel_id: str | None = None,
+    ) -> Iterator[FlashInferPcieIpcAllReducePool]:
+        del stream
+        key = self._canonical_channel_id(channel_id)
+        self._workspace(key)
+        previous = self._active_channel_id
+        self._active_channel_id = key
+        try:
+            yield self
+        finally:
+            self._active_channel_id = previous
+
+    def prepare_graph_all_reduce(
+        self,
+        inp: torch.Tensor,
+        *,
+        stream: torch.cuda.Stream | None = None,
+    ) -> None:
+        del stream
+        channel_id = self._active_channel_id or self._EAGER_CHANNEL_ID
+        if not self._workspace(channel_id).supports(inp):
+            raise ValueError(
+                "FlashInfer PCIe IPC graph warmup received an unsupported "
+                f"shape {tuple(inp.shape)}"
+            )
+
+    def all_reduce(
+        self,
+        inp: torch.Tensor,
+        *,
+        out: torch.Tensor | None = None,
+        stream: torch.cuda.Stream | None = None,
+        channel_id: str | None = None,
+    ) -> torch.Tensor:
+        workspace = self._workspace(channel_id)
+        if stream is None or torch.cuda.current_stream(self.device) == stream:
+            return workspace.all_reduce(inp, out=out)
+        with torch.cuda.stream(stream):
+            return workspace.all_reduce(inp, out=out)
+
+    def checkpoint_channels(self) -> tuple[str, ...]:
+        return tuple(self._workspaces)
+
+    def rollback_channels(self, checkpoint: tuple[str, ...]) -> None:
+        retained = set(checkpoint)
+        for channel_id in reversed(tuple(self._workspaces)):
+            if channel_id in retained:
+                continue
+            self._workspaces.pop(channel_id).destroy()
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        for workspace in reversed(tuple(self._workspaces.values())):
+            workspace.destroy()
+        self._workspaces.clear()
+        self._closed = True

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -234,7 +234,7 @@ if TYPE_CHECKING:
     VLLM_FLASHINFER_AUTOTUNE_SKIP_OPS: list[str] | None = None
     VLLM_FLASHINFER_ALLREDUCE_BACKEND: Literal["auto", "trtllm", "mnnvl"] = "auto"
     VLLM_ENABLE_PCIE_ALLREDUCE: bool = False
-    VLLM_PCIE_ALLREDUCE_BACKEND: Literal["b12x", "cpp"] = "cpp"
+    VLLM_PCIE_ALLREDUCE_BACKEND: Literal["b12x", "cpp", "flashinfer-ipc"] = "cpp"
     VLLM_PCIE_ONESHOT_ALLREDUCE_MAX_SIZE: str = "84KB"
     VLLM_PCIE_ONESHOT_FUSED_ADD_RMS_NORM_MAX_SIZE: str = "84KB"
     VLLM_PCIE_DMA_MIN_BYTES: str = "6MB"
@@ -1852,7 +1852,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_PCIE_ALLREDUCE_BACKEND": env_with_choices(
         "VLLM_PCIE_ALLREDUCE_BACKEND",
         "cpp",
-        ["b12x", "cpp"],
+        ["b12x", "cpp", "flashinfer-ipc"],
     ),
     # Max input size for the b12x PCIe oneshot allreduce dispatch.
     # Accepts raw bytes or a KB/MB suffix (e.g. "84KB").


### PR DESCRIPTION
## Summary

Add FlashInfer's SM120 PCIe IPC one-shot all-reduce as an explicit vLLM backend and give each eager/target/draft CUDA-graph owner a separate, rank-stable protocol workspace.

The DS4 helper selects it automatically only at TP2, where it improved both isolated collectives and end-to-end serving. TP4 and larger remain on B12X by default.

## Runtime contract

- `VLLM_PCIE_ALLREDUCE_BACKEND=flashinfer-ipc` selects the backend explicitly.
- `ALLREDUCE_MODE=auto` selects `flashinfer-ipc` at TP2 and `b12x` otherwise.
- Unsupported shapes fall back to PyNCCL.
- FlashInfer PCIe DMA and fused add+RMSNorm are not claimed by this adapter.
- Each semantic eager/target/draft graph channel owns a distinct IPC workspace.
- Channel creation is checked across ranks and graph rollback/teardown destroys only the corresponding workspaces.

This PR is intentionally a clean diff directly against `dev/gilded-gnosis`. Release enablement also requires #251, which supplies the rank-stable CUDA-graph channel lifecycle used by DSpark target and draft captures.

## FlashInfer provenance

Qualified source branch: `voipmonitor/flashinfer:integration/main-pr4393-pcie-ipc-qualified-20260807` at `1ac69427`.

That branch contains:

- upstream FlashInfer main `553c2280`;
- full upstream PR flashinfer-ai/flashinfer#4393 at `6573c652`;
- review fixes for allocation bounds, staged TP geometry, mutation metadata, TP2 policy, and distributed benchmark failure propagation.

The source build disables optional NVEP/NCCL-EP/NIXL-EP components and uses `--no-deps`, preserving the release's patched NCCL package.

## Validation

### Unit and source tests

- vLLM adapter/helper tests: 8 passed.
- FlashInfer PCIe IPC suite on 4x RTX PRO 6000 Blackwell: 14 passed, 4 skipped.
- FlashInfer focused source tests: 32 passed.
- Ruff, formatting, shell syntax, and `git diff --check`: passed.
- The commit cherry-picks cleanly after #251; the #252 KV-offload lifecycle commit also applies cleanly afterward.

### Isolated graph replay, BF16, hidden size 4096

TP2 p50 latency in microseconds, FlashInfer vs B12X:

| Rows | FlashInfer | B12X |
|---:|---:|---:|
| 1 | 2.58 | 5.01 |
| 8 | 3.69 | 7.03 |
| 32 | 7.73 | 15.00 |
| 128 | 33.95 | 46.36 |

At TP4, B12X remained faster for the serving shapes, which is why auto policy does not select FlashInfer there.

### DS4 target-only E2E, TP2

Compared with the same B12X configuration:

- C1 decode: 124.4 -> 127.1 tok/s (+2.2%).
- C32 aggregate decode: 1113.9 -> 1140.4 tok/s (+2.4%).
- 8k prefill: 13033 -> 13333 tok/s (+2.3%).
- 64k prefill: 12638 -> 12767 tok/s (+1.0%).

TP4 showed no C1 gain and a C32 regression, confirming the TP2-only default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added FlashInfer IPC as a PCIe all-reduce backend.
  * Automatic selection now uses FlashInfer IPC for tensor parallelism 2 and retains B12X for other configurations.
  * Added support for stream-aware execution, CUDA graph channels, workspace management, and backend-specific DMA handling.
  * Added configuration support for selecting the FlashInfer IPC backend.

* **Bug Fixes**
  * Improved backend validation and reporting for automatic and FlashInfer IPC modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->