### PR TITLE
[II] Accept compact Kimi expert routing payloads

### DIFF
--- a/tests/models/kimi_k3/test_sequence_parallel.py
+++ b/tests/models/kimi_k3/test_sequence_parallel.py
@@ -425,6 +425,84 @@ def test_kimi_gate_gathers_fp32_local_projection(monkeypatch):
     assert bias is None
 
 
+def test_kimi_router_decodes_precomputed_topk_payload_without_copy():
+    router = kimi_model.KimiK3PrecomputedTopKRouter(
+        top_k=16,
+        global_num_experts=896,
+        e_score_correction_bias=nn.Parameter(torch.zeros(896)),
+        renormalize=True,
+        routed_scaling_factor=1.0,
+        scoring_func="sigmoid",
+    )
+    num_tokens = 3
+    hidden_states = torch.empty(num_tokens, 4)
+    payload = torch.empty(num_tokens * 2, 16, dtype=torch.float32)
+    expected_weights = torch.arange(num_tokens * 16, dtype=torch.float32).view(
+        num_tokens, 16
+    )
+    expected_ids = torch.arange(num_tokens * 16, dtype=torch.int32).view(num_tokens, 16)
+    payload[:num_tokens].copy_(expected_weights)
+    payload[num_tokens:].view(torch.int32).copy_(expected_ids)
+
+    weights, ids = router._compute_routing(hidden_states, payload, torch.int32)
+
+    assert weights.data_ptr() == payload.data_ptr()
+    assert ids.data_ptr() == payload[num_tokens:].data_ptr()
+    torch.testing.assert_close(weights, expected_weights)
+    torch.testing.assert_close(ids, expected_ids)
+
+
+def test_kimi_router_uses_standard_routing_for_non_payload(monkeypatch):
+    router = kimi_model.KimiK3PrecomputedTopKRouter(
+        top_k=16,
+        global_num_experts=896,
+        e_score_correction_bias=nn.Parameter(torch.zeros(896)),
+        renormalize=True,
+        routed_scaling_factor=1.0,
+        scoring_func="sigmoid",
+    )
+    hidden_states = torch.empty(2, 4)
+    router_logits = torch.empty(2, 896)
+    input_ids = torch.tensor([1, 2])
+    expected = (torch.empty(2, 16), torch.empty(2, 16, dtype=torch.int32))
+    received: dict[str, object] = {}
+
+    def standard_routing(
+        _self,
+        hidden_states_arg,
+        router_logits_arg,
+        indices_type_arg,
+        *,
+        input_ids=None,
+    ):
+        received.update(
+            hidden_states=hidden_states_arg,
+            router_logits=router_logits_arg,
+            indices_type=indices_type_arg,
+            input_ids=input_ids,
+        )
+        return expected
+
+    monkeypatch.setattr(
+        kimi_model.FusedTopKBiasRouter,
+        "_compute_routing",
+        standard_routing,
+    )
+
+    actual = router._compute_routing(
+        hidden_states,
+        router_logits,
+        torch.int32,
+        input_ids=input_ids,
+    )
+
+    assert actual is expected
+    assert received["hidden_states"] is hidden_states
+    assert received["router_logits"] is router_logits
+    assert received["indices_type"] is torch.int32
+    assert received["input_ids"] is input_ids
+
+
 def test_kimi_merged_projection_restores_logical_output_order(monkeypatch):
     layer = object.__new__(kimi_mla.KimiShardedMergedColumnParallelLinear)
     nn.Module.__init__(layer)

