### PR TITLE
[II] Bound MLA prefill projection workspace

### DIFF
--- a/tests/distributed/test_dcp_direct_a2a_lse_reduce.py
+++ b/tests/distributed/test_dcp_direct_a2a_lse_reduce.py
@@ -499,6 +499,35 @@ def test_dcp_chunk_workspace_alignment_covers_interleave():
     assert align_mla_chunked_context_workspace_size(config, 100) == 192
 
 
+def test_mla_chunk_workspace_honors_configured_token_limit(monkeypatch):
+    from vllm.model_executor.layers.attention.mla_attention import (
+        MLACommonMetadataBuilder,
+    )
+
+    config = MagicMock()
+    config.model_config.max_model_len = 1_048_576
+    config.scheduler_config.max_num_seqs = 8
+    config.cache_config.block_size = 32
+    config.parallel_config.decode_context_parallel_size = 16
+    config.parallel_config.cp_kv_cache_interleave_size = 1
+
+    monkeypatch.setenv("VLLM_MLA_CHUNKED_PREFILL_WORKSPACE_SIZE", "4096")
+    assert (
+        MLACommonMetadataBuilder.determine_chunked_prefill_workspace_size(config)
+        == 4096
+    )
+
+    monkeypatch.setenv("VLLM_MLA_CHUNKED_PREFILL_WORKSPACE_SIZE", "0")
+    assert (
+        MLACommonMetadataBuilder.determine_chunked_prefill_workspace_size(config)
+        == 64 * 1024
+    )
+
+    monkeypatch.setenv("VLLM_MLA_CHUNKED_PREFILL_WORKSPACE_SIZE", "-1")
+    with pytest.raises(ValueError, match="must be non-negative"):
+        MLACommonMetadataBuilder.determine_chunked_prefill_workspace_size(config)
+
+
 def test_sparse_mla_builder_initializes_dcp_manager(monkeypatch):
     import vllm.model_executor.layers.attention.sparse_mla_attention as sparse_mla
 

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -64,6 +64,7 @@ if TYPE_CHECKING:
     VLLM_NVFP4_MLA_SCALES_FILE: str = ""
     VLLM_B12X_ABSORB_BMM: bool = False
     VLLM_DSPARK_FP8_DRAFT_HEAD: bool = False
+    VLLM_MLA_CHUNKED_PREFILL_WORKSPACE_SIZE: int = 0
     VLLM_USE_B12X_WO_PROJECTION: bool = False
     VLLM_USE_B12X_MOE: bool = False
     VLLM_NF3_GRID188_DECODE: bool = True
@@ -1137,6 +1138,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # retain target-model semantics. Requires fp8 tensor cores (SM89+).
     "VLLM_DSPARK_FP8_DRAFT_HEAD": lambda: bool(
         int(os.getenv("VLLM_DSPARK_FP8_DRAFT_HEAD", "0"))
+    ),
+    # Bound the number of context tokens expanded into dense MLA K/V tensors
+    # per attention call. Zero selects the automatic memory bound.
+    "VLLM_MLA_CHUNKED_PREFILL_WORKSPACE_SIZE": lambda: int(
+        os.getenv("VLLM_MLA_CHUNKED_PREFILL_WORKSPACE_SIZE", "0")
     ),
     # Use b12x for the DeepSeek V4 WO-A/WO-B fused projection.
     # This is separate from the generic FP8 linear switch for perf isolation.

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -3035,22 +3035,25 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
         cache_config = vllm_config.cache_config
         model_config = vllm_config.model_config
 
-        chunked_prefill_workspace_size = min(
-            # Try for 8 full length request or at least 4 pages per-request
-            max(
-                8 * model_config.max_model_len,
-                4 * scheduler_config.max_num_seqs * cache_config.block_size,
-            ),
-            # For long-context models try not to over-allocate limiting
-            # kv-cache space, limiting it to 64k tokens,
-            # which would result in the workspace being:
-            #   2*(576)*(64*1024) = 144mb
-            # (assuming 576 MLA head dim, and fp16)
-            # which would result in up-projected context being
-            #   2*(192*128)*(64*1024) = 3gb
-            # (assuming 192 QK head dim, 128 heads, and fp16)
-            64 * 1024,
-        )
+        configured_workspace_size = envs.VLLM_MLA_CHUNKED_PREFILL_WORKSPACE_SIZE
+        if configured_workspace_size < 0:
+            raise ValueError(
+                "VLLM_MLA_CHUNKED_PREFILL_WORKSPACE_SIZE must be non-negative, "
+                f"got {configured_workspace_size}."
+            )
+        if configured_workspace_size:
+            chunked_prefill_workspace_size = configured_workspace_size
+        else:
+            chunked_prefill_workspace_size = min(
+                # Try for 8 full-length requests or at least 4 pages per request.
+                max(
+                    8 * model_config.max_model_len,
+                    4 * scheduler_config.max_num_seqs * cache_config.block_size,
+                ),
+                # Bound persistent compressed-KV storage and transient dense K/V
+                # projections for long-context models.
+                64 * 1024,
+            )
 
         return align_mla_chunked_context_workspace_size(
             vllm_config,


### PR DESCRIPTION
## Behavior

Adds `VLLM_MLA_CHUNKED_PREFILL_WORKSPACE_SIZE`, an optional token limit for the dense K/V projection workspace used by MLA chunked-context prefill.

- A positive value selects the requested token capacity before cache-block and DCP alignment.
- `0` preserves the automatic limit, including its 64K-token upper bound.
- A negative value fails configuration with a specific error.
- Cache-block alignment, DCP interleave alignment, and the minimum capacity required by `max_num_seqs` remain authoritative.

Status: implemented and qualified.

## Technical reason

The automatic 64K-token capacity can reserve multi-gigabyte transient dense projection buffers for models with large MLA dimensions. Long-context deployments may need that memory for physical KV cache while using a smaller scheduler prefill chunk. An explicit token limit makes the memory tradeoff controllable without changing the automatic policy for existing deployments.

## Compatibility

The change is independent of model architecture, attention backend, and tensor-parallel size. Existing deployments retain identical behavior unless the environment variable is set.

The environment variable limits workspace capacity; it does not change the scheduler's `max_num_batched_tokens`. Operators must select a capacity that can hold the intended prefill chunk after alignment.

## Validation

Validation used `voipmonitor/vllm:kimi-k3-qsrt-ii-vllm735952b-b12x180ccab-cu133-torch213-20260815-r3` with PyTorch 2.13 and CUDA 13.3:

- `tests/distributed/test_dcp_direct_a2a_lse_reduce.py`: 20 passed, 4 hardware-dependent skipped.
- The focused test covers an explicit 4,096-token limit, unchanged automatic selection at `0`, and rejection of a negative limit.
- Ruff, formatter verification, Python compilation, and `git diff --check` pass.

## Review scope

This pull request replaces only the bounded-MLA-workspace responsibility contained in #317. It does not include Kimi-K3 model integration, DCP collectives, InstantTensor handling, DSpark, DFlash, launch scripts, or B12X kernel bindings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an environment setting to configure workspace size for chunked MLA prefill.
  * Positive values are honored directly, while the default setting retains automatic sizing capped at 64 KiB.

* **Bug Fixes**
  * Invalid negative workspace sizes now produce a clear error.

* **Tests**
  * Added coverage for configured sizes, default behavior, and invalid values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->