### PR TITLE
perf(exl3): load mixed Trellis directly into tier slabs

### DIFF
--- a/tests/quantization/test_exl3.py
+++ b/tests/quantization/test_exl3.py
@@ -208,6 +208,118 @@ def test_rank_sliced_parameter_preallocates_projection_major_slab(monkeypatch):
     torch.testing.assert_close(param.exl3_tensors[(2, "w3")], w3)
 
 
+def test_rank_sliced_parameter_preallocates_bitrate_group_slabs(monkeypatch):
+    monkeypatch.setattr(parameter_module, "get_tensor_model_parallel_rank", lambda: 0)
+    monkeypatch.setattr(
+        parameter_module, "get_tensor_model_parallel_world_size", lambda: 1
+    )
+    groups = ((0, 2), (1, 3))
+    param = Exl3MoEParameter(
+        weight_loader=lambda *args, **kwargs: None,
+        num_experts=4,
+        shard_ids=("w1", "w3"),
+        preallocate_groups=groups,
+    )
+
+    for expert_id in range(4):
+        bits = 3 if expert_id in groups[0] else 4
+        shape = (2, 2, 16 * bits)
+        for shard_id, offset in (("w1", 0), ("w3", 100)):
+            value = torch.full(
+                shape,
+                expert_id + offset,
+                dtype=torch.int16,
+            )
+            param.load_exl3_weight(
+                value,
+                expert_id=expert_id,
+                shard_id=shard_id,
+            )
+
+    k3 = param.exl3_group_backing(groups[0])
+    k4 = param.exl3_group_backing(groups[1])
+    assert tuple(k3.shape) == (2, 2, 2, 2, 48)
+    assert tuple(k4.shape) == (2, 2, 2, 2, 64)
+    assert param.exl3_tensors[(2, "w1")].data_ptr() == k3[0, 1].data_ptr()
+    assert param.exl3_tensors[(1, "w3")].data_ptr() == k4[1, 0].data_ptr()
+    assert k3[0, 0].unique().item() == 0
+    assert k3[0, 1].unique().item() == 2
+    assert k4[1, 0].unique().item() == 101
+    assert k4[1, 1].unique().item() == 103
+
+    with pytest.raises(ValueError, match="partition all experts"):
+        Exl3MoEParameter(
+            weight_loader=lambda *args, **kwargs: None,
+            num_experts=4,
+            shard_ids=("w1",),
+            preallocate_groups=((0, 1),),
+        )
+
+
+def test_rank_sliced_broadcast_pointer_table_repeats_one_physical_row():
+    slab = torch.ones((1, 128), dtype=torch.float16)
+
+    table = Exl3MoEMethod._pointer_table(slab, num_experts=4)
+
+    assert table.tolist() == [slab.data_ptr()] * 4
+    with pytest.raises(RuntimeError, match="per-expert or broadcast"):
+        Exl3MoEMethod._pointer_table(
+            torch.ones((2, 128), dtype=torch.float16), num_experts=4
+        )
+
+
+def test_rank_sliced_shared_h_create_weights_allocates_one_physical_row(
+    monkeypatch,
+):
+    monkeypatch.setattr(parameter_module, "get_tensor_model_parallel_rank", lambda: 0)
+    monkeypatch.setattr(
+        parameter_module, "get_tensor_model_parallel_world_size", lambda: 4
+    )
+    config = Exl3Config()
+    config.maybe_update_config(
+        "unused",
+        SimpleNamespace(
+            hybrid_tr3_tail=_rank_sliced_metadata(
+                rotation_layout="shared_h_v1",
+                shared_h_tensor_schema=(
+                    "model.layers.{L}.mlp.experts.shared_h.{proj}.rank{r}.{suh|svh}"
+                ),
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        exl3_module,
+        "get_current_vllm_config_or_none",
+        lambda: SimpleNamespace(
+            scheduler_config=SimpleNamespace(max_num_batched_tokens=8192),
+            model_config=SimpleNamespace(runner_type="generate"),
+        ),
+    )
+    layer = torch.nn.Module()
+    layer.layer_name = "model.layers.3.mlp.experts"
+    moe = SimpleNamespace(
+        moe_parallel_config=SimpleNamespace(use_ep=False, tp_rank=0, tp_size=4),
+        has_bias=False,
+    )
+    method = Exl3MoEMethod(config, moe)
+
+    method.create_weights(
+        layer,
+        num_experts=256,
+        hidden_size=6144,
+        intermediate_size_per_partition=512,
+        params_dtype=torch.bfloat16,
+    )
+
+    assert layer.exl3_shared_h_rotations
+    assert layer.w13_suh.exl3_num_experts == 1
+    assert layer.w2_svh.exl3_num_experts == 1
+    assert layer.w13_svh.exl3_num_experts == 256
+    assert layer.w2_suh.exl3_num_experts == 256
+    assert layer.w13_trellis.exl3_num_experts == 256
+    assert layer.w2_trellis.exl3_num_experts == 256
+
+
 def test_rank_sliced_weights_use_unified_fused_moe_contract(monkeypatch):
     experts = 2
     hidden = intermediate = 128
@@ -290,18 +402,43 @@ def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(monkeypat
             exl3_backing=backing,
         )
 
-    w13_tensors = {}
-    w2_tensors = {}
+    monkeypatch.setattr(parameter_module, "get_tensor_model_parallel_rank", lambda: 0)
+    monkeypatch.setattr(
+        parameter_module, "get_tensor_model_parallel_world_size", lambda: 1
+    )
+    tier_groups = ((0, 2), (1, 3))
+    w13_param = Exl3MoEParameter(
+        weight_loader=lambda *args, **kwargs: None,
+        num_experts=experts,
+        shard_ids=("w1", "w3"),
+        preallocate_groups=tier_groups,
+    )
+    w2_param = Exl3MoEParameter(
+        weight_loader=lambda *args, **kwargs: None,
+        num_experts=experts,
+        shard_ids=("w2",),
+        preallocate_groups=tier_groups,
+    )
     for expert, bits in enumerate(bitrates):
         for shard in ("w1", "w3"):
-            w13_tensors[(expert, shard)] = torch.zeros(
-                (hidden // 16, intermediate // 16, 16 * bits),
-                dtype=torch.int16,
+            w13_param.load_exl3_weight(
+                torch.zeros(
+                    (hidden // 16, intermediate // 16, 16 * bits),
+                    dtype=torch.int16,
+                ),
+                expert_id=expert,
+                shard_id=shard,
             )
-        w2_tensors[(expert, "w2")] = torch.zeros(
-            (intermediate // 16, hidden // 16, 16 * bits),
-            dtype=torch.int16,
+        w2_param.load_exl3_weight(
+            torch.zeros(
+                (intermediate // 16, hidden // 16, 16 * bits),
+                dtype=torch.int16,
+            ),
+            expert_id=expert,
+            shard_id="w2",
         )
+    k3_w13_ptr = w13_param.exl3_group_backing(tier_groups[0]).data_ptr()
+    k4_w13_ptr = w13_param.exl3_group_backing(tier_groups[1]).data_ptr()
 
     slabs = {
         "w13_suh": torch.ones((2, experts, hidden), dtype=torch.float16),
@@ -316,8 +453,8 @@ def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(monkeypat
         exl3_layer_bitrates=bitrates,
         activation=MoEActivation.SILU,
         layer_name="model.layers.3.mlp.experts",
-        w13_trellis=parameter(("w1", "w3"), w13_tensors),
-        w2_trellis=parameter(("w2",), w2_tensors),
+        w13_trellis=w13_param,
+        w2_trellis=w2_param,
     )
     for prefix, shards in (("w13", ("w1", "w3")), ("w2", ("w2",))):
         for suffix in ("suh", "svh", "mcg", "mul1"):
@@ -353,8 +490,14 @@ def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(monkeypat
 
     method._prepare_mixed_rank_sliced_weights(layer)
 
-    assert [entry["trellis_bits"] for entry in api.prepared] == [3, 4]
-    assert [entry["num_experts"] for entry in api.prepared] == [2, 2]
+    assert [entry["trellis_bits"] for entry in api.prepared] == [3, 3, 4, 4]
+    assert [entry["num_experts"] for entry in api.prepared] == [2] * 4
+    assert [entry["w13"].data_ptr() for entry in api.prepared] == [
+        k3_w13_ptr,
+        k3_w13_ptr,
+        k4_w13_ptr,
+        k4_w13_ptr,
+    ]
     for entry in api.prepared:
         bits = entry["trellis_bits"]
         assert tuple(entry["w13"].shape) == (
@@ -378,6 +521,8 @@ def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(monkeypat
     assert layer.exl3_mixed_trellis["tier_bits"] == (3, 4)
     assert layer.w13_trellis.exl3_tensors == {}
     assert layer.w2_trellis.exl3_tensors == {}
+    assert layer.w13_trellis.exl3_group_backings == [None, None]
+    assert layer.w2_trellis.exl3_group_backings == [None, None]
     assert layer.w13_suh.exl3_backing is None
     assert layer.w2_svh.exl3_backing is None
 

--- a/tests/quantization/test_exl3.py
+++ b/tests/quantization/test_exl3.py
@@ -256,6 +256,115 @@ def test_rank_sliced_parameter_preallocates_bitrate_group_slabs(monkeypatch):
         )
 
 
+def test_grouped_slab_rejects_mismatched_trellis_dtype(monkeypatch):
+    """C15: an int32 trellis tensor among int16 ones must raise, not silently cast."""
+    monkeypatch.setattr(parameter_module, "get_tensor_model_parallel_rank", lambda: 0)
+    monkeypatch.setattr(
+        parameter_module, "get_tensor_model_parallel_world_size", lambda: 1
+    )
+    groups = ((0, 2), (1, 3))
+    param = Exl3MoEParameter(
+        weight_loader=lambda *args, **kwargs: None,
+        num_experts=4,
+        shard_ids=("w1", "w3"),
+        preallocate_groups=groups,
+        suffix="trellis",
+    )
+    # First (correct) int16 tensor pins the slab dtype to the schema value.
+    param.load_exl3_weight(
+        torch.zeros((2, 2, 48), dtype=torch.int16),
+        expert_id=0,
+        shard_id="w1",
+    )
+    # A later int32 tensor must be rejected instead of being truncated to int16
+    # by target.copy_ and then passing _validate_moe_shapes.
+    with pytest.raises(
+        ValueError, match="dtype is torch.int32, expected torch.int16"
+    ):
+        param.load_exl3_weight(
+            torch.zeros((2, 2, 48), dtype=torch.int32),
+            expert_id=2,
+            shard_id="w1",
+        )
+
+
+def test_grouped_slab_rejects_wrong_first_tensor_dtype(monkeypatch):
+    """C15: the schema-derived dtype catches a malformed first tensor too."""
+    monkeypatch.setattr(parameter_module, "get_tensor_model_parallel_rank", lambda: 0)
+    monkeypatch.setattr(
+        parameter_module, "get_tensor_model_parallel_world_size", lambda: 1
+    )
+    param = Exl3MoEParameter(
+        weight_loader=lambda *args, **kwargs: None,
+        num_experts=2,
+        shard_ids=("w1",),
+        preallocate_groups=((0, 1),),
+        suffix="trellis",
+    )
+    with pytest.raises(
+        ValueError, match="dtype is torch.int32, expected torch.int16"
+    ):
+        param.load_exl3_weight(
+            torch.zeros((2, 2, 48), dtype=torch.int32),
+            expert_id=0,
+            shard_id="w1",
+        )
+
+
+def test_projection_slab_rejects_mismatched_scale_dtype(monkeypatch):
+    """C15: a float32 scale among float16 scales must raise, not silently cast."""
+    monkeypatch.setattr(parameter_module, "get_tensor_model_parallel_rank", lambda: 0)
+    monkeypatch.setattr(
+        parameter_module, "get_tensor_model_parallel_world_size", lambda: 1
+    )
+    param = Exl3MoEParameter(
+        weight_loader=lambda *args, **kwargs: None,
+        num_experts=3,
+        shard_ids=("w1", "w3"),
+        preallocate=True,
+        suffix="suh",
+    )
+    param.load_exl3_weight(
+        torch.zeros(8, dtype=torch.float16),
+        expert_id=1,
+        shard_id="w1",
+    )
+    with pytest.raises(
+        ValueError, match="dtype is torch.float32, expected torch.float16"
+    ):
+        param.load_exl3_weight(
+            torch.zeros(8, dtype=torch.float32),
+            expert_id=2,
+            shard_id="w3",
+        )
+
+
+def test_grouped_slab_accepts_consistent_dtype(monkeypatch):
+    """C15: a homogeneous-dtype grouped slab still loads (regression guard)."""
+    monkeypatch.setattr(parameter_module, "get_tensor_model_parallel_rank", lambda: 0)
+    monkeypatch.setattr(
+        parameter_module, "get_tensor_model_parallel_world_size", lambda: 1
+    )
+    groups = ((0, 1),)
+    param = Exl3MoEParameter(
+        weight_loader=lambda *args, **kwargs: None,
+        num_experts=2,
+        shard_ids=("w1", "w3"),
+        preallocate_groups=groups,
+        suffix="trellis",
+    )
+    for expert_id in range(2):
+        for shard_id in ("w1", "w3"):
+            param.load_exl3_weight(
+                torch.full((2, 2, 48), expert_id, dtype=torch.int16),
+                expert_id=expert_id,
+                shard_id=shard_id,
+            )
+    slab = param.exl3_group_backing(groups[0])
+    assert tuple(slab.shape) == (2, 2, 2, 2, 48)
+    assert slab.dtype == torch.int16
+
+
 def test_rank_sliced_broadcast_pointer_table_repeats_one_physical_row():
     slab = torch.ones((1, 128), dtype=torch.float16)
 

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -1174,6 +1174,17 @@ class Exl3LinearMethod(LinearMethodBase):
         return output[..., :logical_n]
 
 
+# Canonical dtype for each EXL3 tensor suffix that may be loaded into a slab.
+# Derived from the kernel boundary (see _validate_moe_shapes) rather than from
+# untrusted checkpoint tensors, so a malformed checkpoint cannot coerce the slab
+# backing dtype via the first tensor it happens to load.  mcg/mul1 markers are
+# int32 but are never slab-preallocated, so they are intentionally absent.
+_EXL3_SLAB_DTYPE: dict[str, torch.dtype] = {
+    "trellis": torch.int16,
+    "suh": torch.float16,
+    "svh": torch.float16,
+}
+
 class Exl3MoEParameter(BasevLLMParameter):
     """EXL3 tensors keyed by expert/projection, optionally in one GPU slab."""
 
@@ -1185,11 +1196,11 @@ class Exl3MoEParameter(BasevLLMParameter):
         shard_ids: tuple[str, ...] = (),
         preallocate: bool = False,
         preallocate_groups: tuple[tuple[int, ...], ...] = (),
+        suffix: str = "",
     ):
-        del num_experts, shard_ids, preallocate, preallocate_groups
+        del num_experts, shard_ids, preallocate, preallocate_groups, suffix
         data = torch.empty(0, dtype=torch.uint8)
         return super().__new__(cls, data=data, weight_loader=weight_loader)
-
     def __init__(
         self,
         *,
@@ -1198,12 +1209,14 @@ class Exl3MoEParameter(BasevLLMParameter):
         shard_ids: tuple[str, ...] = (),
         preallocate: bool = False,
         preallocate_groups: tuple[tuple[int, ...], ...] = (),
+        suffix: str = "",
     ):
         self.exl3_tensors: dict[tuple[int, str], torch.Tensor] = {}
         self.exl3_backing: torch.Tensor | None = None
         self.exl3_num_experts = int(num_experts)
         self.exl3_shard_ids = tuple(shard_ids)
         self.exl3_preallocate = bool(preallocate)
+        self.exl3_suffix = str(suffix)
         self.exl3_preallocate_groups = tuple(
             tuple(int(expert_id) for expert_id in group) for group in preallocate_groups
         )
@@ -1254,6 +1267,10 @@ class Exl3MoEParameter(BasevLLMParameter):
                 ) from exc
             if self.device.type == "meta":
                 raise RuntimeError("rank-sliced EXL3 slabs cannot be allocated on meta")
+            # Schema-derived dtype for this suffix (trellis->int16, suh/svh->
+            # float16); authoritative over the untrusted first tensor so a
+            # malformed checkpoint cannot pin the slab dtype.
+            expected_dtype = _EXL3_SLAB_DTYPE.get(self.exl3_suffix)
             backing = self.exl3_group_backings[group_index]
             if backing is None:
                 group_size = len(self.exl3_preallocate_groups[group_index])
@@ -1262,9 +1279,20 @@ class Exl3MoEParameter(BasevLLMParameter):
                     if len(self.exl3_shard_ids) > 1
                     else (group_size,)
                 )
+                # Allocated with torch.empty: the backing is uninitialized until
+                # every (expert, shard) slot is copy_'d in.  The `loaded ==
+                # expected` completeness check in exl3_group_backing is what
+                # prevents a direct reader of exl3_group_backings[i] from seeing
+                # garbage, so any future caller must go through that accessor
+                # rather than indexing the backing directly.
+                slab_dtype = (
+                    expected_dtype
+                    if expected_dtype is not None
+                    else loaded_weight.dtype
+                )
                 backing = torch.empty(
                     prefix + tuple(loaded_weight.shape),
-                    dtype=loaded_weight.dtype,
+                    dtype=slab_dtype,
                     device=self.device,
                 )
                 self.exl3_group_backings[group_index] = backing
@@ -1278,6 +1306,18 @@ class Exl3MoEParameter(BasevLLMParameter):
                 raise ValueError(
                     "rank-sliced EXL3 tensor shape changed within one grouped slab: "
                     f"expected={tuple(target.shape)}, got={tuple(loaded_weight.shape)}"
+                )
+            # C15: reject a dtype mismatch before copy_, which would otherwise
+            # silently cast (e.g. an int32 trellis tensor among int16 ones) and
+            # let a malformed checkpoint pass _validate_moe_shapes.  When the
+            # suffix has a canonical dtype it is authoritative; otherwise we
+            # enforce consistency against the first tensor (target.dtype).
+            want_dtype = expected_dtype if expected_dtype is not None else target.dtype
+            if loaded_weight.dtype != want_dtype:
+                raise ValueError(
+                    f"EXL3 grouped slab {self.exl3_suffix!r} (expert {expert_id}, "
+                    f"shard {shard_id!r}) dtype is {loaded_weight.dtype}, "
+                    f"expected {want_dtype}"
                 )
             target.copy_(loaded_weight, non_blocking=True)
             self.exl3_tensors[key] = target
@@ -1295,15 +1335,21 @@ class Exl3MoEParameter(BasevLLMParameter):
             )
         if self.device.type == "meta":
             raise RuntimeError("rank-sliced EXL3 slabs cannot be allocated on meta")
+        expected_dtype = _EXL3_SLAB_DTYPE.get(self.exl3_suffix)
         if self.exl3_backing is None:
             prefix = (
                 (len(self.exl3_shard_ids), self.exl3_num_experts)
                 if len(self.exl3_shard_ids) > 1
                 else (self.exl3_num_experts,)
             )
+            slab_dtype = (
+                expected_dtype
+                if expected_dtype is not None
+                else loaded_weight.dtype
+            )
             self.exl3_backing = torch.empty(
                 prefix + tuple(loaded_weight.shape),
-                dtype=loaded_weight.dtype,
+                dtype=slab_dtype,
                 device=self.device,
             )
         shard_index = self.exl3_shard_ids.index(shard_id)
@@ -1317,11 +1363,31 @@ class Exl3MoEParameter(BasevLLMParameter):
                 "rank-sliced EXL3 tensor shape changed within one slab: "
                 f"expected={tuple(target.shape)}, got={tuple(loaded_weight.shape)}"
             )
+        # C15: reject a dtype mismatch before copy_, which would otherwise
+        # silently cast (e.g. a float32 scale among float16 ones) and let a
+        # malformed checkpoint pass _validate_moe_shapes.  When the suffix has
+        # a canonical dtype it is authoritative; otherwise we enforce
+        # consistency against the first tensor (target.dtype).
+        want_dtype = expected_dtype if expected_dtype is not None else target.dtype
+        if loaded_weight.dtype != want_dtype:
+            raise ValueError(
+                f"EXL3 slab {self.exl3_suffix!r} (expert {expert_id}, "
+                f"shard {shard_id!r}) dtype is {loaded_weight.dtype}, "
+                f"expected {want_dtype}"
+            )
         target.copy_(loaded_weight, non_blocking=True)
         self.exl3_tensors[key] = target
 
     def exl3_group_backing(self, expert_ids: tuple[int, ...]) -> torch.Tensor:
-        """Return a fully loaded tier slab in the requested expert order."""
+        """Return a fully loaded tier slab in the requested expert order.
+
+        Layout contract: the backing is shard-major, group-offset-minor, in
+        ``exl3_shard_ids`` order — i.e. ``backing[shard_index, group_offset]``
+        (or ``backing[group_offset]`` for a single shard) where ``shard_index``
+        is the position in ``exl3_shard_ids`` and ``group_offset`` is the
+        expert's position within its preallocation group.  The mixed-rank-sliced
+        loader relies on this exact ordering to stack tiers correctly.
+        """
 
         expert_ids = tuple(int(expert_id) for expert_id in expert_ids)
         try:
@@ -1482,6 +1548,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                         preallocate_groups=(
                             mixed_trellis_groups if suffix == "trellis" else ()
                         ),
+                        suffix=suffix,
                     ),
                 )
 

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -1184,8 +1184,9 @@ class Exl3MoEParameter(BasevLLMParameter):
         num_experts: int = 0,
         shard_ids: tuple[str, ...] = (),
         preallocate: bool = False,
+        preallocate_groups: tuple[tuple[int, ...], ...] = (),
     ):
-        del num_experts, shard_ids, preallocate
+        del num_experts, shard_ids, preallocate, preallocate_groups
         data = torch.empty(0, dtype=torch.uint8)
         return super().__new__(cls, data=data, weight_loader=weight_loader)
 
@@ -1196,12 +1197,39 @@ class Exl3MoEParameter(BasevLLMParameter):
         num_experts: int = 0,
         shard_ids: tuple[str, ...] = (),
         preallocate: bool = False,
+        preallocate_groups: tuple[tuple[int, ...], ...] = (),
     ):
         self.exl3_tensors: dict[tuple[int, str], torch.Tensor] = {}
         self.exl3_backing: torch.Tensor | None = None
         self.exl3_num_experts = int(num_experts)
         self.exl3_shard_ids = tuple(shard_ids)
         self.exl3_preallocate = bool(preallocate)
+        self.exl3_preallocate_groups = tuple(
+            tuple(int(expert_id) for expert_id in group) for group in preallocate_groups
+        )
+        self.exl3_group_backings: list[torch.Tensor | None] = [
+            None for _ in self.exl3_preallocate_groups
+        ]
+        self._exl3_group_locations: dict[int, tuple[int, int]] = {}
+        for group_index, group in enumerate(self.exl3_preallocate_groups):
+            if not group:
+                raise ValueError("EXL3 preallocation groups cannot be empty")
+            for group_offset, expert_id in enumerate(group):
+                if expert_id in self._exl3_group_locations:
+                    raise ValueError(
+                        f"EXL3 expert {expert_id} appears in multiple "
+                        "preallocation groups"
+                    )
+                self._exl3_group_locations[expert_id] = (
+                    group_index,
+                    group_offset,
+                )
+        if self.exl3_preallocate_groups and set(self._exl3_group_locations) != set(
+            range(self.exl3_num_experts)
+        ):
+            raise ValueError(
+                "EXL3 preallocation groups must partition all experts exactly once"
+            )
         super().__init__(data=self.data, weight_loader=weight_loader)
 
     def load_exl3_weight(
@@ -1212,6 +1240,48 @@ class Exl3MoEParameter(BasevLLMParameter):
         shard_id: str,
     ) -> None:
         key = (int(expert_id), str(shard_id))
+        if self.exl3_preallocate_groups:
+            if shard_id not in self.exl3_shard_ids:
+                raise ValueError(
+                    f"invalid EXL3 grouped slab shard {shard_id!r}; "
+                    f"expected one of {self.exl3_shard_ids}"
+                )
+            try:
+                group_index, group_offset = self._exl3_group_locations[int(expert_id)]
+            except KeyError as exc:
+                raise ValueError(
+                    f"EXL3 expert {expert_id} has no preallocation group"
+                ) from exc
+            if self.device.type == "meta":
+                raise RuntimeError("rank-sliced EXL3 slabs cannot be allocated on meta")
+            backing = self.exl3_group_backings[group_index]
+            if backing is None:
+                group_size = len(self.exl3_preallocate_groups[group_index])
+                prefix = (
+                    (len(self.exl3_shard_ids), group_size)
+                    if len(self.exl3_shard_ids) > 1
+                    else (group_size,)
+                )
+                backing = torch.empty(
+                    prefix + tuple(loaded_weight.shape),
+                    dtype=loaded_weight.dtype,
+                    device=self.device,
+                )
+                self.exl3_group_backings[group_index] = backing
+            shard_index = self.exl3_shard_ids.index(shard_id)
+            target = (
+                backing[shard_index, group_offset]
+                if len(self.exl3_shard_ids) > 1
+                else backing[group_offset]
+            )
+            if tuple(target.shape) != tuple(loaded_weight.shape):
+                raise ValueError(
+                    "rank-sliced EXL3 tensor shape changed within one grouped slab: "
+                    f"expected={tuple(target.shape)}, got={tuple(loaded_weight.shape)}"
+                )
+            target.copy_(loaded_weight, non_blocking=True)
+            self.exl3_tensors[key] = target
+            return
         if not self.exl3_preallocate:
             self.exl3_tensors[key] = loaded_weight.contiguous()
             return
@@ -1249,6 +1319,32 @@ class Exl3MoEParameter(BasevLLMParameter):
             )
         target.copy_(loaded_weight, non_blocking=True)
         self.exl3_tensors[key] = target
+
+    def exl3_group_backing(self, expert_ids: tuple[int, ...]) -> torch.Tensor:
+        """Return a fully loaded tier slab in the requested expert order."""
+
+        expert_ids = tuple(int(expert_id) for expert_id in expert_ids)
+        try:
+            group_index = self.exl3_preallocate_groups.index(expert_ids)
+        except ValueError as exc:
+            raise ValueError(
+                f"EXL3 grouped slab has no exact expert tier {expert_ids}"
+            ) from exc
+        backing = self.exl3_group_backings[group_index]
+        if backing is None:
+            raise RuntimeError(f"EXL3 grouped slab {expert_ids} was never loaded")
+        expected = len(expert_ids) * len(self.exl3_shard_ids)
+        loaded = sum(
+            (expert_id, shard_id) in self.exl3_tensors
+            for expert_id in expert_ids
+            for shard_id in self.exl3_shard_ids
+        )
+        if loaded != expected:
+            raise RuntimeError(
+                f"EXL3 grouped slab {expert_ids} is incomplete: "
+                f"{loaded}/{expected} tensors"
+            )
+        return backing
 
 
 def _exl3_moe_weight_loader(
@@ -1358,6 +1454,16 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 str(layer.layer_name)
             )
             layer.exl3_mixed_bitrate = len(set(layer.exl3_layer_bitrates)) > 1
+        mixed_trellis_groups: tuple[tuple[int, ...], ...] = ()
+        if rank_sliced and getattr(layer, "exl3_mixed_bitrate", False):
+            mixed_trellis_groups = tuple(
+                tuple(
+                    expert_id
+                    for expert_id, expert_bits in enumerate(layer.exl3_layer_bitrates)
+                    if int(expert_bits) == bits
+                )
+                for bits in sorted(set(layer.exl3_layer_bitrates))
+            )
         for prefix, shard_ids in (("w13", ("w1", "w3")), ("w2", ("w2",))):
             for suffix in ("suh", "svh", "trellis", "mcg", "mul1"):
                 layer.register_parameter(
@@ -1372,6 +1478,9 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                             {"suh", "svh"}
                             if getattr(layer, "exl3_mixed_bitrate", False)
                             else {"suh", "svh", "trellis"}
+                        ),
+                        preallocate_groups=(
+                            mixed_trellis_groups if suffix == "trellis" else ()
                         ),
                     ),
                 )
