### PR TITLE
[Model Runner V2] Account for prompt-logprobs memory

### DIFF
--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -10,7 +10,7 @@ import pytest
 import torch
 
 import vllm.v1.core.kv_cache_utils as kv_cache_utils
-from vllm.config import ModelConfig, SchedulerConfig, VllmConfig
+from vllm.config import DeviceConfig, ModelConfig, SchedulerConfig, VllmConfig
 from vllm.config.kv_events import KVEventsConfig
 from vllm.lora.request import LoRARequest
 from vllm.multimodal.inputs import (
@@ -2460,6 +2460,30 @@ def test_get_kv_cache_configs_attention_free():
             kv_cache_groups=[],
         )
     ]
+
+
+def test_warns_when_num_gpu_blocks_override_exceeds_profiled_capacity(caplog):
+    model_config = ModelConfig(max_model_len=16)
+    vllm_config = VllmConfig(
+        model_config=model_config, device_config=DeviceConfig(device="cpu")
+    )
+    vllm_config.cache_config.num_gpu_blocks_override = 33
+    mem_per_block_per_layer = 16 * 2 * 64 * 4 * 2
+    kv_cache_specs = {
+        "layer_1": new_kv_cache_spec(),
+        "layer_2": new_kv_cache_spec(),
+    }
+
+    with caplog.at_level("WARNING"):
+        get_kv_cache_configs(
+            vllm_config,
+            [kv_cache_specs],
+            [mem_per_block_per_layer * 2 * 32],
+        )
+
+    assert "exceeds the capacity of 32 blocks implied by available KV memory" in (
+        caplog.text
+    )
 
 
 def test_generate_uniform_type_kv_cache_specs():

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -4348,6 +4348,36 @@ def test_prepend_skipped_requests_order():
     assert waiting_reqs == expected_waiting_reqs
 
 
+def test_skip_reading_prefix_cache_skips_external_connector_lookup():
+    """External KV reads must honor the same request flag as local APC.
+
+    Prompt logprobs require a forward pass over every prompt token, so a
+    connector hit would leave holes in the returned prompt-logprobs tensor.
+    The connector remains active for storing the freshly recomputed KV.
+    """
+    scheduler = create_scheduler(
+        max_num_batched_tokens=64,
+        max_model_len=64,
+        use_kv_connector=True,
+    )
+    scheduler.connector = Mock()
+    scheduler.connector.get_num_new_matched_tokens.return_value = (32, False)
+    request = create_requests(
+        num_requests=1,
+        num_tokens=32,
+        prompt_logprobs=1,
+    )[0]
+    assert request.skip_reading_prefix_cache
+    scheduler.add_request(request)
+
+    output = scheduler.schedule()
+
+    assert output.num_scheduled_tokens[request.request_id] == 32
+    scheduler.connector.get_num_new_matched_tokens.assert_not_called()
+    scheduler.connector.update_state_after_alloc.assert_called_once()
+    assert scheduler.connector.update_state_after_alloc.call_args.args[2] == 0
+
+
 def test_remote_kv_promotion_keeps_fcfs_with_grammar_prefix():
     scheduler = create_scheduler(max_num_seqs=1)
     scheduler.connector = Mock()

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -4348,12 +4348,13 @@ def test_prepend_skipped_requests_order():
     assert waiting_reqs == expected_waiting_reqs
 
 
