### PR TITLE
[II] Preserve grammar bitmask source widths after draft trimming

### DIFF
--- a/tests/v1/structured_output/test_utils.py
+++ b/tests/v1/structured_output/test_utils.py
@@ -1,8 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-import pytest
+from types import SimpleNamespace
 
+import numpy as np
+import pytest
+import torch
+
+from vllm.v1.core.sched.output import GrammarOutput
+from vllm.v1.structured_output import utils
 from vllm.v1.structured_output.backend_xgrammar import (
     has_xgrammar_unsupported_json_features,
 )
@@ -104,3 +110,53 @@ def test_supported_json_features(supported_schema):
     assert not has_xgrammar_unsupported_json_features(supported_schema), (
         "Schema should be supported"
     )
+
+
+def test_apply_grammar_bitmask_preserves_source_offsets_after_draft_trimming(
+    monkeypatch,
+):
+    """A trimmed request must not shift another request's grammar rows.
+
+    The scheduler serializes masks at its scheduled speculative width. A worker
+    may trim grammar-invalid drafts before applying those masks, so source and
+    destination offsets must be advanced with their respective widths.
+    """
+    scheduler_output = SimpleNamespace(
+        scheduled_spec_decode_tokens={
+            "trimmed-request": [1],
+            "full-request": [2, 3, 4],
+        }
+    )
+    grammar_output = GrammarOutput(
+        structured_output_request_ids=["trimmed-request", "full-request"],
+        grammar_bitmask=np.array(
+            [[10], [11], [12], [13], [20], [21], [22], [23]],
+            dtype=np.int32,
+        ),
+        num_spec_tokens=[3, 3],
+    )
+    input_batch = SimpleNamespace(req_ids=["trimmed-request", "full-request"])
+    logits = torch.zeros((6, 32))
+    applied_bitmask = None
+
+    def capture_bitmask(logits, bitmask, indices):
+        nonlocal applied_bitmask
+        applied_bitmask = bitmask.clone()
+        assert indices is None
+
+    monkeypatch.setattr(
+        utils,
+        "xgr",
+        SimpleNamespace(apply_token_bitmask_inplace=capture_bitmask),
+    )
+    monkeypatch.setattr(utils, "PIN_MEMORY", False)
+
+    utils.apply_grammar_bitmask(
+        scheduler_output,
+        grammar_output,
+        input_batch,
+        logits,
+    )
+
+    assert applied_bitmask is not None
+    assert applied_bitmask[:, 0].tolist() == [10, 13, 20, 21, 22, 23]

--- a/tests/v1/worker/test_gpu_structured_outputs.py
+++ b/tests/v1/worker/test_gpu_structured_outputs.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import numpy as np
+
+from vllm.v1.worker.gpu.structured_outputs import _build_grammar_row_mapping
+
+
+def test_grammar_mapping_preserves_bonus_rows_after_zero_draft_budget():
+    """Zero draft capacity retains each request's scheduled bonus mask."""
+    source_indices, logits_indices = _build_grammar_row_mapping(
+        req_ids=["low", "high", "prefill"],
+        grammar_req_ids=["low", "high", "prefill"],
+        grammar_num_spec_tokens=[2, 2, 0],
+        cu_num_logits_np=np.array([0, 1, 2, 3], dtype=np.int32),
+        num_draft_tokens_per_req=np.array([0, 0, 0], dtype=np.int32),
+        num_bonus_tokens=1,
+    )
+
+    assert source_indices == [2, 5, 6]
+    assert logits_indices == [0, 1, 2]
+
+
+def test_grammar_mapping_selects_active_drafts_from_each_source_group():
+    """Compaction preserves per-request draft rows and the final bonus row."""
+    source_indices, logits_indices = _build_grammar_row_mapping(
+        req_ids=["plain", "trimmed", "full"],
+        grammar_req_ids=["trimmed", "full"],
+        grammar_num_spec_tokens=[3, 3],
+        cu_num_logits_np=np.array([0, 1, 3, 7], dtype=np.int32),
+        num_draft_tokens_per_req=np.array([0, 1, 3], dtype=np.int32),
+        num_bonus_tokens=1,
+    )
+
+    assert source_indices == [0, 3, 4, 5, 6, 7]
+    assert logits_indices == [1, 2, 3, 4, 5, 6]
+
+
+def test_grammar_mapping_supports_non_speculative_batches():
+    """A batch without draft tokens maps one bonus row per grammar request."""
+    source_indices, logits_indices = _build_grammar_row_mapping(
+        req_ids=["plain", "grammar"],
+        grammar_req_ids=["grammar"],
+        grammar_num_spec_tokens=[0],
+        cu_num_logits_np=np.array([0, 1, 2], dtype=np.int32),
+        num_draft_tokens_per_req=None,
+        num_bonus_tokens=1,
+    )
+
+    assert source_indices == [0]
+    assert logits_indices == [1]

