### PR TITLE
[II] TP-shard Kimi MLA latent projections

### DIFF
--- a/tests/models/kimi_k3/test_sequence_parallel.py
+++ b/tests/models/kimi_k3/test_sequence_parallel.py
@@ -13,6 +13,7 @@ from vllm.config import ParallelConfig
 from vllm.model_executor.layers.activation import SiluAndMul
 from vllm.model_executor.layers.linear import RowParallelLinear
 from vllm.models.common.ops import sequence_parallel as sp_ops
+from vllm.models.kimi_k3.nvidia import mla as kimi_mla
 from vllm.models.kimi_k3.nvidia import model as kimi_model
 from vllm.models.kimi_k3.nvidia import mtp as kimi_mtp
 from vllm.platforms import current_platform
@@ -356,6 +357,54 @@ def test_kimi_column_parallel_loader_zero_fills_tail():
 
     expected = torch.cat([loaded_weight[3:], torch.zeros(1, 4)])
     torch.testing.assert_close(param, expected)
+
+
+def test_kimi_merged_projection_restores_logical_output_order(monkeypatch):
+    layer = object.__new__(kimi_mla.KimiShardedMergedColumnParallelLinear)
+    nn.Module.__init__(layer)
+    layer.tp_size = 4
+    layer.output_sizes = [8, 4]
+    local_output = torch.empty(1, 3)
+    rank_major_output = torch.tensor(
+        [[0, 1, 8, 2, 3, 9, 4, 5, 10, 6, 7, 11]],
+        dtype=torch.float32,
+    )
+    monkeypatch.setattr(
+        kimi_mla.MergedColumnParallelLinear,
+        "forward",
+        lambda _self, _x: (local_output, None),
+    )
+    monkeypatch.setattr(
+        kimi_mla,
+        "tensor_model_parallel_all_gather",
+        lambda output, dim: rank_major_output,
+    )
+
+    output, bias = layer(torch.empty(1, 1))
+
+    torch.testing.assert_close(output, torch.arange(12).view(1, 12).float())
+    assert bias is None
+
+
+@pytest.mark.parametrize(
+    ("output_sizes", "tp_size", "width", "message"),
+    [
+        ([7, 4], 4, 11, "must be divisible"),
+        ([8, 4], 4, 11, "Unexpected gathered"),
+    ],
+)
+def test_kimi_merged_projection_rejects_invalid_shard_geometry(
+    output_sizes: list[int],
+    tp_size: int,
+    width: int,
+    message: str,
+):
+    with pytest.raises(ValueError, match=message):
+        kimi_mla._restore_merged_output_order(
+            torch.empty(1, width),
+            output_sizes,
+            tp_size,
+        )
 
 
 def test_kimi_row_parallel_loader_zero_fills_tail():

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -351,6 +351,7 @@ if TYPE_CHECKING:
     VLLM_ELASTIC_EP_DRAIN_REQUESTS: bool = False
     VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS: bool = True
     VLLM_MEMORY_PROFILE_INCLUDE_ATTN: bool = False
+    VLLM_KIMI_SHARD_QKV_A: bool = False
     VLLM_NIXL_EP_MAX_NUM_RANKS: int = 32
     VLLM_XPU_ENABLE_XPU_GRAPH: bool = False
     VLLM_XPU_USE_SAMPLER_KERNEL: bool = True
@@ -2343,6 +2344,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_MEMORY_PROFILE_INCLUDE_ATTN": lambda: bool(
         int(os.getenv("VLLM_MEMORY_PROFILE_INCLUDE_ATTN", "0"))
     ),
