### PR TITLE
perf(kimi-k3): use b12x all-reduce policy and full decode graphs

### DIFF
--- a/serve-kimi-k3-full-mxfp4-dcp16-1m-no-dspark.sh
+++ b/serve-kimi-k3-full-mxfp4-dcp16-1m-no-dspark.sh
@@ -89,21 +89,16 @@ case "${KIMI_SHARD_F_A}" in
 esac
 
 export VLLM_ENABLE_PCIE_ALLREDUCE="${VLLM_ENABLE_PCIE_ALLREDUCE:-1}"
-# The base image exports backend=cpp, whose legacy custom-allreduce runtime is
-# limited to world size <= 8.  Do not inherit that image-wide default for this
-# TP16 profile; select the validated hierarchical B12X implementation unless
-# the profile-specific override explicitly requests otherwise.
+# The base image exports backend=cpp, whose custom all-reduce implementation is
+# limited to world size <= 8. This TP16 profile therefore selects the validated
+# hierarchical b12x implementation unless its profile-specific override is set.
 export VLLM_PCIE_ALLREDUCE_BACKEND="${KIMI_NO_DSPARK_PCIE_ALLREDUCE_BACKEND:-b12x}"
 export VLLM_PCIE_ONESHOT_SINGLE_CHANNEL="${VLLM_PCIE_ONESHOT_SINGLE_CHANNEL:-1}"
-# Sync-mode default, re-measured 2026-08-09 on FULL cudagraphs: double-buffer
-# 55.663 vs deferred 54.531 vs plain 51.913 tok/s (no-spec decode, A/B/A'd,
-# healthy machine), DSpark target cycles/s neutral, all three modes bitwise
-# identical at M=1/2/4/8. The earlier "1.2% slower" double-buffer reading
-# predates FULL graphs, whose removal of the per-collective launch changed the
-# economics: deferred pays a separate 3.4us preamble kernel 3x per layer,
-# double-buffer needs neither that nor the in-kernel end-waits. Both knobs
-# stay env-overridable; the guard keeps an explicit DEFERRED=1 from colliding
-# with the double-buffer default (b12x rejects the 1+1 combination).
+# FULL-graph decode defaults to double buffering because deferred consumption
+# adds a separate 3.4-us preamble kernel to each of three per-layer collectives.
+# Double buffering avoids those launches and the in-kernel end waits. Both
+# settings are operator-overridable and bit-identical at M=1, 2, 4, and 8. The
+# guard prevents the unsupported combination in which both modes are enabled.
 export B12X_PCIE_HIERARCHICAL_DEFERRED_CONSUMPTION="${B12X_PCIE_HIERARCHICAL_DEFERRED_CONSUMPTION:-0}"
 if [[ "${B12X_PCIE_HIERARCHICAL_DEFERRED_CONSUMPTION}" == "1" ]]; then
   export B12X_PCIE_HIERARCHICAL_DOUBLE_BUFFER="${B12X_PCIE_HIERARCHICAL_DOUBLE_BUFFER:-0}"
@@ -146,11 +141,10 @@ export VLLM_MLA_CHUNKED_PREFILL_WORKSPACE_SIZE="${VLLM_MLA_CHUNKED_PREFILL_WORKS
 export VLLM_MEMORY_PROFILE_INCLUDE_ATTN="${VLLM_MEMORY_PROFILE_INCLUDE_ATTN:-0}"
 export VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS="${VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS:-0}"
 if [[ -z "${COMPILATION_CONFIG:-}" ]]; then
-  # FULL decode graphs are worth +3.8% here (52.558 -> 54.536 tok/s, no-spec
-  # DCP16 1M, prefill TTFT unchanged) and need the DCP a2a capture-scope fix to
-  # capture at all -- without it startup fails with "PCIe DCP A2A channels are
-  # stream-affine".  The DSpark launcher has requested FULL_AND_PIECEWISE for a
-  # while; this brings the no-speculation profile in line.
+  # FULL_AND_PIECEWISE captures the complete single-sequence decode step. DCP
+  # all-to-all channels bind their pools to the active capture scope, preserving
+  # stream affinity during graph capture. COMPILATION_CONFIG remains an explicit
+  # operator override.
   export COMPILATION_CONFIG='{"mode":0,"cudagraph_mode":"FULL_AND_PIECEWISE","cudagraph_capture_sizes":[1],"pass_config":{"fuse_allreduce_rms":true}}'
 fi
 

