### PR TITLE
[Bugfix] [Infernal] Stream Kimi K3 XTML tool-call arguments incrementally

### DIFF
--- a/tests/tool_use/test_kimi_k3_tool_parser.py
+++ b/tests/tool_use/test_kimi_k3_tool_parser.py
@@ -361,9 +361,62 @@ def test_streaming_split_markers_do_not_leak():
     assert content == "Hi"
     assert OPEN not in content
     assert SEP not in content
-    assert len(tool_deltas) == 1
-    assert tool_deltas[0].function.name == "calc"
-    assert json.loads(tool_deltas[0].function.arguments) == {"x": 1}
+    assert [tool_call.function.name for tool_call in tool_deltas if tool_call.id] == [
+        "calc"
+    ]
+    arguments = "".join(tool_call.function.arguments or "" for tool_call in tool_deltas)
+    assert json.loads(arguments) == {"x": 1}
+
+
+def test_streaming_emits_string_argument_before_call_closes():
+    """String arguments must produce deltas before the closing XTML marker."""
+    parser = KimiK3ToolParser(DummyTokenizer())
+    request = _request()
+    value = "word " * 200
+    body_chunks = [value[i : i + 5] for i in range(0, len(value), 5)]
+    chunks = [
+        f"{OPEN}tools{SEP}",
+        f'{OPEN}call tool="write_file" index="1"{SEP}',
+        f'{OPEN}argument key="content" type="string"{SEP}',
+        *body_chunks,
+        f"{CLOSE}argument{SEP}",
+        f"{CLOSE}call{SEP}",
+    ]
+    previous_text = ""
+    previous_ids: list[int] = []
+    messages: list[DeltaMessage] = []
+
+    for i, chunk in enumerate(chunks, start=1):
+        current_text = previous_text + chunk
+        current_ids = previous_ids + [i]
+        delta = parser.extract_tool_calls_streaming(
+            previous_text=previous_text,
+            current_text=current_text,
+            delta_text=chunk,
+            previous_token_ids=previous_ids,
+            current_token_ids=current_ids,
+            delta_token_ids=[i],
+            request=request,
+        )
+        if delta is not None:
+            messages.append(delta)
+        previous_text = current_text
+        previous_ids = current_ids
+
+    tool_deltas = [
+        tool_call for message in messages for tool_call in (message.tool_calls or [])
+    ]
+
+    assert [tool_call.function.name for tool_call in tool_deltas if tool_call.id] == [
+        "write_file"
+    ]
+    assert len(tool_deltas) >= len(body_chunks)
+    assert all(tool_call.index == 0 for tool_call in tool_deltas)
+
+    arguments = "".join(tool_call.function.arguments or "" for tool_call in tool_deltas)
+    assert json.loads(arguments) == {"content": value}
+    non_streamed = parser.extract_tool_calls(previous_text, request)
+    assert arguments == non_streamed.tool_calls[0].function.arguments
 
 
 def test_tool_call_ids_are_unique_across_messages():

--- a/vllm/tool_parsers/kimi_k3_tool_parser.py
+++ b/vllm/tool_parsers/kimi_k3_tool_parser.py
@@ -37,6 +37,7 @@ from collections.abc import Sequence
 import regex as re
 from openai.types.responses import ToolChoiceFunction
 
+from vllm.entrypoints.chat_utils import make_tool_call_id
 from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionNamedToolChoiceParam,
     ChatCompletionRequest,
@@ -86,6 +87,7 @@ class KimiK3ToolParser(ToolParser):
         self.tools_close = "<|close|>tools<|sep|>"
         self.response_open = "<|open|>response<|sep|>"
         self.response_close = "<|close|>response<|sep|>"
+        self.argument_close = "<|close|>argument<|sep|>"
 
         # Regexes operate on detokenized text. The XTML markers reach us as the
         # literal strings <|open|>/<|close|>/<|sep|>. adjust_request keeps them
@@ -127,6 +129,13 @@ class KimiK3ToolParser(ToolParser):
             + _S,
             re.DOTALL,
         )
