### PR TITLE
[II] Recover hybrid KV cache load failures across cache groups

### DIFF
--- a/tests/v1/kv_connector/unit/test_invalid_blocks_correctness.py
+++ b/tests/v1/kv_connector/unit/test_invalid_blocks_correctness.py
@@ -61,6 +61,7 @@ def test_hybrid_cache_invalid_block_truncates_all_groups():
     scheduler = Scheduler.__new__(Scheduler)
     scheduler.block_size = 16
     scheduler.kv_cache_manager = Mock()
+    scheduler.kv_cache_manager.group_block_sizes = (16, 16)
 
     request = Mock(spec=Request)
     request.request_id = "hybrid-request"
@@ -87,6 +88,7 @@ def test_hybrid_cache_shared_invalid_block_is_recomputed_once():
     scheduler = Scheduler.__new__(Scheduler)
     scheduler.block_size = 16
     scheduler.kv_cache_manager = Mock()
+    scheduler.kv_cache_manager.group_block_sizes = (16, 16)
 
     first_request = Mock(spec=Request)
     first_request.request_id = "first-request"
@@ -110,6 +112,60 @@ def test_hybrid_cache_shared_invalid_block_is_recomputed_once():
     assert second_request.num_computed_tokens == 48
     assert affected_tokens == 32
     assert evicted == {2, 3, 12, 13}
