### PR TITLE
[II] Enforce the B12X mHC input-shape contract for DeepSeek V4 MTP

### DIFF
--- a/tests/models/deepseek_v4/test_b12x_mhc_expected_m.py
+++ b/tests/models/deepseek_v4/test_b12x_mhc_expected_m.py
@@ -8,6 +8,7 @@ import torch
 
 from vllm.model_executor.warmup.deepseek_v4_mhc_warmup import _warmup_layer_mhc
 from vllm.models.deepseek_v4.nvidia import dspark as dspark_module
+from vllm.models.deepseek_v4.nvidia import mtp as mtp_module
 from vllm.models.deepseek_v4.nvidia.model import DeepseekV4DecoderLayer
 
 
@@ -24,6 +25,93 @@ def test_b12x_mhc_requires_fused_norm_weight() -> None:
     norm_weight = torch.ones(4)
 
     assert layer._require_b12x_mhc_norm_weight(norm_weight) is norm_weight
+
+
+def test_b12x_mhc_only_accepts_rank_two_initial_state() -> None:
+    layer = _make_b12x_layer()
+    layer._use_b12x_mhc = True
+
+    assert layer._can_run_b12x_mhc(torch.empty(2, 4))
+    assert not layer._can_run_b12x_mhc(torch.empty(2, 4, 4))
+
+    layer._use_b12x_mhc = False
+    assert not layer._can_run_b12x_mhc(torch.empty(2, 4))
+
+
+def test_mtp_expanded_state_keeps_non_broadcast_mhc_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class HiddenProjection(torch.nn.Module):
+        def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+            return hidden_states
+
+    class EmbeddingProjection(torch.nn.Module):
+        def forward(self, embeddings: torch.Tensor) -> torch.Tensor:
+            return torch.zeros_like(embeddings)
+
+    class ExpandedStateBlock(torch.nn.Module):
+        use_sequence_parallel = False
+
+        def _can_run_b12x_mhc(self, hidden_states: torch.Tensor) -> bool:
+            assert hidden_states.dim() == 3
+            return False
+
+        def forward(
+            self,
+            *,
+            positions: torch.Tensor,
+            x: torch.Tensor,
+            input_ids: torch.Tensor | None,
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+            del positions, input_ids
+            tokens, hc_mult, _ = x.shape
+            post_mix = torch.zeros(tokens, hc_mult)
+            res_mix = torch.zeros(tokens, hc_mult, hc_mult)
+            return x, x.clone(), post_mix, res_mix
+
+    layer = object.__new__(mtp_module.DeepSeekV4MultiTokenPredictorLayer)
+    torch.nn.Module.__init__(layer)
+    layer.hc_mult = 4
+    layer.config = SimpleNamespace(hidden_size=4)
+    layer.enorm = SimpleNamespace(
+        weight=SimpleNamespace(data=torch.ones(4)), variance_epsilon=1e-6
+    )
+    layer.hnorm = SimpleNamespace(weight=SimpleNamespace(data=torch.ones(4)))
+    layer.h_proj = HiddenProjection()
+    layer.e_proj = EmbeddingProjection()
+    layer.mtp_block = ExpandedStateBlock()
+
+    monkeypatch.setattr(
+        mtp_module,
+        "fused_mtp_input_rmsnorm",
+        lambda embeddings, positions, hidden_states, *args: (
+            embeddings,
+            hidden_states,
+        ),
+    )
+    post_calls: list[torch.Tensor] = []
+
+    def mhc_post(
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor,
+        post_mix: torch.Tensor,
+        res_mix: torch.Tensor,
+    ) -> torch.Tensor:
+        del hidden_states, post_mix, res_mix
+        post_calls.append(residual)
+        return residual
+
+    monkeypatch.setattr(mtp_module, "mhc_post_tilelang", mhc_post)
+
+    output = layer(
+        input_ids=torch.arange(2),
+        positions=torch.arange(2),
+        previous_hidden_states=torch.ones(2, 16),
+        inputs_embeds=torch.ones(2, 4),
+    )
+
+    assert output.shape == (2, 16)
+    assert len(post_calls) == 1
 
 
 def test_b12x_forward_broadcasts_initial_residual() -> None:

--- a/vllm/models/deepseek_v4/nvidia/model.py
+++ b/vllm/models/deepseek_v4/nvidia/model.py
@@ -1048,6 +1048,16 @@ class DeepseekV4DecoderLayer(nn.Module):
         del tokens
         return self._use_b12x_mhc
 
+    def _can_run_b12x_mhc(self, x: torch.Tensor) -> bool:
+        """Return whether ``x`` satisfies the B12X mHC input contract.
+
+        B12X ``run_pre`` accepts a rank-2 hidden state and broadcasts it into
+        the hyperconnection residual. DeepSeek V4 MTP already supplies that
+        residual as a rank-3 tensor, so it must retain the non-broadcast
+        TileLang path.
+        """
+        return x.dim() == 2 and self._should_run_b12x_mhc(int(x.shape[0]))
+
     def refresh_b12x_mhc_bf16_weights(self) -> None:
         if not self._use_b12x_mhc:
             return
@@ -1334,11 +1344,10 @@ class DeepseekV4DecoderLayer(nn.Module):
         res_mix: torch.Tensor | None = None,
         residual: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-        if self._should_run_b12x_mhc(int(x.shape[0])):
+        if self._can_run_b12x_mhc(x):
             attn_norm_weight = self.attn_norm.weight.data
             attn_norm_eps = self.attn_norm.variance_epsilon
             if residual is None:
-                assert x.dim() == 2
                 assert self.hc_attn_fn_broadcast is not None
                 residual, post_mix, res_mix, x = self.hc_pre(
                     x,

--- a/vllm/models/deepseek_v4/nvidia/mtp.py
+++ b/vllm/models/deepseek_v4/nvidia/mtp.py
@@ -177,10 +177,11 @@ class DeepSeekV4MultiTokenPredictorLayer(nn.Module):
         hidden_states = self.h_proj(previous_hidden_states) + self.e_proj(
             inputs_embeds
         ).unsqueeze(-2)
+        use_b12x_mhc = self.mtp_block._can_run_b12x_mhc(hidden_states)
         hidden_states, residual, post_mix, res_mix = self.mtp_block(
             positions=positions, x=hidden_states, input_ids=None
         )
-        if self.mtp_block._should_run_b12x_mhc(int(hidden_states.shape[0])):
+        if use_b12x_mhc:
             from b12x.norm.mhc import run_post as b12x_mhc_post
 
             hidden_states = b12x_mhc_post(


### PR DESCRIPTION
## Resulting behavior

B12X mHC pre/post kernels run only for rank-2 hidden states that require residual broadcasting. DeepSeek V4 MTP rank-3 expanded hyperconnection state remains on the non-broadcast TileLang path.

## Technical reason

B12X `run_pre` accepts a rank-2 hidden state and creates the hyperconnection residual by broadcasting it. MTP already supplies an expanded rank-3 residual. Sending that tensor through the broadcast path changes its shape contract and selects an incompatible post kernel.

## Compatibility

Target-model rank-2 mHC execution remains on B12X. Only the MTP expanded-state geometry is routed to its existing non-broadcast implementation.

## Validation

- Rank-2/rank-3 eligibility tests: passed.
- Expanded MTP state forward-path test: passed.
- Existing B12X mHC warmup and residual tests: passed.
- Ruff check and format check: passed.
- Integrated fixed-K5 DS4F correctness and throughput qualification completed successfully.