### PR TITLE
[II] Publish filesystem KV blocks without inode replacement

### DIFF
--- a/csrc/fs_io.cpp
+++ b/csrc/fs_io.cpp
@@ -33,6 +33,23 @@ inline int ensure_parent_dirs(const std::string& path) {
   return ec ? ec.value() : 0;
 }
 
+// Publish a complete content-addressed file without replacing an inode that
+// another writer already made visible. link(2) is atomic and returns EEXIST
+// when a concurrent writer wins, including across processes.
+inline int publish_file_if_absent(const char* tmp_path, const char* dest_path) {
+  if (link(tmp_path, dest_path) != 0) {
+    const int err = errno;
+    if (err != EEXIST) {
+      return err;
+    }
+  }
+
+  if (unlink(tmp_path) != 0 && errno != ENOENT) {
+    return errno;
+  }
+  return 0;
+}
+
 // Core single-block store: src/size are raw pointer + byte count. Returns 0
 // on success, or the errno of the failing step on failure -- captured
 // before any subsequent cleanup call can overwrite it. On failure, the temp
@@ -68,8 +85,7 @@ inline int _store_block(const char* tmp_path, const char* dest_path,
     return err;
   }
 
-  if (rename(tmp_path, dest_path) != 0) {
-    const int err = errno;
+  if (const int err = publish_file_if_absent(tmp_path, dest_path); err != 0) {
     unlink(tmp_path);
     return err;
   }
@@ -190,6 +206,31 @@ static PyObject* batch_lookup(PyObject* /*self*/, PyObject* args) {
     PyList_SetItem(result, i, PyBool_FromLong(exists_flags[i]));
   }
   return result;
+}
+
+/// @brief Publish one complete file without replacing an existing destination.
+/// @param tmp_path  private completed file that remains hidden from readers.
+/// @param dest_path immutable content-addressed destination.
+/// @note Releases the GIL. EEXIST is success because another writer published
+///       the same content key.
+static PyObject* publish_file_if_absent_py(PyObject* /*self*/, PyObject* args) {
+  const char* tmp_path = nullptr;
+  const char* dest_path = nullptr;
+  if (!PyArg_ParseTuple(args, "ss", &tmp_path, &dest_path)) {
+    return nullptr;
+  }
+
+  int err = 0;
+  {
+    Py_BEGIN_ALLOW_THREADS err = publish_file_if_absent(tmp_path, dest_path);
+    Py_END_ALLOW_THREADS
+  }
+  if (err != 0) {
+    errno = err;
+    return PyErr_SetFromErrnoWithFilename(PyExc_OSError, dest_path);
+  }
+
+  Py_RETURN_NONE;
 }
 
 /// @brief Store a batch of blocks, each from its own buffer, to disk.
@@ -342,6 +383,11 @@ static PyMethodDef fs_io_C_methods[] = {
      "batch_lookup(paths: list[str]) -> list[bool]\n"
      "\n"
      "Check file existence for a batch of paths."},
