### PR TITLE
[II] Inherit target identity for in-checkpoint speculative drafts

### DIFF
--- a/tests/config/test_speculative_draft_hf_overrides.py
+++ b/tests/config/test_speculative_draft_hf_overrides.py
@@ -136,43 +136,74 @@ def test_composed_override_is_picklable():
 
 
 @pytest.mark.cpu_test
-def test_mtp_same_model_inherits_target_revisions():
+@pytest.mark.parametrize("method", ["mtp", "dspark"])
+def test_in_checkpoint_draft_inherits_target_identity(method):
     spec = SimpleNamespace(
-        method="mtp",
+        method=method,
         model="org/model",
         revision=None,
         code_revision=None,
+        quantization=None,
         target_model_config=SimpleNamespace(
             model="org/model",
             revision="weights-commit",
             code_revision="code-commit",
+            quantization="deepseek_v4_fp8",
         ),
     )
 
-    SpeculativeConfig._inherit_target_revision_for_mtp(spec)
+    SpeculativeConfig._inherit_target_identity_for_in_checkpoint_draft(spec)
 
     assert spec.revision == "weights-commit"
     assert spec.code_revision == "code-commit"
+    assert spec.quantization == "deepseek_v4_fp8"
 
 
 @pytest.mark.cpu_test
-def test_mtp_explicit_draft_revisions_are_preserved():
+@pytest.mark.parametrize("method", ["mtp", "dspark"])
+def test_in_checkpoint_draft_preserves_explicit_identity(method):
     spec = SimpleNamespace(
-        method="mtp",
+        method=method,
         model="org/model",
         revision="draft-weights",
         code_revision="draft-code",
+        quantization="draft-quantization",
         target_model_config=SimpleNamespace(
             model="org/model",
             revision="target-weights",
             code_revision="target-code",
+            quantization="target-quantization",
         ),
     )
 
-    SpeculativeConfig._inherit_target_revision_for_mtp(spec)
+    SpeculativeConfig._inherit_target_identity_for_in_checkpoint_draft(spec)
 
     assert spec.revision == "draft-weights"
     assert spec.code_revision == "draft-code"
+    assert spec.quantization == "draft-quantization"
+
+
+@pytest.mark.cpu_test
+def test_external_dspark_keeps_its_own_identity():
+    spec = SimpleNamespace(
+        method="dspark",
+        model="org/dspark",
+        revision=None,
+        code_revision=None,
+        quantization=None,
+        target_model_config=SimpleNamespace(
+            model="org/target",
+            revision="target-weights",
+            code_revision="target-code",
+            quantization="target-quantization",
+        ),
+    )
+
+    SpeculativeConfig._inherit_target_identity_for_in_checkpoint_draft(spec)
+
+    assert spec.revision is None
+    assert spec.code_revision is None
+    assert spec.quantization is None
 
 
 @pytest.mark.cpu_test

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -780,15 +780,21 @@ class SpeculativeConfig:
         parts = model.split(".")
         return len(parts) >= 2 and all(part.isidentifier() for part in parts)
 
-    def _inherit_target_revision_for_mtp(self) -> None:
-        """Pin an in-checkpoint MTP draft to the target model revision."""
+    def _inherit_target_identity_for_in_checkpoint_draft(self) -> None:
+        """Use target artifact settings for a draft stored in that artifact."""
         target = self.target_model_config
-        if self.method != "mtp" or target is None or self.model != target.model:
+        if (
+            self.method not in ("mtp", "dspark")
+            or target is None
+            or self.model != target.model
+        ):
             return
         if self.revision is None:
             self.revision = target.revision
         if self.code_revision is None:
             self.code_revision = target.code_revision
+        if self.quantization is None:
+            self.quantization = target.quantization
 
     def _cap_same_model_draft_position_embeddings(self) -> bool:
         """Cap an in-checkpoint draft to the target's effective RoPE table."""
@@ -984,7 +990,7 @@ class SpeculativeConfig:
             self.prompt_lookup_min = 0
 
             if self.model is not None:
-                self._inherit_target_revision_for_mtp()
+                self._inherit_target_identity_for_in_checkpoint_draft()
                 # Old-format Medusa checkpoints (e.g. FasterDecoding/medusa-*)
                 # lack a model_type key in config.json, so AutoConfig cannot
                 # detect them. When the method is explicitly "medusa", inject


### PR DESCRIPTION
## Resulting behavior

MTP and DSpark drafts stored in the target checkpoint inherit the target model revision, code revision, and quantization method when those draft fields are unspecified. A separately hosted draft model keeps its independent artifact identity.

## Technical reason

An in-checkpoint draft and target are one artifact. Resolving them with different implicit revisions or quantization configuration can load incompatible metadata even though both configurations name the same model repository.

## Compatibility

Explicit draft settings take precedence. External DSpark checkpoints are unchanged.

## Validation

- MTP and DSpark same-artifact inheritance tests: passed.
- Explicit override preservation tests: passed.
- External DSpark identity test: passed.
- Ruff check and format check: passed.
- Integrated DS4F fixed-K5 qualification on TP4/DCP1 completed without a decode, prefill, or correctness regression.