### PR TITLE
[II] Dispatch B12X all-reduce through TP16

### DIFF
--- a/tests/distributed/test_b12x_fused_all_reduce.py
+++ b/tests/distributed/test_b12x_fused_all_reduce.py
@@ -218,13 +218,23 @@ def test_b12x_oneshot_defaults_to_stream_isolation(
     assert not envs.environment_variables["VLLM_PCIE_ONESHOT_SINGLE_CHANNEL"]()
 
 
-def test_b12x_pool_prepares_single_stable_eager_owner(
+@pytest.mark.parametrize(
+    ("world_size", "algorithm", "supports_all_peer_auxiliary"),
+    [(2, "oneshot", True), (16, "hierarchical", False)],
+)
+def test_b12x_dispatcher_prepares_single_stable_eager_owner(
     monkeypatch: pytest.MonkeyPatch,
+    world_size: int,
+    algorithm: str,
+    supports_all_peer_auxiliary: bool,
 ) -> None:
     captured = {}
     runtime = MagicMock()
+    runtime.algorithm = algorithm
+    runtime.supports_all_peer_auxiliary = supports_all_peer_auxiliary
+    dma_min_bytes = MagicMock(return_value=None)
 
-    class FakePool:
+    class FakeDispatcher:
         @classmethod
         def from_exchange_group(cls, **kwargs):
             captured.update(kwargs)
@@ -243,10 +253,14 @@ def test_b12x_pool_prepares_single_stable_eager_owner(
     monkeypatch.setattr(
         custom_all_reduce,
         "in_the_same_node_as",
-        lambda group, source_rank=0: [True, True],
+        lambda group, source_rank=0: [True] * world_size,
     )
     monkeypatch.setattr(custom_all_reduce.dist, "get_rank", lambda group=None: 0)
-    monkeypatch.setattr(custom_all_reduce.dist, "get_world_size", lambda group=None: 2)
+    monkeypatch.setattr(
+        custom_all_reduce.dist,
+        "get_world_size",
+        lambda group=None: world_size,
+    )
     monkeypatch.setattr(custom_all_reduce.dist, "all_gather", fake_all_gather)
     monkeypatch.setattr(
         custom_all_reduce.dist, "all_reduce", lambda *args, **kwargs: None
@@ -264,13 +278,13 @@ def test_b12x_pool_prepares_single_stable_eager_owner(
     )
     monkeypatch.setattr(
         custom_all_reduce,
-        "_load_b12x_pcie_oneshot_pool",
-        lambda: FakePool,
+        "_load_b12x_pcie_allreduce",
+        lambda: FakeDispatcher,
     )
     monkeypatch.setattr(
         custom_all_reduce,
         "_b12x_pcie_dma_min_bytes",
-        lambda: None,
+        dma_min_bytes,
     )
     monkeypatch.setattr(
         custom_all_reduce.current_platform,
@@ -331,6 +345,10 @@ def test_b12x_pool_prepares_single_stable_eager_owner(
     assert captured["max_concurrent_channels"] == 2
     runtime.prepare_channels.assert_called_once_with(("vllm:eager:allreduce",))
     runtime.for_stream.assert_called_once_with(channel_id="vllm:eager:allreduce")
+    assert built.backend_name() == (
+        "B12X_PCIE_ONESHOT" if algorithm == "oneshot" else "B12X_PCIE_HIERARCHICAL"
+    )
+    assert dma_min_bytes.call_count == int(supports_all_peer_auxiliary)
 
 
 def test_b12x_channel_checkpoint_delegates_to_runtime() -> None:

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -118,14 +118,12 @@ def _b12x_pcie_dma_min_bytes() -> int | None:
 
 
 @lru_cache(maxsize=1)
-def _load_b12x_pcie_oneshot_pool() -> Any | None:
+def _load_b12x_pcie_allreduce() -> Any | None:
     try:
-        from b12x.comm.pcie import (
-            OneshotAllReducePool as PCIeOneshotAllReducePool,
-        )
+        from b12x.comm.pcie import AllReduce as PCIeAllReduce
     except Exception:
         return None
-    return PCIeOneshotAllReducePool
+    return PCIeAllReduce
 
 
 @lru_cache(maxsize=1)
@@ -515,12 +513,12 @@ class CustomAllreduce:
                     physical_device_ids,
                 )
                 return
-            pool_cls = (
-                _load_b12x_pcie_oneshot_pool()
+            runtime_cls = (
+                _load_b12x_pcie_allreduce()
                 if pcie_backend == "b12x"
                 else _load_flashinfer_pcie_oneshot_pool()
             )
-            if pool_cls is None:
+            if runtime_cls is None:
                 logger.warning(
                     "%s PCIe custom allreduce was requested, but its runtime "
                     "is unavailable.",
@@ -568,7 +566,7 @@ class CustomAllreduce:
             pcie_runtime = None
             pcie_init_error: Exception | None = None
             try:
-                pcie_runtime = pool_cls.from_exchange_group(
+                pcie_runtime = runtime_cls.from_exchange_group(
                     exchange_group=self.nccl_group,
                     device=self.device,
                     eager_buffer_bytes=pcie_oneshot_buffer_size,
@@ -614,14 +612,25 @@ class CustomAllreduce:
             # Prefill-size DMA allreduce alongside the oneshot. A deployment
             # preflight can tune its crossover or disable it when lossless DMA
             # never beats NCCL on the selected PCIe topology.
+            supports_all_peer_auxiliary = bool(
+                getattr(pcie_runtime, "supports_all_peer_auxiliary", True)
+            )
             dma_min_bytes = (
-                _b12x_pcie_dma_min_bytes() if pcie_backend == "b12x" else None
+                _b12x_pcie_dma_min_bytes()
+                if pcie_backend == "b12x" and supports_all_peer_auxiliary
+                else None
             )
             dma_cls = None if dma_min_bytes is None else _load_b12x_pcie_dma()
             if pcie_backend != "b12x":
                 logger.info(
                     "FlashInfer PCIe IPC handles only tuned one-shot shapes; "
                     "larger allreduces stay on PyNCCL."
+                )
+            elif not supports_all_peer_auxiliary:
+                logger.info(
+                    "B12X PCIe %s all-reduce does not expose the all-peer "
+                    "topology required by DMA; larger tensors use PyNCCL.",
+                    getattr(pcie_runtime, "algorithm", "bounded-degree"),
                 )
             elif dma_min_bytes is None:
                 logger.info(
@@ -678,8 +687,9 @@ class CustomAllreduce:
             if rank == 0:
                 logger.info(
                     "Configured %s PCIe crossovers: "
-                    "oneshot max=%d, fused max=%d, DMA min=%s.",
+                    "algorithm=%s, allreduce max=%d, fused max=%d, DMA min=%s.",
                     pcie_backend,
+                    getattr(pcie_runtime, "algorithm", "oneshot"),
                     self._pcie_allreduce_max_size,
                     self._pcie_fused_add_rms_norm_max_size,
                     dma_min_bytes if dma_min_bytes is not None else "off",
@@ -1017,6 +1027,8 @@ class CustomAllreduce:
         if self._pcie_runtime is not None:
             if self._pcie_backend_name == "flashinfer-ipc":
                 return "FLASHINFER_PCIE_IPC"
+            if getattr(self._pcie_runtime, "algorithm", "oneshot") != "oneshot":
+                return "B12X_PCIE_HIERARCHICAL"
             if self._pcie_dma is not None:
                 return "B12X_PCIE_ONESHOT_DMA"
             return "B12X_PCIE_ONESHOT"


### PR DESCRIPTION
## Behavior

The integrated B12X custom all-reduce backend now selects `b12x.comm.pcie.AllReduce`, whose public dispatcher uses direct oneshot communication through TP8 and bounded-degree four-GPU islands at TP12 and TP16.

The vLLM adapter also:

- disables the auxiliary all-peer DMA runtime when the selected topology cannot map every rank safely;
- reports the selected B12X algorithm in initialization logs;
- reports `B12X_PCIE_HIERARCHICAL` as the active backend for TP12 and TP16.

## Technical reason

Constructing `OneshotAllReducePool` directly requires every rank to map every peer, which exceeds the CUDA peer-connection budget at TP12 and TP16. The B12X public dispatcher bounds peer mappings while preserving the existing oneshot path at TP2, TP4, TP6, and TP8.

## Dependency

Requires local-inference-lab/b12x#218, which gives the public dispatcher the named-channel interface already used by vLLM.

## Compatibility

TP2 through TP8 retain the same oneshot runtime, graph owner identities, size cutoffs, fused all-reduce behavior, and optional DMA path. FlashInfer IPC and the vLLM C++ custom-all-reduce backends are unchanged.

## Validation

Status: **qualified** against the source-locked CUDA 13.3 / PyTorch 2.13 Kimi-K3 runtime image.

- Ruff and `git diff --check` pass.
- `tests/distributed/test_b12x_fused_all_reduce.py`: 17 passed, including the two-GPU CUDA graph/fusion test.
- Constructor tests cover both the TP2 oneshot dispatcher and the TP16 bounded-degree dispatcher, including DMA eligibility and backend reporting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved B12X PCIe all-reduce initialization with support for oneshot and hierarchical execution modes.
  - Backend status now clearly identifies the active B12X execution mode, including auxiliary DMA support.

- **Bug Fixes**
  - Improved handling of unsupported topology configurations by falling back to PyNCCL.
  - Updated diagnostics provide clearer information when B12X capabilities are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->