### PR TITLE
[II] Replicate Kimi DSpark cache under target DCP

### DIFF
--- a/tests/models/kimi_k3/test_dspark_dcp_cache.py
+++ b/tests/models/kimi_k3/test_dspark_dcp_cache.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import torch
+
+from vllm.models.kimi_k3.nvidia import mla
+
+
+def _cache_spec(monkeypatch, *, non_causal: bool, dcp_size: int):
+    attention = object.__new__(mla.MultiHeadLatentAttention)
+    attention.kv_cache_dtype = "auto"
+    attention.head_size = 640
+    attention.non_causal_multi_token_decode = non_causal
+    config = SimpleNamespace(
+        cache_config=SimpleNamespace(block_size=64),
+        model_config=object(),
+        parallel_config=SimpleNamespace(
+            decode_context_parallel_size=dcp_size,
+        ),
+    )
+    monkeypatch.setattr(
+        mla,
+        "kv_cache_dtype_str_to_dtype",
+        lambda _cache_dtype, _model_config: torch.bfloat16,
+    )
+    monkeypatch.setattr(mla, "get_kv_quant_mode", lambda _cache_dtype: None)
+    return mla.MultiHeadLatentAttention.get_kv_cache_spec(attention, config)
+
+
+def test_external_k3_dspark_cache_is_replicated_under_target_dcp(
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("VLLM_DCP_SHARD_DRAFT", raising=False)
+
+    spec = _cache_spec(monkeypatch, non_causal=True, dcp_size=16)
+
+    assert spec.dcp_replicated
+
+
+def test_explicit_draft_sharding_disables_cache_replication(monkeypatch) -> None:
+    monkeypatch.setenv("VLLM_DCP_SHARD_DRAFT", "1")
+
+    spec = _cache_spec(monkeypatch, non_causal=True, dcp_size=16)
+
+    assert not spec.dcp_replicated
+
+
+def test_target_k3_cache_is_not_marked_as_draft_replication(monkeypatch) -> None:
+    monkeypatch.delenv("VLLM_DCP_SHARD_DRAFT", raising=False)
+
+    spec = _cache_spec(monkeypatch, non_causal=False, dcp_size=16)
+
+    assert not spec.dcp_replicated

--- a/tests/transformers_utils/test_dspark_mla_config.py
+++ b/tests/transformers_utils/test_dspark_mla_config.py
@@ -8,6 +8,7 @@ import pytest
 from vllm.config import ModelConfig, ParallelConfig, SpeculativeConfig
 from vllm.transformers_utils.config import get_config
 from vllm.transformers_utils.configs.k3_dspark import K3DSparkConfig
+from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
 
 def _write_dspark_config(path, **overrides):
@@ -142,7 +143,7 @@ def test_dspark_mla_speculative_config_preserves_architecture(tmp_path):
     assert speculative_config.draft_model_config.use_mla
 
 
-def test_dspark_mla_rejects_decode_context_parallelism(tmp_path):
+def test_dspark_mla_dcp_requires_b12x_backend(tmp_path):
     target_path = tmp_path / "target"
     draft_path = tmp_path / "draft"
     _write_target_config(target_path)
@@ -151,7 +152,7 @@ def test_dspark_mla_rejects_decode_context_parallelism(tmp_path):
         model=str(target_path), tokenizer_mode="skip", max_model_len=32768
     )
 
-    with pytest.raises(ValueError, match="does not currently support decode context"):
+    with pytest.raises(ValueError, match="requires attention_backend=B12X_MLA"):
         SpeculativeConfig(
             model=str(draft_path),
             method="dspark",
@@ -163,3 +164,29 @@ def test_dspark_mla_rejects_decode_context_parallelism(tmp_path):
                 distributed_executor_backend="external_launcher",
             ),
         )
