### PR TITLE
security(nccl): validate VLLM_NCCL_SO_PATH before ctypes.CDLL

### DIFF
--- a/tests/distributed/test_nccl_path_security.py
+++ b/tests/distributed/test_nccl_path_security.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Security test for NCCL .so path validation (H1)."""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from vllm.utils.path_validation import validate_native_lib_path
+
+
+def test_validate_nccl_path_rejects_symlink(tmp_path):
+    """H1: VLLM_NCCL_SO_PATH must not be a symlink."""
+    target = tmp_path / "real_libnccl.so.2"
+    target.write_text("dummy")
+    link = tmp_path / "libnccl.so.2"
+    link.symlink_to(target)
+
+    with pytest.raises(ValueError, match="symlink"):
+        validate_native_lib_path(str(link), "VLLM_NCCL_SO_PATH")
+
+
+def test_validate_nccl_path_rejects_nonexistent(tmp_path):
+    """H1: non-existent path is rejected."""
+    with pytest.raises(ValueError, match="non-existent"):
+        validate_native_lib_path(
+            str(tmp_path / "missing.so"), "VLLM_NCCL_SO_PATH"
+        )
+
+
+def test_validate_nccl_path_rejects_world_writable(tmp_path):
+    """H1: world-writable .so is rejected."""
+    lib = tmp_path / "libnccl.so.2"
+    lib.write_text("dummy")
+    os.chmod(lib, 0o666)
+
+    with pytest.raises(ValueError, match="group/world-writable"):
+        validate_native_lib_path(str(lib), "VLLM_NCCL_SO_PATH")
+
+
+def test_validate_nccl_path_rejects_world_writable_parent(tmp_path):
+    """H1: world-writable parent directory is rejected."""
+    lib = tmp_path / "libnccl.so.2"
+    lib.write_text("dummy")
+    os.chmod(lib, 0o644)
+    os.chmod(tmp_path, 0o777)
+
+    with pytest.raises(ValueError, match="parent directory"):
+        validate_native_lib_path(str(lib), "VLLM_NCCL_SO_PATH")
+
+
+def test_validate_nccl_path_accepts_safe(tmp_path):
+    """H1: a regular file in a safe directory passes."""
+    lib = tmp_path / "libnccl-local-inference.so.2.30.4"
+    lib.write_text("dummy")
+    os.chmod(lib, 0o644)
+    os.chmod(tmp_path, 0o755)
+
+    validate_native_lib_path(str(lib), "VLLM_NCCL_SO_PATH")
+
+
+def test_find_nccl_library_validates_explicit_path(tmp_path):
+    """H1: find_nccl_library validates VLLM_NCCL_SO_PATH when set."""
+    from vllm.utils.nccl import find_nccl_library
+
+    # A safe path should work (returns the path, doesn't raise)
+    lib = tmp_path / "libnccl.so.2"
+    lib.write_text("dummy")
+    os.chmod(lib, 0o644)
+    os.chmod(tmp_path, 0o755)
+
+    with patch("vllm.envs.VLLM_NCCL_SO_PATH", str(lib)):
+        result = find_nccl_library()
+        assert result == str(lib)
+
+
+def test_find_nccl_library_rejects_world_writable(tmp_path):
+    """H1: find_nccl_library rejects a world-writable VLLM_NCCL_SO_PATH."""
+    from vllm.utils.nccl import find_nccl_library
+
+    lib = tmp_path / "libnccl.so.2"
+    lib.write_text("dummy")
+    os.chmod(lib, 0o666)  # world-writable
+    os.chmod(tmp_path, 0o755)
+
+    with patch("vllm.envs.VLLM_NCCL_SO_PATH", str(lib)):
+        with pytest.raises(ValueError, match="group/world-writable"):
+            find_nccl_library()
+
+
+def test_find_nccl_library_rejects_symlink(tmp_path):
+    """H1: find_nccl_library rejects a symlink VLLM_NCCL_SO_PATH."""
+    from vllm.utils.nccl import find_nccl_library
+
+    target = tmp_path / "real.so"
+    target.write_text("dummy")
+    link = tmp_path / "libnccl.so.2"
+    link.symlink_to(target)
+    os.chmod(target, 0o644)
+    os.chmod(tmp_path, 0o755)
+
+    with patch("vllm.envs.VLLM_NCCL_SO_PATH", str(link)):
+        with pytest.raises(ValueError, match="symlink"):
+            find_nccl_library()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/distributed/test_nccl_path_security.py
+++ b/tests/distributed/test_nccl_path_security.py
@@ -10,81 +10,186 @@ import pytest
 from vllm.utils.path_validation import validate_native_lib_path
 
 
+def _base(tmp_path):
+    """Return a realpath-resolved base dir so the /var -> /private/var
+    symlink on macOS does not itself trip the symlink-component check."""
+    return os.path.realpath(str(tmp_path))
+
+
 def test_validate_nccl_path_rejects_symlink(tmp_path):
     """H1: VLLM_NCCL_SO_PATH must not be a symlink."""
-    target = tmp_path / "real_libnccl.so.2"
-    target.write_text("dummy")
-    link = tmp_path / "libnccl.so.2"
-    link.symlink_to(target)
+    base = _base(tmp_path)
+    target = os.path.join(base, "real_libnccl.so.2")
+    with open(target, "w") as f:
+        f.write("dummy")
+    link = os.path.join(base, "libnccl.so.2")
+    os.symlink(target, link)
 
     with pytest.raises(ValueError, match="symlink"):
-        validate_native_lib_path(str(link), "VLLM_NCCL_SO_PATH")
+        validate_native_lib_path(link, "VLLM_NCCL_SO_PATH")
 
 
 def test_validate_nccl_path_rejects_nonexistent(tmp_path):
-    """H1: non-existent path is rejected."""
-    with pytest.raises(ValueError, match="non-existent"):
+    """H1: non-existent path is rejected (lstat raises FileNotFoundError)."""
+    base = _base(tmp_path)
+    with pytest.raises(FileNotFoundError):
         validate_native_lib_path(
-            str(tmp_path / "missing.so"), "VLLM_NCCL_SO_PATH"
+            os.path.join(base, "missing.so"), "VLLM_NCCL_SO_PATH"
         )
 
 
 def test_validate_nccl_path_rejects_world_writable(tmp_path):
     """H1: world-writable .so is rejected."""
-    lib = tmp_path / "libnccl.so.2"
-    lib.write_text("dummy")
-    os.chmod(lib, 0o666)
+    base = _base(tmp_path)
+    lib = os.path.join(base, "libnccl.so.2")
+    with open(lib, "w") as f:
+        f.write("dummy")
+    os.chmod(lib, 0o666)  # noqa: S103 -- intentional world-writable fixture
 
     with pytest.raises(ValueError, match="group/world-writable"):
-        validate_native_lib_path(str(lib), "VLLM_NCCL_SO_PATH")
+        validate_native_lib_path(lib, "VLLM_NCCL_SO_PATH")
+
+
+def test_validate_nccl_path_rejects_group_writable_file(tmp_path):
+    """H1: group-writable (but not world-writable) .so is rejected.
+
+    Uses 0o664 so the rejection is distinguishable from the world-writable
+    0o666 case (N4).
+    """
+    base = _base(tmp_path)
+    lib = os.path.join(base, "libnccl.so.2")
+    with open(lib, "w") as f:
+        f.write("dummy")
+    os.chmod(lib, 0o664)  # noqa: S103 -- intentional group-writable fixture
+
+    with pytest.raises(ValueError, match="group/world-writable"):
+        validate_native_lib_path(lib, "VLLM_NCCL_SO_PATH")
 
 
 def test_validate_nccl_path_rejects_world_writable_parent(tmp_path):
     """H1: world-writable parent directory is rejected."""
-    lib = tmp_path / "libnccl.so.2"
-    lib.write_text("dummy")
+    base = _base(tmp_path)
+    lib = os.path.join(base, "libnccl.so.2")
+    with open(lib, "w") as f:
+        f.write("dummy")
     os.chmod(lib, 0o644)
-    os.chmod(tmp_path, 0o777)
+    os.chmod(base, 0o777)  # noqa: S103 -- intentional world-writable parent
 
-    with pytest.raises(ValueError, match="parent directory"):
-        validate_native_lib_path(str(lib), "VLLM_NCCL_SO_PATH")
+    with pytest.raises(ValueError, match="ancestor directory"):
+        validate_native_lib_path(lib, "VLLM_NCCL_SO_PATH")
+
+
+def test_validate_nccl_path_rejects_group_writable_parent(tmp_path):
+    """H1: group-writable parent directory (0o775, no sticky) is rejected."""
+    base = _base(tmp_path)
+    sub = os.path.join(base, "subdir")
+    os.makedirs(sub, mode=0o755)
+    lib = os.path.join(sub, "libnccl.so.2")
+    with open(lib, "w") as f:
+        f.write("dummy")
+    os.chmod(lib, 0o644)
+    os.chmod(sub, 0o775)  # noqa: S103 -- intentional group-writable parent
+
+    with pytest.raises(ValueError, match="ancestor directory"):
+        validate_native_lib_path(lib, "VLLM_NCCL_SO_PATH")
+
+
+def test_validate_nccl_path_rejects_symlinked_parent_component(tmp_path):
+    """H1: a symlink in a parent component is rejected even when the final
+    path element is a real file.
+
+    Builds evil_parent/real/lib.so (the file the kernel would load) and a
+    symlink link -> evil_parent/real, then passes link/../real/lib.so.
+    os.path.normpath collapses the '..' lexically giving base/real/lib.so,
+    but os.path.realpath resolves through the symlink giving
+    base/evil_parent/real/lib.so — the two diverge, proving the bypass
+    (B4) and that the validator catches it.
+    """
+    base = _base(tmp_path)
+    evil_parent = os.path.join(base, "evil_parent")
+    real_dir = os.path.join(evil_parent, "real")
+    os.makedirs(real_dir, mode=0o755)
+    lib = os.path.join(real_dir, "lib.so")
+    with open(lib, "w") as f:
+        f.write("dummy")
+    os.chmod(lib, 0o644)
+    os.chmod(evil_parent, 0o755)
+
+    # Symlink at base/link pointing to evil_parent/real (different parent
+    # than link itself, so normpath(..) and realpath(..) diverge).
+    link = os.path.join(base, "link")
+    os.symlink(real_dir, link)
+
+    # normpath -> base/real/lib.so  (lexical collapse of link/..)
+    # realpath -> base/evil_parent/real/lib.so  (kernel resolves link first)
+    bypass_path = os.path.join(link, "..", "real", "lib.so")
+
+    with pytest.raises(ValueError, match="symlink component"):
+        validate_native_lib_path(bypass_path, "VLLM_NCCL_SO_PATH")
+
+
+def test_validate_nccl_path_rejects_relative_path(tmp_path):
+    """H1: a relative path is rejected (dlopen would search its own path)."""
+    with pytest.raises(ValueError, match="absolute path"):
+        validate_native_lib_path("libnccl.so.2", "VLLM_NCCL_SO_PATH")
+
+
+def test_validate_nccl_path_returns_canonical_resolved_path(tmp_path):
+    """H1: the returned value is the canonical realpath-resolved path."""
+    base = _base(tmp_path)
+    lib = os.path.join(base, "libnccl.so.2")
+    with open(lib, "w") as f:
+        f.write("dummy")
+    os.chmod(lib, 0o644)
+    os.chmod(base, 0o755)
+
+    result = validate_native_lib_path(lib, "VLLM_NCCL_SO_PATH")
+    assert result == os.path.realpath(lib)
+    assert os.path.isabs(result)
+    assert result == lib  # already canonical
 
 
 def test_validate_nccl_path_accepts_safe(tmp_path):
     """H1: a regular file in a safe directory passes."""
-    lib = tmp_path / "libnccl-local-inference.so.2.30.4"
-    lib.write_text("dummy")
+    base = _base(tmp_path)
+    lib = os.path.join(base, "libnccl-local-inference.so.2.30.4")
+    with open(lib, "w") as f:
+        f.write("dummy")
     os.chmod(lib, 0o644)
-    os.chmod(tmp_path, 0o755)
+    os.chmod(base, 0o755)
 
-    validate_native_lib_path(str(lib), "VLLM_NCCL_SO_PATH")
+    validate_native_lib_path(lib, "VLLM_NCCL_SO_PATH")
 
 
 def test_find_nccl_library_validates_explicit_path(tmp_path):
-    """H1: find_nccl_library validates VLLM_NCCL_SO_PATH when set."""
+    """H1: find_nccl_library validates VLLM_NCCL_SO_PATH when set and
+    returns the canonical path."""
     from vllm.utils.nccl import find_nccl_library
 
-    # A safe path should work (returns the path, doesn't raise)
-    lib = tmp_path / "libnccl.so.2"
-    lib.write_text("dummy")
+    base = _base(tmp_path)
+    lib = os.path.join(base, "libnccl.so.2")
+    with open(lib, "w") as f:
+        f.write("dummy")
     os.chmod(lib, 0o644)
-    os.chmod(tmp_path, 0o755)
+    os.chmod(base, 0o755)
 
-    with patch("vllm.envs.VLLM_NCCL_SO_PATH", str(lib)):
+    with patch("vllm.envs.VLLM_NCCL_SO_PATH", lib):
         result = find_nccl_library()
-        assert result == str(lib)
+        assert result == lib
 
 
 def test_find_nccl_library_rejects_world_writable(tmp_path):
     """H1: find_nccl_library rejects a world-writable VLLM_NCCL_SO_PATH."""
     from vllm.utils.nccl import find_nccl_library
 
-    lib = tmp_path / "libnccl.so.2"
-    lib.write_text("dummy")
-    os.chmod(lib, 0o666)  # world-writable
-    os.chmod(tmp_path, 0o755)
+    base = _base(tmp_path)
+    lib = os.path.join(base, "libnccl.so.2")
+    with open(lib, "w") as f:
+        f.write("dummy")
+    os.chmod(lib, 0o666)  # noqa: S103 -- intentional world-writable fixture
+    os.chmod(base, 0o755)
 
-    with patch("vllm.envs.VLLM_NCCL_SO_PATH", str(lib)):
+    with patch("vllm.envs.VLLM_NCCL_SO_PATH", lib):
         with pytest.raises(ValueError, match="group/world-writable"):
             find_nccl_library()
 
@@ -93,14 +198,16 @@ def test_find_nccl_library_rejects_symlink(tmp_path):
     """H1: find_nccl_library rejects a symlink VLLM_NCCL_SO_PATH."""
     from vllm.utils.nccl import find_nccl_library
 
-    target = tmp_path / "real.so"
-    target.write_text("dummy")
-    link = tmp_path / "libnccl.so.2"
-    link.symlink_to(target)
+    base = _base(tmp_path)
+    target = os.path.join(base, "real.so")
+    with open(target, "w") as f:
+        f.write("dummy")
+    link = os.path.join(base, "libnccl.so.2")
+    os.symlink(target, link)
     os.chmod(target, 0o644)
-    os.chmod(tmp_path, 0o755)
+    os.chmod(base, 0o755)
 
-    with patch("vllm.envs.VLLM_NCCL_SO_PATH", str(link)):
+    with patch("vllm.envs.VLLM_NCCL_SO_PATH", link):
         with pytest.raises(ValueError, match="symlink"):
             find_nccl_library()
 

--- a/vllm/utils/nccl.py
+++ b/vllm/utils/nccl.py
@@ -22,9 +22,10 @@ def find_nccl_library() -> str:
     """
     so_file = envs.VLLM_NCCL_SO_PATH
     if so_file:
