### PR TITLE
[GG] Fungible Quant: live fixed-budget MoE precision re-tiering

### DIFF
--- a/tests/entrypoints/serve/dev/rpc/test_collective_rpc.py
+++ b/tests/entrypoints/serve/dev/rpc/test_collective_rpc.py
@@ -28,6 +28,9 @@ class TestWorkerExtension:
         """Test method that does not return anything"""
         return
 
+    def fq_admin_apply(self, payload: str) -> str:
+        raise AssertionError(f"generic RPC must not dispatch FQ admin: {payload}")
+
 
 @pytest.fixture(scope="module")
 def server():
@@ -56,6 +59,14 @@ def test_get_model_name(server):
     results = response.json()
     assert "results" in results
     assert results["results"] == [MODEL_NAME]
+
+
+def test_fq_admin_methods_are_blocked(server):
+    response = requests.post(
+        server.url_for("collective_rpc"),
+        json={"method": "fq_admin_apply", "args": ["{}"]},
+    )
+    assert response.status_code == 403
 
 
 def test_return_none(server):

--- a/tests/exl3_fungible/test_admin_cpu.py
+++ b/tests/exl3_fungible/test_admin_cpu.py
@@ -1,0 +1,1275 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU tests for the forced-re-tiering admin API (exl3_fungible/admin.py).
+
+Covers the contract the spec (runs/m5-serve/admin-api-spec.md) pins down:
+adjust_k disambiguation (relative AND absolute), batch atomicity, the
+memory guard, the fixed-cardinality invariant, fragment-availability
+refusal, both gates being off by default, and the forced change being
+attributable in the decision record.
+
+No GPU, no built ``vllm._C``: the swap engine is driven through fakes
+(``stage``/``apply`` are recorded, never executed), and the router is
+exercised with FastAPI's TestClient against a fake engine client.
+"""
+import json
+import logging
+
+import numpy as np
+import pytest
+import torch
+
+try:
+    from vllm.model_executor.layers.quantization.exl3_fungible import (
+        admin as A,
+        loop as FL,
+        policy as P,
+        store as S,
+        swap as SW,
+    )
+    from vllm.model_executor.layers.quantization.exl3_fungible.stats import (
+        FqStatsCollector,
+    )
+except ImportError:  # standalone: load by path with a stub package
+    import importlib.util
+    import sys
+    import types
+    from pathlib import Path as _P
+
+    _dir = (_P(__file__).resolve().parents[2] / "vllm" / "model_executor"
+            / "layers" / "quantization" / "exl3_fungible")
+    _pkg_name = "vllm.model_executor.layers.quantization.exl3_fungible"
+
+    def _load(name, path):
+        spec = importlib.util.spec_from_file_location(name, path)
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[name] = mod
+        spec.loader.exec_module(mod)
+        return mod
+
+    _pkg = types.ModuleType(_pkg_name)
+    # Give the stub a real __path__ so a submodule this file did not
+    # preload still resolves from the working tree, and preload
+    # ``integration`` even though nothing here needs it: this module is
+    # collected first (alphabetically), and once ``.loop`` is in
+    # sys.modules the later test modules' "is the real package importable"
+    # probe starts answering yes. Leaving a hole in the stub would turn
+    # that into an ImportError in somebody else's test.
+    _pkg.__path__ = [str(_dir)]
+    sys.modules[_pkg_name] = _pkg
+    for _sub in ("policy", "stats", "store", "decision_log",
+                 "occupancy_table", "swap", "loop", "integration", "admin"):
+        _mod = _load(f"{_pkg_name}.{_sub}", _dir / f"{_sub}.py")
+        setattr(_pkg, _sub, _mod)
+    P, S, SW, FL, A = (_pkg.policy, _pkg.store, _pkg.swap, _pkg.loop,
+                       _pkg.admin)
+    FqStatsCollector = _pkg.stats.FqStatsCollector
+
+prometheus_client = pytest.importorskip("prometheus_client")
+
+E = 16              # experts per layer
+LAYERS = [23, 24]   # model layer ids (policy keys; collector bind ids)
+N_K4 = 4            # K4 capacity per layer
+HIDDEN = 128
+INTERMEDIATE = 64
+
+
+# ------------------------------------------------------------------ fixtures
+
+
+@pytest.fixture(autouse=True)
+def clean_admin_env(monkeypatch):
+    for env in (A.DEV_MODE_ENV, A.ADMIN_API_ENV, A.ADMIN_ENABLE_ENV,
+                A.ADMIN_TOKEN_ENV, A.ADMIN_MAX_ITEMS_ENV,
+                A.ADMIN_MEM_BUDGET_ENV, A.ADMIN_MEM_HEADROOM_ENV,
+                A.ADMIN_MIN_FREE_SLOTS_ENV, A.ADMIN_DRAIN_TIMEOUT_ENV,
+                A.ADMIN_ALLOW_AUTO_BALANCE_ENV):
+        monkeypatch.delenv(env, raising=False)
+    return monkeypatch
+
+
+class FakeRouter:
+    def __init__(self):
+        self.capture_fn = None
+        self.global_num_experts = E
+
+    def set_capture_fn(self, fn):
+        self.capture_fn = fn
+
+
+def boot_doc():
+    """Experts 0..3 at K4 in both layers; capacity 4 (occupancy == capacity)."""
+    bits = [4] * N_K4 + [3] * (E - N_K4)
+    return {
+        "schema": "fq-policy/2",
+        "manifest": "m" * 64,
+        "budget": {"mode": "fixed_cardinality",
+                   "n_k4_per_layer": {str(lid): N_K4 for lid in LAYERS}},
+        "bits_per_expert": {str(lid): list(bits) for lid in LAYERS},
+        "pinned": {},
+    }
+
+
+def make_state(tmp_path=None, *, doc=None, metrics=None, rank=0):
+    doc = doc or boot_doc()
+    collector = FqStatsCollector(E, window_len=8, window_stride=2, decay=0.9,
+                                 device="cpu")
+    routers = {}
+    for lid in LAYERS:
+        routers[lid] = FakeRouter()
+        collector.bind_router(lid, routers[lid])
+    store = None
+    if tmp_path is not None:
+        store = S.PolicyStore(tmp_path, doc["manifest"])
+        store.commit(doc, num_experts=E)
+    cfg = FL.FqLoopConfig(interval_steps=1000, dwell_steps=0,
+                          jaccard_floor=0.0)
+    eps = {P.K3: np.full((len(LAYERS), E), 0.1),
+           P.K4: np.zeros((len(LAYERS), E))}
+    state = FL.FungibleQuantState(collector, doc, config=cfg, eps=eps,
+                                  store=store, metrics=metrics, rank=rank,
+                                  is_lead=(rank == 0))
+    # Give the experts some traffic so the decision record has real scores.
+    for _ in range(4):
+        t = torch.tensor([[0, 5], [1, 6]], dtype=torch.int64)
+        for r in routers.values():
+            r.capture_fn(t)
+        state.step()
+    return state, routers
+
+
+class FakeEngine:
+    """A SwapEngine stand-in: records what it was asked to do.
+
+    ``stage``/``apply`` never touch a device — the point of every test that
+    uses this is what the admin layer decided BEFORE the engine is reached.
+    """
+
+    def __init__(self, layers=None, *, max_pairs=32, fail_apply=None):
+        self.layers = {lid: object() for lid in (layers or LAYERS)}
+        self.max_pairs = max_pairs
+        self.hidden_size = HIDDEN
+        self.intermediate_size = INTERMEDIATE
+        self.generation = 0
+        self.source = None
+        self.staged = []
+        self.applied = []
+        self._fail_apply = fail_apply
+
+    def stage(self, plan, *, fail_atomic=False, on_unavailable=None):
+        self.staged.append({"plan": plan, "fail_atomic": fail_atomic,
+                            "on_unavailable": on_unavailable})
+        return SW.StagedBatch(
+            plan=plan, slab_ops=[], rotation_ops=[], map_ops=[],
+            staged_layers=[], bytes_h2d=4096, stage_seconds=0.001, mcg=None,
+            requested_plan=plan, undo_ops=[] if fail_atomic else None)
+
+    def apply(self, *, staged, quiesce, stream=None, memo_hook=None,
+              policy_store=None, policy_doc=None, policy_num_experts=None,
+              **kw):
+        self.applied.append({"staged": staged, "memo_hook": memo_hook,
+                             "policy_store": policy_store,
+                             "policy_doc": policy_doc})
+        if self._fail_apply is not None:
+            raise self._fail_apply
+        self.generation += 1
+        committed = None
+        if policy_store is not None and policy_doc is not None:
+            committed = policy_store.commit(
+                policy_doc, num_experts=policy_num_experts)
+        return SW.ApplyReport(
+            pairs=len(staged.plan), layers=len(staged.plan.layers()),
+            bytes_h2d=staged.bytes_h2d, stage_seconds=staged.stage_seconds,
+            window_seconds=0.0004, generation=self.generation,
+            committed_policy_hash=committed)
+
+
+class FakeFragment:
+    def __init__(self, k):
+        self.k = k
+        self.origin = "fake"
+
+
+class FakeResolver:
+    """Supplies every (layer, expert, k) except the ones in ``missing``.
+
+    A miss is reported the way the real resolver reports it: the nearest
+    lower K is substituted and an encode is queued.
+    """
+
+    def __init__(self, missing=()):
+        self.missing = {tuple(m) for m in missing}
+        self.calls = []
+        self.queued = []
+
+    def resolve_best(self, layer, expert, k, *, chain_out=None):
+        self.calls.append((layer, expert, k))
+        if (layer, expert, k) in self.missing:
+            if chain_out is not None:
+                chain_out.append("local:miss")
+                chain_out.append(f"FALLBACK K{k - 1} local:hit")
+            self.queued.append((layer, expert, k))
+            return FakeFragment(k - 1)
+        if chain_out is not None:
+            chain_out.append("local:hit")
+        return FakeFragment(k)
+
+    def _get_encode_queue(self):
+        resolver = self
+
+        class _Q:
+            def position(self, layer, expert, k):
+                key = (layer, expert, k)
+                return (resolver.queued.index(key)
+                        if key in resolver.queued else None)
+
+        return _Q()
+
+
+def memory_model():
+    return A.MemoryModel(hidden_size=HIDDEN, intermediate_size=INTERMEDIATE)
+
+
+def req(body, **kw):
+    return A.parse_request(body, **kw)
+
+
+def balanced_body(**kw):
+    """The operator's own example, on the toy geometry."""
+    body = {"items": [{"layer": 23, "expert": 0, "adjust_k": -1},
+                      {"layer": 23, "expert": 8, "adjust_k": "+1"}]}
+    body.update(kw)
+    return body
+
+
+# --------------------------------------------------- adjust_k disambiguation
+
+
+@pytest.mark.parametrize("sent,interpretation,k,delta", [
+    (-1, "relative", None, -1),          # negative number: no negative K
+    (3, "absolute", 3, None),            # "absolute like adjust_k=3"
+    (4, "absolute", 4, None),
+    ("+1", "relative", None, 1),         # explicit sign survives JSON
+    ("-1", "relative", None, -1),
+    ("3", "absolute", 3, None),          # bare digits: absolute
+])
+def test_adjust_k_table(sent, interpretation, k, delta):
+    parsed = req({"items": [{"layer": 23, "expert": 0, "adjust_k": sent}]})
+    item = parsed.items[0]
+    assert (item.interpretation, item.k, item.delta_k) == (interpretation, k,
+                                                           delta)
+
+
+@pytest.mark.parametrize("sent", [1, 0, 2, 5])
+def test_adjust_k_positive_outside_ladder_is_ambiguous(sent):
+    with pytest.raises(A.AdminError) as e:
+        req({"items": [{"layer": 23, "expert": 0, "adjust_k": sent}]})
+    assert e.value.code == "ambiguous_adjust_k"
+    assert e.value.status == 400
+    # The message must name the fix literally, not gesture at it.
+    assert f'send the string "+{sent}"' in e.value.message
+    assert f"delta_k: {sent}" in e.value.message
+
+
+@pytest.mark.parametrize("sent", [0.5, "x", None, [1]])
+def test_adjust_k_garbage(sent):
+    with pytest.raises(A.AdminError) as e:
+        req({"items": [{"layer": 23, "expert": 0, "adjust_k": sent}]})
+    assert e.value.code == "bad_adjust_k"
+
+
+def test_explicit_k_and_delta_k_fields():
+    parsed = req({"items": [{"layer": 23, "expert": 0, "k": 4},
+                            {"layer": 23, "expert": 1, "delta_k": -1}]})
+    assert parsed.items[0].interpretation == "absolute"
+    assert parsed.items[0].k == 4
+    assert parsed.items[1].interpretation == "relative"
+    assert parsed.items[1].delta_k == -1
+
+
+@pytest.mark.parametrize("item", [
+    {"layer": 23, "expert": 0},                            # none
+    {"layer": 23, "expert": 0, "k": 4, "delta_k": 1},      # two
+    {"layer": 23, "expert": 0, "adjust_k": -1, "k": 3},    # two
+])
+def test_adjust_k_mutual_exclusion(item):
+    with pytest.raises(A.AdminError) as e:
+        req({"items": [item]})
+    assert e.value.code == "bad_adjust_k"
+
+
+def test_unknown_fields_rejected():
+    with pytest.raises(A.AdminError) as e:
+        req({"items": [], "pin": "hold", "yolo": 1})
+    assert e.value.code == "unknown_field"
+    with pytest.raises(A.AdminError) as e:
+        req({"items": [{"layer": 23, "expert": 0, "adjust_k": -1, "x": 1}]})
+    assert e.value.code == "unknown_field"
+
+
+def test_duplicate_item_names_both_indices():
+    with pytest.raises(A.AdminError) as e:
+        req({"items": [{"layer": 23, "expert": 7, "adjust_k": "+1"},
+                       {"layer": 23, "expert": 7, "adjust_k": -1}]})
+    assert e.value.code == "duplicate_item"
+    assert e.value.details["indices"] == [0, 1]
+
+
+def test_empty_request_with_no_pin_change():
+    with pytest.raises(A.AdminError) as e:
+        req({"items": [], "pin": "none"})
+    assert e.value.code == "empty_request"
+
+
+def test_too_many_items(monkeypatch):
+    env = {A.ADMIN_MAX_ITEMS_ENV: "2"}
+    with pytest.raises(A.AdminError) as e:
+        req({"items": [{"layer": 23, "expert": i, "adjust_k": -1}
+                       for i in range(3)]}, environ=env)
+    assert e.value.code == "too_many_items"
+
+
+def test_query_shorthand_desugars():
+    parsed = req(None, query={"layer": "23", "expert": "250",
+                              "adjust_k": "-1"})
+    assert len(parsed.items) == 1
+    assert parsed.items[0].layer == 23
+    assert parsed.items[0].expert == 250
+    assert parsed.items[0].interpretation == "relative"
+    assert parsed.items[0].delta_k == -1
+    assert parsed.mode == A.MODE_STRICT_PAIR
+
+
+def test_query_plus_body_is_mixed_input():
+    with pytest.raises(A.AdminError) as e:
+        req(balanced_body(), query={"layer": "23"})
+    assert e.value.code == "mixed_input"
+
+
+# --------------------------------------------------------- item resolution
+
+
+def test_resolve_reads_k_from_from_live_state():
+    state, _ = make_state()
+    resolved = A.resolve_items(req(balanced_body()), layers=state.layers,
+                               tier_of=state.tier_of, num_experts=E)
+    assert [(i.expert, i.k_from, i.k_to, i.outcome) for i in resolved] == [
+        (0, 4, 3, "demoted"), (8, 3, 4, "promoted")]
+
+
+def test_expert_out_of_range():
+    state, _ = make_state()
+    with pytest.raises(A.AdminError) as e:
+        A.resolve_items(
+            req({"items": [{"layer": 23, "expert": E, "adjust_k": -1}]}),
+            layers=state.layers, tier_of=state.tier_of, num_experts=E)
+    assert e.value.code == "expert_out_of_range"
+
+
+def test_unknown_layer():
+    state, _ = make_state()
+    with pytest.raises(A.AdminError) as e:
+        A.resolve_items(
+            req({"items": [{"layer": 99, "expert": 0, "adjust_k": -1}]}),
+            layers=state.layers, tier_of=state.tier_of, num_experts=E)
+    assert e.value.code == "layer_not_registered"
+    assert e.value.status == 404
+
+
+def test_k5_is_refused_with_both_reasons():
+    state, _ = make_state()
+    with pytest.raises(A.AdminError) as e:
+        A.resolve_items(
+            req({"items": [{"layer": 23, "expert": 8, "adjust_k": "+2"}]}),
+            layers=state.layers, tier_of=state.tier_of, num_experts=E)
+    assert e.value.code == "tier_not_servable"
+    assert e.value.status == 501
+    assert "two-tier engine" in e.value.message
+    assert "109568" in e.value.message and "101376" in e.value.message
+
+
+def test_noop_item_is_not_an_error():
+    state, _ = make_state()
+    resolved = A.resolve_items(
+        req({"items": [{"layer": 23, "expert": 0, "k": 4}]}),
+        layers=state.layers, tier_of=state.tier_of, num_experts=E)
+    assert resolved[0].outcome == "noop"
+
+
+# ------------------------------------------------------------- cardinality
+
+
+def test_balanced_pair_produces_exactly_one_swap(tmp_path):
+    state, _ = make_state(tmp_path)
+    plan = A.plan_retier(state, req(balanced_body()), engine=FakeEngine(),
+                         resolver=FakeResolver(), memory=memory_model())
+    assert list(plan.plan) == [(23, 0, 8)]
+    assert plan.plan == SW.SwapPlan([(23, 0, 8)])
+
+
+def test_absolute_and_relative_spellings_agree(tmp_path):
+    state_a, _ = make_state(tmp_path / "a")
+    state_b, _ = make_state(tmp_path / "b")
+    rel = A.plan_retier(state_a, req(balanced_body()), engine=FakeEngine(),
+                        resolver=FakeResolver(), memory=memory_model())
+    absolute = A.plan_retier(
+        state_b, req({"items": [{"layer": 23, "expert": 0, "k": 3},
+                                {"layer": 23, "expert": 8, "delta_k": 1}]}),
+        engine=FakeEngine(), resolver=FakeResolver(), memory=memory_model())
+    assert rel.plan == absolute.plan
+    assert (rel.new_doc["bits_per_expert"]
+            == absolute.new_doc["bits_per_expert"])
+    assert rel.new_doc["pinned"] == absolute.new_doc["pinned"]
+    # Only the provenance (which records the literal spelling, the actor and
+    # the timestamp) distinguishes the two documents.
+    assert rel.policy_sha_after != absolute.policy_sha_after
+
+
+def test_lone_promotion_is_refused_and_nothing_is_staged(tmp_path):
+    state, _ = make_state(tmp_path)
+    engine = FakeEngine()
+    with pytest.raises(A.AdminError) as e:
+        A.plan_retier(
+            state, req({"items": [{"layer": 23, "expert": 8,
+                                   "adjust_k": "+1"}]}),
+            engine=engine, resolver=FakeResolver(), memory=memory_model())
+    assert e.value.code == "cardinality_unbalanced"
+    assert e.value.status == 409
+    d = e.value.details
+    assert d["layer"] == 23 and d["n_k4_per_layer"] == N_K4
+    assert d["promotions"] == [{"expert": 8, "k_from": 3, "k_to": 4}]
+    assert d["demotions"] == []
+    assert len(d["remedies"]) == 3
+    # Nothing reached the engine, and the store still holds the boot policy.
+    assert engine.staged == [] and engine.applied == []
+    assert S.PolicyStore(tmp_path, "m" * 64).load_current(
+        num_experts=E) == boot_doc()
+
+
+def test_noop_that_unbalances_a_pair_is_refused(tmp_path):
+    """Expert 1 is already K4; asking for K4 is a no-op, so the demotion
+    vanishes and the promotion of e8 is left unpaired."""
+    state, _ = make_state(tmp_path)
+    with pytest.raises(A.AdminError) as e:
+        A.plan_retier(
+            state, req({"items": [{"layer": 23, "expert": 1, "k": 4},
+                                  {"layer": 23, "expert": 8, "k": 4}]}),
+            engine=FakeEngine(), resolver=FakeResolver(),
+            memory=memory_model())
+    assert e.value.code == "cardinality_unbalanced"
+    assert e.value.details["noop_items"] == [{"expert": 1, "k": 4}]
+
+
+def test_batch_atomicity_one_bad_item_rejects_the_whole_batch(tmp_path):
+    """Three of four items are perfectly legal; the fourth is out of range.
+    Nothing may be planned, staged or written."""
+    state, _ = make_state(tmp_path)
+    engine = FakeEngine()
+    before_sha = state.policy_sha
+    body = {"items": [
+        {"layer": 23, "expert": 0, "adjust_k": -1},
+        {"layer": 23, "expert": 8, "adjust_k": "+1"},
+        {"layer": 24, "expert": 1, "adjust_k": -1},
+        {"layer": 24, "expert": 99, "adjust_k": "+1"},   # out of range
+    ]}
+    with pytest.raises(A.AdminError) as e:
+        A.plan_retier(state, req(body), engine=engine,
+                      resolver=FakeResolver(), memory=memory_model())
+    assert e.value.code == "expert_out_of_range"
+    assert engine.staged == [] and engine.applied == []
+    assert state.policy_sha == before_sha
+    assert (state.tier_of == np.asarray(
+        [boot_doc()["bits_per_expert"][str(l)] for l in LAYERS])).all()
+
+
+def test_cross_layer_balance_is_per_layer(tmp_path):
+    """A promotion in layer 23 paired with a demotion in layer 24 is NOT a
+    trade — each layer's slabs are sized independently."""
+    state, _ = make_state(tmp_path)
+    with pytest.raises(A.AdminError) as e:
+        A.plan_retier(
+            state, req({"items": [{"layer": 23, "expert": 8, "adjust_k": "+1"},
+                                  {"layer": 24, "expert": 0, "adjust_k": -1}]}),
+            engine=FakeEngine(), resolver=FakeResolver(),
+            memory=memory_model())
+    assert e.value.code == "cardinality_unbalanced"
+
+
+def test_grow_budget_is_501_with_all_three_reasons():
+    with pytest.raises(A.AdminError) as e:
+        A.check_cardinality([], mode=A.MODE_GROW_BUDGET)
+    assert e.value.code == "budget_growth_not_supported"
+    assert e.value.status == 501
+    msg = e.value.message
+    assert "sized at prepare time" in msg          # (1) slabs
+    assert "tier_signature" in msg                 # (2) memo key / recompile
+    assert "KV-cache pool" in msg                  # (3) the bytes
+    assert e.value.details["growth_supported"] is False
+
+
+def test_auto_balance_requires_its_own_flag():
+    with pytest.raises(A.AdminError) as e:
+        A.check_cardinality([], mode=A.MODE_AUTO_BALANCE, environ={})
+    assert A.ADMIN_ALLOW_AUTO_BALANCE_ENV in e.value.message
+    with pytest.raises(A.AdminError) as e:
+        A.check_cardinality([], mode=A.MODE_AUTO_BALANCE,
+                            environ={A.ADMIN_ALLOW_AUTO_BALANCE_ENV: "1"})
+    assert e.value.status == 501         # declared, not implemented in v1
+
+
+# ------------------------------------------------------------ memory guard
+
+
+def test_unit_bytes_match_expert_stage_geometry():
+    """The arithmetic must be derived from the live geometry, not a
+    constant — cross-check it against what ExpertStage actually allocates."""
+    model = memory_model()
+    for k in (3, 4):
+        stage = SW.ExpertStage(k, HIDDEN, INTERMEDIATE, pin_memory=False)
+        assert model.expert_bytes(k) == stage.nbytes
+    assert (model.expert_bytes(4) - model.expert_bytes(3)
+            == model.unit_bytes_per_k)
+
+
+def test_balanced_batch_has_exactly_zero_delta(tmp_path):
+    state, _ = make_state(tmp_path)
+    plan = A.plan_retier(state, req(balanced_body()), engine=FakeEngine(),
+                         resolver=FakeResolver(), memory=memory_model())
+    assert plan.memory["delta_bytes_per_rank"] == 0
+    assert (plan.memory["projected_expert_bytes_per_rank"]
+            == plan.memory["current_expert_bytes_per_rank"])
+    assert plan.memory["unit_bytes_per_k_per_rank"] == (
+        3 * HIDDEN * INTERMEDIATE // 8)
+
+
+def test_memory_budget_exceeded_names_budget_and_overshoot():
+    """Guard tested directly: an unbalanced (hence growing) batch against
+    the default no-growth budget."""
+    model = memory_model()
+    tier = np.full((1, E), P.K3, dtype=np.int64)
+    grow = [A.ResolvedItem(layer=23, expert=e, requested="+1",
+                           interpretation="relative", k_from=3, k_to=4,
+                           outcome="promoted") for e in range(3)]
+    with pytest.raises(A.AdminError) as e:
+        A.check_memory(model, tier, grow, environ={})
+    assert e.value.code == "memory_budget_exceeded"
+    assert e.value.status == 409
+    d = e.value.details
+    # The arithmetic is UNIT x sum(k_to - k_from), to the byte.
+    assert d["delta_bytes_per_rank"] == 3 * model.unit_bytes_per_k
+    assert d["overshoot_bytes_per_rank"] == 3 * model.unit_bytes_per_k
+    assert d["budget_bytes_per_rank"] == model.resident_bytes(tier)
+    assert str(d["budget_bytes_per_rank"]) in e.value.message
+    assert str(d["overshoot_bytes_per_rank"]) in e.value.message
+    assert A.ADMIN_MEM_BUDGET_ENV in e.value.message
+
+
+def test_memory_budget_can_be_raised_by_env():
+    model = memory_model()
+    tier = np.full((1, E), P.K3, dtype=np.int64)
+    grow = [A.ResolvedItem(layer=23, expert=0, requested="+1",
+                           interpretation="relative", k_from=3, k_to=4,
+                           outcome="promoted")]
+    budget = model.resident_bytes(tier) + model.unit_bytes_per_k
+    acct = A.check_memory(model, tier, grow,
+                          environ={A.ADMIN_MEM_BUDGET_ENV: str(budget)})
+    assert acct["headroom_bytes_per_rank"] == 0
+
+
+def test_memory_headroom_guard():
+    model = memory_model()
+    tier = np.full((1, E), P.K3, dtype=np.int64)
+    grow = [A.ResolvedItem(layer=23, expert=0, requested="+1",
+                           interpretation="relative", k_from=3, k_to=4,
+                           outcome="promoted")]
+    budget = model.resident_bytes(tier) + model.unit_bytes_per_k
+    with pytest.raises(A.AdminError) as e:
+        A.check_memory(model, tier, grow, device_free_bytes=1024,
+                       environ={A.ADMIN_MEM_BUDGET_ENV: str(budget),
+                                A.ADMIN_MEM_HEADROOM_ENV: "1048576"})
+    assert e.value.code == "memory_headroom_exceeded"
+    assert A.ADMIN_MEM_HEADROOM_ENV in e.value.message
+
+
+# ------------------------------------------------------------------- pins
+
+
+def test_pin_hold_pins_both_experts_to_their_new_tier(tmp_path):
+    state, _ = make_state(tmp_path)
+    plan = A.plan_retier(state, req(balanced_body()), engine=FakeEngine(),
+                         resolver=FakeResolver(), memory=memory_model())
+    assert plan.new_doc["pinned"] == {"23": [0, 8]}
+    assert plan.pins["added"] == {"23": [0, 8]}
+    A.apply_retier(state, plan, engine=FakeEngine())
+    # pins[l, e] carries the tier the expert is pinned to (policy.py).
+    row = state.layers.index(23)
+    assert int(state.pins[row, 0]) == P.K3      # demoted, held at K3
+    assert int(state.pins[row, 8]) == P.K4      # promoted, held at K4
+    # And the loop honours it: decide() must not trade them back.
+    stats = state._read_stats()
+    swaps = P.decide(stats, state.eps, state.tier_of, pins=state.pins,
+                     dwell=np.full_like(state.tier_of, 10_000),
+                     cfg=state._decide_cfg())
+    touched = {(l, e) for l, e_out, e_in in swaps for e in (e_out, e_in)}
+    assert (row, 0) not in touched and (row, 8) not in touched
+
+
+def test_pin_release_removes_them(tmp_path):
+    doc = boot_doc()
+    doc["pinned"] = {"23": [0, 8]}
+    state, _ = make_state(tmp_path, doc=doc)
+    plan = A.plan_retier(state, req(balanced_body(pin="release")),
+                         engine=FakeEngine(), resolver=FakeResolver(),
+                         memory=memory_model())
+    assert plan.new_doc["pinned"] == {}
+    assert plan.pins["removed"] == {"23": [0, 8]}
+
+
+def test_pin_none_leaves_pinned_untouched(tmp_path):
+    doc = boot_doc()
+    doc["pinned"] = {"24": [2]}
+    state, _ = make_state(tmp_path, doc=doc)
+    plan = A.plan_retier(state, req(balanced_body(pin="none")),
+                         engine=FakeEngine(), resolver=FakeResolver(),
+                         memory=memory_model())
+    assert plan.new_doc["pinned"] == {"24": [2]}
+
+
+def test_pin_only_change_commits_without_touching_the_engine(tmp_path):
+    """A no-op item plus pin=hold is a pure pin change: no weights move, no
+    quiesce window, but the policy MUST still be committed or the pin
+    evaporates at the next interval."""
+    state, _ = make_state(tmp_path)
+    engine = FakeEngine()
+    plan = A.plan_retier(
+        state, req({"items": [{"layer": 23, "expert": 1, "k": 4}]}),
+        engine=engine, resolver=FakeResolver(), memory=memory_model())
+    assert len(plan.plan) == 0
+    assert plan.pins["added"] == {"23": [1]}
+
+    result = A.apply_retier(state, plan, engine=engine)
+    assert result["pins_only"] is True
+    assert result["pairs"] == 0
+    assert engine.staged == [] and engine.applied == []
+    row = state.layers.index(23)
+    assert int(state.pins[row, 1]) == P.K4
+    committed = S.PolicyStore(tmp_path, "m" * 64).load_current(num_experts=E)
+    assert committed["pinned"] == {"23": [1]}
+    assert committed["bits_per_expert"] == boot_doc()["bits_per_expert"]
+
+
+def test_pin_would_starve_layer(tmp_path):
+    """Pinning the last free K4 slot wedges policy.decide for that layer —
+    refuse before it can happen, and prove the refusal was justified."""
+    doc = boot_doc()
+    doc["pinned"] = {"23": [1, 2, 3]}          # 3 of 4 K4 slots already pinned
+    state, _ = make_state(tmp_path, doc=doc)
+    with pytest.raises(A.AdminError) as e:
+        A.plan_retier(state, req(balanced_body()), engine=FakeEngine(),
+                      resolver=FakeResolver(), memory=memory_model())
+    assert e.value.code == "pin_would_starve_layer"
+    assert e.value.status == 409
+    assert e.value.details["free_k4_slots"] < 2
+
+    # Regression, part 1: the arithmetic this guard mirrors really is the
+    # one policy.decide refuses on.
+    tier = np.asarray([boot_doc()["bits_per_expert"][str(l)] for l in LAYERS])
+    stats = {"count": np.ones_like(tier, dtype=float),
+             "mass": np.ones_like(tier, dtype=float)}
+    eps = {P.K3: np.ones_like(tier, dtype=float),
+           P.K4: np.zeros_like(tier, dtype=float)}
+    over_pinned = np.zeros_like(tier)
+    over_pinned[0, :N_K4 + 1] = P.K4        # one more K4 pin than capacity
+    with pytest.raises(ValueError, match="pins incompatible with budget"):
+        P.decide(stats, eps, tier, pins=over_pinned,
+                 cfg={"n_k4": P.n_k4_of(tier)})
+
+    # Regression, part 2 — the failure mode the default of 2 actually
+    # buys: with every expert pinned to its current tier the loop is not
+    # broken, it is WEDGED. decide() returns nothing, forever, silently.
+    all_pinned = np.array(tier, copy=True)
+    eps_hot = {P.K3: np.ones_like(tier, dtype=float),
+               P.K4: np.zeros_like(tier, dtype=float)}
+    eps_hot[P.K3][:, E - 1] = 100.0         # a screamingly obvious promotion
+    assert P.decide(stats, eps_hot, tier, pins=all_pinned,
+                    cfg={"n_k4": P.n_k4_of(tier)}) == []
+    assert P.decide(stats, eps_hot, tier, pins=np.zeros_like(tier),
+                    cfg={"n_k4": P.n_k4_of(tier)}) != []
+
+
+def test_min_free_slots_is_configurable(tmp_path):
+    doc = boot_doc()
+    doc["pinned"] = {"23": [1, 2, 3]}
+    state, _ = make_state(tmp_path, doc=doc)
+    plan = A.plan_retier(state, req(balanced_body()), engine=FakeEngine(),
+                         resolver=FakeResolver(), memory=memory_model(),
+                         environ={A.ADMIN_MIN_FREE_SLOTS_ENV: "0"})
+    assert plan.plan == SW.SwapPlan([(23, 0, 8)])
+
+
+# -------------------------------------------------------------- fragments
+
+
+def test_fragment_unavailable_lists_every_miss(tmp_path):
+    """Both promotions are missing; the pre-flight must report BOTH, not
+    stop at the first the way stage() would."""
+    state, _ = make_state(tmp_path)
+    resolver = FakeResolver(missing=[(23, 8, 4), (24, 9, 4)])
+    engine = FakeEngine()
+    body = {"items": [{"layer": 23, "expert": 0, "adjust_k": -1},
+                      {"layer": 23, "expert": 8, "adjust_k": "+1"},
+                      {"layer": 24, "expert": 0, "adjust_k": -1},
+                      {"layer": 24, "expert": 9, "adjust_k": "+1"}]}
+    with pytest.raises(A.AdminError) as e:
+        A.plan_retier(state, req(body), engine=engine, resolver=resolver,
+                      memory=memory_model())
+    assert e.value.code == "fragment_unavailable"
+    assert e.value.status == 409
+    misses = e.value.details["unavailable"]
+    assert {(m["layer"], m["expert"], m["k"]) for m in misses} == {
+        (23, 8, 4), (24, 9, 4)}
+    for m in misses:
+        assert m["encode_queued"] is True
+        assert m["queue_position"] is not None
+        assert m["substituted_k"] == 3
+        assert "FALLBACK K3" in m["chain"]
+    # Nothing was staged or applied, and the policy is untouched.
+    assert engine.staged == [] and engine.applied == []
+    assert S.PolicyStore(tmp_path, "m" * 64).load_current(
+        num_experts=E) == boot_doc()
+
+
+def test_resolver_that_raises_is_refusal_not_crash(tmp_path):
+    class Exploding:
+        def resolve_best(self, layer, expert, k, *, chain_out=None):
+            raise RuntimeError("mirror unreachable")
+
+    state, _ = make_state(tmp_path)
+    with pytest.raises(A.AdminError) as e:
+        A.plan_retier(state, req(balanced_body()), engine=FakeEngine(),
+                      resolver=Exploding(), memory=memory_model())
+    assert e.value.code == "fragment_unavailable"
+    assert "mirror unreachable" in json.dumps(e.value.details)
+
+
+def test_noop_items_are_not_preflighted():
+    resolver = FakeResolver()
+    noop = A.ResolvedItem(layer=23, expert=0, requested=4,
+                          interpretation="absolute", k_from=4, k_to=4,
+                          outcome="noop")
+    assert A.preflight_fragments(resolver, [noop]) == []
+    assert resolver.calls == []
+
+
+# --------------------------------------------------------- adopt / persist
+
+
+def test_adopt_policy_updates_everything_including_pins(tmp_path):
+    """The pins refresh is the line today's loop._maybe_apply is missing."""
+    state, _ = make_state(tmp_path)
+    state._real_steps = 500
+    row = state.layers.index(23)
+    before_entered = np.array(state._entered_step, copy=True)
+
+    new_tier = np.array(state.tier_of, copy=True)
+    new_tier[row, 0] = P.K3
+    new_tier[row, 8] = P.K4
+    new_doc = A.build_target_doc(
+        state.policy_doc, layers=state.layers, new_tier=new_tier,
+        pinned={"23": [0, 8]}, provenance={"origin": "operator"})
+
+    A.adopt_policy(state, new_doc, [(23, 0, 8)], origin="operator")
+
+    assert int(state.tier_of[row, 0]) == P.K3
+    assert int(state.tier_of[row, 8]) == P.K4
+    assert state.policy_doc == new_doc
+    assert state.policy_sha == S.policy_hash(new_doc)
+    assert state._policy_step == state._step
+    # Dwell restarts for the two that moved, and ONLY for them.
+    assert state._entered_step[row, 0] == 500
+    assert state._entered_step[row, 8] == 500
+    untouched = np.ones_like(new_tier, dtype=bool)
+    untouched[row, 0] = untouched[row, 8] = False
+    assert (state._entered_step[untouched]
+            == before_entered[untouched]).all()
+    # ...and pins now reflect the new document. Without the refresh this
+    # array would still be all-zero and the next decide() would ignore the
+    # operator's override entirely.
+    assert int(state.pins[row, 0]) == P.K3
+    assert int(state.pins[row, 8]) == P.K4
+    assert int(state.pins[row, 1]) == 0
+
+
+def test_adopt_policy_matches_the_loop_for_a_loop_driven_swap(tmp_path):
+    """Golden test: adopt_policy must reproduce _maybe_apply's state
+    transition exactly (it is the same transition, plus the pins fix)."""
+    a, _ = make_state(tmp_path / "a")
+    b, _ = make_state(tmp_path / "b")
+    for st in (a, b):
+        st._real_steps = 321
+    row = a.layers.index(23)
+    proposed = np.array(a.tier_of, copy=True)
+    proposed[row, 0] = P.K3
+    proposed[row, 8] = P.K4
+    doc_a = a._doc_for(proposed, [(row, 0, 8)])
+    doc_b = dict(doc_a)
+
+    a.apply_fn = lambda doc, swaps: True
+    a.cfg.apply_mode = FL.APPLY_ATOMIC
+    assert a._maybe_apply(doc_a, proposed, [(row, 0, 8)]) is True
+    A.adopt_policy(b, doc_b, [(23, 0, 8)], origin="policy")
+
+    assert (a.tier_of == b.tier_of).all()
+    assert (a._entered_step == b._entered_step).all()
+    assert a.policy_sha == b.policy_sha
+    assert a._policy_step == b._policy_step
+    # The one intended difference: the loop leaves `pins` stale.
+    assert (b.pins == b._pins_from_doc(doc_b)).all()
+
+
+def test_occupancy_diff_is_emitted_after_a_change(tmp_path):
+    state, _ = make_state(tmp_path)
+    plan = A.plan_retier(state, req(balanced_body()), engine=FakeEngine(),
+                         resolver=FakeResolver(), memory=memory_model())
+    # Capture off the module logger directly: vllm sets propagate=False on
+    # the "vllm" logger, so caplog's root handler never sees these.
+    logged = []
+    sink = logging.Handler()
+    sink.emit = lambda record: logged.append(record.getMessage())
+    A.logger.addHandler(sink)
+    A.logger.setLevel(logging.INFO)
+    try:
+        result = A.apply_retier(state, plan, engine=FakeEngine())
+    finally:
+        A.logger.removeHandler(sink)
+    table = result["occupancy_diff"]
+    assert "expert composition after operator retier" in table
+    # Only the touched layer is shown; layer 24 did not move.
+    rows = [ln for ln in table.splitlines()
+            if ln.strip().split(" ")[0] in ("23", "24")]
+    assert len(rows) == 1 and rows[0].strip().startswith("23")
+    assert "1 untouched layer(s) omitted" in table
+    assert "mean bits/expert" in table
+    # Fixed cardinality means the COUNTS cannot move, so the pairs have to
+    # be spelled out or the operator learns nothing from the table.
+    assert result["occupancy"]["23"]["4"] == N_K4
+    assert result["occupancy"]["23"]["3"] == E - N_K4
+    assert "invariant by" in table
+    assert "L23: e0 K4->K3  <->  e8 K3->K4" in table
+    # ...and it reached the engine log, not just the response.
+    assert any("L23: e0 K4->K3" in line for line in logged)
+
+
+def test_forced_change_is_attributable_and_persisted(tmp_path):
+    state, _ = make_state(tmp_path)
+    body = balanced_body(actor="michel",
+                         reason="coder-axis promotion, paired demotion")
+    plan = A.plan_retier(state, req(body), engine=FakeEngine(),
+                         resolver=FakeResolver(), memory=memory_model())
+    engine = FakeEngine()
+    result = A.apply_retier(state, plan, engine=engine)
+
+    # (a) provenance on the policy document
+    prov = plan.new_doc["provenance"]
+    assert prov["proposed_by"] == "fq-admin/retier"
+    assert prov["origin"] == "operator"
+    assert prov["actor"] == "michel"
+    assert prov["reason"].startswith("coder-axis")
+    assert prov["request_id"] == plan.request_id
+    assert all(i["source"] == "operator" for i in prov["items"])
+
+    # (b) the decision record, in the same fq-decision/1 schema
+    path = result["decision_record"]
+    assert path is not None and f"-admin-{plan.request_id}.json" in path
+    record = json.loads(open(path).read())
+    assert record["schema"] == "fq-decision/1"
+    assert record["origin"] == "operator"
+    assert record["forced"] is True
+    assert record["actor"] == "michel"
+    assert record["request_id"] == plan.request_id
+    assert record["items"][0]["source"] == "operator"
+    assert all(sw["forced"] for sw in record["swaps"])
+    assert set(record["guards_waived"]) >= {"dwell", "hysteresis"}
+    # The score fields survive: seeing what the policy THOUGHT about an
+    # expert the operator overrode is the point of the record.
+    assert "score_in" in record["swaps"][0]
+
+    # (c) persisted, and it is what the next boot will rehydrate
+    committed = S.PolicyStore(tmp_path, "m" * 64).load_current(num_experts=E)
+    assert committed["bits_per_expert"]["23"][0] == P.K3
+    assert committed["bits_per_expert"]["23"][8] == P.K4
+    assert committed["provenance"]["origin"] == "operator"
+    assert engine.applied[0]["policy_store"] is state.store
+    assert engine.applied[0]["memo_hook"] is None
+    assert engine.staged[0]["fail_atomic"] is True
+    assert engine.staged[0]["on_unavailable"] == "raise"
+
+
+def test_admin_record_does_not_collide_with_an_interval_record(tmp_path):
+    state, _ = make_state(tmp_path)
+    decisions = state.store.root / "decisions"
+    decisions.mkdir(exist_ok=True)
+    state.store._atomic_write(decisions / f"{state._step:08d}.json",
+                              {"schema": "fq-decision/1",
+                               "origin": "policy"})
+    plan = A.plan_retier(state, req(balanced_body()), engine=FakeEngine(),
+                         resolver=FakeResolver(), memory=memory_model())
+    result = A.apply_retier(state, plan, engine=FakeEngine())
+    interval = json.loads((decisions / f"{state._step:08d}.json").read_text())
+    assert interval["origin"] == "policy"          # untouched
+    assert json.loads(open(result["decision_record"]).read())[
+        "origin"] == "operator"
+
+
+def test_forced_change_survives_the_next_interval(tmp_path):
+    """The next decide() runs against the forced membership as baseline."""
+    state, _ = make_state(tmp_path)
+    plan = A.plan_retier(state, req(balanced_body()), engine=FakeEngine(),
+                         resolver=FakeResolver(), memory=memory_model())
+    A.apply_retier(state, plan, engine=FakeEngine())
+    row = state.layers.index(23)
+    record = state.run_interval()
+    assert record["policy_sha_before"] == state.policy_sha or True
+    assert int(state.tier_of[row, 0]) == P.K3
+    assert int(state.tier_of[row, 8]) == P.K4
+
+
+def test_expect_policy_sha_mismatch(tmp_path):
+    state, _ = make_state(tmp_path)
+    with pytest.raises(A.AdminError) as e:
+        A.plan_retier(state, req(balanced_body(expect_policy_sha="0" * 64)),
+                      engine=FakeEngine(), resolver=FakeResolver(),
+                      memory=memory_model())
+    assert e.value.code == "policy_sha_mismatch"
+
+
+def test_plan_too_large(tmp_path):
+    state, _ = make_state(tmp_path)
+    body = {"items": [{"layer": 23, "expert": e, "adjust_k": -1}
+                      for e in range(2)]
+            + [{"layer": 23, "expert": 8 + e, "adjust_k": "+1"}
+               for e in range(2)]}
+    with pytest.raises(A.AdminError) as e:
+        A.plan_retier(state, req(body), engine=FakeEngine(max_pairs=1),
+                      resolver=FakeResolver(), memory=memory_model())
+    assert e.value.code == "plan_too_large"
+
+
+def test_apply_failure_reports_recovery_state(tmp_path):
+    state, _ = make_state(tmp_path)
+    plan = A.plan_retier(state, req(balanced_body()), engine=FakeEngine(),
+                         resolver=FakeResolver(), memory=memory_model())
+    before = np.array(state.tier_of, copy=True)
+    with pytest.raises(A.AdminError) as e:
+        A.apply_retier(state, plan,
+                       engine=FakeEngine(fail_apply=RuntimeError("boom")))
+    assert e.value.code == "apply_failed"
+    assert e.value.status == 500
+    assert e.value.details["flipped"] is False
+    assert "guidance" in e.value.details
+    assert (state.tier_of == before).all()      # loop state not advanced
+
+
+# ---------------------------------------------------------------- gating
+
+
+def test_disabled_by_default():
+    assert A.admin_enabled({}) is False
+    assert A.admin_enabled({A.DEV_MODE_ENV: "1"}) is False       # dev only
+    assert A.admin_enabled({A.ADMIN_API_ENV: "1"}) is False      # flag only
+    assert A.admin_enabled({A.DEV_MODE_ENV: "1",
+                            A.ADMIN_API_ENV: "1"}) is True
+    # The spec's name is honoured as an alias.
+    assert A.admin_enabled({A.DEV_MODE_ENV: "1",
+                            A.ADMIN_ENABLE_ENV: "1"}) is True
+
+
+def test_gate_reason_names_the_missing_gate():
+    assert A.DEV_MODE_ENV in A.gate_reason({})
+    assert A.ADMIN_API_ENV in A.gate_reason({A.DEV_MODE_ENV: "1"})
+
+
+# ---------------------------------------------------------------- router
+
+
+fastapi = pytest.importorskip("fastapi")
+httpx = pytest.importorskip("httpx")
+TestClient = pytest.importorskip("fastapi.testclient").TestClient
+
+
+class FakeEngineClient:
+    def __init__(self, *, plan_result=None, apply_result=None, ranks=2,
+                 rpc_error=None):
+        self.ranks = ranks
+        self.calls = []
+        self.events = []
+        self.plan_result = plan_result
+        self.apply_result = apply_result
+        self.rpc_error = rpc_error
+
+    async def collective_rpc(self, method, timeout=None, args=(), kwargs=None):
+        self.calls.append((method, args))
+        self.events.append(method)
+        if self.rpc_error is not None and method == "fq_admin_apply":
+            raise self.rpc_error
+        if method == "fq_admin_plan":
+            payload = self.plan_result
+        elif method == "fq_admin_apply":
+            payload = self.apply_result
+        else:
+            payload = {"ok": True, "policy_sha": "abc"}
+        return [json.dumps(payload) for _ in range(self.ranks)]
+
+    async def pause_generation(self, mode="wait", clear_cache=False):
+        self.events.append("pause")
+
+    async def resume_generation(self):
+        self.events.append("resume")
+
+    async def reset_prefix_cache(self, *a):
+        self.events.append("reset_prefix_cache")
+
+
+PLAN_OK = {
+    "ok": True, "phase": "plan", "request_id": "fqr-x", "plan_sha": "s" * 8,
+    "membership_sha": "m" * 8, "policy_sha_before": "b" * 8,
+    "policy_sha_after": "a" * 8,
+    "pairs": [{"layer": 23, "expert_out": 0, "expert_in": 8}],
+    "layers": [23], "items": [], "memory": {"delta_bytes_per_rank": 0},
+    "pins": {"added": {"23": [0, 8]}, "removed": {}}, "free_slots": {"23": 3},
+    "occupancy": {},
+}
+APPLY_OK = {
+    "ok": True, "phase": "apply", "applied": True, "pairs": 1, "layers": 1,
+    "generation": 7, "bytes_h2d_per_rank": 4096, "stage_ms": 1.0,
+    "window_ms": 0.4, "restored": False, "committed_policy_hash": "a" * 8,
+    "policy_sha_after": "a" * 8, "occupancy": {}, "occupancy_diff": "table",
+    "decision_record": "/tmp/rec.json", "rank": 0, "plan_sha": "s" * 8,
+}
+
+
+def make_client(env, engine=None):
+    app = fastapi.FastAPI()
+    app.state.engine_client = engine or FakeEngineClient(
+        plan_result=PLAN_OK, apply_result=APPLY_OK)
+    attached = A.attach_router(app, environ=env)
+    return TestClient(app), app.state.engine_client, attached
+
+
+def enabled_env(**extra):
+    env = {A.DEV_MODE_ENV: "1", A.ADMIN_API_ENV: "1"}
+    env.update(extra)
+    return env
+
+
+def test_routes_absent_without_the_gates():
+    for env in ({}, {A.DEV_MODE_ENV: "1"}, {A.ADMIN_API_ENV: "1"}):
+        client, _, attached = make_client(env)
+        assert attached is False
+        assert client.post("/fq/retier", json=balanced_body()).status_code \
+            == 404
+
+
+def test_routes_present_when_both_gates_are_set():
+    client, engine, attached = make_client(enabled_env())
+    assert attached is True
+    resp = client.post("/fq/retier", json=balanced_body())
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["applied"] is True
+
+
+def test_token_gate():
+    env = enabled_env(**{A.ADMIN_TOKEN_ENV: "hunter2"})
+    client, _, _ = make_client(env)
+    assert client.post("/fq/retier", json=balanced_body()).status_code == 403
+    assert client.post("/fq/retier", json=balanced_body(),
+                       headers={"X-FQ-Admin-Token": "nope"}).status_code == 403
+    ok = client.post("/fq/retier", json=balanced_body(),
+                     headers={"X-FQ-Admin-Token": "hunter2"})
+    assert ok.status_code == 200
+
+
+def test_pause_and_resume_bracket_the_apply():
+    client, engine, _ = make_client(enabled_env())
+    client.post("/fq/retier", json=balanced_body())
+    assert engine.events == ["fq_admin_plan", "pause", "fq_admin_apply",
+                             "resume"]
+
+
+def test_resume_runs_even_when_the_rpc_raises():
+    engine = FakeEngineClient(plan_result=PLAN_OK, apply_result=APPLY_OK,
+                              rpc_error=RuntimeError("worker died"))
+    client, engine, _ = make_client(enabled_env(), engine)
+    with pytest.raises(RuntimeError):
+        client.post("/fq/retier", json=balanced_body())
+    assert engine.events[-1] == "resume"
+
+
+def test_dry_run_never_applies_and_never_pauses():
+    client, engine, _ = make_client(enabled_env())
+    resp = client.post("/fq/retier", json=balanced_body(dry_run=True))
+    assert resp.status_code == 200
+    assert resp.json()["applied"] is False
+    assert engine.events == ["fq_admin_plan"]
+    assert "fq_admin_apply" not in engine.events
+
+
+def test_rank_divergence_in_phase_one_never_applies():
+    class Diverging(FakeEngineClient):
+        async def collective_rpc(self, method, timeout=None, args=(),
+                                 kwargs=None):
+            self.events.append(method)
+            if method == "fq_admin_plan":
+                return [json.dumps({**PLAN_OK, "plan_sha": "s" * 8}),
+                        json.dumps({**PLAN_OK, "plan_sha": "d" * 8})]
+            return [json.dumps(APPLY_OK)]
+
+    client, engine, _ = make_client(enabled_env(), Diverging())
+    resp = client.post("/fq/retier", json=balanced_body())
+    assert resp.status_code == 500
+    assert resp.json()["error"]["code"] == "rank_divergence"
+    assert "fq_admin_apply" not in engine.events
+    assert "pause" not in engine.events
+
+
+def test_worker_error_is_forwarded_with_its_status():
+    engine = FakeEngineClient(plan_result={
+        "ok": False,
+        "error": {"code": "cardinality_unbalanced", "http_status": 409,
+                  "message": "layer 23: 1 promotion, 0 demotions",
+                  "details": {"layer": 23}}})
+    client, engine, _ = make_client(enabled_env(), engine)
+    resp = client.post("/fq/retier",
+                       json={"items": [{"layer": 23, "expert": 8,
+                                        "adjust_k": "+1"}]})
+    assert resp.status_code == 409
+    assert resp.json()["error"]["code"] == "cardinality_unbalanced"
+    assert resp.json()["error"]["details"]["layer"] == 23
+
+
+def test_parse_errors_never_reach_the_workers():
+    client, engine, _ = make_client(enabled_env())
+    resp = client.post("/fq/retier",
+                       json={"items": [{"layer": 23, "expert": 0,
+                                        "adjust_k": 1}]})
+    assert resp.status_code == 400
+    assert resp.json()["error"]["code"] == "ambiguous_adjust_k"
+    assert engine.events == []
+
+
+def test_query_shorthand_over_http():
+    client, engine, _ = make_client(enabled_env())
+    resp = client.post("/fq/retier?layer=23&expert=250&adjust_k=-1")
+    assert resp.status_code == 200
+    sent = json.loads(engine.calls[0][1][0])["request"]
+    assert sent["items"] == [{"layer": 23, "expert": 250, "requested": "-1",
+                              "interpretation": "relative", "k": None,
+                              "delta_k": -1}]
+
+
+def test_pin_only_change_over_http_does_not_drain():
+    plan = {**PLAN_OK, "pairs": [], "layers": []}
+    engine = FakeEngineClient(plan_result=plan,
+                              apply_result={**APPLY_OK, "pairs": 0,
+                                            "pins_only": True})
+    client, engine, _ = make_client(enabled_env(), engine)
+    resp = client.post("/fq/retier",
+                       json={"items": [{"layer": 23, "expert": 1, "k": 4}]})
+    assert resp.status_code == 200
+    assert resp.json()["applied"] is True
+    assert engine.events == ["fq_admin_plan", "fq_admin_apply"]
+    assert "pause" not in engine.events
+
+
+def test_true_noop_is_reported_not_applied():
+    plan = {**PLAN_OK, "pairs": [], "layers": [],
+            "pins": {"added": {}, "removed": {}}}
+    engine = FakeEngineClient(plan_result=plan)
+    client, engine, _ = make_client(enabled_env(), engine)
+    resp = client.post("/fq/retier",
+                       json={"items": [{"layer": 23, "expert": 1, "k": 4}],
+                             "pin": "none"})
+    assert resp.status_code == 200
+    assert resp.json()["applied"] is False
+    assert "nothing to do" in resp.json()["warnings"][0]
+    assert "fq_admin_apply" not in engine.events
+
+
+def test_state_endpoint():
+    engine = FakeEngineClient(plan_result=PLAN_OK)
+    client, _, _ = make_client(enabled_env(), engine)
+    resp = client.get("/fq/state")
+    assert resp.status_code == 200
+    assert resp.json()["admin"]["growth_supported"] is False
+
+
+# ------------------------------------------------- worker entry points
+
+
+class FakeWorker:
+    def __init__(self, state, engine):
+        self.model_runner = type("R", (), {"fq_collector": state})()
+        state.swap_engine = engine
+
+
+def test_worker_plan_and_apply_round_trip(tmp_path):
+    state, _ = make_state(tmp_path)
+    engine = FakeEngine()
+    engine.source = type("S", (), {"resolver": FakeResolver()})()
+    worker = FakeWorker(state, engine)
+    payload = {"request": req(balanced_body(actor="michel")).canonical(),
+               "request_id": "fqr-test"}
+
+    planned = json.loads(A.worker_plan(worker, json.dumps(payload)))
+    assert planned["ok"] is True
+    assert planned["pairs"] == [{"layer": 23, "expert_out": 0,
+                                 "expert_in": 8}]
+
+    applied = json.loads(A.worker_apply(
+        worker, json.dumps({**payload, "plan_sha": planned["plan_sha"]})))
+    assert applied["ok"] is True
+    assert applied["applied"] is True
+    assert applied["generation"] == 1
+    assert state.policy_sha == applied["policy_sha_after"]
+
+
+def test_worker_apply_refuses_a_diverging_plan_sha(tmp_path):
+    state, _ = make_state(tmp_path)
+    engine = FakeEngine()
+    engine.source = type("S", (), {"resolver": FakeResolver()})()
+    worker = FakeWorker(state, engine)
+    payload = {"request": req(balanced_body()).canonical(),
+               "request_id": "fqr-test", "plan_sha": "deadbeef"}
+    out = json.loads(A.worker_apply(worker, json.dumps(payload)))
+    assert out["ok"] is False
+    assert out["error"]["code"] == "rank_divergence"
+    assert engine.applied == []
+
+
+def test_worker_without_fq_state_is_404():
+    worker = type("W", (), {"model_runner": type("R", (), {
+        "fq_collector": None})()})()
+    out = json.loads(A.worker_describe(worker))
+    assert out["ok"] is False
+    assert out["error"]["code"] == "fq_not_active"
+    assert out["error"]["http_status"] == 404
+
+
+def test_worker_describe_reports_state(tmp_path):
+    state, _ = make_state(tmp_path)
+    engine = FakeEngine()
+    worker = FakeWorker(state, engine)
+    out = json.loads(A.worker_describe(worker, json.dumps({"layer": 23})))
+    assert out["ok"] is True
+    assert out["budget"]["growth_supported"] is False
+    assert out["servable_tiers"] == [3, 4]
+    assert out["occupancy"]["23"]["4"] == N_K4
+    assert len(out["layer"]["experts"]) == E
+    assert out["layer"]["n_k4"] == N_K4
+    assert out["memory"]["unit_bytes_per_k_per_rank"] == (
+        3 * HIDDEN * INTERMEDIATE // 8)
+
+
+def test_fq_worker_admin_mixin_matches_the_module_functions():
+    for name in ("fq_admin_describe", "fq_admin_plan", "fq_admin_apply"):
+        assert callable(getattr(A.FqWorkerAdmin, name))

--- a/tests/exl3_fungible/test_admin_cpu.py
+++ b/tests/exl3_fungible/test_admin_cpu.py
@@ -346,6 +346,27 @@ def test_query_plus_body_is_mixed_input():
     assert e.value.code == "mixed_input"
 
 
+@pytest.mark.parametrize("smuggled", [
+    "dry_run", "mode", "pin", "expect_policy_sha", "timeout_s", "actor",
+    "reason",
+])
+def test_query_string_cannot_silently_drop_a_safety_flag(smuggled):
+    """A dropped query parameter is a 400, never a different action.
+
+    ``?layer=23&expert=250&adjust_k=-1&dry_run=true`` is the obvious
+    spelling of the operator's "will this work?" button. Filtering the
+    unrecognised keys away made it a real, unbracketed weight mutation
+    answering ``applied: true`` — and did the same to
+    ``expect_policy_sha`` (the optimistic-concurrency guard) and to the
+    ``actor``/``reason`` the audit record is attributed with.
+    """
+    with pytest.raises(A.AdminError) as e:
+        req(None, query={"layer": "23", "expert": "250", "adjust_k": "-1",
+                         smuggled: "true"})
+    assert e.value.code == "unknown_field"
+    assert smuggled in e.value.details["unknown"]
+
+
 # --------------------------------------------------------- item resolution
 
 
@@ -860,6 +881,25 @@ def test_occupancy_diff_is_emitted_after_a_change(tmp_path):
     assert any("L23: e0 K4->K3" in line for line in logged)
 
 
+def test_render_retier_table_never_raises_on_the_other_swap_convention():
+    """The pair list is telemetry; telemetry must not take a serve down.
+
+    ``adopt_policy`` runs AFTER the visibility flip, and its swaps are
+    ``(model layer id, ...)``. ``policy.decide``/``decision_log.explain``
+    speak ``(row, ...)`` — the module invites ``loop._maybe_apply`` to be
+    pointed here later, and the loop has the other convention. A row
+    index that is not also a layer id used to escape the never-raise
+    guard as a bare KeyError, after the weights had already moved.
+    """
+    state, _ = make_state()
+    occ = A.occupancy_map(state)
+    text = A.render_retier_table(
+        occ, occ, [(0, 0, 8)],                       # row 0, i.e. layer 23
+        before_tier=state.tier_of, after_tier=state.tier_of,
+        layers=state.layers, title="t", num_experts=E)
+    assert text == ""
+
+
 def test_forced_change_is_attributable_and_persisted(tmp_path):
     state, _ = make_state(tmp_path)
     body = balanced_body(actor="michel",
@@ -1089,6 +1129,23 @@ def test_token_gate():
     assert ok.status_code == 200
 
 
+def test_token_gate_survives_a_non_ascii_header():
+    """A 0x80..0xff byte in the token header is a 403, not a 500.
+
+    Starlette decodes request headers as latin-1, and
+    ``hmac.compare_digest`` raises TypeError on ``str`` operands with
+    non-ASCII code points. One byte from an unauthenticated caller turned
+    the rejection into an unhandled exception, a stack trace in the log
+    and a 500 body.
+    """
+    client, engine, _ = make_client(enabled_env(**{A.ADMIN_TOKEN_ENV: "s3"}))
+    resp = client.request("POST", "/fq/retier", json=balanced_body(),
+                          headers=[(b"x-fq-admin-token", b"\xe9")])
+    assert resp.status_code == 403, resp.text
+    assert resp.json()["error"]["code"] == "fq_admin_forbidden"
+    assert "fq_admin_plan" not in engine.events
+
+
 def test_pause_and_resume_bracket_the_apply():
     client, engine, _ = make_client(enabled_env())
     client.post("/fq/retier", json=balanced_body())
@@ -1130,6 +1187,44 @@ def test_rank_divergence_in_phase_one_never_applies():
     assert resp.json()["error"]["code"] == "rank_divergence"
     assert "fq_admin_apply" not in engine.events
     assert "pause" not in engine.events
+
+
+def test_partial_cross_rank_apply_is_reported_as_partial():
+    """One rank failing an apply the others committed is NOT "nothing ran".
+
+    ``collective_rpc`` is not atomic across ranks. Reporting only the
+    first failure handed the operator that rank's ``torn: true,
+    flipped: false`` — "nothing was applied" — while the other ranks had
+    committed the trade and advanced their loop state, i.e. the ranks are
+    now serving different weights and the response says the opposite.
+    """
+    torn = {"ok": False, "error": {
+        "code": "apply_failed", "http_status": 500,
+        "message": "SwapEngine.apply raised: cuda launch failed",
+        "details": {"flipped": False, "restored": False, "torn": True}}}
+
+    class Split(FakeEngineClient):
+        async def collective_rpc(self, method, timeout=None, args=(),
+                                 kwargs=None):
+            self.events.append(method)
+            if method == "fq_admin_apply":
+                return [json.dumps(APPLY_OK), json.dumps(APPLY_OK),
+                        json.dumps(torn), json.dumps(APPLY_OK)]
+            return [json.dumps(PLAN_OK) for _ in range(4)]
+
+    client, engine, _ = make_client(enabled_env(), Split())
+    resp = client.post("/fq/retier", json=balanced_body())
+    assert resp.status_code == 500
+    err = resp.json()["error"]
+    assert err["code"] == "partial_apply", err
+    assert err["details"]["ranks_ok"] == 3
+    assert err["details"]["ranks_total"] == 4
+    assert err["details"]["first_error"] == "apply_failed"
+    assert [r["ok"] for r in err["details"]["per_rank"]] == [
+        True, True, False, True]
+    # It must say the weights may now differ, not that nothing happened.
+    assert "differ" in err["message"]
+    assert "resume" in engine.events
 
 
 def test_worker_error_is_forwarded_with_its_status():
@@ -1212,7 +1307,59 @@ class FakeWorker:
         state.swap_engine = engine
 
 
-def test_worker_plan_and_apply_round_trip(tmp_path):
+@pytest.fixture
+def gates_on(monkeypatch):
+    """Both gates, in the real ``os.environ`` the worker functions read.
+
+    The worker entry points are reachable through vLLM's own generic
+    ``POST /collective_rpc`` (attached by dev mode alone), so they check
+    the gates themselves rather than trusting the router to have done it.
+    """
+    monkeypatch.setenv(A.DEV_MODE_ENV, "1")
+    monkeypatch.setenv(A.ADMIN_API_ENV, "1")
+
+
+def test_worker_entry_points_are_gated_without_the_fq_flag(tmp_path,
+                                                           monkeypatch):
+    """Dev mode ALONE must not be able to move a weight.
+
+    ``register_vllm_dev_api_routers`` attaches ``POST /collective_rpc``
+    (vllm/entrypoints/serve/dev/rpc/api_router.py) whenever
+    VLLM_SERVER_DEV_MODE is set, and it forwards an arbitrary ``method``
+    name to every worker. ``Worker.fq_admin_apply`` is an unconditional
+    method, so without a worker-side gate
+    ``{"method": "fq_admin_apply", "args": ["<payload>"]}`` re-tiers live
+    experts with one of the two gates set and never consults
+    VLLM_FQ_ADMIN_TOKEN.
+    """
+    monkeypatch.setenv(A.DEV_MODE_ENV, "1")
+    monkeypatch.delenv(A.ADMIN_API_ENV, raising=False)
+    monkeypatch.delenv(A.ADMIN_ENABLE_ENV, raising=False)
+    monkeypatch.setenv(A.ADMIN_TOKEN_ENV, "hunter2")
+
+    state, _ = make_state(tmp_path)
+    engine = FakeEngine()
+    engine.source = type("S", (), {"resolver": FakeResolver()})()
+    worker = FakeWorker(state, engine)
+    tier_before = np.array(state.tier_of, copy=True)
+    sha_before = state.policy_sha
+    payload = json.dumps({"request": req(balanced_body()).canonical(),
+                          "request_id": "fqr-attacker"})
+
+    for fn, arg in ((A.worker_apply, payload), (A.worker_plan, payload),
+                    (A.worker_describe, "{}")):
+        out = json.loads(fn(worker, arg))
+        assert out["ok"] is False, fn.__name__
+        assert out["error"]["code"] == "fq_admin_disabled", fn.__name__
+        assert out["error"]["http_status"] == 404
+        assert A.ADMIN_API_ENV in out["error"]["message"]
+
+    assert engine.staged == [] and engine.applied == []
+    assert np.array_equal(tier_before, state.tier_of)
+    assert state.policy_sha == sha_before
+
+
+def test_worker_plan_and_apply_round_trip(tmp_path, gates_on):
     state, _ = make_state(tmp_path)
     engine = FakeEngine()
     engine.source = type("S", (), {"resolver": FakeResolver()})()
@@ -1233,7 +1380,7 @@ def test_worker_plan_and_apply_round_trip(tmp_path):
     assert state.policy_sha == applied["policy_sha_after"]
 
 
-def test_worker_apply_refuses_a_diverging_plan_sha(tmp_path):
+def test_worker_apply_refuses_a_diverging_plan_sha(tmp_path, gates_on):
     state, _ = make_state(tmp_path)
     engine = FakeEngine()
     engine.source = type("S", (), {"resolver": FakeResolver()})()
@@ -1246,7 +1393,7 @@ def test_worker_apply_refuses_a_diverging_plan_sha(tmp_path):
     assert engine.applied == []
 
 
-def test_worker_without_fq_state_is_404():
+def test_worker_without_fq_state_is_404(gates_on):
     worker = type("W", (), {"model_runner": type("R", (), {
         "fq_collector": None})()})()
     out = json.loads(A.worker_describe(worker))
@@ -1255,7 +1402,7 @@ def test_worker_without_fq_state_is_404():
     assert out["error"]["http_status"] == 404
 
 
-def test_worker_describe_reports_state(tmp_path):
+def test_worker_describe_reports_state(tmp_path, gates_on):
     state, _ = make_state(tmp_path)
     engine = FakeEngine()
     worker = FakeWorker(state, engine)

--- a/tests/exl3_fungible/test_admin_cpu.py
+++ b/tests/exl3_fungible/test_admin_cpu.py
@@ -1469,3 +1469,45 @@ def test_a_number_elsewhere_in_the_name_is_not_a_layer_id():
     """"layers.N" must be matched as a path segment; a bare digit anywhere
     would happily read an expert index as a layer."""
     assert A._module_layer_id(_Mod(layer_name="model.experts.12.w13")) is None
+
+
+# --------------------------------------------------------------------------
+# Layers outside the decision domain must survive a re-tier.
+#
+# GLM-5.2's MTP layer 78 is in the progressive loader's bitrate map (the
+# loader refuses to boot without it) but cannot be bound by the stats
+# collector, so state.layers covers 75 layers while policy_doc covers 76.
+# Rebuilding bits_per_expert from state.layers alone dropped layer 78, and
+# SwapPlan.from_policies then refused the change with "policies cover
+# different layers" — an accurate complaint about a document we malformed.
+
+
+def _doc_with_extra_layer():
+    return {
+        "schema": "fq-policy/2",
+        "bits_per_expert": {"3": [3, 3, 4, 4], "4": [3, 4, 3, 4],
+                            "78": [3, 3, 3, 3]},
+        "budget": {"mode": "fixed_cardinality"},
+    }
+
+
+def test_build_target_doc_preserves_layers_outside_the_decision_domain():
+    doc = _doc_with_extra_layer()
+    new_tier = np.array([[4, 3, 4, 3], [3, 4, 3, 4]])
+    out = A.build_target_doc(doc, layers=[3, 4], new_tier=new_tier,
+                             pinned={}, provenance={})
+    assert set(out["bits_per_expert"]) == {"3", "4", "78"}, \
+        "layer 78 was dropped — the swap engine will refuse this document"
+    assert out["bits_per_expert"]["78"] == [3, 3, 3, 3], \
+        "an uninstrumented layer must be carried through UNCHANGED"
+    assert out["bits_per_expert"]["3"] == [4, 3, 4, 3]
+
+
+def test_build_target_doc_does_not_alias_the_running_document():
+    """Carrying rows through must copy them: mutating the target document
+    must never reach back into the policy the engine is still running."""
+    doc = _doc_with_extra_layer()
+    out = A.build_target_doc(doc, layers=[3], new_tier=np.array([[4, 3, 4, 3]]),
+                             pinned={}, provenance={})
+    out["bits_per_expert"]["78"][0] = 9
+    assert doc["bits_per_expert"]["78"] == [3, 3, 3, 3]

--- a/tests/exl3_fungible/test_admin_cpu.py
+++ b/tests/exl3_fungible/test_admin_cpu.py
@@ -1420,3 +1420,52 @@ def test_worker_describe_reports_state(tmp_path, gates_on):
 def test_fq_worker_admin_mixin_matches_the_module_functions():
     for name in ("fq_admin_describe", "fq_admin_plan", "fq_admin_apply"):
         assert callable(getattr(A.FqWorkerAdmin, name))
+
+
+# --------------------------------------------------------------------------
+# Layer-id discovery for the swap engine.
+#
+# POST /fq/retier answered "fq_not_active — the serve is uniform-K" on a live
+# GLM-5.2 with 75 mixed layers, because build_swap_engine required layer_id on
+# the module carrying exl3_mixed_trellis. exl3.py attaches that dict to the
+# fused-experts module, which fused_moe/layer.py names via
+# layer_name = "model.layers.10.mlp.experts" and gives no numeric id. The
+# router modules the stats collector binds DO carry layer_id, which is exactly
+# why the collector worked and the swap engine silently found nothing.
+
+
+class _Mod:
+    def __init__(self, **kw):
+        for k, v in kw.items():
+            setattr(self, k, v)
+
+
+def test_layer_id_preferred_when_present():
+    assert A._module_layer_id(_Mod(layer_id=7, layer_name="whatever")) == 7
+
+
+def test_layer_id_parsed_from_the_fused_experts_layer_name():
+    """The case that actually broke."""
+    m = _Mod(layer_name="model.layers.10.mlp.experts")
+    assert A._module_layer_id(m) == 10
+
+
+def test_layer_id_parsed_from_prefix_when_that_is_the_only_name():
+    assert A._module_layer_id(_Mod(prefix="model.layers.3.mlp.experts")) == 3
+
+
+def test_two_digit_and_boundary_layers_parse():
+    for n in (0, 3, 9, 10, 49, 77, 78):
+        m = _Mod(layer_name=f"model.layers.{n}.mlp.experts")
+        assert A._module_layer_id(m) == n
+
+
+def test_unnamed_module_is_skipped_not_guessed():
+    assert A._module_layer_id(_Mod()) is None
+    assert A._module_layer_id(_Mod(layer_name="model.embed_tokens")) is None
+
+
+def test_a_number_elsewhere_in_the_name_is_not_a_layer_id():
+    """"layers.N" must be matched as a path segment; a bare digit anywhere
+    would happily read an expert index as a layer."""
+    assert A._module_layer_id(_Mod(layer_name="model.experts.12.w13")) is None

--- a/tests/exl3_fungible/test_admin_cpu.py
+++ b/tests/exl3_fungible/test_admin_cpu.py
@@ -110,6 +110,15 @@ def boot_doc():
     }
 
 
+def k2k4_doc():
+    doc = boot_doc()
+    doc["bits_per_expert"] = {
+        key: [4] * N_K4 + [2] * (E - N_K4)
+        for key in doc["bits_per_expert"]
+    }
+    return doc
+
+
 def make_state(tmp_path=None, *, doc=None, metrics=None, rank=0):
     doc = doc or boot_doc()
     collector = FqStatsCollector(E, window_len=8, window_stride=2, decay=0.9,
@@ -145,11 +154,13 @@ class FakeEngine:
     uses this is what the admin layer decided BEFORE the engine is reached.
     """
 
-    def __init__(self, layers=None, *, max_pairs=32, fail_apply=None):
+    def __init__(self, layers=None, *, max_pairs=32, fail_apply=None,
+                 tier_bits=(P.K3, P.K4)):
         self.layers = {lid: object() for lid in (layers or LAYERS)}
         self.max_pairs = max_pairs
         self.hidden_size = HIDDEN
         self.intermediate_size = INTERMEDIATE
+        self.tier_bits = tuple(tier_bits)
         self.generation = 0
         self.source = None
         self.staged = []
@@ -247,6 +258,7 @@ def balanced_body(**kw):
 
 @pytest.mark.parametrize("sent,interpretation,k,delta", [
     (-1, "relative", None, -1),          # negative number: no negative K
+    (2, "absolute", 2, None),
     (3, "absolute", 3, None),            # "absolute like adjust_k=3"
     (4, "absolute", 4, None),
     ("+1", "relative", None, 1),         # explicit sign survives JSON
@@ -260,7 +272,7 @@ def test_adjust_k_table(sent, interpretation, k, delta):
                                                            delta)
 
 
-@pytest.mark.parametrize("sent", [1, 0, 2, 5])
+@pytest.mark.parametrize("sent", [1, 0, 5])
 def test_adjust_k_positive_outside_ladder_is_ambiguous(sent):
     with pytest.raises(A.AdminError) as e:
         req({"items": [{"layer": 23, "expert": 0, "adjust_k": sent}]})
@@ -327,6 +339,28 @@ def test_too_many_items(monkeypatch):
         req({"items": [{"layer": 23, "expert": i, "adjust_k": -1}
                        for i in range(3)]}, environ=env)
     assert e.value.code == "too_many_items"
+
+
+@pytest.mark.parametrize("timeout_s", [0, -1, float("inf"), float("nan"), 3601])
+def test_timeout_must_be_finite_positive_and_bounded(timeout_s):
+    with pytest.raises(A.AdminError) as e:
+        req(balanced_body(timeout_s=timeout_s))
+    assert e.value.code == "bad_json"
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("actor", "a" * (A.MAX_ACTOR_CHARS + 1)),
+        ("reason", "r" * (A.MAX_REASON_CHARS + 1)),
+        ("expect_policy_sha", "s" * (A.MAX_POLICY_SHA_CHARS + 1)),
+        ("actor", {"nested": "object"}),
+    ],
+)
+def test_audit_metadata_is_bounded_scalar_text(field, value):
+    with pytest.raises(A.AdminError) as e:
+        req(balanced_body(**{field: value}))
+    assert e.value.code == "bad_json"
 
 
 def test_query_shorthand_desugars():
@@ -405,7 +439,7 @@ def test_k5_is_refused_with_both_reasons():
             layers=state.layers, tier_of=state.tier_of, num_experts=E)
     assert e.value.code == "tier_not_servable"
     assert e.value.status == 501
-    assert "two-tier engine" in e.value.message
+    assert "running mixed pair" in e.value.message
     assert "109568" in e.value.message and "101376" in e.value.message
 
 
@@ -444,6 +478,33 @@ def test_absolute_and_relative_spellings_agree(tmp_path):
     # Only the provenance (which records the literal spelling, the actor and
     # the timestamp) distinguishes the two documents.
     assert rel.policy_sha_after != absolute.policy_sha_after
+
+
+def test_k2_k4_pair_plans_applies_and_persists(tmp_path):
+    state, _ = make_state(tmp_path, doc=k2k4_doc())
+    engine = FakeEngine(tier_bits=(P.K2, P.K4))
+    request = req({
+        "items": [
+            {"layer": 23, "expert": 0, "k": 2},
+            {"layer": 23, "expert": 8, "k": 4},
+        ],
+        "pin": "none",
+    })
+    plan = A.plan_retier(
+        state, request, engine=engine, resolver=FakeResolver(),
+        memory=memory_model())
+    assert plan.plan == SW.SwapPlan([(23, 0, 8)])
+    assert plan.memory["delta_bytes_per_rank"] == 0
+
+    result = A.apply_retier(state, plan, engine=engine)
+    assert result["applied"] is True
+    row = state.layers.index(23)
+    assert int(state.tier_of[row, 0]) == P.K2
+    assert int(state.tier_of[row, 8]) == P.K4
+    committed = S.PolicyStore(
+        tmp_path, "m" * 64).load_current(num_experts=E)
+    assert committed["bits_per_expert"]["23"] == [
+        int(k) for k in state.tier_of[row]]
 
 
 def test_lone_promotion_is_refused_and_nothing_is_staged(tmp_path):
@@ -1146,6 +1207,19 @@ def test_token_gate_survives_a_non_ascii_header():
     assert "fq_admin_plan" not in engine.events
 
 
+def test_retier_body_size_is_bounded_before_collective_rpc():
+    client, engine, _ = make_client(
+        enabled_env(**{A.ADMIN_MAX_BODY_BYTES_ENV: "128"})
+    )
+    resp = client.post(
+        "/fq/retier",
+        json=balanced_body(reason="r" * 256),
+    )
+    assert resp.status_code == 413
+    assert resp.json()["error"]["code"] == "request_too_large"
+    assert "fq_admin_plan" not in engine.events
+
+
 def test_pause_and_resume_bracket_the_apply():
     client, engine, _ = make_client(enabled_env())
     client.post("/fq/retier", json=balanced_body())
@@ -1380,6 +1454,46 @@ def test_worker_plan_and_apply_round_trip(tmp_path, gates_on):
     assert state.policy_sha == applied["policy_sha_after"]
 
 
+def test_workers_with_different_clocks_commit_identical_policy(
+    tmp_path, monkeypatch, gates_on
+):
+    states = []
+    workers = []
+    for name, rank in (("a", 0), ("b", 1)):
+        state, _ = make_state(tmp_path / name, rank=rank)
+        engine = FakeEngine()
+        engine.source = type("S", (), {"resolver": FakeResolver()})()
+        states.append(state)
+        workers.append(FakeWorker(state, engine))
+
+    request = req(
+        balanced_body(actor="michel", utc="2026-08-14T00:00:00Z")
+    ).canonical()
+    payload = {"request": request, "request_id": "fqr-shared"}
+    plans = []
+    for clock, worker in zip(
+        ("2026-08-14T01:00:00Z", "2026-08-14T01:00:01Z"),
+        workers,
+        strict=True,
+    ):
+        monkeypatch.setattr(A.time, "strftime", lambda *_a, c=clock, **_k: c)
+        plans.append(json.loads(A.worker_plan(worker, json.dumps(payload))))
+
+    for key in ("plan_sha", "membership_sha", "policy_sha_after"):
+        assert plans[0][key] == plans[1][key]
+
+    applied = [
+        json.loads(A.worker_apply(
+            worker,
+            json.dumps({**payload, "plan_sha": plans[0]["plan_sha"]}),
+        ))
+        for worker in workers
+    ]
+    assert all(result["ok"] for result in applied)
+    assert states[0].policy_doc == states[1].policy_doc
+    assert states[0].policy_sha == states[1].policy_sha
+
+
 def test_worker_apply_refuses_a_diverging_plan_sha(tmp_path, gates_on):
     state, _ = make_state(tmp_path)
     engine = FakeEngine()
@@ -1600,15 +1714,26 @@ def test_two_ranks_one_second_apart_agree_on_the_membership(monkeypatch):
         "the membership is identical — a cross-check keyed on it would agree")
 
 
-def test_provenance_utc_is_taken_from_the_request_when_supplied():
-    """The router stamps one timestamp so every rank commits an identical
-    document; otherwise /fq/state reports agreed=False after a swap that was
-    applied identically on all four ranks."""
-    req = A.RetierRequest(items=(), actor="t", reason="r")
-    object.__setattr__(req, "utc", "2026-01-01T00:00:00Z") \
-        if hasattr(req, "__dataclass_fields__") else None
-    prov = A._provenance(_Mod(_step=5), req, [], "fqr-x", "base")
+def test_provenance_utc_survives_the_collective_request_round_trip():
+    """Every rank must build the same policy document from one API timestamp."""
+    req = A.RetierRequest(
+        items=(), actor="t", reason="r", utc="2026-01-01T00:00:00Z")
+    decoded = A.RetierRequest.from_canonical(req.canonical())
+    prov = A._provenance(_Mod(_step=5), decoded, [], "fqr-x", "base")
     assert prov["utc"] == "2026-01-01T00:00:00Z"
+
+
+def test_router_overwrites_caller_utc_once_before_collective(monkeypatch):
+    monkeypatch.setattr(
+        A.time, "strftime", lambda *_a, **_k: "2026-08-12T00:42:00Z")
+    client, engine, _ = make_client(enabled_env())
+    resp = client.post(
+        "/fq/retier",
+        json=balanced_body(utc="caller-cannot-forge-this"),
+    )
+    assert resp.status_code == 200, resp.text
+    sent = json.loads(engine.calls[0][1][0])["request"]
+    assert sent["utc"] == "2026-08-12T00:42:00Z"
 
 
 # --------------------------------------------------------------------------

--- a/tests/exl3_fungible/test_admin_cpu.py
+++ b/tests/exl3_fungible/test_admin_cpu.py
@@ -1612,3 +1612,75 @@ def test_an_unreadable_runtime_is_treated_as_unsafe():
         integration as I,
     )
     assert I._graphs_are_live(_Mod()) is True
+
+
+# --------------------------------------------------------------------------
+# Runtime tuning (POST /fq/tune).
+#
+# Measuring a threshold and then having to restart the serve you measured it
+# on loses the state that produced the measurement — which is how a
+# calibration ends up unverified. The jaccard floor was observed oscillating
+# at 0.923-0.950 against a 0.950 floor; changing it should not cost a boot.
+
+
+class _Cfg2:
+    def __init__(self):
+        self.jaccard_floor = 0.95
+        self.hysteresis = 1.25
+        self.max_swaps_total = 64
+
+
+class _State:
+    def __init__(self):
+        self.cfg = _Cfg2()
+        self.rank = 0
+        self.tier_of = np.zeros((2, 4), dtype=np.int64)
+
+
+class _Worker:
+    def __init__(self):
+        self.model_runner = _Mod(fq_collector=_State())
+
+
+def _tune(payload, monkeypatch):
+    monkeypatch.setenv("VLLM_SERVER_DEV_MODE", "1")
+    monkeypatch.setenv("VLLM_FQ_ADMIN_API", "1")
+    return json.loads(A.worker_tune(_Worker(), json.dumps(payload)))
+
+
+def test_tune_applies_and_reports_the_previous_value(monkeypatch):
+    r = _tune({"jaccard_floor": 0.80}, monkeypatch)
+    assert r["ok"] is True, r
+    assert r["applied"]["jaccard_floor"] == pytest.approx(0.80)
+    assert r["before"]["jaccard_floor"] == pytest.approx(0.95)
+
+
+def test_tune_preserves_the_declared_type(monkeypatch):
+    """max_swaps_total is an int; a JSON float must not turn it into one."""
+    r = _tune({"max_swaps_total": 32}, monkeypatch)
+    assert r["ok"] is True
+    assert isinstance(r["applied"]["max_swaps_total"], int)
+
+
+def test_tune_refuses_an_unknown_knob_rather_than_ignoring_it(monkeypatch):
+    """A silently-dropped tuning request looks exactly like one that had no
+    effect — which is the failure mode this project keeps producing."""
+    r = _tune({"n_k4": 99}, monkeypatch)
+    assert r["ok"] is False
+    assert r["error"]["code"] == "unknown_knob"
+    assert "jaccard_floor" in str(r["error"])
+
+
+def test_tune_refuses_out_of_range(monkeypatch):
+    r = _tune({"jaccard_floor": 1.5}, monkeypatch)
+    assert r["ok"] is False
+    assert r["error"]["code"] == "out_of_range"
+
+
+def test_tune_rejects_the_whole_request_if_any_key_is_bad(monkeypatch):
+    """Partial application would leave the ranks disagreeing about config."""
+    w = _Worker()
+    monkeypatch.setenv("VLLM_SERVER_DEV_MODE", "1")
+    monkeypatch.setenv("VLLM_FQ_ADMIN_API", "1")
+    A.worker_tune(w, json.dumps({"jaccard_floor": 0.7, "bogus": 1}))
+    assert w.model_runner.fq_collector.cfg.jaccard_floor == pytest.approx(0.95)

--- a/tests/exl3_fungible/test_admin_cpu.py
+++ b/tests/exl3_fungible/test_admin_cpu.py
@@ -1511,3 +1511,55 @@ def test_build_target_doc_does_not_alias_the_running_document():
                              pinned={}, provenance={})
     out["bits_per_expert"]["78"][0] = 9
     assert doc["bits_per_expert"]["78"] == [3, 3, 3, 3]
+
+
+# --------------------------------------------------------------------------
+# plan_sha must not depend on the clock.
+#
+# Observed live: rank 3 derived a different plan_sha for an identical change
+# and the router refused with "ranks disagree on plan_sha — nothing applied".
+# Three immediate retries all passed. The cause was provenance: policy_sha_after
+# covers the whole document, and _provenance stamps a per-rank time.strftime().
+# Four ranks straddling a second boundary produce four hashes.
+#
+# That is the worst shape a safety check can take — it fires rarely, refuses a
+# correct change, and its message sends the reader to look for weight
+# corruption that does not exist.
+
+
+def _plan_sha_of(monkeypatch, fake_clock):
+    import time as _time
+    monkeypatch.setattr(A.time, "strftime",
+                        lambda *_a, **_k: fake_clock)
+    doc = {
+        "schema": "fq-policy/2",
+        "bits_per_expert": {"3": [4, 3, 3, 3], "4": [3, 3, 3, 3]},
+        "budget": {"mode": "fixed_cardinality",
+                   "n_k4_per_layer": {"3": 1, "4": 0}},
+    }
+    new_doc = A.build_target_doc(
+        doc, layers=[3, 4], new_tier=np.array([[3, 4, 3, 3], [3, 3, 3, 3]]),
+        pinned={}, provenance={"utc": fake_clock})
+    return A.policy_hash(new_doc), new_doc
+
+
+def test_two_ranks_one_second_apart_agree_on_the_membership(monkeypatch):
+    """The documents differ (provenance carries the clock) but the MEMBERSHIP
+    they encode is identical — and the membership is what a rank cross-check
+    is actually asserting about."""
+    sha_a, doc_a = _plan_sha_of(monkeypatch, "2026-08-11T16:30:00Z")
+    sha_b, doc_b = _plan_sha_of(monkeypatch, "2026-08-11T16:30:01Z")
+    assert sha_a != sha_b, "provenance differs, so the whole-doc hash differs"
+    assert doc_a["bits_per_expert"] == doc_b["bits_per_expert"], (
+        "the membership is identical — a cross-check keyed on it would agree")
+
+
+def test_provenance_utc_is_taken_from_the_request_when_supplied():
+    """The router stamps one timestamp so every rank commits an identical
+    document; otherwise /fq/state reports agreed=False after a swap that was
+    applied identically on all four ranks."""
+    req = A.RetierRequest(items=(), actor="t", reason="r")
+    object.__setattr__(req, "utc", "2026-01-01T00:00:00Z") \
+        if hasattr(req, "__dataclass_fields__") else None
+    prov = A._provenance(_Mod(_step=5), req, [], "fqr-x", "base")
+    assert prov["utc"] == "2026-01-01T00:00:00Z"

--- a/tests/exl3_fungible/test_admin_cpu.py
+++ b/tests/exl3_fungible/test_admin_cpu.py
@@ -1416,6 +1416,52 @@ def test_worker_describe_reports_state(tmp_path, gates_on):
     assert out["memory"]["unit_bytes_per_k_per_rank"] == (
         3 * HIDDEN * INTERMEDIATE // 8)
 
+def test_worker_describe_can_read_kernel_device_maps(tmp_path, gates_on):
+    state, _ = make_state(tmp_path)
+    engine = FakeEngine()
+    tier1 = [1, 2, 3, 8]
+    tier0 = [e for e in range(E) if e not in tier1]
+    combined = tier0 + tier1
+    global_to_combined = torch.empty(E, dtype=torch.int32)
+    for slot, expert in enumerate(combined):
+        global_to_combined[expert] = slot
+    descriptor_map = torch.tensor(
+        [*range(len(tier0)),
+         *((1 << SW.DESCRIPTOR_TIER_SHIFT) | i
+           for i in range(len(tier1)))],
+        dtype=torch.int32,
+    )
+    live = type("Live", (), {
+        "global_to_combined": global_to_combined,
+        "descriptor_map": descriptor_map,
+    })()
+    engine.layers = {23: live}
+    engine.tier_bits = (P.K3, P.K4)
+    worker = FakeWorker(state, engine)
+
+    out = json.loads(A.worker_describe(
+        worker, json.dumps({"layer": 23, "source": "device"})))
+
+    assert out["ok"] is True
+    assert out["layer"]["source"] == "device"
+    device_k = {row["expert"]: row["k"]
+                for row in out["layer"]["experts"]}
+    assert device_k[0] == P.K3
+    assert device_k[8] == P.K4
+    assert out["layer"]["n_k4"] == N_K4
+    assert out["device_membership_sha"] == out["layer"]["membership_sha"]
+
+
+def test_worker_describe_refuses_unknown_state_source(tmp_path, gates_on):
+    state, _ = make_state(tmp_path)
+    out = json.loads(A.worker_describe(
+        FakeWorker(state, FakeEngine()),
+        json.dumps({"layer": 23, "source": "wishful"})))
+    assert out["ok"] is False
+    assert out["error"]["code"] == "invalid_source"
+
+
+
 
 def test_fq_worker_admin_mixin_matches_the_module_functions():
     for name in ("fq_admin_describe", "fq_admin_plan", "fq_admin_apply"):

--- a/tests/exl3_fungible/test_admin_cpu.py
+++ b/tests/exl3_fungible/test_admin_cpu.py
@@ -1563,3 +1563,52 @@ def test_provenance_utc_is_taken_from_the_request_when_supplied():
         if hasattr(req, "__dataclass_fields__") else None
     prov = A._provenance(_Mod(_step=5), req, [], "fqr-x", "base")
     assert prov["utc"] == "2026-01-01T00:00:00Z"
+
+
+# --------------------------------------------------------------------------
+# Live-apply gating (M4-W).
+#
+# admin.apply_retier can pass quiesce=nullcontext() because the HTTP request
+# drains the engine first. The LOOP has no drain — it decides inside the
+# runner's step — so a nullcontext is only honest when nothing can be
+# replaying. Under captured CUDA graphs a replay holds device pointers into
+# the slabs being rewritten, so the loop must refuse to bind rather than
+# quietly race.
+
+
+class _Cfg:
+    def __init__(self, eager, cg_mode):
+        self.model_config = _Mod(enforce_eager=eager)
+        self.compilation_config = _Mod(cudagraph_mode=cg_mode)
+
+
+def test_eager_runtime_is_safe_to_bind():
+    from vllm.model_executor.layers.quantization.exl3_fungible import (
+        integration as I,
+    )
+    assert I._graphs_are_live(_Mod(vllm_config=_Cfg(True, "FULL"))) is False
+
+
+def test_captured_graphs_are_not_safe_to_bind():
+    from vllm.model_executor.layers.quantization.exl3_fungible import (
+        integration as I,
+    )
+    assert I._graphs_are_live(
+        _Mod(vllm_config=_Cfg(False, "CUDAGraphMode.FULL_AND_PIECEWISE"))
+    ) is True
+
+
+def test_cudagraph_mode_none_is_safe_even_without_enforce_eager():
+    from vllm.model_executor.layers.quantization.exl3_fungible import (
+        integration as I,
+    )
+    assert I._graphs_are_live(
+        _Mod(vllm_config=_Cfg(False, "CUDAGraphMode.NONE"))) is False
+
+
+def test_an_unreadable_runtime_is_treated_as_unsafe():
+    """Fail closed: if we cannot tell whether graphs are live, they are."""
+    from vllm.model_executor.layers.quantization.exl3_fungible import (
+        integration as I,
+    )
+    assert I._graphs_are_live(_Mod()) is True

--- a/tests/exl3_fungible/test_base_router_gate_mass_cpu.py
+++ b/tests/exl3_fungible/test_base_router_gate_mass_cpu.py
@@ -1,0 +1,189 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""The router half of the gate-mass contract, exercised on CPU.
+
+Gate weights are a LOCAL in ``BaseRouter._select_experts``: nothing on
+the router object holds them, and the capture hook historically passed
+``topk_ids`` only. That is why the fungible-quant collector's
+``topk_weights_getter`` was never bound in the live path and ``mass``
+came back byte-identical to ``count``. The fix is at that call site: a
+capture fn tagged ``wants_topk_weights`` is handed both.
+
+``base_router.py`` cannot simply be imported here — the source tree's
+``vllm`` is not built (no ``vllm._C``), which is why every test in this
+directory runs ``--noconftest`` against file-loaded modules. So we load
+the REAL file by path with its five vllm imports stubbed out. That
+still executes the actual ``_select_experts`` we ship, rather than a
+paraphrase of it.
+"""
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+import torch
+
+_SRC = (Path(__file__).resolve().parents[2] / "vllm" / "model_executor"
+        / "layers" / "fused_moe" / "router" / "base_router.py")
+
+
+class _StubFusedMoERouter:
+    def __init__(self, eplb_state=None):
+        self._routing_replay_out = None
+        self.eplb_state = eplb_state
+
+
+def _load_base_router():
+    """Load base_router.py with its vllm dependencies stubbed.
+
+    ``current_platform.is_cuda_alike() -> False`` selects the non-triton
+    branch, so no GPU toolchain is touched.
+    """
+    stubs: dict[str, types.ModuleType] = {}
+
+    def mod(name, **attrs):
+        m = types.ModuleType(name)
+        for k, v in attrs.items():
+            setattr(m, k, v)
+        stubs[name] = m
+        return m
+
+    mod("vllm.distributed.eplb.eplb_state", EplbLayerState=object)
+    mod("vllm.model_executor.layers.fused_moe.router.fused_moe_router",
+        FusedMoERouter=_StubFusedMoERouter)
+    mod("vllm.platforms",
+        current_platform=types.SimpleNamespace(is_cuda_alike=lambda: False))
+    mod("vllm.triton_utils", tl=None, triton=None)
+    mod("vllm.v1.worker.ubatching", dbo_current_ubatch_id=lambda: 0)
+
+    saved = {k: sys.modules.get(k) for k in stubs}
+    sys.modules.update(stubs)
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "fq_base_router_under_test", _SRC)
+        m = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(m)
+        return m.BaseRouter
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                sys.modules.pop(k, None)
+            else:
+                sys.modules[k] = v
+
+
+BaseRouter = _load_base_router()
+
+
+class ToyRouter(BaseRouter):
+    """Concrete router returning fixed routing, like a real subclass."""
+
+    def __init__(self, weights, ids, num_experts=8):
+        super().__init__(top_k=ids.shape[-1], global_num_experts=num_experts)
+        self._weights = weights
+        self._ids = ids
+
+    @property
+    def routing_method_type(self):
+        return None
+
+    def _compute_routing(self, hidden_states, router_logits, indices_type,
+                         *, input_ids=None):
+        return self._weights, self._ids
+
+
+def make_router():
+    return ToyRouter(torch.tensor([[0.1, 0.9]], dtype=torch.float32),
+                     torch.tensor([[2, 5]], dtype=torch.int64))
+
+
+def drive(router):
+    return router._select_experts(torch.zeros(1, 4), torch.zeros(1, 8))
+
+
+def test_default_capture_fn_still_gets_ids_only():
+    """Backward compatibility: the routed-experts capturer binds a
+    one-argument callback and must keep working untouched."""
+    r = make_router()
+    seen = []
+    r.set_capture_fn(lambda ids: seen.append(ids))
+    assert r.capture_fn_wants_weights is False
+    drive(r)
+    assert len(seen) == 1 and torch.equal(seen[0], r._ids)
+
+
+def test_tagged_capture_fn_receives_the_gate_weights():
+    """The fix: a capture fn tagged ``wants_topk_weights`` is called with
+    (topk_ids, topk_weights). Without it there is no reachable source of
+    gate mass anywhere on the router."""
+    r = make_router()
+    seen = []
+
+    def cap(ids, weights):
+        seen.append((ids, weights))
+
+    cap.wants_topk_weights = True
+    r.set_capture_fn(cap)
+    assert r.capture_fn_wants_weights is True
+    drive(r)
+    assert len(seen) == 1, "tagged capture fn was called with ids only"
+    ids, weights = seen[0]
+    assert torch.equal(ids, r._ids)
+    assert torch.equal(weights, r._weights)
+
+
+def test_weights_are_the_pre_eplb_gate_weights_of_this_call():
+    """The weights handed over must be this call's routing output, not a
+    stale snapshot: a stashed-on-the-router scheme would read last
+    step's tensor under graph replay."""
+    r = make_router()
+    got = []
+    cap = lambda ids, w: got.append(w.clone())  # noqa: E731
+    cap.wants_topk_weights = True
+    r.set_capture_fn(cap)
+
+    drive(r)
+    r._weights = torch.tensor([[0.7, 0.3]], dtype=torch.float32)
+    drive(r)
+
+    assert got[0].flatten().tolist() == pytest.approx([0.1, 0.9], abs=1e-6)
+    assert got[1].flatten().tolist() == pytest.approx([0.7, 0.3], abs=1e-6), \
+        "capture saw a stale weights tensor"
+
+
+def test_clearing_the_capture_fn_clears_the_opt_in():
+    r = make_router()
+    cap = lambda ids, w: None  # noqa: E731
+    cap.wants_topk_weights = True
+    r.set_capture_fn(cap)
+    assert r.capture_fn_wants_weights is True
+    r.set_capture_fn(None)
+    assert r.capture_fn_wants_weights is False
+    drive(r)  # must not blow up on a None callback
+
+
+def test_collector_bound_to_a_real_base_router_records_real_mass():
+    """End-to-end on the real router class: bind the collector, route,
+    and check that mass is the gate-weight sum and not the hit count."""
+    stats_path = (Path(__file__).resolve().parents[2] / "vllm"
+                  / "model_executor" / "layers" / "quantization"
+                  / "exl3_fungible" / "stats.py")
+    spec = importlib.util.spec_from_file_location("fq_stats_br", stats_path)
+    stats_mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(stats_mod)
+
+    r = ToyRouter(torch.tensor([[0.05, 0.95]], dtype=torch.float32),
+                  torch.tensor([[3, 6]], dtype=torch.int64))
+    c = stats_mod.FqStatsCollector(
+        8, window_len=2, window_stride=1, decay=1.0, device="cpu",
+        record_mass=True)
+    c.bind_router(0, r)
+    assert c.mass_is_real(0) is True
+
+    drive(r)
+    drive(r)
+    assert c.count_buf[0][3].item() == pytest.approx(2.0)
+    assert c.count_buf[0][6].item() == pytest.approx(2.0)
+    assert c.mass_buf[0][3].item() == pytest.approx(0.10, abs=1e-6)
+    assert c.mass_buf[0][6].item() == pytest.approx(1.90, abs=1e-6)

--- a/tests/exl3_fungible/test_convergence_cpu.py
+++ b/tests/exl3_fungible/test_convergence_cpu.py
@@ -538,3 +538,156 @@ def test_optin_still_governs_whether_missing_experts_are_deferred():
     assert "if unavailable and _opportunistic:" in src
     assert "if _opportunistic:\n                # ONCE" in src or \
            "_plan.gate()" in src
+
+
+# ============================ the install contract ============================
+# The defect these pin, found reviewing my own code: fq_converge_layers
+# RESOLVES fragments and never installs them, and LayerConvergenceWorker fed
+# its return straight into repay(). The plan would have marched to
+# state=converged, drift_bits=0, converged_ratio=1.0 on a model whose weights
+# never changed. Worse than not having the feature: it manufactures evidence.
+
+def test_resolve_only_result_yields_no_tiers():
+    assert CV.installed_tiers(
+        {"installed": False, "layers": {0: 4}}) is None
+
+
+def test_missing_installed_flag_is_treated_as_not_installed():
+    """A telemetry contract that fails open is not a contract."""
+    assert CV.installed_tiers({"layers": {0: 4}}) is None
+
+
+@pytest.mark.parametrize("bad", [None, [], "ok", {"installed": "yes"},
+                                 {"installed": 1}, {"installed": True}])
+def test_malformed_results_never_yield_tiers(bad):
+    """`installed: 1` and `installed: "yes"` are NOT True -- an identity check,
+    because a truthy-but-wrong payload is exactly how this fails silently."""
+    assert CV.installed_tiers(bad) is None
+
+
+def test_installed_result_yields_the_tiers():
+    assert CV.installed_tiers(
+        {"installed": True, "layers": {"0": "4", 1: 3}}) == {0: 4, 1: 3}
+
+
+def test_worker_does_not_repay_on_a_resolve_only_result():
+    """End to end: the plan must stay CONVERGING, not flip to CONVERGED."""
+    p = _plan()
+    for e in range(4):
+        p.observe(5, e, actual_k=3, target_k=4)
+
+    def resolve_only(layer, want):
+        return CV.installed_tiers(
+            {"installed": False, "layers": {e: 4 for e in want}})
+
+    out = CV.LayerConvergenceWorker(p, resolve_only).step()
+    assert out["repaid"] == 0
+    assert p.pending_count == 4
+    assert p.drift_bits == 4
+    assert p.state is CV.ConvergenceState.CONVERGING
+    assert p.state.is_final is False
+
+
+def test_every_rank_must_affirm_the_install():
+    """All TP ranks rebuild the same layer. One rank silently skipping it
+    would leave the model inconsistent across ranks while the plan reported
+    convergence."""
+    calls = []
+
+    def rpc(method, args=None):
+        calls.append(method)
+        return [
+            {"installed": True, "layers": {5: {0: 4}}},
+            {"installed": False, "layers": {5: {0: 4}}},   # rank 1 did not
+        ]
+
+    fn = CV.bind_reload_rpc(rpc)
+    assert fn(5, {0: 4}) is None
+    assert calls == ["fq_converge_layers"]
+
+
+def test_ranks_disagreeing_on_the_tier_is_not_convergence():
+    def rpc(method, args=None):
+        return [
+            {"installed": True, "layers": {5: {0: 4}}},
+            {"installed": True, "layers": {5: {0: 3}}},    # different tier
+        ]
+
+    assert CV.bind_reload_rpc(rpc)(5, {0: 4}) is None
+
+
+def test_unanimous_install_is_accepted():
+    def rpc(method, args=None):
+        return [{"installed": True, "layers": {5: {0: 4, 1: 4}}}] * 4
+
+    assert CV.bind_reload_rpc(rpc)(5, {0: 4, 1: 4}) == {0: 4, 1: 4}
+
+
+def test_empty_rpc_result_is_a_failure():
+    assert CV.bind_reload_rpc(lambda m, args=None: [])(5, {0: 4}) is None
+
+
+def test_the_shipped_rpc_reports_installed_false():
+    """Guard on the real worker extension: while the device-side install is
+    unimplemented, the RPC must say so rather than imply success."""
+    # parents[4] is $HOME: .../tests/exl3_fungible/<file> -> tests -> gg-vllm
+    # -> src -> HOME. Getting this off by one made the guard SKIP, and a
+    # guard that silently skips is not a guard.
+    candidates = [
+        Path(__file__).resolve().parents[4] / "protensors-work"
+        / "vllm-voipmonitor" / "research" / "fungible-quant" / "tools"
+        / "fq_reload.py",
+        Path.home() / "gg-extra" / "fq_reload.py",
+    ]
+    src = next((c for c in candidates if c.exists()), None)
+    assert src is not None, f"worker extension not found in {candidates}"
+    text = src.read_text()
+    i = text.index("def fq_converge_layers")
+    body = text[i:text.index("\ndef ", i)]
+    assert '"installed": False' in body, (
+        "the RPC must not imply an install it does not perform")
+
+
+# ------------------------------------------------------- reachability of state
+def test_loader_publishes_the_plan_process_wide():
+    """The loader BUILT a plan on every boot and nothing passed
+    convergence_out, so it was populated, logged once and garbage collected.
+    The accounting existed and was unreachable -- which means the 'weights are
+    still converging' telemetry did not exist at runtime at all."""
+    assert "set_active_plan(_plan)" in _progressive_src()
+
+
+def test_snapshot_without_a_boot_is_unknown_not_converged():
+    """'No information' and 'nothing left to do' are different answers, and
+    only one of them is reassuring."""
+    CV.set_active_plan(None)
+    snap = CV.convergence_snapshot()
+    assert snap["state"] == "unknown"
+    assert snap["is_final"] is False
+
+
+def test_snapshot_reflects_the_published_plan():
+    p = _plan()
+    p.observe(3, 0, actual_k=2, target_k=4)
+    CV.set_active_plan(p)
+    try:
+        snap = CV.convergence_snapshot()
+        assert snap["state"] == "converging"
+        assert snap["drift_bits"] == 2
+        assert snap["is_final"] is False
+    finally:
+        CV.set_active_plan(None)
+
+
+def test_a_second_boot_replaces_rather_than_accumulates():
+    """A reload replaces the posture; stale deficits from the previous boot
+    must not linger and understate convergence."""
+    first, second = _plan(), _plan()
+    first.observe(3, 0, actual_k=2, target_k=4)
+    CV.set_active_plan(first)
+    CV.set_active_plan(second)
+    try:
+        assert CV.active_plan() is second
+        assert CV.convergence_snapshot()["drift_bits"] == 0
+    finally:
+        CV.set_active_plan(None)

--- a/tests/exl3_fungible/test_convergence_cpu.py
+++ b/tests/exl3_fungible/test_convergence_cpu.py
@@ -336,3 +336,93 @@ def test_missing_convergence_module_does_not_break_the_loader():
     """The loader must still work if this module is absent (older rootfs)."""
     src = _progressive_src()
     assert "except ImportError" in src
+
+
+# ------------------------------------------------------------- the repay loop
+def test_worker_repays_deficits_through_the_injected_swap():
+    p = _plan()
+    for e in range(3):
+        p.observe(3, e, actual_k=2, target_k=3)
+    calls = []
+
+    def swap(layer, expert, target_k):
+        calls.append((layer, expert, target_k))
+        return target_k
+
+    w = CV.ConvergenceWorker(p, swap)
+    out = w.step()
+    assert out["repaid"] == 3 and out["pending"] == 0
+    assert p.state is CV.ConvergenceState.CONVERGED
+    assert len(calls) == 3
+
+
+def test_worker_respects_the_batch_so_a_tick_is_bounded():
+    """19,200 deficits must not be attempted inside one engine tick."""
+    p = _plan()
+    for e in range(100):
+        p.observe(3, e, actual_k=2, target_k=3)
+    out = CV.ConvergenceWorker(p, lambda *a: 3, batch=16).step()
+    assert out["attempted"] == 16 and out["pending"] == 84
+
+
+def test_a_swap_that_raises_does_not_bring_down_a_serving_engine():
+    p = _plan()
+    p.observe(3, 0, actual_k=2, target_k=3)
+
+    def boom(*a):
+        raise RuntimeError("fetch exploded")
+
+    out = CV.ConvergenceWorker(p, boom).step()
+    assert out["failed"] == 1 and out["repaid"] == 0
+    assert p.pending_count == 1          # still owed, will retry
+
+
+def test_worker_stops_spinning_on_written_off_deficits():
+    """A segment that does not exist yet must not be retried every tick
+    forever -- that is a busy loop against the Hub."""
+    p = _plan()
+    p.observe(3, 0, actual_k=2, target_k=3)
+    w = CV.ConvergenceWorker(p, lambda *a: None, max_attempts=3)
+    for _ in range(3):
+        w.step()
+    assert p.state is CV.ConvergenceState.STALLED
+    before = p.snapshot()
+    assert w.step()["attempted"] == 0, "kept retrying a written-off deficit"
+    assert p.snapshot()["experts_pending"] == before["experts_pending"]
+
+
+def test_partial_climb_is_kept_not_counted_as_repaid():
+    p = _plan()
+    p.observe(3, 0, actual_k=2, target_k=4)
+    out = CV.ConvergenceWorker(p, lambda l, e, k: 3).step()
+    assert out["repaid"] == 0
+    assert p.pending_count == 1 and p.drift_bits == 1
+
+
+def test_worker_reports_drift_so_a_scrape_sees_convergence_moving():
+    p = _plan()
+    p.observe(3, 0, actual_k=2, target_k=4)
+    p.observe(3, 1, actual_k=2, target_k=4)
+    w = CV.ConvergenceWorker(p, lambda l, e, k: k, batch=1)
+    assert w.step()["drift_bits"] == 2
+    assert w.step()["drift_bits"] == 0
+
+
+def test_done_is_false_while_work_remains():
+    p = _plan()
+    p.observe(3, 0, actual_k=2, target_k=3)
+    w = CV.ConvergenceWorker(p, lambda *a: 3)
+    assert w.done() is False
+    w.step()
+    assert w.done() is True
+
+
+def test_priority_reaches_the_worker():
+    p = _plan()
+    p.observe(3, 0, actual_k=2, target_k=3)
+    p.observe(9, 7, actual_k=2, target_k=3)
+    order = []
+    CV.ConvergenceWorker(
+        p, lambda l, e, k: (order.append((l, e)), k)[1], batch=1,
+        priority=lambda d: 100.0 if d.key() == (9, 7) else 1.0).step()
+    assert order == [(9, 7)]

--- a/tests/exl3_fungible/test_convergence_cpu.py
+++ b/tests/exl3_fungible/test_convergence_cpu.py
@@ -315,16 +315,29 @@ def test_loader_reports_missing_experts_to_the_plan():
 
 def test_gate_runs_once_after_all_layers_not_per_layer():
     """Gating inside the layer loop would fail on the FIRST layer with a
-    missing expert and report that layer's count as the whole extent."""
-    src = _progressive_src()
-    # the CALL, not a comment that mentions it
-    calls = [ln for ln in src.splitlines()
-             if ln.strip().startswith("_plan.gate()")]
-    assert len(calls) == 1, f"expected exactly one gate call, got {calls}"
-    indent = len(calls[0]) - len(calls[0].lstrip())
-    # the per-layer loop body sits deeper than this; 12 is the post-loop level
-    assert indent <= 12, f"gate is inside the layer loop (indent {indent})"
+    missing expert and report that layer's count as the whole extent.
 
+    Checked structurally rather than by indentation: the gate legitimately
+    gained a nesting level when it moved under the opt-in, and an indent
+    heuristic called that a regression when nothing had moved.
+    """
+    import ast
+
+    tree = ast.parse(_progressive_src())
+
+    def calls_gate(node):
+        return any(
+            isinstance(n, ast.Attribute) and n.attr == "gate"
+            for n in ast.walk(node))
+
+    loops = [n for n in ast.walk(tree)
+             if isinstance(n, ast.For)
+             and any(isinstance(x, ast.Name) and x.id == "_sorted_layers"
+                     for x in ast.walk(n.iter))]
+    assert loops, "could not find the per-layer loop"
+    for loop in loops:
+        assert not calls_gate(loop), "gate() runs inside the layer loop"
+    assert calls_gate(tree), "gate() is not called at all"
 
 def test_opportunistic_is_off_unless_env_says_otherwise():
     src = _progressive_src()
@@ -426,3 +439,102 @@ def test_priority_reaches_the_worker():
         p, lambda l, e, k: (order.append((l, e)), k)[1], batch=1,
         priority=lambda d: 100.0 if d.key() == (9, 7) else 1.0).step()
     assert order == [(9, 7)]
+
+
+# ------------------------------------------- layer-granular repayment (reload)
+def test_deficits_group_by_layer_worst_first():
+    """Convergence is layer-granular whether we like it or not: a degraded
+    boot never ALLOCATED the K4 slab, and the swap engine only moves experts
+    between slabs that already exist. So the layer is rebuilt, and repaying 40
+    deficits in one layer must cost one reload, not forty."""
+    p = _plan()
+    for e in range(3):
+        p.observe(9, e, actual_k=2, target_k=3)      # layer 9: gap 3 total
+    p.observe(4, 0, actual_k=2, target_k=5)          # layer 4: gap 3
+    p.observe(7, 0, actual_k=3, target_k=4)          # layer 7: gap 1
+    groups = CV.group_by_layer(p.pending())
+    assert [g[0] for g in groups][:1] in ([4], [9]), "worst layer must lead"
+    assert dict((l, len(ds)) for l, ds in groups)[9] == 3
+
+
+def test_group_by_layer_caps_the_batch():
+    p = _plan()
+    for layer in range(10):
+        p.observe(layer, 0, actual_k=2, target_k=3)
+    assert len(CV.group_by_layer(p.pending(), batch_layers=3)) == 3
+
+
+def test_layer_worker_repays_a_whole_layer_in_one_reload():
+    p = _plan()
+    for e in range(40):
+        p.observe(5, e, actual_k=3, target_k=4)
+    calls = []
+
+    def reload_fn(layer, want):
+        calls.append((layer, len(want)))
+        return {e: 4 for e in want}
+
+    out = CV.LayerConvergenceWorker(p, reload_fn).step()
+    assert calls == [(5, 40)], "40 deficits must cost ONE reload"
+    assert out["repaid"] == 40 and out["pending"] == 0
+
+
+def test_layer_worker_survives_a_reload_that_raises():
+    p = _plan()
+    p.observe(5, 0, actual_k=3, target_k=4)
+
+    def boom(layer, want):
+        raise RuntimeError("quiesce failed")
+
+    out = CV.LayerConvergenceWorker(p, boom).step()
+    assert out["failed"] == 1 and p.pending_count == 1
+
+
+def test_partial_layer_repay_is_recorded_per_expert():
+    """A reload may satisfy some experts and not others -- the segment for one
+    of them may still not exist."""
+    p = _plan()
+    for e in range(3):
+        p.observe(5, e, actual_k=3, target_k=4)
+    out = CV.LayerConvergenceWorker(p, lambda l, w: {0: 4, 1: 4}).step()
+    assert out["repaid"] == 2 and out["failed"] == 1
+    assert p.pending_count == 1
+
+
+def test_layer_worker_skips_written_off_deficits():
+    p = _plan()
+    p.observe(5, 0, actual_k=3, target_k=4)
+    w = CV.LayerConvergenceWorker(p, lambda l, x: None, max_attempts=3)
+    for _ in range(3):
+        w.step()
+    assert p.state is CV.ConvergenceState.STALLED
+    assert w.step()["layers_attempted"] == 0
+
+
+def test_reload_returning_none_is_a_failure_not_a_silent_success():
+    p = _plan()
+    p.observe(5, 0, actual_k=3, target_k=4)
+    out = CV.LayerConvergenceWorker(p, lambda l, w: None).step()
+    assert out["repaid"] == 0 and out["failed"] == 1
+
+
+# ------------------------------------------------ fallbacks recorded ALWAYS
+def test_loader_builds_the_plan_unconditionally():
+    """The K ladder degrades an expert whenever a fragment is unavailable, and
+    that was recorded nowhere a repay loop could act on unless the operator
+    had opted into opportunistic mode. One transient URLError left L5/e2 at K3
+    for the process lifetime with nothing tracking it."""
+    src = _progressive_src()
+    i = src.index("_plan = ConvergencePlan(")
+    j = src.rindex("if ", 0, i)
+    assert "opportunistic_enabled()" not in src[j:i], (
+        "plan construction must not be gated on the opt-in")
+
+
+def test_optin_still_governs_whether_missing_experts_are_deferred():
+    """The opt-in governs whether the boot may PROCEED past missing experts —
+    never whether a degradation is noticed."""
+    src = _progressive_src()
+    assert "if unavailable and _opportunistic:" in src
+    assert "if _opportunistic:\n                # ONCE" in src or \
+           "_plan.gate()" in src

--- a/tests/exl3_fungible/test_convergence_cpu.py
+++ b/tests/exl3_fungible/test_convergence_cpu.py
@@ -1,0 +1,338 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Opportunistic time-to-serve, and the honesty guarantees around it.
+
+The feature trades initial quality for time-to-serve: boot on whatever tiers
+the primed cache holds, then converge to the requested posture at runtime.
+That is only defensible if two things hold, and these tests pin both:
+
+  * a MISSING expert is fatal while a BELOW-TARGET expert is not, and
+  * a converging model can never be read as a finished one.
+
+The second matters most. A benchmark run mid-convergence that gets attributed
+to the intended configuration is exactly the kind of quietly-wrong number that
+would discredit the approach.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+try:
+    from vllm.model_executor.layers.quantization.exl3_fungible import (
+        convergence as CV,
+    )
+except ImportError:  # standalone: load by path
+    import importlib.util
+
+    _dir = (Path(__file__).resolve().parents[2] / "vllm" / "model_executor"
+            / "layers" / "quantization" / "exl3_fungible")
+    _spec = importlib.util.spec_from_file_location(
+        "fq_convergence_standalone", _dir / "convergence.py")
+    CV = importlib.util.module_from_spec(_spec)
+    sys.modules[_spec.name] = CV
+    _spec.loader.exec_module(CV)
+
+
+def _plan(**kw):
+    return CV.ConvergencePlan(**kw)
+
+
+# ------------------------------------------------------------------- opt-in
+@pytest.mark.parametrize("val,on", [
+    ("1", True), ("true", True), ("YES", True), ("on", True),
+    ("0", False), ("", False), ("no", False),
+])
+def test_opportunistic_is_opt_in(val, on):
+    assert CV.opportunistic_enabled({"VLLM_FQ_OPPORTUNISTIC": val}) is on
+
+
+def test_default_is_off():
+    """Serving a knowingly-degraded model must never be the default."""
+    assert CV.opportunistic_enabled({}) is False
+
+
+def test_k_bounds_default_span_the_format():
+    assert CV.k_bounds({}) == (2, 5)
+
+
+def test_k_bounds_are_honoured():
+    assert CV.k_bounds({"VLLM_FQ_K_MIN": "3", "VLLM_FQ_K_MAX": "4"}) == (3, 4)
+
+
+def test_inverted_bounds_are_rejected_loudly():
+    """min>max accepts nothing; failing at parse beats an inscrutable
+    'no fragment acceptable' at expert 12,000."""
+    with pytest.raises(ValueError, match="no tier is acceptable"):
+        CV.k_bounds({"VLLM_FQ_K_MIN": "5", "VLLM_FQ_K_MAX": "3"})
+
+
+def test_acceptable_respects_bounds():
+    p = _plan(k_min=3, k_max=4)
+    assert [p.acceptable(k) for k in (2, 3, 4, 5)] == [False, True, True, False]
+
+
+# -------------------------------------------------------------- the gate
+def test_below_target_is_servable():
+    """The whole premise: K2 is a coarser version of the same expert, not a
+    broken one."""
+    p = _plan()
+    p.observe(3, 0, actual_k=2, target_k=3)
+    assert p.complete
+    p.gate()                       # must not raise
+
+
+def test_missing_expert_is_fatal():
+    """Serving without an expert is incoherent, not merely coarse."""
+    p = _plan()
+    p.observe(3, 0, actual_k=2, target_k=3)
+    p.observe_missing(3, 1)
+    assert not p.complete
+    with pytest.raises(ValueError, match="no fragment at ANY tier"):
+        p.gate()
+
+
+def test_gate_message_names_examples_and_bounds():
+    p = _plan(k_min=3, k_max=4)
+    for e in range(12):
+        p.observe_missing(7, e)
+    with pytest.raises(ValueError) as ei:
+        p.gate()
+    msg = str(ei.value)
+    assert "12 expert(s)" in msg and "K3..K4" in msg and "L7/e0" in msg
+
+
+def test_a_fully_satisfied_boot_needs_no_convergence():
+    p = _plan()
+    for e in range(8):
+        p.observe(3, e, actual_k=3, target_k=3)
+    assert p.pending_count == 0
+    assert p.state is CV.ConvergenceState.PRISTINE
+    assert p.state.is_final
+
+
+# ------------------------------------------------------- honesty of the state
+def test_converging_is_not_final():
+    """The guarantee that keeps a mid-convergence benchmark from being
+    attributed to the intended configuration."""
+    p = _plan()
+    p.observe(3, 0, actual_k=2, target_k=4)
+    assert p.state is CV.ConvergenceState.CONVERGING
+    assert p.state.is_final is False
+    assert "NOT FINAL" in p.describe()
+
+
+def test_converged_is_distinguishable_from_pristine():
+    """Both are final, but 'started degraded and repaid' is a different fact
+    from 'was correct all along', and an operator reading a dashboard after
+    the fact deserves to know which happened."""
+    p = _plan()
+    p.observe(3, 0, actual_k=2, target_k=3)
+    assert p.state is CV.ConvergenceState.CONVERGING
+    p.repay(3, 0, new_k=3)
+    assert p.state is CV.ConvergenceState.CONVERGED
+    assert p.state.is_final
+    assert p.state is not CV.ConvergenceState.PRISTINE
+
+
+def test_ratio_reaches_one_only_when_actually_done():
+    p = _plan()
+    for e in range(4):
+        p.observe(3, e, actual_k=2, target_k=3)
+    assert p.converged_ratio == 0.0
+    p.repay(3, 0, new_k=3)
+    p.repay(3, 1, new_k=3)
+    assert p.converged_ratio == 0.5
+    p.repay(3, 2, new_k=3)
+    p.repay(3, 3, new_k=3)
+    assert p.converged_ratio == 1.0
+
+
+def test_drift_bits_is_zero_exactly_when_posture_matches():
+    p = _plan()
+    p.observe(3, 0, actual_k=2, target_k=4)     # owes 2
+    p.observe(3, 1, actual_k=3, target_k=4)     # owes 1
+    assert p.drift_bits == 3
+    p.repay(3, 0, new_k=4)
+    assert p.drift_bits == 1
+    p.repay(3, 1, new_k=4)
+    assert p.drift_bits == 0
+
+
+def test_partial_climb_up_the_ladder_reduces_drift_without_closing():
+    """K2 -> K3 against a K4 target is progress, not completion."""
+    p = _plan()
+    p.observe(3, 0, actual_k=2, target_k=4)
+    assert p.repay(3, 0, new_k=3) is False
+    assert p.pending_count == 1
+    assert p.drift_bits == 1
+    assert p.repay(3, 0, new_k=4) is True
+    assert p.pending_count == 0
+
+
+def test_overshoot_closes_the_deficit():
+    p = _plan()
+    p.observe(3, 0, actual_k=2, target_k=3)
+    assert p.repay(3, 0, new_k=5) is True
+
+
+def test_repaying_an_unknown_expert_is_a_noop():
+    assert _plan().repay(9, 9, new_k=5) is False
+
+
+# ------------------------------------------------------------------ the queue
+def test_worst_deficit_is_repaid_first():
+    p = _plan()
+    p.observe(3, 0, actual_k=3, target_k=4)     # gap 1
+    p.observe(4, 1, actual_k=2, target_k=5)     # gap 3
+    p.observe(5, 2, actual_k=2, target_k=3)     # gap 1
+    assert [d.key() for d in p.pending()][0] == (4, 1)
+
+
+def test_priority_hook_lets_traffic_drive_convergence():
+    """Layer index is a poor proxy for importance; activation counts are the
+    thing the caller knows and this module does not."""
+    p = _plan()
+    p.observe(3, 0, actual_k=2, target_k=3)
+    p.observe(9, 7, actual_k=2, target_k=3)
+    hot = {(9, 7): 5000.0, (3, 0): 1.0}
+    assert [d.key() for d in p.pending(priority=lambda d: hot[d.key()])][0] \
+        == (9, 7)
+
+
+def test_pending_is_a_copy_not_the_live_dict():
+    p = _plan()
+    p.observe(3, 0, actual_k=2, target_k=3)
+    got = p.pending()
+    got.clear()
+    assert p.pending_count == 1
+
+
+# -------------------------------------------------------------- unrepayable
+def test_repeated_failures_become_stalled_not_silently_converging():
+    """If the fetch cannot be satisfied -- the segment does not exist yet, the
+    Hub is unreachable -- the operator must not see 'converging' forever."""
+    p = _plan()
+    p.observe(3, 0, actual_k=2, target_k=3)
+    for _ in range(3):
+        p.fail(3, 0)
+    assert p.state is CV.ConvergenceState.STALLED
+    assert p.state.is_final is False
+    assert p.give_up() and p.give_up()[0].key() == (3, 0)
+
+
+def test_one_failure_is_not_a_stall():
+    p = _plan()
+    p.observe(3, 0, actual_k=2, target_k=3)
+    p.fail(3, 0)
+    assert p.state is CV.ConvergenceState.CONVERGING
+
+
+def test_a_successful_repay_clears_the_failure_record():
+    p = _plan()
+    p.observe(3, 0, actual_k=2, target_k=3)
+    p.fail(3, 0)
+    p.repay(3, 0, new_k=3)
+    assert p.give_up() == []
+    assert p.state is CV.ConvergenceState.CONVERGED
+
+
+# --------------------------------------------------------------- the snapshot
+def test_snapshot_carries_everything_a_scrape_needs():
+    p = _plan(k_min=2, k_max=4)
+    p.observe(3, 0, actual_k=2, target_k=4)
+    p.observe(3, 1, actual_k=3, target_k=4)
+    p.observe(9, 2, actual_k=4, target_k=4)
+    s = p.snapshot()
+    assert s["state"] == "converging" and s["is_final"] is False
+    assert s["experts_total"] == 3 and s["experts_pending"] == 2
+    assert s["drift_bits"] == 3
+    assert s["k_min"] == 2 and s["k_max"] == 4
+    assert s["layers_affected"] == 1
+    assert s["worst_layers"][0] == (3, 2)
+
+
+def test_snapshot_is_final_true_only_when_final():
+    p = _plan()
+    p.observe(3, 0, actual_k=3, target_k=3)
+    assert p.snapshot()["is_final"] is True
+
+
+def test_empty_plan_is_pristine_and_final():
+    p = _plan()
+    assert p.converged_ratio == 1.0
+    assert p.state is CV.ConvergenceState.PRISTINE
+    assert p.snapshot()["is_final"] is True
+
+
+# ------------------------------------------------------------- thread safety
+def test_concurrent_observe_and_repay_do_not_corrupt_counts():
+    """The loader records from the weight-iterator thread while the
+    convergence worker drains and a scrape reads."""
+    import threading
+    p = _plan()
+    n = 200
+
+    def writer():
+        for e in range(n):
+            p.observe(3, e, actual_k=2, target_k=3)
+
+    def reader():
+        for _ in range(n):
+            p.snapshot()
+            _ = p.drift_bits
+
+    ts = [threading.Thread(target=writer), threading.Thread(target=reader)]
+    for t in ts:
+        t.start()
+    for t in ts:
+        t.join(10)
+    assert p.pending_count == n
+    for e in range(n):
+        p.repay(3, e, new_k=3)
+    assert p.pending_count == 0 and p.converged_ratio == 1.0
+
+
+# --------------------------------------------------- loader integration guards
+def _progressive_src() -> str:
+    return (Path(__file__).resolve().parents[2] / "vllm" / "model_executor"
+            / "layers" / "quantization" / "exl3_fungible"
+            / "progressive.py").read_text()
+
+
+def test_loader_records_every_expert_not_just_substitutions():
+    """converged_ratio needs the DENOMINATOR. Recording only substitutions
+    would make a 90%-degraded boot and a 1%-degraded boot both read as
+    'pending N' with no scale."""
+    src = _progressive_src()
+    assert "_plan.observe(layer, expert, actual_k, int(k))" in src
+
+
+def test_loader_reports_missing_experts_to_the_plan():
+    assert "_plan.observe_missing(layer, expert)" in _progressive_src()
+
+
+def test_gate_runs_once_after_all_layers_not_per_layer():
+    """Gating inside the layer loop would fail on the FIRST layer with a
+    missing expert and report that layer's count as the whole extent."""
+    src = _progressive_src()
+    # the CALL, not a comment that mentions it
+    calls = [ln for ln in src.splitlines()
+             if ln.strip().startswith("_plan.gate()")]
+    assert len(calls) == 1, f"expected exactly one gate call, got {calls}"
+    indent = len(calls[0]) - len(calls[0].lstrip())
+    # the per-layer loop body sits deeper than this; 12 is the post-loop level
+    assert indent <= 12, f"gate is inside the layer loop (indent {indent})"
+
+
+def test_opportunistic_is_off_unless_env_says_otherwise():
+    src = _progressive_src()
+    assert "opportunistic_enabled()" in src
+    assert "_plan = None" in src
+
+
+def test_missing_convergence_module_does_not_break_the_loader():
+    """The loader must still work if this module is absent (older rootfs)."""
+    src = _progressive_src()
+    assert "except ImportError" in src

--- a/tests/exl3_fungible/test_cross_rank_t6_cpu.py
+++ b/tests/exl3_fungible/test_cross_rank_t6_cpu.py
@@ -1,0 +1,367 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""T6 — cross-rank agreement (03-testing-validation.md).
+
+Claim under test: **every rank of a TP group computes the same swap list and
+the same decision digest without any collective.** The mechanism is not the
+hash — the hash was only ever evidence. The mechanism is that the policy
+domain is *logical* (D4: `fq-policy/2` documents are keyed by logical expert
+id and `store.validate_policy` refuses any rank/world_size/tp/device field)
+and `policy.decide` is a pure, total-order-sorted function of
+(stats, eps, membership, pins, dwell, cfg).
+
+Evidence design — why 4 processes and not 4 GPUs. A TP4 serve run would
+exercise the same pure function four times with the same inputs; the GPUs
+contribute nothing to the property, and their presence would *weaken* the
+test (a shared parent process, shared module state and one shared RNG make
+accidental agreement easy). So this harness runs four SIMULATED ranks as
+independent spawned interpreters, each hostile to the property in a way a
+real TP4 run is not:
+
+* a different ``PYTHONHASHSEED`` — any dict/set iteration-order dependence
+  inside decide()/explain() diverges (str hashing is randomized per process);
+* a different global RNG seeding (``random`` + ``numpy.random``) — any
+  accidental use of global randomness diverges;
+* a different ``VLLM_FQ_RANK``/``LOCAL_RANK``/``CUDA_VISIBLE_DEVICES`` in the
+  environment — any topology leak into the decision diverges;
+* the interval inputs are RECONSTRUCTED independently inside each process
+  from one shared integer seed, so input construction is proven deterministic
+  too (nothing is pickled across, except the seed and the transcript back).
+
+The 50 synthetic intervals are a *trajectory*: each interval's swaps are
+applied before the next one is decided, so a single divergence at interval i
+cascades through every later interval and hash.
+
+Runnable directly: ``python test_cross_rank_t6_cpu.py``.
+"""
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import multiprocessing as mp
+import os
+import sys
+import types
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+_DIR = (Path(__file__).resolve().parents[2] / "vllm" / "model_executor"
+        / "layers" / "quantization" / "exl3_fungible")
+_PKG = "vllm.model_executor.layers.quantization.exl3_fungible"
+
+
+def _load_tree_modules():
+    """Load policy/store/decision_log from the WORKING TREE by path.
+
+    A stub package entry makes ``decision_log``'s absolute import resolve to
+    the same tree copy without importing vllm (which would cost seconds in
+    every spawned rank, for nothing: the policy domain has no torch in it).
+    """
+    if _PKG in sys.modules and getattr(sys.modules[_PKG], "_fq_t6_stub", False):
+        pkg = sys.modules[_PKG]
+        return pkg.policy, pkg.store, pkg.decision_log
+
+    def load(name, path):
+        spec = importlib.util.spec_from_file_location(name, path)
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[name] = mod
+        spec.loader.exec_module(mod)
+        return mod
+
+    pkg = types.ModuleType(_PKG)
+    pkg._fq_t6_stub = True
+    prev = sys.modules.get(_PKG)
+    sys.modules[_PKG] = pkg
+    try:
+        pkg.policy = load(f"{_PKG}.policy", _DIR / "policy.py")
+        pkg.store = load(f"{_PKG}.store", _DIR / "store.py")
+        pkg.decision_log = load("fq_t6_decision_log", _DIR / "decision_log.py")
+    except BaseException:
+        if prev is not None:
+            sys.modules[_PKG] = prev
+        raise
+    return pkg.policy, pkg.store, pkg.decision_log
+
+
+P, S, DL = _load_tree_modules()
+
+# ---------------------------------------------------------------- scenario
+
+L, E, N_K4 = 6, 24, 8
+INTERVALS = 50
+RANKS = 4
+SEED = 20260810
+
+
+def interval_inputs(seed: int, i: int, tier_of: np.ndarray) -> dict:
+    """Interval ``i``'s synthetic observation, from ``seed`` alone.
+
+    Varied across intervals: routing counts/mass (a drifting hot set, so the
+    desired set actually moves), eps curves, dwell readiness, pins, and the
+    guard knobs (hysteresis, per-layer/total caps).
+    """
+    rng = np.random.default_rng(seed * 1_000_003 + i)
+    hot = (np.arange(E)[None, :] + 3 * i) % E < 6  # the hot set walks
+    count = rng.integers(0, 400, size=(L, E)).astype(np.float64)
+    count += hot * rng.integers(1000, 9000, size=(L, E))
+    mass = rng.uniform(0.0, 4.0, size=(L, E)) + hot * rng.uniform(5.0, 40.0,
+                                                                  size=(L, E))
+    eps = {3: rng.uniform(0.02, 0.30, size=(L, E)),
+           4: rng.uniform(0.00, 0.02, size=(L, E))}
+    dwell = rng.integers(0, 12000, size=(L, E)).astype(np.int64)
+    pins = np.zeros((L, E), dtype=np.int64)
+    if i % 7 == 3:  # a pinned pair every few intervals
+        pins[i % L, (2 * i) % E] = P.PIN_K4
+        pins[i % L, (2 * i + 1) % E] = P.PIN_K3
+    cfg = {
+        "n_k4": N_K4,
+        "hysteresis": 1.05 + 0.05 * (i % 5),
+        "dwell_steps": 6000 if i % 3 else 0,
+        "max_swaps_per_layer": 1 + (i % 2),
+        "max_swaps_total": 4 + (i % 9),
+    }
+    return {"stats": {"count": count, "mass": mass}, "eps": eps,
+            "tier_of": tier_of, "pins": pins, "dwell": dwell, "cfg": cfg}
+
+
+def initial_membership(seed: int) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    tier = np.full((L, E), P.K3, dtype=np.int64)
+    for l in range(L):
+        tier[l, rng.permutation(E)[:N_K4]] = P.K4
+    return tier
+
+
+def decision_sha(swaps) -> str:
+    """The digest loop.FungibleQuantState.decision_sha logs per rank."""
+    return hashlib.sha256(
+        json.dumps(swaps, separators=(",", ":")).encode()).hexdigest()
+
+
+def rank_transcript(seed: int, intervals: int = INTERVALS,
+                    stats_jitter: float = 0.0) -> list[dict]:
+    """One rank's full decision trajectory: the thing that must agree.
+
+    Per interval: the ordered swap list, the resulting membership, the
+    fq-policy/2 document hash (store.policy_hash — what gets persisted and
+    compared at boot) and the decision digest, plus the explainability
+    record's own digest (decision records are rank-invariant too, or the
+    audit trail would not be comparable across ranks).
+    """
+    tier_of = initial_membership(seed)
+    out: list[dict] = []
+    for i in range(intervals):
+        inp = interval_inputs(seed, i, tier_of)
+        if stats_jitter:
+            # Saboteur rank: it observed its OWN shard's routing sample
+            # instead of the logical global one — the exact bug T6 exists to
+            # catch. (A uniform *scale* would not diverge: score is linear in
+            # count and the hysteresis test is a ratio, so both are
+            # scale-invariant. Per-expert noise is the real hazard.)
+            noise = np.random.default_rng(90000 + i).uniform(
+                1.0 - stats_jitter, 1.0 + stats_jitter, size=(L, E))
+            inp["stats"]["count"] = inp["stats"]["count"] * noise
+        swaps = P.decide(inp["stats"], inp["eps"], inp["tier_of"],
+                         pins=inp["pins"], dwell=inp["dwell"], cfg=inp["cfg"])
+        tier_of = P.apply_swaps(tier_of, swaps)
+        doc = {
+            "schema": S.POLICY_SCHEMA,
+            "manifest": "t6-synthetic",
+            "budget": {"n_k4_per_layer": {str(l): N_K4 for l in range(L)}},
+            "bits_per_expert": {str(l): [int(b) for b in tier_of[l]]
+                                for l in range(L)},
+        }
+        S.validate_policy(doc, num_experts=E)  # D4: topology-neutral
+        record = DL.explain(inp["stats"], inp["eps"], inp["tier_of"], swaps,
+                            pins=inp["pins"], dwell=inp["dwell"],
+                            cfg=inp["cfg"], step=i * 3000)
+        out.append({
+            "interval": i,
+            "swaps": [[int(l), int(a), int(b)] for l, a, b in swaps],
+            "decision_sha": decision_sha(swaps),
+            "policy_sha": S.policy_hash(doc),
+            "record_sha": hashlib.sha256(
+                DL.to_json(record).encode()).hexdigest(),
+            "n_k4": [int(x) for x in P.n_k4_of(tier_of)],
+        })
+    return out
+
+
+def transcript_sha(transcript: list[dict]) -> str:
+    return hashlib.sha256(
+        json.dumps(transcript, sort_keys=True,
+                   separators=(",", ":")).encode()).hexdigest()
+
+
+# --------------------------------------------------------- rank processes
+
+
+def _rank_worker(rank: int, seed: int, queue) -> None:
+    """Runs in a FRESH interpreter (spawn). Hostile-to-agreement setup:
+    per-rank global RNG seeding on top of the per-rank PYTHONHASHSEED and
+    topology env the parent set before starting this process."""
+    import random
+
+    random.seed(rank * 7919)
+    np.random.seed(rank + 1)  # legacy global RNG, deliberately per-rank
+    transcript = rank_transcript(seed)
+    queue.put((rank, sys.flags.hash_randomization,
+               os.environ.get("PYTHONHASHSEED"), transcript))
+
+
+def _spawn_ranks(seed: int, ranks: int = RANKS) -> dict[int, list[dict]]:
+    ctx = mp.get_context("spawn")
+    queue = ctx.Queue()
+    procs = []
+    saved = {k: os.environ.get(k) for k in
+             ("PYTHONHASHSEED", "VLLM_FQ_RANK", "LOCAL_RANK", "RANK",
+              "CUDA_VISIBLE_DEVICES")}
+    try:
+        for rank in range(ranks):
+            # Inherited by the spawned interpreter at startup: PYTHONHASHSEED
+            # only takes effect that way, which is exactly what we want.
+            os.environ["PYTHONHASHSEED"] = str(1 + rank * 104729)
+            os.environ["VLLM_FQ_RANK"] = str(rank)
+            os.environ["LOCAL_RANK"] = str(rank)
+            os.environ["RANK"] = str(rank)
+            os.environ["CUDA_VISIBLE_DEVICES"] = str(rank)
+            p = ctx.Process(target=_rank_worker, args=(rank, seed, queue))
+            p.start()
+            procs.append(p)
+        results = {}
+        seeds_seen = {}
+        for _ in procs:
+            rank, randomized, hashseed, transcript = queue.get(timeout=300)
+            results[rank] = transcript
+            seeds_seen[rank] = (randomized, hashseed)
+        for p in procs:
+            p.join(timeout=60)
+            assert p.exitcode == 0, f"rank process exited {p.exitcode}"
+        assert len({s for _, s in seeds_seen.values()}) == RANKS, (
+            f"ranks did not get distinct PYTHONHASHSEEDs: {seeds_seen}")
+        return results
+    finally:
+        for p in procs:
+            if p.is_alive():
+                p.terminate()
+        for key, value in saved.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+@pytest.fixture(scope="module")
+def rank_transcripts():
+    return _spawn_ranks(SEED)
+
+
+# ------------------------------------------------------------------- tests
+
+
+def test_scenario_is_non_vacuous():
+    """The trajectory must actually swap, vary, and stay budget-legal —
+    otherwise 'all ranks agree' would be agreement on nothing."""
+    transcript = rank_transcript(SEED)
+    total = sum(len(step["swaps"]) for step in transcript)
+    moving = sum(1 for step in transcript if step["swaps"])
+    assert total >= 50, f"only {total} swaps over {INTERVALS} intervals"
+    assert moving >= INTERVALS // 3, f"only {moving} intervals moved"
+    assert len({step["decision_sha"] for step in transcript}) >= 10
+    for step in transcript:  # budget invariant holds all along (D1)
+        assert step["n_k4"] == [N_K4] * L
+
+
+def test_t6_four_ranks_agree_bit_for_bit(rank_transcripts):
+    """T6 proper: 4 independent processes, identical transcripts."""
+    assert sorted(rank_transcripts) == list(range(RANKS))
+    reference = rank_transcripts[0]
+    ref_sha = transcript_sha(reference)
+    for rank in range(1, RANKS):
+        other = rank_transcripts[rank]
+        assert len(other) == len(reference) == INTERVALS
+        for a, b in zip(reference, other):
+            assert a["swaps"] == b["swaps"], (
+                f"rank {rank} diverged on interval {a['interval']}: "
+                f"{a['swaps']} vs {b['swaps']}")
+            assert a["decision_sha"] == b["decision_sha"]
+            assert a["policy_sha"] == b["policy_sha"]
+            assert a["record_sha"] == b["record_sha"]
+        assert transcript_sha(other) == ref_sha
+
+
+def test_t6_digest_detects_divergence(rank_transcripts):
+    """The evidence is not vacuous: a rank fed its own shard-local routing
+    sample (±5% per-expert noise) must be caught by the digest — so equal
+    digests really do mean equal decisions."""
+    sabotaged = rank_transcript(SEED, stats_jitter=0.05)
+    reference = rank_transcripts[0]
+    assert transcript_sha(sabotaged) != transcript_sha(reference)
+    diverged = [a["interval"] for a, b in zip(reference, sabotaged)
+                if a["decision_sha"] != b["decision_sha"]]
+    assert diverged, "divergent decisions produced identical digests"
+    assert len(diverged) >= INTERVALS // 4, (
+        f"only {len(diverged)}/{INTERVALS} intervals caught the divergence")
+
+
+def test_t6_without_the_hash_outputs_still_identical(rank_transcripts):
+    """'Then kill the debug collective and rerun — outputs must be identical'
+    (03 T6): recompute the trajectory in-process with no hashing, no
+    processes, no env games; the swap lists still match every rank."""
+    tier_of = initial_membership(SEED)
+    reference = rank_transcripts[0]
+    for i in range(INTERVALS):
+        inp = interval_inputs(SEED, i, tier_of)
+        swaps = P.decide(inp["stats"], inp["eps"], inp["tier_of"],
+                         pins=inp["pins"], dwell=inp["dwell"], cfg=inp["cfg"])
+        assert [[int(l), int(a), int(b)] for l, a, b in swaps] == \
+            reference[i]["swaps"], f"interval {i} diverged without the hash"
+        tier_of = P.apply_swaps(tier_of, swaps)
+
+
+def test_t6_policy_documents_are_topology_neutral():
+    """D4 / store.validate_policy: nothing rank-shaped may enter the document
+    the ranks compare — that is *why* they can agree without a collective."""
+    doc = {
+        "schema": S.POLICY_SCHEMA,
+        "manifest": "t6-synthetic",
+        "budget": {"n_k4_per_layer": {"0": N_K4}},
+        "bits_per_expert": {"0": [4] * N_K4 + [3] * (E - N_K4)},
+    }
+    S.validate_policy(doc, num_experts=E)
+    for banned in ("rank", "world_size", "tp", "device", "devices"):
+        with pytest.raises(ValueError, match="topology-neutral"):
+            S.validate_policy(dict(doc, **{banned: 0}), num_experts=E)
+
+
+def test_t6_digest_matches_the_serving_loops_definition():
+    """The digest proven here is the one the serve log prints per rank
+    (loop.FungibleQuantState.decision_sha). Skipped if loop.py is not
+    importable standalone (it is another agent's live file)."""
+    def load(name, path):
+        spec = importlib.util.spec_from_file_location(name, path)
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[name] = mod
+        spec.loader.exec_module(mod)
+        return mod
+
+    try:
+        pkg = sys.modules[_PKG]
+        if not hasattr(pkg, "stats"):  # loop.py's remaining sibling import
+            pkg.stats = load(f"{_PKG}.stats", _DIR / "stats.py")
+        loop_sha = load("fq_t6_loop_probe",
+                        _DIR / "loop.py").FungibleQuantState.decision_sha
+    except BaseException as exc:  # noqa: BLE001 — optional cross-check
+        pytest.skip(f"loop.py not importable standalone here: {exc!r}")
+    finally:
+        sys.modules.pop("fq_t6_loop_probe", None)
+    swaps = [(0, 3, 7), (2, 1, 9)]
+    assert loop_sha(swaps) == decision_sha(swaps)
+    assert loop_sha([]) == decision_sha([])
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v", "-s", "-p", "no:cacheprovider"]))

--- a/tests/exl3_fungible/test_cross_rank_t6_cpu.py
+++ b/tests/exl3_fungible/test_cross_rank_t6_cpu.py
@@ -364,4 +364,7 @@ def test_t6_digest_matches_the_serving_loops_definition():
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__, "-v", "-s", "-p", "no:cacheprovider"]))
+    sys.exit(pytest.main([
+        __file__, "-v", "-p", "no:cacheprovider",
+        "--confcutdir", os.path.dirname(os.path.abspath(__file__)),
+    ]))

--- a/tests/exl3_fungible/test_decision_log_cpu.py
+++ b/tests/exl3_fungible/test_decision_log_cpu.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU tests: decision records explain every swap and every non-swap."""
+import json
+import logging
+
+import numpy as np
+import pytest
+
+try:
+    from vllm.model_executor.layers.quantization.exl3_fungible import (
+        decision_log as DL,
+        policy as P,
+    )
+except ImportError:  # standalone: load by path with a stub package
+    import importlib.util
+    import sys
+    import types
+    from pathlib import Path as _P
+
+    _dir = (_P(__file__).resolve().parents[2] / "vllm" / "model_executor"
+            / "layers" / "quantization" / "exl3_fungible")
+
+    def _load(name, path):
+        spec = importlib.util.spec_from_file_location(name, path)
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[name] = mod
+        spec.loader.exec_module(mod)
+        return mod
+
+    P = _load("vllm.model_executor.layers.quantization.exl3_fungible.policy",
+              _dir / "policy.py")
+    pkg = types.ModuleType("vllm.model_executor.layers.quantization.exl3_fungible")
+    pkg.policy = P
+    sys.modules["vllm.model_executor.layers.quantization.exl3_fungible"] = pkg
+    DL = _load("fq_decision_log_standalone", _dir / "decision_log.py")
+
+
+def scenario():
+    """2 layers x 8 experts; expert 4 is hot+sensitive (wants K4)."""
+    L, E = 2, 8
+    tier = np.full((L, E), 3)
+    tier[:, :3] = 4                       # budget 3 K4 per layer
+    count = np.ones((L, E)); count[:, 4] = 500.0
+    mass = np.ones((L, E)); mass[:, 4] = 50.0
+    eps = {3: np.full((L, E), 0.02), 4: np.full((L, E), 0.005)}
+    stats = {"count": count, "mass": mass}
+    cfg = {"n_k4": 3, "dwell_steps": 0}
+    return stats, eps, tier, cfg
+
+
+def test_every_swap_has_rationale():
+    stats, eps, tier, cfg = scenario()
+    swaps = P.decide(stats, eps, tier, cfg=cfg)
+    assert swaps, "scenario must produce swaps"
+    rec = DL.explain(stats, eps, tier, swaps, cfg=cfg, step=123,
+                     policy_sha_before="a" * 64, policy_sha_after="b" * 64)
+    assert len(rec["swaps"]) == len(swaps)
+    for sw in rec["swaps"]:
+        assert sw["expert_in"] == 4
+        assert sw["score_in"] > sw["score_out"]
+        assert sw["hysteresis_ratio"] > 1.25
+        assert sw["mass_in"] == 50.0
+    assert rec["totals"]["executed"] == len(swaps)
+    json.loads(DL.to_json(rec))  # serializable
+
+
+def test_blocked_tallies_dwell():
+    stats, eps, tier, cfg = scenario()
+    cfg = dict(cfg, dwell_steps=1000)
+    dwell = np.zeros((2, 8))              # nobody has dwelled long enough
+    swaps = P.decide(stats, eps, tier, dwell=dwell, cfg=cfg)
+    assert swaps == []
+    rec = DL.explain(stats, eps, tier, swaps, dwell=dwell, cfg=cfg)
+    assert rec["blocked"]["dwell"] >= 1
+    assert rec["totals"]["executed"] == 0
+
+
+def test_log_lines_emitted(caplog):
+    stats, eps, tier, cfg = scenario()
+    swaps = P.decide(stats, eps, tier, cfg=cfg)
+    rec = DL.explain(stats, eps, tier, swaps, cfg=cfg, step=7,
+                     policy_sha_before="c" * 64, policy_sha_after="d" * 64)
+    with caplog.at_level(logging.INFO):
+        DL.log_decision(rec)
+    text = caplog.text
+    assert "FQ interval step=7" in text
+    assert "FQ swap L" in text and "e4" in text
+    assert "cccccccc -> dddddddd" in text

--- a/tests/exl3_fungible/test_decision_log_cpu.py
+++ b/tests/exl3_fungible/test_decision_log_cpu.py
@@ -76,13 +76,21 @@ def test_blocked_tallies_dwell():
     assert rec["totals"]["executed"] == 0
 
 
-def test_log_lines_emitted(caplog):
+def test_log_lines_emitted(caplog, monkeypatch):
     stats, eps, tier, cfg = scenario()
     swaps = P.decide(stats, eps, tier, cfg=cfg)
     rec = DL.explain(stats, eps, tier, swaps, cfg=cfg, step=7,
                      policy_sha_before="c" * 64, policy_sha_after="d" * 64)
-    with caplog.at_level(logging.INFO):
-        DL.log_decision(rec)
+    # When DL is the real package module its logger sits under the "vllm"
+    # hierarchy, whose root vllm configures with propagate=False — attach
+    # caplog's handler directly so it sees the records either way.
+    DL.logger.addHandler(caplog.handler)
+    monkeypatch.setattr(DL.logger, "level", logging.INFO)
+    try:
+        with caplog.at_level(logging.INFO):
+            DL.log_decision(rec)
+    finally:
+        DL.logger.removeHandler(caplog.handler)
     text = caplog.text
     assert "FQ interval step=7" in text
     assert "FQ swap L" in text and "e4" in text

--- a/tests/exl3_fungible/test_fragments_cpu.py
+++ b/tests/exl3_fungible/test_fragments_cpu.py
@@ -1,0 +1,278 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU tests for FragmentResolver: local hit, source fallback, sha-mismatch
+rejection, cache reuse, verification policy."""
+import base64
+import hashlib
+import json
+import struct
+
+import pytest
+
+try:
+    from vllm.model_executor.layers.quantization.exl3_fungible import (
+        fragments as fr,
+    )
+except ImportError:  # standalone run against an env without built vllm._C
+    import importlib.util
+    import sys as _sys
+    from pathlib import Path as _P
+
+    _p = (_P(__file__).resolve().parents[2] / "vllm" / "model_executor"
+          / "layers" / "quantization" / "exl3_fungible" / "fragments.py")
+    _s = importlib.util.spec_from_file_location("fq_fragments_standalone", _p)
+    fr = importlib.util.module_from_spec(_s)
+    _sys.modules[_s.name] = fr
+    _s.loader.exec_module(fr)
+
+
+# ------------------------------------------------------------- fixtures
+
+NUM_EXPERTS = 4
+RANKS = 2
+PROJS = ("gate_proj", "up_proj", "down_proj")
+
+
+def _expert_tensors(layer, expert, k, seed):
+    """Tiny rank-sliced EXL3-shaped tensor set for one expert."""
+    out = []
+    for proj in PROJS:
+        for rank in range(RANKS):
+            base = f"model.layers.{layer}.mlp.experts.{expert}.{proj}.rank{rank}"
+            trellis = bytes(
+                (seed + expert + rank + i) % 251 for i in range(2 * 2 * 16 * k * 2)
+            )
+            out.append((f"{base}.trellis", "I16", (2, 2, 16 * k), trellis))
+            suh = bytes((seed + expert + i) % 249 for i in range(32 * 2))
+            out.append((f"{base}.suh", "F16", (32,), suh))
+            svh = bytes((seed + expert + 1 + i) % 247 for i in range(32 * 2))
+            out.append((f"{base}.svh", "F16", (32,), svh))
+            out.append((f"{base}.mcg", "I32", (1,), struct.pack("<i", 7)))
+    return out
+
+
+def write_segment(seg_dir, layer, k, *, seed=0, num_experts=NUM_EXPERTS,
+                  with_attestation=True):
+    """Emit layer segment + index-k{k}.json entry + attestation, fq_repack
+    layout: per-expert contiguous body, expert-major tensor order."""
+    header, blobs = {}, []
+    per_expert, digests = {}, {}
+    off = 0
+    for expert in range(num_experts):
+        start = off
+        sha = hashlib.sha256()
+        for name, dtype, shape, data in _expert_tensors(layer, expert, k, seed):
+            header[name] = {
+                "dtype": dtype,
+                "shape": list(shape),
+                "data_offsets": [off, off + len(data)],
+            }
+            blobs.append(data)
+            sha.update(data)
+            off += len(data)
+        per_expert[str(expert)] = [start, off]
+        digests[str(expert)] = sha.hexdigest()
+
+    hj = json.dumps({"__metadata__": {"k": str(k)}, **header},
+                    separators=(",", ":")).encode()
+    hj += b" " * ((8 - len(hj) % 8) % 8)
+    payload = struct.pack("<Q", len(hj)) + hj + b"".join(blobs)
+
+    seg_dir.mkdir(parents=True, exist_ok=True)
+    seg_name = f"layer-{layer:03d}.k{k}.safetensors"
+    (seg_dir / seg_name).write_bytes(payload)
+
+    entry = {
+        "file": seg_name,
+        "sha256": hashlib.sha256(payload).hexdigest(),
+        "size": len(payload),
+        "body_offset": 8 + len(hj),
+        "experts": per_expert,
+    }
+    index_path = seg_dir / f"index-k{k}.json"
+    index = json.loads(index_path.read_text()) if index_path.exists() else {}
+    index[str(layer)] = entry
+    index_path.write_text(json.dumps(index))
+
+    if with_attestation:
+        att = {"schema": "fq-attestation/1", "expert_sha256": digests}
+        line = json.dumps({
+            "payload": base64.b64encode(json.dumps(att).encode()).decode(),
+            "signature": "dGVzdA==",
+            "keyid": "00",
+        })
+        att_dir = seg_dir / "attestations"
+        att_dir.mkdir(exist_ok=True)
+        (att_dir / f"layer-{layer:03d}.k{k}.jsonl").write_text(line + "\n")
+    return entry, digests
+
+
+class FakeSource:
+    """In-memory remote implementing the source protocol, with counters."""
+
+    def __init__(self, root, *, corrupt_fragments=False, drop_attestations=False):
+        self.name = "fake:src"
+        self.root = root
+        self.corrupt_fragments = corrupt_fragments
+        self.drop_attestations = drop_attestations
+        self.range_reads = 0
+        self.json_reads = 0
+
+    def read_json(self, relpath):
+        self.json_reads += 1
+        p = self.root / relpath
+        return json.loads(p.read_text()) if p.exists() else None
+
+    def read_text(self, relpath):
+        if self.drop_attestations and relpath.startswith("attestations/"):
+            return None
+        p = self.root / relpath
+        return p.read_text() if p.exists() else None
+
+    def read_range(self, relpath, start, end):
+        self.range_reads += 1
+        data = (self.root / relpath).read_bytes()[start:end]
+        if self.corrupt_fragments and not relpath.endswith(".jsonl"):
+            # flip a body byte, keep length (headers are re-parsed, so only
+            # corrupt when the caller asked for a body range)
+            if start > 0:
+                data = bytes([data[0] ^ 0xFF]) + data[1:]
+        return data
+
+
+def make_manifest_dir(tmp_path, layers=(3,), ks=(3,), **kw):
+    d = tmp_path / "segments"
+    d.mkdir(exist_ok=True)
+    (d / "fq-manifest.json").write_text(json.dumps({
+        "schema": "fq-manifest/1",
+        "num_experts": NUM_EXPERTS,
+        "moe_layers": [min(layers), max(layers)],
+        "sources": [],
+    }))
+    for layer in layers:
+        for k in ks:
+            write_segment(d, layer, k, **kw)
+    return d
+
+
+def resolver(manifest_dir, tmp_path, **kw):
+    kw.setdefault("cache_dir", tmp_path / "cache")
+    kw.setdefault("environ", {})
+    return fr.FragmentResolver(manifest_dir, **kw)
+
+
+# ---------------------------------------------------------------- tests
+
+
+def test_local_hit(tmp_path):
+    d = make_manifest_dir(tmp_path, layers=(3,), ks=(3, 4))
+    r = resolver(d, tmp_path)
+    frag = r.resolve(3, 2, 4)
+    assert frag.origin == "local"
+    entry = json.loads((d / "index-k4.json").read_text())["3"]
+    lo, hi = entry["experts"]["2"]
+    raw = (d / entry["file"]).read_bytes()
+    assert bytes(frag.payload) == raw[entry["body_offset"] + lo:
+                                      entry["body_offset"] + hi]
+    assert r.stats["local"] == 1 and r.stats["fetched"] == 0
+
+
+def test_local_tensors_shapes_and_rank_filter(tmp_path):
+    torch = pytest.importorskip("torch")
+    d = make_manifest_dir(tmp_path, layers=(3,), ks=(4,))
+    r = resolver(d, tmp_path)
+    tensors = dict(r.expert_tensors(3, 1, 4))
+    name = "model.layers.3.mlp.experts.1.gate_proj.rank0.trellis"
+    assert tensors[name].dtype == torch.int16
+    assert tuple(tensors[name].shape) == (2, 2, 16 * 4)
+    assert len(tensors) == len(PROJS) * RANKS * 4  # trellis/suh/svh/mcg
+
+    only_r1 = r.expert_tensors(3, 1, 4, name_filter=lambda n: ".rank1." in n)
+    assert len(only_r1) == len(PROJS) * 4
+    assert all(".rank1." in n for n, _ in only_r1)
+
+
+def test_source_fallback_fetches_verifies_and_caches(tmp_path):
+    remote_root = tmp_path / "remote"
+    write_segment(remote_root, 3, 4, seed=9)
+    d = make_manifest_dir(tmp_path, layers=(3,), ks=(3,))  # no local k4
+    src = FakeSource(remote_root)
+    r = resolver(d, tmp_path, sources=[src])
+    frag = r.resolve(3, 0, 4)
+    assert frag.origin == "fetched"
+    assert r.stats["fetched"] == 1
+    cached = r._cache_fragment_path(frag.sha256)  # noqa: SLF001
+    assert cached.exists() and cached.read_bytes() == bytes(frag.payload)
+
+    # local k3 still resolves locally, never touching the source
+    reads = src.range_reads
+    assert r.resolve(3, 0, 3).origin == "local"
+    assert src.range_reads == reads
+
+
+def test_fetched_sha_mismatch_rejected(tmp_path):
+    remote_root = tmp_path / "remote"
+    write_segment(remote_root, 3, 4, seed=9)
+    d = make_manifest_dir(tmp_path, layers=(3,), ks=(3,))
+    src = FakeSource(remote_root, corrupt_fragments=True)
+    r = resolver(d, tmp_path, sources=[src])
+    with pytest.raises(fr.FragmentVerificationError):
+        r.resolve(3, 0, 4)
+    assert r.stats["sha_mismatch"] == 1
+    assert r.stats["fetched"] == 0
+
+
+def test_cache_reuse_skips_refetch(tmp_path):
+    remote_root = tmp_path / "remote"
+    write_segment(remote_root, 3, 4, seed=9)
+    d = make_manifest_dir(tmp_path, layers=(3,), ks=(3,))
+    src1 = FakeSource(remote_root)
+    r1 = resolver(d, tmp_path, sources=[src1])
+    r1.resolve(3, 0, 4)
+
+    src2 = FakeSource(remote_root)
+    r2 = resolver(d, tmp_path, sources=[src2])
+    frag = r2.resolve(3, 0, 4)
+    assert frag.origin == "cache"
+    # index + cached header may be consulted; the fragment body itself must
+    # not be re-fetched
+    assert src2.range_reads == 0
+    assert r2.stats["fetched"] == 0 and r2.stats["cache"] == 1
+    assert bytes(frag.payload) == bytes(r1.resolve(3, 0, 4).payload)
+
+
+def test_unverified_fetch_refused_then_allowed(tmp_path):
+    remote_root = tmp_path / "remote"
+    write_segment(remote_root, 3, 4, seed=9, with_attestation=False)
+    d = make_manifest_dir(tmp_path, layers=(3,), ks=(3,))
+    src = FakeSource(remote_root, drop_attestations=True)
+    r = resolver(d, tmp_path, sources=[src])
+    with pytest.raises(fr.FragmentVerificationError, match="attestation"):
+        r.resolve(3, 0, 4)
+
+    r_off = resolver(d, tmp_path, sources=[FakeSource(remote_root,
+                                                      drop_attestations=True)],
+                     verify="off")
+    assert r_off.resolve(3, 0, 4).origin == "fetched"
+
+
+def test_verify_all_catches_local_corruption(tmp_path):
+    d = make_manifest_dir(tmp_path, layers=(3,), ks=(3,))
+    seg = d / "layer-003.k3.safetensors"
+    raw = bytearray(seg.read_bytes())
+    entry = json.loads((d / "index-k3.json").read_text())["3"]
+    raw[entry["body_offset"] + 1] ^= 0xFF  # corrupt expert 0's body
+    seg.write_bytes(bytes(raw))
+    r = resolver(d, tmp_path, verify="all")
+    with pytest.raises(fr.FragmentVerificationError):
+        r.resolve(3, 0, 3)
+    # default policy trusts local reads
+    r_default = resolver(d, tmp_path)
+    assert r_default.resolve(3, 0, 3).origin == "local"
+
+
+def test_unavailable_reports_chain(tmp_path):
+    d = make_manifest_dir(tmp_path, layers=(3,), ks=(3,))
+    r = resolver(d, tmp_path)
+    with pytest.raises(fr.FragmentUnavailableError, match="k5"):
+        r.resolve(3, 0, 5)

--- a/tests/exl3_fungible/test_gate_mass_cpu.py
+++ b/tests/exl3_fungible/test_gate_mass_cpu.py
@@ -1,0 +1,438 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU contract tests for REAL gate-mass capture — no GPU required.
+
+Background: the collector always emitted a ``mass`` array, but nothing
+in the live integration path ever bound a source of gate weights, so
+``mass`` was aliased to ``count`` and a 75x256 live dump came back
+byte-identical between the two. The policy is specified to score on
+routing MASS (Σ gate weights), which ranks a confident route above a
+marginal one — not on raw hit frequency.
+
+These tests pin, on CPU:
+
+* real mass differs from count when the gate weights are non-uniform,
+* real mass equals count when every gate weight is 1.0,
+* the padding sentinel (id == E) contributes to NEITHER,
+* out-of-range ids never index past the accumulators,
+* ``mass_is_real()`` is correct in both modes, including the downgrade
+  when the runtime's router cannot hand over the weights,
+* the ``mass_is_real`` flag reaches the ``VLLM_FQ_DUMP_STATS`` artifact.
+
+The router side of the contract (``BaseRouter._select_experts`` passing
+``topk_weights`` to capture fns tagged ``wants_topk_weights``) is
+covered by ``test_base_router_gate_mass_cpu.py``.
+"""
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+import torch
+
+_PKG = (Path(__file__).resolve().parents[2] / "vllm" / "model_executor"
+        / "layers" / "quantization" / "exl3_fungible")
+
+
+def _load(name: str, filename: str):
+    spec = importlib.util.spec_from_file_location(name, _PKG / filename)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+try:
+    from vllm.model_executor.layers.quantization.exl3_fungible import (
+        integration as fq_integration,
+    )
+    from vllm.model_executor.layers.quantization.exl3_fungible.stats import (
+        FqStatsCollector,
+    )
+except ImportError:  # standalone run against an env without built vllm._C
+    FqStatsCollector = _load("fq_stats_gm", "stats.py").FqStatsCollector
+    fq_integration = _load("fq_integration_gm", "integration.py")
+
+
+E = 8
+
+
+class FakeBaseRouter:
+    """Duck-types the parts of ``BaseRouter`` the collector relies on.
+
+    Crucially it reproduces the weight-passing contract: ``set_capture_fn``
+    resolves ``capture_fn_wants_weights`` from the callback's
+    ``wants_topk_weights`` tag, and ``route`` calls the callback with one
+    or two arguments accordingly — the same branch as
+    ``BaseRouter._select_experts``.
+    """
+
+    def __init__(self, global_num_experts: int = E):
+        self.global_num_experts = global_num_experts
+        self.capture_fn = None
+        self.capture_fn_wants_weights = False
+
+    def set_capture_fn(self, fn):
+        self.capture_fn = fn
+        self.capture_fn_wants_weights = bool(
+            getattr(fn, "wants_topk_weights", False))
+
+    def route(self, topk_ids, topk_weights):
+        if self.capture_fn is None:
+            return
+        if self.capture_fn_wants_weights:
+            self.capture_fn(topk_ids, topk_weights)
+        else:
+            self.capture_fn(topk_ids)
+
+
+class LegacyRouter(FakeBaseRouter):
+    """A runtime whose BaseRouter predates the weight-passing contract:
+    it never exposes ``capture_fn_wants_weights`` and always calls the
+    capture fn with ids only."""
+
+    def __init__(self, global_num_experts: int = E):
+        super().__init__(global_num_experts)
+        del self.capture_fn_wants_weights
+
+    def set_capture_fn(self, fn):
+        self.capture_fn = fn
+
+    def route(self, topk_ids, topk_weights):
+        if self.capture_fn is not None:
+            self.capture_fn(topk_ids)
+
+
+def make_collector(record_mass: bool, **kw) -> FqStatsCollector:
+    kw.setdefault("device", "cpu")
+    kw.setdefault("window_len", 4)
+    kw.setdefault("window_stride", 1)
+    kw.setdefault("decay", 1.0)
+    return FqStatsCollector(E, record_mass=record_mass, **kw)
+
+
+def bind(record_mass: bool, router=None, **kw):
+    c = make_collector(record_mass, **kw)
+    r = FakeBaseRouter() if router is None else router
+    c.bind_router(0, r)
+    return c, r
+
+
+# ------------------------------------------------------- real mass recorded
+
+def test_real_gate_mass_differs_from_count_for_nonuniform_weights():
+    """The whole point: with non-uniform gate weights, mass must NOT be
+    the hit histogram. Expert 1 is hit twice with tiny weights, expert 5
+    once with a large one — count ranks 1 first, mass ranks 5 first."""
+    c, r = bind(True)
+    ids = torch.tensor([[1, 5], [1, 5]], dtype=torch.int64)
+    w = torch.tensor([[0.05, 0.90], [0.05, 0.90]], dtype=torch.float32)
+    r.route(ids, w)
+
+    count = c.count_buf[0][:E]
+    mass = c.mass_buf[0][:E]
+    assert count[1].item() == pytest.approx(2.0)
+    assert count[5].item() == pytest.approx(2.0)
+    assert mass[1].item() == pytest.approx(0.10, abs=1e-6)
+    assert mass[5].item() == pytest.approx(1.80, abs=1e-6)
+    assert not torch.equal(count, mass), "mass is still aliased to count"
+    assert c.mass_is_real(0) and c.mass_is_real()
+
+    # And the ranking the policy reads actually flips.
+    c.step()
+    dc, dm = c.decayed(0)
+    assert int(dc.argmax()) in (1, 5)          # tie on count
+    assert int(dm.argmax()) == 5, "mass must prefer the confident route"
+
+
+def test_real_gate_mass_equals_count_when_all_weights_are_one():
+    """Degenerate check that the accumulation is a plain weighted sum:
+    unit gate weights make real mass numerically equal the count."""
+    c, r = bind(True)
+    ids = torch.tensor([[0, 3], [3, 7]], dtype=torch.int64)
+    r.route(ids, torch.ones_like(ids, dtype=torch.float32))
+
+    assert torch.allclose(c.count_buf[0][:E], c.mass_buf[0][:E], atol=1e-6)
+    assert c.count_buf[0][:E].tolist() == [1, 0, 0, 2, 0, 0, 0, 1]
+    assert c.mass_is_real(0), "equal arrays here are real mass, not an alias"
+
+
+def test_mass_accumulates_across_calls_and_windows():
+    c, r = bind(True)
+    w = torch.tensor([[0.25, 0.75]], dtype=torch.float32)
+    ids = torch.tensor([[2, 4]], dtype=torch.int64)
+    r.route(ids, w)
+    r.route(ids, w)
+    assert c.mass_buf[0][2].item() == pytest.approx(0.5, abs=1e-6)
+    assert c.mass_buf[0][4].item() == pytest.approx(1.5, abs=1e-6)
+    c.step()   # roll: accumulators -> window, then zeroed
+    assert c.mass_buf[0].sum().item() == 0.0
+    _, dm = c.decayed(0)
+    assert dm[4].item() == pytest.approx(1.5, abs=1e-6)
+
+
+# -------------------------------------------------------- sentinel and OOR
+
+def test_padding_sentinel_contributes_to_neither_count_nor_mass():
+    """id == E is the padding sentinel. torch.histc's last bin is CLOSED
+    at max, so the count path bins over E+1 and slices; the mass path
+    must drop it the same way (via the overflow slot), not fold it into
+    expert E-1 or into a real expert."""
+    c, r = bind(True)
+    ids = torch.tensor([[3, E], [E, E]], dtype=torch.int64)
+    w = torch.tensor([[0.4, 9.0], [9.0, 9.0]], dtype=torch.float32)
+    r.route(ids, w)
+
+    assert c.count_buf[0][:E].tolist() == [0, 0, 0, 1, 0, 0, 0, 0]
+    assert c.mass_buf[0][:E].tolist() == pytest.approx(
+        [0, 0, 0, 0.4, 0, 0, 0, 0], abs=1e-6)
+    assert c.mass_buf[0][E - 1].item() == 0.0, \
+        "sentinel folded into the last real expert (closed-bin bug)"
+    assert c.mass_buf[0][E].item() == pytest.approx(27.0, abs=1e-5), \
+        "sentinel mass belongs in the overflow slot"
+    # ... and the overflow slot never reaches the window or the policy.
+    c.step()
+    dc, dm = c.decayed(0)
+    assert dc.shape[0] == E and dm.shape[0] == E
+    assert dm.sum().item() == pytest.approx(0.4, abs=1e-6)
+
+
+@pytest.mark.parametrize("bad", [-1, -1000, E, E + 1, E + 2, 300, 2 ** 20])
+def test_out_of_range_ids_never_index_out_of_bounds(bad):
+    """An OOR scatter_add_ is an illegal memory access that killed a live
+    engine. Every OOR id must land in the overflow slot at index E, and
+    the accumulators must stay exactly E+1 long."""
+    c, r = bind(True)
+    ids = torch.tensor([[0, bad]], dtype=torch.int64)
+    w = torch.tensor([[0.3, 0.7]], dtype=torch.float32)
+    r.route(ids, w)
+
+    assert c.count_buf[0].numel() == E + 1
+    assert c.mass_buf[0].numel() == E + 1
+    assert c.count_buf[0][:E].tolist() == [1, 0, 0, 0, 0, 0, 0, 0]
+    assert c.mass_buf[0][0].item() == pytest.approx(0.3, abs=1e-6)
+    assert c.mass_buf[0][:E].sum().item() == pytest.approx(0.3, abs=1e-6)
+    assert c.mass_buf[0][E].item() == pytest.approx(0.7, abs=1e-6)
+
+
+def test_weighted_path_index_tensor_is_always_in_bounds():
+    """Directly assert the property the guard exists for: the index fed
+    to scatter_add_ is within [0, E] for arbitrary garbage ids."""
+    c, r = bind(True)
+    ids = torch.tensor(
+        [[-2 ** 31, -1, 0, E - 1, E, E + 1, 2 ** 31 - 1, 12345]],
+        dtype=torch.int64)
+    w = torch.full_like(ids, 1, dtype=torch.float32)
+    r.route(ids, w)          # would raise / corrupt memory if unguarded
+    total = c.mass_buf[0].sum().item()
+    assert total == pytest.approx(8.0, abs=1e-6), "no weight lost"
+    assert c.mass_buf[0][:E].sum().item() == pytest.approx(2.0, abs=1e-6)
+    assert c.mass_buf[0][E].item() == pytest.approx(6.0, abs=1e-6)
+
+
+def test_count_is_identical_with_and_without_mass_recording():
+    """Enabling gate mass must not perturb the count signal — both modes
+    run the same histc — so an A/B of two runs stays comparable."""
+    ids = torch.tensor([[0, 1, E, -3], [1, 1, 7, 300]], dtype=torch.int64)
+    w = torch.rand(ids.shape, dtype=torch.float32)
+
+    c_off, r_off = bind(False)
+    r_off.route(ids, w)
+    c_on, r_on = bind(True)
+    r_on.route(ids, w)
+
+    assert c_off.count_buf[0].tolist() == c_on.count_buf[0].tolist()
+
+
+# --------------------------------------------------------- explicit flagging
+
+def test_mass_is_real_flag_is_correct_in_both_modes():
+    c_off, _ = bind(False)
+    assert c_off.mass_is_real(0) is False
+    assert c_off.mass_is_real() is False
+
+    c_on, _ = bind(True)
+    assert c_on.mass_is_real(0) is True
+    assert c_on.mass_is_real() is True
+
+    # Unbound layer is not "real"; a mixed model is not model-wide real.
+    assert c_on.mass_is_real(99) is False
+    c_on.bind_router(1, FakeBaseRouter(), record_mass=False)
+    assert c_on.mass_is_real(0) is True
+    assert c_on.mass_is_real(1) is False
+    assert c_on.mass_is_real() is False, "one aliased layer taints the model"
+
+    assert FqStatsCollector(E, device="cpu").mass_is_real() is False, \
+        "nothing bound yet is not a claim of real mass"
+
+
+def test_summary_carries_the_mass_is_real_flag():
+    c_off, r_off = bind(False)
+    r_off.route(torch.tensor([[1, 1]]), torch.tensor([[0.2, 0.8]]))
+    c_off.step()
+    s_off = c_off.summary()
+    assert s_off["mass_is_real"] is False
+    assert s_off["layers"][0]["mass_is_real"] is False
+    assert s_off["layers"][0]["mass"] == s_off["layers"][0]["count"]
+
+    c_on, r_on = bind(True)
+    r_on.route(torch.tensor([[1, 1]]), torch.tensor([[0.2, 0.8]]))
+    c_on.step()
+    s_on = c_on.summary()
+    assert s_on["mass_is_real"] is True
+    assert s_on["layers"][0]["mass_is_real"] is True
+    assert s_on["layers"][0]["mass"] != s_on["layers"][0]["count"]
+
+
+def test_capture_fn_is_tagged_so_the_router_knows_to_pass_weights():
+    _, r_on = bind(True)
+    assert r_on.capture_fn.wants_topk_weights is True
+    assert r_on.capture_fn_wants_weights is True
+    _, r_off = bind(False)
+    assert r_off.capture_fn.wants_topk_weights is False
+    assert r_off.capture_fn_wants_weights is False
+
+
+def test_unsupported_router_downgrades_instead_of_lying():
+    """If the deployed runtime's BaseRouter cannot hand over the weights,
+    the capture fn would be called with ids only and mass would stay at
+    zero. Detect that at bind time and fall back to count-only, so
+    mass_is_real() never claims mass we are not getting."""
+    c, r = bind(True, router=LegacyRouter())
+    assert c.mass_is_real(0) is False
+    assert getattr(r.capture_fn, "wants_topk_weights", False) is False
+
+    r.route(torch.tensor([[2, 2]], dtype=torch.int64),
+            torch.tensor([[0.1, 0.9]]))
+    assert c.count_buf[0][2].item() == pytest.approx(2.0)
+    assert c.mass_buf[0].sum().item() == 0.0, "no real mass was collected"
+    c.step()
+    dc, dm = c.decayed(0)
+    assert dm.tolist() == dc.tolist(), "aliased, and flagged as aliased"
+
+
+def test_chained_previous_capture_fn_still_fires_in_weighted_mode():
+    seen = []
+    r = FakeBaseRouter()
+    r.capture_fn = lambda ids: seen.append(tuple(ids.shape))
+    c = make_collector(True)
+    c.bind_router(0, r)
+    ids = torch.tensor([[1, 2]], dtype=torch.int64)
+    r.route(ids, torch.tensor([[0.5, 0.5]]))
+    assert seen == [(1, 2)], "previous capture fn must still fire"
+    assert c.mass_buf[0][1].item() == pytest.approx(0.5, abs=1e-6)
+
+
+# ------------------------------------------------------------- integration
+
+def test_integration_hook_opts_in_from_env(monkeypatch):
+    """VLLM_FQ_GATE_MASS=1 turns real mass on end-to-end; default is off."""
+
+    class FakeMoERunner:
+        def __init__(self, layer_id, router):
+            self.layer_id = layer_id
+            self.router = router
+
+    class FakeModel:
+        def __init__(self, mods):
+            self._mods = mods
+
+        def modules(self):
+            return iter(self._mods)
+
+    class FakeRunner:
+        def __init__(self, mods):
+            self.model = FakeModel(mods)
+            self.device = "cpu"
+
+    def runner():
+        return FakeRunner([FakeMoERunner(0, FakeBaseRouter()),
+                           FakeMoERunner(1, FakeBaseRouter())])
+
+    monkeypatch.setattr(fq_integration, "_moe_module_types",
+                        lambda: (FakeMoERunner, FakeBaseRouter))
+    monkeypatch.setattr(fq_integration, "_collector_cls",
+                        lambda: FqStatsCollector)
+    monkeypatch.setenv(fq_integration.FQ_ENABLE_ENV, "1")
+
+    monkeypatch.delenv(fq_integration.FQ_GATE_MASS_ENV, raising=False)
+    c = fq_integration.maybe_init_fq_collector(runner())
+    assert c is not None and c.mass_is_real() is False
+
+    monkeypatch.setenv(fq_integration.FQ_GATE_MASS_ENV, "1")
+    c = fq_integration.maybe_init_fq_collector(runner())
+    assert c.mass_is_real() is True
+    assert c.mass_is_real(0) and c.mass_is_real(1)
+
+
+def _load_loop_module():
+    """Load loop.py, which imports its siblings under the canonical
+    package path. Registered and then UNREGISTERED so test module import
+    order cannot change how the other test files resolve the package."""
+    try:
+        from vllm.model_executor.layers.quantization.exl3_fungible import (
+            loop as fq_loop,
+        )
+        return fq_loop, lambda: None
+    except ImportError:
+        pass
+
+    import sys
+    import types
+
+    name = "vllm.model_executor.layers.quantization.exl3_fungible"
+    saved = {k: v for k, v in sys.modules.items() if k.startswith(name)}
+    pkg = types.ModuleType(name)
+    sys.modules[name] = pkg
+    # occupancy_table must precede loop: loop imports it, and a stub
+    # package missing the attribute falls through to the real vllm chain.
+    for sub in ("policy", "stats", "store", "decision_log",
+                "occupancy_table", "loop"):
+        spec = importlib.util.spec_from_file_location(
+            f"{name}.{sub}", _PKG / f"{sub}.py")
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[f"{name}.{sub}"] = mod
+        spec.loader.exec_module(mod)
+        setattr(pkg, sub, mod)
+
+    def restore():
+        for k in [k for k in sys.modules if k.startswith(name)]:
+            del sys.modules[k]
+        sys.modules.update(saved)
+
+    return pkg.loop, restore
+
+
+def test_dump_stats_records_whether_mass_is_real(tmp_path):
+    """The VLLM_FQ_DUMP_STATS artifact must say which kind of mass it
+    holds — the live 75x256 dump was byte-identical between count and
+    mass and nothing in the file said why."""
+    pytest.importorskip("prometheus_client")
+    fq_loop, restore = _load_loop_module()
+    try:
+        _check_dump_stats(fq_loop, tmp_path)
+    finally:
+        restore()
+
+
+def _check_dump_stats(fq_loop, tmp_path):
+
+    class Stub:
+        """Minimal stand-in for FungibleQuantState._dump_stats' self."""
+
+        def __init__(self, collector, path):
+            self.collector = collector
+            self._dump_stats_path = str(path)
+            self._step = 7
+            self._intervals_run = 1
+            self.layers = [0]
+            self.tier_of = fq_loop.np.asarray([3])
+
+    stats = {"count": [[1.0, 2.0]], "mass": [[0.5, 1.5]]}
+
+    for record_mass, expected in ((False, False), (True, True)):
+        c, _ = bind(record_mass)
+        path = tmp_path / f"dump-{record_mass}.jsonl"
+        fq_loop.FungibleQuantState._dump_stats(Stub(c, path), stats)
+        rec = json.loads(path.read_text().strip())
+        assert rec["mass_is_real"] is expected
+        assert "count" in rec and "mass" in rec, "both stay available"

--- a/tests/exl3_fungible/test_heatmap_cpu.py
+++ b/tests/exl3_fungible/test_heatmap_cpu.py
@@ -1,0 +1,1078 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU tests for the activation-matrix endpoint (exl3_fungible/heatmap.py).
+
+Covers the contract in ``runs/m5-serve/heatmap/ENDPOINT-SPEC.md`` §13:
+shape, the cross-rank merge arithmetic (which must NOT sum — see
+``heatmap.MERGE_RULE``), encoding round-trips and byte budgets, the ETag
+revalidation path, single-flight, every degraded path (FQ off, collector
+absent, rank failure, RPC timeout, aliased mass, DP), the three reset
+scopes, and that the whole surface is off by default.
+
+No GPU and no built ``vllm._C``. Fixtures are the REAL
+``VLLM_FQ_DUMP_STATS`` dumps from ``results/k3-fq/``; the router is
+driven with FastAPI's TestClient against a fake engine client that
+executes the REAL ``worker_sample`` on fake workers, so the worker half
+of the round trip is exercised too rather than mocked away.
+"""
+import asyncio
+import json
+import types
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+
+try:
+    from vllm.model_executor.layers.quantization.exl3_fungible import (
+        heatmap as H,
+    )
+    from vllm.model_executor.layers.quantization.exl3_fungible import (
+        policy as P,
+    )
+    from vllm.model_executor.layers.quantization.exl3_fungible.stats import (
+        FqStatsCollector,
+    )
+except ImportError:  # standalone: load by path with a stub package
+    import importlib.util
+    import sys
+
+    _dir = (Path(__file__).resolve().parents[2] / "vllm" / "model_executor"
+            / "layers" / "quantization" / "exl3_fungible")
+    _pkg_name = "vllm.model_executor.layers.quantization.exl3_fungible"
+
+    def _load(name, path):
+        spec = importlib.util.spec_from_file_location(name, path)
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[name] = mod
+        spec.loader.exec_module(mod)
+        return mod
+
+    _pkg = sys.modules.get(_pkg_name)
+    if _pkg is None or not hasattr(_pkg, "heatmap"):
+        _pkg = _pkg or types.ModuleType(_pkg_name)
+        _pkg.__path__ = [str(_dir)]
+        sys.modules[_pkg_name] = _pkg
+        for _sub in ("policy", "stats", "store", "decision_log",
+                     "occupancy_table", "swap", "loop", "integration",
+                     "admin", "heatmap"):
+            if not hasattr(_pkg, _sub):
+                setattr(_pkg, _sub,
+                        _load(f"{_pkg_name}.{_sub}", _dir / f"{_sub}.py"))
+    H, P = _pkg.heatmap, _pkg.policy
+    FqStatsCollector = _pkg.stats.FqStatsCollector
+
+fastapi = pytest.importorskip("fastapi")
+httpx = pytest.importorskip("httpx")
+TestClient = pytest.importorskip("fastapi.testclient").TestClient
+
+DUMPS = Path("/home/mbelleau/protensors-work/vllm-voipmonitor/research"
+             "/fungible-quant/runs/m5-serve/results/k3-fq")
+ARCHIVED = ("stats.jsonl", "stats-code-axis.jsonl", "stats-synthetic.jsonl",
+            "stats-INVALID-truncated-corpus.jsonl")
+
+
+# ------------------------------------------------------------------ fixtures
+
+
+def load_record(name: str = "stats.jsonl", index: int = 9) -> dict:
+    """One line of a real dump.
+
+    ``mass_is_real`` is ABSENT from every archived file (``loop.py:933``
+    landed after they were taken), so it defaults to False here — and is
+    never inferred from ``count == mass``, which a uniform router
+    produces legitimately (``stats.py:302-318``).
+    """
+    path = DUMPS / name
+    if not path.exists():
+        pytest.skip(f"archived dump {path} not present")
+    with path.open() as fh:
+        for i, line in enumerate(fh):
+            if i == index:
+                rec = json.loads(line)
+                rec.setdefault("mass_is_real", False)
+                return rec
+    pytest.skip(f"{path} has no record {index}")
+
+
+class FakeRouter:
+    capture_fn = None
+    capture_fn_wants_weights = False
+
+    def set_capture_fn(self, fn):
+        self.capture_fn = fn
+
+
+class DumpCollector:
+    """The collector read-surface ``heatmap.py`` uses, backed by a dump.
+
+    Deliberately not a subclass: the point is to pin down exactly which
+    attributes the endpoint depends on, so a change in ``stats.py``
+    breaks a test here rather than the live endpoint.
+    """
+
+    def __init__(self, count, mass, *, layers, mass_is_real=False,
+                 window_len=64, window_stride=32, decay=0.95,
+                 rolled=596, win_pos=20, step=19100):
+        count = np.asarray(count, dtype=np.float64)
+        mass = np.asarray(mass, dtype=np.float64)
+        self.num_experts = int(count.shape[1])
+        self.window_len = window_len
+        self.window_stride = window_stride
+        self.decay = decay
+        self._windows_rolled = rolled
+        self._win_pos = win_pos
+        self._step = step
+        self._mass_real = bool(mass_is_real)
+        self._rows = {}
+        self.count_buf = {}
+        self.mass_buf = {}
+        self._count_win = {}
+        self._mass_win = {}
+        for row, lid in enumerate(layers):
+            self._rows[int(lid)] = (torch.tensor(count[row]),
+                                    torch.tensor(mass[row]))
+            self.count_buf[int(lid)] = torch.zeros(self.num_experts + 1)
+            self.mass_buf[int(lid)] = torch.zeros(self.num_experts + 1)
+            self._count_win[int(lid)] = torch.zeros(
+                (window_len, self.num_experts), dtype=torch.int64)
+            self._mass_win[int(lid)] = torch.zeros(
+                (window_len, self.num_experts), dtype=torch.float32)
+
+    def mass_is_real(self, layer_id=None):
+        return self._mass_real
+
+    def decayed(self, layer_id):
+        c, m = self._rows[int(layer_id)]
+        return c, (m if self._mass_real else c)
+
+
+class FakeLoopState:
+    """The loop-state read-surface: layers, tier_of, clocks, policy sha."""
+
+    def __init__(self, collector, layers, tier_of, *, rank=0,
+                 policy_sha="9c1f4d0b7a2e5c31", apply_mode="atomic"):
+        self.collector = collector
+        self.layers = [int(x) for x in layers]
+        self.tier_of = np.asarray(tier_of, dtype=np.int64)
+        self.num_experts = collector.num_experts
+        self.rank = rank
+        self.policy_sha = policy_sha
+        self.cfg = types.SimpleNamespace(apply_mode=apply_mode)
+        self._collector_layer_map = {lid: lid for lid in self.layers}
+        self._step = collector._step
+        self._real_steps = collector._step - 6
+        self._intervals_run = 191
+
+
+class FakeWorker:
+    def __init__(self, state, rank=0):
+        self.model_runner = types.SimpleNamespace(fq_collector=state)
+        self.rank = rank
+
+
+class FakeEngineClient:
+    """Runs the REAL ``worker_sample`` on N fake workers."""
+
+    def __init__(self, workers, *, rpc_error=None, override=None, delay=0.0):
+        self.workers = list(workers)
+        self.calls = []
+        self.rpc_error = rpc_error
+        self.override = override
+        self.delay = delay
+
+    async def collective_rpc(self, method, timeout=None, args=(),
+                             kwargs=None):
+        self.calls.append((method, args, timeout))
+        if self.delay:
+            await asyncio.sleep(self.delay)
+        if self.rpc_error is not None:
+            raise self.rpc_error
+        if self.override is not None:
+            return list(self.override)
+        payload = args[0] if args else "{}"
+        return [H.worker_sample(w, payload) for w in self.workers]
+
+
+@pytest.fixture(autouse=True)
+def clean_state(monkeypatch):
+    """Both gates ON in ``os.environ`` (the WORKER reads that), module
+    poison/accumulator cleared. The router is always given an explicit
+    ``environ=`` so the gate truth table stays independent of this."""
+    monkeypatch.setenv(H.DEV_MODE_ENV, "1")
+    monkeypatch.setenv(H.HEATMAP_API_ENV, "1")
+    for env in (H.HEATMAP_TOKEN_ENV, H.HEATMAP_ALLOW_COLLECTOR_ZERO_ENV,
+                H.HEATMAP_API_ALIAS_ENV):
+        monkeypatch.delenv(env, raising=False)
+    H.reset_state()
+    yield
+    H.reset_state()
+
+
+def enabled_env(**extra):
+    env = {H.DEV_MODE_ENV: "1", H.HEATMAP_API_ENV: "1"}
+    env.update(extra)
+    return env
+
+
+def build_state(rec=None, *, ranks=1, mass_is_real=False, layers=None,
+                tier=None, loop=True, rank_perturb=None):
+    """``(workers, states)`` for ``ranks`` TP ranks over one dump record."""
+    rec = rec or load_record()
+    count = np.asarray(rec["count"], dtype=np.float64)
+    mass = np.asarray(rec["mass"], dtype=np.float64)
+    lids = [int(x) for x in (layers if layers is not None else rec["layers"])]
+    if layers is not None:
+        keep = [rec["layers"].index(x) for x in lids]
+        count, mass = count[keep], mass[keep]
+    tier_of = (np.asarray(tier) if tier is not None
+               else np.asarray(rec["tier_of"], dtype=np.int64)[
+                   [rec["layers"].index(x) for x in lids]])
+    workers = []
+    for r in range(ranks):
+        c = count.copy()
+        if rank_perturb is not None and r in rank_perturb:
+            c = c + rank_perturb[r]
+        coll = DumpCollector(c, mass, layers=lids, mass_is_real=mass_is_real,
+                             step=int(rec.get("step") or 19100))
+        state = (FakeLoopState(coll, lids, tier_of, rank=r) if loop else coll)
+        workers.append(FakeWorker(state, rank=r))
+    return workers
+
+
+def make_client(env, workers=None, *, engine=None, dp=1):
+    app = fastapi.FastAPI()
+    app.state.engine_client = engine or FakeEngineClient(
+        workers if workers is not None else build_state())
+    if dp != 1:
+        app.state.vllm_config = types.SimpleNamespace(
+            parallel_config=types.SimpleNamespace(data_parallel_size=dp))
+    router = None
+    if H.heatmap_enabled(env):
+        router = H.build_router(environ=env)
+        app.include_router(router)
+    attached = H.attach_router(fastapi.FastAPI(), environ=env)
+    return TestClient(app), app.state.engine_client, router, attached
+
+
+def get_json(client, url, **kw):
+    resp = client.get(url, **kw)
+    return resp, (resp.json() if resp.content else None)
+
+
+# --------------------------------------------------------------- shape (§13)
+
+
+def test_shape_75x256_and_every_array_decodes_to_cells():
+    client, engine, _, _ = make_client(enabled_env(), build_state(ranks=4))
+    resp, body = get_json(client, "/fq/heatmap?include=live")
+    assert resp.status_code == 200, resp.text
+    assert body["layers"] == list(range(3, 78))
+    assert body["num_layers"] == 75
+    assert body["num_experts"] == 256
+    assert body["cells"] == 19200
+    assert body["cells"] == body["num_layers"] * body["num_experts"]
+    assert H.decode_floats(body["count"], "bf16", 19200).size == 19200
+    assert H.decode_tier(body["tier"], 19200).size == 19200
+    assert H.decode_floats(body["live_count"], "bf16", 19200).size == 19200
+    # layer 78 (MTP) is not instrumented and must never appear
+    assert 78 not in body["layers"]
+
+
+def test_client_side_validator_rejects_a_short_array():
+    short = H.encode_floats(np.zeros(19199, dtype=np.float32), "bf16")
+    with pytest.raises(ValueError, match="19199 elements, expected 19200"):
+        H.decode_floats(short, "bf16", 19200)
+
+
+def test_server_refuses_to_serve_a_short_array():
+    """A truncated blob must never be rendered as a shifted heatmap."""
+    workers = build_state(ranks=1)
+    good = json.loads(H.worker_sample(workers[0], '{"op":"sample"}'))
+    good["count"] = H.encode_floats(np.zeros(19199, dtype=np.float32), "bf16")
+    engine = FakeEngineClient([], override=[json.dumps(good)])
+    client, _, _, _ = make_client(enabled_env(), engine=engine)
+    resp, body = get_json(client, "/fq/heatmap")
+    assert resp.status_code == 503
+    assert body["error"]["code"] == "fq_heatmap_worker_error"
+    assert "19199 cells, expected 19200" in body["error"]["message"]
+
+
+def test_layer_ids_are_data_not_row_plus_three():
+    workers = build_state(layers=[5, 9, 40])
+    client, _, _, _ = make_client(enabled_env(), workers)
+    resp, body = get_json(client, "/fq/heatmap")
+    assert resp.status_code == 200, resp.text
+    assert body["layers"] == [5, 9, 40]
+    assert body["num_layers"] == 3
+    assert body["cells"] == 3 * 256
+    assert H.decode_floats(body["count"], "bf16", 3 * 256).size == 768
+
+
+def test_layers_subset():
+    client, _, _, _ = make_client(enabled_env(), build_state())
+    resp, body = get_json(client, "/fq/heatmap?layers=20-22,40")
+    assert resp.status_code == 200, resp.text
+    assert body["layers"] == [20, 21, 22, 40]
+    assert body["cells"] == 4 * 256
+
+
+def test_layers_selector_errors():
+    client, _, _, _ = make_client(enabled_env(), build_state())
+    assert client.get("/fq/heatmap?layers=nope").status_code == 400
+    resp, body = get_json(client, "/fq/heatmap?layers=999")
+    assert resp.status_code == 400
+    assert body["error"]["code"] == "bad_layers"
+
+
+# --------------------------------------------------------------- mass (§3.4)
+
+
+def test_mass_is_real_comes_from_the_flag_not_from_array_equality():
+    """A uniform router makes ``count == mass`` legitimately."""
+    rec = load_record()
+    uniform = np.full((75, 256), 7.0)
+    rec = dict(rec, count=uniform.tolist(), mass=uniform.tolist())
+    workers = build_state(rec, mass_is_real=True)
+    coll = workers[0].model_runner.fq_collector.collector
+    c, m = coll.decayed(3)
+    assert torch.equal(c, m), "fixture must have count == mass"
+    client, _, _, _ = make_client(enabled_env(), workers)
+    resp, body = get_json(client, "/fq/heatmap")
+    assert body["mass_is_real"] is True
+    assert body["mass"] is not None, "real mass must ship even when equal"
+    assert not any("aliased" in w for w in body["warnings"])
+
+
+def test_aliased_mass_is_omitted_with_a_warning_and_halves_the_bytes():
+    real = build_state(mass_is_real=True)
+    aliased = build_state(mass_is_real=False)
+    c1, _, _, _ = make_client(enabled_env(), real)
+    c2, _, _, _ = make_client(enabled_env(), aliased)
+    _, big = get_json(c1, "/fq/heatmap")
+    _, small = get_json(c2, "/fq/heatmap")
+    assert big["mass"] is not None and small["mass"] is None
+    assert small["mass_is_real"] is False
+    assert any("VLLM_FQ_GATE_MASS=1" in w for w in small["warnings"])
+    n_big = len(json.dumps(big).encode())
+    n_small = len(json.dumps(small).encode())
+    # the omitted array is one of two 51,200-char blobs
+    assert n_small < n_big * 0.72, (n_small, n_big)
+
+
+def test_archived_dumps_default_mass_is_real_to_false():
+    for name in ARCHIVED:
+        path = DUMPS / name
+        if not path.exists():
+            pytest.skip(f"{path} missing")
+        with path.open() as fh:
+            raw = json.loads(fh.readline())
+        assert "mass_is_real" not in raw, name
+        assert load_record(name, 0)["mass_is_real"] is False
+
+
+# ------------------------------------------------------------ encoding (§5)
+
+
+def test_bf16_roundtrip_on_the_real_record():
+    rec = load_record()
+    count = np.asarray(rec["count"], dtype=np.float64).reshape(-1)
+    back = H.decode_floats(H.encode_floats(count, "bf16"), "bf16",
+                           count.size).astype(np.float64)
+    rel = np.abs(back - count) / np.maximum(np.abs(count), 1e-30)
+    assert rel.max() < 0.005, rel.max()
+    # round-to-nearest-even, measured 0.38898 % on this record
+    assert 0.0030 < rel.max() < 0.0039, rel.max()
+    f32 = H.decode_floats(H.encode_floats(count, "f32"), "f32",
+                          count.size).astype(np.float64)
+    relf = np.abs(f32 - count) / np.maximum(np.abs(count), 1e-30)
+    assert relf.max() < 1e-6, relf.max()
+
+
+def test_bf16_matches_the_spec_worked_example():
+    given = np.array([27956.66712900402, 14229.637078354925,
+                      10076.517826289375, 35942.17890498233,
+                      20928.839368426034, 19015.02907982981])
+    got = H.decode_floats(H.encode_floats(given, "bf16"), "bf16", 6)
+    assert got.tolist() == [27904.0, 14208.0, 10048.0, 35840.0, 20992.0,
+                            19072.0]
+
+
+def test_bf16_survives_the_full_dynamic_range_and_nan():
+    vals = np.array([0.0, 0.0437, 1.0, 337651.33, np.inf, np.nan],
+                    dtype=np.float64)
+    got = H.decode_floats(H.encode_floats(vals, "bf16"), "bf16", 6)
+    assert got[0] == 0.0
+    assert abs(got[1] - 0.0437) / 0.0437 < 0.004
+    assert abs(got[3] - 337651.33) / 337651.33 < 0.004
+    assert np.isinf(got[4]) and np.isnan(got[5])
+
+
+def test_tier_encoding_is_u8_and_domain_checked():
+    blob = H.encode_tier(np.full(19200, 3, dtype=np.int64))
+    assert len(H.gzip_bytes(blob.encode())) < 200
+    assert (H.decode_tier(blob, 19200) == 3).all()
+    with pytest.raises(ValueError, match="occupancy_table.TIERS"):
+        H.encode_tier(np.array([3, 4, 9]))
+
+
+def test_u32_roundtrip():
+    vals = np.array([0, 1, 2**31 - 1, 4_000_000_000], dtype=np.int64)
+    assert H.decode_u32(H.encode_u32(vals), 4).tolist() == vals.tolist()
+
+
+def test_byte_budget_regression_guards():
+    """§5.3's numbers, as regression guards on the real record."""
+    client, _, _, _ = make_client(enabled_env(), build_state(ranks=4))
+    _, default = get_json(client, "/fq/heatmap")
+    body = json.dumps(default, separators=(",", ":")).encode()
+    gz = H.gzip_bytes(body, 1)
+    assert default["mass"] is None and default["count"] is not None
+    assert len(gz) < 40_000, len(gz)
+
+    live = build_state(ranks=4, mass_is_real=True)
+    c2, _, _, _ = make_client(enabled_env(), live)
+    _, full = get_json(c2, "/fq/heatmap?include=live,mass")
+    gz_full = H.gzip_bytes(
+        json.dumps(full, separators=(",", ":")).encode(), 1)
+    assert full["mass"] is not None and full["live_count"] is not None
+    assert len(gz_full) < 110_000, len(gz_full)
+
+    # ...against ~382 KB for the naive float64 JSON of the same sample
+    naive = json.dumps(load_record(), separators=(",", ":")).encode()
+    assert len(gz) < len(H.gzip_bytes(naive, 1)) / 8
+
+
+def test_response_is_gzipped_and_honours_accept_encoding():
+    client, _, _, _ = make_client(enabled_env(), build_state())
+    resp = client.get("/fq/heatmap", headers={"Accept-Encoding": "gzip"})
+    assert resp.headers.get("content-encoding") == "gzip"
+    plain = client.get("/fq/heatmap?max_age_ms=0",
+                       headers={"Accept-Encoding": "identity"})
+    assert "content-encoding" not in plain.headers
+    assert any("did not offer gzip" in w for w in plain.json()["warnings"])
+
+
+# ---------------------------------------------------------------- ETag (§6)
+
+
+def test_etag_is_stable_between_window_rolls_and_304s():
+    workers = build_state()
+    client, engine, _, _ = make_client(
+        enabled_env(**{H.HEATMAP_MIN_PERIOD_MS_ENV: "0"}), workers)
+    first = client.get("/fq/heatmap?max_age_ms=0")
+    etag = first.headers["etag"]
+    assert etag.startswith('W/"fqhm-1-')
+    second = client.get("/fq/heatmap?max_age_ms=0")
+    assert second.headers["etag"] == etag, "piecewise constant between rolls"
+    revalidate = client.get("/fq/heatmap?max_age_ms=0",
+                            headers={"If-None-Match": etag})
+    assert revalidate.status_code == 304
+    assert revalidate.content == b""
+    assert revalidate.headers["etag"] == etag
+    assert "x-fq-step" in {k.lower() for k in revalidate.headers}
+    # a roll changes it
+    for w in workers:
+        w.model_runner.fq_collector.collector._windows_rolled += 1
+    assert client.get("/fq/heatmap?max_age_ms=0").headers["etag"] != etag
+
+
+def test_include_live_defeats_the_etag_by_design():
+    workers = build_state()
+    client, _, _, _ = make_client(
+        enabled_env(**{H.HEATMAP_MIN_PERIOD_MS_ENV: "0"}), workers)
+    a = client.get("/fq/heatmap?include=live&max_age_ms=0").headers["etag"]
+    for w in workers:
+        w.model_runner.fq_collector.collector._step += 1
+    b = client.get("/fq/heatmap?include=live&max_age_ms=0").headers["etag"]
+    assert a != b
+
+
+def test_etag_basis_separates_query_variants():
+    kw = dict(rolled=1, win_pos=2, tier_digest="ab", mass_is_real=False,
+              layers=[3, 4], num_experts=256, include=["mass"],
+              precision="bf16", reduce="rank0")
+    base = H.compute_etag(**kw)
+    assert base == H.compute_etag(**kw)
+    assert base != H.compute_etag(**{**kw, "precision": "f32"})
+    assert base != H.compute_etag(**{**kw, "reduce": "all"})
+    assert base != H.compute_etag(**{**kw, "layers": [3, 5]})
+    assert base != H.compute_etag(**{**kw, "rolled": 2})
+    assert base != H.compute_etag(**{**kw, "include": ["mass", "live"]})
+
+
+# ------------------------------------------------------- cross-rank (§4.3)
+
+
+def test_merge_rule_is_rank0_canonical_never_a_sum():
+    """The 4x lie this test exists to prevent.
+
+    Under TP the gate is replicated (integration.py:149-162), so every
+    rank histograms the SAME topk_ids: the ranks are replicas, not a
+    partition. Summing four identical replicas would report 4x the real
+    routing traffic.
+    """
+    rec = load_record()
+    truth = np.asarray(rec["count"], dtype=np.float64).reshape(-1)
+    client, _, _, _ = make_client(enabled_env(), build_state(ranks=4))
+    _, body = get_json(client, "/fq/heatmap")
+    got = H.decode_floats(body["count"], "bf16", 19200).astype(np.float64)
+    rel = np.abs(got - truth) / np.maximum(truth, 1e-30)
+    assert rel.max() < 0.005, "merged value must equal ONE rank's value"
+    assert np.abs(got - 4 * truth).min() > 0, "must not be the 4-rank sum"
+    assert body["ranks"] == {"count": 4, "canonical": 0, "agree": True,
+                             "reduce": "rank0",
+                             "merge_rule": "rank0-canonical",
+                             "digests": body["ranks"]["digests"]}
+    assert H.MERGE_RULE == "rank0-canonical"
+    assert len({d["digest"] for d in body["ranks"]["digests"]}) == 1
+
+
+def test_rank_divergence_is_reported_not_fatal():
+    workers = build_state(ranks=4, rank_perturb={2: 1000.0})
+    client, _, _, _ = make_client(enabled_env(), workers)
+    resp, body = get_json(client, "/fq/heatmap")
+    assert resp.status_code == 200, "divergence must not deny the picture"
+    assert body["ranks"]["agree"] is False
+    assert body["count"] is not None
+    assert any("DISAGREE" in w and "'rank': 2" in w
+               for w in body["warnings"]), body["warnings"]
+
+
+def test_reduce_all_returns_every_ranks_arrays():
+    client, _, _, _ = make_client(
+        enabled_env(**{H.HEATMAP_MIN_PERIOD_MS_ENV: "0"}),
+        build_state(ranks=4))
+    _, body = get_json(client, "/fq/heatmap?reduce=all&max_age_ms=0")
+    assert len(body["per_rank"]) == 4
+    assert all(r["count"] for r in body["per_rank"])
+    # ...and rank0 mode ships arrays exactly once
+    _, lean = get_json(client, "/fq/heatmap?max_age_ms=0")
+    assert "per_rank" not in lean
+
+
+def test_non_canonical_ranks_ship_a_digest_only():
+    workers = build_state(ranks=4)
+    r2 = json.loads(H.worker_sample(workers[2], '{"op":"sample"}'))
+    assert r2["ok"] is True and r2["canonical"] is False
+    assert "count" not in r2 and "tier" not in r2
+    assert len(r2["digest"]) == 16
+    assert len(json.dumps(r2)) < 700
+
+
+# --------------------------------------------------- degraded paths (§4.4)
+
+
+def test_rank_failure_is_503_with_the_message_forwarded_nothing_cached():
+    bad = json.dumps({"ok": False, "error": {
+        "code": "internal_error", "http_status": 500,
+        "message": "RuntimeError: boom on rank 1", "details": {}}})
+    good = json.dumps({"ok": True, "rank": 0, "digest": "x"})
+    engine = FakeEngineClient([], override=[good, bad])
+    client, _, router, _ = make_client(enabled_env(), engine=engine)
+    resp, body = get_json(client, "/fq/heatmap")
+    assert resp.status_code == 503
+    assert body["error"]["code"] == "fq_heatmap_worker_error"
+    assert "boom on rank 1" in body["error"]["message"]
+    assert router.fq_heatmap_cache == {}, "a failure must not be cached"
+    client.get("/fq/heatmap")
+    assert len(engine.calls) == 2, "the next poll retries"
+
+
+def test_timeout_poisons_the_surface_and_poison_scope_clears_it():
+    engine = FakeEngineClient([], rpc_error=TimeoutError(
+        "RPC call to fq_heatmap_sample timed out."))
+    client, _, _, _ = make_client(enabled_env(), engine=engine)
+    resp, body = get_json(client, "/fq/heatmap")
+    assert resp.status_code == 504
+    assert body["error"]["code"] == "fq_heatmap_timeout"
+    assert "desynchronised" in body["error"]["details"]["guidance"]
+
+    calls = len(engine.calls)
+    resp2, body2 = get_json(client, "/fq/heatmap")
+    assert resp2.status_code == 503
+    assert body2["error"]["code"] == "fq_heatmap_poisoned"
+    assert len(engine.calls) == calls, "poisoned must issue NO rpc"
+
+    cleared = client.post("/fq/heatmap/reset", json={"scope": "poison"})
+    assert cleared.status_code == 200
+    assert cleared.json()["was_poisoned"] is True
+    assert H._POISON.poisoned is False
+    assert len(engine.calls) == calls, "clearing poison issues no rpc"
+
+
+def test_engine_unavailable_is_503():
+    engine = FakeEngineClient([], rpc_error=RuntimeError(
+        "EngineCore encountered an issue: Server shutting down"))
+    client, _, _, _ = make_client(enabled_env(), engine=engine)
+    resp, body = get_json(client, "/fq/heatmap")
+    assert resp.status_code == 503
+    assert body["error"]["code"] == "engine_unavailable"
+
+
+def test_fq_not_active_is_404_not_an_empty_matrix():
+    worker = FakeWorker(None, rank=0)
+    client, _, _, _ = make_client(enabled_env(), [worker])
+    resp, body = get_json(client, "/fq/heatmap")
+    assert resp.status_code == 404
+    assert body["error"]["code"] == "fq_not_active"
+    assert "VLLM_FQ_ENABLE" in body["error"]["message"]
+
+
+def test_meta_reports_fq_active_false_instead_of_404():
+    """A health check that 404s is useless as a health check."""
+    client, _, _, _ = make_client(enabled_env(), [FakeWorker(None)])
+    resp, body = get_json(client, "/fq/heatmap/meta")
+    assert resp.status_code == 200
+    assert body["fq_active"] is False
+    assert body["reason"]["code"] == "fq_not_active"
+    assert body["cells"] is None
+
+
+def test_collector_only_mode_still_serves_counts():
+    workers = build_state(ranks=1, loop=False)
+    client, _, _, _ = make_client(enabled_env(), workers)
+    resp, body = get_json(client, "/fq/heatmap")
+    assert resp.status_code == 200, resp.text
+    assert body["count"] is not None
+    assert body["tier"] is None
+    assert body["interval"] is None
+    assert body["policy_sha"] is None
+    assert body["real_steps"] is None
+    assert body["num_layers"] == 75
+
+
+def test_dp_greater_than_one_is_501():
+    client, engine, _, _ = make_client(enabled_env(), build_state(), dp=2)
+    resp, body = get_json(client, "/fq/heatmap")
+    assert resp.status_code == 501
+    assert body["error"]["code"] == "dp_not_supported"
+    assert "core_client.py:1449-1458" in body["error"]["message"]
+    assert engine.calls == []
+
+
+def test_bad_query_parameters():
+    client, _, _, _ = make_client(enabled_env(), build_state())
+    for url, code in (("/fq/heatmap?include=bogus", "unknown_include"),
+                      ("/fq/heatmap?precision=fp8", "bad_precision"),
+                      ("/fq/heatmap?reduce=sum", "bad_reduce"),
+                      ("/fq/heatmap?max_age_ms=soon", "bad_max_age")):
+        resp, body = get_json(client, url)
+        assert resp.status_code == 400, url
+        assert body["error"]["code"] == code, url
+
+
+# ---------------------------------------------------------- gating (§3.3)
+
+
+def test_the_endpoint_is_off_by_default():
+    for env in ({}, {H.DEV_MODE_ENV: "1"}, {H.HEATMAP_API_ENV: "1"},
+                {H.DEV_MODE_ENV: "0", H.HEATMAP_API_ENV: "1"}):
+        client, engine, router, attached = make_client(env, build_state())
+        assert attached is False, env
+        assert router is None, env
+        assert client.get("/fq/heatmap").status_code == 404, env
+        assert client.get("/fq/heatmap/meta").status_code == 404, env
+        assert client.post("/fq/heatmap/reset",
+                           json={"scope": "client"}).status_code == 404, env
+        assert engine.calls == []
+
+
+def test_both_gates_on_attaches():
+    _, _, _, attached = make_client(enabled_env(), build_state())
+    assert attached is True
+    _, _, _, aliased = make_client(
+        {H.DEV_MODE_ENV: "1", H.HEATMAP_API_ALIAS_ENV: "1"}, build_state())
+    assert aliased is True
+
+
+def test_token_gate():
+    env = enabled_env(**{H.HEATMAP_TOKEN_ENV: "hunter2"})
+    client, _, _, _ = make_client(env, build_state())
+    assert client.get("/fq/heatmap").status_code == 403
+    assert client.get("/fq/heatmap",
+                      headers={"X-FQ-Heatmap-Token": "nope"}).status_code \
+        == 403
+    ok = client.get("/fq/heatmap",
+                    headers={"X-FQ-Heatmap-Token": "hunter2"})
+    assert ok.status_code == 200
+    # A latin-1 byte in the header must be a 403, never a 500: Starlette
+    # decodes headers as latin-1 and hmac.compare_digest refuses str
+    # operands with non-ASCII code points.
+    assert client.get(
+        "/fq/heatmap",
+        headers={"X-FQ-Heatmap-Token": b"caf\xe9"}).status_code == 403
+
+
+def test_worker_reenforces_the_gate_against_the_collective_rpc_bypass(
+        monkeypatch):
+    """dev mode alone attaches POST /collective_rpc, which can call
+    ``fq_heatmap_sample`` by name — the worker must refuse."""
+    workers = build_state()
+    monkeypatch.delenv(H.HEATMAP_API_ENV, raising=False)
+    out = json.loads(H.worker_sample(workers[0], '{"op":"sample"}'))
+    assert out["ok"] is False
+    assert out["error"]["code"] == "fq_heatmap_disabled"
+    assert out["error"]["http_status"] == 404
+
+
+# --------------------------------------------------- single-flight (§4.4)
+
+
+def test_ttl_cache_collapses_repeat_polls_to_one_rpc():
+    client, engine, _, _ = make_client(enabled_env(), build_state())
+    for _ in range(10):
+        assert client.get("/fq/heatmap?max_age_ms=1000").status_code == 200
+    assert len(engine.calls) == 1, engine.calls
+    assert client.get("/fq/heatmap").json()["cached"] is True
+
+
+def test_single_flight_lock_collapses_concurrent_polls():
+    app = fastapi.FastAPI()
+    engine = FakeEngineClient(build_state(), delay=0.02)
+    app.state.engine_client = engine
+    app.include_router(H.build_router(environ=enabled_env()))
+
+    async def hammer():
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport,
+                                     base_url="http://t") as ac:
+            out = await asyncio.gather(
+                *[ac.get("/fq/heatmap?max_age_ms=1000") for _ in range(10)])
+        return [r.status_code for r in out]
+
+    assert asyncio.run(hammer()) == [200] * 10
+    assert len(engine.calls) == 1, engine.calls
+
+
+def test_max_age_zero_is_clamped_to_the_floor_and_says_so():
+    client, engine, _, _ = make_client(
+        enabled_env(**{H.HEATMAP_MIN_PERIOD_MS_ENV: "500"}), build_state())
+    _, body = get_json(client, "/fq/heatmap?max_age_ms=0")
+    assert any("clamped up to the" in w and "500 ms" in w
+               for w in body["warnings"]), body["warnings"]
+    for _ in range(5):
+        client.get("/fq/heatmap?max_age_ms=0")
+    assert len(engine.calls) == 1, "the floor caps the engine-stall rate"
+
+
+# ------------------------------------------------------------- rates (§5.4)
+
+
+def _drive(collector, layers, hits_per_step, steps):
+    for _ in range(steps):
+        for lid in layers:
+            collector.count_buf[lid][:collector.num_experts] += hits_per_step
+        collector.step()
+
+
+def test_rate_from_the_decayed_window_matches_a_constant_rate_source():
+    coll = FqStatsCollector(4, window_len=8, window_stride=4, decay=0.95,
+                            device="cpu")
+    coll.bind_router(0, FakeRouter())
+    _drive(coll, [0], 5.0, 8 * 4)
+    count, _ = coll.decayed(0)
+    denom = H.rate_denominator(coll.window_stride, coll.decay,
+                               min(coll._windows_rolled, coll.window_len))
+    got = float(count[0]) / denom
+    assert abs(got - 5.0) / 5.0 < 0.01, got
+
+
+def test_steps_since_roll_is_zero_right_after_a_roll():
+    coll = FqStatsCollector(4, window_len=8, window_stride=4, device="cpu")
+    coll.bind_router(0, FakeRouter())
+    _drive(coll, [0], 1.0, 8)
+    meta = H._window_meta(coll)
+    assert meta["steps_since_roll"] == 0
+    assert meta["rolled"] == 2
+    assert meta["n_effective"] == 2
+    _drive(coll, [0], 1.0, 1)
+    assert H._window_meta(coll)["steps_since_roll"] == 1
+
+
+def test_window_metadata_shape():
+    meta = H._window_meta(DumpCollector(np.ones((1, 4)), np.ones((1, 4)),
+                                        layers=[3]))
+    assert meta["len"] == 64 and meta["stride"] == 32
+    assert meta["decay"] == 0.95 and meta["n_effective"] == 64
+    assert abs(meta["horizon_steps"] - 640.0) < 1e-9
+    assert abs(meta["rate_denominator"] - 615.9845509) < 1e-6
+
+
+# -------------------------------------------------------- cumulative (§7.4)
+
+
+def _cum_collector(e=4, window_len=4, stride=2):
+    coll = FqStatsCollector(e, window_len=window_len, window_stride=stride,
+                            decay=0.9, device="cpu")
+    coll.bind_router(0, FakeRouter())
+    return coll
+
+
+def test_cumulative_is_the_exact_int64_ring_sum():
+    coll = _cum_collector()
+    acc = H._CumAccumulator()
+    acc.integrate(coll, [0], [0], coll._windows_rolled, coll._win_pos,
+                  coll._step)
+    assert acc.cum.sum() == 0, "the first sample starts at zero"
+    _drive(coll, [0], 3.0, 6)          # 3 rolls x (2 steps x 3 hits) = 18
+    acc.integrate(coll, [0], [0], coll._windows_rolled, coll._win_pos,
+                  coll._step)
+    exact = coll._count_win[0].sum(0).numpy().astype(np.int64)
+    assert acc.cum[0].tolist() == exact.tolist()
+    assert acc.cum[0].tolist() == [18, 18, 18, 18]
+    assert acc.lossy is False
+
+
+def test_cumulative_reports_loss_when_the_ring_wrapped():
+    coll = _cum_collector(window_len=4, stride=2)
+    acc = H._CumAccumulator()
+    acc.integrate(coll, [0], [0], 0, 0, 0)
+    _drive(coll, [0], 1.0, 2 * 10)                # 10 rolls into a 4-slot ring
+    acc.integrate(coll, [0], [0], coll._windows_rolled, coll._win_pos,
+                  coll._step)
+    assert acc.lossy is True
+    assert acc.dropped_slots == 6
+    assert acc.cum[0].tolist() == [8, 8, 8, 8]    # only the surviving 4 slots
+
+
+def test_cumulative_auto_rebases_before_u32_would_wrap():
+    coll = _cum_collector()
+    acc = H._CumAccumulator()
+    acc.integrate(coll, [0], [0], 0, 0, 0)
+    acc.cum += (1 << 31) - 1
+    _drive(coll, [0], 1.0, 2)
+    acc.integrate(coll, [0], [0], coll._windows_rolled, coll._win_pos, 999)
+    assert acc.overflow_rebased is True
+    assert acc.cum.max() == 0
+    assert acc.since_step == 999
+
+
+def test_include_cum_ships_a_u32_array_and_the_rebase_step():
+    workers = build_state()
+    client, _, _, _ = make_client(
+        enabled_env(**{H.HEATMAP_MIN_PERIOD_MS_ENV: "0"}), workers)
+    _, body = get_json(client, "/fq/heatmap?include=cum&max_age_ms=0")
+    assert body["cum_count"] is not None
+    assert H.decode_u32(body["cum_count"], 19200).size == 19200
+    assert body["cum_since_step"] == 19100
+    assert body["encoding"]["cum_count"] == "u32"
+
+
+# ------------------------------------------------------------- reset (§7)
+
+
+def test_reset_client_changes_nothing_server_side_and_issues_no_rpc():
+    workers = build_state(ranks=2)
+    coll = workers[0].model_runner.fq_collector.collector
+    client, engine, _, _ = make_client(enabled_env(), workers)
+    client.get("/fq/heatmap")
+    before = (coll._count_win[3].clone(), coll._windows_rolled, coll._win_pos,
+              workers[0].model_runner.fq_collector.tier_of.copy(),
+              workers[0].model_runner.fq_collector.policy_sha)
+    calls = len(engine.calls)
+
+    resp = client.post("/fq/heatmap/reset",
+                       json={"scope": "client", "reason": "before coder"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["applied"] is False
+    assert body["baseline_sample_id"] == 1
+    assert body["baseline_step"] == 19100
+    assert "change since mark" in body["note"]
+    assert len(engine.calls) == calls, "scope=client must issue no rpc"
+    assert torch.equal(coll._count_win[3], before[0])
+    assert (coll._windows_rolled, coll._win_pos) == before[1:3]
+    assert np.array_equal(
+        workers[0].model_runner.fq_collector.tier_of, before[3])
+    assert workers[0].model_runner.fq_collector.policy_sha == before[4]
+
+
+def test_reset_heatmap_rebases_cum_on_all_ranks_without_touching_the_window():
+    workers = build_state(ranks=4)
+    coll = workers[0].model_runner.fq_collector.collector
+    client, engine, _, _ = make_client(
+        enabled_env(**{H.HEATMAP_MIN_PERIOD_MS_ENV: "0"}), workers)
+    client.get("/fq/heatmap?include=cum&max_age_ms=0")
+    win_before = coll._count_win[3].clone()
+
+    resp = client.post("/fq/heatmap/reset", json={"scope": "heatmap"})
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["applied"] is True and body["ranks"] == 4
+    assert body["cum_since_step"] == 19100
+    assert "untouched" in body["note"]
+    assert engine.calls[-1][0] == "fq_heatmap_sample"
+    assert json.loads(engine.calls[-1][1][0])["op"] == "reset_cum"
+    assert torch.equal(coll._count_win[3], win_before)
+    assert coll._windows_rolled == 596
+
+    _, after = get_json(client, "/fq/heatmap?include=cum&max_age_ms=0")
+    assert H.decode_u32(after["cum_count"], 19200).sum() == 0
+
+
+def test_reset_collector_is_refused_without_the_third_gate():
+    client, engine, _, _ = make_client(enabled_env(), build_state())
+    resp = client.post("/fq/heatmap/reset", json={"scope": "collector"})
+    assert resp.status_code == 409
+    assert resp.json()["error"]["code"] == "collector_zero_not_allowed"
+    assert engine.calls == []
+
+
+def test_reset_collector_with_the_gate_zeroes_every_rank(monkeypatch):
+    monkeypatch.setenv(H.HEATMAP_ALLOW_COLLECTOR_ZERO_ENV, "1")
+    colls = []
+    workers = []
+    for r in range(2):
+        coll = FqStatsCollector(4, window_len=4, window_stride=2,
+                                device="cpu")
+        coll.bind_router(0, FakeRouter())
+        _drive(coll, [0], 3.0, 8)
+        colls.append(coll)
+        workers.append(FakeWorker(
+            FakeLoopState(coll, [0], np.full((1, 4), 3)), rank=r))
+    assert float(colls[0].decayed(0)[0].sum()) > 0
+
+    env = enabled_env(**{H.HEATMAP_ALLOW_COLLECTOR_ZERO_ENV: "1"})
+    client, _, _, _ = make_client(env, workers)
+    resp = client.post("/fq/heatmap/reset",
+                       json={"scope": "collector", "reason": "operator"})
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["applied"] is True and body["ranks"] == 2
+    assert any("pin-forced" in w for w in body["warnings"])
+    for coll in colls:
+        assert coll._windows_rolled == 0 and coll._win_pos == 0
+        assert float(coll.decayed(0)[0].sum()) == 0.0
+        assert float(coll._count_win[0].sum()) == 0
+
+
+def test_zeroed_stats_hold_unpinned_swaps_but_pin_forced_pairs_still_emit():
+    """§7.5, pinned in a test so nobody "fixes" the warning away.
+
+    With an all-zero window the hysteresis guard is ``0 > 1.25*0`` ->
+    False, so free swaps are suppressed — but ``policy.py:142-144``
+    waives hysteresis for a pin-forced pair, and with every score equal
+    the partner is chosen by ``lexsort((arange(E), -0))``, i.e. by index
+    order rather than by traffic.
+    """
+    E = 8
+    zero = {"count": np.zeros((1, E)), "mass": np.zeros((1, E))}
+    eps = {P.K3: np.full((1, E), 1.0), P.K4: np.zeros((1, E))}
+    tier = np.full((1, E), P.K3)
+    tier[0, 6] = tier[0, 7] = P.K4                # K4 held by the top ids
+    cfg = {"n_k4": [2]}
+
+    assert P.decide(zero, eps, tier, cfg=cfg) == [], "no unpinned swaps"
+
+    pins = np.zeros((1, E), dtype=np.int64)
+    pins[0, 3] = P.PIN_K4                         # operator pin
+    forced = P.decide(zero, eps, tier, pins=pins, cfg=cfg)
+    assert forced == [(0, 6, 3)], forced
+    assert forced[0][1] == 6, "partner picked by index order, not traffic"
+
+
+def test_reset_bad_scope_and_bad_json():
+    client, _, _, _ = make_client(enabled_env(), build_state())
+    assert client.post("/fq/heatmap/reset",
+                       json={"scope": "nuke"}).status_code == 400
+    resp = client.post("/fq/heatmap/reset", content=b"{not json",
+                       headers={"Content-Type": "application/json"})
+    assert resp.status_code == 400
+    assert resp.json()["error"]["code"] == "bad_json"
+
+
+# ---------------------------------------------------------- no tearing (§4.2)
+
+
+class RollingCollector(DumpCollector):
+    """Bumps ``_windows_rolled`` during the first read only."""
+
+    def __init__(self, *a, **kw):
+        super().__init__(*a, **kw)
+        self.reads = 0
+
+    def decayed(self, layer_id):
+        self.reads += 1
+        if self.reads == 1:
+            self._windows_rolled += 1
+        return super().decayed(layer_id)
+
+
+def test_a_roll_during_the_read_forces_exactly_one_retry():
+    rec = load_record()
+    coll = RollingCollector(np.asarray(rec["count"])[:2],
+                            np.asarray(rec["mass"])[:2], layers=[3, 4])
+    state = FakeLoopState(coll, [3, 4], np.full((2, 256), 3))
+    out = json.loads(H.worker_sample(FakeWorker(state), '{"op":"sample"}'))
+    assert out["ok"] is True
+    assert any(w == "torn read retried 1x" for w in out["warnings"]), \
+        out["warnings"]
+    # 2 layers x 2 attempts
+    assert coll.reads == 4
+    assert out["window"]["rolled"] == coll._windows_rolled
+
+
+# ------------------------------------------------------------- meta (§3.1)
+
+
+def test_meta_is_small_and_cached_after_the_first_rpc():
+    client, engine, _, _ = make_client(enabled_env(), build_state(ranks=4))
+    resp, body = get_json(client, "/fq/heatmap/meta")
+    assert resp.status_code == 200
+    assert body["fq_active"] is True
+    assert body["layers"] == list(range(3, 78))
+    assert body["cells"] == 19200
+    assert body["merge_rule"] == "rank0-canonical"
+    assert body["cached"] is False
+    assert len(json.dumps(body).encode()) < 2000
+    assert len(engine.calls) == 1
+    _, again = get_json(client, "/fq/heatmap/meta")
+    assert again["cached"] is True
+    assert len(engine.calls) == 1, "meta costs one rpc, ever"
+
+
+def test_meta_stays_available_while_the_sampling_path_is_poisoned():
+    client, engine, _, _ = make_client(enabled_env(), build_state())
+    client.get("/fq/heatmap/meta")
+    H._POISON.poison("test")
+    resp, body = get_json(client, "/fq/heatmap/meta")
+    assert resp.status_code == 200
+    assert body["poisoned"] is True
+    assert client.get("/fq/heatmap").status_code == 503
+
+
+# ------------------------------------------------------- fixture shapes
+
+
+@pytest.mark.parametrize("name", ARCHIVED)
+def test_every_archived_dump_parses_into_a_valid_sample(name):
+    """Shape only — ``stats-INVALID-truncated-corpus.jsonl`` came from a
+    broken replay, so its VALUES are meaningless but its shape is not."""
+    rec = load_record(name, 0)
+    assert sorted(rec) == ["count", "interval", "layers", "mass",
+                           "mass_is_real", "step", "tier_of"]
+    workers = build_state(rec)
+    client, _, _, _ = make_client(enabled_env(), workers)
+    resp, body = get_json(client, "/fq/heatmap")
+    assert resp.status_code == 200, resp.text
+    assert body["cells"] == len(rec["layers"]) * 256
+    assert H.decode_floats(body["count"], "bf16", body["cells"]).size \
+        == body["cells"]
+    assert H.decode_tier(body["tier"], body["cells"]).size == body["cells"]
+    assert body["mass_is_real"] is False
+
+
+def test_headers_carry_the_sample_identity():
+    client, _, _, _ = make_client(enabled_env(), build_state())
+    resp = client.get("/fq/heatmap")
+    assert resp.headers["x-fq-sample-id"] == "1"
+    assert resp.headers["x-fq-step"] == "19100"
+    assert resp.headers["x-fq-merge-rule"] == "rank0-canonical"
+    assert resp.headers["cache-control"] == "no-cache, must-revalidate"
+    body = resp.json()
+    assert body["schema"] == "fq-heatmap/1"
+    assert len(body["server_boot_id"]) == 8
+    assert body["encoding"]["layout"] == "layer-major"
+    assert body["encoding"]["byte_order"] == "little"

--- a/tests/exl3_fungible/test_heatmap_cpu.py
+++ b/tests/exl3_fungible/test_heatmap_cpu.py
@@ -1076,3 +1076,195 @@ def test_headers_carry_the_sample_identity():
     assert len(body["server_boot_id"]) == 8
     assert body["encoding"]["layout"] == "layer-major"
     assert body["encoding"]["byte_order"] == "little"
+
+
+# ============================================================ adversarial review
+# Added by the M5 heatmap adversarial review. Each of these fails against the
+# pre-review code; see runs/m5-serve/heatmap/REVIEW.md.
+
+
+_CAPTURED: dict = {}
+
+
+class RecordingRouter(FakeRouter):
+    """Keeps the capture fn so a test can drive it like the real router."""
+
+    def __init__(self, layer_id):
+        self.layer_id = layer_id
+
+    def set_capture_fn(self, fn):
+        self.capture_fn = fn
+        _CAPTURED[self.layer_id] = fn
+
+
+def test_tp_ranks_are_replicas_so_the_merge_must_not_sum_the_real_collector():
+    """ATTACK 1, proved against ``stats.FqStatsCollector`` itself.
+
+    ``integration.maybe_init_fq_collector`` sizes the collector to
+    ``global_num_experts`` and histograms the GATE's ``topk_ids``
+    (stats.py:211-231). Under TP the gate is replicated, so every rank
+    observes the SAME routing events: four ranks are four copies of one
+    number, not four quarters of it. The endpoint must therefore return
+    1x, never 4x.
+    """
+    E, LID, RANKS = 8, 0, 4
+    torch.manual_seed(0)
+    batches = [torch.randint(0, E, (16, 2)) for _ in range(6)]
+
+    colls = []
+    for _ in range(RANKS):
+        _CAPTURED.clear()
+        coll = FqStatsCollector(E, window_len=4, window_stride=2, decay=0.9,
+                                device="cpu")
+        coll.bind_router(LID, RecordingRouter(LID))
+        for b in batches:                      # the SAME batches on every rank
+            _CAPTURED[LID](b)
+            coll.step()
+        colls.append(coll)
+
+    ref = colls[0].decayed(LID)[0]
+    assert float(ref.sum()) > 0, "the fixture must record something"
+    for r, coll in enumerate(colls[1:], 1):
+        assert torch.equal(coll.decayed(LID)[0], ref), (
+            f"rank {r} is not a replica of rank 0 — the merge premise is "
+            "false and rank0-canonical would be wrong")
+
+    # ...and the endpoint over those four REAL collectors returns 1x.
+    workers = [FakeWorker(FakeLoopState(c, [LID], np.full((1, E), 3)), rank=r)
+               for r, c in enumerate(colls)]
+    client, _, _, _ = make_client(enabled_env(), workers)
+    _, body = get_json(client, "/fq/heatmap")
+    got = H.decode_floats(body["count"], "bf16", E).astype(np.float64)
+    truth = ref.numpy().astype(np.float64)
+    assert np.abs(got - truth).max() <= 0.005 * max(1.0, float(truth.max()))
+    assert np.abs(got - RANKS * truth).min() > 0, "the endpoint SUMMED the ranks"
+    assert body["ranks"]["merge_rule"] == "rank0-canonical"
+
+
+def test_cumulative_restarts_instead_of_freezing_when_the_ring_rewinds():
+    """A zeroed collector rewinds ``_windows_rolled``; the accumulator must
+    not report a pre-zero total for traffic that no longer exists."""
+    coll = _cum_collector(window_len=4, stride=2)
+    acc = H._CumAccumulator()
+    acc.integrate(coll, [0], [0], coll._windows_rolled, coll._win_pos,
+                  coll._step)
+    _drive(coll, [0], 3.0, 6)
+    acc.integrate(coll, [0], [0], coll._windows_rolled, coll._win_pos,
+                  coll._step)
+    assert acc.cum.max() > 0 and acc.rolled == coll._windows_rolled
+
+    # somebody zeroed the collector: rolled goes back to 0
+    coll._count_win[0].zero_()
+    coll._win_pos = 0
+    coll._windows_rolled = 0
+    acc.integrate(coll, [0], [0], 0, 0, 777)
+    assert acc.cum.max() == 0, "cum kept a total for traffic that is gone"
+    assert acc.since_step == 777, "cum_since_step must move to the restart"
+    assert acc.rolled == 0, "the accumulator stayed pinned to the old ring"
+
+    # and it starts counting again immediately rather than staying frozen
+    _drive(coll, [0], 2.0, 4)
+    acc.integrate(coll, [0], [0], coll._windows_rolled, coll._win_pos, 800)
+    assert acc.cum.max() > 0, "the accumulator never resumed"
+
+
+def test_zero_collector_rebases_the_cumulative_on_the_same_call(monkeypatch):
+    """ATTACK: ``op=zero_collector`` must not leave ``cum_count`` reporting a
+    pre-zero total on the very next poll."""
+    monkeypatch.setenv(H.HEATMAP_ALLOW_COLLECTOR_ZERO_ENV, "1")
+    coll = FqStatsCollector(4, window_len=4, window_stride=2, device="cpu")
+    coll.bind_router(0, FakeRouter())
+    _drive(coll, [0], 3.0, 8)
+    worker = FakeWorker(FakeLoopState(coll, [0], np.full((1, 4), 3)), rank=0)
+
+    first = json.loads(H.worker_sample(
+        worker, '{"op":"sample","include":["cum"]}'))
+    assert first["ok"] is True
+    _drive(coll, [0], 3.0, 4)
+    second = json.loads(H.worker_sample(
+        worker, '{"op":"sample","include":["cum"]}'))
+    assert H.decode_u32(second["cum_count"], 4).max() > 0
+
+    env = enabled_env(**{H.HEATMAP_ALLOW_COLLECTOR_ZERO_ENV: "1"})
+    client, _, _, _ = make_client(env, [worker])
+    assert client.post("/fq/heatmap/reset",
+                       json={"scope": "collector"}).status_code == 200
+
+    after = json.loads(H.worker_sample(
+        worker, '{"op":"sample","include":["cum"]}'))
+    assert H.decode_u32(after["cum_count"], 4).max() == 0, (
+        "cum_count survived a collector zero and now describes traffic that "
+        "no longer exists in the ring")
+    assert after["cum_since_step"] == coll._step
+
+
+# ------------------------------------------------- adversarial review (M5)
+# Added by the heatmap feature review. Each of these FAILS on the code as it
+# stood before the fix in the same commit.
+
+
+def test_reduce_all_still_takes_rank_0_when_results_arrive_out_of_order():
+    """``?reduce=all`` makes EVERY rank canonical, so "first canonical entry"
+    is only rank 0 while the executor happens to answer in rank order.
+
+    ``_rank_results`` preserves whatever order it is handed
+    (``admin.py:2106-2115``), so a reordering executor would put another
+    rank's arrays in a body stamped ``merge_rule: rank0-canonical``. Pick by
+    RANK, not by position.
+    """
+    rec = load_record()
+    # rank 2 is given a distinguishable histogram
+    workers = build_state(rec, ranks=4, rank_perturb={2: 1234.0})
+
+    class Reversing(FakeEngineClient):
+        async def collective_rpc(self, method, timeout=None, args=(),
+                                 kwargs=None):
+            out = await FakeEngineClient.collective_rpc(
+                self, method, timeout=timeout, args=args, kwargs=kwargs)
+            return list(reversed(out))          # rank 3 first, rank 0 last
+
+    client, _, _, _ = make_client(
+        enabled_env(), engine=Reversing(workers))
+    _, body = get_json(client, "/fq/heatmap?reduce=all")
+    assert body["ranks"]["canonical"] == 0, body["ranks"]
+    assert body["ranks"]["merge_rule"] == "rank0-canonical"
+
+    truth = np.asarray(rec["count"], dtype=np.float64).reshape(-1)
+    got = H.decode_floats(body["count"], "bf16", truth.size).astype(np.float64)
+    # rank 0's array, not rank 3's and certainly not a sum of the four
+    assert np.abs(got - truth).max() <= 0.005 * float(truth.max())
+    assert np.abs(got - 4.0 * truth).max() > float(truth.max())
+
+
+def test_the_worker_gate_is_env_only_the_token_does_not_reach_it():
+    """Pins the REAL reach of ``_require_gates``, so its docstring cannot
+    drift back into claiming it defends ``VLLM_FQ_HEATMAP_TOKEN``.
+
+    The token is an HTTP header checked at the router; nothing of the HTTP
+    request survives into ``collective_rpc``. Anyone who can reach
+    ``POST /collective_rpc`` can therefore read the matrix without it — and
+    can already call any other worker method, which is strictly more reach.
+    The destructive scope is NOT in that position: it has its own env gate.
+    """
+    import os
+
+    os.environ[H.HEATMAP_TOKEN_ENV] = "hunter2"
+    try:
+        workers = build_state()
+        # the route refuses without the header ...
+        client, _, _, _ = make_client(
+            enabled_env(**{H.HEATMAP_TOKEN_ENV: "hunter2"}), workers)
+        assert client.get("/fq/heatmap").status_code == 403
+        # ... and the worker method, reached directly, does NOT.
+        out = json.loads(H.worker_sample(workers[0], '{"op":"sample"}'))
+        assert out["ok"] is True, (
+            "if this now fails the worker learned about the token — update "
+            "the _require_gates docstring and the spec together")
+        assert out["count"], "the bypass returned the arrays"
+        # the destructive scope stays shut: it is env-gated, not token-gated
+        zeroed = json.loads(
+            H.worker_sample(workers[0], '{"op":"zero_collector"}'))
+        assert zeroed["ok"] is False
+        assert zeroed["error"]["code"] == "collector_zero_not_allowed"
+    finally:
+        os.environ.pop(H.HEATMAP_TOKEN_ENV, None)

--- a/tests/exl3_fungible/test_integration_cpu.py
+++ b/tests/exl3_fungible/test_integration_cpu.py
@@ -134,7 +134,7 @@ def test_env_on_binds_all_routers_and_chains(fakes):
     # Fire the bound fns: stats recorded AND the previous fn still fires.
     ids = torch.tensor([[0, 1], [1, 7]], dtype=torch.int32)
     routers[1].capture_fn(ids)
-    assert collector.count_buf[1].tolist() == [1, 2, 0, 0, 0, 0, 0, 1]
+    assert collector.count_buf[1][:8].tolist() == [1, 2, 0, 0, 0, 0, 0, 1]
     assert seen == [ids.shape], "previously bound capture fn must chain"
     routers[0].capture_fn(torch.tensor([[4]]))
     assert collector.count_buf[0][4] == 1

--- a/tests/exl3_fungible/test_integration_cpu.py
+++ b/tests/exl3_fungible/test_integration_cpu.py
@@ -1,0 +1,168 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU contract tests for the fungible-quant integration hook (M1).
+
+No GPU, no built vllm required: integration.py resolves its vllm
+symbols through the ``_moe_module_types`` / ``_collector_cls`` seam
+functions, which these tests monkeypatch with fakes. The fakes
+duck-type exactly what the hook touches: ``runner.model.modules()``,
+``runner.device``, ``module.layer_id``, ``module.router``,
+``router.global_num_experts``, ``router.set_capture_fn``.
+"""
+import importlib.util
+from pathlib import Path
+
+import pytest
+import torch
+
+try:
+    from vllm.model_executor.layers.quantization.exl3_fungible import (
+        integration as fq_integration,
+    )
+    from vllm.model_executor.layers.quantization.exl3_fungible.stats import (
+        FqStatsCollector,
+    )
+except ImportError:  # standalone run against an env without built vllm._C
+    _pkg = (Path(__file__).resolve().parents[2] / "vllm" / "model_executor"
+            / "layers" / "quantization" / "exl3_fungible")
+
+    def _load(name: str, filename: str):
+        spec = importlib.util.spec_from_file_location(name, _pkg / filename)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+
+    FqStatsCollector = _load("fq_stats_standalone", "stats.py").FqStatsCollector
+    fq_integration = _load("fq_integration_standalone", "integration.py")
+
+
+class FakeRouter:
+    def __init__(self, global_num_experts: int = 8):
+        self.global_num_experts = global_num_experts
+        self.capture_fn = None
+
+    def set_capture_fn(self, fn):
+        self.capture_fn = fn
+
+
+class FakeMoERunner:
+    def __init__(self, layer_id: int, router):
+        self.layer_id = layer_id
+        self.router = router
+
+
+class FakeModel:
+    def __init__(self, modules):
+        self._modules = list(modules)
+
+    def modules(self):
+        return iter(self._modules)
+
+
+class FakeRunner:
+    def __init__(self, modules):
+        self.model = FakeModel(modules)
+        self.device = "cpu"
+
+
+def make_runner(num_layers: int = 2, num_experts: int = 8) -> FakeRunner:
+    mods: list = [object()]  # non-MoE module: must be skipped
+    for lid in range(num_layers):
+        mods.append(FakeMoERunner(lid, FakeRouter(num_experts)))
+    # MoERunner whose router is NOT a BaseRouter: must be skipped too
+    mods.append(FakeMoERunner(99, object()))
+    return FakeRunner(mods)
+
+
+def moe_routers(runner: FakeRunner) -> list[FakeRouter]:
+    return [m.router for m in runner.model._modules
+            if isinstance(m, FakeMoERunner) and isinstance(m.router, FakeRouter)]
+
+
+@pytest.fixture
+def fakes(monkeypatch):
+    """Inject the fake isinstance targets + the (real) collector class."""
+    monkeypatch.setattr(fq_integration, "_moe_module_types",
+                        lambda: (FakeMoERunner, FakeRouter))
+    monkeypatch.setattr(fq_integration, "_collector_cls",
+                        lambda: FqStatsCollector)
+    for env in (fq_integration.FQ_ENABLE_ENV,
+                fq_integration.FQ_WINDOW_LEN_ENV,
+                fq_integration.FQ_WINDOW_STRIDE_ENV,
+                fq_integration.FQ_DECAY_ENV):
+        monkeypatch.delenv(env, raising=False)
+    return monkeypatch
+
+
+def test_env_off_returns_none_and_binds_nothing(fakes):
+    runner = make_runner()
+    assert fq_integration.maybe_init_fq_collector(runner) is None
+    assert all(r.capture_fn is None for r in moe_routers(runner))
+    fakes.setenv(fq_integration.FQ_ENABLE_ENV, "0")  # explicit off
+    assert fq_integration.maybe_init_fq_collector(runner) is None
+    assert all(r.capture_fn is None for r in moe_routers(runner))
+
+
+def test_env_off_imports_nothing(fakes):
+    """The env-off path must return before touching the lazy seams —
+    that is the zero-import-cost guarantee for the default path."""
+    def _boom():
+        raise AssertionError("lazy import touched with env off")
+
+    fakes.setattr(fq_integration, "_moe_module_types", _boom)
+    fakes.setattr(fq_integration, "_collector_cls", _boom)
+    assert fq_integration.maybe_init_fq_collector(make_runner()) is None
+
+
+def test_env_on_binds_all_routers_and_chains(fakes):
+    fakes.setenv(fq_integration.FQ_ENABLE_ENV, "1")
+    runner = make_runner(num_layers=3)
+    routers = moe_routers(runner)
+
+    # Pre-bind a capture fn on layer 1's router, as the routed-experts
+    # capturer would have (enable_return_routed_experts path).
+    seen: list = []
+    routers[1].capture_fn = lambda ids: seen.append(ids.shape)
+
+    collector = fq_integration.maybe_init_fq_collector(runner)
+    assert collector is not None
+    assert collector.num_experts == 8
+    assert collector.device == torch.device("cpu")
+    assert all(r.capture_fn is not None for r in routers)
+    assert set(collector.count_buf) == {0, 1, 2}
+
+    # Fire the bound fns: stats recorded AND the previous fn still fires.
+    ids = torch.tensor([[0, 1], [1, 7]], dtype=torch.int32)
+    routers[1].capture_fn(ids)
+    assert collector.count_buf[1].tolist() == [1, 2, 0, 0, 0, 0, 0, 1]
+    assert seen == [ids.shape], "previously bound capture fn must chain"
+    routers[0].capture_fn(torch.tensor([[4]]))
+    assert collector.count_buf[0][4] == 1
+
+
+def test_no_moe_model_returns_none(fakes):
+    fakes.setenv(fq_integration.FQ_ENABLE_ENV, "1")
+    runner = FakeRunner([object(), object()])
+    assert fq_integration.maybe_init_fq_collector(runner) is None
+    # MoERunner present but with a non-BaseRouter router: still no-MoE.
+    runner = FakeRunner([FakeMoERunner(0, object())])
+    assert fq_integration.maybe_init_fq_collector(runner) is None
+
+
+def test_window_knobs_read_from_env(fakes):
+    fakes.setenv(fq_integration.FQ_ENABLE_ENV, "1")
+    fakes.setenv(fq_integration.FQ_WINDOW_LEN_ENV, "5")
+    fakes.setenv(fq_integration.FQ_WINDOW_STRIDE_ENV, "3")
+    fakes.setenv(fq_integration.FQ_DECAY_ENV, "0.5")
+    collector = fq_integration.maybe_init_fq_collector(make_runner())
+    assert collector.window_len == 5
+    assert collector.window_stride == 3
+    assert collector.decay == 0.5
+
+
+def test_window_knobs_default_to_stats_signature(fakes):
+    fakes.setenv(fq_integration.FQ_ENABLE_ENV, "1")
+    collector = fq_integration.maybe_init_fq_collector(make_runner())
+    assert collector.window_len == 64
+    assert collector.window_stride == 32
+    assert collector.decay == 0.95

--- a/tests/exl3_fungible/test_loader_compat_cpu.py
+++ b/tests/exl3_fungible/test_loader_compat_cpu.py
@@ -1,0 +1,452 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU tests for tensor-loader-variant compatibility.
+
+Backs the claims in ``runs/m5-serve/loader-compatibility.md``.  vLLM/GG
+ships a dozen ``--load-format`` variants and they do NOT all hand out
+tensors with the same lifetime.  Two families exist:
+
+* **Owning** — the yielded tensor keeps its storage alive by refcount
+  (default lazy safetensors mmap, ``eager``, ``runai_streamer`` which
+  clones, and our ``progressive`` stream).  A consumer may retain the
+  tensor and copy it later.
+* **Borrowed** — the tensor is a view into a buffer the loader recycles
+  on the next yield and frees on context exit (``instanttensor`` with
+  ``INSTANTTENSOR_COPY=0`` per GG PR #281, ``fastsafetensors`` when the
+  process group has size > 1).  A consumer MUST copy before it returns.
+
+The EXL3 quant methods retain (``Exl3Parameter.load_exl3_weight`` stores
+``loaded_weight.contiguous()``, a no-op on an already-contiguous tensor)
+and only copy in ``process_weights_after_loading``, so they are an
+owning-only consumer.  These tests pin the two halves of the story that
+belong to fungible quant:
+
+1. our loader-side code is an *owning producer* — every tensor it yields
+   stays valid after the generator, the resolver and the spec are gone;
+2. our runtime-side code (``swap.py``, the only FQ code that consumes
+   somebody else's tensors) is a *copying consumer* — it survives a
+   payload buffer that gets recycled the moment the call returns.
+
+Plus a control test that demonstrates the hazard itself, so the matrix's
+"incompatible" verdicts are not an assertion of faith.
+"""
+import ast
+import gc
+import json
+import os
+import sys
+from contextlib import nullcontext
+from pathlib import Path
+
+import pytest
+import torch
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import test_fragments_cpu as tf  # noqa: E402
+import test_progressive_cpu as tp  # noqa: E402
+import toy_segments as toy  # noqa: E402
+
+fq_swap = toy.load_tree_module("swap")
+pg = tp.pg
+fr = tf.fr
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LOADER_INIT = REPO_ROOT / "vllm" / "model_executor" / "model_loader" / "__init__.py"
+
+
+# ------------------------------------------------------- registry wiring
+#
+# `import vllm` needs the compiled extension, so the registry is checked
+# statically.  That is the point: this guards the one line of ours that an
+# upstream rebase of model_loader/__init__.py can silently drop.
+
+
+def _loader_init_ast() -> ast.Module:
+    return ast.parse(LOADER_INIT.read_text())
+
+
+def _literal_formats(tree: ast.Module) -> set[str]:
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Assign)
+            and any(
+                isinstance(t, ast.Name) and t.id == "LoadFormats"
+                for t in node.targets
+            )
+            and isinstance(node.value, ast.Subscript)
+        ):
+            return {ast.literal_eval(e) for e in node.value.slice.elts}
+    raise AssertionError("LoadFormats Literal not found")
+
+
+def _registry(tree: ast.Module) -> dict[str, str]:
+    for node in ast.walk(tree):
+        target = node.targets[0] if isinstance(node, ast.Assign) else getattr(
+            node, "target", None)
+        if (
+            isinstance(node, (ast.Assign, ast.AnnAssign))
+            and isinstance(target, ast.Name)
+            and target.id == "_LOAD_FORMAT_TO_MODEL_LOADER"
+        ):
+            return {
+                ast.literal_eval(k): ast.unparse(v)
+                for k, v in zip(node.value.keys, node.value.values, strict=True)
+            }
+    raise AssertionError("_LOAD_FORMAT_TO_MODEL_LOADER not found")
+
+
+def test_progressive_is_registered_and_declared():
+    tree = _loader_init_ast()
+    formats, registry = _literal_formats(tree), _registry(tree)
+    assert "progressive" in formats, "progressive dropped from LoadFormats"
+    assert registry["progressive"] == "_progressive_loader_cls"
+    # Every declared format must be resolvable, and nothing may be
+    # resolvable that is not declared -- get_model_loader() raises on the
+    # first mismatch and --load-format rejects on the second.
+    assert formats == set(registry)
+
+
+def test_progressive_loader_is_resolved_lazily():
+    """model_loader/__init__.py must not import exl3_fungible at module
+    scope: progressive_loader.py imports base_loader, so an eager import
+    here makes that module unimportable on its own (circular init)."""
+    tree = _loader_init_ast()
+    for node in tree.body:  # module scope only
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            assert "exl3_fungible" not in ast.unparse(node)
+    fn = next(
+        n for n in tree.body
+        if isinstance(n, ast.FunctionDef) and n.name == "_progressive_loader_cls"
+    )
+    assert "exl3_fungible.progressive_loader" in ast.unparse(fn)
+
+
+# ---------------------------------------------- producer: owning tensors
+
+
+def _all_k3_spec(tmp_path):
+    return tp.make_spec(
+        tmp_path, tp.make_policy({"3": [3] * tp.NUM_EXPERTS}))
+
+
+def _expected_expert_bytes(layer=3, k=3):
+    return {
+        name: data
+        for expert in range(tp.NUM_EXPERTS)
+        for name, _dtype, _shape, data in tf._expert_tensors(
+            layer, expert, k, seed=0)
+    }
+
+
+def _raw(t: torch.Tensor) -> bytes:
+    # reshape(-1) first: 0-dim tensors (the mcg scalars) cannot be viewed
+    # as a wider/narrower dtype.
+    return t.contiguous().reshape(-1).view(torch.uint8).numpy().tobytes()
+
+
+def test_progressive_stream_tensors_outlive_the_generator(tmp_path):
+    """The progressive stream is an OWNING producer.
+
+    EXL3 keeps every loaded tensor until process_weights_after_loading,
+    which runs long after the weights iterator is exhausted and dropped.
+    The mmap behind each yielded view must be kept alive by the view
+    itself, not by a local in the generator frame.
+    """
+    spec = _all_k3_spec(tmp_path)
+    resolver = spec.make_resolver(cache_dir=tmp_path / "cache", environ={})
+    it = pg.progressive_weights_iterator(spec, resolver)
+    retained = dict(it)
+
+    # Drop everything the loader owned, exactly as vLLM does once
+    # model.load_weights() returns, and force finalizers to run.
+    del it, resolver, spec
+    gc.collect()
+
+    expected = _expected_expert_bytes()
+    assert expected  # the fixture actually produced expert tensors
+    for name, data in expected.items():
+        assert _raw(retained[name]) == data, name
+
+
+def _fd_count(path: str) -> int:
+    n = 0
+    for fd in os.listdir("/proc/self/fd"):
+        try:
+            n += os.readlink(f"/proc/self/fd/{fd}") == path
+        except OSError:
+            continue
+    return n
+
+
+@pytest.mark.skipif(
+    not os.path.isdir("/proc/self/fd"), reason="needs /proc/self/fd")
+def test_progressive_stream_keeps_one_fd_per_shard(tmp_path):
+    """The mapping outlives the stream; the *file object* must not.
+
+    CPython's mmap dup()s the descriptor, so one fd per mapped shard is
+    unavoidable and is what the retained views cost.  Keeping the original
+    file object open on top of it doubles the descriptor cost of the load
+    window and makes the close depend on refcounting rather than on scope.
+    Measured mid-stream, where the difference is observable.
+    """
+    spec = _all_k3_spec(tmp_path)
+    first_shard = str(spec.shard_files()[0].resolve())
+    resolver = spec.make_resolver(cache_dir=tmp_path / "cache", environ={})
+
+    it = pg.progressive_weights_iterator(spec, resolver)
+    name, tensor = next(it)  # first shard is now open and mapped
+    assert _fd_count(first_shard) == 1, (
+        "the shard file object outlives its mmap during the load window")
+    assert tensor.numel() > 0 and name
+
+    retained = dict(it)
+    retained[name] = tensor
+    del it
+    gc.collect()
+
+    # Every mapping is still readable with no file object holding it open.
+    for expected_name, data in _expected_expert_bytes().items():
+        assert _raw(retained[expected_name]) == data, expected_name
+
+
+def test_fragment_views_outlive_the_resolver(tmp_path):
+    """fragments.materialize() views must survive the resolver going away
+    -- swap.py stages from them and boot retains them until
+    process_weights_after_loading."""
+    seg_dir = tf.make_manifest_dir(tmp_path, layers=(3,), ks=(3, 4))
+    resolver = tf.resolver(seg_dir, tmp_path / "c")
+    pairs = dict(resolver.expert_tensors(3, 0, 3))
+    assert pairs
+
+    del resolver
+    gc.collect()
+
+    expected = {
+        name: data for name, _d, _s, data in tf._expert_tensors(3, 0, 3, seed=0)
+    }
+    for name, tensor in pairs.items():
+        assert _raw(tensor) == expected[name], name
+
+
+# ------------------------------------------ consumer: borrowed payloads
+
+
+class _BorrowedPayloadResolver:
+    """A resolver that serves tensors the InstantTensor ``copy=False`` way.
+
+    Every fragment is laid out into ONE scratch buffer that is recycled
+    (filled with a poison byte) when the next fragment is materialized and
+    on :meth:`close`.  Tensors carry the ``_vllm_instanttensor_borrowed``
+    marker GG PR #281 stamps.  A consumer that copies out before returning
+    is unaffected; a consumer that retains sees poison.
+    """
+
+    POISON = 0xA5
+
+    def __init__(self, inner):
+        self.inner = inner
+        self._buf: torch.Tensor | None = None
+
+    def resolve(self, layer, expert, k):
+        return self.inner.resolve(layer, expert, k)
+
+    def _recycle(self, nbytes: int) -> torch.Tensor:
+        if self._buf is not None:
+            self._buf.fill_(self.POISON)
+        if self._buf is None or self._buf.numel() < nbytes:
+            self._buf = torch.empty(nbytes, dtype=torch.uint8)
+        return self._buf
+
+    def materialize(self, fragment, *, name_filter=None):
+        pairs = self.inner.materialize(fragment, name_filter=name_filter)
+        sizes = [t.numel() * t.element_size() for _, t in pairs]
+        buf = self._recycle(sum(sizes))
+        out, off = [], 0
+        for (name, src), nbytes in zip(pairs, sizes, strict=True):
+            flat = buf[off:off + nbytes]
+            flat.copy_(src.contiguous().reshape(-1).view(torch.uint8))
+            view = flat.view(src.dtype).reshape(src.shape)
+            view._vllm_instanttensor_borrowed = True
+            out.append((name, view))
+            off += nbytes
+        return out
+
+    def close(self):
+        if self._buf is not None:
+            self._buf.fill_(self.POISON)
+
+    @property
+    def stats(self):
+        return self.inner.stats
+
+
+class _RetainingConsumer:
+    """The EXL3 parameter pattern, reduced: keep ``.contiguous()`` at load
+    time, copy only in a later ``process()``."""
+
+    def __init__(self):
+        self.tensors: dict[str, torch.Tensor] = {}
+
+    def load(self, name, loaded_weight):
+        self.tensors[name] = loaded_weight.contiguous()
+
+    def process(self):
+        for name, t in list(self.tensors.items()):
+            self.tensors[name] = t.to(device=t.device, non_blocking=True).contiguous()
+
+
+def test_contiguous_and_same_device_to_are_not_copies():
+    """The mechanism behind every 'incompatible' cell in the matrix.
+
+    ``.contiguous()`` on a contiguous tensor and ``.to(<same device>)``
+    both return *self*, so the retain-now/copy-later pattern never
+    materializes owned storage.  If torch ever changes this, the matrix
+    needs revisiting -- hence the assert.
+    """
+    t = torch.arange(8, dtype=torch.uint8)
+    assert t.contiguous() is t
+    assert t.to(device=t.device, non_blocking=True) is t
+    assert t.to(device=t.device, non_blocking=True).contiguous() is t
+
+
+def test_retaining_consumer_is_corrupted_by_borrowed_payloads(tmp_path):
+    """Control: the hazard is real, not hypothetical."""
+    seg_dir = tf.make_manifest_dir(tmp_path, layers=(3,), ks=(3, 4))
+    inner = tf.resolver(seg_dir, tmp_path / "cache")
+    borrowed = _BorrowedPayloadResolver(inner)
+
+    consumer = _RetainingConsumer()
+    for name, tensor in borrowed.materialize(borrowed.resolve(3, 0, 3)):
+        assert getattr(tensor, "_vllm_instanttensor_borrowed", False)
+        consumer.load(name, tensor)
+    borrowed.close()          # loader context exits
+    consumer.process()        # process_weights_after_loading
+
+    poisoned = [
+        name for name, t in consumer.tensors.items()
+        if set(_raw(t)) == {_BorrowedPayloadResolver.POISON}
+    ]
+    assert len(poisoned) == len(consumer.tensors), (
+        "the fake borrowed loader failed to model buffer recycling")
+
+
+def test_fragment_reader_copies_out_of_borrowed_payloads(tmp_path):
+    """``swap.ResolverFragmentSource`` is a COPYING consumer.
+
+    It is the only FQ code that consumes tensors it did not produce, so it
+    is the only place a borrowed buffer could reach us.  After the payload
+    is recycled the stage must still hold the right bytes, and no stage
+    buffer may alias the payload.
+    """
+    import test_swap_resolver_cpu as tsr
+
+    root = tmp_path / "segments"
+    tsr.make_segments(root)
+
+    truth = fq_swap.ResolverFragmentSource(tf.resolver(root, tmp_path / "c2"))
+    expected = fq_swap.ExpertStage(
+        3, toy.HIDDEN, toy.INTERMEDIATE, pin_memory=False)
+    truth.read_expert(layer=toy.LAYER_ID, k=3, expert=0, rank=0, dest=expected)
+
+    borrowed = _BorrowedPayloadResolver(tf.resolver(root, tmp_path / "cache"))
+    stage = fq_swap.ExpertStage(
+        3, toy.HIDDEN, toy.INTERMEDIATE, pin_memory=False)
+    fq_swap.ResolverFragmentSource(borrowed).read_expert(
+        layer=toy.LAYER_ID, k=3, expert=0, rank=0, dest=stage)
+
+    payload_ptr = borrowed._buf.data_ptr()
+    payload_end = payload_ptr + borrowed._buf.numel()
+    for proj in ("gate", "up", "down"):
+        for comp in ("trellis", "suh", "svh"):
+            t = stage.dest_tensor(proj, comp)
+            assert not (payload_ptr <= t.data_ptr() < payload_end), (
+                f"{proj}.{comp} aliases the borrowed payload")
+
+    borrowed.close()  # recycle/free the payload
+
+    for proj in ("gate", "up", "down"):
+        for comp in ("trellis", "suh", "svh"):
+            assert torch.equal(
+                stage.dest_tensor(proj, comp), expected.dest_tensor(proj, comp)
+            ), f"{proj}.{comp} corrupted by payload recycling"
+    assert stage.mcg == expected.mcg
+
+
+def test_swap_through_borrowed_payloads_is_byte_identical(tmp_path):
+    """End to end: a whole swap staged through recycled payloads must land
+    the same layer state as one staged from local segments."""
+    import test_swap_resolver_cpu as tsr
+
+    root = tmp_path / "segments"
+    ckpt = tsr.make_segments(root)
+
+    local_state = toy.cpu_layer_state(
+        fq_swap, ckpt, tsr.T0_GLOBALS, tsr.T1_GLOBALS)
+    tsr.make_engine(fq_swap.LocalSegmentSource(root), local_state).apply(
+        tsr.PLAN, quiesce=nullcontext())
+
+    borrowed = _BorrowedPayloadResolver(tf.resolver(root, tmp_path / "cache"))
+    state = toy.cpu_layer_state(
+        fq_swap, ckpt, tsr.T0_GLOBALS, tsr.T1_GLOBALS)
+    report = tsr.make_engine(
+        fq_swap.ResolverFragmentSource(borrowed), state).apply(
+            tsr.PLAN, quiesce=nullcontext())
+    borrowed.close()
+
+    assert report.pairs == 1 and report.dropped == ()
+    toy.assert_states_equal(state, local_state)
+
+
+# --------------------------------------------------- progressive loader
+#
+# Gaps the matrix records as "works, with caveats" -- pinned here so they
+# stay honest documentation rather than folklore.
+
+
+def test_progressive_extra_config_rejects_default_loader_keys(tmp_path):
+    """``--model-loader-extra-config`` is loader-specific: the keys the
+    default loader accepts are NOT accepted here, and vice versa."""
+    src = (REPO_ROOT / "vllm" / "model_executor" / "layers" / "quantization"
+           / "exl3_fungible" / "progressive_loader.py").read_text()
+    tree = ast.parse(src)
+    keys = next(
+        ast.literal_eval(n.value)
+        for n in ast.walk(tree)
+        if isinstance(n, ast.Assign)
+        and isinstance(n.targets[0], ast.Name)
+        and n.targets[0].id == "_EXTRA_CONFIG_KEYS"
+    )
+    assert keys == {"manifest_dir", "policy", "dense_source"}
+    assert "enable_multithread_load" not in keys
+    del tmp_path
+
+
+def test_progressive_ignores_checkpoint_weight_name_prefixes():
+    """Documented gap: DefaultModelLoader honours a model's
+    ``checkpoint_weight_name_prefixes`` (GLM/DeepSeek MTP heads set it to
+    read only their own shard tensors); the progressive loader has no such
+    filter, so an MTP draft booted progressive streams the whole dense
+    source.  Perf-only today -- assert it so a future fix updates the doc.
+    """
+    src = (REPO_ROOT / "vllm" / "model_executor" / "layers" / "quantization"
+           / "exl3_fungible" / "progressive_loader.py").read_text()
+    assert "checkpoint_weight_name_prefixes" not in src
+    assert "secondary_weights" not in src
+
+
+def test_progressive_spec_rejects_a_non_directory_dense_source(tmp_path):
+    """Loader variants that take an object-storage URI (runai_streamer,
+    modelexpress) cannot feed progressive: it needs a local directory and
+    says so instead of failing deep inside the stream."""
+    seg_dir = tf.make_manifest_dir(tmp_path, layers=(3,), ks=(3, 4))
+    policy_path = tmp_path / "policy.json"
+    policy_path.write_text(json.dumps(
+        tp.make_policy({"3": [3] * tp.NUM_EXPERTS})))
+    with pytest.raises(ValueError, match="not a directory"):
+        pg.ProgressiveSpec.from_env(
+            None,
+            environ={},
+            overrides={"manifest_dir": str(seg_dir),
+                       "policy": str(policy_path),
+                       "dense_source": "s3://bucket/model"},
+        )

--- a/tests/exl3_fungible/test_loop_cpu.py
+++ b/tests/exl3_fungible/test_loop_cpu.py
@@ -1,0 +1,474 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU tests for the M2 loop state machine (exl3_fungible/loop.py).
+
+Covers the contract the live wiring depends on: interval firing, dummy
+step semantics, dryrun persists-but-does-not-apply, metric increments,
+decision determinism, eps loading, env config, and boot-glue policy
+resolution/rehydration. No GPU, no built vllm required.
+"""
+import json
+
+import numpy as np
+import pytest
+import torch
+
+try:
+    from vllm.model_executor.layers.quantization.exl3_fungible import (
+        loop as FL,
+        policy as P,
+        store as S,
+    )
+    from vllm.model_executor.layers.quantization.exl3_fungible.stats import (
+        FqStatsCollector,
+    )
+    _PACKAGE_IMPORT = True
+except ImportError:  # standalone: load by path with a stub package
+    import importlib.util
+    import sys
+    import types
+    from pathlib import Path as _P
+
+    _dir = (_P(__file__).resolve().parents[2] / "vllm" / "model_executor"
+            / "layers" / "quantization" / "exl3_fungible")
+    _pkg_name = "vllm.model_executor.layers.quantization.exl3_fungible"
+
+    def _load(name, path):
+        spec = importlib.util.spec_from_file_location(name, path)
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[name] = mod
+        spec.loader.exec_module(mod)
+        return mod
+
+    _pkg = types.ModuleType(_pkg_name)
+    sys.modules[_pkg_name] = _pkg
+    for _sub in ("policy", "stats", "store", "decision_log", "loop"):
+        _mod = _load(f"{_pkg_name}.{_sub}", _dir / f"{_sub}.py")
+        setattr(_pkg, _sub, _mod)
+    P, S, FL = _pkg.policy, _pkg.store, _pkg.loop
+    FqStatsCollector = _pkg.stats.FqStatsCollector
+    _PACKAGE_IMPORT = False
+
+prometheus_client = pytest.importorskip("prometheus_client")
+
+E = 8               # experts per layer
+LAYERS = [3, 4]     # model layer ids (policy keys; collector bind ids)
+
+
+@pytest.fixture(autouse=True)
+def clean_fq_env(monkeypatch):
+    for env in (FL.FQ_INTERVAL_ENV, FL.FQ_APPLY_MODE_ENV,
+                FL.FQ_ARTIFACT_DIR_ENV, FL.FQ_POLICY_ENV, FL.FQ_EPS_ROOT_ENV,
+                FL.FQ_CACHE_ROOT_ENV, FL.FQ_MAX_SWAPS_LAYER_ENV,
+                FL.FQ_MAX_SWAPS_TOTAL_ENV, FL.FQ_DWELL_ENV,
+                FL.FQ_HYSTERESIS_ENV, FL.FQ_JACCARD_FLOOR_ENV):
+        monkeypatch.delenv(env, raising=False)
+    return monkeypatch
+
+
+class FakeRouter:
+    def __init__(self):
+        self.capture_fn = None
+        self.global_num_experts = E
+
+    def set_capture_fn(self, fn):
+        self.capture_fn = fn
+
+
+def make_collector(window_stride=2):
+    c = FqStatsCollector(E, window_len=8, window_stride=window_stride,
+                         decay=0.9, device="cpu")
+    routers = {}
+    for lid in LAYERS:
+        routers[lid] = FakeRouter()
+        c.bind_router(lid, routers[lid])
+    return c, routers
+
+
+def boot_doc():
+    bits = [4, 4, 3, 3, 3, 3, 3, 3]  # experts 0,1 at K4
+    return {
+        "schema": "fq-policy/2",
+        "manifest": "m" * 64,
+        "budget": {"mode": "fixed_cardinality",
+                   "n_k4_per_layer": {str(lid): 2 for lid in LAYERS}},
+        "bits_per_expert": {str(lid): list(bits) for lid in LAYERS},
+        "pinned": {},
+    }
+
+
+def eps_hot4():
+    """Expert 4 has a 10x error gap: the clear upgrade candidate."""
+    e3 = np.full((2, E), 0.05)
+    e3[:, 4] = 0.5
+    return {P.K3: e3, P.K4: np.zeros((2, E))}
+
+
+def route(routers, ids):
+    t = torch.tensor(ids, dtype=torch.int64)
+    for r in routers.values():
+        r.capture_fn(t)
+
+
+def make_state(tmp_path=None, *, interval=4, metrics=None, eps=None,
+               **cfg_kw):
+    cfg_kw.setdefault("dwell_steps", 0)
+    cfg_kw.setdefault("jaccard_floor", 0.0)
+    cfg = FL.FqLoopConfig(interval_steps=interval, **cfg_kw)
+    collector, routers = make_collector()
+    store = None
+    if tmp_path is not None:
+        store = S.PolicyStore(tmp_path, "m" * 64)
+        store.commit(boot_doc(), num_experts=E)
+    state = FL.FungibleQuantState(
+        collector, boot_doc(), config=cfg, eps=eps or eps_hot4(),
+        store=store, metrics=metrics)
+    return state, routers
+
+
+def drive_hot_interval(state, routers, steps=None):
+    """Route heavy traffic to expert 4 for one interval's worth of steps."""
+    for _ in range(steps or state.cfg.interval_steps):
+        route(routers, [[4, 4], [4, 1], [4, 0]])
+        state.step()
+
+
+# ------------------------------------------------------------ interval firing
+
+def test_interval_fires_on_schedule(monkeypatch):
+    state, routers = make_state(interval=4)
+    fired = []
+    monkeypatch.setattr(state, "run_interval", lambda: fired.append(state._step))
+    for _ in range(11):
+        route(routers, [[0, 1]])
+        state.step()
+    assert fired == [4, 8]
+
+
+def test_interval_exception_does_not_propagate(monkeypatch):
+    state, routers = make_state(interval=2)
+    monkeypatch.setattr(state, "run_interval",
+                        lambda: (_ for _ in ()).throw(RuntimeError("boom")))
+    for _ in range(4):
+        route(routers, [[0]])
+        state.step()  # must not raise
+
+
+def test_dummy_steps_advance_interval_but_not_dwell():
+    state, _ = make_state(interval=4)
+    fired = []
+    state.run_interval = lambda: fired.append(state._step)
+    for _ in range(4):
+        state.step(is_dummy=True)
+    # Dummy steps keep rank lockstep: the interval counter advances and
+    # the boundary fires even on a dummy step (EPLB semantics)...
+    assert fired == [4]
+    # ...but dwell time is real-step based and must not have advanced.
+    assert state._real_steps == 0
+    # And the collector discarded the (nonexistent) dummy stats.
+    assert state.collector._windows_rolled == 0
+
+
+# --------------------------------------------------- dryrun persist semantics
+
+def test_dryrun_decides_persists_but_does_not_apply(tmp_path):
+    state, routers = make_state(tmp_path, interval=4)
+    boot_tier = state.tier_of.copy()
+    drive_hot_interval(state, routers)
+
+    # The hot expert was proposed into K4 in every layer...
+    decisions = sorted((state.store.root / "decisions").glob("*.json"))
+    assert len(decisions) == 1
+    rec = json.loads(decisions[0].read_text())
+    assert rec["apply_mode"] == "dryrun" and rec["applied"] is False
+    assert rec["totals"]["executed"] == 2
+    assert all(sw["expert_in"] == 4 for sw in rec["swaps"])
+    assert rec["layer_ids"] == LAYERS
+
+    # ...the proposal landed in history WITHOUT touching current.json...
+    proposals = sorted((state.store.root / "history").glob("*-proposed.json"))
+    assert len(proposals) == 1
+    proposed = json.loads(proposals[0].read_text())
+    assert proposed["bits_per_expert"]["3"][4] == 4
+    assert proposed["provenance"]["proposed_by"] == "fq-loop/dryrun"
+    current = json.loads((state.store.root / "current.json").read_text())
+    assert current["bits_per_expert"] == boot_doc()["bits_per_expert"]
+
+    # ...and the running membership was not modified.
+    assert (state.tier_of == boot_tier).all()
+
+
+def test_no_swap_interval_writes_decision_but_no_proposal(tmp_path):
+    # Uniform eps + uniform traffic: no score separation, desired == cur.
+    state, routers = make_state(tmp_path, interval=4,
+                                eps=FL.uniform_eps_stub(2, E))
+    for _ in range(4):
+        route(routers, [[0, 1, 2, 3, 4, 5, 6, 7]])
+        state.step()
+    rec_files = sorted((state.store.root / "decisions").glob("*.json"))
+    assert len(rec_files) == 1
+    assert json.loads(rec_files[0].read_text())["totals"]["executed"] == 0
+    assert not list((state.store.root / "history").glob("*-proposed.json"))
+
+
+def test_jaccard_guard_holds_swaps(tmp_path):
+    state, routers = make_state(tmp_path, interval=4, jaccard_floor=0.99)
+    # Seed a previous desired set that the hot-4 interval will contradict.
+    prev = np.zeros((2, E), dtype=bool)
+    prev[:, 6] = prev[:, 7] = True
+    state._prev_desired = prev
+    drive_hot_interval(state, routers)
+    rec = json.loads(next(
+        (state.store.root / "decisions").glob("*.json")).read_text())
+    assert rec["jaccard_held"] is True
+    assert rec["jaccard"] < 0.99
+    assert rec["totals"]["executed"] == 0
+    assert not list((state.store.root / "history").glob("*-proposed.json"))
+
+
+# ------------------------------------------------------------------- metrics
+
+def sample(registry, name, labels=None):
+    v = registry.get_sample_value(name, labels or {})
+    return 0.0 if v is None else v
+
+
+def test_metrics_increment(tmp_path):
+    registry = prometheus_client.CollectorRegistry()
+    metrics = FL.FqMetrics(registry=registry)
+    state, routers = make_state(tmp_path, interval=4, metrics=metrics)
+
+    # Boot: occupancy exported, counters materialized at 0.
+    assert sample(registry, "fq_tier_occupancy",
+                  {"layer": "3", "tier": "k4"}) == 2.0
+    assert sample(registry, "fq_tier_occupancy",
+                  {"layer": "3", "tier": "k3"}) == 6.0
+    assert sample(registry, "fq_swaps_total", {"layer": "3"}) == 0.0
+    assert sample(registry, "fq_rollbacks_total") == 0.0
+
+    drive_hot_interval(state, routers)
+    assert sample(registry, "fq_swaps_total", {"layer": "3"}) == 1.0
+    assert sample(registry, "fq_swaps_total", {"layer": "4"}) == 1.0
+    assert sample(registry, "fq_policy_age_steps") == 4.0
+
+    drive_hot_interval(state, routers)
+    assert sample(registry, "fq_swaps_total", {"layer": "3"}) == 2.0
+    assert sample(registry, "fq_jaccard") == 1.0  # same desired set again
+    # Dryrun: occupancy tracks the RUNNING policy, which never moved.
+    assert sample(registry, "fq_tier_occupancy",
+                  {"layer": "3", "tier": "k4"}) == 2.0
+
+
+def test_non_lead_rank_does_not_persist_or_export(tmp_path):
+    registry = prometheus_client.CollectorRegistry()
+    metrics = FL.FqMetrics(registry=registry)
+    cfg = FL.FqLoopConfig(interval_steps=4, dwell_steps=0, jaccard_floor=0.0)
+    collector, routers = make_collector()
+    store = S.PolicyStore(tmp_path, "m" * 64)
+    state = FL.FungibleQuantState(
+        collector, boot_doc(), config=cfg, eps=eps_hot4(),
+        store=store, metrics=metrics, rank=2, is_lead=False)
+    drive_hot_interval(state, routers)
+    assert not (store.root / "decisions").exists()
+    assert sample(registry, "fq_swaps_total", {"layer": "3"}) == 0.0
+
+
+# --------------------------------------------------------------- determinism
+
+def test_same_inputs_same_swaps_and_sha(tmp_path):
+    records = []
+    for i in range(2):
+        state, routers = make_state(tmp_path / str(i), interval=4)
+        drive_hot_interval(state, routers)
+        rec = json.loads(next(
+            (state.store.root / "decisions").glob("*.json")).read_text())
+        records.append(rec)
+    assert records[0]["swaps"] == records[1]["swaps"]
+    assert records[0]["decision_sha"] == records[1]["decision_sha"]
+    assert records[0]["policy_sha_after"] == records[1]["policy_sha_after"]
+
+
+def test_decision_sha_is_order_and_content_sensitive():
+    assert (FL.FungibleQuantState.decision_sha([(0, 1, 4)])
+            != FL.FungibleQuantState.decision_sha([(0, 2, 4)]))
+    assert (FL.FungibleQuantState.decision_sha([(0, 1, 4), (1, 1, 4)])
+            != FL.FungibleQuantState.decision_sha([(1, 1, 4), (0, 1, 4)]))
+
+
+# ---------------------------------------------------------------- eps source
+
+def write_done_jsons(root, layers=LAYERS, ks=(3, 4), num_experts=E):
+    for k in ks:
+        d = root / f"work-k{k}-tr3"
+        d.mkdir(parents=True, exist_ok=True)
+        for layer in layers:
+            # Same per-layer base error, scaled down 1/k: K4 < K3 always.
+            rng = np.random.default_rng(layer)
+            mse = (rng.uniform(0.01, 0.05, num_experts) / k).tolist()
+            (d / f"layer-{layer:03d}.done.json").write_text(
+                json.dumps({"layer": layer, "expert_rel_rt_mse": mse}))
+
+
+def test_eps_loader_reads_done_jsons(tmp_path):
+    write_done_jsons(tmp_path)
+    eps = FL.load_eps_from_work_root(tmp_path, LAYERS, E)
+    assert set(eps) == {3, 4}
+    assert eps[3].shape == (2, E) and eps[4].shape == (2, E)
+    # K4 must be strictly better (smaller eps) than K3 in this fixture.
+    assert (eps[3] > eps[4]).all()
+    # Row order == requested layer order.
+    d3 = json.loads(
+        (tmp_path / "work-k3-tr3" / "layer-003.done.json").read_text())
+    assert eps[3][0].tolist() == pytest.approx(d3["expert_rel_rt_mse"])
+
+
+def test_eps_loader_falls_back_on_missing(tmp_path):
+    write_done_jsons(tmp_path, layers=[3])  # layer 4 missing
+    assert FL.load_eps_from_work_root(tmp_path, LAYERS, E) is None
+    stub = FL.uniform_eps_stub(2, E)
+    assert (stub[P.K3] == 1.0).all() and (stub[P.K4] == 0.0).all()
+
+
+# -------------------------------------------------------------------- config
+
+def test_config_defaults_match_spec():
+    cfg = FL.FqLoopConfig.from_env()
+    assert cfg.interval_steps == 3000
+    assert cfg.apply_mode == "dryrun"
+    assert cfg.dwell_steps == 6000          # 2 x interval
+    assert cfg.hysteresis == 1.25
+    assert cfg.max_swaps_per_layer == 2
+    assert cfg.max_swaps_total == 64
+    assert cfg.jaccard_floor == 0.95
+
+
+def test_config_env_overrides(monkeypatch):
+    monkeypatch.setenv(FL.FQ_INTERVAL_ENV, "200")
+    monkeypatch.setenv(FL.FQ_APPLY_MODE_ENV, "reload")
+    monkeypatch.setenv(FL.FQ_HYSTERESIS_ENV, "1.5")
+    monkeypatch.setenv(FL.FQ_MAX_SWAPS_LAYER_ENV, "1")
+    cfg = FL.FqLoopConfig.from_env()
+    assert cfg.interval_steps == 200
+    assert cfg.apply_mode == "reload"
+    assert cfg.dwell_steps == 400           # follows the interval override
+    assert cfg.hysteresis == 1.5
+    assert cfg.max_swaps_per_layer == 1
+    with pytest.raises(ValueError):
+        FL.FqLoopConfig(apply_mode="yolo")
+
+
+def test_reload_mode_without_apply_fn_records_only(tmp_path):
+    state, routers = make_state(tmp_path, interval=4, apply_mode="reload")
+    boot_tier = state.tier_of.copy()
+    drive_hot_interval(state, routers)
+    rec = json.loads(next(
+        (state.store.root / "decisions").glob("*.json")).read_text())
+    assert rec["apply_mode"] == "reload" and rec["applied"] is False
+    assert (state.tier_of == boot_tier).all()
+
+
+def test_apply_fn_path_commits_and_resets_dwell(tmp_path):
+    applied = []
+    state, routers = make_state(tmp_path, interval=4, apply_mode="reload")
+    state.apply_fn = lambda doc, swaps: applied.append((doc, swaps)) or True
+    drive_hot_interval(state, routers)
+    assert len(applied) == 1
+    # Membership moved, dwell reset for swapped experts, store committed.
+    assert state.tier_of[0, 4] == P.K4
+    assert state._entered_step[0, 4] == state._real_steps
+    assert state._entered_step[0, 2] == 0
+    cur = json.loads((state.store.root / "current.json").read_text())
+    assert cur["bits_per_expert"]["3"][4] == 4
+    assert state.policy_sha == S.policy_hash(cur)
+
+
+# ----------------------------------------------------------------- boot glue
+
+def test_build_from_env_policy_path_and_rehydration(tmp_path, monkeypatch):
+    policy_path = tmp_path / "boot-policy.json"
+    policy_path.write_text(json.dumps(boot_doc()))
+    monkeypatch.setenv(FL.FQ_POLICY_ENV, str(policy_path))
+    monkeypatch.setenv(FL.FQ_CACHE_ROOT_ENV, str(tmp_path / "cache"))
+    monkeypatch.setenv(FL.FQ_INTERVAL_ENV, "4")
+
+    collector, _ = make_collector()
+    state = FL.build_from_env(collector)
+    assert state is not None
+    assert state.layers == LAYERS
+    assert (state.store.root / "current.json").exists()
+    boot_sha = state.policy_sha
+
+    # Second boot rehydrates the committed policy (D8), same identity.
+    collector2, _ = make_collector()
+    state2 = FL.build_from_env(collector2)
+    assert state2.policy_sha == boot_sha
+    # Non-lead ranks compute but never persist.
+    state3 = FL.build_from_env(make_collector()[0], rank=1)
+    assert state3.store is None and state3.is_lead is False
+
+
+def test_build_from_env_synthesizes_from_artifact_dir(tmp_path, monkeypatch):
+    art = tmp_path / "ckpt"
+    art.mkdir()
+    bitmap = {str(lid): {"bits_per_expert": [4, 4, 3, 3, 3, 3, 3, 3]}
+              for lid in LAYERS}
+    (art / "tier_bitmap.json").write_text(json.dumps(bitmap))
+    (art / "MANIFEST.sha256").write_text("deadbeef  model.safetensors\n")
+    monkeypatch.setenv(FL.FQ_ARTIFACT_DIR_ENV, str(art))
+    monkeypatch.setenv(FL.FQ_CACHE_ROOT_ENV, str(tmp_path / "cache"))
+
+    state = FL.build_from_env(make_collector()[0])
+    assert state is not None
+    assert state.n_k4.tolist() == [2, 2]
+    assert state.policy_doc["schema"] == "fq-policy/2"
+
+
+def test_build_from_env_without_policy_source_returns_none(monkeypatch,
+                                                           tmp_path):
+    monkeypatch.setenv(FL.FQ_CACHE_ROOT_ENV, str(tmp_path))
+    assert FL.build_from_env(make_collector()[0]) is None
+
+
+@pytest.mark.skipif(not _PACKAGE_IMPORT,
+                    reason="integration seam needs the real package")
+def test_maybe_init_fq_state_degrades_to_collector(monkeypatch, tmp_path):
+    from vllm.model_executor.layers.quantization.exl3_fungible import (
+        integration as fq_integration,
+    )
+
+    class FakeMoERunner:
+        def __init__(self, layer_id, router):
+            self.layer_id, self.router = layer_id, router
+
+    class FakeModel:
+        def __init__(self, mods):
+            self._m = mods
+
+        def modules(self):
+            return iter(self._m)
+
+    class FakeRunner:
+        def __init__(self, mods):
+            self.model = FakeModel(mods)
+            self.device = "cpu"
+
+    monkeypatch.setattr(fq_integration, "_moe_module_types",
+                        lambda: (FakeMoERunner, FakeRouter))
+    monkeypatch.setattr(fq_integration, "_collector_cls",
+                        lambda: FqStatsCollector)
+    monkeypatch.setenv(fq_integration.FQ_ENABLE_ENV, "1")
+    monkeypatch.setenv(FL.FQ_CACHE_ROOT_ENV, str(tmp_path))
+    runner = FakeRunner([FakeMoERunner(lid, FakeRouter()) for lid in LAYERS])
+
+    # No policy source: falls back to the bare collector (M1-only).
+    got = fq_integration.maybe_init_fq_state(runner)
+    assert isinstance(got, FqStatsCollector)
+
+    # With a policy source: the full loop state.
+    policy_path = tmp_path / "p.json"
+    policy_path.write_text(json.dumps(boot_doc()))
+    monkeypatch.setenv(FL.FQ_POLICY_ENV, str(policy_path))
+    runner2 = FakeRunner([FakeMoERunner(lid, FakeRouter()) for lid in LAYERS])
+    got2 = fq_integration.maybe_init_fq_state(runner2)
+    assert isinstance(got2, FL.FungibleQuantState)
+    got2.step(is_dummy=True)  # runner call contract holds

--- a/tests/exl3_fungible/test_loop_cpu.py
+++ b/tests/exl3_fungible/test_loop_cpu.py
@@ -609,7 +609,7 @@ def test_jaccard_of_an_all_empty_membership_is_not_zero():
     assert FL.FungibleQuantState._jaccard(empty, empty) == 1.0
 
 
-def test_apply_fn_may_report_what_it_actually_installed():
+def test_apply_fn_may_report_what_it_actually_installed(tmp_path):
     """An async backend can install a batch staged an interval earlier.
 
     Trusting `proposed_tier` in that case makes tier_of describe a device
@@ -620,18 +620,40 @@ def test_apply_fn_may_report_what_it_actually_installed():
                     e_in resident K3
 
     Observed live. So a list return is adopted as the incumbent instead.
+
+    This test DRIVES THE LOOP. Its first version recomputed the adoption
+    arithmetic inline and asserted on its own copy, so it stayed green while
+    the real branch raised NameError on the very first install — the swaps
+    landed on the device, the loop died before recording them, and the next
+    interval hit exactly the error quoted above. A test that reimplements the
+    code under test cannot fail with it.
     """
-    import numpy as np
-    tier = np.array([[FL.P.K4, FL.P.K3, FL.P.K3, FL.P.K4]])
-    installed = [(0, 0, 1)]          # e0 K4->K3, e1 K3->K4
-    applied = tier.copy()
-    for row, e_out, e_in in installed:
-        applied[row, e_out] = FL.P.K3
-        applied[row, e_in] = FL.P.K4
-    assert list(applied[0]) == [FL.P.K3, FL.P.K4, FL.P.K3, FL.P.K4]
-    # and the cardinality the device holds is unchanged, which is what makes
-    # adopting it safe rather than a second source of drift.
-    assert (applied == FL.P.K4).sum() == (tier == FL.P.K4).sum()
+    state, routers = make_state(tmp_path, interval=4, apply_mode="reload")
+    seen = {}
+
+    def apply_fn(doc, swaps):
+        # Report a DIFFERENT single swap than proposed, in row coordinates —
+        # the staleness case the adoption path exists for.
+        seen["proposed"] = list(swaps)
+        return [(0, 1, 5)]           # row 0: e1 K4->K3, e5 K3->K4
+
+    state.apply_fn = apply_fn
+    before = state.tier_of.copy()
+    drive_hot_interval(state, routers)
+
+    assert seen["proposed"], "apply_fn was never called"
+    # tier_of reflects what was INSTALLED, not what was proposed.
+    assert state.tier_of[0, 1] == P.K3
+    assert state.tier_of[0, 5] == P.K4
+    # ...and NOT what was proposed (the loop proposed promoting e4).
+    assert state.tier_of[0, 4] == P.K3
+    # Fixed cardinality (D1) survives adoption.
+    assert (state.tier_of == P.K4).sum() == (before == P.K4).sum()
+    # The committed document agrees with the adopted membership, so a restart
+    # rehydrates the device state rather than the proposal.
+    cur = json.loads((state.store.root / "current.json").read_text())
+    assert cur["bits_per_expert"]["3"][5] == 4
+    assert cur["bits_per_expert"]["3"][1] == 3
 
 
 def test_a_bare_true_still_adopts_the_proposal():

--- a/tests/exl3_fungible/test_loop_cpu.py
+++ b/tests/exl3_fungible/test_loop_cpu.py
@@ -42,7 +42,10 @@ except ImportError:  # standalone: load by path with a stub package
 
     _pkg = types.ModuleType(_pkg_name)
     sys.modules[_pkg_name] = _pkg
-    for _sub in ("policy", "stats", "store", "decision_log", "loop"):
+    # occupancy_table must precede loop: loop imports it, and a stub package
+    # missing the attribute falls through to the real vllm import chain.
+    for _sub in ("policy", "stats", "store", "decision_log",
+                 "occupancy_table", "loop"):
         _mod = _load(f"{_pkg_name}.{_sub}", _dir / f"{_sub}.py")
         setattr(_pkg, _sub, _mod)
     P, S, FL = _pkg.policy, _pkg.store, _pkg.loop
@@ -472,3 +475,95 @@ def test_maybe_init_fq_state_degrades_to_collector(monkeypatch, tmp_path):
     got2 = fq_integration.maybe_init_fq_state(runner2)
     assert isinstance(got2, FL.FungibleQuantState)
     got2.step(is_dummy=True)  # runner call contract holds
+
+
+# ------------------------------------------------------- composition table
+class _CaptureLog:
+    """Capture loop.py's own logger.
+
+    vLLM configures its loggers with propagate=False, so pytest's caplog
+    (which listens on the root logger) sees nothing — the table was being
+    emitted correctly while the assertion read an empty string.
+    """
+
+    def __init__(self):
+        self.lines = []
+
+    def __enter__(self):
+        import logging
+
+        class _H(logging.Handler):
+            def __init__(self, sink):
+                super().__init__()
+                self.sink = sink
+
+            def emit(self, record):
+                self.sink.append(record.getMessage())
+
+        self._h = _H(self.lines)
+        self._logger = FL.logger
+        self._prev = self._logger.level
+        self._logger.addHandler(self._h)
+        self._logger.setLevel("INFO")
+        return self
+
+    def __exit__(self, *exc):
+        self._logger.removeHandler(self._h)
+        self._logger.setLevel(self._prev)
+        return False
+
+    @property
+    def text(self):
+        return "\n".join(self.lines)
+
+
+def test_composition_table_printed_at_startup(tmp_path):
+    """The boot shape must be on record, in full, before anything moves."""
+    with _CaptureLog() as cap:
+        make_state(tmp_path)
+    assert "expert composition at startup" in cap.text
+    assert "mean bits/expert" in cap.text
+    for layer in LAYERS:
+        assert any(line.strip().startswith(str(layer))
+                   for line in cap.text.splitlines()), f"layer {layer} missing"
+
+
+def test_composition_table_periodic_is_diff_only(tmp_path, monkeypatch):
+    monkeypatch.setenv("VLLM_FQ_TABLE_EVERY_INTERVALS", "1")
+    state, routers = make_state(tmp_path, interval=4)
+    with _CaptureLog() as cap:
+        drive_hot_interval(state, routers)
+    assert "expert composition @ interval" in cap.text
+    # dryrun proposes without mutating membership, so the table must report
+    # "nothing moved" explicitly rather than printing an empty table that
+    # would read as broken telemetry
+    assert ("no tier changes" in cap.text
+            or "unchanged layers omitted" in cap.text)
+
+
+def test_composition_table_can_be_disabled(tmp_path, monkeypatch):
+    monkeypatch.setenv("VLLM_FQ_TABLE_EVERY_INTERVALS", "0")
+    state, routers = make_state(tmp_path, interval=4)
+    with _CaptureLog() as cap:
+        drive_hot_interval(state, routers)
+    assert "expert composition @ interval" not in cap.text
+
+
+def test_composition_table_reflects_a_real_membership_change(tmp_path):
+    """A mutated membership must show up as a signed per-tier delta."""
+    state, _ = make_state(tmp_path)
+    state.log_composition(title="before", diff_only=False)
+    state.tier_of[0][5] = P.K4          # promote expert 5 in the first layer
+    with _CaptureLog() as cap:
+        state.log_composition(title="after", diff_only=True)
+    assert "-1 K3" in cap.text and "+1 K4" in cap.text
+
+
+def test_composition_table_failure_never_kills_the_serve(tmp_path,
+                                                         monkeypatch):
+    """Telemetry is not allowed to take down inference."""
+    state, _ = make_state(tmp_path)
+    monkeypatch.setattr(FL.OT, "render",
+                        lambda *a, **k: (_ for _ in ()).throw(
+                            RuntimeError("boom")))
+    state.log_composition(title="x", diff_only=False)  # must not raise

--- a/tests/exl3_fungible/test_loop_cpu.py
+++ b/tests/exl3_fungible/test_loop_cpu.py
@@ -149,6 +149,31 @@ def test_interval_fires_on_schedule(monkeypatch):
     assert fired == [4, 8]
 
 
+def test_k2_k4_collects_but_skips_k3_k4_auto_policy():
+    doc = boot_doc()
+    doc["bits_per_expert"] = {
+        key: [4, 4, 2, 2, 2, 2, 2, 2]
+        for key in doc["bits_per_expert"]
+    }
+    collector, routers = make_collector()
+    state = FL.FungibleQuantState(
+        collector, doc,
+        config=FL.FqLoopConfig(
+            interval_steps=1, dwell_steps=0, jaccard_floor=0.0),
+        eps=eps_hot4())
+
+    for _ in range(2):
+        route(routers, [[4, 4], [4, 1]])
+        state.step()
+    assert state._real_steps == 2
+    assert state._intervals_run == 0
+    assert state._auto_decisions_supported is False
+    for layer in LAYERS:
+        count, _ = collector.decayed(layer)
+        assert count[4].item() == 6
+        assert count[1].item() == 2
+
+
 def test_interval_exception_does_not_propagate(monkeypatch):
     state, routers = make_state(interval=2)
     monkeypatch.setattr(state, "run_interval",
@@ -412,12 +437,16 @@ def test_build_from_env_policy_path_and_rehydration(tmp_path, monkeypatch):
     assert state is not None
     assert state.layers == LAYERS
     assert (state.store.root / "current.json").exists()
-    boot_sha = state.policy_sha
+    committed = json.loads(json.dumps(boot_doc()))
+    committed["bits_per_expert"]["3"] = [2, 4, 2, 2, 4, 2, 2, 2]
+    state.store.commit(committed, num_experts=collector.num_experts)
 
-    # Second boot rehydrates the committed policy (D8), same identity.
+    # Second boot rehydrates the committed K2/K4 policy, not the boot file.
     collector2, _ = make_collector()
     state2 = FL.build_from_env(collector2)
-    assert state2.policy_sha == boot_sha
+    assert state2.policy_sha == S.policy_hash(committed)
+    assert state2.tier_of[0].tolist() == [2, 4, 2, 2, 4, 2, 2, 2]
+    assert state2.policy_doc == committed
     # Non-lead ranks compute but never persist.
     state3 = FL.build_from_env(make_collector()[0], rank=1)
     assert state3.store is None and state3.is_lead is False

--- a/tests/exl3_fungible/test_loop_cpu.py
+++ b/tests/exl3_fungible/test_loop_cpu.py
@@ -607,3 +607,33 @@ def test_jaccard_of_an_all_empty_membership_is_not_zero():
     import numpy as np
     empty = np.zeros((4, 8), dtype=bool)
     assert FL.FungibleQuantState._jaccard(empty, empty) == 1.0
+
+
+def test_apply_fn_may_report_what_it_actually_installed():
+    """An async backend can install a batch staged an interval earlier.
+
+    Trusting `proposed_tier` in that case makes tier_of describe a device
+    state that never existed. The next interval then proposes a move off an
+    expert that is not resident and stage() rejects it outright:
+
+        ValueError: invalid swap (5, 82, 3): e_out must be resident K4,
+                    e_in resident K3
+
+    Observed live. So a list return is adopted as the incumbent instead.
+    """
+    import numpy as np
+    tier = np.array([[FL.P.K4, FL.P.K3, FL.P.K3, FL.P.K4]])
+    installed = [(0, 0, 1)]          # e0 K4->K3, e1 K3->K4
+    applied = tier.copy()
+    for row, e_out, e_in in installed:
+        applied[row, e_out] = FL.P.K3
+        applied[row, e_in] = FL.P.K4
+    assert list(applied[0]) == [FL.P.K3, FL.P.K4, FL.P.K3, FL.P.K4]
+    # and the cardinality the device holds is unchanged, which is what makes
+    # adopting it safe rather than a second source of drift.
+    assert (applied == FL.P.K4).sum() == (tier == FL.P.K4).sum()
+
+
+def test_a_bare_true_still_adopts_the_proposal():
+    """Back-compat: the M3 reload path returns a bool and must keep working."""
+    assert bool([(0, 1, 2)]) is True and bool(True) is True

--- a/tests/exl3_fungible/test_loop_cpu.py
+++ b/tests/exl3_fungible/test_loop_cpu.py
@@ -8,6 +8,7 @@ decision determinism, eps loading, env config, and boot-glue policy
 resolution/rehydration. No GPU, no built vllm required.
 """
 import json
+import logging
 
 import numpy as np
 import pytest
@@ -659,3 +660,66 @@ def test_apply_fn_may_report_what_it_actually_installed(tmp_path):
 def test_a_bare_true_still_adopts_the_proposal():
     """Back-compat: the M3 reload path returns a bool and must keep working."""
     assert bool([(0, 1, 2)]) is True and bool(True) is True
+
+
+class _Capture(logging.Handler):
+    """vLLM loggers set propagate=False, so caplog never sees them."""
+
+    def __init__(self):
+        super().__init__(level=logging.INFO)
+        self.lines: list[str] = []
+
+    def emit(self, record):
+        self.lines.append(record.getMessage())
+
+    def __enter__(self):
+        FL.logger.addHandler(self)
+        self._prev = FL.logger.level
+        FL.logger.setLevel(logging.INFO)
+        return self
+
+    def __exit__(self, *exc):
+        FL.logger.removeHandler(self)
+        FL.logger.setLevel(self._prev)
+        return False
+
+    @property
+    def text(self):
+        return "\n".join(self.lines)
+
+
+def test_composition_reports_membership_not_just_counts(tmp_path):
+    """A paired swap must be visible in the log.
+
+    The counts table cannot show one: D1 fixed cardinality makes every
+    per-tier count invariant under a K3<->K4 exchange, so the table reported
+    "no tier changes across 75 layers" at every interval of a live run in
+    which 256 experts had moved — verified independently by diffing the
+    committed policy against the boot policy file. An instrument that goes
+    silent precisely when the thing it watches happens is worse than none.
+    """
+    state, routers = make_state(tmp_path, interval=4, apply_mode="reload")
+    state.apply_fn = lambda doc, swaps: True
+    before = np.array(state.tier_of, copy=True)
+    state.log_composition(title="before", diff_only=False)  # seeds the baseline
+
+    drive_hot_interval(state, routers)
+    with _Capture() as cap:
+        state.log_composition(title="after", diff_only=False)
+
+    n_moved = int((before != state.tier_of).sum())
+    assert n_moved, "fixture did not actually move an expert"
+    assert "membership:" in cap.text, f"no membership line:\n{cap.text}"
+    assert f"{n_moved} expert(s) moved" in cap.text, (
+        f"expected {n_moved} moved, log said:\n{cap.text}")
+    # Cardinality is unchanged — which is exactly why counts alone are blind.
+    assert (state.tier_of == P.K4).sum() == (before == P.K4).sum()
+
+
+def test_composition_says_unchanged_when_nothing_moved(tmp_path):
+    """The quiet case must be stated, not inferred from silence."""
+    state, _ = make_state(tmp_path, interval=4, apply_mode="reload")
+    state.log_composition(title="first", diff_only=False)
+    with _Capture() as cap:
+        state.log_composition(title="second", diff_only=False)
+    assert "membership: unchanged" in cap.text, cap.text

--- a/tests/exl3_fungible/test_loop_cpu.py
+++ b/tests/exl3_fungible/test_loop_cpu.py
@@ -246,16 +246,28 @@ def test_metrics_increment(tmp_path):
                   {"layer": "3", "tier": "k4"}) == 2.0
     assert sample(registry, "fq_tier_occupancy",
                   {"layer": "3", "tier": "k3"}) == 6.0
-    assert sample(registry, "fq_swaps_total", {"layer": "3"}) == 0.0
+    assert sample(registry, "fq_swap_proposals_total", {"layer": "3"}) == 0.0
+    assert sample(registry, "fq_swaps_applied_total", {"layer": "3"}) == 0.0
     assert sample(registry, "fq_rollbacks_total") == 0.0
+    # No apply backend is bound in dryrun, and the gauge must say so: an
+    # operator seeing proposals climb needs one glance to know whether any of
+    # them can become a change.
+    assert sample(registry, "fq_apply_bound") == 0.0
 
     drive_hot_interval(state, routers)
-    assert sample(registry, "fq_swaps_total", {"layer": "3"}) == 1.0
-    assert sample(registry, "fq_swaps_total", {"layer": "4"}) == 1.0
+    assert sample(registry, "fq_swap_proposals_total", {"layer": "3"}) == 1.0
+    assert sample(registry, "fq_swap_proposals_total", {"layer": "4"}) == 1.0
     assert sample(registry, "fq_policy_age_steps") == 4.0
+    # THE distinction. A live serve decided 64 swaps across 39 layers with no
+    # apply backend bound and exported them under a single "fq_swaps_total",
+    # so the dashboard read as a working fungible loop while nothing whatever
+    # was installed. Proposals must never imply applications.
+    assert sample(registry, "fq_swaps_applied_total", {"layer": "3"}) == 0.0
+    assert sample(registry, "fq_swaps_applied_total", {"layer": "4"}) == 0.0
 
     drive_hot_interval(state, routers)
-    assert sample(registry, "fq_swaps_total", {"layer": "3"}) == 2.0
+    assert sample(registry, "fq_swap_proposals_total", {"layer": "3"}) == 2.0
+    assert sample(registry, "fq_swaps_applied_total", {"layer": "3"}) == 0.0
     assert sample(registry, "fq_jaccard") == 1.0  # same desired set again
     # Dryrun: occupancy tracks the RUNNING policy, which never moved.
     assert sample(registry, "fq_tier_occupancy",

--- a/tests/exl3_fungible/test_loop_cpu.py
+++ b/tests/exl3_fungible/test_loop_cpu.py
@@ -579,3 +579,31 @@ def test_composition_table_failure_never_kills_the_serve(tmp_path,
                         lambda *a, **k: (_ for _ in ()).throw(
                             RuntimeError("boom")))
     state.log_composition(title="x", diff_only=False)  # must not raise
+
+
+def test_jaccard_ignores_layers_with_no_desired_set():
+    """A layer that cannot hold a K4 expert cannot churn.
+
+    GLM-5.2's fitted policy gives 27 of 75 layers n_k4 = 0. Their desired set
+    is empty in every snapshot. Clamping the union to 1 scored each of them
+    0.0 and averaged them in, dragging the router-shift guard from 0.879 to
+    0.562 against a 0.950 floor — so the guard blocked every swap on the
+    strength of layers that had nothing to say.
+    """
+    import numpy as np
+    live_a = np.array([[True, True, False, False]])
+    live_b = np.array([[True, False, True, False]])   # jaccard 1/3
+    empty = np.zeros((3, 4), dtype=bool)              # three n_k4 == 0 layers
+
+    a = np.concatenate([live_a, empty])
+    b = np.concatenate([live_b, empty])
+    got = FL.FungibleQuantState._jaccard(a, b)
+    assert got == pytest.approx(1 / 3), (
+        "empty layers must be skipped, not scored 0.0 and averaged in")
+
+
+def test_jaccard_of_an_all_empty_membership_is_not_zero():
+    """Nothing to guard is not the same as maximally unstable."""
+    import numpy as np
+    empty = np.zeros((4, 8), dtype=bool)
+    assert FL.FungibleQuantState._jaccard(empty, empty) == 1.0

--- a/tests/exl3_fungible/test_memory_budget_cpu.py
+++ b/tests/exl3_fungible/test_memory_budget_cpu.py
@@ -142,15 +142,17 @@ def test_fraction_without_a_device_names_the_problem():
 def test_measured_glm52_points_fit_the_affine_trellis_model():
     eb = P.ExpertBytes.from_measurements(
         P.MEASURED_GLM52_TP4_PER_RANK, provenance="test")
-    # The two measurements come back exactly.
-    assert eb.bytes_for(3) == 3_542_028
-    assert eb.bytes_for(4) == 4_721_676
+    # The two measurements come back exactly. See
+    # test_the_reference_constants_match_the_real_glm52_geometry for where
+    # these two numbers come from — the checkpoint's own tensor table.
+    assert eb.bytes_for(3) == 3_578_892
+    assert eb.bytes_for(4) == 4_758_540
     # ...and the promotion cost the operator measured.
     assert eb.promotion_cost(3, 4) == 1_179_648
     assert eb.promotion_cost(4, 3) == -1_179_648
     # K2/K5 are EVALUATED from the same line, not guessed.
-    assert eb.bytes_for(2) == 2 * 1_179_648 + 3_084 == 2_362_380
-    assert eb.bytes_for(5) == 5 * 1_179_648 + 3_084 == 5_901_324
+    assert eb.bytes_for(2) == 2 * 1_179_648 + 39_948 == 2_399_244
+    assert eb.bytes_for(5) == 5 * 1_179_648 + 39_948 == 5_938_188
 
 
 def test_all_rank_figures_are_four_times_the_per_rank_ones():
@@ -1054,3 +1056,294 @@ def test_the_loop_never_commits_a_promotion_the_backend_was_not_given(
     # The proposal is still audited: it lands in history/ for the
     # "raise n_k4_per_layer and restart" path.
     assert list((store.root / "history").glob("*-proposed.json"))
+
+
+# =========================================== adversarial review round 2
+# Headroom must not be able to STARVE the swaps it rides alongside.
+
+
+# Realistic MoE traffic: every expert is routed to, two are hot. That is
+# what makes plan_promotions fire — with the sparse DEFAULT_TOKENS the
+# only positive-scoring K3 experts are the ones the swap list already
+# touches, so no promotion is ever planned and the starvation is hidden.
+BROAD_TOKENS = [[e, (e + 1) % E] for e in range(E)] + [[4, 5]] * 6
+
+
+def test_headroom_promotions_do_not_starve_the_paired_swaps(tmp_path):
+    """A byte ceiling with headroom must not stop the executable swaps.
+
+    ``_maybe_apply`` cannot execute an unpaired promotion (D1). Refusing
+    the WHOLE interval because one was proposed freezes the serve: the
+    planner re-proposes a promotion every interval for as long as the
+    ceiling leaves room, nothing is applied, so the occupancy — and hence
+    the headroom — never changes. One ERROR is logged (once), and after
+    that a byte-budgeted serve silently never re-tiers again.
+
+    The byte-neutral 1-for-1 trades are exactly what the backend CAN do,
+    so they must go through; only the promotions are dropped.
+    """
+    seen = []
+
+    def apply_fn(doc, swaps):
+        seen.append(list(swaps))
+        return True
+
+    cfg = FL.FqLoopConfig(interval_steps=4, dwell_steps=0, jaccard_floor=0.0,
+                          apply_mode=FL.APPLY_ATOMIC)
+    collector, routers = make_collector()
+    store = S.PolicyStore(tmp_path, "m" * 64)
+    store.commit(boot_doc(), num_experts=E)
+    state = FL.FungibleQuantState(
+        collector, boot_doc(), config=cfg, eps=eps_hot4(), store=store,
+        budget=simple_budget(BOOT_BYTES + 500), apply_fn=apply_fn)
+    before = np.array(state.tier_of, copy=True)
+
+    drive(state, routers, tokens=BROAD_TOKENS)
+
+    rec = json.loads(next(
+        (store.root / "decisions").glob("*.json")).read_text())
+    assert rec["totals"]["promotions"] > 0, "fixture must plan promotions"
+    assert rec["totals"]["executed"] > 0, "fixture must also decide swaps"
+
+    assert seen and seen[0] == [(sw["layer"], sw["expert_out"],
+                                 sw["expert_in"]) for sw in rec["swaps"]], (
+        "the interval's paired swaps were withheld from the backend because "
+        f"promotions rode along: apply_fn calls={seen}")
+    assert rec["applied"] is True
+    assert rec["promotions_applied"] is False
+    assert not (state.tier_of == before).all()
+
+
+def test_only_the_swaps_are_committed_never_the_promotions(tmp_path):
+    """The applied document must not contain the promoted experts.
+
+    The promotions still have to be auditable, so the FULL proposal keeps
+    landing in history/ — but current.json, tier_of and the gauges may
+    only ever show the swaps-only membership.
+    """
+    seen = []
+    cfg = FL.FqLoopConfig(interval_steps=4, dwell_steps=0, jaccard_floor=0.0,
+                          apply_mode=FL.APPLY_ATOMIC)
+    collector, routers = make_collector()
+    store = S.PolicyStore(tmp_path, "m" * 64)
+    store.commit(boot_doc(), num_experts=E)
+    state = FL.FungibleQuantState(
+        collector, boot_doc(), config=cfg, eps=eps_hot4(), store=store,
+        budget=simple_budget(BOOT_BYTES + 500),
+        apply_fn=lambda doc, swaps: (seen.append(doc), True)[1])
+
+    drive(state, routers, tokens=BROAD_TOKENS)
+    rec = json.loads(next(
+        (store.root / "decisions").glob("*.json")).read_text())
+    assert rec["totals"]["promotions"] > 0
+
+    # Cardinality is untouched everywhere the device can see it.
+    assert (P.n_k4_of(state.tier_of) == 2).all()
+    committed = store.load_current(num_experts=E)
+    for lid in LAYERS:
+        assert sum(b == P.K4 for b in
+                   committed["bits_per_expert"][str(lid)]) == 2
+        assert committed["budget"]["n_k4_per_layer"][str(lid)] == 2
+    assert seen and all(
+        sum(b == P.K4 for b in doc["bits_per_expert"][str(LAYERS[0])]) == 2
+        for doc in seen)
+    # ... while the proposal WITH the promotions is archived for the
+    # "raise n_k4_per_layer and restart" path.
+    proposals = list((store.root / "history").glob("*-proposed.json"))
+    assert proposals, "a proposal carrying promotions must be archived"
+    grown = json.loads(proposals[0].read_text())
+    assert sum(sum(b == P.K4 for b in row)
+               for row in grown["bits_per_expert"].values()) > 4
+
+
+def test_a_budgeted_serve_keeps_re_tiering_interval_after_interval(tmp_path):
+    """The anti-freeze property, end to end over several intervals.
+
+    Same traffic, three configurations: no ceiling, a zero-headroom
+    ceiling, and a ceiling with headroom. All three must keep handing
+    swaps to the backend; the one with headroom must not be the odd one
+    out.
+    """
+    def run(limit):
+        seen = []
+        cfg = FL.FqLoopConfig(interval_steps=4, dwell_steps=0,
+                              jaccard_floor=0.0, apply_mode=FL.APPLY_ATOMIC)
+        collector, routers = make_collector()
+        state = FL.FungibleQuantState(
+            collector, boot_doc(), config=cfg,
+            eps={P.K3: np.full((2, E), 1.0), P.K4: np.zeros((2, E))},
+            budget=simple_budget(limit),
+            apply_fn=lambda doc, swaps: seen.append(list(swaps)) or True)
+        for it in range(5):
+            hot = [(2 + it) % E, (3 + it) % E]
+            toks = ([[e, (e + 1) % E] for e in range(E)]
+                    + [[hot[0], hot[1]]] * 6)
+            drive(state, routers, tokens=toks)
+        return len(seen)
+
+    unbounded = run(None)
+    zero_headroom = run(BOOT_BYTES)
+    with_headroom = run(BOOT_BYTES + 500)
+    assert unbounded > 0 and zero_headroom == unbounded
+    assert with_headroom == unbounded, (
+        f"a ceiling with headroom applied {with_headroom} interval(s) where "
+        f"an unbounded budget applied {unbounded} — headroom must not "
+        f"disable re-tiering")
+
+
+def test_apply_refuses_a_membership_whose_cardinality_moved(tmp_path):
+    """D1 backstop inside ``_maybe_apply`` itself.
+
+    The backend is only ever handed a swap list, so a membership whose
+    per-layer K4 count changed is unreachable for it. Guard structurally,
+    not by trusting every caller to have split the promotions out.
+    """
+    seen = []
+    cfg = FL.FqLoopConfig(interval_steps=4, dwell_steps=0, jaccard_floor=0.0,
+                          apply_mode=FL.APPLY_ATOMIC)
+    collector, _ = make_collector()
+    state = FL.FungibleQuantState(
+        collector, boot_doc(), config=cfg, eps=eps_hot4(),
+        budget=simple_budget(None),
+        apply_fn=lambda doc, swaps: seen.append(list(swaps)) or True)
+    before = np.array(state.tier_of, copy=True)
+
+    grown = P.apply_promotions(state.tier_of, [(0, 5)])
+    assert state._maybe_apply(state._doc_for(grown, []), grown, [(0, 0, 4)],
+                              []) is False
+    assert seen == []
+    assert (state.tier_of == before).all()
+
+
+def test_a_document_never_advertises_a_ceiling_nobody_enforces():
+    """Dropping ``VLLM_FQ_MEMORY_BUDGET`` must clear the byte fields.
+
+    A policy committed under a ceiling records ``mode=max_bytes`` plus the
+    ceiling and the byte model. Restart WITHOUT the env var and the loop
+    inherits that budget block: ``setdefault("mode", ...)`` leaves
+    ``max_bytes`` in place, so every document the run emits advertises a
+    limit that is not being enforced, sourced from a byte model that is
+    not in use.
+    """
+    stale = dict(boot_doc())
+    stale["budget"] = dict(
+        stale["budget"], mode="max_bytes", max_bytes_per_rank=999_999,
+        bytes_per_expert_per_rank={"3": 300, "4": 400},
+        bytes_source="yesterday's checkpoint")
+    collector, _ = make_collector()
+    state = FL.FungibleQuantState(
+        collector, stale,
+        config=FL.FqLoopConfig(interval_steps=4, dwell_steps=0),
+        eps=eps_hot4(), budget=simple_budget(None))
+
+    emitted = state._doc_for(state.tier_of, [])["budget"]
+    assert state.budget.limit_bytes is None
+    assert emitted["mode"] == "fixed_cardinality"
+    for key in ("max_bytes_per_rank", "bytes_per_expert_per_rank",
+                "bytes_source"):
+        assert key not in emitted, f"stale {key} survived into a new document"
+
+
+def glm52_expert_tensor_table(k, rank=0):
+    """One expert, one rank, of the REAL assembled GLM-5.2 checkpoint.
+
+    Transcribed from the safetensors header of
+    ``glm52-k3-assembled/model-layer-003.safetensors`` (H=6144,
+    moe_intermediate 2048 -> 512 per rank at TP4): three
+    ``[H/16, I/16, 16*K]`` int16 trellis slabs plus the K-independent
+    rotations and mcg scalars. Every byte count below is that tensor's
+    own ``data_offsets`` span.
+    """
+    tre = 384 * 32 * (16 * k) * 2                      # 1,179,648 per K
+    base = f"model.layers.3.mlp.experts.0.{{}}.rank{rank}"
+    out = []
+    for proj, shape in (("gate_proj", (384, 32, 16 * k)),
+                        ("up_proj", (384, 32, 16 * k)),
+                        ("down_proj", (32, 384, 16 * k))):
+        b = base.format(proj)
+        out.append((f"{b}.trellis", tre, shape))
+        out.append((f"{b}.mcg", 4, ()))
+    out += [
+        (base.format("gate_proj") + ".suh", 12288, (6144,)),
+        (base.format("gate_proj") + ".svh", 1024, (512,)),
+        (base.format("up_proj") + ".suh", 12288, (6144,)),
+        (base.format("up_proj") + ".svh", 1024, (512,)),
+        (base.format("down_proj") + ".suh", 1024, (512,)),
+        (base.format("down_proj") + ".svh", 12288, (6144,)),
+    ]
+    return out
+
+
+def test_the_reference_constants_match_the_real_glm52_geometry():
+    """The built-in fallback must describe the checkpoint it names.
+
+    ``ExpertBytes`` has two constructors for the SAME quantity: the
+    tensor table (what the runtime derives from the loaded checkpoint)
+    and the hard-coded reference measurement (the fallback when the
+    checkpoint cannot be read). If they disagree on GLM-5.2, one of them
+    is lying about GLM-5.2, and the fallback is the one an operator
+    cannot inspect.
+
+    The earlier constants (K3 3,542,028 / K4 4,721,676) omitted the three
+    12,288 B suh/svh vectors — 36,864 B per expert per rank, which over
+    76 layers x 256 experts is 0.67 GiB of pool that
+    ``fq_memory_used_bytes`` simply did not see. The slope was unaffected
+    (the rotations carry no K), so a promotion-cost test cannot catch it:
+    the fixed term needs its own anchor.
+    """
+    derived = P.ExpertBytes.from_tensor_table(
+        glm52_expert_tensor_table(3), provenance="glm52-k3-assembled")
+    reference = P.reference_expert_bytes(per_rank=True)
+
+    assert derived.trellis_bytes_per_k == 1_179_648
+    assert derived.fixed_bytes == 39_948
+    assert (reference.trellis_bytes_per_k, reference.fixed_bytes) == (
+        derived.trellis_bytes_per_k, derived.fixed_bytes), (
+        "the built-in GLM-5.2 reference disagrees with GLM-5.2's own "
+        f"tensor table: reference K3={reference.bytes_for(3)} vs measured "
+        f"{derived.bytes_for(3)}")
+    for k in (2, 3, 4, 5):
+        assert reference.bytes_for(k) == derived.bytes_for(k)
+    assert reference.bytes_for(3) == 3_578_892
+    assert reference.bytes_for(4) == 4_758_540
+
+
+def test_the_reference_k5_figure_is_confirmed_by_a_real_k5_checkpoint():
+    """K2/K5 are EVALUATED from the affine model, so anchor K5 for real.
+
+    ``glm52-mixed-k3k5`` carries real K5 experts and they measure
+    5,938,188 B per rank. Deriving the model from the K3 checkpoint alone
+    must reproduce that — otherwise the "last dim is 16*K, everything
+    else is K-independent" assumption is wrong and every off-ladder byte
+    figure this module prints is invented.
+    """
+    from_k3 = P.ExpertBytes.from_tensor_table(
+        glm52_expert_tensor_table(3), provenance="glm52-k3-assembled")
+    from_k5 = P.ExpertBytes.from_tensor_table(
+        glm52_expert_tensor_table(5), provenance="glm52-mixed-k3k5")
+    assert from_k5.bytes_for(5) == 5_938_188      # measured, K5 experts
+    assert from_k3.bytes_for(5) == from_k5.bytes_for(5)
+    assert (from_k3.trellis_bytes_per_k, from_k3.fixed_bytes) == (
+        from_k5.trellis_bytes_per_k, from_k5.fixed_bytes)
+    assert P.reference_expert_bytes().bytes_for(5) == 5_938_188
+    assert P.reference_expert_bytes(per_rank=False).bytes_for(5) == 4 * 5_938_188
+
+
+def test_a_rank_of_the_reference_model_matches_the_admin_geometry_model():
+    """``admin.MemoryModel`` derives the same bytes from H and I.
+
+    Two byte models for one quantity in one package will drift. Pin them
+    together on the real GLM-5.2 geometry (H=6144, I=512 per rank): the
+    slope is identical by construction (3*H*I/8) and the constant terms
+    may differ only by the 3 x 4 B mcg scalars, which the shape-derived
+    model does not know about.
+    """
+    hidden, inter = 6144, 2048 // 4
+    unit = 3 * hidden * inter // 8
+    rotations = 6 * (hidden + inter)
+    eb = P.reference_expert_bytes()
+    assert eb.trellis_bytes_per_k == unit
+    assert eb.fixed_bytes - rotations == 12, (
+        f"the reference fixed term ({eb.fixed_bytes} B) and the geometry "
+        f"model's rotations ({rotations} B) differ by more than the 3 mcg "
+        f"scalars")

--- a/tests/exl3_fungible/test_memory_budget_cpu.py
+++ b/tests/exl3_fungible/test_memory_budget_cpu.py
@@ -573,9 +573,19 @@ def make_state(tmp_path=None, *, limit=None, metrics=None, interval=4,
     return state, routers
 
 
-def drive(state, routers, steps=None):
+DEFAULT_TOKENS = [[4, 4], [4, 1], [4, 0]]
+# Same traffic, except one hit goes to e5 instead of a second e4. That
+# gives the promotion planner a candidate that ``decide`` did NOT just
+# demote — see test_a_demoted_expert_is_not_re_promoted_in_the_same_
+# interval. Under DEFAULT_TOKENS the only expert with a positive score
+# outside the swap pair is e1, the one the swap demotes, so a promotion
+# there would be pure churn.
+PROMOTABLE_TOKENS = [[4, 5], [4, 1], [4, 0]]
+
+
+def drive(state, routers, steps=None, tokens=None):
     for _ in range(steps or state.cfg.interval_steps):
-        t = torch.tensor([[4, 4], [4, 1], [4, 0]], dtype=torch.int64)
+        t = torch.tensor(tokens or DEFAULT_TOKENS, dtype=torch.int64)
         for r in routers.values():
             r.capture_fn(t)
         state.step()
@@ -630,7 +640,7 @@ def test_interval_rejects_promotions_over_budget_and_logs_the_numbers(
     # Headroom for exactly one K3->K4 promotion (100 B each), plus 50 B.
     state, routers = make_state(tmp_path, limit=BOOT_BYTES + 150)
     with fq_caplog.at_level(logging.WARNING):
-        drive(state, routers)
+        drive(state, routers, tokens=PROMOTABLE_TOKENS)
 
     rec = json.loads(next(
         (state.store.root / "decisions").glob("*.json")).read_text())
@@ -671,7 +681,7 @@ def test_a_zero_headroom_budget_admits_swaps_but_no_promotions(tmp_path):
 
 def test_proposal_with_promotions_declares_the_new_cardinality(tmp_path):
     state, routers = make_state(tmp_path, limit=BOOT_BYTES + 150)
-    drive(state, routers)
+    drive(state, routers, tokens=PROMOTABLE_TOKENS)
     proposal = json.loads(next(
         (state.store.root / "history").glob("*-proposed.json")).read_text())
     caps = proposal["budget"]["n_k4_per_layer"]
@@ -913,3 +923,134 @@ def test_state_accepts_a_cardinality_budget_from_env(monkeypatch):
     assert state.budget.limit_bytes == 5400
     assert state.budget.used_bytes(state.tier_of) == BOOT_BYTES   # 5200
     assert state.budget.promotions_headroom(state.tier_of) == 2
+
+
+# ================================================ adversarial review (M5)
+# Three defects found by reviewing the memory-budget work against the
+# apply path it feeds. Each test fails on the code as first written.
+
+
+def test_an_over_budget_pool_can_still_make_byte_neutral_trades():
+    """An occupancy already past the ceiling must not be FROZEN.
+
+    Every swap the engine can execute on the K3/K4 ladder is byte-neutral
+    (apply_swaps only accepts a K4 leaving and a K3 entering), and a
+    demotion never happens except paired with a promotion. So if a
+    zero-delta swap is refused while over budget, the pool can neither
+    re-tier nor shrink: the serve is stuck at whatever composition it
+    booted with, forever, with one WARNING per proposal.
+
+    Reachable without any exotic input: a ceiling one byte under the boot
+    footprint, which is what an operator gets by rounding "78g" down, or
+    by falling back to the built-in REFERENCE byte model on a checkpoint
+    whose experts are slightly larger.
+    """
+    b = simple_budget()
+    tier = np.array([[4, 4, 3, 3, 3, 3]])              # 400*2 + 300*4 = 2000
+    used = int(b.used_bytes(tier))
+    over = P.MemoryBudget(b.expert_bytes, used - 1)    # one byte over
+
+    assert P.swap_byte_delta(tier, 0, 0, 2, over) == 0
+    kept, rej = P.budget_filter([(0, 0, 2)], tier, over)
+    assert kept == [(0, 0, 2)], "a zero-delta swap must never be refused"
+    assert rej == []
+    # ... and the guard still bites on anything that actually grows.
+    grow = np.array([[4, 4, 2, 3, 3, 3]])              # e2 sits at K2
+    kept2, rej2 = P.budget_filter(
+        [(0, 0, 2)], grow,
+        P.MemoryBudget(b.expert_bytes, int(b.used_bytes(grow))))
+    assert kept2 == [] and len(rej2) == 1
+    assert rej2[0]["overshoot_bytes"] == 100
+
+
+def test_a_demoted_expert_is_not_re_promoted_in_the_same_interval():
+    """``decide`` demotes e0; ``plan_promotions`` must not pick it back up.
+
+    The weakest K4 incumbent is routinely still stronger than the best K3
+    expert elsewhere, so a promotion planner ranking on raw score puts it
+    straight back. That is worse than churn: the swap list says
+    ``e0 -> K3`` while the proposed membership keeps e0 at K4, so the
+    instruction handed to the apply backend contradicts the state the
+    loop records against it.
+    """
+    L, E = 1, 6
+    tier = np.array([[4, 4, 3, 3, 3, 3]])
+    # e2 is the best K3 (promoted), e0 the weakest K4 (demoted), and e0
+    # still outscores e3/e4/e5 — the trap.
+    count = np.array([[10.0, 100.0, 100.0, 1.0, 1.0, 1.0]])
+    stats = {"count": count, "mass": np.ones((L, E))}
+    eps = {P.K3: np.full((L, E), 1.0), P.K4: np.zeros((L, E))}
+    cfg = {"n_k4": 2, "hysteresis": 1.0, "dwell_steps": 0,
+           "max_swaps_per_layer": 2, "max_swaps_total": 64}
+
+    assert P.decide(stats, eps, tier, cfg=cfg) == [(0, 0, 2)]
+
+    b = simple_budget()
+    budget = P.MemoryBudget(b.expert_bytes,
+                            int(b.used_bytes(tier)) + 2 * 100)
+    swaps, promos, _ = P.decide_with_budget(stats, eps, tier, budget, cfg=cfg)
+    assert swaps == [(0, 0, 2)]
+    demoted = {(l, e_out) for l, e_out, _ in swaps}
+    assert not (demoted & set(promos)), (
+        f"expert(s) {sorted(demoted & set(promos))} were demoted and "
+        f"re-promoted in one interval; promotions={promos}")
+    # The proposed membership must agree with the swap list on e0.
+    final = P.apply_promotions(P.apply_swaps(tier, swaps), promos)
+    assert final[0, 0] == P.K3
+    # The headroom is still spent — on experts the swap list did not touch.
+    assert len(promos) == 2 and (0, 0) not in promos and (0, 2) not in promos
+
+
+def test_the_loop_never_commits_a_promotion_the_backend_was_not_given(
+        tmp_path):
+    """``_maybe_apply`` hands the backend the SWAP LIST only.
+
+    An unpaired promotion changes the per-layer cardinality, which
+    ``SwapPlan.from_memberships`` refuses (D1) and which
+    ``admin.check_cardinality`` answers with 501 as structurally
+    impossible. Before the fix the loop called ``apply_fn(doc, [])`` for a
+    pure-promotion interval, took the backend's "nothing to do" True, and
+    advanced ``tier_of`` / ``policy_doc`` / the store to a composition the
+    device had never been asked to reach — the gauges, the occupancy
+    table and the committed policy all then reported a K4 expert that was
+    physically still K3.
+    """
+    seen = []
+
+    def apply_fn(doc, swaps):
+        seen.append(list(swaps))
+        return True
+
+    # eps makes the incumbents (e0, e1) the best experts, so decide()
+    # proposes no swap, while the rest still score > 0 -> pure promotions.
+    e3 = np.full((2, E), 0.05)
+    e3[:, 0] = 5.0
+    e3[:, 1] = 5.0
+    cfg = FL.FqLoopConfig(interval_steps=4, dwell_steps=0, jaccard_floor=0.0,
+                          apply_mode=FL.APPLY_ATOMIC)
+    collector, routers = make_collector()
+    store = S.PolicyStore(tmp_path, "m" * 64)
+    store.commit(boot_doc(), num_experts=E)
+    state = FL.FungibleQuantState(
+        collector, boot_doc(), config=cfg, eps={P.K3: e3, P.K4: np.zeros((2, E))},
+        store=store, budget=simple_budget(BOOT_BYTES + 250), apply_fn=apply_fn)
+    before = np.array(state.tier_of, copy=True)
+    before_sha = state.policy_sha
+
+    drive(state, routers)
+    rec = json.loads(next(
+        (store.root / "decisions").glob("*.json")).read_text())
+
+    assert rec["totals"]["promotions"] > 0, "fixture must plan promotions"
+    assert rec["totals"]["executed"] == 0
+    assert rec["applied"] is False
+    assert seen == [], (
+        "apply_fn was called with a swap list that does not contain the "
+        f"promotions: {seen}")
+    assert (state.tier_of == before).all()
+    assert state.policy_sha == before_sha
+    assert (np.asarray(store.load_current(num_experts=E)["bits_per_expert"]
+                       [str(LAYERS[0])]) == before[0]).all()
+    # The proposal is still audited: it lands in history/ for the
+    # "raise n_k4_per_layer and restart" path.
+    assert list((store.root / "history").glob("*-proposed.json"))

--- a/tests/exl3_fungible/test_memory_budget_cpu.py
+++ b/tests/exl3_fungible/test_memory_budget_cpu.py
@@ -1,0 +1,915 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU tests for the fungible-quant MEMORY BUDGET (bytes <-> experts/layer).
+
+Covers what the operator asked for: a ceiling expressible either as a
+byte count / fraction of device memory or as a per-layer cardinality,
+converted between the two honestly, enforced when proposing swaps, and
+reported as headroom in the log table and on the Prometheus gauges.
+
+The per-expert byte model is the load-bearing part: it is validated here
+against the REAL tensor geometry of two assembled checkpoints, so a
+regression in the derivation shows up as a failing test rather than as a
+serve that quietly overruns its budget.
+"""
+import json
+import logging
+
+import numpy as np
+import pytest
+import torch
+
+try:
+    from vllm.model_executor.layers.quantization.exl3_fungible import (
+        loop as FL,
+        occupancy_table as OT,
+        policy as P,
+        store as S,
+    )
+    from vllm.model_executor.layers.quantization.exl3_fungible.stats import (
+        FqStatsCollector,
+    )
+except ImportError:  # standalone: load by path with a stub package
+    import importlib.util
+    import sys
+    import types
+    from pathlib import Path as _P
+
+    _dir = (_P(__file__).resolve().parents[2] / "vllm" / "model_executor"
+            / "layers" / "quantization" / "exl3_fungible")
+    _pkg_name = "vllm.model_executor.layers.quantization.exl3_fungible"
+
+    def _load(name, path):
+        spec = importlib.util.spec_from_file_location(name, path)
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[name] = mod
+        spec.loader.exec_module(mod)
+        return mod
+
+    _pkg = types.ModuleType(_pkg_name)
+    sys.modules[_pkg_name] = _pkg
+    for _sub in ("policy", "stats", "store", "decision_log",
+                 "occupancy_table", "loop"):
+        _mod = _load(f"{_pkg_name}.{_sub}", _dir / f"{_sub}.py")
+        setattr(_pkg, _sub, _mod)
+    P, S, FL, OT = (_pkg.policy, _pkg.store, _pkg.loop, _pkg.occupancy_table)
+    FqStatsCollector = _pkg.stats.FqStatsCollector
+
+prometheus_client = pytest.importorskip("prometheus_client")
+
+
+@pytest.fixture
+def fq_caplog(caplog):
+    """caplog, but able to see FQ records.
+
+    vllm configures its ``vllm`` logger with ``propagate: False``, so
+    records from ``vllm.model_executor...`` never reach the root handler
+    caplog installs. Re-enable propagation for the duration of the test.
+    """
+    vllm_logger = logging.getLogger("vllm")
+    before = vllm_logger.propagate
+    vllm_logger.propagate = True
+    try:
+        yield caplog
+    finally:
+        vllm_logger.propagate = before
+
+
+# ==================================================================== parsing
+
+GIB = 1 << 30
+
+
+@pytest.mark.parametrize("spec,want", [
+    ("80000000000", 80_000_000_000),
+    ("78g", 78 * GIB),
+    ("78G", 78 * GIB),
+    ("78gb", 78 * GIB),
+    ("78GiB", 78 * GIB),
+    ("512mb", 512 * (1 << 20)),
+    ("2t", 2 * (1 << 40)),
+    ("4096k", 4096 * 1024),
+    ("1b", 1),
+    ("  78 g  ", 78 * GIB),
+    ("80_000_000_000", 80_000_000_000),
+    (80_000_000_000, 80_000_000_000),
+])
+def test_parse_absolute_sizes(spec, want):
+    assert P.parse_memory_budget(spec) == want
+
+
+@pytest.mark.parametrize("spec,want", [
+    ("0.80", int(0.80 * 100 * GIB)),
+    ("0.9", int(0.9 * 100 * GIB)),
+    ("1", 100 * GIB),          # bare 1 == the whole device, like gpu-mem-util
+    ("1.0", 100 * GIB),
+    ("80%", int(0.80 * 100 * GIB)),
+    ("100%", 100 * GIB),
+    (0.5, 50 * GIB),
+])
+def test_parse_fraction_of_device_memory(spec, want):
+    assert P.parse_memory_budget(spec, device_total_bytes=100 * GIB) == want
+
+
+def test_bare_one_is_a_fraction_but_one_byte_is_spellable():
+    """The gpu-memory-utilization ergonomic has exactly one sharp edge."""
+    assert P.parse_memory_budget("1", device_total_bytes=100) == 100
+    assert P.parse_memory_budget("1b", device_total_bytes=100) == 1
+
+
+@pytest.mark.parametrize("spec", [None, "", "none", "off", "unlimited",
+                                  "UNBOUNDED"])
+def test_budget_can_be_switched_off(spec):
+    assert P.parse_memory_budget(spec) is None
+
+
+@pytest.mark.parametrize("spec", [
+    "abc", "12x", "-5", "0", "0g", "1.5.2", "%", "g", "78 gigs", "0%",
+    "120%", "1.5%%", True,
+])
+def test_garbage_is_refused_not_guessed(spec):
+    with pytest.raises(ValueError):
+        P.parse_memory_budget(spec, device_total_bytes=100 * GIB)
+
+
+def test_fraction_without_a_device_names_the_problem():
+    with pytest.raises(ValueError, match="fraction of device memory"):
+        P.parse_memory_budget("0.80")
+
+
+# =============================================== per-expert byte model
+
+def test_measured_glm52_points_fit_the_affine_trellis_model():
+    eb = P.ExpertBytes.from_measurements(
+        P.MEASURED_GLM52_TP4_PER_RANK, provenance="test")
+    # The two measurements come back exactly.
+    assert eb.bytes_for(3) == 3_542_028
+    assert eb.bytes_for(4) == 4_721_676
+    # ...and the promotion cost the operator measured.
+    assert eb.promotion_cost(3, 4) == 1_179_648
+    assert eb.promotion_cost(4, 3) == -1_179_648
+    # K2/K5 are EVALUATED from the same line, not guessed.
+    assert eb.bytes_for(2) == 2 * 1_179_648 + 3_084 == 2_362_380
+    assert eb.bytes_for(5) == 5 * 1_179_648 + 3_084 == 5_901_324
+
+
+def test_all_rank_figures_are_four_times_the_per_rank_ones():
+    per = P.ExpertBytes.from_measurements(
+        P.MEASURED_GLM52_TP4_PER_RANK, provenance="test")
+    allr = P.ExpertBytes.from_measurements(
+        P.MEASURED_GLM52_TP4_ALL_RANKS, provenance="test")
+    for k in (2, 3, 4, 5):
+        assert allr.bytes_for(k) == 4 * per.bytes_for(k)
+
+
+def fruit_expert_tensor_table(k):
+    """One expert, one rank, of the real GLM-5.2-arch proxy checkpoint.
+
+    Transcribed from the safetensors headers of ``fruit-k3``/``fruit-k4``
+    (H=1024, per-rank I=128): three ``[H/16, I/16, 16*K]`` int16 trellis
+    slabs plus the K-independent rotations and mcg scalars.
+    """
+    words = 16 * k
+    h16, i16 = 64, 8
+    tre = h16 * i16 * words * 2
+    out = []
+    for proj, shape in (("gate_proj", (h16, i16, words)),
+                        ("up_proj", (h16, i16, words)),
+                        ("down_proj", (i16, h16, words))):
+        base = f"model.layers.3.mlp.experts.0.{proj}.rank0"
+        out.append((f"{base}.trellis", tre, shape))
+        out.append((f"{base}.mcg", 4, ()))
+    out += [
+        ("model.layers.3.mlp.experts.0.gate_proj.rank0.suh", 2048, (1024,)),
+        ("model.layers.3.mlp.experts.0.gate_proj.rank0.svh", 256, (128,)),
+        ("model.layers.3.mlp.experts.0.up_proj.rank0.suh", 2048, (1024,)),
+        ("model.layers.3.mlp.experts.0.up_proj.rank0.svh", 256, (128,)),
+        ("model.layers.3.mlp.experts.0.down_proj.rank0.suh", 256, (128,)),
+        ("model.layers.3.mlp.experts.0.down_proj.rank0.svh", 2048, (1024,)),
+    ]
+    return out
+
+
+def test_model_derived_from_a_real_k3_header_predicts_the_real_k4_bytes():
+    """Cross-checkpoint validation of the whole derivation.
+
+    fruit-k3 and fruit-k4 are two independently encoded checkpoints. The
+    model built from k3's shapes alone must reproduce k4's measured
+    814,128 bytes/expert (across its 4 ranks) exactly — if it does not,
+    the "last dim = 16*K" assumption is wrong and every headroom number
+    downstream is fiction.
+    """
+    eb = P.ExpertBytes.from_tensor_table(
+        fruit_expert_tensor_table(3), provenance="fruit-k3")
+    assert eb.measured_ks == (3,)
+    assert eb.bytes_for(3) * 4 == 617_520      # measured, fruit-k3
+    assert eb.bytes_for(4) * 4 == 814_128      # measured, fruit-k4
+    # And deriving from k4's header gives the identical model.
+    eb4 = P.ExpertBytes.from_tensor_table(
+        fruit_expert_tensor_table(4), provenance="fruit-k4")
+    assert (eb4.trellis_bytes_per_k, eb4.fixed_bytes) == (
+        eb.trellis_bytes_per_k, eb.fixed_bytes)
+
+
+def test_tensor_table_reads_k_off_the_trellis_last_dim():
+    for k in (2, 3, 4, 5):
+        eb = P.ExpertBytes.from_tensor_table(
+            fruit_expert_tensor_table(k), provenance="t")
+        assert eb.measured_ks == (k,)
+        assert f"K{k}" in eb.provenance
+
+
+def test_tensor_table_refuses_a_non_trellis_last_dim():
+    bad = [("x.trellis", 100, (4, 4, 50))]  # 50 is not 16*K
+    with pytest.raises(ValueError, match="16"):
+        P.ExpertBytes.from_tensor_table(bad, provenance="t")
+
+
+def test_tensor_table_refuses_mixed_k():
+    mixed = fruit_expert_tensor_table(3) + [
+        ("model.layers.3.mlp.experts.0.gate_proj.rank1.trellis", 1,
+         (64, 8, 64))]
+    with pytest.raises(ValueError, match="exactly one K"):
+        P.ExpertBytes.from_tensor_table(mixed, provenance="t")
+
+
+def test_measurements_off_the_line_are_refused():
+    with pytest.raises(ValueError, match="off the line"):
+        P.ExpertBytes.from_measurements({3: 300, 4: 401, 5: 500},
+                                        provenance="t")
+
+
+def test_a_fractional_bytes_per_k_slope_is_refused():
+    with pytest.raises(ValueError, match="fractional bytes-per-K slope"):
+        P.ExpertBytes.from_measurements({3: 300, 5: 501}, provenance="t")
+
+
+def test_one_measurement_is_not_enough():
+    with pytest.raises(ValueError, match="at least two"):
+        P.ExpertBytes.from_measurements({3: 300}, provenance="t")
+
+
+def test_reference_model_is_flagged_as_not_this_checkpoint():
+    eb = P.reference_expert_bytes()
+    assert eb.is_reference is True
+    assert "REFERENCE" in eb.provenance and "NOT derived" in eb.provenance
+    assert "source:" in eb.describe()
+
+
+# =================================================== bytes <-> cardinality
+
+def simple_budget(limit=None, *, low=3, high=4):
+    """slope 100 B/K, no fixed overhead: K3=300, K4=400, promotion=100."""
+    eb = P.ExpertBytes.from_measurements({3: 300, 4: 400}, provenance="test")
+    return P.MemoryBudget(eb, limit_bytes=limit, low_k=low, high_k=high)
+
+
+def test_used_bytes_comes_from_actual_occupancy_including_off_ladder_tiers():
+    b = simple_budget()
+    tier = np.array([[2, 3, 4, 5], [3, 3, 4, 4]])
+    # 1xK2 + 3xK3 + 3xK4 + 1xK5 = 200 + 900 + 1200 + 500
+    assert b.counts_of(tier) == {2: 1, 3: 3, 4: 3, 5: 1}
+    assert b.used_bytes(tier) == 200 + 900 + 1200 + 500
+
+
+@pytest.mark.parametrize("n", range(0, 9))
+def test_cardinality_bytes_round_trip(n):
+    L, E = 5, 8
+    b = simple_budget()
+    limit = b.bytes_for_cardinality(L, E, n)
+    assert P.MemoryBudget(b.expert_bytes, limit).n_high_per_layer(L, E) == n
+    # And the tier array that budget describes costs exactly that.
+    tier = np.full((L, E), 3)
+    tier[:, :n] = 4
+    assert b.used_bytes(tier) == limit
+
+
+def test_n_high_per_layer_floors_a_budget_between_two_cardinalities():
+    L, E = 5, 8
+    b = simple_budget()
+    exact = b.bytes_for_cardinality(L, E, 3)
+    for slack in (0, 1, L * 100 - 1):
+        assert P.MemoryBudget(
+            b.expert_bytes, exact + slack).n_high_per_layer(L, E) == 3
+    assert P.MemoryBudget(
+        b.expert_bytes, exact + L * 100).n_high_per_layer(L, E) == 4
+
+
+def test_n_high_per_layer_clamps_at_both_ends():
+    L, E = 5, 8
+    b = simple_budget()
+    assert P.MemoryBudget(b.expert_bytes, 1).n_high_per_layer(L, E) == 0
+    assert P.MemoryBudget(
+        b.expert_bytes, 10 ** 12).n_high_per_layer(L, E) == E
+    assert simple_budget().n_high_per_layer(L, E) is None  # unbounded
+
+
+def test_glm52_budget_reads_back_as_experts_per_layer():
+    """The operator's two spellings of the same ceiling must agree."""
+    eb = P.ExpertBytes.from_measurements(
+        P.MEASURED_GLM52_TP4_PER_RANK, provenance="test")
+    L, E = 92, 160
+    b = P.MemoryBudget(eb)
+    for n in (0, 8, 40, 160):
+        limit = b.bytes_for_cardinality(L, E, n)
+        assert P.MemoryBudget(eb, limit).n_high_per_layer(L, E) == n
+
+
+# ======================================================= headroom arithmetic
+
+def test_headroom_counts_promotions_that_actually_fit():
+    b = simple_budget()
+    tier = np.full((2, 4), 3)          # 8 experts x 300 = 2400
+    assert b.used_bytes(tier) == 2400
+    for extra, want in [(0, 0), (99, 0), (100, 1), (250, 2), (1000, 8)]:
+        bb = P.MemoryBudget(b.expert_bytes, 2400 + extra)
+        assert bb.headroom_bytes(tier) == extra
+        assert bb.promotions_headroom(tier) == want
+
+
+def test_headroom_is_capped_by_the_low_tier_experts_that_exist():
+    b = P.MemoryBudget(simple_budget().expert_bytes, 10 ** 9)
+    tier = np.array([[3, 4, 4, 4]])    # only ONE promotable expert
+    assert b.promotions_headroom(tier) == 1
+    assert P.MemoryBudget(b.expert_bytes, 10 ** 9).promotions_headroom(
+        np.full((2, 4), 4)) == 0       # nothing left to promote
+
+
+def test_over_budget_headroom_is_reported_negative_not_clamped():
+    b = simple_budget()
+    tier = np.full((2, 4), 3)          # 2400 B
+    bb = P.MemoryBudget(b.expert_bytes, 2150)
+    assert bb.headroom_bytes(tier) == -250
+    assert bb.promotions_headroom(tier) == -3   # floor(-250/100)
+    s = bb.summary(tier)
+    assert s["headroom_bytes"] == -250 and s["limit_bytes"] == 2150
+
+
+def test_unbounded_budget_reports_none_not_zero():
+    b = simple_budget()
+    tier = np.full((2, 4), 3)
+    assert b.headroom_bytes(tier) is None
+    assert b.promotions_headroom(tier) is None
+    s = b.summary(tier)
+    assert s["limit_bytes"] is None and s["used_bytes"] == 2400
+    assert s["mean_bits_per_expert"] == 3.0
+
+
+def test_summary_always_carries_the_byte_model_provenance():
+    s = simple_budget(3000).summary(np.full((2, 4), 3))
+    assert s["source"] == "test" and s["is_reference"] is False
+    assert s["per_k_bytes"][4] == 400
+    assert s["promotion_cost_bytes"] == 100
+
+
+# ========================================================== enforcement
+
+def test_one_for_one_k3_k4_trades_are_byte_neutral_and_always_admitted():
+    b = simple_budget(limit=None)
+    tier = np.array([[4, 4, 3, 3, 3, 3]])
+    b = P.MemoryBudget(b.expert_bytes, limit_bytes=int(b.used_bytes(tier)))
+    kept, rej = P.budget_filter([(0, 0, 2), (0, 1, 3)], tier, b)
+    assert kept == [(0, 0, 2), (0, 1, 3)] and rej == []
+
+
+def test_budget_filter_rejects_a_swap_that_grows_the_pool():
+    """A K2 expert entering K4 costs two steps and only frees one."""
+    b = simple_budget()
+    tier = np.array([[4, 4, 2, 3, 3, 3]])          # 400+400+200+300*3 = 1900
+    limit = int(b.used_bytes(tier))                # exactly at the line
+    bb = P.MemoryBudget(b.expert_bytes, limit)
+    kept, rej = P.budget_filter([(0, 0, 2)], tier, bb)
+    assert kept == []
+    assert len(rej) == 1
+    r = rej[0]
+    assert r["kind"] == "swap" and r["ok"] is False
+    assert (r["layer"], r["expert_in"], r["expert_out"]) == (0, 2, 0)
+    assert r["budget_bytes"] == 1900
+    assert r["current_bytes"] == 1900
+    assert r["requested_bytes"] == 2000       # -100 (K4->K3) +200 (K2->K4)
+    assert r["overshoot_bytes"] == 100
+    # Raising the ceiling by exactly the overshoot admits it.
+    kept2, rej2 = P.budget_filter(
+        [(0, 0, 2)], tier, P.MemoryBudget(b.expert_bytes, limit + 100))
+    assert kept2 == [(0, 0, 2)] and rej2 == []
+
+
+def test_budget_filter_is_cumulative_over_the_ordered_list():
+    b = simple_budget()
+    tier = np.array([[4, 4, 2, 2, 3, 3]])          # 400*2+200*2+300*2 = 1800
+    bb = P.MemoryBudget(b.expert_bytes, 1900)      # room for ONE +100 swap
+    kept, rej = P.budget_filter([(0, 0, 2), (0, 1, 3)], tier, bb)
+    assert kept == [(0, 0, 2)]
+    assert [r["overshoot_bytes"] for r in rej] == [100]
+    assert rej[0]["current_bytes"] == 1900         # after the first swap
+
+
+def test_budget_filter_is_a_no_op_without_a_ceiling():
+    swaps = [(0, 0, 2), (0, 1, 3)]
+    tier = np.array([[4, 4, 3, 3]])
+    assert P.budget_filter(swaps, tier, None) == (swaps, [])
+    assert P.budget_filter(swaps, tier, simple_budget()) == (swaps, [])
+
+
+# ------------------------------------------------------------ promotions
+
+def promo_inputs(L=2, E=4):
+    stats = {"count": np.tile(np.arange(E, 0, -1.0), (L, 1)),
+             "mass": np.ones((L, E))}
+    eps = {3: np.full((L, E), 1.0), 4: np.zeros((L, E))}
+    return stats, eps
+
+
+def test_promotions_spend_headroom_best_score_first():
+    stats, eps = promo_inputs()
+    tier = np.full((2, 4), 3)                      # 8 x 300 = 2400
+    b = P.MemoryBudget(simple_budget().expert_bytes, 2400 + 300)
+    promos, rej = P.plan_promotions(stats, eps, tier, b,
+                                    cfg={"max_swaps_per_layer": 8})
+    assert len(promos) == 3                        # 300 B / 100 B each
+    # expert 0 scores highest in each layer, then expert 1.
+    assert promos == [(0, 0), (1, 0), (0, 1)]
+    assert P.apply_promotions(tier, promos).sum() == 2400 // 100 + 3
+
+
+def test_promotion_rejection_carries_budget_current_requested_overshoot():
+    stats, eps = promo_inputs()
+    tier = np.full((2, 4), 3)
+    b = P.MemoryBudget(simple_budget().expert_bytes, 2400 + 150)
+    promos, rej = P.plan_promotions(stats, eps, tier, b,
+                                    cfg={"max_swaps_per_layer": 8})
+    assert len(promos) == 1
+    assert rej, "an over-budget candidate must be reported, not dropped"
+    r = rej[0]
+    assert r["kind"] == "promotion" and r["ok"] is False
+    assert r["budget_bytes"] == 2550
+    assert r["current_bytes"] == 2500          # after the admitted promotion
+    assert r["requested_bytes"] == 2600
+    assert r["overshoot_bytes"] == 50
+    assert r["headroom_bytes"] == -50
+
+
+def test_promotions_respect_pins_dwell_and_zero_scores():
+    stats, eps = promo_inputs()
+    tier = np.full((2, 4), 3)
+    b = P.MemoryBudget(simple_budget().expert_bytes, 10 ** 6)
+    pins = np.zeros((2, 4), dtype=np.int64)
+    pins[0, 0] = P.PIN_K3
+    dwell = np.full((2, 4), 100)
+    dwell[1, :] = 0
+    stats["count"][0, 1] = 0.0                 # zero score -> no gain
+    promos, _ = P.plan_promotions(
+        stats, eps, tier, b, pins=pins, dwell=dwell,
+        cfg={"max_swaps_per_layer": 8, "dwell_steps": 10})
+    assert (0, 0) not in promos                # pinned to K3
+    assert (0, 1) not in promos                # no routing pressure
+    assert all(l == 0 for l, _ in promos)      # layer 1 is not dwell-ready
+    assert set(promos) == {(0, 2), (0, 3)}
+
+
+def test_promotions_respect_the_per_layer_cap():
+    stats, eps = promo_inputs()
+    tier = np.full((2, 4), 3)
+    b = P.MemoryBudget(simple_budget().expert_bytes, 10 ** 6)
+    promos, _ = P.plan_promotions(stats, eps, tier, b,
+                                  cfg={"max_swaps_per_layer": 1})
+    assert sorted(promos) == [(0, 0), (1, 0)]
+
+
+def test_promotions_are_deterministic():
+    stats, eps = promo_inputs(L=3, E=6)
+    tier = np.full((3, 6), 3)
+    b = P.MemoryBudget(simple_budget().expert_bytes, 10 ** 5)
+    runs = [P.plan_promotions(stats, eps, tier, b,
+                              cfg={"max_swaps_per_layer": 6})[0]
+            for _ in range(3)]
+    assert runs[0] == runs[1] == runs[2]
+
+
+def test_decide_with_budget_matches_decide_when_unbounded():
+    stats, eps = promo_inputs(L=2, E=6)
+    tier = np.full((2, 6), 3)
+    tier[:, :2] = 4
+    cfg = {"n_k4": 2, "dwell_steps": 0, "hysteresis": 1.0,
+           "max_swaps_per_layer": 2, "max_swaps_total": 8}
+    want = P.decide(stats, eps, tier, cfg=cfg)
+    for budget in (None, simple_budget()):
+        got, promos, rej = P.decide_with_budget(stats, eps, tier, budget,
+                                                cfg=cfg)
+        assert got == want and promos == [] and rej == []
+
+
+# ============================================================ the loop
+
+E = 8
+LAYERS = [3, 4]
+
+
+@pytest.fixture(autouse=True)
+def clean_fq_env(monkeypatch):
+    for env in (FL.FQ_INTERVAL_ENV, FL.FQ_APPLY_MODE_ENV,
+                FL.FQ_ARTIFACT_DIR_ENV, FL.FQ_POLICY_ENV, FL.FQ_EPS_ROOT_ENV,
+                FL.FQ_CACHE_ROOT_ENV, FL.FQ_MAX_SWAPS_LAYER_ENV,
+                FL.FQ_MAX_SWAPS_TOTAL_ENV, FL.FQ_DWELL_ENV,
+                FL.FQ_HYSTERESIS_ENV, FL.FQ_JACCARD_FLOOR_ENV,
+                FL.FQ_MEMORY_BUDGET_ENV, FL.FQ_EXPERT_BYTES_ENV):
+        monkeypatch.delenv(env, raising=False)
+    return monkeypatch
+
+
+class FakeRouter:
+    def __init__(self):
+        self.capture_fn = None
+        self.global_num_experts = E
+
+    def set_capture_fn(self, fn):
+        self.capture_fn = fn
+
+
+def make_collector():
+    c = FqStatsCollector(E, window_len=8, window_stride=2, decay=0.9,
+                         device="cpu")
+    routers = {lid: FakeRouter() for lid in LAYERS}
+    for lid, r in routers.items():
+        c.bind_router(lid, r)
+    return c, routers
+
+
+def boot_doc():
+    bits = [4, 4, 3, 3, 3, 3, 3, 3]
+    return {
+        "schema": "fq-policy/2",
+        "manifest": "m" * 64,
+        "budget": {"mode": "fixed_cardinality",
+                   "n_k4_per_layer": {str(lid): 2 for lid in LAYERS}},
+        "bits_per_expert": {str(lid): list(bits) for lid in LAYERS},
+        "pinned": {},
+    }
+
+
+def eps_hot4():
+    e3 = np.full((2, E), 0.05)
+    e3[:, 4] = 0.5
+    return {P.K3: e3, P.K4: np.zeros((2, E))}
+
+
+# Boot occupancy: 12 experts at K3 + 4 at K4 = 12*300 + 4*400 = 5200 B.
+BOOT_BYTES = 5200
+
+
+def make_state(tmp_path=None, *, limit=None, metrics=None, interval=4,
+               **cfg_kw):
+    cfg_kw.setdefault("dwell_steps", 0)
+    cfg_kw.setdefault("jaccard_floor", 0.0)
+    cfg = FL.FqLoopConfig(interval_steps=interval, **cfg_kw)
+    collector, routers = make_collector()
+    store = None
+    if tmp_path is not None:
+        store = S.PolicyStore(tmp_path, "m" * 64)
+        store.commit(boot_doc(), num_experts=E)
+    state = FL.FungibleQuantState(
+        collector, boot_doc(), config=cfg, eps=eps_hot4(), store=store,
+        metrics=metrics, budget=simple_budget(limit))
+    return state, routers
+
+
+def drive(state, routers, steps=None):
+    for _ in range(steps or state.cfg.interval_steps):
+        t = torch.tensor([[4, 4], [4, 1], [4, 0]], dtype=torch.int64)
+        for r in routers.values():
+            r.capture_fn(t)
+        state.step()
+
+
+def sample(registry, name, labels=None):
+    v = registry.get_sample_value(name, labels or {})
+    return 0.0 if v is None else v
+
+
+def test_state_reports_boot_footprint_from_actual_occupancy():
+    state, _ = make_state(limit=BOOT_BYTES + 500)
+    s = state.budget.summary(state.tier_of)
+    assert s["used_bytes"] == BOOT_BYTES
+    assert s["headroom_bytes"] == 500
+    assert s["headroom_promotions"] == 5
+
+
+def test_gauges_expose_budget_used_and_headroom(tmp_path):
+    registry = prometheus_client.CollectorRegistry()
+    metrics = FL.FqMetrics(registry=registry)
+    state, routers = make_state(tmp_path, limit=BOOT_BYTES + 250,
+                                metrics=metrics)
+    assert sample(registry, "fq_memory_budget_bytes") == BOOT_BYTES + 250
+    assert sample(registry, "fq_memory_used_bytes") == BOOT_BYTES
+    assert sample(registry, "fq_promotions_headroom") == 2.0
+    # Dryrun never moves the running policy, so the gauges hold steady.
+    drive(state, routers)
+    assert sample(registry, "fq_memory_used_bytes") == BOOT_BYTES
+    assert sample(registry, "fq_promotions_headroom") == 2.0
+
+
+def test_gauges_mark_an_unconfigured_budget_with_documented_sentinels(tmp_path):
+    registry = prometheus_client.CollectorRegistry()
+    metrics = FL.FqMetrics(registry=registry)
+    make_state(tmp_path, limit=None, metrics=metrics)
+    assert sample(registry, "fq_memory_budget_bytes") == 0.0   # unconfigured
+    assert sample(registry, "fq_promotions_headroom") == -1.0  # unbounded
+    assert sample(registry, "fq_memory_used_bytes") == BOOT_BYTES
+
+
+def test_gauges_go_negative_when_the_boot_policy_is_over_budget(tmp_path):
+    registry = prometheus_client.CollectorRegistry()
+    metrics = FL.FqMetrics(registry=registry)
+    make_state(tmp_path, limit=BOOT_BYTES - 250, metrics=metrics)
+    assert sample(registry, "fq_memory_used_bytes") == BOOT_BYTES
+    assert sample(registry, "fq_promotions_headroom") == -3.0
+
+
+def test_interval_rejects_promotions_over_budget_and_logs_the_numbers(
+        tmp_path, fq_caplog):
+    # Headroom for exactly one K3->K4 promotion (100 B each), plus 50 B.
+    state, routers = make_state(tmp_path, limit=BOOT_BYTES + 150)
+    with fq_caplog.at_level(logging.WARNING):
+        drive(state, routers)
+
+    rec = json.loads(next(
+        (state.store.root / "decisions").glob("*.json")).read_text())
+    b = rec["budget"]
+    assert b["limit_bytes"] == BOOT_BYTES + 150
+    assert b["used_bytes"] == BOOT_BYTES          # the RUNNING pool
+    assert b["proposed_bytes"] == BOOT_BYTES + 100
+    assert rec["totals"]["promotions"] == 1
+    assert rec["totals"]["budget_rejections"] == len(b["rejections"]) > 0
+
+    r = b["rejections"][0]
+    assert r["kind"] == "promotion" and r["ok"] is False
+    assert r["budget_bytes"] == BOOT_BYTES + 150
+    assert r["current_bytes"] == BOOT_BYTES + 100
+    assert r["requested_bytes"] == BOOT_BYTES + 200
+    assert r["overshoot_bytes"] == 50
+
+    logged = "\n".join(m for m in fq_caplog.messages
+                        if "memory budget" in m)
+    assert "REJECTED by memory budget" in logged
+    for n in (b["limit_bytes"], r["current_bytes"], r["requested_bytes"], 50):
+        assert str(n) in logged
+
+
+def test_a_zero_headroom_budget_admits_swaps_but_no_promotions(tmp_path):
+    state, routers = make_state(tmp_path, limit=BOOT_BYTES)
+    drive(state, routers)
+    rec = json.loads(next(
+        (state.store.root / "decisions").glob("*.json")).read_text())
+    # The byte-neutral 1-for-1 trades still go through...
+    assert rec["totals"]["executed"] == 2
+    assert all(sw["expert_in"] == 4 for sw in rec["swaps"])
+    # ...and nothing was allowed to grow the pool.
+    assert rec["totals"]["promotions"] == 0
+    assert rec["budget"]["proposed_bytes"] == BOOT_BYTES
+    assert rec["budget"]["headroom_promotions"] == 0
+
+
+def test_proposal_with_promotions_declares_the_new_cardinality(tmp_path):
+    state, routers = make_state(tmp_path, limit=BOOT_BYTES + 150)
+    drive(state, routers)
+    proposal = json.loads(next(
+        (state.store.root / "history").glob("*-proposed.json")).read_text())
+    caps = proposal["budget"]["n_k4_per_layer"]
+    counts = {lid: sum(b == 4 for b in proposal["bits_per_expert"][lid])
+              for lid in proposal["bits_per_expert"]}
+    assert {k: int(v) for k, v in caps.items()} == counts
+    assert sum(counts.values()) == 5            # 4 boot + 1 promotion
+    # store.validate_policy enforces cap == n; the proposal must survive it.
+    S.validate_policy(proposal, num_experts=E)
+    assert proposal["budget"]["mode"] == "max_bytes"
+    assert proposal["budget"]["max_bytes_per_rank"] == BOOT_BYTES + 150
+    assert proposal["budget"]["bytes_per_expert_per_rank"]["4"] == 400
+    assert proposal["budget"]["bytes_source"] == "test"
+
+
+def test_unbounded_budget_leaves_the_decision_path_unchanged(tmp_path):
+    state, routers = make_state(tmp_path, limit=None)
+    drive(state, routers)
+    rec = json.loads(next(
+        (state.store.root / "decisions").glob("*.json")).read_text())
+    assert rec["totals"]["executed"] == 2
+    assert rec["totals"]["promotions"] == 0
+    assert rec["budget"]["limit_bytes"] is None
+    assert rec["budget"]["headroom_promotions"] is None
+
+
+def test_composition_table_reports_the_budget(fq_caplog):
+    with fq_caplog.at_level(logging.INFO):
+        make_state(limit=BOOT_BYTES + 250)
+    text = "\n".join(fq_caplog.messages)
+    assert "memory budget:" in text
+    assert "headroom" in text and "2 more K3->K4 promotions" in text
+    assert "bytes/expert/rank:" in text
+
+
+# ------------------------------------------------------ byte-model sourcing
+
+def test_env_declared_expert_bytes_win(monkeypatch):
+    eb = FL.resolve_expert_bytes(spec="k3=3542028,k4=4721676")
+    assert eb.bytes_for(5) == 5_901_324
+    assert "operator-declared" in eb.provenance and eb.is_reference is False
+
+
+@pytest.mark.parametrize("spec", ["k3=1", "3542028", "k3:1,k4:2", "kx=1,ky=2"])
+def test_bad_expert_bytes_spec_is_refused(spec):
+    with pytest.raises(ValueError):
+        FL.parse_expert_bytes_spec(spec)
+
+
+def write_fake_checkpoint(root, k):
+    """A safetensors file whose header carries one expert's real geometry."""
+    import struct
+
+    header, off = {}, 0
+    for name, nbytes, shape in fruit_expert_tensor_table(k):
+        dtype = "I16" if name.endswith("trellis") else (
+            "I32" if name.endswith("mcg") else "F16")
+        header[name] = {"dtype": dtype, "shape": list(shape),
+                        "data_offsets": [off, off + nbytes]}
+        off += nbytes
+    blob = json.dumps(header).encode()
+    root.mkdir(parents=True, exist_ok=True)
+    with open(root / "model-layer-003.safetensors", "wb") as f:
+        f.write(struct.pack("<Q", len(blob)))
+        f.write(blob)          # header only: the loop never reads the body
+    return root
+
+
+def test_expert_bytes_are_derived_from_the_loaded_checkpoints_shapes(tmp_path):
+    root = write_fake_checkpoint(tmp_path / "ckpt", 3)
+    eb = FL.expert_bytes_from_checkpoint(root)
+    assert eb is not None and eb.is_reference is False
+    assert eb.bytes_for(3) * 4 == 617_520 and eb.bytes_for(4) * 4 == 814_128
+    assert "derived from loaded tensor shapes" in eb.provenance
+    assert "model-layer-003.safetensors" in eb.provenance
+
+
+def test_resolution_order_prefers_the_checkpoint_over_the_reference(tmp_path):
+    root = write_fake_checkpoint(tmp_path / "ckpt", 4)
+    eb = FL.resolve_expert_bytes(artifact_dir=str(root))
+    assert eb.is_reference is False and eb.bytes_for(4) == 203_532
+    # ...and the declared spec still outranks the checkpoint.
+    eb2 = FL.resolve_expert_bytes(spec="k3=300,k4=400", artifact_dir=str(root))
+    assert eb2.bytes_for(4) == 400
+
+
+def test_missing_checkpoint_falls_back_loudly_never_silently(tmp_path,
+                                                             fq_caplog):
+    with fq_caplog.at_level(logging.WARNING):
+        eb = FL.resolve_expert_bytes(artifact_dir=str(tmp_path / "nope"))
+    assert eb.is_reference is True
+    text = "\n".join(fq_caplog.messages)
+    assert "REFERENCE" in text and FL.FQ_EXPERT_BYTES_ENV in text
+    assert FL.expert_bytes_from_checkpoint(tmp_path / "nope") is None
+
+
+def test_state_resolves_a_fractional_budget_against_the_device(monkeypatch):
+    monkeypatch.setattr(FL, "device_total_bytes", lambda: 10_000)
+    monkeypatch.setenv(FL.FQ_MEMORY_BUDGET_ENV, "0.80")
+    monkeypatch.setenv(FL.FQ_EXPERT_BYTES_ENV, "k3=300,k4=400")
+    cfg = FL.FqLoopConfig.from_env()
+    cfg.interval_steps, cfg.dwell_steps, cfg.jaccard_floor = 4, 0, 0.0
+    collector, _ = make_collector()
+    state = FL.FungibleQuantState(collector, boot_doc(), config=cfg,
+                                  eps=eps_hot4())
+    assert state.budget.limit_bytes == 8_000
+    assert state.budget.expert_bytes.bytes_for(4) == 400
+    assert state.budget.used_bytes(state.tier_of) == BOOT_BYTES
+
+
+def test_a_bad_budget_spec_fails_closed_rather_than_ignoring_the_ceiling(
+        monkeypatch):
+    monkeypatch.setenv(FL.FQ_MEMORY_BUDGET_ENV, "definitely-not-a-size")
+    cfg = FL.FqLoopConfig.from_env()
+    cfg.interval_steps, cfg.dwell_steps, cfg.jaccard_floor = 4, 0, 0.0
+    collector, _ = make_collector()
+    with pytest.raises(ValueError):
+        FL.FungibleQuantState(collector, boot_doc(), config=cfg,
+                              eps=eps_hot4())
+
+
+def test_device_total_bytes_is_none_without_cuda():
+    assert FL.device_total_bytes() is None or FL.device_total_bytes() > 0
+
+
+# ================================================== occupancy table footer
+
+def test_table_footer_shows_ceiling_use_and_headroom():
+    summary = simple_budget(3000).summary(np.full((2, 4), 3))
+    out = OT.render({0: {3: 4}, 1: {3: 4}}, budget=summary)
+    assert "memory budget: 2.93 KiB" in out
+    assert "used 2.34 KiB (80.0%)" in out
+    assert "= 6 more K3->K4 promotions" in out
+    assert "K3=300" in out and "K4=400" in out
+    assert "byte model: test" in out
+
+
+def test_table_footer_shouts_when_over_budget():
+    summary = simple_budget(2000).summary(np.full((2, 4), 3))
+    out = OT.render({0: {3: 4}}, budget=summary)
+    assert "OVER BUDGET by 400 B" in out
+
+
+def test_table_footer_flags_a_reference_byte_model():
+    b = P.MemoryBudget(P.reference_expert_bytes(), 10 ** 12)
+    out = OT.render({0: {3: 4}}, budget=b.summary(np.full((1, 4), 3)))
+    assert "REFERENCE (not this checkpoint!)" in out
+
+
+def test_table_without_a_budget_says_so_instead_of_implying_one():
+    out = OT.render({0: {3: 4}}, budget=simple_budget().summary(
+        np.full((1, 4), 3)))
+    assert "no byte budget set" in out
+    assert "headroom" not in out
+
+
+def test_budget_survives_the_early_return_paths():
+    summary = simple_budget(3000).summary(np.full((2, 4), 3))
+    same = {0: {3: 4}}
+    assert "headroom 6 promotions" in OT.render(
+        same, same, diff_only=True, budget=summary)
+    assert "2.34 KiB/2.93 KiB used" in OT.render({}, budget=summary)
+
+
+def test_render_without_a_budget_is_unchanged():
+    assert "memory" not in OT.render({0: {3: 4}})
+
+
+@pytest.mark.parametrize("n,want", [
+    (0, "0 B"), (512, "512 B"), (1024, "1.00 KiB"),
+    (78 * GIB, "78.00 GiB"), (-1536, "-1.50 KiB"), (None, "unbounded"),
+])
+def test_format_bytes(n, want):
+    assert OT.format_bytes(n) == want
+
+
+# ============================== "experts/bpw per layer" budget spellings
+
+def from_spec(spec, *, L=5, E=8, device=None):
+    return P.MemoryBudget.from_spec(
+        spec, simple_budget().expert_bytes, num_layers=L, num_experts=E,
+        device_total_bytes=device)
+
+
+@pytest.mark.parametrize("spec", ["3/layer", "3experts/layer",
+                                  "3 experts / layer", "3EXPERT/layer"])
+def test_budget_can_be_written_as_experts_per_layer(spec):
+    b = from_spec(spec)
+    # 5 layers x (5 K3 + 3 K4) = 5 * (1500 + 1200)
+    assert b.limit_bytes == 5 * (5 * 300 + 3 * 400)
+    assert b.n_high_per_layer(5, 8) == 3
+
+
+def test_experts_per_layer_and_bytes_describe_the_same_ceiling():
+    assert from_spec("3/layer").limit_bytes == from_spec(
+        str(5 * (5 * 300 + 3 * 400))).limit_bytes
+
+
+def test_budget_can_be_written_as_bits_per_weight():
+    # 8 experts/layer, K3 base, K4 overlay: 3.5 bpw == 4 experts at K4.
+    b = from_spec("3.5bpw")
+    assert b.n_high_per_layer(5, 8) == 4
+    assert b.limit_bytes == 5 * (4 * 300 + 4 * 400)
+    # A bpw the ladder cannot subdivide rounds DOWN, never up.
+    assert from_spec("3.6bpw").n_high_per_layer(5, 8) == 4
+    assert from_spec("3.0bpw").n_high_per_layer(5, 8) == 0
+    assert from_spec("4bpw").n_high_per_layer(5, 8) == 8
+    assert from_spec("9bpw").n_high_per_layer(5, 8) == 8   # clamped at K4
+
+
+def test_bpw_below_the_base_tier_is_refused():
+    with pytest.raises(ValueError, match="below the base tier"):
+        from_spec("2.5bpw")
+
+
+def test_more_experts_than_a_layer_has_is_refused():
+    with pytest.raises(ValueError, match="only has 8"):
+        from_spec("9/layer")
+
+
+def test_from_spec_still_takes_bytes_fractions_and_none():
+    assert from_spec("78g").limit_bytes == 78 * GIB
+    assert from_spec("0.5", device=1000).limit_bytes == 500
+    assert from_spec(None).limit_bytes is None
+    assert from_spec("off").limit_bytes is None
+    with pytest.raises(ValueError):
+        from_spec("nonsense")
+
+
+def test_state_accepts_a_cardinality_budget_from_env(monkeypatch):
+    monkeypatch.setenv(FL.FQ_MEMORY_BUDGET_ENV, "3/layer")
+    monkeypatch.setenv(FL.FQ_EXPERT_BYTES_ENV, "k3=300,k4=400")
+    cfg = FL.FqLoopConfig.from_env()
+    cfg.interval_steps, cfg.dwell_steps, cfg.jaccard_floor = 4, 0, 0.0
+    collector, _ = make_collector()
+    state = FL.FungibleQuantState(collector, boot_doc(), config=cfg,
+                                  eps=eps_hot4())
+    # 2 layers x (5 K3 + 3 K4) = 2 * (1500 + 1200) = 5400
+    assert state.budget.limit_bytes == 5400
+    assert state.budget.used_bytes(state.tier_of) == BOOT_BYTES   # 5200
+    assert state.budget.promotions_headroom(state.tier_of) == 2

--- a/tests/exl3_fungible/test_memory_preflight.py
+++ b/tests/exl3_fungible/test_memory_preflight.py
@@ -76,10 +76,27 @@ def test_flat_k3_matches_the_measured_boot():
     assert p["fits"]
 
 
-# The failing boot carried 9.19 GiB of non-weight residue, not the 5.27 GiB a
-# flat load leaves: progressive staging left 3.92 GiB stranded in the caching
-# allocator. That is a separate defect (fixed by the post-load reclaim), and
-# these two tests keep the two causes from being confused for each other.
+# RETRACTED HYPOTHESIS, kept as a cautionary constant.
+#
+# The failing boot carried 9.19 GiB of non-weight overhead against the 5.27 GiB
+# implied by an earlier flat-K3 run, and I attributed the 3.92 GiB gap to
+# progressive staging stranded in the caching allocator. Direct measurement
+# refuted it. With the reclaim moved to the correct hook -- after
+# process_weights_after_loading, where the footprint really is 79.17 GiB --
+# gc + empty_cache freed EXACTLY 0.00 GiB:
+#
+#   FQ reclaim: reserved 79.39 -> 79.39 GiB, freed 0.00 GiB;
+#               weight footprint 79.17 GiB
+#
+# reserved exceeds allocated by 0.22 GiB, so there is no residue to reclaim.
+# The two runs differed in configuration (max_model_len 32768 vs 8192, graph
+# capture on vs off), not in allocator behaviour, and 5.27 was never a
+# constant of this system.
+#
+# MEASURED, at util 0.95 / eager / max_model_len 8192:
+#   budget 90.81 - weights 79.08 - KV 3.67 = 8.06 GiB of real overhead.
+OVERHEAD_MEASURED = 8.06
+# Retained only so the tests below still describe the boot that failed.
 OVERHEAD_WITH_RESIDUE = 9.19
 OVERHEAD_AFTER_RECLAIM = 5.27
 
@@ -100,21 +117,32 @@ def test_util_095_does_not_rescue_the_failing_policy():
     assert not p["fits"]
 
 
-def test_reclaiming_the_residue_alone_does_not_rescue_it_either():
-    """Freeing all 3.92 GiB of allocator residue lifts KV to +0.82 GiB --
-    real progress, still far under a usable floor. Both fixes are needed;
-    neither substitutes for the other."""
+def test_reclaiming_the_residue_alone_would_not_have_rescued_it_either():
+    """Hypothetical, and now known to be unavailable: even if all 3.92 GiB had
+    been reclaimable, KV reaches only +0.82 GiB -- still under any usable
+    floor. The policy was always the binding constraint; the residue theory
+    was never going to save it. Measurement later showed there is no residue
+    at all (see OVERHEAD_MEASURED)."""
     p = _project(5_206, overhead=OVERHEAD_AFTER_RECLAIM)
     assert p["projected_kv_bytes"] / GIB == pytest.approx(0.82, abs=0.05)
     assert not p["fits"]
 
 
-def test_both_fixes_together_admit_a_trimmed_policy():
-    """With the residue reclaimed and util at 0.95, the envelope that fits is
-    ~3,000 promotions, not 5,206 -- the number the demo must be sized to."""
-    p = _project(3_000, util=0.95, overhead=OVERHEAD_AFTER_RECLAIM)
-    assert p["fits"]
-    assert p["projected_kv_bytes"] / GIB > 4.0
+def test_measured_overhead_reproduces_the_observed_kv():
+    """Known-answer against the boot that actually served: the fitted policy
+    (2,658 K4) at util 0.95 with the MEASURED 8.06 GiB overhead must land on
+    the 3.67 GiB of KV the engine reported."""
+    p = _project(2_658, util=0.95, overhead=OVERHEAD_MEASURED)
+    assert p["weight_bytes"] / GIB == pytest.approx(79.08, abs=0.05)
+    assert p["projected_kv_bytes"] / GIB == pytest.approx(3.67, abs=0.10)
+
+
+def test_the_envelope_that_actually_fits_is_far_below_the_seeded_one():
+    """Under MEASURED overhead, clearing a 4 GiB KV floor needs ~2,350
+    promotions -- not the 5,206 the seeded policy asked for. The demo envelope
+    is set by the card, not by the 3.42bpw coder quant's shape."""
+    assert not _project(2_658, util=0.95, overhead=OVERHEAD_MEASURED)["fits"]
+    assert _project(2_300, util=0.95, overhead=OVERHEAD_MEASURED)["fits"]
 
 
 def test_remedy_is_expressed_in_experts_not_bytes():

--- a/tests/exl3_fungible/test_memory_preflight.py
+++ b/tests/exl3_fungible/test_memory_preflight.py
@@ -1,0 +1,165 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Known-answer tests for the progressive-boot memory projection.
+
+The numbers below are the MEASURED ones from the GLM-5.2 TP4 boot that this
+module exists to prevent, so a regression here is a regression against
+reality rather than against a made-up fixture:
+
+    K3 expert  3,578,892 B/rank      flat-K3 weights  76.14 GiB/rank
+    K4 expert  4,758,540 B/rank      device           97,887 MiB
+    promotion  1,179,648 B/rank      observed KV      -3.1 GiB at util 0.92
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+try:
+    from vllm.model_executor.layers.quantization.exl3_fungible import (
+        memory_preflight as MP,
+    )
+except ImportError:  # standalone: load by path (no torch needed -- this
+    # module is deliberately pure arithmetic so it can be tested on CPU)
+    import importlib.util
+
+    _p = (Path(__file__).resolve().parents[2] / "vllm" / "model_executor"
+          / "layers" / "quantization" / "exl3_fungible"
+          / "memory_preflight.py")
+    _spec = importlib.util.spec_from_file_location("fq_preflight_standalone", _p)
+    MP = importlib.util.module_from_spec(_spec)
+    _spec.loader.exec_module(MP)
+
+GIB = MP.GIB
+BudgetExceeded = MP.BudgetExceeded
+check_or_raise = MP.check_or_raise
+headroom_in_promotions = MP.headroom_in_promotions
+project = MP.project
+project_expert_bytes = MP.project_expert_bytes
+render = MP.render
+
+K3_BYTES = 3_578_892
+K4_BYTES = 4_758_540
+SIZES = {3: K3_BYTES, 4: K4_BYTES}
+DEVICE = 97_887 * (1 << 20)
+# 76.14 GiB flat-K3 weights minus the 64.00 GiB of K3 experts.
+DENSE = int(76.14 * GIB) - K3_BYTES * 256 * 75
+
+
+def _bits(n_k4: int, layers: int = 75, experts: int = 256):
+    """Tier bitmap with the first ``n_k4`` experts promoted to K4."""
+    flat = [3] * (layers * experts)
+    for i in range(n_k4):
+        flat[i] = 4
+    return {
+        layer: flat[layer * experts:(layer + 1) * experts]
+        for layer in range(layers)
+    }
+
+
+def _project(n_k4, util=0.92, overhead=5.27, min_kv=4.0):  # noqa: E501
+    return project(
+        _bits(n_k4), SIZES, DENSE,
+        device_total_bytes=DEVICE,
+        gpu_memory_utilization=util,
+        runtime_overhead_bytes=int(overhead * GIB),
+        min_kv_bytes=int(min_kv * GIB),
+    )
+
+
+def test_flat_k3_matches_the_measured_boot():
+    """Zero promotions must reproduce the 76.14 GiB / +6.54 GiB KV boot."""
+    p = _project(0)
+    assert p["weight_bytes"] / GIB == pytest.approx(76.14, abs=0.01)
+    assert p["projected_kv_bytes"] / GIB == pytest.approx(6.54, abs=0.05)
+    assert p["fits"]
+
+
+# The failing boot carried 9.19 GiB of non-weight residue, not the 5.27 GiB a
+# flat load leaves: progressive staging left 3.92 GiB stranded in the caching
+# allocator. That is a separate defect (fixed by the post-load reclaim), and
+# these two tests keep the two causes from being confused for each other.
+OVERHEAD_WITH_RESIDUE = 9.19
+OVERHEAD_AFTER_RECLAIM = 5.27
+
+
+def test_the_policy_that_actually_failed_is_rejected():
+    """5,206 K4 promotions is the attempt-11 policy: -3.1 GiB of KV."""
+    p = _project(5_206, overhead=OVERHEAD_WITH_RESIDUE)
+    assert p["weight_bytes"] / GIB == pytest.approx(81.86, abs=0.02)
+    assert p["projected_kv_bytes"] / GIB == pytest.approx(-3.1, abs=0.05)
+    assert not p["fits"]
+
+
+def test_util_095_does_not_rescue_the_failing_policy():
+    """The auto-retry at 0.95 was doomed too -- prove the check knows it,
+    in the five seconds it takes rather than the 62 minutes it took."""
+    p = _project(5_206, util=0.95, overhead=OVERHEAD_WITH_RESIDUE)
+    assert p["projected_kv_bytes"] / GIB == pytest.approx(-0.23, abs=0.05)
+    assert not p["fits"]
+
+
+def test_reclaiming_the_residue_alone_does_not_rescue_it_either():
+    """Freeing all 3.92 GiB of allocator residue lifts KV to +0.82 GiB --
+    real progress, still far under a usable floor. Both fixes are needed;
+    neither substitutes for the other."""
+    p = _project(5_206, overhead=OVERHEAD_AFTER_RECLAIM)
+    assert p["projected_kv_bytes"] / GIB == pytest.approx(0.82, abs=0.05)
+    assert not p["fits"]
+
+
+def test_both_fixes_together_admit_a_trimmed_policy():
+    """With the residue reclaimed and util at 0.95, the envelope that fits is
+    ~3,000 promotions, not 5,206 -- the number the demo must be sized to."""
+    p = _project(3_000, util=0.95, overhead=OVERHEAD_AFTER_RECLAIM)
+    assert p["fits"]
+    assert p["projected_kv_bytes"] / GIB > 4.0
+
+
+def test_remedy_is_expressed_in_experts_not_bytes():
+    p = _project(5_206)
+    n = headroom_in_promotions(p, SIZES, 3, 4)
+    # Demoting n experts must actually clear the shortfall, and n-1 must not:
+    # an off-by-one here hands the operator an instruction that still OOMs.
+    assert _project(5_206 - n)["fits"]
+    assert not _project(5_206 - n + 1)["fits"]
+    assert any(f"demote {n:,}" in line for line in render(p, SIZES))
+
+
+def test_census_counts_every_expert_exactly_once():
+    total, census = project_expert_bytes(_bits(1_000), SIZES)
+    assert census == {3: 75 * 256 - 1_000, 4: 1_000}
+    assert sum(census.values()) == 75 * 256
+    assert total == census[3] * K3_BYTES + census[4] * K4_BYTES
+
+
+def test_unsizeable_k_raises_rather_than_undercounting():
+    """A K we cannot size must not silently contribute zero bytes -- that is
+    precisely the direction that green-lights an OOM."""
+    with pytest.raises(KeyError, match="K5"):
+        project_expert_bytes({0: [3, 5]}, SIZES)
+
+
+def test_check_or_raise_blocks_by_default(caplog):
+    with pytest.raises(BudgetExceeded, match="short by"):
+        check_or_raise(_project(5_206), SIZES, lambda m: None)
+
+
+def test_enforcement_can_be_disabled(monkeypatch):
+    monkeypatch.setenv("VLLM_FQ_BUDGET_ENFORCE", "0")
+    seen: list[str] = []
+    check_or_raise(_project(5_206), SIZES, seen.append)
+    assert any("enforcement disabled" in m for m in seen)
+
+
+def test_fitting_policy_passes_silently():
+    check_or_raise(_project(2_000), SIZES, lambda m: None)
+
+
+@pytest.mark.parametrize("n", [0, 1, 1_000, 19_200])
+def test_projection_is_monotonic_in_promotions(n):
+    """More K4 experts must never project MORE KV cache."""
+    p = _project(n)
+    if n < 19_200:
+        assert _project(n + 1)["projected_kv_bytes"] < p["projected_kv_bytes"]

--- a/tests/exl3_fungible/test_memory_preflight.py
+++ b/tests/exl3_fungible/test_memory_preflight.py
@@ -94,8 +94,19 @@ def test_flat_k3_matches_the_measured_boot():
 # constant of this system.
 #
 # MEASURED, at util 0.95 / eager / max_model_len 8192:
-#   budget 90.81 - weights 79.08 - KV 3.67 = 8.06 GiB of real overhead.
-OVERHEAD_MEASURED = 8.06
+#   budget 90.22 - weights 79.08 - KV 3.67 = 7.47 GiB of real overhead.
+#
+# The budget is the DEVICE total torch.cuda.mem_get_info reports (90.22 GiB
+# at util 0.95), not nvidia-smi's 90.81: using the latter over-charges the
+# projection by 0.6 GiB, which is a fifth of the KV cache on this box.
+OVERHEAD_MEASURED = 7.47
+DEVICE_BUDGET_GIB = 90.22
+# The loader calibrated dense at 11.40 GiB while sizing 19,456 experts (76
+# layers, including the MTP layer 78 that the DECISION domain excludes). These
+# tests model the 75-layer decision domain, so layer 78's experts move into
+# the dense term: 11.40 + 0.76 = 12.16 GiB. Same total footprint either way,
+# and the split has to be stated or the two views look like a discrepancy.
+DENSE_CALIBRATED = int(12.16 * GIB)
 # Retained only so the tests below still describe the boot that failed.
 OVERHEAD_WITH_RESIDUE = 9.19
 OVERHEAD_AFTER_RECLAIM = 5.27
@@ -128,21 +139,46 @@ def test_reclaiming_the_residue_alone_would_not_have_rescued_it_either():
     assert not p["fits"]
 
 
+def _project_device(n_k4, overhead=OVERHEAD_MEASURED, min_kv=2.0):
+    """Project against the device budget the loader itself sees."""
+    return project(
+        _bits(n_k4), SIZES, DENSE_CALIBRATED,
+        device_total_bytes=int(DEVICE_BUDGET_GIB * GIB),
+        gpu_memory_utilization=1.0,
+        runtime_overhead_bytes=int(overhead * GIB),
+        min_kv_bytes=int(min_kv * GIB),
+    )
+
+
 def test_measured_overhead_reproduces_the_observed_kv():
     """Known-answer against the boot that actually served: the fitted policy
-    (2,658 K4) at util 0.95 with the MEASURED 8.06 GiB overhead must land on
-    the 3.67 GiB of KV the engine reported."""
-    p = _project(2_658, util=0.95, overhead=OVERHEAD_MEASURED)
+    (2,658 K4) with the MEASURED overhead must land on the 3.67 GiB of KV the
+    engine reported."""
+    p = _project_device(2_658)
     assert p["weight_bytes"] / GIB == pytest.approx(79.08, abs=0.05)
     assert p["projected_kv_bytes"] / GIB == pytest.approx(3.67, abs=0.10)
+    assert p["fits"]
 
 
-def test_the_envelope_that_actually_fits_is_far_below_the_seeded_one():
-    """Under MEASURED overhead, clearing a 4 GiB KV floor needs ~2,350
-    promotions -- not the 5,206 the seeded policy asked for. The demo envelope
-    is set by the card, not by the 3.42bpw coder quant's shape."""
-    assert not _project(2_658, util=0.95, overhead=OVERHEAD_MEASURED)["fits"]
-    assert _project(2_300, util=0.95, overhead=OVERHEAD_MEASURED)["fits"]
+def test_the_floor_admits_the_boot_that_served_and_rejects_the_one_that_died():
+    """The floor's whole job. A 4 GiB floor -- which I picked out of the air --
+    would have rejected the policy that serves fine at 3.67 GiB / 73,024
+    tokens, while still catching the seeded policy that reached -3.1 GiB."""
+    assert _project_device(2_658, min_kv=2.0)["fits"]
+    assert not _project_device(2_658, min_kv=4.0)["fits"]   # the bad floor
+    assert not _project_device(5_126, min_kv=2.0)["fits"]   # the real failure
+
+
+def test_the_promotion_ceiling_this_card_actually_allows():
+    """Against the DEVICE budget and a defensible 2 GiB floor, the ceiling is
+    ~4,200 promotions: the fitted policy's 2,658 clears it comfortably and the
+    seeded 5,126 does not. An earlier claim of ~2,300 was wrong twice over --
+    it used nvidia-smi's total instead of the device budget, and a 4 GiB floor
+    I had invented rather than measured."""
+    assert _project_device(4_100)["fits"]
+    assert not _project_device(4_300)["fits"]
+    assert _project_device(2_658)["fits"]
+    assert not _project_device(5_126)["fits"]
 
 
 def test_remedy_is_expressed_in_experts_not_bytes():

--- a/tests/exl3_fungible/test_missing_k_cpu.py
+++ b/tests/exl3_fungible/test_missing_k_cpu.py
@@ -1,0 +1,677 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU tests for the "weight not available at the required K" contract.
+
+The operator requirement these pin: *a weight that is not available at the
+required K bpw must never crash the serve*. Preference order, in this file's
+terms:
+
+1. serve the requested K;
+2. else the nearest available LOWER K, said loudly, encode queued
+   (``FragmentResolver.resolve_best`` + the auto fallback ladder);
+3. else keep the incumbent tier — the pair drops out of the swap batch
+   (``SwapEngine.stage(on_unavailable="drop")``) or the whole apply is
+   downgraded to "not applied" (``FungibleQuantState._maybe_apply``);
+4. never raise into an engine loop.
+
+Every failure mode is injected with fakes: no network, no GPU, no model.
+Covered here: a resolver that has nothing, a resolver that has only a lower
+K, a source that times out, a corrupt local segment dir, an unwritable
+fragment cache, a mid-swap disappearance, an apply backend that throws, and
+the lazy-encode queue end to end (miss -> queue file -> drain command),
+including a torn/garbage queue file.
+"""
+import errno
+import json
+import logging
+import os
+import sys
+from contextlib import nullcontext
+from pathlib import Path
+
+import pytest
+
+_HERE = Path(__file__).resolve()
+# The gg rootfs carries a periodically-synced copy of the package in its
+# site-packages, so a direct ``python test_missing_k_cpu.py`` would grade
+# whatever was last copied there. Put the working tree first, exactly as the
+# pytest-from-repo-root invocation does, so both ways test the same code.
+sys.path.insert(0, str(_HERE.parents[2]))
+sys.path.insert(0, str(_HERE.parent))
+import test_fragments_cpu as tf  # noqa: E402
+import toy_segments as toy  # noqa: E402
+
+fr = tf.fr
+fq_swap = toy.load_tree_module("swap")
+
+try:
+    from vllm.model_executor.layers.quantization.exl3_fungible import (
+        lazy_encode as le,
+    )
+except ImportError:  # standalone run without a built vllm._C
+    le = toy.load_tree_module("lazy_encode")
+
+
+E = 8
+T0_GLOBALS = [0, 2, 4, 5, 6]  # K3 tier, slot order
+T1_GLOBALS = [3, 1, 7]        # K4 tier, slot order
+PLAN = fq_swap.SwapPlan([(toy.LAYER_ID, 1, 4)])  # e_out=1 K4->K3, e_in=4 up
+
+
+@pytest.fixture
+def fq_log():
+    """Records from the fragments logger (vllm loggers do not propagate)."""
+    records = []
+
+    class _Handler(logging.Handler):
+        def emit(self, record):
+            records.append(record)
+
+    handler = _Handler(level=logging.DEBUG)
+    old = fr.logger.level
+    fr.logger.addHandler(handler)
+    fr.logger.setLevel(logging.DEBUG)
+    yield records
+    fr.logger.removeHandler(handler)
+    fr.logger.setLevel(old)
+
+
+def _messages(records, level=None):
+    return [r.getMessage() for r in records
+            if level is None or r.levelno == level]
+
+
+# ============================================================ the resolver
+# ---------------------------------------------- 1. nothing can supply it
+
+
+def test_resolve_best_returns_none_when_nothing_has_it(tmp_path, fq_log):
+    """No local segment, no cache, no source, no other K: ``resolve_best``
+    reports None instead of raising, and the miss is queued for encode."""
+    d = tf.make_manifest_dir(tmp_path, layers=(3,), ks=())  # empty segment dir
+    queue_path = tmp_path / "queue.jsonl"
+    r = tf.resolver(d, tmp_path,
+                    environ={"VLLM_FQ_ENCODE_QUEUE": str(queue_path)})
+
+    assert r.resolve_best(3, 0, 4) is None
+    assert r.stats["unavailable"] == 1 and r.stats["encode_queued"] == 1
+    assert any("UNAVAILABLE" in m for m in _messages(fq_log))
+    assert any("keeping the incumbent tier" in m
+               for m in _messages(fq_log, logging.ERROR))
+    entries = le.EncodeQueue(queue_path).entries()
+    assert [(e["layer"], e["expert"], e["k"]) for e in entries] == [(3, 0, 4)]
+
+    # strict resolve() still raises — tooling keeps its fail-closed contract
+    with pytest.raises(fr.FragmentUnavailableError):
+        r.resolve(3, 0, 4)
+
+
+def test_resolve_best_survives_a_resolver_bug(tmp_path):
+    """Even an internal error is reported as "unavailable": nothing about a
+    fragment may reach the engine loop as an exception."""
+    d = tf.make_manifest_dir(tmp_path, layers=(3,), ks=(3,))
+    r = tf.resolver(d, tmp_path)
+
+    def boom(*_a, **_kw):
+        raise MemoryError("resolver bug")
+
+    r._resolve_k = boom  # noqa: SLF001
+    assert r.resolve_best(3, 0, 4) is None
+    assert r.stats["resolve_error"] == 1
+
+
+# ------------------------------------------- 2. only a lower K is present
+
+
+def test_auto_ladder_substitutes_the_nearest_lower_k(tmp_path, fq_log):
+    """Requested K5, only K2/K3 on disk: K3 (nearest lower) wins, the
+    substitution is logged loudly and the K5 encode is queued."""
+    d = tf.make_manifest_dir(tmp_path, layers=(3,), ks=(2, 3))
+    queue_path = tmp_path / "queue.jsonl"
+    r = tf.resolver(d, tmp_path,
+                    environ={"VLLM_FQ_ENCODE_QUEUE": str(queue_path)})
+
+    assert r.k_universe() == (2, 3)
+    assert r.fallback_ladder(5) == (3, 2)  # nearest lower first
+
+    frag = r.resolve_best(3, 1, 5)
+    assert frag is not None
+    assert frag.k == 3 and frag.requested_k == 5 and frag.substituted
+    assert r.stats["fallback_substituted"] == 1
+    loud = _messages(fq_log, logging.WARNING)
+    assert any("FQ DEGRADED L3/e1: K5 unavailable, serving K3" in m
+               for m in loud)
+    assert [(e["layer"], e["expert"], e["k"])
+            for e in le.EncodeQueue(queue_path).entries()] == [(3, 1, 5)]
+
+
+def test_auto_ladder_never_climbs_unless_asked(tmp_path):
+    """A higher K is not a safe substitute (more memory; on SM120 K5 does
+    not serve as a mixed tier at all), so upward substitution is opt-in."""
+    d = tf.make_manifest_dir(tmp_path, layers=(3,), ks=(4,))
+    r = tf.resolver(d, tmp_path)
+    assert r.fallback_ladder(3) == ()
+    assert r.resolve_best(3, 0, 3) is None
+
+    up = tf.resolver(d, tmp_path / "c2", cache_dir=tmp_path / "c2" / "cache",
+                     environ={"VLLM_FQ_K_FALLBACK_UP": "1"})
+    assert up.fallback_ladder(3) == (4,)
+    frag = up.resolve_best(3, 0, 3)
+    assert frag is not None and frag.k == 4 and frag.requested_k == 3
+
+
+def test_fallback_off_disables_substitution(tmp_path):
+    d = tf.make_manifest_dir(tmp_path, layers=(3,), ks=(3,))
+    r = tf.resolver(d, tmp_path, environ={"VLLM_FQ_K_FALLBACK": "off"})
+    assert r.fallback_ladder(4) == ()
+    assert r.resolve_best(3, 0, 4) is None
+
+
+def test_explicit_ladder_still_wins(tmp_path):
+    """An operator-listed ladder is honoured verbatim by both entry points
+    (that is the pre-existing VLLM_FQ_K_FALLBACK contract)."""
+    d = tf.make_manifest_dir(tmp_path, layers=(3,), ks=(2, 3))
+    r = tf.resolver(d, tmp_path, environ={"VLLM_FQ_K_FALLBACK": "2"})
+    assert r.fallback_ladder(4) == (2,)
+    assert r.resolve(3, 0, 4).k == 2
+    assert r.resolve_best(3, 0, 4).k == 2
+
+
+def test_available_k_probes_without_reading_payloads(tmp_path):
+    d = tf.make_manifest_dir(tmp_path, layers=(3,), ks=(3,))
+    r = tf.resolver(d, tmp_path)
+    assert r.available_k(3, 0, 3) == 3
+    assert r.available_k(3, 0, 4) == 3           # would be substituted
+    assert r.available_k(3, 0, 2) is None        # nothing lower than 2
+    assert r.available_k(9, 0, 3) is None        # unknown layer
+    assert r.available_k(3, 99, 3) is None       # unknown expert
+
+
+def test_project_bits_to_available_matches_what_boot_would_stream(tmp_path):
+    """The boot-side projection: a tier bitmap built from this cannot ask
+    for a K the resolver would have to substitute, which is what keeps a
+    degraded boot from failing a slab shape check instead of crashing."""
+    d = tf.make_manifest_dir(tmp_path, layers=(3,), ks=(3,))
+    r = tf.resolver(d, tmp_path)
+    lines = []
+    projected, subs, missing = fr.project_bits_to_available(
+        r, {3: [4, 3, 5, 3]}, log=lines.append)
+
+    assert projected == {3: [3, 3, 3, 3]}
+    assert subs == [(3, 0, 4, 3), (3, 2, 5, 3)]
+    assert missing == []
+    assert any("K4 unavailable -> K3" in m for m in lines)
+
+    # an expert nothing can supply is reported, not silently demoted
+    _p, _s, missing2 = fr.project_bits_to_available(r, {9: [4]})
+    assert missing2 == [(9, 0, 4)]
+
+
+# --------------------------------------------- 3. a source that times out
+
+
+class TimeoutSource:
+    """A mirror that hangs: every access raises, like a real HF timeout."""
+
+    def __init__(self, name="hf:slow/mirror", exc=None):
+        self.name = name
+        self.exc = exc or TimeoutError("timed out")
+        self.calls = 0
+
+    def _die(self, *_a, **_kw):
+        self.calls += 1
+        raise self.exc
+
+    read_json = read_text = read_range = _die
+
+
+def test_timing_out_source_degrades_to_the_local_lower_k(tmp_path, fq_log):
+    """A dead mirror must not be an exception path: it is one REJECT segment
+    in the decision chain, and the local K3 still serves the request."""
+    d = tf.make_manifest_dir(tmp_path, layers=(3,), ks=(3,))
+    src = TimeoutSource()
+    r = tf.resolver(d, tmp_path, sources=[src])
+
+    frag = r.resolve_best(3, 0, 4)
+    assert frag is not None and frag.k == 3 and frag.requested_k == 4
+    assert src.calls > 0 and r.stats["source_error"] > 0
+    assert any("REJECT error:TimeoutError" in m for m in _messages(fq_log))
+
+
+def test_timing_out_source_with_nothing_local_returns_none(tmp_path):
+    d = tf.make_manifest_dir(tmp_path, layers=(3,), ks=())
+    r = tf.resolver(d, tmp_path, sources=[TimeoutSource()])
+    assert r.resolve_best(3, 0, 4) is None
+    assert r.stats["unavailable"] == 1
+
+
+def test_corrupt_cached_header_is_not_a_fatal_error(tmp_path):
+    """Regression: the fragment-cache step's tensor-table lookup ran the
+    segment-header read unguarded, so a corrupt (or half-written) cached
+    header escaped ``resolve()`` as a raw JSONDecodeError — fatal at boot,
+    and *not* classified as droppable by the swap engine either."""
+    remote = tmp_path / "remote"
+    tf.write_segment(remote, 3, 4, seed=9)
+    d = tf.make_manifest_dir(tmp_path, layers=(3,), ks=(3,))
+
+    warm = tf.resolver(d, tmp_path, sources=[tf.FakeSource(remote)])
+    assert warm.resolve(3, 0, 4).origin == "fetched"  # populates the cache
+    headers = list((tmp_path / "cache" / "headers").glob("*.json"))
+    assert headers
+    for p in headers:
+        p.write_text("{not json")  # torn write of a cached header
+
+    cold = tf.resolver(d, tmp_path, sources=[tf.FakeSource(remote)])
+    frag = cold.resolve(3, 0, 4)  # strict path must not raise either
+    assert frag is not None and frag.k == 4
+    # and the poisoned entry self-heals rather than pinning the segment as
+    # unreadable for the rest of the process
+    assert cold.stats["cache_error"] > 0
+    assert json.loads(headers[0].read_text())  # rewritten, parseable again
+
+
+def test_mirror_that_dies_mid_header_is_droppable_not_fatal(tmp_path):
+    """A mirror that times out re-reading a segment header comes back as
+    "unavailable" (droppable supply failure), never as a raw TimeoutError
+    the swap engine would treat as structural and re-raise."""
+    remote = tmp_path / "remote"
+    tf.write_segment(remote, 3, 4, seed=9)
+    d = tf.make_manifest_dir(tmp_path, layers=(3,), ks=())
+
+    class DyingAfterIndex(tf.FakeSource):
+        """Serves the index (so the entry is found) but not the header."""
+
+        def read_range(self, relpath, start, end):
+            raise TimeoutError("mirror died mid-header")
+
+    r = tf.resolver(d, tmp_path, sources=[DyingAfterIndex(remote)])
+    assert r.resolve_best(3, 0, 4) is None
+    with pytest.raises(fr.FragmentUnavailableError):
+        r.resolve(3, 0, 4)
+    assert fq_swap.is_unavailable_error(fr.FragmentUnavailableError("x"))
+
+
+# ----------------------------------- 4. broken local dirs / unusable cache
+
+
+def test_corrupt_local_index_is_a_miss_not_a_crash(tmp_path, fq_log):
+    """A truncated index-k4.json used to escape as JSONDecodeError from
+    every caller of resolve(). It must degrade that dir to a miss."""
+    d = tf.make_manifest_dir(tmp_path, layers=(3,), ks=(3, 4))
+    (d / "index-k4.json").write_text('{"3": {"file": ')  # torn write
+
+    r = tf.resolver(d, tmp_path)
+    frag = r.resolve_best(3, 0, 4)
+    assert frag is not None and frag.k == 3  # fell back to the intact K3
+    assert r.stats["local_error"] == 1
+    assert any("unusable for L3 K4" in m
+               for m in _messages(fq_log, logging.WARNING))
+
+    # the strict entry point must not leak the parse error either
+    strict = tf.resolver(d, tmp_path / "c2", cache_dir=tmp_path / "c2" / "c",
+                         environ={"VLLM_FQ_K_FALLBACK": "3"})
+    assert strict.resolve(3, 0, 4).k == 3
+
+
+def test_segment_index_skew_is_a_miss_not_a_crash(tmp_path):
+    """index/segment body-offset skew is corruption of one dir, not of the
+    deployment: other Ks and other sources must still be reachable."""
+    d = tf.make_manifest_dir(tmp_path, layers=(3,), ks=(3, 4))
+    index = json.loads((d / "index-k4.json").read_text())
+    index["3"]["body_offset"] = int(index["3"]["body_offset"]) + 8
+    (d / "index-k4.json").write_text(json.dumps(index))
+
+    r = tf.resolver(d, tmp_path, environ={"VLLM_FQ_K_FALLBACK": "3"})
+    assert r.resolve(3, 0, 4).k == 3          # strict path: no ValueError
+    assert r.resolve_best(3, 0, 4).k == 3
+    assert r.stats["local_error"] == 1
+
+
+def test_unwritable_cache_still_serves_the_fetched_fragment(tmp_path):
+    """Disk full / read-only cache: the fragment was fetched and verified,
+    so it must be served. It used to be lost to an OSError from the cache
+    write, taking the boot or the swap with it."""
+    remote = tmp_path / "remote"
+    tf.write_segment(remote, 3, 4, seed=9)
+    d = tf.make_manifest_dir(tmp_path, layers=(3,), ks=(3,))
+    r = tf.resolver(d, tmp_path, sources=[tf.FakeSource(remote)])
+
+    def enospc(_path, _data):
+        raise OSError(errno.ENOSPC, "No space left on device")
+
+    r._atomic_write = enospc  # noqa: SLF001
+    frag = r.resolve(3, 0, 4)  # strict path: the fetch must not be lost
+    assert frag.k == 4 and frag.origin == "fetched"
+    assert r.stats["cache_write_error"] > 0
+    assert r.resolve_best(3, 0, 4).k == 4
+
+
+# ================================================= the live swap (M4 path)
+
+
+def make_engine(source, state, **kw):
+    kw.setdefault("expected_mcg", toy.MCG)
+    return fq_swap.SwapEngine(
+        {toy.LAYER_ID: state}, source,
+        hidden_size=toy.HIDDEN, intermediate_size=toy.INTERMEDIATE,
+        pin_memory=False, build_maps_fn=toy.build_maps_reference, **kw)
+
+
+class VanishingResolver:
+    """Wraps a real resolver; the named expert disappears at a chosen K.
+
+    Models the mid-swap disappearance: the plan was decided while the K4
+    fragment was reachable, and by staging time it is not."""
+
+    def __init__(self, inner, *, gone=(), mode="none"):
+        self.inner = inner
+        self.gone = set(gone)          # {(expert, k)}
+        self.mode = mode               # "none" | "raise"
+
+    def resolve_best(self, layer, expert, k, *, chain_out=None):
+        if (expert, k) in self.gone:
+            if chain_out is not None:
+                chain_out.append("local(1 dirs) MISS")
+            return None
+        return self.inner.resolve_best(layer, expert, k, chain_out=chain_out)
+
+    def resolve(self, layer, expert, k):
+        if (expert, k) in self.gone:
+            raise fr.FragmentUnavailableError(
+                f"L{layer}/e{expert} K{k}: vanished")
+        return self.inner.resolve(layer, expert, k)
+
+    def materialize(self, fragment, *, name_filter=None):
+        return self.inner.materialize(fragment, name_filter=name_filter)
+
+
+@pytest.fixture
+def segments(tmp_path):
+    import test_swap_resolver_cpu as tsr
+
+    root = tmp_path / "segments"
+    ckpt = tsr.make_segments(root)
+    return root, ckpt
+
+
+def test_midswap_disappearance_drops_the_pair_and_leaves_no_trace(
+        segments, tmp_path):
+    """The promotion target vanishes between decide and stage. With
+    ``drop`` the pair pends: no slab op, no map op, no ordering change, and
+    the layer is byte-identical to before. Fragment IO happens entirely
+    before ``apply`` opens the quiesce window, so there is no torn state to
+    roll back from in the first place."""
+    root, ckpt = segments
+    resolver = VanishingResolver(tf.resolver(root, tmp_path), gone={(4, 4)})
+    source = fq_swap.ResolverFragmentSource(resolver)
+    state = toy.cpu_layer_state(fq_swap, ckpt, T0_GLOBALS, T1_GLOBALS)
+    before = toy.cpu_layer_state(fq_swap, ckpt, T0_GLOBALS, T1_GLOBALS)
+    engine = make_engine(source, state)
+
+    staged = engine.stage(PLAN, on_unavailable="drop")
+    assert len(staged.plan) == 0 and staged.requested_plan == PLAN
+    assert staged.slab_ops == [] and staged.rotation_ops == []
+    assert staged.map_ops == [] and staged.staged_layers == []
+    assert [(d.swap, d.expert, d.k) for d in staged.dropped] == [
+        ((toy.LAYER_ID, 1, 4), 4, 4)]
+    assert source.unavailable == 1
+
+    report = engine.apply(staged=staged, quiesce=nullcontext())
+    assert report.pairs == 0 and len(report.dropped) == 1
+    assert state.tier0_globals == T0_GLOBALS
+    assert state.tier1_globals == T1_GLOBALS
+    toy.assert_states_equal(state, before)
+
+
+def test_midswap_disappearance_under_fail_atomic_rolls_back_cleanly(
+        segments, tmp_path):
+    """``fail_atomic`` reads each destination slot twice (new + pre-swap
+    content). A disappearance on the *undo* read must drop the pair just the
+    same — a half-filled staging buffer is never referenced by an op list,
+    and the next pair reuses (and fully overwrites) it."""
+    root, ckpt = segments
+    # (7, 4) is only read by the fail-atomic undo pass of the second pair
+    resolver = VanishingResolver(tf.resolver(root, tmp_path), gone={(7, 4)})
+    source = fq_swap.ResolverFragmentSource(resolver)
+    state = toy.cpu_layer_state(fq_swap, ckpt, T0_GLOBALS, T1_GLOBALS)
+    engine = make_engine(source, state, max_pairs=2)
+    plan = fq_swap.SwapPlan([(toy.LAYER_ID, 7, 6), (toy.LAYER_ID, 1, 4)])
+
+    staged = engine.stage(plan, fail_atomic=True, on_unavailable="drop")
+    assert staged.plan.swaps == ((toy.LAYER_ID, 1, 4),)
+    assert [d.swap for d in staged.dropped] == [(toy.LAYER_ID, 7, 6)]
+
+    engine.apply(staged=staged, quiesce=nullcontext())
+    # only the supplied pair moved; 7 keeps K4, 6 keeps K3 (cardinality D1)
+    toy.assert_states_equal(
+        state, toy.cpu_layer_state(fq_swap, ckpt, [0, 2, 1, 5, 6], [3, 4, 7]))
+    assert sorted(state.tier1_globals) == [3, 4, 7]
+
+
+def test_on_unavailable_default_is_operator_configurable(
+        segments, tmp_path, monkeypatch):
+    """One env knob makes every staging path pend instead of fail, so a
+    serve cannot lose an interval to a missing encode just because some
+    call site forgot to pass ``on_unavailable="drop"``."""
+    root, ckpt = segments
+    resolver = VanishingResolver(tf.resolver(root, tmp_path), gone={(4, 4)})
+    state = toy.cpu_layer_state(fq_swap, ckpt, T0_GLOBALS, T1_GLOBALS)
+    engine = make_engine(fq_swap.ResolverFragmentSource(resolver), state)
+
+    monkeypatch.delenv("VLLM_FQ_ON_UNAVAILABLE", raising=False)
+    with pytest.raises(fq_swap.FragmentUnavailable):
+        engine.stage(PLAN)  # fail-closed default preserved
+
+    monkeypatch.setenv("VLLM_FQ_ON_UNAVAILABLE", "drop")
+    staged = engine.stage(PLAN)
+    assert len(staged.plan) == 0 and len(staged.dropped) == 1
+    toy.assert_states_equal(
+        state, toy.cpu_layer_state(fq_swap, ckpt, T0_GLOBALS, T1_GLOBALS))
+
+    monkeypatch.setenv("VLLM_FQ_ON_UNAVAILABLE", "sideways")
+    with pytest.raises(ValueError, match="raise\\|drop"):
+        engine.stage(PLAN)
+
+
+def test_resolver_crash_during_staging_is_supply_not_structure(
+        segments, tmp_path):
+    """An OSError deep in the resolver (evicted cache, unreadable segment)
+    reaches ``read_expert`` as None through ``resolve_best``, i.e. as a
+    droppable supply failure rather than a fatal structural one."""
+    root, ckpt = segments
+    inner = tf.resolver(root, tmp_path)
+
+    def boom(*_a, **_kw):
+        raise OSError(errno.EIO, "I/O error")
+
+    inner._resolve_k = boom  # noqa: SLF001
+    state = toy.cpu_layer_state(fq_swap, ckpt, T0_GLOBALS, T1_GLOBALS)
+    engine = make_engine(fq_swap.ResolverFragmentSource(inner), state)
+
+    staged = engine.stage(PLAN, on_unavailable="drop")
+    assert len(staged.plan) == 0 and len(staged.dropped) == 1
+    assert inner.stats["resolve_error"] > 0
+
+
+# ==================================================== the interval (M2 loop)
+
+
+def _thrower(exc):
+    def apply_fn(_doc, _swaps):
+        raise exc
+    return apply_fn
+
+
+def _decision(state):
+    return json.loads(
+        next((state.store.root / "decisions").glob("*.json")).read_text())
+
+
+def test_apply_backend_failure_does_not_abort_the_interval(tmp_path):
+    """A swap engine that raises (missing fragment, unreachable mirror, an
+    aborted stage) must not take the interval down: the incumbent tiering
+    stays live, the decision is still explained and persisted, the proposal
+    lands in history for the out-of-band path, and the next interval
+    retries."""
+    import test_loop_cpu as tlc
+
+    state, routers = tlc.make_state(tmp_path, interval=4, apply_mode="reload")
+    state.apply_fn = _thrower(
+        fr.FragmentUnavailableError("L3/e4 K4: the encode has not landed"))
+    tier_before = state.tier_of.copy()
+    sha_before = state.policy_sha
+
+    tlc.drive_hot_interval(state, routers)  # must not raise
+
+    record = _decision(state)
+    assert record["swaps"], "fixture must actually propose swaps"
+    assert record["applied"] is False
+    assert record["apply_failures"] == 1 and state.apply_failures == 1
+    assert (state.tier_of == tier_before).all()
+    assert state.policy_sha == sha_before
+    assert list((state.store.root / "history").glob("*-proposed.json"))
+    # current.json — the running policy — was never advanced
+    current = json.loads((state.store.root / "current.json").read_text())
+    assert current["bits_per_expert"]["3"][4] == 3
+
+
+def test_apply_backend_failure_keeps_the_engine_stepping(tmp_path):
+    """The outermost guarantee: ``step()`` never propagates, and repeated
+    supply failures just accumulate on the counter."""
+    import test_loop_cpu as tlc
+
+    state, routers = tlc.make_state(tmp_path, interval=4, apply_mode="reload")
+    state.apply_fn = _thrower(RuntimeError("swap engine on fire"))
+    for _ in range(3):
+        tlc.drive_hot_interval(state, routers)
+    assert state.apply_failures == 3
+    assert state._intervals_run == 3  # noqa: SLF001
+
+
+# ================================================ the lazy-encode wiring
+
+
+def test_miss_lands_in_the_queue_file_and_drains_to_a_sane_command(tmp_path):
+    """End to end on CPU: a resolver miss appends to the persisted queue,
+    a second process reads it back, and drain renders the encoder command
+    for the layer that is actually missing."""
+    d = tf.make_manifest_dir(tmp_path, layers=(3,), ks=(3,))
+    queue_path = tmp_path / "encode-queue.jsonl"
+    r = tf.resolver(d, tmp_path, environ={
+        "VLLM_FQ_ENCODE_QUEUE": str(queue_path),
+        "VLLM_FQ_K_FALLBACK": "off"})
+    assert r.resolve_best(3, 2, 4) is None
+    assert queue_path.exists()
+
+    bf16 = tmp_path / "bf16"
+    bf16.mkdir()
+    (bf16 / "model.safetensors.index.json").write_text(json.dumps({
+        "weight_map": {
+            f"model.layers.3.mlp.experts.2.{proj}.weight": "s.safetensors"
+            for proj in ("gate_proj", "up_proj", "down_proj")}}))
+    capture = tmp_path / "capture" / "layer_003"
+    capture.mkdir(parents=True)
+    (capture / "h.pt").write_bytes(b"x")
+
+    lines = []
+    rc = le.drain(le.EncodeQueue(queue_path), dry_run=True, bf16_dir=bf16,
+                  capture_dir=capture.parent, out=lines.append)
+    assert rc == 0
+    assert len(lines) == 1
+    assert "L3/e2 K4" in lines[0] and "DRY-RUN OK" in lines[0]
+    assert "--bits 4" in lines[0] and "--layers 3" in lines[0]
+    assert str(bf16) in lines[0] and str(capture.parent) in lines[0]
+
+
+def test_drain_reports_missing_inputs_instead_of_encoding(tmp_path):
+    queue = le.EncodeQueue(tmp_path / "q.jsonl")
+    queue.enqueue(7, 1, 4, "unavailable")
+    lines = []
+    rc = le.drain(queue, dry_run=True, bf16_dir=None, capture_dir=None,
+                  out=lines.append)
+    assert rc == 1
+    assert "BLOCKED" in lines[0] and "bf16-dir unset" in lines[0]
+
+
+def test_corrupt_queue_file_does_not_crash_the_serve(tmp_path):
+    """A queue written by plain appends can be found torn, truncated or
+    byte-garbage. Loading must be total: keep what parses, count the rest,
+    and let the resolver keep enqueueing."""
+    path = tmp_path / "q.jsonl"
+    good = json.dumps({"layer": 3, "expert": 2, "k": 4, "reason": "x"})
+    path.write_bytes(
+        good.encode() + b"\n"
+        + b"not json at all\n"
+        + b'{"layer": 5, "expert": 1\n'          # torn append, no newline yet
+        + b'[1, 2, 3]\n'                          # valid json, wrong shape
+        + b'{"layer": "oops", "expert": 1, "k": 4}\n'
+        + b"\xff\xfe\x00binary garbage\n"
+    )
+    queue = le.EncodeQueue(path)
+    assert [(e["layer"], e["expert"], e["k"]) for e in queue.entries()] == [
+        (3, 2, 4)]
+    assert queue.corrupt_lines == 5
+
+    # still usable: appends land, dedup still holds
+    assert queue.enqueue(3, 2, 4, "again") == (1, False)
+    assert queue.enqueue(4, 0, 5, "unavailable") == (2, True)
+    assert len(le.EncodeQueue(path).entries()) == 2
+
+
+def test_unreadable_queue_degrades_to_empty(tmp_path):
+    """The queue path is a directory (or unreadable): a serve must boot."""
+    as_dir = tmp_path / "queue-is-a-dir"
+    as_dir.mkdir()
+    assert le.EncodeQueue(as_dir).entries() == []
+
+    d = tf.make_manifest_dir(tmp_path, layers=(3,), ks=(3,))
+    r = tf.resolver(d, tmp_path, environ={
+        "VLLM_FQ_ENCODE_QUEUE": str(as_dir), "VLLM_FQ_K_FALLBACK": "off"})
+    assert r.resolve_best(3, 0, 4) is None  # enqueue fails; resolve does not
+
+
+def test_drain_survives_a_bad_encoder_template(tmp_path):
+    queue = le.EncodeQueue(tmp_path / "q.jsonl")
+    queue.enqueue(3, 2, 4, "unavailable")
+    bf16 = tmp_path / "bf16"
+    bf16.mkdir()
+    (bf16 / "w.safetensors").write_bytes(b"x")
+    capture = tmp_path / "capture" / "layer_003"
+    capture.mkdir(parents=True)
+    (capture / "h.pt").write_bytes(b"x")
+
+    lines = []
+    rc = le.drain(queue, dry_run=True, bf16_dir=bf16,
+                  capture_dir=capture.parent, out=lines.append,
+                  encoder_cmd="encode --bits {k} --who {nonexistent_field}")
+    assert rc == 0
+    assert "{nonexistent_field}" in lines[0] and "--bits 4" in lines[0]
+
+
+def test_drain_survives_an_encoder_that_cannot_start(tmp_path):
+    queue = le.EncodeQueue(tmp_path / "q.jsonl")
+    queue.enqueue(3, 2, 4, "unavailable")
+    bf16 = tmp_path / "bf16"
+    bf16.mkdir()
+    (bf16 / "w.safetensors").write_bytes(b"x")
+    capture = tmp_path / "capture" / "layer_003"
+    capture.mkdir(parents=True)
+    (capture / "h.pt").write_bytes(b"x")
+
+    def missing_binary(_argv):
+        raise FileNotFoundError("no such encoder")
+
+    lines = []
+    rc = le.drain(queue, dry_run=False, bf16_dir=bf16,
+                  capture_dir=capture.parent, out=lines.append,
+                  runner=missing_binary)
+    assert rc == 1
+    assert any("FAILED FileNotFoundError" in m for m in lines)
+    assert len(le.EncodeQueue(tmp_path / "q.jsonl").entries()) == 1
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([
+        __file__, "-v", "-p", "no:cacheprovider",
+        "--confcutdir", os.path.dirname(os.path.abspath(__file__)),
+    ]))

--- a/tests/exl3_fungible/test_occupancy_table_cpu.py
+++ b/tests/exl3_fungible/test_occupancy_table_cpu.py
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the operator-facing expert-composition table."""
+from __future__ import annotations
+
+import pytest
+
+try:
+    from vllm.model_executor.layers.quantization.exl3_fungible import (
+        occupancy_table as ot,
+    )
+except ImportError:  # standalone: load by path (no compiled vllm._C needed)
+    import importlib.util
+    import sys
+    from pathlib import Path as _P
+
+    _dir = (_P(__file__).resolve().parents[2] / "vllm" / "model_executor"
+            / "layers" / "quantization" / "exl3_fungible")
+    _spec = importlib.util.spec_from_file_location(
+        "fq_occupancy_table_standalone", _dir / "occupancy_table.py")
+    ot = importlib.util.module_from_spec(_spec)
+    sys.modules[_spec.name] = ot
+    _spec.loader.exec_module(ot)
+
+
+def occ(**layers):
+    return {int(k[1:]): v for k, v in layers.items()}
+
+
+def test_renders_all_four_tier_columns_even_when_empty():
+    out = ot.render(occ(L3={3: 256}))
+    for k in (2, 3, 4, 5):
+        assert f"K{k}" in out
+    # a tier with no experts must show as 0, not vanish
+    assert "      0" in out
+
+
+def test_totals_row_sums_every_layer():
+    out = ot.render(occ(L3={3: 192, 5: 64}, L4={3: 200, 5: 56}))
+    assert "total" in out
+    assert "    392" in out  # 192+200
+    assert "    120" in out  # 64+56
+
+
+def test_mean_bits_is_computed_and_correct():
+    # 128 experts at K3, 128 at K5 -> mean exactly 4
+    out = ot.render(occ(L0={3: 128, 5: 128}))
+    assert "mean bits/expert: 4.0000" in out
+
+
+def test_change_column_shows_signed_per_tier_delta():
+    prev = occ(L3={3: 200, 5: 56})
+    cur = occ(L3={3: 192, 5: 64})
+    out = ot.render(cur, prev)
+    assert "-8 K3" in out and "+8 K5" in out
+
+
+def test_changed_layers_are_flagged():
+    prev = occ(L3={3: 256}, L4={3: 256})
+    cur = occ(L3={3: 250, 5: 6}, L4={3: 256})
+    out = ot.render(cur, prev)
+    rows = [l for l in out.splitlines() if l.strip().startswith("3")]
+    assert any("*" in r for r in rows)
+
+
+def test_diff_only_omits_unchanged_layers_but_totals_stay_complete():
+    prev = occ(L1={3: 256}, L2={3: 256}, L3={3: 256})
+    cur = occ(L1={3: 256}, L2={3: 256}, L3={3: 250, 5: 6})
+    out = ot.render(cur, prev, diff_only=True)
+    assert "2 unchanged layers omitted" in out
+    # totals must cover ALL layers, not just the shown one
+    assert "    762" in out  # 256+256+250
+
+
+def test_diff_only_with_no_changes_says_so_explicitly():
+    same = occ(L1={3: 256})
+    out = ot.render(same, same, diff_only=True)
+    assert "no tier changes" in out
+    # and still reports where things stand, so it is not mistaken for a fault
+    assert "K3=256" in out
+
+
+def test_mean_bits_delta_shown_against_previous():
+    prev = occ(L0={3: 256})
+    cur = occ(L0={3: 128, 5: 128})
+    out = ot.render(cur, prev)
+    assert "mean bits/expert: 4.0000 (+1.0000)" in out
+
+
+def test_empty_occupancy_does_not_crash():
+    assert "no MoE layers" in ot.render({})
+
+
+def test_row_cap_is_reported_not_silent():
+    big = {i: {3: 256} for i in range(200)}
+    out = ot.render(big, max_rows=10)
+    assert "more rows suppressed" in out
+    # totals still cover all 200 layers
+    assert str(200 * 256) in out
+
+
+def test_from_membership_counts_high_tier():
+    membership = [[True, False, False, True], [False, False, False, False]]
+    got = ot.from_membership(membership, [7, 8], bits=(3, 4))
+    assert got == {7: {3: 2, 4: 2}, 8: {3: 4, 4: 0}}
+
+
+def test_string_keys_are_accepted():
+    """Prometheus-derived dicts arrive with string layer/tier keys."""
+    out = ot.render({"3": {"3": 192, "5": 64}})
+    assert "192" in out and "64" in out
+
+
+@pytest.mark.parametrize("n", [1, 2, 3])
+def test_table_is_stable_width(n):
+    out = ot.render({i: {3: 256} for i in range(n)})
+    body = [l for l in out.splitlines() if l.startswith("  ") and "|" in l]
+    assert len({len(l.split("|")[1]) for l in body}) == 1

--- a/tests/exl3_fungible/test_policy_cpu.py
+++ b/tests/exl3_fungible/test_policy_cpu.py
@@ -1,0 +1,216 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+try:
+    from vllm.model_executor.layers.quantization.exl3_fungible import policy as fq
+except ImportError:  # standalone run against an env without built vllm._C
+    import importlib.util
+    from pathlib import Path as _P
+
+    _p = (_P(__file__).resolve().parents[2] / "vllm" / "model_executor"
+          / "layers" / "quantization" / "exl3_fungible" / "policy.py")
+    _s = importlib.util.spec_from_file_location("fq_policy_standalone", _p)
+    fq = importlib.util.module_from_spec(_s)
+    _s.loader.exec_module(fq)
+"""T2 — policy engine property tests (CPU, stdlib + numpy only).
+
+Covers research/fungible-quant/implementation/03-testing-validation.md T2:
+determinism, budget invariant, pin/dwell/cap/hysteresis respect, inverse
+property, and projection onto running cardinality. Runnable via pytest or as
+a plain script (``python3 test_fq_policy.py``).
+"""
+
+
+import numpy as np
+
+
+L, E = 6, 32  # small model: 6 MoE layers, 32 experts/layer
+
+
+def make_inputs(seed=0, n_k4=12, dwell_ready=True, pin_frac=0.0):
+    rng = np.random.default_rng(seed)
+    stats = {
+        "count": rng.integers(0, 5000, size=(L, E)).astype(np.float64),
+        "mass": rng.uniform(0.0, 50.0, size=(L, E)),
+    }
+    eps = {3: rng.uniform(0.02, 0.30, size=(L, E)),
+           4: rng.uniform(0.00, 0.02, size=(L, E))}  # eps3 > eps4: gains positive
+    tier_of = np.full((L, E), fq.K3, dtype=np.int64)
+    for l in range(L):
+        tier_of[l, rng.permutation(E)[:n_k4]] = fq.K4
+    pins = np.zeros((L, E), dtype=np.int64)
+    if pin_frac:
+        for l in range(L):
+            k4_ids = np.nonzero(tier_of[l] == fq.K4)[0]
+            k3_ids = np.nonzero(tier_of[l] == fq.K3)[0]
+            n = max(1, int(pin_frac * E / 2))
+            pins[l, rng.choice(k4_ids, n, replace=False)] = fq.PIN_K4
+            pins[l, rng.choice(k3_ids, n, replace=False)] = fq.PIN_K3
+    dwell = np.full((L, E), 10**9 if dwell_ready else 0, dtype=np.int64)
+    cfg = {"n_k4": n_k4, "dwell_steps": 6000, "hysteresis": 1.25,
+           "max_swaps_per_layer": 2, "max_swaps_total": 64}
+    return stats, eps, tier_of, pins, dwell, cfg
+
+
+def test_determinism():
+    for seed in range(5):
+        stats, eps, tier, pins, dwell, cfg = make_inputs(seed, pin_frac=0.1)
+        a = fq.decide(stats, eps, tier, pins, dwell, cfg)
+        b = fq.decide(stats, eps, tier, pins, dwell, cfg)
+        c = fq.decide({k: v.copy() for k, v in stats.items()},
+                      {k: v.copy() for k, v in eps.items()},
+                      tier.copy(), pins.copy(), dwell.copy(), dict(cfg))
+        assert a == b == c, f"non-deterministic decision at seed {seed}"
+        assert all(isinstance(x, int) for sw in a for x in sw)
+
+
+def test_budget_invariant_after_apply():
+    for seed in range(8):
+        stats, eps, tier, pins, dwell, cfg = make_inputs(seed, n_k4=10, pin_frac=0.1)
+        swaps = fq.decide(stats, eps, tier, pins, dwell, cfg)
+        new = fq.apply_swaps(tier, swaps)
+        assert (fq.n_k4_of(new) == cfg["n_k4"]).all(), "budget broken after apply"
+        assert set(np.unique(new)) <= {fq.K3, fq.K4}
+
+
+def test_pin_respect():
+    for seed in range(8):
+        stats, eps, tier, pins, dwell, cfg = make_inputs(seed, pin_frac=0.25)
+        swaps = fq.decide(stats, eps, tier, pins, dwell, cfg)
+        for l, e_out, e_in in swaps:
+            assert pins[l, e_out] != fq.PIN_K4, "pinned-K4 expert downgraded"
+            assert pins[l, e_in] != fq.PIN_K3, "pinned-K3 expert upgraded"
+        new = fq.apply_swaps(tier, swaps)
+        assert (new[pins == fq.PIN_K4] == fq.K4).all()  # were K4, stayed K4
+        assert (new[pins == fq.PIN_K3] == fq.K3).all()
+
+
+def test_pin_forced_entry():
+    # A pinned-K4 expert currently at K3 must be swapped in despite a low score.
+    stats, eps, tier, pins, dwell, cfg = make_inputs(3)
+    l = 0
+    e_pin = int(np.nonzero(tier[l] == fq.K3)[0][0])
+    pins[l, e_pin] = fq.PIN_K4
+    stats["count"][l, e_pin] = 0.0  # worst possible score
+    swaps = fq.decide(stats, eps, tier, pins, dwell, cfg)
+    assert any(sw[0] == l and sw[2] == e_pin for sw in swaps), "pin-forced entry missing"
+
+
+def test_dwell_respect():
+    for seed in range(5):
+        stats, eps, tier, pins, dwell, cfg = make_inputs(seed)
+        rng = np.random.default_rng(seed + 100)
+        young = rng.random((L, E)) < 0.5
+        dwell[young] = cfg["dwell_steps"] - 1
+        swaps = fq.decide(stats, eps, tier, pins, dwell, cfg)
+        for l, e_out, e_in in swaps:  # no pins here -> dwell is absolute
+            assert dwell[l, e_out] >= cfg["dwell_steps"], "young expert swapped out"
+            assert dwell[l, e_in] >= cfg["dwell_steps"], "young expert swapped in"
+    # All-young: no swaps at all.
+    stats, eps, tier, pins, dwell, cfg = make_inputs(0, dwell_ready=False)
+    assert fq.decide(stats, eps, tier, pins, dwell, cfg) == []
+
+
+def test_cap_respect():
+    stats, eps, tier, pins, dwell, cfg = make_inputs(1)
+    # Adversarial scores: make every K3 expert vastly outscore every K4 one.
+    eps = {3: np.where(tier == fq.K3, 10.0, 0.011), 4: np.full((L, E), 0.01)}
+    for per_layer, total in [(2, 64), (5, 64), (5, 7), (1, 3)]:
+        cfg2 = dict(cfg, max_swaps_per_layer=per_layer, max_swaps_total=total)
+        swaps = fq.decide(stats, eps, tier, pins, dwell, cfg2)
+        assert len(swaps) == min(L * per_layer, total), "caps not saturated"
+        per = {}
+        for l, _, _ in swaps:
+            per[l] = per.get(l, 0) + 1
+        assert max(per.values()) <= per_layer, "per-layer cap exceeded"
+
+
+def test_hysteresis_threshold_and_monotonicity():
+    # Entering expert outscores leaving by exactly 1.2x -> blocked at h=1.25,
+    # admitted at h=1.1.
+    stats = {"count": np.ones((L, E)), "mass": np.ones((L, E))}
+    eps = {3: np.full((L, E), 0.01 + 1.0), 4: np.full((L, E), 0.01)}
+    tier = np.full((L, E), fq.K3, dtype=np.int64)
+    tier[:, :12] = fq.K4
+    eps[3][:, 12] = 0.01 + 1.2  # candidate gain 1.2 vs incumbents' 1.0
+    dwell = np.full((L, E), 10**9)
+    pins = np.zeros((L, E), dtype=np.int64)
+    base = {"n_k4": 12, "dwell_steps": 0, "max_swaps_per_layer": 8,
+            "max_swaps_total": 640}
+    assert fq.decide(stats, eps, tier, pins, dwell, dict(base, hysteresis=1.25)) == []
+    admitted = fq.decide(stats, eps, tier, pins, dwell, dict(base, hysteresis=1.1))
+    assert len(admitted) == L and all(sw[2] == 12 for sw in admitted)
+    # Monotonicity on random positive-score inputs: raising h only removes swaps.
+    for seed in range(5):
+        stats, eps, tier, pins, dwell, cfg = make_inputs(seed)
+        prev = None
+        for h in (1.0, 1.25, 1.5, 2.0, 4.0):
+            cur = set(fq.decide(stats, eps, tier, pins, dwell, dict(cfg, hysteresis=h)))
+            if prev is not None:
+                assert cur <= prev, f"h={h} produced swaps absent at lower h"
+            prev = cur
+
+
+def test_inverse_restores_membership():
+    for seed in range(8):
+        stats, eps, tier, pins, dwell, cfg = make_inputs(seed, pin_frac=0.1)
+        swaps = fq.decide(stats, eps, tier, pins, dwell, cfg)
+        if seed == 0:
+            assert swaps, "want at least one non-empty swap list in this test"
+        restored = fq.apply_swaps(fq.apply_swaps(tier, swaps), fq.inverse(swaps))
+        assert (restored == tier).all(), "inverse did not restore membership"
+
+
+def test_projection_onto_running_cardinality():
+    rng = np.random.default_rng(42)
+    running = np.array([12, 12, 12, 8, 16, 12])
+    for policy_n in (6, 12, 20, 0, E):  # fewer, equal, more, extremes
+        bits = np.full((L, E), fq.K3, dtype=np.int64)
+        for l in range(L):
+            bits[l, rng.permutation(E)[:policy_n]] = fq.K4
+        order = rng.random((L, E))
+        proj = fq.project(bits, running, order)
+        assert (fq.n_k4_of(proj) == running).all(), "projection missed budget"
+        for l in range(L):
+            polk4 = set(np.nonzero(bits[l] == fq.K4)[0])
+            projk4 = set(np.nonzero(proj[l] == fq.K4)[0])
+            if policy_n >= running[l]:  # shrink: keep top-N of the policy's own K4s
+                assert projk4 <= polk4
+                keep = sorted(polk4, key=lambda e: (-order[l, e], e))[: running[l]]
+                assert projk4 == set(keep)
+            else:  # grow: keep all policy K4s, fill by the policy's ordering
+                assert polk4 <= projk4
+                fill = sorted(set(range(E)) - polk4,
+                              key=lambda e: (-order[l, e], e))[: running[l] - policy_n]
+                assert projk4 == polk4 | set(fill)
+        # Projected membership is a valid decide() input (D1 restored).
+        stats, eps, _, pins, dwell, cfg = make_inputs(7)
+        fq.decide(stats, eps, proj, pins, dwell, dict(cfg, n_k4=running))
+    # Equal-cardinality projection with the identity ordering is a no-op.
+    bits = np.full((L, E), fq.K3, dtype=np.int64)
+    bits[:, ::3] = fq.K4
+    n = int((bits[0] == fq.K4).sum())
+    assert (fq.project(bits, n) == bits).all()
+
+
+def test_decide_rejects_budget_mismatch():
+    stats, eps, tier, pins, dwell, cfg = make_inputs(0, n_k4=12)
+    try:
+        fq.decide(stats, eps, tier, pins, dwell, dict(cfg, n_k4=13))
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("decide accepted membership violating the budget")
+
+
+ALL_TESTS = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+
+if __name__ == "__main__":
+    failures = 0
+    for t in ALL_TESTS:
+        try:
+            t()
+            print(f"PASS {t.__name__}")
+        except Exception as exc:  # noqa: BLE001
+            failures += 1
+            print(f"FAIL {t.__name__}: {exc!r}")
+    sys.exit(1 if failures else 0)

--- a/tests/exl3_fungible/test_prefetch_cpu.py
+++ b/tests/exl3_fungible/test_prefetch_cpu.py
@@ -213,3 +213,45 @@ def test_offline_is_not_retried(monkeypatch, tmp_path):
     with pytest.raises(FR.OfflineError):
         src.read_range("seg.safetensors", 0, 16)
     assert calls["n"] == 1, f"offline refusal retried {calls['n']} times"
+
+
+# ------------------------------------------- bulk-fetch threshold (mixed layers)
+def _needed(bits, bulk_min=16):
+    """Which Ks a layer should bulk-fetch, mirroring progressive.py's rule."""
+    from collections import Counter
+    return sorted(k for k, n in Counter(bits).items() if n >= bulk_min)
+
+
+def test_uniform_layer_bulk_fetches_its_single_k():
+    assert _needed([3] * 256) == [3]
+
+
+def test_mixed_layer_bulk_fetches_BOTH_objects():
+    """The case the first version missed. A seeded policy makes most layers
+    mixed, and restricting bulk fetch to uniform layers skipped 48 of 75
+    layers outright — the optimisation did nothing for the majority."""
+    bits = [3] * 192 + [4] * 64
+    assert _needed(bits) == [3, 4], "a mixed layer draws from TWO objects"
+
+
+def test_single_upgraded_expert_does_not_drag_a_segment():
+    """One K4 expert is ~18 MiB; its segment is ~2.5 GB. Ranged read wins."""
+    bits = [3] * 255 + [4]
+    assert _needed(bits) == [3], "K4 must stay on the ranged path here"
+
+
+def test_threshold_is_the_boundary():
+    assert _needed([3] * 240 + [4] * 16, bulk_min=16) == [3, 4]
+    assert _needed([3] * 241 + [4] * 15, bulk_min=16) == [3]
+
+
+def test_request_count_for_a_realistic_mixed_layer():
+    """192xK3 + 64xK4: 2 object fetches, not 256 ranged reads."""
+    bits = [3] * 192 + [4] * 64
+    assert len(_needed(bits)) == 2
+    assert len(bits) == 256
+
+
+def test_all_four_tiers_in_one_layer_each_over_threshold():
+    bits = [2] * 64 + [3] * 64 + [4] * 64 + [5] * 64
+    assert _needed(bits) == [2, 3, 4, 5]

--- a/tests/exl3_fungible/test_prefetch_cpu.py
+++ b/tests/exl3_fungible/test_prefetch_cpu.py
@@ -145,3 +145,71 @@ def test_uniformity_predicate(bits, uniform):
     """The guard that stops a layer needing one K4 expert from dragging a
     whole segment."""
     assert (len(set(bits)) == 1) is uniform
+
+
+# --------------------------------------------------------------- offline mode
+def test_hf_hub_offline_blocks_every_network_read(monkeypatch):
+    """HF_HUB_OFFLINE must actually bind us.
+
+    We never route payload reads through huggingface_hub — only hf_hub_url to
+    build a string, then raw urllib — so the library's own offline handling
+    never applied. Before this, HF_HUB_OFFLINE=1 silently still hit the
+    network, which is the worst kind of wrong for an air-gapped or
+    reproducibility-audited run.
+    """
+    src = FR.HfSource("org/repo")
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    assert FR.HfSource.offline() is True
+    for call in (lambda: src.read_json("index-k3.json"),
+                 lambda: src.read_text("a.jsonl"),
+                 lambda: src.read_range("seg.safetensors", 0, 16)):
+        with pytest.raises(FR.OfflineError):
+            call()
+
+
+@pytest.mark.parametrize("val,off", [
+    ("1", True), ("true", True), ("YES", True), ("on", True),
+    ("0", False), ("", False), ("false", False),
+])
+def test_offline_truthiness(monkeypatch, val, off):
+    monkeypatch.delenv("FQ_ALLOW_NETWORK", raising=False)
+    monkeypatch.setenv("HF_HUB_OFFLINE", val)
+    assert FR.HfSource.offline() is off
+
+
+def test_transformers_offline_also_honoured(monkeypatch):
+    monkeypatch.delenv("HF_HUB_OFFLINE", raising=False)
+    monkeypatch.delenv("FQ_ALLOW_NETWORK", raising=False)
+    monkeypatch.setenv("TRANSFORMERS_OFFLINE", "1")
+    assert FR.HfSource.offline() is True
+
+
+def test_explicit_override_wins(monkeypatch):
+    """An operator who wants Hub access despite the global flag can say so."""
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    monkeypatch.setenv("FQ_ALLOW_NETWORK", "1")
+    assert FR.HfSource.offline() is False
+
+
+def test_offline_error_is_an_oserror_so_callers_treat_it_as_a_miss():
+    """Offline is a configuration, not a fault: the existing source-error
+    handling must degrade to 'this source has nothing' and let the K ladder
+    and the primed cache take over, not abort a boot."""
+    assert issubclass(FR.OfflineError, OSError)
+
+
+def test_offline_is_not_retried(monkeypatch, tmp_path):
+    """Retrying a configuration wastes four backoff sleeps per expert."""
+    src = FR.HfSource("org/repo")
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    calls = {"n": 0}
+    real_open = FR.HfSource._open
+
+    def counting_open(self, relpath, headers):
+        calls["n"] += 1
+        return real_open(self, relpath, headers)
+
+    monkeypatch.setattr(FR.HfSource, "_open", counting_open)
+    with pytest.raises(FR.OfflineError):
+        src.read_range("seg.safetensors", 0, 16)
+    assert calls["n"] == 1, f"offline refusal retried {calls['n']} times"

--- a/tests/exl3_fungible/test_prefetch_cpu.py
+++ b/tests/exl3_fungible/test_prefetch_cpu.py
@@ -34,6 +34,15 @@ except ImportError:  # standalone: load by path
 PAYLOAD = bytes(range(256)) * 512      # 128 KiB of known bytes
 
 
+def _progressive_src() -> str:
+    """Read progressive.py as TEXT. Importing it pulls in torch, which the
+    CPU test venv does not have (it lives in the GG rootfs) -- and these are
+    guard tests over code shape, so the text is exactly what we want."""
+    return (Path(__file__).resolve().parents[2] / "vllm" / "model_executor"
+            / "layers" / "quantization" / "exl3_fungible"
+            / "progressive.py").read_text()
+
+
 class FakeHTTP:
     """Minimal stand-in for the HF source: counts requests, can be flaky."""
 
@@ -269,3 +278,109 @@ def test_resolve_best_lets_systemexit_through():
     assert "SystemExit" in src, "resolve_best must re-raise shutdown signals"
     # and the re-raise must come BEFORE the broad catch, or it never runs
     assert src.index("SystemExit") < src.index("except BaseException")
+
+
+# ------------------------------------------- parallelism (depth x width)
+def test_mixed_layer_fetches_its_two_objects_CONCURRENTLY():
+    """A mixed layer draws from two segment objects. Submitting them as one
+    task ran them back to back, leaving the link idle between files even with
+    hf_transfer chunking inside each. One task PER (layer, K)."""
+    src = _progressive_src()
+    assert "_pool.submit(_fn, _layer, _k) for _k in _ks" in src, (
+        "the two Ks of a mixed layer must be submitted as separate tasks")
+    assert "_cf.wait_for_all" not in src, "stray module attribute assignment"
+
+
+def test_prefetch_depth_is_more_than_one_layer():
+    """One layer of lookahead only hides the download if it is faster than the
+    GPU load; with a real network it usually is not."""
+    src = _progressive_src()
+    assert "VLLM_FQ_PREFETCH_DEPTH" in src
+    assert "for _ahead in range(1, _depth + 1)" in src, (
+        "must keep `depth` layers in flight, not exactly one")
+
+
+def test_pipeline_is_primed_before_the_first_layer():
+    """Otherwise layer 0 fetches its Ks sequentially on the main thread with
+    nothing in flight yet -- the slowest possible start."""
+    src = _progressive_src()
+    assert "_sorted_layers[:_depth + 1]" in src
+
+
+# ------------------------------------------------------- bounded footprint
+def _resolver(tmp_path):
+    return FR.FragmentResolver(tmp_path / "manifest", sources=[],
+                              cache_dir=tmp_path / "cache")
+
+
+def test_release_layer_unlinks_our_own_prefetched_segments(tmp_path):
+    """Prefetch had NO eviction: _prefetched grew monotonically and nothing
+    unlinked, so a 75-layer boot left every segment it touched on disk. Depth
+    bounds lookahead; only release bounds FOOTPRINT."""
+    r = _resolver(tmp_path)
+    seg = r.cache_dir / "segments" / "abc.seg"
+    seg.parent.mkdir(parents=True, exist_ok=True)
+    seg.write_bytes(b"x" * 4096)
+    r._prefetched[(7, 3)] = seg
+    freed = r.release_layer(7)
+    assert freed == 4096
+    assert not seg.exists()
+    assert (7, 3) not in r._prefetched
+
+
+def test_release_layer_leaves_the_SHARED_hf_cache_alone(tmp_path):
+    """A blob the shared HF cache owns may be in use by another process."""
+    r = _resolver(tmp_path)
+    foreign = tmp_path / "hf-cache" / "blobs" / "deadbeef"
+    foreign.parent.mkdir(parents=True, exist_ok=True)
+    foreign.write_bytes(b"y" * 128)
+    r._prefetched[(9, 4)] = foreign
+    r.release_layer(9)
+    assert foreign.exists(), "unlinked a file outside our cache dir"
+
+
+def test_release_layer_only_touches_the_named_layer(tmp_path):
+    r = _resolver(tmp_path)
+    keep = r.cache_dir / "segments" / "keep.seg"
+    drop = r.cache_dir / "segments" / "drop.seg"
+    keep.parent.mkdir(parents=True, exist_ok=True)
+    keep.write_bytes(b"k")
+    drop.write_bytes(b"d")
+    r._prefetched[(3, 3)] = drop
+    r._prefetched[(4, 3)] = keep
+    r.release_layer(3)
+    assert not drop.exists() and keep.exists()
+    assert list(r._prefetched) == [(4, 3)]
+
+
+def test_keep_env_disables_eviction(tmp_path, monkeypatch):
+    """Repeat boots on a roomy box should be able to retain everything."""
+    monkeypatch.setenv("VLLM_FQ_PREFETCH_KEEP", "1")
+    r = _resolver(tmp_path)
+    seg = r.cache_dir / "segments" / "abc.seg"
+    seg.parent.mkdir(parents=True, exist_ok=True)
+    seg.write_bytes(b"z" * 16)
+    r._prefetched[(1, 3)] = seg
+    assert r.release_layer(1) == 0
+    assert seg.exists()
+
+
+def test_release_layer_survives_an_already_deleted_file(tmp_path):
+    r = _resolver(tmp_path)
+    r._prefetched[(2, 3)] = r.cache_dir / "segments" / "gone.seg"
+    assert r.release_layer(2) == 0          # no exception
+
+
+def test_progressive_releases_each_layer_after_it_streams():
+    src = _progressive_src()
+    assert "release_layer" in src, (
+        "layers must be released as they finish, or footprint is O(model)")
+
+
+def test_hf_download_lands_in_our_cache_so_it_can_be_evicted():
+    """hf_hub_download's default is the SHARED cache, which we must not
+    unlink -- so the file would be immortal. local_dir makes it ours."""
+    import inspect
+    src = inspect.getsource(FR.HfSource.prefetch_whole)
+    assert "local_dir" in src
+    assert "FQ_PREFETCH_HF_SHARED" in src, "the opt-out must exist"

--- a/tests/exl3_fungible/test_prefetch_cpu.py
+++ b/tests/exl3_fungible/test_prefetch_cpu.py
@@ -736,3 +736,79 @@ def test_keep_layers_retains_the_file_AND_the_prefetch_handle(tmp_path,
     assert seg.exists(), "kept layer was unlinked"
     assert r._prefetched.get((4, 4)) == seg, (
         "handle dropped: a later swap would re-download instead of slicing")
+
+
+# ------------------------------ transient faults must not permanently degrade
+class _FlakyOpen:
+    """Fails `fail_times` with a transient error, then succeeds."""
+
+    def __init__(self, payload: bytes, fail_times: int, exc=None):
+        import urllib.error
+        self.payload = payload
+        self.left = fail_times
+        self.calls = 0
+        self.exc = exc or urllib.error.URLError("Network is unreachable")
+
+    def __call__(self, relpath, headers):
+        self.calls += 1
+        if self.left > 0:
+            self.left -= 1
+            raise self.exc
+        import io
+        return io.BytesIO(self.payload)
+
+
+def test_attestation_fetch_retries_a_transient_network_error(monkeypatch):
+    """Ranged reads retried; whole-object reads did NOT, and the asymmetry
+    was expensive. One blip fetching an ATTESTATION is indistinguishable from
+    'this source has no attestation', so the expert is permanently degraded a
+    tier. Observed live: URLError(Errno 101) -> 'FQ DEGRADED L5/e2: K4
+    unavailable, serving K3 instead'."""
+    src = FR.HfSource("org/repo")
+    flaky = _FlakyOpen(b'{"ok": true}', fail_times=2)
+    monkeypatch.setattr(FR.HfSource, "_open", flaky)
+    monkeypatch.setattr(FR.HfSource, "_BACKOFF", 0.0)
+    assert src.read_json("index-k3.json") == {"ok": True}
+    assert flaky.calls == 3, "did not retry the transient failure"
+
+
+def test_read_text_retries_too(monkeypatch):
+    src = FR.HfSource("org/repo")
+    flaky = _FlakyOpen(b"line", fail_times=1)
+    monkeypatch.setattr(FR.HfSource, "_open", flaky)
+    monkeypatch.setattr(FR.HfSource, "_BACKOFF", 0.0)
+    assert src.read_text("attestations/layer-005.k4.jsonl") == "line"
+
+
+def test_a_404_is_a_miss_and_is_not_retried(monkeypatch):
+    """Absence is an answer, not a fault; retrying it wastes four backoffs
+    per expert."""
+    import urllib.error
+    src = FR.HfSource("org/repo")
+    calls = {"n": 0}
+
+    def not_found(self, relpath, headers):   # bound: a plain function gets self
+        calls["n"] += 1
+        raise urllib.error.HTTPError(relpath, 404, "nope", {}, None)
+
+    monkeypatch.setattr(FR.HfSource, "_open", not_found)
+    assert src.read_json("missing.json") is None
+    assert calls["n"] == 1
+
+
+def test_offline_is_not_retried_on_whole_object_reads(monkeypatch):
+    src = FR.HfSource("org/repo")
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    monkeypatch.delenv("FQ_ALLOW_NETWORK", raising=False)
+    with pytest.raises(FR.OfflineError):
+        src.read_json("index-k3.json")
+
+
+def test_exhausted_retries_raise_rather_than_report_absence(monkeypatch):
+    """The dangerous failure would be returning None: that reads as 'no
+    attestation' and silently downgrades the expert."""
+    src = FR.HfSource("org/repo")
+    monkeypatch.setattr(FR.HfSource, "_open", _FlakyOpen(b"x", fail_times=99))
+    monkeypatch.setattr(FR.HfSource, "_BACKOFF", 0.0)
+    with pytest.raises(OSError, match="after 4 attempts"):
+        src.read_json("index-k3.json")

--- a/tests/exl3_fungible/test_prefetch_cpu.py
+++ b/tests/exl3_fungible/test_prefetch_cpu.py
@@ -255,3 +255,17 @@ def test_request_count_for_a_realistic_mixed_layer():
 def test_all_four_tiers_in_one_layer_each_over_threshold():
     bits = [2] * 64 + [3] * 64 + [4] * 64 + [5] * 64
     assert _needed(bits) == [2, 3, 4, 5]
+
+
+# ------------------------------------------------- shutdown is not a failure
+def test_resolve_best_lets_systemexit_through():
+    """vLLM's multiproc executor raises SystemExit from its SIGTERM handler,
+    and on a progressive boot it lands mid-socket-read inside the resolver.
+    Catching BaseException swallowed it and logged 'fragment unavailable,
+    keeping the incumbent tier' — so a worker told to stop kept loading with
+    silently degraded tiers instead of exiting."""
+    import inspect
+    src = inspect.getsource(FR.FragmentResolver.resolve_best)
+    assert "SystemExit" in src, "resolve_best must re-raise shutdown signals"
+    # and the re-raise must come BEFORE the broad catch, or it never runs
+    assert src.index("SystemExit") < src.index("except BaseException")

--- a/tests/exl3_fungible/test_prefetch_cpu.py
+++ b/tests/exl3_fungible/test_prefetch_cpu.py
@@ -688,3 +688,21 @@ def test_declared_counters_still_report_zero(tmp_path):
     r = _resolver(tmp_path)
     assert r.stats["bytes_from_prefetch"] == 0
     assert "segments_prefetched" in r.stats
+
+
+def test_monitor_ignores_corpses_from_a_previous_boot(tmp_path):
+    """A killed boot leaves .incomplete files behind. Counting them as
+    in-flight made a HEALTHY boot report a frozen total at 0 MiB/s: two
+    corpses from an hour-old attempt summed to 880 MB and swamped a transfer
+    genuinely running at 308 MiB/s. Diagnosing that cost real time."""
+    root = tmp_path / "segments"
+    dl = root / ".cache" / "huggingface" / "download"
+    dl.mkdir(parents=True)
+    (dl / "corpse.incomplete").write_bytes(b"x" * 880)   # pre-existing
+
+    mon = FR._DownloadMonitor(root, every=0.05)          # baseline taken here
+    assert mon._progress() == (0, 0), "counted a corpse as in-flight"
+
+    (dl / "live.incomplete").write_bytes(b"y" * 100)
+    total, n = mon._progress()
+    assert (total, n) == (100, 1), "live file must be counted alone"

--- a/tests/exl3_fungible/test_prefetch_cpu.py
+++ b/tests/exl3_fungible/test_prefetch_cpu.py
@@ -617,3 +617,74 @@ def test_resolver_has_a_lock_for_its_memo_dicts(tmp_path):
     """Prefetch runs on a thread pool now; the memo dicts were written for a
     single thread."""
     assert hasattr(_resolver(tmp_path), "_memo_lock")
+
+
+def test_download_progress_is_monotonic_across_completions(tmp_path):
+    """Summing in-flight files is NOT progress. A completed file leaves the
+    .incomplete set, so the sum DROPS -- observed live as
+    'FQ downloads: 3 in flight, 1.8 GiB this boot, 0 MiB/s' while gigabytes
+    were genuinely transferring."""
+    root = tmp_path / "segments"
+    dl = root / ".cache" / "huggingface" / "download"
+    dl.mkdir(parents=True)
+    mon = FR._DownloadMonitor(root, every=0.05)
+
+    a = dl / "a.incomplete"
+    a.write_bytes(b"x" * 1000)
+    total1, n1 = mon._progress()
+    assert (total1, n1) == (1000, 1)
+
+    a.write_bytes(b"x" * 3000)                 # grew
+    total2, _ = mon._progress()
+    assert total2 == 3000
+
+    a.unlink()                                  # completed and renamed away
+    total3, n3 = mon._progress()
+    assert n3 == 0
+    assert total3 == 3000, f"progress went backwards: {total3}"
+
+    (dl / "b.incomplete").write_bytes(b"y" * 500)   # next file starts
+    total4, _ = mon._progress()
+    assert total4 == 3500, "completed bytes were dropped from the total"
+
+
+# ------------------------------------------- telemetry must not fail the fetch
+def test_every_incremented_stats_key_is_declared():
+    """THE regression. `self.stats["bytes_from_prefetch"] += len(payload)` was
+    added with the prefetch fast-path but never declared, and it sits on the
+    SUCCESS branch -- right after range_from_prefetched returns bytes. So a
+    KeyError fired exactly when the optimisation WORKED, was caught as a
+    source rejection, and dropped the expert down the K ladder: the better
+    prefetch performed, the more experts degraded to K2. 190 of them, on a
+    real boot, before anything said why."""
+    import re
+    src = (Path(__file__).resolve().parents[2] / "vllm" / "model_executor"
+           / "layers" / "quantization" / "exl3_fungible"
+           / "fragments.py").read_text()
+    used = set(re.findall(r'self\.stats\[\s*"([a-z0-9_]+)"\s*\]\s*\+?=', src))
+    init = src[src.index("self.stats = Counter({"):]
+    declared = set(re.findall(r'"([a-z0-9_]+)"\s*:\s*0', init[:init.index("})")]))
+    missing = sorted(used - declared)
+    assert not missing, f"incremented but never declared: {missing}"
+
+
+def test_stats_is_a_counter_so_a_missing_key_cannot_raise():
+    """Belt as well as braces: telemetry must never be able to fail the thing
+    it measures, even if a future counter is added without declaring it."""
+    src = (Path(__file__).resolve().parents[2] / "vllm" / "model_executor"
+           / "layers" / "quantization" / "exl3_fungible"
+           / "fragments.py").read_text()
+    assert "self.stats = Counter({" in src
+
+
+def test_undeclared_counter_increments_instead_of_raising(tmp_path):
+    r = _resolver(tmp_path)
+    r.stats["a_counter_nobody_declared"] += 5      # must not raise
+    assert r.stats["a_counter_nobody_declared"] == 5
+
+
+def test_declared_counters_still_report_zero(tmp_path):
+    """A Counter must not make declared metrics vanish from a scrape."""
+    r = _resolver(tmp_path)
+    assert r.stats["bytes_from_prefetch"] == 0
+    assert "segments_prefetched" in r.stats

--- a/tests/exl3_fungible/test_prefetch_cpu.py
+++ b/tests/exl3_fungible/test_prefetch_cpu.py
@@ -1,0 +1,147 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Whole-segment prefetch for uniform layers.
+
+A uniform layer's experts all live in one segment object. Fetching them
+per-expert is 256 HTTP round trips for one contiguous file — 19,200 across
+GLM-5.2's 75 layers — and each one is an independent chance to hit the
+transient failure that killed an earlier boot. These tests pin the two
+properties that make the optimisation safe rather than merely fast: the
+sliced bytes are IDENTICAL to the ranged bytes, and a prefetch that fails or
+returns something short must fall back to HTTP instead of serving garbage.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+try:
+    from vllm.model_executor.layers.quantization.exl3_fungible import (
+        fragments as FR,
+    )
+except ImportError:  # standalone: load by path
+    import importlib.util
+
+    _dir = (Path(__file__).resolve().parents[2] / "vllm" / "model_executor"
+            / "layers" / "quantization" / "exl3_fungible")
+    _spec = importlib.util.spec_from_file_location(
+        "fq_fragments_standalone", _dir / "fragments.py")
+    FR = importlib.util.module_from_spec(_spec)
+    sys.modules[_spec.name] = FR
+    _spec.loader.exec_module(FR)
+
+PAYLOAD = bytes(range(256)) * 512      # 128 KiB of known bytes
+
+
+class FakeHTTP:
+    """Minimal stand-in for the HF source: counts requests, can be flaky."""
+
+    name = "fake"
+
+    def __init__(self, blob: bytes, fail_whole: bool = False):
+        self.blob = blob
+        self.fail_whole = fail_whole
+        self.range_calls = 0
+        self.whole_calls = 0
+
+    # the two methods the resolver actually uses
+    def prefetch_whole(self, relpath, dest):
+        self.whole_calls += 1
+        if self.fail_whole:
+            return None
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(self.blob)
+        return dest
+
+    def range_from_prefetched(self, cached, start, end):
+        return FR.HttpSource.range_from_prefetched(self, cached, start, end) \
+            if hasattr(FR, "HttpSource") else _slice(cached, start, end)
+
+    def read_range(self, relpath, start, end):
+        self.range_calls += 1
+        return self.blob[start:end]
+
+
+def _slice(cached: Path, start: int, end: int):
+    try:
+        size = cached.stat().st_size
+        if end > size:
+            return None
+        with open(cached, "rb") as fh:
+            fh.seek(start)
+            data = fh.read(end - start)
+        return data if len(data) == end - start else None
+    except OSError:
+        return None
+
+
+def test_sliced_bytes_are_identical_to_ranged_bytes(tmp_path):
+    """The whole point: same bytes, fewer requests. If these ever diverge the
+    optimisation silently corrupts weights."""
+    src = FakeHTTP(PAYLOAD)
+    dest = tmp_path / "seg.bin"
+    src.prefetch_whole("layer-003.k3.safetensors", dest)
+    for start, end in ((0, 64), (1000, 4096), (len(PAYLOAD) - 32,
+                                               len(PAYLOAD))):
+        assert _slice(dest, start, end) == src.read_range("x", start, end)
+
+
+def test_prefetch_is_atomic_no_torn_file(tmp_path):
+    """A partially written segment must never be readable at its final path."""
+    dest = tmp_path / "deep" / "seg.bin"
+    FakeHTTP(PAYLOAD).prefetch_whole("x", dest)
+    assert dest.exists() and dest.stat().st_size == len(PAYLOAD)
+    assert not list(dest.parent.glob("*.part")), "temp file left behind"
+
+
+def test_slice_past_end_returns_none_so_caller_falls_back(tmp_path):
+    """A truncated or stale cached object must not serve short reads."""
+    dest = tmp_path / "seg.bin"
+    dest.write_bytes(PAYLOAD[:100])
+    assert _slice(dest, 0, 4096) is None
+
+
+def test_missing_cache_file_returns_none(tmp_path):
+    assert _slice(tmp_path / "nope.bin", 0, 16) is None
+
+
+def test_failed_prefetch_returns_none_not_an_exception(tmp_path):
+    """Prefetch is an optimisation; it must never fail a boot."""
+    src = FakeHTTP(PAYLOAD, fail_whole=True)
+    assert src.prefetch_whole("x", tmp_path / "seg.bin") is None
+
+
+def test_request_count_collapses_for_a_uniform_layer(tmp_path):
+    """256 experts from one object: 1 fetch, 0 ranged reads."""
+    src = FakeHTTP(PAYLOAD)
+    dest = tmp_path / "seg.bin"
+    src.prefetch_whole("layer-003.k3.safetensors", dest)
+    per_expert = len(PAYLOAD) // 256
+    for e in range(256):
+        got = _slice(dest, e * per_expert, (e + 1) * per_expert)
+        assert got is not None and len(got) == per_expert
+    assert src.whole_calls == 1
+    assert src.range_calls == 0, (
+        f"{src.range_calls} ranged reads leaked past the prefetch")
+
+
+def test_second_prefetch_reuses_the_cached_object(tmp_path):
+    src = FakeHTTP(PAYLOAD)
+    dest = tmp_path / "seg.bin"
+    src.prefetch_whole("x", dest)
+    first = src.whole_calls
+    # a real resolver checks dest.exists() before calling out again
+    assert dest.exists() and dest.stat().st_size > 0
+    assert first == 1
+
+
+@pytest.mark.parametrize("bits,uniform", [
+    ([3] * 256, True),
+    ([3] * 255 + [4], False),          # one K4 upgrade -> NOT uniform
+    ([4] * 256, True),
+])
+def test_uniformity_predicate(bits, uniform):
+    """The guard that stops a layer needing one K4 expert from dragging a
+    whole segment."""
+    assert (len(set(bits)) == 1) is uniform

--- a/tests/exl3_fungible/test_prefetch_cpu.py
+++ b/tests/exl3_fungible/test_prefetch_cpu.py
@@ -521,32 +521,15 @@ def test_async_prefetch_logs_its_result(tmp_path):
         "the async path must surface the prefetch note, not discard it")
 
 
-def test_download_monitor_reports_aggregate_progress(tmp_path):
-    """hf_hub_download gives ONE completion callback, not incremental ones, so
-    the primary path was a silent log. Watch the client's .incomplete files."""
-    root = tmp_path / "segments"
-    dl = root / ".cache" / "huggingface" / "download"
-    dl.mkdir(parents=True)
-    mon = FR._DownloadMonitor(root, every=0.05)
-    assert mon._scan() == (0, 0)
-    (dl / "a.incomplete").write_bytes(b"x" * 1024)
-    (dl / "b.incomplete").write_bytes(b"y" * 2048)
-    total, count = mon._scan()
-    assert (total, count) == (3072, 2), "must sum bytes across in-flight files"
 
 
-def test_monitor_ignores_completed_files(tmp_path):
-    """A finished download is not 'in flight'."""
-    root = tmp_path / "segments"
-    dl = root / ".cache" / "huggingface" / "download"
-    dl.mkdir(parents=True)
-    (dl / "done.safetensors").write_bytes(b"z" * 4096)
-    assert FR._DownloadMonitor(root, every=0.05)._scan() == (0, 0)
+
+
 
 
 def test_monitor_survives_a_missing_root(tmp_path):
     """It is telemetry; it must never fail a boot."""
-    assert FR._DownloadMonitor(tmp_path / "nope", every=0.05)._scan() == (0, 0)
+    assert FR._DownloadMonitor(tmp_path / "nope", every=0.05)._progress() == (0, 0)
 
 
 def test_monitor_is_a_singleton_per_process():
@@ -619,33 +602,7 @@ def test_resolver_has_a_lock_for_its_memo_dicts(tmp_path):
     assert hasattr(_resolver(tmp_path), "_memo_lock")
 
 
-def test_download_progress_is_monotonic_across_completions(tmp_path):
-    """Summing in-flight files is NOT progress. A completed file leaves the
-    .incomplete set, so the sum DROPS -- observed live as
-    'FQ downloads: 3 in flight, 1.8 GiB this boot, 0 MiB/s' while gigabytes
-    were genuinely transferring."""
-    root = tmp_path / "segments"
-    dl = root / ".cache" / "huggingface" / "download"
-    dl.mkdir(parents=True)
-    mon = FR._DownloadMonitor(root, every=0.05)
 
-    a = dl / "a.incomplete"
-    a.write_bytes(b"x" * 1000)
-    total1, n1 = mon._progress()
-    assert (total1, n1) == (1000, 1)
-
-    a.write_bytes(b"x" * 3000)                 # grew
-    total2, _ = mon._progress()
-    assert total2 == 3000
-
-    a.unlink()                                  # completed and renamed away
-    total3, n3 = mon._progress()
-    assert n3 == 0
-    assert total3 == 3000, f"progress went backwards: {total3}"
-
-    (dl / "b.incomplete").write_bytes(b"y" * 500)   # next file starts
-    total4, _ = mon._progress()
-    assert total4 == 3500, "completed bytes were dropped from the total"
 
 
 # ------------------------------------------- telemetry must not fail the fetch
@@ -690,19 +647,92 @@ def test_declared_counters_still_report_zero(tmp_path):
     assert "segments_prefetched" in r.stats
 
 
-def test_monitor_ignores_corpses_from_a_previous_boot(tmp_path):
-    """A killed boot leaves .incomplete files behind. Counting them as
-    in-flight made a HEALTHY boot report a frozen total at 0 MiB/s: two
-    corpses from an hour-old attempt summed to 880 MB and swamped a transfer
-    genuinely running at 308 MiB/s. Diagnosing that cost real time."""
+
+
+# ------------------------------------------- download progress (delivered bytes)
+def _mon(root):
+    return FR._DownloadMonitor(root, every=0.05)
+
+
+def test_progress_counts_delivered_segments_not_staging_size(tmp_path):
+    """Xet PREALLOCATES its .incomplete staging files, so their size never
+    changes during transfer. Watching that growth produced
+    '3 in flight, 12.1 GiB this boot, 0 MiB/s' forever -- four ranks cycling
+    four constant totals while the box pulled at 300+ MiB/s. Delivery is the
+    only signal preallocation cannot fake."""
     root = tmp_path / "segments"
     dl = root / ".cache" / "huggingface" / "download"
     dl.mkdir(parents=True)
-    (dl / "corpse.incomplete").write_bytes(b"x" * 880)   # pre-existing
+    m = _mon(root)
 
-    mon = FR._DownloadMonitor(root, every=0.05)          # baseline taken here
-    assert mon._progress() == (0, 0), "counted a corpse as in-flight"
+    big = dl / "preallocated.incomplete"
+    big.write_bytes(b"\0" * 4096)              # full size from the start
+    total, n = m._progress()
+    assert total == 0, "preallocated staging bytes must not count as progress"
+    assert n == 1, "but it IS in flight, and the count says so"
 
-    (dl / "live.incomplete").write_bytes(b"y" * 100)
-    total, n = mon._progress()
-    assert (total, n) == (100, 1), "live file must be counted alone"
+    (root / "layer-003.k3.safetensors").write_bytes(b"x" * 1000)
+    total, _ = m._progress()
+    assert total == 1000
+
+
+def test_delivered_survives_release_layer_unlinking_the_file(tmp_path):
+    """release_layer unlinking a segment is not un-delivering it; the series
+    must never go backwards."""
+    root = tmp_path / "segments"
+    root.mkdir(parents=True)
+    m = _mon(root)
+    f = root / "layer-003.k3.safetensors"
+    f.write_bytes(b"x" * 2048)
+    assert m._progress()[0] == 2048
+    f.unlink()
+    assert m._progress()[0] == 2048, "delivered bytes went backwards"
+
+
+def test_preexisting_segments_are_not_counted_as_this_boots_traffic(tmp_path):
+    root = tmp_path / "segments"
+    root.mkdir(parents=True)
+    (root / "old.safetensors").write_bytes(b"z" * 999)
+    m = _mon(root)                              # baseline taken here
+    assert m._progress()[0] == 0
+    (root / "new.safetensors").write_bytes(b"n" * 10)
+    assert m._progress()[0] == 10
+
+
+def test_a_segment_counted_once_not_on_every_scan(tmp_path):
+    root = tmp_path / "segments"
+    root.mkdir(parents=True)
+    m = _mon(root)
+    (root / "a.safetensors").write_bytes(b"x" * 500)
+    assert [m._progress()[0] for _ in range(3)] == [500, 500, 500]
+
+
+# ------------------------------------------------------------- keep layers
+def test_keep_layers_is_opt_in():
+    assert FR.FragmentResolver.keep_layers({}) is False
+
+
+@pytest.mark.parametrize("name", ["VLLM_FQ_KEEP_LAYERS", "VLLM_FQ_PREFETCH_KEEP"])
+def test_both_names_work(name):
+    """The old name stays an alias so existing runs do not silently change
+    behaviour."""
+    assert FR.FragmentResolver.keep_layers({name: "1"}) is True
+
+
+def test_keep_layers_retains_the_file_AND_the_prefetch_handle(tmp_path,
+                                                              monkeypatch):
+    """The point of keeping is the NEXT re-tiering: a K3->K4 promotion should
+    slice the new expert out of the local whole-layer object rather than
+    re-fetch ~2.5 GB. That needs the file on disk AND the _prefetched handle
+    that makes range_from_prefetched reachable -- keeping only the file would
+    leave the swap path fetching over the network anyway."""
+    monkeypatch.setenv("VLLM_FQ_KEEP_LAYERS", "1")
+    r = _resolver(tmp_path)
+    seg = r.cache_dir / "segments" / "layer-004.k4.safetensors"
+    seg.parent.mkdir(parents=True, exist_ok=True)
+    seg.write_bytes(b"w" * 4096)
+    r._prefetched[(4, 4)] = seg
+    assert r.release_layer(4) == 0
+    assert seg.exists(), "kept layer was unlinked"
+    assert r._prefetched.get((4, 4)) == seg, (
+        "handle dropped: a later swap would re-download instead of slicing")

--- a/tests/exl3_fungible/test_prefetch_cpu.py
+++ b/tests/exl3_fungible/test_prefetch_cpu.py
@@ -865,3 +865,40 @@ def test_reflink_falls_back_rather_than_failing(tmp_path, monkeypatch):
     dst = tmp_path / "c.bin"
     assert FR.FragmentResolver.reflink_or_copy(src, dst) == "plain copy"
     assert dst.read_bytes() == src.read_bytes()
+
+
+# ------------------------------------------- the unbounded fragment cache
+def test_fragment_cache_is_opt_outable():
+    assert FR.FragmentResolver.cache_fragments({}) is True
+    assert FR.FragmentResolver.cache_fragments(
+        {"VLLM_FQ_FRAGMENT_CACHE": "0"}) is False
+
+
+def test_prefetched_slices_are_not_re_cached():
+    """The per-expert fragment cache has NO eviction and a progressive boot
+    writes every expert through it: ~14 MiB x 256 = ~3.5 GiB per layer,
+    ~264 GiB for GLM-5.2. Measured live at 69 GiB by layer 21 of 75 on a box
+    with a 180 GiB floor -- it would have exhausted the disk mid-boot.
+
+    A slice of a prefetched segment is pure duplication: the segment IS the
+    cache, and it is already bounded by release_layer."""
+    import re
+    src = (Path(__file__).resolve().parents[2] / "vllm" / "model_executor"
+           / "layers" / "quantization" / "exl3_fungible"
+           / "fragments.py").read_text()
+    i = src.index("_cache_store(self._cache_fragment_path(sha), payload)")
+    guard = src[max(0, i - 400):i]
+    assert "if not from_prefetch" in guard, (
+        "prefetched slices must not be written to the fragment cache")
+
+
+def test_from_prefetch_is_set_only_on_the_slice_path():
+    src = (Path(__file__).resolve().parents[2] / "vllm" / "model_executor"
+           / "layers" / "quantization" / "exl3_fungible"
+           / "fragments.py").read_text()
+    assert "from_prefetch = False" in src
+    assert "from_prefetch = True" in src
+    # and the flag must be reset per expert, not leak across iterations
+    i = src.index("from_prefetch = False")
+    j = src.index("payload = None", max(0, i - 200))
+    assert abs(i - j) < 120, "from_prefetch must reset alongside payload"

--- a/tests/exl3_fungible/test_prefetch_cpu.py
+++ b/tests/exl3_fungible/test_prefetch_cpu.py
@@ -574,3 +574,46 @@ def test_monitor_thread_is_daemon_so_it_cannot_hang_shutdown():
         finally:
             m.stop()
             FR._DownloadMonitor._instance = None
+
+
+# ------------------------------------------------------ diagnosable rejections
+def test_reject_message_carries_the_exception_argument(tmp_path):
+    """`REJECT error:KeyError` named the TYPE and threw away the argument. A
+    boot that degraded 190 experts to K2 produced 270 identical contentless
+    lines, and the cause had to be reverse-engineered from the source. The key
+    IS the diagnosis."""
+    r = _resolver(tmp_path)
+    msg = r._reject("hf:org/repo", KeyError("expert 50 not in segment index "
+                                            "for layer-004.k4.safetensors"),
+                    "remote_tables")
+    assert "KeyError" in msg
+    assert "expert 50" in msg, f"argument dropped: {msg}"
+    assert "layer-004.k4.safetensors" in msg
+
+
+def test_reject_traces_once_per_site_not_per_expert(tmp_path):
+    """19,200 experts must not produce 19,200 stacks."""
+    r = _resolver(tmp_path)
+    for _ in range(5):
+        r._reject("hf:x", KeyError("k"), "remote_tables")
+    assert len(r._reject_traced) == 1
+    r._reject("hf:x", KeyError("k"), "att_decision")
+    assert len(r._reject_traced) == 2
+
+
+def test_reject_detail_is_bounded(tmp_path):
+    """A huge repr must not flood a boot log line."""
+    r = _resolver(tmp_path)
+    msg = r._reject("hf:x", ValueError("y" * 5000), "remote_index")
+    assert len(msg) < 300
+
+
+def test_reject_survives_an_exception_with_no_message(tmp_path):
+    r = _resolver(tmp_path)
+    assert "KeyError" in r._reject("hf:x", KeyError(), "remote_index")
+
+
+def test_resolver_has_a_lock_for_its_memo_dicts(tmp_path):
+    """Prefetch runs on a thread pool now; the memo dicts were written for a
+    single thread."""
+    assert hasattr(_resolver(tmp_path), "_memo_lock")

--- a/tests/exl3_fungible/test_prefetch_cpu.py
+++ b/tests/exl3_fungible/test_prefetch_cpu.py
@@ -384,3 +384,127 @@ def test_hf_download_lands_in_our_cache_so_it_can_be_evicted():
     src = inspect.getsource(FR.HfSource.prefetch_whole)
     assert "local_dir" in src
     assert "FQ_PREFETCH_HF_SHARED" in src, "the opt-out must exist"
+
+
+# --------------------------------------------- cross-rank sharing (TP ranks)
+def test_all_tp_ranks_want_the_SAME_segments():
+    """The premise, from a real TP4 boot log: every rank emitted
+    `FQ progressive layer 3: tiers=((3, 206), (4, 50)) bits_digest=d704612a2fdb`
+    -- identical composition, so identical segment objects. Four ranks racing
+    one file was 4x the bytes and 4x the transient disk."""
+    per_rank = [((3, 206), (4, 50))] * 4
+    assert len(set(per_rank)) == 1
+
+
+def test_segment_lock_serialises_downloads(tmp_path):
+    """Second holder must block while the first has the lock."""
+    import threading
+    r = _resolver(tmp_path)
+    dest = r.cache_dir / "segments" / "abc.seg"
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    entered = threading.Event()
+    release = threading.Event()
+    order = []
+
+    def first():
+        with r._segment_lock(dest):
+            order.append("first-in")
+            entered.set()
+            release.wait(5)
+            order.append("first-out")
+
+    t = threading.Thread(target=first)
+    t.start()
+    assert entered.wait(5)
+    r2 = _resolver(tmp_path)
+
+    def second():
+        with r2._segment_lock(dest):
+            order.append("second-in")
+
+    t2 = threading.Thread(target=second)
+    t2.start()
+    t2.join(0.5)
+    assert "second-in" not in order, "lock did not exclude the second holder"
+    release.set()
+    t.join(5)
+    t2.join(5)
+    assert order == ["first-in", "first-out", "second-in"]
+
+
+def test_lock_timeout_falls_through_rather_than_failing_the_boot(tmp_path):
+    """A wedged rank must not hang a boot forever; a duplicate download is
+    wasteful, not incorrect, because the rename is atomic."""
+    r = _resolver(tmp_path)
+    dest = r.cache_dir / "segments" / "abc.seg"
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    with r._segment_lock(dest):
+        r2 = _resolver(tmp_path)
+        with r2._segment_lock(dest, timeout=0.2) as held:
+            assert held is False        # fell through, did not raise
+
+
+def test_segment_ready_finds_the_hf_local_dir_name(tmp_path):
+    """hf_hub_download with local_dir writes to dest.parent/relpath, NOT to
+    dest. Checking only dest made every rank re-download a file the HF client
+    had already placed."""
+    r = _resolver(tmp_path)
+    dest = r.cache_dir / "segments" / "sha.seg"
+    hf = dest.parent / "layer-003.k3.safetensors"
+    hf.parent.mkdir(parents=True, exist_ok=True)
+    hf.write_bytes(b"payload")
+    assert r._segment_ready(dest, "layer-003.k3.safetensors") == hf
+    assert r._segment_ready(dest, "other.safetensors") is None
+
+
+def test_release_does_not_unlink_while_another_rank_holds_it(tmp_path):
+    """The race this refcount exists for: rank 0 finishing layer 3 must not
+    delete a segment rank 2 is still reading -- that would silently demote
+    rank 2 to 18.2 s-per-expert ranged reads."""
+    seg = tmp_path / "cache" / "segments" / "shared.seg"
+    seg.parent.mkdir(parents=True, exist_ok=True)
+    seg.write_bytes(b"z" * 512)
+    rank0, rank2 = _resolver(tmp_path), _resolver(tmp_path)
+    rank0._claim_segment(seg)
+    # a live OTHER pid also holds it (pid 1 always exists)
+    (rank0._users_dir(seg) / "1").touch()
+    rank0._prefetched[(3, 3)] = seg
+    rank0.release_layer(3)
+    assert seg.exists(), "unlinked a segment another rank still holds"
+    # once the other claim is gone, the next release frees it
+    (rank2._users_dir(seg) / "1").unlink()
+    rank2._prefetched[(3, 3)] = seg
+    rank2.release_layer(3)
+    assert not seg.exists()
+
+
+def test_stale_claim_from_a_killed_rank_does_not_pin_disk(tmp_path):
+    """This box is preemptible. A killed worker's marker must not keep a
+    segment resident forever."""
+    seg = tmp_path / "cache" / "segments" / "s.seg"
+    seg.parent.mkdir(parents=True, exist_ok=True)
+    seg.write_bytes(b"q" * 64)
+    r = _resolver(tmp_path)
+    r._claim_segment(seg)
+    (r._users_dir(seg) / "999999").touch()   # pid that cannot exist
+    r._prefetched[(5, 3)] = seg
+    r.release_layer(5)
+    assert not seg.exists(), "a dead rank's marker pinned the segment"
+
+
+def test_progressive_uses_emit_not_a_module_logger():
+    """progressive.py has NO module logger -- it uses a local _emit() because
+    the CPU tests load this file standalone. Two logger.info() calls added for
+    download verbosity raised `NameError: name 'logger' is not defined` inside
+    the weight iterator and killed all four TP workers mid-boot."""
+    import re
+    src = _progressive_src()
+    bare = re.findall(r"(?<![\w.])logger\.\w+\(", src)
+    assert not bare, f"progressive.py has no logger; found {bare}"
+
+
+def test_download_verbosity_still_present():
+    """...but the fix must not be 'delete the logging'."""
+    src = _progressive_src()
+    assert "waiting on background" in src
+    assert "1 fetch instead of" in src

--- a/tests/exl3_fungible/test_prefetch_cpu.py
+++ b/tests/exl3_fungible/test_prefetch_cpu.py
@@ -508,3 +508,69 @@ def test_download_verbosity_still_present():
     src = _progressive_src()
     assert "waiting on background" in src
     assert "1 fetch instead of" in src
+
+
+# ------------------------------------------------- download-progress visibility
+def test_async_prefetch_logs_its_result(tmp_path):
+    """Background prefetch is now the COMMON path, and it discarded
+    prefetch_layer's return value -- so 'cached', 'shared (fetched by another
+    rank)' and 'prefetched ... from <source>' never reached the log. Only the
+    sync fallback reported anything."""
+    src = _progressive_src()
+    assert "_note = _fut.result()" in src, (
+        "the async path must surface the prefetch note, not discard it")
+
+
+def test_download_monitor_reports_aggregate_progress(tmp_path):
+    """hf_hub_download gives ONE completion callback, not incremental ones, so
+    the primary path was a silent log. Watch the client's .incomplete files."""
+    root = tmp_path / "segments"
+    dl = root / ".cache" / "huggingface" / "download"
+    dl.mkdir(parents=True)
+    mon = FR._DownloadMonitor(root, every=0.05)
+    assert mon._scan() == (0, 0)
+    (dl / "a.incomplete").write_bytes(b"x" * 1024)
+    (dl / "b.incomplete").write_bytes(b"y" * 2048)
+    total, count = mon._scan()
+    assert (total, count) == (3072, 2), "must sum bytes across in-flight files"
+
+
+def test_monitor_ignores_completed_files(tmp_path):
+    """A finished download is not 'in flight'."""
+    root = tmp_path / "segments"
+    dl = root / ".cache" / "huggingface" / "download"
+    dl.mkdir(parents=True)
+    (dl / "done.safetensors").write_bytes(b"z" * 4096)
+    assert FR._DownloadMonitor(root, every=0.05)._scan() == (0, 0)
+
+
+def test_monitor_survives_a_missing_root(tmp_path):
+    """It is telemetry; it must never fail a boot."""
+    assert FR._DownloadMonitor(tmp_path / "nope", every=0.05)._scan() == (0, 0)
+
+
+def test_monitor_is_a_singleton_per_process():
+    """Four TP ranks are four processes, but N resolvers in ONE process must
+    not spawn N threads all logging the same numbers."""
+    FR._DownloadMonitor._instance = None
+    import tempfile
+    with tempfile.TemporaryDirectory() as d:
+        a = FR._DownloadMonitor.ensure(Path(d))
+        b = FR._DownloadMonitor.ensure(Path(d))
+        try:
+            assert a is b
+        finally:
+            a.stop()
+            FR._DownloadMonitor._instance = None
+
+
+def test_monitor_thread_is_daemon_so_it_cannot_hang_shutdown():
+    FR._DownloadMonitor._instance = None
+    import tempfile
+    with tempfile.TemporaryDirectory() as d:
+        m = FR._DownloadMonitor.ensure(Path(d))
+        try:
+            assert m._thread is not None and m._thread.daemon
+        finally:
+            m.stop()
+            FR._DownloadMonitor._instance = None

--- a/tests/exl3_fungible/test_prefetch_cpu.py
+++ b/tests/exl3_fungible/test_prefetch_cpu.py
@@ -11,6 +11,7 @@ returns something short must fall back to HTTP instead of serving garbage.
 """
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 
@@ -812,3 +813,55 @@ def test_exhausted_retries_raise_rather_than_report_absence(monkeypatch):
     monkeypatch.setattr(FR.HfSource, "_BACKOFF", 0.0)
     with pytest.raises(OSError, match="after 4 attempts"):
         src.read_json("index-k3.json")
+
+
+# ------------------------------------------------- local first, then reflink
+def test_prefetch_skips_the_network_when_the_layer_is_already_local(tmp_path,
+                                                                    monkeypatch):
+    """prefetch_layer consulted only the REMOTE sources, so a layer sitting in
+    a local segment dir was re-downloaded from the Hub -- paying network and
+    disk for bytes already present. Nothing needs reflinking here because
+    nothing needs copying: the local segment is mmapped in place."""
+    r = _resolver(tmp_path)
+    sentinel = object()
+
+    class _Seg:
+        pass
+
+    monkeypatch.setattr(type(r), "_local_segment",
+                        lambda self, base, layer, k: _Seg())
+    r.sources = [pytest.fail]          # touching a source is the failure
+    note = r.prefetch_layer(4, 4)
+    assert note is not None and note.startswith("local ")
+    assert r.stats["segments_local"] == 1
+    assert sentinel is not None
+
+
+def test_reflink_shares_extents_and_reports_what_happened(tmp_path):
+    """os.copy_file_range may SILENTLY do a plain copy, so the return value
+    reports the mechanism rather than claiming a reflink we cannot verify."""
+    src = tmp_path / "seg.bin"
+    src.write_bytes(b"x" * (1 << 20))
+    dst = tmp_path / "clone.bin"
+    how = FR.FragmentResolver.reflink_or_copy(src, dst)
+    assert dst.read_bytes() == src.read_bytes(), "clone must be byte-identical"
+    assert how in ("reflink/copy_file_range", "plain copy")
+
+
+def test_reflink_leaves_no_temp_behind(tmp_path):
+    src = tmp_path / "a.bin"
+    src.write_bytes(b"y" * 4096)
+    dst = tmp_path / "sub" / "b.bin"
+    FR.FragmentResolver.reflink_or_copy(src, dst)
+    assert dst.exists()
+    assert not list(dst.parent.glob("*.rl*")), "temp file left behind"
+
+
+def test_reflink_falls_back_rather_than_failing(tmp_path, monkeypatch):
+    """An unsupported filesystem must degrade to a copy, not an error."""
+    monkeypatch.delattr(os, "copy_file_range", raising=False)
+    src = tmp_path / "a.bin"
+    src.write_bytes(b"z" * 2048)
+    dst = tmp_path / "c.bin"
+    assert FR.FragmentResolver.reflink_or_copy(src, dst) == "plain copy"
+    assert dst.read_bytes() == src.read_bytes()

--- a/tests/exl3_fungible/test_progressive_cpu.py
+++ b/tests/exl3_fungible/test_progressive_cpu.py
@@ -162,12 +162,37 @@ def test_rank_filter(tmp_path):
     assert "model.layers.3.mlp.gate.weight" in tensors
 
 
-def test_missing_segment_k_fails_loudly(tmp_path):
+def test_missing_segment_k_degrades_instead_of_killing_the_boot(tmp_path):
+    """A requested K with no fragment must fall back, not abort the engine.
+
+    This asserts the OPPOSITE of what it used to. The old contract raised on
+    the first miss, and on the real model that meant one absent expert out of
+    19,200 (a transient IncompleteRead on layer 3 expert 19) took down the
+    whole engine at boot — the least acceptable place to die, since boot is
+    exactly when fragments are most likely to be missing. Degrading to the
+    nearest available K and logging it is the point of the K ladder.
+    """
     seg_dir = make_manifest_dir(tmp_path, layers=(3,), ks=(3,))  # no k4
     spec = make_spec(tmp_path, make_policy({"3": [4, 3, 3, 3]}),
                      seg_dir=seg_dir)
     resolver = spec.make_resolver(cache_dir=tmp_path / "cache", environ={})
-    with pytest.raises(Exception, match="k4"):
+    out = list(pg.progressive_weights_iterator(spec, resolver))
+    assert out, "expected a weight stream, not an empty one"
+    # expert 0 asked for k4, only k3 exists -> it is served at k3
+    names = [n for n, _ in out]
+    assert any("experts.0." in n for n in names), (
+        "the degraded expert must still be materialized")
+
+
+def test_no_fragment_at_any_k_still_fails_loudly(tmp_path):
+    """Degrading is not the same as pretending. If NOTHING can supply an
+    expert at any K, that is unservable and must be reported, naming how many
+    experts are affected rather than just the first."""
+    seg_dir = make_manifest_dir(tmp_path, layers=(3,), ks=())  # nothing at all
+    spec = make_spec(tmp_path, make_policy({"3": [4, 3, 3, 3]}),
+                     seg_dir=seg_dir)
+    resolver = spec.make_resolver(cache_dir=tmp_path / "cache", environ={})
+    with pytest.raises(Exception, match="no fragment at ANY K|ANY K"):
         list(pg.progressive_weights_iterator(spec, resolver))
 
 

--- a/tests/exl3_fungible/test_progressive_cpu.py
+++ b/tests/exl3_fungible/test_progressive_cpu.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """CPU tests for the progressive weights stream + boot metadata synthesis."""
+import hashlib
 import json
 import struct
 
@@ -108,12 +109,166 @@ def make_spec(tmp_path, policy, *, seg_dir=None, dense=None):
     )
 
 
+def test_committed_policy_overrides_boot_policy_on_restart(tmp_path):
+    seg_dir = make_manifest_dir(tmp_path, layers=(3,), ks=(2, 4))
+    dense = make_dense_source(tmp_path, source_k=2)
+    manifest_hash = hashlib.sha256(
+        (seg_dir / "fq-manifest.json").read_bytes()).hexdigest()
+    boot = make_policy({"3": [4, 2, 2, 2]})
+    boot["manifest"] = manifest_hash
+    committed = make_policy({"3": [2, 4, 2, 2]})
+    committed["manifest"] = manifest_hash
+    policy_path = tmp_path / "boot-policy.json"
+    policy_path.write_text(json.dumps(boot))
+    policy_cache = tmp_path / "policy-cache"
+    current = (
+        policy_cache / "fq" / "policy" / manifest_hash / "current.json"
+    )
+    current.parent.mkdir(parents=True)
+    current.write_text(json.dumps(committed))
+
+    spec = pg.ProgressiveSpec.from_env(
+        dense,
+        environ={
+            pg.FQ_CACHE_ENV: str(tmp_path / "fragment-cache"),
+            "VLLM_FQ_CACHE_ROOT": str(policy_cache),
+        },
+        overrides={
+            "manifest_dir": str(seg_dir),
+            "policy": str(policy_path),
+            "dense_source": str(dense),
+        },
+    )
+
+    assert spec.policy["bits_per_expert"] == committed["bits_per_expert"]
+    assert spec.policy_path is None
+    tensors, _ = stream(spec, tmp_path)
+    for expert, k in enumerate(committed["bits_per_expert"]["3"]):
+        name = (
+            f"model.layers.3.mlp.experts.{expert}.gate_proj.rank0.trellis"
+        )
+        assert tuple(tensors[name].shape) == (2, 2, 16 * k)
+
+
+def test_committed_policy_uses_loop_default_cache_not_fragment_cache(
+    tmp_path, monkeypatch
+):
+    seg_dir = make_manifest_dir(tmp_path, layers=(3,), ks=(2, 4))
+    dense = make_dense_source(tmp_path, source_k=2)
+    manifest_hash = hashlib.sha256(
+        (seg_dir / "fq-manifest.json").read_bytes()).hexdigest()
+    boot = make_policy({"3": [4, 2, 2, 2]})
+    boot["manifest"] = manifest_hash
+    committed = make_policy({"3": [2, 4, 2, 2]})
+    committed["manifest"] = manifest_hash
+    policy_path = tmp_path / "boot-policy.json"
+    policy_path.write_text(json.dumps(boot))
+    home = tmp_path / "home"
+    current = (
+        home / ".cache" / "vllm" / "fq" / "policy"
+        / manifest_hash / "current.json"
+    )
+    current.parent.mkdir(parents=True)
+    current.write_text(json.dumps(committed))
+    monkeypatch.setenv("HOME", str(home))
+
+    spec = pg.ProgressiveSpec.from_env(
+        dense,
+        environ={pg.FQ_CACHE_ENV: str(tmp_path / "fragment-cache")},
+        overrides={
+            "manifest_dir": str(seg_dir),
+            "policy": str(policy_path),
+            "dense_source": str(dense),
+        },
+    )
+
+    assert spec.policy["bits_per_expert"] == committed["bits_per_expert"]
+    assert spec.policy_path is None
+
+
+def test_policy_store_only_boot_uses_manifest_file_digest(tmp_path):
+    seg_dir = make_manifest_dir(tmp_path, layers=(3,), ks=(2, 4))
+    dense = make_dense_source(tmp_path, source_k=2)
+    manifest_hash = hashlib.sha256(
+        (seg_dir / "fq-manifest.json").read_bytes()).hexdigest()
+    committed = make_policy({"3": [2, 4, 2, 2]})
+    committed["manifest"] = manifest_hash
+    policy_cache = tmp_path / "policy-cache"
+    current = (
+        policy_cache / "fq" / "policy" / manifest_hash / "current.json"
+    )
+    current.parent.mkdir(parents=True)
+    current.write_text(json.dumps(committed))
+
+    spec = pg.ProgressiveSpec.from_env(
+        dense,
+        environ={"VLLM_FQ_CACHE_ROOT": str(policy_cache)},
+        overrides={
+            "manifest_dir": str(seg_dir),
+            "dense_source": str(dense),
+        },
+    )
+
+    assert spec.policy["bits_per_expert"] == committed["bits_per_expert"]
+    assert spec.policy_path is None
+
+
+def test_boot_policy_rejects_unsafe_manifest_identity(tmp_path):
+    seg_dir = make_manifest_dir(tmp_path, layers=(3,), ks=(2, 4))
+    dense = make_dense_source(tmp_path, source_k=2)
+    policy = make_policy({"3": [2, 4, 2, 2]})
+    policy["manifest"] = "../../outside"
+    policy_path = tmp_path / "policy.json"
+    policy_path.write_text(json.dumps(policy))
+
+    with pytest.raises(ValueError, match="invalid policy manifest identity"):
+        pg.ProgressiveSpec.from_env(
+            dense,
+            environ={"VLLM_FQ_CACHE_ROOT": str(tmp_path / "policy-cache")},
+            overrides={
+                "manifest_dir": str(seg_dir),
+                "policy": str(policy_path),
+                "dense_source": str(dense),
+            },
+        )
+
+
 def stream(spec, tmp_path, tp_rank=None):
     resolver = spec.make_resolver(cache_dir=tmp_path / "cache", environ={})
     logs = []
     out = list(pg.progressive_weights_iterator(
         spec, resolver, tp_rank=tp_rank, log=logs.append))
     return dict(out), logs
+
+
+def test_boot_policy_projects_fallback_before_bitmap_sizing(tmp_path):
+    seg_dir = make_manifest_dir(tmp_path, layers=(3,), ks=(3,))
+    policy = make_policy({"3": [4, 3, 3, 4]})
+    spec = make_spec(tmp_path, policy, seg_dir=seg_dir)
+    resolver = spec.make_resolver(
+        cache_dir=tmp_path / "cache", environ={}
+    )
+
+    effective, substitutions = pg.project_boot_policy(policy, resolver)
+
+    assert effective["bits_per_expert"] == {"3": [3, 3, 3, 3]}
+    assert effective["budget"]["n_k4_per_layer"] == {"3": 0}
+    assert len(substitutions) == 2
+    assert effective["provenance"]["boot_projection"]["substitutions"] == 2
+
+
+def test_boot_projection_refuses_a_third_runtime_tier():
+    class Resolver:
+        @staticmethod
+        def available_k(layer, expert, k, *, network=True):
+            del layer, network
+            return 3 if expert == 1 and k == 4 else k
+
+    with pytest.raises(ValueError, match="non-binary mixed layers"):
+        pg.project_boot_policy(
+            make_policy({"3": [2, 4, 4, 2]}),
+            Resolver(),
+        )
 
 
 def test_mixed_stream_matches_policy(tmp_path):

--- a/tests/exl3_fungible/test_progressive_cpu.py
+++ b/tests/exl3_fungible/test_progressive_cpu.py
@@ -1,0 +1,241 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU tests for the progressive weights stream + boot metadata synthesis."""
+import json
+import struct
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+try:
+    from vllm.model_executor.layers.quantization.exl3_fungible import (
+        progressive as pg,
+    )
+except ImportError:  # standalone run against an env without built vllm._C
+    import importlib.util
+    import sys as _sys
+    from pathlib import Path as _P
+
+    _p = (_P(__file__).resolve().parents[2] / "vllm" / "model_executor"
+          / "layers" / "quantization" / "exl3_fungible" / "progressive.py")
+    _s = importlib.util.spec_from_file_location("fq_progressive_standalone", _p)
+    pg = importlib.util.module_from_spec(_s)
+    _sys.modules[_s.name] = pg
+    _s.loader.exec_module(pg)
+
+from test_fragments_cpu import (  # noqa: E402
+    NUM_EXPERTS,
+    PROJS,
+    RANKS,
+    _expert_tensors,
+    make_manifest_dir,
+    write_segment,
+)
+
+
+def _write_safetensors(path, tensors):
+    """tensors: list of (name, dtype, shape, data-bytes)."""
+    header, blobs, off = {}, [], 0
+    for name, dtype, shape, data in tensors:
+        header[name] = {"dtype": dtype, "shape": list(shape),
+                        "data_offsets": [off, off + len(data)]}
+        blobs.append(data)
+        off += len(data)
+    hj = json.dumps(header, separators=(",", ":")).encode()
+    hj += b" " * ((8 - len(hj) % 8) % 8)
+    path.write_bytes(struct.pack("<Q", len(hj)) + hj + b"".join(blobs))
+
+
+def make_dense_source(tmp_path, moe_layers=(3,), source_k=3):
+    """Mini rank-sliced checkpoint: one dense shard + MoE layer shards whose
+    expert tensors are the K{source_k} encodings."""
+    d = tmp_path / "dense-src"
+    d.mkdir()
+    _write_safetensors(d / "model-layer-000.safetensors", [
+        ("model.layers.0.input_layernorm.weight", "BF16", (8,), bytes(16)),
+        ("model.layers.0.mlp.weight", "BF16", (4, 4), bytes(32)),
+    ])
+    for layer in moe_layers:
+        tensors = [
+            (f"model.layers.{layer}.input_layernorm.weight", "BF16", (8,),
+             bytes(range(16))),
+            (f"model.layers.{layer}.mlp.gate.weight", "F32", (2, 2),
+             struct.pack("<4f", 1, 2, 3, 4)),
+        ]
+        for expert in range(NUM_EXPERTS):
+            tensors.extend(_expert_tensors(layer, expert, source_k, seed=0))
+        _write_safetensors(d / f"model-layer-{layer:03d}.safetensors", tensors)
+    (d / "config.json").write_text(json.dumps({
+        "hybrid_tr3_tail": {
+            "format": "exl3-trellis",
+            "bits": float(source_k),
+            "codebook": "mcg",
+            "exllamav3_version": "0.0.43",
+            "moe_layers": [min(moe_layers), max(moe_layers)],
+            "experts_per_layer": NUM_EXPERTS,
+            "tensor_schema": ("model.layers.{L}.mlp.experts.{E}.{proj}"
+                              ".rank{r}.{trellis|suh|svh|mcg}"),
+            "tp": RANKS,
+        },
+    }))
+    return d
+
+
+def make_policy(bits_by_layer):
+    return {
+        "schema": "fq-policy/2",
+        "manifest": "test",
+        "budget": {"mode": "fixed_cardinality",
+                   "n_k4_per_layer": {L: sum(b == 4 for b in bits)
+                                      for L, bits in bits_by_layer.items()}},
+        "bits_per_expert": bits_by_layer,
+        "pinned": {},
+        "provenance": {"parent": "test"},
+    }
+
+
+def make_spec(tmp_path, policy, *, seg_dir=None, dense=None):
+    seg_dir = seg_dir or make_manifest_dir(tmp_path, layers=(3,), ks=(3, 4))
+    dense = dense or make_dense_source(tmp_path)
+    policy_path = tmp_path / "policy.json"
+    policy_path.write_text(json.dumps(policy))
+    return pg.ProgressiveSpec.from_env(
+        dense,
+        environ={},
+        overrides={"manifest_dir": str(seg_dir), "policy": str(policy_path),
+                   "dense_source": str(dense)},
+    )
+
+
+def stream(spec, tmp_path, tp_rank=None):
+    resolver = spec.make_resolver(cache_dir=tmp_path / "cache", environ={})
+    logs = []
+    out = list(pg.progressive_weights_iterator(
+        spec, resolver, tp_rank=tp_rank, log=logs.append))
+    return dict(out), logs
+
+
+def test_mixed_stream_matches_policy(tmp_path):
+    bits = [4, 3, 3, 4]
+    spec = make_spec(tmp_path, make_policy({"3": bits}))
+    tensors, logs = stream(spec, tmp_path)
+
+    # dense tensors pass through from the source shards
+    assert "model.layers.0.mlp.weight" in tensors
+    assert "model.layers.3.mlp.gate.weight" in tensors
+
+    # every expert tensor is present and its trellis width follows the policy
+    for expert, k in enumerate(bits):
+        for proj in PROJS:
+            for rank in range(RANKS):
+                name = (f"model.layers.3.mlp.experts.{expert}.{proj}"
+                        f".rank{rank}.trellis")
+                assert tuple(tensors[name].shape) == (2, 2, 16 * k), name
+    # name-set parity with the source shard
+    n_expert_tensors = NUM_EXPERTS * len(PROJS) * RANKS * 4
+    assert len(tensors) == 4 + n_expert_tensors
+    assert any("tiers=((3, 2), (4, 2))" in line for line in logs)
+
+
+def test_all_k3_stream_is_byte_identical_to_source(tmp_path):
+    """The K3 segments are a repack of the source shard: an all-K3 policy
+    must reproduce the source expert bytes exactly (fq_assemble's
+    byte-identity property, now on the stream)."""
+    spec = make_spec(tmp_path, make_policy({"3": [3] * NUM_EXPERTS}))
+    tensors, _ = stream(spec, tmp_path)
+    from test_fragments_cpu import _expert_tensors as et
+    for expert in range(NUM_EXPERTS):
+        for name, dtype, shape, data in et(3, expert, 3, seed=0):
+            got = tensors[name]
+            assert bytes(got.contiguous().view(torch.uint8).flatten()
+                         .numpy().tobytes()) == data, name
+
+
+def test_rank_filter(tmp_path):
+    bits = [4, 3, 3, 4]
+    spec = make_spec(tmp_path, make_policy({"3": bits}))
+    tensors, _ = stream(spec, tmp_path, tp_rank=1)
+    expert_names = [n for n in tensors if ".experts." in n]
+    assert expert_names and all(".rank1." in n for n in expert_names)
+    # dense tensors are never rank-filtered
+    assert "model.layers.3.mlp.gate.weight" in tensors
+
+
+def test_missing_segment_k_fails_loudly(tmp_path):
+    seg_dir = make_manifest_dir(tmp_path, layers=(3,), ks=(3,))  # no k4
+    spec = make_spec(tmp_path, make_policy({"3": [4, 3, 3, 3]}),
+                     seg_dir=seg_dir)
+    resolver = spec.make_resolver(cache_dir=tmp_path / "cache", environ={})
+    with pytest.raises(Exception, match="k4"):
+        list(pg.progressive_weights_iterator(spec, resolver))
+
+
+def test_policy_layer_coverage_enforced(tmp_path):
+    seg_dir = make_manifest_dir(tmp_path, layers=(3,), ks=(3,))
+    manifest = json.loads((seg_dir / "fq-manifest.json").read_text())
+    manifest["moe_layers"] = [3, 4]
+    (seg_dir / "fq-manifest.json").write_text(json.dumps(manifest))
+    with pytest.raises(ValueError, match="missing MoE layers"):
+        make_spec(tmp_path, make_policy({"3": [3] * NUM_EXPERTS}),
+                  seg_dir=seg_dir)
+
+
+# ------------------------------------------------------- boot metadata
+
+
+def test_synthesize_hf_overrides_mixed(tmp_path):
+    dense = make_dense_source(tmp_path)
+    policy = make_policy({"3": [4, 3, 3, 4]})
+    bitmap = tmp_path / "bitmap.json"
+    pg.write_tier_bitmap(policy, bitmap)
+    ov = pg.synthesize_hf_overrides(dense, policy, bitmap)
+
+    tail = ov["hybrid_tr3_tail"]
+    assert tail["bits"] == "mixed"
+    assert tail["k_values"] == [3, 4]
+    ref_file, field = tail["bits_per_expert"].rsplit(":", 1)
+    assert field == "bits_per_expert"
+    payload = json.loads(open(ref_file).read())
+    assert payload["3"]["bits_per_expert"] == [4, 3, 3, 4]
+    # untouched contract keys survive the patch
+    assert tail["tensor_schema"].startswith("model.layers.{L}")
+    assert tail["tp"] == RANKS
+
+    stub = ov["quantization_config"]
+    assert stub["quant_method"] == "exl3" and stub["bits"] == "mixed"
+
+
+def test_synthesize_hf_overrides_uniform_and_existing_stub(tmp_path):
+    dense = make_dense_source(tmp_path)
+    cfg_path = dense / "config.json"
+    cfg = json.loads(cfg_path.read_text())
+    cfg["quantization_config"] = {"quant_method": "exl3", "bits": 3.0}
+    cfg_path.write_text(json.dumps(cfg))
+
+    policy = make_policy({"3": [3] * NUM_EXPERTS})
+    ov = pg.synthesize_hf_overrides(dense, policy, tmp_path / "b.json",
+                                    extra={"use_index_cache": True})
+    tail = ov["hybrid_tr3_tail"]
+    assert tail["bits"] == 3.0
+    assert "k_values" not in tail and "bits_per_expert" not in tail
+    assert "quantization_config" not in ov  # source already has one
+    assert ov["use_index_cache"] is True
+
+
+def test_spec_source_fallback_streams_missing_k(tmp_path):
+    """Local dir has only K3; K4 arrives via the sources chain."""
+    from test_fragments_cpu import FakeSource
+
+    remote_root = tmp_path / "remote"
+    write_segment(remote_root, 3, 4, seed=0)
+    seg_dir = make_manifest_dir(tmp_path, layers=(3,), ks=(3,))
+    spec = make_spec(tmp_path, make_policy({"3": [4, 3, 3, 4]}),
+                     seg_dir=seg_dir)
+    resolver = spec.make_resolver(
+        cache_dir=tmp_path / "cache", environ={},
+        sources=[FakeSource(remote_root)])
+    tensors = dict(pg.progressive_weights_iterator(spec, resolver))
+    name = "model.layers.3.mlp.experts.0.gate_proj.rank0.trellis"
+    assert tuple(tensors[name].shape) == (2, 2, 16 * 4)
+    assert resolver.stats["fetched"] == 2  # experts 0 and 3 at K4

--- a/tests/exl3_fungible/test_stats_cpu.py
+++ b/tests/exl3_fungible/test_stats_cpu.py
@@ -121,14 +121,17 @@ def test_summary_shape():
 
 def test_capture_fn_source_has_no_host_ops():
     """Static discipline check: the capture path must never call host-sync
-    ops (graph-safety contract, 01 §2)."""
+    ops (graph-safety contract, 01 §2). Both variants — count-only and
+    the weighted gate-mass path — are checked."""
     c = make_collector()
     c.bind_router(0, FakeRouter())
-    src = inspect.getsource(c.make_capture_fn.__code__.co_consts[
-        [i for i, k in enumerate(c.make_capture_fn.__code__.co_consts)
-         if getattr(k, "co_name", "") == "_capture"][0]])
-    for banned in (".item(", ".cpu(", ".tolist(", ".numpy(", "print("):
-        assert banned not in src, f"host op {banned} in capture path"
+    bodies = [k for k in c.make_capture_fn.__code__.co_consts
+              if getattr(k, "co_name", "") == "_capture"]
+    assert len(bodies) == 2, "expected count-only and weighted variants"
+    for body in bodies:
+        src = inspect.getsource(body)
+        for banned in (".item(", ".cpu(", ".tolist(", ".numpy(", "print("):
+            assert banned not in src, f"host op {banned} in capture path"
 
 
 def test_out_of_range_ids_are_dropped_not_scattered():
@@ -150,7 +153,12 @@ def test_out_of_range_ids_are_dropped_not_scattered():
 
 
 def test_weighted_capture_redirects_oor_to_overflow_slot():
-    """The scatter (weighted) path keeps the explicit overflow slot."""
+    """The scatter (weighted) mass path keeps the explicit overflow slot.
+
+    Count is the same histc in both modes (so enabling mass cannot move
+    the count signal), which drops OOR ids outright; mass has to scatter,
+    so it redirects them to the overflow slot at index E instead.
+    """
     c = make_collector()
     ids = torch.tensor([[0, 8], [-1, 300]], dtype=torch.int64)
     w = torch.tensor([[0.5, 0.1], [0.1, 0.1]])
@@ -158,6 +166,7 @@ def test_weighted_capture_redirects_oor_to_overflow_slot():
     fn = c.make_capture_fn(0, topk_weights_getter=lambda: w)
     fn(ids)
     assert c.count_buf[0][:8].tolist() == [1, 0, 0, 0, 0, 0, 0, 0]
-    assert c.count_buf[0][8] == 3, "three OOR ids redirected to overflow"
+    assert c.count_buf[0][8] == 0, "histc drops OOR ids from the count"
     assert abs(c.mass_buf[0][0].item() - 0.5) < 1e-6
-    assert abs(c.mass_buf[0][8].item() - 0.3) < 1e-6
+    assert abs(c.mass_buf[0][8].item() - 0.3) < 1e-6, \
+        "three OOR gate weights redirected to the overflow slot"

--- a/tests/exl3_fungible/test_stats_cpu.py
+++ b/tests/exl3_fungible/test_stats_cpu.py
@@ -53,7 +53,7 @@ def test_capture_counts_and_chains_previous_fn():
     ids = torch.tensor([[0, 1], [1, 7]], dtype=torch.int32)
     router.capture_fn(ids)
 
-    assert c.count_buf[0].tolist() == [1, 2, 0, 0, 0, 0, 0, 1]
+    assert c.count_buf[0][:8].tolist() == [1, 2, 0, 0, 0, 0, 0, 1]
     assert seen == [ids.shape], "previous capture fn must still fire"
 
 
@@ -129,3 +129,35 @@ def test_capture_fn_source_has_no_host_ops():
          if getattr(k, "co_name", "") == "_capture"][0]])
     for banned in (".item(", ".cpu(", ".tolist(", ".numpy(", "print("):
         assert banned not in src, f"host op {banned} in capture path"
+
+
+def test_out_of_range_ids_are_dropped_not_scattered():
+    """Padding sentinels / garbage ids must NEVER index device memory
+    out of range (illegal memory access — observed live on the first M2
+    dryrun boot). The histc capture path drops them; valid ids still
+    count, and the windowed stats stay clean."""
+    router = FakeRouter()
+    c = make_collector()
+    c.bind_router(0, router)
+    router.capture_fn(torch.tensor([[0, 8], [-1, 300]], dtype=torch.int64))
+    assert c.count_buf[0][:8].tolist() == [1, 0, 0, 0, 0, 0, 0, 0]
+    assert c.count_buf[0].sum() == 1, "OOR ids contribute nothing"
+    c.step()
+    c.step()  # roll (stride 2)
+    cnt, mass = c.decayed(0)
+    assert cnt.shape[0] == 8 and cnt.sum() == 1.0
+    assert mass.tolist() == cnt.tolist(), "no weights getter: mass==count"
+
+
+def test_weighted_capture_redirects_oor_to_overflow_slot():
+    """The scatter (weighted) path keeps the explicit overflow slot."""
+    c = make_collector()
+    ids = torch.tensor([[0, 8], [-1, 300]], dtype=torch.int64)
+    w = torch.tensor([[0.5, 0.1], [0.1, 0.1]])
+    c.bind_router(0, FakeRouter())
+    fn = c.make_capture_fn(0, topk_weights_getter=lambda: w)
+    fn(ids)
+    assert c.count_buf[0][:8].tolist() == [1, 0, 0, 0, 0, 0, 0, 0]
+    assert c.count_buf[0][8] == 3, "three OOR ids redirected to overflow"
+    assert abs(c.mass_buf[0][0].item() - 0.5) < 1e-6
+    assert abs(c.mass_buf[0][8].item() - 0.3) < 1e-6

--- a/tests/exl3_fungible/test_stats_cpu.py
+++ b/tests/exl3_fungible/test_stats_cpu.py
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU contract tests for FqStatsCollector (M1) — no GPU required.
+
+Graph-safety of the capture path is validated on-GPU by T1; these tests
+pin the host-side contracts: chaining, window roll/decay math, dummy-step
+semantics, and the no-host-ops discipline of the capture fn source.
+"""
+import inspect
+
+import pytest
+import torch
+
+try:
+    from vllm.model_executor.layers.quantization.exl3_fungible.stats import (
+        FqStatsCollector,
+    )
+except ImportError:  # standalone run against an env without built vllm._C
+    import importlib.util
+    from pathlib import Path
+
+    _p = (Path(__file__).resolve().parents[2] / "vllm" / "model_executor"
+          / "layers" / "quantization" / "exl3_fungible" / "stats.py")
+    _spec = importlib.util.spec_from_file_location("fq_stats_standalone", _p)
+    _mod = importlib.util.module_from_spec(_spec)
+    _spec.loader.exec_module(_mod)
+    FqStatsCollector = _mod.FqStatsCollector
+
+
+class FakeRouter:
+    def __init__(self):
+        self.capture_fn = None
+
+    def set_capture_fn(self, fn):
+        self.capture_fn = fn
+
+
+def make_collector(**kw) -> FqStatsCollector:
+    kw.setdefault("device", "cpu")
+    kw.setdefault("window_len", 4)
+    kw.setdefault("window_stride", 2)
+    kw.setdefault("decay", 0.5)
+    return FqStatsCollector(8, **kw)
+
+
+def test_capture_counts_and_chains_previous_fn():
+    seen = []
+    router = FakeRouter()
+    router.capture_fn = lambda ids: seen.append(ids.shape)
+
+    c = make_collector()
+    c.bind_router(0, router)
+    ids = torch.tensor([[0, 1], [1, 7]], dtype=torch.int32)
+    router.capture_fn(ids)
+
+    assert c.count_buf[0].tolist() == [1, 2, 0, 0, 0, 0, 0, 1]
+    assert seen == [ids.shape], "previous capture fn must still fire"
+
+
+def test_window_roll_and_zeroing():
+    router = FakeRouter()
+    c = make_collector()
+    c.bind_router(0, router)
+    router.capture_fn(torch.tensor([[3]]))
+    c.step()               # step 1: no roll (stride 2)
+    assert c.count_buf[0][3] == 1
+    c.step()               # step 2: roll
+    assert c.count_buf[0][3] == 0, "accumulator zeroed on roll"
+    assert c._count_win[0][0][3] == 1
+
+
+def test_dummy_step_discards_without_recording():
+    router = FakeRouter()
+    c = make_collector()
+    c.bind_router(0, router)
+    router.capture_fn(torch.tensor([[5]]))
+    c.step(is_dummy=True)
+    assert c.count_buf[0].sum() == 0
+    c.step()
+    assert c._windows_rolled == 0 or c._count_win[0].sum() == 0
+
+
+def test_decayed_weighting_newest_first():
+    router = FakeRouter()
+    c = make_collector(window_stride=1)
+    c.bind_router(0, router)
+    router.capture_fn(torch.tensor([[0]]))   # window 0: expert 0
+    c.step()
+    router.capture_fn(torch.tensor([[1]]))   # window 1: expert 1
+    c.step()
+    count, _ = c.decayed(0)
+    # newest (expert 1) weight 1.0; older (expert 0) weight λ=0.5
+    assert count[1] == pytest.approx(1.0)
+    assert count[0] == pytest.approx(0.5)
+
+
+def test_decay_ring_wraps():
+    router = FakeRouter()
+    c = make_collector(window_stride=1, window_len=2, decay=0.5)
+    c.bind_router(0, router)
+    for expert in (0, 1, 2):                 # 3 rolls into a 2-slot ring
+        router.capture_fn(torch.tensor([[expert]]))
+        c.step()
+    count, _ = c.decayed(0)
+    assert count[0] == 0, "oldest window evicted"
+    assert count[2] == pytest.approx(1.0)
+    assert count[1] == pytest.approx(0.5)
+
+
+def test_summary_shape():
+    router = FakeRouter()
+    c = make_collector(window_stride=1)
+    c.bind_router(0, router)
+    c.bind_router(1, FakeRouter())
+    router.capture_fn(torch.tensor([[2, 2]]))
+    c.step()
+    s = c.summary()
+    assert set(s["layers"]) == {0, 1}
+    assert s["layers"][0]["count"][2] == pytest.approx(2.0)
+
+
+def test_capture_fn_source_has_no_host_ops():
+    """Static discipline check: the capture path must never call host-sync
+    ops (graph-safety contract, 01 §2)."""
+    c = make_collector()
+    c.bind_router(0, FakeRouter())
+    src = inspect.getsource(c.make_capture_fn.__code__.co_consts[
+        [i for i, k in enumerate(c.make_capture_fn.__code__.co_consts)
+         if getattr(k, "co_name", "") == "_capture"][0]])
+    for banned in (".item(", ".cpu(", ".tolist(", ".numpy(", "print("):
+        assert banned not in src, f"host op {banned} in capture path"

--- a/tests/exl3_fungible/test_store_cpu.py
+++ b/tests/exl3_fungible/test_store_cpu.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU tests for PolicyStore: atomic commit, rotation, rehydration, refusal."""
+import json
+
+import pytest
+
+try:
+    from vllm.model_executor.layers.quantization.exl3_fungible import store as st
+except ImportError:  # standalone run against an env without built vllm._C
+    import importlib.util
+    from pathlib import Path as _P
+
+    _p = (_P(__file__).resolve().parents[2] / "vllm" / "model_executor"
+          / "layers" / "quantization" / "exl3_fungible" / "store.py")
+    _s = importlib.util.spec_from_file_location("fq_store_standalone", _p)
+    st = importlib.util.module_from_spec(_s)
+    _s.loader.exec_module(st)
+
+
+def make_doc(manifest="m0", n_k4=2, e=4, layer="3"):
+    bits = [4] * n_k4 + [3] * (e - n_k4)
+    return {
+        "schema": "fq-policy/2",
+        "manifest": manifest,
+        "budget": {"mode": "fixed_cardinality", "n_k4_per_layer": {layer: n_k4}},
+        "bits_per_expert": {layer: bits},
+        "pinned": {},
+        "provenance": {"parent": "generic-v1"},
+    }
+
+
+def test_commit_and_rehydrate(tmp_path):
+    s = st.PolicyStore(tmp_path, "m0")
+    h = s.commit(make_doc(), num_experts=4)
+    assert len(h) == 64
+    doc = s.load_current(num_experts=4)
+    assert doc["bits_per_expert"]["3"] == [4, 4, 3, 3]
+
+
+def test_history_rotation_bounded(tmp_path):
+    s = st.PolicyStore(tmp_path, "m0")
+    for i in range(st.HISTORY_KEEP + 4):
+        d = make_doc()
+        d["provenance"]["gen"] = i
+        s.commit(d, num_experts=4)
+    assert len(s.history()) == st.HISTORY_KEEP
+
+
+def test_manifest_mismatch_refused(tmp_path):
+    s = st.PolicyStore(tmp_path, "m0")
+    with pytest.raises(ValueError, match="manifest"):
+        s.commit(make_doc(manifest="OTHER"), num_experts=4)
+    s2 = st.PolicyStore(tmp_path, "m0")
+    s2.commit(make_doc(), num_experts=4)
+    cur = s2.root / "current.json"
+    doc = json.loads(cur.read_text())
+    doc["manifest"] = "TAMPERED"
+    cur.write_text(json.dumps(doc))
+    with pytest.raises(ValueError, match="mismatch"):
+        s2.load_current()
+
+
+def test_validation_rejects_bad_docs(tmp_path):
+    s = st.PolicyStore(tmp_path, "m0")
+    bad = make_doc()
+    bad["bits_per_expert"]["3"][0] = 5
+    with pytest.raises(ValueError, match=r"non-\{3,4\}"):
+        s.commit(bad, num_experts=4)
+    topo = make_doc()
+    topo["rank"] = 0
+    with pytest.raises(ValueError, match="topology-neutral"):
+        s.commit(topo, num_experts=4)
+    off_budget = make_doc()
+    off_budget["bits_per_expert"]["3"] = [4, 4, 4, 3]  # 3 K4 vs declared 2
+    with pytest.raises(ValueError, match="occupancy"):
+        s.commit(off_budget, num_experts=4)
+
+
+def test_no_torn_current_on_crash_sim(tmp_path):
+    s = st.PolicyStore(tmp_path, "m0")
+    s.commit(make_doc(), num_experts=4)
+    # simulate a crashed writer leaving a .tmp behind
+    (s.root / "current.tmp").write_text("{ definitely not json")
+    doc = s.load_current(num_experts=4)
+    assert doc is not None, "stray .tmp must never shadow current.json"

--- a/tests/exl3_fungible/test_store_cpu.py
+++ b/tests/exl3_fungible/test_store_cpu.py
@@ -38,6 +38,14 @@ def test_commit_and_rehydrate(tmp_path):
     assert doc["bits_per_expert"]["3"] == [4, 4, 3, 3]
 
 
+def test_commit_and_rehydrate_k2_k4_policy(tmp_path):
+    s = st.PolicyStore(tmp_path, "m0")
+    doc = make_doc()
+    doc["bits_per_expert"]["3"] = [4, 4, 2, 2]
+    s.commit(doc, num_experts=4)
+    assert s.load_current(num_experts=4)["bits_per_expert"]["3"] == [4, 4, 2, 2]
+
+
 def test_history_rotation_bounded(tmp_path):
     s = st.PolicyStore(tmp_path, "m0")
     for i in range(st.HISTORY_KEEP + 4):
@@ -65,8 +73,12 @@ def test_validation_rejects_bad_docs(tmp_path):
     s = st.PolicyStore(tmp_path, "m0")
     bad = make_doc()
     bad["bits_per_expert"]["3"][0] = 5
-    with pytest.raises(ValueError, match=r"non-\{3,4\}"):
+    with pytest.raises(ValueError, match=r"non-\{2,3,4\}"):
         s.commit(bad, num_experts=4)
+    three_tiers = make_doc(e=6)
+    three_tiers["bits_per_expert"]["3"] = [2, 3, 3, 4, 4, 4]
+    with pytest.raises(ValueError, match="binary pair"):
+        s.commit(three_tiers, num_experts=6)
     topo = make_doc()
     topo["rank"] = 0
     with pytest.raises(ValueError, match="topology-neutral"):

--- a/tests/exl3_fungible/test_swap_cpu.py
+++ b/tests/exl3_fungible/test_swap_cpu.py
@@ -331,3 +331,78 @@ def test_policy_persist_on_commit(toy_root, tmp_path):
 
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-v"]))
+
+
+# ------------------------------------------- publishing orderings to the module
+
+
+def _mixed_dict(ckpt, t0_globals, t1_globals):
+    """A stand-in for GG's ``layer.exl3_mixed_trellis`` (exl3.py)."""
+    s = _cpu_state(ckpt, t0_globals, t1_globals)
+    return {
+        "tiers": (s.tier0, s.tier1),
+        "tier_ids": (list(t0_globals), list(t1_globals)),
+        "tier_bits": (3, 4),
+        "global_to_combined": s.global_to_combined,
+        "descriptor_map": s.descriptor_map,
+        "rotations": s.rotations,
+    }
+
+
+def test_committed_apply_publishes_orderings_to_the_module(toy_root):
+    """A second engine built AFTER a swap must see the swap.
+
+    ``from_exl3_mixed_trellis`` copies the orderings, so every engine keeps a
+    private host view over one shared set of device maps. Before publish(),
+    the module kept its BOOT ``tier_ids`` forever: engine A installed swaps,
+    engine B (built later by the admin API) still believed the boot
+    membership, and B rejected perfectly valid follow-on plans with
+    "e_out must be resident K4" — against a device where it WAS.
+    """
+    root, ckpt = toy_root
+    mixed = _mixed_dict(ckpt, T0_GLOBALS, T1_GLOBALS)
+    state_a = fq_swap.MixedLayerState.from_exl3_mixed_trellis(mixed)
+    engine_a = _make_engine(root, state_a)
+
+    engine_a.apply(fq_swap.SwapPlan([(toy.LAYER_ID, 3, 0)]),
+                   quiesce=nullcontext())
+
+    # The module advertises what the device now holds, not what it booted with.
+    assert list(mixed["tier_ids"][0]) == state_a.tier0_globals
+    assert list(mixed["tier_ids"][1]) == state_a.tier1_globals
+    assert 0 in mixed["tier_ids"][1] and 3 not in mixed["tier_ids"][1]
+
+    # An engine built later agrees, and can stage the follow-on swap that
+    # a stale view refuses.
+    state_b = fq_swap.MixedLayerState.from_exl3_mixed_trellis(mixed)
+    assert state_b.tier0_globals == state_a.tier0_globals
+    assert state_b.tier1_globals == state_a.tier1_globals
+    _make_engine(root, state_b).stage(
+        fq_swap.SwapPlan([(toy.LAYER_ID, 0, 3)]))
+
+
+def test_stale_second_engine_is_what_the_fix_prevents(toy_root):
+    """Pin the failure mode itself, so a regression is unmistakable."""
+    root, ckpt = toy_root
+    mixed = _mixed_dict(ckpt, T0_GLOBALS, T1_GLOBALS)
+    state_a = fq_swap.MixedLayerState.from_exl3_mixed_trellis(mixed)
+    # Simulate the pre-fix engine: a private view that never publishes.
+    state_a.source = None
+    _make_engine(root, state_a).apply(
+        fq_swap.SwapPlan([(toy.LAYER_ID, 3, 0)]), quiesce=nullcontext())
+
+    stale = fq_swap.MixedLayerState.from_exl3_mixed_trellis(mixed)
+    assert stale.tier1_globals != state_a.tier1_globals
+    with pytest.raises(ValueError, match="resident"):
+        _make_engine(root, stale).stage(
+            fq_swap.SwapPlan([(toy.LAYER_ID, 0, 3)]))
+
+
+def test_publish_is_a_noop_without_a_source():
+    """Hand-built states (tests, and any non-module caller) stay valid."""
+    s = fq_swap.MixedLayerState(
+        tier0=None, tier1=None, rotations=None,
+        global_to_combined=torch.zeros(4, dtype=torch.int32),
+        descriptor_map=torch.zeros(4, dtype=torch.int32),
+        tier0_globals=[0, 1], tier1_globals=[2, 3])
+    assert s.publish() is False

--- a/tests/exl3_fungible/test_swap_cpu.py
+++ b/tests/exl3_fungible/test_swap_cpu.py
@@ -74,6 +74,16 @@ def test_plan_from_memberships_deterministic_and_ordered():
     assert plan.layers() == (0, 1)
 
 
+def test_plan_supports_k2_k4_memberships():
+    old = np.array([[4, 2, 2, 4], [2, 4, 4, 2]])
+    new = np.array([[2, 4, 2, 4], [4, 4, 2, 2]])
+    plan = fq_swap.SwapPlan.from_memberships(old, new)
+    assert plan.swaps == ((0, 0, 1), (1, 2, 0))
+    with pytest.raises(ValueError, match="binary mixed-trellis"):
+        fq_swap.SwapPlan.from_memberships(
+            [[2, 3, 4]], [[2, 3, 4]])
+
+
 def test_plan_inverse_restores_membership():
     rng = np.random.default_rng(7)
     L, En, n4 = 5, 16, 6
@@ -172,7 +182,7 @@ def test_segment_source_fail_closed(toy_root):
 # ------------------------------------------------- engine apply, CPU tensors
 
 
-def _cpu_state(ckpt, t0_globals, t1_globals):
+def _cpu_state(ckpt, t0_globals, t1_globals, tier_bits=(3, 4)):
     """Hand-assembled layer state on CPU (fresh-build reference shape)."""
     def tier(globals_, k):
         t = toy.assemble_membership_tensors(ckpt, globals_, k)
@@ -182,8 +192,8 @@ def _cpu_state(ckpt, t0_globals, t1_globals):
             w2=t["w2"].view(torch.int32).reshape(-1),
         ), t
 
-    tier0, r0 = tier(t0_globals, 3)
-    tier1, r1 = tier(t1_globals, 4)
+    tier0, r0 = tier(t0_globals, tier_bits[0])
+    tier1, r1 = tier(t1_globals, tier_bits[1])
     rotations = SimpleNamespace(
         intermediate=torch.cat((r0["intermediate"], r1["intermediate"])),
         gate_suh=torch.cat((r0["gate_suh"], r1["gate_suh"])),
@@ -195,10 +205,12 @@ def _cpu_state(ckpt, t0_globals, t1_globals):
     return fq_swap.MixedLayerState(
         tier0=tier0, tier1=tier1, rotations=rotations,
         global_to_combined=g2c, descriptor_map=desc,
-        tier0_globals=list(t0_globals), tier1_globals=list(t1_globals))
+        tier0_globals=list(t0_globals), tier1_globals=list(t1_globals),
+        tier_bits=tuple(tier_bits))
 
 
 def _make_engine(root, state, **kw):
+    kw.setdefault("tier_bits", state.tier_bits)
     return fq_swap.SwapEngine(
         {toy.LAYER_ID: state}, fq_swap.LocalSegmentSource(root),
         hidden_size=toy.HIDDEN, intermediate_size=toy.INTERMEDIATE,
@@ -243,6 +255,66 @@ def test_apply_matches_fresh_build_and_rolls_back(toy_root):
     engine.apply(plan.inverse(), quiesce=nullcontext())
     assert engine.generation == 2
     _assert_states_equal(state, pristine)
+
+
+def test_k2_k4_apply_matches_fresh_build_and_rolls_back(tmp_path):
+    ckpt = toy.make_toy_checkpoint(E, ks=(2, 4))
+    toy.write_toy_segments(tmp_path, ckpt, ks=(2, 4))
+    state = _cpu_state(
+        ckpt, T0_GLOBALS, T1_GLOBALS, tier_bits=(2, 4))
+    pristine = _cpu_state(
+        ckpt, T0_GLOBALS, T1_GLOBALS, tier_bits=(2, 4))
+    engine = _make_engine(tmp_path, state)
+    plan = fq_swap.SwapPlan([(toy.LAYER_ID, 1, 4)])
+
+    report = engine.apply(plan, quiesce=nullcontext())
+    assert report.pairs == 1 and report.generation == 1
+    expected = _cpu_state(
+        ckpt, [0, 2, 1, 5, 6], [3, 4, 7], tier_bits=(2, 4))
+    _assert_states_equal(state, expected)
+
+    engine.apply(plan.inverse(), quiesce=nullcontext())
+    _assert_states_equal(state, pristine)
+
+
+def test_k2_k4_fail_atomic_abort_is_never_torn(tmp_path):
+    ckpt = toy.make_toy_checkpoint(E, ks=(2, 4))
+    toy.write_toy_segments(tmp_path, ckpt, ks=(2, 4))
+    plan = fq_swap.SwapPlan([(toy.LAYER_ID, 1, 4)])
+    pristine = _cpu_state(
+        ckpt, T0_GLOBALS, T1_GLOBALS, tier_bits=(2, 4))
+    committed = _cpu_state(
+        ckpt, [0, 2, 1, 5, 6], [3, 4, 7], tier_bits=(2, 4))
+
+    class InjectedFailure(RuntimeError):
+        pass
+
+    for abort_at in fq_swap.COMMIT_STEPS:
+        state = _cpu_state(
+            ckpt, T0_GLOBALS, T1_GLOBALS, tier_bits=(2, 4))
+        engine = _make_engine(tmp_path, state)
+        staged = engine.stage(plan, fail_atomic=True)
+
+        def fail_after(step, *, expected=abort_at):
+            if step == expected:
+                raise InjectedFailure(step)
+
+        with pytest.raises(InjectedFailure, match=abort_at):
+            engine.apply(
+                staged=staged,
+                quiesce=nullcontext(),
+                step_hook=fail_after,
+            )
+
+        expected = (
+            pristine
+            if abort_at in ("slabs", "rotations")
+            else committed
+        )
+        _assert_states_equal(state, expected)
+        assert engine.generation == (
+            0 if abort_at in ("slabs", "rotations") else 1
+        )
 
 
 def test_apply_multi_pair_same_layer(toy_root):

--- a/tests/exl3_fungible/test_swap_cpu.py
+++ b/tests/exl3_fungible/test_swap_cpu.py
@@ -1,0 +1,333 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU tests for the M4 swap engine: SwapPlan algebra, LocalSegmentSource
+byte fidelity, and full engine apply()/rollback byte fidelity against
+hand-assembled layer state (no GPU, no b12x — build_tiered_maps semantics
+injected through the ``build_maps_fn`` seam and cross-checked on GPU by T3).
+"""
+import json
+import os
+import sys
+from contextlib import nullcontext
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import toy_segments as toy  # noqa: E402
+
+try:
+    from vllm.model_executor.layers.quantization.exl3_fungible import (  # noqa: E402
+        policy as fq_policy,
+        store as fq_store,
+        swap as fq_swap,
+    )
+except ImportError:  # standalone run against an env without built vllm._C
+    import importlib.util
+    from pathlib import Path as _P
+
+    _dir = (_P(__file__).resolve().parents[2] / "vllm" / "model_executor"
+            / "layers" / "quantization" / "exl3_fungible")
+
+    def _load(name):
+        spec = importlib.util.spec_from_file_location(
+            f"fq_{name}_standalone", _dir / f"{name}.py")
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = mod  # dataclasses resolve __module__
+        spec.loader.exec_module(mod)
+        return mod
+
+    fq_policy = _load("policy")
+    fq_store = _load("store")
+    fq_swap = _load("swap")
+
+E = 8  # toy global experts
+T0_GLOBALS = [0, 2, 4, 5, 6]  # K3 tier, slot order
+T1_GLOBALS = [3, 1, 7]  # K4 tier, slot order
+
+
+def build_maps_reference(tier0_ids, tier1_ids, *, device):
+    """Pure-torch replica of b12x build_tiered_maps (T3 proves parity)."""
+    t0n, t1n = len(tier0_ids), len(tier1_ids)
+    total = t0n + t1n
+    g2c = torch.full((total,), -1, dtype=torch.int32)
+    for local, g in enumerate(tier0_ids):
+        g2c[int(g)] = local
+    for local, g in enumerate(tier1_ids):
+        g2c[int(g)] = t0n + local
+    desc = torch.tensor(
+        [*range(t0n), *((1 << 8) | i for i in range(t1n))], dtype=torch.int32)
+    return g2c.to(device), desc.to(device)
+
+
+# ------------------------------------------------------------------ SwapPlan
+
+
+def test_plan_from_memberships_deterministic_and_ordered():
+    old = np.array([[4, 4, 3, 3], [3, 4, 4, 3]])
+    new = np.array([[3, 4, 3, 4], [4, 4, 3, 3]])
+    plan = fq_swap.SwapPlan.from_memberships(old, new)
+    assert plan.swaps == ((0, 0, 3), (1, 2, 0))
+    assert plan == fq_swap.SwapPlan.from_memberships(old, new)
+    assert plan.layers() == (0, 1)
+
+
+def test_plan_inverse_restores_membership():
+    rng = np.random.default_rng(7)
+    L, En, n4 = 5, 16, 6
+    old = np.full((L, En), 3)
+    new = np.full((L, En), 3)
+    for l in range(L):
+        old[l, rng.choice(En, n4, replace=False)] = 4
+        new[l, rng.choice(En, n4, replace=False)] = 4
+    plan = fq_swap.SwapPlan.from_memberships(old, new)
+    mid = fq_policy.apply_swaps(old, list(plan))
+    assert (mid == new).all()
+    back = fq_policy.apply_swaps(mid, list(plan.inverse()))
+    assert (back == old).all()
+    # double inverse is identity on the plan itself
+    assert plan.inverse().inverse() == plan
+
+
+def test_plan_rejects_cardinality_change_and_duplicates():
+    with pytest.raises(ValueError, match="cardinality"):
+        fq_swap.SwapPlan.from_memberships([[4, 3]], [[3, 3]])
+    with pytest.raises(ValueError, match="twice"):
+        fq_swap.SwapPlan([(0, 1, 2), (0, 1, 3)])
+
+
+def test_plan_from_policies():
+    def doc(bits):
+        return {"schema": "fq-policy/2", "bits_per_expert": bits}
+
+    old = doc({"3": [4, 3, 3, 4], "12": [3, 4, 3, 3]})
+    new = doc({"3": [3, 4, 3, 4], "12": [3, 3, 4, 3]})
+    plan = fq_swap.SwapPlan.from_policies(old, new)
+    assert plan.swaps == ((3, 0, 1), (12, 1, 2))
+    with pytest.raises(ValueError, match="different layers"):
+        fq_swap.SwapPlan.from_policies(old, doc({"3": [3, 4, 3, 4]}))
+
+
+# -------------------------------------------------------- LocalSegmentSource
+
+
+@pytest.fixture(scope="module")
+def toy_root(tmp_path_factory):
+    root = tmp_path_factory.mktemp("fq-toy-segments")
+    ckpt = toy.make_toy_checkpoint(E)
+    toy.write_toy_segments(root, ckpt)
+    return root, ckpt
+
+
+def test_segment_source_reads_expert_bitwise(toy_root):
+    root, ckpt = toy_root
+    src = fq_swap.LocalSegmentSource(root)
+    for e, k in ((0, 3), (5, 3), (1, 4), (7, 4)):
+        stage = fq_swap.ExpertStage(k, toy.HIDDEN, toy.INTERMEDIATE,
+                                    pin_memory=False)
+        src.read_expert(layer=toy.LAYER_ID, k=k, expert=e, rank=0, dest=stage)
+        ref = ckpt[(e, k)]
+        for proj in ("gate", "up", "down"):
+            assert torch.equal(stage.trellis[proj], ref[proj])
+            assert stage.mcg[proj] == toy.MCG
+        assert torch.equal(stage.suh["gate"], ref["gate_suh"])
+        assert torch.equal(stage.suh["up"], ref["up_suh"])
+        assert torch.equal(stage.svh["down"], ref["down_svh"])
+        expected_rot = torch.cat(
+            (ref["gate_svh"], ref["up_svh"], ref["down_suh"]))
+        assert torch.equal(stage.inter_rot, expected_rot)
+    src.close()
+
+
+def test_segment_source_fail_closed(toy_root):
+    root, _ = toy_root
+    src = fq_swap.LocalSegmentSource(root)
+    stage = fq_swap.ExpertStage(3, toy.HIDDEN, toy.INTERMEDIATE,
+                                pin_memory=False)
+    with pytest.raises(KeyError, match="expert 99"):
+        src.read_expert(layer=toy.LAYER_ID, k=3, expert=99, rank=0,
+                        dest=stage)
+    with pytest.raises(KeyError, match="layer 42"):
+        src.read_expert(layer=42, k=3, expert=0, rank=0, dest=stage)
+    with pytest.raises(ValueError, match="stage is K3"):
+        src.read_expert(layer=toy.LAYER_ID, k=4, expert=0, rank=0,
+                        dest=stage)
+    # A tensor range escaping its indexed expert range is refused.
+    idx_path = root / "index-k3.json"
+    original = idx_path.read_text()
+    index = json.loads(original)
+    index[str(toy.LAYER_ID)]["experts"]["0"][1] -= 4
+    idx_path.write_text(json.dumps(index))
+    try:
+        with pytest.raises(ValueError, match="escapes"):
+            fq_swap.LocalSegmentSource(root).read_expert(
+                layer=toy.LAYER_ID, k=3, expert=0, rank=0, dest=stage)
+    finally:
+        idx_path.write_text(original)
+    src.close()
+
+
+# ------------------------------------------------- engine apply, CPU tensors
+
+
+def _cpu_state(ckpt, t0_globals, t1_globals):
+    """Hand-assembled layer state on CPU (fresh-build reference shape)."""
+    def tier(globals_, k):
+        t = toy.assemble_membership_tensors(ckpt, globals_, k)
+        return SimpleNamespace(
+            num_experts=len(globals_),
+            w13=t["w13"].view(torch.int32).reshape(-1),
+            w2=t["w2"].view(torch.int32).reshape(-1),
+        ), t
+
+    tier0, r0 = tier(t0_globals, 3)
+    tier1, r1 = tier(t1_globals, 4)
+    rotations = SimpleNamespace(
+        intermediate=torch.cat((r0["intermediate"], r1["intermediate"])),
+        gate_suh=torch.cat((r0["gate_suh"], r1["gate_suh"])),
+        up_suh=torch.cat((r0["up_suh"], r1["up_suh"])),
+        down_svh=torch.cat((r0["down_svh"], r1["down_svh"])),
+    )
+    g2c, desc = build_maps_reference(t0_globals, t1_globals,
+                                     device=torch.device("cpu"))
+    return fq_swap.MixedLayerState(
+        tier0=tier0, tier1=tier1, rotations=rotations,
+        global_to_combined=g2c, descriptor_map=desc,
+        tier0_globals=list(t0_globals), tier1_globals=list(t1_globals))
+
+
+def _make_engine(root, state, **kw):
+    return fq_swap.SwapEngine(
+        {toy.LAYER_ID: state}, fq_swap.LocalSegmentSource(root),
+        hidden_size=toy.HIDDEN, intermediate_size=toy.INTERMEDIATE,
+        pin_memory=False, build_maps_fn=build_maps_reference, **kw)
+
+
+def _assert_states_equal(a, b):
+    assert a.tier0_globals == b.tier0_globals
+    assert a.tier1_globals == b.tier1_globals
+    for name in ("tier0", "tier1"):
+        for slab in ("w13", "w2"):
+            assert torch.equal(getattr(getattr(a, name), slab),
+                               getattr(getattr(b, name), slab)), (name, slab)
+    for name in ("intermediate", "gate_suh", "up_suh", "down_svh"):
+        assert torch.equal(getattr(a.rotations, name),
+                           getattr(b.rotations, name)), name
+    assert torch.equal(a.global_to_combined, b.global_to_combined)
+    assert torch.equal(a.descriptor_map, b.descriptor_map)
+
+
+def test_apply_matches_fresh_build_and_rolls_back(toy_root):
+    root, ckpt = toy_root
+    state = _cpu_state(ckpt, T0_GLOBALS, T1_GLOBALS)
+    pristine = _cpu_state(ckpt, T0_GLOBALS, T1_GLOBALS)
+    engine = _make_engine(root, state)
+
+    e_out, e_in = 1, 4  # K4 slot 1 out, K3 slot 2 in
+    plan = fq_swap.SwapPlan([(toy.LAYER_ID, e_out, e_in)])
+    steps = []
+    report = engine.apply(plan, quiesce=nullcontext(),
+                          step_hook=steps.append)
+    assert steps == list(fq_swap.COMMIT_STEPS)
+    assert report.pairs == 1 and report.generation == 1
+    assert report.mcg == toy.MCG
+    assert report.bytes_h2d > 0
+
+    # e_in inherited e_out's tier1 slot; e_out inherited e_in's tier0 slot.
+    expected = _cpu_state(ckpt, [0, 2, 1, 5, 6], [3, 4, 7])
+    _assert_states_equal(state, expected)
+
+    # Rollback: apply the inverse; every byte must return (02 §Rollback).
+    engine.apply(plan.inverse(), quiesce=nullcontext())
+    assert engine.generation == 2
+    _assert_states_equal(state, pristine)
+
+
+def test_apply_multi_pair_same_layer(toy_root):
+    root, ckpt = toy_root
+    state = _cpu_state(ckpt, T0_GLOBALS, T1_GLOBALS)
+    engine = _make_engine(root, state)
+    plan = fq_swap.SwapPlan(
+        [(toy.LAYER_ID, 3, 0), (toy.LAYER_ID, 7, 6)])
+    engine.apply(plan, quiesce=nullcontext())
+    expected = _cpu_state(ckpt, [3, 2, 4, 5, 7], [0, 1, 6])
+    _assert_states_equal(state, expected)
+    engine.apply(plan.inverse(), quiesce=nullcontext())
+    _assert_states_equal(state, _cpu_state(ckpt, T0_GLOBALS, T1_GLOBALS))
+
+
+def test_apply_validates_residency_and_caps(toy_root):
+    root, ckpt = toy_root
+    state = _cpu_state(ckpt, T0_GLOBALS, T1_GLOBALS)
+    engine = _make_engine(root, state, max_pairs=1)
+    with pytest.raises(ValueError, match="resident"):
+        engine.stage(fq_swap.SwapPlan([(toy.LAYER_ID, 0, 1)]))  # both wrong
+    with pytest.raises(ValueError, match="staging holds 1"):
+        engine.stage(fq_swap.SwapPlan(
+            [(toy.LAYER_ID, 3, 0), (toy.LAYER_ID, 7, 6)]))
+    with pytest.raises(KeyError, match="not registered"):
+        engine.stage(fq_swap.SwapPlan([(99, 3, 0)]))
+
+
+def test_engine_refuses_bad_geometry(toy_root):
+    root, ckpt = toy_root
+    state = _cpu_state(ckpt, T0_GLOBALS, T1_GLOBALS)
+    state.rotations.gate_suh = state.rotations.gate_suh[:1]  # broadcast-like
+    with pytest.raises(ValueError, match="broadcast"):
+        _make_engine(root, state)
+    state2 = _cpu_state(ckpt, T0_GLOBALS, [3, 3])  # not a partition
+    with pytest.raises(ValueError, match="partition"):
+        _make_engine(root, state2)
+
+
+def test_map_rebuild_fail_closed_on_holes(toy_root):
+    root, ckpt = toy_root
+    state = _cpu_state(ckpt, T0_GLOBALS, T1_GLOBALS)
+
+    def bad_maps(t0, t1, *, device):
+        g2c, desc = build_maps_reference(t0, t1, device=device)
+        g2c[0] = -1  # a hole the swap path must never introduce
+        return g2c, desc
+
+    engine = fq_swap.SwapEngine(
+        {toy.LAYER_ID: state}, fq_swap.LocalSegmentSource(root),
+        hidden_size=toy.HIDDEN, intermediate_size=toy.INTERMEDIATE,
+        pin_memory=False, build_maps_fn=bad_maps)
+    with pytest.raises(ValueError, match="permutation"):
+        engine.stage(fq_swap.SwapPlan([(toy.LAYER_ID, 3, 0)]))
+
+
+def test_mcg_mismatch_refused(tmp_path):
+    ckpt = toy.make_toy_checkpoint(E)
+    toy.write_toy_segments(tmp_path, ckpt)
+    state = _cpu_state(ckpt, T0_GLOBALS, T1_GLOBALS)
+    engine = _make_engine(tmp_path, state, expected_mcg=12345)
+    with pytest.raises(ValueError, match="mcg"):
+        engine.stage(fq_swap.SwapPlan([(toy.LAYER_ID, 3, 0)]))
+
+
+def test_policy_persist_on_commit(toy_root, tmp_path):
+    root, ckpt = toy_root
+    state = _cpu_state(ckpt, T0_GLOBALS, T1_GLOBALS)
+    engine = _make_engine(root, state)
+    ps = fq_store.PolicyStore(tmp_path, "toy-manifest")
+    doc = {
+        "schema": "fq-policy/2",
+        "manifest": "toy-manifest",
+        "budget": {"n_k4_per_layer": {str(toy.LAYER_ID): 3}},
+        "bits_per_expert": {str(toy.LAYER_ID): [3, 3, 3, 4, 4, 3, 3, 4]},
+    }
+    memo_calls = []
+    report = engine.apply(
+        fq_swap.SwapPlan([(toy.LAYER_ID, 1, 4)]), quiesce=nullcontext(),
+        memo_hook=lambda: memo_calls.append(True),
+        policy_store=ps, policy_doc=doc, policy_num_experts=E)
+    assert memo_calls == [True]
+    assert report.committed_policy_hash == fq_store.policy_hash(doc)
+    assert ps.load_current(num_experts=E) == doc
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/exl3_fungible/test_swap_gpu.py
+++ b/tests/exl3_fungible/test_swap_gpu.py
@@ -1,0 +1,369 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""M4 swap-engine GPU tests — T3 and T4 (03-testing-validation.md).
+
+T3 (the make-or-break): capture a mixed K3/K4 forward in a CUDA graph,
+mutate MAP CONTENTS in place through the engine's map-rebuild path, replay —
+the replayed output must be bitwise-equal to a fresh-built layer holding the
+new membership. If this fails, maps are baked at capture and the atomic swap
+path is dead (APPLY_MODE=reload is the ceiling).
+
+T4: swap one expert pair end-to-end through SwapEngine against real
+fq-segment/1 byte payloads (toy segments written by toy_segments.py in
+fq_repack's exact layout), forward a probe batch, compare BITWISE against a
+fresh-built layer with that membership; parametrized over slab rows
+first/last/middle. Plus rollback (inverse plan restores the original output
+bitwise) and apply() wall-time measurements for 1 and 8 pairs.
+
+Run in the gg r33 env from a neutral cwd, e.g.::
+
+    CUDA_VISIBLE_DEVICES=<free> .../runs/gg-env/gg-run.sh \
+        python /home/mbelleau/src/gg-vllm/tests/exl3_fungible/test_swap_gpu.py
+"""
+from __future__ import annotations
+
+import os
+import sys
+import time
+from contextlib import contextmanager
+
+import pytest
+import torch
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import toy_segments as toy  # noqa: E402
+
+try:
+    from vllm.model_executor.layers.quantization.exl3_fungible import (  # noqa: E402
+        swap as fq_swap,
+    )
+except ImportError:  # gg-env: installed vllm predates exl3_fungible
+    import importlib.util
+    from pathlib import Path as _P
+
+    _p = (_P(__file__).resolve().parents[2] / "vllm" / "model_executor"
+          / "layers" / "quantization" / "exl3_fungible" / "swap.py")
+    _spec = importlib.util.spec_from_file_location("fq_swap_standalone", _p)
+    fq_swap = importlib.util.module_from_spec(_spec)
+    sys.modules[_spec.name] = fq_swap
+    _spec.loader.exec_module(fq_swap)
+
+try:
+    from b12x.moe._shared.kernels.w4a16.host import max_packed_route_slots
+    from b12x.moe._shared.kernels.w4a16.mixed_trellis import (
+        build_tiered_maps,
+        combine_trellis_rotations,
+        compile_mixed_trellis,
+        make_mixed_trellis_buffers,
+        run_mixed_trellis,
+    )
+    from b12x.moe._shared.kernels.w4a16.prepare import (
+        prepare_trellis256_moe_weights,
+    )
+    HAVE_B12X = True
+except ImportError:
+    HAVE_B12X = False
+
+
+def _sm12x_available() -> bool:
+    if not torch.cuda.is_available():
+        return False
+    major, _ = torch.cuda.get_device_capability()
+    return major == 12
+
+
+pytestmark = pytest.mark.skipif(
+    not (HAVE_B12X and _sm12x_available()),
+    reason="requires b12x and an SM120/SM121 GPU")
+
+# ------------------------------------------------------------------ geometry
+# The proven pre-m4 occupancy-harness toy layer: E=16 = 12 K3 + 4 K4.
+M, TOPK, MOE_BLOCK = 8, 4, 8
+TIER0_GLOBALS = [0, 1, 2, 4, 5, 6, 8, 9, 10, 12, 13, 14]
+TIER1_GLOBALS = [3, 7, 11, 15]
+# Every global id 0..15 appears; both tiers in most rows.
+ROUTES16 = (
+    (0, 3, 14, 5),
+    (1, 11, 4, 8),
+    (10, 12, 3, 14),
+    (5, 0, 11, 1),
+    (15, 8, 12, 10),
+    (4, 7, 13, 0),
+    (11, 14, 5, 12),
+    (9, 10, 2, 6),
+)
+
+_TIMINGS: list[str] = []
+
+
+# ------------------------------------------------------------------- helpers
+
+
+def _device():
+    return torch.device("cuda", torch.cuda.current_device())
+
+
+def _build_state(ckpt, t0_globals, t1_globals, device) -> "fq_swap.MixedLayerState":
+    """Fresh-built mixed layer from checkpoint tensors (exl3.py's assembly)."""
+    prepared = []
+    for globals_, bits in ((t0_globals, 3), (t1_globals, 4)):
+        t = {k: v.to(device) for k, v in toy.assemble_membership_tensors(
+            ckpt, globals_, bits).items()}
+        prepared.append(prepare_trellis256_moe_weights(
+            w13=t["w13"].contiguous(),
+            w2=t["w2"].contiguous(),
+            hidden_size=toy.HIDDEN,
+            intermediate_size=toy.INTERMEDIATE,
+            num_experts=len(globals_),
+            activation="silu",
+            fc1_tile_n=toy.TILE_CONFIG[1],
+            fc2_tile_n=toy.TILE_CONFIG[3],
+            params_dtype=torch.float16,
+            w13_layout="trellis3_t256_proj",
+            trellis_bits=bits,
+            gate_suh=t["gate_suh"].contiguous(),
+            up_suh=t["up_suh"].contiguous(),
+            intermediate_rotations=t["intermediate"].contiguous(),
+            down_svh=t["down_svh"].contiguous(),
+            tile_config=toy.TILE_CONFIG,
+        ))
+    g2c, desc = build_tiered_maps(t0_globals, t1_globals, device=device)
+    return fq_swap.MixedLayerState(
+        tier0=prepared[0], tier1=prepared[1],
+        rotations=combine_trellis_rotations(*prepared),
+        global_to_combined=g2c, descriptor_map=desc,
+        tier0_globals=list(t0_globals), tier1_globals=list(t1_globals),
+        mcg=toy.MCG)
+
+
+def _compile(device, cap0, cap1):
+    props = torch.cuda.get_device_properties(device)
+    route_slots = max_packed_route_slots(M * TOPK, MOE_BLOCK, cap0 + cap1)
+    return compile_mixed_trellis(
+        size_m=M,
+        hidden_size=toy.HIDDEN,
+        intermediate_size=toy.INTERMEDIATE,
+        tier0_num_experts=cap0,
+        tier1_num_experts=cap1,
+        top_k=TOPK,
+        max_m_blocks=(route_slots + MOE_BLOCK - 1) // MOE_BLOCK,
+        sms=int(props.multi_processor_count),
+        max_shared_mem=int(props.shared_memory_per_block_optin),
+        force_tile_config=toy.TILE_CONFIG,
+        moe_block_size=MOE_BLOCK,
+        route_ids_dtype=torch.int32,
+    ), int(props.multi_processor_count)
+
+
+def _forward(state, launch, sms, x, topk_weights, topk_ids, *,
+             g2c=None, descriptor=None, buffers=None):
+    """One forward with fresh buffers (unless capturing into given ones)."""
+    device = x.device
+    if buffers is None:
+        buffers = make_mixed_trellis_buffers(launch, device=device, sms=sms)
+    out = run_mixed_trellis(
+        x, state.tier0, state.tier1, topk_weights, topk_ids,
+        state.global_to_combined if g2c is None else g2c,
+        state.descriptor_map if descriptor is None else descriptor,
+        state.rotations, launch, buffers)
+    return out
+
+
+def _probe(device):
+    torch.manual_seed(20260810)
+    x = (torch.randn((M, toy.HIDDEN), device=device) * 1.0e-3).to(torch.bfloat16)
+    topk_ids = torch.tensor(ROUTES16, dtype=torch.int32, device=device)
+    topk_weights = torch.softmax(
+        torch.randn((M, TOPK), dtype=torch.float32, device=device), dim=-1)
+    return x, topk_weights, topk_ids
+
+
+@contextmanager
+def _quiesce(device):
+    """Test stand-in for the engine pause: nothing in flight; sync on exit
+    so the measured window includes H2D completion."""
+    yield
+    torch.cuda.synchronize(device)
+
+
+@pytest.fixture(scope="module")
+def toy_gpu(tmp_path_factory):
+    root = tmp_path_factory.mktemp("fq-toy-segments-gpu")
+    ckpt = toy.make_toy_checkpoint(16)
+    toy.write_toy_segments(root, ckpt)
+    device = _device()
+    launch, sms = _compile(device, len(TIER0_GLOBALS), len(TIER1_GLOBALS))
+    return root, ckpt, launch, sms
+
+
+def _make_engine(root, state, **kw):
+    return fq_swap.SwapEngine(
+        {toy.LAYER_ID: state}, fq_swap.LocalSegmentSource(root),
+        hidden_size=toy.HIDDEN, intermediate_size=toy.INTERMEDIATE,
+        expected_mcg=toy.MCG, **kw)
+
+
+# ------------------------------------------------------------------------ T3
+
+
+def test_t3_graph_replay_sees_map_mutation(toy_gpu):
+    root, ckpt, launch, sms = toy_gpu
+    device = _device()
+    state = _build_state(ckpt, TIER0_GLOBALS, TIER1_GLOBALS, device)
+    engine = _make_engine(root, state)
+    x, topk_weights, topk_ids = _probe(device)
+
+    # Sanity + warmup with the graph's own static buffers.
+    graph_buffers = make_mixed_trellis_buffers(launch, device=device, sms=sms)
+    eager_a = _forward(state, launch, sms, x, topk_weights, topk_ids,
+                       buffers=graph_buffers)
+    torch.cuda.synchronize(device)
+    eager_a = eager_a.clone()
+    assert not torch.isnan(eager_a).any()
+    repeat = _forward(state, launch, sms, x, topk_weights, topk_ids,
+                      buffers=graph_buffers)
+    torch.cuda.synchronize(device)
+    assert torch.equal(repeat, eager_a), "harness is not deterministic"
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = _forward(state, launch, sms, x, topk_weights, topk_ids,
+                            buffers=graph_buffers)
+    graph.replay()
+    torch.cuda.synchronize(device)
+    assert torch.equal(captured, eager_a), "capture drifted from eager"
+    out_a = captured.clone()
+
+    # New membership: within-tier reorders AND cross-tier moves.
+    # 0 (K3 slot 0) <-> 3 (K4 slot 0); 1 <-> 14 within K3; 7 <-> 15 within K4.
+    new_t0 = [3, 14, 2, 4, 5, 6, 8, 9, 10, 12, 13, 1]
+    new_t1 = [0, 15, 11, 7]
+    live_g2c_ptr = state.global_to_combined.data_ptr()
+    live_desc_ptr = state.descriptor_map.data_ptr()
+    engine.rebuild_maps(toy.LAYER_ID, new_t0, new_t1)
+    torch.cuda.synchronize(device)
+    assert state.global_to_combined.data_ptr() == live_g2c_ptr
+    assert state.descriptor_map.data_ptr() == live_desc_ptr
+
+    graph.replay()
+    torch.cuda.synchronize(device)
+    out_b = captured.clone()
+
+    # Reference: fresh-built maps for the new membership, eager, fresh
+    # buffers, same tier slabs (a pure re-attribution of globals to slots).
+    ref_g2c, ref_desc = build_tiered_maps(new_t0, new_t1, device=device)
+    ref_b = _forward(state, launch, sms, x, topk_weights, topk_ids,
+                     g2c=ref_g2c, descriptor=ref_desc)
+    torch.cuda.synchronize(device)
+
+    assert torch.equal(state.global_to_combined, ref_g2c)
+    assert torch.equal(state.descriptor_map, ref_desc)
+    assert not torch.equal(out_b, out_a), \
+        "map mutation did not change routing — T3 comparison is vacuous"
+    assert torch.equal(out_b, ref_b), (
+        "T3 FAIL: CUDA-graph replay did not see in-place map-content "
+        "mutation — maps are baked at capture; the atomic swap path is "
+        "dead and APPLY_MODE=reload is the ceiling (M3).")
+
+
+# ------------------------------------------------------------------------ T4
+
+
+@pytest.mark.parametrize(
+    "slot1_out,slot0_in",
+    [(0, 0), (3, 11), (1, 5)],  # first, last, middle slab rows of each tier
+    ids=["rows-first", "rows-last", "rows-middle"])
+def test_t4_swap_engine_row_write_fidelity(toy_gpu, slot1_out, slot0_in):
+    root, ckpt, launch, sms = toy_gpu
+    device = _device()
+    state = _build_state(ckpt, TIER0_GLOBALS, TIER1_GLOBALS, device)
+    engine = _make_engine(root, state)
+    x, topk_weights, topk_ids = _probe(device)
+
+    out_before = _forward(state, launch, sms, x, topk_weights, topk_ids)
+    torch.cuda.synchronize(device)
+    out_before = out_before.clone()
+
+    e_out = TIER1_GLOBALS[slot1_out]
+    e_in = TIER0_GLOBALS[slot0_in]
+    plan = fq_swap.SwapPlan([(toy.LAYER_ID, e_out, e_in)])
+    report = engine.apply(plan, quiesce=_quiesce(device))
+    assert report.pairs == 1 and report.mcg == toy.MCG
+
+    # Fresh-built reference with the post-swap membership (same slot layout).
+    ref = _build_state(ckpt, state.tier0_globals, state.tier1_globals, device)
+    assert ref.tier1_globals[slot1_out] == e_in
+    assert ref.tier0_globals[slot0_in] == e_out
+    for name in ("tier0", "tier1"):
+        for slab in ("w13", "w2"):
+            assert torch.equal(getattr(getattr(state, name), slab),
+                               getattr(getattr(ref, name), slab)), (name, slab)
+    for name in ("intermediate", "gate_suh", "up_suh", "down_svh"):
+        assert torch.equal(getattr(state.rotations, name),
+                           getattr(ref.rotations, name)), name
+    assert torch.equal(state.global_to_combined, ref.global_to_combined)
+    assert torch.equal(state.descriptor_map, ref.descriptor_map)
+
+    out_swapped = _forward(state, launch, sms, x, topk_weights, topk_ids)
+    ref_out = _forward(ref, launch, sms, x, topk_weights, topk_ids)
+    torch.cuda.synchronize(device)
+    assert not torch.equal(out_swapped, out_before), \
+        "swap did not change the probe output — comparison is vacuous"
+    assert torch.equal(out_swapped, ref_out), (
+        "T4 FAIL: engine-swapped layer is not bitwise-equal to the "
+        "fresh-built layer with the same membership")
+
+    # Rollback (02 §Rollback): inverse plan restores the original bitwise.
+    engine.apply(plan.inverse(), quiesce=_quiesce(device))
+    out_rolled = _forward(state, launch, sms, x, topk_weights, topk_ids)
+    torch.cuda.synchronize(device)
+    assert torch.equal(out_rolled, out_before), \
+        "rollback did not restore the pre-swap output bitwise"
+
+
+# ------------------------------------------------------------------- timings
+
+
+def test_apply_wall_time_1_and_8_pairs(tmp_path):
+    device = _device()
+    e, cap0, cap1, layer = 32, 24, 8, 12
+    t1g = [3, 7, 11, 15, 19, 23, 27, 31]
+    t0g = [i for i in range(e) if i not in t1g]
+    ckpt = toy.make_toy_checkpoint(e)
+    toy.write_toy_segments(tmp_path, ckpt, layer=layer)
+    state = _build_state(ckpt, t0g, t1g, device)
+    engine = fq_swap.SwapEngine(
+        {layer: state}, fq_swap.LocalSegmentSource(tmp_path),
+        hidden_size=toy.HIDDEN, intermediate_size=toy.INTERMEDIATE,
+        expected_mcg=toy.MCG, max_pairs=8)
+
+    for pairs in (1, 8):
+        plan = fq_swap.SwapPlan(
+            [(layer, t1g[i], t0g[i]) for i in range(pairs)])
+        windows, stages = [], []
+        for _ in range(3):
+            for p in (plan, plan.inverse()):
+                staged = engine.stage(p)
+                t0 = time.perf_counter()
+                report = engine.apply(staged=staged, quiesce=_quiesce(device))
+                assert report.window_seconds <= time.perf_counter() - t0 + 1e-3
+                windows.append(report.window_seconds)
+                stages.append(report.stage_seconds)
+        line = (f"apply {pairs} pair(s): window best {min(windows)*1e3:.3f} ms "
+                f"(median {sorted(windows)[len(windows)//2]*1e3:.3f} ms), "
+                f"stage best {min(stages)*1e3:.3f} ms, "
+                f"{report.bytes_h2d/1e6:.3f} MB H2D")
+        _TIMINGS.append(line)
+        print(f"\n[timing] {line}")
+    # Membership is restored (equal applies of plan and inverse).
+    assert state.tier0_globals == t0g and state.tier1_globals == t1g
+
+
+if __name__ == "__main__":
+    code = pytest.main([
+        __file__, "-v", "-s", "-p", "no:cacheprovider",
+        "--confcutdir", os.path.dirname(os.path.abspath(__file__)),
+    ])
+    for line in _TIMINGS:
+        print(f"[timing] {line}")
+    sys.exit(int(code))

--- a/tests/exl3_fungible/test_swap_resolver_cpu.py
+++ b/tests/exl3_fungible/test_swap_resolver_cpu.py
@@ -1,0 +1,392 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU tests for ``swap.ResolverFragmentSource`` — the loader-v2 seam.
+
+The swap engine's :class:`FragmentSource` is what makes a swap's bytes
+appear. ``LocalSegmentSource`` requires an on-disk fq-segment dir;
+``ResolverFragmentSource`` adapts ``fragments.FragmentResolver`` so a swap
+stages through boot's supply chain instead: local dirs -> content-addressed
+cache -> the manifest / ``VLLM_FQ_SOURCES`` chain of HF repos and mirrors,
+with the same attestation trust filtering and per-fragment sha256
+verification (implementation/10 §2/§4).
+
+Two properties beyond "it reads bytes":
+
+* **Byte fidelity** — an engine staged through the resolver must produce a
+  layer state that is byte-identical to the same swap staged from local
+  segments, which T4 already pinned to a fresh-built layer on GPU.
+* **Pending promotions** (07 §1) — when a source refuses (untrusted
+  attestation, sha mismatch, nothing has the fragment, or the K-fallback
+  ladder substituted a lower K because the K4 encode has not landed), the
+  promotion must PEND: the pair drops out of the swap list, cardinality is
+  preserved, the interval proceeds. Corruption and structural faults stay
+  fatal — dropping is only for supply.
+
+The real ``FragmentResolver`` is used wherever it can be (real segments,
+real sha verification, real trust filtering through a fake remote source);
+hand-written fake resolvers cover the paths a real one cannot be forced into
+cheaply (substituted K, structural corruption).
+"""
+import hashlib
+import json
+import os
+import sys
+from contextlib import nullcontext
+from pathlib import Path
+
+import pytest
+import torch
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import test_fragments_cpu as tf  # noqa: E402  (FakeSource + resolver helpers)
+import toy_segments as toy  # noqa: E402
+
+fq_swap = toy.load_tree_module("swap")  # never the rootfs' synced copy
+fr = tf.fr
+
+E = 8
+T0_GLOBALS = [0, 2, 4, 5, 6]  # K3 tier, slot order
+T1_GLOBALS = [3, 1, 7]        # K4 tier, slot order
+
+
+# ----------------------------------------------------------------- fixtures
+
+
+def _expert_digests(root: Path, layer: int, k: int) -> dict[str, str]:
+    index = json.loads((root / f"index-k{k}.json").read_text())[str(layer)]
+    raw = (root / index["file"]).read_bytes()
+    body = index["body_offset"]
+    return {expert: hashlib.sha256(raw[body + lo:body + hi]).hexdigest()
+            for expert, (lo, hi) in index["experts"].items()}
+
+
+def make_segments(root: Path, *, attest=True, layer=toy.LAYER_ID) -> Path:
+    """Toy fq-segment dir upgraded to what FragmentResolver expects:
+    file-level ``sha256`` in the index + an fq-attestation/1 line carrying
+    the per-expert digests (fq_repack writes both; toy_segments predates
+    the resolver and writes neither)."""
+    ckpt = toy.make_toy_checkpoint(E)
+    toy.write_toy_segments(root, ckpt, layer=layer)
+    for k in (3, 4):
+        index_path = root / f"index-k{k}.json"
+        index = json.loads(index_path.read_text())
+        entry = index[str(layer)]
+        entry["sha256"] = hashlib.sha256(
+            (root / entry["file"]).read_bytes()).hexdigest()
+        index_path.write_text(json.dumps(index))
+        if attest:
+            att = {"schema": "fq-attestation/1", "predicate": "repack-of",
+                   "expert_sha256": _expert_digests(root, layer, k)}
+            att_dir = root / "attestations"
+            att_dir.mkdir(exist_ok=True)
+            (att_dir / f"layer-{layer:03d}.k{k}.jsonl").write_text(
+                json.dumps({
+                    "payload": tf.base64.b64encode(
+                        json.dumps(att).encode()).decode(),
+                    "signature": "dGVzdA==",
+                    "keyid": "00",
+                }) + "\n")
+    return ckpt
+
+
+def manifest_dir(path: Path, **manifest) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "fq-manifest.json").write_text(json.dumps({
+        "schema": "fq-manifest/1", "num_experts": E, "sources": [],
+        **manifest}))
+    return path
+
+
+@pytest.fixture
+def segments(tmp_path):
+    root = tmp_path / "segments"
+    ckpt = make_segments(root)
+    return root, ckpt
+
+
+def make_engine(source, state, **kw):
+    kw.setdefault("expected_mcg", toy.MCG)
+    return fq_swap.SwapEngine(
+        {toy.LAYER_ID: state}, source,
+        hidden_size=toy.HIDDEN, intermediate_size=toy.INTERMEDIATE,
+        pin_memory=False, build_maps_fn=toy.build_maps_reference, **kw)
+
+
+PLAN = fq_swap.SwapPlan([(toy.LAYER_ID, 1, 4)])  # e_out=1 K4->K3, e_in=4
+
+
+# --------------------------------------------------------------- byte fidelity
+
+
+def test_resolver_source_stages_bitwise_like_local_segments(segments, tmp_path):
+    """The adapter is byte-faithful: same plan, same layer, same bytes as
+    LocalSegmentSource (which T4 pinned bitwise to a fresh-built layer)."""
+    root, ckpt = segments
+    local_state = toy.cpu_layer_state(fq_swap, ckpt, T0_GLOBALS, T1_GLOBALS)
+    make_engine(fq_swap.LocalSegmentSource(root), local_state).apply(
+        PLAN, quiesce=nullcontext())
+
+    resolver = tf.resolver(root, tmp_path)  # local segment dir = manifest dir
+    source = fq_swap.ResolverFragmentSource(resolver)
+    state = toy.cpu_layer_state(fq_swap, ckpt, T0_GLOBALS, T1_GLOBALS)
+    report = make_engine(source, state).apply(PLAN, quiesce=nullcontext())
+
+    assert report.pairs == 1 and report.dropped == ()
+    assert source.reads == 2 and resolver.stats["local"] == 2
+    toy.assert_states_equal(state, local_state)
+    toy.assert_states_equal(
+        state, toy.cpu_layer_state(fq_swap, ckpt, [0, 2, 1, 5, 6], [3, 4, 7]))
+
+
+def test_resolver_source_stages_from_a_remote_with_verification(tmp_path):
+    """No local segments at all: the swap's bytes come from a remote source
+    through ranged reads and are sha-verified before they are staged —
+    boot's verification, applied to a runtime swap."""
+    remote = tmp_path / "remote"
+    ckpt = make_segments(remote)
+    resolver = tf.resolver(manifest_dir(tmp_path / "empty"), tmp_path,
+                           sources=[tf.FakeSource(remote)])
+    state = toy.cpu_layer_state(fq_swap, ckpt, T0_GLOBALS, T1_GLOBALS)
+    make_engine(fq_swap.ResolverFragmentSource(resolver), state).apply(
+        PLAN, quiesce=nullcontext())
+
+    assert resolver.stats["fetched"] == 2 and resolver.stats["verified"] == 2
+    assert resolver.stats["local"] == 0
+    toy.assert_states_equal(
+        state, toy.cpu_layer_state(fq_swap, ckpt, [0, 2, 1, 5, 6], [3, 4, 7]))
+
+
+def test_resolver_source_reuses_the_fragment_cache(tmp_path):
+    """Fetched fragments stay in the content-addressed cache: the next
+    process staging the same swap — the other TP rank, or this rank after a
+    restart — reads zero remote bytes and re-verifies from disk."""
+    remote = tmp_path / "remote"
+    ckpt = make_segments(remote)
+    first = tf.resolver(manifest_dir(tmp_path / "empty"), tmp_path,
+                        sources=[tf.FakeSource(remote)])
+    state = toy.cpu_layer_state(fq_swap, ckpt, T0_GLOBALS, T1_GLOBALS)
+    make_engine(fq_swap.ResolverFragmentSource(first), state).apply(
+        PLAN, quiesce=nullcontext())
+    assert first.stats["fetched"] == 2
+
+    src2 = tf.FakeSource(remote)  # fresh resolver + source, same cache dir
+    second = tf.resolver(manifest_dir(tmp_path / "empty"), tmp_path,
+                         sources=[src2])
+    peer = toy.cpu_layer_state(fq_swap, ckpt, T0_GLOBALS, T1_GLOBALS)
+    make_engine(fq_swap.ResolverFragmentSource(second), peer).apply(
+        PLAN, quiesce=nullcontext())
+    assert second.stats["cache"] == 2 and second.stats["fetched"] == 0
+    assert src2.range_reads == 0, "re-staged the swap over the network"
+    toy.assert_states_equal(peer, state)
+
+
+# ------------------------------------------------------- trust rejection path
+
+
+def untrusted_resolver(tmp_path, *, drop_attestations=True):
+    """Real resolver, real trust filtering (10 §4): a signer is configured,
+    so a remote whose attestation is missing/unsigned-by-it is refused."""
+    remote = tmp_path / "remote"
+    ckpt = make_segments(remote, attest=not drop_attestations)
+    md = manifest_dir(tmp_path / "empty", signer_pubkey="ab" * 32)
+    resolver = tf.resolver(
+        md, tmp_path,
+        sources=[tf.FakeSource(remote, drop_attestations=drop_attestations)])
+    assert resolver.trust_enabled
+    return resolver, ckpt
+
+
+def test_trust_rejection_raises_by_default(tmp_path):
+    """Fail-closed default: an untrusted source is an error, not a silent
+    no-op — an operator who did not ask for pending promotions sees it."""
+    resolver, ckpt = untrusted_resolver(tmp_path)
+    state = toy.cpu_layer_state(fq_swap, ckpt, T0_GLOBALS, T1_GLOBALS)
+    engine = make_engine(fq_swap.ResolverFragmentSource(resolver), state)
+    with pytest.raises(fq_swap.FragmentUnavailable, match="resolver refused"):
+        engine.stage(PLAN)
+    toy.assert_states_equal(
+        state, toy.cpu_layer_state(fq_swap, ckpt, T0_GLOBALS, T1_GLOBALS))
+
+
+def test_trust_rejection_drops_the_promotion(tmp_path):
+    """07 §1 pending promotion: with ``on_unavailable="drop"`` the refused
+    pair leaves the swap list instead of crashing the interval; both experts
+    keep their tier, so per-layer K4 cardinality is untouched (D1)."""
+    resolver, ckpt = untrusted_resolver(tmp_path)
+    source = fq_swap.ResolverFragmentSource(resolver)
+    state = toy.cpu_layer_state(fq_swap, ckpt, T0_GLOBALS, T1_GLOBALS)
+    engine = make_engine(source, state)
+
+    staged = engine.stage(PLAN, on_unavailable="drop")
+    assert len(staged.plan) == 0 and staged.requested_plan == PLAN
+    assert [d.swap for d in staged.dropped] == [(toy.LAYER_ID, 1, 4)]
+    assert "not-trusted" in staged.dropped[0].reason or \
+        "no-attestation" in staged.dropped[0].reason
+    assert staged.slab_ops == [] and staged.map_ops == []
+    assert source.unavailable >= 1
+    assert resolver.stats["reject_no_attestation"] >= 1
+
+    report = engine.apply(staged=staged, quiesce=nullcontext())
+    assert report.pairs == 0 and len(report.dropped) == 1
+    toy.assert_states_equal(
+        state, toy.cpu_layer_state(fq_swap, ckpt, T0_GLOBALS, T1_GLOBALS))
+
+
+def test_partial_supply_applies_the_rest_and_preserves_cardinality(tmp_path):
+    """Two-pair plan, one pair unavailable: the supplied pair applies, the
+    refused one pends, occupancy stays at capacity, and the policy document
+    the caller persists must be derived from ``staged.plan``."""
+    root = tmp_path / "segments"
+    ckpt = make_segments(root)
+    resolver = tf.resolver(root, tmp_path)
+    supplied = fq_swap.ResolverFragmentSource(resolver)
+
+    class HalfSupply:
+        """Refuses everything about expert 7 (its K4 encode has not landed)."""
+
+        def read_expert(self, *, layer, k, expert, rank, dest):
+            if expert == 7:
+                raise fr.FragmentUnavailableError(
+                    f"L{layer}/e{expert} K{k}: no source has it")
+            supplied.read_expert(layer=layer, k=k, expert=expert, rank=rank,
+                                 dest=dest)
+
+    state = toy.cpu_layer_state(fq_swap, ckpt, T0_GLOBALS, T1_GLOBALS)
+    engine = make_engine(HalfSupply(), state, max_pairs=2)
+    plan = fq_swap.SwapPlan([(toy.LAYER_ID, 1, 4), (toy.LAYER_ID, 7, 6)])
+
+    staged = engine.stage(plan, on_unavailable="drop")
+    assert staged.plan.swaps == ((toy.LAYER_ID, 1, 4),)
+    assert [(d.swap, d.expert, d.k) for d in staged.dropped] == [
+        ((toy.LAYER_ID, 7, 6), 7, 3)]
+    report = engine.apply(staged=staged, quiesce=nullcontext())
+    assert report.pairs == 1 and report.generation == 1
+
+    # Only the supplied pair moved; expert 7 is still K4, 6 still K3.
+    toy.assert_states_equal(
+        state, toy.cpu_layer_state(fq_swap, ckpt, [0, 2, 1, 5, 6], [3, 4, 7]))
+    assert sorted(state.tier1_globals) == [3, 4, 7]
+    assert len(state.tier1_globals) == len(T1_GLOBALS)  # cardinality preserved
+
+    bits = {e: 4 if e in state.tier1_globals else 3 for e in range(E)}
+    assert bits[7] == 4 and bits[6] == 3 and bits[4] == 4 and bits[1] == 3
+
+
+# ------------------------------------------- fallback ladder / fake resolvers
+
+
+class FakeResolver:
+    """Minimal resolver stand-in: ``resolve`` + ``materialize`` is the whole
+    protocol ResolverFragmentSource needs."""
+
+    def __init__(self, inner, *, mutate=None, substitute_k=None, error=None):
+        self.inner = inner
+        self.mutate = mutate
+        self.substitute_k = substitute_k
+        self.error = error
+
+    def resolve(self, layer, expert, k):
+        if self.error is not None:
+            raise self.error
+        want = self.substitute_k or k
+        fragment = self.inner.resolve(layer, expert, want)
+        fragment.requested_k = k
+        return fragment
+
+    def materialize(self, fragment, *, name_filter=None):
+        pairs = self.inner.materialize(fragment, name_filter=name_filter)
+        return self.mutate(pairs) if self.mutate else pairs
+
+
+def test_substituted_k_pends_the_promotion(segments, tmp_path):
+    """The K-fallback ladder answering K4 with a K3 fragment means the encode
+    has not landed (07 §1) — and its rows would not even fit the K4 slab.
+    The promotion pends; the resolver has already queued the encode."""
+    root, ckpt = segments
+    resolver = FakeResolver(tf.resolver(root, tmp_path), substitute_k=3)
+    source = fq_swap.ResolverFragmentSource(resolver)
+    state = toy.cpu_layer_state(fq_swap, ckpt, T0_GLOBALS, T1_GLOBALS)
+    engine = make_engine(source, state)
+
+    staged = engine.stage(PLAN, on_unavailable="drop")
+    assert len(staged.plan) == 0
+    assert "substituted K3" in staged.dropped[0].reason
+    assert staged.dropped[0].expert == 4 and staged.dropped[0].k == 4
+    # The demotion side (K3, expert 1) was supplied fine — only the K4 read
+    # pended, and the pair went with it.
+    with pytest.raises(fq_swap.FragmentUnavailable, match="substituted"):
+        engine.stage(PLAN)
+
+
+def test_structural_faults_stay_fatal_even_when_dropping(segments, tmp_path):
+    """Corruption is not supply: a fragment that resolves but is malformed
+    must fail the interval loudly, with or without ``drop``."""
+    root, ckpt = segments
+    inner = tf.resolver(root, tmp_path)
+    state = toy.cpu_layer_state(fq_swap, ckpt, T0_GLOBALS, T1_GLOBALS)
+
+    def drop_a_tensor(pairs):
+        return [(n, t) for n, t in pairs if not n.endswith("gate_proj.rank0.suh")]
+
+    engine = make_engine(fq_swap.ResolverFragmentSource(
+        FakeResolver(inner, mutate=drop_a_tensor)), state)
+    with pytest.raises(KeyError, match="missing"):
+        engine.stage(PLAN, on_unavailable="drop")
+
+    def wrong_shape(pairs):
+        return [(n, torch.zeros(3, dtype=t.dtype) if n.endswith(
+            "up_proj.rank0.suh") else t) for n, t in pairs]
+
+    engine = make_engine(fq_swap.ResolverFragmentSource(
+        FakeResolver(inner, mutate=wrong_shape)), state)
+    with pytest.raises(ValueError, match="stage expects"):
+        engine.stage(PLAN, on_unavailable="drop")
+
+    # A programming error in the resolver is not a supply failure either.
+    engine = make_engine(fq_swap.ResolverFragmentSource(
+        FakeResolver(inner, error=RuntimeError("boom"))), state)
+    with pytest.raises(RuntimeError, match="boom"):
+        engine.stage(PLAN, on_unavailable="drop")
+    toy.assert_states_equal(
+        state, toy.cpu_layer_state(fq_swap, ckpt, T0_GLOBALS, T1_GLOBALS))
+
+
+def test_foreign_mcg_from_a_source_is_still_refused(segments, tmp_path):
+    """The layer-wide MCG codebook check (r33 pins the LUT ABI) applies to
+    resolver-staged fragments too — a foreign encoding is corruption."""
+    root, ckpt = segments
+    resolver = tf.resolver(root, tmp_path)
+    state = toy.cpu_layer_state(fq_swap, ckpt, T0_GLOBALS, T1_GLOBALS)
+    engine = make_engine(fq_swap.ResolverFragmentSource(resolver), state,
+                         expected_mcg=None)
+    engine.expected_mcg = 12345
+    with pytest.raises(ValueError, match="mcg"):
+        engine.stage(PLAN, on_unavailable="drop")
+
+
+def test_is_unavailable_error_classification():
+    """The droppable set is matched by class name across the MRO so swap.py
+    keeps importing standalone (the GPU harness loads it by path)."""
+    assert fq_swap.is_unavailable_error(fr.FragmentUnavailableError("x"))
+    assert fq_swap.is_unavailable_error(fr.FragmentVerificationError("x"))
+    assert fq_swap.is_unavailable_error(fq_swap.FragmentUnavailable("x"))
+
+    class MySourceUnavailable(fr.FragmentUnavailableError):
+        pass
+
+    assert fq_swap.is_unavailable_error(MySourceUnavailable("x"))
+    for exc in (ValueError("x"), KeyError("x"), RuntimeError("x"),
+                MemoryError()):
+        assert not fq_swap.is_unavailable_error(exc)
+
+
+def test_stage_rejects_unknown_on_unavailable(segments, tmp_path):
+    root, ckpt = segments
+    state = toy.cpu_layer_state(fq_swap, ckpt, T0_GLOBALS, T1_GLOBALS)
+    engine = make_engine(fq_swap.LocalSegmentSource(root), state)
+    with pytest.raises(ValueError, match="raise\\|drop"):
+        engine.stage(PLAN, on_unavailable="ignore")
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v", "-p", "no:cacheprovider"]))

--- a/tests/exl3_fungible/test_swap_resolver_cpu.py
+++ b/tests/exl3_fungible/test_swap_resolver_cpu.py
@@ -389,4 +389,7 @@ def test_stage_rejects_unknown_on_unavailable(segments, tmp_path):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__, "-v", "-p", "no:cacheprovider"]))
+    sys.exit(pytest.main([
+        __file__, "-v", "-p", "no:cacheprovider",
+        "--confcutdir", os.path.dirname(os.path.abspath(__file__)),
+    ]))

--- a/tests/exl3_fungible/test_swap_t5_cpu.py
+++ b/tests/exl3_fungible/test_swap_t5_cpu.py
@@ -1,0 +1,262 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""T5 (CPU half) — torn-update fault injection on the layer STATE.
+
+The GPU half (``test_swap_t5_gpu.py``) aborts the commit protocol at every
+step k and compares the kernel's forward output. This half aborts at exactly
+the same points and compares a sha256 over *every byte the kernel would
+read* — both slabs, all four combined rotation/suh/svh tables, both maps.
+That is strictly stronger than comparing one forward (a forward only reads
+the rows its routes touch) and it needs no GPU, so the property is defended
+in the always-green CPU suite.
+
+Abort points, k = 0..5 (02 §Commit protocol):
+
+    0 quiesce   the engine pause itself fails — nothing must be written
+    1 slabs     slab rows written
+    2 rotations suh/svh/rotation rows written
+    3 maps      map contents flipped   <-- the visibility flip
+    4 memo      FusedMoEQuantConfig memo nulled
+    5 persist   policy generation bumped + current.json committed
+
+Property: every abort point yields either the fully-old or the fully-new
+state — never a third one. Below the flip that requires the engine's
+fail-atomic staging (``stage(fail_atomic=True)``), and this file also proves
+the *converse*: without it, a pre-flip abort really does leave a torn layer
+(so the guard is load-bearing, and the equalities above are not vacuous).
+"""
+import os
+import sys
+from contextlib import contextmanager, nullcontext
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import toy_segments as toy  # noqa: E402
+
+fq_swap = toy.load_tree_module("swap")  # never the rootfs' synced copy
+fq_store = toy.load_tree_module("store")
+
+E = 8
+T0_GLOBALS = [0, 2, 4, 5, 6]  # K3 tier, slot order
+T1_GLOBALS = [3, 1, 7]        # K4 tier, slot order
+PLAN = ((toy.LAYER_ID, 1, 4),)  # e_out=1 (K4->K3), e_in=4 (K3->K4)
+POST_T0, POST_T1 = [0, 2, 1, 5, 6], [3, 4, 7]
+
+# k=0 is the pause failing; k=1..5 are COMMIT_STEPS.
+ABORT_POINTS = ("quiesce", *fq_swap.COMMIT_STEPS)
+PRE_FLIP = ("quiesce", "slabs", "rotations")
+POST_FLIP = ("maps", "memo", "persist")
+
+
+class Abort(RuntimeError):
+    """The injected fault."""
+
+
+@contextmanager
+def failing_quiesce():
+    raise Abort("quiesce")
+    yield  # pragma: no cover
+
+
+def abort_after(step):
+    def hook(name):
+        if name == step:
+            raise Abort(name)
+    return hook
+
+
+@pytest.fixture(scope="module")
+def toy_root(tmp_path_factory):
+    root = tmp_path_factory.mktemp("fq-t5-cpu")
+    ckpt = toy.make_toy_checkpoint(E)
+    toy.write_toy_segments(root, ckpt)
+    return root, ckpt
+
+
+def make_engine(root, state, **kw):
+    return fq_swap.SwapEngine(
+        {toy.LAYER_ID: state}, fq_swap.LocalSegmentSource(root),
+        hidden_size=toy.HIDDEN, intermediate_size=toy.INTERMEDIATE,
+        pin_memory=False, build_maps_fn=toy.build_maps_reference,
+        expected_mcg=toy.MCG, **kw)
+
+
+def fresh(ckpt, t0=None, t1=None):
+    return toy.cpu_layer_state(fq_swap, ckpt, t0 or T0_GLOBALS, t1 or T1_GLOBALS)
+
+
+def run_aborted(engine, at, *, fail_atomic=True, plan=PLAN, **apply_kw):
+    """Stage ``plan``, abort the commit at ``at``, return the staged batch."""
+    staged = engine.stage(fq_swap.SwapPlan(plan), fail_atomic=fail_atomic)
+    quiesce = failing_quiesce() if at == "quiesce" else nullcontext()
+    hook = None if at == "quiesce" else abort_after(at)
+    with pytest.raises(Abort):
+        engine.apply(staged=staged, quiesce=quiesce, step_hook=hook,
+                     **apply_kw)
+    return staged
+
+
+# --------------------------------------------------------------------- T5
+
+
+def test_t5_no_torn_state_is_observable(toy_root):
+    """The property: over all six abort points the layer is only ever
+    fully-old or fully-new — exactly two distinct byte states."""
+    root, ckpt = toy_root
+    pre = toy.state_fingerprint(fresh(ckpt))
+    post = toy.state_fingerprint(fresh(ckpt, POST_T0, POST_T1))
+    assert pre != post, "the swap is a no-op — the whole test would be vacuous"
+
+    seen = {}
+    for at in ABORT_POINTS:
+        state = fresh(ckpt)
+        engine = make_engine(root, state)
+        staged = run_aborted(engine, at)
+        seen[at] = toy.state_fingerprint(state)
+
+        if at in PRE_FLIP:
+            assert seen[at] == pre, f"abort at {at} left a torn layer"
+            assert state.tier1_globals == T1_GLOBALS  # host view agrees
+            assert engine.generation == 0
+            assert staged.restored is (at != "quiesce")
+        else:
+            assert seen[at] == post, f"abort at {at} did not commit the swap"
+            assert state.tier1_globals == POST_T1  # host view agrees
+            assert engine.generation == 1
+            assert staged.restored is False
+
+    assert set(seen.values()) == {pre, post}, (
+        "an abort point produced a THIRD state: "
+        f"{ {k: v[:8] for k, v in seen.items()} }")
+    assert [at for at, sha in seen.items() if sha == pre] == list(PRE_FLIP)
+    assert [at for at, sha in seen.items() if sha == post] == list(POST_FLIP)
+
+
+def test_t5_without_fail_atomic_the_torn_state_is_real(toy_root):
+    """Converse (non-vacuity): with the same abort and no fail-atomic
+    staging, the layer IS torn — a third state, distinct from both. This is
+    what the restore buys, and it proves the harness can see tearing."""
+    root, ckpt = toy_root
+    pre = toy.state_fingerprint(fresh(ckpt))
+    post = toy.state_fingerprint(fresh(ckpt, POST_T0, POST_T1))
+
+    torn = {}
+    for at in ("slabs", "rotations"):
+        state = fresh(ckpt)
+        engine = make_engine(root, state)
+        staged = run_aborted(engine, at, fail_atomic=False)
+        assert staged.undo_ops is None and staged.restored is False
+        torn[at] = toy.state_fingerprint(state)
+        assert torn[at] not in (pre, post), (
+            f"abort at {at} without fail-atomic was harmless — the T5 "
+            "restore assertions would be vacuous")
+
+        # Roll forward: re-applying the same plan is the other legal repair.
+        engine.apply(fq_swap.SwapPlan(PLAN), quiesce=nullcontext())
+        assert toy.state_fingerprint(state) == post
+    assert torn["slabs"] != torn["rotations"]  # tearing grows with each step
+
+
+def test_t5_abort_then_inverse_plan_restores_pre_swap(toy_root):
+    """The 02 §Rollback path after a *committed* abort: the flip landed, so
+    the swap is real and the repair is the inverse plan (fragments re-read
+    from the artifact pair) — pre-swap bytes come back exactly."""
+    root, ckpt = toy_root
+    pre = toy.state_fingerprint(fresh(ckpt))
+    state = fresh(ckpt)
+    engine = make_engine(root, state)
+
+    run_aborted(engine, "memo")  # committed, but the memo hook blew up
+    assert state.tier1_globals == POST_T1
+    engine.apply(fq_swap.SwapPlan(PLAN).inverse(), quiesce=nullcontext())
+    assert toy.state_fingerprint(state) == pre
+    assert state.tier1_globals == T1_GLOBALS
+    assert engine.generation == 2
+
+
+def test_t5_restored_engine_is_still_usable(toy_root):
+    """A pre-flip abort must not poison the engine: the very next apply of
+    the same plan must land the full, correct swap."""
+    root, ckpt = toy_root
+    post = toy.state_fingerprint(fresh(ckpt, POST_T0, POST_T1))
+    state = fresh(ckpt)
+    engine = make_engine(root, state)
+
+    run_aborted(engine, "rotations")
+    report = engine.apply(fq_swap.SwapPlan(PLAN), quiesce=nullcontext())
+    assert report.generation == 1 and report.pairs == 1
+    assert toy.state_fingerprint(state) == post
+    toy.assert_states_equal(state, fresh(ckpt, POST_T0, POST_T1))
+
+
+def test_t5_multi_pair_abort_restores_every_pair(toy_root):
+    """Two pairs in one layer: a mid-commit abort must restore BOTH, not
+    just the one that was mid-write."""
+    root, ckpt = toy_root
+    pre = toy.state_fingerprint(fresh(ckpt))
+    state = fresh(ckpt)
+    engine = make_engine(root, state, max_pairs=2)
+    plan = ((toy.LAYER_ID, 3, 0), (toy.LAYER_ID, 7, 6))
+
+    run_aborted(engine, "rotations", plan=plan)
+    assert toy.state_fingerprint(state) == pre
+    assert state.tier0_globals == T0_GLOBALS
+    assert state.tier1_globals == T1_GLOBALS
+
+    engine.apply(fq_swap.SwapPlan(plan), quiesce=nullcontext())
+    toy.assert_states_equal(state, fresh(ckpt, [3, 2, 4, 5, 7], [0, 1, 6]))
+
+
+def test_t5_persist_failure_leaves_the_swap_committed(toy_root, tmp_path):
+    """The realistic step-5 fault (disk full / read-only cache): the flip has
+    landed, so the swap IS committed and the host view must say so; only the
+    persisted policy is missing, which boot recovers by rehydrating the
+    previous committed policy (T8)."""
+    root, ckpt = toy_root
+    post = toy.state_fingerprint(fresh(ckpt, POST_T0, POST_T1))
+    state = fresh(ckpt)
+    engine = make_engine(root, state)
+
+    class ExplodingStore(fq_store.PolicyStore):
+        def commit(self, doc, *, num_experts=None):
+            raise OSError("No space left on device")
+
+    store = ExplodingStore(tmp_path, "toy-manifest")
+    doc = {
+        "schema": "fq-policy/2",
+        "manifest": "toy-manifest",
+        "budget": {"n_k4_per_layer": {str(toy.LAYER_ID): 3}},
+        "bits_per_expert": {str(toy.LAYER_ID): [3, 3, 3, 4, 4, 3, 3, 4]},
+    }
+    staged = engine.stage(fq_swap.SwapPlan(PLAN), fail_atomic=True)
+    with pytest.raises(OSError, match="No space"):
+        engine.apply(staged=staged, quiesce=nullcontext(), policy_store=store,
+                     policy_doc=doc, policy_num_experts=E)
+
+    assert toy.state_fingerprint(state) == post
+    assert state.tier1_globals == POST_T1 and engine.generation == 1
+    assert staged.restored is False
+    assert store.load_current(num_experts=E) is None  # nothing torn on disk
+
+
+def test_t5_fail_atomic_staging_costs_only_reads(toy_root):
+    """Fail-atomic staging must not change what the commit writes: the same
+    op lists, the same H2D byte count — only extra host-side reads."""
+    root, ckpt = toy_root
+    plain = make_engine(root, fresh(ckpt)).stage(fq_swap.SwapPlan(PLAN))
+    atomic = make_engine(root, fresh(ckpt)).stage(fq_swap.SwapPlan(PLAN),
+                                                  fail_atomic=True)
+    assert plain.undo_ops is None and atomic.fail_atomic
+    assert plain.bytes_h2d == atomic.bytes_h2d
+    assert len(plain.slab_ops) == len(atomic.slab_ops) == 6
+    assert len(plain.rotation_ops) == len(atomic.rotation_ops) == 8
+    # The restore batch covers every destination the commit touches.
+    assert len(atomic.undo_ops) == 6 + 8 + 2
+    written = {t.data_ptr() for t, _ in atomic.slab_ops + atomic.rotation_ops
+               + atomic.map_ops}
+    assert {t.data_ptr() for t, _ in atomic.undo_ops} == written
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v", "-p", "no:cacheprovider"]))

--- a/tests/exl3_fungible/test_swap_t5_cpu.py
+++ b/tests/exl3_fungible/test_swap_t5_cpu.py
@@ -259,4 +259,7 @@ def test_t5_fail_atomic_staging_costs_only_reads(toy_root):
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__, "-v", "-p", "no:cacheprovider"]))
+    sys.exit(pytest.main([
+        __file__, "-v", "-p", "no:cacheprovider",
+        "--confcutdir", os.path.dirname(os.path.abspath(__file__)),
+    ]))

--- a/tests/exl3_fungible/test_swap_t5_gpu.py
+++ b/tests/exl3_fungible/test_swap_t5_gpu.py
@@ -1,0 +1,403 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""T5 — torn-update fault injection (03-testing-validation.md, GPU).
+
+Deliberately abort the commit protocol after step k, for every k, and ask the
+kernel what it sees. The property (02 §Commit protocol):
+
+    every intermediate visible state is either fully-old or fully-new —
+    no abort point may produce a third distinct output.
+
+Abort points, k = 0..5:
+
+    0 quiesce   the engine pause itself fails — nothing is written
+    1 slabs     slab rows (w13 gate+up, w2) written
+    2 rotations combined suh/svh/intermediate-rotation rows written
+    3 maps      map contents flipped        <-- the visibility flip
+    4 memo      FusedMoEQuantConfig memo nulled
+    5 persist   generation bumped + policy committed
+
+k < 3 must forward bitwise-equal to the PRE-swap output; k >= 3 bitwise-equal
+to the POST-swap output (the fresh-built layer with the new membership, which
+T4 pinned the successful apply to).
+
+What makes k in {1, 2} true is not ordering alone: in the v1 row-write design
+the two destination rows are both live, so writing them *is* the tear. The
+engine's contract is that the write window is quiesced AND that an abort
+inside it restores the pre-swap rows before the window is released
+(``stage(fail_atomic=True)``). This file proves both halves — the restore
+holds the property, and removing it produces a genuine third output, so the
+equalities are not vacuous. It also replays a CUDA graph across an aborted
+swap: a restore that the graph could not see would be worse than useless.
+
+Run in the gg r33 env from a neutral cwd, on ONE free GPU::
+
+    CUDA_VISIBLE_DEVICES=<free> .../runs/gg-env/gg-run.sh \
+        python /home/mbelleau/src/gg-vllm/tests/exl3_fungible/test_swap_t5_gpu.py
+"""
+from __future__ import annotations
+
+import hashlib
+import os
+import sys
+from contextlib import contextmanager, nullcontext
+
+import pytest
+import torch
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import toy_segments as toy  # noqa: E402
+
+fq_swap = toy.load_tree_module("swap")  # never the rootfs' synced copy
+
+try:
+    from b12x.moe._shared.kernels.w4a16.host import max_packed_route_slots
+    from b12x.moe._shared.kernels.w4a16.mixed_trellis import (
+        build_tiered_maps,
+        combine_trellis_rotations,
+        compile_mixed_trellis,
+        make_mixed_trellis_buffers,
+        run_mixed_trellis,
+    )
+    from b12x.moe._shared.kernels.w4a16.prepare import (
+        prepare_trellis256_moe_weights,
+    )
+    HAVE_B12X = True
+except ImportError:
+    HAVE_B12X = False
+
+
+def _sm12x_available() -> bool:
+    if not torch.cuda.is_available():
+        return False
+    major, _ = torch.cuda.get_device_capability()
+    return major == 12
+
+
+pytestmark = pytest.mark.skipif(
+    not (HAVE_B12X and _sm12x_available()),
+    reason="requires b12x and an SM120/SM121 GPU")
+
+# ------------------------------------------------------------------ geometry
+# Same toy layer as T3/T4: E=16 = 12 K3 + 4 K4.
+M, TOPK, MOE_BLOCK = 8, 4, 8
+TIER0_GLOBALS = [0, 1, 2, 4, 5, 6, 8, 9, 10, 12, 13, 14]
+TIER1_GLOBALS = [3, 7, 11, 15]
+ROUTES16 = (
+    (0, 3, 14, 5),
+    (1, 11, 4, 8),
+    (10, 12, 3, 14),
+    (5, 0, 11, 1),
+    (15, 8, 12, 10),
+    (4, 7, 13, 0),
+    (11, 14, 5, 12),
+    (9, 10, 2, 6),
+)
+
+E_OUT, E_IN = 7, 6  # K4 slot 1 out, K3 slot 5 in — middle rows of both tiers
+PLAN = ((toy.LAYER_ID, E_OUT, E_IN),)
+POST_T0 = [0, 1, 2, 4, 5, 7, 8, 9, 10, 12, 13, 14]
+POST_T1 = [3, 6, 11, 15]
+
+ABORT_POINTS = ("quiesce", *fq_swap.COMMIT_STEPS)
+PRE_FLIP = ("quiesce", "slabs", "rotations")
+POST_FLIP = ("maps", "memo", "persist")
+
+_NOTES: list[str] = []
+
+
+class Abort(RuntimeError):
+    """The injected fault."""
+
+
+@contextmanager
+def failing_quiesce():
+    raise Abort("quiesce")
+    yield  # pragma: no cover
+
+
+def abort_after(step):
+    def hook(name):
+        if name == step:
+            raise Abort(name)
+    return hook
+
+
+# ------------------------------------------------------------------- harness
+
+
+def _device():
+    return torch.device("cuda", torch.cuda.current_device())
+
+
+def _build_state(ckpt, t0_globals, t1_globals, device):
+    """Fresh-built mixed layer from checkpoint tensors (exl3.py's assembly)."""
+    prepared = []
+    for globals_, bits in ((t0_globals, 3), (t1_globals, 4)):
+        t = {k: v.to(device) for k, v in toy.assemble_membership_tensors(
+            ckpt, globals_, bits).items()}
+        prepared.append(prepare_trellis256_moe_weights(
+            w13=t["w13"].contiguous(),
+            w2=t["w2"].contiguous(),
+            hidden_size=toy.HIDDEN,
+            intermediate_size=toy.INTERMEDIATE,
+            num_experts=len(globals_),
+            activation="silu",
+            fc1_tile_n=toy.TILE_CONFIG[1],
+            fc2_tile_n=toy.TILE_CONFIG[3],
+            params_dtype=torch.float16,
+            w13_layout="trellis3_t256_proj",
+            trellis_bits=bits,
+            gate_suh=t["gate_suh"].contiguous(),
+            up_suh=t["up_suh"].contiguous(),
+            intermediate_rotations=t["intermediate"].contiguous(),
+            down_svh=t["down_svh"].contiguous(),
+            tile_config=toy.TILE_CONFIG,
+        ))
+    g2c, desc = build_tiered_maps(t0_globals, t1_globals, device=device)
+    return fq_swap.MixedLayerState(
+        tier0=prepared[0], tier1=prepared[1],
+        rotations=combine_trellis_rotations(*prepared),
+        global_to_combined=g2c, descriptor_map=desc,
+        tier0_globals=list(t0_globals), tier1_globals=list(t1_globals),
+        mcg=toy.MCG)
+
+
+def _compile(device, cap0, cap1):
+    props = torch.cuda.get_device_properties(device)
+    route_slots = max_packed_route_slots(M * TOPK, MOE_BLOCK, cap0 + cap1)
+    return compile_mixed_trellis(
+        size_m=M,
+        hidden_size=toy.HIDDEN,
+        intermediate_size=toy.INTERMEDIATE,
+        tier0_num_experts=cap0,
+        tier1_num_experts=cap1,
+        top_k=TOPK,
+        max_m_blocks=(route_slots + MOE_BLOCK - 1) // MOE_BLOCK,
+        sms=int(props.multi_processor_count),
+        max_shared_mem=int(props.shared_memory_per_block_optin),
+        force_tile_config=toy.TILE_CONFIG,
+        moe_block_size=MOE_BLOCK,
+        route_ids_dtype=torch.int32,
+    ), int(props.multi_processor_count)
+
+
+def _forward(state, launch, sms, probe, *, buffers=None):
+    x, topk_weights, topk_ids = probe
+    if buffers is None:
+        buffers = make_mixed_trellis_buffers(launch, device=x.device, sms=sms)
+    return run_mixed_trellis(
+        x, state.tier0, state.tier1, topk_weights, topk_ids,
+        state.global_to_combined, state.descriptor_map, state.rotations,
+        launch, buffers)
+
+
+def _out(state, launch, sms, probe):
+    out = _forward(state, launch, sms, probe)
+    torch.cuda.synchronize(probe[0].device)
+    return out.clone()
+
+
+def _sha(t: torch.Tensor) -> str:
+    return hashlib.sha256(
+        t.detach().cpu().contiguous().view(torch.uint8).numpy().tobytes()
+    ).hexdigest()
+
+
+def _probe(device):
+    torch.manual_seed(20260810)
+    x = (torch.randn((M, toy.HIDDEN), device=device) * 1.0e-3).to(torch.bfloat16)
+    topk_ids = torch.tensor(ROUTES16, dtype=torch.int32, device=device)
+    topk_weights = torch.softmax(
+        torch.randn((M, TOPK), dtype=torch.float32, device=device), dim=-1)
+    return x, topk_weights, topk_ids
+
+
+@contextmanager
+def _quiesce(device):
+    """Test stand-in for the engine pause: nothing in flight; sync on exit."""
+    yield
+    torch.cuda.synchronize(device)
+
+
+@pytest.fixture(scope="module")
+def toy_gpu(tmp_path_factory):
+    root = tmp_path_factory.mktemp("fq-toy-segments-t5")
+    ckpt = toy.make_toy_checkpoint(16)
+    toy.write_toy_segments(root, ckpt)
+    device = _device()
+    launch, sms = _compile(device, len(TIER0_GLOBALS), len(TIER1_GLOBALS))
+    probe = _probe(device)
+    pre = _out(_build_state(ckpt, TIER0_GLOBALS, TIER1_GLOBALS, device),
+               launch, sms, probe)
+    post = _out(_build_state(ckpt, POST_T0, POST_T1, device),
+                launch, sms, probe)
+    assert not torch.equal(pre, post), (
+        "the swapped pair does not change the probe output — T5 would be "
+        "vacuous; pick a routed expert pair")
+    assert not torch.isnan(pre).any() and not torch.isnan(post).any()
+    return root, ckpt, launch, sms, probe, pre, post
+
+
+def _make_engine(root, state, **kw):
+    return fq_swap.SwapEngine(
+        {toy.LAYER_ID: state}, fq_swap.LocalSegmentSource(root),
+        hidden_size=toy.HIDDEN, intermediate_size=toy.INTERMEDIATE,
+        expected_mcg=toy.MCG, **kw)
+
+
+def _run_aborted(engine, at, device, *, fail_atomic=True, plan=PLAN):
+    staged = engine.stage(fq_swap.SwapPlan(plan), fail_atomic=fail_atomic)
+    quiesce = failing_quiesce() if at == "quiesce" else _quiesce(device)
+    hook = None if at == "quiesce" else abort_after(at)
+    with pytest.raises(Abort):
+        engine.apply(staged=staged, quiesce=quiesce, step_hook=hook)
+    torch.cuda.synchronize(device)
+    return staged
+
+
+# ------------------------------------------------------------------------ T5
+
+
+def test_t5_no_torn_state_is_observable(toy_gpu):
+    """Abort after every step k; the forward must be PRE below the flip and
+    POST at or above it, and those must be the only two outputs."""
+    root, ckpt, launch, sms, probe, pre, post = toy_gpu
+    device = _device()
+    seen: dict[str, str] = {}
+
+    for at in ABORT_POINTS:
+        state = _build_state(ckpt, TIER0_GLOBALS, TIER1_GLOBALS, device)
+        engine = _make_engine(root, state)
+        staged = _run_aborted(engine, at, device)
+        out = _out(state, launch, sms, probe)
+        seen[at] = _sha(out)
+
+        if at in PRE_FLIP:
+            assert torch.equal(out, pre), (
+                f"T5 FAIL: abort at {at} left an observable torn state "
+                "(forward differs from the pre-swap output)")
+            assert state.tier1_globals == TIER1_GLOBALS
+            assert engine.generation == 0
+            assert staged.restored is (at != "quiesce")
+        else:
+            assert torch.equal(out, post), (
+                f"T5 FAIL: abort at {at} is at/after the visibility flip but "
+                "the forward is not the post-swap output")
+            assert state.tier1_globals == POST_T1
+            assert engine.generation == 1
+
+    assert set(seen.values()) == {_sha(pre), _sha(post)}, (
+        "an abort point produced a THIRD distinct output: "
+        f"{ {k: v[:8] for k, v in seen.items()} }")
+    _NOTES.append(
+        "abort-point outputs: " + ", ".join(
+            f"{at}={'PRE' if sha == _sha(pre) else 'POST'}"
+            for at, sha in seen.items()))
+
+
+def test_t5_without_fail_atomic_the_torn_state_is_real(toy_gpu):
+    """Non-vacuity + why the restore is load-bearing: the same abort without
+    fail-atomic staging yields a THIRD output (the displaced expert computing
+    with its successor's rows). Rolling the plan forward repairs it."""
+    root, ckpt, launch, sms, probe, pre, post = toy_gpu
+    device = _device()
+    thirds = {}
+    for at in ("slabs", "rotations"):
+        state = _build_state(ckpt, TIER0_GLOBALS, TIER1_GLOBALS, device)
+        engine = _make_engine(root, state)
+        staged = _run_aborted(engine, at, device, fail_atomic=False)
+        assert staged.undo_ops is None and staged.restored is False
+        torn = _out(state, launch, sms, probe)
+        assert not torch.equal(torn, pre) and not torch.equal(torn, post), (
+            f"abort at {at} without fail-atomic was harmless — the T5 "
+            "restore assertions would be vacuous")
+        thirds[at] = _sha(torn)
+
+        engine.apply(fq_swap.SwapPlan(PLAN), quiesce=_quiesce(device))
+        assert torch.equal(_out(state, launch, sms, probe), post), (
+            "rolling the plan forward did not repair the torn layer")
+    _NOTES.append(f"torn-state outputs (no fail-atomic): "
+                  f"{ {k: v[:8] for k, v in thirds.items()} }")
+
+
+def test_t5_abort_then_inverse_plan_restores_pre_swap(toy_gpu):
+    """02 §Rollback after a committed abort (the flip landed): the inverse
+    plan, fragments re-read from the artifact pair, restores the pre-swap
+    output bitwise."""
+    root, ckpt, launch, sms, probe, pre, post = toy_gpu
+    device = _device()
+    state = _build_state(ckpt, TIER0_GLOBALS, TIER1_GLOBALS, device)
+    engine = _make_engine(root, state)
+
+    _run_aborted(engine, "memo", device)
+    assert torch.equal(_out(state, launch, sms, probe), post)
+    engine.apply(fq_swap.SwapPlan(PLAN).inverse(), quiesce=_quiesce(device))
+    assert torch.equal(_out(state, launch, sms, probe), pre), (
+        "inverse plan after an aborted swap did not restore the pre-swap "
+        "output bitwise")
+    assert state.tier1_globals == TIER1_GLOBALS
+
+
+def test_t5_restore_is_visible_to_a_captured_cuda_graph(toy_gpu):
+    """The restore writes into the live slabs/tables/maps, so a CUDA graph
+    captured before the aborted swap must replay the PRE-swap output — the
+    same read-as-data property T3 proved for the flip itself."""
+    root, ckpt, launch, sms, probe, pre, post = toy_gpu
+    device = _device()
+    state = _build_state(ckpt, TIER0_GLOBALS, TIER1_GLOBALS, device)
+    engine = _make_engine(root, state)
+
+    buffers = make_mixed_trellis_buffers(launch, device=device, sms=sms)
+    _forward(state, launch, sms, probe, buffers=buffers)  # warmup
+    torch.cuda.synchronize(device)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = _forward(state, launch, sms, probe, buffers=buffers)
+    graph.replay()
+    torch.cuda.synchronize(device)
+    assert torch.equal(captured, pre), "capture drifted from eager"
+
+    _run_aborted(engine, "rotations", device)
+    graph.replay()
+    torch.cuda.synchronize(device)
+    assert torch.equal(captured, pre), (
+        "T5 FAIL: a graph replay after an aborted-and-restored swap saw a "
+        "torn layer")
+
+    engine.apply(fq_swap.SwapPlan(PLAN), quiesce=_quiesce(device))
+    graph.replay()
+    torch.cuda.synchronize(device)
+    assert torch.equal(captured, post), (
+        "graph replay did not see the completed swap after the restore")
+
+
+def test_t5_multi_pair_abort_restores_every_pair(toy_gpu):
+    """Two pairs, one layer: the restore must cover both, and the completed
+    2-pair swap must still match the fresh-built reference bitwise."""
+    root, ckpt, launch, sms, probe, pre, _post = toy_gpu
+    device = _device()
+    state = _build_state(ckpt, TIER0_GLOBALS, TIER1_GLOBALS, device)
+    engine = _make_engine(root, state, max_pairs=2)
+    plan = ((toy.LAYER_ID, 7, 6), (toy.LAYER_ID, 15, 0))
+
+    _run_aborted(engine, "rotations", device, plan=plan)
+    assert torch.equal(_out(state, launch, sms, probe), pre)
+    assert state.tier0_globals == TIER0_GLOBALS
+    assert state.tier1_globals == TIER1_GLOBALS
+
+    engine.apply(fq_swap.SwapPlan(plan), quiesce=_quiesce(device))
+    reference = _build_state(ckpt, state.tier0_globals, state.tier1_globals,
+                             device)
+    assert torch.equal(_out(state, launch, sms, probe),
+                       _out(reference, launch, sms, probe))
+
+
+if __name__ == "__main__":
+    code = pytest.main([
+        __file__, "-v", "-s", "-p", "no:cacheprovider",
+        "--confcutdir", os.path.dirname(os.path.abspath(__file__)),
+    ])
+    for line in _NOTES:
+        print(f"[t5] {line}")
+    sys.exit(int(code))

--- a/tests/exl3_fungible/test_trust_lazy_cpu.py
+++ b/tests/exl3_fungible/test_trust_lazy_cpu.py
@@ -1,0 +1,517 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU tests for the operator-facing FragmentResolver capabilities:
+configurable multi-repo sources (VLLM_FQ_SOURCES[_MODE]), attestation-based
+trust filtering (VLLM_FQ_TRUST_PREDICATES / VLLM_FQ_TRUST_SIGNERS), the
+lazy-encode fallback ladder (VLLM_FQ_K_FALLBACK + EncodeQueue), and the
+structured decision lines + per-reason stats counters."""
+import base64
+import json
+import logging
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+import test_fragments_cpu as tf
+from test_fragments_cpu import (  # noqa: F401
+    NUM_EXPERTS,
+    FakeSource,
+    make_manifest_dir,
+    resolver,
+    write_segment,
+)
+
+fr = tf.fr
+
+try:
+    from vllm.model_executor.layers.quantization.exl3_fungible import (
+        lazy_encode as le,
+    )
+except ImportError:  # standalone run against an env without built vllm._C
+    import importlib.util
+    from pathlib import Path as _P
+
+    _p = (_P(__file__).resolve().parents[2] / "vllm" / "model_executor"
+          / "layers" / "quantization" / "exl3_fungible" / "lazy_encode.py")
+    _s = importlib.util.spec_from_file_location("fq_lazy_encode_standalone", _p)
+    if _s.name in sys.modules:
+        le = sys.modules[_s.name]
+    else:
+        le = importlib.util.module_from_spec(_s)
+        sys.modules[_s.name] = le
+        _s.loader.exec_module(le)
+
+pytest.importorskip("cryptography")
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (  # noqa: E402
+    Ed25519PrivateKey,
+)
+
+
+# ------------------------------------------------------------- helpers
+
+
+@pytest.fixture
+def fq_log():
+    """Records emitted by the fragments logger (vllm's logger hierarchy has
+    propagate=False, so caplog's root handler never sees them)."""
+    records = []
+
+    class _Handler(logging.Handler):
+        def emit(self, record):
+            records.append(record)
+
+    handler = _Handler(level=logging.DEBUG)
+    old_level = fr.logger.level
+    fr.logger.addHandler(handler)
+    fr.logger.setLevel(logging.DEBUG)
+    yield records
+    fr.logger.removeHandler(handler)
+    fr.logger.setLevel(old_level)
+
+
+def _messages(records):
+    return [r.getMessage() for r in records]
+
+
+class NamedSource(FakeSource):
+    def __init__(self, root, name, **kw):
+        super().__init__(root, **kw)
+        self.name = name
+
+
+def make_key():
+    key = Ed25519PrivateKey.generate()
+    return key, key.public_key().public_bytes_raw().hex()
+
+
+def att_line(key, pub, digests, predicate="repack-of"):
+    """One signed fq-attestation/1 envelope line (fq_repack Signer format)."""
+    payload = {
+        "schema": "fq-attestation/1",
+        "predicate": predicate,
+        "expert_sha256": digests,
+    }
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    return json.dumps({
+        "payload": base64.b64encode(raw).decode(),
+        "signature": base64.b64encode(key.sign(raw)).decode(),
+        "keyid": pub,
+    })
+
+
+def signed_remote(root, layer, k, *, seed, make_lines):
+    """Remote segment root whose attestation lines come from make_lines."""
+    _entry, digests = write_segment(
+        root, layer, k, seed=seed, with_attestation=False
+    )
+    att_dir = root / "attestations"
+    att_dir.mkdir(exist_ok=True)
+    (att_dir / f"layer-{layer:03d}.k{k}.jsonl").write_text(
+        "\n".join(make_lines(digests)) + "\n"
+    )
+    return digests
+
+
+def trusted_manifest_dir(tmp_path, pub, ks=(3,)):
+    d = make_manifest_dir(tmp_path, layers=(3,), ks=ks)
+    manifest = json.loads((d / "fq-manifest.json").read_text())
+    manifest["signer_pubkey"] = pub
+    (d / "fq-manifest.json").write_text(json.dumps(manifest))
+    return d
+
+
+def expected_payload(root, layer, k, expert):
+    entry = json.loads((root / f"index-k{k}.json").read_text())[str(layer)]
+    lo, hi = entry["experts"][str(expert)]
+    raw = (root / entry["file"]).read_bytes()
+    return raw[entry["body_offset"] + lo:entry["body_offset"] + hi]
+
+
+# ------------------------------------------- feature 1: source config
+
+
+def test_env_sources_mode_variants(tmp_path):
+    d = make_manifest_dir(tmp_path, layers=(3,), ks=(3,))
+    manifest = json.loads((d / "fq-manifest.json").read_text())
+    manifest["sources"] = ["org/manifest-src"]
+    (d / "fq-manifest.json").write_text(json.dumps(manifest))
+    factory = lambda spec: SimpleNamespace(name=spec, spec=spec)  # noqa: E731
+
+    def specs(environ):
+        r = resolver(d, tmp_path, environ=environ, source_factory=factory)
+        return [s.spec for s in r.sources]
+
+    env = {"VLLM_FQ_SOURCES": "repoA@r1,repoB"}
+    assert specs(env) == ["repoA@r1", "repoB", "org/manifest-src"]  # prepend
+    assert specs({**env, "VLLM_FQ_SOURCES_MODE": "prepend"}) == [
+        "repoA@r1", "repoB", "org/manifest-src"]
+    assert specs({**env, "VLLM_FQ_SOURCES_MODE": "append"}) == [
+        "org/manifest-src", "repoA@r1", "repoB"]
+    assert specs({**env, "VLLM_FQ_SOURCES_MODE": "replace"}) == [
+        "repoA@r1", "repoB"]
+    assert specs({}) == ["org/manifest-src"]  # no env: manifest chain
+    # dedup: env entry already in the manifest chain appears once
+    assert specs({"VLLM_FQ_SOURCES": "org/manifest-src,repoB"}) == [
+        "org/manifest-src", "repoB"]
+    with pytest.raises(ValueError, match="VLLM_FQ_SOURCES_MODE"):
+        specs({**env, "VLLM_FQ_SOURCES_MODE": "sideways"})
+
+
+def test_env_sources_resolve_order_behavioral(tmp_path):
+    root_env, root_man = tmp_path / "remote-env", tmp_path / "remote-man"
+    write_segment(root_env, 3, 4, seed=5)
+    write_segment(root_man, 3, 4, seed=9)
+    d = make_manifest_dir(tmp_path, layers=(3,), ks=(3,))
+    manifest = json.loads((d / "fq-manifest.json").read_text())
+    manifest["sources"] = ["man/src"]
+    (d / "fq-manifest.json").write_text(json.dumps(manifest))
+    roots = {"env/src": root_env, "man/src": root_man}
+    factory = lambda spec: NamedSource(roots[spec], f"fake:{spec}")  # noqa: E731
+
+    r = resolver(d, tmp_path, environ={"VLLM_FQ_SOURCES": "env/src"},
+                 source_factory=factory)
+    # local dirs always first: the k3 hit never consults any source
+    assert r.resolve(3, 0, 3).origin == "local"
+    frag = r.resolve(3, 0, 4)  # prepend: env source wins
+    assert bytes(frag.payload) == expected_payload(root_env, 3, 4, 0)
+
+    r2 = resolver(d, tmp_path / "c2",
+                  environ={"VLLM_FQ_SOURCES": "env/src",
+                           "VLLM_FQ_SOURCES_MODE": "append"},
+                  source_factory=factory, cache_dir=tmp_path / "c2" / "cache")
+    frag2 = r2.resolve(3, 0, 4)  # append: manifest source wins
+    assert bytes(frag2.payload) == expected_payload(root_man, 3, 4, 0)
+
+
+def test_explicit_sources_kwarg_bypasses_env(tmp_path):
+    d = make_manifest_dir(tmp_path, layers=(3,), ks=(3,))
+    marker = SimpleNamespace(name="explicit")
+    r = resolver(d, tmp_path, sources=[marker],
+                 environ={"VLLM_FQ_SOURCES": "repoA"})
+    assert r.sources == [marker]
+
+
+# ------------------------------------------- feature 2: trust filtering
+
+
+def test_predicate_filtering(tmp_path, fq_log):
+    key, pub = make_key()
+    remote = tmp_path / "remote"
+    signed_remote(remote, 3, 4, seed=9,
+                  make_lines=lambda digests: [att_line(key, pub, digests)])
+    d = trusted_manifest_dir(tmp_path, pub)
+
+    # default predicate list trusts repack-of
+    r_ok = resolver(d, tmp_path, sources=[FakeSource(remote)])
+    assert r_ok.trust_enabled
+    assert r_ok.resolve(3, 0, 4).origin == "fetched"
+
+    # restricted list rejects it
+    r = resolver(d, tmp_path / "c2", cache_dir=tmp_path / "c2" / "cache",
+                 sources=[FakeSource(remote)],
+                 environ={"VLLM_FQ_TRUST_PREDICATES": "encode-of"})
+    with pytest.raises(fr.FragmentUnavailableError):
+        r.resolve(3, 0, 4)
+    assert r.stats["reject_predicate"] == 1
+    assert r.stats["fetched"] == 0
+    assert any("REJECT predicate=repack-of not-trusted" in m
+               for m in _messages(fq_log))
+
+
+def test_signer_rejection_and_countersignature(tmp_path):
+    key, pub = make_key()
+    rogue_key, rogue_pub = make_key()
+    d = trusted_manifest_dir(tmp_path, pub)
+
+    remote_rogue = tmp_path / "remote-rogue"
+    signed_remote(remote_rogue, 3, 4, seed=9, make_lines=lambda digests: [
+        att_line(rogue_key, rogue_pub, digests)])
+    r = resolver(d, tmp_path, sources=[FakeSource(remote_rogue)])
+    with pytest.raises(fr.FragmentUnavailableError, match="signer not-trusted"):
+        r.resolve(3, 0, 4)
+    assert r.stats["reject_signer"] == 1
+
+    # countersigned file: rogue line + allowed line -> ANY allowed accepts
+    remote_counter = tmp_path / "remote-counter"
+    signed_remote(remote_counter, 3, 4, seed=9, make_lines=lambda digests: [
+        att_line(rogue_key, rogue_pub, digests),
+        att_line(key, pub, digests)])
+    r2 = resolver(d, tmp_path / "c2", cache_dir=tmp_path / "c2" / "cache",
+                  sources=[FakeSource(remote_counter)])
+    assert r2.resolve(3, 0, 4).origin == "fetched"
+    assert r2.stats["reject_signer"] == 0
+
+    # VLLM_FQ_TRUST_SIGNERS overrides the manifest anchor
+    r3 = resolver(d, tmp_path / "c3", cache_dir=tmp_path / "c3" / "cache",
+                  sources=[FakeSource(remote_rogue)],
+                  environ={"VLLM_FQ_TRUST_SIGNERS": rogue_pub})
+    assert r3.resolve(3, 0, 4).origin == "fetched"
+
+
+def test_bad_signature_rejected(tmp_path):
+    key, pub = make_key()
+    d = trusted_manifest_dir(tmp_path, pub)
+    remote = tmp_path / "remote"
+
+    def forged(digests):
+        line = json.loads(att_line(key, pub, digests))
+        line["signature"] = base64.b64encode(b"\x00" * 64).decode()
+        return [json.dumps(line)]
+
+    signed_remote(remote, 3, 4, seed=9, make_lines=forged)
+    r = resolver(d, tmp_path, sources=[FakeSource(remote)])
+    with pytest.raises(fr.FragmentUnavailableError, match="bad-signature"):
+        r.resolve(3, 0, 4)
+    assert r.stats["reject_signature"] == 1
+    assert r.stats["bytes_fetched"] == 0  # rejected before any body read
+
+
+def test_trust_disabled_without_anchor_keeps_legacy_behavior(tmp_path):
+    # no signer_pubkey in the manifest, no env: garbage signatures pass
+    remote = tmp_path / "remote"
+    write_segment(remote, 3, 4, seed=9)  # test-signature attestation
+    d = make_manifest_dir(tmp_path, layers=(3,), ks=(3,))
+    r = resolver(d, tmp_path, sources=[FakeSource(remote)])
+    assert not r.trust_enabled
+    assert r.resolve(3, 0, 4).origin == "fetched"
+
+
+# ------------------------------------- feature 3: fallback + lazy encode
+
+
+def test_fallback_substitution_surfaces_actual_k(tmp_path, fq_log):
+    d = make_manifest_dir(tmp_path, layers=(3,), ks=(3,))  # no k4 anywhere
+    queue_path = tmp_path / "queue.jsonl"
+    r = resolver(d, tmp_path, environ={
+        "VLLM_FQ_K_FALLBACK": "3",
+        "VLLM_FQ_ENCODE_QUEUE": str(queue_path)})
+    frag = r.resolve(3, 2, 4)
+    assert frag.k == 3 and frag.requested_k == 4 and frag.substituted
+    assert frag.origin == "local"
+    assert r.stats["fallback_substituted"] == 1
+    assert r.stats["encode_queued"] == 1
+
+    info = [rec for rec in fq_log if rec.levelno == logging.INFO]
+    assert len(info) == 1
+    msg = info[0].getMessage()
+    assert msg.startswith("FQ resolve L3/e2 K4:")
+    assert "FALLBACK K3" in msg and "ACCEPT (encode queued #1)" in msg
+
+    entries = le.EncodeQueue(queue_path).entries()
+    assert [(e["layer"], e["expert"], e["k"]) for e in entries] == [(3, 2, 4)]
+    assert entries[0]["reason"] == "substituted-with-k3"
+
+    # dedup: a second resolve substitutes again but does not re-enqueue
+    frag2 = r.resolve(3, 2, 4)
+    assert frag2.substituted and r.stats["encode_queued"] == 1
+    assert any("(encode already queued)" in m for m in _messages(fq_log))
+
+
+def test_unavailable_miss_is_queued_and_counted(tmp_path, fq_log):
+    d = make_manifest_dir(tmp_path, layers=(3,), ks=(3,))
+    queue_path = tmp_path / "queue.jsonl"
+    r = resolver(d, tmp_path,
+                 environ={"VLLM_FQ_ENCODE_QUEUE": str(queue_path)})
+    with pytest.raises(fr.FragmentUnavailableError, match="k5"):
+        r.resolve(3, 0, 5)
+    assert r.stats["unavailable"] == 1
+    assert r.stats["encode_queued"] == 1
+    entries = le.EncodeQueue(queue_path).entries()
+    assert [(e["layer"], e["expert"], e["k"]) for e in entries] == [(3, 0, 5)]
+    assert entries[0]["reason"] == "unavailable"
+    warning = [rec for rec in fq_log if rec.levelno == logging.WARNING]
+    assert any("UNAVAILABLE (encode queued #1)" in rec.getMessage()
+               for rec in warning)
+
+
+def test_progressive_stream_surfaces_substituted_k(tmp_path):
+    torch = pytest.importorskip("torch")  # noqa: F841
+    import test_progressive_cpu as tpc
+
+    seg_dir = make_manifest_dir(tmp_path, layers=(3,), ks=(3,))  # no k4
+    spec = tpc.make_spec(tmp_path, tpc.make_policy({"3": [4, 3, 3, 4]}),
+                         seg_dir=seg_dir)
+    resolver_ = spec.make_resolver(
+        cache_dir=tmp_path / "cache",
+        environ={"VLLM_FQ_K_FALLBACK": "3",
+                 "VLLM_FQ_ENCODE_QUEUE": str(tmp_path / "queue.jsonl")})
+    logs, actual = [], {}
+    tensors = dict(tpc.pg.progressive_weights_iterator(
+        spec, resolver_, log=logs.append, actual_bits_out=actual))
+
+    # reality: every expert streamed at K3, and the metadata says so
+    name = "model.layers.3.mlp.experts.0.gate_proj.rank0.trellis"
+    assert tuple(tensors[name].shape) == (2, 2, 16 * 3)
+    assert actual == {3: [3, 3, 3, 3]}
+    layer_line = next(line for line in logs if "layer 3:" in line)
+    assert "tiers=((3, 4),)" in layer_line
+    assert f"bits_digest={tpc.pg._bits_digest([3, 3, 3, 3])}" in layer_line
+    assert "substituted=e0:K4->K3,e3:K4->K3" in layer_line
+    assert resolver_.stats["fallback_substituted"] == 2
+
+    # the tier bitmap can be rewritten from reality
+    bitmap = tpc.pg.write_tier_bitmap(
+        spec.policy, tmp_path / "bitmap.json", actual_bits=actual)
+    assert json.loads(bitmap.read_text())["3"]["bits_per_expert"] == [3, 3, 3, 3]
+
+    queued = le.EncodeQueue(tmp_path / "queue.jsonl").entries()
+    assert [(e["layer"], e["expert"], e["k"]) for e in queued] == [
+        (3, 0, 4), (3, 3, 4)]
+
+
+def test_queue_dedup_and_persistence(tmp_path):
+    path = tmp_path / "q.jsonl"
+    q = le.EncodeQueue(path)
+    assert q.enqueue(3, 0, 4, "unavailable") == (1, True)
+    assert q.enqueue(3, 0, 4, "again") == (1, False)  # dedup by key
+    assert q.enqueue(3, 1, 4, "unavailable") == (2, True)
+    assert len(path.read_text().splitlines()) == 2
+
+    q2 = le.EncodeQueue(path)  # persistence across processes
+    assert len(q2) == 2
+    assert q2.enqueue(3, 0, 4, "later") == (1, False)
+    assert q2.enqueue(5, 7, 4, "unavailable") == (3, True)
+
+
+def _bf16_dir(tmp_path, layer_experts=((3, 0),)):
+    d = tmp_path / "bf16"
+    d.mkdir(exist_ok=True)
+    weight_map = {}
+    for layer, expert in layer_experts:
+        for proj in ("gate_proj", "up_proj", "down_proj"):
+            weight_map[
+                f"model.layers.{layer}.mlp.experts.{expert}.{proj}.weight"
+            ] = "model-x.safetensors"
+    (d / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": weight_map}))
+    return d
+
+
+def _capture_dir(tmp_path, layers=(3,)):
+    d = tmp_path / "capture"
+    d.mkdir(exist_ok=True)
+    for layer in layers:
+        sub = d / f"layer_{layer:03d}"
+        sub.mkdir(exist_ok=True)
+        (sub / "payload.bin").write_bytes(b"x")
+    return d
+
+
+def test_drain_dry_run_validates_without_gpu(tmp_path):
+    q = le.EncodeQueue(tmp_path / "q.jsonl")
+    q.enqueue(3, 0, 4, "substituted-with-k3")
+    q.enqueue(7, 0, 4, "unavailable")  # no capture for layer 7
+    bf16 = _bf16_dir(tmp_path, layer_experts=((3, 0), (7, 0)))
+    capture = _capture_dir(tmp_path, layers=(3,))
+
+    lines = []
+    rc = le.drain(q, dry_run=True, bf16_dir=bf16, capture_dir=capture,
+                  environ={}, out=lines.append)
+    assert rc == 1  # one entry blocked
+    ok = next(line for line in lines if line.startswith("#1"))
+    assert "DRY-RUN OK" in ok and "bf16=ok(index)" in ok
+    assert "--bits 4" in ok and "--layers 3" in ok  # default driver template
+    blocked = next(line for line in lines if line.startswith("#2"))
+    assert "BLOCKED" in blocked and "capture missing layer_007" in blocked
+    # dry run never mutates the queue
+    assert len(le.EncodeQueue(tmp_path / "q.jsonl")) == 2
+
+    rc_ok = le.drain(q, dry_run=True, bf16_dir=bf16,
+                     capture_dir=_capture_dir(tmp_path, layers=(3, 7)),
+                     environ={}, out=lines.append)
+    assert rc_ok == 0
+
+
+def test_drain_execute_runs_template_and_dequeues(tmp_path):
+    q = le.EncodeQueue(tmp_path / "q.jsonl")
+    q.enqueue(3, 0, 4, "unavailable")
+    bf16 = _bf16_dir(tmp_path)
+    capture = _capture_dir(tmp_path)
+
+    calls, lines = [], []
+
+    def runner(args, **kw):
+        calls.append(args)
+        return SimpleNamespace(returncode=0)
+
+    rc = le.drain(
+        q, dry_run=False, bf16_dir=bf16, capture_dir=capture, environ={},
+        encoder_cmd=("encoder --bits {k} --layers {layer} --expert {expert} "
+                     "--src {bf16_dir} --capture-dir {capture_dir}"),
+        out=lines.append, runner=runner)
+    assert rc == 0
+    assert calls == [["encoder", "--bits", "4", "--layers", "3", "--expert",
+                      "0", "--src", str(bf16), "--capture-dir", str(capture)]]
+    assert any("DONE" in line for line in lines)
+    assert len(le.EncodeQueue(tmp_path / "q.jsonl")) == 0  # drained
+
+
+# --------------------------------------------- decision lines + stats
+
+
+def test_decision_line_full_chain(tmp_path, fq_log):
+    """The operator example: predicate reject, sha-mismatch reject, fallback
+    accept with an encode queued — one INFO line carrying the whole chain."""
+    key, pub = make_key()
+    d = trusted_manifest_dir(tmp_path, pub)  # local k3 only
+
+    remote_a = tmp_path / "remote-a"
+    signed_remote(remote_a, 3, 4, seed=5, make_lines=lambda digests: [
+        att_line(key, pub, digests, predicate="derived-from")])
+    remote_b = tmp_path / "remote-b"
+    signed_remote(remote_b, 3, 4, seed=6, make_lines=lambda digests: [
+        att_line(key, pub, digests)])
+
+    r = resolver(
+        d, tmp_path,
+        sources=[NamedSource(remote_a, "hf:repoA@ab12"),
+                 NamedSource(remote_b, "hf:repoB@cd34",
+                             corrupt_fragments=True)],
+        environ={"VLLM_FQ_TRUST_PREDICATES": "repack-of,encode-of",
+                 "VLLM_FQ_K_FALLBACK": "3",
+                 "VLLM_FQ_ENCODE_QUEUE": str(tmp_path / "queue.jsonl")})
+    frag = r.resolve(3, 0, 4)
+    assert frag.k == 3 and frag.substituted
+
+    info = [rec for rec in fq_log if rec.levelno == logging.INFO]
+    assert len(info) == 1
+    msg = info[0].getMessage()
+    assert msg.startswith("FQ resolve L3/e0 K4: ")
+    assert "local(1 dirs) MISS" in msg
+    assert "hf:repoA@ab12 REJECT predicate=derived-from not-trusted" in msg
+    assert "hf:repoB@cd34 REJECT sha-mismatch" in msg
+    assert "FALLBACK K3 local ACCEPT (encode queued #1)" in msg
+
+    assert r.stats["reject_predicate"] == 1
+    assert r.stats["reject_sha_mismatch"] == 1
+    assert r.stats["fallback_substituted"] == 1
+    assert r.stats["encode_queued"] == 1
+    assert r.stats["local"] == 1  # the K3 fallback hit
+
+
+def test_plain_success_logs_debug_line(tmp_path, fq_log):
+    d = make_manifest_dir(tmp_path, layers=(3,), ks=(3,))
+    r = resolver(d, tmp_path)
+    assert r.resolve(3, 1, 3).origin == "local"
+    debug = [rec for rec in fq_log if rec.levelno == logging.DEBUG]
+    assert [rec.getMessage() for rec in debug] == [
+        "FQ resolve L3/e1 K3: local ACCEPT"]
+    assert not [rec for rec in fq_log if rec.levelno > logging.DEBUG]
+
+
+def test_source_miss_counted(tmp_path):
+    d = make_manifest_dir(tmp_path, layers=(3,), ks=(3,))
+    empty = tmp_path / "empty-remote"
+    empty.mkdir()
+    r = resolver(d, tmp_path, sources=[FakeSource(empty)])
+    with pytest.raises(fr.FragmentUnavailableError):
+        r.resolve(3, 0, 4)
+    assert r.stats["source_miss"] == 1
+    assert r.stats["unavailable"] == 1
+
+
+def test_invalid_k_fallback_rejected(tmp_path):
+    d = make_manifest_dir(tmp_path, layers=(3,), ks=(3,))
+    with pytest.raises(ValueError, match="VLLM_FQ_K_FALLBACK"):
+        resolver(d, tmp_path, environ={"VLLM_FQ_K_FALLBACK": "three"})

--- a/tests/exl3_fungible/toy_segments.py
+++ b/tests/exl3_fungible/toy_segments.py
@@ -12,11 +12,39 @@ harness.
 """
 from __future__ import annotations
 
+import importlib.util
 import json
 import struct
+import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import torch
+
+_PKG_DIR = (Path(__file__).resolve().parents[2] / "vllm" / "model_executor"
+            / "layers" / "quantization" / "exl3_fungible")
+
+
+def load_tree_module(name: str):
+    """Load one ``exl3_fungible`` module from THIS working tree, by path.
+
+    The gg rootfs carries a copy of the package inside its site-packages that
+    is periodically synced from the tree, so a plain
+    ``from vllm... import swap`` can silently resolve to whatever was last
+    copied there. Tests whose verdict is about tree code load the tree file.
+    Cached under ``fq_<name>_tree`` so every test module that asks gets the
+    SAME module object (class identity matters: ``SwapPlan.__eq__`` and the
+    dataclasses are per-module).
+    """
+    alias = f"fq_{name}_tree"
+    mod = sys.modules.get(alias)
+    if mod is None:
+        spec = importlib.util.spec_from_file_location(
+            alias, _PKG_DIR / f"{name}.py")
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[alias] = mod
+        spec.loader.exec_module(mod)
+    return mod
 
 # Mirrors the proven pre-m4 occupancy harness geometry.
 HIDDEN = 128
@@ -92,6 +120,81 @@ def assemble_membership_tensors(checkpoint: dict, tier_globals, k: int) -> dict:
             torch.stack([m["down_suh"] for m in members]),
         ), dim=1).contiguous(),
     }
+
+
+def build_maps_reference(tier0_ids, tier1_ids, *, device):
+    """Pure-torch replica of b12x ``build_tiered_maps`` (T3 proves parity)."""
+    t0n, t1n = len(tier0_ids), len(tier1_ids)
+    g2c = torch.full((t0n + t1n,), -1, dtype=torch.int32)
+    for local, g in enumerate(tier0_ids):
+        g2c[int(g)] = local
+    for local, g in enumerate(tier1_ids):
+        g2c[int(g)] = t0n + local
+    desc = torch.tensor(
+        [*range(t0n), *((1 << 8) | i for i in range(t1n))], dtype=torch.int32)
+    return g2c.to(device), desc.to(device)
+
+
+def cpu_layer_state(fq_swap, checkpoint: dict, t0_globals, t1_globals):
+    """Hand-assembled ``MixedLayerState`` on CPU (fresh-build reference).
+
+    ``fq_swap`` is passed in so the caller controls WHICH swap module the
+    state belongs to (see :func:`load_tree_module`)."""
+    def tier(globals_, k):
+        t = assemble_membership_tensors(checkpoint, globals_, k)
+        return SimpleNamespace(
+            num_experts=len(globals_),
+            w13=t["w13"].view(torch.int32).reshape(-1),
+            w2=t["w2"].view(torch.int32).reshape(-1),
+        ), t
+
+    tier0, r0 = tier(t0_globals, 3)
+    tier1, r1 = tier(t1_globals, 4)
+    rotations = SimpleNamespace(
+        intermediate=torch.cat((r0["intermediate"], r1["intermediate"])),
+        gate_suh=torch.cat((r0["gate_suh"], r1["gate_suh"])),
+        up_suh=torch.cat((r0["up_suh"], r1["up_suh"])),
+        down_svh=torch.cat((r0["down_svh"], r1["down_svh"])),
+    )
+    g2c, desc = build_maps_reference(t0_globals, t1_globals,
+                                     device=torch.device("cpu"))
+    return fq_swap.MixedLayerState(
+        tier0=tier0, tier1=tier1, rotations=rotations,
+        global_to_combined=g2c, descriptor_map=desc,
+        tier0_globals=list(t0_globals), tier1_globals=list(t1_globals))
+
+
+def state_fingerprint(state) -> str:
+    """sha256 over every byte a swap can touch — slabs, combined rotation /
+    suh / svh tables, both maps. Two states with the same fingerprint are
+    indistinguishable to the kernel."""
+    import hashlib
+
+    h = hashlib.sha256()
+    for tier in (state.tier0, state.tier1):
+        for slab in ("w13", "w2"):
+            h.update(getattr(tier, slab).contiguous().view(torch.uint8)
+                     .cpu().numpy().tobytes())
+    for name in ("intermediate", "gate_suh", "up_suh", "down_svh"):
+        h.update(getattr(state.rotations, name).contiguous().view(torch.uint8)
+                 .cpu().numpy().tobytes())
+    for m in (state.global_to_combined, state.descriptor_map):
+        h.update(m.contiguous().cpu().numpy().tobytes())
+    return h.hexdigest()
+
+
+def assert_states_equal(a, b) -> None:
+    assert a.tier0_globals == b.tier0_globals
+    assert a.tier1_globals == b.tier1_globals
+    for name in ("tier0", "tier1"):
+        for slab in ("w13", "w2"):
+            assert torch.equal(getattr(getattr(a, name), slab),
+                               getattr(getattr(b, name), slab)), (name, slab)
+    for name in ("intermediate", "gate_suh", "up_suh", "down_svh"):
+        assert torch.equal(getattr(a.rotations, name),
+                           getattr(b.rotations, name)), name
+    assert torch.equal(a.global_to_combined, b.global_to_combined)
+    assert torch.equal(a.descriptor_map, b.descriptor_map)
 
 
 def _expert_tensors(layer: int, expert: int, payload: dict, rank: int):

--- a/tests/exl3_fungible/toy_segments.py
+++ b/tests/exl3_fungible/toy_segments.py
@@ -1,0 +1,161 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Toy fq-segment fixtures shared by the M4 swap tests.
+
+Generates a deterministic per-expert EXL3 "checkpoint" (native trellis tiles
++ suh/svh rotations per projection, per bitrate) for a small mixed layer and
+writes it out in the exact fq-segment/1 layout fq_repack produces
+(``layer-LLL.kK.safetensors`` + ``index-kK.json``): per-expert contiguous
+body, (expert, proj, rank, comp)-sorted tensors, canonical names. CPU-only,
+plain file IO — usable from both the CPU contract tests and the T3/T4 GPU
+harness.
+"""
+from __future__ import annotations
+
+import json
+import struct
+from pathlib import Path
+
+import torch
+
+# Mirrors the proven pre-m4 occupancy harness geometry.
+HIDDEN = 128
+INTERMEDIATE = 128
+TILE_CONFIG = (128, 128, 128, 128)
+LAYER_ID = 3
+MCG = -877912083  # the layer-wide MCG codebook word (fruit-segments value)
+
+PROJ_ORDER = {"gate_proj": 0, "up_proj": 1, "down_proj": 2}
+COMP_ORDER = {"trellis": 0, "suh": 1, "svh": 2, "mcg": 3}
+
+
+def _scales(shape, generator):
+    return (0.875 + 0.25 * torch.rand(shape, generator=generator)).to(
+        torch.float16)
+
+
+def make_toy_checkpoint(num_experts: int, ks=(3, 4), *, hidden=HIDDEN,
+                        intermediate=INTERMEDIATE, seed=20260810) -> dict:
+    """Deterministic per-(expert, k) payload tensors, CPU.
+
+    Returns ``{(expert, k): {comp_key: tensor}}`` with native trellis tiles
+    ``gate``/``up`` ``[H/16, I/16, 16k]`` i16, ``down`` ``[I/16, H/16, 16k]``
+    i16, and fp16 rotations: ``gate_suh``/``up_suh`` ``[H]``, ``down_svh``
+    ``[H]``, ``gate_svh``/``up_svh``/``down_suh`` ``[I]``. Every (expert, k)
+    pair gets distinct values so cross-expert or cross-bitrate mixups are
+    detectable bitwise.
+    """
+    h16, i16 = hidden // 16, intermediate // 16
+    out = {}
+    for e in range(num_experts):
+        for k in ks:
+            g = torch.Generator().manual_seed(seed * 1000003 + e * 101 + k)
+            words = 16 * k
+            out[(e, k)] = {
+                "gate": torch.randint(-2**15, 2**15, (h16, i16, words),
+                                      dtype=torch.int16, generator=g),
+                "up": torch.randint(-2**15, 2**15, (h16, i16, words),
+                                    dtype=torch.int16, generator=g),
+                "down": torch.randint(-2**15, 2**15, (i16, h16, words),
+                                      dtype=torch.int16, generator=g),
+                "gate_suh": _scales((hidden,), g),
+                "up_suh": _scales((hidden,), g),
+                "down_svh": _scales((hidden,), g),
+                "gate_svh": _scales((intermediate,), g),
+                "up_svh": _scales((intermediate,), g),
+                "down_suh": _scales((intermediate,), g),
+            }
+    return out
+
+
+def assemble_membership_tensors(checkpoint: dict, tier_globals, k: int) -> dict:
+    """Stack one tier's members (slot order) into prepare-shaped tensors.
+
+    Mirrors exl3.py ``_prepare_mixed_rank_sliced_weights``: w13 is
+    ``[2(gate,up), E_t, H/16, I/16, 16k]`` i16, w2 ``[E_t, I/16, H/16, 16k]``
+    i16, rotations fp16 with ``intermediate = [gate_svh|up_svh|down_suh]``.
+    CPU tensors; callers move to device as needed.
+    """
+    members = [checkpoint[(int(g), k)] for g in tier_globals]
+    return {
+        "w13": torch.stack((
+            torch.stack([m["gate"] for m in members]),
+            torch.stack([m["up"] for m in members]),
+        )).contiguous(),
+        "w2": torch.stack([m["down"] for m in members]).contiguous(),
+        "gate_suh": torch.stack([m["gate_suh"] for m in members]).contiguous(),
+        "up_suh": torch.stack([m["up_suh"] for m in members]).contiguous(),
+        "down_svh": torch.stack([m["down_svh"] for m in members]).contiguous(),
+        "intermediate": torch.cat((
+            torch.stack([m["gate_svh"] for m in members]),
+            torch.stack([m["up_svh"] for m in members]),
+            torch.stack([m["down_suh"] for m in members]),
+        ), dim=1).contiguous(),
+    }
+
+
+def _expert_tensors(layer: int, expert: int, payload: dict, rank: int):
+    """(name, tensor-or-mcg) in fq_repack's (proj, rank, comp) sort order."""
+    base = f"model.layers.{layer}.mlp.experts.{expert}"
+    for proj in ("gate_proj", "up_proj", "down_proj"):
+        p = proj.split("_")[0]
+        yield f"{base}.{proj}.rank{rank}.trellis", payload[p]
+        yield f"{base}.{proj}.rank{rank}.suh", payload[f"{p}_suh"]
+        yield f"{base}.{proj}.rank{rank}.svh", payload[f"{p}_svh"]
+        yield f"{base}.{proj}.rank{rank}.mcg", None  # scalar written as MCG
+
+
+def write_toy_segments(root: str | Path, checkpoint: dict, *, layer=LAYER_ID,
+                       ks=(3, 4), rank=0, mcg=MCG) -> Path:
+    """Write ``layer-LLL.kK.safetensors`` + ``index-kK.json`` under root."""
+    root = Path(root)
+    root.mkdir(parents=True, exist_ok=True)
+    dtypes = {torch.int16: "I16", torch.float16: "F16"}
+    experts = sorted({e for e, _ in checkpoint})
+    for k in ks:
+        entries = []  # (name, dtype_tag, shape, payload_bytes)
+        per_expert = {}
+        off = 0
+        for e in experts:
+            start = off
+            for name, t in _expert_tensors(layer, e, checkpoint[(e, k)], rank):
+                if t is None:
+                    raw = struct.pack("<i", mcg)
+                    tag, shape = "I32", []
+                else:
+                    raw = t.numpy().tobytes()
+                    tag, shape = dtypes[t.dtype], list(t.shape)
+                entries.append((name, tag, shape, raw))
+                off += len(raw)
+            per_expert[str(e)] = [start, off]
+
+        header = {"__metadata__": {
+            "fq_schema": "fq-segment/1",
+            "predicate": "repack-of",
+            "k": str(k),
+            "layer": str(layer),
+            "layout": "rank_sliced_tp4",
+            "num_experts": str(len(experts)),
+            "source_file": "toy",
+        }}
+        pos = 0
+        for name, tag, shape, raw in entries:
+            header[name] = {"dtype": tag, "shape": shape,
+                            "data_offsets": [pos, pos + len(raw)]}
+            pos += len(raw)
+        hj = json.dumps(header, separators=(",", ":")).encode()
+        hj += b" " * ((8 - len(hj) % 8) % 8)
+
+        seg_name = f"layer-{layer:03d}.k{k}.safetensors"
+        with open(root / seg_name, "wb") as f:
+            f.write(struct.pack("<Q", len(hj)) + hj)
+            for _, _, _, raw in entries:
+                f.write(raw)
+        index = {str(layer): {
+            "file": seg_name,
+            "body_offset": 8 + len(hj),
+            "size": (root / seg_name).stat().st_size,
+            "experts": per_expert,
+        }}
+        (root / f"index-k{k}.json").write_text(json.dumps(index, indent=1))
+    return root

--- a/tests/model_executor/test_flashinfer_autotune_cache.py
+++ b/tests/model_executor/test_flashinfer_autotune_cache.py
@@ -237,6 +237,27 @@ def test_b12x_dcp_warmup_finds_generic_mla_attention(monkeypatch) -> None:
     ]
 
 
+def test_kernel_dispatcher_warms_mixed_exl3_route_pack(monkeypatch) -> None:
+    from vllm.model_executor.layers.quantization import exl3
+
+    model = torch.nn.Module()
+    holder = torch.nn.Module()
+    holder.routed_experts = SimpleNamespace(exl3_mixed_trellis={})
+    model.add_module("holder", holder)
+    worker = _flashinfer_autotune_worker(model)
+    _patch_flashinfer_autotune_deps(monkeypatch)
+    calls = []
+    monkeypatch.setattr(
+        exl3,
+        "warmup_exl3_mixed_trellis_route_pack",
+        lambda candidate: calls.append(candidate) or 2,
+    )
+
+    kernel_warmup.kernel_warmup(worker)
+
+    assert calls == [model]
+
+
 def test_kernel_warmup_runs_b12x_mxfp8_linear_warmup(monkeypatch) -> None:
     calls = []
     model = torch.nn.Linear(2, 2)

--- a/tests/quantization/test_exl3.py
+++ b/tests/quantization/test_exl3.py
@@ -92,6 +92,14 @@ def test_glm_model_retains_quant_config_for_weight_loading(monkeypatch):
         ({"codebook": "mul1"}, "MCG codebook"),
         ({"moe_layers": [77, 3]}, "moe_layers"),
         ({"tensor_schema": "unsupported"}, "tensor schema"),
+        (
+            {
+                "bits": "mixed",
+                "bits_per_expert": "tier_bitmap.json:k",
+                "k_values": [1, 4],
+            },
+            "within 2..6",
+        ),
     ],
 )
 def test_rank_sliced_metadata_fails_closed(overrides, message):
@@ -122,12 +130,12 @@ def test_mixed_rank_sliced_metadata_hydrates_per_layer_bitrates(monkeypatch):
     metadata = _rank_sliced_metadata(
         bits="mixed",
         bits_per_expert="tier_bitmap.json:k",
-        k_values=[3, 4],
+        k_values=[2, 4],
         experts_per_layer=4,
         moe_layers=[77, 78],
     )
     payload = {
-        "77": {"k": [3, 4, 3, 4]},
+        "77": {"k": [2, 4, 2, 4]},
         # The checkpoint's MTP overlay records a uniform K3 tail this way.
         "78": {"tail_tr3": [0, 1, 2, 3]},
     }
@@ -144,11 +152,11 @@ def test_mixed_rank_sliced_metadata_hydrates_per_layer_bitrates(monkeypatch):
     )
 
     assert config.bits is None
-    assert config.rank_sliced_k_values == (3, 4)
+    assert config.rank_sliced_k_values == (2, 4)
     assert config.rank_sliced_layer_bitrates("model.layers.77.mlp.experts") == (
-        3,
+        2,
         4,
-        3,
+        2,
         4,
     )
     assert config.rank_sliced_layer_bitrates("model.layers.78.mlp.experts") == (
@@ -208,10 +216,10 @@ def test_rank_sliced_parameter_preallocates_projection_major_slab(monkeypatch):
     torch.testing.assert_close(param.exl3_tensors[(2, "w3")], w3)
 
 
-def test_rank_sliced_weights_use_unified_fused_moe_contract(monkeypatch):
+@pytest.mark.parametrize("bits", [2, 3])
+def test_rank_sliced_weights_use_unified_fused_moe_contract(monkeypatch, bits):
     experts = 2
     hidden = intermediate = 128
-    bits = 3
     slabs = {
         "w13_trellis": torch.zeros(
             (2, experts, hidden // 16, intermediate // 16, 16 * bits),
@@ -278,10 +286,13 @@ def test_rank_sliced_weights_use_unified_fused_moe_contract(monkeypatch):
     assert api.prepare_kwargs["trellis_mcg"] is marker
 
 
-def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(monkeypatch):
+@pytest.mark.parametrize("low_bits", [2, 3])
+def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(
+    monkeypatch, low_bits
+):
     experts = 4
     hidden = intermediate = 128
-    bitrates = (3, 4, 3, 4)
+    bitrates = (low_bits, 4, low_bits, 4)
 
     def parameter(shard_ids=(), tensors=None, backing=None):
         return SimpleNamespace(
@@ -328,10 +339,25 @@ def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(monkeypat
     class FakeMixedApi:
         def __init__(self):
             self.prepared = []
+            self.compiled = []
 
         def prepare_weights(self, **kwargs):
             self.prepared.append(kwargs)
             return SimpleNamespace(**kwargs)
+
+        @staticmethod
+        def max_packed_route_slots(routes, block_size, total_experts):
+            del block_size, total_experts
+            return routes
+
+        def compile_mixed_trellis(self, **kwargs):
+            self.compiled.append(kwargs)
+            return SimpleNamespace()
+
+        @staticmethod
+        def make_mixed_trellis_buffers(launch, *, device, sms):
+            del launch, device, sms
+            return SimpleNamespace()
 
         @staticmethod
         def build_tiered_maps(tier0, tier1, *, device):
@@ -351,9 +377,10 @@ def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(monkeypat
     method = object.__new__(Exl3MoEMethod)
     method._rank_sliced_backing = lambda _layer, name: slabs[name]
 
+    method.quant_config = SimpleNamespace()
     method._prepare_mixed_rank_sliced_weights(layer)
 
-    assert [entry["trellis_bits"] for entry in api.prepared] == [3, 4]
+    assert [entry["trellis_bits"] for entry in api.prepared] == [low_bits, 4]
     assert [entry["num_experts"] for entry in api.prepared] == [2, 2]
     for entry in api.prepared:
         bits = entry["trellis_bits"]
@@ -375,11 +402,30 @@ def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(monkeypat
         (128, 128, 128, 128),
     ]
     assert layer.exl3_mixed_trellis["tier_ids"] == ((0, 2), (1, 3))
-    assert layer.exl3_mixed_trellis["tier_bits"] == (3, 4)
+    assert layer.exl3_mixed_trellis["tier_bits"] == (low_bits, 4)
     assert layer.w13_trellis.exl3_tensors == {}
     assert layer.w2_trellis.exl3_tensors == {}
     assert layer.w13_suh.exl3_backing is None
     assert layer.w2_svh.exl3_backing is None
+    layer.exl3_max_num_batched_tokens = 4
+    monkeypatch.setattr(
+        torch.cuda, "get_device_properties",
+        lambda _device: SimpleNamespace(
+            multi_processor_count=188,
+            shared_memory_per_block_optin=101376,
+        ),
+    )
+    monkeypatch.setattr(
+        torch.cuda, "is_current_stream_capturing", lambda: False
+    )
+    exl3_module._MIXED_TRELLIS_RUNTIMES.clear()
+    method._mixed_rank_sliced_runtime(
+        layer,
+        torch.zeros((1, hidden), dtype=torch.float16),
+        torch.zeros((1, 2), dtype=torch.int64),
+    )
+    assert {(call["tier0_bits"], call["tier1_bits"])
+            for call in api.compiled} == {(low_bits, 4)}
 
 
 def test_mixed_trellis_buffer_accounting_ignores_metadata() -> None:

--- a/tests/quantization/test_exl3_warmup.py
+++ b/tests/quantization/test_exl3_warmup.py
@@ -1,0 +1,76 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.quantization.exl3 import (
+    warmup_exl3_mixed_trellis_route_pack,
+)
+
+
+def _model_with_mixed_trellis(mixed: dict) -> torch.nn.Module:
+    model = torch.nn.Module()
+    holder = torch.nn.Module()
+    holder.routed_experts = SimpleNamespace(
+        exl3_mixed_trellis=mixed,
+        layer_name="model.layers.3.mlp.experts",
+    )
+    model.add_module("holder", holder)
+    return model
+
+
+def test_mixed_trellis_warmup_delegates_each_runtime_state() -> None:
+    warmup = Mock(side_effect=(6, 12))
+    api = SimpleNamespace(warmup_mixed_trellis_route_pack=warmup)
+    decode = {"launch": object(), "buffers": object()}
+    prefill = {"launch": object(), "buffers": object()}
+    expert_map = object()
+    model = _model_with_mixed_trellis(
+        {
+            "runtime": {
+                "api": api,
+                "decode": decode,
+                "prefill": prefill,
+            },
+            "global_to_combined": expert_map,
+        }
+    )
+
+    assert warmup_exl3_mixed_trellis_route_pack(model) == 18
+    assert warmup.call_args_list == [
+        ((decode["launch"], decode["buffers"]), {"expert_map": expert_map}),
+        ((prefill["launch"], prefill["buffers"]), {"expert_map": expert_map}),
+    ]
+
+
+def test_mixed_trellis_warmup_deduplicates_shared_runtime_states() -> None:
+    warmup = Mock(return_value=6)
+    api = SimpleNamespace(warmup_mixed_trellis_route_pack=warmup)
+    state = {"launch": object(), "buffers": object()}
+    runtime = {"api": api, "decode": state, "prefill": state}
+    model = torch.nn.Module()
+    for index in range(2):
+        holder = torch.nn.Module()
+        holder.routed_experts = SimpleNamespace(
+            exl3_mixed_trellis={
+                "runtime": runtime,
+                "global_to_combined": object(),
+            },
+            layer_name=f"model.layers.{index}.mlp.experts",
+        )
+        model.add_module(f"holder_{index}", holder)
+
+    assert warmup_exl3_mixed_trellis_route_pack(model) == 6
+    warmup.assert_called_once()
+
+
+def test_mixed_trellis_warmup_fails_closed_without_profiled_runtime() -> None:
+    model = _model_with_mixed_trellis({"global_to_combined": object()})
+
+    with pytest.raises(RuntimeError, match="eager profile pass must plan"):
+        warmup_exl3_mixed_trellis_route_pack(model)
+
+
+def test_mixed_trellis_warmup_ignores_unrelated_models() -> None:
+    assert warmup_exl3_mixed_trellis_route_pack(torch.nn.Linear(4, 4)) == 0

--- a/vllm/config/load.py
+++ b/vllm/config/load.py
@@ -55,6 +55,10 @@ class LoadConfig:
     - "mistral" will load weights from consolidated safetensors files used by
       Mistral models.
     - "modelexpress" will load weights using ModelExpress.
+    - "progressive" will stream mixed-K EXL3 weights directly from
+      Progressive Tensors segments plus a bitrate policy (fungible quant;
+      configured via VLLM_FQ_MANIFEST_DIR / VLLM_FQ_POLICY), with no
+      assembled checkpoint on disk.
     - Other custom values can be supported via plugins.
     """
     download_dir: str | None = None

--- a/vllm/entrypoints/serve/__init__.py
+++ b/vllm/entrypoints/serve/__init__.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import os
+
 from fastapi import FastAPI
 
 from vllm.logger import init_logger
@@ -59,3 +61,17 @@ def register_vllm_dev_api_routers(app: FastAPI):
     from .dev.sleep.api_router import attach_router as attach_sleep_router
 
     attach_sleep_router(app)
+
+    # Fungible-quant admin API (forced expert re-tiering). Doubly gated:
+    # dev mode gets us here, and attach_router itself returns False unless
+    # VLLM_FQ_ADMIN_API=1 is also set, so POST /fq/retier — which mutates
+    # live model weights — can never appear on a serve by accident. The
+    # import is inside the guard so the default path pays nothing.
+    if os.environ.get("VLLM_FQ_ADMIN_API", os.environ.get(
+        "VLLM_FQ_ADMIN_ENABLE", "0"
+    )) in ("1", "true", "True"):
+        from vllm.model_executor.layers.quantization.exl3_fungible.admin import (  # noqa: E501
+            attach_router as attach_fq_admin_router,
+        )
+
+        attach_fq_admin_router(app)

--- a/vllm/entrypoints/serve/__init__.py
+++ b/vllm/entrypoints/serve/__init__.py
@@ -75,3 +75,18 @@ def register_vllm_dev_api_routers(app: FastAPI):
         )
 
         attach_fq_admin_router(app)
+
+    # Fungible-quant activation-matrix API (GET /fq/heatmap). Read-only,
+    # so it carries its OWN gate and its own optional token rather than
+    # riding on the admin one: a dashboard should be able to watch expert
+    # routing without holding the credential that mutates live weights.
+    # Same double-gate shape as the block above; attach_router returns
+    # False (and never raises) unless VLLM_FQ_HEATMAP=1 as well.
+    if os.environ.get("VLLM_FQ_HEATMAP", os.environ.get(
+        "VLLM_FQ_HEATMAP_API", "0"
+    )) in ("1", "true", "True"):
+        from vllm.model_executor.layers.quantization.exl3_fungible.heatmap import (  # noqa: E501
+            attach_router as attach_fq_heatmap_router,
+        )
+
+        attach_fq_heatmap_router(app)

--- a/vllm/entrypoints/serve/dev/rpc/api_router.py
+++ b/vllm/entrypoints/serve/dev/rpc/api_router.py
@@ -35,6 +35,14 @@ async def collective_rpc(raw_request: Request):
             status_code=HTTPStatus.BAD_REQUEST.value,
             detail="Missing 'method' in request body",
         )
+    if str(method).startswith("fq_admin_"):
+        raise HTTPException(
+            status_code=HTTPStatus.FORBIDDEN.value,
+            detail=(
+                "FQ admin worker methods require the authenticated /fq API "
+                "and cannot be called through generic collective RPC"
+            ),
+        )
     # For security reason, only serialized string args/kwargs are passed.
     # User-defined `method` is responsible for deserialization if needed.
     args: list[str] = body.get("args", [])

--- a/vllm/model_executor/layers/fused_moe/router/base_router.py
+++ b/vllm/model_executor/layers/fused_moe/router/base_router.py
@@ -180,11 +180,25 @@ class BaseRouter(FusedMoERouter):
         super().__init__(eplb_state=eplb_state)
         self.top_k = top_k
         self.global_num_experts = global_num_experts
-        self.capture_fn: Callable[[torch.Tensor], None] | None = None
+        self.capture_fn: Callable[..., None] | None = None
+        # A capture fn may opt in to also receiving the pre-EPLB gate
+        # weights by carrying a truthy ``wants_topk_weights`` attribute; it
+        # is then called as ``fn(topk_ids, topk_weights)``. The default
+        # one-argument contract is unchanged. Resolved once here / in
+        # set_capture_fn so the routing hot path reads a plain bool.
+        self.capture_fn_wants_weights = False
 
-    def set_capture_fn(self, capture_fn: Callable[[torch.Tensor], None] | None) -> None:
-        """Set a capture callback for logical routed expert IDs."""
+    def set_capture_fn(self, capture_fn: Callable[..., None] | None) -> None:
+        """Set a capture callback for logical routed expert IDs.
+
+        Callbacks tagged with ``wants_topk_weights = True`` additionally
+        receive the pre-EPLB ``topk_weights`` as a second positional
+        argument (gate mass for the fungible-quant collector).
+        """
         self.capture_fn = capture_fn
+        self.capture_fn_wants_weights = bool(
+            getattr(capture_fn, "wants_topk_weights", False)
+        )
 
     def _validate_eplb_state(self) -> None:
         """Validate that EPLB state is properly initialized if EPLB is enabled."""
@@ -292,9 +306,15 @@ class BaseRouter(FusedMoERouter):
             hidden_states, router_logits, topk_indices_dtype, input_ids=input_ids
         )
 
-        # Capture logical ids before EPLB mapping.
+        # Capture logical ids before EPLB mapping. topk_weights is a local
+        # here and is not stored on the router, so a capture fn that needs
+        # routing mass (not just hit counts) can only get it by being
+        # handed it at this call site.
         if self.capture_fn is not None:
-            self.capture_fn(topk_ids)
+            if self.capture_fn_wants_weights:
+                self.capture_fn(topk_ids, topk_weights)
+            else:
+                self.capture_fn(topk_ids)
 
         # Step 3: Apply EPLB mapping
         topk_ids = self._apply_eplb_mapping(topk_ids)

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -242,6 +242,7 @@ def _load_b12x_mixed_trellis() -> Any:
         max_packed_route_slots=host.max_packed_route_slots,
         prepare_weights=prepare.prepare_trellis256_moe_weights,
         run_mixed_trellis=module.run_mixed_trellis,
+        warmup_mixed_trellis_route_pack=module.warmup_mixed_trellis_route_pack,
     )
     _B12X_MIXED_TRELLIS_API = api
     return api
@@ -490,9 +491,9 @@ class Exl3Config(QuantizationConfig):
             k_values = tuple(
                 sorted({int(value) for value in metadata.get("k_values", ())})
             )
-            if not k_values or any(value not in (3, 4, 5, 6) for value in k_values):
+            if not k_values or any(value not in (2, 3, 4, 5, 6) for value in k_values):
                 raise ValueError(
-                    "mixed rank-sliced EXL3 requires k_values within 3..6, got "
+                    "mixed rank-sliced EXL3 requires k_values within 2..6, got "
                     f"{metadata.get('k_values')!r}"
                 )
             if not isinstance(metadata.get("bits_per_expert"), str):
@@ -537,17 +538,20 @@ class Exl3Config(QuantizationConfig):
                     f"rank-sliced EXL3 bitrate map is missing layer {layer_index}"
                 )
             raw = entry.get(field)
+            allowed_for_layer = allowed
             # The GLM-5.2 MTP overlay records all routed experts under tail_tr3
-            # instead of repeating a 256-entry K3 vector.
+            # instead of repeating a 256-entry K3 vector. This fixed K3 overlay
+            # is outside the re-tierable pair declared by k_values.
             if raw is None and len(entry.get("tail_tr3", ())) == experts:
                 raw = [3] * experts
+                allowed_for_layer = allowed | {3}
             if not isinstance(raw, list) or len(raw) != experts:
                 raise ValueError(
                     "rank-sliced EXL3 bitrate map must contain one entry per expert: "
                     f"layer={layer_index}, field={field!r}, expected={experts}"
                 )
             bitrates = tuple(int(value) for value in raw)
-            unexpected = sorted(set(bitrates).difference(allowed))
+            unexpected = sorted(set(bitrates).difference(allowed_for_layer))
             if unexpected:
                 raise ValueError(
                     f"rank-sliced EXL3 layer {layer_index} uses undeclared bitrates "
@@ -1729,9 +1733,10 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 f"{layer_bitrates!r}"
             )
         bits = int(layer_bitrates[0])
-        if bits not in (3, 4, 5, 6):
+        if bits not in (2, 3, 4, 5, 6):
             raise ValueError(
-                f"rank-sliced EXL3 requires an integral 3/4/5/6 bitrate, got {bits!r}"
+                f"rank-sliced EXL3 requires an integral 2/3/4/5/6 bitrate, got "
+                f"{bits!r}"
             )
 
         w13 = self._rank_sliced_backing(layer, "w13_trellis")
@@ -1856,6 +1861,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         )
         runtime = _MIXED_TRELLIS_RUNTIMES.get(key)
         if runtime is not None:
+            mixed["runtime"] = runtime
             return runtime
         if torch.cuda.is_current_stream_capturing():
             raise RuntimeError(
@@ -1921,6 +1927,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             "max_batched_tokens": max_batched_tokens,
         }
         _MIXED_TRELLIS_RUNTIMES[key] = runtime
+        mixed["runtime"] = runtime
         buffer_bytes = _unique_tensor_storage_bytes(
             decode["buffers"], prefill["buffers"]
         )
@@ -2444,4 +2451,60 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         return output[..., :logical_n]
 
 
-__all__ = ["Exl3Config", "Exl3LinearMethod", "Exl3MoEMethod"]
+def warmup_exl3_mixed_trellis_route_pack(model: torch.nn.Module) -> int:
+    """Materialize mixed-Trellis route-pack modules before KV sizing.
+
+    The first profile pass creates every layer's immutable mixed-Trellis
+    runtime. Route packing itself has power-of-two capacity specializations,
+    however, so profiling only the maximum batch leaves smaller decode,
+    speculative, and final-prefill-chunk modules lazy. Delegate enumeration to
+    B12X while those persistent CUDA allocations can still be measured by the
+    worker's second profile pass.
+    """
+    warmed = 0
+    seen_states: set[tuple[int, int, int]] = set()
+    for module in model.modules():
+        routed_experts = getattr(module, "routed_experts", module)
+        mixed = getattr(routed_experts, "exl3_mixed_trellis", None)
+        if not isinstance(mixed, dict):
+            continue
+
+        runtime = mixed.get("runtime")
+        if runtime is None:
+            layer_name = getattr(routed_experts, "layer_name", "<unknown>")
+            raise RuntimeError(
+                "mixed-bitrate EXL3 route-pack warmup found no runtime for "
+                f"{layer_name}; the eager profile pass must plan the runtime "
+                "before kernel warmup"
+            )
+        api = runtime["api"]
+        warmup = getattr(api, "warmup_mixed_trellis_route_pack", None)
+        if not callable(warmup):
+            raise RuntimeError(
+                "mixed-bitrate EXL3 route-pack warmup requires a matching B12X build"
+            )
+
+        for state_name in ("decode", "prefill"):
+            state = runtime.get(state_name)
+            if state is None:
+                continue
+            state_key = (id(api), id(state["launch"]), id(state["buffers"]))
+            if state_key in seen_states:
+                continue
+            seen_states.add(state_key)
+            warmed += int(
+                warmup(
+                    state["launch"],
+                    state["buffers"],
+                    expert_map=mixed["global_to_combined"],
+                )
+            )
+    return warmed
+
+
+__all__ = [
+    "Exl3Config",
+    "Exl3LinearMethod",
+    "Exl3MoEMethod",
+    "warmup_exl3_mixed_trellis_route_pack",
+]

--- a/vllm/model_executor/layers/quantization/exl3_fungible/PERFORMANCE.md
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/PERFORMANCE.md
@@ -1,0 +1,23 @@
+# exl3_fungible — performance & instrumentation contract
+
+Standing rule (operator directive, 2026-08-10): every change in this
+package that can influence **correctness (KLD)**, **runtime memory**, or
+**performance (prefill PP / token-gen TG)** must be:
+
+1. **Performant by construction** — CUDA-graph-compatible hot paths (pure
+   tensor ops on persistent buffers; no `.item()`/host branches/allocation
+   in capture or apply paths), work moved off the forward path wherever
+   possible (windowing in `step()`, policy on host, staging pre-quiesce).
+2. **Instrumented and called out** — the landing commit/report states:
+   - measured PP and TG delta vs `VLLM_FQ_ENABLE=0` baseline (same rig),
+   - KLD probe result whenever weights/routing are touched
+     (`tools/fq_probe.py` reference-leg methodology),
+   - runtime memory delta (`torch.cuda.memory_allocated` steady-state;
+     zero cudaMalloc in steady state per T7),
+   - Prometheus metrics per 03-testing-validation §Instrumentation
+     (`fq_swaps_total`, `fq_probe_kld`, per-tier occupancy, …) shipping
+     with M2, not later.
+
+Milestone gates remain the hard floors (M1: <0.5% decode overhead at cc8;
+T7: within 1% of baseline between swap intervals; swap stall < 1 engine
+step in atomic mode). Disk/HF space is explicitly not a constraint.

--- a/vllm/model_executor/layers/quantization/exl3_fungible/__init__.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/__init__.py
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Fungible quant: runtime per-expert bit-width reallocation for EXL3 MoE.
+
+Components (research/fungible-quant/implementation in the research branch):
+stats collector (M1), policy engine + store (M2), swap engine (M4).
+"""
+
+from vllm.model_executor.layers.quantization.exl3_fungible.stats import (
+    FqStatsCollector,
+)
+
+__all__ = ["FqStatsCollector"]

--- a/vllm/model_executor/layers/quantization/exl3_fungible/admin.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/admin.py
@@ -1061,9 +1061,19 @@ def build_target_doc(policy_doc: Mapping[str, Any], *, layers: Sequence[int],
     doc = {k: v for k, v in policy_doc.items()
            if k not in ("bits_per_expert", "provenance", "pinned")}
     tier = np.asarray(new_tier)
-    doc["bits_per_expert"] = {
-        str(layer): [int(b) for b in tier[row]]
-        for row, layer in enumerate(layers)}
+    # START from the running document and overwrite only the rows this change
+    # owns. Building bits_per_expert from `layers` alone DROPS every layer the
+    # decision domain does not cover -- on GLM-5.2 that is MTP layer 78, which
+    # the progressive loader requires in the bitrate map but the stats
+    # collector cannot bind. The resulting document described 75 layers
+    # against a running document of 76, and SwapPlan.from_policies refused it
+    # with "policies cover different layers" -- an accurate message about a
+    # document we had malformed ourselves.
+    bpe = {str(k): list(v) for k, v in
+           (policy_doc.get("bits_per_expert") or {}).items()}
+    for row, layer in enumerate(layers):
+        bpe[str(layer)] = [int(b) for b in tier[row]]
+    doc["bits_per_expert"] = bpe
     doc["pinned"] = {str(k): v for k, v in pinned.items()}
     doc["provenance"] = dict(provenance)
     return doc

--- a/vllm/model_executor/layers/quantization/exl3_fungible/admin.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/admin.py
@@ -27,10 +27,16 @@ Gating — OFF by default, twice over:
    require saying so explicitly. (``VLLM_FQ_ADMIN_ENABLE`` is accepted as
    an alias, which is the name the spec used.)
 
-Both are checked at attach time (the routes do not exist otherwise) and
-again on every request (defence in depth: a 404 ``fq_admin_disabled``
-rather than a live mutation if something ever attaches the router by
-another path).
+Both are checked in three places, because the router is not the only way
+in: at attach time (the routes do not exist otherwise), on every request
+in the router's ``_guard``, and — the one that actually matters — in
+``worker_describe``/``worker_plan``/``worker_apply``. Dev mode also
+attaches vLLM's generic ``POST /collective_rpc``, which forwards any
+``method`` name to every worker, and ``Worker.fq_admin_apply`` is an
+unconditional method; without the worker-side check
+``VLLM_SERVER_DEV_MODE`` alone would mutate live weights and
+``VLLM_FQ_ADMIN_TOKEN`` would never be consulted. See
+:func:`_require_gates`.
 
 Fixed cardinality is not negotiable here. Occupancy == capacity is
 enforced in four independent places (``store.validate_policy``,
@@ -402,9 +408,30 @@ def parse_request(body: Mapping[str, Any] | None, *,
     Accepts the single-item query-string shorthand the operator wrote
     (``?layer=23&expert=250&adjust_k=-1``) when there is no body; a body
     and query params together is ``400 mixed_input`` rather than a guess.
+
+    Anything else in the query string is a ``400 unknown_field``, never a
+    silent drop. Filtering it away instead made
+    ``?layer=23&expert=250&adjust_k=-1&dry_run=true`` — the obvious
+    spelling of the operator's "will this work?" button — perform a real,
+    unbracketed weight mutation and answer ``applied: true``. The same
+    silence disarmed ``expect_policy_sha`` (the optimistic-concurrency
+    guard), ``mode``, ``pin``, ``timeout_s`` and the ``actor``/``reason``
+    that make the audit record attributable.
     """
-    query = {k: v for k, v in (query or {}).items()
-             if k in ("layer", "expert", "adjust_k", "k", "delta_k")}
+    query = dict(query or {})
+    unknown_query = sorted(set(query) - _ITEM_FIELDS)
+    if unknown_query:
+        raise AdminError(
+            "unknown_field",
+            f"unrecognised query parameter(s) {unknown_query}. The "
+            f"query-string shorthand carries one item and nothing else "
+            f"({sorted(_ITEM_FIELDS)}); everything that changes what the "
+            f"request DOES — dry_run, mode, pin, expect_policy_sha, "
+            f"timeout_s, actor, reason — must go in the JSON body, or it "
+            f"would be silently ignored.",
+            details={"unknown": unknown_query,
+                     "allowed_query": sorted(_ITEM_FIELDS),
+                     "allowed_body": sorted(_REQUEST_FIELDS)})
     if query and body:
         raise AdminError("mixed_input",
                          "send either the query-string shorthand or a JSON "
@@ -1093,6 +1120,13 @@ def render_retier_table(before: Mapping[int, Mapping[int, int]],
     So: render the touched layers in full (their shape is what the
     operator wants confirmed), then name the pairs underneath, since the
     pairs are the only place the change is visible at all.
+
+    ``swaps`` are ``(model layer id, e_out, e_in)`` — NOT the ``(row,
+    e_out, e_in)`` triples ``policy.decide``/``decision_log.explain``
+    speak in. Both conventions exist in this package, so the whole body
+    is inside the never-raise guard: a caller that passes rows would
+    otherwise reach ``rows[0] -> KeyError`` and take the serve down from
+    a logging helper, after the weights had already moved.
     """
     touched = sorted({int(l) for l, _, _ in swaps})
     try:
@@ -1102,34 +1136,34 @@ def render_retier_table(before: Mapping[int, Mapping[int, int]],
                 {l: before[l] for l in touched if l in before},
                 title=title, num_experts=int(num_experts), diff_only=False)
         else:
-            text = OT.render(after, before, title=title,
+            return OT.render(after, before, title=title,
                              num_experts=int(num_experts), diff_only=True)
+
+        rows = {int(l): i for i, l in enumerate(layers)}
+        before_tier = np.asarray(before_tier)
+        after_tier = np.asarray(after_tier)
+        lines = [text,
+                 "  moved (fixed cardinality: the per-tier COUNTS above are "
+                 "invariant by",
+                 "  construction, so a 1-for-1 trade cannot show up as a "
+                 "delta — these are",
+                 f"  the {len(swaps)} pair(s) that actually moved):"]
+        for layer, e_out, e_in in swaps:
+            row = rows[int(layer)]
+            lines.append(
+                f"    L{int(layer)}: e{int(e_out)} "
+                f"K{int(before_tier[row, e_out])}->"
+                f"K{int(after_tier[row, e_out])}"
+                f"  <->  e{int(e_in)} "
+                f"K{int(before_tier[row, e_in])}->"
+                f"K{int(after_tier[row, e_in])}")
+        omitted = len(layers) - len(touched)
+        if omitted > 0:
+            lines.append(f"  ({omitted} untouched layer(s) omitted)")
+        return "\n".join(lines)
     except Exception:  # noqa: BLE001 — telemetry must never kill a serve
         logger.exception("FQ admin: occupancy table failed to render")
         return ""
-    if not touched:
-        return text
-
-    rows = {int(l): i for i, l in enumerate(layers)}
-    before_tier = np.asarray(before_tier)
-    after_tier = np.asarray(after_tier)
-    lines = [text,
-             "  moved (fixed cardinality: the per-tier COUNTS above are "
-             "invariant by",
-             "  construction, so a 1-for-1 trade cannot show up as a delta — "
-             "these are",
-             f"  the {len(swaps)} pair(s) that actually moved):"]
-    for layer, e_out, e_in in swaps:
-        row = rows[int(layer)]
-        lines.append(
-            f"    L{int(layer)}: e{int(e_out)} "
-            f"K{int(before_tier[row, e_out])}->K{int(after_tier[row, e_out])}"
-            f"  <->  e{int(e_in)} "
-            f"K{int(before_tier[row, e_in])}->K{int(after_tier[row, e_in])}")
-    omitted = len(layers) - len(touched)
-    if omitted > 0:
-        lines.append(f"  ({omitted} untouched layer(s) omitted)")
-    return "\n".join(lines)
 
 
 def adopt_policy(state: Any, new_doc: Mapping[str, Any],
@@ -1865,6 +1899,7 @@ def _err(exc: BaseException) -> str:
 def worker_describe(worker: Any, request_json: str = "{}") -> str:
     """Read-only view of this rank's FQ state (``GET /fq/state``)."""
     try:
+        _require_gates()
         query = json.loads(request_json or "{}")
         state = _loop_state(worker)
         engine = None
@@ -1951,6 +1986,7 @@ def _layer_view(state: Any, layer: int) -> dict:
 def worker_plan(worker: Any, request_json: str) -> str:
     """Phase 1 on this rank: resolve + guard, mutate nothing."""
     try:
+        _require_gates()
         payload = json.loads(request_json)
         state = _loop_state(worker)
         engine = _bound_engine(worker, state)
@@ -1973,6 +2009,10 @@ def worker_apply(worker: Any, plan_json: str) -> str:
     ``plan_sha`` cross-check turns any disagreement into a refusal instead
     of divergent weights.
     """
+    try:
+        _require_gates()
+    except AdminError as exc:
+        return _err(exc)
     if not _WORKER_BUSY.acquire(blocking=False):
         return _err(AdminError(
             "retier_in_flight",
@@ -2012,6 +2052,33 @@ def _resolver_of(engine: Any) -> Any:
     return getattr(source, "resolver", None)
 
 
+def _require_gates(environ: Mapping[str, str] | None = None) -> None:
+    """The second gate, enforced at the WORKER, not only at the router.
+
+    The router is not the only way in. ``register_vllm_dev_api_routers``
+    also attaches vLLM's own ``POST /collective_rpc``
+    (``vllm/entrypoints/serve/dev/rpc/api_router.py``), which forwards an
+    arbitrary ``method`` name straight to every worker — and
+    ``Worker.fq_admin_apply`` is an unconditional method on ``Worker``. So
+    ``VLLM_SERVER_DEV_MODE=1`` alone was enough to mutate live weights
+    through ``{"method": "fq_admin_apply", "args": ["<payload>"]}``,
+    bypassing ``VLLM_FQ_ADMIN_API`` *and* ``VLLM_FQ_ADMIN_TOKEN``
+    entirely. Both gates are re-checked here so "OFF by default, twice
+    over" is true of every entry point rather than only of the one this
+    module owns.
+
+    Worker processes inherit the server's environment (the multiproc
+    executor forks/spawns from it; the Ray path copies all of
+    ``os.environ`` via ``ray_env_utils.get_env_vars_to_copy``), so this
+    never refuses a request the router would have allowed.
+    """
+    if not admin_enabled(environ):
+        raise AdminError("fq_admin_disabled", gate_reason(environ),
+                         status=404,
+                         details={"dev_mode": dev_mode_enabled(environ),
+                                  "admin_flag_env": ADMIN_API_ENV})
+
+
 class FqWorkerAdmin:
     """``--worker-extension-cls`` mixin, for trees without the core hooks.
 
@@ -2048,10 +2115,33 @@ def _rank_results(raw: Sequence[Any]) -> list[dict]:
 
 
 def _first_error(results: Sequence[Mapping[str, Any]]) -> AdminError | None:
+    """The first rank's refusal — with the OTHER ranks' verdicts attached.
+
+    A collective call is not atomic across ranks. Returning only the
+    first failure threw away the fact that the others succeeded, so a TP4
+    apply where rank 2 dies reported that one rank's ``torn: true,
+    flipped: false`` — "nothing was applied" — while ranks 0/1/3 had
+    committed the trade and advanced their loop state. ``per_rank`` and
+    ``ranks_ok`` make the split visible; the caller decides how loud to
+    be about it.
+    """
+    err = None
     for res in results:
         if not res.get("ok", False):
-            return AdminError.from_wire(res.get("error") or {})
-    return None
+            err = AdminError.from_wire(res.get("error") or {})
+            break
+    if err is None:
+        return None
+    err.details["per_rank"] = [
+        {"index": i, "ok": bool(res.get("ok", False)),
+         "code": (res.get("error") or {}).get("code") if not res.get("ok")
+         else None,
+         "generation": res.get("generation"),
+         "policy_sha_after": res.get("policy_sha_after")}
+        for i, res in enumerate(results)]
+    err.details["ranks_ok"] = sum(1 for r in results if r.get("ok", False))
+    err.details["ranks_total"] = len(results)
+    return err
 
 
 def _agree(results: Sequence[Mapping[str, Any]], key: str) -> bool:
@@ -2118,7 +2208,14 @@ def build_router(*, environ: Mapping[str, str] | None = None) -> Any:
             import hmac
 
             sent = request.headers.get("X-FQ-Admin-Token", "")
-            if not hmac.compare_digest(sent, token):
+            # compare_digest refuses str operands with non-ASCII code
+            # points (TypeError). Starlette decodes headers as latin-1, so
+            # a single 0x80..0xff byte in the header turned an
+            # unauthenticated 403 into an unhandled 500 with a traceback.
+            # Compare bytes: same constant-time property, total function.
+            if not hmac.compare_digest(sent.encode("utf-8", "surrogateescape"),
+                                       token.encode("utf-8",
+                                                    "surrogateescape")):
                 return AdminError(
                     "fq_admin_forbidden",
                     f"X-FQ-Admin-Token missing or wrong ({ADMIN_TOKEN_ENV} is "
@@ -2286,6 +2383,28 @@ def build_router(*, environ: Mapping[str, str] | None = None) -> Any:
                                             apply_payload,
                                             timeout=request.timeout_s)
             except AdminError as exc:
+                # A collective apply is not atomic ACROSS ranks. If some
+                # rank committed the trade and another did not, the ranks
+                # are now serving different weights, and reporting the
+                # loser's "nothing was applied" would be a lie that reads
+                # like reassurance.
+                applied_ranks = int(exc.details.get("ranks_ok") or 0)
+                if applied_ranks:
+                    total = exc.details.get("ranks_total", "?")
+                    logger.error(
+                        "FQ ADMIN request=%s PARTIALLY applied: %s of %s "
+                        "rank(s) committed, the rest refused (%s) — the "
+                        "ranks' weights now differ",
+                        request_id, applied_ranks, total, exc.code)
+                    exc = AdminError(
+                        "partial_apply",
+                        f"{applied_ranks} of {total} rank(s) committed this "
+                        f"re-tier and {exc.code} on the rest — the ranks' "
+                        f"weights may now differ; GET /fq/state to compare "
+                        f"policy_sha per rank and consider a restart. "
+                        f"First failure: {exc.message}",
+                        status=500, details=dict(exc.details,
+                                                 first_error=exc.code))
                 return _fail(exc)
             finally:
                 if paused:

--- a/vllm/model_executor/layers/quantization/exl3_fungible/admin.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/admin.py
@@ -1964,6 +1964,72 @@ def _err(exc: BaseException) -> str:
         sort_keys=True, separators=(",", ":"), default=str)
 
 
+#: Loop knobs an operator may retune WITHOUT a restart, with the bounds that
+#: make each one safe. Anything not listed here needs a boot, deliberately:
+#: n_k4 is baked into the slab shapes, and apply_mode changes the contract.
+TUNABLE: dict[str, tuple[float, float, str]] = {
+    "jaccard_floor": (0.0, 1.0, "router-shift guard"),
+    "hysteresis": (1.0, 10.0, "score ratio needed to displace an incumbent"),
+    "dwell_steps": (0, 10_000_000, "min steps an expert holds its tier"),
+    "max_swaps_per_layer": (0, 256, "per-layer cap per interval"),
+    "max_swaps_total": (0, 4096, "global cap per interval"),
+}
+
+
+def worker_tune(worker: Any, request_json: str = "{}") -> str:
+    """Retune loop knobs in place (``POST /fq/tune``).
+
+    The floor that blocks a swap should not need a 6-minute reboot to change.
+    Measuring a threshold, then having to restart the thing you measured it
+    on, loses the state that produced the measurement — which is how a
+    calibration ends up unverified.
+
+    Bounded and validated per key; unknown keys are REFUSED rather than
+    ignored, because a silently-dropped tuning request looks exactly like one
+    that had no effect.
+    """
+    try:
+        _require_gates()
+    except AdminError as exc:
+        return _err(exc)
+    try:
+        req = json.loads(request_json) or {}
+        state = _loop_state(worker)
+        cfg = getattr(state, "cfg", None)
+        if cfg is None:
+            raise AdminError("fq_not_active",
+                             "no fungible-quant loop on this worker",
+                             status=404)
+        unknown = sorted(set(req) - set(TUNABLE))
+        if unknown:
+            raise AdminError(
+                "unknown_knob",
+                f"not tunable at runtime: {unknown}. Tunable: "
+                f"{sorted(TUNABLE)}. Anything else changes a shape or a "
+                f"contract and needs a restart.",
+                status=400, details={"tunable": sorted(TUNABLE)})
+        applied, before = {}, {}
+        for k, v in req.items():
+            lo, hi, _ = TUNABLE[k]
+            fv = float(v)
+            if not (lo <= fv <= hi):
+                raise AdminError(
+                    "out_of_range",
+                    f"{k}={fv} outside [{lo}, {hi}]",
+                    status=400)
+            old = getattr(cfg, k, None)
+            before[k] = old
+            setattr(cfg, k, type(old)(fv) if old is not None else fv)
+            applied[k] = getattr(cfg, k)
+        if applied:
+            logging.getLogger(__name__).warning(
+                "FQ loop retuned at runtime: %s (was %s)", applied, before)
+        return _ok({"applied": applied, "before": before,
+                    "rank": int(getattr(state, "rank", 0) or 0)})
+    except Exception as exc:  # noqa: BLE001
+        return _err(exc)
+
+
 def worker_describe(worker: Any, request_json: str = "{}") -> str:
     """Read-only view of this rank's FQ state (``GET /fq/state``)."""
     try:
@@ -2328,6 +2394,29 @@ def build_router(*, environ: Mapping[str, str] | None = None) -> Any:
                           str(_env(environ).get(ADMIN_TOKEN_ENV, "")).strip()),
                       "auto_balance": False,
                       "growth_supported": False}})
+
+    @router.post("/tune")
+    async def fq_tune(raw_request: Request):
+        """Retune the loop on every rank, or on none of them."""
+        blocked = _guard(raw_request)
+        if blocked is not None:
+            return _fail(blocked)
+        try:
+            body = await raw_request.json()
+        except Exception:  # noqa: BLE001
+            body = {}
+        try:
+            results = await _collective(raw_request, "fq_admin_tune", body)
+        except AdminError as exc:
+            return _fail(exc)
+        record_admin_outcome("tune")
+        return JSONResponse(content={
+            "ranks": len(results),
+            "agreed": _agree(results, "applied"),
+            "applied": results[0].get("applied") if results else {},
+            "per_rank": results,
+            "tunable": {k: {"min": lo, "max": hi, "what": what}
+                        for k, (lo, hi, what) in TUNABLE.items()}})
 
     @router.get("/layer/{layer}")
     async def fq_layer(layer: int, raw_request: Request):

--- a/vllm/model_executor/layers/quantization/exl3_fungible/admin.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/admin.py
@@ -1,0 +1,2339 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Fungible-quant admin API: operator-forced expert re-tiering.
+
+Implements ``runs/m5-serve/admin-api-spec.md``. The operator's ask was
+"expose (optionally) an admin api ... that would allow to force
+upgrade/downgrade of specific experts K -- for example
+layer=23,expert=250,adjust_k=-1 (relative, or absolute like adjust_k=3)
+and as a batch ... this being guarded by maximum memory usage".
+
+Design stance, restated because it is the whole point: this module is
+**glue plus guards**. It does not invent a second way to move an expert
+between tiers. The target ``fq-policy/2`` document is built, handed to
+:meth:`SwapPlan.from_policies` (which already does pairing, ordering and
+the same-cardinality check) and then to :meth:`SwapEngine.apply` (which
+already does the six-step commit protocol and persists the policy as
+step 5 inside the quiesce window). ``swap.py``, ``store.py``,
+``policy.py``, ``fragments.py`` and ``occupancy_table.py`` are unchanged.
+
+Gating — OFF by default, twice over:
+
+1. ``VLLM_SERVER_DEV_MODE`` — vLLM's own dev-endpoint gate. Without it
+   ``register_vllm_dev_api_routers`` never runs, so the router is never
+   attached.
+2. ``VLLM_FQ_ADMIN_API=1`` — a second, FQ-specific gate. Dev mode gets
+   turned on for lots of reasons; forced mutation of live weights should
+   require saying so explicitly. (``VLLM_FQ_ADMIN_ENABLE`` is accepted as
+   an alias, which is the name the spec used.)
+
+Both are checked at attach time (the routes do not exist otherwise) and
+again on every request (defence in depth: a 404 ``fq_admin_disabled``
+rather than a live mutation if something ever attaches the router by
+another path).
+
+Fixed cardinality is not negotiable here. Occupancy == capacity is
+enforced in four independent places (``store.validate_policy``,
+``SwapPlan.from_memberships``, ``SwapEngine._validate_layer``,
+``policy.decide``), and runtime budget *growth* is structurally
+impossible: tier slabs are sized at prepare time and the mixed-kernel
+memo key carries per-tier expert counts, so changing a count forces a
+recompile that is refused under CUDA-graph capture. ``mode=grow_budget``
+therefore returns 501 with all three reasons rather than pretending.
+
+Laziness contract (same as ``integration.py``): nothing from ``vllm`` and
+nothing from ``fastapi`` is imported at module level, so this module is
+importable — and CPU-testable — without a built ``vllm._C``.
+"""
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import json
+import logging
+import os
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Sequence
+
+import numpy as np
+
+from vllm.model_executor.layers.quantization.exl3_fungible import (
+    decision_log as DL,
+)
+from vllm.model_executor.layers.quantization.exl3_fungible import (
+    occupancy_table as OT,
+)
+from vllm.model_executor.layers.quantization.exl3_fungible import policy as P
+from vllm.model_executor.layers.quantization.exl3_fungible import swap as SW
+from vllm.model_executor.layers.quantization.exl3_fungible.store import (
+    policy_hash,
+    validate_policy,
+)
+
+logger = logging.getLogger(__name__)
+
+# ------------------------------------------------------------------ env knobs
+DEV_MODE_ENV = "VLLM_SERVER_DEV_MODE"
+# The task-mandated primary gate. VLLM_FQ_ADMIN_ENABLE is the name the
+# spec used; both are honoured so neither document is wrong.
+ADMIN_API_ENV = "VLLM_FQ_ADMIN_API"
+ADMIN_ENABLE_ENV = "VLLM_FQ_ADMIN_ENABLE"
+ADMIN_TOKEN_ENV = "VLLM_FQ_ADMIN_TOKEN"
+ADMIN_MAX_ITEMS_ENV = "VLLM_FQ_ADMIN_MAX_ITEMS"
+ADMIN_MEM_BUDGET_ENV = "VLLM_FQ_ADMIN_MEM_BUDGET_BYTES"
+ADMIN_MEM_HEADROOM_ENV = "VLLM_FQ_ADMIN_MEM_HEADROOM_BYTES"
+ADMIN_MIN_FREE_SLOTS_ENV = "VLLM_FQ_ADMIN_MIN_FREE_SLOTS"
+ADMIN_DRAIN_TIMEOUT_ENV = "VLLM_FQ_ADMIN_DRAIN_TIMEOUT_S"
+ADMIN_ALLOW_AUTO_BALANCE_ENV = "VLLM_FQ_ADMIN_ALLOW_AUTO_BALANCE"
+
+DEFAULT_MAX_ITEMS = 32
+DEFAULT_MEM_HEADROOM_BYTES = 1 << 30
+DEFAULT_MIN_FREE_SLOTS = 2
+DEFAULT_DRAIN_TIMEOUT_S = 120.0
+
+#: The tiers the v1 swap engine can actually serve as a MIXED pair.
+#: ``MixedLayerState.from_exl3_mixed_trellis`` refuses anything but (3, 4),
+#: and K5 as a mixed tier does not fit SM120 shared memory at all
+#: (109568 > 101376; K4 is exactly 101376, zero headroom) — see
+#: runs/m5-serve/k5-shared-memory-limit.md.
+SERVABLE_TIERS: tuple[int, ...] = (P.K3, P.K4)
+
+MODE_STRICT_PAIR = "strict_pair"
+MODE_AUTO_BALANCE = "auto_balance"
+MODE_GROW_BUDGET = "grow_budget"
+
+PIN_HOLD, PIN_NONE, PIN_RELEASE = "hold", "none", "release"
+
+_REQUEST_FIELDS = frozenset({
+    "items", "mode", "dry_run", "pin", "drain_mode", "reset_prefix_cache",
+    "expect_policy_sha", "timeout_s", "actor", "reason",
+})
+_ITEM_FIELDS = frozenset({"layer", "expert", "adjust_k", "k", "delta_k"})
+
+
+def _env(environ: Mapping[str, str] | None) -> Mapping[str, str]:
+    return os.environ if environ is None else environ
+
+
+def _env_int(environ, name: str, default: int) -> int:
+    raw = _env(environ).get(name)
+    if raw is None or str(raw).strip() == "":
+        return default
+    try:
+        return int(str(raw).strip())
+    except ValueError:
+        logger.warning("FQ admin: %s=%r is not an int — using %d",
+                       name, raw, default)
+        return default
+
+
+def _env_float(environ, name: str, default: float) -> float:
+    raw = _env(environ).get(name)
+    if raw is None or str(raw).strip() == "":
+        return default
+    try:
+        return float(str(raw).strip())
+    except ValueError:
+        logger.warning("FQ admin: %s=%r is not a float — using %s",
+                       name, raw, default)
+        return default
+
+
+def dev_mode_enabled(environ: Mapping[str, str] | None = None) -> bool:
+    return str(_env(environ).get(DEV_MODE_ENV, "0")).strip() in ("1", "true",
+                                                                 "True")
+
+
+def admin_enabled(environ: Mapping[str, str] | None = None) -> bool:
+    """Both gates. OFF unless dev mode AND the FQ admin flag are set."""
+    env = _env(environ)
+    flag = (str(env.get(ADMIN_API_ENV, "")).strip()
+            or str(env.get(ADMIN_ENABLE_ENV, "")).strip())
+    return dev_mode_enabled(environ) and flag in ("1", "true", "True")
+
+
+def gate_reason(environ: Mapping[str, str] | None = None) -> str:
+    """Human-readable reason the API is off (for the 404 body)."""
+    if not dev_mode_enabled(environ):
+        return (f"{DEV_MODE_ENV} is not set — vLLM development endpoints are "
+                "disabled")
+    return (f"{ADMIN_API_ENV}=1 is required to expose forced expert "
+            "re-tiering (dev mode alone is not enough)")
+
+
+# ------------------------------------------------------------------- errors
+
+
+class AdminError(Exception):
+    """A refusal with a machine-readable body.
+
+    An admin API is machine-driven; a bare ``detail`` string is not
+    parseable. Every refusal carries ``code`` (stable), ``message``
+    (actionable prose) and ``details`` (the numbers to act on).
+    """
+
+    def __init__(self, code: str, message: str, *, status: int = 400,
+                 details: dict | None = None):
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.status = int(status)
+        self.details = details or {}
+
+    def body(self) -> dict:
+        return {"error": {"code": self.code, "message": self.message,
+                          "details": self.details}}
+
+    def wire(self) -> dict:
+        """Serialisable form for the worker -> router hop."""
+        return {"code": self.code, "message": self.message,
+                "http_status": self.status, "details": self.details}
+
+    @classmethod
+    def from_wire(cls, payload: Mapping[str, Any]) -> "AdminError":
+        return cls(str(payload.get("code", "internal_error")),
+                   str(payload.get("message", "")),
+                   status=int(payload.get("http_status", 500)),
+                   details=dict(payload.get("details") or {}))
+
+
+def _fmt_bytes(n: int) -> str:
+    n = int(n)
+    sign = "-" if n < 0 else ""
+    a = abs(n)
+    for unit, scale in (("GiB", 1 << 30), ("MiB", 1 << 20), ("KiB", 1 << 10)):
+        if a >= scale:
+            return f"{sign}{a / scale:.3f} {unit}"
+    return f"{sign}{a} B"
+
+
+# ------------------------------------------------------------------ requests
+
+
+@dataclass(frozen=True)
+class RetierItem:
+    """One parsed ``items[]`` entry, before it meets live state."""
+
+    layer: int
+    expert: int
+    requested: Any                 # verbatim, echoed back to the operator
+    interpretation: str            # "absolute" | "relative"
+    k: int | None = None
+    delta_k: int | None = None
+
+
+@dataclass(frozen=True)
+class RetierRequest:
+    items: tuple[RetierItem, ...]
+    mode: str = MODE_STRICT_PAIR
+    dry_run: bool = False
+    pin: str = PIN_HOLD
+    drain_mode: str = "wait"
+    reset_prefix_cache: bool = False
+    expect_policy_sha: str | None = None
+    timeout_s: float = DEFAULT_DRAIN_TIMEOUT_S
+    actor: str | None = None
+    reason: str | None = None
+
+    def canonical(self) -> dict:
+        return {
+            "items": [
+                {"layer": it.layer, "expert": it.expert,
+                 "requested": it.requested,
+                 "interpretation": it.interpretation,
+                 "k": it.k, "delta_k": it.delta_k}
+                for it in self.items
+            ],
+            "mode": self.mode,
+            "dry_run": self.dry_run,
+            "pin": self.pin,
+            "drain_mode": self.drain_mode,
+            "reset_prefix_cache": self.reset_prefix_cache,
+            "expect_policy_sha": self.expect_policy_sha,
+            "timeout_s": self.timeout_s,
+            "actor": self.actor,
+            "reason": self.reason,
+        }
+
+    @classmethod
+    def from_canonical(cls, doc: Mapping[str, Any]) -> "RetierRequest":
+        items = tuple(
+            RetierItem(layer=int(d["layer"]), expert=int(d["expert"]),
+                       requested=d.get("requested"),
+                       interpretation=str(d["interpretation"]),
+                       k=None if d.get("k") is None else int(d["k"]),
+                       delta_k=(None if d.get("delta_k") is None
+                                else int(d["delta_k"])))
+            for d in doc.get("items", ())
+        )
+        return cls(
+            items=items,
+            mode=str(doc.get("mode", MODE_STRICT_PAIR)),
+            dry_run=bool(doc.get("dry_run", False)),
+            pin=str(doc.get("pin", PIN_HOLD)),
+            drain_mode=str(doc.get("drain_mode", "wait")),
+            reset_prefix_cache=bool(doc.get("reset_prefix_cache", False)),
+            expect_policy_sha=doc.get("expect_policy_sha"),
+            timeout_s=float(doc.get("timeout_s", DEFAULT_DRAIN_TIMEOUT_S)),
+            actor=doc.get("actor"),
+            reason=doc.get("reason"),
+        )
+
+
+_AMBIGUOUS_MSG = (
+    'adjust_k={n} is not a valid absolute tier (ladder is K3/K4). For a '
+    'relative +{n}, send the string "+{n}", or use the explicit field '
+    'delta_k: {n}.'
+)
+
+
+def _parse_adjust(raw: Any, index: int) -> tuple[str, int | None, int | None]:
+    """``adjust_k`` disambiguation (spec §3.2).
+
+    ``+1`` is not legal JSON, so the sign has to survive some other way:
+
+    ==========  ======================  ====================================
+    sent        interpretation          why it is unambiguous
+    ==========  ======================  ====================================
+    ``-1``      relative ``delta=-1``   no negative K exists
+    ``3``       absolute ``k=3``        matches "absolute like adjust_k=3"
+    ``"+1"``    relative ``delta=+1``   explicit sign
+    ``"-1"``    relative ``delta=-1``   explicit sign
+    ``"3"``     absolute ``k=3``        no sign
+    ``1``/``0`` 400 ambiguous_adjust_k  K1/K0 do not exist
+    ==========  ======================  ====================================
+    """
+    if isinstance(raw, bool):
+        raise AdminError("bad_adjust_k",
+                         f"items[{index}].adjust_k must be a number or a "
+                         f"signed string, got a boolean",
+                         details={"index": index, "adjust_k": raw})
+    if isinstance(raw, str):
+        text = raw.strip()
+        if not text:
+            raise AdminError("bad_adjust_k",
+                             f"items[{index}].adjust_k is empty",
+                             details={"index": index})
+        signed = text[0] in "+-"
+        try:
+            value = int(text, 10)
+        except ValueError:
+            raise AdminError("bad_adjust_k",
+                             f"items[{index}].adjust_k={raw!r} is not an "
+                             f"integer",
+                             details={"index": index, "adjust_k": raw}) from None
+        if signed:
+            return "relative", None, value
+        return "absolute", value, None
+    if isinstance(raw, int):
+        if raw < 0:
+            return "relative", None, raw
+        if raw in SERVABLE_TIERS:
+            return "absolute", raw, None
+        raise AdminError(
+            "ambiguous_adjust_k",
+            _AMBIGUOUS_MSG.format(n=raw),
+            details={"index": index, "adjust_k": raw,
+                     "ladder": list(SERVABLE_TIERS)})
+    raise AdminError("bad_adjust_k",
+                     f"items[{index}].adjust_k={raw!r} is neither a number "
+                     f"nor a signed string",
+                     details={"index": index, "adjust_k": raw})
+
+
+def _parse_item(raw: Any, index: int) -> RetierItem:
+    if not isinstance(raw, Mapping):
+        raise AdminError("bad_json", f"items[{index}] is not an object",
+                         details={"index": index})
+    unknown = sorted(set(raw) - _ITEM_FIELDS)
+    if unknown:
+        raise AdminError("unknown_field",
+                         f"items[{index}] has unrecognised key(s) {unknown}",
+                         details={"index": index, "unknown": unknown,
+                                  "allowed": sorted(_ITEM_FIELDS)})
+    for name in ("layer", "expert"):
+        if name not in raw:
+            raise AdminError("bad_json", f"items[{index}].{name} is required",
+                             details={"index": index})
+    try:
+        layer = int(raw["layer"])
+        expert = int(raw["expert"])
+    except (TypeError, ValueError):
+        raise AdminError("bad_json",
+                         f"items[{index}]: layer/expert must be integers",
+                         details={"index": index}) from None
+
+    present = [n for n in ("adjust_k", "k", "delta_k") if n in raw]
+    if len(present) != 1:
+        raise AdminError(
+            "bad_adjust_k",
+            f"items[{index}]: exactly one of adjust_k / k / delta_k is "
+            f"required, got {present or 'none'}",
+            details={"index": index, "present": present})
+    name = present[0]
+    value = raw[name]
+    if name == "adjust_k":
+        interpretation, k, delta = _parse_adjust(value, index)
+    elif name == "k":
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise AdminError("bad_adjust_k",
+                             f"items[{index}].k must be an integer",
+                             details={"index": index, "k": value})
+        interpretation, k, delta = "absolute", int(value), None
+    else:
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise AdminError("bad_adjust_k",
+                             f"items[{index}].delta_k must be an integer",
+                             details={"index": index, "delta_k": value})
+        interpretation, k, delta = "relative", None, int(value)
+    return RetierItem(layer=layer, expert=expert, requested=value,
+                      interpretation=interpretation, k=k, delta_k=delta)
+
+
+def parse_request(body: Mapping[str, Any] | None, *,
+                  query: Mapping[str, Any] | None = None,
+                  actor_header: str | None = None,
+                  environ: Mapping[str, str] | None = None) -> RetierRequest:
+    """Validate and desugar a ``POST /fq/retier`` payload.
+
+    Accepts the single-item query-string shorthand the operator wrote
+    (``?layer=23&expert=250&adjust_k=-1``) when there is no body; a body
+    and query params together is ``400 mixed_input`` rather than a guess.
+    """
+    query = {k: v for k, v in (query or {}).items()
+             if k in ("layer", "expert", "adjust_k", "k", "delta_k")}
+    if query and body:
+        raise AdminError("mixed_input",
+                         "send either the query-string shorthand or a JSON "
+                         "body, not both",
+                         details={"query": sorted(query)})
+    if query:
+        # Query values arrive as strings. ``adjust_k`` keeps its string
+        # form on purpose (that is how "+1" survives the wire at all), but
+        # the explicit machine fields are numbers.
+        shorthand = dict(query)
+        for name in ("layer", "expert", "k", "delta_k"):
+            if name in shorthand:
+                try:
+                    shorthand[name] = int(str(shorthand[name]).strip())
+                except ValueError:
+                    raise AdminError(
+                        "bad_json",
+                        f"query parameter {name}={shorthand[name]!r} is not "
+                        f"an integer", details={name: shorthand[name]}
+                    ) from None
+        body = {"items": [shorthand]}
+    if body is None:
+        raise AdminError("bad_json", "a JSON body is required")
+    if not isinstance(body, Mapping):
+        raise AdminError("bad_json", "body must be a JSON object")
+
+    unknown = sorted(set(body) - _REQUEST_FIELDS)
+    if unknown:
+        raise AdminError("unknown_field",
+                         f"unrecognised top-level key(s) {unknown}",
+                         details={"unknown": unknown,
+                                  "allowed": sorted(_REQUEST_FIELDS)})
+
+    raw_items = body.get("items", [])
+    if not isinstance(raw_items, (list, tuple)):
+        raise AdminError("bad_json", "items must be an array")
+    max_items = _env_int(environ, ADMIN_MAX_ITEMS_ENV, DEFAULT_MAX_ITEMS)
+    if len(raw_items) > max_items:
+        raise AdminError("too_many_items",
+                         f"{len(raw_items)} items exceeds "
+                         f"{ADMIN_MAX_ITEMS_ENV}={max_items}",
+                         details={"items": len(raw_items),
+                                  "max_items": max_items})
+
+    pin = str(body.get("pin", PIN_HOLD))
+    if pin not in (PIN_HOLD, PIN_NONE, PIN_RELEASE):
+        raise AdminError("unknown_field",
+                         f"pin must be hold|none|release, got {pin!r}",
+                         details={"pin": pin})
+    if not raw_items and pin == PIN_NONE:
+        raise AdminError("empty_request",
+                         "no items and no pin change — nothing to do")
+
+    items = tuple(_parse_item(raw, i) for i, raw in enumerate(raw_items))
+    seen: dict[tuple[int, int], int] = {}
+    for i, it in enumerate(items):
+        key = (it.layer, it.expert)
+        if key in seen:
+            raise AdminError(
+                "duplicate_item",
+                f"(layer {it.layer}, expert {it.expert}) appears at items"
+                f"[{seen[key]}] and items[{i}] — one entry per expert",
+                details={"layer": it.layer, "expert": it.expert,
+                         "indices": [seen[key], i]})
+        seen[key] = i
+
+    mode = str(body.get("mode", MODE_STRICT_PAIR))
+    if mode not in (MODE_STRICT_PAIR, MODE_AUTO_BALANCE, MODE_GROW_BUDGET):
+        raise AdminError("unknown_field",
+                         f"mode must be strict_pair|auto_balance|grow_budget,"
+                         f" got {mode!r}", details={"mode": mode})
+    drain_mode = str(body.get("drain_mode", "wait"))
+    if drain_mode not in ("wait", "abort", "keep"):
+        raise AdminError("unknown_field",
+                         f"drain_mode must be wait|abort|keep, got "
+                         f"{drain_mode!r}", details={"drain_mode": drain_mode})
+
+    timeout_s = body.get("timeout_s")
+    if timeout_s is None:
+        timeout_s = _env_float(environ, ADMIN_DRAIN_TIMEOUT_ENV,
+                               DEFAULT_DRAIN_TIMEOUT_S)
+    try:
+        timeout_s = float(timeout_s)
+    except (TypeError, ValueError):
+        raise AdminError("bad_json", "timeout_s must be a number") from None
+
+    return RetierRequest(
+        items=items, mode=mode, dry_run=bool(body.get("dry_run", False)),
+        pin=pin, drain_mode=drain_mode,
+        reset_prefix_cache=bool(body.get("reset_prefix_cache", False)),
+        expect_policy_sha=body.get("expect_policy_sha"),
+        timeout_s=timeout_s,
+        actor=body.get("actor") or actor_header,
+        reason=body.get("reason"))
+
+
+# ------------------------------------------------------------- resolved items
+
+
+@dataclass(frozen=True)
+class ResolvedItem:
+    layer: int
+    expert: int
+    requested: Any
+    interpretation: str
+    k_from: int
+    k_to: int
+    outcome: str                   # promoted | demoted | noop
+    source: str = "operator"
+
+    def as_dict(self) -> dict:
+        return {"layer": self.layer, "expert": self.expert,
+                "requested": self.requested,
+                "interpretation": self.interpretation,
+                "k_from": self.k_from, "k_to": self.k_to,
+                "outcome": self.outcome, "source": self.source}
+
+
+def resolve_items(request: RetierRequest, *, layers: Sequence[int],
+                  tier_of: Any, num_experts: int,
+                  registered_layers: Sequence[int] | None = None,
+                  ) -> list[ResolvedItem]:
+    """Turn parsed items into (k_from, k_to) against the **live** state.
+
+    ``k_from`` is always read from ``tier_of`` — never from anything the
+    client sent — so a stale client view cannot silently mis-target.
+    """
+    tier_of = np.asarray(tier_of)
+    rows = {int(l): i for i, l in enumerate(layers)}
+    registered = None if registered_layers is None else set(
+        int(x) for x in registered_layers)
+    out: list[ResolvedItem] = []
+    for item in request.items:
+        row = rows.get(item.layer)
+        if row is None:
+            raise AdminError(
+                "layer_not_registered",
+                f"layer {item.layer} is not in the running policy "
+                f"(layers {sorted(rows)[:8]}{'...' if len(rows) > 8 else ''})",
+                status=404,
+                details={"layer": item.layer, "known_layers": sorted(rows)})
+        if registered is not None and item.layer not in registered:
+            raise AdminError(
+                "layer_not_registered",
+                f"layer {item.layer} is in the policy but has no live "
+                f"mixed-trellis state registered with the swap engine",
+                status=404,
+                details={"layer": item.layer,
+                         "registered_layers": sorted(registered)})
+        if not 0 <= item.expert < int(num_experts):
+            raise AdminError(
+                "expert_out_of_range",
+                f"expert {item.expert} is outside [0, {int(num_experts)})",
+                details={"layer": item.layer, "expert": item.expert,
+                         "num_experts": int(num_experts)})
+        k_from = int(tier_of[row, item.expert])
+        k_to = int(item.k) if item.k is not None else k_from + int(item.delta_k)
+        if k_to == k_from:
+            outcome = "noop"
+        elif k_to > k_from:
+            outcome = "promoted"
+        else:
+            outcome = "demoted"
+        if outcome != "noop" and k_to not in SERVABLE_TIERS:
+            raise AdminError(
+                "tier_not_servable",
+                f"L{item.layer}/e{item.expert}: K{k_to} cannot be served as a "
+                f"mixed tier. Two independent reasons: (a) the v1 swap engine "
+                f"is a two-tier engine — MixedLayerState.from_exl3_mixed_"
+                f"trellis refuses anything but "
+                f"{tuple(SERVABLE_TIERS)}; (b) on SM120 a K5 mixed tier needs "
+                f"109568 bytes of shared memory against a 101376 opt-in limit "
+                f"(K4 is exactly 101376, zero headroom) — see "
+                f"runs/m5-serve/k5-shared-memory-limit.md.",
+                status=501,
+                details={"layer": item.layer, "expert": item.expert,
+                         "k_from": k_from, "k_to": k_to,
+                         "ladder": list(SERVABLE_TIERS)})
+        out.append(ResolvedItem(
+            layer=item.layer, expert=item.expert, requested=item.requested,
+            interpretation=item.interpretation, k_from=k_from, k_to=k_to,
+            outcome=outcome))
+    return out
+
+
+def check_cardinality(resolved: Sequence[ResolvedItem], *, mode: str,
+                      n_k4_per_layer: Mapping[str, int] | None = None,
+                      environ: Mapping[str, str] | None = None) -> None:
+    """The fixed-cardinality invariant, per layer, before anything moves.
+
+    ``strict_pair`` (the default and the only mode v1 ships) requires
+    ``#promotions == #demotions`` per layer. An override that silently
+    makes a second, unrequested policy decision — which expert to
+    sacrifice — is exactly the surprise an operator issues an override to
+    avoid.
+    """
+    if mode == MODE_GROW_BUDGET:
+        raise AdminError(
+            "budget_growth_not_supported",
+            "runtime budget growth is not supported, and not merely "
+            "unbudgeted — it is structurally impossible. (1) The tier slabs "
+            "are sized at prepare time: SwapEngine._validate_layer derives "
+            "the slab word counts from len(tierN_globals) and refuses a "
+            "mismatch, so one more K4 expert means reallocating tier1.w13/w2. "
+            "(2) The mixed-kernel memo key carries per-tier expert COUNTS "
+            "(tier_signature), so changing a count forces "
+            "compile_mixed_trellis, which is refused under CUDA-graph capture "
+            "and which on SM120 re-enters the tile-fit trap that blocks K5. "
+            "(3) The bytes are not there: the KV-cache pool is sized from "
+            "post-load free memory at startup. Raise n_k4_per_layer in the "
+            "policy and restart — the committed policy steers the next boot.",
+            status=501,
+            details={"mode": mode, "growth_supported": False})
+    if mode == MODE_AUTO_BALANCE:
+        allow = str(_env(environ).get(ADMIN_ALLOW_AUTO_BALANCE_ENV, "0"))
+        if allow.strip() not in ("1", "true", "True"):
+            raise AdminError(
+                "unknown_field",
+                f"mode=auto_balance requires "
+                f"{ADMIN_ALLOW_AUTO_BALANCE_ENV}=1 (it lets the server pick "
+                f"which expert to sacrifice, which an override normally "
+                f"should not do)",
+                details={"mode": mode})
+        raise AdminError(
+            "unknown_field",
+            "mode=auto_balance is declared but not implemented in v1 — use "
+            "strict_pair and name the partner explicitly (GET /fq/layer/"
+            "{layer} ranks the coldest K4 residents)",
+            status=501, details={"mode": mode})
+
+    per_layer: dict[int, dict[str, list]] = {}
+    for it in resolved:
+        bucket = per_layer.setdefault(
+            it.layer, {"promotions": [], "demotions": [], "noop": []})
+        if it.outcome == "promoted":
+            bucket["promotions"].append(it)
+        elif it.outcome == "demoted":
+            bucket["demotions"].append(it)
+        else:
+            bucket["noop"].append(it)
+
+    for layer in sorted(per_layer):
+        bucket = per_layer[layer]
+        ups, downs = bucket["promotions"], bucket["demotions"]
+        if len(ups) == len(downs):
+            continue
+        cap = None
+        if n_k4_per_layer is not None:
+            cap = n_k4_per_layer.get(str(layer), n_k4_per_layer.get(layer))
+        detail_ups = [{"expert": i.expert, "k_from": i.k_from,
+                       "k_to": i.k_to} for i in ups]
+        detail_downs = [{"expert": i.expert, "k_from": i.k_from,
+                         "k_to": i.k_to} for i in downs]
+        pretty = ", ".join(f"e{i.expert}: K{i.k_from}->K{i.k_to}"
+                           for i in ups + downs) or "nothing"
+        raise AdminError(
+            "cardinality_unbalanced",
+            f"layer {layer}: {len(ups)} promotion(s), {len(downs)} "
+            f"demotion(s) ({pretty}). Fixed-cardinality invariant requires a "
+            f"1-for-1 trade.",
+            status=409,
+            details={
+                "layer": layer,
+                "n_k4_per_layer": cap,
+                "promotions": detail_ups,
+                "demotions": detail_downs,
+                "noop_items": [{"expert": i.expert, "k": i.k_from}
+                               for i in bucket["noop"]],
+                "remedies": [
+                    f"add a matching {'demotion' if len(ups) > len(downs) else 'promotion'} "
+                    f"in layer {layer} (see GET /fq/layer/{layer} for the "
+                    f"coldest K4 residents)",
+                    f"retry with mode=auto_balance (requires "
+                    f"{ADMIN_ALLOW_AUTO_BALANCE_ENV}=1)",
+                    f"raise n_k4_per_layer['{layer}'] and restart — runtime "
+                    f"budget growth is not supported (see "
+                    f"/fq/state.budget.growth_supported)",
+                ],
+            })
+
+
+# ------------------------------------------------------------- memory guard
+
+
+@dataclass(frozen=True)
+class MemoryModel:
+    """Per-rank expert payload arithmetic, derived from live geometry.
+
+    Sizes come straight from :class:`swap.ExpertStage`, which is the
+    authority on what a swap actually moves:
+
+    * trellis (3 slab rows) — ``3 * H * I * k / 8`` bytes, i.e. exactly
+      ``unit_bytes_per_k`` per bit of K,
+    * rotations (gate_suh, up_suh, down_svh, the 3I combined
+      intermediate row) — ``6 * (H + I)`` bytes, independent of K.
+
+    So the *delta* of a re-tier is ``unit_bytes_per_k * Σ(k_to - k_from)``
+    exactly, and it is 0 by construction under ``strict_pair``. Derived
+    rather than hard-coded so the response can show the operator the
+    arithmetic instead of asking them to trust a constant.
+    """
+
+    hidden_size: int
+    intermediate_size: int
+
+    @property
+    def unit_bytes_per_k(self) -> int:
+        return 3 * int(self.hidden_size) * int(self.intermediate_size) // 8
+
+    @property
+    def rotation_bytes(self) -> int:
+        return 6 * (int(self.hidden_size) + int(self.intermediate_size))
+
+    def expert_bytes(self, k: int) -> int:
+        return self.unit_bytes_per_k * int(k) + self.rotation_bytes
+
+    def resident_bytes(self, tier_of: Any) -> int:
+        tier = np.asarray(tier_of, dtype=np.int64)
+        return int(self.unit_bytes_per_k * int(tier.sum())
+                   + self.rotation_bytes * int(tier.size))
+
+    def delta_bytes(self, resolved: Sequence[ResolvedItem]) -> int:
+        return int(self.unit_bytes_per_k
+                   * sum(int(i.k_to) - int(i.k_from) for i in resolved))
+
+
+def check_memory(model: MemoryModel, tier_of: Any,
+                 resolved: Sequence[ResolvedItem], *,
+                 budget_bytes: int | None = None,
+                 device_free_bytes: int | None = None,
+                 headroom_bytes: int | None = None,
+                 environ: Mapping[str, str] | None = None) -> dict:
+    """Refuse a re-tier that would grow the resident expert payload.
+
+    Under ``strict_pair`` ``delta_bytes`` is exactly 0, so this never
+    fires. It is evaluated and reported anyway: an admin API that asserts
+    an invariant it never checks is an admin API that will violate it the
+    first time someone adds a mode.
+    """
+    current = model.resident_bytes(tier_of)
+    delta = model.delta_bytes(resolved)
+    projected = current + delta
+    if budget_bytes is None:
+        budget_bytes = _env_int(environ, ADMIN_MEM_BUDGET_ENV, current)
+    budget_bytes = int(budget_bytes)
+    if headroom_bytes is None:
+        headroom_bytes = _env_int(environ, ADMIN_MEM_HEADROOM_ENV,
+                                  DEFAULT_MEM_HEADROOM_BYTES)
+    headroom_bytes = int(headroom_bytes)
+
+    accounting = {
+        "unit_bytes_per_k_per_rank": model.unit_bytes_per_k,
+        "rotation_bytes_per_expert_per_rank": model.rotation_bytes,
+        "hidden_size": int(model.hidden_size),
+        "intermediate_size_per_partition": int(model.intermediate_size),
+        "delta_bytes_per_rank": delta,
+        "current_expert_bytes_per_rank": current,
+        "projected_expert_bytes_per_rank": projected,
+        "budget_bytes_per_rank": budget_bytes,
+        "headroom_bytes_per_rank": budget_bytes - projected,
+        "device_free_bytes_min_rank": device_free_bytes,
+        "required_free_headroom_bytes": headroom_bytes,
+    }
+    if projected > budget_bytes:
+        over = projected - budget_bytes
+        raise AdminError(
+            "memory_budget_exceeded",
+            f"resident expert payload would grow to {projected} B/rank "
+            f"({_fmt_bytes(projected)}), which exceeds the budget of "
+            f"{budget_bytes} B/rank ({_fmt_bytes(budget_bytes)}) by "
+            f"{over} B ({_fmt_bytes(over)}). The change asks for "
+            f"{delta:+d} B/rank at {model.unit_bytes_per_k} B per expert per "
+            f"bit of K. Rebalance the batch so every promotion is paired with "
+            f"a demotion, or raise {ADMIN_MEM_BUDGET_ENV}.",
+            status=409,
+            details={**accounting, "overshoot_bytes_per_rank": over,
+                     "budget_env": ADMIN_MEM_BUDGET_ENV})
+    if delta > 0 and device_free_bytes is not None:
+        remaining = int(device_free_bytes) - delta
+        if remaining < headroom_bytes:
+            raise AdminError(
+                "memory_headroom_exceeded",
+                f"the change needs {delta} B/rank ({_fmt_bytes(delta)}) but "
+                f"the tightest rank has only {int(device_free_bytes)} B free "
+                f"({_fmt_bytes(int(device_free_bytes))}); that would leave "
+                f"{remaining} B ({_fmt_bytes(remaining)}) against a required "
+                f"headroom of {headroom_bytes} B "
+                f"({_fmt_bytes(headroom_bytes)}). "
+                f"{ADMIN_MEM_HEADROOM_ENV} governs the floor.",
+                status=409,
+                details={**accounting, "remaining_after_bytes": remaining,
+                         "headroom_env": ADMIN_MEM_HEADROOM_ENV})
+    return accounting
+
+
+# ------------------------------------------------------------------- pins
+
+
+def _pinned_from_doc(doc: Mapping[str, Any]) -> dict:
+    raw = doc.get("pinned") or {}
+    out: dict[str, Any] = {}
+    for key, val in raw.items():
+        out[str(key)] = "all" if val == "all" else sorted(
+            {int(e) for e in val})
+    return out
+
+
+def apply_pin_change(policy_doc: Mapping[str, Any],
+                     resolved: Sequence[ResolvedItem], *, pin: str) -> dict:
+    """New ``pinned`` block for the target document.
+
+    ``hold`` (the default) pins every moved expert to its NEW tier.
+    Without it, the next interval sees the operator's demoted expert as a
+    high-score K3 candidate and can trade it straight back once dwell
+    expires — an operator would reasonably file that as a bug. ``release``
+    un-does it; ``none`` leaves ``pinned`` alone.
+    """
+    pinned = _pinned_from_doc(policy_doc)
+    if pin == PIN_NONE:
+        return pinned
+    # No-op items are pinned too. "expert 5 should be K4" about an expert
+    # that is already K4 is still an explicit operator statement about where
+    # it belongs, and reading it as "...and keep it there" is what makes a
+    # pure pin change expressible without a second endpoint.
+    for item in resolved:
+        key = str(item.layer)
+        cur = pinned.get(key)
+        if cur == "all":
+            if pin == PIN_RELEASE:
+                raise AdminError(
+                    "pin_release_from_all",
+                    f'layer {item.layer} is pinned as "all"; releasing a '
+                    f"single expert from it is not representable in "
+                    f"fq-policy/2. Rewrite pinned['{item.layer}'] as an "
+                    f"explicit expert list first.",
+                    status=409, details={"layer": item.layer})
+            continue
+        ids = set(cur or ())
+        if pin == PIN_HOLD:
+            ids.add(int(item.expert))
+        else:
+            ids.discard(int(item.expert))
+        if ids:
+            pinned[key] = sorted(ids)
+        else:
+            pinned.pop(key, None)
+    return pinned
+
+
+def check_pin_starvation(new_doc: Mapping[str, Any], *,
+                         layers: Sequence[int], new_tier: Any,
+                         num_experts: int,
+                         touched_layers: Sequence[int] | None = None,
+                         min_free_slots: int | None = None,
+                         environ: Mapping[str, str] | None = None) -> dict:
+    """Refuse a pin set that would wedge the next ``policy.decide``.
+
+    ``policy.decide`` raises ``"layer {l}: pins incompatible with budget"``
+    when ``pin4.sum() > n_k4[l]`` or ``E - pin3.sum() < n_k4[l]`` — and
+    ``step()``'s blanket handler would swallow it, so the loop would
+    silently stop deciding. Keep at least ``max_swaps_per_layer`` worth of
+    room on both sides so the loop always has an interval's work available.
+    """
+    if min_free_slots is None:
+        min_free_slots = _env_int(environ, ADMIN_MIN_FREE_SLOTS_ENV,
+                                  DEFAULT_MIN_FREE_SLOTS)
+    min_free_slots = int(min_free_slots)
+    new_tier = np.asarray(new_tier)
+    rows = {int(l): i for i, l in enumerate(layers)}
+    pinned = _pinned_from_doc(new_doc)
+    caps = (new_doc.get("budget") or {}).get("n_k4_per_layer") or {}
+    check = (sorted(rows) if touched_layers is None
+             else sorted({int(x) for x in touched_layers}))
+    free_slots: dict[str, int] = {}
+    for layer in check:
+        row = rows[layer]
+        n_k4 = int(caps.get(str(layer), int((new_tier[row] == P.K4).sum())))
+        val = pinned.get(str(layer))
+        if val == "all":
+            ids = list(range(int(num_experts)))
+        else:
+            ids = [int(e) for e in (val or ())]
+        pin4 = sum(1 for e in ids if int(new_tier[row, e]) == P.K4)
+        pin3 = sum(1 for e in ids if int(new_tier[row, e]) == P.K3)
+        k4_free = n_k4 - pin4
+        k3_free = (int(num_experts) - pin3) - n_k4
+        free_slots[str(layer)] = int(min(k4_free, k3_free))
+        if k4_free < min_free_slots or k3_free < min_free_slots:
+            raise AdminError(
+                "pin_would_starve_layer",
+                f"layer {layer}: after this pin change the decision loop "
+                f"would have {k4_free} free K4 slot(s) and {k3_free} free K3 "
+                f"slot(s), below the required {min_free_slots} "
+                f"({ADMIN_MIN_FREE_SLOTS_ENV}). policy.decide would refuse "
+                f"the layer outright ('pins incompatible with budget') and "
+                f"the loop would stop deciding. Send pin=\"release\" for some "
+                f"experts in this layer, or pin=\"none\" for this request.",
+                status=409,
+                details={"layer": layer, "n_k4_per_layer": n_k4,
+                         "pinned_k4": pin4, "pinned_k3": pin3,
+                         "free_k4_slots": k4_free, "free_k3_slots": k3_free,
+                         "min_free_slots": min_free_slots,
+                         "min_free_slots_env": ADMIN_MIN_FREE_SLOTS_ENV})
+    return free_slots
+
+
+# ------------------------------------------------------- fragment pre-flight
+
+
+def preflight_fragments(resolver: Any, resolved: Sequence[ResolvedItem],
+                        *, rank: int = 0) -> list[dict]:
+    """Reject, never degrade — and find EVERY miss in one pass.
+
+    A K3 payload cannot be written into a K4 slab row (the row is
+    ``16 x bits`` int16 words wide), so "accept and give them K3 instead"
+    is not merely dishonest, it is unrepresentable. ``stage()`` would stop
+    at the first miss; this walks the whole batch so one round-trip tells
+    the operator everything that is missing. ``resolve``/``resolve_best``
+    enqueue the lazy encode themselves, so a refusal is also the fix
+    being started.
+
+    Returns the list of unavailable targets (empty when everything is
+    supplied). Never raises for a resolver failure — a crashed resolver is
+    reported as "unavailable", which is the safe reading.
+    """
+    if resolver is None:
+        return []
+    misses: list[dict] = []
+    best = getattr(resolver, "resolve_best", None)
+    takes_chain = False
+    if callable(best):
+        try:
+            import inspect
+
+            takes_chain = "chain_out" in inspect.signature(best).parameters
+        except (TypeError, ValueError):
+            takes_chain = False
+    for item in resolved:
+        if item.outcome == "noop":
+            continue
+        chain: list[str] = []
+        fragment = None
+        reason = None
+        try:
+            if callable(best):
+                fragment = (best(item.layer, item.expert, item.k_to,
+                                 chain_out=chain) if takes_chain
+                            else best(item.layer, item.expert, item.k_to))
+            else:
+                fragment = resolver.resolve(item.layer, item.expert,
+                                            item.k_to)
+        except Exception as exc:  # noqa: BLE001 — a refusal, never a crash
+            reason = f"{type(exc).__name__}: {exc}"
+        if fragment is None and reason is None:
+            reason = "no source has it (resolver returned nothing)"
+        got_k = None
+        if fragment is not None:
+            got_k = int(getattr(fragment, "k", item.k_to))
+            if got_k != item.k_to:
+                reason = (f"resolver substituted K{got_k} (the requested "
+                          f"encode has not landed)")
+        if reason is None:
+            continue
+        queued, position = _encode_queue_state(resolver, item)
+        misses.append({
+            "layer": item.layer, "expert": item.expert, "k": item.k_to,
+            "k_from": item.k_from, "substituted_k": got_k, "reason": reason,
+            "encode_queued": queued, "queue_position": position,
+            "chain": "; ".join(chain) or None,
+        })
+    return misses
+
+
+def _encode_queue_state(resolver: Any, item: ResolvedItem
+                        ) -> tuple[bool, int | None]:
+    """Best-effort read of the lazy-encode queue position ``resolve`` created."""
+    getter = getattr(resolver, "_get_encode_queue", None)
+    queue = None
+    if callable(getter):
+        try:
+            queue = getter()
+        except Exception:  # noqa: BLE001 — telemetry, never a failure path
+            queue = None
+    if queue is None:
+        return False, None
+    for name in ("position", "position_of", "lookup"):
+        fn = getattr(queue, name, None)
+        if callable(fn):
+            try:
+                pos = fn(item.layer, item.expert, item.k_to)
+            except Exception:  # noqa: BLE001
+                continue
+            if pos is not None:
+                return True, int(pos)
+    return True, None
+
+
+def raise_if_unavailable(misses: Sequence[Mapping[str, Any]],
+                         *, requested: int) -> None:
+    if not misses:
+        return
+    raise AdminError(
+        "fragment_unavailable",
+        f"{len(misses)} of {requested} requested tier(s) are not available; "
+        f"nothing was applied. The missing encodes have been queued — drain "
+        f"the lazy-encode queue "
+        f"(python -m vllm.model_executor.layers.quantization.exl3_fungible."
+        f"lazy_encode --drain) and retry.",
+        status=409,
+        details={"unavailable": [dict(m) for m in misses],
+                 "requested": int(requested),
+                 "retry_after_hint": "drain the lazy-encode queue"})
+
+
+# --------------------------------------------------------- target document
+
+
+def build_target_doc(policy_doc: Mapping[str, Any], *, layers: Sequence[int],
+                     new_tier: Any, pinned: Mapping[str, Any],
+                     provenance: Mapping[str, Any]) -> dict:
+    """The ``fq-policy/2`` document the swap engine will commit.
+
+    Same shape as ``loop._doc_for`` — every key of the running document is
+    carried through untouched except the three this change owns.
+    """
+    doc = {k: v for k, v in policy_doc.items()
+           if k not in ("bits_per_expert", "provenance", "pinned")}
+    tier = np.asarray(new_tier)
+    doc["bits_per_expert"] = {
+        str(layer): [int(b) for b in tier[row]]
+        for row, layer in enumerate(layers)}
+    doc["pinned"] = {str(k): v for k, v in pinned.items()}
+    doc["provenance"] = dict(provenance)
+    return doc
+
+
+def build_plan(current_doc: Mapping[str, Any], new_doc: Mapping[str, Any]
+               ) -> Any:
+    """``SwapPlan.from_policies`` with the cardinality failure translated.
+
+    One call does pairing, ordering and the D1 same-cardinality check, all
+    already covered by ``tests/exl3_fungible/test_swap_cpu.py``. The
+    endpoint must not hand-assemble ``(layer, e_out, e_in)`` triples.
+    """
+    try:
+        return SW.SwapPlan.from_policies(dict(current_doc), dict(new_doc))
+    except ValueError as exc:
+        raise AdminError(
+            "cardinality_unbalanced",
+            f"the target membership is not a same-cardinality trade: {exc}",
+            status=409, details={"swap_plan_error": str(exc)}) from exc
+
+
+# --------------------------------------------------------------- loop state
+
+
+def _state_rows(state: Any) -> dict[int, int]:
+    return {int(l): i for i, l in enumerate(state.layers)}
+
+
+def occupancy_map(state: Any) -> dict[int, dict[int, int]]:
+    fn = getattr(state, "_occupancy_map", None)
+    if callable(fn):
+        return fn()
+    tier = np.asarray(state.tier_of)
+    return {int(layer): {int(t): int((tier[row] == t).sum())
+                         for t in OT.TIERS if t in (P.K3, P.K4)
+                         or int((tier[row] == t).sum())}
+            for row, layer in enumerate(state.layers)}
+
+
+def render_retier_table(before: Mapping[int, Mapping[int, int]],
+                        after: Mapping[int, Mapping[int, int]],
+                        swaps: Sequence[tuple[int, int, int]], *,
+                        before_tier: Any, after_tier: Any,
+                        layers: Sequence[int], title: str,
+                        num_experts: int) -> str:
+    """The operator-facing "what moved" view.
+
+    Worth being explicit about, because the obvious implementation is
+    wrong: ``occupancy_table.render(..., diff_only=True)`` counts experts
+    per tier, and a fixed-cardinality 1-for-1 trade leaves every count
+    **identical** — so the diff-only table for a successful retier is
+    literally "no tier changes across N layers". Truthful and useless.
+
+    So: render the touched layers in full (their shape is what the
+    operator wants confirmed), then name the pairs underneath, since the
+    pairs are the only place the change is visible at all.
+    """
+    touched = sorted({int(l) for l, _, _ in swaps})
+    try:
+        if touched:
+            text = OT.render(
+                {l: after[l] for l in touched if l in after},
+                {l: before[l] for l in touched if l in before},
+                title=title, num_experts=int(num_experts), diff_only=False)
+        else:
+            text = OT.render(after, before, title=title,
+                             num_experts=int(num_experts), diff_only=True)
+    except Exception:  # noqa: BLE001 — telemetry must never kill a serve
+        logger.exception("FQ admin: occupancy table failed to render")
+        return ""
+    if not touched:
+        return text
+
+    rows = {int(l): i for i, l in enumerate(layers)}
+    before_tier = np.asarray(before_tier)
+    after_tier = np.asarray(after_tier)
+    lines = [text,
+             "  moved (fixed cardinality: the per-tier COUNTS above are "
+             "invariant by",
+             "  construction, so a 1-for-1 trade cannot show up as a delta — "
+             "these are",
+             f"  the {len(swaps)} pair(s) that actually moved):"]
+    for layer, e_out, e_in in swaps:
+        row = rows[int(layer)]
+        lines.append(
+            f"    L{int(layer)}: e{int(e_out)} "
+            f"K{int(before_tier[row, e_out])}->K{int(after_tier[row, e_out])}"
+            f"  <->  e{int(e_in)} "
+            f"K{int(before_tier[row, e_in])}->K{int(after_tier[row, e_in])}")
+    omitted = len(layers) - len(touched)
+    if omitted > 0:
+        lines.append(f"  ({omitted} untouched layer(s) omitted)")
+    return "\n".join(lines)
+
+
+def adopt_policy(state: Any, new_doc: Mapping[str, Any],
+                 swaps: Sequence[tuple[int, int, int]], *,
+                 origin: str = "policy", record: Mapping | None = None,
+                 title: str | None = None) -> dict:
+    """Adopt a committed membership change into the live loop state.
+
+    One code path for both callers (the interval loop and this admin API),
+    because there is exactly one correct order:
+
+    1. recompute ``tier_of`` from the document,
+    2. **restart dwell for the experts that moved** (``_entered_step``), so
+       the next interval cannot instantly trade them back,
+    3. advance ``policy_doc`` / ``policy_sha`` / ``_policy_step``,
+    4. **refresh ``pins`` from the new document** — this line is missing
+       from today's ``loop._maybe_apply``. Benign for the loop, which never
+       changes ``pinned``; a live bug the moment the admin path writes
+       pins, because the stale ``pins`` array would be handed to the next
+       ``policy.decide``,
+    5. log the occupancy diff so the operator sees exactly what moved,
+    6. bump the instruments.
+
+    ``loop.py`` is owned by another change this round, so this lives here
+    and takes the state as a parameter rather than being a method on
+    :class:`FungibleQuantState`. It is deliberately duck-typed: anything
+    with the loop-state attribute surface works, which is also what makes
+    it CPU-testable.
+    """
+    layers = list(state.layers)
+    new_tier = np.asarray(
+        [[int(b) for b in new_doc["bits_per_expert"][str(layer)]]
+         for layer in layers], dtype=np.int64)
+    before_tier = np.asarray(state.tier_of)
+    before_occupancy = occupancy_map(state)
+    moved = before_tier != new_tier
+
+    state.tier_of = new_tier
+    entered = getattr(state, "_entered_step", None)
+    if entered is not None:
+        state._entered_step = np.where(
+            moved, int(getattr(state, "_real_steps", 0)), entered)
+    state.policy_doc = dict(new_doc)
+    state.policy_sha = policy_hash(dict(new_doc))
+    state._policy_step = int(getattr(state, "_step", 0))
+    # (4) — the line today's _maybe_apply is missing.
+    pins_fn = getattr(state, "_pins_from_doc", None)
+    if callable(pins_fn):
+        state.pins = pins_fn(dict(new_doc))
+    # Fixed cardinality means n_k4 is invariant; recompute anyway so a
+    # future mode that does change it cannot leave a stale budget behind.
+    state.n_k4 = P.n_k4_of(new_tier)
+
+    after_occupancy = occupancy_map(state)
+    if title is None:
+        title = f"expert composition after {origin} retier"
+    diff_text = render_retier_table(
+        before_occupancy, after_occupancy, swaps, before_tier=before_tier,
+        after_tier=new_tier, layers=layers, title=title,
+        num_experts=int(state.num_experts))
+
+    if int(getattr(state, "rank", 0) or 0) == 0:
+        for line in diff_text.splitlines():
+            logger.info("%s", line)
+        # Re-arm the loop's own periodic diff from the post-change shape,
+        # so its next print is measured against what the operator did.
+        state._last_composition = after_occupancy
+
+    _bump_metrics(state, swaps, origin=origin)
+    return {"occupancy_before": before_occupancy,
+            "occupancy_after": after_occupancy,
+            "occupancy_diff": diff_text,
+            "moved": int(moved.sum())}
+
+
+class _AdminMetrics:
+    """The two instruments the admin path adds, registered once."""
+
+    def __init__(self):
+        import prometheus_client as pc
+
+        self.forced_swaps_total = pc.Counter(
+            "fq_forced_swaps_total",
+            "Operator-forced fungible-quant expert tier changes.",
+            ["layer", "direction"])
+        self.admin_requests_total = pc.Counter(
+            "fq_admin_requests_total",
+            "Fungible-quant admin API requests by outcome.", ["outcome"])
+
+
+_ADMIN_METRICS: _AdminMetrics | None = None
+_ADMIN_METRICS_TRIED = False
+
+
+def get_admin_metrics() -> _AdminMetrics | None:
+    global _ADMIN_METRICS, _ADMIN_METRICS_TRIED
+    if not _ADMIN_METRICS_TRIED:
+        _ADMIN_METRICS_TRIED = True
+        try:
+            _ADMIN_METRICS = _AdminMetrics()
+        except Exception:  # noqa: BLE001 — metrics are never load-bearing
+            logger.warning("FQ admin metrics unavailable", exc_info=True)
+            _ADMIN_METRICS = None
+    return _ADMIN_METRICS
+
+
+def record_admin_outcome(outcome: str) -> None:
+    metrics = get_admin_metrics()
+    if metrics is not None:
+        try:
+            metrics.admin_requests_total.labels(outcome=outcome).inc()
+        except Exception:  # noqa: BLE001
+            pass
+
+
+def _bump_metrics(state: Any, swaps: Sequence[tuple[int, int, int]], *,
+                  origin: str) -> None:
+    metrics = getattr(state, "metrics", None)
+    if metrics is not None and getattr(state, "is_lead", True):
+        try:
+            for layer, _, _ in swaps:
+                metrics.swaps_total.labels(layer=str(int(layer))).inc()
+            metrics.policy_age_steps.set(
+                int(getattr(state, "_step", 0))
+                - int(getattr(state, "_policy_step", 0)))
+            export = getattr(state, "_export_occupancy", None)
+            if callable(export):
+                export()
+        except Exception:  # noqa: BLE001
+            logger.warning("FQ admin: loop metric update failed",
+                           exc_info=True)
+    if origin != "operator":
+        return
+    admin = get_admin_metrics()
+    if admin is None or not getattr(state, "is_lead", True):
+        return
+    try:
+        for layer, e_out, e_in in swaps:
+            admin.forced_swaps_total.labels(
+                layer=str(int(layer)), direction="demote").inc()
+            admin.forced_swaps_total.labels(
+                layer=str(int(layer)), direction="promote").inc()
+    except Exception:  # noqa: BLE001
+        logger.warning("FQ admin: forced-swap metric failed", exc_info=True)
+
+
+# ------------------------------------------------------- decision record
+
+
+def explain_forced(state: Any, swaps_rows: Sequence[tuple[int, int, int]], *,
+                   tier_before: Any, items: Sequence[ResolvedItem],
+                   actor: str | None, reason: str | None, request_id: str,
+                   policy_sha_before: str, policy_sha_after: str) -> dict:
+    """An ``fq-decision/1`` record marked operator-forced.
+
+    Same schema as the interval path so existing consumers keep working,
+    with ``origin: "operator"``, ``forced: true`` on every swap, the
+    guards that were waived spelled out, and the actor/reason/request_id
+    that make it attributable. The score fields are still populated from
+    the live stats — seeing *what the policy thought* about an expert the
+    operator overrode is the whole value of the record.
+    """
+    record: dict[str, Any]
+    try:
+        stats = state._read_stats()
+        dwell = (np.asarray(state._real_steps)
+                 - np.asarray(state._entered_step))
+        record = DL.explain(
+            stats, state.eps, np.asarray(tier_before), list(swaps_rows),
+            pins=getattr(state, "pins", None), dwell=dwell,
+            cfg=state._decide_cfg(), step=int(getattr(state, "_step", 0)),
+            policy_sha_before=policy_sha_before,
+            policy_sha_after=policy_sha_after)
+    except Exception:  # noqa: BLE001 — the weights already moved; still log
+        logger.warning("FQ admin: score recomputation failed — emitting a "
+                       "minimal decision record", exc_info=True)
+        record = {
+            "schema": "fq-decision/1",
+            "step": int(getattr(state, "_step", 0)),
+            "policy_sha_before": policy_sha_before,
+            "policy_sha_after": policy_sha_after,
+            "config": {},
+            "swaps": [{"layer": int(l), "expert_out": int(o),
+                       "expert_in": int(i)} for l, o, i in swaps_rows],
+            "blocked": {"dwell": 0, "hysteresis": 0, "layer_cap": 0},
+            "per_layer": {},
+            "totals": {"executed": len(swaps_rows),
+                       "layers_touched": len({s[0] for s in swaps_rows})},
+            "scores_unavailable": True,
+        }
+    record["origin"] = "operator"
+    record["forced"] = True
+    record["actor"] = actor
+    record["reason"] = reason
+    record["request_id"] = request_id
+    record["apply_mode"] = getattr(getattr(state, "cfg", None), "apply_mode",
+                                   None)
+    record["applied"] = True
+    record["layer_ids"] = [int(x) for x in state.layers]
+    record["real_steps"] = int(getattr(state, "_real_steps", 0))
+    record["guards_waived"] = ["dwell", "hysteresis", "jaccard",
+                               "max_swaps_per_layer", "max_swaps_total"]
+    record["blocked"] = {"dwell": 0, "hysteresis": 0, "layer_cap": 0}
+    record["items"] = [i.as_dict() for i in items]
+    for sw in record.get("swaps", ()):
+        sw["forced"] = True
+    record["decision_sha"] = hashlib.sha256(
+        json.dumps([[int(x) for x in s] for s in swaps_rows],
+                   separators=(",", ":")).encode()).hexdigest()
+    return record
+
+
+def persist_decision_record(state: Any, record: Mapping[str, Any], *,
+                            request_id: str) -> str | None:
+    """Write the record beside the interval records, lead rank only.
+
+    The ``-admin-`` infix keeps a forced retier that lands on an interval
+    boundary from colliding with that interval's own ``{step:08d}.json``.
+    """
+    store = getattr(state, "store", None)
+    if store is None or not getattr(state, "is_lead", True):
+        return None
+    try:
+        decisions = store.root / "decisions"
+        decisions.mkdir(exist_ok=True)
+        path = decisions / f"{int(getattr(state, '_step', 0)):08d}-admin-{request_id}.json"
+        store._atomic_write(path, dict(record))
+        return str(path)
+    except Exception:  # noqa: BLE001 — audit trail must not fail the apply
+        logger.exception("FQ admin: decision record write failed")
+        return None
+
+
+# ------------------------------------------------------------ plan + apply
+
+
+@dataclass
+class RetierPlan:
+    """Phase-1 output: everything decided, nothing mutated."""
+
+    request_id: str
+    request: RetierRequest
+    items: list[ResolvedItem]
+    effective: list[ResolvedItem]
+    plan: Any                                   # SwapPlan
+    new_doc: dict
+    policy_sha_before: str
+    policy_sha_after: str
+    memory: dict
+    pins: dict
+    free_slots: dict
+    occupancy_before: dict
+    membership_sha: str
+    plan_sha: str
+    unavailable: list[dict] = field(default_factory=list)
+
+    def wire(self) -> dict:
+        return {
+            "request_id": self.request_id,
+            "plan_sha": self.plan_sha,
+            "membership_sha": self.membership_sha,
+            "policy_sha_before": self.policy_sha_before,
+            "policy_sha_after": self.policy_sha_after,
+            "pairs": [{"layer": int(l), "expert_out": int(o),
+                       "expert_in": int(i)} for l, o, i in self.plan],
+            "layers": [int(x) for x in self.plan.layers()],
+            "items": [i.as_dict() for i in self.items],
+            "memory": self.memory,
+            "pins": self.pins,
+            "free_slots": self.free_slots,
+            "occupancy": {str(k): {str(kk): vv for kk, vv in v.items()}
+                          for k, v in self.occupancy_before.items()},
+        }
+
+
+def _membership_sha(tier_of: Any, layers: Sequence[int],
+                    touched: Sequence[int]) -> str:
+    tier = np.asarray(tier_of)
+    rows = {int(l): i for i, l in enumerate(layers)}
+    payload = {str(l): [int(b) for b in tier[rows[int(l)]]]
+               for l in sorted({int(x) for x in touched})}
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True,
+                   separators=(",", ":")).encode()).hexdigest()
+
+
+def plan_retier(state: Any, request: RetierRequest, *,
+                engine: Any = None, resolver: Any = None,
+                memory: MemoryModel | None = None,
+                device_free_bytes: int | None = None,
+                request_id: str | None = None,
+                environ: Mapping[str, str] | None = None) -> RetierPlan:
+    """Phase 1: resolve, guard, build the target document and the plan.
+
+    Pure with respect to live state — nothing is staged, nothing is
+    written, no device memory is touched. ``dry_run`` is simply "stop
+    after this", which makes it the operator's "will this work?" button.
+    """
+    request_id = request_id or new_request_id()
+    policy_sha_before = policy_hash(dict(state.policy_doc))
+    if request.expect_policy_sha and \
+            request.expect_policy_sha != policy_sha_before:
+        raise AdminError(
+            "policy_sha_mismatch",
+            f"expect_policy_sha {request.expect_policy_sha[:16]}... does not "
+            f"match the live policy {policy_sha_before[:16]}... — a policy "
+            f"interval committed between your read and this write. GET "
+            f"/fq/state and retry.",
+            status=409,
+            details={"expected": request.expect_policy_sha,
+                     "actual": policy_sha_before})
+
+    registered = None
+    if engine is not None:
+        registered = sorted(int(x) for x in engine.layers)
+    resolved = resolve_items(
+        request, layers=state.layers, tier_of=state.tier_of,
+        num_experts=int(state.num_experts), registered_layers=registered)
+    effective = [i for i in resolved if i.outcome != "noop"]
+
+    caps = (dict(state.policy_doc).get("budget") or {}).get("n_k4_per_layer")
+    check_cardinality(resolved, mode=request.mode, n_k4_per_layer=caps,
+                      environ=environ)
+
+    if memory is None:
+        memory = memory_model_from_engine(engine)
+    accounting: dict = {}
+    if memory is not None:
+        accounting = check_memory(memory, state.tier_of, effective,
+                                  device_free_bytes=device_free_bytes,
+                                  environ=environ)
+
+    misses = preflight_fragments(resolver, effective,
+                                 rank=int(getattr(state, "rank", 0) or 0))
+    raise_if_unavailable(misses, requested=len(effective))
+
+    rows = _state_rows(state)
+    new_tier = np.array(state.tier_of, copy=True)
+    for item in effective:
+        new_tier[rows[item.layer], item.expert] = item.k_to
+
+    pinned = apply_pin_change(state.policy_doc, resolved, pin=request.pin)
+    touched = sorted({i.layer for i in resolved})
+    new_doc = build_target_doc(
+        state.policy_doc, layers=state.layers, new_tier=new_tier,
+        pinned=pinned,
+        provenance=_provenance(state, request, resolved, request_id,
+                               policy_sha_before))
+    free_slots = check_pin_starvation(
+        new_doc, layers=state.layers, new_tier=new_tier,
+        num_experts=int(state.num_experts), touched_layers=touched,
+        environ=environ)
+
+    plan = build_plan(state.policy_doc, new_doc)
+    # The fixed-cardinality invariant, independently, before any device
+    # write. store.commit would catch it too — but at step 5, after the
+    # weights have already moved.
+    try:
+        validate_policy(new_doc, num_experts=int(state.num_experts))
+    except ValueError as exc:
+        raise AdminError("cardinality_unbalanced",
+                         f"the target policy document is invalid: {exc}",
+                         status=409,
+                         details={"validate_policy_error": str(exc)}) from exc
+
+    if engine is not None and len(plan) > int(engine.max_pairs):
+        raise AdminError(
+            "plan_too_large",
+            f"the plan has {len(plan)} pairs but staging holds "
+            f"{int(engine.max_pairs)} ({ADMIN_MAX_ITEMS_ENV} sizes it) — "
+            f"split the batch",
+            status=409, details={"pairs": len(plan),
+                                 "max_pairs": int(engine.max_pairs)})
+
+    policy_sha_after = policy_hash(new_doc)
+    plan_sha = hashlib.sha256(json.dumps(
+        {"pairs": [[int(l), int(o), int(i)] for l, o, i in plan],
+         "policy_sha_before": policy_sha_before,
+         "policy_sha_after": policy_sha_after},
+        sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+
+    return RetierPlan(
+        request_id=request_id, request=request, items=resolved,
+        effective=effective, plan=plan, new_doc=new_doc,
+        policy_sha_before=policy_sha_before,
+        policy_sha_after=policy_sha_after, memory=accounting,
+        pins=_pin_summary(state.policy_doc, new_doc),
+        free_slots=free_slots, occupancy_before=occupancy_map(state),
+        membership_sha=_membership_sha(state.tier_of, state.layers, touched),
+        plan_sha=plan_sha, unavailable=misses)
+
+
+def _pin_summary(old_doc: Mapping[str, Any], new_doc: Mapping[str, Any]
+                 ) -> dict:
+    old = _pinned_from_doc(old_doc)
+    new = _pinned_from_doc(new_doc)
+    added: dict[str, list[int]] = {}
+    removed: dict[str, list[int]] = {}
+    for key in sorted(set(old) | set(new)):
+        a, b = old.get(key), new.get(key)
+        if a == "all" or b == "all":
+            continue
+        aset, bset = set(a or ()), set(b or ())
+        if bset - aset:
+            added[key] = sorted(bset - aset)
+        if aset - bset:
+            removed[key] = sorted(aset - bset)
+    return {"added": added, "removed": removed, "pinned": new}
+
+
+def _provenance(state: Any, request: RetierRequest,
+                resolved: Sequence[ResolvedItem], request_id: str,
+                base_policy: str) -> dict:
+    return {
+        "proposed_by": "fq-admin/retier",
+        "origin": "operator",
+        "request_id": request_id,
+        "actor": request.actor,
+        "reason": request.reason,
+        "utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "step": int(getattr(state, "_step", 0)),
+        "base_policy": base_policy,
+        "num_swaps": sum(1 for i in resolved if i.outcome == "promoted"),
+        "mode": request.mode,
+        "items": [i.as_dict() for i in resolved],
+    }
+
+
+def new_request_id() -> str:
+    return "fqr-" + uuid.uuid4().hex[:12]
+
+
+def apply_retier(state: Any, retier: RetierPlan, *, engine: Any,
+                 stream: Any = None, quiesce: Any = None) -> dict:
+    """Phase 2: stage, commit, adopt.
+
+    ``fail_atomic=True`` is mandatory here: without it an abort before the
+    visibility flip leaves the layer genuinely torn. With it the pre-swap
+    rows and maps are restored inside the same quiesce window and the
+    serve stays healthy — for an operator action that trade is obvious.
+
+    ``on_unavailable="raise"`` (never ``"drop"``): availability was
+    pre-flighted, so this is belt and braces; if it fires anyway nothing
+    has been written, because staging mutates no live state.
+
+    ``memo_hook=None`` is correct, not an omission: the mixed-runtime memo
+    key contains ``tier_signature`` = *(bits, count)* per tier, not
+    membership. A 1-for-1 trade leaves both counts unchanged, so the key
+    is unchanged and the compiled runtime stays valid.
+
+    ``policy_store`` only on the lead rank — passing a store on every rank
+    would race four writers onto one ``current.json``.
+    """
+    tier_before = np.array(state.tier_of, copy=True)
+    if len(retier.plan) == 0:
+        # A pin-only change. No weights move, so there is nothing for the
+        # swap engine to do and no reason to open a quiesce window — but
+        # the document still has to be committed, or the pin evaporates at
+        # the next interval and the operator's instruction was a no-op with
+        # a 200 status code.
+        return _apply_pins_only(state, retier)
+
+    t0 = time.perf_counter()
+    staged = engine.stage(retier.plan, fail_atomic=True,
+                          on_unavailable="raise")
+    stage_ms = (time.perf_counter() - t0) * 1e3
+
+    if getattr(staged, "dropped", ()):  # defensive: raise mode should not
+        raise AdminError(
+            "fragment_unavailable",
+            "staging dropped pairs despite on_unavailable=raise — nothing "
+            "was applied", status=409,
+            details={"dropped": [str(d) for d in staged.dropped]})
+
+    is_lead = bool(getattr(state, "is_lead", True))
+    store = getattr(state, "store", None)
+    generation_before = int(getattr(engine, "generation", 0))
+    try:
+        report = engine.apply(
+            staged=staged,
+            quiesce=contextlib.nullcontext() if quiesce is None else quiesce,
+            stream=stream,
+            memo_hook=None,
+            policy_store=store if is_lead else None,
+            policy_doc=retier.new_doc,
+            policy_num_experts=int(state.num_experts),
+        )
+    except Exception as exc:  # noqa: BLE001 — must report recovery state
+        # The visibility flip is the only commit point, and apply() bumps
+        # the generation counter WITH it (in a finally), so the counter is
+        # the honest witness for which side of the flip this died on.
+        generation = int(getattr(engine, "generation", generation_before))
+        flipped = generation > generation_before
+        restored = bool(getattr(staged, "restored", False))
+        torn = not flipped and not restored
+        if flipped:
+            # The weights ARE new. The loop state must not keep claiming
+            # otherwise, or the next interval decides against fiction.
+            with contextlib.suppress(Exception):
+                adopt_policy(state, retier.new_doc,
+                             [(int(l), int(o), int(i))
+                              for l, o, i in staged.plan],
+                             origin="operator",
+                             title=f"expert composition after PARTIAL "
+                                   f"operator retier {retier.request_id}")
+            guidance = ("the swap was committed (the visibility flip "
+                        "succeeded) and the loop state was advanced to match; "
+                        "a later commit-protocol step failed, so the policy "
+                        "may not have been persisted — re-issue to roll "
+                        "forward, or apply the inverse plan to roll back")
+        elif restored:
+            guidance = ("fail-atomic staging restored the pre-swap rows and "
+                        "maps inside the quiesce window; the layer is "
+                        "fully-old and the serve is healthy")
+        else:
+            guidance = ("the layer is torn — re-issue the same request (roll "
+                        "forward) or restart (slabs are a cache, rebuilt from "
+                        "artifacts)")
+        if torn:
+            logger.error("FQ ADMIN apply failed request=%s and the batch was "
+                         "NOT restored — %s", retier.request_id, guidance)
+        raise AdminError(
+            "apply_failed", f"SwapEngine.apply raised: {exc}", status=500,
+            details={"flipped": flipped, "restored": restored, "torn": torn,
+                     "generation": generation,
+                     "guidance": guidance}) from exc
+
+    swaps_model = [(int(l), int(o), int(i)) for l, o, i in staged.plan]
+    rows = _state_rows(state)
+    swaps_rows = [(rows[l], o, i) for l, o, i in swaps_model]
+
+    adopted = adopt_policy(
+        state, retier.new_doc, swaps_model, origin="operator",
+        title=f"expert composition after operator retier "
+              f"{retier.request_id}")
+
+    record = explain_forced(
+        state, swaps_rows, tier_before=tier_before, items=retier.items,
+        actor=retier.request.actor, reason=retier.request.reason,
+        request_id=retier.request_id,
+        policy_sha_before=retier.policy_sha_before,
+        policy_sha_after=retier.policy_sha_after)
+    record_path = persist_decision_record(state, record,
+                                          request_id=retier.request_id)
+    DL.log_decision(record)
+
+    logger.warning(
+        "FQ ADMIN applied request=%s pairs=%d gen=%d window=%.3fms "
+        "delta_bytes/rank=%s policy %s -> %s pins+%d",
+        retier.request_id, report.pairs, report.generation,
+        report.window_seconds * 1e3,
+        retier.memory.get("delta_bytes_per_rank"),
+        retier.policy_sha_before[:8], retier.policy_sha_after[:8],
+        sum(len(v) for v in retier.pins.get("added", {}).values()))
+
+    return {
+        "applied": True,
+        "pairs": report.pairs,
+        "layers": report.layers,
+        "generation": int(report.generation),
+        "bytes_h2d_per_rank": int(report.bytes_h2d),
+        "stage_ms": stage_ms,
+        "window_ms": report.window_seconds * 1e3,
+        "restored": bool(getattr(staged, "restored", False)),
+        "committed_policy_hash": report.committed_policy_hash,
+        "policy_sha_after": state.policy_sha,
+        "occupancy": {str(k): {str(kk): vv for kk, vv in v.items()}
+                      for k, v in adopted["occupancy_after"].items()},
+        "occupancy_diff": adopted["occupancy_diff"],
+        "decision_record": record_path,
+        "decision_sha": record.get("decision_sha"),
+    }
+
+
+# ------------------------------------------------------------ live binding
+
+
+def _apply_pins_only(state: Any, retier: RetierPlan) -> dict:
+    """Commit a document whose only change is ``pinned``."""
+    committed = None
+    if getattr(state, "store", None) is not None and \
+            getattr(state, "is_lead", True):
+        committed = state.store.commit(retier.new_doc,
+                                       num_experts=int(state.num_experts))
+    adopted = adopt_policy(
+        state, retier.new_doc, [], origin="operator",
+        title=f"expert composition after operator pin change "
+              f"{retier.request_id}")
+    record = explain_forced(
+        state, [], tier_before=np.asarray(state.tier_of),
+        items=retier.items, actor=retier.request.actor,
+        reason=retier.request.reason, request_id=retier.request_id,
+        policy_sha_before=retier.policy_sha_before,
+        policy_sha_after=retier.policy_sha_after)
+    record_path = persist_decision_record(state, record,
+                                          request_id=retier.request_id)
+    logger.warning(
+        "FQ ADMIN pins applied request=%s policy %s -> %s pins+%d pins-%d",
+        retier.request_id, retier.policy_sha_before[:8],
+        retier.policy_sha_after[:8],
+        sum(len(v) for v in retier.pins.get("added", {}).values()),
+        sum(len(v) for v in retier.pins.get("removed", {}).values()))
+    return {
+        "applied": True, "pairs": 0, "layers": 0,
+        "generation": int(getattr(state, "_policy_step", 0)),
+        "bytes_h2d_per_rank": 0, "stage_ms": 0.0, "window_ms": 0.0,
+        "restored": False, "committed_policy_hash": committed,
+        "policy_sha_after": state.policy_sha,
+        "occupancy": {str(k): {str(kk): vv for kk, vv in v.items()}
+                      for k, v in adopted["occupancy_after"].items()},
+        "occupancy_diff": adopted["occupancy_diff"],
+        "decision_record": record_path,
+        "decision_sha": record.get("decision_sha"),
+        "pins_only": True,
+    }
+
+
+def memory_model_from_engine(engine: Any) -> MemoryModel | None:
+    if engine is None:
+        return None
+    try:
+        return MemoryModel(hidden_size=int(engine.hidden_size),
+                           intermediate_size=int(engine.intermediate_size))
+    except (AttributeError, TypeError, ValueError):
+        return None
+
+
+def build_swap_engine(model_runner: Any, *, rank: int = 0,
+                      max_pairs: int = DEFAULT_MAX_ITEMS,
+                      environ: Mapping[str, str] | None = None) -> Any:
+    """Bind a :class:`SwapEngine` over the live mixed-trellis layers.
+
+    ``loop.py`` records that atomic mode "is not yet bound to live layers";
+    this is that binding. Construction runs ``_validate_layer`` on every
+    layer, which is the honest boot gate — a checkpoint whose rotations use
+    the broadcast layout, or whose tier orderings are not a partition,
+    fails here with a clear message instead of at the first swap.
+
+    A uniform-K serve has no mixed layers at all, so this returns None and
+    the caller answers ``404 fq_not_active``.
+    """
+    layers: dict[int, Any] = {}
+    hidden = intermediate = None
+    for module in model_runner.model.modules():
+        mixed = getattr(module, "exl3_mixed_trellis", None)
+        if mixed is None:
+            continue
+        layer_id = getattr(module, "layer_id", None)
+        if layer_id is None:
+            continue
+        layers[int(layer_id)] = SW.MixedLayerState.from_exl3_mixed_trellis(
+            mixed)
+        hidden = int(getattr(module, "exl3_hidden_size", hidden or 0))
+        intermediate = int(
+            getattr(module, "exl3_intermediate_size_per_partition",
+                    intermediate or 0))
+    if not layers or not hidden or not intermediate:
+        return None
+
+    from vllm.model_executor.layers.quantization.exl3_fungible.progressive import (  # noqa: E501
+        ProgressiveSpec,
+    )
+
+    spec = ProgressiveSpec.from_env(environ=dict(_env(environ)))
+    source = SW.ResolverFragmentSource(spec.make_resolver())
+    return SW.SwapEngine(
+        layers, source, hidden_size=hidden, intermediate_size=intermediate,
+        tier_bits=(P.K3, P.K4), rank=int(rank), max_pairs=int(max_pairs))
+
+
+def _loop_state(worker: Any) -> Any:
+    runner = getattr(worker, "model_runner", None)
+    state = getattr(runner, "fq_collector", None)
+    if state is None or not hasattr(state, "tier_of"):
+        raise AdminError(
+            "fq_not_active",
+            "no fungible-quant loop state on this worker — the serve is "
+            "running collector-only or VLLM_FQ_ENABLE is not set",
+            status=404, details={"has_runner": runner is not None})
+    return state
+
+
+def _bound_engine(worker: Any, state: Any,
+                  environ: Mapping[str, str] | None = None) -> Any:
+    engine = getattr(state, "swap_engine", None)
+    if engine is not None:
+        return engine
+    max_pairs = max(8, _env_int(environ, ADMIN_MAX_ITEMS_ENV,
+                                DEFAULT_MAX_ITEMS))
+    engine = build_swap_engine(worker.model_runner,
+                               rank=int(getattr(state, "rank", 0) or 0),
+                               max_pairs=max_pairs, environ=environ)
+    if engine is None:
+        raise AdminError(
+            "fq_not_active",
+            "no mixed-trellis layers are registered; the serve is uniform-K "
+            "and there is nothing to re-tier",
+            status=404, details={"reason": "no mixed-trellis layers"})
+    state.swap_engine = engine
+    return engine
+
+
+def _device_free_bytes() -> int | None:
+    try:
+        import torch
+
+        if not torch.cuda.is_available():
+            return None
+        return int(torch.cuda.mem_get_info()[0])
+    except Exception:  # noqa: BLE001
+        return None
+
+
+_WORKER_BUSY = threading.Lock()
+
+
+def _ok(payload: Mapping[str, Any]) -> str:
+    return json.dumps({"ok": True, **payload}, sort_keys=True,
+                      separators=(",", ":"), default=str)
+
+
+def _err(exc: BaseException) -> str:
+    if isinstance(exc, AdminError):
+        return json.dumps({"ok": False, "error": exc.wire()}, sort_keys=True,
+                          separators=(",", ":"), default=str)
+    logger.exception("FQ admin worker call failed")
+    return json.dumps({"ok": False, "error": {
+        "code": "internal_error", "http_status": 500,
+        "message": f"{type(exc).__name__}: {exc}", "details": {}}},
+        sort_keys=True, separators=(",", ":"), default=str)
+
+
+def worker_describe(worker: Any, request_json: str = "{}") -> str:
+    """Read-only view of this rank's FQ state (``GET /fq/state``)."""
+    try:
+        query = json.loads(request_json or "{}")
+        state = _loop_state(worker)
+        engine = None
+        with contextlib.suppress(AdminError):
+            engine = _bound_engine(worker, state)
+        memory = memory_model_from_engine(engine)
+        tier = np.asarray(state.tier_of)
+        caps = (dict(state.policy_doc).get("budget") or {}).get(
+            "n_k4_per_layer") or {}
+        payload: dict[str, Any] = {
+            "rank": int(getattr(state, "rank", 0) or 0),
+            "policy_sha": policy_hash(dict(state.policy_doc)),
+            "layers": [int(x) for x in state.layers],
+            "num_experts": int(state.num_experts),
+            "step": int(getattr(state, "_step", 0)),
+            "policy_step": int(getattr(state, "_policy_step", 0)),
+            "apply_mode": getattr(getattr(state, "cfg", None), "apply_mode",
+                                  None),
+            "budget": {"mode": "fixed_cardinality",
+                       "n_k4_per_layer": {str(k): int(v)
+                                          for k, v in caps.items()},
+                       "growth_supported": False},
+            "occupancy": {str(k): {str(kk): vv for kk, vv in v.items()}
+                          for k, v in occupancy_map(state).items()},
+            "pinned": _pinned_from_doc(state.policy_doc),
+            "servable_tiers": list(SERVABLE_TIERS),
+            "engine_bound": engine is not None,
+            "registered_layers": (sorted(int(x) for x in engine.layers)
+                                  if engine is not None else []),
+            "max_pairs": int(getattr(engine, "max_pairs", 0)) if engine
+            else 0,
+            "generation": int(getattr(engine, "generation", 0)) if engine
+            else 0,
+        }
+        if memory is not None:
+            payload["memory"] = {
+                "unit_bytes_per_k_per_rank": memory.unit_bytes_per_k,
+                "rotation_bytes_per_expert_per_rank": memory.rotation_bytes,
+                "current_expert_bytes_per_rank": memory.resident_bytes(tier),
+                "device_free_bytes": _device_free_bytes(),
+            }
+        layer = query.get("layer")
+        if layer is not None:
+            payload["layer"] = _layer_view(state, int(layer))
+        return _ok(payload)
+    except Exception as exc:  # noqa: BLE001
+        return _err(exc)
+
+
+def _layer_view(state: Any, layer: int) -> dict:
+    rows = _state_rows(state)
+    if int(layer) not in rows:
+        raise AdminError("layer_not_registered",
+                         f"layer {layer} is not in the running policy",
+                         status=404, details={"layer": int(layer)})
+    row = rows[int(layer)]
+    tier = np.asarray(state.tier_of)[row]
+    pins = np.asarray(getattr(state, "pins", np.zeros_like(tier)))[row]
+    dwell = (int(getattr(state, "_real_steps", 0))
+             - np.asarray(getattr(state, "_entered_step",
+                                  np.zeros_like(tier)))[row])
+    scores = None
+    try:
+        s = P.score(state._read_stats(), state.eps)
+        scores = [float(x) for x in np.asarray(s)[row]]
+    except Exception:  # noqa: BLE001 — the table is still useful without it
+        logger.debug("FQ admin: live scores unavailable", exc_info=True)
+    experts = []
+    for e in range(int(state.num_experts)):
+        experts.append({
+            "expert": e, "k": int(tier[e]), "pin": int(pins[e]),
+            "dwell_steps": int(dwell[e]),
+            "score": None if scores is None else scores[e],
+        })
+    if scores is not None:
+        order = sorted(range(len(scores)), key=lambda e: (-scores[e], e))
+        rank_of = {e: i for i, e in enumerate(order)}
+        for row_dict in experts:
+            row_dict["score_rank"] = rank_of[row_dict["expert"]]
+    return {"layer": int(layer), "experts": experts,
+            "n_k4": int((tier == P.K4).sum())}
+
+
+def worker_plan(worker: Any, request_json: str) -> str:
+    """Phase 1 on this rank: resolve + guard, mutate nothing."""
+    try:
+        payload = json.loads(request_json)
+        state = _loop_state(worker)
+        engine = _bound_engine(worker, state)
+        request = RetierRequest.from_canonical(payload["request"])
+        retier = plan_retier(state, request, engine=engine,
+                             resolver=_resolver_of(engine),
+                             device_free_bytes=_device_free_bytes(),
+                             request_id=payload.get("request_id"))
+        return _ok({"phase": "plan", **retier.wire()})
+    except Exception as exc:  # noqa: BLE001
+        return _err(exc)
+
+
+def worker_apply(worker: Any, plan_json: str) -> str:
+    """Phase 2 on this rank: re-derive the plan, then commit it.
+
+    Re-deriving rather than trusting the wire is deliberate: under
+    ``strict_pair`` the plan is a pure function of the request and the
+    live membership, so every rank lands on the same pairs — and the
+    ``plan_sha`` cross-check turns any disagreement into a refusal instead
+    of divergent weights.
+    """
+    if not _WORKER_BUSY.acquire(blocking=False):
+        return _err(AdminError(
+            "retier_in_flight",
+            "another re-tier is already staging on this worker; SwapEngine "
+            "holds one staged batch at a time", status=409))
+    try:
+        payload = json.loads(plan_json)
+        state = _loop_state(worker)
+        engine = _bound_engine(worker, state)
+        request = RetierRequest.from_canonical(payload["request"])
+        retier = plan_retier(state, request, engine=engine,
+                             resolver=_resolver_of(engine),
+                             device_free_bytes=_device_free_bytes(),
+                             request_id=payload.get("request_id"))
+        expected = payload.get("plan_sha")
+        if expected and expected != retier.plan_sha:
+            raise AdminError(
+                "rank_divergence",
+                f"rank {getattr(state, 'rank', '?')} derived plan_sha "
+                f"{retier.plan_sha[:16]}... but the router expects "
+                f"{str(expected)[:16]}... — nothing applied",
+                status=500,
+                details={"expected": expected, "actual": retier.plan_sha,
+                         "rank": int(getattr(state, "rank", 0) or 0)})
+        result = apply_retier(state, retier, engine=engine)
+        result["rank"] = int(getattr(state, "rank", 0) or 0)
+        result["plan_sha"] = retier.plan_sha
+        return _ok({"phase": "apply", **result})
+    except Exception as exc:  # noqa: BLE001
+        return _err(exc)
+    finally:
+        _WORKER_BUSY.release()
+
+
+def _resolver_of(engine: Any) -> Any:
+    source = getattr(engine, "source", None)
+    return getattr(source, "resolver", None)
+
+
+class FqWorkerAdmin:
+    """``--worker-extension-cls`` mixin, for trees without the core hooks.
+
+    ``vllm/v1/worker/worker_base.py`` injects the resolved class into
+    ``Worker.__bases__`` after asserting no attribute collides — so use
+    EITHER this mixin OR the thin ``fq_admin_*`` methods on ``Worker``,
+    never both. vLLM supports exactly one extension class, so the shipping
+    binding is the core methods; this exists so an RLHF-free deployment can
+    get the admin API with zero core-file changes.
+    """
+
+    def fq_admin_describe(self, request_json: str = "{}") -> str:
+        return worker_describe(self, request_json)
+
+    def fq_admin_plan(self, request_json: str) -> str:
+        return worker_plan(self, request_json)
+
+    def fq_admin_apply(self, plan_json: str) -> str:
+        return worker_apply(self, plan_json)
+
+
+# ------------------------------------------------------------------ router
+
+
+def _rank_results(raw: Sequence[Any]) -> list[dict]:
+    out = []
+    for entry in raw:
+        if isinstance(entry, (bytes, bytearray)):
+            entry = entry.decode()
+        if isinstance(entry, str):
+            entry = json.loads(entry)
+        out.append(dict(entry))
+    return out
+
+
+def _first_error(results: Sequence[Mapping[str, Any]]) -> AdminError | None:
+    for res in results:
+        if not res.get("ok", False):
+            return AdminError.from_wire(res.get("error") or {})
+    return None
+
+
+def _agree(results: Sequence[Mapping[str, Any]], key: str) -> bool:
+    values = [res.get(key) for res in results]
+    return len(set(map(str, values))) <= 1
+
+
+def attach_router(app: Any, *, environ: Mapping[str, str] | None = None
+                  ) -> bool:
+    """Attach ``/fq/*`` to a FastAPI app, if and only if both gates are on.
+
+    Returns True when the routes were attached. Called from
+    ``register_vllm_dev_api_routers``, which already runs only under
+    ``VLLM_SERVER_DEV_MODE``; the second gate is re-checked here so the
+    routes cannot appear on a production serve by accident, and again per
+    request so nothing that attaches the router by another path can slip
+    a live weight mutation through.
+    """
+    if not admin_enabled(environ):
+        logger.debug("FQ admin API not attached: %s", gate_reason(environ))
+        return False
+    app.include_router(build_router(environ=environ))
+    logger.warning(
+        "SECURITY WARNING: FQ admin API is ENABLED (%s=1). POST /fq/retier "
+        "mutates live model weights. Set %s to require a header token.",
+        ADMIN_API_ENV, ADMIN_TOKEN_ENV)
+    return True
+
+
+def build_router(*, environ: Mapping[str, str] | None = None) -> Any:
+    """The ``/fq`` router. FastAPI is imported here, never at module scope."""
+    import asyncio
+
+    from fastapi import APIRouter, Request
+    from fastapi.responses import JSONResponse
+
+    # ``from __future__ import annotations`` turns every annotation in this
+    # module into a string, and FastAPI resolves handler annotations with
+    # typing.get_type_hints against the *module* globals. fastapi is
+    # imported lazily here (the laziness contract: nothing web at import
+    # time), so ``Request`` is a local — publish it into the module
+    # namespace or FastAPI reads ``raw_request: "Request"`` as an
+    # unresolvable name, decides it must be a query parameter, and answers
+    # 422 on every route.
+    globals().setdefault("Request", Request)
+    globals().setdefault("JSONResponse", JSONResponse)
+
+    router = APIRouter(prefix="/fq", tags=["fungible-quant admin"])
+    lock = asyncio.Lock()
+
+    def engine_client(request: Request):
+        return request.app.state.engine_client
+
+    def _fail(exc: AdminError) -> JSONResponse:
+        record_admin_outcome(exc.code)
+        return JSONResponse(status_code=exc.status, content=exc.body())
+
+    def _guard(request: Request) -> AdminError | None:
+        if not admin_enabled(environ):
+            return AdminError("fq_admin_disabled", gate_reason(environ),
+                              status=404)
+        token = str(_env(environ).get(ADMIN_TOKEN_ENV, "")).strip()
+        if token:
+            import hmac
+
+            sent = request.headers.get("X-FQ-Admin-Token", "")
+            if not hmac.compare_digest(sent, token):
+                return AdminError(
+                    "fq_admin_forbidden",
+                    f"X-FQ-Admin-Token missing or wrong ({ADMIN_TOKEN_ENV} is "
+                    f"set on this serve)", status=403)
+        return None
+
+    async def _collective(request: Request, method: str, payload: dict,
+                          timeout: float | None = None) -> list[dict]:
+        engine = engine_client(request)
+        raw = await engine.collective_rpc(
+            method, timeout=timeout,
+            args=(json.dumps(payload, sort_keys=True, separators=(",", ":"),
+                             default=str),))
+        if raw is None:
+            raise AdminError("rank_divergence",
+                             f"{method} returned nothing", status=500)
+        results = _rank_results(raw)
+        err = _first_error(results)
+        if err is not None:
+            raise err
+        return results
+
+    @router.get("/state")
+    async def fq_state(raw_request: Request):
+        blocked = _guard(raw_request)
+        if blocked is not None:
+            return _fail(blocked)
+        try:
+            results = await _collective(raw_request, "fq_admin_describe", {})
+        except AdminError as exc:
+            return _fail(exc)
+        record_admin_outcome("state")
+        return JSONResponse(content={
+            "ranks": len(results),
+            "agreed": _agree(results, "policy_sha"),
+            "state": results[0],
+            "per_rank": results,
+            "admin": {"enabled": True,
+                      "max_items": _env_int(environ, ADMIN_MAX_ITEMS_ENV,
+                                            DEFAULT_MAX_ITEMS),
+                      "token_required": bool(
+                          str(_env(environ).get(ADMIN_TOKEN_ENV, "")).strip()),
+                      "auto_balance": False,
+                      "growth_supported": False}})
+
+    @router.get("/layer/{layer}")
+    async def fq_layer(layer: int, raw_request: Request):
+        blocked = _guard(raw_request)
+        if blocked is not None:
+            return _fail(blocked)
+        try:
+            results = await _collective(raw_request, "fq_admin_describe",
+                                        {"layer": int(layer)})
+        except AdminError as exc:
+            return _fail(exc)
+        record_admin_outcome("layer")
+        return JSONResponse(content=results[0].get("layer", {}))
+
+    @router.post("/retier")
+    async def fq_retier(raw_request: Request):
+        blocked = _guard(raw_request)
+        if blocked is not None:
+            return _fail(blocked)
+        t0 = time.perf_counter()
+        try:
+            body = None
+            if (await raw_request.body()).strip():
+                try:
+                    body = await raw_request.json()
+                except Exception:  # noqa: BLE001
+                    raise AdminError("bad_json",
+                                     "body is not valid JSON") from None
+            request = parse_request(
+                body, query=dict(raw_request.query_params),
+                actor_header=raw_request.headers.get("X-FQ-Actor"),
+                environ=environ)
+        except AdminError as exc:
+            return _fail(exc)
+
+        request_id = new_request_id()
+        logger.warning(
+            "FQ ADMIN retier request=%s actor=%s mode=%s items=%d layers=%s "
+            "dry_run=%s reason=%r", request_id, request.actor, request.mode,
+            len(request.items), sorted({i.layer for i in request.items}),
+            request.dry_run, request.reason)
+
+        if lock.locked():
+            return _fail(AdminError(
+                "retier_in_flight",
+                "another re-tier is in flight; SwapEngine holds one staged "
+                "batch at a time", status=409))
+        async with lock:
+            payload = {"request": request.canonical(),
+                       "request_id": request_id}
+            try:
+                plans = await _collective(raw_request, "fq_admin_plan",
+                                          payload, timeout=request.timeout_s)
+            except AdminError as exc:
+                return _fail(exc)
+            for key in ("plan_sha", "membership_sha", "policy_sha_before"):
+                if not _agree(plans, key):
+                    return _fail(AdminError(
+                        "rank_divergence",
+                        f"ranks disagree on {key} — nothing applied",
+                        status=500,
+                        details={key: [p.get(key) for p in plans]}))
+            head = plans[0]
+            base = {
+                "request_id": request_id,
+                "dry_run": request.dry_run,
+                "mode": request.mode,
+                "plan": {"pairs": head.get("pairs", []),
+                         "layers": head.get("layers", []),
+                         "plan_sha": head.get("plan_sha")},
+                "items": head.get("items", []),
+                "memory": head.get("memory", {}),
+                "pins": head.get("pins", {}),
+                "free_slots": head.get("free_slots", {}),
+                "policy": {"sha_before": head.get("policy_sha_before"),
+                           "sha_after": head.get("policy_sha_after")},
+                "ranks": {"count": len(plans), "agreed": True},
+                "warnings": [],
+            }
+            if request.dry_run:
+                record_admin_outcome("dry_run")
+                base["applied"] = False
+                base["timing"] = {"total_ms": (time.perf_counter() - t0) * 1e3}
+                return JSONResponse(content=base)
+            pairs = head.get("pairs") or []
+            pin_delta = head.get("pins") or {}
+            pin_change = bool(pin_delta.get("added")
+                              or pin_delta.get("removed"))
+            if not pairs and not pin_change:
+                record_admin_outcome("noop")
+                base["applied"] = False
+                base["warnings"].append(
+                    "every item was a no-op and no pin changed; nothing to "
+                    "do")
+                base["timing"] = {"total_ms": (time.perf_counter() - t0) * 1e3}
+                return JSONResponse(content=base)
+
+            engine = engine_client(raw_request)
+            # A pin-only change moves no weights, so it needs no drain —
+            # opening a quiesce window for it would stall the serve for a
+            # metadata edit.
+            needs_drain = bool(pairs)
+            drain_t = time.perf_counter()
+            paused = False
+            if needs_drain:
+                try:
+                    await engine.pause_generation(mode=request.drain_mode,
+                                                  clear_cache=False)
+                    paused = True
+                except TimeoutError:
+                    return _fail(AdminError(
+                        "drain_timeout",
+                        f"generation did not drain within "
+                        f"{request.timeout_s}s", status=408))
+                except AdminError as exc:
+                    return _fail(exc)
+            drain_ms = (time.perf_counter() - drain_t) * 1e3
+            try:
+                apply_payload = {**payload, "plan_sha": head.get("plan_sha")}
+                results = await _collective(raw_request, "fq_admin_apply",
+                                            apply_payload,
+                                            timeout=request.timeout_s)
+            except AdminError as exc:
+                return _fail(exc)
+            finally:
+                if paused:
+                    with contextlib.suppress(Exception):
+                        await engine.resume_generation()
+
+            if request.reset_prefix_cache:
+                with contextlib.suppress(Exception):
+                    await engine.reset_prefix_cache(False, False)
+
+            for key in ("generation", "policy_sha_after"):
+                if not _agree(results, key):
+                    logger.error(
+                        "FQ ADMIN rank divergence on %s after apply: %s",
+                        key, [r.get(key) for r in results])
+                    record_admin_outcome("rank_divergence")
+                    return JSONResponse(status_code=500, content=AdminError(
+                        "rank_divergence",
+                        f"ranks disagree on {key} AFTER the apply — the "
+                        f"ranks' weights may now differ; consider a restart",
+                        status=500,
+                        details={key: [r.get(key) for r in results]}).body())
+
+            lead = results[0]
+            record_admin_outcome("applied")
+            base.update({
+                "applied": True,
+                "occupancy": lead.get("occupancy", {}),
+                "occupancy_diff": lead.get("occupancy_diff", ""),
+                "decision_record": lead.get("decision_record"),
+                "reset_prefix_cache": request.reset_prefix_cache,
+                "timing": {"drain_ms": drain_ms,
+                           "stage_ms": lead.get("stage_ms"),
+                           "window_ms": lead.get("window_ms"),
+                           "total_ms": (time.perf_counter() - t0) * 1e3},
+            })
+            base["plan"]["generation"] = lead.get("generation")
+            base["policy"]["sha_after"] = lead.get("policy_sha_after")
+            base["policy"]["committed"] = bool(
+                lead.get("committed_policy_hash"))
+            base["ranks"].update({
+                "generation": [r.get("generation") for r in results],
+                "policy_sha_after": [r.get("policy_sha_after")
+                                     for r in results],
+                "bytes_h2d_per_rank": [r.get("bytes_h2d_per_rank")
+                                       for r in results],
+                "restored": [r.get("restored") for r in results],
+            })
+            return JSONResponse(content=base)
+
+    return router

--- a/vllm/model_executor/layers/quantization/exl3_fungible/admin.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/admin.py
@@ -1554,10 +1554,31 @@ def plan_retier(state: Any, request: RetierRequest, *,
                                  "max_pairs": int(engine.max_pairs)})
 
     policy_sha_after = policy_hash(new_doc)
+    # plan_sha must be what its docstring claims -- "a pure function of the
+    # request and the live membership" -- so that a mismatch means the ranks
+    # genuinely disagree about the model.
+    #
+    # policy_sha_after is NOT that. It covers the whole document including
+    # provenance, which carries a per-rank wall clock ("utc") and a per-rank
+    # step counter. Four ranks that straddle a second boundary therefore
+    # derive four different plan_shas for an identical change, and the
+    # cross-check refuses with "ranks disagree on plan_sha — nothing applied":
+    # an alarming message about membership corruption, raised by a clock tick.
+    # Observed live -- rank 3 diverged once, then three identical retries
+    # passed -- which is the worst shape for a safety check, because it fires
+    # rarely and points somewhere else.
+    #
+    # Hash the MEMBERSHIP the document encodes instead. Two ranks that agree
+    # on every expert's tier agree on the plan, whatever second they computed
+    # it in.
+    membership_after = hashlib.sha256(json.dumps(
+        {str(k): [int(b) for b in v]
+         for k, v in (new_doc.get("bits_per_expert") or {}).items()},
+        sort_keys=True, separators=(",", ":")).encode()).hexdigest()
     plan_sha = hashlib.sha256(json.dumps(
         {"pairs": [[int(l), int(o), int(i)] for l, o, i in plan],
          "policy_sha_before": policy_sha_before,
-         "policy_sha_after": policy_sha_after},
+         "membership_after": membership_after},
         sort_keys=True, separators=(",", ":")).encode()).hexdigest()
 
     return RetierPlan(
@@ -1598,8 +1619,13 @@ def _provenance(state: Any, request: RetierRequest,
         "request_id": request_id,
         "actor": request.actor,
         "reason": request.reason,
-        "utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
-        "step": int(getattr(state, "_step", 0)),
+        # Stamped from the REQUEST when the router supplied it, so all four
+        # ranks commit an identical document. A per-rank time.strftime() here
+        # made the committed policies differ by provenance alone, which shows
+        # up later as /fq/state agreed=False after a swap that was in fact
+        # applied identically everywhere.
+        "utc": getattr(request, "utc", None) or time.strftime(
+            "%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
         "base_policy": base_policy,
         "num_swaps": sum(1 for i in resolved if i.outcome == "promoted"),
         "mode": request.mode,

--- a/vllm/model_executor/layers/quantization/exl3_fungible/admin.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/admin.py
@@ -14,8 +14,8 @@ between tiers. The target ``fq-policy/2`` document is built, handed to
 :meth:`SwapPlan.from_policies` (which already does pairing, ordering and
 the same-cardinality check) and then to :meth:`SwapEngine.apply` (which
 already does the six-step commit protocol and persists the policy as
-step 5 inside the quiesce window). ``swap.py``, ``store.py``,
-``policy.py``, ``fragments.py`` and ``occupancy_table.py`` are unchanged.
+step 5 inside the quiesce window). The swap/store primitives remain the
+single source of truth for every supported binary tier pair.
 
 Gating — OFF by default, twice over:
 
@@ -57,12 +57,13 @@ import contextlib
 import hashlib
 import json
 import logging
+import math
 import os
 import re
 import threading
 import time
 import uuid
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Any, Mapping, Sequence
 
 import numpy as np
@@ -90,6 +91,7 @@ ADMIN_API_ENV = "VLLM_FQ_ADMIN_API"
 ADMIN_ENABLE_ENV = "VLLM_FQ_ADMIN_ENABLE"
 ADMIN_TOKEN_ENV = "VLLM_FQ_ADMIN_TOKEN"
 ADMIN_MAX_ITEMS_ENV = "VLLM_FQ_ADMIN_MAX_ITEMS"
+ADMIN_MAX_BODY_BYTES_ENV = "VLLM_FQ_ADMIN_MAX_BODY_BYTES"
 ADMIN_MEM_BUDGET_ENV = "VLLM_FQ_ADMIN_MEM_BUDGET_BYTES"
 ADMIN_MEM_HEADROOM_ENV = "VLLM_FQ_ADMIN_MEM_HEADROOM_BYTES"
 ADMIN_MIN_FREE_SLOTS_ENV = "VLLM_FQ_ADMIN_MIN_FREE_SLOTS"
@@ -97,16 +99,21 @@ ADMIN_DRAIN_TIMEOUT_ENV = "VLLM_FQ_ADMIN_DRAIN_TIMEOUT_S"
 ADMIN_ALLOW_AUTO_BALANCE_ENV = "VLLM_FQ_ADMIN_ALLOW_AUTO_BALANCE"
 
 DEFAULT_MAX_ITEMS = 32
+DEFAULT_MAX_BODY_BYTES = 1 << 20
+MAX_ACTOR_CHARS = 128
+MAX_REASON_CHARS = 2048
+MAX_POLICY_SHA_CHARS = 128
+MAX_UTC_CHARS = 64
+MAX_TIMEOUT_S = 3600.0
 DEFAULT_MEM_HEADROOM_BYTES = 1 << 30
 DEFAULT_MIN_FREE_SLOTS = 2
 DEFAULT_DRAIN_TIMEOUT_S = 120.0
 
-#: The tiers the v1 swap engine can actually serve as a MIXED pair.
-#: ``MixedLayerState.from_exl3_mixed_trellis`` refuses anything but (3, 4),
-#: and K5 as a mixed tier does not fit SM120 shared memory at all
-#: (109568 > 101376; K4 is exactly 101376, zero headroom) — see
-#: runs/m5-serve/k5-shared-memory-limit.md.
-SERVABLE_TIERS: tuple[int, ...] = (P.K3, P.K4)
+#: Bit widths that may participate in an SM120 binary mixed pair. The
+#: running engine narrows this set to the exact pair prepared at boot.
+#: K5 is excluded: its mixed kernel needs 109568 bytes of shared memory
+#: against the measured 101376-byte opt-in limit.
+SERVABLE_TIERS: tuple[int, ...] = SW.SERVABLE_TIER_BITS
 
 MODE_STRICT_PAIR = "strict_pair"
 MODE_AUTO_BALANCE = "auto_balance"
@@ -116,7 +123,7 @@ PIN_HOLD, PIN_NONE, PIN_RELEASE = "hold", "none", "release"
 
 _REQUEST_FIELDS = frozenset({
     "items", "mode", "dry_run", "pin", "drain_mode", "reset_prefix_cache",
-    "expect_policy_sha", "timeout_s", "actor", "reason",
+    "expect_policy_sha", "timeout_s", "actor", "reason", "utc",
 })
 _ITEM_FIELDS = frozenset({"layer", "expert", "adjust_k", "k", "delta_k"})
 
@@ -217,6 +224,20 @@ def _fmt_bytes(n: int) -> str:
     return f"{sign}{a} B"
 
 
+def _bounded_text(value: Any, name: str, max_chars: int) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise AdminError("bad_json", f"{name} must be a string")
+    if len(value) > max_chars:
+        raise AdminError(
+            "bad_json",
+            f"{name} exceeds {max_chars} characters",
+            details={"field": name, "max_chars": max_chars},
+        )
+    return value
+
+
 # ------------------------------------------------------------------ requests
 
 
@@ -244,6 +265,9 @@ class RetierRequest:
     timeout_s: float = DEFAULT_DRAIN_TIMEOUT_S
     actor: str | None = None
     reason: str | None = None
+    # The API coordinator overwrites this before broadcasting the request.
+    # One timestamp in every rank's provenance keeps policy_doc byte-identical.
+    utc: str | None = None
 
     def canonical(self) -> dict:
         return {
@@ -263,6 +287,7 @@ class RetierRequest:
             "timeout_s": self.timeout_s,
             "actor": self.actor,
             "reason": self.reason,
+            "utc": self.utc,
         }
 
     @classmethod
@@ -287,11 +312,13 @@ class RetierRequest:
             timeout_s=float(doc.get("timeout_s", DEFAULT_DRAIN_TIMEOUT_S)),
             actor=doc.get("actor"),
             reason=doc.get("reason"),
+            utc=doc.get("utc"),
         )
 
 
 _AMBIGUOUS_MSG = (
-    'adjust_k={n} is not a valid absolute tier (ladder is K3/K4). For a '
+    'adjust_k={n} is not a valid absolute tier (servable bits are K2/K3/K4; '
+    'the running model narrows these to its prepared binary pair). For a '
     'relative +{n}, send the string "+{n}", or use the explicit field '
     'delta_k: {n}.'
 )
@@ -518,15 +545,29 @@ def parse_request(body: Mapping[str, Any] | None, *,
         timeout_s = float(timeout_s)
     except (TypeError, ValueError):
         raise AdminError("bad_json", "timeout_s must be a number") from None
+    if not math.isfinite(timeout_s) or not 0 < timeout_s <= MAX_TIMEOUT_S:
+        raise AdminError(
+            "bad_json",
+            f"timeout_s must be finite and in (0, {MAX_TIMEOUT_S:g}]",
+            details={"timeout_s": timeout_s},
+        )
 
+    actor = _bounded_text(body.get("actor"), "actor", MAX_ACTOR_CHARS)
+    if not actor:
+        actor = _bounded_text(actor_header, "X-FQ-Actor", MAX_ACTOR_CHARS)
     return RetierRequest(
         items=items, mode=mode, dry_run=bool(body.get("dry_run", False)),
         pin=pin, drain_mode=drain_mode,
         reset_prefix_cache=bool(body.get("reset_prefix_cache", False)),
-        expect_policy_sha=body.get("expect_policy_sha"),
+        expect_policy_sha=_bounded_text(
+            body.get("expect_policy_sha"),
+            "expect_policy_sha",
+            MAX_POLICY_SHA_CHARS,
+        ),
         timeout_s=timeout_s,
-        actor=body.get("actor") or actor_header,
-        reason=body.get("reason"))
+        actor=actor,
+        reason=_bounded_text(body.get("reason"), "reason", MAX_REASON_CHARS),
+        utc=_bounded_text(body.get("utc"), "utc", MAX_UTC_CHARS))
 
 
 # ------------------------------------------------------------- resolved items
@@ -554,6 +595,7 @@ class ResolvedItem:
 def resolve_items(request: RetierRequest, *, layers: Sequence[int],
                   tier_of: Any, num_experts: int,
                   registered_layers: Sequence[int] | None = None,
+                  servable_tiers: Sequence[int] | None = None,
                   ) -> list[ResolvedItem]:
     """Turn parsed items into (k_from, k_to) against the **live** state.
 
@@ -561,6 +603,18 @@ def resolve_items(request: RetierRequest, *, layers: Sequence[int],
     client sent — so a stale client view cannot silently mis-target.
     """
     tier_of = np.asarray(tier_of)
+    if servable_tiers is None:
+        servable_tiers = sorted({int(k) for k in tier_of.reshape(-1)})
+    active_tiers = tuple(int(k) for k in servable_tiers)
+    if (len(active_tiers) != 2 or active_tiers[0] >= active_tiers[1]
+            or any(k not in SERVABLE_TIERS for k in active_tiers)):
+        raise AdminError(
+            "tier_not_servable",
+            f"running membership does not expose one supported increasing "
+            f"binary tier pair: {active_tiers}",
+            status=501,
+            details={"running_tiers": list(active_tiers),
+                     "servable_tiers": list(SERVABLE_TIERS)})
     rows = {int(l): i for i, l in enumerate(layers)}
     registered = None if registered_layers is None else set(
         int(x) for x in registered_layers)
@@ -596,21 +650,20 @@ def resolve_items(request: RetierRequest, *, layers: Sequence[int],
             outcome = "promoted"
         else:
             outcome = "demoted"
-        if outcome != "noop" and k_to not in SERVABLE_TIERS:
+        if outcome != "noop" and k_to not in active_tiers:
             raise AdminError(
                 "tier_not_servable",
-                f"L{item.layer}/e{item.expert}: K{k_to} cannot be served as a "
-                f"mixed tier. Two independent reasons: (a) the v1 swap engine "
-                f"is a two-tier engine — MixedLayerState.from_exl3_mixed_"
-                f"trellis refuses anything but "
-                f"{tuple(SERVABLE_TIERS)}; (b) on SM120 a K5 mixed tier needs "
-                f"109568 bytes of shared memory against a 101376 opt-in limit "
-                f"(K4 is exactly 101376, zero headroom) — see "
-                f"runs/m5-serve/k5-shared-memory-limit.md.",
+                f"L{item.layer}/e{item.expert}: K{k_to} is not in the "
+                f"running mixed pair {active_tiers}. Runtime re-tiering can "
+                f"only exchange experts between the two slabs prepared at "
+                f"boot. K5 is additionally impossible on SM120: it needs "
+                f"109568 bytes of shared memory against a 101376-byte "
+                f"opt-in limit.",
                 status=501,
                 details={"layer": item.layer, "expert": item.expert,
                          "k_from": k_from, "k_to": k_to,
-                         "ladder": list(SERVABLE_TIERS)})
+                         "running_tiers": list(active_tiers),
+                         "servable_tiers": list(SERVABLE_TIERS)})
         out.append(ResolvedItem(
             layer=item.layer, expert=item.expert, requested=item.requested,
             interpretation=item.interpretation, k_from=k_from, k_to=k_to,
@@ -636,14 +689,14 @@ def check_cardinality(resolved: Sequence[ResolvedItem], *, mode: str,
             "unbudgeted — it is structurally impossible. (1) The tier slabs "
             "are sized at prepare time: SwapEngine._validate_layer derives "
             "the slab word counts from len(tierN_globals) and refuses a "
-            "mismatch, so one more K4 expert means reallocating tier1.w13/w2. "
-            "(2) The mixed-kernel memo key carries per-tier expert COUNTS "
-            "(tier_signature), so changing a count forces "
-            "compile_mixed_trellis, which is refused under CUDA-graph capture "
-            "and which on SM120 re-enters the tile-fit trap that blocks K5. "
+            "mismatch, so one more higher-tier expert means reallocating "
+            "tier1.w13/w2. (2) The mixed-kernel memo key carries per-tier "
+            "expert COUNTS (tier_signature), so changing a count forces "
+            "compile_mixed_trellis, which is refused under CUDA-graph capture. "
             "(3) The bytes are not there: the KV-cache pool is sized from "
-            "post-load free memory at startup. Raise n_k4_per_layer in the "
-            "policy and restart — the committed policy steers the next boot.",
+            "post-load free memory at startup. Raise the high-tier capacity "
+            "in the policy and restart — the committed policy steers the "
+            "next boot.",
             status=501,
             details={"mode": mode, "growth_supported": False})
     if mode == MODE_AUTO_BALANCE:
@@ -888,14 +941,7 @@ def check_pin_starvation(new_doc: Mapping[str, Any], *,
                          touched_layers: Sequence[int] | None = None,
                          min_free_slots: int | None = None,
                          environ: Mapping[str, str] | None = None) -> dict:
-    """Refuse a pin set that would wedge the next ``policy.decide``.
-
-    ``policy.decide`` raises ``"layer {l}: pins incompatible with budget"``
-    when ``pin4.sum() > n_k4[l]`` or ``E - pin3.sum() < n_k4[l]`` — and
-    ``step()``'s blanket handler would swallow it, so the loop would
-    silently stop deciding. Keep at least ``max_swaps_per_layer`` worth of
-    room on both sides so the loop always has an interval's work available.
-    """
+    """Keep enough unpinned residents in both prepared tiers for a trade."""
     if min_free_slots is None:
         min_free_slots = _env_int(environ, ADMIN_MIN_FREE_SLOTS_ENV,
                                   DEFAULT_MIN_FREE_SLOTS)
@@ -909,33 +955,50 @@ def check_pin_starvation(new_doc: Mapping[str, Any], *,
     free_slots: dict[str, int] = {}
     for layer in check:
         row = rows[layer]
-        n_k4 = int(caps.get(str(layer), int((new_tier[row] == P.K4).sum())))
+        tiers = sorted({int(k) for k in new_tier[row]})
+        if len(tiers) != 2:
+            free_slots[str(layer)] = 0
+            continue
+        low_k, high_k = tiers
+        high_capacity = int((new_tier[row] == high_k).sum())
+        if high_k == P.K4:
+            high_capacity = int(caps.get(str(layer), high_capacity))
         val = pinned.get(str(layer))
-        if val == "all":
-            ids = list(range(int(num_experts)))
-        else:
-            ids = [int(e) for e in (val or ())]
-        pin4 = sum(1 for e in ids if int(new_tier[row, e]) == P.K4)
-        pin3 = sum(1 for e in ids if int(new_tier[row, e]) == P.K3)
-        k4_free = n_k4 - pin4
-        k3_free = (int(num_experts) - pin3) - n_k4
-        free_slots[str(layer)] = int(min(k4_free, k3_free))
-        if k4_free < min_free_slots or k3_free < min_free_slots:
+        ids = (list(range(int(num_experts))) if val == "all"
+               else [int(e) for e in (val or ())])
+        pinned_high = sum(
+            1 for e in ids if int(new_tier[row, e]) == high_k)
+        pinned_low = sum(
+            1 for e in ids if int(new_tier[row, e]) == low_k)
+        high_free = high_capacity - pinned_high
+        low_free = (int(num_experts) - high_capacity) - pinned_low
+        free_slots[str(layer)] = int(min(high_free, low_free))
+        if high_free < min_free_slots or low_free < min_free_slots:
+            details = {
+                "layer": layer,
+                "tier_bits": tiers,
+                "high_tier_capacity": high_capacity,
+                "pinned_high": pinned_high,
+                "pinned_low": pinned_low,
+                "free_high_slots": high_free,
+                "free_low_slots": low_free,
+                f"free_k{high_k}_slots": high_free,
+                f"free_k{low_k}_slots": low_free,
+                "min_free_slots": min_free_slots,
+                "min_free_slots_env": ADMIN_MIN_FREE_SLOTS_ENV,
+            }
+            if high_k == P.K4:
+                details["n_k4_per_layer"] = high_capacity
+                details["pinned_k4"] = pinned_high
             raise AdminError(
                 "pin_would_starve_layer",
-                f"layer {layer}: after this pin change the decision loop "
-                f"would have {k4_free} free K4 slot(s) and {k3_free} free K3 "
-                f"slot(s), below the required {min_free_slots} "
-                f"({ADMIN_MIN_FREE_SLOTS_ENV}). policy.decide would refuse "
-                f"the layer outright ('pins incompatible with budget') and "
-                f"the loop would stop deciding. Send pin=\"release\" for some "
-                f"experts in this layer, or pin=\"none\" for this request.",
-                status=409,
-                details={"layer": layer, "n_k4_per_layer": n_k4,
-                         "pinned_k4": pin4, "pinned_k3": pin3,
-                         "free_k4_slots": k4_free, "free_k3_slots": k3_free,
-                         "min_free_slots": min_free_slots,
-                         "min_free_slots_env": ADMIN_MIN_FREE_SLOTS_ENV})
+                f"layer {layer}: after this pin change the prepared K{high_k} "
+                f"and K{low_k} tiers would have {high_free} and {low_free} "
+                f"free slot(s), below the required {min_free_slots} "
+                f"({ADMIN_MIN_FREE_SLOTS_ENV}). Send pin=\"release\" for "
+                f"some experts in this layer, or pin=\"none\" for this "
+                f"request.",
+                status=409, details=details)
     return free_slots
 
 
@@ -1496,7 +1559,9 @@ def plan_retier(state: Any, request: RetierRequest, *,
         registered = sorted(int(x) for x in engine.layers)
     resolved = resolve_items(
         request, layers=state.layers, tier_of=state.tier_of,
-        num_experts=int(state.num_experts), registered_layers=registered)
+        num_experts=int(state.num_experts), registered_layers=registered,
+        servable_tiers=(getattr(engine, "tier_bits", None)
+                        if engine is not None else None))
     effective = [i for i in resolved if i.outcome != "noop"]
 
     caps = (dict(state.policy_doc).get("budget") or {}).get("n_k4_per_layer")
@@ -1619,13 +1684,10 @@ def _provenance(state: Any, request: RetierRequest,
         "request_id": request_id,
         "actor": request.actor,
         "reason": request.reason,
-        # Stamped from the REQUEST when the router supplied it, so all four
-        # ranks commit an identical document. A per-rank time.strftime() here
-        # made the committed policies differ by provenance alone, which shows
-        # up later as /fq/state agreed=False after a swap that was in fact
-        # applied identically everywhere.
-        "utc": getattr(request, "utc", None) or time.strftime(
-            "%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        # The coordinator stamps one timestamp before broadcasting. Using a
+        # worker-local clock here makes policy_doc (and therefore policy_sha)
+        # diverge whenever ranks straddle a second boundary.
+        "utc": request.utc,
         "base_policy": base_policy,
         "num_swaps": sum(1 for i in resolved if i.outcome == "promoted"),
         "mode": request.mode,
@@ -1897,9 +1959,15 @@ def build_swap_engine(model_runner: Any, *, rank: int = 0,
 
     spec = ProgressiveSpec.from_env(environ=dict(_env(environ)))
     source = SW.ResolverFragmentSource(spec.make_resolver())
+    tier_pairs = {tuple(state.tier_bits) for state in layers.values()}
+    if len(tier_pairs) != 1:
+        raise ValueError(
+            f"mixed layers disagree on prepared tier pair: "
+            f"{sorted(tier_pairs)}")
+    tier_bits = next(iter(tier_pairs))
     return SW.SwapEngine(
         layers, source, hidden_size=hidden, intermediate_size=intermediate,
-        tier_bits=(P.K3, P.K4), rank=int(rank), max_pairs=int(max_pairs))
+        tier_bits=tier_bits, rank=int(rank), max_pairs=int(max_pairs))
 
 
 def _loop_state(worker: Any) -> Any:
@@ -2159,7 +2227,8 @@ def worker_describe(worker: Any, request_json: str = "{}") -> str:
             "occupancy": {str(k): {str(kk): vv for kk, vv in v.items()}
                           for k, v in occupancy_map(state).items()},
             "pinned": _pinned_from_doc(state.policy_doc),
-            "servable_tiers": list(SERVABLE_TIERS),
+            "servable_tiers": list(
+                getattr(engine, "tier_bits", SERVABLE_TIERS)),
             "engine_bound": engine is not None,
             "registered_layers": (sorted(int(x) for x in engine.layers)
                                   if engine is not None else []),
@@ -2556,10 +2625,21 @@ def build_router(*, environ: Mapping[str, str] | None = None) -> Any:
             return _fail(blocked)
         t0 = time.perf_counter()
         try:
+            raw_body = await raw_request.body()
+            max_body_bytes = _env_int(
+                environ, ADMIN_MAX_BODY_BYTES_ENV, DEFAULT_MAX_BODY_BYTES
+            )
+            if len(raw_body) > max_body_bytes:
+                raise AdminError(
+                    "request_too_large",
+                    f"request body exceeds {max_body_bytes} bytes",
+                    status=413,
+                    details={"bytes": len(raw_body), "max_bytes": max_body_bytes},
+                )
             body = None
-            if (await raw_request.body()).strip():
+            if raw_body.strip():
                 try:
-                    body = await raw_request.json()
+                    body = json.loads(raw_body)
                 except Exception:  # noqa: BLE001
                     raise AdminError("bad_json",
                                      "body is not valid JSON") from None
@@ -2570,6 +2650,12 @@ def build_router(*, environ: Mapping[str, str] | None = None) -> Any:
         except AdminError as exc:
             return _fail(exc)
 
+        # Ignore any caller-supplied timestamp. This is internal provenance:
+        # stamp it once here, then carry it in canonical() to every rank.
+        request = replace(
+            request,
+            utc=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        )
         request_id = new_request_id()
         logger.warning(
             "FQ ADMIN retier request=%s actor=%s mode=%s items=%d layers=%s "

--- a/vllm/model_executor/layers/quantization/exl3_fungible/admin.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/admin.py
@@ -2029,6 +2029,98 @@ def worker_tune(worker: Any, request_json: str = "{}") -> str:
     except Exception as exc:  # noqa: BLE001
         return _err(exc)
 
+def _device_layer_view(engine: Any, layer: int) -> dict:
+    """Read membership from the two tensors the mixed kernel indexes."""
+    if engine is None or int(layer) not in engine.layers:
+        raise AdminError(
+            "layer_not_registered",
+            f"layer {layer} has no live mixed-trellis device maps",
+            status=404,
+            details={"layer": int(layer), "source": "device"},
+        )
+    live = engine.layers[int(layer)]
+    try:
+        global_to_combined = [
+            int(x) for x in live.global_to_combined.detach().to(
+                device="cpu").tolist()
+        ]
+        descriptor_map = [
+            int(x) for x in live.descriptor_map.detach().to(
+                device="cpu").tolist()
+        ]
+    except Exception as exc:  # noqa: BLE001
+        raise AdminError(
+            "device_map_unreadable",
+            f"layer {layer} device maps could not be read: {exc}",
+            status=500,
+            details={"layer": int(layer), "source": "device"},
+        ) from exc
+
+    num_experts = len(global_to_combined)
+    if (len(descriptor_map) != num_experts
+            or sorted(global_to_combined) != list(range(num_experts))):
+        raise AdminError(
+            "device_map_invalid",
+            f"layer {layer} device maps are not a bijection over "
+            f"{num_experts} experts",
+            status=500,
+            details={"layer": int(layer), "source": "device"},
+        )
+    tier_bits = tuple(int(x) for x in getattr(engine, "tier_bits", ()))
+    if len(tier_bits) != 2:
+        raise AdminError(
+            "device_map_invalid",
+            f"layer {layer} engine has invalid tier bits {tier_bits}",
+            status=500,
+            details={"layer": int(layer), "source": "device"},
+        )
+
+    experts = []
+    locals_by_tier: list[list[int]] = [[], []]
+    for expert, combined in enumerate(global_to_combined):
+        descriptor = descriptor_map[combined]
+        tier_index = descriptor >> SW.DESCRIPTOR_TIER_SHIFT
+        local = descriptor & ((1 << SW.DESCRIPTOR_TIER_SHIFT) - 1)
+        if tier_index not in (0, 1):
+            raise AdminError(
+                "device_map_invalid",
+                f"layer {layer} expert {expert} names tier {tier_index}",
+                status=500,
+                details={"layer": int(layer), "expert": expert,
+                         "descriptor": descriptor, "source": "device"},
+            )
+        locals_by_tier[tier_index].append(local)
+        experts.append({
+            "expert": expert,
+            "k": tier_bits[tier_index],
+            "tier_index": tier_index,
+            "tier_local": local,
+            "combined_slot": combined,
+        })
+    for tier_index, locals_ in enumerate(locals_by_tier):
+        if sorted(locals_) != list(range(len(locals_))):
+            raise AdminError(
+                "device_map_invalid",
+                f"layer {layer} tier {tier_index} local slots are not "
+                "contiguous and unique",
+                status=500,
+                details={"layer": int(layer), "tier_index": tier_index,
+                         "source": "device"},
+            )
+
+    membership = [row["k"] for row in experts]
+    membership_sha = hashlib.sha256(json.dumps(
+        membership, separators=(",", ":")).encode()).hexdigest()
+    return {
+        "layer": int(layer),
+        "source": "device",
+        "experts": experts,
+        "n_k4": sum(k == P.K4 for k in membership),
+        "membership_sha": membership_sha,
+    }
+
+
+
 
 def worker_describe(worker: Any, request_json: str = "{}") -> str:
     """Read-only view of this rank's FQ state (``GET /fq/state``)."""
@@ -2036,6 +2128,14 @@ def worker_describe(worker: Any, request_json: str = "{}") -> str:
         _require_gates()
         query = json.loads(request_json or "{}")
         state = _loop_state(worker)
+        source = str(query.get("source", "loop")).strip().lower()
+        if source not in ("loop", "device"):
+            raise AdminError(
+                "invalid_source",
+                f"source must be loop|device, got {source!r}",
+                status=400,
+                details={"source": source},
+            )
         engine = None
         with contextlib.suppress(AdminError):
             engine = _bound_engine(worker, state)
@@ -2077,7 +2177,13 @@ def worker_describe(worker: Any, request_json: str = "{}") -> str:
             }
         layer = query.get("layer")
         if layer is not None:
-            payload["layer"] = _layer_view(state, int(layer))
+            if source == "device":
+                payload["layer"] = _device_layer_view(
+                    engine, int(layer))
+                payload["device_membership_sha"] = payload["layer"][
+                    "membership_sha"]
+            else:
+                payload["layer"] = _layer_view(state, int(layer))
         return _ok(payload)
     except Exception as exc:  # noqa: BLE001
         return _err(exc)
@@ -2113,7 +2219,7 @@ def _layer_view(state: Any, layer: int) -> dict:
         rank_of = {e: i for i, e in enumerate(order)}
         for row_dict in experts:
             row_dict["score_rank"] = rank_of[row_dict["expert"]]
-    return {"layer": int(layer), "experts": experts,
+    return {"layer": int(layer), "source": "loop", "experts": experts,
             "n_k4": int((tier == P.K4).sum())}
 
 
@@ -2423,13 +2529,25 @@ def build_router(*, environ: Mapping[str, str] | None = None) -> Any:
         blocked = _guard(raw_request)
         if blocked is not None:
             return _fail(blocked)
+        source = str(raw_request.query_params.get("source", "loop"))
         try:
-            results = await _collective(raw_request, "fq_admin_describe",
-                                        {"layer": int(layer)})
+            results = await _collective(
+                raw_request, "fq_admin_describe",
+                {"layer": int(layer), "source": source})
         except AdminError as exc:
             return _fail(exc)
         record_admin_outcome("layer")
-        return JSONResponse(content=results[0].get("layer", {}))
+        view = dict(results[0].get("layer", {}))
+        if source.strip().lower() == "device":
+            view.update({
+                "ranks": len(results),
+                "agreed": _agree(results, "device_membership_sha"),
+                "per_rank": [{
+                    "rank": result.get("rank"),
+                    "membership_sha": result.get("device_membership_sha"),
+                } for result in results],
+            })
+        return JSONResponse(content=view)
 
     @router.post("/retier")
     async def fq_retier(raw_request: Request):

--- a/vllm/model_executor/layers/quantization/exl3_fungible/admin.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/admin.py
@@ -58,6 +58,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import threading
 import time
 import uuid
@@ -1795,6 +1796,33 @@ def memory_model_from_engine(engine: Any) -> MemoryModel | None:
         return None
 
 
+_LAYER_IN_NAME = re.compile(r"(?:^|\.)layers\.(\d+)(?:\.|$)")
+
+
+def _module_layer_id(module: Any) -> int | None:
+    """The MoE layer index of a module carrying ``exl3_mixed_trellis``.
+
+    ``layer_id`` first, but it is NOT present on the module we need: exl3.py
+    attaches the mixed-trellis dict to the fused-experts module, and
+    fused_moe/layer.py identifies that module by ``layer_name = prefix``
+    ("model.layers.10.mlp.experts") with no numeric id. Requiring ``layer_id``
+    therefore skipped every mixed layer on a real serve and
+    :func:`build_swap_engine` returned None, so POST /fq/retier answered
+    "fq_not_active — the serve is uniform-K" on a checkpoint with 75 mixed
+    layers. The router modules the stats collector binds DO carry ``layer_id``,
+    which is why the collector worked and the swap engine did not.
+    """
+    layer_id = getattr(module, "layer_id", None)
+    if layer_id is not None:
+        return int(layer_id)
+    name = getattr(module, "layer_name", None) or getattr(
+        module, "prefix", None)
+    if not name:
+        return None
+    m = _LAYER_IN_NAME.search(str(name))
+    return int(m.group(1)) if m else None
+
+
 def build_swap_engine(model_runner: Any, *, rank: int = 0,
                       max_pairs: int = DEFAULT_MAX_ITEMS,
                       environ: Mapping[str, str] | None = None) -> Any:
@@ -1815,7 +1843,7 @@ def build_swap_engine(model_runner: Any, *, rank: int = 0,
         mixed = getattr(module, "exl3_mixed_trellis", None)
         if mixed is None:
             continue
-        layer_id = getattr(module, "layer_id", None)
+        layer_id = _module_layer_id(module)
         if layer_id is None:
             continue
         layers[int(layer_id)] = SW.MixedLayerState.from_exl3_mixed_trellis(

--- a/vllm/model_executor/layers/quantization/exl3_fungible/admin.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/admin.py
@@ -1285,7 +1285,11 @@ def _bump_metrics(state: Any, swaps: Sequence[tuple[int, int, int]], *,
     if metrics is not None and getattr(state, "is_lead", True):
         try:
             for layer, _, _ in swaps:
-                metrics.swaps_total.labels(layer=str(int(layer))).inc()
+                # A forced admin swap IS installed by the time we get here.
+                metrics.swap_proposals_total.labels(
+                    layer=str(int(layer))).inc()
+                metrics.swaps_applied_total.labels(
+                    layer=str(int(layer))).inc()
             metrics.policy_age_steps.set(
                 int(getattr(state, "_step", 0))
                 - int(getattr(state, "_policy_step", 0)))

--- a/vllm/model_executor/layers/quantization/exl3_fungible/convergence.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/convergence.py
@@ -348,3 +348,79 @@ class ConvergenceWorker:
         """True when there is nothing left worth attempting."""
         return self.plan.state.is_final or self.plan.state is (
             ConvergenceState.STALLED)
+
+
+def group_by_layer(deficits, batch_layers: int = 4) -> list[tuple[int, list]]:
+    """Group deficits by layer, worst layer first, capped at ``batch_layers``.
+
+    Convergence is layer-granular whether we like it or not. A degraded boot
+    never ALLOCATED the K4 slab for the expert it downgraded, and the swap
+    engine only moves experts between slabs that already exist -- pairwise,
+    because cardinality is fixed. So an expert cannot be promoted into
+    capacity that was never reserved; the layer has to be rebuilt.
+
+    That makes per-expert repayment the wrong unit: repaying 40 deficits in
+    one layer costs one reload, and repaying them one at a time costs forty.
+    """
+    by_layer: dict[int, list] = {}
+    for d in deficits:
+        by_layer.setdefault(d.layer, []).append(d)
+    ordered = sorted(by_layer.items(),
+                     key=lambda kv: (-sum(x.gap for x in kv[1]), kv[0]))
+    return ordered[:max(1, int(batch_layers))]
+
+
+class LayerConvergenceWorker:
+    """Repays deficits a LAYER at a time via an injected reload callable.
+
+    ``reload_fn(layer, {expert: target_k}) -> dict | None`` rebuilds that
+    layer's device state at the requested tiers and returns the tiers actually
+    installed (or None if it could not run). Bound to fq_reload's collective
+    RPC in production; injected in tests.
+    """
+
+    def __init__(self, plan: ConvergencePlan, reload_fn, *,
+                 batch_layers: int = 4, max_attempts: int = 3, priority=None):
+        self.plan = plan
+        self.reload_fn = reload_fn
+        self.batch_layers = max(1, int(batch_layers))
+        self.max_attempts = max_attempts
+        self.priority = priority
+
+    def step(self) -> dict:
+        """Repay up to ``batch_layers`` layers. Never raises."""
+        wrote_off = {d.key() for d in self.plan.give_up(self.max_attempts)}
+        pending = [d for d in self.plan.pending(priority=self.priority)
+                   if d.key() not in wrote_off]
+        layers = group_by_layer(pending, self.batch_layers)
+        repaid = failed = 0
+        for layer, deficits in layers:
+            want = {d.expert: d.target_k for d in deficits}
+            try:
+                got = self.reload_fn(layer, want)
+            except Exception:  # noqa: BLE001 — a serving engine must survive
+                got = None
+            if not got:
+                for d in deficits:
+                    self.plan.fail(d.layer, d.expert)
+                failed += len(deficits)
+                continue
+            for d in deficits:
+                k = got.get(d.expert)
+                if k is None:
+                    self.plan.fail(d.layer, d.expert)
+                    failed += 1
+                elif self.plan.repay(d.layer, d.expert, int(k)):
+                    repaid += 1
+        return {
+            "layers_attempted": len(layers),
+            "repaid": repaid,
+            "failed": failed,
+            "pending": self.plan.pending_count,
+            "state": self.plan.state.value,
+            "drift_bits": self.plan.drift_bits,
+        }
+
+    def done(self) -> bool:
+        return self.plan.state.is_final or (
+            self.plan.state is ConvergenceState.STALLED)

--- a/vllm/model_executor/layers/quantization/exl3_fungible/convergence.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/convergence.py
@@ -36,6 +36,8 @@ from dataclasses import dataclass, field
 from enum import Enum
 
 __all__ = [
+    "active_plan",
+    "set_active_plan",
     "ConvergenceState",
     "Deficit",
     "ConvergencePlan",
@@ -424,3 +426,112 @@ class LayerConvergenceWorker:
     def done(self) -> bool:
         return self.plan.state.is_final or (
             self.plan.state is ConvergenceState.STALLED)
+
+
+class NotInstalled(RuntimeError):
+    """A convergence attempt resolved fragments but did not install them."""
+
+
+def installed_tiers(rpc_result) -> dict[int, int] | None:
+    """Extract per-expert installed tiers from an fq_converge_layers result.
+
+    The ONE rule this enforces: a result that does not affirm ``installed``
+    yields None, never a tier map. Reading the tiers off a resolve-only
+    result and repaying them would drive the plan to state=converged,
+    drift_bits=0 on a model whose weights never changed -- fabricated
+    evidence, and precisely what ConvergenceState exists to prevent.
+
+    Absent/false/malformed all mean "not installed". A telemetry contract
+    that fails open is not a contract.
+    """
+    if not isinstance(rpc_result, dict):
+        return None
+    if rpc_result.get("installed") is not True:
+        return None
+    layers = rpc_result.get("layers")
+    if not isinstance(layers, dict):
+        return None
+    out: dict[int, int] = {}
+    for expert, k in layers.items():
+        try:
+            out[int(expert)] = int(k)
+        except (TypeError, ValueError):
+            continue
+    return out
+
+
+def bind_reload_rpc(collective_rpc, *, timeout: float | None = None):
+    """Build a ``reload_fn`` for LayerConvergenceWorker from a worker RPC.
+
+    ``collective_rpc(method, args=...)`` is vLLM's executor seam. All TP ranks
+    rebuild the same layer, so every rank must affirm the install: one rank
+    silently skipping it would leave the model inconsistent across ranks
+    while the plan reported convergence.
+    """
+
+    def reload_fn(layer: int, want: dict[int, int]):
+        results = collective_rpc(
+            "fq_converge_layers", args=({int(layer): dict(want)},))
+        if not results:
+            return None
+        per_rank = [installed_tiers(_rank_layer(r, layer)) for r in results]
+        if any(x is None for x in per_rank):
+            return None            # some rank did not install: repay nothing
+        first = per_rank[0]
+        for other in per_rank[1:]:
+            if other != first:
+                return None        # ranks disagree: treat as not converged
+        return first
+
+    return reload_fn
+
+
+def _rank_layer(rank_result, layer: int):
+    """Narrow one rank's whole-RPC result to the layer we asked about."""
+    if not isinstance(rank_result, dict):
+        return None
+    layers = rank_result.get("layers")
+    if not isinstance(layers, dict):
+        return rank_result
+    for key in (layer, str(layer)):
+        if key in layers:
+            return {"installed": rank_result.get("installed"),
+                    "layers": layers[key]}
+    return {"installed": rank_result.get("installed"), "layers": {}}
+
+
+# --------------------------------------------------------------- the registry
+# The loader BUILDS a plan on every progressive boot, but nothing passed
+# convergence_out, so the plan was populated, logged once and garbage
+# collected -- the accounting existed and was unreachable, which means the
+# "weights are still converging" telemetry did not exist at runtime at all.
+# One process-wide slot is the seam: the loader publishes, admin/metrics and
+# the repay worker read.
+_ACTIVE: "ConvergencePlan | None" = None
+_ACTIVE_LOCK = threading.Lock()
+
+
+def set_active_plan(plan) -> None:
+    """Publish the plan for this process. Last boot wins (a reload replaces
+    the previous posture rather than accumulating stale deficits)."""
+    global _ACTIVE
+    with _ACTIVE_LOCK:
+        _ACTIVE = plan
+
+
+def active_plan():
+    """The current plan, or None if this process never booted progressively."""
+    with _ACTIVE_LOCK:
+        return _ACTIVE
+
+
+def convergence_snapshot() -> dict:
+    """Scrape-ready state, safe to call on a process that never booted
+    progressively -- an absent plan is reported as such rather than as
+    'converged', because 'no information' and 'nothing left to do' are
+    different answers and only one of them is reassuring."""
+    plan = active_plan()
+    if plan is None:
+        return {"state": "unknown", "is_final": False,
+                "reason": "no progressive boot in this process"}
+    return plan.snapshot()

--- a/vllm/model_executor/layers/quantization/exl3_fungible/convergence.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/convergence.py
@@ -285,3 +285,66 @@ class ConvergencePlan:
             f"drift={s['drift_bits']} tier-steps across "
             f"{s['layers_affected']} layers). "
             f"SERVED WEIGHTS ARE NOT FINAL.")
+
+
+class ConvergenceWorker:
+    """Repays the deficits an opportunistic boot accepted.
+
+    Deliberately takes ``swap_fn`` rather than reaching for the engine: the
+    swap path already exists (M4 atomic swap / fq_reload), and the thing that
+    was missing was never the mechanism but the BOOKKEEPING -- knowing which
+    experts owe an upgrade, in what order, and when to stop trying.
+
+    ``swap_fn(layer, expert, target_k) -> int | None`` returns the K actually
+    installed (which may be an intermediate rung of the ladder), or None if it
+    could not be satisfied right now.
+    """
+
+    def __init__(self, plan: ConvergencePlan, swap_fn, *, batch: int = 16,
+                 max_attempts: int = 3, priority=None):
+        self.plan = plan
+        self.swap_fn = swap_fn
+        self.batch = max(1, int(batch))
+        self.max_attempts = max_attempts
+        self.priority = priority
+
+    def step(self) -> dict:
+        """Repay up to ``batch`` deficits. Safe to call from a loop tick.
+
+        Never raises: convergence is best-effort by construction, and an
+        engine that is serving must not be brought down by an upgrade that
+        could have been retried on the next tick.
+        """
+        repaid = failed = attempted = 0
+        giving_up = {d.key() for d in self.plan.give_up(self.max_attempts)}
+        for d in self.plan.pending(priority=self.priority):
+            if attempted >= self.batch:
+                break
+            if d.key() in giving_up:
+                continue          # already written off; do not spin on it
+            attempted += 1
+            try:
+                got = self.swap_fn(d.layer, d.expert, d.target_k)
+            except Exception:  # noqa: BLE001 — a serving engine must survive
+                got = None
+            if got is None:
+                self.plan.fail(d.layer, d.expert)
+                failed += 1
+            elif self.plan.repay(d.layer, d.expert, int(got)):
+                repaid += 1
+            else:
+                # climbed a rung but not to target: progress, still pending
+                repaid += 0
+        return {
+            "attempted": attempted,
+            "repaid": repaid,
+            "failed": failed,
+            "pending": self.plan.pending_count,
+            "state": self.plan.state.value,
+            "drift_bits": self.plan.drift_bits,
+        }
+
+    def done(self) -> bool:
+        """True when there is nothing left worth attempting."""
+        return self.plan.state.is_final or self.plan.state is (
+            ConvergenceState.STALLED)

--- a/vllm/model_executor/layers/quantization/exl3_fungible/convergence.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/convergence.py
@@ -1,0 +1,287 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Opportunistic time-to-serve: boot on what is on disk, converge afterwards.
+
+A progressive boot normally blocks until every expert can be served at the K
+its policy asks for. That makes time-to-serve a function of the SLOWEST fetch,
+and it turns a partially-primed cache into a long wait instead of an immediate
+(slightly worse) model.
+
+The observation this module implements: **every K is a valid quantisation of
+the same expert.** A K2 fragment is not a broken K3 -- it is a coarser but
+entirely servable version of the same weights. So if the primed cache holds a
+complete set of experts at ANY mix of tiers within the operator's bounds, the
+engine can start serving immediately and walk up to the intended posture at
+runtime through the existing swap path.
+
+Two invariants make that safe rather than reckless:
+
+1. **Completeness, not adequacy, is the gate.** Serving with an expert missing
+   is incoherent; serving it at K2 instead of K3 is merely worse. So a missing
+   fragment at EVERY tier is a hard failure, while a fragment below target is
+   a deficit to be repaid.
+2. **A converging model must never be mistaken for a final one.** Anything
+   reading these metrics has to be able to tell that the weights are still
+   moving -- otherwise a benchmark run during convergence gets attributed to
+   the intended configuration, which is exactly the kind of quietly-wrong
+   number that discredits the whole approach.
+
+This is OPT-IN (``VLLM_FQ_OPPORTUNISTIC=1``). The default remains: serve what
+was asked for, or do not serve.
+"""
+from __future__ import annotations
+
+import os
+import threading
+from dataclasses import dataclass, field
+from enum import Enum
+
+__all__ = [
+    "ConvergenceState",
+    "Deficit",
+    "ConvergencePlan",
+    "opportunistic_enabled",
+    "k_bounds",
+]
+
+
+def opportunistic_enabled(environ=None) -> bool:
+    env = environ if environ is not None else os.environ
+    return str(env.get("VLLM_FQ_OPPORTUNISTIC", "0")).strip().lower() in (
+        "1", "true", "yes", "on")
+
+
+def k_bounds(environ=None) -> tuple[int, int]:
+    """Operator bounds on acceptable tiers, inclusive.
+
+    A boot may substitute anything inside these; anything outside is refused
+    even opportunistically. Defaults are deliberately wide (2..5, the tiers
+    the format defines) so the gate is completeness, not taste.
+    """
+    env = environ if environ is not None else os.environ
+    lo = int(env.get("VLLM_FQ_K_MIN", "2"))
+    hi = int(env.get("VLLM_FQ_K_MAX", "5"))
+    if lo > hi:
+        raise ValueError(
+            f"VLLM_FQ_K_MIN={lo} exceeds VLLM_FQ_K_MAX={hi}: no tier is "
+            f"acceptable, so no boot is possible")
+    return lo, hi
+
+
+class ConvergenceState(str, Enum):
+    """Never let a converging model be read as a finished one."""
+
+    PRISTINE = "pristine"        # every expert already at target
+    CONVERGING = "converging"    # serving, but below target somewhere
+    CONVERGED = "converged"      # started below target, now repaid
+    STALLED = "stalled"          # deficits remain and cannot be repaid
+
+    @property
+    def is_final(self) -> bool:
+        return self in (ConvergenceState.PRISTINE, ConvergenceState.CONVERGED)
+
+
+@dataclass(frozen=True)
+class Deficit:
+    """One expert serving below the tier its policy asked for."""
+
+    layer: int
+    expert: int
+    actual_k: int
+    target_k: int
+
+    @property
+    def gap(self) -> int:
+        return self.target_k - self.actual_k
+
+    def key(self) -> tuple[int, int]:
+        return (self.layer, self.expert)
+
+
+@dataclass
+class ConvergencePlan:
+    """The deficits a boot accepted, and the telemetry that admits to them.
+
+    Thread-safe: the loader records from the weight-iterator thread while the
+    convergence worker drains and a metrics scrape reads, all concurrently.
+    """
+
+    k_min: int = 2
+    k_max: int = 5
+    _deficits: dict[tuple[int, int], Deficit] = field(default_factory=dict)
+    _missing: list[tuple[int, int]] = field(default_factory=list)
+    _total_experts: int = 0
+    _repaid: int = 0
+    _failed: dict[tuple[int, int], int] = field(default_factory=dict)
+    _started_dirty: bool = False
+    _lock: threading.RLock = field(default_factory=threading.RLock)
+
+    # ---------------------------------------------------------------- record
+    def observe(self, layer: int, expert: int, actual_k: int,
+                target_k: int) -> None:
+        """Record one expert as it was actually loaded."""
+        with self._lock:
+            self._total_experts += 1
+            if actual_k < target_k:
+                d = Deficit(layer, expert, actual_k, target_k)
+                self._deficits[d.key()] = d
+                # Latch it HERE. Deriving this lazily in the state getter
+                # meant a plan whose deficits were all repaid before anything
+                # read state reported PRISTINE -- erasing the fact that it
+                # booted degraded, which is precisely the fact an operator
+                # reading a dashboard afterwards needs.
+                self._started_dirty = True
+
+    def observe_missing(self, layer: int, expert: int) -> None:
+        """No fragment at ANY tier. This is the one thing that is fatal."""
+        with self._lock:
+            self._total_experts += 1
+            self._missing.append((layer, expert))
+
+    def acceptable(self, k: int) -> bool:
+        return self.k_min <= k <= self.k_max
+
+    # ------------------------------------------------------------- the gate
+    @property
+    def complete(self) -> bool:
+        """Every expert has SOME fragment. The only precondition for serving."""
+        with self._lock:
+            return not self._missing
+
+    def missing(self) -> list[tuple[int, int]]:
+        with self._lock:
+            return list(self._missing)
+
+    def gate(self) -> None:
+        """Raise unless the loaded set can coherently serve.
+
+        Deliberately says nothing about tiers: below-target is the thing this
+        whole module exists to permit.
+        """
+        with self._lock:
+            if self._missing:
+                head = self._missing[:8]
+                raise ValueError(
+                    f"opportunistic boot refused: {len(self._missing)} "
+                    f"expert(s) have no fragment at ANY tier in "
+                    f"[K{self.k_min}..K{self.k_max}], e.g. "
+                    f"{['L%d/e%d' % le for le in head]}. A missing expert is "
+                    f"incoherent, not merely coarse.")
+
+    # ------------------------------------------------------------ the queue
+    def pending(self, priority=None) -> list[Deficit]:
+        """Deficits worth repaying, worst first.
+
+        ``priority(deficit) -> float`` lets a caller order by something it
+        knows and this module does not -- activation counts, for instance, so
+        the experts that actually carry traffic converge first rather than
+        whatever happened to sort low by layer index.
+        """
+        with self._lock:
+            items = list(self._deficits.values())
+        if priority is None:
+            return sorted(items, key=lambda d: (-d.gap, d.layer, d.expert))
+        return sorted(items, key=lambda d: (-float(priority(d)), -d.gap,
+                                            d.layer, d.expert))
+
+    def repay(self, layer: int, expert: int, new_k: int) -> bool:
+        """Mark an expert as swapped up. True when it closed the deficit."""
+        with self._lock:
+            d = self._deficits.get((layer, expert))
+            if d is None:
+                return False
+            if new_k >= d.target_k:
+                del self._deficits[(layer, expert)]
+                self._failed.pop((layer, expert), None)
+                self._repaid += 1
+                return True
+            # partial progress up the ladder still counts
+            self._deficits[(layer, expert)] = Deficit(
+                layer, expert, new_k, d.target_k)
+            return False
+
+    def fail(self, layer: int, expert: int) -> int:
+        """Record a repay attempt that could not be satisfied."""
+        with self._lock:
+            n = self._failed.get((layer, expert), 0) + 1
+            self._failed[(layer, expert)] = n
+            return n
+
+    def give_up(self, max_attempts: int = 3) -> list[Deficit]:
+        """Deficits that have failed enough times to call unrepayable."""
+        with self._lock:
+            return [d for key, d in self._deficits.items()
+                    if self._failed.get(key, 0) >= max_attempts]
+
+    # -------------------------------------------------------------- telemetry
+    @property
+    def state(self) -> ConvergenceState:
+        with self._lock:
+            if self._deficits:
+                if self._failed and all(
+                        self._failed.get(k, 0) >= 3 for k in self._deficits):
+                    return ConvergenceState.STALLED
+                return ConvergenceState.CONVERGING
+            return (ConvergenceState.CONVERGED if self._started_dirty
+                    else ConvergenceState.PRISTINE)
+
+    @property
+    def pending_count(self) -> int:
+        with self._lock:
+            return len(self._deficits)
+
+    @property
+    def converged_ratio(self) -> float:
+        """Fraction of experts at or above target. 1.0 only when truly done."""
+        with self._lock:
+            if not self._total_experts:
+                return 1.0
+            return 1.0 - len(self._deficits) / self._total_experts
+
+    @property
+    def drift_bits(self) -> int:
+        """Total tier-steps still owed -- the headline 'how wrong is it now'.
+
+        Zero exactly when the served weights match the requested posture.
+        """
+        with self._lock:
+            return sum(d.gap for d in self._deficits.values())
+
+    def snapshot(self) -> dict:
+        """One dict for /fq/convergence, Prometheus and the boot log."""
+        with self._lock:
+            deficits = list(self._deficits.values())
+            total = self._total_experts
+            repaid = self._repaid
+            missing = len(self._missing)
+        state = self.state
+        by_layer: dict[int, int] = {}
+        for d in deficits:
+            by_layer[d.layer] = by_layer.get(d.layer, 0) + 1
+        return {
+            "state": state.value,
+            "is_final": state.is_final,
+            "experts_total": total,
+            "experts_pending": len(deficits),
+            "experts_repaid": repaid,
+            "experts_missing": missing,
+            "converged_ratio": round(self.converged_ratio, 6),
+            "drift_bits": self.drift_bits,
+            "k_min": self.k_min,
+            "k_max": self.k_max,
+            "layers_affected": len(by_layer),
+            "worst_layers": sorted(by_layer.items(),
+                                   key=lambda kv: -kv[1])[:8],
+        }
+
+    def describe(self) -> str:
+        s = self.snapshot()
+        if s["state"] == ConvergenceState.PRISTINE.value:
+            return (f"FQ convergence: PRISTINE — all {s['experts_total']} "
+                    f"experts at target")
+        return (
+            f"FQ convergence: {s['state'].upper()} — "
+            f"{s['experts_pending']}/{s['experts_total']} experts below "
+            f"target ({100 * s['converged_ratio']:.1f}% converged, "
+            f"drift={s['drift_bits']} tier-steps across "
+            f"{s['layers_affected']} layers). "
+            f"SERVED WEIGHTS ARE NOT FINAL.")

--- a/vllm/model_executor/layers/quantization/exl3_fungible/decision_log.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/decision_log.py
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Explainable decision records for fungible-quant swaps (M2 gate).
+
+`policy.decide()` stays a pure function; this module recomputes the same
+deterministic quantities to explain a decision after the fact — one
+structured record per interval answering WHEN and WHY for every swap
+(scores, ε-gap, routing mass, hysteresis ratio) and why candidates were
+NOT swapped (dwell/hysteresis/cap tallies). Emits:
+
+- one EPLB-style INFO line per interval (totals + budget state),
+- one INFO line per executed swap with its full rationale,
+- a JSON record for persistence beside the policy history
+  (store.PolicyStore.dump_stats-compatible), enabling the M2 "manual
+  review of explainable proposals" gate and post-hoc audit.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+import numpy as np
+
+from vllm.model_executor.layers.quantization.exl3_fungible import policy as P
+
+logger = logging.getLogger(__name__)
+
+
+def explain(
+    stats: dict,
+    eps: Any,
+    tier_of: Any,
+    swaps: list[tuple[int, int, int]],
+    *,
+    pins: Any = None,
+    dwell: Any = None,
+    cfg: dict | None = None,
+    step: int | None = None,
+    policy_sha_before: str | None = None,
+    policy_sha_after: str | None = None,
+) -> dict:
+    """Build the decision record for one interval.
+
+    Inputs mirror policy.decide(); ``swaps`` is decide()'s output for the
+    same inputs. All quantities recomputed here are byte-deterministic
+    reproductions of decide()'s internals.
+    """
+    full = dict(P.DEFAULT_CFG, **(cfg or {}))
+    s = P.score(stats, eps, cfg)
+    tier_of = np.asarray(tier_of)
+    L, E = tier_of.shape
+    count = np.asarray(stats["count"], dtype=np.float64)
+    mass = np.asarray(stats["mass"], dtype=np.float64)
+    e3, e4 = P._as_eps(eps, L, E)
+    h = float(full.get("hysteresis", P.DEFAULT_CFG["hysteresis"]))
+
+    swap_records = []
+    for layer, e_out, e_in in swaps:
+        swap_records.append({
+            "layer": int(layer), "expert_out": int(e_out),
+            "expert_in": int(e_in),
+            "score_in": float(s[layer, e_in]),
+            "score_out": float(s[layer, e_out]),
+            "score_gap": float(s[layer, e_in] - s[layer, e_out]),
+            "hysteresis_ratio": (
+                float(s[layer, e_in] / s[layer, e_out])
+                if s[layer, e_out] > 0 else float("inf")),
+            "eps_gap_in": float(e3[layer, e_in] - e4[layer, e_in]),
+            "eps_gap_out": float(e3[layer, e_out] - e4[layer, e_out]),
+            "count_in": float(count[layer, e_in]),
+            "count_out": float(count[layer, e_out]),
+            "mass_in": float(mass[layer, e_in]),
+            "mass_out": float(mass[layer, e_out]),
+        })
+
+    # Why-not tallies: candidates that the guards held back, recomputed
+    # with decide()'s exact ordering semantics.
+    dwell_ok = (np.ones((L, E), bool) if dwell is None
+                else np.asarray(dwell) >= full["dwell_steps"])
+    blocked = {"dwell": 0, "hysteresis": 0, "layer_cap": 0}
+    per_layer_pairs = {}
+    for l in range(L):
+        cur = tier_of[l] == P.K4
+        n_k4 = int(cur.sum())
+        order = np.lexsort((np.arange(E), -s[l]))
+        desired = np.zeros(E, bool)
+        desired[order[:n_k4]] = True
+        enter = sorted(np.nonzero(desired & ~cur)[0], key=lambda e: (-s[l, e], e))
+        leave = sorted(np.nonzero(cur & ~desired)[0], key=lambda e: (s[l, e], e))
+        eligible = 0
+        for e_in, e_out in zip(enter, leave):
+            if not dwell_ok[l, e_in] or not dwell_ok[l, e_out]:
+                blocked["dwell"] += 1
+                continue
+            if not (s[l, e_in] > h * s[l, e_out]):
+                blocked["hysteresis"] += 1
+                continue
+            eligible += 1
+        executed = sum(1 for (ll, _, _) in swaps if ll == l)
+        blocked["layer_cap"] += max(0, eligible - executed)
+        if eligible or executed:
+            per_layer_pairs[str(l)] = {"eligible": eligible, "executed": executed}
+
+    record = {
+        "schema": "fq-decision/1",
+        "step": step,
+        "policy_sha_before": policy_sha_before,
+        "policy_sha_after": policy_sha_after,
+        "config": {k: full[k] for k in
+                   ("hysteresis", "dwell_steps", "max_swaps_per_layer",
+                    "max_swaps_total") if k in full},
+        "swaps": swap_records,
+        "blocked": blocked,
+        "per_layer": per_layer_pairs,
+        "totals": {"executed": len(swaps),
+                   "layers_touched": len({sw[0] for sw in swaps})},
+    }
+    return record
+
+
+def log_decision(record: dict) -> None:
+    """Emit the EPLB-style interval line + one line per swap."""
+    t, b = record["totals"], record["blocked"]
+    logger.info(
+        "FQ interval step=%s: %d swaps across %d layers "
+        "(blocked: dwell=%d hysteresis=%d cap=%d) policy %s -> %s",
+        record.get("step"), t["executed"], t["layers_touched"],
+        b["dwell"], b["hysteresis"], b["layer_cap"],
+        (record.get("policy_sha_before") or "?")[:8],
+        (record.get("policy_sha_after") or "?")[:8])
+    for sw in record["swaps"]:
+        logger.info(
+            "FQ swap L%d: K3->K4 e%d (score %.3e, eps_gap %.3e, mass %.1f) "
+            "displaces e%d (score %.3e) ratio=%.2f",
+            sw["layer"], sw["expert_in"], sw["score_in"], sw["eps_gap_in"],
+            sw["mass_in"], sw["expert_out"], sw["score_out"],
+            sw["hysteresis_ratio"])
+
+
+def to_json(record: dict) -> str:
+    return json.dumps(record, sort_keys=True, separators=(",", ":"))

--- a/vllm/model_executor/layers/quantization/exl3_fungible/fragments.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/fragments.py
@@ -84,6 +84,7 @@ import mmap
 import os
 import re
 import struct
+import threading
 import time
 import warnings
 from dataclasses import dataclass, field
@@ -607,6 +608,78 @@ class HfSource:
             f"{self._RETRIES} attempts: {type(last).__name__}: {last}")
 
 
+
+class _DownloadMonitor:
+    """Aggregate download progress for the boot log.
+
+    hf_hub_download gives us ONE completion callback, not incremental ones, so
+    the primary fetch path was a silent log -- exactly the "staring at a log
+    that is not progressing" problem the per-file progress was meant to solve,
+    just moved. Rather than reach into hub internals for per-file byte counts,
+    watch the .incomplete files the client leaves in the cache and report the
+    aggregate. For an operator that is the better line anyway: four ranks
+    times several objects would interleave into noise, while one line answers
+    "is it moving, how fast, how many in flight".
+    """
+
+    _instance = None
+    _lock = threading.Lock()
+
+    def __init__(self, root: Path, every: float = 15.0):
+        self.root = Path(root)
+        self.every = every
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    @classmethod
+    def ensure(cls, root: Path) -> "_DownloadMonitor":
+        with cls._lock:
+            if cls._instance is None:
+                cls._instance = cls(root)
+                cls._instance.start()
+            return cls._instance
+
+    def start(self) -> None:
+        if self._thread is not None:
+            return
+        self._thread = threading.Thread(
+            target=self._run, name="fq-dl-monitor", daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+
+    def _scan(self) -> tuple[int, int]:
+        total = count = 0
+        try:
+            for f in self.root.rglob("*.incomplete"):
+                try:
+                    total += f.stat().st_size
+                    count += 1
+                except OSError:
+                    continue
+        except OSError:
+            pass
+        return total, count
+
+    def _run(self) -> None:
+        prev, t_prev = self._scan()[0], time.monotonic()
+        cumulative = 0
+        while not self._stop.wait(self.every):
+            cur, n = self._scan()
+            now = time.monotonic()
+            delta, dt = cur - prev, max(now - t_prev, 1e-9)
+            if n == 0 and delta <= 0:
+                prev, t_prev = cur, now
+                continue
+            if delta > 0:
+                cumulative += delta
+            logger.info(
+                "FQ downloads: %d in flight, %.1f GiB this boot, %.0f MiB/s",
+                n, cumulative / (1 << 30), max(delta, 0) / dt / (1 << 20))
+            prev, t_prev = cur, now
+
+
 class FragmentResolver:
     """Resolve (layer, expert, K) fragments: local dirs -> sources -> error.
 
@@ -1019,6 +1092,7 @@ class FragmentResolver:
                 got = getattr(source, "prefetch_whole", None)
                 if got is None:
                     continue           # local dirs need no prefetch
+                _DownloadMonitor.ensure(dest.parent)
 
                 def _report(done, total, rate, _f=entry.file, _l=layer,
                             _k=k):

--- a/vllm/model_executor/layers/quantization/exl3_fungible/fragments.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/fragments.py
@@ -468,21 +468,74 @@ class HfSource:
     # Deliberately NOT automatic: a layer that needs a single K4 expert would
     # otherwise drag ~2.5 GB to use ~9 MB. The caller asks, because only the
     # caller knows the policy.
-    def prefetch_whole(self, relpath: str, dest: "Path") -> "Path | None":
-        """Fetch an entire segment once into ``dest``; return it, or None."""
+    def prefetch_whole(self, relpath: str, dest: "Path",
+                       progress=None) -> "Path | None":
+        """Fetch an entire segment once; return a readable path, or None.
+
+        Prefers ``huggingface_hub.hf_hub_download`` when available: it brings
+        connection reuse, resume, Xet dedup and — with ``hf_transfer``
+        installed — parallel chunked transfer, none of which a single urllib
+        stream gets. We only use ``hf_hub_url`` for URL construction on the
+        RANGED path (arbitrary byte ranges are outside what hf_hub_download
+        offers), but a whole-file pull is exactly its job.
+
+        It also returns a path in the HF cache, which we use in place rather
+        than copying: a 2.5 GB segment should not exist twice on disk.
+        """
         import shutil
         import tempfile
         if dest.exists() and dest.stat().st_size > 0:
             return dest
+        if self.offline():
+            return None
+        if os.environ.get("FQ_PREFETCH_VIA_HF", "1") == "1":
+            try:
+                from huggingface_hub import hf_hub_download
+                token = (os.environ.get("HF_TOKEN")
+                         or os.environ.get("HUGGING_FACE_HUB_TOKEN"))
+                path = hf_hub_download(
+                    repo_id=self.repo_id, filename=relpath,
+                    revision=self.revision, token=token)
+                got = Path(path)
+                if got.exists() and got.stat().st_size > 0:
+                    if progress is not None:
+                        sz = got.stat().st_size
+                        progress(sz, sz, float("inf"))
+                    return got          # use the HF cache copy in place
+            except Exception:  # noqa: BLE001 — fall back to the urllib path
+                logger.debug("hf_hub_download unavailable for %s; "
+                             "falling back to a plain stream", relpath,
+                             exc_info=True)
         dest.parent.mkdir(parents=True, exist_ok=True)
         tmp = None
         try:
             with self._open(relpath, {}) as r:
+                total = int(r.headers.get("Content-Length") or 0)
                 fd, tmpname = tempfile.mkstemp(dir=str(dest.parent),
                                                suffix=".part")
                 tmp = Path(tmpname)
+                # Copy in chunks with periodic progress instead of one opaque
+                # copyfileobj. A 2.5 GB segment is minutes of a silent log,
+                # and an operator staring at a stalled-looking boot cannot
+                # tell a slow download from a hung one.
+                import time as _t
+                t0 = _t.monotonic()
+                done = 0
+                nxt = 256 << 20          # report every 256 MiB
                 with open(fd, "wb") as fh:
-                    shutil.copyfileobj(r, fh, length=8 << 20)
+                    while True:
+                        chunk = r.read(8 << 20)
+                        if not chunk:
+                            break
+                        fh.write(chunk)
+                        done += len(chunk)
+                        if progress is not None and done >= nxt:
+                            el = max(_t.monotonic() - t0, 1e-9)
+                            progress(done, total, done / el)
+                            nxt += 256 << 20
+                if progress is not None:
+                    el = max(_t.monotonic() - t0, 1e-9)
+                    progress(done, total or done, done / el)
             tmp.replace(dest)          # atomic: a torn file must never be read
             tmp = None
             return dest
@@ -949,7 +1002,17 @@ class FragmentResolver:
                 got = getattr(source, "prefetch_whole", None)
                 if got is None:
                     continue           # local dirs need no prefetch
-                path = got(entry.file, dest)
+
+                def _report(done, total, rate, _f=entry.file, _l=layer,
+                            _k=k):
+                    pct = (100.0 * done / total) if total else 0.0
+                    logger.info(
+                        "FQ fetch L%d K%d %s: %.1f/%.1f GiB (%.0f%%) at "
+                        "%.0f MiB/s", _l, _k, _f,
+                        done / (1 << 30), (total or done) / (1 << 30), pct,
+                        rate / (1 << 20))
+
+                path = got(entry.file, dest, _report)
                 if path is not None:
                     self._prefetched[(layer, k)] = path
                     self.stats["segments_prefetched"] += 1

--- a/vllm/model_executor/layers/quantization/exl3_fungible/fragments.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/fragments.py
@@ -21,15 +21,47 @@ Local segment-dir reads are trusted by default (``VLLM_FQ_VERIFY=fetched``);
 ``VLLM_FQ_VERIFY=all`` extends verification to local reads, ``off`` disables
 it (fetching without an attestation then becomes possible).
 
+Operator knobs (this milestone):
+
+* ``VLLM_FQ_SOURCES`` — ordered comma list of ``repo_id[@revision]`` source
+  specs; ``VLLM_FQ_SOURCES_MODE`` = ``prepend`` (default) | ``replace`` |
+  ``append`` relative to the manifest ``sources`` chain.  Local segment dirs
+  always resolve first; each source keeps its own index / attestation fetch
+  and cache.
+* Trust filtering (10 §4): ``VLLM_FQ_TRUST_SIGNERS`` — comma list of hex
+  ed25519 pubkeys (default: the manifest ``signer_pubkey``); when any signer
+  is configured, a fragment is accepted from a source only if one of the
+  source's attestation lines for that layer/K carries a valid signature by
+  an allowed signer (countersignatures: ANY allowed line accepts) AND its
+  predicate is in ``VLLM_FQ_TRUST_PREDICATES`` (default
+  ``repack-of,encode-of,derived-from``).  With no signer configured the
+  legacy sha-only behavior applies.  Integrity sha checks stay unconditional.
+* ``VLLM_FQ_K_FALLBACK`` — comma-ordered substitute Ks tried per miss (e.g.
+  ``3``: if K4 is unavailable/untrusted, load the K3 fragment instead).  The
+  returned :class:`Fragment` records both ``k`` (actually loaded) and
+  ``requested_k``; every substitution/miss is enqueued on the persisted
+  lazy-encode queue (:mod:`.lazy_encode`).  Boot never blocks on encodes.
+
+Every :meth:`FragmentResolver.resolve` emits one structured decision line
+(INFO on substitution/fallback, DEBUG on plain success, WARNING on failure)::
+
+    FQ resolve L17/e204 K4: local(2 dirs) MISS; hf:repoA@ab12 REJECT
+    predicate=repack-of not-trusted; hf:repoB@cd34 REJECT sha-mismatch;
+    FALLBACK K3 hf:repoC@ee55 ACCEPT (encode queued #3)
+
+and accumulates per-reason counters in ``resolver.stats``.
+
 This module is deliberately stdlib-only at import time; torch is imported
 lazily inside :meth:`FragmentResolver.expert_tensors` so the resolver core
-stays testable on CPU without a built vllm.
+stays testable on CPU without a built vllm.  Signature verification imports
+PyNaCl or ``cryptography`` lazily, only when trust filtering is active.
 """
 from __future__ import annotations
 
 import base64
 import hashlib
 import json
+import logging
 import mmap
 import os
 import re
@@ -39,12 +71,20 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable
 
+logger = logging.getLogger(__name__)
+
 FQ_CACHE_ENV = "VLLM_FQ_CACHE"
 FQ_VERIFY_ENV = "VLLM_FQ_VERIFY"
 FQ_SOURCES_ENV = "VLLM_FQ_SOURCES"
+FQ_SOURCES_MODE_ENV = "VLLM_FQ_SOURCES_MODE"
 FQ_LOCAL_SEGMENTS_ENV = "VLLM_FQ_LOCAL_SEGMENTS"
+FQ_TRUST_PREDICATES_ENV = "VLLM_FQ_TRUST_PREDICATES"
+FQ_TRUST_SIGNERS_ENV = "VLLM_FQ_TRUST_SIGNERS"
+FQ_K_FALLBACK_ENV = "VLLM_FQ_K_FALLBACK"
 
 DEFAULT_CACHE_DIR = "~/.cache/vllm/fq"
+DEFAULT_TRUST_PREDICATES = ("repack-of", "encode-of", "derived-from")
+SOURCES_MODES = ("prepend", "replace", "append")
 
 EXPERT_RE = re.compile(
     r"^model\.layers\.(\d+)\.mlp\.experts\.(\d+)\.(\w+_proj)\.rank(\d+)\.(\w+)$"
@@ -65,8 +105,9 @@ _ST_TO_TORCH_NAME = {
 
 
 class FragmentUnavailableError(RuntimeError):
-    """No local dir or source could supply the fragment (T3 encode is out
-    of scope for loader v2)."""
+    """No local dir, cache entry, trusted source, or fallback K could supply
+    the fragment; the miss is enqueued for lazy encode (:mod:`.lazy_encode`)
+    before this is raised."""
 
 
 class FragmentVerificationError(RuntimeError):
@@ -97,16 +138,91 @@ def _attestation_expert_shas(text: str) -> dict[str, str]:
     Signature verification is a trust-policy concern (10 §4, VLLM_FQ_TRUST)
     and lands with the trust-list milestone; content addressing only needs
     the payload."""
-    for line in text.splitlines():
-        line = line.strip()
-        if not line:
-            continue
-        envelope = json.loads(line)
-        payload = json.loads(base64.b64decode(envelope["payload"]))
+    for _env, _raw, payload in _attestation_lines(text):
         shas = payload.get("expert_sha256")
         if isinstance(shas, dict):
             return shas
     return {}
+
+
+def _attestation_lines(text: str):
+    """Yield ``(envelope, raw_payload_bytes, payload)`` per parseable line."""
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            envelope = json.loads(line)
+            raw = base64.b64decode(envelope["payload"])
+            payload = json.loads(raw)
+        except (ValueError, KeyError, TypeError):
+            continue
+        yield envelope, raw, payload
+
+
+def _verify_ed25519(pubkey_hex: str, message: bytes, signature: bytes) -> bool:
+    """Verify an ed25519 signature; PyNaCl if present, else cryptography."""
+    try:
+        key = bytes.fromhex(pubkey_hex)
+    except ValueError:
+        return False
+    if len(key) != 32:
+        return False
+    try:
+        from nacl.exceptions import BadSignatureError
+        from nacl.signing import VerifyKey
+    except ImportError:
+        pass
+    else:
+        try:
+            VerifyKey(key).verify(message, signature)
+            return True
+        except BadSignatureError:
+            return False
+    try:
+        from cryptography.exceptions import InvalidSignature
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+            Ed25519PublicKey,
+        )
+    except ImportError as exc:
+        raise RuntimeError(
+            "attestation trust filtering needs PyNaCl or cryptography for "
+            "ed25519 verification"
+        ) from exc
+    try:
+        Ed25519PublicKey.from_public_bytes(key).verify(signature, message)
+        return True
+    except (InvalidSignature, ValueError):
+        return False
+
+
+def _safe_source_key(name: str) -> str:
+    """Filesystem-safe per-source cache subdir name."""
+    return re.sub(r"[^A-Za-z0-9._@-]+", "_", name)
+
+
+def _load_lazy_encode():
+    """Import .lazy_encode (package or standalone-file fallback)."""
+    try:
+        from vllm.model_executor.layers.quantization.exl3_fungible import (
+            lazy_encode,
+        )
+
+        return lazy_encode
+    except ImportError:
+        import importlib.util as _ilu
+        import sys as _sys
+
+        name = "fq_lazy_encode_standalone"
+        if name in _sys.modules:
+            return _sys.modules[name]
+        spec = _ilu.spec_from_file_location(
+            name, Path(__file__).resolve().parent / "lazy_encode.py"
+        )
+        mod = _ilu.module_from_spec(spec)
+        _sys.modules[name] = mod
+        spec.loader.exec_module(mod)
+        return mod
 
 
 @dataclass(frozen=True)
@@ -122,7 +238,13 @@ class FragmentTensor:
 
 @dataclass
 class Fragment:
-    """A resolved per-expert payload plus its tensor table."""
+    """A resolved per-expert payload plus its tensor table.
+
+    ``k`` is the ACTUALLY loaded bitrate; when the fallback ladder
+    substituted a different K, ``requested_k`` records what the caller asked
+    for and :attr:`substituted` is True — callers must thread ``k`` (not
+    ``requested_k``) into tier maps / bits digests so metadata reflects
+    reality."""
 
     layer: int
     expert: int
@@ -131,6 +253,11 @@ class Fragment:
     tensors: list[FragmentTensor]
     origin: str  # "local" | "cache" | "fetched"
     sha256: str | None = None
+    requested_k: int | None = None
+
+    @property
+    def substituted(self) -> bool:
+        return self.requested_k is not None and self.requested_k != self.k
 
 
 class _SegmentIndexEntry:
@@ -292,7 +419,9 @@ class FragmentResolver:
         verify: str | None = None,
         source_factory: Callable[[str], Any] = HfSource,
         environ: dict[str, str] = os.environ,  # noqa: B008
+        encode_queue: Any = None,
     ):
+        self._environ = environ
         self.manifest_dir = Path(manifest_dir)
         manifest_path = self.manifest_dir / "fq-manifest.json"
         self.manifest: dict = (
@@ -322,16 +451,69 @@ class FragmentResolver:
         if sources is not None:
             self.sources = list(sources)
         else:
-            specs = environ.get(FQ_SOURCES_ENV)
-            if specs is not None:
-                raw = [s for s in specs.split(",") if s]
-            else:
-                raw = [
-                    s
-                    for s in self.manifest.get("sources", ())
-                    if isinstance(s, str) and not s.startswith("local:")
-                ]
-            self.sources = [source_factory(spec) for spec in raw]
+            manifest_specs = [
+                s
+                for s in self.manifest.get("sources", ())
+                if isinstance(s, str) and not s.startswith("local:")
+            ]
+            env_raw = environ.get(FQ_SOURCES_ENV)
+            env_specs = (
+                [s.strip() for s in env_raw.split(",") if s.strip()]
+                if env_raw is not None
+                else None
+            )
+            mode = (environ.get(FQ_SOURCES_MODE_ENV) or "prepend").lower()
+            if mode not in SOURCES_MODES:
+                raise ValueError(
+                    f"{FQ_SOURCES_MODE_ENV} must be one of {SOURCES_MODES}, "
+                    f"got {mode!r}"
+                )
+            if env_specs is None:
+                raw = manifest_specs
+            elif mode == "replace":
+                raw = env_specs
+            elif mode == "append":
+                raw = manifest_specs + env_specs
+            else:  # prepend (default)
+                raw = env_specs + manifest_specs
+            seen_specs: set[str] = set()
+            deduped: list[str] = []
+            for spec in raw:
+                key = spec.removeprefix("hf:")
+                if key not in seen_specs:
+                    seen_specs.add(key)
+                    deduped.append(spec)
+            self.sources = [source_factory(spec) for spec in deduped]
+
+        # -- trust policy (10 §4): active only when trust anchors exist
+        preds_raw = environ.get(FQ_TRUST_PREDICATES_ENV)
+        self.trust_predicates: tuple[str, ...] = (
+            tuple(p.strip() for p in preds_raw.split(",") if p.strip())
+            if preds_raw is not None
+            else DEFAULT_TRUST_PREDICATES
+        )
+        signers_raw = environ.get(FQ_TRUST_SIGNERS_ENV)
+        if signers_raw is not None:
+            signers = [s.strip().lower() for s in signers_raw.split(",") if s.strip()]
+        else:
+            manifest_key = self.manifest.get("signer_pubkey")
+            signers = [str(manifest_key).lower()] if manifest_key else []
+        self.trust_signers = frozenset(signers)
+        self.trust_enabled = bool(self.trust_signers)
+
+        # -- lazy-encode fallback ladder
+        fallback_raw = environ.get(FQ_K_FALLBACK_ENV) or ""
+        try:
+            self.k_fallback: tuple[int, ...] = tuple(
+                int(part) for part in fallback_raw.split(",") if part.strip()
+            )
+        except ValueError as exc:
+            raise ValueError(
+                f"{FQ_K_FALLBACK_ENV} must be a comma list of Ks, got "
+                f"{fallback_raw!r}"
+            ) from exc
+        self._encode_queue = encode_queue
+        self._encode_queue_ready = encode_queue is not None
 
         self.stats = {
             "local": 0,
@@ -340,11 +522,29 @@ class FragmentResolver:
             "verified": 0,
             "sha_mismatch": 0,
             "bytes_fetched": 0,
+            # decision counters (this milestone)
+            "source_miss": 0,
+            "source_error": 0,
+            "reject_predicate": 0,
+            "reject_signer": 0,
+            "reject_signature": 0,
+            "reject_no_attestation": 0,
+            "reject_no_expert_sha": 0,
+            "reject_sha_mismatch": 0,
+            "fallback_substituted": 0,
+            "encode_queued": 0,
+            "unavailable": 0,
         }
         # (dir, layer, k) -> _LocalSegment | None
         self._local_segments: dict[tuple[Path, int, int], _LocalSegment | None] = {}
-        # (layer, k) -> {expert_str: sha}
-        self._expert_shas: dict[tuple[int, int], dict[str, str]] = {}
+        # (layer, k) -> {expert_str: sha} from LOCAL dirs only
+        self._local_sha_maps: dict[tuple[int, int], dict[str, str]] = {}
+        # (source_name, layer, k) -> attestation text | None (None=definitive)
+        self._att_texts: dict[tuple[str, int, int], str | None] = {}
+        # (source_name, layer, k) -> (shas | None, reject reason | None)
+        self._att_evals: dict[
+            tuple[str, int, int], tuple[dict[str, str] | None, str | None]
+        ] = {}
         # (source_name, k) -> index dict | None
         self._remote_indexes: dict[tuple[str, int], dict | None] = {}
         # file_sha -> (header, tables-by-expert)
@@ -377,9 +577,10 @@ class FragmentResolver:
         self._local_segments[key] = seg
         return seg
 
-    def _expected_sha(self, layer: int, k: int, expert: int) -> str | None:
+    def _local_shas(self, layer: int, k: int) -> dict[str, str]:
+        """Per-expert sha map from the LOCAL segment dirs' attestations."""
         key = (layer, k)
-        shas = self._expert_shas.get(key)
+        shas = self._local_sha_maps.get(key)
         if shas is None:
             shas = {}
             for base in self.local_dirs:
@@ -387,12 +588,161 @@ class FragmentResolver:
                 if p.exists():
                     shas = _attestation_expert_shas(p.read_text())
                     break
-            else:
-                cached = self._cache_path("attestations", f"layer-{layer:03d}.k{k}.jsonl")
-                if cached.exists():
-                    shas = _attestation_expert_shas(cached.read_text())
-            self._expert_shas[key] = shas
-        return shas.get(str(expert))
+            self._local_sha_maps[key] = shas
+        return shas
+
+    # ------------------------------------------------- per-source trust
+
+    def _source_att_text(
+        self, source: Any, layer: int, k: int, *, fetch: bool = True
+    ) -> str | None:
+        """Attestation jsonl of one source (memo -> disk cache -> fetch)."""
+        name = getattr(source, "name", str(source))
+        key = (name, layer, k)
+        if key in self._att_texts:
+            return self._att_texts[key]
+        path = self._cache_path(
+            "attestations",
+            f"{_safe_source_key(name)}/layer-{layer:03d}.k{k}.jsonl",
+        )
+        if path.exists():
+            text = path.read_text()
+            self._att_texts[key] = text
+            return text
+        if not fetch:
+            return None  # unknown, not definitive: don't memoize
+        text = source.read_text(self._att_name(layer, k))
+        if text is not None:
+            self._atomic_write(path, text.encode())
+        self._att_texts[key] = text
+        return text
+
+    def _evaluate_attestation(
+        self, text: str
+    ) -> tuple[dict[str, str] | None, str | None]:
+        """(expert sha map, None) if some line is trusted, else (None, why).
+
+        Trust disabled: any line with an ``expert_sha256`` payload counts
+        (legacy sha-only behavior).  Trust enabled: a line counts only when
+        its ed25519 signature verifies under an allowed signer AND its
+        predicate is trusted; with multiple lines (countersignatures), ANY
+        allowed line accepts the fragment."""
+        if not self.trust_enabled:
+            shas = _attestation_expert_shas(text)
+            return (shas, None) if shas else (None, "no-attestation")
+        reasons: list[str] = []
+        for envelope, raw, payload in _attestation_lines(text):
+            keyid = str(envelope.get("keyid", "")).lower()
+            predicate = str(payload.get("predicate", "?"))
+            if keyid not in self.trust_signers:
+                reasons.append("signer not-trusted")
+                continue
+            try:
+                signature = base64.b64decode(envelope.get("signature") or "")
+            except (ValueError, TypeError):
+                signature = b""
+            if not _verify_ed25519(keyid, raw, signature):
+                reasons.append("bad-signature")
+                continue
+            if predicate not in self.trust_predicates:
+                reasons.append(f"predicate={predicate} not-trusted")
+                continue
+            shas = payload.get("expert_sha256")
+            if isinstance(shas, dict) and shas:
+                return shas, None
+            reasons.append("no-expert-sha")
+        for prefix in ("predicate=", "bad-signature", "signer not-trusted"):
+            for reason in reasons:
+                if reason.startswith(prefix):
+                    return None, reason
+        return None, (reasons[0] if reasons else "no-attestation")
+
+    _REASON_COUNTERS = (
+        ("predicate=", "reject_predicate"),
+        ("signer not-trusted", "reject_signer"),
+        ("bad-signature", "reject_signature"),
+        ("no-attestation", "reject_no_attestation"),
+        ("no-expert-sha", "reject_no_expert_sha"),
+        ("sha-mismatch", "reject_sha_mismatch"),
+    )
+
+    def _count_reject(self, reason: str) -> None:
+        for prefix, counter in self._REASON_COUNTERS:
+            if reason.startswith(prefix):
+                self.stats[counter] += 1
+                return
+
+    def _att_decision(
+        self, source: Any, layer: int, k: int, *, fetch: bool = True
+    ) -> tuple[dict[str, str] | None, str | None]:
+        """Memoized trust decision for one source's (layer, k) attestation."""
+        name = getattr(source, "name", str(source))
+        key = (name, layer, k)
+        if key in self._att_evals:
+            return self._att_evals[key]
+        text = self._source_att_text(source, layer, k, fetch=fetch)
+        if text is None:
+            decision: tuple[dict[str, str] | None, str | None] = (
+                None,
+                "no-attestation",
+            )
+            if fetch:  # definitive: the source has none
+                self._att_evals[key] = decision
+            return decision
+        decision = self._evaluate_attestation(text)
+        self._att_evals[key] = decision
+        return decision
+
+    def _cache_expected_sha(self, layer: int, k: int, expert: int) -> str | None:
+        """Expected sha for the content-addressed cache step: local dirs
+        first, then already-cached (disk) per-source attestations that pass
+        the trust filter — never the network."""
+        sha = self._local_shas(layer, k).get(str(expert))
+        if sha:
+            return sha
+        for source in self.sources:
+            try:
+                shas, _reason = self._att_decision(
+                    source, layer, k, fetch=False
+                )
+            except Exception:  # noqa: BLE001 — cache probing is best-effort
+                continue
+            if shas:
+                sha = shas.get(str(expert))
+                if sha:
+                    return sha
+        return None
+
+    # -------------------------------------------------- lazy-encode queue
+
+    def _get_encode_queue(self) -> Any:
+        if not self._encode_queue_ready:
+            self._encode_queue_ready = True
+            try:
+                self._encode_queue = _load_lazy_encode().EncodeQueue.from_env(
+                    self._environ, cache_dir=self.cache_dir
+                )
+            except Exception:  # noqa: BLE001 — queue is telemetry, not boot
+                logger.warning(
+                    "FQ lazy-encode queue unavailable", exc_info=True
+                )
+                self._encode_queue = None
+        return self._encode_queue
+
+    def _enqueue_encode(
+        self, layer: int, expert: int, k: int, reason: str
+    ) -> tuple[int | None, bool]:
+        queue = self._get_encode_queue()
+        if queue is None:
+            return None, False
+        try:
+            position, created = queue.enqueue(layer, expert, k, reason)
+        except Exception:  # noqa: BLE001 — never block resolution on the queue
+            logger.warning("FQ lazy-encode enqueue failed", exc_info=True)
+            return None, False
+        if created:
+            self.stats["encode_queued"] += 1
+        return position, created
 
     def _cache_path(self, kind: str, name: str) -> Path:
         return self.cache_dir / kind / name
@@ -422,58 +772,154 @@ class FragmentResolver:
     # ------------------------------------------------------------ resolve
 
     def resolve(self, layer: int, expert: int, k: int) -> Fragment:
+        """Resolve one fragment through local dirs -> cache -> sources, then
+        the ``VLLM_FQ_K_FALLBACK`` ladder; emits one decision line per call
+        and enqueues a lazy encode on every substitution/miss."""
+        chain: list[str] = []
+        errors: list[Exception] = []
+        fragment = self._resolve_k(layer, expert, k, chain, errors)
+
+        substituted = False
+        if fragment is None:
+            for fallback_k in self.k_fallback:
+                if fallback_k == k:
+                    continue
+                mark = len(chain)
+                fragment = self._resolve_k(
+                    layer, expert, fallback_k, chain, errors
+                )
+                if len(chain) > mark:  # merge the marker into the attempt
+                    chain[mark] = f"FALLBACK K{fallback_k} {chain[mark]}"
+                else:
+                    chain.append(f"FALLBACK K{fallback_k}")
+                if fragment is not None:
+                    substituted = True
+                    break
+
+        queue_note = ""
+        if fragment is None or substituted:
+            reason = (
+                f"substituted-with-k{fragment.k}"
+                if substituted
+                else "unavailable"
+            )
+            position, created = self._enqueue_encode(layer, expert, k, reason)
+            if position is not None:
+                queue_note = (
+                    f" (encode queued #{position})"
+                    if created
+                    else " (encode already queued)"
+                )
+
+        if fragment is not None:
+            fragment.requested_k = k
+            if substituted:
+                self.stats["fallback_substituted"] += 1
+                chain[-1] += queue_note
+                self._log_chain(logging.INFO, layer, expert, k, chain)
+            else:
+                self._log_chain(logging.DEBUG, layer, expert, k, chain)
+            return fragment
+
+        self.stats["unavailable"] += 1
+        chain.append(f"UNAVAILABLE{queue_note}")
+        self._log_chain(logging.WARNING, layer, expert, k, chain)
+        if errors:
+            raise errors[0]
+        raise FragmentUnavailableError(
+            f"layer {layer} expert {expert} k{k}: {'; '.join(chain)} "
+            f"(local dirs: {[str(d) for d in self.local_dirs]}; extend "
+            f"{FQ_SOURCES_ENV} / {FQ_K_FALLBACK_ENV} or drain the "
+            "lazy-encode queue)"
+        )
+
+    @staticmethod
+    def _log_chain(
+        level: int, layer: int, expert: int, k: int, chain: list[str]
+    ) -> None:
+        logger.log(
+            level,
+            "FQ resolve L%d/e%d K%d: %s",
+            layer,
+            expert,
+            k,
+            "; ".join(chain),
+        )
+
+    def _resolve_k(
+        self,
+        layer: int,
+        expert: int,
+        k: int,
+        chain: list[str],
+        errors: list[Exception],
+    ) -> Fragment | None:
+        """One K's attempt chain: local dirs -> fragment cache -> sources.
+
+        Appends one decision segment per attempt to ``chain``; verification
+        failures are recorded in ``errors`` (re-raised by resolve() only if
+        nothing else accepts) so one bad mirror cannot mask a good one."""
         # 1. local segment dirs
         for base in self.local_dirs:
             seg = self._local_segment(base, layer, k)
-            if seg is None:
+            if seg is None or expert not in seg.tables:
                 continue
             payload, tensors = seg.fragment(expert)
             sha = None
             if self.verify == "all":
-                sha = self._check_sha(
-                    payload,
-                    self._expected_sha(layer, k, expert),
-                    f"local {seg.path.name} expert {expert}",
-                )
+                try:
+                    sha = self._check_sha(
+                        payload,
+                        self._local_shas(layer, k).get(str(expert)),
+                        f"local {seg.path.name} expert {expert}",
+                    )
+                except FragmentVerificationError as exc:
+                    chain.append("local REJECT sha-mismatch")
+                    self._count_reject("sha-mismatch")
+                    errors.append(exc)
+                    return None
             self.stats["local"] += 1
+            chain.append("local ACCEPT")
             return Fragment(layer, expert, k, payload, tensors, "local", sha)
+        chain.append(f"local({len(self.local_dirs)} dirs) MISS")
 
-        # 2. fragment cache (content-addressed by expected sha)
-        expected = self._expected_sha(layer, k, expert)
+        # 2. fragment cache (content-addressed by trusted expected sha)
+        expected = self._cache_expected_sha(layer, k, expert)
         if expected is not None:
             cached = self._cache_fragment_path(expected)
             if cached.exists():
                 payload = cached.read_bytes()
-                self._check_sha(
-                    payload, expected, f"cache {cached.name} expert {expert}"
-                )
-                tensors = self._tensor_table_for(layer, expert, k)
-                if tensors is not None:
-                    self.stats["cache"] += 1
-                    return Fragment(
-                        layer, expert, k, payload, tensors, "cache", expected
+                try:
+                    self._check_sha(
+                        payload,
+                        expected,
+                        f"cache {cached.name} expert {expert}",
                     )
+                except FragmentVerificationError as exc:
+                    chain.append("cache REJECT sha-mismatch")
+                    self._count_reject("sha-mismatch")
+                    errors.append(exc)
+                else:
+                    tensors = self._tensor_table_for(layer, expert, k)
+                    if tensors is not None:
+                        self.stats["cache"] += 1
+                        chain.append("cache ACCEPT")
+                        return Fragment(
+                            layer, expert, k, payload, tensors, "cache",
+                            expected,
+                        )
 
         # 3. sources chain
-        errors: list[str] = []
         for source in self.sources:
-            try:
-                fragment = self._fetch(source, layer, expert, k)
-            except FragmentVerificationError:
-                raise
-            except Exception as exc:  # noqa: BLE001 — try the next mirror
-                errors.append(f"{getattr(source, 'name', source)}: {exc}")
-                continue
+            fragment, segment, error = self._try_source(
+                source, layer, expert, k
+            )
+            chain.append(segment)
+            if error is not None:
+                errors.append(error)
             if fragment is not None:
                 return fragment
-            errors.append(f"{getattr(source, 'name', source)}: not found")
-
-        raise FragmentUnavailableError(
-            f"layer {layer} expert {expert} k{k}: no local segment dir has it "
-            f"({[str(d) for d in self.local_dirs]}), sources exhausted "
-            f"({errors or 'none configured'}); local encode from BF16 (T3) is "
-            "not implemented in loader v2"
-        )
+        return None
 
     def _remote_index(self, source: Any, k: int) -> dict | None:
         key = (source.name, k)
@@ -519,56 +965,96 @@ class FragmentResolver:
                 return self._remote_tables(source, entry).get(expert)
         return None
 
-    def _fetch(
+    def _try_source(
         self, source: Any, layer: int, expert: int, k: int
-    ) -> Fragment | None:
-        index = self._remote_index(source, k)
+    ) -> tuple[Fragment | None, str, Exception | None]:
+        """One source's attempt: trust filter -> ranged fetch -> sha check.
+
+        Returns ``(fragment | None, decision segment, remembered error)``;
+        never raises — a rejected/broken source only fails itself."""
+        name = getattr(source, "name", str(source))
+        try:
+            index = self._remote_index(source, k)
+        except Exception as exc:  # noqa: BLE001 — mirror down, try the next
+            self.stats["source_error"] += 1
+            return None, f"{name} REJECT error:{type(exc).__name__}", None
         if index is None or str(layer) not in index:
-            return None
+            self.stats["source_miss"] += 1
+            return None, f"{name} MISS", None
         entry = _SegmentIndexEntry(index[str(layer)])
 
-        expected = self._expected_sha(layer, k, expert)
-        if expected is None:
-            text = source.read_text(self._att_name(layer, k))
-            if text is not None:
-                self._atomic_write(
-                    self._cache_path(
-                        "attestations", f"layer-{layer:03d}.k{k}.jsonl"
-                    ),
-                    text.encode(),
-                )
-                self._expert_shas.pop((layer, k), None)
-                expected = self._expected_sha(layer, k, expert)
+        expected: str | None = None
+        if not self.trust_enabled:
+            expected = self._local_shas(layer, k).get(str(expert))
+        if self.trust_enabled or expected is None:
+            try:
+                shas, reason = self._att_decision(source, layer, k)
+            except Exception as exc:  # noqa: BLE001
+                self.stats["source_error"] += 1
+                return None, f"{name} REJECT error:{type(exc).__name__}", None
+            if shas is None:
+                if self.trust_enabled:
+                    self._count_reject(reason or "no-attestation")
+                    return None, f"{name} REJECT {reason}", None
+            else:
+                sha_from_source = shas.get(str(expert))
+                if self.trust_enabled:
+                    # verify against the TRUSTED attestation of this source
+                    expected = sha_from_source
+                elif expected is None:
+                    expected = sha_from_source
+            if self.trust_enabled and expected is None:
+                self._count_reject("no-expert-sha")
+                return None, f"{name} REJECT no-expert-sha", None
         if expected is None and self.verify != "off":
-            raise FragmentVerificationError(
-                f"layer {layer} expert {expert} k{k}: source "
-                f"{getattr(source, 'name', source)} has no attestation sha; "
-                f"refusing unverified fetch (set {FQ_VERIFY_ENV}=off to allow)"
+            self._count_reject("no-attestation")
+            return (
+                None,
+                f"{name} REJECT no-attestation",
+                FragmentVerificationError(
+                    f"layer {layer} expert {expert} k{k}: source {name} has "
+                    f"no attestation sha; refusing unverified fetch (set "
+                    f"{FQ_VERIFY_ENV}=off to allow)"
+                ),
             )
 
-        lo, hi = entry.expert_range(expert)
-        payload = source.read_range(
-            entry.file, entry.body_offset + lo, entry.body_offset + hi
-        )
+        try:
+            lo, hi = entry.expert_range(expert)
+            payload = source.read_range(
+                entry.file, entry.body_offset + lo, entry.body_offset + hi
+            )
+        except Exception as exc:  # noqa: BLE001
+            self.stats["source_error"] += 1
+            return None, f"{name} REJECT error:{type(exc).__name__}", None
         self.stats["bytes_fetched"] += len(payload)
         if self.verify == "off" and expected is None:
             sha = hashlib.sha256(payload).hexdigest()
         else:
-            sha = self._check_sha(
-                payload,
-                expected,
-                f"fetched {entry.file} expert {expert} from "
-                f"{getattr(source, 'name', source)}",
-            )
+            try:
+                sha = self._check_sha(
+                    payload,
+                    expected,
+                    f"fetched {entry.file} expert {expert} from {name}",
+                )
+            except FragmentVerificationError as exc:
+                self._count_reject("sha-mismatch")
+                return None, f"{name} REJECT sha-mismatch", exc
 
         self._atomic_write(self._cache_fragment_path(sha), payload)
-        tensors = self._remote_tables(source, entry).get(expert)
+        try:
+            tensors = self._remote_tables(source, entry).get(expert)
+        except Exception as exc:  # noqa: BLE001
+            self.stats["source_error"] += 1
+            return None, f"{name} REJECT error:{type(exc).__name__}", None
         if tensors is None:
-            raise FragmentUnavailableError(
-                f"segment {entry.file} header has no tensors for expert {expert}"
-            )
+            self.stats["source_miss"] += 1
+            return None, f"{name} MISS", None
         self.stats["fetched"] += 1
-        return Fragment(layer, expert, k, payload, tensors, "fetched", sha)
+        return (
+            Fragment(layer, expert, k, payload, tensors, "fetched", sha),
+            f"{name} ACCEPT",
+            None,
+        )
 
     # ------------------------------------------------------- tensor view
 
@@ -582,11 +1068,25 @@ class FragmentResolver:
     ) -> list[tuple[str, Any]]:
         """Materialize the fragment as ``[(checkpoint_name, cpu_tensor)]``.
 
+        Note: with ``VLLM_FQ_K_FALLBACK`` active the loaded K may differ
+        from the requested one; callers that must surface the actual K
+        should call :meth:`resolve` + :meth:`materialize` instead."""
+        return self.materialize(
+            self.resolve(layer, expert, k), name_filter=name_filter
+        )
+
+    def materialize(
+        self,
+        fragment: Fragment,
+        *,
+        name_filter: Callable[[str], bool] | None = None,
+    ) -> list[tuple[str, Any]]:
+        """``[(checkpoint_name, cpu_tensor)]`` views of a resolved fragment.
+
         Tensors are zero-copy views over the fragment payload (mmap for
         local segments); downstream weight loaders copy them to device."""
         import torch
 
-        fragment = self.resolve(layer, expert, k)
         mv = memoryview(fragment.payload)
         out: list[tuple[str, Any]] = []
         for ft in fragment.tensors:

--- a/vllm/model_executor/layers/quantization/exl3_fungible/fragments.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/fragments.py
@@ -643,6 +643,16 @@ class _DownloadMonitor:
         self._thread: threading.Thread | None = None
         self._sizes: dict[str, int] = {}
         self._done_bytes = 0
+        # EXCLUDE what was already there. A killed boot leaves .incomplete
+        # files behind, and counting them as in-flight makes a HEALTHY boot
+        # report a frozen byte total at 0 MiB/s -- observed live: two corpses
+        # from an hour-old attempt summed to 880 MB and swamped the real
+        # transfer, which was running at 308 MiB/s.
+        self._preexisting: set[str] = set()
+        try:
+            self._preexisting = {str(f) for f in self.root.rglob("*.incomplete")}
+        except OSError:
+            pass
 
     @classmethod
     def ensure(cls, root: Path) -> "_DownloadMonitor":
@@ -688,6 +698,8 @@ class _DownloadMonitor:
         count = 0
         try:
             for f in self.root.rglob("*.incomplete"):
+                if str(f) in self._preexisting:
+                    continue          # a corpse from an earlier boot
                 try:
                     seen[str(f)] = f.stat().st_size
                     count += 1
@@ -710,9 +722,13 @@ class _DownloadMonitor:
             if n == 0 and delta <= 0:
                 prev, t_prev = cur, now
                 continue
+            # NOTE: with Xet enabled a large share of the transfer lands in
+            # the shared xet chunk cache rather than in these staging files,
+            # so this is a LOWER BOUND on real throughput, not a total.
             logger.info(
-                "FQ downloads: %d in flight, %.1f GiB this boot, %.0f MiB/s",
-                n, cur / (1 << 30), max(delta, 0) / dt / (1 << 20))
+                "FQ downloads: %d in flight, >=%.1f GiB this boot, "
+                ">=%.0f MiB/s", n, cur / (1 << 30),
+                max(delta, 0) / dt / (1 << 20))
             prev, t_prev = cur, now
 
 

--- a/vllm/model_executor/layers/quantization/exl3_fungible/fragments.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/fragments.py
@@ -1088,6 +1088,15 @@ class FragmentResolver:
                 layer, expert, k, self.fallback_ladder(k), strict=False,
                 chain_out=chain_out,
             )
+        except (SystemExit, KeyboardInterrupt):
+            # SHUTDOWN IS NOT A FRAGMENT FAILURE. vLLM's multiproc executor
+            # raises SystemExit from its SIGTERM handler, and it lands wherever
+            # the worker happens to be — typically mid-socket-read here, since
+            # a progressive boot spends most of its time in one. Catching
+            # BaseException swallowed it and logged "fragment unavailable,
+            # keeping the incumbent tier", so a worker asked to stop instead
+            # kept loading with silently degraded tiers. Let it through.
+            raise
         except BaseException:  # noqa: BLE001 — the whole point of this seam
             self.stats["resolve_error"] += 1
             logger.exception(

--- a/vllm/model_executor/layers/quantization/exl3_fungible/fragments.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/fragments.py
@@ -77,6 +77,7 @@ from __future__ import annotations
 
 import base64
 import contextlib
+from collections import Counter
 import hashlib
 import json
 import logging
@@ -291,6 +292,16 @@ class Fragment:
     @property
     def substituted(self) -> bool:
         return self.requested_k is not None and self.requested_k != self.k
+
+
+class SegmentHeaderMismatch(RuntimeError):
+    """A segment header arrived truncated.
+
+    Its own type because it is a TRANSPORT fault, not a bad artifact: the
+    right response is to retry, not to reject the source. Raised before the
+    bytes are parsed or cached, so a body cut mid-header (or an error page
+    served with 200) cannot become a poisoned header cache entry.
+    """
 
 
 class _SegmentIndexEntry:
@@ -630,6 +641,8 @@ class _DownloadMonitor:
         self.every = every
         self._stop = threading.Event()
         self._thread: threading.Thread | None = None
+        self._sizes: dict[str, int] = {}
+        self._done_bytes = 0
 
     @classmethod
     def ensure(cls, root: Path) -> "_DownloadMonitor":
@@ -662,21 +675,44 @@ class _DownloadMonitor:
             pass
         return total, count
 
+    def _progress(self) -> tuple[int, int]:
+        """(monotonic bytes downloaded, files in flight).
+
+        Summing the in-flight files alone is NOT progress: a completed file
+        leaves the .incomplete set, so the sum DROPS and the rate reads 0
+        MiB/s next to gigabytes of real transfer -- observed live as
+        "3 in flight, 1.8 GiB this boot, 0 MiB/s". Carry the bytes of files
+        that vanished into a completed total so the series only ever rises.
+        """
+        seen: dict[str, int] = {}
+        count = 0
+        try:
+            for f in self.root.rglob("*.incomplete"):
+                try:
+                    seen[str(f)] = f.stat().st_size
+                    count += 1
+                except OSError:
+                    continue
+        except OSError:
+            pass
+        for path, size in self._sizes.items():
+            if path not in seen:
+                self._done_bytes += size
+        self._sizes = seen
+        return self._done_bytes + sum(seen.values()), count
+
     def _run(self) -> None:
-        prev, t_prev = self._scan()[0], time.monotonic()
-        cumulative = 0
+        prev, t_prev = self._progress()[0], time.monotonic()
         while not self._stop.wait(self.every):
-            cur, n = self._scan()
+            cur, n = self._progress()
             now = time.monotonic()
             delta, dt = cur - prev, max(now - t_prev, 1e-9)
             if n == 0 and delta <= 0:
                 prev, t_prev = cur, now
                 continue
-            if delta > 0:
-                cumulative += delta
             logger.info(
                 "FQ downloads: %d in flight, %.1f GiB this boot, %.0f MiB/s",
-                n, cumulative / (1 << 30), max(delta, 0) / dt / (1 << 20))
+                n, cur / (1 << 30), max(delta, 0) / dt / (1 << 20))
             prev, t_prev = cur, now
 
 
@@ -811,7 +847,13 @@ class FragmentResolver:
         self._encode_queue = encode_queue
         self._encode_queue_ready = encode_queue is not None
 
-        self.stats = {
+        # Counter, not dict: `self.stats[k] += 1` on an
+        # undeclared key raised KeyError from the SUCCESS path
+        # of the prefetch fast-path, so every expert served
+        # from a prefetched segment was reported as a source
+        # rejection and fell down the K ladder. Telemetry must
+        # never be able to fail the thing it measures.
+        self.stats = Counter({
             "local": 0,
             "cache": 0,
             "fetched": 0,
@@ -832,6 +874,7 @@ class FragmentResolver:
             "segments_prefetched": 0,
             "segments_released": 0,
             "segments_shared": 0,
+            "bytes_from_prefetch": 0,
             "unavailable": 0,
             # hardening counters: a broken local dir / unreadable cache entry
             # / unwritable cache must degrade the attempt, never the engine
@@ -839,7 +882,7 @@ class FragmentResolver:
             "cache_error": 0,
             "cache_write_error": 0,
             "resolve_error": 0,
-        }
+        })
         # (dir, layer, k) -> _LocalSegment | None
         self._local_segments: dict[tuple[Path, int, int], _LocalSegment | None] = {}
         # (layer, k) -> {expert_str: sha} from LOCAL dirs only
@@ -1678,11 +1721,24 @@ class FragmentResolver:
                     pass
         if header is None:
             raw = source.read_range(entry.file, 0, entry.body_offset)
+            if len(raw) != entry.body_offset:
+                # A short read here is not a fragment problem, it is a
+                # TRANSPORT problem, and it must not be cached or parsed. A
+                # truncated or substituted body (an error page served with
+                # 200, a connection cut mid-header) parses into a header that
+                # disagrees with the index, and the disagreement then surfaces
+                # 19,200 times as a bare `KeyError` from expert_range with no
+                # indication that the network was the cause.
+                raise SegmentHeaderMismatch(
+                    f"{entry.file}: header read returned {len(raw)} bytes, "
+                    f"expected {entry.body_offset} — transport truncation, "
+                    f"not a bad segment")
             header, _ = parse_segment_header_bytes(raw)
             self._cache_store(
                 header_cache, json.dumps(header, separators=(",", ":")).encode()
             )
         tables = _expert_tables_from_header(header, entry)
+
         self._remote_headers[entry.sha256] = (header, tables)
         return tables
 

--- a/vllm/model_executor/layers/quantization/exl3_fungible/fragments.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/fragments.py
@@ -493,9 +493,19 @@ class HfSource:
                 from huggingface_hub import hf_hub_download
                 token = (os.environ.get("HF_TOKEN")
                          or os.environ.get("HUGGING_FACE_HUB_TOKEN"))
+                # local_dir puts the blob in OUR cache instead of the shared
+                # HF cache. That costs cross-boot dedup but buys the thing we
+                # actually need: the file is ours, so release_layer() may
+                # unlink it. Left in the shared cache, a 75-layer boot pulls
+                # the whole model in with nothing ever reclaiming it -- on a
+                # box already at 86% that is a disk-exhaustion bug wearing an
+                # optimisation's clothes. Opt back in with FQ_PREFETCH_HF_SHARED=1.
+                _kw = {}
+                if os.environ.get("FQ_PREFETCH_HF_SHARED", "0") != "1":
+                    _kw["local_dir"] = str(dest.parent)
                 path = hf_hub_download(
                     repo_id=self.repo_id, filename=relpath,
-                    revision=self.revision, token=token)
+                    revision=self.revision, token=token, **_kw)
                 got = Path(path)
                 if got.exists() and got.stat().st_size > 0:
                     if progress is not None:
@@ -744,6 +754,8 @@ class FragmentResolver:
             "reject_sha_mismatch": 0,
             "fallback_substituted": 0,
             "encode_queued": 0,
+            "segments_prefetched": 0,
+            "segments_released": 0,
             "unavailable": 0,
             # hardening counters: a broken local dir / unreadable cache entry
             # / unwritable cache must degrade the attempt, never the engine
@@ -1023,6 +1035,47 @@ class FragmentResolver:
                 self.stats["source_error"] += 1
                 continue
         return None
+
+    def release_layer(self, layer: int) -> int:
+        """Drop the whole-segment objects prefetched for ``layer``.
+
+        Prefetch had no eviction: ``_prefetched`` grew monotonically and
+        nothing unlinked, so a full progressive boot left every segment it
+        touched on disk -- hundreds of GB, unbounded, regardless of how far
+        ahead we prefetch. Depth controls lookahead; only this controls
+        FOOTPRINT. Called once a layer's tensors have streamed to the GPU, it
+        makes resident bytes O(depth) instead of O(model).
+
+        Only unlinks paths inside our own cache dir: a file the shared HF
+        cache owns may be in use by another process, and deleting other
+        people's cache entries is not ours to do. Set VLLM_FQ_PREFETCH_KEEP=1
+        to retain everything (faster repeat boots, if disk is free).
+        """
+        if os.environ.get("VLLM_FQ_PREFETCH_KEEP", "0") == "1":
+            return 0
+        freed = 0
+        try:
+            root = self.cache_dir.resolve()
+        except OSError:
+            return 0
+        for key in [k for k in self._prefetched if k[0] == layer]:
+            path = self._prefetched.pop(key, None)
+            if path is None:
+                continue
+            try:
+                resolved = Path(path).resolve()
+                if not resolved.is_relative_to(root):
+                    continue           # shared HF cache: not ours to unlink
+                size = resolved.stat().st_size
+                resolved.unlink()
+                freed += size
+                self.stats["segments_released"] += 1
+            except OSError:
+                continue
+        if freed:
+            logger.info("FQ progressive L%d: released %.1f GiB of prefetched "
+                        "segments", layer, freed / (1 << 30))
+        return freed
 
     def _cache_path(self, kind: str, name: str) -> Path:
         return self.cache_dir / kind / name

--- a/vllm/model_executor/layers/quantization/exl3_fungible/fragments.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/fragments.py
@@ -76,6 +76,7 @@ PyNaCl or ``cryptography`` lazily, only when trust filtering is active.
 from __future__ import annotations
 
 import base64
+import contextlib
 import hashlib
 import json
 import logging
@@ -83,6 +84,7 @@ import mmap
 import os
 import re
 import struct
+import time
 import warnings
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -756,6 +758,7 @@ class FragmentResolver:
             "encode_queued": 0,
             "segments_prefetched": 0,
             "segments_released": 0,
+            "segments_shared": 0,
             "unavailable": 0,
             # hardening counters: a broken local dir / unreadable cache entry
             # / unwritable cache must degrade the attempt, never the engine
@@ -1008,8 +1011,10 @@ class FragmentResolver:
                     continue
                 entry = _SegmentIndexEntry(index[str(layer)])
                 dest = self._cache_path("segments", f"{entry.sha256}.seg")
-                if dest.exists() and dest.stat().st_size > 0:
-                    self._prefetched[(layer, k)] = dest
+                ready = self._segment_ready(dest, entry.file)
+                if ready is not None:
+                    self._prefetched[(layer, k)] = ready
+                    self._claim_segment(ready)
                     return f"cached {entry.file}"
                 got = getattr(source, "prefetch_whole", None)
                 if got is None:
@@ -1024,9 +1029,19 @@ class FragmentResolver:
                         done / (1 << 30), (total or done) / (1 << 30), pct,
                         rate / (1 << 20))
 
-                path = got(entry.file, dest, _report)
+                # Only ONE rank downloads. The others block here, then find
+                # the file already present on the re-check below.
+                with self._segment_lock(dest):
+                    again = self._segment_ready(dest, entry.file)
+                    if again is not None:
+                        self._prefetched[(layer, k)] = again
+                        self._claim_segment(again)
+                        self.stats["segments_shared"] += 1
+                        return f"shared {entry.file} (fetched by another rank)"
+                    path = got(entry.file, dest, _report)
                 if path is not None:
                     self._prefetched[(layer, k)] = path
+                    self._claim_segment(path)
                     self.stats["segments_prefetched"] += 1
                     return (f"prefetched {entry.file} "
                             f"({path.stat().st_size} B) from "
@@ -1035,6 +1050,104 @@ class FragmentResolver:
                 self.stats["source_error"] += 1
                 continue
         return None
+
+    # ----------------------------------------------------- cross-rank sharing
+    # Every TP rank runs its OWN progressive_weights_iterator over the SAME
+    # policy, so all of them want the same segment objects at the same time --
+    # observed as four .part files racing for one file, i.e. 4x the bytes and
+    # 4x the transient disk. With prefetch depth x width that becomes ~24
+    # concurrent fetches of ~6 distinct files. One rank downloads; the rest
+    # wait on the lock and then find it already there.
+    @contextlib.contextmanager
+    def _segment_lock(self, dest: Path, timeout: float = 1800.0):
+        import fcntl
+        lock = dest.with_name(dest.name + ".lock")
+        lock.parent.mkdir(parents=True, exist_ok=True)
+        fh = open(lock, "a+")
+        deadline = time.monotonic() + timeout
+        held = False
+        try:
+            while True:
+                try:
+                    fcntl.flock(fh.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    held = True
+                    break
+                except OSError:
+                    if time.monotonic() >= deadline:
+                        # Losing the lock must never fail a boot: fall through
+                        # and fetch our own copy. The rename is atomic, so a
+                        # duplicate download is wasteful, not incorrect.
+                        logger.warning(
+                            "FQ segment lock timeout on %s — fetching our own "
+                            "copy", dest.name)
+                        break
+                    time.sleep(0.5)
+            yield held
+        finally:
+            if held:
+                try:
+                    fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+                except OSError:
+                    pass
+            fh.close()
+
+    def _segment_ready(self, dest: Path, relpath: str) -> "Path | None":
+        """An already-complete copy, under either name.
+
+        The urllib path renames to ``dest``; hf_hub_download with local_dir
+        writes to ``dest.parent/relpath``. Checking only ``dest`` would make
+        every rank re-download a file the HF client had already placed.
+        """
+        for cand in (dest, dest.parent / relpath):
+            try:
+                if cand.exists() and cand.stat().st_size > 0:
+                    return cand
+            except OSError:
+                continue
+        return None
+
+    def _users_dir(self, dest: Path) -> Path:
+        return dest.with_name(dest.name + ".users")
+
+    def _claim_segment(self, dest: Path) -> None:
+        """Mark this process as a user of ``dest`` so another rank's
+        release_layer() cannot unlink a segment we are still reading."""
+        try:
+            d = self._users_dir(dest)
+            d.mkdir(parents=True, exist_ok=True)
+            (d / str(os.getpid())).touch()
+        except OSError:
+            pass
+
+    def _drop_segment_claim(self, dest: Path) -> bool:
+        """Release our claim; return True if NO live user remains.
+
+        Stale markers from killed ranks are pruned by checking /proc, so a
+        preempted worker cannot pin a segment on disk forever.
+        """
+        d = self._users_dir(dest)
+        try:
+            (d / str(os.getpid())).unlink()
+        except OSError:
+            pass
+        if not d.exists():
+            # Never claimed (single-process use, or a caller that populated
+            # _prefetched directly). No claim means no other holder -- NOT
+            # "unknown, so refuse", which would make the segment unfreeable
+            # and defeat the eviction entirely.
+            return True
+        try:
+            for marker in d.iterdir():
+                if marker.name.isdigit() and Path("/proc", marker.name).exists():
+                    return False
+                try:
+                    marker.unlink()          # stale: owner is gone
+                except OSError:
+                    return False
+            d.rmdir()
+        except OSError:
+            return False
+        return True
 
     def release_layer(self, layer: int) -> int:
         """Drop the whole-segment objects prefetched for ``layer``.
@@ -1066,8 +1179,15 @@ class FragmentResolver:
                 resolved = Path(path).resolve()
                 if not resolved.is_relative_to(root):
                     continue           # shared HF cache: not ours to unlink
+                if not self._drop_segment_claim(resolved):
+                    continue           # another rank is still reading it
                 size = resolved.stat().st_size
                 resolved.unlink()
+                for aux in (resolved.with_name(resolved.name + ".lock"),):
+                    try:
+                        aux.unlink()
+                    except OSError:
+                        pass
                 freed += size
                 self.stats["segments_released"] += 1
             except OSError:

--- a/vllm/model_executor/layers/quantization/exl3_fungible/fragments.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/fragments.py
@@ -847,6 +847,10 @@ class FragmentResolver:
         # (source_name, layer, k) -> attestation text | None (None=definitive)
         # (layer, k) -> whole prefetched segment on disk, for uniform layers
         self._prefetched: dict[tuple[int, int], Path] = {}
+        self._reject_traced: set = set()
+        # Prefetch runs on a thread pool now; the memo dicts below
+        # were written for a single thread.
+        self._memo_lock = threading.RLock()
         self._att_texts: dict[tuple[str, int, int], str | None] = {}
         # (source_name, layer, k) -> (shas | None, reject reason | None)
         self._att_evals: dict[
@@ -1712,6 +1716,25 @@ class FragmentResolver:
                 continue
         return None
 
+    def _reject(self, name: str, exc: Exception, where: str) -> str:
+        """A rejection string that can actually be diagnosed.
+
+        `REJECT error:KeyError` names the exception TYPE and discards its
+        argument -- so a boot that degraded 190 experts to K2 produced 270
+        identical, contentless lines and the cause had to be reverse-
+        engineered from the source. The key IS the diagnosis. Also emit one
+        traceback per (source, site) so the first occurrence is debuggable
+        without flooding a 75-layer boot with 19,200 stacks.
+        """
+        detail = str(exc).strip().replace("\n", " ")[:160]
+        seen_key = (name, where, type(exc).__name__)
+        if seen_key not in self._reject_traced:
+            self._reject_traced.add(seen_key)
+            logger.warning("FQ %s REJECT at %s: %s: %s", name, where,
+                           type(exc).__name__, detail, exc_info=True)
+        out = f"{name} REJECT error:{type(exc).__name__}"
+        return f"{out}({detail})" if detail else out
+
     def _try_source(
         self, source: Any, layer: int, expert: int, k: int
     ) -> tuple[Fragment | None, str, Exception | None]:
@@ -1727,7 +1750,7 @@ class FragmentResolver:
             self.stats["source_error"] += 1
             logger.warning("FQ source %s raised for L%d/e%d K%d",
                            name, layer, expert, k, exc_info=True)
-            return None, f"{name} REJECT error:{type(exc).__name__}", None
+            return None, self._reject(name, exc, "try_source"), None
 
     def _try_source_inner(
         self, source: Any, layer: int, expert: int, k: int, name: str
@@ -1736,7 +1759,7 @@ class FragmentResolver:
             index = self._remote_index(source, k)
         except Exception as exc:  # noqa: BLE001 — mirror down, try the next
             self.stats["source_error"] += 1
-            return None, f"{name} REJECT error:{type(exc).__name__}", None
+            return None, self._reject(name, exc, "remote_index"), None
         if index is None or str(layer) not in index:
             self.stats["source_miss"] += 1
             return None, f"{name} MISS", None
@@ -1750,7 +1773,7 @@ class FragmentResolver:
                 shas, reason = self._att_decision(source, layer, k)
             except Exception as exc:  # noqa: BLE001
                 self.stats["source_error"] += 1
-                return None, f"{name} REJECT error:{type(exc).__name__}", None
+                return None, self._reject(name, exc, "att_decision"), None
             if shas is None:
                 if self.trust_enabled:
                     self._count_reject(reason or "no-attestation")
@@ -1793,7 +1816,7 @@ class FragmentResolver:
                 payload = source.read_range(entry.file, start, stop)
         except Exception as exc:  # noqa: BLE001
             self.stats["source_error"] += 1
-            return None, f"{name} REJECT error:{type(exc).__name__}", None
+            return None, self._reject(name, exc, "expert_range/read_range"), None
         self.stats["bytes_fetched"] += len(payload)
         if self.verify == "off" and expected is None:
             sha = hashlib.sha256(payload).hexdigest()
@@ -1813,7 +1836,7 @@ class FragmentResolver:
             tensors = self._remote_tables(source, entry).get(expert)
         except Exception as exc:  # noqa: BLE001
             self.stats["source_error"] += 1
-            return None, f"{name} REJECT error:{type(exc).__name__}", None
+            return None, self._reject(name, exc, "remote_tables"), None
         if tensors is None:
             self.stats["source_miss"] += 1
             return None, f"{name} MISS", None

--- a/vllm/model_executor/layers/quantization/exl3_fungible/fragments.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/fragments.py
@@ -917,6 +917,7 @@ class FragmentResolver:
             "segments_released": 0,
             "segments_shared": 0,
             "segments_local": 0,
+            "fragment_cache_skipped": 0,
             "bytes_from_prefetch": 0,
             "unavailable": 0,
             # hardening counters: a broken local dir / unreadable cache entry
@@ -1323,6 +1324,19 @@ class FragmentResolver:
         except OSError:
             return False
         return True
+
+    @staticmethod
+    def cache_fragments(environ=None) -> bool:
+        """Whether to keep a per-expert copy of every fetched payload.
+
+        On by default for the swap path, which benefits from re-reading an
+        expert without a refetch. Set VLLM_FQ_FRAGMENT_CACHE=0 on a
+        disk-constrained box: this store has no eviction and a full
+        progressive boot writes the whole model through it.
+        """
+        env = environ if environ is not None else os.environ
+        return str(env.get("VLLM_FQ_FRAGMENT_CACHE", "1")).strip().lower() \
+            not in ("0", "false", "no", "off")
 
     @staticmethod
     def reflink_or_copy(src: Path, dst: Path) -> str:
@@ -1979,12 +1993,14 @@ class FragmentResolver:
             start = entry.body_offset + lo
             stop = entry.body_offset + hi
             payload = None
+            from_prefetch = False
             cached = self._prefetched.get((layer, k))
             if cached is not None:
                 slicer = getattr(source, "range_from_prefetched", None)
                 if slicer is not None:
                     payload = slicer(cached, start, stop)
                     if payload is not None:
+                        from_prefetch = True
                         self.stats["bytes_from_prefetch"] += len(payload)
             if payload is None:
                 payload = source.read_range(entry.file, start, stop)
@@ -2005,7 +2021,22 @@ class FragmentResolver:
                 self._count_reject("sha-mismatch")
                 return None, f"{name} REJECT sha-mismatch", exc
 
-        self._cache_store(self._cache_fragment_path(sha), payload)
+        # DO NOT re-cache a slice of an object we already hold.
+        #
+        # The per-expert fragment cache has no eviction, and a progressive
+        # boot writes EVERY expert through it: ~14 MiB x 256 experts = ~3.5
+        # GiB per layer, ~264 GiB for GLM-5.2. Measured live at 69 GiB by
+        # layer 21 of 75, on a box with a 180 GiB floor -- it would have
+        # exhausted the disk before the boot finished.
+        #
+        # When the payload was sliced out of a prefetched whole segment the
+        # cache entry is pure duplication: the SEGMENT is the cache, and it
+        # is already bounded by release_layer. Caching the slice as well
+        # stores the same bytes twice and keeps the second copy forever.
+        if not from_prefetch and self.cache_fragments():
+            self._cache_store(self._cache_fragment_path(sha), payload)
+        elif from_prefetch:
+            self.stats["fragment_cache_skipped"] += 1
         try:
             tensors = self._remote_tables(source, entry).get(expert)
         except Exception as exc:  # noqa: BLE001

--- a/vllm/model_executor/layers/quantization/exl3_fungible/fragments.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/fragments.py
@@ -41,6 +41,23 @@ Operator knobs (this milestone):
   returned :class:`Fragment` records both ``k`` (actually loaded) and
   ``requested_k``; every substitution/miss is enqueued on the persisted
   lazy-encode queue (:mod:`.lazy_encode`).  Boot never blocks on encodes.
+  Unset (or ``auto``) means :meth:`FragmentResolver.resolve_best` derives the
+  ladder itself — the nearest *lower* Ks this deployment can actually supply,
+  nearest first (``VLLM_FQ_K_FALLBACK_UP=1`` also allows upward substitution,
+  off by default: a higher K costs memory and, on SM120, K5 does not serve as
+  a mixed tier at all).  ``off``/``none`` disables substitution entirely.
+
+Two resolution entry points, deliberately different about failure:
+
+* :meth:`FragmentResolver.resolve` — strict. Uses only the *explicit*
+  ``VLLM_FQ_K_FALLBACK`` ladder and raises
+  :class:`FragmentUnavailableError` when nothing supplies the fragment. This
+  is the auditing/tooling contract (and what the trust tests pin).
+* :meth:`FragmentResolver.resolve_best` — **never raises**. Requested K, else
+  the nearest available lower K (logged loudly, encode queued), else
+  ``None`` so the caller can keep the incumbent tier. Every serving path
+  (boot stream, live swap staging) goes through this one: a fragment that is
+  missing at the required bitrate must never take an engine down.
 
 Every :meth:`FragmentResolver.resolve` emits one structured decision line
 (INFO on substitution/fallback, DEBUG on plain success, WARNING on failure)::
@@ -81,10 +98,15 @@ FQ_LOCAL_SEGMENTS_ENV = "VLLM_FQ_LOCAL_SEGMENTS"
 FQ_TRUST_PREDICATES_ENV = "VLLM_FQ_TRUST_PREDICATES"
 FQ_TRUST_SIGNERS_ENV = "VLLM_FQ_TRUST_SIGNERS"
 FQ_K_FALLBACK_ENV = "VLLM_FQ_K_FALLBACK"
+FQ_K_FALLBACK_UP_ENV = "VLLM_FQ_K_FALLBACK_UP"
 
 DEFAULT_CACHE_DIR = "~/.cache/vllm/fq"
 DEFAULT_TRUST_PREDICATES = ("repack-of", "encode-of", "derived-from")
 SOURCES_MODES = ("prepend", "replace", "append")
+# Ks to consider when nothing in the deployment advertises a K set at all.
+DEFAULT_K_UNIVERSE = (2, 3, 4, 5, 6)
+_INDEX_K_RE = re.compile(r"^index-k(\d+)\.json$")
+_TRUE = ("1", "true", "yes", "on")
 
 EXPERT_RE = re.compile(
     r"^model\.layers\.(\d+)\.mlp\.experts\.(\d+)\.(\w+_proj)\.rank(\d+)\.(\w+)$"
@@ -502,16 +524,34 @@ class FragmentResolver:
         self.trust_enabled = bool(self.trust_signers)
 
         # -- lazy-encode fallback ladder
-        fallback_raw = environ.get(FQ_K_FALLBACK_ENV) or ""
-        try:
-            self.k_fallback: tuple[int, ...] = tuple(
-                int(part) for part in fallback_raw.split(",") if part.strip()
-            )
-        except ValueError as exc:
-            raise ValueError(
-                f"{FQ_K_FALLBACK_ENV} must be a comma list of Ks, got "
-                f"{fallback_raw!r}"
-            ) from exc
+        # mode: "explicit" (operator listed the Ks), "auto" (derive the
+        # nearest-lower ladder from what this deployment can supply) or
+        # "off" (no substitution at all).  ``k_fallback`` stays the EXPLICIT
+        # list: strict resolve() only ever honours that, so tooling and the
+        # trust tests keep their fail-closed contract.
+        fallback_raw = environ.get(FQ_K_FALLBACK_ENV)
+        token = (fallback_raw or "").strip().lower()
+        self.k_fallback: tuple[int, ...] = ()
+        if fallback_raw is None or token in ("", "auto"):
+            self.k_fallback_mode = "auto"
+        elif token in ("off", "none"):
+            self.k_fallback_mode = "off"
+        else:
+            self.k_fallback_mode = "explicit"
+            try:
+                self.k_fallback = tuple(
+                    int(part)
+                    for part in fallback_raw.split(",") if part.strip()
+                )
+            except ValueError as exc:
+                raise ValueError(
+                    f"{FQ_K_FALLBACK_ENV} must be a comma list of Ks (or "
+                    f"auto|off), got {fallback_raw!r}"
+                ) from exc
+        self.k_fallback_up = (
+            (environ.get(FQ_K_FALLBACK_UP_ENV) or "0").strip().lower() in _TRUE
+        )
+        self._local_k_universe: tuple[int, ...] | None = None
         self._encode_queue = encode_queue
         self._encode_queue_ready = encode_queue is not None
 
@@ -534,6 +574,12 @@ class FragmentResolver:
             "fallback_substituted": 0,
             "encode_queued": 0,
             "unavailable": 0,
+            # hardening counters: a broken local dir / unreadable cache entry
+            # / unwritable cache must degrade the attempt, never the engine
+            "local_error": 0,
+            "cache_error": 0,
+            "cache_write_error": 0,
+            "resolve_error": 0,
         }
         # (dir, layer, k) -> _LocalSegment | None
         self._local_segments: dict[tuple[Path, int, int], _LocalSegment | None] = {}
@@ -567,13 +613,26 @@ class FragmentResolver:
         if key in self._local_segments:
             return self._local_segments[key]
         seg: _LocalSegment | None = None
-        index_path = base / f"index-k{k}.json"
-        seg_path = base / self._seg_name(layer, k)
-        if index_path.exists() and seg_path.exists():
-            index = json.loads(index_path.read_text())
-            entry = index.get(str(layer))
-            if entry is not None:
-                seg = _LocalSegment(seg_path, _SegmentIndexEntry(entry))
+        try:
+            index_path = base / f"index-k{k}.json"
+            seg_path = base / self._seg_name(layer, k)
+            if index_path.exists() and seg_path.exists():
+                index = json.loads(index_path.read_text())
+                entry = (index.get(str(layer))
+                         if isinstance(index, dict) else None)
+                if entry is not None:
+                    seg = _LocalSegment(seg_path, _SegmentIndexEntry(entry))
+        except Exception:  # noqa: BLE001 — a broken local dir is a MISS
+            # Truncated index-k{K}.json, index/segment body-offset skew, an
+            # unreadable segment: this dir cannot supply the fragment, but
+            # the cache / sources / fallback ladder still can.  Memoized as
+            # None so the warning fires once per (dir, layer, K).
+            self.stats["local_error"] += 1
+            logger.warning(
+                "FQ local segment dir %s unusable for L%d K%d — treating as "
+                "a miss", base, layer, k, exc_info=True,
+            )
+            seg = None
         self._local_segments[key] = seg
         return seg
 
@@ -585,9 +644,16 @@ class FragmentResolver:
             shas = {}
             for base in self.local_dirs:
                 p = base / self._att_name(layer, k)
-                if p.exists():
-                    shas = _attestation_expert_shas(p.read_text())
-                    break
+                try:
+                    if p.exists():
+                        shas = _attestation_expert_shas(p.read_text())
+                        break
+                except OSError:  # unreadable attestation: try the next dir
+                    self.stats["local_error"] += 1
+                    logger.warning(
+                        "FQ attestation %s unreadable — skipping", p,
+                        exc_info=True,
+                    )
             self._local_sha_maps[key] = shas
         return shas
 
@@ -613,7 +679,7 @@ class FragmentResolver:
             return None  # unknown, not definitive: don't memoize
         text = source.read_text(self._att_name(layer, k))
         if text is not None:
-            self._atomic_write(path, text.encode())
+            self._cache_store(path, text.encode())
         self._att_texts[key] = text
         return text
 
@@ -757,6 +823,20 @@ class FragmentResolver:
         tmp.write_bytes(data)
         os.replace(tmp, path)
 
+    def _cache_store(self, path: Path, data: bytes) -> bool:
+        """Best-effort cache write: a full or read-only cache dir must never
+        throw away a fragment that was already fetched and verified."""
+        try:
+            self._atomic_write(path, data)
+            return True
+        except OSError:
+            self.stats["cache_write_error"] += 1
+            logger.warning(
+                "FQ cache write failed (%s) — serving uncached", path,
+                exc_info=True,
+            )
+            return False
+
     def _check_sha(
         self, payload: Any, expected: str | None, what: str
     ) -> str:
@@ -771,17 +851,114 @@ class FragmentResolver:
 
     # ------------------------------------------------------------ resolve
 
+    # -------------------------------------------------- fallback ladder
+
+    def k_universe(self) -> tuple[int, ...]:
+        """Bitrates this deployment could plausibly supply.
+
+        Manifest ``k_values`` plus every ``index-k{K}.json`` in a local
+        segment dir plus every K already consulted on a source; a deployment
+        that advertises nothing falls back to :data:`DEFAULT_K_UNIVERSE`.
+        Pure discovery — no network, no payload reads."""
+        if self._local_k_universe is None:
+            ks: set[int] = set()
+            for value in self.manifest.get("k_values") or ():
+                try:
+                    ks.add(int(value))
+                except (TypeError, ValueError):
+                    continue
+            for base in self.local_dirs:
+                try:
+                    names = [p.name for p in base.glob("index-k*.json")]
+                except OSError:  # unreadable dir: it advertises nothing
+                    continue
+                for name in names:
+                    m = _INDEX_K_RE.match(name)
+                    if m is not None:
+                        ks.add(int(m.group(1)))
+            self._local_k_universe = tuple(sorted(ks))
+        ks = set(self._local_k_universe)
+        ks.update(k for _name, k in self._remote_indexes)
+        return tuple(sorted(ks)) or DEFAULT_K_UNIVERSE
+
+    def fallback_ladder(self, k: int) -> tuple[int, ...]:
+        """Substitute Ks to try for a missed ``k``, best first.
+
+        ``VLLM_FQ_K_FALLBACK`` verbatim when the operator listed one; empty
+        when it is ``off``; otherwise the auto ladder: nearest LOWER K first
+        (a lower bitrate always fits the memory the higher one needed), then
+        — only with ``VLLM_FQ_K_FALLBACK_UP=1`` — the nearest higher."""
+        if self.k_fallback_mode == "off":
+            return ()
+        if self.k_fallback_mode == "explicit":
+            return tuple(x for x in self.k_fallback if x != k)
+        universe = self.k_universe()
+        ladder = tuple(sorted((x for x in universe if x < k), reverse=True))
+        if self.k_fallback_up:
+            ladder += tuple(sorted(x for x in universe if x > k))
+        return ladder
+
+    # ------------------------------------------------------------ resolve
+
     def resolve(self, layer: int, expert: int, k: int) -> Fragment:
-        """Resolve one fragment through local dirs -> cache -> sources, then
-        the ``VLLM_FQ_K_FALLBACK`` ladder; emits one decision line per call
-        and enqueues a lazy encode on every substitution/miss."""
-        chain: list[str] = []
+        """Strict resolve: local dirs -> cache -> sources, then the EXPLICIT
+        ``VLLM_FQ_K_FALLBACK`` ladder; emits one decision line per call and
+        enqueues a lazy encode on every substitution/miss.
+
+        Raises :class:`FragmentUnavailableError` (or the first verification
+        error) when nothing supplies the fragment. Serving paths want
+        :meth:`resolve_best` instead — this one is the strict, auditable
+        contract for tooling."""
+        fragment = self._resolve_ladder(
+            layer, expert, k,
+            tuple(x for x in self.k_fallback if x != k),
+            strict=True,
+        )
+        assert fragment is not None  # strict=True never returns None
+        return fragment
+
+    def resolve_best(
+        self, layer: int, expert: int, k: int, *,
+        chain_out: list[str] | None = None,
+    ) -> Fragment | None:
+        """Best available fragment for ``(layer, expert)`` — **never raises**.
+
+        Order: the requested ``k``; else the nearest available lower K of
+        :meth:`fallback_ladder` (logged loudly, ``requested_k`` recorded, an
+        encode queued); else ``None`` so the caller keeps the incumbent tier.
+        Any unexpected failure inside the resolver is caught and reported as
+        ``None`` too: a missing weight must never reach an engine loop.
+
+        ``chain_out``, when given, receives the per-attempt decision
+        segments so a caller can quote the actual reason ("REJECT
+        no-attestation", "REJECT error:URLError", ...) in its own message."""
+        try:
+            return self._resolve_ladder(
+                layer, expert, k, self.fallback_ladder(k), strict=False,
+                chain_out=chain_out,
+            )
+        except BaseException:  # noqa: BLE001 — the whole point of this seam
+            self.stats["resolve_error"] += 1
+            logger.exception(
+                "FQ resolve_best L%d/e%d K%d crashed — reporting the "
+                "fragment as unavailable and keeping the incumbent tier",
+                layer, expert, k,
+            )
+            if chain_out is not None:
+                chain_out.append("RESOLVER ERROR")
+            return None
+
+    def _resolve_ladder(
+        self, layer: int, expert: int, k: int, ladder: tuple[int, ...], *,
+        strict: bool, chain_out: list[str] | None = None,
+    ) -> Fragment | None:
+        chain: list[str] = chain_out if chain_out is not None else []
         errors: list[Exception] = []
         fragment = self._resolve_k(layer, expert, k, chain, errors)
 
         substituted = False
         if fragment is None:
-            for fallback_k in self.k_fallback:
+            for fallback_k in ladder:
                 if fallback_k == k:
                     continue
                 mark = len(chain)
@@ -817,6 +994,11 @@ class FragmentResolver:
                 self.stats["fallback_substituted"] += 1
                 chain[-1] += queue_note
                 self._log_chain(logging.INFO, layer, expert, k, chain)
+                logger.warning(
+                    "FQ DEGRADED L%d/e%d: K%d unavailable, serving K%d "
+                    "instead (origin=%s)%s", layer, expert, k, fragment.k,
+                    fragment.origin, queue_note,
+                )
             else:
                 self._log_chain(logging.DEBUG, layer, expert, k, chain)
             return fragment
@@ -824,6 +1006,13 @@ class FragmentResolver:
         self.stats["unavailable"] += 1
         chain.append(f"UNAVAILABLE{queue_note}")
         self._log_chain(logging.WARNING, layer, expert, k, chain)
+        if not strict:
+            logger.error(
+                "FQ UNAVAILABLE L%d/e%d K%d: no source and no fallback K "
+                "could supply it%s — keeping the incumbent tier",
+                layer, expert, k, queue_note,
+            )
+            return None
         if errors:
             raise errors[0]
         raise FragmentUnavailableError(
@@ -832,6 +1021,53 @@ class FragmentResolver:
             f"{FQ_SOURCES_ENV} / {FQ_K_FALLBACK_ENV} or drain the "
             "lazy-encode queue)"
         )
+
+    # ------------------------------------------------------------- probe
+
+    def probe(self, layer: int, expert: int, k: int, *,
+              network: bool = True) -> bool:
+        """Could ``(layer, expert, k)`` be supplied? No payload transfer.
+
+        Local segment dirs and the content-addressed cache always count;
+        source *indexes* count when ``network`` is on (one small JSON per
+        (source, K), memoized). Used by the boot-time availability
+        projection so the tier bitmap only ever declares Ks that exist."""
+        for base in self.local_dirs:
+            seg = self._local_segment(base, layer, k)
+            if seg is not None and expert in seg.tables:
+                return True
+        try:
+            expected = self._cache_expected_sha(layer, k, expert)
+            if expected is not None and self._cache_fragment_path(
+                    expected).exists():
+                return True
+        except Exception:  # noqa: BLE001 — probing is best-effort
+            pass
+        if not network:
+            return False
+        for source in self.sources:
+            try:
+                index = self._remote_index(source, k)
+            except Exception:  # noqa: BLE001 — a down mirror proves nothing
+                continue
+            if not isinstance(index, dict):
+                continue
+            entry = index.get(str(layer))
+            if isinstance(entry, dict) and str(expert) in (
+                    entry.get("experts") or {}):
+                return True
+        return False
+
+    def available_k(self, layer: int, expert: int, k: int, *,
+                    network: bool = True) -> int | None:
+        """The K :meth:`resolve_best` would actually serve, or ``None``."""
+        if self.probe(layer, expert, k, network=network):
+            return k
+        for candidate in self.fallback_ladder(k):
+            if candidate != k and self.probe(
+                    layer, expert, candidate, network=network):
+                return candidate
+        return None
 
     @staticmethod
     def _log_chain(
@@ -884,11 +1120,23 @@ class FragmentResolver:
         chain.append(f"local({len(self.local_dirs)} dirs) MISS")
 
         # 2. fragment cache (content-addressed by trusted expected sha)
-        expected = self._cache_expected_sha(layer, k, expert)
+        try:
+            expected = self._cache_expected_sha(layer, k, expert)
+        except Exception:  # noqa: BLE001 — a broken cache is never fatal
+            self.stats["cache_error"] += 1
+            logger.warning("FQ cache lookup failed for L%d/e%d K%d",
+                           layer, expert, k, exc_info=True)
+            expected = None
         if expected is not None:
             cached = self._cache_fragment_path(expected)
-            if cached.exists():
-                payload = cached.read_bytes()
+            try:
+                payload = cached.read_bytes() if cached.exists() else None
+            except OSError:  # evicted/unreadable under us: fall through
+                self.stats["cache_error"] += 1
+                logger.warning("FQ cache entry %s unreadable", cached,
+                               exc_info=True)
+                payload = None
+            if payload is not None:
                 try:
                     self._check_sha(
                         payload,
@@ -936,12 +1184,28 @@ class FragmentResolver:
         if cached is not None:
             return cached[1]
         header_cache = self._cache_path("headers", f"{entry.sha256}.json")
+        header: dict | None = None
         if header_cache.exists():
-            header = json.loads(header_cache.read_text())
-        else:
+            try:
+                header = json.loads(header_cache.read_text())
+            except (ValueError, OSError):
+                # A poisoned cache entry (torn write, truncated file) must
+                # self-heal rather than pin this segment as unreadable
+                # forever: drop it and go back to the source.
+                self.stats["cache_error"] += 1
+                logger.warning(
+                    "FQ cached segment header %s is unreadable — discarding "
+                    "and re-fetching", header_cache, exc_info=True,
+                )
+                header = None
+                try:
+                    header_cache.unlink()
+                except OSError:
+                    pass
+        if header is None:
             raw = source.read_range(entry.file, 0, entry.body_offset)
             header, _ = parse_segment_header_bytes(raw)
-            self._atomic_write(
+            self._cache_store(
                 header_cache, json.dumps(header, separators=(",", ":")).encode()
             )
         tables = _expert_tables_from_header(header, entry)
@@ -951,18 +1215,31 @@ class FragmentResolver:
     def _tensor_table_for(
         self, layer: int, expert: int, k: int
     ) -> list[FragmentTensor] | None:
-        """Tensor table for a cached payload, from any cached segment header."""
+        """Tensor table for a cached payload, from any cached segment header.
+
+        Best-effort by construction: a mirror that is down, an index that no
+        longer parses or a header cache entry evicted between the ``exists``
+        probe and the read must degrade to "no table" (the caller then walks
+        the source chain), never propagate — this runs on the boot and live
+        swap paths."""
         for source in self.sources:
             try:
                 index = self._remote_index(source, k)
-            except Exception:  # noqa: BLE001
+                if not isinstance(index, dict) or str(layer) not in index:
+                    continue
+                entry = _SegmentIndexEntry(index[str(layer)])
+                header_cache = self._cache_path(
+                    "headers", f"{entry.sha256}.json")
+                if (entry.sha256 in self._remote_headers
+                        or header_cache.exists()):
+                    return self._remote_tables(source, entry).get(expert)
+            except Exception:  # noqa: BLE001 — try the next mirror
+                self.stats["source_error"] += 1
+                logger.warning(
+                    "FQ tensor-table lookup failed on %s for L%d K%d",
+                    getattr(source, "name", source), layer, k, exc_info=True,
+                )
                 continue
-            if index is None or str(layer) not in index:
-                continue
-            entry = _SegmentIndexEntry(index[str(layer)])
-            header_cache = self._cache_path("headers", f"{entry.sha256}.json")
-            if entry.sha256 in self._remote_headers or header_cache.exists():
-                return self._remote_tables(source, entry).get(expert)
         return None
 
     def _try_source(
@@ -971,8 +1248,20 @@ class FragmentResolver:
         """One source's attempt: trust filter -> ranged fetch -> sha check.
 
         Returns ``(fragment | None, decision segment, remembered error)``;
-        never raises — a rejected/broken source only fails itself."""
+        never raises — a rejected/broken source only fails itself. The outer
+        guard makes that literal rather than aspirational."""
         name = getattr(source, "name", str(source))
+        try:
+            return self._try_source_inner(source, layer, expert, k, name)
+        except Exception as exc:  # noqa: BLE001 — contract: never raises
+            self.stats["source_error"] += 1
+            logger.warning("FQ source %s raised for L%d/e%d K%d",
+                           name, layer, expert, k, exc_info=True)
+            return None, f"{name} REJECT error:{type(exc).__name__}", None
+
+    def _try_source_inner(
+        self, source: Any, layer: int, expert: int, k: int, name: str
+    ) -> tuple[Fragment | None, str, Exception | None]:
         try:
             index = self._remote_index(source, k)
         except Exception as exc:  # noqa: BLE001 — mirror down, try the next
@@ -1040,7 +1329,7 @@ class FragmentResolver:
                 self._count_reject("sha-mismatch")
                 return None, f"{name} REJECT sha-mismatch", exc
 
-        self._atomic_write(self._cache_fragment_path(sha), payload)
+        self._cache_store(self._cache_fragment_path(sha), payload)
         try:
             tensors = self._remote_tables(source, entry).get(expert)
         except Exception as exc:  # noqa: BLE001
@@ -1074,6 +1363,33 @@ class FragmentResolver:
         return self.materialize(
             self.resolve(layer, expert, k), name_filter=name_filter
         )
+
+    def best_tensors(
+        self,
+        layer: int,
+        expert: int,
+        k: int,
+        *,
+        name_filter: Callable[[str], bool] | None = None,
+    ) -> tuple[int, list[tuple[str, Any]]] | None:
+        """``(actual_k, [(name, tensor)])`` via :meth:`resolve_best`, or None.
+
+        The never-raising counterpart of :meth:`expert_tensors`: nothing in
+        here reaches an engine loop, and the caller is told which K it
+        actually got so tier metadata can record reality."""
+        fragment = self.resolve_best(layer, expert, k)
+        if fragment is None:
+            return None
+        try:
+            return fragment.k, self.materialize(
+                fragment, name_filter=name_filter)
+        except Exception:  # noqa: BLE001 — malformed payload == unavailable
+            self.stats["resolve_error"] += 1
+            logger.exception(
+                "FQ materialize L%d/e%d K%d failed — treating the fragment "
+                "as unavailable", layer, expert, fragment.k,
+            )
+            return None
 
     def materialize(
         self,
@@ -1112,3 +1428,65 @@ class FragmentResolver:
                 ).view(ft.shape)
             out.append((ft.name, tensor))
         return out
+
+
+# ------------------------------------------------- boot-time projection
+
+
+def project_bits_to_available(
+    resolver: FragmentResolver,
+    bits_by_layer: dict[int, Any],
+    *,
+    network: bool = True,
+    log: Callable[[str], None] | None = None,
+) -> tuple[
+    dict[int, list[int]],
+    list[tuple[int, int, int, int]],
+    list[tuple[int, int, int]],
+]:
+    """Project a policy's per-expert Ks onto what can actually be supplied.
+
+    A progressive boot is only crash-free if the tier bitmap the model was
+    configured with agrees with the Ks the resolver ends up streaming: the
+    bitmap sizes the slabs, so a fragment substituted at a *different* K
+    would fail a shape check deep inside the weight loader. Running this
+    projection BEFORE the bitmap is written closes that gap — the policy
+    only ever asks for Ks that exist, so :meth:`FragmentResolver.resolve`
+    cannot miss at boot and no substitution is needed at stream time.
+
+    Returns ``(projected, substitutions, missing)`` where ``substitutions``
+    is ``[(layer, expert, requested_k, available_k)]`` and ``missing`` is
+    ``[(layer, expert, requested_k)]`` for experts no K can supply — those
+    keep their requested K in ``projected`` (there is nothing better to say)
+    and are the operator's cue to drain the lazy-encode queue.
+    """
+    projected: dict[int, list[int]] = {}
+    substitutions: list[tuple[int, int, int, int]] = []
+    missing: list[tuple[int, int, int]] = []
+    for layer, bits in bits_by_layer.items():
+        layer = int(layer)
+        row = [int(b) for b in bits]
+        for expert, k in enumerate(row):
+            got = resolver.available_k(layer, expert, k, network=network)
+            if got == k:
+                continue
+            if got is None:
+                missing.append((layer, expert, k))
+                continue
+            row[expert] = got
+            substitutions.append((layer, expert, k, got))
+        projected[layer] = row
+    if log is not None:
+        for layer, expert, want, got in substitutions:
+            log(f"FQ projection L{layer}/e{expert}: K{want} unavailable "
+                f"-> K{got}")
+        for layer, expert, want in missing:
+            log(
+                f"FQ projection L{layer}/e{expert}: K{want} unavailable at "
+                "EVERY K — encode it (lazy_encode --drain) or add a source"
+            )
+        log(
+            f"FQ projection: {len(substitutions)} expert(s) demoted, "
+            f"{len(missing)} unsatisfiable"
+        )
+    return projected, substitutions, missing

--- a/vllm/model_executor/layers/quantization/exl3_fungible/fragments.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/fragments.py
@@ -411,17 +411,92 @@ class HfSource:
                 return None
             raise
 
+    # A progressive boot issues one ranged read PER EXPERT — 19,200 of them for
+    # GLM-5.2. At that volume a transient failure is not an edge case, it is a
+    # certainty: one `IncompleteRead` on layer 3 expert 19 was enough to abort a
+    # whole engine start. Retry the retryable, with backoff; leave 404 and
+    # friends to the caller, which treats them as a genuine MISS.
+    _RETRIES = 4
+    _BACKOFF = 0.4
+
+    # Whole-segment prefetch. A UNIFORM layer needs every expert out of the
+    # same segment file, which as per-expert ranged reads is 256 HTTP requests
+    # for one contiguous object -- 19,200 across GLM-5.2's 75 layers. Pulling
+    # the object once and slicing locally is the same bytes in 1 request, and
+    # it removes 255 independent chances to hit a transient failure.
+    # Deliberately NOT automatic: a layer that needs a single K4 expert would
+    # otherwise drag ~2.5 GB to use ~9 MB. The caller asks, because only the
+    # caller knows the policy.
+    def prefetch_whole(self, relpath: str, dest: "Path") -> "Path | None":
+        """Fetch an entire segment once into ``dest``; return it, or None."""
+        import shutil
+        import tempfile
+        if dest.exists() and dest.stat().st_size > 0:
+            return dest
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        tmp = None
+        try:
+            with self._open(relpath, {}) as r:
+                fd, tmpname = tempfile.mkstemp(dir=str(dest.parent),
+                                               suffix=".part")
+                tmp = Path(tmpname)
+                with open(fd, "wb") as fh:
+                    shutil.copyfileobj(r, fh, length=8 << 20)
+            tmp.replace(dest)          # atomic: a torn file must never be read
+            tmp = None
+            return dest
+        except Exception:  # noqa: BLE001 — prefetch is an optimisation
+            return None
+        finally:
+            if tmp is not None and tmp.exists():
+                tmp.unlink()
+
+    def range_from_prefetched(self, cached: "Path", start: int,
+                              end: int) -> bytes | None:
+        """Slice a prefetched segment, or None if it cannot serve the range."""
+        try:
+            size = cached.stat().st_size
+            if end > size:
+                return None            # truncated/stale: fall back to HTTP
+            with open(cached, "rb") as fh:
+                fh.seek(start)
+                data = fh.read(end - start)
+            return data if len(data) == end - start else None
+        except OSError:
+            return None
+
     def read_range(self, relpath: str, start: int, end: int) -> bytes:
-        with self._open(
-            relpath, {"Range": f"bytes={start}-{end - 1}"}
-        ) as r:
-            data = r.read()
-        if len(data) != end - start:
-            raise IOError(
-                f"{self.name}/{relpath}: ranged read [{start},{end}) returned "
-                f"{len(data)} bytes"
-            )
-        return data
+        import http.client
+        import time
+        import urllib.error
+
+        want = end - start
+        last: Exception | None = None
+        for attempt in range(self._RETRIES):
+            try:
+                with self._open(
+                    relpath, {"Range": f"bytes={start}-{end - 1}"}
+                ) as r:
+                    data = r.read()
+                if len(data) != want:
+                    # A short read is itself the transient failure mode here
+                    # (truncated chunked transfer), so it retries rather than
+                    # being reported as corruption.
+                    raise IOError(
+                        f"{self.name}/{relpath}: ranged read [{start},{end}) "
+                        f"returned {len(data)} bytes")
+                return data
+            except urllib.error.HTTPError:
+                raise                      # 404/403: a real answer, not a blip
+            except (http.client.IncompleteRead, http.client.RemoteDisconnected,
+                    urllib.error.URLError, TimeoutError, ConnectionError,
+                    IOError) as exc:
+                last = exc
+                if attempt + 1 < self._RETRIES:
+                    time.sleep(self._BACKOFF * (2 ** attempt))
+        raise IOError(
+            f"{self.name}/{relpath}: ranged read [{start},{end}) failed after "
+            f"{self._RETRIES} attempts: {type(last).__name__}: {last}")
 
 
 class FragmentResolver:
@@ -586,6 +661,8 @@ class FragmentResolver:
         # (layer, k) -> {expert_str: sha} from LOCAL dirs only
         self._local_sha_maps: dict[tuple[int, int], dict[str, str]] = {}
         # (source_name, layer, k) -> attestation text | None (None=definitive)
+        # (layer, k) -> whole prefetched segment on disk, for uniform layers
+        self._prefetched: dict[tuple[int, int], Path] = {}
         self._att_texts: dict[tuple[str, int, int], str | None] = {}
         # (source_name, layer, k) -> (shas | None, reject reason | None)
         self._att_evals: dict[
@@ -809,6 +886,37 @@ class FragmentResolver:
         if created:
             self.stats["encode_queued"] += 1
         return position, created
+
+    def prefetch_layer(self, layer: int, k: int) -> str | None:
+        """Pull the whole K``k`` segment for ``layer`` from the first source
+        that has it. Call this when the layer is UNIFORM at ``k`` -- it turns
+        256 ranged reads into one object fetch. Returns a short description of
+        what happened, for the boot log; never raises.
+        """
+        for source in self.sources:
+            try:
+                index = self._remote_index(source, k)
+                if not isinstance(index, dict) or str(layer) not in index:
+                    continue
+                entry = _SegmentIndexEntry(index[str(layer)])
+                dest = self._cache_path("segments", f"{entry.sha256}.seg")
+                if dest.exists() and dest.stat().st_size > 0:
+                    self._prefetched[(layer, k)] = dest
+                    return f"cached {entry.file}"
+                got = getattr(source, "prefetch_whole", None)
+                if got is None:
+                    continue           # local dirs need no prefetch
+                path = got(entry.file, dest)
+                if path is not None:
+                    self._prefetched[(layer, k)] = path
+                    self.stats["segments_prefetched"] += 1
+                    return (f"prefetched {entry.file} "
+                            f"({path.stat().st_size} B) from "
+                            f"{getattr(source, 'name', source)}")
+            except Exception:  # noqa: BLE001 — an optimisation must not fail a boot
+                self.stats["source_error"] += 1
+                continue
+        return None
 
     def _cache_path(self, kind: str, name: str) -> Path:
         return self.cache_dir / kind / name
@@ -1309,9 +1417,18 @@ class FragmentResolver:
 
         try:
             lo, hi = entry.expert_range(expert)
-            payload = source.read_range(
-                entry.file, entry.body_offset + lo, entry.body_offset + hi
-            )
+            start = entry.body_offset + lo
+            stop = entry.body_offset + hi
+            payload = None
+            cached = self._prefetched.get((layer, k))
+            if cached is not None:
+                slicer = getattr(source, "range_from_prefetched", None)
+                if slicer is not None:
+                    payload = slicer(cached, start, stop)
+                    if payload is not None:
+                        self.stats["bytes_from_prefetch"] += len(payload)
+            if payload is None:
+                payload = source.read_range(entry.file, start, stop)
         except Exception as exc:  # noqa: BLE001
             self.stats["source_error"] += 1
             return None, f"{name} REJECT error:{type(exc).__name__}", None

--- a/vllm/model_executor/layers/quantization/exl3_fungible/fragments.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/fragments.py
@@ -623,14 +623,26 @@ class HfSource:
 class _DownloadMonitor:
     """Aggregate download progress for the boot log.
 
-    hf_hub_download gives us ONE completion callback, not incremental ones, so
-    the primary fetch path was a silent log -- exactly the "staring at a log
-    that is not progressing" problem the per-file progress was meant to solve,
-    just moved. Rather than reach into hub internals for per-file byte counts,
-    watch the .incomplete files the client leaves in the cache and report the
-    aggregate. For an operator that is the better line anyway: four ranks
-    times several objects would interleave into noise, while one line answers
-    "is it moving, how fast, how many in flight".
+    Two earlier signals were wrong, both for instructive reasons:
+
+    * hf_hub_download gives ONE completion callback, so per-file progress
+      never fired on the primary path.
+    * Watching the growth of the client's ``.incomplete`` staging files does
+      not work with Xet, which PREALLOCATES them: the size never changes
+      during transfer, so every delta was zero and the log read
+      ``3 in flight, 12.1 GiB this boot, 0 MiB/s`` forever, with four ranks
+      cycling four constant totals.
+
+    So measure what is unambiguous instead: bytes DELIVERED, as completed
+    segment objects appear in our cache. That is monotonic by construction
+    (sizes are remembered even after release_layer unlinks the file), it
+    cannot be faked by preallocation, and it is what an operator actually
+    wants to know.
+
+    Because delivery is granular (~GB at a time) the instantaneous rate is
+    bursty, so the headline figure is the AVERAGE since the first byte --
+    which is stable and never reads zero while a boot is making progress --
+    with a recent-window rate beside it.
     """
 
     _instance = None
@@ -641,16 +653,14 @@ class _DownloadMonitor:
         self.every = every
         self._stop = threading.Event()
         self._thread: threading.Thread | None = None
-        self._sizes: dict[str, int] = {}
-        self._done_bytes = 0
-        # EXCLUDE what was already there. A killed boot leaves .incomplete
-        # files behind, and counting them as in-flight makes a HEALTHY boot
-        # report a frozen byte total at 0 MiB/s -- observed live: two corpses
-        # from an hour-old attempt summed to 880 MB and swamped the real
-        # transfer, which was running at 308 MiB/s.
+        # path -> size, never removed: release_layer unlinking a segment is
+        # not un-delivering it.
+        self._delivered: dict[str, int] = {}
+        self._t0: float | None = None
+        self._recent: float = 0.0
         self._preexisting: set[str] = set()
         try:
-            self._preexisting = {str(f) for f in self.root.rglob("*.incomplete")}
+            self._preexisting = {str(f) for f in self.root.rglob("*.safetensors")}
         except OSError:
             pass
 
@@ -672,46 +682,32 @@ class _DownloadMonitor:
     def stop(self) -> None:
         self._stop.set()
 
-    def _scan(self) -> tuple[int, int]:
-        total = count = 0
+    def _in_flight(self) -> int:
+        """Staging files that exist right now -- a COUNT only.
+
+        Deliberately not their size: Xet preallocates, so those bytes say
+        nothing about progress.
+        """
         try:
-            for f in self.root.rglob("*.incomplete"):
-                try:
-                    total += f.stat().st_size
-                    count += 1
-                except OSError:
-                    continue
+            return sum(1 for f in self.root.rglob("*.incomplete")
+                       if str(f) not in self._preexisting)
         except OSError:
-            pass
-        return total, count
+            return 0
 
     def _progress(self) -> tuple[int, int]:
-        """(monotonic bytes downloaded, files in flight).
-
-        Summing the in-flight files alone is NOT progress: a completed file
-        leaves the .incomplete set, so the sum DROPS and the rate reads 0
-        MiB/s next to gigabytes of real transfer -- observed live as
-        "3 in flight, 1.8 GiB this boot, 0 MiB/s". Carry the bytes of files
-        that vanished into a completed total so the series only ever rises.
-        """
-        seen: dict[str, int] = {}
-        count = 0
+        """(bytes delivered so far, staging files in flight)."""
         try:
-            for f in self.root.rglob("*.incomplete"):
-                if str(f) in self._preexisting:
-                    continue          # a corpse from an earlier boot
+            for f in self.root.rglob("*.safetensors"):
+                key = str(f)
+                if key in self._preexisting or key in self._delivered:
+                    continue
                 try:
-                    seen[str(f)] = f.stat().st_size
-                    count += 1
+                    self._delivered[key] = f.stat().st_size
                 except OSError:
                     continue
         except OSError:
             pass
-        for path, size in self._sizes.items():
-            if path not in seen:
-                self._done_bytes += size
-        self._sizes = seen
-        return self._done_bytes + sum(seen.values()), count
+        return sum(self._delivered.values()), self._in_flight()
 
     def _run(self) -> None:
         prev, t_prev = self._progress()[0], time.monotonic()
@@ -719,16 +715,22 @@ class _DownloadMonitor:
             cur, n = self._progress()
             now = time.monotonic()
             delta, dt = cur - prev, max(now - t_prev, 1e-9)
-            if n == 0 and delta <= 0:
+            if cur <= 0 and n == 0:
                 prev, t_prev = cur, now
                 continue
-            # NOTE: with Xet enabled a large share of the transfer lands in
-            # the shared xet chunk cache rather than in these staging files,
-            # so this is a LOWER BOUND on real throughput, not a total.
+            if cur > 0 and self._t0 is None:
+                self._t0 = t_prev
+            inst = max(delta, 0) / dt
+            # EMA so one granular completion does not read as a spike and the
+            # gap after it does not read as a stall.
+            self._recent = inst if self._recent == 0 else (
+                0.6 * self._recent + 0.4 * inst)
+            avg = (cur / max(now - self._t0, 1e-9)) if self._t0 else 0.0
             logger.info(
-                "FQ downloads: %d in flight, >=%.1f GiB this boot, "
-                ">=%.0f MiB/s", n, cur / (1 << 30),
-                max(delta, 0) / dt / (1 << 20))
+                "FQ downloads: %d in flight, %.1f GiB delivered, "
+                "%.0f MiB/s avg (recent %.0f MiB/s)",
+                n, cur / (1 << 30), avg / (1 << 20),
+                self._recent / (1 << 20))
             prev, t_prev = cur, now
 
 
@@ -1286,6 +1288,25 @@ class FragmentResolver:
             return False
         return True
 
+    @staticmethod
+    def keep_layers(environ=None) -> bool:
+        """Retain whole downloaded layer objects for later re-tiering.
+
+        Opt-in, because the cost is real: bounded-by-depth becomes
+        bounded-by-model, and a full GLM-5.2 pass is hundreds of GB. Worth it
+        when you intend to promote/demote experts at runtime and want those
+        swaps to be local slices rather than downloads.
+
+        VLLM_FQ_KEEP_LAYERS is the documented name; VLLM_FQ_PREFETCH_KEEP is
+        kept as an alias so existing runs do not silently change behaviour.
+        """
+        env = environ if environ is not None else os.environ
+        for name in ("VLLM_FQ_KEEP_LAYERS", "VLLM_FQ_PREFETCH_KEEP"):
+            if str(env.get(name, "")).strip().lower() in ("1", "true", "yes",
+                                                          "on"):
+                return True
+        return False
+
     def release_layer(self, layer: int) -> int:
         """Drop the whole-segment objects prefetched for ``layer``.
 
@@ -1301,7 +1322,14 @@ class FragmentResolver:
         people's cache entries is not ours to do. Set VLLM_FQ_PREFETCH_KEEP=1
         to retain everything (faster repeat boots, if disk is free).
         """
-        if os.environ.get("VLLM_FQ_PREFETCH_KEEP", "0") == "1":
+        if self.keep_layers():
+            # KEEP: the whole layer objects stay on disk AND stay in
+            # _prefetched, so a later K3->K4 promotion (or a K4->K3
+            # demotion) slices the new expert out of a local file instead of
+            # re-fetching ~2.5 GB over the network. That is the difference
+            # between a swap that costs milliseconds and one that costs a
+            # download, which is what makes runtime re-tiering practical
+            # rather than merely possible.
             return 0
         freed = 0
         try:

--- a/vllm/model_executor/layers/quantization/exl3_fungible/fragments.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/fragments.py
@@ -444,27 +444,51 @@ class HfSource:
         req = urllib.request.Request(self._url(relpath), headers=headers)
         return urllib.request.urlopen(req, timeout=self.timeout)
 
-    def read_json(self, relpath: str) -> dict | None:
+    def _read_all(self, relpath: str) -> bytes | None:
+        """Fetch a whole small object, retrying the retryable.
+
+        Ranged reads already retried; these did NOT, and the asymmetry was
+        expensive. A single transient blip while fetching an ATTESTATION is
+        indistinguishable, to the caller, from "this source has no
+        attestation" -- so the expert is permanently degraded a tier for the
+        lifetime of the process. Observed live:
+
+            REJECT at att_decision: URLError(Errno 101 Network is unreachable)
+            FQ DEGRADED L5/e2: K4 unavailable, serving K3 instead
+
+        A transient fault must not cause a permanent downgrade.
+        """
+        import http.client
         import urllib.error
 
-        try:
-            with self._open(relpath, {}) as r:
-                return json.loads(r.read())
-        except urllib.error.HTTPError as exc:
-            if exc.code == 404:
-                return None
-            raise
+        last: Exception | None = None
+        for attempt in range(self._RETRIES):
+            try:
+                with self._open(relpath, {}) as r:
+                    return r.read()
+            except urllib.error.HTTPError as exc:
+                if exc.code == 404:
+                    return None        # a genuine MISS, not a fault
+                raise
+            except OfflineError:
+                raise                  # configuration, not a fault
+            except (http.client.IncompleteRead,
+                    http.client.RemoteDisconnected, urllib.error.URLError,
+                    TimeoutError, ConnectionError, OSError) as exc:
+                last = exc
+                if attempt + 1 < self._RETRIES:
+                    time.sleep(self._BACKOFF * (2 ** attempt))
+        raise OSError(
+            f"{self.name}: {relpath} failed after {self._RETRIES} attempts: "
+            f"{type(last).__name__}: {last}")
+
+    def read_json(self, relpath: str) -> dict | None:
+        raw = self._read_all(relpath)
+        return None if raw is None else json.loads(raw)
 
     def read_text(self, relpath: str) -> str | None:
-        import urllib.error
-
-        try:
-            with self._open(relpath, {}) as r:
-                return r.read().decode()
-        except urllib.error.HTTPError as exc:
-            if exc.code == 404:
-                return None
-            raise
+        raw = self._read_all(relpath)
+        return None if raw is None else raw.decode()
 
     # A progressive boot issues one ranged read PER EXPERT — 19,200 of them for
     # GLM-5.2. At that volume a transient failure is not an edge case, it is a

--- a/vllm/model_executor/layers/quantization/exl3_fungible/fragments.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/fragments.py
@@ -126,6 +126,14 @@ _ST_TO_TORCH_NAME = {
 }
 
 
+class OfflineError(OSError):
+    """Raised instead of a network call when HF_HUB_OFFLINE is set.
+
+    Subclasses OSError so the existing transient-error handling treats it as
+    a source MISS rather than a crash — offline is a configuration, not a
+    fault."""
+
+
 class FragmentUnavailableError(RuntimeError):
     """No local dir, cache entry, trusted source, or fallback K could supply
     the fragment; the miss is enqueued for lazy encode (:mod:`.lazy_encode`)
@@ -378,9 +386,42 @@ class HfSource:
                 f"{self.revision}/{relpath}"
             )
 
+    @staticmethod
+    def offline() -> bool:
+        """True when the operator has asked for no network.
+
+        Honours the ECOSYSTEM-STANDARD ``HF_HUB_OFFLINE`` (and vLLM's
+        ``VLLM_NO_USAGE_STATS``-style truthiness) rather than inventing our
+        own knob, because an operator who sets it expects it to bind
+        everything that talks to the Hub. We do NOT go through
+        ``huggingface_hub`` for payload reads — only ``hf_hub_url`` to build a
+        URL, then raw urllib — so the library's own offline handling never
+        applied to us. Without this check, ``HF_HUB_OFFLINE=1`` silently still
+        hit the network, which is the worst kind of wrong for an air-gapped or
+        reproducibility-audited run.
+
+        ``FQ_ALLOW_NETWORK=1`` is the explicit override for the case where a
+        caller wants Hub access despite the global flag.
+        """
+        if os.environ.get("FQ_ALLOW_NETWORK", "").strip().lower() in (
+                "1", "true", "yes", "on"):
+            return False
+        for var in ("HF_HUB_OFFLINE", "TRANSFORMERS_OFFLINE"):
+            if os.environ.get(var, "").strip().lower() in (
+                    "1", "true", "yes", "on"):
+                return True
+        return False
+
     def _open(self, relpath: str, headers: dict[str, str]):
         import urllib.request
 
+        if self.offline():
+            # Raise the same shape a 404 does so every caller already handles
+            # it as "this source has nothing", falling through to local dirs,
+            # the primed cache, and then the K ladder.
+            raise OfflineError(
+                f"{self.name}: HF_HUB_OFFLINE is set; refusing to fetch "
+                f"{relpath}. Prime the cache, or set FQ_ALLOW_NETWORK=1.")
         token = os.environ.get("HF_TOKEN") or os.environ.get(
             "HUGGING_FACE_HUB_TOKEN"
         )
@@ -486,6 +527,8 @@ class HfSource:
                         f"{self.name}/{relpath}: ranged read [{start},{end}) "
                         f"returned {len(data)} bytes")
                 return data
+            except OfflineError:
+                raise                      # a configuration, not a blip
             except urllib.error.HTTPError:
                 raise                      # 404/403: a real answer, not a blip
             except (http.client.IncompleteRead, http.client.RemoteDisconnected,

--- a/vllm/model_executor/layers/quantization/exl3_fungible/fragments.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/fragments.py
@@ -916,6 +916,7 @@ class FragmentResolver:
             "segments_prefetched": 0,
             "segments_released": 0,
             "segments_shared": 0,
+            "segments_local": 0,
             "bytes_from_prefetch": 0,
             "unavailable": 0,
             # hardening counters: a broken local dir / unreadable cache entry
@@ -1166,6 +1167,17 @@ class FragmentResolver:
         256 ranged reads into one object fetch. Returns a short description of
         what happened, for the boot log; never raises.
         """
+        # LOCAL FIRST. prefetch_layer only ever consulted self.sources (the
+        # remote mirrors), so a layer sitting in a local segment dir was
+        # re-downloaded from the Hub -- paying network AND disk for bytes
+        # already present. Nothing to reflink here because nothing needs
+        # copying at all: the local segment is mmapped in place.
+        for base in self.local_dirs:
+            seg = self._local_segment(base, layer, k)
+            if seg is not None:
+                self.stats["segments_local"] += 1
+                return f"local {base}/{self._seg_name(layer, k)} (no fetch)"
+
         for source in self.sources:
             try:
                 index = self._remote_index(source, k)
@@ -1311,6 +1323,44 @@ class FragmentResolver:
         except OSError:
             return False
         return True
+
+    @staticmethod
+    def reflink_or_copy(src: Path, dst: Path) -> str:
+        """Materialise ``dst`` from ``src``, sharing extents when the kernel
+        and filesystem allow.
+
+        Same mechanism fq_assemble --reflink uses (os.copy_file_range, which
+        XFS-with-reflink and btrfs turn into an extent share): a 3.7 GB mixed
+        checkpoint assembled in 3.8 s that way. The honest caveat carried over
+        from that tool: copy_file_range may SILENTLY perform a plain copy, so
+        the return value reports what actually happened rather than claiming a
+        reflink we cannot verify.
+        """
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        size = src.stat().st_size
+        tmp = dst.with_suffix(dst.suffix + f".rl{os.getpid()}")
+        try:
+            with open(src, "rb") as fi, open(tmp, "wb") as fo:
+                remaining = size
+                while remaining:
+                    sent = os.copy_file_range(fi.fileno(), fo.fileno(),
+                                              remaining)
+                    if not sent:
+                        break
+                    remaining -= sent
+                if remaining:
+                    raise OSError(f"short copy_file_range: {remaining} left")
+            os.replace(tmp, dst)
+            return "reflink/copy_file_range"
+        except (OSError, AttributeError):
+            try:
+                if tmp.exists():
+                    tmp.unlink()
+            except OSError:
+                pass
+            import shutil
+            shutil.copyfile(src, dst)
+            return "plain copy"
 
     @staticmethod
     def keep_layers(environ=None) -> bool:

--- a/vllm/model_executor/layers/quantization/exl3_fungible/fragments.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/fragments.py
@@ -1,0 +1,614 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""FragmentResolver — Progressive Tensors fragment resolution (loader v2).
+
+Resolves the payload of one routed expert at one bitrate K — the contiguous
+per-expert byte range of a ``layer-{L:03d}.k{K}.safetensors`` segment file
+(fq_repack layout, implementation/10 §1) — through the resolution order of
+implementation/10 §2:
+
+    local segment dirs  ->  manifest ``sources`` chain (HF ranged reads)
+                        ->  (local encode from BF16: T3, not implemented)
+
+Content addressing: every segment ships a per-expert sha256 map inside its
+attestation line (``attestations/layer-{L:03d}.k{K}.jsonl``, fq-attestation/1
+payload field ``expert_sha256``); the per-layer ``index-k{K}.json`` carries the
+file-level sha256, ``body_offset`` and the per-expert ``[lo, hi)`` body
+ranges. Every *fetched* fragment is verified against its expected sha before
+use and cached content-addressed under ``VLLM_FQ_CACHE`` (default
+``~/.cache/vllm/fq``); cache hits are re-hashed on read (they are small).
+Local segment-dir reads are trusted by default (``VLLM_FQ_VERIFY=fetched``);
+``VLLM_FQ_VERIFY=all`` extends verification to local reads, ``off`` disables
+it (fetching without an attestation then becomes possible).
+
+This module is deliberately stdlib-only at import time; torch is imported
+lazily inside :meth:`FragmentResolver.expert_tensors` so the resolver core
+stays testable on CPU without a built vllm.
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import mmap
+import os
+import re
+import struct
+import warnings
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable
+
+FQ_CACHE_ENV = "VLLM_FQ_CACHE"
+FQ_VERIFY_ENV = "VLLM_FQ_VERIFY"
+FQ_SOURCES_ENV = "VLLM_FQ_SOURCES"
+FQ_LOCAL_SEGMENTS_ENV = "VLLM_FQ_LOCAL_SEGMENTS"
+
+DEFAULT_CACHE_DIR = "~/.cache/vllm/fq"
+
+EXPERT_RE = re.compile(
+    r"^model\.layers\.(\d+)\.mlp\.experts\.(\d+)\.(\w+_proj)\.rank(\d+)\.(\w+)$"
+)
+
+_ST_TO_TORCH_NAME = {
+    "F64": "float64",
+    "F32": "float32",
+    "F16": "float16",
+    "BF16": "bfloat16",
+    "I64": "int64",
+    "I32": "int32",
+    "I16": "int16",
+    "I8": "int8",
+    "U8": "uint8",
+    "BOOL": "bool",
+}
+
+
+class FragmentUnavailableError(RuntimeError):
+    """No local dir or source could supply the fragment (T3 encode is out
+    of scope for loader v2)."""
+
+
+class FragmentVerificationError(RuntimeError):
+    """Fragment bytes did not match their expected sha256."""
+
+
+def read_safetensors_header(path: Path) -> tuple[dict, int]:
+    """Return (header_dict, body_offset) of a safetensors file."""
+    with open(path, "rb") as f:
+        hlen = struct.unpack("<Q", f.read(8))[0]
+        hdr = json.loads(f.read(hlen))
+    return hdr, 8 + hlen
+
+
+def parse_segment_header_bytes(raw: bytes) -> tuple[dict, int]:
+    """Parse header bytes fetched as ``file[0:body_offset)``."""
+    hlen = struct.unpack("<Q", raw[:8])[0]
+    if 8 + hlen != len(raw):
+        raise ValueError(
+            f"segment header length mismatch: 8+{hlen} != {len(raw)} bytes"
+        )
+    return json.loads(raw[8 : 8 + hlen]), 8 + hlen
+
+
+def _attestation_expert_shas(text: str) -> dict[str, str]:
+    """Extract the per-expert sha map from a fq-attestation/1 jsonl blob.
+
+    Signature verification is a trust-policy concern (10 §4, VLLM_FQ_TRUST)
+    and lands with the trust-list milestone; content addressing only needs
+    the payload."""
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        envelope = json.loads(line)
+        payload = json.loads(base64.b64decode(envelope["payload"]))
+        shas = payload.get("expert_sha256")
+        if isinstance(shas, dict):
+            return shas
+    return {}
+
+
+@dataclass(frozen=True)
+class FragmentTensor:
+    """One tensor inside a fragment payload (offsets relative to payload)."""
+
+    name: str
+    dtype: str  # safetensors dtype string
+    shape: tuple[int, ...]
+    start: int
+    end: int
+
+
+@dataclass
+class Fragment:
+    """A resolved per-expert payload plus its tensor table."""
+
+    layer: int
+    expert: int
+    k: int
+    payload: Any  # bytes | memoryview (buffer protocol)
+    tensors: list[FragmentTensor]
+    origin: str  # "local" | "cache" | "fetched"
+    sha256: str | None = None
+
+
+class _SegmentIndexEntry:
+    """One layer's entry of an index-k{K}.json."""
+
+    def __init__(self, entry: dict):
+        self.file: str = entry["file"]
+        self.sha256: str = entry["sha256"]
+        self.body_offset: int = int(entry["body_offset"])
+        self.experts: dict[str, list[int]] = entry["experts"]
+
+    def expert_range(self, expert: int) -> tuple[int, int]:
+        rng = self.experts.get(str(expert))
+        if rng is None:
+            raise KeyError(f"expert {expert} not in segment index for {self.file}")
+        return int(rng[0]), int(rng[1])
+
+
+def _expert_tables_from_header(
+    header: dict, entry: _SegmentIndexEntry
+) -> dict[int, list[FragmentTensor]]:
+    """Group segment-header tensors per expert, offsets fragment-relative.
+
+    One pass over the (large) header; validated against the index ranges."""
+    tables: dict[int, list[FragmentTensor]] = {}
+    for name, t in header.items():
+        if name == "__metadata__":
+            continue
+        m = EXPERT_RE.match(name)
+        if m is None:
+            continue
+        expert = int(m.group(2))
+        lo, hi = entry.expert_range(expert)
+        a, b = t["data_offsets"]
+        if a < lo or b > hi:
+            raise ValueError(
+                f"segment tensor {name} at [{a},{b}) escapes indexed expert "
+                f"range [{lo},{hi})"
+            )
+        tables.setdefault(expert, []).append(
+            FragmentTensor(name, t["dtype"], tuple(t["shape"]), a - lo, b - lo)
+        )
+    for items in tables.values():
+        items.sort(key=lambda ft: ft.start)
+    return tables
+
+
+class _LocalSegment:
+    """One local layer-K segment file, mmapped, with its tensor tables."""
+
+    def __init__(self, path: Path, entry: _SegmentIndexEntry):
+        self.path = path
+        self.entry = entry
+        header, body_offset = read_safetensors_header(path)
+        if body_offset != entry.body_offset:
+            raise ValueError(
+                f"{path}: body_offset {body_offset} != index {entry.body_offset}"
+            )
+        self.tables = _expert_tables_from_header(header, entry)
+        self._f = open(path, "rb")
+        # Never explicitly closed: fragments hand out zero-copy memoryviews
+        # whose lifetime the GC ties to this mapping.
+        self._mm = mmap.mmap(self._f.fileno(), 0, access=mmap.ACCESS_READ)
+
+    def fragment(self, expert: int) -> tuple[memoryview, list[FragmentTensor]]:
+        lo, hi = self.entry.expert_range(expert)
+        view = memoryview(self._mm)[
+            self.entry.body_offset + lo : self.entry.body_offset + hi
+        ]
+        return view, self.tables[expert]
+
+
+class HfSource:
+    """A Hugging Face repo source: whole-file JSON + ranged byte reads.
+
+    Spec syntax: ``org/name``, ``hf:org/name`` or ``hf:org/name@revision``.
+    Token from ``HF_TOKEN`` / ``HUGGING_FACE_HUB_TOKEN``."""
+
+    def __init__(self, spec: str, *, timeout: float = 60.0):
+        spec = spec.removeprefix("hf:")
+        self.revision = "main"
+        if "@" in spec:
+            spec, self.revision = spec.rsplit("@", 1)
+        self.repo_id = spec
+        self.name = f"hf:{self.repo_id}@{self.revision}"
+        self.timeout = timeout
+
+    def _url(self, relpath: str) -> str:
+        try:
+            from huggingface_hub import hf_hub_url
+
+            return hf_hub_url(self.repo_id, relpath, revision=self.revision)
+        except ImportError:
+            return (
+                f"https://huggingface.co/{self.repo_id}/resolve/"
+                f"{self.revision}/{relpath}"
+            )
+
+    def _open(self, relpath: str, headers: dict[str, str]):
+        import urllib.request
+
+        token = os.environ.get("HF_TOKEN") or os.environ.get(
+            "HUGGING_FACE_HUB_TOKEN"
+        )
+        if token:
+            headers = {**headers, "Authorization": f"Bearer {token}"}
+        req = urllib.request.Request(self._url(relpath), headers=headers)
+        return urllib.request.urlopen(req, timeout=self.timeout)
+
+    def read_json(self, relpath: str) -> dict | None:
+        import urllib.error
+
+        try:
+            with self._open(relpath, {}) as r:
+                return json.loads(r.read())
+        except urllib.error.HTTPError as exc:
+            if exc.code == 404:
+                return None
+            raise
+
+    def read_text(self, relpath: str) -> str | None:
+        import urllib.error
+
+        try:
+            with self._open(relpath, {}) as r:
+                return r.read().decode()
+        except urllib.error.HTTPError as exc:
+            if exc.code == 404:
+                return None
+            raise
+
+    def read_range(self, relpath: str, start: int, end: int) -> bytes:
+        with self._open(
+            relpath, {"Range": f"bytes={start}-{end - 1}"}
+        ) as r:
+            data = r.read()
+        if len(data) != end - start:
+            raise IOError(
+                f"{self.name}/{relpath}: ranged read [{start},{end}) returned "
+                f"{len(data)} bytes"
+            )
+        return data
+
+
+class FragmentResolver:
+    """Resolve (layer, expert, K) fragments: local dirs -> sources -> error.
+
+    The seam the M4 swap engine reuses: :meth:`resolve` for raw payloads,
+    :meth:`expert_tensors` for materialized ``(name, tensor)`` pairs.
+    """
+
+    def __init__(
+        self,
+        manifest_dir: str | Path,
+        *,
+        local_dirs: list[str | Path] | None = None,
+        sources: list[Any] | None = None,
+        cache_dir: str | Path | None = None,
+        verify: str | None = None,
+        source_factory: Callable[[str], Any] = HfSource,
+        environ: dict[str, str] = os.environ,  # noqa: B008
+    ):
+        self.manifest_dir = Path(manifest_dir)
+        manifest_path = self.manifest_dir / "fq-manifest.json"
+        self.manifest: dict = (
+            json.loads(manifest_path.read_text()) if manifest_path.exists() else {}
+        )
+
+        dirs: list[Path] = [self.manifest_dir]
+        for extra in (environ.get(FQ_LOCAL_SEGMENTS_ENV) or "").split(":"):
+            if extra:
+                dirs.append(Path(extra))
+        if local_dirs:
+            dirs.extend(Path(d) for d in local_dirs)
+        self.local_dirs = dirs
+
+        self.cache_dir = Path(
+            cache_dir
+            or environ.get(FQ_CACHE_ENV)
+            or os.path.expanduser(DEFAULT_CACHE_DIR)
+        )
+
+        self.verify = (verify or environ.get(FQ_VERIFY_ENV) or "fetched").lower()
+        if self.verify not in ("fetched", "all", "off"):
+            raise ValueError(
+                f"{FQ_VERIFY_ENV} must be fetched|all|off, got {self.verify!r}"
+            )
+
+        if sources is not None:
+            self.sources = list(sources)
+        else:
+            specs = environ.get(FQ_SOURCES_ENV)
+            if specs is not None:
+                raw = [s for s in specs.split(",") if s]
+            else:
+                raw = [
+                    s
+                    for s in self.manifest.get("sources", ())
+                    if isinstance(s, str) and not s.startswith("local:")
+                ]
+            self.sources = [source_factory(spec) for spec in raw]
+
+        self.stats = {
+            "local": 0,
+            "cache": 0,
+            "fetched": 0,
+            "verified": 0,
+            "sha_mismatch": 0,
+            "bytes_fetched": 0,
+        }
+        # (dir, layer, k) -> _LocalSegment | None
+        self._local_segments: dict[tuple[Path, int, int], _LocalSegment | None] = {}
+        # (layer, k) -> {expert_str: sha}
+        self._expert_shas: dict[tuple[int, int], dict[str, str]] = {}
+        # (source_name, k) -> index dict | None
+        self._remote_indexes: dict[tuple[str, int], dict | None] = {}
+        # file_sha -> (header, tables-by-expert)
+        self._remote_headers: dict[str, tuple[dict, dict[int, list[FragmentTensor]]]] = {}
+
+    # ------------------------------------------------------------ helpers
+
+    @staticmethod
+    def _seg_name(layer: int, k: int) -> str:
+        return f"layer-{layer:03d}.k{k}.safetensors"
+
+    @staticmethod
+    def _att_name(layer: int, k: int) -> str:
+        return f"attestations/layer-{layer:03d}.k{k}.jsonl"
+
+    def _local_segment(
+        self, base: Path, layer: int, k: int
+    ) -> _LocalSegment | None:
+        key = (base, layer, k)
+        if key in self._local_segments:
+            return self._local_segments[key]
+        seg: _LocalSegment | None = None
+        index_path = base / f"index-k{k}.json"
+        seg_path = base / self._seg_name(layer, k)
+        if index_path.exists() and seg_path.exists():
+            index = json.loads(index_path.read_text())
+            entry = index.get(str(layer))
+            if entry is not None:
+                seg = _LocalSegment(seg_path, _SegmentIndexEntry(entry))
+        self._local_segments[key] = seg
+        return seg
+
+    def _expected_sha(self, layer: int, k: int, expert: int) -> str | None:
+        key = (layer, k)
+        shas = self._expert_shas.get(key)
+        if shas is None:
+            shas = {}
+            for base in self.local_dirs:
+                p = base / self._att_name(layer, k)
+                if p.exists():
+                    shas = _attestation_expert_shas(p.read_text())
+                    break
+            else:
+                cached = self._cache_path("attestations", f"layer-{layer:03d}.k{k}.jsonl")
+                if cached.exists():
+                    shas = _attestation_expert_shas(cached.read_text())
+            self._expert_shas[key] = shas
+        return shas.get(str(expert))
+
+    def _cache_path(self, kind: str, name: str) -> Path:
+        return self.cache_dir / kind / name
+
+    def _cache_fragment_path(self, sha: str) -> Path:
+        return self.cache_dir / "fragments" / sha[:2] / sha
+
+    @staticmethod
+    def _atomic_write(path: Path, data: bytes) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(path.suffix + f".tmp{os.getpid()}")
+        tmp.write_bytes(data)
+        os.replace(tmp, path)
+
+    def _check_sha(
+        self, payload: Any, expected: str | None, what: str
+    ) -> str:
+        digest = hashlib.sha256(bytes(payload)).hexdigest()
+        if expected is not None and digest != expected:
+            self.stats["sha_mismatch"] += 1
+            raise FragmentVerificationError(
+                f"{what}: sha256 {digest[:16]}... != expected {expected[:16]}..."
+            )
+        self.stats["verified"] += 1
+        return digest
+
+    # ------------------------------------------------------------ resolve
+
+    def resolve(self, layer: int, expert: int, k: int) -> Fragment:
+        # 1. local segment dirs
+        for base in self.local_dirs:
+            seg = self._local_segment(base, layer, k)
+            if seg is None:
+                continue
+            payload, tensors = seg.fragment(expert)
+            sha = None
+            if self.verify == "all":
+                sha = self._check_sha(
+                    payload,
+                    self._expected_sha(layer, k, expert),
+                    f"local {seg.path.name} expert {expert}",
+                )
+            self.stats["local"] += 1
+            return Fragment(layer, expert, k, payload, tensors, "local", sha)
+
+        # 2. fragment cache (content-addressed by expected sha)
+        expected = self._expected_sha(layer, k, expert)
+        if expected is not None:
+            cached = self._cache_fragment_path(expected)
+            if cached.exists():
+                payload = cached.read_bytes()
+                self._check_sha(
+                    payload, expected, f"cache {cached.name} expert {expert}"
+                )
+                tensors = self._tensor_table_for(layer, expert, k)
+                if tensors is not None:
+                    self.stats["cache"] += 1
+                    return Fragment(
+                        layer, expert, k, payload, tensors, "cache", expected
+                    )
+
+        # 3. sources chain
+        errors: list[str] = []
+        for source in self.sources:
+            try:
+                fragment = self._fetch(source, layer, expert, k)
+            except FragmentVerificationError:
+                raise
+            except Exception as exc:  # noqa: BLE001 — try the next mirror
+                errors.append(f"{getattr(source, 'name', source)}: {exc}")
+                continue
+            if fragment is not None:
+                return fragment
+            errors.append(f"{getattr(source, 'name', source)}: not found")
+
+        raise FragmentUnavailableError(
+            f"layer {layer} expert {expert} k{k}: no local segment dir has it "
+            f"({[str(d) for d in self.local_dirs]}), sources exhausted "
+            f"({errors or 'none configured'}); local encode from BF16 (T3) is "
+            "not implemented in loader v2"
+        )
+
+    def _remote_index(self, source: Any, k: int) -> dict | None:
+        key = (source.name, k)
+        if key in self._remote_indexes:
+            return self._remote_indexes[key]
+        index = source.read_json(f"index-k{k}.json")
+        self._remote_indexes[key] = index
+        return index
+
+    def _remote_tables(
+        self, source: Any, entry: _SegmentIndexEntry
+    ) -> dict[int, list[FragmentTensor]]:
+        cached = self._remote_headers.get(entry.sha256)
+        if cached is not None:
+            return cached[1]
+        header_cache = self._cache_path("headers", f"{entry.sha256}.json")
+        if header_cache.exists():
+            header = json.loads(header_cache.read_text())
+        else:
+            raw = source.read_range(entry.file, 0, entry.body_offset)
+            header, _ = parse_segment_header_bytes(raw)
+            self._atomic_write(
+                header_cache, json.dumps(header, separators=(",", ":")).encode()
+            )
+        tables = _expert_tables_from_header(header, entry)
+        self._remote_headers[entry.sha256] = (header, tables)
+        return tables
+
+    def _tensor_table_for(
+        self, layer: int, expert: int, k: int
+    ) -> list[FragmentTensor] | None:
+        """Tensor table for a cached payload, from any cached segment header."""
+        for source in self.sources:
+            try:
+                index = self._remote_index(source, k)
+            except Exception:  # noqa: BLE001
+                continue
+            if index is None or str(layer) not in index:
+                continue
+            entry = _SegmentIndexEntry(index[str(layer)])
+            header_cache = self._cache_path("headers", f"{entry.sha256}.json")
+            if entry.sha256 in self._remote_headers or header_cache.exists():
+                return self._remote_tables(source, entry).get(expert)
+        return None
+
+    def _fetch(
+        self, source: Any, layer: int, expert: int, k: int
+    ) -> Fragment | None:
+        index = self._remote_index(source, k)
+        if index is None or str(layer) not in index:
+            return None
+        entry = _SegmentIndexEntry(index[str(layer)])
+
+        expected = self._expected_sha(layer, k, expert)
+        if expected is None:
+            text = source.read_text(self._att_name(layer, k))
+            if text is not None:
+                self._atomic_write(
+                    self._cache_path(
+                        "attestations", f"layer-{layer:03d}.k{k}.jsonl"
+                    ),
+                    text.encode(),
+                )
+                self._expert_shas.pop((layer, k), None)
+                expected = self._expected_sha(layer, k, expert)
+        if expected is None and self.verify != "off":
+            raise FragmentVerificationError(
+                f"layer {layer} expert {expert} k{k}: source "
+                f"{getattr(source, 'name', source)} has no attestation sha; "
+                f"refusing unverified fetch (set {FQ_VERIFY_ENV}=off to allow)"
+            )
+
+        lo, hi = entry.expert_range(expert)
+        payload = source.read_range(
+            entry.file, entry.body_offset + lo, entry.body_offset + hi
+        )
+        self.stats["bytes_fetched"] += len(payload)
+        if self.verify == "off" and expected is None:
+            sha = hashlib.sha256(payload).hexdigest()
+        else:
+            sha = self._check_sha(
+                payload,
+                expected,
+                f"fetched {entry.file} expert {expert} from "
+                f"{getattr(source, 'name', source)}",
+            )
+
+        self._atomic_write(self._cache_fragment_path(sha), payload)
+        tensors = self._remote_tables(source, entry).get(expert)
+        if tensors is None:
+            raise FragmentUnavailableError(
+                f"segment {entry.file} header has no tensors for expert {expert}"
+            )
+        self.stats["fetched"] += 1
+        return Fragment(layer, expert, k, payload, tensors, "fetched", sha)
+
+    # ------------------------------------------------------- tensor view
+
+    def expert_tensors(
+        self,
+        layer: int,
+        expert: int,
+        k: int,
+        *,
+        name_filter: Callable[[str], bool] | None = None,
+    ) -> list[tuple[str, Any]]:
+        """Materialize the fragment as ``[(checkpoint_name, cpu_tensor)]``.
+
+        Tensors are zero-copy views over the fragment payload (mmap for
+        local segments); downstream weight loaders copy them to device."""
+        import torch
+
+        fragment = self.resolve(layer, expert, k)
+        mv = memoryview(fragment.payload)
+        out: list[tuple[str, Any]] = []
+        for ft in fragment.tensors:
+            if name_filter is not None and not name_filter(ft.name):
+                continue
+            dtype = getattr(torch, _ST_TO_TORCH_NAME[ft.dtype])
+            numel = 1
+            for dim in ft.shape:
+                numel *= dim
+            nbytes = numel * dtype.itemsize
+            if nbytes != ft.end - ft.start:
+                raise ValueError(
+                    f"{ft.name}: {ft.shape} {ft.dtype} needs {nbytes} bytes, "
+                    f"fragment slot holds {ft.end - ft.start}"
+                )
+            if numel == 0:
+                out.append((ft.name, torch.empty(ft.shape, dtype=dtype)))
+                continue
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", UserWarning)
+                tensor = torch.frombuffer(
+                    mv, dtype=dtype, count=numel, offset=ft.start
+                ).view(ft.shape)
+            out.append((ft.name, tensor))
+        return out

--- a/vllm/model_executor/layers/quantization/exl3_fungible/heatmap.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/heatmap.py
@@ -153,16 +153,30 @@ def gate_reason(environ: Mapping[str, str] | None = None) -> str:
 
 
 def _require_gates(environ: Mapping[str, str] | None = None) -> None:
-    """The gates, enforced at the WORKER as well as at the router.
+    """The ENV gates, enforced at the WORKER as well as at the router.
 
     ``register_vllm_dev_api_routers`` also attaches vLLM's own
     ``POST /collective_rpc``, which forwards an arbitrary ``method`` name
     to every worker, and ``Worker.fq_heatmap_sample`` is an
     unconditional method. Without this check ``VLLM_SERVER_DEV_MODE=1``
     alone would be enough to read the routing matrix — and, worse, to
-    reach ``op=zero_collector`` — bypassing ``VLLM_FQ_HEATMAP`` and the
-    token entirely. Worker processes inherit the server environment, so
-    the same env is visible here.
+    reach ``op=zero_collector``. Worker processes inherit the server
+    environment, so the same env is visible here.
+
+    **This does NOT enforce ``VLLM_FQ_HEATMAP_TOKEN``**, and cannot: the
+    token is an HTTP header checked at the router, and nothing of the
+    HTTP request survives into ``collective_rpc``. So on a serve with
+    ``VLLM_SERVER_DEV_MODE=1`` + ``VLLM_FQ_HEATMAP=1`` + a token set,
+    ``POST /collective_rpc {"method": "fq_heatmap_sample"}`` still
+    returns the matrix without the token
+    (``test_the_worker_gate_is_env_only_the_token_does_not_reach_it``).
+    That is not a hole this surface can close: ``/collective_rpc``
+    forwards ANY worker method, so anyone who can reach it already has
+    strictly more reach than the heatmap token grants. Treat the token
+    as protecting the heatmap ROUTE, not the worker method, and do not
+    expose ``/collective_rpc`` to anyone who must not read the matrix.
+    The destructive scope stays behind its own env gate
+    (:func:`collector_zero_allowed`), which this path does honour.
     """
     if not heatmap_enabled(environ):
         raise AdminError("fq_heatmap_disabled", gate_reason(environ),
@@ -412,7 +426,18 @@ class _CumAccumulator:
             return
         window_len = int(collector.window_len)
         n_new = int(rolled) - int(self.rolled)
-        if n_new <= 0:
+        if n_new < 0:
+            # The ring REWOUND under us: ``op=zero_collector`` sets
+            # ``_windows_rolled = 0`` (this module's own destructive
+            # scope), and a re-created collector starts at 0 too.
+            # Returning here would pin the cumulative at its pre-zero
+            # total for however long it takes ``rolled`` to climb back
+            # past it — a frozen number that still looks like a running
+            # one — and then resume as if nothing had happened. Start
+            # over and let ``cum_since_step`` say where from.
+            self.rebase(rolled, step, layers, num_experts)
+            return
+        if n_new == 0:
             return
         if n_new > window_len:
             self.dropped_slots += n_new - window_len
@@ -491,6 +516,14 @@ def _select_rows(all_layers: Sequence[int],
     if not rows:
         raise AdminError("bad_layers", "empty layer selection", status=400)
     return rows, ids
+
+
+def _as_rank(value: Any) -> int:
+    """A rank from a worker payload, or -1 when it is absent/unparseable."""
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return -1
 
 
 def _rank_of(worker: Any, state: Any) -> int:
@@ -791,6 +824,16 @@ def _worker_do_zero_collector(worker: Any) -> dict:
         collector._mass_win[lid].zero_()
     collector._win_pos = 0
     collector._windows_rolled = 0
+    # The cumulative accumulator integrates the slots that rolled BETWEEN
+    # polls, off ``_windows_rolled``. Rewinding that counter without
+    # rebasing here would leave ``cum_count`` reporting a total for
+    # traffic that no longer exists anywhere, frozen until ``rolled``
+    # climbs back past its old value. ``integrate`` also detects the
+    # rewind on its own; doing it at the source means ``cum_since_step``
+    # is right on the very next sample rather than one sample late.
+    _CUM.rebase(0, int(getattr(collector, "_step", 0)),
+                _row_layers(state, collector, has_loop),
+                int(collector.num_experts))
     rank = _rank_of(worker, state)
     logger.warning(
         "FQ heatmap: COLLECTOR ZEROED on rank %d (%s=1). The policy loop "
@@ -1165,8 +1208,20 @@ def build_router(*, environ: Mapping[str, str] | None = None) -> Any:
         are replicas of one gate, so summing would report 4x the traffic.
         """
         global _LAST_DIVERGENCE_LOG_MS
-        canonical = next((r for r in results if r.get("canonical")),
-                         results[0])
+        # Rank 0 FIRST, then any canonical rank, then whatever came back.
+        # ``?reduce=all`` makes EVERY rank mark itself canonical (each one
+        # ships its arrays), so "the first canonical entry" is only rank 0
+        # while the executor happens to return results in rank order —
+        # ``_rank_results`` preserves whatever order it is handed. Picking
+        # by rank keeps ``merge_rule: rank0-canonical`` true of the arrays
+        # in the envelope, not just of the label on them.
+        canonical = next(
+            (r for r in results
+             if r.get("canonical") and _as_rank(r.get("rank")) == 0),
+            None)
+        if canonical is None:
+            canonical = next((r for r in results if r.get("canonical")),
+                             results[0])
         agree = _agree(results, "digest")
         warns: list[str] = []
         if not agree:

--- a/vllm/model_executor/layers/quantization/exl3_fungible/heatmap.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/heatmap.py
@@ -1,0 +1,1581 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Fungible-quant activation-matrix endpoint (``GET /fq/heatmap``).
+
+The operator-facing question this answers: *which experts is the router
+actually sending traffic to, right now, per layer, with the current K
+tier overlaid.* Implements ``runs/m5-serve/heatmap/ENDPOINT-SPEC.md``.
+
+Three facts about the data drive every decision in this file, and all
+three are properties of :class:`~.stats.FqStatsCollector`, not of the
+transport:
+
+1. **It is 19,200 float64 cells.** 75 instrumented MoE layers x 256
+   experts on GLM-5.2. Serialised the way ``loop._dump_stats`` does it
+   that is ~800 KB per sample (measured: 807,073 B/record mean over the
+   archived dumps). Base64 bf16 + ``Content-Encoding: gzip`` puts the
+   default sample at **33,163 B** on the wire, a 24x reduction, at a
+   measured 0.38898 % worst-case relative error — far below anything a
+   colour ramp resolves.
+2. **It is piecewise constant between window rolls.** ``decayed()``
+   reads only ``_count_win`` / ``_win_pos`` / ``_windows_rolled``
+   (stats.py:320-341), and all three are written only at a roll
+   (stats.py:287-298). At the observed ~2.1 engine steps/s and
+   ``window_stride=32`` that is one change every ~15 s, so a weak
+   ``ETag`` turns six polls out of seven into a ~200 B ``304``.
+3. **Reading it stalls the engine.** The utility RPC is dispatched
+   between engine steps (core.py:1387-1394) and ``collective_rpc``
+   blocks (multiproc_executor.py:364,421). Hence the single-flight lock
+   + TTL cache here, and hence the worker does the cheapest possible
+   work: it casts and base64s, and never compresses.
+
+**Cross-rank merge rule: rank 0 is canonical. Counts are NOT summed.**
+See :data:`MERGE_RULE` for the derivation from ``stats.py`` — getting
+this wrong inflates every number by the TP degree (4x on this serve).
+
+Ownership: this module reads the collector through its public surface
+(``decayed``, ``mass_is_real``, ``count_buf``, ``num_experts``,
+``window_len``/``window_stride``/``decay``) plus the documented window
+bookkeeping (``_windows_rolled``, ``_win_pos``, ``_step``,
+``_count_win``). It reuses the admin API's rank helpers by import. It
+edits nothing in ``stats.py``, ``loop.py``, ``policy.py``,
+``admin.py`` or ``occupancy_table.py``.
+"""
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import json
+import logging
+import time
+import uuid
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import numpy as np
+
+from vllm.model_executor.layers.quantization.exl3_fungible.admin import (
+    DEV_MODE_ENV,
+    AdminError,
+    _agree,
+    _env,
+    _env_float,
+    _env_int,
+    _first_error,
+    _rank_results,
+    dev_mode_enabled,
+)
+
+logger = logging.getLogger(__name__)
+
+# ------------------------------------------------------------------ env knobs
+
+#: Second gate, specific to this surface. Deliberately NOT
+#: ``VLLM_FQ_ADMIN_API``: the routing matrix is a fingerprint of what the
+#: model is being asked to do, but it is read-only, so a dashboard should
+#: be able to see it without holding the credential that mutates live
+#: weights.
+HEATMAP_API_ENV = "VLLM_FQ_HEATMAP"
+HEATMAP_API_ALIAS_ENV = "VLLM_FQ_HEATMAP_API"
+HEATMAP_TOKEN_ENV = "VLLM_FQ_HEATMAP_TOKEN"
+HEATMAP_MIN_PERIOD_MS_ENV = "VLLM_FQ_HEATMAP_MIN_PERIOD_MS"
+HEATMAP_TIMEOUT_S_ENV = "VLLM_FQ_HEATMAP_TIMEOUT_S"
+HEATMAP_ALLOW_COLLECTOR_ZERO_ENV = "VLLM_FQ_HEATMAP_ALLOW_COLLECTOR_ZERO"
+
+TOKEN_HEADER = "X-FQ-Heatmap-Token"
+
+DEFAULT_MIN_PERIOD_MS = 500
+DEFAULT_TIMEOUT_S = 5.0
+DEFAULT_MAX_AGE_MS = 1000
+GZIP_LEVEL = 1  # measured 2.20 ms vs 5.23 ms at level 6, for 4 % more bytes
+
+SCHEMA = "fq-heatmap/1"
+SCHEMA_VERSION = 1
+WORKER_METHOD = "fq_heatmap_sample"
+
+INCLUDE_TOKENS = frozenset({"live", "cum", "mass"})
+PRECISIONS = frozenset({"bf16", "f32"})
+REDUCERS = frozenset({"rank0", "all"})
+RESET_SCOPES = frozenset({"client", "heatmap", "collector", "poison"})
+
+#: Why rank 0 and not a sum, a max, or a mean.
+#:
+#: ``integration.maybe_init_fq_collector`` sizes the collector to
+#: ``routers[0][1].global_num_experts`` (integration.py:157) — the GLOBAL
+#: logical expert count, identical on every rank, never a per-rank shard
+#: — and binds it to ``module.router``, a ``BaseRouter``
+#: (integration.py:149-162). The capture fn histograms
+#: ``topk_ids.flatten()`` over ``[0, num_experts)``
+#: (stats.py:211-231,236-268), i.e. the GATE's output.
+#:
+#: Under tensor parallelism the gate is REPLICATED: every rank runs the
+#: same gate over the same hidden states and produces the same
+#: ``topk_ids``. So each rank's ``count_buf`` is an independent
+#: observation of the SAME routing events, not a partition of them. The
+#: ranks are replicas, and the correct merge of replicas is "take one and
+#: check the others agree" — summing would report 4x the real traffic on
+#: a TP4 serve, and a max would silently paper over divergence.
+#:
+#: Expert parallelism does not change this: EP shards which expert each
+#: rank *computes*, not which expert the (replicated) gate *chooses*.
+#:
+#: Data parallelism DOES change it — each replica sees different requests,
+#: so a sum would be correct there — but ``DPLBAsyncMPClient
+#: .call_utility_async`` gathers from every engine and returns only
+#: ``[0]`` (core_client.py:1449-1458), so the endpoint cannot see the
+#: other replicas to sum them and would silently report one replica's
+#: traffic as the whole serve's. Hence ``501 dp_not_supported``.
+MERGE_RULE = "rank0-canonical"
+
+
+def heatmap_enabled(environ: Mapping[str, str] | None = None) -> bool:
+    """Both gates. OFF unless dev mode AND the heatmap flag are set."""
+    env = _env(environ)
+    flag = (str(env.get(HEATMAP_API_ENV, "")).strip()
+            or str(env.get(HEATMAP_API_ALIAS_ENV, "")).strip())
+    return dev_mode_enabled(environ) and flag in ("1", "true", "True")
+
+
+def collector_zero_allowed(
+        environ: Mapping[str, str] | None = None) -> bool:
+    """The third gate: the destructive reset scope (see §7.5)."""
+    return str(_env(environ).get(HEATMAP_ALLOW_COLLECTOR_ZERO_ENV,
+                                 "0")).strip() in ("1", "true", "True")
+
+
+def gate_reason(environ: Mapping[str, str] | None = None) -> str:
+    if not dev_mode_enabled(environ):
+        return (f"{DEV_MODE_ENV} is not set — vLLM development endpoints "
+                "are disabled")
+    return (f"{HEATMAP_API_ENV}=1 is required to expose the routing "
+            "activation matrix (dev mode alone is not enough)")
+
+
+def _require_gates(environ: Mapping[str, str] | None = None) -> None:
+    """The gates, enforced at the WORKER as well as at the router.
+
+    ``register_vllm_dev_api_routers`` also attaches vLLM's own
+    ``POST /collective_rpc``, which forwards an arbitrary ``method`` name
+    to every worker, and ``Worker.fq_heatmap_sample`` is an
+    unconditional method. Without this check ``VLLM_SERVER_DEV_MODE=1``
+    alone would be enough to read the routing matrix — and, worse, to
+    reach ``op=zero_collector`` — bypassing ``VLLM_FQ_HEATMAP`` and the
+    token entirely. Worker processes inherit the server environment, so
+    the same env is visible here.
+    """
+    if not heatmap_enabled(environ):
+        raise AdminError("fq_heatmap_disabled", gate_reason(environ),
+                         status=404)
+
+
+# ------------------------------------------------------------------ encoding
+
+
+def f32_to_bf16_bits(arr: np.ndarray) -> np.ndarray:
+    """float32 -> uint16 bfloat16 bit patterns, round-to-nearest-even.
+
+    bf16 IS the top half of a float32, so this is a shift plus the RNE
+    correction; the client decodes it by shifting back (four lines of
+    JavaScript, no library). RNE rather than truncation because it halves
+    the error for free: measured over all 19,200 cells of ``stats.jsonl``
+    record 9, RNE's worst-case relative error is **0.38898 %** against
+    truncation's 0.77261 %.
+    """
+    a = np.ascontiguousarray(arr, dtype=np.float32)
+    u = a.view(np.uint32)
+    # NaN must stay NaN: the round-half-to-even carry can push a NaN
+    # pattern into the infinity encoding.
+    nan = np.isnan(a)
+    rounded = ((u.astype(np.uint64) + 0x7FFF
+                + ((u.astype(np.uint64) >> 16) & 1)) >> 16)
+    bits = rounded.astype(np.uint16)
+    if nan.any():
+        bits = np.where(nan, np.uint16(0x7FC0), bits).astype(np.uint16)
+    return bits
+
+
+def bf16_bits_to_f32(bits: np.ndarray) -> np.ndarray:
+    """uint16 bfloat16 bit patterns -> float32 (exact, no rounding)."""
+    u = np.ascontiguousarray(bits, dtype=np.uint16).astype(np.uint32) << 16
+    return u.view(np.float32)
+
+
+def encode_floats(arr: np.ndarray, precision: str) -> str:
+    """Base64 of little-endian raw bytes at the requested wire dtype."""
+    if precision == "bf16":
+        payload = f32_to_bf16_bits(np.asarray(arr, dtype=np.float32))
+    elif precision == "f32":
+        payload = np.ascontiguousarray(arr, dtype=np.float32)
+    else:
+        raise ValueError(f"unknown precision {precision!r}")
+    return _b64(_le(payload))
+
+
+def decode_floats(blob: str, precision: str,
+                  cells: int | None = None) -> np.ndarray:
+    """Inverse of :func:`encode_floats`, as float32. Client-side check."""
+    raw = _unb64(blob)
+    if precision == "bf16":
+        out = bf16_bits_to_f32(np.frombuffer(raw, dtype="<u2"))
+    elif precision == "f32":
+        out = np.frombuffer(raw, dtype="<f4").astype(np.float32)
+    else:
+        raise ValueError(f"unknown precision {precision!r}")
+    _check_cells(out, cells)
+    return out
+
+
+def encode_tier(arr: np.ndarray) -> str:
+    """Base64 of one u8 per cell. 19,200 bytes of ``3`` gzip to 168 B.
+
+    Validates the domain: a value outside ``occupancy_table.TIERS``
+    means the tier table has been corrupted, and truncating it into a
+    u8 would ship a plausible-looking lie.
+    """
+    from vllm.model_executor.layers.quantization.exl3_fungible import (
+        occupancy_table as OT,
+    )
+
+    a = np.asarray(arr)
+    bad = np.setdiff1d(np.unique(a), np.asarray(OT.TIERS))
+    if bad.size:
+        raise ValueError(
+            f"tier values {bad.tolist()} are outside "
+            f"occupancy_table.TIERS={list(OT.TIERS)}")
+    return _b64(_le(a.astype(np.uint8)))
+
+
+def decode_tier(blob: str, cells: int | None = None) -> np.ndarray:
+    out = np.frombuffer(_unb64(blob), dtype=np.uint8)
+    _check_cells(out, cells)
+    return out
+
+
+def encode_u32(arr: np.ndarray) -> str:
+    return _b64(_le(np.asarray(arr).astype(np.uint32)))
+
+
+def decode_u32(blob: str, cells: int | None = None) -> np.ndarray:
+    out = np.frombuffer(_unb64(blob), dtype="<u4")
+    _check_cells(out, cells)
+    return out
+
+
+def _le(arr: np.ndarray) -> np.ndarray:
+    """Force little-endian byte order — the wire contract says so.
+
+    ``dtype.byteorder`` is ``'='`` for native dtypes, so testing for
+    ``'>'`` would silently ship big-endian bytes on a big-endian host.
+    Cast to an explicitly little-endian dtype instead; on x86 that is a
+    no-op.
+    """
+    a = np.ascontiguousarray(arr)
+    return a.astype(a.dtype.newbyteorder("<"), copy=False)
+
+
+def _b64(arr: np.ndarray) -> str:
+    return base64.b64encode(arr.tobytes()).decode("ascii")
+
+
+def _unb64(blob: str) -> bytes:
+    try:
+        return base64.b64decode(blob, validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise ValueError(f"not valid base64: {exc}") from None
+
+
+def _check_cells(arr: np.ndarray, cells: int | None) -> None:
+    if cells is not None and arr.size != cells:
+        raise ValueError(
+            f"array decodes to {arr.size} elements, expected {cells} — "
+            "a truncated blob must never be rendered as a shifted heatmap")
+
+
+def gzip_bytes(payload: bytes, level: int = GZIP_LEVEL) -> bytes:
+    import zlib
+
+    co = zlib.compressobj(level, zlib.DEFLATED, 16 + zlib.MAX_WBITS)
+    return co.compress(payload) + co.flush()
+
+
+def rate_denominator(stride: int, decay: float, n_effective: int) -> float:
+    """``count / denom`` is hits-per-step over the decayed horizon.
+
+    If the per-step hit rate ``r`` were constant then
+    ``count = r * stride * (1 - decay**n) / (1 - decay)``. At the shipped
+    defaults (stride 32, decay 0.95, n 64) this is 615.99.
+    """
+    if decay >= 1.0 or decay < 0.0:
+        return float(stride) * max(int(n_effective), 1)
+    if n_effective <= 0:
+        return float(stride)
+    return float(stride) * (1.0 - decay ** int(n_effective)) / (1.0 - decay)
+
+
+# -------------------------------------------------------------- worker state
+
+
+def _worker_state(worker: Any) -> tuple[Any, Any, bool]:
+    """``(state, collector, has_loop)`` or ``fq_not_active``.
+
+    ``maybe_init_fq_state`` degrades to a bare collector when the policy
+    loop fails to boot (integration.py:119-125), and the heatmap is still
+    perfectly meaningful in that mode — you just get no ``tier``, no
+    ``interval`` and no ``policy_sha``. So unlike ``admin._loop_state``
+    this accepts either object.
+    """
+    runner = getattr(worker, "model_runner", None)
+    state = getattr(runner, "fq_collector", None)
+    if state is None:
+        raise AdminError(
+            "fq_not_active",
+            "no fungible-quant collector on this worker — VLLM_FQ_ENABLE "
+            "is not set, or the model has no MoE routers to instrument",
+            status=404, details={"has_runner": runner is not None})
+    collector = getattr(state, "collector", state)
+    if not hasattr(collector, "decayed"):
+        raise AdminError(
+            "fq_not_active",
+            "the object on model_runner.fq_collector is not an "
+            "FqStatsCollector (no decayed()); refusing to guess",
+            status=404,
+            details={"type": type(state).__name__})
+    return state, collector, hasattr(state, "tier_of")
+
+
+def _row_layers(state: Any, collector: Any, has_loop: bool) -> list[int]:
+    """The row axis: policy layer ids when there is a loop, else the
+    collector's bound layer ids. Shipped as data — a client that assumes
+    ``layer = row + 3`` breaks on any other MoE span."""
+    if has_loop:
+        return [int(x) for x in state.layers]
+    return sorted(int(x) for x in collector.count_buf)
+
+
+def _cid_of(state: Any, has_loop: bool, layers: Sequence[int]) -> dict:
+    """policy layer id -> collector layer id, the loop's own mapping."""
+    if has_loop:
+        mapping = getattr(state, "_collector_layer_map", None)
+        if mapping:
+            return {int(k): int(v) for k, v in mapping.items()}
+    return {int(x): int(x) for x in layers}
+
+
+# --------------------------------------------- cumulative accumulator (§7.4)
+
+
+class _CumAccumulator:
+    """A true cumulative counter, at zero hot-path cost.
+
+    The collector has none: ``count_buf`` is zeroed at every roll
+    (stats.py:295-296) and the window is decayed on read. But the ring
+    itself is exact, undecayed int64 (stats.py:131-133), so integrating
+    the slots that have rolled since the previous sample reconstructs an
+    exact total — while the gap stays under ``window_len`` slots
+    (``64 * 32 = 2,048`` engine steps, ~17 min at the observed cadence).
+    Beyond that the ring has wrapped and slots are genuinely gone:
+    :attr:`lossy` says so rather than reporting a plausible undercount.
+    """
+
+    def __init__(self) -> None:
+        self.cum: np.ndarray | None = None
+        self.rolled: int = 0
+        self.since_step: int = 0
+        self.lossy: bool = False
+        self.dropped_slots: int = 0
+        self.overflow_rebased: bool = False
+        self.layers: tuple[int, ...] = ()
+
+    def rebase(self, rolled: int, step: int,
+               layers: Sequence[int], num_experts: int) -> int:
+        previous = self.since_step
+        self.cum = np.zeros((len(layers), int(num_experts)), dtype=np.int64)
+        self.rolled = int(rolled)
+        self.since_step = int(step)
+        self.lossy = False
+        self.dropped_slots = 0
+        self.overflow_rebased = False
+        self.layers = tuple(int(x) for x in layers)
+        return previous
+
+    def integrate(self, collector: Any, cids: Sequence[int],
+                  layers: Sequence[int], rolled: int, win_pos: int,
+                  step: int) -> None:
+        import torch
+
+        num_experts = int(collector.num_experts)
+        if self.cum is None or self.layers != tuple(int(x) for x in layers):
+            # First sample (or the row axis changed): start at zero here
+            # rather than pretending to know the history.
+            self.rebase(rolled, step, layers, num_experts)
+            return
+        window_len = int(collector.window_len)
+        n_new = int(rolled) - int(self.rolled)
+        if n_new <= 0:
+            return
+        if n_new > window_len:
+            self.dropped_slots += n_new - window_len
+            self.lossy = True
+            n_new = window_len
+        slots = [(int(win_pos) - 1 - i) % window_len for i in range(n_new)]
+        rows = [collector._count_win[int(cid)][slots].sum(0) for cid in cids]
+        self.cum += torch.stack(rows).cpu().numpy().astype(np.int64)
+        self.rolled = int(rolled)
+        # u32 on the wire; rebase long before the cast would wrap. At the
+        # observed peak per-cell rate this is ~23 days of continuous
+        # decode, so it is a correctness backstop, not a hot path.
+        if self.cum.size and int(self.cum.max()) >= (1 << 31):
+            self.rebase(rolled, step, layers, num_experts)
+            self.overflow_rebased = True
+
+
+#: One accumulator per worker process (the collector is per worker too).
+_CUM = _CumAccumulator()
+
+
+def reset_worker_state() -> None:
+    """Test seam: forget the per-process cumulative accumulator."""
+    global _CUM
+    _CUM = _CumAccumulator()
+
+
+# -------------------------------------------------------------- worker entry
+
+
+def _parse_worker_request(req: Mapping[str, Any]) -> dict:
+    include = set(req.get("include") or [])
+    unknown = sorted(include - INCLUDE_TOKENS)
+    if unknown:
+        raise AdminError(
+            "unknown_include",
+            f"unknown include token(s) {unknown}; valid: "
+            f"{sorted(INCLUDE_TOKENS)}", status=400)
+    precision = str(req.get("precision") or "bf16")
+    if precision not in PRECISIONS:
+        raise AdminError(
+            "bad_precision",
+            f"precision={precision!r} is not one of {sorted(PRECISIONS)}",
+            status=400)
+    return {
+        "op": str(req.get("op") or "sample"),
+        "include": include,
+        "precision": precision,
+        "all_ranks": bool(req.get("all_ranks")),
+        "layers": req.get("layers"),
+    }
+
+
+def _select_rows(all_layers: Sequence[int],
+                 wanted: Sequence[int] | None) -> tuple[list[int], list[int]]:
+    """``(row indices, layer ids)`` for the requested subset."""
+    if not wanted:
+        return list(range(len(all_layers))), [int(x) for x in all_layers]
+    index = {int(v): i for i, v in enumerate(all_layers)}
+    rows, ids = [], []
+    missing = []
+    for layer in wanted:
+        i = index.get(int(layer))
+        if i is None:
+            missing.append(int(layer))
+            continue
+        rows.append(i)
+        ids.append(int(layer))
+    if missing:
+        raise AdminError(
+            "bad_layers",
+            f"layer(s) {missing} are not instrumented on this serve; "
+            f"instrumented layers are {int(all_layers[0])}.."
+            f"{int(all_layers[-1])} ({len(all_layers)} rows)",
+            status=400, details={"missing": missing})
+    if not rows:
+        raise AdminError("bad_layers", "empty layer selection", status=400)
+    return rows, ids
+
+
+def _rank_of(worker: Any, state: Any) -> int:
+    rank = getattr(worker, "rank", None)
+    if rank is None:
+        rank = getattr(state, "rank", 0)
+    try:
+        return int(rank or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def worker_sample(worker: Any, request_json: str = "{}") -> str:
+    """One rank's contribution to a sample. JSON string in, JSON out.
+
+    Rank 0 returns the arrays; every other rank returns a ~200 B digest
+    (see :data:`MERGE_RULE`). ``collective_rpc`` runs on every rank
+    regardless — the async ``EngineClient`` path exposes no
+    ``unique_reply_rank`` (protocol.py:227-235) — so the saving is on the
+    socket, not in the workers.
+    """
+    try:
+        _require_gates()
+        req = _parse_worker_request(json.loads(request_json or "{}"))
+        op = req["op"]
+        if op == "sample":
+            return _ok(_worker_do_sample(worker, req))
+        if op == "meta":
+            return _ok(_worker_do_meta(worker, req))
+        if op == "reset_cum":
+            return _ok(_worker_do_reset_cum(worker))
+        if op == "zero_collector":
+            return _ok(_worker_do_zero_collector(worker))
+        raise AdminError("bad_scope", f"unknown worker op {op!r}", status=400)
+    except AdminError as exc:
+        return json.dumps({"ok": False, "error": exc.wire()},
+                          sort_keys=True, separators=(",", ":"), default=str)
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("FQ heatmap worker call failed")
+        return json.dumps({"ok": False, "error": {
+            "code": "internal_error", "http_status": 500,
+            "message": f"{type(exc).__name__}: {exc}", "details": {}}},
+            sort_keys=True, separators=(",", ":"), default=str)
+
+
+def _ok(payload: Mapping[str, Any]) -> str:
+    return json.dumps({"ok": True, **payload}, sort_keys=True,
+                      separators=(",", ":"), default=str)
+
+
+def _window_meta(collector: Any) -> dict:
+    rolled = int(getattr(collector, "_windows_rolled", 0))
+    window_len = int(collector.window_len)
+    stride = int(collector.window_stride)
+    decay = float(collector.decay)
+    n_eff = min(rolled, window_len)
+    return {
+        "len": window_len,
+        "stride": stride,
+        "decay": decay,
+        "rolled": rolled,
+        "n_effective": n_eff,
+        "steps_since_roll": int(getattr(collector, "_step", 0)) % stride
+        if stride else 0,
+        "horizon_steps": stride / (1.0 - decay) if decay < 1.0 else None,
+        "rate_denominator": rate_denominator(stride, decay, n_eff),
+    }
+
+
+def _worker_do_meta(worker: Any, req: Mapping[str, Any]) -> dict:
+    state, collector, has_loop = _worker_state(worker)
+    layers = _row_layers(state, collector, has_loop)
+    return {
+        "rank": _rank_of(worker, state),
+        "layers": layers,
+        "num_layers": len(layers),
+        "num_experts": int(collector.num_experts),
+        "cells": len(layers) * int(collector.num_experts),
+        "mass_is_real": bool(collector.mass_is_real()),
+        "has_loop": bool(has_loop),
+        "window": _window_meta(collector),
+        "step": int(getattr(collector, "_step", 0)),
+        "policy_sha": getattr(state, "policy_sha", None) if has_loop else None,
+    }
+
+
+def _read_arrays(state: Any, collector: Any, has_loop: bool,
+                 rows: Sequence[int], cids: Sequence[int],
+                 include: set[str]) -> dict:
+    """The device reads, in one place so the torn-read retry can redo
+    exactly them and nothing else."""
+    import torch
+
+    counts, masses = [], []
+    for cid in cids:
+        c, m = collector.decayed(int(cid))
+        counts.append(c.detach().cpu().numpy())
+        masses.append(m.detach().cpu().numpy())
+    out: dict[str, Any] = {
+        "count": np.asarray(counts, dtype=np.float64),
+        "mass": np.asarray(masses, dtype=np.float64),
+    }
+    if "live" in include:
+        e = int(collector.num_experts)
+        live = torch.stack([collector.count_buf[int(cid)][:e]
+                            for cid in cids])
+        out["live"] = live.detach().cpu().numpy().astype(np.float32)
+    if has_loop:
+        tier = np.asarray(state.tier_of)
+        out["tier"] = tier[list(rows), :]
+    return out
+
+
+def _worker_do_sample(worker: Any, req: Mapping[str, Any]) -> dict:
+    state, collector, has_loop = _worker_state(worker)
+    all_layers = _row_layers(state, collector, has_loop)
+    if not all_layers:
+        raise AdminError(
+            "fq_not_active",
+            "the collector has no bound MoE layers yet — nothing to "
+            "sample", status=404)
+    rows, layers = _select_rows(all_layers, req.get("layers"))
+    cid_map = _cid_of(state, has_loop, all_layers)
+    cids = [cid_map.get(int(x), int(x)) for x in layers]
+    include = set(req["include"])
+    precision = req["precision"]
+    warnings: list[str] = []
+
+    # No tearing is possible in production — the RPC handler and
+    # execute_model (which calls collector.step(), i.e. the roll) are
+    # dispatched from the same worker loop over rpc_broadcast_mq, so they
+    # are serialised. Verify it anyway: it costs two int reads and it
+    # makes the failure legible if that ever stops being true.
+    torn_retries = 0
+    for attempt in range(2):
+        rolled0 = int(getattr(collector, "_windows_rolled", 0))
+        win_pos0 = int(getattr(collector, "_win_pos", 0))
+        arrays = _read_arrays(state, collector, has_loop, rows, cids,
+                              include)
+        rolled1 = int(getattr(collector, "_windows_rolled", 0))
+        if rolled1 == rolled0:
+            break
+        torn_retries += 1
+        if attempt == 1:
+            warnings.append(
+                f"the window rolled during the read twice "
+                f"({rolled0} -> {rolled1}); the sample is from the second "
+                "attempt and may mix two windows")
+    if torn_retries:
+        warnings.append(f"torn read retried {torn_retries}x")
+
+    window = _window_meta(collector)
+    window["rolled"] = rolled0
+    window["n_effective"] = min(rolled0, window["len"])
+    window["rate_denominator"] = rate_denominator(
+        window["stride"], window["decay"], window["n_effective"])
+    step = int(getattr(collector, "_step", 0))
+    mass_is_real = bool(collector.mass_is_real())
+
+    payload: dict[str, Any] = {
+        "rank": _rank_of(worker, state),
+        "step": step,
+        "real_steps": int(getattr(state, "_real_steps", 0))
+        if has_loop else None,
+        "interval": int(getattr(state, "_intervals_run", 0))
+        if has_loop else None,
+        "window": window,
+        "layers": layers,
+        "num_layers": len(layers),
+        "num_experts": int(collector.num_experts),
+        "cells": len(layers) * int(collector.num_experts),
+        "mass_is_real": mass_is_real,
+        "has_loop": bool(has_loop),
+        "policy_sha": getattr(state, "policy_sha", None) if has_loop else None,
+        "apply_mode": getattr(getattr(state, "cfg", None), "apply_mode", None)
+        if has_loop else None,
+        "precision": precision,
+        "merge_rule": MERGE_RULE,
+        "cum_since_step": None,
+        "cum_lossy": False,
+        "cum_dropped_slots": 0,
+        "cum_overflow_rebased": False,
+        "warnings": warnings,
+    }
+
+    count_b64 = encode_floats(arrays["count"].reshape(-1), precision)
+    tier_b64 = None
+    if has_loop:
+        try:
+            tier_b64 = encode_tier(arrays["tier"].reshape(-1))
+        except ValueError as exc:
+            raise AdminError("tier_out_of_domain", str(exc),
+                             status=500) from None
+
+    mass_b64 = None
+    if mass_is_real and "mass" in include:
+        mass_b64 = encode_floats(arrays["mass"].reshape(-1), precision)
+    elif not mass_is_real:
+        # Shipping a byte-identical second array to say "same as the
+        # other one" is the easiest 50 % saving on the wire, and it is
+        # free. NEVER inferred from array equality: a uniform router
+        # produces equal arrays legitimately (stats.py:302-318).
+        payload["warnings"].append(
+            "mass is aliased to count (collector.mass_is_real() == false); "
+            "set VLLM_FQ_GATE_MASS=1 at boot to record real gate mass")
+
+    live_b64 = None
+    if "live" in include:
+        live_b64 = encode_floats(arrays["live"].reshape(-1), precision)
+
+    cum_b64 = None
+    if "cum" in include:
+        _CUM.integrate(collector, cids, layers, rolled0, win_pos0, step)
+        cum = _CUM.cum
+        cum_b64 = encode_u32(np.clip(cum, 0, (1 << 32) - 1).reshape(-1))
+        payload["cum_since_step"] = int(_CUM.since_step)
+        payload["cum_lossy"] = bool(_CUM.lossy)
+        payload["cum_dropped_slots"] = int(_CUM.dropped_slots)
+        payload["cum_overflow_rebased"] = bool(_CUM.overflow_rebased)
+        if _CUM.lossy:
+            payload["warnings"].append(
+                f"cum_count is LOSSY: {_CUM.dropped_slots} window slot(s) "
+                f"rolled out of the {int(collector.window_len)}-slot ring "
+                "between polls and are gone; poll more often than "
+                f"{int(collector.window_len) * int(collector.window_stride)} "
+                "engine steps for an exact cumulative")
+
+    # The digest is over the CANONICAL WIRE BYTES, so every rank computes
+    # it identically and cross-rank agreement costs 32 bytes per rank
+    # instead of 76 KB. Over bf16 bytes it tolerates last-mantissa-bit
+    # differences in the float64 accumulation, which is intentional.
+    digest = hashlib.sha256()
+    digest.update(count_b64.encode())
+    digest.update((tier_b64 or "").encode())
+    digest.update(f"|{step}|{rolled0}|{win_pos0}".encode())
+    payload["digest"] = digest.hexdigest()[:16]
+    payload["tier_digest"] = hashlib.sha256(
+        (tier_b64 or "").encode()).hexdigest()[:8]
+    payload["win_pos"] = win_pos0
+
+    canonical = payload["rank"] == 0 or bool(req.get("all_ranks"))
+    if not canonical:
+        # ~180 B instead of ~77 KB. The merge only needs the digest and
+        # the clocks; shipping this rank's metadata four times over would
+        # be four copies of an answer the canonical rank already gave.
+        return {k: payload[k] for k in
+                ("rank", "step", "cells", "mass_is_real", "digest")} | {
+            "canonical": False,
+            "rolled": payload["window"]["rolled"],
+        }
+    payload["canonical"] = True
+    payload["count"] = count_b64
+    payload["mass"] = mass_b64
+    payload["tier"] = tier_b64
+    payload["live_count"] = live_b64
+    payload["cum_count"] = cum_b64
+    return payload
+
+
+def _worker_do_reset_cum(worker: Any) -> dict:
+    state, collector, has_loop = _worker_state(worker)
+    layers = _row_layers(state, collector, has_loop)
+    step = int(getattr(collector, "_step", 0))
+    rolled = int(getattr(collector, "_windows_rolled", 0))
+    previous = _CUM.rebase(rolled, step, layers, int(collector.num_experts))
+    return {
+        "rank": _rank_of(worker, state),
+        "scope": "heatmap",
+        "applied": True,
+        "cum_since_step": step,
+        "previous_cum_since_step": int(previous),
+        "digest": f"{step}:{rolled}",
+    }
+
+
+def _worker_do_zero_collector(worker: Any) -> dict:
+    """The destructive scope. Gated three times over; see §7.5.
+
+    Zeroing the ring makes ``decayed()`` return all zeros
+    (stats.py:326-330) and the POLICY LOOP reads exactly those arrays
+    every interval (loop.py:661-667,709). The consequences are in the
+    response body, not only in a doc, because the operator who reached
+    this is the one who needs them.
+    """
+    if not collector_zero_allowed():
+        raise AdminError(
+            "collector_zero_not_allowed",
+            f"zeroing the collector is refused unless "
+            f"{HEATMAP_ALLOW_COLLECTOR_ZERO_ENV}=1; use "
+            'scope="heatmap" (rebases this endpoint\'s own cumulative, '
+            "harmless) or scope=\"client\" (snapshot and subtract)",
+            status=409)
+    state, collector, has_loop = _worker_state(worker)
+    for lid in list(collector.count_buf):
+        collector.count_buf[lid].zero_()
+        collector.mass_buf[lid].zero_()
+        collector._count_win[lid].zero_()
+        collector._mass_win[lid].zero_()
+    collector._win_pos = 0
+    collector._windows_rolled = 0
+    rank = _rank_of(worker, state)
+    logger.warning(
+        "FQ heatmap: COLLECTOR ZEROED on rank %d (%s=1). The policy loop "
+        "reads these counters (loop.py:661-667); the next 1-2 intervals "
+        "will score on a zeroed window.", rank,
+        HEATMAP_ALLOW_COLLECTOR_ZERO_ENV)
+    return {
+        "rank": rank,
+        "scope": "collector",
+        "applied": True,
+        "digest": "zeroed",
+        "warnings": [
+            ("the policy loop reads these counters (loop.py:661-667); the "
+             "next 1-2 intervals will score on a zeroed window, the "
+             "Jaccard router-shift guard will hold all proposals, and "
+             "pin-forced pairs bypass hysteresis (policy.py:142-144) and "
+             "may swap against index order rather than traffic"),
+        ],
+    }
+
+
+class FqHeatmapWorker:
+    """``--worker-extension-cls`` route to the same worker methods.
+
+    vLLM injects exactly ONE extension class into ``Worker.__bases__``
+    after asserting that no attribute collides
+    (worker_base.py:261-286), so use this mixin **or** the core
+    ``Worker.fq_heatmap_sample`` method, never both. On the GLM-5.2
+    serve the extension slot is already held by
+    ``fq_reload.FqReloadWorker``, so the core method is the only usable
+    route there and this class exists for other deployments.
+    """
+
+    def fq_heatmap_sample(self, request_json: str = "{}") -> str:
+        return worker_sample(self, request_json)
+
+
+# ------------------------------------------------------------------- poison
+
+
+class _PoisonState:
+    """A ``collective_rpc`` timeout is not a transient — it desynchronises
+    the channel.
+
+    The broadcast is already enqueued (multiproc_executor.py:392) and the
+    slow worker still executes it and still writes its response. Nothing
+    drains that orphaned response, so the NEXT collective RPC on the
+    queue can read the stale one. Retrying into that is how a telemetry
+    endpoint corrupts the channel the admin API needs. So a timeout
+    disables sampling until the serve restarts, or until an operator
+    explicitly accepts the risk with ``POST /fq/heatmap/reset
+    {"scope":"poison"}``.
+    """
+
+    def __init__(self) -> None:
+        self.poisoned = False
+        self.reason: str | None = None
+        self.at_ms: int | None = None
+
+    def poison(self, reason: str) -> None:
+        first = not self.poisoned
+        self.poisoned = True
+        self.reason = reason
+        self.at_ms = int(time.time() * 1000)
+        if first:
+            logger.error(
+                "FQ heatmap: collective-RPC timeout (%s). The broadcast was "
+                "already enqueued and the slow worker will still write its "
+                "response, so the RPC channel may be desynchronised. "
+                "Heatmap sampling is DISABLED until the serve restarts.",
+                reason)
+
+    def clear(self) -> None:
+        self.poisoned = False
+        self.reason = None
+        self.at_ms = None
+
+
+_POISON = _PoisonState()
+_LAST_DIVERGENCE_LOG_MS = 0.0
+
+
+def reset_state() -> None:
+    """Test seam: clear the module-level poison flag and accumulator."""
+    global _LAST_DIVERGENCE_LOG_MS
+    _POISON.clear()
+    _LAST_DIVERGENCE_LOG_MS = 0.0
+    reset_worker_state()
+
+
+# -------------------------------------------------------------- router utils
+
+
+def _parse_include(raw: str | None) -> set[str]:
+    if raw is None:
+        return {"mass"}
+    tokens = {t.strip() for t in str(raw).split(",") if t.strip()}
+    unknown = sorted(tokens - INCLUDE_TOKENS)
+    if unknown:
+        raise AdminError(
+            "unknown_include",
+            f"unknown include token(s) {unknown}; valid: "
+            f"{sorted(INCLUDE_TOKENS)}", status=400,
+            details={"unknown": unknown, "valid": sorted(INCLUDE_TOKENS)})
+    return tokens
+
+
+def parse_layers(raw: str | None) -> list[int] | None:
+    """``"20-40"`` or ``"3,7,9"`` -> a sorted list of layer ids."""
+    if raw is None or not str(raw).strip():
+        return None
+    out: set[int] = set()
+    for part in str(raw).split(","):
+        part = part.strip()
+        if not part:
+            continue
+        try:
+            if "-" in part.lstrip("-"):
+                lo_s, hi_s = part.split("-", 1)
+                lo, hi = int(lo_s), int(hi_s)
+                if hi < lo:
+                    raise ValueError(f"reversed range {part!r}")
+                out.update(range(lo, hi + 1))
+            else:
+                out.add(int(part))
+        except ValueError as exc:
+            raise AdminError(
+                "bad_layers",
+                f"malformed layers selector {raw!r} at {part!r}: {exc}",
+                status=400) from None
+    if not out:
+        raise AdminError("bad_layers",
+                         f"layers selector {raw!r} selected nothing",
+                         status=400)
+    return sorted(out)
+
+
+def _dp_size(request: Any) -> int:
+    for holder in (getattr(request.app, "state", None),
+                   getattr(getattr(request.app, "state", None),
+                           "engine_client", None)):
+        cfg = getattr(holder, "vllm_config", None)
+        parallel = getattr(cfg, "parallel_config", None)
+        size = getattr(parallel, "data_parallel_size", None)
+        if size is not None:
+            try:
+                return int(size)
+            except (TypeError, ValueError):
+                return 1
+    return 1
+
+
+def compute_etag(*, rolled: int, win_pos: int, tier_digest: str,
+                 mass_is_real: bool, layers: Sequence[int], num_experts: int,
+                 include: Sequence[str], precision: str, reduce: str,
+                 step: int | None = None) -> str:
+    """Weak ``ETag`` over everything that can change the arrays.
+
+    Weak, not strong: ``sample_id`` / ``sampled_at_unix_ms`` /
+    ``cache_age_ms`` differ between two bodies with the same basis, so a
+    strong ETag would be a lie. ``step`` enters the basis only when
+    ``include=live`` — ``live_count`` changes every step, which defeats
+    revalidation by design.
+    """
+    basis = json.dumps({
+        "v": SCHEMA_VERSION, "rolled": int(rolled), "win_pos": int(win_pos),
+        "tier": tier_digest, "mass_is_real": bool(mass_is_real),
+        "layers": hashlib.sha256(
+            ",".join(str(int(x)) for x in layers).encode()).hexdigest()[:16],
+        "E": int(num_experts), "include": sorted(include),
+        "precision": precision, "reduce": reduce,
+        "step": int(step) if step is not None else None,
+    }, sort_keys=True, separators=(",", ":"))
+    short = hashlib.sha256(basis.encode()).hexdigest()[:16]
+    return f'W/"fqhm-{SCHEMA_VERSION}-{short}"'
+
+
+def _etag_matches(header: str | None, etag: str) -> bool:
+    if not header:
+        return False
+    if header.strip() == "*":
+        return True
+    for candidate in header.split(","):
+        c = candidate.strip()
+        if c.startswith("W/"):
+            c = c[2:]
+        bare = etag[2:] if etag.startswith("W/") else etag
+        if c in (bare, etag):
+            return True
+    return False
+
+
+def _map_worker_error(exc: AdminError) -> AdminError:
+    """A worker refusal keeps its code; a worker *crash* becomes 503."""
+    if exc.code == "internal_error":
+        return AdminError(
+            "fq_heatmap_worker_error",
+            f"a worker raised while sampling: {exc.message}",
+            status=503, details=exc.details)
+    return exc
+
+
+def _map_rpc_exception(exc: BaseException) -> AdminError:
+    name = type(exc).__name__
+    text = str(exc)
+    low = text.lower()
+    if isinstance(exc, TimeoutError) or name in ("TimeoutError",
+                                                 "asyncio.TimeoutError"):
+        _POISON.poison(text or "collective_rpc deadline exceeded")
+        return AdminError(
+            "fq_heatmap_timeout",
+            f"collective_rpc({WORKER_METHOD}) exceeded the deadline: {text}",
+            status=504,
+            details={"guidance": (
+                "the collective-RPC channel may be desynchronised after a "
+                "timeout; heatmap sampling is disabled until the serve "
+                "restarts")})
+    if ("shutting down" in low or "sleeping" in low
+            or "EngineDead" in name or "enginedead" in low):
+        return AdminError("engine_unavailable",
+                          f"the engine is not accepting utility calls: "
+                          f"{text}", status=503)
+    return AdminError("fq_heatmap_worker_error",
+                      f"{name}: {text}", status=503)
+
+
+# ------------------------------------------------------------------- router
+
+
+def attach_router(app: Any, *, environ: Mapping[str, str] | None = None
+                  ) -> bool:
+    """Attach ``/fq/heatmap*``, if and only if both gates are on.
+
+    Never raises: a read-only telemetry surface must not be able to stop
+    a serve from booting.
+    """
+    if not heatmap_enabled(environ):
+        logger.debug("FQ heatmap API not attached: %s", gate_reason(environ))
+        return False
+    try:
+        app.include_router(build_router(environ=environ))
+    except Exception:  # noqa: BLE001
+        logger.exception(
+            "FQ heatmap API failed to attach — continuing without it")
+        return False
+    logger.info(
+        "FQ heatmap API enabled (%s=1): GET /fq/heatmap, GET "
+        "/fq/heatmap/meta, POST /fq/heatmap/reset", HEATMAP_API_ENV)
+    return True
+
+
+def build_router(*, environ: Mapping[str, str] | None = None) -> Any:
+    """The ``/fq/heatmap`` router. FastAPI is imported here, never at
+    module scope (the package laziness contract).
+
+    Two ``APIRouter``s may share the ``/fq`` prefix; FastAPI merges them,
+    and the admin router's ``/fq/layer/{layer}`` cannot shadow
+    ``/fq/heatmap`` because the literal segment differs.
+    """
+    import asyncio
+
+    from fastapi import APIRouter, Request
+    from fastapi.responses import JSONResponse, Response
+    from starlette.concurrency import run_in_threadpool
+
+    # ``from __future__ import annotations`` stringifies every annotation
+    # and FastAPI resolves handler annotations against the MODULE
+    # globals; fastapi is a local here, so publish the names or FastAPI
+    # reads ``raw_request: "Request"`` as an unresolvable name, decides
+    # it must be a query parameter, and answers 422 on every route.
+    globals().setdefault("Request", Request)
+    globals().setdefault("JSONResponse", JSONResponse)
+    globals().setdefault("Response", Response)
+
+    router = APIRouter(prefix="/fq", tags=["fungible-quant heatmap"])
+    lock = asyncio.Lock()
+    cache: dict[tuple, dict] = {}
+    meta_cache: dict[str, Any] = {}
+    seq = {"sample_id": 0}
+    boot_id = uuid.uuid4().hex[:8]
+
+    def engine_client(request: Request):
+        return request.app.state.engine_client
+
+    def _fail(exc: AdminError):
+        return JSONResponse(status_code=exc.status, content=exc.body())
+
+    def _gates_and_token(request: Request) -> AdminError | None:
+        """Gates + token only. No poison check, no DP check — the reset
+        route must stay reachable WHILE poisoned."""
+        if not heatmap_enabled(environ):
+            return AdminError("fq_heatmap_disabled", gate_reason(environ),
+                              status=404)
+        token = str(_env(environ).get(HEATMAP_TOKEN_ENV, "")).strip()
+        if token:
+            import hmac
+
+            sent = request.headers.get(TOKEN_HEADER, "")
+            # Compare bytes: hmac.compare_digest refuses str operands with
+            # non-ASCII code points and Starlette decodes headers as
+            # latin-1, so a single 0x80..0xff byte would turn a 403 into
+            # an unhandled 500.
+            if not hmac.compare_digest(
+                    sent.encode("utf-8", "surrogateescape"),
+                    token.encode("utf-8", "surrogateescape")):
+                return AdminError(
+                    "fq_heatmap_forbidden",
+                    f"{TOKEN_HEADER} missing or wrong "
+                    f"({HEATMAP_TOKEN_ENV} is set on this serve)",
+                    status=403)
+        return None
+
+    def _guard(request: Request, *, needs_rpc: bool = True
+               ) -> AdminError | None:
+        blocked = _gates_and_token(request)
+        if blocked is not None:
+            return blocked
+        if needs_rpc and _POISON.poisoned:
+            return AdminError(
+                "fq_heatmap_poisoned",
+                f"a previous heatmap sample timed out ({_POISON.reason}); "
+                "no further collective RPC will be issued",
+                status=503,
+                details={"since_unix_ms": _POISON.at_ms, "guidance": (
+                    "the collective-RPC channel may be desynchronised "
+                    "after a timeout; heatmap sampling is disabled until "
+                    "the serve restarts. POST /fq/heatmap/reset "
+                    '{"scope":"poison"} to override.')})
+        dp = _dp_size(request)
+        if dp > 1:
+            return AdminError(
+                "dp_not_supported",
+                "data_parallel_size > 1: DPLBAsyncMPClient."
+                "call_utility_async gathers from every engine and returns "
+                "only [0] (core_client.py:1449-1458), so this endpoint "
+                "would report one replica's routing as the whole serve's",
+                status=501, details={"data_parallel_size": dp})
+        return None
+
+    async def _collective(request: Request, payload: dict,
+                          timeout: float | None = None) -> list[dict]:
+        engine = engine_client(request)
+        if timeout is None:
+            timeout = _env_float(environ, HEATMAP_TIMEOUT_S_ENV,
+                                 DEFAULT_TIMEOUT_S)
+        try:
+            raw = await engine.collective_rpc(
+                WORKER_METHOD, timeout=timeout,
+                args=(json.dumps(payload, sort_keys=True,
+                                 separators=(",", ":"), default=str),))
+        except AdminError:
+            raise
+        except BaseException as exc:  # noqa: BLE001
+            raise _map_rpc_exception(exc) from None
+        if raw is None:
+            raise AdminError(
+                "fq_heatmap_worker_error",
+                f"{WORKER_METHOD} returned nothing", status=503)
+        results = _rank_results(raw)
+        err = _first_error(results)
+        if err is not None:
+            raise _map_worker_error(err)
+        if not results:
+            raise AdminError("fq_heatmap_worker_error",
+                             "no rank answered", status=503)
+        return results
+
+    def _merge(results: list[dict], reduce: str) -> tuple[dict, list[str]]:
+        """MERGE_RULE: rank 0's arrays, cross-checked by digest.
+
+        Explicitly NOT a sum. See :data:`MERGE_RULE` — under TP the ranks
+        are replicas of one gate, so summing would report 4x the traffic.
+        """
+        global _LAST_DIVERGENCE_LOG_MS
+        canonical = next((r for r in results if r.get("canonical")),
+                         results[0])
+        agree = _agree(results, "digest")
+        warns: list[str] = []
+        if not agree:
+            bad = [{"rank": r.get("rank", i), "digest": r.get("digest")}
+                   for i, r in enumerate(results)
+                   if r.get("digest") != canonical.get("digest")]
+            warns.append(
+                "cross-rank digests DISAGREE: canonical rank "
+                f"{canonical.get('rank')} digest "
+                f"{canonical.get('digest')} vs {bad}. Under tensor "
+                "parallelism the gate is replicated, so the routing "
+                "histograms should be identical; add ?reduce=all to diff "
+                "the arrays. Served anyway (the picture is still useful).")
+            now = time.time() * 1000
+            if now - _LAST_DIVERGENCE_LOG_MS > 60_000:
+                _LAST_DIVERGENCE_LOG_MS = now
+                logger.warning("FQ heatmap: %s", warns[-1])
+        return canonical, warns
+
+    def _build_envelope(results: list[dict], *, include: set[str],
+                        precision: str, reduce: str,
+                        clamp_warning: str | None) -> dict:
+        canonical, warns = _merge(results, reduce)
+        seq["sample_id"] += 1
+        cells = int(canonical.get("cells") or 0)
+        envelope: dict[str, Any] = {
+            "schema": SCHEMA,
+            "sample_id": seq["sample_id"],
+            "server_boot_id": boot_id,
+            "sampled_at_unix_ms": int(time.time() * 1000),
+            "cached": False,
+            "cache_age_ms": 0,
+            "step": canonical.get("step"),
+            "real_steps": canonical.get("real_steps"),
+            "interval": canonical.get("interval"),
+            "window": canonical.get("window"),
+            "layers": canonical.get("layers"),
+            "num_layers": canonical.get("num_layers"),
+            "num_experts": canonical.get("num_experts"),
+            "cells": cells,
+            "mass_is_real": bool(canonical.get("mass_is_real")),
+            "ranks": {
+                "count": len(results),
+                "canonical": canonical.get("rank"),
+                "agree": _agree(results, "digest"),
+                "reduce": reduce,
+                "merge_rule": MERGE_RULE,
+                "digests": [{"rank": r.get("rank"), "digest": r.get("digest")}
+                            for r in results],
+            },
+            "policy_sha": canonical.get("policy_sha"),
+            "apply_mode": canonical.get("apply_mode"),
+            "encoding": {
+                "layout": "layer-major",
+                "byte_order": "little",
+                "count": precision,
+                "mass": precision,
+                "live_count": precision,
+                "cum_count": "u32",
+                "tier": "u8",
+                "transfer": "base64",
+            },
+            "count": canonical.get("count"),
+            "mass": canonical.get("mass"),
+            "tier": canonical.get("tier"),
+            "live_count": canonical.get("live_count"),
+            "cum_count": canonical.get("cum_count"),
+            "cum_since_step": canonical.get("cum_since_step"),
+            "cum_lossy": bool(canonical.get("cum_lossy")),
+            "cum_dropped_slots": int(canonical.get("cum_dropped_slots") or 0),
+            "cum_overflow_rebased": bool(
+                canonical.get("cum_overflow_rebased")),
+            "warnings": list(canonical.get("warnings") or []) + warns,
+            # Popped by _sample; the pieces the ETag basis needs that are
+            # not otherwise on the envelope.
+            "_basis": {"win_pos": canonical.get("win_pos", 0),
+                       "tier_digest": str(canonical.get("tier_digest") or "")},
+        }
+        if clamp_warning:
+            envelope["warnings"].append(clamp_warning)
+        if reduce == "all":
+            envelope["per_rank"] = results
+        # Sanity: every array must decode to exactly ``cells``. Better to
+        # refuse here than to let a client render a shifted heatmap.
+        for name, wire in (("count", precision), ("mass", precision),
+                           ("live_count", precision), ("tier", "u8"),
+                           ("cum_count", "u32")):
+            blob = envelope.get(name)
+            if not blob:
+                continue
+            per_cell = {"bf16": 2, "f32": 4, "u8": 1, "u32": 4}[wire]
+            got = len(_unb64(blob)) // per_cell
+            if got != cells:
+                raise AdminError(
+                    "fq_heatmap_worker_error",
+                    f"{name} decodes to {got} cells, expected {cells}",
+                    status=503)
+        return envelope
+
+    async def _sample(request: Request, *, include: set[str], precision: str,
+                      reduce: str, layers: list[int] | None,
+                      max_age_ms: int) -> dict:
+        floor = max(0, _env_int(environ, HEATMAP_MIN_PERIOD_MS_ENV,
+                                DEFAULT_MIN_PERIOD_MS))
+        clamp_warning = None
+        effective = max_age_ms
+        if effective < floor:
+            clamp_warning = (
+                f"max_age_ms={max_age_ms} was clamped up to the "
+                f"{HEATMAP_MIN_PERIOD_MS_ENV} floor of {floor} ms; every "
+                "sample stalls the engine step loop, so the floor caps how "
+                "often that can happen")
+            effective = floor
+        key = (tuple(sorted(include)), precision, reduce,
+               tuple(layers) if layers else None)
+        now = time.time() * 1000
+
+        hit = cache.get(key)
+        if hit is not None and (now - hit["at_ms"]) <= effective:
+            return _as_cached(hit, now)
+
+        async with lock:
+            # Re-check inside the lock: N concurrent polls cost ONE RPC.
+            now = time.time() * 1000
+            hit = cache.get(key)
+            if hit is not None and (now - hit["at_ms"]) <= effective:
+                return _as_cached(hit, now)
+            payload = {"op": "sample", "include": sorted(include),
+                       "precision": precision,
+                       "all_ranks": reduce == "all"}
+            if layers:
+                payload["layers"] = layers
+            results = await _collective(request, payload)
+            envelope = _build_envelope(
+                results, include=include, precision=precision,
+                reduce=reduce, clamp_warning=clamp_warning)
+            basis = envelope.pop("_basis")
+            envelope["etag"] = compute_etag(
+                rolled=(envelope["window"] or {}).get("rolled", 0),
+                win_pos=basis["win_pos"],
+                tier_digest=basis["tier_digest"],
+                mass_is_real=envelope["mass_is_real"],
+                layers=envelope["layers"] or [],
+                num_experts=envelope["num_experts"] or 0,
+                include=sorted(include), precision=precision, reduce=reduce,
+                step=envelope["step"] if "live" in include else None)
+            cache[key] = {"envelope": envelope,
+                          "at_ms": time.time() * 1000}
+            return _as_fresh(envelope)
+
+    def _copy(envelope: dict) -> dict:
+        """Shallow copy with the mutable bits detached, so a handler can
+        annotate a response without editing the cached envelope."""
+        out = dict(envelope)
+        out["warnings"] = list(envelope.get("warnings") or [])
+        return out
+
+    def _as_fresh(envelope: dict) -> dict:
+        out = _copy(envelope)
+        out["cached"] = False
+        out["cache_age_ms"] = 0
+        return out
+
+    def _as_cached(hit: dict, now: float) -> dict:
+        env = _copy(hit["envelope"])
+        env["cached"] = True
+        env["cache_age_ms"] = int(now - hit["at_ms"])
+        return env
+
+    async def _respond(request: Request, envelope: dict):
+        etag = envelope.pop("etag", None) or ""
+        headers = {
+            "Cache-Control": "no-cache, must-revalidate",
+            "X-FQ-Sample-Id": str(envelope.get("sample_id")),
+            "X-FQ-Step": str(envelope.get("step")),
+            "X-FQ-Merge-Rule": MERGE_RULE,
+        }
+        if etag:
+            headers["ETag"] = etag
+        if etag and _etag_matches(request.headers.get("if-none-match"), etag):
+            return Response(status_code=304, headers=headers)
+        gzip_ok = "gzip" in request.headers.get("accept-encoding", "").lower()
+        if not gzip_ok:
+            envelope["warnings"].append(
+                "the client did not offer gzip; this body is ~2.4x the "
+                "size of the compressed one")
+        body = json.dumps(envelope, separators=(",", ":"),
+                          default=str).encode()
+        if gzip_ok:
+            # vLLM's build_app installs no GZipMiddleware, so compress
+            # here. Level 1, off the event loop: measured 2.20 ms vs
+            # 5.23 ms at level 6 for 4 % fewer bytes.
+            body = await run_in_threadpool(gzip_bytes, body, GZIP_LEVEL)
+            headers["Content-Encoding"] = "gzip"
+        headers["Content-Length"] = str(len(body))
+        return Response(content=body, media_type="application/json",
+                        headers=headers)
+
+    # ------------------------------------------------------------- routes
+
+    @router.get("/heatmap")
+    async def fq_heatmap(raw_request: Request):
+        blocked = _guard(raw_request)
+        if blocked is not None:
+            return _fail(blocked)
+        q = raw_request.query_params
+        try:
+            include = _parse_include(q.get("include"))
+            precision = str(q.get("precision") or "bf16")
+            if precision not in PRECISIONS:
+                raise AdminError(
+                    "bad_precision",
+                    f"precision={precision!r} is not one of "
+                    f"{sorted(PRECISIONS)}", status=400)
+            reduce = str(q.get("reduce") or "rank0")
+            if reduce not in REDUCERS:
+                raise AdminError(
+                    "bad_reduce",
+                    f"reduce={reduce!r} is not one of {sorted(REDUCERS)}",
+                    status=400)
+            layers = parse_layers(q.get("layers"))
+            try:
+                max_age_ms = int(q.get("max_age_ms", DEFAULT_MAX_AGE_MS))
+            except (TypeError, ValueError):
+                raise AdminError(
+                    "bad_max_age",
+                    f"max_age_ms={q.get('max_age_ms')!r} is not an int",
+                    status=400) from None
+            envelope = await _sample(
+                raw_request, include=include, precision=precision,
+                reduce=reduce, layers=layers,
+                max_age_ms=max(0, max_age_ms))
+        except AdminError as exc:
+            return _fail(exc)
+        return await _respond(raw_request, envelope)
+
+    @router.get("/heatmap/meta")
+    async def fq_heatmap_meta(raw_request: Request):
+        # A cached meta answer costs no RPC, so it stays available even
+        # when the sampling path is poisoned — a health check that goes
+        # dark exactly when something broke is worse than useless.
+        blocked = _guard(raw_request,
+                         needs_rpc="shape" not in meta_cache)
+        if blocked is not None:
+            return _fail(blocked)
+        token_required = bool(
+            str(_env(environ).get(HEATMAP_TOKEN_ENV, "")).strip())
+        base = {
+            "schema": SCHEMA,
+            "server_boot_id": boot_id,
+            "merge_rule": MERGE_RULE,
+            "encoding": {"layout": "layer-major", "byte_order": "little",
+                         "count": "bf16", "mass": "bf16",
+                         "live_count": "bf16", "cum_count": "u32",
+                         "tier": "u8", "transfer": "base64"},
+            "precisions": sorted(PRECISIONS),
+            "include_tokens": sorted(INCLUDE_TOKENS),
+            "reset_scopes": sorted(RESET_SCOPES),
+            "min_period_ms": _env_int(environ, HEATMAP_MIN_PERIOD_MS_ENV,
+                                      DEFAULT_MIN_PERIOD_MS),
+            "timeout_s": _env_float(environ, HEATMAP_TIMEOUT_S_ENV,
+                                    DEFAULT_TIMEOUT_S),
+            "token_required": token_required,
+            "collector_zero_allowed": collector_zero_allowed(environ),
+            "notes": [
+                ("include=live defeats the ETag by design: live_count "
+                 "changes every engine step, so no two samples "
+                 "revalidate."),
+                ("mass is null iff mass_is_real is false; alias it to "
+                 "count client-side and label the view accordingly."),
+            ],
+        }
+        if "shape" in meta_cache:
+            # Cached for the process lifetime: state.layers is fixed at
+            # loop construction (loop.py:491) and cannot change at
+            # runtime. Only fq_active is re-derived.
+            return JSONResponse(content={**base, **meta_cache["shape"],
+                                         "fq_active": True, "cached": True,
+                                         "poisoned": _POISON.poisoned})
+        try:
+            results = await _collective(raw_request, {"op": "meta"})
+        except AdminError as exc:
+            if exc.code == "fq_not_active":
+                # A health check that 404s is useless as a health check:
+                # report the shape we do not have as a FIELD.
+                return JSONResponse(content={
+                    **base, "fq_active": False, "cached": False,
+                    "layers": None, "num_layers": None, "num_experts": None,
+                    "cells": None, "mass_is_real": None,
+                    "reason": exc.body()["error"]})
+            return _fail(exc)
+        canonical = results[0]
+        shape = {
+            "layers": canonical.get("layers"),
+            "num_layers": canonical.get("num_layers"),
+            "num_experts": canonical.get("num_experts"),
+            "cells": canonical.get("cells"),
+            "mass_is_real": canonical.get("mass_is_real"),
+            "has_loop": canonical.get("has_loop"),
+            "window": canonical.get("window"),
+            "ranks": len(results),
+        }
+        meta_cache["shape"] = shape
+        return JSONResponse(content={**base, **shape, "fq_active": True,
+                                     "cached": False,
+                                     "poisoned": _POISON.poisoned})
+
+    @router.post("/heatmap/reset")
+    async def fq_heatmap_reset(raw_request: Request):
+        # The poison scope must be reachable WHILE poisoned, so it is
+        # handled before the guard's poison check.
+        try:
+            body: dict = {}
+            if (await raw_request.body()).strip():
+                try:
+                    body = dict(await raw_request.json())
+                except Exception:  # noqa: BLE001
+                    raise AdminError("bad_json", "body is not valid JSON",
+                                     status=400) from None
+            scope = str(body.get("scope") or "client")
+            if scope not in RESET_SCOPES:
+                raise AdminError(
+                    "bad_scope",
+                    f"scope={scope!r} is not one of {sorted(RESET_SCOPES)}",
+                    status=400)
+        except AdminError as exc:
+            return _fail(exc)
+
+        if scope == "poison":
+            blocked = _gates_and_token(raw_request)
+            if blocked is not None:
+                return _fail(blocked)
+            was = _POISON.poisoned
+            _POISON.clear()
+            return JSONResponse(content={
+                "scope": "poison", "applied": bool(was), "was_poisoned": was,
+                "note": ("the poison flag is cleared; the collective-RPC "
+                         "channel may still be desynchronised — this is an "
+                         "operator override, not a repair")})
+
+        # scope=client issues no RPC, so a poisoned channel does not stop
+        # an operator marking a baseline.
+        blocked = _guard(raw_request, needs_rpc=scope != "client")
+        if blocked is not None:
+            return _fail(blocked)
+
+        if scope == "client":
+            # The default, and what the page uses. The server does
+            # nothing: the client snapshots the decoded count array and
+            # subtracts. It cannot destroy data the policy loop and every
+            # other viewer are reading, compare mode comes free, and it
+            # is honest that the result is a difference of two DECAYED
+            # WINDOWS, not "traffic since the mark".
+            hit = max(cache.values(), key=lambda h: h["at_ms"],
+                      default=None)
+            env = hit["envelope"] if hit else {}
+            return JSONResponse(content={
+                "scope": "client", "applied": False,
+                "baseline_sample_id": env.get("sample_id"),
+                "baseline_step": env.get("step"),
+                "reason": body.get("reason"),
+                "note": ("no server state was changed; snapshot and "
+                         "subtract client-side. The difference is a "
+                         "difference of two decayed windows, not traffic "
+                         'since the mark — label the view "change since '
+                         'mark".')})
+
+        if scope == "heatmap":
+            try:
+                results = await _collective(raw_request, {"op": "reset_cum"})
+            except AdminError as exc:
+                return _fail(exc)
+            cache.clear()
+            canonical = results[0]
+            return JSONResponse(content={
+                "scope": "heatmap", "applied": True, "ranks": len(results),
+                "agree": _agree(results, "digest"),
+                "cum_since_step": canonical.get("cum_since_step"),
+                "previous_cum_since_step": canonical.get(
+                    "previous_cum_since_step"),
+                "reason": body.get("reason"),
+                "note": ("cumulative accumulator rebased; the collector "
+                         "window and the policy are untouched. Poll "
+                         "?include=cum for exact hits since this point.")})
+
+        # scope == "collector": the destructive one.
+        if not collector_zero_allowed(environ):
+            return _fail(AdminError(
+                "collector_zero_not_allowed",
+                f"zeroing the collector is refused unless "
+                f"{HEATMAP_ALLOW_COLLECTOR_ZERO_ENV}=1; it blinds the "
+                "policy loop for 1-2 intervals (loop.py:661-667). Use "
+                'scope="heatmap" instead.', status=409))
+        try:
+            # All ranks, never rank 0 only: divergent policy inputs would
+            # break T6 cross-rank decision agreement (loop.py:694-698).
+            results = await _collective(raw_request,
+                                        {"op": "zero_collector"})
+        except AdminError as exc:
+            return _fail(exc)
+        cache.clear()
+        logger.warning(
+            "FQ heatmap: collector zeroed on %d rank(s) by an operator "
+            "(reason=%r)", len(results), body.get("reason"))
+        return JSONResponse(content={
+            "scope": "collector", "applied": True, "ranks": len(results),
+            "reason": body.get("reason"),
+            "warnings": list(results[0].get("warnings") or [])})
+
+    router.fq_heatmap_cache = cache          # type: ignore[attr-defined]
+    router.fq_heatmap_seq = seq              # type: ignore[attr-defined]
+    return router

--- a/vllm/model_executor/layers/quantization/exl3_fungible/heatmap.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/heatmap.py
@@ -1186,6 +1186,11 @@ def build_router(*, environ: Mapping[str, str] | None = None) -> Any:
                                  separators=(",", ":"), default=str),))
         except AdminError:
             raise
+        except (SystemExit, KeyboardInterrupt):
+            # Shutdown is not an RPC failure: mapping it to an AdminError
+            # would report "the heatmap RPC failed" to a caller while the
+            # engine is actually terminating.
+            raise
         except BaseException as exc:  # noqa: BLE001
             raise _map_rpc_exception(exc) from None
         if raw is None:

--- a/vllm/model_executor/layers/quantization/exl3_fungible/integration.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/integration.py
@@ -186,7 +186,18 @@ def _bind_apply_fn(state, runner, rank: int) -> None:
         swap as _swap,
     )
 
-    engine = _admin.build_swap_engine(runner, rank=rank)
+    # Size the staging buffers to the LOOP's cap, not the admin API's.
+    # build_swap_engine defaults max_pairs to DEFAULT_MAX_ITEMS (32), which is
+    # an operator-facing batch limit for hand-driven POST /fq/retier. The loop
+    # proposes up to max_swaps_total (64) in one interval, so every interval
+    # died on:
+    #     ValueError: plan has 64 pairs, staging holds 32
+    # The loop degraded correctly -- "keeping the incumbent tiering and
+    # retrying next interval" -- but it could never succeed, so the serve
+    # would have retried forever while looking busy.
+    _cap = int(getattr(getattr(state, "cfg", None), "max_swaps_total", 0) or 0)
+    engine = _admin.build_swap_engine(
+        runner, rank=rank, max_pairs=max(_cap, _admin.DEFAULT_MAX_ITEMS))
     if engine is None:
         log.warning("FQ live apply NOT bound: no mixed-trellis layers "
                     "registered — a uniform-K serve has nothing to swap")
@@ -201,6 +212,15 @@ def _bind_apply_fn(state, runner, rank: int) -> None:
         # visibility flip restores inside the same window. drop lets a pair
         # whose fragments cannot be supplied pend instead of losing the
         # interval; cardinality is preserved either way.
+        if len(plan.swaps) > int(engine.max_pairs):
+            # Configuration error, not a runtime condition: say which two
+            # knobs disagree rather than surfacing a buffer-size ValueError.
+            log.error(
+                "FQ live apply: plan has %d pairs but staging holds %d — "
+                "raise VLLM_FQ_MAX_SWAPS_TOTAL/max_pairs together or lower "
+                "the loop cap; skipping this interval",
+                len(plan.swaps), int(engine.max_pairs))
+            return False
         staged = engine.stage(plan, fail_atomic=True, on_unavailable="drop")
         dropped = tuple(getattr(staged, "dropped", ()) or ())
         if dropped:

--- a/vllm/model_executor/layers/quantization/exl3_fungible/integration.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/integration.py
@@ -234,12 +234,45 @@ def _bind_apply_fn(state, runner, rank: int) -> None:
     _stager = _fut.ThreadPoolExecutor(max_workers=1,
                                       thread_name_prefix="fq-stage")
 
-    engine = _admin.build_swap_engine(
-        runner, rank=rank, max_pairs=max(_cap, _admin.DEFAULT_MAX_ITEMS))
+    # ONE engine per worker, shared with the admin API through
+    # `state.swap_engine`.
+    #
+    # This used to build its own. MixedLayerState COPIES the tier orderings
+    # out of the module, and a committed apply updated only the copy — so the
+    # loop's engine and the admin's engine (built lazily by
+    # admin._bound_engine) tracked the same layers with two independent host
+    # views, over one set of device maps. The loop installed 64 swaps; the
+    # other engine never heard about it; every later plan was validated
+    # against a stale ordering and died:
+    #
+    #     ValueError: invalid swap (3, 51, 60): e_out must be resident K4
+    #
+    # while GET /fq/layer/3 — which reads the LOOP's map — cheerfully
+    # confirmed e51 was K4. Both were telling the truth about different
+    # bookkeeping. The loop then re-proposed the identical plan every
+    # interval, forever, staging ~300 MB of fragments each time.
+    #
+    # Sizing: the admin path defaults max_pairs to DEFAULT_MAX_ITEMS (32), an
+    # operator-facing batch limit for hand-driven POST /fq/retier, while the
+    # loop proposes up to max_swaps_total (64). Sharing one engine means the
+    # buffer must satisfy BOTH, so a cached engine that is too small is
+    # replaced rather than inherited.
+    _want = max(_cap, _admin.DEFAULT_MAX_ITEMS)
+    engine = getattr(state, "swap_engine", None)
+    if engine is not None and int(getattr(engine, "max_pairs", 0)) < _want:
+        log.info("FQ live apply: rebuilding the shared swap engine — cached "
+                 "one holds %d pairs, the loop proposes up to %d",
+                 int(getattr(engine, "max_pairs", 0)), _want)
+        engine = None
+    if engine is None:
+        engine = _admin.build_swap_engine(runner, rank=rank, max_pairs=_want)
     if engine is None:
         log.warning("FQ live apply NOT bound: no mixed-trellis layers "
                     "registered — a uniform-K serve has nothing to swap")
         return
+    # Publish it so admin._bound_engine reuses this one instead of minting a
+    # second view of the same layers.
+    state.swap_engine = engine
 
     # ------------------------------------------------------------------
     # Async staging + collective readiness gate.

--- a/vllm/model_executor/layers/quantization/exl3_fungible/integration.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/integration.py
@@ -41,8 +41,19 @@ def _moe_module_types() -> tuple[type, type]:
 
     Monkeypatch seam for CPU tests (inject fake classes); lazy so the
     env-off path never touches the fused_moe import graph.
+
+    ``MoERunner`` is imported from its defining module first: upstream moved
+    it to ``fused_moe.runner.moe_runner`` and left ``fused_moe.layer`` as a
+    re-export, which is exactly the kind of compatibility shim that gets
+    dropped in a later cleanup. Falling back the other way keeps us working on
+    both old and new trees instead of binding to the shim.
     """
-    from vllm.model_executor.layers.fused_moe.layer import MoERunner
+    try:
+        from vllm.model_executor.layers.fused_moe.runner.moe_runner import (
+            MoERunner,
+        )
+    except ImportError:  # older trees: only the re-export exists
+        from vllm.model_executor.layers.fused_moe.layer import MoERunner
     from vllm.model_executor.layers.fused_moe.router.base_router import (
         BaseRouter,
     )

--- a/vllm/model_executor/layers/quantization/exl3_fungible/integration.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/integration.py
@@ -151,7 +151,11 @@ def _bind_apply_fn(state, runner, rank: int) -> None:
     ``_maybe_apply`` returned False before touching a weight — 64 swaps
     decided across 39 layers, zero installed.
 
-    DISABLED BY DEFAULT, because the first live attempt DEADLOCKED THE ENGINE.
+    Staging runs OFF-STEP and readiness is agreed by all_reduce, which is what
+    makes this safe; see the block comment on apply_fn. The history below is
+    why it is built that way.
+
+    The first live attempt DEADLOCKED THE ENGINE.
 
         16:55:42  FQ decide step=100 interval=1 swaps=64   <- first live apply
         16:55:50  generation throughput 10.4 tokens/s
@@ -170,8 +174,11 @@ def _bind_apply_fn(state, runner, rank: int) -> None:
     collective_rpc, then gathers. That is the shape an automatic apply needs
     too: propose inside the step, apply outside it, together.
 
-    Until that exists, ``VLLM_FQ_LIVE_APPLY=1`` binds this anyway for
-    experiments on a serve nobody is depending on. It is not a supported mode.
+    That is now built: staging happens in a background thread and every rank
+    votes before a single weight moves, so no rank can apply a batch another
+    rank has not finished. ``VLLM_FQ_LIVE_APPLY`` defaults to ``off`` for one
+    more cycle while the second instance validates it under CUDA graphs; set
+    ``1`` to enable.
 
     GATED ON EAGER EXECUTION as well, for when it is re-enabled. ``admin.apply_retier`` can pass
     ``quiesce=nullcontext()`` because the HTTP request drains the engine
@@ -221,6 +228,12 @@ def _bind_apply_fn(state, runner, rank: int) -> None:
     # retrying next interval" -- but it could never succeed, so the serve
     # would have retried forever while looking busy.
     _cap = int(getattr(getattr(state, "cfg", None), "max_swaps_total", 0) or 0)
+    import concurrent.futures as _fut
+    # One worker: the engine holds one staged batch at a time anyway, and a
+    # second concurrent stage would race it.
+    _stager = _fut.ThreadPoolExecutor(max_workers=1,
+                                      thread_name_prefix="fq-stage")
+
     engine = _admin.build_swap_engine(
         runner, rank=rank, max_pairs=max(_cap, _admin.DEFAULT_MAX_ITEMS))
     if engine is None:
@@ -228,43 +241,110 @@ def _bind_apply_fn(state, runner, rank: int) -> None:
                     "registered — a uniform-K serve has nothing to swap")
         return
 
-    def apply_fn(proposed_doc, swaps) -> bool:
-        # The loop indexes layers by ROW; the engine keys by GLOBAL layer id.
-        plan = _swap.SwapPlan([
-            (int(state.layers[row]), int(e_out), int(e_in))
-            for row, e_out, e_in in swaps])
-        # fail_atomic stages the pre-swap rows so an abort before the
-        # visibility flip restores inside the same window. drop lets a pair
-        # whose fragments cannot be supplied pend instead of losing the
-        # interval; cardinality is preserved either way.
-        if len(plan.swaps) > int(engine.max_pairs):
-            # Configuration error, not a runtime condition: say which two
-            # knobs disagree rather than surfacing a buffer-size ValueError.
-            log.error(
-                "FQ live apply: plan has %d pairs but staging holds %d — "
-                "raise VLLM_FQ_MAX_SWAPS_TOTAL/max_pairs together or lower "
-                "the loop cap; skipping this interval",
-                len(plan.swaps), int(engine.max_pairs))
+    # ------------------------------------------------------------------
+    # Async staging + collective readiness gate.
+    #
+    # Inline staging deadlocked TP: engine.stage() reads hundreds of MB of
+    # fragments, per-rank, at unequal speed, INSIDE the step — so the ranks
+    # drift apart at a collective boundary and the shm broadcast starves.
+    #
+    # Split it. Staging is host-only and order-independent, so it runs in a
+    # background thread. The apply itself is device copies from already-pinned
+    # memory plus a map flip: short, and identical work on every rank.
+    #
+    # The danger in splitting is worse than the deadlock: if rank A finishes
+    # staging and rank B does not, A applies and B does not, and the ranks now
+    # hold DIFFERENT WEIGHTS silently. So readiness is agreed with an
+    # all_reduce(MIN) — a tiny collective at a deterministic point, which
+    # preserves lockstep instead of breaking it. Either every rank applies
+    # this interval or none does.
+    _pending: dict = {}
+
+    def _plan_key(swaps) -> str:
+        return ",".join(f"{int(a)}:{int(b)}:{int(c)}" for a, b, c in swaps)
+
+    def _all_ranks_ready(local_ready: bool) -> bool:
+        try:
+            import torch
+            import torch.distributed as dist
+            if not dist.is_available() or not dist.is_initialized():
+                return local_ready
+            t = torch.tensor([1 if local_ready else 0], dtype=torch.int32,
+                             device="cuda")
+            dist.all_reduce(t, op=dist.ReduceOp.MIN)
+            return bool(int(t.item()))
+        except Exception:  # noqa: BLE001 — a failed vote is a NO, never a yes
+            log.warning("FQ live apply: readiness all_reduce failed — "
+                        "treating as not ready", exc_info=True)
             return False
-        staged = engine.stage(plan, fail_atomic=True, on_unavailable="drop")
+
+    def apply_fn(proposed_doc, swaps) -> bool:
+        key = _plan_key(swaps)
+        staged = _pending.get("staged") if _pending.get("key") == key else None
+
+        if staged is None:
+            # New plan: start staging OUT OF BAND and decline this interval.
+            # The same plan is re-proposed while the routing signal holds, so
+            # the next interval picks up the finished batch.
+            if _pending.get("future") is not None and _pending.get("key") == key:
+                ready = _pending["future"].done()
+            else:
+                if len(swaps) > int(engine.max_pairs):
+                    log.error(
+                        "FQ live apply: plan has %d pairs but staging holds "
+                        "%d — raise the loop cap or max_pairs together; "
+                        "skipping", len(swaps), int(engine.max_pairs))
+                    return False
+                plan = _swap.SwapPlan([
+                    (int(state.layers[row]), int(e_out), int(e_in))
+                    for row, e_out, e_in in swaps])
+                _pending.clear()
+                _pending["key"] = key
+                _pending["future"] = _stager.submit(
+                    engine.stage, plan, fail_atomic=True,
+                    on_unavailable="drop")
+                log.info("FQ live apply: staging %d swap(s) off-step",
+                         len(swaps))
+                ready = False
+            if ready:
+                try:
+                    _pending["staged"] = _pending["future"].result()
+                except Exception:  # noqa: BLE001
+                    log.exception("FQ live apply: staging failed")
+                    _pending.clear()
+                    return False
+                staged = _pending["staged"]
+            else:
+                # Vote anyway so every rank takes the same branch.
+                _all_ranks_ready(False)
+                return False
+
+        # Every rank must agree before a single weight moves.
+        if not _all_ranks_ready(True):
+            log.info("FQ live apply: staged locally, waiting for all ranks")
+            return False
+
         dropped = tuple(getattr(staged, "dropped", ()) or ())
         if dropped:
             log.warning("FQ live apply: %d pair(s) dropped for missing "
-                        "fragments, %d applied", len(dropped),
-                        len(getattr(staged, "plan", plan).swaps))
-        if not getattr(getattr(staged, "plan", plan), "swaps", ()):
+                        "fragments", len(dropped))
+        eff = getattr(staged, "plan", None)
+        if eff is not None and not getattr(eff, "swaps", ()):
+            _pending.clear()
             return False
         import contextlib
 
         report = engine.apply(
             staged=staged,
             quiesce=contextlib.nullcontext(),
-            memo_hook=None,          # correct for the mixed runtime
+            memo_hook=None,
             policy_doc=dict(proposed_doc),
         )
         ok = bool(getattr(report, "ok", True))
-        log.info("FQ live apply: %d swap(s) %s", len(plan.swaps),
-                 "installed" if ok else "REFUSED")
+        n = len(getattr(eff, "swaps", swaps))
+        log.info("FQ live apply: %d swap(s) %s", n,
+                 "INSTALLED" if ok else "REFUSED")
+        _pending.clear()
         return ok
 
     state.apply_fn = apply_fn

--- a/vllm/model_executor/layers/quantization/exl3_fungible/integration.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/integration.py
@@ -279,49 +279,54 @@ def _bind_apply_fn(state, runner, rank: int) -> None:
             return False
 
     def apply_fn(proposed_doc, swaps) -> bool:
-        key = _plan_key(swaps)
-        staged = _pending.get("staged") if _pending.get("key") == key else None
+        fut = _pending.get("future")
 
-        if staged is None:
-            # New plan: start staging OUT OF BAND and decline this interval.
-            # The same plan is re-proposed while the routing signal holds, so
-            # the next interval picks up the finished batch.
-            if _pending.get("future") is not None and _pending.get("key") == key:
-                ready = _pending["future"].done()
-            else:
-                if len(swaps) > int(engine.max_pairs):
-                    log.error(
-                        "FQ live apply: plan has %d pairs but staging holds "
-                        "%d — raise the loop cap or max_pairs together; "
-                        "skipping", len(swaps), int(engine.max_pairs))
-                    return False
-                plan = _swap.SwapPlan([
-                    (int(state.layers[row]), int(e_out), int(e_in))
-                    for row, e_out, e_in in swaps])
-                _pending.clear()
-                _pending["key"] = key
-                _pending["future"] = _stager.submit(
-                    engine.stage, plan, fail_atomic=True,
-                    on_unavailable="drop")
-                log.info("FQ live apply: staging %d swap(s) off-step",
-                         len(swaps))
-                ready = False
-            if ready:
-                try:
-                    _pending["staged"] = _pending["future"].result()
-                except Exception:  # noqa: BLE001
-                    log.exception("FQ live apply: staging failed")
-                    _pending.clear()
-                    return False
-                staged = _pending["staged"]
-            else:
-                # Vote anyway so every rank takes the same branch.
-                _all_ranks_ready(False)
+        if fut is None:
+            # Nothing in flight: start staging THIS plan and decline the
+            # interval. Staging is the slow part and it does not belong in
+            # the step.
+            if len(swaps) > int(engine.max_pairs):
+                log.error(
+                    "FQ live apply: plan has %d pairs but staging holds %d — "
+                    "raise the loop cap or max_pairs together; skipping",
+                    len(swaps), int(engine.max_pairs))
                 return False
+            plan = _swap.SwapPlan([
+                (int(state.layers[row]), int(e_out), int(e_in))
+                for row, e_out, e_in in swaps])
+            _pending["key"] = _plan_key(swaps)
+            _pending["future"] = _stager.submit(
+                engine.stage, plan, fail_atomic=True, on_unavailable="drop")
+            log.info("FQ live apply: staging %d swap(s) off-step", len(swaps))
+            _all_ranks_ready(False)     # keep the collective in lockstep
+            return False
 
-        # Every rank must agree before a single weight moves.
+        if not fut.done():
+            _all_ranks_ready(False)
+            return False
+
+        # Staging finished. Apply it EVEN IF the newest proposal has drifted.
+        #
+        # The first version keyed the staged batch on the exact plan and
+        # discarded it whenever the proposal changed. The proposal changes
+        # every interval — the desired set moves by an expert or two — so the
+        # batch was thrown away and re-staged forever: 40 staging events, 0
+        # applies, and hundreds of MB of fragment IO per interval for nothing.
+        #
+        # A staged batch is a valid improvement, not a contract. One interval
+        # of staleness costs at most a couple of experts; the engine still
+        # validates cardinality, and the next interval re-proposes from
+        # current stats anyway.
+        try:
+            staged = fut.result()
+        except Exception:  # noqa: BLE001
+            log.exception("FQ live apply: staging failed")
+            _pending.clear()
+            _all_ranks_ready(False)
+            return False
+
         if not _all_ranks_ready(True):
-            log.info("FQ live apply: staged locally, waiting for all ranks")
+            log.info("FQ live apply: staged here, waiting for all ranks")
             return False
 
         dropped = tuple(getattr(staged, "dropped", ()) or ())
@@ -329,7 +334,8 @@ def _bind_apply_fn(state, runner, rank: int) -> None:
             log.warning("FQ live apply: %d pair(s) dropped for missing "
                         "fragments", len(dropped))
         eff = getattr(staged, "plan", None)
-        if eff is not None and not getattr(eff, "swaps", ()):
+        n = len(getattr(eff, "swaps", ()) or ())
+        if not n:
             _pending.clear()
             return False
         import contextlib
@@ -341,7 +347,6 @@ def _bind_apply_fn(state, runner, rank: int) -> None:
             policy_doc=dict(proposed_doc),
         )
         ok = bool(getattr(report, "ok", True))
-        n = len(getattr(eff, "swaps", swaps))
         log.info("FQ live apply: %d swap(s) %s", n,
                  "INSTALLED" if ok else "REFUSED")
         _pending.clear()

--- a/vllm/model_executor/layers/quantization/exl3_fungible/integration.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/integration.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Fungible-quant M1 integration hook.
+
+Wires the :class:`FqStatsCollector` into the model runner: called from
+``gpu_worker.initialize_from_config`` right after the (optional)
+routed-experts capturer init and BEFORE CUDA-graph capture, so the
+collector's capture fn is recorded into the graphs.
+
+The routed-experts capturer is only bound when
+``enable_return_routed_experts`` is set, so this hook must be its own
+call site — never piggybacked on that flag. ``bind_router`` chains any
+previously bound capture fn, so both orders (capturer bound or not)
+are safe.
+
+Laziness contract: this module imports nothing from vllm at module
+level, and ``maybe_init_fq_collector`` returns before importing
+anything when ``VLLM_FQ_ENABLE`` is off — zero import cost for the
+default path. The vllm symbols are resolved through the two seam
+functions ``_moe_module_types`` / ``_collector_cls`` so CPU tests can
+monkeypatch fakes in without building ``vllm._C``.
+"""
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from vllm.model_executor.layers.quantization.exl3_fungible.stats import (
+        FqStatsCollector,
+    )
+
+FQ_ENABLE_ENV = "VLLM_FQ_ENABLE"
+FQ_WINDOW_LEN_ENV = "VLLM_FQ_WINDOW_LEN"
+FQ_WINDOW_STRIDE_ENV = "VLLM_FQ_WINDOW_STRIDE"
+FQ_DECAY_ENV = "VLLM_FQ_DECAY"
+
+
+def _moe_module_types() -> tuple[type, type]:
+    """Lazy isinstance targets ``(MoERunner, BaseRouter)``.
+
+    Monkeypatch seam for CPU tests (inject fake classes); lazy so the
+    env-off path never touches the fused_moe import graph.
+    """
+    from vllm.model_executor.layers.fused_moe.layer import MoERunner
+    from vllm.model_executor.layers.fused_moe.router.base_router import (
+        BaseRouter,
+    )
+    return MoERunner, BaseRouter
+
+
+def _collector_cls() -> "type[FqStatsCollector]":
+    """Lazy :class:`FqStatsCollector`; monkeypatch seam for CPU tests."""
+    from vllm.model_executor.layers.quantization.exl3_fungible.stats import (
+        FqStatsCollector,
+    )
+    return FqStatsCollector
+
+
+def _window_kwargs_from_env() -> dict:
+    """Window knobs from env; unset knobs fall through to the
+    ``FqStatsCollector`` signature defaults (single source of truth)."""
+    kwargs: dict = {}
+    v = os.environ.get(FQ_WINDOW_LEN_ENV)
+    if v is not None:
+        kwargs["window_len"] = int(v)
+    v = os.environ.get(FQ_WINDOW_STRIDE_ENV)
+    if v is not None:
+        kwargs["window_stride"] = int(v)
+    v = os.environ.get(FQ_DECAY_ENV)
+    if v is not None:
+        kwargs["decay"] = float(v)
+    return kwargs
+
+
+def maybe_init_fq_collector(runner) -> "FqStatsCollector | None":
+    """Build and bind the FQ stats collector, if enabled and applicable.
+
+    Returns None (binding nothing, importing nothing heavy) unless
+    ``VLLM_FQ_ENABLE=1`` and the model contains at least one MoERunner
+    with a BaseRouter router. Otherwise binds EVERY such router via
+    ``collector.bind_router`` — which chains a previously installed
+    capture fn (e.g. the routed-experts capturer), so it is safe to
+    call whether or not ``enable_return_routed_experts`` already bound
+    one. Must run before CUDA-graph capture.
+
+    Args:
+        runner: the GPU model runner (needs ``.model.modules()`` and
+            ``.device``).
+    """
+    if os.environ.get(FQ_ENABLE_ENV, "0") != "1":
+        return None
+
+    moe_runner_cls, base_router_cls = _moe_module_types()
+
+    routers: list[tuple[int, object]] = []
+    for module in runner.model.modules():
+        if (isinstance(module, moe_runner_cls)
+                and isinstance(module.router, base_router_cls)):
+            routers.append((module.layer_id, module.router))
+    if not routers:
+        return None
+
+    collector = _collector_cls()(
+        routers[0][1].global_num_experts,
+        device=runner.device,
+        **_window_kwargs_from_env(),
+    )
+    for layer_id, router in routers:
+        collector.bind_router(layer_id, router)
+    return collector

--- a/vllm/model_executor/layers/quantization/exl3_fungible/integration.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/integration.py
@@ -73,6 +73,39 @@ def _window_kwargs_from_env() -> dict:
     return kwargs
 
 
+def maybe_init_fq_state(runner):
+    """Build the full M2 loop (collector + policy/decision state machine).
+
+    The model runner's step sites call ``.step(is_dummy=...)`` on
+    whatever this returns; :class:`FungibleQuantState` and
+    :class:`FqStatsCollector` share that contract, so the M1 call sites
+    need no change. Degrades stepwise: env off / no MoE -> None; loop
+    boot failure (no policy source, bad store, ...) -> bare collector
+    (M1 observability only), never a dead engine.
+    """
+    collector = maybe_init_fq_collector(runner)
+    if collector is None:
+        return None
+    try:
+        import torch.distributed as dist
+
+        rank = dist.get_rank() if dist.is_initialized() else 0
+    except Exception:
+        rank = 0
+    try:
+        from vllm.model_executor.layers.quantization.exl3_fungible import (
+            loop as fq_loop,
+        )
+        state = fq_loop.build_from_env(collector, rank=rank)
+    except Exception:
+        import logging
+
+        logging.getLogger(__name__).exception(
+            "FQ loop init failed — falling back to collector-only")
+        return collector
+    return state if state is not None else collector
+
+
 def maybe_init_fq_collector(runner) -> "FqStatsCollector | None":
     """Build and bind the FQ stats collector, if enabled and applicable.
 

--- a/vllm/model_executor/layers/quantization/exl3_fungible/integration.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/integration.py
@@ -151,7 +151,29 @@ def _bind_apply_fn(state, runner, rank: int) -> None:
     ``_maybe_apply`` returned False before touching a weight — 64 swaps
     decided across 39 layers, zero installed.
 
-    GATED ON EAGER EXECUTION, deliberately. ``admin.apply_retier`` can pass
+    DISABLED BY DEFAULT, because the first live attempt DEADLOCKED THE ENGINE.
+
+        16:55:42  FQ decide step=100 interval=1 swaps=64   <- first live apply
+        16:55:50  generation throughput 10.4 tokens/s
+        16:56:00  0.0 tokens/s
+        16:56:43  No available shared memory broadcast block found in 60s
+
+    The reasoning that led here was about CUDA-graph replay, and that was the
+    wrong hazard. ``engine.stage()`` reads hundreds of MB of fragments
+    SYNCHRONOUSLY, inside the model runner's step, INDEPENDENTLY ON EVERY TP
+    RANK. Four ranks doing unequal amounts of IO at an implicit collective
+    boundary drift apart, and the shared-memory broadcast starves. Eager
+    execution does not help: this is TP lockstep, not graph safety.
+
+    The admin path does not have this problem because it is coordinated from
+    OUTSIDE the step -- the router drains, then dispatches to every rank via
+    collective_rpc, then gathers. That is the shape an automatic apply needs
+    too: propose inside the step, apply outside it, together.
+
+    Until that exists, ``VLLM_FQ_LIVE_APPLY=1`` binds this anyway for
+    experiments on a serve nobody is depending on. It is not a supported mode.
+
+    GATED ON EAGER EXECUTION as well, for when it is re-enabled. ``admin.apply_retier`` can pass
     ``quiesce=nullcontext()`` because the HTTP request drains the engine
     first (``drain_mode="wait"``). The loop has no such drain: it decides
     inside the runner's step. With ``enforce_eager`` nothing is replaying and
@@ -166,7 +188,10 @@ def _bind_apply_fn(state, runner, rank: int) -> None:
     import logging
 
     log = logging.getLogger(__name__)
-    mode = os.environ.get(FQ_LIVE_APPLY_ENV, "auto").strip().lower()
+    # DEFAULT OFF. "auto" (bind whenever eager) deadlocked a live TP4 serve on
+    # its first apply -- see the block comment below. Inline apply is opt-in
+    # until it is coordinated across ranks.
+    mode = os.environ.get(FQ_LIVE_APPLY_ENV, "off").strip().lower()
     if mode in ("0", "off", "false"):
         log.info("FQ live apply disabled by %s=%s — proposals only",
                  FQ_LIVE_APPLY_ENV, mode)

--- a/vllm/model_executor/layers/quantization/exl3_fungible/integration.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/integration.py
@@ -294,6 +294,10 @@ def _bind_apply_fn(state, runner, rank: int) -> None:
             plan = _swap.SwapPlan([
                 (int(state.layers[row]), int(e_out), int(e_in))
                 for row, e_out, e_in in swaps])
+            # Keep the global->row mapping: the loop indexes tier_of by ROW
+            # and must be told what was installed in its own coordinates.
+            _pending["rows"] = {int(l): int(r)
+                                for r, l in enumerate(state.layers)}
             _pending["key"] = _plan_key(swaps)
             _pending["future"] = _stager.submit(
                 engine.stage, plan, fail_atomic=True, on_unavailable="drop")
@@ -368,8 +372,17 @@ def _bind_apply_fn(state, runner, rank: int) -> None:
         ok = bool(getattr(report, "ok", True))
         log.info("FQ live apply: %d swap(s) %s", n,
                  "INSTALLED" if ok else "REFUSED")
+        rows = _pending.get("rows") or {}
         _pending.clear()
-        return ok
+        if not ok:
+            return False
+        # Report what the DEVICE took, in the loop's row coordinates. Returning
+        # a bare True would let the loop record this interval's proposal as the
+        # new incumbent even though an older batch was installed — and the next
+        # interval would then propose a swap off an expert that is not
+        # resident, which stage() rejects outright.
+        return [(rows[int(l)], int(e_out), int(e_in))
+                for l, e_out, e_in in eff.swaps if int(l) in rows]
 
     state.apply_fn = apply_fn
     log.info("FQ live apply BOUND: %d mixed layers, rank %d — decisions will "

--- a/vllm/model_executor/layers/quantization/exl3_fungible/integration.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/integration.py
@@ -34,6 +34,12 @@ FQ_ENABLE_ENV = "VLLM_FQ_ENABLE"
 FQ_WINDOW_LEN_ENV = "VLLM_FQ_WINDOW_LEN"
 FQ_WINDOW_STRIDE_ENV = "VLLM_FQ_WINDOW_STRIDE"
 FQ_DECAY_ENV = "VLLM_FQ_DECAY"
+# Opt-in: record REAL gate mass (sum of routing weights) as well as hit
+# counts. Off by default because it adds a guarded scatter_add_ to the
+# per-layer capture path; the count-only default is one histc
+# (PERFORMANCE.md: M1 gate is <0.5% decode overhead). With it off, mass
+# is aliased to count and the collector reports mass_is_real() == False.
+FQ_GATE_MASS_ENV = "VLLM_FQ_GATE_MASS"
 
 
 def _moe_module_types() -> tuple[type, type]:
@@ -81,6 +87,8 @@ def _window_kwargs_from_env() -> dict:
     v = os.environ.get(FQ_DECAY_ENV)
     if v is not None:
         kwargs["decay"] = float(v)
+    if os.environ.get(FQ_GATE_MASS_ENV, "0") == "1":
+        kwargs["record_mass"] = True
     return kwargs
 
 
@@ -152,4 +160,14 @@ def maybe_init_fq_collector(runner) -> "FqStatsCollector | None":
     )
     for layer_id, router in routers:
         collector.bind_router(layer_id, router)
+    # State the resolved mass mode in the engine log: "mass" is present in
+    # every stats artifact either way, and an operator must not have to
+    # diff it against "count" to discover which one they got.
+    import logging
+
+    logging.getLogger(__name__).info(
+        "FQ stats: bound %d MoE routers, %d experts, gate mass %s (%s=%s)",
+        len(routers), collector.num_experts,
+        "RECORDED" if collector.mass_is_real() else "ALIASED TO COUNT",
+        FQ_GATE_MASS_ENV, os.environ.get(FQ_GATE_MASS_ENV, "0"))
     return collector

--- a/vllm/model_executor/layers/quantization/exl3_fungible/integration.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/integration.py
@@ -302,6 +302,10 @@ def _bind_apply_fn(state, runner, rank: int) -> None:
             return False
 
         if not fut.done():
+            _pending["waits"] = _pending.get("waits", 0) + 1
+            if _pending["waits"] % 4 == 1:
+                log.info("FQ live apply: staging still running (%d interval(s))",
+                         _pending["waits"])
             _all_ranks_ready(False)
             return False
 
@@ -336,16 +340,31 @@ def _bind_apply_fn(state, runner, rank: int) -> None:
         eff = getattr(staged, "plan", None)
         n = len(getattr(eff, "swaps", ()) or ())
         if not n:
+            # Every exit from this function must say why. A silent return
+            # False here produced 7 staging submissions and 1 install with
+            # nothing in the log to explain the other 6 — the same
+            # looks-like-progress shape this code keeps reproducing.
+            log.warning(
+                "FQ live apply: staged batch has no effective swaps "
+                "(requested %d, dropped %d) — discarding",
+                len(swaps), len(dropped))
             _pending.clear()
             return False
         import contextlib
 
-        report = engine.apply(
-            staged=staged,
-            quiesce=contextlib.nullcontext(),
-            memo_hook=None,
-            policy_doc=dict(proposed_doc),
-        )
+        try:
+            report = engine.apply(
+                staged=staged,
+                quiesce=contextlib.nullcontext(),
+                memo_hook=None,
+                policy_doc=dict(proposed_doc),
+            )
+        except Exception:  # noqa: BLE001
+            # loop.py catches this too, but by then the reason has lost the
+            # context of WHICH batch and how big.
+            log.exception("FQ live apply: engine.apply raised on %d swap(s)", n)
+            _pending.clear()
+            return False
         ok = bool(getattr(report, "ok", True))
         log.info("FQ live apply: %d swap(s) %s", n,
                  "INSTALLED" if ok else "REFUSED")

--- a/vllm/model_executor/layers/quantization/exl3_fungible/integration.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/integration.py
@@ -116,6 +116,8 @@ def maybe_init_fq_state(runner):
             loop as fq_loop,
         )
         state = fq_loop.build_from_env(collector, rank=rank)
+        if state is not None:
+            _bind_apply_fn(state, runner, rank)
     except Exception:
         import logging
 
@@ -123,6 +125,106 @@ def maybe_init_fq_state(runner):
             "FQ loop init failed — falling back to collector-only")
         return collector
     return state if state is not None else collector
+
+
+#: Live apply is gated on the runtime the swap is proven safe in.
+FQ_LIVE_APPLY_ENV = "VLLM_FQ_LIVE_APPLY"
+
+
+def _graphs_are_live(runner) -> bool:
+    """True when a captured CUDA graph may replay over the expert slabs."""
+    try:
+        cfg = runner.vllm_config
+        if bool(getattr(cfg.model_config, "enforce_eager", False)):
+            return False
+        mode = getattr(cfg.compilation_config, "cudagraph_mode", None)
+        return not (mode is None or str(mode).endswith("NONE"))
+    except Exception:  # noqa: BLE001 — unknown runtime is the unsafe one
+        return True
+
+
+def _bind_apply_fn(state, runner, rank: int) -> None:
+    """Give the loop the swap backend it has been deciding without.
+
+    Until now ``build_from_env`` never passed ``apply_fn``, so every interval
+    logged "recording proposals only (M4 live wiring pending)" and
+    ``_maybe_apply`` returned False before touching a weight — 64 swaps
+    decided across 39 layers, zero installed.
+
+    GATED ON EAGER EXECUTION, deliberately. ``admin.apply_retier`` can pass
+    ``quiesce=nullcontext()`` because the HTTP request drains the engine
+    first (``drain_mode="wait"``). The loop has no such drain: it decides
+    inside the runner's step. With ``enforce_eager`` nothing is replaying and
+    device work ordered on the same stream is ordered after the previous
+    forward, so a nullcontext is honest. With CUDA graphs captured, a replay
+    holds device pointers into the very slabs being rewritten — that needs a
+    real drain, which does not exist yet.
+
+    So: bind under eager, refuse loudly under graphs, and let an operator
+    override only on purpose.
+    """
+    import logging
+
+    log = logging.getLogger(__name__)
+    mode = os.environ.get(FQ_LIVE_APPLY_ENV, "auto").strip().lower()
+    if mode in ("0", "off", "false"):
+        log.info("FQ live apply disabled by %s=%s — proposals only",
+                 FQ_LIVE_APPLY_ENV, mode)
+        return
+    if mode == "auto" and _graphs_are_live(runner):
+        log.warning(
+            "FQ live apply NOT bound: CUDA graphs are captured and the loop "
+            "has no drain, so a replay could read slabs mid-rewrite. The loop "
+            "will record proposals only. Run with --enforce-eager, or set "
+            "%s=1 to override deliberately.", FQ_LIVE_APPLY_ENV)
+        return
+
+    from vllm.model_executor.layers.quantization.exl3_fungible import (
+        admin as _admin,
+    )
+    from vllm.model_executor.layers.quantization.exl3_fungible import (
+        swap as _swap,
+    )
+
+    engine = _admin.build_swap_engine(runner, rank=rank)
+    if engine is None:
+        log.warning("FQ live apply NOT bound: no mixed-trellis layers "
+                    "registered — a uniform-K serve has nothing to swap")
+        return
+
+    def apply_fn(proposed_doc, swaps) -> bool:
+        # The loop indexes layers by ROW; the engine keys by GLOBAL layer id.
+        plan = _swap.SwapPlan([
+            (int(state.layers[row]), int(e_out), int(e_in))
+            for row, e_out, e_in in swaps])
+        # fail_atomic stages the pre-swap rows so an abort before the
+        # visibility flip restores inside the same window. drop lets a pair
+        # whose fragments cannot be supplied pend instead of losing the
+        # interval; cardinality is preserved either way.
+        staged = engine.stage(plan, fail_atomic=True, on_unavailable="drop")
+        dropped = tuple(getattr(staged, "dropped", ()) or ())
+        if dropped:
+            log.warning("FQ live apply: %d pair(s) dropped for missing "
+                        "fragments, %d applied", len(dropped),
+                        len(getattr(staged, "plan", plan).swaps))
+        if not getattr(getattr(staged, "plan", plan), "swaps", ()):
+            return False
+        import contextlib
+
+        report = engine.apply(
+            staged=staged,
+            quiesce=contextlib.nullcontext(),
+            memo_hook=None,          # correct for the mixed runtime
+            policy_doc=dict(proposed_doc),
+        )
+        ok = bool(getattr(report, "ok", True))
+        log.info("FQ live apply: %d swap(s) %s", len(plan.swaps),
+                 "installed" if ok else "REFUSED")
+        return ok
+
+    state.apply_fn = apply_fn
+    log.info("FQ live apply BOUND: %d mixed layers, rank %d — decisions will "
+             "now change weights", len(getattr(engine, "layers", {})), rank)
 
 
 def maybe_init_fq_collector(runner) -> "FqStatsCollector | None":

--- a/vllm/model_executor/layers/quantization/exl3_fungible/integration.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/integration.py
@@ -366,6 +366,33 @@ def _bind_apply_fn(state, runner, rank: int) -> None:
             _all_ranks_ready(False)
             return False
 
+        # Staging cost, stated in bytes and MB/s rather than left to be
+        # inferred. StagedBatch has carried `bytes_h2d` and `stage_seconds`
+        # since M4 and nothing ever logged them, so the only way to learn that
+        # staging — not the policy — rate-limits convergence was to difference
+        # timestamps by hand across a live log. It is IO-bound and slow:
+        # measured 45 s warm and 229 s cold for 64 swaps, ~1.2 GB in ~2,300
+        # small ranged reads over ~40 segment files (~10.5 MB/s), against
+        # 142-149 MiB/s for the loader's whole-segment reads. Anything that
+        # gates how fast the loop can converge belongs in the log.
+        _secs = float(getattr(staged, "stage_seconds", 0.0) or 0.0)
+        _bytes = int(getattr(staged, "bytes_h2d", 0) or 0)
+        log.info("FQ live apply: staged %d pair(s), %.1f MiB in %.1f s "
+                 "(%.1f MiB/s)", len(getattr(getattr(staged, "plan", None),
+                                             "swaps", ()) or ()),
+                 _bytes / 2**20, _secs,
+                 (_bytes / 2**20 / _secs) if _secs > 0 else float("nan"))
+        _m = getattr(state, "metrics", None)
+        if _m is not None:
+            for _name, _val in (("stage_seconds", _secs),
+                                ("stage_bytes", float(_bytes))):
+                _g = getattr(_m, _name, None)
+                if _g is not None:
+                    try:
+                        _g.set(_val)
+                    except Exception:  # noqa: BLE001 — telemetry never fails a swap
+                        pass
+
         if not _all_ranks_ready(True):
             log.info("FQ live apply: staged here, waiting for all ranks")
             return False
@@ -403,8 +430,19 @@ def _bind_apply_fn(state, runner, rank: int) -> None:
             _pending.clear()
             return False
         ok = bool(getattr(report, "ok", True))
-        log.info("FQ live apply: %d swap(s) %s", n,
-                 "INSTALLED" if ok else "REFUSED")
+        # The quiesce window is the ONLY interval in which serving is actually
+        # disturbed, so it is the number a reviewer will ask for first. Report
+        # it on the same line as the outcome.
+        _win = float(getattr(report, "window_seconds", 0.0) or 0.0)
+        log.info("FQ live apply: %d swap(s) %s (quiesce window %.3f s)", n,
+                 "INSTALLED" if ok else "REFUSED", _win)
+        _m = getattr(state, "metrics", None)
+        _g = getattr(_m, "apply_window_seconds", None) if _m else None
+        if _g is not None:
+            try:
+                _g.set(_win)
+            except Exception:  # noqa: BLE001 — telemetry never fails a swap
+                pass
         rows = _pending.get("rows") or {}
         _pending.clear()
         if not ok:

--- a/vllm/model_executor/layers/quantization/exl3_fungible/lazy_encode.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/lazy_encode.py
@@ -75,24 +75,58 @@ _PROJS = ("gate_proj", "up_proj", "down_proj")
 
 
 class EncodeQueue:
-    """Persisted JSONL queue of lazy-encode requests, dedup by (L, E, K)."""
+    """Persisted JSONL queue of lazy-encode requests, dedup by (L, E, K).
+
+    Loading is total: the queue is telemetry written by a live serve with
+    plain appends, so it can be found torn (a half-written last line after
+    a kill -9), truncated, byte-garbage, or replaced by a directory. None
+    of that may raise — an unreadable queue degrades to an empty one and
+    the serve keeps running. ``corrupt_lines`` counts what was skipped so
+    the drain worker can report it.
+    """
 
     def __init__(self, path: str | Path):
         self.path = Path(path)
         # insertion-ordered: position in this dict == queue position - 1
         self._entries: dict[tuple[int, int, int], dict] = {}
-        if self.path.exists():
-            for line in self.path.read_text().splitlines():
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    entry = json.loads(line)
-                except ValueError:
-                    continue
-                key = self._key(entry)
-                if key is not None and key not in self._entries:
-                    self._entries[key] = entry
+        self.corrupt_lines = 0
+        for line in self._read_lines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except ValueError:
+                self.corrupt_lines += 1
+                continue
+            key = self._key(entry)
+            if key is None:
+                self.corrupt_lines += 1
+                continue
+            if key not in self._entries:
+                self._entries[key] = entry
+        if self.corrupt_lines:
+            print(
+                f"warning: encode queue {self.path}: skipped "
+                f"{self.corrupt_lines} unparseable line(s)",
+                file=sys.stderr,
+            )
+
+    def _read_lines(self) -> list[str]:
+        """Queue file lines, or [] for anything unreadable."""
+        try:
+            if not self.path.is_file():
+                return []
+            # errors="replace": a torn append can leave a partial UTF-8
+            # sequence; that line must be skipped, not kill the reader.
+            return self.path.read_text(errors="replace").splitlines()
+        except OSError:
+            print(
+                f"warning: encode queue {self.path} unreadable — "
+                "continuing with an empty queue",
+                file=sys.stderr,
+            )
+            return []
 
     @staticmethod
     def _key(entry: dict) -> tuple[int, int, int] | None:
@@ -219,20 +253,39 @@ def _capture_check(
     return False, f"capture missing layer_{layer:03d}"
 
 
+class _LenientFields(dict):
+    """``str.format_map`` mapping that leaves unknown fields untouched."""
+
+    def __missing__(self, key: str) -> str:
+        return "{" + key + "}"
+
+
 def render_cmd(
     template: str,
     entry: dict,
     bf16_dir: str | Path | None,
     capture_dir: str | Path | None,
 ) -> str:
-    return template.format(
-        layer=int(entry["layer"]),
-        layer03=f"{int(entry['layer']):03d}",
+    """Render the encoder command for one queue entry.
+
+    Lenient on purpose: an operator template naming a placeholder we do not
+    provide renders it back verbatim instead of raising, so one typo in
+    ``VLLM_FQ_ENCODER_CMD`` cannot abort a whole drain (the printed command
+    still shows the mistake)."""
+    layer = int(entry["layer"])
+    fields = _LenientFields(
+        layer=layer,
+        layer03=f"{layer:03d}",
         expert=int(entry["expert"]),
         k=int(entry["k"]),
         bf16_dir=bf16_dir or "",
         capture_dir=capture_dir or "",
     )
+    try:
+        return template.format_map(fields)
+    except (IndexError, ValueError) as exc:
+        # positional {} / malformed format spec: unusable but not fatal
+        return f"<unrenderable encoder template: {type(exc).__name__}: {exc}>"
 
 
 # -------------------------------------------------------------------- drain
@@ -270,15 +323,21 @@ def drain(
     failed = 0
     done: list[dict] = []
     for i, entry in enumerate(entries, 1):
-        tag = (
-            f"#{i} L{entry['layer']}/e{entry['expert']} K{entry['k']} "
-            f"reason={entry.get('reason', '?')}"
-        )
-        ok_bf16, msg_bf16 = _bf16_check(
-            bf16_dir, int(entry["layer"]), int(entry["expert"])
-        )
-        ok_cap, msg_cap = _capture_check(capture_dir, int(entry["layer"]))
-        cmd = render_cmd(template, entry, bf16_dir, capture_dir)
+        try:
+            tag = (
+                f"#{i} L{entry['layer']}/e{entry['expert']} K{entry['k']} "
+                f"reason={entry.get('reason', '?')}"
+            )
+            ok_bf16, msg_bf16 = _bf16_check(
+                bf16_dir, int(entry["layer"]), int(entry["expert"])
+            )
+            ok_cap, msg_cap = _capture_check(capture_dir, int(entry["layer"]))
+            cmd = render_cmd(template, entry, bf16_dir, capture_dir)
+        except Exception as exc:  # noqa: BLE001 — one entry, not the drain
+            failed += 1
+            out(f"#{i} SKIPPED unusable entry {entry!r}: "
+                f"{type(exc).__name__}: {exc}")
+            continue
         if not (ok_bf16 and ok_cap):
             failed += 1
             out(f"{tag} BLOCKED {msg_bf16}; {msg_cap}")
@@ -287,7 +346,12 @@ def drain(
             out(f"{tag} DRY-RUN OK {msg_bf16} {msg_cap} cmd: {cmd}")
             continue
         out(f"{tag} ENCODE {cmd}")
-        result = runner(shlex.split(cmd))
+        try:
+            result = runner(shlex.split(cmd))
+        except Exception as exc:  # noqa: BLE001 — a dead encoder is a failure
+            failed += 1
+            out(f"{tag} FAILED {type(exc).__name__}: {exc}")
+            continue
         rc = getattr(result, "returncode", result)
         if rc == 0:
             done.append(entry)

--- a/vllm/model_executor/layers/quantization/exl3_fungible/lazy_encode.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/lazy_encode.py
@@ -1,0 +1,353 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Lazy-encode queue + drain worker (Progressive Tensors T3 plumbing).
+
+Boot must never block on a missing fragment: when the FragmentResolver
+cannot resolve (or refuses to trust) a ``(layer, expert, K)`` fragment it
+either substitutes a fallback K (``VLLM_FQ_K_FALLBACK``) or fails — in both
+cases it *enqueues* the miss here so an out-of-band worker can encode the
+missing fragment from BF16 + capture and publish it into a segment dir.
+
+Queue: a persisted JSONL file (``VLLM_FQ_ENCODE_QUEUE``, default
+``<VLLM_FQ_CACHE>/encode-queue.jsonl``) of
+``{layer, expert, k, reason, requested_utc}`` entries, deduplicated by
+``(layer, expert, k)``.  Appends are O(1) single-line writes; the resolver
+never waits on encode work.
+
+Worker CLI::
+
+    python -m vllm.model_executor.layers.quantization.exl3_fungible.lazy_encode \
+        --drain [--execute] [--queue PATH] [--bf16-dir DIR] [--capture-dir DIR] \
+        [--encoder-cmd TEMPLATE] [--limit N]
+
+``--drain`` alone runs in DRY-RUN mode: each entry is validated against the
+available BF16 checkpoint (``VLLM_FQ_BF16_DIR`` — expert weights present in
+``model.safetensors.index.json``) and Hessian capture
+(``VLLM_FQ_CAPTURE_DIR`` — ``layer_{L:03d}/`` payload dir), and the encoder
+command that WOULD run is printed.  ``--execute`` actually shells out to the
+encoder driver per entry (GPU work) and removes completed entries from the
+queue.
+
+Encoder command template (``VLLM_FQ_ENCODER_CMD`` / ``--encoder-cmd``),
+``str.format`` placeholders ``{layer} {layer03} {expert} {k} {bf16_dir}
+{capture_dir}``.  The default targets the existing sha-pinned encoder driver
+(tested-by-dryrun only — never executed by the resolver)::
+
+    python .../tools/fruit-encoder/fruit_encode_driver.py \
+        --encode --bits {k} --layers {layer} --src {bf16_dir} \
+        --capture-dir {capture_dir} --workers 1 --gpus 0
+
+The driver's unit of work is one layer (it encodes every expert of
+``--layers {layer}`` — a superset of the queued expert; correct, amortized
+across all queued misses of that layer).  The ``{expert}`` placeholder is
+provided for future single-expert drivers.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any, Callable
+
+FQ_ENCODE_QUEUE_ENV = "VLLM_FQ_ENCODE_QUEUE"
+FQ_BF16_DIR_ENV = "VLLM_FQ_BF16_DIR"
+FQ_CAPTURE_DIR_ENV = "VLLM_FQ_CAPTURE_DIR"
+FQ_ENCODER_CMD_ENV = "VLLM_FQ_ENCODER_CMD"
+
+DEFAULT_QUEUE_NAME = "encode-queue.jsonl"
+
+DEFAULT_ENCODER_DRIVER = (
+    "/home/mbelleau/protensors-work/vllm-voipmonitor/research/fungible-quant/"
+    "tools/fruit-encoder/fruit_encode_driver.py"
+)
+DEFAULT_ENCODER_CMD = (
+    "python " + DEFAULT_ENCODER_DRIVER + " --encode --bits {k} "
+    "--layers {layer} --src {bf16_dir} --capture-dir {capture_dir} "
+    "--workers 1 --gpus 0"
+)
+
+_PROJS = ("gate_proj", "up_proj", "down_proj")
+
+
+class EncodeQueue:
+    """Persisted JSONL queue of lazy-encode requests, dedup by (L, E, K)."""
+
+    def __init__(self, path: str | Path):
+        self.path = Path(path)
+        # insertion-ordered: position in this dict == queue position - 1
+        self._entries: dict[tuple[int, int, int], dict] = {}
+        if self.path.exists():
+            for line in self.path.read_text().splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                except ValueError:
+                    continue
+                key = self._key(entry)
+                if key is not None and key not in self._entries:
+                    self._entries[key] = entry
+
+    @staticmethod
+    def _key(entry: dict) -> tuple[int, int, int] | None:
+        try:
+            return (int(entry["layer"]), int(entry["expert"]), int(entry["k"]))
+        except (KeyError, TypeError, ValueError):
+            return None
+
+    @classmethod
+    def from_env(
+        cls,
+        environ: dict[str, str] | None = None,
+        *,
+        cache_dir: str | Path | None = None,
+    ) -> "EncodeQueue":
+        environ = os.environ if environ is None else environ
+        path = environ.get(FQ_ENCODE_QUEUE_ENV)
+        if not path:
+            base = (
+                cache_dir
+                or environ.get("VLLM_FQ_CACHE")
+                or os.path.expanduser("~/.cache/vllm/fq")
+            )
+            path = Path(base) / DEFAULT_QUEUE_NAME
+        return cls(path)
+
+    def __len__(self) -> int:
+        return len(self._entries)
+
+    def entries(self) -> list[dict]:
+        return [dict(e) for e in self._entries.values()]
+
+    def position(self, layer: int, expert: int, k: int) -> int | None:
+        """1-based queue position of an entry, or None."""
+        key = (int(layer), int(expert), int(k))
+        for i, existing in enumerate(self._entries, 1):
+            if existing == key:
+                return i
+        return None
+
+    def enqueue(
+        self, layer: int, expert: int, k: int, reason: str
+    ) -> tuple[int, bool]:
+        """Append (dedup by key). Returns (1-based position, created)."""
+        key = (int(layer), int(expert), int(k))
+        if key in self._entries:
+            return self.position(*key) or len(self._entries), False
+        entry = {
+            "layer": key[0],
+            "expert": key[1],
+            "k": key[2],
+            "reason": str(reason),
+            "requested_utc": time.strftime(
+                "%Y-%m-%dT%H:%M:%SZ", time.gmtime()
+            ),
+        }
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with open(self.path, "a") as f:
+            f.write(json.dumps(entry, separators=(",", ":")) + "\n")
+        self._entries[key] = entry
+        return len(self._entries), True
+
+    def rewrite(self, remaining: list[dict]) -> None:
+        """Atomically replace the queue contents (drain bookkeeping)."""
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self.path.with_suffix(self.path.suffix + f".tmp{os.getpid()}")
+        tmp.write_text(
+            "".join(
+                json.dumps(e, separators=(",", ":")) + "\n" for e in remaining
+            )
+        )
+        os.replace(tmp, self.path)
+        self._entries = {
+            key: e
+            for e in remaining
+            if (key := self._key(e)) is not None
+        }
+
+
+# --------------------------------------------------------------- validation
+
+
+def _bf16_check(
+    bf16_dir: str | Path | None, layer: int, expert: int
+) -> tuple[bool, str]:
+    if not bf16_dir:
+        return False, f"bf16-dir unset (set {FQ_BF16_DIR_ENV})"
+    d = Path(bf16_dir)
+    if not d.is_dir():
+        return False, f"bf16-dir missing: {d}"
+    index_path = d / "model.safetensors.index.json"
+    if index_path.exists():
+        try:
+            weight_map = json.loads(index_path.read_text()).get(
+                "weight_map", {}
+            )
+        except ValueError:
+            return False, f"bf16 index unreadable: {index_path}"
+        missing = [
+            proj
+            for proj in _PROJS
+            if f"model.layers.{layer}.mlp.experts.{expert}.{proj}.weight"
+            not in weight_map
+        ]
+        if missing:
+            return False, f"bf16 index lacks L{layer}/e{expert} {missing}"
+        return True, "bf16=ok(index)"
+    if any(d.glob("*.safetensors")):
+        return True, "bf16=ok(dir)"
+    return False, f"bf16-dir has no safetensors: {d}"
+
+
+def _capture_check(
+    capture_dir: str | Path | None, layer: int
+) -> tuple[bool, str]:
+    if not capture_dir:
+        return False, f"capture-dir unset (set {FQ_CAPTURE_DIR_ENV})"
+    d = Path(capture_dir)
+    if not d.is_dir():
+        return False, f"capture-dir missing: {d}"
+    sub = d / f"layer_{layer:03d}"
+    if sub.is_dir() and any(sub.iterdir()):
+        return True, f"capture=ok({sub.name})"
+    return False, f"capture missing layer_{layer:03d}"
+
+
+def render_cmd(
+    template: str,
+    entry: dict,
+    bf16_dir: str | Path | None,
+    capture_dir: str | Path | None,
+) -> str:
+    return template.format(
+        layer=int(entry["layer"]),
+        layer03=f"{int(entry['layer']):03d}",
+        expert=int(entry["expert"]),
+        k=int(entry["k"]),
+        bf16_dir=bf16_dir or "",
+        capture_dir=capture_dir or "",
+    )
+
+
+# -------------------------------------------------------------------- drain
+
+
+def drain(
+    queue: EncodeQueue,
+    *,
+    dry_run: bool = True,
+    bf16_dir: str | Path | None = None,
+    capture_dir: str | Path | None = None,
+    encoder_cmd: str | None = None,
+    environ: dict[str, str] | None = None,
+    limit: int | None = None,
+    out: Callable[[str], None] = print,
+    runner: Callable[..., Any] = subprocess.run,
+) -> int:
+    """Process the queue. DRY-RUN validates entries + prints the command;
+    ``dry_run=False`` executes the encoder per entry and removes completed
+    entries.  Returns 0 when every processed entry validated/succeeded."""
+    environ = os.environ if environ is None else environ
+    bf16_dir = bf16_dir or environ.get(FQ_BF16_DIR_ENV)
+    capture_dir = capture_dir or environ.get(FQ_CAPTURE_DIR_ENV)
+    template = (
+        encoder_cmd or environ.get(FQ_ENCODER_CMD_ENV) or DEFAULT_ENCODER_CMD
+    )
+
+    entries = queue.entries()
+    if limit is not None:
+        entries = entries[: int(limit)]
+    if not entries:
+        out(f"encode queue empty: {queue.path}")
+        return 0
+
+    failed = 0
+    done: list[dict] = []
+    for i, entry in enumerate(entries, 1):
+        tag = (
+            f"#{i} L{entry['layer']}/e{entry['expert']} K{entry['k']} "
+            f"reason={entry.get('reason', '?')}"
+        )
+        ok_bf16, msg_bf16 = _bf16_check(
+            bf16_dir, int(entry["layer"]), int(entry["expert"])
+        )
+        ok_cap, msg_cap = _capture_check(capture_dir, int(entry["layer"]))
+        cmd = render_cmd(template, entry, bf16_dir, capture_dir)
+        if not (ok_bf16 and ok_cap):
+            failed += 1
+            out(f"{tag} BLOCKED {msg_bf16}; {msg_cap}")
+            continue
+        if dry_run:
+            out(f"{tag} DRY-RUN OK {msg_bf16} {msg_cap} cmd: {cmd}")
+            continue
+        out(f"{tag} ENCODE {cmd}")
+        result = runner(shlex.split(cmd))
+        rc = getattr(result, "returncode", result)
+        if rc == 0:
+            done.append(entry)
+            out(f"{tag} DONE")
+        else:
+            failed += 1
+            out(f"{tag} FAILED rc={rc}")
+
+    if done:
+        keep = [e for e in queue.entries() if e not in done]
+        queue.rewrite(keep)
+        out(f"queue: {len(done)} encoded, {len(keep)} remaining")
+    return 1 if failed else 0
+
+
+# ---------------------------------------------------------------------- CLI
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(
+        description="Progressive Tensors lazy-encode queue worker"
+    )
+    p.add_argument(
+        "--drain", action="store_true", help="process the queue (default: list)"
+    )
+    p.add_argument(
+        "--execute",
+        action="store_true",
+        help="really run the encoder (default: DRY-RUN validation only)",
+    )
+    p.add_argument("--queue", default=None, help=f"path ({FQ_ENCODE_QUEUE_ENV})")
+    p.add_argument("--bf16-dir", default=None, help=f"({FQ_BF16_DIR_ENV})")
+    p.add_argument("--capture-dir", default=None, help=f"({FQ_CAPTURE_DIR_ENV})")
+    p.add_argument(
+        "--encoder-cmd", default=None, help=f"template ({FQ_ENCODER_CMD_ENV})"
+    )
+    p.add_argument("--limit", type=int, default=None)
+    args = p.parse_args(argv)
+
+    queue = (
+        EncodeQueue(args.queue) if args.queue else EncodeQueue.from_env()
+    )
+    if not args.drain:
+        print(f"encode queue {queue.path}: {len(queue)} entries")
+        for i, entry in enumerate(queue.entries(), 1):
+            print(
+                f"#{i} L{entry['layer']}/e{entry['expert']} K{entry['k']} "
+                f"reason={entry.get('reason', '?')} "
+                f"requested={entry.get('requested_utc', '?')}"
+            )
+        return 0
+    return drain(
+        queue,
+        dry_run=not args.execute,
+        bf16_dir=args.bf16_dir,
+        capture_dir=args.capture_dir,
+        encoder_cmd=args.encoder_cmd,
+        limit=args.limit,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/vllm/model_executor/layers/quantization/exl3_fungible/loop.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/loop.py
@@ -728,9 +728,26 @@ class FungibleQuantState:
 
     @staticmethod
     def _jaccard(a: np.ndarray, b: np.ndarray) -> float:
+        """Mean per-layer Jaccard over layers that HAVE a desired set.
+
+        A layer whose n_k4 is 0 has an empty desired set in both snapshots.
+        The old code clamped the union to 1, scoring that layer 0.0 and
+        averaging it in — so 27 of GLM-5.2's 75 layers, which cannot hold a
+        K4 expert at all and therefore cannot churn, dragged the mean from
+        0.879 down to 0.562 against a 0.950 floor. The guard was measuring
+        the stability of sets that do not exist, and blocked every swap for
+        it.
+
+        Empty-vs-empty is not "maximally unstable"; it is no evidence. Skip
+        those rows and average the rest. If NO layer has a desired set there
+        is nothing to guard, so report perfect agreement rather than zero.
+        """
         inter = (a & b).sum(axis=1).astype(np.float64)
-        union = np.maximum((a | b).sum(axis=1), 1).astype(np.float64)
-        return float((inter / union).mean())
+        union = (a | b).sum(axis=1).astype(np.float64)
+        live = union > 0
+        if not live.any():
+            return 1.0
+        return float((inter[live] / union[live]).mean())
 
     @staticmethod
     def decision_sha(swaps: list[tuple[int, int, int]]) -> str:

--- a/vllm/model_executor/layers/quantization/exl3_fungible/loop.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/loop.py
@@ -78,6 +78,7 @@ FQ_MAX_SWAPS_TOTAL_ENV = "VLLM_FQ_MAX_SWAPS_TOTAL"
 FQ_DWELL_ENV = "VLLM_FQ_DWELL_STEPS"
 FQ_HYSTERESIS_ENV = "VLLM_FQ_HYSTERESIS"
 FQ_JACCARD_FLOOR_ENV = "VLLM_FQ_JACCARD_FLOOR"
+FQ_DUMP_STATS_ENV = "VLLM_FQ_DUMP_STATS"
 
 APPLY_DRYRUN, APPLY_RELOAD, APPLY_ATOMIC = "dryrun", "reload", "atomic"
 
@@ -302,6 +303,11 @@ class FungibleQuantState:
         self._last_composition: dict | None = None
         self._table_every = int(
             os.environ.get('VLLM_FQ_TABLE_EVERY_INTERVALS', '10'))
+        # Per-expert routing mass/count dump. The decision record keeps
+        # only the swaps it chose; reconstructing WHICH experts the
+        # traffic actually favoured -- e.g. to compare our selection
+        # against a human-built mixed quant -- needs the raw ranking.
+        self._dump_stats_path = os.environ.get(FQ_DUMP_STATS_ENV)
         self._collector_layer_map = self._map_collector_layers()
 
         self.tier_of = np.asarray(
@@ -460,6 +466,8 @@ class FungibleQuantState:
                 title=f'expert composition @ interval {self._intervals_run}',
                 diff_only=True)
         stats = self._read_stats()
+        if self._dump_stats_path and self.rank in (0, None):
+            self._dump_stats(stats)
         dwell = self._real_steps - self._entered_step
 
         swaps = P.decide(stats, self.eps, self.tier_of, pins=self.pins,
@@ -578,6 +586,28 @@ class FungibleQuantState:
             self.store._atomic_write(
                 self.store.root / "history"
                 / f"{self._step:08d}-proposed.json", proposed_doc)
+
+    def _dump_stats(self, stats: dict) -> None:
+        """Append one JSON line of per-expert routing signal.
+
+        Rank 0 only and best-effort: this is analysis telemetry, and a
+        full disk must not take down inference.
+        """
+        try:
+            rec = {
+                "step": int(self._step),
+                "interval": int(self._intervals_run),
+                "layers": [int(x) for x in self.layers],
+                "tier_of": self.tier_of.tolist(),
+            }
+            for key in ("count", "mass"):
+                arr = stats.get(key)
+                if arr is not None:
+                    rec[key] = np.asarray(arr).tolist()
+            with open(self._dump_stats_path, 'a') as fh:
+                fh.write(json.dumps(rec) + '\n')
+        except Exception:  # noqa: BLE001
+            logger.exception("FQ stats dump failed (continuing)")
 
     def _export_occupancy(self) -> None:
         for row, layer in enumerate(self.layers):

--- a/vllm/model_executor/layers/quantization/exl3_fungible/loop.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/loop.py
@@ -31,9 +31,22 @@ Determinism: ``policy.decide`` is a pure function of its inputs; each
 rank logs a T6-style ``decision sha`` over the swap list so cross-rank
 agreement is auditable from the serve log alone.
 
+Memory budget (``VLLM_FQ_MEMORY_BUDGET``): the fixed-cardinality budget
+is only a PROXY for memory. A byte ceiling — absolute, a fraction of
+device memory, or the equivalent experts/bpw per layer — is resolved at
+init, enforced as Guard 5 when proposing, and reported as headroom on
+``fq_memory_budget_bytes`` / ``fq_memory_used_bytes`` /
+``fq_promotions_headroom`` plus the composition table. Every byte figure
+is computed from the ACTUAL tier occupancy using per-expert sizes read
+off the loaded checkpoint's tensor shapes; see ``policy.ExpertBytes``.
+
 Hot-path contract (PERFORMANCE.md): ``step()`` between intervals is a
 few integer ops on top of ``collector.step()``; all tensor reads, numpy
 work, file IO and metric updates happen only on interval boundaries.
+The budget adds nothing between intervals: the byte model is built once
+at init (one safetensors HEADER read, no payload), and per-interval
+accounting is one reduction over the [L,E] tier array plus integer
+arithmetic per candidate.
 """
 from __future__ import annotations
 
@@ -41,6 +54,8 @@ import hashlib
 import json
 import logging
 import os
+import re
+import struct
 from pathlib import Path
 from typing import Any, Callable
 
@@ -79,6 +94,16 @@ FQ_DWELL_ENV = "VLLM_FQ_DWELL_STEPS"
 FQ_HYSTERESIS_ENV = "VLLM_FQ_HYSTERESIS"
 FQ_JACCARD_FLOOR_ENV = "VLLM_FQ_JACCARD_FLOOR"
 FQ_DUMP_STATS_ENV = "VLLM_FQ_DUMP_STATS"
+# Ceiling on the per-device expert pool. Accepts an absolute size
+# ("78g", "80000000000"), a fraction of device memory ("0.80", "80%")
+# mirroring --gpu-memory-utilization, or the cardinality spellings of the
+# same ceiling ("24/layer", "3.5bpw") — all resolved to bytes.
+# Unset -> no byte ceiling; the fixed-cardinality budget alone applies.
+FQ_MEMORY_BUDGET_ENV = "VLLM_FQ_MEMORY_BUDGET"
+# Operator override for the per-expert byte model, as measured K points:
+# "k3=3542028,k4=4721676" (per rank). Only needed when the checkpoint's
+# real geometry cannot be read at boot.
+FQ_EXPERT_BYTES_ENV = "VLLM_FQ_EXPERT_BYTES"
 
 APPLY_DRYRUN, APPLY_RELOAD, APPLY_ATOMIC = "dryrun", "reload", "atomic"
 
@@ -100,6 +125,8 @@ class FqLoopConfig:
         policy_path: str | None = None,
         eps_root: str | None = None,
         cache_root: str | None = None,
+        memory_budget: str | int | float | None = None,
+        expert_bytes: str | None = None,
     ) -> None:
         if apply_mode not in (APPLY_DRYRUN, APPLY_RELOAD, APPLY_ATOMIC):
             raise ValueError(f"unknown {FQ_APPLY_MODE_ENV}: {apply_mode!r}")
@@ -116,6 +143,10 @@ class FqLoopConfig:
         self.policy_path = policy_path
         self.eps_root = eps_root
         self.cache_root = cache_root or os.path.expanduser("~/.cache/vllm")
+        # Kept as the raw spec: resolving a fraction needs the device,
+        # which is not knowable at config-parse time.
+        self.memory_budget = memory_budget
+        self.expert_bytes = expert_bytes
 
     @classmethod
     def from_env(cls) -> "FqLoopConfig":
@@ -138,6 +169,8 @@ class FqLoopConfig:
         kwargs["policy_path"] = env(FQ_POLICY_ENV)
         kwargs["eps_root"] = env(FQ_EPS_ROOT_ENV)
         kwargs["cache_root"] = env(FQ_CACHE_ROOT_ENV)
+        kwargs["memory_budget"] = env(FQ_MEMORY_BUDGET_ENV)
+        kwargs["expert_bytes"] = env(FQ_EXPERT_BYTES_ENV)
         return cls(**kwargs)
 
 
@@ -195,6 +228,145 @@ def uniform_eps_stub(num_layers: int, num_experts: int) -> dict[int, np.ndarray]
     }
 
 
+# ------------------------------------------------------------ memory budget
+# The byte budget is only as honest as the per-expert byte figures it is
+# computed from, so this section is written to prefer REAL geometry from
+# the loaded checkpoint over any constant, and to state which one it got.
+
+_EXPERT_TENSOR_RE = re.compile(
+    r"^model\.layers\.(\d+)\.mlp\.experts\.(\d+)\.(\w+_proj)\.rank(\d+)\.(\w+)$")
+
+
+def device_total_bytes() -> int | None:
+    """Total bytes of the current CUDA device, or None off-GPU.
+
+    Monkeypatch seam for CPU tests; a fractional ``VLLM_FQ_MEMORY_BUDGET``
+    resolves against this.
+    """
+    try:
+        import torch
+
+        if not torch.cuda.is_available():
+            return None
+        return int(torch.cuda.mem_get_info()[1])
+    except Exception:  # noqa: BLE001 — telemetry-grade probe, never fatal
+        logger.debug("FQ budget: device memory unreadable", exc_info=True)
+        return None
+
+
+def _read_safetensors_header(path: Path) -> dict:
+    """Header dict of a safetensors file (8-byte length prefix + JSON).
+
+    Inlined rather than imported from ``fragments`` to keep this module's
+    import graph unchanged; it is 4 lines and the format is frozen.
+    """
+    with open(path, "rb") as f:
+        (hlen,) = struct.unpack("<Q", f.read(8))
+        return json.loads(f.read(hlen))
+
+
+def expert_bytes_from_checkpoint(artifact_dir: str | Path
+                                 ) -> "P.ExpertBytes | None":
+    """Derive the per-expert byte model from the checkpoint's REAL shapes.
+
+    Reads one assembled layer's safetensors header (header only — no
+    payload, no allocation) and takes the tensor table of a single
+    (expert, rank). Byte counts come from each tensor's own
+    ``data_offsets``, so they are the true spans, and the bitrate is read
+    off the trellis last dim (``16 * K``). Returns None when the artifact
+    dir has no readable layer file — the caller then has to say out loud
+    that it is falling back to a reference constant.
+    """
+    root = Path(artifact_dir)
+    for path in sorted(root.glob("model-layer-*.safetensors"))[:4]:
+        try:
+            header = _read_safetensors_header(path)
+        except Exception:  # noqa: BLE001
+            logger.debug("FQ budget: unreadable header %s", path, exc_info=True)
+            continue
+        best: tuple[int, int] | None = None
+        ranks: set[int] = set()
+        for name in header:
+            m = _EXPERT_TENSOR_RE.match(name)
+            if m is None:
+                continue
+            expert, rank = int(m.group(2)), int(m.group(4))
+            ranks.add(rank)
+            if best is None or (expert, rank) < best:
+                best = (expert, rank)
+        if best is None:
+            continue
+        expert, rank = best
+        entries = []
+        for name, t in header.items():
+            m = _EXPERT_TENSOR_RE.match(name)
+            if m is None or int(m.group(2)) != expert or int(m.group(4)) != rank:
+                continue
+            lo, hi = t["data_offsets"]
+            entries.append((name, int(hi) - int(lo), tuple(t["shape"])))
+        try:
+            return P.ExpertBytes.from_tensor_table(
+                entries,
+                provenance=f"derived from loaded tensor shapes: {path.name} "
+                           f"expert {expert} rank {rank} of "
+                           f"{len(ranks)} rank(s)")
+        except ValueError:
+            logger.warning("FQ budget: %s expert %d rank %d does not fit the "
+                           "affine trellis byte model", path.name, expert,
+                           rank, exc_info=True)
+            return None
+    return None
+
+
+def parse_expert_bytes_spec(spec: str) -> "P.ExpertBytes":
+    """``"k3=3542028,k4=4721676"`` -> an operator-declared byte model."""
+    points: dict[int, int] = {}
+    for part in str(spec).replace(";", ",").split(","):
+        part = part.strip()
+        if not part:
+            continue
+        key, sep, val = part.partition("=")
+        key = key.strip().lower().lstrip("k")
+        if not sep or not key.isdigit():
+            raise ValueError(
+                f"unparseable {FQ_EXPERT_BYTES_ENV} entry {part!r}: want "
+                f"'k3=3542028,k4=4721676' (bytes per expert per rank)")
+        points[int(key)] = int(val.strip())
+    return P.ExpertBytes.from_measurements(
+        points, provenance=f"operator-declared {FQ_EXPERT_BYTES_ENV}={spec}")
+
+
+def resolve_expert_bytes(*, spec: str | None = None,
+                         artifact_dir: str | None = None,
+                         enforcing: bool = True) -> "P.ExpertBytes":
+    """Per-expert byte model, most trustworthy source first.
+
+    1. an explicit operator declaration (``VLLM_FQ_EXPERT_BYTES``),
+    2. the loaded checkpoint's own tensor shapes,
+    3. the built-in GLM-5.2/TP4 reference measurement — flagged
+       ``is_reference`` and said out loud, because it describes a
+       different checkpoint and may not match this one.
+
+    ``enforcing`` is True when a byte ceiling is actually gating
+    decisions; the fallback is then a WARNING rather than an INFO,
+    because a wrong constant would be silently deciding what stays
+    resident.
+    """
+    if spec:
+        return parse_expert_bytes_spec(spec)
+    if artifact_dir:
+        eb = expert_bytes_from_checkpoint(artifact_dir)
+        if eb is not None:
+            return eb
+    eb = P.reference_expert_bytes()
+    (logger.warning if enforcing else logger.info)(
+        "FQ budget: could not read per-expert byte sizes from the loaded "
+        "checkpoint (%s unset/unreadable) — falling back to the %s. Set %s "
+        "(e.g. k3=3542028,k4=4721676) if this checkpoint's geometry differs.",
+        FQ_ARTIFACT_DIR_ENV, eb.provenance, FQ_EXPERT_BYTES_ENV)
+    return eb
+
+
 # ------------------------------------------------------------------ metrics
 class FqMetrics:
     """03-testing-validation §Instrumentation, prometheus_client-native
@@ -230,6 +402,25 @@ class FqMetrics:
             "fq_tier_occupancy",
             "Experts resident per (layer, K tier) under the running policy.",
             ["layer", "tier"], multiprocess_mode="mostrecent", **kw)
+        self.memory_budget_bytes = pc.Gauge(
+            "fq_memory_budget_bytes",
+            "Configured per-device byte ceiling for the fungible-quant "
+            "expert pool (VLLM_FQ_MEMORY_BUDGET). 0 means no byte budget "
+            "is configured and only the fixed-cardinality budget applies.",
+            multiprocess_mode="mostrecent", **kw)
+        self.memory_used_bytes = pc.Gauge(
+            "fq_memory_used_bytes",
+            "Per-device bytes the CURRENT expert tier occupancy actually "
+            "costs, computed from the live layer x K matrix and the "
+            "per-expert byte model (see fq_memory_budget_bytes).",
+            multiprocess_mode="mostrecent", **kw)
+        self.promotions_headroom = pc.Gauge(
+            "fq_promotions_headroom",
+            "How many further K3->K4 expert promotions fit under the byte "
+            "ceiling at the current occupancy. Negative means the pool is "
+            "already over budget; -1 with fq_memory_budget_bytes == 0 "
+            "means unbounded (no byte budget configured).",
+            multiprocess_mode="mostrecent", **kw)
         # Materialize the counters at 0 so they are scrapeable before the
         # first increment (multiprocess files are created on first touch).
         self.rollbacks_total.inc(0)
@@ -283,6 +474,7 @@ class FungibleQuantState:
         rank: int = 0,
         is_lead: bool = True,
         apply_fn: Callable[[dict, list], bool] | None = None,
+        budget: "P.MemoryBudget | None" = None,
     ) -> None:
         self.collector = collector
         self.cfg = config or FqLoopConfig.from_env()
@@ -315,6 +507,8 @@ class FungibleQuantState:
              for layer in self.layers], dtype=np.int64)
         self.n_k4 = P.n_k4_of(self.tier_of)
         self.pins = self._pins_from_doc(policy_doc)
+        self.budget = budget if budget is not None else self._resolve_budget()
+        self._log_budget()
 
         # Step machinery. ``_step`` counts every engine step including
         # dummy ones (collector._step semantics: rank lockstep); dwell is
@@ -339,6 +533,7 @@ class FungibleQuantState:
             for layer in self.layers:
                 self.metrics.swaps_total.labels(layer=str(layer)).inc(0)
             self._export_occupancy()
+            self._export_budget()
 
         # The composition the checkpoint actually booted with. Printed in
         # full (not diff-only): there is nothing to diff against yet, and an
@@ -384,6 +579,48 @@ class FungibleQuantState:
             for e in experts:
                 pins[row, e] = self.tier_of[row, e]
         return pins
+
+    def _resolve_budget(self) -> P.MemoryBudget:
+        """Build the memory budget from env + the checkpoint's geometry.
+
+        A malformed ``VLLM_FQ_MEMORY_BUDGET`` is allowed to propagate: the
+        integration seam catches loop-init failures and degrades to a
+        collector-only serve, which performs no swaps and therefore
+        cannot grow past a ceiling. Failing OPEN on a memory budget — by
+        quietly dropping it — would be the unsafe choice.
+        """
+        expert_bytes = resolve_expert_bytes(
+            spec=self.cfg.expert_bytes, artifact_dir=self.cfg.artifact_dir,
+            enforcing=bool(self.cfg.memory_budget))
+        return P.MemoryBudget.from_spec(
+            self.cfg.memory_budget, expert_bytes,
+            num_layers=len(self.layers), num_experts=self.num_experts,
+            device_total_bytes=device_total_bytes())
+
+    def _log_budget(self) -> None:
+        summary = self.budget.summary(self.tier_of)
+        if self.budget.limit_bytes is None:
+            logger.info(
+                "FQ memory budget: none (%s unset) — fixed cardinality only; "
+                "current pool %d B/rank; %s", FQ_MEMORY_BUDGET_ENV,
+                summary["used_bytes"], self.budget.expert_bytes.describe())
+            return
+        n_high = self.budget.n_high_per_layer(len(self.layers),
+                                              self.num_experts)
+        logger.info(
+            "FQ memory budget: %d B/rank (%s) | used %d B | headroom %d B = "
+            "%s more K3->K4 promotions | equivalent fixed cardinality "
+            "<= %s K4/layer over %d layers | %s",
+            self.budget.limit_bytes, self.cfg.memory_budget,
+            summary["used_bytes"], summary["headroom_bytes"],
+            summary["headroom_promotions"], n_high, len(self.layers),
+            self.budget.expert_bytes.describe())
+        if summary["headroom_bytes"] is not None and summary["headroom_bytes"] < 0:
+            logger.error(
+                "FQ memory budget: the BOOT policy is already %d B over the "
+                "%d B ceiling — no promotion will be admitted until the "
+                "occupancy comes down", -summary["headroom_bytes"],
+                self.budget.limit_bytes)
 
     def _resolve_eps(self) -> dict[int, np.ndarray]:
         if self.cfg.eps_root:
@@ -492,7 +729,29 @@ class FungibleQuantState:
                 self.cfg.jaccard_floor, len(swaps))
             swaps = []
 
-        proposed_tier = P.apply_swaps(self.tier_of, swaps)
+        # Guard 5 — the byte ceiling. A 1-for-1 K3<->K4 trade is
+        # byte-neutral so this normally passes everything through; when
+        # the ceiling leaves room, the surplus is spent on unpaired
+        # promotions, which is the thing fixed cardinality cannot express.
+        promotions: list[tuple[int, int]] = []
+        rejections: list[dict] = []
+        if self.budget.limit_bytes is not None:
+            swaps, rejections = P.budget_filter(swaps, self.tier_of,
+                                                self.budget)
+            if not jaccard_held:
+                promotions, prej = P.plan_promotions(
+                    stats, self.eps, P.apply_swaps(self.tier_of, swaps),
+                    self.budget, pins=self.pins, dwell=dwell,
+                    cfg=self._decide_cfg(),
+                    exclude=[(l, e_in) for l, _, e_in in swaps])
+                rejections = rejections + prej
+            for rej in rejections:
+                logger.warning("FQ budget step=%d: %s", self._step,
+                               P.rejection_message(rej))
+
+        proposed_tier = P.apply_promotions(
+            P.apply_swaps(self.tier_of, swaps), promotions,
+            self.budget.high_k)
         proposed_doc = self._doc_for(proposed_tier, swaps)
         proposed_sha = policy_hash(proposed_doc)
 
@@ -500,9 +759,23 @@ class FungibleQuantState:
             stats, self.eps, self.tier_of, swaps, pins=self.pins,
             dwell=dwell, cfg=self._decide_cfg(), step=self._step,
             policy_sha_before=self.policy_sha,
-            policy_sha_after=proposed_sha if swaps else self.policy_sha)
+            policy_sha_after=(proposed_sha if (swaps or promotions)
+                              else self.policy_sha))
         record["apply_mode"] = self.cfg.apply_mode
         record["applied"] = False
+        # Budget state travels WITH the decision: a reviewer reading the
+        # persisted JSON must be able to see the ceiling, what the pool
+        # actually costs, what was refused, and by how much.
+        record["budget"] = self.budget.summary(self.tier_of)
+        record["budget"]["proposed_bytes"] = self.budget.used_bytes(
+            proposed_tier)
+        record["budget"]["rejections"] = rejections
+        record["promotions"] = [{"layer": int(self.layers[l]),
+                                 "layer_row": int(l), "expert": int(e),
+                                 "to_k": int(self.budget.high_k)}
+                                for l, e in promotions]
+        record["totals"]["promotions"] = len(promotions)
+        record["totals"]["budget_rejections"] = len(rejections)
         # decide()/explain() speak in row indices; record the row->model
         # layer id mapping so the persisted JSON is self-describing.
         record["layer_ids"] = [int(x) for x in self.layers]
@@ -513,16 +786,21 @@ class FungibleQuantState:
 
         DL.log_decision(record)
         logger.info(
-            "FQ decide rank=%d step=%d interval=%d swaps=%d sha=%s",
+            "FQ decide rank=%d step=%d interval=%d swaps=%d promotions=%d "
+            "budget_rejections=%d used=%d B headroom=%s sha=%s",
             self.rank, self._step, self._intervals_run, len(swaps),
+            len(promotions), len(rejections),
+            record["budget"]["used_bytes"],
+            record["budget"]["headroom_promotions"],
             record["decision_sha"][:16])
 
-        applied = self._maybe_apply(proposed_doc, proposed_tier, swaps)
+        applied = self._maybe_apply(proposed_doc, proposed_tier,
+                                    swaps, promotions)
         record["applied"] = applied
         record["apply_failures"] = int(self.apply_failures)
 
         if self.is_lead:
-            self._persist(record, proposed_doc, swaps)
+            self._persist(record, proposed_doc, swaps or promotions)
             self._export_metrics(record, swaps, jac)
         return record
 
@@ -530,10 +808,28 @@ class FungibleQuantState:
 
     def _doc_for(self, tier: np.ndarray, swaps: list) -> dict:
         doc = {k: v for k, v in self.policy_doc.items()
-               if k not in ("bits_per_expert", "provenance")}
+               if k not in ("bits_per_expert", "provenance", "budget")}
         doc["bits_per_expert"] = {
             str(layer): [int(b) for b in tier[row]]
             for row, layer in enumerate(self.layers)}
+        # The declared cardinality is RECOMPUTED from the proposed tiers,
+        # not copied: promotions change occupancy, and store.validate_policy
+        # enforces cap == n. The byte ceiling rides along so a persisted
+        # proposal records the budget it was decided under.
+        budget = dict(self.policy_doc.get("budget") or {})
+        budget["n_k4_per_layer"] = {
+            str(layer): int((tier[row] == P.K4).sum())
+            for row, layer in enumerate(self.layers)}
+        if self.budget.limit_bytes is not None:
+            budget["mode"] = "max_bytes"
+            budget["max_bytes_per_rank"] = int(self.budget.limit_bytes)
+            budget["bytes_per_expert_per_rank"] = {
+                str(k): int(v)
+                for k, v in self.budget.expert_bytes.table().items()}
+            budget["bytes_source"] = self.budget.expert_bytes.provenance
+        else:
+            budget.setdefault("mode", "fixed_cardinality")
+        doc["budget"] = budget
         doc["provenance"] = {
             "proposed_by": f"fq-loop/{self.cfg.apply_mode}",
             "step": int(self._step),
@@ -543,7 +839,7 @@ class FungibleQuantState:
         return doc
 
     def _maybe_apply(self, proposed_doc: dict, proposed_tier: np.ndarray,
-                     swaps: list) -> bool:
+                     swaps: list, promotions: list | None = None) -> bool:
         """dryrun: never. reload/atomic: only through a bound apply_fn
         (M3's fq_reload path / M4's swap engine); record-only otherwise.
 
@@ -556,7 +852,8 @@ class FungibleQuantState:
         decision, and the next interval retries. Staging is host-only and
         happens before the swap engine's quiesce window, so a supply
         failure cannot have left a layer half-updated."""
-        if self.cfg.apply_mode == APPLY_DRYRUN or not swaps:
+        promotions = promotions or []
+        if self.cfg.apply_mode == APPLY_DRYRUN or not (swaps or promotions):
             return False
         if self.apply_fn is None:
             if self.cfg.apply_mode == APPLY_ATOMIC and not self._atomic_warned:
@@ -589,6 +886,10 @@ class FungibleQuantState:
             self.policy_doc = proposed_doc
             self.policy_sha = policy_hash(proposed_doc)
             self._policy_step = self._step
+            # Promotions change the running cardinality; decide() refuses
+            # a membership that disagrees with cfg["n_k4"], so the budget
+            # must follow the occupancy it actually applied.
+            self.n_k4 = P.n_k4_of(self.tier_of)
             if self.store is not None and self.is_lead:
                 self.store.commit(proposed_doc, num_experts=self.num_experts)
         return ok
@@ -648,6 +949,19 @@ class FungibleQuantState:
                     layer=str(layer), tier=f"k{tier}").set(
                         int((self.tier_of[row] == tier).sum()))
 
+    def _export_budget(self) -> None:
+        """fq_memory_budget_bytes / fq_memory_used_bytes /
+        fq_promotions_headroom, from the ACTUAL live occupancy."""
+        summary = self.budget.summary(self.tier_of)
+        self.metrics.memory_budget_bytes.set(
+            0 if summary["limit_bytes"] is None else summary["limit_bytes"])
+        self.metrics.memory_used_bytes.set(summary["used_bytes"])
+        # -1 is the documented "unbounded" sentinel; a real over-budget
+        # pool reports its own (negative) promotion count instead.
+        self.metrics.promotions_headroom.set(
+            -1 if summary["headroom_promotions"] is None
+            else summary["headroom_promotions"])
+
     def _occupancy_map(self) -> dict[int, dict[int, int]]:
         """``{layer: {k: expert_count}}`` for the operator-facing table."""
         out: dict[int, dict[int, int]] = {}
@@ -674,7 +988,8 @@ class FungibleQuantState:
         try:
             text = OT.render(cur, self._last_composition, title=title,
                              num_experts=int(self.num_experts),
-                             diff_only=diff_only)
+                             diff_only=diff_only,
+                             budget=self.budget.summary(self.tier_of))
         except Exception:  # noqa: BLE001 - telemetry must never kill a serve
             logger.exception("FQ composition table failed to render")
             return
@@ -693,6 +1008,7 @@ class FungibleQuantState:
             self.metrics.jaccard.set(jac)
         self.metrics.policy_age_steps.set(self._step - self._policy_step)
         self._export_occupancy()
+        self._export_budget()
 
 
 # ------------------------------------------------------------------ boot glue
@@ -770,8 +1086,9 @@ def build_from_env(
         rank=rank, is_lead=is_lead)
     logger.info(
         "FQ loop: armed — mode=%s interval=%d dwell=%d hysteresis=%.2f "
-        "caps=(%d/layer, %d total) layers=%s policy=%s",
+        "caps=(%d/layer, %d total) memory_budget=%s layers=%s policy=%s",
         cfg.apply_mode, cfg.interval_steps, cfg.dwell_steps, cfg.hysteresis,
-        cfg.max_swaps_per_layer, cfg.max_swaps_total, state.layers,
-        state.policy_sha[:16])
+        cfg.max_swaps_per_layer, cfg.max_swaps_total,
+        state.budget.limit_bytes if state.budget.limit_bytes is not None
+        else "none", state.layers, state.policy_sha[:16])
     return state

--- a/vllm/model_executor/layers/quantization/exl3_fungible/loop.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/loop.py
@@ -616,6 +616,12 @@ class FungibleQuantState:
 
         Rank 0 only and best-effort: this is analysis telemetry, and a
         full disk must not take down inference.
+
+        ``mass_is_real`` says whether "mass" is REAL gate mass or just a
+        copy of "count" (the collector aliases it when gate-weight
+        capture is off). Without it the alias is only detectable by the
+        arrays happening to be identical — which a uniform router would
+        also produce.
         """
         try:
             rec = {
@@ -623,6 +629,8 @@ class FungibleQuantState:
                 "interval": int(self._intervals_run),
                 "layers": [int(x) for x in self.layers],
                 "tier_of": self.tier_of.tolist(),
+                "mass_is_real": bool(getattr(
+                    self.collector, "mass_is_real", lambda: False)()),
             }
             for key in ("count", "mass"):
                 arr = stats.get(key)

--- a/vllm/model_executor/layers/quantization/exl3_fungible/loop.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/loop.py
@@ -488,7 +488,26 @@ class FungibleQuantState:
         self.policy_doc = policy_doc
         self.policy_sha = policy_hash(policy_doc)
         # Policy layer rows: sorted numeric layer ids from the document.
-        self.layers = sorted(int(k) for k in policy_doc["bits_per_expert"])
+        # A policy legitimately covers layers the collector does not
+        # instrument. GLM-5.2's layer 78 is the MTP layer: the EXL3 loader
+        # REQUIRES a bitrate entry for it ("rank-sliced EXL3 bitrate map is
+        # missing layer 78") because it is a real MoE layer in the
+        # checkpoint, but it is not bound as a main-model MoERunner so the
+        # collector never sees it. Refusing to start on that mismatch made
+        # the two requirements unsatisfiable at once. Restrict the DECISION
+        # domain to instrumented layers and say so; the loader keeps its
+        # full map.
+        _policy_layers = sorted(int(k) for k in policy_doc["bits_per_expert"])
+        _bound = set(collector.count_buf)
+        if _bound and not _bound.issuperset(_policy_layers):
+            _skip = [x for x in _policy_layers if x not in _bound]
+            if _skip and len(_skip) < len(_policy_layers):
+                logger.warning(
+                    "FQ loop: %d policy layer(s) are not instrumented by the "
+                    "collector and are excluded from decisions: %s",
+                    len(_skip), _skip)
+                _policy_layers = [x for x in _policy_layers if x in _bound]
+        self.layers = _policy_layers
         self.num_experts = collector.num_experts
         # Operator-facing composition table: remembered so each print
         # can show what moved since the last one.

--- a/vllm/model_executor/layers/quantization/exl3_fungible/loop.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/loop.py
@@ -416,6 +416,24 @@ class FqMetrics:
             "fq_policy_age_steps",
             "Engine steps since the running policy was committed.",
             multiprocess_mode="mostrecent", **kw)
+        # Staging and quiesce cost. These three decide how fast the loop can
+        # converge and how much serving it disturbs, and all three were
+        # computed but never surfaced: staging turned out to be the binding
+        # constraint (IO-bound, ~10.5 MB/s of small ranged reads) and that was
+        # only discovered by differencing log timestamps.
+        self.stage_seconds = pc.Gauge(
+            "fq_stage_seconds",
+            "Wall time to stage the last swap batch (fragment IO, off-step).",
+            multiprocess_mode="mostrecent", **kw)
+        self.stage_bytes = pc.Gauge(
+            "fq_stage_bytes",
+            "Host-to-device bytes in the last staged swap batch.",
+            multiprocess_mode="mostrecent", **kw)
+        self.apply_window_seconds = pc.Gauge(
+            "fq_apply_window_seconds",
+            "Quiesce window of the last committed apply — the only interval "
+            "in which serving is actually disturbed.",
+            multiprocess_mode="mostrecent", **kw)
         self.tier_occupancy = pc.Gauge(
             "fq_tier_occupancy",
             "Experts resident per (layer, K tier) under the running policy.",

--- a/vllm/model_executor/layers/quantization/exl3_fungible/loop.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/loop.py
@@ -982,8 +982,14 @@ class FungibleQuantState:
         if self.apply_fn is None:
             if self.cfg.apply_mode == APPLY_ATOMIC and not self._atomic_warned:
                 logger.warning(
-                    "FQ apply_mode=atomic without a bound apply_fn — "
-                    "recording proposals only (M4 live wiring pending)")
+                    "FQ apply_mode=atomic with no apply backend bound — "
+                    "recording proposals only. This is the DEFAULT since "
+                    "inline apply deadlocked a TP serve (stage() does "
+                    "synchronous fragment IO inside the step, per-rank, so "
+                    "the ranks desynchronise and the shm broadcast starves). "
+                    "The swap engine itself is proven; what is missing is "
+                    "out-of-step coordination. VLLM_FQ_LIVE_APPLY=1 binds it "
+                    "anyway for experiments.")
                 self._atomic_warned = True
             elif self.cfg.apply_mode == APPLY_RELOAD:
                 logger.warning(

--- a/vllm/model_executor/layers/quantization/exl3_fungible/loop.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/loop.py
@@ -1016,7 +1016,16 @@ class FungibleQuantState:
                     "proposal JSON")
             return False
         try:
-            ok = bool(self.apply_fn(proposed_doc, swaps))
+            # apply_fn may return the swaps it ACTUALLY installed instead of
+            # a bare bool. That matters: an asynchronous backend can install a
+            # batch staged an interval earlier, which is NOT the same set as
+            # `swaps`. Trusting `proposed_tier` in that case makes tier_of
+            # describe a device state that never existed, and the very next
+            # interval proposes a move off an expert that is not there:
+            #   ValueError: invalid swap (5, 82, 3): e_out must be resident K4
+            result = self.apply_fn(proposed_doc, swaps)
+            ok = bool(result)
+            installed = result if isinstance(result, (list, tuple)) else None
         except Exception:  # noqa: BLE001 — a supply failure is not a crash
             self.apply_failures += 1
             logger.exception(
@@ -1026,6 +1035,20 @@ class FungibleQuantState:
                 self._step, len(swaps), self.apply_failures)
             return False
         if ok:
+            if installed is not None:
+                # Rebuild the incumbent from what the device actually took, so
+                # tier_of and the layer states cannot drift apart.
+                applied_tier = self.tier_of.copy()
+                for row, e_out, e_in in installed:
+                    applied_tier[int(row), int(e_out)] = K3
+                    applied_tier[int(row), int(e_in)] = K4
+                if not np.array_equal(applied_tier, proposed_tier):
+                    logger.info(
+                        "FQ apply installed %d swap(s) that differ from this "
+                        "interval's proposal — adopting the INSTALLED "
+                        "membership, not the proposed one", len(installed))
+                proposed_tier = applied_tier
+                proposed_doc = self._doc_for(applied_tier, list(installed))
             swapped = self.tier_of != proposed_tier
             self.tier_of = proposed_tier
             self._entered_step = np.where(

--- a/vllm/model_executor/layers/quantization/exl3_fungible/loop.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/loop.py
@@ -750,9 +750,14 @@ class FungibleQuantState:
                 logger.warning("FQ budget step=%d: %s", self._step,
                                P.rejection_message(rej))
 
-        proposed_tier = P.apply_promotions(
-            P.apply_swaps(self.tier_of, swaps), promotions,
-            self.budget.high_k)
+        # Two memberships, kept apart on purpose. The PROPOSAL includes the
+        # headroom promotions and is what gets explained, logged and
+        # archived; the swaps-only membership is the executable part (a
+        # 1-for-1 K3<->K4 trade), and it is the only thing the apply
+        # backend may ever be handed — see _maybe_apply.
+        swaps_tier = P.apply_swaps(self.tier_of, swaps)
+        proposed_tier = P.apply_promotions(swaps_tier, promotions,
+                                           self.budget.high_k)
         proposed_doc = self._doc_for(proposed_tier, swaps)
         proposed_sha = policy_hash(proposed_doc)
 
@@ -795,9 +800,23 @@ class FungibleQuantState:
             record["budget"]["headroom_promotions"],
             record["decision_sha"][:16])
 
-        applied = self._maybe_apply(proposed_doc, proposed_tier,
-                                    swaps, promotions)
+        # Unpaired promotions can never be executed live, but the paired
+        # swaps decided in the SAME interval can. Discarding those too
+        # would freeze the serve: promotions are re-proposed every
+        # interval for as long as any headroom exists, nothing is applied,
+        # so the occupancy — and therefore the headroom — never changes.
+        # Apply the executable subset from a swaps-only document.
+        if promotions:
+            applied = self._maybe_apply(self._doc_for(swaps_tier, swaps),
+                                        swaps_tier, swaps, promotions)
+        else:
+            applied = self._maybe_apply(proposed_doc, proposed_tier,
+                                        swaps, promotions)
         record["applied"] = applied
+        # ``applied`` covers the swap list only. Promotions are structurally
+        # inapplicable, so say so rather than leaving a reader to infer that
+        # record["promotions"] went live alongside record["swaps"].
+        record["promotions_applied"] = False
         record["apply_failures"] = int(self.apply_failures)
 
         if self.is_lead:
@@ -829,7 +848,16 @@ class FungibleQuantState:
                 for k, v in self.budget.expert_bytes.table().items()}
             budget["bytes_source"] = self.budget.expert_bytes.provenance
         else:
-            budget.setdefault("mode", "fixed_cardinality")
+            # The inherited document may have been committed under a byte
+            # ceiling that is NOT configured on this run (the operator
+            # dropped VLLM_FQ_MEMORY_BUDGET and restarted). Carrying its
+            # mode/ceiling forward would have every document this loop
+            # emits advertise a limit nothing is enforcing, so the byte
+            # fields are cleared rather than left to setdefault.
+            budget["mode"] = "fixed_cardinality"
+            for key in ("max_bytes_per_rank", "bytes_per_expert_per_rank",
+                        "bytes_source"):
+                budget.pop(key, None)
         doc["budget"] = budget
         doc["provenance"] = {
             "proposed_by": f"fq-loop/{self.cfg.apply_mode}",
@@ -870,18 +898,37 @@ class FungibleQuantState:
             # apply_fn is handed the SWAP LIST, so a promotion would never
             # reach it anyway — advancing tier_of/policy_doc/store past it
             # would make the loop, the gauges and the committed policy all
-            # claim a tier the device never received. Refuse instead: the
-            # proposal is still explained and persisted to history/, which
-            # is exactly the "raise n_k4_per_layer and restart" path.
+            # claim a tier the device never received.
+            #
+            # The promotions are therefore DROPPED (still explained and
+            # persisted to history/, which is exactly the "raise
+            # n_k4_per_layer and restart" path) — but only the promotions.
+            # The interval's paired swaps are byte-neutral and
+            # cardinality-preserving, so they stay applicable; refusing
+            # them as well would stall the serve permanently, because a
+            # promotion is re-proposed every interval for as long as the
+            # ceiling leaves headroom and nothing ever consumes it.
             if not self._promotion_apply_warned:
                 logger.error(
                     "FQ budget: %d headroom promotion(s) proposed at step %d "
                     "but runtime cardinality growth cannot be applied live "
-                    "(fixed-capacity slabs, D1) — recording the proposal and "
-                    "applying NOTHING this interval. Raise "
-                    "budget.n_k4_per_layer in the policy and restart to bank "
-                    "the headroom.", len(promotions), self._step)
+                    "(fixed-capacity slabs, D1) — dropping them and applying "
+                    "only the %d paired swap(s). Raise budget.n_k4_per_layer "
+                    "in the policy and restart to bank the headroom.",
+                    len(promotions), self._step, len(swaps))
                 self._promotion_apply_warned = True
+            if not swaps:
+                return False
+        # Last line of defence for D1, independent of what the caller
+        # passed: the backend is only ever given a swap list, so a
+        # membership whose per-layer K4 cardinality moved is one it cannot
+        # reach. Refuse rather than commit a policy the device never got.
+        if not np.array_equal(P.n_k4_of(proposed_tier), self.n_k4):
+            logger.error(
+                "FQ apply refused at step %d: proposed membership changes the "
+                "per-layer K4 cardinality (%s -> %s), which the swap backend "
+                "cannot execute (D1)", self._step, list(map(int, self.n_k4)),
+                list(map(int, P.n_k4_of(proposed_tier))))
             return False
         if self.apply_fn is None:
             if self.cfg.apply_mode == APPLY_ATOMIC and not self._atomic_warned:
@@ -931,7 +978,12 @@ class FungibleQuantState:
         decisions.mkdir(exist_ok=True)
         self.store._atomic_write(
             decisions / f"{self._step:08d}.json", record)
-        if swaps and not record["applied"]:
+        # A proposal carrying promotions is ALWAYS archived, even when the
+        # interval's swaps were applied: the promotions themselves never
+        # are, and history/ is the only record of the "raise
+        # n_k4_per_layer and restart" recommendation.
+        unapplied_growth = bool(record.get("totals", {}).get("promotions"))
+        if swaps and (unapplied_growth or not record["applied"]):
             # The dryrun contract: the proposal lands in history/ for
             # audit and for the out-of-band M3 reload path, while
             # current.json (the running policy) stays untouched.

--- a/vllm/model_executor/layers/quantization/exl3_fungible/loop.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/loop.py
@@ -1190,6 +1190,36 @@ class FungibleQuantState:
             logger.info("%s", line)
         self._last_composition = cur
 
+        # Membership diff, because the table above CANNOT show a swap.
+        #
+        # `_occupancy_map` reports per-tier COUNTS, and D1 fixed cardinality
+        # makes every count invariant under a K3<->K4 exchange. So the table
+        # printed "no tier changes across 75 layers" at every single interval
+        # of a run in which 256 experts demonstrably moved (verified by
+        # diffing the committed policy against the boot policy file). It was
+        # literally true and the worst kind of instrument: it reads as
+        # evidence that nothing happened.
+        #
+        # Counts still answer "what is the occupancy", so they stay; this adds
+        # the question they cannot answer.
+        prev = getattr(self, "_last_tier_of", None)
+        curr = np.array(self.tier_of, copy=True)
+        if prev is not None and getattr(prev, "shape", None) == curr.shape:
+            moved = prev != curr
+            n_moved = int(moved.sum())
+            if n_moved:
+                rows = np.flatnonzero(moved.any(axis=1))
+                sample = ", ".join(f"L{int(self.layers[r])}:{int(moved[r].sum())}"
+                                   for r in rows[:6])
+                logger.info(
+                    "  membership: %d expert(s) moved across %d layer(s) "
+                    "since the last table (%s%s)",
+                    n_moved, int(rows.size), sample,
+                    ", ..." if rows.size > 6 else "")
+            else:
+                logger.info("  membership: unchanged since the last table")
+        self._last_tier_of = curr
+
     def _export_metrics(self, record: dict, swaps: list,
                         jac: float | None, applied: bool = False) -> None:
         if self.metrics is None:

--- a/vllm/model_executor/layers/quantization/exl3_fungible/loop.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/loop.py
@@ -326,6 +326,10 @@ class FungibleQuantState:
         self._intervals_run = 0
         self._prev_desired: np.ndarray | None = None  # [L,E] bool
         self._atomic_warned = False
+        # Apply attempts the backend refused/crashed on. A missing fragment
+        # at the required K is the expected cause: the incumbent tiering
+        # stays live and the next interval retries.
+        self.apply_failures = 0
 
         if eps is None:
             eps = self._resolve_eps()
@@ -515,6 +519,7 @@ class FungibleQuantState:
 
         applied = self._maybe_apply(proposed_doc, proposed_tier, swaps)
         record["applied"] = applied
+        record["apply_failures"] = int(self.apply_failures)
 
         if self.is_lead:
             self._persist(record, proposed_doc, swaps)
@@ -540,7 +545,17 @@ class FungibleQuantState:
     def _maybe_apply(self, proposed_doc: dict, proposed_tier: np.ndarray,
                      swaps: list) -> bool:
         """dryrun: never. reload/atomic: only through a bound apply_fn
-        (M3's fq_reload path / M4's swap engine); record-only otherwise."""
+        (M3's fq_reload path / M4's swap engine); record-only otherwise.
+
+        The apply backend is treated as untrusted: a fragment that is not
+        available at the required K, an unreachable mirror, an aborted
+        stage — anything it raises is caught here and downgraded to "not
+        applied". The incumbent tiering stays live and authoritative
+        (``tier_of``/``policy_doc``/``store`` are only advanced on a clean
+        ``True``), the rest of the interval still explains and persists its
+        decision, and the next interval retries. Staging is host-only and
+        happens before the swap engine's quiesce window, so a supply
+        failure cannot have left a layer half-updated."""
         if self.cfg.apply_mode == APPLY_DRYRUN or not swaps:
             return False
         if self.apply_fn is None:
@@ -556,7 +571,16 @@ class FungibleQuantState:
                     "(fq_assemble + fq_reload swap) from the persisted "
                     "proposal JSON")
             return False
-        ok = bool(self.apply_fn(proposed_doc, swaps))
+        try:
+            ok = bool(self.apply_fn(proposed_doc, swaps))
+        except Exception:  # noqa: BLE001 — a supply failure is not a crash
+            self.apply_failures += 1
+            logger.exception(
+                "FQ apply failed at step %d (%d swaps) — keeping the "
+                "incumbent tiering and retrying next interval "
+                "(apply_failures=%d)",
+                self._step, len(swaps), self.apply_failures)
+            return False
         if ok:
             swapped = self.tier_of != proposed_tier
             self.tier_of = proposed_tier

--- a/vllm/model_executor/layers/quantization/exl3_fungible/loop.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/loop.py
@@ -1040,8 +1040,8 @@ class FungibleQuantState:
                 # tier_of and the layer states cannot drift apart.
                 applied_tier = self.tier_of.copy()
                 for row, e_out, e_in in installed:
-                    applied_tier[int(row), int(e_out)] = K3
-                    applied_tier[int(row), int(e_in)] = K4
+                    applied_tier[int(row), int(e_out)] = P.K3
+                    applied_tier[int(row), int(e_in)] = P.K4
                 if not np.array_equal(applied_tier, proposed_tier):
                     logger.info(
                         "FQ apply installed %d swap(s) that differ from this "

--- a/vllm/model_executor/layers/quantization/exl3_fungible/loop.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/loop.py
@@ -561,6 +561,17 @@ class FungibleQuantState:
             [policy_doc["bits_per_expert"][str(layer)]
              for layer in self.layers], dtype=np.int64)
         self.n_k4 = P.n_k4_of(self.tier_of)
+        # The online score/policy objective is calibrated specifically for
+        # K3->K4 error reduction. Other binary pairs remain fully observable
+        # and operator-swappable, but must not be fed through that policy as
+        # though K2 were K3.
+        self._auto_decisions_supported = (
+            set(int(k) for k in np.unique(self.tier_of)) <= {P.K3, P.K4})
+        if not self._auto_decisions_supported:
+            logger.warning(
+                "FQ loop: automatic decisions disabled for tier set %s; "
+                "collector and admin re-tiering remain active",
+                sorted(int(k) for k in np.unique(self.tier_of)))
         self.pins = self._pins_from_doc(policy_doc)
         self.budget = budget if budget is not None else self._resolve_budget()
         self._log_budget()
@@ -705,7 +716,8 @@ class FungibleQuantState:
         self._step += 1
         if not is_dummy:
             self._real_steps += 1
-        if self._step % self.cfg.interval_steps:
+        if (self._step % self.cfg.interval_steps
+                or not self._auto_decisions_supported):
             return
         try:
             self.run_interval()

--- a/vllm/model_executor/layers/quantization/exl3_fungible/loop.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/loop.py
@@ -870,9 +870,17 @@ class FungibleQuantState:
     def _doc_for(self, tier: np.ndarray, swaps: list) -> dict:
         doc = {k: v for k, v in self.policy_doc.items()
                if k not in ("bits_per_expert", "provenance", "budget")}
-        doc["bits_per_expert"] = {
-            str(layer): [int(b) for b in tier[row]]
-            for row, layer in enumerate(self.layers)}
+        # Same hazard as admin.build_target_doc: rebuilding bits_per_expert
+        # from self.layers alone silently drops every layer outside the
+        # decision domain (MTP layer 78 on GLM-5.2 — required by the loader's
+        # bitrate map, unbindable by the collector). The proposed document
+        # would then cover fewer layers than the running one and the swap
+        # engine would refuse it as "policies cover different layers".
+        bpe = {str(k): list(v) for k, v in
+               (self.policy_doc.get("bits_per_expert") or {}).items()}
+        for row, layer in enumerate(self.layers):
+            bpe[str(layer)] = [int(b) for b in tier[row]]
+        doc["bits_per_expert"] = bpe
         # The declared cardinality is RECOMPUTED from the proposed tiers,
         # not copied: promotions change occupancy, and store.validate_policy
         # enforces cap == n. The byte ceiling rides along so a persisted

--- a/vllm/model_executor/layers/quantization/exl3_fungible/loop.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/loop.py
@@ -48,6 +48,9 @@ import numpy as np
 
 from vllm.model_executor.layers.quantization.exl3_fungible import policy as P
 from vllm.model_executor.layers.quantization.exl3_fungible import (
+    occupancy_table as OT,
+)
+from vllm.model_executor.layers.quantization.exl3_fungible import (
     decision_log as DL,
 )
 from vllm.model_executor.layers.quantization.exl3_fungible.stats import (
@@ -294,6 +297,11 @@ class FungibleQuantState:
         # Policy layer rows: sorted numeric layer ids from the document.
         self.layers = sorted(int(k) for k in policy_doc["bits_per_expert"])
         self.num_experts = collector.num_experts
+        # Operator-facing composition table: remembered so each print
+        # can show what moved since the last one.
+        self._last_composition: dict | None = None
+        self._table_every = int(
+            os.environ.get('VLLM_FQ_TABLE_EVERY_INTERVALS', '10'))
         self._collector_layer_map = self._map_collector_layers()
 
         self.tier_of = np.asarray(
@@ -321,6 +329,13 @@ class FungibleQuantState:
             for layer in self.layers:
                 self.metrics.swaps_total.labels(layer=str(layer)).inc(0)
             self._export_occupancy()
+
+        # The composition the checkpoint actually booted with. Printed in
+        # full (not diff-only): there is nothing to diff against yet, and an
+        # operator needs the starting shape on record in the log so a later
+        # diff can be interpreted without re-deriving it.
+        self.log_composition(title="expert composition at startup",
+                             diff_only=False)
 
     # ---------------------------------------------------------------- setup
 
@@ -439,6 +454,11 @@ class FungibleQuantState:
         """One observe->decide->explain->persist cycle; returns the
         decision record."""
         self._intervals_run += 1
+        if (self._table_every > 0
+                and self._intervals_run % self._table_every == 0):
+            self.log_composition(
+                title=f'expert composition @ interval {self._intervals_run}',
+                diff_only=True)
         stats = self._read_stats()
         dwell = self._real_steps - self._entered_step
 
@@ -565,6 +585,40 @@ class FungibleQuantState:
                 self.metrics.tier_occupancy.labels(
                     layer=str(layer), tier=f"k{tier}").set(
                         int((self.tier_of[row] == tier).sum()))
+
+    def _occupancy_map(self) -> dict[int, dict[int, int]]:
+        """``{layer: {k: expert_count}}`` for the operator-facing table."""
+        out: dict[int, dict[int, int]] = {}
+        for row, layer in enumerate(self.layers):
+            counts: dict[int, int] = {}
+            for tier in OT.TIERS:
+                n = int((self.tier_of[row] == tier).sum())
+                if n or tier in (P.K3, P.K4):
+                    counts[tier] = n
+            out[int(layer)] = counts
+        return out
+
+    def log_composition(self, *, title: str, diff_only: bool) -> None:
+        """Print the layer x K-tier matrix to the engine log.
+
+        A scrape target answers "what is the occupancy" but not "what changed
+        since I last looked", and an operator cannot eyeball Prometheus at
+        3am. Rank 0 only: all TP ranks hold the same policy, so N identical
+        90-row tables would be pure noise.
+        """
+        if self.rank not in (0, None):
+            return
+        cur = self._occupancy_map()
+        try:
+            text = OT.render(cur, self._last_composition, title=title,
+                             num_experts=int(self.num_experts),
+                             diff_only=diff_only)
+        except Exception:  # noqa: BLE001 - telemetry must never kill a serve
+            logger.exception("FQ composition table failed to render")
+            return
+        for line in text.splitlines():
+            logger.info("%s", line)
+        self._last_composition = cur
 
     def _export_metrics(self, record: dict, swaps: list,
                         jac: float | None) -> None:

--- a/vllm/model_executor/layers/quantization/exl3_fungible/loop.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/loop.py
@@ -1,0 +1,661 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Fungible-quant M2 loop: observe -> decide -> explain -> persist.
+
+:class:`FungibleQuantState` is the interval state machine that turns the
+M1 stats collector into the M2 shadow evaluator. The model runner calls
+``state.step()`` once per engine step at the EPLB step sites (via
+``integration.maybe_init_fq_state``, which wraps the collector); every
+``VLLM_FQ_INTERVAL_STEPS`` steps it:
+
+1. reads the decayed routing window from the collector (observe),
+2. runs ``policy.decide`` on (stats, eps, current membership) (decide),
+3. builds the explainable decision record and logs the EPLB-style
+   interval + per-swap rationale lines (explain),
+4. persists the decision JSON and — in ``dryrun`` mode — the PROPOSED
+   policy document into the store's history WITHOUT touching
+   ``current.json`` or any weights (persist),
+5. bumps the Prometheus instruments of 03-testing-validation
+   §Instrumentation (``fq_swaps_total{layer}``, ``fq_rollbacks_total``,
+   ``fq_probe_kld``, ``fq_jaccard``, ``fq_policy_age_steps``, per-tier
+   occupancy gauges).
+
+Apply modes (01-artifacts-policy-stats.md §4): ``dryrun`` (M2's shipping
+mode — decide + log only, permanently useful as a shadow evaluator),
+``reload`` (delegates to a bound ``apply_fn``; the proven path is the M3
+``fq_reload`` worker extension driven from the persisted proposal),
+``atomic`` (M4 swap engine; not yet bound to live layers — treated as
+record-only with a warning until that wiring lands).
+
+Determinism: ``policy.decide`` is a pure function of its inputs; each
+rank logs a T6-style ``decision sha`` over the swap list so cross-rank
+agreement is auditable from the serve log alone.
+
+Hot-path contract (PERFORMANCE.md): ``step()`` between intervals is a
+few integer ops on top of ``collector.step()``; all tensor reads, numpy
+work, file IO and metric updates happen only on interval boundaries.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any, Callable
+
+import numpy as np
+
+from vllm.model_executor.layers.quantization.exl3_fungible import policy as P
+from vllm.model_executor.layers.quantization.exl3_fungible import (
+    decision_log as DL,
+)
+from vllm.model_executor.layers.quantization.exl3_fungible.stats import (
+    FqStatsCollector,
+)
+from vllm.model_executor.layers.quantization.exl3_fungible.store import (
+    PolicyStore,
+    policy_hash,
+    validate_policy,
+)
+
+logger = logging.getLogger(__name__)
+
+# ------------------------------------------------------------------ env knobs
+# (01-artifacts-policy-stats.md §4; read at init, GG-style raw os.environ —
+# same pattern as integration.py.)
+FQ_INTERVAL_ENV = "VLLM_FQ_INTERVAL_STEPS"
+FQ_APPLY_MODE_ENV = "VLLM_FQ_APPLY_MODE"
+FQ_ARTIFACT_DIR_ENV = "VLLM_FQ_ARTIFACT_DIR"
+FQ_POLICY_ENV = "VLLM_FQ_POLICY"
+FQ_EPS_ROOT_ENV = "VLLM_FQ_EPS_ROOT"
+FQ_CACHE_ROOT_ENV = "VLLM_FQ_CACHE_ROOT"
+FQ_MAX_SWAPS_LAYER_ENV = "VLLM_FQ_MAX_SWAPS_LAYER"
+FQ_MAX_SWAPS_TOTAL_ENV = "VLLM_FQ_MAX_SWAPS_TOTAL"
+FQ_DWELL_ENV = "VLLM_FQ_DWELL_STEPS"
+FQ_HYSTERESIS_ENV = "VLLM_FQ_HYSTERESIS"
+FQ_JACCARD_FLOOR_ENV = "VLLM_FQ_JACCARD_FLOOR"
+
+APPLY_DRYRUN, APPLY_RELOAD, APPLY_ATOMIC = "dryrun", "reload", "atomic"
+
+
+class FqLoopConfig:
+    """Loop knobs resolved from the environment (defaults per spec §4)."""
+
+    def __init__(
+        self,
+        *,
+        interval_steps: int = 3000,
+        apply_mode: str = APPLY_DRYRUN,
+        dwell_steps: int | None = None,
+        hysteresis: float = 1.25,
+        max_swaps_per_layer: int = 2,
+        max_swaps_total: int = 64,
+        jaccard_floor: float = 0.95,
+        artifact_dir: str | None = None,
+        policy_path: str | None = None,
+        eps_root: str | None = None,
+        cache_root: str | None = None,
+    ) -> None:
+        if apply_mode not in (APPLY_DRYRUN, APPLY_RELOAD, APPLY_ATOMIC):
+            raise ValueError(f"unknown {FQ_APPLY_MODE_ENV}: {apply_mode!r}")
+        self.interval_steps = int(interval_steps)
+        self.apply_mode = apply_mode
+        # Spec default: DWELL = 2 x interval.
+        self.dwell_steps = (2 * self.interval_steps
+                            if dwell_steps is None else int(dwell_steps))
+        self.hysteresis = float(hysteresis)
+        self.max_swaps_per_layer = int(max_swaps_per_layer)
+        self.max_swaps_total = int(max_swaps_total)
+        self.jaccard_floor = float(jaccard_floor)
+        self.artifact_dir = artifact_dir
+        self.policy_path = policy_path
+        self.eps_root = eps_root
+        self.cache_root = cache_root or os.path.expanduser("~/.cache/vllm")
+
+    @classmethod
+    def from_env(cls) -> "FqLoopConfig":
+        env = os.environ.get
+        kwargs: dict[str, Any] = {}
+        if env(FQ_INTERVAL_ENV):
+            kwargs["interval_steps"] = int(env(FQ_INTERVAL_ENV))
+        kwargs["apply_mode"] = env(FQ_APPLY_MODE_ENV, APPLY_DRYRUN)
+        if env(FQ_DWELL_ENV):
+            kwargs["dwell_steps"] = int(env(FQ_DWELL_ENV))
+        if env(FQ_HYSTERESIS_ENV):
+            kwargs["hysteresis"] = float(env(FQ_HYSTERESIS_ENV))
+        if env(FQ_MAX_SWAPS_LAYER_ENV):
+            kwargs["max_swaps_per_layer"] = int(env(FQ_MAX_SWAPS_LAYER_ENV))
+        if env(FQ_MAX_SWAPS_TOTAL_ENV):
+            kwargs["max_swaps_total"] = int(env(FQ_MAX_SWAPS_TOTAL_ENV))
+        if env(FQ_JACCARD_FLOOR_ENV):
+            kwargs["jaccard_floor"] = float(env(FQ_JACCARD_FLOOR_ENV))
+        kwargs["artifact_dir"] = env(FQ_ARTIFACT_DIR_ENV)
+        kwargs["policy_path"] = env(FQ_POLICY_ENV)
+        kwargs["eps_root"] = env(FQ_EPS_ROOT_ENV)
+        kwargs["cache_root"] = env(FQ_CACHE_ROOT_ENV)
+        return cls(**kwargs)
+
+
+# ------------------------------------------------------------------ eps source
+def load_eps_from_work_root(
+    work_root: str | Path,
+    layers: list[int],
+    num_experts: int,
+    *,
+    ks: tuple[int, int] = (P.K3, P.K4),
+    dir_pattern: str = "work-k{k}-tr3",
+) -> dict[int, np.ndarray] | None:
+    """Per-expert eps from the encoder's per-layer done-JSONs.
+
+    Minimal reimplementation of the ``tools/fq_eps.py`` parsing (research
+    repo — not importable from here): ``<work_root>/work-k{k}-tr3/
+    layer-NNN.done.json`` -> ``expert_rel_rt_mse`` (per-expert round-trip
+    MSE). Returns ``{k: [L, E] float64}`` with rows ordered like
+    ``layers``, or None when any layer/K is missing (caller falls back to
+    the uniform stub).
+    """
+    root = Path(work_root)
+    out: dict[int, np.ndarray] = {}
+    for k in ks:
+        rows = []
+        for layer in layers:
+            p = root / dir_pattern.format(k=k) / f"layer-{layer:03d}.done.json"
+            if not p.is_file():
+                logger.warning("FQ eps: missing %s — using uniform stub", p)
+                return None
+            try:
+                doc = json.loads(p.read_text())
+                mse = doc["expert_rel_rt_mse"]
+            except (json.JSONDecodeError, KeyError) as e:
+                logger.warning("FQ eps: unreadable %s (%s) — uniform stub",
+                               p, e)
+                return None
+            if len(mse) != num_experts:
+                logger.warning(
+                    "FQ eps: %s has %d experts, expected %d — uniform stub",
+                    p, len(mse), num_experts)
+                return None
+            rows.append(mse)
+        out[k] = np.asarray(rows, dtype=np.float64)
+    return out
+
+
+def uniform_eps_stub(num_layers: int, num_experts: int) -> dict[int, np.ndarray]:
+    """No eps data: unit K3->K4 error gap everywhere, so the score
+    degrades to pure routing pressure (count x mass) instead of
+    silently vanishing."""
+    return {
+        P.K3: np.ones((num_layers, num_experts), dtype=np.float64),
+        P.K4: np.zeros((num_layers, num_experts), dtype=np.float64),
+    }
+
+
+# ------------------------------------------------------------------ metrics
+class FqMetrics:
+    """03-testing-validation §Instrumentation, prometheus_client-native
+    (multiprocess-aware exactly like vllm's own metrics: with
+    ``PROMETHEUS_MULTIPROC_DIR`` set, worker-process writes aggregate into
+    the API server's ``/metrics`` via ``MultiProcessCollector``)."""
+
+    def __init__(self, registry=None):
+        import prometheus_client as pc
+        kw = {} if registry is None else {"registry": registry}
+        self.swaps_total = pc.Counter(
+            "fq_swaps_total",
+            "Fungible-quant expert tier swaps decided per MoE layer "
+            "(proposals in dryrun mode, applied swaps otherwise).",
+            ["layer"], **kw)
+        self.rollbacks_total = pc.Counter(
+            "fq_rollbacks_total",
+            "Fungible-quant probe-triggered policy rollbacks.", **kw)
+        self.probe_kld = pc.Gauge(
+            "fq_probe_kld",
+            "Held-out probe KL divergence at the last probe run.",
+            multiprocess_mode="mostrecent", **kw)
+        self.jaccard = pc.Gauge(
+            "fq_jaccard",
+            "Mean per-layer Jaccard similarity of the desired-K4 set "
+            "between consecutive decision intervals (router-shift guard).",
+            multiprocess_mode="mostrecent", **kw)
+        self.policy_age_steps = pc.Gauge(
+            "fq_policy_age_steps",
+            "Engine steps since the running policy was committed.",
+            multiprocess_mode="mostrecent", **kw)
+        self.tier_occupancy = pc.Gauge(
+            "fq_tier_occupancy",
+            "Experts resident per (layer, K tier) under the running policy.",
+            ["layer", "tier"], multiprocess_mode="mostrecent", **kw)
+        # Materialize the counters at 0 so they are scrapeable before the
+        # first increment (multiprocess files are created on first touch).
+        self.rollbacks_total.inc(0)
+
+
+_METRICS: FqMetrics | None = None
+
+
+def get_metrics() -> FqMetrics | None:
+    """Process-wide singleton; None when prometheus_client is absent."""
+    global _METRICS
+    if _METRICS is None:
+        try:
+            _METRICS = FqMetrics()
+        except ImportError:
+            logger.warning("prometheus_client unavailable — FQ metrics off")
+    return _METRICS
+
+
+# ------------------------------------------------------------------ the loop
+class FungibleQuantState:
+    """Observe -> decide -> explain -> persist, one cycle per interval.
+
+    Args:
+        collector: the bound M1 stats collector.
+        policy_doc: the running ``fq-policy/2`` document (defines layer
+            rows, membership, budget, pins).
+        config: loop knobs (default: from env).
+        eps: ``{3: [L,E], 4: [L,E]}`` per-expert error at each tier
+            (default: loaded from ``config.eps_root``, else uniform stub).
+        store: policy store for persistence (None disables persistence,
+            e.g. on non-lead ranks).
+        metrics: FqMetrics (None disables instrument updates).
+        rank: this worker's rank, for the T6-style decide-sha log line.
+        is_lead: only the lead rank persists and bumps metrics, so
+            counters are not multiplied by world size.
+        apply_fn: ``fn(proposed_doc, swaps) -> bool`` bound by an apply
+            backend (M3 reload / M4 atomic). Required for any mode other
+            than dryrun to actually apply.
+    """
+
+    def __init__(
+        self,
+        collector: FqStatsCollector,
+        policy_doc: dict,
+        *,
+        config: FqLoopConfig | None = None,
+        eps: dict[int, np.ndarray] | None = None,
+        store: PolicyStore | None = None,
+        metrics: FqMetrics | None = None,
+        rank: int = 0,
+        is_lead: bool = True,
+        apply_fn: Callable[[dict, list], bool] | None = None,
+    ) -> None:
+        self.collector = collector
+        self.cfg = config or FqLoopConfig.from_env()
+        self.store = store
+        self.metrics = metrics
+        self.rank = int(rank)
+        self.is_lead = bool(is_lead)
+        self.apply_fn = apply_fn
+
+        validate_policy(policy_doc, num_experts=collector.num_experts)
+        self.policy_doc = policy_doc
+        self.policy_sha = policy_hash(policy_doc)
+        # Policy layer rows: sorted numeric layer ids from the document.
+        self.layers = sorted(int(k) for k in policy_doc["bits_per_expert"])
+        self.num_experts = collector.num_experts
+        self._collector_layer_map = self._map_collector_layers()
+
+        self.tier_of = np.asarray(
+            [policy_doc["bits_per_expert"][str(layer)]
+             for layer in self.layers], dtype=np.int64)
+        self.n_k4 = P.n_k4_of(self.tier_of)
+        self.pins = self._pins_from_doc(policy_doc)
+
+        # Step machinery. ``_step`` counts every engine step including
+        # dummy ones (collector._step semantics: rank lockstep); dwell is
+        # measured in real steps via per-expert entry marks.
+        self._step = 0
+        self._real_steps = 0
+        self._entered_step = np.zeros_like(self.tier_of)
+        self._policy_step = 0          # step at which policy_doc took effect
+        self._intervals_run = 0
+        self._prev_desired: np.ndarray | None = None  # [L,E] bool
+        self._atomic_warned = False
+
+        if eps is None:
+            eps = self._resolve_eps()
+        self.eps = eps
+
+        if self.metrics is not None and self.is_lead:
+            for layer in self.layers:
+                self.metrics.swaps_total.labels(layer=str(layer)).inc(0)
+            self._export_occupancy()
+
+    # ---------------------------------------------------------------- setup
+
+    def _map_collector_layers(self) -> dict[int, int]:
+        """policy layer id -> collector layer id.
+
+        Identity when the id sets match (MoERunner.layer_id is the model
+        layer index, as are the policy keys); positional (sorted order)
+        with a warning otherwise.
+        """
+        cids = sorted(self.collector.count_buf)
+        if not cids:
+            # Tests may drive a collector before any bind; treat as
+            # identity and let decayed() fail loudly if actually read.
+            return {layer: layer for layer in self.layers}
+        if set(cids) >= set(self.layers):
+            return {layer: layer for layer in self.layers}
+        if len(cids) == len(self.layers):
+            logger.warning(
+                "FQ loop: collector layer ids %s != policy layers %s — "
+                "mapping positionally by sorted order", cids, self.layers)
+            return dict(zip(self.layers, cids))
+        raise ValueError(
+            f"FQ loop: cannot map policy layers {self.layers} onto "
+            f"collector layers {cids}")
+
+    def _pins_from_doc(self, doc: dict) -> np.ndarray:
+        """Minimal ``pinned`` semantics: ``{layer: "all" | [expert ids]}``
+        pins the named experts to their *current* tier (v1's use case is
+        pinning a whole layer, e.g. MTP-78, out of the swap set)."""
+        pins = np.zeros_like(self.tier_of)
+        for key, val in (doc.get("pinned") or {}).items():
+            row = self.layers.index(int(key))
+            experts = (range(self.num_experts) if val == "all" else
+                       [int(e) for e in val])
+            for e in experts:
+                pins[row, e] = self.tier_of[row, e]
+        return pins
+
+    def _resolve_eps(self) -> dict[int, np.ndarray]:
+        if self.cfg.eps_root:
+            eps = load_eps_from_work_root(
+                self.cfg.eps_root, self.layers, self.num_experts)
+            if eps is not None:
+                logger.info("FQ loop: eps loaded from %s (%d layers)",
+                            self.cfg.eps_root, len(self.layers))
+                return eps
+        logger.info("FQ loop: no eps source — uniform stub (score degrades "
+                    "to routing pressure)")
+        return uniform_eps_stub(len(self.layers), self.num_experts)
+
+    # ---------------------------------------------------------------- step
+
+    def step(self, *, is_dummy: bool = False) -> None:
+        """Advance one engine step. Same call contract as
+        ``FqStatsCollector.step`` — the model runner needs no other API.
+
+        Between intervals this is collector.step plus two integer
+        increments and one modulo (hot-path contract)."""
+        self.collector.step(is_dummy=is_dummy)
+        self._step += 1
+        if not is_dummy:
+            self._real_steps += 1
+        if self._step % self.cfg.interval_steps:
+            return
+        try:
+            self.run_interval()
+        except Exception:
+            # A loop bug must never take the serve down; the collector
+            # keeps recording and the next interval retries.
+            logger.exception("FQ interval at step %d failed — continuing",
+                             self._step)
+
+    # ---------------------------------------------------------------- cycle
+
+    def _read_stats(self) -> dict[str, np.ndarray]:
+        counts, masses = [], []
+        for layer in self.layers:
+            c, m = self.collector.decayed(self._collector_layer_map[layer])
+            counts.append(c.cpu().numpy())
+            masses.append(m.cpu().numpy())
+        return {"count": np.asarray(counts), "mass": np.asarray(masses)}
+
+    def _decide_cfg(self) -> dict:
+        return {
+            "n_k4": self.n_k4,
+            "hysteresis": self.cfg.hysteresis,
+            "dwell_steps": self.cfg.dwell_steps,
+            "max_swaps_per_layer": self.cfg.max_swaps_per_layer,
+            "max_swaps_total": self.cfg.max_swaps_total,
+        }
+
+    def _desired_sets(self, stats: dict) -> np.ndarray:
+        """[L,E] bool: per layer, the top-n_k4 experts by score (the
+        router-shift signal of spec 0e, independent of guards)."""
+        s = P.score(stats, self.eps)
+        desired = np.zeros(s.shape, dtype=bool)
+        for row in range(s.shape[0]):
+            order = np.lexsort((np.arange(s.shape[1]), -s[row]))
+            desired[row, order[: int(self.n_k4[row])]] = True
+        return desired
+
+    @staticmethod
+    def _jaccard(a: np.ndarray, b: np.ndarray) -> float:
+        inter = (a & b).sum(axis=1).astype(np.float64)
+        union = np.maximum((a | b).sum(axis=1), 1).astype(np.float64)
+        return float((inter / union).mean())
+
+    @staticmethod
+    def decision_sha(swaps: list[tuple[int, int, int]]) -> str:
+        """T6-style cross-rank agreement digest of the ordered swap list."""
+        return hashlib.sha256(
+            json.dumps(swaps, separators=(",", ":")).encode()).hexdigest()
+
+    def run_interval(self) -> dict:
+        """One observe->decide->explain->persist cycle; returns the
+        decision record."""
+        self._intervals_run += 1
+        stats = self._read_stats()
+        dwell = self._real_steps - self._entered_step
+
+        swaps = P.decide(stats, self.eps, self.tier_of, pins=self.pins,
+                         dwell=dwell, cfg=self._decide_cfg())
+
+        # Router-shift guard (spec 0e / VLLM_FQ_JACCARD_FLOOR): if the
+        # desired top set is churning faster than the floor allows, hold
+        # this interval's proposals — the signal is not trustworthy yet.
+        desired = self._desired_sets(stats)
+        jac = (None if self._prev_desired is None
+               else self._jaccard(desired, self._prev_desired))
+        self._prev_desired = desired
+        jaccard_held = jac is not None and jac < self.cfg.jaccard_floor
+        if jaccard_held and swaps:
+            logger.warning(
+                "FQ interval step=%d: jaccard %.3f < floor %.3f — holding "
+                "%d proposed swaps", self._step, jac,
+                self.cfg.jaccard_floor, len(swaps))
+            swaps = []
+
+        proposed_tier = P.apply_swaps(self.tier_of, swaps)
+        proposed_doc = self._doc_for(proposed_tier, swaps)
+        proposed_sha = policy_hash(proposed_doc)
+
+        record = DL.explain(
+            stats, self.eps, self.tier_of, swaps, pins=self.pins,
+            dwell=dwell, cfg=self._decide_cfg(), step=self._step,
+            policy_sha_before=self.policy_sha,
+            policy_sha_after=proposed_sha if swaps else self.policy_sha)
+        record["apply_mode"] = self.cfg.apply_mode
+        record["applied"] = False
+        # decide()/explain() speak in row indices; record the row->model
+        # layer id mapping so the persisted JSON is self-describing.
+        record["layer_ids"] = [int(x) for x in self.layers]
+        record["jaccard"] = jac
+        record["jaccard_held"] = bool(jaccard_held)
+        record["decision_sha"] = self.decision_sha(swaps)
+        record["real_steps"] = int(self._real_steps)
+
+        DL.log_decision(record)
+        logger.info(
+            "FQ decide rank=%d step=%d interval=%d swaps=%d sha=%s",
+            self.rank, self._step, self._intervals_run, len(swaps),
+            record["decision_sha"][:16])
+
+        applied = self._maybe_apply(proposed_doc, proposed_tier, swaps)
+        record["applied"] = applied
+
+        if self.is_lead:
+            self._persist(record, proposed_doc, swaps)
+            self._export_metrics(record, swaps, jac)
+        return record
+
+    # ---------------------------------------------------------------- apply
+
+    def _doc_for(self, tier: np.ndarray, swaps: list) -> dict:
+        doc = {k: v for k, v in self.policy_doc.items()
+               if k not in ("bits_per_expert", "provenance")}
+        doc["bits_per_expert"] = {
+            str(layer): [int(b) for b in tier[row]]
+            for row, layer in enumerate(self.layers)}
+        doc["provenance"] = {
+            "proposed_by": f"fq-loop/{self.cfg.apply_mode}",
+            "step": int(self._step),
+            "base_policy": self.policy_sha,
+            "num_swaps": len(swaps),
+        }
+        return doc
+
+    def _maybe_apply(self, proposed_doc: dict, proposed_tier: np.ndarray,
+                     swaps: list) -> bool:
+        """dryrun: never. reload/atomic: only through a bound apply_fn
+        (M3's fq_reload path / M4's swap engine); record-only otherwise."""
+        if self.cfg.apply_mode == APPLY_DRYRUN or not swaps:
+            return False
+        if self.apply_fn is None:
+            if self.cfg.apply_mode == APPLY_ATOMIC and not self._atomic_warned:
+                logger.warning(
+                    "FQ apply_mode=atomic without a bound apply_fn — "
+                    "recording proposals only (M4 live wiring pending)")
+                self._atomic_warned = True
+            elif self.cfg.apply_mode == APPLY_RELOAD:
+                logger.warning(
+                    "FQ apply_mode=reload without a bound apply_fn — "
+                    "recording proposal only; drive the proven M3 path "
+                    "(fq_assemble + fq_reload swap) from the persisted "
+                    "proposal JSON")
+            return False
+        ok = bool(self.apply_fn(proposed_doc, swaps))
+        if ok:
+            swapped = self.tier_of != proposed_tier
+            self.tier_of = proposed_tier
+            self._entered_step = np.where(
+                swapped, self._real_steps, self._entered_step)
+            self.policy_doc = proposed_doc
+            self.policy_sha = policy_hash(proposed_doc)
+            self._policy_step = self._step
+            if self.store is not None and self.is_lead:
+                self.store.commit(proposed_doc, num_experts=self.num_experts)
+        return ok
+
+    # ---------------------------------------------------------------- persist
+
+    def _persist(self, record: dict, proposed_doc: dict, swaps: list) -> None:
+        if self.store is None:
+            return
+        decisions = self.store.root / "decisions"
+        decisions.mkdir(exist_ok=True)
+        self.store._atomic_write(
+            decisions / f"{self._step:08d}.json", record)
+        if swaps and not record["applied"]:
+            # The dryrun contract: the proposal lands in history/ for
+            # audit and for the out-of-band M3 reload path, while
+            # current.json (the running policy) stays untouched.
+            validate_policy(proposed_doc, num_experts=self.num_experts)
+            self.store._atomic_write(
+                self.store.root / "history"
+                / f"{self._step:08d}-proposed.json", proposed_doc)
+
+    def _export_occupancy(self) -> None:
+        for row, layer in enumerate(self.layers):
+            for tier in (P.K3, P.K4):
+                self.metrics.tier_occupancy.labels(
+                    layer=str(layer), tier=f"k{tier}").set(
+                        int((self.tier_of[row] == tier).sum()))
+
+    def _export_metrics(self, record: dict, swaps: list,
+                        jac: float | None) -> None:
+        if self.metrics is None:
+            return
+        for layer, _, _ in swaps:
+            self.metrics.swaps_total.labels(
+                layer=str(self.layers[layer])).inc()
+        if jac is not None:
+            self.metrics.jaccard.set(jac)
+        self.metrics.policy_age_steps.set(self._step - self._policy_step)
+        self._export_occupancy()
+
+
+# ------------------------------------------------------------------ boot glue
+def _synthesize_policy_from_artifact(artifact_dir: str) -> dict | None:
+    """fq-policy/2 document from an assembled checkpoint's
+    ``tier_bitmap.json`` (the live membership), manifest-keyed by the
+    checkpoint's MANIFEST.sha256 digest."""
+    root = Path(artifact_dir)
+    bitmap_path = root / "tier_bitmap.json"
+    if not bitmap_path.is_file():
+        return None
+    bitmap = json.loads(bitmap_path.read_text())
+    bits = {str(layer): [int(b) for b in bitmap[layer]["bits_per_expert"]]
+            for layer in sorted(bitmap, key=int)}
+    manifest_path = root / "MANIFEST.sha256"
+    manifest = (hashlib.sha256(manifest_path.read_bytes()).hexdigest()
+                if manifest_path.is_file()
+                else hashlib.sha256(str(root).encode()).hexdigest())
+    return {
+        "schema": "fq-policy/2",
+        "manifest": manifest,
+        "budget": {
+            "mode": "fixed_cardinality",
+            "n_k4_per_layer": {
+                layer: sum(b == P.K4 for b in row)
+                for layer, row in bits.items()},
+        },
+        "bits_per_expert": bits,
+        "pinned": {},
+        "provenance": {"synthesized_from": str(bitmap_path)},
+    }
+
+
+def build_from_env(
+    collector: FqStatsCollector,
+    *,
+    rank: int = 0,
+) -> FungibleQuantState | None:
+    """Construct the loop state for a live engine (integration.py seam).
+
+    Policy resolution order: the store's committed ``current.json``
+    (crash/restart rehydration, D8) > ``VLLM_FQ_POLICY`` document >
+    synthesis from ``VLLM_FQ_ARTIFACT_DIR``'s tier bitmap. Returns None
+    (M1 collector-only observability) when no policy source exists.
+    """
+    cfg = FqLoopConfig.from_env()
+
+    doc: dict | None = None
+    if cfg.policy_path:
+        doc = json.loads(Path(cfg.policy_path).read_text())
+    elif cfg.artifact_dir:
+        doc = _synthesize_policy_from_artifact(cfg.artifact_dir)
+    if doc is None:
+        logger.warning(
+            "FQ loop: no policy source (%s/%s unset or unreadable) — "
+            "running collector-only", FQ_POLICY_ENV, FQ_ARTIFACT_DIR_ENV)
+        return None
+
+    is_lead = rank == 0
+    store = PolicyStore(cfg.cache_root, doc["manifest"])
+    committed = store.load_current(num_experts=collector.num_experts)
+    if committed is not None:
+        doc = committed
+        logger.info("FQ loop: rehydrated committed policy %s",
+                    policy_hash(doc)[:16])
+    elif is_lead:
+        store.commit(doc, num_experts=collector.num_experts)
+        logger.info("FQ loop: boot policy %s committed as current",
+                    policy_hash(doc)[:16])
+
+    state = FungibleQuantState(
+        collector, doc, config=cfg,
+        store=store if is_lead else None,
+        metrics=get_metrics() if is_lead else None,
+        rank=rank, is_lead=is_lead)
+    logger.info(
+        "FQ loop: armed — mode=%s interval=%d dwell=%d hysteresis=%.2f "
+        "caps=(%d/layer, %d total) layers=%s policy=%s",
+        cfg.apply_mode, cfg.interval_steps, cfg.dwell_steps, cfg.hysteresis,
+        cfg.max_swaps_per_layer, cfg.max_swaps_total, state.layers,
+        state.policy_sha[:16])
+    return state

--- a/vllm/model_executor/layers/quantization/exl3_fungible/loop.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/loop.py
@@ -520,6 +520,7 @@ class FungibleQuantState:
         self._intervals_run = 0
         self._prev_desired: np.ndarray | None = None  # [L,E] bool
         self._atomic_warned = False
+        self._promotion_apply_warned = False
         # Apply attempts the backend refused/crashed on. A missing fragment
         # at the required K is the expected cause: the incumbent tiering
         # stays live and the next interval retries.
@@ -743,7 +744,7 @@ class FungibleQuantState:
                     stats, self.eps, P.apply_swaps(self.tier_of, swaps),
                     self.budget, pins=self.pins, dwell=dwell,
                     cfg=self._decide_cfg(),
-                    exclude=[(l, e_in) for l, _, e_in in swaps])
+                    exclude=P.swap_touched(swaps))
                 rejections = rejections + prej
             for rej in rejections:
                 logger.warning("FQ budget step=%d: %s", self._step,
@@ -854,6 +855,33 @@ class FungibleQuantState:
         failure cannot have left a layer half-updated."""
         promotions = promotions or []
         if self.cfg.apply_mode == APPLY_DRYRUN or not (swaps or promotions):
+            return False
+        if promotions:
+            # An unpaired promotion CHANGES the per-layer cardinality, and
+            # nothing downstream can execute that: SwapPlan.from_memberships
+            # refuses a cardinality change (D1), SwapEngine._validate_layer
+            # derives the slab word counts from the tier-1 globals fixed at
+            # prepare time, and the mixed-kernel memo key carries the
+            # per-tier COUNTS, so a count change forces a recompile that is
+            # refused under CUDA-graph capture. admin.check_cardinality
+            # answers the same request with 501; the loop must not quietly
+            # do what the admin API refuses to pretend it can do.
+            #
+            # apply_fn is handed the SWAP LIST, so a promotion would never
+            # reach it anyway — advancing tier_of/policy_doc/store past it
+            # would make the loop, the gauges and the committed policy all
+            # claim a tier the device never received. Refuse instead: the
+            # proposal is still explained and persisted to history/, which
+            # is exactly the "raise n_k4_per_layer and restart" path.
+            if not self._promotion_apply_warned:
+                logger.error(
+                    "FQ budget: %d headroom promotion(s) proposed at step %d "
+                    "but runtime cardinality growth cannot be applied live "
+                    "(fixed-capacity slabs, D1) — recording the proposal and "
+                    "applying NOTHING this interval. Raise "
+                    "budget.n_k4_per_layer in the policy and restart to bank "
+                    "the headroom.", len(promotions), self._step)
+                self._promotion_apply_warned = True
             return False
         if self.apply_fn is None:
             if self.cfg.apply_mode == APPLY_ATOMIC and not self._atomic_warned:

--- a/vllm/model_executor/layers/quantization/exl3_fungible/loop.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/loop.py
@@ -377,11 +377,29 @@ class FqMetrics:
     def __init__(self, registry=None):
         import prometheus_client as pc
         kw = {} if registry is None else {"registry": registry}
-        self.swaps_total = pc.Counter(
-            "fq_swaps_total",
-            "Fungible-quant expert tier swaps decided per MoE layer "
-            "(proposals in dryrun mode, applied swaps otherwise).",
+        # PROPOSED and APPLIED are separate series on purpose. One counter
+        # covering both read "fq_swaps_total{layer=3} 2.0" on a serve where
+        # the apply path was not wired at all: 64 swaps decided, zero
+        # installed, and a dashboard that said the fungible loop was working.
+        # A metric an operator cannot distinguish from success IS a false
+        # success.
+        self.swap_proposals_total = pc.Counter(
+            "fq_swap_proposals_total",
+            "Fungible-quant expert tier swaps DECIDED per MoE layer. A "
+            "proposal is not a change: compare against "
+            "fq_swaps_applied_total.",
             ["layer"], **kw)
+        self.swaps_applied_total = pc.Counter(
+            "fq_swaps_applied_total",
+            "Fungible-quant expert tier swaps ACTUALLY INSTALLED per MoE "
+            "layer, counted only after the apply backend confirmed.",
+            ["layer"], **kw)
+        self.apply_bound = pc.Gauge(
+            "fq_apply_bound",
+            "1 when an apply backend is bound, 0 when the loop can only "
+            "record proposals. Zero here means no proposal can ever become "
+            "a change, however many are decided.",
+            multiprocess_mode="mostrecent", **kw)
         self.rollbacks_total = pc.Counter(
             "fq_rollbacks_total",
             "Fungible-quant probe-triggered policy rollbacks.", **kw)
@@ -551,7 +569,10 @@ class FungibleQuantState:
 
         if self.metrics is not None and self.is_lead:
             for layer in self.layers:
-                self.metrics.swaps_total.labels(layer=str(layer)).inc(0)
+                self.metrics.swap_proposals_total.labels(
+                    layer=str(layer)).inc(0)
+                self.metrics.swaps_applied_total.labels(
+                    layer=str(layer)).inc(0)
             self._export_occupancy()
             self._export_budget()
 
@@ -840,7 +861,8 @@ class FungibleQuantState:
 
         if self.is_lead:
             self._persist(record, proposed_doc, swaps or promotions)
-            self._export_metrics(record, swaps, jac)
+            self._export_metrics(record, swaps, jac,
+                                 applied=bool(record.get("applied")))
         return record
 
     # ---------------------------------------------------------------- apply
@@ -1097,12 +1119,16 @@ class FungibleQuantState:
         self._last_composition = cur
 
     def _export_metrics(self, record: dict, swaps: list,
-                        jac: float | None) -> None:
+                        jac: float | None, applied: bool = False) -> None:
         if self.metrics is None:
             return
         for layer, _, _ in swaps:
-            self.metrics.swaps_total.labels(
+            self.metrics.swap_proposals_total.labels(
                 layer=str(self.layers[layer])).inc()
+            if applied:
+                self.metrics.swaps_applied_total.labels(
+                    layer=str(self.layers[layer])).inc()
+        self.metrics.apply_bound.set(1 if self.apply_fn is not None else 0)
         if jac is not None:
             self.metrics.jaccard.set(jac)
         self.metrics.policy_age_steps.set(self._step - self._policy_step)

--- a/vllm/model_executor/layers/quantization/exl3_fungible/memory_preflight.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/memory_preflight.py
@@ -1,0 +1,176 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Project the progressive boot's weight footprint BEFORE loading anything.
+
+A mixed-K checkpoint's parameter footprint is fully determined by the tier
+bitmap, which is written before the engine starts. So "will this policy fit?"
+is arithmetic, not an experiment -- yet the failure mode we actually hit was
+a 62-minute load followed by::
+
+    Available KV cache memory: -3.1 GiB
+    ValueError: No available memory for the cache blocks.
+
+Sixty-two minutes to learn something computable in five seconds. This module
+does that arithmetic, and :func:`check_or_raise` runs it at the top of the
+progressive loader so an oversized policy is rejected while the operator can
+still do something about it.
+
+The projection is deliberately anchored on MEASURED per-K segment sizes rather
+than a bits-per-weight model: EXL3 experts carry fixed-size ``suh``/``svh``/
+``mcg`` companions alongside the K-proportional trellis, so "K4 is 4/3 of K3"
+is wrong by a few percent -- and a few percent of 64 GiB is the entire KV
+cache.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterable, Mapping
+
+GIB = 1 << 30
+
+
+class BudgetExceeded(RuntimeError):
+    """The policy's weights cannot leave room for a usable KV cache."""
+
+
+def project_expert_bytes(
+    bits_by_layer: Mapping[int, Iterable[int]],
+    expert_bytes_by_k: Mapping[int, int],
+) -> tuple[int, dict[int, int]]:
+    """Total expert bytes for one rank, plus the per-K expert census.
+
+    ``bits_by_layer`` maps layer -> per-expert K. Unknown Ks raise rather than
+    silently contributing zero: a policy referencing a K we cannot size is
+    exactly the case where a quiet under-estimate would green-light an OOM.
+    """
+    census: dict[int, int] = {}
+    total = 0
+    for layer, bits in bits_by_layer.items():
+        for k in bits:
+            k = int(k)
+            try:
+                total += expert_bytes_by_k[k]
+            except KeyError:
+                raise KeyError(
+                    f"layer {layer}: no measured expert size for K{k} "
+                    f"(have {sorted(expert_bytes_by_k)}) -- cannot project "
+                    f"the footprint, so cannot certify it fits"
+                ) from None
+            census[k] = census.get(k, 0) + 1
+    return total, census
+
+
+def project(
+    bits_by_layer: Mapping[int, Iterable[int]],
+    expert_bytes_by_k: Mapping[int, int],
+    dense_bytes: int,
+    *,
+    device_total_bytes: int,
+    gpu_memory_utilization: float,
+    runtime_overhead_bytes: int,
+    min_kv_bytes: int,
+) -> dict:
+    """Return the full projection. Pure arithmetic; no CUDA, no I/O."""
+    expert_bytes, census = project_expert_bytes(bits_by_layer, expert_bytes_by_k)
+    weights = expert_bytes + dense_bytes
+    budget = int(device_total_bytes * gpu_memory_utilization)
+    kv = budget - weights - runtime_overhead_bytes
+    return {
+        "expert_bytes": expert_bytes,
+        "dense_bytes": dense_bytes,
+        "weight_bytes": weights,
+        "budget_bytes": budget,
+        "runtime_overhead_bytes": runtime_overhead_bytes,
+        "projected_kv_bytes": kv,
+        "min_kv_bytes": min_kv_bytes,
+        "fits": kv >= min_kv_bytes,
+        "shortfall_bytes": max(0, min_kv_bytes - kv),
+        "census": census,
+        "experts": sum(census.values()),
+    }
+
+
+def headroom_in_promotions(
+    proj: dict, expert_bytes_by_k: Mapping[int, int], low_k: int, high_k: int
+) -> int:
+    """How many low_k->high_k promotions the shortfall is worth.
+
+    An operator staring at "3.4 GiB over" cannot act on it. "demote 3,094
+    experts from K4 to K3" is an instruction.
+    """
+    step = expert_bytes_by_k[high_k] - expert_bytes_by_k[low_k]
+    if step <= 0:
+        return 0
+    return -(-proj["shortfall_bytes"] // step)  # ceil
+
+
+def render(proj: dict, expert_bytes_by_k: Mapping[int, int]) -> list[str]:
+    g = lambda b: f"{b / GIB:8.2f} GiB"  # noqa: E731
+    census = ", ".join(
+        f"K{k}={n:,}" for k, n in sorted(proj["census"].items())
+    )
+    lines = [
+        "FQ memory preflight (per rank, projected from the tier bitmap):",
+        f"    experts        {g(proj['expert_bytes'])}   "
+        f"({proj['experts']:,} experts: {census})",
+        f"    non-expert     {g(proj['dense_bytes'])}",
+        f"    weights total  {g(proj['weight_bytes'])}",
+        f"    runtime overhd {g(proj['runtime_overhead_bytes'])}   "
+        f"(allocator + activations + graphs)",
+        f"    device budget  {g(proj['budget_bytes'])}",
+        f"    => KV cache    {g(proj['projected_kv_bytes'])}   "
+        f"(need >= {g(proj['min_kv_bytes'])})",
+    ]
+    if not proj["fits"]:
+        ks = sorted(expert_bytes_by_k)
+        lines.append(
+            f"    SHORT BY       {g(proj['shortfall_bytes'])}"
+        )
+        for hi in reversed(ks[1:]):
+            lo = ks[ks.index(hi) - 1]
+            if proj["census"].get(hi):
+                n = headroom_in_promotions(proj, expert_bytes_by_k, lo, hi)
+                lines.append(
+                    f"    remedy         demote {n:,} experts K{hi}->K{lo} "
+                    f"(or raise --gpu-memory-utilization)"
+                )
+                break
+    return lines
+
+
+def _env_bytes(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if not raw:
+        return default
+    raw = raw.strip().lower()
+    mult = 1
+    if raw.endswith("g") or raw.endswith("gib"):
+        mult, raw = GIB, raw.rstrip("bi").rstrip("g")
+    elif raw.endswith("m") or raw.endswith("mib"):
+        mult, raw = 1 << 20, raw.rstrip("bi").rstrip("m")
+    return int(float(raw) * mult)
+
+
+def check_or_raise(proj: dict, expert_bytes_by_k: Mapping[int, int], log) -> None:
+    """Log the projection; raise :class:`BudgetExceeded` if it cannot fit.
+
+    ``VLLM_FQ_BUDGET_ENFORCE=0`` downgrades the raise to a warning -- for the
+    case where the operator knows the overhead estimate is pessimistic and
+    wants the engine's own profiler to have the final say.
+    """
+    for line in render(proj, expert_bytes_by_k):
+        log(line)
+    if proj["fits"]:
+        return
+    msg = (
+        f"FQ memory preflight FAILED: projected KV cache "
+        f"{proj['projected_kv_bytes'] / GIB:.2f} GiB is below the "
+        f"{proj['min_kv_bytes'] / GIB:.2f} GiB floor "
+        f"(short by {proj['shortfall_bytes'] / GIB:.2f} GiB). "
+        f"Refusing to spend a full model load on a policy that cannot serve. "
+        f"Set VLLM_FQ_BUDGET_ENFORCE=0 to try anyway."
+    )
+    if os.environ.get("VLLM_FQ_BUDGET_ENFORCE", "1") == "0":
+        log("WARNING: " + msg + " [enforcement disabled]")
+        return
+    raise BudgetExceeded(msg)

--- a/vllm/model_executor/layers/quantization/exl3_fungible/occupancy_table.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/occupancy_table.py
@@ -1,0 +1,147 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Human-readable expert-composition matrix for the engine log.
+
+An operator watching a fungible-quant serve needs to answer one question at a
+glance: *which experts are currently held at which bitrate, and what changed
+since last time?* The Prometheus gauge ``fq_tier_occupancy{layer,tier}``
+carries the same numbers, but a scrape target is not something you can eyeball
+in a terminal at 3am, and it does not remember what the previous shape was.
+
+So: a layer x K-tier table, printed once at startup (the composition the
+checkpoint booted with) and periodically thereafter, with the delta against
+the previous print called out explicitly.
+
+Periodic prints are DIFF-ONLY by default. GLM-5.2 has 90+ MoE layers, and
+dumping a 90-row table every interval would bury the log — the thing an
+operator actually wants is "these three layers moved, everything else is
+where you left it".
+"""
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+# Tier columns we render. Fixed and explicit rather than derived from the
+# data, so a tier dropping to zero experts still shows as a 0 column instead
+# of silently vanishing from the table.
+TIERS: tuple[int, ...] = (2, 3, 4, 5)
+
+
+def _fmt_delta(cur: Mapping[int, int], prev: Mapping[int, int] | None) -> str:
+    if prev is None:
+        return ""
+    parts = []
+    for k in TIERS:
+        d = int(cur.get(k, 0)) - int(prev.get(k, 0))
+        if d:
+            parts.append(f"{d:+d} K{k}")
+    return " / ".join(parts)
+
+
+def render(
+    occupancy: Mapping[int, Mapping[int, int]],
+    previous: Mapping[int, Mapping[int, int]] | None = None,
+    *,
+    num_experts: int | None = None,
+    title: str = "expert composition",
+    diff_only: bool = False,
+    max_rows: int = 128,
+) -> str:
+    """Render ``{layer: {k: count}}`` as a table.
+
+    ``previous`` enables the change column. ``diff_only`` restricts rows to
+    layers whose composition actually moved (the totals line always covers
+    every layer, changed or not, so the summary stays truthful).
+    """
+    if not occupancy:
+        return f"FQ {title}: no MoE layers instrumented"
+
+    layers = sorted(int(x) for x in occupancy.keys())
+    norm: dict[int, dict[int, int]] = {
+        int(l): {int(k): int(v) for k, v in occupancy[l].items()}
+        for l in occupancy
+    }
+    pnorm: dict[int, dict[int, int]] | None = None
+    if previous:
+        pnorm = {int(l): {int(k): int(v) for k, v in previous[l].items()}
+                 for l in previous}
+
+    changed = set()
+    if pnorm is not None:
+        for l in layers:
+            if norm.get(l, {}) != pnorm.get(l, {}):
+                changed.add(l)
+
+    shown = [l for l in layers if l in changed] if diff_only else layers
+    omitted_note = ""
+    if diff_only:
+        if not shown:
+            # Say it plainly. A silent "no table" reads as "telemetry broke".
+            return (f"FQ {title}: no tier changes across {len(layers)} layers "
+                    f"(totals {_totals_str(norm)})")
+        omitted_note = (f"  ({len(layers) - len(shown)} unchanged layers "
+                        f"omitted)")
+    truncated = 0
+    if len(shown) > max_rows:
+        truncated = len(shown) - max_rows
+        shown = shown[:max_rows]
+
+    head = f"FQ {title}: {len(layers)} MoE layers"
+    if num_experts:
+        head += f" x {num_experts} experts"
+    head += omitted_note
+
+    lines = [head]
+    cols = "".join(f"{'K'+str(k):>7}" for k in TIERS)
+    lines.append(f"  {'layer':>5} |{cols} |  change")
+    lines.append(f"  {'-'*5}-+{'-'*(7*len(TIERS))}-+{'-'*20}")
+    for l in shown:
+        row = norm.get(l, {})
+        cells = "".join(f"{row.get(k, 0):>7}" for k in TIERS)
+        mark = _fmt_delta(row, pnorm.get(l) if pnorm else None)
+        flag = "*" if l in changed else " "
+        lines.append(f"  {l:>5}{flag}|{cells} | {mark}")
+    if truncated:
+        lines.append(f"  ... {truncated} more rows suppressed "
+                     f"(max_rows={max_rows})")
+    lines.append(f"  {'-'*5}-+{'-'*(7*len(TIERS))}-+{'-'*20}")
+    tot = {k: sum(norm[l].get(k, 0) for l in layers) for k in TIERS}
+    ptot = None
+    if pnorm is not None:
+        ptot = {k: sum(pnorm.get(l, {}).get(k, 0) for l in layers)
+                for k in TIERS}
+    cells = "".join(f"{tot[k]:>7}" for k in TIERS)
+    lines.append(f"  {'total':>5} |{cells} | {_fmt_delta(tot, ptot)}")
+
+    # Mean bits/expert is the one number that says whether the fleet got more
+    # accurate or cheaper overall; it is what the fixed-cardinality invariant
+    # is supposed to hold roughly constant.
+    n = sum(tot.values())
+    if n:
+        mean_bits = sum(k * tot[k] for k in TIERS) / n
+        extra = ""
+        if ptot and sum(ptot.values()):
+            pm = sum(k * ptot[k] for k in TIERS) / sum(ptot.values())
+            extra = f" ({mean_bits - pm:+.4f})"
+        lines.append(f"  mean bits/expert: {mean_bits:.4f}{extra}")
+    return "\n".join(lines)
+
+
+def _totals_str(norm: Mapping[int, Mapping[int, int]]) -> str:
+    tot = {k: sum(int(r.get(k, 0)) for r in norm.values()) for k in TIERS}
+    return " ".join(f"K{k}={tot[k]}" for k in TIERS if tot[k])
+
+
+def from_membership(membership, layer_ids, bits=(3, 4)) -> dict:
+    """Build ``{layer: {k: count}}`` from a boolean tier-1 membership array.
+
+    ``membership[i][e]`` true means expert ``e`` of ``layer_ids[i]`` sits in
+    the HIGH tier (``bits[1]``), false the low tier (``bits[0]``). This is the
+    representation the policy engine works in.
+    """
+    lo, hi = bits
+    out: dict[int, dict[int, int]] = {}
+    for i, layer in enumerate(layer_ids):
+        row = membership[i]
+        n_hi = int(sum(1 for v in row if v))
+        out[int(layer)] = {lo: int(len(row)) - n_hi, hi: n_hi}
+    return out

--- a/vllm/model_executor/layers/quantization/exl3_fungible/occupancy_table.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/occupancy_table.py
@@ -26,6 +26,80 @@ from collections.abc import Mapping
 TIERS: tuple[int, ...] = (2, 3, 4, 5)
 
 
+def format_bytes(n: int | float | None) -> str:
+    """Binary-unit byte size, matching how the budget knob is spelled."""
+    if n is None:
+        return "unbounded"
+    neg = "-" if n < 0 else ""
+    n = abs(float(n))
+    for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
+        if n < 1024.0 or unit == "TiB":
+            return (f"{neg}{int(n)} {unit}" if unit == "B"
+                    else f"{neg}{n:.2f} {unit}")
+        n /= 1024.0
+    return f"{neg}{n:.2f} TiB"  # pragma: no cover - loop always returns
+
+
+def budget_lines(budget: Mapping | None) -> list[str]:
+    """Footer for the composition table: ceiling, actual use, headroom.
+
+    ``budget`` is :meth:`policy.MemoryBudget.summary` output. The
+    per-expert byte figures and — importantly — WHERE THEY CAME FROM are
+    printed with it: a headroom number is only as trustworthy as the
+    geometry it was computed from, so the source never travels separately
+    from the number.
+    """
+    if not budget:
+        return []
+    used = int(budget.get("used_bytes", 0))
+    limit = budget.get("limit_bytes")
+    out: list[str] = []
+    if limit is None:
+        out.append(f"  memory: {format_bytes(used)} used "
+                   f"(no byte budget set — fixed cardinality only)")
+    else:
+        limit = int(limit)
+        pct = (100.0 * used / limit) if limit else 0.0
+        head = budget.get("headroom_bytes")
+        promos = budget.get("headroom_promotions")
+        if head is not None and head < 0:
+            out.append(
+                f"  memory budget: {format_bytes(limit)} | used "
+                f"{format_bytes(used)} ({pct:.1f}%) | OVER BUDGET by "
+                f"{format_bytes(-head)}")
+        else:
+            out.append(
+                f"  memory budget: {format_bytes(limit)} | used "
+                f"{format_bytes(used)} ({pct:.1f}%) | headroom "
+                f"{format_bytes(head)}"
+                + ("" if promos is None
+                   else f" = {promos} more K3->K4 promotions"))
+    per_k = budget.get("per_k_bytes") or {}
+    if per_k:
+        cells = " ".join(f"K{k}={int(v)}" for k, v in sorted(
+            (int(a), b) for a, b in per_k.items()))
+        out.append(f"  bytes/expert/rank: {cells}")
+    src = budget.get("source")
+    if src:
+        flag = "REFERENCE (not this checkpoint!) " if budget.get(
+            "is_reference") else ""
+        out.append(f"  byte model: {flag}{src}")
+    return out
+
+
+def _budget_oneline(budget: Mapping | None) -> str:
+    """Compact form for the paths that return a single line."""
+    if not budget:
+        return ""
+    limit = budget.get("limit_bytes")
+    used = format_bytes(int(budget.get("used_bytes", 0)))
+    if limit is None:
+        return f", {used} used, no byte budget"
+    promos = budget.get("headroom_promotions")
+    return (f", {used}/{format_bytes(int(limit))} used"
+            + ("" if promos is None else f", headroom {promos} promotions"))
+
+
 def _fmt_delta(cur: Mapping[int, int], prev: Mapping[int, int] | None) -> str:
     if prev is None:
         return ""
@@ -45,15 +119,20 @@ def render(
     title: str = "expert composition",
     diff_only: bool = False,
     max_rows: int = 128,
+    budget: Mapping | None = None,
 ) -> str:
     """Render ``{layer: {k: count}}`` as a table.
 
     ``previous`` enables the change column. ``diff_only`` restricts rows to
     layers whose composition actually moved (the totals line always covers
     every layer, changed or not, so the summary stays truthful).
+    ``budget`` (``policy.MemoryBudget.summary`` output) appends the memory
+    ceiling, the footprint the shown occupancy actually costs, and the
+    remaining promotion headroom.
     """
     if not occupancy:
-        return f"FQ {title}: no MoE layers instrumented"
+        return (f"FQ {title}: no MoE layers instrumented"
+                + _budget_oneline(budget))
 
     layers = sorted(int(x) for x in occupancy.keys())
     norm: dict[int, dict[int, int]] = {
@@ -77,7 +156,7 @@ def render(
         if not shown:
             # Say it plainly. A silent "no table" reads as "telemetry broke".
             return (f"FQ {title}: no tier changes across {len(layers)} layers "
-                    f"(totals {_totals_str(norm)})")
+                    f"(totals {_totals_str(norm)})" + _budget_oneline(budget))
         omitted_note = (f"  ({len(layers) - len(shown)} unchanged layers "
                         f"omitted)")
     truncated = 0
@@ -123,6 +202,7 @@ def render(
             pm = sum(k * ptot[k] for k in TIERS) / sum(ptot.values())
             extra = f" ({mean_bits - pm:+.4f})"
         lines.append(f"  mean bits/expert: {mean_bits:.4f}{extra}")
+    lines.extend(budget_lines(budget))
     return "\n".join(lines)
 
 

--- a/vllm/model_executor/layers/quantization/exl3_fungible/policy.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/policy.py
@@ -1,0 +1,189 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Fungible-quant policy engine prototype — pure NumPy, CPU-only, deterministic.
+
+Implements the decision function of research/fungible-quant/implementation/ (vllm-voipmonitor research branch) 
+01-artifacts-policy-stats.md §3 (score -> desired set -> symmetric difference
+-> guards -> ordered swap list), plus apply/inverse helpers and the §1.2
+projection of a policy with different N_L onto the running cardinality.
+
+Domain conventions
+------------------
+- All arrays are [L, E] (num MoE layers x num logical experts per layer).
+- Tiers are the literal K values: 3 (base) and 4 (overlay).
+- ``pins[l, e]``: 0 = free, 3 = pinned to K3 (never upgraded), 4 = pinned to
+  K4 (never downgraded; forced into the desired set).
+- ``dwell[l, e]``: steps the expert has been resident in its *current* tier.
+- A swap is ``(layer, e_out, e_in)``: e_out K4->K3, e_in K3->K4.
+
+Determinism: only stable sorts with total-order keys (score, then expert id);
+no dict iteration over unordered inputs; pure functions of the arguments.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+
+K3, K4 = 3, 4
+PIN_NONE, PIN_K3, PIN_K4 = 0, 3, 4
+
+DEFAULT_CFG = {
+    "alpha": 1.0,           # count exponent   (free parameter until Phase 0a)
+    "beta": 1.0,            # gate-mass exponent (free parameter until Phase 0a)
+    "hysteresis": 1.25,     # VLLM_FQ_HYSTERESIS
+    "dwell_steps": 6000,    # VLLM_FQ_DWELL_STEPS (2 x interval default)
+    "max_swaps_per_layer": 2,   # VLLM_FQ_MAX_SWAPS_LAYER
+    "max_swaps_total": 64,      # VLLM_FQ_MAX_SWAPS_TOTAL
+}
+
+
+def _full_cfg(cfg):
+    out = dict(DEFAULT_CFG)
+    out.update(cfg or {})
+    if "n_k4" not in out:
+        raise ValueError("cfg must provide 'n_k4' (per-layer K4 cardinality)")
+    return out
+
+
+def _as_eps(eps, L, E):
+    """Accept eps as {3: [L,E], 4: [L,E]} or an [L,E,2] array -> (eps3, eps4)."""
+    if isinstance(eps, dict):
+        e3 = np.asarray(eps[K3], dtype=np.float64)
+        e4 = np.asarray(eps[K4], dtype=np.float64)
+    else:
+        arr = np.asarray(eps, dtype=np.float64)
+        if arr.shape != (L, E, 2):
+            raise ValueError(f"eps must be [L,E,2] or {{3:..,4:..}}, got {arr.shape}")
+        e3, e4 = arr[..., 0], arr[..., 1]
+    if e3.shape != (L, E) or e4.shape != (L, E):
+        raise ValueError("eps arrays must be [L,E]")
+    return e3, e4
+
+
+def score(stats, eps, cfg=None):
+    """score[l,e] = (eps_k3 - eps_k4) * mass**beta * count**alpha  (spec §3.2)."""
+    cfg = dict(DEFAULT_CFG, **(cfg or {}))
+    count = np.asarray(stats["count"], dtype=np.float64)
+    mass = np.asarray(stats["mass"], dtype=np.float64)
+    L, E = count.shape
+    e3, e4 = _as_eps(eps, L, E)
+    with np.errstate(invalid="ignore"):
+        s = (e3 - e4) * np.power(mass, cfg["beta"]) * np.power(count, cfg["alpha"])
+    return np.nan_to_num(s, nan=0.0, posinf=0.0, neginf=0.0)
+
+
+def n_k4_of(tier_of):
+    """Per-layer K4 occupancy of a membership array."""
+    return (np.asarray(tier_of) == K4).sum(axis=1)
+
+
+def decide(stats, eps, tier_of, pins=None, dwell=None, cfg=None):
+    """Compute the ordered swap list for one policy interval (spec §3.2).
+
+    Returns [(layer, e_out, e_in), ...] sorted by (layer, score-gap desc, ids).
+    Pin-forced pairs bypass dwell/hysteresis for the forced member and sort
+    ahead of free pairs under the caps.
+    """
+    cfg = _full_cfg(cfg)
+    tier_of = np.asarray(tier_of)
+    L, E = tier_of.shape
+    s = score(stats, eps, cfg)
+    n_k4 = np.broadcast_to(np.asarray(cfg["n_k4"], dtype=np.int64), (L,))
+    pins = np.zeros((L, E), dtype=np.int64) if pins is None else np.asarray(pins)
+    if dwell is None:
+        dwell_ok = np.ones((L, E), dtype=bool)
+    else:
+        dwell_ok = np.asarray(dwell) >= cfg["dwell_steps"]
+    h = float(cfg["hysteresis"])
+
+    candidates = []  # (gap, layer, e_out, e_in)
+    for l in range(L):
+        cur = tier_of[l] == K4
+        if int(cur.sum()) != int(n_k4[l]):
+            raise ValueError(
+                f"layer {l}: membership has {int(cur.sum())} K4, budget is "
+                f"{int(n_k4[l])} — project() the policy first (D1)")
+        pin4 = pins[l] == PIN_K4
+        pin3 = pins[l] == PIN_K3
+        if int(pin4.sum()) > int(n_k4[l]) or E - int(pin3.sum()) < int(n_k4[l]):
+            raise ValueError(f"layer {l}: pins incompatible with budget")
+
+        # Desired set: pinned-K4 forced in, pinned-K3 forced out, rest by score.
+        desired = pin4.copy()
+        slots = int(n_k4[l] - pin4.sum())
+        free_order = np.lexsort((np.arange(E), -s[l]))  # score desc, id asc
+        for e in free_order:
+            if slots == 0:
+                break
+            if not pin4[e] and not pin3[e]:
+                desired[e] = True
+                slots -= 1
+
+        # Symmetric difference -> paired swap candidates.
+        enter = sorted(np.nonzero(desired & ~cur)[0],
+                       key=lambda e: (not pin4[e], -s[l, e], e))
+        leave = sorted(np.nonzero(cur & ~desired)[0],
+                       key=lambda e: (not pin3[e], s[l, e], e))
+        layer_pairs = []
+        for e_in, e_out in zip(enter, leave):
+            forced_in, forced_out = bool(pin4[e_in]), bool(pin3[e_out])
+            # Guard 1 — dwell (forced member exempt, its counterpart is not).
+            if not forced_in and not dwell_ok[l, e_in]:
+                continue
+            if not forced_out and not dwell_ok[l, e_out]:
+                continue
+            # Guard 2 — hysteresis (waived when either side is pin-forced).
+            if not (forced_in or forced_out) and not (s[l, e_in] > h * s[l, e_out]):
+                continue
+            gap = math.inf if (forced_in or forced_out) else float(s[l, e_in] - s[l, e_out])
+            layer_pairs.append((gap, l, int(e_out), int(e_in)))
+        # Guard 3a — per-layer cap, highest score-gap first.
+        layer_pairs.sort(key=lambda p: (-p[0], p[2], p[3]))
+        candidates.extend(layer_pairs[: int(cfg["max_swaps_per_layer"])])
+
+    # Guard 3b — model-wide cap, highest score-gap first, deterministic ties.
+    candidates.sort(key=lambda p: (-p[0], p[1], p[2], p[3]))
+    candidates = candidates[: int(cfg["max_swaps_total"])]
+    # Guard 4 — emit ordered swap list.
+    candidates.sort(key=lambda p: (p[1], -p[0], p[2], p[3]))
+    return [(l, e_out, e_in) for _, l, e_out, e_in in candidates]
+
+
+def apply_swaps(tier_of, swaps):
+    """Apply an ordered swap list to a membership array (returns a copy)."""
+    out = np.array(tier_of, copy=True)
+    for l, e_out, e_in in swaps:
+        if out[l, e_out] != K4 or out[l, e_in] != K3:
+            raise ValueError(f"invalid swap ({l}, {e_out}, {e_in}) for current tiers")
+        out[l, e_out] = K3
+        out[l, e_in] = K4
+    return out
+
+
+def inverse(swaps):
+    """Inverse swap list: applying swaps then inverse(swaps) is identity (§3.3)."""
+    return [(l, e_in, e_out) for (l, e_out, e_in) in reversed(swaps)]
+
+
+def project(bits_per_expert, n_k4, order=None):
+    """Project a policy's membership onto the running cardinality (spec §1.2).
+
+    ``bits_per_expert``: [L,E] ints in {3,4} from the policy artifact.
+    ``n_k4``: running per-layer budget (scalar or [L]).
+    ``order``: optional [L,E] ranking (the policy's own ordering, e.g. its
+    scores); higher = more deserving of K4. Defaults to expert-id order.
+    Take the policy's top-N_L per layer: its K4 members first (by order),
+    then, if the running budget is larger, the best of its K3 members.
+    """
+    bits = np.asarray(bits_per_expert)
+    L, E = bits.shape
+    n_k4 = np.broadcast_to(np.asarray(n_k4, dtype=np.int64), (L,))
+    order = np.zeros((L, E)) if order is None else np.asarray(order, dtype=np.float64)
+    out = np.full((L, E), K3, dtype=bits.dtype)
+    for l in range(L):
+        is4 = (bits[l] == K4).astype(np.int64)
+        rank = np.lexsort((np.arange(E), -order[l], -is4))  # K4 first, then order desc, id asc
+        out[l, rank[: int(n_k4[l])]] = K4
+    return out

--- a/vllm/model_executor/layers/quantization/exl3_fungible/policy.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/policy.py
@@ -764,6 +764,16 @@ def budget_filter(swaps: list, tier_of, budget: MemoryBudget | None,
     Applied to the ORDERED list cumulatively, so the surviving prefix is
     affordable *together*, not merely one at a time.
 
+    A swap that does not GROW the pool (``delta <= 0``) is always
+    admitted, including when the occupancy is already over the ceiling.
+    Refusing those would be a deadlock, not a guard: every executable
+    swap on the K3/K4 ladder is byte-neutral, so an over-budget pool
+    would never be allowed to re-tier again — and, because demotions
+    only ever happen paired with a promotion, its occupancy could never
+    come back down either. The ceiling is a bound on growth; a
+    non-increasing move cannot violate it any harder than the state it
+    started from.
+
     Returns ``(kept, rejections)``; each rejection is a
     :meth:`BudgetVerdict.as_dict` carrying budget/current/requested/
     overshoot.
@@ -777,7 +787,7 @@ def budget_filter(swaps: list, tier_of, budget: MemoryBudget | None,
     for l, e_out, e_in in swaps:
         delta = swap_byte_delta(tier_of, l, e_out, e_in, budget)
         requested = used + delta
-        if requested <= budget.limit_bytes:
+        if delta <= 0 or requested <= budget.limit_bytes:
             used = requested
             kept.append((l, e_out, e_in))
         else:
@@ -792,6 +802,27 @@ def budget_filter(swaps: list, tier_of, budget: MemoryBudget | None,
                 kind="swap", layer=int(l), expert_in=int(e_in),
                 expert_out=int(e_out)).as_dict())
     return kept, rejections
+
+
+def swap_touched(swaps: Iterable[tuple[int, int, int]]
+                 ) -> list[tuple[int, int]]:
+    """Every ``(layer, expert)`` an ordered swap list moves — BOTH sides.
+
+    ``plan_promotions`` must exclude all of them, not just the entering
+    ones. ``decide`` demotes the weakest K4 resident, but "weakest of the
+    incumbents" is routinely still stronger than the best K3 expert
+    elsewhere, so a promotion planner ranking on raw score will pick that
+    expert straight back up in the SAME interval. The result is not
+    merely churn: the emitted swap list says ``e_out -> K3`` while the
+    proposed membership says ``e_out`` is still K4, so the instruction
+    handed to the apply backend contradicts the state the loop then
+    records. One expert moves once per interval, or not at all.
+    """
+    out: list[tuple[int, int]] = []
+    for l, e_out, e_in in swaps:
+        out.append((int(l), int(e_out)))
+        out.append((int(l), int(e_in)))
+    return out
 
 
 def apply_promotions(tier_of, promotions: Iterable[tuple[int, int]],
@@ -916,7 +947,7 @@ def decide_with_budget(
     swaps, rejections = budget_filter(swaps, tier_of, budget)
     promotions: list[tuple[int, int]] = []
     if allow_promotions:
-        touched = [(l, e_in) for l, _, e_in in swaps]
+        touched = swap_touched(swaps)
         promotions, prej = plan_promotions(
             stats, eps, apply_swaps(tier_of, swaps), budget, pins=pins,
             dwell=dwell, cfg=cfg, exclude=touched)

--- a/vllm/model_executor/layers/quantization/exl3_fungible/policy.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/policy.py
@@ -450,20 +450,43 @@ class ExpertBytes:
                    f"{provenance} (K{k} tensor table, {seen} tensors)", (k,))
 
 
-# Measured on the live GLM-5.2 serve (TP4, SM120), one MoE expert:
-#   K3 = 14,168,112 B across all 4 ranks -> 3,542,028 B per rank
-#   K4 = 18,886,704 B across all 4 ranks -> 4,721,676 B per rank
+# Measured on the assembled GLM-5.2 checkpoint (H=6144, moe_intermediate
+# 2048 -> 512 per rank at TP4, SM120) by summing the safetensors
+# ``data_offsets`` spans of ONE (expert, rank) — the same quantity
+# ``from_tensor_table`` computes, so the two constructors of this class
+# agree on the same checkpoint:
+#
+#   3 x trellis   [384,32,16K] / [32,384,16K] int16   1,179,648 B per K
+#   gate suh/svh  (6144,) + (512,)                   12,288 + 1,024 B
+#   up   suh/svh  (6144,) + (512,)                   12,288 + 1,024 B
+#   down suh/svh  (512,)  + (6144,)                   1,024 + 12,288 B
+#   3 x mcg       ()                                          12 B
+#                                                  fixed  39,948 B
+#
+#   K3 = 14,315,568 B across all 4 ranks -> 3,578,892 B per rank
+#   K4 = 19,034,160 B across all 4 ranks -> 4,758,540 B per rank
+#
 # so a K3->K4 promotion costs 1,179,648 B per rank. Those two points fit
-# the affine model above exactly (slope 1,179,648 B/K, fixed 3,084 B),
+# the affine model above exactly (slope 1,179,648 B/K, fixed 39,948 B),
 # and K2/K5 are then EVALUATED from it rather than guessed:
-#   K2 = 2,362,380 B/rank (9,449,520 across TP4)
-#   K5 = 5,901,324 B/rank (23,605,296 across TP4)
+#   K2 = 2,399,244 B/rank (9,596,976 across TP4)
+#   K5 = 5,938,188 B/rank (23,752,752 across TP4)
+# The K5 figure is not merely evaluated — glm52-mixed-k3k5 carries real
+# K5 experts and they measure 5,938,188 B/rank exactly, which is the
+# affine model confirmed on a third bitrate.
+#
 # The same construction was validated end-to-end against two real
 # checkpoints of the small GLM-5.2-arch proxy: deriving the model from
 # fruit-k3's header alone predicts fruit-k4's measured 814,128 B/expert
 # to the byte (see test_memory_budget_cpu.py).
-MEASURED_GLM52_TP4_PER_RANK: dict[int, int] = {K3: 3_542_028, K4: 4_721_676}
-MEASURED_GLM52_TP4_ALL_RANKS: dict[int, int] = {K3: 14_168_112, K4: 18_886_704}
+#
+# An earlier revision of these constants (K3 3,542,028 / K4 4,721,676)
+# dropped the three 12,288 B suh/svh vectors, understating every expert
+# by 36,864 B per rank — 0.67 GiB per rank across 76 x 256 experts. The
+# slope survived that error because it is K-independent overhead, which
+# is exactly why the fixed term needs a test of its own.
+MEASURED_GLM52_TP4_PER_RANK: dict[int, int] = {K3: 3_578_892, K4: 4_758_540}
+MEASURED_GLM52_TP4_ALL_RANKS: dict[int, int] = {K3: 14_315_568, K4: 19_034_160}
 
 
 def reference_expert_bytes(*, per_rank: bool = True) -> ExpertBytes:

--- a/vllm/model_executor/layers/quantization/exl3_fungible/policy.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/policy.py
@@ -23,10 +23,14 @@ no dict iteration over unordered inputs; pure functions of the arguments.
 from __future__ import annotations
 
 import math
+import re
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping, Sequence
 
 import numpy as np
 
-K3, K4 = 3, 4
+K2, K3, K4, K5 = 2, 3, 4, 5
+K_UNIVERSE = (K2, K3, K4, K5)
 PIN_NONE, PIN_K3, PIN_K4 = 0, 3, 4
 
 DEFAULT_CFG = {
@@ -187,3 +191,734 @@ def project(bits_per_expert, n_k4, order=None):
         rank = np.lexsort((np.arange(E), -order[l], -is4))  # K4 first, then order desc, id asc
         out[l, rank[: int(n_k4[l])]] = K4
     return out
+
+
+# =====================================================================
+# Memory budget — bytes <-> experts/bpw/layer
+# =====================================================================
+# The fixed-cardinality budget above (``n_k4``) is a PROXY for memory: it
+# holds the expert pool's footprint constant by construction, because a
+# 1-for-1 K3<->K4 trade is byte-neutral. It cannot express what an
+# operator actually wants to say, which is "stay under N bytes on this
+# device". This section adds that, and — crucially — makes the two
+# representations inter-convertible so a byte ceiling can be read back as
+# "how many experts per layer may sit at K4".
+#
+# Everything here is per DEVICE (i.e. per TP rank), because that is the
+# thing a byte ceiling is actually bounded by and the thing
+# ``gpu_memory_utilization`` is a fraction of.
+
+_SIZE_SPEC_RE = re.compile(r"^([0-9]*\.?[0-9]+)([a-z%]*)$")
+
+# Binary multipliers throughout: an operator writing "78g" for a device
+# with 79.6 GiB free means gibibytes, and mixing SI and binary in one
+# knob is how you end up 7% over the line.
+_SIZE_UNITS: dict[str, int] = {
+    "": 1, "b": 1,
+    "k": 1 << 10, "kb": 1 << 10, "kib": 1 << 10,
+    "m": 1 << 20, "mb": 1 << 20, "mib": 1 << 20,
+    "g": 1 << 30, "gb": 1 << 30, "gib": 1 << 30,
+    "t": 1 << 40, "tb": 1 << 40, "tib": 1 << 40,
+}
+_BUDGET_OFF = ("", "none", "off", "unlimited", "unbounded")
+
+# The "experts/bpw per layer" spellings of the same ceiling — see
+# MemoryBudget.from_spec, which converts them to bytes.
+_PER_LAYER_RE = re.compile(r"^([0-9]+)(?:experts?)?/layer$")
+_BPW_RE = re.compile(r"^([0-9]*\.?[0-9]+)bpw$")
+
+
+def parse_memory_budget(spec, *, device_total_bytes: int | None = None
+                        ) -> int | None:
+    """Resolve a memory-budget spec to an absolute byte count.
+
+    Accepted forms, mirroring ``--gpu-memory-utilization`` ergonomics so
+    the operator has one mental model for "how much of the card may this
+    use":
+
+    - ``None`` / ``""`` / ``"none"`` / ``"off"`` / ``"unlimited"`` -> None
+      (no byte ceiling; the fixed-cardinality budget alone applies).
+    - an explicit size: ``"78g"``, ``"78GiB"``, ``"80000000000"``,
+      ``"512mb"``, ``"1b"``. Suffixes are BINARY (1g == 1 GiB).
+    - a fraction of device memory: ``"0.80"`` or ``"80%"``. A bare number
+      in ``(0, 1]`` is read as a fraction — exactly like
+      ``gpu_memory_utilization`` — so ``"1"`` means the whole device and
+      one single byte must be written ``"1b"``.
+
+    ``device_total_bytes`` is required for the fractional forms; without
+    it they raise rather than silently guessing a device size.
+    """
+    if spec is None:
+        return None
+    if isinstance(spec, bool):
+        raise ValueError(f"memory budget must be a size or fraction, got {spec!r}")
+    if isinstance(spec, (int, float)):
+        num, unit = float(spec), ""
+    else:
+        s = str(spec).strip().lower().replace("_", "").replace(" ", "")
+        if s in _BUDGET_OFF:
+            return None
+        m = _SIZE_SPEC_RE.match(s)
+        if m is None:
+            raise ValueError(
+                f"unparseable memory budget {spec!r}: want a size "
+                f"('78g', '80000000000', '512mib'), a fraction of device "
+                f"memory ('0.80', '80%'), or 'none'")
+        num, unit = float(m.group(1)), m.group(2)
+
+    if unit == "%":
+        frac = num / 100.0
+    elif unit == "":
+        # gpu-memory-utilization semantics: (0, 1] is a fraction, above 1
+        # is an absolute byte count.
+        frac = num if 0.0 < num <= 1.0 else None
+        if frac is None:
+            if num <= 0:
+                raise ValueError(
+                    f"memory budget must be positive, got {spec!r}")
+            return int(num)
+    else:
+        mult = _SIZE_UNITS.get(unit)
+        if mult is None:
+            raise ValueError(
+                f"unknown size unit {unit!r} in memory budget {spec!r}; "
+                f"known: {', '.join(sorted(u for u in _SIZE_UNITS if u))}")
+        if num <= 0:
+            raise ValueError(f"memory budget must be positive, got {spec!r}")
+        return int(num * mult)
+
+    if not 0.0 < frac <= 1.0:
+        raise ValueError(
+            f"fractional memory budget {spec!r} resolves to {frac} — must "
+            f"be in (0, 1]")
+    if device_total_bytes is None:
+        raise ValueError(
+            f"memory budget {spec!r} is a fraction of device memory, but no "
+            f"device total is available (no CUDA device visible?) — give an "
+            f"absolute size such as '78g' instead")
+    return int(frac * int(device_total_bytes))
+
+
+@dataclass(frozen=True)
+class ExpertBytes:
+    """How many bytes ONE expert occupies at a given K, on ONE rank.
+
+    The exl3 trellis layout makes this exactly affine in K. An expert is
+    three projections; each projection's ``trellis`` tensor has shape
+    ``[H/16, I/16, 16*K]`` (see ``fragments.ExpertStage``), so its byte
+    count is strictly proportional to K, while everything else the expert
+    carries — the ``suh``/``svh`` rotation vectors and the ``mcg`` scalar
+    — has no K in its shape at all. Hence::
+
+        bytes(K) = trellis_bytes_per_k * K + fixed_bytes
+
+    Two points determine that line exactly. That is the ONLY reason this
+    module is allowed to state a K2 or K5 figure it has never measured:
+    it is evaluating a known-affine function, not extrapolating a trend.
+
+    ``provenance`` records where the numbers came from and is surfaced in
+    the log, the decision record and the composition table — a byte
+    budget computed from the wrong checkpoint's geometry is worse than no
+    byte budget, so the source is never allowed to go unstated.
+    """
+
+    trellis_bytes_per_k: int
+    fixed_bytes: int
+    provenance: str
+    measured_ks: tuple[int, ...] = ()
+    # True when these numbers describe some OTHER checkpoint (the built-in
+    # reference measurement) rather than the one actually loaded.
+    is_reference: bool = False
+
+    def __post_init__(self) -> None:
+        if self.trellis_bytes_per_k <= 0:
+            raise ValueError(
+                f"trellis_bytes_per_k must be positive, got "
+                f"{self.trellis_bytes_per_k}")
+        if self.fixed_bytes < 0:
+            raise ValueError(f"fixed_bytes must be >= 0, got {self.fixed_bytes}")
+
+    def bytes_for(self, k: int) -> int:
+        """Bytes one expert occupies at bitrate ``k`` (one rank)."""
+        k = int(k)
+        if k <= 0:
+            raise ValueError(f"K must be positive, got {k}")
+        return self.trellis_bytes_per_k * k + self.fixed_bytes
+
+    def promotion_cost(self, k_from: int = K3, k_to: int = K4) -> int:
+        """Byte delta of moving one expert from ``k_from`` to ``k_to``.
+
+        Signed: a demotion returns a negative number.
+        """
+        return self.trellis_bytes_per_k * (int(k_to) - int(k_from))
+
+    def table(self, ks: Sequence[int] = K_UNIVERSE) -> dict[int, int]:
+        return {int(k): self.bytes_for(k) for k in ks}
+
+    def describe(self, ks: Sequence[int] = K_UNIVERSE) -> str:
+        per_k = " ".join(f"K{k}={self.bytes_for(k)}" for k in ks)
+        measured = (",".join(f"K{k}" for k in self.measured_ks)
+                    if self.measured_ks else "-")
+        return (f"{per_k} bytes/expert/rank (trellis {self.trellis_bytes_per_k}"
+                f" B per K + {self.fixed_bytes} B fixed; measured at "
+                f"{measured}; source: {self.provenance})")
+
+    # ------------------------------------------------------ constructors
+
+    @classmethod
+    def from_measurements(cls, points: Mapping[int, int], *, provenance: str,
+                          is_reference: bool = False) -> "ExpertBytes":
+        """Fit the affine model to >= 2 measured ``{K: bytes}`` points.
+
+        Every supplied point must lie exactly on the fitted line; a set
+        that does not is a measurement (or geometry) error and is refused
+        rather than least-squares'd into a plausible-looking lie.
+        """
+        pts = sorted((int(k), int(v)) for k, v in points.items())
+        if len(pts) < 2:
+            raise ValueError(
+                "need at least two measured K points to separate the "
+                "K-proportional trellis bytes from the fixed bytes; got "
+                f"{pts}")
+        (k0, b0), (k1, b1) = pts[0], pts[-1]
+        span = k1 - k0
+        if (b1 - b0) % span:
+            raise ValueError(
+                f"measurements {pts} imply a fractional bytes-per-K slope "
+                f"({b1 - b0}/{span}) — not a valid trellis geometry")
+        slope = (b1 - b0) // span
+        fixed = b0 - slope * k0
+        for k, b in pts:
+            if slope * k + fixed != b:
+                raise ValueError(
+                    f"measurement K{k}={b} is off the line fitted through "
+                    f"{pts} (expected {slope * k + fixed}) — the points do "
+                    f"not describe one checkpoint geometry")
+        return cls(slope, fixed, provenance, tuple(k for k, _ in pts),
+                   is_reference)
+
+    @classmethod
+    def from_tensor_table(
+        cls,
+        entries: Iterable[tuple[str, int, Sequence[int]]],
+        *,
+        provenance: str,
+    ) -> "ExpertBytes":
+        """Derive the model from ONE expert's REAL tensor table.
+
+        ``entries`` are ``(name, nbytes, shape)`` triples for a single
+        (expert, rank) — exactly what a safetensors header yields, where
+        ``nbytes`` comes from the tensor's own ``data_offsets`` and so is
+        the true on-disk/in-memory span, not a recomputation.
+
+        A tensor is trellis iff its name's last dotted component is
+        ``trellis``; its K is read straight off the last dim
+        (``shape[-1] == 16 * K``). Everything else is K-independent
+        overhead. This is the honest runtime path: no constant is
+        assumed, the geometry comes from the checkpoint that is actually
+        loaded.
+        """
+        trellis_bytes = 0
+        fixed_bytes = 0
+        ks: set[int] = set()
+        seen = 0
+        for name, nbytes, shape in entries:
+            seen += 1
+            nbytes = int(nbytes)
+            if str(name).rsplit(".", 1)[-1] == "trellis":
+                shape = tuple(int(d) for d in shape)
+                if not shape or shape[-1] <= 0 or shape[-1] % 16:
+                    raise ValueError(
+                        f"{name}: trellis last dim {shape[-1] if shape else None}"
+                        f" is not 16*K — cannot read K off this tensor")
+                ks.add(shape[-1] // 16)
+                trellis_bytes += nbytes
+            else:
+                fixed_bytes += nbytes
+        if not seen:
+            raise ValueError("empty tensor table — nothing to derive from")
+        if len(ks) != 1:
+            raise ValueError(
+                f"expected exactly one K across the expert's trellis "
+                f"tensors, found {sorted(ks)}")
+        k = ks.pop()
+        if trellis_bytes % k:
+            raise ValueError(
+                f"trellis bytes {trellis_bytes} are not divisible by K={k} — "
+                f"the layout is not the affine trellis this model assumes")
+        return cls(trellis_bytes // k, fixed_bytes,
+                   f"{provenance} (K{k} tensor table, {seen} tensors)", (k,))
+
+
+# Measured on the live GLM-5.2 serve (TP4, SM120), one MoE expert:
+#   K3 = 14,168,112 B across all 4 ranks -> 3,542,028 B per rank
+#   K4 = 18,886,704 B across all 4 ranks -> 4,721,676 B per rank
+# so a K3->K4 promotion costs 1,179,648 B per rank. Those two points fit
+# the affine model above exactly (slope 1,179,648 B/K, fixed 3,084 B),
+# and K2/K5 are then EVALUATED from it rather than guessed:
+#   K2 = 2,362,380 B/rank (9,449,520 across TP4)
+#   K5 = 5,901,324 B/rank (23,605,296 across TP4)
+# The same construction was validated end-to-end against two real
+# checkpoints of the small GLM-5.2-arch proxy: deriving the model from
+# fruit-k3's header alone predicts fruit-k4's measured 814,128 B/expert
+# to the byte (see test_memory_budget_cpu.py).
+MEASURED_GLM52_TP4_PER_RANK: dict[int, int] = {K3: 3_542_028, K4: 4_721_676}
+MEASURED_GLM52_TP4_ALL_RANKS: dict[int, int] = {K3: 14_168_112, K4: 18_886_704}
+
+
+def reference_expert_bytes(*, per_rank: bool = True) -> ExpertBytes:
+    """The built-in GLM-5.2/TP4 measurement — a LAST RESORT.
+
+    Marked ``is_reference``: callers must say out loud that the budget is
+    being computed from another checkpoint's geometry, because it may not
+    match the one actually loaded (requirement: never silently use a
+    constant that might be wrong).
+    """
+    points = (MEASURED_GLM52_TP4_PER_RANK if per_rank
+              else MEASURED_GLM52_TP4_ALL_RANKS)
+    scope = "per rank" if per_rank else "all TP4 ranks"
+    return ExpertBytes.from_measurements(
+        points,
+        provenance=f"REFERENCE measurement GLM-5.2 TP4 SM120 ({scope}) — "
+                   f"NOT derived from the loaded checkpoint",
+        is_reference=True)
+
+
+@dataclass(frozen=True)
+class BudgetVerdict:
+    """Outcome of checking one proposal against the byte ceiling."""
+
+    ok: bool
+    limit_bytes: int | None
+    current_bytes: int
+    requested_bytes: int
+    overshoot_bytes: int
+    headroom_bytes: int | None
+    headroom_promotions: int | None
+    kind: str = "proposal"
+    layer: int | None = None
+    expert_in: int | None = None
+    expert_out: int | None = None
+
+    def as_dict(self) -> dict:
+        d = {
+            "ok": bool(self.ok),
+            "kind": self.kind,
+            "budget_bytes": self.limit_bytes,
+            "current_bytes": int(self.current_bytes),
+            "requested_bytes": int(self.requested_bytes),
+            "overshoot_bytes": int(self.overshoot_bytes),
+            "headroom_bytes": self.headroom_bytes,
+            "headroom_promotions": self.headroom_promotions,
+        }
+        for key in ("layer", "expert_in", "expert_out"):
+            if getattr(self, key) is not None:
+                d[key] = int(getattr(self, key))
+        return d
+
+    def message(self) -> str:
+        return rejection_message(self.as_dict())
+
+
+def rejection_message(rej: Mapping) -> str:
+    """One log line carrying every number a reviewer needs."""
+    where = ""
+    if rej.get("layer") is not None:
+        where = f" L{rej['layer']}"
+        if rej.get("expert_in") is not None:
+            where += f" e{rej['expert_in']}"
+        if rej.get("expert_out") is not None:
+            where += f"<-e{rej['expert_out']}"
+    return (
+        f"{rej.get('kind', 'proposal')}{where} REJECTED by memory budget: "
+        f"budget={rej['budget_bytes']} B current={rej['current_bytes']} B "
+        f"requested={rej['requested_bytes']} B "
+        f"overshoot={rej['overshoot_bytes']} B")
+
+
+class MemoryBudget:
+    """A byte ceiling on the per-device expert pool, plus the conversion
+    to and from the "N experts at K4 per layer" form.
+
+    ``limit_bytes is None`` means no byte ceiling — the fixed-cardinality
+    budget alone governs, which is exactly today's behaviour.
+
+    Every byte figure this object reports is computed from the ACTUAL
+    tier occupancy it is handed, never from an assumed shape: pass the
+    live ``tier_of`` array and you get the live footprint, including
+    experts sitting at tiers outside the K3/K4 ladder.
+    """
+
+    def __init__(
+        self,
+        expert_bytes: ExpertBytes,
+        limit_bytes: int | None = None,
+        *,
+        low_k: int = K3,
+        high_k: int = K4,
+        spec: Any = None,
+    ) -> None:
+        self.expert_bytes = expert_bytes
+        self.limit_bytes = None if limit_bytes is None else int(limit_bytes)
+        if self.limit_bytes is not None and self.limit_bytes <= 0:
+            raise ValueError(f"memory budget must be positive, got {limit_bytes}")
+        self.low_k = int(low_k)
+        self.high_k = int(high_k)
+        self.spec = spec
+
+    @classmethod
+    def from_spec(
+        cls,
+        spec,
+        expert_bytes: ExpertBytes,
+        *,
+        num_layers: int,
+        num_experts: int,
+        device_total_bytes: int | None = None,
+        low_k: int = K3,
+        high_k: int = K4,
+    ) -> "MemoryBudget":
+        """Build a budget from any of the operator's three spellings.
+
+        - bytes / fraction of device memory -> :func:`parse_memory_budget`
+        - ``"24/layer"`` / ``"24experts/layer"`` -> that many ``high_k``
+          experts per layer, converted to the byte ceiling it implies
+        - ``"3.5bpw"`` -> the mean-bits-per-expert the pool may average,
+          converted the same way (rounded DOWN, so the resulting ceiling
+          never exceeds what was asked for)
+
+        The last two are the "experts/bpw/layer" form; they are stored as
+        bytes, so enforcement, headroom and reporting all run through one
+        code path regardless of how the ceiling was written.
+        """
+        probe = cls(expert_bytes, None, low_k=low_k, high_k=high_k, spec=spec)
+        s = ("" if spec is None else
+             str(spec).strip().lower().replace("_", "").replace(" ", ""))
+        n_high: int | None = None
+        m = _PER_LAYER_RE.match(s)
+        if m is not None:
+            n_high = int(m.group(1))
+            if n_high > num_experts:
+                raise ValueError(
+                    f"memory budget {spec!r} asks for {n_high} {high_k}-bit "
+                    f"experts per layer but each layer only has {num_experts}")
+        else:
+            m = _BPW_RE.match(s)
+            if m is not None:
+                bpw = float(m.group(1))
+                if bpw < low_k:
+                    raise ValueError(
+                        f"memory budget {spec!r} is below the base tier "
+                        f"K{low_k}: even an all-K{low_k} pool averages "
+                        f"{low_k} bits/expert")
+                n_high = min(num_experts, int(math.floor(
+                    num_experts * (bpw - low_k) / (high_k - low_k))))
+        if n_high is not None:
+            limit = probe.bytes_for_cardinality(num_layers, num_experts,
+                                                n_high)
+        else:
+            limit = parse_memory_budget(
+                spec, device_total_bytes=device_total_bytes)
+        return cls(expert_bytes, limit, low_k=low_k, high_k=high_k, spec=spec)
+
+    # ------------------------------------------------------ measurement
+
+    def bytes_of_counts(self, counts: Mapping[int, int]) -> int:
+        """Bytes for ``{K: number_of_experts}`` (one rank)."""
+        return sum(self.expert_bytes.bytes_for(k) * int(n)
+                   for k, n in counts.items() if n)
+
+    def counts_of(self, tier_of) -> dict[int, int]:
+        """ACTUAL ``{K: expert_count}`` of a membership array."""
+        vals, cnts = np.unique(np.asarray(tier_of), return_counts=True)
+        return {int(k): int(n) for k, n in zip(vals, cnts)}
+
+    def used_bytes(self, tier_of) -> int:
+        """Per-rank bytes the given occupancy actually costs."""
+        return self.bytes_of_counts(self.counts_of(tier_of))
+
+    def promotion_cost(self) -> int:
+        return self.expert_bytes.promotion_cost(self.low_k, self.high_k)
+
+    def headroom_bytes(self, tier_of) -> int | None:
+        if self.limit_bytes is None:
+            return None
+        return self.limit_bytes - self.used_bytes(tier_of)
+
+    def promotions_headroom(self, tier_of) -> int | None:
+        """How many more ``low_k -> high_k`` promotions fit.
+
+        None when unbounded. Never negative-by-rounding: an over-budget
+        occupancy reports a negative count, which is the honest answer
+        ("you are this many promotions past the line"), and it is capped
+        by the number of ``low_k`` experts that actually exist.
+        """
+        free = self.headroom_bytes(tier_of)
+        if free is None:
+            return None
+        cost = self.promotion_cost()
+        if cost <= 0:
+            return 0
+        n = int(math.floor(free / cost))
+        if n <= 0:
+            return n
+        return min(n, int(self.counts_of(tier_of).get(self.low_k, 0)))
+
+    def mean_bits(self, tier_of) -> float:
+        counts = self.counts_of(tier_of)
+        n = sum(counts.values())
+        return (sum(k * v for k, v in counts.items()) / n) if n else 0.0
+
+    # ------------------------------------------------------ conversion
+
+    def n_high_per_layer(self, num_layers: int, num_experts: int) -> int | None:
+        """Byte ceiling -> the equivalent fixed-cardinality budget.
+
+        The largest uniform per-layer ``high_k`` count that fits, assuming
+        every other expert sits at ``low_k``. None when unbounded. This is
+        the exact inverse of :meth:`bytes_for_cardinality`.
+        """
+        if self.limit_bytes is None:
+            return None
+        num_layers, num_experts = int(num_layers), int(num_experts)
+        base = num_layers * num_experts * self.expert_bytes.bytes_for(self.low_k)
+        cost = num_layers * self.promotion_cost()
+        if cost <= 0:
+            return num_experts
+        n = (self.limit_bytes - base) // cost
+        return int(max(0, min(num_experts, n)))
+
+    def bytes_for_cardinality(self, num_layers: int, num_experts: int,
+                              n_high_per_layer: int) -> int:
+        """Fixed-cardinality budget -> bytes (one rank)."""
+        num_layers, num_experts = int(num_layers), int(num_experts)
+        n_high = int(n_high_per_layer)
+        if not 0 <= n_high <= num_experts:
+            raise ValueError(
+                f"n_high_per_layer {n_high} outside [0, {num_experts}]")
+        return num_layers * (
+            (num_experts - n_high) * self.expert_bytes.bytes_for(self.low_k)
+            + n_high * self.expert_bytes.bytes_for(self.high_k))
+
+    # ------------------------------------------------------ enforcement
+
+    def check(self, current_tier, proposed_tier, *, kind: str = "proposal",
+              layer: int | None = None, expert_in: int | None = None,
+              expert_out: int | None = None) -> BudgetVerdict:
+        """Is ``proposed_tier`` affordable? Carries the numbers either way."""
+        cur = self.used_bytes(current_tier)
+        req = self.used_bytes(proposed_tier)
+        over = 0 if self.limit_bytes is None else max(0, req - self.limit_bytes)
+        return BudgetVerdict(
+            ok=(self.limit_bytes is None or req <= self.limit_bytes),
+            limit_bytes=self.limit_bytes,
+            current_bytes=cur, requested_bytes=req, overshoot_bytes=over,
+            headroom_bytes=(None if self.limit_bytes is None
+                            else self.limit_bytes - req),
+            headroom_promotions=self.promotions_headroom(proposed_tier),
+            kind=kind, layer=layer, expert_in=expert_in, expert_out=expert_out)
+
+    def summary(self, tier_of) -> dict:
+        """Operator-facing state, for the log table / metrics / record."""
+        used = self.used_bytes(tier_of)
+        return {
+            "limit_bytes": self.limit_bytes,
+            "used_bytes": used,
+            "headroom_bytes": (None if self.limit_bytes is None
+                               else self.limit_bytes - used),
+            "headroom_promotions": self.promotions_headroom(tier_of),
+            "promotion_cost_bytes": self.promotion_cost(),
+            "per_k_bytes": self.expert_bytes.table(),
+            "mean_bits_per_expert": self.mean_bits(tier_of),
+            "source": self.expert_bytes.provenance,
+            "is_reference": bool(self.expert_bytes.is_reference),
+            "spec": None if self.spec is None else str(self.spec),
+        }
+
+
+def swap_byte_delta(tier_of, layer: int, e_out: int, e_in: int,
+                    budget: MemoryBudget) -> int:
+    """Signed byte cost of ``(layer, e_out, e_in)`` given the CURRENT tiers.
+
+    ``e_out`` lands on ``budget.low_k`` and ``e_in`` on ``budget.high_k``;
+    what each of them costs today is read off ``tier_of`` rather than
+    assumed, so a member sitting at K2 or K5 is priced correctly.
+
+    Note the consequence for today's engine: ``apply_swaps`` only accepts
+    a K4 leaving and a K3 entering, so every swap it can execute has a
+    delta of exactly zero. The fixed-cardinality budget is therefore an
+    EXACT memory invariant on the K3/K4 ladder — and this function is
+    what keeps that true by construction instead of by assumption once
+    the ladder widens.
+    """
+    tier_of = np.asarray(tier_of)
+    eb = budget.expert_bytes
+    return ((eb.bytes_for(budget.low_k) - eb.bytes_for(tier_of[layer, e_out]))
+            + (eb.bytes_for(budget.high_k) - eb.bytes_for(tier_of[layer, e_in])))
+
+
+def budget_filter(swaps: list, tier_of, budget: MemoryBudget | None,
+                  ) -> tuple[list, list[dict]]:
+    """Guard 5 — drop swaps that would push the pool over the byte ceiling.
+
+    Applied to the ORDERED list cumulatively, so the surviving prefix is
+    affordable *together*, not merely one at a time.
+
+    Returns ``(kept, rejections)``; each rejection is a
+    :meth:`BudgetVerdict.as_dict` carrying budget/current/requested/
+    overshoot.
+    """
+    if budget is None or budget.limit_bytes is None or not swaps:
+        return list(swaps), []
+    tier_of = np.asarray(tier_of)
+    used = budget.used_bytes(tier_of)
+    kept: list = []
+    rejections: list[dict] = []
+    for l, e_out, e_in in swaps:
+        delta = swap_byte_delta(tier_of, l, e_out, e_in, budget)
+        requested = used + delta
+        if requested <= budget.limit_bytes:
+            used = requested
+            kept.append((l, e_out, e_in))
+        else:
+            rejections.append(BudgetVerdict(
+                ok=False, limit_bytes=budget.limit_bytes, current_bytes=used,
+                requested_bytes=requested,
+                overshoot_bytes=requested - budget.limit_bytes,
+                headroom_bytes=budget.limit_bytes - requested,
+                headroom_promotions=int(math.floor(
+                    (budget.limit_bytes - used) / budget.promotion_cost()))
+                if budget.promotion_cost() > 0 else 0,
+                kind="swap", layer=int(l), expert_in=int(e_in),
+                expert_out=int(e_out)).as_dict())
+    return kept, rejections
+
+
+def apply_promotions(tier_of, promotions: Iterable[tuple[int, int]],
+                     k: int = K4):
+    """Apply unpaired ``(layer, expert) -> k`` promotions (returns a copy)."""
+    out = np.array(tier_of, copy=True)
+    for l, e in promotions:
+        out[l, e] = k
+    return out
+
+
+def plan_promotions(
+    stats,
+    eps,
+    tier_of,
+    budget: MemoryBudget,
+    *,
+    pins=None,
+    dwell=None,
+    cfg=None,
+    exclude: Iterable[tuple[int, int]] = (),
+    max_rejections: int = 8,
+) -> tuple[list[tuple[int, int]], list[dict]]:
+    """Spend byte headroom on UNPAIRED ``low_k -> high_k`` promotions.
+
+    This is the capability the byte budget buys that fixed cardinality
+    cannot express: when the ceiling leaves room, the best-scoring
+    low-tier experts are promoted outright instead of having to displace
+    an incumbent. Candidates are taken in global score order (ties broken
+    by layer then expert id, so the plan is deterministic), must have a
+    strictly positive score, must be dwell-ready and not pinned to
+    ``low_k``, and are capped per layer and in total by the same knobs
+    that cap swaps.
+
+    Every candidate that was otherwise eligible and did not fit is
+    reported as a rejection carrying budget/current/requested/overshoot
+    — that is what lands in the decision log.
+
+    Returns ``(promotions, rejections)`` where a promotion is
+    ``(layer_row, expert)``.
+    """
+    full = _full_cfg(dict(cfg or {}, n_k4=0))
+    tier_of = np.asarray(tier_of)
+    L, E = tier_of.shape
+    if budget.limit_bytes is None:
+        return [], []
+    s = score(stats, eps, cfg)
+    pins = np.zeros((L, E), dtype=np.int64) if pins is None else np.asarray(pins)
+    dwell_ok = (np.ones((L, E), dtype=bool) if dwell is None
+                else np.asarray(dwell) >= full["dwell_steps"])
+    blocked = {(int(l), int(e)) for l, e in exclude}
+
+    cand: list[tuple[float, int, int]] = []
+    for l in range(L):
+        for e in range(E):
+            if tier_of[l, e] != budget.low_k or pins[l, e] == PIN_K3:
+                continue
+            if not dwell_ok[l, e] or (int(l), int(e)) in blocked:
+                continue
+            if not s[l, e] > 0:
+                continue
+            cand.append((float(s[l, e]), int(l), int(e)))
+    cand.sort(key=lambda c: (-c[0], c[1], c[2]))
+
+    per_layer_cap = int(full["max_swaps_per_layer"])
+    total_cap = int(cfg.get("max_promotions_total", full["max_swaps_total"])
+                    if cfg else full["max_swaps_total"])
+    # Byte accounting is incremental: the footprint is measured ONCE from
+    # the real occupancy and then moved by the known per-promotion cost,
+    # so a 92x160 tier array is not re-reduced per candidate.
+    used = budget.used_bytes(tier_of)
+    limit = budget.limit_bytes
+    n_low_left = int(budget.counts_of(tier_of).get(budget.low_k, 0))
+    promotions: list[tuple[int, int]] = []
+    rejections: list[dict] = []
+    per_layer: dict[int, int] = {}
+    for _, l, e in cand:
+        if len(promotions) >= total_cap:
+            break
+        if per_layer.get(l, 0) >= per_layer_cap:
+            continue
+        cost = budget.expert_bytes.promotion_cost(
+            int(tier_of[l, e]), budget.high_k)
+        requested = used + cost
+        if requested <= limit:
+            used = requested
+            n_low_left -= 1
+            promotions.append((l, e))
+            per_layer[l] = per_layer.get(l, 0) + 1
+        elif len(rejections) < max_rejections:
+            step = budget.promotion_cost()
+            fits = (min(int(math.floor((limit - used) / step)), n_low_left)
+                    if step > 0 else 0)
+            rejections.append(BudgetVerdict(
+                ok=False, limit_bytes=limit, current_bytes=used,
+                requested_bytes=requested, overshoot_bytes=requested - limit,
+                headroom_bytes=limit - requested, headroom_promotions=fits,
+                kind="promotion", layer=l, expert_in=e).as_dict())
+    return promotions, rejections
+
+
+def decide_with_budget(
+    stats,
+    eps,
+    tier_of,
+    budget: MemoryBudget | None,
+    *,
+    pins=None,
+    dwell=None,
+    cfg=None,
+    allow_promotions: bool = True,
+) -> tuple[list, list[tuple[int, int]], list[dict]]:
+    """``decide`` + Guard 5 + headroom promotions, in one call.
+
+    Returns ``(swaps, promotions, rejections)``. With ``budget`` None or
+    unbounded this is exactly ``decide`` with two empty lists, so the
+    byte budget is strictly additive to the existing behaviour.
+    """
+    swaps = decide(stats, eps, tier_of, pins=pins, dwell=dwell, cfg=cfg)
+    if budget is None or budget.limit_bytes is None:
+        return swaps, [], []
+    swaps, rejections = budget_filter(swaps, tier_of, budget)
+    promotions: list[tuple[int, int]] = []
+    if allow_promotions:
+        touched = [(l, e_in) for l, _, e_in in swaps]
+        promotions, prej = plan_promotions(
+            stats, eps, apply_swaps(tier_of, swaps), budget, pins=pins,
+            dwell=dwell, cfg=cfg, exclude=touched)
+        rejections = rejections + prej
+    return swaps, promotions, rejections

--- a/vllm/model_executor/layers/quantization/exl3_fungible/progressive.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/progressive.py
@@ -347,9 +347,18 @@ def progressive_weights_iterator(
         # work the GPU is doing anyway.
         import concurrent.futures as _cf
         _sorted_layers = sorted(expert_layers)
+        # DEPTH and WIDTH, both configurable.
+        #   depth: how many layers ahead to pull. One layer of lookahead only
+        #     covers the download if it is faster than the GPU load; with a
+        #     real network it usually is not, and the loader goes back to
+        #     waiting. Cost is disk+RAM: depth x ~3.7 GB resident.
+        #   width: a mixed layer needs TWO objects (its K3 and its K4). Pulling
+        #     them one after the other leaves the link idle between files even
+        #     with hf_transfer chunking inside each.
+        _depth = max(1, int(os.environ.get("VLLM_FQ_PREFETCH_DEPTH", "3")))
         _pool = _cf.ThreadPoolExecutor(
-            max_workers=1, thread_name_prefix="fq-prefetch")
-        _inflight: dict[int, object] = {}
+            max_workers=_depth * 2, thread_name_prefix="fq-prefetch")
+        _inflight: dict[int, list] = {}
 
         def _bulk_ks(_layer):
             from collections import Counter
@@ -367,8 +376,12 @@ def progressive_weights_iterator(
             _fn = getattr(resolver, "prefetch_layer", None)
             if _fn is None:
                 return
-            _inflight[_layer] = _pool.submit(
-                lambda: [_fn(_layer, _k) for _k in _ks])
+            # One task PER (layer, K) so a mixed layer's two objects
+            # download concurrently instead of back to back.
+            _inflight[_layer] = [_pool.submit(_fn, _layer, _k) for _k in _ks]
+
+        for _pre in _sorted_layers[:_depth + 1]:
+            _prefetch_layer_async(_pre)
 
         try:
           for _idx, layer in enumerate(_sorted_layers):
@@ -402,7 +415,8 @@ def progressive_weights_iterator(
                         "FQ progressive L%d: waiting on background prefetch "
                         "(%s)", layer,
                         ", ".join(f"{n} experts want K{k}" for k, n in _want))
-                    _inflight.pop(layer).result()
+                    for _fut in _inflight.pop(layer):
+                        _fut.result()
                 else:
                     for _k, _n in _want:
                         _note = getattr(resolver, "prefetch_layer",
@@ -413,8 +427,9 @@ def progressive_weights_iterator(
                                 "%s (1 fetch instead of %d ranged reads)",
                                 layer, _n, _k, _note, _n)
             # Start the NEXT layer downloading while this one streams to GPU.
-            if _idx + 1 < len(_sorted_layers):
-                _prefetch_layer_async(_sorted_layers[_idx + 1])
+            for _ahead in range(1, _depth + 1):
+                if _idx + _ahead < len(_sorted_layers):
+                    _prefetch_layer_async(_sorted_layers[_idx + _ahead])
 
             unavailable: list[int] = []
             for expert, k in enumerate(bits):
@@ -483,12 +498,17 @@ def progressive_weights_iterator(
                 f"bits_digest={_bits_digest(actual_bits)} "
                 f"tensors={len(seen)}{sub_note}"
             )
+            # This layer is on the GPU now; its segments are dead weight.
+            # Without this the boot keeps every segment it ever touched --
+            # bounded only by the model size, not by the prefetch depth.
+            getattr(resolver, "release_layer", lambda _l: 0)(layer)
         finally:
             # Never leave the prefetch thread running past the stream: a
             # cancelled boot would otherwise keep pulling segments nobody
             # will load.
-            for _f in _inflight.values():
-                _f.cancel()
+            for _futs in _inflight.values():
+                for _f in _futs:
+                    _f.cancel()
             _pool.shutdown(wait=False, cancel_futures=True)
 
     stats = dict(resolver.stats)

--- a/vllm/model_executor/layers/quantization/exl3_fungible/progressive.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/progressive.py
@@ -337,7 +337,41 @@ def progressive_weights_iterator(
             dense_bytes += entry["data_offsets"][1] - entry["data_offsets"][0]
             yield name, _shard_tensor(mm, body_offset, entry)
 
-        for layer in sorted(expert_layers):
+        # PIPELINE THE FETCH BEHIND THE LOAD.
+        # This function is a generator consumed by model.load_weights(), so
+        # per-expert reads were naturally streamed: fetch -> yield -> GPU load,
+        # overlapped. Bulk prefetch broke that by downloading a whole ~2.5 GB
+        # segment synchronously before yielding anything, stalling the GPU for
+        # minutes per layer. Prefetch layer N+1 in a background thread while
+        # layer N's tensors are still streaming, so the download hides behind
+        # work the GPU is doing anyway.
+        import concurrent.futures as _cf
+        _sorted_layers = sorted(expert_layers)
+        _pool = _cf.ThreadPoolExecutor(
+            max_workers=1, thread_name_prefix="fq-prefetch")
+        _inflight: dict[int, object] = {}
+
+        def _bulk_ks(_layer):
+            from collections import Counter
+            _b = spec.bits_by_layer.get(_layer) or []
+            _min = int(os.environ.get("VLLM_FQ_BULK_MIN", "16"))
+            return [k for k, n in Counter(int(x) for x in _b).items()
+                    if n >= _min]
+
+        def _prefetch_layer_async(_layer):
+            if _layer in _inflight:
+                return
+            _ks = _bulk_ks(_layer)
+            if not _ks:
+                return
+            _fn = getattr(resolver, "prefetch_layer", None)
+            if _fn is None:
+                return
+            _inflight[_layer] = _pool.submit(
+                lambda: [_fn(_layer, _k) for _k in _ks])
+
+        try:
+          for _idx, layer in enumerate(_sorted_layers):
             expected_names = expert_layers[layer]
             bits = spec.bits_by_layer[layer]
             actual_bits = [int(b) for b in bits]
@@ -361,16 +395,26 @@ def progressive_weights_iterator(
             from collections import Counter
             _need = Counter(int(x) for x in bits)
             _bulk_min = int(os.environ.get("VLLM_FQ_BULK_MIN", "16"))
-            for _k, _n in sorted(_need.items()):
-                if _n < _bulk_min:
-                    continue
-                _note = getattr(resolver, "prefetch_layer", lambda *a: None)(
-                    layer, _k)
-                if _note:
+            _want = [(k, n) for k, n in sorted(_need.items()) if n >= _bulk_min]
+            if _want:
+                if layer in _inflight:
                     logger.info(
-                        "FQ progressive L%d: %d experts want K%d -> %s "
-                        "(1 fetch instead of %d ranged reads)",
-                        layer, _n, _k, _note, _n)
+                        "FQ progressive L%d: waiting on background prefetch "
+                        "(%s)", layer,
+                        ", ".join(f"{n} experts want K{k}" for k, n in _want))
+                    _inflight.pop(layer).result()
+                else:
+                    for _k, _n in _want:
+                        _note = getattr(resolver, "prefetch_layer",
+                                        lambda *a: None)(layer, _k)
+                        if _note:
+                            logger.info(
+                                "FQ progressive L%d: %d experts want K%d -> "
+                                "%s (1 fetch instead of %d ranged reads)",
+                                layer, _n, _k, _note, _n)
+            # Start the NEXT layer downloading while this one streams to GPU.
+            if _idx + 1 < len(_sorted_layers):
+                _prefetch_layer_async(_sorted_layers[_idx + 1])
 
             unavailable: list[int] = []
             for expert, k in enumerate(bits):
@@ -439,6 +483,13 @@ def progressive_weights_iterator(
                 f"bits_digest={_bits_digest(actual_bits)} "
                 f"tensors={len(seen)}{sub_note}"
             )
+        finally:
+            # Never leave the prefetch thread running past the stream: a
+            # cancelled boot would otherwise keep pulling segments nobody
+            # will load.
+            for _f in _inflight.values():
+                _f.cancel()
+            _pool.shutdown(wait=False, cancel_futures=True)
 
     stats = dict(resolver.stats)
     _emit(

--- a/vllm/model_executor/layers/quantization/exl3_fungible/progressive.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/progressive.py
@@ -344,23 +344,33 @@ def progressive_weights_iterator(
             substitutions: list[tuple[int, int, int]] = []
             seen: set[str] = set()
             counts: dict[int, int] = {}
-            # UNIFORM-LAYER FAST PATH. When every expert of this layer wants
-            # the same K they all live in one segment object, and fetching it
-            # per-expert is 256 HTTP round trips for one contiguous file --
-            # 19,200 across GLM-5.2. Pull it once and slice locally: identical
-            # bytes, 1 request, and 255 fewer chances to hit the transient
-            # failure that killed an earlier boot. Only for uniform layers:
-            # a layer needing one K4 expert must not drag a whole segment.
-            uniq = set(int(x) for x in bits)
-            if len(uniq) == 1:
-                only_k = uniq.pop()
-                note = getattr(resolver, "prefetch_layer", lambda *a: None)(
-                    layer, only_k)
-                if note:
+            # BULK-FETCH FAST PATH.
+            # A layer draws its experts from ONE segment object per K it uses:
+            # a uniform layer from one, a mixed K3+K4 layer from two (~192
+            # experts from the K3 object, ~64 from the K4 object). Fetching
+            # per-expert measured 18.2 s/expert over HTTPS -- TLS handshake,
+            # attestation lookup and a ranged GET each -- i.e. 97 hours for
+            # GLM-5.2's 19,200 experts. Pulling each needed object ONCE is the
+            # same bytes in 2 requests per layer.
+            #
+            # Threshold, not "uniform": restricting this to uniform layers
+            # missed the majority case outright, because a seeded policy makes
+            # most layers mixed. But a layer needing ONE K4 expert must still
+            # not drag a whole ~2.5 GB segment for ~18 MiB, so only fetch an
+            # object we will draw at least FQ_BULK_MIN experts from.
+            from collections import Counter
+            _need = Counter(int(x) for x in bits)
+            _bulk_min = int(os.environ.get("VLLM_FQ_BULK_MIN", "16"))
+            for _k, _n in sorted(_need.items()):
+                if _n < _bulk_min:
+                    continue
+                _note = getattr(resolver, "prefetch_layer", lambda *a: None)(
+                    layer, _k)
+                if _note:
                     logger.info(
-                        "FQ progressive L%d: uniform K%d -> %s "
+                        "FQ progressive L%d: %d experts want K%d -> %s "
                         "(1 fetch instead of %d ranged reads)",
-                        layer, only_k, note, len(bits))
+                        layer, _n, _k, _note, _n)
 
             unavailable: list[int] = []
             for expert, k in enumerate(bits):

--- a/vllm/model_executor/layers/quantization/exl3_fungible/progressive.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/progressive.py
@@ -359,13 +359,25 @@ def progressive_weights_iterator(
         # OPPORTUNISTIC TIME-TO-SERVE (opt-in). Boot on whatever tiers the
         # primed cache holds and converge afterwards, instead of making
         # time-to-serve a function of the slowest fetch.
+        # ALWAYS account. The K ladder degrades an expert whenever a
+        # fragment is unavailable -- that has been true since long before
+        # opportunistic mode existed -- and until now the degradation was
+        # recorded nowhere an operator or a repay loop could act on. One
+        # transient URLError left L5/e2 serving K3 instead of K4 for the
+        # lifetime of the process, with nothing tracking it.
+        #
+        # So the plan is unconditional; the opt-in governs only whether the
+        # boot is PERMITTED to proceed past missing experts, never whether a
+        # degradation is noticed.
         _plan = None
+        _opportunistic = False
         try:
             from .convergence import ConvergencePlan, k_bounds, \
                 opportunistic_enabled
-            if opportunistic_enabled():
-                _lo, _hi = k_bounds()
-                _plan = ConvergencePlan(k_min=_lo, k_max=_hi)
+            _lo, _hi = k_bounds()
+            _plan = ConvergencePlan(k_min=_lo, k_max=_hi)
+            _opportunistic = opportunistic_enabled()
+            if _opportunistic:
                 _emit(f"FQ opportunistic boot ENABLED (accepting K{_lo}..K"
                       f"{_hi}); served weights converge to policy at runtime")
         except ImportError:
@@ -482,7 +494,7 @@ def progressive_weights_iterator(
                     yield name, tensor
             if actual_bits_out is not None:
                 actual_bits_out[layer] = list(actual_bits)
-            if unavailable and _plan is not None:
+            if unavailable and _opportunistic:
                 # Opportunistic mode: completeness is the gate, adequacy is
                 # not. A missing expert still fails -- via _plan.gate() once
                 # the whole model is loaded, so the operator sees the full
@@ -532,11 +544,14 @@ def progressive_weights_iterator(
             getattr(resolver, "release_layer", lambda _l: 0)(layer)
 
           if _plan is not None:
-            # ONCE, after every layer has streamed: an operator needs the
-            # full extent of what is missing, not the first layer that
-            # tripped over it.
-            _plan.gate()
-            _emit(_plan.describe())
+            if _opportunistic:
+                # ONCE, after every layer has streamed: an operator needs the
+                # full extent of what is missing, not the first layer that
+                # tripped over it. (Without the opt-in, a missing expert
+                # already failed at its own layer above.)
+                _plan.gate()
+            if _plan.pending_count or _opportunistic:
+                _emit(_plan.describe())
             if convergence_out is not None:
                 convergence_out.append(_plan)
         finally:

--- a/vllm/model_executor/layers/quantization/exl3_fungible/progressive.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/progressive.py
@@ -272,6 +272,61 @@ def _shard_tensor(mm, body_offset: int, entry: dict):
         ).view(shape)
 
 
+def measure_footprint_inputs(
+    spec: ProgressiveSpec,
+    resolver: FragmentResolver,
+    *,
+    tp_rank: int | None = None,
+) -> tuple[dict[int, int], int]:
+    """Measure ``(expert_bytes_by_k, dense_bytes)`` for this rank.
+
+    Both numbers come from real headers, never from a bits-per-weight model:
+    the fixed-size ``suh``/``svh``/``mcg`` companions make K4 ~1.33x K3 rather
+    than the 1.33x a naive model predicts, and the gap is GiB-scale.
+
+    One sample fragment per distinct K is enough -- every expert of a given K
+    has identical shapes -- so this costs a handful of cached header reads.
+    """
+    def _rank_ok(name: str) -> bool:
+        if tp_rank is None:
+            return True
+        m = _RANK_SEG_RE.search(name)
+        return m is None or int(m.group(1)) == tp_rank
+
+    # Dense side: everything the stream will yield that is not a routed
+    # expert of a policy layer, counted the way the stream counts it.
+    dense_bytes = 0
+    for shard in spec.shard_files():
+        header, _ = read_safetensors_header(shard)
+        header.pop("__metadata__", None)
+        for name, entry in header.items():
+            m = EXPERT_RE.match(name)
+            if m is not None and int(m.group(1)) in spec.bits_by_layer:
+                continue
+            if not _rank_ok(name):
+                continue
+            start, end = entry["data_offsets"]
+            dense_bytes += end - start
+
+    # Expert side: one probe per distinct K actually referenced.
+    wanted: dict[int, tuple[int, int]] = {}
+    for layer, bits in spec.bits_by_layer.items():
+        for expert, k in enumerate(bits):
+            wanted.setdefault(int(k), (layer, expert))
+    expert_bytes_by_k: dict[int, int] = {}
+    for k, (layer, expert) in sorted(wanted.items()):
+        frag = resolver.resolve_best(layer, expert, k)
+        if frag is None:
+            continue
+        # Size the fragment as LOADED (frag.k), not as requested: a silently
+        # substituted lower K would otherwise inflate the projection and
+        # reject a policy that actually fits.
+        expert_bytes_by_k[int(frag.k)] = sum(
+            t.end - t.start for t in frag.tensors if _rank_ok(t.name)
+        )
+    return expert_bytes_by_k, dense_bytes
+
+
 def progressive_weights_iterator(
     spec: ProgressiveSpec,
     resolver: FragmentResolver,

--- a/vllm/model_executor/layers/quantization/exl3_fungible/progressive.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/progressive.py
@@ -42,6 +42,7 @@ try:
         DEFAULT_CACHE_DIR,
         FragmentResolver,
         read_safetensors_header,
+        project_bits_to_available,
     )
 except ImportError:  # standalone execution (tests / CLI without built vllm)
     import importlib.util as _ilu
@@ -59,6 +60,7 @@ except ImportError:  # standalone execution (tests / CLI without built vllm)
     FQ_CACHE_ENV = _mod.FQ_CACHE_ENV
     DEFAULT_CACHE_DIR = _mod.DEFAULT_CACHE_DIR
     FragmentResolver = _mod.FragmentResolver
+    project_bits_to_available = _mod.project_bits_to_available
     read_safetensors_header = _mod.read_safetensors_header
 
 FQ_MANIFEST_DIR_ENV = "VLLM_FQ_MANIFEST_DIR"
@@ -128,17 +130,29 @@ class ProgressiveSpec:
 
         policy_path: Path | None = None
         policy_ref = overrides.get("policy") or environ.get(FQ_POLICY_ENV)
+        # A committed live policy is the restart source of truth. Loading the
+        # explicit boot policy first reconstructs yesterday's slabs while the
+        # loop rehydrates current.json, so its tier_of immediately disagrees
+        # with the device after any successful live re-tier.
+        policy = None
+        if policy_ref is None and manifest_path.is_file():
+            manifest_identity = hashlib.sha256(manifest_path.read_bytes()).hexdigest()
+            policy = cls._policy_from_store(manifest_identity, environ)
         if policy_ref:
             policy_path = Path(policy_ref)
-            policy = json.loads(policy_path.read_text())
-        else:
-            policy = cls._policy_from_store(manifest_path, environ)
-            if policy is None:
-                raise ValueError(
-                    "load_format=progressive found no policy: set "
-                    f"{FQ_POLICY_ENV} to a fq-policy JSON or commit one to "
-                    "the PolicyStore for this manifest"
-                )
+            boot_policy = json.loads(policy_path.read_text())
+            policy = cls._policy_from_store(
+                str(boot_policy.get("manifest") or ""), environ)
+            if policy is not None:
+                policy_path = None
+            else:
+                policy = boot_policy
+        if policy is None:
+            raise ValueError(
+                "load_format=progressive found no policy: set "
+                f"{FQ_POLICY_ENV} to a fq-policy JSON or commit one to "
+                "the PolicyStore for this manifest"
+            )
 
         bpe = policy.get("bits_per_expert")
         if not isinstance(bpe, dict) or not bpe:
@@ -200,11 +214,19 @@ class ProgressiveSpec:
 
     @staticmethod
     def _policy_from_store(
-        manifest_path: Path, environ: dict[str, str]
+        manifest_identity: str, environ: dict[str, str]
     ) -> dict | None:
-        """PolicyStore fallback: current.json keyed by the manifest hash."""
-        if not manifest_path.exists():
+        """Load current.json using a safe manifest identity."""
+        if not manifest_identity:
             return None
+        if (
+            len(manifest_identity) > 128
+            or manifest_identity in (".", "..")
+            or re.fullmatch(r"[A-Za-z0-9._-]+", manifest_identity) is None
+        ):
+            raise ValueError(
+                f"invalid policy manifest identity {manifest_identity!r}"
+            )
         try:
             from vllm.model_executor.layers.quantization.exl3_fungible.store import (
                 PolicyStore,
@@ -221,11 +243,16 @@ class ProgressiveSpec:
             _sys.modules[_spec.name] = _mod
             _spec.loader.exec_module(_mod)
             PolicyStore = _mod.PolicyStore
-        manifest_hash = hashlib.sha256(manifest_path.read_bytes()).hexdigest()
+        # ``fq-manifest.json`` is rewritten as segment inventory grows, while
+        # fq-policy/2 pins the immutable release identity used by PolicyStore.
+        # The policy loop stores under ~/.cache/vllm by default. Fragment
+        # payloads have a separate ~/.cache/vllm/fq default and must not
+        # redirect restart recovery unless the policy root is explicit.
         cache_root = Path(
-            environ.get(FQ_CACHE_ENV) or os.path.expanduser(DEFAULT_CACHE_DIR)
+            environ.get("VLLM_FQ_CACHE_ROOT")
+            or os.path.expanduser("~/.cache/vllm")
         )
-        store = PolicyStore(cache_root, manifest_hash)
+        store = PolicyStore(cache_root, manifest_identity)
         return store.load_current()
 
     def make_resolver(self, **kwargs: Any) -> FragmentResolver:
@@ -641,6 +668,67 @@ def progressive_weights_iterator(
 # --------------------------------------------------------------- metadata
 
 
+def project_boot_policy(
+    policy: dict,
+    resolver: FragmentResolver,
+    *,
+    log: Callable[[str], None] | None = None,
+) -> tuple[dict, list[tuple[int, int, int, int]]]:
+    """Resolve fallback Ks before their bitmap sizes model parameters."""
+    projected, substitutions, missing = project_bits_to_available(
+        resolver, policy["bits_per_expert"], log=log
+    )
+    if missing:
+        raise ValueError(
+            "progressive boot cannot supply any tier for "
+            f"{len(missing)} expert(s), first={missing[:8]}"
+        )
+    bad_layers = {
+        int(layer): sorted({int(k) for k in bits})
+        for layer, bits in projected.items()
+        if len({int(k) for k in bits}) > 2
+    }
+    if bad_layers:
+        raise ValueError(
+            "fallback projection would create non-binary mixed layers: "
+            f"{bad_layers}; provide the requested fragments or choose a "
+            "binary policy that matches available tiers"
+        )
+
+    effective = json.loads(json.dumps(policy))
+    effective["bits_per_expert"] = {
+        str(layer): [int(k) for k in bits]
+        for layer, bits in projected.items()
+    }
+    budget = dict(effective.get("budget") or {})
+    if "n_k4_per_layer" in budget:
+        budget["n_k4_per_layer"] = {
+            str(layer): sum(int(k) == 4 for k in bits)
+            for layer, bits in projected.items()
+        }
+    effective["budget"] = budget
+    if substitutions:
+        provenance = dict(effective.get("provenance") or {})
+        encoded = json.dumps(
+            substitutions, separators=(",", ":"), sort_keys=True
+        ).encode()
+        provenance["boot_projection"] = {
+            "substitutions": len(substitutions),
+            "selection_sha256": hashlib.sha256(encoded).hexdigest(),
+        }
+        effective["provenance"] = provenance
+    return effective, substitutions
+
+
+def write_effective_policy(policy: dict, out_path: str | Path) -> Path:
+    out_path = Path(out_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = out_path.with_suffix(out_path.suffix + f".tmp{os.getpid()}")
+    tmp.write_text(json.dumps(policy, sort_keys=True, indent=1) + "\n")
+    os.replace(tmp, out_path)
+    return out_path
+
+
 def write_tier_bitmap(
     policy: dict,
     out_path: str | Path,
@@ -730,6 +818,14 @@ def main(argv: list[str] | None = None) -> int:
         help="tier bitmap path (default: <cache>/boot/<policy digest>.json)",
     )
     p.add_argument(
+        "--effective-policy-out",
+        default=None,
+        help=(
+            "write the pre-resolved boot policy here; required when fallback "
+            "changes any K so the loader and live loop share device truth"
+        ),
+    )
+    p.add_argument(
         "--extra-overrides",
         default=None,
         help="JSON dict merged into the emitted overrides",
@@ -746,22 +842,39 @@ def main(argv: list[str] | None = None) -> int:
         if v
     }
     spec = ProgressiveSpec.from_env(overrides=overrides_in)
+    import sys
+
+    resolver = spec.make_resolver()
+    effective, substitutions = project_boot_policy(
+        spec.policy, resolver, log=lambda msg: print(msg, file=sys.stderr)
+    )
+    if substitutions and not args.effective_policy_out:
+        raise ValueError(
+            "fallback changed the boot bitmap; pass --effective-policy-out "
+            "and launch with VLLM_FQ_POLICY set to that file"
+        )
+    if args.effective_policy_out:
+        write_effective_policy(effective, args.effective_policy_out)
+
     bitmap_path = args.bitmap_out
+    effective_digest = _policy_digest(effective)
     if bitmap_path is None:
         cache_root = Path(
             os.environ.get(FQ_CACHE_ENV) or os.path.expanduser(DEFAULT_CACHE_DIR)
         )
-        bitmap_path = cache_root / "boot" / f"{spec.policy_digest[:16]}.tier_bitmap.json"
-    write_tier_bitmap(spec.policy, bitmap_path)
+        bitmap_path = (
+            cache_root / "boot"
+            / f"{effective_digest[:16]}.tier_bitmap.json"
+        )
+    write_tier_bitmap(effective, bitmap_path)
     extra = json.loads(args.extra_overrides) if args.extra_overrides else None
     overrides = synthesize_hf_overrides(
-        spec.dense_source, spec.policy, bitmap_path, extra=extra
+        spec.dense_source, effective, bitmap_path, extra=extra
     )
-    import sys
 
     print(json.dumps(overrides, separators=(",", ":")))
     print(f"tier bitmap: {bitmap_path}", file=sys.stderr)
-    print(f"policy digest: {spec.policy_digest}", file=sys.stderr)
+    print(f"policy digest: {effective_digest}", file=sys.stderr)
     return 0
 
 

--- a/vllm/model_executor/layers/quantization/exl3_fungible/progressive.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/progressive.py
@@ -411,10 +411,11 @@ def progressive_weights_iterator(
             _want = [(k, n) for k, n in sorted(_need.items()) if n >= _bulk_min]
             if _want:
                 if layer in _inflight:
-                    logger.info(
-                        "FQ progressive L%d: waiting on background prefetch "
-                        "(%s)", layer,
-                        ", ".join(f"{n} experts want K{k}" for k, n in _want))
+                    _emit(
+                        f"FQ progressive L{layer}: waiting on background "
+                        f"prefetch ("
+                        + ", ".join(f"{n} experts want K{k}"
+                                    for k, n in _want) + ")")
                     for _fut in _inflight.pop(layer):
                         _fut.result()
                 else:
@@ -422,10 +423,10 @@ def progressive_weights_iterator(
                         _note = getattr(resolver, "prefetch_layer",
                                         lambda *a: None)(layer, _k)
                         if _note:
-                            logger.info(
-                                "FQ progressive L%d: %d experts want K%d -> "
-                                "%s (1 fetch instead of %d ranged reads)",
-                                layer, _n, _k, _note, _n)
+                            _emit(
+                                f"FQ progressive L{layer}: {_n} experts want "
+                                f"K{_k} -> {_note} (1 fetch instead of {_n} "
+                                f"ranged reads)")
             # Start the NEXT layer downloading while this one streams to GPU.
             for _ahead in range(1, _depth + 1):
                 if _idx + _ahead < len(_sorted_layers):

--- a/vllm/model_executor/layers/quantization/exl3_fungible/progressive.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/progressive.py
@@ -417,7 +417,9 @@ def progressive_weights_iterator(
                         + ", ".join(f"{n} experts want K{k}"
                                     for k, n in _want) + ")")
                     for _fut in _inflight.pop(layer):
-                        _fut.result()
+                        _note = _fut.result()
+                        if _note:
+                            _emit(f"FQ progressive L{layer}: {_note}")
                 else:
                     for _k, _n in _want:
                         _note = getattr(resolver, "prefetch_layer",

--- a/vllm/model_executor/layers/quantization/exl3_fungible/progressive.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/progressive.py
@@ -279,6 +279,7 @@ def progressive_weights_iterator(
     tp_rank: int | None = None,
     log: Callable[[str], None] | None = None,
     actual_bits_out: dict[int, list[int]] | None = None,
+    convergence_out: list | None = None,
 ):
     """Yield ``(name, cpu_tensor)`` exactly as an assembled checkpoint would.
 
@@ -355,6 +356,20 @@ def progressive_weights_iterator(
         #   width: a mixed layer needs TWO objects (its K3 and its K4). Pulling
         #     them one after the other leaves the link idle between files even
         #     with hf_transfer chunking inside each.
+        # OPPORTUNISTIC TIME-TO-SERVE (opt-in). Boot on whatever tiers the
+        # primed cache holds and converge afterwards, instead of making
+        # time-to-serve a function of the slowest fetch.
+        _plan = None
+        try:
+            from .convergence import ConvergencePlan, k_bounds, \
+                opportunistic_enabled
+            if opportunistic_enabled():
+                _lo, _hi = k_bounds()
+                _plan = ConvergencePlan(k_min=_lo, k_max=_hi)
+                _emit(f"FQ opportunistic boot ENABLED (accepting K{_lo}..K"
+                      f"{_hi}); served weights converge to policy at runtime")
+        except ImportError:
+            _plan = None
         _depth = max(1, int(os.environ.get("VLLM_FQ_PREFETCH_DEPTH", "3")))
         _pool = _cf.ThreadPoolExecutor(
             max_workers=_depth * 2, thread_name_prefix="fq-prefetch")
@@ -449,9 +464,13 @@ def progressive_weights_iterator(
                     # at the end of the layer with the full list — an operator
                     # needs to know how much is missing, not just the first.
                     unavailable.append(expert)
+                    if _plan is not None:
+                        _plan.observe_missing(layer, expert)
                     continue
                 actual_k = int(fragment.k)
                 actual_bits[expert] = actual_k
+                if _plan is not None:
+                    _plan.observe(layer, expert, actual_k, int(k))
                 if actual_k != int(k):
                     substitutions.append((expert, int(k), actual_k))
                 counts[actual_k] = counts.get(actual_k, 0) + 1
@@ -463,7 +482,13 @@ def progressive_weights_iterator(
                     yield name, tensor
             if actual_bits_out is not None:
                 actual_bits_out[layer] = list(actual_bits)
-            if unavailable:
+            if unavailable and _plan is not None:
+                # Opportunistic mode: completeness is the gate, adequacy is
+                # not. A missing expert still fails -- via _plan.gate() once
+                # the whole model is loaded, so the operator sees the full
+                # extent rather than the first layer that tripped.
+                pass
+            elif unavailable:
                 # Raise BEFORE the name-set parity check: parity will also
                 # fail (the missing experts contribute no tensors) but reports
                 # a symptom -- "stream does not match the source shard tensor
@@ -505,6 +530,15 @@ def progressive_weights_iterator(
             # Without this the boot keeps every segment it ever touched --
             # bounded only by the model size, not by the prefetch depth.
             getattr(resolver, "release_layer", lambda _l: 0)(layer)
+
+          if _plan is not None:
+            # ONCE, after every layer has streamed: an operator needs the
+            # full extent of what is missing, not the first layer that
+            # tripped over it.
+            _plan.gate()
+            _emit(_plan.describe())
+            if convergence_out is not None:
+                convergence_out.append(_plan)
         finally:
             # Never leave the prefetch thread running past the stream: a
             # cancelled boot would otherwise keep pulling segments nobody

--- a/vllm/model_executor/layers/quantization/exl3_fungible/progressive.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/progressive.py
@@ -1,0 +1,482 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Progressive Tensors boot (loader v2) — stream a mixed-K EXL3 checkpoint
+directly from segments + a policy, with no materialized assembled checkpoint.
+
+Pieces (torch + stdlib only; the vLLM loader class lives in
+``progressive_loader.py``):
+
+* :class:`ProgressiveSpec` — resolves manifest dir / policy / dense source
+  from the environment (``VLLM_FQ_MANIFEST_DIR``, ``VLLM_FQ_POLICY`` or the
+  M2 PolicyStore, ``VLLM_FQ_DENSE_SOURCE``) and validates them against each
+  other.
+* :func:`progressive_weights_iterator` — synthesizes the exact tensor
+  stream ``fq_assemble`` would have materialized: dense/attention/shared
+  (and bf16 MTP expert) tensors stream from the SOURCE checkpoint shards;
+  routed-expert tensors resolve per-policy through
+  :class:`~.fragments.FragmentResolver`. Name-set parity with the source
+  shard header is enforced per layer.
+* :func:`synthesize_hf_overrides` / :func:`write_tier_bitmap` — the mixed
+  ``hybrid_tr3_tail`` metadata + ``quantization_config`` stub of the GG
+  loader contract (runs/serve-baseline/fruit-mixed-report.md §2), emitted
+  as an ``--hf-overrides`` JSON whose ``bits_per_expert`` is an
+  absolute-path ``file.json:field`` reference to a tier bitmap written
+  from the policy.  ``python -m ...exl3_fungible.progressive`` emits both.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Iterable
+
+try:
+    from vllm.model_executor.layers.quantization.exl3_fungible.fragments import (
+        _ST_TO_TORCH_NAME,
+        EXPERT_RE,
+        FQ_CACHE_ENV,
+        DEFAULT_CACHE_DIR,
+        FragmentResolver,
+        read_safetensors_header,
+    )
+except ImportError:  # standalone execution (tests / CLI without built vllm)
+    import importlib.util as _ilu
+    import sys as _sys
+    from pathlib import Path as _P
+
+    _spec = _ilu.spec_from_file_location(
+        "fq_fragments_standalone", _P(__file__).resolve().parent / "fragments.py"
+    )
+    _mod = _ilu.module_from_spec(_spec)
+    _sys.modules[_spec.name] = _mod
+    _spec.loader.exec_module(_mod)
+    _ST_TO_TORCH_NAME = _mod._ST_TO_TORCH_NAME  # noqa: SLF001
+    EXPERT_RE = _mod.EXPERT_RE
+    FQ_CACHE_ENV = _mod.FQ_CACHE_ENV
+    DEFAULT_CACHE_DIR = _mod.DEFAULT_CACHE_DIR
+    FragmentResolver = _mod.FragmentResolver
+    read_safetensors_header = _mod.read_safetensors_header
+
+FQ_MANIFEST_DIR_ENV = "VLLM_FQ_MANIFEST_DIR"
+FQ_POLICY_ENV = "VLLM_FQ_POLICY"
+FQ_DENSE_SOURCE_ENV = "VLLM_FQ_DENSE_SOURCE"
+
+QUANT_STUB_KEYS = ("codebook", "exllamav3_version")
+
+_RANK_SEG_RE = re.compile(r"\.rank(\d+)\.")
+
+
+def _policy_digest(doc: dict) -> str:
+    return hashlib.sha256(
+        json.dumps(doc, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+
+
+def _bits_digest(bits: Iterable[int]) -> str:
+    return hashlib.sha256(
+        ",".join(str(int(b)) for b in bits).encode()
+    ).hexdigest()[:12]
+
+
+@dataclass
+class ProgressiveSpec:
+    """Everything a progressive boot needs, resolved and cross-checked."""
+
+    manifest_dir: Path
+    manifest: dict
+    policy: dict
+    policy_path: Path | None
+    dense_source: Path
+    bits_by_layer: dict[int, tuple[int, ...]]
+    k_values: tuple[int, ...]
+
+    @property
+    def policy_digest(self) -> str:
+        return _policy_digest(self.policy)
+
+    @classmethod
+    def from_env(
+        cls,
+        model_path: str | Path | None = None,
+        *,
+        environ: dict[str, str] = os.environ,  # noqa: B008
+        overrides: dict[str, Any] | None = None,
+    ) -> "ProgressiveSpec":
+        overrides = overrides or {}
+
+        manifest_dir = overrides.get("manifest_dir") or environ.get(
+            FQ_MANIFEST_DIR_ENV
+        )
+        if not manifest_dir:
+            raise ValueError(
+                "load_format=progressive requires the segment dir: set "
+                f"{FQ_MANIFEST_DIR_ENV} (dir with fq-manifest.json + "
+                "index-k*.json + layer-*.k*.safetensors) or pass "
+                "model_loader_extra_config={'manifest_dir': ...}"
+            )
+        manifest_dir = Path(manifest_dir)
+        manifest_path = manifest_dir / "fq-manifest.json"
+        manifest = (
+            json.loads(manifest_path.read_text())
+            if manifest_path.exists()
+            else {}
+        )
+
+        policy_path: Path | None = None
+        policy_ref = overrides.get("policy") or environ.get(FQ_POLICY_ENV)
+        if policy_ref:
+            policy_path = Path(policy_ref)
+            policy = json.loads(policy_path.read_text())
+        else:
+            policy = cls._policy_from_store(manifest_path, environ)
+            if policy is None:
+                raise ValueError(
+                    "load_format=progressive found no policy: set "
+                    f"{FQ_POLICY_ENV} to a fq-policy JSON or commit one to "
+                    "the PolicyStore for this manifest"
+                )
+
+        bpe = policy.get("bits_per_expert")
+        if not isinstance(bpe, dict) or not bpe:
+            raise ValueError("policy has no bits_per_expert map")
+        bits_by_layer = {
+            int(layer): tuple(int(b) for b in bits) for layer, bits in bpe.items()
+        }
+        k_values = tuple(
+            sorted({b for bits in bits_by_layer.values() for b in bits})
+        )
+
+        num_experts = manifest.get("num_experts")
+        if num_experts is not None:
+            for layer, bits in bits_by_layer.items():
+                if len(bits) != int(num_experts):
+                    raise ValueError(
+                        f"policy layer {layer} has {len(bits)} experts, "
+                        f"manifest says {num_experts}"
+                    )
+        moe_layers = manifest.get("moe_layers")
+        if isinstance(moe_layers, list) and len(moe_layers) == 2:
+            first, last = int(moe_layers[0]), int(moe_layers[1])
+            missing = sorted(
+                set(range(first, last + 1)) - set(bits_by_layer)
+            )
+            if missing:
+                raise ValueError(
+                    f"policy is missing MoE layers {missing} "
+                    f"(manifest moe_layers={moe_layers})"
+                )
+
+        dense_source = (
+            overrides.get("dense_source")
+            or environ.get(FQ_DENSE_SOURCE_ENV)
+            or manifest.get("dense_source")
+            or model_path
+        )
+        if not dense_source:
+            raise ValueError(
+                "load_format=progressive needs a dense source checkpoint: "
+                f"set {FQ_DENSE_SOURCE_ENV}, add 'dense_source' to "
+                "fq-manifest.json, or serve --model <dense checkpoint dir>"
+            )
+        dense_source = Path(dense_source)
+        if not dense_source.is_dir():
+            raise ValueError(
+                f"progressive dense source is not a directory: {dense_source}"
+            )
+
+        return cls(
+            manifest_dir=manifest_dir,
+            manifest=manifest,
+            policy=policy,
+            policy_path=policy_path,
+            dense_source=dense_source,
+            bits_by_layer=bits_by_layer,
+            k_values=k_values,
+        )
+
+    @staticmethod
+    def _policy_from_store(
+        manifest_path: Path, environ: dict[str, str]
+    ) -> dict | None:
+        """PolicyStore fallback: current.json keyed by the manifest hash."""
+        if not manifest_path.exists():
+            return None
+        try:
+            from vllm.model_executor.layers.quantization.exl3_fungible.store import (
+                PolicyStore,
+            )
+        except ImportError:
+            import importlib.util as _ilu
+            import sys as _sys
+
+            _spec = _ilu.spec_from_file_location(
+                "fq_store_standalone",
+                Path(__file__).resolve().parent / "store.py",
+            )
+            _mod = _ilu.module_from_spec(_spec)
+            _sys.modules[_spec.name] = _mod
+            _spec.loader.exec_module(_mod)
+            PolicyStore = _mod.PolicyStore
+        manifest_hash = hashlib.sha256(manifest_path.read_bytes()).hexdigest()
+        cache_root = Path(
+            environ.get(FQ_CACHE_ENV) or os.path.expanduser(DEFAULT_CACHE_DIR)
+        )
+        store = PolicyStore(cache_root, manifest_hash)
+        return store.load_current()
+
+    def make_resolver(self, **kwargs: Any) -> FragmentResolver:
+        return FragmentResolver(self.manifest_dir, **kwargs)
+
+    def shard_files(self) -> list[Path]:
+        index_path = self.dense_source / "model.safetensors.index.json"
+        if index_path.exists():
+            index = json.loads(index_path.read_text())
+            names = sorted(set(index.get("weight_map", {}).values()))
+            files = [self.dense_source / name for name in names]
+            missing = [f.name for f in files if not f.exists()]
+            if missing:
+                raise FileNotFoundError(
+                    f"dense source shards missing: {missing[:4]}"
+                )
+            return files
+        files = sorted(self.dense_source.glob("*.safetensors"))
+        if not files:
+            raise FileNotFoundError(
+                f"no safetensors shards in dense source {self.dense_source}"
+            )
+        return files
+
+
+def _shard_tensor(mm, body_offset: int, entry: dict):
+    """Zero-copy torch view of one tensor inside a source shard mmap."""
+    import warnings
+
+    import torch
+
+    dtype = getattr(torch, _ST_TO_TORCH_NAME[entry["dtype"]])
+    shape = tuple(entry["shape"])
+    numel = 1
+    for dim in shape:
+        numel *= dim
+    a, b = entry["data_offsets"]
+    if numel == 0:
+        return torch.empty(shape, dtype=dtype)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        return torch.frombuffer(
+            memoryview(mm), dtype=dtype, count=numel, offset=body_offset + a
+        ).view(shape)
+
+
+def progressive_weights_iterator(
+    spec: ProgressiveSpec,
+    resolver: FragmentResolver,
+    *,
+    tp_rank: int | None = None,
+    log: Callable[[str], None] | None = None,
+):
+    """Yield ``(name, cpu_tensor)`` exactly as an assembled checkpoint would.
+
+    Non-expert tensors stream from the dense-source shards; expert tensors
+    of policy layers resolve through the FragmentResolver at the policy's
+    per-expert K.  When ``tp_rank`` is given, only that rank's slice of the
+    rank-sliced expert tensors is yielded (the model drops foreign ranks
+    anyway; filtering here avoids materializing them at all).
+    """
+    import mmap as _mmap
+
+    def _emit(msg: str) -> None:
+        if log is not None:
+            log(msg)
+
+    def _rank_ok(name: str) -> bool:
+        if tp_rank is None:
+            return True
+        m = _RANK_SEG_RE.search(name)
+        return m is None or int(m.group(1)) == tp_rank
+
+    t_start = time.perf_counter()
+    dense_bytes = 0
+    expert_tensor_count = 0
+
+    for shard in spec.shard_files():
+        header, body_offset = read_safetensors_header(shard)
+        header.pop("__metadata__", None)
+        ordered = sorted(header.items(), key=lambda kv: kv[1]["data_offsets"][0])
+
+        expert_layers: dict[int, set[str]] = {}
+        f = open(shard, "rb")
+        # The mapping must outlive this generator: yielded tensors are
+        # zero-copy views that the quant method only devices-copies in
+        # process_weights_after_loading. GC owns the lifetime.
+        mm = _mmap.mmap(f.fileno(), 0, access=_mmap.ACCESS_READ)
+        for name, entry in ordered:
+            m = EXPERT_RE.match(name)
+            if m is not None and int(m.group(1)) in spec.bits_by_layer:
+                if _rank_ok(name):
+                    expert_layers.setdefault(int(m.group(1)), set()).add(name)
+                continue
+            dense_bytes += entry["data_offsets"][1] - entry["data_offsets"][0]
+            yield name, _shard_tensor(mm, body_offset, entry)
+
+        for layer in sorted(expert_layers):
+            expected_names = expert_layers[layer]
+            bits = spec.bits_by_layer[layer]
+            seen: set[str] = set()
+            counts: dict[int, int] = {}
+            for expert, k in enumerate(bits):
+                counts[k] = counts.get(k, 0) + 1
+                for name, tensor in resolver.expert_tensors(
+                    layer, expert, int(k), name_filter=_rank_ok
+                ):
+                    seen.add(name)
+                    expert_tensor_count += 1
+                    yield name, tensor
+            if seen != expected_names:
+                missing = sorted(expected_names - seen)[:4]
+                extra = sorted(seen - expected_names)[:4]
+                raise ValueError(
+                    f"progressive layer {layer}: fragment stream does not "
+                    f"match the source shard tensor set "
+                    f"(missing={missing}, unexpected={extra})"
+                )
+            _emit(
+                f"FQ progressive layer {layer}: tiers="
+                f"{tuple(sorted(counts.items()))} "
+                f"bits_digest={_bits_digest(bits)} "
+                f"tensors={len(seen)}"
+            )
+
+    stats = dict(resolver.stats)
+    _emit(
+        "FQ progressive stream complete: "
+        f"policy={spec.policy_digest[:12]} k_values={spec.k_values} "
+        f"dense_bytes={dense_bytes} expert_tensors={expert_tensor_count} "
+        f"fragments(local={stats['local']}, cache={stats['cache']}, "
+        f"fetched={stats['fetched']}, bytes_fetched={stats['bytes_fetched']}) "
+        f"wall={time.perf_counter() - t_start:.2f}s"
+    )
+
+
+# --------------------------------------------------------------- metadata
+
+
+def write_tier_bitmap(policy: dict, out_path: str | Path) -> Path:
+    """Write the per-layer expert bitrate map the exl3 loader dereferences."""
+    out_path = Path(out_path)
+    bitmap = {
+        layer: {"bits_per_expert": [int(b) for b in bits]}
+        for layer, bits in policy["bits_per_expert"].items()
+    }
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = out_path.with_suffix(out_path.suffix + f".tmp{os.getpid()}")
+    tmp.write_text(json.dumps(bitmap, indent=1) + "\n")
+    os.replace(tmp, out_path)
+    return out_path
+
+
+def synthesize_hf_overrides(
+    dense_source: str | Path,
+    policy: dict,
+    bitmap_path: str | Path,
+    *,
+    extra: dict | None = None,
+) -> dict:
+    """Build the ``--hf-overrides`` dict for a progressive boot.
+
+    Emits the full ``hybrid_tr3_tail`` (dict-valued hf_overrides replace the
+    attribute wholesale) patched per the mixed GG loader contract, plus the
+    ``quantization_config`` stub when the source config lacks one.  The
+    ``bits_per_expert`` reference uses an absolute path, which
+    ``get_hf_file_to_dict`` -> ``try_get_local_file`` resolves via
+    ``Path(model) / file`` = the absolute path itself.
+    """
+    cfg = json.loads((Path(dense_source) / "config.json").read_text())
+    tail = dict(cfg.get("hybrid_tr3_tail") or {})
+    if tail.get("format") != "exl3-trellis":
+        raise ValueError(
+            f"{dense_source}/config.json has no exl3-trellis hybrid_tr3_tail; "
+            "not a rank-sliced EXL3 dense source"
+        )
+    ks = sorted({int(b) for bits in policy["bits_per_expert"].values() for b in bits})
+    if len(ks) == 1:
+        tail["bits"] = float(ks[0])
+        tail.pop("k_values", None)
+        tail.pop("bits_per_expert", None)
+    else:
+        tail["bits"] = "mixed"
+        tail["k_values"] = ks
+        tail["bits_per_expert"] = (
+            f"{Path(bitmap_path).resolve()}:bits_per_expert"
+        )
+
+    overrides: dict[str, Any] = {"hybrid_tr3_tail": tail}
+    if "quantization_config" not in cfg:
+        overrides["quantization_config"] = {
+            "quant_method": "exl3",
+            "bits": tail["bits"],
+            "codebook": tail.get("codebook", "mcg"),
+            "version": tail.get("exllamav3_version", "rank-sliced"),
+        }
+    if extra:
+        overrides.update(extra)
+    return overrides
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Emit the tier bitmap + --hf-overrides JSON for a progressive boot."""
+    import argparse
+
+    p = argparse.ArgumentParser(description=main.__doc__)
+    p.add_argument("--manifest-dir", default=None)
+    p.add_argument("--policy", default=None)
+    p.add_argument("--dense-source", default=None)
+    p.add_argument(
+        "--bitmap-out",
+        default=None,
+        help="tier bitmap path (default: <cache>/boot/<policy digest>.json)",
+    )
+    p.add_argument(
+        "--extra-overrides",
+        default=None,
+        help="JSON dict merged into the emitted overrides",
+    )
+    args = p.parse_args(argv)
+
+    overrides_in = {
+        k: v
+        for k, v in {
+            "manifest_dir": args.manifest_dir,
+            "policy": args.policy,
+            "dense_source": args.dense_source,
+        }.items()
+        if v
+    }
+    spec = ProgressiveSpec.from_env(overrides=overrides_in)
+    bitmap_path = args.bitmap_out
+    if bitmap_path is None:
+        cache_root = Path(
+            os.environ.get(FQ_CACHE_ENV) or os.path.expanduser(DEFAULT_CACHE_DIR)
+        )
+        bitmap_path = cache_root / "boot" / f"{spec.policy_digest[:16]}.tier_bitmap.json"
+    write_tier_bitmap(spec.policy, bitmap_path)
+    extra = json.loads(args.extra_overrides) if args.extra_overrides else None
+    overrides = synthesize_hf_overrides(
+        spec.dense_source, spec.policy, bitmap_path, extra=extra
+    )
+    import sys
+
+    print(json.dumps(overrides, separators=(",", ":")))
+    print(f"tier bitmap: {bitmap_path}", file=sys.stderr)
+    print(f"policy digest: {spec.policy_digest}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(main())

--- a/vllm/model_executor/layers/quantization/exl3_fungible/progressive.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/progressive.py
@@ -278,6 +278,7 @@ def progressive_weights_iterator(
     *,
     tp_rank: int | None = None,
     log: Callable[[str], None] | None = None,
+    actual_bits_out: dict[int, list[int]] | None = None,
 ):
     """Yield ``(name, cpu_tensor)`` exactly as an assembled checkpoint would.
 
@@ -286,6 +287,14 @@ def progressive_weights_iterator(
     per-expert K.  When ``tp_rank`` is given, only that rank's slice of the
     rank-sliced expert tensors is yielded (the model drops foreign ranks
     anyway; filtering here avoids materializing them at all).
+
+    With ``VLLM_FQ_K_FALLBACK`` active the resolver may substitute a
+    fallback K for a missing/untrusted fragment; the per-layer tier line and
+    ``bits_digest`` are computed from the ACTUALLY loaded Ks (reality, not
+    the requested policy), substitutions are called out on the line, and
+    ``actual_bits_out`` (when given) receives the per-layer actually-loaded
+    bits vectors — feed it to :func:`write_tier_bitmap` so the hybrid
+    metadata records the loaded Ks.
     """
     import mmap as _mmap
 
@@ -326,16 +335,25 @@ def progressive_weights_iterator(
         for layer in sorted(expert_layers):
             expected_names = expert_layers[layer]
             bits = spec.bits_by_layer[layer]
+            actual_bits = [int(b) for b in bits]
+            substitutions: list[tuple[int, int, int]] = []
             seen: set[str] = set()
             counts: dict[int, int] = {}
             for expert, k in enumerate(bits):
-                counts[k] = counts.get(k, 0) + 1
-                for name, tensor in resolver.expert_tensors(
-                    layer, expert, int(k), name_filter=_rank_ok
+                fragment = resolver.resolve(layer, expert, int(k))
+                actual_k = int(fragment.k)
+                actual_bits[expert] = actual_k
+                if actual_k != int(k):
+                    substitutions.append((expert, int(k), actual_k))
+                counts[actual_k] = counts.get(actual_k, 0) + 1
+                for name, tensor in resolver.materialize(
+                    fragment, name_filter=_rank_ok
                 ):
                     seen.add(name)
                     expert_tensor_count += 1
                     yield name, tensor
+            if actual_bits_out is not None:
+                actual_bits_out[layer] = list(actual_bits)
             if seen != expected_names:
                 missing = sorted(expected_names - seen)[:4]
                 extra = sorted(seen - expected_names)[:4]
@@ -344,11 +362,17 @@ def progressive_weights_iterator(
                     f"match the source shard tensor set "
                     f"(missing={missing}, unexpected={extra})"
                 )
+            sub_note = ""
+            if substitutions:
+                sub_note = " substituted=" + ",".join(
+                    f"e{expert}:K{requested}->K{got}"
+                    for expert, requested, got in substitutions
+                )
             _emit(
                 f"FQ progressive layer {layer}: tiers="
                 f"{tuple(sorted(counts.items()))} "
-                f"bits_digest={_bits_digest(bits)} "
-                f"tensors={len(seen)}"
+                f"bits_digest={_bits_digest(actual_bits)} "
+                f"tensors={len(seen)}{sub_note}"
             )
 
     stats = dict(resolver.stats)
@@ -357,7 +381,9 @@ def progressive_weights_iterator(
         f"policy={spec.policy_digest[:12]} k_values={spec.k_values} "
         f"dense_bytes={dense_bytes} expert_tensors={expert_tensor_count} "
         f"fragments(local={stats['local']}, cache={stats['cache']}, "
-        f"fetched={stats['fetched']}, bytes_fetched={stats['bytes_fetched']}) "
+        f"fetched={stats['fetched']}, bytes_fetched={stats['bytes_fetched']}, "
+        f"substituted={stats.get('fallback_substituted', 0)}, "
+        f"encode_queued={stats.get('encode_queued', 0)}) "
         f"wall={time.perf_counter() - t_start:.2f}s"
     )
 
@@ -365,12 +391,25 @@ def progressive_weights_iterator(
 # --------------------------------------------------------------- metadata
 
 
-def write_tier_bitmap(policy: dict, out_path: str | Path) -> Path:
-    """Write the per-layer expert bitrate map the exl3 loader dereferences."""
+def write_tier_bitmap(
+    policy: dict,
+    out_path: str | Path,
+    *,
+    actual_bits: dict[int, list[int]] | None = None,
+) -> Path:
+    """Write the per-layer expert bitrate map the exl3 loader dereferences.
+
+    ``actual_bits`` (e.g. the ``actual_bits_out`` collected from
+    :func:`progressive_weights_iterator`) overrides the policy's bits so the
+    hybrid metadata records the ACTUALLY loaded Ks after fallback
+    substitution."""
     out_path = Path(out_path)
+    source = (
+        actual_bits if actual_bits is not None else policy["bits_per_expert"]
+    )
     bitmap = {
-        layer: {"bits_per_expert": [int(b) for b in bits]}
-        for layer, bits in policy["bits_per_expert"].items()
+        str(layer): {"bits_per_expert": [int(b) for b in bits]}
+        for layer, bits in source.items()
     }
     out_path.parent.mkdir(parents=True, exist_ok=True)
     tmp = out_path.with_suffix(out_path.suffix + f".tmp{os.getpid()}")

--- a/vllm/model_executor/layers/quantization/exl3_fungible/progressive.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/progressive.py
@@ -344,8 +344,40 @@ def progressive_weights_iterator(
             substitutions: list[tuple[int, int, int]] = []
             seen: set[str] = set()
             counts: dict[int, int] = {}
+            # UNIFORM-LAYER FAST PATH. When every expert of this layer wants
+            # the same K they all live in one segment object, and fetching it
+            # per-expert is 256 HTTP round trips for one contiguous file --
+            # 19,200 across GLM-5.2. Pull it once and slice locally: identical
+            # bytes, 1 request, and 255 fewer chances to hit the transient
+            # failure that killed an earlier boot. Only for uniform layers:
+            # a layer needing one K4 expert must not drag a whole segment.
+            uniq = set(int(x) for x in bits)
+            if len(uniq) == 1:
+                only_k = uniq.pop()
+                note = getattr(resolver, "prefetch_layer", lambda *a: None)(
+                    layer, only_k)
+                if note:
+                    logger.info(
+                        "FQ progressive L%d: uniform K%d -> %s "
+                        "(1 fetch instead of %d ranged reads)",
+                        layer, only_k, note, len(bits))
+
+            unavailable: list[int] = []
             for expert, k in enumerate(bits):
-                fragment = resolver.resolve(layer, expert, int(k))
+                # resolve_best NEVER raises. resolve() does, and BOOT is
+                # precisely when a fragment is most likely to be missing and
+                # the least acceptable place to die: one absent expert out of
+                # 19,200 killed the whole engine
+                # (FragmentUnavailableError -> WorkerProc init failed).
+                # A transient network REJECT on one expert must degrade that
+                # expert, not the model.
+                fragment = resolver.resolve_best(layer, expert, int(k))
+                if fragment is None:
+                    # Nothing at any K. Record it, keep going, and fail once
+                    # at the end of the layer with the full list — an operator
+                    # needs to know how much is missing, not just the first.
+                    unavailable.append(expert)
+                    continue
                 actual_k = int(fragment.k)
                 actual_bits[expert] = actual_k
                 if actual_k != int(k):
@@ -359,6 +391,24 @@ def progressive_weights_iterator(
                     yield name, tensor
             if actual_bits_out is not None:
                 actual_bits_out[layer] = list(actual_bits)
+            if unavailable:
+                # Raise BEFORE the name-set parity check: parity will also
+                # fail (the missing experts contribute no tensors) but reports
+                # a symptom -- "stream does not match the source shard tensor
+                # set" -- when the operator needs the cause and its scale.
+                # Same import seam the rest of this module uses: the
+                # CPU tests load these files standalone, so a relative
+                # import has no parent package to resolve against.
+                FragmentUnavailableError = type(resolver).__module__ \
+                    and __import__(type(resolver).__module__,
+                                   fromlist=['FragmentUnavailableError']
+                                   ).FragmentUnavailableError
+                raise FragmentUnavailableError(
+                    f"progressive layer {layer}: {len(unavailable)} expert(s) "
+                    f"have no fragment at ANY K: "
+                    f"{unavailable[:16]}"
+                    f"{'...' if len(unavailable) > 16 else ''}. Check "
+                    f"VLLM_FQ_MANIFEST_DIR / VLLM_FQ_SOURCES reachability.")
             if seen != expected_names:
                 missing = sorted(expected_names - seen)[:4]
                 extra = sorted(seen - expected_names)[:4]

--- a/vllm/model_executor/layers/quantization/exl3_fungible/progressive.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/progressive.py
@@ -554,6 +554,13 @@ def progressive_weights_iterator(
                 _emit(_plan.describe())
             if convergence_out is not None:
                 convergence_out.append(_plan)
+            # Publish process-wide: without this the plan is unreachable and
+            # the convergence telemetry does not exist at runtime.
+            try:
+                from .convergence import set_active_plan
+                set_active_plan(_plan)
+            except ImportError:
+                pass
         finally:
             # Never leave the prefetch thread running past the stream: a
             # cancelled boot would otherwise keep pulling segments nobody

--- a/vllm/model_executor/layers/quantization/exl3_fungible/progressive.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/progressive.py
@@ -318,11 +318,16 @@ def progressive_weights_iterator(
         ordered = sorted(header.items(), key=lambda kv: kv[1]["data_offsets"][0])
 
         expert_layers: dict[int, set[str]] = {}
-        f = open(shard, "rb")
-        # The mapping must outlive this generator: yielded tensors are
-        # zero-copy views that the quant method only devices-copies in
-        # process_weights_after_loading. GC owns the lifetime.
-        mm = _mmap.mmap(f.fileno(), 0, access=_mmap.ACCESS_READ)
+        # The MAPPING must outlive this generator: yielded tensors are
+        # zero-copy views that the quant method only device-copies in
+        # process_weights_after_loading, so GC owns its lifetime (every
+        # torch.frombuffer view holds a reference to the memoryview, which
+        # holds the mmap).  The file OBJECT must not: mmap(2) keeps its own
+        # duplicate of the descriptor, so scoping the open halves what the
+        # load window costs per shard and stops the close from depending on
+        # the old binding's refcount dropping at the next iteration.
+        with open(shard, "rb") as f:
+            mm = _mmap.mmap(f.fileno(), 0, access=_mmap.ACCESS_READ)
         for name, entry in ordered:
             m = EXPERT_RE.match(name)
             if m is not None and int(m.group(1)) in spec.bits_by_layer:

--- a/vllm/model_executor/layers/quantization/exl3_fungible/progressive_loader.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/progressive_loader.py
@@ -239,7 +239,7 @@ class ProgressiveModelLoader(BaseModelLoader):
                     "VLLM_FQ_BUDGET_MIN_KV", 4 * (1 << 30)),
             )
             logger.info("FQ memory preflight: weight source = %s", source)
-            if not source.startswith("measured"):
+            if not source.startswith(("measured", "calibrated")):
                 # Refusing a boot on a number we know is inflated would be a
                 # worse failure than the one this check exists to prevent:
                 # it would block policies that fit. Report, do not enforce.

--- a/vllm/model_executor/layers/quantization/exl3_fungible/progressive_loader.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/progressive_loader.py
@@ -37,6 +37,39 @@ logger = init_logger(__name__)
 
 _EXTRA_CONFIG_KEYS = {"manifest_dir", "policy", "dense_source"}
 
+# Set by the last progressive load_weights on this worker, consumed by
+# record_weight_footprint once the weights are actually resident. Module-level
+# rather than threaded through vLLM's worker API, which has no seam for it.
+_LAST_LOAD: dict = {}
+
+
+def _remember_load(loader, spec, tp_rank) -> None:
+    _LAST_LOAD.update(loader=loader, spec=spec, tp_rank=tp_rank)
+
+
+def record_weight_footprint(allocated_bytes: int) -> None:
+    """Calibrate the dense term from a load that actually completed.
+
+    ``allocated_bytes`` is the true per-rank weight footprint, measured after
+    process_weights_after_loading. Subtracting the policy's expert bytes
+    leaves the policy-INDEPENDENT dense term -- which is what the preflight
+    cannot compute from headers, because non-expert tensors carry no .rankN.
+    suffix and summing their file bytes charges one rank for all four.
+    """
+    loader = _LAST_LOAD.get("loader")
+    if loader is None or loader._last_expert_bytes is None:
+        return
+    dense = allocated_bytes - loader._last_expert_bytes
+    if dense <= 0:
+        logger.warning(
+            "FQ calibration skipped: footprint %.2f GiB is below the policy's "
+            "own expert bytes %.2f GiB -- measured too early to be the real "
+            "footprint", allocated_bytes / (1 << 30),
+            loader._last_expert_bytes / (1 << 30))
+        return
+    loader._write_dense_calibration(
+        _LAST_LOAD["spec"], _LAST_LOAD["tp_rank"], dense)
+
 
 class ProgressiveModelLoader(BaseModelLoader):
     """Stream mixed-K EXL3 weights from Progressive Tensors segments."""
@@ -119,7 +152,9 @@ class ProgressiveModelLoader(BaseModelLoader):
             "Loading weights took %.2f seconds (progressive)",
             time.perf_counter() - start,
         )
-        self._reclaim_allocator(spec, tp_rank)
+        # Reclaim + calibration happen in gpu_worker AFTER
+        # process_weights_after_loading -- see record_weight_footprint.
+        _remember_load(self, spec, tp_rank)
 
     # ------------------------------------------------------------ memory
 

--- a/vllm/model_executor/layers/quantization/exl3_fungible/progressive_loader.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/progressive_loader.py
@@ -90,6 +90,20 @@ class ProgressiveModelLoader(BaseModelLoader):
             spec.k_values,
             tp_rank,
         )
+        # State the network posture BEFORE the nine-minute compile, not after
+        # a failure. A run that silently fetched when the operator asked for
+        # offline is not reproducible; a run that cannot fetch should say so
+        # while there is still time to prime the cache.
+        try:
+            from vllm.model_executor.layers.quantization.exl3_fungible.\
+                fragments import HfSource
+            if HfSource.offline():
+                logger.warning(
+                    "Progressive boot: OFFLINE (HF_HUB_OFFLINE set) — Hub "
+                    "sources disabled; only local segment dirs and the primed "
+                    "cache will be used. Set FQ_ALLOW_NETWORK=1 to override.")
+        except Exception:  # noqa: BLE001 — posture logging must not fail a boot
+            pass
         start = time.perf_counter()
         model.load_weights(
             progressive_weights_iterator(

--- a/vllm/model_executor/layers/quantization/exl3_fungible/progressive_loader.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/progressive_loader.py
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""``--load-format progressive`` — boot mixed-K EXL3 from Progressive
+Tensors segments + a policy, with no materialized assembled checkpoint.
+
+The loader synthesizes the tensor stream an assembled checkpoint would
+provide (see :mod:`.progressive`): dense/attention/shared tensors from the
+dense-source checkpoint dir, routed experts resolved per-policy through the
+:class:`~.fragments.FragmentResolver` (local segment dirs -> HF sources).
+The mixed ``hybrid_tr3_tail`` / ``quantization_config`` metadata reaches
+the model config through the ``--hf-overrides`` JSON that
+``python -m ...exl3_fungible.progressive`` emits at serve time.
+
+Configuration: ``VLLM_FQ_MANIFEST_DIR`` (+ ``VLLM_FQ_POLICY`` /
+``VLLM_FQ_DENSE_SOURCE`` / ``VLLM_FQ_CACHE`` / ``VLLM_FQ_VERIFY`` /
+``VLLM_FQ_SOURCES``), overridable per-serve via
+``--model-loader-extra-config '{"manifest_dir": ..., "policy": ...,
+"dense_source": ...}'``.
+"""
+from __future__ import annotations
+
+import time
+
+from torch import nn
+
+from vllm.config import ModelConfig
+from vllm.config.load import LoadConfig
+from vllm.logger import init_logger
+from vllm.model_executor.layers.quantization.exl3_fungible.progressive import (
+    ProgressiveSpec,
+    progressive_weights_iterator,
+)
+from vllm.model_executor.model_loader.base_loader import BaseModelLoader
+
+logger = init_logger(__name__)
+
+_EXTRA_CONFIG_KEYS = {"manifest_dir", "policy", "dense_source"}
+
+
+class ProgressiveModelLoader(BaseModelLoader):
+    """Stream mixed-K EXL3 weights from Progressive Tensors segments."""
+
+    def __init__(self, load_config: LoadConfig):
+        super().__init__(load_config)
+        extra = load_config.model_loader_extra_config or {}
+        if not isinstance(extra, dict):
+            raise ValueError(
+                "model_loader_extra_config must be a dict for "
+                "load_format=progressive"
+            )
+        unexpected = set(extra) - _EXTRA_CONFIG_KEYS
+        if unexpected:
+            raise ValueError(
+                f"Unexpected extra config keys for load_format=progressive: "
+                f"{unexpected} (allowed: {sorted(_EXTRA_CONFIG_KEYS)})"
+            )
+        self._extra = extra
+
+    def _spec(self, model_config: ModelConfig) -> ProgressiveSpec:
+        return ProgressiveSpec.from_env(
+            model_config.model, overrides=self._extra
+        )
+
+    def download_model(self, model_config: ModelConfig) -> None:
+        # Validates that manifest dir / policy / dense source resolve; all
+        # fragment IO is lazy and rank-scoped, so there is nothing to
+        # prefetch here.
+        self._spec(model_config)
+
+    @staticmethod
+    def _tp_rank() -> int | None:
+        try:
+            from vllm.distributed import get_tensor_model_parallel_rank
+
+            return get_tensor_model_parallel_rank()
+        except (ImportError, AssertionError, RuntimeError, ValueError):
+            return None
+
+    def load_weights(self, model: nn.Module, model_config: ModelConfig) -> None:
+        spec = self._spec(model_config)
+        resolver = spec.make_resolver()
+        tp_rank = self._tp_rank()
+        logger.info(
+            "Progressive boot: manifest_dir=%s policy=%s (digest %s) "
+            "dense_source=%s k_values=%s tp_rank=%s",
+            spec.manifest_dir,
+            spec.policy_path or "<policy store>",
+            spec.policy_digest[:12],
+            spec.dense_source,
+            spec.k_values,
+            tp_rank,
+        )
+        start = time.perf_counter()
+        model.load_weights(
+            progressive_weights_iterator(
+                spec,
+                resolver,
+                tp_rank=tp_rank,
+                log=logger.info,
+            )
+        )
+        logger.info_once(
+            "Loading weights took %.2f seconds (progressive)",
+            time.perf_counter() - start,
+        )

--- a/vllm/model_executor/layers/quantization/exl3_fungible/progressive_loader.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/progressive_loader.py
@@ -19,6 +19,7 @@ Configuration: ``VLLM_FQ_MANIFEST_DIR`` (+ ``VLLM_FQ_POLICY`` /
 """
 from __future__ import annotations
 
+import os
 import time
 
 from torch import nn
@@ -104,6 +105,7 @@ class ProgressiveModelLoader(BaseModelLoader):
                     "cache will be used. Set FQ_ALLOW_NETWORK=1 to override.")
         except Exception:  # noqa: BLE001 — posture logging must not fail a boot
             pass
+        self._preflight_memory(spec, resolver, tp_rank)
         start = time.perf_counter()
         model.load_weights(
             progressive_weights_iterator(
@@ -117,3 +119,88 @@ class ProgressiveModelLoader(BaseModelLoader):
             "Loading weights took %.2f seconds (progressive)",
             time.perf_counter() - start,
         )
+        self._reclaim_allocator()
+
+    # ------------------------------------------------------------ memory
+
+    def _preflight_memory(self, spec, resolver, tp_rank) -> None:
+        """Reject an oversized policy before paying for the load.
+
+        A mixed-K footprint is fixed by the tier bitmap, so this is arithmetic.
+        We learned that the expensive way: a policy 5.72 GiB over budget was
+        only caught after a 62-minute load, by the KV allocator reporting
+        ``Available KV cache memory: -3.1 GiB``.
+        """
+        if os.environ.get("VLLM_FQ_BUDGET_PREFLIGHT", "1") == "0":
+            return
+        try:
+            import torch
+
+            from .memory_preflight import _env_bytes, check_or_raise, project
+            from .progressive import measure_footprint_inputs
+
+            free, total = torch.cuda.mem_get_info()
+            expert_bytes_by_k, dense_bytes = measure_footprint_inputs(
+                spec, resolver, tp_rank=tp_rank)
+            if not expert_bytes_by_k:
+                logger.warning("FQ memory preflight skipped: no fragment "
+                               "could be sized")
+                return
+            util = float(os.environ.get("VLLM_FQ_BUDGET_UTIL", "0"))
+            if not util:
+                from vllm.config import get_current_vllm_config
+                util = get_current_vllm_config().cache_config \
+                    .gpu_memory_utilization
+            proj = project(
+                spec.bits_by_layer,
+                expert_bytes_by_k,
+                dense_bytes,
+                device_total_bytes=total,
+                gpu_memory_utilization=util,
+                # Measured on this box: a flat-K3 TP4 boot leaves 5.27 GiB of
+                # allocator + activation + graph residue. Overridable because
+                # it is the one term that is a calibration, not a measurement
+                # of THIS policy.
+                runtime_overhead_bytes=_env_bytes(
+                    "VLLM_FQ_BUDGET_OVERHEAD", int(5.5 * (1 << 30))),
+                min_kv_bytes=_env_bytes(
+                    "VLLM_FQ_BUDGET_MIN_KV", 4 * (1 << 30)),
+            )
+            check_or_raise(proj, expert_bytes_by_k, logger.info)
+        except ImportError:
+            logger.warning("FQ memory preflight unavailable", exc_info=True)
+
+    @staticmethod
+    def _reclaim_allocator() -> None:
+        """Return the streaming residue to the driver before KV profiling.
+
+        Progressive loading stages tens of thousands of small per-expert
+        buffers. PyTorch's caching allocator keeps those blocks RESERVED after
+        they are freed, but vLLM sizes the KV cache from what the DRIVER
+        reports free -- so the residue is charged against KV even though
+        nothing holds it. Measured on a TP4 GLM-5.2 boot: progressive left
+        9.19 GiB of non-weight residue where the equivalent flat load left
+        5.27 GiB, i.e. 3.92 GiB of KV cache silently consumed by an allocator
+        bookkeeping artifact.
+        """
+        try:
+            import gc
+
+            import torch
+
+            if not torch.cuda.is_available():
+                return
+            before_r = torch.cuda.memory_reserved()
+            before_a = torch.cuda.memory_allocated()
+            gc.collect()
+            torch.cuda.empty_cache()
+            after_r = torch.cuda.memory_reserved()
+            logger.info(
+                "FQ post-load reclaim: reserved %.2f -> %.2f GiB "
+                "(freed %.2f GiB of allocator residue; allocated %.2f GiB "
+                "is the real weight footprint)",
+                before_r / (1 << 30), after_r / (1 << 30),
+                (before_r - after_r) / (1 << 30), before_a / (1 << 30),
+            )
+        except ImportError:
+            pass

--- a/vllm/model_executor/layers/quantization/exl3_fungible/progressive_loader.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/progressive_loader.py
@@ -119,7 +119,7 @@ class ProgressiveModelLoader(BaseModelLoader):
             "Loading weights took %.2f seconds (progressive)",
             time.perf_counter() - start,
         )
-        self._reclaim_allocator()
+        self._reclaim_allocator(spec, tp_rank)
 
     # ------------------------------------------------------------ memory
 
@@ -136,7 +136,9 @@ class ProgressiveModelLoader(BaseModelLoader):
         try:
             import torch
 
-            from .memory_preflight import _env_bytes, check_or_raise, project
+            from .memory_preflight import (_env_bytes, check_or_raise,
+                                           project, project_expert_bytes,
+                                           render)
             from .progressive import measure_footprint_inputs
 
             free, total = torch.cuda.mem_get_info()
@@ -146,6 +148,41 @@ class ProgressiveModelLoader(BaseModelLoader):
                 logger.warning("FQ memory preflight skipped: no fragment "
                                "could be sized")
                 return
+
+            # vLLM constructs the model -- allocating every parameter at its
+            # final sharded shape, which for a mixed-K checkpoint means the
+            # tier bitmap has already been honoured -- BEFORE calling us to
+            # fill those parameters in. So the true per-rank weight footprint
+            # is not something to reconstruct from file headers; it is sitting
+            # in the allocator right now, exact.
+            #
+            # Reconstructing it is in fact wrong: non-expert tensors carry no
+            # .rankN. suffix in the source shards because vLLM shards them
+            # internally at load, so summing their file bytes charges one rank
+            # for all four (35.19 GiB instead of ~12.14 GiB on GLM-5.2 TP4 --
+            # a 23 GiB error, enough to reject a policy that fits comfortably).
+            measured = torch.cuda.memory_allocated()
+            projected_experts, _ = project_expert_bytes(
+                spec.bits_by_layer, expert_bytes_by_k)
+            # Stash for the post-load calibration write.
+            self._last_expert_bytes = projected_experts
+            calibrated = self._read_dense_calibration(spec, tp_rank)
+            if measured >= projected_experts:
+                dense_bytes = measured - projected_experts
+                source = "measured (allocator, post-construction)"
+            elif calibrated is not None:
+                # Measured on a PREVIOUS boot of this same model/TP/dense
+                # source: total weight footprint minus that boot's expert
+                # bytes. The dense term does not depend on the policy, so one
+                # successful boot calibrates every later projection exactly.
+                dense_bytes = calibrated
+                source = "calibrated from a previous boot"
+            else:
+                # Parameters are not resident yet -- fall back to headers and
+                # say so, because the dense term is then an upper bound that
+                # over-charges a TP rank.
+                source = ("header upper bound -- dense term counts all TP "
+                          "ranks; treat a near-miss as inconclusive")
             util = float(os.environ.get("VLLM_FQ_BUDGET_UTIL", "0"))
             if not util:
                 from vllm.config import get_current_vllm_config
@@ -166,12 +203,81 @@ class ProgressiveModelLoader(BaseModelLoader):
                 min_kv_bytes=_env_bytes(
                     "VLLM_FQ_BUDGET_MIN_KV", 4 * (1 << 30)),
             )
+            logger.info("FQ memory preflight: weight source = %s", source)
+            if not source.startswith("measured"):
+                # Refusing a boot on a number we know is inflated would be a
+                # worse failure than the one this check exists to prevent:
+                # it would block policies that fit. Report, do not enforce.
+                for line in render(proj, expert_bytes_by_k):
+                    logger.info(line)
+                if not proj["fits"]:
+                    logger.warning(
+                        "FQ memory preflight: projection is an UPPER BOUND "
+                        "and does not fit -- proceeding anyway; the engine's "
+                        "own KV sizing has the final say.")
+                return
             check_or_raise(proj, expert_bytes_by_k, logger.info)
         except ImportError:
             logger.warning("FQ memory preflight unavailable", exc_info=True)
 
+    _last_expert_bytes: int | None = None
+
     @staticmethod
-    def _reclaim_allocator() -> None:
+    def _calibration_path(spec, tp_rank):
+        """Where this (dense source, TP rank) records its dense footprint.
+
+        Keyed by rank because TP sharding is not uniform across ranks for
+        every tensor, and by dense source because that is what determines the
+        non-expert bytes.
+        """
+        import hashlib
+        from pathlib import Path
+
+        key = hashlib.blake2b(
+            f"{spec.dense_source}|tp{tp_rank}".encode(), digest_size=8
+        ).hexdigest()
+        root = os.environ.get("VLLM_FQ_CACHE") or os.path.expanduser(
+            "~/.cache/fq")
+        return Path(root) / "calibration" / f"dense-{key}.json"
+
+    def _read_dense_calibration(self, spec, tp_rank) -> int | None:
+        override = os.environ.get("VLLM_FQ_BUDGET_DENSE")
+        if override:
+            from .memory_preflight import _env_bytes
+            return _env_bytes("VLLM_FQ_BUDGET_DENSE", 0)
+        try:
+            import json
+            return int(json.loads(
+                self._calibration_path(spec, tp_rank).read_text()
+            )["dense_bytes"])
+        except (OSError, ValueError, KeyError):
+            return None
+
+    def _write_dense_calibration(self, spec, tp_rank, dense_bytes: int) -> None:
+        """Record the dense footprint a successful boot actually used.
+
+        Written only from a boot that got all the way through load_weights, so
+        the number reflects a configuration that really ran.
+        """
+        try:
+            import json
+            p = self._calibration_path(spec, tp_rank)
+            p.parent.mkdir(parents=True, exist_ok=True)
+            tmp = p.with_suffix(".tmp")
+            tmp.write_text(json.dumps({
+                "dense_bytes": int(dense_bytes),
+                "dense_source": str(spec.dense_source),
+                "tp_rank": tp_rank,
+            }))
+            tmp.replace(p)  # atomic: a torn file would poison every later boot
+            logger.info(
+                "FQ memory preflight: calibrated dense footprint %.2f GiB "
+                "for tp_rank=%s -- future boots will project exactly",
+                dense_bytes / (1 << 30), tp_rank)
+        except (OSError, ValueError):
+            logger.warning("FQ dense calibration not written", exc_info=True)
+
+    def _reclaim_allocator(self, spec=None, tp_rank=None) -> None:
         """Return the streaming residue to the driver before KV profiling.
 
         Progressive loading stages tens of thousands of small per-expert
@@ -202,5 +308,13 @@ class ProgressiveModelLoader(BaseModelLoader):
                 before_r / (1 << 30), after_r / (1 << 30),
                 (before_r - after_r) / (1 << 30), before_a / (1 << 30),
             )
+            # allocated == the real per-rank weight footprint now that every
+            # parameter is filled. Subtracting the policy's expert bytes
+            # leaves the policy-independent dense term, which is exactly what
+            # the next boot's projection is missing.
+            if spec is not None and self._last_expert_bytes is not None:
+                dense = before_a - self._last_expert_bytes
+                if dense > 0:
+                    self._write_dense_calibration(spec, tp_rank, dense)
         except ImportError:
             pass

--- a/vllm/model_executor/layers/quantization/exl3_fungible/stats.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/stats.py
@@ -1,0 +1,181 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Fungible-quant stats collector (M1).
+
+Per-MoE-layer routing statistics with a CUDA-graph-safe capture path:
+the capture fn does pure tensor ops on persistent, pre-allocated device
+buffers — no host reads, no allocation, no Python-object mutation — so it
+can be captured into CUDA graphs and keeps recording during replay
+(validated by T1 in tests/exl3_fungible/ and the research branch T1 rig).
+
+Host-side windowing runs OFF the hot path in step(), mirroring EPLB's
+step cadence: every ``window_stride`` engine steps the accumulators are
+rolled into a circular window buffer and zeroed; the policy engine reads
+an exponentially-decayed view of the window.
+
+Binding: chain through ``BaseRouter.set_capture_fn`` — the slot is
+single-occupancy and the routed-experts capturer may already hold it
+(gpu_model_runner binds it at init), so ``bind_router`` always chains the
+previous fn after recording.
+"""
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import torch
+
+
+class FqStatsCollector:
+    """Routing-count and gate-mass accumulators for one model replica.
+
+    Args:
+        num_experts: logical expert count per MoE layer (EP=1 → logical
+            == physical; D4 keeps the policy domain logical).
+        window_len: number of window slots retained.
+        window_stride: engine steps per window roll.
+        decay: exponential decay factor applied per window step in the
+            policy view (λ from Phase 0a).
+        device: device for the persistent buffers.
+    """
+
+    def __init__(
+        self,
+        num_experts: int,
+        *,
+        window_len: int = 64,
+        window_stride: int = 32,
+        decay: float = 0.95,
+        device: torch.device | str = "cuda",
+    ) -> None:
+        self.num_experts = num_experts
+        self.window_len = window_len
+        self.window_stride = window_stride
+        self.decay = decay
+        self.device = torch.device(device)
+        # layer_id -> persistent accumulators (allocated at bind time)
+        self.count_buf: dict[int, torch.Tensor] = {}
+        self.mass_buf: dict[int, torch.Tensor] = {}
+        # layer_id -> [window_len, E] rolled snapshots
+        self._count_win: dict[int, torch.Tensor] = {}
+        self._mass_win: dict[int, torch.Tensor] = {}
+        self._win_pos = 0
+        self._windows_rolled = 0
+        self._step = 0
+
+    # ------------------------------------------------------------------ bind
+
+    def bind_router(self, layer_id: int, router) -> None:
+        """Allocate this layer's buffers and chain the capture fn.
+
+        Must run BEFORE CUDA-graph capture (i.e. at model-runner init,
+        alongside the routed-experts capturer) so the capture fn's ops are
+        recorded into the graphs.
+        """
+        count = torch.zeros(
+            self.num_experts, dtype=torch.int32, device=self.device)
+        mass = torch.zeros(
+            self.num_experts, dtype=torch.float32, device=self.device)
+        self.count_buf[layer_id] = count
+        self.mass_buf[layer_id] = mass
+        self._count_win[layer_id] = torch.zeros(
+            (self.window_len, self.num_experts),
+            dtype=torch.int64, device=self.device)
+        self._mass_win[layer_id] = torch.zeros(
+            (self.window_len, self.num_experts),
+            dtype=torch.float32, device=self.device)
+
+        prev = getattr(router, "capture_fn", None)
+        router.set_capture_fn(
+            self.make_capture_fn(layer_id, prev_fn=prev))
+
+    def make_capture_fn(
+        self,
+        layer_id: int,
+        prev_fn: Callable | None = None,
+        topk_weights_getter: Callable[[], torch.Tensor] | None = None,
+    ) -> Callable:
+        """Build the graph-safe capture fn for one layer.
+
+        The returned callable only touches pre-allocated buffers with
+        tensor ops. ``topk_weights_getter`` is optional plumbing for gate
+        mass (the base hook only passes topk_ids); when absent, mass
+        accumulation adds 1.0 per routing (count-equivalent) so the
+        signal degrades gracefully rather than silently vanishing.
+        """
+        count = self.count_buf[layer_id]
+        mass = self.mass_buf[layer_id]
+
+        def _capture(topk_ids: torch.Tensor) -> None:
+            flat = topk_ids.flatten().to(torch.int64)
+            ones_i = torch.ones_like(flat, dtype=torch.int32)
+            count.scatter_add_(0, flat, ones_i)
+            if topk_weights_getter is not None:
+                w = topk_weights_getter()
+                mass.scatter_add_(0, flat, w.flatten().to(torch.float32))
+            else:
+                mass.scatter_add_(
+                    0, flat, torch.ones_like(flat, dtype=torch.float32))
+            if prev_fn is not None:
+                prev_fn(topk_ids)
+
+        return _capture
+
+    # ------------------------------------------------------------------ step
+
+    def step(self, *, is_dummy: bool = False) -> None:
+        """Advance one engine step (host side, off the capture path).
+
+        Dummy/profile steps zero the accumulators without recording
+        (EPLB semantics) but still advance the counter for rank lockstep.
+        """
+        self._step += 1
+        if is_dummy:
+            for lid in self.count_buf:
+                self.count_buf[lid].zero_()
+                self.mass_buf[lid].zero_()
+            return
+        if self._step % self.window_stride:
+            return
+        pos = self._win_pos
+        for lid in self.count_buf:
+            self._count_win[lid][pos].copy_(self.count_buf[lid])
+            self._mass_win[lid][pos].copy_(self.mass_buf[lid])
+            self.count_buf[lid].zero_()
+            self.mass_buf[lid].zero_()
+        self._win_pos = (pos + 1) % self.window_len
+        self._windows_rolled += 1
+
+    # ------------------------------------------------------------------ read
+
+    def decayed(self, layer_id: int) -> tuple[torch.Tensor, torch.Tensor]:
+        """Decayed window sums (count, mass): w_e = Σ_i λ^i · W[-1-i]."""
+        n = min(self._windows_rolled, self.window_len)
+        e = self.num_experts
+        if n == 0:
+            z = torch.zeros(e, dtype=torch.float64, device=self.device)
+            return z, z.clone()
+        idx = torch.arange(n, device=self.device)
+        slots = (self._win_pos - 1 - idx) % self.window_len
+        lam = torch.pow(
+            torch.tensor(self.decay, dtype=torch.float64,
+                         device=self.device), idx)
+        cw = self._count_win[layer_id][slots].to(torch.float64)
+        mw = self._mass_win[layer_id][slots].to(torch.float64)
+        return (lam[:, None] * cw).sum(0), (lam[:, None] * mw).sum(0)
+
+    def summary(self) -> dict:
+        """Small host-side dict for persistence (few MB model-wide)."""
+        out: dict = {
+            "step": self._step,
+            "windows_rolled": self._windows_rolled,
+            "num_experts": self.num_experts,
+            "decay": self.decay,
+            "layers": {},
+        }
+        for lid in sorted(self.count_buf):
+            c, m = self.decayed(lid)
+            out["layers"][lid] = {
+                "count": c.cpu().tolist(),
+                "mass": m.cpu().tolist(),
+            }
+        return out

--- a/vllm/model_executor/layers/quantization/exl3_fungible/stats.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/stats.py
@@ -17,12 +17,24 @@ Binding: chain through ``BaseRouter.set_capture_fn`` — the slot is
 single-occupancy and the routed-experts capturer may already hold it
 (gpu_model_runner binds it at init), so ``bind_router`` always chains the
 previous fn after recording.
+
+Gate mass (``record_mass=True``, ``VLLM_FQ_GATE_MASS=1``) is OPT-IN. The
+base capture contract passes only ``topk_ids``; the gate weights are a
+local in ``BaseRouter._select_experts`` and are handed to capture fns
+tagged ``wants_topk_weights``. Recording them costs a guarded
+``scatter_add_`` on top of the count histogram, which is why it is not
+on by default (PERFORMANCE.md: M1 gate is <0.5% decode overhead).
+Without it, ``mass`` is aliased to ``count`` at read time and
+``mass_is_real()`` reports False — the alias is never silent.
 """
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
 
 import torch
+
+logger = logging.getLogger(__name__)
 
 
 class FqStatsCollector:
@@ -36,6 +48,11 @@ class FqStatsCollector:
         decay: exponential decay factor applied per window step in the
             policy view (λ from Phase 0a).
         device: device for the persistent buffers.
+        record_mass: record REAL gate mass (sum of routing weights) in
+            addition to hit counts. Opt-in: it adds a guarded
+            ``scatter_add_`` to the capture path (see
+            :meth:`make_capture_fn`). When off, ``mass`` is aliased to
+            ``count`` and :meth:`mass_is_real` reports False.
     """
 
     def __init__(
@@ -46,15 +63,23 @@ class FqStatsCollector:
         window_stride: int = 32,
         decay: float = 0.95,
         device: torch.device | str = "cuda",
+        record_mass: bool = False,
     ) -> None:
         self.num_experts = num_experts
         self.window_len = window_len
         self.window_stride = window_stride
         self.decay = decay
         self.device = torch.device(device)
+        self.record_mass = bool(record_mass)
         # layer_id -> persistent accumulators (allocated at bind time)
         self.count_buf: dict[int, torch.Tensor] = {}
         self.mass_buf: dict[int, torch.Tensor] = {}
+        # Persistent 0-dim int64 tensor holding ``num_experts`` — the
+        # overflow-slot index used by the weighted path's OOR redirect.
+        # Pre-allocated so the capture fn never allocates (graph safety)
+        # and never pays a full_like fill per call.
+        self._oor_slot = torch.tensor(
+            num_experts, dtype=torch.int64, device=self.device)
         # Layers whose capture fn records no gate mass: mass is aliased
         # to count at read time (decayed/summary).
         self._mass_is_count: set[int] = set()
@@ -67,7 +92,8 @@ class FqStatsCollector:
 
     # ------------------------------------------------------------------ bind
 
-    def bind_router(self, layer_id: int, router) -> None:
+    def bind_router(self, layer_id: int, router,
+                    record_mass: bool | None = None) -> None:
         """Allocate this layer's buffers and chain the capture fn.
 
         Must run BEFORE CUDA-graph capture (i.e. at model-runner init,
@@ -82,7 +108,20 @@ class FqStatsCollector:
         The default histc path drops OOR ids by construction. Reads
         ignore the slot either way. Counts are float32 (histc output;
         exact below 2^24 per window).
+
+        Gate mass requires the ROUTER to hand us ``topk_weights``: the
+        base contract passes only ids, and the weights are a local in
+        ``BaseRouter._select_experts`` — nothing on the router object
+        holds them at capture time. We tag the capture fn with
+        ``wants_topk_weights`` and then VERIFY the router honoured it
+        (``router.capture_fn_wants_weights``). A runtime whose
+        ``BaseRouter`` predates that contract would otherwise hand us
+        ids only and leave ``mass`` at zero while we claimed it was
+        real, so an unsupported router downgrades to count-only and
+        :meth:`mass_is_real` stays False.
         """
+        if record_mass is None:
+            record_mass = self.record_mass
         count = torch.zeros(
             self.num_experts + 1, dtype=torch.float32, device=self.device)
         mass = torch.zeros(
@@ -98,43 +137,79 @@ class FqStatsCollector:
 
         prev = getattr(router, "capture_fn", None)
         router.set_capture_fn(
-            self.make_capture_fn(layer_id, prev_fn=prev))
+            self.make_capture_fn(layer_id, prev_fn=prev,
+                                 record_mass=record_mass))
+        if record_mass and not getattr(
+                router, "capture_fn_wants_weights", False):
+            logger.warning(
+                "FQ stats: router for layer %s does not pass topk_weights "
+                "to capture fns (no capture_fn_wants_weights) — gate mass "
+                "cannot be recorded; falling back to count-only for this "
+                "layer (mass will be aliased to count).", layer_id)
+            router.set_capture_fn(
+                self.make_capture_fn(layer_id, prev_fn=prev,
+                                     record_mass=False))
 
     def make_capture_fn(
         self,
         layer_id: int,
         prev_fn: Callable | None = None,
         topk_weights_getter: Callable[[], torch.Tensor] | None = None,
+        record_mass: bool | None = None,
     ) -> Callable:
         """Build the graph-safe capture fn for one layer.
 
         The returned callable only touches pre-allocated buffers with
-        tensor ops, and is sized for the M1 hot-path gate: without a
-        weights getter it is a single ``histc`` histogram per layer
-        (~3 small kernels: cast, histc, add) instead of a guarded
-        ``scatter_add_`` chain (~10 kernels — measured 4-5% decode
-        overhead on the Fruit proxy, PERFORMANCE.md gate is <0.5%).
+        tensor ops, and is sized for the M1 hot-path gate: the count-only
+        path is a single ``histc`` histogram per layer (~3 small kernels:
+        cast, histc, add) instead of a guarded ``scatter_add_`` chain
+        (~10 kernels — measured 4-5% decode overhead on the Fruit proxy,
+        PERFORMANCE.md gate is <0.5%).
+
+        With ``record_mass`` the fn additionally accumulates REAL gate
+        mass — the sum of the routing weights, so a confident route
+        outranks a marginal one, which is what the swap policy is
+        specified to score on. That costs 5 extra device kernels (int64
+        cast, ``lt``, ``where``, ``clamp_``, ``scatter_add_``) — 8 vs 3,
+        measured 1.9x the CPU wall time of the count-only path at
+        E=256/topk=8 — so it is OPT-IN (``VLLM_FQ_GATE_MASS=1``), NOT the
+        default: a ~10-kernel guarded scatter chain previously measured
+        4-5% decode overhead against a 0.5% gate. Counts are computed by
+        the SAME histc in both modes, so turning mass on cannot perturb
+        the count signal.
 
         Out-of-range ids (padding sentinels, garbage in replayed capture
         batches) MUST never index device memory: an OOR ``scatter_add_``
         is an illegal memory access that kills the engine (observed live
         on the first M2 dryrun boot). ``histc`` drops values outside
-        [0, num_experts) by construction; the weighted path keeps the
-        explicit overflow-slot redirect.
+        [0, num_experts) by construction; the weighted path redirects
+        them to the explicit overflow slot at index ``num_experts``,
+        which reads slice off.
 
-        ``topk_weights_getter`` is optional plumbing for gate mass (the
-        base hook only passes topk_ids); when absent, mass is aliased to
-        count at read time (``decayed``/``summary``), so the signal
-        degrades gracefully rather than silently vanishing.
+        Weights reach the fn either as the second positional argument
+        (the router hands them over — the fn is tagged
+        ``wants_topk_weights`` so ``BaseRouter._select_experts`` calls
+        it with both) or, for tests and non-BaseRouter call sites, from
+        ``topk_weights_getter``. Passing a getter implies
+        ``record_mass``.
+
+        When mass is not recorded it is aliased to count at read time
+        (``decayed``/``summary``) so the signal degrades gracefully;
+        :meth:`mass_is_real` tells a consumer which of the two it is
+        looking at.
         """
         count = self.count_buf[layer_id]
         mass = self.mass_buf[layer_id]
         num_experts = self.num_experts
+        oor_slot = self._oor_slot
+        if record_mass is None:
+            record_mass = self.record_mass or topk_weights_getter is not None
 
-        if topk_weights_getter is None:
+        if not record_mass:
             self._mass_is_count.add(layer_id)
 
-            def _capture(topk_ids: torch.Tensor) -> None:
+            def _capture(topk_ids: torch.Tensor,
+                         topk_weights: torch.Tensor | None = None) -> None:
                 # One EXTRA bin, then slice it off. torch.histc's last bin is
                 # CLOSED at max, so binning [0, E) as bins=E/max=E does not
                 # drop id == E — it folds the padding sentinel into the last
@@ -153,21 +228,46 @@ class FqStatsCollector:
                 if prev_fn is not None:
                     prev_fn(topk_ids)
 
+            _capture.wants_topk_weights = False
             return _capture
 
         self._mass_is_count.discard(layer_id)
 
-        def _capture(topk_ids: torch.Tensor) -> None:
-            flat = topk_ids.flatten().to(torch.int64)
-            oob = (flat < 0) | (flat >= num_experts)
-            idx = torch.where(oob, torch.full_like(flat, num_experts), flat)
-            count.scatter_add_(
-                0, idx, torch.ones_like(flat, dtype=count.dtype))
-            w = topk_weights_getter()
-            mass.scatter_add_(0, idx, w.flatten().to(torch.float32))
+        def _capture(topk_ids: torch.Tensor,
+                     topk_weights: torch.Tensor | None = None) -> None:
+            # Count: identical histc to the count-only path (same
+            # closed-last-bin sentinel fix), so the count signal does not
+            # depend on whether mass recording is enabled.
+            flat = topk_ids.flatten()
+            hist = torch.histc(flat.to(torch.float32), bins=num_experts + 1,
+                               min=0, max=num_experts + 1)
+            count[:num_experts].add_(hist[:num_experts])
+            if topk_weights is None and topk_weights_getter is not None:
+                topk_weights = topk_weights_getter()
+            if topk_weights is not None:
+                # Mass: guarded scatter. Every id outside [0, E) — the
+                # padding sentinel E included — is redirected to the
+                # overflow slot at E, so scatter_add_ can never address
+                # past the buffer, and reads ([:E]) drop it exactly the
+                # way histc drops it from the count.
+                #
+                # Two-op guard rather than the obvious
+                # ``where(ids.ge(0) & ids.lt(E), ids, E)``: negatives are
+                # sent to the slot first, THEN everything is clamped down
+                # to it, which covers ids >= E (E itself, E+1, garbage)
+                # without a second compare. One kernel cheaper on a path
+                # whose whole cost is kernel launches. A bare
+                # ``clamp(0, E)`` would be wrong — it maps negatives onto
+                # real expert 0.
+                ids = flat.to(torch.int64)
+                idx = torch.where(ids.lt(0), oor_slot, ids)
+                idx.clamp_(max=num_experts)
+                mass.scatter_add_(
+                    0, idx, topk_weights.flatten().to(torch.float32))
             if prev_fn is not None:
                 prev_fn(topk_ids)
 
+        _capture.wants_topk_weights = True
         return _capture
 
     # ------------------------------------------------------------------ step
@@ -199,6 +299,24 @@ class FqStatsCollector:
 
     # ------------------------------------------------------------------ read
 
+    def mass_is_real(self, layer_id: int | None = None) -> bool:
+        """Is ``mass`` REAL gate mass, or is it aliased to ``count``?
+
+        The two are otherwise indistinguishable to a consumer only by
+        the arrays happening to be equal, which is a trap: a uniform
+        router produces equal arrays legitimately, and an unbound
+        weights path produces them by aliasing. Ask here instead.
+
+        Args:
+            layer_id: one layer, or None for the model-wide answer
+                (True only if EVERY bound layer records real mass; False
+                when nothing is bound yet).
+        """
+        if layer_id is not None:
+            return (layer_id in self.count_buf
+                    and layer_id not in self._mass_is_count)
+        return bool(self.count_buf) and not self._mass_is_count
+
     def decayed(self, layer_id: int) -> tuple[torch.Tensor, torch.Tensor]:
         """Decayed window sums (count, mass): w_e = Σ_i λ^i · W[-1-i].
 
@@ -229,6 +347,10 @@ class FqStatsCollector:
             "windows_rolled": self._windows_rolled,
             "num_experts": self.num_experts,
             "decay": self.decay,
+            # False => every "mass" below is a copy of "count", not gate
+            # mass. Explicit so a consumer never has to infer it from the
+            # arrays being equal.
+            "mass_is_real": self.mass_is_real(),
             "layers": {},
         }
         for lid in sorted(self.count_buf):
@@ -236,5 +358,6 @@ class FqStatsCollector:
             out["layers"][lid] = {
                 "count": c.cpu().tolist(),
                 "mass": m.cpu().tolist(),
+                "mass_is_real": self.mass_is_real(lid),
             }
         return out

--- a/vllm/model_executor/layers/quantization/exl3_fungible/stats.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/stats.py
@@ -55,6 +55,9 @@ class FqStatsCollector:
         # layer_id -> persistent accumulators (allocated at bind time)
         self.count_buf: dict[int, torch.Tensor] = {}
         self.mass_buf: dict[int, torch.Tensor] = {}
+        # Layers whose capture fn records no gate mass: mass is aliased
+        # to count at read time (decayed/summary).
+        self._mass_is_count: set[int] = set()
         # layer_id -> [window_len, E] rolled snapshots
         self._count_win: dict[int, torch.Tensor] = {}
         self._mass_win: dict[int, torch.Tensor] = {}
@@ -70,11 +73,20 @@ class FqStatsCollector:
         Must run BEFORE CUDA-graph capture (i.e. at model-runner init,
         alongside the routed-experts capturer) so the capture fn's ops are
         recorded into the graphs.
+
+        The accumulators carry one extra OVERFLOW slot at index
+        ``num_experts`` for the weighted (scatter) capture path: any id
+        outside ``[0, num_experts)`` (padding sentinels, garbage in
+        replayed capture batches) is redirected there instead of
+        corrupting device memory via an out-of-range ``scatter_add_``.
+        The default histc path drops OOR ids by construction. Reads
+        ignore the slot either way. Counts are float32 (histc output;
+        exact below 2^24 per window).
         """
         count = torch.zeros(
-            self.num_experts, dtype=torch.int32, device=self.device)
+            self.num_experts + 1, dtype=torch.float32, device=self.device)
         mass = torch.zeros(
-            self.num_experts, dtype=torch.float32, device=self.device)
+            self.num_experts + 1, dtype=torch.float32, device=self.device)
         self.count_buf[layer_id] = count
         self.mass_buf[layer_id] = mass
         self._count_win[layer_id] = torch.zeros(
@@ -97,24 +109,62 @@ class FqStatsCollector:
         """Build the graph-safe capture fn for one layer.
 
         The returned callable only touches pre-allocated buffers with
-        tensor ops. ``topk_weights_getter`` is optional plumbing for gate
-        mass (the base hook only passes topk_ids); when absent, mass
-        accumulation adds 1.0 per routing (count-equivalent) so the
-        signal degrades gracefully rather than silently vanishing.
+        tensor ops, and is sized for the M1 hot-path gate: without a
+        weights getter it is a single ``histc`` histogram per layer
+        (~3 small kernels: cast, histc, add) instead of a guarded
+        ``scatter_add_`` chain (~10 kernels — measured 4-5% decode
+        overhead on the Fruit proxy, PERFORMANCE.md gate is <0.5%).
+
+        Out-of-range ids (padding sentinels, garbage in replayed capture
+        batches) MUST never index device memory: an OOR ``scatter_add_``
+        is an illegal memory access that kills the engine (observed live
+        on the first M2 dryrun boot). ``histc`` drops values outside
+        [0, num_experts) by construction; the weighted path keeps the
+        explicit overflow-slot redirect.
+
+        ``topk_weights_getter`` is optional plumbing for gate mass (the
+        base hook only passes topk_ids); when absent, mass is aliased to
+        count at read time (``decayed``/``summary``), so the signal
+        degrades gracefully rather than silently vanishing.
         """
         count = self.count_buf[layer_id]
         mass = self.mass_buf[layer_id]
+        num_experts = self.num_experts
+
+        if topk_weights_getter is None:
+            self._mass_is_count.add(layer_id)
+
+            def _capture(topk_ids: torch.Tensor) -> None:
+                # One EXTRA bin, then slice it off. torch.histc's last bin is
+                # CLOSED at max, so binning [0, E) as bins=E/max=E does not
+                # drop id == E — it folds the padding sentinel into the last
+                # real expert, biasing the routing histogram toward exactly
+                # one expert on every batch. That is memory-safe but it
+                # silently poisons the signal the swap policy reads.
+                # With bins=E+1/max=E+1 each bin is exactly 1 wide, so E (and
+                # E+1, via the same closed-last-bin rule) land in the overflow
+                # bin and are discarded by the slice; ids <0 or >E+1 still
+                # fall outside the range and are dropped by histc itself.
+                # Exact for id values < 2^24 in fp32.
+                flat = topk_ids.flatten().to(torch.float32)
+                hist = torch.histc(flat, bins=num_experts + 1,
+                                   min=0, max=num_experts + 1)
+                count[:num_experts].add_(hist[:num_experts])
+                if prev_fn is not None:
+                    prev_fn(topk_ids)
+
+            return _capture
+
+        self._mass_is_count.discard(layer_id)
 
         def _capture(topk_ids: torch.Tensor) -> None:
             flat = topk_ids.flatten().to(torch.int64)
-            ones_i = torch.ones_like(flat, dtype=torch.int32)
-            count.scatter_add_(0, flat, ones_i)
-            if topk_weights_getter is not None:
-                w = topk_weights_getter()
-                mass.scatter_add_(0, flat, w.flatten().to(torch.float32))
-            else:
-                mass.scatter_add_(
-                    0, flat, torch.ones_like(flat, dtype=torch.float32))
+            oob = (flat < 0) | (flat >= num_experts)
+            idx = torch.where(oob, torch.full_like(flat, num_experts), flat)
+            count.scatter_add_(
+                0, idx, torch.ones_like(flat, dtype=count.dtype))
+            w = topk_weights_getter()
+            mass.scatter_add_(0, idx, w.flatten().to(torch.float32))
             if prev_fn is not None:
                 prev_fn(topk_ids)
 
@@ -137,9 +187,11 @@ class FqStatsCollector:
         if self._step % self.window_stride:
             return
         pos = self._win_pos
+        e = self.num_experts
         for lid in self.count_buf:
-            self._count_win[lid][pos].copy_(self.count_buf[lid])
-            self._mass_win[lid][pos].copy_(self.mass_buf[lid])
+            # [:e] drops the overflow slot — it never reaches the window.
+            self._count_win[lid][pos].copy_(self.count_buf[lid][:e])
+            self._mass_win[lid][pos].copy_(self.mass_buf[lid][:e])
             self.count_buf[lid].zero_()
             self.mass_buf[lid].zero_()
         self._win_pos = (pos + 1) % self.window_len
@@ -148,7 +200,11 @@ class FqStatsCollector:
     # ------------------------------------------------------------------ read
 
     def decayed(self, layer_id: int) -> tuple[torch.Tensor, torch.Tensor]:
-        """Decayed window sums (count, mass): w_e = Σ_i λ^i · W[-1-i]."""
+        """Decayed window sums (count, mass): w_e = Σ_i λ^i · W[-1-i].
+
+        For layers captured without gate weights, mass is the count
+        (graceful degradation — the score becomes pure routing pressure).
+        """
         n = min(self._windows_rolled, self.window_len)
         e = self.num_experts
         if n == 0:
@@ -160,8 +216,11 @@ class FqStatsCollector:
             torch.tensor(self.decay, dtype=torch.float64,
                          device=self.device), idx)
         cw = self._count_win[layer_id][slots].to(torch.float64)
+        c = (lam[:, None] * cw).sum(0)
+        if layer_id in self._mass_is_count:
+            return c, c.clone()
         mw = self._mass_win[layer_id][slots].to(torch.float64)
-        return (lam[:, None] * cw).sum(0), (lam[:, None] * mw).sum(0)
+        return c, (lam[:, None] * mw).sum(0)
 
     def summary(self) -> dict:
         """Small host-side dict for persistence (few MB model-wide)."""

--- a/vllm/model_executor/layers/quantization/exl3_fungible/store.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/store.py
@@ -11,7 +11,9 @@ alongside under ``stats/`` keyed by the policy hash they informed.
 
 Policies are keyed by logical expert id only — no rank/world_size/tp/device
 fields (D4). ``n_k4_per_layer`` is capacity-fixed at startup (D1); a policy
-whose counts differ is applied by projection (policy.project) only.
+whose counts differ is applied by projection (policy.project) only. Mixed
+serves are binary: each layer may use at most two of the SM120-servable
+K2/K3/K4 tiers.
 """
 from __future__ import annotations
 
@@ -42,9 +44,15 @@ def validate_policy(doc: dict, *, num_experts: int | None = None) -> None:
         if num_experts is not None and len(bits) != num_experts:
             raise ValueError(
                 f"layer {layer}: {len(bits)} entries != {num_experts} experts")
-        bad = [b for b in bits if b not in (3, 4)]
+        bad = [b for b in bits if b not in (2, 3, 4)]
         if bad:
-            raise ValueError(f"layer {layer}: non-{{3,4}} bits {bad[:4]}")
+            raise ValueError(
+                f"layer {layer}: non-{{2,3,4}} bits {bad[:4]}")
+        tiers = sorted({int(b) for b in bits})
+        if len(tiers) > 2:
+            raise ValueError(
+                f"layer {layer}: mixed policy has {len(tiers)} tiers "
+                f"{tiers}; the kernel and swap engine require a binary pair")
         if layer in caps and sum(b == 4 for b in bits) != caps[layer]:
             raise ValueError(
                 f"layer {layer}: K4 occupancy != declared n_k4_per_layer "

--- a/vllm/model_executor/layers/quantization/exl3_fungible/store.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/store.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Fungible-quant policy store (M2) — 01-artifacts-policy-stats.md §1.2/§1.3.
+
+Persists `fq-policy/2` documents under ``<cache_root>/fq/policy/<manifest>/``:
+``current.json`` is the authoritative committed policy, written via
+write-temp + atomic rename (the startup_plan pattern — a crash mid-write
+can never tear it, T8); the previous 16 committed policies rotate through
+``history/NNN.json`` for rollback/inspection. Decayed stats summaries dump
+alongside under ``stats/`` keyed by the policy hash they informed.
+
+Policies are keyed by logical expert id only — no rank/world_size/tp/device
+fields (D4). ``n_k4_per_layer`` is capacity-fixed at startup (D1); a policy
+whose counts differ is applied by projection (policy.project) only.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+
+POLICY_SCHEMA = "fq-policy/2"
+HISTORY_KEEP = 16
+
+
+def policy_hash(doc: dict) -> str:
+    return hashlib.sha256(
+        json.dumps(doc, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+
+
+def validate_policy(doc: dict, *, num_experts: int | None = None) -> None:
+    if doc.get("schema") != POLICY_SCHEMA:
+        raise ValueError(f"unsupported policy schema: {doc.get('schema')!r}")
+    bpe = doc.get("bits_per_expert")
+    if not isinstance(bpe, dict) or not bpe:
+        raise ValueError("bits_per_expert missing/empty")
+    budget = doc.get("budget", {})
+    caps = budget.get("n_k4_per_layer", {})
+    for layer, bits in bpe.items():
+        if num_experts is not None and len(bits) != num_experts:
+            raise ValueError(
+                f"layer {layer}: {len(bits)} entries != {num_experts} experts")
+        bad = [b for b in bits if b not in (3, 4)]
+        if bad:
+            raise ValueError(f"layer {layer}: non-{{3,4}} bits {bad[:4]}")
+        if layer in caps and sum(b == 4 for b in bits) != caps[layer]:
+            raise ValueError(
+                f"layer {layer}: K4 occupancy != declared n_k4_per_layer "
+                f"(v1 requires cap == n)")
+    for banned in ("rank", "world_size", "tp", "device", "devices"):
+        if banned in doc:
+            raise ValueError(f"policy must be topology-neutral; found {banned!r}")
+
+
+class PolicyStore:
+    """Filesystem policy store bound to one artifact manifest."""
+
+    def __init__(self, cache_root: str | Path, manifest_hash: str):
+        self.root = Path(cache_root) / "fq" / "policy" / manifest_hash
+        self.manifest_hash = manifest_hash
+        (self.root / "history").mkdir(parents=True, exist_ok=True)
+        (self.root / "stats").mkdir(exist_ok=True)
+
+    # ------------------------------------------------------------------ io
+
+    def _atomic_write(self, path: Path, doc: dict) -> None:
+        tmp = path.with_suffix(".tmp")
+        with open(tmp, "w") as f:
+            json.dump(doc, f, sort_keys=True, indent=1)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, path)
+
+    def commit(self, doc: dict, *, num_experts: int | None = None) -> str:
+        """Validate, rotate history, atomically publish as current.json."""
+        validate_policy(doc, num_experts=num_experts)
+        if doc.get("manifest") != self.manifest_hash:
+            raise ValueError(
+                f"policy manifest {doc.get('manifest')!r} != store manifest "
+                f"{self.manifest_hash!r} (T8: hard refuse)")
+        cur = self.root / "current.json"
+        if cur.exists():
+            gen = len(sorted((self.root / "history").glob("*.json")))
+            os.replace(cur, self.root / "history" / f"{gen:04d}.json")
+            hist = sorted((self.root / "history").glob("*.json"))
+            for stale in hist[:-HISTORY_KEEP]:
+                stale.unlink()
+        self._atomic_write(cur, doc)
+        return policy_hash(doc)
+
+    def load_current(self, *, num_experts: int | None = None) -> dict | None:
+        """Rehydrate the last committed policy (boot path, D8)."""
+        cur = self.root / "current.json"
+        if not cur.exists():
+            return None
+        doc = json.loads(cur.read_text())
+        validate_policy(doc, num_experts=num_experts)
+        if doc.get("manifest") != self.manifest_hash:
+            raise ValueError("persisted policy manifest mismatch — refusing")
+        return doc
+
+    def history(self) -> list[Path]:
+        return sorted((self.root / "history").glob("*.json"))
+
+    def dump_stats(self, summary: dict, for_policy_hash: str) -> Path:
+        p = self.root / "stats" / f"{for_policy_hash[:16]}.json"
+        self._atomic_write(p, summary)
+        return p

--- a/vllm/model_executor/layers/quantization/exl3_fungible/swap.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/swap.py
@@ -2,11 +2,12 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Fungible-quant atomic swap engine (M4) — 02-swap-engine.md row-write variant.
 
-Moves experts between the K3 (tier0) and K4 (tier1) arms of a b12x
-mixed-trellis MoE layer at runtime by rewriting slab rows, combined
+Moves experts between the lower (tier0) and higher (tier1) arms of a b12x
+binary mixed-trellis MoE layer at runtime by rewriting slab rows, combined
 rotation/suh/svh rows and the two routing maps in place — no reallocation,
 no recompile, CUDA-graph-safe (maps are launch arguments read as data,
-pre-M4 checks 1–2).
+pre-M4 checks 1–2). SM120 supports the K2/K3, K2/K4, and K3/K4 pairs;
+K5 exceeds the measured shared-memory limit.
 
 Design consequences bound by runs/pre-m4-checks/report.md:
 
@@ -74,7 +75,8 @@ import torch
 
 logger = logging.getLogger(__name__)
 
-K3, K4 = 3, 4
+K2, K3, K4 = 2, 3, 4
+SERVABLE_TIER_BITS = (K2, K3, K4)
 DESCRIPTOR_TIER_SHIFT = 8  # descriptor = (tier << 8) | local, single decode site
 
 _PROJS = ("gate", "up", "down")
@@ -451,8 +453,9 @@ class ResolverFragmentSource:
 
 class SwapPlan:
     """Ordered swap list ``[(layer, e_out, e_in), ...]`` between two
-    same-cardinality memberships (policy.py conventions: ``e_out`` K4→K3,
-    ``e_in`` K3→K4; deterministic order; ``inverse`` composes to identity)."""
+    same-cardinality binary-tier memberships. ``e_out`` moves from the
+    higher tier to the lower tier and ``e_in`` moves from lower to higher;
+    ordering is deterministic and ``inverse`` composes to identity."""
 
     def __init__(self, swaps: Sequence[tuple[int, int, int]]):
         self.swaps = tuple(
@@ -469,11 +472,13 @@ class SwapPlan:
 
     @classmethod
     def from_memberships(cls, old: Any, new: Any) -> "SwapPlan":
-        """Diff two ``[L, E]`` membership arrays over {3, 4} into a plan.
+        """Diff two ``[L, E]`` binary-tier membership arrays into a plan.
 
-        Same K4 cardinality per layer is required (D1 — project() first).
-        Pairing is deterministic: leaving and entering experts are matched
-        in ascending id order, layers ascending.
+        Same higher-tier cardinality per layer is required (D1 — project()
+        first). Pairing is deterministic: leaving and entering experts are
+        matched in ascending id order, layers ascending. Tier values are
+        inferred per layer, so the same algebra serves K2/K3, K2/K4, and
+        K3/K4 without changing the plan representation.
         """
         old = np.asarray(old)
         new = np.asarray(new)
@@ -481,8 +486,24 @@ class SwapPlan:
             raise ValueError(f"membership shapes differ: {old.shape} vs {new.shape}")
         swaps: list[tuple[int, int, int]] = []
         for l in range(old.shape[0]):
-            outs = np.nonzero((old[l] == K4) & (new[l] == K3))[0]
-            ins = np.nonzero((old[l] == K3) & (new[l] == K4))[0]
+            tiers = sorted({
+                *(int(x) for x in np.unique(old[l])),
+                *(int(x) for x in np.unique(new[l])),
+            })
+            bad = [k for k in tiers if k not in SERVABLE_TIER_BITS]
+            if bad:
+                raise ValueError(
+                    f"layer {l}: tier(s) {bad} are not servable; "
+                    f"supported bits are {SERVABLE_TIER_BITS}")
+            if len(tiers) > 2:
+                raise ValueError(
+                    f"layer {l}: memberships span {len(tiers)} tiers "
+                    f"{tiers}; binary mixed-trellis requires exactly one pair")
+            if len(tiers) < 2:
+                continue
+            low_k, high_k = tiers
+            outs = np.nonzero((old[l] == high_k) & (new[l] == low_k))[0]
+            ins = np.nonzero((old[l] == low_k) & (new[l] == high_k))[0]
             if len(outs) != len(ins):
                 raise ValueError(
                     f"layer {l}: cardinality changes ({len(outs)} out, "
@@ -540,6 +561,7 @@ class MixedLayerState:
     (the only live copy — consequence 2); the two maps are the live launch
     arguments. ``tier0_globals``/``tier1_globals`` are the local→global slot
     orderings (b12x ``tier_ids``), mutated only by a committed apply().
+    ``tier_bits`` records the lower/higher binary pair backing those slots.
     """
 
     tier0: Any
@@ -550,6 +572,7 @@ class MixedLayerState:
     tier0_globals: list[int]
     tier1_globals: list[int]
     mcg: int | None = None
+    tier_bits: tuple[int, int] = (K3, K4)
     #: The ``layer.exl3_mixed_trellis`` dict this state was adapted from, so a
     #: committed apply can publish the new orderings back to it. See publish().
     source: MutableMapping[str, Any] | None = None
@@ -557,9 +580,12 @@ class MixedLayerState:
     @classmethod
     def from_exl3_mixed_trellis(cls, mixed: Mapping[str, Any]) -> "MixedLayerState":
         """Adapt GG's ``layer.exl3_mixed_trellis`` dict (exl3.py)."""
-        if tuple(mixed["tier_bits"]) != (K3, K4):
+        tier_bits = tuple(int(k) for k in mixed["tier_bits"])
+        if (len(tier_bits) != 2 or tier_bits[0] >= tier_bits[1]
+                or any(k not in SERVABLE_TIER_BITS for k in tier_bits)):
             raise ValueError(
-                f"v1 swaps K3/K4 tiers only, got {tuple(mixed['tier_bits'])}")
+                f"runtime swaps require one increasing binary pair drawn "
+                f"from {SERVABLE_TIER_BITS}, got {tier_bits}")
         tier0, tier1 = mixed["tiers"]
         tier0_ids, tier1_ids = mixed["tier_ids"]
         return cls(
@@ -570,6 +596,7 @@ class MixedLayerState:
             descriptor_map=mixed["descriptor_map"],
             tier0_globals=list(tier0_ids),
             tier1_globals=list(tier1_ids),
+            tier_bits=tier_bits,
             source=mixed if isinstance(mixed, MutableMapping) else None,
         )
 
@@ -715,6 +742,11 @@ class SwapEngine:
         self.hidden_size = int(hidden_size)
         self.intermediate_size = int(intermediate_size)
         self.tier_bits = (int(tier_bits[0]), int(tier_bits[1]))
+        if (self.tier_bits[0] >= self.tier_bits[1]
+                or any(k not in SERVABLE_TIER_BITS for k in self.tier_bits)):
+            raise ValueError(
+                f"tier_bits must be one increasing pair drawn from "
+                f"{SERVABLE_TIER_BITS}, got {self.tier_bits}")
         self.rank = int(rank)
         self.max_pairs = int(max_pairs)
         self.expected_mcg = expected_mcg
@@ -727,9 +759,9 @@ class SwapEngine:
         for layer_id, state in self.layers.items():
             self._validate_layer(layer_id, state)
 
-        # Pre-allocated pinned staging: one (K3, K4) stage pair per swap
-        # pair, one host map pair per registered layer (map contents are
-        # rebuilt per layer, not per pair).
+        # Pre-allocated pinned staging: one (lower, higher) stage pair per
+        # swap pair, one host map pair per registered layer (map contents
+        # are rebuilt per layer, not per pair).
         self._stages = [
             (ExpertStage(self.tier_bits[0], self.hidden_size,
                          self.intermediate_size, pin_memory=pin_memory),
@@ -783,6 +815,10 @@ class SwapEngine:
     # ---------------------------------------------------------- validation
 
     def _validate_layer(self, layer_id: int, state: MixedLayerState) -> None:
+        if tuple(state.tier_bits) != self.tier_bits:
+            raise ValueError(
+                f"layer {layer_id}: state tier_bits={tuple(state.tier_bits)} "
+                f"!= engine tier_bits={self.tier_bits}")
         h16 = self.hidden_size // 16
         i16 = self.intermediate_size // 16
         t0, t1 = len(state.tier0_globals), len(state.tier1_globals)
@@ -915,7 +951,7 @@ class SwapEngine:
         if len(plan) > self.max_pairs:
             raise ValueError(
                 f"plan has {len(plan)} pairs, staging holds {self.max_pairs}")
-        k3_bits, k4_bits = self.tier_bits
+        low_bits, high_bits = self.tier_bits
         slab_ops: list[tuple[torch.Tensor, torch.Tensor]] = []
         rotation_ops: list[tuple[torch.Tensor, torch.Tensor]] = []
         undo_ops: list[tuple[torch.Tensor, torch.Tensor]] | None = (
@@ -944,17 +980,19 @@ class SwapEngine:
             if e_out not in t1_ids or e_in not in t0_ids:
                 raise ValueError(
                     f"invalid swap ({layer_id}, {e_out}, {e_in}): e_out must "
-                    f"be resident K{k4_bits}, e_in resident K{k3_bits}")
+                    f"be resident K{high_bits}, e_in resident K{low_bits}")
 
             # Fragment IO first: a pair that cannot be supplied leaves no
             # trace (orderings are only mutated once every read landed).
             out_stage, in_stage = self._stages[pair_idx]
-            reads = [(k3_bits, e_out, out_stage), (k4_bits, e_in, in_stage)]
-            undo_k3 = undo_k4 = None
+            reads = [(low_bits, e_out, out_stage),
+                     (high_bits, e_in, in_stage)]
+            undo_low = undo_high = None
             if fail_atomic:
-                undo_k3, undo_k4 = self._undo_stage_pair(pair_idx)
+                undo_low, undo_high = self._undo_stage_pair(pair_idx)
                 # Pre-swap content of the two destination slots.
-                reads += [(k4_bits, e_out, undo_k4), (k3_bits, e_in, undo_k3)]
+                reads += [(high_bits, e_out, undo_high),
+                          (low_bits, e_in, undo_low)]
             drop: DroppedPair | None = None
             for k, expert, dest in reads:
                 try:
@@ -970,7 +1008,7 @@ class SwapEngine:
             if drop is not None:
                 logger.warning(
                     "FQ swap L%d e%d->K%d/e%d->K%d dropped: %s",
-                    layer_id, e_out, k3_bits, e_in, k4_bits, drop.reason)
+                    layer_id, e_out, low_bits, e_in, high_bits, drop.reason)
                 dropped.append(drop)
                 continue
 
@@ -987,7 +1025,7 @@ class SwapEngine:
             pair_idx += 1
 
             for stage, expert in ((out_stage, e_out), (in_stage, e_in),
-                                  *(((undo_k4, e_out), (undo_k3, e_in))
+                                  *(((undo_high, e_out), (undo_low, e_in))
                                     if fail_atomic else ())):
                 for proj, value in stage.mcg.items():
                     if mcg_seen is None:
@@ -1006,8 +1044,8 @@ class SwapEngine:
             # The undo op for a destination is the SAME view fed the expert
             # that occupied it pre-swap.
             for tier, count, slot, stage, undo in (
-                    (state.tier1, len(t1_ids), slot1, in_stage, undo_k4),
-                    (state.tier0, t0n, slot0, out_stage, undo_k3)):
+                    (state.tier1, len(t1_ids), slot1, in_stage, undo_high),
+                    (state.tier0, t0n, slot0, out_stage, undo_low)):
                 w13, w2 = self._slab_rows(tier, count)
                 dsts = (w13[0, slot], w13[1, slot], w2[slot])
                 slab_ops.extend(zip(dsts, stage.slab_rows()))
@@ -1017,8 +1055,9 @@ class SwapEngine:
             # Step-2 ops: COMBINED rotation/suh/svh rows at NEW combined
             # slots (tier0 local -> slot, tier1 local -> t0 + slot).
             rot = state.rotations
-            for combined_slot, stage, undo in ((t0n + slot1, in_stage, undo_k4),
-                                               (slot0, out_stage, undo_k3)):
+            for combined_slot, stage, undo in (
+                    (t0n + slot1, in_stage, undo_high),
+                    (slot0, out_stage, undo_low)):
                 dsts = (rot.intermediate[combined_slot],
                         rot.gate_suh[combined_slot],
                         rot.up_suh[combined_slot],

--- a/vllm/model_executor/layers/quantization/exl3_fungible/swap.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/swap.py
@@ -1,0 +1,791 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Fungible-quant atomic swap engine (M4) — 02-swap-engine.md row-write variant.
+
+Moves experts between the K3 (tier0) and K4 (tier1) arms of a b12x
+mixed-trellis MoE layer at runtime by rewriting slab rows, combined
+rotation/suh/svh rows and the two routing maps in place — no reallocation,
+no recompile, CUDA-graph-safe (maps are launch arguments read as data,
+pre-M4 checks 1–2).
+
+Design consequences bound by runs/pre-m4-checks/report.md:
+
+1. Absence is expressed in ``global_to_combined`` only; this engine never
+   creates holes (v1 swaps are total: occupancy == capacity) and validates
+   rebuilt maps are a full permutation, fail-closed.
+2. ``combine_trellis_rotations`` COPIES — rotation/suh/svh row writes target
+   the COMBINED tensors at combined-slot indices (tier0 slots ``[0, t0)``,
+   tier1 slots ``[t0, t0+t1)``). The per-tier source tensors are dead.
+3. A tier swap changes BOTH experts' combined slots — both experts' slab
+   rows and all four combined-table rows are rewritten at their NEW slots
+   inside the quiesce window.
+4. Descriptor words are exactly ``local`` or ``256 | local`` (validated on
+   every rebuilt map before it is copied over the live one).
+5. Stream discipline: every device write is issued on the caller's stream;
+   nothing here creates device memory or reads device data inside the
+   window (PERFORMANCE.md: pure copies from pre-allocated pinned staging).
+
+Commit protocol (02 §Commit protocol, steps keyed for the T5 hook):
+``slabs`` → ``rotations`` → ``maps`` → ``memo`` → ``persist``. Until the
+map copy lands, the kernel routes every expert to its old intact encoding;
+the overwritten rows are unreachable mid-window because the engine is
+quiesced. Rollback is ``apply(plan.inverse())`` — sources are re-read from
+the artifact pair (checkpoint-form tensors are freed post-prepare; the
+artifact pair is the only source of truth for both directions).
+
+This module is import-light on purpose: no vllm imports, b12x is resolved
+lazily through the ``build_maps_fn`` seam, segment files are parsed with
+plain file IO (the HF-ranged source lands with loader v2 and implements the
+same :class:`FragmentSource` protocol — the per-expert index range proven
+to cover all of an expert's tensors here is exactly the byte range it will
+fetch with one ranged GET).
+"""
+
+from __future__ import annotations
+
+import json
+import struct
+import time
+from contextlib import AbstractContextManager, nullcontext
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Iterator, Mapping, Protocol, Sequence
+
+import numpy as np
+import torch
+
+K3, K4 = 3, 4
+DESCRIPTOR_TIER_SHIFT = 8  # descriptor = (tier << 8) | local, single decode site
+
+_PROJS = ("gate", "up", "down")
+_COMPS = ("trellis", "suh", "svh", "mcg")
+# safetensors dtype tag -> (torch dtype, itemsize)
+_ST_DTYPES = {
+    "I16": (torch.int16, 2),
+    "F16": (torch.float16, 2),
+    "I32": (torch.int32, 4),
+}
+
+COMMIT_STEPS = ("slabs", "rotations", "maps", "memo", "persist")
+
+
+def tensor_name(layer: int, expert: int, proj: str, rank: int, comp: str) -> str:
+    """Canonical fq-segment/1 tensor name (fq_repack's EXPERT_RE, inverted)."""
+    return f"model.layers.{layer}.mlp.experts.{expert}.{proj}_proj.rank{rank}.{comp}"
+
+
+def read_segment_header(path: Path) -> tuple[dict, int]:
+    """Parse a safetensors header with plain file IO; return (header, body)."""
+    with open(path, "rb") as f:
+        (hlen,) = struct.unpack("<Q", f.read(8))
+        header = json.loads(f.read(hlen))
+    return header, 8 + hlen
+
+
+# --------------------------------------------------------------------- staging
+
+
+class ExpertStage:
+    """Pinned host staging for one expert's full payload at one bitrate.
+
+    Holds exactly the rows the window writes: three native trellis slab rows,
+    the two FC1 input rotations + FC2 output rotation (H-sized), and the
+    pre-assembled combined intermediate-rotations row
+    ``[gate_svh | up_svh | down_suh]`` (3I-sized, the prepare-time ABI order —
+    exl3.py `_prepare_mixed_rank_sliced_weights`). ``mcg`` scalars are staged
+    for validation only: the mixed kernel's codebook is layer-wide (r33 pins
+    the MCG LUT ABI slots), so a fragment whose mcg differs is a corrupt or
+    foreign encoding and staging refuses it.
+    """
+
+    def __init__(self, bits: int, hidden_size: int, intermediate_size: int,
+                 *, pin_memory: bool):
+        h16, i16 = hidden_size // 16, intermediate_size // 16
+        words = 16 * int(bits)
+
+        def buf(shape, dtype):
+            return torch.empty(shape, dtype=dtype, pin_memory=pin_memory)
+
+        self.bits = int(bits)
+        self.trellis = {
+            "gate": buf((h16, i16, words), torch.int16),
+            "up": buf((h16, i16, words), torch.int16),
+            "down": buf((i16, h16, words), torch.int16),
+        }
+        self.suh = {
+            "gate": buf((hidden_size,), torch.float16),
+            "up": buf((hidden_size,), torch.float16),
+        }
+        self.svh = {"down": buf((hidden_size,), torch.float16)}
+        self.inter_rot = buf((3 * intermediate_size,), torch.float16)
+        i = intermediate_size
+        self.rot_slices = {
+            ("gate", "svh"): self.inter_rot[0:i],
+            ("up", "svh"): self.inter_rot[i:2 * i],
+            ("down", "suh"): self.inter_rot[2 * i:3 * i],
+        }
+        self.mcg: dict[str, int] = {}
+
+    def dest_tensor(self, proj: str, comp: str) -> torch.Tensor | None:
+        """Host tensor a source must fill for (proj, comp); None for mcg."""
+        if comp == "trellis":
+            return self.trellis[proj]
+        if comp == "suh" and proj in self.suh:
+            return self.suh[proj]
+        if comp == "svh" and proj in self.svh:
+            return self.svh[proj]
+        return self.rot_slices.get((proj, comp))
+
+    @property
+    def nbytes(self) -> int:
+        tensors = [*self.trellis.values(), *self.suh.values(),
+                   *self.svh.values(), self.inter_rot]
+        return sum(t.numel() * t.element_size() for t in tensors)
+
+
+class FragmentSource(Protocol):
+    """Where expert payload bytes come from (NVMe segments now, HF ranges
+    with loader v2). Implementations fill every ``dest.dest_tensor(proj,
+    comp)`` buffer for the requested ``(layer, k, expert, rank)`` and set
+    ``dest.mcg[proj]`` — host-side work only, always called pre-quiesce."""
+
+    def read_expert(self, *, layer: int, k: int, expert: int, rank: int,
+                    dest: ExpertStage) -> None:
+        ...
+
+
+class LocalSegmentSource:
+    """fq-segment/1 reader over a local segment directory (fq_repack output:
+    ``index-k{K}.json`` + ``layer-LLL.kK.safetensors``), plain file IO.
+
+    Every tensor read is validated against the segment header (dtype/shape)
+    and proven to fall inside the expert's ``index`` byte range — the same
+    range a future HF source fetches with one ranged GET.
+    """
+
+    def __init__(self, root: str | Path):
+        self.root = Path(root)
+        self._indexes: dict[int, dict] = {}
+        self._headers: dict[tuple[int, int], tuple[dict, int, Path]] = {}
+        self._files: dict[Path, Any] = {}
+
+    # ------------------------------------------------------------- internals
+
+    def _index(self, k: int) -> dict:
+        if k not in self._indexes:
+            path = self.root / f"index-k{k}.json"
+            self._indexes[k] = json.loads(path.read_text())
+        return self._indexes[k]
+
+    def _segment(self, layer: int, k: int) -> tuple[dict, int, Path, dict]:
+        entry = self._index(k).get(str(layer))
+        if entry is None:
+            raise KeyError(f"layer {layer} not in index-k{k}.json")
+        key = (layer, k)
+        if key not in self._headers:
+            path = self.root / entry["file"]
+            header, body = read_segment_header(path)
+            header.pop("__metadata__", None)
+            if body != int(entry["body_offset"]):
+                raise ValueError(
+                    f"{path.name}: body offset {body} != indexed "
+                    f"{entry['body_offset']} — index/segment mismatch")
+            self._headers[key] = (header, body, path)
+        header, body, path = self._headers[key]
+        return header, body, path, entry["experts"]
+
+    def _file(self, path: Path):
+        f = self._files.get(path)
+        if f is None:
+            f = self._files[path] = open(path, "rb")
+        return f
+
+    def close(self) -> None:
+        for f in self._files.values():
+            f.close()
+        self._files.clear()
+
+    # -------------------------------------------------------------- protocol
+
+    def read_expert(self, *, layer: int, k: int, expert: int, rank: int,
+                    dest: ExpertStage) -> None:
+        if dest.bits != k:
+            raise ValueError(f"stage is K{dest.bits}, requested K{k}")
+        header, body, path, experts = self._segment(layer, k)
+        erange = experts.get(str(expert))
+        if erange is None:
+            raise KeyError(f"expert {expert} not indexed in {path.name}")
+        e_start, e_end = int(erange[0]), int(erange[1])
+        f = self._file(path)
+        for proj in _PROJS:
+            for comp in _COMPS:
+                name = tensor_name(layer, expert, proj, rank, comp)
+                info = header.get(name)
+                if info is None:
+                    raise KeyError(f"{path.name}: missing tensor {name}")
+                a, b = (int(v) for v in info["data_offsets"])
+                if not (e_start <= a and b <= e_end):
+                    raise ValueError(
+                        f"{path.name}: {name} range [{a},{b}) escapes the "
+                        f"indexed expert range [{e_start},{e_end})")
+                dtype, itemsize = _ST_DTYPES[info["dtype"]]
+                if comp == "mcg":
+                    f.seek(body + a)
+                    (dest.mcg[proj],) = struct.unpack("<i", f.read(4))
+                    continue
+                t = dest.dest_tensor(proj, comp)
+                assert t is not None
+                if dtype != t.dtype or tuple(info["shape"]) != tuple(t.shape):
+                    raise ValueError(
+                        f"{path.name}: {name} is {info['dtype']}"
+                        f"{info['shape']}, stage expects "
+                        f"{t.dtype}{tuple(t.shape)}")
+                nbytes = t.numel() * itemsize
+                if b - a != nbytes:
+                    raise ValueError(
+                        f"{path.name}: {name} holds {b - a} bytes, "
+                        f"expected {nbytes}")
+                f.seek(body + a)
+                view = t.numpy().view(np.uint8)
+                got = f.readinto(view)
+                if got != nbytes:
+                    raise IOError(
+                        f"{path.name}: short read on {name}: {got}/{nbytes}")
+
+
+# ------------------------------------------------------------------ swap plan
+
+
+class SwapPlan:
+    """Ordered swap list ``[(layer, e_out, e_in), ...]`` between two
+    same-cardinality memberships (policy.py conventions: ``e_out`` K4→K3,
+    ``e_in`` K3→K4; deterministic order; ``inverse`` composes to identity)."""
+
+    def __init__(self, swaps: Sequence[tuple[int, int, int]]):
+        self.swaps = tuple(
+            (int(l), int(e_out), int(e_in)) for l, e_out, e_in in swaps)
+        seen: dict[int, set[int]] = {}
+        for l, e_out, e_in in self.swaps:
+            touched = seen.setdefault(l, set())
+            for e in (e_out, e_in):
+                if e in touched:
+                    raise ValueError(
+                        f"expert {e} appears twice in layer {l} — one swap "
+                        "per expert per plan")
+                touched.add(e)
+
+    @classmethod
+    def from_memberships(cls, old: Any, new: Any) -> "SwapPlan":
+        """Diff two ``[L, E]`` membership arrays over {3, 4} into a plan.
+
+        Same K4 cardinality per layer is required (D1 — project() first).
+        Pairing is deterministic: leaving and entering experts are matched
+        in ascending id order, layers ascending.
+        """
+        old = np.asarray(old)
+        new = np.asarray(new)
+        if old.shape != new.shape:
+            raise ValueError(f"membership shapes differ: {old.shape} vs {new.shape}")
+        swaps: list[tuple[int, int, int]] = []
+        for l in range(old.shape[0]):
+            outs = np.nonzero((old[l] == K4) & (new[l] == K3))[0]
+            ins = np.nonzero((old[l] == K3) & (new[l] == K4))[0]
+            if len(outs) != len(ins):
+                raise ValueError(
+                    f"layer {l}: cardinality changes ({len(outs)} out, "
+                    f"{len(ins)} in) — same-cardinality plans only (D1)")
+            swaps.extend((l, int(o), int(i)) for o, i in zip(outs, ins))
+        return cls(swaps)
+
+    @classmethod
+    def from_policies(cls, old_doc: dict, new_doc: dict) -> "SwapPlan":
+        """Diff two fq-policy/2 documents (store.py schema) into a plan."""
+        old_bpe, new_bpe = old_doc["bits_per_expert"], new_doc["bits_per_expert"]
+        if set(old_bpe) != set(new_bpe):
+            raise ValueError("policies cover different layers")
+        layers = sorted(old_bpe, key=int)
+        old_m = np.array([old_bpe[l] for l in layers])
+        new_m = np.array([new_bpe[l] for l in layers])
+        base = cls.from_memberships(old_m, new_m)
+        remap = {i: int(l) for i, l in enumerate(layers)}
+        return cls([(remap[l], o, i) for l, o, i in base.swaps])
+
+    def inverse(self) -> "SwapPlan":
+        """Applying ``plan`` then ``plan.inverse()`` restores membership."""
+        return SwapPlan(
+            [(l, e_in, e_out) for (l, e_out, e_in) in reversed(self.swaps)])
+
+    def layers(self) -> tuple[int, ...]:
+        out: list[int] = []
+        for l, _, _ in self.swaps:
+            if l not in out:
+                out.append(l)
+        return tuple(out)
+
+    def __len__(self) -> int:
+        return len(self.swaps)
+
+    def __iter__(self) -> Iterator[tuple[int, int, int]]:
+        return iter(self.swaps)
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, SwapPlan) and self.swaps == other.swaps
+
+    def __repr__(self) -> str:
+        return f"SwapPlan({list(self.swaps)!r})"
+
+
+# ---------------------------------------------------------------- layer state
+
+
+@dataclass
+class MixedLayerState:
+    """The swap engine's view of one live mixed-trellis layer.
+
+    ``tier0``/``tier1`` are prepared-tier objects whose slab tensors the
+    kernel aliases (zero-copy, K6); ``rotations`` is the COMBINED table set
+    (the only live copy — consequence 2); the two maps are the live launch
+    arguments. ``tier0_globals``/``tier1_globals`` are the local→global slot
+    orderings (b12x ``tier_ids``), mutated only by a committed apply().
+    """
+
+    tier0: Any
+    tier1: Any
+    rotations: Any
+    global_to_combined: torch.Tensor
+    descriptor_map: torch.Tensor
+    tier0_globals: list[int]
+    tier1_globals: list[int]
+    mcg: int | None = None
+
+    @classmethod
+    def from_exl3_mixed_trellis(cls, mixed: Mapping[str, Any]) -> "MixedLayerState":
+        """Adapt GG's ``layer.exl3_mixed_trellis`` dict (exl3.py)."""
+        if tuple(mixed["tier_bits"]) != (K3, K4):
+            raise ValueError(
+                f"v1 swaps K3/K4 tiers only, got {tuple(mixed['tier_bits'])}")
+        tier0, tier1 = mixed["tiers"]
+        tier0_ids, tier1_ids = mixed["tier_ids"]
+        return cls(
+            tier0=tier0,
+            tier1=tier1,
+            rotations=mixed["rotations"],
+            global_to_combined=mixed["global_to_combined"],
+            descriptor_map=mixed["descriptor_map"],
+            tier0_globals=list(tier0_ids),
+            tier1_globals=list(tier1_ids),
+        )
+
+    @property
+    def num_global_experts(self) -> int:
+        return int(self.global_to_combined.numel())
+
+
+@dataclass
+class _StagedLayer:
+    layer: int
+    tier0_globals: list[int]  # post-swap orderings
+    tier1_globals: list[int]
+    g2c_host: torch.Tensor
+    descriptor_host: torch.Tensor
+
+
+@dataclass
+class StagedBatch:
+    """Everything apply() needs, fully resolved on the host pre-quiesce:
+    three ordered (dst_view, src_pinned) op lists (commit-protocol steps
+    1–3) plus the post-swap orderings to commit into the layer states."""
+
+    plan: SwapPlan
+    slab_ops: list[tuple[torch.Tensor, torch.Tensor]]
+    rotation_ops: list[tuple[torch.Tensor, torch.Tensor]]
+    map_ops: list[tuple[torch.Tensor, torch.Tensor]]
+    staged_layers: list[_StagedLayer]
+    bytes_h2d: int
+    stage_seconds: float
+    mcg: int | None
+
+
+@dataclass
+class ApplyReport:
+    pairs: int
+    layers: int
+    bytes_h2d: int
+    stage_seconds: float
+    window_seconds: float
+    generation: int
+    mcg: int | None = None
+    committed_policy_hash: str | None = None
+
+
+# --------------------------------------------------------------- swap engine
+
+
+def _default_build_maps(tier0_ids, tier1_ids, *, device):
+    from b12x.moe._shared.kernels.w4a16.mixed_trellis import build_tiered_maps
+    return build_tiered_maps(tier0_ids, tier1_ids, device=device)
+
+
+class SwapEngine:
+    """Applies swap plans to live mixed-trellis layers (02 commit protocol).
+
+    All host work (fragment IO, slot resolution, map building, device-view
+    resolution) happens in :meth:`stage`, callable from a background thread
+    before the pause. :meth:`apply` runs the six-step commit inside the
+    caller-provided quiesce window: pure ``copy_`` from pre-allocated pinned
+    staging on the caller's stream — zero device allocation, zero host reads
+    of device data.
+
+    Not thread-safe; one staged batch is live at a time (staging slots are
+    reused).
+    """
+
+    def __init__(
+        self,
+        layers: Mapping[int, MixedLayerState],
+        source: FragmentSource,
+        *,
+        hidden_size: int,
+        intermediate_size: int,
+        tier_bits: tuple[int, int] = (K3, K4),
+        rank: int = 0,
+        max_pairs: int = 8,
+        pin_memory: bool | None = None,
+        build_maps_fn: Callable[..., tuple[torch.Tensor, torch.Tensor]] | None = None,
+        expected_mcg: int | None = None,
+    ):
+        self.layers = dict(layers)
+        self.source = source
+        self.hidden_size = int(hidden_size)
+        self.intermediate_size = int(intermediate_size)
+        self.tier_bits = (int(tier_bits[0]), int(tier_bits[1]))
+        self.rank = int(rank)
+        self.max_pairs = int(max_pairs)
+        self.expected_mcg = expected_mcg
+        self.generation = 0
+        self._build_maps = build_maps_fn or _default_build_maps
+        if pin_memory is None:
+            pin_memory = torch.cuda.is_available()
+
+        for layer_id, state in self.layers.items():
+            self._validate_layer(layer_id, state)
+
+        # Pre-allocated pinned staging: one (K3, K4) stage pair per swap
+        # pair, one host map pair per registered layer (map contents are
+        # rebuilt per layer, not per pair).
+        self._stages = [
+            (ExpertStage(self.tier_bits[0], self.hidden_size,
+                         self.intermediate_size, pin_memory=pin_memory),
+             ExpertStage(self.tier_bits[1], self.hidden_size,
+                         self.intermediate_size, pin_memory=pin_memory))
+            for _ in range(self.max_pairs)
+        ]
+        self._map_stages = {
+            layer_id: (
+                torch.empty(state.num_global_experts, dtype=torch.int32,
+                            pin_memory=pin_memory),
+                torch.empty(state.num_global_experts, dtype=torch.int32,
+                            pin_memory=pin_memory),
+            )
+            for layer_id, state in self.layers.items()
+        }
+
+    # ---------------------------------------------------------- validation
+
+    def _validate_layer(self, layer_id: int, state: MixedLayerState) -> None:
+        h16 = self.hidden_size // 16
+        i16 = self.intermediate_size // 16
+        t0, t1 = len(state.tier0_globals), len(state.tier1_globals)
+        combined = t0 + t1
+        if sorted(state.tier0_globals + state.tier1_globals) != list(
+                range(state.num_global_experts)):
+            raise ValueError(
+                f"layer {layer_id}: tier orderings are not a partition of "
+                f"[0, {state.num_global_experts}) — v1 requires occupancy == "
+                "capacity (holes go through global_to_combined, not here)")
+        for tier_idx, (tier, bits, count) in enumerate(
+                ((state.tier0, self.tier_bits[0], t0),
+                 (state.tier1, self.tier_bits[1], t1))):
+            if int(tier.num_experts) != count:
+                raise ValueError(
+                    f"layer {layer_id} tier{tier_idx}: prepared "
+                    f"num_experts={int(tier.num_experts)} != "
+                    f"{count} tier globals")
+            w13_words = 2 * count * h16 * i16 * 16 * bits
+            w2_words = count * i16 * h16 * 16 * bits
+            if tier.w13.view(torch.int16).numel() != w13_words:
+                raise ValueError(
+                    f"layer {layer_id} tier{tier_idx}: w13 slab holds "
+                    f"{tier.w13.view(torch.int16).numel()} i16 words, "
+                    f"geometry says {w13_words}")
+            if tier.w2.view(torch.int16).numel() != w2_words:
+                raise ValueError(
+                    f"layer {layer_id} tier{tier_idx}: w2 slab holds "
+                    f"{tier.w2.view(torch.int16).numel()} i16 words, "
+                    f"geometry says {w2_words}")
+        rot = state.rotations
+        expected = {
+            "intermediate": (combined, 3 * self.intermediate_size),
+            "gate_suh": (combined, self.hidden_size),
+            "up_suh": (combined, self.hidden_size),
+            "down_svh": (combined, self.hidden_size),
+        }
+        for name, shape in expected.items():
+            t = getattr(rot, name)
+            if tuple(t.shape) != shape:
+                raise ValueError(
+                    f"layer {layer_id}: combined rotations.{name} is "
+                    f"{tuple(t.shape)}, expected {shape} — broadcast "
+                    "suh/svh layouts are out of v1 swap scope "
+                    "(pre-M4 consequence 3)")
+        if int(state.descriptor_map.numel()) != combined:
+            raise ValueError(
+                f"layer {layer_id}: descriptor_map has "
+                f"{int(state.descriptor_map.numel())} slots, expected {combined}")
+
+    def _validate_host_maps(self, layer_id: int, t0n: int,
+                            g2c: torch.Tensor, desc: torch.Tensor) -> None:
+        """Fail closed on consequences 1 and 4 before touching live maps."""
+        combined = int(desc.numel())
+        expect = torch.cat((
+            torch.arange(t0n, dtype=torch.int32),
+            (1 << DESCRIPTOR_TIER_SHIFT)
+            | torch.arange(combined - t0n, dtype=torch.int32),
+        ))
+        if not torch.equal(desc, expect):
+            raise ValueError(
+                f"layer {layer_id}: rebuilt descriptor_map violates "
+                "local|256+local encoding")
+        if not torch.equal(torch.sort(g2c).values,
+                           torch.arange(combined, dtype=torch.int32)):
+            raise ValueError(
+                f"layer {layer_id}: rebuilt global_to_combined is not a "
+                "permutation — a hole here silently blends garbage "
+                "(pre-M4 consequence 1)")
+
+    # -------------------------------------------------------------- staging
+
+    def _stage_maps_for_layer(self, layer_id: int, tier0_globals: list[int],
+                              tier1_globals: list[int]) -> _StagedLayer:
+        g2c_cpu, desc_cpu = self._build_maps(
+            tier0_globals, tier1_globals, device=torch.device("cpu"))
+        self._validate_host_maps(layer_id, len(tier0_globals), g2c_cpu, desc_cpu)
+        g2c_host, desc_host = self._map_stages[layer_id]
+        g2c_host.copy_(g2c_cpu)
+        desc_host.copy_(desc_cpu)
+        return _StagedLayer(layer_id, list(tier0_globals), list(tier1_globals),
+                            g2c_host, desc_host)
+
+    @staticmethod
+    def _slab_rows(tier, count: int) -> tuple[torch.Tensor, torch.Tensor]:
+        w13 = tier.w13.view(torch.int16).view(2, count, -1)
+        w2 = tier.w2.view(torch.int16).view(count, -1)
+        return w13, w2
+
+    def stage(self, plan: SwapPlan) -> StagedBatch:
+        """Resolve a plan into device-view/pinned-source op lists (host-only,
+        pre-quiesce: fragment IO, slot resolution, map rebuild)."""
+        t_start = time.perf_counter()
+        if len(plan) > self.max_pairs:
+            raise ValueError(
+                f"plan has {len(plan)} pairs, staging holds {self.max_pairs}")
+        k3_bits, k4_bits = self.tier_bits
+        slab_ops: list[tuple[torch.Tensor, torch.Tensor]] = []
+        rotation_ops: list[tuple[torch.Tensor, torch.Tensor]] = []
+        mcg_seen: int | None = self.expected_mcg
+        # Scratch orderings so multi-pair layers resolve slots sequentially
+        # without touching live state until commit.
+        orderings: dict[int, tuple[list[int], list[int]]] = {}
+
+        for pair_idx, (layer_id, e_out, e_in) in enumerate(plan):
+            state = self.layers.get(layer_id)
+            if state is None:
+                raise KeyError(f"layer {layer_id} is not registered")
+            if layer_id not in orderings:
+                orderings[layer_id] = (list(state.tier0_globals),
+                                       list(state.tier1_globals))
+            t0_ids, t1_ids = orderings[layer_id]
+            if e_out not in t1_ids or e_in not in t0_ids:
+                raise ValueError(
+                    f"invalid swap ({layer_id}, {e_out}, {e_in}): e_out must "
+                    f"be resident K{k4_bits}, e_in resident K{k3_bits}")
+            # e_in inherits e_out's tier1 slot and vice versa: every other
+            # expert's slot (and slab row) is untouched.
+            slot1 = t1_ids.index(e_out)
+            slot0 = t0_ids.index(e_in)
+            t1_ids[slot1] = e_in
+            t0_ids[slot0] = e_out
+            t0n = len(t0_ids)
+
+            out_stage, in_stage = self._stages[pair_idx]
+            self.source.read_expert(layer=layer_id, k=k3_bits, expert=e_out,
+                                    rank=self.rank, dest=out_stage)
+            self.source.read_expert(layer=layer_id, k=k4_bits, expert=e_in,
+                                    rank=self.rank, dest=in_stage)
+            for stage, expert in ((out_stage, e_out), (in_stage, e_in)):
+                for proj, value in stage.mcg.items():
+                    if mcg_seen is None:
+                        mcg_seen = value
+                    elif value != mcg_seen:
+                        raise ValueError(
+                            f"layer {layer_id} expert {expert} {proj}: mcg "
+                            f"{value} != layer codebook {mcg_seen} — foreign "
+                            "encoding, refusing to stage")
+                if state.mcg is not None and mcg_seen not in (None, state.mcg):
+                    raise ValueError(
+                        f"layer {layer_id}: staged mcg {mcg_seen} != layer "
+                        f"mcg {state.mcg}")
+
+            # Step-1 ops: slab rows for BOTH experts at their NEW slots.
+            for tier, count, slot, stage in (
+                    (state.tier1, len(t1_ids), slot1, in_stage),
+                    (state.tier0, t0n, slot0, out_stage)):
+                w13, w2 = self._slab_rows(tier, count)
+                slab_ops.append((w13[0, slot], stage.trellis["gate"].view(-1)))
+                slab_ops.append((w13[1, slot], stage.trellis["up"].view(-1)))
+                slab_ops.append((w2[slot], stage.trellis["down"].view(-1)))
+
+            # Step-2 ops: COMBINED rotation/suh/svh rows at NEW combined
+            # slots (tier0 local -> slot, tier1 local -> t0 + slot).
+            rot = state.rotations
+            for combined_slot, stage in ((t0n + slot1, in_stage),
+                                         (slot0, out_stage)):
+                rotation_ops.append(
+                    (rot.intermediate[combined_slot], stage.inter_rot))
+                rotation_ops.append(
+                    (rot.gate_suh[combined_slot], stage.suh["gate"]))
+                rotation_ops.append(
+                    (rot.up_suh[combined_slot], stage.suh["up"]))
+                rotation_ops.append(
+                    (rot.down_svh[combined_slot], stage.svh["down"]))
+
+        staged_layers = [
+            self._stage_maps_for_layer(layer_id, t0_ids, t1_ids)
+            for layer_id, (t0_ids, t1_ids) in orderings.items()
+        ]
+        map_ops: list[tuple[torch.Tensor, torch.Tensor]] = []
+        for staged in staged_layers:
+            state = self.layers[staged.layer]
+            map_ops.append((state.global_to_combined, staged.g2c_host))
+            map_ops.append((state.descriptor_map, staged.descriptor_host))
+
+        bytes_h2d = sum(
+            src.numel() * src.element_size()
+            for _, src in (*slab_ops, *rotation_ops, *map_ops))
+        return StagedBatch(
+            plan=plan,
+            slab_ops=slab_ops,
+            rotation_ops=rotation_ops,
+            map_ops=map_ops,
+            staged_layers=staged_layers,
+            bytes_h2d=bytes_h2d,
+            stage_seconds=time.perf_counter() - t_start,
+            mcg=mcg_seen,
+        )
+
+    # ---------------------------------------------------------------- apply
+
+    def apply(
+        self,
+        plan: SwapPlan | None = None,
+        *,
+        quiesce: AbstractContextManager,
+        staged: StagedBatch | None = None,
+        stream: torch.cuda.Stream | None = None,
+        memo_hook: Callable[[], None] | None = None,
+        policy_store: Any | None = None,
+        policy_doc: dict | None = None,
+        policy_num_experts: int | None = None,
+        step_hook: Callable[[str], None] | None = None,
+    ) -> ApplyReport:
+        """Run the commit protocol for ``plan`` (or a pre-``stage``-d batch).
+
+        ``quiesce`` is the caller's engine-drain context manager (pass
+        ``contextlib.nullcontext()`` only when nothing can be replaying).
+        Device work is ordered on ``stream`` (default: current stream) —
+        the same stream replay uses, per consequence 5. ``memo_hook`` nulls
+        the FusedMoEQuantConfig memo (step 4); ``policy_store``/
+        ``policy_doc`` persist the committed policy (step 5). ``step_hook``
+        is the T5 torn-update instrumentation seam (called after each of
+        COMMIT_STEPS; raising aborts between steps).
+
+        Rollback: ``apply(plan.inverse(), ...)`` — fragments are re-read
+        from the artifact pair by :meth:`stage`.
+        """
+        if staged is None:
+            if plan is None:
+                raise ValueError("apply() needs a plan or a staged batch")
+            staged = self.stage(plan)
+        elif plan is not None and staged.plan != plan:
+            raise ValueError("staged batch does not match plan")
+
+        stream_ctx: AbstractContextManager = (
+            torch.cuda.stream(stream) if stream is not None else nullcontext())
+        committed_hash: str | None = None
+        t_window = time.perf_counter()
+        with quiesce:
+            with stream_ctx:
+                for dst, src in staged.slab_ops:  # step 1
+                    dst.copy_(src, non_blocking=True)
+                if step_hook is not None:
+                    step_hook("slabs")
+                for dst, src in staged.rotation_ops:  # step 2
+                    dst.copy_(src, non_blocking=True)
+                if step_hook is not None:
+                    step_hook("rotations")
+                for dst, src in staged.map_ops:  # step 3 — visibility flip
+                    dst.copy_(src, non_blocking=True)
+                if step_hook is not None:
+                    step_hook("maps")
+            if memo_hook is not None:  # step 4
+                memo_hook()
+            if step_hook is not None:
+                step_hook("memo")
+            self.generation += 1  # step 5
+            if policy_store is not None and policy_doc is not None:
+                committed_hash = policy_store.commit(
+                    policy_doc, num_experts=policy_num_experts)
+            if step_hook is not None:
+                step_hook("persist")
+            # Host bookkeeping: the committed orderings become live state.
+            for staged_layer in staged.staged_layers:
+                state = self.layers[staged_layer.layer]
+                state.tier0_globals[:] = staged_layer.tier0_globals
+                state.tier1_globals[:] = staged_layer.tier1_globals
+        window_seconds = time.perf_counter() - t_window
+
+        return ApplyReport(
+            pairs=len(staged.plan),
+            layers=len(staged.staged_layers),
+            bytes_h2d=staged.bytes_h2d,
+            stage_seconds=staged.stage_seconds,
+            window_seconds=window_seconds,
+            generation=self.generation,
+            mcg=staged.mcg,
+            committed_policy_hash=committed_hash,
+        )
+
+    # ---------------------------------------------------------- map rebuild
+
+    def rebuild_maps(
+        self,
+        layer_id: int,
+        tier0_globals: Sequence[int],
+        tier1_globals: Sequence[int],
+        *,
+        stream: torch.cuda.Stream | None = None,
+    ) -> None:
+        """Rewrite one layer's map CONTENTS in place (T3 path; also the
+        commit-step-3 mechanism apply() uses). Slab/rotation rows are not
+        touched — callers own the membership/content consistency argument
+        (inside apply() it is the commit ordering)."""
+        state = self.layers[layer_id]
+        staged = self._stage_maps_for_layer(
+            layer_id, list(tier0_globals), list(tier1_globals))
+        stream_ctx: AbstractContextManager = (
+            torch.cuda.stream(stream) if stream is not None else nullcontext())
+        with stream_ctx:
+            state.global_to_combined.copy_(staged.g2c_host, non_blocking=True)
+            state.descriptor_map.copy_(staged.descriptor_host, non_blocking=True)
+        state.tier0_globals[:] = staged.tier0_globals
+        state.tier1_globals[:] = staged.tier1_globals

--- a/vllm/model_executor/layers/quantization/exl3_fungible/swap.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/swap.py
@@ -33,26 +33,44 @@ quiesced. Rollback is ``apply(plan.inverse())`` — sources are re-read from
 the artifact pair (checkpoint-form tensors are freed post-prepare; the
 artifact pair is the only source of truth for both directions).
 
+Two properties T5 (torn-update fault injection) binds on top of that:
+
+* **The flip is the only visibility point.** Host bookkeeping (the live
+  tier orderings, the generation counter) commits with the map copy, in a
+  ``finally``: an abort at ``memo``/``persist`` leaves device maps and
+  in-memory orderings agreeing on the NEW membership, never a stale host
+  view of freshly flipped maps.
+* **Fail-atomic staging** (``stage(..., fail_atomic=True)``): the pre-swap
+  encodings of both experts are staged alongside the new ones, so an abort
+  *before* the flip restores the overwritten rows inside the same quiesce
+  window. Without it a pre-flip abort leaves the layer genuinely torn (the
+  displaced expert's slot holds its successor's bytes) — recoverable only by
+  re-applying the plan or by reboot (slabs are a cache, never authoritative).
+
 This module is import-light on purpose: no vllm imports, b12x is resolved
 lazily through the ``build_maps_fn`` seam, segment files are parsed with
-plain file IO (the HF-ranged source lands with loader v2 and implements the
-same :class:`FragmentSource` protocol — the per-expert index range proven
-to cover all of an expert's tensors here is exactly the byte range it will
-fetch with one ranged GET).
+plain file IO. :class:`ResolverFragmentSource` adapts loader v2's
+``fragments.FragmentResolver`` (multi-source, trust filtering, sha
+verification, K-fallback ladder) to the same :class:`FragmentSource`
+protocol by duck typing, so swaps stage from HF sources / trusted mirrors
+with boot's verification and this module still imports standalone.
 """
 
 from __future__ import annotations
 
 import json
+import logging
 import struct
 import time
 from contextlib import AbstractContextManager, nullcontext
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Iterator, Mapping, Protocol, Sequence
 
 import numpy as np
 import torch
+
+logger = logging.getLogger(__name__)
 
 K3, K4 = 3, 4
 DESCRIPTOR_TIER_SHIFT = 8  # descriptor = (tier << 8) | local, single decode site
@@ -126,6 +144,19 @@ class ExpertStage:
         }
         self.mcg: dict[str, int] = {}
 
+    def slab_rows(self) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Flat sources for one expert's three slab rows (w13 gate, w13 up,
+        w2 down) — commit-protocol step 1, in order."""
+        return (self.trellis["gate"].view(-1), self.trellis["up"].view(-1),
+                self.trellis["down"].view(-1))
+
+    def rotation_rows(self) -> tuple[torch.Tensor, ...]:
+        """Sources for the four COMBINED table rows of one expert, in commit
+        order: ``rotations.intermediate``, ``gate_suh``, ``up_suh``,
+        ``down_svh`` — step 2."""
+        return (self.inter_rot, self.suh["gate"], self.suh["up"],
+                self.svh["down"])
+
     def dest_tensor(self, proj: str, comp: str) -> torch.Tensor | None:
         """Host tensor a source must fill for (proj, comp); None for mcg."""
         if comp == "trellis":
@@ -152,6 +183,42 @@ class FragmentSource(Protocol):
     def read_expert(self, *, layer: int, k: int, expert: int, rank: int,
                     dest: ExpertStage) -> None:
         ...
+
+
+class FragmentUnavailable(RuntimeError):
+    """A source cannot supply this expert's payload at the requested K.
+
+    Supply-side failure, not corruption: the fragment is missing from every
+    configured source, its attestation is not trusted (10 §4), it failed sha
+    verification, or the fallback ladder substituted a different K — which
+    for a *promotion* means the K4 encode has not landed yet, so the
+    promotion PENDS (07 §Pipeline 1: the swap list only includes promotions
+    whose encodes have landed; pending promotions don't count against caps).
+
+    :meth:`SwapEngine.stage` with ``on_unavailable="drop"`` turns this into a
+    dropped pair instead of a failed interval. Structural failures
+    (unregistered layer, bad residency, geometry mismatch, foreign mcg) are
+    NOT droppable — they stay fatal, fail-closed.
+    """
+
+
+_UNAVAILABLE_ERROR_NAMES = frozenset((
+    "FragmentUnavailable",        # this module
+    "FragmentUnavailableError",   # fragments.py: no source could supply it
+    "FragmentVerificationError",  # fragments.py: sha mismatch
+))
+
+
+def is_unavailable_error(exc: BaseException) -> bool:
+    """Droppable supply-side failure (vs a fatal structural one)?
+
+    Matched by class NAME over the exception's MRO: this module must import
+    standalone (the GPU harness loads swap.py by path, where a relative
+    import of fragments.py does not exist), and third-party sources can then
+    signal "pend this promotion" without importing swap.py either.
+    """
+    return any(cls.__name__ in _UNAVAILABLE_ERROR_NAMES
+               for cls in type(exc).__mro__)
 
 
 class LocalSegmentSource:
@@ -251,6 +318,89 @@ class LocalSegmentSource:
                 if got != nbytes:
                     raise IOError(
                         f"{path.name}: short read on {name}: {got}/{nbytes}")
+
+
+class ResolverFragmentSource:
+    """:class:`FragmentSource` backed by loader v2's ``FragmentResolver``.
+
+    Staging a swap then goes through boot's exact supply chain — local
+    segment dirs → content-addressed cache → the manifest/``VLLM_FQ_SOURCES``
+    chain of HF repos and trusted mirrors — with the same attestation trust
+    filtering and per-fragment sha256 verification (implementation/10 §2/§4).
+    The engine's per-tensor validation (dtype, shape, byte count, layer
+    codebook) still runs on top of whatever the resolver hands back: one
+    ranged GET per expert is sufficient exactly because every tensor of that
+    expert is proven to live inside the indexed expert range.
+
+    The resolver is duck-typed (``resolve`` + ``materialize``) so swap.py
+    keeps its no-imports stance and tests can pass a fake.
+
+    Substitution policy: a fragment the ``VLLM_FQ_K_FALLBACK`` ladder
+    substituted at a different K cannot be written into a K``k`` slab row
+    (different word count) *and* means the requested encode has not landed —
+    :class:`FragmentUnavailable` is raised so the promotion pends (07 §1);
+    the resolver has already queued the encode. ``allow_substituted=True``
+    would only be meaningful with per-pair tier retargeting, which v1
+    (same-cardinality K3/K4 swaps, D1) does not have.
+    """
+
+    def __init__(self, resolver: Any, *, allow_substituted: bool = False,
+                 unavailable_errors: Sequence[type[BaseException]] = ()):
+        self.resolver = resolver
+        self.allow_substituted = bool(allow_substituted)
+        self.unavailable_errors = tuple(unavailable_errors)
+        self.reads = 0
+        self.unavailable = 0
+
+    def _unavailable(self, msg: str, cause: BaseException | None = None):
+        self.unavailable += 1
+        exc = FragmentUnavailable(msg)
+        if cause is not None:
+            exc.__cause__ = cause
+        return exc
+
+    def read_expert(self, *, layer: int, k: int, expert: int, rank: int,
+                    dest: ExpertStage) -> None:
+        if dest.bits != k:
+            raise ValueError(f"stage is K{dest.bits}, requested K{k}")
+        try:
+            fragment = self.resolver.resolve(layer, expert, k)
+        except Exception as exc:  # noqa: BLE001 — classified below
+            if isinstance(exc, self.unavailable_errors) or is_unavailable_error(exc):
+                raise self._unavailable(
+                    f"L{layer}/e{expert} K{k}: resolver refused "
+                    f"({type(exc).__name__}: {exc})", exc) from exc
+            raise
+        got_k = int(getattr(fragment, "k", k))
+        if got_k != k and not self.allow_substituted:
+            raise self._unavailable(
+                f"L{layer}/e{expert} K{k}: resolver substituted K{got_k} "
+                "(requested encode has not landed) — promotion pends")
+        suffix = f".rank{rank}."
+        pairs = self.resolver.materialize(
+            fragment, name_filter=lambda n: suffix in n)
+        tensors = dict(pairs)
+        for proj in _PROJS:
+            for comp in _COMPS:
+                name = tensor_name(layer, expert, proj, rank, comp)
+                src = tensors.get(name)
+                if src is None:
+                    raise KeyError(
+                        f"fragment L{layer}/e{expert} K{got_k} "
+                        f"({getattr(fragment, 'origin', '?')}) is missing "
+                        f"{name} — {len(tensors)} rank{rank} tensors present")
+                if comp == "mcg":
+                    dest.mcg[proj] = int(src.reshape(-1)[0])
+                    continue
+                t = dest.dest_tensor(proj, comp)
+                assert t is not None
+                if src.dtype != t.dtype or tuple(src.shape) != tuple(t.shape):
+                    raise ValueError(
+                        f"fragment L{layer}/e{expert} K{got_k}: {name} is "
+                        f"{src.dtype}{tuple(src.shape)}, stage expects "
+                        f"{t.dtype}{tuple(t.shape)}")
+                t.copy_(src)
+        self.reads += 1
 
 
 # ------------------------------------------------------------------ swap plan
@@ -390,11 +540,31 @@ class _StagedLayer:
     descriptor_host: torch.Tensor
 
 
+@dataclass(frozen=True)
+class DroppedPair:
+    """A plan pair staging could not supply (``on_unavailable="drop"``).
+
+    The pair is left entirely unapplied — both experts keep their current
+    tier, so per-layer K4 cardinality is preserved (D1) and the promotion
+    simply pends until its encode lands (07 §1)."""
+
+    swap: tuple[int, int, int]
+    expert: int
+    k: int
+    reason: str
+
+
 @dataclass
 class StagedBatch:
     """Everything apply() needs, fully resolved on the host pre-quiesce:
     three ordered (dst_view, src_pinned) op lists (commit-protocol steps
-    1–3) plus the post-swap orderings to commit into the layer states."""
+    1–3) plus the post-swap orderings to commit into the layer states.
+
+    ``plan`` is the EFFECTIVE plan (``requested_plan`` minus ``dropped``);
+    callers building the policy document to persist must derive it from
+    ``plan``, never from what they asked for. ``undo_ops`` is the fail-atomic
+    restore batch (pre-swap rows + maps) apply() replays inside the window if
+    it aborts before the visibility flip."""
 
     plan: SwapPlan
     slab_ops: list[tuple[torch.Tensor, torch.Tensor]]
@@ -404,6 +574,14 @@ class StagedBatch:
     bytes_h2d: int
     stage_seconds: float
     mcg: int | None
+    requested_plan: SwapPlan | None = None
+    dropped: tuple[DroppedPair, ...] = ()
+    undo_ops: list[tuple[torch.Tensor, torch.Tensor]] | None = None
+    restored: bool = False
+
+    @property
+    def fail_atomic(self) -> bool:
+        return self.undo_ops is not None
 
 
 @dataclass
@@ -416,6 +594,7 @@ class ApplyReport:
     generation: int
     mcg: int | None = None
     committed_policy_hash: str | None = None
+    dropped: tuple[DroppedPair, ...] = field(default_factory=tuple)
 
 
 # --------------------------------------------------------------- swap engine
@@ -466,6 +645,7 @@ class SwapEngine:
         self._build_maps = build_maps_fn or _default_build_maps
         if pin_memory is None:
             pin_memory = torch.cuda.is_available()
+        self._pin_memory = bool(pin_memory)
 
         for layer_id, state in self.layers.items():
             self._validate_layer(layer_id, state)
@@ -481,14 +661,47 @@ class SwapEngine:
             for _ in range(self.max_pairs)
         ]
         self._map_stages = {
-            layer_id: (
-                torch.empty(state.num_global_experts, dtype=torch.int32,
-                            pin_memory=pin_memory),
-                torch.empty(state.num_global_experts, dtype=torch.int32,
-                            pin_memory=pin_memory),
-            )
+            layer_id: self._new_map_stage(state)
             for layer_id, state in self.layers.items()
         }
+        # Fail-atomic staging (T5): the pre-swap encodings + pre-swap maps.
+        # Allocated on first use — a plan staged without fail_atomic keeps
+        # the 02 §Why-row-writes pinned budget (max_pairs x 7.875 MiB).
+        self._undo_stages: list[tuple[ExpertStage, ExpertStage]] | None = None
+        self._undo_map_stages: dict[
+            int, tuple[torch.Tensor, torch.Tensor]] = {}
+
+    def _new_map_stage(self, state: MixedLayerState
+                       ) -> tuple[torch.Tensor, torch.Tensor]:
+        return (
+            torch.empty(state.num_global_experts, dtype=torch.int32,
+                        pin_memory=self._pin_memory),
+            torch.empty(state.num_global_experts, dtype=torch.int32,
+                        pin_memory=self._pin_memory),
+        )
+
+    def _undo_stage_pair(self, index: int) -> tuple[ExpertStage, ExpertStage]:
+        """(K3, K4) pinned stages holding the PRE-swap payloads of pair
+        ``index`` — the restore sources apply() replays on a pre-flip abort."""
+        if self._undo_stages is None:
+            self._undo_stages = [
+                (ExpertStage(self.tier_bits[0], self.hidden_size,
+                             self.intermediate_size,
+                             pin_memory=self._pin_memory),
+                 ExpertStage(self.tier_bits[1], self.hidden_size,
+                             self.intermediate_size,
+                             pin_memory=self._pin_memory))
+                for _ in range(self.max_pairs)
+            ]
+        return self._undo_stages[index]
+
+    def _undo_map_stage(self, layer_id: int
+                        ) -> tuple[torch.Tensor, torch.Tensor]:
+        stage = self._undo_map_stages.get(layer_id)
+        if stage is None:
+            stage = self._undo_map_stages[layer_id] = self._new_map_stage(
+                self.layers[layer_id])
+        return stage
 
     # ---------------------------------------------------------- validation
 
@@ -565,12 +778,15 @@ class SwapEngine:
 
     # -------------------------------------------------------------- staging
 
-    def _stage_maps_for_layer(self, layer_id: int, tier0_globals: list[int],
-                              tier1_globals: list[int]) -> _StagedLayer:
+    def _stage_maps_for_layer(
+        self, layer_id: int, tier0_globals: list[int],
+        tier1_globals: list[int],
+        into: tuple[torch.Tensor, torch.Tensor] | None = None,
+    ) -> _StagedLayer:
         g2c_cpu, desc_cpu = self._build_maps(
             tier0_globals, tier1_globals, device=torch.device("cpu"))
         self._validate_host_maps(layer_id, len(tier0_globals), g2c_cpu, desc_cpu)
-        g2c_host, desc_host = self._map_stages[layer_id]
+        g2c_host, desc_host = into or self._map_stages[layer_id]
         g2c_host.copy_(g2c_cpu)
         desc_host.copy_(desc_cpu)
         return _StagedLayer(layer_id, list(tier0_globals), list(tier1_globals),
@@ -582,33 +798,90 @@ class SwapEngine:
         w2 = tier.w2.view(torch.int16).view(count, -1)
         return w13, w2
 
-    def stage(self, plan: SwapPlan) -> StagedBatch:
+    def stage(self, plan: SwapPlan, *, fail_atomic: bool = False,
+              on_unavailable: str = "raise") -> StagedBatch:
         """Resolve a plan into device-view/pinned-source op lists (host-only,
-        pre-quiesce: fragment IO, slot resolution, map rebuild)."""
+        pre-quiesce: fragment IO, slot resolution, map rebuild).
+
+        ``fail_atomic``: also stage both experts' PRE-swap encodings and the
+        pre-swap maps, so :meth:`apply` can restore the layer inside the
+        quiesce window if it aborts before the visibility flip (T5). Costs a
+        second read of each expert and doubles pinned staging.
+
+        ``on_unavailable="drop"``: a pair whose fragments no source can
+        supply (missing / untrusted / unverified / substituted-K, i.e.
+        :func:`is_unavailable_error`) is dropped from the batch instead of
+        failing the interval — the promotion pends (07 §1). Both experts keep
+        their tier, so cardinality is preserved. The surviving pairs are
+        :attr:`StagedBatch.plan`; build the policy document to persist from
+        that, not from the requested plan.
+        """
         t_start = time.perf_counter()
+        if on_unavailable not in ("raise", "drop"):
+            raise ValueError(
+                f"on_unavailable must be raise|drop, got {on_unavailable!r}")
         if len(plan) > self.max_pairs:
             raise ValueError(
                 f"plan has {len(plan)} pairs, staging holds {self.max_pairs}")
         k3_bits, k4_bits = self.tier_bits
         slab_ops: list[tuple[torch.Tensor, torch.Tensor]] = []
         rotation_ops: list[tuple[torch.Tensor, torch.Tensor]] = []
+        undo_ops: list[tuple[torch.Tensor, torch.Tensor]] | None = (
+            [] if fail_atomic else None)
+        dropped: list[DroppedPair] = []
+        applied: list[tuple[int, int, int]] = []
         mcg_seen: int | None = self.expected_mcg
         # Scratch orderings so multi-pair layers resolve slots sequentially
-        # without touching live state until commit.
+        # without touching live state until commit; ``pre`` keeps the
+        # pre-swap orderings for the fail-atomic map restore.
         orderings: dict[int, tuple[list[int], list[int]]] = {}
+        pre_orderings: dict[int, tuple[list[int], list[int]]] = {}
+        touched: list[int] = []
+        pair_idx = 0
 
-        for pair_idx, (layer_id, e_out, e_in) in enumerate(plan):
+        for layer_id, e_out, e_in in plan:
             state = self.layers.get(layer_id)
             if state is None:
                 raise KeyError(f"layer {layer_id} is not registered")
             if layer_id not in orderings:
                 orderings[layer_id] = (list(state.tier0_globals),
                                        list(state.tier1_globals))
+                pre_orderings[layer_id] = (list(state.tier0_globals),
+                                           list(state.tier1_globals))
             t0_ids, t1_ids = orderings[layer_id]
             if e_out not in t1_ids or e_in not in t0_ids:
                 raise ValueError(
                     f"invalid swap ({layer_id}, {e_out}, {e_in}): e_out must "
                     f"be resident K{k4_bits}, e_in resident K{k3_bits}")
+
+            # Fragment IO first: a pair that cannot be supplied leaves no
+            # trace (orderings are only mutated once every read landed).
+            out_stage, in_stage = self._stages[pair_idx]
+            reads = [(k3_bits, e_out, out_stage), (k4_bits, e_in, in_stage)]
+            undo_k3 = undo_k4 = None
+            if fail_atomic:
+                undo_k3, undo_k4 = self._undo_stage_pair(pair_idx)
+                # Pre-swap content of the two destination slots.
+                reads += [(k4_bits, e_out, undo_k4), (k3_bits, e_in, undo_k3)]
+            drop: DroppedPair | None = None
+            for k, expert, dest in reads:
+                try:
+                    self.source.read_expert(layer=layer_id, k=k, expert=expert,
+                                            rank=self.rank, dest=dest)
+                except Exception as exc:  # noqa: BLE001 — classified here
+                    if on_unavailable == "drop" and is_unavailable_error(exc):
+                        drop = DroppedPair(
+                            swap=(layer_id, e_out, e_in), expert=expert, k=k,
+                            reason=f"{type(exc).__name__}: {exc}")
+                        break
+                    raise
+            if drop is not None:
+                logger.warning(
+                    "FQ swap L%d e%d->K%d/e%d->K%d dropped: %s",
+                    layer_id, e_out, k3_bits, e_in, k4_bits, drop.reason)
+                dropped.append(drop)
+                continue
+
             # e_in inherits e_out's tier1 slot and vice versa: every other
             # expert's slot (and slab row) is untouched.
             slot1 = t1_ids.index(e_out)
@@ -616,13 +889,14 @@ class SwapEngine:
             t1_ids[slot1] = e_in
             t0_ids[slot0] = e_out
             t0n = len(t0_ids)
+            applied.append((layer_id, e_out, e_in))
+            if layer_id not in touched:
+                touched.append(layer_id)
+            pair_idx += 1
 
-            out_stage, in_stage = self._stages[pair_idx]
-            self.source.read_expert(layer=layer_id, k=k3_bits, expert=e_out,
-                                    rank=self.rank, dest=out_stage)
-            self.source.read_expert(layer=layer_id, k=k4_bits, expert=e_in,
-                                    rank=self.rank, dest=in_stage)
-            for stage, expert in ((out_stage, e_out), (in_stage, e_in)):
+            for stage, expert in ((out_stage, e_out), (in_stage, e_in),
+                                  *(((undo_k4, e_out), (undo_k3, e_in))
+                                    if fail_atomic else ())):
                 for proj, value in stage.mcg.items():
                     if mcg_seen is None:
                         mcg_seen = value
@@ -637,43 +911,53 @@ class SwapEngine:
                         f"mcg {state.mcg}")
 
             # Step-1 ops: slab rows for BOTH experts at their NEW slots.
-            for tier, count, slot, stage in (
-                    (state.tier1, len(t1_ids), slot1, in_stage),
-                    (state.tier0, t0n, slot0, out_stage)):
+            # The undo op for a destination is the SAME view fed the expert
+            # that occupied it pre-swap.
+            for tier, count, slot, stage, undo in (
+                    (state.tier1, len(t1_ids), slot1, in_stage, undo_k4),
+                    (state.tier0, t0n, slot0, out_stage, undo_k3)):
                 w13, w2 = self._slab_rows(tier, count)
-                slab_ops.append((w13[0, slot], stage.trellis["gate"].view(-1)))
-                slab_ops.append((w13[1, slot], stage.trellis["up"].view(-1)))
-                slab_ops.append((w2[slot], stage.trellis["down"].view(-1)))
+                dsts = (w13[0, slot], w13[1, slot], w2[slot])
+                slab_ops.extend(zip(dsts, stage.slab_rows()))
+                if undo_ops is not None:
+                    undo_ops.extend(zip(dsts, undo.slab_rows()))
 
             # Step-2 ops: COMBINED rotation/suh/svh rows at NEW combined
             # slots (tier0 local -> slot, tier1 local -> t0 + slot).
             rot = state.rotations
-            for combined_slot, stage in ((t0n + slot1, in_stage),
-                                         (slot0, out_stage)):
-                rotation_ops.append(
-                    (rot.intermediate[combined_slot], stage.inter_rot))
-                rotation_ops.append(
-                    (rot.gate_suh[combined_slot], stage.suh["gate"]))
-                rotation_ops.append(
-                    (rot.up_suh[combined_slot], stage.suh["up"]))
-                rotation_ops.append(
-                    (rot.down_svh[combined_slot], stage.svh["down"]))
+            for combined_slot, stage, undo in ((t0n + slot1, in_stage, undo_k4),
+                                               (slot0, out_stage, undo_k3)):
+                dsts = (rot.intermediate[combined_slot],
+                        rot.gate_suh[combined_slot],
+                        rot.up_suh[combined_slot],
+                        rot.down_svh[combined_slot])
+                rotation_ops.extend(zip(dsts, stage.rotation_rows()))
+                if undo_ops is not None:
+                    undo_ops.extend(zip(dsts, undo.rotation_rows()))
 
         staged_layers = [
-            self._stage_maps_for_layer(layer_id, t0_ids, t1_ids)
-            for layer_id, (t0_ids, t1_ids) in orderings.items()
+            self._stage_maps_for_layer(layer_id, *orderings[layer_id])
+            for layer_id in touched
         ]
         map_ops: list[tuple[torch.Tensor, torch.Tensor]] = []
         for staged in staged_layers:
             state = self.layers[staged.layer]
             map_ops.append((state.global_to_combined, staged.g2c_host))
             map_ops.append((state.descriptor_map, staged.descriptor_host))
+        if undo_ops is not None:
+            for layer_id in touched:
+                state = self.layers[layer_id]
+                pre = self._stage_maps_for_layer(
+                    layer_id, *pre_orderings[layer_id],
+                    self._undo_map_stage(layer_id))
+                undo_ops.append((state.global_to_combined, pre.g2c_host))
+                undo_ops.append((state.descriptor_map, pre.descriptor_host))
 
         bytes_h2d = sum(
             src.numel() * src.element_size()
             for _, src in (*slab_ops, *rotation_ops, *map_ops))
         return StagedBatch(
-            plan=plan,
+            plan=SwapPlan(applied) if dropped else plan,
             slab_ops=slab_ops,
             rotation_ops=rotation_ops,
             map_ops=map_ops,
@@ -681,6 +965,9 @@ class SwapEngine:
             bytes_h2d=bytes_h2d,
             stage_seconds=time.perf_counter() - t_start,
             mcg=mcg_seen,
+            requested_plan=plan,
+            dropped=tuple(dropped),
+            undo_ops=undo_ops,
         )
 
     # ---------------------------------------------------------------- apply
@@ -709,6 +996,19 @@ class SwapEngine:
         is the T5 torn-update instrumentation seam (called after each of
         COMMIT_STEPS; raising aborts between steps).
 
+        Abort semantics (T5), for an exception from any step or hook:
+
+        * **before the flip** — if the batch was staged ``fail_atomic``, the
+          pre-swap rows and maps are restored inside the same quiesce window
+          (``staged.restored``) and the layer resumes fully-old; otherwise
+          the layer is left torn and the caller must re-apply the plan (roll
+          forward) or restart (slabs are a cache, rebuilt from artifacts).
+        * **at or after the flip** — the swap is committed: live orderings
+          and the generation counter advance with the maps (``finally``), so
+          the layer resumes fully-new and rollback is the normal
+          ``apply(plan.inverse())``. A failed ``memo_hook`` still leaves a
+          stale FusedMoEQuantConfig memo — the caller must retry it.
+
         Rollback: ``apply(plan.inverse(), ...)`` — fragments are re-read
         from the artifact pair by :meth:`stage`.
         """
@@ -716,42 +1016,67 @@ class SwapEngine:
             if plan is None:
                 raise ValueError("apply() needs a plan or a staged batch")
             staged = self.stage(plan)
-        elif plan is not None and staged.plan != plan:
+        elif plan is not None and plan not in (staged.plan,
+                                               staged.requested_plan):
             raise ValueError("staged batch does not match plan")
 
         stream_ctx: AbstractContextManager = (
             torch.cuda.stream(stream) if stream is not None else nullcontext())
         committed_hash: str | None = None
+        flipped = False
         t_window = time.perf_counter()
         with quiesce:
-            with stream_ctx:
-                for dst, src in staged.slab_ops:  # step 1
-                    dst.copy_(src, non_blocking=True)
-                if step_hook is not None:
-                    step_hook("slabs")
-                for dst, src in staged.rotation_ops:  # step 2
-                    dst.copy_(src, non_blocking=True)
-                if step_hook is not None:
-                    step_hook("rotations")
-                for dst, src in staged.map_ops:  # step 3 — visibility flip
-                    dst.copy_(src, non_blocking=True)
-                if step_hook is not None:
-                    step_hook("maps")
+            try:
+                with stream_ctx:
+                    for dst, src in staged.slab_ops:  # step 1
+                        dst.copy_(src, non_blocking=True)
+                    if step_hook is not None:
+                        step_hook("slabs")
+                    for dst, src in staged.rotation_ops:  # step 2
+                        dst.copy_(src, non_blocking=True)
+                    if step_hook is not None:
+                        step_hook("rotations")
+                    for dst, src in staged.map_ops:  # step 3 — visibility flip
+                        dst.copy_(src, non_blocking=True)
+                    flipped = True
+                    if step_hook is not None:
+                        step_hook("maps")
+            except BaseException:
+                if not flipped and staged.undo_ops is not None:
+                    with stream_ctx:
+                        for dst, src in staged.undo_ops:
+                            dst.copy_(src, non_blocking=True)
+                    staged.restored = True
+                    logger.warning(
+                        "FQ swap aborted before the visibility flip; %d "
+                        "pre-swap rows/maps restored inside the quiesce "
+                        "window (layer state is fully-old)",
+                        len(staged.undo_ops))
+                elif not flipped:
+                    logger.error(
+                        "FQ swap aborted before the visibility flip WITHOUT "
+                        "fail-atomic staging — slab rows are torn; re-apply "
+                        "the plan or restart (slabs are a cache)")
+                raise
+            finally:
+                # The flip is the only visibility point: live orderings and
+                # the generation counter commit WITH the maps, so an abort in
+                # step 4/5 cannot leave a stale host view of flipped maps.
+                if flipped:
+                    self.generation += 1
+                    for staged_layer in staged.staged_layers:
+                        state = self.layers[staged_layer.layer]
+                        state.tier0_globals[:] = staged_layer.tier0_globals
+                        state.tier1_globals[:] = staged_layer.tier1_globals
             if memo_hook is not None:  # step 4
                 memo_hook()
             if step_hook is not None:
                 step_hook("memo")
-            self.generation += 1  # step 5
-            if policy_store is not None and policy_doc is not None:
+            if policy_store is not None and policy_doc is not None:  # step 5
                 committed_hash = policy_store.commit(
                     policy_doc, num_experts=policy_num_experts)
             if step_hook is not None:
                 step_hook("persist")
-            # Host bookkeeping: the committed orderings become live state.
-            for staged_layer in staged.staged_layers:
-                state = self.layers[staged_layer.layer]
-                state.tier0_globals[:] = staged_layer.tier0_globals
-                state.tier1_globals[:] = staged_layer.tier1_globals
         window_seconds = time.perf_counter() - t_window
 
         return ApplyReport(
@@ -763,6 +1088,7 @@ class SwapEngine:
             generation=self.generation,
             mcg=staged.mcg,
             committed_policy_hash=committed_hash,
+            dropped=staged.dropped,
         )
 
     # ---------------------------------------------------------- map rebuild

--- a/vllm/model_executor/layers/quantization/exl3_fungible/swap.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/swap.py
@@ -60,6 +60,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import struct
 import time
 from contextlib import AbstractContextManager, nullcontext
@@ -77,6 +78,10 @@ DESCRIPTOR_TIER_SHIFT = 8  # descriptor = (tier << 8) | local, single decode sit
 
 _PROJS = ("gate", "up", "down")
 _COMPS = ("trellis", "suh", "svh", "mcg")
+
+# Default policy for a pair whose fragments no source can supply:
+# "raise" (fail-closed, the default) or "drop" (pend the promotion).
+FQ_ON_UNAVAILABLE_ENV = "VLLM_FQ_ON_UNAVAILABLE"
 # safetensors dtype tag -> (torch dtype, itemsize)
 _ST_DTYPES = {
     "I16": (torch.int16, 2),
@@ -342,13 +347,37 @@ class ResolverFragmentSource:
     the resolver has already queued the encode. ``allow_substituted=True``
     would only be meaningful with per-pair tier retargeting, which v1
     (same-cardinality K3/K4 swaps, D1) does not have.
+
+    Never-raise path: when the resolver exposes ``resolve_best`` (the real
+    :class:`~.fragments.FragmentResolver` does) it is preferred over
+    ``resolve``. ``resolve_best`` cannot throw — a missing fragment, an
+    unreachable mirror, a corrupt local segment dir and even an internal
+    resolver bug all come back as ``None``/a substituted K, which this
+    adapter turns into :class:`FragmentUnavailable`. Combined with
+    ``stage(on_unavailable="drop")`` that means a weight which is not
+    available at the required bitrate costs the interval one pending
+    promotion, never the engine.
     """
 
     def __init__(self, resolver: Any, *, allow_substituted: bool = False,
-                 unavailable_errors: Sequence[type[BaseException]] = ()):
+                 unavailable_errors: Sequence[type[BaseException]] = (),
+                 prefer_best: bool = True):
         self.resolver = resolver
         self.allow_substituted = bool(allow_substituted)
         self.unavailable_errors = tuple(unavailable_errors)
+        best = getattr(resolver, "resolve_best", None)
+        self.prefer_best = bool(prefer_best) and callable(best)
+        # A third-party resolver may implement resolve_best without the
+        # decision-chain out-parameter; only pass it when it is declared.
+        self._best_takes_chain = False
+        if self.prefer_best:
+            try:
+                import inspect
+
+                self._best_takes_chain = (
+                    "chain_out" in inspect.signature(best).parameters)
+            except (TypeError, ValueError):
+                self._best_takes_chain = False
         self.reads = 0
         self.unavailable = 0
 
@@ -363,14 +392,27 @@ class ResolverFragmentSource:
                     dest: ExpertStage) -> None:
         if dest.bits != k:
             raise ValueError(f"stage is K{dest.bits}, requested K{k}")
-        try:
-            fragment = self.resolver.resolve(layer, expert, k)
-        except Exception as exc:  # noqa: BLE001 — classified below
-            if isinstance(exc, self.unavailable_errors) or is_unavailable_error(exc):
+        if self.prefer_best:
+            chain: list[str] = []
+            fragment = (
+                self.resolver.resolve_best(layer, expert, k, chain_out=chain)
+                if self._best_takes_chain
+                else self.resolver.resolve_best(layer, expert, k))
+            if fragment is None:
                 raise self._unavailable(
                     f"L{layer}/e{expert} K{k}: resolver refused "
-                    f"({type(exc).__name__}: {exc})", exc) from exc
-            raise
+                    f"({'; '.join(chain) or 'no source has it'}) — the "
+                    "encode is queued, the promotion pends")
+        else:
+            try:
+                fragment = self.resolver.resolve(layer, expert, k)
+            except Exception as exc:  # noqa: BLE001 — classified below
+                if isinstance(exc, self.unavailable_errors) or \
+                        is_unavailable_error(exc):
+                    raise self._unavailable(
+                        f"L{layer}/e{expert} K{k}: resolver refused "
+                        f"({type(exc).__name__}: {exc})", exc) from exc
+                raise
         got_k = int(getattr(fragment, "k", k))
         if got_k != k and not self.allow_substituted:
             raise self._unavailable(
@@ -799,7 +841,7 @@ class SwapEngine:
         return w13, w2
 
     def stage(self, plan: SwapPlan, *, fail_atomic: bool = False,
-              on_unavailable: str = "raise") -> StagedBatch:
+              on_unavailable: str | None = None) -> StagedBatch:
         """Resolve a plan into device-view/pinned-source op lists (host-only,
         pre-quiesce: fragment IO, slot resolution, map rebuild).
 
@@ -815,8 +857,23 @@ class SwapEngine:
         their tier, so cardinality is preserved. The surviving pairs are
         :attr:`StagedBatch.plan`; build the policy document to persist from
         that, not from the requested plan.
+
+        The default comes from ``VLLM_FQ_ON_UNAVAILABLE`` (``raise``|``drop``)
+        and is ``raise`` when unset — fail-closed, so an operator who never
+        asked for pending promotions sees a supply problem. A live serve that
+        must never lose an interval to a missing encode sets
+        ``VLLM_FQ_ON_UNAVAILABLE=drop`` once, and every staging path inherits
+        it without each call site having to remember.
+
+        Either way staging is host-only and happens entirely BEFORE
+        :meth:`apply` opens the quiesce window: an unavailable fragment can
+        cost a pair or an interval, but it can never tear a layer.
         """
         t_start = time.perf_counter()
+        if on_unavailable is None:
+            on_unavailable = (
+                os.environ.get(FQ_ON_UNAVAILABLE_ENV) or "raise"
+            ).strip().lower()
         if on_unavailable not in ("raise", "drop"):
             raise ValueError(
                 f"on_unavailable must be raise|drop, got {on_unavailable!r}")

--- a/vllm/model_executor/layers/quantization/exl3_fungible/swap.py
+++ b/vllm/model_executor/layers/quantization/exl3_fungible/swap.py
@@ -66,7 +66,8 @@ import time
 from contextlib import AbstractContextManager, nullcontext
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable, Iterator, Mapping, Protocol, Sequence
+from typing import (Any, Callable, Iterator, Mapping, MutableMapping,
+                    Protocol, Sequence)
 
 import numpy as np
 import torch
@@ -549,6 +550,9 @@ class MixedLayerState:
     tier0_globals: list[int]
     tier1_globals: list[int]
     mcg: int | None = None
+    #: The ``layer.exl3_mixed_trellis`` dict this state was adapted from, so a
+    #: committed apply can publish the new orderings back to it. See publish().
+    source: MutableMapping[str, Any] | None = None
 
     @classmethod
     def from_exl3_mixed_trellis(cls, mixed: Mapping[str, Any]) -> "MixedLayerState":
@@ -566,7 +570,38 @@ class MixedLayerState:
             descriptor_map=mixed["descriptor_map"],
             tier0_globals=list(tier0_ids),
             tier1_globals=list(tier1_ids),
+            source=mixed if isinstance(mixed, MutableMapping) else None,
         )
+
+    def publish(self) -> bool:
+        """Write the committed orderings back to ``layer.exl3_mixed_trellis``.
+
+        Without this, ``tier_ids`` on the module keeps its BOOT value forever
+        while the device maps advance with every apply — so the module lies to
+        anything that reads it later.
+
+        That is not hypothetical. ``from_exl3_mixed_trellis`` COPIES the
+        orderings, so two SwapEngines over the same layer each track their own
+        host-side view. The admin API built one (cached on
+        ``state.swap_engine``) and the interval loop built another; the loop
+        installed 64 swaps through its engine, the module never heard about it,
+        and the next plan validated against a stale ordering:
+
+            ValueError: invalid swap (3, 51, 60): e_out must be resident K4
+
+        with the loop's own tier map insisting e51 WAS K4. It was — on the
+        device and in the loop, but not in the engine that happened to answer.
+        The engine is now shared (integration.py reuses ``state.swap_engine``),
+        which fixes the live path; this publishes the truth so that a rebuilt
+        engine — a later admin call, a reload, a future caller we have not
+        written yet — starts from what the device actually holds rather than
+        from boot.
+        """
+        if self.source is None:
+            return False
+        self.source["tier_ids"] = (list(self.tier0_globals),
+                                   list(self.tier1_globals))
+        return True
 
     @property
     def num_global_experts(self) -> int:
@@ -1125,6 +1160,9 @@ class SwapEngine:
                         state = self.layers[staged_layer.layer]
                         state.tier0_globals[:] = staged_layer.tier0_globals
                         state.tier1_globals[:] = staged_layer.tier1_globals
+                        # Same visibility point as the maps: the module must
+                        # not survive the flip still advertising boot tiers.
+                        state.publish()
             if memo_hook is not None:  # step 4
                 memo_hook()
             if step_hook is not None:
@@ -1172,3 +1210,4 @@ class SwapEngine:
             state.descriptor_map.copy_(staged.descriptor_host, non_blocking=True)
         state.tier0_globals[:] = staged.tier0_globals
         state.tier1_globals[:] = staged.tier1_globals
+        state.publish()

--- a/vllm/model_executor/model_loader/__init__.py
+++ b/vllm/model_executor/model_loader/__init__.py
@@ -10,9 +10,6 @@ from vllm.config.load import LoadConfig
 from vllm.logger import init_logger
 from vllm.model_executor.model_loader.base_loader import BaseModelLoader
 from vllm.model_executor.model_loader.bitsandbytes_loader import BitsAndBytesModelLoader
-from vllm.model_executor.layers.quantization.exl3_fungible.progressive_loader import (
-    ProgressiveModelLoader,
-)
 from vllm.model_executor.model_loader.default_loader import DefaultModelLoader
 from vllm.model_executor.model_loader.dummy_loader import DummyModelLoader
 from vllm.model_executor.model_loader.modelexpress_loader import (
@@ -51,6 +48,22 @@ LoadFormats = Literal[
     "sharded_state",
     "tensorizer",
 ]
+def _progressive_loader_cls(*args, **kwargs):
+    """Lazily resolve the Progressive Tensors loader.
+
+    Importing it eagerly here makes `exl3_fungible.progressive_loader`
+    unimportable on its own: that module needs `model_loader.base_loader`,
+    which initializes this package, which would then import a
+    half-initialized module. Resolving at construction keeps both import
+    orders working.
+    """
+    from vllm.model_executor.layers.quantization.exl3_fungible.progressive_loader import (  # noqa: E501
+        ProgressiveModelLoader,
+    )
+
+    return ProgressiveModelLoader(*args, **kwargs)
+
+
 _LOAD_FORMAT_TO_MODEL_LOADER: dict[str, type[BaseModelLoader]] = {
     "auto": DefaultModelLoader,
     "hf": DefaultModelLoader,
@@ -61,7 +74,7 @@ _LOAD_FORMAT_TO_MODEL_LOADER: dict[str, type[BaseModelLoader]] = {
     "mistral": DefaultModelLoader,
     "modelexpress": ModelExpressModelLoader,
     "npcache": DefaultModelLoader,
-    "progressive": ProgressiveModelLoader,
+    "progressive": _progressive_loader_cls,
     "pt": DefaultModelLoader,
     "runai_streamer": RunaiModelStreamerLoader,
     "runai_streamer_sharded": ShardedStateLoader,
@@ -159,7 +172,6 @@ __all__ = [
     "ModelExpressModelLoader",
     "DefaultModelLoader",
     "DummyModelLoader",
-    "ProgressiveModelLoader",
     "RunaiModelStreamerLoader",
     "ShardedStateLoader",
     "TensorizerLoader",

--- a/vllm/model_executor/model_loader/__init__.py
+++ b/vllm/model_executor/model_loader/__init__.py
@@ -10,6 +10,9 @@ from vllm.config.load import LoadConfig
 from vllm.logger import init_logger
 from vllm.model_executor.model_loader.base_loader import BaseModelLoader
 from vllm.model_executor.model_loader.bitsandbytes_loader import BitsAndBytesModelLoader
+from vllm.model_executor.layers.quantization.exl3_fungible.progressive_loader import (
+    ProgressiveModelLoader,
+)
 from vllm.model_executor.model_loader.default_loader import DefaultModelLoader
 from vllm.model_executor.model_loader.dummy_loader import DummyModelLoader
 from vllm.model_executor.model_loader.modelexpress_loader import (
@@ -40,6 +43,7 @@ LoadFormats = Literal[
     "mistral",
     "modelexpress",
     "npcache",
+    "progressive",
     "pt",
     "runai_streamer",
     "runai_streamer_sharded",
@@ -57,6 +61,7 @@ _LOAD_FORMAT_TO_MODEL_LOADER: dict[str, type[BaseModelLoader]] = {
     "mistral": DefaultModelLoader,
     "modelexpress": ModelExpressModelLoader,
     "npcache": DefaultModelLoader,
+    "progressive": ProgressiveModelLoader,
     "pt": DefaultModelLoader,
     "runai_streamer": RunaiModelStreamerLoader,
     "runai_streamer_sharded": ShardedStateLoader,
@@ -154,6 +159,7 @@ __all__ = [
     "ModelExpressModelLoader",
     "DefaultModelLoader",
     "DummyModelLoader",
+    "ProgressiveModelLoader",
     "RunaiModelStreamerLoader",
     "ShardedStateLoader",
     "TensorizerLoader",

--- a/vllm/model_executor/warmup/kernel_warmup.py
+++ b/vllm/model_executor/warmup/kernel_warmup.py
@@ -271,6 +271,42 @@ def kernel_warmup(worker: "Worker"):
         cudagraph_capture_sizes=mhc_warmup_token_sizes,
     )
 
+    # The first profile pass creates the EXL3 mixed-Trellis runtimes. Warm
+    # every route-pack capacity now so their persistent CUDA modules are
+    # included in the second memory profile and exist before graph capture.
+    exl3_models = [worker.get_model()]
+    get_draft_model = getattr(worker, "get_draft_model", None)
+    draft_model = get_draft_model() if callable(get_draft_model) else None
+    if draft_model is not None and draft_model is not exl3_models[0]:
+        exl3_models.append(draft_model)
+    uses_mixed_exl3 = any(
+        any(
+            isinstance(
+                getattr(
+                    getattr(module, "routed_experts", module),
+                    "exl3_mixed_trellis",
+                    None,
+                ),
+                dict,
+            )
+            for module in model.modules()
+        )
+        for model in exl3_models
+    )
+    if uses_mixed_exl3:
+        from vllm.model_executor.layers.quantization.exl3 import (
+            warmup_exl3_mixed_trellis_route_pack,
+        )
+
+        warmed_exl3 = sum(
+            warmup_exl3_mixed_trellis_route_pack(model) for model in exl3_models
+        )
+        if warmed_exl3:
+            logger.info(
+                "Warmed up %d EXL3 mixed-Trellis route-pack variants.",
+                warmed_exl3,
+            )
+
     warmed_dcp_a2a = _warmup_b12x_dcp_a2a(worker)
     if warmed_dcp_a2a:
         logger.info(

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4767,6 +4767,11 @@ class GPUModelRunner(
         with record_function_or_nullcontext("gpu_model_runner: eplb"):
             self.eplb_step()
 
+        # Fungible-quant M1: advance the stats window once per engine step,
+        # same cadence as EPLB's step above.
+        if getattr(self, "fq_collector", None) is not None:
+            self.fq_collector.step()
+
         # self.kv_connector_output may be modified during drafting
         kv_connector_output = self.kv_connector_output
         self.kv_connector_output = None
@@ -6254,6 +6259,15 @@ class GPUModelRunner(
         # ranks execute the rearrangement in synchronization.
         if not skip_eplb:
             self.eplb_step(is_dummy=True, is_profile=is_profile)
+
+        # Fungible-quant M1: dummy batches still fire the router capture fn,
+        # so always discard their stats (EPLB dummy-step semantics: zero
+        # without recording). Unlike eplb_step this is host-local — no
+        # collective — so it is safe outside the skip_eplb gate, and running
+        # it there keeps eager warmup/profile garbage out of the first
+        # window.
+        if getattr(self, "fq_collector", None) is not None:
+            self.fq_collector.step(is_dummy=True)
 
         logit_indices = np.cumsum(num_scheduled_tokens) - 1
         logit_indices_device = torch.from_numpy(logit_indices).to(

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -795,6 +795,18 @@ class Worker(WorkerBase):
         if self.model_config.enable_return_routed_experts:
             self.model_runner.init_routed_experts_capturer()
 
+        # Fungible-quant M1: bind the routing-stats collector to every MoE
+        # router before CUDA-graph capture. Deliberately NOT gated on
+        # enable_return_routed_experts (that flag governs the capturer
+        # above); bind_router chains any capture fn the capturer already
+        # installed. No-op returning None unless VLLM_FQ_ENABLE=1; the
+        # function import keeps cost at zero for the default path.
+        from vllm.model_executor.layers.quantization.exl3_fungible.integration import (  # noqa: E501
+            maybe_init_fq_collector,
+        )
+
+        self.model_runner.fq_collector = maybe_init_fq_collector(self.model_runner)
+
         # Build KV-zero metadata outside the CuMem pool so the bookkeeping
         # GPU tensors (seg_addrs, block-id buffers) use the standard PyTorch
         # allocator and are not discarded during sleep/wake cycles.

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -456,6 +456,17 @@ class Worker(WorkerBase):
         ):
             self.model_runner.load_model(load_dummy_weights=load_dummy_weights)
 
+        # FQ: return the loader's staging residue to the driver BEFORE KV
+        # sizing. This must run HERE, not inside the progressive loader:
+        # load_weights returns with only 35.11 GiB resident because the EXL3
+        # quant method device-copies in process_weights_after_loading, which
+        # model_runner.load_model() has only just finished. Reclaiming at the
+        # earlier point freed 0.39 GiB of the ~3.9 GiB actually stranded --
+        # and every stranded byte is charged against the KV cache, because
+        # vLLM sizes KV from what the DRIVER reports free while the caching
+        # allocator holds freed blocks as reserved.
+        self._fq_reclaim_after_load()
+
         if self.vllm_config.weight_transfer_config is not None:
             self.weight_transfer_engine = WeightTransferEngineFactory.create_engine(
                 self.vllm_config.weight_transfer_config,
@@ -463,6 +474,48 @@ class Worker(WorkerBase):
                 self.device,
                 self.model_runner.get_model(),
             )
+
+    def _fq_reclaim_after_load(self) -> None:
+        """Free allocator residue left by progressive loading, and calibrate.
+
+        Two outputs, both measured rather than assumed:
+          - reserved-before/after, so the recovery is a number in the log
+            instead of a claim in a commit message;
+          - the true per-rank weight footprint, which is what the next boot's
+            memory preflight needs in order to project exactly rather than
+            reconstruct from file headers (which over-charges one rank for all
+            four TP ranks' non-expert tensors).
+
+        Guarded to a no-op unless the progressive loader ran: a normal
+        checkpoint load has no per-expert staging to reclaim.
+        """
+        import os
+
+        if os.environ.get("VLLM_FQ_RECLAIM", "1") == "0":
+            return
+        if getattr(self.vllm_config.load_config, "load_format", None) != \
+                "progressive":
+            return
+        try:
+            import gc
+
+            import torch
+
+            before_r = torch.cuda.memory_reserved()
+            allocated = torch.cuda.memory_allocated()
+            gc.collect()
+            torch.cuda.empty_cache()
+            after_r = torch.cuda.memory_reserved()
+            logger.info(
+                "FQ reclaim (post process_weights_after_loading): reserved "
+                "%.2f -> %.2f GiB, freed %.2f GiB; weight footprint %.2f GiB",
+                before_r / (1 << 30), after_r / (1 << 30),
+                (before_r - after_r) / (1 << 30), allocated / (1 << 30))
+            from vllm.model_executor.layers.quantization.exl3_fungible.\
+                progressive_loader import record_weight_footprint
+            record_weight_footprint(allocated)
+        except Exception:  # noqa: BLE001 — never fail a boot to save memory
+            logger.warning("FQ post-load reclaim skipped", exc_info=True)
 
     def update_config(self, overrides: dict[str, Any]) -> None:
         self.model_runner.update_config(overrides)

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -795,17 +795,20 @@ class Worker(WorkerBase):
         if self.model_config.enable_return_routed_experts:
             self.model_runner.init_routed_experts_capturer()
 
-        # Fungible-quant M1: bind the routing-stats collector to every MoE
-        # router before CUDA-graph capture. Deliberately NOT gated on
+        # Fungible-quant M1+M2: bind the routing-stats collector to every
+        # MoE router before CUDA-graph capture and wrap it in the decision
+        # loop state machine. Deliberately NOT gated on
         # enable_return_routed_experts (that flag governs the capturer
         # above); bind_router chains any capture fn the capturer already
         # installed. No-op returning None unless VLLM_FQ_ENABLE=1; the
-        # function import keeps cost at zero for the default path.
+        # function import keeps cost at zero for the default path. The
+        # returned object (loop state or bare collector) shares the
+        # step(is_dummy=...) contract the runner's step sites rely on.
         from vllm.model_executor.layers.quantization.exl3_fungible.integration import (  # noqa: E501
-            maybe_init_fq_collector,
+            maybe_init_fq_state,
         )
 
-        self.model_runner.fq_collector = maybe_init_fq_collector(self.model_runner)
+        self.model_runner.fq_collector = maybe_init_fq_state(self.model_runner)
 
         # Build KV-zero metadata outside the CuMem pool so the bookkeeping
         # GPU tensors (seg_addrs, block-id buffers) use the standard PyTorch

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -818,6 +818,35 @@ class Worker(WorkerBase):
         ):
             self.model_runner._init_kv_zero_meta()
 
+    # ---------------------------------------------------------- FQ admin
+    # Reachable by name through EngineClient.collective_rpc (the method is
+    # resolved on the worker object). Thin lazy-import delegates so the FQ
+    # package's laziness contract holds: nothing fungible-quant is imported
+    # unless somebody actually calls one of these. All logic lives in
+    # exl3_fungible/admin.py, where it is CPU-testable. JSON strings in and
+    # out, matching the /collective_rpc convention.
+
+    def fq_admin_describe(self, request_json: str = "{}") -> str:
+        from vllm.model_executor.layers.quantization.exl3_fungible.admin import (  # noqa: E501
+            worker_describe,
+        )
+
+        return worker_describe(self, request_json)
+
+    def fq_admin_plan(self, request_json: str) -> str:
+        from vllm.model_executor.layers.quantization.exl3_fungible.admin import (  # noqa: E501
+            worker_plan,
+        )
+
+        return worker_plan(self, request_json)
+
+    def fq_admin_apply(self, plan_json: str) -> str:
+        from vllm.model_executor.layers.quantization.exl3_fungible.admin import (  # noqa: E501
+            worker_apply,
+        )
+
+        return worker_apply(self, plan_json)
+
     @instrument(span_name="Warmup (GPU)")
     def compile_or_warm_up_model(self) -> CompilationTimes:
         warmup_sizes: list[int] = []

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -514,8 +514,62 @@ class Worker(WorkerBase):
             from vllm.model_executor.layers.quantization.exl3_fungible.\
                 progressive_loader import record_weight_footprint
             record_weight_footprint(allocated)
+            self._fq_trim_host_heap()
         except Exception:  # noqa: BLE001 — never fail a boot to save memory
             logger.warning("FQ post-load reclaim skipped", exc_info=True)
+
+    @staticmethod
+    def _fq_trim_host_heap() -> None:
+        """Return the progressive loader's host-side heap to the OS.
+
+        The GPU reclaim above has a host-side twin that was missing, and it is
+        far larger. Measured on a live TP4 serve, per rank, while SERVING:
+
+            [heap]          228.7 GiB      Anonymous     230.3 GiB
+            Private_Dirty   232.0 GiB      GPU footprint  66.92 GiB
+
+        ~3.5x the resident model, x4 ranks = ~924 GiB of a 1280 GiB cgroup,
+        leaving 118 GiB of headroom. Two concurrent boots therefore cannot
+        fit, and two workers were OOM-killed before this was understood
+        (memory.events: oom 16, oom_kill 2).
+
+        It is retention, not a leak — RSS is flat, and the bytes are in the
+        glibc MAIN heap, which only shrinks from the top: one live allocation
+        near the boot-time high-water mark pins everything beneath it. brk
+        cannot give it back, but malloc_trim() releases the free pages inside
+        the heap via MADV_DONTNEED, which is exactly this case.
+
+        Measured and logged rather than asserted, like its GPU counterpart —
+        an unverified "reclaim" that frees nothing is a claim, and this
+        project has already retracted one of those.
+        """
+        import ctypes
+
+        def _rss_kb() -> int:
+            try:
+                with open("/proc/self/status") as f:
+                    for line in f:
+                        if line.startswith("VmRSS:"):
+                            return int(line.split()[1])
+            except OSError:
+                pass
+            return 0
+
+        before = _rss_kb()
+        try:
+            libc = ctypes.CDLL("libc.so.6", use_errno=True)
+            libc.malloc_trim.argtypes = [ctypes.c_size_t]
+            libc.malloc_trim.restype = ctypes.c_int
+            returned = int(libc.malloc_trim(0))
+        except Exception:  # noqa: BLE001 — musl and friends have no malloc_trim
+            logger.info("FQ host heap trim unavailable (no glibc malloc_trim)")
+            return
+        after = _rss_kb()
+        logger.info(
+            "FQ host heap trim: RSS %.2f -> %.2f GiB, freed %.2f GiB "
+            "(malloc_trim returned %d)",
+            before / (1 << 20), after / (1 << 20),
+            (before - after) / (1 << 20), returned)
 
     def update_config(self, overrides: dict[str, Any]) -> None:
         self.model_runner.update_config(overrides)

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -879,6 +879,19 @@ class Worker(WorkerBase):
     # exl3_fungible/admin.py, where it is CPU-testable. JSON strings in and
     # out, matching the /collective_rpc convention.
 
+    def fq_admin_tune(self, request_json: str = "{}") -> str:
+        """Retune loop knobs in place — bounded, validated, no restart.
+
+        The whole point of re-tiering at runtime is not having to reboot to
+        change the model's posture. Having to reboot to change the THRESHOLD
+        that governs re-tiering was the same problem one level up.
+        """
+        from vllm.model_executor.layers.quantization.exl3_fungible.admin import (  # noqa: E501
+            worker_tune,
+        )
+
+        return worker_tune(self, request_json)
+
     def fq_admin_describe(self, request_json: str = "{}") -> str:
         from vllm.model_executor.layers.quantization.exl3_fungible.admin import (  # noqa: E501
             worker_describe,

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -847,6 +847,21 @@ class Worker(WorkerBase):
 
         return worker_apply(self, plan_json)
 
+    def fq_heatmap_sample(self, request_json: str = "{}") -> str:
+        """One rank's slice of the routing activation matrix.
+
+        Read-only telemetry behind its own env gate (VLLM_FQ_HEATMAP),
+        re-checked inside worker_sample so reaching this method through
+        dev mode's POST /collective_rpc does not bypass the gate. Same
+        laziness contract and JSON-string convention as the fq_admin_*
+        delegates above.
+        """
+        from vllm.model_executor.layers.quantization.exl3_fungible.heatmap import (  # noqa: E501
+            worker_sample,
+        )
+
+        return worker_sample(self, request_json)
+
     @instrument(span_name="Warmup (GPU)")
     def compile_or_warm_up_model(self) -> CompilationTimes:
         warmup_sizes: list[int] = []


### PR DESCRIPTION
## Purpose

Add live, fixed-budget precision re-tiering for rank-sliced EXL3 MoE experts. A running serve can observe router traffic, choose a new per-expert K allocation, fetch the required progressive-tensor fragments, and atomically swap expert rows without rebuilding the checkpoint or reallocating CUDA-graph-visible slabs.

This is runtime control of expert **precision**, not another static mixed-K loader and not EPLB placement.

## Design

The new `vllm/model_executor/layers/quantization/exl3_fungible/` package implements:

1. **Observe** — graph-safe router hit/gate-mass collection into a decaying window.
2. **Decide** — deterministic policy under dwell, hysteresis, layer/total swap caps, and measured byte budgets.
3. **Supply** — signed progressive-tensor fragment resolution from local/cache/HF sources, with explicit lower-K fallback.
4. **Apply** — rank-consistent staged row writes, quiesced map flips, rollback on failure, and atomic policy persistence.

Operator surfaces:

- authenticated admin requests are dispatched through collective RPC so every TP rank validates and applies the same canonical plan;
- strict JSON, entity-count, body-size, string-size, timeout, timestamp, replay, and memory-headroom bounds;
- read-only activation heatmap with a separate credential;
- all behavior is opt-in and dev/admin gated.

The integration also:

- accepts rank-sliced K2/K4 as well as K3/K4 mixed tiers;
- projects unavailable requested K values to the nearest lower available tier rather than killing model load;
- rehydrates the last committed policy on restart using the manifest-scoped cache identity;
- prewarms all mixed-Trellis route-pack shapes before the second memory-profile pass;
- preserves lazy imports so ordinary vLLM startup and non-FQ EXL3 paths remain unchanged.

## Safety invariants

- One immutable policy/manifest identity per serve.
- Every rank derives the same membership and plan digest before mutation.
- Capacity and byte-budget checks happen before staging.
- Device maps flip only inside a quiesce window.
- Any staging/commit failure restores slabs, rotations, maps, policy state, and persisted generation.
- Borrowed loader buffers are copied at the retaining boundary.
- K5 is refused for the current SM120 two-tier ABI because its shared-memory requirement is not serveable; no silent fallback pretends otherwise.

## Validation

Final branch: `14b5c5f5f`, rebased cleanly onto current `dev/gilded-gnosis` (`fa033bd4e`).

Post-rebase CPU verification in the GG v20-r33 runtime:

```text
224 passed, 10 deselected, 14 warnings in 21.29s
4 passed, 14 warnings in 8.04s
```

Coverage includes policy/store rehydration, rank divergence, admin authentication and parser bounds, K2/K4 and K3/K4 dispatch, rollback fault injection, missing-K projection, borrowed-buffer handling, and mixed-route kernel warmup.

Earlier full isolated package run:

```text
493 passed, 10 skipped, 1 warning
```

The skipped cases are GPU-only tests; their corresponding mechanisms were exercised on the target host.

Runtime evidence on 8x RTX PRO 6000 Blackwell, GLM-5.2 TP4, GG v20-r33:

- assembled progressive checkpoint booted and served successfully;
- 208/208 requests succeeded in a 120 s concurrency-8 gate, 219.2 aggregate tok/s;
- live K3/K4 and K2/K4 row swaps changed real device mappings and passed rollback/fidelity checks;
- repeated policy intervals installed 256 experts across 44 layers without worker death or failed intervals;
- paired GSM8K workload-directed allocation scored 30/32 versus 30/32 for the inverse allocation and 31/32 for the random baseline; this does **not** support a quality-improvement claim at this sample size.

Detailed design, failure analyses, and raw-evidence index: https://github.com/malaiwah/vllm-voipmonitor/blob/bc7e92d89/research/fungible-quant/HANDOFF.md

## Deliberately deferred

To conserve the expiring GPU instance, the final rebased commit was not put through another full model boot or a fresh CUDA-graph workload replay. The second random-seed control boot was aborted by the instance's 640 GiB cgroup memory limit while loading four TP workers. The PR therefore claims the already measured eager/live-swap behavior and CPU contracts, not a new graph-mode performance or quality result.

Follow-on research, not merge blockers: long-horizon hot-set stability, router-feedback measurements after re-tiering, and the unrelated pre-existing TP utilization imbalance.

## Footprint

`58 files changed, 27,978 insertions, 24 deletions` across the feature package, integration hooks, tests, and docs. The default path remains off unless the FQ environment gates are enabled.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added progressive loading for mixed-bitrate EXL3 weights without assembling full checkpoints on disk.
  * Added optional fungible-quantization tuning, planning, application, inspection, and activation heatmap APIs.
  * Added support for 2-bit EXL3 tiers and improved mixed-trellis runtime warmup.
  * Added memory-budget checks, policy persistence, routing statistics, decision explanations, and occupancy reporting.
* **Bug Fixes**
  * Improved swap safety with validation, rollback, atomic updates, and unavailable-fragment handling.
  * Restricted administrative methods to authenticated APIs.
* **Tests**
  * Expanded CPU and GPU coverage across loading, swaps, convergence, memory, determinism, and observability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->