### PR TITLE
[II] Bind lazy B12X DCP pools to graph channels

### DIFF
--- a/tests/distributed/test_dcp_a2a.py
+++ b/tests/distributed/test_dcp_a2a.py
@@ -10,7 +10,7 @@ Tests cover:
 
 import importlib.util
 import math
-from contextlib import contextmanager, nullcontext
+from contextlib import ExitStack, contextmanager, nullcontext
 from typing import Any
 
 import multiprocess as mp
@@ -690,6 +690,73 @@ def test_b12x_dcp_capture_rejects_missing_semantic_id(monkeypatch):
         pass
 
 
+def test_b12x_pool_initialized_inside_graph_context_joins_graph_channel(monkeypatch):
+    from vllm.v1.attention.ops import dcp_alltoall
+
+    events: list[Any] = []
+
+    class _FakePool:
+        @classmethod
+        def from_exchange_group(cls, **kwargs):
+            events.append(("create", kwargs["exchange_group"]))
+            return cls()
+
+        def prepare_channels(self, channel_ids):
+            events.append(("prepare", tuple(channel_ids)))
+
+        def for_stream(self, *, channel_id):
+            events.append(("eager", channel_id))
+
+        @contextmanager
+        def capture(self, *, stream, channel_id):
+            events.append(("enter", stream, channel_id))
+            try:
+                yield
+            finally:
+                events.append(("exit", stream, channel_id))
+
+    device_group = object()
+    group = _FakeCPGroup(2, device_group)  # type: ignore[arg-type]
+    stream = object()
+    monkeypatch.setattr(dcp_alltoall, "_B12X_DCP_A2A_POOLS", {})
+    monkeypatch.setattr(dcp_alltoall, "_B12X_DCP_A2A_DISABLED", set())
+    monkeypatch.setattr(dcp_alltoall, "_B12X_DCP_ACTIVE_CAPTURE", {})
+    monkeypatch.setattr(dcp_alltoall, "_load_b12x_dcp_a2a_pool", lambda: _FakePool)
+    monkeypatch.setattr(dcp_alltoall, "_b12x_dcp_init_failed", lambda *args: False)
+    monkeypatch.setattr(
+        dcp_alltoall.torch.cuda,
+        "is_current_stream_capturing",
+        lambda: False,
+    )
+
+    with dcp_alltoall.capture_b12x_dcp_a2a(
+        group,  # type: ignore[arg-type]
+        stream,
+        channel_id="vllm:target:decode",
+    ):
+        pool = dcp_alltoall._get_b12x_dcp_a2a_pool(
+            group,  # type: ignore[arg-type]
+            device=torch.device("cuda:0"),
+            total_heads=64,
+            head_dim=512,
+            query_head_dim=576,
+            max_batch_size=64,
+        )
+        assert pool is not None
+        assert (
+            dcp_alltoall._b12x_dcp_channel_id(group)  # type: ignore[arg-type]
+            == "vllm:target:decode"
+        )
+
+    assert dcp_alltoall._b12x_dcp_channel_id(group) == "vllm:eager:dcp"  # type: ignore[arg-type]
+    assert events == [
+        ("create", device_group),
+        ("prepare", ("vllm:eager:dcp", "vllm:target:decode")),
+        ("enter", stream, "vllm:target:decode"),
+        ("exit", stream, "vllm:target:decode"),
+    ]
+
+
 def test_b12x_dcp_channel_rollback_restores_existing_and_closes_new_pools(
     monkeypatch,
 ):
@@ -1043,6 +1110,23 @@ def test_b12x_lse_reduce_honors_token_cap(monkeypatch: pytest.MonkeyPatch):
     assert created["max_batch_size"] == 4
     assert created["channel_id"] == "vllm:eager:dcp"
 
