### PR TITLE
[II] Allow disabling fused-MoE output aliasing

### DIFF
--- a/tests/kernels/moe/test_modular_output_alias.py
+++ b/tests/kernels/moe/test_modular_output_alias.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+import vllm.envs as envs
+from vllm.model_executor.layers.fused_moe.modular_kernel import (
+    _can_alias_fused_moe_output,
+)
+
+
+def test_fused_moe_output_alias_can_be_disabled(monkeypatch) -> None:
+    allocated = torch.empty((2, 8), dtype=torch.bfloat16)
+    caller_output = torch.empty_like(allocated)
+
+    monkeypatch.setattr(envs, "VLLM_DISABLE_FUSED_MOE_OUTPUT_ALIAS", False)
+    assert _can_alias_fused_moe_output(caller_output, allocated)
+
+    monkeypatch.setattr(envs, "VLLM_DISABLE_FUSED_MOE_OUTPUT_ALIAS", True)
+    assert not _can_alias_fused_moe_output(caller_output, allocated)
+
+
+def test_fused_moe_output_alias_requires_matching_storage() -> None:
+    allocated = torch.empty((2, 8), dtype=torch.bfloat16)
+
+    assert not _can_alias_fused_moe_output(None, allocated)
+    assert not _can_alias_fused_moe_output(
+        torch.empty((1, 8), dtype=torch.bfloat16), allocated
+    )
+    assert not _can_alias_fused_moe_output(
+        torch.empty((2, 8), dtype=torch.float32), allocated
+    )

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -330,6 +330,7 @@ if TYPE_CHECKING:
     VLLM_GC_DEBUG: str = ""
     VLLM_DEBUG_WORKSPACE: bool = False
     VLLM_DISABLE_SHARED_EXPERTS_STREAM: bool = False
+    VLLM_DISABLE_FUSED_MOE_OUTPUT_ALIAS: bool = False
     VLLM_SHARED_EXPERTS_STREAM_TOKEN_THRESHOLD: int = 256
     VLLM_MULTI_STREAM_GEMM_TOKEN_THRESHOLD: int = 1024
     VLLM_COMPILE_CACHE_SAVE_FORMAT: Literal["binary", "unpacked"] = "binary"
@@ -2243,6 +2244,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Disables parallel execution of shared_experts via separate cuda stream
     "VLLM_DISABLE_SHARED_EXPERTS_STREAM": lambda: bool(
         int(os.getenv("VLLM_DISABLE_SHARED_EXPERTS_STREAM", "0"))
+    ),
+    # Preserve a separate fused-MoE result buffer when the caller-owned output
+    # has a lifetime that overlaps the expert kernel's writeback.
+    "VLLM_DISABLE_FUSED_MOE_OUTPUT_ALIAS": lambda: bool(
+        int(os.getenv("VLLM_DISABLE_FUSED_MOE_OUTPUT_ALIAS", "0"))
     ),
     # Limits when we run shared_experts in a separate stream.
     # We found out that for large batch sizes, the separate stream

--- a/vllm/model_executor/layers/fused_moe/modular_kernel.py
+++ b/vllm/model_executor/layers/fused_moe/modular_kernel.py
@@ -43,6 +43,22 @@ from vllm.v1.worker.workspace import current_workspace_manager
 
 logger = init_logger(__name__)
 
+
+def _can_alias_fused_moe_output(
+    output_alias: torch.Tensor | None,
+    allocated_output: torch.Tensor,
+) -> bool:
+    """Return whether the expert kernel may write into caller-owned output."""
+    return bool(
+        not envs.VLLM_DISABLE_FUSED_MOE_OUTPUT_ALIAS
+        and output_alias is not None
+        and output_alias.shape == allocated_output.shape
+        and output_alias.dtype == allocated_output.dtype
+        and output_alias.device == allocated_output.device
+        and output_alias.is_contiguous()
+    )
+
+
 #
 # This file defines a set of base classes used to make MoE kernels more modular.
 # The goal is to be able to utilize different communication mechanisms with
@@ -1306,13 +1322,7 @@ class FusedMoEKernelModularImpl:
             activation,
         )
 
-        use_output_alias = (
-            output_alias is not None
-            and output_alias.shape == fused_out.shape
-            and output_alias.dtype == fused_out.dtype
-            and output_alias.device == fused_out.device
-            and output_alias.is_contiguous()
-        )
+        use_output_alias = _can_alias_fused_moe_output(output_alias, fused_out)
 
         # If caller's output buffer already matches fused_out shape/dtype, alias
         # to skip the redundant copy in TopKWeightAndReduceNoOP.apply downstream.


### PR DESCRIPTION
## Status

Implemented.

## Behavior

`VLLM_DISABLE_FUSED_MOE_OUTPUT_ALIAS=1` keeps the modular fused-MoE expert result in its independently allocated output buffer even when the caller provides a shape-compatible destination. The default remains `0`, preserving the existing zero-copy alias optimization.

## Technical reason

Some model runners retain or reuse the caller-owned destination while the fused expert kernel and finalization path are still active. Those runners require distinct storage to preserve buffer lifetime invariants. The environment control provides that compatibility mode without disabling the optimization globally.

## Compatibility

The default execution path and public fused-MoE interfaces are unchanged. CUDA and ROCm apply the same eligibility guard. Only servers that set the environment variable allocate and copy the separate result.

## Validation

- Two focused tests verify the enabled and disabled policies and reject incompatible aliases.
- Ruff check, Ruff format check, Python compilation, and `git diff --check` pass.
- The focused tests pass in the CUDA 13.3 / PyTorch 2.13 source-locked Kimi-K3 runtime image.

Kimi-K3 DFlash composed serving qualification is tracked in local-inference-lab/rtx6kpro#66.
