### PR TITLE
Support external Kimi speculative draft runtimes

### DIFF
--- a/cmake/external_projects/vllm_flash_attn.cmake
+++ b/cmake/external_projects/vllm_flash_attn.cmake
@@ -43,7 +43,7 @@ else()
   FetchContent_Declare(
           vllm-flash-attn
           GIT_REPOSITORY https://github.com/vllm-project/flash-attention.git
-          GIT_TAG f3e1a4f74c99145c0717709860bf765de1703779
+          GIT_TAG 7484d4751a4569fb30e5c0604581f1b02ae3df71
           GIT_SUBMODULES ${VLLM_FLASH_ATTN_GIT_SUBMODULES}
           GIT_PROGRESS TRUE
           # Don't share the vllm-flash-attn build between build types

--- a/tests/kernels/moe/test_modular_output_alias.py
+++ b/tests/kernels/moe/test_modular_output_alias.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+import vllm.envs as envs
+from vllm.model_executor.layers.fused_moe.modular_kernel import (
+    _can_alias_fused_moe_output,
+)
+
+
+def test_fused_moe_output_alias_can_be_disabled(monkeypatch) -> None:
+    allocated = torch.empty((2, 8), dtype=torch.bfloat16)
+    caller_output = torch.empty_like(allocated)
+
+    monkeypatch.setattr(envs, "VLLM_DISABLE_FUSED_MOE_OUTPUT_ALIAS", False)
+    assert _can_alias_fused_moe_output(caller_output, allocated)
+
+    monkeypatch.setattr(envs, "VLLM_DISABLE_FUSED_MOE_OUTPUT_ALIAS", True)
+    assert not _can_alias_fused_moe_output(caller_output, allocated)
+
+
+def test_fused_moe_output_alias_requires_matching_storage() -> None:
+    allocated = torch.empty((2, 8), dtype=torch.bfloat16)
+
+    assert not _can_alias_fused_moe_output(None, allocated)
+    assert not _can_alias_fused_moe_output(
+        torch.empty((1, 8), dtype=torch.bfloat16), allocated
+    )
+    assert not _can_alias_fused_moe_output(
+        torch.empty((2, 8), dtype=torch.float32), allocated
+    )

--- a/tests/model_executor/test_kimi_k3_triton_warmup.py
+++ b/tests/model_executor/test_kimi_k3_triton_warmup.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import torch
+
+from vllm.model_executor.warmup.kimi_k3_triton_warmup import (
+    _warm_recurrent_kda,
+)
+from vllm.models.kimi_k3.nvidia.ops.third_party.kda import fused_recurrent
+
+
+def test_speculative_kda_warmup_before_kv_cache_binding(monkeypatch) -> None:
+    calls = []
+    monkeypatch.setattr(
+        fused_recurrent,
+        "get_fused_recurrent_kda_fwd_warmup_profiles",
+        lambda _num_heads: (2,),
+    )
+    monkeypatch.setattr(
+        fused_recurrent,
+        "fused_recurrent_kda",
+        lambda **kwargs: calls.append(kwargs),
+    )
+
+    layer = SimpleNamespace(
+        num_spec=7,
+        local_num_heads=2,
+        head_dim=4,
+        A_log=torch.empty(2, dtype=torch.float32),
+        dt_bias=torch.empty(8, dtype=torch.float32),
+        gate_lower_bound=-10.0,
+        get_state_shape=lambda: ((10, 4), (2, 4, 4)),
+        get_state_dtype=lambda: (torch.bfloat16, torch.float32),
+    )
+
+    _warm_recurrent_kda(layer, torch.bfloat16)
+
+    assert len(calls) == 1
+    call = calls[0]
+    assert call["initial_state"].shape == (1, 2, 4, 4)
+    assert call["initial_state"].dtype == torch.float32
+    assert call["q"].shape == (1, 16, 2, 4)
+    assert call["ssm_state_indices"].shape == (2, 8)

--- a/tests/models/test_qwen3_dflash_weight_retention.py
+++ b/tests/models/test_qwen3_dflash_weight_retention.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+from vllm.model_executor.models.qwen3_dflash import _retain_dflash_weight
+
+
+def test_cpu_weight_retention_reuses_owned_storage() -> None:
+    weight = torch.arange(8, dtype=torch.float32)
+
+    retained = _retain_dflash_weight(weight)
+
+    assert retained is weight
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_cuda_weight_retention_survives_source_storage_reuse() -> None:
+    source = torch.arange(8, dtype=torch.float32, device="cuda")
+    expected = source.cpu()
+
+    retained = _retain_dflash_weight(source)
+    source.fill_(-1)
+
+    assert retained.device.type == "cpu"
+    torch.testing.assert_close(retained, expected)

--- a/tests/transformers_utils/test_dspark_mla_config.py
+++ b/tests/transformers_utils/test_dspark_mla_config.py
@@ -5,7 +5,12 @@ import json
 
 import pytest
 
-from vllm.config import ModelConfig, ParallelConfig, SpeculativeConfig
+from vllm.config import LoadConfig, ModelConfig, ParallelConfig, SpeculativeConfig
+from vllm.config.quantization import QuantizationConfigArgs, QuantSpec
+from vllm.model_executor.layers.quantization.online.base import (
+    OnlineQuantizationConfig,
+)
+from vllm.model_executor.model_loader.weight_utils import get_quant_config
 from vllm.transformers_utils.config import get_config
 from vllm.transformers_utils.configs.k3_dspark import K3DSparkConfig
 
@@ -140,6 +145,43 @@ def test_dspark_mla_speculative_config_preserves_architecture(tmp_path):
     assert speculative_config.draft_model_config.architectures == ["K3DSparkModel"]
     assert speculative_config.draft_model_config.hf_config.model_type == "k3_dspark"
     assert speculative_config.draft_model_config.use_mla
+
+
+def test_dspark_mla_accepts_draft_online_quantization(tmp_path):
+    target_path = tmp_path / "target"
+    draft_path = tmp_path / "draft"
+    _write_target_config(target_path)
+    _write_dspark_config(draft_path)
+    target_config = ModelConfig(
+        model=str(target_path), tokenizer_mode="skip", max_model_len=32768
+    )
+
+    speculative_config = SpeculativeConfig(
+        model=str(draft_path),
+        method="dspark",
+        num_speculative_tokens=7,
+        quantization="mxfp8",
+        quantization_config={
+            "linear": "mxfp8",
+            "ignore": ["re:.*fused_qkv_a_proj$", "model.markov_head.markov_w2"],
+        },
+        target_model_config=target_config,
+        target_parallel_config=ParallelConfig(),
+    )
+
+    draft = speculative_config.draft_model_config
+    assert draft.quantization == "mxfp8"
+    assert isinstance(draft.quantization_config, QuantizationConfigArgs)
+    assert draft.quantization_config.linear == QuantSpec(weight="mxfp8")
+    assert draft.quantization_config.ignore == [
+        "re:.*fused_qkv_a_proj$",
+        "model.markov_head.markov_w2",
+    ]
+
+    draft.hf_overrides = lambda hf_config: hf_config
+    quant_config = get_quant_config(draft, LoadConfig())
+    assert isinstance(quant_config, OnlineQuantizationConfig)
+    assert quant_config.args == draft.quantization_config
 
 
 def test_dspark_mla_rejects_decode_context_parallelism(tmp_path):

--- a/tests/v1/spec_decode/test_dflash_cudagraph_lifetime.py
+++ b/tests/v1/spec_decode/test_dflash_cudagraph_lifetime.py
@@ -8,7 +8,10 @@ import torch
 
 from vllm.config.compilation import CUDAGraphMode
 from vllm.v1.attention.backend import AttentionCGSupport
+from vllm.v1.worker.gpu.cudagraph_utils import CudaGraphManager
+from vllm.v1.worker.gpu.spec_decode.dflash import cudagraph as cudagraph_module
 from vllm.v1.worker.gpu.spec_decode.dflash import speculator as spec_module
+from vllm.v1.worker.gpu.spec_decode.dflash.cudagraph import DFlashCudaGraphManager
 from vllm.v1.worker.gpu.spec_decode.dflash.speculator import DFlashSpeculator
 
 
@@ -65,6 +68,55 @@ def test_dflash_does_not_retain_eager_backbone_output(monkeypatch):
     )
 
     assert speculator._captured_backbone_outputs == []
