### PR TITLE
[II] Sample DSpark proposals from local vocabulary shards

### DIFF
--- a/tests/v1/spec_decode/test_dspark_local_vocab_sampling.py
+++ b/tests/v1/spec_decode/test_dspark_local_vocab_sampling.py
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+from vllm.v1.worker.gpu.spec_decode.dspark import speculator as speculator_module
+from vllm.v1.worker.gpu.spec_decode.dspark.speculator import DSparkSpeculator
+
+
+def test_sharded_markov_model_selects_local_sampling(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model = SimpleNamespace(
+        supports_local_draft_argmax=lambda: True,
+        draft_id_to_target_id=None,
+    )
+    speculator = SimpleNamespace(
+        vllm_config=object(),
+        use_draft_token_capacity=False,
+        draft_logits=None,
+        _draft_topk=None,
+        _use_local_draft_argmax=False,
+    )
+    monkeypatch.setenv("VLLM_DSPARK_SHARD_MARKOV_HEAD", "1")
+    monkeypatch.setattr(
+        speculator_module,
+        "load_dspark_model",
+        lambda _target_model, _vllm_config: model,
+    )
+
+    loaded = DSparkSpeculator.load_draft_model(
+        speculator,
+        target_model=object(),
+        target_attn_layer_names=set(),
+    )
+
+    assert loaded is model
+    assert speculator._use_local_draft_argmax
+
+
+def test_sharded_markov_model_rejects_reduced_topk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model = SimpleNamespace(
+        supports_local_draft_argmax=lambda: True,
+        draft_id_to_target_id=None,
+    )
+    speculator = SimpleNamespace(
+        vllm_config=object(),
+        use_draft_token_capacity=False,
+        draft_logits=None,
+        _draft_topk=32,
+        _use_local_draft_argmax=False,
+    )
+    monkeypatch.setenv("VLLM_DSPARK_SHARD_MARKOV_HEAD", "1")
+    monkeypatch.setattr(
+        speculator_module,
+        "load_dspark_model",
+        lambda _target_model, _vllm_config: model,
+    )
+
+    with pytest.raises(ValueError, match="does not support dspark_draft_topk"):
+        DSparkSpeculator.load_draft_model(
+            speculator,
+            target_model=object(),
+            target_attn_layer_names=set(),
+        )
+
+
+def test_sequential_greedy_sampling_keeps_vocabulary_shards_local() -> None:
+    base_logits = torch.tensor(
+        [
+            [1.0, 5.0, 0.0, 0.0],
+            [0.0, 0.0, 2.0, 1.0],
+        ],
+        dtype=torch.bfloat16,
+    )
+    local_bias = torch.zeros((1, 4), dtype=torch.bfloat16)
+    model = SimpleNamespace(
+        compute_local_draft_logits=Mock(return_value=base_logits),
+        markov_embed=Mock(side_effect=lambda token_ids: token_ids[:, None].float()),
+        compute_local_markov_bias=Mock(return_value=local_bias),
+        sample_local_draft_logits=Mock(
+            side_effect=lambda base, bias: (base + bias).argmax(dim=-1)
+        ),
+    )
+    speculator = SimpleNamespace(
+        sample_indices=torch.tensor([0, 1]),
+        model=model,
+        _use_local_draft_argmax=True,
+        draft_logits=None,
+        _draft_topk=None,
+        sample_idx_mapping=torch.tensor([0, 1]),
+        sample_pos=torch.tensor([1, 2]),
+        draft_token_confidence_logits=torch.empty((1, 2)),
+        min_survival_probability=0.0,
+        use_draft_token_capacity=False,
+        input_buffers=SimpleNamespace(input_ids=torch.tensor([3, 0])),
+        device=torch.device("cpu"),
+        vocab_size=16,
+        draft_token_valid_lengths=torch.empty((1,), dtype=torch.int32),
+        draft_tokens=torch.empty((1, 2), dtype=torch.int64),
+        draft_token_capacity=torch.empty((1,), dtype=torch.int32),
+        _sample_logits=Mock(side_effect=AssertionError("full logits were sampled")),
+    )
+
+    DSparkSpeculator._sample_sequential(
+        speculator,
+        num_reqs=1,
+        head_hidden=torch.randn((2, 8)),
+        num_speculative_steps=2,
+        num_query_per_req=2,
+    )
+
+    assert speculator.draft_tokens.tolist() == [[1, 2]]
+    model.compute_local_draft_logits.assert_called_once()
+    assert model.compute_local_markov_bias.call_count == 2
+    assert model.sample_local_draft_logits.call_count == 2
+    speculator._sample_logits.assert_not_called()

--- a/vllm/v1/worker/gpu/spec_decode/dspark/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dspark/speculator.py
@@ -77,6 +77,7 @@ class DSparkSpeculator(DFlashSpeculator):
         self._draft_topk: int | None = getattr(
             self.draft_model_config.hf_config, "dspark_draft_topk", None
         )
+        self._use_local_draft_argmax = False
 
         self.draft_token_confidence_logits = torch.empty(
             self.max_num_reqs,
@@ -192,6 +193,19 @@ class DSparkSpeculator(DFlashSpeculator):
                 dtype=self.draft_logits.dtype,
                 device=self.device,
             )
+        if envs.VLLM_DSPARK_SHARD_MARKOV_HEAD:
+            supports_local_argmax = getattr(model, "supports_local_draft_argmax", None)
+            if supports_local_argmax is None or not supports_local_argmax():
+                raise RuntimeError(
+                    "A TP-sharded DSpark Markov head requires matching "
+                    "rank-local target and Markov vocabulary projections."
+                )
+            if self._draft_topk is not None:
+                raise ValueError(
+                    "TP-sharded DSpark Markov sampling does not support "
+                    "dspark_draft_topk."
+                )
+            self._use_local_draft_argmax = True
         return model
 
     def _sample_logits(
@@ -240,9 +254,14 @@ class DSparkSpeculator(DFlashSpeculator):
         sample_hidden = head_hidden[self.sample_indices[:num_sample]]
         sample_hidden = sample_hidden.view(num_reqs, n_spec, -1)
         # Draft-vocab logits; sampled ids are remapped to target vocab below.
-        base_logits = self.model.compute_draft_logits(
-            sample_hidden.reshape(num_sample, -1)
-        )
+        if self._use_local_draft_argmax:
+            base_logits = self.model.compute_local_draft_logits(
+                sample_hidden.reshape(num_sample, -1)
+            )
+        else:
+            base_logits = self.model.compute_draft_logits(
+                sample_hidden.reshape(num_sample, -1)
+            )
         vocab_size = base_logits.shape[-1]
         base_logits = base_logits.view(num_reqs, n_spec, vocab_size)
         base_values = draft_indices = None
@@ -279,7 +298,24 @@ class DSparkSpeculator(DFlashSpeculator):
                     )
                 confidence_logits[:, i] = confidence_i
             if draft_indices is None:
-                logits_i = base_logits[:, i] + self.model.markov_bias(markov_embed)
+                if self._use_local_draft_argmax:
+                    markov_bias = self.model.compute_local_markov_bias(markov_embed)
+                    if self.draft_logits is None:
+                        draft_sampled_i = self.model.sample_local_draft_logits(
+                            base_logits[:, i], markov_bias
+                        )
+                    else:
+                        logits_i = self.model.gather_local_draft_logits(
+                            base_logits[:, i], markov_bias
+                        )
+                        draft_sampled_i = self._sample_logits(
+                            logits_i, idx_map[:, i], sample_pos[:, i], i
+                        )
+                else:
+                    logits_i = base_logits[:, i] + self.model.markov_bias(markov_embed)
+                    draft_sampled_i = self._sample_logits(
+                        logits_i, idx_map[:, i], sample_pos[:, i], i
+                    )
             else:
                 assert base_values is not None
                 logits_i = self.model.apply_markov_bias_gathered(
@@ -288,9 +324,9 @@ class DSparkSpeculator(DFlashSpeculator):
                     base_values[:, i],
                     draft_indices[:, i],
                 )
-            draft_sampled_i = self._sample_logits(
-                logits_i, idx_map[:, i], sample_pos[:, i], i
-            )
+                draft_sampled_i = self._sample_logits(
+                    logits_i, idx_map[:, i], sample_pos[:, i], i
+                )
             valid_prefix.logical_and_(
                 (draft_sampled_i >= 0) & (draft_sampled_i < self.vocab_size)
             )


### PR DESCRIPTION
## Behavior

The DSpark speculator detects a TP-sharded Markov head and keeps the target LM-head projection and Markov-bias projection rank-local. Greedy decoding delegates exact token selection to the model adapter; probabilistic decoding gathers the combined distribution once before the existing sampler.

The speculator rejects a sharded Markov head when its target and Markov vocabulary layouts cannot be combined. Reduced `dspark_draft_topk` sampling remains unsupported with this storage layout because rank-local top-k candidates do not define the existing global truncation contract.

## Technical reason

Gathering both 163,840-token projections before adding them transfers two full distributions for every proposal step. Combining matching shards first permits an exact distributed argmax or one combined gather.

## Compatibility

This pull request is stacked on #369. Replicated Markov heads retain the existing implementation. Sharded heads are opt-in through `VLLM_DSPARK_SHARD_MARKOV_HEAD=1`; unsupported model adapters fail during draft-model loading instead of producing inconsistent samples.

## Validation

- 3 focused tests passed in `voipmonitor/vllm:kimi-k3-qsrt-ii-vllm735952b-b12x180ccab-cu133-torch213-20260815-r3` (CUDA 13.3, PyTorch 2.13).
- Tests cover sharded-mode selection, reduced-top-k rejection, and a two-step sequential greedy proposal that never invokes full-logit sampling.
- Ruff, Ruff format, Python compilation, and `git diff --check` pass.