### PR TITLE
fix(b12x): prewarm full-CKV prefill kernels before KV sizing

### DIFF
--- a/tests/model_executor/test_sparse_mla_triton_warmup.py
+++ b/tests/model_executor/test_sparse_mla_triton_warmup.py
@@ -1,14 +1,32 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import math
 from types import SimpleNamespace
 
+import pytest
 import torch
 
 from vllm.model_executor.warmup import sparse_mla_triton_warmup
 
+# Mirrors the production runner interface: both the V1 (gpu_model_runner) and
+# V2 (gpu/model_runner) runners expose ``vllm_config.parallel_config`` and
+# ``dcp_rank``.  The V2-only aliases ``dcp_size``/``cp_interleave`` are
+# deliberately *not* provided here so that a regression to ``getattr(runner,
+# "dcp_size", 1)`` silently degrades to DCP1 and fails the DCP4 assertion.
+_DCP_CASES = [(1, 1, 0), (4, 64, 2)]
 
-def test_b12x_prefill_metadata_warmup_uses_runtime_dcp_shape(monkeypatch) -> None:
+
+@pytest.mark.parametrize(
+    ("dcp_world_size", "cp_kv_cache_interleave_size", "dcp_rank"),
+    _DCP_CASES,
+)
+def test_b12x_prefill_metadata_warmup_uses_runtime_dcp_shape(
+    monkeypatch,
+    dcp_world_size: int,
+    cp_kv_cache_interleave_size: int,
+    dcp_rank: int,
+) -> None:
     calls = []
 
     class B12xBackend:
@@ -16,12 +34,15 @@ def test_b12x_prefill_metadata_warmup_uses_runtime_dcp_shape(monkeypatch) -> Non
         def get_name() -> str:
             return "B12X_MLA_SPARSE"
 
+    parallel_config = SimpleNamespace(
+        decode_context_parallel_size=dcp_world_size,
+        cp_kv_cache_interleave_size=cp_kv_cache_interleave_size,
+    )
     runner = SimpleNamespace(
         is_pooling_model=False,
         device=torch.device("cpu"),
-        dcp_rank=2,
-        dcp_size=4,
-        cp_interleave=64,
+        dcp_rank=dcp_rank,
+        vllm_config=SimpleNamespace(parallel_config=parallel_config),
         attn_groups=[[SimpleNamespace(backend=B12xBackend())]],
     )
     worker = SimpleNamespace(
@@ -43,9 +64,112 @@ def test_b12x_prefill_metadata_warmup_uses_runtime_dcp_shape(monkeypatch) -> Non
             {
                 "compress_ratio": 1,
                 "query_len": 8,
-                "dcp_rank": 2,
-                "dcp_world_size": 4,
-                "cp_kv_cache_interleave_size": 64,
+                "dcp_rank": dcp_rank,
+                "dcp_world_size": dcp_world_size,
+                "cp_kv_cache_interleave_size": cp_kv_cache_interleave_size,
             },
         )
     ]
