### PR TITLE
[II] Prepare B12X MLA speculative decode rows

### DIFF
--- a/tests/v1/attention/test_b12x_mla.py
+++ b/tests/v1/attention/test_b12x_mla.py
@@ -122,6 +122,10 @@ def test_b12x_mla_rejects_unsupported_parallel_geometry(monkeypatch) -> None:
 
 
 class _FakePlan:
+    caps = SimpleNamespace(max_page_table_width=4)
+    num_splits = 1
+    chunks_per_split = 1
+
     def shapes_and_dtypes(self):
         return (((256,), torch.uint8),)
 
@@ -239,12 +243,27 @@ def test_b12x_mla_adapter_binds_causal_multiquery_blocks(monkeypatch) -> None:
     q = torch.randn(total_q, 8, 576, dtype=torch.bfloat16)
     cache = torch.randn(8, 16, 576, dtype=torch.bfloat16)
     query_start_loc = torch.tensor([0, 8, 16], dtype=torch.int32)
+    source_table = torch.tensor(
+        [[0, 1, 2, 3], [4, 5, 6, 7]],
+        dtype=torch.int32,
+    )
+    flat_table = source_table[:, None, :].expand(-1, query_len, -1).reshape(total_q, -1)
+    flat_lens = torch.cat(
+        (
+            torch.arange(25, 33, dtype=torch.int32),
+            torch.arange(41, 49, dtype=torch.int32),
+        )
+    )
+    flat_query_start = torch.arange(total_q + 1, dtype=torch.int32)
     metadata = SimpleNamespace(
         dense_mla_plan=_FakePlan(),
         dense_mla_scratch=torch.empty(256, dtype=torch.uint8),
+        dense_mla_flat_block_table=flat_table,
+        dense_mla_flat_seq_lens=flat_lens,
+        dense_mla_flat_query_start_loc=flat_query_start,
         query_start_loc=query_start_loc,
         decode=SimpleNamespace(
-            block_table=torch.tensor([[0, 1, 2, 3], [4, 5, 6, 7]], dtype=torch.int32),
+            block_table=source_table,
             seq_lens=torch.tensor([32, 48], dtype=torch.int32),
         ),
     )
@@ -259,8 +278,8 @@ def test_b12x_mla_adapter_binds_causal_multiquery_blocks(monkeypatch) -> None:
     assert output.shape == (total_q, 8, 512)
     assert lse is not None and lse.shape == (total_q, 8)
     assert binding.q.shape[0] == total_q
-    assert binding.cache_seqlens.shape[0] == batch
-    assert binding.cu_seqlens_q.data_ptr() == query_start_loc.data_ptr()
+    assert binding.cache_seqlens.data_ptr() == flat_lens.data_ptr()
+    assert binding.cu_seqlens_q.data_ptr() == flat_query_start.data_ptr()
 
 
 def test_b12x_mla_builder_flattens_non_causal_draft_block(monkeypatch) -> None:
