### PR TITLE
[II] Enforce canonical B12X package identifiers

### DIFF
--- a/tests/test_b12x_package_contract.py
+++ b/tests/test_b12x_package_contract.py
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from pathlib import Path
+
+
+def test_vllm_uses_b12x_package_names():
+    """Reject runtime references to the superseded SparkInfer package name."""
+    root = Path(__file__).parents[1]
+    markers = ("sparkinfer.", "SPARKINFER_")
+    offenders: list[str] = []
+
+    for source_root in (root / "vllm", root / "tests"):
+        for path in source_root.rglob("*.py"):
+            if path == Path(__file__):
+                continue
+            text = path.read_text(encoding="utf-8")
+            if any(marker in text for marker in markers):
+                offenders.append(str(path.relative_to(root)))
+
+    assert not offenders, f"legacy SparkInfer package references: {offenders}"

--- a/vllm/model_executor/layers/quantization/nvfp4_nf3_hybrid.py
+++ b/vllm/model_executor/layers/quantization/nvfp4_nf3_hybrid.py
@@ -26,7 +26,6 @@ launch with an expert map.
 """
 
 import dataclasses
-import os
 from typing import TYPE_CHECKING, Any
 
 import regex as re
@@ -221,9 +220,6 @@ def _apply_nf3_codebook_override(levels: list[float]) -> None:
         )
         kernel_module._NF3_CODEBOOK = codebook
         prepare_module._NF3_CODEBOOK = codebook
-    os.environ["SPARKINFER_NF3_CODEBOOK"] = ",".join(
-        f"{value:.10g}" for value in codebook
-    )
 
 
 def _b12x_tiles_for_geometry(


### PR DESCRIPTION
## Resulting behavior

The NVFP4/NF3 hybrid codebook override updates B12X runtime modules directly and no longer exports the superseded `SPARKINFER_NF3_CODEBOOK` environment variable. A source-contract test rejects Python references to the superseded package and environment prefix.

## Technical reason

The runtime package is named `b12x`. Retaining a second package identity in environment state makes process behavior depend on an interface that no installed component owns.

## Compatibility

The active B12X codebook modules receive the same values. Deployments must use B12X package and environment names; the superseded SparkInfer identifiers are unsupported.

## Validation

- Canonical package source-contract test: passed.
- Hybrid quantization tests in the composed runtime: passed.
- Ruff check and format check: passed.