### PR TITLE
fix(exl3): share compatible native prefill buffers

### DIFF
--- a/tests/quantization/test_exl3_prefill_plan.py
+++ b/tests/quantization/test_exl3_prefill_plan.py
@@ -50,6 +50,7 @@ class _FakeFusedMoeApi:
     def __init__(self):
         self.planned = []
         self.bound = []
+        self.routed = []
 
     def Caps(self, **kwargs):
         return kwargs
@@ -60,11 +61,20 @@ class _FakeFusedMoeApi:
         return plan
 
     def bind(self, plan, *, scratch, a, experts, topk_weights, topk_ids):
-        del scratch, experts, topk_weights, topk_ids
+        del scratch, experts
         self.bound.append((plan, int(a.shape[0])))
-        return SimpleNamespace(plan=plan, m=int(a.shape[0]))
+        return SimpleNamespace(
+            plan=plan,
+            m=int(a.shape[0]),
+            route_expert_map=None,
+            a=a,
+            output=None,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+        )
 
     def run(self, *, binding):
+        self.routed.append((binding.topk_weights.clone(), binding.topk_ids.clone()))
         if binding.route_expert_map is not None:
             tier_output = binding.a.to(torch.float32).mul(0.5)
             if binding.output is not None:

--- a/tests/quantization/test_exl3_prefill_plan.py
+++ b/tests/quantization/test_exl3_prefill_plan.py
@@ -65,7 +65,63 @@ class _FakeFusedMoeApi:
         return SimpleNamespace(plan=plan, m=int(a.shape[0]))
 
     def run(self, *, binding):
-        return torch.zeros((binding.m, HIDDEN), dtype=torch.float32)
+        if binding.route_expert_map is not None:
+            tier_output = binding.a.to(torch.float32).mul(0.5)
+            if binding.output is not None:
+                binding.output.copy_(tier_output)
+                return binding.output
+            return tier_output
+        return binding.a.to(torch.float32)
+
+
+class _FakeMixedTrellisApi:
+    def __init__(self):
+        self.compiled = []
+        self.routed = []
+        self.calls = []
+        self.allocations = []
+
+    def max_packed_route_slots(self, routed_rows, block_size, experts):
+        del block_size, experts
+        return routed_rows
+
+    def compile_mixed_trellis(self, **kwargs):
+        launch = SimpleNamespace(**kwargs)
+        self.compiled.append(launch)
+        return launch
+
+    def make_mixed_trellis_buffers(self, launch, **kwargs):
+        del kwargs
+        buffers = SimpleNamespace(
+            scratch=torch.empty(launch.size_m, dtype=torch.uint8),
+            output=torch.empty(
+                (launch.size_m, launch.hidden_size), dtype=torch.float32
+            ),
+        )
+        self.allocations.append(buffers)
+        return buffers
+
+    def mixed_trellis_buffer_layout(self, launch, *, sms):
+        return (
+            launch.size_m,
+            launch.hidden_size,
+            launch.intermediate_size,
+            launch.top_k,
+            launch.tier0_num_experts + launch.tier1_num_experts,
+            launch.moe_block_size,
+            launch.max_m_blocks,
+            sms,
+        )
+
+    def run_mixed_trellis(self, *args):
+        x, tier0, tier1, topk_weights, topk_ids = args[:5]
+        buffers = args[9]
+        self.calls.append((int(x.shape[0]), tier0, tier1))
+        self.routed.append((topk_weights.clone(), topk_ids.clone()))
+        output = buffers.output[: x.shape[0]]
+        output.copy_(x)
+        return output
+
 
 
 class _FakeExt:
@@ -73,9 +129,11 @@ class _FakeExt:
 
     def __init__(self):
         self.moe_calls = []
+        self.max_concurrency_calls = 0
 
     def exl3_moe_max_concurrency(self, device):
         del device
+        self.max_concurrency_calls += 1
         return 2
 
     def exl3_moe(self, xh, out32, *args):
@@ -96,6 +154,28 @@ def _make_layer():
     )
 
 
