### PR TITLE
[II] Bound Kimi DSpark draft KV state

### DIFF
--- a/tests/models/kimi_k3/test_dspark_dcp_cache.py
+++ b/tests/models/kimi_k3/test_dspark_dcp_cache.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import torch
+
+from vllm.models.kimi_k3.nvidia import mla
+
+
+def _cache_spec(monkeypatch, *, non_causal: bool, dcp_size: int):
+    attention = object.__new__(mla.MultiHeadLatentAttention)
+    attention.kv_cache_dtype = "auto"
+    attention.head_size = 640
+    attention.non_causal_multi_token_decode = non_causal
+    config = SimpleNamespace(
+        cache_config=SimpleNamespace(block_size=64),
+        model_config=object(),
+        parallel_config=SimpleNamespace(
+            decode_context_parallel_size=dcp_size,
+        ),
+    )
+    monkeypatch.setattr(
+        mla,
+        "kv_cache_dtype_str_to_dtype",
+        lambda _cache_dtype, _model_config: torch.bfloat16,
+    )
+    monkeypatch.setattr(mla, "get_kv_quant_mode", lambda _cache_dtype: None)
+    return mla.MultiHeadLatentAttention.get_kv_cache_spec(attention, config)
+
+
+def test_external_k3_dspark_cache_is_replicated_under_target_dcp(
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("VLLM_DCP_SHARD_DRAFT", raising=False)
+
+    spec = _cache_spec(monkeypatch, non_causal=True, dcp_size=16)
+
+    assert spec.dcp_replicated
+
+
+def test_explicit_draft_sharding_disables_cache_replication(monkeypatch) -> None:
+    monkeypatch.setenv("VLLM_DCP_SHARD_DRAFT", "1")
+
+    spec = _cache_spec(monkeypatch, non_causal=True, dcp_size=16)
+
+    assert not spec.dcp_replicated
+
+
+def test_target_k3_cache_is_not_marked_as_draft_replication(monkeypatch) -> None:
+    monkeypatch.delenv("VLLM_DCP_SHARD_DRAFT", raising=False)
+
+    spec = _cache_spec(monkeypatch, non_causal=False, dcp_size=16)
+
+    assert not spec.dcp_replicated

--- a/tests/models/kimi_k3/test_dspark_dcp_cache.py
+++ b/tests/models/kimi_k3/test_dspark_dcp_cache.py
@@ -8,11 +8,18 @@ import torch
 from vllm.models.kimi_k3.nvidia import mla
 
 
-def _cache_spec(monkeypatch, *, non_causal: bool, dcp_size: int):
+def _cache_spec(
+    monkeypatch,
+    *,
+    non_causal: bool,
+    dcp_size: int,
+    draft_kv_window: int = 0,
+):
     attention = object.__new__(mla.MultiHeadLatentAttention)
     attention.kv_cache_dtype = "auto"
     attention.head_size = 640
     attention.non_causal_multi_token_decode = non_causal
+    attention.draft_kv_window = draft_kv_window
     config = SimpleNamespace(
         cache_config=SimpleNamespace(block_size=64),
         model_config=object(),
@@ -53,3 +60,19 @@ def test_target_k3_cache_is_not_marked_as_draft_replication(monkeypatch) -> None
     spec = _cache_spec(monkeypatch, non_causal=False, dcp_size=16)
 
     assert not spec.dcp_replicated
+
+
+def test_bounded_dspark_cache_preserves_non_causal_mode(monkeypatch) -> None:
+    monkeypatch.delenv("VLLM_DCP_SHARD_DRAFT", raising=False)
+
+    spec = _cache_spec(
+        monkeypatch,
+        non_causal=True,
+        dcp_size=16,
+        draft_kv_window=65_536,
+    )
+
+    assert isinstance(spec, mla.SlidingWindowMLASpec)
+    assert spec.sliding_window == 65_536
+    assert spec.non_causal_multi_token_decode
+    assert spec.dcp_replicated

--- a/tests/transformers_utils/test_dspark_mla_config.py
+++ b/tests/transformers_utils/test_dspark_mla_config.py
@@ -8,6 +8,7 @@ import pytest
 from vllm.config import ModelConfig, ParallelConfig, SpeculativeConfig
 from vllm.transformers_utils.config import get_config
 from vllm.transformers_utils.configs.k3_dspark import K3DSparkConfig
+from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
 
 def _write_dspark_config(path, **overrides):
@@ -142,7 +143,7 @@ def test_dspark_mla_speculative_config_preserves_architecture(tmp_path):
     assert speculative_config.draft_model_config.use_mla
 
 
-def test_dspark_mla_rejects_decode_context_parallelism(tmp_path):
+def test_dspark_mla_dcp_requires_b12x_backend(tmp_path):
     target_path = tmp_path / "target"
     draft_path = tmp_path / "draft"
     _write_target_config(target_path)
@@ -151,7 +152,7 @@ def test_dspark_mla_rejects_decode_context_parallelism(tmp_path):
         model=str(target_path), tokenizer_mode="skip", max_model_len=32768
     )
 
-    with pytest.raises(ValueError, match="does not currently support decode context"):
+    with pytest.raises(ValueError, match="requires attention_backend=B12X_MLA"):
         SpeculativeConfig(
             model=str(draft_path),
             method="dspark",
@@ -163,3 +164,29 @@ def test_dspark_mla_rejects_decode_context_parallelism(tmp_path):
                 distributed_executor_backend="external_launcher",
             ),
         )