+
+
+def test_hybrid_cache_aligns_recovery_across_different_block_sizes():
+    """Recovery starts where every hybrid-cache group has a block boundary."""
+    scheduler = Scheduler.__new__(Scheduler)
+    scheduler.block_size = 32
+    scheduler.kv_cache_manager = Mock()
+    scheduler.kv_cache_manager.group_block_sizes = (16, 32)
+
+    request = Mock(spec=Request)
+    request.request_id = "different-block-sizes"
+    request.num_computed_tokens = 96
+    scheduler.kv_cache_manager.get_block_ids.return_value = (
+        [1, 2, 3, 4, 5, 6],
+        [11, 12, 13],
+    )
+
+    affected, affected_tokens, evicted = scheduler._update_requests_with_invalid_blocks(
+        [request],
+        invalid_block_ids={4},
+        num_scheduled_tokens={},
+    )
+
+    assert affected == {request.request_id}
+    assert request.num_computed_tokens == 32
+    assert affected_tokens == 64
+    assert evicted == {3, 4, 5, 6, 12, 13}
+
+
+def test_hybrid_cache_ignores_invalid_blocks_after_external_prefix():
+    """A block used only by scheduled local tokens is not a load failure."""
+    scheduler = Scheduler.__new__(Scheduler)
+    scheduler.block_size = 32
+    scheduler.kv_cache_manager = Mock()
+    scheduler.kv_cache_manager.group_block_sizes = (16, 32)
+
+    request = Mock(spec=Request)
+    request.request_id = "local-suffix"
+    request.num_computed_tokens = 64
+    scheduler.kv_cache_manager.get_block_ids.return_value = (
+        [1, 2, 3, 4],
+        [11, 12],
+    )
+
+    affected, affected_tokens, evicted = scheduler._update_requests_with_invalid_blocks(
+        [request],
+        invalid_block_ids={3, 12},
+        num_scheduled_tokens={request.request_id: 32},
+    )
+
+    assert affected == set()
+    assert request.num_computed_tokens == 64
+    assert affected_tokens == 0
+    assert evicted == set()
 
 
 def test_sync_recompute_blocks_not_freed_for_running_requests(

--- a/tests/v1/kv_connector/unit/test_invalid_blocks_correctness.py
+++ b/tests/v1/kv_connector/unit/test_invalid_blocks_correctness.py
@@ -56,6 +56,62 @@ def recompute_scheduler():
     return create_scheduler(vllm_config)
 
 
+def test_hybrid_cache_invalid_block_truncates_all_groups():
+    """A failed hybrid-cache group invalidates the shared logical position."""
+    scheduler = Scheduler.__new__(Scheduler)
+    scheduler.block_size = 16
+    scheduler.kv_cache_manager = Mock()
+
+    request = Mock(spec=Request)
+    request.request_id = "hybrid-request"
+    request.num_computed_tokens = 64
+    scheduler.kv_cache_manager.get_block_ids.return_value = (
+        [1, 2, 3, 4],
+        [11, 12, 13, 14],
+    )
+
+    affected, affected_tokens, evicted = scheduler._update_requests_with_invalid_blocks(
+        [request],
+        invalid_block_ids={12},
+        num_scheduled_tokens={},
+    )
+
+    assert affected == {request.request_id}
+    assert request.num_computed_tokens == 16
+    assert affected_tokens == 48
+    assert evicted == {2, 3, 4, 12, 13, 14}
+
+
+def test_hybrid_cache_shared_invalid_block_is_recomputed_once():
+    """Shared failed blocks retain the existing single-recompute contract."""
+    scheduler = Scheduler.__new__(Scheduler)
+    scheduler.block_size = 16
+    scheduler.kv_cache_manager = Mock()
+
+    first_request = Mock(spec=Request)
+    first_request.request_id = "first-request"
+    first_request.num_computed_tokens = 48
+    second_request = Mock(spec=Request)
+    second_request.request_id = "second-request"
+    second_request.num_computed_tokens = 48
+    scheduler.kv_cache_manager.get_block_ids.side_effect = (
+        ([1, 2, 3], [11, 12, 13]),
+        ([21, 22, 23], [31, 12, 33]),
+    )
+
+    affected, affected_tokens, evicted = scheduler._update_requests_with_invalid_blocks(
+        [first_request, second_request],
+        invalid_block_ids={12},
+        num_scheduled_tokens={},
+    )
+
+    assert affected == {first_request.request_id, second_request.request_id}
+    assert first_request.num_computed_tokens == 16
+    assert second_request.num_computed_tokens == 48
+    assert affected_tokens == 32
+    assert evicted == {2, 3, 12, 13}
+
+
 def test_sync_recompute_blocks_not_freed_for_running_requests(
     recompute_scheduler: Scheduler,
 ):

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -165,6 +165,9 @@ class KVCacheManager:
         self.num_kv_cache_groups = len(kv_cache_config.kv_cache_groups)
         self.block_pool = self.coordinator.block_pool
         self.kv_cache_config = kv_cache_config
+        self.group_block_sizes = tuple(
+            manager.block_size for manager in self.coordinator.single_type_managers
+        )
 
         # Watermark: minimum number of KV cache blocks to keep free when
         # admitting waiting/preempted requests, to avoid frequent preemptions.

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -2911,8 +2911,6 @@ class Scheduler(SchedulerInterface):
         # it. This set tracks blocks already marked for recomputation.
         marked_invalid_block_ids: set[int] = set()
         for request in requests:
-            is_affected = False
-            marked_invalid_block = False
             req_id = request.request_id
             req_block_ids_by_group = self.kv_cache_manager.get_block_ids(req_id)
             # We iterate only over blocks that may contain externally computed
@@ -2921,64 +2919,62 @@ class Scheduler(SchedulerInterface):
                 request.num_computed_tokens - num_scheduled_tokens.get(req_id, 0)
             )
 
-            req_num_computed_blocks = (
-                req_num_computed_tokens + self.block_size - 1
-            ) // self.block_size
-            # KV cache groups currently use the same logical block positions.
-            # A failed load in any group invalidates that position for the
-            # request, and recomputation must evict all groups from there on.
-            logical_block_ids = zip(
-                *(group[:req_num_computed_blocks] for group in req_block_ids_by_group)
-            )
-            for idx, block_ids in enumerate(logical_block_ids):
-                invalid_ids = invalid_block_ids.intersection(block_ids)
-                if not invalid_ids:
-                    continue
+            invalid_blocks: list[tuple[int, int]] = []
+            for group_block_ids, group_block_size in zip(
+                req_block_ids_by_group,
+                self.kv_cache_manager.group_block_sizes,
+                strict=True,
+            ):
+                req_num_group_blocks = (
+                    req_num_computed_tokens + group_block_size - 1
+                ) // group_block_size
+                for block_idx, block_id in enumerate(
+                    group_block_ids[:req_num_group_blocks]
+                ):
+                    if block_id not in invalid_block_ids:
+                        continue
+                    block_start = block_idx * group_block_size
+                    # Recompute from a boundary shared by every KV cache group.
+                    # This avoids retaining a partially invalid larger block.
+                    recovery_boundary = block_start // self.block_size * self.block_size
+                    invalid_blocks.append((recovery_boundary, block_id))
 
