### PR TITLE
[II] Expose rank-local Kimi projection outputs

### DIFF
--- a/tests/models/kimi_k3/test_sequence_parallel.py
+++ b/tests/models/kimi_k3/test_sequence_parallel.py
@@ -359,6 +359,72 @@ def test_kimi_column_parallel_loader_zero_fills_tail():
     torch.testing.assert_close(param, expected)
 
 
+def test_kimi_padded_column_gathers_and_removes_logical_tail(monkeypatch):
+    layer = object.__new__(kimi_model.KimiPaddedColumnParallelLinear)
+    nn.Module.__init__(layer)
+    layer.kimi_gather_output = True
+    layer.logical_output_size = 5
+    local_output = torch.arange(3, dtype=torch.float32).view(1, 3)
+    gathered_output = torch.arange(6, dtype=torch.float32).view(1, 6)
+    monkeypatch.setattr(
+        kimi_model.ColumnParallelLinear,
+        "forward",
+        lambda _self, _x: (local_output, None),
+    )
+    monkeypatch.setattr(
+        kimi_model,
+        "gather_kimi_sharded_projection",
+        lambda output: gathered_output,
+    )
+
+    output, bias = layer(torch.empty(1, 1))
+
+    torch.testing.assert_close(output, gathered_output[:, :5])
+    assert output.is_contiguous()
+    assert bias is None
+
+
+def test_kimi_gate_local_projection_preserves_linear_return_contract():
+    layer = object.__new__(kimi_model.KimiColumnParallelGate)
+    nn.Module.__init__(layer)
+    layer.weight = nn.Parameter(torch.arange(12).view(3, 4).float())
+    hidden_states = torch.arange(8).view(2, 4).float()
+
+    output, bias = layer.forward_local(hidden_states)
+
+    torch.testing.assert_close(
+        output,
+        torch.nn.functional.linear(hidden_states, layer.weight),
+    )
+    assert output.dtype == torch.float32
+    assert bias is None
+
+
+def test_kimi_gate_gathers_fp32_local_projection(monkeypatch):
+    layer = object.__new__(kimi_model.KimiColumnParallelGate)
+    nn.Module.__init__(layer)
+    layer.logical_output_size = 5
+    layer.weight = nn.Parameter(torch.arange(12).view(3, 4).float())
+    hidden_states = torch.arange(8).view(2, 4).float()
+    gathered = torch.arange(12).view(2, 6).float()
+    received: dict[str, torch.Tensor] = {}
+
+    def gather(output: torch.Tensor) -> torch.Tensor:
+        received["local"] = output
+        return gathered
+
+    monkeypatch.setattr(kimi_model, "gather_kimi_sharded_projection", gather)
+
+    output, bias = layer(hidden_states)
+
+    torch.testing.assert_close(
+        received["local"],
+        torch.nn.functional.linear(hidden_states, layer.weight),
+    )
+    torch.testing.assert_close(output, gathered[:, :5])
+    assert bias is None
+
+
 def test_kimi_merged_projection_restores_logical_output_order(monkeypatch):
     layer = object.__new__(kimi_mla.KimiShardedMergedColumnParallelLinear)
     nn.Module.__init__(layer)

--- a/vllm/models/kimi_k3/nvidia/model.py
+++ b/vllm/models/kimi_k3/nvidia/model.py
@@ -17,7 +17,6 @@ from vllm.distributed import (
     get_ep_group,
     get_pp_group,
     get_tensor_model_parallel_world_size,
-    tensor_model_parallel_all_gather,
     tensor_model_parallel_all_reduce,
 )
 from vllm.forward_context import get_forward_context, is_forward_context_available
@@ -107,6 +106,9 @@ from vllm.models.kimi_k3.nvidia.low_latency_gemm import (
 )
 from vllm.models.kimi_k3.nvidia.mla import MultiHeadLatentAttention
 from vllm.models.kimi_k3.nvidia.ops import attn_res
+from vllm.models.kimi_k3.nvidia.tp_projection import (
+    gather_kimi_sharded_projection,
+)
 from vllm.multimodal import MULTIMODAL_REGISTRY
 from vllm.multimodal.inputs import NestedTensors
 from vllm.platforms import current_platform
@@ -343,19 +345,24 @@ class KimiPaddedColumnParallelLinear(ColumnParallelLinear):
     ) -> None:
         tp_size = get_tensor_model_parallel_world_size()
         self.logical_output_size = output_size
+        self.kimi_gather_output = gather_output
         padded_output_size = cdiv(output_size, tp_size) * tp_size
         super().__init__(
             input_size,
             padded_output_size,
             bias=False,
-            gather_output=gather_output,
+            gather_output=False,
             quant_config=None,
             prefix=prefix,
         )
 
+    def forward_local(self, x: torch.Tensor):
+        return super().forward(x)
+
     def forward(self, x: torch.Tensor):
-        output, bias = super().forward(x)
-        if self.gather_output:
+        output, bias = self.forward_local(x)
+        if self.kimi_gather_output:
+            output = gather_kimi_sharded_projection(output)
             output = output[..., : self.logical_output_size].contiguous()
         return output, bias
 
@@ -371,17 +378,20 @@ class KimiColumnParallelGate(KimiPaddedColumnParallelLinear):
             gather_output=False,
         )
 
-    def forward(self, x: torch.Tensor):
+    def forward_local(
+        self, x: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
         if x.is_cuda and x.dtype == self.weight.dtype == torch.bfloat16:
-            output_parallel = torch.mm(x, self.weight.T, out_dtype=torch.float32)
+            output = torch.mm(x, self.weight.T, out_dtype=torch.float32)
         else:
-            output_parallel = torch.nn.functional.linear(
+            output = torch.nn.functional.linear(
                 x.to(self.weight.dtype), self.weight
             ).float()
-        if self.tp_size > 1:
-            output = tensor_model_parallel_all_gather(output_parallel)
-        else:
-            output = output_parallel
+        return output, None
+
+    def forward(self, x: torch.Tensor):
+        output_parallel, _ = self.forward_local(x)
+        output = gather_kimi_sharded_projection(output_parallel)
         return output[..., : self.logical_output_size].contiguous(), None
 
 


### PR DESCRIPTION
## Behavior

- Exposes rank-local output from Kimi's padded column-parallel projection and FP32 router projection.
- Routes the ordinary gathered forward path through `gather_kimi_sharded_projection`.
- Removes checkpoint-alignment rows only after the complete tensor-parallel result has been assembled.
- Preserves the existing `(output, bias)` linear-layer contract.

## Technical reason

Kimi decode can combine latent and router projection transport behind one tensor-parallel synchronization barrier only when both rank-local projections are available to the caller. The built-in column-parallel gather synchronizes each projection independently.

## Compatibility

The change is limited to the NVIDIA Kimi-K3 model implementation. The ordinary forward path retains its logical output shape and exact standard all-gather fallback. Callers that do not use the rank-local methods keep the existing behavior.

This pull request is stacked on #350, which provides the paired Kimi projection transport.

## Validation

- `pytest -q tests/models/kimi_k3/test_sequence_parallel.py`
- Result: 33 passed.
- `git diff --check`
- Ruff formatting and lint checks pass.