--- a/serve-kimi-k3-full-mxfp4-dcp16-1m-no-dspark.sh
+++ b/serve-kimi-k3-full-mxfp4-dcp16-1m-no-dspark.sh
@@ -138,7 +138,12 @@ export VLLM_MLA_CHUNKED_PREFILL_WORKSPACE_SIZE="${VLLM_MLA_CHUNKED_PREFILL_WORKS
 export VLLM_MEMORY_PROFILE_INCLUDE_ATTN="${VLLM_MEMORY_PROFILE_INCLUDE_ATTN:-0}"
 export VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS="${VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS:-0}"
 if [[ -z "${COMPILATION_CONFIG:-}" ]]; then
-  export COMPILATION_CONFIG='{"mode":0,"cudagraph_mode":"PIECEWISE","cudagraph_capture_sizes":[1],"pass_config":{"fuse_allreduce_rms":true}}'
+  # FULL decode graphs are worth +3.8% here (52.558 -> 54.536 tok/s, no-spec
+  # DCP16 1M, prefill TTFT unchanged) and need the DCP a2a capture-scope fix to
+  # capture at all -- without it startup fails with "PCIe DCP A2A channels are
+  # stream-affine".  The DSpark launcher has requested FULL_AND_PIECEWISE for a
+  # while; this brings the no-speculation profile in line.
+  export COMPILATION_CONFIG='{"mode":0,"cudagraph_mode":"FULL_AND_PIECEWISE","cudagraph_capture_sizes":[1],"pass_config":{"fuse_allreduce_rms":true}}'
 fi
 
 "${PYTHON_BIN}" - <<'PY'

--- a/serve-kimi-k3-full-mxfp4-dcp16-1m-no-dspark.sh
+++ b/serve-kimi-k3-full-mxfp4-dcp16-1m-no-dspark.sh
@@ -95,13 +95,21 @@ export VLLM_ENABLE_PCIE_ALLREDUCE="${VLLM_ENABLE_PCIE_ALLREDUCE:-1}"
 # the profile-specific override explicitly requests otherwise.
 export VLLM_PCIE_ALLREDUCE_BACKEND="${KIMI_NO_DSPARK_PCIE_ALLREDUCE_BACKEND:-b12x}"
 export VLLM_PCIE_ONESHOT_SINGLE_CHANNEL="${VLLM_PCIE_ONESHOT_SINGLE_CHANNEL:-1}"
-# The optional two-generation staging path is exact but was 1.2% slower in
-# full-model decode, so retain the single-generation serving default.
-export B12X_PCIE_HIERARCHICAL_DOUBLE_BUFFER="${B12X_PCIE_HIERARCHICAL_DOUBLE_BUFFER:-0}"
-# The mixed 32/16/32-grid TP16 harness is bit-exact through 48,000 collectives
-# and cuts the measured all-reduce sequence latency by 6.87%.  Keep the switch
-# independently overridable so serving A/B tests can select the legacy path.
-export B12X_PCIE_HIERARCHICAL_DEFERRED_CONSUMPTION="${B12X_PCIE_HIERARCHICAL_DEFERRED_CONSUMPTION:-1}"
+# Sync-mode default, re-measured 2026-08-09 on FULL cudagraphs: double-buffer
+# 55.663 vs deferred 54.531 vs plain 51.913 tok/s (no-spec decode, A/B/A'd,
+# healthy machine), DSpark target cycles/s neutral, all three modes bitwise
+# identical at M=1/2/4/8. The earlier "1.2% slower" double-buffer reading
+# predates FULL graphs, whose removal of the per-collective launch changed the
+# economics: deferred pays a separate 3.4us preamble kernel 3x per layer,
+# double-buffer needs neither that nor the in-kernel end-waits. Both knobs
+# stay env-overridable; the guard keeps an explicit DEFERRED=1 from colliding
+# with the double-buffer default (b12x rejects the 1+1 combination).
+export B12X_PCIE_HIERARCHICAL_DEFERRED_CONSUMPTION="${B12X_PCIE_HIERARCHICAL_DEFERRED_CONSUMPTION:-0}"
+if [[ "${B12X_PCIE_HIERARCHICAL_DEFERRED_CONSUMPTION}" == "1" ]]; then
+  export B12X_PCIE_HIERARCHICAL_DOUBLE_BUFFER="${B12X_PCIE_HIERARCHICAL_DOUBLE_BUFFER:-0}"
+else
+  export B12X_PCIE_HIERARCHICAL_DOUBLE_BUFFER="${B12X_PCIE_HIERARCHICAL_DOUBLE_BUFFER:-1}"
+fi
 # K3's 7168/32 and 3584/16 grids both contain exactly 224 BF16 values per
 # block.  The vectorized path processes 112 BF16 pairs with four warps,
 # preserves the scalar FP32 accumulation order, and is bit-exact in the TP16

