### PR TITLE
[II] Bind fused Kimi projection routing

### DIFF
--- a/tests/distributed/test_dcp_a2a.py
+++ b/tests/distributed/test_dcp_a2a.py
@@ -1392,6 +1392,119 @@ def test_pair_gather_fallback_preserves_tensor_order(monkeypatch):
     assert calls[1][0] is local_second and calls[1][1] == -1
 
 
+@pytest.mark.parametrize("world_size", [2, 4, 8, 16])
+@pytest.mark.skipif(torch.accelerator.device_count() < 1, reason="CUDA is required.")
+def test_b12x_kimi_pair_topk_supports_projection_world_sizes(
+    monkeypatch: pytest.MonkeyPatch,
+    world_size: int,
+):
+    from vllm.v1.attention.ops import dcp_alltoall
+
+    monkeypatch.setenv("VLLM_USE_B12X_DCP_A2A", "1")
+    local_down = torch.zeros(1, 3584 // world_size, dtype=torch.bfloat16, device="cuda")
+    local_router = torch.zeros(1, 896 // world_size, dtype=torch.float32, device="cuda")
+    correction_bias = torch.zeros(896, dtype=torch.float32, device="cuda")
+    received: dict[str, Any] = {}
+
+    class _FakePool:
+        def all_gather_pair_kimi_topk(
+            self,
+            down,
+            router,
+            bias,
+            out_down,
+            topk_weights,
+            topk_ids,
+            *,
+            channel_id,
+        ):
+            received.update(
+                down=down,
+                router=router,
+                bias=bias,
+                out_down=out_down,
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
+                channel_id=channel_id,
+            )
+
+    def fake_get_pool(cp_group, **kwargs):
+        received.update(kwargs)
+        return _FakePool()
+
+    monkeypatch.setattr(dcp_alltoall, "_get_b12x_dcp_a2a_pool", fake_get_pool)
+    monkeypatch.setattr(
+        dcp_alltoall,
+        "_b12x_dcp_channel_id",
+        lambda _group: "vllm:draft:decode:graph-2",
+    )
+    group = _FakeCPGroup(world_size, object())  # type: ignore[arg-type]
+
+    actual = dcp_alltoall.try_dcp_b12x_all_gather_pair_kimi_topk(
+        local_down,
+        local_router,
+        correction_bias,
+        group,  # type: ignore[arg-type]
+    )
+
+    assert actual is not None
+    gathered_down, routing_payload = actual
+    assert gathered_down.shape == (1, 3584)
+    assert gathered_down.dtype == torch.bfloat16
+    assert routing_payload.shape == (2, 16)
+    assert routing_payload.dtype == torch.float32
+    assert received.pop("down") is local_down
+    assert received.pop("router") is local_router
+    assert received.pop("bias") is correction_bias
+    assert received.pop("out_down") is gathered_down
+    assert received.pop("topk_weights").data_ptr() == routing_payload.data_ptr()
+    assert received.pop("topk_ids").data_ptr() == routing_payload[1].data_ptr()
+    combined_row_bytes = 7168 // world_size + 3584 // world_size
+    assert received == {
+        "channel_id": "vllm:draft:decode:graph-2",
+        "device": local_down.device,
+        "total_heads": world_size,
+        "head_dim": combined_row_bytes,
+        "query_head_dim": combined_row_bytes,
+        "max_batch_size": 1,
+    }
+
+
+@pytest.mark.skipif(torch.accelerator.device_count() < 1, reason="CUDA is required.")
+def test_b12x_kimi_pair_topk_rejects_non_contract_inputs(monkeypatch):
+    from vllm.v1.attention.ops import dcp_alltoall
+
+    monkeypatch.setenv("VLLM_USE_B12X_DCP_A2A", "1")
+    monkeypatch.setattr(
+        dcp_alltoall,
+        "_get_b12x_dcp_a2a_pool",
+        lambda *args, **kwargs: pytest.fail("invalid inputs must not create a pool"),
+    )
+    group = _FakeCPGroup(8, object())  # type: ignore[arg-type]
+    down = torch.zeros(1, 448, dtype=torch.bfloat16, device="cuda")
+    router = torch.zeros(1, 112, dtype=torch.float32, device="cuda")
+    bias = torch.zeros(896, dtype=torch.float32, device="cuda")
+
+    invalid_inputs = (
+        (down.expand(2, -1), router.expand(2, -1), bias),
+        (down[:, :-1].contiguous(), router, bias),
+        (down, router[:, :-1].contiguous(), bias),
+        (down, router, bias[:-1].contiguous()),
+        (down.float(), router, bias),
+        (down, router.bfloat16(), bias),
+    )
+    for invalid_down, invalid_router, invalid_bias in invalid_inputs:
+        assert (
+            dcp_alltoall.try_dcp_b12x_all_gather_pair_kimi_topk(
+                invalid_down,
+                invalid_router,
+                invalid_bias,
+                group,  # type: ignore[arg-type]
+            )
+            is None
+        )
+
+
 def test_warmup_skips_unsupported_world_size(monkeypatch: pytest.MonkeyPatch):
     from vllm.v1.attention.ops import dcp_alltoall
 

--- a/vllm/v1/attention/ops/dcp_alltoall.py
+++ b/vllm/v1/attention/ops/dcp_alltoall.py
@@ -49,6 +49,9 @@ _B12X_DCP_MAX_CONCURRENT_CHANNELS = 2
 # owns the graph's semantic channel, stream, and cleanup stack.
 _B12X_DCP_ACTIVE_CAPTURE: dict[int, tuple[str, Any, ExitStack]] = {}
 _B12X_DCP_WORLD_SIZES = (2, 4, 8, 16)
+_KIMI_LATENT_WIDTH = 3584
+_KIMI_ROUTER_WIDTH = 896
+_KIMI_ROUTER_TOPK = 16
 _DCP_A2A_GRAPH_BUFFERS: dict[
     tuple[tuple[int, ...], torch.device, torch.dtype],
     tuple[torch.Tensor, torch.Tensor],
@@ -519,6 +522,85 @@ def dcp_b12x_all_gather_pair(
         cp_group.all_gather(local_first, dim=-1),
         cp_group.all_gather(local_second, dim=-1),
     )
+
+
+def try_dcp_b12x_all_gather_pair_kimi_topk(
+    local_down: torch.Tensor,
+    local_router: torch.Tensor,
+    correction_bias: torch.Tensor,
+    cp_group: GroupCoordinator,
+) -> tuple[torch.Tensor, torch.Tensor] | None:
+    """Gather Kimi projections and select routed experts in one operation.
+
+    The returned routing payload has contiguous FP32 weight and int32 expert-ID
+    planes, each shaped ``[1, 16]``. The expert-ID plane is an integer view of
+    the second FP32 row, which gives graph callers one allocation to retain.
+
+    This binding has no collective fallback because the ordinary paired gather
+    and router are model-level operations. Callers must use those operations
+    when this function returns ``None``.
+    """
+    world_size = cp_group.world_size
+    if world_size not in _B12X_DCP_WORLD_SIZES:
+        return None
+    local_down_width = _KIMI_LATENT_WIDTH // world_size
+    local_router_width = _KIMI_ROUTER_WIDTH // world_size
+    if (
+        not envs.VLLM_USE_B12X_DCP_A2A
+        or local_down.shape != (1, local_down_width)
+        or local_down.dtype != torch.bfloat16
+        or local_router.shape != (1, local_router_width)
+        or local_router.dtype != torch.float32
+        or correction_bias.shape != (_KIMI_ROUTER_WIDTH,)
+        or correction_bias.dtype != torch.float32
+        or not local_down.is_cuda
+        or not local_router.is_cuda
+        or not correction_bias.is_cuda
+        or local_down.device != local_router.device
+        or local_down.device != correction_bias.device
+        or not local_down.is_contiguous()
+        or not local_router.is_contiguous()
+        or not correction_bias.is_contiguous()
+    ):
+        return None
+
+    combined_row_bytes = (
+        local_down_width * local_down.element_size()
+        + local_router_width * local_router.element_size()
+    )
+    pool = _get_b12x_dcp_a2a_pool(
+        cp_group,
+        device=local_down.device,
+        total_heads=world_size,
+        head_dim=combined_row_bytes,
+        query_head_dim=combined_row_bytes,
+        max_batch_size=1,
+    )
+    if pool is None or not hasattr(pool, "all_gather_pair_kimi_topk"):
+        return None
+
+    gathered_down = torch.empty(
+        (1, _KIMI_LATENT_WIDTH),
+        device=local_down.device,
+        dtype=torch.bfloat16,
+    )
+    routing_payload = torch.empty(
+        (2, _KIMI_ROUTER_TOPK),
+        device=local_down.device,
+        dtype=torch.float32,
+    )
+    topk_weights = routing_payload[:1]
+    topk_ids = routing_payload[1:].view(torch.int32)
+    pool.all_gather_pair_kimi_topk(
+        local_down,
+        local_router,
+        correction_bias,
+        gathered_down,
+        topk_weights,
+        topk_ids,
+        channel_id=_b12x_dcp_channel_id(cp_group),
+    )
+    return gathered_down, routing_payload
 
 
 def warmup_b12x_dcp_a2a(


### PR DESCRIPTION
## Status

Implemented and independently validated.

## Behavior

Exposes the B12X fused Kimi-K3 projection operation through the vLLM DCP transport. One operation gathers the 3,584-element BF16 latent projection, gathers the 896-element FP32 router projection, applies the correction bias, and selects the exact top 16 routed experts.

The binding supports TP2, TP4, TP8, and TP16. It returns a contiguous BF16 latent tensor and one FP32 allocation containing separate weight and int32 expert-ID planes.

## Technical reason

Kimi-K3 can avoid a separate router collective and a separate global top-k launch when B12X supplies the fused CuTeDSL operation. Keeping the operation in the DCP transport layer separates the collective contract from Kimi model dispatch and graph warm-up policy.

## Compatibility

- Unsupported world sizes, shapes, dtypes, devices, missing B12X methods, and disabled B12X transport return `None` before launch.
- The binding has no semantic fallback. Model code retains the exact paired-gather and router path when the binding returns `None`.
- The operation accepts one decode row, matching the B12X fused interface.
- The parent PR preserves the separate paired-gather interface for multi-row verification batches.
- Requires local-inference-lab/b12x#216.

## Validation

Environment: NVIDIA PyTorch 26.07 image, PyTorch 2.13, CUDA 13.3, NVIDIA RTX PRO 6000 Blackwell GPUs.

- Seven focused dispatch and contract tests pass for TP2, TP4, TP8, and TP16.
- Forty-four non-distributed DCP transport tests pass; seventeen hardware-distributed or unrelated packed-LSE tests are excluded from this slice.
- Ruff format and check pass.
- `git diff --check` passes.