### PR TITLE
[II] Support FP8 B12X gathers into caller storage

### DIFF
--- a/tests/distributed/test_dcp_a2a.py
+++ b/tests/distributed/test_dcp_a2a.py
@@ -1013,6 +1013,86 @@ def test_b12x_query_gather_honors_token_cap(monkeypatch: pytest.MonkeyPatch):
 
 
 @pytest.mark.skipif(torch.accelerator.device_count() < 1, reason="CUDA is required.")
+def test_b12x_query_gather_supports_fp8_caller_output(monkeypatch):
+    from vllm.v1.attention.ops import dcp_alltoall
+
+    received: dict[str, Any] = {}
+
+    class _FakePool:
+        def all_gather_heads(self, local_input, *, out, channel_id):
+            received.update(input=local_input, out=out, channel_id=channel_id)
+            return out
+
+    def fake_get_pool(
+        cp_group, *, device, total_heads, head_dim, query_head_dim, max_batch_size
+    ):
+        received.update(
+            total_heads=total_heads,
+            head_dim=head_dim,
+            query_head_dim=query_head_dim,
+            max_batch_size=max_batch_size,
+        )
+        return _FakePool()
+
+    monkeypatch.setattr(dcp_alltoall, "_get_b12x_dcp_a2a_pool", fake_get_pool)
+    group = _FakeCPGroup(4, object())  # type: ignore[arg-type]
+    local_input = torch.zeros(2, 2, 64, dtype=torch.float8_e4m3fn, device="cuda")
+    out = torch.empty(2, 8, 64, dtype=local_input.dtype, device=local_input.device)
+
+    actual = dcp_alltoall._try_b12x_dcp_all_gather_heads(
+        local_input,
+        group,  # type: ignore[arg-type]
+        max_batch_size=8,
+        output_head_dim=512,
+        out=out,
+    )
+
+    assert actual is out
+    assert received.pop("input") is local_input
+    assert received.pop("out") is out
+    assert received == {
+        "channel_id": "vllm:eager:dcp",
+        "total_heads": 8,
+        "head_dim": 512,
+        "query_head_dim": 64,
+        "max_batch_size": 8,
+    }
+
+    unaligned = torch.zeros(
+        2, 2, 24, dtype=torch.float8_e4m3fn, device=local_input.device
+    )
+    assert (
+        dcp_alltoall._try_b12x_dcp_all_gather_heads(
+            unaligned,
+            group,  # type: ignore[arg-type]
+            max_batch_size=8,
+            output_head_dim=512,
+        )
+        is None
+    )
+
+
+def test_query_gather_fallback_copies_into_caller_output(monkeypatch):
+    from vllm.v1.attention.ops import dcp_alltoall
+
+    monkeypatch.delenv("VLLM_USE_B12X_DCP_A2A", raising=False)
+    local_input = torch.zeros(2, 2, 8, dtype=torch.bfloat16)
+    gathered = torch.arange(64, dtype=torch.bfloat16).reshape(2, 4, 8)
+    out = torch.empty_like(gathered)
+    group = _FakeCPGroup(2, object())  # type: ignore[arg-type]
+    group.all_gather = lambda _value, dim: gathered  # type: ignore[attr-defined]
+
+    actual = dcp_alltoall.dcp_b12x_all_gather_heads(
+        local_input,
+        group,  # type: ignore[arg-type]
+        out=out,
+    )
+
+    assert actual is out
+    torch.testing.assert_close(actual, gathered)
+
+
+@pytest.mark.skipif(torch.accelerator.device_count() < 1, reason="CUDA is required.")
 def test_b12x_lse_reduce_preserves_supported_layouts(monkeypatch: pytest.MonkeyPatch):
     """Preserve head-major input while materializing legacy head slices."""
     from vllm.v1.attention.ops import dcp_alltoall

