### PR TITLE
[II] Bind B12X TP pools to CUDA graph owners

### DIFF
--- a/tests/distributed/test_dcp_a2a.py
+++ b/tests/distributed/test_dcp_a2a.py
@@ -749,23 +749,25 @@ def test_profile_channel_checkpoint_rolls_back_all_b12x_transports(monkeypatch):
             events.append(("rollback-tp", checkpoint))
 
     class _FakeGroup:
-        def __init__(self, *, world_size, communicator=None):
+        def __init__(self, name, *, world_size, communicator=None):
+            self.name = name
             self.world_size = world_size
+            self.device_group = object()
             self.device_communicator = type(
                 "DeviceCommunicator", (), {"ca_comm": communicator}
             )()
 
     communicator = _FakeCommunicator()
-    tp_group = _FakeGroup(world_size=8, communicator=communicator)
-    pp_group = _FakeGroup(world_size=1, communicator=communicator)
-    dcp_group = _FakeGroup(world_size=2)
+    tp_group = _FakeGroup("tp", world_size=8, communicator=communicator)
+    pp_group = _FakeGroup("pp", world_size=1, communicator=communicator)
+    dcp_group = _FakeGroup("dcp", world_size=2)
     monkeypatch.setattr(parallel_state, "_TP", tp_group)
     monkeypatch.setattr(parallel_state, "_PP", pp_group)
     monkeypatch.setattr(parallel_state, "_DCP", dcp_group)
 
     def checkpoint_dcp(group):
-        events.append("checkpoint-dcp")
-        return "dcp-checkpoint"
+        events.append(("checkpoint-pool", group.name))
+        return f"{group.name}-pool-checkpoint"
 
     monkeypatch.setattr(
         dcp_alltoall,
@@ -783,13 +785,46 @@ def test_profile_channel_checkpoint_rolls_back_all_b12x_transports(monkeypatch):
 
     assert events == [
         "checkpoint-tp",
-        "checkpoint-dcp",
-        ("rollback-dcp", "dcp-checkpoint"),
+        ("checkpoint-pool", "tp"),
+        ("checkpoint-pool", "dcp"),
+        ("rollback-dcp", "dcp-pool-checkpoint"),
+        ("rollback-dcp", "tp-pool-checkpoint"),
         ("rollback-tp", "tp-checkpoint"),
     ]
 
 
-def test_global_graph_capture_enters_b12x_dcp_pool(monkeypatch):
+def test_profile_channel_checkpoint_deduplicates_shared_b12x_pool(monkeypatch):
+    from vllm.distributed import parallel_state
+    from vllm.v1.attention.ops import dcp_alltoall
+
+    class _FakeGroup:
+        def __init__(self, name, *, world_size, device_group):
+            self.name = name
+            self.world_size = world_size
+            self.device_group = device_group
+            self.device_communicator = type(
+                "DeviceCommunicator", (), {"ca_comm": None}
+            )()
+
+    events: list[str] = []
+    shared_device_group = object()
+    tp_group = _FakeGroup("tp", world_size=16, device_group=shared_device_group)
+    dcp_group = _FakeGroup("dcp", world_size=16, device_group=shared_device_group)
+    monkeypatch.setattr(parallel_state, "_TP", tp_group)
+    monkeypatch.setattr(parallel_state, "_PP", None)
+    monkeypatch.setattr(parallel_state, "_DCP", dcp_group)
+    monkeypatch.setattr(
+        dcp_alltoall,
+        "checkpoint_b12x_dcp_a2a_channels",
+        lambda group: events.append(group.name) or group.name,
+    )
+
+    parallel_state.checkpoint_b12x_graph_channels()
+
+    assert events == ["tp"]
+
+
+def test_global_graph_capture_enters_b12x_tp_and_dcp_pools(monkeypatch):
     from vllm.distributed import parallel_state
     from vllm.v1.attention.ops import dcp_alltoall
 
@@ -800,6 +835,7 @@ def test_global_graph_capture_enters_b12x_dcp_pool(monkeypatch):
 
         def __init__(self, name):
             self.name = name
+            self.device_group = object()
 
         @contextmanager
         def graph_capture(self, context):
@@ -841,6 +877,12 @@ def test_global_graph_capture_enters_b12x_dcp_pool(monkeypatch):
         ("enter-group", "dcp", "vllm:target:profile"),
         (
             "enter-b12x",
+            tp_group,
+            stream,
+            "vllm:target:profile",
+        ),
+        (
+            "enter-b12x",
             dcp_group,
             stream,
             "vllm:target:profile",
@@ -851,10 +893,58 @@ def test_global_graph_capture_enters_b12x_dcp_pool(monkeypatch):
             stream,
             "vllm:target:profile",
         ),
+        (
+            "exit-b12x",
+            tp_group,
+            stream,
+            "vllm:target:profile",
+        ),
         ("exit-group", "dcp", "vllm:target:profile"),
         ("exit-group", "pp", "vllm:target:profile"),
         ("exit-group", "tp", "vllm:target:profile"),
     ]