-        validate_native_lib_path(so_file, "VLLM_NCCL_SO_PATH")
+        so_file = validate_native_lib_path(so_file, "VLLM_NCCL_SO_PATH")
         logger.info(
-            "Found nccl from environment variable VLLM_NCCL_SO_PATH=%s", so_file
+            "Found nccl from environment variable VLLM_NCCL_SO_PATH=%s",
+            so_file,
         )
     else:
         if torch.version.cuda is not None:

--- a/vllm/utils/nccl.py
+++ b/vllm/utils/nccl.py
@@ -9,6 +9,7 @@ import os
 import torch
 
 import vllm.envs as envs
+from vllm.utils.path_validation import validate_native_lib_path
 from vllm.logger import init_logger
 
 logger = init_logger(__name__)
@@ -21,6 +22,7 @@ def find_nccl_library() -> str:
     """
     so_file = envs.VLLM_NCCL_SO_PATH
     if so_file:
+        validate_native_lib_path(so_file, "VLLM_NCCL_SO_PATH")
         logger.info(
             "Found nccl from environment variable VLLM_NCCL_SO_PATH=%s", so_file
         )

--- a/vllm/utils/path_validation.py
+++ b/vllm/utils/path_validation.py
@@ -1,57 +1,70 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Path validation helpers for operator-supplied native library paths.
-
-Used by callers that load shared libraries (``.so``) via ``ctypes.CDLL``
-from paths taken from environment variables (e.g. ``VLLM_NCCL_SO_PATH``,
-``VLLM_EXL3_ABI_SHIM``). Without validation, any process that can set
-the env var achieves arbitrary native code execution (supply-chain /
-local privilege boundary).
-"""
+"""Validation helpers for operator-supplied native library paths."""
 
 import os