@@ -304,6 +323,144 @@ def test_b12x_mla_builder_flattens_non_causal_draft_block(monkeypatch) -> None:
     torch.testing.assert_close(
         result.dense_mla_flat_query_start_loc,
         torch.arange(9, dtype=torch.int32),
+    )
+
+
+def test_b12x_mla_builder_flattens_causal_verification_block(monkeypatch) -> None:
+    builder = object.__new__(B12xMLAMetadataBuilder)
+    builder._dense_mla_plan = _FakePlan()
+    builder._dense_mla_scratch = torch.empty(256, dtype=torch.uint8)
+    builder._dense_mla_padded_q = None
+    builder._dense_mla_padded_output = None
+    builder._max_dense_mla_rows = 16
+    builder._dense_mla_flat_block_table = torch.zeros(16, 4, dtype=torch.int32)
+    builder._dense_mla_flat_seq_lens = torch.empty(16, dtype=torch.int32)
+    builder._dense_mla_flat_query_start_loc = torch.arange(17, dtype=torch.int32)
+    builder._dense_mla_causal_offsets = torch.arange(-7, 1, dtype=torch.int32)
+    builder._dense_mla_flat_global_seq_lens = None
+    builder._dense_mla_flat_dcp_remainder = None
+    builder.dcp_world_size = 1
+
+    source_table = torch.tensor([[3, 4, 5, 6]], dtype=torch.int32)
+    metadata = SimpleNamespace(
+        causal=True,
+        num_decodes=1,
+        num_decode_tokens=8,
+        decode=SimpleNamespace(
+            block_table=source_table,
+            seq_lens=torch.tensor([32], dtype=torch.int32),
+        ),
+    )
+    monkeypatch.setattr(
+        b12x_mla.MLACommonMetadataBuilder,
+        "build",
+        lambda *args, **kwargs: metadata,
+    )
+
+    result = builder.build(0, SimpleNamespace())
+
+    torch.testing.assert_close(
+        result.dense_mla_flat_block_table,
+        source_table.expand(8, -1),
+    )
+    torch.testing.assert_close(
+        result.dense_mla_flat_seq_lens,
+        torch.arange(25, 33, dtype=torch.int32),
+    )
+    torch.testing.assert_close(
+        result.dense_mla_flat_query_start_loc,
+        torch.arange(9, dtype=torch.int32),
+    )
+
+
+def test_b12x_mla_builder_maps_causal_verification_lengths_to_dcp_rank(
+    monkeypatch,
+) -> None:
+    builder = object.__new__(B12xMLAMetadataBuilder)
+    builder._dense_mla_plan = _FakePlan()
+    builder._dense_mla_scratch = torch.empty(256, dtype=torch.uint8)
+    builder._dense_mla_padded_q = None
+    builder._dense_mla_padded_output = None
+    builder._max_dense_mla_rows = 8
+    builder._dense_mla_flat_block_table = torch.zeros(8, 4, dtype=torch.int32)
+    builder._dense_mla_flat_seq_lens = torch.empty(8, dtype=torch.int32)
+    builder._dense_mla_flat_query_start_loc = torch.arange(9, dtype=torch.int32)
+    builder._dense_mla_causal_offsets = torch.arange(-3, 1, dtype=torch.int32)
+    builder._dense_mla_flat_global_seq_lens = torch.empty(8, dtype=torch.int32)
+    builder._dense_mla_flat_dcp_remainder = torch.empty(8, dtype=torch.int32)
+    builder.dcp_world_size = 4
+    builder._dcp_rank = 3
+    builder.cp_kv_cache_interleave_size = 2
+
+    metadata = SimpleNamespace(
+        causal=True,
+        num_decodes=1,
+        num_decode_tokens=4,
+        decode=SimpleNamespace(
+            block_table=torch.tensor([[3, 4, 5, 6]], dtype=torch.int32),
+            seq_lens=torch.tensor([3], dtype=torch.int32),
+            dcp_tot_seq_lens=torch.tensor([17], dtype=torch.int32),
+        ),
+    )
+    monkeypatch.setattr(
+        b12x_mla.MLACommonMetadataBuilder,
+        "build",
+        lambda *args, **kwargs: metadata,
+    )
+
+    result = builder.build(0, SimpleNamespace())
+
+    torch.testing.assert_close(
+        result.dense_mla_flat_seq_lens,
+        torch.tensor([2, 3, 4, 4], dtype=torch.int32),
+    )
+
+
+def test_b12x_mla_builder_bounds_single_token_draft_table(monkeypatch) -> None:
+    builder = object.__new__(B12xMLAMetadataBuilder)
+    builder._dense_mla_plan = _FakePlan()
+    builder._dense_mla_scratch = torch.empty(256, dtype=torch.uint8)
+    builder._dense_mla_padded_q = None
+    builder._dense_mla_padded_output = None
+    builder._max_dense_mla_rows = 2
+    builder._dense_mla_flat_block_table = torch.zeros(2, 4, dtype=torch.int32)
+    builder._dense_mla_flat_seq_lens = torch.empty(2, dtype=torch.int32)
+    builder._dense_mla_flat_query_start_loc = torch.arange(3, dtype=torch.int32)
+    builder._dense_mla_causal_offsets = torch.zeros(1, dtype=torch.int32)
+    builder._dense_mla_flat_global_seq_lens = None
+    builder._dense_mla_flat_dcp_remainder = None
+    builder.dcp_world_size = 1
+
+    source_table = torch.tensor(
+        [[0, 1, 2, 3, 90, 91], [4, 5, 6, 7, 92, 93]],
+        dtype=torch.int32,
+    )
+    source_lens = torch.tensor([32, 48], dtype=torch.int32)
+    metadata = SimpleNamespace(
+        causal=False,
+        num_decodes=2,
+        num_decode_tokens=2,
+        decode=SimpleNamespace(
+            block_table=source_table,
+            seq_lens=source_lens,
+        ),
+    )
+    monkeypatch.setattr(
+        b12x_mla.MLACommonMetadataBuilder,
+        "build",
+        lambda *args, **kwargs: metadata,
+    )
+
+    result = builder.build(0, SimpleNamespace())
+
+    torch.testing.assert_close(
+        result.dense_mla_flat_block_table,
+        source_table[:, :4],
+    )
+    torch.testing.assert_close(result.dense_mla_flat_seq_lens, source_lens)
+    torch.testing.assert_close(
+        result.dense_mla_flat_query_start_loc,
+        torch.arange(3, dtype=torch.int32),
     )
 
 