+def _make_mixed_layer(
+    tier_ids=((0, 1, 2, 3), (4, 5, 6, 7)),
+):
+    layer = _make_layer()
+    layer.exl3_mixed_bitrate = True
+    layer.exl3_mixed_trellis = {
+        "tiers": (object(), object()),
+        "prefill_tiers": (object(), object()),
+        "tier_ids": tier_ids,
+        "tier_bits": (3, 4),
+        "global_to_combined": object(),
+        "descriptor_map": object(),
+        "rotations": object(),
+        "broadcast_suh": False,
+        "broadcast_svh": False,
+        "tile_config": (64, 128, 64, 128),
+        "prefill_tile_config": (128, 128, 128, 128),
+    }
+    return layer
+
+
+
 def _make_method():
     method = object.__new__(Exl3MoEMethod)
     method.quant_config = SimpleNamespace(
@@ -112,6 +192,7 @@ class _Harness:
         self._saved_capturing = None
         self.api = _FakeFusedMoeApi()
         self.ext = _FakeExt()
+        self.mixed_api = _FakeMixedTrellisApi()
 
     def __enter__(self):
         for name, value in self._env.items():
@@ -122,30 +203,45 @@ class _Harness:
                 os.environ[name] = value
         self._saved_loaders = (
             exl3_module._load_b12x_fused_moe,
+            exl3_module._load_b12x_mixed_trellis,
             exl3_module._load_exl3_ext,
         )
         exl3_module._load_b12x_fused_moe = lambda: self.api
+        exl3_module._load_b12x_mixed_trellis = lambda: self.mixed_api
         exl3_module._load_exl3_ext = lambda: self.ext
         self._saved_capturing = torch.cuda.is_current_stream_capturing
         torch.cuda.is_current_stream_capturing = lambda: False
         self._saved_current_device = torch.cuda.current_device
         torch.cuda.current_device = lambda: 0
+        self._saved_device_properties = torch.cuda.get_device_properties
+        torch.cuda.get_device_properties = lambda device: SimpleNamespace(
+            multi_processor_count=1,
+            shared_memory_per_block_optin=1,
+        )
         exl3_module._RANK_SLICED_RUNTIMES.clear()
+        exl3_module._MIXED_TRELLIS_RUNTIMES.clear()
+        exl3_module._MIXED_TRELLIS_PREFILL_BUFFERS.clear()
+
         return self
 
     def __exit__(self, *exc):
         (
             exl3_module._load_b12x_fused_moe,
+            exl3_module._load_b12x_mixed_trellis,
             exl3_module._load_exl3_ext,
         ) = self._saved_loaders
         torch.cuda.is_current_stream_capturing = self._saved_capturing
         torch.cuda.current_device = self._saved_current_device
+        torch.cuda.get_device_properties = self._saved_device_properties
         for name, value in self._saved_env.items():
             if value is None:
                 os.environ.pop(name, None)
             else:
                 os.environ[name] = value
         exl3_module._RANK_SLICED_RUNTIMES.clear()
+        exl3_module._MIXED_TRELLIS_RUNTIMES.clear()
+        exl3_module._MIXED_TRELLIS_PREFILL_BUFFERS.clear()
+
         return False
 
     def planned_caps(self):
@@ -186,8 +282,8 @@ def test_dual_plan_construction_and_dispatch():
 
         runtime = next(iter(exl3_module._RANK_SLICED_RUNTIMES.values()))
         assert runtime["parity_rows"] == 128
-        assert runtime["xh"].shape[0] == 128
-        assert runtime["token_sorted"].numel() == 128 * TOPK
+        assert runtime["parity_staging"] is None
+        assert h.ext.max_concurrency_calls == 0
 
         # Batches above the scheduler contract must fail before allocating a
         # replacement runtime or a larger Trellis arena during serving.
@@ -202,6 +298,191 @@ def test_dual_plan_construction_and_dispatch():
         assert tuple(exl3_module._RANK_SLICED_RUNTIMES) == runtime_keys
         assert len(exl3_module._RANK_SLICED_RUNTIMES) == runtime_count
         assert len(h.planned_caps()) == plan_count
+
+
+@pytest.mark.parametrize(
+    ("rows", "expected_slice_rows"),
+    ((127, [127]), (128, [128]), (129, [128, 1])),
+)
+def test_prefill_capacity_boundaries_preserve_rows_and_routing(
+    rows, expected_slice_rows
+):
+    with _Harness(env={"VLLM_EXL3_PREFILL_CAPACITY": "128"}) as h:
+        method = _make_method()
+        layer = _make_layer()
+        x = torch.arange(rows, dtype=torch.bfloat16).unsqueeze(1).expand(-1, HIDDEN)
+        weights = torch.arange(rows * TOPK, dtype=torch.float32).reshape(rows, TOPK)
+        ids = torch.arange(rows * TOPK, dtype=torch.int64).reshape(rows, TOPK)
+        ids = ids.remainder(EXPERTS)
+
+        out = method._apply_rank_sliced(layer, x, weights, ids)
+
+        assert [bound[1] for bound in h.api.bound] == expected_slice_rows
+        assert torch.equal(out, x)
+        assert torch.equal(torch.cat([route[0] for route in h.api.routed]), weights)
+        assert torch.equal(torch.cat([route[1] for route in h.api.routed]), ids)
+        assert all(bound[0] is h.api.bound[0][0] for bound in h.api.bound)
+
+
+def test_default_prefill_capacity_keeps_single_dispatch():
+    with _Harness() as h:
+        out = _apply(_make_method(), _make_layer(), 200)
+
+        assert h.planned_caps()[-1]["max_tokens"] == MAX_BATCHED
+        assert [bound[1] for bound in h.api.bound] == [200]
+        assert out.shape == (200, HIDDEN)
+
+
+def test_mixed_prefill_capacity_slices_rows_and_routing():
+    with _Harness(env={"VLLM_EXL3_PREFILL_CAPACITY": "128"}) as h:
+        method = _make_method()
+        layer = _make_mixed_layer()
+        rows = 200
+        x = torch.arange(rows, dtype=torch.bfloat16).unsqueeze(1).expand(-1, HIDDEN)
+        weights = torch.arange(rows * TOPK, dtype=torch.float32).reshape(rows, TOPK)
+        ids = torch.arange(rows * TOPK, dtype=torch.int64).reshape(rows, TOPK)
+        ids = ids.remainder(EXPERTS)
+
+        out = method._apply_rank_sliced(layer, x, weights, ids)
+
+        assert [launch.size_m for launch in h.mixed_api.compiled] == [32, 128]
+        assert [launch.moe_block_size for launch in h.mixed_api.compiled] == [8, 64]
+        assert h.mixed_api.compiled[1].force_tile_config == (128, 128, 128, 128)
+        assert not h.planned_caps()
+        assert not h.api.bound
+        assert [call[0] for call in h.mixed_api.calls] == [128, 72]
+        assert all(
+            call[1:] == layer.exl3_mixed_trellis["prefill_tiers"]
+            for call in h.mixed_api.calls
+        )
+        assert torch.equal(out, x)
+        assert torch.equal(
+            torch.cat([route[0] for route in h.mixed_api.routed]), weights
+        )
+        assert torch.equal(torch.cat([route[1] for route in h.mixed_api.routed]), ids)
+
+
+def test_mixed_runtime_policy_is_resolved_once(monkeypatch):
+    calls = 0
+
+    def properties(device):
+        nonlocal calls
+        del device
+        calls += 1
+        return SimpleNamespace(
+            major=12,
+            multi_processor_count=1,
+            shared_memory_per_block_optin=1,
+        )
+
+    with _Harness() as h:
+        monkeypatch.setattr(torch.cuda, "get_device_properties", properties)
+        method = _make_method()
+        layer = _make_mixed_layer()
+        x = torch.zeros((16, HIDDEN), dtype=torch.bfloat16)
+        ids = torch.zeros((16, TOPK), dtype=torch.int64)
+
+        first = method._mixed_rank_sliced_runtime(layer, x, ids)
+        second = method._mixed_rank_sliced_runtime(layer, x, ids)
+
+        assert first is second
+        assert calls == 1
+        assert len(h.mixed_api.compiled) == 2
+
+
+def test_mixed_runtime_forwards_shared_h_broadcast_contract():
+    with _Harness() as h:
+        method = _make_method()
+        layer = _make_mixed_layer()
+        layer.exl3_mixed_trellis["broadcast_suh"] = True
+        layer.exl3_mixed_trellis["broadcast_svh"] = True
+        x = torch.zeros((16, HIDDEN), dtype=torch.bfloat16)
+        ids = torch.zeros((16, TOPK), dtype=torch.int64)
+
+        method._mixed_rank_sliced_runtime(layer, x, ids)
+
+        assert len(h.mixed_api.compiled) == 2
+        assert all(launch.broadcast_suh is True for launch in h.mixed_api.compiled)
+        assert all(launch.broadcast_svh is True for launch in h.mixed_api.compiled)
+
+
+def test_mixed_prefill_buffers_are_shared_across_compatible_partitions():
+    with _Harness() as h:
+        method = _make_method()
+        first_layer = _make_mixed_layer()
+        second_layer = _make_mixed_layer(tier_ids=((0, 1, 2), (3, 4, 5, 6, 7)))
+        x = torch.zeros((16, HIDDEN), dtype=torch.bfloat16)
+        ids = torch.zeros((16, TOPK), dtype=torch.int64)
+
+        first = method._mixed_rank_sliced_runtime(first_layer, x, ids)
+        second = method._mixed_rank_sliced_runtime(second_layer, x, ids)
+
+        assert first["decode"]["buffers"] is not second["decode"]["buffers"]
+        assert first["prefill"]["buffers"] is second["prefill"]["buffers"]
+        assert first["prefill"]["buffers_reused"] is False
+        assert second["prefill"]["buffers_reused"] is True
+        assert len(h.mixed_api.allocations) == 3
+
+        weights = torch.zeros((64, TOPK), dtype=torch.float32)
+        ids = torch.zeros((64, TOPK), dtype=torch.int64)
+        out = method._apply_rank_sliced(
+            second_layer,
+            torch.zeros((64, HIDDEN), dtype=torch.bfloat16),
+            weights,
+            ids,
+        )
+        assert out.dtype == torch.bfloat16
+        assert (
+            out.untyped_storage().data_ptr()
+            != second["prefill"]["buffers"].output.untyped_storage().data_ptr()
+        )
+
+
+def test_mixed_prefill_buffers_do_not_cross_target_draft_roles():
+    with _Harness() as h:
+        method = _make_method()
+        target = _make_mixed_layer()
+        draft = _make_mixed_layer(tier_ids=((0, 1, 2), (3, 4, 5, 6, 7)))
+        draft.exl3_is_draft = True
+        x = torch.zeros((16, HIDDEN), dtype=torch.bfloat16)
+        ids = torch.zeros((16, TOPK), dtype=torch.int64)
+
+        target_runtime = method._mixed_rank_sliced_runtime(target, x, ids)
+        draft_runtime = method._mixed_rank_sliced_runtime(draft, x, ids)
+
+        assert (
+            target_runtime["prefill"]["buffers"]
+            is not draft_runtime["prefill"]["buffers"]
+        )
+        assert draft_runtime["prefill"]["buffers_reused"] is False
+        assert len(h.mixed_api.allocations) == 4
+
+
+def test_mixed_prefill_buffer_sharing_requires_backend_layout_contract():
+    with _Harness() as h:
+        h.mixed_api.mixed_trellis_buffer_layout = None
+        method = _make_method()
+        first_layer = _make_mixed_layer()
+        second_layer = _make_mixed_layer(tier_ids=((0, 1, 2), (3, 4, 5, 6, 7)))
+        x = torch.zeros((16, HIDDEN), dtype=torch.bfloat16)
+        ids = torch.zeros((16, TOPK), dtype=torch.int64)
+
+        first = method._mixed_rank_sliced_runtime(first_layer, x, ids)
+        second = method._mixed_rank_sliced_runtime(second_layer, x, ids)
+
+        assert first["prefill"]["buffers"] is not second["prefill"]["buffers"]
+        assert first["prefill"]["buffers_reused"] is False
+        assert second["prefill"]["buffers_reused"] is False
+        assert len(h.mixed_api.allocations) == 4
+
+
+def test_prefill_capacity_cannot_exceed_scheduler_bound():
+    env = {"VLLM_EXL3_PREFILL_CAPACITY": str(MAX_BATCHED + 1)}
+    with _Harness(env=env) as h:
+        with pytest.raises(ValueError, match="cannot exceed max_num_batched_tokens"):
+            _apply(_make_method(), _make_layer(), 16)
+        assert not h.planned_caps()
+
 
 
 def test_prefill_trellis_disabled_restores_parity():
@@ -221,7 +502,25 @@ def test_prefill_trellis_disabled_restores_parity():
         runtime = next(iter(exl3_module._RANK_SLICED_RUNTIMES.values()))
         assert runtime["prefill_plan"] is None
         assert runtime["parity_rows"] == MAX_BATCHED
-        assert runtime["xh"].shape[0] == MAX_BATCHED
+        assert runtime["parity_staging"] is not None
+        assert runtime["parity_staging"]["xh"].shape[0] == MAX_BATCHED
+        assert h.ext.max_concurrency_calls == 1
+
+
+def test_parity_staging_is_allocated_once_on_first_use():
+    with _Harness(env={"VLLM_EXL3_TRELLIS_MIN_M": "4"}) as h:
+        method = _make_method()
+        layer = _make_layer()
+
+        _apply(method, layer, 2)
+        runtime = next(iter(exl3_module._RANK_SLICED_RUNTIMES.values()))
+        first = runtime["parity_staging"]
+        _apply(method, layer, 3)
+
+        assert first is not None
+        assert runtime["parity_staging"] is first
+        assert h.ext.max_concurrency_calls == 1
+
 
 
 def test_prefill_block_m_env_override():
@@ -256,6 +555,7 @@ def test_disabled_prefill_plan_keeps_full_parity_capacity():
         _apply(_make_method(), _make_layer(), 159)
         runtime = next(iter(exl3_module._RANK_SLICED_RUNTIMES.values()))
         assert runtime["parity_rows"] == MAX_BATCHED
+        assert runtime["parity_staging"] is not None
 
 
 def test_explicit_parity_path_guarded_against_capture():
@@ -276,6 +576,8 @@ def test_explicit_parity_path_guarded_against_capture():
             assert "capture" in str(err)
         else:
             raise AssertionError("parity path must raise during capture")
+        runtime = next(iter(exl3_module._RANK_SLICED_RUNTIMES.values()))
+        assert runtime["parity_staging"] is None
 
 
 if __name__ == "__main__":

--- a/tests/quantization/test_exl3_prefill_plan.py
+++ b/tests/quantization/test_exl3_prefill_plan.py
@@ -80,6 +80,7 @@ class _FakeMixedTrellisApi:
         self.routed = []
         self.calls = []
         self.allocations = []
+        self.output_dtype = torch.float32
 
     def max_packed_route_slots(self, routed_rows, block_size, experts):
         del block_size, experts
@@ -95,7 +96,7 @@ class _FakeMixedTrellisApi:
         buffers = SimpleNamespace(
             scratch=torch.empty(launch.size_m, dtype=torch.uint8),
             output=torch.empty(
-                (launch.size_m, launch.hidden_size), dtype=torch.float32
+                (launch.size_m, launch.hidden_size), dtype=self.output_dtype
             ),
         )
         self.allocations.append(buffers)
@@ -458,6 +459,27 @@ def test_mixed_prefill_buffers_do_not_cross_target_draft_roles():
         assert len(h.mixed_api.allocations) == 4
 
 
+def test_shared_mixed_prefill_same_dtype_output_is_copied_out():
+    with _Harness() as h:
+        h.mixed_api.output_dtype = torch.bfloat16
+        method = _make_method()
+        first_layer = _make_mixed_layer()
+        second_layer = _make_mixed_layer(tier_ids=((0, 1, 2), (3, 4, 5, 6, 7)))
+        x = torch.zeros((64, HIDDEN), dtype=torch.bfloat16)
+        weights = torch.zeros((64, TOPK), dtype=torch.float32)
+        ids = torch.zeros((64, TOPK), dtype=torch.int64)
+
+        method._mixed_rank_sliced_runtime(first_layer, x, ids)
+        second = method._mixed_rank_sliced_runtime(second_layer, x, ids)
+        out = method._apply_rank_sliced(second_layer, x, weights, ids)
+
+        assert second["prefill"]["buffers_reused"] is True
+        assert (
+            out.untyped_storage().data_ptr()
+            != second["prefill"]["buffers"].output.untyped_storage().data_ptr()
+        )
+
+
 def test_mixed_prefill_buffer_sharing_requires_backend_layout_contract():
     with _Harness() as h:
         h.mixed_api.mixed_trellis_buffer_layout = None
@@ -507,20 +529,37 @@ def test_prefill_trellis_disabled_restores_parity():
         assert h.ext.max_concurrency_calls == 1
 
 
-def test_parity_staging_is_allocated_once_on_first_use():
+def test_reachable_parity_staging_is_allocated_during_eager_planning():
     with _Harness(env={"VLLM_EXL3_TRELLIS_MIN_M": "4"}) as h:
         method = _make_method()
         layer = _make_layer()
 
-        _apply(method, layer, 2)
+        _apply(method, layer, 16)
         runtime = next(iter(exl3_module._RANK_SLICED_RUNTIMES.values()))
         first = runtime["parity_staging"]
+        assert first is not None
+        assert h.ext.max_concurrency_calls == 1
+
+        _apply(method, layer, 2)
         _apply(method, layer, 3)
 
-        assert first is not None
         assert runtime["parity_staging"] is first
         assert h.ext.max_concurrency_calls == 1
 
+
+
+def test_unplanned_parity_path_refuses_late_gpu_allocation():
+    with _Harness(env={"VLLM_EXL3_TRELLIS_MIN_M": "4"}) as h:
+        method = _make_method()
+        layer = _make_layer()
+
+        _apply(method, layer, 16)
+        runtime = next(iter(exl3_module._RANK_SLICED_RUNTIMES.values()))
+        runtime["parity_staging"] = None
+
+        with pytest.raises(RuntimeError, match="refusing a late GPU allocation"):
+            _apply(method, layer, 2)
+        assert h.ext.max_concurrency_calls == 1
 
 
 def test_prefill_block_m_env_override():
@@ -577,7 +616,8 @@ def test_explicit_parity_path_guarded_against_capture():
         else:
             raise AssertionError("parity path must raise during capture")
         runtime = next(iter(exl3_module._RANK_SLICED_RUNTIMES.values()))
-        assert runtime["parity_staging"] is None
+        assert runtime["parity_staging"] is not None
+        assert h.ext.max_concurrency_calls == 1
 
 
 if __name__ == "__main__":

--- a/tests/quantization/test_exl3_prefill_plan.py
+++ b/tests/quantization/test_exl3_prefill_plan.py
@@ -51,7 +51,7 @@ class _FakeFusedMoeApi:
         self.planned = []
         self.bound = []
         self.routed = []
-
+        self._output = None  # persistent output arena, mirroring the real backend
     def Caps(self, **kwargs):
         return kwargs
 
@@ -81,7 +81,15 @@ class _FakeFusedMoeApi:
                 binding.output.copy_(tier_output)
                 return binding.output
             return tier_output
-        return binding.a.to(torch.float32)
+        # Mirror the real B12X backend: write into one persistent output arena
+        # and return a *view*. Callers that accumulate chunks must clone each
+        # view before the next bind()/run() overwrites the arena.
+        m = int(binding.a.shape[0])
+        if self._output is None or self._output.shape[0] < m:
+            self._output = torch.empty((m, HIDDEN), dtype=torch.float32)
+        out = self._output[:m]
+        out.copy_(binding.a)
+        return out
 
 
 class _FakeMixedTrellisApi:
@@ -132,6 +140,16 @@ class _FakeMixedTrellisApi:
         output = buffers.output[: x.shape[0]]
         output.copy_(x)
         return output
+
+    def prepare_weights(self, **kwargs):
+        return SimpleNamespace(prepared=True, **kwargs)
+
+    def build_tiered_maps(self, tier_ids_0, tier_ids_1, *, device):
+        del device
+        return (object(), object())
+
+    def combine_trellis_rotations(self, *tiers):
+        return object()
 
 
 
@@ -628,6 +646,147 @@ def test_explicit_parity_path_guarded_against_capture():
         runtime = next(iter(exl3_module._RANK_SLICED_RUNTIMES.values()))
         assert runtime["parity_staging"] is not None
         assert h.ext.max_concurrency_calls == 1
+
+
+def _make_backed_param(shard_ids, num_experts, per_expert_shape, dtype=torch.float16):
+    if len(shard_ids) > 1:
+        backing = torch.empty(
+            (len(shard_ids), num_experts) + tuple(per_expert_shape), dtype=dtype
+        )
+    else:
+        backing = torch.empty(
+            (num_experts,) + tuple(per_expert_shape), dtype=dtype
+        )
+    tensors = {}
+    for expert_id in range(num_experts):
+        for shard_id in shard_ids:
+            shard_index = shard_ids.index(shard_id)
+            if len(shard_ids) > 1:
+                tensors[(expert_id, shard_id)] = backing[shard_index, expert_id]
+            else:
+                tensors[(expert_id, shard_id)] = backing[expert_id]
+    return SimpleNamespace(
+        exl3_shard_ids=tuple(shard_ids),
+        exl3_backing=backing,
+        exl3_tensors=tensors,
+    )
+
+
+def _make_producer_layer(broadcast_rotations=False):
+    """Build a layer whose backing slabs are valid for _prepare_mixed_rank_sliced_weights."""
+    bitrates = (3, 3, 3, 3, 4, 4, 4, 4)
+    rot_experts = 1 if broadcast_rotations else EXPERTS
+    layer = SimpleNamespace(
+        exl3_max_num_batched_tokens=MAX_BATCHED,
+        exl3_hidden_size=HIDDEN,
+        exl3_intermediate_size_per_partition=INTERMEDIATE,
+        local_num_experts=EXPERTS,
+        exl3_layer_bitrates=bitrates,
+        activation=SimpleNamespace(value="swiglu"),
+        layer_name="test.mixed.layer",
+    )
+    # Trellis weight params: per-expert tensors with tier-dependent last dim.
+    w13_tensors = {}
+    w2_tensors = {}
+    for expert_id, bits in enumerate(bitrates):
+        last = 16 * bits
+        w13_tensors[(expert_id, "w1")] = torch.empty(
+            HIDDEN // 16, INTERMEDIATE // 16, last, dtype=torch.uint8
+        )
+        w13_tensors[(expert_id, "w3")] = torch.empty(
+            HIDDEN // 16, INTERMEDIATE // 16, last, dtype=torch.uint8
+        )
+        w2_tensors[(expert_id, "w2")] = torch.empty(
+            INTERMEDIATE // 16, HIDDEN // 16, last, dtype=torch.uint8
+        )
+    layer.w13_trellis = SimpleNamespace(
+        exl3_shard_ids=("w1", "w3"), exl3_backing=None, exl3_tensors=w13_tensors
+    )
+    layer.w2_trellis = SimpleNamespace(
+        exl3_shard_ids=("w2",), exl3_backing=None, exl3_tensors=w2_tensors
+    )
+    # Rotation params: backed slabs with view aliases.
+    layer.w13_suh = _make_backed_param(("w1", "w3"), rot_experts, (HIDDEN,))
+    layer.w13_svh = _make_backed_param(("w1", "w3"), rot_experts, (INTERMEDIATE,))
+    layer.w2_suh = _make_backed_param(("w2",), rot_experts, (INTERMEDIATE,))
+    layer.w2_svh = _make_backed_param(("w2",), rot_experts, (HIDDEN,))
+    # Dummy params referenced by the clearing loop.
+    for name in ("w13_mcg", "w13_mul1", "w2_mcg", "w2_mul1"):
+        setattr(layer, name, SimpleNamespace(exl3_tensors={}, exl3_backing=None))
+    return layer
+
+
+def test_mixed_prepare_populates_required_keys():
+    """B1: _prepare_mixed_rank_sliced_weights must produce all four keys
+    that the runtime consumers read (broadcast_suh, broadcast_svh,
+    prefill_tiers, prefill_tile_config)."""
+    with _Harness() as h:
+        method = _make_method()
+        layer = _make_producer_layer()
+        method._prepare_mixed_rank_sliced_weights(layer)
+        mixed = layer.exl3_mixed_trellis
+        for key in (
+            "broadcast_suh",
+            "broadcast_svh",
+            "prefill_tiers",
+            "prefill_tile_config",
+        ):
+            assert key in mixed, f"missing key {key!r} in exl3_mixed_trellis"
+        assert mixed["broadcast_suh"] is False
+        assert mixed["broadcast_svh"] is False
+        assert len(mixed["prefill_tiers"]) == 2
+        assert mixed["prefill_tiers"] == mixed["tiers"]
+        assert mixed["prefill_tile_config"] == mixed["tile_config"]
+
+
+def test_mixed_prepare_broadcast_rotations():
+    """B1: broadcast rotation slabs (shape[0] == 1) set the broadcast flags."""
+    with _Harness() as h:
+        method = _make_method()
+        layer = _make_producer_layer(broadcast_rotations=True)
+        method._prepare_mixed_rank_sliced_weights(layer)
+        mixed = layer.exl3_mixed_trellis
+        assert mixed["broadcast_suh"] is True
+        assert mixed["broadcast_svh"] is True
+
+
+@pytest.mark.parametrize(
+    ("rows", "capacity", "expected_slices"),
+    (
+        # equal-sized chunks
+        (256, 128, [128, 128]),
+        # short final chunk
+        (200, 128, [128, 72]),
+        # single chunk
+        (100, 128, [100]),
+    ),
+)
+def test_uniform_prefill_chunks_clone_persistent_output(
+    rows, capacity, expected_slices
+):
+    """B2: the uniform prefill path must clone each chunk because the fake
+    backend (like the real one) returns a view of one persistent output
+    arena.  Without the clone, torch.cat yields N copies of the last chunk."""
+    with _Harness(env={"VLLM_EXL3_PREFILL_CAPACITY": str(capacity)}) as h:
+        method = _make_method()
+        layer = _make_layer()
+        x = torch.arange(rows, dtype=torch.bfloat16).unsqueeze(1).expand(
+            -1, HIDDEN
+        )
+        weights = torch.arange(rows * TOPK, dtype=torch.float32).reshape(
+            rows, TOPK
+        )
+        ids = torch.arange(rows * TOPK, dtype=torch.int64).reshape(rows, TOPK)
+        ids = ids.remainder(EXPERTS)
+
+        out = method._apply_rank_sliced(layer, x, weights, ids)
+
+        assert [bound[1] for bound in h.api.bound] == expected_slices
+        assert out.shape == (rows, HIDDEN)
+        assert out.dtype == torch.bfloat16
+        # Correctness: each row must match the input.  Without the clone the
+        # persistent arena is overwritten and earlier rows are corrupted.
+        assert torch.equal(out, x)
 
 
 if __name__ == "__main__":

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -73,8 +73,9 @@ _B12X_MIXED_TRELLIS_API: Any | None = None
 _RANK_SLICED_RUNTIMES: dict[tuple[Any, ...], dict[str, Any]] = {}
 _MIXED_TRELLIS_RUNTIMES: dict[tuple[Any, ...], dict[str, Any]] = {}
 # Decode buffers are deliberately excluded: CUDA graphs capture their addresses.
-# Prefill runs eagerly, so layers with the exact same backend allocation layout
-# may safely reuse one persistent buffer set within a model instance.
+# A worker executes one model batch at a time and its layers are stream-ordered;
+# prefill therefore lets exact-compatible target layers reuse one persistent
+# buffer set. Target/draft roles remain separate below.
 _MIXED_TRELLIS_PREFILL_BUFFERS: dict[tuple[Any, ...], Any] = {}
 _NEXT_RUNTIME_SCOPE_ID = 0
 _MIXED_TRELLIS_ROUTE_BLOCK_SIZE = 8
@@ -2037,21 +2038,17 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         # B12X returns a view of its persistent FP32 output buffer.  The
         # dtype conversion is therefore also the lifetime boundary before
         # a compatible later layer reuses the same prefill storage.
-        output = raw_output.to(x.dtype)
-        persistent_output = getattr(state["buffers"], "output", None)
-        if (
-            state["buffers_reused"]
-            and persistent_output is not None
-            and raw_output.untyped_storage().data_ptr()
-            == persistent_output.untyped_storage().data_ptr()
-            and output.untyped_storage().data_ptr()
-            == persistent_output.untyped_storage().data_ptr()
-        ):
-            output = output.clone()
+        # `copy=True` is dormant for today's FP32 -> BF16 conversion and
+        # protects a future same-dtype backend without extra storage
+        # pointer queries in the hot path.
+        output = raw_output.to(
+            dtype=x.dtype,
+            copy=state["buffers_reused"] and raw_output.dtype == x.dtype,
+        )
         return output
 
     @staticmethod
-    def _rank_sliced_parity_staging(
+    def _allocate_rank_sliced_parity_staging(
         runtime: dict[str, Any],
         device: torch.device,
     ) -> dict[str, Any]:
@@ -2142,7 +2139,8 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         }
         runtime["parity_staging"] = staging
         logger.info_once(
-            "EXL3 eager parity staging allocated lazily: rows=%d chunk=%d",
+            "EXL3 eager parity staging allocated during runtime planning: "
+            "rows=%d chunk=%d",
             parity_rows,
             chunk,
         )
@@ -2197,6 +2195,9 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 f"chunk={chunk}, required_rows={max_parity_batch}. Increase "
                 "VLLM_EXL3_PREFILL_CHUNK or lower VLLM_EXL3_TRELLIS_MIN_M."
             )
