### PR TITLE
[II] Fix duplicate DeepSeek V4 tool closer leakage

### DIFF
--- a/tests/parser/engine/test_deepseek_v4.py
+++ b/tests/parser/engine/test_deepseek_v4.py
@@ -231,6 +231,36 @@ class TestMissingInvokeEnd:
         assert "Done." in collect_content(results)
 
 
+class TestToolEndAbsorption:
+    def test_duplicate_tool_end_is_not_streamed_as_content(
+        self, mock_tokenizer, mock_request
+    ):
+        parser = DeepSeekV4Parser(mock_tokenizer)
+        chunks = [
+            DSML_TOOL_START,
+            DSML_INVOKE_PREFIX
+            + "get_weather"
+            + DSML_INVOKE_NAME_END
+            + "\n"
+            + _param("location", "true", "NYC")
+            + "\n"
+            + DSML_INVOKE_END
+            + "\n</",
+            "｜DSML｜tool_calls></",
+            "｜DSML｜tool_calls></think>",
+            "Done.",
+        ]
+
+        results = simulate_tool_streaming(parser, mock_request, chunks)
+
+        assert collect_function_name(results) == "get_weather"
+        assert json.loads(collect_tool_arguments(results)) == {"location": "NYC"}
+        content = collect_content(results)
+        assert content == "Done."
+        assert "DSML" not in content
+        assert "</think>" not in content
+
+
 # ── Thinking mode initial state ──────────────────────────────────────
 
 

--- a/tests/parser/engine/test_deepseek_v4.py
+++ b/tests/parser/engine/test_deepseek_v4.py
@@ -246,8 +246,8 @@ class TestToolEndAbsorption:
             + "\n"
             + DSML_INVOKE_END
             + "\n</",
-            "｜DSML｜tool_calls></",
-            "｜DSML｜tool_calls></think>",
+            DSML_TOOL_END.removeprefix("</") + "</",
+            DSML_TOOL_END.removeprefix("</") + "</think>",
             "Done.",
         ]
 

--- a/vllm/parser/deepseek_v4.py
+++ b/vllm/parser/deepseek_v4.py
@@ -152,6 +152,13 @@ def deepseek_v4_config(thinking: bool = False) -> ParserEngineConfig:
                 ParserState.CONTENT,
                 (),
             ),
+            # A DSML tool block owns its closing marker. Treat a repeated
+            # closer as idempotent instead of exposing protocol markup as
+            # assistant content after the first closer leaves tool state.
+            (ParserState.CONTENT, "TOOL_END"): Transition(
+                ParserState.CONTENT,
+                (),
+            ),
             # Absorb a duplicate <think> while already reasoning
             (ParserState.REASONING, "THINK_START"): Transition(
                 ParserState.REASONING,


### PR DESCRIPTION
## Resulting behavior

The DeepSeek V4 streaming parser treats a repeated `</｜DSML｜tool_calls>` marker as an idempotent protocol closer after a parsed tool-call block. Reserved DSML framing is no longer returned as assistant `content`; text following the repeated closer remains unchanged.

## Technical reason

DeepSeek V4 can emit this valid-but-redundant suffix:

```text
</｜DSML｜tool_calls></｜DSML｜tool_calls></think>
```

The first tool closer moves the parser from `TOOL_BETWEEN` to `CONTENT`. The state machine previously had no `CONTENT` transition for a second tool closer, so it exposed that marker as normal text. The parser already applies the same idempotent rule to a repeated `</think>` marker.

## Compatibility

The change affects only the reserved DeepSeek V4 DSML closer while the DeepSeek V4 parser is active. Tool names, arguments, structural-output grammar, reasoning text, and content after the marker are unchanged.

## Validation

- `78 passed`: `tests/parser/engine/test_deepseek_v4.py` and `tests/tool_parsers/test_deepseekv4_tool_parser.py`
- `ruff check` passed for both changed files.
- `ruff format --check` passed for both changed files.
- The regression test splits the duplicate closer across streaming chunk boundaries and verifies that the following `Done.` content is preserved exactly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate DeepSeek tool-call and thinking-end markers appearing in streamed assistant responses.
  * Ensured repeated closing markers are suppressed while legitimate trailing content, such as “Done.”, remains visible.
* **Tests**
  * Added regression coverage for streaming responses containing duplicate markers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->