### PR TITLE
[II] Gather sharded Kimi projections through B12X

### DIFF
--- a/tests/models/kimi_k3/test_sequence_parallel.py
+++ b/tests/models/kimi_k3/test_sequence_parallel.py
@@ -376,8 +376,8 @@ def test_kimi_merged_projection_restores_logical_output_order(monkeypatch):
     )
     monkeypatch.setattr(
         kimi_mla,
-        "tensor_model_parallel_all_gather",
-        lambda output, dim: rank_major_output,
+        "gather_kimi_sharded_projection",
+        lambda output: rank_major_output,
     )
 
     output, bias = layer(torch.empty(1, 1))

--- a/tests/models/kimi_k3/test_tp_projection.py
+++ b/tests/models/kimi_k3/test_tp_projection.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.models.kimi_k3.nvidia import tp_projection
+
+
+def test_projection_group_uses_matching_dcp_coordinator(monkeypatch):
+    tp_group = SimpleNamespace(world_size=8, ranks=list(range(8)))
+    dcp_group = SimpleNamespace(world_size=8, ranks=list(range(8)))
+    monkeypatch.setattr(
+        tp_projection, "get_tensor_model_parallel_world_size", lambda: 8
+    )
+    monkeypatch.setattr(tp_projection, "get_tp_group", lambda: tp_group)
+    monkeypatch.setattr(tp_projection, "get_dcp_group", lambda: dcp_group)
+
+    assert tp_projection._get_kimi_projection_group() is dcp_group
+
+
+def test_projection_group_uses_tp_for_different_dcp_ranks(monkeypatch):
+    tp_group = SimpleNamespace(world_size=8, ranks=list(range(8)))
+    dcp_group = SimpleNamespace(world_size=4, ranks=list(range(4)))
+    monkeypatch.setattr(
+        tp_projection, "get_tensor_model_parallel_world_size", lambda: 8
+    )
+    monkeypatch.setattr(tp_projection, "get_tp_group", lambda: tp_group)
+    monkeypatch.setattr(tp_projection, "get_dcp_group", lambda: dcp_group)
+
+    assert tp_projection._get_kimi_projection_group() is tp_group
+
+
+def test_projection_group_rejects_incomplete_tp_coordinator(monkeypatch):
+    monkeypatch.setattr(
+        tp_projection, "get_tensor_model_parallel_world_size", lambda: 8
+    )
+    monkeypatch.setattr(
+        tp_projection,
+        "get_tp_group",
+        lambda: SimpleNamespace(world_size=4, ranks=list(range(4))),
+    )
+    monkeypatch.setattr(
+        tp_projection,
+        "get_dcp_group",
+        lambda: SimpleNamespace(world_size=4, ranks=list(range(4))),
+    )
+
+    with pytest.raises(RuntimeError, match="does not span"):
+        tp_projection._get_kimi_projection_group()
+
+
+@pytest.mark.skipif(torch.accelerator.device_count() < 1, reason="CUDA is required.")
+def test_b12x_projection_gather_removes_each_rank_padding(monkeypatch):
+    tp_size = 2
+    local_width = 132
+    local = torch.arange(local_width, dtype=torch.bfloat16, device="cuda").view(1, -1)
+    group = SimpleNamespace(world_size=tp_size, ranks=list(range(tp_size)))
+    received: dict[str, object] = {}
+    monkeypatch.setattr(tp_projection.envs, "VLLM_USE_B12X_DCP_A2A", True)
+    monkeypatch.setattr(
+        tp_projection, "get_tensor_model_parallel_world_size", lambda: tp_size
+    )
+    monkeypatch.setattr(tp_projection, "_get_kimi_projection_group", lambda: group)
+
+    def gather(transport, projection_group, *, max_batch_size):
+        received.update(
+            transport=transport,
+            projection_group=projection_group,
+            max_batch_size=max_batch_size,
+        )
+        padded_width = transport.shape[-1]
+        result = torch.full(
+            (1, tp_size, padded_width),
+            -1,
+            dtype=transport.dtype,
+            device=transport.device,
+        )
+        result[0, 0, :local_width] = torch.arange(
+            local_width, dtype=transport.dtype, device=transport.device
+        )
+        result[0, 1, :local_width] = torch.arange(
+            local_width,
+            2 * local_width,
+            dtype=transport.dtype,
+            device=transport.device,
+        )
+        return result
+
+    monkeypatch.setattr(tp_projection, "dcp_b12x_all_gather_heads", gather)
+
+    actual = tp_projection.gather_kimi_sharded_projection(local)
+
+    expected = torch.arange(
+        2 * local_width, dtype=local.dtype, device=local.device
+    ).view(1, -1)
+    torch.testing.assert_close(actual, expected)
+    assert received["projection_group"] is group
+    assert received["max_batch_size"] == 1
+    assert received["transport"].shape == (1, 1, 136)
+
+
+def test_projection_gather_uses_standard_collective_outside_decode(monkeypatch):
+    local = torch.arange(12).view(3, 4)
+    expected = torch.cat((local, local), dim=-1)
+    monkeypatch.setattr(
+        tp_projection, "get_tensor_model_parallel_world_size", lambda: 2
+    )
+    monkeypatch.setattr(
+        tp_projection,
+        "tensor_model_parallel_all_gather",
+        lambda output, dim: expected,
+    )
+
+    actual = tp_projection.gather_kimi_sharded_projection(local)
+
+    assert actual is expected

