### PR TITLE
[II] Combine Kimi latent and router projection transport

### DIFF
--- a/tests/models/kimi_k3/test_sequence_parallel.py
+++ b/tests/models/kimi_k3/test_sequence_parallel.py
@@ -503,6 +503,110 @@ def test_kimi_router_uses_standard_routing_for_non_payload(monkeypatch):
     assert received["input_ids"] is input_ids
 
 
+def _make_paired_projection_moe():
+    moe = object.__new__(kimi_model.KimiMoE)
+    nn.Module.__init__(moe)
+    moe.use_mega_moe = False
+    moe.gate = object.__new__(kimi_model.KimiColumnParallelGate)
+    nn.Module.__init__(moe.gate)
+    moe.gate.logical_output_size = 5
+    moe.gate.e_score_correction_bias = nn.Parameter(torch.zeros(5))
+    moe.routed_expert_down_proj = object.__new__(
+        kimi_model.KimiPaddedColumnParallelLinear
+    )
+    nn.Module.__init__(moe.routed_expert_down_proj)
+    moe.routed_expert_down_proj.logical_output_size = 3
+    moe._down_proj_events = (None, None)
+    moe._down_proj_stream = None
+    return moe
+
+
+def test_kimi_moe_uses_fused_projection_routing_payload(monkeypatch):
+    moe = _make_paired_projection_moe()
+    hidden_states = torch.empty(1, 4)
+    local_router = torch.empty(1, 3)
+    local_down = torch.empty(1, 2)
+    gathered_down = torch.empty(1, 3)
+    routing_payload = torch.empty(2, 16)
+    monkeypatch.setattr(
+        kimi_model.KimiColumnParallelGate,
+        "forward_local",
+        lambda _self, _hidden: (local_router, None),
+    )
+    monkeypatch.setattr(
+        kimi_model.KimiPaddedColumnParallelLinear,
+        "forward_local",
+        lambda _self, _hidden: (local_down, None),
+    )
+    monkeypatch.setattr(
+        kimi_model,
+        "maybe_execute_in_parallel",
+        lambda first, second, *_args: (first(), second()),
+    )
+    monkeypatch.setattr(
+        kimi_model,
+        "try_gather_kimi_sharded_projection_pair_topk",
+        lambda down, router, bias: (gathered_down, routing_payload),
+    )
+    monkeypatch.setattr(
+        kimi_model,
+        "gather_kimi_sharded_projection_pair",
+        lambda *_args: pytest.fail("the fused result must skip paired gather"),
+    )
+
+    routed_hidden, router_output, topk_ids = moe._maybe_overlap_router_and_down_proj(
+        hidden_states
+    )
+
+    assert routed_hidden is gathered_down
+    assert router_output is routing_payload
+    assert topk_ids is None
+
+
+def test_kimi_moe_paired_projection_uses_exact_router_fallback(monkeypatch):
+    moe = _make_paired_projection_moe()
+    hidden_states = torch.empty(2, 4)
+    local_router = torch.empty(2, 3)
+    local_down = torch.empty(2, 2)
+    gathered_router = torch.arange(12, dtype=torch.float32).view(2, 6)
+    gathered_down = torch.arange(8, dtype=torch.float32).view(2, 4)
+    monkeypatch.setattr(
+        kimi_model.KimiColumnParallelGate,
+        "forward_local",
+        lambda _self, _hidden: (local_router, None),
+    )
+    monkeypatch.setattr(
+        kimi_model.KimiPaddedColumnParallelLinear,
+        "forward_local",
+        lambda _self, _hidden: (local_down, None),
+    )
+    monkeypatch.setattr(
+        kimi_model,
+        "maybe_execute_in_parallel",
+        lambda first, second, *_args: (first(), second()),
+    )
+    monkeypatch.setattr(
+        kimi_model,
+        "try_gather_kimi_sharded_projection_pair_topk",
+        lambda *_args: None,
+    )
+    monkeypatch.setattr(
+        kimi_model,
+        "gather_kimi_sharded_projection_pair",
+        lambda down, router: (gathered_down, gathered_router),
+    )
+
+    routed_hidden, router_output, topk_ids = moe._maybe_overlap_router_and_down_proj(
+        hidden_states
+    )
+
+    torch.testing.assert_close(routed_hidden, gathered_down[:, :3])
+    torch.testing.assert_close(router_output, gathered_router[:, :5])
+    assert routed_hidden.is_contiguous()
+    assert router_output.is_contiguous()
+    assert topk_ids is None
+
+
 def test_kimi_merged_projection_restores_logical_output_order(monkeypatch):
     layer = object.__new__(kimi_mla.KimiShardedMergedColumnParallelLinear)
     nn.Module.__init__(layer)

