### PR TITLE
[II] Propagate external draft online quantization

### DIFF
--- a/tests/transformers_utils/test_dspark_mla_config.py
+++ b/tests/transformers_utils/test_dspark_mla_config.py
@@ -5,7 +5,12 @@ import json
 
 import pytest
 
-from vllm.config import ModelConfig, ParallelConfig, SpeculativeConfig
+from vllm.config import LoadConfig, ModelConfig, ParallelConfig, SpeculativeConfig
+from vllm.config.quantization import QuantizationConfigArgs, QuantSpec
+from vllm.model_executor.layers.quantization.online.base import (
+    OnlineQuantizationConfig,
+)
+from vllm.model_executor.model_loader.weight_utils import get_quant_config
 from vllm.transformers_utils.config import get_config
 from vllm.transformers_utils.configs.k3_dspark import K3DSparkConfig
 
@@ -140,6 +145,43 @@ def test_dspark_mla_speculative_config_preserves_architecture(tmp_path):
     assert speculative_config.draft_model_config.architectures == ["K3DSparkModel"]
     assert speculative_config.draft_model_config.hf_config.model_type == "k3_dspark"
     assert speculative_config.draft_model_config.use_mla
+
+
+def test_dspark_mla_accepts_draft_online_quantization(tmp_path):
+    target_path = tmp_path / "target"
+    draft_path = tmp_path / "draft"
+    _write_target_config(target_path)
+    _write_dspark_config(draft_path)
+    target_config = ModelConfig(
+        model=str(target_path), tokenizer_mode="skip", max_model_len=32768
+    )
+
+    speculative_config = SpeculativeConfig(
+        model=str(draft_path),
+        method="dspark",
+        num_speculative_tokens=7,
+        quantization="mxfp8",
+        quantization_config={
+            "linear": "mxfp8",
+            "ignore": ["re:.*fused_qkv_a_proj$", "model.markov_head.markov_w2"],
+        },
+        target_model_config=target_config,
+        target_parallel_config=ParallelConfig(),
+    )
+
+    draft = speculative_config.draft_model_config
+    assert draft.quantization == "mxfp8"
+    assert isinstance(draft.quantization_config, QuantizationConfigArgs)
+    assert draft.quantization_config.linear == QuantSpec(weight="mxfp8")
+    assert draft.quantization_config.ignore == [
+        "re:.*fused_qkv_a_proj$",
+        "model.markov_head.markov_w2",
+    ]
+
+    draft.hf_overrides = lambda hf_config: hf_config
+    quant_config = get_quant_config(draft, LoadConfig())
+    assert isinstance(quant_config, OnlineQuantizationConfig)
+    assert quant_config.args == draft.quantization_config
 
 
 def test_dspark_mla_rejects_decode_context_parallelism(tmp_path):

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -16,6 +16,7 @@ from vllm.config.cache import CacheDType
 from vllm.config.kernel import MoEBackend
 from vllm.config.model import HfOverrides, ModelConfig
 from vllm.config.parallel import ParallelConfig
+from vllm.config.quantization import QuantizationConfigArgs, resolve_quantization_config
 from vllm.config.utils import config
 from vllm.logger import init_logger
 from vllm.transformers_utils.config import get_hf_text_config
@@ -117,6 +118,8 @@ class SpeculativeConfig:
     """Quantization method that was used to quantize the draft model weights.
     If `None`, we assume the model weights are not quantized. Note that it only
     takes effect when using the draft model-based speculative method."""
+    quantization_config: dict[str, Any] | QuantizationConfigArgs | None = None
+    """Optional per-layer online quantization settings for the draft model."""
     moe_backend: MoEBackend | None = None
     """MoE backend to use for the draft model. When `None`, the draft model
     inherits the target model's `--moe-backend` setting. Useful when the
@@ -1035,6 +1038,9 @@ class SpeculativeConfig:
                     max_model_len=self.max_model_len,  # type: ignore[arg-type]
                     spec_target_max_model_len=self.target_model_config.max_model_len,
                     quantization=self.quantization,
+                    quantization_config=resolve_quantization_config(
+                        self.quantization, self.quantization_config
+                    ),
                     enforce_eager=self.target_model_config.enforce_eager,
                     max_logprobs=self.target_model_config.max_logprobs,
                     hf_overrides=draft_hf_overrides,

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -290,12 +290,19 @@ def get_quant_config(
     # if hf_quant_config is None, we will try to get config from
     # hf_overrides
     hf_overrides = model_config.hf_overrides
-    if not isinstance(hf_overrides, dict):
+    if not isinstance(hf_overrides, dict) and model_config.quantization_config is None:
         raise ValueError(
             "hf_overrides must be a dict for get_quant_config "
             "to get the quantization config from it."
         )
-    quantization_config_file = hf_overrides.get("quantization_config_file", None)
+    # Callable HF overrides cannot carry checkpoint-side quantization metadata,
+    # but online quantization is fully defined by ModelConfig.quantization_config.
+    # Draft models can inherit a callable override from the target model.
+    quantization_config_file = (
+        hf_overrides.get("quantization_config_file", None)
+        if isinstance(hf_overrides, dict)
+        else None
+    )
     if quantization_config_file is not None:
         if hasattr(quant_cls, "from_config_file"):
             return quant_cls.from_config_file(quantization_config_file)
@@ -305,7 +312,11 @@ def get_quant_config(
                 "but quant_cls.from_config_file is not implemented in "
                 f"{quant_cls}"
             )
-    quantization_config_json = hf_overrides.get("quantization_config_dict_json", None)
+    quantization_config_json = (
+        hf_overrides.get("quantization_config_dict_json", None)
+        if isinstance(hf_overrides, dict)
+        else None
+    )
     if quantization_config_json is not None:
         if hasattr(quant_cls, "from_config_dict_json"):
             return quant_cls.from_config_dict_json(quantization_config_json)


### PR DESCRIPTION
## Behavior

`SpeculativeConfig` accepts the same per-layer `quantization_config` structure
as `ModelConfig`, resolves online quantization shorthand, and stores the
resolved configuration on the external draft model.

`get_quant_config()` accepts callable Hugging Face overrides when
`ModelConfig.quantization_config` completely defines online quantization.
Checkpoint-defined quantization still requires dictionary overrides when no
checkpoint metadata is present.

## Technical reason

External DSpark and DFlash models can use BF16 checkpoint weights while
quantizing selected draft projections during loading. Passing only the
quantization method loses per-layer formats and ignore patterns. Draft models
can also inherit a callable Hugging Face transform from the target model; that
callable does not contain checkpoint metadata, but it must not block a complete
online quantization configuration.

## Compatibility

- Draft configurations without `quantization_config` retain their existing
  behavior.
- Online shorthand and explicit fields use the shared
  `resolve_quantization_config()` precedence rules.
- Checkpoint quantization metadata and dictionary-based
  `quantization_config_file` or `quantization_config_dict_json` overrides retain
  their existing precedence.
- The change is speculative-model generic and contains no Kimi execution or DCP
  code.

## Validation

- Thirteen DSpark MLA configuration tests pass in
  `voipmonitor/vllm:kimi-k3-qsrt-ii-vllm735952b-b12x180ccab-cu133-torch213-20260815-r3`.
- The focused test resolves an MXFP8 draft linear configuration with two ignore
  patterns, verifies the resulting `QuantizationConfigArgs`, applies a callable
  Hugging Face override, and constructs the expected
  `OnlineQuantizationConfig`.
- Ruff formatting, Ruff lint, Python bytecode compilation, and `git diff
  --check` pass.
