### PR TITLE
[II] Isolate external draft attention geometry

### DIFF
--- a/tests/v1/spec_decode/test_external_draft_attention_config.py
+++ b/tests/v1/spec_decode/test_external_draft_attention_config.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm.v1.attention.backends.registry import AttentionBackendEnum
+from vllm.v1.worker.gpu.spec_decode.dflash import speculator as dflash_speculator
+from vllm.v1.worker.gpu.spec_decode.dspark import utils as dspark_utils
+
+
+def test_dspark_loader_uses_external_draft_parallel_geometry(monkeypatch) -> None:
+    """The external draft model constructor receives its DCP1 configuration."""
+    draft_model_config = SimpleNamespace(hf_config=SimpleNamespace())
+    target_config = SimpleNamespace(
+        speculative_config=SimpleNamespace(
+            draft_model_config=draft_model_config,
+            attention_backend=AttentionBackendEnum.B12X_MLA,
+        )
+    )
+    draft_config = SimpleNamespace(
+        parallel_config=SimpleNamespace(decode_context_parallel_size=1),
+        attention_config=SimpleNamespace(backend=None, use_non_causal=False),
+        quant_config=object(),
+    )
+    draft_quant_config = object()
+    captured = {}
+
+    class ModelCaptured(RuntimeError):
+        pass
+
+    def fake_get_model(*, vllm_config, model_config):
+        captured["vllm_config"] = vllm_config
+        captured["model_config"] = model_config
+        raise ModelCaptured
+
+    monkeypatch.setattr(
+        dspark_utils,
+        "_create_draft_vllm_config",
+        lambda config: draft_config if config is target_config else None,
+    )
+    monkeypatch.setattr(dspark_utils, "get_model", fake_get_model)
+    monkeypatch.setattr(
+        "vllm.model_executor.models.qwen3_dflash.dflash_has_any_non_causal",
+        lambda _config: True,
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.models.utils.get_draft_quant_config",
+        lambda config: draft_quant_config if config is target_config else None,
+    )
+
+    with pytest.raises(ModelCaptured):
+        dspark_utils.load_dspark_model(object(), target_config)
+
+    assert captured["model_config"] is draft_model_config
+    loaded_config = captured["vllm_config"]
+    assert loaded_config.parallel_config.decode_context_parallel_size == 1
+    assert loaded_config.attention_config.backend == AttentionBackendEnum.B12X_MLA
+    assert loaded_config.attention_config.use_non_causal
+    assert loaded_config.quant_config is draft_quant_config
+
+
+def test_dflash_attention_metadata_uses_external_draft_geometry(monkeypatch) -> None:
+    """Attention metadata retains the external draft's DCP1 geometry."""
+    target_config = SimpleNamespace(
+        parallel_config=SimpleNamespace(decode_context_parallel_size=16)
+    )
+    draft_config = SimpleNamespace(
+        parallel_config=SimpleNamespace(decode_context_parallel_size=1),
+        attention_config=SimpleNamespace(
+            backend=AttentionBackendEnum.B12X_MLA,
+            use_non_causal=False,
+        ),
+    )
+    monkeypatch.setattr(
+        dflash_speculator,
+        "_create_draft_vllm_config",
+        lambda config: draft_config if config is target_config else None,
+    )
+    speculator = object.__new__(dflash_speculator.DFlashSpeculator)
+    speculator.vllm_config = target_config
+    speculator.requires_non_causal = True
+
+    attention_config = speculator.attn_vllm_config
+
+    assert attention_config.parallel_config.decode_context_parallel_size == 1
+    assert attention_config.attention_config.use_non_causal
+    assert not draft_config.attention_config.use_non_causal

