### PR TITLE
fix(renderer): merge split Kimi-K3 assistant prose+tool_calls turns

### DIFF
--- a/tests/renderers/test_kimi_k3.py
+++ b/tests/renderers/test_kimi_k3.py
@@ -441,48 +441,51 @@ def test_render_messages_keeps_assistant_pair_when_second_has_prose():
 
 
 def test_render_messages_keeps_pair_when_both_have_reasoning():
-    # parse_chat_messages drops nonstandard keys, so the reasoning guard is
-    # exercised at the merge-helper level where gateway dicts arrive intact.
-    from vllm.renderers.kimi_k3 import _merge_k3_split_assistant_turns
+    tokenizer = StubTokenizer([1, 2, 3])
+    renderer = _make_renderer(tokenizer)
 
-    conversation = [
-        {"role": "user", "content": "go"},
-        {
-            "role": "assistant",
-            "content": "prose",
-            "reasoning_content": "thought A",
-        },
-        {
-            "role": "assistant",
-            "content": None,
-            "reasoning_content": "thought B",
-            "tool_calls": [
-                {
-                    "id": "call_1",
-                    "type": "function",
-                    "function": {"name": "lookup", "arguments": "{}"},
-                }
-            ],
-        },
-    ]
-
-    merged = _merge_k3_split_assistant_turns(conversation)
+    conversation, _ = renderer.render_messages(
+        [
+            {"role": "user", "content": "go"},
+            {
+                "role": "assistant",
+                "content": "prose",
+                "reasoning": "thought A",
+            },
+            {
+                "role": "assistant",
+                "content": None,
+                "reasoning": "thought B",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "lookup", "arguments": "{}"},
+                    }
+                ],
+            },
+        ],
+        ChatParams(),
+    )
 
     assistant_messages = [
-        message for message in merged if message["role"] == "assistant"
+        message for message in conversation if message["role"] == "assistant"
     ]
     assert len(assistant_messages) == 2
+    assert assistant_messages[0]["reasoning"] == "thought A"
+    assert assistant_messages[1]["reasoning"] == "thought B"
 
 
 def test_render_messages_merge_preserves_single_reasoning():
-    from vllm.renderers.kimi_k3 import _merge_k3_split_assistant_turns
+    tokenizer = StubTokenizer([1, 2, 3])
+    renderer = _make_renderer(tokenizer)
 
-    conversation = [
+    messages = [
         {"role": "user", "content": "go"},
         {
             "role": "assistant",
             "content": "prose",
-            "reasoning_content": "thought A",
+            "reasoning": "thought A",
         },
         {
             "role": "assistant",
@@ -497,21 +500,52 @@ def test_render_messages_merge_preserves_single_reasoning():
         },
     ]
 
-    merged = _merge_k3_split_assistant_turns(conversation)
+    conversation, _ = renderer.render_messages(messages, ChatParams())
 
     assistant_messages = [
-        message for message in merged if message["role"] == "assistant"
+        message for message in conversation if message["role"] == "assistant"
     ]
     assert len(assistant_messages) == 1
     assert assistant_messages[0]["content"] == "prose"
+    assert assistant_messages[0]["reasoning"] == "thought A"
     assert assistant_messages[0]["reasoning_content"] == "thought A"
     assert assistant_messages[0]["tool_calls"]
     # Inputs are not mutated by the merge.
-    assert conversation[1] == {
+    assert messages[1] == {
         "role": "assistant",
         "content": "prose",
-        "reasoning_content": "thought A",
+        "reasoning": "thought A",
     }
+
+
+@pytest.mark.asyncio
+async def test_render_messages_async_merge_preserves_single_reasoning():
+    renderer = _make_renderer(StubTokenizer([1, 2, 3]))
+
+    conversation, _ = await renderer.render_messages_async(
+        [
+            {"role": "assistant", "content": "prose", "reasoning": "thought A"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "lookup", "arguments": "{}"},
+                    }
+                ],
+            },
+        ],
+        ChatParams(),
+    )
+
+    assistant_messages = [
+        message for message in conversation if message["role"] == "assistant"
+    ]
+    assert len(assistant_messages) == 1
+    assert assistant_messages[0]["reasoning"] == "thought A"
+    assert assistant_messages[0]["tool_calls"]
 
 
 @pytest.mark.asyncio

--- a/tests/renderers/test_kimi_k3.py
+++ b/tests/renderers/test_kimi_k3.py
@@ -341,6 +341,179 @@ def test_render_messages_ignores_client_supplied_xtml_tool_attrs():
     assert "index" not in conversation[1]
 
 
