### PR TITLE
Shard Kimi projections without padding checkpoint weights

### DIFF
--- a/tests/models/kimi_k3/test_kda.py
+++ b/tests/models/kimi_k3/test_kda.py
@@ -11,6 +11,7 @@ from types import SimpleNamespace
 import pytest
 import torch
 import torch.nn.functional as F
+from torch import nn
 
 from vllm import _custom_ops as ops
 from vllm.model_executor.layers.mamba.ops.causal_conv1d import causal_conv1d_update
@@ -20,7 +21,9 @@ from vllm.model_executor.layers.mamba.ops.gather_initial_states import (
 from vllm.models.kimi_k3.amd.ops.third_party.kda import (
     fused_recurrent_kda_packed_decode as fused_recurrent_kda_packed_decode_amd,
 )
+from vllm.models.kimi_k3.nvidia import kda as kimi_kda
 from vllm.models.kimi_k3.nvidia.kda import (
+    get_kda_f_a_partition,
     is_flashkda_supported,
     is_fused_kda_decode_supported,
     use_split_mixed_precision_input_projection,
@@ -65,6 +68,92 @@ def test_kda_mixed_precision_input_projection_selection(
     )
 
     assert use_split_mixed_precision_input_projection(quant_config) is expected
+
+
+@pytest.mark.parametrize(
+    ("additional_config", "tp_size", "expected"),
+    [
+        (None, 16, (False, 128)),
+        ({}, 16, (False, 128)),
+        ({"kda_shard_f_a": False}, 8, (False, 128)),
+        ({"kda_shard_f_a": True}, 8, (True, 16)),
+        ({"kda_shard_f_a": True}, 16, (True, 8)),
+    ],
+)
+def test_kda_f_a_partition(
+    additional_config: object,
+    tp_size: int,
+    expected: tuple[bool, int],
+):
+    assert get_kda_f_a_partition(128, tp_size, additional_config) == expected
+
+
+def test_kda_f_a_partition_rejects_nondivisible_tp_size():
+    with pytest.raises(ValueError, match="head_dim=128, TP=12"):
+        get_kda_f_a_partition(128, 12, {"kda_shard_f_a": True})
+
+
+class _StaticLinear(nn.Module):
+    def __init__(self, output: torch.Tensor):
+        super().__init__()
+        self.output = output
+
+    def forward(self, _input: torch.Tensor):
+        return self.output, None
+
+
+class _CaptureLinear(nn.Module):
+    def __init__(self, output_width: int):
+        super().__init__()
+        self.output_width = output_width
+        self.input: torch.Tensor | None = None
+
+    def forward(self, input_: torch.Tensor):
+        self.input = input_.clone()
+        return input_.new_zeros(input_.shape[0], self.output_width), None
+
+
+class _IdentityLinear(nn.Module):
+    def forward(self, input_: torch.Tensor):
+        return input_, None
+
+
+def test_sharded_kda_f_a_is_gathered_before_f_b(monkeypatch):
+    layer = object.__new__(kimi_kda.KimiK3DeltaAttention)
+    nn.Module.__init__(layer)
+    layer.split_mixed_precision_input = False
+    layer.local_projection_size = 2
+    layer.local_fa_size = 1
+    layer.local_num_heads = 1
+    layer.in_proj_padding = 0
+    layer.shard_f_a = True
+    layer.head_dim = 2
+
+    projected = torch.arange(20, dtype=torch.float32).view(2, 10)
+    layer.in_proj_qkvgfab = _StaticLinear(projected)
+    f_b_proj = _CaptureLinear(output_width=2)
+    layer.f_b_proj = f_b_proj
+    layer.o_proj = _IdentityLinear()
+    layer._forward = lambda **kwargs: kwargs["core_attn_out"].zero_()
+
+    gathered: dict[str, torch.Tensor] = {}
+
+    def gather_f_a(local_f_a: torch.Tensor) -> torch.Tensor:
+        gathered["local"] = local_f_a.clone()
+        return torch.cat((local_f_a, local_f_a + 100), dim=-1)
+
+    monkeypatch.setattr(kimi_kda, "gather_kimi_sharded_projection", gather_f_a)
+
+    output = layer(torch.empty(2, 1), positions=torch.arange(2))
+
+    expected_local = projected[:, 8:9]
+    torch.testing.assert_close(gathered["local"], expected_local)
+    assert f_b_proj.input is not None
+    torch.testing.assert_close(
+        f_b_proj.input,
+        torch.cat((expected_local, expected_local + 100), dim=-1),
+    )
+    torch.testing.assert_close(output, torch.zeros(2, 2))
 
 
 @torch.inference_mode()

--- a/tests/models/kimi_k3/test_kda.py
+++ b/tests/models/kimi_k3/test_kda.py
@@ -24,6 +24,7 @@ from vllm.models.kimi_k3.amd.ops.third_party.kda import (
 from vllm.models.kimi_k3.nvidia import kda as kimi_kda
 from vllm.models.kimi_k3.nvidia.kda import (
     get_kda_f_a_partition,
+    initialize_kda_input_projection_padding,
     is_flashkda_supported,
     is_fused_kda_decode_supported,
     use_split_mixed_precision_input_projection,
@@ -154,6 +155,35 @@ def test_sharded_kda_f_a_is_gathered_before_f_b(monkeypatch):
         torch.cat((expected_local, expected_local + 100), dim=-1),
     )
     torch.testing.assert_close(output, torch.zeros(2, 2))
+
+
+def test_kda_input_projection_padding_is_declared_and_zeroed():
+    layer = nn.Linear(3, 4, bias=False)
+    layer.weight.data.fill_(1)
+
+    initialize_kda_input_projection_padding(layer, padding_rows=2, hidden_size=3)
+
+    assert layer._vllm_online_processing_unloaded == {"weight": 6}
+    torch.testing.assert_close(layer.weight[:2], torch.ones(2, 3))
+    torch.testing.assert_close(layer.weight[2:], torch.zeros(2, 3))
+
+
+def test_kda_input_projection_without_padding_has_no_declaration():
+    layer = nn.Linear(3, 4, bias=False)
+    original = layer.weight.detach().clone()
+
+    initialize_kda_input_projection_padding(layer, padding_rows=0, hidden_size=3)
+
+    assert not hasattr(layer, "_vllm_online_processing_unloaded")
+    torch.testing.assert_close(layer.weight, original)
+
+
+@pytest.mark.parametrize("padding_rows", [-1, 5])
+def test_kda_input_projection_rejects_invalid_padding(padding_rows: int):
+    layer = nn.Linear(3, 4, bias=False)
+
+    with pytest.raises(ValueError, match="must fit"):
+        initialize_kda_input_projection_padding(layer, padding_rows, hidden_size=3)
 
 
 @torch.inference_mode()

--- a/tests/models/kimi_k3/test_sequence_parallel.py
+++ b/tests/models/kimi_k3/test_sequence_parallel.py
@@ -330,6 +330,32 @@ def test_auxiliary_projection_sharding_requires_shared_token_rows(
     assert kimi_model.shard_auxiliary_projections(use_sequence_parallel) is expected
 
 
+@pytest.mark.parametrize(
+    ("quantization", "moe_backend", "b12x_env", "expected"),
+    [
+        ("mxfp4", "b12x", False, True),
+        ("mxfp4", "auto", True, True),
+        ("mxfp4", "auto", False, False),
+        ("mxfp4", "flashinfer_cutlass", True, False),
+        (None, "b12x", True, False),
+    ],
+)
+def test_native_mxfp4_moe_shard_requires_b12x_backend(
+    monkeypatch: pytest.MonkeyPatch,
+    quantization: str | None,
+    moe_backend: str,
+    b12x_env: bool,
+    expected: bool,
+):
+    monkeypatch.setattr(kimi_model.envs, "VLLM_USE_B12X_MOE", b12x_env)
+    vllm_config = SimpleNamespace(
+        model_config=SimpleNamespace(quantization=quantization),
+        kernel_config=SimpleNamespace(moe_backend=moe_backend),
+    )
+
+    assert kimi_model._uses_native_b12x_mxfp4_intermediate_size(vllm_config) is expected
+
+
 def test_partial_routed_output_transform_adds_partial_residual(monkeypatch):
     monkeypatch.delenv("VLLM_KQUANT_CAPTURE_DIR", raising=False)
     weight = torch.arange(12, dtype=torch.float32).view(4, 3)

--- a/tests/models/kimi_k3/test_sequence_parallel.py
+++ b/tests/models/kimi_k3/test_sequence_parallel.py
@@ -402,8 +402,8 @@ def test_kimi_merged_projection_restores_logical_output_order(monkeypatch):
     )
     monkeypatch.setattr(
         kimi_mla,
-        "tensor_model_parallel_all_gather",
-        lambda output, dim: rank_major_output,
+        "gather_kimi_sharded_projection",
+        lambda output: rank_major_output,
     )
 
     output, bias = layer(torch.empty(1, 1))

--- a/tests/models/kimi_k3/test_sequence_parallel.py
+++ b/tests/models/kimi_k3/test_sequence_parallel.py
@@ -13,6 +13,7 @@ from vllm.config import ParallelConfig
 from vllm.model_executor.layers.activation import SiluAndMul
 from vllm.model_executor.layers.linear import RowParallelLinear
 from vllm.models.common.ops import sequence_parallel as sp_ops
+from vllm.models.kimi_k3.nvidia import mla as kimi_mla
 from vllm.models.kimi_k3.nvidia import model as kimi_model
 from vllm.models.kimi_k3.nvidia import mtp as kimi_mtp
 from vllm.platforms import current_platform
@@ -382,6 +383,54 @@ def test_kimi_column_parallel_loader_zero_fills_tail():
 
     expected = torch.cat([loaded_weight[3:], torch.zeros(1, 4)])
     torch.testing.assert_close(param, expected)
+
+
+def test_kimi_merged_projection_restores_logical_output_order(monkeypatch):
+    layer = object.__new__(kimi_mla.KimiShardedMergedColumnParallelLinear)
+    nn.Module.__init__(layer)
+    layer.tp_size = 4
+    layer.output_sizes = [8, 4]
+    local_output = torch.empty(1, 3)
+    rank_major_output = torch.tensor(
+        [[0, 1, 8, 2, 3, 9, 4, 5, 10, 6, 7, 11]],
+        dtype=torch.float32,
+    )
+    monkeypatch.setattr(
+        kimi_mla.MergedColumnParallelLinear,
+        "forward",
+        lambda _self, _x: (local_output, None),
+    )
+    monkeypatch.setattr(
+        kimi_mla,
+        "tensor_model_parallel_all_gather",
+        lambda output, dim: rank_major_output,
+    )
+
+    output, bias = layer(torch.empty(1, 1))
+
+    torch.testing.assert_close(output, torch.arange(12).view(1, 12).float())
+    assert bias is None
+
+
+@pytest.mark.parametrize(
+    ("output_sizes", "tp_size", "width", "message"),
+    [
+        ([7, 4], 4, 11, "must be divisible"),
+        ([8, 4], 4, 11, "Unexpected gathered"),
+    ],
+)
+def test_kimi_merged_projection_rejects_invalid_shard_geometry(
+    output_sizes: list[int],
+    tp_size: int,
+    width: int,
+    message: str,
+):
+    with pytest.raises(ValueError, match=message):
+        kimi_mla._restore_merged_output_order(
+            torch.empty(1, width),
+            output_sizes,
+            tp_size,
+        )
 
 
 def test_kimi_row_parallel_loader_zero_fills_tail():

--- a/tests/models/kimi_k3/test_tp_projection.py
+++ b/tests/models/kimi_k3/test_tp_projection.py
@@ -102,6 +102,74 @@ def test_b12x_projection_gather_removes_each_rank_padding(monkeypatch):
     assert received["transport"].shape == (1, 1, 136)
 
 
+@pytest.mark.skipif(torch.accelerator.device_count() < 1, reason="CUDA is required.")
+def test_b12x_projection_gather_preserves_fp32_payload_bits(monkeypatch):
+    tp_size = 2
+    local = torch.tensor([[1.25, -2.5]], dtype=torch.float32, device="cuda")
+    other = torch.tensor([[3.75, -4.5]], dtype=torch.float32, device="cuda")
+    group = SimpleNamespace(world_size=tp_size, ranks=list(range(tp_size)))
+    received: dict[str, object] = {}
+    monkeypatch.setattr(tp_projection.envs, "VLLM_USE_B12X_DCP_A2A", True)
+    monkeypatch.setattr(
+        tp_projection, "get_tensor_model_parallel_world_size", lambda: tp_size
+    )
+    monkeypatch.setattr(tp_projection, "_get_kimi_projection_group", lambda: group)
+
+    def gather(transport, projection_group, *, max_batch_size):
+        received["transport"] = transport
+        result = torch.empty(
+            (1, tp_size, transport.shape[-1]),
+            dtype=transport.dtype,
+            device=transport.device,
+        )
+        result[0, 0].copy_(transport[0, 0])
+        result[0, 1].copy_(other.view(torch.float8_e4m3fn).flatten())
+        return result
+
+    monkeypatch.setattr(tp_projection, "dcp_b12x_all_gather_heads", gather)
+
+    actual = tp_projection.gather_kimi_sharded_projection(local)
+
+    torch.testing.assert_close(actual, torch.cat((local, other), dim=-1))
+    assert actual.dtype == torch.float32
+    assert received["transport"].dtype == torch.float8_e4m3fn
+    assert received["transport"].shape == (1, 1, 8)
+
+
+@pytest.mark.skipif(torch.accelerator.device_count() < 1, reason="CUDA is required.")
+def test_b12x_projection_gather_preserves_fp8_payload(monkeypatch):
+    tp_size = 2
+    local = (
+        torch.arange(16, dtype=torch.float32, device="cuda")
+        .to(torch.float8_e4m3fn)
+        .view(1, -1)
+    )
+    other = (
+        torch.arange(16, 32, dtype=torch.float32, device="cuda")
+        .to(torch.float8_e4m3fn)
+        .view(1, -1)
+    )
+    group = SimpleNamespace(world_size=tp_size, ranks=list(range(tp_size)))
+    monkeypatch.setattr(tp_projection.envs, "VLLM_USE_B12X_DCP_A2A", True)
+    monkeypatch.setattr(
+        tp_projection, "get_tensor_model_parallel_world_size", lambda: tp_size
+    )
+    monkeypatch.setattr(tp_projection, "_get_kimi_projection_group", lambda: group)
+
+    def gather(transport, projection_group, *, max_batch_size):
+        return torch.stack((transport[:, 0], other), dim=1)
+
+    monkeypatch.setattr(tp_projection, "dcp_b12x_all_gather_heads", gather)
+
+    actual = tp_projection.gather_kimi_sharded_projection(local)
+
+    torch.testing.assert_close(
+        actual.float(),
+        torch.cat((local, other), dim=-1).float(),
+    )
+    assert actual.dtype == torch.float8_e4m3fn
+
+
 def test_projection_gather_uses_standard_collective_outside_decode(monkeypatch):
     local = torch.arange(12).view(3, 4)
     expected = torch.cat((local, local), dim=-1)

--- a/tests/models/kimi_k3/test_tp_projection.py
+++ b/tests/models/kimi_k3/test_tp_projection.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.models.kimi_k3.nvidia import tp_projection
+
+
+def test_projection_group_uses_matching_dcp_coordinator(monkeypatch):
+    tp_group = SimpleNamespace(world_size=8, ranks=list(range(8)))
+    dcp_group = SimpleNamespace(world_size=8, ranks=list(range(8)))
+    monkeypatch.setattr(
+        tp_projection, "get_tensor_model_parallel_world_size", lambda: 8
+    )
+    monkeypatch.setattr(tp_projection, "get_tp_group", lambda: tp_group)
+    monkeypatch.setattr(tp_projection, "get_dcp_group", lambda: dcp_group)
+
+    assert tp_projection._get_kimi_projection_group() is dcp_group
+
+
+def test_projection_group_uses_tp_for_different_dcp_ranks(monkeypatch):
+    tp_group = SimpleNamespace(world_size=8, ranks=list(range(8)))
+    dcp_group = SimpleNamespace(world_size=4, ranks=list(range(4)))
+    monkeypatch.setattr(
+        tp_projection, "get_tensor_model_parallel_world_size", lambda: 8
+    )
+    monkeypatch.setattr(tp_projection, "get_tp_group", lambda: tp_group)
+    monkeypatch.setattr(tp_projection, "get_dcp_group", lambda: dcp_group)
+
+    assert tp_projection._get_kimi_projection_group() is tp_group
+
+
+def test_projection_group_rejects_incomplete_tp_coordinator(monkeypatch):
+    monkeypatch.setattr(
+        tp_projection, "get_tensor_model_parallel_world_size", lambda: 8
+    )
+    monkeypatch.setattr(
+        tp_projection,
+        "get_tp_group",
+        lambda: SimpleNamespace(world_size=4, ranks=list(range(4))),
+    )
+    monkeypatch.setattr(
+        tp_projection,
+        "get_dcp_group",
+        lambda: SimpleNamespace(world_size=4, ranks=list(range(4))),
+    )
+
+    with pytest.raises(RuntimeError, match="does not span"):
+        tp_projection._get_kimi_projection_group()
+
+
+@pytest.mark.skipif(torch.accelerator.device_count() < 1, reason="CUDA is required.")
+def test_b12x_projection_gather_removes_each_rank_padding(monkeypatch):
+    tp_size = 2
+    local_width = 132
+    local = torch.arange(local_width, dtype=torch.bfloat16, device="cuda").view(1, -1)
+    group = SimpleNamespace(world_size=tp_size, ranks=list(range(tp_size)))
+    received: dict[str, object] = {}
+    monkeypatch.setattr(tp_projection.envs, "VLLM_USE_B12X_DCP_A2A", True)
+    monkeypatch.setattr(
+        tp_projection, "get_tensor_model_parallel_world_size", lambda: tp_size
+    )
+    monkeypatch.setattr(tp_projection, "_get_kimi_projection_group", lambda: group)
+
+    def gather(transport, projection_group, *, max_batch_size):
+        received.update(
+            transport=transport,
+            projection_group=projection_group,
+            max_batch_size=max_batch_size,
+        )
+        padded_width = transport.shape[-1]
+        result = torch.full(
+            (1, tp_size, padded_width),
+            -1,
+            dtype=transport.dtype,
+            device=transport.device,
+        )
+        result[0, 0, :local_width] = torch.arange(
+            local_width, dtype=transport.dtype, device=transport.device
+        )
+        result[0, 1, :local_width] = torch.arange(
+            local_width,
+            2 * local_width,
+            dtype=transport.dtype,
+            device=transport.device,
+        )
+        return result
+
+    monkeypatch.setattr(tp_projection, "dcp_b12x_all_gather_heads", gather)
+
+    actual = tp_projection.gather_kimi_sharded_projection(local)
+
+    expected = torch.arange(
+        2 * local_width, dtype=local.dtype, device=local.device
+    ).view(1, -1)
+    torch.testing.assert_close(actual, expected)
+    assert received["projection_group"] is group
+    assert received["max_batch_size"] == 1
+    assert received["transport"].shape == (1, 1, 136)
+
+
+def test_projection_gather_uses_standard_collective_outside_decode(monkeypatch):
+    local = torch.arange(12).view(3, 4)
+    expected = torch.cat((local, local), dim=-1)
+    monkeypatch.setattr(
+        tp_projection, "get_tensor_model_parallel_world_size", lambda: 2
+    )
+    monkeypatch.setattr(
+        tp_projection,
+        "tensor_model_parallel_all_gather",
+        lambda output, dim: expected,
+    )
+
+    actual = tp_projection.gather_kimi_sharded_projection(local)
+
+    assert actual is expected

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -352,6 +352,7 @@ if TYPE_CHECKING:
     VLLM_ELASTIC_EP_DRAIN_REQUESTS: bool = False
     VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS: bool = True
     VLLM_MEMORY_PROFILE_INCLUDE_ATTN: bool = False
+    VLLM_KIMI_SHARD_QKV_A: bool = False
     VLLM_NIXL_EP_MAX_NUM_RANKS: int = 32
     VLLM_XPU_ENABLE_XPU_GRAPH: bool = False
     VLLM_XPU_USE_SAMPLER_KERNEL: bool = True
@@ -2347,6 +2348,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_MEMORY_PROFILE_INCLUDE_ATTN": lambda: bool(
         int(os.getenv("VLLM_MEMORY_PROFILE_INCLUDE_ATTN", "0"))
     ),
+    # TP-shard Kimi-K3's merged MLA q_a/kv_a projection. The rank-major
+    # collective result is restored to logical q_a/kv_a order before use.
+    "VLLM_KIMI_SHARD_QKV_A": lambda: bool(int(os.getenv("VLLM_KIMI_SHARD_QKV_A", "0"))),
     # NIXL EP environment variables
     "VLLM_NIXL_EP_MAX_NUM_RANKS": lambda: int(
         os.getenv("VLLM_NIXL_EP_MAX_NUM_RANKS", "32")

--- a/vllm/models/kimi_k3/nvidia/kda.py
+++ b/vllm/models/kimi_k3/nvidia/kda.py
@@ -114,6 +114,25 @@ def get_kda_f_a_partition(
     return True, divide(head_dim, tp_size)
 
 
+def initialize_kda_input_projection_padding(
+    layer: nn.Module,
+    padding_rows: int,
+    hidden_size: int,
+) -> None:
+    """Declare and zero local KDA projection rows absent from the checkpoint."""
+    if padding_rows == 0:
+        return
+    if padding_rows < 0 or padding_rows > layer.weight.shape[0]:
+        raise ValueError(
+            "KDA input projection padding must fit the local weight rows, got "
+            f"padding_rows={padding_rows}, rows={layer.weight.shape[0]}."
+        )
+    layer._vllm_online_processing_unloaded = {
+        "weight": padding_rows * hidden_size,
+    }
+    layer.weight.data[-padding_rows:].zero_()
+
+
 class _KimiGDNMergedColumnParallelLinear(MergedColumnParallelLinear):
     """Merged projection with one output replicated across TP ranks."""
 
@@ -426,8 +445,11 @@ class KimiK3DeltaAttention(GatedDeltaNetAttention):
                     quant_config=self.quant_config,
                     prefix=f"{prefix}.in_proj_gfab",
                 )
-            if self.in_proj_padding:
-                self.in_proj_gfab.weight.data[-self.in_proj_padding :].zero_()
+            initialize_kda_input_projection_padding(
+                self.in_proj_gfab,
+                self.in_proj_padding,
+                self.hidden_size,
+            )
         else:
             if self.in_proj_padding:
                 in_proj_output_sizes.append(self.in_proj_padding * self.tp_size)
@@ -449,8 +471,11 @@ class KimiK3DeltaAttention(GatedDeltaNetAttention):
                     quant_config=self.quant_config,
                     prefix=f"{prefix}.in_proj_qkvgfab",
                 )
-            if self.in_proj_padding:
-                self.in_proj_qkvgfab.weight.data[-self.in_proj_padding :].zero_()
+            initialize_kda_input_projection_padding(
+                self.in_proj_qkvgfab,
+                self.in_proj_padding,
+                self.hidden_size,
+            )
 
         self.f_b_proj = ColumnParallelLinear(
             self.head_dim,

--- a/vllm/models/kimi_k3/nvidia/kda.py
+++ b/vllm/models/kimi_k3/nvidia/kda.py
@@ -43,6 +43,9 @@ from vllm.models.kimi_k3.nvidia.kda_metadata import (
     KimiK3KDAAttentionBackend,
     KimiK3KDAMetadata,
 )
+from vllm.models.kimi_k3.nvidia.tp_projection import (
+    gather_kimi_sharded_projection,
+)
 from vllm.platforms import current_platform
 from vllm.third_party.flash_linear_attention.ops.kda import FusedRMSNormGated
 from vllm.transformers_utils.configs.kimi_linear import KimiLinearConfig
@@ -88,6 +91,27 @@ def use_split_mixed_precision_input_projection(quant_config: object | None) -> b
         and not dense_ignored.intersection({"q_proj", "k_proj", "v_proj"})
         and {"g_proj", "f_a_proj", "b_proj"}.issubset(dense_ignored)
     )
+
+
+def get_kda_f_a_partition(
+    head_dim: int,
+    tp_size: int,
+    additional_config: object,
+) -> tuple[bool, int]:
+    """Return whether KDA ``f_a`` is sharded and its local output width."""
+    shard_f_a = bool(
+        additional_config.get("kda_shard_f_a", False)
+        if isinstance(additional_config, dict)
+        else False
+    )
+    if not shard_f_a:
+        return False, head_dim
+    if head_dim % tp_size != 0:
+        raise ValueError(
+            "KDA f_a output sharding requires head_dim to be divisible by "
+            f"TP size, got head_dim={head_dim}, TP={tp_size}."
+        )
+    return True, divide(head_dim, tp_size)
 
 
 class _KimiGDNMergedColumnParallelLinear(MergedColumnParallelLinear):
@@ -334,6 +358,17 @@ class KimiK3DeltaAttention(GatedDeltaNetAttention):
         self.num_heads = kda_config["num_heads"]
         assert self.num_heads % self.tp_size == 0
         self.local_num_heads = divide(self.num_heads, self.tp_size)
+        self.shard_f_a, self.local_fa_size = get_kda_f_a_partition(
+            self.head_dim,
+            self.tp_size,
+            vllm_config.additional_config,
+        )
+        if self.shard_f_a:
+            logger.info_once(
+                "TP-sharding the KDA f_a projection output (%d -> %d rows/rank).",
+                self.head_dim,
+                self.local_fa_size,
+            )
         self.projection_size = self.head_dim * self.num_heads
         self.local_projection_size = divide(self.projection_size, self.tp_size)
         self.conv_size = kda_config["short_conv_kernel_size"]
@@ -349,7 +384,7 @@ class KimiK3DeltaAttention(GatedDeltaNetAttention):
             self.num_heads,
         ]
         local_output_size = (
-            4 * self.local_projection_size + self.head_dim + self.local_num_heads
+            4 * self.local_projection_size + self.local_fa_size + self.local_num_heads
         )
         self.in_proj_padding = -local_output_size % 16
         self.split_mixed_precision_input = use_split_mixed_precision_input_projection(
@@ -373,29 +408,47 @@ class KimiK3DeltaAttention(GatedDeltaNetAttention):
             ]
             if self.in_proj_padding:
                 gfab_output_sizes.append(self.in_proj_padding * self.tp_size)
-            self.in_proj_gfab = _KimiGDNMergedColumnParallelLinear(
-                self.hidden_size,
-                gfab_output_sizes,
-                replicated_shard_id=1,
-                tp_size=self.tp_size,
-                bias=False,
-                quant_config=self.quant_config,
-                prefix=f"{prefix}.in_proj_gfab",
-            )
+            if self.shard_f_a:
+                self.in_proj_gfab = MergedColumnParallelLinear(
+                    self.hidden_size,
+                    gfab_output_sizes,
+                    bias=False,
+                    quant_config=self.quant_config,
+                    prefix=f"{prefix}.in_proj_gfab",
+                )
+            else:
+                self.in_proj_gfab = _KimiGDNMergedColumnParallelLinear(
+                    self.hidden_size,
+                    gfab_output_sizes,
+                    replicated_shard_id=1,
+                    tp_size=self.tp_size,
+                    bias=False,
+                    quant_config=self.quant_config,
+                    prefix=f"{prefix}.in_proj_gfab",
+                )
             if self.in_proj_padding:
                 self.in_proj_gfab.weight.data[-self.in_proj_padding :].zero_()
         else:
             if self.in_proj_padding:
                 in_proj_output_sizes.append(self.in_proj_padding * self.tp_size)
-            self.in_proj_qkvgfab = _KimiGDNMergedColumnParallelLinear(
-                self.hidden_size,
-                in_proj_output_sizes,
-                replicated_shard_id=4,
-                tp_size=self.tp_size,
-                bias=False,
-                quant_config=self.quant_config,
-                prefix=f"{prefix}.in_proj_qkvgfab",
-            )
+            if self.shard_f_a:
+                self.in_proj_qkvgfab = MergedColumnParallelLinear(
+                    self.hidden_size,
+                    in_proj_output_sizes,
+                    bias=False,
+                    quant_config=self.quant_config,
+                    prefix=f"{prefix}.in_proj_qkvgfab",
+                )
+            else:
+                self.in_proj_qkvgfab = _KimiGDNMergedColumnParallelLinear(
+                    self.hidden_size,
+                    in_proj_output_sizes,
+                    replicated_shard_id=4,
+                    tp_size=self.tp_size,
+                    bias=False,
+                    quant_config=self.quant_config,
+                    prefix=f"{prefix}.in_proj_qkvgfab",
+                )
             if self.in_proj_padding:
                 self.in_proj_qkvgfab.weight.data[-self.in_proj_padding :].zero_()
 
@@ -524,7 +577,7 @@ class KimiK3DeltaAttention(GatedDeltaNetAttention):
             mixed_qkv = self.in_proj_qkv(hidden_states)[0]
             gfab_split_sizes = [
                 self.local_projection_size,
-                self.head_dim,
+                self.local_fa_size,
                 self.local_num_heads,
             ]
             if self.in_proj_padding:
@@ -538,7 +591,7 @@ class KimiK3DeltaAttention(GatedDeltaNetAttention):
             split_sizes = [
                 3 * self.local_projection_size,
                 self.local_projection_size,
-                self.head_dim,
+                self.local_fa_size,
                 self.local_num_heads,
             ]
             if self.in_proj_padding:
@@ -546,6 +599,8 @@ class KimiK3DeltaAttention(GatedDeltaNetAttention):
             projected = projected_qkvgfab.split(split_sizes, dim=-1)
             mixed_qkv, g_proj_states, f_a, beta = projected[:4]
 
+        if self.shard_f_a:
+            f_a = gather_kimi_sharded_projection(f_a)
         g1 = self.f_b_proj(f_a)[0]
         beta = beta.unsqueeze(0)
         g1 = rearrange(g1, "n (h d) -> 1 n h d", d=self.head_dim)

--- a/vllm/models/kimi_k3/nvidia/mla.py
+++ b/vllm/models/kimi_k3/nvidia/mla.py
@@ -44,7 +44,6 @@ from vllm.config import (
 )
 from vllm.distributed import (
     get_tensor_model_parallel_world_size,
-    tensor_model_parallel_all_gather,
 )
 from vllm.forward_context import get_forward_context
 from vllm.logger import init_logger
@@ -73,6 +72,9 @@ from vllm.models.kimi_k3.nvidia.ops.fused_mla_key_concat_kv_cache import (
     fused_mla_key_concat_ds_mla_insert,
     fused_mla_key_concat_kv_cache_insert,
     fused_mla_qkv_quant_kv_cache_fp8_insert,
+)
+from vllm.models.kimi_k3.nvidia.tp_projection import (
+    gather_kimi_sharded_projection,
 )
 from vllm.platforms import current_platform
 from vllm.transformers_utils.configs.kimi_linear import KimiLinearConfig
@@ -161,7 +163,7 @@ class KimiShardedMergedColumnParallelLinear(MergedColumnParallelLinear):
         output_parallel, output_bias = super().forward(x)
         if self.tp_size == 1:
             return output_parallel, output_bias
-        rank_major_output = tensor_model_parallel_all_gather(output_parallel, dim=-1)
+        rank_major_output = gather_kimi_sharded_projection(output_parallel)
         output = _restore_merged_output_order(
             rank_major_output,
             self.output_sizes,

--- a/vllm/models/kimi_k3/nvidia/mla.py
+++ b/vllm/models/kimi_k3/nvidia/mla.py
@@ -34,6 +34,7 @@ from typing import TYPE_CHECKING, cast
 import torch
 from torch import nn
 
+import vllm.envs as envs
 from vllm import _custom_ops as ops
 from vllm.compilation.breakable_cudagraph import eager_break_during_capture
 from vllm.config import (
@@ -41,7 +42,10 @@ from vllm.config import (
     VllmConfig,
     get_current_vllm_config,
 )
-from vllm.distributed import get_tensor_model_parallel_world_size
+from vllm.distributed import (
+    get_tensor_model_parallel_world_size,
+    tensor_model_parallel_all_gather,
+)
 from vllm.forward_context import get_forward_context
 from vllm.logger import init_logger
 from vllm.model_executor.layers.attention.attention import (
@@ -103,6 +107,67 @@ _GATE_MULTI_STREAM_TOKEN_THRESHOLD = 512
 def _gate_sigmoid_mul(attn_out: torch.Tensor, gate: torch.Tensor) -> torch.Tensor:
     """Apply the sigmoid output gate to a precomputed ``g_proj`` projection."""
     return attn_out * gate.sigmoid()
+
+
+def _restore_merged_output_order(
+    rank_major_output: torch.Tensor,
+    output_sizes: list[int],
+    tp_size: int,
+) -> torch.Tensor:
+    """Convert rank-major merged shards into logical projection order."""
+    if tp_size == 1:
+        return rank_major_output
+    if any(size % tp_size for size in output_sizes):
+        raise ValueError(
+            f"Merged output sizes {output_sizes} must be divisible by TP={tp_size}"
+        )
+    local_sizes = [size // tp_size for size in output_sizes]
+    local_total = sum(local_sizes)
+    expected_width = local_total * tp_size
+    if rank_major_output.shape[-1] != expected_width:
+        raise ValueError(
+            "Unexpected gathered merged projection width: "
+            f"got {rank_major_output.shape[-1]}, expected {expected_width}"
+        )
+    rank_major = rank_major_output.unflatten(-1, (tp_size, local_total))
+    logical_local_shards = rank_major.split(local_sizes, dim=-1)
+    return torch.cat(
+        [shards.flatten(-2) for shards in logical_local_shards],
+        dim=-1,
+    )
+
+
+class KimiShardedMergedColumnParallelLinear(MergedColumnParallelLinear):
+    """Merged column projection with one gather and logical-shard reorder."""
+
+    def __init__(
+        self,
+        input_size: int,
+        output_sizes: list[int],
+        *,
+        quant_config: QuantizationConfig | None,
+        prefix: str,
+    ) -> None:
+        super().__init__(
+            input_size,
+            output_sizes,
+            bias=False,
+            gather_output=False,
+            quant_config=quant_config,
+            prefix=prefix,
+        )
+
+    def forward(self, x: torch.Tensor):
+        output_parallel, output_bias = super().forward(x)
+        if self.tp_size == 1:
+            return output_parallel, output_bias
+        rank_major_output = tensor_model_parallel_all_gather(output_parallel, dim=-1)
+        output = _restore_merged_output_order(
+            rank_major_output,
+            self.output_sizes,
+            self.tp_size,
+        )
+        return output, output_bias
 
 
 class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
@@ -190,14 +255,26 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
             # the low-rank latents are shared across TP ranks; TP splitting
             # happens at q_b_proj / kv_b_proj. Checkpoint weights ``q_a_proj``
             # and ``kv_a_proj_with_mqa`` map onto shards 0 and 1 respectively.
-            self.fused_qkv_a_proj = MergedColumnParallelLinear(
-                self.hidden_size,
-                [self.q_lora_rank, self.kv_lora_rank + self.qk_rope_head_dim],
-                bias=False,
-                quant_config=quant_config,
-                prefix=f"{prefix}.fused_qkv_a_proj",
-                disable_tp=True,
-            )
+            qkv_a_output_sizes = [
+                self.q_lora_rank,
+                self.kv_lora_rank + self.qk_rope_head_dim,
+            ]
+            if envs.VLLM_KIMI_SHARD_QKV_A and tp_size > 1:
+                self.fused_qkv_a_proj = KimiShardedMergedColumnParallelLinear(
+                    self.hidden_size,
+                    qkv_a_output_sizes,
+                    quant_config=quant_config,
+                    prefix=f"{prefix}.fused_qkv_a_proj",
+                )
+            else:
+                self.fused_qkv_a_proj = MergedColumnParallelLinear(
+                    self.hidden_size,
+                    qkv_a_output_sizes,
+                    bias=False,
+                    quant_config=quant_config,
+                    prefix=f"{prefix}.fused_qkv_a_proj",
+                    disable_tp=True,
+                )
             self.q_a_layernorm = RMSNorm(self.q_lora_rank, eps=config.rms_norm_eps)
             self.q_b_proj = ColumnParallelLinear(
                 self.q_lora_rank,

--- a/vllm/models/kimi_k3/nvidia/model.py
+++ b/vllm/models/kimi_k3/nvidia/model.py
@@ -134,6 +134,22 @@ logger = init_logger(__name__)
 _ROUTED_DOWN_PROJ_STREAM_TOKEN_THRESHOLD = 256
 
 
+def _uses_native_b12x_mxfp4_intermediate_size(
+    vllm_config: VllmConfig,
+) -> bool:
+    """Return whether B12X consumes the checkpoint MoE shard width.
+
+    The B12X W4A16 kernel accepts intermediate tails such as Kimi-K3's
+    3,072 / TP16 = 192 shard. Generic model-level padding to 256 channels per
+    rank would increase every routed-expert layer without changing its logical
+    shape.
+    """
+    if vllm_config.model_config.quantization != "mxfp4":
+        return False
+    moe_backend = vllm_config.kernel_config.moe_backend
+    return moe_backend == "b12x" or (moe_backend == "auto" and envs.VLLM_USE_B12X_MOE)
+
+
 def shard_sequence_parallel_mlp(
     hidden_size: int,
     intermediate_size: int,
@@ -667,12 +683,28 @@ class KimiMoE(nn.Module):
         min_moe_intermediate_per_partition = getattr(
             config, "min_moe_intermediate_per_partition", 256
         )
-        if self.tp_size > 1 and not vllm_config.parallel_config.enable_expert_parallel:
+        use_native_b12x_intermediate = (
+            not self.use_mega_moe
+            and _uses_native_b12x_mxfp4_intermediate_size(vllm_config)
+        )
+        if (
+            self.tp_size > 1
+            and not vllm_config.parallel_config.enable_expert_parallel
+            and not use_native_b12x_intermediate
+        ):
             moe_intermediate_per_partition = moe_intermediate_size // self.tp_size
             if moe_intermediate_per_partition < min_moe_intermediate_per_partition:
                 self.padded_moe_intermediate_size = (
                     min_moe_intermediate_per_partition * self.tp_size
                 )
+        elif use_native_b12x_intermediate:
+            logger.info_once(
+                "Kimi-K3 B12X MXFP4 keeps the checkpoint MoE intermediate "
+                "shard (%d / TP%d = %d).",
+                moe_intermediate_size,
+                self.tp_size,
+                moe_intermediate_size // self.tp_size,
+            )
         activation_situ_beta = (
             config.activation_situ_beta if config.hidden_act == "situ" else None
         )

--- a/vllm/models/kimi_k3/nvidia/tp_projection.py
+++ b/vllm/models/kimi_k3/nvidia/tp_projection.py
@@ -43,7 +43,6 @@ def _try_b12x_kimi_projection_gather(
         not envs.VLLM_USE_B12X_DCP_A2A
         or output_parallel.ndim != 2
         or output_parallel.shape[0] != 1
-        or output_parallel.dtype not in (torch.float16, torch.bfloat16)
         or not output_parallel.is_cuda
         or not output_parallel.is_contiguous()
     ):
@@ -55,15 +54,31 @@ def _try_b12x_kimi_projection_gather(
     projection_group = _get_kimi_projection_group()
 
     local_width = output_parallel.shape[1]
+    restore_dtype: torch.dtype | None = None
     strip_local_width: int | None = None
-    if local_width % 8 == 0:
+    if output_parallel.dtype in (torch.float16, torch.bfloat16):
+        if local_width % 8 == 0:
+            transport = output_parallel.view(1, 1, local_width)
+        else:
+            padded_width = (local_width + 7) // 8 * 8
+            transport = torch.nn.functional.pad(
+                output_parallel, (0, padded_width - local_width)
+            ).view(1, 1, padded_width)
+            strip_local_width = local_width
+    elif output_parallel.dtype == torch.float32:
+        raw_width = local_width * output_parallel.element_size()
+        if raw_width % 8 != 0:
+            return None
+        # The FP8 view exposes one-byte transport lanes without converting the
+        # FP32 payload. The gathered result is restored to the original dtype.
+        transport = output_parallel.view(torch.float8_e4m3fn).view(1, 1, raw_width)
+        restore_dtype = torch.float32
+    elif output_parallel.dtype == torch.float8_e4m3fn:
+        if local_width % 16 != 0:
+            return None
         transport = output_parallel.view(1, 1, local_width)
     else:
-        padded_width = (local_width + 7) // 8 * 8
-        transport = torch.nn.functional.pad(
-            output_parallel, (0, padded_width - local_width)
-        ).view(1, 1, padded_width)
-        strip_local_width = local_width
+        return None
 
     gathered = dcp_b12x_all_gather_heads(
         transport,
@@ -72,7 +87,10 @@ def _try_b12x_kimi_projection_gather(
     )
     if strip_local_width is not None:
         gathered = gathered.narrow(-1, 0, strip_local_width).contiguous()
-    return gathered.flatten(1)
+    gathered = gathered.flatten(1)
+    if restore_dtype is not None:
+        gathered = gathered.view(restore_dtype)
+    return gathered
 
 
 def gather_kimi_sharded_projection(output_parallel: torch.Tensor) -> torch.Tensor:

--- a/vllm/models/kimi_k3/nvidia/tp_projection.py
+++ b/vllm/models/kimi_k3/nvidia/tp_projection.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tensor-parallel collectives for Kimi-K3 projection outputs."""
+
+import torch
+
+import vllm.envs as envs
+from vllm.distributed import (
+    get_dcp_group,
+    get_tensor_model_parallel_world_size,
+    get_tp_group,
+    tensor_model_parallel_all_gather,
+)
+from vllm.v1.attention.ops.dcp_alltoall import dcp_b12x_all_gather_heads
+
+
+def _get_kimi_projection_group():
+    """Return the coordinator that spans every projection weight shard.
+
+    Projection weights are sharded across the full tensor-parallel group. The
+    DCP coordinator is valid only when its ordered rank list matches the
+    tensor-parallel coordinator.
+    """
+    tp_size = get_tensor_model_parallel_world_size()
+    dcp_group = get_dcp_group()
+    tp_group = get_tp_group()
+    if tp_group.world_size != tp_size:
+        raise RuntimeError(
+            "Kimi projection group does not span tensor-parallel ranks: "
+            f"group={tp_group.world_size}, TP={tp_size}"
+        )
+    if dcp_group.world_size == tp_size and list(dcp_group.ranks) == list(
+        tp_group.ranks
+    ):
+        return dcp_group
+    return tp_group
+
+
+def _try_b12x_kimi_projection_gather(
+    output_parallel: torch.Tensor,
+) -> torch.Tensor | None:
+    """Gather one decode projection over the lossless B12X copy channel."""
+    if (
+        not envs.VLLM_USE_B12X_DCP_A2A
+        or output_parallel.ndim != 2
+        or output_parallel.shape[0] != 1
+        or output_parallel.dtype not in (torch.float16, torch.bfloat16)
+        or not output_parallel.is_cuda
+        or not output_parallel.is_contiguous()
+    ):
+        return None
+
+    tp_size = get_tensor_model_parallel_world_size()
+    if tp_size <= 1:
+        return None
+    projection_group = _get_kimi_projection_group()
+
+    local_width = output_parallel.shape[1]
+    strip_local_width: int | None = None
+    if local_width % 8 == 0:
+        transport = output_parallel.view(1, 1, local_width)
+    else:
+        padded_width = (local_width + 7) // 8 * 8
+        transport = torch.nn.functional.pad(
+            output_parallel, (0, padded_width - local_width)
+        ).view(1, 1, padded_width)
+        strip_local_width = local_width
+
+    gathered = dcp_b12x_all_gather_heads(
+        transport,
+        projection_group,
+        max_batch_size=1,
+    )
+    if strip_local_width is not None:
+        gathered = gathered.narrow(-1, 0, strip_local_width).contiguous()
+    return gathered.flatten(1)
+
+
+def gather_kimi_sharded_projection(output_parallel: torch.Tensor) -> torch.Tensor:
+    """Gather a rank-major Kimi-K3 projection through a lossless fast path."""
+    if get_tensor_model_parallel_world_size() <= 1:
+        return output_parallel
+    gathered = _try_b12x_kimi_projection_gather(output_parallel)
+    if gathered is not None:
+        return gathered
+    return tensor_model_parallel_all_gather(output_parallel, dim=-1)


### PR DESCRIPTION
## Status

Implemented. This pull request is stacked on #384 and requires local-inference-lab/b12x#215 for unaligned multi-row FP8 output storage.

## Behavior

- Preserves the official Kimi-K3 MXFP4 routed-expert shard width instead of padding each TP16 shard from 192 to 256 channels.
- Tensor-parallel shards the merged MLA latent projection and restores logical row order after gather.
- Gathers BF16, FP16, FP32, and FP8 projection payloads through B12X while removing transport-only alignment rows.
- Supports opt-in KDA `f_a` sharding when the output width is divisible by the tensor-parallel size.
- Declares checkpoint-omitted KDA alignment rows and initializes them to zero before online quantization.

## Technical reason

Checkpoint padding increases routed-expert storage and can prevent the official MXFP4 checkpoint from fitting with the required KV cache. Projection sharding reduces replicated dense weight memory without changing logical tensor shapes or executed values.

## Compatibility

KDA `f_a` sharding remains disabled unless requested. TP12 rejects that option because width 128 is not divisible by 12. The replicated path remains the default because TP16 decode measurements favor replication despite its 113.20 MiB per-GPU memory cost.

## Validation

- Kimi model, TP-projection, sequence-parallel, KDA, omitted-tail, and native-MoE-shard tests pass.
- The official checkpoint keeps a 192-channel local routed-expert shard at TP16.
- The merged latent projection saves approximately 0.634 GiB per GPU at TP16.
