### PR TITLE
[II] Require decode state for FULL CUDA graph dispatch

### DIFF
--- a/tests/v1/spec_decode/test_dynamic_sd_cug.py
+++ b/tests/v1/spec_decode/test_dynamic_sd_cug.py
@@ -16,6 +16,7 @@ from vllm.config import (
     VllmConfig,
 )
 from vllm.v1.worker.gpu import cudagraph_utils as gpu_cudagraph_utils
+from vllm.v1.worker.utils import get_uniform_decode_token_count
 
 pytestmark = pytest.mark.cpu_test
 
@@ -197,6 +198,77 @@ def test_dynamic_sd_non_uniform_batch_falls_back_to_piecewise(monkeypatch):
     assert desc.num_reqs is None
     assert desc.num_tokens == 3
     assert desc.num_active_loras == 0
+
+
+def test_prompt_chunks_shaped_like_spec_decode_miss_the_full_graph(monkeypatch):
+    """A batch holding K+1-token prompt chunks must not replay a decode graph.
+
+    Prompt chunks of exactly K + 1 tokens give the batch a spec-decode shape
+    by coincidence; replaying the FULL graph over them corrupts every request
+    in the batch. See https://github.com/vllm-project/vllm/issues/49918.
+    """
+
+    max_spec_tokens = 7
+    decode_query_len = max_spec_tokens + 1
+
+    monkeypatch.setattr(
+        gpu_cudagraph_utils,
+        "get_pp_group",
+        lambda: SimpleNamespace(is_first_rank=True, is_last_rank=True),
+    )
+
+    vllm_config = _create_vllm_config_for_dsd(
+        max_num_seqs=64,
+        max_spec_tokens=max_spec_tokens,
+        use_dynamic_sd=False,
+    )
+    manager = gpu_cudagraph_utils.CudaGraphManager(
+        vllm_config=vllm_config,
+        device=torch.device("cpu"),
+        cudagraph_mode=CUDAGraphMode.FULL_AND_PIECEWISE,
+        decode_query_len=decode_query_len,
+    )
+    manager._graphs_captured = True
+
+    num_decodes, num_chunks = 6, 2
+    num_reqs = num_decodes + num_chunks
+    num_tokens = num_reqs * decode_query_len
+
+    # The batch shape is indistinguishable from a full batch of spec decodes.
+    assert (
+        gpu_cudagraph_utils.get_uniform_token_count(
+            num_reqs, num_tokens, decode_query_len
+        )
+        == decode_query_len
+    )
+
+    # Two of the requests are decode_query_len tokens into a longer prompt.
+    uniform_tok_count = get_uniform_decode_token_count(
+        num_reqs, num_tokens, decode_query_len, has_prefill=True
+    )
+    assert uniform_tok_count is None
+    desc = manager.dispatch(
+        num_reqs=num_reqs,
+        num_tokens=num_tokens,
+        uniform_token_count=uniform_tok_count,
+        num_active_loras=0,
+    )
+    assert desc.cg_mode == CUDAGraphMode.PIECEWISE
+    assert desc.uniform_token_count is None
+
+    # The same shape with every request decoding still gets its FULL graph.
+    uniform_tok_count = get_uniform_decode_token_count(
+        num_reqs, num_tokens, decode_query_len, has_prefill=False
+    )
+    assert uniform_tok_count == decode_query_len
+    desc = manager.dispatch(
+        num_reqs=num_reqs,
+        num_tokens=num_tokens,
+        uniform_token_count=uniform_tok_count,
+        num_active_loras=0,
+    )
+    assert desc.cg_mode == CUDAGraphMode.FULL
+    assert desc.uniform_token_count == decode_query_len
 
 
 def test_basic_sd_does_not_capture_shorter_full_decode_shapes(monkeypatch):