--- a/tests/v1/cudagraph/test_breakable_cudagraph.py
+++ b/tests/v1/cudagraph/test_breakable_cudagraph.py
@@ -401,7 +401,7 @@ def test_piecewise_capture_builds_fresh_metadata_for_both_passes():
     assert create_calls[0][1] is not create_calls[1][1]
 
 
-def test_compile_only_prewarm_skips_manager_full_forward(monkeypatch):
+def test_compile_only_prewarm_skips_breakable_piecewise_direct_warmup(monkeypatch):
     import vllm.envs as envs
     from vllm.config import CUDAGraphMode
     from vllm.v1.worker.gpu.cudagraph_utils import (
@@ -444,6 +444,72 @@ def test_compile_only_prewarm_skips_manager_full_forward(monkeypatch):
 
     assert create_calls == [True, False]
     assert forward_calls == [(False, CUDAGraphMode.PIECEWISE)]
+
+
+def test_compile_only_prewarm_guards_full_capture_warmup(monkeypatch):
+    import vllm.envs as envs
+    from vllm.compilation.b12x_capture import is_b12x_compile_only_warmup
+    from vllm.config import CUDAGraphMode
+    from vllm.v1.worker.gpu import cudagraph_utils
+    from vllm.v1.worker.gpu.cudagraph_utils import (
+        BatchExecutionDescriptor,
+        CudaGraphManager,
+    )
+
+    monkeypatch.setenv("VLLM_B12X_CUDAGRAPH_COMPILE_ONLY_PREWARM", "1")
+    envs.disable_envs_cache()
+
+    manager = CudaGraphManager.__new__(CudaGraphManager)
+    desc = BatchExecutionDescriptor(CUDAGraphMode.FULL, 8, 1)
+    manager.device = torch.device("cpu")
+    manager._capture_descs = {CUDAGraphMode.FULL: [desc]}
+    manager._graphs_captured = False
+    manager.use_breakable_cg = True
+    manager.graphs = {}
+    manager.pool = object()
+
+    create_calls = []
+    forward_calls = []
+
+    def create_forward_fn(desc_arg, warmup):
+        assert desc_arg == desc
+        create_calls.append(warmup)
+
+        def forward_fn(cg_mode):
+            forward_calls.append(
+                (warmup, cg_mode, is_b12x_compile_only_warmup())
+            )
+
+        return forward_fn
+
+    offloader = SimpleNamespace(
+        sync_prev_onload=lambda: None,
+        join_after_forward=lambda: None,
+    )
+    with (
+        patch.object(cudagraph_utils, "graph_capture", return_value=nullcontext()),
+        patch.object(
+            cudagraph_utils,
+            "_b12x_dcp_a2a_capture_scope",
+            return_value=nullcontext(),
+        ),
+        patch.object(cudagraph_utils, "is_global_first_rank", return_value=False),
+        patch.object(
+            cudagraph_utils, "b12x_cuda_graph_prewarm_enabled", return_value=True
+        ),
+        patch.object(cudagraph_utils, "get_offloader", return_value=offloader),
+        patch.object(cudagraph_utils.torch.cuda, "CUDAGraph", return_value=object()),
+        patch.object(
+            cudagraph_utils.torch.cuda, "graph", return_value=nullcontext()
+        ),
+    ):
+        manager.capture(create_forward_fn)
+
+    assert create_calls == [True, False]
+    assert forward_calls == [
+        (False, CUDAGraphMode.NONE, True),
+        (False, CUDAGraphMode.NONE, False),
+    ]
 
 
 @pytest.fixture(autouse=True)

--- a/tests/v1/spec_decode/test_dynamic_sd_cug.py
+++ b/tests/v1/spec_decode/test_dynamic_sd_cug.py
@@ -257,6 +257,60 @@ def test_basic_sd_does_not_capture_shorter_full_decode_shapes(monkeypatch):
             assert desc.num_active_loras == 0
 
 
+def test_compile_only_breakable_capture_covers_no_draft_decode(monkeypatch):
+    """B12X compile-only prewarm must capture the one-token verifier shape."""
+
+    import vllm.envs as envs
+
+    monkeypatch.setenv("VLLM_USE_BREAKABLE_CUDAGRAPH", "1")
+    monkeypatch.setenv("VLLM_B12X_CUDAGRAPH_COMPILE_ONLY_PREWARM", "1")
+    envs.disable_envs_cache()
+    monkeypatch.setattr(
+        gpu_cudagraph_utils,
+        "get_pp_group",
+        lambda: SimpleNamespace(is_first_rank=True, is_last_rank=True),
+    )
+    monkeypatch.setattr(
+        gpu_cudagraph_utils.current_platform,
+        "get_global_graph_pool",
+        lambda: object(),
+    )
+
+    max_spec_tokens = 7
+    max_decode_query_len = max_spec_tokens + 1
+    vllm_config = _create_vllm_config_for_dsd(
+        max_num_seqs=1,
+        max_spec_tokens=max_spec_tokens,
+        cudagraph_mode="FULL_AND_PIECEWISE",
+        use_dynamic_sd=False,
+    )
+    manager = gpu_cudagraph_utils.CudaGraphManager(
+        vllm_config=vllm_config,
+        device=torch.device("cpu"),
+        cudagraph_mode=CUDAGraphMode.FULL_AND_PIECEWISE,
+        decode_query_len=max_decode_query_len,
+    )
+    manager._graphs_captured = True
+
+    no_draft_desc = manager.dispatch(
+        num_reqs=1,
+        num_tokens=1,
+        uniform_token_count=1,
+        num_active_loras=0,
+    )
+    partial_draft_desc = manager.dispatch(
+        num_reqs=1,
+        num_tokens=4,
+        uniform_token_count=4,
+        num_active_loras=0,
+    )
+
+    assert no_draft_desc.cg_mode == CUDAGraphMode.FULL
+    assert no_draft_desc.uniform_token_count == 1
+    assert no_draft_desc.num_tokens == 1
+    assert partial_draft_desc.cg_mode == CUDAGraphMode.PIECEWISE
+
+
 def test_dynamic_sd_only_captures_scheduled_query_lengths(monkeypatch):
     """DSD should only capture FULL graphs for query lengths in the schedule.
 

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -81,12 +81,11 @@ def _parse_byte_size(value: str) -> int:
 
 
 def _b12x_pcie_allreduce_default_max_size(world_size: int) -> str:
-    """Ask b12x how large an all-reduce it expects to win at, for this world.
+    """Resolve the PCIe all-reduce limit from configuration and b12x policy.
 
-    The 84KB default predates the TP16 equal-quarter runtime, which stays ahead
-    of NCCL well past it; hard-coding a single number here would keep that
-    unreachable on every world size at once. An explicit environment setting
-    always wins, so the previous behaviour remains one variable away.
+    ``VLLM_PCIE_ONESHOT_ALLREDUCE_MAX_SIZE`` has highest priority. Otherwise,
+    b12x supplies a world-size-specific threshold when it is installed, and
+    environments without b12x use the vLLM configuration default.
     """
 
     configured = os.getenv("VLLM_PCIE_ONESHOT_ALLREDUCE_MAX_SIZE")

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -97,7 +97,17 @@ def _b12x_pcie_allreduce_default_max_size(world_size: int) -> str:
     except Exception:
         return envs.VLLM_PCIE_ONESHOT_ALLREDUCE_MAX_SIZE
     default = _parse_byte_size(envs.VLLM_PCIE_ONESHOT_ALLREDUCE_MAX_SIZE)
-    return str(recommended_max_bytes(world_size, default=default))
+    resolved = recommended_max_bytes(world_size, default=default)
+    if resolved != default:
+        # b12x loggers are not configured by vLLM, so this is the only place the
+        # operator can see that the wider band is in play.
+        logger.info(
+            "b12x raised the PCIe all-reduce limit for TP%d from %d to %d bytes.",
+            world_size,
+            default,
+            resolved,
+        )
+    return str(resolved)
 
 
 def _b12x_pcie_oneshot_limits(world_size: int) -> tuple[int, int, int]:

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -80,8 +80,30 @@ def _parse_byte_size(value: str) -> int:
     return int(value)
 
 
-def _b12x_pcie_oneshot_limits() -> tuple[int, int, int]:
-    allreduce_max_size = _parse_byte_size(envs.VLLM_PCIE_ONESHOT_ALLREDUCE_MAX_SIZE)
+def _b12x_pcie_allreduce_default_max_size(world_size: int) -> str:
+    """Ask b12x how large an all-reduce it expects to win at, for this world.
+
+    The 84KB default predates the TP16 equal-quarter runtime, which stays ahead
+    of NCCL well past it; hard-coding a single number here would keep that
+    unreachable on every world size at once. An explicit environment setting
+    always wins, so the previous behaviour remains one variable away.
+    """
+
+    configured = os.getenv("VLLM_PCIE_ONESHOT_ALLREDUCE_MAX_SIZE")
+    if configured is not None:
+        return configured
+    try:
+        from b12x.comm.pcie.pcie_allreduce import recommended_max_bytes
+    except Exception:
+        return envs.VLLM_PCIE_ONESHOT_ALLREDUCE_MAX_SIZE
+    default = _parse_byte_size(envs.VLLM_PCIE_ONESHOT_ALLREDUCE_MAX_SIZE)
+    return str(recommended_max_bytes(world_size, default=default))
+
+
+def _b12x_pcie_oneshot_limits(world_size: int) -> tuple[int, int, int]:
+    allreduce_max_size = _parse_byte_size(
+        _b12x_pcie_allreduce_default_max_size(world_size)
+    )
     fused_max_size = _parse_byte_size(
         envs.VLLM_PCIE_ONESHOT_FUSED_ADD_RMS_NORM_MAX_SIZE
     )
@@ -502,7 +524,7 @@ class CustomAllreduce:
                 self._pcie_allreduce_max_size,
                 self._pcie_fused_add_rms_norm_max_size,
                 pcie_oneshot_buffer_size,
-            ) = _b12x_pcie_oneshot_limits()
+            ) = _b12x_pcie_oneshot_limits(world_size)
             self._pcie_composed_add_rms_norm_max_size = (
                 self._pcie_fused_add_rms_norm_max_size
             )

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -14,6 +14,7 @@ from tqdm import tqdm
 
 import vllm.envs as envs
 from vllm.compilation.b12x_capture import (
+    b12x_compile_only_warmup,
     b12x_cuda_graph_prewarm_enabled,
     guard_b12x_kernel_resolution,
 )