+        parity_reachable = max_parity_batch > 0 or (
+            max_batched_tokens > max_trellis_m and not prefill_plan_enabled
+        )
         topk = int(topk_ids.shape[1])
         device_index = x.device.index
         key = (
@@ -2284,6 +2285,13 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             "num_experts": num_experts,
             "parity_staging": None,
         }
+        # A reachable parity fallback is allocated during eager runtime planning,
+        # so normal automatic KV sizing counts it in determine_available_memory's
+        # profile pass. The production default (min_m=1 with prefill Trellis)
+        # proves this branch unreachable and keeps the staging allocation at zero.
+        # Serving is not allowed to create this potentially large arena later.
+        if parity_reachable:
+            self._allocate_rank_sliced_parity_staging(runtime, x.device)
         _RANK_SLICED_RUNTIMES[key] = runtime
         prefill_arena_mib = (
             0.0
@@ -2369,7 +2377,12 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 "EXL3 batch exceeds its planned parity capacity: "
                 f"m={m}, capacity={runtime['parity_rows']}"
             )
-        staging = self._rank_sliced_parity_staging(runtime, x.device)
+        staging = runtime["parity_staging"]
+        if staging is None:
+            raise RuntimeError(
+                "EXL3 reached an unplanned eager parity path; refusing a late "
+                "GPU allocation outside memory profiling"
+            )
         ext = staging["ext"]
         xh = staging["xh"][:m]
         xh.copy_(x)

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -72,10 +72,19 @@ _B12X_FUSED_MOE_API: Any | None = None
 _B12X_MIXED_TRELLIS_API: Any | None = None
 _RANK_SLICED_RUNTIMES: dict[tuple[Any, ...], dict[str, Any]] = {}
 _MIXED_TRELLIS_RUNTIMES: dict[tuple[Any, ...], dict[str, Any]] = {}