+
+
+def test_dflash_graph_capture_marks_forward_as_capture_only(monkeypatch):
+    forward = Mock()
+    manager = object.__new__(DFlashCudaGraphManager)
+    manager.max_num_reqs = 4
+    manager.dp_size = 1
+    desc = SimpleNamespace(
+        num_tokens=6,
+        num_reqs=2,
+        cg_mode=CUDAGraphMode.FULL,
+        uniform_token_count=3,
+    )
+
+    monkeypatch.setattr(
+        cudagraph_module,
+        "_prepare_dflash_inputs_to_capture",
+        lambda *args, **kwargs: ("attention", "slots"),
+    )
+
+    def fake_capture(_manager, create_forward_fn, **kwargs):
+        create_forward_fn(desc, warmup=True)(CUDAGraphMode.FULL)
+
+    monkeypatch.setattr(CudaGraphManager, "capture", fake_capture)
+
+    DFlashCudaGraphManager.capture(
+        manager,
+        forward_fn=forward,
+        input_buffers=object(),
+        block_tables=object(),
+        attn_groups=[],
+        kv_cache_config=object(),
+        max_model_len=1024,
+        causal=False,
+        channel_id="draft-query",
+    )
+
+    assert forward.call_args.args == (
+        2,
+        6,
+        "attention",
+        "slots",
+        None,
+        CUDAGraphMode.FULL,
+    )
+    assert forward.call_args.kwargs == {
+        "num_query_per_req": 3,
+        "capture_only": True,
+    }
 
 
 def test_dflash_capture_uses_phase_specific_draft_channel_ids():