--- a/vllm/v1/attention/backends/mla/b12x_mla.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla.py
@@ -219,6 +219,9 @@ class B12xMLAMetadataBuilder(MLACommonMetadataBuilder[B12xMLAMetadata]):
             B12xMLAMetadata,
             supports_dcp_with_varlen=True,
         )
+        self._dcp_rank = (
+            int(get_dcp_group().rank_in_group) if self.dcp_world_size > 1 else 0
+        )
         max_dense_mla_rows = int(vllm_config.scheduler_config.max_num_seqs) * int(
             self.reorder_batch_threshold
         )
@@ -280,6 +283,30 @@ class B12xMLAMetadataBuilder(MLACommonMetadataBuilder[B12xMLAMetadata]):
             dtype=torch.int32,
             device=device,
         )
+        self._dense_mla_causal_offsets = torch.arange(
+            1 - int(self.reorder_batch_threshold),
+            1,
+            dtype=torch.int32,
+            device=device,
+        )
+        self._dense_mla_flat_global_seq_lens = (
+            torch.empty(
+                max_dense_mla_rows,
+                dtype=torch.int32,
+                device=device,
+            )
+            if self.dcp_world_size > 1
+            else None
+        )
+        self._dense_mla_flat_dcp_remainder = (
+            torch.empty(
+                max_dense_mla_rows,
+                dtype=torch.int32,
+                device=device,
+            )
+            if self.dcp_world_size > 1
+            else None
+        )
         logger.info_once(
             "B12X dense K3 MLA plan: local_heads=%d, effective_heads=%d, "
             "kernel_heads=%d, page_size=%d, "
@@ -312,41 +339,84 @@ class B12xMLAMetadataBuilder(MLACommonMetadataBuilder[B12xMLAMetadata]):
         metadata.dense_mla_padded_q = self._dense_mla_padded_q
         metadata.dense_mla_padded_output = self._dense_mla_padded_output
         decode_metadata = metadata.decode
-        if (
-            not metadata.causal
-            and decode_metadata is not None
-            and metadata.num_decodes > 0
-            and metadata.num_decode_tokens > metadata.num_decodes
-        ):
+        flatten_decode = False
+        if decode_metadata is not None and metadata.num_decodes > 0:
+            flatten_decode = metadata.num_decode_tokens > metadata.num_decodes or int(
+                decode_metadata.block_table.shape[1]
+            ) > int(self._dense_mla_plan.caps.max_page_table_width)
+        if flatten_decode:
+            assert decode_metadata is not None
             total_q = int(metadata.num_decode_tokens)
             if total_q > self._max_dense_mla_rows:
                 raise ValueError(
-                    "B12X_MLA non-causal query block exceeds its capacity: "
+                    "B12X_MLA query block exceeds its flattened capacity: "
                     f"rows={total_q}, capacity={self._max_dense_mla_rows}."
                 )
             if total_q % metadata.num_decodes:
                 raise ValueError(
-                    "B12X_MLA requires a uniform non-causal query block, got "
+                    "B12X_MLA requires a uniform query block, got "
                     f"tokens={total_q}, requests={metadata.num_decodes}."
                 )
             query_len = total_q // metadata.num_decodes
             source_table = decode_metadata.block_table
-            source_width = int(source_table.shape[1])
             flat_table = self._dense_mla_flat_block_table[:total_q]
-            if source_width > int(flat_table.shape[1]):
-                raise ValueError(
-                    "B12X_MLA block table exceeds its planned width: "
-                    f"actual={source_width}, planned={flat_table.shape[1]}."
-                )
+            # A bounded speculative cache can retain a position-indexed worker
+            # table wider than the resident cache. Sequence lengths make the
+            # omitted suffix unreachable by the dense-MLA kernel.
+            source_width = min(int(source_table.shape[1]), int(flat_table.shape[1]))
             flat_table[:, :source_width].copy_(
-                source_table[:, None, :]
+                source_table[:, None, :source_width]
                 .expand(-1, query_len, -1)
                 .reshape(total_q, source_width)
             )
             flat_lens = self._dense_mla_flat_seq_lens[:total_q]
-            flat_lens.copy_(
-                decode_metadata.seq_lens[:, None].expand(-1, query_len).reshape(total_q)
-            )
+            if metadata.causal:
+                offsets = self._dense_mla_causal_offsets[-query_len:]
+                if self.dcp_world_size > 1:
+                    global_source_lens = decode_metadata.dcp_tot_seq_lens
+                    if global_source_lens is None:
+                        raise RuntimeError(
+                            "B12X_MLA causal DCP verification requires global "
+                            "decode sequence lengths."
+                        )
+                    assert self._dense_mla_flat_global_seq_lens is not None
+                    assert self._dense_mla_flat_dcp_remainder is not None
+                    global_flat_lens = self._dense_mla_flat_global_seq_lens[:total_q]
+                    torch.add(
+                        global_source_lens[:, None],
+                        offsets,
+                        out=global_flat_lens.view(metadata.num_decodes, query_len),
+                    )
+                    virtual_block = (
+                        self.dcp_world_size * self.cp_kv_cache_interleave_size
+                    )
+                    torch.div(
+                        global_flat_lens,
+                        virtual_block,
+                        rounding_mode="floor",
+                        out=flat_lens,
+                    )
+                    flat_lens.mul_(self.cp_kv_cache_interleave_size)
+                    remainder = self._dense_mla_flat_dcp_remainder[:total_q]
+                    torch.remainder(global_flat_lens, virtual_block, out=remainder)
+                    remainder.sub_(self._dcp_rank * self.cp_kv_cache_interleave_size)
+                    remainder.clamp_(
+                        min=0,
+                        max=self.cp_kv_cache_interleave_size,
+                    )
+                    flat_lens.add_(remainder)
+                else:
+                    torch.add(
+                        decode_metadata.seq_lens[:, None],
+                        offsets,
+                        out=flat_lens.view(metadata.num_decodes, query_len),
+                    )
+            else:
+                flat_lens.copy_(
+                    decode_metadata.seq_lens[:, None]
+                    .expand(-1, query_len)
+                    .reshape(total_q)
+                )
             metadata.dense_mla_flat_block_table = flat_table
             metadata.dense_mla_flat_seq_lens = flat_lens
             metadata.dense_mla_flat_query_start_loc = (
@@ -590,15 +660,15 @@ class B12xMLAImpl(MLACommonImpl[B12xMLAMetadata]):
             )
             if seq_lens is None or query_start_loc is None:
                 raise RuntimeError(
-                    "B12X_MLA metadata is missing flattened non-causal rows."
+                    "B12X_MLA metadata is missing flattened decode rows."
                 )
 
         batch = int(seq_lens.shape[0])
         total_q = int(q.shape[0])
-        if total_q < batch:
+        if total_q != batch:
             raise ValueError(
-                "B12X_MLA requires at least one query row per prepared decode "
-                f"sequence, got {total_q} rows for {batch} sequences."
+                "B12X_MLA requires one query row per prepared decode sequence, "
+                f"got {total_q} rows for {batch} sequences."
             )
         if int(q.shape[1]) != self.num_heads:
             raise ValueError(


### PR DESCRIPTION
## Status

Implemented. This pull request is stacked on #362.

## Behavior

The B12X dense-MLA metadata builder converts each token in a uniform speculative verification block into an independent one-token decode row. Causal target rows receive monotonically increasing visible sequence lengths, while non-causal draft rows retain one shared visible prefix.

Decode-context-parallel target rows derive their rank-local sequence lengths from the preserved global sequence length and the configured round-robin KV interleave. The conversion uses preallocated buffers and is compatible with CUDA graph replay.

A bounded speculative cache may expose a position-indexed block table wider than the dense-MLA plan. The builder copies only the resident table prefix; the shortened sequence length makes the omitted suffix unreachable.

## Technical reason

The B12X dense-MLA kernel accepts one query row per prepared decode sequence. Speculative target verification presents several causal query tokens per request, and a bounded draft cache can retain a wider logical worker table than its resident kernel plan. Both layouts require explicit metadata normalization before binding the kernel.

## Compatibility

Ordinary one-token decode metadata is unchanged. The adapter now rejects an unnormalized multi-query binding instead of passing an unsupported layout to B12X. No model weights, quantization, collective implementation, or sampling behavior changes.

## Validation

- 27 focused B12X MLA tests pass in the CUDA 13.3 / PyTorch 2.13 source-locked Kimi-K3 runtime image.
- The tests cover causal and non-causal blocks, DCP-interleaved sequence lengths, bounded block tables, head padding, DCP gather/reduce, FP8 scales, active split selection, and caller-owned scratch.
- Ruff check, Ruff format check, Python compilation, and `git diff --check` pass.

Composed serving qualification with the remaining Kimi-K3 runtime pull requests is tracked separately in local-inference-lab/rtx6kpro#66.
