### PR TITLE
[II] Shard DSpark Markov vocabulary state

### DIFF
--- a/tests/models/test_dspark_mla.py
+++ b/tests/models/test_dspark_mla.py
@@ -83,6 +83,8 @@ def test_dspark_markov_head_is_replicated(
         "get_current_vllm_config",
         lambda: SimpleNamespace(model_config=None),
     )
+    monkeypatch.delenv("VLLM_DSPARK_SHARD_MARKOV_HEAD", raising=False)
+    monkeypatch.delenv("VLLM_DSPARK_REPLICATE_MARKOV_W1", raising=False)
 
     head = DSparkMarkovHead(128, 128, 8, prefix="markov_head")
     assert head.markov_w2.tp_size == 1
@@ -104,6 +106,65 @@ def test_dspark_markov_head_is_replicated(
     bias = head.bias(markov_embed, logits_processor)
     assert markov_embed.shape == (2, 8)
     assert bias.shape == (2, 128)
+
+
+@pytest.mark.cpu_test
+@pytest.mark.parametrize("replicate_w1", [False, True])
+def test_dspark_markov_head_shards_vocabulary_weights(
+    monkeypatch: pytest.MonkeyPatch,
+    replicate_w1: bool,
+) -> None:
+    from vllm.model_executor.layers import logits_processor, vocab_parallel_embedding
+
+    monkeypatch.setenv("VLLM_DSPARK_SHARD_MARKOV_HEAD", "1")
+    monkeypatch.setenv(
+        "VLLM_DSPARK_REPLICATE_MARKOV_W1",
+        "1" if replicate_w1 else "0",
+    )
+    monkeypatch.setattr(
+        vocab_parallel_embedding, "get_tensor_model_parallel_rank", lambda: 3
+    )
+    monkeypatch.setattr(
+        vocab_parallel_embedding,
+        "get_tensor_model_parallel_world_size",
+        lambda: 8,
+    )
+    monkeypatch.setattr(
+        logits_processor,
+        "get_current_vllm_config",
+        lambda: SimpleNamespace(model_config=None),
+    )
+
+    head = DSparkMarkovHead(128, 128, 8, prefix="markov_head")
+
+    assert head.shard_across_tp
+    assert head.replicate_w1 is replicate_w1
+    assert head.markov_w2.tp_size == 8
+    assert head.markov_w2.weight.shape == (16, 8)
+    if replicate_w1:
+        assert isinstance(head.markov_w1, nn.Embedding)
+        assert head.markov_w1.weight.shape == (128, 8)
+    else:
+        assert isinstance(
+            head.markov_w1,
+            vocab_parallel_embedding.VocabParallelEmbedding,
+        )
+        assert head.markov_w1.weight.shape == (16, 8)
+
+    processor = LogitsProcessor(128)
+    local_bias = head.local_bias(torch.ones((2, 8)), processor)
+    assert local_bias.shape == (2, 16)
+
+
+@pytest.mark.cpu_test
+def test_replicated_markov_w1_requires_sharded_head(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("VLLM_DSPARK_SHARD_MARKOV_HEAD", raising=False)
+    monkeypatch.setenv("VLLM_DSPARK_REPLICATE_MARKOV_W1", "1")
+
+    with pytest.raises(ValueError, match="requires VLLM_DSPARK_SHARD_MARKOV_HEAD"):
+        DSparkMarkovHead(128, 128, 8, prefix="markov_head")
 
 
 @pytest.mark.cpu_test

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -66,6 +66,8 @@ if TYPE_CHECKING:
     VLLM_DSPARK_FP8_DRAFT_HEAD: bool = False
     VLLM_DSPARK_DRAFT_KV_WINDOW: int = 0
     VLLM_DSPARK_COMPACT_ROPE: bool = False
+    VLLM_DSPARK_SHARD_MARKOV_HEAD: bool = False
+    VLLM_DSPARK_REPLICATE_MARKOV_W1: bool = False
     VLLM_USE_B12X_WO_PROJECTION: bool = False
     VLLM_USE_B12X_MOE: bool = False
     VLLM_NF3_GRID188_DECODE: bool = True
@@ -1150,6 +1152,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # workspaces that materialize only rows consumed by one draft forward.
     "VLLM_DSPARK_COMPACT_ROPE": lambda: bool(
         int(os.getenv("VLLM_DSPARK_COMPACT_ROPE", "0"))
+    ),
+    "VLLM_DSPARK_SHARD_MARKOV_HEAD": lambda: bool(
+        int(os.getenv("VLLM_DSPARK_SHARD_MARKOV_HEAD", "0"))
+    ),
+    "VLLM_DSPARK_REPLICATE_MARKOV_W1": lambda: bool(
+        int(os.getenv("VLLM_DSPARK_REPLICATE_MARKOV_W1", "0"))
     ),
     # Use b12x for the DeepSeek V4 WO-A/WO-B fused projection.
     # This is separate from the generic FP8 linear switch for perf isolation.

--- a/vllm/model_executor/models/qwen3_dspark.py
+++ b/vllm/model_executor/models/qwen3_dspark.py
@@ -20,6 +20,7 @@ from collections.abc import Iterable
 import torch
 import torch.nn as nn
 
+from vllm import envs
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
 from vllm.model_executor.layers.linear import ReplicatedLinear
@@ -27,6 +28,7 @@ from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
+    VocabParallelEmbedding,
 )
 
 from .qwen3_dflash import DFlashQwen3ForCausalLM, DFlashQwen3Model
@@ -43,9 +45,8 @@ class DSparkMarkovHead(nn.Module):
     (``draft_vocab_size``) added to the base draft logits. The two sizes
     coincide for full-vocab drafts.
 
-    Both weights are replicated because the head runs sequentially for every
-    draft position. Sharding them would add an all-reduce and a full-vocab
-    gather to each position.
+    Both weights are replicated by default. The TP-sharded layout reduces
+    persistent draft memory and retains the ordinary exact gathered-logit path.
     """
 
     def __init__(
@@ -57,6 +58,31 @@ class DSparkMarkovHead(nn.Module):
         quant_config: QuantizationConfig | None = None,
     ) -> None:
         super().__init__()
+        self.shard_across_tp = envs.VLLM_DSPARK_SHARD_MARKOV_HEAD
+        self.replicate_w1 = envs.VLLM_DSPARK_REPLICATE_MARKOV_W1
+        if self.replicate_w1 and not self.shard_across_tp:
+            raise ValueError(
+                "VLLM_DSPARK_REPLICATE_MARKOV_W1 requires "
+                "VLLM_DSPARK_SHARD_MARKOV_HEAD=1."
+            )
+        if self.shard_across_tp:
+            self.markov_w1 = (
+                nn.Embedding(vocab_size, markov_rank)
+                if self.replicate_w1
+                else VocabParallelEmbedding(
+                    vocab_size,
+                    markov_rank,
+                    prefix=maybe_prefix(prefix, "markov_w1"),
+                )
+            )
+            self.markov_w2 = ParallelLMHead(
+                draft_vocab_size,
+                markov_rank,
+                bias=False,
+                quant_config=quant_config,
+                prefix=maybe_prefix(prefix, "markov_w2"),
+            )
+            return
         self.markov_w1 = nn.Embedding(vocab_size, markov_rank)
         self.markov_w2 = ParallelLMHead(
             draft_vocab_size,
@@ -78,6 +104,16 @@ class DSparkMarkovHead(nn.Module):
     ) -> torch.Tensor:
         """Vocab-size transition bias from a Markov embedding ([B, r] -> [B, V])."""
         return logits_processor(self.markov_w2, markov_embed)
+
+    def local_bias(
+        self,
+        markov_embed: torch.Tensor,
+        logits_processor: LogitsProcessor,
+    ) -> torch.Tensor:
+        """Return the unprocessed transition-bias shard owned by this TP rank."""
+        if not self.shard_across_tp:
+            raise RuntimeError("Local Markov bias requires a TP-sharded head.")
+        return logits_processor._apply_head(self.markov_w2, markov_embed, None)
 
     def apply_bias_gathered(
         self,


### PR DESCRIPTION
## Behavior

`VLLM_DSPARK_SHARD_MARKOV_HEAD=1` stores the DSpark Markov input embedding and vocabulary projection across tensor-parallel ranks. The ordinary `LogitsProcessor` path still gathers the complete transition-bias distribution, so enabling storage sharding does not require a specialized sampler.

`VLLM_DSPARK_REPLICATE_MARKOV_W1=1` keeps the input embedding replicated while sharding only the vocabulary projection. The setting avoids a sequential W1 all-reduce at the cost of 80 MiB per rank for Kimi-K3.

## Technical reason

For Kimi-K3, each 163,840 × 256 BF16 Markov matrix occupies 80 MiB. TP16 sharding reduces one matrix to 5 MiB per rank. Sharding W2 while replicating W1 saves 75 MiB/rank; sharding both matrices saves 150 MiB/rank.

## Compatibility

- Both settings default to disabled.
- The replicated implementation and exact gathered logits remain unchanged.
- Requesting replicated W1 without a sharded head is rejected.
- `local_bias` exposes a rank-local W2 result for a separate distributed sampler; this pull request does not change sampling.
- This pull request is stacked on vLLM #367.

## Validation

- Ruff, Python compilation, and whitespace validation pass.
- Eighteen Kimi-K3 DSpark tests pass in the source-locked CUDA 13.3 / PyTorch 2.13 runtime image.
- Focused tests cover replicated storage, fully sharded storage, replicated-W1/sharded-W2 storage, local W2 output shape, and invalid configuration.
