### PR TITLE
[II] Own deferred accelerator weight tensors

### DIFF
--- a/tests/model_executor/model_loader/instanttensor_loader/test_weight_utils.py
+++ b/tests/model_executor/model_loader/instanttensor_loader/test_weight_utils.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import glob
+import inspect
 import sys
 from contextlib import contextmanager
 from types import SimpleNamespace
@@ -11,6 +12,9 @@ import torch
 from safetensors.torch import save_file
 
 import vllm.model_executor.model_loader.weight_utils as weight_utils
+from vllm.model_executor.model_loader.reload.layerwise import (
+    _own_deferred_accelerator_tensors,
+)
 from vllm.model_executor.model_loader.weight_utils import (
     download_weights_from_hf,
     instanttensor_weights_iterator,
@@ -160,6 +164,73 @@ def test_instanttensor_restricts_io_to_indexed_shards(tmp_path):
         "model.expert.weight": 1,
     }
     assert buffer_sizes == [None]
+
+
+def test_deferred_loader_preserves_destination_and_cpu_tensors():
+    def loader(param, loaded_weight):
+        pass
+
+    destination = torch.empty(4)
+    source = torch.arange(4)
+    bound_args = inspect.signature(loader).bind(destination, source)
+
+    _own_deferred_accelerator_tensors(bound_args)
+
+    assert bound_args.arguments["param"] is destination
+    assert bound_args.arguments["loaded_weight"] is source
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda(),
+    reason="Borrowed accelerator storage requires CUDA",
+)
+def test_deferred_loader_owns_accelerator_tensor():
+    def loader(param, loaded_weight):
+        pass
+
+    destination = torch.empty(8, device="cuda")
+    source = torch.arange(8, device="cuda")
+    bound_args = inspect.signature(loader).bind(destination, source)
+
+    _own_deferred_accelerator_tensors(bound_args)
+
+    owned = bound_args.arguments["loaded_weight"]
+    assert bound_args.arguments["param"] is destination
+    assert owned.data_ptr() != source.data_ptr()
+    assert torch.equal(owned, source)
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda(),
+    reason="InstantTensor requires NVIDIA GPUs",
+)
+def test_instanttensor_deferred_tensors_survive_ring_reuse(tmp_path, monkeypatch):
+    shard = tmp_path / "model.safetensors"
+    source = {
+        f"model.weight_{index}": torch.full(
+            (2 * 1024 * 1024,), index, dtype=torch.bfloat16
+        )
+        for index in range(5)
+    }
+    save_file(source, shard)
+    monkeypatch.setenv("INSTANTTENSOR_BUFFER_SIZE", str(8 * 1024 * 1024))
+    monkeypatch.setenv("INSTANTTENSOR_COPY", "0")
+
+    def deferred_loader(param, loaded_weight):
+        raise AssertionError("Deferred arguments must not execute while queued")
+
+    signature = inspect.signature(deferred_loader)
+    retained = {}
+    for name, tensor in instanttensor_weights_iterator(
+        [str(shard)], use_tqdm_on_load=False
+    ):
+        bound_args = signature.bind(None, tensor)
+        _own_deferred_accelerator_tensors(bound_args)
+        retained[name] = bound_args.arguments["loaded_weight"]
+    torch.cuda.synchronize()
+
+    for name, expected in source.items():
+        assert torch.equal(retained[name].cpu(), expected)
 
 
 @pytest.mark.skipif(

--- a/vllm/model_executor/model_loader/reload/layerwise.py
+++ b/vllm/model_executor/model_loader/reload/layerwise.py
@@ -146,6 +146,28 @@ def _wrap_parameters_weight_loader(layer: torch.nn.Module) -> None:
             tensor.weight_loader = make_online_process_loader(layer, name)
 
 
+def _own_deferred_accelerator_tensors(bound_args: inspect.BoundArguments) -> None:
+    """Give deferred weight-loader arguments independent device storage.
+
+    Streaming model loaders may yield views into reusable staging storage.
+    Layerwise processing replays bound arguments only after every checkpoint
+    shard for a layer arrives, so accelerator tensors must be cloned before
+    they enter the deferred queue. This also covers views created by name or
+    shard mapping because custom attributes on the source tensor are not
+    guaranteed to propagate to those views.
+
+    Args:
+        bound_args: Normalized weight-loader arguments to update in place.
+    """
+    for name, value in tuple(bound_args.arguments.items()):
+        if (
+            name != "param"
+            and isinstance(value, torch.Tensor)
+            and value.device.type not in ("meta", "cpu")
+        ):
+            bound_args.arguments[name] = value.clone()
+
+
 def make_online_process_loader(layer: torch.nn.Module, param_name: str) -> Callable:
     """Create a wrapped weight loader that defers processing."""
     info = get_layerwise_info(layer)
@@ -182,6 +204,8 @@ def make_online_process_loader(layer: torch.nn.Module, param_name: str) -> Calla
         # Bind and normalize arguments
         bound_args = loader_signature.bind(*args, **kwargs)
         bound_args.apply_defaults()
+
+        _own_deferred_accelerator_tensors(bound_args)
 
         # Buffer loaded weights, track loading progress
         info.loaded_weights.append((param_name, bound_args))


### PR DESCRIPTION
## Behavior

Layerwise online processing gives every deferred accelerator tensor independent
storage before queuing its normalized weight-loader arguments. The destination
parameter is never cloned, and CPU and meta tensors retain their existing
storage.

## Technical reason

Streaming checkpoint loaders can expose accelerator views backed by a reusable
staging ring. Layerwise processing retains weight-loader arguments until all
checkpoint shards required by a layer arrive. Retaining a borrowed view across
another iterator step allows the staging ring to overwrite data that has not
yet reached the quantizer.

The ownership boundary is applied only where weight-loader execution is
deferred. Synchronous parameter loading remains zero-copy.

## Compatibility

- Applies to every streaming loader that supplies accelerator tensors to
  layerwise online processing; it is not model-specific.
- Preserves the existing loader signature and return behavior.
- Does not change CPU checkpoint loading or synchronous full-checkpoint loading.
- Does not change InstantTensor buffer sizing or its default copy policy.

## Validation

- Ruff formatting and lint checks pass for both changed files.
- Python bytecode compilation passes.
- A CUDA test verifies that queued source storage differs from the borrowed
  source while tensor values remain exact.
- A CUDA integration test streams five 4 MiB BF16 tensors through an 8 MiB
  InstantTensor ring, forcing multiple wraps; every retained deferred tensor
  remains exact after iteration completes.
- A CPU test verifies that the destination parameter and CPU source tensor keep
  their original identities.

Test result: 3 passed on one NVIDIA GPU in the source-locked Kimi-K3 runtime
image; 5 unrelated tests were deselected.
