### PR TITLE
[II] Keep recurrent state on the hybrid cache planner

### DIFF
--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -2857,6 +2857,16 @@ def test_group_and_unify_kv_cache_specs_uniform_page_size_returns_none():
     assert group_and_unify_kv_cache_specs(specs) is None
 
 
+def test_group_and_unify_kv_cache_specs_defers_recurrent_state():
+    specs = {
+        "mla.0": new_mla_spec(),
+        "swa.0": new_bf16_swa_mla_spec(head_size=1024),
+        "state.0": new_mamba_spec(),
+    }
+
+    assert group_and_unify_kv_cache_specs(specs) is None
+
+
 def test_group_and_unify_kv_cache_specs_mixed_page_size_groups():
     # DeepseekV4-style: differing page sizes across MLA and sliding-window MLA
     # layers do require tuple packing, so grouping must still be produced.

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1745,6 +1745,12 @@ def group_and_unify_kv_cache_specs(
     Group the KV cache specs and unify each group into one UniformTypeKVCacheSpecs.
     Currently, this is only used for DeepseekV4.
     """
+    # Recurrent state pages require the generic hybrid-cache planner. Packing
+    # them into the heterogeneous MLA tuple layout would charge the larger
+    # state page to every packed block and reduce attention-cache capacity.
+    if any(isinstance(spec, MambaSpec) for spec in kv_cache_spec.values()):
+        return None
+
     has_swa = any(
         isinstance(spec, SlidingWindowMLASpec) for spec in kv_cache_spec.values()
     )


### PR DESCRIPTION
## Behavior

`group_and_unify_kv_cache_specs` now defers every cache collection containing recurrent `MambaSpec` state to the generic hybrid-cache planner.

## Technical reason

The heterogeneous MLA tuple-packing path is designed for attention pages whose block geometry can be unified. A recurrent state page has fixed state shapes rather than attention-token geometry. Including it in the packed layout charges the largest recurrent page to each packed block and can remove most of the available attention-cache capacity.

## Compatibility

DeepSeek-V4 cache collections containing only attention specifications retain heterogeneous tuple packing. Hybrid models containing recurrent state use the existing uniform-page-size grouping path.

## Validation

Status: **qualified**.

- Ruff and `git diff --check` pass.
- Recurrent-state and heterogeneous-MLA grouping tests: 7 passed.
- The focused `group_and_unify_kv_cache_specs` suite: 4 passed.
