### PR TITLE
[II] Expose explicit in-place tensor-parallel all-reduce

### DIFF
--- a/tests/distributed/test_inplace_allreduce.py
+++ b/tests/distributed/test_inplace_allreduce.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+import vllm.distributed.communication_op as communication_op
+from vllm.distributed.device_communicators.cuda_communicator import CudaCommunicator
+from vllm.distributed.parallel_state import GroupCoordinator
+
+
+def _make_group(world_size: int) -> GroupCoordinator:
+    group = GroupCoordinator.__new__(GroupCoordinator)
+    group.world_size = world_size
+    group.device_communicator = None
+    return group
+
+
+def test_tensor_model_parallel_all_reduce_in_place_delegates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tensor = torch.arange(4, dtype=torch.float32)
+    group = Mock()
+
+    def reduce_in_place(value: torch.Tensor) -> torch.Tensor:
+        value.add_(1)
+        return value
+
+    group.all_reduce_in_place.side_effect = reduce_in_place
+    monkeypatch.setattr(communication_op, "get_tp_group", lambda: group)
+
+    result = communication_op.tensor_model_parallel_all_reduce_in_place(tensor)
+
+    assert result is tensor
+    torch.testing.assert_close(tensor, torch.arange(4, dtype=torch.float32) + 1)
+    group.all_reduce_in_place.assert_called_once_with(tensor)
+
+
+def test_group_all_reduce_in_place_preserves_single_rank_storage() -> None:
+    tensor = torch.arange(4)
+    group = _make_group(world_size=1)
+
+    assert group.all_reduce_in_place(tensor) is tensor
+
+
+def test_group_all_reduce_in_place_delegates_to_device_communicator() -> None:
+    tensor = torch.arange(4)
+    group = _make_group(world_size=2)
+    communicator = Mock()
+    communicator.all_reduce_in_place.return_value = tensor
+    group.device_communicator = communicator
+
+    result = group.all_reduce_in_place(tensor)
+
+    assert result is tensor
+    communicator.all_reduce_in_place.assert_called_once_with(tensor)
+
+
+def test_cuda_all_reduce_in_place_uses_pynccl_alias() -> None:
+    tensor = torch.arange(4, dtype=torch.float32)
+    communicator = CudaCommunicator.__new__(CudaCommunicator)
+    pynccl = Mock()
+    pynccl.disabled = False
+
+    def reduce(value: torch.Tensor, *, out_tensor: torch.Tensor) -> torch.Tensor:
+        assert value is tensor
+        assert out_tensor is tensor
+        out_tensor.add_(2)
+        return out_tensor
+
+    pynccl.all_reduce.side_effect = reduce
+    communicator.pynccl_comm = pynccl
+
+    result = communicator.all_reduce_in_place(tensor)
+
+    assert result is tensor
+    torch.testing.assert_close(tensor, torch.arange(4, dtype=torch.float32) + 2)
+
+
+def test_cuda_all_reduce_in_place_uses_torch_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tensor = torch.arange(4, dtype=torch.float32)
+    communicator = CudaCommunicator.__new__(CudaCommunicator)
+    communicator.pynccl_comm = None
+    communicator.device_group = object()
+
+    def reduce(value: torch.Tensor, *, group: object) -> None:
+        assert value is tensor
+        assert group is communicator.device_group
+        value.add_(3)
+
+    monkeypatch.setattr(torch.distributed, "all_reduce", reduce)
+
+    result = communicator.all_reduce_in_place(tensor)
+
+    assert result is tensor
+    torch.testing.assert_close(tensor, torch.arange(4, dtype=torch.float32) + 3)

--- a/vllm/distributed/communication_op.py
+++ b/vllm/distributed/communication_op.py
@@ -14,6 +14,11 @@ def tensor_model_parallel_all_reduce(input_: torch.Tensor) -> torch.Tensor:
     return get_tp_group().all_reduce(input_)
 
 
+def tensor_model_parallel_all_reduce_in_place(input_: torch.Tensor) -> torch.Tensor:
+    """All-reduce a dead input tensor without allocating an output tensor."""
+    return get_tp_group().all_reduce_in_place(input_)
+
+
 def tensor_model_parallel_all_gather(
     input_: torch.Tensor, dim: int = -1
 ) -> torch.Tensor:

--- a/vllm/distributed/device_communicators/base_device_communicator.py
+++ b/vllm/distributed/device_communicators/base_device_communicator.py
@@ -220,6 +220,11 @@ class DeviceCommunicatorBase:
         dist.all_reduce(input_, group=self.device_group)
         return input_
 
+    def all_reduce_in_place(self, input_: torch.Tensor) -> torch.Tensor:
+        """All-reduce while allowing the input storage to hold the result."""
+        dist.all_reduce(input_, group=self.device_group)
+        return input_
+
     def checkpoint_prepare(self) -> None:
         """Prepare reclaimable communicator state for checkpoint (default: no-op)."""
 

--- a/vllm/distributed/device_communicators/cuda_communicator.py
+++ b/vllm/distributed/device_communicators/cuda_communicator.py
@@ -348,6 +348,22 @@ class CudaCommunicator(DeviceCommunicatorBase):
             torch.distributed.all_reduce(out, group=self.device_group)
         return out
 
+    def all_reduce_in_place(self, input_: torch.Tensor) -> torch.Tensor:
+        """Run NCCL with the same tensor as its input and output.
+
+        Functional custom operators cannot return aliased mutable storage, so
+        callers must use this method only when the source tensor is dead after
+        the collective.
+        """
+        pynccl_comm = self.pynccl_comm
+        if pynccl_comm is None or pynccl_comm.disabled:
+            torch.distributed.all_reduce(input_, group=self.device_group)
+            return input_
+        out = pynccl_comm.all_reduce(input_, out_tensor=input_)
+        if out is None:
+            torch.distributed.all_reduce(input_, group=self.device_group)
+        return input_
+
     def custom_all_gather(self, input_: torch.Tensor) -> torch.Tensor | None:
         ca_comm = self.ca_comm
         if ca_comm is None:

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -687,6 +687,14 @@ class GroupCoordinator:
         else:
             return self._all_reduce_out_place(input_)
 
+    def all_reduce_in_place(self, input_: torch.Tensor) -> torch.Tensor:
+        """All-reduce a tensor whose input storage may hold the result."""
+        if self.world_size == 1:
+            return input_
+        if self.device_communicator is None:
+            raise ValueError("No device communicator found")
+        return self.device_communicator.all_reduce_in_place(input_)
+
     def _all_reduce_out_place(self, input_: torch.Tensor) -> torch.Tensor:
         if self.device_communicator is None:
             raise ValueError("No device communicator found")


### PR DESCRIPTION
## Behavior

Tensor-parallel callers can explicitly all-reduce into input storage through
`tensor_model_parallel_all_reduce_in_place()`. The API delegates through
`GroupCoordinator` and the active device communicator.

CUDA execution passes the input tensor as PyNCCL's output tensor. The torch
distributed fallback also reduces the input tensor directly. A single-rank
group returns the input unchanged.

## Technical reason

The functional all-reduce custom operator must return non-aliased storage and
therefore allocates an output tensor. A caller that has proven its input dead
after the collective can avoid that allocation, but the mutating lifetime
contract must remain explicit and must not replace the safe functional API.

## Compatibility

- `tensor_model_parallel_all_reduce()` and its custom-operator behavior are
  unchanged.
- In-place use is opt-in and requires the caller to own a dead input tensor.
- Device communicators retain a torch distributed fallback when PyNCCL is
  disabled or unavailable.
- The API is model-independent and supports any tensor-parallel world size
  accepted by the active communicator.

## Validation

- Five CPU unit tests verify TP delegation, single-rank identity, device
  communicator delegation, PyNCCL output aliasing, and the torch distributed
  fallback.
- A two-GPU process test used NCCL 2.31.2 to sum rank values through
  `PyNcclCommunicator.all_reduce(input, out_tensor=input)`. Both ranks produced
  the exact expected result and retained the original storage pointer.
- Ruff formatting, Ruff lint, Python bytecode compilation, and `git diff
  --check` pass.
