### PR TITLE
security(exl3): harden native-extension loading and config path traversal

### DIFF
--- a/tests/quantization/test_exl3_security.py
+++ b/tests/quantization/test_exl3_security.py
@@ -1,22 +1,43 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Security tests for EXL3 trust-boundary hardening (C1, C2, C3)."""
+"""Security tests for EXL3 trust-boundary hardening (C1, C2, C3).
+
+Covers:
+  * validate_native_lib_path (shared canonical primitive in
+    vllm/utils/path_validation.py) — absolute-path requirement, symlink
+    component rejection, symlink-final rejection, non-regular rejection,
+    group/world-writable file rejection, group/world-writable ancestor
+    rejection, and a safe-path acceptance.
+  * _validate_ext_search_dir (exl3.py) — symlink rejection (component and
+    final), group/world-writable rejection, non-directory rejection,
+    relative-path rejection, and a safe-dir acceptance.
+  * _load_rank_sliced_bitrates bits_per_expert filename sanitization —
+    path separators, absolute paths, '..', '.', and empty string are
+    rejected; a safe bare filename is accepted via a stubbed
+    get_hf_file_to_dict.
+"""
 
 import os
-import sys
 from unittest.mock import patch
 
 import pytest
 
-# We test the validation helpers and the bits_per_expert sanitization in
-# isolation, without loading the actual exllamav3_ext native library.
+# ---------------------------------------------------------------------------
+# validate_native_lib_path — canonical shared primitive
+# ---------------------------------------------------------------------------
+
+
+def test_validate_native_lib_path_rejects_relative(tmp_path):
+    """A bare soname / relative path lets dlopen search its own path."""
+    from vllm.utils.path_validation import validate_native_lib_path
+
+    with pytest.raises(ValueError, match="absolute path"):
+        validate_native_lib_path("libfoo.so", "VLLM_EXL3_ABI_SHIM")
 
 
 def test_validate_native_lib_path_rejects_symlink(tmp_path):
-    """C1: VLLM_EXL3_ABI_SHIM must not be a symlink."""
-    from vllm.model_executor.layers.quantization.exl3 import (
-        _validate_native_lib_path,
-    )
+    """A symlink as the final component is rejected."""
+    from vllm.utils.path_validation import validate_native_lib_path
 
     target = tmp_path / "real.so"
     target.write_text("dummy")
@@ -24,87 +45,184 @@ def test_validate_native_lib_path_rejects_symlink(tmp_path):
     link.symlink_to(target)
 
     with pytest.raises(ValueError, match="symlink"):
-        _validate_native_lib_path(str(link), "VLLM_EXL3_ABI_SHIM")
+        validate_native_lib_path(str(link), "VLLM_EXL3_ABI_SHIM")
+
+
+def test_validate_native_lib_path_rejects_symlink_ancestor(tmp_path):
+    """A symlink *anywhere* on the path is rejected (islink only checks
+    the final component, so realpath-equality is the real gate)."""
+    from vllm.utils.path_validation import validate_native_lib_path
+
+    real_dir = tmp_path / "real_dir"
+    real_dir.mkdir()
+    lib = real_dir / "good.so"
+    lib.write_text("dummy")
+    os.chmod(lib, 0o644)
+    os.chmod(real_dir, 0o755)
+
+    link_dir = tmp_path / "link_dir"
+    link_dir.symlink_to(real_dir)
+    linked_lib = link_dir / "good.so"
+
+    with pytest.raises(ValueError, match="symlink component"):
+        validate_native_lib_path(str(linked_lib), "VLLM_EXL3_ABI_SHIM")
 
 
 def test_validate_native_lib_path_rejects_nonexistent(tmp_path):
-    """C1: non-existent path is rejected."""
-    from vllm.model_executor.layers.quantization.exl3 import (
-        _validate_native_lib_path,
-    )
+    """A non-existent path is rejected (os.lstat raises FileNotFoundError
+    before the S_ISREG check)."""
+    from vllm.utils.path_validation import validate_native_lib_path
 
-    with pytest.raises(ValueError, match="non-existent"):
-        _validate_native_lib_path(str(tmp_path / "missing.so"), "VLLM_EXL3_ABI_SHIM")
+    with pytest.raises((ValueError, FileNotFoundError)):
+        validate_native_lib_path(str(tmp_path / "missing.so"),
+                                 "VLLM_EXL3_ABI_SHIM")
 
 
 def test_validate_native_lib_path_rejects_world_writable(tmp_path):
-    """C1: world-writable .so is rejected."""
-    from vllm.model_executor.layers.quantization.exl3 import (
-        _validate_native_lib_path,
-    )
+    """A world-writable .so is rejected."""
+    from vllm.utils.path_validation import validate_native_lib_path
 
     lib = tmp_path / "evil.so"
     lib.write_text("dummy")
     os.chmod(lib, 0o666)  # rw-rw-rw-
 
     with pytest.raises(ValueError, match="group/world-writable"):
-        _validate_native_lib_path(str(lib), "VLLM_EXL3_ABI_SHIM")
+        validate_native_lib_path(str(lib), "VLLM_EXL3_ABI_SHIM")
+
+
+def test_validate_native_lib_path_rejects_group_writable(tmp_path):
+    """A group-writable .so is rejected."""
+    from vllm.utils.path_validation import validate_native_lib_path
+
+    lib = tmp_path / "evil.so"
+    lib.write_text("dummy")
+    os.chmod(lib, 0o664)  # rw-rw-r--
+
+    with pytest.raises(ValueError, match="group/world-writable"):
+        validate_native_lib_path(str(lib), "VLLM_EXL3_ABI_SHIM")
 
 
 def test_validate_native_lib_path_rejects_world_writable_parent(tmp_path):
-    """C1: world-writable parent directory is rejected."""
-    from vllm.model_executor.layers.quantization.exl3 import (
-        _validate_native_lib_path,
-    )
+    """A world-writable parent directory (non-sticky) is rejected."""
+    from vllm.utils.path_validation import validate_native_lib_path
 
     lib = tmp_path / "evil.so"
     lib.write_text("dummy")
     os.chmod(lib, 0o644)
-    os.chmod(tmp_path, 0o777)  # world-writable parent
+    os.chmod(tmp_path, 0o777)  # world-writable parent, no sticky bit
 
-    with pytest.raises(ValueError, match="parent directory"):
-        _validate_native_lib_path(str(lib), "VLLM_EXL3_ABI_SHIM")
+    try:
+        with pytest.raises(ValueError, match="ancestor directory"):
+            validate_native_lib_path(str(lib), "VLLM_EXL3_ABI_SHIM")
+    finally:
+        os.chmod(tmp_path, 0o755)  # restore for teardown
 
 
 def test_validate_native_lib_path_accepts_safe(tmp_path):
-    """C1: a regular file in a safe directory passes."""
-    from vllm.model_executor.layers.quantization.exl3 import (
-        _validate_native_lib_path,
-    )
+    """A regular file in a safe directory passes and returns the canonical
+    path."""
+    from vllm.utils.path_validation import validate_native_lib_path
 
     lib = tmp_path / "good.so"
     lib.write_text("dummy")
     os.chmod(lib, 0o644)
     os.chmod(tmp_path, 0o755)
 
-    # Should not raise
-    _validate_native_lib_path(str(lib), "VLLM_EXL3_ABI_SHIM")
+    result = validate_native_lib_path(str(lib), "VLLM_EXL3_ABI_SHIM")
+    assert result == os.path.realpath(str(lib))
+
+
+# ---------------------------------------------------------------------------
+# _validate_ext_search_dir
+# ---------------------------------------------------------------------------
+
+
+def test_validate_ext_search_dir_rejects_relative(tmp_path):
+    """A relative directory path is rejected."""
+    from vllm.model_executor.layers.quantization.exl3 import (
+        _validate_ext_search_dir,
+    )
+
+    with pytest.raises(ValueError, match="absolute path"):
+        _validate_ext_search_dir("some/rel/dir", "VLLM_EXL3_EXT_PATH")
+
+
+def test_validate_ext_search_dir_rejects_symlink(tmp_path):
+    """A symlink as the final component is rejected."""
+    from vllm.model_executor.layers.quantization.exl3 import (
+        _validate_ext_search_dir,
+    )
+
+    real = tmp_path / "real_dir"
+    real.mkdir()
+    os.chmod(real, 0o755)
+    link = tmp_path / "link_dir"
+    link.symlink_to(real)
+
+    with pytest.raises(ValueError, match="symlink"):
+        _validate_ext_search_dir(str(link), "VLLM_EXL3_EXT_PATH")
+
+
+def test_validate_ext_search_dir_rejects_symlink_ancestor(tmp_path):
+    """A symlink component anywhere on the path is rejected."""
+    from vllm.model_executor.layers.quantization.exl3 import (
+        _validate_ext_search_dir,
+    )
+
+    real_dir = tmp_path / "real_dir"
+    real_dir.mkdir()
+    os.chmod(real_dir, 0o755)
+    link_dir = tmp_path / "link_dir"
+    link_dir.symlink_to(real_dir)
+
+    target = link_dir / "sub"
+    with pytest.raises(ValueError, match="symlink component"):
+        _validate_ext_search_dir(str(target), "VLLM_EXL3_EXT_PATH")
 
 
 def test_validate_ext_search_dir_rejects_world_writable(tmp_path):
-    """C2: world-writable directory for VLLM_EXL3_EXT_PATH is rejected."""
+    """A world-writable directory is rejected."""
     from vllm.model_executor.layers.quantization.exl3 import (
         _validate_ext_search_dir,
     )
 
     os.chmod(tmp_path, 0o777)
 
-    with pytest.raises(ValueError, match="world-writable"):
-        _validate_ext_search_dir(str(tmp_path), "VLLM_EXL3_EXT_PATH")
+    try:
+        with pytest.raises(ValueError, match="group/world-writable"):
+            _validate_ext_search_dir(str(tmp_path), "VLLM_EXL3_EXT_PATH")
+    finally:
+        os.chmod(tmp_path, 0o755)
 
 
-def test_validate_ext_search_dir_rejects_nonexistent(tmp_path):
-    """C2: non-existent directory is rejected."""
+def test_validate_ext_search_dir_rejects_group_writable(tmp_path):
+    """A group-writable directory is rejected."""
     from vllm.model_executor.layers.quantization.exl3 import (
         _validate_ext_search_dir,
     )
 
-    with pytest.raises(ValueError, match="directory"):
+    os.chmod(tmp_path, 0o775)
+
+    try:
+        with pytest.raises(ValueError, match="group/world-writable"):
+            _validate_ext_search_dir(str(tmp_path), "VLLM_EXL3_EXT_PATH")
+    finally:
+        os.chmod(tmp_path, 0o755)
+
+
+def test_validate_ext_search_dir_rejects_nonexistent(tmp_path):
+    """A non-existent / non-directory path is rejected (os.lstat raises
+    FileNotFoundError before the S_ISDIR check)."""
+    from vllm.model_executor.layers.quantization.exl3 import (
+        _validate_ext_search_dir,
+    )
+
+    with pytest.raises((ValueError, FileNotFoundError)):
         _validate_ext_search_dir(str(tmp_path / "nope"), "VLLM_EXL3_EXT_PATH")
 
 
 def test_validate_ext_search_dir_accepts_safe(tmp_path):
-    """C2: a safe directory passes."""
+    """A safe directory passes."""
     from vllm.model_executor.layers.quantization.exl3 import (
         _validate_ext_search_dir,
     )
@@ -113,45 +231,96 @@ def test_validate_ext_search_dir_accepts_safe(tmp_path):
     _validate_ext_search_dir(str(tmp_path), "VLLM_EXL3_EXT_PATH")
 
 
-def test_bits_per_expert_rejects_path_traversal():
-    """C3: bits_per_expert filename with path separators is rejected."""
+# ---------------------------------------------------------------------------
+# _load_rank_sliced_bitrates — bits_per_expert filename sanitization
+# ---------------------------------------------------------------------------
+
+
+def _make_config(bits_per_expert: str) -> "object":
+    """Build a minimal Exl3Config for _load_rank_sliced_bitrates."""
     from vllm.model_executor.layers.quantization.exl3 import Exl3Config
 
     config = Exl3Config.__new__(Exl3Config)
     config.rank_sliced_metadata = {
-        "bits_per_expert": "../../../../etc/passwd:k",
-        "experts_per_layer": 256,
-        "moe_layers": [3, 13],
+        "bits_per_expert": bits_per_expert,
+        "experts_per_layer": 2,
+        "moe_layers": [3, 4],
     }
     config.rank_sliced_k_values = [3, 4]
+    return config
 
-    with pytest.raises(ValueError, match="path separators"):
-        config._load_rank_sliced_bitrates("dummy_model", revision=None)
+
+def _stub_payload(filename, model_name, revision=None):
+    """A stub get_hf_file_to_dict returning a valid bitrate map."""
+    return {
+        "3": {"k": [3, 4]},
+        "4": {"k": [4, 3]},
+    }
+
+
+def test_bits_per_expert_rejects_path_traversal():
+    """C3: bits_per_expert filename with path separators is rejected."""
+    config = _make_config("../../../../etc/passwd:k")
+
+    with patch(
+        "vllm.model_executor.layers.quantization.exl3.get_hf_file_to_dict"
+    ) as mock:
+        with pytest.raises(ValueError, match="bare file name"):
+            config._load_rank_sliced_bitrates("dummy_model", revision=None)
+        mock.assert_not_called()
 
 
 def test_bits_per_expert_rejects_absolute_path():
     """C3: absolute path in bits_per_expert filename is rejected."""
-    from vllm.model_executor.layers.quantization.exl3 import Exl3Config
+    config = _make_config("/etc/passwd:k")
 
-    config = Exl3Config.__new__(Exl3Config)
-    config.rank_sliced_metadata = {
-        "bits_per_expert": "/etc/passwd:k",
-        "experts_per_layer": 256,
-        "moe_layers": [3, 13],
-    }
-    config.rank_sliced_k_values = [3, 4]
+    with pytest.raises(ValueError, match="bare file name"):
+        config._load_rank_sliced_bitrates("dummy_model", revision=None)
 
-    with pytest.raises(ValueError, match="path separators"):
+
+def test_bits_per_expert_rejects_dotdot():
+    """C3: '..' passes the naive basename identity test but is a traversal."""
+    config = _make_config("..:k")
+
+    with pytest.raises(ValueError, match="bare file name"):
+        config._load_rank_sliced_bitrates("dummy_model", revision=None)
+
+
+def test_bits_per_expert_rejects_dot():
+    """C3: '.' passes the naive basename identity test but is a traversal."""
+    config = _make_config(".:k")
+
+    with pytest.raises(ValueError, match="bare file name"):
+        config._load_rank_sliced_bitrates("dummy_model", revision=None)
+
+
+def test_bits_per_expert_rejects_empty():
+    """C3: empty filename ('':k from ':k') is rejected."""
+    config = _make_config(":k")
+
+    with pytest.raises(ValueError, match="bare file name"):
         config._load_rank_sliced_bitrates("dummy_model", revision=None)
 
 
 def test_bits_per_expert_accepts_safe_filename():
-    """C3: a bare filename (no path separators) passes the sanitization."""
-    # We can't fully test _load_rank_sliced_bitrates without a real model dir,
-    # but we can verify the basename check passes for a safe name.
-    assert os.path.basename("tier_bitmap.json") == "tier_bitmap.json"
-    assert os.path.basename("../evil.json") != "../evil.json"
-    assert os.path.basename("/etc/passwd") != "/etc/passwd"
+    """C3: a safe bare filename is accepted — exercises real vLLM code via
+    a stubbed get_hf_file_to_dict."""
+    config = _make_config("tier_bitmap.json:k")
+
+    with patch(
+        "vllm.model_executor.layers.quantization.exl3.get_hf_file_to_dict",
+        side_effect=_stub_payload,
+    ) as mock:
+        config._load_rank_sliced_bitrates("dummy_model", revision=None)
+        mock.assert_called_once_with(
+            "tier_bitmap.json", "dummy_model", revision=None
+        )
+
+    # The function should have populated rank_sliced_bits_by_layer.
+    assert config.rank_sliced_bits_by_layer == {
+        3: (3, 4),
+        4: (4, 3),
+    }
 
 
 if __name__ == "__main__":

--- a/tests/quantization/test_exl3_security.py
+++ b/tests/quantization/test_exl3_security.py
@@ -1,0 +1,158 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Security tests for EXL3 trust-boundary hardening (C1, C2, C3)."""
+
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+# We test the validation helpers and the bits_per_expert sanitization in
+# isolation, without loading the actual exllamav3_ext native library.
+
+
+def test_validate_native_lib_path_rejects_symlink(tmp_path):
+    """C1: VLLM_EXL3_ABI_SHIM must not be a symlink."""
+    from vllm.model_executor.layers.quantization.exl3 import (
+        _validate_native_lib_path,
+    )
+
+    target = tmp_path / "real.so"
+    target.write_text("dummy")
+    link = tmp_path / "shim.so"
+    link.symlink_to(target)
+
+    with pytest.raises(ValueError, match="symlink"):
+        _validate_native_lib_path(str(link), "VLLM_EXL3_ABI_SHIM")
+
+
+def test_validate_native_lib_path_rejects_nonexistent(tmp_path):
+    """C1: non-existent path is rejected."""
+    from vllm.model_executor.layers.quantization.exl3 import (
+        _validate_native_lib_path,
+    )
+
+    with pytest.raises(ValueError, match="non-existent"):
+        _validate_native_lib_path(str(tmp_path / "missing.so"), "VLLM_EXL3_ABI_SHIM")
+
+
+def test_validate_native_lib_path_rejects_world_writable(tmp_path):
+    """C1: world-writable .so is rejected."""
+    from vllm.model_executor.layers.quantization.exl3 import (
+        _validate_native_lib_path,
+    )
+
+    lib = tmp_path / "evil.so"
+    lib.write_text("dummy")
+    os.chmod(lib, 0o666)  # rw-rw-rw-
+
+    with pytest.raises(ValueError, match="group/world-writable"):
+        _validate_native_lib_path(str(lib), "VLLM_EXL3_ABI_SHIM")
+
+
+def test_validate_native_lib_path_rejects_world_writable_parent(tmp_path):
+    """C1: world-writable parent directory is rejected."""
+    from vllm.model_executor.layers.quantization.exl3 import (
+        _validate_native_lib_path,
+    )
+
+    lib = tmp_path / "evil.so"
+    lib.write_text("dummy")
+    os.chmod(lib, 0o644)
+    os.chmod(tmp_path, 0o777)  # world-writable parent
+
+    with pytest.raises(ValueError, match="parent directory"):
+        _validate_native_lib_path(str(lib), "VLLM_EXL3_ABI_SHIM")
+
+
+def test_validate_native_lib_path_accepts_safe(tmp_path):
+    """C1: a regular file in a safe directory passes."""
+    from vllm.model_executor.layers.quantization.exl3 import (
+        _validate_native_lib_path,
+    )
+
+    lib = tmp_path / "good.so"
+    lib.write_text("dummy")
+    os.chmod(lib, 0o644)
+    os.chmod(tmp_path, 0o755)
+
+    # Should not raise
+    _validate_native_lib_path(str(lib), "VLLM_EXL3_ABI_SHIM")
+
+
+def test_validate_ext_search_dir_rejects_world_writable(tmp_path):
+    """C2: world-writable directory for VLLM_EXL3_EXT_PATH is rejected."""
+    from vllm.model_executor.layers.quantization.exl3 import (
+        _validate_ext_search_dir,
+    )
+
+    os.chmod(tmp_path, 0o777)
+
+    with pytest.raises(ValueError, match="world-writable"):
+        _validate_ext_search_dir(str(tmp_path), "VLLM_EXL3_EXT_PATH")
+
+
+def test_validate_ext_search_dir_rejects_nonexistent(tmp_path):
+    """C2: non-existent directory is rejected."""
+    from vllm.model_executor.layers.quantization.exl3 import (
+        _validate_ext_search_dir,
+    )
+
+    with pytest.raises(ValueError, match="directory"):
+        _validate_ext_search_dir(str(tmp_path / "nope"), "VLLM_EXL3_EXT_PATH")
+
+
+def test_validate_ext_search_dir_accepts_safe(tmp_path):
+    """C2: a safe directory passes."""
+    from vllm.model_executor.layers.quantization.exl3 import (
+        _validate_ext_search_dir,
+    )
+
+    os.chmod(tmp_path, 0o755)
+    _validate_ext_search_dir(str(tmp_path), "VLLM_EXL3_EXT_PATH")
+
+
+def test_bits_per_expert_rejects_path_traversal():
+    """C3: bits_per_expert filename with path separators is rejected."""
+    from vllm.model_executor.layers.quantization.exl3 import Exl3Config
+
+    config = Exl3Config.__new__(Exl3Config)
+    config.rank_sliced_metadata = {
+        "bits_per_expert": "../../../../etc/passwd:k",
+        "experts_per_layer": 256,
+        "moe_layers": [3, 13],
+    }
+    config.rank_sliced_k_values = [3, 4]
+
+    with pytest.raises(ValueError, match="path separators"):
+        config._load_rank_sliced_bitrates("dummy_model", revision=None)
+
+
+def test_bits_per_expert_rejects_absolute_path():
+    """C3: absolute path in bits_per_expert filename is rejected."""
+    from vllm.model_executor.layers.quantization.exl3 import Exl3Config
+
+    config = Exl3Config.__new__(Exl3Config)
+    config.rank_sliced_metadata = {
+        "bits_per_expert": "/etc/passwd:k",
+        "experts_per_layer": 256,
+        "moe_layers": [3, 13],
+    }
+    config.rank_sliced_k_values = [3, 4]
+
+    with pytest.raises(ValueError, match="path separators"):
+        config._load_rank_sliced_bitrates("dummy_model", revision=None)
+
+
+def test_bits_per_expert_accepts_safe_filename():
+    """C3: a bare filename (no path separators) passes the sanitization."""
+    # We can't fully test _load_rank_sliced_bitrates without a real model dir,
+    # but we can verify the basename check passes for a safe name.
+    assert os.path.basename("tier_bitmap.json") == "tier_bitmap.json"
+    assert os.path.basename("../evil.json") != "../evil.json"
+    assert os.path.basename("/etc/passwd") != "/etc/passwd"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -19,10 +19,10 @@ one or initialize CUDA.
 
 from __future__ import annotations
 
