### PR TITLE
[II] Select Kimi-K3 DSpark tokens from vocabulary shards

### DIFF
--- a/tests/models/test_dspark_mla.py
+++ b/tests/models/test_dspark_mla.py
@@ -9,6 +9,7 @@ import torch.nn as nn
 
 from vllm.compilation.wrapper import TorchCompileWithNoGuardsWrapper
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.vocab_parallel_embedding import ParallelLMHead
 from vllm.model_executor.models.qwen3_dspark import DSparkMarkovHead
 from vllm.model_executor.models.registry import ModelRegistry
 from vllm.model_executor.warmup.kimi_k3_triton_warmup import _get_kda_layer
@@ -337,3 +338,114 @@ def test_kda_warmup_ignores_cacheless_dspark_layers(
     monkeypatch.setattr(kimi_k3_kda, "KimiK3DeltaAttention", FakeKDA)
 
     assert _get_kda_layer(worker) is target_layer
+
+
+def _make_local_argmax_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> K3DSparkForCausalLM:
+    from vllm.model_executor.layers import logits_processor, vocab_parallel_embedding
+
+    monkeypatch.setenv("VLLM_DSPARK_SHARD_MARKOV_HEAD", "1")
+    monkeypatch.delenv("VLLM_DSPARK_REPLICATE_MARKOV_W1", raising=False)
+    monkeypatch.setattr(
+        vocab_parallel_embedding, "get_tensor_model_parallel_rank", lambda: 0
+    )
+    monkeypatch.setattr(
+        vocab_parallel_embedding,
+        "get_tensor_model_parallel_world_size",
+        lambda: 8,
+    )
+    monkeypatch.setattr(
+        logits_processor,
+        "get_current_vllm_config",
+        lambda: SimpleNamespace(model_config=None),
+    )
+
+    model = object.__new__(K3DSparkForCausalLM)
+    nn.Module.__init__(model)
+    model.lm_head = ParallelLMHead(128, 8, prefix="lm_head")
+    model.model = nn.Module()
+    model.model.markov_head = DSparkMarkovHead(128, 128, 8, prefix="markov_head")
+    model.logits_processor = LogitsProcessor(128)
+    model._b12x_dspark_argmax_enabled = False
+    model._b12x_dspark_argmax_cls = None
+    model._b12x_dspark_argmax_runtime = None
+    model._b12x_dspark_argmax_output = None
+    model._b12x_dspark_argmax_max_batch = 8
+    return model
+
+
+@pytest.mark.cpu_test
+def test_k3_dspark_local_argmax_requires_matching_unpadded_shards(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model = _make_local_argmax_model(monkeypatch)
+    assert model.supports_local_draft_argmax()
+
+    model.model.markov_head.markov_w2.num_embeddings_padded += 64
+    assert not model.supports_local_draft_argmax()
+
+
+@pytest.mark.cpu_test
+def test_k3_dspark_cutedsl_argmax_uses_tp8_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model = _make_local_argmax_model(monkeypatch)
+    calls = []
+
+    class FakeArgmax:
+        @classmethod
+        def from_exchange_group(cls, **kwargs):
+            calls.append(("construct", kwargs))
+            return cls()
+
+        def fused_add_argmax(self, base, bias, out):
+            calls.append(("sample", base.clone(), bias.clone(), out))
+            return out.fill_(7)
+
+    monkeypatch.setattr(
+        dspark_mla,
+        "get_tp_group",
+        lambda: SimpleNamespace(cpu_group="tp-metadata-group"),
+    )
+    model._b12x_dspark_argmax_cls = FakeArgmax
+    model._b12x_dspark_argmax_enabled = True
+    base = torch.randn((3, 16), dtype=torch.bfloat16)
+    bias = torch.randn_like(base)
+
+    sampled = model.sample_local_draft_logits(base, bias)
+
+    assert sampled.tolist() == [7, 7, 7]
+    assert calls[0] == (
+        "construct",
+        {
+            "exchange_group": "tp-metadata-group",
+            "device": torch.device("cpu"),
+            "local_vocab_size": 16,
+            "max_batch_size": 8,
+        },
+    )
+    assert calls[1][0] == "sample"
+    assert calls[1][3].shape == (3,)
+
+
+@pytest.mark.cpu_test
+def test_k3_dspark_local_argmax_falls_back_to_exact_gather(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model = _make_local_argmax_model(monkeypatch)
+    gathered = []
+
+    def fake_all_gather(logits: torch.Tensor, dim: int) -> torch.Tensor:
+        gathered.append((logits.clone(), dim))
+        return logits
+
+    monkeypatch.setattr(dspark_mla, "tensor_model_parallel_all_gather", fake_all_gather)
+    base = torch.tensor([[1.0, 2.0, 3.0, 4.0]], dtype=torch.bfloat16)
+    bias = torch.tensor([[0.0, 4.0, 0.0, 0.0]], dtype=torch.bfloat16)
+
+    sampled = model.sample_local_draft_logits(base, bias)
+
+    assert sampled.tolist() == [1]
+    torch.testing.assert_close(gathered[0][0], base + bias)
+    assert gathered[0][1] == -1

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -68,6 +68,7 @@ if TYPE_CHECKING:
     VLLM_DSPARK_COMPACT_ROPE: bool = False
     VLLM_DSPARK_SHARD_MARKOV_HEAD: bool = False
     VLLM_DSPARK_REPLICATE_MARKOV_W1: bool = False
+    VLLM_KIMI_K3_B12X_DSPARK_ARGMAX: bool = False
     VLLM_USE_B12X_WO_PROJECTION: bool = False
     VLLM_USE_B12X_MOE: bool = False
     VLLM_NF3_GRID188_DECODE: bool = True
@@ -1158,6 +1159,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     "VLLM_DSPARK_REPLICATE_MARKOV_W1": lambda: bool(
         int(os.getenv("VLLM_DSPARK_REPLICATE_MARKOV_W1", "0"))
+    ),
+    # Select a Kimi-K3 DSpark token without gathering full vocabulary shards.
+    # B12X performs an exact BF16 add and global greedy argmax for compatible
+    # unpadded vocabulary layouts. Unsupported layouts retain the exact vLLM
+    # all-gather fallback.
+    "VLLM_KIMI_K3_B12X_DSPARK_ARGMAX": lambda: bool(
+        int(os.getenv("VLLM_KIMI_K3_B12X_DSPARK_ARGMAX", "0"))
     ),
     # Use b12x for the DeepSeek V4 WO-A/WO-B fused projection.
     # This is separate from the generic FP8 linear switch for perf isolation.

--- a/vllm/models/kimi_k3/nvidia/dspark_mla.py
+++ b/vllm/models/kimi_k3/nvidia/dspark_mla.py
@@ -4,6 +4,7 @@
 
 from collections.abc import Iterable, Iterator
 from contextlib import contextmanager
+from typing import Any
 
 import torch
 import torch.nn as nn
@@ -11,6 +12,7 @@ import torch.nn as nn
 import vllm._custom_ops as ops
 from vllm import envs
 from vllm.config import VllmConfig
+from vllm.distributed import get_tp_group, tensor_model_parallel_all_gather
 from vllm.logger import init_logger
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import (
@@ -19,6 +21,9 @@ from vllm.model_executor.layers.linear import (
     ReplicatedLinear,
 )
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    VocabParallelEmbedding,
+)
 from vllm.model_executor.models.qwen3_dspark import DSparkMarkovHead
 from vllm.model_executor.models.utils import (
     AutoWeightsLoader,
@@ -35,6 +40,19 @@ from vllm.v1.worker.workspace import current_workspace_manager
 logger = init_logger(__name__)
 
 _COMPACT_ROPE_PROTECTED_IDS: set[int] = set()
+
+
+def _load_b12x_vocab_parallel_argmax() -> Any | None:
+    """Return B12X's exact vocabulary reducer when its API is complete."""
+    try:
+        from b12x.comm.pcie import VocabParallelArgmax
+    except ImportError:
+        return None
+    if not callable(getattr(VocabParallelArgmax, "from_exchange_group", None)):
+        return None
+    if not callable(getattr(VocabParallelArgmax, "fused_add_argmax", None)):
+        return None
+    return VocabParallelArgmax
 
 
 @contextmanager
@@ -613,6 +631,21 @@ class K3DSparkForCausalLM(nn.Module):
         self.logits_processor = LogitsProcessor(
             self.config.draft_vocab_size, scale=logit_scale
         )
+        argmax_requested = bool(envs.VLLM_KIMI_K3_B12X_DSPARK_ARGMAX)
+        self._b12x_dspark_argmax_cls = (
+            _load_b12x_vocab_parallel_argmax() if argmax_requested else None
+        )
+        self._b12x_dspark_argmax_enabled = self._b12x_dspark_argmax_cls is not None
+        if argmax_requested and not self._b12x_dspark_argmax_enabled:
+            logger.warning_once(
+                "B12X does not provide the complete VocabParallelArgmax API; "
+                "Kimi-K3 DSpark uses the exact vocabulary all-gather fallback."
+            )
+        self._b12x_dspark_argmax_max_batch = min(
+            vllm_config.scheduler_config.max_num_seqs, 8
+        )
+        self._b12x_dspark_argmax_runtime: Any = None
+        self._b12x_dspark_argmax_output: torch.Tensor | None = None
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)
@@ -647,6 +680,112 @@ class K3DSparkForCausalLM(nn.Module):
 
     def compute_draft_logits(self, hidden_states: torch.Tensor) -> torch.Tensor:
         return self.compute_logits(hidden_states)
+
+    def supports_local_draft_argmax(self) -> bool:
+        """Return whether rank-local target and Markov logits can be combined."""
+        markov_head = self.model.markov_head
+        if not markov_head.shard_across_tp:
+            return False
+        if not isinstance(self.lm_head, VocabParallelEmbedding):
+            return False
+        markov_w2 = markov_head.markov_w2
+        if not isinstance(markov_w2, VocabParallelEmbedding):
+            return False
+        layout_fields = (
+            "tp_size",
+            "tp_rank",
+            "num_embeddings",
+            "org_vocab_size",
+            "num_embeddings_padded",
+            "num_embeddings_per_partition",
+        )
+        if any(
+            getattr(self.lm_head, field) != getattr(markov_w2, field)
+            for field in layout_fields
+        ):
+            return False
+        if self.lm_head.shard_indices != markov_w2.shard_indices:
+            return False
+        # B12X maps every local row to a global token. Restrict its fast path
+        # to a dense vocabulary so a zero-filled padding row cannot win.
+        if self.lm_head.num_embeddings_padded != self.lm_head.org_vocab_size:
+            return False
+        if self.logits_processor.soft_cap is not None:
+            return False
+        return self.logits_processor.scale > 0.0
+
+    def compute_local_draft_logits(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """Project target hidden states into this rank's vocabulary shard."""
+        assert isinstance(self.lm_head, VocabParallelEmbedding)
+        return self.logits_processor._apply_head(self.lm_head, hidden_states, None)
+
+    def compute_local_markov_bias(self, markov_embed: torch.Tensor) -> torch.Tensor:
+        """Project a Markov embedding into the matching vocabulary shard."""
+        return self.model.markov_head.local_bias(markov_embed, self.logits_processor)
+
+    def gather_local_draft_logits(
+        self,
+        base_logits: torch.Tensor,
+        markov_bias: torch.Tensor,
+    ) -> torch.Tensor:
+        """Add matching shards and gather the exact complete distribution."""
+        logits = tensor_model_parallel_all_gather(base_logits + markov_bias, dim=-1)
+        return logits[..., : self.logits_processor.org_vocab_size]
+
+    def _get_b12x_dspark_argmax(self, base_logits: torch.Tensor) -> Any | None:
+        runtime = self._b12x_dspark_argmax_runtime
+        if runtime is not None:
+            return runtime
+
+        argmax_cls = self._b12x_dspark_argmax_cls
+        if argmax_cls is None:
+            self._b12x_dspark_argmax_enabled = False
+            return None
+
+        runtime = argmax_cls.from_exchange_group(
+            exchange_group=get_tp_group().cpu_group,
+            device=base_logits.device,
+            local_vocab_size=base_logits.shape[-1],
+            max_batch_size=self._b12x_dspark_argmax_max_batch,
+        )
+        self._b12x_dspark_argmax_output = torch.empty(
+            self._b12x_dspark_argmax_max_batch,
+            dtype=torch.int64,
+            device=base_logits.device,
+        )
+        self._b12x_dspark_argmax_runtime = runtime
+        logger.info_once(
+            "Kimi-K3 DSpark uses B12X TP%d fused BF16 add and global argmax "
+            "for up to %d requests.",
+            self.lm_head.tp_size,
+            self._b12x_dspark_argmax_max_batch,
+        )
+        return runtime
+
+    def sample_local_draft_logits(
+        self,
+        base_logits: torch.Tensor,
+        markov_bias: torch.Tensor,
+    ) -> torch.Tensor:
+        """Return exact greedy tokens through B12X or the full-logit fallback."""
+        assert isinstance(self.lm_head, VocabParallelEmbedding)
+        batch_size = int(base_logits.shape[0])
+        if (
+            self._b12x_dspark_argmax_enabled
+            and self.lm_head.tp_size in (8, 12, 16)
+            and base_logits.dtype == torch.bfloat16
+            and markov_bias.dtype == torch.bfloat16
+            and 0 < batch_size <= self._b12x_dspark_argmax_max_batch
+        ):
+            runtime = self._get_b12x_dspark_argmax(base_logits)
+            if runtime is not None:
+                assert self._b12x_dspark_argmax_output is not None
+                return runtime.fused_add_argmax(
+                    base_logits,
+                    markov_bias,
+                    out=self._b12x_dspark_argmax_output[:batch_size],
+                )
+        return self.gather_local_draft_logits(base_logits, markov_bias).argmax(dim=-1)
 
     def map_draft_to_target(self, draft_ids: torch.Tensor) -> torch.Tensor:
         return draft_ids


### PR DESCRIPTION
## Behavior

Kimi-K3 DSpark can combine the target LM-head shard with the matching TP-sharded Markov-bias shard and select the exact global greedy token through B12X `VocabParallelArgmax`. The fast path is opt-in through `VLLM_KIMI_K3_B12X_DSPARK_ARGMAX=1`.

The adapter accepts TP8, TP12, and TP16 when both heads have identical, unpadded vocabulary layouts, BF16 outputs, positive logit scaling, and no soft cap. Unsupported layouts and unavailable B12X APIs retain the exact full-vocabulary all-gather fallback.

## Technical reason

A sharded Markov head otherwise gathers a 163,840-token distribution for every DSpark proposal step. B12X performs the BF16 add and global argmax with bounded-degree CUDA-IPC exchange while preserving the same greedy token and tie-breaking contract.

## Compatibility

This pull request is stacked on #368 and requires the CuTeDSL implementation in local-inference-lab/b12x#217 for the fast path. It introduces no native CUDA source. The environment variable defaults to disabled. Vocabulary padding fails closed to the existing all-gather implementation.

## Validation

- 21 tests passed in `voipmonitor/vllm:kimi-k3-qsrt-ii-vllm735952b-b12x180ccab-cu133-torch213-20260815-r3` (CUDA 13.3, PyTorch 2.13).
- Focused tests cover matching shard geometry, padding rejection, TP8 B12X dispatch, stable output storage, and exact fallback sampling.
- Ruff, Ruff format, Python compilation, and `git diff --check` pass.