### PR TITLE
[II] Pack DCP attention LSE as FP32

### DIFF
--- a/tests/distributed/test_dcp_a2a.py
+++ b/tests/distributed/test_dcp_a2a.py
@@ -369,6 +369,52 @@ class TestLSEWeightedCombine:
         assert _dcp_a2a_lse_pack_dim(torch.float32) == 1
 
 
+def test_a2a_converts_activation_dtype_lse_before_packing(monkeypatch):
+    from vllm.v1.attention.ops import dcp_alltoall
+
+    output = torch.zeros(2, 4, 8, dtype=torch.bfloat16)
+    lse = torch.zeros(2, 4, dtype=torch.bfloat16)
+    send = torch.empty(2, 2, 2, 10, dtype=torch.bfloat16)
+    recv = torch.empty_like(send)
+    result = torch.empty(2, 2, 8, dtype=torch.bfloat16)
+    received: dict[str, torch.dtype] = {}
+
+    monkeypatch.setattr(
+        dcp_alltoall,
+        "_dcp_a2a_send_recv_buffers",
+        lambda *args, **kwargs: (send, recv),
+    )
+
+    def record_pack(_cp_attn_out, cp_attn_lse, *_args, **_kwargs):
+        received["dtype"] = cp_attn_lse.dtype
+
+    class _Work:
+        def wait(self):
+            return None
+
+    monkeypatch.setattr(dcp_alltoall, "_dcp_a2a_pack_send", record_pack)
+    monkeypatch.setattr(
+        dcp_alltoall.dist,
+        "all_to_all_single",
+        lambda *args, **kwargs: _Work(),
+    )
+    monkeypatch.setattr(
+        dcp_alltoall,
+        "_dcp_a2a_unpack_combine",
+        lambda *args, **kwargs: result,
+    )
+    group = _FakeCPGroup(2, object())  # type: ignore[arg-type]
+
+    actual = dcp_alltoall.dcp_a2a_lse_reduce(
+        output,
+        lse,
+        group,  # type: ignore[arg-type]
+    )
+
+    assert actual is result
+    assert received == {"dtype": torch.float32}
+
+
 def test_b12x_dispatch_bypasses_packed_nccl(monkeypatch: pytest.MonkeyPatch):
     from vllm.v1.attention.ops import dcp_alltoall
 
@@ -1159,7 +1205,7 @@ class TestPackedA2AKernels:
         world_size, B, h_per_rank, D = 4, 7, 2, 32
         H = world_size * h_per_rank
         cp_attn_out = torch.randn(B, H, D, device=device, dtype=dtype)
-        cp_attn_lse = torch.randn(B, H, device=device, dtype=dtype)
+        cp_attn_lse = torch.randn(B, H, device=device, dtype=torch.float32)
         lse_pack_dim = _dcp_a2a_lse_pack_dim(dtype)
         send_buffer = torch.empty(
             (world_size, B, h_per_rank, D + lse_pack_dim),
@@ -1355,7 +1401,7 @@ def _distributed_packed_a2a_worker(env: dict[str, str]) -> None:
         lses = torch.stack(
             [t[:, rank * h_per_rank : (rank + 1) * h_per_rank] for t in gathered_lse],
             dim=0,
-        )
+        ).float()
         from vllm.v1.attention.ops.dcp_alltoall import _lse_weighted_combine
 
         expected_out, expected_lse = _lse_weighted_combine(

--- a/vllm/v1/attention/ops/dcp_alltoall.py
+++ b/vllm/v1/attention/ops/dcp_alltoall.py
@@ -709,7 +709,7 @@ def _dcp_a2a_pack_send_kernel(
 
         lse_val = tl.load(
             lse_ptr + batch_idx * lse_stride_B + src_head_idx * lse_stride_H
-        ).to(tl.float32)
+        )
         if LSE_PACK_DIM == 1:
             tl.store(
                 send_ptr + send_base + HEAD_DIM * send_stride_D,
@@ -947,12 +947,13 @@ def dcp_a2a_lse_reduce(
     """
     Combine partial attention outputs across DCP ranks using All-to-All.
 
-    The output and LSE are packed into a single output-dtype buffer, sent
+    The output and FP32 LSE are packed into a single output-dtype buffer, sent
     with one All-to-All, then unpacked and combined with exact LSE weighting.
 
     Args:
         cp_attn_out: [B, H, D] where B=num_tokens, H=total_heads, D=head_dim
-        cp_attn_lse: [B, H] floating-point log-sum-exp values
+        cp_attn_lse: [B, H] floating-point log-sum-exp values; non-FP32 input
+            is converted before bit packing
         cp_group: GroupCoordinator for DCP communication
         ctx: CPTritonContext (unused, for signature compatibility)
         return_lse: If True, also return the combined global LSE
@@ -992,6 +993,10 @@ def dcp_a2a_lse_reduce(
     if H % world_size != 0:
         raise ValueError(f"H={H} must be divisible by DCP world size {world_size}.")
     H_per_rank = H // world_size
+    # The pack kernel preserves the FP32 bit pattern across an output-dtype
+    # transport buffer. Normalize backends that emit LSE in activation dtype.
+    if cp_attn_lse.dtype != torch.float32:
+        cp_attn_lse = cp_attn_lse.to(torch.float32)
     lse_pack_dim = _dcp_a2a_lse_pack_dim(cp_attn_out.dtype)
 
     send_buffer, recv_buffer = _dcp_a2a_send_recv_buffers(


### PR DESCRIPTION
## Status

Qualified.

## Behavior

The DCP all-to-all path converts FP16 or BF16 log-sum-exp tensors to FP32 before packing. The transport preserves each FP32 LSE bit pattern in one FP32 lane or two 16-bit output-dtype lanes, and unpacking returns the global LSE in FP32.

## Technical reason

MLA backends may emit LSE in the activation dtype, while the packed DCP protocol interprets the payload as FP32 bits. Normalizing before the Triton pack kernel gives every backend the same wire representation and prevents dtype-dependent bit reinterpretation.

## Compatibility

The communication topology, output activation dtype, LSE-weighted combination formula, B12X dispatch, and NCCL fallback are unchanged. FP32 LSE inputs avoid an allocation and retain their existing representation.

## Validation

- Ruff formatting and checks pass.
- `git diff --check` passes.
- 13 pack/unpack tests pass across FP16, BF16, and FP32 output buffers.
- Four 4-GPU NCCL tests pass for FP16, BF16, and FP32 outputs, including the vLLM workspace-manager path.
- Distributed tests use a 1 GiB Docker shared-memory allocation required by NCCL 2.31.2.