### PR TITLE
[GG] Bound native filesystem KV offload and recover stale loads

### DIFF
--- a/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
@@ -53,6 +53,19 @@ def _reduce_kv_connector_stats(runner):
     return reduced
 
 
+def test_remove_pending_job_deduplicates_lockstep_mla_block_ids() -> None:
+    """Clean one shared physical block once per transfer job."""
+    scheduler = object.__new__(OffloadingConnectorScheduler)
+    scheduler._block_id_to_pending_jobs = {
+        7: {42, 43},
+        9: {42},
+    }
+
+    scheduler._remove_pending_job(42, [7, 7, 9, 9])
+
+    assert scheduler._block_id_to_pending_jobs == {7: {43}}
+
+
 def test_scheduler_reports_allocation_failure(request_runner):
     runner = request_runner(
         block_size=4,

--- a/tests/v1/kv_offload/tiering/test_fs_gc.py
+++ b/tests/v1/kv_offload/tiering/test_fs_gc.py
@@ -1,0 +1,257 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Unit tests for FsGCManager, the fs secondary tier's capacity bound.
+
+These use real files on disk with explicitly set mtimes, since mtime is the
+GC's single source of truth for recency. The background thread is neutralized
+by giving every manager a very long `interval_s` and driving `sweep()` directly,
+so nothing here depends on timing except the two stamping tests, which poll.
+"""
+
+import hashlib
+import os
+import time
+
+import pytest
+
+from vllm.v1.kv_offload.base import make_offload_key
+from vllm.v1.kv_offload.file_mapper import FileMapper
+from vllm.v1.kv_offload.tiering.fs.gc_manager import FsGCManager
+
+_BLOCK_BYTES = 4096
+
+
+def _make_file_mapper(root_dir: str) -> FileMapper:
+    return FileMapper(
+        root_dir=root_dir,
+        model_name="test/model",
+        tokens_per_hash=16,
+        blocks_per_file=1,
+        tp_size=1,
+        pp_size=1,
+        pcp_size=1,
+        dcp_size=1,
+        rank=0,
+        dtype="float32",
+    )
+
+
+def _key(index: int):
+    return make_offload_key(hashlib.sha256(str(index).encode()).digest()[:16], 0)
+
+
+def _write_block(mapper: FileMapper, index: int, age_s: float) -> str:
+    """Create a block file for `index` whose mtime is `age_s` in the past."""
+    path = mapper.get_file_name(_key(index))
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "wb") as f:
+        f.write(b"\0" * _BLOCK_BYTES)
+    stamp = time.time() - age_s
+    os.utime(path, (stamp, stamp))
+    return path
+
+
+@pytest.fixture
+def mapper(tmp_path):
+    return _make_file_mapper(str(tmp_path))
+
+
+def _make_gc(mapper: FileMapper, **kwargs) -> FsGCManager:
+    params = dict(
+        max_bytes=10 * _BLOCK_BYTES,
+        low_watermark=0.8,
+        # Long enough that the background thread never sweeps on its own; each
+        # test calls sweep() explicitly so assertions are deterministic.
+        interval_s=3600.0,
+        stamp_interval_s=1.0,
+        grace_s=60.0,
+    )
+    params.update(kwargs)
+    return FsGCManager(mapper, **params)  # type: ignore[arg-type]
+
+
+def test_rejects_grace_not_exceeding_stamp_interval(mapper):
+    # Otherwise a block in active use can be stamped, then age past the grace
+    # window before its next stamp is due, and be swept while still hot.
+    with pytest.raises(ValueError, match="must exceed stamp_interval_s"):
+        _make_gc(mapper, stamp_interval_s=60.0, grace_s=60.0)
+
+
+def test_rejects_out_of_range_low_watermark(mapper):
+    with pytest.raises(ValueError, match="low_watermark"):
+        _make_gc(mapper, low_watermark=1.5)
+
+
+def test_under_cap_is_a_noop(mapper):
+    gc = _make_gc(mapper)
+    try:
+        paths = [_write_block(mapper, i, age_s=1000) for i in range(5)]
+        assert gc.sweep() == 0
+        assert all(os.path.exists(p) for p in paths)
+    finally:
+        gc.shutdown()
+
+
+def test_evicts_in_mtime_order_down_to_the_low_watermark(mapper):
+    gc = _make_gc(mapper)
+    try:
+        # 15 blocks over a 10-block cap, oldest first. The sweep must free down
+        # to the 8-block watermark, i.e. remove exactly the 7 oldest.
+        paths = [_write_block(mapper, i, age_s=1000 - i) for i in range(15)]
+
+        freed = gc.sweep()
+
+        assert freed == 7 * _BLOCK_BYTES
+        assert not any(os.path.exists(p) for p in paths[:7])
+        assert all(os.path.exists(p) for p in paths[7:])
+    finally:
+        gc.shutdown()
+
+
+def test_grace_window_keeps_recently_used_blocks_even_over_cap(mapper):
+    gc = _make_gc(mapper, grace_s=60.0)
+    try:
+        # Everything is inside the grace window, so the tier is knowingly left
+        # over its cap rather than evicting blocks that are still in use.
+        paths = [_write_block(mapper, i, age_s=1) for i in range(15)]
+
+        assert gc.sweep() == 0
+        assert all(os.path.exists(p) for p in paths)
+    finally:
+        gc.shutdown()
+
+
+def test_protect_keeps_an_lru_block_a_sweep_would_otherwise_evict(mapper):
+    """The one case the grace window cannot cover.
+
+    A promotion stamps its keys when the scheduler matches them, but the read
+    itself can execute much later -- queued behind other reads on a busy tier.
+    Once the mtime ages past grace_s the sweep would happily unlink the file out
+    from under the in-flight read, so submit_load/submit_store pin the keys.
+    """
+    gc = _make_gc(mapper)
+    try:
+        # All 15 are far outside the grace window, so recency protects nothing.
+        paths = [_write_block(mapper, i, age_s=1000 - i) for i in range(15)]
+
+        # The 3 oldest have reads in flight; they are exactly the blocks the
+        # sweep wants to remove first.
+        gc.protect([_key(0), _key(1), _key(2)])
+
+        freed = gc.sweep()
+
+        # Still frees the full 7 blocks needed to reach the watermark, just
+        # taking the next-oldest unprotected ones instead.
+        assert freed == 7 * _BLOCK_BYTES
+        assert all(os.path.exists(p) for p in paths[:3]), "in-flight blocks unlinked"
+        assert not any(os.path.exists(p) for p in paths[3:10])
+        assert all(os.path.exists(p) for p in paths[10:])
+
+        # Once the jobs finish the blocks become evictable again. Refill past
+        # the cap first: the previous sweep left the tier at its watermark, so
+        # another sweep would legitimately have nothing to do.
+        gc.release([_key(0), _key(1), _key(2)])
+        for i in range(15, 20):
+            _write_block(mapper, i, age_s=1)
+
+        # 13 blocks over a 10-block cap needs 5 freed, and the released blocks
+        # are still the oldest on disk, so they are now the first to go.
+        assert gc.sweep() == 5 * _BLOCK_BYTES
+        assert not any(os.path.exists(p) for p in paths[:3]), (
+            "still pinned after release"
+        )
+    finally:
+        gc.shutdown()
+
+
+def test_release_is_refcounted(mapper):
+    """Two tiers' jobs can protect the same key; one finishing must not unpin it."""
+    gc = _make_gc(mapper)
+    try:
+        paths = [_write_block(mapper, i, age_s=1000 - i) for i in range(15)]
+
+        gc.protect([_key(0)])
+        gc.protect([_key(0)])
+        gc.release([_key(0)])
+
+        gc.sweep()
+        assert os.path.exists(paths[0]), "unpinned while a job was still in flight"
+    finally:
+        gc.shutdown()
+
+
+def test_touch_stamps_mtime_so_eviction_order_follows_use(mapper):
+    gc = _make_gc(mapper)
+    try:
+        path = _write_block(mapper, 0, age_s=1000)
+        before = os.stat(path).st_mtime
+
+        gc.touch([_key(0)])
+
+        deadline = time.monotonic() + 5.0
+        while os.stat(path).st_mtime == before and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert os.stat(path).st_mtime > before
+    finally:
+        gc.shutdown()
+
+
+def test_touch_rate_limits_repeat_stamps_of_the_same_key(mapper):
+    """touch() arrives once per request per scheduling attempt with every key of
+    the request, so an unthrottled utime per call would be thousands of syscalls
+    per step."""
+    gc = _make_gc(mapper, stamp_interval_s=30.0, grace_s=60.0)
+    try:
+        path = _write_block(mapper, 0, age_s=1000)
+        gc.touch([_key(0)])
+
+        deadline = time.monotonic() + 5.0
+        while os.stat(path).st_mtime < time.time() - 900 and (
+            time.monotonic() < deadline
+        ):
+            time.sleep(0.01)
+        stamped = os.stat(path).st_mtime
+
+        # Backdate the file, then touch again well inside stamp_interval_s: the
+        # second touch must be dropped, leaving the backdated mtime in place.
+        old = time.time() - 1000
+        os.utime(path, (old, old))
+        gc.touch([_key(0)])
+        time.sleep(0.5)
+
+        assert os.stat(path).st_mtime == pytest.approx(old)
+        assert stamped > old
+    finally:
+        gc.shutdown()
+
+
+def test_touch_tolerates_keys_with_no_file(mapper):
+    """A block can live only in the DRAM primary tier, or its cascade to disk
+    can have failed; neither is an error."""
+    gc = _make_gc(mapper)
+    try:
+        gc.touch([_key(0), _key(1)])
+        time.sleep(0.2)
+        assert gc.sweep() == 0
+    finally:
+        gc.shutdown()
+
+
+def test_sweep_ignores_non_block_files(mapper):
+    """store_block writes <dest>.tmp before os.replace, and config.json must
+    survive; only .bin files are eviction candidates."""
+    gc = _make_gc(mapper, max_bytes=_BLOCK_BYTES)
+    try:
+        paths = [_write_block(mapper, i, age_s=1000 - i) for i in range(4)]
+        tmp_path = paths[0] + ".tmp"
+        with open(tmp_path, "wb") as f:
+            f.write(b"\0" * _BLOCK_BYTES)
+        stamp = time.time() - 2000
+        os.utime(tmp_path, (stamp, stamp))
+
+        gc.sweep()
+
+        assert os.path.exists(tmp_path), "in-progress store was unlinked"
+    finally:
+        gc.shutdown()

--- a/tests/v1/kv_offload/tiering/test_fs_tier.py
+++ b/tests/v1/kv_offload/tiering/test_fs_tier.py
@@ -298,6 +298,45 @@ def test_failed_load_missing_file(fs_tier):
     assert not results[0].success
 
 
+def test_failed_load_invalidates_cached_lookup(fs_tier):
+    """A block that vanished must not stay cached as a hit.
+
+    The cached existence result is what routes a promotion to this tier, and
+    nothing else clears it until every request that looked the key up has
+    finished. If a failed load left it cached as present, the scheduler would
+    re-submit the same failing promotion on every step and the request waiting
+    for those tokens would never finish, so the entry would never be cleaned
+    up either -- a livelock rather than a recompute.
+    """
+    tier, _ = fs_tier
+    tier.submit_store(make_job(1, [key(1)], [0]))
+    assert all(r.success for r in drain(tier))
+    assert lookup_and_wait(tier, [key(1)]) == [LookupResult.HIT]
+
+    # Removed behind the tier's back: by capacity management, by another
+    # instance sharing root_dir, or by any external cleanup.
+    os.unlink(tier.file_mapper.get_file_name(key(1)))
+
+    tier.submit_load(make_job(2, [key(1)], [0], is_promotion=True))
+    results = drain(tier)
+    assert not results[0].success
+
+    assert tier.lookup(key(1), _CTX) == LookupResult.MISS
+
+
+def test_successful_load_keeps_cached_lookup(fs_tier):
+    """The invalidation above must be scoped to failures."""
+    tier, _ = fs_tier
+    tier.submit_store(make_job(1, [key(1)], [0]))
+    assert all(r.success for r in drain(tier))
+    assert lookup_and_wait(tier, [key(1)]) == [LookupResult.HIT]
+
+    tier.submit_load(make_job(2, [key(1)], [0], is_promotion=True))
+    assert all(r.success for r in drain(tier))
+
+    assert tier.lookup(key(1), _CTX) == LookupResult.HIT
+
+
 def test_multiple_jobs_tracked_independently(fs_tier):
     tier, _ = fs_tier
     job1 = make_job(1, [key(1)], [0])

--- a/tests/v1/kv_offload/tiering/test_fs_tier.py
+++ b/tests/v1/kv_offload/tiering/test_fs_tier.py
@@ -324,6 +324,34 @@ def test_failed_load_invalidates_cached_lookup(fs_tier):
     assert tier.lookup(key(1), _CTX) == LookupResult.MISS
 
 
+def test_successful_restore_revalidates_cached_lookup(fs_tier):
+    """A recomputed block must become visible before active requests finish.
+
+    Continuous overlapping requests can keep the shared lookup state alive, so
+    cleanup is not a sufficient way to recover from a failed load's cached
+    MISS. A successful store is the authoritative signal that the block exists
+    again.
+    """
+    tier, _ = fs_tier
+    block_key = key(1)
+    tier.submit_store(make_job(1, [block_key], [0]))
+    assert all(r.success for r in drain(tier))
+    assert lookup_and_wait(tier, [block_key]) == [LookupResult.HIT]
+
+    os.unlink(tier.file_mapper.get_file_name(block_key))
+    tier.submit_load(make_job(2, [block_key], [0], is_promotion=True))
+    assert not drain(tier)[0].success
+    assert tier.lookup(block_key, _CTX) == LookupResult.MISS
+
+    overlapping_ctx = ReqContext(req_id="overlapping-request")
+    assert tier.lookup(block_key, overlapping_ctx) == LookupResult.MISS
+
+    tier.submit_store(make_job(3, [block_key], [0]))
+    assert all(r.success for r in drain(tier))
+    assert tier.lookup(block_key, _CTX) == LookupResult.HIT
+    assert tier.lookup(block_key, overlapping_ctx) == LookupResult.HIT
+
+
 def test_successful_load_keeps_cached_lookup(fs_tier):
     """The invalidation above must be scoped to failures."""
     tier, _ = fs_tier

--- a/tests/v1/kv_offload/tiering/test_obj_tier.py
+++ b/tests/v1/kv_offload/tiering/test_obj_tier.py
@@ -437,6 +437,62 @@ class TestMockObjTierFailures:
         assert not by_id[1].success
         assert by_id[2].success
 
+    def test_failed_load_invalidates_cached_lookup(self):
+        """An object that vanished must not stay cached as a hit.
+
+        The cached existence result is what routes a promotion to this tier,
+        and nothing else clears it until every request that looked the key up
+        has finished. If a failed load left it cached as present, the
+        scheduler would re-submit the same failing promotion on every step and
+        the request waiting for those tokens would never finish, so the entry
+        would never be cleaned up either -- a livelock rather than a
+        recompute.
+        """
+        tier, agent = _make_tier(num_blocks=4)
+        tier.submit_store(make_job(1, [key(1)], [0]))
+        assert all(r.success for r in drain(tier))
+        assert lookup_and_wait(tier, [key(1)]) == [LookupResult.HIT]
+
+        # Removed behind the tier's back: a bucket lifecycle rule, another
+        # instance sharing the bucket, or any external cleanup. The probe hit
+        # is now stale and the read against it fails.
+        agent._stored_obj_keys.clear()
+        agent.check_xfer_state = lambda h: "ERR"
+
+        tier.submit_load(make_job(2, [key(1)], [0]))
+        results = drain(tier)
+        assert not results[0].success
+
+        assert tier.lookup(key(1), _CTX) == LookupResult.MISS
+
+    def test_submission_time_load_failure_invalidates_cached_lookup(self):
+        """Loads that die before the transfer starts must invalidate too;
+        re-submitting them against the same cached hit is the same livelock."""
+        tier, agent = _make_tier(num_blocks=4)
+        tier.submit_store(make_job(1, [key(1)], [0]))
+        assert all(r.success for r in drain(tier))
+        assert lookup_and_wait(tier, [key(1)]) == [LookupResult.HIT]
+
+        agent.register_memory = lambda *a, **k: None
+        tier.submit_load(make_job(2, [key(1)], [0]))
+        results = list(tier.get_finished_jobs())
+        assert len(results) == 1
+        assert not results[0].success
+
+        assert tier.lookup(key(1), _CTX) == LookupResult.MISS
+
+    def test_successful_load_keeps_cached_lookup(self):
+        """The invalidation above must be scoped to failures."""
+        tier, _ = _make_tier(num_blocks=4)
+        tier.submit_store(make_job(1, [key(1)], [0]))
+        assert all(r.success for r in drain(tier))
+        assert lookup_and_wait(tier, [key(1)]) == [LookupResult.HIT]
+
+        tier.submit_load(make_job(2, [key(1)], [0]))
+        assert all(r.success for r in drain(tier))
+
+        assert tier.lookup(key(1), _CTX) == LookupResult.HIT
+
 
 class TestMockObjTierShutdown:
     def test_shutdown_clears_in_flight_transfers(self):

--- a/tests/v1/kv_offload/tiering/test_obj_tier.py
+++ b/tests/v1/kv_offload/tiering/test_obj_tier.py
@@ -465,6 +465,30 @@ class TestMockObjTierFailures:
 
         assert tier.lookup(key(1), _CTX) == LookupResult.MISS
 
+    def test_successful_restore_revalidates_cached_lookup(self):
+        """A successful rewrite supersedes a failed load's cached MISS."""
+        tier, agent = _make_tier(num_blocks=4)
+        block_key = key(1)
+        tier.submit_store(make_job(1, [block_key], [0]))
+        assert all(r.success for r in drain(tier))
+        assert lookup_and_wait(tier, [block_key]) == [LookupResult.HIT]
+
+        agent._stored_obj_keys.clear()
+        original_check_xfer_state = agent.check_xfer_state
+        agent.check_xfer_state = lambda h: "ERR"
+        tier.submit_load(make_job(2, [block_key], [0]))
+        assert not drain(tier)[0].success
+        assert tier.lookup(block_key, _CTX) == LookupResult.MISS
+
+        overlapping_ctx = ReqContext(req_id="overlapping-request")
+        assert tier.lookup(block_key, overlapping_ctx) == LookupResult.MISS
+
+        agent.check_xfer_state = original_check_xfer_state
+        tier.submit_store(make_job(3, [block_key], [0]))
+        assert all(r.success for r in drain(tier))
+        assert tier.lookup(block_key, _CTX) == LookupResult.HIT
+        assert tier.lookup(block_key, overlapping_ctx) == LookupResult.HIT
+
     def test_submission_time_load_failure_invalidates_cached_lookup(self):
         """Loads that die before the transfer starts must invalidate too;
         re-submitting them against the same cached hit is the same livelock."""

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -458,7 +458,10 @@ class OffloadingConnectorScheduler:
         return job_id
 
     def _remove_pending_job(self, job_id: int, block_ids: list[int] | None) -> None:
-        for bid in block_ids or ():
+        # Lockstep MLA groups share physical block IDs, so a transfer job may
+        # contain the same ID once per logical group. The pending-job index is
+        # set-backed and therefore registers each (block, job) pair only once.
+        for bid in set(block_ids or ()):
             pending = self._block_id_to_pending_jobs[bid]
             pending.remove(job_id)
             if not pending:

--- a/vllm/v1/kv_offload/tiering/async_lookup.py
+++ b/vllm/v1/kv_offload/tiering/async_lookup.py
@@ -172,6 +172,33 @@ class AsyncLookupManager(ABC):
                 if state is not None:
                     state.result = result
 
+    def invalidate(self, keys: Iterable[OffloadKey]) -> None:
+        """Mark keys as absent so the next lookup() stops reporting a hit.
+
+        A cached ``True`` is only a snapshot of the tier at the time of the
+        existence check; the block can disappear afterwards (evicted by this
+        instance's own capacity management, by another instance sharing
+        ``root_dir``, or by any external cleanup). Nothing else clears the
+        entry until every request that looked the key up has finished, so a
+        transfer that fails on a vanished block would otherwise be retried
+        against the same stale ``True`` on every subsequent step, and the
+        request that is waiting for it never finishes -- a livelock, with the
+        failing job re-submitted forever.
+
+        ``False`` rather than ``None``: a fresh lookup is only ever queued for a
+        key with no state at all, so ``None`` would make lookup() report RETRY
+        forever instead of recomputing. Whether absence is also literally true
+        depends on the tier -- the fs tier's ``load_block`` unlinks any file it
+        could not read, while a failed object-store read leaves the object in
+        place -- but a pessimistic ``False`` is always safe: it costs at most a
+        recompute, and it expires with the requests that looked the key up,
+        after which a fresh existence check can hit again.
+        """
+        for key in keys:
+            state = self._lookup_state.get(key)
+            if state is not None:
+                state.result = False
+
     def cleanup(self, req_id: str) -> None:
         """Remove entries no longer needed by any active request.
 

--- a/vllm/v1/kv_offload/tiering/async_lookup.py
+++ b/vllm/v1/kv_offload/tiering/async_lookup.py
@@ -199,6 +199,20 @@ class AsyncLookupManager(ABC):
             if state is not None:
                 state.result = False
 
+    def mark_present(self, keys: Iterable[OffloadKey]) -> None:
+        """Refresh cached states after an authoritative successful store.
+
+        A failed load marks an entry absent so the request can recompute it.
+        Overlapping requests may keep that shared state alive after the
+        recomputed block has been stored again, so waiting for cleanup would
+        leave a stale miss until all of them finish. Only update existing
+        states; a key nobody has looked up does not need a cache entry.
+        """
+        for key in keys:
+            state = self._lookup_state.get(key)
+            if state is not None:
+                state.result = True
+
     def cleanup(self, req_id: str) -> None:
         """Remove entries no longer needed by any active request.
 

--- a/vllm/v1/kv_offload/tiering/fs/gc_manager.py
+++ b/vllm/v1/kv_offload/tiering/fs/gc_manager.py
@@ -1,0 +1,324 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Garbage collection for the fs secondary tier.
+
+The fs tier keeps no index of its own -- the filesystem *is* the index, since
+`lookup()` is a plain existence check -- so out of the box it has neither a
+capacity limit nor eviction, and grows until the filesystem fills.
+
+`FsGCManager` adds both, using file mtime as the single source of truth for
+recency:
+
+  - `touch()` stamps mtime when the scheduler marks a block recently used.
+    `TieringOffloadingManager` calls this on every secondary tier, including
+    for blocks served from the DRAM primary tier -- which never read this
+    tier's files and would otherwise age out while still hot. Reads cannot
+    supply this signal on their own: `store_block` sets mtime once at write
+    time, reads never update file metadata, and `load_block` opens O_DIRECT so
+    a read need not touch the device at all.
+  - A background sweep walks the tree, and when the total exceeds `max_bytes`
+    unlinks in mtime order until it is back under the low watermark.
+
+Keeping recency on disk rather than in a private dict means the ordering
+survives a restart (the fs tier's contents are reusable across runs when
+PYTHONHASHSEED is pinned), the accounting cannot drift from reality since every
+sweep re-measures it, and external tooling (`du`, `find -newermt`, a separate
+reaper) sees the same truth.
+
+Both `touch()` and the sweep run off the scheduler thread. `touch()` is called
+once per request per scheduling attempt with *all* of the request's offload keys
+(~1.9k keys for a 200k-token context), so stamping inline would cost
+milliseconds of syscalls per call and dirty thousands of inodes; instead a key
+is stamped at most once per `stamp_interval_s` and the `os.utime` calls happen
+on a daemon thread.
+
+Deleting a file that a promotion is about to read is not a correctness problem
+-- the failed promotion frees the DRAM block and the tokens get recomputed --
+but it wastes work and silently drops the block from disk, so the sweep protects
+any key with an in-flight job (`protect`/`release`) and any file whose mtime is
+within `grace_s`. Because `stamp_interval_s < grace_s`, every key used within
+`grace_s - stamp_interval_s` is guaranteed to have a protected mtime. That
+margin is eroded by clock skew wherever mtimes are not set by this host's
+clock -- on NFS or a network PVC the server stamps them while the sweep cutoff
+comes from local `time.time()` -- so on shared storage keep it well above the
+sweep duration rather than tightening the two intervals toward each other.
+
+Known limitation: sweeps do not emit KV events. When the owning tier publishes
+BlockStored events (enable_kv_events), a sweep's unlinks have no removed=True
+counterpart, so an external consumer of the event stream can believe evicted
+blocks still exist. Emitting removals would require reconstructing OffloadKeys
+from the swept paths and handing them across threads to the scheduler-owned
+events list -- and the stream would still be incomplete, because failed-load
+unlinks, peer instances sharing root_dir, and external reapers also remove
+files without events. MEDIUM_FS presence events are best-effort by design;
+consumers must tolerate a BlockStored block that is no longer there. This
+instance's own scheduler already does: a failed load invalidates its cached
+lookup and the tokens are recomputed.
+"""
+
+import os
+import threading
+import time
+from collections import OrderedDict
+from collections.abc import Collection, Iterator
+
+from vllm.logger import init_logger
+from vllm.v1.kv_offload.base import OffloadKey
+from vllm.v1.kv_offload.file_mapper import FileMapper
+
+logger = init_logger(__name__)
+
+# Bound the wait so shutdown() stays responsive when no work arrives.
+_WAKE_TIMEOUT_S = 1.0
+
+# Only block files are candidates. In particular `store_block` writes to
+# "<dest>.tmp" before os.replace, and config.json must never be removed. A
+# writer killed mid-store therefore leaks a .tmp that no sweep counts or
+# reaps; the window is one block write wide, so this is bounded in practice.
+_BLOCK_SUFFIX = ".bin"
+
+
+class FsGCManager:
+    """Bounds the fs tier's on-disk size, evicting least-recently-used blocks."""
+
+    def __init__(
+        self,
+        file_mapper: FileMapper,
+        max_bytes: int,
+        low_watermark: float = 0.9,
+        interval_s: float = 60.0,
+        stamp_interval_s: float = 60.0,
+        grace_s: float = 300.0,
+        max_tracked: int = 200_000,
+    ) -> None:
+        if not 0.0 < low_watermark <= 1.0:
+            raise ValueError(f"low_watermark must be in (0, 1], got {low_watermark}")
+        if grace_s <= stamp_interval_s:
+            raise ValueError(
+                f"grace_s ({grace_s}) must exceed stamp_interval_s "
+                f"({stamp_interval_s}), otherwise a block in active use can "
+                f"have an mtime old enough to be swept"
+            )
+
+        self.file_mapper = file_mapper
+        self.max_bytes = max_bytes
+        self.target_bytes = int(max_bytes * low_watermark)
+        self.interval_s = interval_s
+        self.stamp_interval_s = stamp_interval_s
+        self.grace_s = grace_s
+        self.max_tracked = max_tracked
+
+        # Blocks live under a per-rank sibling of the digest directory.
+        self.block_root = f"{file_mapper.base_path}_r{file_mapper.rank}"
+
+        # key -> monotonic time of last stamp, in LRU order so it can be
+        # trimmed. Losing an entry only costs one redundant utime later.
+        self._last_stamped: OrderedDict[OffloadKey, float] = OrderedDict()
+        # Dedup set of keys awaiting a stamp; dict preserves insertion order.
+        self._pending_stamps: dict[OffloadKey, None] = {}
+        # Keys with in-flight store/load jobs, which must not be unlinked.
+        self._protected: dict[OffloadKey, int] = {}
+
+        self._lock = threading.Lock()
+        self._wake = threading.Event()
+        self._stopping = False
+        self._stamped = 0
+        self._stamp_errors = 0
+
+        self._thread = threading.Thread(
+            target=self._run, name="vllm_kv_fs_gc", daemon=True
+        )
+        self._thread.start()
+        logger.info(
+            "fs tier GC enabled: cap %.1f GiB, sweeping to %.1f GiB every %gs "
+            "(mtime tracks last use, so eviction is LRU and survives restarts)",
+            max_bytes / 2**30,
+            self.target_bytes / 2**30,
+            interval_s,
+        )
+
+    # ------------------------------------------------------------------
+    # Scheduler-thread entry points
+    # ------------------------------------------------------------------
+
+    def touch(self, keys: Collection[OffloadKey]) -> None:
+        """Record keys as recently used. Cheap: one dict lookup per key."""
+        now = time.monotonic()
+        with self._lock:
+            if self._stopping:
+                return
+            for key in keys:
+                last = self._last_stamped.get(key)
+                if last is not None and now - last < self.stamp_interval_s:
+                    continue
+                self._last_stamped[key] = now
+                self._last_stamped.move_to_end(key)
+                self._pending_stamps[key] = None
+            while len(self._last_stamped) > self.max_tracked:
+                self._last_stamped.popitem(last=False)
+            has_work = bool(self._pending_stamps)
+        if has_work:
+            self._wake.set()
+
+    def protect(self, keys: Collection[OffloadKey]) -> None:
+        """Pin keys with an in-flight job so the sweep cannot unlink them."""
+        with self._lock:
+            for key in keys:
+                self._protected[key] = self._protected.get(key, 0) + 1
+
+    def release(self, keys: Collection[OffloadKey]) -> None:
+        """Undo one `protect` for each key."""
+        with self._lock:
+            for key in keys:
+                count = self._protected.get(key)
+                if count is None:
+                    continue
+                if count <= 1:
+                    del self._protected[key]
+                else:
+                    self._protected[key] = count - 1
+
+    # ------------------------------------------------------------------
+    # Background thread
+    # ------------------------------------------------------------------
+
+    def _run(self) -> None:
+        next_sweep = time.monotonic() + self.interval_s
+        while True:
+            self._wake.wait(_WAKE_TIMEOUT_S)
+            self._wake.clear()
+
+            with self._lock:
+                stopping = self._stopping
+                batch = list(self._pending_stamps)
+                self._pending_stamps.clear()
+            try:
+                self._stamp(batch)
+            except Exception:
+                # _stamp handles the expected per-key OSError itself; anything
+                # else escaping here would kill this daemon thread and
+                # silently un-bound the tier again, with no signal beyond the
+                # absence of sweep logs.
+                logger.exception("fs tier GC stamping failed")
+
+            if stopping:
+                return
+            now = time.monotonic()
+            if now >= next_sweep:
+                next_sweep = now + self.interval_s
+                try:
+                    self.sweep()
+                except Exception:
+                    logger.exception("fs tier GC sweep failed")
+
+    def _stamp(self, keys: list[OffloadKey]) -> None:
+        for key in keys:
+            # A key legitimately may have no file: the block can live only in
+            # the DRAM primary tier, or its cascade may have failed.
+            try:
+                os.utime(self.file_mapper.get_file_name(key), None)
+                self._stamped += 1
+            except OSError:
+                self._stamp_errors += 1
+
+    def _iter_blocks(self, path: str) -> Iterator[tuple[str, int, float]]:
+        """Yield (path, size, mtime) for every block file under `path`."""
+        try:
+            entries = list(os.scandir(path))
+        except FileNotFoundError:
+            return
+        for entry in entries:
+            try:
+                if entry.is_dir(follow_symlinks=False):
+                    yield from self._iter_blocks(entry.path)
+                elif entry.name.endswith(_BLOCK_SUFFIX):
+                    stat = entry.stat(follow_symlinks=False)
+                    yield entry.path, stat.st_size, stat.st_mtime
+            except OSError:
+                # Raced with a store or another sweep; skip it.
+                continue
+
+    def sweep(self) -> int:
+        """Unlink LRU blocks until under the low watermark. Returns bytes freed."""
+        started = time.monotonic()
+        blocks = list(self._iter_blocks(self.block_root))
+        total = sum(size for _, size, _ in blocks)
+        if total <= self.max_bytes:
+            logger.debug(
+                "fs tier GC: %.2f GiB in %d blocks, under the %.2f GiB cap",
+                total / 2**30,
+                len(blocks),
+                self.max_bytes / 2**30,
+            )
+            return 0
+
+        with self._lock:
+            protected_paths = {
+                self.file_mapper.get_file_name(key) for key in self._protected
+            }
+        cutoff = time.time() - self.grace_s
+
+        blocks.sort(key=lambda block: block[2])
+        freed = 0
+        removed = 0
+        in_flight = 0
+        within_grace = 0
+        for path, size, mtime in blocks:
+            if total - freed <= self.target_bytes:
+                break
+            # Check protection before recency: a block with an in-flight job must
+            # survive however old its mtime is, and the two reasons are worth
+            # telling apart. in_flight > 0 means the grace window alone was not
+            # enough and protect() is doing real work; within_grace > 0 means the
+            # working set itself is at least as large as the cap.
+            if path in protected_paths:
+                in_flight += 1
+                continue
+            if mtime > cutoff:
+                within_grace += 1
+                continue
+            try:
+                os.unlink(path)
+            except OSError:
+                continue
+            freed += size
+            removed += 1
+
+        logger.info(
+            "fs tier GC: %.2f GiB over the %.2f GiB cap, freed %.2f GiB in %d "
+            "blocks, kept %d with jobs in flight and %d used within the %gs "
+            "grace window, now %.2f GiB, took %.2fs",
+            total / 2**30,
+            self.max_bytes / 2**30,
+            freed / 2**30,
+            removed,
+            in_flight,
+            within_grace,
+            self.grace_s,
+            (total - freed) / 2**30,
+            time.monotonic() - started,
+        )
+        return freed
+
+    def shutdown(self) -> None:
+        """Stop the sweep thread. Best-effort, and nothing depends on it.
+
+        The engine reaches this through scheduler -> connector -> tier only if
+        it gets that far: EngineCore.shutdown() tears the executor down first,
+        and the API server's SIGTERM path force-kills the engine core with
+        timeout=0s, so in practice this often does not run at all. That is
+        safe -- the thread is a daemon, mtimes are already committed on disk
+        and sweeps are idempotent -- but it means queued stamps can be dropped
+        (costing at most `stamp_interval_s` of recency) and the summary below
+        should not be relied on as a shutdown signal.
+        """
+        with self._lock:
+            self._stopping = True
+        self._wake.set()
+        self._thread.join(timeout=5.0)
+        logger.info(
+            "fs tier GC stopped (%d mtime stamps, %d failed)",
+            self._stamped,
+            self._stamp_errors,
+        )

--- a/vllm/v1/kv_offload/tiering/fs/manager.py
+++ b/vllm/v1/kv_offload/tiering/fs/manager.py
@@ -171,7 +171,8 @@ class FileSystemTierManager(SecondaryTierManager):
                     "emit events.",
                     tier_type,
                 )
