### PR TITLE
Define Kimi hybrid cache geometry

### DIFF
--- a/tests/models/kimi_k3/test_mla_padding.py
+++ b/tests/models/kimi_k3/test_mla_padding.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import torch
+
+
+def test_kimi_mla_defines_graph_padding_before_output_projection(monkeypatch):
+    from vllm.models.kimi_k3.nvidia import mla
+
+    attention = object.__new__(mla.MultiHeadLatentAttention)
+    torch.nn.Module.__init__(attention)
+    attention.layer_name = "model.layers.0.self_attn"
+    attention.rotary_emb = None
+
+    metadata = SimpleNamespace(num_actual_tokens=2, num_decode_tokens=0)
+    context = SimpleNamespace(
+        attn_metadata={attention.layer_name: metadata},
+        slot_mapping={attention.layer_name: torch.arange(4)},
+    )
+    monkeypatch.setattr(mla, "get_forward_context", lambda: context)
+
+    def write_active_prefill(*args):
+        args[-1].fill_(3)
+
+    attention._forward_prefill_fused = write_active_prefill
+    output = torch.full((4, 8), 9, dtype=torch.bfloat16)
+    attention_method = type(attention)._attention
+    invoke_attention = getattr(attention_method, "__wrapped__", attention_method)
+    invoke_attention(
+        attention,
+        torch.arange(4),
+        torch.zeros((4, 1, 8), dtype=torch.bfloat16),
+        torch.zeros((4, 8), dtype=torch.bfloat16),
+        torch.zeros((4, 8), dtype=torch.bfloat16),
+        output,
+    )
+
+    torch.testing.assert_close(output[:2], torch.full_like(output[:2], 3))
+    torch.testing.assert_close(output[2:], torch.zeros_like(output[2:]))

--- a/tests/v1/attention/test_mla_noncausal.py
+++ b/tests/v1/attention/test_mla_noncausal.py
@@ -12,7 +12,7 @@ from vllm.model_executor.layers.attention.mla_attention import (
     QueryLenSupport,
 )
 from vllm.v1.attention.backend import CommonAttentionMetadata
-from vllm.v1.kv_cache_interface import MLAAttentionSpec
+from vllm.v1.kv_cache_interface import MLAAttentionSpec, SlidingWindowMLASpec
 
 
 class _NonCausalMLAMetadataBuilder(MLACommonMetadataBuilder[MLACommonMetadata]):
@@ -120,7 +120,30 @@ def test_mla_cache_marker_is_promoted_to_group_capability():
     unmarked = MLAAttentionSpec(**kwargs)
 
     assert MLAAttentionSpec.merge([marked, marked]).non_causal_multi_token_decode
-    assert MLAAttentionSpec.merge([marked, unmarked]).non_causal_multi_token_decode
+    with pytest.raises(AssertionError, match="causal mode"):
+        MLAAttentionSpec.merge([marked, unmarked])
     assert not MLAAttentionSpec.merge(
         [unmarked, unmarked]
     ).non_causal_multi_token_decode
+
+
+def test_sliding_mla_cache_marker_is_a_group_invariant():
+    kwargs = {
+        "block_size": 64,
+        "num_kv_heads": 1,
+        "head_size": 576,
+        "dtype": torch.bfloat16,
+        "sliding_window": 32768,
+    }
+    marked = SlidingWindowMLASpec(
+        **kwargs,
+        non_causal_multi_token_decode=True,
+    )
+    unmarked = SlidingWindowMLASpec(**kwargs)
+
+    merged = SlidingWindowMLASpec.merge([marked, marked])
+    assert merged.non_causal_multi_token_decode
+    assert merged.is_uniform_with_collection({"first": marked, "second": marked})
+    assert not merged.is_uniform_with_collection({"first": marked, "second": unmarked})
+    with pytest.raises(AssertionError, match="causal mode"):
+        SlidingWindowMLASpec.merge([marked, unmarked])