--- a/vllm/models/kimi_k3/nvidia/model.py
+++ b/vllm/models/kimi_k3/nvidia/model.py
@@ -111,6 +111,8 @@ from vllm.models.kimi_k3.nvidia.mla import MultiHeadLatentAttention
 from vllm.models.kimi_k3.nvidia.ops import attn_res
 from vllm.models.kimi_k3.nvidia.tp_projection import (
     gather_kimi_sharded_projection,
+    gather_kimi_sharded_projection_pair,
+    try_gather_kimi_sharded_projection_pair_topk,
 )
 from vllm.multimodal import MULTIMODAL_REGISTRY
 from vllm.multimodal.inputs import NestedTensors
@@ -926,10 +928,9 @@ class KimiMoE(nn.Module):
             logits and ``topk_ids`` is ``None``.
         """
 
-        def _router(
-            hidden_states: torch.Tensor,
+        def _finish_router(
+            router_logits: torch.Tensor,
         ) -> tuple[torch.Tensor, torch.Tensor | None]:
-            router_logits, _ = self.gate(hidden_states)
             if not self.use_mega_moe:
                 return router_logits, None
             return fused_grouped_topk(
@@ -944,11 +945,50 @@ class KimiMoE(nn.Module):
                 routed_scaling_factor=self.routed_scaling_factor,
             )
 
+        def _router(
+            hidden_states: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor | None]:
+            router_logits, _ = self.gate(hidden_states)
+            return _finish_router(router_logits)
+
         down_proj = self.routed_expert_down_proj
         if down_proj is None:
             router_output, topk_ids = _router(hidden_states)
             return hidden_states, router_output, topk_ids
         num_tokens = hidden_states.shape[0]
+        if (
+            0 < num_tokens <= 8
+            and not self.use_mega_moe
+            and isinstance(self.gate, KimiColumnParallelGate)
+            and isinstance(down_proj, KimiPaddedColumnParallelLinear)
+        ):
+            (router_local, _), (down_local, _) = maybe_execute_in_parallel(
+                lambda: self.gate.forward_local(hidden_states),
+                lambda: down_proj.forward_local(hidden_states),
+                self._down_proj_events[0],
+                self._down_proj_events[1],
+                self._down_proj_stream,
+            )
+            fused_pair_topk = try_gather_kimi_sharded_projection_pair_topk(
+                down_local,
+                router_local,
+                self.gate.e_score_correction_bias.data,
+            )
+            if fused_pair_topk is not None:
+                routed_hidden_states, routing_payload = fused_pair_topk
+                return routed_hidden_states, routing_payload, None
+            routed_hidden_states, router_logits = gather_kimi_sharded_projection_pair(
+                down_local,
+                router_local,
+            )
+            routed_hidden_states = routed_hidden_states[
+                ..., : down_proj.logical_output_size
+            ].contiguous()
+            router_logits = router_logits[
+                ..., : self.gate.logical_output_size
+            ].contiguous()
+            router_output, topk_ids = _finish_router(router_logits)
+            return routed_hidden_states, router_output, topk_ids
         (router_output, topk_ids), (routed_hidden_states, _) = (
             maybe_execute_in_parallel(
                 lambda: _router(hidden_states),


### PR DESCRIPTION
## Behavior

- Computes Kimi's tensor-parallel latent and FP32 router projections from rank-local weights before either projection is gathered.
- Overlaps the two local projections on the existing auxiliary stream.
- Uses the B12X paired gather and deterministic top-16 operation when its exact Kimi contract is eligible.
- Uses one lossless paired gather followed by the ordinary router when fused expert selection is unavailable.
- Removes alignment rows after a complete fallback gather.

## Technical reason

Gathering each projection inside its linear layer forces two independent tensor-parallel synchronization barriers. Kimi decode needs both rank-local results at the same point so B12X can transport them together and optionally select routed experts before materializing 896 global router logits.

## Compatibility

The combined path applies only to batches of one through eight when both auxiliary projections use Kimi's column-parallel layers and MegaMoE is disabled. Replicated projections, sequence-parallel execution, MegaMoE, larger batches, unavailable B12X operations, and unsupported tensor-parallel geometry retain the existing execution path or the exact paired-gather fallback.

This pull request is stacked on #353. Fused expert selection requires vLLM #343 and B12X #216.

## Validation

- `pytest -q tests/models/kimi_k3/test_sequence_parallel.py`
- Result: 37 passed in the source-locked CUDA 13.3, PyTorch 2.13 Kimi-K3 image.
- Tests cover fused payload use, exact fallback, logical-tail removal, and the ordinary projection contracts.
- Ruff lint and formatting checks pass.
- `git diff --check` passes.
