### PR TITLE
[II] Keep B12X dense MLA scratch caller-owned

### DIFF
--- a/tests/v1/attention/test_b12x_mla.py
+++ b/tests/v1/attention/test_b12x_mla.py
@@ -3,6 +3,7 @@
 
 from types import SimpleNamespace
 
+import pytest
 import torch
 
 from vllm.platforms.interface import DeviceCapability
@@ -59,13 +60,11 @@ class _FakeDenseMLA:
 
 
 def _fake_impl(monkeypatch, *, num_heads: int = 8) -> tuple[B12xMLAImpl, _FakeDenseMLA]:
-    monkeypatch.setattr(b12x_mla, "is_workspace_manager_initialized", lambda: False)
     impl = object.__new__(B12xMLAImpl)
     impl.num_heads = num_heads
     impl.kv_lora_rank = 512
     impl.scale = 192**-0.5
     impl._compiled_bindings = set()
-    impl._fallback_scratch = {}
     dense_mla = _FakeDenseMLA()
     impl._dense_mla = dense_mla
     return impl, dense_mla
@@ -79,6 +78,7 @@ def test_b12x_mla_adapter_binds_common_decode_metadata(monkeypatch) -> None:
     cache = torch.randn(4, 16, 576, dtype=torch.bfloat16)
     metadata = SimpleNamespace(
         dense_mla_plan=_FakePlan(),
+        dense_mla_scratch=torch.empty(256, dtype=torch.uint8),
         query_start_loc=torch.tensor([0, 1, 2], dtype=torch.int32),
         decode=SimpleNamespace(
             block_table=torch.tensor([[0, 1], [2, 3]], dtype=torch.int32),
@@ -107,6 +107,7 @@ def test_b12x_mla_adapter_binds_common_decode_metadata(monkeypatch) -> None:
     assert binding.q_scale is None
     assert binding.kv_scale is None
     assert binding.sm_scale == impl.scale
+    assert binding.scratch is metadata.dense_mla_scratch
 
 
 def test_b12x_mla_adapter_accepts_non_multiple_of_eight_heads(monkeypatch) -> None:
@@ -115,6 +116,7 @@ def test_b12x_mla_adapter_accepts_non_multiple_of_eight_heads(monkeypatch) -> No
     cache = torch.randn(2, 16, 576, dtype=torch.bfloat16)
     metadata = SimpleNamespace(
         dense_mla_plan=_FakePlan(),
+        dense_mla_scratch=torch.empty(256, dtype=torch.uint8),
         query_start_loc=torch.tensor([0, 1], dtype=torch.int32),
         decode=SimpleNamespace(
             block_table=torch.tensor([[0, 1]], dtype=torch.int32),
@@ -139,6 +141,7 @@ def test_b12x_mla_adapter_binds_causal_multiquery_blocks(monkeypatch) -> None:
     query_start_loc = torch.tensor([0, 8, 16], dtype=torch.int32)
     metadata = SimpleNamespace(
         dense_mla_plan=_FakePlan(),
+        dense_mla_scratch=torch.empty(256, dtype=torch.uint8),
         query_start_loc=query_start_loc,
         decode=SimpleNamespace(
             block_table=torch.tensor([[0, 1, 2, 3], [4, 5, 6, 7]], dtype=torch.int32),
@@ -163,6 +166,7 @@ def test_b12x_mla_adapter_binds_causal_multiquery_blocks(monkeypatch) -> None:
 def test_b12x_mla_builder_flattens_non_causal_draft_block(monkeypatch) -> None:
     builder = object.__new__(B12xMLAMetadataBuilder)
     builder._dense_mla_plan = _FakePlan()
+    builder._dense_mla_scratch = torch.empty(256, dtype=torch.uint8)
     builder._max_dense_mla_rows = 16
     builder._dense_mla_flat_block_table = torch.zeros(16, 4, dtype=torch.int32)
     builder._dense_mla_flat_seq_lens = torch.empty(16, dtype=torch.int32)
@@ -186,6 +190,7 @@ def test_b12x_mla_builder_flattens_non_causal_draft_block(monkeypatch) -> None:
 
     result = builder.build(0, SimpleNamespace())
 
+    assert result.dense_mla_scratch is builder._dense_mla_scratch
     torch.testing.assert_close(
         result.dense_mla_flat_block_table,
         source_table.expand(8, -1),
@@ -211,6 +216,7 @@ def test_b12x_mla_adapter_uses_flattened_non_causal_rows(monkeypatch) -> None:
     flat_query_start = torch.arange(query_rows + 1, dtype=torch.int32)
     metadata = SimpleNamespace(
         dense_mla_plan=_FakePlan(),
+        dense_mla_scratch=torch.empty(256, dtype=torch.uint8),
         dense_mla_flat_block_table=flat_table,
         dense_mla_flat_seq_lens=flat_lens,
         dense_mla_flat_query_start_loc=flat_query_start,
@@ -238,6 +244,7 @@ def test_b12x_mla_adapter_passes_fp8_scales(monkeypatch) -> None:
     cache = torch.empty(2, 16, 576, dtype=torch.float8_e4m3fn)
     metadata = SimpleNamespace(
         dense_mla_plan=_FakePlan(),
+        dense_mla_scratch=torch.empty(256, dtype=torch.uint8),
         query_start_loc=torch.tensor([0, 1], dtype=torch.int32),
         decode=SimpleNamespace(
             block_table=torch.tensor([[0, 1]], dtype=torch.int32),
@@ -254,3 +261,23 @@ def test_b12x_mla_adapter_passes_fp8_scales(monkeypatch) -> None:
     binding = dense_mla.bindings[0]
     assert binding.q_scale is layer._q_scale
     assert binding.kv_scale is layer._k_scale
+
+
+def test_b12x_mla_adapter_requires_caller_owned_scratch(monkeypatch) -> None:
+    impl, _ = _fake_impl(monkeypatch)
+    metadata = SimpleNamespace(
+        dense_mla_plan=_FakePlan(),
+        query_start_loc=torch.tensor([0, 1], dtype=torch.int32),
+        decode=SimpleNamespace(
+            block_table=torch.tensor([[0]], dtype=torch.int32),
+            seq_lens=torch.tensor([1], dtype=torch.int32),
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="caller-owned dense MLA scratch"):
+        impl.forward_mqa(
+            torch.randn(1, 8, 576, dtype=torch.bfloat16),
+            torch.randn(1, 16, 576, dtype=torch.bfloat16),
+            metadata,
+            SimpleNamespace(_q_scale=None, _k_scale=None),
+        )

--- a/vllm/v1/attention/backends/mla/b12x_mla.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla.py
@@ -29,10 +29,6 @@ from vllm.v1.attention.backend import (
     MultipleOf,
 )
 from vllm.v1.kv_cache_interface import AttentionSpec
-from vllm.v1.worker.workspace import (
-    current_workspace_manager,
-    is_workspace_manager_initialized,
-)
 
 logger = init_logger(__name__)
 
@@ -128,6 +124,7 @@ class B12xMLAMetadata(MLACommonMetadata):
     """Common MLA metadata plus the capture-static B12X launch plan."""
 
     dense_mla_plan: Any | None = None
+    dense_mla_scratch: torch.Tensor | None = None
     dense_mla_flat_block_table: torch.Tensor | None = None
     dense_mla_flat_seq_lens: torch.Tensor | None = None
     dense_mla_flat_query_start_loc: torch.Tensor | None = None
@@ -169,8 +166,18 @@ class B12xMLAMetadataBuilder(MLACommonMetadataBuilder[B12xMLAMetadata]):
             max_total_q=max_dense_mla_rows,
         )
         self._workspace_specs = self._dense_mla_plan.shapes_and_dtypes()
-        if is_workspace_manager_initialized():
-            current_workspace_manager().get_simultaneous(*self._workspace_specs)
+        if len(self._workspace_specs) != 1:
+            raise RuntimeError("B12X_MLA expected exactly one scratch buffer.")
+        scratch_shape, scratch_dtype = self._workspace_specs[0]
+        # Every attention layer represented by this builder executes serially
+        # on the model stream. One builder-owned buffer therefore gives each
+        # eager bind a stable caller-owned address without a backend workspace
+        # cache or one allocation per layer.
+        self._dense_mla_scratch = torch.empty(
+            scratch_shape,
+            dtype=scratch_dtype,
+            device=device,
+        )
         max_table_width = int(self._dense_mla_plan.caps.max_page_table_width)
         self._dense_mla_flat_block_table = torch.zeros(
             (max_dense_mla_rows, max_table_width),
@@ -212,6 +219,7 @@ class B12xMLAMetadataBuilder(MLACommonMetadataBuilder[B12xMLAMetadata]):
             ),
         )
         metadata.dense_mla_plan = self._dense_mla_plan
+        metadata.dense_mla_scratch = self._dense_mla_scratch
         decode_metadata = metadata.decode
         if (
             not metadata.causal
@@ -447,23 +455,6 @@ class B12xMLAImpl(MLACommonImpl[B12xMLAMetadata]):
 
         self._dense_mla = _load_dense_mla()
         self._compiled_bindings: set[tuple[object, ...]] = set()
-        self._fallback_scratch: dict[int, torch.Tensor] = {}
-
-    def _borrow_scratch(self, plan: Any, device: torch.device) -> torch.Tensor:
-        specs = plan.shapes_and_dtypes()
-        if is_workspace_manager_initialized():
-            (scratch,) = current_workspace_manager().get_simultaneous(*specs)
-            return scratch
-
-        key = id(plan)
-        scratch = self._fallback_scratch.get(key)
-        if scratch is None:
-            if len(specs) != 1:
-                raise RuntimeError("B12X_MLA expected exactly one scratch buffer.")
-            shape, dtype = specs[0]
-            scratch = torch.empty(shape, dtype=dtype, device=device)
-            self._fallback_scratch[key] = scratch
-        return scratch
 
     def forward_mqa(
         self,
@@ -517,7 +508,11 @@ class B12xMLAImpl(MLACommonImpl[B12xMLAMetadata]):
             dtype=torch.bfloat16,
             device=q.device,
         )
-        scratch = self._borrow_scratch(plan, q.device)
+        scratch = getattr(attn_metadata, "dense_mla_scratch", None)
+        if scratch is None:
+            raise RuntimeError(
+                "B12X_MLA metadata is missing caller-owned dense MLA scratch."
+            )
         quantized = q.dtype == torch.float8_e4m3fn
         binding = self._dense_mla.bind(
             plan,


### PR DESCRIPTION
## Behavior

`B12xMLAMetadataBuilder` allocates one capture-stable dense-MLA scratch tensor for the attention layers represented by the builder. Each `forward_mqa()` call passes that tensor to a fresh `dense_mla.bind(plan, scratch=...)` operation.

The B12X backend no longer borrows vLLM's resizable workspace or retains a per-plan scratch cache. Missing caller-owned scratch fails before binding. Layers sharing one metadata builder execute serially on the model stream, so the buffer cannot be consumed concurrently.

## Compatibility

The attention arithmetic, plan geometry, KV-cache layout, supported tensor-parallel sizes, and backend-selection rules are unchanged. This is a source-level prerequisite for adding decode-context-parallel dense MLA without introducing backend-owned workspace state.

## Validation

Status: **implemented and unit-qualified**.

- `ruff format --check` and `ruff check`: pass.
- `tests/v1/attention/test_b12x_mla.py`: 8 passed in the Kimi-K3 CUDA 13.3 / PyTorch 2.13 source-locked runtime image.
- The focused tests verify scratch identity at bind time and rejection of metadata without caller-owned scratch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved B12X MLA attention execution by reusing dedicated scratch memory across operations.
  * Reduced internal workspace management overhead during attention processing.

* **Reliability**
  * Added validation to detect missing attention scratch resources and report a clear runtime error.
  * Expanded automated coverage for adapter and builder attention scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->