### PR TITLE
[II] Zero recycled blocks for heterogeneous attention caches

### DIFF
--- a/tests/v1/core/test_single_type_kv_cache_manager.py
+++ b/tests/v1/core/test_single_type_kv_cache_manager.py
@@ -63,15 +63,28 @@ def get_chunked_local_attention_manager(
     )
 
 
-def test_sliding_window_records_new_blocks_for_zeroing():
-    block_size = 2
-    spec = SlidingWindowSpec(
-        block_size=block_size,
-        num_kv_heads=1,
-        head_size=1,
-        dtype=torch.float32,
-        sliding_window=4,
-    )
+@pytest.mark.parametrize(
+    "spec",
+    [
+        SlidingWindowSpec(
+            block_size=2,
+            num_kv_heads=1,
+            head_size=1,
+            dtype=torch.float32,
+            sliding_window=4,
+        ),
+        SlidingWindowMLASpec(
+            block_size=2,
+            num_kv_heads=1,
+            head_size=1,
+            dtype=torch.float32,
+            sliding_window=4,
+        ),
+    ],
+    ids=["sliding-window", "sliding-window-mla"],
+)
+def test_sliding_window_records_new_blocks_for_zeroing(spec):
+    block_size = spec.block_size
     block_pool = BlockPool(
         num_gpu_blocks=10, enable_caching=False, hash_block_size=block_size
     )

