### PR TITLE
[II] Gather paired DCP projections behind one barrier

### DIFF
--- a/tests/distributed/test_dcp_a2a.py
+++ b/tests/distributed/test_dcp_a2a.py
@@ -1302,6 +1302,96 @@ def test_b12x_query_gather_requires_env(monkeypatch: pytest.MonkeyPatch):
     assert actual is expected
 
 
+@pytest.mark.skipif(torch.accelerator.device_count() < 1, reason="CUDA is required.")
+def test_b12x_pair_gather_uses_one_pool_operation_at_dcp16(monkeypatch):
+    from vllm.v1.attention.ops import dcp_alltoall
+
+    monkeypatch.setenv("VLLM_USE_B12X_DCP_A2A", "1")
+    received: dict[str, Any] = {}
+    local_first = torch.zeros(2, 224, dtype=torch.bfloat16, device="cuda")
+    local_second = torch.zeros(2, 56, dtype=torch.float32, device="cuda")
+    expected = (
+        torch.empty(2, 224 * 16, dtype=local_first.dtype, device="cuda"),
+        torch.empty(2, 56 * 16, dtype=local_second.dtype, device="cuda"),
+    )
+
+    class _FakePool:
+        def all_gather_pair(self, first, second, *, channel_id):
+            received.update(first=first, second=second, channel_id=channel_id)
+            return expected
+
+    def fake_get_pool(cp_group, **kwargs):
+        received.update(kwargs)
+        return _FakePool()
+
+    monkeypatch.setattr(dcp_alltoall, "_get_b12x_dcp_a2a_pool", fake_get_pool)
+    monkeypatch.setattr(
+        dcp_alltoall,
+        "_b12x_dcp_channel_id",
+        lambda _group: "vllm:target:decode:graph-1",
+    )
+    group = _FakeCPGroup(16, object())  # type: ignore[arg-type]
+
+    actual = dcp_alltoall.dcp_b12x_all_gather_pair(
+        local_first,
+        local_second,
+        group,  # type: ignore[arg-type]
+        max_batch_size=8,
+    )
+
+    assert actual is expected
+    assert received.pop("first") is local_first
+    assert received.pop("second") is local_second
+    assert received.pop("device") == local_first.device
+    assert received == {
+        "channel_id": "vllm:target:decode:graph-1",
+        "total_heads": 16,
+        "head_dim": 672,
+        "query_head_dim": 672,
+        "max_batch_size": 8,
+    }
+    unaligned_first = local_first[:, :223].contiguous()
+    assert (
+        dcp_alltoall._try_b12x_dcp_all_gather_pair(
+            unaligned_first,
+            local_second,
+            group,  # type: ignore[arg-type]
+            max_batch_size=8,
+        )
+        is None
+    )
+
+
+def test_pair_gather_fallback_preserves_tensor_order(monkeypatch):
+    from vllm.v1.attention.ops import dcp_alltoall
+
+    monkeypatch.delenv("VLLM_USE_B12X_DCP_A2A", raising=False)
+    local_first = torch.zeros(2, 8)
+    local_second = torch.ones(2, 4)
+    gathered_first = torch.full((2, 16), 2.0)
+    gathered_second = torch.full((2, 8), 3.0)
+    calls: list[tuple[torch.Tensor, int]] = []
+
+    def gather(value, dim):
+        calls.append((value, dim))
+        return gathered_first if value is local_first else gathered_second
+
+    group = _FakeCPGroup(2, object())  # type: ignore[arg-type]
+    group.all_gather = gather  # type: ignore[attr-defined]
+
+    actual = dcp_alltoall.dcp_b12x_all_gather_pair(
+        local_first,
+        local_second,
+        group,  # type: ignore[arg-type]
+    )
+
+    assert actual[0] is gathered_first
+    assert actual[1] is gathered_second
+    assert len(calls) == 2
+    assert calls[0][0] is local_first and calls[0][1] == -1
+    assert calls[1][0] is local_second and calls[1][1] == -1
+
+
 def test_warmup_skips_unsupported_world_size(monkeypatch: pytest.MonkeyPatch):
     from vllm.v1.attention.ops import dcp_alltoall
 