+
+
+def test_dspark_mla_allows_dcp_with_b12x_backend(tmp_path):
+    target_path = tmp_path / "target"
+    draft_path = tmp_path / "draft"
+    _write_target_config(target_path)
+    _write_dspark_config(draft_path)
+    target_config = ModelConfig(
+        model=str(target_path), tokenizer_mode="skip", max_model_len=32768
+    )
+
+    config = SpeculativeConfig(
+        model=str(draft_path),
+        method="dspark",
+        num_speculative_tokens=7,
+        attention_backend=AttentionBackendEnum.B12X_MLA,
+        target_model_config=target_config,
+        target_parallel_config=ParallelConfig(
+            tensor_parallel_size=8,
+            decode_context_parallel_size=8,
+            distributed_executor_backend="external_launcher",
+        ),
+    )
+
+    assert config.attention_backend is AttentionBackendEnum.B12X_MLA
+    assert config.target_parallel_config.decode_context_parallel_size == 8

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -1166,10 +1166,12 @@ class SpeculativeConfig:
                     self.method == "dspark"
                     and "K3DSparkModel" in self.draft_model_config.architectures
                     and self.target_parallel_config.decode_context_parallel_size > 1
+                    and self.attention_backend != AttentionBackendEnum.B12X_MLA
                 ):
                     raise ValueError(
-                        "MLA DSpark does not currently support decode context "
-                        "parallelism; set decode_context_parallel_size=1."
+                        "K3 DSpark decode context parallelism requires "
+                        "attention_backend=B12X_MLA; otherwise set "
+                        "decode_context_parallel_size=1."
                     )
 
                 if self.num_speculative_tokens is not None and hasattr(

--- a/vllm/models/kimi_k3/nvidia/mla.py
+++ b/vllm/models/kimi_k3/nvidia/mla.py
@@ -34,6 +34,7 @@ from typing import TYPE_CHECKING, cast
 import torch
 from torch import nn
 
+import vllm.envs as envs
 from vllm import _custom_ops as ops
 from vllm.compilation.breakable_cudagraph import eager_break_during_capture
 from vllm.config import (
@@ -372,6 +373,17 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
         kv_cache_dtype = kv_cache_dtype_str_to_dtype(
             self.kv_cache_dtype, vllm_config.model_config
         )
+        raw_shard_draft = envs.VLLM_DCP_SHARD_DRAFT
+        shard_draft = (
+            False
+            if raw_shard_draft is None
+            else raw_shard_draft.lower() in ("1", "true", "yes")
+        )
+        dcp_replicated = bool(
+            self.non_causal_multi_token_decode
+            and not shard_draft
+            and vllm_config.parallel_config.decode_context_parallel_size > 1
+        )
         # TODO: Remove this mypy workaround once the K3 PR is fully merged.
         return MLAAttentionSpec(  # type: ignore[call-arg]
             block_size=vllm_config.cache_config.block_size,
@@ -381,6 +393,7 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
             cache_dtype_str=self.kv_cache_dtype,
             kv_quant_mode=get_kv_quant_mode(self.kv_cache_dtype),
             non_causal_multi_token_decode=self.non_causal_multi_token_decode,
+            dcp_replicated=dcp_replicated,
         )
 
     def process_weights_after_loading(self, act_dtype: torch.dtype) -> None:


### PR DESCRIPTION
## Behavior

Kimi-K3 DSpark may run with a B12X MLA target that uses decode context parallelism. The external draft keeps a complete DCP1 KV cache on every target rank unless `VLLM_DCP_SHARD_DRAFT=1` explicitly requests draft sharding.

The speculative configuration accepts target DCP only when the external Kimi draft selects `B12X_MLA`; other attention backends retain the DCP1 requirement.

## Technical reason

Kimi-K3 target KV is partitioned by DCP, while an external DSpark model executes independently on every target rank. Marking the non-causal draft MLA cache as `dcp_replicated` gives each rank complete draft context without changing the target cache layout.

## Compatibility

- Causal Kimi-K3 target layers are never marked as replicated draft cache.
- `VLLM_DCP_SHARD_DRAFT=1` preserves explicit draft-cache sharding.
- DCP1 behavior is unchanged.
- Runtime activation requires the backend-owned Kimi B12X DCP implementation in vLLM #360.
- This pull request is stacked on vLLM #363.

## Validation

- Ruff and Python compilation pass for all changed files.
- Six Kimi DSpark configuration and cache-replication tests pass in the source-locked CUDA 13.3 / PyTorch 2.13 runtime image.
