### PR TITLE
[II] Define inactive Kimi MLA graph rows

### DIFF
--- a/tests/models/kimi_k3/test_mla_padding.py
+++ b/tests/models/kimi_k3/test_mla_padding.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import torch
+
+
+def test_kimi_mla_defines_graph_padding_before_output_projection(monkeypatch):
+    from vllm.models.kimi_k3.nvidia import mla
+
+    attention = object.__new__(mla.MultiHeadLatentAttention)
+    torch.nn.Module.__init__(attention)
+    attention.layer_name = "model.layers.0.self_attn"
+    attention.rotary_emb = None
+
+    metadata = SimpleNamespace(num_actual_tokens=2, num_decode_tokens=0)
+    context = SimpleNamespace(
+        attn_metadata={attention.layer_name: metadata},
+        slot_mapping={attention.layer_name: torch.arange(4)},
+    )
+    monkeypatch.setattr(mla, "get_forward_context", lambda: context)
+
+    def write_active_prefill(*args):
+        args[-1].fill_(3)
+
+    attention._forward_prefill_fused = write_active_prefill
+    output = torch.full((4, 8), 9, dtype=torch.bfloat16)
+    attention_method = type(attention)._attention
+    invoke_attention = getattr(attention_method, "__wrapped__", attention_method)
+    invoke_attention(
+        attention,
+        torch.arange(4),
+        torch.zeros((4, 1, 8), dtype=torch.bfloat16),
+        torch.zeros((4, 8), dtype=torch.bfloat16),
+        torch.zeros((4, 8), dtype=torch.bfloat16),
+        output,
+    )
+
+    torch.testing.assert_close(output[:2], torch.full_like(output[:2], 3))
+    torch.testing.assert_close(output[2:], torch.zeros_like(output[2:]))

--- a/vllm/models/kimi_k3/nvidia/mla.py
+++ b/vllm/models/kimi_k3/nvidia/mla.py
@@ -558,6 +558,10 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
         )
 
         num_actual_toks = attn_metadata.num_actual_tokens
+        if num_actual_toks < int(attn_out.shape[0]):
+            # Downstream gate and output projections consume graph-padded rows.
+            # Define inactive rows before they enter a collective operation.
+            attn_out[num_actual_toks:].zero_()
         slot_mapping_by_layer = forward_context.slot_mapping
         assert isinstance(slot_mapping_by_layer, dict)
         slot_mapping = slot_mapping_by_layer[self.layer_name]


### PR DESCRIPTION
## Behavior

Defines every CUDA-graph-padded Kimi-K3 MLA output row before downstream gate and output projections consume the capacity-sized tensor.

- Rows below `num_actual_tokens` retain the attention result.
- Rows from `num_actual_tokens` to graph capacity are zero.
- Batches whose active size equals graph capacity execute without the additional write.

Status: implemented and qualified.

## Technical reason

Kimi-K3 attention writes only active token rows, but CUDA graph replay retains a capacity-sized `attn_out` tensor. The gate projection, output projection, and their collective operations can consume padded rows. Leaving those rows undefined allows allocator contents to enter downstream kernels and can produce non-finite or non-deterministic padded values.

## Compatibility

The change is limited to Kimi-K3 MLA execution with graph padding. Active-token values and non-padded batches are unchanged. It does not select an attention backend, modify DCP communication, or change model weights.

## Validation

- `tests/models/kimi_k3/test_mla_padding.py`: 1 passed in the PyTorch 2.13/CUDA 13.3 Kimi-K3 image.
- The regression test fills active prefill rows with a known nonzero value and verifies that only inactive capacity rows become zero.
- Ruff, formatter verification, Python compilation, and `git diff --check` pass.

## Review scope

This pull request replaces only the inactive-row correctness responsibility contained in #317. B12X graph-pool ownership is reviewed independently in #324.
