### PR TITLE
[EXL3] keep online-overlay shards BF16 when neither Trellis nor MXFP8 can represent them

### DIFF
--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -74,6 +74,9 @@ from vllm.model_executor.layers.quantization.online.mxfp8 import (
     Mxfp8OnlineLinearMethod,
     is_shared_expert_projection,
 )
+from vllm.model_executor.layers.quantization.utils.mxfp8_utils import (
+    MXFP8_BLOCK_SIZE,
+)
 from vllm.model_executor.layers.quantization.utils.quant_utils import kMxfp8Dynamic
 from vllm.model_executor.parameter import BasevLLMParameter
 from vllm.model_executor.utils import replace_parameter
@@ -1714,7 +1717,7 @@ class Exl3OnlineLinearMethod(_Fp8OnlineLinearBase):
         self.prefix = prefix
         self.model_identity = model_identity
         self.encoder_identity = encoder_identity
-        self.fallback: Mxfp8OnlineLinearMethod | None = None
+        self.fallback: QuantizeMethodBase | None = None
 
     def create_weights(
         self,
@@ -1731,7 +1734,28 @@ class Exl3OnlineLinearMethod(_Fp8OnlineLinearBase):
             input_size_per_partition, output_size_per_partition
         )
         if not layer.exl3_online_trellis:
-            self.fallback = Mxfp8OnlineLinearMethod()
+            # Trellis needs 128-aligned K and N; MXFP8 needs K divisible by 32.
+            # A shard that satisfies neither (e.g. the Qwen3.5/3.6/3.8 vision
+            # tower, K=1152 N=4304) has no online representation at all, so keep
+            # it unquantized instead of raising out of MXFP8 create_weights.
+            if input_size_per_partition % MXFP8_BLOCK_SIZE == 0:
+                self.fallback = Mxfp8OnlineLinearMethod()
+                logger.info_once(
+                    "EXL3 online Trellis retains MXFP8 for 128-unaligned shards "
+                    "(example %s: K=%d, N=%d).",
+                    self.prefix,
+                    input_size_per_partition,
+                    output_size_per_partition,
+                )
+            else:
+                self.fallback = UnquantizedLinearMethod()
+                logger.warning_once(
+                    "EXL3 online overlay keeps %s unquantized: K=%d is neither "
+                    "128-aligned for Trellis nor divisible by %d for MXFP8.",
+                    self.prefix,
+                    input_size_per_partition,
+                    MXFP8_BLOCK_SIZE,
+                )
             self.fallback.create_weights(
                 layer,
                 input_size_per_partition,
@@ -1740,13 +1764,6 @@ class Exl3OnlineLinearMethod(_Fp8OnlineLinearBase):
                 output_size,
                 params_dtype,
                 **extra_weight_attrs,
-            )
-            logger.info_once(
-                "EXL3 online Trellis retains MXFP8 for 128-unaligned shards "
-                "(example %s: K=%d, N=%d).",
-                self.prefix,
-                input_size_per_partition,
-                output_size_per_partition,
             )
             return
 


### PR DESCRIPTION
Fixes the startup abort reported in #311.

### Problem

`Exl3OnlineLinearMethod.create_weights` installs `Mxfp8OnlineLinearMethod` as an *unconditional* fallback for shards that fail `_online_trellis_shape_supported` (K and N both 128-aligned). But `Mxfp8OnlineLinearMethod.create_weights` itself raises for `input_size_per_partition % 32 != 0`, so a shard that satisfies neither constraint kills engine startup instead of degrading.

Reachable with a stock upstream model: the `Qwen3_5ForConditionalGeneration` vision tower has `visual.blocks.N.mlp.linear_fc2` with **K=4304**, which is neither 128-aligned nor 32-divisible.

```
ValueError: MXFP8 requires input_size_per_partition (4304) to be divisible by 32.
RuntimeError: Engine core initialization failed.
```

### Change

Three-way branch instead of two: Trellis if the shape supports it, MXFP8 if MXFP8 can represent it, otherwise **keep the weight unquantized** (it is already BF16 on disk) and warn. `process_weights_after_loading` and `apply` already delegate to `self.fallback` unconditionally, so `UnquantizedLinearMethod` needs no additional plumbing; only the `self.fallback` annotation widens to `QuantizeMethodBase | None`.

The existing MXFP8 `info_once` message is preserved verbatim for the shapes that still take that path.

### Verification

On 1x RTX PRO 6000 Blackwell (SM120, 96 GB), driver 595.58.03, TP1, inside the r34 image (`voipmonitor/vllm@sha256:820181fb...df20592b`, vLLM `0.11.2.dev280+gilded.gnosis.v20...r34`), whose `exl3.py` and `online/mxfp8.py` are byte-identical to this branch. Model: a dense EXL3 quant of `Qwen/Qwen3.8-27B` (MLP K4 in `tensor_storage`, attention BF16 for the b6 overlay, vision tower BF16), `VLLM_EXL3_ONLINE_TRELLIS_BITS=6`.

**Before** (same command, unpatched): `ValueError: MXFP8 requires input_size_per_partition (4304) to be divisible by 32` during `create_weights`, engine core init fails.

**After**, with an `ignore` list that deliberately leaves only the unrepresentable shards claimed:

```
WARNING [exl3.py:1752] EXL3 online overlay keeps visual.blocks.20.mlp.linear_fc2 unquantized:
        K=4304 is neither 128-aligned for Trellis nor divisible by 32 for MXFP8.
... (27 blocks) ...
INFO:     Application startup complete.
```

and the model answers a multimodal request correctly through that path — a 96x96 PNG, left half pure red, right half pure blue, prompt "Name the left colour then the right colour, comma separated." returns `red, blue`.

Text generation and the K6 overlay for attention are unaffected: the same checkpoint with a correct `ignore` list serves at 17.89 GiB resident weights and measures mean KLD 0.034030 against a BF16 teacher (2047 full-vocabulary positions, 3 repeats, run SD 0).

### Related finding, not addressed here

With shapes that *are* 32-divisible but not 128-aligned (e.g. `visual.blocks.N.attn.qkv`, K=1152, and the fused GDN `linear_attn.in_proj_ba`, K=5120 N=96), the MXFP8 fallback in this image fails later with:

```
AttributeError: module 'vllm.utils.flashinfer' has no attribute 'mm_mxfp8'
```

So in the r34 build the documented "128-unaligned matrices retain the configured MXFP8 path" is not actually functional for the linear overlay. That is a separate defect (kernel availability, not shape logic) and I have left it alone rather than widen this PR; happy to follow up with a probe-and-degrade patch if you would prefer the overlay to fall back to BF16 whenever the MXFP8 kernel is unavailable.

### Operator note worth documenting separately

The overlay's `ignore` regexes are matched against prefixes with **no** leading `model.` (e.g. `visual.blocks.0.mlp.linear_fc1`), so the natural-looking `re:.*\.visual\..*` never matches while `re:.*visual\..*` does. Packed modules are expanded before matching, which is why `re:.*in_proj_a$` + `re:.*in_proj_b$` correctly excludes the fused `in_proj_ba`. Both behaviours are useful and non-obvious.
