### PR TITLE
[II] Make DS4 launch identity and capacity explicit

### DIFF
--- a/serve-ds4-flash.sh
+++ b/serve-ds4-flash.sh
@@ -125,7 +125,13 @@ if [[ -n "${kv_offloading_size}" \
   exit 2
 fi
 native_l2_enabled=0
-if [[ -n "${native_l2_path}" || -n "${native_l2_size}" ]]; then
+# A zero capacity disables filesystem L2 even when a deployment supplies a
+# reusable default path. Positive capacities require the complete L1/L2
+# contract below.
+if [[ -n "${native_l2_size}" \
+  && "${native_l2_size}" =~ ^0*([.]0*)?$ ]]; then
+  :
+elif [[ -n "${native_l2_path}" || -n "${native_l2_size}" ]]; then
   if [[ -z "${native_l2_path}" || -z "${native_l2_size}" ]]; then
     echo "NATIVE_L2_PATH and NATIVE_L2_GB must be set together" >&2
     exit 2

--- a/serve-ds4-flash.sh
+++ b/serve-ds4-flash.sh
@@ -85,6 +85,11 @@ revision_args=()
 if [[ -n "${model_revision}" ]]; then
   revision_args=(--revision "${model_revision}")
 fi
+tokenizer_revision=${TOKENIZER_REVISION:-${model_revision}}
+tokenizer_revision_args=()
+if [[ -n "${tokenizer_revision}" ]]; then
+  tokenizer_revision_args=(--tokenizer-revision "${tokenizer_revision}")
+fi
 
 host=${HOST:-0.0.0.0}
 port=${PORT:-8000}
@@ -299,6 +304,7 @@ spec_args=()
 spec_tokens=0
 graph_multiplier=4
 dspark_depth_mode=disabled
+capacity_activation_summary=disabled
 if [[ "${mode}" == "mtp2" || "${mode}" == "mtp3" ]]; then
   if [[ "${mode}" == "mtp2" ]]; then spec_tokens=2; else spec_tokens=3; fi
   mtp_moe_json=
@@ -343,7 +349,7 @@ elif [[ "${mode}" == "dspark" ]]; then
     dynamic)
       default_dspark_capacity=1
       default_dynamic_depth=1
-      default_activation_batch_size=1
+      default_activation_batch_size=0
       ;;
     *)
       echo "DSPARK_DEPTH_MODE must be fixed or dynamic" >&2
@@ -400,13 +406,20 @@ elif [[ "${mode}" == "dspark" ]]; then
   export VLLM_DSPARK_CAPACITY_ACTIVATION_BATCH_SIZE=${activation_batch_size}
   require_nonnegative_int DSPARK_CAPACITY_ACTIVATION_BATCH_SIZE \
     "${VLLM_DSPARK_CAPACITY_ACTIVATION_BATCH_SIZE}"
+  if [[ "${dspark_capacity}" == "1" ]]; then
+    if [[ "${activation_batch_size}" == "0" ]]; then
+      capacity_activation_summary=auto
+    else
+      capacity_activation_summary=${activation_batch_size}
+    fi
+  fi
   export VLLM_DSPARK_CAPACITY_LOG_INTERVAL=${DSPARK_CAPACITY_LOG_INTERVAL:-0}
   export VLLM_DSPARK_STS_LOG_INTERVAL=${DSPARK_STS_LOG_INTERVAL:-0}
   export VLLM_DSPARK_TP_CHECK=${DSPARK_TP_CHECK:-0}
 fi
 
-# v9 used graph 256 for MTP-off and 512 for MTP modes at cc64. Keep that MTP
-# contract; DSpark uses its exact (K + 1) physical verifier width.
+# Target-only profiles reserve four graph rows per request and MTP profiles
+# reserve eight. DSpark uses its exact one-target-plus-K-drafts verifier width.
 graph_cap=${MAX_CUDAGRAPH_CAPTURE_SIZE:-${GRAPH:-}}
 if [[ -z "${graph_cap}" || "${graph_cap}" == "auto" ]]; then
   graph_cap=$((max_num_seqs * graph_multiplier))
