### PR TITLE
[II] Enable B12X DCP collectives at world size 16

### DIFF
--- a/tests/distributed/test_dcp_a2a.py
+++ b/tests/distributed/test_dcp_a2a.py
@@ -1064,7 +1064,10 @@ def test_group_capture_forwards_semantic_id_to_custom_allreduce(monkeypatch):
 
 
 @pytest.mark.skipif(torch.accelerator.device_count() < 1, reason="CUDA is required.")
-def test_b12x_lse_reduce_honors_token_cap(monkeypatch: pytest.MonkeyPatch):
+@pytest.mark.parametrize("world_size", [4, 16])
+def test_b12x_lse_reduce_honors_token_cap(
+    monkeypatch: pytest.MonkeyPatch, world_size: int
+):
     from vllm.v1.attention.ops import dcp_alltoall
 
     monkeypatch.setenv("VLLM_USE_B12X_DCP_A2A", "1")
@@ -1092,7 +1095,7 @@ def test_b12x_lse_reduce_honors_token_cap(monkeypatch: pytest.MonkeyPatch):
         return _FakePool()
 
     monkeypatch.setattr(dcp_alltoall, "_get_b12x_dcp_a2a_pool", fake_get_pool)
-    group = _FakeCPGroup(4, None)  # type: ignore[arg-type]
+    group = _FakeCPGroup(world_size, None)  # type: ignore[arg-type]
 
     out = torch.zeros(4, 16, 64, dtype=torch.bfloat16, device="cuda")
     lse = torch.zeros(4, 16, dtype=torch.float32, device="cuda")
@@ -1143,7 +1146,10 @@ def test_b12x_lse_reduce_honors_token_cap(monkeypatch: pytest.MonkeyPatch):
 
 
 @pytest.mark.skipif(torch.accelerator.device_count() < 1, reason="CUDA is required.")
-def test_b12x_query_gather_honors_token_cap(monkeypatch: pytest.MonkeyPatch):
+@pytest.mark.parametrize("world_size", [4, 16])
+def test_b12x_query_gather_honors_token_cap(
+    monkeypatch: pytest.MonkeyPatch, world_size: int
+):
     from vllm.v1.attention.ops import dcp_alltoall
 
     monkeypatch.setenv("VLLM_USE_B12X_DCP_A2A", "1")
@@ -1163,7 +1169,7 @@ def test_b12x_query_gather_honors_token_cap(monkeypatch: pytest.MonkeyPatch):
         return _FakePool()
 
     monkeypatch.setattr(dcp_alltoall, "_get_b12x_dcp_a2a_pool", fake_get_pool)
-    group = _FakeCPGroup(4, None)  # type: ignore[arg-type]
+    group = _FakeCPGroup(world_size, None)  # type: ignore[arg-type]
 
     small = torch.zeros(4, 8, 64, dtype=torch.bfloat16, device="cuda")
     result = dcp_alltoall._try_b12x_dcp_all_gather_heads(
@@ -1320,6 +1326,40 @@ def test_warmup_skips_unsupported_world_size(monkeypatch: pytest.MonkeyPatch):
         head_dim=512,
         query_head_dim=576,
     )
+
+
+def test_warmup_accepts_dcp16_geometry(monkeypatch: pytest.MonkeyPatch):
+    from vllm.v1.attention.ops import dcp_alltoall
+
+    monkeypatch.setenv("VLLM_USE_B12X_DCP_A2A", "1")
+    calls: list[tuple[str, tuple[int, ...]]] = []
+
+    def gather(local_input, *args, **kwargs):
+        calls.append(("gather", tuple(local_input.shape)))
+        return torch.empty(1)
+
+    def reduce(partial_output, *args, **kwargs):
+        calls.append(("reduce", tuple(partial_output.shape)))
+        return torch.empty(1)
+
+    monkeypatch.setattr(dcp_alltoall, "_try_b12x_dcp_all_gather_heads", gather)
+    monkeypatch.setattr(dcp_alltoall, "_try_b12x_dcp_lse_reduce", reduce)
+    group = _FakeCPGroup(16, None)  # type: ignore[arg-type]
+
+    dcp_alltoall.warmup_b12x_dcp_a2a(
+        group,  # type: ignore[arg-type]
+        device=torch.device("cpu"),
+        dtype=torch.bfloat16,
+        max_batch_size=8192,
+        total_heads=96,
+        head_dim=512,
+        query_head_dim=576,
+    )
+
+    assert calls == [
+        ("gather", (1, 6, 576)),
+        ("reduce", (1, 96, 512)),
+    ]
 
 
 class TestPackedA2AKernels:

--- a/vllm/v1/attention/ops/dcp_alltoall.py
+++ b/vllm/v1/attention/ops/dcp_alltoall.py
@@ -48,6 +48,7 @@ _B12X_DCP_MAX_CONCURRENT_CHANNELS = 2
 # its first operation. Each entry is keyed by the process-group identity and
 # owns the graph's semantic channel, stream, and cleanup stack.
 _B12X_DCP_ACTIVE_CAPTURE: dict[int, tuple[str, Any, ExitStack]] = {}
+_B12X_DCP_WORLD_SIZES = (2, 4, 8, 16)
 _DCP_A2A_GRAPH_BUFFERS: dict[
     tuple[tuple[int, ...], torch.device, torch.dtype],
     tuple[torch.Tensor, torch.Tensor],
@@ -289,7 +290,7 @@ def _try_b12x_dcp_lse_reduce(
         or not cp_attn_out.is_cuda
         or cp_attn_out.dtype not in (torch.float16, torch.bfloat16)
         or cp_attn_lse.dtype != torch.float32
-        or world_size not in (2, 4, 8)
+        or world_size not in _B12X_DCP_WORLD_SIZES
         or cp_attn_out.ndim != 3
         or cp_attn_lse.shape != cp_attn_out.shape[:2]
     ):
@@ -372,7 +373,7 @@ def _try_b12x_dcp_all_gather_heads(
     if (
         not local_input.is_cuda
         or local_input.dtype not in (torch.float16, torch.bfloat16)
-        or world_size not in (2, 4, 8)
+        or world_size not in _B12X_DCP_WORLD_SIZES
         or local_input.ndim != 3
         or not local_input.is_contiguous()
     ):
@@ -447,12 +448,12 @@ def warmup_b12x_dcp_a2a(
     """Create and exercise the B12X DCP channel before CUDA graph capture."""
     if not envs.VLLM_USE_B12X_DCP_A2A:
         return
-    if cp_group.world_size not in (2, 4, 8):
+    if cp_group.world_size not in _B12X_DCP_WORLD_SIZES:
         # The PCIe channel only exists for these world sizes. The runtime
         # dispatchers already fall back to NCCL collectives per call, so an
         # unsupported DCP size (e.g. TP6 with DCP3/DCP6) must not fail boot.
         logger.warning_once(
-            "B12X PCIe DCP collectives support world sizes 2/4/8; "
+            "B12X PCIe DCP collectives support world sizes 2/4/8/16; "
             "DCP world size %d uses NCCL collectives instead.",
             cp_group.world_size,
         )


### PR DESCRIPTION
## Status

Qualified.

## Behavior

B12X query-head gather, LSE reduction, and graph warmup accept DCP world sizes 2, 4, 8, and 16. Other world sizes continue to use the existing NCCL fallback.

## Technical reason

B12X `DcpAllToAllPool` supports world size 16, but the vLLM dispatch guards excluded it. The guard prevented TP16/DCP16 serving from selecting the B12X DCP transport even when its tensor geometry satisfied the runtime contract.

## Compatibility

No model-specific geometry, numerical operation, tensor format, channel ownership, or fallback behavior changes. TP2, TP4, and TP8 retain the same path.

## Validation

- Ruff formatting and checks pass.
- `git diff --check` passes.
- 37 relevant tests from `tests/distributed/test_dcp_a2a.py` pass in the CUDA 13.3/PyTorch 2.13 Kimi-K3 image.
- Explicit coverage exercises DCP16 query gather, LSE reduction, and warmup; world size 6 still verifies the NCCL fallback.