### PR TITLE
[II] Defer MLA DCP workspace allocation until CUDA materialization

### DIFF
--- a/tests/distributed/test_dcp_direct_a2a_lse_reduce.py
+++ b/tests/distributed/test_dcp_direct_a2a_lse_reduce.py
@@ -390,6 +390,50 @@ def test_mla_dcp_manager_selects_direct_backends(monkeypatch):
     )
 
 
+def test_mla_dcp_manager_materializes_direct_backends_after_meta_init(monkeypatch):
+    import vllm.v1.attention.ops.dcp_utils as dcp_manager
+
+    group = MagicMock(world_size=2)
+    monkeypatch.setattr(dcp_manager, "get_dcp_group", lambda: group)
+    direct_a2a = MagicMock()
+    direct_query = MagicMock()
+    init_a2a = MagicMock(return_value=direct_a2a)
+    init_query = MagicMock(return_value=direct_query)
+    monkeypatch.setattr(dcp_manager, "get_direct_dcp_a2a_workspace", init_a2a)
+    monkeypatch.setattr(
+        dcp_manager,
+        "get_direct_dcp_q_gather_workspace",
+        init_query,
+    )
+
+    manager = dcp_manager.MLADCPManager(
+        vllm_config=_manager_config(),
+        device=torch.device("meta"),
+        num_heads=2,
+        query_head_dim=8,
+        output_head_dim=4,
+        query_dtype=torch.bfloat16,
+        output_dtype=torch.bfloat16,
+        padded_num_heads=None,
+        is_lse_base_on_e=False,
+        use_pcp=False,
+    )
+
+    init_a2a.assert_not_called()
+    init_query.assert_not_called()
+    assert isinstance(manager.combine, functools.partial)
+    assert manager.combine.func is dcp_manager.dcp_a2a_lse_reduce
+    assert manager.query_gather == manager._gather_query
+
+    manager.materialize(torch.device("cuda", 0))
+
+    init_a2a.assert_called_once()
+    init_query.assert_called_once()
+    assert manager.device == torch.device("cuda", 0)
+    assert manager.combine.func == direct_a2a.lse_reduce
+    assert manager.query_gather == direct_query.gather
+
+
 def test_mla_dcp_manager_selects_fallback_backends(monkeypatch):
     import vllm.v1.attention.ops.dcp_utils as dcp_manager
 

--- a/tests/v1/attention/test_mla_backends.py
+++ b/tests/v1/attention/test_mla_backends.py
@@ -89,6 +89,8 @@ def test_mla_post_load_preallocates_quantized_absorbed_weights(monkeypatch):
     layer.kv_cache_dtype = "auto"
     layer.quant_config = None
     layer.layer_name = "test"
+    materialized_devices = []
+    layer.dcp_manager = SimpleNamespace(materialize=materialized_devices.append)
     dequantized = torch.arange(28.0, dtype=torch.float32).reshape(14, 2)
     events = []
     preallocated = []
@@ -124,6 +126,7 @@ def test_mla_post_load_preallocates_quantized_absorbed_weights(monkeypatch):
     assert layer.W_UK_T.data_ptr() == preallocated[1].data_ptr()
     assert layer.W_UV.device == layer.kv_b_proj.qweight.device
     assert layer.W_UK_T.device == layer.kv_b_proj.qweight.device
+    assert materialized_devices == [layer.kv_b_proj.qweight.device]
 
 
 @pytest.mark.cpu_test

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -2047,6 +2047,15 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             set_default_quant_scales(self, register_buffer=False)
 
     def process_weights_after_loading(self, act_dtype: torch.dtype):