-import ctypes
 import importlib
 import os
 import re
+import stat
 import sys
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
@@ -55,6 +55,7 @@ from vllm.model_executor.layers.quantization.base_config import (
     QuantizeMethodBase,
 )
 from vllm.model_executor.parameter import BasevLLMParameter
+from vllm.utils.path_validation import validate_native_lib_path
 from vllm.transformers_utils.repo_utils import get_hf_file_to_dict
 
 if TYPE_CHECKING:
@@ -167,56 +168,62 @@ _WORLD_WRITABLE = 0o002
 _GROUP_WRITABLE = 0o020
 
 
-def _validate_native_lib_path(path: str, env_var: str) -> None:
-    """Validate a path to a native .so before loading it via ctypes.CDLL.
-
-    The EXL3 ABI shim and the NCCL library are loaded from operator-supplied
-    paths.  Without validation, any process that can set the env var achieves
-    arbitrary native code execution (supply-chain / local privilege boundary).
-    """
-    p = os.path.abspath(path)
-    if not os.path.isfile(p):
-        raise ValueError(
-            f"{env_var} points to a non-existent or non-regular file: {path!r}"
-        )
-    if os.path.islink(path):
-        raise ValueError(
-            f"{env_var} must not be a symlink: {path!r}"
-        )
-    st = os.stat(p)
-    if st.st_mode & (_WORLD_WRITABLE | _GROUP_WRITABLE):
-        raise ValueError(
-            f"{env_var} file must not be group/world-writable "
-            f"(mode {oct(st.st_mode & 0o777)}): {path!r}"
-        )
-    parent = os.path.dirname(p)
-    if parent:
-        pst = os.stat(parent)
-        if pst.st_mode & _WORLD_WRITABLE:
-            raise ValueError(
-                f"{env_var} parent directory must not be world-writable: "
-                f"{parent!r}"
-            )
-
-
 def _validate_ext_search_dir(path: str, env_var: str) -> None:
     """Validate the directory inserted into sys.path for the EXL3 extension.
 
-    Rejects world-writable directories (e.g. /tmp, /dev/shm) and symlinks so
-    a compromised path entry cannot shadow arbitrary later imports.
+    Enforced controls:
+      * the path must resolve to an existing directory;
+      * the resolved path must equal its lexical abspath (no symlink
+        component anywhere on the chain) and ``lstat`` must not report the
+        final component as a symlink;
+      * neither the directory nor any ancestor may be group- or
+        world-writable (sticky-bit directories like /tmp are allowed).
+
+    These together stop a compromised path entry from being swapped for an
+    attacker-controlled module after validation, and from shadowing arbitrary
+    later imports.
     """
     if not path:
         return
