### PR TITLE
[II] Route oversized B12X DCP batches through AG/RS

### DIFF
--- a/tests/distributed/test_dcp_a2a.py
+++ b/tests/distributed/test_dcp_a2a.py
@@ -421,6 +421,55 @@ def test_b12x_dispatch_bypasses_packed_nccl(monkeypatch: pytest.MonkeyPatch):
     }
 
 
+def test_b12x_large_batch_uses_configured_ag_rs(monkeypatch: pytest.MonkeyPatch):
+    from vllm.v1.attention.ops import common, dcp_alltoall
+
+    monkeypatch.setenv("VLLM_USE_B12X_DCP_A2A", "1")
+    monkeypatch.setenv("VLLM_DCP_A2A_MAX_TOKENS", "4")
+    monkeypatch.setenv("VLLM_DCP_A2A_LARGE_BACKEND", "ag_rs")
+    partial_output = torch.zeros(5, 4, 8, dtype=torch.bfloat16)
+    partial_lse = torch.zeros(5, 4, dtype=torch.float32)
+    expected = torch.ones(5, 2, 8, dtype=torch.bfloat16)
+    captured: dict[str, Any] = {}
+    group = _FakeCPGroup(2, object())  # type: ignore[arg-type]
+
+    monkeypatch.setattr(
+        dcp_alltoall,
+        "_try_b12x_dcp_lse_reduce",
+        lambda *args, **kwargs: None,
+    )
+
+    def fake_ag_rs(output, lse, cp_group, **kwargs):
+        captured.update(output=output, lse=lse, group=cp_group, **kwargs)
+        return expected
+
+    monkeypatch.setattr(common, "cp_lse_ag_out_rs", fake_ag_rs)
+    monkeypatch.setattr(
+        dcp_alltoall.dist,
+        "all_to_all_single",
+        lambda *args, **kwargs: pytest.fail("packed NCCL A2A must not run"),
+    )
+
+    actual = dcp_alltoall.dcp_a2a_lse_reduce(
+        partial_output,
+        partial_lse,
+        group,  # type: ignore[arg-type]
+        use_b12x=True,
+        b12x_max_batch_size=4,
+    )
+
+    assert actual is expected
+    assert captured == {
+        "output": partial_output,
+        "lse": partial_lse,
+        "group": group,
+        "ctx": None,
+        "return_lse": False,
+        "is_lse_base_on_e": True,
+        "head_major_output": True,
+    }
+
+
 def test_packed_a2a_capture_buffers_stay_live_per_shape(
     monkeypatch: pytest.MonkeyPatch,
 ):

--- a/vllm/v1/attention/ops/dcp_alltoall.py
+++ b/vllm/v1/attention/ops/dcp_alltoall.py
@@ -987,6 +987,26 @@ def dcp_a2a_lse_reduce(
         )
         if b12x_result is not None:
             return b12x_result
+        token_cap = envs.VLLM_DCP_A2A_MAX_TOKENS
+        if (
+            token_cap > 0
+            and cp_attn_out.shape[0] > token_cap
+            and envs.VLLM_DCP_A2A_LARGE_BACKEND == "ag_rs"
+        ):
+            # PyNccl AG+RS uses the DCP communicator warmed during startup.
+            # This avoids ProcessGroupNCCL's first-use all-to-all workspace
+            # allocation after a near-capacity KV cache has been allocated.
+            from vllm.v1.attention.ops.common import cp_lse_ag_out_rs
+
+            return cp_lse_ag_out_rs(
+                cp_attn_out,
+                cp_attn_lse,
+                cp_group,
+                ctx=ctx,
+                return_lse=return_lse,
+                is_lse_base_on_e=is_lse_base_on_e,
+                head_major_output=True,
+            )
 
     B, H, D = cp_attn_out.shape
     if H % world_size != 0:


### PR DESCRIPTION
## Status

Qualified.

## Behavior

A B12X DCP request larger than `VLLM_DCP_A2A_MAX_TOKENS` uses the warmed PyNccl all-gather/reduce-scatter implementation when `VLLM_DCP_A2A_LARGE_BACKEND=ag_rs`. Decode-sized requests continue to use B12X. Setting the large-batch backend to `a2a`, or setting the token cap to zero, retains packed NCCL all-to-all.

## Technical reason

ProcessGroupNCCL can allocate a substantial all-to-all transport workspace on first use. That implicit allocation can fail when an explicitly sized KV cache has already consumed the available device memory. The AG/RS implementation uses the DCP communicator initialized during startup and avoids that late allocation.

## Compatibility

The default environment already selects `ag_rs` for batches beyond a nonzero cap. The numerical merge function, output layout, decode path, uncapped configuration, and explicit `a2a` configuration are unchanged.

## Validation

- Ruff formatting and checks pass.
- `git diff --check` passes.
- Focused tests verify normal B12X dispatch and oversized-batch AG/RS dispatch.
- The oversized-batch test proves that packed ProcessGroupNCCL all-to-all is not entered.