+    monkeypatch.setattr(
+        dcp_alltoall,
+        "_B12X_DCP_ACTIVE_CAPTURE",
+        {id(group.device_group): ("vllm:target:decode", None, ExitStack())},
+    )
+    result = dcp_alltoall._try_b12x_dcp_lse_reduce(
+        out,
+        lse,
+        group,  # type: ignore[arg-type]
+        return_lse=False,
+        is_lse_base_on_e=True,
+        max_batch_size=8192,
+        query_head_dim=64,
+    )
+    assert result is sentinel
+    assert created["channel_id"] == "vllm:target:decode"
+
     out_large = torch.zeros(8, 16, 64, dtype=torch.bfloat16, device="cuda")
     lse_large = torch.zeros(8, 16, dtype=torch.float32, device="cuda")
     result = dcp_alltoall._try_b12x_dcp_lse_reduce(
@@ -1091,6 +1175,20 @@ def test_b12x_query_gather_honors_token_cap(monkeypatch: pytest.MonkeyPatch):
     assert result is sentinel
     assert created["max_batch_size"] == 4
     assert created["channel_id"] == "vllm:eager:dcp"
+
+    monkeypatch.setattr(
+        dcp_alltoall,
+        "_B12X_DCP_ACTIVE_CAPTURE",
+        {id(group.device_group): ("vllm:target:decode", None, ExitStack())},
+    )
+    result = dcp_alltoall._try_b12x_dcp_all_gather_heads(
+        small,
+        group,  # type: ignore[arg-type]
+        max_batch_size=8192,
+        output_head_dim=64,
+    )
+    assert result is sentinel
+    assert created["channel_id"] == "vllm:target:decode"
 
     large = torch.zeros(8, 8, 64, dtype=torch.bfloat16, device="cuda")
     result = dcp_alltoall._try_b12x_dcp_all_gather_heads(

--- a/vllm/v1/attention/ops/dcp_alltoall.py
+++ b/vllm/v1/attention/ops/dcp_alltoall.py
@@ -42,14 +42,24 @@ logger = init_logger(__name__)
 
 _B12X_DCP_A2A_POOLS: dict[tuple[int, int, int, int, int, int], Any] = {}
 _B12X_DCP_A2A_DISABLED: set[tuple[int, int, int, int, int, int]] = set()
-# DCP likewise has one stable eager scheduler owner.  Graph target/draft/encoder
-# identities are supplied separately by their GraphCaptureContext.
 _B12X_DCP_EAGER_CHANNEL_ID = "vllm:eager:dcp"
 _B12X_DCP_MAX_CONCURRENT_CHANNELS = 2
+# A pool initialized after a graph context opens must join that graph before
+# its first operation. Each entry is keyed by the process-group identity and
+# owns the graph's semantic channel, stream, and cleanup stack.
+_B12X_DCP_ACTIVE_CAPTURE: dict[int, tuple[str, Any, ExitStack]] = {}
 _DCP_A2A_GRAPH_BUFFERS: dict[
     tuple[tuple[int, ...], torch.device, torch.dtype],
     tuple[torch.Tensor, torch.Tensor],
 ] = {}
+
+
+def _b12x_dcp_channel_id(cp_group: GroupCoordinator) -> str:
+    """Return the B12X channel owned by the group's active execution mode."""
+    active = _B12X_DCP_ACTIVE_CAPTURE.get(id(cp_group.device_group))
+    if active is not None:
+        return active[0]
+    return _B12X_DCP_EAGER_CHANNEL_ID
 
 
 def _is_supported_bhd_layout(tensor: torch.Tensor) -> bool:
@@ -135,8 +145,16 @@ def _get_b12x_dcp_a2a_pool(
             single_channel=False,
             max_concurrent_channels=_B12X_DCP_MAX_CONCURRENT_CHANNELS,
         )
-        pool.prepare_channels((_B12X_DCP_EAGER_CHANNEL_ID,))
-        pool.for_stream(channel_id=_B12X_DCP_EAGER_CHANNEL_ID)
+        active = _B12X_DCP_ACTIVE_CAPTURE.get(id(cp_group.device_group))
+        if active is None:
+            pool.prepare_channels((_B12X_DCP_EAGER_CHANNEL_ID,))
+            pool.for_stream(channel_id=_B12X_DCP_EAGER_CHANNEL_ID)
+        else:
+            active_channel, active_stream, active_stack = active
+            pool.prepare_channels((_B12X_DCP_EAGER_CHANNEL_ID, active_channel))
+            active_stack.enter_context(
+                pool.capture(stream=active_stream, channel_id=active_channel)
+            )
     except Exception as exc:
         init_error = exc
 
@@ -198,15 +216,27 @@ def capture_b12x_dcp_a2a(
         ),
         key=lambda item: item[0][1:],
     )
-    if matching_pools and channel_id is None:
-        raise RuntimeError(
-            "distributed PCIe DCP graph capture requires an explicit semantic "
-            "channel_id"
-        )
-    with ExitStack() as stack:
-        for _, pool in matching_pools:
-            stack.enter_context(pool.capture(stream=stream, channel_id=channel_id))
+    if channel_id is None:
+        if matching_pools or envs.VLLM_USE_B12X_DCP_A2A:
+            raise RuntimeError(
+                "distributed PCIe DCP graph capture requires an explicit "
+                "semantic channel_id"
+            )
         yield
+        return
+
+    previous_active = _B12X_DCP_ACTIVE_CAPTURE.get(group_id)
+    try:
+        with ExitStack() as stack:
+            _B12X_DCP_ACTIVE_CAPTURE[group_id] = (channel_id, stream, stack)
+            for _, pool in matching_pools:
+                stack.enter_context(pool.capture(stream=stream, channel_id=channel_id))
+            yield
+    finally:
+        if previous_active is None:
+            _B12X_DCP_ACTIVE_CAPTURE.pop(group_id, None)
+        else:
+            _B12X_DCP_ACTIVE_CAPTURE[group_id] = previous_active
 
 
 def checkpoint_b12x_dcp_a2a_channels(
@@ -326,7 +356,7 @@ def _try_b12x_dcp_lse_reduce(
         cp_attn_lse,
         out=reduced,
         is_lse_base_on_e=is_lse_base_on_e,
-        channel_id=_B12X_DCP_EAGER_CHANNEL_ID,
+        channel_id=_b12x_dcp_channel_id(cp_group),
     )
 
 
@@ -379,7 +409,7 @@ def _try_b12x_dcp_all_gather_heads(
         return None
     return pool.all_gather_heads(
         local_input,
-        channel_id=_B12X_DCP_EAGER_CHANNEL_ID,
+        channel_id=_b12x_dcp_channel_id(cp_group),
     )
 
 


### PR DESCRIPTION
## Status

Qualified.

## Behavior

B12X DCP pools initialized after a CUDA graph context opens join that graph's semantic channel before their first operation. LSE reduce-scatter and query-head gather select the channel associated with their process group; eager execution continues to use `vllm:eager:dcp`.

## Technical reason

Projection geometry can create a B12X pool after the graph-owner context has already entered. Binding only the pools present at context entry leaves such a pool on the eager channel, which violates B12X graph ownership and prevents safe graph replay.

## Compatibility

The change is generic to B12X DCP collectives and does not alter model geometry, supported world sizes, tensor formats, numerical operations, or NCCL fallback behavior. It depends on the graph-owner integration in #324.

## Validation

- Ruff formatting and checks pass.
- `git diff --check` passes.
- 37 relevant tests from `tests/distributed/test_dcp_a2a.py` pass in the CUDA 13.3/PyTorch 2.13 Kimi-K3 image.
- Four focused tests cover pool creation inside graph context, active channel selection for LSE reduction and query gather, existing-pool capture, and eager-channel preservation.

The remaining full-file test categories are outside this change: packed-LSE dtype expectations, NCCL tests requiring a larger Docker shared-memory allocation, and a test for the removed B12X `_load_extension` symbol.