-    p = os.path.abspath(path)
-    if not os.path.isdir(p):
+    if not os.path.isabs(path):
+        raise ValueError(
+            f"{env_var} must be an absolute path: {path!r}"
+        )
+    resolved = os.path.realpath(path)
+    if resolved != os.path.normpath(path):
+        raise ValueError(
+            f"{env_var} must not contain a symlink component: "
+            f"{path!r} resolves to {resolved!r}"
+        )
+    st = os.lstat(resolved)
+    if stat.S_ISLNK(st.st_mode):
+        raise ValueError(
+            f"{env_var} must not be a symlink: {resolved!r}"
+        )
+    if not stat.S_ISDIR(st.st_mode):
         raise ValueError(
             f"{env_var} does not resolve to a directory: {path!r}"
         )
-    st = os.stat(p)
-    if st.st_mode & _WORLD_WRITABLE:
+    if st.st_mode & (_GROUP_WRITABLE | _WORLD_WRITABLE):
         raise ValueError(
-            f"{env_var} directory must not be world-writable: {path!r}"
+            f"{env_var} directory must not be group/world-writable: "
+            f"{resolved!r}"
         )
+    # Walk ancestors: a writable directory anywhere on the chain lets an
+    # attacker swap a component and redirect the import.
+    parent = os.path.dirname(resolved)
+    while True:
+        pst = os.lstat(parent)
+        writable = pst.st_mode & (_GROUP_WRITABLE | _WORLD_WRITABLE)
+        if writable and not (pst.st_mode & stat.S_ISVTX):
+            raise ValueError(
+                f"{env_var} ancestor directory must not be "
+                f"group/world-writable: {parent!r}"
+            )
+        nxt = os.path.dirname(parent)
+        if nxt == parent:
+            break
+        parent = nxt
 
 def _load_exl3_ext() -> Any:
     """Load the existing ExLlamaV3 extension only from an actual CUDA call."""