--- a/vllm/v1/core/sched/output.py
+++ b/vllm/v1/core/sched/output.py
@@ -295,3 +295,7 @@ class GrammarOutput:
     structured_output_request_ids: list[str]
     # Bitmask ordered as structured_output_request_ids.
     grammar_bitmask: "npt.NDArray[np.int32]"
+    # Number of speculative rows represented in grammar_bitmask for each
+    # structured output request. Worker-side draft trimming may reduce the
+    # number of logits without changing this compact source layout.
+    num_spec_tokens: list[int]

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1691,7 +1691,15 @@ class Scheduler(SchedulerInterface):
             structured_output_request_ids,
             scheduler_output.scheduled_spec_decode_tokens,
         )
-        return GrammarOutput(structured_output_request_ids, bitmask)
+        num_spec_tokens = [
+            len(scheduler_output.scheduled_spec_decode_tokens.get(req_id, ()))
+            for req_id in structured_output_request_ids
+        ]
+        return GrammarOutput(
+            structured_output_request_ids,
+            bitmask,
+            num_spec_tokens,
+        )
 
     def update_from_output(
         self,

--- a/vllm/v1/structured_output/utils.py
+++ b/vllm/v1/structured_output/utils.py
@@ -131,14 +131,24 @@ def apply_grammar_bitmask(
     )
     sorted_bitmask = sorted_bitmask_tensor.numpy()
     cumulative_index = 0
-    for req_id in grammar_output.structured_output_request_ids:
-        num_spec_tokens = len(spec_tokens.get(req_id, ()))
+    for req_id, num_grammar_spec_tokens in zip(
+        grammar_output.structured_output_request_ids,
+        grammar_output.num_spec_tokens,
+        strict=True,
+    ):
+        num_worker_spec_tokens = len(spec_tokens.get(req_id, ()))
+        assert num_worker_spec_tokens <= num_grammar_spec_tokens
         if (logit_idx := struct_out_req_batch_indices.get(req_id)) is not None:
-            for i in range(1 + num_spec_tokens):
+            for i in range(num_worker_spec_tokens):
                 bitmask_index = logit_idx + i
                 sorted_bitmask[bitmask_index] = grammar_bitmask[cumulative_index + i]
                 out_indices.append(bitmask_index)
-        cumulative_index += 1 + num_spec_tokens
+            bonus_index = logit_idx + num_worker_spec_tokens
+            sorted_bitmask[bonus_index] = grammar_bitmask[
+                cumulative_index + num_grammar_spec_tokens
+            ]
+            out_indices.append(bonus_index)
+        cumulative_index += 1 + num_grammar_spec_tokens
 
     # Copy async to device.
     grammar_bitmask = sorted_bitmask_tensor.to(logits.device, non_blocking=True)

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -500,6 +500,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 max_num_logits=self.max_num_reqs * self.decode_query_len,
                 vocab_size=self.vocab_size,
                 device=self.device,
+                num_bonus_tokens=self.model_state.num_new_sampled_tokens_per_step,
             )
 
         if self.is_pooling_model and self.is_last_pp_rank:
@@ -1606,6 +1607,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                     input_batch,
                     grammar_output.structured_output_request_ids,
                     grammar_output.grammar_bitmask,
+                    grammar_output.num_spec_tokens,
                 )
 
         if input_batch.num_draft_tokens == 0 or self.rejection_sampler is None:

