### PR TITLE
Select the B12X all-reduce limit by tensor-parallel size

### DIFF
--- a/tests/distributed/test_b12x_fused_all_reduce.py
+++ b/tests/distributed/test_b12x_fused_all_reduce.py
@@ -29,6 +29,7 @@ from vllm.distributed import tensor_model_parallel_all_reduce
 from vllm.distributed.device_communicators import custom_all_reduce
 from vllm.distributed.device_communicators.custom_all_reduce import (
     CustomAllreduce,
+    _b12x_pcie_allreduce_max_size,
     _b12x_pcie_dma_min_bytes,
     _b12x_pcie_oneshot_limits,
     get_b12x_pcie_allreduce,
@@ -425,11 +426,59 @@ def test_b12x_oneshot_buffer_tracks_dispatch_limits(
         "84KB",
     )
 
-    assert _b12x_pcie_oneshot_limits() == (
+    assert _b12x_pcie_oneshot_limits(16) == (
         64 * 1024,
         84 * 1024,
         84 * 1024,
     )
+
+
+def test_b12x_allreduce_limit_uses_world_size_policy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("VLLM_PCIE_ONESHOT_ALLREDUCE_MAX_SIZE", raising=False)
+    recommender = MagicMock(return_value=160 * 1024)
+    monkeypatch.setattr(
+        custom_all_reduce,
+        "_load_b12x_pcie_recommended_max_bytes",
+        lambda: recommender,
+    )
+
+    assert _b12x_pcie_allreduce_max_size(16) == 160 * 1024
+    assert _b12x_pcie_oneshot_limits(16) == (
+        160 * 1024,
+        84 * 1024,
+        160 * 1024,
+    )
+    recommender.assert_called_with(16, default=84 * 1024)
+
+
+def test_b12x_allreduce_limit_preserves_explicit_operator_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VLLM_PCIE_ONESHOT_ALLREDUCE_MAX_SIZE", "64KB")
+    recommender = MagicMock(return_value=160 * 1024)
+    monkeypatch.setattr(
+        custom_all_reduce,
+        "_load_b12x_pcie_recommended_max_bytes",
+        lambda: recommender,
+    )
+
+    assert _b12x_pcie_allreduce_max_size(16) == 64 * 1024
+    recommender.assert_not_called()
+
+
+def test_b12x_allreduce_limit_uses_vllm_default_without_b12x_policy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("VLLM_PCIE_ONESHOT_ALLREDUCE_MAX_SIZE", raising=False)
+    monkeypatch.setattr(
+        custom_all_reduce,
+        "_load_b12x_pcie_recommended_max_bytes",
+        lambda: None,
+    )
+
+    assert _b12x_pcie_allreduce_max_size(16) == 84 * 1024
 
 
 def test_b12x_dma_min_bytes_is_configurable(

--- a/tests/distributed/test_b12x_fused_all_reduce.py
+++ b/tests/distributed/test_b12x_fused_all_reduce.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import builtins
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -32,6 +33,7 @@ from vllm.distributed.device_communicators.custom_all_reduce import (
     _b12x_pcie_allreduce_max_size,
     _b12x_pcie_dma_min_bytes,
     _b12x_pcie_oneshot_limits,
+    _load_b12x_pcie_recommended_max_bytes,
     get_b12x_pcie_allreduce,
 )
 from vllm.distributed.parallel_state import get_tp_group, graph_capture
@@ -479,6 +481,39 @@ def test_b12x_allreduce_limit_uses_vllm_default_without_b12x_policy(
     )
 
     assert _b12x_pcie_allreduce_max_size(16) == 84 * 1024
+
+
+def test_b12x_policy_loader_accepts_absent_optional_package(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_import = builtins.__import__
+
+    def import_without_b12x(name, *args, **kwargs):
+        if name == "b12x.comm.pcie.pcie_allreduce":
+            raise ModuleNotFoundError("No module named 'b12x'", name="b12x")
+        return original_import(name, *args, **kwargs)
+
+    _load_b12x_pcie_recommended_max_bytes.cache_clear()
+    monkeypatch.setattr(builtins, "__import__", import_without_b12x)
+    assert _load_b12x_pcie_recommended_max_bytes() is None
+    _load_b12x_pcie_recommended_max_bytes.cache_clear()
+
+
+def test_b12x_policy_loader_surfaces_broken_dependency(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_import = builtins.__import__
+
+    def import_with_broken_dependency(name, *args, **kwargs):
+        if name == "b12x.comm.pcie.pcie_allreduce":
+            raise ModuleNotFoundError("No module named 'cutlass'", name="cutlass")
+        return original_import(name, *args, **kwargs)
+
+    _load_b12x_pcie_recommended_max_bytes.cache_clear()
+    monkeypatch.setattr(builtins, "__import__", import_with_broken_dependency)
+    with pytest.raises(ModuleNotFoundError, match="cutlass"):
+        _load_b12x_pcie_recommended_max_bytes()
+    _load_b12x_pcie_recommended_max_bytes.cache_clear()
 
 
 def test_b12x_dma_min_bytes_is_configurable(

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -96,8 +96,44 @@ def _parse_byte_size(value: str) -> int:
     return int(value)
 
 
-def _b12x_pcie_oneshot_limits() -> tuple[int, int, int]:
-    allreduce_max_size = _parse_byte_size(envs.VLLM_PCIE_ONESHOT_ALLREDUCE_MAX_SIZE)
+@lru_cache(maxsize=1)
+def _load_b12x_pcie_recommended_max_bytes() -> Any | None:
+    try:
+        from b12x.comm.pcie.pcie_allreduce import recommended_max_bytes
+    except Exception:
+        return None
+    return recommended_max_bytes
+
+
+def _b12x_pcie_allreduce_max_size(world_size: int) -> int:
+    """Resolve the custom all-reduce limit from operator and B12X policy.
+
+    An explicitly configured vLLM limit has priority. Otherwise B12X may
+    enlarge the vLLM default only for tensor-parallel sizes with a qualified
+    implementation for the additional message-size band.
+    """
+
+    configured = os.getenv("VLLM_PCIE_ONESHOT_ALLREDUCE_MAX_SIZE")
+    if configured is not None:
+        return _parse_byte_size(configured)
+    default = _parse_byte_size(envs.VLLM_PCIE_ONESHOT_ALLREDUCE_MAX_SIZE)
+    recommended_max_bytes = _load_b12x_pcie_recommended_max_bytes()
+    if recommended_max_bytes is None:
+        return default
+    resolved = int(recommended_max_bytes(world_size, default=default))
+    if resolved != default:
+        logger.info(
+            "B12X selected a %d-byte PCIe all-reduce limit for TP%d; "
+            "the vLLM default is %d bytes.",
+            resolved,
+            world_size,
+            default,
+        )
+    return resolved
+
+
+def _b12x_pcie_oneshot_limits(world_size: int) -> tuple[int, int, int]:
+    allreduce_max_size = _b12x_pcie_allreduce_max_size(world_size)
     fused_max_size = _parse_byte_size(
         envs.VLLM_PCIE_ONESHOT_FUSED_ADD_RMS_NORM_MAX_SIZE
     )
@@ -554,7 +590,7 @@ class CustomAllreduce:
                 self._pcie_allreduce_max_size,
                 self._pcie_fused_add_rms_norm_max_size,
                 pcie_oneshot_buffer_size,
-            ) = _b12x_pcie_oneshot_limits()
+            ) = _b12x_pcie_oneshot_limits(world_size)
             if self.nccl_group is None:
                 logger.warning(
                     "Custom allreduce is disabled because %s PCIe oneshot "

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -100,7 +100,9 @@ def _parse_byte_size(value: str) -> int:
 def _load_b12x_pcie_recommended_max_bytes() -> Any | None:
     try:
         from b12x.comm.pcie.pcie_allreduce import recommended_max_bytes
-    except Exception:
+    except ModuleNotFoundError as exc:
+        if exc.name != "b12x":
+            raise
         return None
     return recommended_max_bytes
 
@@ -111,6 +113,12 @@ def _b12x_pcie_allreduce_max_size(world_size: int) -> int:
     An explicitly configured vLLM limit has priority. Otherwise B12X may
     enlarge the vLLM default only for tensor-parallel sizes with a qualified
     implementation for the additional message-size band.
+
+    Args:
+        world_size: Active tensor-parallel world size.
+
+    Returns:
+        Resolved maximum all-reduce size in bytes.
     """
 
     configured = os.getenv("VLLM_PCIE_ONESHOT_ALLREDUCE_MAX_SIZE")


### PR DESCRIPTION
## Status

**Implemented and unit-qualified.** This pull request targets `dev/infernal-invocation`; the DCP collective dependency from #384 is merged. It requires `local-inference-lab/b12x#220` for the TP16 island reduce-scatter size policy.

## Behavior

- Uses an explicitly configured `VLLM_PCIE_ONESHOT_ALLREDUCE_MAX_SIZE` without consulting B12X.
- Otherwise asks B12X for the largest qualified custom-all-reduce message size for the active tensor-parallel world size.
- Retains the 84 KiB vLLM default when B12X is unavailable or does not provide a wider qualified band.
- Allocates the B12X IPC buffer from the resolved all-reduce and fused all-reduce/RMSNorm limits.
- Logs a world-size-specific limit selected by B12X.

## Technical reason

B12X owns the mapping between tensor-parallel topology, collective implementation, and measured message-size crossover. A global vLLM constant cannot expose the TP16 160 KiB island reduce-scatter band without also widening unsupported TP sizes.

## Compatibility

Operator configuration remains authoritative. TP2 through TP12 retain their B12X-recommended or vLLM-default limit. Environments without B12X preserve the vLLM default. An absent optional B12X package retains the vLLM default; a broken installed B12X policy import is reported instead of being silently ignored.

## Validation

- Ruff lint and format checks passed for both changed files.
- Five focused size-policy and import-contract tests passed in the CUDA 13.3, PyTorch 2.13 Kimi-K3 runtime image.
- Tests cover TP-aware recommendation, explicit operator override, missing B12X policy, broken dependency propagation, and IPC buffer sizing.
- `git range-diff` reports patch equivalence for both commits before and after restacking on merged `dev/infernal-invocation`.
- Full-model Kimi-K3 no-speculative, DSpark, and DFlash qualification is tracked by `local-inference-lab/rtx6kpro#66`.

## AI assistance

Implementation, validation, and pull-request text were produced with AI assistance. The committed tests define configuration precedence and compatibility behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved PCIe all-reduce limit selection based on tensor-parallel world size.
  * Added support for B12X-recommended limits when available.
  * Explicit environment-based limits continue to take precedence.

* **Bug Fixes**
  * Added fallback to the standard default limit when no B12X recommendation is available.

* **Tests**
  * Expanded coverage for world-size policies, explicit overrides, and default-limit fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
