### PR TITLE
[II] Bind fused Kimi projection routing

### DIFF
--- a/tests/models/kimi_k3/test_tp_projection.py
+++ b/tests/models/kimi_k3/test_tp_projection.py
@@ -258,3 +258,70 @@ def test_projection_pair_uses_exact_separate_fallback(monkeypatch):
     assert actual[1] is gathered_second
     assert calls[0] is first
     assert calls[1] is second
+
+
+def test_projection_pair_topk_uses_available_b12x_binding(monkeypatch):
+    local_down = torch.empty(1, 448)
+    local_router = torch.empty(1, 112)
+    correction_bias = torch.empty(896)
+    group = SimpleNamespace(world_size=8, ranks=list(range(8)))
+    expected = (torch.empty(1, 3584), torch.empty(2, 16))
+    received: dict[str, object] = {}
+    monkeypatch.setattr(
+        tp_projection, "get_tensor_model_parallel_world_size", lambda: 8
+    )
+    monkeypatch.setattr(tp_projection, "_get_kimi_projection_group", lambda: group)
+
+    def pair_topk(local_down_arg, local_router_arg, bias_arg, group_arg):
+        received.update(
+            local_down=local_down_arg,
+            local_router=local_router_arg,
+            correction_bias=bias_arg,
+            group=group_arg,
+        )
+        return expected
+
+    monkeypatch.setattr(
+        tp_projection.dcp_alltoall,
+        "try_dcp_b12x_all_gather_pair_kimi_topk",
+        pair_topk,
+        raising=False,
+    )
+
+    actual = tp_projection.try_gather_kimi_sharded_projection_pair_topk(
+        local_down,
+        local_router,
+        correction_bias,
+    )
+
+    assert actual is expected
+    assert received == {
+        "local_down": local_down,
+        "local_router": local_router,
+        "correction_bias": correction_bias,
+        "group": group,
+    }
+
+
+def test_projection_pair_topk_returns_none_without_b12x_binding(monkeypatch):
+    monkeypatch.setattr(
+        tp_projection, "get_tensor_model_parallel_world_size", lambda: 8
+    )
+    monkeypatch.delattr(
+        tp_projection.dcp_alltoall,
+        "try_dcp_b12x_all_gather_pair_kimi_topk",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        tp_projection,
+        "_get_kimi_projection_group",
+        lambda: pytest.fail("an unavailable binding must not resolve a group"),
+    )
+
+    actual = tp_projection.try_gather_kimi_sharded_projection_pair_topk(
+        torch.empty(1, 448),
+        torch.empty(1, 112),
+        torch.empty(896),
+    )
+
+    assert actual is None

--- a/vllm/models/kimi_k3/nvidia/tp_projection.py
+++ b/vllm/models/kimi_k3/nvidia/tp_projection.py
@@ -10,6 +10,7 @@ from vllm.distributed import (
     get_tp_group,
     tensor_model_parallel_all_gather,
 )
+from vllm.v1.attention.ops import dcp_alltoall
 from vllm.v1.attention.ops.dcp_alltoall import (
     dcp_b12x_all_gather_heads,
     dcp_b12x_all_gather_pair,
@@ -136,4 +137,31 @@ def gather_kimi_sharded_projection_pair(
     return (
         gather_kimi_sharded_projection(local_first),
         gather_kimi_sharded_projection(local_second),
+    )
+
+
+def try_gather_kimi_sharded_projection_pair_topk(
+    local_down: torch.Tensor,
+    local_router: torch.Tensor,
+    correction_bias: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor] | None:
+    """Use B12X fused Kimi projection transport and expert selection.
+
+    A missing or ineligible fused binding returns ``None``. The model caller
+    must then use the exact paired gather and ordinary router operations.
+    """
+    if get_tensor_model_parallel_world_size() <= 1:
+        return None
+    pair_topk = getattr(
+        dcp_alltoall,
+        "try_dcp_b12x_all_gather_pair_kimi_topk",
+        None,
+    )
+    if pair_topk is None:
+        return None
+    return pair_topk(
+        local_down,
+        local_router,
+        correction_bias,
+        _get_kimi_projection_group(),
     )


### PR DESCRIPTION
## Behavior

- Exposes a Kimi projection helper that invokes the B12X fused paired gather and deterministic top-16 selector when the binding is available.
- Returns `None` when TP1 or a vLLM build without the fused binding is used.
- Leaves the exact paired-gather and ordinary-router fallback under the model caller's control.

## Technical reason

The B12X collective binding operates on rank-local latent and FP32 router projections. Keeping its eligibility result optional lets Kimi model code use one fused operation without weakening the ordinary semantic fallback or requiring B12X-specific logic inside projection layers.

## Compatibility

The helper does not change an existing forward path. Activation requires vLLM #343 and B12X #216; builds without that interface retain the non-fused path. The projection group must still span the complete tensor-parallel rank set.

This pull request is stacked on #351.

## Validation

- `pytest -q /workspace/test_tp_projection.py` in the source-locked CUDA 13.3, PyTorch 2.13 Kimi-K3 image.
- Result: 12 passed.
- Ruff lint and formatting checks pass.
- `git diff --check` passes.
