### PR TITLE
[GG] loader: add explicit InstantTensor borrowed-buffer mode

### DIFF
--- a/tests/model_executor/model_loader/instanttensor_loader/test_weight_utils.py
+++ b/tests/model_executor/model_loader/instanttensor_loader/test_weight_utils.py
@@ -2,18 +2,96 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import glob
+import sys
 import tempfile
+from contextlib import contextmanager
+from types import SimpleNamespace
 
 import huggingface_hub.constants
 import pytest
 import torch
 
+import vllm.model_executor.model_loader.weight_utils as weight_utils
 from vllm.model_executor.model_loader.weight_utils import (
     download_weights_from_hf,
     instanttensor_weights_iterator,
     safetensors_weights_iterator,
 )
 from vllm.platforms import current_platform
+
+
+@pytest.mark.parametrize(
+    ("setting", "expected_copy", "expected_borrowed"),
+    [("0", False, True), ("1", True, False)],
+)
+def test_instanttensor_copy_contract(
+    setting, expected_copy, expected_borrowed, monkeypatch
+):
+    tensor = torch.ones(4)
+    observed = {}
+
+    class FakeReader:
+        def keys(self):
+            return ["weight"]
+
+        def tensors(self):
+            yield "weight", tensor
+
+    @contextmanager
+    def fake_safe_open(files, *, framework, device, process_group, copy):
+        observed.update(
+            files=files,
+            framework=framework,
+            device=device,
+            process_group=process_group,
+            copy=copy,
+        )
+        yield FakeReader()
+
+    def no_world_group():
+        raise AssertionError
+
+    monkeypatch.setenv("INSTANTTENSOR_COPY", setting)
+    monkeypatch.setattr(
+        weight_utils,
+        "current_platform",
+        SimpleNamespace(is_cuda=lambda: True, current_device=lambda: 0),
+    )
+    monkeypatch.setattr(weight_utils, "get_world_group", no_world_group)
+    monkeypatch.setitem(
+        sys.modules, "instanttensor", SimpleNamespace(safe_open=fake_safe_open)
+    )
+
+    loaded = list(instanttensor_weights_iterator(["model.safetensors"], False))
+
+    assert len(loaded) == 1
+    assert loaded[0][0] == "weight"
+    assert loaded[0][1] is tensor
+    assert observed == {
+        "files": ["model.safetensors"],
+        "framework": "pt",
+        "device": 0,
+        "process_group": None,
+        "copy": expected_copy,
+    }
+    assert getattr(tensor, "_vllm_instanttensor_borrowed", False) is expected_borrowed
+
+
+def test_instanttensor_copy_rejects_unknown_value(monkeypatch):
+    def no_world_group():
+        raise AssertionError
+
+    monkeypatch.setenv("INSTANTTENSOR_COPY", "sometimes")
+    monkeypatch.setattr(
+        weight_utils,
+        "current_platform",
+        SimpleNamespace(is_cuda=lambda: True, current_device=lambda: 0),
+    )
+    monkeypatch.setattr(weight_utils, "get_world_group", no_world_group)
+    monkeypatch.setitem(sys.modules, "instanttensor", SimpleNamespace())
+
+    with pytest.raises(ValueError, match="INSTANTTENSOR_COPY must be 0 or 1"):
+        next(instanttensor_weights_iterator(["model.safetensors"], False))
 
 
 @pytest.mark.skipif(

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -1229,9 +1229,17 @@ def instanttensor_weights_iterator(
         process_group = world_group.device_group if world_group.world_size > 1 else None
 
     device = current_platform.current_device()
+    copy_setting = os.getenv("INSTANTTENSOR_COPY", "1")
+    if copy_setting not in {"0", "1"}:
+        raise ValueError(f"INSTANTTENSOR_COPY must be 0 or 1, got {copy_setting!r}")
+    copy_tensors = copy_setting == "1"
 
     with instanttensor.safe_open(
-        hf_weights_files, framework="pt", device=device, process_group=process_group
+        hf_weights_files,
+        framework="pt",
+        device=device,
+        process_group=process_group,
+        copy=copy_tensors,
     ) as f:
         for name, tensor in tqdm(
             f.tensors(),
@@ -1242,6 +1250,11 @@ def instanttensor_weights_iterator(
             total=len(f.keys()),
             mininterval=1.0,
         ):
+            if not copy_tensors:
+                # Parameter loaders consume borrowed tensors synchronously.
+                # Loaders retaining a tensor past this yield must materialize
+                # owned storage before InstantTensor advances its ring buffer.
+                tensor._vllm_instanttensor_borrowed = True
             if weight_name_prefixes and not _matches_weight_name_prefixes(
                 name, weight_name_prefixes
             ):


### PR DESCRIPTION
## Summary

Add an explicit, opt-in InstantTensor borrowed-buffer mode for large model
loads. `INSTANTTENSOR_COPY=0` forwards `copy=False` to `safe_open`; the default
remains the existing owned-copy behavior.

## Why

The R7 EXL3 checkpoint is close enough to the per-rank memory ceiling that an
extra loader-owned copy can OOM before quantized weights finish preparation.
InstantTensor already supports borrowed buffers, but vLLM did not expose that
contract and therefore always requested copied tensors.

## Contract

- `INSTANTTENSOR_COPY=1` is the default and preserves current behavior;
- `INSTANTTENSOR_COPY=0` requests borrowed tensors and marks each yielded tensor
  with `_vllm_instanttensor_borrowed=True`;
- parameter loaders consume borrowed tensors synchronously; a loader that
  retains one beyond the yield must materialize owned storage;
- values other than `0` or `1` fail immediately with a clear error.

This PR deliberately does not change InstantTensor's default or the model
quantization runtime.

## Validation

- focused iterator tests: **3 passed, 1 skipped**;
- tests verify both copy modes, marker behavior, forwarded arguments, and
  invalid configuration;
- clean 4x RTX PRO 6000 Blackwell TP4 model load completed with
  `LOAD_FORMAT=instanttensor`, BUFFERED backend, and `INSTANTTENSOR_COPY=0`;
- the resulting model passed full-graph MTP0/MTP3 decode, 8k/64k prefill,
  prompt-logprob, and correctness smoke tests;
- Ruff, formatting, and `git diff --check`: pass.
