### PR TITLE
[II] Bound InstantTensor staging for oversized tensors

### DIFF
--- a/tests/model_executor/model_loader/instanttensor_loader/test_weight_utils.py
+++ b/tests/model_executor/model_loader/instanttensor_loader/test_weight_utils.py
@@ -53,6 +53,7 @@ def test_instanttensor_copy_contract(
         raise AssertionError
 
     monkeypatch.setenv("INSTANTTENSOR_COPY", setting)
+    monkeypatch.delenv("INSTANTTENSOR_BUFFER_SIZE", raising=False)
     monkeypatch.setattr(
         weight_utils,
         "current_platform",
@@ -136,7 +137,7 @@ def test_instanttensor_restricts_io_to_indexed_shards(tmp_path):
         "model.expert.weight": str(overlay_shard.resolve()),
     }
 
-    weight_utils._restrict_instanttensor_to_selected_ranges(
+    cpu_fallback = weight_utils._restrict_instanttensor_to_selected_ranges(
         instant_open,
         indexed_tensor_files=indexed_tensor_files,
         weight_name_prefixes=None,
@@ -160,6 +161,77 @@ def test_instanttensor_restricts_io_to_indexed_shards(tmp_path):
         "model.expert.weight": 1,
     }
     assert buffer_sizes == [None]
+    assert cpu_fallback == []
+
+
+def test_instanttensor_routes_oversized_selected_tensors_to_cpu(tmp_path):
+    shard = tmp_path / "model.safetensors"
+    save_file(
+        {
+            "model.large.weight": torch.arange(8, dtype=torch.float32),
+            "model.small.weight": torch.arange(2, dtype=torch.float32),
+        },
+        shard,
+    )
+    with weight_utils.safe_open(shard, framework="pt") as physical_file:
+        physical_names = list(physical_file.offset_keys())
+    metadata_by_name = {
+        "model.large.weight": {"data_offsets": [0, 32]},
+        "model.small.weight": {"data_offsets": [32, 40]},
+    }
+    offsets_by_name = {
+        "model.large.weight": (0, 32),
+        "model.small.weight": (32, 40),
+    }
+    metadata = [(name, metadata_by_name[name]) for name in physical_names]
+    offsets = [(0, offsets_by_name[physical_names[0]][0])]
+    offsets.extend((0, offsets_by_name[name][1]) for name in physical_names)
+    buffer_sizes = []
+    instant_open = SimpleNamespace(
+        filename=[str(shard)],
+        ordered_tensor_metadatas=metadata,
+        tensor_offsets=offsets,
+        tensor_sizes=[32, 8],
+        total_tensor_size=40,
+        tensor_name_to_index={},
+        loader_handle=None,
+        _determine_buffer_size=lambda requested: buffer_sizes.append(requested),
+    )
+
+    cpu_fallback = weight_utils._restrict_instanttensor_to_selected_ranges(
+        instant_open,
+        indexed_tensor_files=None,
+        weight_name_prefixes=None,
+        max_tensor_size=16,
+    )
+
+    assert [name for name, _ in instant_open.ordered_tensor_metadatas] == [
+        "model.small.weight"
+    ]
+    assert cpu_fallback == [("model.large.weight", str(shard))]
+    assert instant_open.total_tensor_size == 8
+    assert buffer_sizes == [None]
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda(),
+    reason="InstantTensor requires NVIDIA GPUs",
+)
+def test_instanttensor_loads_tensor_larger_than_staging_buffer(tmp_path, monkeypatch):
+    shard = tmp_path / "model.safetensors"
+    small = torch.arange(256 * 1024, dtype=torch.float32)
+    large = torch.arange(9 * 256 * 1024, dtype=torch.float32)
+    save_file({"model.small": small, "model.large": large}, shard)
+    monkeypatch.setenv("INSTANTTENSOR_BUFFER_SIZE", str(8 * 1024 * 1024))
+    monkeypatch.setenv("INSTANTTENSOR_COPY", "1")
+
+    loaded = list(instanttensor_weights_iterator([str(shard)], use_tqdm_on_load=False))
+    devices = {name: tensor.device.type for name, tensor in loaded}
+    weights = {name: tensor.cpu() for name, tensor in loaded}
+
+    assert devices == {"model.small": "cuda", "model.large": "cpu"}
+    torch.testing.assert_close(weights["model.small"], small)
+    torch.testing.assert_close(weights["model.large"], large)
 
 
 @pytest.mark.skipif(

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -1229,7 +1229,23 @@ def instanttensor_weights_iterator(
         raise ValueError(f"INSTANTTENSOR_COPY must be 0 or 1, got {copy_setting!r}")
     copy_tensors = copy_setting == "1"
 
-    restrict_before_io = indexed_tensor_files is not None or bool(weight_name_prefixes)
+    configured_buffer_size = os.getenv("INSTANTTENSOR_BUFFER_SIZE")
+    max_gpu_tensor_size: int | None = None
+    if configured_buffer_size is not None:
+        try:
+            max_gpu_tensor_size = int(configured_buffer_size)
+        except ValueError as e:
+            raise ValueError(
+                "INSTANTTENSOR_BUFFER_SIZE must be an integer number of bytes"
+            ) from e
+        if max_gpu_tensor_size <= 0:
+            raise ValueError("INSTANTTENSOR_BUFFER_SIZE must be greater than zero")
+
+    restrict_before_io = (
+        indexed_tensor_files is not None
+        or bool(weight_name_prefixes)
+        or max_gpu_tensor_size is not None
+    )
     open_kwargs: dict[str, Any] = {}
     if restrict_before_io:
         open_kwargs["load_now"] = False
@@ -1244,41 +1260,63 @@ def instanttensor_weights_iterator(
         copy=copy_tensors,
         **open_kwargs,
     )
+    cpu_fallback_weights: list[tuple[str, str]] = []
     if restrict_before_io:
-        _restrict_instanttensor_to_selected_ranges(
+        cpu_fallback_weights = _restrict_instanttensor_to_selected_ranges(
             instant_open,
             indexed_tensor_files=indexed_tensor_files,
             weight_name_prefixes=weight_name_prefixes,
+            max_tensor_size=max_gpu_tensor_size,
         )
 
-    with instant_open as f:
-        # Track bytes so the bar reports load throughput (GB/s).
-        pbar = tqdm(
-            total=f.total_tensor_size,
-            desc="Loading safetensors using InstantTensor loader",
-            disable=not enable_tqdm(use_tqdm_on_load),
-            bar_format=_BAR_FORMAT,
-            position=tqdm._get_free_pos(),
-            unit="B",
-            unit_scale=True,
-            unit_divisor=1024,
-            mininterval=1.0,
+    if not restrict_before_io or instant_open.ordered_tensor_metadatas:
+        with instant_open as f:
+            # Track bytes so the bar reports load throughput (GB/s).
+            pbar = tqdm(
+                total=f.total_tensor_size,
+                desc="Loading safetensors using InstantTensor loader",
+                disable=not enable_tqdm(use_tqdm_on_load),
+                bar_format=_BAR_FORMAT,
+                position=tqdm._get_free_pos(),
+                unit="B",
+                unit_scale=True,
+                unit_divisor=1024,
+                mininterval=1.0,
+            )
+            try:
+                tensor: torch.Tensor | None = None
+                for name, tensor in f.tensors():
+                    pbar.update(tensor.numel() * tensor.element_size())
+                    if weight_name_prefixes and not _matches_weight_name_prefixes(
+                        name, weight_name_prefixes
+                    ):
+                        continue
+                    if not copy_tensors:
+                        # Parameter loaders consume borrowed tensors synchronously.
+                        # A deferred loader must own the tensor before advancing.
+                        tensor._vllm_instanttensor_borrowed = True
+                    yield name, tensor
+                # A generator frame retains its final DLPack-backed view. Drop it
+                # before the InstantTensor context releases the staging ring.
+                tensor = None
+            finally:
+                pbar.close()
+
+    if cpu_fallback_weights:
+        assert max_gpu_tensor_size is not None
+        logger.info_once(
+            "Loading %d tensors larger than the %d-byte InstantTensor buffer "
+            "through CPU safetensors",
+            len(cpu_fallback_weights),
+            max_gpu_tensor_size,
         )
-        try:
-            for name, tensor in f.tensors():
-                pbar.update(tensor.numel() * tensor.element_size())
-                if weight_name_prefixes and not _matches_weight_name_prefixes(
-                    name, weight_name_prefixes
-                ):
-                    continue
-                if not copy_tensors:
-                    # Parameter loaders consume borrowed tensors synchronously.
-                    # Loaders retaining a tensor past this yield must materialize
-                    # owned storage before InstantTensor advances its ring buffer.
-                    tensor._vllm_instanttensor_borrowed = True
-                yield name, tensor
-        finally:
-            pbar.close()
+        fallback_by_file: dict[str, list[str]] = defaultdict(list)
+        for name, filename in cpu_fallback_weights:
+            fallback_by_file[filename].append(name)
+        for filename, names in fallback_by_file.items():
+            with safe_open(filename, framework="pt", device="cpu") as fallback_file:
+                for name in names:
+                    yield name, fallback_file.get_tensor(name)
 
 
 def _restrict_instanttensor_to_selected_ranges(
@@ -1286,8 +1324,23 @@ def _restrict_instanttensor_to_selected_ranges(
     *,
     indexed_tensor_files: dict[str, str] | None,
     weight_name_prefixes: Sequence[str] | None,
-) -> None:
-    """Replace an unopened InstantTensor layout with selected byte ranges."""
+    max_tensor_size: int | None = None,
+) -> list[tuple[str, str]]:
+    """Restrict an InstantTensor loader to requested checkpoint ranges.
+
+    Args:
+        instant_open: Unopened InstantTensor safetensors loader whose metadata
+            can be restricted before I/O starts.
+        indexed_tensor_files: Mapping from tensor names to their canonical
+            checkpoint files. ``None`` accepts tensors from every input file.
+        weight_name_prefixes: Model parameter prefixes selected for loading.
+            ``None`` or an empty sequence accepts every prefix.
+        max_tensor_size: Largest tensor payload, in bytes, retained in the GPU
+            staging path. Larger selected tensors are assigned to CPU loading.
+
+    Returns:
+        Pairs of tensor name and checkpoint filename assigned to CPU loading.
+    """
     required_attrs = (
         "filename",
         "ordered_tensor_metadatas",
@@ -1313,6 +1366,7 @@ def _restrict_instanttensor_to_selected_ranges(
     selected_filenames: list[str] = []
     selected_metadata: list[tuple[str, dict[str, Any]]] = []
     selected_offsets: list[tuple[int, int]] = []
+    cpu_fallback_weights: list[tuple[str, str]] = []
     metadata_pos = 0
     offset_pos = 0
 
@@ -1334,17 +1388,26 @@ def _restrict_instanttensor_to_selected_ranges(
                 f"for {filename}"
             )
 
-        keep = [
-            (
-                indexed_tensor_files is None
-                or indexed_tensor_files.get(name) == filename_abs
+        keep = []
+        for item_index, name in enumerate(physical_names):
+            indexed_here = indexed_tensor_files is None or (
+                indexed_tensor_files.get(name) == filename_abs
             )
-            and (
-                not weight_name_prefixes
-                or _matches_weight_name_prefixes(name, weight_name_prefixes)
+            prefix_matches = not weight_name_prefixes or _matches_weight_name_prefixes(
+                name, weight_name_prefixes
             )
-            for name in physical_names
-        ]
+            selected_here = indexed_here and prefix_matches
+            tensor_size = int(file_offsets[item_index + 1][1]) - int(
+                file_offsets[item_index][1]
+            )
+            use_cpu_fallback = (
+                selected_here
+                and max_tensor_size is not None
+                and tensor_size > max_tensor_size
+            )
+            keep.append(selected_here and not use_cpu_fallback)
+            if use_cpu_fallback:
+                cpu_fallback_weights.append((name, filename))
 
         run_start = 0
         while run_start < tensor_count:
@@ -1373,13 +1436,23 @@ def _restrict_instanttensor_to_selected_ranges(
         raise RuntimeError(
             "InstantTensor layout contains unaccounted metadata or offsets"
         )
-    if not selected_metadata:
+    if not selected_metadata and not cpu_fallback_weights:
         raise RuntimeError("InstantTensor index/prefix selection matched no tensors")
 
     selected_names = [name for name, _ in selected_metadata]
     if len(selected_names) != len(set(selected_names)):
         raise RuntimeError(
             "InstantTensor index-aware selection still contains duplicate tensor names"
+        )
+    fallback_names = [name for name, _ in cpu_fallback_weights]
+    if len(fallback_names) != len(set(fallback_names)):
+        raise RuntimeError(
+            "InstantTensor CPU fallback selection contains duplicate tensor names"
+        )
+    overlap = set(selected_names).intersection(fallback_names)
+    if overlap:
+        raise RuntimeError(
+            f"InstantTensor GPU and CPU selections overlap: {sorted(overlap)[:3]}"
         )
     selected_sizes = [
         int(item["data_offsets"][1]) - int(item["data_offsets"][0])
@@ -1394,6 +1467,7 @@ def _restrict_instanttensor_to_selected_ranges(
     instant_open.tensor_sizes = selected_sizes
     instant_open.total_tensor_size = sum(selected_sizes)
     instant_open._determine_buffer_size(None)
+    return cpu_fallback_weights
 
 
 def pt_weights_iterator(


### PR DESCRIPTION
## Behavior

Treats `INSTANTTENSOR_BUFFER_SIZE` as the maximum individual tensor payload admitted to InstantTensor GPU staging.

- Selected tensors at or below the limit use the existing InstantTensor path.
- Selected tensors above the limit load directly from their indexed safetensors file on CPU.
- Safetensors index and weight-prefix filtering occur before GPU-versus-CPU assignment.
- Duplicate fallback names, overlap between GPU and CPU selections, invalid buffer values, and empty selections fail explicitly.

Status: implemented and qualified.

## Technical reason

InstantTensor otherwise enlarges its reusable GPU staging ring to the checkpoint's largest tensor. A checkpoint with a small desired ring and a few exceptionally large dense tensors cannot honor the memory bound. Loading only those exceptional tensors from CPU keeps the ring bounded while retaining GPU-direct streaming for the rest of the checkpoint.

## Compatibility

Deployments without `INSTANTTENSOR_BUFFER_SIZE` retain their existing loading behavior. `INSTANTTENSOR_COPY` and borrowed-buffer semantics are unchanged. The fallback applies only to tensors already selected by the checkpoint index and weight-prefix filters.

The CPU path can be slower for an oversized tensor. It is a bounded-memory fallback, not a replacement for InstantTensor streaming.

## Validation

Validation used the PyTorch 2.13/CUDA 13.3 Kimi-K3 image:

- Five CPU metadata, selection, and copy-contract tests pass.
- One CUDA integration test passes with an 8 MiB staging limit: the 1 MiB tensor is yielded on CUDA, the 9 MiB tensor is yielded on CPU, and both values match their safetensors source exactly.
- Ruff, formatter verification, Python compilation, and `git diff --check` pass.

## Review scope

This pull request replaces only the oversized-tensor staging responsibility contained in #317. Deferred online-quantization ownership is reviewed independently.

The bounded-staging behavior derives from Luke Alonso's implementation in commit `88721d90dcd90a1f5236b9ecf7e94798245e43bf`; the commit retains co-author attribution.
