### PR TITLE
[II] Select backend-owned Kimi dense MLA DCP

### DIFF
--- a/tests/models/kimi_k3/test_sequence_parallel.py
+++ b/tests/models/kimi_k3/test_sequence_parallel.py
@@ -13,6 +13,7 @@ from vllm.config import ParallelConfig
 from vllm.model_executor.layers.activation import SiluAndMul
 from vllm.model_executor.layers.linear import RowParallelLinear
 from vllm.models.common.ops import sequence_parallel as sp_ops
+from vllm.models.kimi_k3.nvidia import mla as kimi_mla
 from vllm.models.kimi_k3.nvidia import model as kimi_model
 from vllm.models.kimi_k3.nvidia import mtp as kimi_mtp
 from vllm.platforms import current_platform
@@ -75,6 +76,17 @@ class _SequenceParallelMTPBlock:
     ):
         assert residual is None
         return hidden_states * 2, None, hidden_states * 3
+
+
+@pytest.mark.parametrize(
+    ("dcp_world_size", "backend_owns", "expected"),
+    ((1, True, False), (8, False, False), (8, True, True)),
+)
+def test_kimi_detects_backend_owned_decode_dcp(
+    dcp_world_size: int, backend_owns: bool, expected: bool
+) -> None:
+    impl = SimpleNamespace(owns_decode_dcp_collectives=backend_owns)
+    assert kimi_mla._backend_owns_decode_dcp(impl, dcp_world_size) is expected
 
 
 def _mock_sequence_parallel_collectives(monkeypatch):

--- a/tests/v1/attention/test_b12x_mla.py
+++ b/tests/v1/attention/test_b12x_mla.py
@@ -61,6 +61,55 @@ def test_b12x_mla_plans_local_interleaved_dcp_cache() -> None:
     assert b12x_mla._max_dcp_local_cache_tokens(config) == 131_072
 
 
+def _support_reason(monkeypatch, *, dcp_size: int, pcp_size: int = 1) -> str | None:
+    parallel_config = SimpleNamespace(
+        decode_context_parallel_size=dcp_size,
+        prefill_context_parallel_size=pcp_size,
+        cp_kv_cache_interleave_size=64,
+    )
+    model_config = SimpleNamespace(
+        hf_text_config=SimpleNamespace(
+            model_type="kimi_linear",
+            kv_lora_rank=512,
+            qk_nope_head_dim=128,
+            qk_rope_head_dim=64,
+            v_head_dim=128,
+        ),
+        max_model_len=1_048_576,
+        get_num_attention_heads=lambda _: 6,
+    )
+    config = SimpleNamespace(
+        parallel_config=parallel_config,
+        model_config=model_config,
+        scheduler_config=SimpleNamespace(max_num_seqs=8),
+    )
+    monkeypatch.setattr(b12x_mla, "_load_dense_mla", lambda: object())
+    monkeypatch.setattr(b12x_mla, "get_current_vllm_config", lambda: config)
+    return B12xMLABackend.supports_combination(
+        head_size=576,
+        dtype=torch.bfloat16,
+        kv_cache_dtype="fp8",
+        block_size=944,
+        use_mla=True,
+        has_sink=False,
+        use_sparse=False,
+        use_mm_prefix=False,
+        device_capability=DeviceCapability(12, 0),
+    )
+
+
+def test_b12x_mla_selects_supported_native_dcp_geometry(monkeypatch) -> None:
+    assert _support_reason(monkeypatch, dcp_size=8) is None
+    assert _support_reason(monkeypatch, dcp_size=16) is None
+
+
+def test_b12x_mla_rejects_unsupported_parallel_geometry(monkeypatch) -> None:
+    assert "multiple of eight" in _support_reason(monkeypatch, dcp_size=2)
+    assert "prefill context parallelism" in _support_reason(
+        monkeypatch, dcp_size=8, pcp_size=2
+    )
+
+
 class _FakePlan:
     def shapes_and_dtypes(self):
         return (((256,), torch.uint8),)

--- a/vllm/models/kimi_k3/nvidia/mla.py
+++ b/vllm/models/kimi_k3/nvidia/mla.py
@@ -105,6 +105,13 @@ def _gate_sigmoid_mul(attn_out: torch.Tensor, gate: torch.Tensor) -> torch.Tenso
     return attn_out * gate.sigmoid()
 
 
+def _backend_owns_decode_dcp(impl: object, dcp_world_size: int) -> bool:
+    """Return whether the selected backend gathers and combines DCP itself."""
+    return dcp_world_size > 1 and bool(
+        getattr(impl, "owns_decode_dcp_collectives", False)
+    )
+
+
 class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
     """Kimi-K3 Multi-head Latent Attention with optional RoPE and output gate."""
 
@@ -321,13 +328,19 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
             "parallelism."
         )
         self.dcp_world_size = parallel_config.decode_context_parallel_size
