### PR TITLE
[II] Bound DeepSeek V4 sparse metadata to active context

### DIFF
--- a/tests/v1/attention/test_deepseek_v4_sparse_mla_metadata.py
+++ b/tests/v1/attention/test_deepseek_v4_sparse_mla_metadata.py
@@ -11,7 +11,81 @@ from vllm.models.deepseek_v4.sparse_mla import (
     build_c128a_topk_metadata,
 )
 from vllm.v1.attention.backend import CommonAttentionMetadata
+from vllm.v1.attention.backends.mla.compressor_utils import (
+    get_c128a_active_topk_width,
+)
 from vllm.v1.kv_cache_interface import MLAAttentionSpec
+
+
+@pytest.mark.parametrize(
+    ("max_seq_len", "capacity", "expected"),
+    [
+        (0, 8192, 128),
+        (16384, 8192, 128),
+        (16385, 8192, 128),
+        (16512, 8192, 256),
+        (524288, 8192, 4096),
+        (1048576, 4096, 4096),
+    ],
+)
+def test_c128a_active_topk_width(
+    max_seq_len: int,
+    capacity: int,
+    expected: int,
+) -> None:
+    assert get_c128a_active_topk_width(max_seq_len, 128, capacity) == expected
+
+
+def test_c128a_metadata_builder_uses_shared_active_width(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import vllm.models.deepseek_v4.sparse_mla as sparse_mla
+
+    builder = object.__new__(DeepseekV4FlashMLAMetadataBuilder)
+    builder.compress_ratio = 128
+    builder.deepseek_v4_decode_threshold = 6
+    builder.c128a_max_compressed = 8192
+    builder.kv_cache_spec = SimpleNamespace(block_size=256)
+    builder.c128a_global_decode_buffer = torch.empty((1, 8192), dtype=torch.int32)
+    builder.c128a_decode_lens_buffer = torch.empty(1, dtype=torch.int32)
+    builder.c128a_prefill_buffer = torch.empty((1, 8192), dtype=torch.int32)
+
+    common = SimpleNamespace(
+        positions=torch.tensor([16383], dtype=torch.int64),
+        max_seq_len=16384,
+        block_table_tensor=torch.zeros((1, 1), dtype=torch.int32),
+        slot_mapping=torch.zeros(1, dtype=torch.int64),
+    )
+    req_id_per_token = torch.zeros(1, dtype=torch.int32)
+    observed: dict[str, int] = {}
+
+    monkeypatch.setattr(
+        sparse_mla,
+        "split_decodes_and_prefills",
+        lambda *_args, **_kwargs: (1, 0, 1, 0),
+    )
+
+    def fake_build(*_args, max_compressed_tokens: int, **_kwargs):
+        observed["width"] = max_compressed_tokens
+        return (
+            torch.zeros((1, max_compressed_tokens), dtype=torch.int32),
+            torch.ones(1, dtype=torch.int32),
+            torch.empty((0, max_compressed_tokens), dtype=torch.int32),
+        )
+
+    monkeypatch.setattr(sparse_mla, "build_c128a_topk_metadata", fake_build)
+
+    result = builder._build_c128a_metadata(
+        common,
+        req_id_per_token,
+        actual_num_query_tokens=1,
+        dcp_world_size=1,
+        dcp_rank=0,
+        cp_kv_cache_interleave_size=1,
+    )
+
+    assert observed["width"] == 128
+    assert result["c128a_global_decode_topk_indices"].shape == (1, 1, 128)
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")

--- a/vllm/models/deepseek_v4/sparse_mla.py
+++ b/vllm/models/deepseek_v4/sparse_mla.py
@@ -20,6 +20,7 @@ from vllm.v1.attention.backend import (
     MultipleOf,
 )
 from vllm.v1.attention.backends.mla.compressor_utils import (
+    get_c128a_active_topk_width,
     get_c128a_topk_width,
     get_compressed_slot_mapping,
 )
@@ -311,11 +312,9 @@ class DeepseekV4FlashMLAMetadataBuilder(
         assert cm.positions is not None, (
             "positions is required for C128A metadata build"
         )
-        active_topk_width = min(
-            max(
-                triton.next_power_of_2(max(cm.max_seq_len // self.compress_ratio, 1)),
-                _C128A_TOPK_ALIGNMENT,
-            ),
+        active_topk_width = get_c128a_active_topk_width(
+            cm.max_seq_len,
+            self.compress_ratio,
             self.c128a_max_compressed,
         )
         block_size = self.kv_cache_spec.block_size // self.compress_ratio

--- a/vllm/v1/attention/backends/mla/compressor_utils.py
+++ b/vllm/v1/attention/backends/mla/compressor_utils.py
@@ -6,7 +6,7 @@ from functools import cache
 import torch
 
 from vllm.triton_utils import tl, triton
-from vllm.utils.math_utils import cdiv
+from vllm.utils.math_utils import cdiv, next_power_of_2
 
 _C128A_TOPK_ALIGNMENT = 128
 _COMPRESSED_MLA_SPLIT_ALIGNMENT = 64
@@ -25,6 +25,27 @@ def get_c128a_topk_width(max_model_len: int, compress_ratio: int) -> int:
     """
     compressed_width = cdiv(max_model_len, compress_ratio)
     return cdiv(compressed_width, _C128A_TOPK_ALIGNMENT) * _C128A_TOPK_ALIGNMENT
+
+
+def get_c128a_active_topk_width(
+    max_seq_len: int,
+    compress_ratio: int,
+    capacity: int,
+) -> int:
+    """Return the active C128 index width for one scheduler step.
+
+    Only complete compression groups produce selectable records. The metadata
+    kernel uses a power-of-two width, with the FlashMLA alignment as its lower
+    bound and the preallocated metadata buffer width as its upper bound.
+    """
+    complete_records = max(int(max_seq_len), 0) // compress_ratio
+    return min(
+        max(
+            next_power_of_2(max(complete_records, 1)),
+            _C128A_TOPK_ALIGNMENT,
+        ),
+        capacity,
+    )
 
 
 def get_dspark_swa_index_width(


### PR DESCRIPTION
## Resulting behavior

DeepSeek V4 C128 sparse-attention metadata uses the number of complete compression records reachable by the active sequence length. The width remains power-of-two padded, has a 128-entry minimum, and cannot exceed the preallocated model-length capacity.

## Technical reason

A partial 128-token compression group does not produce a selectable record. Deriving metadata width from a rounded sequence quotient can activate an extra index region that has no complete source record.

## Compatibility

Buffer allocation remains sized from `max_model_len`. The change only narrows the active region used by a scheduler step; the alignment and capacity contracts are preserved.

## Validation

- Active-width boundary and capacity tests: passed.
- Sparse metadata builder tests: passed.
- Ruff check and format check: passed.
- Integrated DS4F TP4/DCP1 qualification: C1 220.36 tok/s, C8 781.00 tok/s, 64k prefill 15,014 tok/s.