+
+
+def test_dspark_mla_allows_dcp_with_b12x_backend(tmp_path):
+    target_path = tmp_path / "target"
+    draft_path = tmp_path / "draft"
+    _write_target_config(target_path)
+    _write_dspark_config(draft_path)
+    target_config = ModelConfig(
+        model=str(target_path), tokenizer_mode="skip", max_model_len=32768
+    )
+
+    config = SpeculativeConfig(
+        model=str(draft_path),
+        method="dspark",
+        num_speculative_tokens=7,
+        attention_backend=AttentionBackendEnum.B12X_MLA,
+        target_model_config=target_config,
+        target_parallel_config=ParallelConfig(
+            tensor_parallel_size=8,
+            decode_context_parallel_size=8,
+            distributed_executor_backend="external_launcher",
+        ),
+    )
+
+    assert config.attention_backend is AttentionBackendEnum.B12X_MLA
+    assert config.target_parallel_config.decode_context_parallel_size == 8

--- a/tests/v1/spec_decode/test_dflash_prefix_cache_masking.py
+++ b/tests/v1/spec_decode/test_dflash_prefix_cache_masking.py
@@ -168,3 +168,35 @@ def test_shift_copy_bounded_by_seq_len():
 
     torch.testing.assert_close(block_table[0, :4], original[0, 4:8])
     torch.testing.assert_close(block_table[0, 4:], original[0, 4:])
+
+
+def test_window_shift_updates_shared_sequence_length_once_for_two_groups():
+    tables = [_make_block_table(1), _make_block_table(1)]
+    originals = [table.clone() for table in tables]
+    idx_mapping = torch.zeros(1, dtype=torch.int32, device=DEVICE)
+    num_cached_tokens = torch.zeros(1, dtype=torch.int32, device=DEVICE)
+    seq_lens = torch.full((1,), 8 * BLOCK_SIZE, dtype=torch.int32, device=DEVICE)
+    draft_kv_window = 4 * BLOCK_SIZE
+
+    shift_draft_block_tables(
+        tables[0],
+        idx_mapping,
+        num_cached_tokens,
+        seq_lens,
+        BLOCK_SIZE,
+        draft_kv_window,
+        update_seq_lens=False,
+    )
+    shift_draft_block_tables(
+        tables[1],
+        idx_mapping,
+        num_cached_tokens,
+        seq_lens,
+        BLOCK_SIZE,
+        draft_kv_window,
+        update_seq_lens=True,
+    )
+
+    assert seq_lens.item() == draft_kv_window
+    for table, original in zip(tables, originals, strict=True):
+        torch.testing.assert_close(table[0, :4], original[0, 4:8])

