### PR TITLE
[II] Pad B12X dense MLA query-head tiles

### DIFF
--- a/tests/v1/attention/test_b12x_mla.py
+++ b/tests/v1/attention/test_b12x_mla.py
@@ -32,6 +32,16 @@ def test_b12x_mla_is_registered_with_k3_envelope() -> None:
     assert B12xMLAMetadataBuilder.query_len_support is b12x_mla.QueryLenSupport.UNIFORM
 
 
+@pytest.mark.parametrize(
+    ("logical_heads", "kernel_heads"),
+    ((6, 8), (8, 8), (12, 16), (16, 16)),
+)
+def test_b12x_mla_pads_query_heads_to_kernel_tile(
+    logical_heads: int, kernel_heads: int
+) -> None:
+    assert b12x_mla._kernel_query_heads(logical_heads) == kernel_heads
+
+
 class _FakePlan:
     def shapes_and_dtypes(self):
         return (((256,), torch.uint8),)
@@ -64,6 +74,7 @@ def _fake_impl(monkeypatch, *, num_heads: int = 8) -> tuple[B12xMLAImpl, _FakeDe
     impl.num_heads = num_heads
     impl.kv_lora_rank = 512
     impl.scale = 192**-0.5
+    impl._kernel_heads = b12x_mla._kernel_query_heads(num_heads)
     impl._compiled_bindings = set()
     dense_mla = _FakeDenseMLA()
     impl._dense_mla = dense_mla
@@ -117,6 +128,8 @@ def test_b12x_mla_adapter_accepts_non_multiple_of_eight_heads(monkeypatch) -> No
     metadata = SimpleNamespace(
         dense_mla_plan=_FakePlan(),
         dense_mla_scratch=torch.empty(256, dtype=torch.uint8),
+        dense_mla_padded_q=torch.empty(1, 8, 576, dtype=torch.bfloat16),
+        dense_mla_padded_output=torch.empty(1, 8, 512, dtype=torch.bfloat16),
         query_start_loc=torch.tensor([0, 1], dtype=torch.int32),
         decode=SimpleNamespace(
             block_table=torch.tensor([[0, 1]], dtype=torch.int32),
@@ -128,7 +141,10 @@ def test_b12x_mla_adapter_accepts_non_multiple_of_eight_heads(monkeypatch) -> No
     output, _ = impl.forward_mqa(q, cache, metadata, layer)
 
     assert output.shape == (1, 6, 512)
-    assert dense_mla.bindings[0].q.shape == (1, 6, 576)
+    binding = dense_mla.bindings[0]
+    assert binding.q.shape == (1, 8, 576)
+    torch.testing.assert_close(binding.q[:, :6], q)
+    torch.testing.assert_close(binding.q[:, 6:], torch.zeros_like(binding.q[:, 6:]))
 
 
 def test_b12x_mla_adapter_binds_causal_multiquery_blocks(monkeypatch) -> None:
@@ -167,6 +183,8 @@ def test_b12x_mla_builder_flattens_non_causal_draft_block(monkeypatch) -> None:
     builder = object.__new__(B12xMLAMetadataBuilder)
     builder._dense_mla_plan = _FakePlan()
     builder._dense_mla_scratch = torch.empty(256, dtype=torch.uint8)
+    builder._dense_mla_padded_q = None
+    builder._dense_mla_padded_output = None
     builder._max_dense_mla_rows = 16
     builder._dense_mla_flat_block_table = torch.zeros(16, 4, dtype=torch.int32)
     builder._dense_mla_flat_seq_lens = torch.empty(16, dtype=torch.int32)
@@ -217,6 +235,8 @@ def test_b12x_mla_adapter_uses_flattened_non_causal_rows(monkeypatch) -> None:
     metadata = SimpleNamespace(
         dense_mla_plan=_FakePlan(),
         dense_mla_scratch=torch.empty(256, dtype=torch.uint8),
+        dense_mla_padded_q=torch.empty(query_rows, 8, 576, dtype=torch.bfloat16),
+        dense_mla_padded_output=torch.empty(query_rows, 8, 512, dtype=torch.bfloat16),
         dense_mla_flat_block_table=flat_table,
         dense_mla_flat_seq_lens=flat_lens,
         dense_mla_flat_query_start_loc=flat_query_start,

--- a/vllm/v1/attention/backends/mla/b12x_mla.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla.py
@@ -40,6 +40,7 @@ _K3_QK_HEAD_DIM = 192
 _K3_V_HEAD_DIM = 128
 _MAX_B12X_QUERY_ROWS = 1024
 _MAX_B12X_CACHE_TOKENS = 1_048_576
+_B12X_QUERY_HEAD_TILE = 8
 _MAX_I32 = torch.iinfo(torch.int32).max
 
 
@@ -73,6 +74,17 @@ def _planned_kv_dtype(vllm_config: VllmConfig) -> torch.dtype:
         return fp8_dtype
     raise ValueError(
         f"B12X_MLA supports only BF16 or E4M3 KV cache storage, got {cache_dtype!r}."
+    )
+
+
+def _kernel_query_heads(num_heads: int) -> int:
+    """Pad independent query heads to the B12X launch tile."""
+    if num_heads <= 0:
+        raise ValueError(f"B12X_MLA requires positive query heads, got {num_heads}.")
+    return (
+        (num_heads + _B12X_QUERY_HEAD_TILE - 1)
+        // _B12X_QUERY_HEAD_TILE
+        * _B12X_QUERY_HEAD_TILE
     )
 
 
@@ -125,6 +137,8 @@ class B12xMLAMetadata(MLACommonMetadata):
 
     dense_mla_plan: Any | None = None
     dense_mla_scratch: torch.Tensor | None = None
+    dense_mla_padded_q: torch.Tensor | None = None
+    dense_mla_padded_output: torch.Tensor | None = None
     dense_mla_flat_block_table: torch.Tensor | None = None
     dense_mla_flat_seq_lens: torch.Tensor | None = None
     dense_mla_flat_query_start_loc: torch.Tensor | None = None
@@ -158,11 +172,12 @@ class B12xMLAMetadataBuilder(MLACommonMetadataBuilder[B12xMLAMetadata]):
                 f"rows={max_dense_mla_rows}, limit={_MAX_B12X_QUERY_ROWS}."
             )
         self._max_dense_mla_rows = max_dense_mla_rows
+        self._kernel_heads = _kernel_query_heads(self.num_heads)
         self._dense_mla_plan = _create_dense_mla_plan(
             vllm_config,
             device,
             page_size=self.page_size,
-            num_q_heads=self.num_heads,
+            num_q_heads=self._kernel_heads,
             max_total_q=max_dense_mla_rows,
         )
         self._workspace_specs = self._dense_mla_plan.shapes_and_dtypes()
@@ -178,6 +193,19 @@ class B12xMLAMetadataBuilder(MLACommonMetadataBuilder[B12xMLAMetadata]):
             dtype=scratch_dtype,
             device=device,
         )
+        self._dense_mla_padded_q: torch.Tensor | None = None
+        self._dense_mla_padded_output: torch.Tensor | None = None
+        if self._kernel_heads != self.num_heads:
+            self._dense_mla_padded_q = torch.empty(
+                (max_dense_mla_rows, self._kernel_heads, _K3_ABSORBED_HEAD_DIM),
+                dtype=_planned_kv_dtype(vllm_config),
+                device=device,
+            )
+            self._dense_mla_padded_output = torch.empty(
+                (max_dense_mla_rows, self._kernel_heads, _K3_KV_LORA_RANK),
+                dtype=torch.bfloat16,
+                device=device,
+            )
         max_table_width = int(self._dense_mla_plan.caps.max_page_table_width)
         self._dense_mla_flat_block_table = torch.zeros(
             (max_dense_mla_rows, max_table_width),
@@ -195,9 +223,10 @@ class B12xMLAMetadataBuilder(MLACommonMetadataBuilder[B12xMLAMetadata]):
             device=device,
         )
         logger.info_once(
-            "B12X dense K3 MLA plan: heads=%d, page_size=%d, "
+            "B12X dense K3 MLA plan: logical_heads=%d, kernel_heads=%d, page_size=%d, "
             "max_decode_rows=%d, max_cache_tokens=%d, splits=%d",
             self.num_heads,
+            self._kernel_heads,
             self.page_size,
             max_dense_mla_rows,
             vllm_config.model_config.max_model_len,
@@ -220,6 +249,8 @@ class B12xMLAMetadataBuilder(MLACommonMetadataBuilder[B12xMLAMetadata]):
         )
         metadata.dense_mla_plan = self._dense_mla_plan
         metadata.dense_mla_scratch = self._dense_mla_scratch
+        metadata.dense_mla_padded_q = self._dense_mla_padded_q
+        metadata.dense_mla_padded_output = self._dense_mla_padded_output
         decode_metadata = metadata.decode
         if (
             not metadata.causal
@@ -454,6 +485,7 @@ class B12xMLAImpl(MLACommonImpl[B12xMLAMetadata]):
             )
 
         self._dense_mla = _load_dense_mla()
+        self._kernel_heads = _kernel_query_heads(num_heads)
         self._compiled_bindings: set[tuple[object, ...]] = set()
 
     def forward_mqa(
@@ -503,11 +535,35 @@ class B12xMLAImpl(MLACommonImpl[B12xMLAMetadata]):
                 f"B12X_MLA expected {self.num_heads} query heads, got {q.shape[1]}."
             )
 
-        output = torch.empty(
-            (total_q, self.num_heads, self.kv_lora_rank),
-            dtype=torch.bfloat16,
-            device=q.device,
-        )
+        if self._kernel_heads == self.num_heads:
+            output = torch.empty(
+                (total_q, self.num_heads, self.kv_lora_rank),
+                dtype=torch.bfloat16,
+                device=q.device,
+            )
+        else:
+            padded_q = getattr(attn_metadata, "dense_mla_padded_q", None)
+            output = getattr(attn_metadata, "dense_mla_padded_output", None)
+            if padded_q is None or output is None:
+                raise RuntimeError(
+                    "B12X_MLA metadata is missing caller-owned padded query buffers."
+                )
+            if int(padded_q.shape[0]) < total_q or int(output.shape[0]) < total_q:
+                raise ValueError(
+                    "B12X_MLA padded query capacity is smaller than the decode "
+                    f"batch: query={padded_q.shape[0]}, output={output.shape[0]}, "
+                    f"required={total_q}."
+                )
+            padded_q = padded_q[:total_q]
+            output = output[:total_q]
+            if padded_q.dtype != q.dtype:
+                raise TypeError(
+                    "B12X_MLA padded query dtype does not match the live query: "
+                    f"buffer={padded_q.dtype}, query={q.dtype}."
+                )
+            padded_q[:, : self.num_heads].copy_(q)
+            padded_q[:, self.num_heads :].zero_()
+            q = padded_q
         scratch = getattr(attn_metadata, "dense_mla_scratch", None)
         if scratch is None:
             raise RuntimeError(
@@ -544,7 +600,8 @@ class B12xMLAImpl(MLACommonImpl[B12xMLAMetadata]):
             self._dense_mla.compile(binding=binding)
             self._compiled_bindings.add(compile_key)
 
-        return self._dense_mla.run(binding=binding)
+        output, lse = self._dense_mla.run(binding=binding)
+        return output[:, : self.num_heads], lse[:, : self.num_heads]
 
 
 __all__ = [


### PR DESCRIPTION
## Behavior

B12X dense MLA plans round the logical query-head count up to the kernel's eight-head launch tile. Metadata owns capture-stable padded query and output buffers only when padding is required. Each decode call copies the logical query heads, zeros synthetic heads, executes the planned kernel, and returns only logical output and LSE heads.

Kimi-K3 has 96 attention heads. TP16 therefore presents six heads per rank and executes an eight-head B12X plan; TP8 presents twelve heads per rank and executes a sixteen-head plan. The added heads are independent zero queries and cannot alter logical attention outputs.

## Compatibility

Tensor-parallel layouts whose local head count is already divisible by eight retain their existing shapes and allocation path. Decode-context parallelism remains unsupported by this pull request.

Depends on #356 for caller-owned dense-MLA scratch.

## Validation

Status: **implemented and unit-qualified**.

- `ruff format` and `ruff check`: pass.
- `tests/v1/attention/test_b12x_mla.py`: 12 passed in the Kimi-K3 CUDA 13.3 / PyTorch 2.13 source-locked runtime image.
- Focused cases cover 6→8, 8→8, 12→16, and 16→16 planning, zero-filled synthetic query heads, output trimming, flattened decode rows, and FP8 scale forwarding.