--- a/tests/v1/core/test_single_type_kv_cache_manager.py
+++ b/tests/v1/core/test_single_type_kv_cache_manager.py
@@ -28,7 +28,12 @@ from vllm.v1.kv_cache_interface import (
 pytestmark = pytest.mark.cpu_test
 
 
-def get_sliding_window_manager(sliding_window_spec, block_pool, enable_caching=True):
+def get_sliding_window_manager(
+    sliding_window_spec,
+    block_pool,
+    enable_caching=True,
+    needs_kv_cache_zeroing=False,
+):
     # Tests don't exercise admission gating; pass a large cap that is a no-op.
     return SlidingWindowManager(
         sliding_window_spec,
@@ -36,12 +41,16 @@ def get_sliding_window_manager(sliding_window_spec, block_pool, enable_caching=T
         enable_caching=enable_caching,
         kv_cache_group_id=0,
         scheduler_block_size=sliding_window_spec.block_size,
+        needs_kv_cache_zeroing=needs_kv_cache_zeroing,
         max_admission_blocks_per_request=10**9,
     )
 
 
 def get_chunked_local_attention_manager(
-    chunked_local_attention_spec, block_pool, enable_caching=True
+    chunked_local_attention_spec,
+    block_pool,
+    enable_caching=True,
+    needs_kv_cache_zeroing=False,
 ):
     return ChunkedLocalAttentionManager(
         chunked_local_attention_spec,
@@ -49,8 +58,65 @@ def get_chunked_local_attention_manager(
         enable_caching=enable_caching,
         kv_cache_group_id=0,
         scheduler_block_size=chunked_local_attention_spec.block_size,
+        needs_kv_cache_zeroing=needs_kv_cache_zeroing,
         max_admission_blocks_per_request=10**9,
     )
+
+
+def test_sliding_window_records_new_blocks_for_zeroing():
+    block_size = 2
+    spec = SlidingWindowSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        sliding_window=4,
+    )
+    block_pool = BlockPool(
+        num_gpu_blocks=10, enable_caching=False, hash_block_size=block_size
+    )
+    manager = get_sliding_window_manager(
+        spec,
+        block_pool,
+        enable_caching=False,
+        needs_kv_cache_zeroing=True,
+    )
+
+    blocks = manager.allocate_new_blocks(
+        "request", num_tokens=4, num_tokens_main_model=4
+    )
+
+    assert manager.records_new_block_ids
+    assert manager.take_new_block_ids() == [block.block_id for block in blocks]
+    assert manager.take_new_block_ids() == []
+
+
+def test_chunked_local_attention_records_new_blocks_for_zeroing():
+    block_size = 2
+    spec = ChunkedLocalAttentionSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        attention_chunk_size=4,
+    )
+    block_pool = BlockPool(
+        num_gpu_blocks=10, enable_caching=False, hash_block_size=block_size
+    )
+    manager = get_chunked_local_attention_manager(
+        spec,
+        block_pool,
+        enable_caching=False,
+        needs_kv_cache_zeroing=True,
+    )
+
+    blocks = manager.allocate_new_blocks(
+        "request", num_tokens=4, num_tokens_main_model=4
+    )
+
+    assert manager.records_new_block_ids
+    assert manager.take_new_block_ids() == [block.block_id for block in blocks]
+    assert manager.take_new_block_ids() == []
 
 
 def test_chunked_local_attention_possible_cached_prefix():

--- a/tests/v1/worker/test_kv_block_zeroer.py
+++ b/tests/v1/worker/test_kv_block_zeroer.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import math
 from types import SimpleNamespace
 
 import pytest
@@ -10,6 +11,7 @@ from vllm.v1.kv_cache_interface import (
     ChunkedLocalAttentionSpec,
     SlidingWindowSpec,
 )
+from vllm.v1.worker import utils as worker_utils
 from vllm.v1.worker.utils import (
     AttentionGroup,
     KVBlockZeroer,
@@ -121,10 +123,7 @@ def test_non_uniform_page_sizes():
     seg_page_sizes = [page_size_a, page_size_b]
     max_ps = max(seg_page_sizes)
 
-    def largest_power_of_2_divisor(n):
-        return n & -n
-
-    blk_size = min(min(largest_power_of_2_divisor(ps) for ps in seg_page_sizes), 1024)
+    blk_size = min(1 << (max_ps - 1).bit_length(), 1024)
 
     zeroer._meta = (
         torch.tensor(
@@ -134,7 +133,7 @@ def test_non_uniform_page_sizes():
         ),
         torch.tensor(seg_page_sizes, dtype=torch.int64, device=device),
         torch.tensor(seg_page_sizes, dtype=torch.int64, device=device),
-        max_ps // blk_size,
+        (max_ps + blk_size - 1) // blk_size,
         blk_size,
         2,
     )
@@ -186,12 +185,74 @@ def test_packed_segment_zeros_only_its_last_block_page():
     assert torch.equal(backing, expected)
 
 
+def test_large_dsv4_launch_geometry(monkeypatch):
+    """Keep the failing DSV4 shape efficient and within launch limits."""
+    device = torch.device("cpu")
+    n_blocks, n_segs = 6870, 181
+    layer_names = [f"layer.{i}" for i in range(n_segs)]
+    page_sizes = [9344 if i % 2 == 0 else 292 for i in range(n_segs)]
+    spec = SlidingWindowSpec(
+        block_size=1,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.int32,
+        sliding_window=1,
+    )
+    storages = {
+        name: torch.ones((1, page_size), dtype=torch.int32)
+        for name, page_size in zip(layer_names, page_sizes)
+    }
+    zeroer = KVBlockZeroer(
+        device,
+        attn_groups_iter=[
+            AttentionGroup(
+                _BlockFirstBackend,  # type: ignore[arg-type]
+                [name],
+                spec,
+                group_id,
+            )
+            for group_id, name in enumerate(layer_names)
+        ],
+        kernel_block_sizes=[1] * n_segs,
+        cache_dtype="auto",
+        static_forward_context={
+            name: SimpleNamespace(kv_cache=storage)
+            for name, storage in storages.items()
+        },
+    )
+
+    assert zeroer._meta is not None
+    _, _, seg_page_sizes, max_chunks, blk_size, n_segs = zeroer._meta
+    assert seg_page_sizes.tolist() == page_sizes
+    assert (max_chunks, blk_size, n_segs) == (10, 1024, 181)
+
+    captured_grids = []
+
+    class FakeKernel:
+        def __getitem__(self, grid):
+            captured_grids.append(grid)
+            return lambda *args, **kwargs: None
+
+    monkeypatch.setattr(worker_utils, "_zero_kv_blocks_kernel", FakeKernel())
+    monkeypatch.setattr(
+        worker_utils,
+        "async_tensor_h2d",
+        lambda values, **kwargs: torch.tensor(values, dtype=torch.int64),
+    )
+
+    zeroer.zero_block_ids(list(range(n_blocks)))
+
+    old_max_chunks = max(page_sizes) // 4
+    assert math.prod((n_blocks, n_segs, old_max_chunks)) > 2**31 - 1
+    assert captured_grids == [(n_blocks, n_segs, max_chunks)]
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
-def test_warmup_compiles_every_n_blocks_specialization():
+def test_warmup_compiles_for_all_block_counts():
     """After warmup, no launch should trigger a first-request JIT compile.
 
-    ``n_blocks`` is ``do_not_specialize``, so a single warmup launch must
-    cover every block count.
+    The block count is carried by the launch grid, so changing it must reuse
+    the warmup's compiled kernel.
     """
     device = torch.device("cuda")
     num_blocks = 64

--- a/tests/v1/worker/test_kv_block_zeroer.py
+++ b/tests/v1/worker/test_kv_block_zeroer.py
@@ -1,10 +1,71 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 
-from vllm.v1.worker.utils import KVBlockZeroer, _zero_kv_blocks_kernel
+from vllm.v1.kv_cache_interface import (
+    ChunkedLocalAttentionSpec,
+    SlidingWindowSpec,
+)
+from vllm.v1.worker.utils import (
+    AttentionGroup,
+    KVBlockZeroer,
+    _zero_kv_blocks_kernel,
+)
+
+
+class _BlockFirstBackend:
+    @staticmethod
+    def get_kv_cache_block_dim(*args, **kwargs):
+        return 0
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize(
+    "spec",
+    [
+        SlidingWindowSpec(
+            block_size=2,
+            num_kv_heads=1,
+            head_size=1,
+            dtype=torch.uint8,
+            sliding_window=4,
+        ),
+        ChunkedLocalAttentionSpec(
+            block_size=2,
+            num_kv_heads=1,
+            head_size=1,
+            dtype=torch.uint8,
+            attention_chunk_size=4,
+        ),
+    ],
+    ids=["sliding-window", "chunked-local"],
+)
+def test_attention_blocks_are_zeroed(spec):
+    device = torch.device("cuda")
+    storage = torch.ones((4, 1, 2, 2), dtype=torch.uint8, device=device)
+    layer_name = "draft.self_attn"
+    zeroer = KVBlockZeroer(
+        device,
+        attn_groups_iter=[
+            AttentionGroup(_BlockFirstBackend, [layer_name], spec, 0)  # type: ignore[arg-type]
+        ],
+        kernel_block_sizes=[2],
+        cache_dtype="fp8",
+        static_forward_context={
+            layer_name: SimpleNamespace(kv_cache=storage),
+        },
+    )
+
+    zeroer.zero_block_ids([1])
+    torch.accelerator.synchronize()
+
+    expected = torch.ones_like(storage)
+    expected[1] = 0
+    assert torch.equal(storage, expected)
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")

--- a/tests/v1/worker/test_kv_block_zeroer.py
+++ b/tests/v1/worker/test_kv_block_zeroer.py
@@ -9,6 +9,7 @@ import torch
 
 from vllm.v1.kv_cache_interface import (
     ChunkedLocalAttentionSpec,
+    SlidingWindowMLASpec,
     SlidingWindowSpec,
 )
 from vllm.v1.worker import utils as worker_utils
@@ -36,6 +37,13 @@ class _BlockFirstBackend:
             dtype=torch.uint8,
             sliding_window=4,
         ),
+        SlidingWindowMLASpec(
+            block_size=2,
+            num_kv_heads=1,
+            head_size=1,
+            dtype=torch.uint8,
+            sliding_window=4,
+        ),
         ChunkedLocalAttentionSpec(
             block_size=2,
             num_kv_heads=1,
@@ -44,7 +52,7 @@ class _BlockFirstBackend:
             attention_chunk_size=4,
         ),
     ],