--- a/tests/v1/spec_decode/test_external_draft_attention_config.py
+++ b/tests/v1/spec_decode/test_external_draft_attention_config.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm.v1.attention.backends.registry import AttentionBackendEnum
+from vllm.v1.worker.gpu.spec_decode.dflash import speculator as dflash_speculator
+from vllm.v1.worker.gpu.spec_decode.dspark import utils as dspark_utils
+
+
+def test_dspark_loader_uses_external_draft_parallel_geometry(monkeypatch) -> None:
+    """The external draft model constructor receives its DCP1 configuration."""
+    draft_model_config = SimpleNamespace(hf_config=SimpleNamespace())
+    target_config = SimpleNamespace(
+        speculative_config=SimpleNamespace(
+            draft_model_config=draft_model_config,
+            attention_backend=AttentionBackendEnum.B12X_MLA,
+        )
+    )
+    draft_config = SimpleNamespace(
+        parallel_config=SimpleNamespace(decode_context_parallel_size=1),
+        attention_config=SimpleNamespace(backend=None, use_non_causal=False),
+        quant_config=object(),
+    )
+    draft_quant_config = object()
+    captured = {}
+
+    class ModelCaptured(RuntimeError):
+        pass
+
+    def fake_get_model(*, vllm_config, model_config):
+        captured["vllm_config"] = vllm_config
+        captured["model_config"] = model_config
+        raise ModelCaptured
+
+    monkeypatch.setattr(
+        dspark_utils,
+        "_create_draft_vllm_config",
+        lambda config: draft_config if config is target_config else None,
+    )
+    monkeypatch.setattr(dspark_utils, "get_model", fake_get_model)
+    monkeypatch.setattr(
+        "vllm.model_executor.models.qwen3_dflash.dflash_has_any_non_causal",
+        lambda _config: True,
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.models.utils.get_draft_quant_config",
+        lambda config: draft_quant_config if config is target_config else None,
+    )
+
+    with pytest.raises(ModelCaptured):
+        dspark_utils.load_dspark_model(object(), target_config)
+
+    assert captured["model_config"] is draft_model_config
+    loaded_config = captured["vllm_config"]
+    assert loaded_config.parallel_config.decode_context_parallel_size == 1
+    assert loaded_config.attention_config.backend == AttentionBackendEnum.B12X_MLA
+    assert loaded_config.attention_config.use_non_causal
+    assert loaded_config.quant_config is draft_quant_config
+
+
+def test_dflash_attention_metadata_uses_external_draft_geometry(monkeypatch) -> None:
+    """Attention metadata retains the external draft's DCP1 geometry."""
+    target_config = SimpleNamespace(
+        parallel_config=SimpleNamespace(decode_context_parallel_size=16)
+    )
+    draft_config = SimpleNamespace(
+        parallel_config=SimpleNamespace(decode_context_parallel_size=1),
+        attention_config=SimpleNamespace(
+            backend=AttentionBackendEnum.B12X_MLA,
+            use_non_causal=False,
+        ),
+    )
+    monkeypatch.setattr(
+        dflash_speculator,
+        "_create_draft_vllm_config",
+        lambda config: draft_config if config is target_config else None,
+    )
+    speculator = object.__new__(dflash_speculator.DFlashSpeculator)
+    speculator.vllm_config = target_config
+    speculator.requires_non_causal = True
+
+    attention_config = speculator.attn_vllm_config
+
+    assert attention_config.parallel_config.decode_context_parallel_size == 1
+    assert attention_config.attention_config.use_non_causal
+    assert not draft_config.attention_config.use_non_causal

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -16,6 +16,7 @@ from vllm.config.cache import CacheDType
 from vllm.config.kernel import MoEBackend
 from vllm.config.model import HfOverrides, ModelConfig
 from vllm.config.parallel import ParallelConfig