--- a/tests/v1/worker/test_gpu_batch_ordering.py
+++ b/tests/v1/worker/test_gpu_batch_ordering.py
@@ -1,21 +1,39 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Batch ordering in Model Runner V2 (vllm.v1.worker.gpu).
+"""Batch ordering and classification in Model Runner V2 (vllm.v1.worker.gpu).
 
 split_decodes_and_prefills assumes decode -> short_extend -> prefill request
 ordering. With spec decode (decode_query_len > 1), a shorter chunked-prefill
 tail sorted in front of the uniform decodes misclassifies every decode as a
 prefill.
+
+Conversely, a prompt chunk of exactly decode_query_len tokens has a decode
+batch's shape, and must not be classified as a uniform decode batch.
 """
 
+import ast
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import numpy as np
 import torch
 
 from vllm.v1.attention.backend import CommonAttentionMetadata
 from vllm.v1.attention.backends.utils import split_decodes_and_prefills
-from vllm.v1.worker.gpu.model_runner import sort_batch_req_ids
+from vllm.v1.worker.gpu.model_runner import GPUModelRunner, sort_batch_req_ids
+from vllm.v1.worker.utils import get_uniform_decode_token_count
 
 
 def _make_common_attn_metadata(query_lens: list[int]) -> CommonAttentionMetadata:
+    """Build minimal attention metadata for the requested query lengths.
+
+    Args:
+        query_lens: Query length for each request in execution order.
+
+    Returns:
+        Attention metadata with deterministic sequence lengths and empty blocks.
+    """
     num_reqs = len(query_lens)
     num_tokens = sum(query_lens)
     query_start_loc = torch.zeros(num_reqs + 1, dtype=torch.int32)
@@ -35,6 +53,90 @@ def _make_common_attn_metadata(query_lens: list[int]) -> CommonAttentionMetadata
         block_table_tensor=torch.zeros(num_reqs, 1, dtype=torch.int32),
         slot_mapping=torch.zeros(num_tokens, dtype=torch.int64),
     )
+
+
+def _make_runner(
+    req_states: dict[str, tuple[int, int]], decode_query_len: int = 8
+) -> Any:
+    """Build a runner stub with request prefill state.
+
+    Args:
+        req_states: Mapping from request ID to computed tokens and prefill length.
+        decode_query_len: Query length used to order speculative decode requests.
+
+    Returns:
+        A model-runner stub that supports pre-dispatch state gathering.
+    """
+    prefill_lens = np.array([s[1] for s in req_states.values()], dtype=np.int32)
+    num_computed = np.array([s[0] for s in req_states.values()], dtype=np.int32)
+    runner: Any = GPUModelRunner.__new__(GPUModelRunner)
+    runner.decode_query_len = decode_query_len
+    runner.req_states = SimpleNamespace(
+        req_id_to_index={req_id: i for i, req_id in enumerate(req_states)},
+        # The runner keeps this as min(num_computed_tokens, prefill_len).
+        num_computed_prefill_tokens=np.minimum(num_computed, prefill_lens),
+        prefill_len=SimpleNamespace(np=prefill_lens),
+    )
+    return runner
+
+
+def _uniform_token_count(
+    req_states: dict[str, tuple[int, int]],
+    query_len: int,
+    dummy_run: bool = False,
+) -> int | None:
+    """Classify a synthetic scheduled batch through the runner state gather.
+
+    Args:
+        req_states: Mapping from request ID to computed tokens and prefill length.
+        query_len: Scheduled query length for every request.
+        dummy_run: Whether to classify the batch as graph-capture input.
+
+    Returns:
+        The common decode query length when FULL replay is eligible, otherwise
+        None.
+    """
+    scheduler_output = SimpleNamespace(
+        num_scheduled_tokens={req_id: query_len for req_id in req_states},
+        total_num_scheduled_tokens=query_len * len(req_states),
+    )
+    runner = _make_runner(req_states, decode_query_len=query_len)
+    _, uniform_tok_count = runner.gather_batch_req_state(scheduler_output, dummy_run)
+    return uniform_tok_count
+
+
+def test_spec_decode_batch_is_uniform_decode():
+    # decode_query_len == 8 (K=7): every request past its prefill.
+    decodes = {f"d{i}": (16, 16) for i in range(6)}
+    assert _uniform_token_count(decodes, 8) == 8
+
+
+def test_prompt_chunk_of_decode_query_len_is_not_uniform_decode():
+    # Two prompt chunks whose query length coincides with the K+1 spec-decode
+    # query length must reject the batch (issue #49918).
+    batch = {f"d{i}": (16, 16) for i in range(6)}
+    batch.update({f"p{i}": (8, 40) for i in range(2)})
+    assert _uniform_token_count(batch, 8) is None
+
+    # Same collision without spec decoding: 1-token prompt vs 1-token decode.
+    assert _uniform_token_count({"p0": (0, 1)}, 1) is None
+
+    # A fresh prompt of exactly decode_query_len tokens.
+    assert _uniform_token_count({"p0": (0, 8)}, 8) is None
+
+
+def test_dummy_batches_stay_uniform_decode():
+    # Dummy batches have no request state to consult and must stay classified
+    # by shape alone; rejecting them would make capture and replay disagree.
+    scheduler_output = SimpleNamespace(
+        num_scheduled_tokens={f"_dummy_req_{i}": 8 for i in range(4)},
+        total_num_scheduled_tokens=32,
+    )
+    state, uniform_tok_count = _make_runner({}).gather_batch_req_state(
+        scheduler_output, True
+    )
+    assert state is None
+    assert uniform_tok_count == 8
 
 
 def test_sort_batch_req_ids_no_spec():