+    # TP-shard Kimi-K3's merged MLA q_a/kv_a projection. The rank-major
+    # collective result is restored to logical q_a/kv_a order before use.
+    "VLLM_KIMI_SHARD_QKV_A": lambda: bool(int(os.getenv("VLLM_KIMI_SHARD_QKV_A", "0"))),
     # NIXL EP environment variables
     "VLLM_NIXL_EP_MAX_NUM_RANKS": lambda: int(
         os.getenv("VLLM_NIXL_EP_MAX_NUM_RANKS", "32")

--- a/vllm/models/kimi_k3/nvidia/mla.py
+++ b/vllm/models/kimi_k3/nvidia/mla.py
@@ -34,6 +34,7 @@ from typing import TYPE_CHECKING, cast
 import torch
 from torch import nn
 
+import vllm.envs as envs
 from vllm import _custom_ops as ops
 from vllm.compilation.breakable_cudagraph import eager_break_during_capture
 from vllm.config import (
@@ -41,7 +42,10 @@ from vllm.config import (
     VllmConfig,
     get_current_vllm_config,
 )
-from vllm.distributed import get_tensor_model_parallel_world_size
+from vllm.distributed import (
+    get_tensor_model_parallel_world_size,
+    tensor_model_parallel_all_gather,
+)
 from vllm.forward_context import get_forward_context
 from vllm.logger import init_logger
 from vllm.model_executor.layers.attention.attention import (
@@ -103,6 +107,67 @@ _GATE_MULTI_STREAM_TOKEN_THRESHOLD = 512
 def _gate_sigmoid_mul(attn_out: torch.Tensor, gate: torch.Tensor) -> torch.Tensor:
     """Apply the sigmoid output gate to a precomputed ``g_proj`` projection."""
     return attn_out * gate.sigmoid()
+
+
+def _restore_merged_output_order(
+    rank_major_output: torch.Tensor,
+    output_sizes: list[int],
+    tp_size: int,
+) -> torch.Tensor:
+    """Convert rank-major merged shards into logical projection order."""
+    if tp_size == 1:
+        return rank_major_output
+    if any(size % tp_size for size in output_sizes):
+        raise ValueError(
+            f"Merged output sizes {output_sizes} must be divisible by TP={tp_size}"
+        )
+    local_sizes = [size // tp_size for size in output_sizes]
+    local_total = sum(local_sizes)
+    expected_width = local_total * tp_size
+    if rank_major_output.shape[-1] != expected_width:
+        raise ValueError(
+            "Unexpected gathered merged projection width: "
+            f"got {rank_major_output.shape[-1]}, expected {expected_width}"
+        )
+    rank_major = rank_major_output.unflatten(-1, (tp_size, local_total))
+    logical_local_shards = rank_major.split(local_sizes, dim=-1)
+    return torch.cat(
+        [shards.flatten(-2) for shards in logical_local_shards],
+        dim=-1,
+    )
+
+
+class KimiShardedMergedColumnParallelLinear(MergedColumnParallelLinear):
+    """Merged column projection with one gather and logical-shard reorder."""
+
+    def __init__(
+        self,
+        input_size: int,
+        output_sizes: list[int],
+        *,
+        quant_config: QuantizationConfig | None,
+        prefix: str,
+    ) -> None:
+        super().__init__(
+            input_size,
+            output_sizes,
+            bias=False,
+            gather_output=False,
+            quant_config=quant_config,
+            prefix=prefix,
+        )
+
+    def forward(self, x: torch.Tensor):
+        output_parallel, output_bias = super().forward(x)
+        if self.tp_size == 1:
+            return output_parallel, output_bias
+        rank_major_output = tensor_model_parallel_all_gather(output_parallel, dim=-1)
+        output = _restore_merged_output_order(
+            rank_major_output,
+            self.output_sizes,
+            self.tp_size,
+        )
+        return output, output_bias
 
 
 class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
@@ -190,14 +255,26 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
             # the low-rank latents are shared across TP ranks; TP splitting
             # happens at q_b_proj / kv_b_proj. Checkpoint weights ``q_a_proj``
             # and ``kv_a_proj_with_mqa`` map onto shards 0 and 1 respectively.
-            self.fused_qkv_a_proj = MergedColumnParallelLinear(
-                self.hidden_size,
-                [self.q_lora_rank, self.kv_lora_rank + self.qk_rope_head_dim],
-                bias=False,
-                quant_config=quant_config,
-                prefix=f"{prefix}.fused_qkv_a_proj",
-                disable_tp=True,
-            )
+            qkv_a_output_sizes = [
+                self.q_lora_rank,
+                self.kv_lora_rank + self.qk_rope_head_dim,
+            ]
+            if envs.VLLM_KIMI_SHARD_QKV_A and tp_size > 1:
+                self.fused_qkv_a_proj = KimiShardedMergedColumnParallelLinear(
+                    self.hidden_size,
+                    qkv_a_output_sizes,
+                    quant_config=quant_config,
+                    prefix=f"{prefix}.fused_qkv_a_proj",
+                )
+            else:
+                self.fused_qkv_a_proj = MergedColumnParallelLinear(
+                    self.hidden_size,
+                    qkv_a_output_sizes,
+                    bias=False,
+                    quant_config=quant_config,
+                    prefix=f"{prefix}.fused_qkv_a_proj",
+                    disable_tp=True,
+                )
             self.q_a_layernorm = RMSNorm(self.q_lora_rank, eps=config.rms_norm_eps)
             self.q_b_proj = ColumnParallelLinear(
                 self.q_lora_rank,


### PR DESCRIPTION
## Status

Implemented and independently validated.

## Behavior

`VLLM_KIMI_SHARD_QKV_A=1` stores the merged Kimi-K3 `q_a` and `kv_a` projection as tensor-parallel column shards. Each forward pass gathers one rank-local merged output and restores the logical `q_a` followed by `kv_a` layout before either latent is consumed.

For `moonshotai/Kimi-K3@2496450e92e425c886db095102a52a6682ca3970`, each of 24 MLA layers has a 2,112 by 7,168 BF16 merged projection. TP16 sharding reduces this replicated weight storage by approximately 0.634 GiB per GPU.

## Technical reason

The low-rank latent tensors are logically replicated, but their projection weights do not need to be. A standard tensor-parallel gather reconstructs the exact output. Merged-column collectives produce rank-major shards, so the implementation explicitly restores the two logical projection ranges.

## Compatibility

- The feature is disabled by default.
- Disabled or TP1 operation retains the replicated `disable_tp` layer.
- Enabled operation requires every merged output size to be divisible by the tensor-parallel size.
- This pull request uses the standard tensor-parallel gather. A separate transport optimization may replace that gather without changing the weight layout or logical result.
- Quantization behavior is inherited from `MergedColumnParallelLinear`.

## Validation

Environment: NVIDIA PyTorch 26.07 image, PyTorch 2.13, CUDA 13.3.

- Thirty Kimi sequence-parallel and projection tests pass.
- Focused tests verify rank-major to logical projection ordering and reject non-divisible or truncated collective geometry.
- Ruff format and check pass.
- `git diff --check` passes.