@@ -227,9 +234,12 @@ def _load_exl3_ext() -> Any:
 
     shim = envs.VLLM_EXL3_ABI_SHIM
     if shim:
-        _validate_native_lib_path(shim, "VLLM_EXL3_ABI_SHIM")
-        ctypes.CDLL(shim, mode=ctypes.RTLD_GLOBAL)
-        logger.info("Loaded EXL3 ABI shim from %s", shim)
+        # Validate and load the *canonical* resolved path: validating one path
+        # and loading another re-opens the bypass validate_native_lib_path
+        # closes.
+        shim_canonical = validate_native_lib_path(shim, "VLLM_EXL3_ABI_SHIM")
+        ctypes.CDLL(shim_canonical, mode=ctypes.RTLD_GLOBAL)
+        logger.info("Loaded EXL3 ABI shim from %s", shim_canonical)
 
     ext_path = envs.VLLM_EXL3_EXT_PATH
     if ext_path:
@@ -595,10 +605,17 @@ class Exl3Config(QuantizationConfig):
         # relative or absolute path.  A malicious model's config.json could
         # set bits_per_expert to "../../../../etc/passwd:k" to read arbitrary
         # files via get_hf_file_to_dict → Path(model) / file_name.
-        if os.path.basename(filename) != filename:
+        # basename('..') == '..' and basename('.') == '.' both pass the naive
+        # identity test, so reject those (and the empty string) explicitly,
+        # along with any platform path separator.
+        if (not filename
+                or filename in (".", "..")
+                or os.sep in filename
+                or (os.altsep is not None and os.altsep in filename)
+                or os.path.basename(filename) != filename):
             raise ValueError(
-                "rank-sliced EXL3 bits_per_expert filename must not contain "
-                f"path separators: {filename!r}"
+                "rank-sliced EXL3 bits_per_expert filename must be a bare "
+                f"file name with no path components: {filename!r}"
             )
         payload = get_hf_file_to_dict(filename, model_name, revision=revision)
         if not isinstance(payload, dict):

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -31,6 +31,7 @@ import torch
 from transformers import PretrainedConfig
 
 from vllm.config import get_current_vllm_config_or_none
