### PR TITLE
[II] Support backend-owned MLA decode DCP

### DIFF
--- a/tests/v1/attention/test_mla_context_chunks.py
+++ b/tests/v1/attention/test_mla_context_chunks.py
@@ -12,6 +12,7 @@ import pytest
 import torch
 
 from vllm.model_executor.layers.attention.mla_attention import (
+    _gather_dcp_context_kv,
     build_mla_chunked_context_metadata,
     init_mla_context_partial,
     reorg_kvcache,
@@ -27,6 +28,7 @@ def build_chunked_context(
     block_size: int = BLOCK_SIZE,
     dcp_world_size: int = 1,
     dcp_local_block_size: int = 1,
+    direct_dcp_kv_gather: bool = False,
 ):
     query_start_loc = torch.zeros(len(query_lens) + 1, dtype=torch.int32)
     query_start_loc[1:] = torch.tensor(query_lens, dtype=torch.int32).cumsum(0)
@@ -42,6 +44,7 @@ def build_chunked_context(
         dcp_world_size=dcp_world_size,
         dcp_local_block_size=dcp_local_block_size,
         dcp_virtual_block_size=dcp_local_block_size * dcp_world_size,
+        direct_dcp_kv_gather=direct_dcp_kv_gather,
     )
 
 
@@ -231,6 +234,57 @@ def test_dcp_chunks_fit_the_per_rank_row_budget():
     for request, length in enumerate(context_lens):
         padded_local = -(-length // virtual_block_size) * interleave
         assert local_cursor[request] == padded_local
+
+
+def test_dcp_metadata_preserves_direct_kv_gather_capability():
+    """Manager-free DCP prefill records the process-group gather contract."""
+    metadata = build_chunked_context(
+        [256],
+        [4],
+        1024,
+        dcp_world_size=2,
+        dcp_local_block_size=64,
+        direct_dcp_kv_gather=True,
+    )
+
+    assert metadata is not None
+    assert metadata.dcp_manager is None
+    assert metadata.direct_dcp_kv_gather
+
+
+def test_direct_dcp_kv_gather_writes_caller_storage(monkeypatch):
+    local = torch.tensor([[1.0], [2.0]])
+    gathered = torch.empty(4, 1)
+
+    class FakeGroup:
+        def all_gather(self, value, *, dim):
+            assert value is local
+            assert dim == 0
+            return torch.cat((value, value + 10), dim=0)
+
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.attention.mla_attention.get_dcp_group",
+        lambda: FakeGroup(),
+    )
+
+    _gather_dcp_context_kv(
+        gathered,
+        local,
+        dcp_manager=None,
+        direct_dcp_kv_gather=True,
+    )
+
+    torch.testing.assert_close(gathered, torch.tensor([[1.0], [2.0], [11.0], [12.0]]))
+
+
+def test_dcp_kv_gather_requires_manager_or_direct_path():
+    with pytest.raises(RuntimeError, match="no configured KV gather path"):
+        _gather_dcp_context_kv(
+            torch.empty(2, 1),
+            torch.empty(1, 1),
+            dcp_manager=None,
+            direct_dcp_kv_gather=False,
+        )
 
 
 def test_dcp_reorg_uses_each_chunks_local_starts():

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -2503,6 +2503,7 @@ class MLACommonPrefillMetadata:
         context_lens_list: list[int]
         empty_token_slices: list[slice]
         dcp_manager: MLADCPManager | None = None
+        direct_dcp_kv_gather: bool = False
 
     block_table: torch.Tensor
     query_start_loc: torch.Tensor
@@ -2792,6 +2793,7 @@ def build_mla_chunked_context_metadata(
     dcp_local_block_size: int,
     dcp_virtual_block_size: int,
     dcp_manager: MLADCPManager | None = None,
+    direct_dcp_kv_gather: bool = False,
 ) -> "MLACommonPrefillMetadata.ChunkedContextMetadata | None":
     """Build chunked-context metadata for an MLA prefill.
 
@@ -2811,6 +2813,8 @@ def build_mla_chunked_context_metadata(
         dcp_local_block_size: Per-rank interleave block size for DCP.
         dcp_virtual_block_size: ``dcp_local_block_size * dcp_world_size``.
         dcp_manager: Shared MLA DCP collective manager.
+        direct_dcp_kv_gather: Gather context KV through the process DCP group
+            when the decode backend owns its query and output collectives.
 
     Returns:
         The chunked-context metadata, or None when no prefill has any context.
@@ -3000,6 +3004,7 @@ def build_mla_chunked_context_metadata(
         context_lens_list=context_lens,
         empty_token_slices=empty_token_slices,
         dcp_manager=dcp_manager,
+        direct_dcp_kv_gather=direct_dcp_kv_gather,
     )
 
 
@@ -3021,6 +3026,11 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
 
     # Whether this builder can flatten a non-causal query block into decode rows.
     supports_non_causal_multi_token_decode: ClassVar[bool] = False
+
+    # A decode backend that owns DCP query and output collectives can omit an
+    # MLADCPManager. Chunked-context prefill still gathers KV through the
+    # process DCP group before it runs the configured prefill backend.
+    supports_direct_dcp_kv_gather: ClassVar[bool] = False
 
     # The threshold for reordering the batch into decode and prefill requests.
     # If > 1, the batch will be reordered such that requests with
@@ -3179,11 +3189,20 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
                 device=device,
             )
             self.dcp_manager = getattr(attention_layer, "dcp_manager", None)
-            assert isinstance(self.dcp_manager, MLADCPManager)
-            self.dcp_manager.init_kv_gather(
-                self.chunked_prefill_workspace,
-                self.chunked_prefill_workspace_size,
-            )
+            if self.dcp_manager is not None:
+                if not isinstance(self.dcp_manager, MLADCPManager):
+                    raise TypeError(
+                        "MLA attention layer dcp_manager must be an "
+                        f"MLADCPManager, got {type(self.dcp_manager).__name__}."
+                    )
+                self.dcp_manager.init_kv_gather(
+                    self.chunked_prefill_workspace,
+                    self.chunked_prefill_workspace_size,
+                )
+            elif not self.supports_direct_dcp_kv_gather:
+                raise RuntimeError(
+                    f"{type(self).__name__} requires MLADCPManager when DCP is enabled."
+                )
         else:
             self.chunked_prefill_workspace = torch.empty(
                 (
@@ -3339,6 +3358,11 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
                 dcp_local_block_size=self.dcp_local_block_size,
                 dcp_virtual_block_size=self.dcp_virtual_block_size,
                 dcp_manager=self.dcp_manager,
+                direct_dcp_kv_gather=(
+                    self.dcp_world_size > 1
+                    and self.dcp_manager is None
+                    and self.supports_direct_dcp_kv_gather
+                ),
             )
 
             prefill_metadata = MLACommonPrefillMetadata(
@@ -3469,6 +3493,23 @@ def reorg_kvcache(
     assert reorganized_k_pe.shape[0] == sum_seq_len
     assert max_seq_len_check == max_seq_len
     return reorganized_kv_c_normed, reorganized_k_pe
+
+
+def _gather_dcp_context_kv(
+    gathered_kv: torch.Tensor,
+    local_kv: torch.Tensor,
+    *,
+    dcp_manager: MLADCPManager | None,
+    direct_dcp_kv_gather: bool,
+) -> None:
+    """Gather one chunk of DCP-sharded context KV into caller storage."""
+    if dcp_manager is not None:
+        dcp_manager.kv_gather(gathered_kv, local_kv)
+        return
+    if direct_dcp_kv_gather:
+        gathered_kv.copy_(get_dcp_group().all_gather(local_kv, dim=0))
+        return
+    raise RuntimeError("MLA DCP chunked prefill has no configured KV gather path.")
 
 
 def init_mla_context_partial(
@@ -3778,8 +3819,12 @@ class MLACommonBaseImpl(MLAAttentionImpl[A], Generic[A]):
             ]
             assert toks * dcp_world_size <= cur_allgather_workspace.shape[0]
             cur_allgather_kvcache = cur_allgather_workspace[: toks * dcp_world_size]
-            dcp_manager = cast(MLADCPManager, chunked_context.dcp_manager)
-            dcp_manager.kv_gather(cur_allgather_kvcache, local_gathered_kvcache)
+            _gather_dcp_context_kv(
+                cur_allgather_kvcache,
+                local_gathered_kvcache,
+                dcp_manager=chunked_context.dcp_manager,
+                direct_dcp_kv_gather=chunked_context.direct_dcp_kv_gather,
+            )
             assert (
                 cur_allgather_kvcache.shape[-1]
                 == self.kv_lora_rank + self.qk_rope_head_dim


### PR DESCRIPTION
## Behavior

MLA metadata builders may declare `supports_direct_dcp_kv_gather=True` when their decode backend owns query-gather and output-combine collectives instead of using `MLADCPManager`. Chunked-context prefill for such a backend gathers each local KV chunk through the process DCP group into the existing caller workspace.

Builders that do not declare the capability still require `MLADCPManager`. Metadata with neither a manager nor the explicit direct-gather capability fails before context attention.

## Compatibility

Existing MLA backends retain the manager-owned query, output, and KV collective path. This pull request does not enable backend-owned DCP for any backend; it defines the common metadata and prefill contract consumed by a separate backend integration.

Depends on #357 only for stack ordering; it does not depend on B12X symbols.

## Validation

Status: **implemented and unit-qualified**.

- `ruff format` and `ruff check`: pass.
- `tests/v1/attention/test_mla_context_chunks.py`: 14 passed in the Kimi-K3 CUDA 13.3 / PyTorch 2.13 source-locked runtime image.
- Focused cases verify metadata propagation, process-group gathering into caller storage, and rejection when no gather mechanism is configured.