+import stat
 
-_WORLD_WRITABLE = 0o002
-_GROUP_WRITABLE = 0o020
+_GROUP_WRITABLE = stat.S_IWGRP
+_WORLD_WRITABLE = stat.S_IWOTH
 
 
-def validate_native_lib_path(path: str, env_var: str) -> None:
-    """Validate a path to a native .so before loading it via ctypes.CDLL.
+def validate_native_lib_path(path: str, env_var: str) -> str:
+    """Validate a native library path and return the path to load.
 
-    Checks:
-      - The path resolves to a regular file (not a directory or device node).
-      - The path is not a symlink (prevents symlink-swap attacks).
-      - The file is not group/world-writable (prevents in-place replacement
-        by an unprivileged user).
-      - The parent directory is not world-writable (prevents an attacker
-        from creating a new .so in the same directory).
+    The returned value MUST be the one handed to ``ctypes.CDLL``. Validating
+    one path and loading another re-opens the bypass this function closes.
 
     Args:
-        path: The filesystem path to validate.
-        env_var: The name of the env var the path came from, used in error
-            messages for operator diagnostics.
+        path: Operator-supplied path from ``env_var``.
+        env_var: Environment variable name, used in error messages.
+
+    Returns:
+        The canonical absolute path that passed validation.
 
     Raises:
-        ValueError: If any check fails.
+        ValueError: The path is relative, contains a symlink component, is not
+            a regular file, or it/an ancestor is group- or world-writable.
     """
-    p = os.path.abspath(path)
-    if not os.path.isfile(p):
+    if not os.path.isabs(path):
+        # A bare soname makes dlopen search its own path, so the inode that
+        # was validated is not necessarily the inode that gets loaded.
+        raise ValueError(f"{env_var} must be an absolute path: {path!r}")
+
+    resolved = os.path.realpath(path)
+    if resolved != os.path.normpath(path):
+        # realpath differs => at least one component is a symlink. islink()
+        # only inspects the final component, so it cannot catch this.
         raise ValueError(
-            f"{env_var} points to a non-existent or non-regular file: {path!r}"
+            f"{env_var} must not contain a symlink component: "
+            f"{path!r} resolves to {resolved!r}"
         )
-    if os.path.islink(path):
-        raise ValueError(f"{env_var} must not be a symlink: {path!r}")
-    st = os.stat(p)
-    if st.st_mode & (_WORLD_WRITABLE | _GROUP_WRITABLE):
+
+    st = os.lstat(resolved)
+    if stat.S_ISLNK(st.st_mode):
+        raise ValueError(f"{env_var} must not be a symlink: {resolved!r}")
+    if not stat.S_ISREG(st.st_mode):
+        raise ValueError(f"{env_var} must be a regular file: {resolved!r}")
+    if st.st_mode & (_GROUP_WRITABLE | _WORLD_WRITABLE):
         raise ValueError(
-            f"{env_var} file must not be group/world-writable "
-            f"(mode {oct(st.st_mode & 0o777)}): {path!r}"
+            f"{env_var} must not be group/world-writable: {resolved!r}"
         )
-    parent = os.path.dirname(p)
-    if parent:
-        pst = os.stat(parent)
-        if pst.st_mode & _WORLD_WRITABLE:
+
+    # Walk every ancestor: a writable directory anywhere on the chain lets an
+    # attacker replace a component and redirect the load.
+    parent = os.path.dirname(resolved)
+    while True:
+        pst = os.lstat(parent)
+        writable = pst.st_mode & (_GROUP_WRITABLE | _WORLD_WRITABLE)
+        # The sticky bit (/tmp) stops non-owners from replacing entries.
+        if writable and not (pst.st_mode & stat.S_ISVTX):
             raise ValueError(
-                f"{env_var} parent directory must not be world-writable: "
-                f"{parent!r}"
+                f"{env_var} ancestor directory must not be "
+                f"group/world-writable: {parent!r}"
             )
+        nxt = os.path.dirname(parent)
+        if nxt == parent:
+            break
+        parent = nxt
+
+    return resolved

--- a/vllm/utils/path_validation.py
+++ b/vllm/utils/path_validation.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Path validation helpers for operator-supplied native library paths.
+
+Used by callers that load shared libraries (``.so``) via ``ctypes.CDLL``
+from paths taken from environment variables (e.g. ``VLLM_NCCL_SO_PATH``,
+``VLLM_EXL3_ABI_SHIM``). Without validation, any process that can set
+the env var achieves arbitrary native code execution (supply-chain /
+local privilege boundary).
+"""
+
+import os
+
+_WORLD_WRITABLE = 0o002
+_GROUP_WRITABLE = 0o020
+
+
+def validate_native_lib_path(path: str, env_var: str) -> None:
+    """Validate a path to a native .so before loading it via ctypes.CDLL.
+
+    Checks:
+      - The path resolves to a regular file (not a directory or device node).
+      - The path is not a symlink (prevents symlink-swap attacks).
+      - The file is not group/world-writable (prevents in-place replacement
+        by an unprivileged user).
+      - The parent directory is not world-writable (prevents an attacker
+        from creating a new .so in the same directory).
+
+    Args:
+        path: The filesystem path to validate.
+        env_var: The name of the env var the path came from, used in error
+            messages for operator diagnostics.
+
+    Raises:
+        ValueError: If any check fails.
+    """
+    p = os.path.abspath(path)
+    if not os.path.isfile(p):
+        raise ValueError(
+            f"{env_var} points to a non-existent or non-regular file: {path!r}"
+        )
+    if os.path.islink(path):
+        raise ValueError(f"{env_var} must not be a symlink: {path!r}")
+    st = os.stat(p)
+    if st.st_mode & (_WORLD_WRITABLE | _GROUP_WRITABLE):
+        raise ValueError(
+            f"{env_var} file must not be group/world-writable "
+            f"(mode {oct(st.st_mode & 0o777)}): {path!r}"
+        )
+    parent = os.path.dirname(p)
+    if parent:
+        pst = os.stat(parent)
+        if pst.st_mode & _WORLD_WRITABLE:
+            raise ValueError(
+                f"{env_var} parent directory must not be world-writable: "
+                f"{parent!r}"
+            )