+    {"_publish_file_if_absent", publish_file_if_absent_py, METH_VARARGS,
+     "_publish_file_if_absent(tmp_path: str, dest_path: str) -> None\n"
+     "\n"
+     "Publish a complete private file without replacing an existing "
+     "content-addressed destination."},
     {"batch_store_block", batch_store_block, METH_VARARGS,
      "batch_store_block(tmp_paths: list[str], dest_paths: list[str],\n"
      "                  buffers: list[bytes-like],\n"

--- a/tests/v1/kv_offload/tiering/test_fs_tier.py
+++ b/tests/v1/kv_offload/tiering/test_fs_tier.py
@@ -37,6 +37,7 @@ from vllm.v1.kv_offload.config import (
 )
 from vllm.v1.kv_offload.tiering.base import TransferJob
 from vllm.v1.kv_offload.tiering.factory import SecondaryTierFactory
+from vllm.v1.kv_offload.tiering.fs import io as fs_io
 from vllm.v1.kv_offload.tiering.fs.manager import (
     FileSystemTierManager,
 )
@@ -227,6 +228,53 @@ def test_store_creates_file_and_lookup_succeeds(fs_tier):
     assert lookup_and_wait(tier, [key(1)]) == [LookupResult.HIT]
     dest = tier.file_mapper.get_file_name(key(1))
     assert os.path.exists(dest), f"Expected file at {dest}"
+
+
+def test_python_store_preserves_first_published_inode(tmp_path, monkeypatch):
+    """A writer that finishes later must not replace a published cache block."""
+    destination = tmp_path / "blocks" / "shared.bin"
+    delayed_at_publish = threading.Event()
+    first_published = threading.Event()
+    real_link = os.link
+    errors: list[Exception] = []
+
+    def ordered_link(source: str, target: str) -> None:
+        if threading.current_thread().name == "delayed-writer":
+            delayed_at_publish.set()
+            assert first_published.wait(timeout=5)
+        real_link(source, target)
+        if threading.current_thread().name == "first-writer":
+            first_published.set()
+
+    monkeypatch.setattr(fs_io.os, "link", ordered_link)
+
+    def store(value: int) -> None:
+        try:
+            data = bytearray([value]) * mmap.PAGESIZE
+            fs_io._store_block(
+                str(destination),
+                memoryview(data),
+                0,
+                len(data),
+                use_o_direct=False,
+            )
+        except Exception as exc:
+            errors.append(exc)
+
+    delayed = threading.Thread(target=store, args=(0xA5,), name="delayed-writer")
+    delayed.start()
+    assert delayed_at_publish.wait(timeout=5)
+
+    first = threading.Thread(target=store, args=(0x5A,), name="first-writer")
+    first.start()
+    first.join(timeout=5)
+    delayed.join(timeout=5)
+
+    assert not first.is_alive()
+    assert not delayed.is_alive()
+    assert not errors
+    assert destination.read_bytes() == bytes([0x5A]) * mmap.PAGESIZE
+    assert not list(destination.parent.glob("*.tmp"))
 
 
 def test_store_then_load_roundtrip(fs_tier):
@@ -471,6 +519,61 @@ def test_store_load_data_integrity(fs_tier, monkeypatch, use_c_ext, batch_size):
         assert torch.allclose(tensor[bid], expected[i]), (
             f"Block {bid} data mismatch after store+load"
         )
+
+
+def test_c_publish_preserves_first_writer_content_and_inode(tmp_path):
+    """C publication must preserve the first complete file for a shared key."""
+    try:
+        from vllm.fs_io_C import _publish_file_if_absent as publish_file_C
+    except ImportError:
+        pytest.skip("fs_io_C extension not built")
+
+    writer_count = 16
+    destination = tmp_path / "shared.bin"
+    start = threading.Barrier(writer_count + 1)
+    first_published = threading.Event()
+    authoritative_inodes: list[int] = []
+    observed_inodes: list[int] = []
+    errors: list[OSError | threading.BrokenBarrierError | TimeoutError] = []
+
+    temp_paths = [tmp_path / f"writer-{writer}.tmp" for writer in range(writer_count)]
+    for writer, temp_path in enumerate(temp_paths):
+        temp_path.write_bytes(bytes([writer + 1]) * mmap.PAGESIZE)
+
+    def publish(writer: int) -> None:
+        try:
+            start.wait(timeout=5)
+            if writer != 0 and not first_published.wait(timeout=5):
+                raise TimeoutError("first writer did not publish")
+            publish_file_C(str(temp_paths[writer]), str(destination))
+            inode = destination.stat().st_ino
+            if writer == 0:
+                authoritative_inodes.append(inode)
+                first_published.set()
+            else:
+                observed_inodes.append(inode)
+        except (OSError, threading.BrokenBarrierError, TimeoutError) as exc:
+            errors.append(exc)
+            first_published.set()
+
+    threads = [
+        threading.Thread(target=publish, args=(writer,))
+        for writer in range(writer_count)
+    ]
+    for thread in threads:
+        thread.start()
+    start.wait(timeout=5)
+
+    for thread in threads:
+        thread.join(timeout=5)
+
+    assert not any(thread.is_alive() for thread in threads)
+    assert not errors
+    assert len(authoritative_inodes) == 1
+    assert set(observed_inodes) == {authoritative_inodes[0]}
+    assert destination.stat().st_ino == authoritative_inodes[0]
+    assert destination.read_bytes() == bytes([1]) * mmap.PAGESIZE
+    assert not list(tmp_path.glob("*.tmp"))
 
 
 def test_store_load_roundtrip_without_o_direct(tmp_path, monkeypatch):

--- a/vllm/v1/kv_offload/tiering/fs/io.py
+++ b/vllm/v1/kv_offload/tiering/fs/io.py
@@ -87,6 +87,25 @@ def _validate_offsets(view: memoryview, offsets: list[int], block_size: int) -> 
             )
 
 