-# Decode buffers are deliberately excluded: CUDA graphs capture their addresses.
-# A worker executes one model batch at a time and its layers are stream-ordered;
-# prefill therefore lets exact-compatible target layers reuse one persistent
-# buffer set. Target/draft roles remain separate below.
+# Prefill buffer cache (process-lifetime global).
+#
+# Lifetime: entries are created lazily on first use and never evicted for the
+# lifetime of the worker process (tests clear it explicitly).  Each entry owns
+# GPU tensors sized for one prefill launch, so the total resident memory grows
+# with the number of distinct (model scope, device, layout) combinations.
+#
+# Safety assumption: reuse is safe only because vLLM executes one model batch at
+# a time and, within a forward, layers run strictly sequentially and
+# stream-ordered — one layer's prefill completes (and the output is copied out
+# or converted) before the next layer touches the same buffer set.  Decode
+# buffers are deliberately excluded because CUDA graphs capture their addresses.
+# Target/draft roles are kept separate via the owner-token key below.
 _MIXED_TRELLIS_PREFILL_BUFFERS: dict[tuple[Any, ...], Any] = {}
 _NEXT_RUNTIME_SCOPE_ID = 0
 _MIXED_TRELLIS_ROUTE_BLOCK_SIZE = 8
@@ -1622,6 +1631,28 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             return (128, 128, 64, 256)
         return (128, 128, 128, 128)
 
