### PR TITLE
[II] Gather paired Kimi projections through B12X

### DIFF
--- a/tests/models/kimi_k3/test_tp_projection.py
+++ b/tests/models/kimi_k3/test_tp_projection.py
@@ -185,3 +185,76 @@ def test_projection_gather_uses_standard_collective_outside_decode(monkeypatch):
     actual = tp_projection.gather_kimi_sharded_projection(local)
 
     assert actual is expected
+
+
+def test_projection_pair_is_identity_at_tp1(monkeypatch):
+    first = torch.empty(2, 8)
+    second = torch.empty(2, 4)
+    monkeypatch.setattr(
+        tp_projection, "get_tensor_model_parallel_world_size", lambda: 1
+    )
+
+    actual = tp_projection.gather_kimi_sharded_projection_pair(first, second)
+
+    assert actual[0] is first
+    assert actual[1] is second
+
+
+@pytest.mark.skipif(torch.accelerator.device_count() < 1, reason="CUDA is required.")
+def test_projection_pair_uses_one_b12x_barrier(monkeypatch):
+    tp_size = 2
+    first = torch.empty(2, 8, dtype=torch.bfloat16, device="cuda")
+    second = torch.empty(2, 4, dtype=torch.float32, device="cuda")
+    expected = (
+        torch.empty(2, 16, dtype=first.dtype, device=first.device),
+        torch.empty(2, 8, dtype=second.dtype, device=second.device),
+    )
+    group = SimpleNamespace(world_size=tp_size, ranks=list(range(tp_size)))
+    received: dict[str, object] = {}
+    monkeypatch.setattr(
+        tp_projection, "get_tensor_model_parallel_world_size", lambda: tp_size
+    )
+    monkeypatch.setattr(tp_projection, "_get_kimi_projection_group", lambda: group)
+
+    def gather_pair(local_first, local_second, projection_group, *, max_batch_size):
+        received.update(
+            local_first=local_first,
+            local_second=local_second,
+            projection_group=projection_group,
+            max_batch_size=max_batch_size,
+        )
+        return expected
+
+    monkeypatch.setattr(tp_projection, "dcp_b12x_all_gather_pair", gather_pair)
+
+    actual = tp_projection.gather_kimi_sharded_projection_pair(first, second)
+
+    assert actual is expected
+    assert received["local_first"] is first
+    assert received["local_second"] is second
+    assert received["projection_group"] is group
+    assert received["max_batch_size"] == 8
+
+
+def test_projection_pair_uses_exact_separate_fallback(monkeypatch):
+    first = torch.empty(9, 8)
+    second = torch.empty(9, 4)
+    gathered_first = torch.empty(9, 16)
+    gathered_second = torch.empty(9, 8)
+    calls: list[torch.Tensor] = []
+    monkeypatch.setattr(
+        tp_projection, "get_tensor_model_parallel_world_size", lambda: 2
+    )
+
+    def gather_one(local: torch.Tensor) -> torch.Tensor:
+        calls.append(local)
+        return gathered_first if local is first else gathered_second
+
+    monkeypatch.setattr(tp_projection, "gather_kimi_sharded_projection", gather_one)
+
+    actual = tp_projection.gather_kimi_sharded_projection_pair(first, second)
+
+    assert actual[0] is gathered_first
+    assert actual[1] is gathered_second
+    assert calls[0] is first
+    assert calls[1] is second

--- a/vllm/models/kimi_k3/nvidia/tp_projection.py
+++ b/vllm/models/kimi_k3/nvidia/tp_projection.py
@@ -10,7 +10,12 @@ from vllm.distributed import (
     get_tp_group,
     tensor_model_parallel_all_gather,
 )
-from vllm.v1.attention.ops.dcp_alltoall import dcp_b12x_all_gather_heads
+from vllm.v1.attention.ops.dcp_alltoall import (
+    dcp_b12x_all_gather_heads,
+    dcp_b12x_all_gather_pair,
+)
+
+_KIMI_B12X_PAIRED_PROJECTION_MAX_TOKENS = 8
 
 
 def _get_kimi_projection_group():
@@ -101,3 +106,34 @@ def gather_kimi_sharded_projection(output_parallel: torch.Tensor) -> torch.Tenso
     if gathered is not None:
         return gathered
     return tensor_model_parallel_all_gather(output_parallel, dim=-1)
+
+
+def gather_kimi_sharded_projection_pair(
+    local_first: torch.Tensor,
+    local_second: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Gather two decode projections behind one lossless B12X barrier."""
+    tp_size = get_tensor_model_parallel_world_size()
+    if tp_size <= 1:
+        return local_first, local_second
+    if (
+        local_first.ndim == local_second.ndim == 2
+        and local_first.shape[0] == local_second.shape[0]
+        and 0 < local_first.shape[0] <= _KIMI_B12X_PAIRED_PROJECTION_MAX_TOKENS
+        and local_first.is_cuda
+        and local_second.is_cuda
+        and local_first.is_contiguous()
+        and local_second.is_contiguous()
+    ):
+        projection_group = _get_kimi_projection_group()
+        if projection_group.world_size == tp_size:
+            return dcp_b12x_all_gather_pair(
+                local_first,
+                local_second,
+                projection_group,
+                max_batch_size=_KIMI_B12X_PAIRED_PROJECTION_MAX_TOKENS,
+            )
+    return (
+        gather_kimi_sharded_projection(local_first),
+        gather_kimi_sharded_projection(local_second),
+    )


### PR DESCRIPTION
## Behavior

- Gathers two rank-local Kimi-K3 decode projections through one B12X synchronization barrier.
- Supports batches from one through eight tokens and mixed projection dtypes accepted by the public paired-gather transport.
- Preserves TP1 identity and exact separate-gather fallbacks for unsupported shapes, devices, layouts, and batch sizes.

## Technical reason

Kimi-K3 computes the routed-down activation and FP32 router scores from the same hidden-state rows. Both tensors must be reconstructed across tensor-parallel ranks. A paired transport removes one per-layer synchronization without changing either payload.

## Compatibility

- This pull request is stacked on #349 and also requires the public paired B12X transport in #342.
- The helper is not called by a model in this pull request; Kimi MoE integration is intentionally separate.
- No top-k implementation or native CUDA extension is included.
- TP2, TP4, TP8, and TP16 are supported by the transport dependency. Unsupported tensor-parallel sizes use exact separate collectives.

## Validation

Executed in `voipmonitor/vllm:kimi-k3-qsrt-ii-vllm735952b-b12x180ccab-cu133-torch213-20260815-r3` with the changed source files mounted over the installed tree:

```text
pytest -q tests/models/kimi_k3/test_tp_projection.py
10 passed
```

The tests verify TP1 identity, one-barrier dispatch, mixed BF16/FP32 inputs, the eight-token bound, and exact separate fallback behavior in addition to the single-projection coverage inherited from #349. Ruff formatting, Ruff lint, and `git diff --check` also pass.