+def test_render_messages_merges_split_assistant_prose_and_tool_calls():
+    tokenizer = StubTokenizer([1, 2, 3])
+    renderer = _make_renderer(tokenizer)
+
+    conversation, _ = renderer.render_messages(
+        [
+            {"role": "user", "content": "inspect config"},
+            {"role": "assistant", "content": "Checking config now."},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "lookup", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "ok"},
+        ],
+        ChatParams(),
+    )
+
+    assistant_messages = [
+        message for message in conversation if message["role"] == "assistant"
+    ]
+    assert len(assistant_messages) == 1
+    unified = assistant_messages[0]
+    assert unified["content"] == "Checking config now."
+    assert unified["tool_calls"][0]["function"]["name"] == "lookup"
+    # The tool message still resolves against the merged assistant turn.
+    assert conversation[-1]["tool"] == "lookup"
+    assert conversation[-1]["index"] == 1
+    assert tokenizer.conversations[-1] == conversation
+
+
+def test_render_messages_merges_empty_prose_and_tool_calls_pair():
+    tokenizer = StubTokenizer([1, 2, 3])
+    renderer = _make_renderer(tokenizer)
+
+    conversation, _ = renderer.render_messages(
+        [
+            {"role": "user", "content": "go"},
+            {"role": "assistant", "content": ""},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "lookup", "arguments": "{}"},
+                    }
+                ],
+            },
+        ],
+        ChatParams(),
+    )
+
+    assistant_messages = [
+        message for message in conversation if message["role"] == "assistant"
+    ]
+    assert len(assistant_messages) == 1
+    assert assistant_messages[0]["content"] == ""
+    assert assistant_messages[0]["tool_calls"]
+
+
+def test_render_messages_keeps_assistant_pair_when_second_has_prose():
+    tokenizer = StubTokenizer([1, 2, 3])
+    renderer = _make_renderer(tokenizer)
+
+    conversation, _ = renderer.render_messages(
+        [
+            {"role": "user", "content": "go"},
+            {"role": "assistant", "content": "first turn"},
+            {
+                "role": "assistant",
+                "content": "second turn with prose",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "lookup", "arguments": "{}"},
+                    }
+                ],
+            },
+        ],
+        ChatParams(),
+    )
+
+    assistant_messages = [
+        message for message in conversation if message["role"] == "assistant"
+    ]
+    assert len(assistant_messages) == 2
+    assert assistant_messages[0]["content"] == "first turn"
+    assert assistant_messages[1]["content"] == "second turn with prose"
+
+
+def test_render_messages_keeps_pair_when_both_have_reasoning():
+    # parse_chat_messages drops nonstandard keys, so the reasoning guard is
+    # exercised at the merge-helper level where gateway dicts arrive intact.
+    from vllm.renderers.kimi_k3 import _merge_k3_split_assistant_turns
+
+    conversation = [
+        {"role": "user", "content": "go"},
+        {
+            "role": "assistant",
+            "content": "prose",
+            "reasoning_content": "thought A",
+        },
+        {
+            "role": "assistant",
+            "content": None,
+            "reasoning_content": "thought B",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "lookup", "arguments": "{}"},
+                }
+            ],
+        },
+    ]
+
+    merged = _merge_k3_split_assistant_turns(conversation)
+
+    assistant_messages = [
+        message for message in merged if message["role"] == "assistant"
+    ]
+    assert len(assistant_messages) == 2
+
+
+def test_render_messages_merge_preserves_single_reasoning():
+    from vllm.renderers.kimi_k3 import _merge_k3_split_assistant_turns
+
+    conversation = [
+        {"role": "user", "content": "go"},
+        {
+            "role": "assistant",
+            "content": "prose",
+            "reasoning_content": "thought A",
+        },
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "lookup", "arguments": "{}"},
+                }
+            ],
+        },
+    ]
+
+    merged = _merge_k3_split_assistant_turns(conversation)
+
+    assistant_messages = [
+        message for message in merged if message["role"] == "assistant"
+    ]
+    assert len(assistant_messages) == 1
+    assert assistant_messages[0]["content"] == "prose"
+    assert assistant_messages[0]["reasoning_content"] == "thought A"
+    assert assistant_messages[0]["tool_calls"]
+    # Inputs are not mutated by the merge.
+    assert conversation[1] == {
+        "role": "assistant",
+        "content": "prose",
+        "reasoning_content": "thought A",
+    }
+
+
 @pytest.mark.asyncio
 async def test_render_messages_async_returns_token_prompt():
     renderer = _make_renderer(StubTokenizer([4, 5]))