+
+
+def test_global_graph_capture_keeps_distinct_b12x_coordinator_scopes(monkeypatch):
+    from vllm.distributed import parallel_state
+    from vllm.v1.attention.ops import dcp_alltoall
+
+    class _FakeGroup:
+        world_size = 16
+
+        def __init__(self, name, device_group):
+            self.name = name
+            self.device_group = device_group
+
+        @contextmanager
+        def graph_capture(self, context):
+            yield context
+
+    shared_device_group = object()
+    tp_group = _FakeGroup("tp", shared_device_group)
+    dcp_group = _FakeGroup("dcp", shared_device_group)
+    pp_group = _FakeGroup("pp", object())
+    entered_pools: list[str] = []
+
+    @contextmanager
+    def fake_b12x_capture(group, selected_stream, *, channel_id):
+        entered_pools.append(group.name)
+        yield
+
+    monkeypatch.setattr(parallel_state, "_DCP", dcp_group)
+    monkeypatch.setattr(parallel_state, "get_tp_group", lambda: tp_group)
+    monkeypatch.setattr(parallel_state, "get_pp_group", lambda: pp_group)
+    monkeypatch.setattr(parallel_state, "get_dcp_group", lambda: dcp_group)
+    monkeypatch.setattr(dcp_alltoall, "capture_b12x_dcp_a2a", fake_b12x_capture)
+    context = parallel_state.GraphCaptureContext(  # type: ignore[arg-type]
+        object(),
+        channel_id="vllm:target:decode",
+    )
+
+    with parallel_state.graph_capture(torch.device("cpu"), context):
+        pass
+
+    assert entered_pools == ["tp", "dcp"]
 
 
 def test_group_capture_forwards_semantic_id_to_custom_allreduce(monkeypatch):

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -1606,18 +1606,30 @@ def checkpoint_b12x_graph_channels() -> tuple[tuple[Callable[[Any], None], Any],
         if checkpoint is not None:
             checkpoints.append((rollback_fn, checkpoint))
 
-    if _DCP is not None and _DCP.world_size > 1:
+    b12x_pool_groups: list[GroupCoordinator] = []
+    seen_device_groups: set[int] = set()
+    for group in (_TP, _DCP):
+        if group is None or group.world_size <= 1:
+            continue
+        group_id = id(group.device_group)
+        if group_id in seen_device_groups:
+            continue
+        seen_device_groups.add(group_id)
+        b12x_pool_groups.append(group)
+
+    if b12x_pool_groups:
         from vllm.v1.attention.ops.dcp_alltoall import (
             checkpoint_b12x_dcp_a2a_channels,
             rollback_b12x_dcp_a2a_channels,
         )
 
-        checkpoints.append(
-            (
-                rollback_b12x_dcp_a2a_channels,
-                checkpoint_b12x_dcp_a2a_channels(_DCP),
+        for group in b12x_pool_groups:
+            checkpoints.append(
+                (
+                    rollback_b12x_dcp_a2a_channels,
+                    checkpoint_b12x_dcp_a2a_channels(group),
+                )
             )
-        )
     return tuple(checkpoints)
 
 
@@ -1721,15 +1733,25 @@ def graph_capture(
         if _DCP is not None and get_dcp_group().world_size > 1
         else nullcontext()
     )
+    from vllm.v1.attention.ops.dcp_alltoall import capture_b12x_dcp_a2a
+
+    maybe_b12x_tp_capture: contextlib.AbstractContextManager[Any]
+    if get_tp_group().world_size > 1:
+        # Tensor-parallel projection gathers use the generic B12X PCIe pool.
+        # Bind that pool to the graph owner just like the attention DCP pool.
+        maybe_b12x_tp_capture = capture_b12x_dcp_a2a(
+            get_tp_group(),
+            context.stream,
+            channel_id=context.channel_id,
+        )
+    else:
+        maybe_b12x_tp_capture = nullcontext()
+
     maybe_b12x_dcp_capture: contextlib.AbstractContextManager[Any]
     if _DCP is not None and get_dcp_group().world_size > 1:
-        # Import locally to avoid making distributed initialization depend on
-        # attention modules. The helper is a no-op until DCP warmup creates a
-        # B12X pool for this process group.
-        from vllm.v1.attention.ops.dcp_alltoall import capture_b12x_dcp_a2a
-
+        dcp_group = get_dcp_group()
         maybe_b12x_dcp_capture = capture_b12x_dcp_a2a(
-            get_dcp_group(),
+            dcp_group,
             context.stream,
             channel_id=context.channel_id,
         )
@@ -1739,6 +1761,7 @@ def graph_capture(
         get_tp_group().graph_capture(context),
         get_pp_group().graph_capture(context),
         maybe_dcp_capture,
+        maybe_b12x_tp_capture,
         maybe_b12x_dcp_capture,
     ):
         yield context


### PR DESCRIPTION
## Behavior

Registers B12X PCIe pools associated with tensor-parallel process groups with the owning CUDA graph capture. Disposable profiling captures also checkpoint and roll back both tensor-parallel and decode-context-parallel B12X pool state.

- TP and DCP coordinators receive separate graph-capture scopes.
- Pool storage shared by TP and DCP through the same device process group is checkpointed once.
- Existing custom-all-reduce channel checkpointing remains unchanged.
- Process groups without registered B12X pools retain no-op B12X capture behavior.

Status: implemented and qualified.

## Technical reason

B12X tensor-parallel projection collectives allocate graph-owned communication channels through the same pool implementation used by DCP attention collectives. Registering only the DCP coordinator leaves TP projection channels outside the CUDA graph lifecycle and allows disposable profiling captures to leak or reuse channels with the wrong owner.

## Compatibility

The change does not enable a B12X kernel or collective. It only extends lifecycle handling to a B12X pool after another runtime path registers that pool for a tensor-parallel process group. Models without B12X TP collectives retain their existing execution path.

The patch changes only distributed graph lifecycle code and its tests. It contains no Kimi-K3 model logic, DCP algorithm changes, speculative decoding, loader changes, or launch scripts.

## Validation

Validation used `voipmonitor/vllm:kimi-k3-qsrt-ii-vllm735952b-b12x180ccab-cu133-torch213-20260815-r3` with PyTorch 2.13 and CUDA 13.3:

- `tests/distributed/test_dcp_a2a.py`: 33 passed, 20 hardware-dependent skipped.
- Focused graph-pool ownership, rollback, and custom-all-reduce tests: 5 passed.
- Ruff, formatter verification, Python compilation, and `git diff --check` pass.

## Review scope

This pull request replaces only the B12X graph-pool lifecycle responsibility contained in #317. The TP projection operation that registers the pool is reviewed separately.