-def test_skip_reading_prefix_cache_skips_external_connector_lookup():
+def test_skip_reading_prefix_cache_rejects_external_connector_hit():
     """External KV reads must honor the same request flag as local APC.
 
     Prompt logprobs require a forward pass over every prompt token, so a
     connector hit would leave holes in the returned prompt-logprobs tensor.
-    The connector remains active for storing the freshly recomputed KV.
+    The connector lookup still runs to establish its request tracker before
+    update_state_after_alloc(), but its hit is not admitted by the scheduler.
     """
     scheduler = create_scheduler(
         max_num_batched_tokens=64,
@@ -4373,7 +4374,7 @@ def test_skip_reading_prefix_cache_skips_external_connector_lookup():
     output = scheduler.schedule()
 
     assert output.num_scheduled_tokens[request.request_id] == 32
-    scheduler.connector.get_num_new_matched_tokens.assert_not_called()
+    scheduler.connector.get_num_new_matched_tokens.assert_called_once_with(request, 0)
     scheduler.connector.update_state_after_alloc.assert_called_once()
     assert scheduler.connector.update_state_after_alloc.call_args.args[2] == 0
 

--- a/tests/v1/worker/test_prompt_logprobs.py
+++ b/tests/v1/worker/test_prompt_logprobs.py
@@ -1,0 +1,218 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import numpy as np
+import pytest
+import torch
+
+from vllm.v1.worker.gpu.model_runner import GPUModelRunner
+from vllm.v1.worker.gpu.sample import prompt_logprob
+from vllm.v1.worker.gpu.sample.prompt_logprob import (
+    PromptLogprobsWorker,
+    compute_prompt_logprobs_with_chunking,
+)
+
+
+@pytest.mark.parametrize("chunk_size", [0, -1])
+def test_prompt_logprobs_worker_rejects_invalid_chunk_size(
+    monkeypatch: pytest.MonkeyPatch, chunk_size: int
+):
+    monkeypatch.setenv("VLLM_PROMPT_LOGPROBS_CHUNK_SIZE", str(chunk_size))
+
+    with pytest.raises(ValueError, match="must be greater than zero"):
+        PromptLogprobsWorker(max_num_reqs=1)
+
+
+def test_prompt_logprobs_chunk_size_bounds_logits_rows(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    chunk_rows: list[int] = []
+
+    def logits_fn(hidden_states: torch.Tensor) -> torch.Tensor:
+        chunk_rows.append(hidden_states.shape[0])
+        return torch.zeros((hidden_states.shape[0], 8))
+
+    def fake_compute_topk_logprobs(
+        logits: torch.Tensor,
+        num_logprobs: int,
+        sampled_token_ids: torch.Tensor,
+    ) -> SimpleNamespace:
+        del num_logprobs
+        return SimpleNamespace(
+            logprob_token_ids=sampled_token_ids.unsqueeze(-1),
+            logprobs=torch.zeros((logits.shape[0], 1)),
+            selected_token_ranks=torch.ones(logits.shape[0], dtype=torch.int64),
+        )
+
+    monkeypatch.setattr(
+        prompt_logprob, "compute_topk_logprobs", fake_compute_topk_logprobs
+    )
+    prompt_token_ids = torch.arange(5)
+    prompt_hidden_states = torch.zeros((5, 4))
+
+    token_ids, logprobs, ranks = compute_prompt_logprobs_with_chunking(
+        prompt_token_ids,
+        prompt_hidden_states,
+        logits_fn,
+        num_prompt_logprobs=1,
+        chunk_size=2,
+    )
+
+    assert chunk_rows == [2, 2, 1]
+    torch.testing.assert_close(token_ids.squeeze(-1), prompt_token_ids)
+    assert logprobs.shape == (5, 1)
+    torch.testing.assert_close(ranks, torch.ones(5, dtype=torch.int64))
+
+
+def test_prompt_logprobs_profile_uses_full_batch(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("VLLM_PROMPT_LOGPROBS_CHUNK_SIZE", "2")
+    worker = PromptLogprobsWorker(max_num_reqs=1)
+    helper = Mock()
+    monkeypatch.setattr(prompt_logprob, "compute_prompt_logprobs_with_chunking", helper)
+    hidden_states = torch.zeros((5, 4))
+    logits_fn = Mock()
+
+    worker.profile_run(logits_fn, hidden_states, max_num_logprobs=-1)
+
+    prompt_token_ids, profiled_hidden_states, fn, max_logprobs, chunk_size = (
+        helper.call_args.args
+    )
+    assert prompt_token_ids.shape == (5,)
+    assert profiled_hidden_states is hidden_states
+    assert fn is logits_fn
+    assert max_logprobs == -1
+    assert chunk_size == 2
+
+
+def test_prompt_logprobs_accumulates_chunks_on_cpu(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    worker = PromptLogprobsWorker(max_num_reqs=1)
+    worker.uses_prompt_logprobs[0] = True
+    worker.num_prompt_logprobs[0] = 1
+    worker.in_progress_prompt_logprobs["req"] = None
+
+    monkeypatch.setattr(
+        prompt_logprob,
+        "get_prompt_logprobs_token_ids",
+        lambda *args, **kwargs: torch.arange(args[0]),
+    )
+    chunks = iter(
+        [
+            (
+                torch.tensor([[10, 11], [20, 21]]),
+                torch.tensor([[1.0, 1.1], [2.0, 2.1]]),
+                torch.tensor([1, 2]),
+            ),
+            (
+                torch.tensor([[30, 31], [40, 41], [50, 51]]),
+                torch.tensor([[3.0, 3.1], [4.0, 4.1], [5.0, 5.1]]),
+                torch.tensor([3, 4, 5]),
+            ),
+        ]
+    )
+    monkeypatch.setattr(
+        prompt_logprob,
+        "compute_prompt_logprobs_with_chunking",
+        lambda *args, **kwargs: next(chunks),
+    )
+    synchronize = Mock()
+    monkeypatch.setattr(torch.accelerator, "synchronize", synchronize)
+
+    def make_batch(computed: int, scheduled: int) -> SimpleNamespace:
+        return SimpleNamespace(
+            idx_mapping_np=np.array([0]),
+            idx_mapping=torch.tensor([0]),
+            num_computed_prefill_tokens_np=np.array([computed]),
+            prefill_len_np=np.array([5]),
+            num_scheduled_tokens=np.array([scheduled]),
+            num_tokens=scheduled,
+            query_start_loc=torch.tensor([0, scheduled]),
+            query_start_loc_np=np.array([0, scheduled]),
+            req_ids=["req"],
+        )
+
+    output = worker.compute_prompt_logprobs(
+        Mock(),
+        torch.zeros((2, 4)),
+        make_batch(computed=0, scheduled=2),
+        torch.zeros((1, 5), dtype=torch.int64),
+        torch.zeros(1, dtype=torch.int64),
+        np.array([5]),
+    )
+    assert output == {}
+    in_progress = worker.in_progress_prompt_logprobs["req"]
+    assert in_progress is not None
+    assert in_progress.logprobs.device.type == "cpu"
+    synchronize.assert_not_called()
+
+    output = worker.compute_prompt_logprobs(
+        Mock(),
+        torch.zeros((3, 4)),
+        make_batch(computed=2, scheduled=3),
+        torch.zeros((1, 5), dtype=torch.int64),
+        torch.full((1,), 2, dtype=torch.int64),
+        np.array([5]),
+    )
+    result = output["req"]
+    torch.testing.assert_close(
+        result.logprob_token_ids,
+        torch.tensor([[10, 11], [20, 21], [30, 31], [40, 41]], dtype=torch.int32),
+    )
+    torch.testing.assert_close(
+        result.logprobs,
+        torch.tensor([[1.0, 1.1], [2.0, 2.1], [3.0, 3.1], [4.0, 4.1]]),
+    )
+    torch.testing.assert_close(
+        result.selected_token_ranks, torch.tensor([1, 2, 3, 4], dtype=torch.int32)
+    )
+    assert worker.in_progress_prompt_logprobs["req"] is None
+    synchronize.assert_not_called()
+
+
+def test_model_runner_profiles_prompt_logprobs(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    hidden_states = torch.zeros((8, 4))
+    sample_hidden_states = hidden_states[:2]
+    logits_fn = Mock()
+    runner = object.__new__(GPUModelRunner)
+    runner.max_num_tokens = 8
+    runner.is_last_pp_rank = True
+    runner.pooling_runner = None
+    runner.model = SimpleNamespace(compute_logits=logits_fn)
+    runner.model_config = SimpleNamespace(max_logprobs=20)
+    runner.prompt_logprobs_worker = Mock(chunk_size=256)
+    runner._dummy_run = Mock(return_value=(hidden_states, sample_hidden_states))
+    runner._dummy_sampler_run = Mock()
+    monkeypatch.setattr(torch.accelerator, "synchronize", Mock())
+
+    GPUModelRunner.profile_run(runner)
+
+    runner._dummy_run.assert_called_once_with(8, skip_attn=True, is_profile=True)
+    runner._dummy_sampler_run.assert_called_once_with(sample_hidden_states)
+    runner.prompt_logprobs_worker.profile_run.assert_called_once_with(
+        logits_fn, hidden_states, 20
+    )
+
+
+def test_non_last_pp_rank_does_not_profile_prompt_logprobs(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    hidden_states = torch.zeros((8, 4))
+    runner = object.__new__(GPUModelRunner)
+    runner.max_num_tokens = 8
+    runner.is_last_pp_rank = False
+    runner.pooling_runner = None
+    runner.prompt_logprobs_worker = Mock()
+    runner._dummy_run = Mock(return_value=(hidden_states, None))
+    monkeypatch.setattr(torch.accelerator, "synchronize", Mock())
+
+    GPUModelRunner.profile_run(runner)
+
+    runner.prompt_logprobs_worker.profile_run.assert_not_called()

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -188,6 +188,7 @@ if TYPE_CHECKING:
     VLLM_RUST_FRONTEND_PATH: str | None = "auto"
     VLLM_SERVER_DEV_MODE: bool = False
     VLLM_V1_OUTPUT_PROC_CHUNK_SIZE: int = 128
+    VLLM_PROMPT_LOGPROBS_CHUNK_SIZE: int = 1024
     VLLM_MLA_DISABLE: bool = False
     VLLM_DSPARK_DYNAMIC_DRAFT_DEPTH: bool = False
     VLLM_DSPARK_DYNAMIC_DRAFT_DEPTH_WINDOW: int = 8
@@ -1551,6 +1552,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_V1_OUTPUT_PROC_CHUNK_SIZE": lambda: int(
         os.getenv("VLLM_V1_OUTPUT_PROC_CHUNK_SIZE", "128")
     ),
+    # Maximum prompt-token rows materialized in the full-vocabulary logits
+    # tensor at once while computing V1 prompt logprobs.
+    "VLLM_PROMPT_LOGPROBS_CHUNK_SIZE": lambda: int(
+        os.getenv("VLLM_PROMPT_LOGPROBS_CHUNK_SIZE", "1024")
+    ),
     # If set, vLLM will disable the MLA attention optimizations.
     "VLLM_MLA_DISABLE": lambda: bool(int(os.getenv("VLLM_MLA_DISABLE", "0"))),
     # Physically shorten DSpark's next draft block from the historical
@@ -2292,7 +2298,6 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Prebuilt exllamav3 extension location and torch-ABI compatibility shim.
     "VLLM_EXL3_EXT_PATH": lambda: os.getenv("VLLM_EXL3_EXT_PATH"),
     "VLLM_EXL3_ABI_SHIM": lambda: os.getenv("VLLM_EXL3_ABI_SHIM"),
-
 }
 
 
@@ -2438,6 +2443,7 @@ def compile_factors() -> dict[str, object]:
         "VLLM_WORKER_MULTIPROC_METHOD",
         "VLLM_ENABLE_V1_MULTIPROCESSING",
         "VLLM_V1_OUTPUT_PROC_CHUNK_SIZE",
+        "VLLM_PROMPT_LOGPROBS_CHUNK_SIZE",
         "VLLM_CPU_KVCACHE_SPACE",
         "VLLM_CPU_MOE_PREPACK",
         "VLLM_ZENTORCH_WEIGHT_PREPACK",

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -2363,9 +2363,18 @@ def get_kv_cache_configs(
                 adjusted_memory.append(avail_mem)
                 continue
             bytes_per_block = _pool_bytes_per_block(vllm_config, groups)
+            profiled_num_blocks = avail_mem // bytes_per_block
+            if override > profiled_num_blocks:
+                logger.warning(
+                    "num_gpu_blocks_override=%d exceeds the capacity of %d "
+                    "blocks implied by available KV memory. The override "
+                    "bypasses memory accounting and can cause runtime CUDA OOMs.",
+                    override,
+                    profiled_num_blocks,
+                )
             logger.info(
                 "Overriding num_gpu_blocks=%d with num_gpu_blocks_override=%d",
-                avail_mem // bytes_per_block,
+                profiled_num_blocks,
                 override,
             )
             adjusted_memory.append(override * bytes_per_block)

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -774,21 +774,22 @@ class Scheduler(SchedulerInterface):
                         ) = self.kv_cache_manager.get_computed_blocks(request)
 
                     # Get externally-cached tokens if using a KVConnector.
-                    # ``skip_reading_prefix_cache`` applies to every cache
-                    # reader, including external KV connectors. Prompt
-                    # logprobs set this flag because cached KV cannot recover
-                    # the logits for skipped prompt tokens. Keep the connector
-                    # active below so freshly recomputed KV may still be
-                    # stored, but do not admit an external cache hit here.
-                    if (
-                        self.connector is not None
-                        and not request.skip_reading_prefix_cache
-                    ):
+                    # Even when reads are disabled, call the connector so it
+                    # can establish its per-request lifecycle state before
+                    # update_state_after_alloc(). Prompt logprobs must not
+                    # *admit* an external hit because cached KV cannot recover
+                    # logits for skipped prompt tokens, so discard the lookup
+                    # result and force a local forward pass in that case.
+                    if self.connector is not None:
                         ext_tokens, load_kv_async = (
                             self.connector.get_num_new_matched_tokens(
                                 request, num_new_local_computed_tokens
                             )
                         )
+
+                        if request.skip_reading_prefix_cache:
+                            ext_tokens = 0
+                            load_kv_async = False
 
                         if ext_tokens is None:
                             # The request cannot be scheduled because

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -774,7 +774,16 @@ class Scheduler(SchedulerInterface):
                         ) = self.kv_cache_manager.get_computed_blocks(request)
 
                     # Get externally-cached tokens if using a KVConnector.
-                    if self.connector is not None:
+                    # ``skip_reading_prefix_cache`` applies to every cache
+                    # reader, including external KV connectors. Prompt
+                    # logprobs set this flag because cached KV cannot recover
+                    # the logits for skipped prompt tokens. Keep the connector
+                    # active below so freshly recomputed KV may still be
+                    # stored, but do not admit an external cache hit here.
+                    if (
+                        self.connector is not None
+                        and not request.skip_reading_prefix_cache
+                    ):
                         ext_tokens, load_kv_async = (
                             self.connector.get_num_new_matched_tokens(
                                 request, num_new_local_computed_tokens

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -813,6 +813,17 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             assert sample_hidden_states is not None
             if self.pooling_runner is None:
                 self._dummy_sampler_run(sample_hidden_states)
+                assert hidden_states is not None
+                assert self.prompt_logprobs_worker is not None
+                self.prompt_logprobs_worker.profile_run(
+                    self.model.compute_logits,
+                    hidden_states,
+                    self.model_config.max_logprobs,
+                )
+                logger.info_once(
+                    "Profiled V1 prompt-logprobs workspace with chunk size %d",
+                    self.prompt_logprobs_worker.chunk_size,
+                )
             else:
                 self._dummy_pooler_run(hidden_states)
 

--- a/vllm/v1/worker/gpu/sample/prompt_logprob.py
+++ b/vllm/v1/worker/gpu/sample/prompt_logprob.py
@@ -5,6 +5,7 @@ from collections.abc import Callable
 import numpy as np
 import torch
 
+from vllm import envs
 from vllm.sampling_params import SamplingParams
 from vllm.triton_utils import tl, triton
 from vllm.v1.outputs import LogprobsTensors
@@ -15,21 +16,46 @@ from vllm.v1.worker.gpu.sample.logprob import compute_topk_logprobs
 class PromptLogprobsWorker:
     def __init__(self, max_num_reqs: int):
         self.max_num_reqs = max_num_reqs
+        self.chunk_size = envs.VLLM_PROMPT_LOGPROBS_CHUNK_SIZE
+        if self.chunk_size <= 0:
+            raise ValueError(
+                "VLLM_PROMPT_LOGPROBS_CHUNK_SIZE must be greater than zero, "
+                f"got {self.chunk_size}"
+            )
 
         self.uses_prompt_logprobs = np.zeros(self.max_num_reqs, dtype=bool)
         self.num_prompt_logprobs = np.zeros(self.max_num_reqs, dtype=np.int32)
-        # req_idx -> list of in-progress LogprobsTensors
-        self.in_progress_prompt_logprobs: dict[str, list[LogprobsTensors]] = {}
+        # req_id -> CPU buffer containing all prompt logprobs accumulated so far.
+        # Keeping chunk results on GPU until prompt completion can consume
+        # unbounded device memory for long or concurrent prompts.
+        self.in_progress_prompt_logprobs: dict[str, LogprobsTensors | None] = {}
 
     def add_request(self, req_id: str, req_idx: int, sampling_params: SamplingParams):
         uses_prompt_logprobs = sampling_params.prompt_logprobs is not None
         self.uses_prompt_logprobs[req_idx] = uses_prompt_logprobs
         self.num_prompt_logprobs[req_idx] = sampling_params.prompt_logprobs or 0
         if uses_prompt_logprobs:
-            self.in_progress_prompt_logprobs[req_id] = []
+            self.in_progress_prompt_logprobs[req_id] = None
 
     def remove_request(self, req_id: str) -> None:
         self.in_progress_prompt_logprobs.pop(req_id, None)
+
+    def profile_run(
+        self,
+        logits_fn: Callable[[torch.Tensor], torch.Tensor],
+        hidden_states: torch.Tensor,
+        max_num_logprobs: int,
+    ) -> None:
+        prompt_token_ids = torch.zeros(
+            hidden_states.shape[0], dtype=torch.int64, device=hidden_states.device
+        )
+        compute_prompt_logprobs_with_chunking(
+            prompt_token_ids,
+            hidden_states,
+            logits_fn,
+            max_num_logprobs,
+            self.chunk_size,
+        )
 
     def compute_prompt_logprobs(
         self,
@@ -82,6 +108,7 @@ class PromptLogprobsWorker:
                 hidden_states[: input_batch.num_tokens],
                 logits_fn,
                 max_num_prompt_logprobs,
+                self.chunk_size,
             )
         )
 
@@ -109,41 +136,35 @@ class PromptLogprobsWorker:
                 if req_num_prompt_logprobs == -1
                 else req_num_prompt_logprobs + 1
             )
-            # no logprobs if start_idx >= end_idx
-            logprobs = (
-                None
-                if start_idx >= end_idx
-                else LogprobsTensors(
-                    logprob_token_ids=prompt_token_ids[start_idx:end_idx, :width],
-                    logprobs=prompt_logprobs[start_idx:end_idx, :width],
-                    selected_token_ranks=prompt_ranks[start_idx:end_idx],
-                )
-            )
+            prompt_logprobs_cpu = self.in_progress_prompt_logprobs[req_id]
+            if start_idx < end_idx:
+                if prompt_logprobs_cpu is None:
+                    prompt_logprobs_cpu = LogprobsTensors.empty_cpu(
+                        int(prompt_lens[i]) - 1, width
+                    )
+                    self.in_progress_prompt_logprobs[req_id] = prompt_logprobs_cpu
 
-            prompt_logprobs_list = self.in_progress_prompt_logprobs[req_id]
-            if logprobs is not None and (req_is_prompt_chunked or prompt_logprobs_list):
-                prompt_logprobs_list.append(logprobs)
+                dst_start = int(computed_prefill[i])
+                dst_end = dst_start + end_idx - start_idx
+                prompt_logprobs_cpu.logprob_token_ids[dst_start:dst_end].copy_(
+                    prompt_token_ids[start_idx:end_idx, :width]
+                )
+                prompt_logprobs_cpu.logprobs[dst_start:dst_end].copy_(
+                    prompt_logprobs[start_idx:end_idx, :width]
+                )
+                prompt_logprobs_cpu.selected_token_ranks[dst_start:dst_end].copy_(
+                    prompt_ranks[start_idx:end_idx]
+                )
+
             if req_is_prompt_chunked:
                 # Prompt is chunked. Do not return the logprobs yet.
                 continue
 
-            if prompt_logprobs_list:
-                # Merge the in-progress logprobs.
-                logprobs = LogprobsTensors(
-                    logprob_token_ids=torch.cat(
-                        [x.logprob_token_ids for x in prompt_logprobs_list]
-                    ),
-                    logprobs=torch.cat([x.logprobs for x in prompt_logprobs_list]),
-                    selected_token_ranks=torch.cat(
-                        [x.selected_token_ranks for x in prompt_logprobs_list]
-                    ),
-                )
-                prompt_logprobs_list.clear()
-
-            if logprobs is None:
+            if prompt_logprobs_cpu is None:
                 continue
 
-            prompt_logprobs_dict[req_id] = logprobs
+            prompt_logprobs_dict[req_id] = prompt_logprobs_cpu
+            self.in_progress_prompt_logprobs[req_id] = None
         return prompt_logprobs_dict
 
 
@@ -206,16 +227,18 @@ def compute_prompt_logprobs_with_chunking(
     prompt_hidden_states: torch.Tensor,
     logits_fn: Callable[[torch.Tensor], torch.Tensor],
     num_prompt_logprobs: int,
+    chunk_size: int = 1024,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    if chunk_size <= 0:
+        raise ValueError(f"chunk_size must be greater than zero, got {chunk_size}")
     # Since materializing the full prompt logits can take too much memory,
     # we compute it in chunks.
-    CHUNK_SIZE = 1024
     token_ids = []
     logprobs = []
     ranks = []
     prompt_token_ids = prompt_token_ids.to(torch.int64)
-    for start_idx in range(0, prompt_token_ids.shape[0], CHUNK_SIZE):
-        end_idx = start_idx + CHUNK_SIZE
+    for start_idx in range(0, prompt_token_ids.shape[0], chunk_size):
+        end_idx = start_idx + chunk_size
         # NOTE(woosuk): logits_fn can be slow because it involves all-gather.
         prompt_logits = logits_fn(prompt_hidden_states[start_idx:end_idx])
         requested_num_prompt_logprobs = (
@@ -228,6 +251,7 @@ def compute_prompt_logprobs_with_chunking(
             requested_num_prompt_logprobs,
             prompt_token_ids[start_idx:end_idx],
         )
+        del prompt_logits
         token_ids.append(prompt_logprobs.logprob_token_ids)
         logprobs.append(prompt_logprobs.logprobs)
         ranks.append(prompt_logprobs.selected_token_ranks)

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -5698,28 +5698,44 @@ class GPUModelRunner(
             req_idx = self.input_batch.req_id_to_index[req_id]
             offset = self.query_start_loc.np[req_idx].item()
             prompt_hidden_states = hidden_states[offset : offset + num_logits]
-            logits = self.model.compute_logits(prompt_hidden_states)
-
             # Get the "target" tokens for each index. For prompt at index i,
             # the token at prompt index i+1 is the "sampled" token we want
             # to gather the logprob for.
             tgt_token_ids = prompt_token_ids[start_tok : start_tok + num_logits]
-
-            # Compute prompt logprobs.
-            logprobs = self.sampler.compute_logprobs(logits)
-            token_ids, logprobs, ranks, _ = self.sampler.gather_logprobs(
-                logprobs, num_prompt_logprobs, tgt_token_ids
-            )
-
-            # Transfer GPU->CPU async.
-            chunk_slice = slice(start_idx, start_idx + num_logits)
-            logprobs_tensors.logprob_token_ids[chunk_slice].copy_(
-                token_ids, non_blocking=True
-            )
-            logprobs_tensors.logprobs[chunk_slice].copy_(logprobs, non_blocking=True)
-            logprobs_tensors.selected_token_ranks[chunk_slice].copy_(
-                ranks, non_blocking=True
-            )
+            # Compute prompt logprobs in chunks to bound the full-vocabulary
+            # logits tensor memory.  The legacy path materialized
+            # [num_logits, vocab_size] in one shot, which OOMs on
+            # memory-dense profiles (upstream vllm-project/vllm#14239).
+            # Mirrors the chunking in compute_prompt_logprobs_with_chunking
+            # (vllm/v1/worker/gpu/sample/prompt_logprob.py) and the V2
+            # PromptLogprobsWorker path.  V1 is not used in the production
+            # stack (VLLM_USE_V2_MODEL_RUNNER=1), but this keeps the two
+            # paths consistent so the same VLLM_PROMPT_LOGPROBS_CHUNK_SIZE
+            # guard applies to both.
+            chunk_size = envs.VLLM_PROMPT_LOGPROBS_CHUNK_SIZE
+            for chunk_start in range(0, num_logits, chunk_size):
+                chunk_end = min(chunk_start + chunk_size, num_logits)
+                chunk_logits = self.model.compute_logits(
+                    prompt_hidden_states[chunk_start:chunk_end]
+                )
+                chunk_tgt = tgt_token_ids[chunk_start:chunk_end]
+                chunk_logprobs = self.sampler.compute_logprobs(chunk_logits)
+                del chunk_logits
+                token_ids, logprobs, ranks, _ = self.sampler.gather_logprobs(
+                    chunk_logprobs, num_prompt_logprobs, chunk_tgt
+                )
+                del chunk_logprobs
+                # Transfer GPU->CPU async.
+                dst_slice = slice(start_idx + chunk_start, start_idx + chunk_end)
+                logprobs_tensors.logprob_token_ids[dst_slice].copy_(
+                    token_ids, non_blocking=True
+                )
+                logprobs_tensors.logprobs[dst_slice].copy_(
+                    logprobs, non_blocking=True
+                )
+                logprobs_tensors.selected_token_ranks[dst_slice].copy_(
+                    ranks, non_blocking=True
+                )
 
         # Remove requests that have completed prefill from the batch
         # num_prompt_logprobs_dict.


### PR DESCRIPTION
## Summary

- include the Model Runner V2 prompt-logprobs logits/all-gather/top-k path in startup memory profiling on the last pipeline stage
- make the existing 1,024-row logits chunk an explicit validated `VLLM_PROMPT_LOGPROBS_CHUNK_SIZE` setting
- accumulate chunked-prefill prompt-logprob results in a preallocated CPU buffer instead of retaining every chunk on GPU
- warn when `num_gpu_blocks_override` exceeds the capacity implied by available KV memory

Closes #257.

## Root cause and impact

A production TP4/DCP4 GLM-5.2 service had 218.81 MiB physically free per rank when four valid requests used `prompt_logprobs=20`. The V1 prompt-logprobs path attempted a 304 MiB allocation on every rank and killed EngineCore:

```text
1024 prompt rows * 154880 vocabulary * 2 BF16 bytes = 302.5 MiB
```

The allocation is the full-vocabulary tensor-parallel logits all-gather performed before top-k selection. Startup memory profiling did not exercise this path, so KV sizing could consume the required headroom. Model Runner V2 is implemented beneath the V1 engine namespace at `vllm/v1/worker/gpu/`; the similarly named legacy runner is `vllm/v1/worker/gpu_model_runner.py`.

MRv2 also retained each prompt-logprobs result chunk on GPU until prompt completion and concatenated the full result on GPU. For long or concurrent prompts that memory grows across scheduler steps. This change adopts the bounded CPU-accumulation design already used by the legacy runner.

The observed 92.2% logical KV occupancy was workload context, not the cause of the missing physical memory: the GPU KV tensor is normally allocated at startup.

## Duplicate-work check

- vllm-project/vllm#45327 changes the **legacy** runner from a full `log_softmax` tensor to `compute_topk_logprobs`; this fork's MRv2 path already uses top-k and the PR does not profile its TP logits workspace or fix cross-step GPU retention.
- vllm-project/vllm#37518 profiles sampler logits workspaces; its discussion explicitly notes that prompt logprobs bypass the sampler and remain a separate path.
- no open `local-inference-lab/vllm` PR references #257 or implements this repair.

## Validation

Passed locally on macOS/CPU:

```text
.venv/bin/python -m pytest tests/v1/worker/test_prompt_logprobs.py tests/v1/core/test_kv_cache_utils.py::test_warns_when_num_gpu_blocks_override_exceeds_profiled_capacity -q
8 passed
```

Focused coverage verifies:

- invalid chunk settings fail closed
- every logits call stays within the configured row bound
- startup profiles the full batch and forwards `max_logprobs=-1`
- two scheduler steps preserve CPU-accumulated values and order
- only the last PP rank profiles prompt logprobs
- unsafe block overrides emit a warning

`ruff check`, `ruff format`, `typos`, SPDX, configuration validation, and the other applicable pre-commit hooks passed. The full pre-commit invocation also surfaced one pre-existing custom-branch mypy error at `vllm/v1/worker/gpu/model_runner.py:1987` (`bool | None` passed to `defer_copy_event: bool`); this patch does not change that code.

GPU qualification is deliberately left pending in this draft. The planned gate is TP2/TP4 startup-capacity comparison plus concurrent `prompt_logprobs=20`, long chunked prefill, and MTP smoke tests on an authorized non-production host.

## AI assistance disclosure

AI assistance was used for source auditing, implementation, and test drafting. The human submitter reviewed the incident evidence and is expected to review every changed line and the GPU qualification results before this PR is marked ready.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable chunk sizing for prompt logprobs through an environment setting.
  * Improved prompt logprob processing to reduce GPU memory usage during large requests.

* **Bug Fixes**
  * Added warnings when configured GPU cache capacity exceeds profiled capacity, helping identify potential CUDA out-of-memory risks.
  * Improved validation and profiling for prompt logprob processing across supported execution modes.
  * Prevented prompt-logprob requests from reading externally cached prefix data while preserving newly generated cache state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->