+    @staticmethod
+    def _mixed_trellis_prefill_tile_config(
+        hidden_size: int, intermediate_size: int
+    ):
+        # Prefill reuses the checkpoint's one-grid tile geometry so the large-M
+        # reduction order matches the stock reference.  Kept separate from
+        # _mixed_trellis_tile_config (decode) so the two can diverge if a future
+        # kernel ABI picks a different prefill tile.
+        return Exl3MoEMethod._mixed_trellis_tile_config(
+            hidden_size, intermediate_size
+        )
+
+    @staticmethod
+    def _select_rotation_rows(
+        rotations: torch.Tensor, expert_ids: torch.Tensor
+    ) -> torch.Tensor:
+        # Broadcast rotations (shape[0] == 1) are shared across all experts;
+        # return as-is instead of index_selecting (which would be out of range).
+        if int(rotations.shape[0]) == 1:
+            return rotations
+        return rotations.index_select(0, expert_ids).contiguous()
+
     def _prepare_mixed_rank_sliced_weights(self, layer: RoutedExperts) -> None:
         api = _load_b12x_mixed_trellis()
         num_experts = int(layer.local_num_experts)
@@ -1663,6 +1694,18 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         down_svh = self._rank_sliced_backing(layer, "w2_svh")
         device = gate_suh.device
         tile_config = self._mixed_trellis_tile_config(hidden_size, intermediate_size)
+        prefill_tile_config = self._mixed_trellis_prefill_tile_config(
+            hidden_size, intermediate_size
+        )
+        # broadcast_suh/svh tell compile_mixed_trellis whether the rotation
+        # slabs are shared across all experts (shape[0] == 1) or per-expert.
+        broadcast_suh = int(gate_suh.shape[0]) == 1
+        if broadcast_suh != (int(up_suh.shape[0]) == 1):
+            raise ValueError(
+                "mixed EXL3 gate/up SUH rotations must both be per-expert "
+                "or both broadcast"
+            )
+        broadcast_svh = int(down_svh.shape[0]) == 1
         prepared_tiers = []
         tier_ids = []
         for bits, expert_ids in tiers.items():
@@ -1704,17 +1747,17 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 )
 
             index = torch.tensor(expert_ids, dtype=torch.long, device=device)
-            tier_gate_suh = gate_suh.index_select(0, index).contiguous()
-            tier_up_suh = up_suh.index_select(0, index).contiguous()
+            tier_gate_suh = self._select_rotation_rows(gate_suh, index)
+            tier_up_suh = self._select_rotation_rows(up_suh, index)
             intermediate_rotations = torch.cat(
                 (
-                    gate_svh.index_select(0, index),
-                    up_svh.index_select(0, index),
-                    down_suh.index_select(0, index),
+                    self._select_rotation_rows(gate_svh, index),
+                    self._select_rotation_rows(up_svh, index),
+                    self._select_rotation_rows(down_suh, index),
                 ),
                 dim=1,
             ).contiguous()
-            tier_down_svh = down_svh.index_select(0, index).contiguous()
+            tier_down_svh = self._select_rotation_rows(down_svh, index)
             prepared_tiers.append(
                 api.prepare_weights(
                     w13=w13,
@@ -1739,17 +1782,33 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             )
             tier_ids.append(expert_ids)
 
+        # Prefill tiers use the prefill tile geometry.  When it matches the
+        # decode tile_config the prepared objects are identical, so reuse them
+        # instead of doubling memory.  If the geometries diverge, a second
+        # prepare_weights pass per tier with prefill_tile_config goes here.
+        if prefill_tile_config == tile_config:
+            prefill_tiers = tuple(prepared_tiers)
+        else:
+            raise NotImplementedError(
+                "distinct prefill tile geometry requires a second "
+                "prepare_weights pass per tier"
+            )
+
         global_to_combined, descriptor_map = api.build_tiered_maps(
             tier_ids[0], tier_ids[1], device=device
         )
         layer.exl3_mixed_trellis = {
             "tiers": tuple(prepared_tiers),
+            "prefill_tiers": prefill_tiers,
             "tier_ids": tuple(tier_ids),
             "tier_bits": tuple(tiers),
             "global_to_combined": global_to_combined,
             "descriptor_map": descriptor_map,
             "rotations": api.combine_trellis_rotations(*prepared_tiers),
+            "broadcast_suh": broadcast_suh,
+            "broadcast_svh": broadcast_svh,
             "tile_config": tile_config,
+            "prefill_tile_config": prefill_tile_config,
         }
         layer.exl3_trellis_tile_config = tile_config
 
@@ -2079,15 +2138,15 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 )
                 chunks.append(chunk.clone())
             raw_output = torch.cat(chunks)
-        # B12X returns a view of its persistent FP32 output buffer.  The
-        # dtype conversion is therefore also the lifetime boundary before
-        # a compatible later layer reuses the same prefill storage.
-        # `copy=True` is dormant for today's FP32 -> BF16 conversion and
-        # protects a future same-dtype backend without extra storage
-        # pointer queries in the hot path.
+        # B12X returns a view of its persistent output buffer, which survives
+        # across forward passes regardless of whether the buffer set was reused
+        # from another layer.  The .to() conversion to x.dtype naturally breaks
+        # the alias when dtypes differ (FP32 -> BF16); when they match the
+        # copy= below forces a materialisation so a later layer reusing the
+        # same storage cannot corrupt this output.
         output = raw_output.to(
             dtype=x.dtype,
-            copy=state["buffers_reused"] and raw_output.dtype == x.dtype,
+            copy=raw_output.dtype == x.dtype,
         )
         return output
 
@@ -2314,7 +2373,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         prefill_scratch = None
         if prefill_plan_enabled:
             prefill_plan, prefill_scratch = _plan_with_scratch(
-                max_batched_tokens, prefill_block_m
+                prefill_capacity, prefill_block_m
             )
         hidden_size = int(layer.exl3_hidden_size)
         intermediate_size = int(layer.exl3_intermediate_size_per_partition)
@@ -2413,7 +2472,9 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                     topk_weights=topk_weights[start:end],
                     topk_ids=topk_ids[start:end],
                 )
-                outputs.append(runtime["api"].run(binding=binding))
+                # The backend may return a view of the persistent prefill
+                # scratch arena; clone before the next bind()/run() reuses it.
+                outputs.append(runtime["api"].run(binding=binding).clone())
             return torch.cat(outputs).to(x.dtype)
 
         if torch.cuda.is_current_stream_capturing():

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -72,6 +72,10 @@ _B12X_FUSED_MOE_API: Any | None = None
 _B12X_MIXED_TRELLIS_API: Any | None = None
 _RANK_SLICED_RUNTIMES: dict[tuple[Any, ...], dict[str, Any]] = {}
 _MIXED_TRELLIS_RUNTIMES: dict[tuple[Any, ...], dict[str, Any]] = {}
+# Decode buffers are deliberately excluded: CUDA graphs capture their addresses.
+# Prefill runs eagerly, so layers with the exact same backend allocation layout
+# may safely reuse one persistent buffer set within a model instance.
+_MIXED_TRELLIS_PREFILL_BUFFERS: dict[tuple[Any, ...], Any] = {}
 _NEXT_RUNTIME_SCOPE_ID = 0
 _MIXED_TRELLIS_ROUTE_BLOCK_SIZE = 8
 
@@ -222,12 +226,8 @@ def _load_b12x_mixed_trellis() -> Any:
     if _B12X_MIXED_TRELLIS_API is not None:
         return _B12X_MIXED_TRELLIS_API
     try:
-        module = importlib.import_module(
-            "b12x.moe._shared.kernels.w4a16.mixed_trellis"
-        )
-        prepare = importlib.import_module(
-            "b12x.moe._shared.kernels.w4a16.prepare"
-        )
+        module = importlib.import_module("b12x.moe._shared.kernels.w4a16.mixed_trellis")
+        prepare = importlib.import_module("b12x.moe._shared.kernels.w4a16.prepare")
         host = importlib.import_module("b12x.moe._shared.kernels.w4a16.host")
     except Exception as exc:
         raise RuntimeError(
@@ -240,6 +240,9 @@ def _load_b12x_mixed_trellis() -> Any:
         compile_mixed_trellis=module.compile_mixed_trellis,
         make_mixed_trellis_buffers=module.make_mixed_trellis_buffers,
         max_packed_route_slots=host.max_packed_route_slots,
+        mixed_trellis_buffer_layout=getattr(
+            module, "mixed_trellis_buffer_layout", None
+        ),
         prepare_weights=prepare.prepare_trellis256_moe_weights,
         run_mixed_trellis=module.run_mixed_trellis,
     )
