### PR TITLE
[II] Limit B12X MLA work to active cache splits

### DIFF
--- a/tests/v1/attention/test_b12x_mla.py
+++ b/tests/v1/attention/test_b12x_mla.py
@@ -49,6 +49,17 @@ def test_b12x_mla_uses_gathered_dcp_head_geometry() -> None:
         b12x_mla._kernel_query_heads(6, 2)
 
 
+@pytest.mark.parametrize(
+    ("max_seq_len", "expected"),
+    ((None, 8), (0, 1), (64, 1), (65, 1), (256, 1), (257, 2), (4096, 8)),
+)
+def test_b12x_mla_limits_active_cache_splits(
+    max_seq_len: int | None, expected: int
+) -> None:
+    plan = SimpleNamespace(num_splits=8, chunks_per_split=4)
+    assert b12x_mla._active_dense_mla_splits(plan, max_seq_len) == expected
+
+
 def test_b12x_mla_plans_local_interleaved_dcp_cache() -> None:
     config = SimpleNamespace(
         parallel_config=SimpleNamespace(
@@ -190,6 +201,7 @@ def test_b12x_mla_adapter_binds_common_decode_metadata(monkeypatch) -> None:
     assert binding.q_scale is None
     assert binding.kv_scale is None
     assert binding.sm_scale == impl.scale
+    assert binding.active_splits == 1
     assert binding.scratch is metadata.dense_mla_scratch
 
 

--- a/vllm/v1/attention/backends/mla/b12x_mla.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla.py
@@ -123,6 +123,24 @@ def _kernel_query_heads(local_heads: int, dcp_size: int = 1) -> int:
     )
 
 
+def _active_dense_mla_splits(plan: Any, max_seq_len: int | None) -> int:
+    """Return the split-plan prefix that can contain live cache rows."""
+    num_splits = int(getattr(plan, "num_splits", 1))
+    chunks_per_split = int(getattr(plan, "chunks_per_split", 1))
+    if num_splits <= 0 or chunks_per_split <= 0:
+        raise ValueError(
+            "B12X_MLA received invalid split geometry: "
+            f"splits={num_splits}, chunks_per_split={chunks_per_split}."
+        )
+    if max_seq_len is None:
+        return num_splits
+    valid_chunks = max(1, (max(0, int(max_seq_len)) + 63) // 64)
+    return min(
+        num_splits,
+        (valid_chunks + chunks_per_split - 1) // chunks_per_split,
+    )
+
+
 def _create_dense_mla_plan(
     vllm_config: VllmConfig,
     device: torch.device,
@@ -662,6 +680,17 @@ class B12xMLAImpl(MLACommonImpl[B12xMLAMetadata]):
                 "B12X_MLA metadata is missing caller-owned dense MLA scratch."
             )
         quantized = q.dtype == torch.float8_e4m3fn
+        # Direct CUDA graph capture fixes the launch grid and therefore uses
+        # every planned split. Piecewise eager attention may omit only trailing
+        # splits whose first 64-token chunk lies beyond every live sequence.
+        active_splits = (
+            int(plan.num_splits)
+            if q.is_cuda and torch.cuda.is_current_stream_capturing()
+            else _active_dense_mla_splits(
+                plan,
+                getattr(attn_metadata, "max_seq_len", None),
+            )
+        )
         binding = self._dense_mla.bind(
             plan,
             scratch=scratch,
@@ -674,6 +703,7 @@ class B12xMLAImpl(MLACommonImpl[B12xMLAMetadata]):
             q_scale=layer._q_scale if quantized else None,
             kv_scale=layer._k_scale if quantized else None,
             sm_scale=self.scale,
+            active_splits=active_splits,
         )
 
         compile_key = (


### PR DESCRIPTION
## Behavior

Piecewise-eager B12X dense MLA decode derives the number of active 64-token cache chunks from metadata `max_seq_len` and launches only the prefix of the capture-static split plan that can contain live rows. Split boundaries, scratch layout, and the reduction order for every contributing partial remain unchanged.

Direct CUDA graph capture retains the complete planned split count because launch-grid dimensions are fixed at capture time. Missing sequence-length metadata also retains the complete plan.

## Compatibility

The optimization applies to DCP1 and DCP configurations and changes no attention arithmetic. Invalid split plans fail before binding.

Depends on #361.

## Validation

Status: **implemented and unit-qualified; composed throughput qualification is pending**.

- `ruff format` and `ruff check`: pass.
- `tests/v1/attention/test_b12x_mla.py`: 24 passed in the Kimi-K3 CUDA 13.3 / PyTorch 2.13 source-locked runtime image.
- Split-selection cases cover absent metadata, empty and boundary-aligned contexts, cross-split contexts, and saturation at the planned split count.
- Adapter tests verify that the selected split count reaches the B12X binding.