### PR TITLE
[II] Shard Kimi DSpark context projection

### DIFF
--- a/tests/models/test_dspark_mla.py
+++ b/tests/models/test_dspark_mla.py
@@ -166,6 +166,68 @@ def test_k3_dspark_uses_replicated_markov_head(monkeypatch: pytest.MonkeyPatch):
     ]
 
 
+@pytest.mark.cpu_test
+@pytest.mark.parametrize(
+    ("tp_size", "expect_sharded"),
+    [(1, False), (8, True), (12, False), (16, True)],
+)
+def test_k3_dspark_context_projection_uses_divisible_tp_geometry(
+    monkeypatch: pytest.MonkeyPatch,
+    tp_size: int,
+    expect_sharded: bool,
+) -> None:
+    context_projection_calls = []
+
+    class DummyModule(nn.Module):
+        def __init__(self, *args, **kwargs):
+            super().__init__()
+
+    def make_sharded_projection(*args, **kwargs):
+        context_projection_calls.append((args, kwargs))
+        return DummyModule()
+
+    monkeypatch.setattr(dspark_mla, "get_draft_quant_config", lambda _: None)
+    monkeypatch.setattr(dspark_mla, "ColumnParallelLinear", make_sharded_projection)
+    monkeypatch.setattr(dspark_mla, "ReplicatedLinear", DummyModule)
+    monkeypatch.setattr(dspark_mla, "MergedColumnParallelLinear", DummyModule)
+    monkeypatch.setattr(dspark_mla, "RMSNorm", DummyModule)
+    monkeypatch.setattr(dspark_mla, "K3DSparkDecoderLayer", DummyModule)
+    monkeypatch.setattr(dspark_mla, "DSparkMarkovHead", DummyModule)
+
+    config = SimpleNamespace(
+        target_hidden_size=7168,
+        num_target_layers=5,
+        hidden_size=7168,
+        kv_lora_rank=512,
+        qk_rope_head_dim=64,
+        rms_norm_eps=1e-6,
+        num_hidden_layers=1,
+        vocab_size=163840,
+        draft_vocab_size=163840,
+        markov_rank=256,
+    )
+    vllm_config = SimpleNamespace(
+        speculative_config=SimpleNamespace(
+            draft_model_config=SimpleNamespace(hf_config=config)
+        ),
+        parallel_config=SimpleNamespace(tensor_parallel_size=tp_size),
+        scheduler_config=SimpleNamespace(max_num_batched_tokens=16),
+    )
+
+    model = K3DSparkModel(
+        vllm_config=vllm_config,
+        start_layer_id=0,
+        prefix="model",
+    )
+
+    assert model.context_proj_sharded is expect_sharded
+    assert bool(context_projection_calls) is expect_sharded
+    if expect_sharded:
+        args, kwargs = context_projection_calls[0]
+        assert args == (7168 * 5, 7168)
+        assert kwargs["gather_output"] is True
+
+
 def test_context_kv_weights_are_loaded_as_merged_linear_shards():
     weights = [
         (

--- a/vllm/models/kimi_k3/nvidia/dspark_mla.py
+++ b/vllm/models/kimi_k3/nvidia/dspark_mla.py
@@ -14,6 +14,7 @@ from vllm.config import VllmConfig
 from vllm.logger import init_logger
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import (
+    ColumnParallelLinear,
     MergedColumnParallelLinear,
     ReplicatedLinear,
 )
@@ -189,14 +190,37 @@ class K3DSparkModel(nn.Module):
         # The frozen target embedding is aliased after the draft checkpoint loads.
         self.embed_tokens: nn.Module | None = None
 
-        self.context_proj = ReplicatedLinear(
-            self.config.target_hidden_size * self.config.num_target_layers,
-            self.config.hidden_size,
-            bias=False,
-            return_bias=False,
-            quant_config=self.quant_config,
-            prefix=maybe_prefix(prefix, "context_proj"),
+        parallel_config = getattr(vllm_config, "parallel_config", None)
+        tp_size = int(getattr(parallel_config, "tensor_parallel_size", 1))
+        self.context_proj_sharded = (
+            tp_size > 1 and self.config.hidden_size % tp_size == 0
         )
+        context_input_size = (
+            self.config.target_hidden_size * self.config.num_target_layers
+        )
+        context_prefix = maybe_prefix(prefix, "context_proj")
+        if self.context_proj_sharded:
+            # Target auxiliary states are identical across TP ranks. Each rank
+            # retains and evaluates only its output rows; the gathered result
+            # preserves the draft hidden-state layout exactly.
+            self.context_proj = ColumnParallelLinear(
+                context_input_size,
+                self.config.hidden_size,
+                bias=False,
+                gather_output=True,
+                return_bias=False,
+                quant_config=self.quant_config,
+                prefix=context_prefix,
+            )
+        else:
+            self.context_proj = ReplicatedLinear(
+                context_input_size,
+                self.config.hidden_size,
+                bias=False,
+                return_bias=False,
+                quant_config=self.quant_config,
+                prefix=context_prefix,
+            )
         self.context_norm = RMSNorm(
             self.config.hidden_size, eps=self.config.rms_norm_eps
         )


### PR DESCRIPTION
## Behavior

The external Kimi-K3 DSpark context projection stores and evaluates output rows across tensor-parallel ranks when the 7,168-row output is divisible by the configured TP size. The small projected activation is gathered before the draft normalization step.

TP1 and non-divisible layouts use the replicated projection. Kimi-K3 therefore uses sharding at TP8 and TP16 and retains the replicated implementation at TP12.

## Technical reason

The five-layer Kimi-K3 DSpark checkpoint projects five 7,168-wide target auxiliary states into one 7,168-wide draft state. Its BF16 matrix occupies 490 MiB per rank when replicated. TP16 stores 30.625 MiB per rank, a 459.375 MiB reduction, while preserving independent output-row arithmetic exactly.

## Compatibility

- Weight loading uses the standard `ColumnParallelLinear` shard loader.
- Output ordering and dtype match the replicated projection after the standard TP gather.
- Unsupported TP divisibility falls back to `ReplicatedLinear` instead of padding weights.
- This pull request is stacked on vLLM #366.

## Validation

- Ruff, Python compilation, and whitespace validation pass.
- Nineteen Kimi-K3 DSpark model and compact-RoPE tests pass in the source-locked CUDA 13.3 / PyTorch 2.13 runtime image.
- Focused construction tests cover TP1, TP8, TP12, and TP16 selection.