+from vllm.config.quantization import QuantizationConfigArgs, resolve_quantization_config
 from vllm.config.utils import config
 from vllm.logger import init_logger
 from vllm.transformers_utils.config import get_hf_text_config
@@ -117,6 +118,8 @@ class SpeculativeConfig:
     """Quantization method that was used to quantize the draft model weights.
     If `None`, we assume the model weights are not quantized. Note that it only
     takes effect when using the draft model-based speculative method."""
+    quantization_config: dict[str, Any] | QuantizationConfigArgs | None = None
+    """Optional per-layer online quantization settings for the draft model."""
     moe_backend: MoEBackend | None = None
     """MoE backend to use for the draft model. When `None`, the draft model
     inherits the target model's `--moe-backend` setting. Useful when the
@@ -1035,6 +1038,9 @@ class SpeculativeConfig:
                     max_model_len=self.max_model_len,  # type: ignore[arg-type]
                     spec_target_max_model_len=self.target_model_config.max_model_len,
                     quantization=self.quantization,
+                    quantization_config=resolve_quantization_config(
+                        self.quantization, self.quantization_config
+                    ),
                     enforce_eager=self.target_model_config.enforce_eager,
                     max_logprobs=self.target_model_config.max_logprobs,
                     hf_overrides=draft_hf_overrides,

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -332,6 +332,7 @@ if TYPE_CHECKING:
     VLLM_GC_DEBUG: str = ""
     VLLM_DEBUG_WORKSPACE: bool = False
     VLLM_DISABLE_SHARED_EXPERTS_STREAM: bool = False
+    VLLM_DISABLE_FUSED_MOE_OUTPUT_ALIAS: bool = False
     VLLM_SHARED_EXPERTS_STREAM_TOKEN_THRESHOLD: int = 256
     VLLM_MULTI_STREAM_GEMM_TOKEN_THRESHOLD: int = 1024
     VLLM_COMPILE_CACHE_SAVE_FORMAT: Literal["binary", "unpacked"] = "binary"
@@ -2254,6 +2255,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Disables parallel execution of shared_experts via separate cuda stream
     "VLLM_DISABLE_SHARED_EXPERTS_STREAM": lambda: bool(
         int(os.getenv("VLLM_DISABLE_SHARED_EXPERTS_STREAM", "0"))
+    ),
+    # Preserve a separate fused-MoE result buffer when the caller-owned output
+    # has a lifetime that overlaps the expert kernel's writeback.
+    "VLLM_DISABLE_FUSED_MOE_OUTPUT_ALIAS": lambda: bool(
+        int(os.getenv("VLLM_DISABLE_FUSED_MOE_OUTPUT_ALIAS", "0"))
     ),
     # Limits when we run shared_experts in a separate stream.
     # We found out that for large batch sizes, the separate stream

--- a/vllm/model_executor/layers/fused_moe/modular_kernel.py
+++ b/vllm/model_executor/layers/fused_moe/modular_kernel.py
@@ -43,6 +43,22 @@ from vllm.v1.worker.workspace import current_workspace_manager
 
 logger = init_logger(__name__)
 
+
+def _can_alias_fused_moe_output(
+    output_alias: torch.Tensor | None,
+    allocated_output: torch.Tensor,
+) -> bool:
+    """Return whether the expert kernel may write into caller-owned output."""
+    return bool(
+        not envs.VLLM_DISABLE_FUSED_MOE_OUTPUT_ALIAS
+        and output_alias is not None
+        and output_alias.shape == allocated_output.shape
+        and output_alias.dtype == allocated_output.dtype
+        and output_alias.device == allocated_output.device
+        and output_alias.is_contiguous()
+    )
+
+
 #
 # This file defines a set of base classes used to make MoE kernels more modular.
 # The goal is to be able to utilize different communication mechanisms with
@@ -1306,13 +1322,7 @@ class FusedMoEKernelModularImpl:
             activation,
         )
 
-        use_output_alias = (
-            output_alias is not None
-            and output_alias.shape == fused_out.shape
-            and output_alias.dtype == fused_out.dtype
-            and output_alias.device == fused_out.device
-            and output_alias.is_contiguous()
-        )
+        use_output_alias = _can_alias_fused_moe_output(output_alias, fused_out)
 
         # If caller's output buffer already matches fused_out shape/dtype, alias
         # to skip the redundant copy in TopKWeightAndReduceNoOP.apply downstream.

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -291,12 +291,19 @@ def get_quant_config(
     # if hf_quant_config is None, we will try to get config from
     # hf_overrides
     hf_overrides = model_config.hf_overrides
-    if not isinstance(hf_overrides, dict):
+    if not isinstance(hf_overrides, dict) and model_config.quantization_config is None:
         raise ValueError(
             "hf_overrides must be a dict for get_quant_config "
             "to get the quantization config from it."
         )
-    quantization_config_file = hf_overrides.get("quantization_config_file", None)
+    # Callable HF overrides cannot carry checkpoint-side quantization metadata,
+    # but online quantization is fully defined by ModelConfig.quantization_config.
+    # Draft models can inherit a callable override from the target model.
+    quantization_config_file = (
+        hf_overrides.get("quantization_config_file", None)
+        if isinstance(hf_overrides, dict)
+        else None
+    )
     if quantization_config_file is not None:
         if hasattr(quant_cls, "from_config_file"):
             return quant_cls.from_config_file(quantization_config_file)
@@ -306,7 +313,11 @@ def get_quant_config(
                 "but quant_cls.from_config_file is not implemented in "
                 f"{quant_cls}"
             )
-    quantization_config_json = hf_overrides.get("quantization_config_dict_json", None)
+    quantization_config_json = (
+        hf_overrides.get("quantization_config_dict_json", None)
+        if isinstance(hf_overrides, dict)
+        else None
+    )
     if quantization_config_json is not None:
         if hasattr(quant_cls, "from_config_dict_json"):
             return quant_cls.from_config_dict_json(quantization_config_json)

--- a/vllm/model_executor/models/qwen3_dflash.py
+++ b/vllm/model_executor/models/qwen3_dflash.py
@@ -62,6 +62,13 @@ logger = init_logger(__name__)
 _SLIDING_ATTENTION = "sliding_attention"
 
 
+def _retain_dflash_weight(weight: torch.Tensor) -> torch.Tensor:
+    """Give a retained streaming-loader tensor storage with stable ownership."""
+    if weight.is_cuda:
+        return weight.to("cpu", copy=True)
+    return weight
+
+
 def _dflash_layer_causal(config: Qwen3Config, layer_idx: int) -> bool:
     """``dflash_config.causal`` overrides all layers; else only SWA layers causal."""
     override = (getattr(config, "dflash_config", None) or {}).get("causal")
@@ -866,7 +873,7 @@ class DFlashQwen3ForCausalLM(Qwen3ForCausalLM):
                 name = "model." + name
             if "embed_tokens" in name:
                 includes_embed_tokens = True
-            model_weights[name] = loaded_weight
+            model_weights[name] = _retain_dflash_weight(loaded_weight)
             process_eagle_weight(self, name)
 
         # Route the separately-trained mask embedding (if shipped) through the

--- a/vllm/model_executor/warmup/kimi_k3_triton_warmup.py
+++ b/vllm/model_executor/warmup/kimi_k3_triton_warmup.py
@@ -103,12 +103,25 @@ def _warm_recurrent_kda(
     if num_speculative_tokens <= 0:
         return
 
-    kv_cache = layer.kv_cache
-    if not isinstance(kv_cache, (list, tuple)) or len(kv_cache) < 2:
-        return
-    state = kv_cache[1]
-    if not isinstance(state, torch.Tensor) or not state.numel():
-        return
+    kv_cache = getattr(layer, "kv_cache", None)
+    state = (
+        kv_cache[1]
+        if isinstance(kv_cache, (list, tuple))
+        and len(kv_cache) >= 2
+        and isinstance(kv_cache[1], torch.Tensor)
+        and kv_cache[1].numel()
+        else None
+    )
+    if state is None:
+        # Kernel warmup runs before production KV-cache binding. One temporary
+        # state page preserves the production layout and dtype for compilation.
+        state_shape = layer.get_state_shape()[1]
+        state_dtype = layer.get_state_dtype()[1]
+        state = torch.empty(
+            (1, *state_shape),
+            dtype=state_dtype,
+            device=layer.A_log.device,
+        )
 
     logger.info("Warming up Kimi-K3 speculative KDA kernels.")
     h = int(layer.local_num_heads)

--- a/vllm/v1/worker/gpu/spec_decode/dflash/cudagraph.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/cudagraph.py
@@ -109,6 +109,7 @@ class DFlashCudaGraphManager(CudaGraphManager):
                 num_tokens_across_dp,
                 cg_mode,
                 num_query_per_req=desc.uniform_token_count,
+                capture_only=True,
             )
 
         super().capture(

--- a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
@@ -514,6 +514,7 @@ class DFlashSpeculator(DraftModelSpeculator):
         cudagraph_runtime_mode: CUDAGraphMode = CUDAGraphMode.NONE,
         is_profile: bool = False,
         num_query_per_req: int | None = None,
+        capture_only: bool = False,
     ) -> None:
         if num_query_per_req is None:
             num_speculative_steps = self.num_speculative_steps
@@ -548,6 +549,16 @@ class DFlashSpeculator(DraftModelSpeculator):
         self.draft_tokens[:num_reqs, :num_speculative_steps] = draft_tokens.view(
             num_reqs, num_speculative_steps
         )
+
+    def _finish_captured_draft(
+        self,
+        *,
+        num_reqs: int,
+        num_tokens_padded: int,
+        num_query_per_req: int,
+        is_profile: bool,
+    ) -> None:
+        """Run speculator work that is intentionally excluded from its graph."""
 
     def _build_draft_attn_metadata(
         self,
@@ -789,6 +800,12 @@ class DFlashSpeculator(DraftModelSpeculator):
         if batch_desc.cg_mode == CUDAGraphMode.FULL:
             assert self.query_cudagraph_manager is not None
             self.query_cudagraph_manager.run_fullgraph(batch_desc)
+            self._finish_captured_draft(
+                num_reqs=num_reqs,
+                num_tokens_padded=num_tokens_padded,
+                num_query_per_req=active_query_len,
+                is_profile=is_profile,
+            )
         else:
             self._generate_draft(
                 num_reqs,

--- a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
@@ -9,6 +9,7 @@ states, which are fc-combined, normed, projected to K/V by every draft
 layer, and written into the draft KV cache.
 """
 
