### PR TITLE
[II] Support draft work outside CUDA graph replay

### DIFF
--- a/tests/v1/spec_decode/test_dflash_cudagraph_lifetime.py
+++ b/tests/v1/spec_decode/test_dflash_cudagraph_lifetime.py
@@ -8,7 +8,10 @@ import torch
 
 from vllm.config.compilation import CUDAGraphMode
 from vllm.v1.attention.backend import AttentionCGSupport
+from vllm.v1.worker.gpu.cudagraph_utils import CudaGraphManager
+from vllm.v1.worker.gpu.spec_decode.dflash import cudagraph as cudagraph_module
 from vllm.v1.worker.gpu.spec_decode.dflash import speculator as spec_module
+from vllm.v1.worker.gpu.spec_decode.dflash.cudagraph import DFlashCudaGraphManager
 from vllm.v1.worker.gpu.spec_decode.dflash.speculator import DFlashSpeculator
 
 
@@ -65,6 +68,55 @@ def test_dflash_does_not_retain_eager_backbone_output(monkeypatch):
     )
 
     assert speculator._captured_backbone_outputs == []
+
+
+def test_dflash_graph_capture_marks_forward_as_capture_only(monkeypatch):
+    forward = Mock()
+    manager = object.__new__(DFlashCudaGraphManager)
+    manager.max_num_reqs = 4
+    manager.dp_size = 1
+    desc = SimpleNamespace(
+        num_tokens=6,
+        num_reqs=2,
+        cg_mode=CUDAGraphMode.FULL,
+        uniform_token_count=3,
+    )
+
+    monkeypatch.setattr(
+        cudagraph_module,
+        "_prepare_dflash_inputs_to_capture",
+        lambda *args, **kwargs: ("attention", "slots"),
+    )
+
+    def fake_capture(_manager, create_forward_fn, **kwargs):
+        create_forward_fn(desc, warmup=True)(CUDAGraphMode.FULL)
+
+    monkeypatch.setattr(CudaGraphManager, "capture", fake_capture)
+
+    DFlashCudaGraphManager.capture(
+        manager,
+        forward_fn=forward,
+        input_buffers=object(),
+        block_tables=object(),
+        attn_groups=[],
+        kv_cache_config=object(),
+        max_model_len=1024,
+        causal=False,
+        channel_id="draft-query",
+    )
+
+    assert forward.call_args.args == (
+        2,
+        6,
+        "attention",
+        "slots",
+        None,
+        CUDAGraphMode.FULL,
+    )
+    assert forward.call_args.kwargs == {
+        "num_query_per_req": 3,
+        "capture_only": True,
+    }
 
 
 def test_dflash_capture_uses_phase_specific_draft_channel_ids():

--- a/vllm/v1/worker/gpu/spec_decode/dflash/cudagraph.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/cudagraph.py
@@ -109,6 +109,7 @@ class DFlashCudaGraphManager(CudaGraphManager):
                 num_tokens_across_dp,
                 cg_mode,
                 num_query_per_req=desc.uniform_token_count,
+                capture_only=True,
             )
 
         super().capture(

--- a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
@@ -581,6 +581,7 @@ class DFlashSpeculator(DraftModelSpeculator):
         cudagraph_runtime_mode: CUDAGraphMode = CUDAGraphMode.NONE,
         is_profile: bool = False,
         num_query_per_req: int | None = None,
+        capture_only: bool = False,
     ) -> None:
         if num_query_per_req is None:
             num_speculative_steps = self.num_speculative_steps
@@ -615,6 +616,16 @@ class DFlashSpeculator(DraftModelSpeculator):
         self.draft_tokens[:num_reqs, :num_speculative_steps] = draft_tokens.view(
             num_reqs, num_speculative_steps
         )
+
+    def _finish_captured_draft(
+        self,
+        *,
+        num_reqs: int,
+        num_tokens_padded: int,
+        num_query_per_req: int,
+        is_profile: bool,
+    ) -> None:
+        """Run speculator work that is intentionally excluded from its graph."""
 
     def _build_draft_attn_metadata(
         self,
@@ -865,6 +876,12 @@ class DFlashSpeculator(DraftModelSpeculator):
         if batch_desc.cg_mode == CUDAGraphMode.FULL:
             assert self.query_cudagraph_manager is not None
             self.query_cudagraph_manager.run_fullgraph(batch_desc)
+            self._finish_captured_draft(
+                num_reqs=num_reqs,
+                num_tokens_padded=num_tokens_padded,
+                num_query_per_req=active_query_len,
+                is_profile=is_profile,
+            )
         else:
             self._generate_draft(
                 num_reqs,


### PR DESCRIPTION
## Behavior

The DFlash CUDA-graph interface identifies warmup and capture invocations with `capture_only=True` and provides `_finish_captured_draft()` after every full-graph replay. DFlash itself keeps the hook empty, so its generated tokens and execution order are unchanged. Specialized draft engines can retain graph-safe backbone work while running an incompatible tail eagerly after replay.

## Technical reason

A draft implementation may contain collectives whose runtime resources cannot be owned by the draft CUDA graph. The capture callback must omit those operations during both eager capture warmup and stream capture, and replay must execute them exactly once after the graph completes.

## Compatibility

This pull request is stacked on #370. The added keyword and hook are internal speculative-decoding interfaces. Existing DFlash execution retains the complete graph because its `_generate_draft()` ignores `capture_only` and its completion hook has no work.

## Validation

- 8 DFlash graph-lifetime tests passed in `voipmonitor/vllm:kimi-k3-qsrt-ii-vllm735952b-b12x180ccab-cu133-torch213-20260815-r3` (CUDA 13.3, PyTorch 2.13).
- The focused capture test verifies that the graph callback receives the same attention state and `capture_only=True`.
- Ruff, Python compilation, and `git diff --check` pass.