### PR TITLE
[II] Pin the FlashAttention FA4 dynamic-causal fix

### DIFF
--- a/cmake/external_projects/vllm_flash_attn.cmake
+++ b/cmake/external_projects/vllm_flash_attn.cmake
@@ -43,7 +43,7 @@ else()
   FetchContent_Declare(
           vllm-flash-attn
           GIT_REPOSITORY https://github.com/vllm-project/flash-attention.git
-          GIT_TAG f3e1a4f74c99145c0717709860bf765de1703779
+          GIT_TAG 7484d4751a4569fb30e5c0604581f1b02ae3df71
           GIT_SUBMODULES ${VLLM_FLASH_ATTN_GIT_SUBMODULES}
           GIT_PROGRESS TRUE
           # Don't share the vllm-flash-attn build between build types


### PR DESCRIPTION
## Behavior

The CUDA build fetches `vllm-project/flash-attention@7484d4751a4569fb30e5c0604581f1b02ae3df71`. That upstream revision forwards the per-sequence `mDynamicCausal` tensor into the SM80/SM120 FA4 kernel and initializes the non-split-KV mode read by those launch paths.

## Technical reason

The previous pin `f3e1a4f74c99145c0717709860bf765de1703779` references `mDynamicCausal` inside the kernel without accepting it in the kernel signature or passing it from the launch. It also reads `self.is_split_kv` without initialization. A DFlash draft with mixed causal and non-causal groups can encounter `NameError` or `AttributeError` on first FA4 execution.

## Compatibility

This is an official FlashAttention fix, not FlashKDA integration and not a local source patch. The pinned revision is the upstream fix from vllm-project/flash-attention#178 and includes its direct parent change for SM90 FP8 KV support. vLLM interfaces are unchanged.

## Validation

- The pinned commit is a descendant of the previous revision and changes three lines in `flash_attn/cute/flash_fwd.py` for the stated dynamic-causal and split-KV invariants.
- The corresponding three-line patch is present in the source-locked Kimi-K3 DFlash image; the replacement-stack container build and DFlash serving qualification are tracked separately in local-inference-lab/rtx6kpro#66.
- `git diff --check` passes.