### PR TITLE
[II] Warm Kimi projection graph operations eagerly

### DIFF
--- a/tests/distributed/test_dcp_a2a.py
+++ b/tests/distributed/test_dcp_a2a.py
@@ -1505,6 +1505,45 @@ def test_b12x_kimi_pair_topk_rejects_non_contract_inputs(monkeypatch):
         )
 
 
+def test_kimi_projection_warmup_respects_transport_token_cap(monkeypatch):
+    from vllm.v1.attention.ops import dcp_alltoall
+
+    monkeypatch.setenv("VLLM_USE_B12X_DCP_A2A", "1")
+    monkeypatch.setenv("VLLM_DCP_A2A_MAX_TOKENS", "4")
+    group = _FakeCPGroup(8, object())  # type: ignore[arg-type]
+    calls: list[tuple[str, tuple[int, ...], tuple[int, ...]]] = []
+
+    def pair(local_down, local_router, projection_group, *, max_batch_size):
+        assert projection_group is group
+        assert max_batch_size == 8
+        calls.append(("pair", tuple(local_down.shape), tuple(local_router.shape)))
+        return local_down, local_router
+
+    def topk(local_down, local_router, correction_bias, projection_group):
+        assert projection_group is group
+        assert correction_bias.shape == (896,)
+        calls.append(("topk", tuple(local_down.shape), tuple(local_router.shape)))
+        return local_down, torch.empty(2, 16)
+
+    monkeypatch.setattr(dcp_alltoall, "_try_b12x_dcp_all_gather_pair", pair)
+    monkeypatch.setattr(
+        dcp_alltoall,
+        "try_dcp_b12x_all_gather_pair_kimi_topk",
+        topk,
+    )
+
+    warmed = dcp_alltoall.warmup_b12x_kimi_projection_gathers(
+        group,  # type: ignore[arg-type]
+        device=torch.device("cpu"),
+    )
+
+    assert warmed == 2
+    assert calls == [
+        ("pair", (4, 448), (4, 112)),
+        ("topk", (1, 448), (1, 112)),
+    ]
+
+
 def test_warmup_skips_unsupported_world_size(monkeypatch: pytest.MonkeyPatch):
     from vllm.v1.attention.ops import dcp_alltoall
 

--- a/tests/model_executor/test_flashinfer_autotune_cache.py
+++ b/tests/model_executor/test_flashinfer_autotune_cache.py
@@ -244,6 +244,41 @@ def test_b12x_dcp_warmup_finds_generic_mla_attention(monkeypatch) -> None:
     ]
 
 
+def test_b12x_projection_warmup_uses_complete_projection_group(monkeypatch) -> None:
+    from vllm.distributed import parallel_state
+    from vllm.models.kimi_k3.nvidia.model import KimiMoE
+    from vllm.v1.attention.ops import dcp_alltoall
+
+    monkeypatch.setenv("VLLM_USE_B12X_DCP_A2A", "1")
+    moe = object.__new__(KimiMoE)
+    torch.nn.Module.__init__(moe)
+    moe.auxiliary_projections_tp_sharded = True
+    moe.register_parameter("device_probe", torch.nn.Parameter(torch.empty(1)))
+    model = torch.nn.Module()
+    model.add_module("moe", moe)
+    worker = SimpleNamespace(get_model=lambda: model)
+    tp_group = SimpleNamespace(world_size=16, ranks=list(range(16)))
+    dcp_group = SimpleNamespace(world_size=8, ranks=list(range(8)))
+    calls = []
+    monkeypatch.setattr(parallel_state, "get_tp_group", lambda: tp_group)
+    monkeypatch.setattr(parallel_state, "get_dcp_group", lambda: dcp_group)
+    monkeypatch.setattr(
+        dcp_alltoall,
+        "warmup_b12x_kimi_projection_gathers",
+        lambda *args, **kwargs: calls.append((args, kwargs)) or 2,
+    )
+
+    warmed = kernel_warmup._warmup_b12x_kimi_projection_gathers(worker)
+
+    assert warmed == 2
+    assert calls == [
+        (
+            (tp_group,),
+            {"device": torch.device("cpu")},
+        )
+    ]
+
+
 def test_kernel_warmup_runs_b12x_mxfp8_linear_warmup(monkeypatch) -> None:
     calls = []
     model = torch.nn.Linear(2, 2)

--- a/vllm/model_executor/warmup/kernel_warmup.py
+++ b/vllm/model_executor/warmup/kernel_warmup.py
@@ -262,6 +262,40 @@ def _warmup_b12x_dcp_a2a(worker: "Worker") -> int:
     return len(warmed_signatures)
 
 
+def _warmup_b12x_kimi_projection_gathers(worker: "Worker") -> int:
+    """Warm projection collectives only for feature-sharded Kimi MoE layers."""
+    if not envs.VLLM_USE_B12X_DCP_A2A:
+        return 0
+
+    from vllm.distributed.parallel_state import get_dcp_group, get_tp_group
+    from vllm.models.kimi_k3.nvidia.model import KimiMoE
+    from vllm.v1.attention.ops.dcp_alltoall import (
+        warmup_b12x_kimi_projection_gathers,
+    )
+
+    model = worker.get_model()
+    uses_sharded_projections = any(
+        isinstance(module, KimiMoE)
+        and bool(getattr(module, "auxiliary_projections_tp_sharded", False))
+        for module in model.modules()
+    )
+    if not uses_sharded_projections:
+        return 0
+
+    dcp_group = get_dcp_group()
+    tp_group = get_tp_group()
+    projection_group = (
+        dcp_group
+        if dcp_group.world_size == tp_group.world_size
+        and list(dcp_group.ranks) == list(tp_group.ranks)
+        else tp_group
+    )
+    return warmup_b12x_kimi_projection_gathers(
+        projection_group,
+        device=next(model.parameters()).device,
+    )
+
+
 def kernel_warmup(worker: "Worker", *, process_local_only: bool = False) -> bool:
     if not worker.use_v2_model_runner:
         # Pooling models do not use the generation slot-mapping path.
