### PR TITLE
Run DCP collectives through B12X

### DIFF
--- a/tests/distributed/test_active_b12x_allreduce_accessor.py
+++ b/tests/distributed/test_active_b12x_allreduce_accessor.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+from vllm.distributed.device_communicators.custom_all_reduce import (
+    CustomAllreduce,
+    get_active_b12x_pcie_allreduce,
+)
+
+
+def test_accessor_accepts_active_runtime_without_fused_rms_norm(monkeypatch):
+    custom_allreduce = object.__new__(CustomAllreduce)
+    custom_allreduce.disabled = False
+    custom_allreduce._pcie_runtime = object()
+    group = SimpleNamespace(
+        device_communicator=SimpleNamespace(ca_comm=custom_allreduce)
+    )
+    monkeypatch.setattr("vllm.distributed.parallel_state.get_tp_group", lambda: group)
+
+    assert get_active_b12x_pcie_allreduce() is custom_allreduce
+
+
+def test_accessor_rejects_disabled_runtime(monkeypatch):
+    custom_allreduce = object.__new__(CustomAllreduce)
+    custom_allreduce.disabled = True
+    custom_allreduce._pcie_runtime = object()
+    group = SimpleNamespace(
+        device_communicator=SimpleNamespace(ca_comm=custom_allreduce)
+    )
+    monkeypatch.setattr("vllm.distributed.parallel_state.get_tp_group", lambda: group)
+
+    assert get_active_b12x_pcie_allreduce() is None
+
+
+def test_accessor_rejects_missing_runtime(monkeypatch):
+    custom_allreduce = object.__new__(CustomAllreduce)
+    custom_allreduce.disabled = False
+    custom_allreduce._pcie_runtime = None
+    custom_allreduce._pcie_dma = None
+    custom_allreduce._ptr = 0
+    group = SimpleNamespace(
+        device_communicator=SimpleNamespace(ca_comm=custom_allreduce)
+    )
+    monkeypatch.setattr("vllm.distributed.parallel_state.get_tp_group", lambda: group)
+
+    assert get_active_b12x_pcie_allreduce() is None