--- a/tests/v1/attention/test_mla_noncausal.py
+++ b/tests/v1/attention/test_mla_noncausal.py
@@ -7,6 +7,7 @@ import pytest
 import torch
 
 from vllm.model_executor.layers.attention.mla_attention import (
+    MLAAttention,
     MLACommonMetadata,
     MLACommonMetadataBuilder,
     QueryLenSupport,
@@ -147,3 +148,20 @@ def test_sliding_mla_cache_marker_is_a_group_invariant():
     assert not merged.is_uniform_with_collection({"first": marked, "second": unmarked})
     with pytest.raises(AssertionError, match="causal mode"):
         SlidingWindowMLASpec.merge([marked, unmarked])
+
+
+def test_sliding_mla_cache_spec_preserves_noncausal_marker():
+    layer = SimpleNamespace(
+        kv_cache_dtype="auto",
+        head_size=576,
+        non_causal_multi_token_decode=True,
+        sliding_window=32768,
+    )
+    vllm_config = SimpleNamespace(
+        cache_config=SimpleNamespace(block_size=64), model_config=None
+    )
+
+    spec = MLAAttention.get_kv_cache_spec(layer, vllm_config)
+
+    assert isinstance(spec, SlidingWindowMLASpec)
+    assert spec.non_causal_multi_token_decode

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -2857,6 +2857,16 @@ def test_group_and_unify_kv_cache_specs_uniform_page_size_returns_none():
     assert group_and_unify_kv_cache_specs(specs) is None
 
 
+def test_group_and_unify_kv_cache_specs_defers_recurrent_state():
+    specs = {
+        "mla.0": new_mla_spec(),
+        "swa.0": new_bf16_swa_mla_spec(head_size=1024),
+        "state.0": new_mamba_spec(),
+    }
+
+    assert group_and_unify_kv_cache_specs(specs) is None
+
+
 def test_group_and_unify_kv_cache_specs_mixed_page_size_groups():
     # DeepseekV4-style: differing page sizes across MLA and sliding-window MLA
     # layers do require tuple packing, so grouping must still be produced.

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -2867,6 +2867,74 @@ def test_group_and_unify_kv_cache_specs_defers_recurrent_state():
     assert group_and_unify_kv_cache_specs(specs) is None
 
 
+def _k3_hybrid_cache_specs() -> dict[str, KVCacheSpec]:
+    recurrent = MambaSpec(
+        block_size=16,
+        shapes=((9216,),),
+        dtypes=(torch.bfloat16,),
+    )
+    draft = SlidingWindowMLASpec(
+        block_size=16,
+        num_kv_heads=1,
+        head_size=576,
+        dtype=torch.bfloat16,
+        sliding_window=32768,
+        non_causal_multi_token_decode=True,
+    )
+    assert recurrent.page_size_bytes == draft.page_size_bytes
+    return {
+        **{f"state.{index}": recurrent for index in range(8)},
+        **{f"draft.{index}": draft for index in range(6)},
+    }
+
+
+def test_uniform_page_group_size_override_is_explicit():
+    specs = _k3_hybrid_cache_specs()
+
+    groups = kv_cache_utils._get_kv_cache_groups_uniform_page_size(
+        specs,
+        group_size_override=2,
+    )
+
+    assert len(groups) == 7
+    assert all(len(group.layer_names) == 2 for group in groups)
+    with pytest.raises(ValueError, match="must be positive"):
+        kv_cache_utils._get_kv_cache_groups_uniform_page_size(
+            specs,
+            group_size_override=0,
+        )
+
+
+@pytest.mark.parametrize(
+    ("model_type", "expected_groups"), [("kimi_k3", 7), ("other", 2)]
+)
+def test_k3_hybrid_group_size_is_model_and_cache_specific(
+    monkeypatch: pytest.MonkeyPatch,
+    model_type: str,
+    expected_groups: int,
+):
+    config = SimpleNamespace(
+        scheduler_config=SimpleNamespace(disable_hybrid_kv_cache_manager=False),
+        parallel_config=SimpleNamespace(
+            decode_context_parallel_size=1,
+            prefill_context_parallel_size=1,
+        ),
+        model_config=SimpleNamespace(
+            hf_config=SimpleNamespace(model_type=model_type),
+        ),
+    )
+    monkeypatch.setenv("VLLM_K3_KV_GROUP_SIZE", "2")
+    monkeypatch.setattr(
+        kv_cache_utils,
+        "group_and_unify_kv_cache_specs",
+        lambda *args, **kwargs: None,
+    )
+
+    groups = get_kv_cache_groups(config, _k3_hybrid_cache_specs())
+
+    assert len(groups) == expected_groups
+
+
 def test_group_and_unify_kv_cache_specs_mixed_page_size_groups():
     # DeepseekV4-style: differing page sizes across MLA and sliding-window MLA
     # layers do require tuple packing, so grouping must still be produced.

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -64,6 +64,7 @@ if TYPE_CHECKING:
     VLLM_NVFP4_MLA_SCALES_FILE: str = ""
     VLLM_B12X_ABSORB_BMM: bool = False
     VLLM_DSPARK_FP8_DRAFT_HEAD: bool = False
+    VLLM_K3_KV_GROUP_SIZE: int = 0
     VLLM_USE_B12X_WO_PROJECTION: bool = False
     VLLM_USE_B12X_MOE: bool = False
     VLLM_NF3_GRID188_DECODE: bool = True
@@ -1138,6 +1139,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_DSPARK_FP8_DRAFT_HEAD": lambda: bool(
         int(os.getenv("VLLM_DSPARK_FP8_DRAFT_HEAD", "0"))
     ),
