### PR TITLE
[II] Bound Kimi hybrid cache group width

### DIFF
--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -2857,6 +2857,74 @@ def test_group_and_unify_kv_cache_specs_uniform_page_size_returns_none():
     assert group_and_unify_kv_cache_specs(specs) is None
 
 
+def _k3_hybrid_cache_specs() -> dict[str, KVCacheSpec]:
+    recurrent = MambaSpec(
+        block_size=16,
+        shapes=((9216,),),
+        dtypes=(torch.bfloat16,),
+    )
+    draft = SlidingWindowMLASpec(
+        block_size=16,
+        num_kv_heads=1,
+        head_size=576,
+        dtype=torch.bfloat16,
+        sliding_window=32768,
+        non_causal_multi_token_decode=True,
+    )
+    assert recurrent.page_size_bytes == draft.page_size_bytes
+    return {
+        **{f"state.{index}": recurrent for index in range(8)},
+        **{f"draft.{index}": draft for index in range(6)},
+    }
+
+
+def test_uniform_page_group_size_override_is_explicit():
+    specs = _k3_hybrid_cache_specs()
+
+    groups = kv_cache_utils._get_kv_cache_groups_uniform_page_size(
+        specs,
+        group_size_override=2,
+    )
+
+    assert len(groups) == 7
+    assert all(len(group.layer_names) == 2 for group in groups)
+    with pytest.raises(ValueError, match="must be positive"):
+        kv_cache_utils._get_kv_cache_groups_uniform_page_size(
+            specs,
+            group_size_override=0,
+        )
+
+
+@pytest.mark.parametrize(
+    ("model_type", "expected_groups"), [("kimi_k3", 7), ("other", 2)]
+)
+def test_k3_hybrid_group_size_is_model_and_cache_specific(
+    monkeypatch: pytest.MonkeyPatch,
+    model_type: str,
+    expected_groups: int,
+):
+    config = SimpleNamespace(
+        scheduler_config=SimpleNamespace(disable_hybrid_kv_cache_manager=False),
+        parallel_config=SimpleNamespace(
+            decode_context_parallel_size=1,
+            prefill_context_parallel_size=1,
+        ),
+        model_config=SimpleNamespace(
+            hf_config=SimpleNamespace(model_type=model_type),
+        ),
+    )
+    monkeypatch.setenv("VLLM_K3_KV_GROUP_SIZE", "2")
+    monkeypatch.setattr(
+        kv_cache_utils,
+        "group_and_unify_kv_cache_specs",
+        lambda *args, **kwargs: None,
+    )
+
+    groups = get_kv_cache_groups(config, _k3_hybrid_cache_specs())
+
+    assert len(groups) == expected_groups
+
+
 def test_group_and_unify_kv_cache_specs_mixed_page_size_groups():
     # DeepseekV4-style: differing page sizes across MLA and sliding-window MLA
     # layers do require tuple packing, so grouping must still be produced.

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -64,6 +64,7 @@ if TYPE_CHECKING:
     VLLM_NVFP4_MLA_SCALES_FILE: str = ""
     VLLM_B12X_ABSORB_BMM: bool = False
     VLLM_DSPARK_FP8_DRAFT_HEAD: bool = False
+    VLLM_K3_KV_GROUP_SIZE: int = 0
     VLLM_USE_B12X_WO_PROJECTION: bool = False
     VLLM_USE_B12X_MOE: bool = False
     VLLM_NF3_GRID188_DECODE: bool = True
@@ -1138,6 +1139,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_DSPARK_FP8_DRAFT_HEAD": lambda: bool(
         int(os.getenv("VLLM_DSPARK_FP8_DRAFT_HEAD", "0"))
     ),
