### PR TITLE
Sample Kimi DSpark proposals from vocabulary shards

### DIFF
--- a/tests/models/test_dspark_mla.py
+++ b/tests/models/test_dspark_mla.py
@@ -9,6 +9,7 @@ import torch.nn as nn
 
 from vllm.compilation.wrapper import TorchCompileWithNoGuardsWrapper
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.vocab_parallel_embedding import ParallelLMHead
 from vllm.model_executor.models.qwen3_dspark import DSparkMarkovHead
 from vllm.model_executor.models.registry import ModelRegistry
 from vllm.model_executor.warmup.kimi_k3_triton_warmup import _get_kda_layer
@@ -337,3 +338,114 @@ def test_kda_warmup_ignores_cacheless_dspark_layers(
     monkeypatch.setattr(kimi_k3_kda, "KimiK3DeltaAttention", FakeKDA)
 
     assert _get_kda_layer(worker) is target_layer
+
+
+def _make_local_argmax_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> K3DSparkForCausalLM:
+    from vllm.model_executor.layers import logits_processor, vocab_parallel_embedding
+
+    monkeypatch.setenv("VLLM_DSPARK_SHARD_MARKOV_HEAD", "1")
+    monkeypatch.delenv("VLLM_DSPARK_REPLICATE_MARKOV_W1", raising=False)
+    monkeypatch.setattr(
+        vocab_parallel_embedding, "get_tensor_model_parallel_rank", lambda: 0
+    )
+    monkeypatch.setattr(
+        vocab_parallel_embedding,
+        "get_tensor_model_parallel_world_size",
+        lambda: 8,
+    )
+    monkeypatch.setattr(
+        logits_processor,
+        "get_current_vllm_config",
+        lambda: SimpleNamespace(model_config=None),
+    )
+
+    model = object.__new__(K3DSparkForCausalLM)
+    nn.Module.__init__(model)
+    model.lm_head = ParallelLMHead(128, 8, prefix="lm_head")
+    model.model = nn.Module()
+    model.model.markov_head = DSparkMarkovHead(128, 128, 8, prefix="markov_head")
+    model.logits_processor = LogitsProcessor(128)
+    model._b12x_dspark_argmax_enabled = False
+    model._b12x_dspark_argmax_cls = None
+    model._b12x_dspark_argmax_runtime = None
+    model._b12x_dspark_argmax_output = None
+    model._b12x_dspark_argmax_max_batch = 8
+    return model
+
+
+@pytest.mark.cpu_test
+def test_k3_dspark_local_argmax_requires_matching_unpadded_shards(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model = _make_local_argmax_model(monkeypatch)
+    assert model.supports_local_draft_argmax()
+
+    model.model.markov_head.markov_w2.num_embeddings_padded += 64
+    assert not model.supports_local_draft_argmax()
+
+
+@pytest.mark.cpu_test
+def test_k3_dspark_cutedsl_argmax_uses_tp8_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model = _make_local_argmax_model(monkeypatch)
+    calls = []
+
+    class FakeArgmax:
+        @classmethod
+        def from_exchange_group(cls, **kwargs):
+            calls.append(("construct", kwargs))
+            return cls()
+
+        def fused_add_argmax(self, base, bias, out):
+            calls.append(("sample", base.clone(), bias.clone(), out))
+            return out.fill_(7)
+
+    monkeypatch.setattr(
+        dspark_mla,
+        "get_tp_group",
+        lambda: SimpleNamespace(cpu_group="tp-metadata-group"),
+    )
+    model._b12x_dspark_argmax_cls = FakeArgmax
+    model._b12x_dspark_argmax_enabled = True
+    base = torch.randn((3, 16), dtype=torch.bfloat16)
+    bias = torch.randn_like(base)
+
+    sampled = model.sample_local_draft_logits(base, bias)
+
+    assert sampled.tolist() == [7, 7, 7]
+    assert calls[0] == (
+        "construct",
+        {
+            "exchange_group": "tp-metadata-group",
+            "device": torch.device("cpu"),
+            "local_vocab_size": 16,
+            "max_batch_size": 8,
+        },
+    )
+    assert calls[1][0] == "sample"
+    assert calls[1][3].shape == (3,)
+
+
+@pytest.mark.cpu_test
+def test_k3_dspark_local_argmax_falls_back_to_exact_gather(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model = _make_local_argmax_model(monkeypatch)
+    gathered = []
+
+    def fake_all_gather(logits: torch.Tensor, dim: int) -> torch.Tensor:
+        gathered.append((logits.clone(), dim))
+        return logits
+
+    monkeypatch.setattr(dspark_mla, "tensor_model_parallel_all_gather", fake_all_gather)
+    base = torch.tensor([[1.0, 2.0, 3.0, 4.0]], dtype=torch.bfloat16)
+    bias = torch.tensor([[0.0, 4.0, 0.0, 0.0]], dtype=torch.bfloat16)
+
+    sampled = model.sample_local_draft_logits(base, bias)
+
+    assert sampled.tolist() == [1]
+    torch.testing.assert_close(gathered[0][0], base + bias)
+    assert gathered[0][1] == -1

--- a/tests/models/test_dspark_mla.py
+++ b/tests/models/test_dspark_mla.py
@@ -342,18 +342,24 @@ def test_kda_warmup_ignores_cacheless_dspark_layers(
 
 def _make_local_argmax_model(
     monkeypatch: pytest.MonkeyPatch,
+    *,
+    tp_size: int = 8,
+    tp_rank: int = 0,
+    vocab_size: int = 128,
 ) -> K3DSparkForCausalLM:
     from vllm.model_executor.layers import logits_processor, vocab_parallel_embedding
 
     monkeypatch.setenv("VLLM_DSPARK_SHARD_MARKOV_HEAD", "1")
     monkeypatch.delenv("VLLM_DSPARK_REPLICATE_MARKOV_W1", raising=False)
     monkeypatch.setattr(
-        vocab_parallel_embedding, "get_tensor_model_parallel_rank", lambda: 0
+        vocab_parallel_embedding,
+        "get_tensor_model_parallel_rank",
+        lambda: tp_rank,
     )
     monkeypatch.setattr(
         vocab_parallel_embedding,
         "get_tensor_model_parallel_world_size",
-        lambda: 8,
+        lambda: tp_size,
     )
     monkeypatch.setattr(
         logits_processor,
@@ -363,10 +369,12 @@ def _make_local_argmax_model(
 
     model = object.__new__(K3DSparkForCausalLM)
     nn.Module.__init__(model)
-    model.lm_head = ParallelLMHead(128, 8, prefix="lm_head")
+    model.lm_head = ParallelLMHead(vocab_size, 8, prefix="lm_head")
     model.model = nn.Module()
-    model.model.markov_head = DSparkMarkovHead(128, 128, 8, prefix="markov_head")
-    model.logits_processor = LogitsProcessor(128)
+    model.model.markov_head = DSparkMarkovHead(
+        vocab_size, vocab_size, 8, prefix="markov_head"
+    )
+    model.logits_processor = LogitsProcessor(vocab_size)
     model._b12x_dspark_argmax_enabled = False
     model._b12x_dspark_argmax_cls = None
     model._b12x_dspark_argmax_runtime = None
@@ -376,7 +384,7 @@ def _make_local_argmax_model(
 
 
 @pytest.mark.cpu_test
-def test_k3_dspark_local_argmax_requires_matching_unpadded_shards(
+def test_k3_dspark_local_argmax_requires_matching_shards(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     model = _make_local_argmax_model(monkeypatch)
@@ -387,20 +395,63 @@ def test_k3_dspark_local_argmax_requires_matching_unpadded_shards(
 
 
 @pytest.mark.cpu_test
-def test_k3_dspark_cutedsl_argmax_uses_tp8_runtime(
+def test_k3_dspark_cutedsl_argmax_masks_tp12_vocab_padding(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    model = _make_local_argmax_model(monkeypatch)
-    calls = []
+    model = _make_local_argmax_model(
+        monkeypatch,
+        tp_size=12,
+        tp_rank=11,
+        vocab_size=190,
+    )
+    assert model.lm_head.num_embeddings_padded == 192
+    assert model.supports_local_draft_argmax()
+    calls: list[tuple[torch.Tensor, torch.Tensor]] = []
 
     class FakeArgmax:
         @classmethod
         def from_exchange_group(cls, **kwargs):
-            calls.append(("construct", kwargs))
             return cls()
 
         def fused_add_argmax(self, base, bias, out):
-            calls.append(("sample", base.clone(), bias.clone(), out))
+            calls.append((base.clone(), bias.clone()))
+            return out.fill_(7)
+
+    monkeypatch.setattr(
+        dspark_mla,
+        "get_tp_group",
+        lambda: SimpleNamespace(cpu_group="tp-metadata-group"),
+    )
+    model._b12x_dspark_argmax_cls = FakeArgmax
+    model._b12x_dspark_argmax_enabled = True
+    base = torch.zeros((1, 16), dtype=torch.bfloat16)
+    bias = torch.zeros_like(base)
+    base[:, -2:] = 1000
+    bias[:, -2:] = 1000
+
+    sampled = model.sample_local_draft_logits(base, bias)
+
+    assert sampled.tolist() == [7]
+    assert torch.isneginf(calls[0][0][:, -2:]).all()
+    assert torch.isneginf(calls[0][1][:, -2:]).all()
+
+
+@pytest.mark.cpu_test
+def test_k3_dspark_cutedsl_argmax_uses_tp8_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model = _make_local_argmax_model(monkeypatch)
+    construct_calls: list[dict[str, object]] = []
+    sample_calls: list[tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = []
+
+    class FakeArgmax:
+        @classmethod
+        def from_exchange_group(cls, **kwargs):
+            construct_calls.append(kwargs)
+            return cls()
+
+        def fused_add_argmax(self, base, bias, out):
+            sample_calls.append((base.clone(), bias.clone(), out))
             return out.fill_(7)
 
     monkeypatch.setattr(
@@ -416,17 +467,13 @@ def test_k3_dspark_cutedsl_argmax_uses_tp8_runtime(
     sampled = model.sample_local_draft_logits(base, bias)
 
     assert sampled.tolist() == [7, 7, 7]
-    assert calls[0] == (
-        "construct",
-        {
-            "exchange_group": "tp-metadata-group",
-            "device": torch.device("cpu"),
-            "local_vocab_size": 16,
-            "max_batch_size": 8,
-        },
-    )
-    assert calls[1][0] == "sample"
-    assert calls[1][3].shape == (3,)
+    assert construct_calls[0] == {
+        "exchange_group": "tp-metadata-group",
+        "device": torch.device("cpu"),
+        "local_vocab_size": 16,
+        "max_batch_size": 8,
+    }
+    assert sample_calls[0][2].shape == (3,)
 
 
 @pytest.mark.cpu_test

--- a/tests/v1/spec_decode/test_dspark_captured_markov.py
+++ b/tests/v1/spec_decode/test_dspark_captured_markov.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.distributed.device_communicators import custom_all_reduce
+from vllm.v1.worker.gpu.spec_decode.dspark import speculator as speculator_module
+from vllm.v1.worker.gpu.spec_decode.dspark.speculator import DSparkSpeculator
+
+
+def _captured_speculator() -> SimpleNamespace:
+    return SimpleNamespace(
+        use_draft_token_capacity=False,
+        draft_logits=None,
+        _draft_topk=None,
+        _use_local_draft_argmax=False,
+        _capture_sharded_markov=True,
+        _markov_outside_cudagraph=False,
+        max_num_reqs=8,
+        num_speculative_steps=7,
+        vllm_config=object(),
+        draft_model_config=SimpleNamespace(hf_config=SimpleNamespace(markov_rank=128)),
+        dtype=torch.bfloat16,
+        device=torch.device("cpu"),
+    )
+
+
+def test_captured_markov_allreduce_probe_covers_every_draft_step(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    probe_shapes = []
+
+    class ActiveAllreduce:
+        def should_custom_ar(self, probe):
+            probe_shapes.append(tuple(probe.shape))
+            return True
+
+    model = SimpleNamespace(
+        supports_local_draft_argmax=lambda: True,
+        draft_id_to_target_id=None,
+        _b12x_dspark_argmax_enabled=True,
+        model=SimpleNamespace(markov_head=SimpleNamespace(replicate_w1=False)),
+    )
+    speculator = _captured_speculator()
+    monkeypatch.setenv("VLLM_DSPARK_SHARD_MARKOV_HEAD", "1")
+    monkeypatch.setattr(
+        speculator_module,
+        "load_dspark_model",
+        lambda _target_model, _config: model,
+    )
+    monkeypatch.setattr(
+        custom_all_reduce,
+        "get_active_b12x_pcie_allreduce",
+        lambda: ActiveAllreduce(),
+        raising=False,
+    )
+
+    loaded = DSparkSpeculator.load_draft_model(
+        speculator,
+        target_model=object(),
+        target_attn_layer_names=set(),
+    )
+
+    assert loaded is model
+    assert speculator._use_local_draft_argmax
+    assert probe_shapes == [(56, 128)]
+
+
+def test_captured_markov_with_replicated_w1_needs_no_allreduce_probe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model = SimpleNamespace(
+        supports_local_draft_argmax=lambda: True,
+        draft_id_to_target_id=None,
+        _b12x_dspark_argmax_enabled=True,
+        model=SimpleNamespace(markov_head=SimpleNamespace(replicate_w1=True)),
+    )
+    speculator = _captured_speculator()
+    monkeypatch.setenv("VLLM_DSPARK_SHARD_MARKOV_HEAD", "1")
+    monkeypatch.setattr(
+        speculator_module,
+        "load_dspark_model",
+        lambda _target_model, _config: model,
+    )
+    monkeypatch.setattr(
+        custom_all_reduce,
+        "get_active_b12x_pcie_allreduce",
+        lambda: pytest.fail("replicated W1 must not inspect TP all-reduce"),
+        raising=False,
+    )
+
+    loaded = DSparkSpeculator.load_draft_model(
+        speculator,
+        target_model=object(),
+        target_attn_layer_names=set(),
+    )
+
+    assert loaded is model
+    assert speculator._use_local_draft_argmax

--- a/tests/v1/spec_decode/test_dspark_local_vocab_sampling.py
+++ b/tests/v1/spec_decode/test_dspark_local_vocab_sampling.py
@@ -24,6 +24,8 @@ def test_sharded_markov_model_selects_local_sampling(
         draft_logits=None,
         _draft_topk=None,
         _use_local_draft_argmax=False,
+        _capture_sharded_markov=False,
+        _markov_outside_cudagraph=False,
     )
     monkeypatch.setenv("VLLM_DSPARK_SHARD_MARKOV_HEAD", "1")
     monkeypatch.setattr(
@@ -55,6 +57,8 @@ def test_sharded_markov_model_rejects_reduced_topk(
         draft_logits=None,
         _draft_topk=32,
         _use_local_draft_argmax=False,
+        _capture_sharded_markov=False,
+        _markov_outside_cudagraph=False,
     )
     monkeypatch.setenv("VLLM_DSPARK_SHARD_MARKOV_HEAD", "1")
     monkeypatch.setattr(

--- a/tests/v1/spec_decode/test_dspark_local_vocab_sampling.py
+++ b/tests/v1/spec_decode/test_dspark_local_vocab_sampling.py
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+from vllm.v1.worker.gpu.spec_decode.dspark import speculator as speculator_module
+from vllm.v1.worker.gpu.spec_decode.dspark.speculator import DSparkSpeculator
+
+
+def test_sharded_markov_model_selects_local_sampling(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model = SimpleNamespace(
+        supports_local_draft_argmax=lambda: True,
+        draft_id_to_target_id=None,
+    )
+    speculator = SimpleNamespace(
+        vllm_config=object(),
+        use_draft_token_capacity=False,
+        draft_logits=None,
+        _draft_topk=None,
+        _use_local_draft_argmax=False,
+    )
+    monkeypatch.setenv("VLLM_DSPARK_SHARD_MARKOV_HEAD", "1")
+    monkeypatch.setattr(
+        speculator_module,
+        "load_dspark_model",
+        lambda _target_model, _vllm_config: model,
+    )
+
+    loaded = DSparkSpeculator.load_draft_model(
+        speculator,
+        target_model=object(),
+        target_attn_layer_names=set(),
+    )
+
+    assert loaded is model
+    assert speculator._use_local_draft_argmax
+
+
+def test_sharded_markov_model_rejects_reduced_topk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model = SimpleNamespace(
+        supports_local_draft_argmax=lambda: True,
+        draft_id_to_target_id=None,
+    )
+    speculator = SimpleNamespace(
+        vllm_config=object(),
+        use_draft_token_capacity=False,
+        draft_logits=None,
+        _draft_topk=32,
+        _use_local_draft_argmax=False,
+    )
+    monkeypatch.setenv("VLLM_DSPARK_SHARD_MARKOV_HEAD", "1")
+    monkeypatch.setattr(
+        speculator_module,
+        "load_dspark_model",
+        lambda _target_model, _vllm_config: model,
+    )
+
+    with pytest.raises(ValueError, match="does not support dspark_draft_topk"):
+        DSparkSpeculator.load_draft_model(
+            speculator,
+            target_model=object(),
+            target_attn_layer_names=set(),
+        )
+
+
+def test_sequential_greedy_sampling_keeps_vocabulary_shards_local() -> None:
+    base_logits = torch.tensor(
+        [
+            [1.0, 5.0, 0.0, 0.0],
+            [0.0, 0.0, 2.0, 1.0],
+        ],
+        dtype=torch.bfloat16,
+    )
+    local_bias = torch.zeros((1, 4), dtype=torch.bfloat16)
+    model = SimpleNamespace(
+        compute_local_draft_logits=Mock(return_value=base_logits),
+        markov_embed=Mock(side_effect=lambda token_ids: token_ids[:, None].float()),
+        compute_local_markov_bias=Mock(return_value=local_bias),
+        sample_local_draft_logits=Mock(
+            side_effect=lambda base, bias: (base + bias).argmax(dim=-1)
+        ),
+    )
+    speculator = SimpleNamespace(
+        sample_indices=torch.tensor([0, 1]),
+        model=model,
+        _use_local_draft_argmax=True,
+        draft_logits=None,
+        _draft_topk=None,
+        sample_idx_mapping=torch.tensor([0, 1]),
+        sample_pos=torch.tensor([1, 2]),
+        draft_token_confidence_logits=torch.empty((1, 2)),
+        min_survival_probability=0.0,
+        use_draft_token_capacity=False,
+        input_buffers=SimpleNamespace(input_ids=torch.tensor([3, 0])),
+        device=torch.device("cpu"),
+        vocab_size=16,
+        draft_token_valid_lengths=torch.empty((1,), dtype=torch.int32),
+        draft_tokens=torch.empty((1, 2), dtype=torch.int64),
+        draft_token_capacity=torch.empty((1,), dtype=torch.int32),
+        _sample_logits=Mock(side_effect=AssertionError("full logits were sampled")),
+    )
+
+    DSparkSpeculator._sample_sequential(
+        speculator,
+        num_reqs=1,
+        head_hidden=torch.randn((2, 8)),
+        num_speculative_steps=2,
+        num_query_per_req=2,
+    )
+
+    assert speculator.draft_tokens.tolist() == [[1, 2]]
+    model.compute_local_draft_logits.assert_called_once()
+    assert model.compute_local_markov_bias.call_count == 2
+    assert model.sample_local_draft_logits.call_count == 2
+    speculator._sample_logits.assert_not_called()

--- a/tests/v1/spec_decode/test_dspark_postgraph_markov_tail.py
+++ b/tests/v1/spec_decode/test_dspark_postgraph_markov_tail.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import torch
+
+from vllm.config.compilation import CUDAGraphMode
+from vllm.v1.worker.gpu.spec_decode.dspark.speculator import DSparkSpeculator
+
+
+def _make_speculator() -> SimpleNamespace:
+    head_hidden = torch.randn(8, 16)
+    model = SimpleNamespace(
+        compute_local_draft_logits=Mock(side_effect=lambda hidden: hidden[:, :11] + 1)
+    )
+    return SimpleNamespace(
+        _run_model=Mock(return_value=head_hidden),
+        model=model,
+        _markov_outside_cudagraph=True,
+        _ensure_captured_markov_buffers=Mock(),
+        _captured_markov_hidden=torch.empty(7, 16),
+        _captured_base_logits=torch.empty(7, 11),
+        sample_indices=torch.arange(7),
+        num_query_per_req=7,
+        _speculative_steps_for_query_len=lambda query_len: query_len,
+        _sample_sequential=Mock(),
+        capacity_activation_batch_size=0,
+    )
+
+
+def test_capture_records_backbone_output_without_markov_collectives(monkeypatch):
+    speculator = _make_speculator()
+    monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: True)
+
+    DSparkSpeculator._generate_draft(
+        speculator,
+        num_reqs=1,
+        num_tokens_padded=8,
+        attn_metadata=None,
+        slot_mappings=None,
+        num_tokens_across_dp=None,
+        cudagraph_runtime_mode=CUDAGraphMode.FULL,
+    )
+
+    speculator._sample_sequential.assert_not_called()
+    speculator._ensure_captured_markov_buffers.assert_called_once_with()
+    torch.testing.assert_close(
+        speculator._captured_markov_hidden,
+        speculator._run_model.return_value[:7],
+    )
+    torch.testing.assert_close(
+        speculator._captured_base_logits,
+        speculator._run_model.return_value[:7, :11] + 1,
+    )
+
+
+def test_capture_warmup_does_not_launch_markov_collectives(monkeypatch):
+    speculator = _make_speculator()
+    monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: False)
+
+    DSparkSpeculator._generate_draft(
+        speculator,
+        num_reqs=1,
+        num_tokens_padded=8,
+        attn_metadata=None,
+        slot_mappings=None,
+        num_tokens_across_dp=None,
+        cudagraph_runtime_mode=CUDAGraphMode.NONE,
+        capture_only=True,
+    )
+
+    speculator._sample_sequential.assert_not_called()
+    speculator._ensure_captured_markov_buffers.assert_called_once_with()
+    torch.testing.assert_close(
+        speculator._captured_markov_hidden,
+        speculator._run_model.return_value[:7],
+    )
+    torch.testing.assert_close(
+        speculator._captured_base_logits,
+        speculator._run_model.return_value[:7, :11] + 1,
+    )
+
+
+def test_eager_generation_samples_complete_markov_tail(monkeypatch):
+    speculator = _make_speculator()
+    monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: False)
+
+    DSparkSpeculator._generate_draft(
+        speculator,
+        num_reqs=1,
+        num_tokens_padded=8,
+        attn_metadata=None,
+        slot_mappings=None,
+        num_tokens_across_dp=None,
+        cudagraph_runtime_mode=CUDAGraphMode.NONE,
+    )
+
+    speculator._sample_sequential.assert_called_once_with(
+        1,
+        speculator._run_model.return_value,
+        7,
+        7,
+        is_profile=False,
+        use_capacity=True,
+    )
+    speculator._ensure_captured_markov_buffers.assert_not_called()
+
+
+def test_graph_replay_finishes_markov_tail_from_stable_buffers():
+    speculator = _make_speculator()
+
+    DSparkSpeculator._finish_captured_draft(
+        speculator,
+        num_reqs=1,
+        num_tokens_padded=8,
+        num_query_per_req=7,
+        is_profile=False,
+    )
+
+    args = speculator._sample_sequential.call_args
+    assert args.args[:4] == (1, None, 7, 7)
+    assert args.kwargs["is_profile"] is False
+    assert args.kwargs["use_capacity"] is True
+    assert (
+        args.kwargs["prepared_sample_hidden"].untyped_storage().data_ptr()
+        == speculator._captured_markov_hidden.untyped_storage().data_ptr()
+    )
+    assert (
+        args.kwargs["precomputed_base_logits"].untyped_storage().data_ptr()
+        == speculator._captured_base_logits.untyped_storage().data_ptr()
+    )

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -70,6 +70,7 @@ if TYPE_CHECKING:
     VLLM_DSPARK_COMPACT_ROPE: bool = False
     VLLM_DSPARK_SHARD_MARKOV_HEAD: bool = False
     VLLM_DSPARK_REPLICATE_MARKOV_W1: bool = False
+    VLLM_KIMI_K3_B12X_DSPARK_ARGMAX: bool = False
     VLLM_USE_B12X_WO_PROJECTION: bool = False
     VLLM_USE_B12X_MOE: bool = False
     VLLM_NF3_GRID188_DECODE: bool = True
@@ -1170,6 +1171,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     "VLLM_DSPARK_REPLICATE_MARKOV_W1": lambda: bool(
         int(os.getenv("VLLM_DSPARK_REPLICATE_MARKOV_W1", "0"))
+    ),
+    # Select a Kimi-K3 DSpark token without gathering full vocabulary shards.
+    # B12X performs an exact BF16 add and global greedy argmax for compatible
+    # unpadded vocabulary layouts. Unsupported layouts retain the exact vLLM
+    # all-gather fallback.
+    "VLLM_KIMI_K3_B12X_DSPARK_ARGMAX": lambda: bool(
+        int(os.getenv("VLLM_KIMI_K3_B12X_DSPARK_ARGMAX", "0"))
     ),
     # Use b12x for the DeepSeek V4 WO-A/WO-B fused projection.
     # This is separate from the generic FP8 linear switch for perf isolation.

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -71,6 +71,7 @@ if TYPE_CHECKING:
     VLLM_DSPARK_SHARD_MARKOV_HEAD: bool = False
     VLLM_DSPARK_REPLICATE_MARKOV_W1: bool = False
     VLLM_KIMI_K3_B12X_DSPARK_ARGMAX: bool = False
+    VLLM_DSPARK_CAPTURE_SHARDED_MARKOV: bool = False
     VLLM_USE_B12X_WO_PROJECTION: bool = False
     VLLM_USE_B12X_MOE: bool = False
     VLLM_NF3_GRID188_DECODE: bool = True
@@ -1178,6 +1179,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # all-gather fallback.
     "VLLM_KIMI_K3_B12X_DSPARK_ARGMAX": lambda: bool(
         int(os.getenv("VLLM_KIMI_K3_B12X_DSPARK_ARGMAX", "0"))
+    ),
+    # Capture TP-sharded deterministic Markov sampling only when every
+    # collective in the tail uses a CUDA-graph-safe B12X implementation.
+    "VLLM_DSPARK_CAPTURE_SHARDED_MARKOV": lambda: bool(
+        int(os.getenv("VLLM_DSPARK_CAPTURE_SHARDED_MARKOV", "0"))
     ),
     # Use b12x for the DeepSeek V4 WO-A/WO-B fused projection.
     # This is separate from the generic FP8 linear switch for perf isolation.

--- a/vllm/models/kimi_k3/nvidia/dspark_mla.py
+++ b/vllm/models/kimi_k3/nvidia/dspark_mla.py
@@ -706,13 +706,21 @@ class K3DSparkForCausalLM(nn.Module):
             return False
         if self.lm_head.shard_indices != markov_w2.shard_indices:
             return False
-        # B12X maps every local row to a global token. Restrict its fast path
-        # to a dense vocabulary so a zero-filled padding row cannot win.
-        if self.lm_head.num_embeddings_padded != self.lm_head.org_vocab_size:
+        # Rank-major base-vocabulary padding preserves B12X's global token
+        # mapping. Added-vocabulary shards interleave padding and require a
+        # different local-index mapping.
+        if self.lm_head.num_embeddings != self.lm_head.org_vocab_size:
             return False
         if self.logits_processor.soft_cap is not None:
             return False
         return self.logits_processor.scale > 0.0
+
+    def _mask_local_draft_padding(self, logits: torch.Tensor) -> None:
+        """Exclude this rank's padded vocabulary tail from token selection."""
+        assert isinstance(self.lm_head, VocabParallelEmbedding)
+        valid_rows = self.lm_head.shard_indices.num_org_elements
+        if valid_rows < logits.shape[-1]:
+            logits[..., valid_rows:].fill_(float("-inf"))
 
     def compute_local_draft_logits(self, hidden_states: torch.Tensor) -> torch.Tensor:
         """Project target hidden states into this rank's vocabulary shard."""
@@ -733,6 +741,8 @@ class K3DSparkForCausalLM(nn.Module):
         return logits[..., : self.logits_processor.org_vocab_size]
 
     def _get_b12x_dspark_argmax(self, base_logits: torch.Tensor) -> Any | None:
+        lm_head = self.lm_head
+        assert isinstance(lm_head, VocabParallelEmbedding)
         runtime = self._b12x_dspark_argmax_runtime
         if runtime is not None:
             return runtime
@@ -757,7 +767,7 @@ class K3DSparkForCausalLM(nn.Module):
         logger.info_once(
             "Kimi-K3 DSpark uses B12X TP%d fused BF16 add and global argmax "
             "for up to %d requests.",
-            self.lm_head.tp_size,
+            lm_head.tp_size,
             self._b12x_dspark_argmax_max_batch,
         )
         return runtime
@@ -769,6 +779,8 @@ class K3DSparkForCausalLM(nn.Module):
     ) -> torch.Tensor:
         """Return exact greedy tokens through B12X or the full-logit fallback."""
         assert isinstance(self.lm_head, VocabParallelEmbedding)
+        self._mask_local_draft_padding(base_logits)
+        self._mask_local_draft_padding(markov_bias)
         batch_size = int(base_logits.shape[0])
         if (
             self._b12x_dspark_argmax_enabled

--- a/vllm/models/kimi_k3/nvidia/dspark_mla.py
+++ b/vllm/models/kimi_k3/nvidia/dspark_mla.py
@@ -4,6 +4,7 @@
 
 from collections.abc import Iterable, Iterator
 from contextlib import contextmanager
+from typing import Any
 
 import torch
 import torch.nn as nn
@@ -11,6 +12,7 @@ import torch.nn as nn
 import vllm._custom_ops as ops
 from vllm import envs
 from vllm.config import VllmConfig
+from vllm.distributed import get_tp_group, tensor_model_parallel_all_gather
 from vllm.logger import init_logger
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import (
@@ -19,6 +21,9 @@ from vllm.model_executor.layers.linear import (
     ReplicatedLinear,
 )
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    VocabParallelEmbedding,
+)
 from vllm.model_executor.models.qwen3_dspark import DSparkMarkovHead
 from vllm.model_executor.models.utils import (
     AutoWeightsLoader,
@@ -35,6 +40,19 @@ from vllm.v1.worker.workspace import current_workspace_manager
 logger = init_logger(__name__)
 
 _COMPACT_ROPE_PROTECTED_IDS: set[int] = set()
+
+
+def _load_b12x_vocab_parallel_argmax() -> Any | None:
+    """Return B12X's exact vocabulary reducer when its API is complete."""
+    try:
+        from b12x.comm.pcie import VocabParallelArgmax
+    except ImportError:
+        return None
+    if not callable(getattr(VocabParallelArgmax, "from_exchange_group", None)):
+        return None
+    if not callable(getattr(VocabParallelArgmax, "fused_add_argmax", None)):
+        return None
+    return VocabParallelArgmax
 
 
 @contextmanager
@@ -613,6 +631,21 @@ class K3DSparkForCausalLM(nn.Module):
         self.logits_processor = LogitsProcessor(
             self.config.draft_vocab_size, scale=logit_scale
         )
+        argmax_requested = bool(envs.VLLM_KIMI_K3_B12X_DSPARK_ARGMAX)
+        self._b12x_dspark_argmax_cls = (
+            _load_b12x_vocab_parallel_argmax() if argmax_requested else None
+        )
+        self._b12x_dspark_argmax_enabled = self._b12x_dspark_argmax_cls is not None
+        if argmax_requested and not self._b12x_dspark_argmax_enabled:
+            logger.warning_once(
+                "B12X does not provide the complete VocabParallelArgmax API; "
+                "Kimi-K3 DSpark uses the exact vocabulary all-gather fallback."
+            )
+        self._b12x_dspark_argmax_max_batch = min(
+            vllm_config.scheduler_config.max_num_seqs, 8
+        )
+        self._b12x_dspark_argmax_runtime: Any = None
+        self._b12x_dspark_argmax_output: torch.Tensor | None = None
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)
@@ -647,6 +680,112 @@ class K3DSparkForCausalLM(nn.Module):
 
     def compute_draft_logits(self, hidden_states: torch.Tensor) -> torch.Tensor:
         return self.compute_logits(hidden_states)
+
+    def supports_local_draft_argmax(self) -> bool:
+        """Return whether rank-local target and Markov logits can be combined."""
+        markov_head = self.model.markov_head
+        if not markov_head.shard_across_tp:
+            return False
+        if not isinstance(self.lm_head, VocabParallelEmbedding):
+            return False
+        markov_w2 = markov_head.markov_w2
+        if not isinstance(markov_w2, VocabParallelEmbedding):
+            return False
+        layout_fields = (
+            "tp_size",
+            "tp_rank",
+            "num_embeddings",
+            "org_vocab_size",
+            "num_embeddings_padded",
+            "num_embeddings_per_partition",
+        )
+        if any(
+            getattr(self.lm_head, field) != getattr(markov_w2, field)
+            for field in layout_fields
+        ):
+            return False
+        if self.lm_head.shard_indices != markov_w2.shard_indices:
+            return False
+        # B12X maps every local row to a global token. Restrict its fast path
+        # to a dense vocabulary so a zero-filled padding row cannot win.
+        if self.lm_head.num_embeddings_padded != self.lm_head.org_vocab_size:
+            return False
+        if self.logits_processor.soft_cap is not None:
+            return False
+        return self.logits_processor.scale > 0.0
+
+    def compute_local_draft_logits(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """Project target hidden states into this rank's vocabulary shard."""
+        assert isinstance(self.lm_head, VocabParallelEmbedding)
+        return self.logits_processor._apply_head(self.lm_head, hidden_states, None)
+
+    def compute_local_markov_bias(self, markov_embed: torch.Tensor) -> torch.Tensor:
+        """Project a Markov embedding into the matching vocabulary shard."""
+        return self.model.markov_head.local_bias(markov_embed, self.logits_processor)
+
+    def gather_local_draft_logits(
+        self,
+        base_logits: torch.Tensor,
+        markov_bias: torch.Tensor,
+    ) -> torch.Tensor:
+        """Add matching shards and gather the exact complete distribution."""
+        logits = tensor_model_parallel_all_gather(base_logits + markov_bias, dim=-1)
+        return logits[..., : self.logits_processor.org_vocab_size]
+
+    def _get_b12x_dspark_argmax(self, base_logits: torch.Tensor) -> Any | None:
+        runtime = self._b12x_dspark_argmax_runtime
+        if runtime is not None:
+            return runtime
+
+        argmax_cls = self._b12x_dspark_argmax_cls
+        if argmax_cls is None:
+            self._b12x_dspark_argmax_enabled = False
+            return None
+
+        runtime = argmax_cls.from_exchange_group(
+            exchange_group=get_tp_group().cpu_group,
+            device=base_logits.device,
+            local_vocab_size=base_logits.shape[-1],
+            max_batch_size=self._b12x_dspark_argmax_max_batch,
+        )
+        self._b12x_dspark_argmax_output = torch.empty(
+            self._b12x_dspark_argmax_max_batch,
+            dtype=torch.int64,
+            device=base_logits.device,
+        )
+        self._b12x_dspark_argmax_runtime = runtime
+        logger.info_once(
+            "Kimi-K3 DSpark uses B12X TP%d fused BF16 add and global argmax "
+            "for up to %d requests.",
+            self.lm_head.tp_size,
+            self._b12x_dspark_argmax_max_batch,
+        )
+        return runtime
+
+    def sample_local_draft_logits(
+        self,
+        base_logits: torch.Tensor,
+        markov_bias: torch.Tensor,
+    ) -> torch.Tensor:
+        """Return exact greedy tokens through B12X or the full-logit fallback."""
+        assert isinstance(self.lm_head, VocabParallelEmbedding)
+        batch_size = int(base_logits.shape[0])
+        if (
+            self._b12x_dspark_argmax_enabled
+            and self.lm_head.tp_size in (8, 12, 16)
+            and base_logits.dtype == torch.bfloat16
+            and markov_bias.dtype == torch.bfloat16
+            and 0 < batch_size <= self._b12x_dspark_argmax_max_batch
+        ):
+            runtime = self._get_b12x_dspark_argmax(base_logits)
+            if runtime is not None:
+                assert self._b12x_dspark_argmax_output is not None
+                return runtime.fused_add_argmax(
+                    base_logits,
+                    markov_bias,
+                    out=self._b12x_dspark_argmax_output[:batch_size],
+                )
+        return self.gather_local_draft_logits(base_logits, markov_bias).argmax(dim=-1)
 
     def map_draft_to_target(self, draft_ids: torch.Tensor) -> torch.Tensor:
         return draft_ids

--- a/vllm/v1/worker/gpu/spec_decode/dspark/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dspark/speculator.py
@@ -67,6 +67,10 @@ class DSparkSpeculator(DFlashSpeculator):
             self.max_num_tokens, draft_hidden, dtype=self.dtype, device=device
         )
 
+        self._markov_outside_cudagraph = envs.VLLM_DSPARK_SHARD_MARKOV_HEAD
+        self._captured_markov_hidden: torch.Tensor | None = None
+        self._captured_base_logits: torch.Tensor | None = None
+
         self._step_cols = torch.arange(
             self.num_speculative_steps, dtype=torch.int32, device=device
         )
@@ -208,6 +212,40 @@ class DSparkSpeculator(DFlashSpeculator):
             self._use_local_draft_argmax = True
         return model
 
+    def _ensure_captured_markov_buffers(self) -> None:
+        """Allocate graph handoff buffers before stream capture begins."""
+        if (
+            self._captured_markov_hidden is not None
+            and self._captured_base_logits is not None
+        ):
+            return
+        if (
+            self._captured_markov_hidden is not None
+            or self._captured_base_logits is not None
+        ):
+            raise RuntimeError("DSpark graph handoff buffers are only partly set")
+        if torch.cuda.is_current_stream_capturing():
+            raise RuntimeError(
+                "DSpark graph handoff buffers must be allocated by eager "
+                "graph warmup before stream capture"
+            )
+
+        max_markov_rows = self.max_num_reqs * self.num_speculative_steps
+        local_vocab_size = self.model.lm_head.num_embeddings_per_partition
+        logits_dtype = self.model.logits_processor.head_dtype or self.dtype
+        self._captured_markov_hidden = torch.empty(
+            max_markov_rows,
+            self.draft_model_config.get_hidden_size(),
+            dtype=self.dtype,
+            device=self.device,
+        )
+        self._captured_base_logits = torch.empty(
+            max_markov_rows,
+            local_vocab_size,
+            dtype=logits_dtype,
+            device=self.device,
+        )
+
     def _sample_logits(
         self,
         logits: torch.Tensor,
@@ -241,20 +279,28 @@ class DSparkSpeculator(DFlashSpeculator):
     def _sample_sequential(
         self,
         num_reqs: int,
-        head_hidden: torch.Tensor,
+        head_hidden: torch.Tensor | None,
         num_speculative_steps: int,
         num_query_per_req: int,
         is_profile: bool = False,
         use_capacity: bool = True,
+        prepared_sample_hidden: torch.Tensor | None = None,
+        precomputed_base_logits: torch.Tensor | None = None,
     ) -> None:
         # Sequential Markov sampling over the backbone's output hidden states.
         n_spec = num_speculative_steps
         num_sample = num_reqs * n_spec
         # Per-(req, position) head hidden, ordered (req, step).
-        sample_hidden = head_hidden[self.sample_indices[:num_sample]]
-        sample_hidden = sample_hidden.view(num_reqs, n_spec, -1)
+        if prepared_sample_hidden is None:
+            assert head_hidden is not None
+            sample_hidden = head_hidden[self.sample_indices[:num_sample]]
+            sample_hidden = sample_hidden.view(num_reqs, n_spec, -1)
+        else:
+            sample_hidden = prepared_sample_hidden.view(num_reqs, n_spec, -1)
         # Draft-vocab logits; sampled ids are remapped to target vocab below.
-        if self._use_local_draft_argmax:
+        if precomputed_base_logits is not None:
+            base_logits = precomputed_base_logits
+        elif self._use_local_draft_argmax:
             base_logits = self.model.compute_local_draft_logits(
                 sample_hidden.reshape(num_sample, -1)
             )
@@ -460,6 +506,7 @@ class DSparkSpeculator(DFlashSpeculator):
         cudagraph_runtime_mode: CUDAGraphMode = CUDAGraphMode.NONE,
         is_profile: bool = False,
         num_query_per_req: int | None = None,
+        capture_only: bool = False,
     ) -> None:
         if num_query_per_req is None:
             num_query_per_req = self.num_query_per_req
@@ -473,6 +520,24 @@ class DSparkSpeculator(DFlashSpeculator):
             num_tokens_across_dp,
             cudagraph_runtime_mode,
         )
+        if self._markov_outside_cudagraph and (
+            capture_only or torch.cuda.is_current_stream_capturing()
+        ):
+            self._ensure_captured_markov_buffers()
+            assert self._captured_markov_hidden is not None
+            assert self._captured_base_logits is not None
+            num_sample = num_reqs * num_speculative_steps
+            if num_sample > self._captured_markov_hidden.shape[0]:
+                raise ValueError(
+                    "DSpark graph handoff buffer is too small: "
+                    f"rows={num_sample}, "
+                    f"capacity={self._captured_markov_hidden.shape[0]}."
+                )
+            sample_hidden = head_hidden[self.sample_indices[:num_sample]]
+            base_logits = self.model.compute_local_draft_logits(sample_hidden)
+            self._captured_markov_hidden[:num_sample].copy_(sample_hidden)
+            self._captured_base_logits[:num_sample].copy_(base_logits)
+            return
         self._sample_sequential(
             num_reqs,
             head_hidden,
@@ -483,4 +548,32 @@ class DSparkSpeculator(DFlashSpeculator):
                 self.capacity_activation_batch_size <= 0
                 or num_reqs >= self.capacity_activation_batch_size
             ),
+        )
+
+    def _finish_captured_draft(
+        self,
+        *,
+        num_reqs: int,
+        num_tokens_padded: int,
+        num_query_per_req: int,
+        is_profile: bool,
+    ) -> None:
+        if not self._markov_outside_cudagraph:
+            return
+        assert self._captured_markov_hidden is not None
+        assert self._captured_base_logits is not None
+        num_speculative_steps = self._speculative_steps_for_query_len(num_query_per_req)
+        num_sample = num_reqs * num_speculative_steps
+        self._sample_sequential(
+            num_reqs,
+            None,
+            num_speculative_steps,
+            num_query_per_req,
+            is_profile=is_profile,
+            use_capacity=(
+                self.capacity_activation_batch_size <= 0
+                or num_reqs >= self.capacity_activation_batch_size
+            ),
+            prepared_sample_hidden=self._captured_markov_hidden[:num_sample],
+            precomputed_base_logits=self._captured_base_logits[:num_sample],
         )

--- a/vllm/v1/worker/gpu/spec_decode/dspark/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dspark/speculator.py
@@ -30,6 +30,7 @@ import torch
 import vllm.envs as envs
 from vllm.config import VllmConfig
 from vllm.config.compilation import CUDAGraphMode
+from vllm.logger import init_logger
 from vllm.triton_utils import triton
 from vllm.v1.worker.gpu.input_batch import InputBatch
 from vllm.v1.worker.gpu.spec_decode.dflash.speculator import DFlashSpeculator
@@ -39,6 +40,8 @@ from vllm.v1.worker.gpu.spec_decode.dspark.capacity import (
 )
 from vllm.v1.worker.gpu.spec_decode.dspark.online_sts import DSparkOnlineSTS
 from vllm.v1.worker.gpu.spec_decode.dspark.utils import load_dspark_model
+
+logger = init_logger(__name__)
 
 
 class DSparkSpeculator(DFlashSpeculator):
@@ -67,7 +70,15 @@ class DSparkSpeculator(DFlashSpeculator):
             self.max_num_tokens, draft_hidden, dtype=self.dtype, device=device
         )
 
-        self._markov_outside_cudagraph = envs.VLLM_DSPARK_SHARD_MARKOV_HEAD
+        self._capture_sharded_markov = envs.VLLM_DSPARK_CAPTURE_SHARDED_MARKOV
+        if self._capture_sharded_markov and not envs.VLLM_DSPARK_SHARD_MARKOV_HEAD:
+            raise ValueError(
+                "VLLM_DSPARK_CAPTURE_SHARDED_MARKOV requires "
+                "VLLM_DSPARK_SHARD_MARKOV_HEAD=1."
+            )
+        self._markov_outside_cudagraph = (
+            envs.VLLM_DSPARK_SHARD_MARKOV_HEAD and not self._capture_sharded_markov
+        )
         self._captured_markov_hidden: torch.Tensor | None = None
         self._captured_base_logits: torch.Tensor | None = None
 
@@ -210,6 +221,44 @@ class DSparkSpeculator(DFlashSpeculator):
                     "dspark_draft_topk."
                 )
             self._use_local_draft_argmax = True
+        if self._capture_sharded_markov:
+            if not getattr(model, "_b12x_dspark_argmax_enabled", False):
+                raise RuntimeError(
+                    "Captured TP-sharded Markov sampling requires B12X "
+                    "vocabulary argmax."
+                )
+            markov_head = model.model.markov_head
+            if not markov_head.replicate_w1:
+                from vllm.distributed.device_communicators.custom_all_reduce import (
+                    get_active_b12x_pcie_allreduce,
+                )
+
+                custom_allreduce = get_active_b12x_pcie_allreduce()
+                if custom_allreduce is None:
+                    raise RuntimeError(
+                        "Captured TP-sharded Markov sampling requires an active "
+                        "B12X TP all-reduce runtime."
+                    )
+                probe = torch.empty(
+                    self.max_num_reqs * self.num_speculative_steps,
+                    self.draft_model_config.hf_config.markov_rank,
+                    dtype=self.dtype,
+                    device=self.device,
+                )
+                if not custom_allreduce.should_custom_ar(probe):
+                    raise RuntimeError(
+                        "The active B12X TP all-reduce cannot capture the "
+                        f"Markov W1 output shape {tuple(probe.shape)}."
+                    )
+            logger.info_once(
+                "DSpark captures its TP-sharded Markov tail with B12X collectives."
+            )
+        elif self._markov_outside_cudagraph:
+            logger.info_once(
+                "DSpark keeps TP-sharded Markov collectives outside the draft "
+                "CUDA graph. The graph retains the draft backbone and local "
+                "base-logit projection."
+            )
         return model
 
     def _ensure_captured_markov_buffers(self) -> None:

--- a/vllm/v1/worker/gpu/spec_decode/dspark/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dspark/speculator.py
@@ -77,6 +77,7 @@ class DSparkSpeculator(DFlashSpeculator):
         self._draft_topk: int | None = getattr(
             self.draft_model_config.hf_config, "dspark_draft_topk", None
         )
+        self._use_local_draft_argmax = False
 
         self.draft_token_confidence_logits = torch.empty(
             self.max_num_reqs,
@@ -192,6 +193,19 @@ class DSparkSpeculator(DFlashSpeculator):
                 dtype=self.draft_logits.dtype,
                 device=self.device,
             )
+        if envs.VLLM_DSPARK_SHARD_MARKOV_HEAD:
+            supports_local_argmax = getattr(model, "supports_local_draft_argmax", None)
+            if supports_local_argmax is None or not supports_local_argmax():
+                raise RuntimeError(
+                    "A TP-sharded DSpark Markov head requires matching "
+                    "rank-local target and Markov vocabulary projections."
+                )
+            if self._draft_topk is not None:
+                raise ValueError(
+                    "TP-sharded DSpark Markov sampling does not support "
+                    "dspark_draft_topk."
+                )
+            self._use_local_draft_argmax = True
         return model
 
     def _sample_logits(
@@ -240,9 +254,14 @@ class DSparkSpeculator(DFlashSpeculator):
         sample_hidden = head_hidden[self.sample_indices[:num_sample]]
         sample_hidden = sample_hidden.view(num_reqs, n_spec, -1)
         # Draft-vocab logits; sampled ids are remapped to target vocab below.
-        base_logits = self.model.compute_draft_logits(
-            sample_hidden.reshape(num_sample, -1)
-        )
+        if self._use_local_draft_argmax:
+            base_logits = self.model.compute_local_draft_logits(
+                sample_hidden.reshape(num_sample, -1)
+            )
+        else:
+            base_logits = self.model.compute_draft_logits(
+                sample_hidden.reshape(num_sample, -1)
+            )
         vocab_size = base_logits.shape[-1]
         base_logits = base_logits.view(num_reqs, n_spec, vocab_size)
         base_values = draft_indices = None
@@ -279,7 +298,24 @@ class DSparkSpeculator(DFlashSpeculator):
                     )
                 confidence_logits[:, i] = confidence_i
             if draft_indices is None:
-                logits_i = base_logits[:, i] + self.model.markov_bias(markov_embed)
+                if self._use_local_draft_argmax:
+                    markov_bias = self.model.compute_local_markov_bias(markov_embed)
+                    if self.draft_logits is None:
+                        draft_sampled_i = self.model.sample_local_draft_logits(
+                            base_logits[:, i], markov_bias
+                        )
+                    else:
+                        logits_i = self.model.gather_local_draft_logits(
+                            base_logits[:, i], markov_bias
+                        )
+                        draft_sampled_i = self._sample_logits(
+                            logits_i, idx_map[:, i], sample_pos[:, i], i
+                        )
+                else:
+                    logits_i = base_logits[:, i] + self.model.markov_bias(markov_embed)
+                    draft_sampled_i = self._sample_logits(
+                        logits_i, idx_map[:, i], sample_pos[:, i], i
+                    )
             else:
                 assert base_values is not None
                 logits_i = self.model.apply_markov_bias_gathered(
@@ -288,9 +324,9 @@ class DSparkSpeculator(DFlashSpeculator):
                     base_values[:, i],
                     draft_indices[:, i],
                 )
-            draft_sampled_i = self._sample_logits(
-                logits_i, idx_map[:, i], sample_pos[:, i], i
-            )
+                draft_sampled_i = self._sample_logits(
+                    logits_i, idx_map[:, i], sample_pos[:, i], i
+                )
             valid_prefix.logical_and_(
                 (draft_sampled_i >= 0) & (draft_sampled_i < self.vocab_size)
             )


### PR DESCRIPTION
## Status

Implemented. This pull request requires local-inference-lab/b12x#217. End-to-end acceptance and throughput qualification is tracked by local-inference-lab/rtx6kpro#66.

## Behavior

- Selects local vocabulary maxima from the sharded DSpark Markov head.
- Computes the exact global greedy token through the B12X CuTeDSL vocabulary-parallel argmax.
- Samples DSpark proposals without assembling full-vocabulary logits on every rank.
- Masks base-vocabulary padding before distributed selection, including Kimi-K3's TP12 layout.
- Runs the sharded Markov tail after graph replay when required.
- Captures eligible sharded Markov sampling work with the active B12X all-reduce runtime.

## Technical reason

A replicated DSpark Markov vocabulary head costs several GiB per GPU. Sharding that head requires exact distributed argmax and graph-lifecycle handling; otherwise memory savings either change token selection or introduce an uncaptured decode tail. TP12 pads the 163,840-token vocabulary to 163,968 rows, so padded rows must be excluded without rejecting the otherwise compatible rank-major layout.

## Compatibility

The runtime supports TP8, TP12, and TP16 through the B12X vocabulary argmax. Base-only padded vocabularies retain globally contiguous token indices; added-vocabulary layouts remain excluded because their padding is interleaved. The runtime retains an exact full-vocabulary all-gather fallback. Non-greedy or unsupported sampling configurations use the fallback instead of the sharded argmax path.

## Validation

- The original focused local-vocabulary sampling, post-graph tail, captured Markov, and exact tie-handling tests passed before the TP12 padding correction.
- B12X #217 supports TP8, TP12, and TP16 with batches one through eight.
- `git range-diff` reports patch equivalence for the four original commits after rebasing onto `dev/infernal-invocation`.
- The TP12 padding regression test was added but not executed, per the requested accelerated review. An automatic commit hook ran Ruff successfully and reported mypy errors; those annotations were corrected and the hook was not rerun.

AI assistance was used to review, rebase, and correct this pull request. The human submitter is responsible for reviewing the resulting diff and validation evidence.