--- a/vllm/v1/worker/gpu/structured_outputs.py
+++ b/vllm/v1/worker/gpu/structured_outputs.py
@@ -9,8 +9,61 @@ from vllm.v1.worker.gpu.buffer_utils import async_copy_to_gpu
 from vllm.v1.worker.gpu.input_batch import InputBatch
 
 
+def _build_grammar_row_mapping(
+    req_ids: list[str],
+    grammar_req_ids: list[str],
+    grammar_num_spec_tokens: list[int],
+    cu_num_logits_np: np.ndarray,
+    num_draft_tokens_per_req: np.ndarray | None,
+    num_bonus_tokens: int,
+) -> tuple[list[int], list[int]]:
+    """Map serialized grammar rows to the active compact logits layout."""
+    assert len(grammar_req_ids) == len(grammar_num_spec_tokens)
+    assert num_bonus_tokens in (0, 1)
+
+    req_id_to_idx = {req_id: i for i, req_id in enumerate(req_ids)}
+    source_indices: list[int] = []
+    logits_indices: list[int] = []
+    source_offset = 0
+
+    for grammar_req_id, num_source_drafts in zip(
+        grammar_req_ids,
+        grammar_num_spec_tokens,
+        strict=True,
+    ):
+        req_idx = req_id_to_idx[grammar_req_id]
+        num_active_drafts = (
+            0
+            if num_draft_tokens_per_req is None
+            else int(num_draft_tokens_per_req[req_idx])
+        )
+        assert 0 <= num_active_drafts <= num_source_drafts
+
+        logits_start = int(cu_num_logits_np[req_idx])
+        num_active_logits = int(
+            cu_num_logits_np[req_idx + 1] - cu_num_logits_np[req_idx]
+        )
+        assert num_active_logits == num_active_drafts + num_bonus_tokens
+
+        source_indices.extend(range(source_offset, source_offset + num_active_drafts))
+        logits_indices.extend(range(logits_start, logits_start + num_active_drafts))
+        if num_bonus_tokens:
+            source_indices.append(source_offset + num_source_drafts)
+            logits_indices.append(logits_start + num_active_drafts)
+
+        source_offset += num_source_drafts + num_bonus_tokens
+
+    return source_indices, logits_indices
+
+
 class StructuredOutputsWorker:
-    def __init__(self, max_num_logits: int, vocab_size: int, device: torch.device):
+    def __init__(
+        self,
+        max_num_logits: int,
+        vocab_size: int,
+        device: torch.device,
+        num_bonus_tokens: int,
+    ):
         self.logits_indices = torch.zeros(
             max_num_logits, dtype=torch.int32, device=device
         )
@@ -19,6 +72,7 @@ class StructuredOutputsWorker:
         )
         self.device = device
         self.copy_stream = torch.cuda.Stream()
+        self.num_bonus_tokens = num_bonus_tokens
 
     def apply_grammar_bitmask(
         self,
@@ -26,26 +80,30 @@ class StructuredOutputsWorker:
         input_batch: InputBatch,
         grammar_req_ids: list[str],
         grammar_bitmask: np.ndarray,
+        grammar_num_spec_tokens: list[int],
     ) -> None:
         if not grammar_req_ids:
             return
 
-        # Asynchronously copy the bitmask to GPU.
+        source_indices, mapping = _build_grammar_row_mapping(
+            input_batch.req_ids,
+            grammar_req_ids,
+            grammar_num_spec_tokens,
+            input_batch.cu_num_logits_np,
+            input_batch.num_draft_tokens_per_req,
+            self.num_bonus_tokens,
+        )
+        expected_source_rows = sum(
+            num_drafts + self.num_bonus_tokens for num_drafts in grammar_num_spec_tokens
+        )
+        assert grammar_bitmask.shape[0] == expected_source_rows
+        grammar_bitmask = grammar_bitmask[source_indices]
+
+        # Asynchronously copy the active bitmask rows to GPU.
         with torch.cuda.stream(self.copy_stream):
             bitmask = async_copy_to_gpu(
                 grammar_bitmask, out=self.grammar_bitmask[: grammar_bitmask.shape[0]]
             )
