### PR TITLE
[II] Compact Kimi DSpark rotary state

### DIFF
--- a/tests/models/kimi_k3/test_dspark_compact_rope.py
+++ b/tests/models/kimi_k3/test_dspark_compact_rope.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+from torch import nn
+
+from vllm.models.kimi_k3.nvidia import dspark_mla
+
+
+class _Rotary(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.scaling_factor = 2.0
+        self.mscale = 1.25
+        self.head_size = 4
+        self.is_neox_style = False
+        self.register_buffer(
+            "cos_sin_cache",
+            torch.arange(64, dtype=torch.float32).view(16, 4),
+        )
+
+    def _compute_inv_freq(self, scaling_factor: float) -> torch.Tensor:
+        assert scaling_factor == self.scaling_factor
+        return torch.tensor([0.5, 0.25], dtype=torch.float32)
+
+
+class _Attention(nn.Module):
+    def __init__(self, rotary: _Rotary) -> None:
+        super().__init__()
+        self.rotary_emb = rotary
+
+
+class _Layer(nn.Module):
+    def __init__(self, rotary: _Rotary) -> None:
+        super().__init__()
+        self.self_attn = _Attention(rotary)
+
+
+def _draft_model(rotary: _Rotary) -> dspark_mla.K3DSparkModel:
+    model = object.__new__(dspark_mla.K3DSparkModel)
+    nn.Module.__init__(model)
+    model.layers = nn.ModuleList([_Layer(rotary), _Layer(rotary)])
+    model._max_num_context_tokens = 8
+    return model
+
+
+def test_compact_rope_materializes_requested_global_positions() -> None:
+    positions = torch.tensor([2, 7], dtype=torch.int64)
+    inv_freq = torch.tensor([0.5, 0.25], dtype=torch.float32)
+    freqs = torch.empty((4, 2), dtype=torch.float32)
+    cache = torch.empty((4, 4), dtype=torch.float32)
+
+    result = dspark_mla._fill_compact_rope_cache(
+        positions,
+        inv_freq,
+        freqs,
+        cache,
+        mscale=1.25,
+    )
+
+    expected_freqs = positions[:, None] * inv_freq[None, :]
+    expected = torch.cat((expected_freqs.cos(), expected_freqs.sin()), dim=-1) * 1.25
+    torch.testing.assert_close(result, expected)
+    assert result.untyped_storage().data_ptr() == cache.untyped_storage().data_ptr()
+
+
+def test_compact_rope_rejects_more_positions_than_workspace() -> None:
+    with pytest.raises(ValueError, match="workspace is too small"):
+        dspark_mla._fill_compact_rope_cache(
+            torch.arange(3),
+            torch.ones(2),
+            torch.empty((2, 2)),
+            torch.empty((2, 4)),
+            mscale=1.0,
+        )
+
+
+def test_compact_rope_releases_unshared_full_position_table() -> None:
+    rotary = _Rotary()
+    original_bytes = rotary.cos_sin_cache.nbytes
+    model = _draft_model(rotary)
+
+    model._init_compact_rope()
+    model._compact_rope_enabled = True
+    remapped_positions, compact_cache = model._get_rope_inputs(
+        torch.tensor([2, 7], dtype=torch.int64)
+    )
+
+    assert original_bytes == 256
+    assert rotary.cos_sin_cache.shape == (0, 4)
+    torch.testing.assert_close(remapped_positions, torch.tensor([0, 1]))
+    expected_freqs = torch.tensor([[1.0, 0.5], [3.5, 1.75]])
+    expected_cache = (
+        torch.cat((expected_freqs.cos(), expected_freqs.sin()), dim=-1) * 1.25
+    )
+    torch.testing.assert_close(compact_cache, expected_cache)
+
+
+def test_compact_rope_retains_target_owned_position_table() -> None:
+    rotary = _Rotary()
+    target = nn.Module()
+    target.rotary = rotary
+    model = _draft_model(rotary)
+
+    with dspark_mla.protect_k3_compact_rope_sources(target):
+        model._init_compact_rope()
+
+    assert rotary.cos_sin_cache.shape == (16, 4)
+    assert not dspark_mla._COMPACT_ROPE_PROTECTED_IDS

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -65,6 +65,7 @@ if TYPE_CHECKING:
     VLLM_B12X_ABSORB_BMM: bool = False
     VLLM_DSPARK_FP8_DRAFT_HEAD: bool = False
     VLLM_DSPARK_DRAFT_KV_WINDOW: int = 0
+    VLLM_DSPARK_COMPACT_ROPE: bool = False
     VLLM_USE_B12X_WO_PROJECTION: bool = False
     VLLM_USE_B12X_MOE: bool = False
     VLLM_NF3_GRID188_DECODE: bool = True
@@ -1144,6 +1145,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # the setting quality-safe, but acceptance may change with the window.
     "VLLM_DSPARK_DRAFT_KV_WINDOW": lambda: int(
         os.getenv("VLLM_DSPARK_DRAFT_KV_WINDOW", "0")
+    ),
+    # Replace the persistent Kimi-K3 draft position table with fixed-address
+    # workspaces that materialize only rows consumed by one draft forward.
+    "VLLM_DSPARK_COMPACT_ROPE": lambda: bool(
+        int(os.getenv("VLLM_DSPARK_COMPACT_ROPE", "0"))
     ),
     # Use b12x for the DeepSeek V4 WO-A/WO-B fused projection.
     # This is separate from the generic FP8 linear switch for perf isolation.

--- a/vllm/models/kimi_k3/nvidia/dspark_mla.py
+++ b/vllm/models/kimi_k3/nvidia/dspark_mla.py
@@ -2,13 +2,16 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """K3 dense MLA draft model for DSpark speculative decoding."""
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
+from contextlib import contextmanager
 
 import torch
 import torch.nn as nn
 
 import vllm._custom_ops as ops
+from vllm import envs
 from vllm.config import VllmConfig
+from vllm.logger import init_logger
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import (
     MergedColumnParallelLinear,
@@ -27,6 +30,24 @@ from vllm.models.kimi_k3.nvidia.mla import MultiHeadLatentAttention
 from vllm.models.kimi_k3.nvidia.model import KimiMLP
 from vllm.utils.torch_utils import is_quantized_kv_cache
 from vllm.v1.worker.workspace import current_workspace_manager
+
+logger = init_logger(__name__)
+
+_COMPACT_ROPE_PROTECTED_IDS: set[int] = set()
+
+
+@contextmanager
+def protect_k3_compact_rope_sources(model: nn.Module) -> Iterator[None]:
+    """Prevent a draft from releasing position tables owned by ``model``."""
+    previous = _COMPACT_ROPE_PROTECTED_IDS.copy()
+    _COMPACT_ROPE_PROTECTED_IDS.update(
+        id(module) for module in model.modules() if hasattr(module, "cos_sin_cache")
+    )
+    try:
+        yield
+    finally:
+        _COMPACT_ROPE_PROTECTED_IDS.clear()
+        _COMPACT_ROPE_PROTECTED_IDS.update(previous)
 
 
 def _duplicate_context_kv_weights(
@@ -49,6 +70,32 @@ def _duplicate_context_kv_weights(
         fused_weight = weight.detach()
         fused_weight.shard_id = layer_idx
         yield f"context_kv_proj.{param_name}", fused_weight
+
+
+def _fill_compact_rope_cache(
+    positions: torch.Tensor,
+    inv_freq: torch.Tensor,
+    freqs_workspace: torch.Tensor,
+    cache_workspace: torch.Tensor,
+    *,
+    mscale: float,
+) -> torch.Tensor:
+    """Materialize RoPE rows consumed by one Kimi-K3 draft forward."""
+    num_positions = int(positions.shape[0])
+    if num_positions > int(freqs_workspace.shape[0]):
+        raise ValueError(
+            "Kimi-K3 DSpark compact RoPE workspace is too small: "
+            f"positions={num_positions}, capacity={freqs_workspace.shape[0]}."
+        )
+    freqs = freqs_workspace[:num_positions]
+    cache = cache_workspace[:num_positions]
+    half_dim = int(inv_freq.shape[0])
+    torch.mul(positions[:, None], inv_freq[None, :], out=freqs)
+    torch.cos(freqs, out=cache[:, :half_dim])
+    torch.sin(freqs, out=cache[:, half_dim:])
+    if mscale != 1.0:
+        cache.mul_(mscale)
+    return cache
 
 
 class K3DSparkDecoderLayer(nn.Module):
@@ -101,6 +148,7 @@ class K3DSparkDecoderLayer(nn.Module):
         positions: torch.Tensor,
         hidden_states: torch.Tensor,
         residual: torch.Tensor | None,
+        rope_cos_sin_cache: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         if residual is None:
             # First layer: hidden_states is the (already reduced) embedding.
@@ -114,6 +162,7 @@ class K3DSparkDecoderLayer(nn.Module):
         hidden_states = self.self_attn(
             positions=positions,
             hidden_states=hidden_states,
+            rope_cos_sin_cache=rope_cos_sin_cache,
         )
         hidden_states, residual = fused_allreduce_rms_norm(
             hidden_states, residual, self.post_attention_layernorm
@@ -187,6 +236,111 @@ class K3DSparkModel(nn.Module):
         self._max_num_context_tokens = (
             vllm_config.scheduler_config.max_num_batched_tokens
         )
+        self._compact_rope_enabled = bool(envs.VLLM_DSPARK_COMPACT_ROPE)
+        if self._compact_rope_enabled:
+            self._init_compact_rope()
+
+    def _init_compact_rope(self) -> None:
+        rotary_modules = [layer.self_attn.rotary_emb for layer in self.layers]
+        if not rotary_modules or any(rotary is None for rotary in rotary_modules):
+            raise RuntimeError(
+                "Kimi-K3 DSpark compact RoPE requires rotary draft layers."
+            )
+        rotary = rotary_modules[0]
+        assert rotary is not None
+        if any(candidate is not rotary for candidate in rotary_modules[1:]):
+            raise RuntimeError(
+                "Kimi-K3 DSpark compact RoPE requires every draft layer to "
+                "share one immutable rotary embedding."
+            )
+        if not hasattr(rotary, "scaling_factor"):
+            raise TypeError(
+                "Kimi-K3 DSpark compact RoPE requires a YaRN rotary embedding, "
+                f"got {type(rotary).__name__}."
+            )
+
+        full_cache = rotary.cos_sin_cache
+        if full_cache.dtype != torch.float32 or full_cache.ndim != 2:
+            raise TypeError(
+                "Kimi-K3 DSpark compact RoPE requires a 2-D fp32 source cache, "
+                f"got shape={tuple(full_cache.shape)}, dtype={full_cache.dtype}."
+            )
+        with torch.device(full_cache.device):
+            inv_freq = rotary._compute_inv_freq(rotary.scaling_factor)  # noqa: SLF001
+        inv_freq = inv_freq.to(dtype=torch.float32)
+        half_dim = int(inv_freq.shape[0])
+        if int(full_cache.shape[1]) != 2 * half_dim:
+            raise ValueError(
+                "Kimi-K3 DSpark compact RoPE frequency width does not match "
+                f"its source table: inv_freq={half_dim}, "
+                f"cache={full_cache.shape[1]}."
+            )
+
+        self.register_buffer("_compact_rope_inv_freq", inv_freq, persistent=False)
+        self.register_buffer(
+            "_compact_rope_freqs",
+            torch.empty(
+                (self._max_num_context_tokens, half_dim),
+                dtype=torch.float32,
+                device=full_cache.device,
+            ),
+            persistent=False,
+        )
+        self.register_buffer(
+            "_compact_rope_cache",
+            torch.empty(
+                (self._max_num_context_tokens, 2 * half_dim),
+                dtype=torch.float32,
+                device=full_cache.device,
+            ),
+            persistent=False,
+        )
+        self.register_buffer(
+            "_compact_rope_positions",
+            torch.arange(
+                self._max_num_context_tokens,
+                dtype=torch.int64,
+                device=full_cache.device,
+            ),
+            persistent=False,
+        )
+        self._compact_rope_mscale = float(rotary.mscale)
+
+        if id(rotary) in _COMPACT_ROPE_PROTECTED_IDS:
+            logger.warning_once(
+                "Kimi-K3 DSpark compact RoPE retains a position table shared "
+                "with the target model."
+            )
+            return
+
+        released_bytes = full_cache.numel() * full_cache.element_size()
+        rotary.cos_sin_cache = torch.empty(
+            (0, 2 * half_dim),
+            dtype=torch.float32,
+            device=full_cache.device,
+        )
+        logger.info_once(
+            "Kimi-K3 DSpark compact RoPE released %.2f MiB/rank and "
+            "materializes at most %d fp32 rows per forward.",
+            released_bytes / (1024**2),
+            self._max_num_context_tokens,
+        )
+
+    def _get_rope_inputs(
+        self, positions: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        rotary = self.layers[0].self_attn.rotary_emb
+        assert rotary is not None
+        if not self._compact_rope_enabled:
+            return positions, rotary.cos_sin_cache
+        cache = _fill_compact_rope_cache(
+            positions,
+            self._compact_rope_inv_freq,
+            self._compact_rope_freqs,
+            self._compact_rope_cache,
+            mscale=self._compact_rope_mscale,
+        )
+        return self._compact_rope_positions[: positions.shape[0]], cache
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         assert self.embed_tokens is not None
@@ -267,7 +421,8 @@ class K3DSparkModel(nn.Module):
             ((num_layers * self._max_num_context_tokens,), torch.int64),
         )
         repeated_positions = repeated_positions[: num_layers * num_ctx]
-        repeated_positions.view(num_layers, num_ctx).copy_(context_positions)
+        rope_positions, rope_cos_sin_cache = self._get_rope_inputs(context_positions)
+        repeated_positions.view(num_layers, num_ctx).copy_(rope_positions)
         # Keep the single-tensor context RoPE on vLLM's optimized CUDA op;
         # DeepSeek YaRN's FlashInfer wrapper assumes a non-null key tensor.
         rotary_emb = self.layers[0].self_attn.rotary_emb
@@ -277,7 +432,7 @@ class K3DSparkModel(nn.Module):
             all_k_pe_flat,
             None,
             rotary_emb.head_size,
-            rotary_emb.cos_sin_cache,
+            rope_cos_sin_cache,
             rotary_emb.is_neox_style,
         )
         all_k_pe = all_k_pe_flat.view(num_layers, num_ctx, 1, self._context_rope_dim)
@@ -383,11 +538,13 @@ class K3DSparkModel(nn.Module):
 
         hidden_states = inputs_embeds
         residual = None
+        rope_positions, rope_cos_sin_cache = self._get_rope_inputs(positions)
         for layer in self.layers:
             hidden_states, residual = layer(
-                positions=positions,
+                positions=rope_positions,
                 hidden_states=hidden_states,
                 residual=residual,
+                rope_cos_sin_cache=rope_cos_sin_cache,
             )
         hidden_states, _ = fused_allreduce_rms_norm(
             hidden_states, residual, self.final_norm

--- a/vllm/models/kimi_k3/nvidia/mla.py
+++ b/vllm/models/kimi_k3/nvidia/mla.py
@@ -506,6 +506,7 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
         self,
         positions: torch.Tensor,
         hidden_states: torch.Tensor,
+        rope_cos_sin_cache: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """Attention front-end: fused qkv-a proj -> norms -> q_b -> attention.
 
@@ -544,13 +545,21 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
             dtype=hidden_states.dtype,
             device=hidden_states.device,
         )
-        self._attention(positions, q, kv_c_normed, k_pe, attn_out)
+        self._attention(
+            positions,
+            q,
+            kv_c_normed,
+            k_pe,
+            attn_out,
+            rope_cos_sin_cache=rope_cos_sin_cache,
+        )
         return attn_out
 
     def forward(
         self,
         positions: torch.Tensor,
         hidden_states: torch.Tensor,
+        rope_cos_sin_cache: torch.Tensor | None = None,
     ) -> torch.Tensor:
         # Both branches produce (attn_out, gate); they differ only in whether
         # the g_proj GEMM is overlapped on the aux stream.
@@ -563,14 +572,16 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
             and hidden_states.shape[0] < _GATE_MULTI_STREAM_TOKEN_THRESHOLD
         ):
             attn_out, gate = maybe_execute_in_parallel(
-                lambda: self._forward_attn(positions, hidden_states),
+                lambda: self._forward_attn(
+                    positions, hidden_states, rope_cos_sin_cache
+                ),
                 lambda: g_proj(hidden_states)[0],
                 events[0],
                 events[1],
                 self.aux_stream,
             )
         else:
-            attn_out = self._forward_attn(positions, hidden_states)
+            attn_out = self._forward_attn(positions, hidden_states, rope_cos_sin_cache)
             gate = g_proj(hidden_states)[0] if g_proj is not None else None
 
         if gate is not None:
@@ -590,6 +601,8 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
         kv_c_normed: torch.Tensor,
         k_pe: torch.Tensor,
         attn_out: torch.Tensor,
+        *,
+        rope_cos_sin_cache: torch.Tensor | None = None,
     ) -> None:
         forward_context = get_forward_context()
         attn_metadata_by_layer = forward_context.attn_metadata
@@ -617,7 +630,11 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
         if self.rotary_emb is not None:
             # Pass the fp32 cos/sin table straight to the fused epilogue (it reads
             # fp32 and does the RoPE math in fp32) -- no per-forward dtype cast.
-            cos_sin_cache = self.rotary_emb.cos_sin_cache
+            cos_sin_cache = (
+                rope_cos_sin_cache
+                if rope_cos_sin_cache is not None
+                else self.rotary_emb.cos_sin_cache
+            )
             rope_positions = positions
 
         # Decode tokens are laid out first, prefill tokens after. The fused

--- a/vllm/v1/worker/gpu/spec_decode/dspark/utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/dspark/utils.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from contextlib import nullcontext
+
 import torch.nn as nn
 
 from vllm.config import VllmConfig
@@ -41,7 +43,21 @@ def load_dspark_model(target_model: nn.Module, vllm_config: VllmConfig) -> nn.Mo
     # The draft must not inherit the target checkpoint's quantization method.
     draft_vllm_config.quant_config = get_draft_quant_config(vllm_config)
 
-    with set_model_tag("dspark_head"):
+    target_language_model = (
+        target_model.get_language_model()
+        if hasattr(target_model, "get_language_model")
+        else target_model
+    )
+    if getattr(draft_model_config.hf_config, "model_type", None) == "k3_dspark":
+        from vllm.models.kimi_k3.nvidia.dspark_mla import (
+            protect_k3_compact_rope_sources,
+        )
+
+        rope_ownership = protect_k3_compact_rope_sources(target_language_model)
+    else:
+        rope_ownership = nullcontext()
+
+    with rope_ownership, set_model_tag("dspark_head"):
         draft_model = get_model(
             vllm_config=draft_vllm_config, model_config=draft_model_config
         )
@@ -49,11 +65,6 @@ def load_dspark_model(target_model: nn.Module, vllm_config: VllmConfig) -> nn.Mo
     if get_pp_group().world_size != 1:
         raise NotImplementedError("DSpark does not support pipeline parallelism.")
 
-    target_language_model = (
-        target_model.get_language_model()
-        if hasattr(target_model, "get_language_model")
-        else target_model
-    )
     target_inner = target_language_model.model
     draft_inner = draft_model.model
 


### PR DESCRIPTION
## Behavior

`VLLM_DSPARK_COMPACT_ROPE=1` replaces the external Kimi-K3 DSpark model's persistent 1,048,576-position FP32 rotary table with fixed-address workspaces sized by `max_num_batched_tokens`.

Each context or draft forward:

1. computes FP32 cosine and sine rows for the supplied global positions;
2. stores them in caller-stable workspaces; and
3. remaps the attention positions to the compact row range.

The Kimi MLA adapter accepts the explicit rotary table without changing the default full-table path. A source table shared with the target model is detected during draft construction and retained.

## Technical reason

The Kimi-K3 YaRN rotary table has 1,048,576 rows and width 64 in FP32, which occupies 256 MiB per rank. The compact representation preserves identical rotary arithmetic while allocating only the rows one forward can consume.

## Compatibility

- The setting is opt-in and applies only to the Kimi-K3 external DSpark model.
- Disabled behavior is unchanged.
- Non-YaRN, non-FP32, inconsistent-width, and non-shared-per-layer rotary layouts fail with explicit errors.
- This pull request is stacked on vLLM #365.

## Validation

- Ruff, Python compilation, and whitespace validation pass.
- Eighteen compact-RoPE, Kimi DSpark model, and external-draft configuration tests pass in the source-locked CUDA 13.3 / PyTorch 2.13 runtime image.
- Existing Kimi-K3 DSpark runtime logs record a 256.00 MiB/rank release with 512-, 2,048-, and 4,096-row workspaces.