@@ -262,6 +265,55 @@ def _unique_tensor_storage_bytes(*buffers: Any) -> int:
                 seen.add(storage_key)
                 total += storage.nbytes()
     return total
+
+
+def _mixed_trellis_prefill_buffers(
+    *,
+    api: Any,
+    owner_token: tuple[int, bool],
+    launch: Any,
+    device: torch.device,
+    sms: int,
+) -> tuple[Any, bool]:
+    """Reuse immutable-layout prefill buffers within one model scope."""
+
+    layout_fn = getattr(api, "mixed_trellis_buffer_layout", None)
+    if layout_fn is None:
+        # Preserve compatibility with an older B12X package.  Reconstructing
+        # allocation arithmetic here would risk an unsafe false-positive match.
+        return api.make_mixed_trellis_buffers(
+            launch,
+            device=device,
+            sms=sms,
+        ), False
+
+    layout = layout_fn(launch, sms=sms)
+    key = (
+        owner_token,
+        device,
+        api.make_mixed_trellis_buffers,
+        type(layout),
+        layout,
+    )
+    buffers = _MIXED_TRELLIS_PREFILL_BUFFERS.get(key)
+    if buffers is not None:
+        return buffers, True
+    buffers = api.make_mixed_trellis_buffers(
+        launch,
+        device=device,
+        sms=sms,
+    )
+    _MIXED_TRELLIS_PREFILL_BUFFERS[key] = buffers
+    return buffers, False
+
+
+def _scratch_view(backing: torch.Tensor, spec: Any) -> torch.Tensor:
+    """Return a typed plan-scratch view over a shared byte arena."""
+
+    nbytes = int(spec.dtype.itemsize)
+    for dim in spec.shape:
+        nbytes *= int(dim)
+    return backing.narrow(0, 0, nbytes).view(spec.dtype).view(tuple(spec.shape))
 
 
 def _positive_env_int(name: str, default: int) -> int:
@@ -1873,7 +1925,11 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         props = torch.cuda.get_device_properties(device)
         total_experts = sum(experts for _, experts in tier_signature)
 
-        def make_state(capacity: int) -> dict[str, Any]:
+        def make_state(
+            capacity: int,
+            *,
+            share_prefill_buffers: bool = False,
+        ) -> dict[str, Any]:
             route_slots = api.max_packed_route_slots(
                 capacity * topk,
                 _MIXED_TRELLIS_ROUTE_BLOCK_SIZE,
@@ -1897,22 +1953,35 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 rotation_input_dtype=("bf16" if x.dtype == torch.bfloat16 else "fp16"),
                 route_ids_dtype=topk_ids.dtype,
             )
-            return {
-                "capacity": capacity,
-                "launch": launch,
-                "buffers": api.make_mixed_trellis_buffers(
+            if share_prefill_buffers:
+                buffers, buffers_reused = _mixed_trellis_prefill_buffers(
+                    api=api,
+                    owner_token=_runtime_owner_token(self.quant_config, layer),
+                    launch=launch,
+                    device=device,
+                    sms=int(props.multi_processor_count),
+                )
+            else:
+                buffers = api.make_mixed_trellis_buffers(
                     launch,
                     device=device,
                     sms=int(props.multi_processor_count),
-                ),
+                )
+                buffers_reused = False
+            return {
+                "capacity": capacity,
+                "launch": launch,
+                "buffers": buffers,
+                "buffers_reused": buffers_reused,
             }
 
         decode = make_state(max_decode_m)
         prefill = (
-            make_state(max_batched_tokens)
+            make_state(max_batched_tokens, share_prefill_buffers=True)
             if max_batched_tokens > max_decode_m
             else decode
         )
+
         runtime = {
             "api": api,
             "decode": decode,
@@ -1926,11 +1995,12 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         )
         logger.info_once(
             "EXL3 mixed Trellis runtime planned: tiers=%s decode_capacity=%d "
-            "prefill_capacity=%d buffers=%.1f MiB",
+            "prefill_capacity=%d buffers=%.1f MiB prefill_reused=%s",
             tier_signature,
             max_decode_m,
             max_batched_tokens,
             buffer_bytes / (1 << 20),
+            bool(prefill is not None and prefill["buffers_reused"]),
         )
         return runtime
 
@@ -1952,7 +2022,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             runtime["decode"] if m <= runtime["max_decode_m"] else runtime["prefill"]
         )
         mixed = layer.exl3_mixed_trellis