+        dcp_manager = getattr(self, "dcp_manager", None)
+        if dcp_manager is not None:
+            dcp_device = _find_linear_weight_device(self.kv_b_proj)
+            if dcp_device is None:
+                raise RuntimeError(
+                    "Cannot determine the device for MLA DCP collective workspaces."
+                )
+            dcp_manager.materialize(dcp_device)
+
         self._use_b12x_absorb_bmm = self._prepare_b12x_absorb_bmm(act_dtype)
         self._fused_mla_query_output_dtype = (
             current_platform.fp8_dtype()

--- a/vllm/v1/attention/ops/dcp_utils.py
+++ b/vllm/v1/attention/ops/dcp_utils.py
@@ -614,23 +614,55 @@ class MLADCPManager:
         self.max_num_tokens = get_dcp_workspace_max_num_tokens(vllm_config)
         self.use_a2a = parallel_config.dcp_comm_backend == "a2a"
         self.padded_num_heads = padded_num_heads
-
-        self.combine = self._init_combine(
+        self._combine_args = (
             num_heads,
             output_head_dim,
             output_dtype,
             is_lse_base_on_e,
             use_pcp,
         )
+        self._query_gather_args = (
+            num_heads,
+            query_head_dim,
+            query_dtype,
+        )
+        self._use_pcp = use_pcp
+        self._configure_collectives(allow_direct=self.device.type != "meta")
+
+    def _configure_collectives(self, *, allow_direct: bool) -> None:
+        self.combine = self._init_combine(
+            *self._combine_args,
+            allow_direct=allow_direct,
+        )
         self.query_gather = (
             None
-            if use_pcp
+            if self._use_pcp
             else self._init_query_gather(
-                num_heads,
-                query_head_dim,
-                query_dtype,
+                *self._query_gather_args,
+                allow_direct=allow_direct,
             )
         )
+
+    def materialize(self, device: torch.device) -> None:
+        """Allocate direct collective workspaces after weights reach a device.
+
+        InstantTensor constructs model layers on the meta device. Symmetric
+        memory requires a physical CUDA device, so direct workspaces must be
+        selected only after model loading has materialized the layer weights.
+        """
+        device = torch.device(device)
+        if device.type == "meta":
+            return
+        if self.device.type != "meta":
+            if self.device != device:
+                raise RuntimeError(
+                    "MLA DCP collectives are already materialized on "
+                    f"{self.device}, but the layer weights are on {device}."
+                )
+            return
+
+        self.device = device
+        self._configure_collectives(allow_direct=True)
 
     def _init_combine(
         self,
@@ -639,9 +671,11 @@ class MLADCPManager:
         dtype: torch.dtype,
         is_lse_base_on_e: bool,
         use_pcp: bool,
+        *,
+        allow_direct: bool = True,
     ) -> DCPCombine:
         direct_workspace = None
-        if self.use_a2a:
+        if self.use_a2a and allow_direct:
             direct_workspace = get_direct_dcp_a2a_workspace(
                 self.group,
                 self.device,
@@ -676,16 +710,22 @@ class MLADCPManager:
         num_heads: int,
         head_dim: int,
         dtype: torch.dtype,
+        *,
+        allow_direct: bool = True,
     ) -> Callable[[torch.Tensor], torch.Tensor]:
-        direct_workspace = get_direct_dcp_q_gather_workspace(
-            self.group,
-            self.device,
-            self.max_num_tokens,
-            num_heads,
-            head_dim,
-            dtype,
-            self.num_ubatches,
-            self.padded_num_heads,
+        direct_workspace = (
+            get_direct_dcp_q_gather_workspace(
+                self.group,
+                self.device,
+                self.max_num_tokens,
+                num_heads,
+                head_dim,
+                dtype,
+                self.num_ubatches,
+                self.padded_num_heads,
+            )
+            if allow_direct
+            else None
         )
         if direct_workspace is not None:
             logger.info_once("Using direct symmetric-memory DCP query gather for MLA.")


### PR DESCRIPTION
## Resulting behavior

- `MLADCPManager` can be constructed while model parameters use the PyTorch `meta` device.
- Direct symmetric-memory workspaces are allocated after `kv_b_proj` weights reach their CUDA device.
- Repeated materialization on the same CUDA device is idempotent.
- Materialization on a different device is rejected to prevent a stale workspace/device contract.
- CUDA construction, collective selection, tensor layouts, and attention arithmetic are unchanged.

## Technical reason

InstantTensor and other deferred model loaders construct MLA modules before CUDA storage exists. Direct DCP all-to-all initialization requests CUDA symmetric memory, which cannot be allocated for a `meta` tensor. The attention layer establishes its fallback collective contract during construction and materializes direct workspaces from the loaded projection weight device in `process_weights_after_loading`.

## Compatibility

The change does not add an environment variable or alter model output semantics. Models constructed directly on CUDA retain eager workspace allocation. Configurations that do not qualify for direct symmetric-memory collectives retain the existing fallback path.

## Validation

- `tests/distributed/test_dcp_direct_a2a_lse_reduce.py`: 4 focused tests passed.
- `tests/v1/attention/test_mla_backends.py`: the MLA post-load materialization test passed.
- Ruff check and format validation passed.
- Exact integration image `voipmonitor/vllm:infernal-invocation-vllmdc2934e-b12xd48c62b-fi1ac6942-cu133-torch213-20260814-r12`, GLM-5.2 EXL3, TP4/DCP4/MTP3, and four direct-attached SM120 GPUs:
  - model initialization selected direct symmetric-memory DCP all-to-all;
  - full and piecewise CUDA graph capture completed;
  - prefill and decode returned a correct response.
- Same-host MTP0 comparison at 8,192 prompt tokens:
  - DCP1: 3,235 prefill tok/s;
  - DCP4: 3,062 prefill tok/s, or 94.7% of DCP1.

The throughput comparison is scoped to one direct-attached four-GPU host and is not used as a regression comparison against switched systems.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quantized MLA weight loading to materialize workspaces on the correct device.
  * Fixed deferred initialization for distributed attention operations when starting on a meta device.
  * Ensured direct distributed backends activate correctly after materialization on a physical device.
* **Tests**
  * Added coverage for deferred workspace initialization and device transitions.
  * Updated weight-loading tests to verify correct device placement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->