### PR TITLE
[II] Stream online quantization into TP-local parameters

### DIFF
--- a/tests/model_executor/model_loader/test_reload.py
+++ b/tests/model_executor/model_loader/test_reload.py
@@ -16,6 +16,7 @@ from vllm.model_executor.layers.linear import QKVParallelLinear
 from vllm.model_executor.layers.quantization.base_config import QuantizeMethodBase
 from vllm.model_executor.model_loader.reload.layerwise import (
     finalize_layerwise_reload,
+    get_layerwise_info,
     initialize_layerwise_reload,
     initialize_online_processing,
     record_metadata_for_reloading,
@@ -684,6 +685,25 @@ def test_online_processing_waits_for_late_registered_bias():
     layer.bias.weight_loader(layer.bias, loaded_bias)
     assert quant_method.bias_at_process is not None
     assert torch.equal(quant_method.bias_at_process, loaded_bias)
+
+
+def test_initial_online_processing_loads_into_materialized_parameters():
+    quant_method = _RecordingQuantMethod()
+    layer = _LateBiasLayer(quant_method)
+    loaded_weight = torch.full((4, 2), 2.0)
+    loaded_bias = torch.full((4,), 3.0)
+
+    layer.weight.weight_loader(layer.weight, loaded_weight)
+
+    assert not layer.weight.is_meta
+    assert torch.equal(layer.weight, loaded_weight)
+    assert not get_layerwise_info(layer).loaded_weights
+    assert quant_method.bias_at_process is None
+
+    layer.bias.weight_loader(layer.bias, loaded_bias)
+
+    assert torch.equal(quant_method.bias_at_process, loaded_bias)
+    assert not get_layerwise_info(layer).loaded_weights
 
 
 def test_layerwise_reload_skips_non_persistent_parameter_alias_buffers(monkeypatch):

--- a/vllm/model_executor/model_loader/reload/layerwise.py
+++ b/vllm/model_executor/model_loader/reload/layerwise.py
@@ -205,11 +205,22 @@ def make_online_process_loader(layer: torch.nn.Module, param_name: str) -> Calla
         bound_args = loader_signature.bind(*args, **kwargs)
         bound_args.apply_defaults()
 
-        _own_deferred_accelerator_tensors(bound_args)
+        direct_load = info.kernel_tensors is None and not is_deferred_attention_layer(
+            layer
+        )
+        if direct_load:
+            # Initial online quantization can write each checkpoint shard into
+            # its materialized TP-local destination before the iterator
+            # advances. Reloading and deferred attention retain their queued
+            # arguments because their processing has different lifetime rules.
+            materialize_layer(layer, info)
+            bound_args.arguments["param"] = getattr(layer, param_name)
+            num_loaded, ret = get_numel_loaded(original_loader, bound_args)
+        else:
+            _own_deferred_accelerator_tensors(bound_args)
+            info.loaded_weights.append((param_name, bound_args))
+            num_loaded, ret = get_numel_loaded(original_loader, bound_args)
 
-        # Buffer loaded weights, track loading progress
-        info.loaded_weights.append((param_name, bound_args))
-        num_loaded, ret = get_numel_loaded(original_loader, bound_args)
         info.load_numel += num_loaded
 
         logger.debug(
@@ -224,7 +235,7 @@ def make_online_process_loader(layer: torch.nn.Module, param_name: str) -> Calla
             return ret
 
         # Log warnings allocating excessive buffers on device
-        if has_device_tensors(bound_args):
+        if not direct_load and has_device_tensors(bound_args):
             LOADING_LAYERS.add(layer)
             if len(LOADING_LAYERS) >= 2:
                 names = sorted([layer.__class__.__name__ for layer in LOADING_LAYERS])


### PR DESCRIPTION
## Behavior

Initial layerwise online quantization materializes each TP-local parameter and
loads its checkpoint shard immediately. The loader retains no duplicate
checkpoint tensor while it waits for the remaining parameters in the layer.

Model reload preserves its deferred queue because processed kernel storage must
retain stable addresses. Attention layers that require model-wide finalization
also preserve deferred loading.

## Technical reason

The initial quantization path does not need to replay a checkpoint shard after
the shard has been copied into its TP-local destination. Queuing the shard until
quantization begins overlaps checkpoint storage, materialized parameters, and
quantizer or repack workspace. Immediate loading removes that unnecessary
overlap without changing quantization order.

## Compatibility

- Applies to every layerwise online quantizer; it is not model-specific.
- Preserves deferred loading for reload and deferred attention.
- Preserves late parameter registration and loaded-element accounting.
- Depends on #327 for safe ownership of accelerator tensors that remain on the
  deferred path.

## Validation

- Ruff formatting, Ruff lint, Python bytecode compilation, and `git diff
  --check` pass.
- A focused regression verifies that a meta parameter is materialized and
  populated before the layer's trailing bias arrives, that no checkpoint
  tensor remains queued, and that post-load quantization still waits for the
  complete layer.
- Twenty-four non-model-download reload tests pass on one NVIDIA GPU in
  `voipmonitor/vllm:kimi-k3-qsrt-ii-vllm735952b-b12x180ccab-cu133-torch213-20260815-r3`.
  `test_kv_scale_reload` was excluded because its process-group teardown does
  not terminate in that image.

Focused result: 2 passed. Broader result: 24 passed, 22 deselected.
