### PR TITLE
[II] Capture DSpark sharded Markov sampling with B12X

### DIFF
--- a/tests/v1/spec_decode/test_dspark_captured_markov.py
+++ b/tests/v1/spec_decode/test_dspark_captured_markov.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.distributed.device_communicators import custom_all_reduce
+from vllm.v1.worker.gpu.spec_decode.dspark import speculator as speculator_module
+from vllm.v1.worker.gpu.spec_decode.dspark.speculator import DSparkSpeculator
+
+
+def _captured_speculator() -> SimpleNamespace:
+    return SimpleNamespace(
+        use_draft_token_capacity=False,
+        draft_logits=None,
+        _draft_topk=None,
+        _use_local_draft_argmax=False,
+        _capture_sharded_markov=True,
+        _markov_outside_cudagraph=False,
+        max_num_reqs=8,
+        num_speculative_steps=7,
+        vllm_config=object(),
+        draft_model_config=SimpleNamespace(hf_config=SimpleNamespace(markov_rank=128)),
+        dtype=torch.bfloat16,
+        device=torch.device("cpu"),
+    )
+
+
+def test_captured_markov_allreduce_probe_covers_every_draft_step(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    probe_shapes = []
+
+    class ActiveAllreduce:
+        def should_custom_ar(self, probe):
+            probe_shapes.append(tuple(probe.shape))
+            return True
+
+    model = SimpleNamespace(
+        supports_local_draft_argmax=lambda: True,
+        draft_id_to_target_id=None,
+        _b12x_dspark_argmax_enabled=True,
+        model=SimpleNamespace(markov_head=SimpleNamespace(replicate_w1=False)),
+    )
+    speculator = _captured_speculator()
+    monkeypatch.setenv("VLLM_DSPARK_SHARD_MARKOV_HEAD", "1")
+    monkeypatch.setattr(
+        speculator_module,
+        "load_dspark_model",
+        lambda _target_model, _config: model,
+    )
+    monkeypatch.setattr(
+        custom_all_reduce,
+        "get_active_b12x_pcie_allreduce",
+        lambda: ActiveAllreduce(),
+        raising=False,
+    )
+
+    loaded = DSparkSpeculator.load_draft_model(
+        speculator,
+        target_model=object(),
+        target_attn_layer_names=set(),
+    )
+
+    assert loaded is model
+    assert speculator._use_local_draft_argmax
+    assert probe_shapes == [(56, 128)]
+
+
+def test_captured_markov_with_replicated_w1_needs_no_allreduce_probe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model = SimpleNamespace(
+        supports_local_draft_argmax=lambda: True,
+        draft_id_to_target_id=None,
+        _b12x_dspark_argmax_enabled=True,
+        model=SimpleNamespace(markov_head=SimpleNamespace(replicate_w1=True)),
+    )
+    speculator = _captured_speculator()
+    monkeypatch.setenv("VLLM_DSPARK_SHARD_MARKOV_HEAD", "1")
+    monkeypatch.setattr(
+        speculator_module,
+        "load_dspark_model",
+        lambda _target_model, _config: model,
+    )
+    monkeypatch.setattr(
+        custom_all_reduce,
+        "get_active_b12x_pcie_allreduce",
+        lambda: pytest.fail("replicated W1 must not inspect TP all-reduce"),
+        raising=False,
+    )
+
+    loaded = DSparkSpeculator.load_draft_model(
+        speculator,
+        target_model=object(),
+        target_attn_layer_names=set(),
+    )
+
+    assert loaded is model
+    assert speculator._use_local_draft_argmax

--- a/tests/v1/spec_decode/test_dspark_local_vocab_sampling.py
+++ b/tests/v1/spec_decode/test_dspark_local_vocab_sampling.py
@@ -24,6 +24,8 @@ def test_sharded_markov_model_selects_local_sampling(
         draft_logits=None,
         _draft_topk=None,
         _use_local_draft_argmax=False,
+        _capture_sharded_markov=False,
+        _markov_outside_cudagraph=False,
     )
     monkeypatch.setenv("VLLM_DSPARK_SHARD_MARKOV_HEAD", "1")
     monkeypatch.setattr(
@@ -55,6 +57,8 @@ def test_sharded_markov_model_rejects_reduced_topk(
         draft_logits=None,
         _draft_topk=32,
         _use_local_draft_argmax=False,
+        _capture_sharded_markov=False,
+        _markov_outside_cudagraph=False,
     )
     monkeypatch.setenv("VLLM_DSPARK_SHARD_MARKOV_HEAD", "1")
     monkeypatch.setattr(

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -69,6 +69,7 @@ if TYPE_CHECKING:
     VLLM_DSPARK_SHARD_MARKOV_HEAD: bool = False
     VLLM_DSPARK_REPLICATE_MARKOV_W1: bool = False
     VLLM_KIMI_K3_B12X_DSPARK_ARGMAX: bool = False
+    VLLM_DSPARK_CAPTURE_SHARDED_MARKOV: bool = False
     VLLM_USE_B12X_WO_PROJECTION: bool = False
     VLLM_USE_B12X_MOE: bool = False
     VLLM_NF3_GRID188_DECODE: bool = True
@@ -1166,6 +1167,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # all-gather fallback.
     "VLLM_KIMI_K3_B12X_DSPARK_ARGMAX": lambda: bool(
         int(os.getenv("VLLM_KIMI_K3_B12X_DSPARK_ARGMAX", "0"))
+    ),
+    # Capture TP-sharded deterministic Markov sampling only when every
+    # collective in the tail uses a CUDA-graph-safe B12X implementation.
+    "VLLM_DSPARK_CAPTURE_SHARDED_MARKOV": lambda: bool(
+        int(os.getenv("VLLM_DSPARK_CAPTURE_SHARDED_MARKOV", "0"))
     ),
     # Use b12x for the DeepSeek V4 WO-A/WO-B fused projection.
     # This is separate from the generic FP8 linear switch for perf isolation.

--- a/vllm/v1/worker/gpu/spec_decode/dspark/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dspark/speculator.py
@@ -30,6 +30,7 @@ import torch
 import vllm.envs as envs
 from vllm.config import VllmConfig
 from vllm.config.compilation import CUDAGraphMode
+from vllm.logger import init_logger
 from vllm.triton_utils import triton
 from vllm.v1.worker.gpu.input_batch import InputBatch
 from vllm.v1.worker.gpu.spec_decode.dflash.speculator import DFlashSpeculator
@@ -39,6 +40,8 @@ from vllm.v1.worker.gpu.spec_decode.dspark.capacity import (
 )
 from vllm.v1.worker.gpu.spec_decode.dspark.online_sts import DSparkOnlineSTS
 from vllm.v1.worker.gpu.spec_decode.dspark.utils import load_dspark_model
+
+logger = init_logger(__name__)
 
 
 class DSparkSpeculator(DFlashSpeculator):
@@ -67,7 +70,15 @@ class DSparkSpeculator(DFlashSpeculator):
             self.max_num_tokens, draft_hidden, dtype=self.dtype, device=device
         )
 
-        self._markov_outside_cudagraph = envs.VLLM_DSPARK_SHARD_MARKOV_HEAD
+        self._capture_sharded_markov = envs.VLLM_DSPARK_CAPTURE_SHARDED_MARKOV
+        if self._capture_sharded_markov and not envs.VLLM_DSPARK_SHARD_MARKOV_HEAD:
+            raise ValueError(
+                "VLLM_DSPARK_CAPTURE_SHARDED_MARKOV requires "
+                "VLLM_DSPARK_SHARD_MARKOV_HEAD=1."
+            )
+        self._markov_outside_cudagraph = (
+            envs.VLLM_DSPARK_SHARD_MARKOV_HEAD and not self._capture_sharded_markov
+        )
         self._captured_markov_hidden: torch.Tensor | None = None
         self._captured_base_logits: torch.Tensor | None = None
 
@@ -210,6 +221,44 @@ class DSparkSpeculator(DFlashSpeculator):
                     "dspark_draft_topk."
                 )
             self._use_local_draft_argmax = True
+        if self._capture_sharded_markov:
+            if not getattr(model, "_b12x_dspark_argmax_enabled", False):
+                raise RuntimeError(
+                    "Captured TP-sharded Markov sampling requires B12X "
+                    "vocabulary argmax."
+                )
+            markov_head = model.model.markov_head
+            if not markov_head.replicate_w1:
+                from vllm.distributed.device_communicators.custom_all_reduce import (
+                    get_active_b12x_pcie_allreduce,
+                )
+
+                custom_allreduce = get_active_b12x_pcie_allreduce()
+                if custom_allreduce is None:
+                    raise RuntimeError(
+                        "Captured TP-sharded Markov sampling requires an active "
+                        "B12X TP all-reduce runtime."
+                    )
+                probe = torch.empty(
+                    self.max_num_reqs * self.num_speculative_steps,
+                    self.draft_model_config.hf_config.markov_rank,
+                    dtype=self.dtype,
+                    device=self.device,
+                )
+                if not custom_allreduce.should_custom_ar(probe):
+                    raise RuntimeError(
+                        "The active B12X TP all-reduce cannot capture the "
+                        f"Markov W1 output shape {tuple(probe.shape)}."
+                    )
+            logger.info_once(
+                "DSpark captures its TP-sharded Markov tail with B12X collectives."
+            )
+        elif self._markov_outside_cudagraph:
+            logger.info_once(
+                "DSpark keeps TP-sharded Markov collectives outside the draft "
+                "CUDA graph. The graph retains the draft backbone and local "
+                "base-logit projection."
+            )
         return model
 
     def _ensure_captured_markov_buffers(self) -> None:


### PR DESCRIPTION
## Behavior

`VLLM_DSPARK_CAPTURE_SHARDED_MARKOV=1` keeps a TP-sharded DSpark Markov tail inside the draft CUDA graph only when every distributed operation has a qualified B12X path. The model must expose B12X vocabulary argmax. A sharded Markov W1 must also select the active B12X TP all-reduce for the complete `max_num_seqs * num_speculative_tokens` row envelope. A replicated W1 requires no all-reduce.

Without the capture flag, #372 keeps the distributed tail after graph replay. Enabling capture without `VLLM_DSPARK_SHARD_MARKOV_HEAD=1`, without B12X argmax, or without a compatible B12X all-reduce fails before graph creation.

## Technical reason

Captured distributed operations must use stable CUDA-IPC resources and cover every graph replay shape. Checking the maximum Markov W1 tensor proves that all smaller scheduled batches stay within the selected B12X collective envelope.

## Compatibility

This pull request is stacked on #372. It depends on #373 for active-runtime inspection, #333 and B12X #218 for hierarchical TP12/TP16 all-reduce, and #369 with B12X #217 for exact vocabulary argmax. The environment variable defaults to disabled.

## Validation

- 9 focused local-sampling, graph-handoff, and captured-tail tests passed in `voipmonitor/vllm:kimi-k3-qsrt-ii-vllm735952b-b12x180ccab-cu133-torch213-20260815-r3` (CUDA 13.3, PyTorch 2.13).
- Tests verify the complete 56x128 W1 probe for eight requests and seven draft steps, and verify that replicated W1 bypasses the all-reduce requirement.
- Ruff, Python compilation, and `git diff --check` pass.