-        assert self.dcp_world_size <= 1 or self.rotary_emb is None, (
-            "Kimi-K3 MultiHeadLatentAttention does not support RoPE with decode "
-            "context parallelism because gathered queries require gathered "
-            "positions."
+        self.backend_owns_decode_dcp = _backend_owns_decode_dcp(
+            self.impl, self.dcp_world_size
+        )
+        assert (
+            self.dcp_world_size <= 1
+            or self.rotary_emb is None
+            or self.backend_owns_decode_dcp
+        ), (
+            "Kimi-K3 RoPE with decode context parallelism requires an attention "
+            "backend that owns its DCP query and output collectives."
         )
         self.dcp_manager: MLADCPManager | None = None
-        if self.dcp_world_size > 1:
+        if self.dcp_world_size > 1 and not self.backend_owns_decode_dcp:
             query_dtype = (
                 torch.float8_e4m3fn
                 if is_quantized_kv_cache(self.kv_cache_dtype)
@@ -616,16 +629,14 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
                 cos_sin_cache,
                 slot_mapping[:num_mqa_tokens],
             )
-            if self.dcp_world_size > 1:
-                assert self.dcp_manager is not None
+            if self.dcp_manager is not None:
                 assert self.dcp_manager.query_gather is not None
                 mqa_q = self.dcp_manager.query_gather(mqa_q)
             latent_out, lse = self.impl.forward_mqa(  # type: ignore[attr-defined]
                 mqa_q, self._attn_read_kv_cache(), attn_metadata, self
             )
-            if self.dcp_world_size > 1:
+            if self.dcp_manager is not None:
                 assert lse is not None
-                assert self.dcp_manager is not None
                 assert attn_metadata.decode is not None
                 latent_out = self.dcp_manager.combine(
                     latent_out,

--- a/vllm/v1/attention/backends/mla/b12x_mla.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla.py
@@ -429,20 +429,24 @@ class B12xMLABackend(MLACommonBackend):
             )
 
         parallel_config = vllm_config.parallel_config
-        if parallel_config.decode_context_parallel_size != 1:
-            return "B12X_MLA does not support decode context parallelism"
+        if parallel_config.prefill_context_parallel_size != 1:
+            return "B12X_MLA does not support prefill context parallelism"
+        dcp_size = int(parallel_config.decode_context_parallel_size)
         local_heads = model_config.get_num_attention_heads(parallel_config)
-        if local_heads <= 0:
-            return f"B12X_MLA requires a positive query-head count, got {local_heads}"
+        try:
+            _kernel_query_heads(local_heads, dcp_size)
+        except ValueError as exc:
+            return str(exc)
         if vllm_config.scheduler_config.max_num_seqs > _MAX_B12X_QUERY_ROWS:
             return (
                 "B12X_MLA max_num_seqs exceeds its 1024-row decode capacity: "
                 f"{vllm_config.scheduler_config.max_num_seqs}"
             )
-        if model_config.max_model_len > _MAX_B12X_CACHE_TOKENS:
+        local_cache_tokens = _max_dcp_local_cache_tokens(vllm_config)
+        if local_cache_tokens > _MAX_B12X_CACHE_TOKENS:
             return (
-                "B12X_MLA max_model_len exceeds its 1048576-token capacity: "
-                f"{model_config.max_model_len}"
+                "B12X_MLA local DCP cache exceeds its 1048576-token capacity: "
+                f"{local_cache_tokens}"
             )
         return None
 
@@ -453,6 +457,7 @@ class B12xMLABackend(MLACommonBackend):
 
 class B12xMLAImpl(MLACommonImpl[B12xMLAMetadata]):
     can_return_lse_for_decode: bool = True
+    owns_decode_dcp_collectives: bool = True
 
     def __init__(
         self,


### PR DESCRIPTION
## Behavior

Kimi-K3 detects attention implementations that declare `owns_decode_dcp_collectives=True`. For those implementations, the model passes rank-local queries directly to the backend and accepts the backend's combined output. It does not allocate or invoke `MLADCPManager` for decode query gathering or output combination.

`B12xMLAImpl` declares that contract. `B12xMLABackend` accepts supported DCP geometries when prefill context parallelism is disabled, the gathered head count satisfies the eight-head kernel tile, and the largest local interleaved KV shard does not exceed 1,048,576 tokens. Kimi RoPE decode is permitted because the B12X backend gathers already-rotated rank-local queries.

Backends without the declaration retain the existing `MLADCPManager` path.

## Dependencies

Depends on #359. TP16 serving also requires #338 for world-size-16 B12X transport, #339 for FP32 LSE transport, and #340 for bounded transport fallback.

## Validation

Status: **implemented and unit-qualified; composed serving qualification is pending**.

- `ruff format`, `ruff check`, and Python compilation: pass.
- `tests/v1/attention/test_b12x_mla.py` plus `tests/models/kimi_k3/test_sequence_parallel.py`: 47 passed in the Kimi-K3 CUDA 13.3 / PyTorch 2.13 source-locked runtime image.
- Selector cases cover TP16/DCP8, TP16/DCP16, unsupported DCP2 head geometry, and rejected prefill context parallelism.
- Model cases verify that DCP1 and undeclared backends retain generic orchestration while a declared DCP backend owns the collectives.