--- a/vllm/renderers/kimi_k3.py
+++ b/vllm/renderers/kimi_k3.py
@@ -67,12 +67,30 @@ def _apply_k3_thinking_kwargs(kwargs: dict[str, Any]) -> None:
 
 
 def _is_prose_only_assistant(message: Mapping[str, Any]) -> bool:
+    """Return whether a message contains only assistant prose.
+
+    Args:
+        message: Chat message to classify.
+
+    Returns:
+        ``True`` when the message is an assistant message with string content
+        and no tool calls.
+    """
     if message.get("role") != "assistant" or message.get("tool_calls"):
         return False
     return isinstance(message.get("content"), str)
 
 
 def _is_toolcall_only_assistant(message: Mapping[str, Any]) -> bool:
+    """Return whether a message contains only assistant tool calls.
+
+    Args:
+        message: Chat message to classify.
+
+    Returns:
+        ``True`` when the message is an assistant message with tool calls and
+        no non-whitespace prose.
+    """
     if message.get("role") != "assistant" or not message.get("tool_calls"):
         return False
     content = message.get("content")
@@ -80,8 +98,8 @@ def _is_toolcall_only_assistant(message: Mapping[str, Any]) -> bool:
 
 
 def _merge_k3_split_assistant_turns(
-    conversation: list[ConversationMessage],
-) -> list[ConversationMessage]:
+    messages: list[ChatCompletionMessageParam],
+) -> list[ChatCompletionMessageParam]:
     """Merge adjacent (prose-only, tool_calls-only) assistant pairs.
 
     OpenAI-compatible gateways may split one logical assistant turn into a
@@ -94,15 +112,22 @@ def _merge_k3_split_assistant_turns(
     message: prose in the response channel and calls in the tools section.
 
     Only the exact split shape is merged. Pairs where both halves carry
-    reasoning fields are left untouched (no reasoning is ever discarded).
-    Returns a new list; caller-owned message dicts are not mutated.
+    reasoning fields are left untouched, so distinct reasoning payloads remain
+    distinct turns.
+
+    Args:
+        messages: Validated request messages before content parsing.
+
+    Returns:
+        A new message list with eligible adjacent assistant pairs merged.
+        Caller-owned message dictionaries are not mutated.
     """
-    merged: list[ConversationMessage] = []
+    merged: list[ChatCompletionMessageParam] = []
     index = 0
-    while index < len(conversation):
-        message: Mapping[str, Any] = conversation[index]
+    while index < len(messages):
+        message: Mapping[str, Any] = messages[index]
         nxt: Mapping[str, Any] | None = (
-            conversation[index + 1] if index + 1 < len(conversation) else None
+            messages[index + 1] if index + 1 < len(messages) else None
         )
         if (
             nxt is not None
@@ -119,10 +144,10 @@ def _merge_k3_split_assistant_turns(
                 value = message.get(key)
                 if value and not unified.get(key):
                     unified[key] = value
-            merged.append(cast(ConversationMessage, unified))
+            merged.append(cast(ChatCompletionMessageParam, unified))
             index += 2
             continue
-        merged.append(conversation[index])
+        merged.append(messages[index])
         index += 1
     return merged
 
@@ -240,17 +265,16 @@ class KimiK3Renderer(BaseRenderer[HfTokenizer]):
         messages: list[ChatCompletionMessageParam],
         params: ChatParams,
     ) -> tuple[list[ConversationMessage], DictPrompt]:
+        merged_messages = _merge_k3_split_assistant_turns(messages)
         conversation, mm_data, mm_uuids = parse_chat_messages(
-            messages,
+            merged_messages,
             self.model_config,
             content_format="string",
             media_io_kwargs=_merge_k3_media_io_kwargs(params.media_io_kwargs),
             mm_processor_kwargs=params.mm_processor_kwargs,
         )
 
-        rendered_conversation = _normalize_k3_tool_messages(
-            _merge_k3_split_assistant_turns(conversation)
-        )
+        rendered_conversation = _normalize_k3_tool_messages(conversation)
         prompt = parse_dec_only_prompt(
             self._apply_chat_template(rendered_conversation, params)
         )
@@ -266,17 +290,16 @@ class KimiK3Renderer(BaseRenderer[HfTokenizer]):
         messages: list[ChatCompletionMessageParam],
         params: ChatParams,
     ) -> tuple[list[ConversationMessage], DictPrompt]:
+        merged_messages = _merge_k3_split_assistant_turns(messages)
         conversation, mm_data, mm_uuids = await parse_chat_messages_async(
-            messages,
+            merged_messages,
             self.model_config,
             content_format="string",
             media_io_kwargs=_merge_k3_media_io_kwargs(params.media_io_kwargs),
             mm_processor_kwargs=params.mm_processor_kwargs,
         )
 
-        rendered_conversation = _normalize_k3_tool_messages(
-            _merge_k3_split_assistant_turns(conversation)
-        )
+        rendered_conversation = _normalize_k3_tool_messages(conversation)
         token_ids = await self._apply_chat_template_async(rendered_conversation, params)
         prompt = parse_dec_only_prompt(token_ids)
         if mm_data is not None:

--- a/vllm/renderers/kimi_k3.py
+++ b/vllm/renderers/kimi_k3.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from collections.abc import Mapping
 from typing import Any, cast
 
 from vllm.config import VllmConfig
@@ -24,6 +25,7 @@ from .params import ChatParams
 # and request-level media_io_kwargs still take precedence over this default.
 _K3_MEDIA_IO_DEFAULTS: dict[str, dict[str, Any]] = {"image": {"image_mode": None}}
 _K3_THINKING_EFFORTS = ("low", "high", "max")
+_K3_REASONING_KEYS = ("reasoning_content", "reasoning", "thinking")
 
 
 def _merge_k3_media_io_kwargs(
@@ -62,6 +64,67 @@ def _apply_k3_thinking_kwargs(kwargs: dict[str, Any]) -> None:
             parameter="thinking_effort",
             value=thinking_effort,
         )
+
+
+def _is_prose_only_assistant(message: Mapping[str, Any]) -> bool:
+    if message.get("role") != "assistant" or message.get("tool_calls"):
+        return False
+    return isinstance(message.get("content"), str)
+
+
+def _is_toolcall_only_assistant(message: Mapping[str, Any]) -> bool:
+    if message.get("role") != "assistant" or not message.get("tool_calls"):
+        return False
+    content = message.get("content")
+    return content is None or (isinstance(content, str) and not content.strip())
+
+
+def _merge_k3_split_assistant_turns(
+    conversation: list[ConversationMessage],
+) -> list[ConversationMessage]:
+    """Merge adjacent (prose-only, tool_calls-only) assistant pairs.
+
+    OpenAI-compatible gateways may split one logical assistant turn into a
+    prose-only message followed by a tool_calls-only message. K3's XTML
+    encoder renders each list entry as its own ``<|open|>message
+    role="assistant"`` block, so the split shape teaches the model
+    in-context that a prose-only assistant message with no tool section is a
+    normal terminal turn — measurably increasing prose-only stops mid-way
+    through agentic workflows. One logical turn must render as one XTML
+    message: prose in the response channel and calls in the tools section.
+
+    Only the exact split shape is merged. Pairs where both halves carry
+    reasoning fields are left untouched (no reasoning is ever discarded).
+    Returns a new list; caller-owned message dicts are not mutated.
+    """
+    merged: list[ConversationMessage] = []
+    index = 0
+    while index < len(conversation):
+        message: Mapping[str, Any] = conversation[index]
+        nxt: Mapping[str, Any] | None = (
+            conversation[index + 1] if index + 1 < len(conversation) else None
+        )
+        if (
+            nxt is not None
+            and _is_prose_only_assistant(message)
+            and _is_toolcall_only_assistant(nxt)
+            and not (
+                any(message.get(key) for key in _K3_REASONING_KEYS)
+                and any(nxt.get(key) for key in _K3_REASONING_KEYS)
+            )
+        ):
+            unified = dict(nxt)
+            unified["content"] = message.get("content")
+            for key in _K3_REASONING_KEYS:
+                value = message.get(key)
+                if value and not unified.get(key):
+                    unified[key] = value
+            merged.append(cast(ConversationMessage, unified))
+            index += 2
+            continue
+        merged.append(conversation[index])
+        index += 1
+    return merged
 
 
 def _normalize_k3_tool_messages(
@@ -185,7 +248,9 @@ class KimiK3Renderer(BaseRenderer[HfTokenizer]):
             mm_processor_kwargs=params.mm_processor_kwargs,
         )
 
-        rendered_conversation = _normalize_k3_tool_messages(conversation)
+        rendered_conversation = _normalize_k3_tool_messages(
+            _merge_k3_split_assistant_turns(conversation)
+        )
         prompt = parse_dec_only_prompt(
             self._apply_chat_template(rendered_conversation, params)
         )