@@ -301,6 +302,18 @@ class CudaGraphManager:
         else:
             decode_query_lens = [self.decode_query_len]
 
+        if (
+            speculative_config is not None
+            and self.use_breakable_cg
+            and envs.VLLM_B12X_CUDAGRAPH_COMPILE_ONLY_PREWARM
+            and not self.varlen_spec_decode
+        ):
+            # A request can receive no draft tokens even when speculative
+            # decoding is enabled. Compile-only B12X prewarm must give that
+            # one-token verifier step its own executable FULL graph instead of
+            # making its first execution a breakable PIECEWISE replay.
+            decode_query_lens = sorted({1, *decode_query_lens})
+
         def decode_descs(
             num_tokens: int,
             num_active_loras: int,
@@ -539,7 +552,14 @@ class CudaGraphManager:
                             # the CuTe launcher contract. Re-warm the exact
                             # fresh state that FULL capture will use, so CUDA
                             # graph capture only records resolved launches.
-                            forward_fn(CUDAGraphMode.NONE)
+                            if envs.VLLM_B12X_CUDAGRAPH_COMPILE_ONLY_PREWARM:
+                                # Kernel resolution must see every B12X call,
+                                # but memory-constrained captures cannot afford
+                                # a second eager model execution here.
+                                with b12x_compile_only_warmup():
+                                    forward_fn(CUDAGraphMode.NONE)
+                            else:
+                                forward_fn(CUDAGraphMode.NONE)
                         graph = torch.cuda.CUDAGraph()
                         # Sync offloader's copy stream before capture.
                         # Ensure any pre-capture prefetches from offloader are complete.


### PR DESCRIPTION
## Status

**Qualified** for Kimi-K3 TP16/DCP16 serving when composed after #242. The resulting vLLM Git tree is `6ecf5dbe724774b170fca82a366ab48ea9264830` over `dev/heraldic-harbinger` commit `6389c45f4d172d5414526e0969e3c689096f1959`.

## Resulting behavior

- An explicit `VLLM_PCIE_ONESHOT_ALLREDUCE_MAX_SIZE` has highest priority. Otherwise vLLM reads the message-size policy from `b12x.comm.pcie.pcie_allreduce.recommended_max_bytes(world_size)` and retains the vLLM default when the installed B12X package lacks that API.
- TP16 serving selects the B12X all-reduce backend because the C++ custom all-reduce implementation supports at most eight ranks.
- DCP all-to-all pools bind to the active graph-capture scope, preserving channel stream affinity.
- `FULL_AND_PIECEWISE` capture records an M=8 speculative verifier graph and an M=1 no-draft verifier graph. A request with zero accepted draft proposals therefore executes an available FULL graph instead of entering an uncaptured 92-layer PIECEWISE path.
- `VLLM_B12X_CUDAGRAPH_COMPILE_ONLY_PREWARM=1` resolves B12X kernels for FULL capture without executing a second eager model forward. Kernel-resolution state is unfrozen before the executable capture pass.
- FULL decode graphs default to hierarchical double buffering. Deferred consumption remains an explicit alternative because B12X does not support both synchronization modes simultaneously.

## Validation

- Three targeted compile-only and speculative-fallback graph tests passed.
- A five-layer linked checkpoint captured all PIECEWISE, M=8 FULL, and M=1 FULL graphs and completed startup.
- A full 497,218-tensor Kimi-K3 checkpoint completed graph capture, speculative M=8 warmup, no-draft M=1 warmup, capacity warmup, and API startup.
- The full-checkpoint DCP16/DSpark profile exposed 1,057,049 physical KV tokens and produced a median 112.351 output tok/s in three deterministic 512-token runs.
- `bash -n` and `git diff --check` pass at commit `792cccccb60803e61f04dd350cc8107de1880efd`.

## Dependencies and limitations

- #242 supplies the Kimi-K3 target, loader, speculation, and serving profiles.
- `local-inference-lab/b12x#139` supplies the TP16 size-routed island reduce-scatter implementation.
- `local-inference-lab/b12x#141` is not part of the qualified source composition.
- Compile-only prewarm is opt-in and affects graph preparation only; ordinary graph capture retains the standard eager warmup.

## Review disclosure

Implementation and PR text were AI-assisted. Human review is required before merge.
