### PR TITLE
Add hot-swappable EXL3 MSRT expert cartridges with TP support

### DIFF
--- a/docs/features/quantization/README.md
+++ b/docs/features/quantization/README.md
@@ -73,6 +73,71 @@ th:not(:first-child) {
 
     For the most up-to-date information on hardware support and quantization methods, please refer to [vllm/model_executor/layers/quantization](../../../vllm/model_executor/layers/quantization) or consult with the vLLM development team.
 
+## EXL3 MSRT cartridges
+
+EXL3 MSRT cartridges hot-swap additive, trellis-quantized routed-expert
+residuals without materializing dense expert weights. They are not LoRA
+adapters and cannot be loaded through the LoRA manager.
+
+The base checkpoint must advertise the closed `exl3-msrt-base/1` rank-sliced
+EXL3 profile. Runtime loading remains an operator policy: set
+`VLLM_ENABLE_EXL3_CARTRIDGE=1` independently of checkpoint metadata. The
+adapter path must name a
+directory containing `adapter_config.json` conforming to
+[`fq-cartridge-adapter/3`](https://github.com/malaiwah/progressive-tensors/blob/f8b5c491574bf2a7efa13d588a009d5ea8843e69/schemas/fq-cartridge-adapter-3.schema.json)
+and every digest-pinned safetensors shard listed by that manifest. Loading
+fails before the serving pause when the manifest is missing, its recomputed
+per-layer compatibility fingerprint does not match the loaded base tensors, a
+shard digest or declared byte size changed, the MCG layout differs, or the
+declared TP topology,
+stage order, bitrate, expert count, projection set, or tensor geometry is
+incompatible.
+
+The runtime supports one model-wide active cartridge. It supports a manifest-
+declared full artifact sliced locally by TP workers, or a rank-sharded artifact
+whose explicit ranks and world size exactly match the runtime (including a
+rank-sharded world size of one). Pipeline, data, and expert parallelism, the V2
+model runner, and simultaneous vLLM LoRA adapters are not supported. The
+ExLlamaV3 extension must export `exl3_moe_additive_fused` with
+`EXL3_MOE_ADDITIVE_ABI_VERSION = 1`.
+
+`fq-cartridge-adapter/3` is a closed schema: unknown fields are rejected and
+any schema change requires a new version. `producer_verified_signer` is
+unauthenticated producer provenance; vLLM does not use it as a trust decision.
+Dynamic cartridge loading is a trusted-admin operation and should use local,
+trusted storage. Verification timeouts are cooperative between regular-file
+reads; remote or FUSE filesystems can still block inside the operating system.
+
+Async engine users call:
+
+```python
+await async_llm.load_exl3_cartridge("/srv/cartridges/k4like")
+await async_llm.deactivate_exl3_cartridge()
+```
+
+The synchronous `LLMEngine` API is unsupported because it cannot serialize
+request admission with this model-wide graph transition. Each model worker
+copies and digest-verifies its shards into private staging before generation is
+paused; the drained transaction consumes only those verified bytes.
+
+The server endpoints are development APIs and are registered only with
+`VLLM_SERVER_DEV_MODE=1`:
+
+```bash
+curl -X POST http://localhost:8000/load_exl3_cartridge \
+  -H 'content-type: application/json' \
+  -d '{"adapter_path":"/srv/cartridges/k4like"}'
+curl http://localhost:8000/exl3_cartridge_status
+curl -X POST http://localhost:8000/deactivate_exl3_cartridge
+```
+
+Load and deactivation pause admission, drain in-flight requests, release the
+old CUDA graphs, switch packed tensors, recapture, and then resume. A failed
+load restores the compressed base path. The adapter path must resolve to the
+same files on every worker. These development endpoints are unauthenticated,
+can read worker-local paths, mutate model output, and consume GPU memory; do
+not expose them to untrusted clients.
+
 ## Out-of-Tree Quantization Plugins
 
 vLLM supports registering custom, out-of-tree quantization methods using the `@register_quantization_config` decorator. This allows you to implement and use your own quantization schemes without modifying the vLLM codebase.

--- a/tests/entrypoints/serve/dev/test_cartridge.py
+++ b/tests/entrypoints/serve/dev/test_cartridge.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from unittest.mock import AsyncMock
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from vllm.entrypoints.serve.dev.cartridge.api_router import attach_router
+
+
+def _client(engine) -> TestClient:
+    app = FastAPI()
+    attach_router(app)
+    app.state.engine_client = engine
+    return TestClient(app)
+
+
+def test_load_cartridge_returns_updated_layers():
+    engine = AsyncMock()
+    engine.load_exl3_cartridge.return_value = [2, 2]
+    client = _client(engine)
+
+    response = client.post(
+        "/load_exl3_cartridge", json={"adapter_path": "/tmp/cart.safetensors"}
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "loaded", "updated_layers": [2, 2]}
+    engine.load_exl3_cartridge.assert_awaited_once_with("/tmp/cart.safetensors")
+
+
+def test_load_cartridge_requires_adapter_path():
+    client = _client(AsyncMock())
+
+    response = client.post("/load_exl3_cartridge", json={})
+
+    assert response.status_code == 400
+
+
+def test_load_cartridge_maps_value_error_to_bad_request():
+    engine = AsyncMock()
+    engine.load_exl3_cartridge.side_effect = ValueError("bad cartridge")
+    client = _client(engine)
+
+    response = client.post(
+        "/load_exl3_cartridge", json={"adapter_path": "/tmp/cart.safetensors"}
+    )
+
+    assert response.status_code == 400
+    assert "bad cartridge" in response.json()["error"]
+
+
+def test_deactivate_cartridge_returns_updated_layers():
+    engine = AsyncMock()
+    engine.deactivate_exl3_cartridge.return_value = [0, 0]
+    client = _client(engine)
+
+    response = client.post("/deactivate_exl3_cartridge")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "deactivated", "updated_layers": [0, 0]}
+
+
+def test_cartridge_status_reports_active_workers():
+    engine = AsyncMock()
+    engine.collective_rpc.return_value = [True, False]
+    client = _client(engine)
+
+    response = client.get("/exl3_cartridge_status")
+
+    assert response.status_code == 200
+    assert response.json() == {"active": [True, False]}
+    engine.collective_rpc.assert_awaited_once_with("has_exl3_cartridge")
+
+
+def test_endpoints_reject_engine_without_cartridge_support():
+    engine = object()  # no load_exl3_cartridge attribute
+    client = _client(engine)
+
+    response = client.post(
+        "/load_exl3_cartridge", json={"adapter_path": "/tmp/cart.safetensors"}
+    )
+
+    assert response.status_code == 501

--- a/tests/entrypoints/serve/dev/test_cartridge.py
+++ b/tests/entrypoints/serve/dev/test_cartridge.py
@@ -38,6 +38,19 @@ def test_load_cartridge_requires_adapter_path():
     assert response.status_code == 400
 
 
+def test_load_cartridge_rejects_invalid_utf8_json():
+    client = _client(AsyncMock())
+
+    response = client.post(
+        "/load_exl3_cartridge",
+        content=b'{"adapter_path":"\xff"}',
+        headers={"content-type": "application/json"},
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Invalid JSON request body"}
+
+
 def test_load_cartridge_maps_value_error_to_bad_request():
     engine = AsyncMock()
     engine.load_exl3_cartridge.side_effect = ValueError("bad cartridge")
@@ -48,7 +61,8 @@ def test_load_cartridge_maps_value_error_to_bad_request():
     )
 
     assert response.status_code == 400
-    assert "bad cartridge" in response.json()["error"]
+    assert response.json()["error"] == "EXL3 cartridge validation failed"
+    assert "bad cartridge" not in response.text
 
 
 def test_deactivate_cartridge_returns_updated_layers():

--- a/tests/quantization/test_exl3_lora_cartridge.py
+++ b/tests/quantization/test_exl3_lora_cartridge.py
@@ -12,6 +12,7 @@ import torch
 from safetensors.torch import save_file
 
 import vllm.model_executor.layers.quantization.exl3 as exl3_module
+from vllm.config import CUDAGraphMode
 from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 from vllm.model_executor.layers.quantization.exl3 import Exl3Config, Exl3MoEMethod
 from vllm.model_executor.layers.quantization.exl3_lora_cartridge import (
@@ -19,12 +20,16 @@ from vllm.model_executor.layers.quantization.exl3_lora_cartridge import (
     Exl3LoraCartridge,
     apply_exl3_cartridge,
     apply_exl3_cudagraph_cartridge,
+    deactivate_exl3_cartridge,
     load_cartridge_from_adapter,
     load_exl3_cartridge_into_model,
+    prepare_exl3_cartridge_into_model,
     prepare_exl3_cudagraph_cartridge_runtime,
 )
 from vllm.v1.engine.async_llm import AsyncLLM
+from vllm.v1.engine.exceptions import EngineDeadError
 from vllm.v1.engine.llm_engine import LLMEngine
+from vllm.v1.worker.gpu_model_runner import GPUModelRunner
 from vllm.v1.worker.gpu_worker import Worker
 
 CPU = torch.device("cpu")
@@ -36,6 +41,8 @@ def _runtime_layer(device: torch.device = CPU):
         exl3_hidden_size=4,
         exl3_intermediate_size_per_partition=2,
         exl3_params_dtype=torch.float16,
+        exl3_cartridge_capable=True,
+        exl3_cartridge_enabled=False,
         w13_trellis=SimpleNamespace(device=device),
         activation=SimpleNamespace(value="silu"),
         layer_name="model.layers.3.mlp.experts",
@@ -208,10 +215,40 @@ def test_runtime_rejects_nonfinite_materialized_weights():
         runtime.materialize(layer, cartridge)
 
     assert runtime.active.item() is False
-    assert not runtime._materialized
 
 
-def test_cartridge_runtime_rejects_data_parallel_creation(monkeypatch):
+@pytest.mark.parametrize(
+    ("parallel_config", "use_v2_model_runner", "lora_config", "error"),
+    [
+        (
+            SimpleNamespace(data_parallel_size=2, tensor_parallel_size=1),
+            False,
+            None,
+            "data_parallel_size=1",
+        ),
+        (
+            SimpleNamespace(data_parallel_size=1, tensor_parallel_size=2),
+            False,
+            None,
+            "tensor_parallel_size=1",
+        ),
+        (
+            SimpleNamespace(data_parallel_size=1, tensor_parallel_size=1),
+            True,
+            None,
+            "V2 model runner",
+        ),
+        (
+            SimpleNamespace(data_parallel_size=1, tensor_parallel_size=1),
+            False,
+            SimpleNamespace(),
+            "LoRA adapters",
+        ),
+    ],
+)
+def test_cartridge_runtime_rejects_unsupported_execution_config(
+    monkeypatch, parallel_config, use_v2_model_runner, lora_config, error
+):
     method = object.__new__(Exl3MoEMethod)
     method.moe = SimpleNamespace(
         moe_parallel_config=SimpleNamespace(use_ep=False, tp_rank=0, tp_size=1),
@@ -222,13 +259,15 @@ def test_cartridge_runtime_rejects_data_parallel_creation(monkeypatch):
         cartridge_runtime=True,
     )
     config = SimpleNamespace(
-        parallel_config=SimpleNamespace(data_parallel_size=2),
+        parallel_config=parallel_config,
         scheduler_config=SimpleNamespace(max_num_batched_tokens=16),
         model_config=SimpleNamespace(runner_type="generate"),
+        use_v2_model_runner=use_v2_model_runner,
+        lora_config=lora_config,
     )
     monkeypatch.setattr(exl3_module, "get_current_vllm_config_or_none", lambda: config)
 
-    with pytest.raises(NotImplementedError, match="data_parallel_size=1"):
+    with pytest.raises(NotImplementedError, match=error):
         method.create_weights(
             SimpleNamespace(layer_name="model.layers.3.mlp.experts"),
             num_experts=2,
@@ -238,7 +277,13 @@ def test_cartridge_runtime_rejects_data_parallel_creation(monkeypatch):
         )
 
 
-def test_create_weights_stamps_draft_layer_cartridge_disabled(monkeypatch):
+@pytest.mark.parametrize(
+    ("runner_type", "cartridge_capable"),
+    [("draft", False), ("generate", True)],
+)
+def test_create_weights_stamps_cartridge_capability_without_enabling(
+    monkeypatch, runner_type, cartridge_capable
+):
     method = object.__new__(Exl3MoEMethod)
     method.moe = SimpleNamespace(
         moe_parallel_config=SimpleNamespace(use_ep=False, tp_rank=0, tp_size=1),
@@ -250,9 +295,11 @@ def test_create_weights_stamps_draft_layer_cartridge_disabled(monkeypatch):
         rank_sliced_layer_bitrates=MagicMock(return_value=(2, 2)),
     )
     config = SimpleNamespace(
-        parallel_config=SimpleNamespace(data_parallel_size=1),
+        parallel_config=SimpleNamespace(data_parallel_size=1, tensor_parallel_size=1),
         scheduler_config=SimpleNamespace(max_num_batched_tokens=16),
-        model_config=SimpleNamespace(runner_type="draft"),
+        use_v2_model_runner=False,
+        lora_config=None,
+        model_config=SimpleNamespace(runner_type=runner_type),
     )
     monkeypatch.setattr(exl3_module, "get_current_vllm_config_or_none", lambda: config)
     monkeypatch.setattr(exl3_module, "Exl3MoEParameter", MagicMock())
@@ -269,7 +316,8 @@ def test_create_weights_stamps_draft_layer_cartridge_disabled(monkeypatch):
         params_dtype=torch.float16,
     )
 
-    assert layer.exl3_is_draft is True
+    assert layer.exl3_is_draft is (runner_type == "draft")
+    assert layer.exl3_cartridge_capable is cartridge_capable
     assert layer.exl3_cartridge_enabled is False
 
 
@@ -302,10 +350,40 @@ def test_rank_sliced_draft_layer_skips_cartridge_path():
     cartridge.assert_not_called()
 
 
-def test_graph_path_uses_device_scalar_without_host_branch():
+def test_active_rank_sliced_layer_skips_compressed_base_path():
+    method = object.__new__(Exl3MoEMethod)
+    method.quant_config = SimpleNamespace(rank_sliced_metadata={"tp": 1})
+    method._apply_rank_sliced = MagicMock()
+    layer = SimpleNamespace(
+        activation=MoEActivation.SILU,
+        expert_map=None,
+        apply_router_weight_on_input=False,
+        exl3_cartridge_enabled=True,
+    )
+    x = torch.ones(2, 4, dtype=torch.float16)
+    weights = torch.ones(2, 1, dtype=torch.float32)
+    ids = torch.zeros(2, 1, dtype=torch.long)
+
+    with patch(
+        "vllm.model_executor.layers.quantization.exl3_lora_cartridge."
+        "apply_exl3_cudagraph_cartridge",
+        return_value=torch.ones(2, 4, dtype=torch.float16),
+    ) as cartridge:
+        output = method.apply(layer, x, weights, ids, None, None)
+
+    assert output.shape == (2, 4)
+    method._apply_rank_sliced.assert_not_called()
+    cartridge.assert_called_once()
+    call_x, call_weights, call_ids, call_layer = cartridge.call_args.args
+    assert torch.equal(call_x, x)
+    assert torch.equal(call_weights, weights)
+    assert torch.equal(call_ids, ids)
+    assert call_layer is layer
+
+
+def test_graph_path_routes_original_ids_once():
     layer = _runtime_layer()
-    runtime = prepare_exl3_cudagraph_cartridge_runtime(layer)
-    base = torch.full((3, 4), 2.0, dtype=torch.float16)
+    prepare_exl3_cudagraph_cartridge_runtime(layer)
     dense = torch.full((3, 4), torch.nan, dtype=torch.float16)
     inputs = torch.zeros(3, 4, dtype=torch.float16)
     weights = torch.ones(3, 1, dtype=torch.float32)
@@ -315,59 +393,45 @@ def test_graph_path_uses_device_scalar_without_host_branch():
         "vllm.model_executor.layers.quantization.exl3_lora_cartridge.fused_experts",
         return_value=dense,
     ) as fused:
-        runtime.deactivate()
-        inactive = apply_exl3_cudagraph_cartridge(base, inputs, weights, ids, layer)
-        runtime.active.fill_(1)
-        active = apply_exl3_cudagraph_cartridge(base, inputs, weights, ids, layer)
+        output = apply_exl3_cudagraph_cartridge(inputs, weights, ids, layer)
 
-    assert torch.equal(inactive, base)
-    assert torch.isnan(active).all()
-    assert fused.call_count == 2
-    assert torch.equal(fused.call_args_list[0].args[4], torch.zeros_like(ids))
-    assert torch.equal(fused.call_args_list[1].args[4], ids)
+    assert torch.isnan(output).all()
+    fused.assert_called_once()
+    assert torch.equal(fused.call_args.args[4], ids)
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
-def test_device_activation_replays_real_fused_moe_in_one_cuda_graph():
+def test_dense_cartridge_replays_with_fixed_weights_in_one_cuda_graph():
     device = torch.device("cuda")
     layer = _loader_layer()
     layer.w13_trellis.device = device
     runtime = prepare_exl3_cudagraph_cartridge_runtime(layer)
-    base = torch.full((3, 16), 2.0, dtype=torch.float16, device=device)
     inputs = torch.ones(3, 16, dtype=torch.float16, device=device)
     weights = torch.ones(3, 1, dtype=torch.float32, device=device)
     ids = torch.zeros(3, 1, dtype=torch.long, device=device)
 
     runtime.w13.fill_(0.1)
     runtime.w2.fill_(0.1)
-    apply_exl3_cudagraph_cartridge(base, inputs, weights, ids, layer)
+    runtime._materialized = True
+    runtime.activate()
     w13_pointer = runtime.w13.data_ptr()
     w2_pointer = runtime.w2.data_ptr()
 
     graph = torch.cuda.CUDAGraph()
-    runtime.deactivate()
     torch.cuda.synchronize()
     with torch.cuda.graph(graph):
-        output = apply_exl3_cudagraph_cartridge(base, inputs, weights, ids, layer)
+        output = apply_exl3_cudagraph_cartridge(inputs, weights, ids, layer)
     graph.replay()
     torch.cuda.synchronize()
-    assert torch.equal(output, base)
+    initial = output.clone()
 
     runtime.w13.fill_(0.2)
-    runtime._materialized = True
     runtime.w2.fill_(0.2)
-    runtime.activate()
     graph.replay()
     torch.cuda.synchronize()
-    assert not torch.equal(output, base)
+    assert not torch.equal(output, initial)
     assert runtime.w13.data_ptr() == w13_pointer
     assert runtime.w2.data_ptr() == w2_pointer
-
-    runtime.w13.fill_(torch.nan)
-    runtime.deactivate()
-    graph.replay()
-    torch.cuda.synchronize()
-    assert torch.equal(output, base)
 
 
 def test_loader_filters_layer_and_sorts_stage_numbers(tmp_path):
@@ -523,6 +587,50 @@ def test_model_loader_deactivates_every_layer_after_materialization_failure():
     assert all(runtime.active.item() == 0.0 for runtime in runtimes)
 
 
+def test_model_loader_skips_layers_without_cartridge_capability():
+    layer = _runtime_layer()
+    layer.exl3_cartridge_capable = False
+    model = SimpleNamespace(modules=lambda: iter((layer,)))
+
+    with patch(
+        "vllm.model_executor.layers.quantization.exl3_lora_cartridge."
+        "load_cartridge_from_adapter"
+    ) as load:
+        assert prepare_exl3_cartridge_into_model(model, "cartridge.safetensors") == 0
+
+    load.assert_not_called()
+    assert not hasattr(layer, "_exl3_cartridge_runtime")
+
+
+def test_model_loader_allocates_and_releases_runtime_lazily():
+    layer = _runtime_layer()
+    model = SimpleNamespace(modules=lambda: iter((layer,)))
+
+    def mark_materialized(runtime, _layer, _cartridge):
+        runtime._materialized = True
+
+    with (
+        patch(
+            "vllm.model_executor.layers.quantization.exl3_lora_cartridge."
+            "load_cartridge_from_adapter",
+            return_value=_cartridge(),
+        ),
+        patch.object(
+            Exl3CUDAGraphCartridgeRuntime,
+            "materialize",
+            autospec=True,
+            side_effect=mark_materialized,
+        ),
+    ):
+        assert load_exl3_cartridge_into_model(model, "cartridge.safetensors") == 1
+
+    assert isinstance(layer._exl3_cartridge_runtime, Exl3CUDAGraphCartridgeRuntime)
+    assert layer.exl3_cartridge_enabled is True
+    assert deactivate_exl3_cartridge(model) == 1
+    assert not hasattr(layer, "_exl3_cartridge_runtime")
+    assert layer.exl3_cartridge_enabled is False
+
+
 def test_model_loader_activates_every_layer_only_after_materialization():
     layers = [_runtime_layer(), _runtime_layer()]
     layers[1].layer_name = "model.layers.4.mlp.experts"
@@ -551,8 +659,20 @@ def test_model_loader_activates_every_layer_only_after_materialization():
 
 def test_worker_cartridge_operations_use_collective_rpc_target_model():
     model = SimpleNamespace()
-    worker = SimpleNamespace(model_runner=SimpleNamespace(model=model))
+    model_runner = SimpleNamespace(
+        model=model,
+        clear_cudagraphs=MagicMock(),
+        capture_model=MagicMock(return_value=123),
+        _dummy_run=MagicMock(),
+        max_num_tokens=16,
+    )
+    worker = SimpleNamespace(model_runner=model_runner)
     with (
+        patch(
+            "vllm.model_executor.layers.quantization.exl3_lora_cartridge."
+            "has_exl3_cartridge",
+            return_value=True,
+        ) as has_cartridge,
         patch(
             "vllm.model_executor.layers.quantization.exl3_lora_cartridge."
             "prepare_exl3_cartridge_into_model",
@@ -568,46 +688,144 @@ def test_worker_cartridge_operations_use_collective_rpc_target_model():
             "deactivate_exl3_cartridge",
             return_value=10,
         ) as deactivate,
+        patch("torch.accelerator.synchronize") as synchronize,
+        patch("torch.accelerator.empty_cache") as empty_cache,
     ):
+        Worker.clear_exl3_cartridge_cudagraphs(worker)
+        assert Worker.has_exl3_cartridge(worker) is True
         assert Worker.prepare_exl3_cartridge(worker, "cartridge.safetensors") == 10
         assert Worker.activate_exl3_cartridge(worker) == 10
         assert Worker.deactivate_exl3_cartridge(worker) == 10
+        assert Worker.capture_exl3_cartridge_cudagraphs(worker) == 123
 
+    model_runner.clear_cudagraphs.assert_called_once_with()
+    model_runner.capture_model.assert_called_once_with()
+    model_runner._dummy_run.assert_called_once_with(16, is_profile=True, skip_eplb=True)
+    has_cartridge.assert_called_once_with(model)
     prepare.assert_called_once_with(model, "cartridge.safetensors")
     activate.assert_called_once_with(model)
     deactivate.assert_called_once_with(model)
+    synchronize.assert_called_once_with()
+    empty_cache.assert_called_once_with()
+
+
+def test_worker_relocks_workspace_after_recapture_failure():
+    worker = SimpleNamespace(
+        model_runner=SimpleNamespace(
+            _dummy_run=MagicMock(),
+            max_num_tokens=16,
+            capture_model=MagicMock(side_effect=RuntimeError("capture failed")),
+        )
+    )
+    with (
+        patch("vllm.v1.worker.gpu_worker.lock_workspace") as lock,
+        pytest.raises(RuntimeError, match="capture failed"),
+    ):
+        Worker.capture_exl3_cartridge_cudagraphs(worker)
+
+    lock.assert_called_once_with()
+
+
+def test_gpu_runner_clear_cudagraphs_releases_every_graph_owner():
+    runner = object.__new__(GPUModelRunner)
+    runner.compilation_config = SimpleNamespace(cudagraph_mode=CUDAGraphMode.FULL)
+    runner.encoder_cudagraph_manager = MagicMock()
+    with (
+        patch(
+            "vllm.v1.worker.gpu_model_runner.CUDAGraphWrapper.clear_all_graphs"
+        ) as clear_graphs,
+        patch(
+            "vllm.v1.worker.gpu_model_runner.BreakableCUDAGraphWrapper.clear_all_graphs"
+        ) as clear_breakable,
+        patch("vllm.v1.worker.gpu_model_runner.unlock_workspace") as unlock,
+        patch("torch.accelerator.synchronize") as synchronize,
+        patch("torch.accelerator.empty_cache") as empty_cache,
+    ):
+        GPUModelRunner.clear_cudagraphs(runner)
+
+    clear_graphs.assert_called_once_with()
+    clear_breakable.assert_called_once_with()
+    runner.encoder_cudagraph_manager.clear.assert_called_once_with()
+    unlock.assert_called_once_with()
+    synchronize.assert_called_once_with()
+    empty_cache.assert_called_once_with()
 
 
 def test_engine_cartridge_operations_dispatch_to_every_worker():
     engine = SimpleNamespace(
         _prepare_for_exl3_weight_switch=MagicMock(),
-        collective_rpc=MagicMock(side_effect=[[10], [10], [10]]),
+        collective_rpc=MagicMock(
+            side_effect=[None, [10], [10], 123, [True], None, [10], 123]
+        ),
     )
 
     assert LLMEngine.load_exl3_cartridge(engine, "cartridge.safetensors") == [10]
     assert LLMEngine.deactivate_exl3_cartridge(engine) == [10]
     assert engine.collective_rpc.call_args_list == [
+        (("clear_exl3_cartridge_cudagraphs",), {}),
         (("prepare_exl3_cartridge",), {"args": ("cartridge.safetensors",)}),
         (("activate_exl3_cartridge",), {}),
+        (("capture_exl3_cartridge_cudagraphs",), {}),
+        (("has_exl3_cartridge",), {}),
+        (("clear_exl3_cartridge_cudagraphs",), {}),
         (("deactivate_exl3_cartridge",), {}),
+        (("capture_exl3_cartridge_cudagraphs",), {}),
     ]
+
+
+def test_engine_cartridge_deactivate_is_noop_without_runtime():
+    engine = SimpleNamespace(
+        _prepare_for_exl3_weight_switch=MagicMock(),
+        collective_rpc=MagicMock(return_value=[False, False]),
+    )
+
+    assert LLMEngine.deactivate_exl3_cartridge(engine) == [0, 0]
+    engine.collective_rpc.assert_called_once_with("has_exl3_cartridge")
+    engine._prepare_for_exl3_weight_switch.assert_not_called()
 
 
 def test_engine_cartridge_load_rolls_back_every_worker_on_commit_failure():
     engine = SimpleNamespace(
         _prepare_for_exl3_weight_switch=MagicMock(),
         collective_rpc=MagicMock(
-            side_effect=[[10, 10], RuntimeError("commit failed"), [10, 10]]
+            side_effect=[
+                None,
+                [10, 10],
+                RuntimeError("commit failed"),
+                None,
+                [10, 10],
+                123,
+            ]
         ),
     )
 
     with pytest.raises(RuntimeError, match="commit failed"):
         LLMEngine.load_exl3_cartridge(engine, "cartridge.safetensors")
 
-    assert engine.collective_rpc.call_args_list[-1] == (
-        ("deactivate_exl3_cartridge",),
-        {},
+    assert [call.args[0] for call in engine.collective_rpc.call_args_list[-3:]] == [
+        "clear_exl3_cartridge_cudagraphs",
+        "deactivate_exl3_cartridge",
+        "capture_exl3_cartridge_cudagraphs",
+    ]
+
+
+def test_engine_shuts_down_when_base_graph_restore_fails():
+    engine = SimpleNamespace(
+        _prepare_for_exl3_weight_switch=MagicMock(),
+        collective_rpc=MagicMock(
+            side_effect=[
+                None,
+                RuntimeError("load failed"),
+                RuntimeError("restore failed"),
+            ]
+        ),
+        engine_core=SimpleNamespace(shutdown=MagicMock()),
     )
+
+    with pytest.raises(RuntimeError, match="engine was shut down"):
+        LLMEngine.load_exl3_cartridge(engine, "cartridge.safetensors")
+
+    engine.engine_core.shutdown.assert_called_once_with()
 
 
 def test_sync_engine_weight_switch_requires_cache_invalidation():
@@ -650,15 +868,79 @@ def test_async_load_clears_caches_and_rolls_back_on_cancellation():
         engine.is_paused = AsyncMock(return_value=False)
         engine.pause_generation = AsyncMock()
         engine.resume_generation = AsyncMock()
-        engine.collective_rpc = AsyncMock(side_effect=[asyncio.CancelledError(), [2]])
+        engine.collective_rpc = AsyncMock(
+            side_effect=[asyncio.CancelledError(), None, [2], 123]
+        )
 
         with pytest.raises(asyncio.CancelledError):
             await AsyncLLM._load_exl3_cartridge(engine, "cartridge.safetensors")
 
         engine.pause_generation.assert_awaited_once_with(mode="wait", clear_cache=True)
-        assert engine.collective_rpc.await_args_list[-1].args == (
+        assert [call.args[0] for call in engine.collective_rpc.await_args_list] == [
+            "clear_exl3_cartridge_cudagraphs",
+            "clear_exl3_cartridge_cudagraphs",
             "deactivate_exl3_cartridge",
-        )
+            "capture_exl3_cartridge_cudagraphs",
+        ]
         engine.resume_generation.assert_awaited_once_with()
+
+    asyncio.run(run())
+
+
+def test_async_deactivate_recaptures_before_resuming():
+    async def run():
+        engine = object.__new__(AsyncLLM)
+        engine.is_paused = AsyncMock(return_value=False)
+        engine.pause_generation = AsyncMock()
+        engine.resume_generation = AsyncMock()
+        engine.collective_rpc = AsyncMock(side_effect=[[True], None, [2], 123])
+
+        assert await AsyncLLM._deactivate_exl3_cartridge(engine) == [2]
+        assert [call.args[0] for call in engine.collective_rpc.await_args_list] == [
+            "has_exl3_cartridge",
+            "clear_exl3_cartridge_cudagraphs",
+            "deactivate_exl3_cartridge",
+            "capture_exl3_cartridge_cudagraphs",
+        ]
+        engine.pause_generation.assert_awaited_once_with(mode="wait", clear_cache=True)
+        engine.resume_generation.assert_awaited_once_with()
+
+    asyncio.run(run())
+
+
+def test_async_deactivate_is_noop_without_runtime():
+    async def run():
+        engine = object.__new__(AsyncLLM)
+        engine.is_paused = AsyncMock()
+        engine.pause_generation = AsyncMock()
+        engine.collective_rpc = AsyncMock(return_value=[False, False])
+
+        assert await AsyncLLM._deactivate_exl3_cartridge(engine) == [0, 0]
+        engine.collective_rpc.assert_awaited_once_with("has_exl3_cartridge")
+        engine.is_paused.assert_not_awaited()
+        engine.pause_generation.assert_not_awaited()
+
+    asyncio.run(run())
+
+
+def test_async_load_shuts_down_when_base_graph_restore_fails():
+    async def run():
+        engine = object.__new__(AsyncLLM)
+        engine.is_paused = AsyncMock(return_value=False)
+        engine.pause_generation = AsyncMock()
+        engine.resume_generation = AsyncMock()
+        engine.shutdown = MagicMock()
+        engine.collective_rpc = AsyncMock(
+            side_effect=[
+                RuntimeError("load failed"),
+                RuntimeError("restore failed"),
+            ]
+        )
+
+        with pytest.raises(EngineDeadError):
+            await AsyncLLM._load_exl3_cartridge(engine, "cartridge.safetensors")
+
+        engine.shutdown.assert_called_once_with()
+        engine.resume_generation.assert_not_awaited()
 
     asyncio.run(run())

--- a/tests/quantization/test_exl3_lora_cartridge.py
+++ b/tests/quantization/test_exl3_lora_cartridge.py
@@ -1,132 +1,664 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-"""Tests for EXL3 LoRA cartridge support.
+"""Tests for CUDA-graph-safe EXL3 MSRT cartridges."""
 
-Tests the cartridge data structures, the _apply_expert patching mechanism,
-and the adapter loading logic. Uses mocks for the EXL3 GEMM kernel.
-"""
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import torch
-from unittest.mock import MagicMock, patch
+from safetensors.torch import save_file
 
+import vllm.model_executor.layers.quantization.exl3 as exl3_module
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+from vllm.model_executor.layers.quantization.exl3 import Exl3Config, Exl3MoEMethod
 from vllm.model_executor.layers.quantization.exl3_lora_cartridge import (
+    Exl3CUDAGraphCartridgeRuntime,
     Exl3LoraCartridge,
     apply_exl3_cartridge,
-    exl3_get_supported_lora_modules,
+    apply_exl3_cudagraph_cartridge,
     load_cartridge_from_adapter,
+    load_exl3_cartridge_into_model,
+    prepare_exl3_cudagraph_cartridge_runtime,
 )
+from vllm.v1.engine.async_llm import AsyncLLM
+from vllm.v1.engine.llm_engine import LLMEngine
+from vllm.v1.worker.gpu_worker import Worker
+
+CPU = torch.device("cpu")
 
 
-def test_get_supported_lora_modules():
-    """Test that EXL3 returns the correct LoRA-capable module names."""
-    modules = exl3_get_supported_lora_modules()
-    assert "gate_proj" in modules
-    assert "up_proj" in modules
-    assert "down_proj" in modules
-    assert len(modules) == 3
+def _runtime_layer(device: torch.device = CPU):
+    return SimpleNamespace(
+        local_num_experts=2,
+        exl3_hidden_size=4,
+        exl3_intermediate_size_per_partition=2,
+        exl3_params_dtype=torch.float16,
+        w13_trellis=SimpleNamespace(device=device),
+        activation=SimpleNamespace(value="silu"),
+        layer_name="model.layers.3.mlp.experts",
+    )
 
 
-def test_cartridge_init():
-    """Test Exl3LoraCartridge initialization."""
-    cart = Exl3LoraCartridge(num_stages=2, num_experts=256, device=torch.device("cpu"))
-    assert cart.num_stages == 2
-    assert cart.num_experts == 256
-    assert not cart.active
-    assert len(cart.stages) == 2
-    assert all(isinstance(s, dict) for s in cart.stages)
+def _loader_layer():
+    layer = _runtime_layer()
+    layer.exl3_hidden_size = 16
+    layer.exl3_intermediate_size_per_partition = 16
+    return layer
 
 
-def test_cartridge_set_get_tensors():
-    """Test setting and getting cartridge tensors."""
-    cart = Exl3LoraCartridge(num_stages=1, num_experts=4, device=torch.device("cpu"))
-    trellis = torch.zeros(8, 16, 32, dtype=torch.int16)
-    suh = torch.ones(128, dtype=torch.float16)
-    svh = torch.ones(64, dtype=torch.float16)
-    scale = 2.5
-
-    cart.set_stage_tensors(0, 0, "w1", trellis, suh, svh, scale)
-    result = cart.get_stage_tensors(0, 0, "w1")
-    assert result is not None
-    assert torch.equal(result["trellis"], trellis)
-    assert result["scale"] == 2.5
-
-    # Non-existent expert
-    assert cart.get_stage_tensors(0, 1, "w1") is None
-
-
-def test_cartridge_clear():
-    """Test clearing cartridge tensors."""
-    cart = Exl3LoraCartridge(num_stages=1, num_experts=4, device=torch.device("cpu"))
-    cart.set_stage_tensors(0, 0, "w1", torch.zeros(8, 16, 32, dtype=torch.int16),
-                           torch.ones(128, dtype=torch.float16),
-                           torch.ones(64, dtype=torch.float16), 1.0)
-    cart.active = True
-    cart.clear()
-    assert not cart.active
-    assert len(cart.stages[0]) == 0
+def _cartridge(device: torch.device = CPU):
+    cartridge = Exl3LoraCartridge(1, 2, device)
+    for expert_id in range(2):
+        for shard_id in ("w1", "w3", "w2"):
+            cartridge.set_stage_tensors(
+                0,
+                expert_id,
+                shard_id,
+                torch.zeros(1, 1, 16, dtype=torch.int16),
+                torch.ones(1, dtype=torch.float16),
+                torch.ones(1, dtype=torch.float16),
+                1.0,
+            )
+    cartridge.active = True
+    return cartridge
 
 
-def test_apply_cartridge_noop():
-    """Test that apply_exl3_cartridge is a no-op when cartridge is None or inactive."""
-    base_output = torch.randn(4, 64, dtype=torch.float16)
-    x = torch.randn(4, 128, dtype=torch.float16)
-    layer = MagicMock()
-
-    # No cartridge
-    result = apply_exl3_cartridge(base_output, x, layer, "w13", 0, "w1", None)
-    assert torch.equal(result, base_output)
-
-    # Inactive cartridge
-    cart = Exl3LoraCartridge(1, 4, torch.device("cpu"))
-    result = apply_exl3_cartridge(base_output, x, layer, "w13", 0, "w1", cart)
-    assert torch.equal(result, base_output)
+def test_config_requires_explicit_cartridge_runtime():
+    assert not Exl3Config.from_config({}).cartridge_runtime
+    assert Exl3Config.from_config({"cartridge_runtime": True}).cartridge_runtime
+    with pytest.raises(TypeError, match="must be a boolean"):
+        Exl3Config.from_config({"cartridge_runtime": 1})
 
 
-def test_apply_cartridge_with_stage():
-    """Test that apply_exl3_cartridge applies correction when cartridge is active."""
-    base_output = torch.randn(4, 64, dtype=torch.float16)
-    x = torch.randn(4, 128, dtype=torch.float16)
-    layer = MagicMock()
-    cart = Exl3LoraCartridge(1, 4, torch.device("cpu"))
-    cart.active = True
-    cart.set_stage_tensors(0, 0, "w1",
-                           torch.zeros(8, 16, 32, dtype=torch.int16),
-                           torch.ones(128, dtype=torch.float16),
-                           torch.ones(64, dtype=torch.float16),
-                           1.0)
-
-    with patch("vllm.model_executor.layers.quantization.exl3_lora_cartridge._exl3_gemm") as mock_gemm:
-        mock_gemm.return_value = torch.ones(4, 64, dtype=torch.float16)
-        result = apply_exl3_cartridge(base_output, x, layer, "w13", 0, "w1", cart)
-        # Should be base + cartridge_output * (1/scale) = base + ones * 1.0
-        expected = base_output + torch.ones(4, 64, dtype=torch.float16)
-        assert torch.allclose(result, expected, rtol=1e-5)
-        mock_gemm.assert_called_once()
+def test_runtime_rejects_tensor_parallel_weights():
+    layer = _runtime_layer()
+    layer.exl3_tp_size = 2
+    with pytest.raises(NotImplementedError, match="tensor_parallel_size=1"):
+        prepare_exl3_cudagraph_cartridge_runtime(layer)
 
 
-def test_cartridge_scale_correction():
-    """Test that rescaling factor is applied correctly."""
-    base_output = torch.zeros(4, 64, dtype=torch.float16)
-    x = torch.randn(4, 128, dtype=torch.float16)
-    layer = MagicMock()
-    cart = Exl3LoraCartridge(1, 4, torch.device("cpu"))
-    cart.active = True
-    scale = 3.0  # output should be cartridge_output / 3.0
-    cart.set_stage_tensors(0, 0, "w1",
-                           torch.zeros(8, 16, 32, dtype=torch.int16),
-                           torch.ones(128, dtype=torch.float16),
-                           torch.ones(64, dtype=torch.float16),
-                           scale)
-
-    with patch("vllm.model_executor.layers.quantization.exl3_lora_cartridge._exl3_gemm") as mock_gemm:
-        mock_gemm.return_value = torch.full((4, 64), 9.0, dtype=torch.float16)
-        result = apply_exl3_cartridge(base_output, x, layer, "w13", 0, "w1", cart)
-        # Should be 0 + 9.0 / 3.0 = 3.0
-        expected = torch.full((4, 64), 3.0, dtype=torch.float16)
-        assert torch.allclose(result, expected, rtol=1e-5)
+def test_runtime_preserves_fp16_dense_kernel_contract():
+    layer = _runtime_layer()
+    layer.exl3_params_dtype = torch.bfloat16
+    runtime = prepare_exl3_cudagraph_cartridge_runtime(layer)
+    assert runtime.dtype == torch.float16
+    assert runtime.w13.dtype == torch.float16
+    assert runtime.w2.dtype == torch.float16
 
 
-if __name__ == "__main__":
-    pytest.main([__file__, "-v"])
+def test_runtime_rejects_activation_before_materialization():
+    runtime = prepare_exl3_cudagraph_cartridge_runtime(_runtime_layer())
+    with pytest.raises(RuntimeError, match="unmaterialized"):
+        runtime.activate()
+
+
+def test_cartridge_validates_indices_and_scale():
+    cartridge = Exl3LoraCartridge(1, 2, torch.device("cpu"))
+    tensors = (
+        torch.zeros(1, 1, 16, dtype=torch.int16),
+        torch.ones(1, dtype=torch.float16),
+        torch.ones(1, dtype=torch.float16),
+    )
+    with pytest.raises(IndexError, match="stage index"):
+        cartridge.set_stage_tensors(1, 0, "w1", *tensors, 1.0)
+    with pytest.raises(IndexError, match="expert index"):
+        cartridge.set_stage_tensors(0, 2, "w1", *tensors, 1.0)
+    with pytest.raises(ValueError, match="unsupported EXL3 shard"):
+        cartridge.set_stage_tensors(0, 0, "bad", *tensors, 1.0)
+    with pytest.raises(ValueError, match="finite and positive"):
+        cartridge.set_stage_tensors(0, 0, "w1", *tensors, 0.0)
+
+
+def test_apply_cartridge_sums_stages_with_scale():
+    base_output = torch.zeros(4, 2, dtype=torch.float16)
+    inputs = torch.randn(4, 4, dtype=torch.float16)
+    cartridge = Exl3LoraCartridge(2, 1, torch.device("cpu"))
+    for stage, scale in enumerate((2.0, 4.0)):
+        cartridge.set_stage_tensors(
+            stage,
+            0,
+            "w1",
+            torch.zeros(1, 1, 16, dtype=torch.int16),
+            torch.ones(4, dtype=torch.float16),
+            torch.ones(2, dtype=torch.float16),
+            scale,
+        )
+    cartridge.active = True
+
+    with patch(
+        "vllm.model_executor.layers.quantization.exl3_lora_cartridge._exl3_gemm",
+        return_value=torch.full((4, 16), 8.0, dtype=torch.float16),
+    ) as gemm:
+        result = apply_exl3_cartridge(
+            base_output, inputs, None, "w13", 0, "w1", cartridge
+        )
+
+    assert torch.equal(result, torch.full((4, 2), 6.0, dtype=torch.float32))
+    assert gemm.call_count == 2
+    assert gemm.call_args.args[0].shape == (4, 16)
+
+
+def test_runtime_materializes_exact_combined_projection_weights():
+    layer = _runtime_layer()
+    runtime = Exl3CUDAGraphCartridgeRuntime(layer)
+    cartridge = _cartridge()
+
+    def base_projection(_layer, group, inputs, _expert_id, shard_id):
+        value = {"w1": 1.0, "w3": 2.0, "w2": 3.0}[shard_id]
+        width = 4 if group == "w2" else 2
+        return torch.full((inputs.shape[0], width), value, dtype=torch.float16)
+
+    def residual_projection(inputs, trellis, *_args, **_kwargs):
+        return torch.ones((inputs.shape[0], trellis.shape[1] * 16), dtype=torch.float16)
+
+    with (
+        patch.object(
+            __import__(
+                "vllm.model_executor.layers.quantization.exl3_lora_cartridge",
+                fromlist=["Exl3MoEMethod"],
+            ).Exl3MoEMethod,
+            "_apply_expert",
+            side_effect=base_projection,
+        ),
+        patch(
+            "vllm.model_executor.layers.quantization.exl3_lora_cartridge._exl3_gemm",
+            side_effect=residual_projection,
+        ),
+    ):
+        runtime.materialize(layer, cartridge)
+
+    assert torch.equal(runtime.w13[:, :2], torch.full((2, 2, 4), 2.0))
+    assert torch.equal(runtime.w13[:, 2:], torch.full((2, 2, 4), 3.0))
+    assert torch.equal(runtime.w2, torch.full((2, 4, 2), 4.0))
+    assert runtime.active.item() == 0.0
+
+
+def test_runtime_rejects_nonfinite_materialized_weights():
+    layer = _runtime_layer()
+    runtime = Exl3CUDAGraphCartridgeRuntime(layer)
+    cartridge = _cartridge()
+    for stage in cartridge.stages:
+        for tensors in stage.values():
+            tensors["scale"] = 1e-30
+
+    def base_projection(_layer, group, inputs, _expert_id, _shard_id):
+        width = 4 if group == "w2" else 2
+        return torch.zeros((inputs.shape[0], width), dtype=torch.float16)
+
+    with (
+        patch.object(
+            __import__(
+                "vllm.model_executor.layers.quantization.exl3_lora_cartridge",
+                fromlist=["Exl3MoEMethod"],
+            ).Exl3MoEMethod,
+            "_apply_expert",
+            side_effect=base_projection,
+        ),
+        patch(
+            "vllm.model_executor.layers.quantization.exl3_lora_cartridge._exl3_gemm",
+            side_effect=lambda inputs, *_args, **_kwargs: torch.ones(
+                (inputs.shape[0], 16), dtype=torch.float16
+            ),
+        ),
+        pytest.raises(ValueError, match="non-finite weights"),
+    ):
+        runtime.materialize(layer, cartridge)
+
+    assert runtime.active.item() is False
+    assert not runtime._materialized
+
+
+def test_cartridge_runtime_rejects_data_parallel_creation(monkeypatch):
+    method = object.__new__(Exl3MoEMethod)
+    method.moe = SimpleNamespace(
+        moe_parallel_config=SimpleNamespace(use_ep=False, tp_rank=0, tp_size=1),
+        has_bias=False,
+    )
+    method.quant_config = SimpleNamespace(
+        rank_sliced_metadata={"tp": 1, "experts_per_layer": 2},
+        cartridge_runtime=True,
+    )
+    config = SimpleNamespace(
+        parallel_config=SimpleNamespace(data_parallel_size=2),
+        scheduler_config=SimpleNamespace(max_num_batched_tokens=16),
+        model_config=SimpleNamespace(runner_type="generate"),
+    )
+    monkeypatch.setattr(exl3_module, "get_current_vllm_config_or_none", lambda: config)
+
+    with pytest.raises(NotImplementedError, match="data_parallel_size=1"):
+        method.create_weights(
+            SimpleNamespace(layer_name="model.layers.3.mlp.experts"),
+            num_experts=2,
+            hidden_size=128,
+            intermediate_size_per_partition=128,
+            params_dtype=torch.float16,
+        )
+
+
+def test_create_weights_stamps_draft_layer_cartridge_disabled(monkeypatch):
+    method = object.__new__(Exl3MoEMethod)
+    method.moe = SimpleNamespace(
+        moe_parallel_config=SimpleNamespace(use_ep=False, tp_rank=0, tp_size=1),
+        has_bias=False,
+    )
+    method.quant_config = SimpleNamespace(
+        rank_sliced_metadata={"tp": 1, "experts_per_layer": 2},
+        cartridge_runtime=True,
+        rank_sliced_layer_bitrates=MagicMock(return_value=(2, 2)),
+    )
+    config = SimpleNamespace(
+        parallel_config=SimpleNamespace(data_parallel_size=1),
+        scheduler_config=SimpleNamespace(max_num_batched_tokens=16),
+        model_config=SimpleNamespace(runner_type="draft"),
+    )
+    monkeypatch.setattr(exl3_module, "get_current_vllm_config_or_none", lambda: config)
+    monkeypatch.setattr(exl3_module, "Exl3MoEParameter", MagicMock())
+    layer = SimpleNamespace(
+        layer_name="model.layers.3.mlp.experts",
+        register_parameter=MagicMock(),
+    )
+
+    method.create_weights(
+        layer,
+        num_experts=2,
+        hidden_size=128,
+        intermediate_size_per_partition=128,
+        params_dtype=torch.float16,
+    )
+
+    assert layer.exl3_is_draft is True
+    assert layer.exl3_cartridge_enabled is False
+
+
+def test_rank_sliced_draft_layer_skips_cartridge_path():
+    method = object.__new__(Exl3MoEMethod)
+    method.quant_config = SimpleNamespace(
+        rank_sliced_metadata={"tp": 1},
+        cartridge_runtime=True,
+    )
+    method._apply_rank_sliced = MagicMock(
+        return_value=torch.ones(2, 4, dtype=torch.float16)
+    )
+    layer = SimpleNamespace(
+        activation=MoEActivation.SILU,
+        expert_map=None,
+        apply_router_weight_on_input=False,
+        exl3_cartridge_enabled=False,
+    )
+    x = torch.ones(2, 4, dtype=torch.float16)
+    weights = torch.ones(2, 1, dtype=torch.float32)
+    ids = torch.zeros(2, 1, dtype=torch.long)
+
+    with patch(
+        "vllm.model_executor.layers.quantization.exl3_lora_cartridge."
+        "apply_exl3_cudagraph_cartridge"
+    ) as cartridge:
+        output = method.apply(layer, x, weights, ids, None, None)
+
+    assert output.shape == (2, 4)
+    cartridge.assert_not_called()
+
+
+def test_graph_path_uses_device_scalar_without_host_branch():
+    layer = _runtime_layer()
+    runtime = prepare_exl3_cudagraph_cartridge_runtime(layer)
+    base = torch.full((3, 4), 2.0, dtype=torch.float16)
+    dense = torch.full((3, 4), torch.nan, dtype=torch.float16)
+    inputs = torch.zeros(3, 4, dtype=torch.float16)
+    weights = torch.ones(3, 1, dtype=torch.float32)
+    ids = torch.tensor([[1], [0], [1]], dtype=torch.long)
+
+    with patch(
+        "vllm.model_executor.layers.quantization.exl3_lora_cartridge.fused_experts",
+        return_value=dense,
+    ) as fused:
+        runtime.deactivate()
+        inactive = apply_exl3_cudagraph_cartridge(base, inputs, weights, ids, layer)
+        runtime.active.fill_(1)
+        active = apply_exl3_cudagraph_cartridge(base, inputs, weights, ids, layer)
+
+    assert torch.equal(inactive, base)
+    assert torch.isnan(active).all()
+    assert fused.call_count == 2
+    assert torch.equal(fused.call_args_list[0].args[4], torch.zeros_like(ids))
+    assert torch.equal(fused.call_args_list[1].args[4], ids)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_device_activation_replays_real_fused_moe_in_one_cuda_graph():
+    device = torch.device("cuda")
+    layer = _loader_layer()
+    layer.w13_trellis.device = device
+    runtime = prepare_exl3_cudagraph_cartridge_runtime(layer)
+    base = torch.full((3, 16), 2.0, dtype=torch.float16, device=device)
+    inputs = torch.ones(3, 16, dtype=torch.float16, device=device)
+    weights = torch.ones(3, 1, dtype=torch.float32, device=device)
+    ids = torch.zeros(3, 1, dtype=torch.long, device=device)
+
+    runtime.w13.fill_(0.1)
+    runtime.w2.fill_(0.1)
+    apply_exl3_cudagraph_cartridge(base, inputs, weights, ids, layer)
+    w13_pointer = runtime.w13.data_ptr()
+    w2_pointer = runtime.w2.data_ptr()
+
+    graph = torch.cuda.CUDAGraph()
+    runtime.deactivate()
+    torch.cuda.synchronize()
+    with torch.cuda.graph(graph):
+        output = apply_exl3_cudagraph_cartridge(base, inputs, weights, ids, layer)
+    graph.replay()
+    torch.cuda.synchronize()
+    assert torch.equal(output, base)
+
+    runtime.w13.fill_(0.2)
+    runtime._materialized = True
+    runtime.w2.fill_(0.2)
+    runtime.activate()
+    graph.replay()
+    torch.cuda.synchronize()
+    assert not torch.equal(output, base)
+    assert runtime.w13.data_ptr() == w13_pointer
+    assert runtime.w2.data_ptr() == w2_pointer
+
+    runtime.w13.fill_(torch.nan)
+    runtime.deactivate()
+    graph.replay()
+    torch.cuda.synchronize()
+    assert torch.equal(output, base)
+
+
+def test_loader_filters_layer_and_sorts_stage_numbers(tmp_path):
+    path = tmp_path / "cartridge.safetensors"
+
+    def tensors_for(layer: int, value: int):
+        tensors = {}
+        for projection in ("gate_proj", "up_proj", "down_proj"):
+            prefix = f"model.layers.{layer}.mlp.experts.0.{projection}.rank0"
+            tensors.update(
+                {
+                    f"{prefix}.trellis_res{value}": torch.full(
+                        (8, 8, 32), value, dtype=torch.int16
+                    ),
+                    f"{prefix}.suh_res{value}": torch.ones(128, dtype=torch.float16),
+                    f"{prefix}.svh_res{value}": torch.ones(128, dtype=torch.float16),
+                    f"{prefix}.scale_res{value}": torch.tensor(float(value)),
+                }
+            )
+        return tensors
+
+    tensors = {}
+    tensors.update(tensors_for(3, 10))
+    tensors.update(tensors_for(3, 2))
+    tensors.update(tensors_for(4, 1))
+    save_file(tensors, path)
+
+    cartridge = load_cartridge_from_adapter(
+        str(path), _loader_layer(), 2, torch.device("cpu")
+    )
+
+    assert cartridge is not None
+    assert cartridge.num_stages == 2
+    stage0 = cartridge.get_stage_tensors(0, 0, "w1")
+    stage1 = cartridge.get_stage_tensors(1, 0, "w1")
+    assert stage0 is not None and stage0["scale"] == 2.0
+    assert stage1 is not None and stage1["scale"] == 10.0
+
+
+def test_loader_rejects_incomplete_projection(tmp_path):
+    path = tmp_path / "broken.safetensors"
+    save_file(
+        {
+            "model.layers.3.mlp.experts.0.gate_proj.rank0.trellis_res1": (
+                torch.zeros(8, 8, 32, dtype=torch.int16)
+            ),
+            "model.layers.3.mlp.experts.0.gate_proj.rank0.suh_res1": (
+                torch.ones(128, dtype=torch.float16)
+            ),
+        },
+        path,
+    )
+
+    with pytest.raises(ValueError, match="Incomplete MSRT cartridge"):
+        load_cartridge_from_adapter(str(path), _loader_layer(), 2, CPU)
+
+
+def test_loader_rejects_invalid_trellis_shape(tmp_path):
+    path = tmp_path / "invalid-shape.safetensors"
+    prefix = "model.layers.3.mlp.experts.0"
+    tensors = {}
+    for projection in ("gate_proj", "up_proj", "down_proj"):
+        tensor_prefix = f"{prefix}.{projection}.rank0"
+        tensors[f"{tensor_prefix}.trellis_res1"] = torch.zeros(
+            8, 8, 15 if projection == "gate_proj" else 32, dtype=torch.int16
+        )
+        tensors[f"{tensor_prefix}.suh_res1"] = torch.ones(128, dtype=torch.float16)
+        tensors[f"{tensor_prefix}.svh_res1"] = torch.ones(128, dtype=torch.float16)
+    save_file(tensors, path)
+
+    with pytest.raises(ValueError, match="Invalid MSRT cartridge trellis"):
+        load_cartridge_from_adapter(str(path), _loader_layer(), 2, CPU)
+
+
+def test_loader_rejects_oversized_packed_dimensions(tmp_path):
+    path = tmp_path / "oversized.safetensors"
+    prefix = "model.layers.3.mlp.experts.0"
+    tensors = {}
+    for projection in ("gate_proj", "up_proj", "down_proj"):
+        tensor_prefix = f"{prefix}.{projection}.rank0"
+        tensors[f"{tensor_prefix}.trellis_res1"] = torch.zeros(
+            16, 8, 32, dtype=torch.int16
+        )
+        tensors[f"{tensor_prefix}.suh_res1"] = torch.ones(256, dtype=torch.float16)
+        tensors[f"{tensor_prefix}.svh_res1"] = torch.ones(128, dtype=torch.float16)
+    save_file(tensors, path)
+
+    with pytest.raises(ValueError, match="128-aligned logical shape"):
+        load_cartridge_from_adapter(str(path), _loader_layer(), 2, CPU)
+
+
+def test_loader_rejects_malformed_target_key(tmp_path):
+    path = tmp_path / "malformed.safetensors"
+    save_file(
+        {
+            "model.layers.3.mlp.experts.0.gate_proj.rankx.trellis_res1": (
+                torch.zeros(1, 1, 16, dtype=torch.int16)
+            )
+        },
+        path,
+    )
+
+    with pytest.raises(ValueError, match="Malformed MSRT cartridge key"):
+        load_cartridge_from_adapter(str(path), _loader_layer(), 2, CPU)
+
+
+def test_model_loader_preflights_every_layer_before_materializing():
+    layers = [_runtime_layer(), _runtime_layer()]
+    layers[1].layer_name = "model.layers.4.mlp.experts"
+    for layer in layers:
+        prepare_exl3_cudagraph_cartridge_runtime(layer)
+    model = SimpleNamespace(modules=lambda: iter(layers))
+
+    with (
+        patch(
+            "vllm.model_executor.layers.quantization.exl3_lora_cartridge."
+            "load_cartridge_from_adapter",
+            side_effect=[_cartridge(), None],
+        ),
+        patch.object(layers[0]._exl3_cartridge_runtime, "materialize") as materialize,
+        pytest.raises(ValueError, match="has no tensors"),
+    ):
+        load_exl3_cartridge_into_model(model, "cartridge.safetensors")
+
+    materialize.assert_not_called()
+
+
+def test_model_loader_deactivates_every_layer_after_materialization_failure():
+    layers = [_runtime_layer(), _runtime_layer()]
+    layers[1].layer_name = "model.layers.4.mlp.experts"
+    runtimes = [prepare_exl3_cudagraph_cartridge_runtime(layer) for layer in layers]
+    model = SimpleNamespace(modules=lambda: iter(layers))
+
+    def activate(_layer, _cartridge):
+        runtimes[0].active.fill_(1)
+
+    with (
+        patch(
+            "vllm.model_executor.layers.quantization.exl3_lora_cartridge."
+            "load_cartridge_from_adapter",
+            side_effect=[_cartridge(), _cartridge()],
+        ),
+        patch.object(runtimes[0], "materialize", side_effect=activate),
+        patch.object(
+            runtimes[1],
+            "materialize",
+            MagicMock(side_effect=RuntimeError("decode failed")),
+        ),
+        pytest.raises(RuntimeError, match="decode failed"),
+    ):
+        load_exl3_cartridge_into_model(model, "cartridge.safetensors")
+
+    assert all(runtime.active.item() == 0.0 for runtime in runtimes)
+
+
+def test_model_loader_activates_every_layer_only_after_materialization():
+    layers = [_runtime_layer(), _runtime_layer()]
+    layers[1].layer_name = "model.layers.4.mlp.experts"
+    runtimes = [prepare_exl3_cudagraph_cartridge_runtime(layer) for layer in layers]
+    model = SimpleNamespace(modules=lambda: iter(layers))
+
+    def mark_materialized(_layer, _cartridge):
+        for runtime in runtimes:
+            if not runtime._materialized:
+                runtime._materialized = True
+                return
+
+    with (
+        patch(
+            "vllm.model_executor.layers.quantization.exl3_lora_cartridge."
+            "load_cartridge_from_adapter",
+            side_effect=[_cartridge(), _cartridge()],
+        ),
+        patch.object(runtimes[0], "materialize", side_effect=mark_materialized),
+        patch.object(runtimes[1], "materialize", side_effect=mark_materialized),
+    ):
+        assert load_exl3_cartridge_into_model(model, "cartridge.safetensors") == 2
+
+    assert all(runtime.active.item() == 1.0 for runtime in runtimes)
+
+
+def test_worker_cartridge_operations_use_collective_rpc_target_model():
+    model = SimpleNamespace()
+    worker = SimpleNamespace(model_runner=SimpleNamespace(model=model))
+    with (
+        patch(
+            "vllm.model_executor.layers.quantization.exl3_lora_cartridge."
+            "prepare_exl3_cartridge_into_model",
+            return_value=10,
+        ) as prepare,
+        patch(
+            "vllm.model_executor.layers.quantization.exl3_lora_cartridge."
+            "activate_exl3_cartridge",
+            return_value=10,
+        ) as activate,
+        patch(
+            "vllm.model_executor.layers.quantization.exl3_lora_cartridge."
+            "deactivate_exl3_cartridge",
+            return_value=10,
+        ) as deactivate,
+    ):
+        assert Worker.prepare_exl3_cartridge(worker, "cartridge.safetensors") == 10
+        assert Worker.activate_exl3_cartridge(worker) == 10
+        assert Worker.deactivate_exl3_cartridge(worker) == 10
+
+    prepare.assert_called_once_with(model, "cartridge.safetensors")
+    activate.assert_called_once_with(model)
+    deactivate.assert_called_once_with(model)
+
+
+def test_engine_cartridge_operations_dispatch_to_every_worker():
+    engine = SimpleNamespace(
+        _prepare_for_exl3_weight_switch=MagicMock(),
+        collective_rpc=MagicMock(side_effect=[[10], [10], [10]]),
+    )
+
+    assert LLMEngine.load_exl3_cartridge(engine, "cartridge.safetensors") == [10]
+    assert LLMEngine.deactivate_exl3_cartridge(engine) == [10]
+    assert engine.collective_rpc.call_args_list == [
+        (("prepare_exl3_cartridge",), {"args": ("cartridge.safetensors",)}),
+        (("activate_exl3_cartridge",), {}),
+        (("deactivate_exl3_cartridge",), {}),
+    ]
+
+
+def test_engine_cartridge_load_rolls_back_every_worker_on_commit_failure():
+    engine = SimpleNamespace(
+        _prepare_for_exl3_weight_switch=MagicMock(),
+        collective_rpc=MagicMock(
+            side_effect=[[10, 10], RuntimeError("commit failed"), [10, 10]]
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="commit failed"):
+        LLMEngine.load_exl3_cartridge(engine, "cartridge.safetensors")
+
+    assert engine.collective_rpc.call_args_list[-1] == (
+        ("deactivate_exl3_cartridge",),
+        {},
+    )
+
+
+def test_sync_engine_weight_switch_requires_cache_invalidation():
+    engine = SimpleNamespace(
+        has_unfinished_requests=MagicMock(return_value=False),
+        reset_prefix_cache=MagicMock(return_value=True),
+        reset_mm_cache=MagicMock(),
+        reset_encoder_cache=MagicMock(),
+    )
+
+    LLMEngine._prepare_for_exl3_weight_switch(engine)
+
+    engine.reset_prefix_cache.assert_called_once_with(
+        reset_running_requests=True, reset_connector=True
+    )
+    engine.reset_mm_cache.assert_called_once_with()
+    engine.reset_encoder_cache.assert_called_once_with()
+
+
+def test_sync_engine_weight_switch_refuses_active_requests():
+    engine = SimpleNamespace(has_unfinished_requests=MagicMock(return_value=True))
+
+    with pytest.raises(RuntimeError, match="quiescent"):
+        LLMEngine._prepare_for_exl3_weight_switch(engine)
+
+
+def test_sync_engine_weight_switch_refuses_failed_cache_reset():
+    engine = SimpleNamespace(
+        has_unfinished_requests=MagicMock(return_value=False),
+        reset_prefix_cache=MagicMock(return_value=False),
+    )
+
+    with pytest.raises(RuntimeError, match="Unable to clear prefix cache"):
+        LLMEngine._prepare_for_exl3_weight_switch(engine)
+
+
+def test_async_load_clears_caches_and_rolls_back_on_cancellation():
+    async def run():
+        engine = object.__new__(AsyncLLM)
+        engine.is_paused = AsyncMock(return_value=False)
+        engine.pause_generation = AsyncMock()
+        engine.resume_generation = AsyncMock()
+        engine.collective_rpc = AsyncMock(side_effect=[asyncio.CancelledError(), [2]])
+
+        with pytest.raises(asyncio.CancelledError):
+            await AsyncLLM._load_exl3_cartridge(engine, "cartridge.safetensors")
+
+        engine.pause_generation.assert_awaited_once_with(mode="wait", clear_cache=True)
+        assert engine.collective_rpc.await_args_list[-1].args == (
+            "deactivate_exl3_cartridge",
+        )
+        engine.resume_generation.assert_awaited_once_with()
+
+    asyncio.run(run())

--- a/tests/quantization/test_exl3_lora_cartridge.py
+++ b/tests/quantization/test_exl3_lora_cartridge.py
@@ -4,14 +4,20 @@
 """Tests for CUDA-graph-safe EXL3 MSRT cartridges."""
 
 import asyncio
+import hashlib
+import json
+import os
+import re
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import torch
-from safetensors.torch import save_file
+from safetensors.torch import save_file as _save_file
 
 import vllm.model_executor.layers.quantization.exl3 as exl3_module
+import vllm.model_executor.layers.quantization.exl3_lora_cartridge as cartridge_module
 from vllm.config import CUDAGraphMode
 from vllm.config.compilation import CompilationMode
 from vllm.model_executor.layers.fused_moe.activation import MoEActivation
@@ -20,11 +26,8 @@ from vllm.model_executor.layers.quantization.exl3_lora_cartridge import (
     Exl3CUDAGraphCartridgeRuntime,
     Exl3LoraCartridge,
     apply_exl3_cudagraph_cartridge,
-    deactivate_exl3_cartridge,
-    load_cartridge_from_adapter,
-    load_exl3_cartridge_into_model,
-    prepare_exl3_cartridge_into_model,
     prepare_exl3_cudagraph_cartridge_runtime,
+    stage_exl3_cartridge_adapter,
 )
 from vllm.v1.engine.async_llm import AsyncLLM
 from vllm.v1.engine.exceptions import EngineDeadError
@@ -33,6 +36,214 @@ from vllm.v1.worker.gpu_model_runner import GPUModelRunner
 from vllm.v1.worker.gpu_worker import Worker
 
 CPU = torch.device("cpu")
+BASE_COMPATIBILITY_SHA256 = "a" * 64
+
+
+def _canonical_tensor_record(name, tensor):
+    logical_name = re.sub(r"\.rank0(?=\.)", "", name)
+    raw = tensor.contiguous().view(-1).view(torch.uint8).numpy().tobytes()
+    dtype = {
+        torch.float16: "F16",
+        torch.float32: "F32",
+        torch.int16: "I16",
+        torch.int32: "I32",
+    }[tensor.dtype]
+    return {
+        "name": logical_name,
+        "dtype": dtype,
+        "shape": list(tensor.shape),
+        "sha256": hashlib.sha256(raw).hexdigest(),
+    }
+
+
+def _rank_sliced_metadata(tensors_by_layer):
+    compatibility_by_layer = {}
+    for layer, tensors in tensors_by_layer.items():
+        records = [
+            _canonical_tensor_record(name, tensor) for name, tensor in tensors.items()
+        ]
+        payload = {
+            "schema": "fq-msrt-base-layer-compatibility/1",
+            "k": 2,
+            "layer": layer,
+            "tensors": sorted(records, key=lambda record: record["name"]),
+        }
+        encoded = json.dumps(
+            payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+        ).encode()
+        compatibility_by_layer[str(layer)] = hashlib.sha256(encoded).hexdigest()
+    coverage = sorted(tensors_by_layer)
+    root_payload = {
+        "schema": "fq-msrt-base-compatibility/2",
+        "k": 2,
+        "layers": compatibility_by_layer,
+    }
+    encoded_root = json.dumps(
+        root_payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    ).encode()
+    return {
+        "format": "exl3-trellis",
+        "runtime_profile": "exl3-msrt-base/1",
+        "bits": 2,
+        "codebook": "mcg",
+        "experts_per_layer": 2,
+        "moe_layers": [coverage[0], coverage[-1]],
+        "moe_layer_coverage": coverage,
+        "tensor_schema": (
+            "model.layers.{L}.mlp.experts.{E}.{proj}.rank{r}.{trellis|suh|svh|mcg}"
+        ),
+        "tensor_parallel": dict(exl3_module._RANK_SLICED_FULL_TP),
+        "mcg_multiplier": 3417055213,
+        "compatibility_by_layer": compatibility_by_layer,
+        "compatibility_sha256": hashlib.sha256(encoded_root).hexdigest(),
+    }
+
+
+def _producer_valid_base_layer(layer=3):
+    tensors = {}
+    for projection in ("gate_proj", "up_proj", "down_proj"):
+        prefix = f"model.layers.{layer}.mlp.experts.0.{projection}.rank0"
+        tensors[f"{prefix}.trellis"] = torch.zeros(8, 8, 32, dtype=torch.int16)
+        tensors[f"{prefix}.suh"] = torch.zeros(128, dtype=torch.float16)
+        tensors[f"{prefix}.svh"] = torch.zeros(128, dtype=torch.float16)
+        tensors[f"{prefix}.mcg"] = torch.tensor(-877912083, dtype=torch.int32)
+    return tensors
+
+
+def save_file(tensors, path, *, layout=None):
+    """Write one test shard and its required v3 adapter contract."""
+    path = Path(path)
+    _save_file(tensors, path)
+    labels = {key.rsplit(".trellis_", 1)[1] for key in tensors if ".trellis_" in key}
+
+    def stage_key(label):
+        match = re.match(r"^(.*?)(\d+)$", label)
+        return (match.group(1), int(match.group(2))) if match else (label, -1)
+
+    ordered = sorted(labels, key=stage_key)
+    ranks = {
+        int(match.group(1))
+        for key in tensors
+        if (match := re.search(r"\.rank(\d+)\.", key))
+    }
+    rank_sharded = layout == "rank-sharded" or (
+        layout is None and bool(ranks) and ranks != {0}
+    )
+    parent = "k2"
+    chain = []
+    for label in ordered:
+        trellis = next(
+            tensor
+            for key, tensor in tensors.items()
+            if key.endswith(f".trellis_{label}")
+        )
+        chain.append(
+            {
+                "label": label,
+                "k": max(1, trellis.shape[-1] // 16),
+                "parent": parent,
+                "experts": "all",
+            }
+        )
+        parent = label
+    digest = hashlib.sha256(path.read_bytes()).hexdigest()
+    coverage = {}
+    selected_layers = set()
+    selected_experts = set()
+    for key in tensors:
+        target = re.match(
+            r"^model\.layers\.(\d+)\.mlp\.experts\.(\d+)\.",
+            key,
+        )
+        if target is None or ".trellis_" not in key:
+            continue
+        layer_id, expert_id = map(int, target.groups())
+        label = key.rsplit(".trellis_", 1)[1]
+        selected_layers.add(layer_id)
+        selected_experts.add(expert_id)
+        by_layer = coverage.setdefault(label, {})
+        by_layer.setdefault(str(layer_id), set()).add(expert_id)
+    coverage = {
+        label: {
+            layer_id: sorted(experts) for layer_id, experts in sorted(by_layer.items())
+        }
+        for label, by_layer in sorted(
+            coverage.items(), key=lambda item: stage_key(item[0])
+        )
+    }
+    config = {
+        "schema": "fq-cartridge-adapter/3",
+        "assembly": "test",
+        "format": "exl3-msrt-packed",
+        "runtime_profile": "exl3-msrt-additive/1",
+        "rotation_ownership": "base",
+        "standard_lora_compatible": False,
+        "codebook": "mcg",
+        "mcg_ownership": "adapter-config",
+        "runtime_operation": ("base_exl3_gemm + sum(stage_exl3_gemm / stage_scale)"),
+        "mcg_multiplier": 3417055213,
+        "scale_shape": [],
+        "base": {
+            "label": "k2",
+            "k": 2,
+            "compatibility_sha256": BASE_COMPATIBILITY_SHA256,
+            "compatibility_by_layer": {
+                str(layer): "b" * 64 for layer in sorted(selected_layers)
+            },
+        },
+        "chain": chain,
+        "tensor_parallel": {
+            "layout": "rank-sharded" if rank_sharded else "full",
+            "world_size": len(ranks) if rank_sharded else 1,
+            "ranks": sorted(ranks) if rank_sharded else [0],
+            "axis_by_projection": {
+                "gate_proj": "output",
+                "up_proj": "output",
+                "down_proj": "input",
+            },
+        },
+        "shards": [{"path": path.name, "size": path.stat().st_size, "sha256": digest}],
+        "num_tensors": len(tensors),
+        "selected_experts": sorted(selected_experts),
+        "selected_layers": sorted(selected_layers),
+        "coverage": coverage,
+        "producer_verified_signer": None,
+        "campaign": {
+            "recipe_sha256": "e" * 64,
+            "base_model": "test",
+            "base_revision": "test",
+            "encoder_sha256": None,
+            "signer_pubkey": "f" * 64,
+            "block_size": 128,
+            "moe_layers": sorted(selected_layers),
+        },
+        "source_assembly": {
+            "path": "assemblies/test/assembly.jsonl",
+            "sha256": "d" * 64,
+        },
+        "tool_version": "test",
+        "created_utc": "2026-01-01T00:00:00Z",
+    }
+    (path.parent / "adapter_config.json").write_text(json.dumps(config))
+
+
+def load_cartridge_from_adapter(adapter_path, layer, num_experts, device):
+    layer.exl3_base_compatibility_verified = True
+    layer.exl3_base_layer_compatibility_sha256 = "b" * 64
+    with stage_exl3_cartridge_adapter(
+        SimpleNamespace(modules=lambda: iter((layer,))), adapter_path
+    ) as staged:
+        return cartridge_module._load_cartridge_from_staged_adapter(
+            staged, adapter_path, layer, num_experts, device
+        )
+
+
+def prepare_exl3_cartridge_into_model(model, adapter_path):
+    for layer in model.modules():
+        layer.exl3_base_compatibility_verified = True
+        layer.exl3_base_layer_compatibility_sha256 = "b" * 64
+    with stage_exl3_cartridge_adapter(model, adapter_path) as staged:
+        return cartridge_module.prepare_staged_exl3_cartridge_into_model(model, staged)
 
 
 def _runtime_layer(device: torch.device = CPU):
@@ -45,6 +256,11 @@ def _runtime_layer(device: torch.device = CPU):
         exl3_cartridge_capable=True,
         exl3_cartridge_enabled=False,
         exl3_tp_size=1,
+        exl3_tp_rank=0,
+        exl3_base_compatibility_sha256=BASE_COMPATIBILITY_SHA256,
+        exl3_base_compatibility_by_layer={"3": "b" * 64, "4": "b" * 64},
+        exl3_base_compatibility_verified=True,
+        exl3_base_layer_compatibility_sha256="b" * 64,
         exl3_max_num_batched_tokens=16,
         exl3_layer_bitrates=(2, 2),
         exl3_pointer_tables=pointers,
@@ -71,6 +287,21 @@ def _loader_layer():
     return layer
 
 
+def _loader_tensors(*, ranks=(0,), label="res1", bits=2, layer=3):
+    tensors = {}
+    for rank in ranks:
+        for projection in ("gate_proj", "up_proj", "down_proj"):
+            prefix = f"model.layers.{layer}.mlp.experts.0.{projection}.rank{rank}"
+            tensors[f"{prefix}.trellis_{label}"] = torch.zeros(
+                8,
+                8,
+                bits * 16,
+                dtype=torch.int16,
+            )
+            tensors[f"{prefix}.scale_{label}"] = torch.tensor(1.0)
+    return tensors
+
+
 def _cartridge(device: torch.device = CPU, num_stages: int = 1):
     cartridge = Exl3LoraCartridge(num_stages, 2, device)
     for stage_idx in range(num_stages):
@@ -87,17 +318,93 @@ def _cartridge(device: torch.device = CPU, num_stages: int = 1):
     return cartridge
 
 
-def test_config_requires_explicit_cartridge_runtime():
-    assert not Exl3Config.from_config({}).cartridge_runtime
-    assert Exl3Config.from_config({"cartridge_runtime": True}).cartridge_runtime
-    with pytest.raises(TypeError, match="must be a boolean"):
-        Exl3Config.from_config({"cartridge_runtime": 1})
+def test_checkpoint_metadata_cannot_enable_cartridge_runtime():
+    config = Exl3Config.from_config({"cartridge_runtime": True})
+    assert not hasattr(config, "cartridge_runtime")
 
 
-def test_runtime_rejects_tensor_parallel_weights():
+def test_base_compatibility_identity_is_byte_exact_and_layer_scoped():
+    tensors_by_layer = {
+        3: _producer_valid_base_layer(3),
+        78: _producer_valid_base_layer(78),
+    }
+    metadata = _rank_sliced_metadata(tensors_by_layer)
+    assert (
+        metadata["compatibility_by_layer"]["3"]
+        == "3518095ac1ae5fd32f775862acce5daa5f0c8a4c96fb308b45df4e95da377d58"
+    )
+    single_layer_metadata = _rank_sliced_metadata({3: _producer_valid_base_layer(3)})
+    assert (
+        single_layer_metadata["compatibility_sha256"]
+        == "cbb1f591900487ad16f33fd2d33174beb09d55d301f164aff37ed829f712ce01"
+    )
+
+    for layer_id in (3, 78):
+        config = Exl3Config()
+        config._configure_rank_sliced(metadata)
+        for name, tensor in tensors_by_layer[layer_id].items():
+            config.record_rank_sliced_compatibility_tensor(name, tensor)
+        assert (
+            config.verified_rank_sliced_layer_compatibility_sha256(
+                f"wrapped.model.layers.{layer_id}.mlp.experts"
+            )
+            == metadata["compatibility_by_layer"][str(layer_id)]
+        )
+
+    changed = Exl3Config()
+    changed._configure_rank_sliced(metadata)
+    for index, (name, tensor) in enumerate(tensors_by_layer[3].items()):
+        changed.record_rank_sliced_compatibility_tensor(
+            name,
+            tensor.clone().add_(1) if index == 0 else tensor,
+        )
+    with pytest.raises(ValueError, match="do not match compatibility digest"):
+        changed.verified_rank_sliced_layer_compatibility_sha256(
+            "model.layers.3.mlp.experts"
+        )
+
+
+def test_base_compatibility_root_rejects_map_mismatch():
+    tensors = {
+        3: {
+            "model.layers.3.mlp.experts.0.gate_proj.rank0.mcg": torch.tensor(
+                -877912083, dtype=torch.int32
+            )
+        }
+    }
+    metadata = _rank_sliced_metadata(tensors)
+    metadata["compatibility_by_layer"]["3"] = "f" * 64
+
+    with pytest.raises(ValueError, match="does not match its compatibility"):
+        Exl3Config()._configure_rank_sliced(metadata)
+
+
+def test_base_runtime_profile_is_closed():
+    metadata = _rank_sliced_metadata({3: _producer_valid_base_layer(3)})
+    metadata["unknown"] = True
+
+    with pytest.raises(ValueError, match="closed exl3-msrt-base/1"):
+        Exl3Config()._configure_rank_sliced(metadata)
+
+
+def test_runtime_accepts_tensor_parallel_weights():
     layer = _runtime_layer()
+    layer.exl3_tp_rank = 1
     layer.exl3_tp_size = 2
-    with pytest.raises(NotImplementedError, match="tensor_parallel_size=1"):
+
+    runtime = prepare_exl3_cudagraph_cartridge_runtime(layer)
+
+    assert runtime.tp_rank == 1
+    assert runtime.tp_size == 2
+    assert runtime.ig.shape[-1] == layer.exl3_intermediate_size_per_partition
+
+
+def test_runtime_rejects_invalid_tensor_parallel_rank():
+    layer = _runtime_layer()
+    layer.exl3_tp_rank = 2
+    layer.exl3_tp_size = 2
+
+    with pytest.raises(ValueError, match="rank=2, size=2"):
         prepare_exl3_cudagraph_cartridge_runtime(layer)
 
 
@@ -120,11 +427,24 @@ def test_runtime_rejects_extension_without_additive_entrypoint():
         patch(
             "vllm.model_executor.layers.quantization.exl3_lora_cartridge."
             "_load_exl3_ext",
-            return_value=SimpleNamespace(),
+            return_value=SimpleNamespace(EXL3_MOE_ADDITIVE_ABI_VERSION=1),
         ),
         pytest.raises(RuntimeError, match="exl3_moe_additive_fused"),
     ):
         Exl3CUDAGraphCartridgeRuntime(layer)
+
+
+@pytest.mark.parametrize("abi", [None, 0, 2, "1"])
+def test_runtime_rejects_missing_or_wrong_additive_abi(abi):
+    extension = SimpleNamespace(exl3_moe_additive_fused=MagicMock())
+    if abi is not None:
+        extension.EXL3_MOE_ADDITIVE_ABI_VERSION = abi
+    with (
+        patch.object(exl3_module, "_EXL3_EXT", extension),
+        patch.object(cartridge_module, "_load_exl3_ext", return_value=extension),
+        pytest.raises(RuntimeError, match="EXL3_MOE_ADDITIVE_ABI_VERSION=1"),
+    ):
+        cartridge_module._load_additive_exl3_ext()
 
 
 def test_runtime_rejects_activation_before_materialization():
@@ -196,7 +516,9 @@ def test_runtime_zero_scales_sparse_stage_entries():
     runtime = Exl3CUDAGraphCartridgeRuntime(layer)
     runtime.materialize(layer, cartridge)
 
-    for pointers, scales in zip(runtime.pointer_args[:3], runtime.pointer_args[3:6]):
+    for pointers, scales in zip(
+        runtime.pointer_args[:3], runtime.pointer_args[3:6], strict=True
+    ):
         assert pointers[1, 1].item() == pointers[1, 0].item()
         assert torch.equal(
             scales,
@@ -218,96 +540,47 @@ def test_runtime_rejects_nonfinite_inverse_scale():
     assert runtime._active is False
 
 
-@pytest.mark.parametrize(
-    ("parallel_config", "use_v2_model_runner", "lora_config", "error"),
-    [
-        (
-            SimpleNamespace(data_parallel_size=2, tensor_parallel_size=1),
-            False,
-            None,
-            "data_parallel_size=1",
-        ),
-        (
-            SimpleNamespace(data_parallel_size=1, tensor_parallel_size=2),
-            False,
-            None,
-            "tensor_parallel_size=1",
-        ),
-        (
-            SimpleNamespace(data_parallel_size=1, tensor_parallel_size=1),
-            True,
-            None,
-            "V2 model runner",
-        ),
-        (
-            SimpleNamespace(data_parallel_size=1, tensor_parallel_size=1),
-            False,
-            SimpleNamespace(),
-            "LoRA adapters",
-        ),
-    ],
-)
-def test_cartridge_runtime_rejects_unsupported_execution_config(
-    monkeypatch, parallel_config, use_v2_model_runner, lora_config, error
-):
-    method = object.__new__(Exl3MoEMethod)
-    method.moe = SimpleNamespace(
-        moe_parallel_config=SimpleNamespace(use_ep=False, tp_rank=0, tp_size=1),
+def test_create_weights_supports_full_rank_base_at_tp2(monkeypatch):
+    identity_tensors = {
+        3: {
+            "model.layers.3.mlp.experts.0.gate_proj.rank0.mcg": torch.tensor(
+                -877912083, dtype=torch.int32
+            )
+        }
+    }
+    quant_config = Exl3Config()
+    quant_config._configure_rank_sliced(_rank_sliced_metadata(identity_tensors))
+    moe = SimpleNamespace(
+        moe_parallel_config=SimpleNamespace(use_ep=False, tp_rank=1, tp_size=2),
         has_bias=False,
     )
-    method.quant_config = SimpleNamespace(
-        rank_sliced_metadata={"tp": 1, "experts_per_layer": 2},
-        cartridge_runtime=True,
-    )
+    method = Exl3MoEMethod(quant_config, moe)
     config = SimpleNamespace(
-        parallel_config=parallel_config,
-        scheduler_config=SimpleNamespace(max_num_batched_tokens=16),
-        model_config=SimpleNamespace(runner_type="generate"),
-        use_v2_model_runner=use_v2_model_runner,
-        lora_config=lora_config,
-    )
-    monkeypatch.setattr(exl3_module, "get_current_vllm_config_or_none", lambda: config)
-
-    with pytest.raises(NotImplementedError, match=error):
-        method.create_weights(
-            SimpleNamespace(layer_name="model.layers.3.mlp.experts"),
-            num_experts=2,
-            hidden_size=128,
-            intermediate_size_per_partition=128,
-            params_dtype=torch.float16,
-        )
-
-
-@pytest.mark.parametrize(
-    ("runner_type", "cartridge_capable"),
-    [("draft", False), ("generate", True)],
-)
-def test_create_weights_stamps_cartridge_capability_without_enabling(
-    monkeypatch, runner_type, cartridge_capable
-):
-    method = object.__new__(Exl3MoEMethod)
-    method.moe = SimpleNamespace(
-        moe_parallel_config=SimpleNamespace(use_ep=False, tp_rank=0, tp_size=1),
-        has_bias=False,
-    )
-    method.quant_config = SimpleNamespace(
-        rank_sliced_metadata={"tp": 1, "experts_per_layer": 2},
-        cartridge_runtime=True,
-        rank_sliced_layer_bitrates=MagicMock(return_value=(2, 2)),
-    )
-    config = SimpleNamespace(
-        parallel_config=SimpleNamespace(data_parallel_size=1, tensor_parallel_size=1),
+        parallel_config=SimpleNamespace(
+            data_parallel_size=1,
+            tensor_parallel_size=2,
+        ),
         scheduler_config=SimpleNamespace(max_num_batched_tokens=16),
         use_v2_model_runner=False,
         lora_config=None,
-        model_config=SimpleNamespace(runner_type=runner_type),
+        model_config=SimpleNamespace(runner_type="generate"),
     )
-    monkeypatch.setattr(exl3_module, "get_current_vllm_config_or_none", lambda: config)
-    monkeypatch.setattr(exl3_module, "Exl3MoEParameter", MagicMock())
-    layer = SimpleNamespace(
-        layer_name="model.layers.3.mlp.experts",
-        register_parameter=MagicMock(),
+    monkeypatch.setattr(
+        exl3_module,
+        "get_current_vllm_config_or_none",
+        lambda: config,
     )
+    monkeypatch.setattr(
+        "vllm.model_executor.parameter.get_tensor_model_parallel_rank",
+        lambda: 1,
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.parameter.get_tensor_model_parallel_world_size",
+        lambda: 2,
+    )
+    monkeypatch.setattr(exl3_module.envs, "VLLM_ENABLE_EXL3_CARTRIDGE", True)
+    layer = torch.nn.Module()
+    layer.layer_name = "model.layers.3.mlp.experts"
 
     method.create_weights(
         layer,
@@ -317,16 +590,69 @@ def test_create_weights_stamps_cartridge_capability_without_enabling(
         params_dtype=torch.float16,
     )
 
-    assert layer.exl3_is_draft is (runner_type == "draft")
-    assert layer.exl3_cartridge_capable is cartridge_capable
+    assert layer.exl3_tp_rank == 1
+    assert layer.exl3_tp_size == 2
+    assert layer.exl3_cartridge_capable is True
     assert layer.exl3_cartridge_enabled is False
+    assert (
+        layer.exl3_base_compatibility_sha256
+        == quant_config.rank_sliced_metadata["compatibility_sha256"]
+    )
+    assert isinstance(layer.w13_trellis, exl3_module.Exl3MoEParameter)
+    assert layer.w13_trellis.exl3_tp_slice == (1, 128, 128, True)
+    assert layer.w2_trellis.exl3_tp_slice == (0, 128, 128, True)
+    assert (
+        quant_config.normalize_rank_sliced_weight_name(
+            "model.layers.3.mlp.experts.0.gate_proj.rank0.trellis"
+        )
+        == "model.layers.3.mlp.experts.0.gate_proj.trellis"
+    )
+    assert (
+        quant_config.normalize_rank_sliced_weight_name(
+            "model.layers.3.mlp.experts.0.gate_proj.rank1.trellis"
+        )
+        is None
+    )
+
+    full_trellis = torch.cat(
+        (
+            torch.ones(8, 8, 32, dtype=torch.int16),
+            torch.full((8, 8, 32), 2, dtype=torch.int16),
+        ),
+        dim=1,
+    )
+    layer.w13_trellis.load_exl3_weight(
+        full_trellis,
+        expert_id=0,
+        shard_id="w1",
+    )
+    assert torch.equal(
+        layer.w13_trellis.exl3_tensors[(0, "w1")],
+        torch.full((8, 8, 32), 2, dtype=torch.int16),
+    )
+
+    full_rotation = torch.cat(
+        (
+            torch.ones(128, dtype=torch.float16),
+            torch.full((128,), 2, dtype=torch.float16),
+        )
+    )
+    layer.w13_svh.load_exl3_weight(
+        full_rotation,
+        expert_id=0,
+        shard_id="w1",
+    )
+    assert torch.equal(
+        layer.w13_svh.exl3_tensors[(0, "w1")],
+        torch.full((128,), 2, dtype=torch.float16),
+    )
 
 
 def test_rank_sliced_draft_layer_skips_cartridge_path():
     method = object.__new__(Exl3MoEMethod)
     method.quant_config = SimpleNamespace(
         rank_sliced_metadata={"tp": 1},
-        cartridge_runtime=True,
+        rank_sliced_supports_dynamic_tp=MagicMock(return_value=False),
     )
     method._apply_rank_sliced = MagicMock(
         return_value=torch.ones(2, 4, dtype=torch.float16)
@@ -457,7 +783,9 @@ def test_loader_filters_layer_and_sorts_stage_numbers(tmp_path):
     tensors = {}
     tensors.update(tensors_for(3, 10))
     tensors.update(tensors_for(3, 2))
-    tensors.update(tensors_for(4, 1))
+    tensors.update(tensors_for(4, 20))
+    tensors.update(tensors_for(4, 10))
+    tensors.update(tensors_for(4, 2))
     save_file(tensors, path)
 
     cartridge = load_cartridge_from_adapter(
@@ -472,12 +800,216 @@ def test_loader_filters_layer_and_sorts_stage_numbers(tmp_path):
     assert stage1 is not None and stage1["scale"] == 10.0
 
 
+def _tp_loader_layer(rank: int):
+    layer = _loader_layer()
+    layer.exl3_hidden_size = 128
+    layer.exl3_intermediate_size_per_partition = 128
+    layer.exl3_tp_rank = rank
+    layer.exl3_tp_size = 2
+    return layer
+
+
+def test_loader_slices_legacy_full_rank_cartridge_for_each_tp_worker(tmp_path):
+    path = tmp_path / "full-rank.safetensors"
+    tensors = {}
+    for projection in ("gate_proj", "up_proj", "down_proj"):
+        dim = 0 if projection == "down_proj" else 1
+        trellis = torch.cat(
+            (
+                torch.ones(8, 8, 16, dtype=torch.int16),
+                torch.full((8, 8, 16), 2, dtype=torch.int16),
+            ),
+            dim=dim,
+        )
+        prefix = f"model.layers.3.mlp.experts.0.{projection}.rank0"
+        tensors[f"{prefix}.trellis_res1"] = trellis
+        tensors[f"{prefix}.scale_res1"] = torch.tensor(3.0)
+    save_file(tensors, path)
+
+    rank0 = load_cartridge_from_adapter(str(path), _tp_loader_layer(0), 2, CPU)
+    rank1 = load_cartridge_from_adapter(str(path), _tp_loader_layer(1), 2, CPU)
+
+    assert rank0 is not None and rank1 is not None
+    for shard_id in ("w1", "w3", "w2"):
+        rank0_tensors = rank0.get_stage_tensors(0, 0, shard_id)
+        rank1_tensors = rank1.get_stage_tensors(0, 0, shard_id)
+        assert rank0_tensors is not None and rank1_tensors is not None
+        assert rank0_tensors["trellis"].shape == (8, 8, 16)
+        assert rank1_tensors["trellis"].shape == (8, 8, 16)
+        assert torch.equal(
+            rank0_tensors["trellis"],
+            torch.ones(8, 8, 16, dtype=torch.int16),
+        )
+        assert torch.equal(
+            rank1_tensors["trellis"],
+            torch.full((8, 8, 16), 2, dtype=torch.int16),
+        )
+
+
+def test_loader_selects_matching_rank_from_tp_sharded_cartridge(tmp_path):
+    path = tmp_path / "rank-sharded.safetensors"
+    tensors = {}
+    for rank in range(2):
+        for projection in ("gate_proj", "up_proj", "down_proj"):
+            prefix = f"model.layers.3.mlp.experts.0.{projection}.rank{rank}"
+            tensors[f"{prefix}.trellis_res1"] = torch.full(
+                (8, 8, 16), rank + 1, dtype=torch.int16
+            )
+            tensors[f"{prefix}.scale_res1"] = torch.tensor(2.0)
+    save_file(tensors, path)
+
+    layer = _tp_loader_layer(1)
+    cartridge = load_cartridge_from_adapter(str(path), layer, 2, CPU)
+
+    assert cartridge is not None
+    for shard_id in ("w1", "w3", "w2"):
+        stage = cartridge.get_stage_tensors(0, 0, shard_id)
+        assert stage is not None
+        assert stage["scale"] == 2.0
+        assert torch.equal(
+            stage["trellis"],
+            torch.full((8, 8, 16), 2, dtype=torch.int16),
+        )
+
+    runtime = prepare_exl3_cudagraph_cartridge_runtime(layer)
+    runtime.materialize(layer, cartridge)
+    assert runtime.pointer_args[0].shape == (1, 2)
+    assert runtime.pointer_args[3].shape == (1, 2)
+    assert runtime.pointer_args[6].shape == (1,)
+
+
+def test_loader_honors_rank_sharded_world_size_one(tmp_path):
+    path = tmp_path / "rank-sharded-tp1.safetensors"
+    save_file(_loader_tensors(bits=1), path, layout="rank-sharded")
+
+    cartridge = load_cartridge_from_adapter(str(path), _loader_layer(), 2, CPU)
+
+    assert cartridge is not None
+    assert cartridge.get_stage_tensors(0, 0, "w1") is not None
+
+
+def test_loader_rejects_divergent_replicated_rank_scales(tmp_path):
+    path = tmp_path / "rank-scales.safetensors"
+    tensors = _loader_tensors(ranks=(0, 1), bits=1)
+    tensors["model.layers.3.mlp.experts.0.gate_proj.rank1.scale_res1"] = torch.tensor(
+        2.0
+    )
+    save_file(tensors, path)
+
+    with pytest.raises(ValueError, match="scales differ across TP ranks"):
+        load_cartridge_from_adapter(str(path), _tp_loader_layer(1), 2, CPU)
+
+
+def test_loader_rejects_inconsistent_tp_rank_topology(tmp_path):
+    path = tmp_path / "inconsistent-ranks.safetensors"
+    tensors = {}
+    for rank in range(2):
+        projections = (
+            ("gate_proj", "up_proj", "down_proj")
+            if rank == 0
+            else ("gate_proj", "up_proj")
+        )
+        for projection in projections:
+            prefix = f"model.layers.3.mlp.experts.0.{projection}.rank{rank}"
+            tensors[f"{prefix}.trellis_res1"] = torch.zeros(8, 8, 16, dtype=torch.int16)
+            tensors[f"{prefix}.scale_res1"] = torch.tensor(1.0)
+    save_file(tensors, path)
+
+    with pytest.raises(ValueError, match="inconsistent stage topology"):
+        load_cartridge_from_adapter(str(path), _tp_loader_layer(1), 2, CPU)
+
+
+def test_loader_rejects_missing_scale_on_nonlocal_tp_rank(tmp_path):
+    path = tmp_path / "missing-scale.safetensors"
+    tensors = _loader_tensors(ranks=(0, 1), bits=1)
+    del tensors["model.layers.3.mlp.experts.0.gate_proj.rank0.scale_res1"]
+    save_file(tensors, path)
+
+    with pytest.raises(ValueError, match="has no scalar scale companion"):
+        load_cartridge_from_adapter(str(path), _tp_loader_layer(1), 2, CPU)
+
+
+@pytest.mark.parametrize(
+    ("key", "message"),
+    [
+        (
+            "model.layers.3.mlp.experts.0.gate_proj.rank0.trellis_res1",
+            "has no scalar scale companion",
+        ),
+        (
+            "model.layers.3.mlp.experts.0.gate_proj.rank0.scale_res1",
+            "Orphaned MSRT cartridge scale",
+        ),
+    ],
+)
+def test_cartridge_key_index_reports_orphaned_companions(key, message):
+    with pytest.raises(ValueError, match=message):
+        cartridge_module._index_cartridge_keys((key,))
+
+
+def test_manifest_layer_names_remain_canonical():
+    key = "wrapped.model.layers.3.mlp.experts.0.gate_proj.rank0.trellis_res1"
+    match = cartridge_module._CARTRIDGE_KEY_RE.fullmatch(key)
+    assert match is not None
+    config = {
+        "coverage": {"res1": {"3": [0]}},
+        "selected_layers": [3],
+        "selected_experts": [0],
+        "chain": [{"label": "res1", "experts": "all"}],
+    }
+
+    with pytest.raises(ValueError, match="Invalid MSRT cartridge layer name"):
+        cartridge_module._validate_manifest_tensor_coverage(
+            config, {match.group("layer"): [(key, match)]}
+        )
+
+
+def test_loader_rejects_fp32_inverse_scale_overflow(tmp_path):
+    path = tmp_path / "inverse-overflow.safetensors"
+    tensors = _loader_tensors()
+    for key in tuple(tensors):
+        if ".scale_" in key:
+            tensors[key] = torch.tensor(1e-40, dtype=torch.float32)
+    save_file(tensors, path)
+
+    with pytest.raises(ValueError, match="inverse scale is not finite in FP32"):
+        load_cartridge_from_adapter(str(path), _loader_layer(), 2, CPU)
+
+
+def test_loader_validates_tp_sharded_trellis_against_local_shape(tmp_path):
+    path = tmp_path / "wrong-local-shape.safetensors"
+    tensors = {}
+    for rank in range(2):
+        for projection in ("gate_proj", "up_proj", "down_proj"):
+            prefix = f"model.layers.3.mlp.experts.0.{projection}.rank{rank}"
+            shape = (
+                (8, 16, 16) if rank == 1 and projection == "gate_proj" else (8, 8, 16)
+            )
+            tensors[f"{prefix}.trellis_res1"] = torch.zeros(
+                *shape,
+                dtype=torch.int16,
+            )
+            tensors[f"{prefix}.scale_res1"] = torch.tensor(1.0)
+    save_file(tensors, path)
+
+    with pytest.raises(ValueError, match="Invalid MSRT cartridge trellis"):
+        load_cartridge_from_adapter(
+            str(path),
+            _tp_loader_layer(1),
+            2,
+            CPU,
+        )
+
+
 def test_loader_rejects_incomplete_projection(tmp_path):
     path = tmp_path / "broken.safetensors"
     save_file(
         {
             "model.layers.3.mlp.experts.0.gate_proj.rank0.trellis_res1": (
                 torch.zeros(8, 8, 32, dtype=torch.int16)
+            ),
+            "model.layers.3.mlp.experts.0.gate_proj.rank0.scale_res1": (
+                torch.tensor(1.0)
             ),
         },
         path,
@@ -494,8 +1026,12 @@ def test_loader_rejects_invalid_trellis_shape(tmp_path):
     for projection in ("gate_proj", "up_proj", "down_proj"):
         tensor_prefix = f"{prefix}.{projection}.rank0"
         tensors[f"{tensor_prefix}.trellis_res1"] = torch.zeros(
-            8, 8, 15 if projection == "gate_proj" else 32, dtype=torch.int16
+            8,
+            8,
+            15,
+            dtype=torch.int16,
         )
+        tensors[f"{tensor_prefix}.scale_res1"] = torch.tensor(1.0)
     save_file(tensors, path)
 
     with pytest.raises(ValueError, match="Invalid MSRT cartridge trellis"):
@@ -511,6 +1047,7 @@ def test_loader_rejects_oversized_packed_dimensions(tmp_path):
         tensors[f"{tensor_prefix}.trellis_res1"] = torch.zeros(
             16, 8, 32, dtype=torch.int16
         )
+        tensors[f"{tensor_prefix}.scale_res1"] = torch.tensor(1.0)
     save_file(tensors, path)
 
     with pytest.raises(ValueError, match="128-aligned logical shape"):
@@ -532,194 +1069,361 @@ def test_loader_rejects_malformed_target_key(tmp_path):
         load_cartridge_from_adapter(str(path), _loader_layer(), 2, CPU)
 
 
-def test_model_loader_streams_layers_and_rolls_back_if_later_layer_is_missing():
+def test_loader_requires_versioned_adapter_manifest(tmp_path):
+    path = tmp_path / "cartridge.safetensors"
+    save_file(_loader_tensors(), path)
+    (tmp_path / "adapter_config.json").unlink()
+
+    with pytest.raises(ValueError, match="cannot open EXL3 cartridge adapter_config"):
+        load_cartridge_from_adapter(str(path), _loader_layer(), 2, CPU)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("runtime_operation", "base + residual", "runtime_operation"),
+        ("codebook", "mul1", "codebook"),
+        ("mcg_multiplier", 1, "mcg_multiplier"),
+    ],
+)
+def test_loader_rejects_decode_contract_mismatch(
+    tmp_path,
+    field,
+    value,
+    message,
+):
+    path = tmp_path / "cartridge.safetensors"
+    save_file(_loader_tensors(), path)
+    config_path = tmp_path / "adapter_config.json"
+    config = json.loads(config_path.read_text())
+    config[field] = value
+    config_path.write_text(json.dumps(config))
+
+    with pytest.raises(ValueError, match=message):
+        load_cartridge_from_adapter(str(path), _loader_layer(), 2, CPU)
+
+
+def test_loader_rejects_incomplete_v3_manifest(tmp_path):
+    path = tmp_path / "cartridge.safetensors"
+    save_file(_loader_tensors(), path)
+    config_path = tmp_path / "adapter_config.json"
+    config = json.loads(config_path.read_text())
+    config.pop("source_assembly")
+    config_path.write_text(json.dumps(config))
+
+    with pytest.raises(ValueError, match="manifest fields do not match"):
+        load_cartridge_from_adapter(str(path), _loader_layer(), 2, CPU)
+
+
+@pytest.mark.parametrize("label", ["-bad", "_bad", "bad.label", "a" * 33])
+def test_loader_rejects_noncanonical_labels(tmp_path, label):
+    path = tmp_path / "cartridge.safetensors"
+    save_file(_loader_tensors(), path)
+    config_path = tmp_path / "adapter_config.json"
+    config = json.loads(config_path.read_text())
+    config["assembly"] = label
+    config_path.write_text(json.dumps(config))
+
+    with pytest.raises(ValueError, match="invalid assembly label"):
+        load_cartridge_from_adapter(str(path), _loader_layer(), 2, CPU)
+
+
+def test_loader_accepts_32_character_label(tmp_path):
+    path = tmp_path / "cartridge.safetensors"
+    save_file(_loader_tensors(), path)
+    config_path = tmp_path / "adapter_config.json"
+    config = json.loads(config_path.read_text())
+    config["assembly"] = "a" * 32
+    config_path.write_text(json.dumps(config))
+
+    assert load_cartridge_from_adapter(str(path), _loader_layer(), 2, CPU)
+
+
+def test_loader_rejects_manifest_coverage_mismatch(tmp_path):
+    path = tmp_path / "cartridge.safetensors"
+    save_file(_loader_tensors(), path)
+    config_path = tmp_path / "adapter_config.json"
+    config = json.loads(config_path.read_text())
+    config["coverage"]["res1"]["3"] = [1]
+    config_path.write_text(json.dumps(config))
+
+    with pytest.raises(ValueError, match=r"do not match adapter_config\.json coverage"):
+        load_cartridge_from_adapter(str(path), _loader_layer(), 2, CPU)
+
+
+def test_loader_rejects_cartridge_bound_to_different_base(tmp_path):
+    path = tmp_path / "cartridge.safetensors"
+    save_file(_loader_tensors(), path)
+    config_path = tmp_path / "adapter_config.json"
+    config = json.loads(config_path.read_text())
+    config["base"]["compatibility_sha256"] = "b" * 64
+    config_path.write_text(json.dumps(config))
+
+    with pytest.raises(ValueError, match="different base checkpoint"):
+        load_cartridge_from_adapter(str(path), _loader_layer(), 2, CPU)
+
+
+def test_loader_rejects_base_bitrate_mismatch(tmp_path):
+    path = tmp_path / "cartridge.safetensors"
+    save_file(_loader_tensors(), path)
+    config_path = tmp_path / "adapter_config.json"
+    config = json.loads(config_path.read_text())
+    config["base"]["k"] = 3
+    config_path.write_text(json.dumps(config))
+
+    with pytest.raises(ValueError, match=r"base\.k does not match"):
+        load_cartridge_from_adapter(str(path), _loader_layer(), 2, CPU)
+
+
+def test_loader_rejects_shard_changed_after_manifest(tmp_path):
+    path = tmp_path / "cartridge.safetensors"
+    save_file(_loader_tensors(), path)
+    path.write_bytes(path.read_bytes() + b"tampered")
+
+    with pytest.raises(ValueError, match=r"does not match adapter_config\.json"):
+        load_cartridge_from_adapter(str(path), _loader_layer(), 2, CPU)
+
+
+def test_loader_rejects_stage_bitrate_mismatch(tmp_path):
+    path = tmp_path / "cartridge.safetensors"
+    save_file(_loader_tensors(bits=2), path)
+    config_path = tmp_path / "adapter_config.json"
+    config = json.loads(config_path.read_text())
+    config["chain"][0]["k"] = 1
+    config_path.write_text(json.dumps(config))
+
+    with pytest.raises(ValueError, match="declares K1"):
+        load_cartridge_from_adapter(str(path), _loader_layer(), 2, CPU)
+
+
+def test_loader_rejects_tensor_ranks_disagreeing_with_manifest(tmp_path):
+    path = tmp_path / "cartridge.safetensors"
+    save_file(_loader_tensors(ranks=(0, 1), bits=1), path)
+    config_path = tmp_path / "adapter_config.json"
+    config = json.loads(config_path.read_text())
+    config["tensor_parallel"] = {
+        "layout": "full",
+        "world_size": 1,
+        "ranks": [0],
+        "axis_by_projection": {
+            "gate_proj": "output",
+            "up_proj": "output",
+            "down_proj": "input",
+        },
+    }
+    config_path.write_text(json.dumps(config))
+
+    with pytest.raises(ValueError, match="ranks do not match adapter_config"):
+        load_cartridge_from_adapter(
+            str(path),
+            _tp_loader_layer(1),
+            2,
+            CPU,
+        )
+
+
+def test_loader_rejects_ignored_codebook_companion(tmp_path):
+    path = tmp_path / "cartridge.safetensors"
+    tensors = _loader_tensors()
+    tensors["model.layers.3.mlp.experts.0.gate_proj.rank0.mul1_res1"] = torch.tensor(
+        1, dtype=torch.int32
+    )
+    save_file(tensors, path)
+
+    with pytest.raises(ValueError, match="Malformed MSRT cartridge key"):
+        load_cartridge_from_adapter(str(path), _loader_layer(), 2, CPU)
+
+
+def test_loader_rejects_child_only_expert_coverage(tmp_path):
+    path = tmp_path / "child-only.safetensors"
+    tensors = {}
+    for label, experts in (("res1", (0,)), ("res2", (0, 1))):
+        for expert in experts:
+            for projection in ("gate_proj", "up_proj", "down_proj"):
+                prefix = f"model.layers.3.mlp.experts.{expert}.{projection}.rank0"
+                tensors[f"{prefix}.trellis_{label}"] = torch.zeros(
+                    8, 8, 16, dtype=torch.int16
+                )
+                tensors[f"{prefix}.scale_{label}"] = torch.tensor(1.0)
+    save_file(tensors, path)
+    config_path = tmp_path / "adapter_config.json"
+    config = json.loads(config_path.read_text())
+    config["chain"][0]["experts"] = [0]
+    config["chain"][1]["experts"] = "all"
+    config_path.write_text(json.dumps(config))
+
+    with pytest.raises(ValueError, match="not parent-closed"):
+        load_cartridge_from_adapter(str(path), _loader_layer(), 2, CPU)
+
+
+def test_staging_uses_verified_private_bytes_after_source_replacement(tmp_path):
+    path = tmp_path / "source.safetensors"
+    save_file(_loader_tensors(bits=1), path)
+    layer = _loader_layer()
+
+    with stage_exl3_cartridge_adapter(
+        SimpleNamespace(modules=lambda: iter((layer,))), str(path)
+    ) as staged:
+        replacement = tmp_path / "replacement.safetensors"
+        _save_file(_loader_tensors(bits=2), replacement)
+        os.replace(replacement, path)
+        cartridge = cartridge_module._load_cartridge_from_staged_adapter(
+            staged, str(path), layer, 2, CPU
+        )
+
+    assert cartridge is not None
+    stage = cartridge.get_stage_tensors(0, 0, "w1")
+    assert stage is not None and stage["trellis"].shape[-1] == 16
+
+
+def test_staging_rejects_missing_and_non_regular_requested_paths(tmp_path):
+    layer = _loader_layer()
+    model = SimpleNamespace(modules=lambda: iter((layer,)))
+    with pytest.raises(ValueError, match="must exist"):
+        stage_exl3_cartridge_adapter(model, str(tmp_path / "typo.safetensors"))
+
+    fifo = tmp_path / "adapter.fifo"
+    os.mkfifo(fifo)
+    with pytest.raises(ValueError, match="directory or regular file"):
+        stage_exl3_cartridge_adapter(model, str(fifo))
+
+    adapter_dir = tmp_path / "adapter"
+    adapter_dir.mkdir()
+    shard = adapter_dir / "cartridge.safetensors"
+    save_file(_loader_tensors(), shard)
+    shard.unlink()
+    os.mkfifo(shard)
+    with pytest.raises(ValueError, match="must be a regular file"):
+        stage_exl3_cartridge_adapter(model, str(adapter_dir))
+
+
+def test_model_loader_prepares_only_manifest_selected_layers(tmp_path, monkeypatch):
+    path = tmp_path / "cartridge.safetensors"
+    save_file(_loader_tensors(), path)
     layers = [_runtime_layer(), _runtime_layer()]
     layers[1].layer_name = "model.layers.4.mlp.experts"
-    for layer in layers:
-        prepare_exl3_cudagraph_cartridge_runtime(layer)
-    first_runtime = layers[0]._exl3_cartridge_runtime
     model = SimpleNamespace(modules=lambda: iter(layers))
-
-    with (
-        patch(
-            "safetensors.safe_open",
-            return_value=MagicMock(
-                __enter__=MagicMock(return_value=MagicMock()),
-                __exit__=MagicMock(return_value=False),
-            ),
-        ),
-        patch(
-            "vllm.model_executor.layers.quantization.exl3_lora_cartridge."
-            "_index_cartridge_keys",
-            return_value={},
-        ),
-        patch(
-            "vllm.model_executor.layers.quantization.exl3_lora_cartridge."
-            "_build_cartridge_from_entries",
-            side_effect=[_cartridge(), None],
-        ),
-        patch.object(first_runtime, "materialize") as materialize,
-        pytest.raises(ValueError, match="has no tensors"),
-    ):
-        load_exl3_cartridge_into_model(model, "cartridge.safetensors")
-
-    materialize.assert_called_once()
-    assert all(not hasattr(layer, "_exl3_cartridge_runtime") for layer in layers)
-
-
-def test_model_loader_deactivates_every_layer_after_materialization_failure():
-    layers = [_runtime_layer(), _runtime_layer()]
-    layers[1].layer_name = "model.layers.4.mlp.experts"
-    runtimes = [prepare_exl3_cudagraph_cartridge_runtime(layer) for layer in layers]
-    model = SimpleNamespace(modules=lambda: iter(layers))
-
-    def activate(_layer, _cartridge):
-        runtimes[0]._active = True
-
-    with (
-        patch(
-            "safetensors.safe_open",
-            return_value=MagicMock(
-                __enter__=MagicMock(return_value=MagicMock()),
-                __exit__=MagicMock(return_value=False),
-            ),
-        ),
-        patch(
-            "vllm.model_executor.layers.quantization.exl3_lora_cartridge."
-            "_index_cartridge_keys",
-            return_value={},
-        ),
-        patch(
-            "vllm.model_executor.layers.quantization.exl3_lora_cartridge."
-            "_build_cartridge_from_entries",
-            side_effect=[_cartridge(), _cartridge()],
-        ),
-        patch.object(runtimes[0], "materialize", side_effect=activate),
-        patch.object(
-            runtimes[1],
-            "materialize",
-            MagicMock(side_effect=RuntimeError("decode failed")),
-        ),
-        pytest.raises(RuntimeError, match="decode failed"),
-    ):
-        load_exl3_cartridge_into_model(model, "cartridge.safetensors")
-
-    assert all(not runtime._active for runtime in runtimes)
-
-
-def test_model_loader_skips_layers_without_cartridge_capability():
-    layer = _runtime_layer()
-    layer.exl3_cartridge_capable = False
-    model = SimpleNamespace(modules=lambda: iter((layer,)))
-
-    with (
-        patch(
-            "safetensors.safe_open",
-            return_value=MagicMock(
-                __enter__=MagicMock(return_value=MagicMock()),
-                __exit__=MagicMock(return_value=False),
-            ),
-        ),
-        patch(
-            "vllm.model_executor.layers.quantization.exl3_lora_cartridge."
-            "_index_cartridge_keys",
-            return_value={},
-        ),
-        patch(
-            "vllm.model_executor.layers.quantization.exl3_lora_cartridge."
-            "_build_cartridge_from_entries"
-        ) as build,
-    ):
-        assert prepare_exl3_cartridge_into_model(model, "cartridge.safetensors") == 0
-
-    build.assert_not_called()
-    assert not hasattr(layer, "_exl3_cartridge_runtime")
-
-
-def test_model_loader_allocates_and_releases_runtime_lazily():
-    layer = _runtime_layer()
-    model = SimpleNamespace(modules=lambda: iter((layer,)))
 
     def mark_materialized(runtime, _layer, _cartridge):
         runtime._materialized = True
 
-    with (
-        patch(
-            "safetensors.safe_open",
-            return_value=MagicMock(
-                __enter__=MagicMock(return_value=MagicMock()),
-                __exit__=MagicMock(return_value=False),
-            ),
-        ),
-        patch(
-            "vllm.model_executor.layers.quantization.exl3_lora_cartridge."
-            "_index_cartridge_keys",
-            return_value={},
-        ),
-        patch(
-            "vllm.model_executor.layers.quantization.exl3_lora_cartridge."
-            "_build_cartridge_from_entries",
-            return_value=_cartridge(),
-        ),
-        patch.object(
-            Exl3CUDAGraphCartridgeRuntime,
-            "materialize",
-            autospec=True,
-            side_effect=mark_materialized,
-        ),
-    ):
-        assert load_exl3_cartridge_into_model(model, "cartridge.safetensors") == 1
+    monkeypatch.setattr(
+        Exl3CUDAGraphCartridgeRuntime,
+        "materialize",
+        mark_materialized,
+    )
 
-    assert isinstance(layer._exl3_cartridge_runtime, Exl3CUDAGraphCartridgeRuntime)
-    assert layer.exl3_cartridge_enabled is True
-    assert deactivate_exl3_cartridge(model) == 1
-    assert not hasattr(layer, "_exl3_cartridge_runtime")
-    assert layer.exl3_cartridge_enabled is False
+    assert prepare_exl3_cartridge_into_model(model, str(path)) == 1
+    assert isinstance(
+        layers[0]._exl3_cartridge_runtime,
+        Exl3CUDAGraphCartridgeRuntime,
+    )
+    assert not hasattr(layers[1], "_exl3_cartridge_runtime")
 
 
-def test_model_loader_activates_every_layer_only_after_materialization():
-    layers = [_runtime_layer(), _runtime_layer()]
+def test_model_loader_matches_wrapped_live_layer_by_numeric_index(
+    tmp_path, monkeypatch
+):
+    path = tmp_path / "cartridge.safetensors"
+    save_file(_loader_tensors(), path)
+    layer = _loader_layer()
+    layer.layer_name = "language_model.model.layers.3.mlp.experts"
+    model = SimpleNamespace(modules=lambda: iter((layer,)))
+
+    monkeypatch.setattr(
+        Exl3CUDAGraphCartridgeRuntime,
+        "materialize",
+        lambda runtime, _layer, _cartridge: setattr(runtime, "_materialized", True),
+    )
+
+    with stage_exl3_cartridge_adapter(model, str(path)) as staged:
+        assert staged.local_layer_names == ("model.layers.3.mlp.experts",)
+        cartridge = cartridge_module._load_cartridge_from_staged_adapter(
+            staged, str(path), layer, 2, CPU
+        )
+        assert cartridge is not None
+        assert (
+            cartridge_module.prepare_staged_exl3_cartridge_into_model(model, staged)
+            == 1
+        )
+
+
+def test_model_loader_rejects_ambiguous_wrapped_live_layer(tmp_path):
+    path = tmp_path / "cartridge.safetensors"
+    save_file(_loader_tensors(), path)
+    layer = _loader_layer()
+    layer.layer_name = "model.layers.3.wrapper.layers.4.mlp.experts"
+    model = SimpleNamespace(modules=lambda: iter((layer,)))
+
+    with pytest.raises(ValueError, match=r"exactly one numeric layers\.<index>"):
+        stage_exl3_cartridge_adapter(model, str(path))
+
+
+def test_model_loader_accepts_authenticated_nonlocal_mtp_layer(tmp_path):
+    path = tmp_path / "target-and-mtp.safetensors"
+    tensors = _loader_tensors(layer=3)
+    tensors.update(_loader_tensors(layer=78))
+    save_file(tensors, path)
+    target = _loader_layer()
+    target.exl3_base_compatibility_by_layer["78"] = "b" * 64
+    draft = _loader_layer()
+    draft.layer_name = "model.layers.78.mlp.experts"
+    draft.exl3_cartridge_capable = False
+    draft.exl3_is_draft = True
+    model = SimpleNamespace(modules=lambda: iter((target, draft)))
+
+    with stage_exl3_cartridge_adapter(model, str(path)) as staged:
+        assert staged.local_layer_names == ("model.layers.3.mlp.experts",)
+        assert set(staged.state.by_layer) == {
+            "model.layers.3.mlp.experts",
+            "model.layers.78.mlp.experts",
+        }
+        assert not hasattr(draft, "_exl3_cartridge_runtime")
+
+
+def test_model_swap_to_narrower_cartridge_and_shared_workspace(tmp_path, monkeypatch):
+    wide_dir = tmp_path / "wide"
+    narrow_dir = tmp_path / "narrow"
+    wide_dir.mkdir()
+    narrow_dir.mkdir()
+    wide_path = wide_dir / "cartridge.safetensors"
+    narrow_path = narrow_dir / "cartridge.safetensors"
+    wide_tensors = _loader_tensors(layer=3)
+    wide_tensors.update(_loader_tensors(layer=4))
+    save_file(wide_tensors, wide_path)
+    save_file(_loader_tensors(layer=3), narrow_path)
+
+    layers = [_loader_layer(), _loader_layer()]
     layers[1].layer_name = "model.layers.4.mlp.experts"
-    runtimes = [prepare_exl3_cudagraph_cartridge_runtime(layer) for layer in layers]
     model = SimpleNamespace(modules=lambda: iter(layers))
 
-    def mark_materialized(_layer, _cartridge):
-        for runtime in runtimes:
-            if not runtime._materialized:
-                runtime._materialized = True
-                return
+    def mark_materialized(runtime, _layer, _cartridge):
+        runtime._materialized = True
 
-    with (
-        patch(
-            "safetensors.safe_open",
-            return_value=MagicMock(
-                __enter__=MagicMock(return_value=MagicMock()),
-                __exit__=MagicMock(return_value=False),
-            ),
-        ),
-        patch(
-            "vllm.model_executor.layers.quantization.exl3_lora_cartridge."
-            "_index_cartridge_keys",
-            return_value={},
-        ),
-        patch(
-            "vllm.model_executor.layers.quantization.exl3_lora_cartridge."
-            "_build_cartridge_from_entries",
-            side_effect=[_cartridge(), _cartridge()],
-        ),
-        patch.object(runtimes[0], "materialize", side_effect=mark_materialized),
-        patch.object(runtimes[1], "materialize", side_effect=mark_materialized),
-    ):
-        assert load_exl3_cartridge_into_model(model, "cartridge.safetensors") == 2
+    monkeypatch.setattr(
+        Exl3CUDAGraphCartridgeRuntime,
+        "materialize",
+        mark_materialized,
+    )
 
-    assert all(runtime._active for runtime in runtimes)
+    assert prepare_exl3_cartridge_into_model(model, str(wide_path)) == 2
+    first_runtime = layers[0]._exl3_cartridge_runtime
+    second_runtime = layers[1]._exl3_cartridge_runtime
+    assert first_runtime.xh is second_runtime.xh
+
+    assert prepare_exl3_cartridge_into_model(model, str(narrow_path)) == 1
+    assert layers[0]._exl3_cartridge_runtime is first_runtime
+    assert not hasattr(layers[1], "_exl3_cartridge_runtime")
+    assert cartridge_module.deactivate_exl3_cartridge(model) == 1
+    assert not hasattr(model, "_exl3_cartridge_workspaces")
 
 
-def test_worker_cartridge_operations_use_collective_rpc_target_model():
+def test_worker_cartridge_graph_operations_target_model():
     model = SimpleNamespace()
     compilation_config = SimpleNamespace(
         mode=CompilationMode.VLLM_COMPILE,
         compile_sizes=[32, 16],
+        cudagraph_mode=CUDAGraphMode.FULL,
         cudagraph_capture_sizes=[16],
         get_compile_ranges=lambda: [],
     )
@@ -729,22 +1433,18 @@ def test_worker_cartridge_operations_use_collective_rpc_target_model():
         capture_model=MagicMock(return_value=123),
         _dummy_run=MagicMock(),
     )
-    worker = SimpleNamespace(
-        model_runner=model_runner,
-        vllm_config=SimpleNamespace(compilation_config=compilation_config),
-        _warmup_kernels_once=MagicMock(),
+    worker = object.__new__(Worker)
+    worker.model_runner = model_runner
+    worker.vllm_config = SimpleNamespace(
+        compilation_config=compilation_config,
     )
+    worker._warmup_kernels_once = MagicMock()
     with (
         patch(
             "vllm.model_executor.layers.quantization.exl3_lora_cartridge."
             "has_exl3_cartridge",
             return_value=True,
         ) as has_cartridge,
-        patch(
-            "vllm.model_executor.layers.quantization.exl3_lora_cartridge."
-            "prepare_exl3_cartridge_into_model",
-            return_value=10,
-        ) as prepare,
         patch(
             "vllm.model_executor.layers.quantization.exl3_lora_cartridge."
             "activate_exl3_cartridge",
@@ -760,17 +1460,17 @@ def test_worker_cartridge_operations_use_collective_rpc_target_model():
     ):
         Worker.clear_exl3_cartridge_cudagraphs(worker)
         assert Worker.has_exl3_cartridge(worker) is True
-        assert Worker.prepare_exl3_cartridge(worker, "cartridge.safetensors") == 10
         assert Worker.activate_exl3_cartridge(worker) == 10
         assert Worker.deactivate_exl3_cartridge(worker) == 10
         assert Worker.capture_exl3_cartridge_cudagraphs(worker) == 123
 
     model_runner.clear_cudagraphs.assert_called_once_with()
     model_runner.capture_model.assert_called_once_with()
-    model_runner._dummy_run.assert_called_once_with(32, skip_eplb=True)
+    model_runner._dummy_run.assert_called_once_with(
+        32, skip_eplb=True, remove_lora=False
+    )
     worker._warmup_kernels_once.assert_called_once_with()
     has_cartridge.assert_called_once_with(model)
-    prepare.assert_called_once_with(model, "cartridge.safetensors")
     activate.assert_called_once_with(model)
     deactivate.assert_called_once_with(model)
     synchronize.assert_called_once_with()
@@ -781,13 +1481,12 @@ def test_worker_relocks_workspace_after_recapture_failure():
     model_runner = SimpleNamespace(
         capture_model=MagicMock(side_effect=RuntimeError("capture failed"))
     )
-    worker = SimpleNamespace(
-        model_runner=model_runner,
-        vllm_config=SimpleNamespace(
-            compilation_config=SimpleNamespace(mode=CompilationMode.NONE)
-        ),
-        _warmup_kernels_once=MagicMock(),
+    worker = object.__new__(Worker)
+    worker.model_runner = model_runner
+    worker.vllm_config = SimpleNamespace(
+        compilation_config=SimpleNamespace(mode=CompilationMode.NONE)
     )
+    worker._warmup_kernels_once = MagicMock()
     with (
         patch("vllm.v1.worker.gpu_worker.lock_workspace") as lock,
         pytest.raises(RuntimeError, match="capture failed"),
@@ -795,6 +1494,65 @@ def test_worker_relocks_workspace_after_recapture_failure():
         Worker.capture_exl3_cartridge_cudagraphs(worker)
 
     lock.assert_called_once_with()
+
+
+def test_worker_stages_only_after_abi_preflight():
+    staged = SimpleNamespace(
+        state=SimpleNamespace(by_layer={"model.layers.3.mlp.experts": []}),
+        local_layer_names=("model.layers.3.mlp.experts",),
+    )
+    worker = SimpleNamespace(
+        model_runner=SimpleNamespace(model=SimpleNamespace()),
+        vllm_config=SimpleNamespace(
+            parallel_config=SimpleNamespace(
+                data_parallel_size=1,
+                pipeline_parallel_size=1,
+            ),
+            use_v2_model_runner=False,
+            lora_config=None,
+        ),
+    )
+    order = []
+    with (
+        patch.object(
+            cartridge_module,
+            "_load_additive_exl3_ext",
+            side_effect=lambda: order.append("abi"),
+        ),
+        patch.object(
+            cartridge_module,
+            "stage_exl3_cartridge_adapter",
+            side_effect=lambda *_args: (order.append("stage"), staged)[1],
+        ),
+    ):
+        assert Worker.stage_exl3_cartridge(worker, "/adapter", "id") == 1
+    assert order == ["abi", "stage"]
+
+
+def test_worker_does_not_register_stage_on_abi_failure():
+    worker = SimpleNamespace(
+        model_runner=SimpleNamespace(model=SimpleNamespace()),
+        vllm_config=SimpleNamespace(
+            parallel_config=SimpleNamespace(
+                data_parallel_size=1,
+                pipeline_parallel_size=1,
+            ),
+            use_v2_model_runner=False,
+            lora_config=None,
+        ),
+    )
+    with (
+        patch.object(
+            cartridge_module,
+            "_load_additive_exl3_ext",
+            side_effect=RuntimeError("ABI mismatch"),
+        ),
+        patch.object(cartridge_module, "stage_exl3_cartridge_adapter") as stage,
+        pytest.raises(RuntimeError, match="ABI mismatch"),
+    ):
+        Worker.stage_exl3_cartridge(worker, "/adapter", "id")
+    stage.assert_not_called()
+    assert not hasattr(worker, "_exl3_cartridge_stages")
 
 
 def test_gpu_runner_clear_cudagraphs_releases_every_graph_owner():
@@ -822,138 +1580,267 @@ def test_gpu_runner_clear_cudagraphs_releases_every_graph_owner():
     empty_cache.assert_called_once_with()
 
 
-def test_engine_cartridge_operations_dispatch_to_every_worker():
-    engine = SimpleNamespace(
-        _prepare_for_exl3_weight_switch=MagicMock(),
-        collective_rpc=MagicMock(
-            side_effect=[None, [10], [10], 123, [True], None, [10], 123]
-        ),
-    )
+def test_sync_engine_rejects_cartridge_graph_switches():
+    engine = SimpleNamespace()
 
-    assert LLMEngine.load_exl3_cartridge(engine, "cartridge.safetensors") == [10]
-    assert LLMEngine.deactivate_exl3_cartridge(engine) == [10]
-    assert engine.collective_rpc.call_args_list == [
-        (("clear_exl3_cartridge_cudagraphs",), {}),
-        (("prepare_exl3_cartridge",), {"args": ("cartridge.safetensors",)}),
-        (("activate_exl3_cartridge",), {}),
-        (("capture_exl3_cartridge_cudagraphs",), {}),
-        (("has_exl3_cartridge",), {}),
-        (("clear_exl3_cartridge_cudagraphs",), {}),
-        (("deactivate_exl3_cartridge",), {}),
-        (("capture_exl3_cartridge_cudagraphs",), {}),
-    ]
-
-
-def test_engine_cartridge_deactivate_is_noop_without_runtime():
-    engine = SimpleNamespace(
-        _prepare_for_exl3_weight_switch=MagicMock(),
-        collective_rpc=MagicMock(return_value=[False, False]),
-    )
-
-    assert LLMEngine.deactivate_exl3_cartridge(engine) == [0, 0]
-    engine.collective_rpc.assert_called_once_with("has_exl3_cartridge")
-    engine._prepare_for_exl3_weight_switch.assert_not_called()
-
-
-def test_engine_cartridge_load_rolls_back_every_worker_on_commit_failure():
-    engine = SimpleNamespace(
-        _prepare_for_exl3_weight_switch=MagicMock(),
-        collective_rpc=MagicMock(
-            side_effect=[
-                None,
-                [10, 10],
-                RuntimeError("commit failed"),
-                None,
-                [10, 10],
-                123,
-            ]
-        ),
-    )
-
-    with pytest.raises(RuntimeError, match="commit failed"):
+    with pytest.raises(NotImplementedError, match="only by AsyncLLM"):
         LLMEngine.load_exl3_cartridge(engine, "cartridge.safetensors")
-
-    assert [call.args[0] for call in engine.collective_rpc.call_args_list[-3:]] == [
-        "clear_exl3_cartridge_cudagraphs",
-        "deactivate_exl3_cartridge",
-        "capture_exl3_cartridge_cudagraphs",
-    ]
+    with pytest.raises(NotImplementedError, match="only by AsyncLLM"):
+        LLMEngine.deactivate_exl3_cartridge(engine)
 
 
-def test_engine_shuts_down_when_base_graph_restore_fails():
-    engine = SimpleNamespace(
-        _prepare_for_exl3_weight_switch=MagicMock(),
-        collective_rpc=MagicMock(
-            side_effect=[
-                None,
-                RuntimeError("load failed"),
-                RuntimeError("restore failed"),
-            ]
-        ),
-        engine_core=SimpleNamespace(shutdown=MagicMock()),
-    )
-
-    with pytest.raises(RuntimeError, match="engine was shut down"):
-        LLMEngine.load_exl3_cartridge(engine, "cartridge.safetensors")
-
-    engine.engine_core.shutdown.assert_called_once_with()
-
-
-def test_sync_engine_weight_switch_requires_cache_invalidation():
-    engine = SimpleNamespace(
-        has_unfinished_requests=MagicMock(return_value=False),
-        reset_prefix_cache=MagicMock(return_value=True),
-        reset_mm_cache=MagicMock(),
-        reset_encoder_cache=MagicMock(),
-    )
-
-    LLMEngine._prepare_for_exl3_weight_switch(engine)
-
-    engine.reset_prefix_cache.assert_called_once_with(
-        reset_running_requests=True, reset_connector=True
-    )
-    engine.reset_mm_cache.assert_called_once_with()
-    engine.reset_encoder_cache.assert_called_once_with()
-
-
-def test_sync_engine_weight_switch_refuses_active_requests():
-    engine = SimpleNamespace(has_unfinished_requests=MagicMock(return_value=True))
-
-    with pytest.raises(RuntimeError, match="quiescent"):
-        LLMEngine._prepare_for_exl3_weight_switch(engine)
-
-
-def test_sync_engine_weight_switch_refuses_failed_cache_reset():
-    engine = SimpleNamespace(
-        has_unfinished_requests=MagicMock(return_value=False),
-        reset_prefix_cache=MagicMock(return_value=False),
-    )
-
-    with pytest.raises(RuntimeError, match="Unable to clear prefix cache"):
-        LLMEngine._prepare_for_exl3_weight_switch(engine)
-
-
-def test_async_load_clears_caches_and_rolls_back_on_cancellation():
+def test_async_load_stages_before_pause_and_discards_after_success():
     async def run():
         engine = object.__new__(AsyncLLM)
         engine.is_paused = AsyncMock(return_value=False)
-        engine.pause_generation = AsyncMock()
-        engine.resume_generation = AsyncMock()
-        engine.collective_rpc = AsyncMock(
-            side_effect=[asyncio.CancelledError(), None, [2], 123]
-        )
+        engine._pause_generation = AsyncMock()
+        engine._resume_generation = AsyncMock()
+        methods = []
 
+        async def rpc(method, *args, **kwargs):
+            del args, kwargs
+            methods.append(method)
+            if method == "stage_exl3_cartridge":
+                engine._pause_generation.assert_not_awaited()
+                return [2, 2]
+            if method in {
+                "prepare_staged_exl3_cartridge",
+                "activate_exl3_cartridge",
+            }:
+                return [2, 2]
+            return None
+
+        engine.collective_rpc = AsyncMock(side_effect=rpc)
+
+        assert await AsyncLLM._load_exl3_cartridge(engine, "cartridge.safetensors") == [
+            2,
+            2,
+        ]
+        assert methods == [
+            "stage_exl3_cartridge",
+            "clear_exl3_cartridge_cudagraphs",
+            "prepare_staged_exl3_cartridge",
+            "activate_exl3_cartridge",
+            "capture_exl3_cartridge_cudagraphs",
+            "discard_staged_exl3_cartridge",
+        ]
+        engine._pause_generation.assert_awaited_once_with(mode="wait", clear_cache=True)
+        engine._resume_generation.assert_awaited_once_with()
+
+    asyncio.run(run())
+
+
+@pytest.mark.parametrize(
+    "stage_result",
+    [RuntimeError("worker preflight failed"), [2, 0]],
+)
+def test_async_stage_failure_discards_without_pausing(stage_result):
+    async def run():
+        engine = object.__new__(AsyncLLM)
+        engine.is_paused = AsyncMock(return_value=False)
+        engine._pause_generation = AsyncMock()
+        engine._resume_generation = AsyncMock()
+        methods = []
+
+        async def rpc(method, *args, **kwargs):
+            del args, kwargs
+            methods.append(method)
+            if method == "stage_exl3_cartridge":
+                if isinstance(stage_result, BaseException):
+                    raise stage_result
+                return stage_result
+            return None
+
+        engine.collective_rpc = AsyncMock(side_effect=rpc)
+        with pytest.raises(RuntimeError):
+            await AsyncLLM._load_exl3_cartridge(engine, "cartridge.safetensors")
+        assert methods == [
+            "stage_exl3_cartridge",
+            "discard_staged_exl3_cartridge",
+        ]
+        engine._pause_generation.assert_not_awaited()
+        engine._resume_generation.assert_not_awaited()
+
+    asyncio.run(run())
+
+
+def test_async_load_rolls_back_after_post_pause_cancellation():
+    async def run():
+        engine = object.__new__(AsyncLLM)
+        engine.is_paused = AsyncMock(return_value=False)
+        engine._pause_generation = AsyncMock()
+        engine._resume_generation = AsyncMock()
+        methods = []
+        first_clear = True
+
+        async def rpc(method, *args, **kwargs):
+            nonlocal first_clear
+            del args, kwargs
+            methods.append(method)
+            if method == "stage_exl3_cartridge":
+                return [2, 2]
+            if method == "clear_exl3_cartridge_cudagraphs" and first_clear:
+                first_clear = False
+                raise asyncio.CancelledError()
+            if method == "deactivate_exl3_cartridge":
+                return [2, 2]
+            return None
+
+        engine.collective_rpc = AsyncMock(side_effect=rpc)
         with pytest.raises(asyncio.CancelledError):
             await AsyncLLM._load_exl3_cartridge(engine, "cartridge.safetensors")
-
-        engine.pause_generation.assert_awaited_once_with(mode="wait", clear_cache=True)
-        assert [call.args[0] for call in engine.collective_rpc.await_args_list] == [
+        assert methods == [
+            "stage_exl3_cartridge",
             "clear_exl3_cartridge_cudagraphs",
             "clear_exl3_cartridge_cudagraphs",
             "deactivate_exl3_cartridge",
             "capture_exl3_cartridge_cudagraphs",
+            "discard_staged_exl3_cartridge",
         ]
-        engine.resume_generation.assert_awaited_once_with()
+        engine._resume_generation.assert_awaited_once_with()
+
+    asyncio.run(run())
+
+
+def test_async_discard_failure_still_resumes():
+    async def run():
+        engine = object.__new__(AsyncLLM)
+        engine.is_paused = AsyncMock(return_value=False)
+        engine._pause_generation = AsyncMock()
+        engine._resume_generation = AsyncMock()
+
+        async def rpc(method, *args, **kwargs):
+            del args, kwargs
+            if method == "stage_exl3_cartridge":
+                return [1]
+            if method in {
+                "prepare_staged_exl3_cartridge",
+                "activate_exl3_cartridge",
+            }:
+                return [1]
+            if method == "discard_staged_exl3_cartridge":
+                raise RuntimeError("discard failed")
+            return None
+
+        engine.collective_rpc = AsyncMock(side_effect=rpc)
+        with pytest.raises(RuntimeError, match="discard failed"):
+            await AsyncLLM._load_exl3_cartridge(engine, "cartridge.safetensors")
+        engine._resume_generation.assert_awaited_once_with()
+
+    asyncio.run(run())
+
+
+@pytest.mark.parametrize("cancel_phase", ["discard", "resume"])
+def test_async_cleanup_cancellation_is_not_hidden_by_primary_error(cancel_phase):
+    async def run():
+        engine = object.__new__(AsyncLLM)
+        engine.is_paused = AsyncMock(return_value=False)
+        engine._pause_generation = AsyncMock()
+        phase_started = asyncio.Event()
+        finish_phase = asyncio.Event()
+        first_clear = True
+
+        async def rpc(method, *args, **kwargs):
+            nonlocal first_clear
+            del args, kwargs
+            if method == "stage_exl3_cartridge":
+                return [1]
+            if method == "clear_exl3_cartridge_cudagraphs" and first_clear:
+                first_clear = False
+                raise RuntimeError("primary failed")
+            if method == "deactivate_exl3_cartridge":
+                return [1]
+            if method == "discard_staged_exl3_cartridge" and cancel_phase == "discard":
+                phase_started.set()
+                await finish_phase.wait()
+            return None
+
+        async def resume():
+            if cancel_phase == "resume":
+                phase_started.set()
+                await finish_phase.wait()
+
+        engine.collective_rpc = AsyncMock(side_effect=rpc)
+        engine._resume_generation = AsyncMock(side_effect=resume)
+
+        with patch("vllm.v1.engine.async_llm.logger.error") as log_error:
+            load_task = asyncio.create_task(
+                AsyncLLM._load_exl3_cartridge(engine, "cartridge.safetensors")
+            )
+            await phase_started.wait()
+            load_task.cancel()
+            await asyncio.sleep(0)
+            finish_phase.set()
+            with pytest.raises(asyncio.CancelledError):
+                await load_task
+
+        engine._resume_generation.assert_awaited_once_with()
+        log_error.assert_not_called()
+
+    asyncio.run(run())
+
+
+def test_async_primary_error_survives_non_cancellation_cleanup_failure():
+    async def run():
+        engine = object.__new__(AsyncLLM)
+        engine.is_paused = AsyncMock(return_value=False)
+        engine._pause_generation = AsyncMock()
+        engine._resume_generation = AsyncMock()
+        first_clear = True
+
+        async def rpc(method, *args, **kwargs):
+            nonlocal first_clear
+            del args, kwargs
+            if method == "stage_exl3_cartridge":
+                return [1]
+            if method == "clear_exl3_cartridge_cudagraphs" and first_clear:
+                first_clear = False
+                raise RuntimeError("primary failed")
+            if method == "deactivate_exl3_cartridge":
+                return [1]
+            if method == "discard_staged_exl3_cartridge":
+                raise RuntimeError("discard failed")
+            return None
+
+        engine.collective_rpc = AsyncMock(side_effect=rpc)
+        with (
+            patch("vllm.v1.engine.async_llm.logger.error") as log_error,
+            pytest.raises(RuntimeError, match="primary failed"),
+        ):
+            await AsyncLLM._load_exl3_cartridge(engine, "cartridge.safetensors")
+
+        engine._resume_generation.assert_awaited_once_with()
+        log_error.assert_called_once()
+        assert log_error.call_args.args[0].startswith("EXL3 cartridge cleanup failed")
+
+    asyncio.run(run())
+
+
+def test_public_resume_waits_for_cartridge_transaction_lock():
+    async def run():
+        engine = object.__new__(AsyncLLM)
+        engine._engine_mutation_lock = asyncio.Lock()
+        entered = asyncio.Event()
+        release = asyncio.Event()
+
+        async def load(_path):
+            entered.set()
+            await release.wait()
+            return [1]
+
+        engine._load_exl3_cartridge = AsyncMock(side_effect=load)
+        engine._resume_generation = AsyncMock()
+        load_task = asyncio.create_task(
+            AsyncLLM.load_exl3_cartridge(engine, "cartridge.safetensors")
+        )
+        await entered.wait()
+        resume_task = asyncio.create_task(AsyncLLM.resume_generation(engine))
+        await asyncio.sleep(0)
+        engine._resume_generation.assert_not_awaited()
+        release.set()
+        assert await load_task == [1]
+        await resume_task
+        engine._resume_generation.assert_awaited_once_with()
 
     asyncio.run(run())
 
@@ -962,8 +1849,8 @@ def test_async_deactivate_recaptures_before_resuming():
     async def run():
         engine = object.__new__(AsyncLLM)
         engine.is_paused = AsyncMock(return_value=False)
-        engine.pause_generation = AsyncMock()
-        engine.resume_generation = AsyncMock()
+        engine._pause_generation = AsyncMock()
+        engine._resume_generation = AsyncMock()
         engine.collective_rpc = AsyncMock(side_effect=[[True], None, [2], 123])
 
         assert await AsyncLLM._deactivate_exl3_cartridge(engine) == [2]
@@ -973,8 +1860,8 @@ def test_async_deactivate_recaptures_before_resuming():
             "deactivate_exl3_cartridge",
             "capture_exl3_cartridge_cudagraphs",
         ]
-        engine.pause_generation.assert_awaited_once_with(mode="wait", clear_cache=True)
-        engine.resume_generation.assert_awaited_once_with()
+        engine._pause_generation.assert_awaited_once_with(mode="wait", clear_cache=True)
+        engine._resume_generation.assert_awaited_once_with()
 
     asyncio.run(run())
 
@@ -983,13 +1870,13 @@ def test_async_deactivate_is_noop_without_runtime():
     async def run():
         engine = object.__new__(AsyncLLM)
         engine.is_paused = AsyncMock()
-        engine.pause_generation = AsyncMock()
+        engine._pause_generation = AsyncMock()
         engine.collective_rpc = AsyncMock(return_value=[False, False])
 
         assert await AsyncLLM._deactivate_exl3_cartridge(engine) == [0, 0]
         engine.collective_rpc.assert_awaited_once_with("has_exl3_cartridge")
         engine.is_paused.assert_not_awaited()
-        engine.pause_generation.assert_not_awaited()
+        engine._pause_generation.assert_not_awaited()
 
     asyncio.run(run())
 
@@ -998,13 +1885,15 @@ def test_async_load_shuts_down_when_base_graph_restore_fails():
     async def run():
         engine = object.__new__(AsyncLLM)
         engine.is_paused = AsyncMock(return_value=False)
-        engine.pause_generation = AsyncMock()
-        engine.resume_generation = AsyncMock()
+        engine._pause_generation = AsyncMock()
+        engine._resume_generation = AsyncMock()
         engine.shutdown = MagicMock()
         engine.collective_rpc = AsyncMock(
             side_effect=[
+                [1],
                 RuntimeError("load failed"),
                 RuntimeError("restore failed"),
+                None,
             ]
         )
 
@@ -1012,6 +1901,6 @@ def test_async_load_shuts_down_when_base_graph_restore_fails():
             await AsyncLLM._load_exl3_cartridge(engine, "cartridge.safetensors")
 
         engine.shutdown.assert_called_once_with()
-        engine.resume_generation.assert_not_awaited()
+        engine._resume_generation.assert_not_awaited()
 
     asyncio.run(run())

--- a/tests/quantization/test_exl3_lora_cartridge.py
+++ b/tests/quantization/test_exl3_lora_cartridge.py
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Tests for EXL3 LoRA cartridge support.
+
+Tests the cartridge data structures, the _apply_expert patching mechanism,
+and the adapter loading logic. Uses mocks for the EXL3 GEMM kernel.
+"""
+
+import pytest
+import torch
+from unittest.mock import MagicMock, patch
+
+from vllm.model_executor.layers.quantization.exl3_lora_cartridge import (
+    Exl3LoraCartridge,
+    apply_exl3_cartridge,
+    exl3_get_supported_lora_modules,
+    load_cartridge_from_adapter,
+)
+
+
+def test_get_supported_lora_modules():
+    """Test that EXL3 returns the correct LoRA-capable module names."""
+    modules = exl3_get_supported_lora_modules()
+    assert "gate_proj" in modules
+    assert "up_proj" in modules
+    assert "down_proj" in modules
+    assert len(modules) == 3
+
+
+def test_cartridge_init():
+    """Test Exl3LoraCartridge initialization."""
+    cart = Exl3LoraCartridge(num_stages=2, num_experts=256, device=torch.device("cpu"))
+    assert cart.num_stages == 2
+    assert cart.num_experts == 256
+    assert not cart.active
+    assert len(cart.stages) == 2
+    assert all(isinstance(s, dict) for s in cart.stages)
+
+
+def test_cartridge_set_get_tensors():
+    """Test setting and getting cartridge tensors."""
+    cart = Exl3LoraCartridge(num_stages=1, num_experts=4, device=torch.device("cpu"))
+    trellis = torch.zeros(8, 16, 32, dtype=torch.int16)
+    suh = torch.ones(128, dtype=torch.float16)
+    svh = torch.ones(64, dtype=torch.float16)
+    scale = 2.5
+
+    cart.set_stage_tensors(0, 0, "w1", trellis, suh, svh, scale)
+    result = cart.get_stage_tensors(0, 0, "w1")
+    assert result is not None
+    assert torch.equal(result["trellis"], trellis)
+    assert result["scale"] == 2.5
+
+    # Non-existent expert
+    assert cart.get_stage_tensors(0, 1, "w1") is None
+
+
+def test_cartridge_clear():
+    """Test clearing cartridge tensors."""
+    cart = Exl3LoraCartridge(num_stages=1, num_experts=4, device=torch.device("cpu"))
+    cart.set_stage_tensors(0, 0, "w1", torch.zeros(8, 16, 32, dtype=torch.int16),
+                           torch.ones(128, dtype=torch.float16),
+                           torch.ones(64, dtype=torch.float16), 1.0)
+    cart.active = True
+    cart.clear()
+    assert not cart.active
+    assert len(cart.stages[0]) == 0
+
+
+def test_apply_cartridge_noop():
+    """Test that apply_exl3_cartridge is a no-op when cartridge is None or inactive."""
+    base_output = torch.randn(4, 64, dtype=torch.float16)
+    x = torch.randn(4, 128, dtype=torch.float16)
+    layer = MagicMock()
+
+    # No cartridge
+    result = apply_exl3_cartridge(base_output, x, layer, "w13", 0, "w1", None)
+    assert torch.equal(result, base_output)
+
+    # Inactive cartridge
+    cart = Exl3LoraCartridge(1, 4, torch.device("cpu"))
+    result = apply_exl3_cartridge(base_output, x, layer, "w13", 0, "w1", cart)
+    assert torch.equal(result, base_output)
+
+
+def test_apply_cartridge_with_stage():
+    """Test that apply_exl3_cartridge applies correction when cartridge is active."""
+    base_output = torch.randn(4, 64, dtype=torch.float16)
+    x = torch.randn(4, 128, dtype=torch.float16)
+    layer = MagicMock()
+    cart = Exl3LoraCartridge(1, 4, torch.device("cpu"))
+    cart.active = True
+    cart.set_stage_tensors(0, 0, "w1",
+                           torch.zeros(8, 16, 32, dtype=torch.int16),
+                           torch.ones(128, dtype=torch.float16),
+                           torch.ones(64, dtype=torch.float16),
+                           1.0)
+
+    with patch("vllm.model_executor.layers.quantization.exl3_lora_cartridge._exl3_gemm") as mock_gemm:
+        mock_gemm.return_value = torch.ones(4, 64, dtype=torch.float16)
+        result = apply_exl3_cartridge(base_output, x, layer, "w13", 0, "w1", cart)
+        # Should be base + cartridge_output * (1/scale) = base + ones * 1.0
+        expected = base_output + torch.ones(4, 64, dtype=torch.float16)
+        assert torch.allclose(result, expected, rtol=1e-5)
+        mock_gemm.assert_called_once()
+
+
+def test_cartridge_scale_correction():
+    """Test that rescaling factor is applied correctly."""
+    base_output = torch.zeros(4, 64, dtype=torch.float16)
+    x = torch.randn(4, 128, dtype=torch.float16)
+    layer = MagicMock()
+    cart = Exl3LoraCartridge(1, 4, torch.device("cpu"))
+    cart.active = True
+    scale = 3.0  # output should be cartridge_output / 3.0
+    cart.set_stage_tensors(0, 0, "w1",
+                           torch.zeros(8, 16, 32, dtype=torch.int16),
+                           torch.ones(128, dtype=torch.float16),
+                           torch.ones(64, dtype=torch.float16),
+                           scale)
+
+    with patch("vllm.model_executor.layers.quantization.exl3_lora_cartridge._exl3_gemm") as mock_gemm:
+        mock_gemm.return_value = torch.full((4, 64), 9.0, dtype=torch.float16)
+        result = apply_exl3_cartridge(base_output, x, layer, "w13", 0, "w1", cart)
+        # Should be 0 + 9.0 / 3.0 = 3.0
+        expected = torch.full((4, 64), 3.0, dtype=torch.float16)
+        assert torch.allclose(result, expected, rtol=1e-5)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/quantization/test_exl3_lora_cartridge.py
+++ b/tests/quantization/test_exl3_lora_cartridge.py
@@ -542,8 +542,20 @@ def test_model_loader_streams_layers_and_rolls_back_if_later_layer_is_missing():
 
     with (
         patch(
+            "safetensors.safe_open",
+            return_value=MagicMock(
+                __enter__=MagicMock(return_value=MagicMock()),
+                __exit__=MagicMock(return_value=False),
+            ),
+        ),
+        patch(
             "vllm.model_executor.layers.quantization.exl3_lora_cartridge."
-            "load_cartridge_from_adapter",
+            "_index_cartridge_keys",
+            return_value={},
+        ),
+        patch(
+            "vllm.model_executor.layers.quantization.exl3_lora_cartridge."
+            "_build_cartridge_from_entries",
             side_effect=[_cartridge(), None],
         ),
         patch.object(first_runtime, "materialize") as materialize,
@@ -566,8 +578,20 @@ def test_model_loader_deactivates_every_layer_after_materialization_failure():
 
     with (
         patch(
+            "safetensors.safe_open",
+            return_value=MagicMock(
+                __enter__=MagicMock(return_value=MagicMock()),
+                __exit__=MagicMock(return_value=False),
+            ),
+        ),
+        patch(
             "vllm.model_executor.layers.quantization.exl3_lora_cartridge."
-            "load_cartridge_from_adapter",
+            "_index_cartridge_keys",
+            return_value={},
+        ),
+        patch(
+            "vllm.model_executor.layers.quantization.exl3_lora_cartridge."
+            "_build_cartridge_from_entries",
             side_effect=[_cartridge(), _cartridge()],
         ),
         patch.object(runtimes[0], "materialize", side_effect=activate),
@@ -588,13 +612,27 @@ def test_model_loader_skips_layers_without_cartridge_capability():
     layer.exl3_cartridge_capable = False
     model = SimpleNamespace(modules=lambda: iter((layer,)))
 
-    with patch(
-        "vllm.model_executor.layers.quantization.exl3_lora_cartridge."
-        "load_cartridge_from_adapter"
-    ) as load:
+    with (
+        patch(
+            "safetensors.safe_open",
+            return_value=MagicMock(
+                __enter__=MagicMock(return_value=MagicMock()),
+                __exit__=MagicMock(return_value=False),
+            ),
+        ),
+        patch(
+            "vllm.model_executor.layers.quantization.exl3_lora_cartridge."
+            "_index_cartridge_keys",
+            return_value={},
+        ),
+        patch(
+            "vllm.model_executor.layers.quantization.exl3_lora_cartridge."
+            "_build_cartridge_from_entries"
+        ) as build,
+    ):
         assert prepare_exl3_cartridge_into_model(model, "cartridge.safetensors") == 0
 
-    load.assert_not_called()
+    build.assert_not_called()
     assert not hasattr(layer, "_exl3_cartridge_runtime")
 
 
@@ -607,8 +645,20 @@ def test_model_loader_allocates_and_releases_runtime_lazily():
 
     with (
         patch(
+            "safetensors.safe_open",
+            return_value=MagicMock(
+                __enter__=MagicMock(return_value=MagicMock()),
+                __exit__=MagicMock(return_value=False),
+            ),
+        ),
+        patch(
             "vllm.model_executor.layers.quantization.exl3_lora_cartridge."
-            "load_cartridge_from_adapter",
+            "_index_cartridge_keys",
+            return_value={},
+        ),
+        patch(
+            "vllm.model_executor.layers.quantization.exl3_lora_cartridge."
+            "_build_cartridge_from_entries",
             return_value=_cartridge(),
         ),
         patch.object(
@@ -641,8 +691,20 @@ def test_model_loader_activates_every_layer_only_after_materialization():
 
     with (
         patch(
+            "safetensors.safe_open",
+            return_value=MagicMock(
+                __enter__=MagicMock(return_value=MagicMock()),
+                __exit__=MagicMock(return_value=False),
+            ),
+        ),
+        patch(
             "vllm.model_executor.layers.quantization.exl3_lora_cartridge."
-            "load_cartridge_from_adapter",
+            "_index_cartridge_keys",
+            return_value={},
+        ),
+        patch(
+            "vllm.model_executor.layers.quantization.exl3_lora_cartridge."
+            "_build_cartridge_from_entries",
             side_effect=[_cartridge(), _cartridge()],
         ),
         patch.object(runtimes[0], "materialize", side_effect=mark_materialized),

--- a/tests/quantization/test_exl3_lora_cartridge.py
+++ b/tests/quantization/test_exl3_lora_cartridge.py
@@ -13,12 +13,12 @@ from safetensors.torch import save_file
 
 import vllm.model_executor.layers.quantization.exl3 as exl3_module
 from vllm.config import CUDAGraphMode
+from vllm.config.compilation import CompilationMode
 from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 from vllm.model_executor.layers.quantization.exl3 import Exl3Config, Exl3MoEMethod
 from vllm.model_executor.layers.quantization.exl3_lora_cartridge import (
     Exl3CUDAGraphCartridgeRuntime,
     Exl3LoraCartridge,
-    apply_exl3_cartridge,
     apply_exl3_cudagraph_cartridge,
     deactivate_exl3_cartridge,
     load_cartridge_from_adapter,
@@ -36,6 +36,7 @@ CPU = torch.device("cpu")
 
 
 def _runtime_layer(device: torch.device = CPU):
+    pointers = tuple(torch.zeros(2, dtype=torch.int64, device=device) for _ in range(9))
     return SimpleNamespace(
         local_num_experts=2,
         exl3_hidden_size=4,
@@ -43,6 +44,11 @@ def _runtime_layer(device: torch.device = CPU):
         exl3_params_dtype=torch.float16,
         exl3_cartridge_capable=True,
         exl3_cartridge_enabled=False,
+        exl3_tp_size=1,
+        exl3_max_num_batched_tokens=16,
+        exl3_layer_bitrates=(2, 2),
+        exl3_pointer_tables=pointers,
+        top_k=1,
         w13_trellis=SimpleNamespace(device=device),
         activation=SimpleNamespace(value="silu"),
         layer_name="model.layers.3.mlp.experts",
@@ -53,22 +59,32 @@ def _loader_layer():
     layer = _runtime_layer()
     layer.exl3_hidden_size = 16
     layer.exl3_intermediate_size_per_partition = 16
+    rotations = {
+        (0, "w1"): torch.ones(128, dtype=torch.float16),
+        (0, "w3"): torch.ones(128, dtype=torch.float16),
+    }
+    layer.w13_suh = SimpleNamespace(exl3_tensors=rotations)
+    layer.w13_svh = SimpleNamespace(exl3_tensors=rotations)
+    down_rotations = {(0, "w2"): torch.ones(128, dtype=torch.float16)}
+    layer.w2_suh = SimpleNamespace(exl3_tensors=down_rotations)
+    layer.w2_svh = SimpleNamespace(exl3_tensors=down_rotations)
     return layer
 
 
-def _cartridge(device: torch.device = CPU):
-    cartridge = Exl3LoraCartridge(1, 2, device)
-    for expert_id in range(2):
-        for shard_id in ("w1", "w3", "w2"):
-            cartridge.set_stage_tensors(
-                0,
-                expert_id,
-                shard_id,
-                torch.zeros(1, 1, 16, dtype=torch.int16),
-                torch.ones(1, dtype=torch.float16),
-                torch.ones(1, dtype=torch.float16),
-                1.0,
-            )
+def _cartridge(device: torch.device = CPU, num_stages: int = 1):
+    cartridge = Exl3LoraCartridge(num_stages, 2, device)
+    for stage_idx in range(num_stages):
+        for expert_id in range(2):
+            for shard_id in ("w1", "w3", "w2"):
+                cartridge.set_stage_tensors(
+                    stage_idx,
+                    expert_id,
+                    shard_id,
+                    torch.zeros(1, 1, 16, dtype=torch.int16),
+                    torch.ones(1, dtype=torch.float16),
+                    torch.ones(1, dtype=torch.float16),
+                    float(stage_idx + 1),
+                )
     cartridge.active = True
     return cartridge
 
@@ -87,13 +103,30 @@ def test_runtime_rejects_tensor_parallel_weights():
         prepare_exl3_cudagraph_cartridge_runtime(layer)
 
 
-def test_runtime_preserves_fp16_dense_kernel_contract():
+def test_runtime_allocates_packed_kernel_workspaces_without_dense_weights():
     layer = _runtime_layer()
     layer.exl3_params_dtype = torch.bfloat16
     runtime = prepare_exl3_cudagraph_cartridge_runtime(layer)
     assert runtime.dtype == torch.float16
-    assert runtime.w13.dtype == torch.float16
-    assert runtime.w2.dtype == torch.float16
+    assert runtime._packed_tensors == ()
+    assert not hasattr(runtime, "w13")
+    assert not hasattr(runtime, "w2")
+    assert runtime.xh.shape == (16, 4)
+    assert runtime.ig.shape[-2:] == (16, 2)
+
+
+def test_runtime_rejects_extension_without_additive_entrypoint():
+    layer = _runtime_layer()
+    layer.w13_trellis = SimpleNamespace(device=torch.device("cuda"))
+    with (
+        patch(
+            "vllm.model_executor.layers.quantization.exl3_lora_cartridge."
+            "_load_exl3_ext",
+            return_value=SimpleNamespace(),
+        ),
+        pytest.raises(RuntimeError, match="exl3_moe_additive_fused"),
+    ):
+        Exl3CUDAGraphCartridgeRuntime(layer)
 
 
 def test_runtime_rejects_activation_before_materialization():
@@ -119,102 +152,76 @@ def test_cartridge_validates_indices_and_scale():
         cartridge.set_stage_tensors(0, 0, "w1", *tensors, 0.0)
 
 
-def test_apply_cartridge_sums_stages_with_scale():
-    base_output = torch.zeros(4, 2, dtype=torch.float16)
-    inputs = torch.randn(4, 4, dtype=torch.float16)
-    cartridge = Exl3LoraCartridge(2, 1, torch.device("cpu"))
-    for stage, scale in enumerate((2.0, 4.0)):
-        cartridge.set_stage_tensors(
-            stage,
-            0,
-            "w1",
-            torch.zeros(1, 1, 16, dtype=torch.int16),
-            torch.ones(4, dtype=torch.float16),
-            torch.ones(2, dtype=torch.float16),
-            scale,
-        )
-    cartridge.active = True
-
-    with patch(
-        "vllm.model_executor.layers.quantization.exl3_lora_cartridge._exl3_gemm",
-        return_value=torch.full((4, 16), 8.0, dtype=torch.float16),
-    ) as gemm:
-        result = apply_exl3_cartridge(
-            base_output, inputs, None, "w13", 0, "w1", cartridge
-        )
-
-    assert torch.equal(result, torch.full((4, 2), 6.0, dtype=torch.float32))
-    assert gemm.call_count == 2
-    assert gemm.call_args.args[0].shape == (4, 16)
-
-
-def test_runtime_materializes_exact_combined_projection_weights():
+def test_runtime_retains_packed_stages_and_builds_kernel_metadata():
     layer = _runtime_layer()
     runtime = Exl3CUDAGraphCartridgeRuntime(layer)
     cartridge = _cartridge()
 
-    def base_projection(_layer, group, inputs, _expert_id, shard_id):
-        value = {"w1": 1.0, "w3": 2.0, "w2": 3.0}[shard_id]
-        width = 4 if group == "w2" else 2
-        return torch.full((inputs.shape[0], width), value, dtype=torch.float16)
+    runtime.materialize(layer, cartridge)
 
-    def residual_projection(inputs, trellis, *_args, **_kwargs):
-        return torch.ones((inputs.shape[0], trellis.shape[1] * 16), dtype=torch.float16)
-
-    with (
-        patch.object(
-            __import__(
-                "vllm.model_executor.layers.quantization.exl3_lora_cartridge",
-                fromlist=["Exl3MoEMethod"],
-            ).Exl3MoEMethod,
-            "_apply_expert",
-            side_effect=base_projection,
-        ),
-        patch(
-            "vllm.model_executor.layers.quantization.exl3_lora_cartridge._exl3_gemm",
-            side_effect=residual_projection,
-        ),
-    ):
-        runtime.materialize(layer, cartridge)
-
-    assert torch.equal(runtime.w13[:, :2], torch.full((2, 2, 4), 2.0))
-    assert torch.equal(runtime.w13[:, 2:], torch.full((2, 2, 4), 3.0))
-    assert torch.equal(runtime.w2, torch.full((2, 4, 2), 4.0))
-    assert runtime.active.item() == 0.0
+    assert len(runtime.pointer_args) == 9
+    assert len(runtime._packed_tensors) == 15
+    assert all(table.shape == (1, 2) for table in runtime.pointer_args[:6])
+    assert all(table.shape == (1,) for table in runtime.pointer_args[6:])
+    assert runtime.max_residual_bits == 1
+    gate_scales, up_scales, down_scales = runtime.pointer_args[3:6]
+    expected_scales = torch.ones(1, 2, dtype=torch.float32)
+    assert torch.equal(gate_scales, expected_scales)
+    assert torch.equal(up_scales, expected_scales)
+    assert torch.equal(down_scales, expected_scales)
+    assert runtime._active is False
 
 
-def test_runtime_rejects_nonfinite_materialized_weights():
+def test_runtime_builds_multistage_extension_metadata():
+    layer = _runtime_layer()
+    runtime = Exl3CUDAGraphCartridgeRuntime(layer)
+    runtime.materialize(layer, _cartridge(num_stages=2))
+
+    pointers = runtime.pointer_args[:3]
+    scales = runtime.pointer_args[3:6]
+    bitrates = runtime.pointer_args[6:]
+    assert all(table.shape == (2, 2) for table in pointers)
+    assert all(
+        torch.equal(
+            table,
+            torch.tensor([[1.0, 1.0], [0.5, 0.5]], dtype=torch.float32),
+        )
+        for table in scales
+    )
+    assert all(
+        torch.equal(table, torch.tensor([1, 1], dtype=torch.int32))
+        for table in bitrates
+    )
+
+
+def test_runtime_zero_scales_sparse_stage_entries():
+    layer = _runtime_layer()
+    cartridge = _cartridge(num_stages=2)
+    for shard_id in ("w1", "w3", "w2"):
+        del cartridge.stages[1][(1, shard_id)]
+    runtime = Exl3CUDAGraphCartridgeRuntime(layer)
+    runtime.materialize(layer, cartridge)
+
+    for pointers, scales in zip(runtime.pointer_args[:3], runtime.pointer_args[3:6]):
+        assert pointers[1, 1].item() == pointers[1, 0].item()
+        assert torch.equal(
+            scales,
+            torch.tensor([[1.0, 1.0], [0.5, 0.0]], dtype=torch.float32),
+        )
+
+
+def test_runtime_rejects_nonfinite_inverse_scale():
     layer = _runtime_layer()
     runtime = Exl3CUDAGraphCartridgeRuntime(layer)
     cartridge = _cartridge()
     for stage in cartridge.stages:
         for tensors in stage.values():
-            tensors["scale"] = 1e-30
+            tensors["scale"] = 1e-40
 
-    def base_projection(_layer, group, inputs, _expert_id, _shard_id):
-        width = 4 if group == "w2" else 2
-        return torch.zeros((inputs.shape[0], width), dtype=torch.float16)
-
-    with (
-        patch.object(
-            __import__(
-                "vllm.model_executor.layers.quantization.exl3_lora_cartridge",
-                fromlist=["Exl3MoEMethod"],
-            ).Exl3MoEMethod,
-            "_apply_expert",
-            side_effect=base_projection,
-        ),
-        patch(
-            "vllm.model_executor.layers.quantization.exl3_lora_cartridge._exl3_gemm",
-            side_effect=lambda inputs, *_args, **_kwargs: torch.ones(
-                (inputs.shape[0], 16), dtype=torch.float16
-            ),
-        ),
-        pytest.raises(ValueError, match="non-finite weights"),
-    ):
+    with pytest.raises(ValueError, match="inverse scale is not finite in FP32"):
         runtime.materialize(layer, cartridge)
 
-    assert runtime.active.item() is False
+    assert runtime._active is False
 
 
 @pytest.mark.parametrize(
@@ -383,55 +390,57 @@ def test_active_rank_sliced_layer_skips_compressed_base_path():
 
 def test_graph_path_routes_original_ids_once():
     layer = _runtime_layer()
-    prepare_exl3_cudagraph_cartridge_runtime(layer)
-    dense = torch.full((3, 4), torch.nan, dtype=torch.float16)
+    runtime = prepare_exl3_cudagraph_cartridge_runtime(layer)
+    runtime.pointer_args = tuple(torch.zeros(2, dtype=torch.int64) for _ in range(9))
+    runtime._materialized = True
+    runtime.activate()
     inputs = torch.zeros(3, 4, dtype=torch.float16)
     weights = torch.ones(3, 1, dtype=torch.float32)
     ids = torch.tensor([[1], [0], [1]], dtype=torch.long)
 
-    with patch(
-        "vllm.model_executor.layers.quantization.exl3_lora_cartridge.fused_experts",
-        return_value=dense,
-    ) as fused:
-        output = apply_exl3_cudagraph_cartridge(inputs, weights, ids, layer)
+    def run_additive(*args):
+        args[1].fill_(torch.nan)
+
+    additive = MagicMock(side_effect=run_additive)
+    runtime.ext = SimpleNamespace(exl3_moe_additive_fused=additive)
+    output = apply_exl3_cudagraph_cartridge(inputs, weights, ids, layer)
 
     assert torch.isnan(output).all()
-    fused.assert_called_once()
-    assert torch.equal(fused.call_args.args[4], ids)
+    additive.assert_called_once()
+    assert torch.equal(additive.call_args.args[2], ids)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
-def test_dense_cartridge_replays_with_fixed_weights_in_one_cuda_graph():
-    device = torch.device("cuda")
-    layer = _loader_layer()
-    layer.w13_trellis.device = device
+def test_graph_path_accepts_empty_route_batch():
+    layer = _runtime_layer()
     runtime = prepare_exl3_cudagraph_cartridge_runtime(layer)
-    inputs = torch.ones(3, 16, dtype=torch.float16, device=device)
-    weights = torch.ones(3, 1, dtype=torch.float32, device=device)
-    ids = torch.zeros(3, 1, dtype=torch.long, device=device)
-
-    runtime.w13.fill_(0.1)
-    runtime.w2.fill_(0.1)
     runtime._materialized = True
     runtime.activate()
-    w13_pointer = runtime.w13.data_ptr()
-    w2_pointer = runtime.w2.data_ptr()
+    runtime.ext = SimpleNamespace(exl3_moe_additive_fused=MagicMock())
 
-    graph = torch.cuda.CUDAGraph()
-    torch.cuda.synchronize()
-    with torch.cuda.graph(graph):
-        output = apply_exl3_cudagraph_cartridge(inputs, weights, ids, layer)
-    graph.replay()
-    torch.cuda.synchronize()
-    initial = output.clone()
+    output = apply_exl3_cudagraph_cartridge(
+        torch.empty(0, 4, dtype=torch.float16),
+        torch.empty(0, 1, dtype=torch.float32),
+        torch.empty(0, 1, dtype=torch.long),
+        layer,
+    )
 
-    runtime.w13.fill_(0.2)
-    runtime.w2.fill_(0.2)
-    graph.replay()
-    torch.cuda.synchronize()
-    assert not torch.equal(output, initial)
-    assert runtime.w13.data_ptr() == w13_pointer
-    assert runtime.w2.data_ptr() == w2_pointer
+    assert output.shape == (0, 4)
+    runtime.ext.exl3_moe_additive_fused.assert_not_called()
+
+
+def test_packed_runtime_retains_trellis_storage_after_cartridge_clear():
+    layer = _runtime_layer()
+    runtime = Exl3CUDAGraphCartridgeRuntime(layer)
+    cartridge = _cartridge()
+    source_trellis = cartridge.get_stage_tensors(0, 0, "w1")["trellis"]
+    assert isinstance(source_trellis, torch.Tensor)
+
+    runtime.materialize(layer, cartridge)
+    pointer = source_trellis.data_ptr()
+    cartridge.clear()
+
+    assert any(tensor.data_ptr() == pointer for tensor in runtime._packed_tensors)
+    assert runtime.pointer_args[0][0, 0].item() == pointer
 
 
 def test_loader_filters_layer_and_sorts_stage_numbers(tmp_path):
@@ -469,6 +478,21 @@ def test_loader_filters_layer_and_sorts_stage_numbers(tmp_path):
     stage1 = cartridge.get_stage_tensors(1, 0, "w1")
     assert stage0 is not None and stage0["scale"] == 2.0
     assert stage1 is not None and stage1["scale"] == 10.0
+
+
+def test_loader_rejects_rotations_that_differ_from_base(tmp_path):
+    path = tmp_path / "different-rotations.safetensors"
+    tensors = {}
+    for projection in ("gate_proj", "up_proj", "down_proj"):
+        prefix = f"model.layers.3.mlp.experts.0.{projection}.rank0"
+        tensors[f"{prefix}.trellis_res1"] = torch.zeros(8, 8, 32, dtype=torch.int16)
+        tensors[f"{prefix}.suh_res1"] = torch.ones(128, dtype=torch.float16)
+        tensors[f"{prefix}.svh_res1"] = torch.ones(128, dtype=torch.float16)
+    tensors["model.layers.3.mlp.experts.0.gate_proj.rank0.suh_res1"].zero_()
+    save_file(tensors, path)
+
+    with pytest.raises(ValueError, match="rotations must match"):
+        load_cartridge_from_adapter(str(path), _loader_layer(), 1, CPU)
 
 
 def test_loader_rejects_incomplete_projection(tmp_path):
@@ -538,11 +562,12 @@ def test_loader_rejects_malformed_target_key(tmp_path):
         load_cartridge_from_adapter(str(path), _loader_layer(), 2, CPU)
 
 
-def test_model_loader_preflights_every_layer_before_materializing():
+def test_model_loader_streams_layers_and_rolls_back_if_later_layer_is_missing():
     layers = [_runtime_layer(), _runtime_layer()]
     layers[1].layer_name = "model.layers.4.mlp.experts"
     for layer in layers:
         prepare_exl3_cudagraph_cartridge_runtime(layer)
+    first_runtime = layers[0]._exl3_cartridge_runtime
     model = SimpleNamespace(modules=lambda: iter(layers))
 
     with (
@@ -551,12 +576,13 @@ def test_model_loader_preflights_every_layer_before_materializing():
             "load_cartridge_from_adapter",
             side_effect=[_cartridge(), None],
         ),
-        patch.object(layers[0]._exl3_cartridge_runtime, "materialize") as materialize,
+        patch.object(first_runtime, "materialize") as materialize,
         pytest.raises(ValueError, match="has no tensors"),
     ):
         load_exl3_cartridge_into_model(model, "cartridge.safetensors")
 
-    materialize.assert_not_called()
+    materialize.assert_called_once()
+    assert all(not hasattr(layer, "_exl3_cartridge_runtime") for layer in layers)
 
 
 def test_model_loader_deactivates_every_layer_after_materialization_failure():
@@ -566,7 +592,7 @@ def test_model_loader_deactivates_every_layer_after_materialization_failure():
     model = SimpleNamespace(modules=lambda: iter(layers))
 
     def activate(_layer, _cartridge):
-        runtimes[0].active.fill_(1)
+        runtimes[0]._active = True
 
     with (
         patch(
@@ -584,7 +610,7 @@ def test_model_loader_deactivates_every_layer_after_materialization_failure():
     ):
         load_exl3_cartridge_into_model(model, "cartridge.safetensors")
 
-    assert all(runtime.active.item() == 0.0 for runtime in runtimes)
+    assert all(not runtime._active for runtime in runtimes)
 
 
 def test_model_loader_skips_layers_without_cartridge_capability():
@@ -654,19 +680,28 @@ def test_model_loader_activates_every_layer_only_after_materialization():
     ):
         assert load_exl3_cartridge_into_model(model, "cartridge.safetensors") == 2
 
-    assert all(runtime.active.item() == 1.0 for runtime in runtimes)
+    assert all(runtime._active for runtime in runtimes)
 
 
 def test_worker_cartridge_operations_use_collective_rpc_target_model():
     model = SimpleNamespace()
+    compilation_config = SimpleNamespace(
+        mode=CompilationMode.VLLM_COMPILE,
+        compile_sizes=[32, 16],
+        cudagraph_capture_sizes=[16],
+        get_compile_ranges=lambda: [],
+    )
     model_runner = SimpleNamespace(
         model=model,
         clear_cudagraphs=MagicMock(),
         capture_model=MagicMock(return_value=123),
         _dummy_run=MagicMock(),
-        max_num_tokens=16,
     )
-    worker = SimpleNamespace(model_runner=model_runner)
+    worker = SimpleNamespace(
+        model_runner=model_runner,
+        vllm_config=SimpleNamespace(compilation_config=compilation_config),
+        _warmup_kernels_once=MagicMock(),
+    )
     with (
         patch(
             "vllm.model_executor.layers.quantization.exl3_lora_cartridge."
@@ -700,7 +735,8 @@ def test_worker_cartridge_operations_use_collective_rpc_target_model():
 
     model_runner.clear_cudagraphs.assert_called_once_with()
     model_runner.capture_model.assert_called_once_with()
-    model_runner._dummy_run.assert_called_once_with(16, is_profile=True, skip_eplb=True)
+    model_runner._dummy_run.assert_called_once_with(32, skip_eplb=True)
+    worker._warmup_kernels_once.assert_called_once_with()
     has_cartridge.assert_called_once_with(model)
     prepare.assert_called_once_with(model, "cartridge.safetensors")
     activate.assert_called_once_with(model)
@@ -710,12 +746,15 @@ def test_worker_cartridge_operations_use_collective_rpc_target_model():
 
 
 def test_worker_relocks_workspace_after_recapture_failure():
+    model_runner = SimpleNamespace(
+        capture_model=MagicMock(side_effect=RuntimeError("capture failed"))
+    )
     worker = SimpleNamespace(
-        model_runner=SimpleNamespace(
-            _dummy_run=MagicMock(),
-            max_num_tokens=16,
-            capture_model=MagicMock(side_effect=RuntimeError("capture failed")),
-        )
+        model_runner=model_runner,
+        vllm_config=SimpleNamespace(
+            compilation_config=SimpleNamespace(mode=CompilationMode.NONE)
+        ),
+        _warmup_kernels_once=MagicMock(),
     )
     with (
         patch("vllm.v1.worker.gpu_worker.lock_workspace") as lock,

--- a/tests/quantization/test_exl3_lora_cartridge.py
+++ b/tests/quantization/test_exl3_lora_cartridge.py
@@ -81,8 +81,6 @@ def _cartridge(device: torch.device = CPU, num_stages: int = 1):
                     expert_id,
                     shard_id,
                     torch.zeros(1, 1, 16, dtype=torch.int16),
-                    torch.ones(1, dtype=torch.float16),
-                    torch.ones(1, dtype=torch.float16),
                     float(stage_idx + 1),
                 )
     cartridge.active = True
@@ -137,11 +135,7 @@ def test_runtime_rejects_activation_before_materialization():
 
 def test_cartridge_validates_indices_and_scale():
     cartridge = Exl3LoraCartridge(1, 2, torch.device("cpu"))
-    tensors = (
-        torch.zeros(1, 1, 16, dtype=torch.int16),
-        torch.ones(1, dtype=torch.float16),
-        torch.ones(1, dtype=torch.float16),
-    )
+    tensors = (torch.zeros(1, 1, 16, dtype=torch.int16),)
     with pytest.raises(IndexError, match="stage index"):
         cartridge.set_stage_tensors(1, 0, "w1", *tensors, 1.0)
     with pytest.raises(IndexError, match="expert index"):
@@ -455,8 +449,6 @@ def test_loader_filters_layer_and_sorts_stage_numbers(tmp_path):
                     f"{prefix}.trellis_res{value}": torch.full(
                         (8, 8, 32), value, dtype=torch.int16
                     ),
-                    f"{prefix}.suh_res{value}": torch.ones(128, dtype=torch.float16),
-                    f"{prefix}.svh_res{value}": torch.ones(128, dtype=torch.float16),
                     f"{prefix}.scale_res{value}": torch.tensor(float(value)),
                 }
             )
@@ -480,30 +472,12 @@ def test_loader_filters_layer_and_sorts_stage_numbers(tmp_path):
     assert stage1 is not None and stage1["scale"] == 10.0
 
 
-def test_loader_rejects_rotations_that_differ_from_base(tmp_path):
-    path = tmp_path / "different-rotations.safetensors"
-    tensors = {}
-    for projection in ("gate_proj", "up_proj", "down_proj"):
-        prefix = f"model.layers.3.mlp.experts.0.{projection}.rank0"
-        tensors[f"{prefix}.trellis_res1"] = torch.zeros(8, 8, 32, dtype=torch.int16)
-        tensors[f"{prefix}.suh_res1"] = torch.ones(128, dtype=torch.float16)
-        tensors[f"{prefix}.svh_res1"] = torch.ones(128, dtype=torch.float16)
-    tensors["model.layers.3.mlp.experts.0.gate_proj.rank0.suh_res1"].zero_()
-    save_file(tensors, path)
-
-    with pytest.raises(ValueError, match="rotations must match"):
-        load_cartridge_from_adapter(str(path), _loader_layer(), 1, CPU)
-
-
 def test_loader_rejects_incomplete_projection(tmp_path):
     path = tmp_path / "broken.safetensors"
     save_file(
         {
             "model.layers.3.mlp.experts.0.gate_proj.rank0.trellis_res1": (
                 torch.zeros(8, 8, 32, dtype=torch.int16)
-            ),
-            "model.layers.3.mlp.experts.0.gate_proj.rank0.suh_res1": (
-                torch.ones(128, dtype=torch.float16)
             ),
         },
         path,
@@ -522,8 +496,6 @@ def test_loader_rejects_invalid_trellis_shape(tmp_path):
         tensors[f"{tensor_prefix}.trellis_res1"] = torch.zeros(
             8, 8, 15 if projection == "gate_proj" else 32, dtype=torch.int16
         )
-        tensors[f"{tensor_prefix}.suh_res1"] = torch.ones(128, dtype=torch.float16)
-        tensors[f"{tensor_prefix}.svh_res1"] = torch.ones(128, dtype=torch.float16)
     save_file(tensors, path)
 
     with pytest.raises(ValueError, match="Invalid MSRT cartridge trellis"):
@@ -539,8 +511,6 @@ def test_loader_rejects_oversized_packed_dimensions(tmp_path):
         tensors[f"{tensor_prefix}.trellis_res1"] = torch.zeros(
             16, 8, 32, dtype=torch.int16
         )
-        tensors[f"{tensor_prefix}.suh_res1"] = torch.ones(256, dtype=torch.float16)
-        tensors[f"{tensor_prefix}.svh_res1"] = torch.ones(128, dtype=torch.float16)
     save_file(tensors, path)
 
     with pytest.raises(ValueError, match="128-aligned logical shape"):

--- a/tests/v1/worker/test_gpu_worker.py
+++ b/tests/v1/worker/test_gpu_worker.py
@@ -3,11 +3,14 @@
 
 import sys
 from types import SimpleNamespace
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, call, patch
 
 import pytest
 
 import vllm.v1.worker.gpu_worker as gpu_worker_module
+from vllm.config import CUDAGraphMode
+from vllm.config.compilation import CompilationMode
+from vllm.config.utils import Range
 from vllm.multimodal.video import (
     PYNVVIDEOCODEC_CUDA_CONTEXT_BYTES,
     PYNVVIDEOCODEC_DECODER_GPU_MEMORY_BYTES,
@@ -104,6 +107,62 @@ def test_failed_kernel_warmup_is_retryable(monkeypatch: pytest.MonkeyPatch):
 
     assert calls == 2
     assert worker._kernel_warmup_complete is True
+
+
+@pytest.mark.parametrize(
+    ("cudagraph_mode", "expected_sizes"),
+    [
+        (CUDAGraphMode.NONE, [32, 16, 8, 64]),
+        (CUDAGraphMode.FULL, [32, 8, 64]),
+    ],
+)
+def test_compile_warmup_sizes_respect_cudagraph_mode(
+    cudagraph_mode: CUDAGraphMode,
+    expected_sizes: list[int],
+):
+    worker = object.__new__(Worker)
+    worker.vllm_config = SimpleNamespace(
+        compilation_config=SimpleNamespace(
+            mode=CompilationMode.VLLM_COMPILE,
+            compile_sizes=[32, 16],
+            cudagraph_mode=cudagraph_mode,
+            cudagraph_capture_sizes=[16],
+            get_compile_ranges=lambda: [
+                Range(1, 8),
+                Range(9, 16),
+                Range(17, 32),
+                Range(33, 64),
+            ],
+        )
+    )
+
+    assert worker._get_compile_warmup_sizes() == expected_sizes
+
+
+def test_cartridge_recapture_uses_shared_warmup_contract():
+    worker = object.__new__(Worker)
+    worker.vllm_config = SimpleNamespace(
+        compilation_config=SimpleNamespace(
+            mode=CompilationMode.VLLM_COMPILE,
+            compile_sizes=[32, 16],
+            cudagraph_mode=CUDAGraphMode.FULL,
+            cudagraph_capture_sizes=[16],
+            get_compile_ranges=lambda: [Range(1, 8)],
+        )
+    )
+    worker.model_runner = SimpleNamespace(
+        _dummy_run=Mock(),
+        capture_model=Mock(return_value=123),
+    )
+    worker._warmup_kernels_once = Mock()
+
+    assert worker.capture_exl3_cartridge_cudagraphs() == 123
+    assert worker.model_runner._dummy_run.call_args_list == [
+        call(32, skip_eplb=True, remove_lora=False),
+        call(8, skip_eplb=True, remove_lora=False),
+    ]
+    worker._warmup_kernels_once.assert_called_once_with()
+    worker.model_runner.capture_model.assert_called_once_with()
 
 
 def test_memory_profile_replays_model_after_kernel_warmup(

--- a/vllm/entrypoints/serve/__init__.py
+++ b/vllm/entrypoints/serve/__init__.py
@@ -42,6 +42,12 @@ def register_vllm_dev_api_routers(app: FastAPI):
 
     attach_cache_router(app)
 
+    from .dev.cartridge.api_router import (
+        attach_router as attach_cartridge_router,
+    )
+
+    attach_cartridge_router(app)
+
     from .dev.rlhf.api_router import attach_router as attach_rlhf_router
 
     attach_rlhf_router(app)

--- a/vllm/entrypoints/serve/dev/cartridge/api_router.py
+++ b/vllm/entrypoints/serve/dev/cartridge/api_router.py
@@ -16,6 +16,14 @@ router = APIRouter()
 
 
 def engine_client(request: Request) -> EngineClient:
+    """Return the engine client attached to the application.
+
+    Args:
+        request: Incoming request whose application owns the engine client.
+
+    Returns:
+        The application's engine client.
+    """
     return request.app.state.engine_client
 
 
@@ -25,6 +33,15 @@ def _require_cartridge_engine(request: Request) -> EngineClient:
     Cartridge hot-swap (drain, swap, resume) is implemented on the V1
     ``AsyncLLM`` engine only; it is not part of the generic ``EngineClient``
     protocol.
+
+    Args:
+        request: Incoming request whose application owns the engine client.
+
+    Returns:
+        The cartridge-capable engine client.
+
+    Raises:
+        HTTPException: If the engine does not support cartridge hot-swap.
     """
     engine = engine_client(request)
     if not hasattr(engine, "load_exl3_cartridge"):
@@ -41,16 +58,27 @@ async def load_exl3_cartridge(raw_request: Request) -> JSONResponse:
 
     On failure the compressed base graphs are restored automatically before
     generation resumes; if the restore itself fails the engine shuts down.
+
+    Args:
+        raw_request: Request containing an ``adapter_path`` JSON field.
+
+    Returns:
+        A response containing the load status and per-worker layer counts.
+
+    Raises:
+        HTTPException: If the JSON body is malformed, ``adapter_path`` is
+            missing, or the engine does not support cartridge hot-swap.
     """
     try:
         body = await raw_request.json()
-    except json.JSONDecodeError as e:
+    except (json.JSONDecodeError, UnicodeDecodeError) as e:
+        logger.warning("Invalid JSON for EXL3 cartridge load")
         raise HTTPException(
             status_code=HTTPStatus.BAD_REQUEST.value,
-            detail=f"JSON decode error: {e}",
+            detail="Invalid JSON request body",
         ) from e
-    adapter_path = body.get("adapter_path")
-    if not adapter_path:
+    adapter_path = body.get("adapter_path") if isinstance(body, dict) else None
+    if not isinstance(adapter_path, str) or not adapter_path:
         raise HTTPException(
             status_code=HTTPStatus.BAD_REQUEST.value,
             detail="Missing 'adapter_path' in request body",
@@ -59,9 +87,10 @@ async def load_exl3_cartridge(raw_request: Request) -> JSONResponse:
     engine = _require_cartridge_engine(raw_request)
     try:
         updated_layers = await engine.load_exl3_cartridge(adapter_path)
-    except (ValueError, RuntimeError) as err:
+    except (ValueError, RuntimeError, TimeoutError):
+        logger.exception("EXL3 cartridge validation failed")
         return JSONResponse(
-            content={"error": str(err)},
+            content={"error": "EXL3 cartridge validation failed"},
             status_code=HTTPStatus.BAD_REQUEST.value,
         )
     return JSONResponse(
@@ -76,6 +105,15 @@ async def deactivate_exl3_cartridge(raw_request: Request) -> JSONResponse:
 
     A no-op (returns zero updated layers per worker) if no cartridge is
     currently active.
+
+    Args:
+        raw_request: Incoming deactivation request.
+
+    Returns:
+        A response containing the deactivation status and per-worker counts.
+
+    Raises:
+        HTTPException: If the engine does not support cartridge hot-swap.
     """
     engine = _require_cartridge_engine(raw_request)
     updated_layers = await engine.deactivate_exl3_cartridge()
@@ -87,11 +125,29 @@ async def deactivate_exl3_cartridge(raw_request: Request) -> JSONResponse:
 
 @router.get("/exl3_cartridge_status")
 async def exl3_cartridge_status(raw_request: Request) -> JSONResponse:
-    """Return whether each worker currently has an active cartridge."""
+    """Return whether each worker currently has an active cartridge.
+
+    Args:
+        raw_request: Incoming status request.
+
+    Returns:
+        A response containing each worker's active-cartridge state.
+
+    Raises:
+        HTTPException: If the engine does not support cartridge hot-swap.
+    """
     engine = _require_cartridge_engine(raw_request)
     active = await engine.collective_rpc("has_exl3_cartridge")
     return JSONResponse(content={"active": list(active)})
 
 
-def attach_router(app: FastAPI):
+def attach_router(app: FastAPI) -> None:
+    """Attach the EXL3 cartridge development routes to an application.
+
+    Args:
+        app: FastAPI application to receive the routes.
+
+    Returns:
+        None.
+    """
     app.include_router(router)

--- a/vllm/entrypoints/serve/dev/cartridge/api_router.py
+++ b/vllm/entrypoints/serve/dev/cartridge/api_router.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import json
+from http import HTTPStatus
+
+from fastapi import APIRouter, FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse
+
+from vllm.engine.protocol import EngineClient
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+router = APIRouter()
+
+
+def engine_client(request: Request) -> EngineClient:
+    return request.app.state.engine_client
+
+
+def _require_cartridge_engine(request: Request) -> EngineClient:
+    """Return the engine client if it supports EXL3 cartridge hot-swap.
+
+    Cartridge hot-swap (drain, swap, resume) is implemented on the V1
+    ``AsyncLLM`` engine only; it is not part of the generic ``EngineClient``
+    protocol.
+    """
+    engine = engine_client(request)
+    if not hasattr(engine, "load_exl3_cartridge"):
+        raise HTTPException(
+            status_code=HTTPStatus.NOT_IMPLEMENTED.value,
+            detail="EXL3 cartridge hot-swap requires the V1 AsyncLLM engine",
+        )
+    return engine
+
+
+@router.post("/load_exl3_cartridge")
+async def load_exl3_cartridge(raw_request: Request) -> JSONResponse:
+    """Drain in-flight requests, load an EXL3 MSRT cartridge, and resume.
+
+    On failure the compressed base graphs are restored automatically before
+    generation resumes; if the restore itself fails the engine shuts down.
+    """
+    try:
+        body = await raw_request.json()
+    except json.JSONDecodeError as e:
+        raise HTTPException(
+            status_code=HTTPStatus.BAD_REQUEST.value,
+            detail=f"JSON decode error: {e}",
+        ) from e
+    adapter_path = body.get("adapter_path")
+    if not adapter_path:
+        raise HTTPException(
+            status_code=HTTPStatus.BAD_REQUEST.value,
+            detail="Missing 'adapter_path' in request body",
+        )
+
+    engine = _require_cartridge_engine(raw_request)
+    try:
+        updated_layers = await engine.load_exl3_cartridge(adapter_path)
+    except (ValueError, RuntimeError) as err:
+        return JSONResponse(
+            content={"error": str(err)},
+            status_code=HTTPStatus.BAD_REQUEST.value,
+        )
+    return JSONResponse(
+        content={"status": "loaded", "updated_layers": updated_layers},
+        status_code=HTTPStatus.OK.value,
+    )
+
+
+@router.post("/deactivate_exl3_cartridge")
+async def deactivate_exl3_cartridge(raw_request: Request) -> JSONResponse:
+    """Drain in-flight requests, release the active cartridge, and resume.
+
+    A no-op (returns zero updated layers per worker) if no cartridge is
+    currently active.
+    """
+    engine = _require_cartridge_engine(raw_request)
+    updated_layers = await engine.deactivate_exl3_cartridge()
+    return JSONResponse(
+        content={"status": "deactivated", "updated_layers": updated_layers},
+        status_code=HTTPStatus.OK.value,
+    )
+
+
+@router.get("/exl3_cartridge_status")
+async def exl3_cartridge_status(raw_request: Request) -> JSONResponse:
+    """Return whether each worker currently has an active cartridge."""
+    engine = _require_cartridge_engine(raw_request)
+    active = await engine.collective_rpc("has_exl3_cartridge")
+    return JSONResponse(content={"active": list(active)})
+
+
+def attach_router(app: FastAPI):
+    app.include_router(router)

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -295,6 +295,7 @@ if TYPE_CHECKING:
     VLLM_SYMM_MEM_PCIE_SAFE_BARRIER: bool = False
     VLLM_TUNED_CONFIG_FOLDER: str | None = None
     VLLM_ENABLE_STARTUP_PLAN: bool = False
+    VLLM_ENABLE_EXL3_CARTRIDGE: bool = False
     VLLM_GPT_OSS_SYSTEM_TOOL_MCP_LABELS: set[str] = set()
     VLLM_USE_EXPERIMENTAL_PARSER_CONTEXT: bool = False
     VLLM_GPT_OSS_HARMONY_SYSTEM_INSTRUCTIONS: bool = False
@@ -2070,6 +2071,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # See vllm/v1/worker/startup_plan.py.
     "VLLM_ENABLE_STARTUP_PLAN": lambda: bool(
         int(os.getenv("VLLM_ENABLE_STARTUP_PLAN", "0"))
+    ),
+    "VLLM_ENABLE_EXL3_CARTRIDGE": lambda: bool(
+        int(os.getenv("VLLM_ENABLE_EXL3_CARTRIDGE", "0"))
     ),
     # Valid values are container,code_interpreter,web_search_preview
     # ex VLLM_GPT_OSS_SYSTEM_TOOL_MCP_LABELS=container,code_interpreter

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -360,6 +360,15 @@ class Exl3Config(QuantizationConfig):
         self.rank_sliced_k_values: tuple[int, ...] | None = None
         self.rank_sliced_bits_by_layer: dict[int, tuple[int, ...]] = {}
 
+    def get_supported_lora_modules(self) -> list[str]:
+        """Return module names that support EXL3 LoRA cartridge adapters.
+
+        MSRT (Multi-Stage Rescaled Trellis) cartridges add full-rank trellis-
+        quantized residual weights as LoRA-like adapters. They are applied to
+        MoE expert projections via additional exl3_gemm passes.
+        """
+        return ["gate_proj", "up_proj", "down_proj"]
+
     def get_name(self) -> str:
         return "exl3"
 
@@ -1729,9 +1738,9 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 f"{layer_bitrates!r}"
             )
         bits = int(layer_bitrates[0])
-        if bits not in (3, 4, 5, 6):
+        if bits not in (2, 3, 4, 5, 6):
             raise ValueError(
-                f"rank-sliced EXL3 requires an integral 3/4/5/6 bitrate, got {bits!r}"
+                f"rank-sliced EXL3 requires an integral 2/3/4/5/6 bitrate, got {bits!r}"
             )
 
         w13 = self._rank_sliced_backing(layer, "w13_trellis")

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -20,7 +20,9 @@ one or initialize CUDA.
 from __future__ import annotations
 
 import ctypes
+import hashlib
 import importlib
+import json
 import os
 import re
 import sys
@@ -30,6 +32,7 @@ from typing import TYPE_CHECKING, Any
 import torch
 from transformers import PretrainedConfig
 
+import vllm.envs as envs
 from vllm.config import get_current_vllm_config_or_none
 from vllm.distributed import (
     get_tensor_model_parallel_rank,
@@ -154,8 +157,37 @@ def _runtime_scope_id(quant_config: Any) -> int:
 
 
 _RANK_SLICED_FORMAT = "exl3-trellis"
+_RANK_SLICED_RUNTIME_PROFILE = "exl3-msrt-base/1"
+_RANK_SLICED_PROFILE_FIELDS = frozenset(
+    {
+        "format",
+        "runtime_profile",
+        "bits",
+        "codebook",
+        "moe_layers",
+        "moe_layer_coverage",
+        "tensor_schema",
+        "tensor_parallel",
+        "mcg_multiplier",
+        "compatibility_sha256",
+        "compatibility_by_layer",
+        "experts_per_layer",
+    }
+)
+_RANK_SLICED_FULL_TP = {
+    "storage_layout": "full-rank",
+    "storage_world_size": 1,
+    "storage_ranks": [0],
+    "runtime_partitioning": "slice-full-rank",
+    "slice_alignment": _HADAMARD_BLOCK,
+    "axis_by_projection": {
+        "gate_proj": "output",
+        "up_proj": "output",
+        "down_proj": "input",
+    },
+}
 _RANK_SLICED_WEIGHT_RE = re.compile(
-    r"^(?P<prefix>.+)\.rank(?P<rank>\d+)\."
+    r"^(?P<prefix>.+)\.rank(?P<rank>[0-9]+)\."
     r"(?P<field>trellis|suh|svh|mcg|mul1)$"
 )
 
@@ -344,7 +376,6 @@ class Exl3Config(QuantizationConfig):
         codebook: str | None = None,
         version: str | None = None,
         tensor_storage: dict[str, Any] | None = None,
-        cartridge_runtime: bool = False,
     ) -> None:
         super().__init__()
         self.bits = bits
@@ -352,15 +383,11 @@ class Exl3Config(QuantizationConfig):
         self.codebook = codebook
         self.version = version
         self.tensor_storage = tensor_storage or {}
-        if not isinstance(cartridge_runtime, bool):
-            raise TypeError(
-                f"EXL3 cartridge_runtime must be a boolean, got {cartridge_runtime!r}"
-            )
-        self.cartridge_runtime = cartridge_runtime
         self._eager_checked = False
         self.rank_sliced_metadata: dict[str, Any] | None = None
         self.rank_sliced_k_values: tuple[int, ...] | None = None
         self.rank_sliced_bits_by_layer: dict[int, tuple[int, ...]] = {}
+        self._rank_sliced_compatibility_tensors: dict[str, dict[str, Any]] = {}
 
     def get_name(self) -> str:
         return "exl3"
@@ -386,7 +413,6 @@ class Exl3Config(QuantizationConfig):
             codebook=config.get("codebook"),
             version=config.get("version"),
             tensor_storage=config.get("tensor_storage"),
-            cartridge_runtime=config.get("cartridge_runtime", False),
         )
 
     @classmethod
@@ -459,8 +485,9 @@ class Exl3Config(QuantizationConfig):
             "experts_per_layer",
             "moe_layers",
             "tensor_schema",
-            "tp",
         }
+        if metadata.get("runtime_profile") != _RANK_SLICED_RUNTIME_PROFILE:
+            required.add("tp")
         missing = sorted(required.difference(metadata))
         if missing:
             raise ValueError(
@@ -487,6 +514,92 @@ class Exl3Config(QuantizationConfig):
                 "unsupported rank-sliced EXL3 tensor schema: "
                 f"{metadata['tensor_schema']!r}"
             )
+        runtime_profile = metadata.get("runtime_profile")
+        if (
+            runtime_profile is not None
+            and runtime_profile != _RANK_SLICED_RUNTIME_PROFILE
+        ):
+            raise ValueError(
+                f"unsupported rank-sliced EXL3 runtime_profile: {runtime_profile!r}"
+            )
+        if runtime_profile == _RANK_SLICED_RUNTIME_PROFILE:
+            if set(metadata) != _RANK_SLICED_PROFILE_FIELDS:
+                raise ValueError(
+                    "rank-sliced EXL3 runtime profile fields do not match the "
+                    "closed exl3-msrt-base/1 contract"
+                )
+            bits = metadata.get("bits")
+            if (
+                isinstance(bits, bool)
+                or not isinstance(bits, (int, float))
+                or float(bits) != int(bits)
+                or int(bits) not in (2, 3, 4, 5, 6)
+            ):
+                raise ValueError(
+                    "cartridge-capable rank-sliced EXL3 requires one uniform "
+                    "integral K in 2..6"
+                )
+            if metadata.get("mcg_multiplier") != _MCG_SENTINEL:
+                raise ValueError(
+                    "cartridge-capable rank-sliced EXL3 requires the canonical "
+                    f"MCG multiplier {_MCG_SENTINEL}"
+                )
+            if metadata.get("tensor_parallel") != _RANK_SLICED_FULL_TP:
+                raise ValueError(
+                    "rank-sliced EXL3 runtime profile requires the canonical "
+                    "full-rank tensor_parallel storage contract"
+                )
+            if "tp" in metadata:
+                raise ValueError(
+                    "rank-sliced EXL3 runtime profiles use tensor_parallel storage "
+                    "metadata; the legacy tp field must be absent"
+                )
+            coverage = metadata.get("moe_layer_coverage")
+            if (
+                not isinstance(coverage, list)
+                or not coverage
+                or any(
+                    isinstance(index, bool) or not isinstance(index, int) or index < 0
+                    for index in coverage
+                )
+                or coverage != sorted(set(coverage))
+                or coverage[0] != int(layers[0])
+                or coverage[-1] != int(layers[1])
+            ):
+                raise ValueError(
+                    "rank-sliced EXL3 moe_layer_coverage must be sorted, unique, "
+                    "and agree with moe_layers"
+                )
+            compatibility_by_layer = metadata.get("compatibility_by_layer")
+            if (
+                not isinstance(compatibility_by_layer, dict)
+                or set(compatibility_by_layer) != {str(index) for index in coverage}
+                or any(
+                    re.fullmatch(r"[0-9a-f]{64}", str(digest)) is None
+                    for digest in compatibility_by_layer.values()
+                )
+            ):
+                raise ValueError(
+                    "rank-sliced EXL3 compatibility_by_layer must cover every "
+                    "declared MoE layer"
+                )
+            compatibility_root = metadata.get("compatibility_sha256")
+            root_payload = {
+                "schema": "fq-msrt-base-compatibility/2",
+                "k": int(bits),
+                "layers": compatibility_by_layer,
+            }
+            encoded_root = json.dumps(
+                root_payload,
+                sort_keys=True,
+                separators=(",", ":"),
+                ensure_ascii=True,
+            ).encode()
+            if hashlib.sha256(encoded_root).hexdigest() != compatibility_root:
+                raise ValueError(
+                    "rank-sliced EXL3 compatibility_sha256 does not match its "
+                    "compatibility_by_layer map"
+                )
         self.rank_sliced_metadata = dict(metadata)
         bits_field = metadata["bits"]
         if isinstance(bits_field, str) and bits_field.strip().lower() == "mixed":
@@ -530,10 +643,20 @@ class Exl3Config(QuantizationConfig):
             raise ValueError(f"rank-sliced EXL3 could not load {filename!r}")
 
         experts = int(self.rank_sliced_metadata["experts_per_layer"])
-        first, last = (int(value) for value in self.rank_sliced_metadata["moe_layers"])
+        coverage = self.rank_sliced_metadata.get("moe_layer_coverage")
+        layer_indices = (
+            tuple(int(value) for value in coverage)
+            if isinstance(coverage, list)
+            else tuple(
+                range(
+                    int(self.rank_sliced_metadata["moe_layers"][0]),
+                    int(self.rank_sliced_metadata["moe_layers"][1]) + 1,
+                )
+            )
+        )
         allowed = set(self.rank_sliced_k_values or ())
         by_layer: dict[int, tuple[int, ...]] = {}
-        for layer_index in range(first, last + 1):
+        for layer_index in layer_indices:
             entry = payload.get(str(layer_index))
             if not isinstance(entry, dict):
                 raise ValueError(
@@ -560,7 +683,7 @@ class Exl3Config(QuantizationConfig):
         self.rank_sliced_bits_by_layer = by_layer
 
     def rank_sliced_layer_bitrates(self, layer_name: str) -> tuple[int, ...]:
-        match = re.search(r"(?:^|\.)layers\.(\d+)(?:\.|$)", layer_name)
+        match = re.search(r"(?:^|\.)layers\.([0-9]+)(?:\.|$)", layer_name)
         if match is None:
             raise ValueError(
                 f"cannot resolve rank-sliced EXL3 layer index from {layer_name!r}"
@@ -718,9 +841,12 @@ class Exl3Config(QuantizationConfig):
         self, prefix: str, layer: torch.nn.Module | None = None
     ) -> bool:
         if self.rank_sliced_metadata is not None:
-            match = re.search(r"layers\.(\d+)\b", prefix)
+            match = re.search(r"layers\.([0-9]+)\b", prefix)
             if match is None:
                 return False
+            coverage = self.rank_sliced_metadata.get("moe_layer_coverage")
+            if isinstance(coverage, list):
+                return int(match.group(1)) in coverage
             first, last = (int(v) for v in self.rank_sliced_metadata["moe_layers"])
             return first <= int(match.group(1)) <= last
         # Use the layer's checkpoint projection names (the same fields
@@ -746,9 +872,12 @@ class Exl3Config(QuantizationConfig):
 
     def codebook_for_prefix(self, prefix: str) -> str | None:
         if self.rank_sliced_metadata is not None:
-            match = re.search(r"layers\.(\d+)\b", prefix)
+            match = re.search(r"layers\.([0-9]+)\b", prefix)
             if match is None:
                 return None
+            coverage = self.rank_sliced_metadata.get("moe_layer_coverage")
+            if isinstance(coverage, list):
+                return "mcg" if int(match.group(1)) in coverage else None
             first, last = (int(v) for v in self.rank_sliced_metadata["moe_layers"])
             return "mcg" if first <= int(match.group(1)) <= last else None
         entry = self._storage_entry(prefix)
@@ -771,9 +900,125 @@ class Exl3Config(QuantizationConfig):
         match = _RANK_SLICED_WEIGHT_RE.match(name)
         if match is None:
             return name
-        if int(match.group("rank")) != get_tensor_model_parallel_rank():
+        storage_rank = (
+            0
+            if self.rank_sliced_supports_dynamic_tp()
+            else get_tensor_model_parallel_rank()
+        )
+        if int(match.group("rank")) != storage_rank:
             return None
         return f"{match.group('prefix')}.{match.group('field')}"
+
+    def rank_sliced_supports_dynamic_tp(self) -> bool:
+        """Return whether rank0 payloads may be sliced for the runtime TP size."""
+        metadata = self.rank_sliced_metadata or {}
+        return (
+            metadata.get("runtime_profile") == _RANK_SLICED_RUNTIME_PROFILE
+            and metadata.get("tensor_parallel") == _RANK_SLICED_FULL_TP
+        )
+
+    def record_rank_sliced_compatibility_tensor(
+        self,
+        name: str,
+        tensor: torch.Tensor,
+    ) -> None:
+        """Record one full logical base tensor before runtime TP slicing."""
+        if not self.rank_sliced_supports_dynamic_tp():
+            return
+        dtype_tokens = {
+            torch.float16: "F16",
+            torch.bfloat16: "BF16",
+            torch.float32: "F32",
+            torch.int16: "I16",
+            torch.int32: "I32",
+            torch.int64: "I64",
+        }
+        try:
+            dtype = dtype_tokens[tensor.dtype]
+        except KeyError as exc:
+            raise ValueError(
+                f"unsupported EXL3 compatibility tensor dtype {tensor.dtype}"
+            ) from exc
+        logical_name = re.sub(r"\.rank0(?=\.)", "", name)
+        payload = (
+            tensor.detach()
+            .contiguous()
+            .view(-1)
+            .view(torch.uint8)
+            .cpu()
+            .numpy()
+            .tobytes()
+        )
+        record = {
+            "name": logical_name,
+            "dtype": dtype,
+            "shape": list(tensor.shape),
+            "sha256": hashlib.sha256(payload).hexdigest(),
+        }
+        previous = self._rank_sliced_compatibility_tensors.setdefault(
+            logical_name, record
+        )
+        if previous != record:
+            raise ValueError(
+                f"EXL3 logical base tensor {logical_name!r} was loaded inconsistently"
+            )
+
+    def verified_rank_sliced_layer_compatibility_sha256(self, layer_name: str) -> str:
+        """Recompute one layer's TP-invariant base identity from loaded bytes."""
+        metadata = self.rank_sliced_metadata or {}
+        layer_match = re.search(r"(?:^|\.)layers\.([0-9]+)(?:\.|$)", layer_name)
+        if layer_match is None:
+            raise ValueError(f"cannot resolve EXL3 layer index from {layer_name!r}")
+        layer_index = int(layer_match.group(1))
+        compatibility_by_layer = metadata.get("compatibility_by_layer")
+        expected = (
+            compatibility_by_layer.get(str(layer_index))
+            if isinstance(compatibility_by_layer, dict)
+            else None
+        )
+        if (
+            not isinstance(expected, str)
+            or re.fullmatch(r"[0-9a-f]{64}", expected) is None
+        ):
+            raise ValueError(
+                f"rank-sliced EXL3 base has no compatibility identity for layer "
+                f"{layer_index}"
+            )
+        bits = metadata.get("bits")
+        if isinstance(bits, bool) or not isinstance(bits, (int, float)):
+            raise ValueError(
+                "cartridge-capable EXL3 base requires one uniform integral bitrate"
+            )
+        k = int(bits)
+        if float(bits) != k or k not in (2, 3, 4, 5, 6):
+            raise ValueError(
+                "cartridge-capable EXL3 base requires one uniform K in 2..6"
+            )
+        prefix = f"model.layers.{layer_index}."
+        records = [
+            record
+            for name, record in self._rank_sliced_compatibility_tensors.items()
+            if name.startswith(prefix)
+        ]
+        payload = {
+            "schema": "fq-msrt-base-layer-compatibility/1",
+            "k": k,
+            "layer": layer_index,
+            "tensors": sorted(records, key=lambda record: record["name"]),
+        }
+        encoded = json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+        ).encode()
+        actual = hashlib.sha256(encoded).hexdigest()
+        if actual != expected:
+            raise ValueError(
+                "loaded EXL3 base layer tensors do not match compatibility digest: "
+                f"metadata={expected}, loaded={actual}"
+            )
+        return actual
 
 
 class Exl3Parameter(BasevLLMParameter):
@@ -1187,8 +1432,20 @@ class Exl3MoEParameter(BasevLLMParameter):
         num_experts: int = 0,
         shard_ids: tuple[str, ...] = (),
         preallocate: bool = False,
+        quant_config: Exl3Config | None = None,
+        tp_slice: tuple[int, int, int, bool] | None = None,
+        logical_component: str | None = None,
+        logical_layer_name: str | None = None,
     ):
-        del num_experts, shard_ids, preallocate
+        del (
+            num_experts,
+            shard_ids,
+            preallocate,
+            quant_config,
+            tp_slice,
+            logical_component,
+            logical_layer_name,
+        )
         data = torch.empty(0, dtype=torch.uint8)
         return super().__new__(cls, data=data, weight_loader=weight_loader)
 
@@ -1199,21 +1456,75 @@ class Exl3MoEParameter(BasevLLMParameter):
         num_experts: int = 0,
         shard_ids: tuple[str, ...] = (),
         preallocate: bool = False,
+        quant_config: Exl3Config | None = None,
+        tp_slice: tuple[int, int, int, bool] | None = None,
+        logical_component: str | None = None,
+        logical_layer_name: str | None = None,
     ):
         self.exl3_tensors: dict[tuple[int, str], torch.Tensor] = {}
         self.exl3_backing: torch.Tensor | None = None
         self.exl3_num_experts = int(num_experts)
         self.exl3_shard_ids = tuple(shard_ids)
         self.exl3_preallocate = bool(preallocate)
+        self.exl3_quant_config = quant_config
+        self.exl3_tp_slice = tp_slice
+        self.exl3_logical_component = logical_component
+        self.exl3_logical_layer_name = logical_layer_name
         super().__init__(data=self.data, weight_loader=weight_loader)
 
     def load_exl3_weight(
         self,
         loaded_weight: torch.Tensor,
         *,
+        weight_name: str = "",
         expert_id: int,
         shard_id: str,
     ) -> None:
+        if self.exl3_quant_config is not None:
+            if (
+                self.exl3_logical_component is None
+                or self.exl3_logical_layer_name is None
+            ):
+                raise RuntimeError("EXL3 compatibility tensor lacks a component name")
+            projection = {
+                "w1": "gate_proj",
+                "w3": "up_proj",
+                "w2": "down_proj",
+            }[shard_id]
+            layer_match = re.search(
+                r"(?:^|\.)layers\.([0-9]+)(?:\.|$)",
+                self.exl3_logical_layer_name,
+            )
+            if layer_match is None:
+                raise ValueError(
+                    "cannot canonicalize EXL3 compatibility layer name "
+                    f"{self.exl3_logical_layer_name!r}"
+                )
+            canonical_name = (
+                f"model.layers.{layer_match.group(1)}.mlp.experts.{expert_id}."
+                f"{projection}.rank0."
+                f"{self.exl3_logical_component}"
+            )
+            self.exl3_quant_config.record_rank_sliced_compatibility_tensor(
+                canonical_name, loaded_weight
+            )
+        if self.exl3_tp_slice is not None:
+            dim, start, size, packed = self.exl3_tp_slice
+            if packed:
+                loaded_weight = Exl3LinearMethod._slice_exl3_tensor(
+                    loaded_weight,
+                    dim=dim,
+                    start=start,
+                    size=size,
+                )
+            else:
+                if start < 0 or size <= 0 or start + size > loaded_weight.shape[dim]:
+                    raise ValueError(
+                        "rank-sliced EXL3 TP rotation slice exceeds the full tensor: "
+                        f"shape={tuple(loaded_weight.shape)}, dim={dim}, "
+                        f"start={start}, size={size}"
+                    )
+                loaded_weight = loaded_weight.narrow(dim, start, size).contiguous()
         key = (int(expert_id), str(shard_id))
         if not self.exl3_preallocate:
             self.exl3_tensors[key] = loaded_weight.contiguous()
@@ -1262,9 +1573,9 @@ def _exl3_moe_weight_loader(
     expert_id: int,
     return_success: bool = False,
 ) -> bool | None:
-    del weight_name
     param.load_exl3_weight(
         loaded_weight,
+        weight_name=weight_name,
         expert_id=expert_id,
         shard_id=shard_id,
     )
@@ -1310,13 +1621,31 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         layer.exl3_hidden_size = hidden_size
         layer.exl3_intermediate_size_per_partition = intermediate_size_per_partition
         layer.exl3_params_dtype = params_dtype
+        layer.exl3_base_compatibility_sha256 = (
+            self.quant_config.rank_sliced_metadata or {}
+        ).get("compatibility_sha256")
+        layer.exl3_base_compatibility_by_layer = (
+            self.quant_config.rank_sliced_metadata or {}
+        ).get("compatibility_by_layer")
+        layer.exl3_quant_config = self.quant_config
+        layer.exl3_base_compatibility_verified = False
         rank_sliced = self.quant_config.rank_sliced_metadata is not None
+        dynamic_tp = False
         if rank_sliced:
-            checkpoint_tp = int(self.quant_config.rank_sliced_metadata["tp"])
-            if checkpoint_tp != layer.exl3_tp_size:
+            dynamic_tp = self.quant_config.rank_sliced_supports_dynamic_tp()
+            checkpoint_tp = int(
+                self.quant_config.rank_sliced_metadata.get("tp", layer.exl3_tp_size)
+            )
+            if not dynamic_tp and checkpoint_tp != layer.exl3_tp_size:
                 raise ValueError(
                     "rank-sliced EXL3 checkpoint TP does not match runtime: "
                     f"checkpoint={checkpoint_tp}, runtime={layer.exl3_tp_size}"
+                )
+            if dynamic_tp and intermediate_size_per_partition % _HADAMARD_BLOCK:
+                raise ValueError(
+                    "rank-sliced EXL3 runtime TP partitions must be "
+                    f"{_HADAMARD_BLOCK}-aligned, got "
+                    f"{intermediate_size_per_partition}"
                 )
             expected_experts = int(
                 self.quant_config.rank_sliced_metadata["experts_per_layer"]
@@ -1330,25 +1659,6 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             scheduler_config = (
                 vllm_config.scheduler_config if vllm_config is not None else None
             )
-            if self.quant_config.cartridge_runtime:
-                assert vllm_config is not None
-                if vllm_config.parallel_config.data_parallel_size != 1:
-                    raise NotImplementedError(
-                        "EXL3 cartridge runtime currently requires data_parallel_size=1"
-                    )
-                if vllm_config.parallel_config.tensor_parallel_size != 1:
-                    raise NotImplementedError(
-                        "EXL3 cartridge runtime currently requires "
-                        "tensor_parallel_size=1"
-                    )
-                if vllm_config.use_v2_model_runner:
-                    raise NotImplementedError(
-                        "EXL3 cartridge runtime does not support the V2 model runner"
-                    )
-                if vllm_config.lora_config is not None:
-                    raise NotImplementedError(
-                        "EXL3 cartridge runtime cannot be combined with LoRA adapters"
-                    )
             # No silent fallback: a wrong capacity here puts the target and the
             # rank-sliced MTP draft on different plans with no error, which is
             # exactly the class of mismatch that corrupts only at scale.
@@ -1377,7 +1687,9 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 getattr(vllm_config.model_config, "runner_type", None) == "draft"
             )
             layer.exl3_cartridge_capable = (
-                self.quant_config.cartridge_runtime and not layer.exl3_is_draft
+                dynamic_tp
+                and envs.VLLM_ENABLE_EXL3_CARTRIDGE
+                and not layer.exl3_is_draft
             )
             layer.exl3_cartridge_enabled = False
             layer.exl3_layer_bitrates = self.quant_config.rank_sliced_layer_bitrates(
@@ -1386,6 +1698,26 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             layer.exl3_mixed_bitrate = len(set(layer.exl3_layer_bitrates)) > 1
         for prefix, shard_ids in (("w13", ("w1", "w3")), ("w2", ("w2",))):
             for suffix in ("suh", "svh", "trellis", "mcg", "mul1"):
+                tp_slice = None
+                if rank_sliced and dynamic_tp:
+                    start = layer.exl3_tp_rank * intermediate_size_per_partition
+                    if (prefix, suffix) in {
+                        ("w13", "svh"),
+                        ("w2", "suh"),
+                    }:
+                        tp_slice = (
+                            0,
+                            start,
+                            intermediate_size_per_partition,
+                            False,
+                        )
+                    elif suffix == "trellis":
+                        tp_slice = (
+                            1 if prefix == "w13" else 0,
+                            start,
+                            intermediate_size_per_partition,
+                            True,
+                        )
                 layer.register_parameter(
                     f"{prefix}_{suffix}",
                     Exl3MoEParameter(
@@ -1399,6 +1731,10 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                             if getattr(layer, "exl3_mixed_bitrate", False)
                             else {"suh", "svh", "trellis"}
                         ),
+                        quant_config=self.quant_config if rank_sliced else None,
+                        tp_slice=tp_slice,
+                        logical_component=suffix if rank_sliced else None,
+                        logical_layer_name=str(layer.layer_name),
                     ),
                 )
 
@@ -1419,6 +1755,13 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 + (" ..." if len(missing) > 32 else "")
             )
         self._validate_codebooks(layer)
+        if self.quant_config.rank_sliced_supports_dynamic_tp():
+            layer.exl3_base_layer_compatibility_sha256 = (
+                self.quant_config.verified_rank_sliced_layer_compatibility_sha256(
+                    str(layer.layer_name)
+                )
+            )
+            layer.exl3_base_compatibility_verified = True
         if self.quant_config.rank_sliced_metadata is None:
             self._shard_tensors_for_tensor_parallel(layer)
         device = layer.w13_trellis.device
@@ -2298,6 +2641,13 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         out32.zero_()
         chunk = int(runtime["chunk"])
         pointer_args = layer.exl3_pointer_tables
+        layer_bitrates = tuple(int(value) for value in layer.exl3_layer_bitrates)
+        if not layer_bitrates or len(set(layer_bitrates)) != 1:
+            raise ValueError(
+                "EXL3 parity fallback requires one uniform base bitrate, got "
+                f"{layer_bitrates!r}"
+            )
+        base_bits = layer_bitrates[0]
         if m > chunk and hasattr(ext, "exl3_moe_fused"):
             ext.exl3_moe_fused(
                 xh,
@@ -2314,9 +2664,9 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 runtime["ig"],
                 runtime["iu"],
                 0,
-                3,
-                3,
-                3,
+                base_bits,
+                base_bits,
+                base_bits,
                 *pointer_args,
                 True,
                 False,
@@ -2325,7 +2675,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 True,
                 False,
                 0.0,
-                0,
+                min(m * int(runtime["topk"]), int(layer.local_num_experts)),
             )
             return out32.to(x.dtype)
 
@@ -2357,9 +2707,9 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 runtime["ig"],
                 runtime["iu"],
                 0,
-                3,
-                3,
-                3,
+                base_bits,
+                base_bits,
+                base_bits,
                 *pointer_args,
                 True,
                 False,
@@ -2368,6 +2718,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 True,
                 False,
                 0.0,
+                min(route_count, int(layer.local_num_experts)),
             )
         return out32.to(x.dtype)
 

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -222,12 +222,8 @@ def _load_b12x_mixed_trellis() -> Any:
     if _B12X_MIXED_TRELLIS_API is not None:
         return _B12X_MIXED_TRELLIS_API
     try:
-        module = importlib.import_module(
-            "b12x.moe._shared.kernels.w4a16.mixed_trellis"
-        )
-        prepare = importlib.import_module(
-            "b12x.moe._shared.kernels.w4a16.prepare"
-        )
+        module = importlib.import_module("b12x.moe._shared.kernels.w4a16.mixed_trellis")
+        prepare = importlib.import_module("b12x.moe._shared.kernels.w4a16.prepare")
         host = importlib.import_module("b12x.moe._shared.kernels.w4a16.host")
     except Exception as exc:
         raise RuntimeError(
@@ -348,6 +344,7 @@ class Exl3Config(QuantizationConfig):
         codebook: str | None = None,
         version: str | None = None,
         tensor_storage: dict[str, Any] | None = None,
+        cartridge_runtime: bool = False,
     ) -> None:
         super().__init__()
         self.bits = bits
@@ -355,19 +352,15 @@ class Exl3Config(QuantizationConfig):
         self.codebook = codebook
         self.version = version
         self.tensor_storage = tensor_storage or {}
+        if not isinstance(cartridge_runtime, bool):
+            raise TypeError(
+                f"EXL3 cartridge_runtime must be a boolean, got {cartridge_runtime!r}"
+            )
+        self.cartridge_runtime = cartridge_runtime
         self._eager_checked = False
         self.rank_sliced_metadata: dict[str, Any] | None = None
         self.rank_sliced_k_values: tuple[int, ...] | None = None
         self.rank_sliced_bits_by_layer: dict[int, tuple[int, ...]] = {}
-
-    def get_supported_lora_modules(self) -> list[str]:
-        """Return module names that support EXL3 LoRA cartridge adapters.
-
-        MSRT (Multi-Stage Rescaled Trellis) cartridges add full-rank trellis-
-        quantized residual weights as LoRA-like adapters. They are applied to
-        MoE expert projections via additional exl3_gemm passes.
-        """
-        return ["gate_proj", "up_proj", "down_proj"]
 
     def get_name(self) -> str:
         return "exl3"
@@ -393,6 +386,7 @@ class Exl3Config(QuantizationConfig):
             codebook=config.get("codebook"),
             version=config.get("version"),
             tensor_storage=config.get("tensor_storage"),
+            cartridge_runtime=config.get("cartridge_runtime", False),
         )
 
     @classmethod
@@ -1336,6 +1330,12 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             scheduler_config = (
                 vllm_config.scheduler_config if vllm_config is not None else None
             )
+            if self.quant_config.cartridge_runtime:
+                assert vllm_config is not None
+                if vllm_config.parallel_config.data_parallel_size != 1:
+                    raise NotImplementedError(
+                        "EXL3 cartridge runtime currently requires data_parallel_size=1"
+                    )
             # No silent fallback: a wrong capacity here puts the target and the
             # rank-sliced MTP draft on different plans with no error, which is
             # exactly the class of mismatch that corrupts only at scale.
@@ -1362,6 +1362,9 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             # which also covers speculators that bypass load_eagle_model.
             layer.exl3_is_draft = (
                 getattr(vllm_config.model_config, "runner_type", None) == "draft"
+            )
+            layer.exl3_cartridge_enabled = (
+                self.quant_config.cartridge_runtime and not layer.exl3_is_draft
             )
             layer.exl3_layer_bitrates = self.quant_config.rank_sliced_layer_bitrates(
                 str(layer.layer_name)
@@ -1415,7 +1418,19 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         self._validate_moe_shapes(layer)
 
         if self.quant_config.rank_sliced_metadata is not None:
+            cartridge_enabled = bool(layer.exl3_cartridge_enabled)
+            if cartridge_enabled and layer.exl3_mixed_bitrate:
+                raise NotImplementedError(
+                    "EXL3 cartridge runtime currently requires a uniform "
+                    "rank-sliced base checkpoint"
+                )
             self._prepare_rank_sliced_weights(layer)
+            if cartridge_enabled:
+                from .exl3_lora_cartridge import (
+                    prepare_exl3_cudagraph_cartridge_runtime,
+                )
+
+                prepare_exl3_cudagraph_cartridge_runtime(layer)
             return
 
     def _validate_codebooks(self, layer: RoutedExperts) -> None:
@@ -2376,6 +2391,18 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         weights = topk_weights.reshape_as(ids).to(torch.float32).contiguous()
         if self.quant_config.rank_sliced_metadata is not None:
             output = self._apply_rank_sliced(layer, x_2d, weights, ids)
+            if bool(layer.exl3_cartridge_enabled):
+                from .exl3_lora_cartridge import (
+                    apply_exl3_cudagraph_cartridge,
+                )
+
+                output = apply_exl3_cudagraph_cartridge(
+                    output,
+                    x_2d,
+                    weights,
+                    ids,
+                    layer,
+                )
             return output.reshape(*original_shape, output.shape[-1])
 
         x_2d = x_2d.to(torch.float16)

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -1336,6 +1336,19 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                     raise NotImplementedError(
                         "EXL3 cartridge runtime currently requires data_parallel_size=1"
                     )
+                if vllm_config.parallel_config.tensor_parallel_size != 1:
+                    raise NotImplementedError(
+                        "EXL3 cartridge runtime currently requires "
+                        "tensor_parallel_size=1"
+                    )
+                if vllm_config.use_v2_model_runner:
+                    raise NotImplementedError(
+                        "EXL3 cartridge runtime does not support the V2 model runner"
+                    )
+                if vllm_config.lora_config is not None:
+                    raise NotImplementedError(
+                        "EXL3 cartridge runtime cannot be combined with LoRA adapters"
+                    )
             # No silent fallback: a wrong capacity here puts the target and the
             # rank-sliced MTP draft on different plans with no error, which is
             # exactly the class of mismatch that corrupts only at scale.
@@ -1363,9 +1376,10 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             layer.exl3_is_draft = (
                 getattr(vllm_config.model_config, "runner_type", None) == "draft"
             )
-            layer.exl3_cartridge_enabled = (
+            layer.exl3_cartridge_capable = (
                 self.quant_config.cartridge_runtime and not layer.exl3_is_draft
             )
+            layer.exl3_cartridge_enabled = False
             layer.exl3_layer_bitrates = self.quant_config.rank_sliced_layer_bitrates(
                 str(layer.layer_name)
             )
@@ -1418,19 +1432,13 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         self._validate_moe_shapes(layer)
 
         if self.quant_config.rank_sliced_metadata is not None:
-            cartridge_enabled = bool(layer.exl3_cartridge_enabled)
-            if cartridge_enabled and layer.exl3_mixed_bitrate:
+            cartridge_capable = bool(layer.exl3_cartridge_capable)
+            if cartridge_capable and layer.exl3_mixed_bitrate:
                 raise NotImplementedError(
                     "EXL3 cartridge runtime currently requires a uniform "
                     "rank-sliced base checkpoint"
                 )
             self._prepare_rank_sliced_weights(layer)
-            if cartridge_enabled:
-                from .exl3_lora_cartridge import (
-                    prepare_exl3_cudagraph_cartridge_runtime,
-                )
-
-                prepare_exl3_cudagraph_cartridge_runtime(layer)
             return
 
     def _validate_codebooks(self, layer: RoutedExperts) -> None:
@@ -2390,19 +2398,19 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         ids = topk_ids.reshape(x_2d.shape[0], -1).contiguous()
         weights = topk_weights.reshape_as(ids).to(torch.float32).contiguous()
         if self.quant_config.rank_sliced_metadata is not None:
-            output = self._apply_rank_sliced(layer, x_2d, weights, ids)
             if bool(layer.exl3_cartridge_enabled):
                 from .exl3_lora_cartridge import (
                     apply_exl3_cudagraph_cartridge,
                 )
 
                 output = apply_exl3_cudagraph_cartridge(
-                    output,
                     x_2d,
                     weights,
                     ids,
                     layer,
                 )
+            else:
+                output = self._apply_rank_sliced(layer, x_2d, weights, ids)
             return output.reshape(*original_shape, output.shape[-1])
 
         x_2d = x_2d.to(torch.float16)

--- a/vllm/model_executor/layers/quantization/exl3_lora_cartridge.py
+++ b/vllm/model_executor/layers/quantization/exl3_lora_cartridge.py
@@ -61,7 +61,7 @@ _CARTRIDGE_COMPANION_KEY_RE = re.compile(
     r"^(?P<layer>.+\.experts)\."
     r"(?P<expert>\d+)\."
     r"(?P<projection>gate_proj|up_proj|down_proj)\."
-    r"rank(?P<rank>\d+)\.(?:suh|svh|scale|mcg|mul1)_(?P<label>.+)$"
+    r"rank(?P<rank>\d+)\.(?:scale|mcg|mul1)_(?P<label>.+)$"
 )
 _SHARD_MAP = {"gate_proj": "w1", "up_proj": "w3", "down_proj": "w2"}
 
@@ -70,8 +70,8 @@ class Exl3LoraCartridge:
     """MSRT residual tensors for one routed-expert layer.
 
     Each stage is keyed by ``(expert_id, shard_id)`` and stores packed trellis
-    indices, input/output Hadamard vectors, and the positive rescaling factor
-    used by the MCG-only rank-sliced encoder.
+    indices and the positive rescaling factor used by the MCG-only rank-sliced
+    encoder; residuals reuse the base layer's own suh/svh.
     """
 
     def __init__(self, num_stages: int, num_experts: int, device: torch.device):
@@ -93,8 +93,6 @@ class Exl3LoraCartridge:
         expert_id: int,
         shard_id: str,
         trellis: torch.Tensor,
-        suh: torch.Tensor,
-        svh: torch.Tensor,
         scale: float,
     ) -> None:
         """Set one stage of one expert projection."""
@@ -110,8 +108,6 @@ class Exl3LoraCartridge:
             )
         self.stages[stage_idx][(expert_id, shard_id)] = {
             "trellis": trellis.to(self.device).contiguous(),
-            "suh": suh.to(self.device).contiguous(),
-            "svh": svh.to(self.device).contiguous(),
             "scale": float(scale),
         }
 
@@ -125,10 +121,9 @@ class Exl3LoraCartridge:
         """Move source tensors to one device without changing stage metadata."""
         for stage in self.stages:
             for tensors in stage.values():
-                for name in ("trellis", "suh", "svh"):
-                    tensor = tensors[name]
-                    assert isinstance(tensor, torch.Tensor)
-                    tensors[name] = tensor.to(device).contiguous()
+                tensor = tensors["trellis"]
+                assert isinstance(tensor, torch.Tensor)
+                tensors["trellis"] = tensor.to(device).contiguous()
         self.device = device
 
     def clear(self) -> None:
@@ -333,6 +328,15 @@ class Exl3CUDAGraphCartridgeRuntime:
         self.max_residual_bits = max(
             bits for projection in projection_bits.values() for bits in projection
         )
+        computed_max_residual_bits = max(
+            int(table.max().item()) for table in bit_tables
+        )
+        if computed_max_residual_bits != self.max_residual_bits:
+            raise ValueError(
+                "packed cartridge max_residual_bits does not match its "
+                f"per-stage bit tables: {self.max_residual_bits} != "
+                f"{computed_max_residual_bits}"
+            )
         self._packed_tensors = tuple(retained) + self.pointer_args
         self._materialized = True
 
@@ -426,13 +430,13 @@ def _stage_sort_key(label: str) -> tuple[str, int]:
     return label, -1
 
 
-def _validate_stage_tensors(
-    layer: Any,
-    shard_id: str,
-    trellis: torch.Tensor,
-    suh: torch.Tensor,
-    svh: torch.Tensor,
-) -> None:
+def _validate_stage_trellis(layer: Any, shard_id: str, trellis: torch.Tensor) -> None:
+    """Validate an MSRT residual trellis against this layer's base shape.
+
+    A cartridge does not carry its own suh/svh: MSRT residuals are quantized
+    in the same regularized rotation space as the rank-sliced base, so the
+    base's own suh/svh apply unchanged to every stage.
+    """
     hidden_size = int(layer.exl3_hidden_size)
     intermediate_size = int(layer.exl3_intermediate_size_per_partition)
     input_size, output_size = (
@@ -461,39 +465,6 @@ def _validate_stage_tensors(
             f"K={input_size}, N={output_size}; use K in "
             "{1,2,3,4,5,6} and dtype=torch.int16"
         )
-    for name, tensor, expected_size in (
-        ("suh", suh, packed_k),
-        ("svh", svh, packed_n),
-    ):
-        if tensor.dtype != torch.float16 or tensor.shape != (expected_size,):
-            raise ValueError(
-                f"Invalid MSRT cartridge {name}: shape={tuple(tensor.shape)}, "
-                f"dtype={tensor.dtype}, expected=({expected_size},), "
-                "dtype=torch.float16"
-            )
-        if not torch.isfinite(tensor).all().item():
-            raise ValueError(f"MSRT cartridge {name} contains non-finite values")
-
-
-def _validate_base_rotations(
-    layer: Any,
-    expert_id: int,
-    shard_id: str,
-    suh: torch.Tensor,
-    svh: torch.Tensor,
-) -> None:
-    group = "w2" if shard_id == "w2" else "w13"
-    key = (expert_id, shard_id)
-    for name, cartridge_tensor in (("suh", suh), ("svh", svh)):
-        parameter = getattr(layer, f"{group}_{name}")
-        base_tensor = parameter.exl3_tensors[key]
-        if cartridge_tensor.device != base_tensor.device:
-            cartridge_tensor = cartridge_tensor.to(base_tensor.device)
-        if not torch.equal(cartridge_tensor, base_tensor):
-            raise ValueError(
-                "MSRT cartridge rotations must match the rank-sliced EXL3 base: "
-                f"expert={expert_id}, projection={shard_id}, tensor={name}"
-            )
 
 
 def load_cartridge_from_adapter(
@@ -505,9 +476,10 @@ def load_cartridge_from_adapter(
     """Load the stages belonging to one routed-expert layer.
 
     Expected tensor names are
-    ``{layer}.<expert>.<projection>.rank0.{trellis,suh,svh,scale}_<label>``.
-    Keys for other layers are ignored rather than accidentally overwriting the
-    same expert/shard entries.
+    ``{layer}.<expert>.<projection>.rank0.{trellis,scale}_<label>``.  A
+    cartridge does not carry its own suh/svh: MSRT residuals reuse the base
+    layer's own regularized rotations.  Keys for other layers are ignored
+    rather than accidentally overwriting the same expert/shard entries.
     """
     from safetensors import safe_open
 
@@ -558,28 +530,12 @@ def load_cartridge_from_adapter(
                 )
             shard_id = _SHARD_MAP[projection]
             prefix = trellis_key[: -len(f"trellis_{label}")]
-            companion_keys = {
-                "suh": f"{prefix}suh_{label}",
-                "svh": f"{prefix}svh_{label}",
-                "scale": f"{prefix}scale_{label}",
-            }
-            missing = [
-                key_name
-                for key_name in (companion_keys["suh"], companion_keys["svh"])
-                if key_name not in key_set
-            ]
-            if missing:
-                raise ValueError(
-                    f"Incomplete MSRT cartridge entry {trellis_key}: missing {missing}"
-                )
+            scale_key = f"{prefix}scale_{label}"
             trellis = handle.get_tensor(trellis_key)
-            suh = handle.get_tensor(companion_keys["suh"])
-            svh = handle.get_tensor(companion_keys["svh"])
-            _validate_stage_tensors(layer, shard_id, trellis, suh, svh)
-            _validate_base_rotations(layer, expert_id, shard_id, suh, svh)
+            _validate_stage_trellis(layer, shard_id, trellis)
             scale = 1.0
-            if companion_keys["scale"] in key_set:
-                scale_tensor = handle.get_tensor(companion_keys["scale"])
+            if scale_key in key_set:
+                scale_tensor = handle.get_tensor(scale_key)
                 if scale_tensor.numel() != 1:
                     raise ValueError(
                         f"MSRT cartridge scale must be scalar, got "
@@ -591,8 +547,6 @@ def load_cartridge_from_adapter(
                 expert_id,
                 shard_id,
                 trellis,
-                suh,
-                svh,
                 scale,
             )
             shards_by_stage_expert.setdefault((label, expert_id), set()).add(shard_id)

--- a/vllm/model_executor/layers/quantization/exl3_lora_cartridge.py
+++ b/vllm/model_executor/layers/quantization/exl3_lora_cartridge.py
@@ -356,11 +356,27 @@ class Exl3CUDAGraphCartridgeRuntime:
         outputs: list[torch.Tensor] = []
         for start in range(0, x.shape[0], self.chunk):
             rows = min(self.chunk, x.shape[0] - start)
-            xh = self.xh[:rows]
-            xh.copy_(x[start : start + rows])
+            chunk_x = x[start : start + rows]
+            if x.dtype == self.dtype and chunk_x.is_contiguous():
+                # Under CUDA-graph capture/replay this chunk's slice of `x`
+                # already sits at a fixed address (it is itself the output of
+                # an earlier op in the same captured graph); copying it into
+                # the fixed self.xh landing buffer is then pure overhead.
+                xh = chunk_x
+            else:
+                xh = self.xh[:rows]
+                xh.copy_(chunk_x)
             out32 = self.out32[:rows]
             out32.zero_()
             route_count = rows * self.topk
+            # Upper bound on distinct experts this chunk can hit. The kernel's
+            # ticket scheduler already loops over every expert with tokens
+            # regardless of grid shape (correctness never depends on this
+            # value), so an upper bound is always safe; it only narrows the
+            # host-side group_size/num_groups launch split to avoid
+            # over-subscribing SMs when few experts can possibly be active,
+            # e.g. every single-token decode step.
+            num_active = min(route_count, self.num_experts)
             self.ext.exl3_moe_additive_fused(
                 xh,
                 out32,
@@ -389,7 +405,12 @@ class Exl3CUDAGraphCartridgeRuntime:
                 True,
                 False,
                 0.0,
+                num_active,
             )
+            # out32 is fp32 because the kernel's multi-expert scatter-add
+            # (top_k > 1 contributions to one token) uses atomicAdd, which
+            # requires fp32; this cast-copy is architecturally required, not
+            # an avoidable inefficiency like the input copy above.
             outputs.append(out32.to(x.dtype))
         return outputs[0] if len(outputs) == 1 else torch.cat(outputs)
 
@@ -467,6 +488,97 @@ def _validate_stage_trellis(layer: Any, shard_id: str, trellis: torch.Tensor) ->
         )
 
 
+def _index_cartridge_keys(
+    keys: tuple[str, ...],
+) -> dict[str, list[tuple[str, re.Match[str]]]]:
+    """Group every trellis key by its owning layer in one pass.
+
+    Scanning is O(total keys) once, rather than re-scanning the full key
+    list once per layer. Also validates, in the same pass, that every key
+    is either a recognized trellis key or a recognized companion (scale,
+    mcg, mul1) key; anything else raises immediately.
+    """
+    by_layer: dict[str, list[tuple[str, re.Match[str]]]] = {}
+    for key in keys:
+        match = _CARTRIDGE_KEY_RE.match(key)
+        if match is not None:
+            by_layer.setdefault(match.group("layer"), []).append((key, match))
+            continue
+        if _CARTRIDGE_COMPANION_KEY_RE.match(key) is None:
+            raise ValueError(f"Malformed MSRT cartridge key {key!r}")
+    return by_layer
+
+
+def _build_cartridge_from_entries(
+    handle: Any,
+    entries: list[tuple[str, re.Match[str]]],
+    layer: Any,
+    num_experts: int,
+    device: torch.device,
+) -> Exl3LoraCartridge | None:
+    """Construct one layer's cartridge from its pre-filtered trellis keys."""
+    if not entries:
+        return None
+
+    key_set = {key for key, _ in entries} | set(handle.keys())
+    labels = sorted(
+        {match.group("label") for _, match in entries},
+        key=_stage_sort_key,
+    )
+    label_to_stage = {label: index for index, label in enumerate(labels)}
+    cartridge = Exl3LoraCartridge(len(labels), num_experts, device)
+    shards_by_stage_expert: dict[tuple[str, int], set[str]] = {}
+
+    for trellis_key, match in entries:
+        rank = int(match.group("rank"))
+        if rank != 0:
+            raise ValueError(
+                f"MSRT cartridge only supports rank0 tensors, got rank{rank}"
+            )
+        expert_id = int(match.group("expert"))
+        projection = match.group("projection")
+        label = match.group("label")
+        if not 0 <= expert_id < num_experts:
+            raise ValueError(
+                f"MSRT cartridge expert {expert_id} is outside [0, {num_experts})"
+            )
+        shard_id = _SHARD_MAP[projection]
+        prefix = trellis_key[: -len(f"trellis_{label}")]
+        scale_key = f"{prefix}scale_{label}"
+        trellis = handle.get_tensor(trellis_key)
+        _validate_stage_trellis(layer, shard_id, trellis)
+        scale = 1.0
+        if scale_key in key_set:
+            scale_tensor = handle.get_tensor(scale_key)
+            if scale_tensor.numel() != 1:
+                raise ValueError(
+                    f"MSRT cartridge scale must be scalar, got "
+                    f"shape={tuple(scale_tensor.shape)}"
+                )
+            scale = float(scale_tensor.item())
+        cartridge.set_stage_tensors(
+            label_to_stage[label],
+            expert_id,
+            shard_id,
+            trellis,
+            scale,
+        )
+        shards_by_stage_expert.setdefault((label, expert_id), set()).add(shard_id)
+
+    required_shards = {"w1", "w2", "w3"}
+    incomplete = {
+        key: sorted(required_shards - shards)
+        for key, shards in shards_by_stage_expert.items()
+        if shards != required_shards
+    }
+    if incomplete:
+        raise ValueError(
+            f"Incomplete MSRT cartridge expert stages; missing shards: {incomplete}"
+        )
+    cartridge.active = True
+    return cartridge
+
+
 def load_cartridge_from_adapter(
     adapter_path: str,
     layer: Any,
@@ -480,88 +592,27 @@ def load_cartridge_from_adapter(
     cartridge does not carry its own suh/svh: MSRT residuals reuse the base
     layer's own regularized rotations.  Keys for other layers are ignored
     rather than accidentally overwriting the same expert/shard entries.
+
+    Loading many layers from the same file: prefer opening the file once
+    and calling ``_index_cartridge_keys``/``_build_cartridge_from_entries``
+    directly (see ``prepare_exl3_cartridge_into_model``), which scans the
+    key list once instead of once per layer.
     """
     from safetensors import safe_open
 
     layer_name = str(layer.layer_name)
-    entries: list[tuple[str, re.Match[str]]] = []
     with safe_open(adapter_path, framework="pt") as handle:
-        keys = tuple(handle.keys())
-        key_set = set(keys)
-        for key in keys:
-            match = _CARTRIDGE_KEY_RE.match(key)
-            if match is not None and match.group("layer") == layer_name:
-                entries.append((key, match))
-                continue
-            companion = _CARTRIDGE_COMPANION_KEY_RE.match(key)
-            if key.startswith(f"{layer_name}.") and (
-                companion is None or companion.group("layer") != layer_name
-            ):
-                raise ValueError(f"Malformed MSRT cartridge key {key!r}")
-
-        if not entries:
-            logger.warning(
-                "No MSRT cartridge tensors for %s in %s",
-                layer_name,
-                adapter_path,
-            )
-            return None
-
-        labels = sorted(
-            {match.group("label") for _, match in entries},
-            key=_stage_sort_key,
+        by_layer = _index_cartridge_keys(tuple(handle.keys()))
+        cartridge = _build_cartridge_from_entries(
+            handle, by_layer.get(layer_name, []), layer, num_experts, device
         )
-        label_to_stage = {label: index for index, label in enumerate(labels)}
-        cartridge = Exl3LoraCartridge(len(labels), num_experts, device)
-        shards_by_stage_expert: dict[tuple[str, int], set[str]] = {}
-
-        for trellis_key, match in entries:
-            rank = int(match.group("rank"))
-            if rank != 0:
-                raise ValueError(
-                    f"MSRT cartridge only supports rank0 tensors, got rank{rank}"
-                )
-            expert_id = int(match.group("expert"))
-            projection = match.group("projection")
-            label = match.group("label")
-            if not 0 <= expert_id < num_experts:
-                raise ValueError(
-                    f"MSRT cartridge expert {expert_id} is outside [0, {num_experts})"
-                )
-            shard_id = _SHARD_MAP[projection]
-            prefix = trellis_key[: -len(f"trellis_{label}")]
-            scale_key = f"{prefix}scale_{label}"
-            trellis = handle.get_tensor(trellis_key)
-            _validate_stage_trellis(layer, shard_id, trellis)
-            scale = 1.0
-            if scale_key in key_set:
-                scale_tensor = handle.get_tensor(scale_key)
-                if scale_tensor.numel() != 1:
-                    raise ValueError(
-                        f"MSRT cartridge scale must be scalar, got "
-                        f"shape={tuple(scale_tensor.shape)}"
-                    )
-                scale = float(scale_tensor.item())
-            cartridge.set_stage_tensors(
-                label_to_stage[label],
-                expert_id,
-                shard_id,
-                trellis,
-                scale,
-            )
-            shards_by_stage_expert.setdefault((label, expert_id), set()).add(shard_id)
-
-        required_shards = {"w1", "w2", "w3"}
-        incomplete = {
-            key: sorted(required_shards - shards)
-            for key, shards in shards_by_stage_expert.items()
-            if shards != required_shards
-        }
-        if incomplete:
-            raise ValueError(
-                f"Incomplete MSRT cartridge expert stages; missing shards: {incomplete}"
-            )
-    cartridge.active = True
+    if cartridge is None:
+        logger.warning(
+            "No MSRT cartridge tensors for %s in %s",
+            layer_name,
+            adapter_path,
+        )
+        return None
     logger.info(
         "Loaded %d-stage MSRT cartridge for %s from %s",
         cartridge.num_stages,
@@ -573,32 +624,48 @@ def load_cartridge_from_adapter(
 
 @torch.inference_mode()
 def prepare_exl3_cartridge_into_model(model: torch.nn.Module, adapter_path: str) -> int:
-    """Load each layer into packed storage without a dense or staging peak."""
+    """Load each layer into packed storage without a dense or staging peak.
+
+    Opens the cartridge file once and indexes its keys once, rather than
+    reopening the file and rescanning every key per layer.
+    """
+    from safetensors import safe_open
+
     prepared_count = 0
     try:
-        for layer in model.modules():
-            runtime = getattr(layer, "_exl3_cartridge_runtime", None)
-            if not isinstance(runtime, Exl3CUDAGraphCartridgeRuntime):
-                if not bool(getattr(layer, "exl3_cartridge_capable", False)):
-                    continue
-                runtime = prepare_exl3_cudagraph_cartridge_runtime(layer)
-            cartridge = load_cartridge_from_adapter(
-                adapter_path,
-                layer,
-                runtime.num_experts,
-                torch.device("cpu"),
-            )
-            if cartridge is None:
-                raise ValueError(
-                    f"Cartridge {adapter_path} has no tensors for {layer.layer_name}"
+        with safe_open(adapter_path, framework="pt") as handle:
+            by_layer = _index_cartridge_keys(tuple(handle.keys()))
+            for layer in model.modules():
+                runtime = getattr(layer, "_exl3_cartridge_runtime", None)
+                if not isinstance(runtime, Exl3CUDAGraphCartridgeRuntime):
+                    if not bool(getattr(layer, "exl3_cartridge_capable", False)):
+                        continue
+                    runtime = prepare_exl3_cudagraph_cartridge_runtime(layer)
+                layer_name = str(layer.layer_name)
+                cartridge = _build_cartridge_from_entries(
+                    handle,
+                    by_layer.get(layer_name, []),
+                    layer,
+                    runtime.num_experts,
+                    torch.device("cpu"),
                 )
-            runtime.deactivate()
-            cartridge.to(runtime.device)
-            try:
-                runtime.materialize(layer, cartridge)
-            finally:
-                cartridge.clear()
-            prepared_count += 1
+                if cartridge is None:
+                    raise ValueError(
+                        f"Cartridge {adapter_path} has no tensors for {layer_name}"
+                    )
+                logger.info(
+                    "Loaded %d-stage MSRT cartridge for %s from %s",
+                    cartridge.num_stages,
+                    layer_name,
+                    adapter_path,
+                )
+                runtime.deactivate()
+                cartridge.to(runtime.device)
+                try:
+                    runtime.materialize(layer, cartridge)
+                finally:
+                    cartridge.clear()
+                prepared_count += 1
         return prepared_count
     except Exception:
         deactivate_exl3_cartridge(model)

--- a/vllm/model_executor/layers/quantization/exl3_lora_cartridge.py
+++ b/vllm/model_executor/layers/quantization/exl3_lora_cartridge.py
@@ -8,20 +8,18 @@ trellis-quantized residuals for the gate, up, and down expert projections.
 Applying those residuals projection-by-projection is exact but cannot be added
 after a fused MoE call: gate and up residuals must be present before SiLU.
 
-For rank-sliced EXL3, this module materializes the combined base+cartridge
-expert matrices into fixed-address GPU buffers. The normal rank-sliced kernel
-remains the inactive path. A graph-capturable dense fused-MoE call computes the
-active path, and a device scalar selects its output. Loading or removing a
-cartridge only mutates preallocated buffers and the scalar, so captured graph
-pointers and topology remain unchanged.
+For rank-sliced EXL3, this module lazily materializes the combined
+base+cartridge expert matrices into fixed-address GPU buffers. Cartridge load
+quiesces the engine, drops the base CUDA graphs, allocates the dense buffers,
+and captures cartridge graphs. Deactivation performs the inverse transition
+and releases the buffers before recapturing the compressed base path.
 
-The runtime is opt-in because dense shadow weights consume substantially more
-GPU memory and the graph-stable inactive path still launches a null-routed
-dense MoE alongside the compressed base path. This reduces steady-state
-throughput and the transient memory profiled for KV-cache sizing. Set
-``cartridge_runtime: true`` in the EXL3 quantization configuration before
-engine construction so the buffers exist before CUDA graph capture.
-Use ``llm_engine.load_exl3_cartridge(path)`` and
+The runtime is opt-in because an active cartridge's dense shadow weights
+consume substantially more GPU memory. Inactive cartridge support has no
+shadow buffers, dense-MoE work, or alternate graph path. Set
+``cartridge_runtime: true`` in the EXL3 quantization configuration to allow
+the quiescent recapture transaction. Use
+``llm_engine.load_exl3_cartridge(path)`` and
 ``llm_engine.deactivate_exl3_cartridge()``; both dispatch through the worker
 control plane to every model worker.
 
@@ -130,12 +128,10 @@ class Exl3LoraCartridge:
 
 
 class Exl3CUDAGraphCartridgeRuntime:
-    """Fixed-address dense shadow weights used by captured CUDA graphs.
+    """Fixed-address dense shadow weights used by active CUDA graphs.
 
-    There is one runtime per routed-expert layer. ``w13`` and ``w2`` are
-    allocated before graph capture and never rebound. ``active`` is a scalar on
-    the same device; changing it does not alter Python control flow or graph
-    topology.
+    There is one runtime per routed-expert layer while a cartridge is loaded.
+    ``w13`` and ``w2`` remain fixed for the lifetime of those captured graphs.
     """
 
     def __init__(self, layer: Any):
@@ -310,38 +306,28 @@ def apply_exl3_cartridge(
 
 
 def apply_exl3_cudagraph_cartridge(
-    base_output: torch.Tensor,
     x: torch.Tensor,
     topk_weights: torch.Tensor,
     topk_ids: torch.Tensor,
     layer: Any,
 ) -> torch.Tensor:
-    """Run and device-select the graph-stable dense cartridge path.
-
-    Both paths and the device-side selection are present during capture, while
-    the scalar controls which result becomes visible at replay time.
-    """
+    """Run the dense cartridge path captured for the active topology."""
     runtime = getattr(layer, "_exl3_cartridge_runtime", None)
     if not isinstance(runtime, Exl3CUDAGraphCartridgeRuntime):
         raise RuntimeError(
             "EXL3 cartridge runtime was not prepared before CUDA graph capture"
         )
 
-    # Preserve graph topology while inactive, but collapse dense routing to one
-    # expert so the discarded shadow path reads one expert's weights, not every
-    # routed expert's weights.
-    dense_topk_ids = topk_ids * runtime.active
-    dense_output = fused_experts(
+    return fused_experts(
         x.to(runtime.dtype),
         runtime.w13,
         runtime.w2,
         topk_weights,
-        dense_topk_ids,
+        topk_ids,
         activation=layer.activation,
         apply_router_weight_on_input=False,
         global_num_experts=runtime.num_experts,
-    ).to(base_output.dtype)
-    return torch.where(runtime.active, dense_output, base_output)
+    ).to(x.dtype)
 
 
 def _stage_sort_key(label: str) -> tuple[str, int]:
@@ -525,43 +511,44 @@ def load_cartridge_from_adapter(
 
 @torch.inference_mode()
 def prepare_exl3_cartridge_into_model(model: torch.nn.Module, adapter_path: str) -> int:
-    """Materialize a cartridge into every layer without activating it."""
+    """Lazily allocate and materialize a cartridge without activating it."""
     prepared: list[tuple[Any, Exl3CUDAGraphCartridgeRuntime, Exl3LoraCartridge]] = []
-    for layer in model.modules():
-        runtime = getattr(layer, "_exl3_cartridge_runtime", None)
-        if not isinstance(runtime, Exl3CUDAGraphCartridgeRuntime):
-            continue
-        cartridge = load_cartridge_from_adapter(
-            adapter_path,
-            layer,
-            runtime.num_experts,
-            torch.device("cpu"),
-        )
-        if cartridge is None:
-            raise ValueError(
-                f"Cartridge {adapter_path} has no tensors for {layer.layer_name}"
-            )
-        prepared.append((layer, runtime, cartridge))
-    if not prepared:
-        return 0
-
-    prepared_count = len(prepared)
-    for _, runtime, _ in prepared:
-        runtime.deactivate()
     try:
+        for layer in model.modules():
+            runtime = getattr(layer, "_exl3_cartridge_runtime", None)
+            if not isinstance(runtime, Exl3CUDAGraphCartridgeRuntime):
+                if not bool(getattr(layer, "exl3_cartridge_capable", False)):
+                    continue
+                runtime = prepare_exl3_cudagraph_cartridge_runtime(layer)
+            cartridge = load_cartridge_from_adapter(
+                adapter_path,
+                layer,
+                runtime.num_experts,
+                torch.device("cpu"),
+            )
+            if cartridge is None:
+                raise ValueError(
+                    f"Cartridge {adapter_path} has no tensors for {layer.layer_name}"
+                )
+            prepared.append((layer, runtime, cartridge))
+        if not prepared:
+            return 0
+
+        prepared_count = len(prepared)
+        for _, runtime, _ in prepared:
+            runtime.deactivate()
         for layer, runtime, cartridge in prepared:
             cartridge.to(runtime.device)
             try:
                 runtime.materialize(layer, cartridge)
             finally:
                 cartridge.clear()
+        return prepared_count
     except Exception:
-        for _, runtime, _ in prepared:
-            runtime.deactivate()
+        deactivate_exl3_cartridge(model)
         raise
     finally:
         prepared.clear()
-    return prepared_count
 
 
 @torch.inference_mode()
@@ -572,6 +559,7 @@ def activate_exl3_cartridge(model: torch.nn.Module) -> int:
         runtime = getattr(layer, "_exl3_cartridge_runtime", None)
         if isinstance(runtime, Exl3CUDAGraphCartridgeRuntime):
             runtime.activate()
+            layer.exl3_cartridge_enabled = True
             updated += 1
     return updated
 
@@ -591,14 +579,27 @@ def load_exl3_cartridge_into_model(model: torch.nn.Module, adapter_path: str) ->
     return updated
 
 
+def has_exl3_cartridge(model: torch.nn.Module) -> bool:
+    """Return whether this worker owns any dense cartridge runtime."""
+    return any(
+        isinstance(
+            getattr(layer, "_exl3_cartridge_runtime", None),
+            Exl3CUDAGraphCartridgeRuntime,
+        )
+        for layer in model.modules()
+    )
+
+
 @torch.inference_mode()
 def deactivate_exl3_cartridge(model: torch.nn.Module) -> int:
-    """Select the rank-sliced base path in every prepared layer."""
+    """Select the compressed base path and release every dense runtime."""
     updated = 0
     for layer in model.modules():
         runtime = getattr(layer, "_exl3_cartridge_runtime", None)
         if isinstance(runtime, Exl3CUDAGraphCartridgeRuntime):
             runtime.deactivate()
+            layer.exl3_cartridge_enabled = False
+            del layer._exl3_cartridge_runtime
             updated += 1
     return updated
 
@@ -610,6 +611,7 @@ __all__ = [
     "apply_exl3_cartridge",
     "apply_exl3_cudagraph_cartridge",
     "deactivate_exl3_cartridge",
+    "has_exl3_cartridge",
     "load_cartridge_from_adapter",
     "load_exl3_cartridge_into_model",
     "prepare_exl3_cartridge_into_model",

--- a/vllm/model_executor/layers/quantization/exl3_lora_cartridge.py
+++ b/vllm/model_executor/layers/quantization/exl3_lora_cartridge.py
@@ -8,17 +8,17 @@ trellis-quantized residuals for the gate, up, and down expert projections.
 Applying those residuals projection-by-projection is exact but cannot be added
 after a fused MoE call: gate and up residuals must be present before SiLU.
 
-For rank-sliced EXL3, this module lazily materializes the combined
-base+cartridge expert matrices into fixed-address GPU buffers. Cartridge load
-quiesces the engine, drops the base CUDA graphs, allocates the dense buffers,
-and captures cartridge graphs. Deactivation performs the inverse transition
-and releases the buffers before recapturing the compressed base path.
+For rank-sliced EXL3, this module keeps cartridge trellises compressed on the
+GPU and builds stable pointer tables for the additive routed-expert kernel.
+Cartridge load quiesces the engine, drops the base CUDA graphs, allocates the
+packed tensors, and captures cartridge graphs. Deactivation performs the
+inverse transition and releases the cartridge tensors before recapturing the
+compressed base path.
 
-The runtime is opt-in because an active cartridge's dense shadow weights
-consume substantially more GPU memory. Inactive cartridge support has no
-shadow buffers, dense-MoE work, or alternate graph path. Set
-``cartridge_runtime: true`` in the EXL3 quantization configuration to allow
-the quiescent recapture transaction. Use
+The runtime is opt-in. Inactive cartridge support has no cartridge buffers,
+alternate graph path, or runtime overhead. Set ``cartridge_runtime: true`` in
+the EXL3 quantization configuration to allow the quiescent recapture
+transaction. Use
 ``llm_engine.load_exl3_cartridge(path)`` and
 ``llm_engine.deactivate_exl3_cartridge()``; both dispatch through the worker
 control plane to every model worker.
@@ -36,10 +36,20 @@ from typing import Any
 
 import torch
 
-from vllm.model_executor.layers.fused_moe.fused_moe import fused_experts
-from vllm.model_executor.layers.quantization.exl3 import Exl3MoEMethod, _exl3_gemm
+from vllm.model_executor.layers.quantization.exl3 import _load_exl3_ext
 
 logger = logging.getLogger(__name__)
+
+
+def _load_additive_exl3_ext() -> Any:
+    ext = _load_exl3_ext()
+    if not hasattr(ext, "exl3_moe_additive_fused"):
+        raise RuntimeError(
+            "packed EXL3 cartridges require an ExLlamaV3 extension that "
+            "exports exl3_moe_additive_fused"
+        )
+    return ext
+
 
 _CARTRIDGE_KEY_RE = re.compile(
     r"^(?P<layer>.+\.experts)\."
@@ -128,11 +138,7 @@ class Exl3LoraCartridge:
 
 
 class Exl3CUDAGraphCartridgeRuntime:
-    """Fixed-address dense shadow weights used by active CUDA graphs.
-
-    There is one runtime per routed-expert layer while a cartridge is loaded.
-    ``w13`` and ``w2`` remain fixed for the lifetime of those captured graphs.
-    """
+    """Fixed-address packed cartridge tensors and additive MoE workspaces."""
 
     def __init__(self, layer: Any):
         tp_size = int(getattr(layer, "exl3_tp_size", 1))
@@ -140,48 +146,86 @@ class Exl3CUDAGraphCartridgeRuntime:
             raise NotImplementedError(
                 "EXL3 cartridge runtime currently requires tensor_parallel_size=1"
             )
-        num_experts = int(layer.local_num_experts)
-        hidden_size = int(layer.exl3_hidden_size)
-        intermediate_size = int(layer.exl3_intermediate_size_per_partition)
-        dtype = torch.float16
-        device = layer.w13_trellis.device
-
-        self.w13 = torch.zeros(
-            (num_experts, 2 * intermediate_size, hidden_size),
-            dtype=dtype,
-            device=device,
+        self.num_experts = int(layer.local_num_experts)
+        self.hidden_size = int(layer.exl3_hidden_size)
+        self.intermediate_size = int(layer.exl3_intermediate_size_per_partition)
+        self.topk = int(layer.top_k)
+        self.dtype = torch.float16
+        self.device = layer.w13_trellis.device
+        self.chunk = min(128, int(layer.exl3_max_num_batched_tokens))
+        self.ext = _load_additive_exl3_ext() if self.device.type == "cuda" else None
+        if self.ext is not None:
+            if not hasattr(self.ext, "exl3_moe_max_concurrency"):
+                raise RuntimeError(
+                    "The EXL3 extension lacks packed cartridge entry point "
+                    "exl3_moe_max_concurrency"
+                )
+            concurrency = int(self.ext.exl3_moe_max_concurrency(self.device.index or 0))
+        else:
+            concurrency = 1
+        self.xh = torch.empty(
+            (self.chunk, self.hidden_size), dtype=self.dtype, device=self.device
         )
-        self.w2 = torch.zeros(
-            (num_experts, hidden_size, intermediate_size),
-            dtype=dtype,
-            device=device,
+        self.out32 = torch.empty(
+            (self.chunk, self.hidden_size), dtype=torch.float32, device=self.device
         )
-        self.active = torch.zeros((), dtype=torch.bool, device=device)
-        self.num_experts = num_experts
-        self.hidden_size = hidden_size
-        self.intermediate_size = intermediate_size
-        self.dtype = dtype
-        self.device = device
+        self.tg = torch.empty(
+            (concurrency, self.chunk, self.hidden_size),
+            dtype=self.dtype,
+            device=self.device,
+        )
+        self.tu = torch.empty_like(self.tg)
+        self.ig = torch.empty(
+            (concurrency, self.chunk, self.intermediate_size),
+            dtype=self.dtype,
+            device=self.device,
+        )
+        self.iu = torch.empty_like(self.ig)
+        self.expert_count = torch.empty(
+            self.num_experts + 1, dtype=torch.int64, device=self.device
+        )
+        self.expert_offsets = torch.empty_like(self.expert_count)
+        self.token_sorted = torch.empty(
+            self.chunk * self.topk, dtype=torch.int64, device=self.device
+        )
+        self.weight_sorted = torch.empty(
+            self.chunk * self.topk, dtype=self.dtype, device=self.device
+        )
+        self.expert_map = torch.arange(
+            self.num_experts, dtype=torch.int64, device=self.device
+        )
+        self._active = False
         self._materialized = False
+        self._packed_tensors: tuple[torch.Tensor, ...] = ()
+        self.pointer_args: tuple[torch.Tensor, ...] = ()
+        self.max_residual_bits = 0
+        layer_bitrates = tuple(getattr(layer, "exl3_layer_bitrates", ()))
+        if len(set(layer_bitrates)) != 1:
+            raise ValueError("packed cartridge runtime requires a uniform base bitrate")
+        self.base_bits = int(layer_bitrates[0])
+
+    @staticmethod
+    def _pointer_table(tensors: list[torch.Tensor]) -> torch.Tensor:
+        return torch.tensor(
+            [tensor.data_ptr() for tensor in tensors],
+            dtype=torch.int64,
+            device=tensors[0].device,
+        )
 
     def deactivate(self) -> None:
-        """Select the rank-sliced base path without changing graph pointers."""
-        self.active.zero_()
+        """Select the rank-sliced base path."""
+        self._active = False
 
     def activate(self) -> None:
-        """Select the fully materialized dense cartridge path."""
+        """Select the prepared packed cartridge path."""
         if not self._materialized:
             raise RuntimeError("cannot activate an unmaterialized EXL3 cartridge")
-        self.active.fill_(True)
+        self._active = True
 
     @torch.inference_mode()
     def materialize(self, layer: Any, cartridge: Exl3LoraCartridge) -> None:
-        """Decode exact base+cartridge matrices into the shadow buffers.
-
-        Identity activations turn each EXL3 GEMM into a matrix materialization.
-        Base and residual outputs are summed before transposition, preserving
-        the exact projection-level MSRT semantics across the SiLU boundary.
-        """
+        """Retain packed stages and construct fixed-address kernel metadata."""
+        del layer
         if cartridge.num_experts != self.num_experts:
             raise ValueError(
                 "cartridge expert count does not match runtime: "
@@ -192,55 +236,158 @@ class Exl3CUDAGraphCartridgeRuntime:
 
         self._materialized = False
         self.deactivate()
-        hidden_identity = torch.eye(
-            self.hidden_size, dtype=torch.float16, device=self.device
+        projection_tensors: dict[str, list[torch.Tensor]] = {
+            "w1": [],
+            "w3": [],
+            "w2": [],
+        }
+        projection_scales: dict[str, list[float]] = {
+            "w1": [],
+            "w3": [],
+            "w2": [],
+        }
+        projection_bits: dict[str, list[int]] = {
+            "w1": [],
+            "w3": [],
+            "w2": [],
+        }
+        retained: list[torch.Tensor] = []
+        for stage_idx in range(cartridge.num_stages):
+            for shard_id in ("w1", "w3", "w2"):
+                stage_tensors = [
+                    cartridge.get_stage_tensors(stage_idx, expert_id, shard_id)
+                    for expert_id in range(self.num_experts)
+                ]
+                present_trellises = [
+                    tensors["trellis"]
+                    for tensors in stage_tensors
+                    if tensors is not None
+                ]
+                if present_trellises:
+                    fallback = present_trellises[0]
+                    stage_bits = {
+                        trellis.shape[2] // 16 for trellis in present_trellises
+                    }
+                    if len(stage_bits) != 1:
+                        raise ValueError(
+                            "packed cartridge stage bitrate must be uniform across "
+                            f"experts: stage={stage_idx}, projection={shard_id}, "
+                            f"bitrates={sorted(stage_bits)}"
+                        )
+                    stage_bit = stage_bits.pop()
+                elif projection_tensors[shard_id]:
+                    fallback = projection_tensors[shard_id][0]
+                    stage_bit = fallback.shape[2] // 16
+                else:
+                    raise ValueError(
+                        "packed cartridge stage has no fallback tensor: "
+                        f"stage={stage_idx}, projection={shard_id}"
+                    )
+
+                for expert_id, tensors in enumerate(stage_tensors):
+                    if tensors is None:
+                        projection_tensors[shard_id].append(fallback)
+                        projection_scales[shard_id].append(0.0)
+                        continue
+                    trellis = tensors["trellis"]
+                    scale = tensors["scale"]
+                    assert isinstance(trellis, torch.Tensor)
+                    assert isinstance(scale, float)
+                    projection_tensors[shard_id].append(trellis)
+                    inverse_scale = 1.0 / scale
+                    if (
+                        not math.isfinite(inverse_scale)
+                        or inverse_scale > torch.finfo(torch.float32).max
+                    ):
+                        raise ValueError(
+                            "packed cartridge inverse scale is not finite in FP32: "
+                            f"stage={stage_idx}, expert={expert_id}, "
+                            f"projection={shard_id}, scale={scale}"
+                        )
+                    projection_scales[shard_id].append(inverse_scale)
+                    retained.append(trellis)
+                projection_bits[shard_id].append(stage_bit)
+
+        table_shape = (cartridge.num_stages, self.num_experts)
+        pointer_tables = tuple(
+            self._pointer_table(projection_tensors[shard_id]).view(table_shape)
+            for shard_id in ("w1", "w3", "w2")
         )
-        intermediate_identity = torch.eye(
-            self.intermediate_size, dtype=torch.float16, device=self.device
+        scale_tables = tuple(
+            torch.tensor(
+                projection_scales[shard_id],
+                dtype=torch.float32,
+                device=self.device,
+            ).view(table_shape)
+            for shard_id in ("w1", "w3", "w2")
         )
-
-        for expert_id in range(self.num_experts):
-            for shard_id, offset in (("w1", 0), ("w3", self.intermediate_size)):
-                base = Exl3MoEMethod._apply_expert(
-                    layer, "w13", hidden_identity, expert_id, shard_id
-                )
-                combined = apply_exl3_cartridge(
-                    base,
-                    hidden_identity,
-                    layer,
-                    "w13",
-                    expert_id,
-                    shard_id,
-                    cartridge,
-                )
-                self.w13[expert_id, offset : offset + self.intermediate_size].copy_(
-                    combined.T.to(self.dtype)
-                )
-
-            base = Exl3MoEMethod._apply_expert(
-                layer, "w2", intermediate_identity, expert_id, "w2"
+        bit_tables = tuple(
+            torch.tensor(
+                projection_bits[shard_id],
+                dtype=torch.int32,
+                device=self.device,
             )
-            combined = apply_exl3_cartridge(
-                base,
-                intermediate_identity,
-                layer,
-                "w2",
-                expert_id,
-                "w2",
-                cartridge,
-            )
-            self.w2[expert_id].copy_(combined.T.to(self.dtype))
-
-        for weights in (self.w13, self.w2):
-            minimum, maximum = torch.aminmax(weights)
-            if not torch.isfinite(minimum).item() or not torch.isfinite(maximum).item():
-                raise ValueError(
-                    "materialized EXL3 cartridge contains non-finite weights"
-                )
+            for shard_id in ("w1", "w3", "w2")
+        )
+        self.pointer_args = pointer_tables + scale_tables + bit_tables
+        self.max_residual_bits = max(
+            bits for projection in projection_bits.values() for bits in projection
+        )
+        self._packed_tensors = tuple(retained) + self.pointer_args
         self._materialized = True
 
-        # Activation is a separate model-wide commit step. Keeping this runtime
-        # inactive until every layer materializes prevents mixed-model states.
+    def apply(
+        self,
+        layer: Any,
+        x: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+    ) -> torch.Tensor:
+        if not self._materialized or not self._active:
+            raise RuntimeError("packed EXL3 cartridge runtime is not active")
+        if self.ext is None:
+            raise RuntimeError("packed EXL3 cartridge execution requires CUDA")
+        if x.shape[0] == 0:
+            return torch.empty_like(x)
+        outputs: list[torch.Tensor] = []
+        for start in range(0, x.shape[0], self.chunk):
+            rows = min(self.chunk, x.shape[0] - start)
+            xh = self.xh[:rows]
+            xh.copy_(x[start : start + rows])
+            out32 = self.out32[:rows]
+            out32.zero_()
+            route_count = rows * self.topk
+            self.ext.exl3_moe_additive_fused(
+                xh,
+                out32,
+                topk_ids[start : start + rows],
+                topk_weights[start : start + rows],
+                self.expert_map,
+                self.expert_count,
+                self.expert_offsets,
+                self.token_sorted[:route_count],
+                self.weight_sorted[:route_count],
+                self.tg,
+                self.tu,
+                self.ig,
+                self.iu,
+                0,
+                self.base_bits,
+                self.base_bits,
+                self.base_bits,
+                *layer.exl3_pointer_tables,
+                *self.pointer_args,
+                self.max_residual_bits,
+                True,
+                False,
+                True,
+                False,
+                True,
+                False,
+                0.0,
+            )
+            outputs.append(out32.to(x.dtype))
+        return outputs[0] if len(outputs) == 1 else torch.cat(outputs)
 
 
 def prepare_exl3_cudagraph_cartridge_runtime(
@@ -254,80 +401,19 @@ def prepare_exl3_cudagraph_cartridge_runtime(
     return runtime
 
 
-def apply_exl3_cartridge(
-    base_output: torch.Tensor,
-    x: torch.Tensor,
-    layer: Any,
-    group: str,
-    expert_id: int,
-    shard_id: str,
-    cartridge: Exl3LoraCartridge | None,
-) -> torch.Tensor:
-    """Add every residual stage to one projection output."""
-    del layer, group
-    if cartridge is None or not cartridge.active:
-        return base_output
-
-    output = base_output.float()
-    for stage_idx in range(cartridge.num_stages):
-        stage_tensors = cartridge.get_stage_tensors(stage_idx, expert_id, shard_id)
-        if stage_tensors is None:
-            continue
-
-        trellis = stage_tensors["trellis"]
-        suh = stage_tensors["suh"]
-        svh = stage_tensors["svh"]
-        scale = stage_tensors["scale"]
-        assert isinstance(trellis, torch.Tensor)
-        assert isinstance(suh, torch.Tensor)
-        assert isinstance(svh, torch.Tensor)
-        assert isinstance(scale, float)
-
-        packed_k = trellis.shape[0] * 16
-        if x.shape[-1] > packed_k:
-            raise ValueError(
-                f"MSRT cartridge input width {x.shape[-1]} exceeds packed K={packed_k}"
-            )
-        padded_x = x
-        if x.shape[-1] < packed_k:
-            padded_x = torch.nn.functional.pad(x, (0, packed_k - x.shape[-1]))
-        # Rank-sliced EXL3 metadata and the fq-cartridge/1 producer both
-        # require MCG; cartridge files do not override the base codebook.
-        correction = _exl3_gemm(padded_x, trellis, suh, svh, True, False)
-        logical_n = base_output.shape[-1]
-        if correction.shape[-1] < logical_n:
-            raise ValueError(
-                "MSRT cartridge packed output width "
-                f"{correction.shape[-1]} is below logical N={logical_n}"
-            )
-        output = output + correction[..., :logical_n].float() * (1.0 / scale)
-
-    return output
-
-
 def apply_exl3_cudagraph_cartridge(
     x: torch.Tensor,
     topk_weights: torch.Tensor,
     topk_ids: torch.Tensor,
     layer: Any,
 ) -> torch.Tensor:
-    """Run the dense cartridge path captured for the active topology."""
+    """Run the packed additive path captured for the active topology."""
     runtime = getattr(layer, "_exl3_cartridge_runtime", None)
     if not isinstance(runtime, Exl3CUDAGraphCartridgeRuntime):
         raise RuntimeError(
             "EXL3 cartridge runtime was not prepared before CUDA graph capture"
         )
-
-    return fused_experts(
-        x.to(runtime.dtype),
-        runtime.w13,
-        runtime.w2,
-        topk_weights,
-        topk_ids,
-        activation=layer.activation,
-        apply_router_weight_on_input=False,
-        global_num_experts=runtime.num_experts,
-    ).to(x.dtype)
+    return runtime.apply(layer, x, topk_weights, topk_ids)
 
 
 def _stage_sort_key(label: str) -> tuple[str, int]:
@@ -387,6 +473,27 @@ def _validate_stage_tensors(
             )
         if not torch.isfinite(tensor).all().item():
             raise ValueError(f"MSRT cartridge {name} contains non-finite values")
+
+
+def _validate_base_rotations(
+    layer: Any,
+    expert_id: int,
+    shard_id: str,
+    suh: torch.Tensor,
+    svh: torch.Tensor,
+) -> None:
+    group = "w2" if shard_id == "w2" else "w13"
+    key = (expert_id, shard_id)
+    for name, cartridge_tensor in (("suh", suh), ("svh", svh)):
+        parameter = getattr(layer, f"{group}_{name}")
+        base_tensor = parameter.exl3_tensors[key]
+        if cartridge_tensor.device != base_tensor.device:
+            cartridge_tensor = cartridge_tensor.to(base_tensor.device)
+        if not torch.equal(cartridge_tensor, base_tensor):
+            raise ValueError(
+                "MSRT cartridge rotations must match the rank-sliced EXL3 base: "
+                f"expert={expert_id}, projection={shard_id}, tensor={name}"
+            )
 
 
 def load_cartridge_from_adapter(
@@ -469,6 +576,7 @@ def load_cartridge_from_adapter(
             suh = handle.get_tensor(companion_keys["suh"])
             svh = handle.get_tensor(companion_keys["svh"])
             _validate_stage_tensors(layer, shard_id, trellis, suh, svh)
+            _validate_base_rotations(layer, expert_id, shard_id, suh, svh)
             scale = 1.0
             if companion_keys["scale"] in key_set:
                 scale_tensor = handle.get_tensor(companion_keys["scale"])
@@ -511,8 +619,8 @@ def load_cartridge_from_adapter(
 
 @torch.inference_mode()
 def prepare_exl3_cartridge_into_model(model: torch.nn.Module, adapter_path: str) -> int:
-    """Lazily allocate and materialize a cartridge without activating it."""
-    prepared: list[tuple[Any, Exl3CUDAGraphCartridgeRuntime, Exl3LoraCartridge]] = []
+    """Load each layer into packed storage without a dense or staging peak."""
+    prepared_count = 0
     try:
         for layer in model.modules():
             runtime = getattr(layer, "_exl3_cartridge_runtime", None)
@@ -530,25 +638,17 @@ def prepare_exl3_cartridge_into_model(model: torch.nn.Module, adapter_path: str)
                 raise ValueError(
                     f"Cartridge {adapter_path} has no tensors for {layer.layer_name}"
                 )
-            prepared.append((layer, runtime, cartridge))
-        if not prepared:
-            return 0
-
-        prepared_count = len(prepared)
-        for _, runtime, _ in prepared:
             runtime.deactivate()
-        for layer, runtime, cartridge in prepared:
             cartridge.to(runtime.device)
             try:
                 runtime.materialize(layer, cartridge)
             finally:
                 cartridge.clear()
+            prepared_count += 1
         return prepared_count
     except Exception:
         deactivate_exl3_cartridge(model)
         raise
-    finally:
-        prepared.clear()
 
 
 @torch.inference_mode()
@@ -580,7 +680,7 @@ def load_exl3_cartridge_into_model(model: torch.nn.Module, adapter_path: str) ->
 
 
 def has_exl3_cartridge(model: torch.nn.Module) -> bool:
-    """Return whether this worker owns any dense cartridge runtime."""
+    """Return whether this worker owns any packed cartridge runtime."""
     return any(
         isinstance(
             getattr(layer, "_exl3_cartridge_runtime", None),
@@ -592,7 +692,7 @@ def has_exl3_cartridge(model: torch.nn.Module) -> bool:
 
 @torch.inference_mode()
 def deactivate_exl3_cartridge(model: torch.nn.Module) -> int:
-    """Select the compressed base path and release every dense runtime."""
+    """Select the compressed base path and release every cartridge runtime."""
     updated = 0
     for layer in model.modules():
         runtime = getattr(layer, "_exl3_cartridge_runtime", None)
@@ -608,7 +708,6 @@ __all__ = [
     "Exl3CUDAGraphCartridgeRuntime",
     "Exl3LoraCartridge",
     "activate_exl3_cartridge",
-    "apply_exl3_cartridge",
     "apply_exl3_cudagraph_cartridge",
     "deactivate_exl3_cartridge",
     "has_exl3_cartridge",

--- a/vllm/model_executor/layers/quantization/exl3_lora_cartridge.py
+++ b/vllm/model_executor/layers/quantization/exl3_lora_cartridge.py
@@ -1,0 +1,270 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""EXL3 LoRA cartridge support for MSRT additive quantization.
+
+This module extends EXL3 MoE quantization to support MSRT (Multi-Stage Rescaled
+Trellis) additive cartridge adapters. Unlike standard LoRA (low-rank A·B
+decomposition), MSRT cartridges contain full-rank trellis-quantized residual
+weights that are applied as additional exl3_gemm passes summed with the base
+output.
+
+The cartridge is loaded via vLLM's LoRA hot-swap API (add_lora / remove_lora)
+and applied at runtime without model reload. Each cartridge stage adds one
+exl3_gemm pass per expert; the outputs are summed with per-stage rescaling.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import torch
+
+from vllm.model_executor.layers.quantization.exl3 import (
+    Exl3Config,
+    Exl3MoEMethod,
+    _exl3_gemm,
+)
+from vllm.model_executor.layers.fused_moe import FusedMoEMethodBase
+
+logger = logging.getLogger(__name__)
+
+
+def exl3_get_supported_lora_modules() -> list[str]:
+    """Return the module names that support EXL3 LoRA cartridges.
+
+    EXL3 quantizes MoE expert projections (gate_proj, up_proj, down_proj).
+    These are the modules that can receive additive cartridge corrections.
+    """
+    return ["gate_proj", "up_proj", "down_proj"]
+
+
+def exl3_lora_can_replace_layer(
+    source_layer: Any,
+    lora_config: Any,
+    packed_modules_list: list[str],
+    model_config: Any,
+) -> bool:
+    """Check if a layer can be replaced with an EXL3 LoRA-wrapped version.
+
+    This replaces the standard FusedMoEWithLoRA check for EXL3 layers.
+    Returns True when the source layer uses EXL3 MoE quantization.
+    """
+    # EXL3 LoRA works with the monolithic per-expert path, not the modular kernel
+    # path. We check if the layer's quant method is Exl3MoEMethod.
+    quant_method = getattr(getattr(source_layer, "routed_experts", source_layer),
+                          "quant_method", None)
+    if isinstance(quant_method, Exl3MoEMethod):
+        return True
+    return False
+
+
+class Exl3LoraCartridge:
+    """Holds MSRT cartridge tensors for one MoE layer.
+
+    Each cartridge stage contains:
+    - trellis: int16 packed trellis indices (k//16, n//16, K*16)
+    - suh: float16 row-side Hadamard scales
+    - svh: float16 column-side Hadamard scales
+    - scale: float32 rescaling factor (codebook_scale / RMS(residual))
+
+    The cartridge is applied as:
+      output += (1/scale) * exl3_gemm(x, trellis, suh, svh, mcg=True)
+    """
+
+    def __init__(self, num_stages: int, num_experts: int, device: torch.device):
+        self.num_stages = num_stages
+        self.num_experts = num_experts
+        self.device = device
+        # Per-stage storage: list of dicts keyed by (expert_id, shard_id)
+        self.stages: list[dict[tuple[int, str], dict[str, torch.Tensor]]] = [
+            {} for _ in range(num_stages)
+        ]
+        self.active = False
+
+    def set_stage_tensors(
+        self,
+        stage_idx: int,
+        expert_id: int,
+        shard_id: str,
+        trellis: torch.Tensor,
+        suh: torch.Tensor,
+        svh: torch.Tensor,
+        scale: float,
+    ) -> None:
+        """Set cartridge tensors for one expert's projection at one stage."""
+        self.stages[stage_idx][(expert_id, shard_id)] = {
+            "trellis": trellis.to(self.device),
+            "suh": suh.to(self.device),
+            "svh": svh.to(self.device),
+            "scale": scale,
+        }
+
+    def get_stage_tensors(
+        self, stage_idx: int, expert_id: int, shard_id: str
+    ) -> dict[str, torch.Tensor] | None:
+        """Get cartridge tensors for one expert's projection at one stage."""
+        return self.stages[stage_idx].get((expert_id, shard_id))
+
+    def clear(self) -> None:
+        """Remove all cartridge tensors."""
+        self.stages = [{} for _ in range(self.num_stages)]
+        self.active = False
+
+
+def apply_exl3_cartridge(
+    base_output: torch.Tensor,
+    x: torch.Tensor,
+    layer: Any,
+    group: str,
+    expert_id: int,
+    shard_id: str,
+    cartridge: Exl3LoraCartridge | None,
+) -> torch.Tensor:
+    """Apply MSRT cartridge correction to a base EXL3 GEMM output.
+
+    Args:
+        base_output: Output from the base EXL3 GEMM (K2 or K3 tier)
+        x: Input activations (float16, padded to packed_k)
+        layer: The RoutedExperts layer (for accessing trellis tensors)
+        group: Weight group ("w13" or "w2")
+        expert_id: Expert index
+        shard_id: Projection shard ("w1", "w3", or "w2")
+        cartridge: The cartridge to apply, or None
+
+    Returns:
+        Corrected output: base_output + sum of cartridge stage corrections
+    """
+    if cartridge is None or not cartridge.active:
+        return base_output
+
+    key = (expert_id, shard_id)
+    output = base_output
+
+    for stage_idx in range(cartridge.num_stages):
+        stage_tensors = cartridge.get_stage_tensors(stage_idx, expert_id, shard_id)
+        if stage_tensors is None:
+            continue
+
+        trellis = stage_tensors["trellis"]
+        suh = stage_tensors["suh"]
+        svh = stage_tensors["svh"]
+        scale = stage_tensors["scale"]
+
+        # Run additional EXL3 GEMM for this cartridge stage
+        cartridge_output = _exl3_gemm(x, trellis, suh, svh, True, False)
+        # Sum with rescaling: output += cartridge_output / scale
+        output = output + cartridge_output * (1.0 / scale)
+
+    return output
+
+
+# Patch Exl3MoEMethod._apply_expert to support cartridges
+_original_apply_expert = Exl3MoEMethod._apply_expert
+
+
+@staticmethod
+def _apply_expert_with_cartridge(
+    layer: Any,
+    group: str,
+    x: torch.Tensor,
+    expert_id: int,
+    shard_id: str,
+) -> torch.Tensor:
+    """Extended _apply_expert that applies MSRT cartridge after base GEMM."""
+    # Run the original base EXL3 GEMM
+    output = _original_apply_expert(layer, group, x, expert_id, shard_id)
+
+    # Apply cartridge if present
+    cartridge = getattr(layer, "_exl3_cartridge", None)
+    if cartridge is not None and cartridge.active:
+        key = (expert_id, shard_id)
+        trellis = getattr(layer, f"{group}_trellis").exl3_tensors[key]
+        packed_k = trellis.shape[0] * 16
+        x_padded = x
+        if x.shape[-1] < packed_k:
+            x_padded = torch.nn.functional.pad(x, (0, packed_k - x.shape[-1]))
+        output = apply_exl3_cartridge(
+            output, x_padded, layer, group, expert_id, shard_id, cartridge)
+
+    return output
+
+
+# Install the patched method
+Exl3MoEMethod._apply_expert = _apply_expert_with_cartridge
+
+
+def load_cartridge_from_adapter(
+    adapter_path: str,
+    layer: Any,
+    num_experts: int,
+    device: torch.device,
+) -> Exl3LoraCartridge | None:
+    """Load an MSRT cartridge adapter from a safetensors file.
+
+    The adapter contains tensors named:
+      model.layers.{L}.mlp.experts.{E}.{proj}.rank0.trellis_{label}
+      model.layers.{L}.mlp.experts.{E}.{proj}.rank0.suh_{label}
+      model.layers.{L}.mlp.experts.{E}.{proj}.rank0.svh_{label}
+      model.layers.{L}.mlp.experts.{E}.{proj}.rank0.scale_{label}
+
+    Returns an Exl3LoraCartridge loaded onto the device.
+    """
+    from safetensors import safe_open
+
+    # Detect number of stages from tensor names
+    stage_labels = set()
+    with safe_open(adapter_path, framework="pt") as f:
+        keys = list(f.keys())
+        for key in keys:
+            if ".trellis_" in key:
+                label = key.split(".trellis_")[-1]
+                stage_labels.add(label)
+
+    if not stage_labels:
+        logger.warning("No MSRT cartridge stages found in %s", adapter_path)
+        return None
+
+    # Sort labels to maintain stage order
+    sorted_labels = sorted(stage_labels)
+    num_stages = len(sorted_labels)
+    cartridge = Exl3LoraCartridge(num_stages, num_experts, device)
+
+    shard_map = {"gate_proj": "w1", "up_proj": "w3", "down_proj": "w2"}
+
+    with safe_open(adapter_path, framework="pt") as f:
+        for stage_idx, label in enumerate(sorted_labels):
+            for key in keys:
+                if f".trellis_{label}" not in key:
+                    continue
+                # Parse: model.layers.{L}.mlp.experts.{E}.{proj}.rank{R}.trellis_{label}
+                parts = key.split(".")
+                # Find expert ID and projection
+                expert_id = int(parts[5])
+                proj = parts[6]
+                rank = int(parts[7].replace("rank", ""))
+                shard_id = shard_map.get(proj, proj)
+
+                prefix = ".".join(parts[:-1])  # without .trellis_{label}
+                trellis_key = f"{prefix}.trellis_{label}"
+                suh_key = f"{prefix}.suh_{label}"
+                svh_key = f"{prefix}.svh_{label}"
+                scale_key = f"{prefix}.scale_{label}"
+
+                if trellis_key in f.keys() and suh_key in f.keys():
+                    trellis = f.get_tensor(trellis_key)
+                    suh = f.get_tensor(suh_key)
+                    svh = f.get_tensor(svh_key) if svh_key in f.keys() else suh
+                    scale_val = 1.0
+                    if scale_key in f.keys():
+                        scale_val = float(f.get_tensor(scale_key).item())
+
+                    cartridge.set_stage_tensors(
+                        stage_idx, expert_id, shard_id,
+                        trellis, suh, svh, scale_val)
+
+    cartridge.active = True
+    logger.info("Loaded MSRT cartridge: %d stages, %d experts from %s",
+                num_stages, num_experts, adapter_path)
+    return cartridge

--- a/vllm/model_executor/layers/quantization/exl3_lora_cartridge.py
+++ b/vllm/model_executor/layers/quantization/exl3_lora_cartridge.py
@@ -16,33 +16,55 @@ inverse transition and releases the cartridge tensors before recapturing the
 compressed base path.
 
 The runtime is opt-in. Inactive cartridge support has no cartridge buffers,
-alternate graph path, or runtime overhead. Set ``cartridge_runtime: true`` in
-the EXL3 quantization configuration to allow the quiescent recapture
-transaction. Use
-``llm_engine.load_exl3_cartridge(path)`` and
-``llm_engine.deactivate_exl3_cartridge()``; both dispatch through the worker
-control plane to every model worker.
+alternate graph path, or runtime overhead. Set
+``VLLM_ENABLE_EXL3_CARTRIDGE=1`` on a trusted-admin deployment to allow the
+quiescent recapture transaction. Use
+``await async_llm.load_exl3_cartridge(path)`` and
+``await async_llm.deactivate_exl3_cartridge()``; both dispatch through the worker
+control plane to every model worker. The synchronous ``LLMEngine`` interface is
+intentionally unsupported because it cannot serialize request admission with a
+model-wide graph transition.
 
-The initial implementation supports tensor parallel size one and one
-model-wide slot; per-request cartridge selection is intentionally not claimed.
+Tensor parallel workers either slice a manifest-declared full-rank ``rank0``
+cartridge or select their matching rank from a cartridge containing every TP
+rank. The runtime exposes one model-wide slot; per-request selection is not
+claimed.
 """
 
 from __future__ import annotations
 
-import logging
+import hashlib
+import json
 import math
+import os
 import re
-from typing import Any
+import stat
+import tempfile
+import time
+from contextlib import ExitStack
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from types import TracebackType
+from typing import Any, TypedDict
 
 import torch
 
-from vllm.model_executor.layers.quantization.exl3 import _load_exl3_ext
+from vllm.logger import init_logger
+from vllm.model_executor.layers.quantization.exl3 import (
+    Exl3LinearMethod,
+    _load_exl3_ext,
+)
 
-logger = logging.getLogger(__name__)
+logger = init_logger(__name__)
 
 
 def _load_additive_exl3_ext() -> Any:
     ext = _load_exl3_ext()
+    if getattr(ext, "EXL3_MOE_ADDITIVE_ABI_VERSION", None) != 1:
+        raise RuntimeError(
+            "packed EXL3 cartridges require EXL3_MOE_ADDITIVE_ABI_VERSION=1"
+        )
     if not hasattr(ext, "exl3_moe_additive_fused"):
         raise RuntimeError(
             "packed EXL3 cartridges require an ExLlamaV3 extension that "
@@ -53,17 +75,97 @@ def _load_additive_exl3_ext() -> Any:
 
 _CARTRIDGE_KEY_RE = re.compile(
     r"^(?P<layer>.+\.experts)\."
-    r"(?P<expert>\d+)\."
+    r"(?P<expert>[0-9]+)\."
     r"(?P<projection>gate_proj|up_proj|down_proj)\."
-    r"rank(?P<rank>\d+)\.trellis_(?P<label>.+)$"
+    r"rank(?P<rank>[0-9]+)\.trellis_(?P<label>.+)$"
 )
 _CARTRIDGE_COMPANION_KEY_RE = re.compile(
     r"^(?P<layer>.+\.experts)\."
-    r"(?P<expert>\d+)\."
+    r"(?P<expert>[0-9]+)\."
     r"(?P<projection>gate_proj|up_proj|down_proj)\."
-    r"rank(?P<rank>\d+)\.(?:scale|mcg|mul1)_(?P<label>.+)$"
+    r"rank(?P<rank>[0-9]+)\.scale_(?P<label>.+)$"
 )
+_ADAPTER_SCHEMA = "fq-cartridge-adapter/3"
+_MCG_MULTIPLIER = 3417055213
+_RUNTIME_OPERATION = "base_exl3_gemm + sum(stage_exl3_gemm / stage_scale)"
+_RUNTIME_PROFILE = "exl3-msrt-additive/1"
+_LABEL_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,31}$")
+_LAYER_NAME_RE = re.compile(r"^model\.layers\.([0-9]+)\.mlp\.experts$")
+_LIVE_LAYER_INDEX_RE = re.compile(r"(?:^|\.)layers\.([0-9]+)(?=\.|$)")
+_ADAPTER_FIELDS = frozenset(
+    {
+        "schema",
+        "assembly",
+        "base",
+        "chain",
+        "format",
+        "runtime_profile",
+        "rotation_ownership",
+        "standard_lora_compatible",
+        "runtime_operation",
+        "codebook",
+        "mcg_multiplier",
+        "mcg_ownership",
+        "scale_shape",
+        "tensor_parallel",
+        "shards",
+        "num_tensors",
+        "selected_experts",
+        "selected_layers",
+        "coverage",
+        "producer_verified_signer",
+        "campaign",
+        "source_assembly",
+        "tool_version",
+        "created_utc",
+    }
+)
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 _SHARD_MAP = {"gate_proj": "w1", "up_proj": "w3", "down_proj": "w2"}
+_HADAMARD_BLOCK = 128
+_TP_AXES = {
+    "gate_proj": "output",
+    "up_proj": "output",
+    "down_proj": "input",
+}
+_MAX_MANIFEST_BYTES = 16 * 1024 * 1024
+_MAX_SHARD_BYTES = 64 * 1024 * 1024 * 1024
+_MAX_ADAPTER_BYTES = 1024 * 1024 * 1024 * 1024
+_STAGING_TIMEOUT_SECONDS = 15 * 60
+_COPY_CHUNK_BYTES = 8 * 1024 * 1024
+
+
+@dataclass(frozen=True)
+class _AdapterState:
+    config: dict[str, Any]
+    stage_labels: tuple[str, ...]
+    stage_bits: dict[str, int]
+    paths: tuple[Path, ...]
+    by_layer: dict[str, list[tuple[str, re.Match[str]]]]
+    key_count: int
+
+
+class StagedExl3Cartridge:
+    """Verified private shard copies ready for the drained transaction."""
+
+    def __init__(self, temporary: tempfile.TemporaryDirectory[str]) -> None:
+        self._temporary = temporary
+        self.state: _AdapterState | None = None
+        self.local_layer_names: tuple[str, ...] = ()
+
+    def close(self) -> None:
+        self._temporary.cleanup()
+
+    def __enter__(self) -> StagedExl3Cartridge:
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        self.close()
+
+
+class _StageTensors(TypedDict):
+    trellis: torch.Tensor
+    scale: float
 
 
 class Exl3LoraCartridge:
@@ -82,7 +184,7 @@ class Exl3LoraCartridge:
         self.num_stages = num_stages
         self.num_experts = num_experts
         self.device = device
-        self.stages: list[dict[tuple[int, str], dict[str, torch.Tensor | float]]] = [
+        self.stages: list[dict[tuple[int, str], _StageTensors]] = [
             {} for _ in range(num_stages)
         ]
         self.active = False
@@ -106,6 +208,15 @@ class Exl3LoraCartridge:
             raise ValueError(
                 f"cartridge scale must be finite and positive, got {scale}"
             )
+        inverse_scale = 1.0 / scale
+        if (
+            not math.isfinite(inverse_scale)
+            or inverse_scale > torch.finfo(torch.float32).max
+        ):
+            raise ValueError(
+                "cartridge inverse scale is not finite in FP32: "
+                f"scale={scale}, inverse={inverse_scale}"
+            )
         self.stages[stage_idx][(expert_id, shard_id)] = {
             "trellis": trellis.to(self.device).contiguous(),
             "scale": float(scale),
@@ -113,7 +224,7 @@ class Exl3LoraCartridge:
 
     def get_stage_tensors(
         self, stage_idx: int, expert_id: int, shard_id: str
-    ) -> dict[str, torch.Tensor | float] | None:
+    ) -> _StageTensors | None:
         """Return one stage of one expert projection, if present."""
         return self.stages[stage_idx].get((expert_id, shard_id))
 
@@ -122,7 +233,6 @@ class Exl3LoraCartridge:
         for stage in self.stages:
             for tensors in stage.values():
                 tensor = tensors["trellis"]
-                assert isinstance(tensor, torch.Tensor)
                 tensors["trellis"] = tensor.to(device).contiguous()
         self.device = device
 
@@ -135,11 +245,13 @@ class Exl3LoraCartridge:
 class Exl3CUDAGraphCartridgeRuntime:
     """Fixed-address packed cartridge tensors and additive MoE workspaces."""
 
-    def __init__(self, layer: Any):
-        tp_size = int(getattr(layer, "exl3_tp_size", 1))
-        if tp_size != 1:
-            raise NotImplementedError(
-                "EXL3 cartridge runtime currently requires tensor_parallel_size=1"
+    def __init__(self, layer: Any, workspace: dict[str, torch.Tensor] | None = None):
+        self.tp_rank = int(getattr(layer, "exl3_tp_rank", 0))
+        self.tp_size = int(getattr(layer, "exl3_tp_size", 1))
+        if self.tp_size < 1 or not 0 <= self.tp_rank < self.tp_size:
+            raise ValueError(
+                "invalid EXL3 cartridge tensor-parallel configuration: "
+                f"rank={self.tp_rank}, size={self.tp_size}"
             )
         self.num_experts = int(layer.local_num_experts)
         self.hidden_size = int(layer.exl3_hidden_size)
@@ -158,46 +270,64 @@ class Exl3CUDAGraphCartridgeRuntime:
             concurrency = int(self.ext.exl3_moe_max_concurrency(self.device.index or 0))
         else:
             concurrency = 1
-        self.xh = torch.empty(
-            (self.chunk, self.hidden_size), dtype=self.dtype, device=self.device
-        )
-        self.out32 = torch.empty(
-            (self.chunk, self.hidden_size), dtype=torch.float32, device=self.device
-        )
-        self.tg = torch.empty(
-            (concurrency, self.chunk, self.hidden_size),
-            dtype=self.dtype,
-            device=self.device,
-        )
-        self.tu = torch.empty_like(self.tg)
-        self.ig = torch.empty(
-            (concurrency, self.chunk, self.intermediate_size),
-            dtype=self.dtype,
-            device=self.device,
-        )
-        self.iu = torch.empty_like(self.ig)
-        self.expert_count = torch.empty(
-            self.num_experts + 1, dtype=torch.int64, device=self.device
-        )
-        self.expert_offsets = torch.empty_like(self.expert_count)
-        self.token_sorted = torch.empty(
-            self.chunk * self.topk, dtype=torch.int64, device=self.device
-        )
-        self.weight_sorted = torch.empty(
-            self.chunk * self.topk, dtype=self.dtype, device=self.device
-        )
-        self.expert_map = torch.arange(
-            self.num_experts, dtype=torch.int64, device=self.device
-        )
+        workspace = {} if workspace is None else workspace
+        if not workspace:
+            workspace.update(
+                xh=torch.empty(
+                    (self.chunk, self.hidden_size),
+                    dtype=self.dtype,
+                    device=self.device,
+                ),
+                out32=torch.empty(
+                    (self.chunk, self.hidden_size),
+                    dtype=torch.float32,
+                    device=self.device,
+                ),
+                tg=torch.empty(
+                    (concurrency, self.chunk, self.hidden_size),
+                    dtype=self.dtype,
+                    device=self.device,
+                ),
+                ig=torch.empty(
+                    (concurrency, self.chunk, self.intermediate_size),
+                    dtype=self.dtype,
+                    device=self.device,
+                ),
+                expert_count=torch.empty(
+                    self.num_experts + 1,
+                    dtype=torch.int64,
+                    device=self.device,
+                ),
+                token_sorted=torch.empty(
+                    self.chunk * self.topk,
+                    dtype=torch.int64,
+                    device=self.device,
+                ),
+                weight_sorted=torch.empty(
+                    self.chunk * self.topk,
+                    dtype=self.dtype,
+                    device=self.device,
+                ),
+                expert_map=torch.arange(
+                    self.num_experts,
+                    dtype=torch.int64,
+                    device=self.device,
+                ),
+            )
+            workspace["tu"] = torch.empty_like(workspace["tg"])
+            workspace["iu"] = torch.empty_like(workspace["ig"])
+            workspace["expert_offsets"] = torch.empty_like(workspace["expert_count"])
+        for name, tensor in workspace.items():
+            setattr(self, name, tensor)
         self._active = False
         self._materialized = False
         self._packed_tensors: tuple[torch.Tensor, ...] = ()
         self.pointer_args: tuple[torch.Tensor, ...] = ()
         self.max_residual_bits = 0
         layer_bitrates = tuple(getattr(layer, "exl3_layer_bitrates", ()))
-        if len(set(layer_bitrates)) != 1:
+        if not layer_bitrates or len(set(layer_bitrates)) != 1:
             raise ValueError("packed cartridge runtime requires a uniform base bitrate")
-        self.base_bits = int(layer_bitrates[0])
+        self.base_bits = int(next(iter(layer_bitrates)))
 
     @staticmethod
     def _pointer_table(tensors: list[torch.Tensor]) -> torch.Tensor:
@@ -417,13 +547,36 @@ class Exl3CUDAGraphCartridgeRuntime:
 
 def prepare_exl3_cudagraph_cartridge_runtime(
     layer: Any,
+    workspace: dict[str, torch.Tensor] | None = None,
 ) -> Exl3CUDAGraphCartridgeRuntime:
     """Allocate a layer's fixed-address cartridge buffers before capture."""
     runtime = getattr(layer, "_exl3_cartridge_runtime", None)
     if runtime is None:
-        runtime = Exl3CUDAGraphCartridgeRuntime(layer)
+        runtime = Exl3CUDAGraphCartridgeRuntime(layer, workspace)
         layer._exl3_cartridge_runtime = runtime
     return runtime
+
+
+def _model_workspace(
+    model: torch.nn.Module,
+    layer: Any,
+) -> dict[str, torch.Tensor]:
+    cache = getattr(model, "_exl3_cartridge_workspaces", None)
+    if cache is None:
+        cache = {}
+        model._exl3_cartridge_workspaces = cache
+    device = layer.w13_trellis.device
+    key = (
+        device.type,
+        device.index,
+        torch.float16,
+        int(layer.exl3_hidden_size),
+        int(layer.exl3_intermediate_size_per_partition),
+        int(layer.local_num_experts),
+        int(layer.top_k),
+        min(128, int(layer.exl3_max_num_batched_tokens)),
+    )
+    return cache.setdefault(key, {})
 
 
 def apply_exl3_cudagraph_cartridge(
@@ -441,30 +594,12 @@ def apply_exl3_cudagraph_cartridge(
     return runtime.apply(layer, x, topk_weights, topk_ids)
 
 
-def _stage_sort_key(label: str) -> tuple[str, int]:
-    prefix, separator, suffix = label.rpartition("_")
-    if separator and suffix.isdigit():
-        return prefix, int(suffix)
-    match = re.match(r"^(.*?)(\d+)$", label)
-    if match is not None:
-        return match.group(1), int(match.group(2))
-    return label, -1
-
-
-def _validate_stage_trellis(layer: Any, shard_id: str, trellis: torch.Tensor) -> None:
-    """Validate an MSRT residual trellis against this layer's base shape.
-
-    A cartridge does not carry its own suh/svh: MSRT residuals are quantized
-    in the same regularized rotation space as the rank-sliced base, so the
-    base's own suh/svh apply unchanged to every stage.
-    """
-    hidden_size = int(layer.exl3_hidden_size)
-    intermediate_size = int(layer.exl3_intermediate_size_per_partition)
-    input_size, output_size = (
-        (intermediate_size, hidden_size)
-        if shard_id == "w2"
-        else (hidden_size, intermediate_size)
-    )
+def _validate_stage_trellis_shape(
+    trellis: torch.Tensor,
+    *,
+    input_size: int,
+    output_size: int,
+) -> None:
     shape_valid = trellis.ndim == 3
     packed_k = trellis.shape[0] * 16 if shape_valid else 0
     packed_n = trellis.shape[1] * 16 if shape_valid else 0
@@ -488,25 +623,774 @@ def _validate_stage_trellis(layer: Any, shard_id: str, trellis: torch.Tensor) ->
         )
 
 
+def _validate_stage_trellis(layer: Any, shard_id: str, trellis: torch.Tensor) -> None:
+    """Validate one rank-local MSRT residual against its base shard."""
+    hidden_size = int(layer.exl3_hidden_size)
+    intermediate_size = int(layer.exl3_intermediate_size_per_partition)
+    input_size, output_size = (
+        (intermediate_size, hidden_size)
+        if shard_id == "w2"
+        else (hidden_size, intermediate_size)
+    )
+    _validate_stage_trellis_shape(
+        trellis,
+        input_size=input_size,
+        output_size=output_size,
+    )
+
+
+def _slice_full_stage_trellis_for_tp(
+    layer: Any,
+    shard_id: str,
+    trellis: torch.Tensor,
+) -> torch.Tensor:
+    """Select this TP worker's shard from a full-rank cartridge."""
+    tp_rank = int(getattr(layer, "exl3_tp_rank", 0))
+    tp_size = int(getattr(layer, "exl3_tp_size", 1))
+    local_intermediate = int(layer.exl3_intermediate_size_per_partition)
+    full_intermediate = local_intermediate * tp_size
+    hidden_size = int(layer.exl3_hidden_size)
+    input_size, output_size = (
+        (full_intermediate, hidden_size)
+        if shard_id == "w2"
+        else (hidden_size, full_intermediate)
+    )
+    _validate_stage_trellis_shape(
+        trellis,
+        input_size=input_size,
+        output_size=output_size,
+    )
+    if tp_size == 1:
+        return trellis
+
+    return Exl3LinearMethod._slice_exl3_tensor(
+        trellis,
+        dim=0 if shard_id == "w2" else 1,
+        start=tp_rank * local_intermediate,
+        size=local_intermediate,
+    )
+
+
+def _select_rank_entries(
+    entries: list[tuple[str, re.Match[str]]],
+    layer: Any,
+    *,
+    layout: str,
+    manifest_ranks: tuple[int, ...],
+) -> list[tuple[str, re.Match[str]]]:
+    """Select local tensors according to the manifest-declared TP layout."""
+    if not entries:
+        return entries
+
+    tp_rank = int(getattr(layer, "exl3_tp_rank", 0))
+    tp_size = int(getattr(layer, "exl3_tp_size", 1))
+    entries_by_rank: dict[int, list[tuple[str, re.Match[str]]]] = {}
+    for entry in entries:
+        entries_by_rank.setdefault(int(entry[1].group("rank")), []).append(entry)
+
+    ranks = set(entries_by_rank)
+    expected_ranks = set(manifest_ranks)
+    if ranks != expected_ranks:
+        raise ValueError(
+            "MSRT cartridge tensor ranks do not match adapter_config.json: "
+            f"tensors={sorted(ranks)}, manifest={sorted(expected_ranks)}"
+        )
+    if layout == "full":
+        return entries_by_rank[0]
+    if layout != "rank-sharded":
+        raise ValueError(f"unsupported MSRT cartridge TP layout {layout!r}")
+
+    def signature(
+        rank_entries: list[tuple[str, re.Match[str]]],
+    ) -> set[tuple[str, int, str]]:
+        return {
+            (
+                match.group("label"),
+                int(match.group("expert")),
+                match.group("projection"),
+            )
+            for _, match in rank_entries
+        }
+
+    expected_signature = signature(entries_by_rank[0])
+    inconsistent = [
+        rank
+        for rank, rank_entries in entries_by_rank.items()
+        if signature(rank_entries) != expected_signature
+    ]
+    if inconsistent:
+        raise ValueError(
+            "MSRT cartridge TP ranks have inconsistent stage topology: "
+            f"ranks={inconsistent}"
+        )
+    if tp_size != len(manifest_ranks) or tp_rank not in entries_by_rank:
+        raise ValueError(
+            "MSRT cartridge TP ranks do not match the runtime: "
+            f"cartridge={list(manifest_ranks)}, runtime=0..{tp_size - 1}"
+        )
+    return entries_by_rank[tp_rank]
+
+
 def _index_cartridge_keys(
     keys: tuple[str, ...],
 ) -> dict[str, list[tuple[str, re.Match[str]]]]:
-    """Group every trellis key by its owning layer in one pass.
-
-    Scanning is O(total keys) once, rather than re-scanning the full key
-    list once per layer. Also validates, in the same pass, that every key
-    is either a recognized trellis key or a recognized companion (scale,
-    mcg, mul1) key; anything else raises immediately.
-    """
+    """Group trellises by layer and reject orphaned or unknown companions."""
+    key_set = set(keys)
     by_layer: dict[str, list[tuple[str, re.Match[str]]]] = {}
     for key in keys:
-        match = _CARTRIDGE_KEY_RE.match(key)
+        match = _CARTRIDGE_KEY_RE.fullmatch(key)
         if match is not None:
+            scale_key = (
+                f"{match.group('layer')}.{match.group('expert')}."
+                f"{match.group('projection')}.rank{match.group('rank')}."
+                f"scale_{match.group('label')}"
+            )
+            if scale_key not in key_set:
+                raise ValueError(
+                    f"MSRT cartridge trellis {key!r} has no scalar scale companion"
+                )
             by_layer.setdefault(match.group("layer"), []).append((key, match))
             continue
-        if _CARTRIDGE_COMPANION_KEY_RE.match(key) is None:
+        companion = _CARTRIDGE_COMPANION_KEY_RE.fullmatch(key)
+        if companion is None:
             raise ValueError(f"Malformed MSRT cartridge key {key!r}")
+        trellis_key = (
+            f"{companion.group('layer')}.{companion.group('expert')}."
+            f"{companion.group('projection')}.rank{companion.group('rank')}."
+            f"trellis_{companion.group('label')}"
+        )
+        if trellis_key not in key_set:
+            raise ValueError(
+                f"Orphaned MSRT cartridge scale {key!r}; missing {trellis_key!r}"
+            )
     return by_layer
+
+
+def _validate_manifest_tensor_coverage(
+    config: dict[str, Any],
+    by_layer: dict[str, list[tuple[str, re.Match[str]]]],
+) -> None:
+    observed: dict[str, dict[str, set[int]]] = {}
+    observed_layers: set[int] = set()
+    observed_experts: set[int] = set()
+    for layer_name, entries in by_layer.items():
+        layer_match = _LAYER_NAME_RE.fullmatch(layer_name)
+        if layer_match is None:
+            raise ValueError(f"Invalid MSRT cartridge layer name {layer_name!r}")
+        layer_id = int(layer_match.group(1))
+        observed_layers.add(layer_id)
+        for _, match in entries:
+            expert_id = int(match.group("expert"))
+            observed_experts.add(expert_id)
+            by_stage = observed.setdefault(match.group("label"), {})
+            by_stage.setdefault(str(layer_id), set()).add(expert_id)
+
+    declared = {
+        label: {layer_id: set(experts) for layer_id, experts in layers.items()}
+        for label, layers in config["coverage"].items()
+    }
+    if observed != declared:
+        raise ValueError(
+            "MSRT cartridge tensors do not match adapter_config.json coverage"
+        )
+    if observed_layers != set(config["selected_layers"]):
+        raise ValueError(
+            "MSRT cartridge tensors do not match adapter_config.json selected_layers"
+        )
+    if observed_experts != set(config["selected_experts"]):
+        raise ValueError(
+            "MSRT cartridge tensors do not match adapter_config.json selected_experts"
+        )
+    stages = config["chain"]
+    previous: dict[str, set[int]] | None = None
+    for stage in stages:
+        label = stage["label"]
+        current = declared[label]
+        if previous is not None:
+            child_only = {
+                layer_id: sorted(experts - previous.get(layer_id, set()))
+                for layer_id, experts in current.items()
+                if experts - previous.get(layer_id, set())
+            }
+            if child_only:
+                raise ValueError(
+                    "MSRT cartridge coverage is not parent-closed at "
+                    f"stage {label!r}: {child_only}"
+                )
+        stage_experts = stage["experts"]
+        covered_experts = set().union(*current.values())
+        if stage_experts != "all" and covered_experts != set(stage_experts):
+            raise ValueError(f"MSRT stage {label!r} experts do not match its coverage")
+        if stage_experts == "all" and covered_experts != set(
+            config["selected_experts"]
+        ):
+            raise ValueError(
+                f"MSRT stage {label!r} declares all experts but coverage is sparse"
+            )
+        previous = current
+
+
+def _valid_id_list(value: object) -> bool:
+    return (
+        isinstance(value, list)
+        and bool(value)
+        and all(
+            not isinstance(item, bool) and isinstance(item, int) and item >= 0
+            for item in value
+        )
+        and len(set(value)) == len(value)
+    )
+
+
+def _manifest_layer_name_for_live_layer(layer_name: str) -> tuple[str, str]:
+    layer_ids = _LIVE_LAYER_INDEX_RE.findall(layer_name)
+    if len(layer_ids) != 1:
+        raise ValueError(
+            "Invalid live EXL3 layer name; expected exactly one numeric "
+            f"layers.<index> segment, got {layer_name!r}"
+        )
+    layer_id = str(int(layer_ids[0]))
+    return f"model.layers.{layer_id}.mlp.experts", layer_id
+
+
+def _read_regular_file(path: Path, *, max_bytes: int, description: str) -> bytes:
+    flags = (
+        os.O_RDONLY
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_NONBLOCK", 0)
+    )
+    try:
+        fd = os.open(path, flags)
+    except OSError as exc:
+        raise ValueError(f"cannot open {description}") from exc
+    try:
+        metadata = os.fstat(fd)
+        if not stat.S_ISREG(metadata.st_mode):
+            raise ValueError(f"{description} must be a regular file")
+        if metadata.st_size > max_bytes:
+            raise ValueError(
+                f"{description} exceeds the {max_bytes}-byte verification limit"
+            )
+        chunks: list[bytes] = []
+        remaining = metadata.st_size
+        while remaining:
+            chunk = os.read(fd, min(_COPY_CHUNK_BYTES, remaining))
+            if not chunk:
+                raise ValueError(f"{description} changed while it was read")
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        if os.read(fd, 1):
+            raise ValueError(f"{description} grew while it was read")
+        return b"".join(chunks)
+    finally:
+        os.close(fd)
+
+
+def _copy_verified_regular_file(
+    source: Path,
+    destination: Path,
+    *,
+    expected_size: int,
+    expected_sha256: str,
+    deadline: float,
+) -> None:
+    flags = (
+        os.O_RDONLY
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_NONBLOCK", 0)
+    )
+    try:
+        source_fd = os.open(source, flags)
+    except OSError as exc:
+        raise ValueError("cannot open manifest-listed cartridge shard") from exc
+    try:
+        before = os.fstat(source_fd)
+        if not stat.S_ISREG(before.st_mode):
+            raise ValueError("manifest-listed cartridge shard must be a regular file")
+        if before.st_size != expected_size:
+            raise ValueError(
+                "manifest-listed cartridge shard size does not match "
+                "adapter_config.json"
+            )
+        digest = hashlib.sha256()
+        with destination.open("xb") as output:
+            remaining = expected_size
+            while remaining:
+                if time.monotonic() > deadline:
+                    raise TimeoutError("EXL3 cartridge shard verification timed out")
+                chunk = os.read(source_fd, min(_COPY_CHUNK_BYTES, remaining))
+                if not chunk:
+                    raise ValueError("cartridge shard changed during verification")
+                output.write(chunk)
+                digest.update(chunk)
+                remaining -= len(chunk)
+            if os.read(source_fd, 1):
+                raise ValueError("cartridge shard grew during verification")
+        after = os.fstat(source_fd)
+        identity_before = (
+            before.st_dev,
+            before.st_ino,
+            before.st_size,
+            before.st_mtime_ns,
+            before.st_ctime_ns,
+        )
+        identity_after = (
+            after.st_dev,
+            after.st_ino,
+            after.st_size,
+            after.st_mtime_ns,
+            after.st_ctime_ns,
+        )
+        if identity_before != identity_after:
+            raise ValueError("cartridge shard changed during verification")
+        if digest.hexdigest() != expected_sha256:
+            raise ValueError(
+                "cartridge shard sha256 does not match adapter_config.json"
+            )
+    finally:
+        os.close(source_fd)
+
+
+def _validate_adapter_manifest_shape(
+    config: dict[str, Any],
+    config_path: Path,
+) -> None:
+    fields = set(config)
+    if fields != _ADAPTER_FIELDS:
+        missing = sorted(_ADAPTER_FIELDS - fields)
+        unexpected = sorted(fields - _ADAPTER_FIELDS)
+        raise ValueError(
+            f"{config_path}: manifest fields do not match {_ADAPTER_SCHEMA}; "
+            f"missing={missing}, unexpected={unexpected}"
+        )
+    if _LABEL_RE.fullmatch(str(config.get("assembly"))) is None:
+        raise ValueError(f"{config_path}: invalid assembly label")
+    for field in ("selected_experts", "selected_layers"):
+        if not _valid_id_list(config.get(field)):
+            raise ValueError(f"{config_path}: {field} must be unique non-negative IDs")
+    if not isinstance(config.get("coverage"), dict) or not config["coverage"]:
+        raise ValueError(f"{config_path}: coverage must be a non-empty object")
+    for label, layers in config["coverage"].items():
+        if _LABEL_RE.fullmatch(str(label)) is None or not isinstance(layers, dict):
+            raise ValueError(f"{config_path}: invalid coverage entry {label!r}")
+        for layer_id, experts in layers.items():
+            if (
+                not isinstance(layer_id, str)
+                or re.fullmatch(r"[0-9]+", layer_id) is None
+                or not _valid_id_list(experts)
+            ):
+                raise ValueError(
+                    f"{config_path}: invalid coverage for {label!r}/{layer_id!r}"
+                )
+    signer = config.get("producer_verified_signer")
+    if signer is not None and _SHA256_RE.fullmatch(str(signer)) is None:
+        raise ValueError(
+            f"{config_path}: producer_verified_signer must be a SHA256 or null"
+        )
+    campaign = config.get("campaign")
+    campaign_fields = {
+        "recipe_sha256",
+        "base_model",
+        "base_revision",
+        "encoder_sha256",
+        "signer_pubkey",
+        "block_size",
+        "moe_layers",
+    }
+    if (
+        not isinstance(campaign, dict)
+        or set(campaign) != campaign_fields
+        or _SHA256_RE.fullmatch(str(campaign.get("recipe_sha256"))) is None
+        or not isinstance(campaign.get("base_model"), str)
+        or not campaign["base_model"]
+        or not isinstance(campaign.get("base_revision"), str)
+        or not campaign["base_revision"]
+        or (
+            campaign.get("encoder_sha256") is not None
+            and _SHA256_RE.fullmatch(str(campaign["encoder_sha256"])) is None
+        )
+        or _SHA256_RE.fullmatch(str(campaign.get("signer_pubkey"))) is None
+        or isinstance(campaign.get("block_size"), bool)
+        or not isinstance(campaign.get("block_size"), int)
+        or campaign["block_size"] < 1
+        or not _valid_id_list(campaign.get("moe_layers"))
+    ):
+        raise ValueError(f"{config_path}: invalid campaign provenance")
+    source = config.get("source_assembly")
+    if (
+        not isinstance(source, dict)
+        or set(source) != {"path", "sha256"}
+        or not isinstance(source.get("path"), str)
+        or not source["path"]
+        or Path(source["path"]).is_absolute()
+        or ".." in Path(source["path"]).parts
+        or _SHA256_RE.fullmatch(str(source.get("sha256"))) is None
+    ):
+        raise ValueError(f"{config_path}: invalid source_assembly identity")
+    if not isinstance(config.get("tool_version"), str) or not config["tool_version"]:
+        raise ValueError(f"{config_path}: tool_version must be a non-empty string")
+    created_utc = config.get("created_utc")
+    if not isinstance(created_utc, str):
+        raise ValueError(f"{config_path}: created_utc must be an RFC 3339 time")
+    normalized_created_utc = (
+        created_utc[:-1] + "+00:00" if created_utc.endswith("Z") else created_utc
+    )
+    try:
+        parsed_created_utc = datetime.fromisoformat(normalized_created_utc)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"{config_path}: created_utc must be an RFC 3339 time"
+        ) from exc
+    if parsed_created_utc.tzinfo is None:
+        raise ValueError(f"{config_path}: created_utc must include a timezone")
+    num_tensors = config.get("num_tensors")
+    if (
+        isinstance(num_tensors, bool)
+        or not isinstance(num_tensors, int)
+        or num_tensors < 1
+    ):
+        raise ValueError(f"{config_path}: num_tensors must be a positive integer")
+
+
+def _stage_adapter_contract(
+    adapter_path: str,
+    layer: Any,
+) -> StagedExl3Cartridge:
+    requested_input = Path(adapter_path).expanduser()
+    if requested_input.is_symlink() or not requested_input.exists():
+        raise ValueError("EXL3 cartridge path must exist and must not be a symlink")
+    if requested_input.absolute() != requested_input.resolve():
+        raise ValueError("EXL3 cartridge path must not traverse symlinks")
+    if requested_input.is_dir():
+        directory = requested_input.resolve()
+        requested: Path | None = None
+    elif requested_input.is_file():
+        requested = requested_input.resolve()
+        directory = requested.parent
+    else:
+        raise ValueError("EXL3 cartridge path must be a directory or regular file")
+    config_path = directory / "adapter_config.json"
+    try:
+        config = json.loads(
+            _read_regular_file(
+                config_path,
+                max_bytes=_MAX_MANIFEST_BYTES,
+                description="EXL3 cartridge adapter_config.json",
+            )
+        )
+    except json.JSONDecodeError as exc:
+        raise ValueError("EXL3 cartridge adapter_config.json is invalid JSON") from exc
+    if not isinstance(config, dict) or config.get("schema") != _ADAPTER_SCHEMA:
+        raise ValueError(
+            f"{config_path}: schema must be {_ADAPTER_SCHEMA!r}; "
+            "unversioned cartridge tensors are not supported"
+        )
+    _validate_adapter_manifest_shape(config, config_path)
+    if config.get("format") != "exl3-msrt-packed":
+        raise ValueError(f"{config_path}: format must be 'exl3-msrt-packed'")
+    if config.get("runtime_profile") != _RUNTIME_PROFILE:
+        raise ValueError(f"{config_path}: unsupported runtime_profile")
+    if config.get("rotation_ownership") != "base":
+        raise ValueError(f"{config_path}: rotation_ownership must be 'base'")
+    if config.get("standard_lora_compatible") is not False:
+        raise ValueError(f"{config_path}: standard_lora_compatible must be false")
+    for field, expected in (
+        ("runtime_operation", _RUNTIME_OPERATION),
+        ("codebook", "mcg"),
+        ("mcg_ownership", "adapter-config"),
+    ):
+        if config.get(field) != expected:
+            raise ValueError(f"{config_path}: {field} must be {expected!r}")
+    if config.get("mcg_multiplier") != _MCG_MULTIPLIER:
+        raise ValueError(f"{config_path}: mcg_multiplier must be {_MCG_MULTIPLIER}")
+    if config.get("scale_shape") != []:
+        raise ValueError(f"{config_path}: scale_shape must be []")
+
+    base = config.get("base")
+    expected_compatibility = getattr(
+        layer,
+        "exl3_base_compatibility_sha256",
+        None,
+    )
+    if (
+        not isinstance(base, dict)
+        or set(base) != {"label", "k", "compatibility_sha256", "compatibility_by_layer"}
+        or _LABEL_RE.fullmatch(str(base.get("label"))) is None
+        or isinstance(base.get("k"), bool)
+        or not isinstance(base.get("k"), int)
+        or base["k"] not in (2, 3, 4, 5, 6)
+        or _SHA256_RE.fullmatch(str(base.get("compatibility_sha256"))) is None
+        or not isinstance(base.get("compatibility_by_layer"), dict)
+        or set(base["compatibility_by_layer"])
+        != {str(index) for index in config["selected_layers"]}
+        or any(
+            _SHA256_RE.fullmatch(str(digest)) is None
+            for digest in base["compatibility_by_layer"].values()
+        )
+    ):
+        raise ValueError(f"{config_path}: invalid base compatibility identity")
+    if (
+        not isinstance(expected_compatibility, str)
+        or _SHA256_RE.fullmatch(expected_compatibility) is None
+        or getattr(layer, "exl3_base_compatibility_verified", False) is not True
+    ):
+        raise ValueError(
+            "Loaded EXL3 base has no verified compatibility_sha256; use a "
+            "checkpoint emitted for fq-cartridge-adapter/3"
+        )
+    if base["compatibility_sha256"] != expected_compatibility:
+        raise ValueError(
+            "EXL3 cartridge was encoded for a different base checkpoint: "
+            f"adapter={base['compatibility_sha256']}, "
+            f"loaded={expected_compatibility}"
+        )
+
+    chain = config.get("chain")
+    if not isinstance(chain, list) or not chain:
+        raise ValueError(f"{config_path}: chain must be a non-empty list")
+    parent = base.get("label")
+    labels: list[str] = []
+    for stage in chain:
+        if (
+            not isinstance(stage, dict)
+            or set(stage) != {"label", "k", "parent", "experts"}
+            or _LABEL_RE.fullmatch(str(stage.get("label"))) is None
+            or stage.get("parent") != parent
+            or isinstance(stage.get("k"), bool)
+            or not isinstance(stage.get("k"), int)
+            or stage["k"] not in (1, 2, 3, 4, 5, 6)
+        ):
+            raise ValueError(f"{config_path}: chain is not an ordered MSRT stage path")
+        experts = stage.get("experts")
+        if experts != "all" and (
+            not isinstance(experts, list)
+            or not experts
+            or any(
+                isinstance(expert, bool) or not isinstance(expert, int) or expert < 0
+                for expert in experts
+            )
+            or len(set(experts)) != len(experts)
+        ):
+            raise ValueError(
+                f"{config_path}: stage {stage.get('label')!r} has an invalid expert set"
+            )
+        label = stage["label"]
+        if label in labels:
+            raise ValueError(f"{config_path}: duplicate stage label {label!r}")
+        labels.append(label)
+        parent = label
+    if set(config["coverage"]) != set(labels):
+        raise ValueError(f"{config_path}: coverage must describe every chain stage")
+    stage_bits = {stage["label"]: stage["k"] for stage in chain}
+
+    tp = config.get("tensor_parallel")
+    tp_size = int(getattr(layer, "exl3_tp_size", 1))
+    if (
+        not isinstance(tp, dict)
+        or set(tp) != {"layout", "world_size", "ranks", "axis_by_projection"}
+        or tp.get("layout") not in {"full", "rank-sharded"}
+        or isinstance(tp.get("world_size"), bool)
+        or not isinstance(tp.get("world_size"), int)
+        or tp["world_size"] < 1
+        or tp.get("ranks") != list(range(tp["world_size"]))
+        or tp.get("axis_by_projection") != _TP_AXES
+    ):
+        raise ValueError(f"{config_path}: invalid tensor_parallel contract")
+    if tp["layout"] == "full" and (tp["world_size"], tp["ranks"]) != (1, [0]):
+        raise ValueError(f"{config_path}: full layout must contain only rank0")
+    if tp["layout"] == "rank-sharded" and tp["world_size"] != tp_size:
+        raise ValueError(
+            f"{config_path}: cartridge TP topology {tp!r} does not match "
+            f"runtime TP={tp_size}"
+        )
+
+    shard_entries = config.get("shards")
+    if not isinstance(shard_entries, list) or not shard_entries:
+        raise ValueError(f"{config_path}: shards must be a non-empty list")
+    temporary = tempfile.TemporaryDirectory(prefix="vllm-exl3-cartridge-")
+    staged = StagedExl3Cartridge(temporary)
+    try:
+        staged_root = Path(temporary.name)
+        shards: list[Path] = []
+        source_shards: list[Path] = []
+        total_size = 0
+        deadline = time.monotonic() + _STAGING_TIMEOUT_SECONDS
+        for entry in shard_entries:
+            if (
+                not isinstance(entry, dict)
+                or set(entry) != {"path", "size", "sha256"}
+                or not isinstance(entry.get("path"), str)
+                or not entry["path"]
+                or Path(entry["path"]).is_absolute()
+                or ".." in Path(entry["path"]).parts
+                or isinstance(entry.get("size"), bool)
+                or not isinstance(entry.get("size"), int)
+                or not 0 < entry["size"] <= _MAX_SHARD_BYTES
+                or _SHA256_RE.fullmatch(str(entry.get("sha256"))) is None
+            ):
+                raise ValueError(f"{config_path}: invalid shard entry {entry!r}")
+            source = directory / entry["path"]
+            if source.is_symlink():
+                raise ValueError(
+                    "manifest-listed cartridge shards must not be symlinks"
+                )
+            shard = source.resolve()
+            if source.absolute() != shard:
+                raise ValueError(
+                    "manifest-listed cartridge shard paths must not traverse symlinks"
+                )
+            if directory != shard and directory not in shard.parents:
+                raise ValueError(
+                    f"{config_path}: shard path {entry['path']!r} escapes "
+                    "the adapter directory"
+                )
+            if shard == directory:
+                raise ValueError(
+                    f"{config_path}: shard path names the adapter directory"
+                )
+            if shard in source_shards:
+                raise ValueError(f"{config_path}: duplicate shard {entry['path']!r}")
+            total_size += entry["size"]
+            if total_size > _MAX_ADAPTER_BYTES:
+                raise ValueError("EXL3 cartridge exceeds the total staging size limit")
+            destination = staged_root / f"{len(shards):06d}.safetensors"
+            _copy_verified_regular_file(
+                shard,
+                destination,
+                expected_size=entry["size"],
+                expected_sha256=entry["sha256"],
+                deadline=deadline,
+            )
+            source_shards.append(shard)
+            shards.append(destination)
+        if requested is not None and requested not in source_shards:
+            raise ValueError(f"{requested}: not listed by adjacent adapter_config.json")
+        with _SafeTensorCollection(shards) as handle:
+            keys = handle.keys()
+            by_layer = _index_cartridge_keys(keys)
+            _validate_manifest_tensor_coverage(config, by_layer)
+            if config["tensor_parallel"]["layout"] == "rank-sharded":
+                _validate_rank_scales(
+                    handle,
+                    by_layer,
+                    tuple(config["tensor_parallel"]["ranks"]),
+                )
+            if len(keys) != config["num_tensors"]:
+                raise ValueError(
+                    "MSRT cartridge tensor count does not match adapter_config.json"
+                )
+        staged.state = _AdapterState(
+            config=config,
+            stage_labels=tuple(labels),
+            stage_bits=stage_bits,
+            paths=tuple(shards),
+            by_layer=by_layer,
+            key_count=len(keys),
+        )
+    except Exception:
+        staged.close()
+        raise
+    return staged
+
+
+class _SafeTensorCollection:
+    """One duplicate-free tensor namespace spanning manifest-listed shards."""
+
+    def __init__(self, paths: list[Path]) -> None:
+        self.paths = paths
+        self.stack = ExitStack()
+        self.key_to_handle: dict[str, Any] = {}
+
+    def __enter__(self) -> _SafeTensorCollection:
+        from safetensors import safe_open
+
+        try:
+            for path in self.paths:
+                handle = self.stack.enter_context(safe_open(str(path), framework="pt"))
+                for key in tuple(handle.keys()):
+                    if key in self.key_to_handle:
+                        raise ValueError(f"Duplicate MSRT cartridge tensor {key!r}")
+                    self.key_to_handle[key] = handle
+        except Exception:
+            self.stack.close()
+            raise
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        self.stack.__exit__(exc_type, exc_value, traceback)
+
+    def keys(self) -> tuple[str, ...]:
+        return tuple(self.key_to_handle)
+
+    def get_tensor(self, key: str) -> torch.Tensor:
+        return self.key_to_handle[key].get_tensor(key)
+
+
+def _validate_rank_scales(
+    handle: _SafeTensorCollection,
+    by_layer: dict[str, list[tuple[str, re.Match[str]]]],
+    ranks: tuple[int, ...],
+) -> None:
+    if len(ranks) < 2:
+        return
+    for entries in by_layer.values():
+        signatures_by_rank: dict[int, set[tuple[str, int, str]]] = {}
+        for _, match in entries:
+            signatures_by_rank.setdefault(int(match.group("rank")), set()).add(
+                (
+                    match.group("label"),
+                    int(match.group("expert")),
+                    match.group("projection"),
+                )
+            )
+        expected_signature = signatures_by_rank.get(ranks[0], set())
+        inconsistent = [
+            rank
+            for rank in ranks
+            if signatures_by_rank.get(rank, set()) != expected_signature
+        ]
+        if inconsistent:
+            raise ValueError(
+                "MSRT cartridge TP ranks have inconsistent stage topology: "
+                f"ranks={inconsistent}"
+            )
+        grouped: dict[tuple[str, int, str], dict[int, bytes]] = {}
+        for _, match in entries:
+            scale_key = (
+                f"{match.group('layer')}.{match.group('expert')}."
+                f"{match.group('projection')}.rank{match.group('rank')}."
+                f"scale_{match.group('label')}"
+            )
+            scale = handle.get_tensor(scale_key)
+            if (
+                scale.dtype != torch.float32
+                or scale.ndim != 0
+                or not math.isfinite(float(scale.item()))
+                or float(scale.item()) <= 0
+            ):
+                raise ValueError(
+                    "rank-sharded MSRT scales must be finite positive float32 scalars"
+                )
+            signature = (
+                match.group("label"),
+                int(match.group("expert")),
+                match.group("projection"),
+            )
+            grouped.setdefault(signature, {})[int(match.group("rank"))] = (
+                scale.view(-1).view(torch.uint8).numpy().tobytes()
+            )
+        for signature, values in grouped.items():
+            if set(values) != set(ranks) or len(set(values.values())) != 1:
+                raise ValueError(
+                    f"rank-sharded MSRT scales differ across TP ranks: {signature}"
+                )
 
 
 def _build_cartridge_from_entries(
@@ -515,26 +1399,36 @@ def _build_cartridge_from_entries(
     layer: Any,
     num_experts: int,
     device: torch.device,
+    *,
+    expected_stage_labels: tuple[str, ...],
+    expected_stage_bits: dict[str, int],
+    tp_layout: str,
+    tp_ranks: tuple[int, ...],
 ) -> Exl3LoraCartridge | None:
-    """Construct one layer's cartridge from its pre-filtered trellis keys."""
+    """Construct one layer's cartridge and select this worker's TP shard."""
     if not entries:
         return None
 
-    key_set = {key for key, _ in entries} | set(handle.keys())
-    labels = sorted(
-        {match.group("label") for _, match in entries},
-        key=_stage_sort_key,
+    entries = _select_rank_entries(
+        entries,
+        layer,
+        layout=tp_layout,
+        manifest_ranks=tp_ranks,
     )
+    key_set = set(handle.keys())
+    observed_labels = {match.group("label") for _, match in entries}
+    unknown_labels = observed_labels - set(expected_stage_labels)
+    if unknown_labels:
+        raise ValueError(
+            "MSRT cartridge tensor stages are absent from adapter_config.json: "
+            f"{sorted(unknown_labels)}"
+        )
+    labels = [label for label in expected_stage_labels if label in observed_labels]
     label_to_stage = {label: index for index, label in enumerate(labels)}
     cartridge = Exl3LoraCartridge(len(labels), num_experts, device)
     shards_by_stage_expert: dict[tuple[str, int], set[str]] = {}
 
     for trellis_key, match in entries:
-        rank = int(match.group("rank"))
-        if rank != 0:
-            raise ValueError(
-                f"MSRT cartridge only supports rank0 tensors, got rank{rank}"
-            )
         expert_id = int(match.group("expert"))
         projection = match.group("projection")
         label = match.group("label")
@@ -543,25 +1437,41 @@ def _build_cartridge_from_entries(
                 f"MSRT cartridge expert {expert_id} is outside [0, {num_experts})"
             )
         shard_id = _SHARD_MAP[projection]
-        prefix = trellis_key[: -len(f"trellis_{label}")]
-        scale_key = f"{prefix}scale_{label}"
+        scale_key = (
+            f"{match.group('layer')}.{match.group('expert')}.{projection}."
+            f"rank{match.group('rank')}.scale_{label}"
+        )
         trellis = handle.get_tensor(trellis_key)
-        _validate_stage_trellis(layer, shard_id, trellis)
-        scale = 1.0
-        if scale_key in key_set:
-            scale_tensor = handle.get_tensor(scale_key)
-            if scale_tensor.numel() != 1:
-                raise ValueError(
-                    f"MSRT cartridge scale must be scalar, got "
-                    f"shape={tuple(scale_tensor.shape)}"
-                )
-            scale = float(scale_tensor.item())
+        if tp_layout == "rank-sharded":
+            _validate_stage_trellis(layer, shard_id, trellis)
+        else:
+            trellis = _slice_full_stage_trellis_for_tp(
+                layer,
+                shard_id,
+                trellis,
+            )
+        if trellis.shape[2] // 16 != expected_stage_bits[label]:
+            raise ValueError(
+                f"MSRT stage {label!r} declares K"
+                f"{expected_stage_bits[label]} but tensor {trellis_key!r} "
+                f"contains K{trellis.shape[2] // 16}"
+            )
+        if scale_key not in key_set:
+            raise ValueError(
+                f"MSRT cartridge trellis {trellis_key!r} has no scalar scale companion"
+            )
+        scale_tensor = handle.get_tensor(scale_key)
+        if scale_tensor.dtype != torch.float32 or scale_tensor.ndim != 0:
+            raise ValueError(
+                "MSRT cartridge scale must be a float32 scalar, got "
+                f"shape={tuple(scale_tensor.shape)}, dtype={scale_tensor.dtype}"
+            )
         cartridge.set_stage_tensors(
             label_to_stage[label],
             expert_id,
             shard_id,
             trellis,
-            scale,
+            float(scale_tensor.item()),
         )
         shards_by_stage_expert.setdefault((label, expert_id), set()).add(shard_id)
 
@@ -579,85 +1489,218 @@ def _build_cartridge_from_entries(
     return cartridge
 
 
-def load_cartridge_from_adapter(
+def _load_cartridge_from_staged_adapter(
+    staged: StagedExl3Cartridge,
     adapter_path: str,
     layer: Any,
     num_experts: int,
     device: torch.device,
 ) -> Exl3LoraCartridge | None:
-    """Load the stages belonging to one routed-expert layer.
-
-    Expected tensor names are
-    ``{layer}.<expert>.<projection>.rank0.{trellis,scale}_<label>``.  A
-    cartridge does not carry its own suh/svh: MSRT residuals reuse the base
-    layer's own regularized rotations.  Keys for other layers are ignored
-    rather than accidentally overwriting the same expert/shard entries.
-
-    Loading many layers from the same file: prefer opening the file once
-    and calling ``_index_cartridge_keys``/``_build_cartridge_from_entries``
-    directly (see ``prepare_exl3_cartridge_into_model``), which scans the
-    key list once instead of once per layer.
-    """
-    from safetensors import safe_open
-
-    layer_name = str(layer.layer_name)
-    with safe_open(adapter_path, framework="pt") as handle:
-        by_layer = _index_cartridge_keys(tuple(handle.keys()))
+    """Load one routed-expert layer from one already-verified adapter."""
+    if staged.state is None:
+        raise RuntimeError("EXL3 cartridge adapter has not been staged")
+    state = staged.state
+    config = state.config
+    live_layer_name = str(layer.layer_name)
+    manifest_layer_name, _ = _manifest_layer_name_for_live_layer(live_layer_name)
+    tp = config["tensor_parallel"]
+    with _SafeTensorCollection(list(state.paths)) as handle:
         cartridge = _build_cartridge_from_entries(
-            handle, by_layer.get(layer_name, []), layer, num_experts, device
+            handle,
+            state.by_layer.get(manifest_layer_name, []),
+            layer,
+            num_experts,
+            device,
+            expected_stage_labels=state.stage_labels,
+            expected_stage_bits=state.stage_bits,
+            tp_layout=tp["layout"],
+            tp_ranks=tuple(tp["ranks"]),
         )
     if cartridge is None:
         logger.warning(
             "No MSRT cartridge tensors for %s in %s",
-            layer_name,
+            live_layer_name,
             adapter_path,
         )
         return None
     logger.info(
         "Loaded %d-stage MSRT cartridge for %s from %s",
         cartridge.num_stages,
-        layer_name,
+        live_layer_name,
         adapter_path,
     )
     return cartridge
 
 
 @torch.inference_mode()
-def prepare_exl3_cartridge_into_model(model: torch.nn.Module, adapter_path: str) -> int:
-    """Load each layer into packed storage without a dense or staging peak.
-
-    Opens the cartridge file once and indexes its keys once, rather than
-    reopening the file and rescanning every key per layer.
-    """
-    from safetensors import safe_open
-
-    prepared_count = 0
+def stage_exl3_cartridge_adapter(
+    model: torch.nn.Module, adapter_path: str
+) -> StagedExl3Cartridge:
+    """Verify and privately stage one adapter without mutating model state."""
+    layers = [
+        layer
+        for layer in model.modules()
+        if isinstance(
+            getattr(layer, "_exl3_cartridge_runtime", None),
+            Exl3CUDAGraphCartridgeRuntime,
+        )
+        or bool(getattr(layer, "exl3_cartridge_capable", False))
+    ]
+    if not layers:
+        raise RuntimeError("Model is not compatible with EXL3 cartridges")
+    staged = _stage_adapter_contract(adapter_path, layers[0])
+    assert staged.state is not None
+    state = staged.state
     try:
-        with safe_open(adapter_path, framework="pt") as handle:
-            by_layer = _index_cartridge_keys(tuple(handle.keys()))
-            for layer in model.modules():
-                runtime = getattr(layer, "_exl3_cartridge_runtime", None)
-                if not isinstance(runtime, Exl3CUDAGraphCartridgeRuntime):
-                    if not bool(getattr(layer, "exl3_cartridge_capable", False)):
-                        continue
-                    runtime = prepare_exl3_cudagraph_cartridge_runtime(layer)
-                layer_name = str(layer.layer_name)
+        live_layers = []
+        for layer in layers:
+            live_layer_name = str(layer.layer_name)
+            manifest_layer_name, layer_id = _manifest_layer_name_for_live_layer(
+                live_layer_name
+            )
+            live_layers.append((layer, live_layer_name, manifest_layer_name, layer_id))
+        model_layer_names = {entry[2] for entry in live_layers}
+        selected = set(state.by_layer)
+        local_selected = selected & model_layer_names
+        if not local_selected:
+            raise ValueError(
+                "MSRT cartridge does not select any layer in this local model"
+            )
+        checkpoint_compatibility = getattr(
+            layers[0], "exl3_base_compatibility_by_layer", None
+        )
+        if not isinstance(checkpoint_compatibility, dict):
+            raise ValueError("Loaded EXL3 base has no per-layer compatibility identity")
+        for selected_layer_name in selected:
+            selected_match = _LAYER_NAME_RE.fullmatch(selected_layer_name)
+            if selected_match is None:
+                raise ValueError(
+                    f"Invalid MSRT cartridge layer name {selected_layer_name!r}"
+                )
+            layer_id = selected_match.group(1)
+            if checkpoint_compatibility.get(layer_id) != state.config["base"][
+                "compatibility_by_layer"
+            ].get(layer_id):
+                raise ValueError(
+                    "EXL3 cartridge base compatibility identity differs at "
+                    f"{selected_layer_name}"
+                )
+        staged.local_layer_names = tuple(sorted(local_selected))
+        tp = state.config["tensor_parallel"]
+        with _SafeTensorCollection(list(state.paths)) as handle:
+            for layer, live_layer_name, manifest_layer_name, layer_id in live_layers:
+                if manifest_layer_name not in local_selected:
+                    continue
+                if (
+                    getattr(layer, "exl3_base_compatibility_verified", False)
+                    is not True
+                    or getattr(layer, "exl3_base_compatibility_sha256", None)
+                    != state.config["base"]["compatibility_sha256"]
+                    or getattr(layer, "exl3_base_layer_compatibility_sha256", None)
+                    != state.config["base"]["compatibility_by_layer"].get(layer_id)
+                ):
+                    raise ValueError(
+                        "EXL3 cartridge base compatibility identity differs "
+                        f"at {live_layer_name}"
+                    )
+                layer_bitrates = tuple(
+                    int(value) for value in getattr(layer, "exl3_layer_bitrates", ())
+                )
+                if (
+                    not layer_bitrates
+                    or len(set(layer_bitrates)) != 1
+                    or layer_bitrates[0] != state.config["base"]["k"]
+                ):
+                    raise ValueError(
+                        f"EXL3 cartridge base.k does not match {live_layer_name}"
+                    )
                 cartridge = _build_cartridge_from_entries(
                     handle,
-                    by_layer.get(layer_name, []),
+                    state.by_layer[manifest_layer_name],
+                    layer,
+                    int(layer.local_num_experts),
+                    torch.device("cpu"),
+                    expected_stage_labels=state.stage_labels,
+                    expected_stage_bits=state.stage_bits,
+                    tp_layout=tp["layout"],
+                    tp_ranks=tuple(tp["ranks"]),
+                )
+                if cartridge is None:
+                    raise ValueError(f"Cartridge has no tensors for {live_layer_name}")
+                cartridge.clear()
+        return staged
+    except Exception:
+        staged.close()
+        raise
+
+
+@torch.inference_mode()
+def prepare_staged_exl3_cartridge_into_model(
+    model: torch.nn.Module, staged: StagedExl3Cartridge
+) -> int:
+    """Materialize one verified adapter during the drained transaction."""
+
+    if staged.state is None:
+        raise RuntimeError("EXL3 cartridge adapter has not been staged")
+    state = staged.state
+    config = state.config
+    layers = [
+        layer
+        for layer in model.modules()
+        if isinstance(
+            getattr(layer, "_exl3_cartridge_runtime", None),
+            Exl3CUDAGraphCartridgeRuntime,
+        )
+        or bool(getattr(layer, "exl3_cartridge_capable", False))
+    ]
+    if not layers:
+        return 0
+    selected = set(state.by_layer)
+    for layer in layers:
+        live_layer_name = str(layer.layer_name)
+        manifest_layer_name, _ = _manifest_layer_name_for_live_layer(live_layer_name)
+        runtime = getattr(layer, "_exl3_cartridge_runtime", None)
+        if (
+            isinstance(runtime, Exl3CUDAGraphCartridgeRuntime)
+            and manifest_layer_name not in selected
+        ):
+            runtime.deactivate()
+            layer.exl3_cartridge_enabled = False
+            del layer._exl3_cartridge_runtime
+    prepared_count = 0
+    try:
+        tp = config["tensor_parallel"]
+        with _SafeTensorCollection(list(state.paths)) as handle:
+            for layer in layers:
+                live_layer_name = str(layer.layer_name)
+                manifest_layer_name, _ = _manifest_layer_name_for_live_layer(
+                    live_layer_name
+                )
+                if manifest_layer_name not in state.by_layer:
+                    continue
+                runtime = getattr(layer, "_exl3_cartridge_runtime", None)
+                if not isinstance(runtime, Exl3CUDAGraphCartridgeRuntime):
+                    runtime = prepare_exl3_cudagraph_cartridge_runtime(
+                        layer, _model_workspace(model, layer)
+                    )
+                cartridge = _build_cartridge_from_entries(
+                    handle,
+                    state.by_layer[manifest_layer_name],
                     layer,
                     runtime.num_experts,
                     torch.device("cpu"),
+                    expected_stage_labels=state.stage_labels,
+                    expected_stage_bits=state.stage_bits,
+                    tp_layout=tp["layout"],
+                    tp_ranks=tuple(tp["ranks"]),
                 )
                 if cartridge is None:
-                    raise ValueError(
-                        f"Cartridge {adapter_path} has no tensors for {layer_name}"
-                    )
+                    raise ValueError(f"Cartridge has no tensors for {live_layer_name}")
                 logger.info(
                     "Loaded %d-stage MSRT cartridge for %s from %s",
                     cartridge.num_stages,
-                    layer_name,
-                    adapter_path,
+                    live_layer_name,
+                    "verified private staging",
                 )
                 runtime.deactivate()
                 cartridge.to(runtime.device)
@@ -688,7 +1731,8 @@ def activate_exl3_cartridge(model: torch.nn.Module) -> int:
 @torch.inference_mode()
 def load_exl3_cartridge_into_model(model: torch.nn.Module, adapter_path: str) -> int:
     """Prepare and activate a cartridge in a quiescent single-worker model."""
-    updated = prepare_exl3_cartridge_into_model(model, adapter_path)
+    with stage_exl3_cartridge_adapter(model, adapter_path) as staged:
+        updated = prepare_staged_exl3_cartridge_into_model(model, staged)
     if updated == 0:
         raise RuntimeError("Model has no prepared EXL3 cartridge runtime")
     activated = activate_exl3_cartridge(model)
@@ -722,6 +1766,8 @@ def deactivate_exl3_cartridge(model: torch.nn.Module) -> int:
             layer.exl3_cartridge_enabled = False
             del layer._exl3_cartridge_runtime
             updated += 1
+    if hasattr(model, "_exl3_cartridge_workspaces"):
+        del model._exl3_cartridge_workspaces
     return updated
 
 
@@ -732,8 +1778,8 @@ __all__ = [
     "apply_exl3_cudagraph_cartridge",
     "deactivate_exl3_cartridge",
     "has_exl3_cartridge",
-    "load_cartridge_from_adapter",
     "load_exl3_cartridge_into_model",
-    "prepare_exl3_cartridge_into_model",
     "prepare_exl3_cudagraph_cartridge_runtime",
+    "prepare_staged_exl3_cartridge_into_model",
+    "stage_exl3_cartridge_adapter",
 ]

--- a/vllm/model_executor/layers/quantization/exl3_lora_cartridge.py
+++ b/vllm/model_executor/layers/quantization/exl3_lora_cartridge.py
@@ -1,84 +1,80 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-"""EXL3 LoRA cartridge support for MSRT additive quantization.
+"""CUDA-graph-safe EXL3 cartridge runtime for MSRT additive quantization.
 
-This module extends EXL3 MoE quantization to support MSRT (Multi-Stage Rescaled
-Trellis) additive cartridge adapters. Unlike standard LoRA (low-rank A·B
-decomposition), MSRT cartridges contain full-rank trellis-quantized residual
-weights that are applied as additional exl3_gemm passes summed with the base
-output.
+MSRT (Multi-Stage Rescaled Trellis) cartridges contain full-rank,
+trellis-quantized residuals for the gate, up, and down expert projections.
+Applying those residuals projection-by-projection is exact but cannot be added
+after a fused MoE call: gate and up residuals must be present before SiLU.
 
-The cartridge is loaded via vLLM's LoRA hot-swap API (add_lora / remove_lora)
-and applied at runtime without model reload. Each cartridge stage adds one
-exl3_gemm pass per expert; the outputs are summed with per-stage rescaling.
+For rank-sliced EXL3, this module materializes the combined base+cartridge
+expert matrices into fixed-address GPU buffers. The normal rank-sliced kernel
+remains the inactive path. A graph-capturable dense fused-MoE call computes the
+active path, and a device scalar selects its output. Loading or removing a
+cartridge only mutates preallocated buffers and the scalar, so captured graph
+pointers and topology remain unchanged.
+
+The runtime is opt-in because dense shadow weights consume substantially more
+GPU memory and the graph-stable inactive path still launches a null-routed
+dense MoE alongside the compressed base path. This reduces steady-state
+throughput and the transient memory profiled for KV-cache sizing. Set
+``cartridge_runtime: true`` in the EXL3 quantization configuration before
+engine construction so the buffers exist before CUDA graph capture.
+Use ``llm_engine.load_exl3_cartridge(path)`` and
+``llm_engine.deactivate_exl3_cartridge()``; both dispatch through the worker
+control plane to every model worker.
+
+The initial implementation supports tensor parallel size one and one
+model-wide slot; per-request cartridge selection is intentionally not claimed.
 """
 
 from __future__ import annotations
 
 import logging
+import math
+import re
 from typing import Any
 
 import torch
 
-from vllm.model_executor.layers.quantization.exl3 import (
-    Exl3Config,
-    Exl3MoEMethod,
-    _exl3_gemm,
-)
-from vllm.model_executor.layers.fused_moe import FusedMoEMethodBase
+from vllm.model_executor.layers.fused_moe.fused_moe import fused_experts
+from vllm.model_executor.layers.quantization.exl3 import Exl3MoEMethod, _exl3_gemm
 
 logger = logging.getLogger(__name__)
 
-
-def exl3_get_supported_lora_modules() -> list[str]:
-    """Return the module names that support EXL3 LoRA cartridges.
-
-    EXL3 quantizes MoE expert projections (gate_proj, up_proj, down_proj).
-    These are the modules that can receive additive cartridge corrections.
-    """
-    return ["gate_proj", "up_proj", "down_proj"]
-
-
-def exl3_lora_can_replace_layer(
-    source_layer: Any,
-    lora_config: Any,
-    packed_modules_list: list[str],
-    model_config: Any,
-) -> bool:
-    """Check if a layer can be replaced with an EXL3 LoRA-wrapped version.
-
-    This replaces the standard FusedMoEWithLoRA check for EXL3 layers.
-    Returns True when the source layer uses EXL3 MoE quantization.
-    """
-    # EXL3 LoRA works with the monolithic per-expert path, not the modular kernel
-    # path. We check if the layer's quant method is Exl3MoEMethod.
-    quant_method = getattr(getattr(source_layer, "routed_experts", source_layer),
-                          "quant_method", None)
-    if isinstance(quant_method, Exl3MoEMethod):
-        return True
-    return False
+_CARTRIDGE_KEY_RE = re.compile(
+    r"^(?P<layer>.+\.experts)\."
+    r"(?P<expert>\d+)\."
+    r"(?P<projection>gate_proj|up_proj|down_proj)\."
+    r"rank(?P<rank>\d+)\.trellis_(?P<label>.+)$"
+)
+_CARTRIDGE_COMPANION_KEY_RE = re.compile(
+    r"^(?P<layer>.+\.experts)\."
+    r"(?P<expert>\d+)\."
+    r"(?P<projection>gate_proj|up_proj|down_proj)\."
+    r"rank(?P<rank>\d+)\.(?:suh|svh|scale|mcg|mul1)_(?P<label>.+)$"
+)
+_SHARD_MAP = {"gate_proj": "w1", "up_proj": "w3", "down_proj": "w2"}
 
 
 class Exl3LoraCartridge:
-    """Holds MSRT cartridge tensors for one MoE layer.
+    """MSRT residual tensors for one routed-expert layer.
 
-    Each cartridge stage contains:
-    - trellis: int16 packed trellis indices (k//16, n//16, K*16)
-    - suh: float16 row-side Hadamard scales
-    - svh: float16 column-side Hadamard scales
-    - scale: float32 rescaling factor (codebook_scale / RMS(residual))
-
-    The cartridge is applied as:
-      output += (1/scale) * exl3_gemm(x, trellis, suh, svh, mcg=True)
+    Each stage is keyed by ``(expert_id, shard_id)`` and stores packed trellis
+    indices, input/output Hadamard vectors, and the positive rescaling factor
+    used by the MCG-only rank-sliced encoder.
     """
 
     def __init__(self, num_stages: int, num_experts: int, device: torch.device):
+        if num_stages < 1:
+            raise ValueError(f"num_stages must be positive, got {num_stages}")
+        if num_experts < 1:
+            raise ValueError(f"num_experts must be positive, got {num_experts}")
         self.num_stages = num_stages
         self.num_experts = num_experts
         self.device = device
-        # Per-stage storage: list of dicts keyed by (expert_id, shard_id)
-        self.stages: list[dict[tuple[int, str], dict[str, torch.Tensor]]] = [
+        self.stages: list[dict[tuple[int, str], dict[str, torch.Tensor | float]]] = [
             {} for _ in range(num_stages)
         ]
         self.active = False
@@ -93,24 +89,173 @@ class Exl3LoraCartridge:
         svh: torch.Tensor,
         scale: float,
     ) -> None:
-        """Set cartridge tensors for one expert's projection at one stage."""
+        """Set one stage of one expert projection."""
+        if not 0 <= stage_idx < self.num_stages:
+            raise IndexError(f"stage index {stage_idx} is out of range")
+        if not 0 <= expert_id < self.num_experts:
+            raise IndexError(f"expert index {expert_id} is out of range")
+        if shard_id not in {"w1", "w2", "w3"}:
+            raise ValueError(f"unsupported EXL3 shard {shard_id!r}")
+        if not math.isfinite(scale) or scale <= 0:
+            raise ValueError(
+                f"cartridge scale must be finite and positive, got {scale}"
+            )
         self.stages[stage_idx][(expert_id, shard_id)] = {
-            "trellis": trellis.to(self.device),
-            "suh": suh.to(self.device),
-            "svh": svh.to(self.device),
-            "scale": scale,
+            "trellis": trellis.to(self.device).contiguous(),
+            "suh": suh.to(self.device).contiguous(),
+            "svh": svh.to(self.device).contiguous(),
+            "scale": float(scale),
         }
 
     def get_stage_tensors(
         self, stage_idx: int, expert_id: int, shard_id: str
-    ) -> dict[str, torch.Tensor] | None:
-        """Get cartridge tensors for one expert's projection at one stage."""
+    ) -> dict[str, torch.Tensor | float] | None:
+        """Return one stage of one expert projection, if present."""
         return self.stages[stage_idx].get((expert_id, shard_id))
 
+    def to(self, device: torch.device) -> None:
+        """Move source tensors to one device without changing stage metadata."""
+        for stage in self.stages:
+            for tensors in stage.values():
+                for name in ("trellis", "suh", "svh"):
+                    tensor = tensors[name]
+                    assert isinstance(tensor, torch.Tensor)
+                    tensors[name] = tensor.to(device).contiguous()
+        self.device = device
+
     def clear(self) -> None:
-        """Remove all cartridge tensors."""
+        """Release source cartridge tensors."""
         self.stages = [{} for _ in range(self.num_stages)]
         self.active = False
+
+
+class Exl3CUDAGraphCartridgeRuntime:
+    """Fixed-address dense shadow weights used by captured CUDA graphs.
+
+    There is one runtime per routed-expert layer. ``w13`` and ``w2`` are
+    allocated before graph capture and never rebound. ``active`` is a scalar on
+    the same device; changing it does not alter Python control flow or graph
+    topology.
+    """
+
+    def __init__(self, layer: Any):
+        tp_size = int(getattr(layer, "exl3_tp_size", 1))
+        if tp_size != 1:
+            raise NotImplementedError(
+                "EXL3 cartridge runtime currently requires tensor_parallel_size=1"
+            )
+        num_experts = int(layer.local_num_experts)
+        hidden_size = int(layer.exl3_hidden_size)
+        intermediate_size = int(layer.exl3_intermediate_size_per_partition)
+        dtype = torch.float16
+        device = layer.w13_trellis.device
+
+        self.w13 = torch.zeros(
+            (num_experts, 2 * intermediate_size, hidden_size),
+            dtype=dtype,
+            device=device,
+        )
+        self.w2 = torch.zeros(
+            (num_experts, hidden_size, intermediate_size),
+            dtype=dtype,
+            device=device,
+        )
+        self.active = torch.zeros((), dtype=torch.bool, device=device)
+        self.num_experts = num_experts
+        self.hidden_size = hidden_size
+        self.intermediate_size = intermediate_size
+        self.dtype = dtype
+        self.device = device
+        self._materialized = False
+
+    def deactivate(self) -> None:
+        """Select the rank-sliced base path without changing graph pointers."""
+        self.active.zero_()
+
+    def activate(self) -> None:
+        """Select the fully materialized dense cartridge path."""
+        if not self._materialized:
+            raise RuntimeError("cannot activate an unmaterialized EXL3 cartridge")
+        self.active.fill_(True)
+
+    @torch.inference_mode()
+    def materialize(self, layer: Any, cartridge: Exl3LoraCartridge) -> None:
+        """Decode exact base+cartridge matrices into the shadow buffers.
+
+        Identity activations turn each EXL3 GEMM into a matrix materialization.
+        Base and residual outputs are summed before transposition, preserving
+        the exact projection-level MSRT semantics across the SiLU boundary.
+        """
+        if cartridge.num_experts != self.num_experts:
+            raise ValueError(
+                "cartridge expert count does not match runtime: "
+                f"{cartridge.num_experts} != {self.num_experts}"
+            )
+        if not cartridge.active:
+            raise ValueError("cannot materialize an inactive cartridge")
+
+        self._materialized = False
+        self.deactivate()
+        hidden_identity = torch.eye(
+            self.hidden_size, dtype=torch.float16, device=self.device
+        )
+        intermediate_identity = torch.eye(
+            self.intermediate_size, dtype=torch.float16, device=self.device
+        )
+
+        for expert_id in range(self.num_experts):
+            for shard_id, offset in (("w1", 0), ("w3", self.intermediate_size)):
+                base = Exl3MoEMethod._apply_expert(
+                    layer, "w13", hidden_identity, expert_id, shard_id
+                )
+                combined = apply_exl3_cartridge(
+                    base,
+                    hidden_identity,
+                    layer,
+                    "w13",
+                    expert_id,
+                    shard_id,
+                    cartridge,
+                )
+                self.w13[expert_id, offset : offset + self.intermediate_size].copy_(
+                    combined.T.to(self.dtype)
+                )
+
+            base = Exl3MoEMethod._apply_expert(
+                layer, "w2", intermediate_identity, expert_id, "w2"
+            )
+            combined = apply_exl3_cartridge(
+                base,
+                intermediate_identity,
+                layer,
+                "w2",
+                expert_id,
+                "w2",
+                cartridge,
+            )
+            self.w2[expert_id].copy_(combined.T.to(self.dtype))
+
+        for weights in (self.w13, self.w2):
+            minimum, maximum = torch.aminmax(weights)
+            if not torch.isfinite(minimum).item() or not torch.isfinite(maximum).item():
+                raise ValueError(
+                    "materialized EXL3 cartridge contains non-finite weights"
+                )
+        self._materialized = True
+
+        # Activation is a separate model-wide commit step. Keeping this runtime
+        # inactive until every layer materializes prevents mixed-model states.
+
+
+def prepare_exl3_cudagraph_cartridge_runtime(
+    layer: Any,
+) -> Exl3CUDAGraphCartridgeRuntime:
+    """Allocate a layer's fixed-address cartridge buffers before capture."""
+    runtime = getattr(layer, "_exl3_cartridge_runtime", None)
+    if runtime is None:
+        runtime = Exl3CUDAGraphCartridgeRuntime(layer)
+        layer._exl3_cartridge_runtime = runtime
+    return runtime
 
 
 def apply_exl3_cartridge(
@@ -122,26 +267,12 @@ def apply_exl3_cartridge(
     shard_id: str,
     cartridge: Exl3LoraCartridge | None,
 ) -> torch.Tensor:
-    """Apply MSRT cartridge correction to a base EXL3 GEMM output.
-
-    Args:
-        base_output: Output from the base EXL3 GEMM (K2 or K3 tier)
-        x: Input activations (float16, padded to packed_k)
-        layer: The RoutedExperts layer (for accessing trellis tensors)
-        group: Weight group ("w13" or "w2")
-        expert_id: Expert index
-        shard_id: Projection shard ("w1", "w3", or "w2")
-        cartridge: The cartridge to apply, or None
-
-    Returns:
-        Corrected output: base_output + sum of cartridge stage corrections
-    """
+    """Add every residual stage to one projection output."""
+    del layer, group
     if cartridge is None or not cartridge.active:
         return base_output
 
-    key = (expert_id, shard_id)
-    output = base_output
-
+    output = base_output.float()
     for stage_idx in range(cartridge.num_stages):
         stage_tensors = cartridge.get_stage_tensors(stage_idx, expert_id, shard_id)
         if stage_tensors is None:
@@ -151,48 +282,125 @@ def apply_exl3_cartridge(
         suh = stage_tensors["suh"]
         svh = stage_tensors["svh"]
         scale = stage_tensors["scale"]
+        assert isinstance(trellis, torch.Tensor)
+        assert isinstance(suh, torch.Tensor)
+        assert isinstance(svh, torch.Tensor)
+        assert isinstance(scale, float)
 
-        # Run additional EXL3 GEMM for this cartridge stage
-        cartridge_output = _exl3_gemm(x, trellis, suh, svh, True, False)
-        # Sum with rescaling: output += cartridge_output / scale
-        output = output + cartridge_output * (1.0 / scale)
-
-    return output
-
-
-# Patch Exl3MoEMethod._apply_expert to support cartridges
-_original_apply_expert = Exl3MoEMethod._apply_expert
-
-
-@staticmethod
-def _apply_expert_with_cartridge(
-    layer: Any,
-    group: str,
-    x: torch.Tensor,
-    expert_id: int,
-    shard_id: str,
-) -> torch.Tensor:
-    """Extended _apply_expert that applies MSRT cartridge after base GEMM."""
-    # Run the original base EXL3 GEMM
-    output = _original_apply_expert(layer, group, x, expert_id, shard_id)
-
-    # Apply cartridge if present
-    cartridge = getattr(layer, "_exl3_cartridge", None)
-    if cartridge is not None and cartridge.active:
-        key = (expert_id, shard_id)
-        trellis = getattr(layer, f"{group}_trellis").exl3_tensors[key]
         packed_k = trellis.shape[0] * 16
-        x_padded = x
+        if x.shape[-1] > packed_k:
+            raise ValueError(
+                f"MSRT cartridge input width {x.shape[-1]} exceeds packed K={packed_k}"
+            )
+        padded_x = x
         if x.shape[-1] < packed_k:
-            x_padded = torch.nn.functional.pad(x, (0, packed_k - x.shape[-1]))
-        output = apply_exl3_cartridge(
-            output, x_padded, layer, group, expert_id, shard_id, cartridge)
+            padded_x = torch.nn.functional.pad(x, (0, packed_k - x.shape[-1]))
+        # Rank-sliced EXL3 metadata and the fq-cartridge/1 producer both
+        # require MCG; cartridge files do not override the base codebook.
+        correction = _exl3_gemm(padded_x, trellis, suh, svh, True, False)
+        logical_n = base_output.shape[-1]
+        if correction.shape[-1] < logical_n:
+            raise ValueError(
+                "MSRT cartridge packed output width "
+                f"{correction.shape[-1]} is below logical N={logical_n}"
+            )
+        output = output + correction[..., :logical_n].float() * (1.0 / scale)
 
     return output
 
 
-# Install the patched method
-Exl3MoEMethod._apply_expert = _apply_expert_with_cartridge
+def apply_exl3_cudagraph_cartridge(
+    base_output: torch.Tensor,
+    x: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    layer: Any,
+) -> torch.Tensor:
+    """Run and device-select the graph-stable dense cartridge path.
+
+    Both paths and the device-side selection are present during capture, while
+    the scalar controls which result becomes visible at replay time.
+    """
+    runtime = getattr(layer, "_exl3_cartridge_runtime", None)
+    if not isinstance(runtime, Exl3CUDAGraphCartridgeRuntime):
+        raise RuntimeError(
+            "EXL3 cartridge runtime was not prepared before CUDA graph capture"
+        )
+
+    # Preserve graph topology while inactive, but collapse dense routing to one
+    # expert so the discarded shadow path reads one expert's weights, not every
+    # routed expert's weights.
+    dense_topk_ids = topk_ids * runtime.active
+    dense_output = fused_experts(
+        x.to(runtime.dtype),
+        runtime.w13,
+        runtime.w2,
+        topk_weights,
+        dense_topk_ids,
+        activation=layer.activation,
+        apply_router_weight_on_input=False,
+        global_num_experts=runtime.num_experts,
+    ).to(base_output.dtype)
+    return torch.where(runtime.active, dense_output, base_output)
+
+
+def _stage_sort_key(label: str) -> tuple[str, int]:
+    prefix, separator, suffix = label.rpartition("_")
+    if separator and suffix.isdigit():
+        return prefix, int(suffix)
+    match = re.match(r"^(.*?)(\d+)$", label)
+    if match is not None:
+        return match.group(1), int(match.group(2))
+    return label, -1
+
+
+def _validate_stage_tensors(
+    layer: Any,
+    shard_id: str,
+    trellis: torch.Tensor,
+    suh: torch.Tensor,
+    svh: torch.Tensor,
+) -> None:
+    hidden_size = int(layer.exl3_hidden_size)
+    intermediate_size = int(layer.exl3_intermediate_size_per_partition)
+    input_size, output_size = (
+        (intermediate_size, hidden_size)
+        if shard_id == "w2"
+        else (hidden_size, intermediate_size)
+    )
+    shape_valid = trellis.ndim == 3
+    packed_k = trellis.shape[0] * 16 if shape_valid else 0
+    packed_n = trellis.shape[1] * 16 if shape_valid else 0
+    expected_packed_k = ((input_size + 127) // 128) * 128
+    expected_packed_n = ((output_size + 127) // 128) * 128
+    if (
+        trellis.dtype != torch.int16
+        or not shape_valid
+        or packed_k != expected_packed_k
+        or packed_n != expected_packed_n
+        or trellis.shape[2] % 16
+        or trellis.shape[2] // 16 not in (1, 2, 3, 4, 5, 6)
+    ):
+        raise ValueError(
+            "Invalid MSRT cartridge trellis: "
+            f"shape={tuple(trellis.shape)}, dtype={trellis.dtype}; "
+            f"packed K/N must equal the 128-aligned logical shape "
+            f"({expected_packed_k}, {expected_packed_n}) for "
+            f"K={input_size}, N={output_size}; use K in "
+            "{1,2,3,4,5,6} and dtype=torch.int16"
+        )
+    for name, tensor, expected_size in (
+        ("suh", suh, packed_k),
+        ("svh", svh, packed_n),
+    ):
+        if tensor.dtype != torch.float16 or tensor.shape != (expected_size,):
+            raise ValueError(
+                f"Invalid MSRT cartridge {name}: shape={tuple(tensor.shape)}, "
+                f"dtype={tensor.dtype}, expected=({expected_size},), "
+                "dtype=torch.float16"
+            )
+        if not torch.isfinite(tensor).all().item():
+            raise ValueError(f"MSRT cartridge {name} contains non-finite values")
 
 
 def load_cartridge_from_adapter(
@@ -201,70 +409,209 @@ def load_cartridge_from_adapter(
     num_experts: int,
     device: torch.device,
 ) -> Exl3LoraCartridge | None:
-    """Load an MSRT cartridge adapter from a safetensors file.
+    """Load the stages belonging to one routed-expert layer.
 
-    The adapter contains tensors named:
-      model.layers.{L}.mlp.experts.{E}.{proj}.rank0.trellis_{label}
-      model.layers.{L}.mlp.experts.{E}.{proj}.rank0.suh_{label}
-      model.layers.{L}.mlp.experts.{E}.{proj}.rank0.svh_{label}
-      model.layers.{L}.mlp.experts.{E}.{proj}.rank0.scale_{label}
-
-    Returns an Exl3LoraCartridge loaded onto the device.
+    Expected tensor names are
+    ``{layer}.<expert>.<projection>.rank0.{trellis,suh,svh,scale}_<label>``.
+    Keys for other layers are ignored rather than accidentally overwriting the
+    same expert/shard entries.
     """
     from safetensors import safe_open
 
-    # Detect number of stages from tensor names
-    stage_labels = set()
-    with safe_open(adapter_path, framework="pt") as f:
-        keys = list(f.keys())
+    layer_name = str(layer.layer_name)
+    entries: list[tuple[str, re.Match[str]]] = []
+    with safe_open(adapter_path, framework="pt") as handle:
+        keys = tuple(handle.keys())
+        key_set = set(keys)
         for key in keys:
-            if ".trellis_" in key:
-                label = key.split(".trellis_")[-1]
-                stage_labels.add(label)
+            match = _CARTRIDGE_KEY_RE.match(key)
+            if match is not None and match.group("layer") == layer_name:
+                entries.append((key, match))
+                continue
+            companion = _CARTRIDGE_COMPANION_KEY_RE.match(key)
+            if key.startswith(f"{layer_name}.") and (
+                companion is None or companion.group("layer") != layer_name
+            ):
+                raise ValueError(f"Malformed MSRT cartridge key {key!r}")
 
-    if not stage_labels:
-        logger.warning("No MSRT cartridge stages found in %s", adapter_path)
-        return None
+        if not entries:
+            logger.warning(
+                "No MSRT cartridge tensors for %s in %s",
+                layer_name,
+                adapter_path,
+            )
+            return None
 
-    # Sort labels to maintain stage order
-    sorted_labels = sorted(stage_labels)
-    num_stages = len(sorted_labels)
-    cartridge = Exl3LoraCartridge(num_stages, num_experts, device)
+        labels = sorted(
+            {match.group("label") for _, match in entries},
+            key=_stage_sort_key,
+        )
+        label_to_stage = {label: index for index, label in enumerate(labels)}
+        cartridge = Exl3LoraCartridge(len(labels), num_experts, device)
+        shards_by_stage_expert: dict[tuple[str, int], set[str]] = {}
 
-    shard_map = {"gate_proj": "w1", "up_proj": "w3", "down_proj": "w2"}
+        for trellis_key, match in entries:
+            rank = int(match.group("rank"))
+            if rank != 0:
+                raise ValueError(
+                    f"MSRT cartridge only supports rank0 tensors, got rank{rank}"
+                )
+            expert_id = int(match.group("expert"))
+            projection = match.group("projection")
+            label = match.group("label")
+            if not 0 <= expert_id < num_experts:
+                raise ValueError(
+                    f"MSRT cartridge expert {expert_id} is outside [0, {num_experts})"
+                )
+            shard_id = _SHARD_MAP[projection]
+            prefix = trellis_key[: -len(f"trellis_{label}")]
+            companion_keys = {
+                "suh": f"{prefix}suh_{label}",
+                "svh": f"{prefix}svh_{label}",
+                "scale": f"{prefix}scale_{label}",
+            }
+            missing = [
+                key_name
+                for key_name in (companion_keys["suh"], companion_keys["svh"])
+                if key_name not in key_set
+            ]
+            if missing:
+                raise ValueError(
+                    f"Incomplete MSRT cartridge entry {trellis_key}: missing {missing}"
+                )
+            trellis = handle.get_tensor(trellis_key)
+            suh = handle.get_tensor(companion_keys["suh"])
+            svh = handle.get_tensor(companion_keys["svh"])
+            _validate_stage_tensors(layer, shard_id, trellis, suh, svh)
+            scale = 1.0
+            if companion_keys["scale"] in key_set:
+                scale_tensor = handle.get_tensor(companion_keys["scale"])
+                if scale_tensor.numel() != 1:
+                    raise ValueError(
+                        f"MSRT cartridge scale must be scalar, got "
+                        f"shape={tuple(scale_tensor.shape)}"
+                    )
+                scale = float(scale_tensor.item())
+            cartridge.set_stage_tensors(
+                label_to_stage[label],
+                expert_id,
+                shard_id,
+                trellis,
+                suh,
+                svh,
+                scale,
+            )
+            shards_by_stage_expert.setdefault((label, expert_id), set()).add(shard_id)
 
-    with safe_open(adapter_path, framework="pt") as f:
-        for stage_idx, label in enumerate(sorted_labels):
-            for key in keys:
-                if f".trellis_{label}" not in key:
-                    continue
-                # Parse: model.layers.{L}.mlp.experts.{E}.{proj}.rank{R}.trellis_{label}
-                parts = key.split(".")
-                # Find expert ID and projection
-                expert_id = int(parts[5])
-                proj = parts[6]
-                rank = int(parts[7].replace("rank", ""))
-                shard_id = shard_map.get(proj, proj)
-
-                prefix = ".".join(parts[:-1])  # without .trellis_{label}
-                trellis_key = f"{prefix}.trellis_{label}"
-                suh_key = f"{prefix}.suh_{label}"
-                svh_key = f"{prefix}.svh_{label}"
-                scale_key = f"{prefix}.scale_{label}"
-
-                if trellis_key in f.keys() and suh_key in f.keys():
-                    trellis = f.get_tensor(trellis_key)
-                    suh = f.get_tensor(suh_key)
-                    svh = f.get_tensor(svh_key) if svh_key in f.keys() else suh
-                    scale_val = 1.0
-                    if scale_key in f.keys():
-                        scale_val = float(f.get_tensor(scale_key).item())
-
-                    cartridge.set_stage_tensors(
-                        stage_idx, expert_id, shard_id,
-                        trellis, suh, svh, scale_val)
-
+        required_shards = {"w1", "w2", "w3"}
+        incomplete = {
+            key: sorted(required_shards - shards)
+            for key, shards in shards_by_stage_expert.items()
+            if shards != required_shards
+        }
+        if incomplete:
+            raise ValueError(
+                f"Incomplete MSRT cartridge expert stages; missing shards: {incomplete}"
+            )
     cartridge.active = True
-    logger.info("Loaded MSRT cartridge: %d stages, %d experts from %s",
-                num_stages, num_experts, adapter_path)
+    logger.info(
+        "Loaded %d-stage MSRT cartridge for %s from %s",
+        cartridge.num_stages,
+        layer_name,
+        adapter_path,
+    )
     return cartridge
+
+
+@torch.inference_mode()
+def prepare_exl3_cartridge_into_model(model: torch.nn.Module, adapter_path: str) -> int:
+    """Materialize a cartridge into every layer without activating it."""
+    prepared: list[tuple[Any, Exl3CUDAGraphCartridgeRuntime, Exl3LoraCartridge]] = []
+    for layer in model.modules():
+        runtime = getattr(layer, "_exl3_cartridge_runtime", None)
+        if not isinstance(runtime, Exl3CUDAGraphCartridgeRuntime):
+            continue
+        cartridge = load_cartridge_from_adapter(
+            adapter_path,
+            layer,
+            runtime.num_experts,
+            torch.device("cpu"),
+        )
+        if cartridge is None:
+            raise ValueError(
+                f"Cartridge {adapter_path} has no tensors for {layer.layer_name}"
+            )
+        prepared.append((layer, runtime, cartridge))
+    if not prepared:
+        return 0
+
+    prepared_count = len(prepared)
+    for _, runtime, _ in prepared:
+        runtime.deactivate()
+    try:
+        for layer, runtime, cartridge in prepared:
+            cartridge.to(runtime.device)
+            try:
+                runtime.materialize(layer, cartridge)
+            finally:
+                cartridge.clear()
+    except Exception:
+        for _, runtime, _ in prepared:
+            runtime.deactivate()
+        raise
+    finally:
+        prepared.clear()
+    return prepared_count
+
+
+@torch.inference_mode()
+def activate_exl3_cartridge(model: torch.nn.Module) -> int:
+    """Activate the fully prepared cartridge on every local layer."""
+    updated = 0
+    for layer in model.modules():
+        runtime = getattr(layer, "_exl3_cartridge_runtime", None)
+        if isinstance(runtime, Exl3CUDAGraphCartridgeRuntime):
+            runtime.activate()
+            updated += 1
+    return updated
+
+
+@torch.inference_mode()
+def load_exl3_cartridge_into_model(model: torch.nn.Module, adapter_path: str) -> int:
+    """Prepare and activate a cartridge in a quiescent single-worker model."""
+    updated = prepare_exl3_cartridge_into_model(model, adapter_path)
+    if updated == 0:
+        raise RuntimeError("Model has no prepared EXL3 cartridge runtime")
+    activated = activate_exl3_cartridge(model)
+    if activated != updated:
+        deactivate_exl3_cartridge(model)
+        raise RuntimeError(
+            f"Prepared {updated} EXL3 cartridge layers but activated {activated}"
+        )
+    return updated
+
+
+@torch.inference_mode()
+def deactivate_exl3_cartridge(model: torch.nn.Module) -> int:
+    """Select the rank-sliced base path in every prepared layer."""
+    updated = 0
+    for layer in model.modules():
+        runtime = getattr(layer, "_exl3_cartridge_runtime", None)
+        if isinstance(runtime, Exl3CUDAGraphCartridgeRuntime):
+            runtime.deactivate()
+            updated += 1
+    return updated
+
+
+__all__ = [
+    "Exl3CUDAGraphCartridgeRuntime",
+    "Exl3LoraCartridge",
+    "activate_exl3_cartridge",
+    "apply_exl3_cartridge",
+    "apply_exl3_cudagraph_cartridge",
+    "deactivate_exl3_cartridge",
+    "load_cartridge_from_adapter",
+    "load_exl3_cartridge_into_model",
+    "prepare_exl3_cartridge_into_model",
+    "prepare_exl3_cudagraph_cartridge_runtime",
+]

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -4,6 +4,7 @@ import asyncio
 import os
 import socket
 import time
+import uuid
 import warnings
 from collections.abc import AsyncGenerator, Iterable, Mapping
 from copy import copy
@@ -53,6 +54,27 @@ from vllm.v1.metrics.prometheus import shutdown_prometheus
 from vllm.v1.metrics.stats import IterationStats
 
 logger = init_logger(__name__)
+
+
+def _uniform_positive_worker_counts(counts: object) -> bool:
+    return (
+        isinstance(counts, list)
+        and bool(counts)
+        and all(type(count) is int and count > 0 for count in counts)
+        and len(set(counts)) == 1
+    )
+
+
+async def _finish_shielded(coro):
+    """Finish critical cleanup before propagating task cancellation."""
+    task = asyncio.create_task(coro)
+    try:
+        return await asyncio.shield(task)
+    except asyncio.CancelledError:
+        try:
+            await task
+        finally:
+            raise
 
 
 class InputStreamError(Exception):
@@ -110,7 +132,10 @@ class AsyncLLM(EngineClient):
         self.vllm_config = vllm_config
         self.model_config = vllm_config.model_config
         self.observability_config = vllm_config.observability_config
-        self._exl3_cartridge_lock = asyncio.Lock()
+        # Serialize all scheduler pause/resume controls with cartridge graph
+        # transitions. A concurrent public resume must never reopen request
+        # admission while fixed-address cartridge buffers are being replaced.
+        self._engine_mutation_lock = asyncio.Lock()
 
         tracing_endpoint = self.observability_config.otlp_traces_endpoint
         if tracing_endpoint is not None:
@@ -773,6 +798,20 @@ class AsyncLLM(EngineClient):
             clear_cache: Whether to clear KV cache and prefix cache after
                 draining. Set to ``False`` to preserve cache for faster resume.
         """
+        async with self._engine_mutation_lock:
+            await self._pause_generation(
+                mode=mode,
+                wait_for_inflight_requests=wait_for_inflight_requests,
+                clear_cache=clear_cache,
+            )
+
+    async def _pause_generation(
+        self,
+        *,
+        mode: PauseMode = "abort",
+        wait_for_inflight_requests: bool | None = None,
+        clear_cache: bool = True,
+    ) -> None:
         if wait_for_inflight_requests:
             warnings.warn(
                 "The `wait_for_inflight_requests` parameter in "
@@ -795,6 +834,10 @@ class AsyncLLM(EngineClient):
 
     async def resume_generation(self) -> None:
         """Resume generation after :meth:`pause_generation`."""
+        async with self._engine_mutation_lock:
+            await self._resume_generation()
+
+    async def _resume_generation(self) -> None:
         await self.engine_core.resume_scheduler_async()
 
     async def is_paused(self) -> bool:
@@ -984,22 +1027,40 @@ class AsyncLLM(EngineClient):
 
     async def load_exl3_cartridge(self, adapter_path: str) -> list[int]:
         """Serialize cartridge load; failures restore the compressed base."""
-        async with self._exl3_cartridge_lock:
+        async with self._engine_mutation_lock:
             return await self._load_exl3_cartridge(adapter_path)
 
     async def _load_exl3_cartridge(self, adapter_path: str) -> list[int]:
         """Quiesce serving, switch model topology, and recapture graphs."""
-        resume_needed = not await self.is_paused()
+        stage_id = uuid.uuid4().hex
+        resume_needed = False
+        primary_error: BaseException | None = None
         try:
-            await self.pause_generation(mode="wait", clear_cache=True)
+            staged = await self.collective_rpc(
+                "stage_exl3_cartridge",
+                timeout=16 * 60,
+                args=(adapter_path, stage_id),
+            )
+            if not _uniform_positive_worker_counts(staged):
+                raise RuntimeError(
+                    "EXL3 cartridge staging returned inconsistent worker counts: "
+                    f"{staged}"
+                )
+            resume_needed = not await self.is_paused()
+            await self._pause_generation(mode="wait", clear_cache=True)
             try:
                 await self.collective_rpc("clear_exl3_cartridge_cudagraphs")
                 prepared = await self.collective_rpc(
-                    "prepare_exl3_cartridge",
-                    args=(adapter_path,),
+                    "prepare_staged_exl3_cartridge",
+                    args=(stage_id,),
                 )
                 activated = await self.collective_rpc("activate_exl3_cartridge")
-                if activated != prepared or sum(prepared) == 0:
+                if (
+                    not _uniform_positive_worker_counts(prepared)
+                    or not _uniform_positive_worker_counts(activated)
+                    or prepared != staged
+                    or activated != prepared
+                ):
                     raise RuntimeError(
                         f"EXL3 cartridge prepare/activate mismatch: "
                         f"{prepared} != {activated}"
@@ -1022,17 +1083,70 @@ class AsyncLLM(EngineClient):
                     self.shutdown()
                     raise EngineDeadError() from restore_error
                 raise
+        except asyncio.CancelledError as error:
+            primary_error = error
+            raise
+        except Exception as error:  # noqa: BLE001 - cleanup must still run
+            primary_error = error
+            raise
         finally:
+            cleanup_error: Exception | None = None
+            cancellation_error: asyncio.CancelledError | None = None
+            try:
+                await _finish_shielded(
+                    self.collective_rpc(
+                        "discard_staged_exl3_cartridge", args=(stage_id,)
+                    )
+                )
+            except asyncio.CancelledError as error:
+                cancellation_error = error
+            except Exception as error:  # noqa: BLE001 - resume still must run
+                cleanup_error = error
             if resume_needed:
-                resume = asyncio.create_task(self.resume_generation())
                 try:
-                    await asyncio.shield(resume)
-                except asyncio.CancelledError:
-                    await resume
+                    await _finish_shielded(self._resume_generation())
+                except asyncio.CancelledError as error:
+                    if cancellation_error is None:
+                        cancellation_error = error
+                except Exception as error:  # noqa: BLE001 - aggregate cleanup
+                    if cleanup_error is None:
+                        cleanup_error = error
+                    else:
+                        logger.error(
+                            "EXL3 cartridge resume failed after staging cleanup "
+                            "also failed",
+                            exc_info=(type(error), error, error.__traceback__),
+                        )
+            if cancellation_error is not None and not isinstance(
+                primary_error, asyncio.CancelledError
+            ):
+                if cleanup_error is not None:
+                    logger.error(
+                        "EXL3 cartridge cleanup failed while propagating "
+                        "transaction cancellation",
+                        exc_info=(
+                            type(cleanup_error),
+                            cleanup_error,
+                            cleanup_error.__traceback__,
+                        ),
+                    )
+                raise cancellation_error
+            if cleanup_error is not None:
+                if primary_error is None:
+                    raise cleanup_error
+                logger.error(
+                    "EXL3 cartridge cleanup failed while propagating the primary "
+                    "transaction error",
+                    exc_info=(
+                        type(cleanup_error),
+                        cleanup_error,
+                        cleanup_error.__traceback__,
+                    ),
+                )
 
     async def deactivate_exl3_cartridge(self) -> list[int]:
         """Serialize model-wide EXL3 cartridge deactivation."""
-        async with self._exl3_cartridge_lock:
+        async with self._engine_mutation_lock:
             return await self._deactivate_exl3_cartridge()
 
     async def _deactivate_exl3_cartridge(self) -> list[int]:
@@ -1042,7 +1156,7 @@ class AsyncLLM(EngineClient):
             return [0] * len(active)
         resume_needed = not await self.is_paused()
         try:
-            await self.pause_generation(mode="wait", clear_cache=True)
+            await self._pause_generation(mode="wait", clear_cache=True)
             transition = asyncio.create_task(self._select_exl3_base_and_recapture())
             try:
                 return await asyncio.shield(transition)
@@ -1060,11 +1174,7 @@ class AsyncLLM(EngineClient):
                 raise EngineDeadError() from transition_error
         finally:
             if resume_needed:
-                resume = asyncio.create_task(self.resume_generation())
-                try:
-                    await asyncio.shield(resume)
-                except asyncio.CancelledError:
-                    await resume
+                await _finish_shielded(self._resume_generation())
 
     async def wait_for_requests_to_drain(self, drain_timeout: int = 300):
         """Wait for all requests to be drained."""

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -110,6 +110,7 @@ class AsyncLLM(EngineClient):
         self.vllm_config = vllm_config
         self.model_config = vllm_config.model_config
         self.observability_config = vllm_config.observability_config
+        self._exl3_cartridge_lock = asyncio.Lock()
 
         tracing_endpoint = self.observability_config.otlp_traces_endpoint
         if tracing_endpoint is not None:
@@ -974,6 +975,68 @@ class AsyncLLM(EngineClient):
         return await self.engine_core.collective_rpc_async(
             method, timeout, args, kwargs
         )
+
+    async def load_exl3_cartridge(self, adapter_path: str) -> list[int]:
+        """Serialize and atomically load one model-wide EXL3 cartridge."""
+        async with self._exl3_cartridge_lock:
+            return await self._load_exl3_cartridge(adapter_path)
+
+    async def _load_exl3_cartridge(self, adapter_path: str) -> list[int]:
+        """Quiesce serving, clear caches, and load one EXL3 cartridge."""
+        resume_needed = not await self.is_paused()
+        try:
+            await self.pause_generation(mode="wait", clear_cache=True)
+            try:
+                prepared = await self.collective_rpc(
+                    "prepare_exl3_cartridge",
+                    args=(adapter_path,),
+                )
+                activated = await self.collective_rpc("activate_exl3_cartridge")
+                if activated != prepared or sum(prepared) == 0:
+                    raise RuntimeError(
+                        f"EXL3 cartridge prepare/activate mismatch: "
+                        f"{prepared} != {activated}"
+                    )
+                return prepared
+            except BaseException:
+                rollback = asyncio.create_task(
+                    self.collective_rpc("deactivate_exl3_cartridge")
+                )
+                try:
+                    await asyncio.shield(rollback)
+                except asyncio.CancelledError:
+                    await rollback
+                except Exception:
+                    logger.exception(
+                        "Failed to deactivate EXL3 cartridge after load error"
+                    )
+                raise
+        finally:
+            if resume_needed:
+                resume = asyncio.create_task(self.resume_generation())
+                try:
+                    await asyncio.shield(resume)
+                except asyncio.CancelledError:
+                    await resume
+
+    async def deactivate_exl3_cartridge(self) -> list[int]:
+        """Serialize model-wide EXL3 cartridge deactivation."""
+        async with self._exl3_cartridge_lock:
+            return await self._deactivate_exl3_cartridge()
+
+    async def _deactivate_exl3_cartridge(self) -> list[int]:
+        """Quiesce serving, clear caches, and select the base model."""
+        resume_needed = not await self.is_paused()
+        try:
+            await self.pause_generation(mode="wait", clear_cache=True)
+            return await self.collective_rpc("deactivate_exl3_cartridge")
+        finally:
+            if resume_needed:
+                resume = asyncio.create_task(self.resume_generation())
+                try:
+                    await asyncio.shield(resume)
+                except asyncio.CancelledError:
+                    await resume
 
     async def wait_for_requests_to_drain(self, drain_timeout: int = 300):
         """Wait for all requests to be drained."""

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -976,17 +976,24 @@ class AsyncLLM(EngineClient):
             method, timeout, args, kwargs
         )
 
+    async def _select_exl3_base_and_recapture(self) -> list[int]:
+        await self.collective_rpc("clear_exl3_cartridge_cudagraphs")
+        updated = await self.collective_rpc("deactivate_exl3_cartridge")
+        await self.collective_rpc("capture_exl3_cartridge_cudagraphs")
+        return updated
+
     async def load_exl3_cartridge(self, adapter_path: str) -> list[int]:
-        """Serialize and atomically load one model-wide EXL3 cartridge."""
+        """Serialize cartridge load; failures restore the compressed base."""
         async with self._exl3_cartridge_lock:
             return await self._load_exl3_cartridge(adapter_path)
 
     async def _load_exl3_cartridge(self, adapter_path: str) -> list[int]:
-        """Quiesce serving, clear caches, and load one EXL3 cartridge."""
+        """Quiesce serving, switch model topology, and recapture graphs."""
         resume_needed = not await self.is_paused()
         try:
             await self.pause_generation(mode="wait", clear_cache=True)
             try:
+                await self.collective_rpc("clear_exl3_cartridge_cudagraphs")
                 prepared = await self.collective_rpc(
                     "prepare_exl3_cartridge",
                     args=(adapter_path,),
@@ -997,19 +1004,23 @@ class AsyncLLM(EngineClient):
                         f"EXL3 cartridge prepare/activate mismatch: "
                         f"{prepared} != {activated}"
                     )
+                await self.collective_rpc("capture_exl3_cartridge_cudagraphs")
                 return prepared
             except BaseException:
-                rollback = asyncio.create_task(
-                    self.collective_rpc("deactivate_exl3_cartridge")
-                )
+                rollback = asyncio.create_task(self._select_exl3_base_and_recapture())
                 try:
                     await asyncio.shield(rollback)
                 except asyncio.CancelledError:
-                    await rollback
-                except Exception:
-                    logger.exception(
-                        "Failed to deactivate EXL3 cartridge after load error"
-                    )
+                    try:
+                        await rollback
+                    except Exception as restore_error:
+                        resume_needed = False
+                        self.shutdown()
+                        raise EngineDeadError() from restore_error
+                except Exception as restore_error:
+                    resume_needed = False
+                    self.shutdown()
+                    raise EngineDeadError() from restore_error
                 raise
         finally:
             if resume_needed:
@@ -1025,11 +1036,28 @@ class AsyncLLM(EngineClient):
             return await self._deactivate_exl3_cartridge()
 
     async def _deactivate_exl3_cartridge(self) -> list[int]:
-        """Quiesce serving, clear caches, and select the base model."""
+        """Quiesce serving, release the cartridge, and recapture base graphs."""
+        active = await self.collective_rpc("has_exl3_cartridge")
+        if not any(active):
+            return [0] * len(active)
         resume_needed = not await self.is_paused()
         try:
             await self.pause_generation(mode="wait", clear_cache=True)
-            return await self.collective_rpc("deactivate_exl3_cartridge")
+            transition = asyncio.create_task(self._select_exl3_base_and_recapture())
+            try:
+                return await asyncio.shield(transition)
+            except asyncio.CancelledError:
+                try:
+                    await transition
+                except Exception as transition_error:
+                    resume_needed = False
+                    self.shutdown()
+                    raise EngineDeadError() from transition_error
+                raise
+            except Exception as transition_error:
+                resume_needed = False
+                self.shutdown()
+                raise EngineDeadError() from transition_error
         finally:
             if resume_needed:
                 resume = asyncio.create_task(self.resume_generation())

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -423,6 +423,45 @@ class LLMEngine:
     ) -> list[_R]:
         return self.engine_core.collective_rpc(method, timeout, args, kwargs)
 
+    def _prepare_for_exl3_weight_switch(self) -> None:
+        if self.has_unfinished_requests():
+            raise RuntimeError(
+                "EXL3 cartridge switching requires a quiescent LLMEngine"
+            )
+        if not self.reset_prefix_cache(
+            reset_running_requests=True, reset_connector=True
+        ):
+            raise RuntimeError("Unable to clear prefix cache before weight switch")
+        self.reset_mm_cache()
+        self.reset_encoder_cache()
+
+    def load_exl3_cartridge(self, adapter_path: str) -> list[int]:
+        """Load one cartridge while quiescent and invalidate model caches."""
+        self._prepare_for_exl3_weight_switch()
+        try:
+            prepared = self.collective_rpc(
+                "prepare_exl3_cartridge",
+                args=(adapter_path,),
+            )
+            activated = self.collective_rpc("activate_exl3_cartridge")
+            if activated != prepared or sum(prepared) == 0:
+                raise RuntimeError(
+                    f"EXL3 cartridge prepare/activate mismatch: "
+                    f"{prepared} != {activated}"
+                )
+            return prepared
+        except Exception:
+            try:
+                self.collective_rpc("deactivate_exl3_cartridge")
+            except Exception:
+                logger.exception("Failed to deactivate EXL3 cartridge after load error")
+            raise
+
+    def deactivate_exl3_cartridge(self) -> list[int]:
+        """Select the base model while quiescent and invalidate caches."""
+        self._prepare_for_exl3_weight_switch()
+        return self.collective_rpc("deactivate_exl3_cartridge")
+
     def apply_model(self, func: Callable[[nn.Module], _R]) -> list[_R]:
         return self.collective_rpc("apply_model", args=(func,))
 

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -436,9 +436,10 @@ class LLMEngine:
         self.reset_encoder_cache()
 
     def load_exl3_cartridge(self, adapter_path: str) -> list[int]:
-        """Load one cartridge while quiescent and invalidate model caches."""
+        """Load one cartridge and restore the compressed base on failure."""
         self._prepare_for_exl3_weight_switch()
         try:
+            self.collective_rpc("clear_exl3_cartridge_cudagraphs")
             prepared = self.collective_rpc(
                 "prepare_exl3_cartridge",
                 args=(adapter_path,),
@@ -449,18 +450,30 @@ class LLMEngine:
                     f"EXL3 cartridge prepare/activate mismatch: "
                     f"{prepared} != {activated}"
                 )
+            self.collective_rpc("capture_exl3_cartridge_cudagraphs")
             return prepared
-        except Exception:
+        except BaseException:
             try:
+                self.collective_rpc("clear_exl3_cartridge_cudagraphs")
                 self.collective_rpc("deactivate_exl3_cartridge")
-            except Exception:
-                logger.exception("Failed to deactivate EXL3 cartridge after load error")
+                self.collective_rpc("capture_exl3_cartridge_cudagraphs")
+            except BaseException as restore_error:
+                self.engine_core.shutdown()
+                raise RuntimeError(
+                    "Failed to restore EXL3 base graphs; engine was shut down"
+                ) from restore_error
             raise
 
     def deactivate_exl3_cartridge(self) -> list[int]:
-        """Select the base model while quiescent and invalidate caches."""
+        """Release one cartridge while quiescent and recapture base graphs."""
+        active = self.collective_rpc("has_exl3_cartridge")
+        if not any(active):
+            return [0] * len(active)
         self._prepare_for_exl3_weight_switch()
-        return self.collective_rpc("deactivate_exl3_cartridge")
+        self.collective_rpc("clear_exl3_cartridge_cudagraphs")
+        updated = self.collective_rpc("deactivate_exl3_cartridge")
+        self.collective_rpc("capture_exl3_cartridge_cudagraphs")
+        return updated
 
     def apply_model(self, func: Callable[[nn.Module], _R]) -> list[_R]:
         return self.collective_rpc("apply_model", args=(func,))

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -423,57 +423,18 @@ class LLMEngine:
     ) -> list[_R]:
         return self.engine_core.collective_rpc(method, timeout, args, kwargs)
 
-    def _prepare_for_exl3_weight_switch(self) -> None:
-        if self.has_unfinished_requests():
-            raise RuntimeError(
-                "EXL3 cartridge switching requires a quiescent LLMEngine"
-            )
-        if not self.reset_prefix_cache(
-            reset_running_requests=True, reset_connector=True
-        ):
-            raise RuntimeError("Unable to clear prefix cache before weight switch")
-        self.reset_mm_cache()
-        self.reset_encoder_cache()
-
     def load_exl3_cartridge(self, adapter_path: str) -> list[int]:
-        """Load one cartridge and restore the compressed base on failure."""
-        self._prepare_for_exl3_weight_switch()
-        try:
-            self.collective_rpc("clear_exl3_cartridge_cudagraphs")
-            prepared = self.collective_rpc(
-                "prepare_exl3_cartridge",
-                args=(adapter_path,),
-            )
-            activated = self.collective_rpc("activate_exl3_cartridge")
-            if activated != prepared or sum(prepared) == 0:
-                raise RuntimeError(
-                    f"EXL3 cartridge prepare/activate mismatch: "
-                    f"{prepared} != {activated}"
-                )
-            self.collective_rpc("capture_exl3_cartridge_cudagraphs")
-            return prepared
-        except BaseException:
-            try:
-                self.collective_rpc("clear_exl3_cartridge_cudagraphs")
-                self.collective_rpc("deactivate_exl3_cartridge")
-                self.collective_rpc("capture_exl3_cartridge_cudagraphs")
-            except BaseException as restore_error:
-                self.engine_core.shutdown()
-                raise RuntimeError(
-                    "Failed to restore EXL3 base graphs; engine was shut down"
-                ) from restore_error
-            raise
+        """Reject sync hot-swap because request admission cannot be serialized."""
+        del adapter_path
+        raise NotImplementedError(
+            "EXL3 cartridge switching is supported only by AsyncLLM"
+        )
 
     def deactivate_exl3_cartridge(self) -> list[int]:
-        """Release one cartridge while quiescent and recapture base graphs."""
-        active = self.collective_rpc("has_exl3_cartridge")
-        if not any(active):
-            return [0] * len(active)
-        self._prepare_for_exl3_weight_switch()
-        self.collective_rpc("clear_exl3_cartridge_cudagraphs")
-        updated = self.collective_rpc("deactivate_exl3_cartridge")
-        self.collective_rpc("capture_exl3_cartridge_cudagraphs")
-        return updated
+        """Reject sync hot-swap because request admission cannot be serialized."""
+        raise NotImplementedError(
+            "EXL3 cartridge switching is supported only by AsyncLLM"
+        )
 
     def apply_model(self, func: Callable[[nn.Module], _R]) -> list[_R]:
         return self.collective_rpc("apply_model", args=(func,))

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -397,6 +397,7 @@ class MultiprocExecutor(Executor):
 
         def get_response():
             responses = []
+            failures: list[str] = []
             for mq in response_mqs:
                 dequeue_timeout = (
                     None if deadline is None else (deadline - time.monotonic())
@@ -406,11 +407,14 @@ class MultiprocExecutor(Executor):
                 except TimeoutError as e:
                     raise TimeoutError(f"RPC call to {method} timed out.") from e
                 if status != WorkerProc.ResponseStatus.SUCCESS:
-                    raise RuntimeError(
-                        f"Worker failed with error '{result}', please check the"
-                        " stack trace above for the root cause"
-                    )
-                responses.append(result)
+                    failures.append(str(result))
+                else:
+                    responses.append(result)
+            if failures:
+                raise RuntimeError(
+                    f"Worker failed with error '{failures[0]}', please check the "
+                    "stack trace above for the root cause"
+                )
             return responses[0] if output_rank is not None else responses
 
         future = FutureWrapper(

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -235,7 +235,7 @@ from vllm.v1.worker.ubatch_utils import (
     split_attn_metadata,
 )
 from vllm.v1.worker.utils import is_residual_scattered_for_sp
-from vllm.v1.worker.workspace import lock_workspace
+from vllm.v1.worker.workspace import lock_workspace, unlock_workspace
 
 from .utils import (
     AttentionGroup,
@@ -5728,9 +5728,7 @@ class GPUModelRunner(
                 logprobs_tensors.logprob_token_ids[dst_slice].copy_(
                     token_ids, non_blocking=True
                 )
-                logprobs_tensors.logprobs[dst_slice].copy_(
-                    logprobs, non_blocking=True
-                )
+                logprobs_tensors.logprobs[dst_slice].copy_(logprobs, non_blocking=True)
                 logprobs_tensors.selected_token_ranks[dst_slice].copy_(
                     ranks, non_blocking=True
                 )
@@ -6884,6 +6882,20 @@ class GPUModelRunner(
         )
 
         return int(total_estimate)
+
+    @torch.inference_mode()
+    def clear_cudagraphs(self) -> None:
+        """Release captured graphs before a model topology change."""
+        if self.compilation_config.cudagraph_mode == CUDAGraphMode.NONE:
+            return
+        set_cudagraph_capturing_enabled(False)
+        CUDAGraphWrapper.clear_all_graphs()
+        BreakableCUDAGraphWrapper.clear_all_graphs()
+        if self.encoder_cudagraph_manager is not None:
+            self.encoder_cudagraph_manager.clear()
+        unlock_workspace()
+        torch.accelerator.synchronize()
+        torch.accelerator.empty_cache()
 
     @instrument(span_name="Capture model")
     def capture_model(self) -> int:

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -1227,6 +1227,30 @@ class Worker(WorkerBase):
     def pin_lora(self, lora_id: int) -> bool:
         return self.model_runner.pin_lora(lora_id)
 
+    def prepare_exl3_cartridge(self, adapter_path: str) -> int:
+        """Materialize an inactive EXL3 cartridge through collective RPC."""
+        from vllm.model_executor.layers.quantization.exl3_lora_cartridge import (
+            prepare_exl3_cartridge_into_model,
+        )
+
+        return prepare_exl3_cartridge_into_model(self.model_runner.model, adapter_path)
+
+    def activate_exl3_cartridge(self) -> int:
+        """Commit a prepared EXL3 cartridge through collective RPC."""
+        from vllm.model_executor.layers.quantization.exl3_lora_cartridge import (
+            activate_exl3_cartridge,
+        )
+
+        return activate_exl3_cartridge(self.model_runner.model)
+
+    def deactivate_exl3_cartridge(self) -> int:
+        """Deactivate a model-wide EXL3 cartridge through collective RPC."""
+        from vllm.model_executor.layers.quantization.exl3_lora_cartridge import (
+            deactivate_exl3_cartridge,
+        )
+
+        return deactivate_exl3_cartridge(self.model_runner.model)
+
     def check_health(self) -> None:
         # worker will always be healthy as long as it's running.
         return

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -83,7 +83,7 @@ from vllm.v1.worker.startup_plan import (
 )
 from vllm.v1.worker.utils import is_residual_scattered_for_sp
 from vllm.v1.worker.worker_base import CompilationTimes, WorkerBase
-from vllm.v1.worker.workspace import init_workspace_manager
+from vllm.v1.worker.workspace import init_workspace_manager, lock_workspace
 
 from ...model_executor.model_loader import TensorizerLoader
 from .gpu.warmup import warmup_kernels
@@ -1227,6 +1227,18 @@ class Worker(WorkerBase):
     def pin_lora(self, lora_id: int) -> bool:
         return self.model_runner.pin_lora(lora_id)
 
+    def clear_exl3_cartridge_cudagraphs(self) -> None:
+        """Release graphs before changing the EXL3 cartridge topology."""
+        self.model_runner.clear_cudagraphs()
+
+    def has_exl3_cartridge(self) -> bool:
+        """Return whether this worker owns a dense cartridge runtime."""
+        from vllm.model_executor.layers.quantization.exl3_lora_cartridge import (
+            has_exl3_cartridge,
+        )
+
+        return has_exl3_cartridge(self.model_runner.model)
+
     def prepare_exl3_cartridge(self, adapter_path: str) -> int:
         """Materialize an inactive EXL3 cartridge through collective RPC."""
         from vllm.model_executor.layers.quantization.exl3_lora_cartridge import (
@@ -1244,12 +1256,29 @@ class Worker(WorkerBase):
         return activate_exl3_cartridge(self.model_runner.model)
 
     def deactivate_exl3_cartridge(self) -> int:
-        """Deactivate a model-wide EXL3 cartridge through collective RPC."""
+        """Release a model-wide EXL3 cartridge through collective RPC."""
         from vllm.model_executor.layers.quantization.exl3_lora_cartridge import (
             deactivate_exl3_cartridge,
         )
 
-        return deactivate_exl3_cartridge(self.model_runner.model)
+        updated = deactivate_exl3_cartridge(self.model_runner.model)
+        if updated:
+            torch.accelerator.synchronize()
+            torch.accelerator.empty_cache()
+        return updated
+
+    def capture_exl3_cartridge_cudagraphs(self) -> int:
+        """Recapture graphs after changing the EXL3 cartridge topology."""
+        try:
+            self.model_runner._dummy_run(
+                self.model_runner.max_num_tokens,
+                is_profile=True,
+                skip_eplb=True,
+            )
+            return self.model_runner.capture_model()
+        except BaseException:
+            lock_workspace()
+            raise
 
     def check_health(self) -> None:
         # worker will always be healthy as long as it's running.

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -803,35 +803,41 @@ class Worker(WorkerBase):
         ):
             self.model_runner._init_kv_zero_meta()
 
+    def _get_compile_warmup_sizes(self) -> list[int]:
+        """Return compile sizes requiring an eager warmup run.
+
+        Returns:
+            Compile sizes not covered by CUDA-graph capture, plus one size for
+            each otherwise-uncovered compile range.
+        """
+        compilation_config = self.vllm_config.compilation_config
+        if compilation_config.mode != CompilationMode.VLLM_COMPILE:
+            return []
+
+        compile_sizes = compilation_config.compile_sizes
+        warmup_sizes = compile_sizes.copy() if compile_sizes is not None else []
+        cudagraph_capture_sizes: list[int] = []
+        if compilation_config.cudagraph_mode != CUDAGraphMode.NONE:
+            configured_capture_sizes = compilation_config.cudagraph_capture_sizes
+            cudagraph_capture_sizes = (
+                [] if configured_capture_sizes is None else configured_capture_sizes
+            )
+            warmup_sizes = [
+                size for size in warmup_sizes if size not in cudagraph_capture_sizes
+            ]
+
+        covered_sizes = set(cudagraph_capture_sizes)
+        covered_sizes.update(size for size in warmup_sizes if isinstance(size, int))
+        for compile_range in compilation_config.get_compile_ranges():
+            if not any(size in compile_range for size in covered_sizes):
+                warmup_sizes.append(compile_range.end)
+
+        return [size for size in warmup_sizes if isinstance(size, int)]
+
     @instrument(span_name="Warmup (GPU)")
     def compile_or_warm_up_model(self) -> CompilationTimes:
-        warmup_sizes: list[int] = []
-
-        if self.vllm_config.compilation_config.mode == CompilationMode.VLLM_COMPILE:
-            # warm up sizes that are not in cudagraph capture sizes,
-            # but users still want to compile for better performance,
-            # e.g. for the max-num-batched token size in chunked prefill.
-            compile_sizes = self.vllm_config.compilation_config.compile_sizes
-            warmup_sizes = compile_sizes.copy() if compile_sizes is not None else []  # type: ignore[assignment]
-            cg_capture_sizes: list[int] = []
-
-            if self.vllm_config.compilation_config.cudagraph_mode != CUDAGraphMode.NONE:
-                cg_sizes = self.vllm_config.compilation_config.cudagraph_capture_sizes
-                cg_capture_sizes = [] if cg_sizes is None else cg_sizes
-                warmup_sizes = [x for x in warmup_sizes if x not in cg_capture_sizes]
-
-            compile_ranges = self.vllm_config.compilation_config.get_compile_ranges()
-            # For each compile_range, if none of the batch sizes
-            # in warmup_sizes or cudagraph_capture_sizes are in the range,
-            # add the end of the range to ensure compilation/warmup.
-            all_sizes = set(cg_capture_sizes)
-            all_sizes.update([x for x in warmup_sizes if isinstance(x, int)])
-            for compile_range in compile_ranges:
-                if not any(x in compile_range for x in all_sizes):
-                    warmup_sizes.append(compile_range.end)
-
         # We skip EPLB here since we don't want to record dummy metrics
-        for size in sorted(warmup_sizes, reverse=True):
+        for size in sorted(self._get_compile_warmup_sizes(), reverse=True):
             logger.info("Compile and warming up model for size %d", size)
             self.model_runner._dummy_run(size, skip_eplb=True, remove_lora=False)
         self.model_runner.maybe_remove_all_loras(self.model_runner.lora_config)
@@ -1239,13 +1245,66 @@ class Worker(WorkerBase):
 
         return has_exl3_cartridge(self.model_runner.model)
 
-    def prepare_exl3_cartridge(self, adapter_path: str) -> int:
-        """Materialize an inactive EXL3 cartridge through collective RPC."""
+    def stage_exl3_cartridge(self, adapter_path: str, stage_id: str) -> int:
+        """Verify an EXL3 cartridge before the engine is paused."""
         from vllm.model_executor.layers.quantization.exl3_lora_cartridge import (
-            prepare_exl3_cartridge_into_model,
+            _load_additive_exl3_ext,
+            stage_exl3_cartridge_adapter,
         )
 
-        return prepare_exl3_cartridge_into_model(self.model_runner.model, adapter_path)
+        parallel = self.vllm_config.parallel_config
+        if parallel.data_parallel_size != 1:
+            raise NotImplementedError(
+                "EXL3 cartridge runtime currently requires data_parallel_size=1"
+            )
+        if parallel.pipeline_parallel_size != 1:
+            raise NotImplementedError(
+                "EXL3 cartridge runtime currently requires pipeline_parallel_size=1"
+            )
+        if self.vllm_config.use_v2_model_runner:
+            raise NotImplementedError(
+                "EXL3 cartridge runtime does not support the V2 model runner"
+            )
+        if self.vllm_config.lora_config is not None:
+            raise NotImplementedError(
+                "EXL3 cartridge runtime cannot be combined with LoRA adapters"
+            )
+        _load_additive_exl3_ext()
+        stages = getattr(self, "_exl3_cartridge_stages", None)
+        if stages is None:
+            stages = {}
+            self._exl3_cartridge_stages = stages
+        if stage_id in stages:
+            raise ValueError(f"duplicate EXL3 cartridge stage id {stage_id!r}")
+        staged = stage_exl3_cartridge_adapter(self.model_runner.model, adapter_path)
+        stages[stage_id] = staged
+        assert staged.state is not None
+        return len(staged.local_layer_names)
+
+    def prepare_staged_exl3_cartridge(self, stage_id: str) -> int:
+        """Materialize a verified EXL3 cartridge through collective RPC."""
+        from vllm.model_executor.layers.quantization.exl3_lora_cartridge import (
+            prepare_staged_exl3_cartridge_into_model,
+        )
+
+        stages = getattr(self, "_exl3_cartridge_stages", {})
+        try:
+            staged = stages.pop(stage_id)
+        except KeyError as exc:
+            raise ValueError(f"unknown EXL3 cartridge stage id {stage_id!r}") from exc
+        try:
+            return prepare_staged_exl3_cartridge_into_model(
+                self.model_runner.model, staged
+            )
+        finally:
+            staged.close()
+
+    def discard_staged_exl3_cartridge(self, stage_id: str) -> None:
+        """Release one verified EXL3 cartridge staging area."""
+        stages = getattr(self, "_exl3_cartridge_stages", {})
+        staged = stages.pop(stage_id, None)
+        if staged is not None:
+            staged.close()
 
     def activate_exl3_cartridge(self) -> int:
         """Commit a prepared EXL3 cartridge through collective RPC."""
@@ -1270,23 +1329,8 @@ class Worker(WorkerBase):
     def capture_exl3_cartridge_cudagraphs(self) -> int:
         """Recapture graphs after changing the EXL3 cartridge topology."""
         try:
-            if self.vllm_config.compilation_config.mode == CompilationMode.VLLM_COMPILE:
-                compile_sizes = self.vllm_config.compilation_config.compile_sizes or []
-                capture_sizes = (
-                    self.vllm_config.compilation_config.cudagraph_capture_sizes or []
-                )
-                warmup_sizes = [
-                    size
-                    for size in compile_sizes
-                    if isinstance(size, int) and size not in capture_sizes
-                ]
-                for (
-                    compile_range
-                ) in self.vllm_config.compilation_config.get_compile_ranges():
-                    if not any(size in compile_range for size in capture_sizes):
-                        warmup_sizes.append(compile_range.end)
-                for size in sorted(set(warmup_sizes), reverse=True):
-                    self.model_runner._dummy_run(size, skip_eplb=True)
+            for size in sorted(self._get_compile_warmup_sizes(), reverse=True):
+                self.model_runner._dummy_run(size, skip_eplb=True, remove_lora=False)
             self._warmup_kernels_once()
             return self.model_runner.capture_model()
         except BaseException:

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -1270,11 +1270,24 @@ class Worker(WorkerBase):
     def capture_exl3_cartridge_cudagraphs(self) -> int:
         """Recapture graphs after changing the EXL3 cartridge topology."""
         try:
-            self.model_runner._dummy_run(
-                self.model_runner.max_num_tokens,
-                is_profile=True,
-                skip_eplb=True,
-            )
+            if self.vllm_config.compilation_config.mode == CompilationMode.VLLM_COMPILE:
+                compile_sizes = self.vllm_config.compilation_config.compile_sizes or []
+                capture_sizes = (
+                    self.vllm_config.compilation_config.cudagraph_capture_sizes or []
+                )
+                warmup_sizes = [
+                    size
+                    for size in compile_sizes
+                    if isinstance(size, int) and size not in capture_sizes
+                ]
+                for (
+                    compile_range
+                ) in self.vllm_config.compilation_config.get_compile_ranges():
+                    if not any(size in compile_range for size in capture_sizes):
+                        warmup_sizes.append(compile_range.end)
+                for size in sorted(set(warmup_sizes), reverse=True):
+                    self.model_runner._dummy_run(size, skip_eplb=True)
+            self._warmup_kernels_once()
             return self.model_runner.capture_model()
         except BaseException:
             lock_workspace()

--- a/vllm/v1/worker/worker_base.py
+++ b/vllm/v1/worker/worker_base.py
@@ -174,6 +174,18 @@ class WorkerBase:
     def list_loras(self) -> set[int]:
         raise NotImplementedError
 
+    def prepare_exl3_cartridge(self, adapter_path: str) -> int:
+        """Materialize an inactive model-wide EXL3 cartridge."""
+        raise NotImplementedError
+
+    def activate_exl3_cartridge(self) -> int:
+        """Activate the prepared model-wide EXL3 cartridge."""
+        raise NotImplementedError
+
+    def deactivate_exl3_cartridge(self) -> int:
+        """Deactivate the model-wide EXL3 cartridge."""
+        raise NotImplementedError
+
     @property
     def vocab_size(self) -> int:
         """Get vocabulary size from model configuration."""

--- a/vllm/v1/worker/worker_base.py
+++ b/vllm/v1/worker/worker_base.py
@@ -182,8 +182,16 @@ class WorkerBase:
         """Return whether this worker owns a dense cartridge runtime."""
         raise NotImplementedError
 
-    def prepare_exl3_cartridge(self, adapter_path: str) -> int:
-        """Materialize an inactive model-wide EXL3 cartridge."""
+    def stage_exl3_cartridge(self, adapter_path: str, stage_id: str) -> int:
+        """Verify a model-wide EXL3 cartridge before serving is paused."""
+        raise NotImplementedError
+
+    def prepare_staged_exl3_cartridge(self, stage_id: str) -> int:
+        """Materialize an inactive, previously verified EXL3 cartridge."""
+        raise NotImplementedError
+
+    def discard_staged_exl3_cartridge(self, stage_id: str) -> None:
+        """Release one verified EXL3 cartridge staging area."""
         raise NotImplementedError
 
     def activate_exl3_cartridge(self) -> int:

--- a/vllm/v1/worker/worker_base.py
+++ b/vllm/v1/worker/worker_base.py
@@ -174,6 +174,14 @@ class WorkerBase:
     def list_loras(self) -> set[int]:
         raise NotImplementedError
 
+    def clear_exl3_cartridge_cudagraphs(self) -> None:
+        """Release graphs before changing the EXL3 cartridge topology."""
+        raise NotImplementedError
+
+    def has_exl3_cartridge(self) -> bool:
+        """Return whether this worker owns a dense cartridge runtime."""
+        raise NotImplementedError
+
     def prepare_exl3_cartridge(self, adapter_path: str) -> int:
         """Materialize an inactive model-wide EXL3 cartridge."""
         raise NotImplementedError
@@ -184,6 +192,10 @@ class WorkerBase:
 
     def deactivate_exl3_cartridge(self) -> int:
         """Deactivate the model-wide EXL3 cartridge."""
+        raise NotImplementedError
+
+    def capture_exl3_cartridge_cudagraphs(self) -> int:
+        """Recapture graphs after changing the EXL3 cartridge topology."""
         raise NotImplementedError
 
     @property


### PR DESCRIPTION
## Summary

This adds opt-in, model-wide hot-swapping of packed EXL3 MSRT residual cartridges for routed-expert MoE models.

Operators can switch additive expert-quality stages without materializing dense expert weights or restarting the engine. `AsyncLLM` stages and validates the cartridge before pausing serving, drains requests, replaces the fixed-address CUDA-graph state, recaptures, and resumes. Failed transitions restore the compressed base path.

## Artifact contracts

This PR implements the closed cross-repository runtime contracts:

- base checkpoint profile: `exl3-msrt-base/1`
- adapter schema: `fq-cartridge-adapter/3`
- adapter runtime profile: `exl3-msrt-additive/1`
- ExLlamaV3 extension ABI: `EXL3_MOE_ADDITIVE_ABI_VERSION = 1`

The loader validates ordered residual chains, parent-closed sparse coverage, exact layer/expert/projection/stage coverage, uniform base bitrate, scalar FP32 scales, MCG semantics, tensor geometry, and the base's per-layer byte identities plus aggregate root.

## Tensor parallelism

TP is supported end to end, including TP > 1.

- Full-rank base and adapter artifacts use logical `rank0` tensors and are sliced consistently at runtime.
- Rank-sharded adapters declare an exact world size and rank set; rank-sharded TP=1 remains distinct from full-rank storage.
- Replicated stage scales must match bit-for-bit across ranks.
- Base compatibility identities are computed from full logical tensor bytes before slicing, so identity is invariant across supported runtime TP layouts.

## Runtime lifecycle and safety

Dynamic loading requires an independent operator opt-in:

```bash
VLLM_ENABLE_EXL3_CARTRIDGE=1
```

Checkpoint metadata advertises capability but cannot enable this control path.

Before serving is paused, each worker validates the closed manifest and extension ABI, copies only bounded regular files into private staging while checking declared size and SHA-256, and preflights coverage, topology, scales, K values, and tensor geometry. The drained transaction then performs only model materialization and CUDA-graph replacement.

The implementation also provides:

- one mutation lock shared with pause/resume controls;
- bounded distributed staging RPC and uniform worker-count checks;
- shielded rollback, staging cleanup, and resume paths;
- cleanup after partial-worker failures and correct A-to-narrower-B replacement;
- model-scoped fixed-address scratch shared across sequential MoE layers;
- generic development-API errors while retaining server-side diagnostics.

The API accepts only trusted-admin, worker-local paths. `producer_verified_signer` is provenance metadata, not runtime authentication.

## Current scope

Supported initially:

- V1 `AsyncLLM`;
- tensor parallelism, including TP > 1;
- one model-wide active cartridge;
- the MCG codebook with base-owned rotations.

Explicitly rejected for now:

- synchronous `LLMEngine` hot-swapping;
- pipeline, data, or expert parallelism;
- the V2 model runner;
- simultaneous vLLM LoRA adapters.

## Companion changes

This is one coordinated three-repository implementation:

- [ExLlamaV3 #284](https://github.com/turboderp-org/exllamav3/pull/284): fused additive MoE kernel and versioned ABI.
- [progressive-tensors #41](https://github.com/malaiwah/progressive-tensors/pull/41): base/cartridge production, schemas, TP layouts, and compatibility identities.

## Validation

- 93/93 focused and review-regression tests passed on a two-GPU Blackwell host.
- A real two-process NCCL TP=2 run exercised `Exl3MoEMethod.create_weights` and the full-rank loading path on both GPUs; gathered gate/up/down trellises and rotations reconstructed the original tensors exactly, and both ranks verified the same pre-slice byte identity.
- Unit coverage includes full and rank-sharded adapters (including rank-sharded TP=1), malformed rank topology, divergent scale replicas, parent closure, source replacement, bounded-file handling, wrapped live-layer names, narrower swaps, compile warmups, malformed UTF-8 requests, and the Async failure/cancellation matrix.
- Producer and consumer assert the same hard-coded compatibility golden: layer `3518095a...377d58`, root `cbb1f591...2ce01`.
- Local Ruff formatting/lint, Python compilation, and diff-whitespace checks pass.
- Earlier RTX 5090 functional validation covered base → active cartridge → base graph recapture with exact restored-base logprobs (`max |delta| = 0.0`).

## AI assistance

AI assistance was used for implementation and adversarial review. I reviewed the changed code, focused tests, cross-repository contracts, and GPU validation evidence.