@@ -68,3 +170,74 @@ def test_spec_decodes_lead_short_prefill_tail():
     )
     assert (num_decodes, num_prefills) == (8, 1)
     assert (num_decode_tokens, num_prefill_tokens) == (16, 1)
+
+
+def test_uniform_decode_uses_state_index_not_batch_position():
+    """The gather must read each request's own state, not its batch slot.
+
+    Batch position and state index diverge as requests come and go; here the
+    only prefilling request sits at state index 0, so a gather keyed on batch
+    position would read its row and wrongly reject the two decodes.
+    """
+    runner: Any = GPUModelRunner.__new__(GPUModelRunner)
+    runner.decode_query_len = 8
+    # State arrays in state-index order: a prefilling request, then two decodes.
+    runner.req_states = SimpleNamespace(
+        req_id_to_index={"prefilling": 0, "decode_a": 1, "decode_b": 2},
+        num_computed_prefill_tokens=np.array([8, 16, 16], dtype=np.int32),
+        prefill_len=SimpleNamespace(np=np.array([40, 16, 16], dtype=np.int32)),
+    )
+    scheduler_output = SimpleNamespace(
+        num_scheduled_tokens={"decode_a": 8, "decode_b": 8},
+        total_num_scheduled_tokens=16,
+    )
+
+    state, uniform_tok_count = runner.gather_batch_req_state(scheduler_output, False)
+    assert not state.has_prefill
+    assert uniform_tok_count == 8
+
+    # Scheduling the prefilling request alongside them must reject the batch.
+    scheduler_output.num_scheduled_tokens = {
+        "decode_a": 8,
+        "prefilling": 8,
+        "decode_b": 8,
+    }
+    scheduler_output.total_num_scheduled_tokens = 24
+    state, uniform_tok_count = runner.gather_batch_req_state(scheduler_output, False)
+    assert state.has_prefill
+    assert uniform_tok_count is None
+
+
+def test_uniform_decode_predicate():
+    # Shape and prefill state must both pass.
+    assert get_uniform_decode_token_count(2, 16, 8, False) == 8
+    assert get_uniform_decode_token_count(2, 16, 8, True) is None
+    # 12 tokens over 2 requests is no shared query length.
+    assert get_uniform_decode_token_count(2, 12, 8, False) is None
+
+
+def test_no_speculator_dispatches_on_query_length_alone():
+    """No speculator may pick its cudagraph from a shape-only test.
+
+    Written over the whole package because speculators are added by copying an
+    existing one: the shape-only call already reappeared verbatim in a
+    speculator added after the original call sites were fixed.
+    """
+    import vllm.v1.worker.gpu.spec_decode as spec_decode
+
+    shape_only = {"get_uniform_token_count", "is_uniform_query_len"}
+    root = Path(spec_decode.__file__).parent
+    offenders = []
+    for path in sorted(root.rglob("speculator.py")):
+        for node in ast.walk(ast.parse(path.read_text())):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            name = func.id if isinstance(func, ast.Name) else getattr(func, "attr", "")
+            if name in shape_only:
+                offenders.append(f"{path.relative_to(root)}:{node.lineno} {name}")
+
+    assert not offenders, (
+        "these speculators classify a decode batch by query length alone; use "
+        f"get_uniform_decode_token_count instead: {offenders}"
+    )

