### PR TITLE
[II] Warm Kimi B12X MLA DCP transport

### DIFF
--- a/tests/model_executor/test_flashinfer_autotune_cache.py
+++ b/tests/model_executor/test_flashinfer_autotune_cache.py
@@ -244,6 +244,66 @@ def test_b12x_dcp_warmup_finds_generic_mla_attention(monkeypatch) -> None:
     ]
 
 
+def test_b12x_dcp_warmup_finds_kimi_dense_mla_attention(monkeypatch) -> None:
+    from vllm.distributed import parallel_state
+    from vllm.models.kimi_k3.nvidia.mla import MultiHeadLatentAttention
+    from vllm.v1.attention.ops import dcp_alltoall
+
+    monkeypatch.setenv("VLLM_USE_B12X_DCP_A2A", "1")
+    attention = MultiHeadLatentAttention.__new__(MultiHeadLatentAttention)
+    torch.nn.Module.__init__(attention)
+    attention.register_parameter(
+        "device_probe",
+        torch.nn.Parameter(torch.empty(1)),
+    )
+    attention.attn_backend = SimpleNamespace(get_name=lambda: "B12X_MLA")
+    attention.impl = SimpleNamespace(dcp_world_size=16)
+    attention.num_local_heads = 6
+    attention.head_size = 576
+    attention.kv_lora_rank = 512
+
+    model = torch.nn.Module()
+    model.add_module("attention", attention)
+    worker = SimpleNamespace(
+        get_model=lambda: model,
+        model_runner=SimpleNamespace(),
+        model_config=SimpleNamespace(dtype=torch.bfloat16),
+        scheduler_config=SimpleNamespace(max_num_batched_tokens=4096),
+        vllm_config=SimpleNamespace(
+            parallel_config=SimpleNamespace(
+                decode_context_parallel_size=16,
+                dcp_comm_backend="a2a",
+            ),
+            compilation_config=SimpleNamespace(
+                static_forward_context={"model.layers.0.attn": attention}
+            ),
+        ),
+    )
+    group = object()
+    calls = []
+    monkeypatch.setattr(parallel_state, "get_dcp_group", lambda: group)
+    monkeypatch.setattr(
+        dcp_alltoall,
+        "warmup_b12x_dcp_a2a",
+        lambda *args, **kwargs: calls.append((args, kwargs)),
+    )
+
+    assert kernel_warmup._warmup_b12x_dcp_a2a(worker) == 1
+    assert calls == [
+        (
+            (group,),
+            {
+                "device": torch.device("cpu"),
+                "dtype": torch.bfloat16,
+                "max_batch_size": 4096,
+                "total_heads": 96,
+                "head_dim": 512,
+                "query_head_dim": 576,
+            },
+        )
+    ]
+
+
 def test_kernel_warmup_runs_b12x_mxfp8_linear_warmup(monkeypatch) -> None:
     calls = []
     model = torch.nn.Linear(2, 2)

--- a/vllm/model_executor/warmup/kernel_warmup.py
+++ b/vllm/model_executor/warmup/kernel_warmup.py
@@ -210,6 +210,9 @@ def _warmup_b12x_dcp_a2a(worker: "Worker") -> int:
     from vllm.models.deepseek_v4.nvidia.b12x import (
         DeepseekV4B12xMLAAttention,
     )
+    from vllm.models.kimi_k3.nvidia.mla import (
+        MultiHeadLatentAttention as KimiK3MLAAttention,
+    )
     from vllm.v1.attention.ops.dcp_alltoall import warmup_b12x_dcp_a2a
 
     model = worker.get_model()
@@ -234,6 +237,17 @@ def _warmup_b12x_dcp_a2a(worker: "Worker") -> int:
             device = next(module.parameters()).device
             total_heads = int(module.num_heads) * dcp_world_size
             query_head_dim = int(module.kv_lora_rank + module.qk_rope_head_dim)
+            output_head_dim = int(module.kv_lora_rank)
+        elif (
+            isinstance(module, KimiK3MLAAttention)
+            and module.attn_backend.get_name() == "B12X_MLA"
+        ):
+            module_dcp_world_size = int(module.impl.dcp_world_size)
+            if module_dcp_world_size <= 1:
+                continue
+            device = next(module.parameters()).device
+            total_heads = int(module.num_local_heads) * module_dcp_world_size
+            query_head_dim = int(module.head_size)
             output_head_dim = int(module.kv_lora_rank)
         else:
             continue


### PR DESCRIPTION
## Status

Implemented. This pull request is stacked on #360.

## Behavior

Kernel warmup recognizes Kimi-K3 attention layers that selected the B12X dense-MLA backend and initializes their decode-context-parallel query-gather and output-reduction transport signature before CUDA graph capture.

For Kimi-K3 TP16/DCP16, six local query heads become the 96-head DCP transport geometry, with a 576-element query head and a 512-element reduced output head. Duplicate module references share one warmed signature.

## Technical reason

Kimi-K3 invokes its native attention adapter directly rather than through the generic `MLAAttention` module class. The existing B12X DCP warmup therefore did not discover the Kimi layer, leaving its transport specialization to first execution or graph capture.

## Compatibility

DeepSeek-V4 and generic MLA discovery are unchanged. Kimi layers using another attention backend or DCP1 are ignored. The change allocates no persistent model storage beyond the transport resources already required by B12X DCP execution.

## Validation

- The generic MLA warmup regression test passes.
- A focused Kimi-K3 test verifies one TP16/DCP16 signature with 96 total heads, 576 query dimensions, and 512 output dimensions.
- Ruff check, Ruff format check, Python compilation, and `git diff --check` pass.
- Both focused tests pass in the CUDA 13.3 / PyTorch 2.13 source-locked Kimi-K3 runtime image.

Composed serving qualification is tracked in local-inference-lab/rtx6kpro#66.
