### PR TITLE
[II] Restore DeepSeek V4 DSpark quantization

### DIFF
--- a/tests/config/test_speculative_dspark.py
+++ b/tests/config/test_speculative_dspark.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm.config import ModelConfig, ParallelConfig, SpeculativeConfig
+from vllm.model_executor.layers import quantization as me_quant
+from vllm.model_executor.layers.quantization.fp8 import Fp8Config
+from vllm.models.deepseek_v4.quant_config import DeepseekV4FP8Config
+from vllm.transformers_utils.configs.deepseek_v4 import DeepseekV4Config
+
+
+class _NoOverrideQuantizationConfig:
+    @classmethod
+    def override_quantization_method(cls, hf_quant_cfg, user_quant, hf_config=None):
+        return None
+
+
+@pytest.mark.cpu_test
+def test_deepseek_v4_dspark_preserves_specialized_fp8_quantization(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    quantization_configs = {
+        "fp8": Fp8Config,
+        "deepseek_v4_fp8": DeepseekV4FP8Config,
+    }
+    # Keep this config test independent of unrelated optional quant backends.
+    monkeypatch.setattr(me_quant, "QUANTIZATION_METHODS", list(quantization_configs))
+    monkeypatch.setattr(
+        me_quant,
+        "get_quantization_config",
+        lambda name: quantization_configs.get(name, _NoOverrideQuantizationConfig),
+    )
+
+    model_path = tmp_path / "deepseek-v4-dspark"
+    DeepseekV4Config(
+        architectures=["DeepseekV4ForCausalLM"],
+        hidden_size=16,
+        intermediate_size=32,
+        moe_intermediate_size=8,
+        num_hidden_layers=1,
+        num_attention_heads=1,
+        num_key_value_heads=1,
+        vocab_size=32,
+        torch_dtype="bfloat16",
+        quantization_config={
+            "activation_scheme": "dynamic",
+            "quant_method": "fp8",
+            "weight_block_size": [128, 128],
+        },
+    ).save_pretrained(model_path)
+    target_model_config = ModelConfig(
+        model=str(model_path), tokenizer_mode="skip", max_model_len=32
+    )
+
+    speculative_config = SpeculativeConfig(
+        model=str(model_path),
+        method="dspark",
+        num_speculative_tokens=5,
+        target_model_config=target_model_config,
+        target_parallel_config=ParallelConfig(),
+    )
+
+    draft_model_config = speculative_config.draft_model_config
+    assert draft_model_config.architectures == ["DSparkDraftModel"]
+    assert draft_model_config.quantization == "deepseek_v4_fp8"

--- a/tests/config/test_speculative_dspark.py
+++ b/tests/config/test_speculative_dspark.py
@@ -41,6 +41,7 @@ def test_deepseek_v4_dspark_preserves_specialized_fp8_quantization(
         num_hidden_layers=1,
         num_attention_heads=1,
         num_key_value_heads=1,
+        o_groups=1,
         vocab_size=32,
         torch_dtype="bfloat16",
         quantization_config={

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -1125,6 +1125,8 @@ class SpeculativeConfig:
                         "DSparkDraftModel"
                     ]
                     self.update_arch_()
+                    if self.draft_model_config.quantization == "fp8":
+                        self.draft_model_config.quantization = "deepseek_v4_fp8"
                 elif (
                     self.method == "dspark"
                     and "Gemma4DSparkModel" in self.draft_model_config.architectures


### PR DESCRIPTION
## Purpose

DeepSeek V4 stores its DSpark draft layers in the target checkpoint. Those
layers use the target model's specialized `deepseek_v4_fp8` configuration,
which combines FP8 linear weights with MXFP4 expert weights.

The speculative-config builder temporarily identifies the draft as
`deepseek_mtp` while it verifies quantization. Generic quantization discovery
therefore selected plain `fp8`; B12X then rejected the draft MoE backend or the
loader failed while looking for FP8 expert scales such as
`w13_weight_scale`.

## Behavior

When DSpark restores the embedded DeepSeek V4 draft architecture, it also
restores `deepseek_v4_fp8`. Standalone DSpark checkpoints retain their existing
quantization discovery behavior.

This is a port of
[vllm-project/vllm#51835](https://github.com/vllm-project/vllm/pull/51835),
commit `60912c3e3925001a5be7a78d1b57c9cf842fbdf2`, to
`dev/infernal-invocation`. The only II-specific change supplies `o_groups` in
the synthetic DeepSeek V4 test fixture because the II virtual-TP planner
requires the output-group contract. The runtime fix is unchanged.

## Duplicate check

Upstream PR #51835 is the authoritative upstream implementation. This PR is
limited to making that implementation reviewable and mergeable against the II
release branch; it does not introduce an alternative loader path. Searches for
`DSpark quantization`, `DeepSeek V4 DSpark MXFP4`, and
`w13_weight_scale` found no equivalent open PR against
`dev/infernal-invocation`.

## Validation

- 14 focused configuration and draft-quantization tests passed.
- Ruff check, Ruff format check, and `git diff --check` passed.
- Full checkpoint startup passed with
  `deepseek-ai/DeepSeek-V4-Flash-0731`, TP2, DCP1, DSpark K5, B12X-A8,
  FP8 DS-MLA KV, and full/piecewise CUDA graphs.
- Target and DSpark draft weights both loaded; the draft loader reported 97
  parameters and B12X selected the MXFP4 expert backend.
- A normal chat completion returned the requested content.
- One warmed CC1 measurement produced 214.0 aggregate tok/s. The change only
  corrects pre-load quantization selection and does not alter target-model
  inference math.

AI assistance was used for source inspection, test adaptation, live validation,
and drafting this description. Every changed line and the upstream source PR
were reviewed before submission.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed DeepSeek V4 speculative decoding so FP8 draft models retain their specialized quantization configuration.
  * Improved compatibility and reliability for DSpark draft model setup.

* **Tests**
  * Added CPU coverage to verify DeepSeek V4 DSpark configurations preserve the expected draft architecture and quantization method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->