### PR TITLE
[II] Expose the active B12X TP all-reduce runtime

### DIFF
--- a/tests/distributed/test_active_b12x_allreduce_accessor.py
+++ b/tests/distributed/test_active_b12x_allreduce_accessor.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+from vllm.distributed.device_communicators.custom_all_reduce import (
+    CustomAllreduce,
+    get_active_b12x_pcie_allreduce,
+)
+
+
+def test_accessor_accepts_active_runtime_without_fused_rms_norm(monkeypatch):
+    custom_allreduce = object.__new__(CustomAllreduce)
+    custom_allreduce.disabled = False
+    custom_allreduce._pcie_runtime = object()
+    group = SimpleNamespace(
+        device_communicator=SimpleNamespace(ca_comm=custom_allreduce)
+    )
+    monkeypatch.setattr("vllm.distributed.parallel_state.get_tp_group", lambda: group)
+
+    assert get_active_b12x_pcie_allreduce() is custom_allreduce
+
+
+def test_accessor_rejects_disabled_runtime(monkeypatch):
+    custom_allreduce = object.__new__(CustomAllreduce)
+    custom_allreduce.disabled = True
+    custom_allreduce._pcie_runtime = object()
+    group = SimpleNamespace(
+        device_communicator=SimpleNamespace(ca_comm=custom_allreduce)
+    )
+    monkeypatch.setattr("vllm.distributed.parallel_state.get_tp_group", lambda: group)
+
+    assert get_active_b12x_pcie_allreduce() is None
+
+
+def test_accessor_rejects_missing_runtime(monkeypatch):
+    custom_allreduce = object.__new__(CustomAllreduce)
+    custom_allreduce.disabled = False
+    custom_allreduce._pcie_runtime = None
+    custom_allreduce._pcie_dma = None
+    custom_allreduce._ptr = 0
+    group = SimpleNamespace(
+        device_communicator=SimpleNamespace(ca_comm=custom_allreduce)
+    )
+    monkeypatch.setattr("vllm.distributed.parallel_state.get_tp_group", lambda: group)
+
+    assert get_active_b12x_pcie_allreduce() is None

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -1368,3 +1368,23 @@ def get_b12x_pcie_allreduce() -> CustomAllreduce | None:
     ):
         return custom_allreduce
     return None
+
+
+def get_active_b12x_pcie_allreduce() -> CustomAllreduce | None:
+    """Return the active TP B12X runtime for any supported algorithm."""
+    try:
+        from vllm.distributed.parallel_state import get_tp_group
+
+        device_communicator = get_tp_group().device_communicator
+    except (AssertionError, RuntimeError):
+        return None
+    if device_communicator is None:
+        return None
+    custom_allreduce = getattr(device_communicator, "ca_comm", None)
+    if (
+        isinstance(custom_allreduce, CustomAllreduce)
+        and not custom_allreduce.disabled
+        and custom_allreduce._pcie_runtime is not None
+    ):
+        return custom_allreduce
+    return None


### PR DESCRIPTION
## Behavior

`get_active_b12x_pcie_allreduce()` returns the tensor-parallel `CustomAllreduce` instance when it is enabled and owns an initialized B12X PCIe runtime. The accessor accepts both direct and hierarchical B12X algorithms and does not require fused add-plus-RMSNorm support. Missing process groups, disabled communicators, absent device communicators, and uninitialized runtimes return `None`.

## Technical reason

Callers that qualify a graph-captured distributed operation need to inspect the active B12X runtime and ask whether a specific tensor shape uses it. The existing `get_b12x_pcie_allreduce()` accessor is intentionally narrower because it serves fused add-plus-RMSNorm.

## Compatibility

This pull request targets `dev/infernal-invocation` directly and changes no collective selection or execution. It only adds a read-only accessor. Hierarchical TP12/TP16 availability remains provided by #333 and B12X #218.

## Validation

- 3 focused tests passed in `voipmonitor/vllm:kimi-k3-qsrt-ii-vllm735952b-b12x180ccab-cu133-torch213-20260815-r3` (CUDA 13.3, PyTorch 2.13).
- Tests cover an active runtime without fused RMSNorm support, a disabled runtime, and a communicator without an initialized runtime.
- Ruff, Python compilation, and `git diff --check` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for detecting and accessing an active PCIe all-reduce runtime independently of fused RMS normalization.
  * The system now safely reports when the PCIe all-reduce runtime is unavailable or disabled.

* **Tests**
  * Added coverage for enabled, disabled, missing, and unsupported runtime configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->