--- a/tests/v1/worker/test_gpu_input_batch_v2.py
+++ b/tests/v1/worker/test_gpu_input_batch_v2.py
@@ -51,3 +51,15 @@ def test_make_dummy_distributes_remainder(num_reqs: int, num_tokens: int):
     assert torch.equal(
         batch.query_start_loc.cpu(), torch.from_numpy(batch.query_start_loc_np)
     )
+
+
+def test_has_prefill_reflects_request_state():
+    """FULL decode graph eligibility must observe every scheduled request."""
+    buffers = InputBuffers(
+        max_num_reqs=2, max_num_tokens=16, device=torch.device(DEVICE)
+    )
+    batch = InputBatch.make_dummy(num_reqs=2, num_tokens=16, input_buffers=buffers)
+
+    assert not batch.has_prefill
+    batch.is_prefilling_np[1] = True
+    assert batch.has_prefill

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -42,7 +42,7 @@ from vllm.v1.worker.gpu.block_table import BlockTables
 from vllm.v1.worker.gpu.cp_utils import prepare_dcp_local_seq_lens
 from vllm.v1.worker.gpu.input_batch import InputBatch, InputBuffers
 from vllm.v1.worker.gpu.model_states.interface import ModelState
-from vllm.v1.worker.utils import AttentionGroup
+from vllm.v1.worker.utils import AttentionGroup, is_uniform_query_len
 
 logger = init_logger(__name__)
 