+
+
+def test_b12x_prewarm_extend_kernels_warms_ckv_plan_and_global_topk_remap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The 96-line ``_prewarm_extend_kernels_once`` restructuring must warm both
+    the full-CKV local-head extend plan *and* the global top-k → gathered-CKV
+    remap kernel, using the runtime DCP specialization."""
+    import vllm.v1.attention.backends.mla.b12x_mla_sparse as b12x
+
+    # Isolate the module-level dedup set so prior tests do not short-circuit.
+    monkeypatch.setattr(b12x, "_EXTEND_PREWARM_DONE", set())
+
+    remap_calls: list[dict] = []
+    mask_calls: list = []
+
+    def fake_remap(*args, **kwargs) -> None:
+        remap_calls.append(kwargs)
+
+    def fake_mask(*args, **kwargs) -> None:
+        mask_calls.append(args)
+
+    monkeypatch.setattr(b12x, "_map_global_topk_to_gathered_ckv", fake_remap)
+    monkeypatch.setattr(b12x, "_mask_page_table_after_nsa_len", fake_mask)
+
+    class FakePlan:
+        def __init__(self, name: str) -> None:
+            self.name = name
+            self.bind_calls: list[dict] = []
+
+        def bind(self, **kwargs):
+            self.bind_calls.append(kwargs)
+            return SimpleNamespace(plan=self.name)
+
+    ckv_plan = FakePlan("ckv")
+    base_plan = FakePlan("base")
+
+    forward_calls: list[dict] = []
+
+    # The real method allocates tensors on ``self.device``.  On a CPU-only host
+    # we cannot allocate on CUDA, so redirect every ``device=cuda`` allocation
+    # to CPU.  The tensors are only ever handed to the mocked kernels/plans, so
+    # their backing store is irrelevant.
+    _real_zeros = torch.zeros
+    _real_empty = torch.empty
+    _real_full = torch.full
+    _real_ones = torch.ones
+
+    def _to_cpu(device):
+        if device is not None and str(device).startswith("cuda"):
+            return torch.device("cpu")
+        return device
+
+    def _patched(fn):
+        def wrapper(*args, **kwargs):
+            if "device" in kwargs:
+                kwargs["device"] = _to_cpu(kwargs["device"])
+            return fn(*args, **kwargs)
+
+        return wrapper
+
+    monkeypatch.setattr(torch, "zeros", _patched(_real_zeros))
+    monkeypatch.setattr(torch, "empty", _patched(_real_empty))
+    monkeypatch.setattr(torch, "full", _patched(_real_full))
+    monkeypatch.setattr(torch, "ones", _patched(_real_ones))
+
+    mock_self = SimpleNamespace(
+        device=torch.device("cuda"),
+        q_head_dim=576,
+        kv_lora_rank=512,
+        scale=1.0 / math.sqrt(576),
+        _kernel_num_heads=8,
+        _ckv_kernel_num_heads=8,
+        topk_tokens=128,
+        block_size=128,
+        need_to_return_lse_for_decode=False,
+        kv_cache_dtype="fp8_ds_mla",
+        _kv_fp8_rope=True,
+        _ckv_extend_plan=ckv_plan,
+        _extend_plan=base_plan,
+        dcp_world_size=4,
+        cp_kv_cache_interleave_size=64,
+        _kv_record_bytes=656,
+        _scratch_nbytes=1024,
+        _b12x_kernel_format_kwargs=lambda *a, **k: {},
+        _sync_warmup=lambda *a, **k: None,
+        _sparse_mla_extend_forward=lambda **k: forward_calls.append(k),
+    )
+
+    b12x.B12xMLASparseImpl._prewarm_extend_kernels_once(mock_self, 8)
+
+    # Global top-k remap prewarmed with the runtime DCP specialization.
+    assert len(remap_calls) == 1
+    assert remap_calls[0]["dcp_size"] == 4
+    assert remap_calls[0]["cp_kv_cache_interleave_size"] == 64
+    # Page-table masking ran immediately after the remap.
+    assert len(mask_calls) == 1
+    # Full-CKV local-head extend plan was warmed.
+    assert len(ckv_plan.bind_calls) >= 1
+    # Base extend plan was also warmed.
+    assert len(base_plan.bind_calls) >= 1
+    # Both plans drove at least one forward launch.
+    assert len(forward_calls) >= 2

--- a/tests/model_executor/test_sparse_mla_triton_warmup.py
+++ b/tests/model_executor/test_sparse_mla_triton_warmup.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import torch
+
+from vllm.model_executor.warmup import sparse_mla_triton_warmup
+
+
+def test_b12x_prefill_metadata_warmup_uses_runtime_dcp_shape(monkeypatch) -> None:
+    calls = []
+
+    class B12xBackend:
+        @staticmethod
+        def get_name() -> str:
+            return "B12X_MLA_SPARSE"
+
+    runner = SimpleNamespace(
+        is_pooling_model=False,
+        device=torch.device("cpu"),
+        dcp_rank=2,
+        dcp_size=4,
+        cp_interleave=64,
+        attn_groups=[[SimpleNamespace(backend=B12xBackend())]],
+    )
+    worker = SimpleNamespace(
+        model_runner=runner,
+        scheduler_config=SimpleNamespace(max_num_batched_tokens=3072),
+    )
+
+    monkeypatch.setattr(
+        sparse_mla_triton_warmup,
+        "_warm_prefill_chunk_metadata_kernel",
+        lambda *args, **kwargs: calls.append((args, kwargs)),
+    )
+
+    sparse_mla_triton_warmup.sparse_mla_triton_warmup_if_needed(worker)
+
+    assert calls == [
+        (
+            (torch.device("cpu"),),
+            {
+                "compress_ratio": 1,
+                "query_len": 8,
+                "dcp_rank": 2,
+                "dcp_world_size": 4,
+                "cp_kv_cache_interleave_size": 64,
+            },
+        )
+    ]

--- a/vllm/model_executor/warmup/sparse_mla_triton_warmup.py
+++ b/vllm/model_executor/warmup/sparse_mla_triton_warmup.py
@@ -75,6 +75,25 @@ def _hf_config_int(runner: "GPUModelRunner", name: str, default: int) -> int:
     return int(getattr(hf_config, name, default) or default)
 
 
+def _dcp_params(runner: "GPUModelRunner") -> tuple[int, int, int]:
+    """Return ``(dcp_rank, dcp_world_size, cp_kv_cache_interleave_size)``.
+
+    Both the V1 (``gpu_model_runner``) and V2 (``gpu/model_runner``) runners
+    derive DCP shape from ``parallel_config``. The V2 runner also exposes
+    ``dcp_size``/``cp_interleave`` aliases, but the V1 production runner only
+    defines ``dcp_world_size`` and reads the interleave from the config
+    directly. Reading the runner-specific aliases therefore silently fell back
+    to DCP1 on V1 (compiling the wrong Triton specialization); reading the
+    shared ``parallel_config`` source fixes that and surfaces a missing
+    attribute as an error instead of a silent degradation.
+    """
+    parallel_config = runner.vllm_config.parallel_config
+    dcp_world_size = int(parallel_config.decode_context_parallel_size)
+    cp_kv_cache_interleave_size = int(parallel_config.cp_kv_cache_interleave_size)
+    dcp_rank = int(runner.dcp_rank)
+    return dcp_rank, dcp_world_size, cp_kv_cache_interleave_size
+
+
 def _attention_backend_name(backend: object) -> str | None:
     get_name = getattr(backend, "get_name", None)
     if get_name is None:
@@ -288,9 +307,7 @@ def sparse_mla_triton_warmup(
 ) -> None:
     device = getattr(runner, "device", torch.device("cuda"))
     window_size = _hf_config_int(runner, "sliding_window", 128)
-    dcp_rank = int(getattr(runner, "dcp_rank", 0))
-    dcp_world_size = int(getattr(runner, "dcp_size", 1))
-    cp_kv_cache_interleave_size = int(getattr(runner, "cp_interleave", 1))
+    dcp_rank, dcp_world_size, cp_kv_cache_interleave_size = _dcp_params(runner)
 
     _warm_sparse_swa_prefill_metadata_kernel(device, window_size, num_tokens)
     for compress_ratio in compress_ratios:
@@ -346,13 +363,16 @@ def sparse_mla_triton_warmup_if_needed(worker: "Worker") -> None:
                 compress_ratios=(1,),
             )
         elif _has_attention_backend(runner, _B12X_SPARSE_MLA_BACKENDS):
+            dcp_rank, dcp_world_size, cp_kv_cache_interleave_size = _dcp_params(
+                runner
+            )
             _warm_prefill_chunk_metadata_kernel(
                 getattr(runner, "device", torch.device("cuda")),
                 compress_ratio=1,
                 query_len=num_tokens,
-                dcp_rank=int(getattr(runner, "dcp_rank", 0)),
-                dcp_world_size=int(getattr(runner, "dcp_size", 1)),
-                cp_kv_cache_interleave_size=int(getattr(runner, "cp_interleave", 1)),
+                dcp_rank=dcp_rank,
+                dcp_world_size=dcp_world_size,
+                cp_kv_cache_interleave_size=cp_kv_cache_interleave_size,
             )
         elif _has_attention_backend(runner, _INDEXER_PREFILL_CHUNK_METADATA_BACKENDS):
             _warm_prefill_chunk_metadata_kernel(

--- a/vllm/model_executor/warmup/sparse_mla_triton_warmup.py
+++ b/vllm/model_executor/warmup/sparse_mla_triton_warmup.py
@@ -29,6 +29,7 @@ _GENERIC_SPARSE_MLA_BACKENDS = frozenset(
         "FLASHINFER_MLA_SPARSE_SM120",
     }
 )
+_B12X_SPARSE_MLA_BACKENDS = frozenset({"B12X_MLA_SPARSE"})
 _INDEXER_PREFILL_CHUNK_METADATA_BACKENDS = frozenset({"DEEPSEEK_V32_INDEXER"})
 
 _SPARSE_PREFILL_METADATA_NUM_PREFILLS = (1, 2, 4, 8)
@@ -140,6 +141,10 @@ def _warm_prefill_chunk_metadata_kernel(
     device: torch.device,
     compress_ratio: int,
     query_len: int,
+    *,
+    dcp_rank: int = 0,
+    dcp_world_size: int = 1,
+    cp_kv_cache_interleave_size: int = 1,
 ) -> None:
     from vllm.v1.attention.backends.mla.indexer import build_prefill_chunk_metadata
 
@@ -189,6 +194,9 @@ def _warm_prefill_chunk_metadata_kernel(
                 block_table,
                 compress_ratio,
                 query_slice=query_slice,
+                dcp_rank=dcp_rank,
+                dcp_world_size=dcp_world_size,
+                cp_kv_cache_interleave_size=cp_kv_cache_interleave_size,
             )
 
 
@@ -280,10 +288,20 @@ def sparse_mla_triton_warmup(
 ) -> None:
     device = getattr(runner, "device", torch.device("cuda"))
     window_size = _hf_config_int(runner, "sliding_window", 128)
+    dcp_rank = int(getattr(runner, "dcp_rank", 0))
+    dcp_world_size = int(getattr(runner, "dcp_size", 1))
+    cp_kv_cache_interleave_size = int(getattr(runner, "cp_interleave", 1))
 
     _warm_sparse_swa_prefill_metadata_kernel(device, window_size, num_tokens)
     for compress_ratio in compress_ratios:
-        _warm_prefill_chunk_metadata_kernel(device, compress_ratio, num_tokens)
+        _warm_prefill_chunk_metadata_kernel(
+            device,
+            compress_ratio,
+            num_tokens,
+            dcp_rank=dcp_rank,
+            dcp_world_size=dcp_world_size,
+            cp_kv_cache_interleave_size=cp_kv_cache_interleave_size,
+        )
     for compress_ratio, topk, topk_width, n in combine_topk_swa_cases:
         _warm_combine_topk_swa_indices_kernel(
             device,
@@ -326,6 +344,15 @@ def sparse_mla_triton_warmup_if_needed(worker: "Worker") -> None:
                 runner,
                 num_tokens,
                 compress_ratios=(1,),
+            )
+        elif _has_attention_backend(runner, _B12X_SPARSE_MLA_BACKENDS):
+            _warm_prefill_chunk_metadata_kernel(
+                getattr(runner, "device", torch.device("cuda")),
+                compress_ratio=1,
+                query_len=num_tokens,
+                dcp_rank=int(getattr(runner, "dcp_rank", 0)),
+                dcp_world_size=int(getattr(runner, "dcp_size", 1)),
+                cp_kv_cache_interleave_size=int(getattr(runner, "cp_interleave", 1)),
             )
         elif _has_attention_backend(runner, _INDEXER_PREFILL_CHUNK_METADATA_BACKENDS):
             _warm_prefill_chunk_metadata_kernel(

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -79,7 +79,7 @@ _DECODE_SPLIT_TILE = 64
 _HEAD_ALIGNMENT = 8
 _BF16_BYTES = 2
 _EXTEND_PREWARM_DONE: set[
-    tuple[int | None, int, int, int, int, int, bool, str, bool]
+    tuple[int | None, int, int, int, int | None, int, int, bool, str, bool]
 ] = set()
 _KV_FP8_ROPE_REQUESTED = NVFP4_MLA_CACHE_FORMAT.fp8_rope
 
@@ -2417,6 +2417,7 @@ class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
             self.q_head_dim,
             self.kv_lora_rank,
             self._kernel_num_heads,
+            self._ckv_kernel_num_heads if self._ckv_extend_plan is not None else None,
             int(self.topk_tokens),
             int(self.block_size),
             bool(self.need_to_return_lse_for_decode),
@@ -2445,54 +2446,106 @@ class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
             dtype=torch.uint8,
             device=self.device,
         )
-        for rows in rows_to_warm:
-            rows = int(rows)
-            if rows in seen_rows:
-                continue
-            seen_rows.add(rows)
-            q = torch.zeros(
-                (rows, self._kernel_num_heads, self.q_head_dim),
-                dtype=torch.bfloat16,
+        if self._ckv_extend_plan is not None:
+            # The full-CKV path maps globally merged top-k ids into the
+            # rank-ordered gather buffer before launching attention. Its
+            # DCP/interleave specialization is otherwise first compiled by a
+            # real long prefill, after KV sizing has consumed the spare VRAM.
+            warm_req_ids = torch.zeros(1, dtype=torch.int32, device=self.device)
+            warm_topk = torch.zeros(
+                (1, self.topk_tokens), dtype=torch.int32, device=self.device
+            )
+            warm_rank_req_starts = torch.zeros(
+                (self.dcp_world_size, 1), dtype=torch.int32, device=self.device
+            )
+            warm_rank_req_lens = torch.full(
+                (self.dcp_world_size, 1),
+                self.block_size,
+                dtype=torch.int32,
                 device=self.device,
             )
-            selected_indices = torch.zeros(
-                (rows, self.topk_tokens), dtype=torch.int32, device=self.device
+            warm_page_table = torch.empty_like(warm_topk)
+            warm_valid_counts = torch.empty(1, dtype=torch.int32, device=self.device)
+            _map_global_topk_to_gathered_ckv(
+                warm_req_ids,
+                warm_topk,
+                warm_rank_req_starts,
+                warm_rank_req_lens,
+                warm_page_table,
+                warm_valid_counts,
+                dcp_size=self.dcp_world_size,
+                cp_kv_cache_interleave_size=self.cp_kv_cache_interleave_size,
+                padded_rank_tokens=self.block_size,
             )
-            cache_seqlens = torch.full(
-                (1,), self.block_size, dtype=torch.int32, device=self.device
+            _mask_page_table_after_nsa_len(warm_page_table, warm_valid_counts)
+
+        plans_to_warm = [
+            (
+                self._extend_plan,
+                self._kernel_num_heads,
+                self.need_to_return_lse_for_decode,
             )
-            nsa_cache_seqlens = torch.ones(
-                (rows,), dtype=torch.int32, device=self.device
+        ]
+        if self._ckv_extend_plan is not None:
+            # Full-CKV gather changes the query-head geometry from the
+            # all-gathered DCP head set to this rank's local heads. CuTe DSL
+            # therefore emits a distinct UnifiedPrefillMG specialization.
+            # Warm it here, before automatic KV sizing, so its persistent
+            # module allocation cannot first appear under a real long prompt.
+            plans_to_warm.append(
+                (self._ckv_extend_plan, self._ckv_kernel_num_heads, False)
             )
-            scratch_storage = torch.empty(
-                (self._scratch_nbytes,), dtype=torch.uint8, device=self.device
-            )
-            binding = self._extend_plan.bind(
-                scratch=scratch_storage,
-                q=q,
-                selected_indices=selected_indices,
-                cache_seqlens_int32=cache_seqlens,
-                nsa_cache_seqlens_int32=nsa_cache_seqlens,
-            )
-            if self.need_to_return_lse_for_decode:
-                self._sparse_mla_extend_forward(
-                    binding=binding,
-                    kv_cache=kv_cache,
-                    sm_scale=self.scale,
-                    v_head_dim=self.kv_lora_rank,
-                    return_lse=True,
-                    lse_scale="natural",
-                    **kernel_format_kwargs,
+
+        for extend_plan, num_heads, return_lse in plans_to_warm:
+            seen_rows.clear()
+            for rows in rows_to_warm:
+                rows = int(rows)
+                if rows in seen_rows:
+                    continue
+                seen_rows.add(rows)
+                q = torch.zeros(
+                    (rows, num_heads, self.q_head_dim),
+                    dtype=torch.bfloat16,
+                    device=self.device,
                 )
-            else:
-                self._sparse_mla_extend_forward(
-                    binding=binding,
-                    kv_cache=kv_cache,
-                    sm_scale=self.scale,
-                    v_head_dim=self.kv_lora_rank,
-                    **kernel_format_kwargs,
+                selected_indices = torch.zeros(
+                    (rows, self.topk_tokens), dtype=torch.int32, device=self.device
                 )
-            self._sync_warmup()
+                cache_seqlens = torch.full(
+                    (1,), self.block_size, dtype=torch.int32, device=self.device
+                )
+                nsa_cache_seqlens = torch.ones(
+                    (rows,), dtype=torch.int32, device=self.device
+                )
+                scratch_storage = torch.empty(
+                    (self._scratch_nbytes,), dtype=torch.uint8, device=self.device
+                )
+                binding = extend_plan.bind(
+                    scratch=scratch_storage,
+                    q=q,
+                    selected_indices=selected_indices,
+                    cache_seqlens_int32=cache_seqlens,
+                    nsa_cache_seqlens_int32=nsa_cache_seqlens,
+                )
+                if return_lse:
+                    self._sparse_mla_extend_forward(
+                        binding=binding,
+                        kv_cache=kv_cache,
+                        sm_scale=self.scale,
+                        v_head_dim=self.kv_lora_rank,
+                        return_lse=True,
+                        lse_scale="natural",
+                        **kernel_format_kwargs,
+                    )
+                else:
+                    self._sparse_mla_extend_forward(
+                        binding=binding,
+                        kv_cache=kv_cache,
+                        sm_scale=self.scale,
+                        v_head_dim=self.kv_lora_rank,
+                        **kernel_format_kwargs,
+                    )
+                self._sync_warmup()
 
     def forward_mqa(
         self,


### PR DESCRIPTION
## Problem

The B12X sparse-MLA constructor prewarms the ordinary extend plan, but TP4/DCP4 full-CKV gather uses a distinct local-head `UnifiedPrefillMGKernel` specialization. Its CuTe module and two DCP-specific Triton helpers can therefore first compile under a real long prompt, after automatic KV sizing has consumed the spare VRAM.

On GLM-5.2 EXL3 TP4/DCP4/MTP3, the first 16K prompt produced late-JIT warnings for `UnifiedPrefillMGKernel`, `_build_prefill_chunk_metadata_kernel`, and `_map_global_topk_to_gathered_ckv_kernel`; physical free memory fell from about 2.4 GiB/rank at idle to 245-255 MiB/rank. This did not OOM in that run, but it defeats the startup memory-safety contract.

## Change

- prewarm the full-CKV local-head extend plan in addition to the ordinary gathered-head plan;
- prewarm the global-top-k remap/mask with the active DCP/interleave shape;
- route B12X through the sparse-prefill metadata warmup with the runtime DCP rank/size/interleave;
- add a CPU routing regression test.

The serving hot path is unchanged.

## Validation so far

- focused CPU routing test: passed;
- Ruff/pre-commit source checks: passed (the branch base has four pre-existing mypy findings in `b12x_mla_sparse.py`);
- exact GG v20 r31 + vLLM #258/#270 + B12X #130 GPU qualification is in progress on 4x RTX PRO 6000 Blackwell. Before/after startup capacity, first-long-prompt JIT, physical high-water, PP/TG/MAL, and correctness evidence will be posted before marking ready.