@@ -1614,22 +1723,28 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         tier_ids = []
         for bits, expert_ids in tiers.items():
             expected_last = 16 * bits
-            w13 = torch.stack(
-                tuple(
-                    torch.stack(
-                        tuple(
-                            w13_param.exl3_tensors[(expert_id, shard_id)]
-                            for expert_id in expert_ids
+            if isinstance(w13_param, Exl3MoEParameter):
+                w13 = w13_param.exl3_group_backing(expert_ids)
+                w2 = w2_param.exl3_group_backing(expert_ids)
+            else:
+                # Compatibility for synthetic tests and older reload paths.
+                w13 = torch.stack(
+                    tuple(
+                        torch.stack(
+                            tuple(
+                                w13_param.exl3_tensors[(expert_id, shard_id)]
+                                for expert_id in expert_ids
+                            )
                         )
+                        for shard_id in w13_shards
                     )
-                    for shard_id in w13_shards
-                )
-            ).contiguous()
-            w2 = torch.stack(
-                tuple(
-                    w2_param.exl3_tensors[(expert_id, "w2")] for expert_id in expert_ids
-                )
-            ).contiguous()
+                ).contiguous()
+                w2 = torch.stack(
+                    tuple(
+                        w2_param.exl3_tensors[(expert_id, "w2")]
+                        for expert_id in expert_ids
+                    )
+                ).contiguous()
             expected_w13 = (
                 2,
                 len(expert_ids),
@@ -1708,6 +1823,10 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 param = getattr(layer, f"{prefix}_{suffix}")
                 param.exl3_tensors.clear()
                 param.exl3_backing = None
+                if isinstance(param, Exl3MoEParameter):
+                    param.exl3_group_backings[:] = [
+                        None for _ in param.exl3_preallocate_groups
+                    ]
         logger.info(
             "EXL3 mixed Trellis %s: tiers=%s",
             layer.layer_name,


### PR DESCRIPTION
## What changed

Mixed-bitrate rank-sliced EXL3 tensors now load directly into their final
contiguous K3/K4 tier slabs instead of retaining 256 per-expert tensors and
repacking every layer with nested `torch.stack` calls after loading.

`Exl3MoEParameter` accepts an exact expert partition, maps each incoming expert
to a deterministic `(group, offset)`, and preallocates one projection-major
backing per bitrate. `_prepare_mixed_rank_sliced_weights` binds those backings
zero-copy. The cleanup path resets the backing slots rather than deleting their
shape, preserving reload behavior.

This is a small child PR against the current EXL3 integration head in #228 so
reviewers see only the startup change. It addresses #276.

## Why

An exact r33 launch of `willfalco/GLM-5.2-EXL3-TR3-3.42bpw`, TP4/DCP4/MTP3,
showed the layer-3 through layer-77 mixed-Trellis materialization phase taking
336 seconds (`11:26:21` to `11:31:57`) on every rank. Total model loading was
1217.15 seconds, so this serial per-rank phase represented 27.6% of the reported
load interval.

The ranks are already concurrent. The serialization is within each worker's
generic `process_weights_after_loading()` module walk. A typical 3.42-bpw layer
(`H=6144`, TP-local `I=512`, 148 K3 + 108 K4 experts) contains about 985.5 MiB
of Trellis payload per rank. The old path temporarily holds both the per-expert
source storage and a second tier-ordered copy for each layer.

This patch moves the mandatory loader copy into the final layout and removes
the later device-to-device repack. It should eliminate roughly 985.5 MiB of
transient VRAM for a typical layer and collapse most of the visible 336-second
post-load phase. The honest total startup improvement still needs a matched GPU
A/B because the mandatory host-to-device transfer moves earlier into the
safetensors phase rather than disappearing.

## Validation

On the exact r33 runtime, in a separate CPU-only/network-isolated container:

```text
45 passed, 15 warnings in 10.43s
```

Coverage includes:

- deterministic K3/K4 expert partitioning;
- projection-major W13 and single-shard W2 layouts;
- zero-copy pointer identity from loader backing to both prepared tier plans;
- exact partition and incomplete-load failures;
- cleanup state that remains reusable by a later reload.

Additional checks:

```text
ruff check vllm/model_executor/layers/quantization/exl3.py \
  tests/quantization/test_exl3.py
All checks passed!

git diff --check
```

## GPU qualification still required

Before merging, compare patched/unpatched warm-cache launches on the same
checkpoint and profile:

1. total model load and layer-3-to-layer-77 materialization time;
2. peak/final VRAM and allocator fragmentation;
3. load correctness and deterministic tier counts;
4. short generation, C1/C8 decode, 8K/64K prefill, MTP acceptance;
5. long-context needle/correctness gate.

