### PR TITLE
[II] Make Kimi KDA f_a sharding opt-in

### DIFF
--- a/tests/models/kimi_k3/test_kda.py
+++ b/tests/models/kimi_k3/test_kda.py
@@ -11,6 +11,7 @@ from types import SimpleNamespace
 import pytest
 import torch
 import torch.nn.functional as F
+from torch import nn
 
 from vllm import _custom_ops as ops
 from vllm.model_executor.layers.mamba.ops.causal_conv1d import causal_conv1d_update
@@ -20,7 +21,9 @@ from vllm.model_executor.layers.mamba.ops.gather_initial_states import (
 from vllm.models.kimi_k3.amd.ops.third_party.kda import (
     fused_recurrent_kda_packed_decode as fused_recurrent_kda_packed_decode_amd,
 )
+from vllm.models.kimi_k3.nvidia import kda as kimi_kda
 from vllm.models.kimi_k3.nvidia.kda import (
+    get_kda_f_a_partition,
     is_flashkda_supported,
     is_fused_kda_decode_supported,
     use_split_mixed_precision_input_projection,
@@ -65,6 +68,92 @@ def test_kda_mixed_precision_input_projection_selection(
     )
 
     assert use_split_mixed_precision_input_projection(quant_config) is expected
+
+
+@pytest.mark.parametrize(
+    ("additional_config", "tp_size", "expected"),
+    [
+        (None, 16, (False, 128)),
+        ({}, 16, (False, 128)),
+        ({"kda_shard_f_a": False}, 8, (False, 128)),
+        ({"kda_shard_f_a": True}, 8, (True, 16)),
+        ({"kda_shard_f_a": True}, 16, (True, 8)),
+    ],
+)
+def test_kda_f_a_partition(
+    additional_config: object,
+    tp_size: int,
+    expected: tuple[bool, int],
+):
+    assert get_kda_f_a_partition(128, tp_size, additional_config) == expected
+
+
+def test_kda_f_a_partition_rejects_nondivisible_tp_size():
+    with pytest.raises(ValueError, match="head_dim=128, TP=12"):
+        get_kda_f_a_partition(128, 12, {"kda_shard_f_a": True})
+
+
+class _StaticLinear(nn.Module):
+    def __init__(self, output: torch.Tensor):
+        super().__init__()
+        self.output = output
+
+    def forward(self, _input: torch.Tensor):
+        return self.output, None
+
+
+class _CaptureLinear(nn.Module):
+    def __init__(self, output_width: int):
+        super().__init__()
+        self.output_width = output_width
+        self.input: torch.Tensor | None = None
+
+    def forward(self, input_: torch.Tensor):
+        self.input = input_.clone()
+        return input_.new_zeros(input_.shape[0], self.output_width), None
+
+
+class _IdentityLinear(nn.Module):
+    def forward(self, input_: torch.Tensor):
+        return input_, None
+
+
+def test_sharded_kda_f_a_is_gathered_before_f_b(monkeypatch):
+    layer = object.__new__(kimi_kda.KimiK3DeltaAttention)
+    nn.Module.__init__(layer)
+    layer.split_mixed_precision_input = False
+    layer.local_projection_size = 2
+    layer.local_fa_size = 1
+    layer.local_num_heads = 1
+    layer.in_proj_padding = 0
+    layer.shard_f_a = True
+    layer.head_dim = 2
+
+    projected = torch.arange(20, dtype=torch.float32).view(2, 10)
+    layer.in_proj_qkvgfab = _StaticLinear(projected)
+    f_b_proj = _CaptureLinear(output_width=2)
+    layer.f_b_proj = f_b_proj
+    layer.o_proj = _IdentityLinear()
+    layer._forward = lambda **kwargs: kwargs["core_attn_out"].zero_()
+
+    gathered: dict[str, torch.Tensor] = {}
+
+    def gather_f_a(local_f_a: torch.Tensor) -> torch.Tensor:
+        gathered["local"] = local_f_a.clone()
+        return torch.cat((local_f_a, local_f_a + 100), dim=-1)
+
+    monkeypatch.setattr(kimi_kda, "gather_kimi_sharded_projection", gather_f_a)
+
+    output = layer(torch.empty(2, 1), positions=torch.arange(2))
+
+    expected_local = projected[:, 8:9]
+    torch.testing.assert_close(gathered["local"], expected_local)
+    assert f_b_proj.input is not None
+    torch.testing.assert_close(
+        f_b_proj.input,
+        torch.cat((expected_local, expected_local + 100), dim=-1),
+    )
+    torch.testing.assert_close(output, torch.zeros(2, 2))
 
 
 @torch.inference_mode()

--- a/vllm/models/kimi_k3/nvidia/kda.py
+++ b/vllm/models/kimi_k3/nvidia/kda.py
@@ -43,6 +43,9 @@ from vllm.models.kimi_k3.nvidia.kda_metadata import (
     KimiK3KDAAttentionBackend,
     KimiK3KDAMetadata,
 )
+from vllm.models.kimi_k3.nvidia.tp_projection import (
+    gather_kimi_sharded_projection,
+)
 from vllm.platforms import current_platform
 from vllm.third_party.flash_linear_attention.ops.kda import FusedRMSNormGated
 from vllm.transformers_utils.configs.kimi_linear import KimiLinearConfig
@@ -88,6 +91,27 @@ def use_split_mixed_precision_input_projection(quant_config: object | None) -> b
         and not dense_ignored.intersection({"q_proj", "k_proj", "v_proj"})
         and {"g_proj", "f_a_proj", "b_proj"}.issubset(dense_ignored)
     )
+
+
+def get_kda_f_a_partition(
+    head_dim: int,
+    tp_size: int,
+    additional_config: object,
+) -> tuple[bool, int]:
+    """Return whether KDA ``f_a`` is sharded and its local output width."""
+    shard_f_a = bool(
+        additional_config.get("kda_shard_f_a", False)
+        if isinstance(additional_config, dict)
+        else False
+    )
+    if not shard_f_a:
+        return False, head_dim
+    if head_dim % tp_size != 0:
+        raise ValueError(
+            "KDA f_a output sharding requires head_dim to be divisible by "
+            f"TP size, got head_dim={head_dim}, TP={tp_size}."
+        )
+    return True, divide(head_dim, tp_size)
 
 
 class _KimiGDNMergedColumnParallelLinear(MergedColumnParallelLinear):
@@ -334,6 +358,17 @@ class KimiK3DeltaAttention(GatedDeltaNetAttention):
         self.num_heads = kda_config["num_heads"]
         assert self.num_heads % self.tp_size == 0
         self.local_num_heads = divide(self.num_heads, self.tp_size)
+        self.shard_f_a, self.local_fa_size = get_kda_f_a_partition(
+            self.head_dim,
+            self.tp_size,
+            vllm_config.additional_config,
+        )
+        if self.shard_f_a:
+            logger.info_once(
+                "TP-sharding the KDA f_a projection output (%d -> %d rows/rank).",
+                self.head_dim,
+                self.local_fa_size,
+            )
         self.projection_size = self.head_dim * self.num_heads
         self.local_projection_size = divide(self.projection_size, self.tp_size)
         self.conv_size = kda_config["short_conv_kernel_size"]
@@ -349,7 +384,7 @@ class KimiK3DeltaAttention(GatedDeltaNetAttention):
             self.num_heads,
         ]
         local_output_size = (
-            4 * self.local_projection_size + self.head_dim + self.local_num_heads
+            4 * self.local_projection_size + self.local_fa_size + self.local_num_heads
         )
         self.in_proj_padding = -local_output_size % 16
         self.split_mixed_precision_input = use_split_mixed_precision_input_projection(
@@ -373,29 +408,47 @@ class KimiK3DeltaAttention(GatedDeltaNetAttention):
             ]
             if self.in_proj_padding:
                 gfab_output_sizes.append(self.in_proj_padding * self.tp_size)
