### PR TITLE
[II] Profile serving-reachable shapes before KV cache sizing

### DIFF
--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -2145,6 +2145,101 @@ def test_v1_profile_rolls_back_distinct_target_and_draft_channels(monkeypatch):
     assert events[-1] == ("rollback", checkpoint)
 
 
+@pytest.mark.parametrize("dummy_run_fails", [False, True])
+def test_single_request_prefill_profile_uses_serving_shape_and_cleans_up(
+    monkeypatch: pytest.MonkeyPatch,
+    dummy_run_fails: bool,
+):
+    runner = GPUModelRunner.__new__(GPUModelRunner)
+    runner.vllm_config = object()
+    runner.max_num_tokens = 8192
+    runner.is_pooling_model = False
+    runner.encoder_cache = {"temporary": object()}
+    events: list[object] = []
+
+    runner._init_minimal_kv_cache_for_profiling = lambda: events.append("init-kv")
+
+    def dummy_run(*args, **kwargs):
+        events.append(("dummy-run", args, kwargs))
+        if dummy_run_fails:
+            raise RuntimeError("expected prefill failure")
+        return torch.empty(1), torch.empty(1)
+
+    runner._dummy_run = dummy_run
+    runner._dummy_sampler_run = lambda hidden_states: events.append(
+        ("sampler", hidden_states)
+    )
+    runner._sync_device = lambda: events.append("sync")
+    runner._cleanup_profiling_kv_cache = lambda: events.append("cleanup")
+
+    monkeypatch.setattr(
+        gpu_model_runner_module,
+        "set_current_vllm_config",
+        lambda _: nullcontext(),
+    )
+    monkeypatch.setattr(
+        gpu_model_runner_module,
+        "get_pp_group",
+        lambda: SimpleNamespace(is_last_rank=True),
+    )
+
+    if dummy_run_fails:
+        with pytest.raises(RuntimeError, match="expected prefill failure"):
+            runner.profile_single_request_prefill()
+    else:
+        runner.profile_single_request_prefill()
+
+    assert events[0] == "init-kv"
+    assert events[1] == (
+        "dummy-run",
+        (8192,),
+        {
+            "force_attention": True,
+            "skip_eplb": True,
+            "is_profile": True,
+            "include_mm_inputs": False,
+            "single_request_prefill": True,
+        },
+    )
+    assert events[-1] == "cleanup"
+    assert runner.encoder_cache == {}
+    if not dummy_run_fails:
+        assert events[-2] == "sync"
+
+
+def test_dummy_sampler_profiles_configured_speculative_width(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    runner = GPUModelRunner.__new__(GPUModelRunner)
+    runner.device = torch.device("cpu")
+    runner.vllm_config = SimpleNamespace(
+        model_config=SimpleNamespace(multimodal_config=None)
+    )
+    runner.model = SimpleNamespace(
+        compute_logits=lambda hidden_states: torch.zeros(hidden_states.shape[0], 16)
+    )
+    runner.sampler = Mock(logprobs_mode="raw_logits")
+    runner.sampler.return_value = torch.empty(0)
+    runner.speculative_config = SimpleNamespace(
+        rejection_sample_method="standard",
+        draft_sample_method="greedy",
+    )
+    runner.num_spec_tokens = 5
+    runner.rejection_sampler = Mock()
+    make_dummy = Mock(return_value=object())
+    monkeypatch.setattr(
+        gpu_model_runner_module.SpecDecodeMetadata,
+        "make_dummy",
+        make_dummy,
+    )
+
+    runner._dummy_sampler_run(torch.zeros(3, 8))
+
+    make_dummy.assert_called_once_with([[0] * 5 for _ in range(3)], runner.device)
+    rejection_logits = runner.rejection_sampler.call_args.args[2]
+    assert rejection_logits.shape == (18, 16)
+
+
 @pytest.mark.parametrize("cleanup_fails", [False, True])
 def test_v1_profile_restores_state_when_capture_or_cleanup_fails(
     monkeypatch,

--- a/tests/v1/worker/test_gpu_worker.py
+++ b/tests/v1/worker/test_gpu_worker.py
@@ -197,6 +197,7 @@ def test_memory_profile_replays_model_after_kernel_warmup(
     worker.device = "cuda:0"
     worker.model_runner = SimpleNamespace(
         profile_run=lambda: calls.append("profile"),
+        profile_single_request_prefill=lambda: calls.append("single-prefill"),
     )
     worker.vllm_config = SimpleNamespace()
     worker.get_model = lambda: object()
@@ -225,6 +226,7 @@ def test_memory_profile_replays_model_after_kernel_warmup(
         "kernel_warmup",
         ("reset_peak", "cuda:0"),
         "profile",
+        "single-prefill",
     ]
 
 

--- a/tests/v1/worker/test_prompt_logprobs.py
+++ b/tests/v1/worker/test_prompt_logprobs.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from contextlib import nullcontext
 from types import SimpleNamespace
 from unittest.mock import Mock
 
@@ -8,7 +9,9 @@ import numpy as np
 import pytest
 import torch
 
+import vllm.v1.worker.gpu.model_runner as gpu_model_runner_module
 from vllm.config.model import LogprobsMode
+from vllm.v1.worker.gpu.input_batch import InputBuffers
 from vllm.v1.worker.gpu.model_runner import GPUModelRunner
 from vllm.v1.worker.gpu.sample import prompt_logprob
 from vllm.v1.worker.gpu.sample.prompt_logprob import (
@@ -234,3 +237,106 @@ def test_non_last_pp_rank_does_not_profile_prompt_logprobs(
     GPUModelRunner.profile_run(runner)
 
     runner.prompt_logprobs_worker.profile_run.assert_not_called()
+
+
+@pytest.mark.parametrize("dummy_run_fails", [False, True])
+def test_v2_single_request_prefill_profile_uses_attention_and_cleans_up(
+    monkeypatch: pytest.MonkeyPatch,
+    dummy_run_fails: bool,
+):
+    hidden_states = torch.zeros((8, 4))
+    sample_hidden_states = hidden_states[-1:]
+    runner = object.__new__(GPUModelRunner)
+    runner.vllm_config = object()
+    runner.max_num_tokens = 8192
+    runner.is_last_pp_rank = True
+    runner.pooling_runner = None
+    runner._init_minimal_kv_cache_for_profiling = Mock()
+    runner._dummy_sampler_run = Mock()
+    runner.reset_encoder_cache = Mock()
+    runner._cleanup_cudagraph_memory_profile = Mock()
+
+    if dummy_run_fails:
+        runner._dummy_run = Mock(side_effect=RuntimeError("expected prefill failure"))
+    else:
+        runner._dummy_run = Mock(return_value=(hidden_states, sample_hidden_states))
+
+    monkeypatch.setattr(
+        gpu_model_runner_module,
+        "set_current_vllm_config",
+        lambda _: nullcontext(),
+    )
+    synchronize = Mock()
+    monkeypatch.setattr(torch.accelerator, "synchronize", synchronize)
+
+    if dummy_run_fails:
+        with pytest.raises(RuntimeError, match="expected prefill failure"):
+            runner.profile_single_request_prefill()
+    else:
+        runner.profile_single_request_prefill()
+
+    runner._init_minimal_kv_cache_for_profiling.assert_called_once_with()
+    runner._dummy_run.assert_called_once_with(
+        8192,
+        skip_eplb=True,
+        is_profile=True,
+        single_request_prefill=True,
+    )
+    runner.reset_encoder_cache.assert_called_once_with()
+    runner._cleanup_cudagraph_memory_profile.assert_called_once_with()
+    if dummy_run_fails:
+        synchronize.assert_not_called()
+        runner._dummy_sampler_run.assert_not_called()
+    else:
+        synchronize.assert_called_once_with()
+        runner._dummy_sampler_run.assert_called_once_with(sample_hidden_states)
+
+
+def test_v2_dummy_sampler_profiles_configured_speculative_width():
+    runner = object.__new__(GPUModelRunner)
+    runner.device = torch.device("cpu")
+    runner.input_buffers = InputBuffers(8, 48, runner.device)
+    runner.num_speculative_steps = 5
+    runner.decode_query_len = 6
+    runner.model = SimpleNamespace(
+        compute_logits=lambda hidden_states: torch.zeros(
+            hidden_states.shape[0], 16, dtype=hidden_states.dtype
+        )
+    )
+    runner.sampler = Mock()
+    runner.rejection_sampler = Mock()
+    draft_logits = torch.zeros(8, 5, 16)
+    runner.speculator = SimpleNamespace(draft_logits=draft_logits)
+
+    runner._dummy_sampler_run(torch.zeros(3, 8))
+
+    runner.sampler.assert_called_once()
+    verify_logits, input_batch, passed_draft_logits = (
+        runner.rejection_sampler.call_args.args
+    )
+    assert verify_logits.shape == (18, 16)
+    assert input_batch.num_draft_tokens == 15
+    assert input_batch.num_draft_tokens_per_req.tolist() == [5, 5, 5]
+    assert input_batch.cu_num_logits_np.tolist() == [0, 6, 12, 18]
+    assert input_batch.expanded_idx_mapping.tolist() == [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+    ]
+    assert input_batch.expanded_local_pos.tolist() == [0, 1, 2, 3, 4, 5] * 3
+    assert passed_draft_logits is draft_logits

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -758,6 +758,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         uniform_query_len: int | None = None,
         skip_eplb: bool = False,
         is_profile: bool = False,
+        single_request_prefill: bool = False,
         **kwargs,
     ) -> tuple[torch.Tensor | None, torch.Tensor | None]:
         if self.is_encoder_only:
@@ -770,7 +771,13 @@ class GPUModelRunner(LoRAModelRunnerMixin):
 
         # Create a dummy scheduler output.
         num_reqs = min(num_tokens, self.max_num_reqs)
-        if uniform_decode:
+        if single_request_prefill:
+            if uniform_decode:
+                raise ValueError(
+                    "single_request_prefill and uniform_decode are mutually exclusive"
+                )
+            num_reqs = 1
+        elif uniform_decode:
             if uniform_query_len is not None:
                 # Sub-depth uniform decode (SPS curve profiling): dispatch a
                 # capacity-pruned verify shape, e.g. one request at a query
@@ -900,6 +907,49 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         return hidden_states, sample_hidden_states
 
     @torch.inference_mode()
+    def _make_dummy_spec_decode_batch(self, num_reqs: int) -> InputBatch:
+        """Construct a verifier batch at the configured speculative width."""
+        assert self.num_speculative_steps > 0
+        assert self.decode_query_len > self.num_speculative_steps
+
+        num_logits_per_req = self.decode_query_len
+        num_logits = num_reqs * num_logits_per_req
+        input_batch = InputBatch.make_dummy(
+            num_reqs,
+            num_logits,
+            self.input_buffers,
+            max_req_tokens=num_logits_per_req,
+        )
+
+        num_draft_tokens_per_req = np.full(
+            num_reqs, self.num_speculative_steps, dtype=np.int32
+        )
+        cu_num_logits_np = np.arange(
+            0, num_logits + 1, num_logits_per_req, dtype=np.int32
+        )
+        local_pos = torch.arange(
+            num_logits_per_req, dtype=torch.int32, device=self.device
+        ).repeat(num_reqs)
+
+        input_batch.num_draft_tokens = int(num_draft_tokens_per_req.sum())
+        input_batch.num_draft_tokens_per_req = num_draft_tokens_per_req
+        input_batch.valid_num_draft_tokens_per_req = num_draft_tokens_per_req
+        input_batch.expanded_idx_mapping = input_batch.idx_mapping.repeat_interleave(
+            num_logits_per_req
+        )
+        input_batch.expanded_local_pos = local_pos
+        input_batch.positions.copy_(local_pos)
+        input_batch.logits_indices = torch.arange(
+            num_logits, dtype=torch.int64, device=self.device
+        )
+        input_batch.cu_num_logits_np = cu_num_logits_np
+        input_batch.cu_num_logits = torch.from_numpy(cu_num_logits_np).to(
+            device=self.device
+        )
+        input_batch.is_padding.fill_(False)
+        return input_batch
+
+    @torch.inference_mode()
     def _dummy_sampler_run(self, hidden_states: torch.Tensor) -> None:
         num_reqs = hidden_states.shape[0]
         logits = self.model.compute_logits(hidden_states)
@@ -912,6 +962,22 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         # during actual execution.
         assert self.sampler is not None
         self.sampler(logits, dummy_input_batch)
+
+        if self.rejection_sampler is None or self.num_speculative_steps == 0:
+            return
+
+        assert self.speculator is not None
+        del logits
+        verify_hidden_states = hidden_states.repeat_interleave(
+            self.decode_query_len, dim=0
+        )
+        verify_logits = self.model.compute_logits(verify_hidden_states)
+        dummy_spec_batch = self._make_dummy_spec_decode_batch(num_reqs)
+        self.rejection_sampler(
+            verify_logits,
+            dummy_spec_batch,
+            self.speculator.draft_logits,
+        )
 
     @torch.inference_mode()
     def _dummy_pooler_run(self, hidden_states: torch.Tensor) -> None:
@@ -969,6 +1035,43 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         del hidden_states, sample_hidden_states
         self.reset_encoder_cache()
         gc.collect()
+
+    @torch.inference_mode()
+    def profile_single_request_prefill(self) -> None:
+        """Profile the maximum text-prefill shape before sizing the KV cache.
+
+        The ordinary V2 profile omits attention and distributes
+        ``max_num_batched_tokens`` across ``max_num_seqs`` requests. Sparse
+        attention can initialize persistent metadata buffers and reach a larger
+        transient peak when one request consumes the complete token budget.
+        A temporary minimal KV cache exposes that serving path while dummy slot
+        mappings suppress cache writes.
+        """
+        with set_current_vllm_config(self.vllm_config):
+            self._init_minimal_kv_cache_for_profiling()
+
+        hidden_states: torch.Tensor | None = None
+        sample_hidden_states: torch.Tensor | None = None
+        try:
+            hidden_states, sample_hidden_states = self._dummy_run(
+                self.max_num_tokens,
+                skip_eplb=True,
+                is_profile=True,
+                single_request_prefill=True,
+            )
+            if self.is_last_pp_rank:
+                assert hidden_states is not None
+                assert sample_hidden_states is not None
+                if self.pooling_runner is None:
+                    self._dummy_sampler_run(sample_hidden_states)
+                else:
+                    self._dummy_pooler_run(hidden_states)
+            torch.accelerator.synchronize()
+        finally:
+            hidden_states = None
+            sample_hidden_states = None
+            self.reset_encoder_cache()
+            self._cleanup_cudagraph_memory_profile()
 
     def post_kv_cache_wake_up(self) -> None:
         self.block_tables.init_block_table_layout_tensors()

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6492,7 +6492,7 @@ class GPUModelRunner(
             else:
                 raise e
         if self.speculative_config:
-            draft_token_ids = [[0] for _ in range(num_reqs)]
+            draft_token_ids = [[0] * self.num_spec_tokens for _ in range(num_reqs)]
             dummy_spec_decode_metadata = SpecDecodeMetadata.make_dummy(
                 draft_token_ids, self.device
             )
@@ -6695,6 +6695,42 @@ class GPUModelRunner(
         del hidden_states, output
         self.encoder_cache.clear()
         gc.collect()
+
+    @torch.inference_mode()
+    def profile_single_request_prefill(self) -> None:
+        """Profile the maximum text-prefill shape before sizing the KV cache.
+
+        The ordinary profile distributes ``max_num_batched_tokens`` across
+        ``max_num_seqs`` requests. Sparse-attention metadata and communication
+        workspaces can have a larger peak for one request containing the entire
+        token budget. A temporary KV cache makes that attention path available;
+        dummy slot mappings suppress cache writes, so minimal storage is enough.
+        """
+        with set_current_vllm_config(self.vllm_config):
+            self._init_minimal_kv_cache_for_profiling()
+
+        model_output: tuple[torch.Tensor, torch.Tensor] | None = None
+        sampler_output: Any = None
+        try:
+            model_output = self._dummy_run(
+                self.max_num_tokens,
+                force_attention=True,
+                skip_eplb=True,
+                is_profile=True,
+                include_mm_inputs=False,
+                single_request_prefill=True,
+            )
+            hidden_states, last_hidden_states = model_output
+            if get_pp_group().is_last_rank:
+                if self.is_pooling_model:
+                    sampler_output = self._dummy_pooler_run(hidden_states)
+                else:
+                    sampler_output = self._dummy_sampler_run(last_hidden_states)
+            self._sync_device()
+        finally:
+            del model_output, sampler_output
+            self.encoder_cache.clear()
+            self._cleanup_profiling_kv_cache()
 
     def _init_minimal_kv_cache_for_profiling(self) -> None:
         from vllm.v1.core.kv_cache_utils import (

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -529,6 +529,12 @@ class Worker(WorkerBase):
         # allocations and the model's transient activation workspace.
         self.model_runner.profile_run()
 
+        # Distributed sparse-attention backends can defer metadata kernels and
+        # persistent workspaces until they see a single long request with a KV
+        # cache. Profile that serving shape before the remaining memory is
+        # assigned to the production KV cache.
+        self.model_runner.profile_single_request_prefill()
+
     def _release_unoccupied_accelerator_memory(self) -> None:
         """Return unoccupied caching-allocator blocks to the device.
 


### PR DESCRIPTION
## Resulting behavior

GPU memory sizing now includes two serving-reachable peaks that the generic dummy profile can miss:

- one request consuming the complete text-prefill token budget with attention enabled;
- speculative verification and rejection sampling at the configured draft width.

Persistent sparse-attention workspaces initialized during kernel warmup are retained while the serving-shape profile runs. Temporary profiling KV state is always released, including exception paths.

## Technical reason

The generic profile distributes tokens across requests and historically represented one draft token per request. Sparse attention can allocate its largest transient workspace for one long prefill, while DSpark and MTP verify `1 + K` rows per request. Omitting either shape can assign their runtime memory to the KV cache and cause allocation failure under valid serving load.

## Compatibility

The profile changes startup-time memory accounting only. Scheduler limits, model math, and runtime kernels are unchanged. KV capacity may decrease by the amount required to reserve an actually reachable serving peak.

## Validation

- Single-request prefill profile tests for both GPU model runners: passed.
- Configured speculative-width sampler tests: passed.
- Profiling cleanup and exception tests: passed.
- GPU worker replay-order test: passed.
- Ruff check and format check: passed.
- Integrated DS4F TP4/DCP1 startup, decode, 64k prefill, and correctness qualification completed successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved GPU profiling for single-request, long-context prefilling.
  * Enhanced profiling coverage for speculative decoding and rejection sampling.
  * Improved memory planning for distributed sparse-attention workloads.

* **Reliability**
  * Added cleanup and failure-path handling during profiling to prevent temporary state from persisting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->