### PR TITLE
[II] Own retained DFlash streaming weights

### DIFF
--- a/tests/models/test_qwen3_dflash_weight_retention.py
+++ b/tests/models/test_qwen3_dflash_weight_retention.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+from vllm.model_executor.models.qwen3_dflash import _retain_dflash_weight
+
+
+def test_cpu_weight_retention_reuses_owned_storage() -> None:
+    weight = torch.arange(8, dtype=torch.float32)
+
+    retained = _retain_dflash_weight(weight)
+
+    assert retained is weight
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_cuda_weight_retention_survives_source_storage_reuse() -> None:
+    source = torch.arange(8, dtype=torch.float32, device="cuda")
+    expected = source.cpu()
+
+    retained = _retain_dflash_weight(source)
+    source.fill_(-1)
+
+    assert retained.device.type == "cpu"
+    torch.testing.assert_close(retained, expected)

--- a/vllm/model_executor/models/qwen3_dflash.py
+++ b/vllm/model_executor/models/qwen3_dflash.py
@@ -62,6 +62,13 @@ logger = init_logger(__name__)
 _SLIDING_ATTENTION = "sliding_attention"
 
 
+def _retain_dflash_weight(weight: torch.Tensor) -> torch.Tensor:
+    """Give a retained streaming-loader tensor storage with stable ownership."""
+    if weight.is_cuda:
+        return weight.to("cpu", copy=True)
+    return weight
+
+
 def _dflash_layer_causal(config: Qwen3Config, layer_idx: int) -> bool:
     """``dflash_config.causal`` overrides all layers; else only SWA layers causal."""
     override = (getattr(config, "dflash_config", None) or {}).get("causal")
@@ -866,7 +873,7 @@ class DFlashQwen3ForCausalLM(Qwen3ForCausalLM):
                 name = "model." + name
             if "embed_tokens" in name:
                 includes_embed_tokens = True
-            model_weights[name] = loaded_weight
+            model_weights[name] = _retain_dflash_weight(loaded_weight)
             process_eagle_weight(self, name)
 
         # Route the separately-trained mask embedding (if shipped) through the


### PR DESCRIPTION
## Behavior

DFlash weight loading copies CUDA checkpoint tensors into independent CPU storage before retaining them in its name-mapping dictionary. CPU tensors are retained without a copy. The later `AutoWeightsLoader` pass therefore reads stable values even when a streaming loader reuses one device staging buffer between iterator yields.

## Technical reason

`DFlashQwen3ForCausalLM.load_weights()` consumes the complete iterator before applying mapped weights. A CUDA tensor yielded by InstantTensor or another ring-buffer loader can be a view whose storage is overwritten by the next yield. Retaining that view without taking ownership silently associates later tensor contents with an earlier parameter name.

## Compatibility

This pull request targets `dev/infernal-invocation` directly. Non-streaming CPU safetensor loading keeps the same tensor objects and allocation behavior. Streaming CUDA inputs incur a device-to-host ownership copy only for tensors that DFlash must retain across iterator advancement.

## Validation

- 2 focused tests passed in `voipmonitor/vllm:kimi-k3-qsrt-ii-vllm735952b-b12x180ccab-cu133-torch213-20260815-r3` (CUDA 13.3, PyTorch 2.13).
- The CUDA test mutates the source allocation after retention and verifies that the retained CPU tensor preserves its original values; the CPU test verifies zero-copy retention.
- Ruff, Python compilation, and `git diff --check` pass.