--- a/tests/v1/spec_decode/test_external_draft_attention_config.py
+++ b/tests/v1/spec_decode/test_external_draft_attention_config.py
@@ -81,9 +81,43 @@ def test_dflash_attention_metadata_uses_external_draft_geometry(monkeypatch) -> 
     speculator = object.__new__(dflash_speculator.DFlashSpeculator)
     speculator.vllm_config = target_config
     speculator.requires_non_causal = True
+    speculator.draft_kv_window = None
+    speculator.draft_kv_window_block_size = None
 
     attention_config = speculator.attn_vllm_config
 
     assert attention_config.parallel_config.decode_context_parallel_size == 1
     assert attention_config.attention_config.use_non_causal
     assert not draft_config.attention_config.use_non_causal
+
+
+def test_bounded_draft_attention_preserves_derived_model_attributes(
+    monkeypatch,
+) -> None:
+    """Bounded plan sizing copies runtime objects without reconstructing them."""
+    draft_model_config = SimpleNamespace(
+        max_model_len=1_048_576,
+        model_arch_config=object(),
+    )
+    draft_config = SimpleNamespace(
+        model_config=draft_model_config,
+        attention_config=SimpleNamespace(use_non_causal=False),
+    )
+    target_config = object()
+    monkeypatch.setattr(
+        dflash_speculator,
+        "_create_draft_vllm_config",
+        lambda config: draft_config if config is target_config else None,
+    )
+    speculator = object.__new__(dflash_speculator.DFlashSpeculator)
+    speculator.vllm_config = target_config
+    speculator.requires_non_causal = True
+    speculator.draft_kv_window = 65_536
+    speculator.draft_kv_window_block_size = 768
+
+    attention_config = speculator.attn_vllm_config
+
+    assert draft_model_config.max_model_len == 1_048_576
+    assert attention_config.model_config.max_model_len == 65_536 + 768 - 1
+    assert attention_config.model_config.model_arch_config is not None
+    assert attention_config.attention_config.use_non_causal

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -1166,10 +1166,12 @@ class SpeculativeConfig:
                     self.method == "dspark"
                     and "K3DSparkModel" in self.draft_model_config.architectures
                     and self.target_parallel_config.decode_context_parallel_size > 1
+                    and self.attention_backend != AttentionBackendEnum.B12X_MLA
                 ):
                     raise ValueError(
-                        "MLA DSpark does not currently support decode context "
-                        "parallelism; set decode_context_parallel_size=1."
+                        "K3 DSpark decode context parallelism requires "
+                        "attention_backend=B12X_MLA; otherwise set "
+                        "decode_context_parallel_size=1."
                     )
 
                 if self.num_speculative_tokens is not None and hasattr(

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -64,6 +64,7 @@ if TYPE_CHECKING:
     VLLM_NVFP4_MLA_SCALES_FILE: str = ""
     VLLM_B12X_ABSORB_BMM: bool = False
     VLLM_DSPARK_FP8_DRAFT_HEAD: bool = False
+    VLLM_DSPARK_DRAFT_KV_WINDOW: int = 0
     VLLM_USE_B12X_WO_PROJECTION: bool = False
     VLLM_USE_B12X_MOE: bool = False
     VLLM_NF3_GRID188_DECODE: bool = True
@@ -1137,6 +1138,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # retain target-model semantics. Requires fp8 tensor cores (SM89+).
     "VLLM_DSPARK_FP8_DRAFT_HEAD": lambda: bool(
         int(os.getenv("VLLM_DSPARK_FP8_DRAFT_HEAD", "0"))
+    ),
+    # Limit an external DSpark draft to a replicated rolling MLA KV tail while
+    # the target model retains its complete context. Target verification makes
+    # the setting quality-safe, but acceptance may change with the window.
+    "VLLM_DSPARK_DRAFT_KV_WINDOW": lambda: int(
+        os.getenv("VLLM_DSPARK_DRAFT_KV_WINDOW", "0")
     ),
     # Use b12x for the DeepSeek V4 WO-A/WO-B fused projection.
     # This is separate from the generic FP8 linear switch for perf isolation.

--- a/vllm/models/kimi_k3/nvidia/mla.py
+++ b/vllm/models/kimi_k3/nvidia/mla.py
@@ -87,7 +87,12 @@ from vllm.v1.attention.backends.mla.prefill import get_mla_prefill_backend
 from vllm.v1.attention.ops.dcp_utils import MLADCPManager
 from vllm.v1.attention.ops.merge_attn_states import merge_attn_states
 from vllm.v1.attention.selector import get_attn_backend
-from vllm.v1.kv_cache_interface import KVCacheSpec, MLAAttentionSpec, get_kv_quant_mode
+from vllm.v1.kv_cache_interface import (
+    KVCacheSpec,
+    MLAAttentionSpec,
+    SlidingWindowMLASpec,
+    get_kv_quant_mode,
+)
 
 if TYPE_CHECKING:
     from vllm.model_executor.layers.attention.mla_attention import MLACommonMetadata
@@ -136,6 +141,16 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
         self.q_lora_rank = q_lora_rank
         self.kv_lora_rank = kv_lora_rank
         self.non_causal_multi_token_decode = non_causal_multi_token_decode
+        self.draft_kv_window = (
+            int(envs.VLLM_DSPARK_DRAFT_KV_WINDOW)
+            if non_causal_multi_token_decode
+            else 0
+        )
+        if self.draft_kv_window < 0:
+            raise ValueError(
+                "VLLM_DSPARK_DRAFT_KV_WINDOW must be non-negative, got "
+                f"{self.draft_kv_window}."
+            )
         # Latent "head" seen by the attention kernel / KV cache.
         self.head_size = kv_lora_rank + qk_rope_head_dim
         self.scale = self.qk_head_dim**-0.5
@@ -384,16 +399,32 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
             and not shard_draft
             and vllm_config.parallel_config.decode_context_parallel_size > 1
         )