-            self.in_proj_gfab = _KimiGDNMergedColumnParallelLinear(
-                self.hidden_size,
-                gfab_output_sizes,
-                replicated_shard_id=1,
-                tp_size=self.tp_size,
-                bias=False,
-                quant_config=self.quant_config,
-                prefix=f"{prefix}.in_proj_gfab",
-            )
+            if self.shard_f_a:
+                self.in_proj_gfab = MergedColumnParallelLinear(
+                    self.hidden_size,
+                    gfab_output_sizes,
+                    bias=False,
+                    quant_config=self.quant_config,
+                    prefix=f"{prefix}.in_proj_gfab",
+                )
+            else:
+                self.in_proj_gfab = _KimiGDNMergedColumnParallelLinear(
+                    self.hidden_size,
+                    gfab_output_sizes,
+                    replicated_shard_id=1,
+                    tp_size=self.tp_size,
+                    bias=False,
+                    quant_config=self.quant_config,
+                    prefix=f"{prefix}.in_proj_gfab",
+                )
             if self.in_proj_padding:
                 self.in_proj_gfab.weight.data[-self.in_proj_padding :].zero_()
         else:
             if self.in_proj_padding:
                 in_proj_output_sizes.append(self.in_proj_padding * self.tp_size)
-            self.in_proj_qkvgfab = _KimiGDNMergedColumnParallelLinear(
-                self.hidden_size,
-                in_proj_output_sizes,
-                replicated_shard_id=4,
-                tp_size=self.tp_size,
-                bias=False,
-                quant_config=self.quant_config,
-                prefix=f"{prefix}.in_proj_qkvgfab",
-            )
+            if self.shard_f_a:
+                self.in_proj_qkvgfab = MergedColumnParallelLinear(
+                    self.hidden_size,
+                    in_proj_output_sizes,
+                    bias=False,
+                    quant_config=self.quant_config,
+                    prefix=f"{prefix}.in_proj_qkvgfab",
+                )
+            else:
+                self.in_proj_qkvgfab = _KimiGDNMergedColumnParallelLinear(
+                    self.hidden_size,
+                    in_proj_output_sizes,
+                    replicated_shard_id=4,
+                    tp_size=self.tp_size,
+                    bias=False,
+                    quant_config=self.quant_config,
+                    prefix=f"{prefix}.in_proj_qkvgfab",
+                )
             if self.in_proj_padding:
                 self.in_proj_qkvgfab.weight.data[-self.in_proj_padding :].zero_()
 
