### PR TITLE
Bound and shard Kimi DSpark state

### DIFF
--- a/tests/models/kimi_k3/test_dspark_compact_rope.py
+++ b/tests/models/kimi_k3/test_dspark_compact_rope.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+from torch import nn
+
+from vllm.models.kimi_k3.nvidia import dspark_mla
+
+
+class _Rotary(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.scaling_factor = 2.0
+        self.mscale = 1.25
+        self.head_size = 4
+        self.is_neox_style = False
+        self.register_buffer(
+            "cos_sin_cache",
+            torch.arange(64, dtype=torch.float32).view(16, 4),
+        )
+
+    def _compute_inv_freq(self, scaling_factor: float) -> torch.Tensor:
+        assert scaling_factor == self.scaling_factor
+        return torch.tensor([0.5, 0.25], dtype=torch.float32)
+
+
+class _Attention(nn.Module):
+    def __init__(self, rotary: _Rotary) -> None:
+        super().__init__()
+        self.rotary_emb = rotary
+
+
+class _Layer(nn.Module):
+    def __init__(self, rotary: _Rotary) -> None:
+        super().__init__()
+        self.self_attn = _Attention(rotary)
+
+
+def _draft_model(rotary: _Rotary) -> dspark_mla.K3DSparkModel:
+    model = object.__new__(dspark_mla.K3DSparkModel)
+    nn.Module.__init__(model)
+    model.layers = nn.ModuleList([_Layer(rotary), _Layer(rotary)])
+    model._max_num_context_tokens = 8
+    return model
+
+
+def test_compact_rope_materializes_requested_global_positions() -> None:
+    positions = torch.tensor([2, 7], dtype=torch.int64)
+    inv_freq = torch.tensor([0.5, 0.25], dtype=torch.float32)
+    freqs = torch.empty((4, 2), dtype=torch.float32)
+    cache = torch.empty((4, 4), dtype=torch.float32)
+
+    result = dspark_mla._fill_compact_rope_cache(
+        positions,
+        inv_freq,
+        freqs,
+        cache,
+        mscale=1.25,
+    )
+
+    expected_freqs = positions[:, None] * inv_freq[None, :]
+    expected = torch.cat((expected_freqs.cos(), expected_freqs.sin()), dim=-1) * 1.25
+    torch.testing.assert_close(result, expected)
+    assert result.untyped_storage().data_ptr() == cache.untyped_storage().data_ptr()
+
+
+def test_compact_rope_rejects_more_positions_than_workspace() -> None:
+    with pytest.raises(ValueError, match="workspace is too small"):
+        dspark_mla._fill_compact_rope_cache(
+            torch.arange(3),
+            torch.ones(2),
+            torch.empty((2, 2)),
+            torch.empty((2, 4)),
+            mscale=1.0,
+        )
+
+
+def test_compact_rope_releases_unshared_full_position_table() -> None:
+    rotary = _Rotary()
+    original_bytes = rotary.cos_sin_cache.nbytes
+    model = _draft_model(rotary)
+
+    model._init_compact_rope()
+    model._compact_rope_enabled = True
+    remapped_positions, compact_cache = model._get_rope_inputs(
+        torch.tensor([2, 7], dtype=torch.int64)
+    )
+
+    assert original_bytes == 256
+    assert rotary.cos_sin_cache.shape == (0, 4)
+    torch.testing.assert_close(remapped_positions, torch.tensor([0, 1]))
+    expected_freqs = torch.tensor([[1.0, 0.5], [3.5, 1.75]])
+    expected_cache = (
+        torch.cat((expected_freqs.cos(), expected_freqs.sin()), dim=-1) * 1.25
+    )
+    torch.testing.assert_close(compact_cache, expected_cache)
+
+
+def test_compact_rope_retains_target_owned_position_table() -> None:
+    rotary = _Rotary()
+    target = nn.Module()
+    target.rotary = rotary
+    model = _draft_model(rotary)
+
+    with dspark_mla.protect_k3_compact_rope_sources(target):
+        model._init_compact_rope()
+
+    assert rotary.cos_sin_cache.shape == (16, 4)
+    assert not dspark_mla._COMPACT_ROPE_PROTECTED_IDS

--- a/tests/models/kimi_k3/test_dspark_dcp_cache.py
+++ b/tests/models/kimi_k3/test_dspark_dcp_cache.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import torch
+
+from vllm.models.kimi_k3.nvidia import mla
+
+
+def _cache_spec(monkeypatch, *, non_causal: bool, dcp_size: int):
+    attention = object.__new__(mla.MultiHeadLatentAttention)
+    attention.kv_cache_dtype = "auto"
+    attention.head_size = 640
+    attention.non_causal_multi_token_decode = non_causal
+    config = SimpleNamespace(
+        cache_config=SimpleNamespace(block_size=64),
+        model_config=object(),
+        parallel_config=SimpleNamespace(
+            decode_context_parallel_size=dcp_size,
+        ),
+    )
+    monkeypatch.setattr(
+        mla,
+        "kv_cache_dtype_str_to_dtype",
+        lambda _cache_dtype, _model_config: torch.bfloat16,
+    )
+    monkeypatch.setattr(mla, "get_kv_quant_mode", lambda _cache_dtype: None)
+    return mla.MultiHeadLatentAttention.get_kv_cache_spec(attention, config)
+
+
+def test_external_k3_dspark_cache_is_replicated_under_target_dcp(
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("VLLM_DCP_SHARD_DRAFT", raising=False)
+
+    spec = _cache_spec(monkeypatch, non_causal=True, dcp_size=16)
+
+    assert spec.dcp_replicated
+
+
+def test_explicit_draft_sharding_disables_cache_replication(monkeypatch) -> None:
+    monkeypatch.setenv("VLLM_DCP_SHARD_DRAFT", "1")
+
+    spec = _cache_spec(monkeypatch, non_causal=True, dcp_size=16)
+
+    assert not spec.dcp_replicated
+
+
+def test_target_k3_cache_is_not_marked_as_draft_replication(monkeypatch) -> None:
+    monkeypatch.delenv("VLLM_DCP_SHARD_DRAFT", raising=False)
+
+    spec = _cache_spec(monkeypatch, non_causal=False, dcp_size=16)
+
+    assert not spec.dcp_replicated

--- a/tests/models/kimi_k3/test_dspark_dcp_cache.py
+++ b/tests/models/kimi_k3/test_dspark_dcp_cache.py
@@ -8,11 +8,18 @@ import torch
 from vllm.models.kimi_k3.nvidia import mla
 
 
-def _cache_spec(monkeypatch, *, non_causal: bool, dcp_size: int):
+def _cache_spec(
+    monkeypatch,
+    *,
+    non_causal: bool,
+    dcp_size: int,
+    draft_kv_window: int = 0,
+):
     attention = object.__new__(mla.MultiHeadLatentAttention)
     attention.kv_cache_dtype = "auto"
     attention.head_size = 640
     attention.non_causal_multi_token_decode = non_causal
+    attention.draft_kv_window = draft_kv_window
     config = SimpleNamespace(
         cache_config=SimpleNamespace(block_size=64),
         model_config=object(),
@@ -53,3 +60,19 @@ def test_target_k3_cache_is_not_marked_as_draft_replication(monkeypatch) -> None
     spec = _cache_spec(monkeypatch, non_causal=False, dcp_size=16)
 
     assert not spec.dcp_replicated
+
+
+def test_bounded_dspark_cache_preserves_non_causal_mode(monkeypatch) -> None:
+    monkeypatch.delenv("VLLM_DCP_SHARD_DRAFT", raising=False)
+
+    spec = _cache_spec(
+        monkeypatch,
+        non_causal=True,
+        dcp_size=16,
+        draft_kv_window=65_536,
+    )
+
+    assert isinstance(spec, mla.SlidingWindowMLASpec)
+    assert spec.sliding_window == 65_536
+    assert spec.non_causal_multi_token_decode
+    assert spec.dcp_replicated

--- a/tests/models/test_dspark_mla.py
+++ b/tests/models/test_dspark_mla.py
@@ -166,6 +166,68 @@ def test_k3_dspark_uses_replicated_markov_head(monkeypatch: pytest.MonkeyPatch):
     ]
 
 
+@pytest.mark.cpu_test
+@pytest.mark.parametrize(
+    ("tp_size", "expect_sharded"),
+    [(1, False), (8, True), (12, False), (16, True)],
+)
+def test_k3_dspark_context_projection_uses_divisible_tp_geometry(
+    monkeypatch: pytest.MonkeyPatch,
+    tp_size: int,
+    expect_sharded: bool,
+) -> None:
+    context_projection_calls = []
+
+    class DummyModule(nn.Module):
+        def __init__(self, *args, **kwargs):
+            super().__init__()
+
+    def make_sharded_projection(*args, **kwargs):
+        context_projection_calls.append((args, kwargs))
+        return DummyModule()
+
+    monkeypatch.setattr(dspark_mla, "get_draft_quant_config", lambda _: None)
+    monkeypatch.setattr(dspark_mla, "ColumnParallelLinear", make_sharded_projection)
+    monkeypatch.setattr(dspark_mla, "ReplicatedLinear", DummyModule)
+    monkeypatch.setattr(dspark_mla, "MergedColumnParallelLinear", DummyModule)
+    monkeypatch.setattr(dspark_mla, "RMSNorm", DummyModule)
+    monkeypatch.setattr(dspark_mla, "K3DSparkDecoderLayer", DummyModule)
+    monkeypatch.setattr(dspark_mla, "DSparkMarkovHead", DummyModule)
+
+    config = SimpleNamespace(
+        target_hidden_size=7168,
+        num_target_layers=5,
+        hidden_size=7168,
+        kv_lora_rank=512,
+        qk_rope_head_dim=64,
+        rms_norm_eps=1e-6,
+        num_hidden_layers=1,
+        vocab_size=163840,
+        draft_vocab_size=163840,
+        markov_rank=256,
+    )
+    vllm_config = SimpleNamespace(
+        speculative_config=SimpleNamespace(
+            draft_model_config=SimpleNamespace(hf_config=config)
+        ),
+        parallel_config=SimpleNamespace(tensor_parallel_size=tp_size),
+        scheduler_config=SimpleNamespace(max_num_batched_tokens=16),
+    )
+
+    model = K3DSparkModel(
+        vllm_config=vllm_config,
+        start_layer_id=0,
+        prefix="model",
+    )
+
+    assert model.context_proj_sharded is expect_sharded
+    assert bool(context_projection_calls) is expect_sharded
+    if expect_sharded:
+        args, kwargs = context_projection_calls[0]
+        assert args == (7168 * 5, 7168)
+        assert kwargs["gather_output"] is True
+
+
 def test_context_kv_weights_are_loaded_as_merged_linear_shards():
     weights = [
         (

--- a/tests/models/test_dspark_mla.py
+++ b/tests/models/test_dspark_mla.py
@@ -83,6 +83,8 @@ def test_dspark_markov_head_is_replicated(
         "get_current_vllm_config",
         lambda: SimpleNamespace(model_config=None),
     )
+    monkeypatch.delenv("VLLM_DSPARK_SHARD_MARKOV_HEAD", raising=False)
+    monkeypatch.delenv("VLLM_DSPARK_REPLICATE_MARKOV_W1", raising=False)
 
     head = DSparkMarkovHead(128, 128, 8, prefix="markov_head")
     assert head.markov_w2.tp_size == 1
@@ -104,6 +106,65 @@ def test_dspark_markov_head_is_replicated(
     bias = head.bias(markov_embed, logits_processor)
     assert markov_embed.shape == (2, 8)
     assert bias.shape == (2, 128)
+
+
+@pytest.mark.cpu_test
+@pytest.mark.parametrize("replicate_w1", [False, True])
+def test_dspark_markov_head_shards_vocabulary_weights(
+    monkeypatch: pytest.MonkeyPatch,
+    replicate_w1: bool,
+) -> None:
+    from vllm.model_executor.layers import logits_processor, vocab_parallel_embedding
+
+    monkeypatch.setenv("VLLM_DSPARK_SHARD_MARKOV_HEAD", "1")
+    monkeypatch.setenv(
+        "VLLM_DSPARK_REPLICATE_MARKOV_W1",
+        "1" if replicate_w1 else "0",
+    )
+    monkeypatch.setattr(
+        vocab_parallel_embedding, "get_tensor_model_parallel_rank", lambda: 3
+    )
+    monkeypatch.setattr(
+        vocab_parallel_embedding,
+        "get_tensor_model_parallel_world_size",
+        lambda: 8,
+    )
+    monkeypatch.setattr(
+        logits_processor,
+        "get_current_vllm_config",
+        lambda: SimpleNamespace(model_config=None),
+    )
+
+    head = DSparkMarkovHead(128, 128, 8, prefix="markov_head")
+
+    assert head.shard_across_tp
+    assert head.replicate_w1 is replicate_w1
+    assert head.markov_w2.tp_size == 8
+    assert head.markov_w2.weight.shape == (16, 8)
+    if replicate_w1:
+        assert isinstance(head.markov_w1, nn.Embedding)
+        assert head.markov_w1.weight.shape == (128, 8)
+    else:
+        assert isinstance(
+            head.markov_w1,
+            vocab_parallel_embedding.VocabParallelEmbedding,
+        )
+        assert head.markov_w1.weight.shape == (16, 8)
+
+    processor = LogitsProcessor(128)
+    local_bias = head.local_bias(torch.ones((2, 8)), processor)
+    assert local_bias.shape == (2, 16)
+
+
+@pytest.mark.cpu_test
+def test_replicated_markov_w1_requires_sharded_head(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("VLLM_DSPARK_SHARD_MARKOV_HEAD", raising=False)
+    monkeypatch.setenv("VLLM_DSPARK_REPLICATE_MARKOV_W1", "1")
+
+    with pytest.raises(ValueError, match="requires VLLM_DSPARK_SHARD_MARKOV_HEAD"):
+        DSparkMarkovHead(128, 128, 8, prefix="markov_head")
 
 
 @pytest.mark.cpu_test

--- a/tests/transformers_utils/test_dspark_mla_config.py
+++ b/tests/transformers_utils/test_dspark_mla_config.py
@@ -13,6 +13,7 @@ from vllm.model_executor.layers.quantization.online.base import (
 from vllm.model_executor.model_loader.weight_utils import get_quant_config
 from vllm.transformers_utils.config import get_config
 from vllm.transformers_utils.configs.k3_dspark import K3DSparkConfig
+from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
 
 def _write_dspark_config(path, **overrides):
@@ -184,7 +185,7 @@ def test_dspark_mla_accepts_draft_online_quantization(tmp_path):
     assert quant_config.args == draft.quantization_config
 
 
-def test_dspark_mla_rejects_decode_context_parallelism(tmp_path):
+def test_dspark_mla_dcp_requires_b12x_backend(tmp_path):
     target_path = tmp_path / "target"
     draft_path = tmp_path / "draft"
     _write_target_config(target_path)
@@ -193,7 +194,7 @@ def test_dspark_mla_rejects_decode_context_parallelism(tmp_path):
         model=str(target_path), tokenizer_mode="skip", max_model_len=32768
     )
 
-    with pytest.raises(ValueError, match="does not currently support decode context"):
+    with pytest.raises(ValueError, match="requires attention_backend=B12X_MLA"):
         SpeculativeConfig(
             model=str(draft_path),
             method="dspark",
@@ -205,3 +206,29 @@ def test_dspark_mla_rejects_decode_context_parallelism(tmp_path):
                 distributed_executor_backend="external_launcher",
             ),
         )
+
+
+def test_dspark_mla_allows_dcp_with_b12x_backend(tmp_path):
+    target_path = tmp_path / "target"
+    draft_path = tmp_path / "draft"
+    _write_target_config(target_path)
+    _write_dspark_config(draft_path)
+    target_config = ModelConfig(
+        model=str(target_path), tokenizer_mode="skip", max_model_len=32768
+    )
+
+    config = SpeculativeConfig(
+        model=str(draft_path),
+        method="dspark",
+        num_speculative_tokens=7,
+        attention_backend=AttentionBackendEnum.B12X_MLA,
+        target_model_config=target_config,
+        target_parallel_config=ParallelConfig(
+            tensor_parallel_size=8,
+            decode_context_parallel_size=8,
+            distributed_executor_backend="external_launcher",
+        ),
+    )
+
+    assert config.attention_backend is AttentionBackendEnum.B12X_MLA
+    assert config.target_parallel_config.decode_context_parallel_size == 8

--- a/tests/v1/spec_decode/test_dflash_prefix_cache_masking.py
+++ b/tests/v1/spec_decode/test_dflash_prefix_cache_masking.py
@@ -168,3 +168,35 @@ def test_shift_copy_bounded_by_seq_len():
 
     torch.testing.assert_close(block_table[0, :4], original[0, 4:8])
     torch.testing.assert_close(block_table[0, 4:], original[0, 4:])
+
+
+def test_window_shift_updates_shared_sequence_length_once_for_two_groups():
+    tables = [_make_block_table(1), _make_block_table(1)]
+    originals = [table.clone() for table in tables]
+    idx_mapping = torch.zeros(1, dtype=torch.int32, device=DEVICE)
+    num_cached_tokens = torch.zeros(1, dtype=torch.int32, device=DEVICE)
+    seq_lens = torch.full((1,), 8 * BLOCK_SIZE, dtype=torch.int32, device=DEVICE)
+    draft_kv_window = 4 * BLOCK_SIZE
+
+    shift_draft_block_tables(
+        tables[0],
+        idx_mapping,
+        num_cached_tokens,
+        seq_lens,
+        BLOCK_SIZE,
+        draft_kv_window,
+        update_seq_lens=False,
+    )
+    shift_draft_block_tables(
+        tables[1],
+        idx_mapping,
+        num_cached_tokens,
+        seq_lens,
+        BLOCK_SIZE,
+        draft_kv_window,
+        update_seq_lens=True,
+    )
+
+    assert seq_lens.item() == draft_kv_window
+    for table, original in zip(tables, originals, strict=True):
+        torch.testing.assert_close(table[0, :4], original[0, 4:8])

--- a/tests/v1/spec_decode/test_external_draft_attention_config.py
+++ b/tests/v1/spec_decode/test_external_draft_attention_config.py
@@ -81,9 +81,43 @@ def test_dflash_attention_metadata_uses_external_draft_geometry(monkeypatch) -> 
     speculator = object.__new__(dflash_speculator.DFlashSpeculator)
     speculator.vllm_config = target_config
     speculator.requires_non_causal = True
+    speculator.draft_kv_window = None
+    speculator.draft_kv_window_block_size = None
 
     attention_config = speculator.attn_vllm_config
 
     assert attention_config.parallel_config.decode_context_parallel_size == 1
     assert attention_config.attention_config.use_non_causal
     assert not draft_config.attention_config.use_non_causal
+
+
+def test_bounded_draft_attention_preserves_derived_model_attributes(
+    monkeypatch,
+) -> None:
+    """Bounded plan sizing copies runtime objects without reconstructing them."""
+    draft_model_config = SimpleNamespace(
+        max_model_len=1_048_576,
+        model_arch_config=object(),
+    )
+    draft_config = SimpleNamespace(
+        model_config=draft_model_config,
+        attention_config=SimpleNamespace(use_non_causal=False),
+    )
+    target_config = object()
+    monkeypatch.setattr(
+        dflash_speculator,
+        "_create_draft_vllm_config",
+        lambda config: draft_config if config is target_config else None,
+    )
+    speculator = object.__new__(dflash_speculator.DFlashSpeculator)
+    speculator.vllm_config = target_config
+    speculator.requires_non_causal = True
+    speculator.draft_kv_window = 65_536
+    speculator.draft_kv_window_block_size = 768
+
+    attention_config = speculator.attn_vllm_config
+
+    assert draft_model_config.max_model_len == 1_048_576
+    assert attention_config.model_config.max_model_len == 65_536 + 768 - 1
+    assert attention_config.model_config.model_arch_config is not None
+    assert attention_config.attention_config.use_non_causal

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -1172,10 +1172,12 @@ class SpeculativeConfig:
                     self.method == "dspark"
                     and "K3DSparkModel" in self.draft_model_config.architectures
                     and self.target_parallel_config.decode_context_parallel_size > 1
+                    and self.attention_backend != AttentionBackendEnum.B12X_MLA
                 ):
                     raise ValueError(
-                        "MLA DSpark does not currently support decode context "
-                        "parallelism; set decode_context_parallel_size=1."
+                        "K3 DSpark decode context parallelism requires "
+                        "attention_backend=B12X_MLA; otherwise set "
+                        "decode_context_parallel_size=1."
                     )
 
                 if self.num_speculative_tokens is not None and hasattr(

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -67,6 +67,7 @@ if TYPE_CHECKING:
     VLLM_MLA_CHUNKED_PREFILL_WORKSPACE_SIZE: int = 0
     VLLM_K3_KV_GROUP_SIZE: int = 0
     VLLM_DSPARK_DRAFT_KV_WINDOW: int = 0
+    VLLM_DSPARK_COMPACT_ROPE: bool = False
     VLLM_USE_B12X_WO_PROJECTION: bool = False
     VLLM_USE_B12X_MOE: bool = False
     VLLM_NF3_GRID188_DECODE: bool = True
@@ -1156,6 +1157,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # the setting quality-safe, but acceptance may change with the window.
     "VLLM_DSPARK_DRAFT_KV_WINDOW": lambda: int(
         os.getenv("VLLM_DSPARK_DRAFT_KV_WINDOW", "0")
+    ),
+    # Replace the persistent Kimi-K3 draft position table with fixed-address
+    # workspaces that materialize only rows consumed by one draft forward.
+    "VLLM_DSPARK_COMPACT_ROPE": lambda: bool(
+        int(os.getenv("VLLM_DSPARK_COMPACT_ROPE", "0"))
     ),
     # Use b12x for the DeepSeek V4 WO-A/WO-B fused projection.
     # This is separate from the generic FP8 linear switch for perf isolation.

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -66,6 +66,7 @@ if TYPE_CHECKING:
     VLLM_DSPARK_FP8_DRAFT_HEAD: bool = False
     VLLM_MLA_CHUNKED_PREFILL_WORKSPACE_SIZE: int = 0
     VLLM_K3_KV_GROUP_SIZE: int = 0
+    VLLM_DSPARK_DRAFT_KV_WINDOW: int = 0
     VLLM_USE_B12X_WO_PROJECTION: bool = False
     VLLM_USE_B12X_MOE: bool = False
     VLLM_NF3_GRID188_DECODE: bool = True
@@ -1150,6 +1151,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Bound the number of physical Kimi-K3 layers sharing each hybrid-cache
     # block table. Zero preserves the general grouping heuristic.
     "VLLM_K3_KV_GROUP_SIZE": lambda: int(os.getenv("VLLM_K3_KV_GROUP_SIZE", "0")),
+    # Limit an external DSpark draft to a replicated rolling MLA KV tail while
+    # the target model retains its complete context. Target verification makes
+    # the setting quality-safe, but acceptance may change with the window.
+    "VLLM_DSPARK_DRAFT_KV_WINDOW": lambda: int(
+        os.getenv("VLLM_DSPARK_DRAFT_KV_WINDOW", "0")
+    ),
     # Use b12x for the DeepSeek V4 WO-A/WO-B fused projection.
     # This is separate from the generic FP8 linear switch for perf isolation.
     "VLLM_USE_B12X_WO_PROJECTION": lambda: bool(

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -68,6 +68,8 @@ if TYPE_CHECKING:
     VLLM_K3_KV_GROUP_SIZE: int = 0
     VLLM_DSPARK_DRAFT_KV_WINDOW: int = 0
     VLLM_DSPARK_COMPACT_ROPE: bool = False
+    VLLM_DSPARK_SHARD_MARKOV_HEAD: bool = False
+    VLLM_DSPARK_REPLICATE_MARKOV_W1: bool = False
     VLLM_USE_B12X_WO_PROJECTION: bool = False
     VLLM_USE_B12X_MOE: bool = False
     VLLM_NF3_GRID188_DECODE: bool = True
@@ -1162,6 +1164,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # workspaces that materialize only rows consumed by one draft forward.
     "VLLM_DSPARK_COMPACT_ROPE": lambda: bool(
         int(os.getenv("VLLM_DSPARK_COMPACT_ROPE", "0"))
+    ),
+    "VLLM_DSPARK_SHARD_MARKOV_HEAD": lambda: bool(
+        int(os.getenv("VLLM_DSPARK_SHARD_MARKOV_HEAD", "0"))
+    ),
+    "VLLM_DSPARK_REPLICATE_MARKOV_W1": lambda: bool(
+        int(os.getenv("VLLM_DSPARK_REPLICATE_MARKOV_W1", "0"))
     ),
     # Use b12x for the DeepSeek V4 WO-A/WO-B fused projection.
     # This is separate from the generic FP8 linear switch for perf isolation.

--- a/vllm/model_executor/models/qwen3_dspark.py
+++ b/vllm/model_executor/models/qwen3_dspark.py
@@ -20,6 +20,7 @@ from collections.abc import Iterable
 import torch
 import torch.nn as nn
 
+from vllm import envs
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
 from vllm.model_executor.layers.linear import ReplicatedLinear
@@ -27,6 +28,7 @@ from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
+    VocabParallelEmbedding,
 )
 
 from .qwen3_dflash import DFlashQwen3ForCausalLM, DFlashQwen3Model
@@ -43,9 +45,8 @@ class DSparkMarkovHead(nn.Module):
     (``draft_vocab_size``) added to the base draft logits. The two sizes
     coincide for full-vocab drafts.
 
-    Both weights are replicated because the head runs sequentially for every
-    draft position. Sharding them would add an all-reduce and a full-vocab
-    gather to each position.
+    Both weights are replicated by default. The TP-sharded layout reduces
+    persistent draft memory and retains the ordinary exact gathered-logit path.
     """
 
     def __init__(
@@ -57,6 +58,31 @@ class DSparkMarkovHead(nn.Module):
         quant_config: QuantizationConfig | None = None,
     ) -> None:
         super().__init__()
+        self.shard_across_tp = envs.VLLM_DSPARK_SHARD_MARKOV_HEAD
+        self.replicate_w1 = envs.VLLM_DSPARK_REPLICATE_MARKOV_W1
+        if self.replicate_w1 and not self.shard_across_tp:
+            raise ValueError(
+                "VLLM_DSPARK_REPLICATE_MARKOV_W1 requires "
+                "VLLM_DSPARK_SHARD_MARKOV_HEAD=1."
+            )
+        if self.shard_across_tp:
+            self.markov_w1 = (
+                nn.Embedding(vocab_size, markov_rank)
+                if self.replicate_w1
+                else VocabParallelEmbedding(
+                    vocab_size,
+                    markov_rank,
+                    prefix=maybe_prefix(prefix, "markov_w1"),
+                )
+            )
+            self.markov_w2 = ParallelLMHead(
+                draft_vocab_size,
+                markov_rank,
+                bias=False,
+                quant_config=quant_config,
+                prefix=maybe_prefix(prefix, "markov_w2"),
+            )
+            return
         self.markov_w1 = nn.Embedding(vocab_size, markov_rank)
         self.markov_w2 = ParallelLMHead(
             draft_vocab_size,
@@ -78,6 +104,16 @@ class DSparkMarkovHead(nn.Module):
     ) -> torch.Tensor:
         """Vocab-size transition bias from a Markov embedding ([B, r] -> [B, V])."""
         return logits_processor(self.markov_w2, markov_embed)
+
+    def local_bias(
+        self,
+        markov_embed: torch.Tensor,
+        logits_processor: LogitsProcessor,
+    ) -> torch.Tensor:
+        """Return the unprocessed transition-bias shard owned by this TP rank."""
+        if not self.shard_across_tp:
+            raise RuntimeError("Local Markov bias requires a TP-sharded head.")
+        return logits_processor._apply_head(self.markov_w2, markov_embed, None)
 
     def apply_bias_gathered(
         self,

--- a/vllm/models/kimi_k3/nvidia/dspark_mla.py
+++ b/vllm/models/kimi_k3/nvidia/dspark_mla.py
@@ -2,13 +2,16 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """K3 dense MLA draft model for DSpark speculative decoding."""
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
+from contextlib import contextmanager
 
 import torch
 import torch.nn as nn
 
 import vllm._custom_ops as ops
+from vllm import envs
 from vllm.config import VllmConfig
+from vllm.logger import init_logger
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import (
     MergedColumnParallelLinear,
@@ -27,6 +30,24 @@ from vllm.models.kimi_k3.nvidia.mla import MultiHeadLatentAttention
 from vllm.models.kimi_k3.nvidia.model import KimiMLP
 from vllm.utils.torch_utils import is_quantized_kv_cache
 from vllm.v1.worker.workspace import current_workspace_manager
+
+logger = init_logger(__name__)
+
+_COMPACT_ROPE_PROTECTED_IDS: set[int] = set()
+
+
+@contextmanager
+def protect_k3_compact_rope_sources(model: nn.Module) -> Iterator[None]:
+    """Prevent a draft from releasing position tables owned by ``model``."""
+    previous = _COMPACT_ROPE_PROTECTED_IDS.copy()
+    _COMPACT_ROPE_PROTECTED_IDS.update(
+        id(module) for module in model.modules() if hasattr(module, "cos_sin_cache")
+    )
+    try:
+        yield
+    finally:
+        _COMPACT_ROPE_PROTECTED_IDS.clear()
+        _COMPACT_ROPE_PROTECTED_IDS.update(previous)
 
 
 def _duplicate_context_kv_weights(
@@ -49,6 +70,32 @@ def _duplicate_context_kv_weights(
         fused_weight = weight.detach()
         fused_weight.shard_id = layer_idx
         yield f"context_kv_proj.{param_name}", fused_weight
+
+
+def _fill_compact_rope_cache(
+    positions: torch.Tensor,
+    inv_freq: torch.Tensor,
+    freqs_workspace: torch.Tensor,
+    cache_workspace: torch.Tensor,
+    *,
+    mscale: float,
+) -> torch.Tensor:
+    """Materialize RoPE rows consumed by one Kimi-K3 draft forward."""
+    num_positions = int(positions.shape[0])
+    if num_positions > int(freqs_workspace.shape[0]):
+        raise ValueError(
+            "Kimi-K3 DSpark compact RoPE workspace is too small: "
+            f"positions={num_positions}, capacity={freqs_workspace.shape[0]}."
+        )
+    freqs = freqs_workspace[:num_positions]
+    cache = cache_workspace[:num_positions]
+    half_dim = int(inv_freq.shape[0])
+    torch.mul(positions[:, None], inv_freq[None, :], out=freqs)
+    torch.cos(freqs, out=cache[:, :half_dim])
+    torch.sin(freqs, out=cache[:, half_dim:])
+    if mscale != 1.0:
+        cache.mul_(mscale)
+    return cache
 
 
 class K3DSparkDecoderLayer(nn.Module):
@@ -101,6 +148,7 @@ class K3DSparkDecoderLayer(nn.Module):
         positions: torch.Tensor,
         hidden_states: torch.Tensor,
         residual: torch.Tensor | None,
+        rope_cos_sin_cache: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         if residual is None:
             # First layer: hidden_states is the (already reduced) embedding.
@@ -114,6 +162,7 @@ class K3DSparkDecoderLayer(nn.Module):
         hidden_states = self.self_attn(
             positions=positions,
             hidden_states=hidden_states,
+            rope_cos_sin_cache=rope_cos_sin_cache,
         )
         hidden_states, residual = fused_allreduce_rms_norm(
             hidden_states, residual, self.post_attention_layernorm
@@ -187,6 +236,111 @@ class K3DSparkModel(nn.Module):
         self._max_num_context_tokens = (
             vllm_config.scheduler_config.max_num_batched_tokens
         )
+        self._compact_rope_enabled = bool(envs.VLLM_DSPARK_COMPACT_ROPE)
+        if self._compact_rope_enabled:
+            self._init_compact_rope()
+
+    def _init_compact_rope(self) -> None:
+        rotary_modules = [layer.self_attn.rotary_emb for layer in self.layers]
+        if not rotary_modules or any(rotary is None for rotary in rotary_modules):
+            raise RuntimeError(
+                "Kimi-K3 DSpark compact RoPE requires rotary draft layers."
+            )
+        rotary = rotary_modules[0]
+        assert rotary is not None
+        if any(candidate is not rotary for candidate in rotary_modules[1:]):
+            raise RuntimeError(
+                "Kimi-K3 DSpark compact RoPE requires every draft layer to "
+                "share one immutable rotary embedding."
+            )
+        if not hasattr(rotary, "scaling_factor"):
+            raise TypeError(
+                "Kimi-K3 DSpark compact RoPE requires a YaRN rotary embedding, "
+                f"got {type(rotary).__name__}."
+            )
+
+        full_cache = rotary.cos_sin_cache
+        if full_cache.dtype != torch.float32 or full_cache.ndim != 2:
+            raise TypeError(
+                "Kimi-K3 DSpark compact RoPE requires a 2-D fp32 source cache, "
+                f"got shape={tuple(full_cache.shape)}, dtype={full_cache.dtype}."
+            )
+        with torch.device(full_cache.device):
+            inv_freq = rotary._compute_inv_freq(rotary.scaling_factor)  # noqa: SLF001
+        inv_freq = inv_freq.to(dtype=torch.float32)
+        half_dim = int(inv_freq.shape[0])
+        if int(full_cache.shape[1]) != 2 * half_dim:
+            raise ValueError(
+                "Kimi-K3 DSpark compact RoPE frequency width does not match "
+                f"its source table: inv_freq={half_dim}, "
+                f"cache={full_cache.shape[1]}."
+            )
+
+        self.register_buffer("_compact_rope_inv_freq", inv_freq, persistent=False)
+        self.register_buffer(
+            "_compact_rope_freqs",
+            torch.empty(
+                (self._max_num_context_tokens, half_dim),
+                dtype=torch.float32,
+                device=full_cache.device,
+            ),
+            persistent=False,
+        )
+        self.register_buffer(
+            "_compact_rope_cache",
+            torch.empty(
+                (self._max_num_context_tokens, 2 * half_dim),
+                dtype=torch.float32,
+                device=full_cache.device,
+            ),
+            persistent=False,
+        )
+        self.register_buffer(
+            "_compact_rope_positions",
+            torch.arange(
+                self._max_num_context_tokens,
+                dtype=torch.int64,
+                device=full_cache.device,
+            ),
+            persistent=False,
+        )
+        self._compact_rope_mscale = float(rotary.mscale)
+
+        if id(rotary) in _COMPACT_ROPE_PROTECTED_IDS:
+            logger.warning_once(
+                "Kimi-K3 DSpark compact RoPE retains a position table shared "
+                "with the target model."
+            )
+            return
+
+        released_bytes = full_cache.numel() * full_cache.element_size()
+        rotary.cos_sin_cache = torch.empty(
+            (0, 2 * half_dim),
+            dtype=torch.float32,
+            device=full_cache.device,
+        )
+        logger.info_once(
+            "Kimi-K3 DSpark compact RoPE released %.2f MiB/rank and "
+            "materializes at most %d fp32 rows per forward.",
+            released_bytes / (1024**2),
+            self._max_num_context_tokens,
+        )
+
+    def _get_rope_inputs(
+        self, positions: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        rotary = self.layers[0].self_attn.rotary_emb
+        assert rotary is not None
+        if not self._compact_rope_enabled:
+            return positions, rotary.cos_sin_cache
+        cache = _fill_compact_rope_cache(
+            positions,
+            self._compact_rope_inv_freq,
+            self._compact_rope_freqs,
+            self._compact_rope_cache,
+            mscale=self._compact_rope_mscale,
+        )
+        return self._compact_rope_positions[: positions.shape[0]], cache
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         assert self.embed_tokens is not None
@@ -267,7 +421,8 @@ class K3DSparkModel(nn.Module):
             ((num_layers * self._max_num_context_tokens,), torch.int64),
         )
         repeated_positions = repeated_positions[: num_layers * num_ctx]
-        repeated_positions.view(num_layers, num_ctx).copy_(context_positions)
+        rope_positions, rope_cos_sin_cache = self._get_rope_inputs(context_positions)
+        repeated_positions.view(num_layers, num_ctx).copy_(rope_positions)
         # Keep the single-tensor context RoPE on vLLM's optimized CUDA op;
         # DeepSeek YaRN's FlashInfer wrapper assumes a non-null key tensor.
         rotary_emb = self.layers[0].self_attn.rotary_emb
@@ -277,7 +432,7 @@ class K3DSparkModel(nn.Module):
             all_k_pe_flat,
             None,
             rotary_emb.head_size,
-            rotary_emb.cos_sin_cache,
+            rope_cos_sin_cache,
             rotary_emb.is_neox_style,
         )
         all_k_pe = all_k_pe_flat.view(num_layers, num_ctx, 1, self._context_rope_dim)
@@ -383,11 +538,13 @@ class K3DSparkModel(nn.Module):
 
         hidden_states = inputs_embeds
         residual = None
+        rope_positions, rope_cos_sin_cache = self._get_rope_inputs(positions)
         for layer in self.layers:
             hidden_states, residual = layer(
-                positions=positions,
+                positions=rope_positions,
                 hidden_states=hidden_states,
                 residual=residual,
+                rope_cos_sin_cache=rope_cos_sin_cache,
             )
         hidden_states, _ = fused_allreduce_rms_norm(
             hidden_states, residual, self.final_norm

--- a/vllm/models/kimi_k3/nvidia/dspark_mla.py
+++ b/vllm/models/kimi_k3/nvidia/dspark_mla.py
@@ -14,6 +14,7 @@ from vllm.config import VllmConfig
 from vllm.logger import init_logger
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import (
+    ColumnParallelLinear,
     MergedColumnParallelLinear,
     ReplicatedLinear,
 )
@@ -189,14 +190,37 @@ class K3DSparkModel(nn.Module):
         # The frozen target embedding is aliased after the draft checkpoint loads.
         self.embed_tokens: nn.Module | None = None
 
-        self.context_proj = ReplicatedLinear(
-            self.config.target_hidden_size * self.config.num_target_layers,
-            self.config.hidden_size,
-            bias=False,
-            return_bias=False,
-            quant_config=self.quant_config,
-            prefix=maybe_prefix(prefix, "context_proj"),
+        parallel_config = getattr(vllm_config, "parallel_config", None)
+        tp_size = int(getattr(parallel_config, "tensor_parallel_size", 1))
+        self.context_proj_sharded = (
+            tp_size > 1 and self.config.hidden_size % tp_size == 0
         )
+        context_input_size = (
+            self.config.target_hidden_size * self.config.num_target_layers
+        )
+        context_prefix = maybe_prefix(prefix, "context_proj")
+        if self.context_proj_sharded:
+            # Target auxiliary states are identical across TP ranks. Each rank
+            # retains and evaluates only its output rows; the gathered result
+            # preserves the draft hidden-state layout exactly.
+            self.context_proj = ColumnParallelLinear(
+                context_input_size,
+                self.config.hidden_size,
+                bias=False,
+                gather_output=True,
+                return_bias=False,
+                quant_config=self.quant_config,
+                prefix=context_prefix,
+            )
+        else:
+            self.context_proj = ReplicatedLinear(
+                context_input_size,
+                self.config.hidden_size,
+                bias=False,
+                return_bias=False,
+                quant_config=self.quant_config,
+                prefix=context_prefix,
+            )
         self.context_norm = RMSNorm(
             self.config.hidden_size, eps=self.config.rms_norm_eps
         )

--- a/vllm/models/kimi_k3/nvidia/mla.py
+++ b/vllm/models/kimi_k3/nvidia/mla.py
@@ -464,6 +464,17 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
         kv_cache_dtype = kv_cache_dtype_str_to_dtype(
             self.kv_cache_dtype, vllm_config.model_config
         )
+        raw_shard_draft = envs.VLLM_DCP_SHARD_DRAFT
+        shard_draft = (
+            False
+            if raw_shard_draft is None
+            else raw_shard_draft.lower() in ("1", "true", "yes")
+        )
+        dcp_replicated = bool(
+            self.non_causal_multi_token_decode
+            and not shard_draft
+            and vllm_config.parallel_config.decode_context_parallel_size > 1
+        )
         # TODO: Remove this mypy workaround once the K3 PR is fully merged.
         return MLAAttentionSpec(  # type: ignore[call-arg]
             block_size=vllm_config.cache_config.block_size,
@@ -473,6 +484,7 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
             cache_dtype_str=self.kv_cache_dtype,
             kv_quant_mode=get_kv_quant_mode(self.kv_cache_dtype),
             non_causal_multi_token_decode=self.non_causal_multi_token_decode,
+            dcp_replicated=dcp_replicated,
         )
 
     def process_weights_after_loading(self, act_dtype: torch.dtype) -> None:

--- a/vllm/models/kimi_k3/nvidia/mla.py
+++ b/vllm/models/kimi_k3/nvidia/mla.py
@@ -597,6 +597,7 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
         self,
         positions: torch.Tensor,
         hidden_states: torch.Tensor,
+        rope_cos_sin_cache: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """Attention front-end: fused qkv-a proj -> norms -> q_b -> attention.
 
@@ -635,13 +636,21 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
             dtype=hidden_states.dtype,
             device=hidden_states.device,
         )
-        self._attention(positions, q, kv_c_normed, k_pe, attn_out)
+        self._attention(
+            positions,
+            q,
+            kv_c_normed,
+            k_pe,
+            attn_out,
+            rope_cos_sin_cache=rope_cos_sin_cache,
+        )
         return attn_out
 
     def forward(
         self,
         positions: torch.Tensor,
         hidden_states: torch.Tensor,
+        rope_cos_sin_cache: torch.Tensor | None = None,
     ) -> torch.Tensor:
         # Both branches produce (attn_out, gate); they differ only in whether
         # the g_proj GEMM is overlapped on the aux stream.
@@ -654,14 +663,16 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
             and hidden_states.shape[0] < _GATE_MULTI_STREAM_TOKEN_THRESHOLD
         ):
             attn_out, gate = maybe_execute_in_parallel(
-                lambda: self._forward_attn(positions, hidden_states),
+                lambda: self._forward_attn(
+                    positions, hidden_states, rope_cos_sin_cache
+                ),
                 lambda: g_proj(hidden_states)[0],
                 events[0],
                 events[1],
                 self.aux_stream,
             )
         else:
-            attn_out = self._forward_attn(positions, hidden_states)
+            attn_out = self._forward_attn(positions, hidden_states, rope_cos_sin_cache)
             gate = g_proj(hidden_states)[0] if g_proj is not None else None
 
         if gate is not None:
@@ -681,6 +692,8 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
         kv_c_normed: torch.Tensor,
         k_pe: torch.Tensor,
         attn_out: torch.Tensor,
+        *,
+        rope_cos_sin_cache: torch.Tensor | None = None,
     ) -> None:
         forward_context = get_forward_context()
         attn_metadata_by_layer = forward_context.attn_metadata
@@ -712,7 +725,11 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
         if self.rotary_emb is not None:
             # Pass the fp32 cos/sin table straight to the fused epilogue (it reads
             # fp32 and does the RoPE math in fp32) -- no per-forward dtype cast.
-            cos_sin_cache = self.rotary_emb.cos_sin_cache
+            cos_sin_cache = (
+                rope_cos_sin_cache
+                if rope_cos_sin_cache is not None
+                else self.rotary_emb.cos_sin_cache
+            )
             rope_positions = positions
 
         # Decode tokens are laid out first, prefill tokens after. The fused

--- a/vllm/models/kimi_k3/nvidia/mla.py
+++ b/vllm/models/kimi_k3/nvidia/mla.py
@@ -92,7 +92,12 @@ from vllm.v1.attention.backends.mla.prefill import get_mla_prefill_backend
 from vllm.v1.attention.ops.dcp_utils import MLADCPManager
 from vllm.v1.attention.ops.merge_attn_states import merge_attn_states
 from vllm.v1.attention.selector import get_attn_backend
-from vllm.v1.kv_cache_interface import KVCacheSpec, MLAAttentionSpec, get_kv_quant_mode
+from vllm.v1.kv_cache_interface import (
+    KVCacheSpec,
+    MLAAttentionSpec,
+    SlidingWindowMLASpec,
+    get_kv_quant_mode,
+)
 
 if TYPE_CHECKING:
     from vllm.model_executor.layers.attention.mla_attention import MLACommonMetadata
@@ -209,6 +214,16 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
         self.q_lora_rank = q_lora_rank
         self.kv_lora_rank = kv_lora_rank
         self.non_causal_multi_token_decode = non_causal_multi_token_decode
+        self.draft_kv_window = (
+            int(envs.VLLM_DSPARK_DRAFT_KV_WINDOW)
+            if non_causal_multi_token_decode
+            else 0
+        )
+        if self.draft_kv_window < 0:
+            raise ValueError(
+                "VLLM_DSPARK_DRAFT_KV_WINDOW must be non-negative, got "
+                f"{self.draft_kv_window}."
+            )
         # Latent "head" seen by the attention kernel / KV cache.
         self.head_size = kv_lora_rank + qk_rope_head_dim
         self.scale = self.qk_head_dim**-0.5
@@ -475,16 +490,32 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
             and not shard_draft
             and vllm_config.parallel_config.decode_context_parallel_size > 1
         )
-        # TODO: Remove this mypy workaround once the K3 PR is fully merged.
-        return MLAAttentionSpec(  # type: ignore[call-arg]
+        common_kwargs = dict(
             block_size=vllm_config.cache_config.block_size,
             num_kv_heads=1,
             head_size=self.head_size,
             dtype=kv_cache_dtype,
             cache_dtype_str=self.kv_cache_dtype,
             kv_quant_mode=get_kv_quant_mode(self.kv_cache_dtype),
-            non_causal_multi_token_decode=self.non_causal_multi_token_decode,
             dcp_replicated=dcp_replicated,
+        )
+        if self.draft_kv_window:
+            if self.draft_kv_window < vllm_config.cache_config.block_size:
+                raise ValueError(
+                    "VLLM_DSPARK_DRAFT_KV_WINDOW must be at least one KV "
+                    f"block ({vllm_config.cache_config.block_size}), got "
+                    f"{self.draft_kv_window}."
+                )
+            return SlidingWindowMLASpec(
+                **common_kwargs,
+                sliding_window=self.draft_kv_window,
+                non_causal_multi_token_decode=self.non_causal_multi_token_decode,
+            )
+        # TODO: Remove this type suppression when MLAAttentionSpec declares
+        # non_causal_multi_token_decode in its constructor signature.
+        return MLAAttentionSpec(  # type: ignore[call-arg]
+            **common_kwargs,
+            non_causal_multi_token_decode=self.non_causal_multi_token_decode,
         )
 
     def process_weights_after_loading(self, act_dtype: torch.dtype) -> None:

--- a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
@@ -25,7 +25,12 @@ from vllm.logger import init_logger
 from vllm.triton_utils import tl, triton
 from vllm.v1.attention.backend import AttentionCGSupport
 from vllm.v1.attention.backends.utils import PAD_SLOT_ID
-from vllm.v1.kv_cache_interface import KVCacheConfig
+from vllm.v1.kv_cache_interface import (
+    KVCacheConfig,
+    SlidingWindowMLASpec,
+    UniformTypeKVCacheSpecs,
+    get_kv_cache_spec_sliding_window,
+)
 from vllm.v1.worker.gpu.attn_utils import build_slot_mappings_by_layer
 from vllm.v1.worker.gpu.block_table import BlockTables
 from vllm.v1.worker.gpu.cudagraph_utils import (
@@ -151,6 +156,8 @@ class DFlashSpeculator(DraftModelSpeculator):
         self.query_cudagraph_manager: DFlashCudaGraphManager | None = None
         self.context_cudagraph_manager: DFlashContextCudaGraphManager | None = None
         self.draft_kv_cache_group_id: int = -1
+        self.draft_kv_window: int | None = None
+        self.draft_kv_window_block_size: int | None = None
         # Manual CUDA graphs keep raw addresses for model intermediates. Retain
         # each captured backbone output so its storage cannot be recycled while
         # a graph still reads it during sampling.
@@ -173,6 +180,15 @@ class DFlashSpeculator(DraftModelSpeculator):
     def attn_vllm_config(self) -> VllmConfig:
         """Return an isolated attention view with draft parallel geometry."""
         draft_vllm_config = copy.copy(_create_draft_vllm_config(self.vllm_config))
+        if self.draft_kv_window is not None:
+            # Plan only enough positional capacity for the rolling draft tail.
+            # Global token positions and target admission retain their range.
+            assert self.draft_kv_window_block_size is not None
+            draft_model_config = copy.copy(draft_vllm_config.model_config)
+            draft_model_config.max_model_len = (
+                self.draft_kv_window + self.draft_kv_window_block_size - 1
+            )
+            draft_vllm_config.model_config = draft_model_config
         draft_attention_config = copy.copy(draft_vllm_config.attention_config)
         draft_attention_config.use_non_causal = self.requires_non_causal
         draft_vllm_config.attention_config = draft_attention_config
@@ -386,6 +402,7 @@ class DFlashSpeculator(DraftModelSpeculator):
         target_input_buffers: InputBuffers,
         target_attn_groups: list[list[AttentionGroup]],
     ) -> None:
+        self._configure_bounded_k3_draft_kv(kv_cache_config)
         super().set_attn(
             model_state,
             kv_cache_config,
@@ -443,6 +460,56 @@ class DFlashSpeculator(DraftModelSpeculator):
                         layer_names, self.model.get_draft_attn_causal()
                     )
                 }
+
+    def _configure_bounded_k3_draft_kv(self, kv_cache_config: KVCacheConfig) -> None:
+        """Discover one uniform rolling window for Kimi-K3 draft MLA layers."""
+        self.draft_kv_window = None
+        self.draft_kv_window_block_size = None
+        if (
+            getattr(self.draft_model_config.hf_config, "model_type", None)
+            != "k3_dspark"
+        ):
+            return
+
+        draft_windows: set[int] = set()
+        draft_block_sizes: set[int] = set()
+        saw_non_mla_window = False
+        for group in kv_cache_config.kv_cache_groups:
+            active_names = set(group.layer_names) & self.draft_attn_layer_names
+            if not active_names:
+                continue
+            group_spec = group.kv_cache_spec
+            for layer_name in active_names:
+                layer_spec = (
+                    group_spec.kv_cache_specs[layer_name]
+                    if isinstance(group_spec, UniformTypeKVCacheSpecs)
+                    else group_spec
+                )
+                window = get_kv_cache_spec_sliding_window(layer_spec)
+                if window is None:
+                    continue
+                if not isinstance(layer_spec, SlidingWindowMLASpec):
+                    saw_non_mla_window = True
+                    continue
+                draft_windows.add(int(window))
+                draft_block_sizes.add(int(layer_spec.block_size))
+
+        if saw_non_mla_window or not draft_windows:
+            return
+        if len(draft_windows) != 1 or len(draft_block_sizes) != 1:
+            raise ValueError(
+                "Kimi-K3 DSpark bounded KV requires one uniform window and "
+                f"block size, got windows={sorted(draft_windows)}, "
+                f"block_sizes={sorted(draft_block_sizes)}."
+            )
+        self.draft_kv_window = draft_windows.pop()
+        self.draft_kv_window_block_size = draft_block_sizes.pop()
+        logger.info_once(
+            "Kimi-K3 DSpark uses a bounded replicated DCP1 KV tail: "
+            "window=%d, manager_block_size=%d.",
+            self.draft_kv_window,
+            self.draft_kv_window_block_size,
+        )
 
     @torch.inference_mode()
     def _run_model(
@@ -641,6 +708,12 @@ class DFlashSpeculator(DraftModelSpeculator):
         num_query_tokens = num_reqs * active_query_len
         max_seq_len = input_batch.seq_lens_cpu_upper_bound[:num_reqs].max().item()
         self.draft_max_seq_len = min(max_seq_len + active_query_len, self.max_model_len)
+        if self.draft_kv_window is not None:
+            assert self.draft_kv_window_block_size is not None
+            self.draft_max_seq_len = min(
+                self.draft_max_seq_len,
+                self.draft_kv_window + self.draft_kv_window_block_size - 1,
+            )
 
         # NOTE: To avoid CPU-GPU synchronization without CPU knowing the
         # number of rejected tokens, we maintain the size of input_ids and
@@ -735,13 +808,16 @@ class DFlashSpeculator(DraftModelSpeculator):
         # block-table shift cannot hide the residual partial block. Skipped for
         # dummy runs, whose idx_mapping does not reference live requests.
         if not dummy_run:
-            for gid in self.draft_kv_cache_group_ids:
+            last_group_index = len(self.draft_kv_cache_group_ids) - 1
+            for group_index, gid in enumerate(self.draft_kv_cache_group_ids):
                 shift_draft_block_tables(
                     self.block_tables.input_block_tables[gid],
                     input_batch.idx_mapping,
                     self.num_cached_tokens,
                     self.input_buffers.seq_lens,
                     self.block_tables.kernel_block_sizes[gid],
+                    self.draft_kv_window or 0,
+                    update_seq_lens=group_index == last_group_index,
                 )
 
         # Pre-insert context K/V into the cache. Decode replays a row-bucketed
@@ -1128,19 +1204,27 @@ def _shift_draft_block_tables_kernel(
     num_cached_tokens_ptr,
     seq_lens_ptr,
     block_size,
+    draft_kv_window,
     BLOCK_SIZE: tl.constexpr,
+    UPDATE_SEQ_LENS: tl.constexpr,
 ):
     req_idx = tl.program_id(0)
     req_state_idx = tl.load(idx_mapping_ptr + req_idx)
     num_cached = tl.load(num_cached_tokens_ptr + req_state_idx)
-    shift = num_cached // block_size
+    cached_shift = num_cached // block_size
+    seq_len = tl.load(seq_lens_ptr + req_idx)
+    window_shift = tl.maximum(seq_len - draft_kv_window, 0) // block_size
+    window_shift = tl.where(draft_kv_window > 0, window_shift, 0)
+    shift = cached_shift + window_shift
     if shift == 0:
         return
     row_ptr = block_table_ptr + req_idx.to(tl.int64) * block_table_stride
     # Only the blocks the shifted sequence still references need to move;
     # seq_lens holds the cache-shifted draft length (written by
     # _prepare_dflash_inputs_kernel, which must run first).
-    seq_len = tl.load(seq_lens_ptr + req_idx)
+    seq_len -= window_shift * block_size
+    if UPDATE_SEQ_LENS:
+        tl.store(seq_lens_ptr + req_idx, seq_len)
     num_needed = (seq_len + block_size - 1) // block_size
     num_remaining = tl.minimum(block_table_stride - shift, num_needed)
     # In-place left shift is safe: iterations run in ascending order and each
@@ -1174,11 +1258,17 @@ def shift_draft_block_tables(
     # [num_reqs] cache-shifted draft sequence lengths
     seq_lens: torch.Tensor,
     block_size: int,
+    draft_kv_window: int = 0,
+    *,
+    update_seq_lens: bool = True,
 ) -> None:
-    """Shift each request's draft block-table row left by its cache-restored
-    whole blocks, hiding slots that hold no draft context KV from the draft's
-    attention. Must run after prepare_dflash_inputs (slot mappings index the
-    unshifted table, and seq_lens must already hold the shifted lengths)."""
+    """Hide restored-prefix and expired rolling-window blocks from attention.
+
+    The operation must follow ``prepare_dflash_inputs`` because slot mappings
+    index the unshifted table and sequence lengths already exclude restored
+    prefix tokens. Multiple draft cache groups share the sequence-length
+    buffer, so only the final group updates it.
+    """
     num_reqs = idx_mapping.shape[0]
     _shift_draft_block_tables_kernel[(num_reqs,)](
         block_table,
@@ -1187,5 +1277,7 @@ def shift_draft_block_tables(
         num_cached_tokens,
         seq_lens,
         block_size,
+        draft_kv_window,
         BLOCK_SIZE=1024,  # type: ignore
+        UPDATE_SEQ_LENS=update_seq_lens,
     )

--- a/vllm/v1/worker/gpu/spec_decode/dspark/utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/dspark/utils.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from contextlib import nullcontext
+
 import torch.nn as nn
 
 from vllm.config import VllmConfig
@@ -41,7 +43,21 @@ def load_dspark_model(target_model: nn.Module, vllm_config: VllmConfig) -> nn.Mo
     # The draft must not inherit the target checkpoint's quantization method.
     draft_vllm_config.quant_config = get_draft_quant_config(vllm_config)
 
-    with set_model_tag("dspark_head"):
+    target_language_model = (
+        target_model.get_language_model()
+        if hasattr(target_model, "get_language_model")
+        else target_model
+    )
+    if getattr(draft_model_config.hf_config, "model_type", None) == "k3_dspark":
+        from vllm.models.kimi_k3.nvidia.dspark_mla import (
+            protect_k3_compact_rope_sources,
+        )
+
+        rope_ownership = protect_k3_compact_rope_sources(target_language_model)
+    else:
+        rope_ownership = nullcontext()
+
+    with rope_ownership, set_model_tag("dspark_head"):
         draft_model = get_model(
             vllm_config=draft_vllm_config, model_config=draft_model_config
         )
@@ -49,11 +65,6 @@ def load_dspark_model(target_model: nn.Module, vllm_config: VllmConfig) -> nn.Mo
     if get_pp_group().world_size != 1:
         raise NotImplementedError("DSpark does not support pipeline parallelism.")
 
-    target_language_model = (
-        target_model.get_language_model()
-        if hasattr(target_model, "get_language_model")
-        else target_model
-    )
     target_inner = target_language_model.model
     draft_inner = draft_model.model
 

--- a/vllm/v1/worker/gpu/spec_decode/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/speculator.py
@@ -318,7 +318,7 @@ class DraftModelSpeculator(BaseSpeculator):
             step,
             out=draft_seq_lens_cpu_upper_bound[:num_reqs],
         )
-        draft_seq_lens_cpu_upper_bound[:num_reqs].clamp_(max=self.max_model_len)
+        draft_seq_lens_cpu_upper_bound[:num_reqs].clamp_(max=self.draft_max_seq_len)
         seq_lens = self.input_buffers.seq_lens[:num_reqs_padded]
         dcp_local_seq_lens = None
         if self.block_tables.cp_size > 1:


### PR DESCRIPTION
## Status

Implemented. This pull request is stacked on #388. DSpark TP8/DCP8 and TP16/DCP16 capacity qualification is tracked by local-inference-lab/rtx6kpro#66.

## Behavior

- Keeps a replicated Kimi DSpark draft at DCP1 while the target uses decode context parallelism.
- Bounds the draft KV tail with `VLLM_DSPARK_DRAFT_KV_WINDOW`.
- Stores compact rotary state for the bounded draft window.
- Tensor-parallel shards the DSpark context projection.
- Vocabulary-shards the DSpark Markov output state while allowing Markov W1 replication.

## Technical reason

Replicating every DSpark cache and Markov tensor on each target rank consumes memory reserved for the physical target KV cache. Bounded draft history and tensor-parallel state placement preserve draft behavior while making one-million-token target capacity feasible.

## Compatibility

Draft sharding is controlled by explicit DSpark configuration. Models without the Kimi DSpark architecture retain their existing speculative cache and projection layout.

## Validation

- Focused DCP cache, bounded-tail, compact-RoPE, context-projection, and Markov-storage tests pass.
- Hardware qualification records physical target KV capacity separately from the bounded draft tail.
