### PR TITLE
[II] Release deferred online-quant sources before repack

### DIFF
--- a/tests/model_executor/model_loader/test_reload.py
+++ b/tests/model_executor/model_loader/test_reload.py
@@ -138,6 +138,47 @@ class _ReloadableAttentionLayer(
         self.post_load_called = True
 
 
+class _SourceLifetimeQuantMethod(QuantizeMethodBase):
+    """Observes checkpoint-source ownership when online processing starts."""
+
+    uses_meta_device = True
+
+    def __init__(self, source_refs):
+        self.source_refs = source_refs
+        self.sources_alive_at_process = None
+
+    def create_weights(self, layer, *weight_args, **extra_weight_attrs):
+        pass
+
+    def apply(self, layer, *args, **kwargs):
+        raise NotImplementedError
+
+    def process_weights_after_loading(self, layer):
+        gc.collect()
+        self.sources_alive_at_process = [
+            source_ref() is not None for source_ref in self.source_refs
+        ]
+
+
+class _DeferredOnlineQuantAttention(_ReloadableAttentionLayer):
+    """Attention layer whose checkpoint tensor is processed after loading."""
+
+    def __init__(self):
+        torch.nn.Module.__init__(self)
+        self.source_refs = []
+        self.quant_method = _SourceLifetimeQuantMethod(self.source_refs)
+
+        def tracking_weight_loader(param, loaded_weight):
+            self.source_refs.append(ref(loaded_weight))
+            default_weight_loader(param, loaded_weight)
+
+        weight = torch.nn.Parameter(torch.empty(2, 2, device="meta"))
+        weight.weight_loader = tracking_weight_loader
+        self.register_parameter("weight", weight)
+        self.post_load_called = False
+        initialize_online_processing(self)
+
+
 def test_move_metatensors():
     tensor = torch.empty((1, 2, 3))
     meta_tensor = to_meta_tensor(tensor)
@@ -191,6 +232,24 @@ def test_attention_first_load_processes_weights(default_vllm_config, layer_cls):
 
     assert layer.post_load_called
     assert torch.equal(layer.weight, loaded_weight)
+
+
+def test_attention_first_load_releases_sources_before_online_quantization(
+    default_vllm_config,
+):
+    default_vllm_config.model_config = ModelConfig()
+    layer = _DeferredOnlineQuantAttention()
+    model = torch.nn.Sequential(layer)
+
+    layer.weight.weight_loader(layer.weight, torch.full((2, 2), 7.0))
+
+    assert layer.source_refs[0]() is not None
+    finalize_layerwise_reload(model, default_vllm_config.model_config)
+
+    assert layer.quant_method.sources_alive_at_process
+    assert not any(layer.quant_method.sources_alive_at_process)
+    assert layer.post_load_called
+    assert torch.equal(layer.weight, torch.full((2, 2), 7.0))
 
 
 def test_reload_lifecycle():

--- a/vllm/model_executor/model_loader/reload/layerwise.py
+++ b/vllm/model_executor/model_loader/reload/layerwise.py
@@ -387,10 +387,19 @@ def _layerwise_process(layer: torch.nn.Module, info: LayerReloadingInfo):
         param.weight_loader = _get_original_loader(param)
 
     # Load all buffered weights into materialized layer (using original loaders)
-    for name, args in info.loaded_weights:
+    loaded_args = None
+    for name, loaded_args in info.loaded_weights:
         param = getattr(layer, name)
-        args.arguments["param"] = param
-        param.weight_loader(*args.args, **args.kwargs)
+        loaded_args.arguments["param"] = param
+        param.weight_loader(*loaded_args.args, **loaded_args.kwargs)
+
+    if info.kernel_tensors is None:
+        # Initial online quantization no longer needs checkpoint tensors after
+        # their values have reached the materialized parameters. Release the
+        # buffered sources before quantization and kernel repacking allocate
+        # their transient workspaces.
+        info.loaded_weights.clear()
+        loaded_args = None
 
     # Process weights (quantization, repacking, etc.)
     quant_method = getattr(layer, "quant_method", None)


### PR DESCRIPTION
## Behavior

Initial online quantization now releases deferred checkpoint tensors after their values reach materialized parameters and before quantization or kernel repacking allocates transient workspaces.

Reloading retains the deferred tensor inventory until processed values have been copied back into the stable kernel tensor addresses.

## Technical reason

Attention layers defer online processing until model loading finishes. Their buffered checkpoint tensors otherwise overlap quantizer output and repack workspaces, increasing peak device memory. The loader now clears that ownership only for initial online quantization; reload address-preservation semantics are unchanged.

## Compatibility

This pull request is stacked on #328. Synchronous non-attention online quantization continues to stream directly into materialized parameters. Deferred reload and attention processing preserve their existing load order and values.

## Validation

- Five focused online-processing and deferred-attention tests passed in the source-locked CUDA 13.3 / PyTorch 2.13 Kimi-K3 runtime image.
- The source-lifetime test observes checkpoint tensors through weak references and verifies that no source remains live when online quantization begins.
- Ruff check and format verification passed.
- Python compilation and git diff validation passed.