@@ -322,6 +356,12 @@ def kernel_warmup(worker: "Worker", *, process_local_only: bool = False) -> bool
         logger.info(
             "Warmed up %d B12X DCP collective signature(s).",
             warmed_dcp_a2a,
+        )
+    warmed_projection_gathers = _warmup_b12x_kimi_projection_gathers(worker)
+    if warmed_projection_gathers:
+        logger.info(
+            "Warmed up %d B12X Kimi projection operation(s).",
+            warmed_projection_gathers,
         )
 
     flashinfer_sparse_mla_decode_autotune_warmup(worker)

--- a/vllm/v1/attention/ops/dcp_alltoall.py
+++ b/vllm/v1/attention/ops/dcp_alltoall.py
@@ -52,6 +52,7 @@ _B12X_DCP_WORLD_SIZES = (2, 4, 8, 16)
 _KIMI_LATENT_WIDTH = 3584
 _KIMI_ROUTER_WIDTH = 896
 _KIMI_ROUTER_TOPK = 16
+_KIMI_PAIRED_MAX_BATCH_SIZE = 8
 _DCP_A2A_GRAPH_BUFFERS: dict[
     tuple[tuple[int, ...], torch.device, torch.dtype],
     tuple[torch.Tensor, torch.Tensor],
@@ -601,6 +602,60 @@ def try_dcp_b12x_all_gather_pair_kimi_topk(
         channel_id=_b12x_dcp_channel_id(cp_group),
     )
     return gathered_down, routing_payload
+
+
+def warmup_b12x_kimi_projection_gathers(
+    projection_group: GroupCoordinator,
+    *,
+    device: torch.device,
+) -> int:
+    """Compile B12X Kimi paired-projection graph operations eagerly."""
+    world_size = projection_group.world_size
+    if not envs.VLLM_USE_B12X_DCP_A2A or world_size not in _B12X_DCP_WORLD_SIZES:
+        return 0
+
+    token_cap = envs.VLLM_DCP_A2A_MAX_TOKENS
+    pair_batch = (
+        _KIMI_PAIRED_MAX_BATCH_SIZE
+        if token_cap <= 0
+        else min(token_cap, _KIMI_PAIRED_MAX_BATCH_SIZE)
+    )
+    local_down_width = _KIMI_LATENT_WIDTH // world_size
+    local_router_width = _KIMI_ROUTER_WIDTH // world_size
+    local_down = torch.zeros(
+        (pair_batch, local_down_width),
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    local_router = torch.zeros(
+        (pair_batch, local_router_width),
+        device=device,
+        dtype=torch.float32,
+    )
+    warmed = 0
+    paired = _try_b12x_dcp_all_gather_pair(
+        local_down,
+        local_router,
+        projection_group,
+        max_batch_size=_KIMI_PAIRED_MAX_BATCH_SIZE,
+    )
+    if paired is not None:
+        warmed += 1
+
+    correction_bias = torch.zeros(
+        (_KIMI_ROUTER_WIDTH,),
+        device=device,
+        dtype=torch.float32,
+    )
+    fused = try_dcp_b12x_all_gather_pair_kimi_topk(
+        local_down[:1],
+        local_router[:1],
+        correction_bias,
+        projection_group,
+    )
+    if fused is not None:
+        warmed += 1
+    return warmed
 
 
 def warmup_b12x_dcp_a2a(


### PR DESCRIPTION
## Behavior

- Initializes the B12X Kimi paired-projection pool before CUDA graph capture.
- Eagerly compiles both the lossless paired gather for batches up to eight and the deterministic top-16 operation for batch one.
- Selects the complete tensor-parallel projection group when DCP spans only a subset of the projection shards.
- Honors `VLLM_DCP_A2A_MAX_TOKENS` and skips models without feature-sharded Kimi MoE projections.

## Technical reason

B12X projection pools exchange CUDA IPC handles and compile graph-visible CuTeDSL operations. Performing either action for the first time inside CUDA graph capture is unsupported. Decode-sized Kimi projection operations are not guaranteed to execute during the large-token memory-profile forward, so the generic attention warmup does not prepare them.

## Compatibility

The warmup is inactive unless `VLLM_USE_B12X_DCP_A2A=1` and the loaded model contains a Kimi MoE layer whose auxiliary projections are tensor-parallel sharded. Unsupported B12X world sizes and unavailable optional operations return without changing the exact runtime fallback.

This pull request is stacked on #343 and requires B12X #216 for fused expert selection.

## Validation

- Two focused warmup tests pass in the source-locked CUDA 13.3, PyTorch 2.13 Kimi-K3 image.
- The tests cover transport token-cap geometry and selection of TP16 when DCP spans eight ranks.
- Ruff lint and formatting checks pass.
- `git diff --check` passes.
