### PR TITLE
[GG] Preserve activation dtype for int32-packed MLA weights

### DIFF
--- a/tests/kernels/attention/test_mla_kv_b_dtype_guard.py
+++ b/tests/kernels/attention/test_mla_kv_b_dtype_guard.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Packed-quantized kv_b_proj weights must not drive a kv_c_normed upcast.
+
+NVFP4 packs into uint8 and compressed-tensors int4/int8 packs into int32.
+Both are containers, not real activation dtypes -- casting kv_c_normed to
+either corrupts chunked prefill past ~4K prompts.
+"""
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.attention.mla_attention import (
+    is_packed_quantized_dtype,
+)
+
+
+@pytest.mark.parametrize(
+    "dtype,expected",
+    [
+        (torch.uint8, True),  # NVFP4
+        (torch.int32, True),  # compressed-tensors int4/int8
+        (torch.bfloat16, False),
+        (torch.float16, False),
+        (torch.float8_e4m3fn, False),
+    ],
+)
+def test_is_packed_quantized_dtype(dtype: torch.dtype, expected: bool):
+    assert is_packed_quantized_dtype(dtype) is expected

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -333,6 +333,16 @@ def _run_mla_query_bmm(
     torch.bmm(query.contiguous() if use_safe_op else query, weight, out=output)
 
 
+def is_packed_quantized_dtype(dtype: torch.dtype) -> bool:
+    """True if ``dtype`` is a container for packed quantized weights.
+
+    NVFP4 packs into ``uint8``; compressed-tensors int4/int8 packs into
+    ``int32``. Neither is a real activation dtype, so ``kv_c_normed`` must not
+    be cast to them -- the linear layer unpacks and quantizes internally.
+    """
+    return dtype in (torch.uint8, torch.int32)
+
+
 @functools.cache
 def _b12x_absorb_bmm_enabled() -> bool:
     return envs.VLLM_B12X_ABSORB_BMM
@@ -3178,12 +3188,13 @@ class MLACommonBaseImpl(MLAAttentionImpl[A], Generic[A]):
                 if hasattr(self.kv_b_proj, "weight")
                 else self.kv_b_proj.params_dtype
             )
-            # For NVFP4, weights are packed uint8 — keep input in model dtype
-            # since the NVFP4 linear layer quantizes internally.
+            # Packed quantized weights (NVFP4 → uint8, compressed-tensors
+            # int4/int8 → int32) are containers, not activation dtypes — keep
+            # the input in model dtype; the linear layer quantizes internally.
             if (
                 use_fp8_prefill or _kv_b_proj_w_dtype != current_platform.fp8_dtype()
-            ) and _kv_b_proj_w_dtype != torch.uint8:
-                kv_c_normed = kv_c_normed.to(self.kv_b_proj.weight.dtype)
+            ) and not is_packed_quantized_dtype(_kv_b_proj_w_dtype):
+                kv_c_normed = kv_c_normed.to(_kv_b_proj_w_dtype)
 
             k_pe = workspace[:toks][..., self.kv_lora_rank :].unsqueeze(1)
             kv_nope = self.kv_b_proj(kv_c_normed)[0].view(
@@ -3334,9 +3345,11 @@ class MLACommonBaseImpl(MLAAttentionImpl[A], Generic[A]):
                 if hasattr(self.kv_b_proj, "weight")
                 else self.kv_b_proj.params_dtype
             )
+            # Same packed-container rule as _compute_prefill_context above; this
+            # is the branch forward_mha takes when dcp_world_size > 1.
             if (
                 use_fp8_prefill or kv_b_proj_w_dtype != current_platform.fp8_dtype()
-            ) and kv_b_proj_w_dtype != torch.uint8:
+            ) and not is_packed_quantized_dtype(kv_b_proj_w_dtype):
                 kv_c_normed = kv_c_normed.to(kv_b_proj_w_dtype)
 
             kv_nope = self.kv_b_proj(kv_c_normed)[0].view(

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -334,11 +334,17 @@ def _run_mla_query_bmm(
 
 
 def is_packed_quantized_dtype(dtype: torch.dtype) -> bool:
-    """True if ``dtype`` is a container for packed quantized weights.
+    """Return whether ``dtype`` is a packed quantized-weight container.
 
     NVFP4 packs into ``uint8``; compressed-tensors int4/int8 packs into
     ``int32``. Neither is a real activation dtype, so ``kv_c_normed`` must not
     be cast to them -- the linear layer unpacks and quantizes internally.
+
+    Args:
+        dtype: Data type to classify.
+
+    Returns:
+        Whether the data type stores packed quantized weights.
     """
     return dtype in (torch.uint8, torch.int32)
 


### PR DESCRIPTION
## Summary

Treat both `uint8` NVFP4 and `int32` compressed-tensors weights as packed containers in the MLA `kv_b_proj` dtype guard. Activations must stay in model dtype; casting `kv_c_normed` to the packed container dtype corrupts chunked prefill for int4/int8 checkpoints.

This is a clean current-GG port of #187. Toby Mao's implementation and test commit retain original authorship; the follow-up resolves the remaining CodeRabbit docstring request.

## Practical impact

The original report reproduced garbage beyond roughly 4K prompt tokens on `QuantTrio/GLM-5.2-Int4-Int8Mix`. NVFP4 behavior is unchanged, and ordinary floating weight dtypes retain the existing cast.

## Validation

- `tests/kernels/attention/test_mla_kv_b_dtype_guard.py`: 5 passed in the CUDA 13.2 release environment
- Ruff check and format: pass
- `git diff --check`: pass