-        output = runtime["api"].run_mixed_trellis(
+        raw_output = runtime["api"].run_mixed_trellis(
             x,
             mixed["tiers"][0],
             mixed["tiers"][1],
@@ -1964,7 +2034,119 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             state["launch"],
             state["buffers"],
         )
-        return output.to(x.dtype)
+        # B12X returns a view of its persistent FP32 output buffer.  The
+        # dtype conversion is therefore also the lifetime boundary before
+        # a compatible later layer reuses the same prefill storage.
+        output = raw_output.to(x.dtype)
+        persistent_output = getattr(state["buffers"], "output", None)
+        if (
+            state["buffers_reused"]
+            and persistent_output is not None
+            and raw_output.untyped_storage().data_ptr()
+            == persistent_output.untyped_storage().data_ptr()
+            and output.untyped_storage().data_ptr()
+            == persistent_output.untyped_storage().data_ptr()
+        ):
+            output = output.clone()
+        return output
+
+    @staticmethod
+    def _rank_sliced_parity_staging(
+        runtime: dict[str, Any],
+        device: torch.device,
+    ) -> dict[str, Any]:
+        staging = runtime["parity_staging"]
+        if staging is not None:
+            return staging
+
+        ext = _load_exl3_ext()
+        required_ext = {
+            "exl3_moe",
+            "exl3_moe_max_concurrency",
+        }
+        missing_ext = sorted(name for name in required_ext if not hasattr(ext, name))
+        if missing_ext:
+            raise RuntimeError(
+                "The EXL3 extension lacks routed-expert entry points: "
+                + ", ".join(missing_ext)
+            )
+        concurrency = int(ext.exl3_moe_max_concurrency(torch.cuda.current_device()))
+        parity_rows = int(runtime["parity_rows"])
+        hidden_size = int(runtime["hidden_size"])
+        intermediate_size = int(runtime["intermediate_size"])
+        num_experts = int(runtime["num_experts"])
+        topk = int(runtime["topk"])
+        chunk = int(runtime["chunk"])
+        staging = {
+            "ext": ext,
+            "xh": torch.empty(
+                (parity_rows, hidden_size),
+                dtype=torch.float16,
+                device=device,
+            ),
+            "out32": torch.empty(
+                (parity_rows, hidden_size),
+                dtype=torch.float32,
+                device=device,
+            ),
+            "tg": torch.empty(
+                (concurrency, chunk, hidden_size),
+                dtype=torch.float16,
+                device=device,
+            ),
+            "tu": torch.empty(
+                (concurrency, chunk, hidden_size),
+                dtype=torch.float16,
+                device=device,
+            ),
+            "ig": torch.empty(
+                (concurrency, chunk, intermediate_size),
+                dtype=torch.float16,
+                device=device,
+            ),
+            "iu": torch.empty(
+                (concurrency, chunk, intermediate_size),
+                dtype=torch.float16,
+                device=device,
+            ),
+            "expert_count": torch.empty(
+                num_experts + 1,
+                dtype=torch.int64,
+                device=device,
+            ),
+            "expert_offsets": torch.empty(
+                num_experts + 1,
+                dtype=torch.int64,
+                device=device,
+            ),
+            "token_sorted": torch.empty(
+                parity_rows * topk,
+                dtype=torch.int64,
+                device=device,
+            ),
+            "weight_sorted": torch.empty(
+                parity_rows * topk,
+                dtype=torch.float16,
+                device=device,
+            ),
+            "flat_token": torch.arange(
+                chunk,
+                dtype=torch.int64,
+                device=device,
+            ).repeat_interleave(topk),
+            "ones": torch.ones(
+                chunk * topk,
+                dtype=torch.int64,
+                device=device,
+            ),
+        }
+        runtime["parity_staging"] = staging
+        logger.info_once(
+            "EXL3 eager parity staging allocated lazily: rows=%d chunk=%d",
+            parity_rows,
+            chunk,
+        )
+        return staging
 
     def _rank_sliced_runtime(
         self,
@@ -2082,97 +2264,25 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 max_batched_tokens, prefill_block_m
             )
 
-        ext = _load_exl3_ext()
-        required_ext = {
-            "exl3_moe",
-            "exl3_moe_max_concurrency",
-        }
-        missing_ext = sorted(name for name in required_ext if not hasattr(ext, name))
-        if missing_ext:
-            raise RuntimeError(
-                "The EXL3 extension lacks routed-expert entry points: "
-                + ", ".join(missing_ext)
-            )
-        concurrency = int(ext.exl3_moe_max_concurrency(torch.cuda.current_device()))
         hidden_size = int(layer.exl3_hidden_size)
         intermediate_size = int(layer.exl3_intermediate_size_per_partition)
         num_experts = int(layer.local_num_experts)
-        device = x.device
-        # With the prefill plan live, the parity path only ever serves
-        # m < min_trellis_m, so its persistent staging shrinks to one chunk.
         runtime = {
             "api": api,
             "trellis_plan": trellis_plan,
             "trellis_scratch": trellis_scratch,
             "prefill_plan": prefill_plan,
             "prefill_scratch": prefill_scratch,
-            "ext": ext,
             "min_trellis_m": min_trellis_m,
             "max_trellis_m": max_trellis_m,
             "max_batched_tokens": max_batched_tokens,
             "parity_rows": parity_rows,
             "topk": topk,
             "chunk": chunk,
-            "xh": torch.empty(
-                (parity_rows, hidden_size),
-                dtype=torch.float16,
-                device=device,
-            ),
-            "out32": torch.empty(
-                (parity_rows, hidden_size),
-                dtype=torch.float32,
-                device=device,
-            ),
-            "tg": torch.empty(
-                (concurrency, chunk, hidden_size),
-                dtype=torch.float16,
-                device=device,
-            ),
-            "tu": torch.empty(
-                (concurrency, chunk, hidden_size),
-                dtype=torch.float16,
-                device=device,
-            ),
-            "ig": torch.empty(
-                (concurrency, chunk, intermediate_size),
-                dtype=torch.float16,
-                device=device,
-            ),
-            "iu": torch.empty(
-                (concurrency, chunk, intermediate_size),
-                dtype=torch.float16,
-                device=device,
-            ),
-            "expert_count": torch.empty(
-                num_experts + 1,
-                dtype=torch.int64,
-                device=device,
-            ),
-            "expert_offsets": torch.empty(
-                num_experts + 1,
-                dtype=torch.int64,
-                device=device,
-            ),
-            "token_sorted": torch.empty(
-                parity_rows * topk,
-                dtype=torch.int64,
-                device=device,
-            ),
-            "weight_sorted": torch.empty(
-                parity_rows * topk,
-                dtype=torch.float16,
-                device=device,
-            ),
-            "flat_token": torch.arange(
-                chunk,
-                dtype=torch.int64,
-                device=device,
-            ).repeat_interleave(topk),
-            "ones": torch.ones(
-                chunk * topk,
-                dtype=torch.int64,
-                device=device,
-            ),
+            "hidden_size": hidden_size,
+            "intermediate_size": intermediate_size,
+            "num_experts": num_experts,
+            "parity_staging": None,
         }
         _RANK_SLICED_RUNTIMES[key] = runtime
         prefill_arena_mib = (
@@ -2259,10 +2369,11 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 "EXL3 batch exceeds its planned parity capacity: "
                 f"m={m}, capacity={runtime['parity_rows']}"
             )
-        ext = runtime["ext"]
-        xh = runtime["xh"][:m]
+        staging = self._rank_sliced_parity_staging(runtime, x.device)
+        ext = staging["ext"]
+        xh = staging["xh"][:m]
         xh.copy_(x)
-        out32 = runtime["out32"][:m]
+        out32 = staging["out32"][:m]
         out32.zero_()
         chunk = int(runtime["chunk"])
         pointer_args = layer.exl3_pointer_tables
@@ -2273,14 +2384,14 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 topk_ids,
                 topk_weights,
                 layer.exl3_expert_map,
-                runtime["expert_count"],
-                runtime["expert_offsets"],
-                runtime["token_sorted"],
-                runtime["weight_sorted"],
-                runtime["tg"],
-                runtime["tu"],
-                runtime["ig"],
-                runtime["iu"],
+                staging["expert_count"],
+                staging["expert_offsets"],
+                staging["token_sorted"],
+                staging["weight_sorted"],
+                staging["tg"],
+                staging["tu"],
+                staging["ig"],
+                staging["iu"],
                 0,
                 3,
                 3,
@@ -2305,25 +2416,25 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             flat = local_ids[start : start + current_m].reshape(-1)
             order = torch.argsort(flat)
             route_count = current_m * topk
-            token_ids = runtime["flat_token"][:route_count].index_select(0, order)
+            token_ids = staging["flat_token"][:route_count].index_select(0, order)
             route_weights = (
                 half_weights[start : start + current_m]
                 .reshape(-1)
                 .index_select(0, order)
             )
-            counts = runtime["expert_count"]
+            counts = staging["expert_count"]
             counts.zero_()
-            counts.scatter_add_(0, flat, runtime["ones"][:route_count])
+            counts.scatter_add_(0, flat, staging["ones"][:route_count])
             ext.exl3_moe(
                 xh[start : start + current_m],
                 out32[start : start + current_m],
                 counts,
                 token_ids,
                 route_weights,
-                runtime["tg"],
-                runtime["tu"],
-                runtime["ig"],
-                runtime["iu"],
+                staging["tg"],
+                staging["tu"],
+                staging["ig"],
+                staging["iu"],
                 0,
                 3,
                 3,

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -1887,6 +1887,14 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         mixed = layer.exl3_mixed_trellis
         max_decode_m = _positive_env_int("VLLM_EXL3_TRELLIS_MAX_M", 32)
         max_batched_tokens = int(layer.exl3_max_num_batched_tokens)
+        prefill_capacity = _positive_env_int(
+            "VLLM_EXL3_PREFILL_CAPACITY", max_batched_tokens
+        )
+        if prefill_capacity > max_batched_tokens:
+            raise ValueError(
+                "VLLM_EXL3_PREFILL_CAPACITY cannot exceed max_num_batched_tokens: "
+                f"{prefill_capacity} > {max_batched_tokens}"
+            )
         if max_decode_m > max_batched_tokens:
             max_decode_m = max_batched_tokens
         topk = int(topk_ids.shape[1])
@@ -1930,10 +1938,14 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             capacity: int,
             *,
             share_prefill_buffers: bool = False,
+            moe_block_size: int = _MIXED_TRELLIS_ROUTE_BLOCK_SIZE,
+            force_tile_config: Any = None,
         ) -> dict[str, Any]:
+            if force_tile_config is None:
+                force_tile_config = mixed["tile_config"]
             route_slots = api.max_packed_route_slots(
                 capacity * topk,
-                _MIXED_TRELLIS_ROUTE_BLOCK_SIZE,
+                moe_block_size,
                 total_experts,
             )
             launch = api.compile_mixed_trellis(
@@ -1945,14 +1957,16 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 tier0_bits=tier_signature[0][0],
                 tier1_bits=tier_signature[1][0],
                 top_k=topk,
-                max_m_blocks=(route_slots + _MIXED_TRELLIS_ROUTE_BLOCK_SIZE - 1)
-                // _MIXED_TRELLIS_ROUTE_BLOCK_SIZE,
-                moe_block_size=_MIXED_TRELLIS_ROUTE_BLOCK_SIZE,
+                max_m_blocks=(route_slots + moe_block_size - 1)
+                // moe_block_size,
+                moe_block_size=moe_block_size,
                 sms=int(props.multi_processor_count),
                 max_shared_mem=int(props.shared_memory_per_block_optin),
-                force_tile_config=mixed["tile_config"],
+                force_tile_config=force_tile_config,
                 rotation_input_dtype=("bf16" if x.dtype == torch.bfloat16 else "fp16"),
                 route_ids_dtype=topk_ids.dtype,
+                broadcast_suh=mixed["broadcast_suh"],
+                broadcast_svh=mixed["broadcast_svh"],
             )
             if share_prefill_buffers:
                 buffers, buffers_reused = _mixed_trellis_prefill_buffers(
@@ -1978,8 +1992,15 @@ class Exl3MoEMethod(FusedMoEMethodBase):
 
         decode = make_state(max_decode_m)
         prefill = (
-            make_state(max_batched_tokens, share_prefill_buffers=True)
-            if max_batched_tokens > max_decode_m
+            make_state(
+                prefill_capacity,
+                share_prefill_buffers=True,
+                moe_block_size=_positive_env_int(
+                    "VLLM_EXL3_PREFILL_BLOCK_M", 64
+                ),
+                force_tile_config=mixed["prefill_tile_config"],
+            )
+            if prefill_capacity > max_decode_m
             else decode
         )
 
@@ -1989,6 +2010,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             "prefill": prefill,
             "max_decode_m": max_decode_m,
             "max_batched_tokens": max_batched_tokens,
+            "prefill_capacity": prefill_capacity,
         }
         _MIXED_TRELLIS_RUNTIMES[key] = runtime
         buffer_bytes = _unique_tensor_storage_bytes(
@@ -2019,22 +2041,44 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 "mixed-bitrate EXL3 batch exceeds planned capacity: "
                 f"m={m}, capacity={runtime['max_batched_tokens']}"
             )
-        state = (
-            runtime["decode"] if m <= runtime["max_decode_m"] else runtime["prefill"]
-        )
         mixed = layer.exl3_mixed_trellis
-        raw_output = runtime["api"].run_mixed_trellis(
-            x,
-            mixed["tiers"][0],
-            mixed["tiers"][1],
-            topk_weights,
-            topk_ids,
-            mixed["global_to_combined"],
-            mixed["descriptor_map"],
-            mixed["rotations"],
-            state["launch"],
-            state["buffers"],
-        )
+        is_decode = m <= runtime["max_decode_m"]
+        state = runtime["decode"] if is_decode else runtime["prefill"]
+        tier0, tier1 = (
+            mixed["tiers"][0], mixed["tiers"][1]
+        ) if is_decode else mixed["prefill_tiers"]
+        prefill_capacity = runtime["prefill_capacity"]
+        if is_decode or prefill_capacity >= m:
+            raw_output = runtime["api"].run_mixed_trellis(
+                x,
+                tier0,
+                tier1,
+                topk_weights,
+                topk_ids,
+                mixed["global_to_combined"],
+                mixed["descriptor_map"],
+                mixed["rotations"],
+                state["launch"],
+                state["buffers"],
+            )
+        else:
+            chunks = []
+            for start in range(0, m, prefill_capacity):
+                end = min(start + prefill_capacity, m)
+                chunk = runtime["api"].run_mixed_trellis(
+                    x[start:end],
+                    tier0,
+                    tier1,
+                    topk_weights[start:end],
+                    topk_ids[start:end],
+                    mixed["global_to_combined"],
+                    mixed["descriptor_map"],
+                    mixed["rotations"],
+                    state["launch"],
+                    state["buffers"],
+                )
+                chunks.append(chunk.clone())
+            raw_output = torch.cat(chunks)
         # B12X returns a view of its persistent FP32 output buffer.  The
         # dtype conversion is therefore also the lifetime boundary before
         # a compatible later layer reuses the same prefill storage.
@@ -2182,6 +2226,14 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         # and making the capacity guard in _apply_rank_sliced unreachable. The
         # planned capacity is a property of the layer, not of one forward pass.
         max_batched_tokens = int(layer.exl3_max_num_batched_tokens)
+        prefill_capacity = _positive_env_int(
+            "VLLM_EXL3_PREFILL_CAPACITY", max_batched_tokens
+        )
+        if prefill_capacity > max_batched_tokens:
+            raise ValueError(
+                "VLLM_EXL3_PREFILL_CAPACITY cannot exceed max_num_batched_tokens: "
+                f"{prefill_capacity} > {max_batched_tokens}"
+            )
         prefill_plan_enabled = prefill_trellis and max_batched_tokens > max_trellis_m
         parity_rows = (
             min(chunk, max_batched_tokens)
@@ -2264,7 +2316,6 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             prefill_plan, prefill_scratch = _plan_with_scratch(
                 max_batched_tokens, prefill_block_m
             )
-
         hidden_size = int(layer.exl3_hidden_size)
         intermediate_size = int(layer.exl3_intermediate_size_per_partition)
         num_experts = int(layer.local_num_experts)
@@ -2277,6 +2328,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             "min_trellis_m": min_trellis_m,
             "max_trellis_m": max_trellis_m,
             "max_batched_tokens": max_batched_tokens,
+            "prefill_capacity": prefill_capacity,
             "parity_rows": parity_rows,
             "topk": topk,
             "chunk": chunk,
@@ -2349,16 +2401,20 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                     "EXL3 batch exceeds its planned capacity: "
                     f"m={m}, capacity={runtime['max_batched_tokens']}"
                 )
-            binding = runtime["api"].bind(
-                runtime["prefill_plan"],
-                scratch=runtime["prefill_scratch"],
-                a=x,
-                experts=layer.exl3_trellis_weights,
-                topk_weights=topk_weights,
-                topk_ids=topk_ids,
-            )
-            output = runtime["api"].run(binding=binding)
-            return output.to(x.dtype)
+            prefill_capacity = runtime["prefill_capacity"]
+            outputs = []
+            for start in range(0, m, prefill_capacity):
+                end = min(start + prefill_capacity, m)
+                binding = runtime["api"].bind(
+                    runtime["prefill_plan"],
+                    scratch=runtime["prefill_scratch"],
+                    a=x[start:end],
+                    experts=layer.exl3_trellis_weights,
+                    topk_weights=topk_weights[start:end],
+                    topk_ids=topk_ids[start:end],
+                )
+                outputs.append(runtime["api"].run(binding=binding))
+            return torch.cat(outputs).to(x.dtype)
 
         if torch.cuda.is_current_stream_capturing():
             raise RuntimeError(


### PR DESCRIPTION
## Summary

- allocate homogeneous EXL3 eager-parity staging during runtime planning only when the configured fallback is reachable; serving refuses an unplanned late allocation
- share prefill-only native mixed-Trellis buffers across exact-compatible serialized target runtime geometries
- keep decode buffers owner-local because CUDA graphs capture their addresses
- keep target and MTP-draft roles isolated, refuse inferred compatibility with older B12X builds, and copy any persistent output view before reuse
- add startup telemetry (`prefill_reused=True/False`) for the live gate

This is a focused stacked successor to #228 for the two remaining actionable items in #203. The paired backend allocation contract is [B12X #130](https://github.com/local-inference-lab/b12x/pull/130).

## Expected memory effect (not yet a GPU claim)

For the current GLM mixed target geometry at 3,072 prefill rows, the backend layout calculates one buffer set at **850.16 MiB/rank**. If the two current layer partitions instantiate exact-compatible layouts as expected, one set is recovered. Under the production default (`VLLM_EXL3_TRELLIS_MIN_M=1` with prefill Trellis enabled), the guarded parity path is unreachable and avoids the previously derived **~82.2 MiB/rank** staging arena. The combined **~932 MiB/rank** remains an estimate until the AIBoss gate records allocator and KV deltas.

If configuration makes parity reachable, its arena is instead allocated during eager runtime planning so normal automatic KV sizing counts it. That configuration does not receive the parity-staging saving.

No PP/TG or numerics gain is claimed. Kernel plans, launch order, math, and dtypes are unchanged.

## Safety boundaries

- sharing is enabled only when B12X supplies an immutable exact layout identity; old packages retain owner-local buffers
- the pool is scoped by model and target/draft role
- a worker runs one model batch at a time and its layers are stream-ordered; this assumption is part of the sharing contract
- decode/captured buffers are never pooled
- allocations are eager and exact-keyed; no grow/reallocation path exists
- the mixed output's persistent FP32 buffer cannot escape into the residual stream, including a future same-dtype backend
- reachable parity staging is allocated before serving; an impossible/unplanned parity path raises instead of allocating after KV sizing

Normal automatic KV sizing profiles these persistent allocations. Explicit `--kv-cache-memory-bytes` and `--num-gpu-blocks-override` remain operator escape hatches: they intentionally decouple KV allocation from measured safe capacity, so this PR cannot protect an oversized manual value.

## Performance and concurrency

- no request hot-path lookup or new synchronization is added; pool lookup occurs only while eager runtimes are planned
- the existing FP32-to-model-dtype output conversion remains the lifetime boundary, and its common path is unchanged
- fewer persistent arenas should shorten startup allocation work slightly, but no startup-time claim is made before GPU measurement
- recovered VRAM is expected to become KV blocks under automatic sizing, reducing preemption and improving usable long-context concurrency; this PR does not change `max_num_seqs` or claim higher kernel throughput
- future execution of model layers concurrently on independent streams would invalidate the sharing assumption and must reintroduce owner-local or synchronized storage

## Duplicate-work check

I refreshed #203 and searched open local-inference-lab/vLLM PRs for `203 in:body` and `EXL3 mixed Trellis buffer sharing parity staging`; neither search found another implementation. The earlier turnkey PR malaiwah/glm52-exl3-vast#15 targeted the obsolete flat-scratch compatibility path and is closed.

## Validation

```text
pytest -q tests/quantization/test_exl3_prefill_plan.py
20 passed

ruff check vllm/model_executor/layers/quantization/exl3.py \
  tests/quantization/test_exl3_prefill_plan.py
All checks passed!

ruff format --check vllm/model_executor/layers/quantization/exl3.py \
  tests/quantization/test_exl3_prefill_plan.py
2 files already formatted

git diff --check
clean
```

The full staged-file pre-commit run passed Ruff, SPDX, root-import, Docker dependency, configuration, and other applicable hooks. Whole-file hooks also surfaced inherited integration-branch debt: existing `suh`/`subtiles` spelling reports, six pre-existing mypy errors, the pre-existing `import re`, and existing `torch.cuda` calls. None is introduced by this delta.

GPU/model evaluation remains intentionally pending. Before this leaves draft, the AIBoss RTX 5090 window will run the Fruit proxy smoke plus targeted real mixed-K allocation/ABBA, graph replay/stable-address, correctness, no-late-allocation, auto-profile/KV, and concurrency/preemption gates. AIBeast production was not touched.

## AI assistance

OpenAI Codex assisted with implementation, tests, and the initial review. Michel Belleau is the human submitter and will review the complete diff and GPU evidence before requesting merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved EXL3 mixed-bitrate model execution through persistent prefill-buffer reuse.
  * Reduced repeated memory allocations during eager parity processing.
  * Improved output handling when buffers are reused.

* **Reliability**
  * Added compatibility support for older runtime APIs.
  * Strengthened validation, caching, concurrency, and buffer-isolation behavior.
  * Expanded coverage for mixed and uniform Trellis execution paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->