### PR DESCRIPTION
## Summary

Fixes #267

The fork ships a custom NCCL build (`libnccl-local-inference.so.2.30.4`) loaded via `VLLM_NCCL_SO_PATH`. `ctypes.CDLL(so_file)` at `pynccl_wrapper.py:335` loaded the `.so` with no path validation — any process that can set the env var or replace the file achieves arbitrary native code execution.

### What was already hardened

Unlike C1/C2 (EXL3 ABI shim in PR #265), the NCCL path already:
- Routes through `envs.VLLM_NCCL_SO_PATH` (not raw `os.environ.get`)
- Logs the loaded path at INFO level

### What was missing

No integrity check before `ctypes.CDLL`. The `.so` could be a symlink, world-writable, or in a world-writable directory — any of which enables an attacker to substitute a malicious library.

### The fix

Call `validate_native_lib_path(so_file, "VLLM_NCCL_SO_PATH")` in `find_nccl_library` when an explicit path is set. The validator is factored into `vllm/utils/path_validation.py` so both the NCCL loader and the EXL3 loader (PR #265) share the same checks:

- **Regular file** — not a directory or device node
- **Not a symlink** — prevents symlink-swap attacks
- **Not group/world-writable** — prevents in-place replacement by an unprivileged user
- **Parent directory not world-writable** — prevents creating a new `.so` in the same directory

The system-search fallback (`ctypes.CDLL("libnccl.so.2")` via `dlopen`) is **not** validated — `dlopen` searches root-owned system paths (`/usr/lib`, `LD_LIBRARY_PATH`), and validating a bare soname (not a path) doesn't make sense.

## Files changed

- `vllm/utils/path_validation.py` — new shared `validate_native_lib_path` utility (factored out so PR #265 can also use it)
- `vllm/utils/nccl.py` — call `validate_native_lib_path` when `VLLM_NCCL_SO_PATH` is set (+2 lines)
- `tests/distributed/test_nccl_path_security.py` — 8 new tests

## Verification

Tested on AIBoss (RTX 5090, r28 image) with the patched files overlaid:

```
8 passed
```

- `validate_native_lib_path` rejects symlinks, nonexistent files, world-writable files, world-writable parent dirs; accepts safe paths
- `find_nccl_library` validates explicit `VLLM_NCCL_SO_PATH` (accepts safe, rejects world-writable, rejects symlink)

## Impact

Closes the supply-chain / local privilege boundary for the custom NCCL build. No behavioral change for legitimate configurations — production's `/opt/libnccl-local-inference.so.2.30.4` is a regular file in `/opt` (root-owned, not world-writable), so it passes validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added security validation for configured NCCL/RCCL native library paths.
  - Unsafe paths are now rejected, including symlinks, nonexistent files, non-regular files, writable files, and files located in world-writable directories.
  - Invalid configurations now produce clear diagnostic errors identifying the relevant environment variable.

- **Tests**
  - Added coverage for accepted secure paths and rejected insecure path configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->