-        # TODO: Remove this mypy workaround once the K3 PR is fully merged.
-        return MLAAttentionSpec(  # type: ignore[call-arg]
+        common_kwargs = dict(
             block_size=vllm_config.cache_config.block_size,
             num_kv_heads=1,
             head_size=self.head_size,
             dtype=kv_cache_dtype,
             cache_dtype_str=self.kv_cache_dtype,
             kv_quant_mode=get_kv_quant_mode(self.kv_cache_dtype),
-            non_causal_multi_token_decode=self.non_causal_multi_token_decode,
             dcp_replicated=dcp_replicated,
+        )
+        if self.draft_kv_window:
+            if self.draft_kv_window < vllm_config.cache_config.block_size:
+                raise ValueError(
+                    "VLLM_DSPARK_DRAFT_KV_WINDOW must be at least one KV "
+                    f"block ({vllm_config.cache_config.block_size}), got "
+                    f"{self.draft_kv_window}."
+                )
+            return SlidingWindowMLASpec(
+                **common_kwargs,
+                sliding_window=self.draft_kv_window,
+                non_causal_multi_token_decode=self.non_causal_multi_token_decode,
+            )
+        # TODO: Remove this type suppression when MLAAttentionSpec declares
+        # non_causal_multi_token_decode in its constructor signature.
+        return MLAAttentionSpec(  # type: ignore[call-arg]
+            **common_kwargs,
+            non_causal_multi_token_decode=self.non_causal_multi_token_decode,
         )
 
     def process_weights_after_loading(self, act_dtype: torch.dtype) -> None:

--- a/vllm/models/kimi_k3/nvidia/mla.py
+++ b/vllm/models/kimi_k3/nvidia/mla.py
@@ -34,6 +34,7 @@ from typing import TYPE_CHECKING, cast
 import torch
 from torch import nn
 
+import vllm.envs as envs
 from vllm import _custom_ops as ops
 from vllm.compilation.breakable_cudagraph import eager_break_during_capture
 from vllm.config import (
@@ -372,6 +373,17 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
         kv_cache_dtype = kv_cache_dtype_str_to_dtype(
             self.kv_cache_dtype, vllm_config.model_config
         )
+        raw_shard_draft = envs.VLLM_DCP_SHARD_DRAFT
+        shard_draft = (
+            False
+            if raw_shard_draft is None
+            else raw_shard_draft.lower() in ("1", "true", "yes")
+        )
+        dcp_replicated = bool(
+            self.non_causal_multi_token_decode
+            and not shard_draft
+            and vllm_config.parallel_config.decode_context_parallel_size > 1
+        )
         # TODO: Remove this mypy workaround once the K3 PR is fully merged.
         return MLAAttentionSpec(  # type: ignore[call-arg]
             block_size=vllm_config.cache_config.block_size,
@@ -381,6 +393,7 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
             cache_dtype_str=self.kv_cache_dtype,
             kv_quant_mode=get_kv_quant_mode(self.kv_cache_dtype),
             non_causal_multi_token_decode=self.non_causal_multi_token_decode,
+            dcp_replicated=dcp_replicated,
         )
 
     def process_weights_after_loading(self, act_dtype: torch.dtype) -> None:

--- a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
@@ -25,7 +25,12 @@ from vllm.logger import init_logger
 from vllm.triton_utils import tl, triton
 from vllm.v1.attention.backend import AttentionCGSupport
 from vllm.v1.attention.backends.utils import PAD_SLOT_ID
-from vllm.v1.kv_cache_interface import KVCacheConfig
+from vllm.v1.kv_cache_interface import (
+    KVCacheConfig,
+    SlidingWindowMLASpec,
+    UniformTypeKVCacheSpecs,
+    get_kv_cache_spec_sliding_window,
+)
 from vllm.v1.worker.gpu.attn_utils import build_slot_mappings_by_layer
 from vllm.v1.worker.gpu.block_table import BlockTables
 from vllm.v1.worker.gpu.cudagraph_utils import (
@@ -151,6 +156,8 @@ class DFlashSpeculator(DraftModelSpeculator):
         self.query_cudagraph_manager: DFlashCudaGraphManager | None = None
         self.context_cudagraph_manager: DFlashContextCudaGraphManager | None = None
         self.draft_kv_cache_group_id: int = -1
+        self.draft_kv_window: int | None = None
+        self.draft_kv_window_block_size: int | None = None
         # Manual CUDA graphs keep raw addresses for model intermediates. Retain
         # each captured backbone output so its storage cannot be recycled while
         # a graph still reads it during sampling.
@@ -173,6 +180,15 @@ class DFlashSpeculator(DraftModelSpeculator):
     def attn_vllm_config(self) -> VllmConfig:
         """Return an isolated attention view with draft parallel geometry."""
         draft_vllm_config = copy.copy(_create_draft_vllm_config(self.vllm_config))
+        if self.draft_kv_window is not None:
+            # Plan only enough positional capacity for the rolling draft tail.
+            # Global token positions and target admission retain their range.
+            assert self.draft_kv_window_block_size is not None
+            draft_model_config = copy.copy(draft_vllm_config.model_config)
+            draft_model_config.max_model_len = (
+                self.draft_kv_window + self.draft_kv_window_block_size - 1
+            )
+            draft_vllm_config.model_config = draft_model_config
         draft_attention_config = copy.copy(draft_vllm_config.attention_config)
         draft_attention_config.use_non_causal = self.requires_non_causal
         draft_vllm_config.attention_config = draft_attention_config
@@ -386,6 +402,7 @@ class DFlashSpeculator(DraftModelSpeculator):
         target_input_buffers: InputBuffers,
         target_attn_groups: list[list[AttentionGroup]],
     ) -> None:
+        self._configure_bounded_k3_draft_kv(kv_cache_config)
         super().set_attn(
             model_state,
             kv_cache_config,
@@ -443,6 +460,56 @@ class DFlashSpeculator(DraftModelSpeculator):
                         layer_names, self.model.get_draft_attn_causal()
                     )
                 }
+
+    def _configure_bounded_k3_draft_kv(self, kv_cache_config: KVCacheConfig) -> None:
+        """Discover one uniform rolling window for Kimi-K3 draft MLA layers."""
+        self.draft_kv_window = None
+        self.draft_kv_window_block_size = None
+        if (
+            getattr(self.draft_model_config.hf_config, "model_type", None)
+            != "k3_dspark"
+        ):
+            return
+
+        draft_windows: set[int] = set()
+        draft_block_sizes: set[int] = set()
+        saw_non_mla_window = False
+        for group in kv_cache_config.kv_cache_groups:
+            active_names = set(group.layer_names) & self.draft_attn_layer_names
+            if not active_names:
+                continue
+            group_spec = group.kv_cache_spec
+            for layer_name in active_names:
+                layer_spec = (
+                    group_spec.kv_cache_specs[layer_name]
+                    if isinstance(group_spec, UniformTypeKVCacheSpecs)
+                    else group_spec
+                )
+                window = get_kv_cache_spec_sliding_window(layer_spec)
+                if window is None:
+                    continue
+                if not isinstance(layer_spec, SlidingWindowMLASpec):
+                    saw_non_mla_window = True
+                    continue
+                draft_windows.add(int(window))
+                draft_block_sizes.add(int(layer_spec.block_size))
+
+        if saw_non_mla_window or not draft_windows:
+            return
+        if len(draft_windows) != 1 or len(draft_block_sizes) != 1:
+            raise ValueError(
+                "Kimi-K3 DSpark bounded KV requires one uniform window and "
+                f"block size, got windows={sorted(draft_windows)}, "
+                f"block_sizes={sorted(draft_block_sizes)}."
+            )
+        self.draft_kv_window = draft_windows.pop()
+        self.draft_kv_window_block_size = draft_block_sizes.pop()
+        logger.info_once(
+            "Kimi-K3 DSpark uses a bounded replicated DCP1 KV tail: "
+            "window=%d, manager_block_size=%d.",
+            self.draft_kv_window,
+            self.draft_kv_window_block_size,
+        )
 
     @torch.inference_mode()
     def _run_model(
@@ -630,6 +697,12 @@ class DFlashSpeculator(DraftModelSpeculator):
         num_query_tokens = num_reqs * active_query_len
         max_seq_len = input_batch.seq_lens_cpu_upper_bound[:num_reqs].max().item()
         self.draft_max_seq_len = min(max_seq_len + active_query_len, self.max_model_len)
+        if self.draft_kv_window is not None:
+            assert self.draft_kv_window_block_size is not None
+            self.draft_max_seq_len = min(
+                self.draft_max_seq_len,
+                self.draft_kv_window + self.draft_kv_window_block_size - 1,
+            )
 
         # NOTE: To avoid CPU-GPU synchronization without CPU knowing the
         # number of rejected tokens, we maintain the size of input_ids and
@@ -724,13 +797,16 @@ class DFlashSpeculator(DraftModelSpeculator):
         # block-table shift cannot hide the residual partial block. Skipped for
         # dummy runs, whose idx_mapping does not reference live requests.
         if not dummy_run:
-            for gid in self.draft_kv_cache_group_ids:
+            last_group_index = len(self.draft_kv_cache_group_ids) - 1
+            for group_index, gid in enumerate(self.draft_kv_cache_group_ids):
                 shift_draft_block_tables(
                     self.block_tables.input_block_tables[gid],
                     input_batch.idx_mapping,
                     self.num_cached_tokens,
                     self.input_buffers.seq_lens,
                     self.block_tables.kernel_block_sizes[gid],
+                    self.draft_kv_window or 0,
+                    update_seq_lens=group_index == last_group_index,
                 )
 
         # Pre-insert context K/V into the cache. Decode replays a row-bucketed
@@ -1111,19 +1187,27 @@ def _shift_draft_block_tables_kernel(
     num_cached_tokens_ptr,
     seq_lens_ptr,
     block_size,
+    draft_kv_window,
     BLOCK_SIZE: tl.constexpr,
+    UPDATE_SEQ_LENS: tl.constexpr,
 ):
     req_idx = tl.program_id(0)
     req_state_idx = tl.load(idx_mapping_ptr + req_idx)
     num_cached = tl.load(num_cached_tokens_ptr + req_state_idx)
-    shift = num_cached // block_size
+    cached_shift = num_cached // block_size
+    seq_len = tl.load(seq_lens_ptr + req_idx)
+    window_shift = tl.maximum(seq_len - draft_kv_window, 0) // block_size
+    window_shift = tl.where(draft_kv_window > 0, window_shift, 0)
+    shift = cached_shift + window_shift
     if shift == 0:
         return
     row_ptr = block_table_ptr + req_idx.to(tl.int64) * block_table_stride
     # Only the blocks the shifted sequence still references need to move;
     # seq_lens holds the cache-shifted draft length (written by
     # _prepare_dflash_inputs_kernel, which must run first).
-    seq_len = tl.load(seq_lens_ptr + req_idx)
+    seq_len -= window_shift * block_size
+    if UPDATE_SEQ_LENS:
+        tl.store(seq_lens_ptr + req_idx, seq_len)
     num_needed = (seq_len + block_size - 1) // block_size
     num_remaining = tl.minimum(block_table_stride - shift, num_needed)
     # In-place left shift is safe: iterations run in ascending order and each
@@ -1157,11 +1241,17 @@ def shift_draft_block_tables(
     # [num_reqs] cache-shifted draft sequence lengths
     seq_lens: torch.Tensor,
     block_size: int,
+    draft_kv_window: int = 0,
+    *,
+    update_seq_lens: bool = True,
 ) -> None:
-    """Shift each request's draft block-table row left by its cache-restored
-    whole blocks, hiding slots that hold no draft context KV from the draft's
-    attention. Must run after prepare_dflash_inputs (slot mappings index the
-    unshifted table, and seq_lens must already hold the shifted lengths)."""
+    """Hide restored-prefix and expired rolling-window blocks from attention.
+
+    The operation must follow ``prepare_dflash_inputs`` because slot mappings
+    index the unshifted table and sequence lengths already exclude restored
+    prefix tokens. Multiple draft cache groups share the sequence-length
+    buffer, so only the final group updates it.
+    """
     num_reqs = idx_mapping.shape[0]
     _shift_draft_block_tables_kernel[(num_reqs,)](
         block_table,
@@ -1170,5 +1260,7 @@ def shift_draft_block_tables(
         num_cached_tokens,
         seq_lens,
         block_size,
+        draft_kv_window,
         BLOCK_SIZE=1024,  # type: ignore
+        UPDATE_SEQ_LENS=update_seq_lens,
     )

--- a/vllm/v1/worker/gpu/spec_decode/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/speculator.py
@@ -318,7 +318,7 @@ class DraftModelSpeculator(BaseSpeculator):
             step,
             out=draft_seq_lens_cpu_upper_bound[:num_reqs],
         )
-        draft_seq_lens_cpu_upper_bound[:num_reqs].clamp_(max=self.max_model_len)
+        draft_seq_lens_cpu_upper_bound[:num_reqs].clamp_(max=self.draft_max_seq_len)
         seq_lens = self.input_buffers.seq_lens[:num_reqs_padded]
         dcp_local_seq_lens = None
         if self.block_tables.cp_size > 1:


### PR DESCRIPTION
## Behavior

`VLLM_DSPARK_DRAFT_KV_WINDOW` gives an external Kimi-K3 DSpark model a rolling replicated MLA KV tail while the target model keeps its complete DCP-sharded context.

The runtime:

- emits a non-causal `SlidingWindowMLASpec` for draft MLA layers;
- sizes draft attention metadata to the window plus one manager block;
- removes expired blocks from every draft cache-group block table;
- updates the shared draft sequence length exactly once across cache groups; and
- clamps draft metadata to the bounded plan without changing global token positions or target request admission.

A value of zero preserves the full draft cache. Negative values and windows smaller than one KV block are rejected.

## Technical reason

A replicated full-context draft cache consumes the same KV capacity on every target DCP rank. DSpark proposals are verified by the target, so retaining a bounded draft tail can change proposal acceptance but cannot bypass target-model verification.

## Compatibility

- Only non-causal Kimi-K3 draft MLA layers consume the environment setting.
- DFlash checkpoints and causal Kimi-K3 target layers keep their existing cache specifications.
- This pull request is stacked on vLLM #364 and requires the sliding-window MLA causal-mode contract in vLLM #334.
- The recurrent-state and Kimi cache-group capacity fixes in vLLM #335 and #336 are independent deployment dependencies for the 1,048,576-token profile.

## Validation

- Ruff, Python compilation, and whitespace validation pass.
- Sixteen focused tests pass in the source-locked CUDA 13.3 / PyTorch 2.13 runtime image.
- The test set includes GPU Triton validation of two cache groups sharing one bounded sequence-length buffer.