@@ -559,6 +572,7 @@ mkdir -p \
 command=(
   vllm serve "${model}"
   "${revision_args[@]}"
+  "${tokenizer_revision_args[@]}"
   --served-model-name "${served_model_name}"
   --host "${host}"
   --port "${port}"
@@ -603,8 +617,8 @@ if [[ -n "${EXTRA_VLLM_ARGS:-}" ]]; then
 fi
 command+=("$@")
 
-printf 'DS4 launch: mode=%s depth=%s backend=%s allreduce=%s b12x_dma=%s indexer=%s tp=%s dcp=%s max_seqs=%s graph=%s load_format=%s instanttensor_backend=%s native_l2=%s allocator=%s model=%s\n' \
-  "${mode}" "${dspark_depth_mode}" \
+printf 'DS4 launch: mode=%s depth=%s capacity_activation=%s backend=%s allreduce=%s b12x_dma=%s indexer=%s tp=%s dcp=%s max_seqs=%s graph=%s load_format=%s instanttensor_backend=%s native_l2=%s allocator=%s model=%s\n' \
+  "${mode}" "${dspark_depth_mode}" "${capacity_activation_summary}" \
   "${backend}" "${allreduce_mode}" "${b12x_pcie_dma}" \
   "${indexer_backend}" "${tp_size}" "${dcp_size}" "${max_num_seqs}" \
   "${graph_cap}" "${load_format}" "${INSTANTTENSOR_BACKEND}" \

--- a/serve-ds4-flash.sh
+++ b/serve-ds4-flash.sh
@@ -7,6 +7,11 @@ set -euo pipefail
 
 unset NCCL_GRAPH_FILE NCCL_GRAPH_DUMP_FILE VLLM_B12X_MLA_EXTEND_MAX_CHUNKS
 
+# All distributed workers launched by this entrypoint share one host. Keep
+# process-group bootstrap local unless a multi-node wrapper selects an interface.
+export GLOO_SOCKET_IFNAME="${GLOO_SOCKET_IFNAME:-lo}"
+export NCCL_SOCKET_IFNAME="${NCCL_SOCKET_IFNAME:-lo}"
+
 bool_value() {
   local name=$1 value=${2,,}
   case "${value}" in
@@ -630,6 +635,8 @@ printf 'DS4 launch: mode=%s depth=%s capacity_activation=%s backend=%s allreduce
   "${graph_cap}" "${load_format}" "${INSTANTTENSOR_BACKEND}" \
   "${native_l2_enabled}" \
   "${PYTORCH_CUDA_ALLOC_CONF:-<unset>}" "${model}" >&2
+printf 'Process-group interfaces: GLOO_SOCKET_IFNAME=%s NCCL_SOCKET_IFNAME=%s\n' \
+  "${GLOO_SOCKET_IFNAME}" "${NCCL_SOCKET_IFNAME}" >&2
 printf 'Command:' >&2
 printf ' %q' "${command[@]}" >&2
 printf '\n' >&2

--- a/tests/entrypoints/test_ds4_flash_launcher.py
+++ b/tests/entrypoints/test_ds4_flash_launcher.py
@@ -53,6 +53,30 @@ def test_ds4_launcher_defaults_to_0731_fixed_k7(tmp_path: Path) -> None:
     assert "max_seqs=16 graph=128" in output
     assert "--max-model-len 131072" in output
     assert "--gpu-memory-utilization 0.975" in output
+    assert (
+        "Process-group interfaces: GLOO_SOCKET_IFNAME=lo "
+        "NCCL_SOCKET_IFNAME=lo" in output
+    )
+
+
+def test_ds4_launcher_preserves_explicit_process_group_interfaces(
+    tmp_path: Path,
+) -> None:
+    """Verify that a multi-node wrapper can select bootstrap interfaces.
+
+    Args:
+        tmp_path: Temporary home and cache root.
+    """
+    output = _dry_run(
+        tmp_path,
+        GLOO_SOCKET_IFNAME="bond0",
+        NCCL_SOCKET_IFNAME="ib0",
+    )
+
+    assert (
+        "Process-group interfaces: GLOO_SOCKET_IFNAME=bond0 "
+        "NCCL_SOCKET_IFNAME=ib0" in output
+    )
 
 
 def test_ds4_launcher_accepts_distinct_tokenizer_revision(tmp_path: Path) -> None:

--- a/tests/entrypoints/test_ds4_flash_launcher.py
+++ b/tests/entrypoints/test_ds4_flash_launcher.py
@@ -46,11 +46,29 @@ def test_ds4_launcher_defaults_to_0731_fixed_k7(tmp_path: Path) -> None:
 
     assert "mode=dspark depth=fixed" in output
     assert "model=deepseek-ai/DeepSeek-V4-Flash-0731" in output
-    assert "9e165c30e2704aec5d9d593cce3eebd58bbef1cb" in output
+    revision = "9e165c30e2704aec5d9d593cce3eebd58bbef1cb"
+    assert f"--revision {revision}" in output
+    assert f"--tokenizer-revision {revision}" in output
     assert 'num_speculative_tokens\\":7' in output
     assert "max_seqs=16 graph=128" in output
     assert "--max-model-len 131072" in output
     assert "--gpu-memory-utilization 0.975" in output
+
+
+def test_ds4_launcher_accepts_distinct_tokenizer_revision(tmp_path: Path) -> None:
+    """Verify that a tokenizer snapshot can be pinned independently.
+
+    Args:
+        tmp_path: Temporary home and cache root.
+    """
+    output = _dry_run(
+        tmp_path,
+        MODEL_REVISION="weights-commit",
+        TOKENIZER_REVISION="tokenizer-commit",
+    )
+
+    assert "--revision weights-commit" in output
+    assert "--tokenizer-revision tokenizer-commit" in output
 
 
 def test_ds4_launcher_dynamic_depth_enables_capacity_mode(tmp_path: Path) -> None:
@@ -61,9 +79,26 @@ def test_ds4_launcher_dynamic_depth_enables_capacity_mode(tmp_path: Path) -> Non
     """
     output = _dry_run(tmp_path, DSPARK_DEPTH_MODE="dynamic")
 
-    assert "mode=dspark depth=dynamic" in output
+    assert "mode=dspark depth=dynamic capacity_activation=auto" in output
     assert 'dspark_capacity_verification_mode\\":\\"varlen' in output
     assert 'dspark_sps_curve\\":\\"auto' in output
+
+
+def test_ds4_launcher_accepts_explicit_capacity_activation_threshold(
+    tmp_path: Path,
+) -> None:
+    """Verify that a numeric capacity threshold overrides profile selection.
+
+    Args:
+        tmp_path: Temporary home and cache root.
+    """
+    output = _dry_run(
+        tmp_path,
+        DSPARK_DEPTH_MODE="dynamic",
+        DSPARK_CAPACITY_ACTIVATION_BATCH_SIZE="4",
+    )
+
+    assert "mode=dspark depth=dynamic capacity_activation=4" in output
 
 
 def test_ds4_launcher_uses_speculative_attention_backend_field(

--- a/tests/entrypoints/test_ds4_flash_launcher.py
+++ b/tests/entrypoints/test_ds4_flash_launcher.py
@@ -289,6 +289,25 @@ def test_ds4_launcher_zero_kv_offload_stays_disabled(tmp_path: Path) -> None:
     assert "--kv-offloading-size" not in output
 
 
+def test_ds4_launcher_zero_native_l2_stays_disabled_with_path(
+    tmp_path: Path,
+) -> None:
+    """Verify that a zero L2 capacity permits a reusable default path.
+
+    Args:
+        tmp_path: Temporary home and cache root.
+    """
+    output = _dry_run(
+        tmp_path,
+        NATIVE_L2_GB="0",
+        NATIVE_L2_PATH="/cache/native-l2",
+    )
+
+    assert "native_l2=0" in output
+    assert "--kv-transfer-config" not in output
+    assert "OffloadingConnector" not in output
+
+
 def test_ds4_launcher_rejects_invalid_kv_offload_size(tmp_path: Path) -> None:
     """Verify rejection of a nonnumeric native-offload size.
 


### PR DESCRIPTION
## Resulting behavior

The DeepSeek V4 launcher pins model and tokenizer revisions independently, reports the effective DSpark capacity-activation policy, and lets profile-driven capacity selection remain automatic unless an operator supplies a numeric threshold.

Single-host launches default Gloo and NCCL bootstrap to the loopback interface. Multi-node wrappers can override `GLOO_SOCKET_IFNAME` and `NCCL_SOCKET_IFNAME` explicitly. A zero `NATIVE_L2_GB` value leaves the filesystem tier disabled even when a reusable path is configured.

## Technical reason

A model revision alone does not pin tokenizer files when a deployment uses independently revised tokenizer assets. Dynamic DSpark depth also needs an observable activation policy: zero denotes runtime profile selection, while a positive value is an explicit request-count threshold.

The DS4 launcher starts all distributed workers on one host. Leaving process-group interfaces to network autodetection can select an unsuitable interface on multi-interface hosts and leave FlashInfer autotune waiting in its local object broadcast before CUDA graph capture.

## Compatibility

`TOKENIZER_REVISION` defaults to `MODEL_REVISION`. `DSPARK_CAPACITY_ACTIVATION_BATCH_SIZE` remains an override. Existing fixed-depth launches retain their graph and scheduler contract. Explicit process-group interfaces and positive native L2 capacities preserve their prior behavior.

## Scope and duplication

This PR owns the DS4 launcher contract, so the loopback and zero-capacity fixes are included here instead of being split into small dependent PRs. No other open Infernal Invocation PR owns these launcher defaults.

## Validation

- DS4 launcher suite: 18 passed.
- Shell syntax and whitespace checks: passed.
- TP2 fixed-K5 startup on a 16-GPU, multi-interface host completed FlashInfer autotune and FULL CUDA graph capture with loopback bootstrap.
- Integrated TP4/DCP1 fixed-K5 serving, arithmetic correctness, and long-prefill qualification passed.

AI assistance was used for implementation and test development.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for specifying a separate tokenizer revision.
  * Added automatic dynamic-capacity activation, with an option to set an explicit activation batch size.
  * Added support for disabling native L2 validation with a zero capacity.
  * Added clearer startup diagnostics for capacity activation and network interface settings.

* **Improvements**
  * Launcher defaults now use the loopback interface for GLOO and NCCL communications while preserving explicit overrides.
  * Documented graph sizing behavior and included tokenizer revision settings in vLLM startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->