### PR TITLE
Fuse Kimi routed-MoE projection transport

### DIFF
--- a/tests/distributed/test_dcp_a2a.py
+++ b/tests/distributed/test_dcp_a2a.py
@@ -1719,6 +1719,45 @@ def test_b12x_kimi_pair_topk_rejects_non_contract_inputs(monkeypatch):
         )
 
 
+def test_kimi_projection_warmup_respects_transport_token_cap(monkeypatch):
+    from vllm.v1.attention.ops import dcp_alltoall
+
+    monkeypatch.setenv("VLLM_USE_B12X_DCP_A2A", "1")
+    monkeypatch.setenv("VLLM_DCP_A2A_MAX_TOKENS", "4")
+    group = _FakeCPGroup(8, object())  # type: ignore[arg-type]
+    calls: list[tuple[str, tuple[int, ...], tuple[int, ...]]] = []
+
+    def pair(local_down, local_router, projection_group, *, max_batch_size):
+        assert projection_group is group
+        assert max_batch_size == 8
+        calls.append(("pair", tuple(local_down.shape), tuple(local_router.shape)))
+        return local_down, local_router
+
+    def topk(local_down, local_router, correction_bias, projection_group):
+        assert projection_group is group
+        assert correction_bias.shape == (896,)
+        calls.append(("topk", tuple(local_down.shape), tuple(local_router.shape)))
+        return local_down, torch.empty(2, 16)
+
+    monkeypatch.setattr(dcp_alltoall, "_try_b12x_dcp_all_gather_pair", pair)
+    monkeypatch.setattr(
+        dcp_alltoall,
+        "try_dcp_b12x_all_gather_pair_kimi_topk",
+        topk,
+    )
+
+    warmed = dcp_alltoall.warmup_b12x_kimi_projection_gathers(
+        group,  # type: ignore[arg-type]
+        device=torch.device("cpu"),
+    )
+
+    assert warmed == 2
+    assert calls == [
+        ("pair", (4, 448), (4, 112)),
+        ("topk", (1, 448), (1, 112)),
+    ]
+
+
 def test_warmup_skips_unsupported_world_size(monkeypatch: pytest.MonkeyPatch):
     from vllm.v1.attention.ops import dcp_alltoall
 

--- a/tests/distributed/test_dcp_a2a.py
+++ b/tests/distributed/test_dcp_a2a.py
@@ -1606,6 +1606,119 @@ def test_pair_gather_fallback_preserves_tensor_order(monkeypatch):
     assert calls[1][0] is local_second and calls[1][1] == -1
 
 