+        self._call_open_re = re.compile(
+            _O + r"\s*call\s+(?P<attrs>" + _TEXT_UNTIL_SEP + r")" + _S
+        )
+        self._call_close_re = re.compile(_C + r"\s*call\s*" + _S)
+        self._arg_open_re = re.compile(
+            _O + r"\s*argument\s+(?P<attrs>" + _TEXT_UNTIL_SEP + r")" + _S
+        )
         # attr segment: key="value" (value already escaped on the encode side)
         self._attr_re = re.compile(r'(?P<k>\w+)="(?P<v>[^"]*)"')
         self._response_re = re.compile(
@@ -136,7 +145,7 @@ class KimiK3ToolParser(ToolParser):
 
         # streaming state
         self._sent_content_idx = 0
-        self._sent_tool_call_count = 0
+        self._streamed_args: list[str] = []
 
         if not self.model_tokenizer:
             raise ValueError(
@@ -218,6 +227,17 @@ class KimiK3ToolParser(ToolParser):
         """
         call_attrs = self._attrs(attrs)
         tool_name = call_attrs.get("tool", "")
+        if not tool_name:
+            return None
+        return ToolCall(
+            type="function",
+            function=FunctionCall(
+                name=tool_name,
+                arguments=json.dumps(self._decode_arguments(body), ensure_ascii=False),
+            ),
+        )
+
+    def _decode_arguments(self, body: str) -> dict:
         arguments: dict = {}
         for arg_match in self._arg_re.finditer(body):
             arg_attrs = self._attrs(arg_match["attrs"])
@@ -231,15 +251,31 @@ class KimiK3ToolParser(ToolParser):
                     arguments[key] = json.loads(raw_value)
                 except json.JSONDecodeError:
                     arguments[key] = raw_value
-        if not tool_name:
-            return None
-        return ToolCall(
-            type="function",
-            function=FunctionCall(
-                name=tool_name,
-                arguments=json.dumps(arguments, ensure_ascii=False),
-            ),
-        )
+        return arguments
+
+    def _partial_arguments(self, body: str) -> str:
+        """Serialize arguments whose enclosing ``call`` block remains open.
+
+        The returned text is a prefix of the completed call's JSON arguments.
+        String values can therefore stream as generated. Other argument types
+        remain buffered until their complete JSON literal is available.
+        """
+        closed_end = 0
+        for arg_match in self._arg_re.finditer(body):
+            closed_end = arg_match.end()
+        arguments = self._decode_arguments(body[:closed_end])
+
+        m_open = self._arg_open_re.search(body, closed_end)
+        if m_open is None:
+            return json.dumps(arguments, ensure_ascii=False)[:-1]
+
+        arg_attrs = self._attrs(m_open["attrs"])
+        if arg_attrs.get("type", "string") != "string":
+            return json.dumps(arguments, ensure_ascii=False)[:-1]
+        raw_value = body[m_open.end() :]
+        held = _partial_tag_overlap(raw_value, self.argument_close)
+        arguments[arg_attrs.get("key", "")] = raw_value[: len(raw_value) - held]
+        return json.dumps(arguments, ensure_ascii=False)[:-2]
 
     def _strip_response_content(self, text: str) -> str | None:
         """Strip XTML response/message markers from generated response text.
@@ -274,8 +310,9 @@ class KimiK3ToolParser(ToolParser):
         #   <|open|> / response / <|sep|>Hi     -> emit only "Hi" after open closes
         #   Hi<|open|> / tools / <|sep|>...     -> emit "Hi", hold the tools marker
         #   Hi<|close|> / response / <|sep|>... -> emit "Hi", hold the close marker
-        # Tool calls are even simpler: they are not emitted until a full
-        # <|close|>call<|sep|> is present in current_text.
+        # Tool-call names are emitted once their call-open marker is complete.
+        # String arguments then stream as JSON-prefix deltas while closing XTML
+        # marker fragments remain buffered.
         m_open = self._response_open_re.search(current_text)
         # In the normal chat path, the response-open marker may be consumed as
         # the generation prefix. Then generated text starts directly with the
@@ -361,35 +398,54 @@ class KimiK3ToolParser(ToolParser):
         delta_token_ids: Sequence[int],
         request: ChatCompletionRequest,
     ) -> DeltaMessage | None:
-        # Conservative streaming: stream unwrapped response-channel text, then
-        # buffer tool calls and emit each call once its block closes.
         content = self._extract_response_content(current_text)
 
-        # tools channel is open: parse fully-closed calls we have not emitted yet
         m_tools = self._tools_open_re.search(current_text)
         if m_tools is None:
             return DeltaMessage(content=content) if content else None
 
         section = current_text[m_tools.end() :]
-        calls = [
-            tc
-            for m in self._call_re.finditer(section)
-            if (tc := self._decode_call(m["attrs"], m["body"])) is not None
-        ]
-        if len(calls) <= self._sent_tool_call_count:
-            return DeltaMessage(content=content) if content else None
-        new = calls[self._sent_tool_call_count :]
+        opens = list(self._call_open_re.finditer(section))
+        deltas: list[DeltaToolCall] = []
+        index = 0
+        for i, m_open in enumerate(opens):
+            end = opens[i + 1].start() if i + 1 < len(opens) else len(section)
+            body = section[m_open.end() : end]
+            name = self._attrs(m_open["attrs"]).get("tool", "")
+            if not name:
+                continue
+            m_close = self._call_close_re.search(body)
+            if m_close is None:
+                arguments = self._partial_arguments(body)
+            else:
+                arguments = json.dumps(
+                    self._decode_arguments(body[: m_close.start()]), ensure_ascii=False
+                )
 
-        deltas = [
-            DeltaToolCall(
-                index=self._sent_tool_call_count + i,
-                id=tc.id,
-                type="function",
-                function=DeltaFunctionCall(
-                    name=tc.function.name, arguments=tc.function.arguments
-                ).model_dump(exclude_none=True),
-            )
-            for i, tc in enumerate(new)
-        ]
-        self._sent_tool_call_count = len(calls)
+            if index == len(self._streamed_args):
+                self._streamed_args.append(arguments)
+                deltas.append(
+                    DeltaToolCall(
+                        index=index,
+                        id=make_tool_call_id(),
+                        type="function",
+                        function=DeltaFunctionCall(name=name, arguments=arguments),
+                    )
+                )
+            else:
+                sent = self._streamed_args[index]
+                if arguments != sent and arguments.startswith(sent):
+                    self._streamed_args[index] = arguments
+                    deltas.append(
+                        DeltaToolCall(
+                            index=index,
+                            function=DeltaFunctionCall(
+                                arguments=arguments[len(sent) :]
+                            ),
+                        )
+                    )
+            index += 1
+
+        if not deltas:
+            return DeltaMessage(content=content) if content else None
         return DeltaMessage(content=content, tool_calls=deltas)


### PR DESCRIPTION
## Summary

- Stream Kimi K3 XTML string arguments as OpenAI tool-call deltas while a call is still being generated.
- Emit each function name, generated call ID, and tool-call type once, then emit only unseen argument suffixes.
- Preserve buffered extraction and non-string argument decoding behavior.

This is a branch-local backport for `dev/infernal-invocation`. Equivalent mainline work is tracked by vllm-project/vllm#50604 and vllm-project/vllm#50627; that pull request targets `main` and is not present in this base branch.

## Root Cause

`KimiK3ToolParser.extract_tool_calls_streaming` discovered calls through `_call_re`, which requires the complete `<|close|>call<|sep|>` marker. A long string argument therefore produced no tool-call SSE traffic until the whole call closed, after which the parser emitted the complete JSON document in one delta. Clients and protocol gateways could remain silent for the full generation and reach stream-idle timeouts even though token generation was progressing.

## Changes

- Detect a call from its complete call-open marker rather than waiting for call-close.
- Serialize the unclosed argument object as a stable prefix of the final JSON document.
- Forward raw string content incrementally while withholding partial XTML closing markers.
- Keep non-string JSON literals buffered until their argument blocks are complete and unambiguous.
- Track the serialized prefix per tool-call index and emit only the unseen suffix.
- Add a regression test that requires argument deltas before the call-close marker and verifies that concatenated deltas match buffered extraction.

## Testing

- `pytest tests/tool_use/test_kimi_k3_tool_parser.py -q`: **27 passed** in the built vLLM image.
- Repository pre-commit hooks passed for both modified files.
- Live Kimi K3 direct OpenAI SSE qualification reconstructed an exact 512-character argument from **74 argument deltas**.
- Live downstream gateway qualification reconstructed an exact 128-character argument from **26 argument deltas** after protocol conversion.
- The qualified container artifact is `docker.io/g0san94/kimi-k3-qsrt-lmcache@sha256:e9d83225b334eaf9f05bafdcf4341a1d6cab51900d0feb5df931e25e2e2fa403`.

Model-quality evaluations were not run because this change does not alter token generation, sampling, logits, or the buffered tool-call result. The live model checks validate parser timing and byte-exact argument reconstruction.

## Compatibility / Rollback

- Non-streaming extraction is unchanged.
- Concatenated streaming argument deltas remain byte-equivalent to the buffered JSON result.
- Partial XTML markers are withheld rather than exposed as argument content.
- Non-string values retain conservative complete-block decoding.
- Multiple calls retain stable OpenAI tool-call indexes.

Rollback is a revert of commit `9d852296d6a12e1c580108868eef7bc07ec6476e`; clients then return to one buffered argument delta after call-close.

## Duplicate-Work Check

- vllm-project/vllm#50627 implements the equivalent Python frontend fix for `main`.
- No equivalent pull request exists against `local-inference-lab/vllm:dev/infernal-invocation`.
- This proposal is limited to making the behavior available and qualified on the independently deployed infernal branch; it is not a competing mainline proposal.

## AI Assistance

Hermes Agent assisted with implementation, regression-test construction, debugging, and deployment qualification. The human submitter directed the scope, authorized the deployment and submission, and remains responsible for reviewing and maintaining the change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved streaming tool-call handling for Kimi K3 responses.
  * Tool names and long string arguments can now appear incrementally as calls stream.
  * Streaming output preserves tool-call metadata and reconstructs arguments consistently with non-streaming results.

* **Bug Fixes**
  * Fixed incomplete or delayed argument emission during streamed tool calls.
  * Improved handling of JSON decoding while arguments are still being received.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->