+import vllm.envs as envs
 from vllm.distributed import (
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
@@ -162,6 +163,61 @@ _RANK_SLICED_WEIGHT_RE = re.compile(
 ShardId = str | int | tuple[int, ...] | None
 
 
+_WORLD_WRITABLE = 0o002
+_GROUP_WRITABLE = 0o020
+
+
+def _validate_native_lib_path(path: str, env_var: str) -> None:
+    """Validate a path to a native .so before loading it via ctypes.CDLL.
+
+    The EXL3 ABI shim and the NCCL library are loaded from operator-supplied
+    paths.  Without validation, any process that can set the env var achieves
+    arbitrary native code execution (supply-chain / local privilege boundary).
+    """
+    p = os.path.abspath(path)
+    if not os.path.isfile(p):
+        raise ValueError(
+            f"{env_var} points to a non-existent or non-regular file: {path!r}"
+        )
+    if os.path.islink(path):
+        raise ValueError(
+            f"{env_var} must not be a symlink: {path!r}"
+        )
+    st = os.stat(p)
+    if st.st_mode & (_WORLD_WRITABLE | _GROUP_WRITABLE):
+        raise ValueError(
+            f"{env_var} file must not be group/world-writable "
+            f"(mode {oct(st.st_mode & 0o777)}): {path!r}"
+        )
+    parent = os.path.dirname(p)
+    if parent:
+        pst = os.stat(parent)
+        if pst.st_mode & _WORLD_WRITABLE:
+            raise ValueError(
+                f"{env_var} parent directory must not be world-writable: "
+                f"{parent!r}"
+            )
+
+
+def _validate_ext_search_dir(path: str, env_var: str) -> None:
+    """Validate the directory inserted into sys.path for the EXL3 extension.
+
+    Rejects world-writable directories (e.g. /tmp, /dev/shm) and symlinks so
+    a compromised path entry cannot shadow arbitrary later imports.
+    """
+    if not path:
+        return
+    p = os.path.abspath(path)
+    if not os.path.isdir(p):
+        raise ValueError(
+            f"{env_var} does not resolve to a directory: {path!r}"
+        )
+    st = os.stat(p)
+    if st.st_mode & _WORLD_WRITABLE:
+        raise ValueError(
+            f"{env_var} directory must not be world-writable: {path!r}"
+        )
+
 def _load_exl3_ext() -> Any:
     """Load the existing ExLlamaV3 extension only from an actual CUDA call."""
 
@@ -169,15 +225,25 @@ def _load_exl3_ext() -> Any:
     if _EXL3_EXT is not None:
         return _EXL3_EXT
 
-    shim = os.environ.get("VLLM_EXL3_ABI_SHIM")
+    shim = envs.VLLM_EXL3_ABI_SHIM
     if shim:
+        _validate_native_lib_path(shim, "VLLM_EXL3_ABI_SHIM")
         ctypes.CDLL(shim, mode=ctypes.RTLD_GLOBAL)
+        logger.info("Loaded EXL3 ABI shim from %s", shim)
 
-    ext_path = os.environ.get("VLLM_EXL3_EXT_PATH")
+    ext_path = envs.VLLM_EXL3_EXT_PATH
     if ext_path:
         search_dir = ext_path if os.path.isdir(ext_path) else os.path.dirname(ext_path)
+        _validate_ext_search_dir(search_dir, "VLLM_EXL3_EXT_PATH")
+        # Insert scoped — import immediately, then remove so a compromised
+        # path entry cannot shadow arbitrary later imports.
         if search_dir and search_dir not in sys.path:
             sys.path.insert(0, search_dir)
+            _scoped_path = search_dir
+        else:
+            _scoped_path = None
+    else:
+        _scoped_path = None
 
     try:
         ext = importlib.import_module("exllamav3_ext")
@@ -188,6 +254,9 @@ def _load_exl3_ext() -> Any:
             "PyTorch ABI shim is required)."
         )
         raise RuntimeError(f"Unable to import exllamav3_ext. {hint}") from exc
+    finally:
+        if _scoped_path is not None and _scoped_path in sys.path:
+            sys.path.remove(_scoped_path)
 
     if not hasattr(ext, "exl3_gemm"):
         raise RuntimeError(
@@ -522,6 +591,15 @@ class Exl3Config(QuantizationConfig):
                 "rank-sliced EXL3 bits_per_expert must use 'file.json:field' syntax, "
                 f"got {reference!r}"
             ) from exc
+        # Reject path traversal: the filename must be a bare file name, not a
+        # relative or absolute path.  A malicious model's config.json could
+        # set bits_per_expert to "../../../../etc/passwd:k" to read arbitrary
+        # files via get_hf_file_to_dict → Path(model) / file_name.
+        if os.path.basename(filename) != filename:
+            raise ValueError(
+                "rank-sliced EXL3 bits_per_expert filename must not contain "
+                f"path separators: {filename!r}"
+            )
         payload = get_hf_file_to_dict(filename, model_name, revision=revision)
         if not isinstance(payload, dict):
             raise ValueError(f"rank-sliced EXL3 could not load {filename!r}")

--- a/vllm/utils/path_validation.py
+++ b/vllm/utils/path_validation.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Validation helpers for operator-supplied native library paths."""
+
+import os
+import stat
+
+_GROUP_WRITABLE = stat.S_IWGRP
+_WORLD_WRITABLE = stat.S_IWOTH
+
+
+def validate_native_lib_path(path: str, env_var: str) -> str:
+    """Validate a native library path and return the path to load.
+
+    The returned value MUST be the one handed to ``ctypes.CDLL``. Validating
+    one path and loading another re-opens the bypass this function closes.
+
+    Args:
+        path: Operator-supplied path from ``env_var``.
+        env_var: Environment variable name, used in error messages.
+
+    Returns:
+        The canonical absolute path that passed validation.
+
+    Raises:
+        ValueError: The path is relative, contains a symlink component, is not
+            a regular file, or it/an ancestor is group- or world-writable.
+    """
+    if not os.path.isabs(path):
+        # A bare soname makes dlopen search its own path, so the inode that
+        # was validated is not necessarily the inode that gets loaded.
+        raise ValueError(f"{env_var} must be an absolute path: {path!r}")
+
+    resolved = os.path.realpath(path)
+    if resolved != os.path.normpath(path):
+        # realpath differs => at least one component is a symlink. islink()
+        # only inspects the final component, so it cannot catch this.
+        raise ValueError(
+            f"{env_var} must not contain a symlink component: "
+            f"{path!r} resolves to {resolved!r}"
+        )
+
+    st = os.lstat(resolved)
+    if stat.S_ISLNK(st.st_mode):
+        raise ValueError(f"{env_var} must not be a symlink: {resolved!r}")
+    if not stat.S_ISREG(st.st_mode):
+        raise ValueError(f"{env_var} must be a regular file: {resolved!r}")
+    if st.st_mode & (_GROUP_WRITABLE | _WORLD_WRITABLE):
+        raise ValueError(
+            f"{env_var} must not be group/world-writable: {resolved!r}"
+        )
+
+    # Walk every ancestor: a writable directory anywhere on the chain lets an
+    # attacker replace a component and redirect the load.
+    parent = os.path.dirname(resolved)
+    while True:
+        pst = os.lstat(parent)
+        writable = pst.st_mode & (_GROUP_WRITABLE | _WORLD_WRITABLE)
+        # The sticky bit (/tmp) stops non-owners from replacing entries.
+        if writable and not (pst.st_mode & stat.S_ISVTX):
+            raise ValueError(
+                f"{env_var} ancestor directory must not be "
+                f"group/world-writable: {parent!r}"
+            )
+        nxt = os.path.dirname(parent)
+        if nxt == parent:
+            break
+        parent = nxt
+
+    return resolved


### PR DESCRIPTION
## Summary

Fixes #263

Three fork-specific Critical security vulnerabilities in the EXL3 quantization integration (`vllm/model_executor/layers/quantization/exl3.py`):

### C1 — Arbitrary `.so` loading via `VLLM_EXL3_ABI_SHIM` (line 174)

`ctypes.CDLL(shim, mode=ctypes.RTLD_GLOBAL)` loaded any `.so` from the env var with no validation. The path was read via raw `os.environ.get`, bypassing `vllm.envs` registration. Any process that can set the env var achieved arbitrary native code execution.

**Fix:** Route through `envs.VLLM_EXL3_ABI_SHIM`. Validate: regular file (not symlink), not group/world-writable, parent directory not world-writable. Log the loaded path.

### C2 — `sys.path` injection via `VLLM_EXL3_EXT_PATH` (line 180)

Arbitrary directory inserted into `sys.path[0]` with no validation. `importlib.import_module("exllamav3_ext")` then loaded from it. Same `os.environ` bypass. The `sys.path` insertion was persistent for the process lifetime.

**Fix:** Route through `envs.VLLM_EXL3_EXT_PATH`. Validate directory is not world-writable. Scope the `sys.path` insertion (insert, import, remove in a `finally` block) so a compromised path entry cannot shadow arbitrary later imports.

### C3 — Config path traversal via `bits_per_expert` (line 518)

The model's `config.json` field `bits_per_expert` was split on `:` to get a filename, then passed to `get_hf_file_to_dict` → `try_get_local_file` which computes `Path(model) / file_name` with no sanitization. A malicious model could set `bits_per_expert` to `"../../../../etc/passwd:k"` to read arbitrary files.

**Fix:** Reject if `os.path.basename(filename) != filename` — catches `../` traversal, absolute paths, and any separator injection in one check.

## Files changed

- `vllm/model_executor/layers/quantization/exl3.py` — added `_validate_native_lib_path` and `_validate_ext_search_dir` helpers; routed env reads through `vllm.envs`; scoped `sys.path` insertion; added `basename` check in `_load_rank_sliced_bitrates`
- `tests/quantization/test_exl3_security.py` — 11 new tests covering all three fixes

## Verification

Tested on AIBoss (RTX 5090, r28 image) with the patched files overlaid:

```
11 passed
```

All validation tests pass:
- `_validate_native_lib_path` rejects symlinks, nonexistent files, world-writable files, world-writable parent dirs; accepts safe paths
- `_validate_ext_search_dir` rejects world-writable and nonexistent dirs; accepts safe dirs
- `bits_per_expert` rejects `../../../../etc/passwd:k` and `/etc/passwd:k`; accepts `tier_bitmap.json`

## Impact

These are trust-boundary fixes. C1/C2 close arbitrary native code execution via env var injection. C3 closes arbitrary file read via malicious model checkpoints. The fixes are minimal and surgical — no behavioral change for legitimate configurations.
