### PR TITLE
[II] Preserve Kimi MXFP4 MoE shard width

### DIFF
--- a/tests/models/kimi_k3/test_sequence_parallel.py
+++ b/tests/models/kimi_k3/test_sequence_parallel.py
@@ -330,6 +330,32 @@ def test_auxiliary_projection_sharding_requires_shared_token_rows(
     assert kimi_model.shard_auxiliary_projections(use_sequence_parallel) is expected
 
 
+@pytest.mark.parametrize(
+    ("quantization", "moe_backend", "b12x_env", "expected"),
+    [
+        ("mxfp4", "b12x", False, True),
+        ("mxfp4", "auto", True, True),
+        ("mxfp4", "auto", False, False),
+        ("mxfp4", "flashinfer_cutlass", True, False),
+        (None, "b12x", True, False),
+    ],
+)
+def test_native_mxfp4_moe_shard_requires_b12x_backend(
+    monkeypatch: pytest.MonkeyPatch,
+    quantization: str | None,
+    moe_backend: str,
+    b12x_env: bool,
+    expected: bool,
+):
+    monkeypatch.setattr(kimi_model.envs, "VLLM_USE_B12X_MOE", b12x_env)
+    vllm_config = SimpleNamespace(
+        model_config=SimpleNamespace(quantization=quantization),
+        kernel_config=SimpleNamespace(moe_backend=moe_backend),
+    )
+
+    assert kimi_model._uses_native_b12x_mxfp4_intermediate_size(vllm_config) is expected
+
+
 def test_partial_routed_output_transform_adds_partial_residual(monkeypatch):
     monkeypatch.delenv("VLLM_KQUANT_CAPTURE_DIR", raising=False)
     weight = torch.arange(12, dtype=torch.float32).view(4, 3)

--- a/vllm/models/kimi_k3/nvidia/model.py
+++ b/vllm/models/kimi_k3/nvidia/model.py
@@ -134,6 +134,22 @@ logger = init_logger(__name__)
 _ROUTED_DOWN_PROJ_STREAM_TOKEN_THRESHOLD = 256
 
 
+def _uses_native_b12x_mxfp4_intermediate_size(
+    vllm_config: VllmConfig,
+) -> bool:
+    """Return whether B12X consumes the checkpoint MoE shard width.
+
+    The B12X W4A16 kernel accepts intermediate tails such as Kimi-K3's
+    3,072 / TP16 = 192 shard. Generic model-level padding to 256 channels per
+    rank would increase every routed-expert layer without changing its logical
+    shape.
+    """
+    if vllm_config.model_config.quantization != "mxfp4":
+        return False
+    moe_backend = vllm_config.kernel_config.moe_backend
+    return moe_backend == "b12x" or (moe_backend == "auto" and envs.VLLM_USE_B12X_MOE)
+
+
 def shard_sequence_parallel_mlp(
     hidden_size: int,
     intermediate_size: int,
@@ -667,12 +683,28 @@ class KimiMoE(nn.Module):
         min_moe_intermediate_per_partition = getattr(
             config, "min_moe_intermediate_per_partition", 256
         )
-        if self.tp_size > 1 and not vllm_config.parallel_config.enable_expert_parallel:
+        use_native_b12x_intermediate = (
+            not self.use_mega_moe
+            and _uses_native_b12x_mxfp4_intermediate_size(vllm_config)
+        )
+        if (
+            self.tp_size > 1
+            and not vllm_config.parallel_config.enable_expert_parallel
+            and not use_native_b12x_intermediate
+        ):
             moe_intermediate_per_partition = moe_intermediate_size // self.tp_size
             if moe_intermediate_per_partition < min_moe_intermediate_per_partition:
                 self.padded_moe_intermediate_size = (
                     min_moe_intermediate_per_partition * self.tp_size
                 )
+        elif use_native_b12x_intermediate:
+            logger.info_once(
+                "Kimi-K3 B12X MXFP4 keeps the checkpoint MoE intermediate "
+                "shard (%d / TP%d = %d).",
+                moe_intermediate_size,
+                self.tp_size,
+                moe_intermediate_size // self.tp_size,
+            )
         activation_situ_beta = (
             config.activation_situ_beta if config.hidden_act == "situ" else None
         )


### PR DESCRIPTION
## Status

Implemented and independently validated.

## Behavior

Kimi-K3 routed experts retain the checkpoint intermediate width when MXFP4 weights execute through the B12X W4A16 backend. At TP16, the 3,072-element intermediate dimension remains a 192-element local shard instead of being padded to 256 elements per rank.

## Technical reason

The generic Kimi minimum-shard policy protects kernels that require at least 256 intermediate channels per tensor-parallel rank. B12X W4A16 accepts the 192-channel TP16 tail directly. Applying the generic minimum expands every routed-expert intermediate dimension by 33.33 percent without changing the logical model.

## Compatibility

- The exception applies only to Kimi-K3 MXFP4 with an explicit B12X MoE backend or `auto` with B12X MoE enabled.
- MegaMoE, expert-parallel, non-MXFP4, and non-B12X configurations retain their established padding behavior.
- TP8 and TP12 geometry is unchanged because their local intermediate widths are already at least 256.

## Validation

Environment: NVIDIA PyTorch 26.07 image, PyTorch 2.13, CUDA 13.3.

- Thirty-two Kimi sequence-parallel and projection tests pass.
- Five backend-selection cases cover explicit B12X, automatic B12X, disabled B12X, another MXFP4 backend, and non-MXFP4 weights.
- Ruff format and check pass.
- `git diff --check` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for preserving native MXFP4 MoE intermediate shard sizes in Kimi-K3 models using the B12X backend.
  * Automatically detects eligible MXFP4 configurations while excluding unsupported MegaMoE setups.

* **Bug Fixes**
  * Prevented unnecessary padding of checkpoint shard dimensions for supported Kimi-K3 configurations.
  * Added coverage to ensure sharding behavior remains disabled for incompatible backends, quantization modes, and environment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->