### PR TITLE
[II] Normalize padded B12X MoE routes without allocation

### DIFF
--- a/tests/model_executor/layers/test_b12x_moe_warmup.py
+++ b/tests/model_executor/layers/test_b12x_moe_warmup.py
@@ -198,6 +198,21 @@ def test_b12x_moe_run_binds_only_the_prepared_expert_owner(monkeypatch) -> None:
     }
 
 
+@pytest.mark.parametrize("skip_padding", [False, True])
+def test_b12x_moe_padding_route_normalization_is_in_place(
+    monkeypatch, skip_padding: bool
+) -> None:
+    monkeypatch.setenv("VLLM_MOE_SKIP_PADDING", "1" if skip_padding else "0")
+    topk_ids = torch.tensor([[-1, -1], [2, 7]], dtype=torch.int32)
+    data_ptr = topk_ids.data_ptr()
+
+    normalized = b12x_moe._normalize_b12x_moe_padding_routes(topk_ids)
+
+    assert normalized.data_ptr() == data_ptr
+    expected = [[0, 0], [2, 7]] if skip_padding else [[-1, -1], [2, 7]]
+    assert normalized.tolist() == expected
+
+
 def test_b12x_source_release_leaves_prepared_owner_as_storage_owner() -> None:
     layer = torch.nn.Module()
     layer.w13_weight = torch.nn.Parameter(

--- a/vllm/model_executor/layers/fused_moe/b12x_moe.py
+++ b/vllm/model_executor/layers/fused_moe/b12x_moe.py
@@ -762,6 +762,20 @@ def _normalize_b12x_moe_topk_weights(topk_weights: torch.Tensor) -> torch.Tensor
     return topk_weights
 
 
+def _normalize_b12x_moe_padding_routes(topk_ids: torch.Tensor) -> torch.Tensor:
+    """Map vLLM padding sentinels to an expert index accepted by B12X.
+
+    The vLLM top-k kernels assign every padded route an expert ID of ``-1``
+    and a weight of zero. B12X indexes prepared expert storage directly and
+    therefore requires IDs in ``[0, num_experts)``. Mapping the sentinel to
+    expert zero preserves the zero contribution while keeping the operation
+    allocation-free and CUDA-graph-capturable.
+    """
+    if envs.VLLM_MOE_SKIP_PADDING:
+        topk_ids.clamp_min_(0)
+    return topk_ids
+
+
 def _normalize_modelopt_expert_scale(scale: torch.Tensor) -> torch.Tensor:
     if scale.dim() == 2:
         if scale.size(1) not in (1, 2):
@@ -1589,6 +1603,7 @@ class B12xExperts(mk.FusedMoEExpertsModular):
         ):
             swiglu_limit = None
         topk_ids = _normalize_b12x_moe_topk_ids(topk_ids)
+        topk_ids = _normalize_b12x_moe_padding_routes(topk_ids)
         topk_weights = _normalize_b12x_moe_topk_weights(topk_weights)
         plan = _plan_b12x_moe_fp4_scratch(
             tokens=int(hidden_states.shape[0]),


### PR DESCRIPTION
## Resulting behavior

When `VLLM_MOE_SKIP_PADDING=1`, zero-weight padded routes use expert ID zero before entering B12X. The normalization mutates the existing ID tensor in place, so it remains allocation-free and CUDA-graph-capturable.

## Technical reason

vLLM denotes padded top-k routes with expert ID `-1` and weight zero. B12X directly indexes prepared expert storage and requires a non-negative ID even when the route contributes zero to the output. Expert zero is a valid inert target because the corresponding weight remains zero.

## Compatibility

The mapping is enabled only with the existing skip-padding option. Non-padding routes, route weights, and output math are unchanged.

## Validation

- Enabled and disabled normalization tests: passed.
- Storage-pointer identity test: passed.
- Existing B12X MoE warmup tests: passed.
- Ruff check and format check: passed.
- Integrated DS4F fixed-K5 qualification completed without a correctness regression.