-        # Keys of in-flight store jobs, tracked only when events are enabled.
+        # Keys of in-flight stores, used to refresh lookup state on success and
+        # to emit events when enabled.
         self._store_job_keys: dict[JobId, list[OffloadKey]] = {}
 
         # Extract block size from primary view
@@ -235,8 +236,7 @@ class FileSystemTierManager(SecondaryTierManager):
 
     @override
     def submit_store(self, job_metadata: JobMetadata) -> None:
-        if self.events is not None:
-            self._store_job_keys[job_metadata.job_id] = list(job_metadata.keys)
+        self._store_job_keys[job_metadata.job_id] = list(job_metadata.keys)
         self._gc_protect(job_metadata)
         tasks = (
             functools.partial(
@@ -285,12 +285,13 @@ class FileSystemTierManager(SecondaryTierManager):
                 # the tokens are recomputed; leaving them cached as present
                 # would re-submit this same failing load on every step.
                 self._lookup_manager.invalidate(load_keys)
-            if self.events is not None:
-                keys = self._store_job_keys.pop(job_id, None)
-                if success and keys:
+            store_keys = self._store_job_keys.pop(job_id, None)
+            if success and store_keys:
+                self._lookup_manager.mark_present(store_keys)
+                if self.events is not None:
                     self.events.append(
                         OffloadingEvent(
-                            keys=keys,
+                            keys=store_keys,
                             medium=self.medium,
                             removed=False,
                             locality=self.locality,

--- a/vllm/v1/kv_offload/tiering/fs/manager.py
+++ b/vllm/v1/kv_offload/tiering/fs/manager.py
@@ -176,6 +176,10 @@ class FileSystemTierManager(SecondaryTierManager):
 
         self._lookup_manager = FsAsyncLookupManager(tier=self, tier_type=self.tier_type)
 
+        # Keys of in-flight load jobs, so a failed load can invalidate the
+        # cached existence results that sent it here.
+        self._load_job_keys: dict[JobId, list[OffloadKey]] = {}
+
     @override
     def on_new_request(self, req_context: ReqContext) -> RequestOffloadingContext:
         return RequestOffloadingContext()
@@ -205,6 +209,7 @@ class FileSystemTierManager(SecondaryTierManager):
 
     @override
     def submit_load(self, job_metadata: JobMetadata) -> None:
+        self._load_job_keys[job_metadata.job_id] = list(job_metadata.keys)
         tasks = (
             functools.partial(
                 load_block,
@@ -224,6 +229,14 @@ class FileSystemTierManager(SecondaryTierManager):
         """
         results = []
         for job_id, success in self._pool.get_finished():
+            load_keys = self._load_job_keys.pop(job_id, None)
+            if load_keys is not None and not success:
+                # The blocks this load needed are gone or unreadable, and
+                # load_block has unlinked whatever it could not read. Drop the
+                # cached existence results so the next lookup reports a miss and
+                # the tokens are recomputed; leaving them cached as present
+                # would re-submit this same failing load on every step.
+                self._lookup_manager.invalidate(load_keys)
             if self.events is not None:
                 keys = self._store_job_keys.pop(job_id, None)
                 if success and keys:

--- a/vllm/v1/kv_offload/tiering/fs/manager.py
+++ b/vllm/v1/kv_offload/tiering/fs/manager.py
@@ -18,7 +18,7 @@ File naming:  <base_path>_r<rank>/<hhh>/<hh>_g<group_idx>/<hash_hex>.bin
 import functools
 import json
 import os
-from collections.abc import Iterable
+from collections.abc import Collection, Iterable
 from typing import TYPE_CHECKING, ClassVar
 
 try:
@@ -49,6 +49,7 @@ from vllm.v1.kv_offload.tiering.base import (
     ScheduleEndContext,
     SecondaryTierManager,
 )
+from vllm.v1.kv_offload.tiering.fs.gc_manager import FsGCManager
 from vllm.v1.kv_offload.tiering.fs.io import load_block, store_block
 from vllm.v1.kv_offload.tiering.fs.thread_pool import DualQueueThreadPool
 
@@ -112,6 +113,12 @@ class FileSystemTierManager(SecondaryTierManager):
         n_write_threads: int = 16,
         enable_kv_events: bool = False,
         locality: str | None = None,
+        gc_max_size_gb: float | None = None,
+        gc_low_watermark: float = 0.9,
+        gc_interval_s: float = 60.0,
+        gc_stamp_interval_s: float = 60.0,
+        gc_grace_s: float = 300.0,
+        gc_max_tracked: int = 200_000,
     ):
         """
         Args:
@@ -127,6 +134,28 @@ class FileSystemTierManager(SecondaryTierManager):
                 cache events are enabled globally (kv_events_config).
             locality: Whether this tier's storage is LOCAL or REMOTE relative
                 to the publishing vLLM instance.
+            gc_max_size_gb: On-disk budget for this tier, in GiB. None (the
+                default) leaves the tier unbounded, as before. When set, a
+                background sweep evicts least-recently-used blocks to stay under
+                it; see FsGCManager. The budget is per engine rather than per
+                rank: the tier is constructed once on the scheduler side
+                (get_manager), so TP and PP ranks share a single
+                <base_path>_r<rank> subtree and a single budget. Engines sharing
+                a root_dir enforce the budget independently over the same
+                subtree and so evict each other's blocks, and blocks written
+                under a different layout fingerprint (a different <base_path>)
+                are never swept at all. Note that sweeps emit no removed=True KV
+                events (see FsGCManager for why), so with enable_kv_events an
+                external consumer must treat BlockStored as best-effort.
+            gc_low_watermark: Fraction of gc_max_size_gb a sweep evicts down to,
+                so eviction is batched rather than continuous.
+            gc_interval_s: Seconds between sweeps.
+            gc_stamp_interval_s: Minimum seconds between mtime stamps of the
+                same block. Must be less than gc_grace_s.
+            gc_grace_s: Blocks used within this many seconds are never swept,
+                which keeps a sweep from racing a promotion that is about to
+                read the file.
+            gc_max_tracked: Cap on keys tracked for the stamp rate limit.
         """
         super().__init__(offloading_spec, primary_kv_view, tier_type)
         self.locality = Locality(locality) if locality is not None else None
@@ -180,6 +209,19 @@ class FileSystemTierManager(SecondaryTierManager):
         # cached existence results that sent it here.
         self._load_job_keys: dict[JobId, list[OffloadKey]] = {}
 
+        self._gc_manager: FsGCManager | None = None
+        self._gc_job_keys: dict[JobId, list[OffloadKey]] = {}
+        if gc_max_size_gb is not None:
+            self._gc_manager = FsGCManager(
+                self.file_mapper,
+                max_bytes=int(gc_max_size_gb * 2**30),
+                low_watermark=gc_low_watermark,
+                interval_s=gc_interval_s,
+                stamp_interval_s=gc_stamp_interval_s,
+                grace_s=gc_grace_s,
+                max_tracked=gc_max_tracked,
+            )
+
     @override
     def on_new_request(self, req_context: ReqContext) -> RequestOffloadingContext:
         return RequestOffloadingContext()
@@ -195,6 +237,7 @@ class FileSystemTierManager(SecondaryTierManager):
     def submit_store(self, job_metadata: JobMetadata) -> None:
         if self.events is not None:
             self._store_job_keys[job_metadata.job_id] = list(job_metadata.keys)
+        self._gc_protect(job_metadata)
         tasks = (
             functools.partial(
                 store_block,
@@ -209,6 +252,7 @@ class FileSystemTierManager(SecondaryTierManager):
 
     @override
     def submit_load(self, job_metadata: JobMetadata) -> None:
+        self._gc_protect(job_metadata)
         self._load_job_keys[job_metadata.job_id] = list(job_metadata.keys)
         tasks = (
             functools.partial(
@@ -229,6 +273,10 @@ class FileSystemTierManager(SecondaryTierManager):
         """
         results = []
         for job_id, success in self._pool.get_finished():
+            if self._gc_manager is not None:
+                keys = self._gc_job_keys.pop(job_id, None)
+                if keys is not None:
+                    self._gc_manager.release(keys)
             load_keys = self._load_job_keys.pop(job_id, None)
             if load_keys is not None and not success:
                 # The blocks this load needed are gone or unreadable, and
@@ -270,6 +318,26 @@ class FileSystemTierManager(SecondaryTierManager):
         self._lookup_manager.flush()
 
     @override
+    def touch(self, keys: Collection[OffloadKey], req_context: ReqContext) -> None:
+        """Refresh on-disk recency so GC evicts least-recently-used blocks.
+
+        Called by TieringOffloadingManager for every tier whenever the scheduler
+        matches a request's blocks -- including blocks served from the DRAM
+        primary tier, which never read this tier's files and would otherwise age
+        out while still hot. No-op unless a GC budget is configured.
+        """
+        if self._gc_manager is not None:
+            self._gc_manager.touch(keys)
+
+    def _gc_protect(self, job_metadata: JobMetadata) -> None:
+        """Pin a job's keys for as long as its transfers are in flight."""
+        if self._gc_manager is None:
+            return
+        keys = list(job_metadata.keys)
+        self._gc_job_keys[job_metadata.job_id] = keys
+        self._gc_manager.protect(keys)
+
+    @override
     def shutdown(self) -> None:
         """
         Release resources held by this tier.
@@ -277,5 +345,7 @@ class FileSystemTierManager(SecondaryTierManager):
         Shuts down the lookup manager and the thread pool,
         clearing pending tasks and waiting for active threads to complete.
         """
+        if self._gc_manager is not None:
+            self._gc_manager.shutdown()
         self._lookup_manager.shutdown()
         self._pool.shutdown(wait=True)

--- a/vllm/v1/kv_offload/tiering/obj/manager.py
+++ b/vllm/v1/kv_offload/tiering/obj/manager.py
@@ -141,6 +141,9 @@ class ObjectStoreSecondaryTierManager(SecondaryTierManager):
                 )
         # Keys of in-flight store jobs, tracked only when events are enabled.
         self._store_job_keys: dict[JobId, list[OffloadKey]] = {}
+        # Keys of in-flight load jobs, so a failed load can invalidate the
+        # cached existence results that sent it here.
+        self._load_job_keys: dict[JobId, list[OffloadKey]] = {}
 
         agent_config = nixl_agent_config(backends=[])
         self._agent = nixl_agent("ObjAgent", agent_config)
@@ -281,6 +284,11 @@ class ObjectStoreSecondaryTierManager(SecondaryTierManager):
         )
 
     def submit_load(self, job_metadata: JobMetadata) -> None:
+        # Recorded before _submit_transfer so its submission-time failure
+        # paths (register_memory, prep_xfer_dlist, make_prepped_xfer,
+        # transfer) also invalidate the cached lookups that routed this
+        # load here, not just transfers that fail in flight.
+        self._load_job_keys[job_metadata.job_id] = list(job_metadata.keys)
         obj_keys = (self._file_mapper.get_file_name(k) for k in job_metadata.keys)
         self._submit_transfer(
             job_metadata.job_id, job_metadata.block_ids, obj_keys, NIXL_READ
@@ -323,8 +331,20 @@ class ObjectStoreSecondaryTierManager(SecondaryTierManager):
         self._poll_active_transfers()
         results = self._pending_results
         self._pending_results = []
-        if self.events is not None:
-            for result in results:
+        for result in results:
+            load_keys = self._load_job_keys.pop(result.job_id, None)
+            if load_keys is not None and not result.success:
+                # The store no longer answers for these keys (vanished object
+                # or persistently failing read). Drop the cached existence
+                # results so the next lookup reports a miss and the tokens are
+                # recomputed; leaving them cached as present would re-submit
+                # this same failing load on every step. Unlike the fs tier's
+                # load_block, a failed read does not remove the object, so
+                # this can be pessimistic -- but only until the requests that
+                # looked the keys up finish, after which a fresh existence
+                # probe can hit again.
+                self._lookup_manager.invalidate(load_keys)
+            if self.events is not None:
                 keys = self._store_job_keys.pop(result.job_id, None)
                 if result.success and keys:
                     self.events.append(

--- a/vllm/v1/kv_offload/tiering/obj/manager.py
+++ b/vllm/v1/kv_offload/tiering/obj/manager.py
@@ -139,7 +139,8 @@ class ObjectStoreSecondaryTierManager(SecondaryTierManager):
                     "emit events.",
                     tier_type,
                 )
-        # Keys of in-flight store jobs, tracked only when events are enabled.
+        # Keys of in-flight stores, used to refresh lookup state on success and
+        # to emit events when enabled.
         self._store_job_keys: dict[JobId, list[OffloadKey]] = {}
         # Keys of in-flight load jobs, so a failed load can invalidate the
         # cached existence results that sent it here.
@@ -276,8 +277,7 @@ class ObjectStoreSecondaryTierManager(SecondaryTierManager):
         return LookupResult.HIT if result else LookupResult.MISS
 
     def submit_store(self, job_metadata: JobMetadata) -> None:
-        if self.events is not None:
-            self._store_job_keys[job_metadata.job_id] = list(job_metadata.keys)
+        self._store_job_keys[job_metadata.job_id] = list(job_metadata.keys)
         obj_keys = (self._file_mapper.get_file_name(k) for k in job_metadata.keys)
         self._submit_transfer(
             job_metadata.job_id, job_metadata.block_ids, obj_keys, NIXL_WRITE
@@ -344,12 +344,13 @@ class ObjectStoreSecondaryTierManager(SecondaryTierManager):
                 # looked the keys up finish, after which a fresh existence
                 # probe can hit again.
                 self._lookup_manager.invalidate(load_keys)
-            if self.events is not None:
-                keys = self._store_job_keys.pop(result.job_id, None)
-                if result.success and keys:
+            store_keys = self._store_job_keys.pop(result.job_id, None)
+            if result.success and store_keys:
+                self._lookup_manager.mark_present(store_keys)
+                if self.events is not None:
                     self.events.append(
                         OffloadingEvent(
-                            keys=keys,
+                            keys=store_keys,
                             medium=self.medium,
                             removed=False,
                             locality=self.locality,


### PR DESCRIPTION
## Summary

Port the remaining native L2 filesystem-offload fixes from procr1337/vllm#10 and #11 onto the current `dev/gilded-gnosis` branch.

- Invalidate cached secondary-tier hits after a load fails, so a vanished block is recomputed instead of being resubmitted indefinitely.
- Add an opt-in `gc_max_size_gb` limit for the filesystem tier.
- Evict least-recently-used block files by persisted mtime to a configurable low watermark.
- Keep recency stamping and sweeping off the scheduler thread.
- Protect in-flight load/store keys and preserve existing unbounded behavior when no limit is configured.

The two commits remain separate because stale-hit invalidation is the correctness contract that makes filesystem eviction safe. Original authorship is preserved.

## Root Cause

The filesystem tier used file existence as its index but had no capacity management, so an L2 cache could fill the backing filesystem. External deletion or eviction also exposed a lifecycle bug: `AsyncLookupManager` could retain a cached hit after the corresponding file/object disappeared, repeatedly routing the same failed promotion instead of allowing recomputation.

## Configuration

The feature is off by default. Set `gc_max_size_gb` on an `fs` secondary tier to enable it; the low watermark, sweep interval, stamp interval, and grace settings are optional tuning controls.

## Validation

- `284 passed, 2 skipped`: complete `tests/v1/kv_offload/tiering` suite
- `71 passed, 2 skipped`: focused fs/object/GC suite
- Ruff check and format check pass
- `git diff --check` passes
- Existing filesystem-tier tests run without a GC limit and cover the unchanged default path

This replaces the stale release-branch versions of procr1337/vllm#10 and #11. It targets current GG directly and has no dependency on a historical rNN branch.

## Lockstep MLA cleanup

This PR also supersedes #197 while preserving Procr's original commit authorship. Lockstep MLA groups can repeat one physical block ID across logical groups; cleanup now deduplicates those IDs before removing the set-backed pending-job entry. A focused regression test covers duplicate IDs shared by two jobs and fails with the former `KeyError`.

Additional validation: `test_remove_pending_job_deduplicates_lockstep_mla_block_ids` passes in the CUDA 13.2 release environment; Ruff, format, and `git diff --check` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic filesystem-tier garbage collection with configurable capacity, eviction watermarks, recency tracking, grace periods, and protection for in-flight data.
  * Added cache state updates after successful stores and loads.

* **Bug Fixes**
  * Improved cache invalidation after failed filesystem and object-store loads.
  * Prevented duplicate pending-job cleanup for repeated block references.
  * Improved handling of missing files and filesystem cleanup races.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->