### PR TITLE
[II] Own borrowed weights before deferred online processing

### DIFF
--- a/tests/model_executor/model_loader/test_reload.py
+++ b/tests/model_executor/model_loader/test_reload.py
@@ -686,6 +686,19 @@ def test_online_processing_waits_for_late_registered_bias():
     assert torch.equal(quant_method.bias_at_process, loaded_bias)
 
 
+def test_online_processing_owns_deferred_instanttensor_weight():
+    quant_method = _RecordingQuantMethod()
+    layer = _LateBiasLayer(quant_method)
+    loaded_weight = torch.full((4, 2), 2.0)
+    loaded_weight._vllm_instanttensor_borrowed = True
+
+    layer.weight.weight_loader(layer.weight, loaded_weight)
+    loaded_weight.fill_(9.0)
+    layer.bias.weight_loader(layer.bias, torch.zeros(4))
+
+    assert torch.equal(layer.weight, torch.full((4, 2), 2.0))
+
+
 def test_layerwise_reload_skips_non_persistent_parameter_alias_buffers(monkeypatch):
     layer = _AliasedBufferLayer()
     model = torch.nn.Sequential(layer)

--- a/vllm/model_executor/model_loader/reload/layerwise.py
+++ b/vllm/model_executor/model_loader/reload/layerwise.py
@@ -183,6 +183,14 @@ def make_online_process_loader(layer: torch.nn.Module, param_name: str) -> Calla
         bound_args = loader_signature.bind(*args, **kwargs)
         bound_args.apply_defaults()
 
+        # Deferred loaders retain their arguments beyond the caller's yield.
+        # Materialize InstantTensor views before its staging buffer is reused.
+        for name, value in bound_args.arguments.items():
+            if isinstance(value, torch.Tensor) and getattr(
+                value, "_vllm_instanttensor_borrowed", False
+            ):
+                bound_args.arguments[name] = value.clone()
+
         # Buffer loaded weights, track loading progress
         info.loaded_weights.append((param_name, bound_args))
         num_loaded, ret = get_numel_loaded(original_loader, bound_args)


### PR DESCRIPTION
## Status

- Implementation: **implemented**
- Unit qualification: **qualified**
- GLM-5.2 EXL3 E2E qualification: **qualified for the profile below**

## Purpose

Preserve weight values when layerwise online quantization defers a parameter
loader while InstantTensor uses borrowed staging-buffer views.

## Resulting behavior

`make_online_process_loader()` may retain bound loader arguments until every
parameter required by the layer is available. A tensor marked
`_vllm_instanttensor_borrowed` is cloned before entering that deferred state.
Unmarked tensors and loaders that consume their inputs synchronously retain
their allocation behavior.

The owned copy is scoped to the incomplete layer and released after online
processing. This avoids the checkpoint-wide memory cost of
`INSTANTTENSOR_COPY=1` while preventing staging-buffer reuse from changing a
deferred weight.

## Technical reason

InstantTensor borrowed mode permits the loader to reuse backing storage after
the iterator advances. Layerwise online processing retained the borrowed view
in `LayerReloadingInfo.loaded_weights`. A later tensor load could overwrite a
parameter before the layer's online quantizer consumed it.

Pull request #281 defines the borrowed-buffer contract and requires retaining
consumers to materialize owned storage. This change enforces that contract at
the layerwise deferred-loader ownership boundary.

## Compatibility

The clone is gated by the explicit borrowed-tensor marker. Safetensors,
owned-copy InstantTensor loads, ordinary parameter loaders, and completed
layers do not acquire an additional copy.

## Validation

Focused tests in the Infernal Invocation CUDA 13.3 / PyTorch 2.13 image:

```text
python -m pytest -q --confcutdir=/tmp /tmp/test_reload.py \
  -k 'online_processing or (layerwise_reload and not marlin)'
8 passed, 38 deselected
```

Ruff check, Ruff format, and `git diff --check` passed for the implementation
and tests.

Exact-image E2E qualification used:

```text
image: voipmonitor/vllm:infernal-invocation-vllm908522a-b12x5d648d9-fi1ac6942-cu133-torch213-20260813-r11
digest: sha256:01b973d1ae132882bcc1bf62ea232f6aabe649dd4a89b961d81f3c41cc53f971
checkpoint: brandonmusic/GLM-5.2-EXL3-TR3v4-3.5bpw-MTP78
revision: 9ab9579774cc432df91567a36f6e9e863e0d4c9f
configuration: TP4/DCP1/MTP3, online K6, NVFP4 DS-MLA KV,
               InstantTensor BUFFERED COPY=0, FULL decode graphs,
               MNS8, graph cap 32, max model length 65,536
```

- The 322 GiB checkpoint loaded and every mixed K3/K4/K5 routed-expert layer
  completed preparation.
- A deterministic arithmetic request returned `703` for `37 * 19`.
- Two warmed CC1/context-zero, 20-second measurements reached 131.45 and
  127.22 aggregate tok/s with zero request errors.
- No source file was mounted over the published image.

Machine-readable evidence:
https://github.com/local-inference-lab/blackwell-llm-docker/blob/6f92a9ecff35f0dabd6f444b05daab4024b49257/validation/infernal-invocation-r11-local-gpu.json

## Duplicate-work check

Open local and upstream pull requests and issues were searched for
InstantTensor borrowed-buffer ownership in deferred layerwise processing. No
overlapping implementation was found. Pull request #281 is the prerequisite
producer contract rather than a duplicate consumer-side fix.

## Qualification boundary

The E2E result qualifies the checkpoint revision and TP4/DCP1/MTP3 profile
above. Other retained consumers still require their own ownership audit; this
pull request changes only layerwise online processing.

## AI assistance

AI assistance was used for investigation, implementation, validation, and
pull-request text. The human submitter must review and be able to defend every
changed line before merge.