-
-        # Construct bitmask -> logits mapping
-        mapping: list[int] = []
-        req_ids = input_batch.req_ids
-        cu_num_logits = input_batch.cu_num_logits_np.tolist()
-        req_id_to_idx = {req_id: i for i, req_id in enumerate(req_ids)}
-        for grammar_req_id in grammar_req_ids:
-            req_idx = req_id_to_idx[grammar_req_id]
-            logits_start_idx = cu_num_logits[req_idx]
-            logits_end_idx = cu_num_logits[req_idx + 1]
-            mapping.extend(range(logits_start_idx, logits_end_idx))
 
         # Asynchronously copy the mapping to GPU.
         with torch.cuda.stream(self.copy_stream):

--- a/vllm/v1/worker/gpu/warmup.py
+++ b/vllm/v1/worker/gpu/warmup.py
@@ -367,7 +367,9 @@ def warmup_kernels(
                 (len(req_ids), bitmask_width), fill_value=-1, dtype=np.int32
             )
             grammar_output = GrammarOutput(
-                structured_output_request_ids=req_ids, grammar_bitmask=grammar_bitmask
+                structured_output_request_ids=req_ids,
+                grammar_bitmask=grammar_bitmask,
+                num_spec_tokens=[0] * len(req_ids),
             )
 
         worker_sample_tokens(grammar_output)

--- a/vllm/v1/worker/gpu/warmup.py
+++ b/vllm/v1/worker/gpu/warmup.py
@@ -583,6 +583,7 @@ def _profile_sps_curve(
         if sps_debug:
             events = model_runner._sps_debug_events
             model_runner._sps_debug_events = None
+            assert events is not None
             # Skip the warmup iters; report mean verify/draft GPU ms.
             timed = events[warmup_iters:]
             if timed:


### PR DESCRIPTION
## Behavior

Structured-output grammar masks retain the scheduler-serialized speculative width when a worker trims draft tokens. Source offsets advance by the serialized width; destination offsets and logits mappings use the active worker width. A request whose adaptive DSpark budget becomes zero maps its bonus grammar row without applying masks to removed draft logits.

## Technical reason

The scheduler serializes grammar rows before worker-side capacity policy and draft validation can reduce the active draft count for a request. Using the reduced count for both layouts shifts later requests onto masks owned by another request or creates a mask-count mismatch.

## Source relationship

Merged upstream vLLM [#52436](https://github.com/vllm-project/vllm/pull/52436) handles the same zero-budget condition through the fixed-stride grammar-mask ABI. Infernal Invocation uses compact serialized grammar rows and does not contain that ABI, so the upstream commit does not apply without replacing the mask representation used by the branch. Commits `826bb4088f4671fe79e01183e0301f79134662c1` and `a18a86e1faf246e4d022071d72645e57c90b71cf` implement the equivalent invariant for the compact-row representation.

## Compatibility

Scheduler and worker mappings are unchanged when no draft rows are trimmed. The change affects only structured-output batches whose speculative width is reduced after scheduler serialization. Target sampling, speculative acceptance, non-structured batches, and warmup geometry are unchanged.

## Validation

Base: `dev/infernal-invocation@337ef76dcd30198d8dd47f6c9e61ae1d8be73656`

```bash
PYTHONPATH=. .venv/bin/python -m pytest -q \
  tests/v1/structured_output/test_utils.py \
  tests/v1/worker/test_gpu_structured_outputs.py
```

Result: 10 passed.

Coverage includes draft validation trimming, zero adaptive budget, partial compaction, multiple grammar requests, a non-grammar request before grammar requests, and non-speculative batches.

A composed DeepSeek-V4-Flash-0731 TP2/DCP1 DSpark K5 runtime completed 24 strict tool-call responses and 160 long-context factual responses without malformed structured output, matcher warnings, or engine errors. The clean Kimi-K3 composition will receive its own DSpark, DFlash, tool-streaming, and long-context qualification before publication.

## Development assistance

OpenAI Codex assisted with upstream source comparison and test execution. Martin Vit reviewed the resulting diff and owns the Infernal Invocation adaptation.