### PR TITLE
[II] Keep MLA cache groups causally uniform

### DIFF
--- a/tests/v1/attention/test_mla_noncausal.py
+++ b/tests/v1/attention/test_mla_noncausal.py
@@ -12,7 +12,7 @@ from vllm.model_executor.layers.attention.mla_attention import (
     QueryLenSupport,
 )
 from vllm.v1.attention.backend import CommonAttentionMetadata
-from vllm.v1.kv_cache_interface import MLAAttentionSpec
+from vllm.v1.kv_cache_interface import MLAAttentionSpec, SlidingWindowMLASpec
 
 
 class _NonCausalMLAMetadataBuilder(MLACommonMetadataBuilder[MLACommonMetadata]):
@@ -120,7 +120,30 @@ def test_mla_cache_marker_is_promoted_to_group_capability():
     unmarked = MLAAttentionSpec(**kwargs)
 
     assert MLAAttentionSpec.merge([marked, marked]).non_causal_multi_token_decode
-    assert MLAAttentionSpec.merge([marked, unmarked]).non_causal_multi_token_decode
+    with pytest.raises(AssertionError, match="causal mode"):
+        MLAAttentionSpec.merge([marked, unmarked])
     assert not MLAAttentionSpec.merge(
         [unmarked, unmarked]
     ).non_causal_multi_token_decode
+
+
+def test_sliding_mla_cache_marker_is_a_group_invariant():
+    kwargs = {
+        "block_size": 64,
+        "num_kv_heads": 1,
+        "head_size": 576,
+        "dtype": torch.bfloat16,
+        "sliding_window": 32768,
+    }
+    marked = SlidingWindowMLASpec(
+        **kwargs,
+        non_causal_multi_token_decode=True,
+    )
+    unmarked = SlidingWindowMLASpec(**kwargs)
+
+    merged = SlidingWindowMLASpec.merge([marked, marked])
+    assert merged.non_causal_multi_token_decode
+    assert merged.is_uniform_with_collection({"first": marked, "second": marked})
+    assert not merged.is_uniform_with_collection({"first": marked, "second": unmarked})
+    with pytest.raises(AssertionError, match="causal mode"):
+        SlidingWindowMLASpec.merge([marked, unmarked])

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -533,6 +533,7 @@ class MLAAttentionSpec(FullAttentionSpec):
         block_stride_set = set(spec.indexes_kv_by_block_stride for spec in specs)
         dcp_replicated_set = set(spec.dcp_replicated for spec in specs)
         dcp_kv_shard_count_set = set(spec.dcp_kv_shard_count for spec in specs)
+        non_causal_set = set(spec.non_causal_multi_token_decode for spec in specs)
         assert (
             len(cache_dtype_str_set) == 1
             and len(dtype_set) == 1
@@ -542,10 +543,11 @@ class MLAAttentionSpec(FullAttentionSpec):
             and len(block_stride_set) == 1
             and len(dcp_replicated_set) == 1
             and len(dcp_kv_shard_count_set) == 1
+            and len(non_causal_set) == 1
         ), (
             "All attention layers in the same KV cache group must use the same "
             "dtype, quantization method, compress ratio, model version, and "
-            "KV block stride indexing, and DCP replication mode."
+            "KV block stride indexing, DCP replication mode, and causal mode."
         )
         merged_spec = cls(
             block_size=specs[0].block_size,
@@ -558,9 +560,7 @@ class MLAAttentionSpec(FullAttentionSpec):
             cache_dtype_str=cache_dtype_str_set.pop(),
             compress_ratio=compress_ratio_set.pop(),
             model_version=model_version_set.pop(),
-            non_causal_multi_token_decode=any(
-                spec.non_causal_multi_token_decode for spec in specs
-            ),
+            non_causal_multi_token_decode=non_causal_set.pop(),
             dcp_replicated=dcp_replicated_set.pop(),
             dcp_kv_shard_count=dcp_kv_shard_count_set.pop(),
         )
@@ -750,6 +750,9 @@ class SlidingWindowMLASpec(SlidingWindowSpec):
     compress_ratio: int = 1
     model_version: str | None = None
     dcp_sharded: bool = False
+    # Parallel draft blocks are flattened into independent decode rows by MLA
+    # backends. Preserve that execution property when the cache is windowed.
+    non_causal_multi_token_decode: bool = False
 
     def __post_init__(self):
         _apply_alignment_padding(self)
@@ -812,6 +815,7 @@ class SlidingWindowMLASpec(SlidingWindowSpec):
         block_stride_set = set(spec.indexes_kv_by_block_stride for spec in specs)
         dcp_replicated_set = set(spec.dcp_replicated for spec in specs)
         dcp_sharded_set = set(spec.dcp_sharded for spec in specs)
+        non_causal_set = set(spec.non_causal_multi_token_decode for spec in specs)
         assert (
             len(cache_dtype_str_set) == 1
             and len(dtype_set) == 1
@@ -822,11 +826,12 @@ class SlidingWindowMLASpec(SlidingWindowSpec):
             and len(block_stride_set) == 1
             and len(dcp_replicated_set) == 1
             and len(dcp_sharded_set) == 1
+            and len(non_causal_set) == 1
         ), (
             "All attention layers in the same KV cache group must use the same "
             "dtype, quantization method, compress ratio, model version, "
             "sliding window size, KV block stride indexing, and DCP sharding "
-            "mode."
+            "mode and causal mode."
         )
         return cls(
             block_size=specs[0].block_size,
@@ -842,6 +847,7 @@ class SlidingWindowMLASpec(SlidingWindowSpec):
             compress_ratio=compress_ratio_set.pop(),
             model_version=model_version_set.pop(),
             dcp_sharded=dcp_sharded_set.pop(),
+            non_causal_multi_token_decode=non_causal_set.pop(),
         )
 
     def is_uniform_with_collection(
@@ -852,6 +858,7 @@ class SlidingWindowMLASpec(SlidingWindowSpec):
             and spec.sliding_window == self.sliding_window
             and spec.dcp_replicated == self.dcp_replicated
             and spec.dcp_sharded == self.dcp_sharded
+            and spec.non_causal_multi_token_decode == self.non_causal_multi_token_decode
             for spec in kv_cache_specs.values()
         )
 


### PR DESCRIPTION
## Behavior

MLA cache groups now require every member to use the same causal execution mode. `SlidingWindowMLASpec` stores `non_causal_multi_token_decode`, preserves it through merges, and includes it in cache-uniformity checks.

## Technical reason

Parallel speculative draft blocks use non-causal multi-token decode, while ordinary target decode remains causal. Merging those layers into one cache specification by promoting a single non-causal marker changes the execution contract of the causal members. Cache grouping must preserve this property rather than combine incompatible layers.

## Compatibility

Groups whose MLA layers are all causal or all non-causal retain their existing layout. A mixed group now fails during specification merging with an explicit causal-mode invariant instead of producing an ambiguous merged specification. Full-attention and sliding-window MLA use the same rule.

## Validation

Status: **qualified**.

- Ruff and `git diff --check` pass.
- `tests/v1/attention/test_mla_noncausal.py`: 7 passed.
- Sliding-window cache specification and registry checks: 5 passed.