+def _publish_file_if_absent(tmp_path: str, dest_path: str) -> None:
+    """Publish a complete content-addressed file without replacing its inode.
+
+    Args:
+        tmp_path: Path to the completed private temporary file.
+        dest_path: Path to the content-addressed destination file.
+
+    Returns:
+        None.
+
+    Raises:
+        OSError: If publication or temporary-file cleanup fails.
+    """
+    # A competing writer may have published the same immutable key.
+    with contextlib.suppress(FileExistsError):
+        os.link(tmp_path, dest_path)
+    os.remove(tmp_path)
+
+
 def _store_block(
     dest_path: str,
     buffer: memoryview,
@@ -95,7 +114,7 @@ def _store_block(
     use_o_direct: bool = True,
 ) -> None:
     """
-    Store callback: Writes to a temp file then atomically replaces the destination.
+    Store callback: Writes to a temp file then publishes it if absent.
     """
     # Check if block already exists to avoid redundant writes
     if os.path.exists(dest_path):
@@ -123,7 +142,7 @@ def _store_block(
                 )
         finally:
             os.close(fd)
-        os.replace(tmp_path, dest_path)
+        _publish_file_if_absent(tmp_path, dest_path)
     except Exception:
         try:
             os.remove(tmp_path)
@@ -175,8 +194,9 @@ def batch_store_block(
     """
     Store a batch of KV blocks from a shared buffer to disk in one call.
 
-    Each block buffer[offsets[i] : offsets[i]+block_size] is written atomically
-    to dest_paths[i] via a temp-file rename.  Raises on first error.
+    Each block buffer[offsets[i] : offsets[i]+block_size] is written to a
+    private temp file and atomically published only if dest_paths[i] is absent.
+    Raises on first error.
     """
     _validate_offsets(view, offsets, block_size)
 

--- a/vllm/v1/kv_offload/tiering/fs/manager.py
+++ b/vllm/v1/kv_offload/tiering/fs/manager.py
@@ -4,8 +4,8 @@
 FileSystemTierManager: Pure-Python file system secondary tier for KV cache offloading.
 
 Store path:
-    Data is written to a temp file (<dest_path.tmp>) via os.write,
-    then os.replace'd to the final path (without .tmp).
+    Data is written to a private temp file via os.write, then atomically linked
+    to the final content-addressed path only if that path is absent.
 
 Load path:
     Data is read from the block file directly via os.readv into the


### PR DESCRIPTION
## Purpose

Filesystem KV offloading stores immutable, content-addressed blocks. This change makes publication of each block create-if-absent across threads and processes.

## Behavior

- Each writer writes a complete block to a private temporary file.
- The writer publishes the block with `link(2)`, which atomically creates the destination only when it does not exist.
- `EEXIST` means another writer published the same immutable content key and is treated as success.
- The private temporary file is removed after publication.
- The Python fallback and the C batch implementation enforce the same contract.

The block format, direct-I/O selection, batch interface, lookup behavior, and garbage-collection policy are unchanged.

## Technical reason

The C batch path used `rename(tmp, destination)`. Concurrent writers for one content key could each observe a missing destination and then replace the visible inode repeatedly. Readers could therefore hold an inode that a later writer removed from the namespace even though the content key was already published.

A model-free 16-writer probe observed 16 destination inode identities per iteration with the replacement contract. The create-if-absent contract retained one inode per iteration across five iterations.

No existing open pull request in `local-inference-lab/vllm` or upstream vLLM implements create-if-absent publication for this filesystem tier.

## Validation

- `tests/v1/kv_offload/tiering/test_fs_tier.py`: 49 passed with the compiled `fs_io_C` extension.
- Deterministic Python test: a delayed writer cannot replace the first published inode.
- C batch test: 16 concurrent writers retain one published inode and leave no temporary files.
- Model-free concurrency probe: `inode_counts=[1,1,1,1,1]` after the change; `inode_counts=[16,16,16,16,16]` before it.
- Ruff check and format: passed.
- `clang-format` pre-commit check: passed.
- `typos` and `git diff --check`: passed.

The userspace publication race is qualified on ext4. A separately reported host freeze on btrfs was not reproduced locally and still requires reporter validation on btrfs.

No model evaluation is required because this change does not alter model arithmetic, scheduling, cache-key construction, or loaded KV bytes.

## AI assistance

OpenAI Codex assisted with source review, implementation, test construction, and validation. The code and evidence were reviewed before publication.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved concurrent file writes so the first successfully published result is preserved.
  * Prevented competing writers from replacing an existing destination or producing errors.
  * Ensured temporary files are cleaned up after publication.

* **Documentation**
  * Updated file-system storage documentation to describe the atomic publish behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->