--- a/vllm/v1/attention/ops/dcp_alltoall.py
+++ b/vllm/v1/attention/ops/dcp_alltoall.py
@@ -336,12 +336,13 @@ def _try_b12x_dcp_all_gather_heads(
     *,
     max_batch_size: int | None,
     output_head_dim: int | None,
+    out: torch.Tensor | None = None,
 ) -> torch.Tensor | None:
     """Gather rank-local query heads with the B12X PCIe channel."""
     world_size = cp_group.world_size
     if (
         not local_input.is_cuda
-        or local_input.dtype not in (torch.float16, torch.bfloat16)
+        or local_input.dtype not in (torch.float16, torch.bfloat16, torch.float8_e4m3fn)
         or world_size not in (2, 4, 8)
         or local_input.ndim != 3
         or not local_input.is_contiguous()
@@ -349,7 +350,8 @@ def _try_b12x_dcp_all_gather_heads(
         return None
 
     batch, local_heads, head_dim = local_input.shape
-    if local_heads <= 0 or head_dim % 8 != 0:
+    gather_alignment = 16 if local_input.dtype == torch.float8_e4m3fn else 8
+    if local_heads <= 0 or head_dim % gather_alignment != 0:
         return None
     if max_batch_size is None:
         max_batch_size = batch
@@ -377,6 +379,12 @@ def _try_b12x_dcp_all_gather_heads(
     )
     if pool is None:
         return None
+    if out is not None:
+        return pool.all_gather_heads(
+            local_input,
+            out=out,
+            channel_id=_B12X_DCP_EAGER_CHANNEL_ID,
+        )
     return pool.all_gather_heads(
         local_input,
         channel_id=_B12X_DCP_EAGER_CHANNEL_ID,
@@ -389,19 +397,33 @@ def dcp_b12x_all_gather_heads(
     *,
     max_batch_size: int | None = None,
     output_head_dim: int | None = None,
+    out: torch.Tensor | None = None,
 ) -> torch.Tensor:
-    """Gather query heads with B12X, falling back to the group backend."""
+    """Gather query heads into optional caller-owned output storage."""
     local_input = local_input.contiguous()
     if envs.VLLM_USE_B12X_DCP_A2A:
-        result = _try_b12x_dcp_all_gather_heads(
-            local_input,
-            cp_group,
-            max_batch_size=max_batch_size,
-            output_head_dim=output_head_dim,
-        )
+        if out is None:
+            result = _try_b12x_dcp_all_gather_heads(
+                local_input,
+                cp_group,
+                max_batch_size=max_batch_size,
+                output_head_dim=output_head_dim,
+            )
+        else:
+            result = _try_b12x_dcp_all_gather_heads(
+                local_input,
+                cp_group,
+                max_batch_size=max_batch_size,
+                output_head_dim=output_head_dim,
+                out=out,
+            )
         if result is not None:
             return result
-    return cp_group.all_gather(local_input, dim=1)
+    result = cp_group.all_gather(local_input, dim=1)
+    if out is None:
+        return result
+    out.copy_(result)
+    return out
 
 
 def warmup_b12x_dcp_a2a(


### PR DESCRIPTION
## Status

Qualified.

## Behavior

The vLLM B12X DCP gather binding accepts FP8 E4M3 query or projection rows whose byte width is 16-byte aligned. A caller may supply the output tensor; B12X writes directly into that storage, while the exact process-group fallback copies its result into the same tensor.

## Technical reason

Quantized projection paths already produce FP8 rows and graph-safe projection code owns reusable scratch storage. Rejecting FP8 forces an unnecessary conversion, and allocating an internal gather result prevents the caller from controlling graph-lifetime memory.

## Compatibility

BF16 and FP16 allocation-returning calls retain their existing behavior. FP8 rows that violate B12X alignment use the exact group fallback. The vLLM binding does not cache or own caller scratch.

## Validation

- Ruff formatting and checks pass.
- `git diff --check` passes.
- Four focused tests cover capped BF16 gather, aligned and unaligned FP8 dispatch, caller-owned output, exact fallback copy, and disabled-B12X behavior.

B12X already exposes FP8 and caller-output support through `DcpAllToAllPool.all_gather_heads`; no B12X source change is required.