+    # Bound the number of physical Kimi-K3 layers sharing each hybrid-cache
+    # block table. Zero preserves the general grouping heuristic.
+    "VLLM_K3_KV_GROUP_SIZE": lambda: int(os.getenv("VLLM_K3_KV_GROUP_SIZE", "0")),
     # Use b12x for the DeepSeek V4 WO-A/WO-B fused projection.
     # This is separate from the generic FP8 linear switch for perf isolation.
     "VLLM_USE_B12X_WO_PROJECTION": lambda: bool(

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -2085,6 +2085,7 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             return SlidingWindowMLASpec(
                 **common_kwargs,
                 sliding_window=self.sliding_window,
+                non_causal_multi_token_decode=self.non_causal_multi_token_decode,
             )
 
         layer_id = _extract_single_layer_index(self.layer_name)

--- a/vllm/models/kimi_k3/nvidia/mla.py
+++ b/vllm/models/kimi_k3/nvidia/mla.py
@@ -558,6 +558,10 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
         )
 
         num_actual_toks = attn_metadata.num_actual_tokens
+        if num_actual_toks < int(attn_out.shape[0]):
+            # Downstream gate and output projections consume graph-padded rows.
+            # Define inactive rows before they enter a collective operation.
+            attn_out[num_actual_toks:].zero_()
         slot_mapping_by_layer = forward_context.slot_mapping
         assert isinstance(slot_mapping_by_layer, dict)
         slot_mapping = slot_mapping_by_layer[self.layer_name]

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1745,6 +1745,12 @@ def group_and_unify_kv_cache_specs(
     Group the KV cache specs and unify each group into one UniformTypeKVCacheSpecs.
     Currently, this is only used for DeepseekV4.
     """
+    # Recurrent state pages require the generic hybrid-cache planner. Packing
+    # them into the heterogeneous MLA tuple layout would charge the larger
+    # state page to every packed block and reduce attention-cache capacity.
+    if any(isinstance(spec, MambaSpec) for spec in kv_cache_spec.values()):
+        return None
+
     has_swa = any(
         isinstance(spec, SlidingWindowMLASpec) for spec in kv_cache_spec.values()
     )

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1181,6 +1181,7 @@ def is_kv_cache_type_attention_free(kv_cache_spec: dict[str, KVCacheSpec]) -> bo
 
 def _get_kv_cache_groups_uniform_page_size(
     kv_cache_spec: dict[str, KVCacheSpec],
+    group_size_override: int | None = None,
 ) -> list[KVCacheGroupSpec]:
     """
     Generates the KV cache groups for hybrid models with multiple
@@ -1240,9 +1241,16 @@ def _get_kv_cache_groups_uniform_page_size(
     memory per block is the same for all groups.
 
     Args:
-        kv_cache_spec: The KVCacheSpec of each attention layer in the model
+        kv_cache_spec: KV-cache specification for each attention layer.
+        group_size_override: Number of physical layers assigned to every
+            cache group. When omitted, the grouping heuristic derives the
+            size from the attention-layer counts.
+
     Returns:
-        The generated KVCacheGroupSpecs
+        Cache-group specifications with a uniform physical page size.
+
+    Raises:
+        ValueError: If ``group_size_override`` is not positive.
     """
     # Group all layers by kv_cache_spec.
     # E.g., 2 full attention layers and 3 sliding window attention layers,
@@ -1296,6 +1304,13 @@ def _get_kv_cache_groups_uniform_page_size(
         # layers while accommodating speculative decoding drafters that add
         # extra layers to one attention type.
         group_size = max_num_layers
+    if group_size_override is not None:
+        if group_size_override <= 0:
+            raise ValueError(
+                "KV cache group size override must be positive, got "
+                f"{group_size_override}."
+            )
+        group_size = group_size_override
     grouped_layers = []
     for layers in layer_buckets:
         num_padding_layers = group_size - len(layers) % group_size
@@ -2070,7 +2085,30 @@ def get_kv_cache_groups(
         if fallback_groups is None:
             raise
         return fallback_groups
-    groups = _get_kv_cache_groups_uniform_page_size(filtered_spec)
+    model_type = getattr(vllm_config.model_config.hf_config, "model_type", None)
+    k3_group_size = envs.VLLM_K3_KV_GROUP_SIZE
+    use_k3_group_size_override = (
+        k3_group_size > 0
+        and model_type == "kimi_k3"
+        and any(isinstance(spec, MambaSpec) for spec in filtered_spec.values())
+        and any(
+            isinstance(spec, SlidingWindowMLASpec)
+            and spec.non_causal_multi_token_decode
+            for spec in filtered_spec.values()
+        )
+    )
+    if use_k3_group_size_override:
+        groups = _get_kv_cache_groups_uniform_page_size(
+            filtered_spec, group_size_override=k3_group_size
+        )
+        logger.info_once(
+            "Kimi-K3 uses hybrid KV group size %d (%d groups) to reduce "
+            "cache padding and block-table overhead.",
+            k3_group_size,
+            len(groups),
+        )
+    else:
+        groups = _get_kv_cache_groups_uniform_page_size(filtered_spec)
 
     # Add hidden-state layers back with page aligned to the common page.
     if hidden_specs:

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -2085,7 +2085,9 @@ def get_kv_cache_groups(
         if fallback_groups is None:
             raise
         return fallback_groups
-    model_type = getattr(vllm_config.model_config.hf_config, "model_type", None)
+    model_config = getattr(vllm_config, "model_config", None)
+    hf_config = getattr(model_config, "hf_config", None)
+    model_type = getattr(hf_config, "model_type", None)
     k3_group_size = envs.VLLM_K3_KV_GROUP_SIZE
     use_k3_group_size_override = (
         k3_group_size > 0

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -533,6 +533,7 @@ class MLAAttentionSpec(FullAttentionSpec):
         block_stride_set = set(spec.indexes_kv_by_block_stride for spec in specs)
         dcp_replicated_set = set(spec.dcp_replicated for spec in specs)
         dcp_kv_shard_count_set = set(spec.dcp_kv_shard_count for spec in specs)
+        non_causal_set = set(spec.non_causal_multi_token_decode for spec in specs)
         assert (
             len(cache_dtype_str_set) == 1
             and len(dtype_set) == 1
@@ -542,10 +543,11 @@ class MLAAttentionSpec(FullAttentionSpec):
             and len(block_stride_set) == 1
             and len(dcp_replicated_set) == 1
             and len(dcp_kv_shard_count_set) == 1
+            and len(non_causal_set) == 1
         ), (
             "All attention layers in the same KV cache group must use the same "
             "dtype, quantization method, compress ratio, model version, and "
-            "KV block stride indexing, and DCP replication mode."
+            "KV block stride indexing, DCP replication mode, and causal mode."
         )
         merged_spec = cls(
             block_size=specs[0].block_size,
@@ -558,9 +560,7 @@ class MLAAttentionSpec(FullAttentionSpec):
             cache_dtype_str=cache_dtype_str_set.pop(),
             compress_ratio=compress_ratio_set.pop(),
             model_version=model_version_set.pop(),
-            non_causal_multi_token_decode=any(
-                spec.non_causal_multi_token_decode for spec in specs
-            ),
+            non_causal_multi_token_decode=non_causal_set.pop(),
             dcp_replicated=dcp_replicated_set.pop(),
             dcp_kv_shard_count=dcp_kv_shard_count_set.pop(),
         )
@@ -750,6 +750,9 @@ class SlidingWindowMLASpec(SlidingWindowSpec):
     compress_ratio: int = 1
     model_version: str | None = None
     dcp_sharded: bool = False
+    # Parallel draft blocks are flattened into independent decode rows by MLA
+    # backends. Preserve that execution property when the cache is windowed.
+    non_causal_multi_token_decode: bool = False
 
     def __post_init__(self):
         _apply_alignment_padding(self)
@@ -812,6 +815,7 @@ class SlidingWindowMLASpec(SlidingWindowSpec):
         block_stride_set = set(spec.indexes_kv_by_block_stride for spec in specs)
         dcp_replicated_set = set(spec.dcp_replicated for spec in specs)
         dcp_sharded_set = set(spec.dcp_sharded for spec in specs)
+        non_causal_set = set(spec.non_causal_multi_token_decode for spec in specs)
         assert (
             len(cache_dtype_str_set) == 1
             and len(dtype_set) == 1
@@ -822,11 +826,12 @@ class SlidingWindowMLASpec(SlidingWindowSpec):
             and len(block_stride_set) == 1
             and len(dcp_replicated_set) == 1
             and len(dcp_sharded_set) == 1
+            and len(non_causal_set) == 1
         ), (
             "All attention layers in the same KV cache group must use the same "
             "dtype, quantization method, compress ratio, model version, "
             "sliding window size, KV block stride indexing, and DCP sharding "
-            "mode."
+            "mode and causal mode."
         )
         return cls(
             block_size=specs[0].block_size,
@@ -842,6 +847,7 @@ class SlidingWindowMLASpec(SlidingWindowSpec):
             compress_ratio=compress_ratio_set.pop(),
             model_version=model_version_set.pop(),
             dcp_sharded=dcp_sharded_set.pop(),
+            non_causal_multi_token_decode=non_causal_set.pop(),
         )
 
     def is_uniform_with_collection(
@@ -852,6 +858,7 @@ class SlidingWindowMLASpec(SlidingWindowSpec):
             and spec.sliding_window == self.sliding_window
             and spec.dcp_replicated == self.dcp_replicated
             and spec.dcp_sharded == self.dcp_sharded
+            and spec.non_causal_multi_token_decode == self.non_causal_multi_token_decode
             for spec in kv_cache_specs.values()
         )
 


### PR DESCRIPTION
## Status

Implemented. This pull request is stacked on #382. Composed serving qualification is tracked by local-inference-lab/rtx6kpro#66.

## Behavior

- Defines inactive Kimi MLA CUDA-graph rows before collective operations.
- Requires every MLA cache group to use one causal mode.
- Keeps recurrent Mamba fixed state on the generic hybrid-cache planner instead of charging it to packed MLA attention capacity.
- Exposes `VLLM_K3_KV_GROUP_SIZE` so Kimi-K3 deployments can bound the number of physical layers sharing one cache block table.

## Technical reason

Kimi-K3 combines recurrent state, causal MLA, and non-causal sliding-window MLA. Cache capacity and graph replay are correct only when inactive rows are initialized, causal modes are not mixed within one group, and fixed recurrent state is accounted independently from token capacity.

## Compatibility

The default cache-group width remains the generic planner heuristic. Models without the Kimi-K3 hybrid layout retain the existing cache planner.

## Validation

- Focused inactive-row, non-causal MLA, cache-interface, and cache-planner tests pass in the source-locked runtime environment.
- The diff contains four commits across seven files and is independently reviewable after #382.
