### PR TITLE
[II] Fix GLM-5.2 B12X sparse MLA runtime contracts

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1374,6 +1374,28 @@ def test_validate_mamba_align_subblock_prefill():
     VllmConfig.validate_block_size(config)
 
 
+@pytest.mark.parametrize("cache_dtype", ["nvfp4", "nvfp4_4over6"])
+def test_generic_nvfp4_kv_cache_rejects_mla(cache_dtype: str):
+    """Generic NVFP4 records do not encode MLA latent-cache geometry."""
+    config = SimpleNamespace(
+        cache_config=SimpleNamespace(cache_dtype=cache_dtype),
+        model_config=SimpleNamespace(use_mla=True),
+    )
+
+    with pytest.raises(ValueError, match="nvfp4 KV cache is not supported with MLA"):
+        VllmConfig.validate_nvfp4_kv_cache_with_mla(config)
+
+
+def test_b12x_nvfp4_ds_mla_cache_accepts_mla():
+    """The B12X packed latent record is an MLA-specific cache format."""
+    config = SimpleNamespace(
+        cache_config=SimpleNamespace(cache_dtype="nvfp4_ds_mla"),
+        model_config=SimpleNamespace(use_mla=True),
+    )
+
+    assert VllmConfig.validate_nvfp4_kv_cache_with_mla(config) is config
+
+
 @pytest.mark.parametrize(
     ("model_id", "compilation_config", "optimization_level"),
     [

--- a/tests/v1/attention/test_b12x_ckv_prefetch_policy.py
+++ b/tests/v1/attention/test_b12x_ckv_prefetch_policy.py
@@ -241,6 +241,22 @@ def test_ckv_prefetch_target_and_draft_lifecycles_are_isolated(monkeypatch):
     assert draft_state.pending_layers == {}
 
 
+def test_ckv_prefetch_capture_and_runtime_builders_share_workspace_state():
+    pool = _CKVPrefetchWorkspacePool(torch.device("cpu"), 64, 2)
+    capture_registry = _CKVPrefetchStateRegistry(pool)
+    runtime_registry = _CKVPrefetchStateRegistry(pool)
+    workspace_buffer = torch.empty(16, dtype=torch.uint8)
+
+    capture_state = capture_registry.for_workspace(workspace_buffer)
+    capture_ring = capture_state.get_ckv_workspace(64)
+    runtime_state = runtime_registry.for_workspace(workspace_buffer)
+
+    assert runtime_state is capture_state
+    assert runtime_state.get_ckv_workspace(64) is capture_ring
+    assert capture_registry.states is runtime_registry.states
+    assert pool._leased_slots == {0}
+
+
 def test_ckv_prefetch_lazily_owns_one_stream_per_workspace_lane(monkeypatch):
     monkeypatch.setattr(workspace, "dbo_current_ubatch_id", lambda: 0)
     monkeypatch.setattr(torch.accelerator, "empty_cache", lambda: None)

--- a/tests/v1/attention/test_b12x_mla_dcp_workspace.py
+++ b/tests/v1/attention/test_b12x_mla_dcp_workspace.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 
@@ -10,11 +12,44 @@ from vllm.model_executor.layers.attention.mla_attention import (
     MLAAttention,
     _can_use_b12x_dcp_prefill_workspace,
     _estimate_dcp_ag_rs_transient_bytes,
+    _get_dcp_batch_metadata,
     _should_allocate_sparse_profile_workspace,
 )
 from vllm.utils.multi_stream_utils import vllm_cudagraph_capture_scope
 from vllm.v1.attention.backends.mla.b12x_mla_sparse import B12xMLASparseImpl
 from vllm.v1.attention.ops import common
+
+
+def test_dcp_batch_metadata_uses_nested_dense_decode_metadata():
+    seq_lens = torch.tensor([11, 17], dtype=torch.int32)
+    query_start_loc = torch.tensor([0, 1, 2, 4], dtype=torch.int32)
+    metadata = SimpleNamespace(
+        decode=SimpleNamespace(seq_lens=seq_lens),
+        num_decodes=2,
+        num_reqs=3,
+        query_start_loc=query_start_loc,
+    )
+
+    actual_seq_lens, actual_query_start_loc = _get_dcp_batch_metadata(metadata)
+
+    assert actual_seq_lens is seq_lens
+    assert torch.equal(actual_query_start_loc, query_start_loc[:3])
+
+
+def test_dcp_batch_metadata_uses_every_sparse_mla_request():
+    seq_lens = torch.tensor([11, 17, 29], dtype=torch.int32)
+    query_start_loc = torch.tensor([0, 4, 9, 15], dtype=torch.int32)
+    metadata = SimpleNamespace(
+        seq_lens=seq_lens,
+        num_decodes=0,
+        num_reqs=3,
+        query_start_loc=query_start_loc,
+    )
+
+    actual_seq_lens, actual_query_start_loc = _get_dcp_batch_metadata(metadata)
+
+    assert torch.equal(actual_seq_lens, seq_lens)
+    assert torch.equal(actual_query_start_loc, query_start_loc)
 
 
 def test_ckv_prefetch_reset_drops_old_cache_generation(monkeypatch):

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -2495,8 +2495,13 @@ class VllmConfig:
     def validate_nvfp4_kv_cache_with_mla(self) -> "VllmConfig":
         if self.model_config is None:
             return self
+        cache_dtype = self.cache_config.cache_dtype
+        # nvfp4_ds_mla is a distinct packed MLA record implemented by the
+        # B12X sparse-MLA backend. Generic NVFP4 cache layouts remain invalid
+        # because they store full attention heads rather than MLA latents.
         if (
-            self.cache_config.cache_dtype.startswith("nvfp4")
+            cache_dtype.startswith("nvfp4")
+            and cache_dtype != "nvfp4_ds_mla"
             and self.model_config.use_mla
         ):
             raise ValueError(

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -617,6 +617,30 @@ def _get_kv_b_proj_input_dtype(
     return weight_dtype
 
 
+def _get_dcp_batch_metadata(
+    attn_metadata: AttentionMetadata,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return aligned request lengths and query offsets for MLA DCP merge."""
+    decode_metadata = getattr(attn_metadata, "decode", None)
+    if decode_metadata is not None:
+        num_reqs = attn_metadata.num_decodes  # type: ignore[attr-defined]
+        seq_lens = cast(torch.Tensor, decode_metadata.seq_lens)
+    else:
+        # Sparse MLA routes prefill and decode through one MQA path. Its
+        # metadata therefore describes every request at the top level rather
+        # than exposing a nested decode-only object.
+        num_reqs = attn_metadata.num_reqs  # type: ignore[attr-defined]
+        seq_lens = cast(
+            torch.Tensor, attn_metadata.seq_lens
+        )[  # type: ignore[attr-defined]
+            :num_reqs
+        ]
+    query_start_loc = attn_metadata.query_start_loc[  # type: ignore[attr-defined]
+        : num_reqs + 1
+    ]
+    return seq_lens, query_start_loc
+
+
 class MLAAttention(nn.Module, AttentionLayerBase):
     """Multi-Head Latent Attention layer.
 
@@ -1584,16 +1608,7 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                         "softmax LSE required by DCP."
                     )
                 assert self.dcp_manager is not None
-                seq_lens = (
-                    attn_metadata.decode.seq_lens
-                    if attn_metadata.decode is not None
-                    else cast(torch.Tensor, attn_metadata.seq_lens)[  # type: ignore[attr-defined]
-                        : attn_metadata.num_decodes
-                    ]
-                )
-                query_start_loc = attn_metadata.query_start_loc[
-                    : attn_metadata.num_decodes + 1
-                ]
+                seq_lens, query_start_loc = _get_dcp_batch_metadata(attn_metadata)
                 valid_counts = None
                 if project_before_merge:
                     valid_counts_tensor = getattr(

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -224,6 +224,11 @@ class _CKVPrefetchWorkspacePool:
         )
         self._free_slots = list(reversed(range(self.max_slots)))
         self._leased_slots: set[int] = set()
+        # Metadata builders used for graph capture and ordinary execution can
+        # differ while borrowing the same physical WorkspaceManager lane. The
+        # pool owns the state map so those builders share one ring and one
+        # pending-work lifecycle for each backing workspace.
+        self._state_map: dict[_CKVWorkspaceIdentity, _CKVPrefetchState] = {}
 
     def acquire(self) -> tuple[int, torch.Tensor]:
         if not self._free_slots:
@@ -414,16 +419,23 @@ _CKV_PREFETCH_STATE_REGISTRIES: weakref.WeakSet = weakref.WeakSet()
 
 
 class _CKVPrefetchStateRegistry:
-    """Builder-owned states partitioned by lane-scoped CKV workspace."""
+    """Access pool-owned states partitioned by lane-scoped CKV workspace."""
 
     def __init__(self, workspace_pool: _CKVPrefetchWorkspacePool | None = None) -> None:
         self.states: dict[_CKVWorkspaceIdentity, _CKVPrefetchState] = {}
-        self.workspace_pool = workspace_pool
+        self.workspace_pool: _CKVPrefetchWorkspacePool | None = None
+        if workspace_pool is not None:
+            self._bind_workspace_pool(workspace_pool)
         _CKV_PREFETCH_STATE_REGISTRIES.add(self)
 
     def _bind_workspace_pool(self, pool: _CKVPrefetchWorkspacePool) -> None:
         if self.workspace_pool is None:
+            if self.states:
+                raise RuntimeError(
+                    "CKV prefetch registry cannot bind a pool after creating states"
+                )
             self.workspace_pool = pool
+            self.states = pool._state_map
         elif self.workspace_pool is not pool:
             raise RuntimeError("CKV prefetch registry cannot switch workspace pools")
 


### PR DESCRIPTION
## Resulting behavior

GLM-5.2 B12X sparse MLA can use the packed `nvfp4_ds_mla` KV format on the Infernal Invocation branch.

The runtime preserves three backend contracts:

- `nvfp4_ds_mla` is accepted as an MLA-specific latent record. Generic `nvfp4` and `nvfp4_4over6` records remain rejected for MLA.
- DCP merge receives aligned request lengths and query offsets from either dense MLA's nested decode metadata or B12X sparse MLA's top-level all-request metadata.
- CUDA graph-capture and runtime metadata builders share CKV prefetch state when they borrow the same physical `WorkspaceManager` lane. One physical lane therefore owns one ring, stream/event lifecycle, and pool lease.

Without these contracts, the sparse backend is rejected during configuration, dereferences metadata it does not define, or leases duplicate CKV slots after graph capture.

## Compatibility

Dense MLA retains its nested decode path. Generic NVFP4 MLA remains unsupported. The CKV change does not allocate additional workspace or reduce KV capacity; it changes state ownership from a metadata-builder instance to the existing physical workspace pool.

## Validation

- 70 targeted unit tests passed.
- Ruff check, Ruff format, and `git diff --check` passed.
- GLM-5.2 EXL3 3.25bpw, TP4/DCP4/MTP3, `nvfp4_ds_mla`: HTTP correctness smoke passed; warmed CC1/context-zero decode measured 112.3 tok/s with 422,912 physical KV tokens.
- GLM-5.2 NVFP4, TP8/DCP1/MTP3, online MXFP8: warmed CC1/context-zero decode measured 179.28 tok/s.
- GLM-5.2 NVFP4, TP6/DCP1/MTP3, online MXFP8: virtual-TP startup and correctness passed; warmed CC1/context-zero decode measured 133.5 tok/s.

The throughput checks are 30-second CC1 regression gates, not a concurrency sweep.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the specialized `nvfp4_ds_mla` KV-cache format with MLA models.

- **Bug Fixes**
  - Improved MLA attention handling for dense decode and sparse batches, ensuring sequence lengths and query positions are interpreted correctly.
  - Improved distributed context parallel processing for sparse MLA workloads.
  - Improved workspace reuse during CKV prefetch operations, reducing duplicate allocation and improving resource tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->