### PR TITLE
[GG] Register runtime controls consumed outside vllm.envs

### DIFF
--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -63,6 +63,8 @@ def _clear_unknown_vllm_envs(monkeypatch: pytest.MonkeyPatch) -> None:
         ("VLLM_PCIE_DMA_FP8", "ring", "ring"),
         ("VLLM_CPP_AR_1STAGE_NCCL_CUTOFF", "56KB", "56KB"),
         ("VLLM_CPP_AR_IGNORE_CUTOFF_MAX_ROWS", "4", 4),
+        ("VLLM_USE_B12X_PCIE_DMA", "1", True),
+        ("VLLM_CACHE_DIR", "/cache/vllm", "/cache/vllm"),
     ],
 )
 def test_gilded_gnosis_runtime_envs_are_registered(

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -48,6 +48,51 @@ def test_p2p_side_channel_defaults_and_override(monkeypatch: pytest.MonkeyPatch)
     assert envs.VLLM_P2P_SIDE_CHANNEL_PORT == 5799
 
 
+def _clear_unknown_vllm_envs(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Remove inherited VLLM variables not known by this source tree."""
+    for name in list(os.environ):
+        if name.startswith("VLLM_") and name not in environment_variables:
+            monkeypatch.delenv(name)
+
+
+@pytest.mark.parametrize(
+    ("name", "value", "expected"),
+    [
+        ("VLLM_B12X_MLA_SPEC_DECODE_MAX_Q", "12", 12),
+        ("VLLM_B12X_MLA_SPEC_EXTEND_AS_DECODE", "1", "1"),
+        ("VLLM_PCIE_DMA_FP8", "ring", "ring"),
+        ("VLLM_CPP_AR_1STAGE_NCCL_CUTOFF", "56KB", "56KB"),
+        ("VLLM_CPP_AR_IGNORE_CUTOFF_MAX_ROWS", "4", 4),
+    ],
+)
+def test_gilded_gnosis_runtime_envs_are_registered(
+    monkeypatch: pytest.MonkeyPatch,
+    name: str,
+    value: str,
+    expected: str | int,
+) -> None:
+    """Accept every GG runtime variable consumed outside the env registry."""
+    _clear_unknown_vllm_envs(monkeypatch)
+    monkeypatch.setenv(name, value)
+
+    envs.validate_environ(hard_fail=True)
+    assert environment_variables[name]() == expected
+
+
+def test_gilded_gnosis_env_registration_keeps_unknown_detection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Continue rejecting misspelled VLLM variables after registration."""
+    _clear_unknown_vllm_envs(monkeypatch)
+    monkeypatch.setenv("VLLM_GILDED_GNOSIS_TYPO", "1")
+
+    with pytest.raises(
+        ValueError,
+        match="Unknown vLLM environment variable detected: VLLM_GILDED_GNOSIS_TYPO",
+    ):
+        envs.validate_environ(hard_fail=True)
+
+
 def test_getattr_with_cache(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("VLLM_HOST_IP", "1.1.1.1")
     monkeypatch.setenv("VLLM_PORT", "1234")

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -87,6 +87,8 @@ if TYPE_CHECKING:
     VLLM_B12X_MLA_CKV_GATHER_MAX_TOKENS: int = 524288
     VLLM_B12X_MLA_CKV_PREFETCH_DEPTH: int = 1
     VLLM_B12X_MLA_CKV_PREFETCH_WORKSPACE_MIB: int = 1024
+    VLLM_B12X_MLA_SPEC_DECODE_MAX_Q: int = 8
+    VLLM_B12X_MLA_SPEC_EXTEND_AS_DECODE: str = "auto"
     VLLM_MINIMAX_M3_ENABLE_TORCH_COMPILE: bool = False
     VLLM_B12X_CUDAGRAPH_PIECEWISE_PREWARM: bool = False
     VLLM_B12X_MOE_FORCE_MODELOPT_PREP: bool = False
@@ -240,6 +242,9 @@ if TYPE_CHECKING:
     VLLM_PCIE_DMA_MIN_BYTES: str = "6MB"
     VLLM_PCIE_ONESHOT_ALLOW_CROSS_NUMA: bool = True
     VLLM_PCIE_ONESHOT_SINGLE_CHANNEL: bool = False
+    VLLM_PCIE_DMA_FP8: str | None = None
+    VLLM_CPP_AR_1STAGE_NCCL_CUTOFF: str | None = None
+    VLLM_CPP_AR_IGNORE_CUTOFF_MAX_ROWS: int | None = None
     VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE: int = 394 * 1024 * 1024
     VLLM_XGRAMMAR_CACHE_MB: int = 0
     VLLM_REGEX_COMPILATION_TIMEOUT_S: int = 5
@@ -1225,6 +1230,15 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_B12X_MLA_CKV_PREFETCH_WORKSPACE_MIB": lambda: int(
         os.getenv("VLLM_B12X_MLA_CKV_PREFETCH_WORKSPACE_MIB", "1024")
     ),
+    # Short speculative extends may use the B12X sparse-MLA decode kernel.
+    # Backend validation remains authoritative because eligibility also
+    # depends on the active speculative configuration.
+    "VLLM_B12X_MLA_SPEC_DECODE_MAX_Q": lambda: int(
+        os.getenv("VLLM_B12X_MLA_SPEC_DECODE_MAX_Q", "8")
+    ),
+    "VLLM_B12X_MLA_SPEC_EXTEND_AS_DECODE": lambda: os.getenv(
+        "VLLM_B12X_MLA_SPEC_EXTEND_AS_DECODE", "auto"
+    ),
     # Diagnostic flag retained for local experiments. MiniMax M3 compile is
     # fail-closed in the model until the no-break path is validated.
     "VLLM_MINIMAX_M3_ENABLE_TORCH_COMPILE": lambda: bool(
@@ -1878,6 +1892,17 @@ environment_variables: dict[str, Callable[[], Any]] = {
         os.getenv("VLLM_PCIE_ONESHOT_SINGLE_CHANNEL", "0").strip().lower()
         not in ("", "0", "false", "no", "off")
     ),
+    # Optional wire format and crossover tuning read by the custom-allreduce
+    # integration. Unset values delegate to backend-owned defaults.
+    "VLLM_PCIE_DMA_FP8": lambda: os.getenv("VLLM_PCIE_DMA_FP8"),
+    "VLLM_CPP_AR_1STAGE_NCCL_CUTOFF": lambda: os.getenv(
+        "VLLM_CPP_AR_1STAGE_NCCL_CUTOFF"
+    ),
+    "VLLM_CPP_AR_IGNORE_CUTOFF_MAX_ROWS": lambda: (
+        int(value)
+        if (value := os.getenv("VLLM_CPP_AR_IGNORE_CUTOFF_MAX_ROWS")) is not None
+        else None
+    ),
     # Control the workspace buffer size for the FlashInfer backend.
     "VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE": lambda: int(
         os.getenv("VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE", str(394 * 1024 * 1024))
@@ -2292,7 +2317,6 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Prebuilt exllamav3 extension location and torch-ABI compatibility shim.
     "VLLM_EXL3_EXT_PATH": lambda: os.getenv("VLLM_EXL3_EXT_PATH"),
     "VLLM_EXL3_ABI_SHIM": lambda: os.getenv("VLLM_EXL3_ABI_SHIM"),
-
 }
 
 

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -245,6 +245,8 @@ if TYPE_CHECKING:
     VLLM_PCIE_DMA_FP8: str | None = None
     VLLM_CPP_AR_1STAGE_NCCL_CUTOFF: str | None = None
     VLLM_CPP_AR_IGNORE_CUTOFF_MAX_ROWS: int | None = None
+    VLLM_USE_B12X_PCIE_DMA: bool = False
+    VLLM_CACHE_DIR: str | None = None
     VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE: int = 394 * 1024 * 1024
     VLLM_XGRAMMAR_CACHE_MB: int = 0
     VLLM_REGEX_COMPILATION_TIMEOUT_S: int = 5
@@ -1903,6 +1905,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
         if (value := os.getenv("VLLM_CPP_AR_IGNORE_CUTOFF_MAX_ROWS")) is not None
         else None
     ),
+    # The DS4 launcher exports these for B12X and compiler-cache consumers.
+    # Register them so vLLM validation does not reject a supported launch.
+    "VLLM_USE_B12X_PCIE_DMA": lambda: bool(
+        int(os.getenv("VLLM_USE_B12X_PCIE_DMA", "0"))
+    ),
+    "VLLM_CACHE_DIR": lambda: os.getenv("VLLM_CACHE_DIR"),
     # Control the workspace buffer size for the FlashInfer backend.
     "VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE": lambda: int(
         os.getenv("VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE", str(394 * 1024 * 1024))


### PR DESCRIPTION
## Summary

Register seven `VLLM_*` controls already exported or consumed by the current GG sparse-MLA, custom-allreduce, DS4 launcher, and B12X integrations. This prevents supported launches from being reported as unknown while preserving typo detection.

This cleanly supersedes #186 on current `dev/gilded-gnosis`. It keeps the already-merged `VLLM_NVFP4_MLA_SCALES_FILE` empty-string contract and leaves EXL3 registrations with the EXL3 runtime PR instead of duplicating them.

Registered controls:

- `VLLM_B12X_MLA_SPEC_DECODE_MAX_Q`
- `VLLM_B12X_MLA_SPEC_EXTEND_AS_DECODE`
- `VLLM_PCIE_DMA_FP8`
- `VLLM_CPP_AR_1STAGE_NCCL_CUTOFF`
- `VLLM_CPP_AR_IGNORE_CUTOFF_MAX_ROWS`
- `VLLM_USE_B12X_PCIE_DMA`
- `VLLM_CACHE_DIR`

The last two are launcher-owned: the DS4 helper exports them for B12X and compiler-cache consumers, so vLLM must recognize them even though Python does not otherwise read them.

## Validation

- full `tests/test_envs.py` module passed in the CUDA 13.2 release environment
- focused registration matrix: 8 passed
- Ruff check and format: pass
- `git diff --check`: pass

Defaults remain backend-owned; this PR adds the existing controls to vLLM's validated environment contract.