--- a/vllm/v1/attention/ops/dcp_alltoall.py
+++ b/vllm/v1/attention/ops/dcp_alltoall.py
@@ -435,6 +435,92 @@ def dcp_b12x_all_gather_heads(
     return cp_group.all_gather(local_input, dim=1)
 
 
+def _try_b12x_dcp_all_gather_pair(
+    local_first: torch.Tensor,
+    local_second: torch.Tensor,
+    cp_group: GroupCoordinator,
+    *,
+    max_batch_size: int | None,
+) -> tuple[torch.Tensor, torch.Tensor] | None:
+    """Gather two projection rows behind one B12X IPC barrier."""
+    supported_dtypes = (
+        torch.float16,
+        torch.bfloat16,
+        torch.float32,
+        torch.float8_e4m3fn,
+    )
+    if (
+        cp_group.world_size not in _B12X_DCP_WORLD_SIZES
+        or local_first.dtype not in supported_dtypes
+        or local_second.dtype not in supported_dtypes
+        or not local_first.is_cuda
+        or not local_second.is_cuda
+        or local_first.device != local_second.device
+        or local_first.ndim != 2
+        or local_second.ndim != 2
+        or local_first.shape[0] != local_second.shape[0]
+        or not local_first.is_contiguous()
+        or not local_second.is_contiguous()
+    ):
+        return None
+
+    batch = int(local_first.shape[0])
+    first_row_bytes = int(local_first.shape[1]) * local_first.element_size()
+    second_row_bytes = int(local_second.shape[1]) * local_second.element_size()
+    if batch < 1 or first_row_bytes % 16 != 0 or second_row_bytes % 16 != 0:
+        return None
+    if max_batch_size is None:
+        max_batch_size = batch
+    max_batch_size = int(max_batch_size)
+    token_cap = envs.VLLM_DCP_A2A_MAX_TOKENS
+    if token_cap > 0:
+        if batch > token_cap:
+            return None
+        max_batch_size = min(max_batch_size, token_cap)
+    if max_batch_size < batch:
+        return None
+
+    combined_row_bytes = first_row_bytes + second_row_bytes
+    pool = _get_b12x_dcp_a2a_pool(
+        cp_group,
+        device=local_first.device,
+        total_heads=cp_group.world_size,
+        head_dim=combined_row_bytes,
+        query_head_dim=combined_row_bytes,
+        max_batch_size=max_batch_size,
+    )
+    if pool is None or not hasattr(pool, "all_gather_pair"):
+        return None
+    return pool.all_gather_pair(
+        local_first,
+        local_second,
+        channel_id=_b12x_dcp_channel_id(cp_group),
+    )
+
+
+def dcp_b12x_all_gather_pair(
+    local_first: torch.Tensor,
+    local_second: torch.Tensor,
+    cp_group: GroupCoordinator,
+    *,
+    max_batch_size: int | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Gather two rank-local rows together, with exact separate fallbacks."""
+    if envs.VLLM_USE_B12X_DCP_A2A:
+        result = _try_b12x_dcp_all_gather_pair(
+            local_first,
+            local_second,
+            cp_group,
+            max_batch_size=max_batch_size,
+        )
+        if result is not None:
+            return result
+    return (
+        cp_group.all_gather(local_first, dim=-1),
+        cp_group.all_gather(local_second, dim=-1),
+    )
+
+
 def warmup_b12x_dcp_a2a(
     cp_group: GroupCoordinator,
     *,


### PR DESCRIPTION
## Status

Qualified.

## Behavior

`dcp_b12x_all_gather_pair` gathers two contiguous rank-local projection rows through one B12X IPC synchronization epoch. FP16, BF16, FP32, and FP8 E4M3 rows are accepted when each row occupies a multiple of 16 bytes.

Unsupported shapes, dtypes, capacities, alignments, world sizes, or B12X availability use two exact process-group gathers in the original tensor order.

## Technical reason

Decode pipelines often gather a latent projection and a router projection together. Separate collectives pay two system-scope barrier epochs even though both tensors have the same batch and process group. B12X already exposes a paired gather that shares the barrier.

## Compatibility

The public helper has an exact fallback and does not change existing single-tensor gather behavior. The change depends on the DCP16 dispatch guard in #338. B12X `DcpAllToAllPool.all_gather_pair` already provides the transport primitive.

## Validation

- Ruff formatting and checks pass.
- `git diff --check` passes.
- Focused tests cover TP16/DCP16 paired dispatch, mixed BF16/FP32 rows, 16-byte alignment rejection, exact fallback ordering, and DCP16 warmup.