### PR TITLE
[II] Bind B12X MLA DCP query output storage

### DIFF
--- a/tests/v1/attention/test_b12x_mla.py
+++ b/tests/v1/attention/test_b12x_mla.py
@@ -368,12 +368,14 @@ def test_b12x_mla_adapter_gathers_and_combines_dcp(monkeypatch) -> None:
 
     monkeypatch.setattr(b12x_mla, "get_dcp_group", lambda: group)
 
-    def gather(local_q, actual_group, *, max_batch_size, output_head_dim):
+    def gather(local_q, actual_group, *, max_batch_size, output_head_dim, out):
         assert actual_group is group
         assert max_batch_size == 16
         assert output_head_dim == 512
+        assert out.shape == (batch, 48, 576)
         calls.append("gather")
-        return local_q.repeat(1, 8, 1)
+        out.copy_(local_q.repeat(1, 8, 1))
+        return out
 
     def reduce(output, lse, actual_group, **kwargs):
         assert actual_group is group
@@ -408,6 +410,7 @@ def test_b12x_mla_adapter_gathers_and_combines_dcp(monkeypatch) -> None:
 
     assert calls == ["gather", "reduce"]
     assert dense_mla.bindings[0].q.shape == (batch, 48, 576)
+    assert dense_mla.bindings[0].q.data_ptr() == metadata.dense_mla_padded_q.data_ptr()
     torch.testing.assert_close(output, torch.ones_like(output))
     assert lse is None
 

--- a/vllm/v1/attention/backends/mla/b12x_mla.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla.py
@@ -590,11 +590,28 @@ class B12xMLAImpl(MLACommonImpl[B12xMLAMetadata]):
         dcp_group = None
         if self.dcp_world_size > 1:
             dcp_group = get_dcp_group()
+            gathered_q = getattr(attn_metadata, "dense_mla_padded_q", None)
+            if gathered_q is None:
+                raise RuntimeError(
+                    "B12X_MLA DCP metadata is missing caller-owned query storage."
+                )
+            if int(gathered_q.shape[0]) < total_q:
+                raise ValueError(
+                    "B12X_MLA DCP query capacity is smaller than the decode "
+                    f"batch: capacity={gathered_q.shape[0]}, required={total_q}."
+                )
+            if gathered_q.dtype != q.dtype:
+                raise TypeError(
+                    "B12X_MLA DCP query storage does not match the live query: "
+                    f"buffer={gathered_q.dtype}, query={q.dtype}."
+                )
+            gathered_q = gathered_q[:total_q, : self._effective_heads]
             q = dcp_b12x_all_gather_heads(
                 q,
                 dcp_group,
                 max_batch_size=self._dcp_max_batch_size,
                 output_head_dim=self.kv_lora_rank,
+                out=gathered_q,
             )
 
         effective_heads = int(q.shape[1])


### PR DESCRIPTION
## Behavior

B12X dense MLA DCP gathers rank-local query heads directly into the capture-stable query tensor owned by `B12xMLAMetadataBuilder`. The backend validates row capacity and dtype before passing the tensor as `out=` to the DCP gather adapter.

The exact NCCL fallback and the B12X transport write to the same caller-owned tensor. The dense-MLA binding therefore sees one stable query address without a backend allocation or cached workspace.

## Compatibility and dependencies

DCP1 behavior is unchanged. Unsupported DCP transport geometry retains the exact collective fallback supplied by #341.

Depends on #360 and #341.

## Validation

Status: **implemented and unit-qualified; composed serving qualification is pending**.

- `ruff format` and `ruff check`: pass.
- `tests/v1/attention/test_b12x_mla.py`: 17 passed in the Kimi-K3 CUDA 13.3 / PyTorch 2.13 source-locked runtime image.
- The DCP case verifies capacity and dtype checks, direct gather into metadata-owned storage, stable data-pointer identity at dense-MLA bind time, and exact output reduction.