### PR TITLE
[Spec] Optionally requantise the draft model's lm_head to FP8

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -76,6 +76,7 @@ if TYPE_CHECKING:
     VLLM_DCP_A2A_MAX_TOKENS: int = 0
     VLLM_DCP_A2A_LARGE_BACKEND: Literal["ag_rs", "a2a"] = "ag_rs"
     VLLM_DCP_SHARD_DRAFT: str | None = None
+    VLLM_DRAFT_LM_HEAD_FP8: bool = False
     VLLM_DCP_REPLICATE_INDEXER_CACHE: bool = False
     VLLM_DCP_INDEXER_SHARDS: int = 0
     VLLM_DCP_GLOBAL_TOPK: bool = True
@@ -1183,6 +1184,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # target indexer cache and native MTP drafts, replicated for external
     # (Eagle-style) drafts.
     "VLLM_DCP_SHARD_DRAFT": lambda: os.getenv("VLLM_DCP_SHARD_DRAFT", None),
+    # Requantise the DRAFT model's lm_head to FP8. Draft tokens are proposals the target
+    # verifies, so this can cost acceptance, never correctness. On an MTP drafter the head
+    # is read once per speculative step.
+    "VLLM_DRAFT_LM_HEAD_FP8": lambda: bool(int(os.getenv("VLLM_DRAFT_LM_HEAD_FP8", "0"))),
     # Replicate the target model's sparse-indexer K cache on every DCP rank.
     "VLLM_DCP_REPLICATE_INDEXER_CACHE": lambda: (
         os.getenv("VLLM_DCP_REPLICATE_INDEXER_CACHE", "0").lower()

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -1185,9 +1185,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # (Eagle-style) drafts.
     "VLLM_DCP_SHARD_DRAFT": lambda: os.getenv("VLLM_DCP_SHARD_DRAFT", None),
     # Requantise the DRAFT model's lm_head to FP8. Draft tokens are proposals the target
-    # verifies, so this can cost acceptance, never correctness. On an MTP drafter the head
-    # is read once per speculative step.
-    "VLLM_DRAFT_LM_HEAD_FP8": lambda: bool(int(os.getenv("VLLM_DRAFT_LM_HEAD_FP8", "0"))),
+    # verifies, so this can cost acceptance, never correctness. On an MTP drafter
+    # the head is read once per speculative step.
+    "VLLM_DRAFT_LM_HEAD_FP8": lambda: bool(
+        int(os.getenv("VLLM_DRAFT_LM_HEAD_FP8", "0"))
+    ),
     # Replicate the target model's sparse-indexer K cache on every DCP rank.
     "VLLM_DCP_REPLICATE_INDEXER_CACHE": lambda: (
         os.getenv("VLLM_DCP_REPLICATE_INDEXER_CACHE", "0").lower()

--- a/vllm/v1/spec_decode/draft_head_fp8.py
+++ b/vllm/v1/spec_decode/draft_head_fp8.py
@@ -64,14 +64,25 @@ class Fp8DraftHeadMethod:
 ROWS_PER_CHUNK = 4096
 
 
+def _fp8_supported() -> bool:
+    """FP8 GEMM support. Kept narrow on purpose: ROCm needs the FNUZ dtype and a
+    different scale layout, which this path does not implement."""
+    from vllm.platforms import current_platform
+
+    if not current_platform.is_cuda():
+        return False
+    major, minor = current_platform.get_device_capability()
+    return major * 10 + minor >= 89
+
+
 def _quantize_rowwise(wd: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
     """Row-scaled FP8 copy of ``wd``, built in chunks.
 
     Per-output-row rather than per-tensor: a few high-magnitude vocabulary rows would
     otherwise set one global scale and crush every other token's logit resolution.
 
-    Chunked because promoting a 454 MB head to fp32 whole allocates ~908 MB and the clamp
-    another -- unaffordable on unified memory. Caps the transient at ~100 MB.
+    Chunked because promoting a 454 MB head to fp32 whole allocates ~908 MB and
+    the clamp another. Caps the transient at ~100 MB.
     """
     out = torch.empty_like(wd, dtype=FP8_DTYPE)
     scale = torch.empty(wd.shape[0], 1, dtype=torch.float32, device=wd.device)
@@ -85,20 +96,34 @@ def _quantize_rowwise(wd: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
     return out, scale
 
 
-def quantize_draft_lm_head_fp8(model: torch.nn.Module) -> int:
-    """Swap every ParallelLMHead in ``model`` to FP8. Returns bytes freed."""
+def quantize_draft_lm_head_fp8(model: torch.nn.Module) -> tuple[int, int]:
+    """Swap every ParallelLMHead in ``model`` to FP8.
+
+    Returns ``(bytes_freed, bytes_per_read_saved)``. They differ: a tied or otherwise
+    still-referenced head keeps its bf16 copy (frees nothing) but the matmul still reads
+    less, so traffic is saved either way.
+    """
     from vllm.model_executor.layers.vocab_parallel_embedding import ParallelLMHead
 
-    # Tied embeddings share one storage between lm_head and embed_tokens. Quantising stays
-    # safe (separate FP8 tensor, only the matmul swaps) but freeing the bf16 copy would
-    # delete the input embedding. Detect by storage, not by tie_word_embeddings, so a model
-    # that ties without advertising it is still handled.
+    if not _fp8_supported():
+        logger.warning(
+            "VLLM_DRAFT_LM_HEAD_FP8 requested but this device has no FP8 GEMM support; "
+            "leaving the draft head in its original dtype."
+        )
+        return 0, 0
+
+    # remove_duplicate=False is REQUIRED: the default deduplicates, so a tied weight is
+    # yielded once and every head would look untied.
     shared: dict[int, int] = {}
-    for p in model.parameters():
+    for _, p in model.named_parameters(remove_duplicate=False):
         if p is not None and p.device.type != "meta":
             shared[p.data_ptr()] = shared.get(p.data_ptr(), 0) + 1
 
-    freed = 0
+    # Some draft models read lm_head.weight after loading (gemma4_mtp's
+    # _get_full_lm_head_weight); freeing it there would break them.
+    has_weight_reader = hasattr(model, "_get_full_lm_head_weight")
+
+    freed = saved_per_read = 0
     for name, mod in model.named_modules():
         if not isinstance(mod, ParallelLMHead):
             continue
@@ -109,28 +134,26 @@ def quantize_draft_lm_head_fp8(model: torch.nn.Module) -> int:
         wd = w.data
         w_fp8, scale = _quantize_rowwise(wd)
         before = wd.numel() * wd.element_size()
-        after = w_fp8.numel() * w_fp8.element_size() + scale.numel() * scale.element_size()
+        after = (w_fp8.numel() * w_fp8.element_size()
+                 + scale.numel() * scale.element_size())
         mod.quant_method = Fp8DraftHeadMethod(w_fp8, scale)
+        saved_per_read += before - after
 
-        tied = shared.get(wd.data_ptr(), 1) > 1
-        if tied:
-            # Keep bf16: the input embedding still needs it. The traffic saving comes from
-            # the matmul, not from freeing, so it still applies.
+        keep = shared.get(wd.data_ptr(), 1) > 1 or has_weight_reader
+        if keep:
+            # Tied to the input embedding, or read elsewhere after load. The traffic
+            # saving comes from the matmul, so it still applies.
             logger.info(
-                "Draft lm_head %s is tied: using FP8 for the matmul, keeping the bf16 copy "
-                "(%.0f MB not freed)", name, before / 2**20
+                "Draft lm_head %s: FP8 matmul, keeping the bf16 copy (%.0f MB)",
+                name, before / 2**20,
             )
         else:
-            # Freeing makes this net-negative on memory. A later read of `.weight` now fails
-            # loudly rather than silently falling back to bf16 and faking the speedup.
+            # A later read of `.weight` now fails loudly rather than silently falling
+            # back to bf16 and faking the speedup.
             mod.register_parameter("weight", None)
             freed += before - after
         del wd, w
-        logger.info(
-            "Draft lm_head %s requantised to FP8: %.0f MB -> %.0f MB",
-            name, before / 2**20, after / 2**20,
-        )
 
     if freed:
         torch.cuda.empty_cache()
-    return freed
+    return freed, saved_per_read

--- a/vllm/v1/spec_decode/draft_head_fp8.py
+++ b/vllm/v1/spec_decode/draft_head_fp8.py
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Requantise a draft model's lm_head to FP8.
+
+Draft tokens are proposals the target verifies or replaces, so the served distribution
+depends on the target alone: this can cost acceptance, never correctness.
+
+Worth doing because an MTP head is read once per speculative step -- at k=3 a
+154,880 x 6,144 bf16 head is 1.4 GB/rank/step at TP=4, a large share of a memory-bound
+decode step. Draft model only; the target's head is untouched.
+"""
+
+import torch
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+FP8_DTYPE = torch.float8_e4m3fn
+FP8_MAX = 448.0
+
+
+class Fp8DraftHeadMethod:
+    """Drop-in ``quant_method`` replacement: only the matmul changes.
+
+    Swapped in after loading, so the checkpoint path, vocab-parallel sharding and the TP
+    gather are untouched.
+    """
+
+    def __init__(self, weight_fp8: torch.Tensor, weight_scale: torch.Tensor):
+        from vllm import _custom_ops as ops
+
+        self.weight_fp8 = weight_fp8                              # [vocab_rank, hidden]
+        # [1, N] to broadcast against cutlass_scaled_mm's [K, N] operand; bound once
+        # rather than reshaped/imported per drafter step.
+        self.weight_scale = weight_scale.reshape(1, -1).contiguous()
+        self._scaled_mm = ops.cutlass_scaled_mm
+
+    def apply(self, layer, x: torch.Tensor, bias: torch.Tensor | None = None):
+        if x.dtype not in (torch.bfloat16, torch.float16):
+            raise ValueError(
+                f"FP8 draft head needs bf16/fp16 hidden states, got {x.dtype}."
+            )
+        flat = x.reshape(-1, x.shape[-1])
+        # Per-token scale; decode drafts a handful of rows, so this is far cheaper than
+        # the weight read it enables.
+        x_amax = flat.abs().amax(dim=-1, keepdim=True).clamp(min=1e-6)
+        x_scale = (x_amax / FP8_MAX).to(torch.float32)
+        x_fp8 = (flat / x_scale).clamp(-FP8_MAX, FP8_MAX).to(FP8_DTYPE)
+
+        # cutlass_scaled_mm, not torch._scaled_mm: runs at M=1, where _scaled_mm's
+        # alignment requirements are version-dependent.
+        out = self._scaled_mm(
+            x_fp8,
+            self.weight_fp8.t(),
+            scale_a=x_scale,
+            scale_b=self.weight_scale,
+            out_dtype=x.dtype,
+            bias=bias,
+        )
+        return out.reshape(*x.shape[:-1], out.shape[-1])
+
+
+ROWS_PER_CHUNK = 4096
+
+
+def _quantize_rowwise(wd: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Row-scaled FP8 copy of ``wd``, built in chunks.
+
+    Per-output-row rather than per-tensor: a few high-magnitude vocabulary rows would
+    otherwise set one global scale and crush every other token's logit resolution.
+
+    Chunked because promoting a 454 MB head to fp32 whole allocates ~908 MB and the clamp
+    another -- unaffordable on unified memory. Caps the transient at ~100 MB.
+    """
+    out = torch.empty_like(wd, dtype=FP8_DTYPE)
+    scale = torch.empty(wd.shape[0], 1, dtype=torch.float32, device=wd.device)
+    for lo in range(0, wd.shape[0], ROWS_PER_CHUNK):
+        hi = min(lo + ROWS_PER_CHUNK, wd.shape[0])
+        block = wd[lo:hi].to(torch.float32)
+        s = (block.abs().amax(dim=1, keepdim=True) / FP8_MAX).clamp(min=1e-12)
+        out[lo:hi] = (block / s).clamp(-FP8_MAX, FP8_MAX).to(FP8_DTYPE)
+        scale[lo:hi] = s
+        del block, s
+    return out, scale
+
+
+def quantize_draft_lm_head_fp8(model: torch.nn.Module) -> int:
+    """Swap every ParallelLMHead in ``model`` to FP8. Returns bytes freed."""
+    from vllm.model_executor.layers.vocab_parallel_embedding import ParallelLMHead
+
+    # Tied embeddings share one storage between lm_head and embed_tokens. Quantising stays
+    # safe (separate FP8 tensor, only the matmul swaps) but freeing the bf16 copy would
+    # delete the input embedding. Detect by storage, not by tie_word_embeddings, so a model
+    # that ties without advertising it is still handled.
+    shared: dict[int, int] = {}
+    for p in model.parameters():
+        if p is not None and p.device.type != "meta":
+            shared[p.data_ptr()] = shared.get(p.data_ptr(), 0) + 1
+
+    freed = 0
+    for name, mod in model.named_modules():
+        if not isinstance(mod, ParallelLMHead):
+            continue
+        w = getattr(mod, "weight", None)
+        if w is None or w.dtype not in (torch.bfloat16, torch.float16):
+            continue
+
+        wd = w.data
+        w_fp8, scale = _quantize_rowwise(wd)
+        before = wd.numel() * wd.element_size()
+        after = w_fp8.numel() * w_fp8.element_size() + scale.numel() * scale.element_size()
+        mod.quant_method = Fp8DraftHeadMethod(w_fp8, scale)
+
+        tied = shared.get(wd.data_ptr(), 1) > 1
+        if tied:
+            # Keep bf16: the input embedding still needs it. The traffic saving comes from
+            # the matmul, not from freeing, so it still applies.
+            logger.info(
+                "Draft lm_head %s is tied: using FP8 for the matmul, keeping the bf16 copy "
+                "(%.0f MB not freed)", name, before / 2**20
+            )
+        else:
+            # Freeing makes this net-negative on memory. A later read of `.weight` now fails
+            # loudly rather than silently falling back to bf16 and faking the speedup.
+            mod.register_parameter("weight", None)
+            freed += before - after
+        del wd, w
+        logger.info(
+            "Draft lm_head %s requantised to FP8: %.0f MB -> %.0f MB",
+            name, before / 2**20, after / 2**20,
+        )
+
+    if freed:
+        torch.cuda.empty_cache()
+    return freed

--- a/vllm/v1/worker/gpu/spec_decode/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/speculator.py
@@ -10,6 +10,7 @@ import torch.nn as nn
 from vllm.config import VllmConfig, get_layers_from_vllm_config
 from vllm.config.compilation import CUDAGraphMode
 from vllm.distributed.eplb.eplb_state import EplbState
+from vllm import envs
 from vllm.logger import init_logger
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.v1.kv_cache_interface import KVCacheConfig
@@ -187,6 +188,19 @@ class DraftModelSpeculator(BaseSpeculator):
 
         self.model = self.load_draft_model(target_model, target_attn_layer_names)
         self._validate_local_argmax_reduction()
+
+        if envs.VLLM_DRAFT_LM_HEAD_FP8:
+            # Draft model only, after loading; the target's head is never reached from here.
+            from vllm.v1.spec_decode.draft_head_fp8 import quantize_draft_lm_head_fp8
+
+            freed = quantize_draft_lm_head_fp8(self.model)
+            logger.info(
+                "VLLM_DRAFT_LM_HEAD_FP8: freed %.0f MB/rank and removed %.0f MB/rank "
+                "of weight traffic per decode step (%d speculative steps)",
+                freed / 2**20,
+                freed * self.num_speculative_steps / 2**20,
+                self.num_speculative_steps,
+            )
 
         all_attn_layers = set[str](
             get_layers_from_vllm_config(

--- a/vllm/v1/worker/gpu/spec_decode/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/speculator.py
@@ -190,15 +190,15 @@ class DraftModelSpeculator(BaseSpeculator):
         self._validate_local_argmax_reduction()
 
         if envs.VLLM_DRAFT_LM_HEAD_FP8:
-            # Draft model only, after loading; the target's head is never reached from here.
+            # Draft model only, after loading; the target's head is not reached.
             from vllm.v1.spec_decode.draft_head_fp8 import quantize_draft_lm_head_fp8
 
-            freed = quantize_draft_lm_head_fp8(self.model)
+            freed, per_read = quantize_draft_lm_head_fp8(self.model)
             logger.info(
-                "VLLM_DRAFT_LM_HEAD_FP8: freed %.0f MB/rank and removed %.0f MB/rank "
-                "of weight traffic per decode step (%d speculative steps)",
+                "VLLM_DRAFT_LM_HEAD_FP8: freed %.0f MB/rank, removed %.0f MB/rank of "
+                "weight traffic per decode step (%d speculative steps)",
                 freed / 2**20,
-                freed * self.num_speculative_steps / 2**20,
+                per_read * self.num_speculative_steps / 2**20,
                 self.num_speculative_steps,
             )
 


### PR DESCRIPTION
Opt-in (`VLLM_DRAFT_LM_HEAD_FP8=1`, default off) FP8 requantisation of the **draft** model's `lm_head`.

### Why this is a speed knob, not a quality one

Draft tokens are proposals: each is either accepted by the target's rejection test or replaced by a token from the target's distribution. The served distribution depends on the target alone, so degrading the drafter costs **acceptance**, never correctness.

### Why the drafter's `lm_head`

Easy to miss because an MTP drafter is "just one layer" — but the head is read **once per speculative step**. At `num_speculative_tokens=3`, a 154,880 × 6,144 bf16 head is 1.4 GB/rank/step at TP=4, a large share of the bytes a memory-bound decode step streams.

### Measured

GLM-5.2 Int4-Int8Mix, TP=4 + DCP=4, MTP k=3, sm121. Four kept runs per arm, arms identical apart from the flag:

| | TPOT | acceptance | step |
|---|---|---|---|
| off | 40.86 ms | 2.918 | 119.15 ms |
| on | 38.46 ms | 3.015 | 115.98 ms |

Step time is the part attributable to this change alone: 680 MB/rank/step removed at a measured 216 GB/s = **2.70% predicted vs 2.66% measured**. Acceptance did not regress.

### Notes

- Swaps the head's `quant_method` after loading — checkpoint path, vocab-parallel sharding and the TP gather are untouched.
- Per-output-row scales; a few high-magnitude rows would otherwise set one global scale.
- **Tied embeddings handled**: where `lm_head` shares storage with `embed_tokens` the FP8 matmul is used but the bf16 copy is *not* freed, since freeing it would delete the input embedding. Detected via `data_ptr()`, not `tie_word_embeddings`. Where the head is a private copy (e.g. `glm4_moe_mtp`) the bf16 copy is dropped and this frees ~227 MB/rank.
- Quantisation chunked at 4096 rows; promoting a 454 MB head to fp32 whole would spike ~2 GB. Bit-identical.
- `cutlass_scaled_mm` rather than `torch._scaled_mm`, which runs at M=1 here where its alignment requirements are version-dependent.

155 additive lines, default off.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional setting to enable FP8 quantization for draft-model language-model heads.
  * Reduced draft-model memory usage and weight-transfer overhead when the setting is enabled.
  * Supports common half-precision inputs while preserving model output compatibility.
* **Configuration**
  * The new optimization is disabled by default and can be enabled through the environment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->