### PR TITLE
Execute Kimi dense MLA with decode context parallelism

### DIFF
--- a/tests/distributed/test_dcp_direct_a2a_lse_reduce.py
+++ b/tests/distributed/test_dcp_direct_a2a_lse_reduce.py
@@ -499,6 +499,35 @@ def test_dcp_chunk_workspace_alignment_covers_interleave():
     assert align_mla_chunked_context_workspace_size(config, 100) == 192
 
 
+def test_mla_chunk_workspace_honors_configured_token_limit(monkeypatch):
+    from vllm.model_executor.layers.attention.mla_attention import (
+        MLACommonMetadataBuilder,
+    )
+
+    config = MagicMock()
+    config.model_config.max_model_len = 1_048_576
+    config.scheduler_config.max_num_seqs = 8
+    config.cache_config.block_size = 32
+    config.parallel_config.decode_context_parallel_size = 16
+    config.parallel_config.cp_kv_cache_interleave_size = 1
+
+    monkeypatch.setenv("VLLM_MLA_CHUNKED_PREFILL_WORKSPACE_SIZE", "4096")
+    assert (
+        MLACommonMetadataBuilder.determine_chunked_prefill_workspace_size(config)
+        == 4096
+    )
+
+    monkeypatch.setenv("VLLM_MLA_CHUNKED_PREFILL_WORKSPACE_SIZE", "0")
+    assert (
+        MLACommonMetadataBuilder.determine_chunked_prefill_workspace_size(config)
+        == 64 * 1024
+    )
+
+    monkeypatch.setenv("VLLM_MLA_CHUNKED_PREFILL_WORKSPACE_SIZE", "-1")
+    with pytest.raises(ValueError, match="must be non-negative"):
+        MLACommonMetadataBuilder.determine_chunked_prefill_workspace_size(config)
+
+
 def test_sparse_mla_builder_initializes_dcp_manager(monkeypatch):
     import vllm.model_executor.layers.attention.sparse_mla_attention as sparse_mla
 

--- a/tests/model_executor/test_flashinfer_autotune_cache.py
+++ b/tests/model_executor/test_flashinfer_autotune_cache.py
@@ -6,6 +6,7 @@ from hashlib import sha256
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
 import torch
 
 from vllm.model_executor.warmup import flashinfer_autotune_cache, kernel_warmup
@@ -284,7 +285,13 @@ def test_b12x_projection_warmup_uses_complete_projection_group(monkeypatch) -> N
     ]
 
 
-def test_b12x_dcp_warmup_finds_kimi_dense_mla_attention(monkeypatch) -> None:
+@pytest.mark.parametrize(
+    ("dcp_world_size", "num_local_heads"),
+    ((12, 8), (16, 6)),
+)
+def test_b12x_dcp_warmup_finds_kimi_dense_mla_attention(
+    monkeypatch, dcp_world_size: int, num_local_heads: int
+) -> None:
     from vllm.distributed import parallel_state
     from vllm.models.kimi_k3.nvidia.mla import MultiHeadLatentAttention
     from vllm.v1.attention.ops import dcp_alltoall
@@ -297,8 +304,8 @@ def test_b12x_dcp_warmup_finds_kimi_dense_mla_attention(monkeypatch) -> None:
         torch.nn.Parameter(torch.empty(1)),
     )
     attention.attn_backend = SimpleNamespace(get_name=lambda: "B12X_MLA")
-    attention.impl = SimpleNamespace(dcp_world_size=16)
-    attention.num_local_heads = 6
+    attention.impl = SimpleNamespace(dcp_world_size=dcp_world_size)
+    attention.num_local_heads = num_local_heads
     attention.head_size = 576
     attention.kv_lora_rank = 512
 
