### PR TITLE
[II] Declare omitted Kimi KDA padding rows

### DIFF
--- a/tests/models/kimi_k3/test_kda.py
+++ b/tests/models/kimi_k3/test_kda.py
@@ -11,6 +11,7 @@ from types import SimpleNamespace
 import pytest
 import torch
 import torch.nn.functional as F
+from torch import nn
 
 from vllm import _custom_ops as ops
 from vllm.model_executor.layers.mamba.ops.causal_conv1d import causal_conv1d_update
@@ -21,6 +22,7 @@ from vllm.models.kimi_k3.amd.ops.third_party.kda import (
     fused_recurrent_kda_packed_decode as fused_recurrent_kda_packed_decode_amd,
 )
 from vllm.models.kimi_k3.nvidia.kda import (
+    initialize_kda_input_projection_padding,
     is_flashkda_supported,
     is_fused_kda_decode_supported,
     use_split_mixed_precision_input_projection,
@@ -65,6 +67,35 @@ def test_kda_mixed_precision_input_projection_selection(
     )
 
     assert use_split_mixed_precision_input_projection(quant_config) is expected
+
+
+def test_kda_input_projection_padding_is_declared_and_zeroed():
+    layer = nn.Linear(3, 4, bias=False)
+    layer.weight.data.fill_(1)
+
+    initialize_kda_input_projection_padding(layer, padding_rows=2, hidden_size=3)
+
+    assert layer._vllm_online_processing_unloaded == {"weight": 6}
+    torch.testing.assert_close(layer.weight[:2], torch.ones(2, 3))
+    torch.testing.assert_close(layer.weight[2:], torch.zeros(2, 3))
+
+
+def test_kda_input_projection_without_padding_has_no_declaration():
+    layer = nn.Linear(3, 4, bias=False)
+    original = layer.weight.detach().clone()
+
+    initialize_kda_input_projection_padding(layer, padding_rows=0, hidden_size=3)
+
+    assert not hasattr(layer, "_vllm_online_processing_unloaded")
+    torch.testing.assert_close(layer.weight, original)
+
+
+@pytest.mark.parametrize("padding_rows", [-1, 5])
+def test_kda_input_projection_rejects_invalid_padding(padding_rows: int):
+    layer = nn.Linear(3, 4, bias=False)
+
+    with pytest.raises(ValueError, match="must fit"):
+        initialize_kda_input_projection_padding(layer, padding_rows, hidden_size=3)
 
 
 @torch.inference_mode()

--- a/vllm/models/kimi_k3/nvidia/kda.py
+++ b/vllm/models/kimi_k3/nvidia/kda.py
@@ -90,6 +90,25 @@ def use_split_mixed_precision_input_projection(quant_config: object | None) -> b
     )
 
 
+def initialize_kda_input_projection_padding(
+    layer: nn.Module,
+    padding_rows: int,
+    hidden_size: int,
+) -> None:
+    """Declare and zero local KDA projection rows absent from the checkpoint."""
+    if padding_rows == 0:
+        return
+    if padding_rows < 0 or padding_rows > layer.weight.shape[0]:
+        raise ValueError(
+            "KDA input projection padding must fit the local weight rows, got "
+            f"padding_rows={padding_rows}, rows={layer.weight.shape[0]}."
+        )
+    layer._vllm_online_processing_unloaded = {
+        "weight": padding_rows * hidden_size,
+    }
+    layer.weight.data[-padding_rows:].zero_()
+
+
 class _KimiGDNMergedColumnParallelLinear(MergedColumnParallelLinear):
     """Merged projection with one output replicated across TP ranks."""
 
@@ -382,8 +401,11 @@ class KimiK3DeltaAttention(GatedDeltaNetAttention):
                 quant_config=self.quant_config,
                 prefix=f"{prefix}.in_proj_gfab",
             )
-            if self.in_proj_padding:
-                self.in_proj_gfab.weight.data[-self.in_proj_padding :].zero_()
+            initialize_kda_input_projection_padding(
+                self.in_proj_gfab,
+                self.in_proj_padding,
+                self.hidden_size,
+            )
         else:
             if self.in_proj_padding:
                 in_proj_output_sizes.append(self.in_proj_padding * self.tp_size)
@@ -396,8 +418,11 @@ class KimiK3DeltaAttention(GatedDeltaNetAttention):
                 quant_config=self.quant_config,
                 prefix=f"{prefix}.in_proj_qkvgfab",
             )
-            if self.in_proj_padding:
-                self.in_proj_qkvgfab.weight.data[-self.in_proj_padding :].zero_()
+            initialize_kda_input_projection_padding(
+                self.in_proj_qkvgfab,
+                self.in_proj_padding,
+                self.hidden_size,
+            )
 
         self.f_b_proj = ColumnParallelLinear(
             self.head_dim,


### PR DESCRIPTION
## Behavior

- Declares Kimi-K3 KDA input-projection alignment rows as checkpoint-omitted tensor tails.
- Zeros every declared local row before any online quantization or kernel repacking can consume the parameter.
- Applies the same contract to the checkpoint-native fused input projection and the split mixed-precision gate/factor/beta projection.

## Technical reason

Kimi-K3 pads each TP-local KDA input projection to a 16-row BF16 GEMM alignment. The checkpoint does not serialize those synthetic rows. The layerwise online-processing loader implemented by #329 needs the exact omitted element count to decide when a parameter is complete; without the declaration it can wait for checkpoint data that does not exist or process undefined tail storage.

## Compatibility

- This pull request is stacked on #329 and uses its `_vllm_online_processing_unloaded` contract.
- The projection shapes, checkpoint mapping, and executed arithmetic are unchanged.
- KDA projections with zero alignment rows receive no declaration.
- The helper consolidates the existing deterministic tail zeroing. Invalid negative or oversized padding is rejected.
- KDA `f_a` tensor-parallel sharding in #347 is independent and composes with this declaration.

## Validation

Executed in `voipmonitor/vllm:kimi-k3-qsrt-ii-vllm735952b-b12x180ccab-cu133-torch213-20260815-r3` with the changed source files mounted over the installed tree:

```text
pytest -q tests/models/kimi_k3/test_kda.py \
  tests/model_executor/model_loader/test_reload.py \
  -k 'kda_input_projection or online_processing_finalizes_checkpoint_omitted_padding'
5 passed, 101 deselected
```

The tests verify the declared element count, deterministic zero tail, zero-padding identity behavior, invalid geometry rejection, and the layerwise loader's omitted-tail completion contract. Ruff formatting, Ruff lint, and `git diff --check` also pass.