-    ids=["sliding-window", "chunked-local"],
+    ids=["sliding-window", "sliding-window-mla", "chunked-local"],
 )
 def test_attention_blocks_are_zeroed(spec):
     device = torch.device("cuda")

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -16,6 +16,7 @@ from vllm.v1.core.kv_cache_utils import (
     resolve_block_hashes,
 )
 from vllm.v1.kv_cache_interface import (
+    AttentionSpec,
     ChunkedLocalAttentionSpec,
     CrossAttentionSpec,
     FullAttentionSpec,
@@ -92,11 +93,8 @@ class SingleTypeKVCacheManager(ABC):
         self._max_admission_blocks_per_request = max_admission_blocks_per_request
         # Record newly allocated block ids only when worker-side zeroing will
         # consume them and this manager holds a spec type that gets zeroed.
-        self._record_new_block_ids = needs_kv_cache_zeroing and type(kv_cache_spec) in (
-            FullAttentionSpec,
-            TQFullAttentionSpec,
-            MLAAttentionSpec,
-            HiddenStateCacheSpec,
+        self._record_new_block_ids = needs_kv_cache_zeroing and isinstance(
+            kv_cache_spec, AttentionSpec
         )
         self.new_block_ids: list[int] = []
 

--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -17,7 +17,6 @@ from vllm.model_executor.models.interfaces import MultiModalEmbeddings
 from vllm.model_executor.models.utils import extract_layer_index
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
-from vllm.utils.math_utils import largest_power_of_2_divisor
 from vllm.utils.mem_utils import MemorySnapshot, format_gib
 from vllm.utils.torch_utils import async_tensor_h2d
 from vllm.v1.attention.backend import (
@@ -52,15 +51,12 @@ def raise_if_nan_logits(num_nans_in_logits: Mapping[str, int]) -> None:
     raise RuntimeError(f"NaNs detected in logits: {corrupted_requests}")
 
 
-@triton.jit(do_not_specialize=["n_blocks"])
+@triton.jit
 def _zero_kv_blocks_kernel(
     seg_addrs_ptr,
     seg_block_strides_ptr,
     seg_page_sizes_ptr,
     block_ids_ptr,
-    n_blocks,
-    N_SEGS: tl.constexpr,
-    MAX_CHUNKS: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
 ):
     """Zero KV cache blocks across all segments in a single launch.
@@ -78,29 +74,27 @@ def _zero_kv_blocks_kernel(
     seg_addrs_ptr holds absolute byte addresses (int64) for each segment,
     allowing segments to live in different CUDA allocations.
 
-    Programs are mapped as (block_index, seg_index, chunk_index).
+    Programs are mapped directly onto a 3-D grid as
+    (block_index, seg_index, chunk_index).
     """
-    pid = tl.program_id(0)
-    work_per_block = N_SEGS * MAX_CHUNKS
-    block_index = pid // work_per_block
-    if block_index >= n_blocks:
-        return
-    remainder = pid % work_per_block
-    seg_index = remainder // MAX_CHUNKS
-    chunk_index = remainder % MAX_CHUNKS
+    block_index = tl.program_id(0)
+    seg_index = tl.program_id(1)
+    chunk_index = tl.program_id(2)
     block_stride_el = tl.load(seg_block_strides_ptr + seg_index)
     page_size_el = tl.load(seg_page_sizes_ptr + seg_index)
-    if chunk_index >= page_size_el // BLOCK_SIZE:
+    chunk_offset = chunk_index.to(tl.int64) * BLOCK_SIZE
+    if chunk_offset >= page_size_el:
         return
     block_id = tl.load(block_ids_ptr + block_index)
     seg_addr = tl.load(seg_addrs_ptr + seg_index)
     ptr = tl.cast(seg_addr, tl.pointer_type(tl.int32))
-    offset = (
-        block_id.to(tl.int64) * block_stride_el.to(tl.int64)
-        + chunk_index.to(tl.int64) * BLOCK_SIZE
+    block_offset = block_id.to(tl.int64) * block_stride_el.to(tl.int64)
+    cols = chunk_offset + tl.arange(0, BLOCK_SIZE).to(tl.int64)
+    tl.store(
+        ptr + block_offset + cols,
+        tl.zeros([BLOCK_SIZE], dtype=tl.int32),
+        mask=cols < page_size_el,
     )
-    cols = tl.arange(0, BLOCK_SIZE).to(tl.int64)
-    tl.store(ptr + offset + cols, tl.zeros([BLOCK_SIZE], dtype=tl.int32))
 
 
 class KVBlockZeroer:
@@ -204,15 +198,12 @@ class KVBlockZeroer:
             return
 
         max_page_size_el = max(seg_page_sizes)
-        blk_size = min(
-            min(largest_power_of_2_divisor(ps) for ps in seg_page_sizes),
-            1024,
-        )
+        blk_size = min(1 << (max_page_size_el - 1).bit_length(), 1024)
         self._meta = (
             torch.tensor(seg_addrs, dtype=torch.uint64, device=self.device),
             torch.tensor(seg_block_strides, dtype=torch.int64, device=self.device),
             torch.tensor(seg_page_sizes, dtype=torch.int64, device=self.device),
-            max_page_size_el // blk_size,
+            (max_page_size_el + blk_size - 1) // blk_size,
             blk_size,
             len(seg_addrs),
         )
@@ -231,15 +222,12 @@ class KVBlockZeroer:
         ) = self._meta
         n_blocks = len(block_ids)
         idx = async_tensor_h2d(block_ids, device=self.device, dtype=torch.int64)
-        grid = (n_blocks * n_segs * max_chunks,)
+        grid = (n_blocks, n_segs, max_chunks)
         _zero_kv_blocks_kernel[grid](
             seg_addrs,
             seg_block_strides,
             seg_page_sizes,
             idx,
-            n_blocks,
-            N_SEGS=n_segs,
-            MAX_CHUNKS=max_chunks,
             BLOCK_SIZE=blk_size,
         )
 

--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -29,7 +29,6 @@ from vllm.v1.core.kv_cache_utils import KVCacheBlockCopy
 from vllm.v1.kv_cache_interface import (
     AttentionSpec,
     EncoderOnlyAttentionSpec,
-    FullAttentionSpec,
     KVCacheConfig,
     KVCacheGroupSpec,
     KVCacheSpec,
@@ -147,7 +146,7 @@ class KVBlockZeroer:
 
         for group in attn_groups_iter:
             spec = group.kv_cache_spec
-            if not isinstance(spec, FullAttentionSpec):
+            if not isinstance(spec, AttentionSpec):
                 continue
             if group.kv_cache_group_id >= len(kernel_block_sizes):
                 continue


### PR DESCRIPTION
## Resulting behavior

- KV-cache managers record newly allocated block IDs for every `AttentionSpec` when a heterogeneous cache configuration requires block zeroing.
- The GPU zeroer handles block-first and block-second tensors for every attention specification instead of restricting execution to `FullAttentionSpec`.
- CUDA launch geometry is bounded as `(blocks, tensors, chunks)` so models with many heterogeneous cache tensors do not create a flat Cartesian launch.
- Regression coverage includes `SlidingWindowMLASpec`, which is the compressor-cache specification used by DeepSeek-V4-Flash DSpark.

## Technical reason

DeepSeek-V4-Flash DSpark combines an FP8 target MLA cache with an FP32 sliding-window compressor cache. This mixed-precision cache configuration sets `KVCacheConfig.needs_kv_cache_zeroing`, but the scheduler recorded recycled block IDs only for a fixed list of manager types and the worker zeroed only `FullAttentionSpec` tensors. Recycled compressor blocks could therefore retain data from a previous request.

Generalizing the zeroer also requires bounded launch geometry. The DeepSeek-V4-Flash configuration exposes 181 heterogeneous cache tensors; flattening the block-by-tensor-by-element product would create an impractically large launch. The three-dimensional launch processes each tensor in masked 1,024-element chunks.

The implementation ports upstream vLLM changes from [#51749](https://github.com/vllm-project/vllm/pull/51749) and [#52058](https://github.com/vllm-project/vllm/pull/52058), with an additional DSpark compressor regression case.

## Compatibility

The change affects only cache groups whose specification requires block zeroing. Attention math, cache layout, and allocation capacity are unchanged. Existing full-attention behavior remains covered by the same zeroing path.

## Validation

- Scheduler regression: the unmodified Infernal Invocation source failed all three sliding-window/chunked-local recording cases; the patched source passes them.
- GPU regression: the unmodified source failed all three generalized zeroing cases; the patched source passes nine CUDA cases, including DeepSeek-V4-Flash launch geometry.
- Focused source suites: 13 CPU tests and 9 CUDA tests passed on `dev/infernal-invocation` at `ad848fc414`.
- Static checks: Ruff check, Ruff format, and `git diff --check` passed.
- Runtime qualification: TP2/DCP1 DeepSeek-V4-Flash with fixed probabilistic DSpark K5 completed concurrent 150k/300k-token requests, two forced 4,096-token decode runs, and two approximately 506k-token prefills. The server remained healthy and the response-integrity checks reported no cross-request markers, raw token IDs, replacement characters, or malformed text.

The reported intermittent long-horizon output corruption was not reproduced in finite A/B runs on the qualification host. This PR fixes the independently demonstrated KV block lifecycle violation; it does not claim that every possible source of long-running model repetition or malformed output has been excluded.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved KV-cache zeroing across supported attention layouts and cache configurations.
  * Ensured newly allocated cache blocks are tracked reliably, including during concurrent operations.
  * Added safer handling for partial final chunks, varied page sizes, and large workloads.
  * Improved cache reuse and warmup behavior across different block counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->