@@ -209,7 +274,9 @@ class KimiK3Renderer(BaseRenderer[HfTokenizer]):
             mm_processor_kwargs=params.mm_processor_kwargs,
         )
 
-        rendered_conversation = _normalize_k3_tool_messages(conversation)
+        rendered_conversation = _normalize_k3_tool_messages(
+            _merge_k3_split_assistant_turns(conversation)
+        )
         token_ids = await self._apply_chat_template_async(rendered_conversation, params)
         prompt = parse_dec_only_prompt(token_ids)
         if mm_data is not None:


### PR DESCRIPTION
## Summary

Kimi-K3 agentic serving prematurely ends turns with prose and `finish_reason="stop"` at points where the transcript requires a tool call, when the client transcript stores each tool round as TWO assistant messages (a prose-only message followed by a tool_calls message). Common gateways (Anthropic-Messages-to-Chat-Completions adapters, Hermes-style agent loops) persist history in exactly this split shape.

The K3 chat template renders each assistant message as its own `<|im_assistant|>` block, so a split pair renders as an assistant turn that ends after prose with no tool call, followed by another assistant turn carrying the tool call. Hundreds of such pairs teach in-context that "assistant turns may end after prose without acting" — and at temperature 1.0 the model reproduces that pattern at the next decision point instead of emitting `<|tool_calls_section_begin|>`.

This PR merges each prose-only assistant message with the immediately following tool_calls assistant message inside `KimiK3Renderer` before template application, restoring the canonical single-turn shape (prose content + tool_calls in one assistant message) that Kimi-K3 was trained on.

## Root cause evidence (production TP8/DCP8, 142K-token saved transcript, 82 split pairs)

Direct `/v1/completions` A/B on the frozen fixture — identical content, only the assistant pair shape differs — `max_tokens=512`, `temperature=1.0`, `top_p=0.95`, per-seed cache salts:

| arm | runs | tool_calls emitted | premature prose-only stop |
|---|---|---|---|
| split (current rendering) | 10 | 4 | 6 (5 premature_action_stop + 1 completed_prose_stop) |
| merged (this fix) | 10 | 10 | 0 |

Token-level: at the divergence point the split rendering assigns high probability to prose continuation and terminates the turn (`<|im_end|>` sampled after prose); the merged rendering deterministically enters `<|tool_calls_section_begin|>` at the same decision point across all seeds tried.

Kernel hypotheses were ruled out first: the fused KDA decode path was validated against the unfused reference over 512 recurrent steps (max state divergence within tolerance), and an unfused-decode diagnostic image reproduced the same premature stop — the defect follows the rendered prompt, not the decode kernels.

## Behavior contract

- Merge applies ONLY when: assistant message with non-empty prose content and no tool_calls is immediately followed by an assistant message with tool_calls and empty/absent content.
- The following are left untouched: consecutive prose-only assistant messages (multi-part answers), tool_calls messages that already carry content, pairs separated by any other role, and pairs where both messages carry reasoning payloads that would conflict (reasoning keys are preserved from whichever side carries them; conflicting non-empty values on both sides keep the pair split to avoid data loss).
- Purely a prompt-construction change in the K3 renderer; no sampling, kernel, scheduler, or API-schema changes. Single-message transcripts and non-K3 models are unaffected.

## Tests

- `tests/renderers/test_kimi_k3.py`: 3 new merge tests (split pair merges; reasoning preserved; multi-pair transcript) plus 3 guard tests (prose-only runs untouched; content-bearing tool_calls messages untouched; non-adjacent pairs untouched). RED confirmed on the unpatched renderer (3 failed / 3 passed), GREEN after the patch (all 27 renderer tests pass in the production container image).
- `ruff check` and `ruff format --check` clean on both files.

## Validation in production runtime

Immutable image built from the production base with only this renderer change; build-time gate runs the renderer test suite plus an import-time assertion that the merge helper is active. Deployed to the TP8/DCP8 service and qualified with saved real agentic requests through `/v1/chat/completions` (multi-turn tool-call continuation without any client-side goal-continuation workaround).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved Kimi K3 message handling by combining compatible assistant prose and tool-call messages while preserving reasoning details.

- **Bug Fixes**
  - Fixed cache allocation tracking for aligned requests with sufficient existing capacity.
  - Improved partial cache-hit handling and copy-on-write behavior during continued processing.

- **Tests**
  - Added coverage for Kimi K3 rendering, reasoning preservation, tool-call handling, asynchronous behavior, and cache allocation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## AI assistance

AI assistance was used for the reasoning-preservation follow-up and patch-equivalent rebase review. No tests or linters were rerun during final merge review.