+    # Bound the number of physical Kimi-K3 layers sharing each hybrid-cache
+    # block table. Zero preserves the general grouping heuristic.
+    "VLLM_K3_KV_GROUP_SIZE": lambda: int(os.getenv("VLLM_K3_KV_GROUP_SIZE", "0")),
     # Use b12x for the DeepSeek V4 WO-A/WO-B fused projection.
     # This is separate from the generic FP8 linear switch for perf isolation.
     "VLLM_USE_B12X_WO_PROJECTION": lambda: bool(

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1181,6 +1181,7 @@ def is_kv_cache_type_attention_free(kv_cache_spec: dict[str, KVCacheSpec]) -> bo
 
 def _get_kv_cache_groups_uniform_page_size(
     kv_cache_spec: dict[str, KVCacheSpec],
+    group_size_override: int | None = None,
 ) -> list[KVCacheGroupSpec]:
     """
     Generates the KV cache groups for hybrid models with multiple
@@ -1240,9 +1241,16 @@ def _get_kv_cache_groups_uniform_page_size(
     memory per block is the same for all groups.
 
     Args:
-        kv_cache_spec: The KVCacheSpec of each attention layer in the model
+        kv_cache_spec: KV-cache specification for each attention layer.
+        group_size_override: Number of physical layers assigned to every
+            cache group. When omitted, the grouping heuristic derives the
+            size from the attention-layer counts.
+
     Returns:
-        The generated KVCacheGroupSpecs
+        Cache-group specifications with a uniform physical page size.
+
+    Raises:
+        ValueError: If ``group_size_override`` is not positive.
     """
     # Group all layers by kv_cache_spec.
     # E.g., 2 full attention layers and 3 sliding window attention layers,
@@ -1296,6 +1304,13 @@ def _get_kv_cache_groups_uniform_page_size(
         # layers while accommodating speculative decoding drafters that add
         # extra layers to one attention type.
         group_size = max_num_layers
+    if group_size_override is not None:
+        if group_size_override <= 0:
+            raise ValueError(
+                "KV cache group size override must be positive, got "
+                f"{group_size_override}."
+            )
+        group_size = group_size_override
     grouped_layers = []
     for layers in layer_buckets:
         num_padding_layers = group_size - len(layers) % group_size
@@ -2064,7 +2079,30 @@ def get_kv_cache_groups(
         if fallback_groups is None:
             raise
         return fallback_groups
-    groups = _get_kv_cache_groups_uniform_page_size(filtered_spec)
+    model_type = getattr(vllm_config.model_config.hf_config, "model_type", None)
+    k3_group_size = envs.VLLM_K3_KV_GROUP_SIZE
+    use_k3_group_size_override = (
+        k3_group_size > 0
+        and model_type == "kimi_k3"
+        and any(isinstance(spec, MambaSpec) for spec in filtered_spec.values())
+        and any(
+            isinstance(spec, SlidingWindowMLASpec)
+            and spec.non_causal_multi_token_decode
+            for spec in filtered_spec.values()
+        )
+    )
+    if use_k3_group_size_override:
+        groups = _get_kv_cache_groups_uniform_page_size(
+            filtered_spec, group_size_override=k3_group_size
+        )
+        logger.info_once(
+            "Kimi-K3 uses hybrid KV group size %d (%d groups) to reduce "
+            "cache padding and block-table overhead.",
+            k3_group_size,
+            len(groups),
+        )
+    else:
+        groups = _get_kv_cache_groups_uniform_page_size(filtered_spec)
 
     # Add hidden-state layers back with page aligned to the common page.
     if hidden_specs:


### PR DESCRIPTION
## Behavior

Kimi-K3 deployments can set `VLLM_K3_KV_GROUP_SIZE` to a positive number of physical layers per hybrid KV-cache group. The override applies only when all of these conditions hold:

- the model type is `kimi_k3`;
- recurrent state is present;
- a sliding-window MLA cache is marked for non-causal multi-token decode.

Zero preserves the general grouping heuristic. Invalid direct API overrides fail with `ValueError`.

## Technical reason

Kimi-K3 combines recurrent state with a rolling speculative-draft MLA cache. The general layer-count heuristic can create wide groups whose padding and block-table allocation consume memory reserved for the target context. An explicit group width lets the deployment choose the measured cache layout without changing cache semantics for other models.

## Dependencies

- local-inference-lab/vllm#334 defines the sliding-window MLA non-causal marker used by the scope guard. This pull request is stacked on #334.
- local-inference-lab/vllm#335 keeps recurrent state on the generic hybrid planner, where this group-width selection is applied.

## Compatibility

The default value is zero. Models other than Kimi-K3, Kimi-K3 without recurrent state, and Kimi-K3 without a non-causal sliding-window draft retain the existing grouping heuristic. The setting is independent of TP and DCP world size.

## Validation

Status: **qualified**.

- Ruff and `git diff --check` pass.
- Three focused tests cover explicit grouping, invalid values, Kimi-K3 activation, and non-Kimi isolation.