--- a/vllm/models/kimi_k3/nvidia/model.py
+++ b/vllm/models/kimi_k3/nvidia/model.py
@@ -29,6 +29,9 @@ from vllm.model_executor.layers.fused_moe import (
 from vllm.model_executor.layers.fused_moe.router.base_router import (
     eplb_map_to_physical_and_record,
 )
+from vllm.model_executor.layers.fused_moe.router.fused_topk_bias_router import (
+    FusedTopKBiasRouter,
+)
 from vllm.model_executor.layers.fused_moe.router.gate_linear import GateLinear
 from vllm.model_executor.layers.fused_moe.router.grouped_topk_router import (
     fused_grouped_topk,
@@ -612,6 +615,41 @@ def make_kimi_k3_mega_moe_expert_params_mapping(
     return mapping
 
 
+class KimiK3PrecomputedTopKRouter(FusedTopKBiasRouter):
+    """Consume Kimi's compact, already-selected routed-expert payload."""
+
+    def _compute_routing(
+        self,
+        hidden_states: torch.Tensor,
+        router_logits: torch.Tensor,
+        indices_type: torch.dtype | None,
+        *,
+        input_ids: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        num_tokens = hidden_states.shape[0]
+        if (
+            self.top_k == 16
+            and self.global_num_experts == 896
+            and self.scoring_func == "sigmoid"
+            and self.renormalize
+            and self.routed_scaling_factor == 1.0
+            and indices_type in (None, torch.int32)
+            and router_logits.shape == (num_tokens * 2, self.top_k)
+            and router_logits.dtype == torch.float32
+            and router_logits.device == hidden_states.device
+            and router_logits.is_contiguous()
+        ):
+            topk_weights = router_logits[:num_tokens]
+            topk_ids = router_logits[num_tokens:].view(torch.int32)
+            return topk_weights, topk_ids
+        return super()._compute_routing(
+            hidden_states,
+            router_logits,
+            indices_type,
+            input_ids=input_ids,
+        )
+
+
 class KimiMoE(nn.Module):
     def __init__(
         self,
@@ -805,6 +843,25 @@ class KimiMoE(nn.Module):
                 activation_linear_beta=activation_situ_linear_beta,
             )
         else:
+            router = None
+            if (
+                num_experts == 896
+                and num_experts_per_token == 16
+                and config.use_grouped_topk
+                and config.num_expert_group == 1
+                and config.topk_group == 1
+                and config.moe_router_activation_func == "sigmoid"
+                and moe_renormalize
+                and self.routed_scaling_factor == 1.0
+            ):
+                router = KimiK3PrecomputedTopKRouter(
+                    top_k=num_experts_per_token,
+                    global_num_experts=num_experts,
+                    e_score_correction_bias=self.gate.e_score_correction_bias,
+                    renormalize=moe_renormalize,
+                    routed_scaling_factor=self.routed_scaling_factor,
+                    scoring_func=self.moe_router_activation_func,
+                )
             self.experts = FusedMoEFactory(
                 shared_experts=self.shared_experts,
                 num_experts=num_experts,
@@ -823,6 +880,7 @@ class KimiMoE(nn.Module):
                 scoring_func=config.moe_router_activation_func,
                 e_score_correction_bias=self.gate.e_score_correction_bias,
                 routed_scaling_factor=self.routed_scaling_factor,
+                router=router,
                 # Down projection runs outside MoERunner so it can overlap the
                 # router gate on the aux stream (see forward()); the original
                 # hidden states are passed to forward() as shared_experts_input


### PR DESCRIPTION
## Behavior

- Accepts a contiguous Kimi-K3 routing payload containing FP32 top-16 weights followed by int32 expert IDs in the same allocation.
- Returns zero-copy views of the payload to the MoE runner.
- Uses the standard biased sigmoid router for ordinary 896-logit inputs and every unsupported configuration.
- Installs the payload-aware router only for Kimi's 896-expert, top-16, one-group, renormalized sigmoid routing contract with a routed scaling factor of 1.0.

## Technical reason

B12X can select Kimi's experts while gathering the rank-local router projection. The MoE runner must recognize that compact result without recomputing sigmoid, correction bias, top-k selection, and normalization over 896 gathered logits.

## Compatibility

Ordinary router logits retain the existing `FusedTopKBiasRouter` implementation. Kimi variants with different expert geometry, grouping, score function, normalization, index dtype, or routed scaling use the factory's standard router.

This pull request is stacked on #352. Producing the compact payload requires vLLM #343 and B12X #216.

## Validation

- `pytest -q tests/models/kimi_k3/test_sequence_parallel.py`
- Result: 35 passed in the source-locked CUDA 13.3, PyTorch 2.13 Kimi-K3 image.
- Ruff lint and formatting checks pass.
- `git diff --check` passes.