-                is_affected = True
+            if not invalid_blocks:
+                continue
 
-                unmarked_invalid_ids = invalid_ids - marked_invalid_block_ids
-                marked_invalid_block_ids.update(invalid_ids)
-                if not unmarked_invalid_ids:
-                    # This invalid block is shared with a previous request
-                    # and was already marked for recomputation.
-                    # This means this request can still consider this block
-                    # as computed when rescheduled.
-                    # Currently this only applies to sync loading; Async
-                    # loading does not yet support block sharing
-                    continue
+            affected_req_ids.add(req_id)
+            request_invalid_ids = {block_id for _, block_id in invalid_blocks}
+            unmarked_invalid_ids = request_invalid_ids - marked_invalid_block_ids
+            marked_invalid_block_ids.update(request_invalid_ids)
 
-                if marked_invalid_block:
-                    # This request has already marked an invalid block for
-                    # recomputation and updated its num_computed_tokens.
-                    continue
-
-                marked_invalid_block = True
-                # Truncate the computed tokens at the first failed block
-                request.num_computed_tokens = idx * self.block_size
-                num_affected_tokens = (
-                    req_num_computed_tokens - request.num_computed_tokens
+            if not unmarked_invalid_ids:
+                # Every failed block is shared with an earlier request that
+                # owns its recomputation. Discard only tokens scheduled after
+                # the external prefix so this request can reuse that work.
+                total_affected_tokens += (
+                    request.num_computed_tokens - req_num_computed_tokens
                 )
-                total_affected_tokens += num_affected_tokens
+                request.num_computed_tokens = req_num_computed_tokens
+                continue
 
-                # collect invalid block and all downstream dependent blocks
-                if evict_blocks:
-                    for group_block_ids in req_block_ids_by_group:
-                        blocks_to_evict.update(group_block_ids[idx:])
+            recovery_boundary = min(
+                boundary
+                for boundary, block_id in invalid_blocks
+                if block_id in unmarked_invalid_ids
+            )
+            request.num_computed_tokens = recovery_boundary
+            total_affected_tokens += req_num_computed_tokens - recovery_boundary
 
-            if is_affected:
-                if not marked_invalid_block:
-                    # All invalid blocks of this request are shared with
-                    # previous requests and will be recomputed by them.
-                    # Revert to considering only cached tokens as computed.
-                    # Currently this only applies to sync loading; Async
-                    # loading does not yet support block sharing
-                    total_affected_tokens += (
-                        request.num_computed_tokens - req_num_computed_tokens
-                    )
-                    request.num_computed_tokens = req_num_computed_tokens
-
-                affected_req_ids.add(request.request_id)
+            if evict_blocks:
+                # Every group restarts at a complete physical block. The
+                # scheduler block size is the LCM of effective group sizes.
+                for group_block_ids, group_block_size in zip(
+                    req_block_ids_by_group,
+                    self.kv_cache_manager.group_block_sizes,
+                    strict=True,
+                ):
+                    first_block = recovery_boundary // group_block_size
+                    blocks_to_evict.update(group_block_ids[first_block:])
 
         return affected_req_ids, total_affected_tokens, blocks_to_evict
 

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -2914,8 +2914,7 @@ class Scheduler(SchedulerInterface):
             is_affected = False
             marked_invalid_block = False
             req_id = request.request_id
-            # TODO (davidb): add support for hybrid memory allocator
-            (req_block_ids,) = self.kv_cache_manager.get_block_ids(req_id)
+            req_block_ids_by_group = self.kv_cache_manager.get_block_ids(req_id)
             # We iterate only over blocks that may contain externally computed
             # tokens
             req_num_computed_tokens = (
@@ -2925,13 +2924,22 @@ class Scheduler(SchedulerInterface):
             req_num_computed_blocks = (
                 req_num_computed_tokens + self.block_size - 1
             ) // self.block_size
-            for idx, block_id in zip(range(req_num_computed_blocks), req_block_ids):
-                if block_id not in invalid_block_ids:
+            # KV cache groups currently use the same logical block positions.
+            # A failed load in any group invalidates that position for the
+            # request, and recomputation must evict all groups from there on.
+            logical_block_ids = zip(
+                *(group[:req_num_computed_blocks] for group in req_block_ids_by_group)
+            )
+            for idx, block_ids in enumerate(logical_block_ids):
+                invalid_ids = invalid_block_ids.intersection(block_ids)
+                if not invalid_ids:
                     continue
 
                 is_affected = True
 
-                if block_id in marked_invalid_block_ids:
+                unmarked_invalid_ids = invalid_ids - marked_invalid_block_ids
+                marked_invalid_block_ids.update(invalid_ids)
+                if not unmarked_invalid_ids:
                     # This invalid block is shared with a previous request
                     # and was already marked for recomputation.
                     # This means this request can still consider this block
@@ -2939,8 +2947,6 @@ class Scheduler(SchedulerInterface):
                     # Currently this only applies to sync loading; Async
                     # loading does not yet support block sharing
                     continue
-
-                marked_invalid_block_ids.add(block_id)
 
                 if marked_invalid_block:
                     # This request has already marked an invalid block for
@@ -2957,7 +2963,8 @@ class Scheduler(SchedulerInterface):
 
                 # collect invalid block and all downstream dependent blocks
                 if evict_blocks:
-                    blocks_to_evict.update(req_block_ids[idx:])
+                    for group_block_ids in req_block_ids_by_group:
+                        blocks_to_evict.update(group_block_ids[idx:])
 
             if is_affected:
                 if not marked_invalid_block:


### PR DESCRIPTION
## Behavior

KV connector load failures recover requests that use one or more KV cache groups. The scheduler maps every invalid physical block to its token interval, aligns recomputation to the scheduler block size shared by all groups, truncates the computed prefix, and evicts dependent blocks from every group. A failed block shared by multiple requests retains one recomputation owner.

## Technical reason

`Scheduler._update_requests_with_invalid_blocks` previously unpacked exactly one cache group. Hybrid attention layouts return multiple groups, so a connector read failure raised `ValueError: too many values to unpack` instead of applying the configured failure policy.

Hybrid groups can also have different effective block sizes. Recovery therefore cannot pair group block lists by index. `KVCacheManager.group_block_sizes` exposes each group's scheduler-visible block size, and recovery maps invalid blocks to token ranges before aligning down to the scheduler block size, which is the least common multiple of effective group sizes. Every group can restart from a complete physical block at that boundary.

## Compatibility

Single-group behavior is preserved. Successful connector transfers, cache allocation, and model computation are unchanged. A hybrid failure can recompute additional valid tokens within one scheduler-alignment segment to avoid retaining a partially invalid larger block.

## Validation

- `tests/v1/kv_connector/unit/test_invalid_blocks_correctness.py`
- `tests/v1/kv_connector/unit/test_kv_load_failure_recovery.py`
- 18 focused tests passed, including unequal group block sizes, shared invalid blocks, and invalid IDs outside the externally loaded prefix.
- Ruff check and format passed.
- `git diff --check` passed.

Runtime qualification uses DeepSeek-V4-Flash-0731 TP4/DCP1 with LMCache disk storage. Hybrid-group restore failures now follow the scheduler recomputation contract; LMCache object serialization is handled by its own integration changes.