--- a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
@@ -9,6 +9,7 @@ states, which are fc-combined, normed, projected to K/V by every draft
 layer, and written into the draft KV cache.
 """
 
+import copy
 from collections.abc import Mapping
 from typing import Any, NamedTuple
 
@@ -17,7 +18,7 @@ import torch
 import torch.nn as nn
 
 import vllm.envs as envs
-from vllm.config import VllmConfig, replace
+from vllm.config import VllmConfig
 from vllm.config.compilation import CUDAGraphMode
 from vllm.forward_context import BatchDescriptor, set_forward_context
 from vllm.logger import init_logger
@@ -42,6 +43,7 @@ from vllm.v1.worker.gpu.spec_decode.dflash.utils import (
     load_dflash_model,
     maybe_load_mask_embedding,
 )
+from vllm.v1.worker.gpu.spec_decode.eagle.utils import _create_draft_vllm_config
 from vllm.v1.worker.gpu.spec_decode.speculator import (
     CUDAGraphCapturePhase,
     DraftModelSpeculator,
@@ -169,14 +171,12 @@ class DFlashSpeculator(DraftModelSpeculator):
 
     @property
     def attn_vllm_config(self) -> VllmConfig:
-        # The draft's attention differs from the target's in causality.
-        return replace(
-            self.vllm_config,
-            attention_config=replace(
-                self.vllm_config.attention_config,
-                use_non_causal=self.requires_non_causal,
-            ),
-        )
+        """Return an isolated attention view with draft parallel geometry."""
+        draft_vllm_config = copy.copy(_create_draft_vllm_config(self.vllm_config))
+        draft_attention_config = copy.copy(draft_vllm_config.attention_config)
+        draft_attention_config.use_non_causal = self.requires_non_causal
+        draft_vllm_config.attention_config = draft_attention_config
+        return draft_vllm_config
 
     def init_cudagraph_manager(self, cudagraph_mode: CUDAGraphMode) -> None:
         wants_full = cudagraph_mode.decode_mode() == CUDAGraphMode.FULL

--- a/vllm/v1/worker/gpu/spec_decode/dspark/utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/dspark/utils.py
@@ -3,11 +3,12 @@
 
 import torch.nn as nn
 
-from vllm.config import VllmConfig, replace
+from vllm.config import VllmConfig
 from vllm.distributed.parallel_state import get_pp_group
 from vllm.model_executor.model_loader import get_model
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 from vllm.v1.worker.gpu.spec_decode.eagle.utils import (
+    _create_draft_vllm_config,
     _should_share,
     get_target_lm_head,
 )
@@ -28,24 +29,16 @@ def load_dspark_model(target_model: nn.Module, vllm_config: VllmConfig) -> nn.Mo
         # auto-selection may pick one that downgrades the spec-decode
         # cudagraph to PIECEWISE.
         backend = AttentionBackendEnum.FLASH_ATTN
-    draft_vllm_config = replace(
-        vllm_config,
-        attention_config=replace(
-            vllm_config.attention_config,
-            use_non_causal=dflash_has_any_non_causal(draft_model_config.hf_config),
-            backend=backend,
-        ),
-        cache_config=(
-            replace(
-                vllm_config.cache_config,
-                cache_dtype=speculative_config.kv_cache_dtype,
-            )
-            if speculative_config.kv_cache_dtype is not None
-            else vllm_config.cache_config
-        ),
+    # External drafts own their model, cache dtype, and DCP1 attention geometry.
+    # Reusing target DCP geometry would partition a cache that every target rank
+    # must populate and consume independently.
+    draft_vllm_config = _create_draft_vllm_config(vllm_config)
+    draft_vllm_config.attention_config.backend = backend
+    draft_vllm_config.attention_config.use_non_causal = dflash_has_any_non_causal(
+        draft_model_config.hf_config
     )
-    # VllmConfig post-init restores the target's quant config because the target
-    # config is retained for DSpark's target-layer metadata, so we must override it.
+    # Replacing the model config does not recompute VllmConfig.quant_config.
+    # The draft must not inherit the target checkpoint's quantization method.
     draft_vllm_config.quant_config = get_draft_quant_config(vllm_config)
 
     with set_model_tag("dspark_head"):


### PR DESCRIPTION
## Behavior

External DFlash and DSpark checkpoints construct their model and attention metadata from the draft `VllmConfig` produced by `_create_draft_vllm_config`.

The draft retains its own:

- DCP1 parallel geometry;
- cache dtype;
- attention backend selection;
- causal mode; and
- quantization configuration.

The target model configuration is not mutated.

## Technical reason

An external speculative model owns a replicated cache on every target DCP rank. Building the draft with the target model's DCP geometry partitions that independent cache and gives its metadata builder the wrong process groups. Reconstructing `VllmConfig` also discards derived runtime attributes; the implementation copies the validated draft configuration and changes only its attention view.

## Compatibility

The change applies to external DFlash-family and DSpark models. Target-model attention configuration and non-external speculative methods are unchanged. This pull request does not enable Kimi-K3 DSpark DCP by itself; target-side native DCP remains a separate backend dependency.

## Validation

- Ruff and Python compilation pass for all changed files.
- `tests/v1/spec_decode/test_external_draft_attention_config.py`: 2 passed in the source-locked CUDA 13.3 / PyTorch 2.13 Kimi-K3 runtime image.