+import copy
 from collections.abc import Mapping
 from typing import Any, NamedTuple
 
@@ -17,7 +18,7 @@ import torch
 import torch.nn as nn
 
 import vllm.envs as envs
-from vllm.config import VllmConfig, replace
+from vllm.config import VllmConfig
 from vllm.config.compilation import CUDAGraphMode
 from vllm.forward_context import BatchDescriptor, set_forward_context
 from vllm.logger import init_logger
@@ -42,6 +43,7 @@ from vllm.v1.worker.gpu.spec_decode.dflash.utils import (
     load_dflash_model,
     maybe_load_mask_embedding,
 )
+from vllm.v1.worker.gpu.spec_decode.eagle.utils import _create_draft_vllm_config
 from vllm.v1.worker.gpu.spec_decode.speculator import (
     CUDAGraphCapturePhase,
     DraftModelSpeculator,
@@ -169,14 +171,12 @@ class DFlashSpeculator(DraftModelSpeculator):
 
     @property
     def attn_vllm_config(self) -> VllmConfig:
-        # The draft's attention differs from the target's in causality.
-        return replace(
-            self.vllm_config,
-            attention_config=replace(
-                self.vllm_config.attention_config,
-                use_non_causal=self.requires_non_causal,
-            ),
-        )
+        """Return an isolated attention view with draft parallel geometry."""
+        draft_vllm_config = copy.copy(_create_draft_vllm_config(self.vllm_config))
+        draft_attention_config = copy.copy(draft_vllm_config.attention_config)
+        draft_attention_config.use_non_causal = self.requires_non_causal
+        draft_vllm_config.attention_config = draft_attention_config
+        return draft_vllm_config
 
     def init_cudagraph_manager(self, cudagraph_mode: CUDAGraphMode) -> None:
         wants_full = cudagraph_mode.decode_mode() == CUDAGraphMode.FULL

--- a/vllm/v1/worker/gpu/spec_decode/dspark/utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/dspark/utils.py
@@ -3,11 +3,12 @@
 
 import torch.nn as nn
 
-from vllm.config import VllmConfig, replace
+from vllm.config import VllmConfig
 from vllm.distributed.parallel_state import get_pp_group
 from vllm.model_executor.model_loader import get_model
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 from vllm.v1.worker.gpu.spec_decode.eagle.utils import (
+    _create_draft_vllm_config,
     _should_share,
     get_target_lm_head,
 )
@@ -28,24 +29,16 @@ def load_dspark_model(target_model: nn.Module, vllm_config: VllmConfig) -> nn.Mo
         # auto-selection may pick one that downgrades the spec-decode
         # cudagraph to PIECEWISE.
         backend = AttentionBackendEnum.FLASH_ATTN
-    draft_vllm_config = replace(
-        vllm_config,
-        attention_config=replace(
-            vllm_config.attention_config,
-            use_non_causal=dflash_has_any_non_causal(draft_model_config.hf_config),
-            backend=backend,
-        ),
-        cache_config=(
-            replace(
-                vllm_config.cache_config,
-                cache_dtype=speculative_config.kv_cache_dtype,
-            )
-            if speculative_config.kv_cache_dtype is not None
-            else vllm_config.cache_config
-        ),
+    # External drafts own their model, cache dtype, and DCP1 attention geometry.
+    # Reusing target DCP geometry would partition a cache that every target rank
+    # must populate and consume independently.
+    draft_vllm_config = _create_draft_vllm_config(vllm_config)
+    draft_vllm_config.attention_config.backend = backend
+    draft_vllm_config.attention_config.use_non_causal = dflash_has_any_non_causal(
+        draft_model_config.hf_config
     )
-    # VllmConfig post-init restores the target's quant config because the target
-    # config is retained for DSpark's target-layer metadata, so we must override it.
+    # Replacing the model config does not recompute VllmConfig.quant_config.
+    # The draft must not inherit the target checkpoint's quantization method.
     draft_vllm_config.quant_config = get_draft_quant_config(vllm_config)
 
     with set_model_tag("dspark_head"):


### PR DESCRIPTION
## Status

Implemented. This pull request is stacked on #387. DFlash and DSpark serving qualification is tracked by local-inference-lab/rtx6kpro#66.

## Behavior

- Builds external draft models and attention metadata from the isolated draft configuration.
- Propagates a complete online-quantization contract to external drafts.
- Supports DFlash work that must execute after CUDA graph replay.
- Gives retained DFlash streaming weights independent storage.
- Pins the FlashAttention revision that implements dynamic causal behavior used by speculative attention.
- Allows target and draft graph captures to disable fused-MoE output aliasing when they require distinct storage.
- Compiles speculative KDA paths before KV-cache binding.

## Technical reason

A replicated external draft has DCP1 attention geometry even when the target uses DCP16. Draft quantization, cache dtype, causal mode, retained weight lifetime, and CUDA graph storage must therefore come from the draft configuration rather than the target model.

## Compatibility

Non-speculative serving is unchanged. Output aliasing remains enabled unless explicitly disabled. External drafts without an online-quantization contract retain their checkpoint-defined configuration.

## Validation

- Focused external-draft configuration, DFlash graph lifetime, retained-weight ownership, fused-MoE output aliasing, and KDA warmup tests pass.
- The FlashAttention dependency is pinned to commit `7484d475` rather than carried as a local source patch.