@@ -524,7 +577,7 @@ class KimiK3DeltaAttention(GatedDeltaNetAttention):
             mixed_qkv = self.in_proj_qkv(hidden_states)[0]
             gfab_split_sizes = [
                 self.local_projection_size,
-                self.head_dim,
+                self.local_fa_size,
                 self.local_num_heads,
             ]
             if self.in_proj_padding:
@@ -538,7 +591,7 @@ class KimiK3DeltaAttention(GatedDeltaNetAttention):
             split_sizes = [
                 3 * self.local_projection_size,
                 self.local_projection_size,
-                self.head_dim,
+                self.local_fa_size,
                 self.local_num_heads,
             ]
             if self.in_proj_padding:
@@ -546,6 +599,8 @@ class KimiK3DeltaAttention(GatedDeltaNetAttention):
             projected = projected_qkvgfab.split(split_sizes, dim=-1)
             mixed_qkv, g_proj_states, f_a, beta = projected[:4]
 
+        if self.shard_f_a:
+            f_a = gather_kimi_sharded_projection(f_a)
         g1 = self.f_b_proj(f_a)[0]
         beta = beta.unsqueeze(0)
         g1 = rearrange(g1, "n (h d) -> 1 n h d", d=self.head_dim)


### PR DESCRIPTION
## Behavior

- Adds the opt-in Kimi-K3 runtime setting `additional_config={"kda_shard_f_a": true}`.
- Tensor-parallel shards the 128-row KDA `f_a` projection, reconstructs its complete BF16 output before `f_b`, and applies the same behavior to checkpoint-native and split mixed-precision KDA input projections.
- Preserves the replicated `f_a` projection by default.
- Rejects a tensor-parallel size that does not divide the KDA head width. Kimi-K3 therefore supports this option at TP2, TP4, TP8, and TP16; TP12 is unsupported because 128 is not divisible by 12.

## Technical reason

Kimi-K3 contains 69 KDA layers. Each replicated BF16 `f_a` weight has shape `[128, 7168]`. At TP16, sharding reduces this allocation from 120.75 MiB to 7.55 MiB per GPU, a net reduction of 113.20 MiB per GPU. The memory reduction costs one 128-element tensor-parallel gather in every KDA layer and target cycle.

## Compatibility and operating point

- This pull request is stacked on #346, which supplies a lossless B12X gather and an exact standard-collective fallback.
- No serving behavior changes unless `kda_shard_f_a` is explicitly true.
- Checkpoint-native KDA projections require no online quantization support. Online quantization of an aligned KDA input projection additionally requires the checkpoint-omitted-tail accounting in #329 and a Kimi model declaration; that integration is outside this pull request.
- A same-window TP16 DSpark A/B used 256 input tokens, 1,024 generated tokens, greedy decoding, two warmups, and six measured runs. Replicated `f_a` produced 26.159 target cycles/s; two bracketing sharded controls produced 25.297 and 25.325 target cycles/s. Replication was 3.3--3.4% faster, and both configurations retained physical KV capacity of 1,057,049 tokens. The default therefore remains replicated.
- An 8-context, 16,376-position capture measured `KL(sharded || replicated)=0.004001`, against a runtime repeat floor of `0.003444`. The replicated layout was also marginally closer to the canonical capture (`0.004230` versus `0.005090`). This option is a memory tradeoff, not a numerical-fidelity or throughput optimization.

## Validation

Executed in `voipmonitor/vllm:kimi-k3-qsrt-ii-vllm735952b-b12x180ccab-cu133-torch213-20260815-r3` with the changed source files mounted over the installed tree:

```text
pytest -q tests/models/kimi_k3/test_kda.py \
  -k 'mixed_precision_input_projection_selection or kda_f_a_partition or sharded_kda_f_a'
11 passed, 51 deselected
```

The tests cover default behavior, TP8 and TP16 partition geometry, explicit TP12 rejection, and reconstruction of `f_a` before `f_b`. Ruff formatting, Ruff lint, and `git diff --check` also pass.
