### PR TITLE
[II] Fix reasoning-aware strict tool grammar activation

### DIFF
--- a/tests/tool_parsers/test_structural_tag_registry.py
+++ b/tests/tool_parsers/test_structural_tag_registry.py
@@ -473,11 +473,54 @@ def test_unified_parser_get_structural_tag_disables_reasoning(
         tool_choice="auto",
     )
     parser = TestParser(MagicMock(), tools=sample_tools_strict)
-    parser.reasoning_parser = MagicMock(adjust_request=lambda request: request)
+    parser.reasoning_parser = MagicMock(
+        thinking_enabled=False,
+        adjust_request=lambda request: request,
+    )
 
     parser.adjust_request(request)
 
     assert captured == [False]
+
+
+@pytest.mark.parametrize(
+    ("reasoning_enabled", "expected_grammar_from_parser"),
+    [(False, False), (True, True)],
+)
+def test_unified_parser_activates_reasoning_aware_grammar_at_token_zero(
+    sample_tools_strict: list[ChatCompletionToolsParam],
+    reasoning_enabled: bool,
+    expected_grammar_from_parser: bool,
+):
+    class TestParser(DelegatingParser):
+        pass
+
+    request = ChatCompletionRequest(
+        messages=[],
+        model="m",
+        tools=sample_tools_strict,
+        tool_choice="required",
+    )
+    reasoning_parser = MagicMock()
+    reasoning_parser.thinking_enabled = reasoning_enabled
+    reasoning_parser.adjust_request.side_effect = lambda request: request
+    tool_parser = MagicMock()
+    tool_parser.structural_tag_model = "deepseek_v4"
+    tool_parser.get_structural_tag.return_value = SimpleNamespace(
+        model_dump=lambda: {"type": "structural_tag"}
+    )
+    tool_parser.adjust_request.side_effect = lambda request: request
+
+    parser = TestParser(MagicMock())
+    parser.reasoning_parser = reasoning_parser
+    parser.tool_parser = tool_parser
+
+    result = parser.adjust_request(request)
+
+    assert result._grammar_from_parser is expected_grammar_from_parser
+    tool_parser.get_structural_tag.assert_called_once_with(
+        request, reasoning=reasoning_enabled
+    )
 
 
 def test_xgrammar_function_parameters_are_preserved(

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -562,13 +562,8 @@ class DelegatingParser(Parser):
 
         reasoning_enabled = self._reasoning_enabled()
 
-        # When the model emits a reasoning prefix (e.g. ``...</think>``) before
-        # its tool call, the structural-tag grammar MUST include the reasoning
-        # section. Otherwise the grammar only models the tool-call format and
-        # the structured-output FSM rejects the reasoning tokens at the
-        # reasoning->tool boundary (HTTP 500 non-streaming / mid-stream error
-        # streaming). The engine's structural-tag same-step advance also assumes
-        # the tag models this phased (reasoning -> tool) output.
+        # A reasoning-aware structural grammar owns both the unconstrained
+        # reasoning prefix and the constrained tool-call suffix.
         structure_tag = self._tool_parser.get_structural_tag(
             request,
             reasoning=reasoning_enabled,
@@ -585,22 +580,10 @@ class DelegatingParser(Parser):
         else:
             request.response_format = None
 
-        # The structural tag now models the reasoning phase itself (an
-        # unconstrained prefix terminated by the reasoning-end marker), so the
-        # structured-output engine must enforce the grammar from the FIRST
-        # token rather than deferring past a reasoning section it would no
-        # longer detect separately. Without this, tokens sampled immediately
-        # after the reasoning-end marker escape the grammar bitmask, so a
-        # forced/required tool suffix can be violated (e.g. the model samples
-        # prose instead of the tool call); the FSM advance then rejects those
-        # tokens and the request fails with an internal error. This reuses the
-        # same signal the Mistral grammar path uses to mark "the grammar
-        # handles reasoning" (-> reasoning_ended=True at generation start). The
-        # reasoning prefix is unconstrained, so thinking is not restricted; only
-        # the post-reasoning tool call is enforced. PrivateAttr exists only on
-        # ChatCompletionRequest, hence the guard.
-        if reasoning_enabled and hasattr(request, "_grammar_from_tool_parser"):
-            request._grammar_from_tool_parser = True
+        # Chat serving normally defers grammar activation until reasoning ends.
+        # This grammar already models reasoning, so activate it at token zero.
+        if reasoning_enabled and hasattr(request, "_grammar_from_parser"):
+            request._grammar_from_parser = True
         return request
 
     def extract_reasoning_streaming(


### PR DESCRIPTION
## Resulting behavior

Reasoning-enabled strict tool requests activate a reasoning-aware structural grammar at the first generated token. The grammar therefore owns both the unconstrained reasoning prefix and the constrained tool-call suffix, and each model-emitted tool call is parsed once.

## Technical reason

`ChatCompletionRequest` exposes the private `_grammar_from_parser` signal consumed by chat serving. The unified parser checked and assigned a nonexistent `_grammar_from_tool_parser` attribute, so the signal remained false. Chat serving deferred grammar activation until reasoning ended even though the structural grammar already included the reasoning section. A model-emitted tool block could consequently be consumed as part of the unconstrained prefix before the grammar required a second reasoning terminator and tool block.

The parser now sets the existing `_grammar_from_parser` signal. Requests without reasoning retain deferred grammar activation, and request types without that private signal remain unchanged.

## Validation

- `tests/tool_parsers/test_structural_tag_registry.py`: 78 passed.
- Ruff check and format: passed for the modified source and test files.
- DeepSeek-V4-Flash-0731, TP2, DSpark K5, strict tool schema: `auto`, `required`, and named tool choice each passed four buffered and four streaming requests with exactly one schema-valid tool call per request.
- The same named request produced two identical tool calls before the fix and one tool call after the fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved structured tool parsing for reasoning-enabled requests.
  - Grammar handling now correctly reflects reasoning settings from the beginning of generation, helping ensure more consistent parser behavior and tool-call formatting.
  - Updated parser configuration to provide the appropriate reasoning mode when processing structured outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->