@@ -100,17 +100,24 @@ def _is_compatible(
 
 
 def get_uniform_token_count(
-    num_reqs: int,
-    num_tokens: int,
-    max_query_len: int,
+    num_reqs: int, num_tokens: int, max_query_len: int
 ) -> int | None:
+    """Return the common query length for a shape-uniform batch.
+
+    Shape test only, valid for batches known to be decoding by construction
+    (e.g. dummy runs). Scheduled batches must use
+    `get_uniform_decode_token_count`.
+
+    Args:
+        num_reqs: Number of requests in the constructed batch.
+        num_tokens: Total number of query tokens in the batch.
+        max_query_len: Largest query length in the batch.
+
+    Returns:
+        The common query length when all requests have that length, otherwise
+        None.
     """
-    Return the uniform token count if batch is uniform, else None.
-    A batch is uniform if all requests have the same number of tokens.
-    """
-    if (max_query_len == num_tokens // num_reqs) and (
-        num_tokens == max_query_len * num_reqs
-    ):
+    if is_uniform_query_len(num_reqs, num_tokens, max_query_len):
         return max_query_len
     return None
 

--- a/vllm/v1/worker/gpu/input_batch.py
+++ b/vllm/v1/worker/gpu/input_batch.py
@@ -112,6 +112,15 @@ class InputBatch:
     # Seeded per num_tokens so all TP ranks generate identical ids.
     dummy_input_ids_random_high: ClassVar[int] = 0
 
+    @property
+    def has_prefill(self) -> bool:
+        """Whether any scheduled request is still consuming prompt tokens.
+
+        Returns:
+            True when at least one request is prefilling.
+        """
+        return bool(self.is_prefilling_np.any())
+
     @classmethod
     def make_dummy(
         cls,

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -155,7 +155,11 @@ from vllm.v1.worker.gpu.spec_decode.utils import (
 from vllm.v1.worker.gpu.states import RequestState
 from vllm.v1.worker.gpu.structured_outputs import StructuredOutputsWorker
 from vllm.v1.worker.lora_model_runner_mixin import LoRAModelRunnerMixin
-from vllm.v1.worker.utils import KVBlockZeroer, copy_kv_cache_blocks_inplace
+from vllm.v1.worker.utils import (
+    KVBlockZeroer,
+    copy_kv_cache_blocks_inplace,
+    get_uniform_decode_token_count,
+)
 from vllm.v1.worker.workspace import lock_workspace, use_workspace_lane
 
 logger = init_logger(__name__)
@@ -1329,25 +1333,77 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 scheduler_output.kv_cache_block_copies,
             )
 
+    def gather_batch_req_state(
+        self, scheduler_output: SchedulerOutput, dummy_run: bool
+    ) -> tuple["BatchReqState | None", int | None]:
+        """Classify scheduled requests before selecting a CUDA graph.
+
+        A prompt chunk can have the same token-count shape as a speculative
+        decode batch. Request state, rather than shape alone, determines
+        whether a FULL decode graph is eligible.
+
+        Args:
+            scheduler_output: Scheduler decisions for the model invocation.
+            dummy_run: Whether the invocation constructs graph-capture inputs.
+
+        Returns:
+            A tuple containing ordered CPU request state (None for a dummy run)
+            and the common decode query length when FULL replay is eligible.
+        """
+        num_tokens_per_req = scheduler_output.num_scheduled_tokens
+        num_reqs = len(num_tokens_per_req)
+        num_tokens = scheduler_output.total_num_scheduled_tokens
+        max_query_len = max(num_tokens_per_req.values())
+
+        if dummy_run:
+            return None, get_uniform_token_count(num_reqs, num_tokens, max_query_len)
+
+        req_ids = sort_batch_req_ids(num_tokens_per_req, self.decode_query_len)
+        num_scheduled_tokens = np.fromiter(
+            map(num_tokens_per_req.__getitem__, req_ids),
+            dtype=np.int32,
+            count=num_reqs,
+        )
+        idx_mapping_np = np.fromiter(
+            map(self.req_states.req_id_to_index.__getitem__, req_ids),
+            dtype=np.intp,
+            count=num_reqs,
+        )
+        prefill_len_np = self.req_states.prefill_len.np[idx_mapping_np]
+        num_computed_prefill_tokens_np = self.req_states.num_computed_prefill_tokens[
+            idx_mapping_np
+        ]
+        is_prefilling_np = num_computed_prefill_tokens_np < prefill_len_np
+        batch_req_state = BatchReqState(
+            req_ids=req_ids,
+            num_scheduled_tokens=num_scheduled_tokens,
+            idx_mapping_np=idx_mapping_np,
+            prefill_len_np=prefill_len_np,
+            num_computed_prefill_tokens_np=num_computed_prefill_tokens_np,
+            is_prefilling_np=is_prefilling_np,
+            has_prefill=bool(is_prefilling_np.any()),
+        )
+        return batch_req_state, get_uniform_decode_token_count(
+            num_reqs,
+            num_tokens,
+            max_query_len,
+            batch_req_state.has_prefill,
+        )
+
     def prepare_inputs(
         self,
         scheduler_output: SchedulerOutput,
+        batch_req_state: "BatchReqState",
         batch_desc: BatchExecutionDescriptor,
         max_query_len: int,
     ) -> InputBatch:
         num_tokens = scheduler_output.total_num_scheduled_tokens
         num_tokens_after_padding = batch_desc.num_tokens
-        num_tokens_per_req = scheduler_output.num_scheduled_tokens
-        num_reqs = len(num_tokens_per_req)
-
-        # batch_idx -> req_id
-        req_ids = sort_batch_req_ids(num_tokens_per_req, self.decode_query_len)
-        numtoks_iter = map(num_tokens_per_req.__getitem__, req_ids)
-        num_scheduled_tokens = np.fromiter(numtoks_iter, dtype=np.int32, count=num_reqs)
-
-        idx_mapping_iter = map(self.req_states.req_id_to_index.__getitem__, req_ids)
-        idx_mapping_np = np.fromiter(idx_mapping_iter, dtype=np.intp, count=num_reqs)
+        req_ids = batch_req_state.req_ids
+        num_scheduled_tokens = batch_req_state.num_scheduled_tokens
+        idx_mapping_np = batch_req_state.idx_mapping_np
         idx_mapping = async_copy_to_gpu(idx_mapping_np, device=self.device)
+        num_reqs = len(req_ids)
 
         # Get the number of draft tokens for each request.
         draft_tokens = scheduler_output.scheduled_spec_decode_tokens
@@ -1411,13 +1467,8 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         async_copy_to_gpu(query_start_loc_np, out=self.input_buffers.query_start_loc)
         query_start_loc_np = query_start_loc_np[: num_reqs_padded + 1]
         query_start_loc = self.input_buffers.query_start_loc[: num_reqs_padded + 1]
-        prefill_len_np = self.req_states.prefill_len.np[idx_mapping_np]
-        computed_prefill_tokens_np = self.req_states.num_computed_prefill_tokens
-        num_computed_prefill_tokens_np = computed_prefill_tokens_np[idx_mapping_np]
-        is_prefilling_np = num_computed_prefill_tokens_np < prefill_len_np
-
         # Get prefill tokens if any.
-        if np.any(is_prefilling_np):
+        if batch_req_state.has_prefill:
             prepare_prefill_inputs(
                 self.input_buffers.input_ids,
                 self.req_states.next_prefill_tokens,
@@ -1508,9 +1559,11 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             max_seq_len_upper_bound=max_seq_len_upper_bound,
             dcp_local_seq_lens=dcp_local_seq_lens,
             num_computed_tokens_np=num_computed_tokens_np,
-            prefill_len_np=prefill_len_np,
-            num_computed_prefill_tokens_np=num_computed_prefill_tokens_np,
-            is_prefilling_np=is_prefilling_np,
+            prefill_len_np=batch_req_state.prefill_len_np,
+            num_computed_prefill_tokens_np=(
+                batch_req_state.num_computed_prefill_tokens_np
+            ),
+            is_prefilling_np=batch_req_state.is_prefilling_np,
             max_seq_len_np=max_seq_len_np,
             input_ids=self.input_buffers.input_ids[:num_tokens_after_padding],
             positions=self.input_buffers.positions[:num_tokens_after_padding],
@@ -1703,7 +1756,9 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         num_reqs = len(scheduler_output.num_scheduled_tokens)
         num_toks = scheduler_output.total_num_scheduled_tokens
         max_query_len = max(scheduler_output.num_scheduled_tokens.values())
-        uniform_tok_count = get_uniform_token_count(num_reqs, num_toks, max_query_len)
+        batch_req_state, uniform_tok_count = self.gather_batch_req_state(
+            scheduler_output, dummy_run
+        )
         # Per-request token bound for graph dispatch: varlen spec-decode graphs
         # are captured for at most `max_req_tokens` tokens per request, so a
         # batch may only replay one if its longest request fits.
@@ -1790,9 +1845,13 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         if not dummy_run:
             # Common case.
             # Prepare all the inputs and copy to the input buffers.
+            assert batch_req_state is not None
             with record_function_or_nullcontext("vllm:v2/target/prepare_inputs"):
                 input_batch = self.prepare_inputs(
-                    scheduler_output, batch_desc, max_query_len
+                    scheduler_output,
+                    batch_req_state,
+                    batch_desc,
+                    max_query_len,
                 )
             phase = _profile_batch_phase(input_batch)
             with record_function_or_nullcontext(
@@ -2379,6 +2438,18 @@ class GPUModelRunner(LoRAModelRunnerMixin):
     @property
     def pcp_manager_cls(self) -> type[pcp.PCPManager]:
         return pcp.PCPManager
+
+
+class BatchReqState(NamedTuple):
+    """CPU request state for a scheduled batch, in execution order."""
+
+    req_ids: list[str]
+    num_scheduled_tokens: np.ndarray
+    idx_mapping_np: np.ndarray
+    prefill_len_np: np.ndarray
+    num_computed_prefill_tokens_np: np.ndarray
+    is_prefilling_np: np.ndarray
+    has_prefill: bool
 
 
 class ExecuteModelState(NamedTuple):

--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
@@ -12,10 +12,7 @@ from vllm.logger import init_logger
 from vllm.triton_utils import tl, triton
 from vllm.v1.utils import record_function_or_nullcontext
 from vllm.v1.worker.gpu.attn_utils import build_slot_mappings_by_layer
-from vllm.v1.worker.gpu.cudagraph_utils import (
-    BatchExecutionDescriptor,
-    get_uniform_token_count,
-)
+from vllm.v1.worker.gpu.cudagraph_utils import BatchExecutionDescriptor
 from vllm.v1.worker.gpu.dp_utils import dispatch_cg_and_sync_dp
 from vllm.v1.worker.gpu.input_batch import InputBatch, InputBuffers
 from vllm.v1.worker.gpu.spec_decode.autoregressive.cudagraph_utils import (
@@ -25,6 +22,7 @@ from vllm.v1.worker.gpu.spec_decode.speculator import (
     CUDAGraphCapturePhase,
     DraftModelSpeculator,
 )
+from vllm.v1.worker.utils import get_uniform_decode_token_count
 
 logger = init_logger(__name__)
 
@@ -252,13 +250,14 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
                 self.max_num_reqs,
             )
 
-        # Uniform decode query lengths enable FULL graph replay.
-        uniform_token_count = get_uniform_token_count(
+        # FULL graph replay is valid only when every request is decoding.
+        uniform_token_count = get_uniform_decode_token_count(
             num_reqs,
             # Use the actual number of tokens without padding added by
             # the target model during FULL cudagraph.
             num_tokens,
             max_query_len,
+            input_batch.has_prefill,
         )
         with record_function_or_nullcontext("vllm:v2/speculator/prefill/dispatch"):
             rebuild_prefill_attn_metadata = getattr(

--- a/vllm/v1/worker/gpu/spec_decode/multi_module_mtp/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/multi_module_mtp/speculator.py
@@ -12,9 +12,6 @@ from vllm.logger import init_logger
 from vllm.triton_utils import tl, triton
 from vllm.v1.attention.backends.utils import PAD_SLOT_ID
 from vllm.v1.worker.gpu.attn_utils import build_slot_mappings_by_layer
-from vllm.v1.worker.gpu.cudagraph_utils import (
-    get_uniform_token_count,
-)
 from vllm.v1.worker.gpu.dp_utils import dispatch_cg_and_sync_dp
 from vllm.v1.worker.gpu.input_batch import InputBatch, InputBuffers
 from vllm.v1.worker.gpu.spec_decode.autoregressive.cudagraph_utils import (
@@ -25,6 +22,7 @@ from vllm.v1.worker.gpu.spec_decode.speculator import (
     CUDAGraphCapturePhase,
     DraftModelSpeculator,
 )
+from vllm.v1.worker.utils import get_uniform_decode_token_count
 
 logger = init_logger(__name__)
 
@@ -195,10 +193,11 @@ class MultiModuleMTPSpeculator(DraftModelSpeculator):
 
         # When all requests are decoding (no true prefills), each has
         # num_speculative_steps + 1 tokens, enabling FULL graph replay.
-        uniform_token_count = get_uniform_token_count(
+        uniform_token_count = get_uniform_decode_token_count(
             num_reqs,
             num_tokens,
             max_query_len,
+            input_batch.has_prefill,
         )
         batch_desc, num_tokens_across_dp = dispatch_cg_and_sync_dp(
             self.cudagraph_manager,

--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -601,6 +601,42 @@ def copy_kv_cache_blocks_inplace(
         blocks[dst_indices] = blocks[src_indices]
 
 
+def is_uniform_query_len(num_reqs: int, num_tokens: int, max_query_len: int) -> bool:
+    """Whether every request in the batch has the same query length.
+
+    Shape test only; use ``get_uniform_decode_token_count`` to classify a
+    scheduled batch, since a prompt chunk can have a decode batch's shape.
+
+    Args:
+        num_reqs: Number of scheduled requests.
+        num_tokens: Total number of scheduled query tokens.
+        max_query_len: Largest scheduled query length in the batch.
+
+    Returns:
+        True when the batch is non-empty and every query has the same length.
+    """
+    return num_reqs > 0 and num_tokens == max_query_len * num_reqs
+
+
+def get_uniform_decode_token_count(
+    num_reqs: int, num_tokens: int, max_query_len: int, has_prefill: bool
+) -> int | None:
+    """Return the per-request token count for a uniform decode batch.
+
+    Args:
+        num_reqs: Number of scheduled requests.
+        num_tokens: Total number of scheduled query tokens.
+        max_query_len: Largest scheduled query length in the batch.
+        has_prefill: Whether any scheduled request is consuming prompt tokens.
+
+    Returns:
+        The common query length for a uniform all-decode batch, otherwise None.
+    """
+    if not has_prefill and is_uniform_query_len(num_reqs, num_tokens, max_query_len):
+        return max_query_len
+    return None
+
+
 def is_residual_scattered_for_sp(
     vllm_config: VllmConfig, num_input_tokens: int
 ) -> bool:


### PR DESCRIPTION
## Behavior

FULL CUDA graph replay is selected only when every scheduled request is decoding and every request has the same query length. Prompt-only batches and mixed prompt/decode batches use the non-FULL dispatch path even when their token-count shape matches speculative decode.

Dummy capture batches retain shape-only classification because the capture input is uniform by construction. Uniform decode remains eligible for FULL replay in the target runner, autoregressive speculator, and multi-module MTP speculator.

## Root cause

Model Runner V2 classified uniform decode from token shape alone. A prompt chunk can contain the same `K+1` tokens per request as speculative decode, allowing a decode CUDA graph to replay over prompt state.

DeepSeek-V4-Flash-0731 with DSpark K5 exposed the collision at six tokens per request. The failure returned syntactically valid API responses containing repeated, raw-token, or multilingual output; the engine did not necessarily raise an exception.

This change ports the state-aware classification from vLLM commit [`0a94d85a`](https://github.com/vllm-project/vllm/commit/0a94d85a66499cad8297ead86a470967de5c0212), merged through [vLLM #51865](https://github.com/vllm-project/vllm/pull/51865).

## Compatibility

- Uniform all-decode batches retain FULL CUDA graph replay.
- Prompt-only and mixed prompt/decode batches use the valid non-FULL graph mode.
- Input preparation reuses one CPU request-state snapshot, so graph dispatch and tensor construction cannot classify different request states.
- The commit merges cleanly after all twelve vLLM PR heads used by the Infernal Invocation r3 source composition.

## Validation

- 50 focused unit tests passed across CUDA graph dispatch, request ordering, V2 input batches, autoregressive speculation, multi-module MTP, and acceptance control.
- The exact Infernal Invocation integration tree passed 36 focused tests.
- Ruff, formatting, compileall, and staged-diff checks passed.
- Control image `voipmonitor/vllm:infernal-invocation-vllm6c50b0a-b12x1584743-fi1ac6942-cu133-torch213-20260812-r3`: two independent TP2/DSpark-K5/C4 runs each produced one corrupt response, at request 159 and request 155 respectively.
- State-aware build: 160/160 responses passed the same long-running profile; the response-integrity watchdog found no raw-token, replacement-character, or multilingual corruption, and the server log contained no runtime error.
- Concurrent strict tool-call requests with 150,003 and 300,128 prompt tokens passed with 40 GiB native KV offload enabled. Both returned isolated tool calls and the server remained healthy.
- Aggregate generation throughput was 115.76 tok/s for the state-aware build versus 116.34 tok/s for the second control run on a different GPU pair (`-0.50%`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved batch classification for speculative decoding and CUDA graph dispatch.
  - Prevented prompt-prefill batches from incorrectly selecting full CUDA graphs.
  - Corrected prefill detection when requests appear at different positions in a batch.
  - Improved handling of uniform decode batches, dummy batches, and mixed request states.

- **Tests**
  - Added regression coverage for speculative decoding, batch ordering, prompt-length collisions, and prefill detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->