@@ -311,7 +318,7 @@ def test_b12x_dcp_warmup_finds_kimi_dense_mla_attention(monkeypatch) -> None:
         scheduler_config=SimpleNamespace(max_num_batched_tokens=4096),
         vllm_config=SimpleNamespace(
             parallel_config=SimpleNamespace(
-                decode_context_parallel_size=16,
+                decode_context_parallel_size=dcp_world_size,
                 dcp_comm_backend="a2a",
             ),
             compilation_config=SimpleNamespace(

--- a/tests/model_executor/test_flashinfer_autotune_cache.py
+++ b/tests/model_executor/test_flashinfer_autotune_cache.py
@@ -284,6 +284,66 @@ def test_b12x_projection_warmup_uses_complete_projection_group(monkeypatch) -> N
     ]
 
 
+def test_b12x_dcp_warmup_finds_kimi_dense_mla_attention(monkeypatch) -> None:
+    from vllm.distributed import parallel_state
+    from vllm.models.kimi_k3.nvidia.mla import MultiHeadLatentAttention
+    from vllm.v1.attention.ops import dcp_alltoall
+
+    monkeypatch.setenv("VLLM_USE_B12X_DCP_A2A", "1")
+    attention = MultiHeadLatentAttention.__new__(MultiHeadLatentAttention)
+    torch.nn.Module.__init__(attention)
+    attention.register_parameter(
+        "device_probe",
+        torch.nn.Parameter(torch.empty(1)),
+    )
+    attention.attn_backend = SimpleNamespace(get_name=lambda: "B12X_MLA")
+    attention.impl = SimpleNamespace(dcp_world_size=16)
+    attention.num_local_heads = 6
+    attention.head_size = 576
+    attention.kv_lora_rank = 512
+
+    model = torch.nn.Module()
+    model.add_module("attention", attention)
+    worker = SimpleNamespace(
+        get_model=lambda: model,
+        model_runner=SimpleNamespace(),
+        model_config=SimpleNamespace(dtype=torch.bfloat16),
+        scheduler_config=SimpleNamespace(max_num_batched_tokens=4096),
+        vllm_config=SimpleNamespace(
+            parallel_config=SimpleNamespace(
+                decode_context_parallel_size=16,
+                dcp_comm_backend="a2a",
+            ),
+            compilation_config=SimpleNamespace(
+                static_forward_context={"model.layers.0.attn": attention}
+            ),
+        ),
+    )
+    group = object()
+    calls = []
+    monkeypatch.setattr(parallel_state, "get_dcp_group", lambda: group)
+    monkeypatch.setattr(
+        dcp_alltoall,
+        "warmup_b12x_dcp_a2a",
+        lambda *args, **kwargs: calls.append((args, kwargs)),
+    )
+
+    assert kernel_warmup._warmup_b12x_dcp_a2a(worker) == 1
+    assert calls == [
+        (
+            (group,),
+            {
+                "device": torch.device("cpu"),
+                "dtype": torch.bfloat16,
+                "max_batch_size": 4096,
+                "total_heads": 96,
+                "head_dim": 512,
+                "query_head_dim": 576,
+            },
+        )
+    ]
+
+
 def test_kernel_warmup_runs_b12x_mxfp8_linear_warmup(monkeypatch) -> None:
     calls = []
     model = torch.nn.Linear(2, 2)

--- a/tests/models/kimi_k3/test_sequence_parallel.py
+++ b/tests/models/kimi_k3/test_sequence_parallel.py
@@ -78,6 +78,17 @@ class _SequenceParallelMTPBlock:
         return hidden_states * 2, None, hidden_states * 3
 
 
+@pytest.mark.parametrize(
+    ("dcp_world_size", "backend_owns", "expected"),
+    ((1, True, False), (8, False, False), (8, True, True)),
+)
+def test_kimi_detects_backend_owned_decode_dcp(
+    dcp_world_size: int, backend_owns: bool, expected: bool
+) -> None:
+    impl = SimpleNamespace(owns_decode_dcp_collectives=backend_owns)
+    assert kimi_mla._backend_owns_decode_dcp(impl, dcp_world_size) is expected
+
+
 def _mock_sequence_parallel_collectives(monkeypatch):
     monkeypatch.setattr(
         kimi_model,

--- a/tests/v1/attention/test_b12x_mla.py
+++ b/tests/v1/attention/test_b12x_mla.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 import pytest
 import torch
 
+from vllm.model_executor.layers.attention import mla_attention
 from vllm.platforms.interface import DeviceCapability
 from vllm.v1.attention.backends.mla import b12x_mla
 from vllm.v1.attention.backends.mla.b12x_mla import (
@@ -70,6 +71,21 @@ def test_b12x_mla_plans_local_interleaved_dcp_cache() -> None:
     )
 
     assert b12x_mla._max_dcp_local_cache_tokens(config) == 131_072
+
+
+def test_mla_uses_one_kv_shard_for_replicated_dcp_cache() -> None:
+    replicated = SimpleNamespace(dcp_replicated=True, dcp_kv_shard_count=None)
+    sharded = SimpleNamespace(dcp_replicated=False, dcp_kv_shard_count=None)
+
+    assert mla_attention._get_mla_kv_dcp_world_size(replicated, 16) == 1
+    assert mla_attention._get_mla_kv_dcp_world_size(sharded, 16) == 16
+
+
+def test_mla_rejects_partial_dcp_cache_without_matching_subgroup() -> None:
+    partial = SimpleNamespace(dcp_replicated=False, dcp_kv_shard_count=4)
+
+    with pytest.raises(NotImplementedError, match="partial DCP KV sharding"):
+        mla_attention._get_mla_kv_dcp_world_size(partial, 16)
 
 
 def _support_reason(monkeypatch, *, dcp_size: int, pcp_size: int = 1) -> str | None:
@@ -158,8 +174,6 @@ def _fake_impl(monkeypatch, *, num_heads: int = 8) -> tuple[B12xMLAImpl, _FakeDe
     impl.kv_lora_rank = 512
     impl.scale = 192**-0.5
     impl.dcp_world_size = 1
-    impl._effective_heads = num_heads
-    impl._kernel_heads = b12x_mla._kernel_query_heads(num_heads, 1)
     impl._dcp_comm_backend = "a2a"
     impl._dcp_max_batch_size = 16
     impl._compiled_bindings = set()
@@ -292,6 +306,7 @@ def test_b12x_mla_builder_flattens_non_causal_draft_block(monkeypatch) -> None:
     builder._dense_mla_flat_block_table = torch.zeros(16, 4, dtype=torch.int32)
     builder._dense_mla_flat_seq_lens = torch.empty(16, dtype=torch.int32)
     builder._dense_mla_flat_query_start_loc = torch.arange(17, dtype=torch.int32)
+    builder.dcp_world_size = 1
 
     source_table = torch.tensor([[3, 4, 5, 6]], dtype=torch.int32)
     metadata = SimpleNamespace(
@@ -527,8 +542,6 @@ def test_b12x_mla_adapter_passes_fp8_scales(monkeypatch) -> None:
 def test_b12x_mla_adapter_gathers_and_combines_dcp(monkeypatch) -> None:
     impl, dense_mla = _fake_impl(monkeypatch, num_heads=6)
     impl.dcp_world_size = 8
-    impl._effective_heads = 48
-    impl._kernel_heads = 48
     batch = 2
     q = torch.randn(batch, 6, 576, dtype=torch.bfloat16)
     cache = torch.randn(4, 16, 576, dtype=torch.bfloat16)
@@ -582,6 +595,44 @@ def test_b12x_mla_adapter_gathers_and_combines_dcp(monkeypatch) -> None:
     assert dense_mla.bindings[0].q.data_ptr() == metadata.dense_mla_padded_q.data_ptr()
     torch.testing.assert_close(output, torch.ones_like(output))
     assert lse is None
+
+
+def test_b12x_mla_adapter_skips_dcp_for_replicated_cache(monkeypatch) -> None:
+    impl, dense_mla = _fake_impl(monkeypatch, num_heads=6)
+    impl.dcp_world_size = 8
+    batch = 2
+    q = torch.randn(batch, 6, 576, dtype=torch.bfloat16)
+    cache = torch.randn(4, 16, 576, dtype=torch.bfloat16)
+
+    def unexpected_collective(*args, **kwargs):
+        raise AssertionError("replicated KV attention must not use DCP collectives")
+
+    monkeypatch.setattr(b12x_mla, "get_dcp_group", unexpected_collective)
+    monkeypatch.setattr(b12x_mla, "dcp_b12x_all_gather_heads", unexpected_collective)
+    monkeypatch.setattr(b12x_mla, "dcp_a2a_lse_reduce", unexpected_collective)
+    metadata = SimpleNamespace(
+        dense_mla_plan=_FakePlan(),
+        dense_mla_scratch=torch.empty(256, dtype=torch.uint8),
+        dense_mla_padded_q=torch.empty(batch, 8, 576, dtype=torch.bfloat16),
+        dense_mla_padded_output=torch.empty(batch, 8, 512, dtype=torch.bfloat16),
+        dense_mla_dcp_world_size=1,
+        query_start_loc=torch.tensor([0, 1, 2], dtype=torch.int32),
+        decode=SimpleNamespace(
+            block_table=torch.tensor([[0, 1], [2, 3]], dtype=torch.int32),
+            seq_lens=torch.tensor([17, 31], dtype=torch.int32),
+        ),
+    )
+
+    output, lse = impl.forward_mqa(
+        q,
+        cache,
+        metadata,
+        SimpleNamespace(_q_scale=None, _k_scale=None),
+    )
+
+    assert output.shape == (batch, 6, 512)
+    assert lse is not None and lse.shape == (batch, 6)
+    assert dense_mla.bindings[0].q.shape == (batch, 8, 576)
 
 
 def test_b12x_mla_adapter_requires_caller_owned_scratch(monkeypatch) -> None:

--- a/tests/v1/attention/test_b12x_mla.py
+++ b/tests/v1/attention/test_b12x_mla.py
@@ -42,6 +42,25 @@ def test_b12x_mla_pads_query_heads_to_kernel_tile(
     assert b12x_mla._kernel_query_heads(logical_heads) == kernel_heads
 
 
+def test_b12x_mla_uses_gathered_dcp_head_geometry() -> None:
+    assert b12x_mla._kernel_query_heads(6, 8) == 48
+    assert b12x_mla._kernel_query_heads(12, 8) == 96
+    with pytest.raises(ValueError, match="multiple of eight"):
+        b12x_mla._kernel_query_heads(6, 2)
+
+
+def test_b12x_mla_plans_local_interleaved_dcp_cache() -> None:
+    config = SimpleNamespace(
+        parallel_config=SimpleNamespace(
+            decode_context_parallel_size=8,
+            cp_kv_cache_interleave_size=64,
+        ),
+        model_config=SimpleNamespace(max_model_len=1_048_576),
+    )
+
+    assert b12x_mla._max_dcp_local_cache_tokens(config) == 131_072
+
+
 class _FakePlan:
     def shapes_and_dtypes(self):
         return (((256,), torch.uint8),)
@@ -74,7 +93,11 @@ def _fake_impl(monkeypatch, *, num_heads: int = 8) -> tuple[B12xMLAImpl, _FakeDe
     impl.num_heads = num_heads
     impl.kv_lora_rank = 512
     impl.scale = 192**-0.5
-    impl._kernel_heads = b12x_mla._kernel_query_heads(num_heads)
+    impl.dcp_world_size = 1
+    impl._effective_heads = num_heads
+    impl._kernel_heads = b12x_mla._kernel_query_heads(num_heads, 1)
+    impl._dcp_comm_backend = "a2a"
+    impl._dcp_max_batch_size = 16
     impl._compiled_bindings = set()
     dense_mla = _FakeDenseMLA()
     impl._dense_mla = dense_mla
@@ -281,6 +304,63 @@ def test_b12x_mla_adapter_passes_fp8_scales(monkeypatch) -> None:
     binding = dense_mla.bindings[0]
     assert binding.q_scale is layer._q_scale
     assert binding.kv_scale is layer._k_scale
+
+
+def test_b12x_mla_adapter_gathers_and_combines_dcp(monkeypatch) -> None:
+    impl, dense_mla = _fake_impl(monkeypatch, num_heads=6)
+    impl.dcp_world_size = 8
+    impl._effective_heads = 48
+    impl._kernel_heads = 48
+    batch = 2
+    q = torch.randn(batch, 6, 576, dtype=torch.bfloat16)
+    cache = torch.randn(4, 16, 576, dtype=torch.bfloat16)
+    group = SimpleNamespace(world_size=8)
+    calls: list[str] = []
+
+    monkeypatch.setattr(b12x_mla, "get_dcp_group", lambda: group)
+
+    def gather(local_q, actual_group, *, max_batch_size, output_head_dim):
+        assert actual_group is group
+        assert max_batch_size == 16
+        assert output_head_dim == 512
+        calls.append("gather")
+        return local_q.repeat(1, 8, 1)
+
+    def reduce(output, lse, actual_group, **kwargs):
+        assert actual_group is group
+        assert output.shape == (batch, 48, 512)
+        assert lse.shape == (batch, 48)
+        assert kwargs["seq_lens"].tolist() == [17, 31]
+        assert kwargs["query_start_loc"].tolist() == [0, 1, 2]
+        assert kwargs["b12x_query_head_dim"] == 576
+        calls.append("reduce")
+        return output[:, :6].add(1)
+
+    monkeypatch.setattr(b12x_mla, "dcp_b12x_all_gather_heads", gather)
+    monkeypatch.setattr(b12x_mla, "dcp_a2a_lse_reduce", reduce)
+    metadata = SimpleNamespace(
+        dense_mla_plan=_FakePlan(),
+        dense_mla_scratch=torch.empty(256, dtype=torch.uint8),
+        dense_mla_padded_q=torch.empty(batch, 48, 576, dtype=torch.bfloat16),
+        dense_mla_padded_output=torch.zeros(batch, 48, 512, dtype=torch.bfloat16),
+        query_start_loc=torch.tensor([0, 1, 2], dtype=torch.int32),
+        decode=SimpleNamespace(
+            block_table=torch.tensor([[0, 1], [2, 3]], dtype=torch.int32),
+            seq_lens=torch.tensor([17, 31], dtype=torch.int32),
+        ),
+    )
+
+    output, lse = impl.forward_mqa(
+        q,
+        cache,
+        metadata,
+        SimpleNamespace(_q_scale=None, _k_scale=None),
+    )
+
+    assert calls == ["gather", "reduce"]
+    assert dense_mla.bindings[0].q.shape == (batch, 48, 576)
+    torch.testing.assert_close(output, torch.ones_like(output))
+    assert lse is None
 
 
 def test_b12x_mla_adapter_requires_caller_owned_scratch(monkeypatch) -> None:

--- a/tests/v1/attention/test_b12x_mla.py
+++ b/tests/v1/attention/test_b12x_mla.py
@@ -563,8 +563,8 @@ def test_b12x_mla_adapter_gathers_and_combines_dcp(monkeypatch) -> None:
         assert actual_group is group
         assert output.shape == (batch, 48, 512)
         assert lse.shape == (batch, 48)
-        assert kwargs["seq_lens"].tolist() == [17, 31]
-        assert kwargs["query_start_loc"].tolist() == [0, 1, 2]
+        assert "seq_lens" not in kwargs
+        assert "query_start_loc" not in kwargs
         assert kwargs["b12x_query_head_dim"] == 576
         calls.append("reduce")
         return output[:, :6].add(1)

--- a/tests/v1/attention/test_b12x_mla.py
+++ b/tests/v1/attention/test_b12x_mla.py
@@ -122,6 +122,10 @@ def test_b12x_mla_rejects_unsupported_parallel_geometry(monkeypatch) -> None:
 
 
 class _FakePlan:
+    caps = SimpleNamespace(max_page_table_width=4)
+    num_splits = 1
+    chunks_per_split = 1
+
     def shapes_and_dtypes(self):
         return (((256,), torch.uint8),)
 
@@ -239,12 +243,27 @@ def test_b12x_mla_adapter_binds_causal_multiquery_blocks(monkeypatch) -> None:
     q = torch.randn(total_q, 8, 576, dtype=torch.bfloat16)
     cache = torch.randn(8, 16, 576, dtype=torch.bfloat16)
     query_start_loc = torch.tensor([0, 8, 16], dtype=torch.int32)
+    source_table = torch.tensor(
+        [[0, 1, 2, 3], [4, 5, 6, 7]],
+        dtype=torch.int32,
+    )
+    flat_table = source_table[:, None, :].expand(-1, query_len, -1).reshape(total_q, -1)
+    flat_lens = torch.cat(
+        (
+            torch.arange(25, 33, dtype=torch.int32),
+            torch.arange(41, 49, dtype=torch.int32),
+        )
+    )
+    flat_query_start = torch.arange(total_q + 1, dtype=torch.int32)
     metadata = SimpleNamespace(
         dense_mla_plan=_FakePlan(),
         dense_mla_scratch=torch.empty(256, dtype=torch.uint8),
+        dense_mla_flat_block_table=flat_table,
+        dense_mla_flat_seq_lens=flat_lens,
+        dense_mla_flat_query_start_loc=flat_query_start,
         query_start_loc=query_start_loc,
         decode=SimpleNamespace(
-            block_table=torch.tensor([[0, 1, 2, 3], [4, 5, 6, 7]], dtype=torch.int32),
+            block_table=source_table,
             seq_lens=torch.tensor([32, 48], dtype=torch.int32),
         ),
     )
@@ -259,8 +278,8 @@ def test_b12x_mla_adapter_binds_causal_multiquery_blocks(monkeypatch) -> None:
     assert output.shape == (total_q, 8, 512)
     assert lse is not None and lse.shape == (total_q, 8)
     assert binding.q.shape[0] == total_q
-    assert binding.cache_seqlens.shape[0] == batch
-    assert binding.cu_seqlens_q.data_ptr() == query_start_loc.data_ptr()
+    assert binding.cache_seqlens.data_ptr() == flat_lens.data_ptr()
+    assert binding.cu_seqlens_q.data_ptr() == flat_query_start.data_ptr()
 
 
 def test_b12x_mla_builder_flattens_non_causal_draft_block(monkeypatch) -> None:
@@ -304,6 +323,144 @@ def test_b12x_mla_builder_flattens_non_causal_draft_block(monkeypatch) -> None:
     torch.testing.assert_close(
         result.dense_mla_flat_query_start_loc,
         torch.arange(9, dtype=torch.int32),
+    )
+
+
+def test_b12x_mla_builder_flattens_causal_verification_block(monkeypatch) -> None:
+    builder = object.__new__(B12xMLAMetadataBuilder)
+    builder._dense_mla_plan = _FakePlan()
+    builder._dense_mla_scratch = torch.empty(256, dtype=torch.uint8)
+    builder._dense_mla_padded_q = None
+    builder._dense_mla_padded_output = None
+    builder._max_dense_mla_rows = 16
+    builder._dense_mla_flat_block_table = torch.zeros(16, 4, dtype=torch.int32)
+    builder._dense_mla_flat_seq_lens = torch.empty(16, dtype=torch.int32)
+    builder._dense_mla_flat_query_start_loc = torch.arange(17, dtype=torch.int32)
+    builder._dense_mla_causal_offsets = torch.arange(-7, 1, dtype=torch.int32)
+    builder._dense_mla_flat_global_seq_lens = None
+    builder._dense_mla_flat_dcp_remainder = None
+    builder.dcp_world_size = 1
+
+    source_table = torch.tensor([[3, 4, 5, 6]], dtype=torch.int32)
+    metadata = SimpleNamespace(
+        causal=True,
+        num_decodes=1,
+        num_decode_tokens=8,
+        decode=SimpleNamespace(
+            block_table=source_table,
+            seq_lens=torch.tensor([32], dtype=torch.int32),
+        ),
+    )
+    monkeypatch.setattr(
+        b12x_mla.MLACommonMetadataBuilder,
+        "build",
+        lambda *args, **kwargs: metadata,
+    )
+
+    result = builder.build(0, SimpleNamespace())
+
+    torch.testing.assert_close(
+        result.dense_mla_flat_block_table,
+        source_table.expand(8, -1),
+    )
+    torch.testing.assert_close(
+        result.dense_mla_flat_seq_lens,
+        torch.arange(25, 33, dtype=torch.int32),
+    )
+    torch.testing.assert_close(
+        result.dense_mla_flat_query_start_loc,
+        torch.arange(9, dtype=torch.int32),
+    )
+
+
+def test_b12x_mla_builder_maps_causal_verification_lengths_to_dcp_rank(
+    monkeypatch,
+) -> None:
+    builder = object.__new__(B12xMLAMetadataBuilder)
+    builder._dense_mla_plan = _FakePlan()
+    builder._dense_mla_scratch = torch.empty(256, dtype=torch.uint8)
+    builder._dense_mla_padded_q = None
+    builder._dense_mla_padded_output = None
+    builder._max_dense_mla_rows = 8
+    builder._dense_mla_flat_block_table = torch.zeros(8, 4, dtype=torch.int32)
+    builder._dense_mla_flat_seq_lens = torch.empty(8, dtype=torch.int32)
+    builder._dense_mla_flat_query_start_loc = torch.arange(9, dtype=torch.int32)
+    builder._dense_mla_causal_offsets = torch.arange(-3, 1, dtype=torch.int32)
+    builder._dense_mla_flat_global_seq_lens = torch.empty(8, dtype=torch.int32)
+    builder._dense_mla_flat_dcp_remainder = torch.empty(8, dtype=torch.int32)
+    builder.dcp_world_size = 4
+    builder._dcp_rank = 3
+    builder.cp_kv_cache_interleave_size = 2
+
+    metadata = SimpleNamespace(
+        causal=True,
+        num_decodes=1,
+        num_decode_tokens=4,
+        decode=SimpleNamespace(
+            block_table=torch.tensor([[3, 4, 5, 6]], dtype=torch.int32),
+            seq_lens=torch.tensor([3], dtype=torch.int32),
+            dcp_tot_seq_lens=torch.tensor([17], dtype=torch.int32),
+        ),
+    )
+    monkeypatch.setattr(
+        b12x_mla.MLACommonMetadataBuilder,
+        "build",
+        lambda *args, **kwargs: metadata,
+    )
+
+    result = builder.build(0, SimpleNamespace())
+
+    torch.testing.assert_close(
+        result.dense_mla_flat_seq_lens,
+        torch.tensor([2, 3, 4, 4], dtype=torch.int32),
+    )
+
+
+def test_b12x_mla_builder_bounds_single_token_draft_table(monkeypatch) -> None:
+    builder = object.__new__(B12xMLAMetadataBuilder)
+    builder._dense_mla_plan = _FakePlan()
+    builder._dense_mla_scratch = torch.empty(256, dtype=torch.uint8)
+    builder._dense_mla_padded_q = None
+    builder._dense_mla_padded_output = None
+    builder._max_dense_mla_rows = 2
+    builder._dense_mla_flat_block_table = torch.zeros(2, 4, dtype=torch.int32)
+    builder._dense_mla_flat_seq_lens = torch.empty(2, dtype=torch.int32)
+    builder._dense_mla_flat_query_start_loc = torch.arange(3, dtype=torch.int32)
+    builder._dense_mla_causal_offsets = torch.zeros(1, dtype=torch.int32)
+    builder._dense_mla_flat_global_seq_lens = None
+    builder._dense_mla_flat_dcp_remainder = None
+    builder.dcp_world_size = 1
+
+    source_table = torch.tensor(
+        [[0, 1, 2, 3, 90, 91], [4, 5, 6, 7, 92, 93]],
+        dtype=torch.int32,
+    )
+    source_lens = torch.tensor([32, 48], dtype=torch.int32)
+    metadata = SimpleNamespace(
+        causal=False,
+        num_decodes=2,
+        num_decode_tokens=2,
+        decode=SimpleNamespace(
+            block_table=source_table,
+            seq_lens=source_lens,
+        ),
+    )
+    monkeypatch.setattr(
+        b12x_mla.MLACommonMetadataBuilder,
+        "build",
+        lambda *args, **kwargs: metadata,
+    )
+
+    result = builder.build(0, SimpleNamespace())
+
+    torch.testing.assert_close(
+        result.dense_mla_flat_block_table,
+        source_table[:, :4],
+    )
+    torch.testing.assert_close(result.dense_mla_flat_seq_lens, source_lens)
+    torch.testing.assert_close(
+        result.dense_mla_flat_query_start_loc,
+        torch.arange(3, dtype=torch.int32),
     )
 
 

--- a/tests/v1/attention/test_b12x_mla.py
+++ b/tests/v1/attention/test_b12x_mla.py
@@ -49,6 +49,17 @@ def test_b12x_mla_uses_gathered_dcp_head_geometry() -> None:
         b12x_mla._kernel_query_heads(6, 2)
 
 
+@pytest.mark.parametrize(
+    ("max_seq_len", "expected"),
+    ((None, 8), (0, 1), (64, 1), (65, 1), (256, 1), (257, 2), (4096, 8)),
+)
+def test_b12x_mla_limits_active_cache_splits(
+    max_seq_len: int | None, expected: int
+) -> None:
+    plan = SimpleNamespace(num_splits=8, chunks_per_split=4)
+    assert b12x_mla._active_dense_mla_splits(plan, max_seq_len) == expected
+
+
 def test_b12x_mla_plans_local_interleaved_dcp_cache() -> None:
     config = SimpleNamespace(
         parallel_config=SimpleNamespace(
@@ -190,6 +201,7 @@ def test_b12x_mla_adapter_binds_common_decode_metadata(monkeypatch) -> None:
     assert binding.q_scale is None
     assert binding.kv_scale is None
     assert binding.sm_scale == impl.scale
+    assert binding.active_splits == 1
     assert binding.scratch is metadata.dense_mla_scratch
 
 

--- a/tests/v1/attention/test_b12x_mla.py
+++ b/tests/v1/attention/test_b12x_mla.py
@@ -368,12 +368,14 @@ def test_b12x_mla_adapter_gathers_and_combines_dcp(monkeypatch) -> None:
 
     monkeypatch.setattr(b12x_mla, "get_dcp_group", lambda: group)
 
-    def gather(local_q, actual_group, *, max_batch_size, output_head_dim):
+    def gather(local_q, actual_group, *, max_batch_size, output_head_dim, out):
         assert actual_group is group
         assert max_batch_size == 16
         assert output_head_dim == 512
+        assert out.shape == (batch, 48, 576)
         calls.append("gather")
-        return local_q.repeat(1, 8, 1)
+        out.copy_(local_q.repeat(1, 8, 1))
+        return out
 
     def reduce(output, lse, actual_group, **kwargs):
         assert actual_group is group
@@ -408,6 +410,7 @@ def test_b12x_mla_adapter_gathers_and_combines_dcp(monkeypatch) -> None:
 
     assert calls == ["gather", "reduce"]
     assert dense_mla.bindings[0].q.shape == (batch, 48, 576)
+    assert dense_mla.bindings[0].q.data_ptr() == metadata.dense_mla_padded_q.data_ptr()
     torch.testing.assert_close(output, torch.ones_like(output))
     assert lse is None
 

--- a/tests/v1/attention/test_b12x_mla.py
+++ b/tests/v1/attention/test_b12x_mla.py
@@ -46,6 +46,8 @@ def test_b12x_mla_pads_query_heads_to_kernel_tile(
 def test_b12x_mla_uses_gathered_dcp_head_geometry() -> None:
     assert b12x_mla._kernel_query_heads(6, 8) == 48
     assert b12x_mla._kernel_query_heads(12, 8) == 96
+    assert b12x_mla._kernel_query_heads(8, 12) == 96
+    assert b12x_mla._kernel_query_heads(6, 16) == 96
     with pytest.raises(ValueError, match="multiple of eight"):
         b12x_mla._kernel_query_heads(6, 2)
 
@@ -88,7 +90,9 @@ def test_mla_rejects_partial_dcp_cache_without_matching_subgroup() -> None:
         mla_attention._get_mla_kv_dcp_world_size(partial, 16)
 
 
-def _support_reason(monkeypatch, *, dcp_size: int, pcp_size: int = 1) -> str | None:
+def _support_reason(
+    monkeypatch, *, dcp_size: int, local_heads: int = 6, pcp_size: int = 1
+) -> str | None:
     parallel_config = SimpleNamespace(
         decode_context_parallel_size=dcp_size,
         prefill_context_parallel_size=pcp_size,
@@ -103,7 +107,7 @@ def _support_reason(monkeypatch, *, dcp_size: int, pcp_size: int = 1) -> str | N
             v_head_dim=128,
         ),
         max_model_len=1_048_576,
-        get_num_attention_heads=lambda _: 6,
+        get_num_attention_heads=lambda _: local_heads,
     )
     config = SimpleNamespace(
         parallel_config=parallel_config,
@@ -125,16 +129,31 @@ def _support_reason(monkeypatch, *, dcp_size: int, pcp_size: int = 1) -> str | N
     )
 
 
-def test_b12x_mla_selects_supported_native_dcp_geometry(monkeypatch) -> None:
-    assert _support_reason(monkeypatch, dcp_size=8) is None
-    assert _support_reason(monkeypatch, dcp_size=16) is None
+@pytest.mark.parametrize(
+    ("dcp_size", "local_heads"),
+    ((8, 12), (12, 8), (16, 6)),
+)
+def test_b12x_mla_selects_supported_native_dcp_geometry(
+    monkeypatch, dcp_size: int, local_heads: int
+) -> None:
+    assert (
+        _support_reason(
+            monkeypatch,
+            dcp_size=dcp_size,
+            local_heads=local_heads,
+        )
+        is None
+    )
 
 
 def test_b12x_mla_rejects_unsupported_parallel_geometry(monkeypatch) -> None:
-    assert "multiple of eight" in _support_reason(monkeypatch, dcp_size=2)
-    assert "prefill context parallelism" in _support_reason(
-        monkeypatch, dcp_size=8, pcp_size=2
-    )
+    dcp_reason = _support_reason(monkeypatch, dcp_size=2)
+    pcp_reason = _support_reason(monkeypatch, dcp_size=8, pcp_size=2)
+
+    assert dcp_reason is not None
+    assert "multiple of eight" in dcp_reason
+    assert pcp_reason is not None
+    assert "prefill context parallelism" in pcp_reason
 
 
 class _FakePlan:

--- a/tests/v1/attention/test_b12x_mla.py
+++ b/tests/v1/attention/test_b12x_mla.py
@@ -3,6 +3,7 @@
 
 from types import SimpleNamespace
 
+import pytest
 import torch
 
 from vllm.platforms.interface import DeviceCapability
@@ -59,13 +60,11 @@ class _FakeDenseMLA:
 
 
 def _fake_impl(monkeypatch, *, num_heads: int = 8) -> tuple[B12xMLAImpl, _FakeDenseMLA]:
-    monkeypatch.setattr(b12x_mla, "is_workspace_manager_initialized", lambda: False)
     impl = object.__new__(B12xMLAImpl)
     impl.num_heads = num_heads
     impl.kv_lora_rank = 512
     impl.scale = 192**-0.5
     impl._compiled_bindings = set()
-    impl._fallback_scratch = {}
     dense_mla = _FakeDenseMLA()
     impl._dense_mla = dense_mla
     return impl, dense_mla
@@ -79,6 +78,7 @@ def test_b12x_mla_adapter_binds_common_decode_metadata(monkeypatch) -> None:
     cache = torch.randn(4, 16, 576, dtype=torch.bfloat16)
     metadata = SimpleNamespace(
         dense_mla_plan=_FakePlan(),
+        dense_mla_scratch=torch.empty(256, dtype=torch.uint8),
         query_start_loc=torch.tensor([0, 1, 2], dtype=torch.int32),
         decode=SimpleNamespace(
             block_table=torch.tensor([[0, 1], [2, 3]], dtype=torch.int32),
@@ -107,6 +107,7 @@ def test_b12x_mla_adapter_binds_common_decode_metadata(monkeypatch) -> None:
     assert binding.q_scale is None
     assert binding.kv_scale is None
     assert binding.sm_scale == impl.scale
+    assert binding.scratch is metadata.dense_mla_scratch
 
 
 def test_b12x_mla_adapter_accepts_non_multiple_of_eight_heads(monkeypatch) -> None:
@@ -115,6 +116,7 @@ def test_b12x_mla_adapter_accepts_non_multiple_of_eight_heads(monkeypatch) -> No
     cache = torch.randn(2, 16, 576, dtype=torch.bfloat16)
     metadata = SimpleNamespace(
         dense_mla_plan=_FakePlan(),
+        dense_mla_scratch=torch.empty(256, dtype=torch.uint8),
         query_start_loc=torch.tensor([0, 1], dtype=torch.int32),
         decode=SimpleNamespace(
             block_table=torch.tensor([[0, 1]], dtype=torch.int32),
@@ -139,6 +141,7 @@ def test_b12x_mla_adapter_binds_causal_multiquery_blocks(monkeypatch) -> None:
     query_start_loc = torch.tensor([0, 8, 16], dtype=torch.int32)
     metadata = SimpleNamespace(
         dense_mla_plan=_FakePlan(),
+        dense_mla_scratch=torch.empty(256, dtype=torch.uint8),
         query_start_loc=query_start_loc,
         decode=SimpleNamespace(
             block_table=torch.tensor([[0, 1, 2, 3], [4, 5, 6, 7]], dtype=torch.int32),
@@ -163,6 +166,7 @@ def test_b12x_mla_adapter_binds_causal_multiquery_blocks(monkeypatch) -> None:
 def test_b12x_mla_builder_flattens_non_causal_draft_block(monkeypatch) -> None:
     builder = object.__new__(B12xMLAMetadataBuilder)
     builder._dense_mla_plan = _FakePlan()
+    builder._dense_mla_scratch = torch.empty(256, dtype=torch.uint8)
     builder._max_dense_mla_rows = 16
     builder._dense_mla_flat_block_table = torch.zeros(16, 4, dtype=torch.int32)
     builder._dense_mla_flat_seq_lens = torch.empty(16, dtype=torch.int32)
@@ -186,6 +190,7 @@ def test_b12x_mla_builder_flattens_non_causal_draft_block(monkeypatch) -> None:
 
     result = builder.build(0, SimpleNamespace())
 
+    assert result.dense_mla_scratch is builder._dense_mla_scratch
     torch.testing.assert_close(
         result.dense_mla_flat_block_table,
         source_table.expand(8, -1),
@@ -211,6 +216,7 @@ def test_b12x_mla_adapter_uses_flattened_non_causal_rows(monkeypatch) -> None:
     flat_query_start = torch.arange(query_rows + 1, dtype=torch.int32)
     metadata = SimpleNamespace(
         dense_mla_plan=_FakePlan(),
+        dense_mla_scratch=torch.empty(256, dtype=torch.uint8),
         dense_mla_flat_block_table=flat_table,
         dense_mla_flat_seq_lens=flat_lens,
         dense_mla_flat_query_start_loc=flat_query_start,
@@ -238,6 +244,7 @@ def test_b12x_mla_adapter_passes_fp8_scales(monkeypatch) -> None:
     cache = torch.empty(2, 16, 576, dtype=torch.float8_e4m3fn)
     metadata = SimpleNamespace(
         dense_mla_plan=_FakePlan(),
+        dense_mla_scratch=torch.empty(256, dtype=torch.uint8),
         query_start_loc=torch.tensor([0, 1], dtype=torch.int32),
         decode=SimpleNamespace(
             block_table=torch.tensor([[0, 1]], dtype=torch.int32),
@@ -254,3 +261,23 @@ def test_b12x_mla_adapter_passes_fp8_scales(monkeypatch) -> None:
     binding = dense_mla.bindings[0]
     assert binding.q_scale is layer._q_scale
     assert binding.kv_scale is layer._k_scale
+
+
+def test_b12x_mla_adapter_requires_caller_owned_scratch(monkeypatch) -> None:
+    impl, _ = _fake_impl(monkeypatch)
+    metadata = SimpleNamespace(
+        dense_mla_plan=_FakePlan(),
+        query_start_loc=torch.tensor([0, 1], dtype=torch.int32),
+        decode=SimpleNamespace(
+            block_table=torch.tensor([[0]], dtype=torch.int32),
+            seq_lens=torch.tensor([1], dtype=torch.int32),
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="caller-owned dense MLA scratch"):
+        impl.forward_mqa(
+            torch.randn(1, 8, 576, dtype=torch.bfloat16),
+            torch.randn(1, 16, 576, dtype=torch.bfloat16),
+            metadata,
+            SimpleNamespace(_q_scale=None, _k_scale=None),
+        )

--- a/tests/v1/attention/test_b12x_mla.py
+++ b/tests/v1/attention/test_b12x_mla.py
@@ -61,6 +61,55 @@ def test_b12x_mla_plans_local_interleaved_dcp_cache() -> None:
     assert b12x_mla._max_dcp_local_cache_tokens(config) == 131_072
 
 
+def _support_reason(monkeypatch, *, dcp_size: int, pcp_size: int = 1) -> str | None:
+    parallel_config = SimpleNamespace(
+        decode_context_parallel_size=dcp_size,
+        prefill_context_parallel_size=pcp_size,
+        cp_kv_cache_interleave_size=64,
+    )
+    model_config = SimpleNamespace(
+        hf_text_config=SimpleNamespace(
+            model_type="kimi_linear",
+            kv_lora_rank=512,
+            qk_nope_head_dim=128,
+            qk_rope_head_dim=64,
+            v_head_dim=128,
+        ),
+        max_model_len=1_048_576,
+        get_num_attention_heads=lambda _: 6,
+    )
+    config = SimpleNamespace(
+        parallel_config=parallel_config,
+        model_config=model_config,
+        scheduler_config=SimpleNamespace(max_num_seqs=8),
+    )
+    monkeypatch.setattr(b12x_mla, "_load_dense_mla", lambda: object())
+    monkeypatch.setattr(b12x_mla, "get_current_vllm_config", lambda: config)
+    return B12xMLABackend.supports_combination(
+        head_size=576,
+        dtype=torch.bfloat16,
+        kv_cache_dtype="fp8",
+        block_size=944,
+        use_mla=True,
+        has_sink=False,
+        use_sparse=False,
+        use_mm_prefix=False,
+        device_capability=DeviceCapability(12, 0),
+    )
+
+
+def test_b12x_mla_selects_supported_native_dcp_geometry(monkeypatch) -> None:
+    assert _support_reason(monkeypatch, dcp_size=8) is None
+    assert _support_reason(monkeypatch, dcp_size=16) is None
+
+
+def test_b12x_mla_rejects_unsupported_parallel_geometry(monkeypatch) -> None:
+    assert "multiple of eight" in _support_reason(monkeypatch, dcp_size=2)
+    assert "prefill context parallelism" in _support_reason(
+        monkeypatch, dcp_size=8, pcp_size=2
+    )
+
+
 class _FakePlan:
     def shapes_and_dtypes(self):
         return (((256,), torch.uint8),)

--- a/tests/v1/attention/test_b12x_mla.py
+++ b/tests/v1/attention/test_b12x_mla.py
@@ -32,6 +32,16 @@ def test_b12x_mla_is_registered_with_k3_envelope() -> None:
     assert B12xMLAMetadataBuilder.query_len_support is b12x_mla.QueryLenSupport.UNIFORM
 
 
+@pytest.mark.parametrize(
+    ("logical_heads", "kernel_heads"),
+    ((6, 8), (8, 8), (12, 16), (16, 16)),
+)
+def test_b12x_mla_pads_query_heads_to_kernel_tile(
+    logical_heads: int, kernel_heads: int
+) -> None:
+    assert b12x_mla._kernel_query_heads(logical_heads) == kernel_heads
+
+
 class _FakePlan:
     def shapes_and_dtypes(self):
         return (((256,), torch.uint8),)
@@ -64,6 +74,7 @@ def _fake_impl(monkeypatch, *, num_heads: int = 8) -> tuple[B12xMLAImpl, _FakeDe
     impl.num_heads = num_heads
     impl.kv_lora_rank = 512
     impl.scale = 192**-0.5
+    impl._kernel_heads = b12x_mla._kernel_query_heads(num_heads)
     impl._compiled_bindings = set()
     dense_mla = _FakeDenseMLA()
     impl._dense_mla = dense_mla
@@ -117,6 +128,8 @@ def test_b12x_mla_adapter_accepts_non_multiple_of_eight_heads(monkeypatch) -> No
     metadata = SimpleNamespace(
         dense_mla_plan=_FakePlan(),
         dense_mla_scratch=torch.empty(256, dtype=torch.uint8),
+        dense_mla_padded_q=torch.empty(1, 8, 576, dtype=torch.bfloat16),
+        dense_mla_padded_output=torch.empty(1, 8, 512, dtype=torch.bfloat16),
         query_start_loc=torch.tensor([0, 1], dtype=torch.int32),
         decode=SimpleNamespace(
             block_table=torch.tensor([[0, 1]], dtype=torch.int32),
@@ -128,7 +141,10 @@ def test_b12x_mla_adapter_accepts_non_multiple_of_eight_heads(monkeypatch) -> No
     output, _ = impl.forward_mqa(q, cache, metadata, layer)
 
     assert output.shape == (1, 6, 512)
-    assert dense_mla.bindings[0].q.shape == (1, 6, 576)
+    binding = dense_mla.bindings[0]
+    assert binding.q.shape == (1, 8, 576)
+    torch.testing.assert_close(binding.q[:, :6], q)
+    torch.testing.assert_close(binding.q[:, 6:], torch.zeros_like(binding.q[:, 6:]))
 
 
 def test_b12x_mla_adapter_binds_causal_multiquery_blocks(monkeypatch) -> None:
@@ -167,6 +183,8 @@ def test_b12x_mla_builder_flattens_non_causal_draft_block(monkeypatch) -> None:
     builder = object.__new__(B12xMLAMetadataBuilder)
     builder._dense_mla_plan = _FakePlan()
     builder._dense_mla_scratch = torch.empty(256, dtype=torch.uint8)
+    builder._dense_mla_padded_q = None
+    builder._dense_mla_padded_output = None
     builder._max_dense_mla_rows = 16
     builder._dense_mla_flat_block_table = torch.zeros(16, 4, dtype=torch.int32)
     builder._dense_mla_flat_seq_lens = torch.empty(16, dtype=torch.int32)
@@ -217,6 +235,8 @@ def test_b12x_mla_adapter_uses_flattened_non_causal_rows(monkeypatch) -> None:
     metadata = SimpleNamespace(
         dense_mla_plan=_FakePlan(),
         dense_mla_scratch=torch.empty(256, dtype=torch.uint8),
+        dense_mla_padded_q=torch.empty(query_rows, 8, 576, dtype=torch.bfloat16),
+        dense_mla_padded_output=torch.empty(query_rows, 8, 512, dtype=torch.bfloat16),
         dense_mla_flat_block_table=flat_table,
         dense_mla_flat_seq_lens=flat_lens,
         dense_mla_flat_query_start_loc=flat_query_start,

--- a/tests/v1/attention/test_mla_context_chunks.py
+++ b/tests/v1/attention/test_mla_context_chunks.py
@@ -12,6 +12,7 @@ import pytest
 import torch
 
 from vllm.model_executor.layers.attention.mla_attention import (
+    _gather_dcp_context_kv,
     build_mla_chunked_context_metadata,
     init_mla_context_partial,
     reorg_kvcache,
@@ -27,6 +28,7 @@ def build_chunked_context(
     block_size: int = BLOCK_SIZE,
     dcp_world_size: int = 1,
     dcp_local_block_size: int = 1,
+    direct_dcp_kv_gather: bool = False,
 ):
     query_start_loc = torch.zeros(len(query_lens) + 1, dtype=torch.int32)
     query_start_loc[1:] = torch.tensor(query_lens, dtype=torch.int32).cumsum(0)
@@ -42,6 +44,7 @@ def build_chunked_context(
         dcp_world_size=dcp_world_size,
         dcp_local_block_size=dcp_local_block_size,
         dcp_virtual_block_size=dcp_local_block_size * dcp_world_size,
+        direct_dcp_kv_gather=direct_dcp_kv_gather,
     )
 
 
@@ -231,6 +234,57 @@ def test_dcp_chunks_fit_the_per_rank_row_budget():
     for request, length in enumerate(context_lens):
         padded_local = -(-length // virtual_block_size) * interleave
         assert local_cursor[request] == padded_local
+
+
+def test_dcp_metadata_preserves_direct_kv_gather_capability():
+    """Manager-free DCP prefill records the process-group gather contract."""
+    metadata = build_chunked_context(
+        [256],
+        [4],
+        1024,
+        dcp_world_size=2,
+        dcp_local_block_size=64,
+        direct_dcp_kv_gather=True,
+    )
+
+    assert metadata is not None
+    assert metadata.dcp_manager is None
+    assert metadata.direct_dcp_kv_gather
+
+
+def test_direct_dcp_kv_gather_writes_caller_storage(monkeypatch):
+    local = torch.tensor([[1.0], [2.0]])
+    gathered = torch.empty(4, 1)
+
+    class FakeGroup:
+        def all_gather(self, value, *, dim):
+            assert value is local
+            assert dim == 0
+            return torch.cat((value, value + 10), dim=0)
+
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.attention.mla_attention.get_dcp_group",
+        lambda: FakeGroup(),
+    )
+
+    _gather_dcp_context_kv(
+        gathered,
+        local,
+        dcp_manager=None,
+        direct_dcp_kv_gather=True,
+    )
+
+    torch.testing.assert_close(gathered, torch.tensor([[1.0], [2.0], [11.0], [12.0]]))
+
+
+def test_dcp_kv_gather_requires_manager_or_direct_path():
+    with pytest.raises(RuntimeError, match="no configured KV gather path"):
+        _gather_dcp_context_kv(
+            torch.empty(2, 1),
+            torch.empty(1, 1),
+            dcp_manager=None,
+            direct_dcp_kv_gather=False,
+        )
 
 
 def test_dcp_reorg_uses_each_chunks_local_starts():

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -64,6 +64,7 @@ if TYPE_CHECKING:
     VLLM_NVFP4_MLA_SCALES_FILE: str = ""
     VLLM_B12X_ABSORB_BMM: bool = False
     VLLM_DSPARK_FP8_DRAFT_HEAD: bool = False
+    VLLM_MLA_CHUNKED_PREFILL_WORKSPACE_SIZE: int = 0
     VLLM_K3_KV_GROUP_SIZE: int = 0
     VLLM_USE_B12X_WO_PROJECTION: bool = False
     VLLM_USE_B12X_MOE: bool = False
@@ -1139,6 +1140,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # retain target-model semantics. Requires fp8 tensor cores (SM89+).
     "VLLM_DSPARK_FP8_DRAFT_HEAD": lambda: bool(
         int(os.getenv("VLLM_DSPARK_FP8_DRAFT_HEAD", "0"))
+    ),
+    # Bound the number of context tokens expanded into dense MLA K/V tensors
+    # per attention call. Zero selects the automatic memory bound.
+    "VLLM_MLA_CHUNKED_PREFILL_WORKSPACE_SIZE": lambda: int(
+        os.getenv("VLLM_MLA_CHUNKED_PREFILL_WORKSPACE_SIZE", "0")
     ),
     # Bound the number of physical Kimi-K3 layers sharing each hybrid-cache
     # block table. Zero preserves the general grouping heuristic.

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -319,6 +319,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheSpec,
     MLAAttentionSpec,
     SlidingWindowMLASpec,
+    get_kv_cache_dcp_shard_count,
     get_kv_quant_mode,
 )
 
@@ -326,6 +327,19 @@ logger = init_logger(__name__)
 
 _FP8_DTYPE = current_platform.fp8_dtype()
 _B12X_ABSORB_BMM_MAX_M = 32
+
+
+def _get_mla_kv_dcp_world_size(
+    kv_cache_spec: KVCacheSpec, configured_dcp_world_size: int
+) -> int:
+    """Return the DCP group size that owns distinct KV position shards."""
+    shard_count = get_kv_cache_dcp_shard_count(kv_cache_spec, configured_dcp_world_size)
+    if shard_count not in (1, configured_dcp_world_size):
+        raise NotImplementedError(
+            "MLA metadata supports fully sharded or replicated DCP KV groups; "
+            "partial DCP KV sharding requires a matching subgroup"
+        )
+    return shard_count
 
 
 def _run_mla_query_bmm(
@@ -3159,10 +3173,13 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
         attention_layer = self.compilation_config.static_forward_context[layer_names[0]]
 
         try:
-            self.dcp_world_size = get_dcp_group().world_size
+            configured_dcp_world_size = int(get_dcp_group().world_size)
         except AssertionError:
             # DCP might not be initialized in testing
-            self.dcp_world_size = 1
+            configured_dcp_world_size = 1
+        self.dcp_world_size = _get_mla_kv_dcp_world_size(
+            kv_cache_spec, configured_dcp_world_size
+        )
         self.dcp_local_block_size = parallel_config.cp_kv_cache_interleave_size
         self.dcp_virtual_block_size = self.dcp_local_block_size * self.dcp_world_size
         self.cp_kv_cache_interleave_size = parallel_config.cp_kv_cache_interleave_size

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -2504,6 +2504,7 @@ class MLACommonPrefillMetadata:
         context_lens_list: list[int]
         empty_token_slices: list[slice]
         dcp_manager: MLADCPManager | None = None
+        direct_dcp_kv_gather: bool = False
 
     block_table: torch.Tensor
     query_start_loc: torch.Tensor
@@ -2793,6 +2794,7 @@ def build_mla_chunked_context_metadata(
     dcp_local_block_size: int,
     dcp_virtual_block_size: int,
     dcp_manager: MLADCPManager | None = None,
+    direct_dcp_kv_gather: bool = False,
 ) -> "MLACommonPrefillMetadata.ChunkedContextMetadata | None":
     """Build chunked-context metadata for an MLA prefill.
 
@@ -2812,6 +2814,8 @@ def build_mla_chunked_context_metadata(
         dcp_local_block_size: Per-rank interleave block size for DCP.
         dcp_virtual_block_size: ``dcp_local_block_size * dcp_world_size``.
         dcp_manager: Shared MLA DCP collective manager.
+        direct_dcp_kv_gather: Gather context KV through the process DCP group
+            when the decode backend owns its query and output collectives.
 
     Returns:
         The chunked-context metadata, or None when no prefill has any context.
@@ -3001,6 +3005,7 @@ def build_mla_chunked_context_metadata(
         context_lens_list=context_lens,
         empty_token_slices=empty_token_slices,
         dcp_manager=dcp_manager,
+        direct_dcp_kv_gather=direct_dcp_kv_gather,
     )
 
 
@@ -3022,6 +3027,11 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
 
     # Whether this builder can flatten a non-causal query block into decode rows.
     supports_non_causal_multi_token_decode: ClassVar[bool] = False
+
+    # A decode backend that owns DCP query and output collectives can omit an
+    # MLADCPManager. Chunked-context prefill still gathers KV through the
+    # process DCP group before it runs the configured prefill backend.
+    supports_direct_dcp_kv_gather: ClassVar[bool] = False
 
     # The threshold for reordering the batch into decode and prefill requests.
     # If > 1, the batch will be reordered such that requests with
@@ -3183,11 +3193,20 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
                 device=device,
             )
             self.dcp_manager = getattr(attention_layer, "dcp_manager", None)
-            assert isinstance(self.dcp_manager, MLADCPManager)
-            self.dcp_manager.init_kv_gather(
-                self.chunked_prefill_workspace,
-                self.chunked_prefill_workspace_size,
-            )
+            if self.dcp_manager is not None:
+                if not isinstance(self.dcp_manager, MLADCPManager):
+                    raise TypeError(
+                        "MLA attention layer dcp_manager must be an "
+                        f"MLADCPManager, got {type(self.dcp_manager).__name__}."
+                    )
+                self.dcp_manager.init_kv_gather(
+                    self.chunked_prefill_workspace,
+                    self.chunked_prefill_workspace_size,
+                )
+            elif not self.supports_direct_dcp_kv_gather:
+                raise RuntimeError(
+                    f"{type(self).__name__} requires MLADCPManager when DCP is enabled."
+                )
         else:
             self.chunked_prefill_workspace = torch.empty(
                 (
@@ -3343,6 +3362,11 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
                 dcp_local_block_size=self.dcp_local_block_size,
                 dcp_virtual_block_size=self.dcp_virtual_block_size,
                 dcp_manager=self.dcp_manager,
+                direct_dcp_kv_gather=(
+                    self.dcp_world_size > 1
+                    and self.dcp_manager is None
+                    and self.supports_direct_dcp_kv_gather
+                ),
             )
 
             prefill_metadata = MLACommonPrefillMetadata(
@@ -3473,6 +3497,23 @@ def reorg_kvcache(
     assert reorganized_k_pe.shape[0] == sum_seq_len
     assert max_seq_len_check == max_seq_len
     return reorganized_kv_c_normed, reorganized_k_pe
+
+
+def _gather_dcp_context_kv(
+    gathered_kv: torch.Tensor,
+    local_kv: torch.Tensor,
+    *,
+    dcp_manager: MLADCPManager | None,
+    direct_dcp_kv_gather: bool,
+) -> None:
+    """Gather one chunk of DCP-sharded context KV into caller storage."""
+    if dcp_manager is not None:
+        dcp_manager.kv_gather(gathered_kv, local_kv)
+        return
+    if direct_dcp_kv_gather:
+        gathered_kv.copy_(get_dcp_group().all_gather(local_kv, dim=0))
+        return
+    raise RuntimeError("MLA DCP chunked prefill has no configured KV gather path.")
 
 
 def init_mla_context_partial(
@@ -3782,8 +3823,12 @@ class MLACommonBaseImpl(MLAAttentionImpl[A], Generic[A]):
             ]
             assert toks * dcp_world_size <= cur_allgather_workspace.shape[0]
             cur_allgather_kvcache = cur_allgather_workspace[: toks * dcp_world_size]
-            dcp_manager = cast(MLADCPManager, chunked_context.dcp_manager)
-            dcp_manager.kv_gather(cur_allgather_kvcache, local_gathered_kvcache)
+            _gather_dcp_context_kv(
+                cur_allgather_kvcache,
+                local_gathered_kvcache,
+                dcp_manager=chunked_context.dcp_manager,
+                direct_dcp_kv_gather=chunked_context.direct_dcp_kv_gather,
+            )
             assert (
                 cur_allgather_kvcache.shape[-1]
                 == self.kv_lora_rank + self.qk_rope_head_dim

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -3036,22 +3036,25 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
         cache_config = vllm_config.cache_config
         model_config = vllm_config.model_config
 
-        chunked_prefill_workspace_size = min(
-            # Try for 8 full length request or at least 4 pages per-request
-            max(
-                8 * model_config.max_model_len,
-                4 * scheduler_config.max_num_seqs * cache_config.block_size,
-            ),
-            # For long-context models try not to over-allocate limiting
-            # kv-cache space, limiting it to 64k tokens,
-            # which would result in the workspace being:
-            #   2*(576)*(64*1024) = 144mb
-            # (assuming 576 MLA head dim, and fp16)
-            # which would result in up-projected context being
-            #   2*(192*128)*(64*1024) = 3gb
-            # (assuming 192 QK head dim, 128 heads, and fp16)
-            64 * 1024,
-        )
+        configured_workspace_size = envs.VLLM_MLA_CHUNKED_PREFILL_WORKSPACE_SIZE
+        if configured_workspace_size < 0:
+            raise ValueError(
+                "VLLM_MLA_CHUNKED_PREFILL_WORKSPACE_SIZE must be non-negative, "
+                f"got {configured_workspace_size}."
+            )
+        if configured_workspace_size:
+            chunked_prefill_workspace_size = configured_workspace_size
+        else:
+            chunked_prefill_workspace_size = min(
+                # Try for 8 full-length requests or at least 4 pages per request.
+                max(
+                    8 * model_config.max_model_len,
+                    4 * scheduler_config.max_num_seqs * cache_config.block_size,
+                ),
+                # Bound persistent compressed-KV storage and transient dense K/V
+                # projections for long-context models.
+                64 * 1024,
+            )
 
         return align_mla_chunked_context_workspace_size(
             vllm_config,

--- a/vllm/model_executor/warmup/kernel_warmup.py
+++ b/vllm/model_executor/warmup/kernel_warmup.py
@@ -210,6 +210,9 @@ def _warmup_b12x_dcp_a2a(worker: "Worker") -> int:
     from vllm.models.deepseek_v4.nvidia.b12x import (
         DeepseekV4B12xMLAAttention,
     )
+    from vllm.models.kimi_k3.nvidia.mla import (
+        MultiHeadLatentAttention as KimiK3MLAAttention,
+    )
     from vllm.v1.attention.ops.dcp_alltoall import warmup_b12x_dcp_a2a
 
     model = worker.get_model()
@@ -234,6 +237,17 @@ def _warmup_b12x_dcp_a2a(worker: "Worker") -> int:
             device = next(module.parameters()).device
             total_heads = int(module.num_heads) * dcp_world_size
             query_head_dim = int(module.kv_lora_rank + module.qk_rope_head_dim)
+            output_head_dim = int(module.kv_lora_rank)
+        elif (
+            isinstance(module, KimiK3MLAAttention)
+            and module.attn_backend.get_name() == "B12X_MLA"
+        ):
+            module_dcp_world_size = int(module.impl.dcp_world_size)
+            if module_dcp_world_size <= 1:
+                continue
+            device = next(module.parameters()).device
+            total_heads = int(module.num_local_heads) * module_dcp_world_size
+            query_head_dim = int(module.head_size)
             output_head_dim = int(module.kv_lora_rank)
         else:
             continue

--- a/vllm/models/kimi_k3/nvidia/mla.py
+++ b/vllm/models/kimi_k3/nvidia/mla.py
@@ -172,6 +172,13 @@ class KimiShardedMergedColumnParallelLinear(MergedColumnParallelLinear):
         return output, output_bias
 
 
+def _backend_owns_decode_dcp(impl: object, dcp_world_size: int) -> bool:
+    """Return whether the selected backend gathers and combines DCP itself."""
+    return dcp_world_size > 1 and bool(
+        getattr(impl, "owns_decode_dcp_collectives", False)
+    )
+
+
 class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
     """Kimi-K3 Multi-head Latent Attention with optional RoPE and output gate."""
 
@@ -400,13 +407,19 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
             "parallelism."
         )
         self.dcp_world_size = parallel_config.decode_context_parallel_size
-        assert self.dcp_world_size <= 1 or self.rotary_emb is None, (
-            "Kimi-K3 MultiHeadLatentAttention does not support RoPE with decode "
-            "context parallelism because gathered queries require gathered "
-            "positions."
+        self.backend_owns_decode_dcp = _backend_owns_decode_dcp(
+            self.impl, self.dcp_world_size
+        )
+        assert (
+            self.dcp_world_size <= 1
+            or self.rotary_emb is None
+            or self.backend_owns_decode_dcp
+        ), (
+            "Kimi-K3 RoPE with decode context parallelism requires an attention "
+            "backend that owns its DCP query and output collectives."
         )
         self.dcp_manager: MLADCPManager | None = None
-        if self.dcp_world_size > 1:
+        if self.dcp_world_size > 1 and not self.backend_owns_decode_dcp:
             query_dtype = (
                 torch.float8_e4m3fn
                 if is_quantized_kv_cache(self.kv_cache_dtype)
@@ -699,16 +712,14 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
                 cos_sin_cache,
                 slot_mapping[:num_mqa_tokens],
             )
-            if self.dcp_world_size > 1:
-                assert self.dcp_manager is not None
+            if self.dcp_manager is not None:
                 assert self.dcp_manager.query_gather is not None
                 mqa_q = self.dcp_manager.query_gather(mqa_q)
             latent_out, lse = self.impl.forward_mqa(  # type: ignore[attr-defined]
                 mqa_q, self._attn_read_kv_cache(), attn_metadata, self
             )
-            if self.dcp_world_size > 1:
+            if self.dcp_manager is not None:
                 assert lse is not None
-                assert self.dcp_manager is not None
                 assert attn_metadata.decode is not None
                 latent_out = self.dcp_manager.combine(
                     latent_out,

--- a/vllm/v1/attention/backends/mla/b12x_mla.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla.py
@@ -123,6 +123,24 @@ def _kernel_query_heads(local_heads: int, dcp_size: int = 1) -> int:
     )
 
 
+def _active_dense_mla_splits(plan: Any, max_seq_len: int | None) -> int:
+    """Return the split-plan prefix that can contain live cache rows."""
+    num_splits = int(getattr(plan, "num_splits", 1))
+    chunks_per_split = int(getattr(plan, "chunks_per_split", 1))
+    if num_splits <= 0 or chunks_per_split <= 0:
+        raise ValueError(
+            "B12X_MLA received invalid split geometry: "
+            f"splits={num_splits}, chunks_per_split={chunks_per_split}."
+        )
+    if max_seq_len is None:
+        return num_splits
+    valid_chunks = max(1, (max(0, int(max_seq_len)) + 63) // 64)
+    return min(
+        num_splits,
+        (valid_chunks + chunks_per_split - 1) // chunks_per_split,
+    )
+
+
 def _create_dense_mla_plan(
     vllm_config: VllmConfig,
     device: torch.device,
@@ -662,6 +680,17 @@ class B12xMLAImpl(MLACommonImpl[B12xMLAMetadata]):
                 "B12X_MLA metadata is missing caller-owned dense MLA scratch."
             )
         quantized = q.dtype == torch.float8_e4m3fn
+        # Direct CUDA graph capture fixes the launch grid and therefore uses
+        # every planned split. Piecewise eager attention may omit only trailing
+        # splits whose first 64-token chunk lies beyond every live sequence.
+        active_splits = (
+            int(plan.num_splits)
+            if q.is_cuda and torch.cuda.is_current_stream_capturing()
+            else _active_dense_mla_splits(
+                plan,
+                getattr(attn_metadata, "max_seq_len", None),
+            )
+        )
         binding = self._dense_mla.bind(
             plan,
             scratch=scratch,
@@ -674,6 +703,7 @@ class B12xMLAImpl(MLACommonImpl[B12xMLAMetadata]):
             q_scale=layer._q_scale if quantized else None,
             kv_scale=layer._k_scale if quantized else None,
             sm_scale=self.scale,
+            active_splits=active_splits,
         )
 
         compile_key = (

--- a/vllm/v1/attention/backends/mla/b12x_mla.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla.py
@@ -429,20 +429,24 @@ class B12xMLABackend(MLACommonBackend):
             )
 
         parallel_config = vllm_config.parallel_config
-        if parallel_config.decode_context_parallel_size != 1:
-            return "B12X_MLA does not support decode context parallelism"
+        if parallel_config.prefill_context_parallel_size != 1:
+            return "B12X_MLA does not support prefill context parallelism"
+        dcp_size = int(parallel_config.decode_context_parallel_size)
         local_heads = model_config.get_num_attention_heads(parallel_config)
-        if local_heads <= 0:
-            return f"B12X_MLA requires a positive query-head count, got {local_heads}"
+        try:
+            _kernel_query_heads(local_heads, dcp_size)
+        except ValueError as exc:
+            return str(exc)
         if vllm_config.scheduler_config.max_num_seqs > _MAX_B12X_QUERY_ROWS:
             return (
                 "B12X_MLA max_num_seqs exceeds its 1024-row decode capacity: "
                 f"{vllm_config.scheduler_config.max_num_seqs}"
             )
-        if model_config.max_model_len > _MAX_B12X_CACHE_TOKENS:
+        local_cache_tokens = _max_dcp_local_cache_tokens(vllm_config)
+        if local_cache_tokens > _MAX_B12X_CACHE_TOKENS:
             return (
-                "B12X_MLA max_model_len exceeds its 1048576-token capacity: "
-                f"{model_config.max_model_len}"
+                "B12X_MLA local DCP cache exceeds its 1048576-token capacity: "
+                f"{local_cache_tokens}"
             )
         return None
 
@@ -453,6 +457,7 @@ class B12xMLABackend(MLACommonBackend):
 
 class B12xMLAImpl(MLACommonImpl[B12xMLAMetadata]):
     can_return_lse_for_decode: bool = True
+    owns_decode_dcp_collectives: bool = True
 
     def __init__(
         self,

--- a/vllm/v1/attention/backends/mla/b12x_mla.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla.py
@@ -11,6 +11,7 @@ import torch
 
 from vllm.config import VllmConfig, get_current_vllm_config
 from vllm.config.cache import CacheDType
+from vllm.distributed.parallel_state import get_dcp_group
 from vllm.logger import init_logger
 from vllm.model_executor.layers.attention.mla_attention import (
     MLACommonBackend,
@@ -27,6 +28,11 @@ from vllm.v1.attention.backend import (
     AttentionType,
     CommonAttentionMetadata,
     MultipleOf,
+)
+from vllm.v1.attention.ops.common import cp_lse_ag_out_rs
+from vllm.v1.attention.ops.dcp_alltoall import (
+    dcp_a2a_lse_reduce,
+    dcp_b12x_all_gather_heads,
 )
 from vllm.v1.kv_cache_interface import AttentionSpec
 
@@ -77,12 +83,41 @@ def _planned_kv_dtype(vllm_config: VllmConfig) -> torch.dtype:
     )
 
 
-def _kernel_query_heads(num_heads: int) -> int:
-    """Pad independent query heads to the B12X launch tile."""
-    if num_heads <= 0:
-        raise ValueError(f"B12X_MLA requires positive query heads, got {num_heads}.")
+def _max_dcp_local_cache_tokens(
+    vllm_config: VllmConfig, *, dcp_size: int | None = None
+) -> int:
+    """Return the largest interleaved KV shard held by one DCP rank."""
+    parallel_config = vllm_config.parallel_config
+    dcp_size = int(
+        parallel_config.decode_context_parallel_size if dcp_size is None else dcp_size
+    )
+    interleave = int(parallel_config.cp_kv_cache_interleave_size)
+    if dcp_size <= 0 or interleave <= 0:
+        raise ValueError(
+            "B12X_MLA requires positive DCP and KV-interleave sizes, got "
+            f"DCP={dcp_size}, interleave={interleave}."
+        )
+    max_model_len = int(vllm_config.model_config.max_model_len)
+    partitions = dcp_size * interleave
+    return ((max_model_len + partitions - 1) // partitions) * interleave
+
+
+def _kernel_query_heads(local_heads: int, dcp_size: int = 1) -> int:
+    """Return the tiled head count after an optional DCP query gather."""
+    if local_heads <= 0 or dcp_size <= 0:
+        raise ValueError(
+            "B12X_MLA requires positive query-head and DCP sizes, got "
+            f"heads={local_heads}, DCP={dcp_size}."
+        )
+    effective_heads = local_heads * dcp_size
+    if dcp_size > 1 and effective_heads % _B12X_QUERY_HEAD_TILE:
+        raise ValueError(
+            "B12X_MLA requires a multiple of eight query heads after DCP "
+            f"gather, got local={local_heads}, DCP={dcp_size}, "
+            f"effective={effective_heads}."
+        )
     return (
-        (num_heads + _B12X_QUERY_HEAD_TILE - 1)
+        (effective_heads + _B12X_QUERY_HEAD_TILE - 1)
         // _B12X_QUERY_HEAD_TILE
         * _B12X_QUERY_HEAD_TILE
     )
@@ -95,6 +130,7 @@ def _create_dense_mla_plan(
     page_size: int,
     num_q_heads: int,
     max_total_q: int | None = None,
+    dcp_size: int | None = None,
 ) -> Any:
     dense_mla = _load_dense_mla()
     max_total_q = int(
@@ -102,7 +138,7 @@ def _create_dense_mla_plan(
         if max_total_q is not None
         else vllm_config.scheduler_config.max_num_seqs
     )
-    max_cache_tokens = int(vllm_config.model_config.max_model_len)
+    max_cache_tokens = _max_dcp_local_cache_tokens(vllm_config, dcp_size=dcp_size)
     if max_total_q > _MAX_B12X_QUERY_ROWS:
         raise ValueError(
             "B12X_MLA supports at most "
@@ -148,6 +184,7 @@ class B12xMLAMetadataBuilder(MLACommonMetadataBuilder[B12xMLAMetadata]):
     _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.UNIFORM_BATCH
     query_len_support: ClassVar[QueryLenSupport] = QueryLenSupport.UNIFORM
     supports_non_causal_multi_token_decode: ClassVar[bool] = True
+    supports_direct_dcp_kv_gather: ClassVar[bool] = True
 
     def __init__(
         self,
@@ -162,6 +199,7 @@ class B12xMLAMetadataBuilder(MLACommonMetadataBuilder[B12xMLAMetadata]):
             vllm_config,
             device,
             B12xMLAMetadata,
+            supports_dcp_with_varlen=True,
         )
         max_dense_mla_rows = int(vllm_config.scheduler_config.max_num_seqs) * int(
             self.reorder_batch_threshold
@@ -172,13 +210,15 @@ class B12xMLAMetadataBuilder(MLACommonMetadataBuilder[B12xMLAMetadata]):
                 f"rows={max_dense_mla_rows}, limit={_MAX_B12X_QUERY_ROWS}."
             )
         self._max_dense_mla_rows = max_dense_mla_rows
-        self._kernel_heads = _kernel_query_heads(self.num_heads)
+        self._effective_heads = self.num_heads * self.dcp_world_size
+        self._kernel_heads = _kernel_query_heads(self.num_heads, self.dcp_world_size)
         self._dense_mla_plan = _create_dense_mla_plan(
             vllm_config,
             device,
             page_size=self.page_size,
             num_q_heads=self._kernel_heads,
             max_total_q=max_dense_mla_rows,
+            dcp_size=self.dcp_world_size,
         )
         self._workspace_specs = self._dense_mla_plan.shapes_and_dtypes()
         if len(self._workspace_specs) != 1:
@@ -223,13 +263,15 @@ class B12xMLAMetadataBuilder(MLACommonMetadataBuilder[B12xMLAMetadata]):
             device=device,
         )
         logger.info_once(
-            "B12X dense K3 MLA plan: logical_heads=%d, kernel_heads=%d, page_size=%d, "
+            "B12X dense K3 MLA plan: local_heads=%d, effective_heads=%d, "
+            "kernel_heads=%d, page_size=%d, "
             "max_decode_rows=%d, max_cache_tokens=%d, splits=%d",
             self.num_heads,
+            self._effective_heads,
             self._kernel_heads,
             self.page_size,
             max_dense_mla_rows,
-            vllm_config.model_config.max_model_len,
+            _max_dcp_local_cache_tokens(vllm_config, dcp_size=self.dcp_world_size),
             self._dense_mla_plan.num_splits,
         )
 
@@ -411,7 +453,6 @@ class B12xMLABackend(MLACommonBackend):
 
 class B12xMLAImpl(MLACommonImpl[B12xMLAMetadata]):
     can_return_lse_for_decode: bool = True
-    supports_dcp: bool = False
 
     def __init__(
         self,
@@ -479,13 +520,19 @@ class B12xMLAImpl(MLACommonImpl[B12xMLAMetadata]):
             raise ValueError(
                 f"B12xMLAImpl requires a positive query-head count, got {num_heads}."
             )
-        if get_current_vllm_config().parallel_config.decode_context_parallel_size != 1:
+        vllm_config = get_current_vllm_config()
+        self.dcp_world_size = int(
+            vllm_config.parallel_config.decode_context_parallel_size
+        )
+        if vllm_config.parallel_config.prefill_context_parallel_size != 1:
             raise NotImplementedError(
-                "B12xMLAImpl does not support decode context parallelism."
+                "B12xMLAImpl does not support prefill context parallelism."
             )
-
         self._dense_mla = _load_dense_mla()
-        self._kernel_heads = _kernel_query_heads(num_heads)
+        self._effective_heads = num_heads * self.dcp_world_size
+        self._kernel_heads = _kernel_query_heads(num_heads, self.dcp_world_size)
+        self._dcp_comm_backend = vllm_config.parallel_config.dcp_comm_backend
+        self._dcp_max_batch_size = vllm_config.scheduler_config.max_num_batched_tokens
         self._compiled_bindings: set[tuple[object, ...]] = set()
 
     def forward_mqa(
@@ -535,35 +582,58 @@ class B12xMLAImpl(MLACommonImpl[B12xMLAMetadata]):
                 f"B12X_MLA expected {self.num_heads} query heads, got {q.shape[1]}."
             )
 
-        if self._kernel_heads == self.num_heads:
+        dcp_group = None
+        if self.dcp_world_size > 1:
+            dcp_group = get_dcp_group()
+            q = dcp_b12x_all_gather_heads(
+                q,
+                dcp_group,
+                max_batch_size=self._dcp_max_batch_size,
+                output_head_dim=self.kv_lora_rank,
+            )
+
+        effective_heads = int(q.shape[1])
+        if effective_heads != self._effective_heads:
+            raise ValueError(
+                "B12X_MLA gathered an unexpected query-head count: "
+                f"expected {self._effective_heads}, got {effective_heads}."
+            )
+        if self._kernel_heads == effective_heads and self.dcp_world_size == 1:
             output = torch.empty(
-                (total_q, self.num_heads, self.kv_lora_rank),
+                (total_q, effective_heads, self.kv_lora_rank),
                 dtype=torch.bfloat16,
                 device=q.device,
             )
         else:
             padded_q = getattr(attn_metadata, "dense_mla_padded_q", None)
             output = getattr(attn_metadata, "dense_mla_padded_output", None)
-            if padded_q is None or output is None:
+            if output is None or (
+                self._kernel_heads != effective_heads and padded_q is None
+            ):
                 raise RuntimeError(
                     "B12X_MLA metadata is missing caller-owned padded query buffers."
                 )
-            if int(padded_q.shape[0]) < total_q or int(output.shape[0]) < total_q:
+            query_capacity = (
+                int(padded_q.shape[0]) if padded_q is not None else int(output.shape[0])
+            )
+            if query_capacity < total_q or int(output.shape[0]) < total_q:
                 raise ValueError(
                     "B12X_MLA padded query capacity is smaller than the decode "
-                    f"batch: query={padded_q.shape[0]}, output={output.shape[0]}, "
+                    f"batch: query={query_capacity}, output={output.shape[0]}, "
                     f"required={total_q}."
                 )
-            padded_q = padded_q[:total_q]
             output = output[:total_q]
-            if padded_q.dtype != q.dtype:
-                raise TypeError(
-                    "B12X_MLA padded query dtype does not match the live query: "
-                    f"buffer={padded_q.dtype}, query={q.dtype}."
-                )
-            padded_q[:, : self.num_heads].copy_(q)
-            padded_q[:, self.num_heads :].zero_()
-            q = padded_q
+            if self._kernel_heads != effective_heads:
+                assert padded_q is not None
+                padded_q = padded_q[:total_q]
+                if padded_q.dtype != q.dtype:
+                    raise TypeError(
+                        "B12X_MLA padded query dtype does not match the live query: "
+                        f"buffer={padded_q.dtype}, query={q.dtype}."
+                    )
+                padded_q[:, :effective_heads].copy_(q)
+                padded_q[:, effective_heads:].zero_()
+                q = padded_q
         scratch = getattr(attn_metadata, "dense_mla_scratch", None)
         if scratch is None:
             raise RuntimeError(
@@ -601,7 +671,30 @@ class B12xMLAImpl(MLACommonImpl[B12xMLAMetadata]):
             self._compiled_bindings.add(compile_key)
 
         output, lse = self._dense_mla.run(binding=binding)
-        return output[:, : self.num_heads], lse[:, : self.num_heads]
+        output = output[:, : self._effective_heads]
+        lse = lse[:, : self._effective_heads]
+        if dcp_group is None:
+            return output, lse
+        if self._dcp_comm_backend == "a2a":
+            reduced = dcp_a2a_lse_reduce(
+                output,
+                lse,
+                dcp_group,
+                is_lse_base_on_e=True,
+                seq_lens=seq_lens,
+                query_start_loc=query_start_loc[: batch + 1],
+                use_b12x=True,
+                b12x_max_batch_size=self._dcp_max_batch_size,
+                b12x_query_head_dim=_K3_ABSORBED_HEAD_DIM,
+            )
+        else:
+            reduced = cp_lse_ag_out_rs(
+                output,
+                lse,
+                dcp_group,
+                is_lse_base_on_e=True,
+            )
+        return reduced, None
 
 
 __all__ = [

--- a/vllm/v1/attention/backends/mla/b12x_mla.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla.py
@@ -819,13 +819,15 @@ class B12xMLAImpl(MLACommonImpl[B12xMLAMetadata]):
         if dcp_group is None:
             return output, lse
         if self._dcp_comm_backend == "a2a":
+            # B12X dense MLA writes -inf LSE for rows with no visible local KV
+            # chunks. The B12X DCP reduction converts every non-finite LSE to
+            # zero weight before reading its payload, so empty rows already
+            # contribute the exact neutral value without a sanitization pass.
             reduced = dcp_a2a_lse_reduce(
                 output,
                 lse,
                 dcp_group,
                 is_lse_base_on_e=True,
-                seq_lens=seq_lens,
-                query_start_loc=query_start_loc[: batch + 1],
                 use_b12x=True,
                 b12x_max_batch_size=self._dcp_max_batch_size,
                 b12x_query_head_dim=_K3_ABSORBED_HEAD_DIM,

--- a/vllm/v1/attention/backends/mla/b12x_mla.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla.py
@@ -590,11 +590,28 @@ class B12xMLAImpl(MLACommonImpl[B12xMLAMetadata]):
         dcp_group = None
         if self.dcp_world_size > 1:
             dcp_group = get_dcp_group()
+            gathered_q = getattr(attn_metadata, "dense_mla_padded_q", None)
+            if gathered_q is None:
+                raise RuntimeError(
+                    "B12X_MLA DCP metadata is missing caller-owned query storage."
+                )
+            if int(gathered_q.shape[0]) < total_q:
+                raise ValueError(
+                    "B12X_MLA DCP query capacity is smaller than the decode "
+                    f"batch: capacity={gathered_q.shape[0]}, required={total_q}."
+                )
+            if gathered_q.dtype != q.dtype:
+                raise TypeError(
+                    "B12X_MLA DCP query storage does not match the live query: "
+                    f"buffer={gathered_q.dtype}, query={q.dtype}."
+                )
+            gathered_q = gathered_q[:total_q, : self._effective_heads]
             q = dcp_b12x_all_gather_heads(
                 q,
                 dcp_group,
                 max_batch_size=self._dcp_max_batch_size,
                 output_head_dim=self.kv_lora_rank,
+                out=gathered_q,
             )
 
         effective_heads = int(q.shape[1])

--- a/vllm/v1/attention/backends/mla/b12x_mla.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla.py
@@ -149,6 +149,7 @@ def _create_dense_mla_plan(
     num_q_heads: int,
     max_total_q: int | None = None,
     dcp_size: int | None = None,
+    max_cache_tokens: int | None = None,
 ) -> Any:
     dense_mla = _load_dense_mla()
     max_total_q = int(
@@ -156,7 +157,11 @@ def _create_dense_mla_plan(
         if max_total_q is not None
         else vllm_config.scheduler_config.max_num_seqs
     )
-    max_cache_tokens = _max_dcp_local_cache_tokens(vllm_config, dcp_size=dcp_size)
+    max_cache_tokens = int(
+        max_cache_tokens
+        if max_cache_tokens is not None
+        else _max_dcp_local_cache_tokens(vllm_config, dcp_size=dcp_size)
+    )
     if max_total_q > _MAX_B12X_QUERY_ROWS:
         raise ValueError(
             "B12X_MLA supports at most "
@@ -196,6 +201,7 @@ class B12xMLAMetadata(MLACommonMetadata):
     dense_mla_flat_block_table: torch.Tensor | None = None
     dense_mla_flat_seq_lens: torch.Tensor | None = None
     dense_mla_flat_query_start_loc: torch.Tensor | None = None
+    dense_mla_dcp_world_size: int = 1
 
 
 class B12xMLAMetadataBuilder(MLACommonMetadataBuilder[B12xMLAMetadata]):
@@ -233,6 +239,12 @@ class B12xMLAMetadataBuilder(MLACommonMetadataBuilder[B12xMLAMetadata]):
         self._max_dense_mla_rows = max_dense_mla_rows
         self._effective_heads = self.num_heads * self.dcp_world_size
         self._kernel_heads = _kernel_query_heads(self.num_heads, self.dcp_world_size)
+        max_cache_tokens = _max_dcp_local_cache_tokens(
+            vllm_config, dcp_size=self.dcp_world_size
+        )
+        sliding_window = getattr(kv_cache_spec, "sliding_window", None)
+        if sliding_window is not None:
+            max_cache_tokens = min(max_cache_tokens, int(sliding_window))
         self._dense_mla_plan = _create_dense_mla_plan(
             vllm_config,
             device,
@@ -240,6 +252,7 @@ class B12xMLAMetadataBuilder(MLACommonMetadataBuilder[B12xMLAMetadata]):
             num_q_heads=self._kernel_heads,
             max_total_q=max_dense_mla_rows,
             dcp_size=self.dcp_world_size,
+            max_cache_tokens=max_cache_tokens,
         )
         self._workspace_specs = self._dense_mla_plan.shapes_and_dtypes()
         if len(self._workspace_specs) != 1:
@@ -316,7 +329,7 @@ class B12xMLAMetadataBuilder(MLACommonMetadataBuilder[B12xMLAMetadata]):
             self._kernel_heads,
             self.page_size,
             max_dense_mla_rows,
-            _max_dcp_local_cache_tokens(vllm_config, dcp_size=self.dcp_world_size),
+            max_cache_tokens,
             self._dense_mla_plan.num_splits,
         )
 
@@ -338,6 +351,7 @@ class B12xMLAMetadataBuilder(MLACommonMetadataBuilder[B12xMLAMetadata]):
         metadata.dense_mla_scratch = self._dense_mla_scratch
         metadata.dense_mla_padded_q = self._dense_mla_padded_q
         metadata.dense_mla_padded_output = self._dense_mla_padded_output
+        metadata.dense_mla_dcp_world_size = self.dcp_world_size
         decode_metadata = metadata.decode
         flatten_decode = False
         if decode_metadata is not None and metadata.num_decodes > 0:
@@ -622,8 +636,6 @@ class B12xMLAImpl(MLACommonImpl[B12xMLAMetadata]):
                 "B12xMLAImpl does not support prefill context parallelism."
             )
         self._dense_mla = _load_dense_mla()
-        self._effective_heads = num_heads * self.dcp_world_size
-        self._kernel_heads = _kernel_query_heads(num_heads, self.dcp_world_size)
         self._dcp_comm_backend = vllm_config.parallel_config.dcp_comm_backend
         self._dcp_max_batch_size = vllm_config.scheduler_config.max_num_batched_tokens
         self._compiled_bindings: set[tuple[object, ...]] = set()
@@ -675,8 +687,19 @@ class B12xMLAImpl(MLACommonImpl[B12xMLAMetadata]):
                 f"B12X_MLA expected {self.num_heads} query heads, got {q.shape[1]}."
             )
 
+        metadata_dcp_world_size = int(
+            getattr(attn_metadata, "dense_mla_dcp_world_size", self.dcp_world_size)
+        )
+        if metadata_dcp_world_size not in (1, self.dcp_world_size):
+            raise ValueError(
+                "B12X_MLA metadata uses an unsupported DCP KV shard count: "
+                f"metadata={metadata_dcp_world_size}, runtime={self.dcp_world_size}."
+            )
+        effective_heads = self.num_heads * metadata_dcp_world_size
+        kernel_heads = _kernel_query_heads(self.num_heads, metadata_dcp_world_size)
+
         dcp_group = None
-        if self.dcp_world_size > 1:
+        if metadata_dcp_world_size > 1:
             dcp_group = get_dcp_group()
             gathered_q = getattr(attn_metadata, "dense_mla_padded_q", None)
             if gathered_q is None:
@@ -693,7 +716,7 @@ class B12xMLAImpl(MLACommonImpl[B12xMLAMetadata]):
                     "B12X_MLA DCP query storage does not match the live query: "
                     f"buffer={gathered_q.dtype}, query={q.dtype}."
                 )
-            gathered_q = gathered_q[:total_q, : self._effective_heads]
+            gathered_q = gathered_q[:total_q, :effective_heads]
             q = dcp_b12x_all_gather_heads(
                 q,
                 dcp_group,
@@ -702,13 +725,13 @@ class B12xMLAImpl(MLACommonImpl[B12xMLAMetadata]):
                 out=gathered_q,
             )
 
-        effective_heads = int(q.shape[1])
-        if effective_heads != self._effective_heads:
+        actual_heads = int(q.shape[1])
+        if actual_heads != effective_heads:
             raise ValueError(
                 "B12X_MLA gathered an unexpected query-head count: "
-                f"expected {self._effective_heads}, got {effective_heads}."
+                f"expected {effective_heads}, got {actual_heads}."
             )
-        if self._kernel_heads == effective_heads and self.dcp_world_size == 1:
+        if kernel_heads == effective_heads and metadata_dcp_world_size == 1:
             output = torch.empty(
                 (total_q, effective_heads, self.kv_lora_rank),
                 dtype=torch.bfloat16,
@@ -717,9 +740,7 @@ class B12xMLAImpl(MLACommonImpl[B12xMLAMetadata]):
         else:
             padded_q = getattr(attn_metadata, "dense_mla_padded_q", None)
             output = getattr(attn_metadata, "dense_mla_padded_output", None)
-            if output is None or (
-                self._kernel_heads != effective_heads and padded_q is None
-            ):
+            if output is None or (kernel_heads != effective_heads and padded_q is None):
                 raise RuntimeError(
                     "B12X_MLA metadata is missing caller-owned padded query buffers."
                 )
@@ -733,7 +754,7 @@ class B12xMLAImpl(MLACommonImpl[B12xMLAMetadata]):
                     f"required={total_q}."
                 )
             output = output[:total_q]
-            if self._kernel_heads != effective_heads:
+            if kernel_heads != effective_heads:
                 assert padded_q is not None
                 padded_q = padded_q[:total_q]
                 if padded_q.dtype != q.dtype:
@@ -793,8 +814,8 @@ class B12xMLAImpl(MLACommonImpl[B12xMLAMetadata]):
             self._compiled_bindings.add(compile_key)
 
         output, lse = self._dense_mla.run(binding=binding)
-        output = output[:, : self._effective_heads]
-        lse = lse[:, : self._effective_heads]
+        output = output[:, :effective_heads]
+        lse = lse[:, :effective_heads]
         if dcp_group is None:
             return output, lse
         if self._dcp_comm_backend == "a2a":

--- a/vllm/v1/attention/backends/mla/b12x_mla.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla.py
@@ -40,6 +40,7 @@ _K3_QK_HEAD_DIM = 192
 _K3_V_HEAD_DIM = 128
 _MAX_B12X_QUERY_ROWS = 1024
 _MAX_B12X_CACHE_TOKENS = 1_048_576
+_B12X_QUERY_HEAD_TILE = 8
 _MAX_I32 = torch.iinfo(torch.int32).max
 
 
@@ -73,6 +74,17 @@ def _planned_kv_dtype(vllm_config: VllmConfig) -> torch.dtype:
         return fp8_dtype
     raise ValueError(
         f"B12X_MLA supports only BF16 or E4M3 KV cache storage, got {cache_dtype!r}."
+    )
+
+
+def _kernel_query_heads(num_heads: int) -> int:
+    """Pad independent query heads to the B12X launch tile."""
+    if num_heads <= 0:
+        raise ValueError(f"B12X_MLA requires positive query heads, got {num_heads}.")
+    return (
+        (num_heads + _B12X_QUERY_HEAD_TILE - 1)
+        // _B12X_QUERY_HEAD_TILE
+        * _B12X_QUERY_HEAD_TILE
     )
 
 
@@ -125,6 +137,8 @@ class B12xMLAMetadata(MLACommonMetadata):
 
     dense_mla_plan: Any | None = None
     dense_mla_scratch: torch.Tensor | None = None
+    dense_mla_padded_q: torch.Tensor | None = None
+    dense_mla_padded_output: torch.Tensor | None = None
     dense_mla_flat_block_table: torch.Tensor | None = None
     dense_mla_flat_seq_lens: torch.Tensor | None = None
     dense_mla_flat_query_start_loc: torch.Tensor | None = None
@@ -158,11 +172,12 @@ class B12xMLAMetadataBuilder(MLACommonMetadataBuilder[B12xMLAMetadata]):
                 f"rows={max_dense_mla_rows}, limit={_MAX_B12X_QUERY_ROWS}."
             )
         self._max_dense_mla_rows = max_dense_mla_rows
+        self._kernel_heads = _kernel_query_heads(self.num_heads)
         self._dense_mla_plan = _create_dense_mla_plan(
             vllm_config,
             device,
             page_size=self.page_size,
-            num_q_heads=self.num_heads,
+            num_q_heads=self._kernel_heads,
             max_total_q=max_dense_mla_rows,
         )
         self._workspace_specs = self._dense_mla_plan.shapes_and_dtypes()
@@ -178,6 +193,19 @@ class B12xMLAMetadataBuilder(MLACommonMetadataBuilder[B12xMLAMetadata]):
             dtype=scratch_dtype,
             device=device,
         )
+        self._dense_mla_padded_q: torch.Tensor | None = None
+        self._dense_mla_padded_output: torch.Tensor | None = None
+        if self._kernel_heads != self.num_heads:
+            self._dense_mla_padded_q = torch.empty(
+                (max_dense_mla_rows, self._kernel_heads, _K3_ABSORBED_HEAD_DIM),
+                dtype=_planned_kv_dtype(vllm_config),
+                device=device,
+            )
+            self._dense_mla_padded_output = torch.empty(
+                (max_dense_mla_rows, self._kernel_heads, _K3_KV_LORA_RANK),
+                dtype=torch.bfloat16,
+                device=device,
+            )
         max_table_width = int(self._dense_mla_plan.caps.max_page_table_width)
         self._dense_mla_flat_block_table = torch.zeros(
             (max_dense_mla_rows, max_table_width),
@@ -195,9 +223,10 @@ class B12xMLAMetadataBuilder(MLACommonMetadataBuilder[B12xMLAMetadata]):
             device=device,
         )
         logger.info_once(
-            "B12X dense K3 MLA plan: heads=%d, page_size=%d, "
+            "B12X dense K3 MLA plan: logical_heads=%d, kernel_heads=%d, page_size=%d, "
             "max_decode_rows=%d, max_cache_tokens=%d, splits=%d",
             self.num_heads,
+            self._kernel_heads,
             self.page_size,
             max_dense_mla_rows,
             vllm_config.model_config.max_model_len,
@@ -220,6 +249,8 @@ class B12xMLAMetadataBuilder(MLACommonMetadataBuilder[B12xMLAMetadata]):
         )
         metadata.dense_mla_plan = self._dense_mla_plan
         metadata.dense_mla_scratch = self._dense_mla_scratch
+        metadata.dense_mla_padded_q = self._dense_mla_padded_q
+        metadata.dense_mla_padded_output = self._dense_mla_padded_output
         decode_metadata = metadata.decode
         if (
             not metadata.causal
@@ -454,6 +485,7 @@ class B12xMLAImpl(MLACommonImpl[B12xMLAMetadata]):
             )
 
         self._dense_mla = _load_dense_mla()
+        self._kernel_heads = _kernel_query_heads(num_heads)
         self._compiled_bindings: set[tuple[object, ...]] = set()
 
     def forward_mqa(
@@ -503,11 +535,35 @@ class B12xMLAImpl(MLACommonImpl[B12xMLAMetadata]):
                 f"B12X_MLA expected {self.num_heads} query heads, got {q.shape[1]}."
             )
 
-        output = torch.empty(
-            (total_q, self.num_heads, self.kv_lora_rank),
-            dtype=torch.bfloat16,
-            device=q.device,
-        )
+        if self._kernel_heads == self.num_heads:
+            output = torch.empty(
+                (total_q, self.num_heads, self.kv_lora_rank),
+                dtype=torch.bfloat16,
+                device=q.device,
+            )
+        else:
+            padded_q = getattr(attn_metadata, "dense_mla_padded_q", None)
+            output = getattr(attn_metadata, "dense_mla_padded_output", None)
+            if padded_q is None or output is None:
+                raise RuntimeError(
+                    "B12X_MLA metadata is missing caller-owned padded query buffers."
+                )
+            if int(padded_q.shape[0]) < total_q or int(output.shape[0]) < total_q:
+                raise ValueError(
+                    "B12X_MLA padded query capacity is smaller than the decode "
+                    f"batch: query={padded_q.shape[0]}, output={output.shape[0]}, "
+                    f"required={total_q}."
+                )
+            padded_q = padded_q[:total_q]
+            output = output[:total_q]
+            if padded_q.dtype != q.dtype:
+                raise TypeError(
+                    "B12X_MLA padded query dtype does not match the live query: "
+                    f"buffer={padded_q.dtype}, query={q.dtype}."
+                )
+            padded_q[:, : self.num_heads].copy_(q)
+            padded_q[:, self.num_heads :].zero_()
+            q = padded_q
         scratch = getattr(attn_metadata, "dense_mla_scratch", None)
         if scratch is None:
             raise RuntimeError(
@@ -544,7 +600,8 @@ class B12xMLAImpl(MLACommonImpl[B12xMLAMetadata]):
             self._dense_mla.compile(binding=binding)
             self._compiled_bindings.add(compile_key)
 
-        return self._dense_mla.run(binding=binding)
+        output, lse = self._dense_mla.run(binding=binding)
+        return output[:, : self.num_heads], lse[:, : self.num_heads]
 
 
 __all__ = [

--- a/vllm/v1/attention/backends/mla/b12x_mla.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla.py
@@ -29,10 +29,6 @@ from vllm.v1.attention.backend import (
     MultipleOf,
 )
 from vllm.v1.kv_cache_interface import AttentionSpec
-from vllm.v1.worker.workspace import (
-    current_workspace_manager,
-    is_workspace_manager_initialized,
-)
 
 logger = init_logger(__name__)
 
@@ -128,6 +124,7 @@ class B12xMLAMetadata(MLACommonMetadata):
     """Common MLA metadata plus the capture-static B12X launch plan."""
 
     dense_mla_plan: Any | None = None
+    dense_mla_scratch: torch.Tensor | None = None
     dense_mla_flat_block_table: torch.Tensor | None = None
     dense_mla_flat_seq_lens: torch.Tensor | None = None
     dense_mla_flat_query_start_loc: torch.Tensor | None = None
@@ -169,8 +166,18 @@ class B12xMLAMetadataBuilder(MLACommonMetadataBuilder[B12xMLAMetadata]):
             max_total_q=max_dense_mla_rows,
         )
         self._workspace_specs = self._dense_mla_plan.shapes_and_dtypes()
-        if is_workspace_manager_initialized():
-            current_workspace_manager().get_simultaneous(*self._workspace_specs)
+        if len(self._workspace_specs) != 1:
+            raise RuntimeError("B12X_MLA expected exactly one scratch buffer.")
+        scratch_shape, scratch_dtype = self._workspace_specs[0]
+        # Every attention layer represented by this builder executes serially
+        # on the model stream. One builder-owned buffer therefore gives each
+        # eager bind a stable caller-owned address without a backend workspace
+        # cache or one allocation per layer.
+        self._dense_mla_scratch = torch.empty(
+            scratch_shape,
+            dtype=scratch_dtype,
+            device=device,
+        )
         max_table_width = int(self._dense_mla_plan.caps.max_page_table_width)
         self._dense_mla_flat_block_table = torch.zeros(
             (max_dense_mla_rows, max_table_width),
@@ -212,6 +219,7 @@ class B12xMLAMetadataBuilder(MLACommonMetadataBuilder[B12xMLAMetadata]):
             ),
         )
         metadata.dense_mla_plan = self._dense_mla_plan
+        metadata.dense_mla_scratch = self._dense_mla_scratch
         decode_metadata = metadata.decode
         if (
             not metadata.causal
@@ -447,23 +455,6 @@ class B12xMLAImpl(MLACommonImpl[B12xMLAMetadata]):
 
         self._dense_mla = _load_dense_mla()
         self._compiled_bindings: set[tuple[object, ...]] = set()
-        self._fallback_scratch: dict[int, torch.Tensor] = {}
-
-    def _borrow_scratch(self, plan: Any, device: torch.device) -> torch.Tensor:
-        specs = plan.shapes_and_dtypes()
-        if is_workspace_manager_initialized():
-            (scratch,) = current_workspace_manager().get_simultaneous(*specs)
-            return scratch
-
-        key = id(plan)
-        scratch = self._fallback_scratch.get(key)
-        if scratch is None:
-            if len(specs) != 1:
-                raise RuntimeError("B12X_MLA expected exactly one scratch buffer.")
-            shape, dtype = specs[0]
-            scratch = torch.empty(shape, dtype=dtype, device=device)
-            self._fallback_scratch[key] = scratch
-        return scratch
 
     def forward_mqa(
         self,
@@ -517,7 +508,11 @@ class B12xMLAImpl(MLACommonImpl[B12xMLAMetadata]):
             dtype=torch.bfloat16,
             device=q.device,
         )
-        scratch = self._borrow_scratch(plan, q.device)
+        scratch = getattr(attn_metadata, "dense_mla_scratch", None)
+        if scratch is None:
+            raise RuntimeError(
+                "B12X_MLA metadata is missing caller-owned dense MLA scratch."
+            )
         quantized = q.dtype == torch.float8_e4m3fn
         binding = self._dense_mla.bind(
             plan,

--- a/vllm/v1/attention/backends/mla/b12x_mla.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla.py
@@ -219,6 +219,9 @@ class B12xMLAMetadataBuilder(MLACommonMetadataBuilder[B12xMLAMetadata]):
             B12xMLAMetadata,
             supports_dcp_with_varlen=True,
         )
+        self._dcp_rank = (
+            int(get_dcp_group().rank_in_group) if self.dcp_world_size > 1 else 0
+        )
         max_dense_mla_rows = int(vllm_config.scheduler_config.max_num_seqs) * int(
             self.reorder_batch_threshold
         )
@@ -280,6 +283,30 @@ class B12xMLAMetadataBuilder(MLACommonMetadataBuilder[B12xMLAMetadata]):
             dtype=torch.int32,
             device=device,
         )
+        self._dense_mla_causal_offsets = torch.arange(
+            1 - int(self.reorder_batch_threshold),
+            1,
+            dtype=torch.int32,
+            device=device,
+        )
+        self._dense_mla_flat_global_seq_lens = (
+            torch.empty(
+                max_dense_mla_rows,
+                dtype=torch.int32,
+                device=device,
+            )
+            if self.dcp_world_size > 1
+            else None
+        )
+        self._dense_mla_flat_dcp_remainder = (
+            torch.empty(
+                max_dense_mla_rows,
+                dtype=torch.int32,
+                device=device,
+            )
+            if self.dcp_world_size > 1
+            else None
+        )
         logger.info_once(
             "B12X dense K3 MLA plan: local_heads=%d, effective_heads=%d, "
             "kernel_heads=%d, page_size=%d, "
@@ -312,41 +339,84 @@ class B12xMLAMetadataBuilder(MLACommonMetadataBuilder[B12xMLAMetadata]):
         metadata.dense_mla_padded_q = self._dense_mla_padded_q
         metadata.dense_mla_padded_output = self._dense_mla_padded_output
         decode_metadata = metadata.decode
-        if (
-            not metadata.causal
-            and decode_metadata is not None
-            and metadata.num_decodes > 0
-            and metadata.num_decode_tokens > metadata.num_decodes
-        ):
+        flatten_decode = False
+        if decode_metadata is not None and metadata.num_decodes > 0:
+            flatten_decode = metadata.num_decode_tokens > metadata.num_decodes or int(
+                decode_metadata.block_table.shape[1]
+            ) > int(self._dense_mla_plan.caps.max_page_table_width)
+        if flatten_decode:
+            assert decode_metadata is not None
             total_q = int(metadata.num_decode_tokens)
             if total_q > self._max_dense_mla_rows:
                 raise ValueError(
-                    "B12X_MLA non-causal query block exceeds its capacity: "
+                    "B12X_MLA query block exceeds its flattened capacity: "
                     f"rows={total_q}, capacity={self._max_dense_mla_rows}."
                 )
             if total_q % metadata.num_decodes:
                 raise ValueError(
-                    "B12X_MLA requires a uniform non-causal query block, got "
+                    "B12X_MLA requires a uniform query block, got "
                     f"tokens={total_q}, requests={metadata.num_decodes}."
                 )
             query_len = total_q // metadata.num_decodes
             source_table = decode_metadata.block_table
-            source_width = int(source_table.shape[1])
             flat_table = self._dense_mla_flat_block_table[:total_q]
-            if source_width > int(flat_table.shape[1]):
-                raise ValueError(
-                    "B12X_MLA block table exceeds its planned width: "
-                    f"actual={source_width}, planned={flat_table.shape[1]}."
-                )
+            # A bounded speculative cache can retain a position-indexed worker
+            # table wider than the resident cache. Sequence lengths make the
+            # omitted suffix unreachable by the dense-MLA kernel.
+            source_width = min(int(source_table.shape[1]), int(flat_table.shape[1]))
             flat_table[:, :source_width].copy_(
-                source_table[:, None, :]
+                source_table[:, None, :source_width]
                 .expand(-1, query_len, -1)
                 .reshape(total_q, source_width)
             )
             flat_lens = self._dense_mla_flat_seq_lens[:total_q]
-            flat_lens.copy_(
-                decode_metadata.seq_lens[:, None].expand(-1, query_len).reshape(total_q)
-            )
+            if metadata.causal:
+                offsets = self._dense_mla_causal_offsets[-query_len:]
+                if self.dcp_world_size > 1:
+                    global_source_lens = decode_metadata.dcp_tot_seq_lens
+                    if global_source_lens is None:
+                        raise RuntimeError(
+                            "B12X_MLA causal DCP verification requires global "
+                            "decode sequence lengths."
+                        )
+                    assert self._dense_mla_flat_global_seq_lens is not None
+                    assert self._dense_mla_flat_dcp_remainder is not None
+                    global_flat_lens = self._dense_mla_flat_global_seq_lens[:total_q]
+                    torch.add(
+                        global_source_lens[:, None],
+                        offsets,
+                        out=global_flat_lens.view(metadata.num_decodes, query_len),
+                    )
+                    virtual_block = (
+                        self.dcp_world_size * self.cp_kv_cache_interleave_size
+                    )
+                    torch.div(
+                        global_flat_lens,
+                        virtual_block,
+                        rounding_mode="floor",
+                        out=flat_lens,
+                    )
+                    flat_lens.mul_(self.cp_kv_cache_interleave_size)
+                    remainder = self._dense_mla_flat_dcp_remainder[:total_q]
+                    torch.remainder(global_flat_lens, virtual_block, out=remainder)
+                    remainder.sub_(self._dcp_rank * self.cp_kv_cache_interleave_size)
+                    remainder.clamp_(
+                        min=0,
+                        max=self.cp_kv_cache_interleave_size,
+                    )
+                    flat_lens.add_(remainder)
+                else:
+                    torch.add(
+                        decode_metadata.seq_lens[:, None],
+                        offsets,
+                        out=flat_lens.view(metadata.num_decodes, query_len),
+                    )
+            else:
+                flat_lens.copy_(
+                    decode_metadata.seq_lens[:, None]
+                    .expand(-1, query_len)
+                    .reshape(total_q)
+                )
             metadata.dense_mla_flat_block_table = flat_table
             metadata.dense_mla_flat_seq_lens = flat_lens
             metadata.dense_mla_flat_query_start_loc = (
@@ -590,15 +660,15 @@ class B12xMLAImpl(MLACommonImpl[B12xMLAMetadata]):
             )
             if seq_lens is None or query_start_loc is None:
                 raise RuntimeError(
-                    "B12X_MLA metadata is missing flattened non-causal rows."
+                    "B12X_MLA metadata is missing flattened decode rows."
                 )
 
         batch = int(seq_lens.shape[0])
         total_q = int(q.shape[0])
-        if total_q < batch:
+        if total_q != batch:
             raise ValueError(
-                "B12X_MLA requires at least one query row per prepared decode "
-                f"sequence, got {total_q} rows for {batch} sequences."
+                "B12X_MLA requires one query row per prepared decode sequence, "
+                f"got {total_q} rows for {batch} sequences."
             )
         if int(q.shape[1]) != self.num_heads:
             raise ValueError(


### PR DESCRIPTION
## Status

Implemented and runtime-qualified. This pull request is stacked on #386. TP16/DCP16 no-speculation, DSpark, and DFlash serving qualification is tracked by local-inference-lab/rtx6kpro#66.

## Behavior

- Bounds MLA prefill projection workspace through `VLLM_MLA_CHUNKED_PREFILL_WORKSPACE_SIZE`.
- Requires caller-owned scratch for every eager B12X dense-MLA bind.
- Pads logical query-head counts to the B12X eight-head launch tile and removes synthetic heads from output and LSE tensors.
- Lets B12X dense MLA own decode-DCP query gather, local cache execution, and exact LSE-weighted output combination.
- Writes gathered query heads directly into capture-stable metadata storage.
- Skips cache splits that cannot contain live rows during piecewise-eager execution.
- Flattens speculative block metadata and warms DCP transport before graph capture.
- Uses the B12X empty-shard contract directly: dense MLA emits negative-infinite LSE and the DCP reduction assigns non-finite LSE values zero weight before reading payload data.

## Technical reason

Kimi-K3 TP16 has six logical query heads per rank, while the SM120 B12X kernel launches in eight-head tiles. Decode DCP also requires graph-stable query, scratch, transport, and cache metadata ownership.

The generic DCP empty-shard mask rebuilds row-to-sequence indices through eight PyTorch CUDA kernels. Kimi-K3 executes 24 dense-MLA layers, so applying that generic mask adds 192 CUDA kernel launches to every decode token. B12X dense MLA and the B12X DCP reduction already implement the same neutral empty-shard semantics without a separate pass.

## Compatibility

Backends that do not declare decode-DCP ownership keep `MLADCPManager` and the generic empty-shard mask. Direct CUDA graph capture retains the complete planned split list. Unsupported attention geometry retains backend selection fallback. The B12X-specific mask bypass requires both the dense-MLA negative-infinite LSE contract and the B12X reduction zero-weight contract.

## Validation

- `ruff check` and `ruff format --check` pass for the changed backend and test.
- `tests/v1/attention/test_b12x_mla.py`: 30 passed.
- Runtime: official Kimi-K3 MXFP4, TP16/DCP16, FP8 KV cache, physical capacity 1,460,937 tokens, no speculative decoder, image `voipmonitor/vllm@sha256:9230c19c6b16ca6216613360619b0cca2356dba65c2297c99817750b3f9e4b83`.
- Benchmark: 256 prompt tokens, 1,024 forced decode tokens, two warmups and eight measured runs, all GPUs idle in P8 before measurement. Token-input SHA-256: `64c2ff11a83dda71caea12ea10b16511b0114c15973b949cde3ebd2bc4c712af`.
- Patched median: 55.925 tok/s; range: 55.814-55.958 tok/s.
- Unpatched median under the same runtime and B12X source: 55.275 tok/s.
- Infernal-vLLM control under the same runtime and B12X source: 56.034 tok/s.
- Every patched run and control run produced output SHA-256 `ca33403cfcb21bae20f21507475a3525c7f4bd36bb2a7074891e3307c5fd47d5`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable workspace sizing for chunked MLA prefill through an environment setting.
  * Enabled improved decode context-parallel support for Kimi K3 and B12X MLA attention.
  * Added support for direct KV gathering in compatible attention backends.

* **Bug Fixes**
  * Improved validation and handling of distributed cache sizing, query padding, sequence lengths, and communication capacity.
  * Preserved safe defaults and clear errors for invalid workspace and sharding configurations.

* **Tests**
  * Expanded coverage for distributed decode, prefill workspace sizing, cache gathering, warmup behavior, padding, metadata, and unsupported configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->