+@pytest.mark.parametrize("world_size", [2, 4, 8, 16])
+@pytest.mark.skipif(torch.accelerator.device_count() < 1, reason="CUDA is required.")
+def test_b12x_kimi_pair_topk_supports_projection_world_sizes(
+    monkeypatch: pytest.MonkeyPatch,
+    world_size: int,
+):
+    from vllm.v1.attention.ops import dcp_alltoall
+
+    monkeypatch.setenv("VLLM_USE_B12X_DCP_A2A", "1")
+    local_down = torch.zeros(1, 3584 // world_size, dtype=torch.bfloat16, device="cuda")
+    local_router = torch.zeros(1, 896 // world_size, dtype=torch.float32, device="cuda")
+    correction_bias = torch.zeros(896, dtype=torch.float32, device="cuda")
+    received: dict[str, Any] = {}
+
+    class _FakePool:
+        def all_gather_pair_kimi_topk(
+            self,
+            down,
+            router,
+            bias,
+            out_down,
+            topk_weights,
+            topk_ids,
+            *,
+            channel_id,
+        ):
+            received.update(
+                down=down,
+                router=router,
+                bias=bias,
+                out_down=out_down,
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
+                channel_id=channel_id,
+            )
+
+    def fake_get_pool(cp_group, **kwargs):
+        received.update(kwargs)
+        return _FakePool()
+
+    monkeypatch.setattr(dcp_alltoall, "_get_b12x_dcp_a2a_pool", fake_get_pool)
+    monkeypatch.setattr(
+        dcp_alltoall,
+        "_b12x_dcp_channel_id",
+        lambda _group: "vllm:draft:decode:graph-2",
+    )
+    group = _FakeCPGroup(world_size, object())  # type: ignore[arg-type]
+
+    actual = dcp_alltoall.try_dcp_b12x_all_gather_pair_kimi_topk(
+        local_down,
+        local_router,
+        correction_bias,
+        group,  # type: ignore[arg-type]
+    )
+
+    assert actual is not None
+    gathered_down, routing_payload = actual
+    assert gathered_down.shape == (1, 3584)
+    assert gathered_down.dtype == torch.bfloat16
+    assert routing_payload.shape == (2, 16)
+    assert routing_payload.dtype == torch.float32
+    assert received.pop("down") is local_down
+    assert received.pop("router") is local_router
+    assert received.pop("bias") is correction_bias
+    assert received.pop("out_down") is gathered_down
+    assert received.pop("topk_weights").data_ptr() == routing_payload.data_ptr()
+    assert received.pop("topk_ids").data_ptr() == routing_payload[1].data_ptr()
+    combined_row_bytes = 7168 // world_size + 3584 // world_size
+    assert received == {
+        "channel_id": "vllm:draft:decode:graph-2",
+        "device": local_down.device,
+        "total_heads": world_size,
+        "head_dim": combined_row_bytes,
+        "query_head_dim": combined_row_bytes,
+        "max_batch_size": 1,
+    }
+
+
+@pytest.mark.skipif(torch.accelerator.device_count() < 1, reason="CUDA is required.")
+def test_b12x_kimi_pair_topk_rejects_non_contract_inputs(monkeypatch):
+    from vllm.v1.attention.ops import dcp_alltoall
+
+    monkeypatch.setenv("VLLM_USE_B12X_DCP_A2A", "1")
+    monkeypatch.setattr(
+        dcp_alltoall,
+        "_get_b12x_dcp_a2a_pool",
+        lambda *args, **kwargs: pytest.fail("invalid inputs must not create a pool"),
+    )
+    group = _FakeCPGroup(8, object())  # type: ignore[arg-type]
+    down = torch.zeros(1, 448, dtype=torch.bfloat16, device="cuda")
+    router = torch.zeros(1, 112, dtype=torch.float32, device="cuda")
+    bias = torch.zeros(896, dtype=torch.float32, device="cuda")
+
+    invalid_inputs = (
+        (down.expand(2, -1), router.expand(2, -1), bias),
+        (down[:, :-1].contiguous(), router, bias),
+        (down, router[:, :-1].contiguous(), bias),
+        (down, router, bias[:-1].contiguous()),
+        (down.float(), router, bias),
+        (down, router.bfloat16(), bias),
+    )
+    for invalid_down, invalid_router, invalid_bias in invalid_inputs:
+        assert (
+            dcp_alltoall.try_dcp_b12x_all_gather_pair_kimi_topk(
+                invalid_down,
+                invalid_router,
+                invalid_bias,
+                group,  # type: ignore[arg-type]
+            )
+            is None
+        )
+
+
 def test_warmup_skips_unsupported_world_size(monkeypatch: pytest.MonkeyPatch):
     from vllm.v1.attention.ops import dcp_alltoall
 

--- a/tests/distributed/test_dcp_a2a.py
+++ b/tests/distributed/test_dcp_a2a.py
@@ -1607,16 +1607,22 @@ def test_pair_gather_fallback_preserves_tensor_order(monkeypatch):
 
 
 @pytest.mark.parametrize("world_size", [2, 4, 8, 16])
+@pytest.mark.parametrize("batch", [1, 8])
 @pytest.mark.skipif(torch.accelerator.device_count() < 1, reason="CUDA is required.")
 def test_b12x_kimi_pair_topk_supports_projection_world_sizes(
     monkeypatch: pytest.MonkeyPatch,
     world_size: int,
+    batch: int,
 ):
     from vllm.v1.attention.ops import dcp_alltoall
 
     monkeypatch.setenv("VLLM_USE_B12X_DCP_A2A", "1")
-    local_down = torch.zeros(1, 3584 // world_size, dtype=torch.bfloat16, device="cuda")
-    local_router = torch.zeros(1, 896 // world_size, dtype=torch.float32, device="cuda")
+    local_down = torch.zeros(
+        batch, 3584 // world_size, dtype=torch.bfloat16, device="cuda"
+    )
+    local_router = torch.zeros(
+        batch, 896 // world_size, dtype=torch.float32, device="cuda"
+    )
     correction_bias = torch.zeros(896, dtype=torch.float32, device="cuda")
     received: dict[str, Any] = {}
 
@@ -1633,6 +1639,7 @@ def test_b12x_kimi_pair_topk_supports_projection_world_sizes(
             channel_id,
         ):
             received.update(
+                operation="combined",
                 down=down,
                 router=router,
                 bias=bias,
@@ -1640,6 +1647,40 @@ def test_b12x_kimi_pair_topk_supports_projection_world_sizes(
                 topk_weights=topk_weights,
                 topk_ids=topk_ids,
                 channel_id=channel_id,
+            )
+
+        def all_gather_pair(self, down, router, *, channel_id):
+            gathered_down = torch.empty(
+                batch, 3584, dtype=torch.bfloat16, device="cuda"
+            )
+            gathered_router = torch.empty(
+                batch, 896, dtype=torch.float32, device="cuda"
+            )
+            received.update(
+                operation="batched",
+                down=down,
+                router=router,
+                gathered_down=gathered_down,
+                gathered_router=gathered_router,
+                channel_id=channel_id,
+            )
+            return gathered_down, gathered_router
+
+        def kimi_topk16(
+            self,
+            router,
+            bias,
+            topk_weights,
+            topk_ids,
+            *,
+            channel_id,
+        ):
+            received.update(
+                topk_router=router,
+                bias=bias,
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
+                topk_channel_id=channel_id,
             )
 
     def fake_get_pool(cp_group, **kwargs):
@@ -1663,16 +1704,23 @@ def test_b12x_kimi_pair_topk_supports_projection_world_sizes(
 
     assert actual is not None
     gathered_down, routing_payload = actual
-    assert gathered_down.shape == (1, 3584)
+    assert gathered_down.shape == (batch, 3584)
     assert gathered_down.dtype == torch.bfloat16
-    assert routing_payload.shape == (2, 16)
+    assert routing_payload.shape == (batch * 2, 16)
     assert routing_payload.dtype == torch.float32
     assert received.pop("down") is local_down
     assert received.pop("router") is local_router
     assert received.pop("bias") is correction_bias
-    assert received.pop("out_down") is gathered_down
     assert received.pop("topk_weights").data_ptr() == routing_payload.data_ptr()
-    assert received.pop("topk_ids").data_ptr() == routing_payload[1].data_ptr()
+    assert received.pop("topk_ids").data_ptr() == routing_payload[batch].data_ptr()
+    if batch == 1:
+        assert received.pop("operation") == "combined"
+        assert received.pop("out_down") is gathered_down
+    else:
+        assert received.pop("operation") == "batched"
+        assert received.pop("gathered_down") is gathered_down
+        assert received.pop("topk_router") is received.pop("gathered_router")
+        assert received.pop("topk_channel_id") == "vllm:draft:decode:graph-2"
     combined_row_bytes = 7168 // world_size + 3584 // world_size
     assert received == {
         "channel_id": "vllm:draft:decode:graph-2",
@@ -1680,7 +1728,7 @@ def test_b12x_kimi_pair_topk_supports_projection_world_sizes(
         "total_heads": world_size,
         "head_dim": combined_row_bytes,
         "query_head_dim": combined_row_bytes,
-        "max_batch_size": 1,
+        "max_batch_size": 1 if batch == 1 else 8,
     }
 
 
@@ -1700,7 +1748,8 @@ def test_b12x_kimi_pair_topk_rejects_non_contract_inputs(monkeypatch):
     bias = torch.zeros(896, dtype=torch.float32, device="cuda")
 
     invalid_inputs = (
-        (down.expand(2, -1), router.expand(2, -1), bias),
+        (down.expand(9, -1), router.expand(9, -1), bias),
+        (down.expand(2, -1), router, bias),
         (down[:, :-1].contiguous(), router, bias),
         (down, router[:, :-1].contiguous(), bias),
         (down, router, bias[:-1].contiguous()),
@@ -1717,6 +1766,33 @@ def test_b12x_kimi_pair_topk_rejects_non_contract_inputs(monkeypatch):
             )
             is None
         )
+
+
+@pytest.mark.skipif(torch.accelerator.device_count() < 1, reason="CUDA is required.")
+def test_b12x_kimi_batched_topk_requires_batched_router_binding(monkeypatch):
+    from vllm.v1.attention.ops import dcp_alltoall
+
+    monkeypatch.setenv("VLLM_USE_B12X_DCP_A2A", "1")
+
+    class _OneTokenPool:
+        def all_gather_pair_kimi_topk(self, *args, **kwargs):
+            pytest.fail("an eight-token input must not use the one-token operation")
+
+    monkeypatch.setattr(
+        dcp_alltoall,
+        "_get_b12x_dcp_a2a_pool",
+        lambda *args, **kwargs: _OneTokenPool(),
+    )
+    group = _FakeCPGroup(8, object())  # type: ignore[arg-type]
+
+    result = dcp_alltoall.try_dcp_b12x_all_gather_pair_kimi_topk(
+        torch.zeros(8, 448, dtype=torch.bfloat16, device="cuda"),
+        torch.zeros(8, 112, dtype=torch.float32, device="cuda"),
+        torch.zeros(896, dtype=torch.float32, device="cuda"),
+        group,  # type: ignore[arg-type]
+    )
+
+    assert result is None
 
 
 def test_kimi_projection_warmup_respects_transport_token_cap(monkeypatch):
@@ -1737,7 +1813,7 @@ def test_kimi_projection_warmup_respects_transport_token_cap(monkeypatch):
         assert projection_group is group
         assert correction_bias.shape == (896,)
         calls.append(("topk", tuple(local_down.shape), tuple(local_router.shape)))
-        return local_down, torch.empty(2, 16)
+        return local_down, torch.empty(local_down.shape[0] * 2, 16)
 
     monkeypatch.setattr(dcp_alltoall, "_try_b12x_dcp_all_gather_pair", pair)
     monkeypatch.setattr(
@@ -1751,10 +1827,11 @@ def test_kimi_projection_warmup_respects_transport_token_cap(monkeypatch):
         device=torch.device("cpu"),
     )
 
-    assert warmed == 2
+    assert warmed == 3
     assert calls == [
         ("pair", (4, 448), (4, 112)),
         ("topk", (1, 448), (1, 112)),
+        ("topk", (4, 448), (4, 112)),
     ]
 
 

--- a/tests/distributed/test_dcp_a2a.py
+++ b/tests/distributed/test_dcp_a2a.py
@@ -1014,10 +1014,15 @@ def test_profile_channel_checkpoint_deduplicates_shared_b12x_pool(monkeypatch):
     monkeypatch.setattr(parallel_state, "_TP", tp_group)
     monkeypatch.setattr(parallel_state, "_PP", None)
     monkeypatch.setattr(parallel_state, "_DCP", dcp_group)
+
+    def checkpoint(group: _FakeGroup) -> str:
+        events.append(group.name)
+        return group.name
+
     monkeypatch.setattr(
         dcp_alltoall,
         "checkpoint_b12x_dcp_a2a_channels",
-        lambda group: events.append(group.name) or group.name,
+        checkpoint,
     )
 
     parallel_state.checkpoint_b12x_graph_channels()

--- a/tests/model_executor/test_flashinfer_autotune_cache.py
+++ b/tests/model_executor/test_flashinfer_autotune_cache.py
@@ -244,6 +244,41 @@ def test_b12x_dcp_warmup_finds_generic_mla_attention(monkeypatch) -> None:
     ]
 
 
+def test_b12x_projection_warmup_uses_complete_projection_group(monkeypatch) -> None:
+    from vllm.distributed import parallel_state
+    from vllm.models.kimi_k3.nvidia.model import KimiMoE
+    from vllm.v1.attention.ops import dcp_alltoall
+
+    monkeypatch.setenv("VLLM_USE_B12X_DCP_A2A", "1")
+    moe = object.__new__(KimiMoE)
+    torch.nn.Module.__init__(moe)
+    moe.auxiliary_projections_tp_sharded = True
+    moe.register_parameter("device_probe", torch.nn.Parameter(torch.empty(1)))
+    model = torch.nn.Module()
+    model.add_module("moe", moe)
+    worker = SimpleNamespace(get_model=lambda: model)
+    tp_group = SimpleNamespace(world_size=16, ranks=list(range(16)))
+    dcp_group = SimpleNamespace(world_size=8, ranks=list(range(8)))
+    calls = []
+    monkeypatch.setattr(parallel_state, "get_tp_group", lambda: tp_group)
+    monkeypatch.setattr(parallel_state, "get_dcp_group", lambda: dcp_group)
+    monkeypatch.setattr(
+        dcp_alltoall,
+        "warmup_b12x_kimi_projection_gathers",
+        lambda *args, **kwargs: calls.append((args, kwargs)) or 2,
+    )
+
+    warmed = kernel_warmup._warmup_b12x_kimi_projection_gathers(worker)
+
+    assert warmed == 2
+    assert calls == [
+        (
+            (tp_group,),
+            {"device": torch.device("cpu")},
+        )
+    ]
+
+
 def test_kernel_warmup_runs_b12x_mxfp8_linear_warmup(monkeypatch) -> None:
     calls = []
     model = torch.nn.Linear(2, 2)

--- a/tests/model_executor/test_flashinfer_autotune_cache.py
+++ b/tests/model_executor/test_flashinfer_autotune_cache.py
@@ -262,10 +262,15 @@ def test_b12x_projection_warmup_uses_complete_projection_group(monkeypatch) -> N
     calls = []
     monkeypatch.setattr(parallel_state, "get_tp_group", lambda: tp_group)
     monkeypatch.setattr(parallel_state, "get_dcp_group", lambda: dcp_group)
+
+    def warmup(*args, **kwargs):
+        calls.append((args, kwargs))
+        return 2
+
     monkeypatch.setattr(
         dcp_alltoall,
         "warmup_b12x_kimi_projection_gathers",
-        lambda *args, **kwargs: calls.append((args, kwargs)) or 2,
+        warmup,
     )
 
     warmed = kernel_warmup._warmup_b12x_kimi_projection_gathers(worker)

--- a/tests/models/kimi_k3/test_sequence_parallel.py
+++ b/tests/models/kimi_k3/test_sequence_parallel.py
@@ -547,13 +547,16 @@ def _make_paired_projection_moe():
     return moe
 
 
-def test_kimi_moe_uses_fused_projection_routing_payload(monkeypatch):
+@pytest.mark.parametrize("num_tokens", [1, 8])
+def test_kimi_moe_uses_precomputed_projection_routing_payload(
+    monkeypatch, num_tokens: int
+):
     moe = _make_paired_projection_moe()
-    hidden_states = torch.empty(1, 4)
-    local_router = torch.empty(1, 3)
-    local_down = torch.empty(1, 2)
-    gathered_down = torch.empty(1, 3)
-    routing_payload = torch.empty(2, 16)
+    hidden_states = torch.empty(num_tokens, 4)
+    local_router = torch.empty(num_tokens, 3)
+    local_down = torch.empty(num_tokens, 2)
+    gathered_down = torch.empty(num_tokens, 3)
+    routing_payload = torch.empty(num_tokens * 2, 16)
     monkeypatch.setattr(
         kimi_model.KimiColumnParallelGate,
         "forward_local",
@@ -577,7 +580,9 @@ def test_kimi_moe_uses_fused_projection_routing_payload(monkeypatch):
     monkeypatch.setattr(
         kimi_model,
         "gather_kimi_sharded_projection_pair",
-        lambda *_args: pytest.fail("the fused result must skip paired gather"),
+        lambda *_args: pytest.fail(
+            "precomputed routing must skip the model-level paired gather"
+        ),
     )
 
     routed_hidden, router_output, topk_ids = moe._maybe_overlap_router_and_down_proj(

--- a/tests/models/kimi_k3/test_sequence_parallel.py
+++ b/tests/models/kimi_k3/test_sequence_parallel.py
@@ -385,6 +385,72 @@ def test_kimi_column_parallel_loader_zero_fills_tail():
     torch.testing.assert_close(param, expected)
 
 
+def test_kimi_padded_column_gathers_and_removes_logical_tail(monkeypatch):
+    layer = object.__new__(kimi_model.KimiPaddedColumnParallelLinear)
+    nn.Module.__init__(layer)
+    layer.kimi_gather_output = True
+    layer.logical_output_size = 5
+    local_output = torch.arange(3, dtype=torch.float32).view(1, 3)
+    gathered_output = torch.arange(6, dtype=torch.float32).view(1, 6)
+    monkeypatch.setattr(
+        kimi_model.ColumnParallelLinear,
+        "forward",
+        lambda _self, _x: (local_output, None),
+    )
+    monkeypatch.setattr(
+        kimi_model,
+        "gather_kimi_sharded_projection",
+        lambda output: gathered_output,
+    )
+
+    output, bias = layer(torch.empty(1, 1))
+
+    torch.testing.assert_close(output, gathered_output[:, :5])
+    assert output.is_contiguous()
+    assert bias is None
+
+
+def test_kimi_gate_local_projection_preserves_linear_return_contract():
+    layer = object.__new__(kimi_model.KimiColumnParallelGate)
+    nn.Module.__init__(layer)
+    layer.weight = nn.Parameter(torch.arange(12).view(3, 4).float())
+    hidden_states = torch.arange(8).view(2, 4).float()
+
+    output, bias = layer.forward_local(hidden_states)
+
+    torch.testing.assert_close(
+        output,
+        torch.nn.functional.linear(hidden_states, layer.weight),
+    )
+    assert output.dtype == torch.float32
+    assert bias is None
+
+
+def test_kimi_gate_gathers_fp32_local_projection(monkeypatch):
+    layer = object.__new__(kimi_model.KimiColumnParallelGate)
+    nn.Module.__init__(layer)
+    layer.logical_output_size = 5
+    layer.weight = nn.Parameter(torch.arange(12).view(3, 4).float())
+    hidden_states = torch.arange(8).view(2, 4).float()
+    gathered = torch.arange(12).view(2, 6).float()
+    received: dict[str, torch.Tensor] = {}
+
+    def gather(output: torch.Tensor) -> torch.Tensor:
+        received["local"] = output
+        return gathered
+
+    monkeypatch.setattr(kimi_model, "gather_kimi_sharded_projection", gather)
+
+    output, bias = layer(hidden_states)
+
+    torch.testing.assert_close(
+        received["local"],
+        torch.nn.functional.linear(hidden_states, layer.weight),
+    )
+    torch.testing.assert_close(output, gathered[:, :5])
+    assert bias is None
+
+
 def test_kimi_merged_projection_restores_logical_output_order(monkeypatch):
     layer = object.__new__(kimi_mla.KimiShardedMergedColumnParallelLinear)
     nn.Module.__init__(layer)

--- a/tests/models/kimi_k3/test_sequence_parallel.py
+++ b/tests/models/kimi_k3/test_sequence_parallel.py
@@ -451,6 +451,84 @@ def test_kimi_gate_gathers_fp32_local_projection(monkeypatch):
     assert bias is None
 
 
+def test_kimi_router_decodes_precomputed_topk_payload_without_copy():
+    router = kimi_model.KimiK3PrecomputedTopKRouter(
+        top_k=16,
+        global_num_experts=896,
+        e_score_correction_bias=nn.Parameter(torch.zeros(896)),
+        renormalize=True,
+        routed_scaling_factor=1.0,
+        scoring_func="sigmoid",
+    )
+    num_tokens = 3
+    hidden_states = torch.empty(num_tokens, 4)
+    payload = torch.empty(num_tokens * 2, 16, dtype=torch.float32)
+    expected_weights = torch.arange(num_tokens * 16, dtype=torch.float32).view(
+        num_tokens, 16
+    )
+    expected_ids = torch.arange(num_tokens * 16, dtype=torch.int32).view(num_tokens, 16)
+    payload[:num_tokens].copy_(expected_weights)
+    payload[num_tokens:].view(torch.int32).copy_(expected_ids)
+
+    weights, ids = router._compute_routing(hidden_states, payload, torch.int32)
+
+    assert weights.data_ptr() == payload.data_ptr()
+    assert ids.data_ptr() == payload[num_tokens:].data_ptr()
+    torch.testing.assert_close(weights, expected_weights)
+    torch.testing.assert_close(ids, expected_ids)
+
+
+def test_kimi_router_uses_standard_routing_for_non_payload(monkeypatch):
+    router = kimi_model.KimiK3PrecomputedTopKRouter(
+        top_k=16,
+        global_num_experts=896,
+        e_score_correction_bias=nn.Parameter(torch.zeros(896)),
+        renormalize=True,
+        routed_scaling_factor=1.0,
+        scoring_func="sigmoid",
+    )
+    hidden_states = torch.empty(2, 4)
+    router_logits = torch.empty(2, 896)
+    input_ids = torch.tensor([1, 2])
+    expected = (torch.empty(2, 16), torch.empty(2, 16, dtype=torch.int32))
+    received: dict[str, object] = {}
+
+    def standard_routing(
+        _self,
+        hidden_states_arg,
+        router_logits_arg,
+        indices_type_arg,
+        *,
+        input_ids=None,
+    ):
+        received.update(
+            hidden_states=hidden_states_arg,
+            router_logits=router_logits_arg,
+            indices_type=indices_type_arg,
+            input_ids=input_ids,
+        )
+        return expected
+
+    monkeypatch.setattr(
+        kimi_model.FusedTopKBiasRouter,
+        "_compute_routing",
+        standard_routing,
+    )
+
+    actual = router._compute_routing(
+        hidden_states,
+        router_logits,
+        torch.int32,
+        input_ids=input_ids,
+    )
+
+    assert actual is expected
+    assert received["hidden_states"] is hidden_states
+    assert received["router_logits"] is router_logits
+    assert received["indices_type"] is torch.int32
+    assert received["input_ids"] is input_ids
+
+
 def test_kimi_merged_projection_restores_logical_output_order(monkeypatch):
     layer = object.__new__(kimi_mla.KimiShardedMergedColumnParallelLinear)
     nn.Module.__init__(layer)

--- a/tests/models/kimi_k3/test_sequence_parallel.py
+++ b/tests/models/kimi_k3/test_sequence_parallel.py
@@ -478,6 +478,42 @@ def test_kimi_router_decodes_precomputed_topk_payload_without_copy():
     torch.testing.assert_close(ids, expected_ids)
 
 
+def test_kimi_router_marks_precomputed_padding_routes_inactive(monkeypatch):
+    router = kimi_model.KimiK3PrecomputedTopKRouter(
+        top_k=16,
+        global_num_experts=896,
+        e_score_correction_bias=nn.Parameter(torch.zeros(896)),
+        renormalize=True,
+        routed_scaling_factor=1.0,
+        scoring_func="sigmoid",
+    )
+    num_tokens = 3
+    hidden_states = torch.empty(num_tokens, 4)
+    payload = torch.empty(num_tokens * 2, 16, dtype=torch.float32)
+    expected_weights = torch.arange(num_tokens * 16, dtype=torch.float32).view(
+        num_tokens, 16
+    )
+    expected_ids = torch.arange(num_tokens * 16, dtype=torch.int32).view(num_tokens, 16)
+    payload[:num_tokens].copy_(expected_weights)
+    payload[num_tokens:].view(torch.int32).copy_(expected_ids)
+    monkeypatch.setattr(kimi_model.envs, "VLLM_MOE_SKIP_PADDING", True)
+    monkeypatch.setattr(kimi_model, "is_forward_context_available", lambda: True)
+    monkeypatch.setattr(
+        kimi_model,
+        "get_forward_context",
+        lambda: SimpleNamespace(is_padding=torch.tensor([False, True, False])),
+    )
+
+    weights, ids = router._compute_routing(hidden_states, payload, torch.int32)
+
+    assert weights.data_ptr() == payload.data_ptr()
+    assert ids.data_ptr() == payload[num_tokens:].data_ptr()
+    torch.testing.assert_close(weights, expected_weights)
+    torch.testing.assert_close(ids[0], expected_ids[0])
+    torch.testing.assert_close(ids[1], torch.full((16,), -1, dtype=torch.int32))
+    torch.testing.assert_close(ids[2], expected_ids[2])
+
+
 def test_kimi_router_uses_standard_routing_for_non_payload(monkeypatch):
     router = kimi_model.KimiK3PrecomputedTopKRouter(
         top_k=16,

--- a/tests/models/kimi_k3/test_sequence_parallel.py
+++ b/tests/models/kimi_k3/test_sequence_parallel.py
@@ -529,6 +529,110 @@ def test_kimi_router_uses_standard_routing_for_non_payload(monkeypatch):
     assert received["input_ids"] is input_ids
 
 
+def _make_paired_projection_moe():
+    moe = object.__new__(kimi_model.KimiMoE)
+    nn.Module.__init__(moe)
+    moe.use_mega_moe = False
+    moe.gate = object.__new__(kimi_model.KimiColumnParallelGate)
+    nn.Module.__init__(moe.gate)
+    moe.gate.logical_output_size = 5
+    moe.gate.e_score_correction_bias = nn.Parameter(torch.zeros(5))
+    moe.routed_expert_down_proj = object.__new__(
+        kimi_model.KimiPaddedColumnParallelLinear
+    )
+    nn.Module.__init__(moe.routed_expert_down_proj)
+    moe.routed_expert_down_proj.logical_output_size = 3
+    moe._down_proj_events = (None, None)
+    moe._down_proj_stream = None
+    return moe
+
+
+def test_kimi_moe_uses_fused_projection_routing_payload(monkeypatch):
+    moe = _make_paired_projection_moe()
+    hidden_states = torch.empty(1, 4)
+    local_router = torch.empty(1, 3)
+    local_down = torch.empty(1, 2)
+    gathered_down = torch.empty(1, 3)
+    routing_payload = torch.empty(2, 16)
+    monkeypatch.setattr(
+        kimi_model.KimiColumnParallelGate,
+        "forward_local",
+        lambda _self, _hidden: (local_router, None),
+    )
+    monkeypatch.setattr(
+        kimi_model.KimiPaddedColumnParallelLinear,
+        "forward_local",
+        lambda _self, _hidden: (local_down, None),
+    )
+    monkeypatch.setattr(
+        kimi_model,
+        "maybe_execute_in_parallel",
+        lambda first, second, *_args: (first(), second()),
+    )
+    monkeypatch.setattr(
+        kimi_model,
+        "try_gather_kimi_sharded_projection_pair_topk",
+        lambda down, router, bias: (gathered_down, routing_payload),
+    )
+    monkeypatch.setattr(
+        kimi_model,
+        "gather_kimi_sharded_projection_pair",
+        lambda *_args: pytest.fail("the fused result must skip paired gather"),
+    )
+
+    routed_hidden, router_output, topk_ids = moe._maybe_overlap_router_and_down_proj(
+        hidden_states
+    )
+
+    assert routed_hidden is gathered_down
+    assert router_output is routing_payload
+    assert topk_ids is None
+
+
+def test_kimi_moe_paired_projection_uses_exact_router_fallback(monkeypatch):
+    moe = _make_paired_projection_moe()
+    hidden_states = torch.empty(2, 4)
+    local_router = torch.empty(2, 3)
+    local_down = torch.empty(2, 2)
+    gathered_router = torch.arange(12, dtype=torch.float32).view(2, 6)
+    gathered_down = torch.arange(8, dtype=torch.float32).view(2, 4)
+    monkeypatch.setattr(
+        kimi_model.KimiColumnParallelGate,
+        "forward_local",
+        lambda _self, _hidden: (local_router, None),
+    )
+    monkeypatch.setattr(
+        kimi_model.KimiPaddedColumnParallelLinear,
+        "forward_local",
+        lambda _self, _hidden: (local_down, None),
+    )
+    monkeypatch.setattr(
+        kimi_model,
+        "maybe_execute_in_parallel",
+        lambda first, second, *_args: (first(), second()),
+    )
+    monkeypatch.setattr(
+        kimi_model,
+        "try_gather_kimi_sharded_projection_pair_topk",
+        lambda *_args: None,
+    )
+    monkeypatch.setattr(
+        kimi_model,
+        "gather_kimi_sharded_projection_pair",
+        lambda down, router: (gathered_down, gathered_router),
+    )
+
+    routed_hidden, router_output, topk_ids = moe._maybe_overlap_router_and_down_proj(
+        hidden_states
+    )
+
+    torch.testing.assert_close(routed_hidden, gathered_down[:, :3])
+    torch.testing.assert_close(router_output, gathered_router[:, :5])
+    assert routed_hidden.is_contiguous()
+    assert router_output.is_contiguous()
+    assert topk_ids is None
+
+
 def test_kimi_merged_projection_restores_logical_output_order(monkeypatch):
     layer = object.__new__(kimi_mla.KimiShardedMergedColumnParallelLinear)
     nn.Module.__init__(layer)

--- a/tests/models/kimi_k3/test_tp_projection.py
+++ b/tests/models/kimi_k3/test_tp_projection.py
@@ -262,3 +262,70 @@ def test_projection_pair_uses_exact_separate_fallback(monkeypatch):
     assert actual[1] is gathered_second
     assert calls[0] is first
     assert calls[1] is second
+
+
+def test_projection_pair_topk_uses_available_b12x_binding(monkeypatch):
+    local_down = torch.empty(1, 448)
+    local_router = torch.empty(1, 112)
+    correction_bias = torch.empty(896)
+    group = SimpleNamespace(world_size=8, ranks=list(range(8)))
+    expected = (torch.empty(1, 3584), torch.empty(2, 16))
+    received: dict[str, object] = {}
+    monkeypatch.setattr(
+        tp_projection, "get_tensor_model_parallel_world_size", lambda: 8
+    )
+    monkeypatch.setattr(tp_projection, "_get_kimi_projection_group", lambda: group)
+
+    def pair_topk(local_down_arg, local_router_arg, bias_arg, group_arg):
+        received.update(
+            local_down=local_down_arg,
+            local_router=local_router_arg,
+            correction_bias=bias_arg,
+            group=group_arg,
+        )
+        return expected
+
+    monkeypatch.setattr(
+        tp_projection.dcp_alltoall,
+        "try_dcp_b12x_all_gather_pair_kimi_topk",
+        pair_topk,
+        raising=False,
+    )
+
+    actual = tp_projection.try_gather_kimi_sharded_projection_pair_topk(
+        local_down,
+        local_router,
+        correction_bias,
+    )
+
+    assert actual is expected
+    assert received == {
+        "local_down": local_down,
+        "local_router": local_router,
+        "correction_bias": correction_bias,
+        "group": group,
+    }
+
+
+def test_projection_pair_topk_returns_none_without_b12x_binding(monkeypatch):
+    monkeypatch.setattr(
+        tp_projection, "get_tensor_model_parallel_world_size", lambda: 8
+    )
+    monkeypatch.delattr(
+        tp_projection.dcp_alltoall,
+        "try_dcp_b12x_all_gather_pair_kimi_topk",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        tp_projection,
+        "_get_kimi_projection_group",
+        lambda: pytest.fail("an unavailable binding must not resolve a group"),
+    )
+
+    actual = tp_projection.try_gather_kimi_sharded_projection_pair_topk(
+        torch.empty(1, 448),
+        torch.empty(1, 112),
+        torch.empty(896),
+    )
+
+    assert actual is None

--- a/tests/models/kimi_k3/test_tp_projection.py
+++ b/tests/models/kimi_k3/test_tp_projection.py
@@ -189,3 +189,76 @@ def test_projection_gather_uses_standard_collective_outside_decode(monkeypatch):
     actual = tp_projection.gather_kimi_sharded_projection(local)
 
     assert actual is expected
+
+
+def test_projection_pair_is_identity_at_tp1(monkeypatch):
+    first = torch.empty(2, 8)
+    second = torch.empty(2, 4)
+    monkeypatch.setattr(
+        tp_projection, "get_tensor_model_parallel_world_size", lambda: 1
+    )
+
+    actual = tp_projection.gather_kimi_sharded_projection_pair(first, second)
+
+    assert actual[0] is first
+    assert actual[1] is second
+
+
+@pytest.mark.skipif(torch.accelerator.device_count() < 1, reason="CUDA is required.")
+def test_projection_pair_uses_one_b12x_barrier(monkeypatch):
+    tp_size = 2
+    first = torch.empty(2, 8, dtype=torch.bfloat16, device="cuda")
+    second = torch.empty(2, 4, dtype=torch.float32, device="cuda")
+    expected = (
+        torch.empty(2, 16, dtype=first.dtype, device=first.device),
+        torch.empty(2, 8, dtype=second.dtype, device=second.device),
+    )
+    group = SimpleNamespace(world_size=tp_size, ranks=list(range(tp_size)))
+    received: dict[str, object] = {}
+    monkeypatch.setattr(
+        tp_projection, "get_tensor_model_parallel_world_size", lambda: tp_size
+    )
+    monkeypatch.setattr(tp_projection, "_get_kimi_projection_group", lambda: group)
+
+    def gather_pair(local_first, local_second, projection_group, *, max_batch_size):
+        received.update(
+            local_first=local_first,
+            local_second=local_second,
+            projection_group=projection_group,
+            max_batch_size=max_batch_size,
+        )
+        return expected
+
+    monkeypatch.setattr(tp_projection, "dcp_b12x_all_gather_pair", gather_pair)
+
+    actual = tp_projection.gather_kimi_sharded_projection_pair(first, second)
+
+    assert actual is expected
+    assert received["local_first"] is first
+    assert received["local_second"] is second
+    assert received["projection_group"] is group
+    assert received["max_batch_size"] == 8
+
+
+def test_projection_pair_uses_exact_separate_fallback(monkeypatch):
+    first = torch.empty(9, 8)
+    second = torch.empty(9, 4)
+    gathered_first = torch.empty(9, 16)
+    gathered_second = torch.empty(9, 8)
+    calls: list[torch.Tensor] = []
+    monkeypatch.setattr(
+        tp_projection, "get_tensor_model_parallel_world_size", lambda: 2
+    )
+
+    def gather_one(local: torch.Tensor) -> torch.Tensor:
+        calls.append(local)
+        return gathered_first if local is first else gathered_second
+
+    monkeypatch.setattr(tp_projection, "gather_kimi_sharded_projection", gather_one)
+
+    actual = tp_projection.gather_kimi_sharded_projection_pair(first, second)
+
+    assert actual[0] is gathered_first
+    assert actual[1] is gathered_second
+    assert calls[0] is first
+    assert calls[1] is second

--- a/vllm/model_executor/warmup/kernel_warmup.py
+++ b/vllm/model_executor/warmup/kernel_warmup.py
@@ -262,6 +262,40 @@ def _warmup_b12x_dcp_a2a(worker: "Worker") -> int:
     return len(warmed_signatures)
 
 
+def _warmup_b12x_kimi_projection_gathers(worker: "Worker") -> int:
+    """Warm projection collectives only for feature-sharded Kimi MoE layers."""
+    if not envs.VLLM_USE_B12X_DCP_A2A:
+        return 0
+
+    from vllm.distributed.parallel_state import get_dcp_group, get_tp_group
+    from vllm.models.kimi_k3.nvidia.model import KimiMoE
+    from vllm.v1.attention.ops.dcp_alltoall import (
+        warmup_b12x_kimi_projection_gathers,
+    )
+
+    model = worker.get_model()
+    uses_sharded_projections = any(
+        isinstance(module, KimiMoE)
+        and bool(getattr(module, "auxiliary_projections_tp_sharded", False))
+        for module in model.modules()
+    )
+    if not uses_sharded_projections:
+        return 0
+
+    dcp_group = get_dcp_group()
+    tp_group = get_tp_group()
+    projection_group = (
+        dcp_group
+        if dcp_group.world_size == tp_group.world_size
+        and list(dcp_group.ranks) == list(tp_group.ranks)
+        else tp_group
+    )
+    return warmup_b12x_kimi_projection_gathers(
+        projection_group,
+        device=next(model.parameters()).device,
+    )
+
+
 def kernel_warmup(worker: "Worker", *, process_local_only: bool = False) -> bool:
     if not worker.use_v2_model_runner:
         # Pooling models do not use the generation slot-mapping path.
@@ -322,6 +356,12 @@ def kernel_warmup(worker: "Worker", *, process_local_only: bool = False) -> bool
         logger.info(
             "Warmed up %d B12X DCP collective signature(s).",
             warmed_dcp_a2a,
+        )
+    warmed_projection_gathers = _warmup_b12x_kimi_projection_gathers(worker)
+    if warmed_projection_gathers:
+        logger.info(
+            "Warmed up %d B12X Kimi projection operation(s).",
+            warmed_projection_gathers,
         )
 
     flashinfer_sparse_mla_decode_autotune_warmup(worker)

--- a/vllm/models/kimi_k3/nvidia/model.py
+++ b/vllm/models/kimi_k3/nvidia/model.py
@@ -1001,13 +1001,13 @@ class KimiMoE(nn.Module):
                 self._down_proj_events[1],
                 self._down_proj_stream,
             )
-            fused_pair_topk = try_gather_kimi_sharded_projection_pair_topk(
+            precomputed_pair_topk = try_gather_kimi_sharded_projection_pair_topk(
                 down_local,
                 router_local,
                 self.gate.e_score_correction_bias.data,
             )
-            if fused_pair_topk is not None:
-                routed_hidden_states, routing_payload = fused_pair_topk
+            if precomputed_pair_topk is not None:
+                routed_hidden_states, routing_payload = precomputed_pair_topk
                 return routed_hidden_states, routing_payload, None
             routed_hidden_states, router_logits = gather_kimi_sharded_projection_pair(
                 down_local,

--- a/vllm/models/kimi_k3/nvidia/model.py
+++ b/vllm/models/kimi_k3/nvidia/model.py
@@ -17,7 +17,6 @@ from vllm.distributed import (
     get_ep_group,
     get_pp_group,
     get_tensor_model_parallel_world_size,
-    tensor_model_parallel_all_gather,
     tensor_model_parallel_all_reduce,
 )
 from vllm.forward_context import get_forward_context, is_forward_context_available
@@ -107,6 +106,9 @@ from vllm.models.kimi_k3.nvidia.low_latency_gemm import (
 )
 from vllm.models.kimi_k3.nvidia.mla import MultiHeadLatentAttention
 from vllm.models.kimi_k3.nvidia.ops import attn_res
+from vllm.models.kimi_k3.nvidia.tp_projection import (
+    gather_kimi_sharded_projection,
+)
 from vllm.multimodal import MULTIMODAL_REGISTRY
 from vllm.multimodal.inputs import NestedTensors
 from vllm.platforms import current_platform
@@ -359,19 +361,24 @@ class KimiPaddedColumnParallelLinear(ColumnParallelLinear):
     ) -> None:
         tp_size = get_tensor_model_parallel_world_size()
         self.logical_output_size = output_size
+        self.kimi_gather_output = gather_output
         padded_output_size = cdiv(output_size, tp_size) * tp_size
         super().__init__(
             input_size,
             padded_output_size,
             bias=False,
-            gather_output=gather_output,
+            gather_output=False,
             quant_config=None,
             prefix=prefix,
         )
 
+    def forward_local(self, x: torch.Tensor):
+        return super().forward(x)
+
     def forward(self, x: torch.Tensor):
-        output, bias = super().forward(x)
-        if self.gather_output:
+        output, bias = self.forward_local(x)
+        if self.kimi_gather_output:
+            output = gather_kimi_sharded_projection(output)
             output = output[..., : self.logical_output_size].contiguous()
         return output, bias
 
@@ -387,17 +394,20 @@ class KimiColumnParallelGate(KimiPaddedColumnParallelLinear):
             gather_output=False,
         )
 
-    def forward(self, x: torch.Tensor):
+    def forward_local(
+        self, x: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
         if x.is_cuda and x.dtype == self.weight.dtype == torch.bfloat16:
-            output_parallel = torch.mm(x, self.weight.T, out_dtype=torch.float32)
+            output = torch.mm(x, self.weight.T, out_dtype=torch.float32)
         else:
-            output_parallel = torch.nn.functional.linear(
+            output = torch.nn.functional.linear(
                 x.to(self.weight.dtype), self.weight
             ).float()
-        if self.tp_size > 1:
-            output = tensor_model_parallel_all_gather(output_parallel)
-        else:
-            output = output_parallel
+        return output, None
+
+    def forward(self, x: torch.Tensor):
+        output_parallel, _ = self.forward_local(x)
+        output = gather_kimi_sharded_projection(output_parallel)
         return output[..., : self.logical_output_size].contiguous(), None
 
 

--- a/vllm/models/kimi_k3/nvidia/model.py
+++ b/vllm/models/kimi_k3/nvidia/model.py
@@ -111,6 +111,8 @@ from vllm.models.kimi_k3.nvidia.mla import MultiHeadLatentAttention
 from vllm.models.kimi_k3.nvidia.ops import attn_res
 from vllm.models.kimi_k3.nvidia.tp_projection import (
     gather_kimi_sharded_projection,
+    gather_kimi_sharded_projection_pair,
+    try_gather_kimi_sharded_projection_pair_topk,
 )
 from vllm.multimodal import MULTIMODAL_REGISTRY
 from vllm.multimodal.inputs import NestedTensors
@@ -958,10 +960,9 @@ class KimiMoE(nn.Module):
             logits and ``topk_ids`` is ``None``.
         """
 
-        def _router(
-            hidden_states: torch.Tensor,
+        def _finish_router(
+            router_logits: torch.Tensor,
         ) -> tuple[torch.Tensor, torch.Tensor | None]:
-            router_logits, _ = self.gate(hidden_states)
             if not self.use_mega_moe:
                 return router_logits, None
             return fused_grouped_topk(
@@ -976,11 +977,50 @@ class KimiMoE(nn.Module):
                 routed_scaling_factor=self.routed_scaling_factor,
             )
 
+        def _router(
+            hidden_states: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor | None]:
+            router_logits, _ = self.gate(hidden_states)
+            return _finish_router(router_logits)
+
         down_proj = self.routed_expert_down_proj
         if down_proj is None:
             router_output, topk_ids = _router(hidden_states)
             return hidden_states, router_output, topk_ids
         num_tokens = hidden_states.shape[0]
+        if (
+            0 < num_tokens <= 8
+            and not self.use_mega_moe
+            and isinstance(self.gate, KimiColumnParallelGate)
+            and isinstance(down_proj, KimiPaddedColumnParallelLinear)
+        ):
+            (router_local, _), (down_local, _) = maybe_execute_in_parallel(
+                lambda: self.gate.forward_local(hidden_states),
+                lambda: down_proj.forward_local(hidden_states),
+                self._down_proj_events[0],
+                self._down_proj_events[1],
+                self._down_proj_stream,
+            )
+            fused_pair_topk = try_gather_kimi_sharded_projection_pair_topk(
+                down_local,
+                router_local,
+                self.gate.e_score_correction_bias.data,
+            )
+            if fused_pair_topk is not None:
+                routed_hidden_states, routing_payload = fused_pair_topk
+                return routed_hidden_states, routing_payload, None
+            routed_hidden_states, router_logits = gather_kimi_sharded_projection_pair(
+                down_local,
+                router_local,
+            )
+            routed_hidden_states = routed_hidden_states[
+                ..., : down_proj.logical_output_size
+            ].contiguous()
+            router_logits = router_logits[
+                ..., : self.gate.logical_output_size
+            ].contiguous()
+            router_output, topk_ids = _finish_router(router_logits)
+            return routed_hidden_states, router_output, topk_ids
         (router_output, topk_ids), (routed_hidden_states, _) = (
             maybe_execute_in_parallel(
                 lambda: _router(hidden_states),

--- a/vllm/models/kimi_k3/nvidia/model.py
+++ b/vllm/models/kimi_k3/nvidia/model.py
@@ -659,6 +659,10 @@ class KimiK3PrecomputedTopKRouter(FusedTopKBiasRouter):
         ):
             topk_weights = router_logits[:num_tokens]
             topk_ids = router_logits[num_tokens:].view(torch.int32)
+            if envs.VLLM_MOE_SKIP_PADDING and is_forward_context_available():
+                is_padding = get_forward_context().is_padding
+                if is_padding is not None:
+                    topk_ids.masked_fill_(is_padding[:num_tokens, None], -1)
             return topk_weights, topk_ids
         return super()._compute_routing(
             hidden_states,

--- a/vllm/models/kimi_k3/nvidia/model.py
+++ b/vllm/models/kimi_k3/nvidia/model.py
@@ -29,6 +29,9 @@ from vllm.model_executor.layers.fused_moe import (
 from vllm.model_executor.layers.fused_moe.router.base_router import (
     eplb_map_to_physical_and_record,
 )
+from vllm.model_executor.layers.fused_moe.router.fused_topk_bias_router import (
+    FusedTopKBiasRouter,
+)
 from vllm.model_executor.layers.fused_moe.router.gate_linear import GateLinear
 from vllm.model_executor.layers.fused_moe.router.grouped_topk_router import (
     fused_grouped_topk,
@@ -628,6 +631,41 @@ def make_kimi_k3_mega_moe_expert_params_mapping(
     return mapping
 
 
+class KimiK3PrecomputedTopKRouter(FusedTopKBiasRouter):
+    """Consume Kimi's compact, already-selected routed-expert payload."""
+
+    def _compute_routing(
+        self,
+        hidden_states: torch.Tensor,
+        router_logits: torch.Tensor,
+        indices_type: torch.dtype | None,
+        *,
+        input_ids: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        num_tokens = hidden_states.shape[0]
+        if (
+            self.top_k == 16
+            and self.global_num_experts == 896
+            and self.scoring_func == "sigmoid"
+            and self.renormalize
+            and self.routed_scaling_factor == 1.0
+            and indices_type in (None, torch.int32)
+            and router_logits.shape == (num_tokens * 2, self.top_k)
+            and router_logits.dtype == torch.float32
+            and router_logits.device == hidden_states.device
+            and router_logits.is_contiguous()
+        ):
+            topk_weights = router_logits[:num_tokens]
+            topk_ids = router_logits[num_tokens:].view(torch.int32)
+            return topk_weights, topk_ids
+        return super()._compute_routing(
+            hidden_states,
+            router_logits,
+            indices_type,
+            input_ids=input_ids,
+        )
+
+
 class KimiMoE(nn.Module):
     def __init__(
         self,
@@ -837,6 +875,25 @@ class KimiMoE(nn.Module):
                 activation_linear_beta=activation_situ_linear_beta,
             )
         else:
+            router = None
+            if (
+                num_experts == 896
+                and num_experts_per_token == 16
+                and config.use_grouped_topk
+                and config.num_expert_group == 1
+                and config.topk_group == 1
+                and config.moe_router_activation_func == "sigmoid"
+                and moe_renormalize
+                and self.routed_scaling_factor == 1.0
+            ):
+                router = KimiK3PrecomputedTopKRouter(
+                    top_k=num_experts_per_token,
+                    global_num_experts=num_experts,
+                    e_score_correction_bias=self.gate.e_score_correction_bias,
+                    renormalize=moe_renormalize,
+                    routed_scaling_factor=self.routed_scaling_factor,
+                    scoring_func=self.moe_router_activation_func,
+                )
             self.experts = FusedMoEFactory(
                 shared_experts=self.shared_experts,
                 num_experts=num_experts,
@@ -855,6 +912,7 @@ class KimiMoE(nn.Module):
                 scoring_func=config.moe_router_activation_func,
                 e_score_correction_bias=self.gate.e_score_correction_bias,
                 routed_scaling_factor=self.routed_scaling_factor,
+                router=router,
                 # Down projection runs outside MoERunner so it can overlap the
                 # router gate on the aux stream (see forward()); the original
                 # hidden states are passed to forward() as shared_experts_input

--- a/vllm/models/kimi_k3/nvidia/tp_projection.py
+++ b/vllm/models/kimi_k3/nvidia/tp_projection.py
@@ -11,6 +11,7 @@ from vllm.distributed import (
     get_tp_group,
     tensor_model_parallel_all_gather,
 )
+from vllm.v1.attention.ops import dcp_alltoall
 from vllm.v1.attention.ops.dcp_alltoall import (
     dcp_b12x_all_gather_heads,
     dcp_b12x_all_gather_pair,
@@ -137,4 +138,31 @@ def gather_kimi_sharded_projection_pair(
     return (
         gather_kimi_sharded_projection(local_first),
         gather_kimi_sharded_projection(local_second),
+    )
+
+
+def try_gather_kimi_sharded_projection_pair_topk(
+    local_down: torch.Tensor,
+    local_router: torch.Tensor,
+    correction_bias: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor] | None:
+    """Use B12X fused Kimi projection transport and expert selection.
+
+    A missing or ineligible fused binding returns ``None``. The model caller
+    must then use the exact paired gather and ordinary router operations.
+    """
+    if get_tensor_model_parallel_world_size() <= 1:
+        return None
+    pair_topk = getattr(
+        dcp_alltoall,
+        "try_dcp_b12x_all_gather_pair_kimi_topk",
+        None,
+    )
+    if pair_topk is None:
+        return None
+    return pair_topk(
+        local_down,
+        local_router,
+        correction_bias,
+        _get_kimi_projection_group(),
     )

--- a/vllm/models/kimi_k3/nvidia/tp_projection.py
+++ b/vllm/models/kimi_k3/nvidia/tp_projection.py
@@ -11,7 +11,12 @@ from vllm.distributed import (
     get_tp_group,
     tensor_model_parallel_all_gather,
 )
-from vllm.v1.attention.ops.dcp_alltoall import dcp_b12x_all_gather_heads
+from vllm.v1.attention.ops.dcp_alltoall import (
+    dcp_b12x_all_gather_heads,
+    dcp_b12x_all_gather_pair,
+)
+
+_KIMI_B12X_PAIRED_PROJECTION_MAX_TOKENS = 8
 
 
 def _get_kimi_projection_group():
@@ -102,3 +107,34 @@ def gather_kimi_sharded_projection(output_parallel: torch.Tensor) -> torch.Tenso
     if gathered is not None:
         return gathered
     return tensor_model_parallel_all_gather(output_parallel, dim=-1)
+
+
+def gather_kimi_sharded_projection_pair(
+    local_first: torch.Tensor,
+    local_second: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Gather two decode projections behind one lossless B12X barrier."""
+    tp_size = get_tensor_model_parallel_world_size()
+    if tp_size <= 1:
+        return local_first, local_second
+    if (
+        local_first.ndim == local_second.ndim == 2
+        and local_first.shape[0] == local_second.shape[0]
+        and 0 < local_first.shape[0] <= _KIMI_B12X_PAIRED_PROJECTION_MAX_TOKENS
+        and local_first.is_cuda
+        and local_second.is_cuda
+        and local_first.is_contiguous()
+        and local_second.is_contiguous()
+    ):
+        projection_group = _get_kimi_projection_group()
+        if projection_group.world_size == tp_size:
+            return dcp_b12x_all_gather_pair(
+                local_first,
+                local_second,
+                projection_group,
+                max_batch_size=_KIMI_B12X_PAIRED_PROJECTION_MAX_TOKENS,
+            )
+    return (
+        gather_kimi_sharded_projection(local_first),
+        gather_kimi_sharded_projection(local_second),
+    )

--- a/vllm/models/kimi_k3/nvidia/tp_projection.py
+++ b/vllm/models/kimi_k3/nvidia/tp_projection.py
@@ -146,10 +146,10 @@ def try_gather_kimi_sharded_projection_pair_topk(
     local_router: torch.Tensor,
     correction_bias: torch.Tensor,
 ) -> tuple[torch.Tensor, torch.Tensor] | None:
-    """Use B12X fused Kimi projection transport and expert selection.
+    """Use B12X Kimi projection transport and precomputed expert selection.
 
-    A missing or ineligible fused binding returns ``None``. The model caller
-    must then use the exact paired gather and ordinary router operations.
+    A missing or ineligible binding returns ``None``. The model caller must
+    then use the exact paired gather and ordinary router operations.
     """
     if get_tensor_model_parallel_world_size() <= 1:
         return None

--- a/vllm/v1/attention/ops/dcp_alltoall.py
+++ b/vllm/v1/attention/ops/dcp_alltoall.py
@@ -52,6 +52,7 @@ _B12X_DCP_WORLD_SIZES = (2, 4, 8, 16)
 _KIMI_LATENT_WIDTH = 3584
 _KIMI_ROUTER_WIDTH = 896
 _KIMI_ROUTER_TOPK = 16
+_KIMI_PAIRED_MAX_BATCH_SIZE = 8
 _DCP_A2A_GRAPH_BUFFERS: dict[
     tuple[tuple[int, ...], torch.device, torch.dtype],
     tuple[torch.Tensor, torch.Tensor],
@@ -630,6 +631,60 @@ def try_dcp_b12x_all_gather_pair_kimi_topk(
         channel_id=_b12x_dcp_channel_id(cp_group),
     )
     return gathered_down, routing_payload
+
+
+def warmup_b12x_kimi_projection_gathers(
+    projection_group: GroupCoordinator,
+    *,
+    device: torch.device,
+) -> int:
+    """Compile B12X Kimi paired-projection graph operations eagerly."""
+    world_size = projection_group.world_size
+    if not envs.VLLM_USE_B12X_DCP_A2A or world_size not in _B12X_DCP_WORLD_SIZES:
+        return 0
+
+    token_cap = envs.VLLM_DCP_A2A_MAX_TOKENS
+    pair_batch = (
+        _KIMI_PAIRED_MAX_BATCH_SIZE
+        if token_cap <= 0
+        else min(token_cap, _KIMI_PAIRED_MAX_BATCH_SIZE)
+    )
+    local_down_width = _KIMI_LATENT_WIDTH // world_size
+    local_router_width = _KIMI_ROUTER_WIDTH // world_size
+    local_down = torch.zeros(
+        (pair_batch, local_down_width),
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    local_router = torch.zeros(
+        (pair_batch, local_router_width),
+        device=device,
+        dtype=torch.float32,
+    )
+    warmed = 0
+    paired = _try_b12x_dcp_all_gather_pair(
+        local_down,
+        local_router,
+        projection_group,
+        max_batch_size=_KIMI_PAIRED_MAX_BATCH_SIZE,
+    )
+    if paired is not None:
+        warmed += 1
+
+    correction_bias = torch.zeros(
+        (_KIMI_ROUTER_WIDTH,),
+        device=device,
+        dtype=torch.float32,
+    )
+    fused = try_dcp_b12x_all_gather_pair_kimi_topk(
+        local_down[:1],
+        local_router[:1],
+        correction_bias,
+        projection_group,
+    )
+    if fused is not None:
+        warmed += 1
+    return warmed
 
 
 def warmup_b12x_dcp_a2a(

--- a/vllm/v1/attention/ops/dcp_alltoall.py
+++ b/vllm/v1/attention/ops/dcp_alltoall.py
@@ -49,6 +49,9 @@ _B12X_DCP_MAX_CONCURRENT_CHANNELS = 2
 # owns the graph's semantic channel, stream, and cleanup stack.
 _B12X_DCP_ACTIVE_CAPTURE: dict[int, tuple[str, Any, ExitStack]] = {}
 _B12X_DCP_WORLD_SIZES = (2, 4, 8, 16)
+_KIMI_LATENT_WIDTH = 3584
+_KIMI_ROUTER_WIDTH = 896
+_KIMI_ROUTER_TOPK = 16
 _DCP_A2A_GRAPH_BUFFERS: dict[
     tuple[tuple[int, ...], torch.device, torch.dtype],
     tuple[torch.Tensor, torch.Tensor],
@@ -548,6 +551,85 @@ def dcp_b12x_all_gather_pair(
         cp_group.all_gather(local_first, dim=-1),
         cp_group.all_gather(local_second, dim=-1),
     )
+
+
+def try_dcp_b12x_all_gather_pair_kimi_topk(
+    local_down: torch.Tensor,
+    local_router: torch.Tensor,
+    correction_bias: torch.Tensor,
+    cp_group: GroupCoordinator,
+) -> tuple[torch.Tensor, torch.Tensor] | None:
+    """Gather Kimi projections and select routed experts in one operation.
+
+    The returned routing payload has contiguous FP32 weight and int32 expert-ID
+    planes, each shaped ``[1, 16]``. The expert-ID plane is an integer view of
+    the second FP32 row, which gives graph callers one allocation to retain.
+
+    This binding has no collective fallback because the ordinary paired gather
+    and router are model-level operations. Callers must use those operations
+    when this function returns ``None``.
+    """
+    world_size = cp_group.world_size
+    if world_size not in _B12X_DCP_WORLD_SIZES:
+        return None
+    local_down_width = _KIMI_LATENT_WIDTH // world_size
+    local_router_width = _KIMI_ROUTER_WIDTH // world_size
+    if (
+        not envs.VLLM_USE_B12X_DCP_A2A
+        or local_down.shape != (1, local_down_width)
+        or local_down.dtype != torch.bfloat16
+        or local_router.shape != (1, local_router_width)
+        or local_router.dtype != torch.float32
+        or correction_bias.shape != (_KIMI_ROUTER_WIDTH,)
+        or correction_bias.dtype != torch.float32
+        or not local_down.is_cuda
+        or not local_router.is_cuda
+        or not correction_bias.is_cuda
+        or local_down.device != local_router.device
+        or local_down.device != correction_bias.device
+        or not local_down.is_contiguous()
+        or not local_router.is_contiguous()
+        or not correction_bias.is_contiguous()
+    ):
+        return None
+
+    combined_row_bytes = (
+        local_down_width * local_down.element_size()
+        + local_router_width * local_router.element_size()
+    )
+    pool = _get_b12x_dcp_a2a_pool(
+        cp_group,
+        device=local_down.device,
+        total_heads=world_size,
+        head_dim=combined_row_bytes,
+        query_head_dim=combined_row_bytes,
+        max_batch_size=1,
+    )
+    if pool is None or not hasattr(pool, "all_gather_pair_kimi_topk"):
+        return None
+
+    gathered_down = torch.empty(
+        (1, _KIMI_LATENT_WIDTH),
+        device=local_down.device,
+        dtype=torch.bfloat16,
+    )
+    routing_payload = torch.empty(
+        (2, _KIMI_ROUTER_TOPK),
+        device=local_down.device,
+        dtype=torch.float32,
+    )
+    topk_weights = routing_payload[:1]
+    topk_ids = routing_payload[1:].view(torch.int32)
+    pool.all_gather_pair_kimi_topk(
+        local_down,
+        local_router,
+        correction_bias,
+        gathered_down,
+        topk_weights,
+        topk_ids,
+        channel_id=_b12x_dcp_channel_id(cp_group),
+    )
+    return gathered_down, routing_payload
 
 
 def warmup_b12x_dcp_a2a(

--- a/vllm/v1/attention/ops/dcp_alltoall.py
+++ b/vllm/v1/attention/ops/dcp_alltoall.py
@@ -560,11 +560,16 @@ def try_dcp_b12x_all_gather_pair_kimi_topk(
     correction_bias: torch.Tensor,
     cp_group: GroupCoordinator,
 ) -> tuple[torch.Tensor, torch.Tensor] | None:
-    """Gather Kimi projections and select routed experts in one operation.
+    """Gather Kimi projections and select routed experts through B12X.
 
     The returned routing payload has contiguous FP32 weight and int32 expert-ID
-    planes, each shaped ``[1, 16]``. The expert-ID plane is an integer view of
-    the second FP32 row, which gives graph callers one allocation to retain.
+    planes, each shaped ``[num_tokens, 16]``. The expert-ID plane is an integer
+    view of the second half of the FP32 allocation, which gives graph callers
+    one allocation to retain.
+
+    A one-token input uses the combined B12X projection-gather and expert-
+    selection operation. Inputs of two through eight tokens use the paired
+    projection gather followed by one batched B12X expert-selection kernel.
 
     This binding has no collective fallback because the ordinary paired gather
     and router are model-level operations. Callers must use those operations
@@ -573,13 +578,18 @@ def try_dcp_b12x_all_gather_pair_kimi_topk(
     world_size = cp_group.world_size
     if world_size not in _B12X_DCP_WORLD_SIZES:
         return None
+    if local_down.ndim != 2 or local_router.ndim != 2:
+        return None
+    batch = int(local_down.shape[0])
     local_down_width = _KIMI_LATENT_WIDTH // world_size
     local_router_width = _KIMI_ROUTER_WIDTH // world_size
     if (
         not envs.VLLM_USE_B12X_DCP_A2A
-        or local_down.shape != (1, local_down_width)
+        or batch < 1
+        or batch > _KIMI_PAIRED_MAX_BATCH_SIZE
+        or local_down.shape != (batch, local_down_width)
         or local_down.dtype != torch.bfloat16
-        or local_router.shape != (1, local_router_width)
+        or local_router.shape != (batch, local_router_width)
         or local_router.dtype != torch.float32
         or correction_bias.shape != (_KIMI_ROUTER_WIDTH,)
         or correction_bias.dtype != torch.float32
@@ -594,6 +604,13 @@ def try_dcp_b12x_all_gather_pair_kimi_topk(
     ):
         return None
 
+    token_cap = envs.VLLM_DCP_A2A_MAX_TOKENS
+    if token_cap > 0 and batch > token_cap:
+        return None
+    max_batch_size = 1 if batch == 1 else _KIMI_PAIRED_MAX_BATCH_SIZE
+    if token_cap > 0:
+        max_batch_size = min(max_batch_size, token_cap)
+
     combined_row_bytes = (
         local_down_width * local_down.element_size()
         + local_router_width * local_router.element_size()
@@ -604,32 +621,52 @@ def try_dcp_b12x_all_gather_pair_kimi_topk(
         total_heads=world_size,
         head_dim=combined_row_bytes,
         query_head_dim=combined_row_bytes,
-        max_batch_size=1,
+        max_batch_size=max_batch_size,
     )
-    if pool is None or not hasattr(pool, "all_gather_pair_kimi_topk"):
+    if pool is None:
+        return None
+    if batch == 1:
+        if not hasattr(pool, "all_gather_pair_kimi_topk"):
+            return None
+    elif not hasattr(pool, "all_gather_pair") or not hasattr(pool, "kimi_topk16"):
         return None
 
-    gathered_down = torch.empty(
-        (1, _KIMI_LATENT_WIDTH),
-        device=local_down.device,
-        dtype=torch.bfloat16,
-    )
     routing_payload = torch.empty(
-        (2, _KIMI_ROUTER_TOPK),
+        (batch * 2, _KIMI_ROUTER_TOPK),
         device=local_down.device,
         dtype=torch.float32,
     )
-    topk_weights = routing_payload[:1]
-    topk_ids = routing_payload[1:].view(torch.int32)
-    pool.all_gather_pair_kimi_topk(
-        local_down,
-        local_router,
-        correction_bias,
-        gathered_down,
-        topk_weights,
-        topk_ids,
-        channel_id=_b12x_dcp_channel_id(cp_group),
-    )
+    topk_weights = routing_payload[:batch]
+    topk_ids = routing_payload[batch:].view(torch.int32)
+    channel_id = _b12x_dcp_channel_id(cp_group)
+    if batch == 1:
+        gathered_down = torch.empty(
+            (1, _KIMI_LATENT_WIDTH),
+            device=local_down.device,
+            dtype=torch.bfloat16,
+        )
+        pool.all_gather_pair_kimi_topk(
+            local_down,
+            local_router,
+            correction_bias,
+            gathered_down,
+            topk_weights,
+            topk_ids,
+            channel_id=channel_id,
+        )
+    else:
+        gathered_down, gathered_router = pool.all_gather_pair(
+            local_down,
+            local_router,
+            channel_id=channel_id,
+        )
+        pool.kimi_topk16(
+            gathered_router,
+            correction_bias,
+            topk_weights,
+            topk_ids,
+            channel_id=channel_id,
+        )
     return gathered_down, routing_payload
 
 
@@ -684,6 +721,15 @@ def warmup_b12x_kimi_projection_gathers(
     )
     if fused is not None:
         warmed += 1
+    if pair_batch > 1:
+        batched = try_dcp_b12x_all_gather_pair_kimi_topk(
+            local_down,
+            local_router,
+            correction_bias,
+            projection_group,
+        )
+        if batched is not None:
+            warmed += 1
     return warmed
 
 


### PR DESCRIPTION
## Status

Implemented. Runtime-qualified for the official Kimi-K3 MXFP4 checkpoint with
TP16/DCP16 and an Inferact seven-token DSpark draft.

## Behavior

- Produces rank-local latent and router projection outputs for Kimi-K3.
- Gathers paired projections through one B12X synchronization barrier.
- Uses the B12X combined gather-selection operation for one router row.
- Uses paired projection gathering followed by one batched B12X top-16
  operation for two through eight router rows.
- Stores precomputed FP32 routing weights and int32 expert identifiers in one
  graph-retained allocation.
- Uses the ordinary paired gather and vLLM router when the B12X binding,
  geometry, dtype, or token capacity is ineligible.
- Warms every graph-visible projection operation before CUDA Graph capture.

## Technical reason

Kimi-K3 target verification evaluates up to eight speculative token rows in
each cycle. Separate sigmoid and top-k kernels added 92 launches per target
step after paired projection transport. The batched B12X operation removes
those launches while preserving the official 896-expert, top-16,
renormalized-sigmoid routing contract.

## Dependencies

- vLLM #385 supplies tensor-parallel Kimi projection sharding.
- B12X #216 supplies the one-row combined gather-selection operation.
- B12X #224 supplies the batched CuTeDSL top-16 operation.
- B12X #214 defines inactive-route handling used by padded MoE execution.

No other open vLLM pull request provides Kimi-K3 paired latent/router
transport with graph-prewarmed one-row and batched expert selection. The pull
request therefore does not duplicate an open implementation.

## Compatibility

Replicated projections, sequence-parallel execution, MegaMoE, token batches
above eight, and unsupported Kimi geometries retain their established paths.
The B12X batched API is detected at runtime, so an installation without B12X
#224 uses the exact model-level router fallback.

## Validation

- `pytest -q tests/distributed/test_dcp_a2a.py tests/models/kimi_k3/test_sequence_parallel.py -k "b12x_kimi_pair_topk_supports_projection_world_sizes or b12x_kimi_pair_topk_rejects_non_contract_inputs or b12x_kimi_batched_topk_requires_batched_router_binding or kimi_projection_warmup_respects_transport_token_cap or kimi_moe_uses_precomputed_projection_routing_payload"`: 13 passed on CUDA.
- Ruff, Python bytecode compilation, and `git diff --check`: passed.
- B12X TP16 batch-8 graph replay matched vLLM `topk_sigmoid` expert IDs and
  FP32 routing weights exactly for random, tied, near-tied, and nonfinite
  inputs.
- Official Kimi-K3 MXFP4 target, TP16/DCP16, Inferact seven-token DSpark draft,
  256-token prompt and 1,024 generated tokens: median target-cycle rate was
  31.146 cycles/s across eight runs. The source-identical configuration without
  batched selection measured 29.848 cycles/s; the published serving image
  measured 30.827 cycles/s.
- The same eight-run series measured 112.255 output tok/s at median acceptance
  0.3727. At the published image's median emitted-token ratio, 31.146 target
  cycles/s corresponds to 117.4 output tok/s; output throughput is reported
  separately because DSpark acceptance varies between generations.
- Post-rebase fix validation: file-scoped pre-commit, Python bytecode compilation, and git diff --check passed.
- Post-rebase fix validation: tests/distributed/test_dcp_a2a.py::test_profile_channel_checkpoint_deduplicates_shared_b12x_pool passed (1 passed).
- The focused Kimi router pytest selection could not collect in this checkout because vllm.third_party.flashmla.flash_mla_interface is unavailable.

AI assistance was used for implementation and validation. The human submitter
reviewed every changed line, the graph-capture contract, exact routing outputs,
and the full-model runtime path.