--- a/vllm/models/kimi_k3/nvidia/mla.py
+++ b/vllm/models/kimi_k3/nvidia/mla.py
@@ -44,7 +44,6 @@ from vllm.config import (
 )
 from vllm.distributed import (
     get_tensor_model_parallel_world_size,
-    tensor_model_parallel_all_gather,
 )
 from vllm.forward_context import get_forward_context
 from vllm.logger import init_logger
@@ -73,6 +72,9 @@ from vllm.models.kimi_k3.nvidia.ops.fused_mla_key_concat_kv_cache import (
     fused_mla_key_concat_ds_mla_insert,
     fused_mla_key_concat_kv_cache_insert,
     fused_mla_qkv_quant_kv_cache_fp8_insert,
+)
+from vllm.models.kimi_k3.nvidia.tp_projection import (
+    gather_kimi_sharded_projection,
 )
 from vllm.platforms import current_platform
 from vllm.transformers_utils.configs.kimi_linear import KimiLinearConfig
@@ -161,7 +163,7 @@ class KimiShardedMergedColumnParallelLinear(MergedColumnParallelLinear):
         output_parallel, output_bias = super().forward(x)
         if self.tp_size == 1:
             return output_parallel, output_bias
-        rank_major_output = tensor_model_parallel_all_gather(output_parallel, dim=-1)
+        rank_major_output = gather_kimi_sharded_projection(output_parallel)
         output = _restore_merged_output_order(
             rank_major_output,
             self.output_sizes,

--- a/vllm/models/kimi_k3/nvidia/tp_projection.py
+++ b/vllm/models/kimi_k3/nvidia/tp_projection.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tensor-parallel collectives for Kimi-K3 projection outputs."""
+
+import torch
+
+import vllm.envs as envs
+from vllm.distributed import (
+    get_dcp_group,
+    get_tensor_model_parallel_world_size,
+    get_tp_group,
+    tensor_model_parallel_all_gather,
+)
+from vllm.v1.attention.ops.dcp_alltoall import dcp_b12x_all_gather_heads
+
+
+def _get_kimi_projection_group():
+    """Return the coordinator that spans every projection weight shard.
+
+    Projection weights are sharded across the full tensor-parallel group. The
+    DCP coordinator is valid only when its ordered rank list matches the
+    tensor-parallel coordinator.
+    """
+    tp_size = get_tensor_model_parallel_world_size()
+    dcp_group = get_dcp_group()
+    tp_group = get_tp_group()
+    if tp_group.world_size != tp_size:
+        raise RuntimeError(
+            "Kimi projection group does not span tensor-parallel ranks: "
+            f"group={tp_group.world_size}, TP={tp_size}"
+        )
+    if dcp_group.world_size == tp_size and list(dcp_group.ranks) == list(
+        tp_group.ranks
+    ):
+        return dcp_group
+    return tp_group
+
+
+def _try_b12x_kimi_projection_gather(
+    output_parallel: torch.Tensor,
+) -> torch.Tensor | None:
+    """Gather one decode projection over the lossless B12X copy channel."""
+    if (
+        not envs.VLLM_USE_B12X_DCP_A2A
+        or output_parallel.ndim != 2
+        or output_parallel.shape[0] != 1
+        or output_parallel.dtype not in (torch.float16, torch.bfloat16)
+        or not output_parallel.is_cuda
+        or not output_parallel.is_contiguous()
+    ):
+        return None
+
+    tp_size = get_tensor_model_parallel_world_size()
+    if tp_size <= 1:
+        return None
+    projection_group = _get_kimi_projection_group()
+
+    local_width = output_parallel.shape[1]
+    strip_local_width: int | None = None
+    if local_width % 8 == 0:
+        transport = output_parallel.view(1, 1, local_width)
+    else:
+        padded_width = (local_width + 7) // 8 * 8
+        transport = torch.nn.functional.pad(
+            output_parallel, (0, padded_width - local_width)
+        ).view(1, 1, padded_width)
+        strip_local_width = local_width
+
+    gathered = dcp_b12x_all_gather_heads(
+        transport,
+        projection_group,
+        max_batch_size=1,
+    )
+    if strip_local_width is not None:
+        gathered = gathered.narrow(-1, 0, strip_local_width).contiguous()
+    return gathered.flatten(1)
+
+
+def gather_kimi_sharded_projection(output_parallel: torch.Tensor) -> torch.Tensor:
+    """Gather a rank-major Kimi-K3 projection through a lossless fast path."""
+    if get_tensor_model_parallel_world_size() <= 1:
+        return output_parallel
+    gathered = _try_b12x_kimi_projection_gather(output_parallel)
+    if gathered is not None:
+        return gathered
+    return tensor_model_parallel_all_gather(output_parallel, dim=-1)


### PR DESCRIPTION
## Behavior

- Routes a one-row BF16 or FP16 Kimi-K3 tensor-parallel projection gather through the public B12X DCP copy collective when `VLLM_USE_B12X_DCP_A2A=1`.
- Pads each local projection row to the B12X transport contract and removes every rank's padding after the gather, preserving the exact rank-major payload.
- Uses the tensor-parallel coordinator unless the DCP coordinator has the same ordered rank set.
- Preserves tensor-parallel identity at TP1 and the standard vLLM all-gather for prefill, unsupported dtypes, non-CUDA tensors, and unsupported layouts.

## Technical reason

The opt-in Kimi-K3 latent-projection sharding implemented by #345 requires every rank to reconstruct the full projection result. The B12X copy collective provides a CUDA-graph-compatible transport for decode without changing the projection's numerical representation.

## Compatibility

- This pull request is stacked on #345.
- The B12X path requires both Kimi-K3 projection sharding and `VLLM_USE_B12X_DCP_A2A=1`; other model and projection configurations retain the standard collective.
- B12X TP2, TP4, and TP8 use the existing public transport. B12X TP16 requires #338.
- CUDA graph pool ownership is provided separately by #324 and #337; composed serving qualification must include those dependencies.

## Validation

Executed in `voipmonitor/vllm:kimi-k3-qsrt-ii-vllm735952b-b12x180ccab-cu133-torch213-20260815-r3` with the changed source files mounted over the installed tree:

```text
pytest -q tests/models/kimi_k3/test_tp_projection.py tests/models/kimi_k3/test_sequence_parallel.py
35 passed
```

Ruff formatting, Ruff lint, and `git diff --check` also pass for all changed files.
