### PR TITLE
[II] Warm speculative KDA before KV-cache binding

### DIFF
--- a/tests/model_executor/test_kimi_k3_triton_warmup.py
+++ b/tests/model_executor/test_kimi_k3_triton_warmup.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import torch
+
+from vllm.model_executor.warmup.kimi_k3_triton_warmup import (
+    _warm_recurrent_kda,
+)
+from vllm.models.kimi_k3.nvidia.ops.third_party.kda import fused_recurrent
+
+
+def test_speculative_kda_warmup_before_kv_cache_binding(monkeypatch) -> None:
+    calls = []
+    monkeypatch.setattr(
+        fused_recurrent,
+        "get_fused_recurrent_kda_fwd_warmup_profiles",
+        lambda _num_heads: (2,),
+    )
+    monkeypatch.setattr(
+        fused_recurrent,
+        "fused_recurrent_kda",
+        lambda **kwargs: calls.append(kwargs),
+    )
+
+    layer = SimpleNamespace(
+        num_spec=7,
+        local_num_heads=2,
+        head_dim=4,
+        A_log=torch.empty(2, dtype=torch.float32),
+        dt_bias=torch.empty(8, dtype=torch.float32),
+        gate_lower_bound=-10.0,
+        get_state_shape=lambda: ((10, 4), (2, 4, 4)),
+        get_state_dtype=lambda: (torch.bfloat16, torch.float32),
+    )
+
+    _warm_recurrent_kda(layer, torch.bfloat16)
+
+    assert len(calls) == 1
+    call = calls[0]
+    assert call["initial_state"].shape == (1, 2, 4, 4)
+    assert call["initial_state"].dtype == torch.float32
+    assert call["q"].shape == (1, 16, 2, 4)
+    assert call["ssm_state_indices"].shape == (2, 8)

--- a/vllm/model_executor/warmup/kimi_k3_triton_warmup.py
+++ b/vllm/model_executor/warmup/kimi_k3_triton_warmup.py
@@ -103,12 +103,25 @@ def _warm_recurrent_kda(
     if num_speculative_tokens <= 0:
         return
 
-    kv_cache = layer.kv_cache
-    if not isinstance(kv_cache, (list, tuple)) or len(kv_cache) < 2:
-        return
-    state = kv_cache[1]
-    if not isinstance(state, torch.Tensor) or not state.numel():
-        return
+    kv_cache = getattr(layer, "kv_cache", None)
+    state = (
+        kv_cache[1]
+        if isinstance(kv_cache, (list, tuple))
+        and len(kv_cache) >= 2
+        and isinstance(kv_cache[1], torch.Tensor)
+        and kv_cache[1].numel()
+        else None
+    )
+    if state is None:
+        # Kernel warmup runs before production KV-cache binding. One temporary
+        # state page preserves the production layout and dtype for compilation.
+        state_shape = layer.get_state_shape()[1]
+        state_dtype = layer.get_state_dtype()[1]
+        state = torch.empty(
+            (1, *state_shape),
+            dtype=state_dtype,
+            device=layer.A_log.device,
+        )
 
     logger.info("Warming up Kimi-K3 speculative KDA kernels.")
     h = int(layer.local_num_heads)


### PR DESCRIPTION
## Status

Implemented.

## Behavior

Kimi-K3 speculative KDA warmup compiles the recurrent kernel before production KV-cache binding. If the model cache is already available, warmup uses its state tensor. Otherwise it allocates one temporary state page with the layer-reported production shape, dtype, and device, then releases it after warmup.

## Technical reason

Kernel warmup runs before vLLM binds the production KV cache. Returning early at that point leaves the speculative recurrent specialization uncompiled and permits first execution or CUDA graph capture to trigger JIT compilation.

## Compatibility

Non-speculative Kimi-K3 execution remains unchanged. Existing bound-cache warmup retains its exact behavior. The temporary allocation is one state page and exists only during startup warmup.

## Validation

- A focused test exercises seven-token speculation before cache binding and verifies the temporary FP32 state shape plus the generated recurrent-KDA inputs.
- Ruff check, Ruff format check, Python compilation, and `git diff --check` pass.
- The focused test passes in the CUDA 13.3 / PyTorch 2.13 source-locked Kimi-K3 runtime image.

DSpark and DFlash composed serving qualification is tracked in local-inference-lab/rtx6kpro#66.
