### PR TITLE
[Qwen3.5] pass quant_config to VocabParallelEmbedding so the embedding table can be quantized

### DIFF
--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -243,6 +243,13 @@ class Qwen3_5Model(Qwen3NextModel):
         self.embed_tokens = VocabParallelEmbedding(
             self.vocab_size,
             config.hidden_size,
+            # Hand the quantization config to the embedding so a backend can narrow the
+            # table. It is 2.543 GB of BF16 on this model - second only to the MLP stack -
+            # and on a 32 GB card it is the difference between 196,608 and native 262,144
+            # context. Backends that do not implement embedding() are unaffected: the layer
+            # falls back to UnquantizedEmbeddingMethod when get_quant_method returns None.
+            quant_config=self.quant_config,
+            prefix=f"{prefix}.embed_tokens" if prefix else "embed_tokens",
         )
 
         def get_layer(prefix: str):

--- a/vllm/model_executor/models/qwen3_5_mtp.py
+++ b/vllm/model_executor/models/qwen3_5_mtp.py
@@ -83,6 +83,12 @@ class Qwen3_5MultiTokenPredictor(nn.Module):
         self.embed_tokens = VocabParallelEmbedding(
             self.vocab_size,
             config.hidden_size,
+            # The draft head builds a second full embedding table - another 2.543 GB of BF16
+            # on this model, which is why enabling MTP costs far more resident memory than
+            # the draft weights themselves. Same rationale as the target model: hand over the
+            # quantization config so a backend can narrow it.
+            quant_config=vllm_config.quant_config,
+            prefix=f"{prefix}.embed_tokens" if prefix else "mtp.embed_tokens",
         )
 
         # Workaround: mtp.fc is stored as BF16 in NVFP4 checkpoints but is

--- a/vllm/model_executor/models/qwen3_5_mtp.py
+++ b/vllm/model_executor/models/qwen3_5_mtp.py
@@ -83,10 +83,9 @@ class Qwen3_5MultiTokenPredictor(nn.Module):
         self.embed_tokens = VocabParallelEmbedding(
             self.vocab_size,
             config.hidden_size,
-            # The draft head builds a second full embedding table - another 2.543 GB of BF16
-            # on this model, which is why enabling MTP costs far more resident memory than
-            # the draft weights themselves. Same rationale as the target model: hand over the
-            # quantization config so a backend can narrow it.
+            # The draft table is materialized during model construction, then aliased to the
+            # target embedding after loading. Pass the quantization config so embedding-aware
+            # backends also handle this transient construction consistently.
             quant_config=vllm_config.quant_config,
             prefix=f"{prefix}.embed_tokens" if prefix else "mtp.embed_tokens",
         )


### PR DESCRIPTION
`VocabParallelEmbedding` already supports quantization: it calls
`quant_config.get_quant_method(self, prefix)` and refuses a method that does not implement
`embedding()`. Both Qwen3.5 model files construct it without passing the config:

```python
self.embed_tokens = VocabParallelEmbedding(self.vocab_size, config.hidden_size)
```

so the hook can never fire and the table stays BF16 no matter what the backend supports.

## Why it matters

On Qwen3.8-27B the input embedding table is **248,320 x 5,120 = 2.543 GB resident** - second
only to the MLP stack, larger than the whole attention stack after quantization, and the only
large tensor in the model that is never multiplied (it is a gather).

With an int8 overlay behind it (EXL3 side, #318) the effect on a 32 GB card is:

| | BF16 embeddings | int8 embeddings |
|---|---:|---:|
| resident weights | 19.31 GiB | **18.13 GiB** |
| max `--max-model-len` that starts | 229,376 | **262,144 (native)** |
| KV allocated | 240,080 tokens | **279,007 tokens** |
| mean KLD, 136 held-out contexts | 0.009673 | 0.009738 (+0.000065, CI [+4.6e-06, +1.3e-04]) |
| multimodal, 30 synthetic cases | 24/30 | 24/30, identical |

Verified by use rather than allocation: exact needle retrieval at depths 0.1/0.5/0.9 from
**227,334-token prompts** on a 5090-sized budget with vision enabled.

## Why the MTP file still needs this change

`Qwen3_5MultiTokenPredictor` materializes an embedding table while its weights load, so it must
pass the quant config for the same hook to be reachable. The current vLLM proposer then aliases
that table to the target model embedding (`llm_base_proposer.py` logs "Sharing target model
embedding weights with the draft model"). It is therefore **not a second resident table**, and
quantizing it separately cannot increase steady-state KV capacity or change draft acceptance.
This patch lowers transient load memory and keeps standalone MTP construction consistent; the
native-context MTP gap is elsewhere.

## Compatibility

Backends that do not implement `embedding()` are unaffected: `get_quant_method` returns `None`
and the layer falls back to `UnquantizedEmbeddingMethod`, which is today's behaviour.