--- a/tests/distributed/test_b12x_fused_all_reduce.py
+++ b/tests/distributed/test_b12x_fused_all_reduce.py
@@ -219,14 +219,26 @@ def test_b12x_oneshot_defaults_to_stream_isolation(
 
 
 @pytest.mark.parametrize(
-    ("world_size", "algorithm", "supports_all_peer_auxiliary"),
-    [(2, "oneshot", True), (16, "hierarchical", False)],
+    (
+        "world_size",
+        "algorithm",
+        "supports_all_peer_auxiliary",
+        "single_channel",
+        "expected_channel_capacity",
+    ),
+    [
+        (2, "oneshot", True, False, 2),
+        (16, "hierarchical", False, False, 1),
+        (16, "hierarchical", False, True, 1),
+    ],
 )
 def test_b12x_dispatcher_prepares_single_stable_eager_owner(
     monkeypatch: pytest.MonkeyPatch,
     world_size: int,
     algorithm: str,
     supports_all_peer_auxiliary: bool,
+    single_channel: bool,
+    expected_channel_capacity: int,
 ) -> None:
     captured = {}
     runtime = MagicMock()
@@ -324,7 +336,7 @@ def test_b12x_dispatcher_prepares_single_stable_eager_owner(
     monkeypatch.setattr(
         custom_all_reduce.envs,
         "VLLM_PCIE_ONESHOT_SINGLE_CHANNEL",
-        False,
+        single_channel,
         raising=False,
     )
     monkeypatch.setattr(
@@ -341,10 +353,14 @@ def test_b12x_dispatcher_prepares_single_stable_eager_owner(
     )
 
     assert not built.disabled
-    assert captured["single_channel"] is False
-    assert captured["max_concurrent_channels"] == 2
-    runtime.prepare_channels.assert_called_once_with(("vllm:eager:allreduce",))
-    runtime.for_stream.assert_called_once_with(channel_id="vllm:eager:allreduce")
+    assert captured["single_channel"] is single_channel
+    assert captured["max_concurrent_channels"] == expected_channel_capacity
+    if single_channel:
+        runtime.prepare_channels.assert_not_called()
+        runtime.for_stream.assert_called_once_with(channel_id=None)
+    else:
+        runtime.prepare_channels.assert_called_once_with(("vllm:eager:allreduce",))
+        runtime.for_stream.assert_called_once_with(channel_id="vllm:eager:allreduce")
     assert built.backend_name() == (
         "B12X_PCIE_ONESHOT" if algorithm == "oneshot" else "B12X_PCIE_HIERARCHICAL"
     )

--- a/tests/distributed/test_b12x_fused_all_reduce.py
+++ b/tests/distributed/test_b12x_fused_all_reduce.py
@@ -218,13 +218,23 @@ def test_b12x_oneshot_defaults_to_stream_isolation(
     assert not envs.environment_variables["VLLM_PCIE_ONESHOT_SINGLE_CHANNEL"]()
 
 
-def test_b12x_pool_prepares_single_stable_eager_owner(
+@pytest.mark.parametrize(
+    ("world_size", "algorithm", "supports_all_peer_auxiliary"),
+    [(2, "oneshot", True), (16, "hierarchical", False)],
+)
+def test_b12x_dispatcher_prepares_single_stable_eager_owner(
     monkeypatch: pytest.MonkeyPatch,
+    world_size: int,
+    algorithm: str,
+    supports_all_peer_auxiliary: bool,
 ) -> None:
     captured = {}
     runtime = MagicMock()
+    runtime.algorithm = algorithm
+    runtime.supports_all_peer_auxiliary = supports_all_peer_auxiliary
+    dma_min_bytes = MagicMock(return_value=None)
 
-    class FakePool:
+    class FakeDispatcher:
         @classmethod
         def from_exchange_group(cls, **kwargs):
             captured.update(kwargs)
@@ -243,10 +253,14 @@ def test_b12x_pool_prepares_single_stable_eager_owner(
     monkeypatch.setattr(
         custom_all_reduce,
         "in_the_same_node_as",
-        lambda group, source_rank=0: [True, True],
+        lambda group, source_rank=0: [True] * world_size,
     )
     monkeypatch.setattr(custom_all_reduce.dist, "get_rank", lambda group=None: 0)
-    monkeypatch.setattr(custom_all_reduce.dist, "get_world_size", lambda group=None: 2)
+    monkeypatch.setattr(
+        custom_all_reduce.dist,
+        "get_world_size",
+        lambda group=None: world_size,
+    )
     monkeypatch.setattr(custom_all_reduce.dist, "all_gather", fake_all_gather)
     monkeypatch.setattr(
         custom_all_reduce.dist, "all_reduce", lambda *args, **kwargs: None
@@ -264,13 +278,13 @@ def test_b12x_pool_prepares_single_stable_eager_owner(
     )
     monkeypatch.setattr(
         custom_all_reduce,
-        "_load_b12x_pcie_oneshot_pool",
-        lambda: FakePool,
+        "_load_b12x_pcie_allreduce",
+        lambda: FakeDispatcher,
     )
     monkeypatch.setattr(
         custom_all_reduce,
         "_b12x_pcie_dma_min_bytes",
-        lambda: None,
+        dma_min_bytes,
     )
     monkeypatch.setattr(
         custom_all_reduce.current_platform,
@@ -331,6 +345,10 @@ def test_b12x_pool_prepares_single_stable_eager_owner(
     assert captured["max_concurrent_channels"] == 2
     runtime.prepare_channels.assert_called_once_with(("vllm:eager:allreduce",))
     runtime.for_stream.assert_called_once_with(channel_id="vllm:eager:allreduce")
+    assert built.backend_name() == (
+        "B12X_PCIE_ONESHOT" if algorithm == "oneshot" else "B12X_PCIE_HIERARCHICAL"
+    )
+    assert dma_min_bytes.call_count == int(supports_all_peer_auxiliary)
 
 
 def test_b12x_channel_checkpoint_delegates_to_runtime() -> None:

--- a/tests/distributed/test_dcp_a2a.py
+++ b/tests/distributed/test_dcp_a2a.py
@@ -2088,9 +2088,6 @@ def test_distributed_packed_a2a_with_workspace_matches_reference():
     reason="Need two GPUs and b12x.",
 )
 def test_distributed_b12x_a2a_eager_and_graph_matches_reference():
-    from b12x.comm.pcie.pcie_dcp_a2a import _load_extension
-
-    _load_extension()
     _distributed_run(
         _distributed_b12x_a2a_worker,
         world_size=2,

--- a/tests/distributed/test_dcp_a2a.py
+++ b/tests/distributed/test_dcp_a2a.py
@@ -10,7 +10,7 @@ Tests cover:
 
 import importlib.util
 import math
-from contextlib import contextmanager, nullcontext
+from contextlib import ExitStack, contextmanager, nullcontext
 from typing import Any
 
 import multiprocess as mp
@@ -690,6 +690,73 @@ def test_b12x_dcp_capture_rejects_missing_semantic_id(monkeypatch):
         pass
 
 
+def test_b12x_pool_initialized_inside_graph_context_joins_graph_channel(monkeypatch):
+    from vllm.v1.attention.ops import dcp_alltoall
+
+    events: list[Any] = []
+
+    class _FakePool:
+        @classmethod
+        def from_exchange_group(cls, **kwargs):
+            events.append(("create", kwargs["exchange_group"]))
+            return cls()
+
+        def prepare_channels(self, channel_ids):
+            events.append(("prepare", tuple(channel_ids)))
+
+        def for_stream(self, *, channel_id):
+            events.append(("eager", channel_id))
+
+        @contextmanager
+        def capture(self, *, stream, channel_id):
+            events.append(("enter", stream, channel_id))
+            try:
+                yield
+            finally:
+                events.append(("exit", stream, channel_id))
+
+    device_group = object()
+    group = _FakeCPGroup(2, device_group)  # type: ignore[arg-type]
+    stream = object()
+    monkeypatch.setattr(dcp_alltoall, "_B12X_DCP_A2A_POOLS", {})
+    monkeypatch.setattr(dcp_alltoall, "_B12X_DCP_A2A_DISABLED", set())
+    monkeypatch.setattr(dcp_alltoall, "_B12X_DCP_ACTIVE_CAPTURE", {})
+    monkeypatch.setattr(dcp_alltoall, "_load_b12x_dcp_a2a_pool", lambda: _FakePool)
+    monkeypatch.setattr(dcp_alltoall, "_b12x_dcp_init_failed", lambda *args: False)
+    monkeypatch.setattr(
+        dcp_alltoall.torch.cuda,
+        "is_current_stream_capturing",
+        lambda: False,
+    )
+
+    with dcp_alltoall.capture_b12x_dcp_a2a(
+        group,  # type: ignore[arg-type]
+        stream,
+        channel_id="vllm:target:decode",
+    ):
+        pool = dcp_alltoall._get_b12x_dcp_a2a_pool(
+            group,  # type: ignore[arg-type]
+            device=torch.device("cuda:0"),
+            total_heads=64,
+            head_dim=512,
+            query_head_dim=576,
+            max_batch_size=64,
+        )
+        assert pool is not None
+        assert (
+            dcp_alltoall._b12x_dcp_channel_id(group)  # type: ignore[arg-type]
+            == "vllm:target:decode"
+        )
+
+    assert dcp_alltoall._b12x_dcp_channel_id(group) == "vllm:eager:dcp"  # type: ignore[arg-type]
+    assert events == [
+        ("create", device_group),
+        ("prepare", ("vllm:eager:dcp", "vllm:target:decode")),
+        ("enter", stream, "vllm:target:decode"),
+        ("exit", stream, "vllm:target:decode"),
+    ]
+
+
 def test_b12x_dcp_channel_rollback_restores_existing_and_closes_new_pools(
     monkeypatch,
 ):
@@ -1043,6 +1110,23 @@ def test_b12x_lse_reduce_honors_token_cap(monkeypatch: pytest.MonkeyPatch):
     assert created["max_batch_size"] == 4
     assert created["channel_id"] == "vllm:eager:dcp"
 
+    monkeypatch.setattr(
+        dcp_alltoall,
+        "_B12X_DCP_ACTIVE_CAPTURE",
+        {id(group.device_group): ("vllm:target:decode", None, ExitStack())},
+    )
+    result = dcp_alltoall._try_b12x_dcp_lse_reduce(
+        out,
+        lse,
+        group,  # type: ignore[arg-type]
+        return_lse=False,
+        is_lse_base_on_e=True,
+        max_batch_size=8192,
+        query_head_dim=64,
+    )
+    assert result is sentinel
+    assert created["channel_id"] == "vllm:target:decode"
+
     out_large = torch.zeros(8, 16, 64, dtype=torch.bfloat16, device="cuda")
     lse_large = torch.zeros(8, 16, dtype=torch.float32, device="cuda")
     result = dcp_alltoall._try_b12x_dcp_lse_reduce(
@@ -1091,6 +1175,20 @@ def test_b12x_query_gather_honors_token_cap(monkeypatch: pytest.MonkeyPatch):
     assert result is sentinel
     assert created["max_batch_size"] == 4
     assert created["channel_id"] == "vllm:eager:dcp"
+
+    monkeypatch.setattr(
+        dcp_alltoall,
+        "_B12X_DCP_ACTIVE_CAPTURE",
+        {id(group.device_group): ("vllm:target:decode", None, ExitStack())},
+    )
+    result = dcp_alltoall._try_b12x_dcp_all_gather_heads(
+        small,
+        group,  # type: ignore[arg-type]
+        max_batch_size=8192,
+        output_head_dim=64,
+    )
+    assert result is sentinel
+    assert created["channel_id"] == "vllm:target:decode"
 
     large = torch.zeros(8, 8, 64, dtype=torch.bfloat16, device="cuda")
     result = dcp_alltoall._try_b12x_dcp_all_gather_heads(

--- a/tests/distributed/test_dcp_a2a.py
+++ b/tests/distributed/test_dcp_a2a.py
@@ -1477,6 +1477,96 @@ def test_b12x_query_gather_requires_env(monkeypatch: pytest.MonkeyPatch):
     assert actual is expected
 
 
+@pytest.mark.skipif(torch.accelerator.device_count() < 1, reason="CUDA is required.")
+def test_b12x_pair_gather_uses_one_pool_operation_at_dcp16(monkeypatch):
+    from vllm.v1.attention.ops import dcp_alltoall
+
+    monkeypatch.setenv("VLLM_USE_B12X_DCP_A2A", "1")
+    received: dict[str, Any] = {}
+    local_first = torch.zeros(2, 224, dtype=torch.bfloat16, device="cuda")
+    local_second = torch.zeros(2, 56, dtype=torch.float32, device="cuda")
+    expected = (
+        torch.empty(2, 224 * 16, dtype=local_first.dtype, device="cuda"),
+        torch.empty(2, 56 * 16, dtype=local_second.dtype, device="cuda"),
+    )
+
+    class _FakePool:
+        def all_gather_pair(self, first, second, *, channel_id):
+            received.update(first=first, second=second, channel_id=channel_id)
+            return expected
+
+    def fake_get_pool(cp_group, **kwargs):
+        received.update(kwargs)
+        return _FakePool()
+
+    monkeypatch.setattr(dcp_alltoall, "_get_b12x_dcp_a2a_pool", fake_get_pool)
+    monkeypatch.setattr(
+        dcp_alltoall,
+        "_b12x_dcp_channel_id",
+        lambda _group: "vllm:target:decode:graph-1",
+    )
+    group = _FakeCPGroup(16, object())  # type: ignore[arg-type]
+
+    actual = dcp_alltoall.dcp_b12x_all_gather_pair(
+        local_first,
+        local_second,
+        group,  # type: ignore[arg-type]
+        max_batch_size=8,
+    )
+
+    assert actual is expected
+    assert received.pop("first") is local_first
+    assert received.pop("second") is local_second
+    assert received.pop("device") == local_first.device
+    assert received == {
+        "channel_id": "vllm:target:decode:graph-1",
+        "total_heads": 16,
+        "head_dim": 672,
+        "query_head_dim": 672,
+        "max_batch_size": 8,
+    }
+    unaligned_first = local_first[:, :223].contiguous()
+    assert (
+        dcp_alltoall._try_b12x_dcp_all_gather_pair(
+            unaligned_first,
+            local_second,
+            group,  # type: ignore[arg-type]
+            max_batch_size=8,
+        )
+        is None
+    )
+
+
+def test_pair_gather_fallback_preserves_tensor_order(monkeypatch):
+    from vllm.v1.attention.ops import dcp_alltoall
+
+    monkeypatch.delenv("VLLM_USE_B12X_DCP_A2A", raising=False)
+    local_first = torch.zeros(2, 8)
+    local_second = torch.ones(2, 4)
+    gathered_first = torch.full((2, 16), 2.0)
+    gathered_second = torch.full((2, 8), 3.0)
+    calls: list[tuple[torch.Tensor, int]] = []
+
+    def gather(value, dim):
+        calls.append((value, dim))
+        return gathered_first if value is local_first else gathered_second
+
+    group = _FakeCPGroup(2, object())  # type: ignore[arg-type]
+    group.all_gather = gather  # type: ignore[attr-defined]
+
+    actual = dcp_alltoall.dcp_b12x_all_gather_pair(
+        local_first,
+        local_second,
+        group,  # type: ignore[arg-type]
+    )
+
+    assert actual[0] is gathered_first
+    assert actual[1] is gathered_second
+    assert len(calls) == 2
+    assert calls[0][0] is local_first and calls[0][1] == -1
+    assert calls[1][0] is local_second and calls[1][1] == -1
+
+
 def test_warmup_skips_unsupported_world_size(monkeypatch: pytest.MonkeyPatch):
     from vllm.v1.attention.ops import dcp_alltoall
 

--- a/tests/distributed/test_dcp_a2a.py
+++ b/tests/distributed/test_dcp_a2a.py
@@ -1064,7 +1064,10 @@ def test_group_capture_forwards_semantic_id_to_custom_allreduce(monkeypatch):
 
 
 @pytest.mark.skipif(torch.accelerator.device_count() < 1, reason="CUDA is required.")
-def test_b12x_lse_reduce_honors_token_cap(monkeypatch: pytest.MonkeyPatch):
+@pytest.mark.parametrize("world_size", [4, 16])
+def test_b12x_lse_reduce_honors_token_cap(
+    monkeypatch: pytest.MonkeyPatch, world_size: int
+):
     from vllm.v1.attention.ops import dcp_alltoall
 
     monkeypatch.setenv("VLLM_USE_B12X_DCP_A2A", "1")
@@ -1092,7 +1095,7 @@ def test_b12x_lse_reduce_honors_token_cap(monkeypatch: pytest.MonkeyPatch):
         return _FakePool()
 
     monkeypatch.setattr(dcp_alltoall, "_get_b12x_dcp_a2a_pool", fake_get_pool)
-    group = _FakeCPGroup(4, None)  # type: ignore[arg-type]
+    group = _FakeCPGroup(world_size, None)  # type: ignore[arg-type]
 
     out = torch.zeros(4, 16, 64, dtype=torch.bfloat16, device="cuda")
     lse = torch.zeros(4, 16, dtype=torch.float32, device="cuda")
@@ -1143,7 +1146,10 @@ def test_b12x_lse_reduce_honors_token_cap(monkeypatch: pytest.MonkeyPatch):
 
 
 @pytest.mark.skipif(torch.accelerator.device_count() < 1, reason="CUDA is required.")
-def test_b12x_query_gather_honors_token_cap(monkeypatch: pytest.MonkeyPatch):
+@pytest.mark.parametrize("world_size", [4, 16])
+def test_b12x_query_gather_honors_token_cap(
+    monkeypatch: pytest.MonkeyPatch, world_size: int
+):
     from vllm.v1.attention.ops import dcp_alltoall
 
     monkeypatch.setenv("VLLM_USE_B12X_DCP_A2A", "1")
@@ -1163,7 +1169,7 @@ def test_b12x_query_gather_honors_token_cap(monkeypatch: pytest.MonkeyPatch):
         return _FakePool()
 
     monkeypatch.setattr(dcp_alltoall, "_get_b12x_dcp_a2a_pool", fake_get_pool)
-    group = _FakeCPGroup(4, None)  # type: ignore[arg-type]
+    group = _FakeCPGroup(world_size, None)  # type: ignore[arg-type]
 
     small = torch.zeros(4, 8, 64, dtype=torch.bfloat16, device="cuda")
     result = dcp_alltoall._try_b12x_dcp_all_gather_heads(
@@ -1320,6 +1326,40 @@ def test_warmup_skips_unsupported_world_size(monkeypatch: pytest.MonkeyPatch):
         head_dim=512,
         query_head_dim=576,
     )
+
+
+def test_warmup_accepts_dcp16_geometry(monkeypatch: pytest.MonkeyPatch):
+    from vllm.v1.attention.ops import dcp_alltoall
+
+    monkeypatch.setenv("VLLM_USE_B12X_DCP_A2A", "1")
+    calls: list[tuple[str, tuple[int, ...]]] = []
+
+    def gather(local_input, *args, **kwargs):
+        calls.append(("gather", tuple(local_input.shape)))
+        return torch.empty(1)
+
+    def reduce(partial_output, *args, **kwargs):
+        calls.append(("reduce", tuple(partial_output.shape)))
+        return torch.empty(1)
+
+    monkeypatch.setattr(dcp_alltoall, "_try_b12x_dcp_all_gather_heads", gather)
+    monkeypatch.setattr(dcp_alltoall, "_try_b12x_dcp_lse_reduce", reduce)
+    group = _FakeCPGroup(16, None)  # type: ignore[arg-type]
+
+    dcp_alltoall.warmup_b12x_dcp_a2a(
+        group,  # type: ignore[arg-type]
+        device=torch.device("cpu"),
+        dtype=torch.bfloat16,
+        max_batch_size=8192,
+        total_heads=96,
+        head_dim=512,
+        query_head_dim=576,
+    )
+
+    assert calls == [
+        ("gather", (1, 6, 576)),
+        ("reduce", (1, 96, 512)),
+    ]
 
 
 class TestPackedA2AKernels:

--- a/tests/distributed/test_dcp_a2a.py
+++ b/tests/distributed/test_dcp_a2a.py
@@ -1302,6 +1302,86 @@ def test_b12x_query_gather_honors_token_cap(
 
 
 @pytest.mark.skipif(torch.accelerator.device_count() < 1, reason="CUDA is required.")
+def test_b12x_query_gather_supports_fp8_caller_output(monkeypatch):
+    from vllm.v1.attention.ops import dcp_alltoall
+
+    received: dict[str, Any] = {}
+
+    class _FakePool:
+        def all_gather_heads(self, local_input, *, out, channel_id):
+            received.update(input=local_input, out=out, channel_id=channel_id)
+            return out
+
+    def fake_get_pool(
+        cp_group, *, device, total_heads, head_dim, query_head_dim, max_batch_size
+    ):
+        received.update(
+            total_heads=total_heads,
+            head_dim=head_dim,
+            query_head_dim=query_head_dim,
+            max_batch_size=max_batch_size,
+        )
+        return _FakePool()
+
+    monkeypatch.setattr(dcp_alltoall, "_get_b12x_dcp_a2a_pool", fake_get_pool)
+    group = _FakeCPGroup(4, object())  # type: ignore[arg-type]
+    local_input = torch.zeros(2, 2, 64, dtype=torch.float8_e4m3fn, device="cuda")
+    out = torch.empty(2, 8, 64, dtype=local_input.dtype, device=local_input.device)
+
+    actual = dcp_alltoall._try_b12x_dcp_all_gather_heads(
+        local_input,
+        group,  # type: ignore[arg-type]
+        max_batch_size=8,
+        output_head_dim=512,
+        out=out,
+    )
+
+    assert actual is out
+    assert received.pop("input") is local_input
+    assert received.pop("out") is out
+    assert received == {
+        "channel_id": "vllm:eager:dcp",
+        "total_heads": 8,
+        "head_dim": 512,
+        "query_head_dim": 64,
+        "max_batch_size": 8,
+    }
+
+    unaligned = torch.zeros(
+        2, 2, 24, dtype=torch.float8_e4m3fn, device=local_input.device
+    )
+    assert (
+        dcp_alltoall._try_b12x_dcp_all_gather_heads(
+            unaligned,
+            group,  # type: ignore[arg-type]
+            max_batch_size=8,
+            output_head_dim=512,
+        )
+        is None
+    )
+
+
+def test_query_gather_fallback_copies_into_caller_output(monkeypatch):
+    from vllm.v1.attention.ops import dcp_alltoall
+
+    monkeypatch.delenv("VLLM_USE_B12X_DCP_A2A", raising=False)
+    local_input = torch.zeros(2, 2, 8, dtype=torch.bfloat16)
+    gathered = torch.arange(64, dtype=torch.bfloat16).reshape(2, 4, 8)
+    out = torch.empty_like(gathered)
+    group = _FakeCPGroup(2, object())  # type: ignore[arg-type]
+    group.all_gather = lambda _value, dim: gathered  # type: ignore[attr-defined]
+
+    actual = dcp_alltoall.dcp_b12x_all_gather_heads(
+        local_input,
+        group,  # type: ignore[arg-type]
+        out=out,
+    )
+
+    assert actual is out
+    torch.testing.assert_close(actual, gathered)
+
+
+@pytest.mark.skipif(torch.accelerator.device_count() < 1, reason="CUDA is required.")
 def test_b12x_lse_reduce_preserves_supported_layouts(monkeypatch: pytest.MonkeyPatch):
     """Preserve head-major input while materializing legacy head slices."""
     from vllm.v1.attention.ops import dcp_alltoall

--- a/tests/distributed/test_dcp_a2a.py
+++ b/tests/distributed/test_dcp_a2a.py
@@ -467,6 +467,55 @@ def test_b12x_dispatch_bypasses_packed_nccl(monkeypatch: pytest.MonkeyPatch):
     }
 
 
+def test_b12x_large_batch_uses_configured_ag_rs(monkeypatch: pytest.MonkeyPatch):
+    from vllm.v1.attention.ops import common, dcp_alltoall
+
+    monkeypatch.setenv("VLLM_USE_B12X_DCP_A2A", "1")
+    monkeypatch.setenv("VLLM_DCP_A2A_MAX_TOKENS", "4")
+    monkeypatch.setenv("VLLM_DCP_A2A_LARGE_BACKEND", "ag_rs")
+    partial_output = torch.zeros(5, 4, 8, dtype=torch.bfloat16)
+    partial_lse = torch.zeros(5, 4, dtype=torch.float32)
+    expected = torch.ones(5, 2, 8, dtype=torch.bfloat16)
+    captured: dict[str, Any] = {}
+    group = _FakeCPGroup(2, object())  # type: ignore[arg-type]
+
+    monkeypatch.setattr(
+        dcp_alltoall,
+        "_try_b12x_dcp_lse_reduce",
+        lambda *args, **kwargs: None,
+    )
+
+    def fake_ag_rs(output, lse, cp_group, **kwargs):
+        captured.update(output=output, lse=lse, group=cp_group, **kwargs)
+        return expected
+
+    monkeypatch.setattr(common, "cp_lse_ag_out_rs", fake_ag_rs)
+    monkeypatch.setattr(
+        dcp_alltoall.dist,
+        "all_to_all_single",
+        lambda *args, **kwargs: pytest.fail("packed NCCL A2A must not run"),
+    )
+
+    actual = dcp_alltoall.dcp_a2a_lse_reduce(
+        partial_output,
+        partial_lse,
+        group,  # type: ignore[arg-type]
+        use_b12x=True,
+        b12x_max_batch_size=4,
+    )
+
+    assert actual is expected
+    assert captured == {
+        "output": partial_output,
+        "lse": partial_lse,
+        "group": group,
+        "ctx": None,
+        "return_lse": False,
+        "is_lse_base_on_e": True,
+        "head_major_output": True,
+    }
+
+
 def test_packed_a2a_capture_buffers_stay_live_per_shape(
     monkeypatch: pytest.MonkeyPatch,
 ):

--- a/tests/distributed/test_dcp_a2a.py
+++ b/tests/distributed/test_dcp_a2a.py
@@ -766,6 +766,45 @@ def test_b12x_dcp_capture_selects_only_current_group_pools(monkeypatch):
     ]
 
 
+def test_b12x_dcp_capture_reuses_nested_shared_group_scope(monkeypatch):
+    from vllm.v1.attention.ops import dcp_alltoall
+
+    events: list[str] = []
+
+    class _FakePool:
+        @contextmanager
+        def capture(self, *, stream, channel_id):
+            events.append("enter")
+            try:
+                yield
+            finally:
+                events.append("exit")
+
+    device_group = object()
+    tp_group = _FakeCPGroup(16, device_group)  # type: ignore[arg-type]
+    dcp_group = _FakeCPGroup(16, device_group)  # type: ignore[arg-type]
+    stream = object()
+    key = (id(device_group), 0, 64, 512, 576, 64)
+    monkeypatch.setattr(dcp_alltoall, "_B12X_DCP_A2A_POOLS", {key: _FakePool()})
+    monkeypatch.setattr(dcp_alltoall, "_B12X_DCP_ACTIVE_CAPTURE", {})
+
+    with (
+        dcp_alltoall.capture_b12x_dcp_a2a(
+            tp_group,  # type: ignore[arg-type]
+            stream,
+            channel_id="vllm:target:decode",
+        ),
+        dcp_alltoall.capture_b12x_dcp_a2a(
+            dcp_group,  # type: ignore[arg-type]
+            stream,
+            channel_id="vllm:target:decode",
+        ),
+    ):
+        events.append("body")
+
+    assert events == ["enter", "body", "exit"]
+
+
 def test_b12x_dcp_capture_rejects_missing_semantic_id(monkeypatch):
     from vllm.v1.attention.ops import dcp_alltoall
 

--- a/tests/distributed/test_dcp_a2a.py
+++ b/tests/distributed/test_dcp_a2a.py
@@ -369,6 +369,52 @@ class TestLSEWeightedCombine:
         assert _dcp_a2a_lse_pack_dim(torch.float32) == 1
 
 
+def test_a2a_converts_activation_dtype_lse_before_packing(monkeypatch):
+    from vllm.v1.attention.ops import dcp_alltoall
+
+    output = torch.zeros(2, 4, 8, dtype=torch.bfloat16)
+    lse = torch.zeros(2, 4, dtype=torch.bfloat16)
+    send = torch.empty(2, 2, 2, 10, dtype=torch.bfloat16)
+    recv = torch.empty_like(send)
+    result = torch.empty(2, 2, 8, dtype=torch.bfloat16)
+    received: dict[str, torch.dtype] = {}
+
+    monkeypatch.setattr(
+        dcp_alltoall,
+        "_dcp_a2a_send_recv_buffers",
+        lambda *args, **kwargs: (send, recv),
+    )
+
+    def record_pack(_cp_attn_out, cp_attn_lse, *_args, **_kwargs):
+        received["dtype"] = cp_attn_lse.dtype
+
+    class _Work:
+        def wait(self):
+            return None
+
+    monkeypatch.setattr(dcp_alltoall, "_dcp_a2a_pack_send", record_pack)
+    monkeypatch.setattr(
+        dcp_alltoall.dist,
+        "all_to_all_single",
+        lambda *args, **kwargs: _Work(),
+    )
+    monkeypatch.setattr(
+        dcp_alltoall,
+        "_dcp_a2a_unpack_combine",
+        lambda *args, **kwargs: result,
+    )
+    group = _FakeCPGroup(2, object())  # type: ignore[arg-type]
+
+    actual = dcp_alltoall.dcp_a2a_lse_reduce(
+        output,
+        lse,
+        group,  # type: ignore[arg-type]
+    )
+
+    assert actual is result
+    assert received == {"dtype": torch.float32}
+
+
 def test_b12x_dispatch_bypasses_packed_nccl(monkeypatch: pytest.MonkeyPatch):
     from vllm.v1.attention.ops import dcp_alltoall
 
@@ -1387,7 +1433,7 @@ class TestPackedA2AKernels:
         world_size, B, h_per_rank, D = 4, 7, 2, 32
         H = world_size * h_per_rank
         cp_attn_out = torch.randn(B, H, D, device=device, dtype=dtype)
-        cp_attn_lse = torch.randn(B, H, device=device, dtype=dtype)
+        cp_attn_lse = torch.randn(B, H, device=device, dtype=torch.float32)
         lse_pack_dim = _dcp_a2a_lse_pack_dim(dtype)
         send_buffer = torch.empty(
             (world_size, B, h_per_rank, D + lse_pack_dim),
@@ -1583,7 +1629,7 @@ def _distributed_packed_a2a_worker(env: dict[str, str]) -> None:
         lses = torch.stack(
             [t[:, rank * h_per_rank : (rank + 1) * h_per_rank] for t in gathered_lse],
             dim=0,
-        )
+        ).float()
         from vllm.v1.attention.ops.dcp_alltoall import _lse_weighted_combine
 
         expected_out, expected_lse = _lse_weighted_combine(

--- a/tests/distributed/test_dcp_a2a.py
+++ b/tests/distributed/test_dcp_a2a.py
@@ -749,23 +749,25 @@ def test_profile_channel_checkpoint_rolls_back_all_b12x_transports(monkeypatch):
             events.append(("rollback-tp", checkpoint))
 
     class _FakeGroup:
-        def __init__(self, *, world_size, communicator=None):
+        def __init__(self, name, *, world_size, communicator=None):
+            self.name = name
             self.world_size = world_size
+            self.device_group = object()
             self.device_communicator = type(
                 "DeviceCommunicator", (), {"ca_comm": communicator}
             )()
 
     communicator = _FakeCommunicator()
-    tp_group = _FakeGroup(world_size=8, communicator=communicator)
-    pp_group = _FakeGroup(world_size=1, communicator=communicator)
-    dcp_group = _FakeGroup(world_size=2)
+    tp_group = _FakeGroup("tp", world_size=8, communicator=communicator)
+    pp_group = _FakeGroup("pp", world_size=1, communicator=communicator)
+    dcp_group = _FakeGroup("dcp", world_size=2)
     monkeypatch.setattr(parallel_state, "_TP", tp_group)
     monkeypatch.setattr(parallel_state, "_PP", pp_group)
     monkeypatch.setattr(parallel_state, "_DCP", dcp_group)
 
     def checkpoint_dcp(group):
-        events.append("checkpoint-dcp")
-        return "dcp-checkpoint"
+        events.append(("checkpoint-pool", group.name))
+        return f"{group.name}-pool-checkpoint"
 
     monkeypatch.setattr(
         dcp_alltoall,
@@ -783,13 +785,46 @@ def test_profile_channel_checkpoint_rolls_back_all_b12x_transports(monkeypatch):
 
     assert events == [
         "checkpoint-tp",
-        "checkpoint-dcp",
-        ("rollback-dcp", "dcp-checkpoint"),
+        ("checkpoint-pool", "tp"),
+        ("checkpoint-pool", "dcp"),
+        ("rollback-dcp", "dcp-pool-checkpoint"),
+        ("rollback-dcp", "tp-pool-checkpoint"),
         ("rollback-tp", "tp-checkpoint"),
     ]
 
 
-def test_global_graph_capture_enters_b12x_dcp_pool(monkeypatch):
+def test_profile_channel_checkpoint_deduplicates_shared_b12x_pool(monkeypatch):
+    from vllm.distributed import parallel_state
+    from vllm.v1.attention.ops import dcp_alltoall
+
+    class _FakeGroup:
+        def __init__(self, name, *, world_size, device_group):
+            self.name = name
+            self.world_size = world_size
+            self.device_group = device_group
+            self.device_communicator = type(
+                "DeviceCommunicator", (), {"ca_comm": None}
+            )()
+
+    events: list[str] = []
+    shared_device_group = object()
+    tp_group = _FakeGroup("tp", world_size=16, device_group=shared_device_group)
+    dcp_group = _FakeGroup("dcp", world_size=16, device_group=shared_device_group)
+    monkeypatch.setattr(parallel_state, "_TP", tp_group)
+    monkeypatch.setattr(parallel_state, "_PP", None)
+    monkeypatch.setattr(parallel_state, "_DCP", dcp_group)
+    monkeypatch.setattr(
+        dcp_alltoall,
+        "checkpoint_b12x_dcp_a2a_channels",
+        lambda group: events.append(group.name) or group.name,
+    )
+
+    parallel_state.checkpoint_b12x_graph_channels()
+
+    assert events == ["tp"]
+
+
+def test_global_graph_capture_enters_b12x_tp_and_dcp_pools(monkeypatch):
     from vllm.distributed import parallel_state
     from vllm.v1.attention.ops import dcp_alltoall
 
@@ -800,6 +835,7 @@ def test_global_graph_capture_enters_b12x_dcp_pool(monkeypatch):
 
         def __init__(self, name):
             self.name = name
+            self.device_group = object()
 
         @contextmanager
         def graph_capture(self, context):
@@ -841,6 +877,12 @@ def test_global_graph_capture_enters_b12x_dcp_pool(monkeypatch):
         ("enter-group", "dcp", "vllm:target:profile"),
         (
             "enter-b12x",
+            tp_group,
+            stream,
+            "vllm:target:profile",
+        ),
+        (
+            "enter-b12x",
             dcp_group,
             stream,
             "vllm:target:profile",
@@ -851,10 +893,58 @@ def test_global_graph_capture_enters_b12x_dcp_pool(monkeypatch):
             stream,
             "vllm:target:profile",
         ),
+        (
+            "exit-b12x",
+            tp_group,
+            stream,
+            "vllm:target:profile",
+        ),
         ("exit-group", "dcp", "vllm:target:profile"),
         ("exit-group", "pp", "vllm:target:profile"),
         ("exit-group", "tp", "vllm:target:profile"),
     ]
+
+
+def test_global_graph_capture_keeps_distinct_b12x_coordinator_scopes(monkeypatch):
+    from vllm.distributed import parallel_state
+    from vllm.v1.attention.ops import dcp_alltoall
+
+    class _FakeGroup:
+        world_size = 16
+
+        def __init__(self, name, device_group):
+            self.name = name
+            self.device_group = device_group
+
+        @contextmanager
+        def graph_capture(self, context):
+            yield context
+
+    shared_device_group = object()
+    tp_group = _FakeGroup("tp", shared_device_group)
+    dcp_group = _FakeGroup("dcp", shared_device_group)
+    pp_group = _FakeGroup("pp", object())
+    entered_pools: list[str] = []
+
+    @contextmanager
+    def fake_b12x_capture(group, selected_stream, *, channel_id):
+        entered_pools.append(group.name)
+        yield
+
+    monkeypatch.setattr(parallel_state, "_DCP", dcp_group)
+    monkeypatch.setattr(parallel_state, "get_tp_group", lambda: tp_group)
+    monkeypatch.setattr(parallel_state, "get_pp_group", lambda: pp_group)
+    monkeypatch.setattr(parallel_state, "get_dcp_group", lambda: dcp_group)
+    monkeypatch.setattr(dcp_alltoall, "capture_b12x_dcp_a2a", fake_b12x_capture)
+    context = parallel_state.GraphCaptureContext(  # type: ignore[arg-type]
+        object(),
+        channel_id="vllm:target:decode",
+    )
+
+    with parallel_state.graph_capture(torch.device("cpu"), context):
+        pass
+
+    assert entered_pools == ["tp", "dcp"]
 
 
 def test_group_capture_forwards_semantic_id_to_custom_allreduce(monkeypatch):

--- a/tests/distributed/test_inplace_allreduce.py
+++ b/tests/distributed/test_inplace_allreduce.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+import vllm.distributed.communication_op as communication_op
+from vllm.distributed.device_communicators.cuda_communicator import CudaCommunicator
+from vllm.distributed.parallel_state import GroupCoordinator
+
+
+def _make_group(world_size: int) -> GroupCoordinator:
+    group = GroupCoordinator.__new__(GroupCoordinator)
+    group.world_size = world_size
+    group.device_communicator = None
+    return group
+
+
+def test_tensor_model_parallel_all_reduce_in_place_delegates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tensor = torch.arange(4, dtype=torch.float32)
+    group = Mock()
+
+    def reduce_in_place(value: torch.Tensor) -> torch.Tensor:
+        value.add_(1)
+        return value
+
+    group.all_reduce_in_place.side_effect = reduce_in_place
+    monkeypatch.setattr(communication_op, "get_tp_group", lambda: group)
+
+    result = communication_op.tensor_model_parallel_all_reduce_in_place(tensor)
+
+    assert result is tensor
+    torch.testing.assert_close(tensor, torch.arange(4, dtype=torch.float32) + 1)
+    group.all_reduce_in_place.assert_called_once_with(tensor)
+
+
+def test_group_all_reduce_in_place_preserves_single_rank_storage() -> None:
+    tensor = torch.arange(4)
+    group = _make_group(world_size=1)
+
+    assert group.all_reduce_in_place(tensor) is tensor
+
+
+def test_group_all_reduce_in_place_delegates_to_device_communicator() -> None:
+    tensor = torch.arange(4)
+    group = _make_group(world_size=2)
+    communicator = Mock()
+    communicator.all_reduce_in_place.return_value = tensor
+    group.device_communicator = communicator
+
+    result = group.all_reduce_in_place(tensor)
+
+    assert result is tensor
+    communicator.all_reduce_in_place.assert_called_once_with(tensor)
+
+
+def test_cuda_all_reduce_in_place_uses_pynccl_alias() -> None:
+    tensor = torch.arange(4, dtype=torch.float32)
+    communicator = CudaCommunicator.__new__(CudaCommunicator)
+    pynccl = Mock()
+    pynccl.disabled = False
+
+    def reduce(value: torch.Tensor, *, out_tensor: torch.Tensor) -> torch.Tensor:
+        assert value is tensor
+        assert out_tensor is tensor
+        out_tensor.add_(2)
+        return out_tensor
+
+    pynccl.all_reduce.side_effect = reduce
+    communicator.pynccl_comm = pynccl
+
+    result = communicator.all_reduce_in_place(tensor)
+
+    assert result is tensor
+    torch.testing.assert_close(tensor, torch.arange(4, dtype=torch.float32) + 2)
+
+
+def test_cuda_all_reduce_in_place_uses_torch_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tensor = torch.arange(4, dtype=torch.float32)
+    communicator = CudaCommunicator.__new__(CudaCommunicator)
+    communicator.pynccl_comm = None
+    communicator.device_group = object()
+
+    def reduce(value: torch.Tensor, *, group: object) -> None:
+        assert value is tensor
+        assert group is communicator.device_group
+        value.add_(3)
+
+    monkeypatch.setattr(torch.distributed, "all_reduce", reduce)
+
+    result = communicator.all_reduce_in_place(tensor)
+
+    assert result is tensor
+    torch.testing.assert_close(tensor, torch.arange(4, dtype=torch.float32) + 3)

--- a/vllm/distributed/communication_op.py
+++ b/vllm/distributed/communication_op.py
@@ -14,6 +14,11 @@ def tensor_model_parallel_all_reduce(input_: torch.Tensor) -> torch.Tensor:
     return get_tp_group().all_reduce(input_)
 
 
+def tensor_model_parallel_all_reduce_in_place(input_: torch.Tensor) -> torch.Tensor:
+    """All-reduce a dead input tensor without allocating an output tensor."""
+    return get_tp_group().all_reduce_in_place(input_)
+
+
 def tensor_model_parallel_all_gather(
     input_: torch.Tensor, dim: int = -1
 ) -> torch.Tensor:

--- a/vllm/distributed/device_communicators/base_device_communicator.py
+++ b/vllm/distributed/device_communicators/base_device_communicator.py
@@ -220,6 +220,11 @@ class DeviceCommunicatorBase:
         dist.all_reduce(input_, group=self.device_group)
         return input_
 
+    def all_reduce_in_place(self, input_: torch.Tensor) -> torch.Tensor:
+        """All-reduce while allowing the input storage to hold the result."""
+        dist.all_reduce(input_, group=self.device_group)
+        return input_
+
     def checkpoint_prepare(self) -> None:
         """Prepare reclaimable communicator state for checkpoint (default: no-op)."""
 

--- a/vllm/distributed/device_communicators/cuda_communicator.py
+++ b/vllm/distributed/device_communicators/cuda_communicator.py
@@ -348,6 +348,22 @@ class CudaCommunicator(DeviceCommunicatorBase):
             torch.distributed.all_reduce(out, group=self.device_group)
         return out
 
+    def all_reduce_in_place(self, input_: torch.Tensor) -> torch.Tensor:
+        """Run NCCL with the same tensor as its input and output.
+
+        Functional custom operators cannot return aliased mutable storage, so
+        callers must use this method only when the source tensor is dead after
+        the collective.
+        """
+        pynccl_comm = self.pynccl_comm
+        if pynccl_comm is None or pynccl_comm.disabled:
+            torch.distributed.all_reduce(input_, group=self.device_group)
+            return input_
+        out = pynccl_comm.all_reduce(input_, out_tensor=input_)
+        if out is None:
+            torch.distributed.all_reduce(input_, group=self.device_group)
+        return input_
+
     def custom_all_gather(self, input_: torch.Tensor) -> torch.Tensor | None:
         ca_comm = self.ca_comm
         if ca_comm is None:

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -41,6 +41,9 @@ logger = init_logger(__name__)
 # fails closed if the same logical owner is rebound to a second eager stream.
 _B12X_PCIE_EAGER_CHANNEL_ID = "vllm:eager:allreduce"
 _B12X_PCIE_MAX_CONCURRENT_CHANNELS = 2
+# B12X TP12/TP16 uses one ordered bounded-degree channel. Distinct graph
+# owners serialize their collectives through that channel.
+_B12X_PCIE_SINGLE_CHANNEL_WORLD_SIZES = frozenset((12, 16))
 
 
 def _get_pcie_allreduce_backend() -> str:
@@ -572,7 +575,15 @@ class CustomAllreduce:
                     eager_buffer_bytes=pcie_oneshot_buffer_size,
                     max_size=pcie_oneshot_buffer_size,
                     single_channel=pcie_single_channel,
-                    max_concurrent_channels=_B12X_PCIE_MAX_CONCURRENT_CHANNELS,
+                    max_concurrent_channels=(
+                        1
+                        if pcie_single_channel
+                        or (
+                            pcie_backend == "b12x"
+                            and world_size in _B12X_PCIE_SINGLE_CHANNEL_WORLD_SIZES
+                        )
+                        else _B12X_PCIE_MAX_CONCURRENT_CHANNELS
+                    ),
                 )
                 if not pcie_single_channel:
                     pcie_runtime.prepare_channels((_B12X_PCIE_EAGER_CHANNEL_ID,))

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -1380,3 +1380,23 @@ def get_b12x_pcie_allreduce() -> CustomAllreduce | None:
     ):
         return custom_allreduce
     return None
+
+
+def get_active_b12x_pcie_allreduce() -> CustomAllreduce | None:
+    """Return the active TP B12X runtime for any supported algorithm."""
+    try:
+        from vllm.distributed.parallel_state import get_tp_group
+
+        device_communicator = get_tp_group().device_communicator
+    except (AssertionError, RuntimeError):
+        return None
+    if device_communicator is None:
+        return None
+    custom_allreduce = getattr(device_communicator, "ca_comm", None)
+    if (
+        isinstance(custom_allreduce, CustomAllreduce)
+        and not custom_allreduce.disabled
+        and custom_allreduce._pcie_runtime is not None
+    ):
+        return custom_allreduce
+    return None

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -118,14 +118,12 @@ def _b12x_pcie_dma_min_bytes() -> int | None:
 
 
 @lru_cache(maxsize=1)
-def _load_b12x_pcie_oneshot_pool() -> Any | None:
+def _load_b12x_pcie_allreduce() -> Any | None:
     try:
-        from b12x.comm.pcie import (
-            OneshotAllReducePool as PCIeOneshotAllReducePool,
-        )
+        from b12x.comm.pcie import AllReduce as PCIeAllReduce
     except Exception:
         return None
-    return PCIeOneshotAllReducePool
+    return PCIeAllReduce
 
 
 @lru_cache(maxsize=1)
@@ -515,12 +513,12 @@ class CustomAllreduce:
                     physical_device_ids,
                 )
                 return
-            pool_cls = (
-                _load_b12x_pcie_oneshot_pool()
+            runtime_cls = (
+                _load_b12x_pcie_allreduce()
                 if pcie_backend == "b12x"
                 else _load_flashinfer_pcie_oneshot_pool()
             )
-            if pool_cls is None:
+            if runtime_cls is None:
                 logger.warning(
                     "%s PCIe custom allreduce was requested, but its runtime "
                     "is unavailable.",
@@ -568,7 +566,7 @@ class CustomAllreduce:
             pcie_runtime = None
             pcie_init_error: Exception | None = None
             try:
-                pcie_runtime = pool_cls.from_exchange_group(
+                pcie_runtime = runtime_cls.from_exchange_group(
                     exchange_group=self.nccl_group,
                     device=self.device,
                     eager_buffer_bytes=pcie_oneshot_buffer_size,
@@ -614,14 +612,25 @@ class CustomAllreduce:
             # Prefill-size DMA allreduce alongside the oneshot. A deployment
             # preflight can tune its crossover or disable it when lossless DMA
             # never beats NCCL on the selected PCIe topology.
+            supports_all_peer_auxiliary = bool(
+                getattr(pcie_runtime, "supports_all_peer_auxiliary", True)
+            )
             dma_min_bytes = (
-                _b12x_pcie_dma_min_bytes() if pcie_backend == "b12x" else None
+                _b12x_pcie_dma_min_bytes()
+                if pcie_backend == "b12x" and supports_all_peer_auxiliary
+                else None
             )
             dma_cls = None if dma_min_bytes is None else _load_b12x_pcie_dma()
             if pcie_backend != "b12x":
                 logger.info(
                     "FlashInfer PCIe IPC handles only tuned one-shot shapes; "
                     "larger allreduces stay on PyNCCL."
+                )
+            elif not supports_all_peer_auxiliary:
+                logger.info(
+                    "B12X PCIe %s all-reduce does not expose the all-peer "
+                    "topology required by DMA; larger tensors use PyNCCL.",
+                    getattr(pcie_runtime, "algorithm", "bounded-degree"),
                 )
             elif dma_min_bytes is None:
                 logger.info(
@@ -678,8 +687,9 @@ class CustomAllreduce:
             if rank == 0:
                 logger.info(
                     "Configured %s PCIe crossovers: "
-                    "oneshot max=%d, fused max=%d, DMA min=%s.",
+                    "algorithm=%s, allreduce max=%d, fused max=%d, DMA min=%s.",
                     pcie_backend,
+                    getattr(pcie_runtime, "algorithm", "oneshot"),
                     self._pcie_allreduce_max_size,
                     self._pcie_fused_add_rms_norm_max_size,
                     dma_min_bytes if dma_min_bytes is not None else "off",
@@ -1017,6 +1027,8 @@ class CustomAllreduce:
         if self._pcie_runtime is not None:
             if self._pcie_backend_name == "flashinfer-ipc":
                 return "FLASHINFER_PCIE_IPC"
+            if getattr(self._pcie_runtime, "algorithm", "oneshot") != "oneshot":
+                return "B12X_PCIE_HIERARCHICAL"
             if self._pcie_dma is not None:
                 return "B12X_PCIE_ONESHOT_DMA"
             return "B12X_PCIE_ONESHOT"

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -1606,18 +1606,30 @@ def checkpoint_b12x_graph_channels() -> tuple[tuple[Callable[[Any], None], Any],
         if checkpoint is not None:
             checkpoints.append((rollback_fn, checkpoint))
 
-    if _DCP is not None and _DCP.world_size > 1:
+    b12x_pool_groups: list[GroupCoordinator] = []
+    seen_device_groups: set[int] = set()
+    for group in (_TP, _DCP):
+        if group is None or group.world_size <= 1:
+            continue
+        group_id = id(group.device_group)
+        if group_id in seen_device_groups:
+            continue
+        seen_device_groups.add(group_id)
+        b12x_pool_groups.append(group)
+
+    if b12x_pool_groups:
         from vllm.v1.attention.ops.dcp_alltoall import (
             checkpoint_b12x_dcp_a2a_channels,
             rollback_b12x_dcp_a2a_channels,
         )
 
-        checkpoints.append(
-            (
-                rollback_b12x_dcp_a2a_channels,
-                checkpoint_b12x_dcp_a2a_channels(_DCP),
+        for group in b12x_pool_groups:
+            checkpoints.append(
+                (
+                    rollback_b12x_dcp_a2a_channels,
+                    checkpoint_b12x_dcp_a2a_channels(group),
+                )
             )
-        )
     return tuple(checkpoints)
 
 
@@ -1721,15 +1733,25 @@ def graph_capture(
         if _DCP is not None and get_dcp_group().world_size > 1
         else nullcontext()
     )
+    from vllm.v1.attention.ops.dcp_alltoall import capture_b12x_dcp_a2a
+
+    maybe_b12x_tp_capture: contextlib.AbstractContextManager[Any]
+    if get_tp_group().world_size > 1:
+        # Tensor-parallel projection gathers use the generic B12X PCIe pool.
+        # Bind that pool to the graph owner just like the attention DCP pool.
+        maybe_b12x_tp_capture = capture_b12x_dcp_a2a(
+            get_tp_group(),
+            context.stream,
+            channel_id=context.channel_id,
+        )
+    else:
+        maybe_b12x_tp_capture = nullcontext()
+
     maybe_b12x_dcp_capture: contextlib.AbstractContextManager[Any]
     if _DCP is not None and get_dcp_group().world_size > 1:
-        # Import locally to avoid making distributed initialization depend on
-        # attention modules. The helper is a no-op until DCP warmup creates a
-        # B12X pool for this process group.
-        from vllm.v1.attention.ops.dcp_alltoall import capture_b12x_dcp_a2a
-
+        dcp_group = get_dcp_group()
         maybe_b12x_dcp_capture = capture_b12x_dcp_a2a(
-            get_dcp_group(),
+            dcp_group,
             context.stream,
             channel_id=context.channel_id,
         )
@@ -1739,6 +1761,7 @@ def graph_capture(
         get_tp_group().graph_capture(context),
         get_pp_group().graph_capture(context),
         maybe_dcp_capture,
+        maybe_b12x_tp_capture,
         maybe_b12x_dcp_capture,
     ):
         yield context

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -687,6 +687,14 @@ class GroupCoordinator:
         else:
             return self._all_reduce_out_place(input_)
 
+    def all_reduce_in_place(self, input_: torch.Tensor) -> torch.Tensor:
+        """All-reduce a tensor whose input storage may hold the result."""
+        if self.world_size == 1:
+            return input_
+        if self.device_communicator is None:
+            raise ValueError("No device communicator found")
+        return self.device_communicator.all_reduce_in_place(input_)
+
     def _all_reduce_out_place(self, input_: torch.Tensor) -> torch.Tensor:
         if self.device_communicator is None:
             raise ValueError("No device communicator found")

--- a/vllm/v1/attention/ops/dcp_alltoall.py
+++ b/vllm/v1/attention/ops/dcp_alltoall.py
@@ -48,6 +48,7 @@ _B12X_DCP_MAX_CONCURRENT_CHANNELS = 2
 # its first operation. Each entry is keyed by the process-group identity and
 # owns the graph's semantic channel, stream, and cleanup stack.
 _B12X_DCP_ACTIVE_CAPTURE: dict[int, tuple[str, Any, ExitStack]] = {}
+_B12X_DCP_WORLD_SIZES = (2, 4, 8, 16)
 _DCP_A2A_GRAPH_BUFFERS: dict[
     tuple[tuple[int, ...], torch.device, torch.dtype],
     tuple[torch.Tensor, torch.Tensor],
@@ -289,7 +290,7 @@ def _try_b12x_dcp_lse_reduce(
         or not cp_attn_out.is_cuda
         or cp_attn_out.dtype not in (torch.float16, torch.bfloat16)
         or cp_attn_lse.dtype != torch.float32
-        or world_size not in (2, 4, 8)
+        or world_size not in _B12X_DCP_WORLD_SIZES
         or cp_attn_out.ndim != 3
         or cp_attn_lse.shape != cp_attn_out.shape[:2]
     ):
@@ -372,7 +373,7 @@ def _try_b12x_dcp_all_gather_heads(
     if (
         not local_input.is_cuda
         or local_input.dtype not in (torch.float16, torch.bfloat16)
-        or world_size not in (2, 4, 8)
+        or world_size not in _B12X_DCP_WORLD_SIZES
         or local_input.ndim != 3
         or not local_input.is_contiguous()
     ):
@@ -447,12 +448,12 @@ def warmup_b12x_dcp_a2a(
     """Create and exercise the B12X DCP channel before CUDA graph capture."""
     if not envs.VLLM_USE_B12X_DCP_A2A:
         return
-    if cp_group.world_size not in (2, 4, 8):
+    if cp_group.world_size not in _B12X_DCP_WORLD_SIZES:
         # The PCIe channel only exists for these world sizes. The runtime
         # dispatchers already fall back to NCCL collectives per call, so an
         # unsupported DCP size (e.g. TP6 with DCP3/DCP6) must not fail boot.
         logger.warning_once(
-            "B12X PCIe DCP collectives support world sizes 2/4/8; "
+            "B12X PCIe DCP collectives support world sizes 2/4/8/16; "
             "DCP world size %d uses NCCL collectives instead.",
             cp_group.world_size,
         )

--- a/vllm/v1/attention/ops/dcp_alltoall.py
+++ b/vllm/v1/attention/ops/dcp_alltoall.py
@@ -367,12 +367,13 @@ def _try_b12x_dcp_all_gather_heads(
     *,
     max_batch_size: int | None,
     output_head_dim: int | None,
+    out: torch.Tensor | None = None,
 ) -> torch.Tensor | None:
     """Gather rank-local query heads with the B12X PCIe channel."""
     world_size = cp_group.world_size
     if (
         not local_input.is_cuda
-        or local_input.dtype not in (torch.float16, torch.bfloat16)
+        or local_input.dtype not in (torch.float16, torch.bfloat16, torch.float8_e4m3fn)
         or world_size not in _B12X_DCP_WORLD_SIZES
         or local_input.ndim != 3
         or not local_input.is_contiguous()
@@ -380,7 +381,8 @@ def _try_b12x_dcp_all_gather_heads(
         return None
 
     batch, local_heads, head_dim = local_input.shape
-    if local_heads <= 0 or head_dim % 8 != 0:
+    gather_alignment = 16 if local_input.dtype == torch.float8_e4m3fn else 8
+    if local_heads <= 0 or head_dim % gather_alignment != 0:
         return None
     if max_batch_size is None:
         max_batch_size = batch
@@ -408,6 +410,12 @@ def _try_b12x_dcp_all_gather_heads(
     )
     if pool is None:
         return None
+    if out is not None:
+        return pool.all_gather_heads(
+            local_input,
+            out=out,
+            channel_id=_B12X_DCP_EAGER_CHANNEL_ID,
+        )
     return pool.all_gather_heads(
         local_input,
         channel_id=_b12x_dcp_channel_id(cp_group),
@@ -420,19 +428,33 @@ def dcp_b12x_all_gather_heads(
     *,
     max_batch_size: int | None = None,
     output_head_dim: int | None = None,
+    out: torch.Tensor | None = None,
 ) -> torch.Tensor:
-    """Gather query heads with B12X, falling back to the group backend."""
+    """Gather query heads into optional caller-owned output storage."""
     local_input = local_input.contiguous()
     if envs.VLLM_USE_B12X_DCP_A2A:
-        result = _try_b12x_dcp_all_gather_heads(
-            local_input,
-            cp_group,
-            max_batch_size=max_batch_size,
-            output_head_dim=output_head_dim,
-        )
+        if out is None:
+            result = _try_b12x_dcp_all_gather_heads(
+                local_input,
+                cp_group,
+                max_batch_size=max_batch_size,
+                output_head_dim=output_head_dim,
+            )
+        else:
+            result = _try_b12x_dcp_all_gather_heads(
+                local_input,
+                cp_group,
+                max_batch_size=max_batch_size,
+                output_head_dim=output_head_dim,
+                out=out,
+            )
         if result is not None:
             return result
-    return cp_group.all_gather(local_input, dim=1)
+    result = cp_group.all_gather(local_input, dim=1)
+    if out is None:
+        return result
+    out.copy_(result)
+    return out
 
 
 def warmup_b12x_dcp_a2a(

--- a/vllm/v1/attention/ops/dcp_alltoall.py
+++ b/vllm/v1/attention/ops/dcp_alltoall.py
@@ -740,7 +740,7 @@ def _dcp_a2a_pack_send_kernel(
 
         lse_val = tl.load(
             lse_ptr + batch_idx * lse_stride_B + src_head_idx * lse_stride_H
-        ).to(tl.float32)
+        )
         if LSE_PACK_DIM == 1:
             tl.store(
                 send_ptr + send_base + HEAD_DIM * send_stride_D,
@@ -978,12 +978,13 @@ def dcp_a2a_lse_reduce(
     """
     Combine partial attention outputs across DCP ranks using All-to-All.
 
-    The output and LSE are packed into a single output-dtype buffer, sent
+    The output and FP32 LSE are packed into a single output-dtype buffer, sent
     with one All-to-All, then unpacked and combined with exact LSE weighting.
 
     Args:
         cp_attn_out: [B, H, D] where B=num_tokens, H=total_heads, D=head_dim
-        cp_attn_lse: [B, H] floating-point log-sum-exp values
+        cp_attn_lse: [B, H] floating-point log-sum-exp values; non-FP32 input
+            is converted before bit packing
         cp_group: GroupCoordinator for DCP communication
         ctx: CPTritonContext (unused, for signature compatibility)
         return_lse: If True, also return the combined global LSE
@@ -1023,6 +1024,10 @@ def dcp_a2a_lse_reduce(
     if H % world_size != 0:
         raise ValueError(f"H={H} must be divisible by DCP world size {world_size}.")
     H_per_rank = H // world_size
+    # The pack kernel preserves the FP32 bit pattern across an output-dtype
+    # transport buffer. Normalize backends that emit LSE in activation dtype.
+    if cp_attn_lse.dtype != torch.float32:
+        cp_attn_lse = cp_attn_lse.to(torch.float32)
     lse_pack_dim = _dcp_a2a_lse_pack_dim(cp_attn_out.dtype)
 
     send_buffer, recv_buffer = _dcp_a2a_send_recv_buffers(

--- a/vllm/v1/attention/ops/dcp_alltoall.py
+++ b/vllm/v1/attention/ops/dcp_alltoall.py
@@ -226,7 +226,17 @@ def capture_b12x_dcp_a2a(
         yield
         return
 
-    previous_active = _B12X_DCP_ACTIVE_CAPTURE.get(group_id)
+    active = _B12X_DCP_ACTIVE_CAPTURE.get(group_id)
+    if active is not None:
+        active_channel_id, active_stream, _ = active
+        if channel_id != active_channel_id or stream is not active_stream:
+            raise RuntimeError(
+                "nested PCIe DCP graph capture must reuse the active "
+                "channel_id and stream"
+            )
+        yield
+        return
+
     try:
         with ExitStack() as stack:
             _B12X_DCP_ACTIVE_CAPTURE[group_id] = (channel_id, stream, stack)
@@ -234,10 +244,7 @@ def capture_b12x_dcp_a2a(
                 stack.enter_context(pool.capture(stream=stream, channel_id=channel_id))
             yield
     finally:
-        if previous_active is None:
-            _B12X_DCP_ACTIVE_CAPTURE.pop(group_id, None)
-        else:
-            _B12X_DCP_ACTIVE_CAPTURE[group_id] = previous_active
+        _B12X_DCP_ACTIVE_CAPTURE.pop(group_id, None)
 
 
 def checkpoint_b12x_dcp_a2a_channels(

--- a/vllm/v1/attention/ops/dcp_alltoall.py
+++ b/vllm/v1/attention/ops/dcp_alltoall.py
@@ -1019,6 +1019,26 @@ def dcp_a2a_lse_reduce(
         )
         if b12x_result is not None:
             return b12x_result
+        token_cap = envs.VLLM_DCP_A2A_MAX_TOKENS
+        if (
+            token_cap > 0
+            and cp_attn_out.shape[0] > token_cap
+            and envs.VLLM_DCP_A2A_LARGE_BACKEND == "ag_rs"
+        ):
+            # PyNccl AG+RS uses the DCP communicator warmed during startup.
+            # This avoids ProcessGroupNCCL's first-use all-to-all workspace
+            # allocation after a near-capacity KV cache has been allocated.
+            from vllm.v1.attention.ops.common import cp_lse_ag_out_rs
+
+            return cp_lse_ag_out_rs(
+                cp_attn_out,
+                cp_attn_lse,
+                cp_group,
+                ctx=ctx,
+                return_lse=return_lse,
+                is_lse_base_on_e=is_lse_base_on_e,
+                head_major_output=True,
+            )
 
     B, H, D = cp_attn_out.shape
     if H % world_size != 0:

--- a/vllm/v1/attention/ops/dcp_alltoall.py
+++ b/vllm/v1/attention/ops/dcp_alltoall.py
@@ -42,14 +42,24 @@ logger = init_logger(__name__)
 
 _B12X_DCP_A2A_POOLS: dict[tuple[int, int, int, int, int, int], Any] = {}
 _B12X_DCP_A2A_DISABLED: set[tuple[int, int, int, int, int, int]] = set()
-# DCP likewise has one stable eager scheduler owner.  Graph target/draft/encoder
-# identities are supplied separately by their GraphCaptureContext.
 _B12X_DCP_EAGER_CHANNEL_ID = "vllm:eager:dcp"
 _B12X_DCP_MAX_CONCURRENT_CHANNELS = 2
+# A pool initialized after a graph context opens must join that graph before
+# its first operation. Each entry is keyed by the process-group identity and
+# owns the graph's semantic channel, stream, and cleanup stack.
+_B12X_DCP_ACTIVE_CAPTURE: dict[int, tuple[str, Any, ExitStack]] = {}
 _DCP_A2A_GRAPH_BUFFERS: dict[
     tuple[tuple[int, ...], torch.device, torch.dtype],
     tuple[torch.Tensor, torch.Tensor],
 ] = {}
+
+
+def _b12x_dcp_channel_id(cp_group: GroupCoordinator) -> str:
+    """Return the B12X channel owned by the group's active execution mode."""
+    active = _B12X_DCP_ACTIVE_CAPTURE.get(id(cp_group.device_group))
+    if active is not None:
+        return active[0]
+    return _B12X_DCP_EAGER_CHANNEL_ID
 
 
 def _is_supported_bhd_layout(tensor: torch.Tensor) -> bool:
@@ -135,8 +145,16 @@ def _get_b12x_dcp_a2a_pool(
             single_channel=False,
             max_concurrent_channels=_B12X_DCP_MAX_CONCURRENT_CHANNELS,
         )
-        pool.prepare_channels((_B12X_DCP_EAGER_CHANNEL_ID,))
-        pool.for_stream(channel_id=_B12X_DCP_EAGER_CHANNEL_ID)
+        active = _B12X_DCP_ACTIVE_CAPTURE.get(id(cp_group.device_group))
+        if active is None:
+            pool.prepare_channels((_B12X_DCP_EAGER_CHANNEL_ID,))
+            pool.for_stream(channel_id=_B12X_DCP_EAGER_CHANNEL_ID)
+        else:
+            active_channel, active_stream, active_stack = active
+            pool.prepare_channels((_B12X_DCP_EAGER_CHANNEL_ID, active_channel))
+            active_stack.enter_context(
+                pool.capture(stream=active_stream, channel_id=active_channel)
+            )
     except Exception as exc:
         init_error = exc
 
@@ -198,15 +216,27 @@ def capture_b12x_dcp_a2a(
         ),
         key=lambda item: item[0][1:],
     )
-    if matching_pools and channel_id is None:
-        raise RuntimeError(
-            "distributed PCIe DCP graph capture requires an explicit semantic "
-            "channel_id"
-        )
-    with ExitStack() as stack:
-        for _, pool in matching_pools:
-            stack.enter_context(pool.capture(stream=stream, channel_id=channel_id))
+    if channel_id is None:
+        if matching_pools or envs.VLLM_USE_B12X_DCP_A2A:
+            raise RuntimeError(
+                "distributed PCIe DCP graph capture requires an explicit "
+                "semantic channel_id"
+            )
         yield
+        return
+
+    previous_active = _B12X_DCP_ACTIVE_CAPTURE.get(group_id)
+    try:
+        with ExitStack() as stack:
+            _B12X_DCP_ACTIVE_CAPTURE[group_id] = (channel_id, stream, stack)
+            for _, pool in matching_pools:
+                stack.enter_context(pool.capture(stream=stream, channel_id=channel_id))
+            yield
+    finally:
+        if previous_active is None:
+            _B12X_DCP_ACTIVE_CAPTURE.pop(group_id, None)
+        else:
+            _B12X_DCP_ACTIVE_CAPTURE[group_id] = previous_active
 
 
 def checkpoint_b12x_dcp_a2a_channels(
@@ -326,7 +356,7 @@ def _try_b12x_dcp_lse_reduce(
         cp_attn_lse,
         out=reduced,
         is_lse_base_on_e=is_lse_base_on_e,
-        channel_id=_B12X_DCP_EAGER_CHANNEL_ID,
+        channel_id=_b12x_dcp_channel_id(cp_group),
     )
 
 
@@ -379,7 +409,7 @@ def _try_b12x_dcp_all_gather_heads(
         return None
     return pool.all_gather_heads(
         local_input,
-        channel_id=_B12X_DCP_EAGER_CHANNEL_ID,
+        channel_id=_b12x_dcp_channel_id(cp_group),
     )
 
 

--- a/vllm/v1/attention/ops/dcp_alltoall.py
+++ b/vllm/v1/attention/ops/dcp_alltoall.py
@@ -457,6 +457,92 @@ def dcp_b12x_all_gather_heads(
     return out
 
 
+def _try_b12x_dcp_all_gather_pair(
+    local_first: torch.Tensor,
+    local_second: torch.Tensor,
+    cp_group: GroupCoordinator,
+    *,
+    max_batch_size: int | None,
+) -> tuple[torch.Tensor, torch.Tensor] | None:
+    """Gather two projection rows behind one B12X IPC barrier."""
+    supported_dtypes = (
+        torch.float16,
+        torch.bfloat16,
+        torch.float32,
+        torch.float8_e4m3fn,
+    )
+    if (
+        cp_group.world_size not in _B12X_DCP_WORLD_SIZES
+        or local_first.dtype not in supported_dtypes
+        or local_second.dtype not in supported_dtypes
+        or not local_first.is_cuda
+        or not local_second.is_cuda
+        or local_first.device != local_second.device
+        or local_first.ndim != 2
+        or local_second.ndim != 2
+        or local_first.shape[0] != local_second.shape[0]
+        or not local_first.is_contiguous()
+        or not local_second.is_contiguous()
+    ):
+        return None
+
+    batch = int(local_first.shape[0])
+    first_row_bytes = int(local_first.shape[1]) * local_first.element_size()
+    second_row_bytes = int(local_second.shape[1]) * local_second.element_size()
+    if batch < 1 or first_row_bytes % 16 != 0 or second_row_bytes % 16 != 0:
+        return None
+    if max_batch_size is None:
+        max_batch_size = batch
+    max_batch_size = int(max_batch_size)
+    token_cap = envs.VLLM_DCP_A2A_MAX_TOKENS
+    if token_cap > 0:
+        if batch > token_cap:
+            return None
+        max_batch_size = min(max_batch_size, token_cap)
+    if max_batch_size < batch:
+        return None
+
+    combined_row_bytes = first_row_bytes + second_row_bytes
+    pool = _get_b12x_dcp_a2a_pool(
+        cp_group,
+        device=local_first.device,
+        total_heads=cp_group.world_size,
+        head_dim=combined_row_bytes,
+        query_head_dim=combined_row_bytes,
+        max_batch_size=max_batch_size,
+    )
+    if pool is None or not hasattr(pool, "all_gather_pair"):
+        return None
+    return pool.all_gather_pair(
+        local_first,
+        local_second,
+        channel_id=_b12x_dcp_channel_id(cp_group),
+    )
+
+
+def dcp_b12x_all_gather_pair(
+    local_first: torch.Tensor,
+    local_second: torch.Tensor,
+    cp_group: GroupCoordinator,
+    *,
+    max_batch_size: int | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Gather two rank-local rows together, with exact separate fallbacks."""
+    if envs.VLLM_USE_B12X_DCP_A2A:
+        result = _try_b12x_dcp_all_gather_pair(
+            local_first,
+            local_second,
+            cp_group,
+            max_batch_size=max_batch_size,
+        )
+        if result is not None:
+            return result
+    return (
+        cp_group.all_gather(local_first, dim=-1),
+        cp_group.all_gather(local_second, dim=-1),
+    )
+
+
 def warmup_b12x_dcp_a2a(
     cp_group: GroupCoordinator,
     *,


### PR DESCRIPTION
## Status

Implemented. This pull request is stacked on #383 and requires local-inference-lab/b12x#218. TP8, TP12, and TP16 hardware qualification is tracked by local-inference-lab/rtx6kpro#66.

## Behavior

- Binds B12X transport pools to CUDA-graph owners, including pools initialized after graph-context entry.
- Exposes explicit in-place tensor-parallel all-reduce and the active B12X all-reduce runtime.
- Dispatches direct oneshot collectives at supported small world sizes and bounded-degree collectives at TP12 and TP16.
- Enables B12X DCP transport at world size 16.
- Preserves FP32 attention LSE, FP8 projection payloads, and caller-owned output storage.
- Routes batches above the B12X fast-path capacity through warmed all-gather/reduce-scatter communicators.
- Gathers paired DCP projections behind one synchronization barrier with an exact two-collective fallback.

## Technical reason

Kimi-K3 TP16/DCP16 requires graph-stable collective ownership and bounded peer connectivity. Transport dtypes and output aliasing are part of the numerical and CUDA-graph contract, so fallback paths must preserve the same result and destination storage.

## Compatibility

TP2 through TP8 retain their direct transport path. Unsupported sizes and oversized batches use the exact collective fallback. The public B12X API dependency is local-inference-lab/b12x#218.

## Validation

- Focused in-place all-reduce, graph ownership, DCP packing, fallback, FP8 gather, and paired-gather tests pass.
- Hardware qualification explicitly covers TP8, TP12, and TP16 before aggregate PR #317 is closed.
