### PR TITLE
[EXL3] share one reconstruct-scratch arena across dense prefill geometries

### DIFF
--- a/docs/features/quantization/online.md
+++ b/docs/features/quantization/online.md
@@ -100,7 +100,7 @@ vllm serve <glm-5.2-modelopt-checkpoint> \
 Serialized checkpoint-quantized shared experts are preserved; only excluded
 BF16 projection weights are converted at load time.
 
-### MXFP8 dense linears on ModelOpt checkpoints
+### MXFP8 dense linears on quantized checkpoints
 
 The `linear` field overlays online MXFP8 the same way onto every other
 BF16 dense linear the ModelOpt checkpoint excludes: attention projections,
@@ -142,6 +142,22 @@ vllm serve lukealonso/GLM-5.2-NVFP4 \
   --quantization modelopt_fp4 \
   --quantization-config '{"linear":{"weight":"mxfp8"},"ignore":["re:.*kv_b_proj"]}'
 ```
+
+EXL3 checkpoints can use the same overlay for dense and shared-expert
+projections that are absent from the EXL3 tensor metadata. Serialized EXL3
+dense matrices and routed experts always retain their checkpoint format;
+`moe` overlays are rejected. `lm_head` also remains in its checkpoint format
+or BF16. For example:
+
+```bash
+vllm serve <exl3-checkpoint> \
+  --quantization exl3 \
+  --quantization-config '{"linear":{"weight":"mxfp8"},"shared_experts":{"weight":"mxfp8"},"ignore":["re:.*\\.q_a_proj$","re:.*kv_a_proj_with_mqa","lm_head"]}'
+```
+
+As with ModelOpt, `linear` does not select shared experts. Add the
+`shared_experts` field explicitly when those BF16 projections should also be
+converted. Ignore patterns are matched against unfused checkpoint names.
 
 ### Activation overrides on already-quantized checkpoints
 

--- a/tests/models/test_deepseek_v2_mtp_weights.py
+++ b/tests/models/test_deepseek_v2_mtp_weights.py
@@ -26,6 +26,18 @@ def test_spec_layer_index_uses_valid_layer_counts():
     assert get_spec_layer_idx_from_weight_name(config, "model.layers.81.weight") is None
 
 
+def test_spec_layer_index_does_not_scan_configured_layer_count():
+    config = SimpleNamespace(
+        num_hidden_layers=78,
+        num_nextn_predict_layers=10**12,
+    )
+
+    assert get_spec_layer_idx_from_weight_name(config, "model.layers.80.weight") == 80
+    assert (
+        get_spec_layer_idx_from_weight_name(config, "model.embed_tokens.weight") is None
+    )
+
+
 @pytest.mark.parametrize("invalid", [None, True, "3", 3.0, -1, [3]])
 def test_malformed_mtp_layer_counts_fail_closed(invalid):
     valid = SimpleNamespace(num_hidden_layers=78, num_nextn_predict_layers=3)

--- a/tests/models/test_deepseek_v2_mtp_weights.py
+++ b/tests/models/test_deepseek_v2_mtp_weights.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm.model_executor.models.deepseek_v2 import (
+    _skip_disabled_mtp_weight,
+    get_spec_layer_idx_from_weight_name,
+)
+
+
+def test_disabled_mtp_checkpoint_weights_are_skipped():
+    config = SimpleNamespace(num_hidden_layers=78, num_nextn_predict_layers=0)
+
+    assert not _skip_disabled_mtp_weight(config, "model.layers.77.self_attn.weight")
+    assert _skip_disabled_mtp_weight(config, "model.layers.78.self_attn.weight")
+
+
+def test_spec_layer_index_uses_valid_layer_counts():
+    config = SimpleNamespace(num_hidden_layers=78, num_nextn_predict_layers=3)
+
+    assert get_spec_layer_idx_from_weight_name(config, "model.layers.79.weight") == 79
+    assert get_spec_layer_idx_from_weight_name(config, "layers.80.weight") == 80
+    assert get_spec_layer_idx_from_weight_name(config, "model.layers.81.weight") is None
+
+
+@pytest.mark.parametrize("invalid", [None, True, "3", 3.0, -1, [3]])
+def test_malformed_mtp_layer_counts_fail_closed(invalid):
+    valid = SimpleNamespace(num_hidden_layers=78, num_nextn_predict_layers=3)
+    bad_nextn = SimpleNamespace(num_hidden_layers=78, num_nextn_predict_layers=invalid)
+    bad_hidden = SimpleNamespace(num_hidden_layers=invalid, num_nextn_predict_layers=3)
+
+    for config in (bad_nextn, bad_hidden):
+        assert not _skip_disabled_mtp_weight(config, "model.layers.78.weight")
+        assert (
+            get_spec_layer_idx_from_weight_name(config, "model.layers.78.weight")
+            is None
+        )
+
+    assert get_spec_layer_idx_from_weight_name(valid, "model.layers.78.weight") == 78

--- a/tests/quantization/test_exl3.py
+++ b/tests/quantization/test_exl3.py
@@ -934,7 +934,38 @@ def test_mixed_trellis_dispatches_decode_and_one_grid_prefill(monkeypatch):
     assert all(call[1:3] == prefill_tiers for call in mixed_api.calls[1:])
 
 
-def test_mixed_trellis_prefill_block_policy_is_narrow_and_overridable() -> None:
+@pytest.mark.parametrize(
+    "tier_signature",
+    [
+        ((3, 192), (4, 64)),
+        ((3, 206), (4, 50)),
+        ((3, 148), (4, 108)),
+    ],
+)
+def test_mixed_trellis_prefill_block_policy_qualified_partitions(
+    tier_signature,
+) -> None:
+    common = {
+        "configured_block_m": 64,
+        "explicit_override": False,
+        "hidden_size": 6144,
+        "intermediate_size": 512,
+        "tier_signature": tier_signature,
+        "topk": 8,
+        "device_major": 12,
+        "prefill_tile_config": (128, 128, 32, 512),
+    }
+
+    assert exl3_module._resolve_mixed_trellis_prefill_block_m(**common) == 32
+    assert (
+        exl3_module._resolve_mixed_trellis_prefill_block_m(
+            **{**common, "explicit_override": True}
+        )
+        == 64
+    )
+
+
+def test_mixed_trellis_prefill_block_policy_rejects_unqualified_partition() -> None:
     common = {
         "configured_block_m": 64,
         "explicit_override": False,
@@ -945,11 +976,9 @@ def test_mixed_trellis_prefill_block_policy_is_narrow_and_overridable() -> None:
         "device_major": 12,
         "prefill_tile_config": (128, 128, 32, 512),
     }
-
-    assert exl3_module._resolve_mixed_trellis_prefill_block_m(**common) == 32
     assert (
         exl3_module._resolve_mixed_trellis_prefill_block_m(
-            **{**common, "explicit_override": True}
+            **{**common, "tier_signature": ((3, 128), (4, 128))}
         )
         == 64
     )

--- a/tests/quantization/test_exl3.py
+++ b/tests/quantization/test_exl3.py
@@ -702,9 +702,9 @@ def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(
         )
     assert [entry["tile_config"] for entry in api.prepared] == [
         (128, 128, 128, 128),
-        (128, 64, 64, 128),
         (128, 128, 128, 128),
-        (128, 64, 64, 128),
+        (128, 128, 128, 128),
+        (128, 128, 128, 128),
     ]
     assert layer.exl3_mixed_trellis["tier_ids"] == ((0, 2), (1, 3))
     assert layer.exl3_mixed_trellis["tier_bits"] == (3, 4)

--- a/tests/quantization/test_exl3.py
+++ b/tests/quantization/test_exl3.py
@@ -792,6 +792,39 @@ def test_mixed_trellis_dispatches_decode_and_one_grid_prefill(monkeypatch):
     assert all(call[1:3] == prefill_tiers for call in mixed_api.calls[1:])
 
 
+def test_mixed_trellis_prefill_block_policy_is_narrow_and_overridable() -> None:
+    common = {
+        "configured_block_m": 64,
+        "explicit_override": False,
+        "hidden_size": 6144,
+        "intermediate_size": 512,
+        "tier_signature": ((3, 192), (4, 64)),
+        "topk": 8,
+        "device_major": 12,
+        "prefill_tile_config": (128, 128, 32, 512),
+    }
+
+    assert exl3_module._resolve_mixed_trellis_prefill_block_m(**common) == 32
+    assert (
+        exl3_module._resolve_mixed_trellis_prefill_block_m(
+            **{**common, "explicit_override": True}
+        )
+        == 64
+    )
+    assert (
+        exl3_module._resolve_mixed_trellis_prefill_block_m(
+            **{**common, "tier_signature": ((4, 256),)}
+        )
+        == 64
+    )
+    assert (
+        exl3_module._resolve_mixed_trellis_prefill_block_m(
+            **{**common, "device_major": 11}
+        )
+        == 64
+    )
+
+
 @pytest.mark.parametrize(
     ("hidden", "intermediate", "expected"),
     [

--- a/tests/quantization/test_exl3.py
+++ b/tests/quantization/test_exl3.py
@@ -8,6 +8,7 @@ import pytest
 import torch
 
 import vllm.model_executor.layers.quantization.exl3 as exl3_module
+import vllm.model_executor.layers.quantization.online.fp8 as fp8_module
 import vllm.model_executor.parameter as parameter_module
 from vllm.config import CompilationMode
 from vllm.config.quantization import QuantizationConfigArgs
@@ -19,6 +20,10 @@ from vllm.model_executor.layers.quantization.exl3 import (
     Exl3LinearMethod,
     Exl3MoEMethod,
     Exl3MoEParameter,
+    Exl3OnlineLinearMethod,
+)
+from vllm.model_executor.layers.quantization.exl3_online_cache import (
+    Exl3OnlineCacheResult,
 )
 from vllm.model_executor.models import glm4_moe
 
@@ -171,6 +176,77 @@ def test_exl3_online_overlay_preserves_rank_sliced_routed_experts(monkeypatch):
     method = config.get_quant_method(routed, "model.layers.3.mlp.experts")
 
     assert isinstance(method, Exl3MoEMethod)
+
+
+def test_exl3_online_trellis_selects_cached_k6_method(monkeypatch):
+    config = Exl3Config()
+    config._online_model_identity = "model"  # noqa: SLF001
+    config._online_encoder_identity = "encoder"  # noqa: SLF001
+    _set_online_overlay(monkeypatch, QuantizationConfigArgs(linear="mxfp8"))
+    monkeypatch.setattr(
+        fp8_module,
+        "get_current_vllm_config",
+        lambda: SimpleNamespace(model_config=SimpleNamespace(dtype=torch.bfloat16)),
+    )
+    monkeypatch.setenv("VLLM_EXL3_ONLINE_TRELLIS_BITS", "6")
+
+    method = config.get_quant_method(_mock_linear(), "model.layers.3.self_attn.o_proj")
+
+    assert isinstance(method, Exl3OnlineLinearMethod)
+    assert method.bits == 6
+    assert method.model_identity == "model"
+    assert method.encoder_identity == "encoder"
+
+
+def test_exl3_online_trellis_cache_hit_skips_encoder(monkeypatch):
+    monkeypatch.setattr(
+        fp8_module,
+        "get_current_vllm_config",
+        lambda: SimpleNamespace(model_config=SimpleNamespace(dtype=torch.bfloat16)),
+    )
+    method = Exl3OnlineLinearMethod(
+        bits=6,
+        prefix="model.layers.3.self_attn.o_proj",
+        model_identity="model",
+        encoder_identity="encoder",
+    )
+    layer = torch.nn.Module()
+    layer.register_parameter(
+        "weight",
+        torch.nn.Parameter(torch.zeros((256, 128), dtype=torch.float16)),
+    )
+    layer.exl3_online_input_size = 128
+    layer.exl3_online_output_size = 256
+    tensors = {
+        "trellis": torch.zeros((8, 16, 96), dtype=torch.int16),
+        "suh": torch.ones(128, dtype=torch.float16),
+        "svh": torch.ones(256, dtype=torch.float16),
+    }
+    captured = {}
+
+    def cache_hit(key, *, device, quantize):
+        del quantize
+        captured["key"] = key
+        captured["device"] = device
+        return Exl3OnlineCacheResult(tensors, 0.25, True, None)
+
+    monkeypatch.setattr(exl3_module, "load_or_quantize", cache_hit)
+    monkeypatch.setattr(
+        exl3_module,
+        "_load_exl3_online_quantizer",
+        lambda: pytest.fail("cache hit must not import the encoder"),
+    )
+    monkeypatch.setattr(exl3_module, "get_tensor_model_parallel_world_size", lambda: 4)
+    monkeypatch.setattr(exl3_module, "get_tensor_model_parallel_rank", lambda: 2)
+    monkeypatch.setattr(method, "_warm_decode_shapes", lambda layer: None)
+
+    method.process_weights_after_loading(layer)
+
+    assert captured["key"].tp_world_size == 4
+    assert captured["key"].tp_rank == 2
+    assert captured["device"] == torch.device("cpu")
+    assert layer.weight.numel() == 0
+    assert layer.exl3_online_trellis_weight is tensors["trellis"]
 
 
 def test_rank_sliced_checkpoint_selects_exl3_override():

--- a/tests/quantization/test_exl3.py
+++ b/tests/quantization/test_exl3.py
@@ -827,6 +827,8 @@ def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(
     assert rotations.gate_suh.shape[0] == expected_h_rows
     assert rotations.up_suh.shape[0] == expected_h_rows
     assert rotations.down_svh.shape[0] == expected_h_rows
+    assert layer.exl3_mixed_trellis["broadcast_suh"] is shared_h
+    assert layer.exl3_mixed_trellis["broadcast_svh"] is shared_h
     for entry in api.prepared:
         expected_tier_rows = 1 if shared_h else 2
         assert entry["gate_suh"].shape[0] == expected_tier_rows

--- a/tests/quantization/test_exl3.py
+++ b/tests/quantization/test_exl3.py
@@ -1032,6 +1032,42 @@ def test_rank_sliced_runtime_scope_is_per_owning_model():
     assert exl3_module._runtime_scope_id(draft_config) == draft_scope
 
 
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("moe_layers", [3.5, 77]),
+        ("moe_layers", [False, 77]),
+        ("k_values", [3.5, 4]),
+        ("k_values", [True, 4]),
+    ],
+)
+def test_r7_schema_rejects_lossy_integer_coercion(field, value):
+    r7 = {
+        "schema": "r7-complete-v2-checkpoint-v1",
+        "codebook": "mcg",
+        "bits": "mixed_tensor",
+        "moe_layers": [3, 77],
+        "k_values": [3, 4, 5],
+    }
+    r7[field] = value
+    with pytest.raises(ValueError):
+        Exl3Config.from_config({"r7_routed_experts": r7})
+
+
+def test_r7_schema_normalizes_declared_integer_contract():
+    config = Exl3Config.from_config({
+        "r7_routed_experts": {
+            "schema": "r7-complete-v2-checkpoint-v1",
+            "codebook": "mcg",
+            "bits": "mixed_tensor",
+            "moe_layers": [3, 77],
+            "k_values": [5, 3, 4, 3],
+        }
+    })
+    assert config.r7_routed_experts["moe_layers"] == (3, 77)
+    assert config.r7_routed_experts["k_values"] == (3, 4, 5)
+
+
 def test_rank_sliced_runtime_key_differs_across_models_with_same_shape():
     """Two same-shape layers owned by different models get different cache keys."""
 

--- a/tests/quantization/test_exl3.py
+++ b/tests/quantization/test_exl3.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import gc
+import weakref
 from types import SimpleNamespace
 from unittest.mock import Mock
 
@@ -196,6 +198,39 @@ def test_exl3_online_trellis_selects_cached_k6_method(monkeypatch):
     assert method.bits == 6
     assert method.model_identity == "model"
     assert method.encoder_identity == "encoder"
+
+
+def test_online_trellis_cache_off_does_not_require_hub_commit(tmp_path, monkeypatch):
+    config = Exl3Config()
+    monkeypatch.setenv("VLLM_EXL3_ONLINE_CACHE_MODE", "off")
+    monkeypatch.setenv("VLLM_EXL3_ENCODER_SOURCE", str(tmp_path))
+
+    config._configure_online_cache_identity(  # noqa: SLF001
+        "org/model", hf_config=None, revision=None
+    )
+
+    assert config._online_model_identity == "cache-disabled"  # noqa: SLF001
+    assert config._online_encoder_identity == "cache-disabled"  # noqa: SLF001
+
+
+def test_online_trellis_encoder_requires_quantize_entrypoint(tmp_path, monkeypatch):
+    encoder = tmp_path / "encoder"
+    quantizer = encoder / "modules" / "quant" / "exl3_lib"
+    quantizer.mkdir(parents=True)
+    (quantizer / "quantize.py").write_text("VALUE = 1\n", encoding="utf-8")
+    monkeypatch.setenv("VLLM_EXL3_ENCODER_SOURCE", str(encoder))
+    monkeypatch.setattr(exl3_module, "_EXL3_ONLINE_QUANTIZER", None)
+    monkeypatch.setattr(
+        exl3_module.importlib,
+        "import_module",
+        lambda name: SimpleNamespace(),
+    )
+
+    with pytest.raises(RuntimeError, match="has no quantize_exl3"):
+        exl3_module._load_exl3_online_quantizer()
+    for name in tuple(exl3_module.sys.modules):
+        if name == "_vllm_exl3_encoder" or name.startswith("_vllm_exl3_encoder."):
+            monkeypatch.delitem(exl3_module.sys.modules, name, raising=False)
 
 
 def test_exl3_online_trellis_cache_hit_skips_encoder(monkeypatch):
@@ -731,6 +766,7 @@ def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(
             name = f"{prefix}_{suffix}"
             backing = slabs.get(name)
             setattr(layer, name, parameter(shards, backing=backing))
+
     class FakeMixedApi:
         def __init__(self):
             self.prepared = []
@@ -814,9 +850,37 @@ def test_mixed_trellis_buffer_accounting_ignores_metadata() -> None:
     assert exl3_module._unique_tensor_storage_bytes(first, second) == 8
 
 
+def test_prepared_dense_weight_is_owned_by_source_tensor(monkeypatch) -> None:
+    class FakeApi:
+        def __init__(self):
+            self.calls = 0
+
+        def prepare_weight(self, trellis, suh, svh, **kwargs):
+            del kwargs
+            self.calls += 1
+            return SimpleNamespace(trellis=trellis, suh=suh, svh=svh)
+
+    api = FakeApi()
+    monkeypatch.setattr(exl3_module, "_load_sparkinfer_trellis_linear", lambda: api)
+    trellis = torch.empty((8, 8, 96), dtype=torch.int16)
+    suh = torch.empty(128, dtype=torch.float16)
+    svh = torch.empty(128, dtype=torch.float16)
+
+    first = exl3_module._sparkinfer_trellis_weight(trellis, suh, svh, torch.float16)
+    second = exl3_module._sparkinfer_trellis_weight(trellis, suh, svh, torch.float16)
+    assert first is second
+    assert api.calls == 1
+
+    source_ref = weakref.ref(trellis)
+    del first, second, trellis
+    gc.collect()
+    assert source_ref() is None
+
+
 def test_mixed_trellis_dispatches_decode_and_one_grid_prefill(monkeypatch):
     class FakeMixedApi:
-        calls = []
+        def __init__(self):
+            self.calls = []
 
         def run_mixed_trellis(self, x, *args):
             launch = args[7]

--- a/tests/quantization/test_exl3.py
+++ b/tests/quantization/test_exl3.py
@@ -463,9 +463,10 @@ def test_mixed_trellis_dispatches_decode_and_serial_prefill(monkeypatch):
         "decode": {"launch": object(), "buffers": object()},
         "prefill_plans": (FakePlan(), FakePlan()),
         "prefill_arena": torch.empty(16, dtype=torch.uint8),
-        "prefill_accum": torch.empty((16, 4), dtype=torch.float32),
+        "prefill_accum": torch.empty((8, 4), dtype=torch.float32),
         "max_decode_m": 8,
         "max_batched_tokens": 16,
+        "prefill_capacity": 8,
     }
     tiers = (
         {"weights": object(), "route_expert_map": torch.tensor([0, -1])},
@@ -495,12 +496,32 @@ def test_mixed_trellis_dispatches_decode_and_serial_prefill(monkeypatch):
     torch.testing.assert_close(decode, torch.ones_like(decode))
     torch.testing.assert_close(prefill, torch.full_like(prefill, 3))
     assert mixed_api.calls == 1
-    assert len(fused_api.bindings) == 2
+    assert len(fused_api.bindings) == 4
+    assert [binding["a"].shape[0] for binding in fused_api.bindings] == [8] * 4
+    assert all(
+        torch.equal(binding["topk_weights"], weights[:8])
+        for binding in fused_api.bindings[:2]
+    )
+    assert all(
+        torch.equal(binding["topk_weights"], weights[8:])
+        for binding in fused_api.bindings[2:]
+    )
+    assert all(
+        torch.equal(binding["topk_ids"], ids[:8]) for binding in fused_api.bindings[:2]
+    )
+    assert all(
+        torch.equal(binding["topk_ids"], ids[8:]) for binding in fused_api.bindings[2:]
+    )
     assert (
         fused_api.bindings[0]["output"].data_ptr()
         == runtime["prefill_accum"].data_ptr()
     )
     assert fused_api.bindings[1]["output"] is None
+    assert (
+        fused_api.bindings[2]["output"].data_ptr()
+        == runtime["prefill_accum"].data_ptr()
+    )
+    assert fused_api.bindings[3]["output"] is None
 
 
 @pytest.mark.parametrize(

--- a/tests/quantization/test_exl3.py
+++ b/tests/quantization/test_exl3.py
@@ -227,11 +227,13 @@ def test_online_trellis_encoder_requires_quantize_entrypoint(tmp_path, monkeypat
         lambda name: SimpleNamespace(),
     )
 
-    with pytest.raises(RuntimeError, match="has no quantize_exl3"):
-        exl3_module._load_exl3_online_quantizer()
-    for name in tuple(exl3_module.sys.modules):
-        if name == "_vllm_exl3_encoder" or name.startswith("_vllm_exl3_encoder."):
-            monkeypatch.delitem(exl3_module.sys.modules, name, raising=False)
+    try:
+        with pytest.raises(RuntimeError, match="has no quantize_exl3"):
+            exl3_module._load_exl3_online_quantizer()
+    finally:
+        for name in tuple(exl3_module.sys.modules):
+            if name == "_vllm_exl3_encoder" or name.startswith("_vllm_exl3_encoder."):
+                exl3_module.sys.modules.pop(name, None)
 
 
 def test_exl3_online_trellis_cache_hit_skips_encoder(monkeypatch):

--- a/tests/quantization/test_exl3.py
+++ b/tests/quantization/test_exl3.py
@@ -23,6 +23,7 @@ from vllm.model_executor.layers.quantization.exl3 import (
     Exl3MoEMethod,
     Exl3MoEParameter,
     Exl3OnlineLinearMethod,
+    Exl3Parameter,
 )
 from vllm.model_executor.layers.quantization.exl3_online_cache import (
     Exl3OnlineCacheResult,
@@ -524,6 +525,98 @@ def test_rank_sliced_parameter_preallocates_projection_major_slab(monkeypatch):
     torch.testing.assert_close(param.exl3_tensors[(2, "w3")], w3)
 
 
+@pytest.mark.parametrize(
+    ("shape", "tp_slice", "expected"),
+    [
+        ((12,), (0, 4, 4, 1), torch.arange(4, 8)),
+        (
+            (4, 6, 2),
+            (1, 32, 32, 16),
+            torch.tensor(
+                [
+                    [[4, 5], [6, 7]],
+                    [[16, 17], [18, 19]],
+                    [[28, 29], [30, 31]],
+                    [[40, 41], [42, 43]],
+                ]
+            ),
+        ),
+        ((6, 4, 2), (0, 32, 32, 16), torch.arange(16, 32).reshape(2, 4, 2)),
+    ],
+)
+def test_r7_parameter_streams_owned_tp_slice(monkeypatch, shape, tp_slice, expected):
+    monkeypatch.setattr(parameter_module, "get_tensor_model_parallel_rank", lambda: 0)
+    monkeypatch.setattr(
+        parameter_module, "get_tensor_model_parallel_world_size", lambda: 1
+    )
+    source = torch.arange(torch.tensor(shape).prod().item(), dtype=torch.int16).reshape(
+        shape
+    )
+    param = Exl3MoEParameter(
+        weight_loader=lambda *args, **kwargs: None,
+        num_experts=1,
+        shard_ids=("w1",),
+        tp_slice=tp_slice,
+    )
+
+    param.load_exl3_weight(source, expert_id=0, shard_id="w1")
+    loaded = param.exl3_tensors[(0, "w1")]
+
+    torch.testing.assert_close(loaded, expected.to(torch.int16))
+    assert loaded.is_contiguous()
+    assert loaded.untyped_storage().data_ptr() != source.untyped_storage().data_ptr()
+    assert loaded.untyped_storage().nbytes() == loaded.numel() * loaded.element_size()
+
+
+def test_r7_parameter_streaming_tp_slice_fails_closed(monkeypatch):
+    monkeypatch.setattr(parameter_module, "get_tensor_model_parallel_rank", lambda: 0)
+    monkeypatch.setattr(
+        parameter_module, "get_tensor_model_parallel_world_size", lambda: 1
+    )
+    param = Exl3MoEParameter(
+        weight_loader=lambda *args, **kwargs: None,
+        num_experts=1,
+        shard_ids=("w1",),
+        tp_slice=(1, 24, 32, 16),
+    )
+
+    with pytest.raises(ValueError, match="not quantum-aligned"):
+        param.load_exl3_weight(
+            torch.zeros((4, 8, 2), dtype=torch.int16),
+            expert_id=0,
+            shard_id="w1",
+        )
+
+
+@pytest.mark.parametrize(
+    ("parameter_cls", "load_kwargs"),
+    [
+        (Exl3Parameter, {"shard_id": "w1"}),
+        (Exl3MoEParameter, {"expert_id": 0, "shard_id": "w1"}),
+    ],
+)
+def test_exl3_parameters_own_borrowed_instanttensor_storage(
+    monkeypatch, parameter_cls, load_kwargs
+):
+    monkeypatch.setattr(parameter_module, "get_tensor_model_parallel_rank", lambda: 0)
+    monkeypatch.setattr(
+        parameter_module, "get_tensor_model_parallel_world_size", lambda: 1
+    )
+    source = torch.arange(8, dtype=torch.int16)
+    source._vllm_instanttensor_borrowed = True
+    kwargs = {"weight_loader": lambda *args, **kwargs: None}
+    if parameter_cls is Exl3MoEParameter:
+        kwargs.update(num_experts=1, shard_ids=("w1",))
+    param = parameter_cls(**kwargs)
+
+    param.load_exl3_weight(source, **load_kwargs)
+    loaded = next(iter(param.exl3_tensors.values()))
+    source.zero_()
+
+    torch.testing.assert_close(loaded, torch.arange(8, dtype=torch.int16))
+    assert loaded.untyped_storage().data_ptr() != source.untyped_storage().data_ptr()
+
+
 def test_rank_sliced_broadcast_pointer_table_repeats_one_physical_row():
     slab = torch.ones((1, 128), dtype=torch.float16)
 
@@ -686,9 +779,7 @@ def test_rank_sliced_weights_pass_shared_h_rows_without_expansion(monkeypatch):
         def prepare_weights(**kwargs):
             return SimpleNamespace(**kwargs)
 
-    monkeypatch.setattr(
-        exl3_module, "_load_b12x_fused_moe", lambda: FakeFusedMoe()
-    )
+    monkeypatch.setattr(exl3_module, "_load_b12x_fused_moe", lambda: FakeFusedMoe())
     method = object.__new__(Exl3MoEMethod)
     method.quant_config = SimpleNamespace(bits=float(bits))
     method._rank_sliced_backing = lambda _layer, name: slabs[name]
@@ -965,6 +1056,38 @@ def test_mixed_trellis_prefill_block_policy_qualified_partitions(
     )
 
 
+@pytest.mark.parametrize(
+    "tier_signature",
+    [
+        ((3, 171), (4, 86), (5, 1)),
+        ((3, 197), (4, 58), (5, 2)),
+    ],
+)
+def test_mixed_trellis_prefill_block_policy_qualifies_native_k5(
+    tier_signature,
+) -> None:
+    assert (
+        exl3_module._resolve_mixed_trellis_prefill_block_m(
+            configured_block_m=64,
+            explicit_override=False,
+            hidden_size=6144,
+            intermediate_size=512,
+            tier_signature=tier_signature,
+            topk=8,
+            device_major=12,
+            prefill_tile_config=(128, 128, 32, 512),
+        )
+        == 32
+    )
+
+
+def test_r7_native_layer_budget_is_unlimited_by_default(monkeypatch) -> None:
+    monkeypatch.delenv("VLLM_EXL3_R7_FUSED_LAYERS", raising=False)
+    assert exl3_module._r7_fused_layer_budget() is None
+    monkeypatch.setenv("VLLM_EXL3_R7_FUSED_LAYERS", "48")
+    assert exl3_module._r7_fused_layer_budget() == 48
+
+
 def test_mixed_trellis_prefill_block_policy_rejects_unqualified_partition() -> None:
     common = {
         "configured_block_m": 64,
@@ -1006,6 +1129,42 @@ def test_mixed_trellis_prefill_block_policy_rejects_unqualified_partition() -> N
 )
 def test_mixed_trellis_uses_large_m_safe_tile_geometry(hidden, intermediate, expected):
     assert Exl3MoEMethod._mixed_trellis_tile_config(hidden, intermediate) == expected
+
+
+def test_r7_projection_tiers_accept_native_k3_k4_k5() -> None:
+    projection_bits = {
+        ("w13", "w1"): (3, 4, 5, 3),
+        ("w13", "w3"): (4, 3, 5, 4),
+        ("w2", "w2"): (5, 4, 3, 5),
+    }
+
+    def parameter(group: str, shard: str):
+        return SimpleNamespace(
+            exl3_tensors={
+                (expert, shard): torch.empty((1, 1, 16 * bits), dtype=torch.int16)
+                for expert, bits in enumerate(projection_bits[(group, shard)])
+            }
+        )
+
+    layer = SimpleNamespace(
+        local_num_experts=4,
+        w13_trellis=SimpleNamespace(exl3_tensors={}),
+        w2_trellis=SimpleNamespace(exl3_tensors={}),
+    )
+    layer.w13_trellis.exl3_tensors.update(parameter("w13", "w1").exl3_tensors)
+    layer.w13_trellis.exl3_tensors.update(parameter("w13", "w3").exl3_tensors)
+    layer.w2_trellis.exl3_tensors.update(parameter("w2", "w2").exl3_tensors)
+    method = object.__new__(Exl3MoEMethod)
+    method.quant_config = SimpleNamespace(r7_routed_experts={"k_values": (3, 4, 5)})
+
+    bits, tiers = method._r7_projection_tiers(layer)
+
+    assert bits == (3, 4, 5)
+    assert tiers == {
+        "gate": (0, 1, 2, 0),
+        "up": (1, 0, 2, 1),
+        "down": (2, 1, 0, 2),
+    }
 
 
 def test_rank_sliced_runtime_scope_is_per_owning_model():
@@ -1055,15 +1214,17 @@ def test_r7_schema_rejects_lossy_integer_coercion(field, value):
 
 
 def test_r7_schema_normalizes_declared_integer_contract():
-    config = Exl3Config.from_config({
-        "r7_routed_experts": {
-            "schema": "r7-complete-v2-checkpoint-v1",
-            "codebook": "mcg",
-            "bits": "mixed_tensor",
-            "moe_layers": [3, 77],
-            "k_values": [5, 3, 4, 3],
+    config = Exl3Config.from_config(
+        {
+            "r7_routed_experts": {
+                "schema": "r7-complete-v2-checkpoint-v1",
+                "codebook": "mcg",
+                "bits": "mixed_tensor",
+                "moe_layers": [3, 77],
+                "k_values": [5, 3, 4, 3],
+            }
         }
-    })
+    )
     assert config.r7_routed_experts["moe_layers"] == (3, 77)
     assert config.r7_routed_experts["k_values"] == (3, 4, 5)
 

--- a/tests/quantization/test_exl3.py
+++ b/tests/quantization/test_exl3.py
@@ -201,6 +201,30 @@ def test_exl3_online_trellis_selects_cached_k6_method(monkeypatch):
     assert method.encoder_identity == "encoder"
 
 
+def test_exl3_online_trellis_logs_one_stable_summary(monkeypatch):
+    config = Exl3Config()
+    config._online_model_identity = "model"  # noqa: SLF001
+    config._online_encoder_identity = "encoder"  # noqa: SLF001
+    _set_online_overlay(monkeypatch, QuantizationConfigArgs(linear="mxfp8"))
+    monkeypatch.setattr(
+        fp8_module,
+        "get_current_vllm_config",
+        lambda: SimpleNamespace(model_config=SimpleNamespace(dtype=torch.bfloat16)),
+    )
+    monkeypatch.setenv("VLLM_EXL3_ONLINE_TRELLIS_BITS", "6")
+    warning_keys = set()
+    monkeypatch.setattr(
+        exl3_module.logger,
+        "warning_once",
+        lambda message, *args: warning_keys.add((message, args)),
+    )
+
+    config.get_quant_method(_mock_linear(), "model.layers.3.self_attn.o_proj")
+    config.get_quant_method(_mock_linear(), "model.layers.4.self_attn.o_proj")
+
+    assert len(warning_keys) == 1
+
+
 def test_online_trellis_cache_off_does_not_require_hub_commit(tmp_path, monkeypatch):
     config = Exl3Config()
     monkeypatch.setenv("VLLM_EXL3_ONLINE_CACHE_MODE", "off")

--- a/tests/quantization/test_exl3.py
+++ b/tests/quantization/test_exl3.py
@@ -576,7 +576,7 @@ def test_rank_sliced_weights_pass_shared_h_rows_without_expansion(monkeypatch):
             return SimpleNamespace(**kwargs)
 
     monkeypatch.setattr(
-        exl3_module, "_load_sparkinfer_fused_moe", lambda: FakeFusedMoe()
+        exl3_module, "_load_b12x_fused_moe", lambda: FakeFusedMoe()
     )
     method = object.__new__(Exl3MoEMethod)
     method.quant_config = SimpleNamespace(bits=float(bits))
@@ -655,9 +655,6 @@ def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(
             name = f"{prefix}_{suffix}"
             backing = slabs.get(name)
             setattr(layer, name, parameter(shards, backing=backing))
-    marker = torch.tensor(0xCBAC1FED - (1 << 32), dtype=torch.int32)
-    layer.w13_mcg.exl3_tensors[(0, "w1")] = marker
-
     class FakeMixedApi:
         def __init__(self):
             self.prepared = []
@@ -679,30 +676,15 @@ def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(
         def combine_trellis_rotations(tier0, tier1):
             return tier0, tier1
 
-    class FakeFusedApi:
-        def __init__(self):
-            self.plans = []
-            self.prepared = []
-
-        def plan_weights(self, **kwargs):
-            self.plans.append(kwargs)
-            return SimpleNamespace(**kwargs)
-
-        def prepare_weights(self, **kwargs):
-            self.prepared.append(kwargs)
-            return SimpleNamespace(plan=kwargs["plan"])
-
     api = FakeMixedApi()
-    fused_api = FakeFusedApi()
     monkeypatch.setattr(exl3_module, "_load_b12x_mixed_trellis", lambda: api)
-    monkeypatch.setattr(exl3_module, "_load_b12x_fused_moe", lambda: fused_api)
     method = object.__new__(Exl3MoEMethod)
     method._rank_sliced_backing = lambda _layer, name: slabs[name]
 
     method._prepare_mixed_rank_sliced_weights(layer)
 
-    assert [entry["trellis_bits"] for entry in api.prepared] == [3, 4]
-    assert [entry["num_experts"] for entry in api.prepared] == [2, 2]
+    assert [entry["trellis_bits"] for entry in api.prepared] == [3, 3, 4, 4]
+    assert [entry["num_experts"] for entry in api.prepared] == [2] * 4
     for entry in api.prepared:
         bits = entry["trellis_bits"]
         assert tuple(entry["w13"].shape) == (
@@ -720,33 +702,26 @@ def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(
         )
     assert [entry["tile_config"] for entry in api.prepared] == [
         (128, 128, 128, 128),
+        (128, 64, 64, 128),
         (128, 128, 128, 128),
+        (128, 64, 64, 128),
     ]
     assert layer.exl3_mixed_trellis["tier_ids"] == ((0, 2), (1, 3))
     assert layer.exl3_mixed_trellis["tier_bits"] == (3, 4)
-    assert [entry["trellis_bits"] for entry in fused_api.plans] == [3, 4]
-    assert [entry["trellis_tile_config"] for entry in fused_api.plans] == [
-        (64, 128, 64, 128),
-        (64, 128, 64, 128),
-    ]
-    assert all(entry["trellis_mcg"] is marker for entry in fused_api.prepared)
-    assert len(layer.exl3_mixed_trellis["serial_tiers"]) == 2
+    assert len(layer.exl3_mixed_trellis["tiers"]) == 2
+    assert len(layer.exl3_mixed_trellis["prefill_tiers"]) == 2
     rotations = layer.exl3_mixed_trellis["rotations"]
     expected_h_rows = 1 if shared_h else experts
     assert rotations.gate_suh.shape[0] == expected_h_rows
     assert rotations.up_suh.shape[0] == expected_h_rows
     assert rotations.down_svh.shape[0] == expected_h_rows
-    for mixed_entry, serial_entry in zip(api.prepared, fused_api.prepared, strict=True):
+    for entry in api.prepared:
         expected_tier_rows = 1 if shared_h else 2
-        assert mixed_entry["gate_suh"].shape[0] == expected_tier_rows
-        assert mixed_entry["up_suh"].shape[0] == expected_tier_rows
-        assert mixed_entry["down_svh"].shape[0] == expected_tier_rows
+        assert entry["gate_suh"].shape[0] == expected_tier_rows
+        assert entry["up_suh"].shape[0] == expected_tier_rows
+        assert entry["down_svh"].shape[0] == expected_tier_rows
         assert (
-            mixed_entry["gate_suh"].untyped_storage().data_ptr()
-            == rotations.gate_suh.untyped_storage().data_ptr()
-        )
-        assert (
-            serial_entry["gate_suh"].untyped_storage().data_ptr()
+            entry["gate_suh"].untyped_storage().data_ptr()
             == rotations.gate_suh.untyped_storage().data_ptr()
         )
     assert layer.w13_trellis.exl3_tensors == {}
@@ -763,57 +738,36 @@ def test_mixed_trellis_buffer_accounting_ignores_metadata() -> None:
     assert exl3_module._unique_tensor_storage_bytes(first, second) == 8
 
 
-def test_mixed_trellis_dispatches_decode_and_serial_prefill(monkeypatch):
+def test_mixed_trellis_dispatches_decode_and_one_grid_prefill(monkeypatch):
     class FakeMixedApi:
-        calls = 0
+        calls = []
 
         def run_mixed_trellis(self, x, *args):
-            self.calls += 1
-            return torch.ones_like(x)
-
-    class FakeFusedApi:
-        def __init__(self):
-            self.bindings = []
-
-        def bind(self, plan, **kwargs):
-            del plan
-            self.bindings.append(kwargs)
-            return kwargs
-
-        @staticmethod
-        def run(*, binding):
-            output = binding["output"]
-            if output is not None:
-                output.fill_(1)
-                return output
-            return torch.full_like(binding["a"], 2, dtype=torch.float32)
-
-    class FakePlan:
-        @staticmethod
-        def scratch_specs():
-            return [SimpleNamespace(shape=(16,), dtype=torch.uint8)]
+            launch = args[7]
+            self.calls.append((int(x.shape[0]), args[0], args[1], launch))
+            return torch.full_like(x, launch.value)
 
     mixed_api = FakeMixedApi()
-    fused_api = FakeFusedApi()
+    decode_tiers = (object(), object())
+    prefill_tiers = (object(), object())
     runtime = {
         "mixed_api": mixed_api,
-        "fused_api": fused_api,
-        "decode": {"launch": object(), "buffers": object()},
-        "prefill_plans": (FakePlan(), FakePlan()),
-        "prefill_arena": torch.empty(16, dtype=torch.uint8),
-        "prefill_accum": torch.empty((8, 4), dtype=torch.float32),
+        "decode": {
+            "launch": SimpleNamespace(value=1),
+            "buffers": object(),
+        },
+        "prefill": {
+            "launch": SimpleNamespace(value=3),
+            "buffers": object(),
+        },
         "max_decode_m": 8,
         "max_batched_tokens": 16,
         "prefill_capacity": 8,
     }
-    tiers = (
-        {"weights": object(), "route_expert_map": torch.tensor([0, -1])},
-        {"weights": object(), "route_expert_map": torch.tensor([-1, 0])},
-    )
     layer = SimpleNamespace(
         exl3_mixed_trellis={
-            "tiers": (object(), object()),
-            "serial_tiers": tiers,
+            "tiers": decode_tiers,
+            "prefill_tiers": prefill_tiers,
             "global_to_combined": object(),
             "descriptor_map": object(),
             "rotations": object(),
@@ -833,33 +787,9 @@ def test_mixed_trellis_dispatches_decode_and_serial_prefill(monkeypatch):
 
     torch.testing.assert_close(decode, torch.ones_like(decode))
     torch.testing.assert_close(prefill, torch.full_like(prefill, 3))
-    assert mixed_api.calls == 1
-    assert len(fused_api.bindings) == 4
-    assert [binding["a"].shape[0] for binding in fused_api.bindings] == [8] * 4
-    assert all(
-        torch.equal(binding["topk_weights"], weights[:8])
-        for binding in fused_api.bindings[:2]
-    )
-    assert all(
-        torch.equal(binding["topk_weights"], weights[8:])
-        for binding in fused_api.bindings[2:]
-    )
-    assert all(
-        torch.equal(binding["topk_ids"], ids[:8]) for binding in fused_api.bindings[:2]
-    )
-    assert all(
-        torch.equal(binding["topk_ids"], ids[8:]) for binding in fused_api.bindings[2:]
-    )
-    assert (
-        fused_api.bindings[0]["output"].data_ptr()
-        == runtime["prefill_accum"].data_ptr()
-    )
-    assert fused_api.bindings[1]["output"] is None
-    assert (
-        fused_api.bindings[2]["output"].data_ptr()
-        == runtime["prefill_accum"].data_ptr()
-    )
-    assert fused_api.bindings[3]["output"] is None
+    assert [call[0] for call in mixed_api.calls] == [4, 8, 8]
+    assert mixed_api.calls[0][1:3] == decode_tiers
+    assert all(call[1:3] == prefill_tiers for call in mixed_api.calls[1:])
 
 
 @pytest.mark.parametrize(

--- a/tests/quantization/test_exl3.py
+++ b/tests/quantization/test_exl3.py
@@ -863,13 +863,13 @@ def test_prepared_dense_weight_is_owned_by_source_tensor(monkeypatch) -> None:
             return SimpleNamespace(trellis=trellis, suh=suh, svh=svh)
 
     api = FakeApi()
-    monkeypatch.setattr(exl3_module, "_load_sparkinfer_trellis_linear", lambda: api)
+    monkeypatch.setattr(exl3_module, "_load_b12x_trellis_linear", lambda: api)
     trellis = torch.empty((8, 8, 96), dtype=torch.int16)
     suh = torch.empty(128, dtype=torch.float16)
     svh = torch.empty(128, dtype=torch.float16)
 
-    first = exl3_module._sparkinfer_trellis_weight(trellis, suh, svh, torch.float16)
-    second = exl3_module._sparkinfer_trellis_weight(trellis, suh, svh, torch.float16)
+    first = exl3_module._b12x_trellis_weight(trellis, suh, svh, torch.float16)
+    second = exl3_module._b12x_trellis_weight(trellis, suh, svh, torch.float16)
     assert first is second
     assert api.calls == 1
 

--- a/tests/quantization/test_exl3.py
+++ b/tests/quantization/test_exl3.py
@@ -603,7 +603,10 @@ def test_rank_sliced_weights_pass_shared_h_rows_without_expansion(monkeypatch):
     assert all(tuple(table.shape) == (experts,) for table in layer.exl3_pointer_tables)
 
 
-def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(monkeypatch):
+@pytest.mark.parametrize("shared_h", [False, True])
+def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(
+    monkeypatch, shared_h
+):
     experts = 4
     hidden = intermediate = 128
     bitrates = (3, 4, 3, 4)
@@ -629,10 +632,12 @@ def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(monkeypat
         )
 
     slabs = {
-        "w13_suh": torch.ones((2, experts, hidden), dtype=torch.float16),
+        "w13_suh": torch.ones(
+            (2, 1 if shared_h else experts, hidden), dtype=torch.float16
+        ),
         "w13_svh": torch.ones((2, experts, intermediate), dtype=torch.float16),
         "w2_suh": torch.ones((experts, intermediate), dtype=torch.float16),
-        "w2_svh": torch.ones((experts, hidden), dtype=torch.float16),
+        "w2_svh": torch.ones((1 if shared_h else experts, hidden), dtype=torch.float16),
     }
     layer = SimpleNamespace(
         local_num_experts=experts,
@@ -727,7 +732,15 @@ def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(monkeypat
     assert all(entry["trellis_mcg"] is marker for entry in fused_api.prepared)
     assert len(layer.exl3_mixed_trellis["serial_tiers"]) == 2
     rotations = layer.exl3_mixed_trellis["rotations"]
+    expected_h_rows = 1 if shared_h else experts
+    assert rotations.gate_suh.shape[0] == expected_h_rows
+    assert rotations.up_suh.shape[0] == expected_h_rows
+    assert rotations.down_svh.shape[0] == expected_h_rows
     for mixed_entry, serial_entry in zip(api.prepared, fused_api.prepared, strict=True):
+        expected_tier_rows = 1 if shared_h else 2
+        assert mixed_entry["gate_suh"].shape[0] == expected_tier_rows
+        assert mixed_entry["up_suh"].shape[0] == expected_tier_rows
+        assert mixed_entry["down_svh"].shape[0] == expected_tier_rows
         assert (
             mixed_entry["gate_suh"].untyped_storage().data_ptr()
             == rotations.gate_suh.untyped_storage().data_ptr()

--- a/tests/quantization/test_exl3.py
+++ b/tests/quantization/test_exl3.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pytest
 import torch
@@ -9,10 +10,13 @@ import torch
 import vllm.model_executor.layers.quantization.exl3 as exl3_module
 import vllm.model_executor.parameter as parameter_module
 from vllm.config import CompilationMode
-from vllm.model_executor.layers.fused_moe import MoEActivation
+from vllm.config.quantization import QuantizationConfigArgs
+from vllm.model_executor.layers.fused_moe import MoEActivation, RoutedExperts
+from vllm.model_executor.layers.linear import LinearBase, UnquantizedLinearMethod
 from vllm.model_executor.layers.quantization import get_quantization_config
 from vllm.model_executor.layers.quantization.exl3 import (
     Exl3Config,
+    Exl3LinearMethod,
     Exl3MoEMethod,
     Exl3MoEParameter,
 )
@@ -33,6 +37,125 @@ def _rank_sliced_metadata(**overrides):
     }
     metadata.update(overrides)
     return metadata
+
+
+def _set_online_overlay(monkeypatch, args: QuantizationConfigArgs) -> object:
+    current = SimpleNamespace(
+        model_config=SimpleNamespace(
+            quantization_config=args,
+            enforce_eager=True,
+        )
+    )
+    sentinel = object()
+    monkeypatch.setattr(exl3_module, "get_current_vllm_config_or_none", lambda: current)
+    monkeypatch.setattr(exl3_module, "Mxfp8OnlineLinearMethod", lambda: sentinel)
+    return sentinel
+
+
+def _mock_linear() -> Mock:
+    return Mock(spec=LinearBase)
+
+
+def test_exl3_online_overlay_quantizes_only_bf16_dense_and_shared(monkeypatch):
+    config = Exl3Config(
+        tensor_storage={"model.layers.3.self_attn.q_b_proj": {"quant_format": "exl3"}}
+    )
+    sentinel = _set_online_overlay(
+        monkeypatch,
+        QuantizationConfigArgs(linear="mxfp8", shared_experts="mxfp8"),
+    )
+
+    serialized = config.get_quant_method(
+        _mock_linear(), "model.layers.3.self_attn.q_b_proj"
+    )
+    dense_bf16 = config.get_quant_method(
+        _mock_linear(), "model.layers.3.self_attn.kv_b_proj"
+    )
+    shared_bf16 = config.get_quant_method(
+        _mock_linear(), "model.layers.3.mlp.shared_experts.down_proj"
+    )
+
+    assert isinstance(serialized, Exl3LinearMethod)
+    assert dense_bf16 is sentinel
+    assert shared_bf16 is sentinel
+
+
+def test_exl3_linear_overlay_does_not_select_shared_experts(monkeypatch):
+    config = Exl3Config()
+    sentinel = _set_online_overlay(monkeypatch, QuantizationConfigArgs(linear="mxfp8"))
+
+    dense = config.get_quant_method(
+        _mock_linear(), "model.layers.3.self_attn.kv_b_proj"
+    )
+    shared = config.get_quant_method(
+        _mock_linear(), "model.layers.3.mlp.shared_experts.down_proj"
+    )
+
+    assert dense is sentinel
+    assert isinstance(shared, UnquantizedLinearMethod)
+
+
+def test_exl3_online_overlay_honors_unfused_ignore_names(monkeypatch):
+    config = Exl3Config()
+    config.packed_modules_mapping = {
+        "fused_qkv_a_proj": ["q_a_proj", "kv_a_proj_with_mqa"]
+    }
+    sentinel = _set_online_overlay(
+        monkeypatch,
+        QuantizationConfigArgs(
+            linear="mxfp8",
+            ignore=["re:.*\\.q_a_proj$", "re:.*kv_a_proj_with_mqa"],
+        ),
+    )
+
+    ignored = config.get_quant_method(
+        _mock_linear(), "model.layers.3.self_attn.fused_qkv_a_proj"
+    )
+    kept = config.get_quant_method(_mock_linear(), "model.layers.3.self_attn.kv_b_proj")
+
+    assert isinstance(ignored, UnquantizedLinearMethod)
+    assert kept is sentinel
+
+
+def test_exl3_online_overlay_rejects_split_packed_quantization(monkeypatch):
+    config = Exl3Config()
+    config.packed_modules_mapping = {
+        "fused_qkv_a_proj": ["q_a_proj", "kv_a_proj_with_mqa"]
+    }
+    _set_online_overlay(
+        monkeypatch,
+        QuantizationConfigArgs(linear="mxfp8", ignore=["re:.*\\.q_a_proj$"]),
+    )
+
+    with pytest.raises(ValueError, match="different quantization schemes"):
+        config.get_quant_method(
+            _mock_linear(), "model.layers.3.self_attn.fused_qkv_a_proj"
+        )
+
+
+def test_exl3_online_overlay_never_quantizes_bf16_lm_head(monkeypatch):
+    config = Exl3Config()
+    _set_online_overlay(monkeypatch, QuantizationConfigArgs(linear="mxfp8"))
+    lm_head = type("ParallelLMHead", (torch.nn.Module,), {})()
+
+    method = config.get_quant_method(lm_head, "lm_head")
+
+    assert isinstance(method, UnquantizedLinearMethod)
+
+
+def test_exl3_online_overlay_preserves_rank_sliced_routed_experts(monkeypatch):
+    config = Exl3Config()
+    config.rank_sliced_metadata = _rank_sliced_metadata()
+    _set_online_overlay(
+        monkeypatch,
+        QuantizationConfigArgs(linear="mxfp8", shared_experts="mxfp8"),
+    )
+    routed = Mock(spec=RoutedExperts)
+    routed.moe_config = object()
+
+    method = config.get_quant_method(routed, "model.layers.3.mlp.experts")
+
+    assert isinstance(method, Exl3MoEMethod)
 
 
 def test_rank_sliced_checkpoint_selects_exl3_override():

--- a/tests/quantization/test_exl3.py
+++ b/tests/quantization/test_exl3.py
@@ -133,6 +133,21 @@ def test_exl3_online_overlay_rejects_split_packed_quantization(monkeypatch):
         )
 
 
+def test_exl3_online_overlay_rejects_mixed_packed_storage(monkeypatch):
+    config = Exl3Config(
+        tensor_storage={"model.layers.3.self_attn.q_a_proj": {"quant_format": "exl3"}}
+    )
+    config.packed_modules_mapping = {
+        "fused_qkv_a_proj": ["q_a_proj", "kv_a_proj_with_mqa"]
+    }
+    _set_online_overlay(monkeypatch, QuantizationConfigArgs(linear="mxfp8"))
+
+    with pytest.raises(ValueError, match="mixes EXL3 and BF16 source shards"):
+        config.get_quant_method(
+            _mock_linear(), "model.layers.3.self_attn.fused_qkv_a_proj"
+        )
+
+
 def test_exl3_online_overlay_never_quantizes_bf16_lm_head(monkeypatch):
     config = Exl3Config()
     _set_online_overlay(monkeypatch, QuantizationConfigArgs(linear="mxfp8"))

--- a/tests/quantization/test_exl3.py
+++ b/tests/quantization/test_exl3.py
@@ -230,6 +230,8 @@ def test_glm_model_retains_quant_config_for_weight_loading(monkeypatch):
         ({"codebook": "mul1"}, "MCG codebook"),
         ({"moe_layers": [77, 3]}, "moe_layers"),
         ({"tensor_schema": "unsupported"}, "tensor schema"),
+        ({"rotation_layout": "implicit_magic"}, "rotation_layout"),
+        ({"rotation_layout": "shared_h_v1"}, "shared_h_tensor_schema"),
     ],
 )
 def test_rank_sliced_metadata_fails_closed(overrides, message):
@@ -254,6 +256,28 @@ def test_rank_sliced_metadata_admits_only_declared_moe_layers():
     assert (
         config.codebook_for_prefix("model.layers.10.mlp.experts.0.gate_proj") == "mcg"
     )
+
+
+def test_rank_sliced_shared_h_metadata_is_explicit_and_legacy_defaults_unchanged():
+    legacy = Exl3Config()
+    legacy.maybe_update_config(
+        "unused", SimpleNamespace(hybrid_tr3_tail=_rank_sliced_metadata())
+    )
+    shared = Exl3Config()
+    shared.maybe_update_config(
+        "unused",
+        SimpleNamespace(
+            hybrid_tr3_tail=_rank_sliced_metadata(
+                rotation_layout="shared_h_v1",
+                shared_h_tensor_schema=(
+                    "model.layers.{L}.mlp.experts.shared_h.{proj}.rank{r}.{suh|svh}"
+                ),
+            )
+        ),
+    )
+
+    assert legacy.rank_sliced_rotation_layout == "per_expert_v1"
+    assert shared.rank_sliced_rotation_layout == "shared_h_v1"
 
 
 def test_mixed_rank_sliced_metadata_hydrates_per_layer_bitrates(monkeypatch):
@@ -317,6 +341,49 @@ def test_rank_sliced_weight_name_keeps_only_local_tp_rank(monkeypatch):
     )
 
 
+def test_rank_sliced_shared_h_names_map_once_and_fail_closed(monkeypatch):
+    config = Exl3Config()
+    config.maybe_update_config(
+        "unused",
+        SimpleNamespace(
+            hybrid_tr3_tail=_rank_sliced_metadata(
+                rotation_layout="shared_h_v1",
+                shared_h_tensor_schema=(
+                    "model.layers.{L}.mlp.experts.shared_h.{proj}.rank{r}.{suh|svh}"
+                ),
+            )
+        ),
+    )
+    monkeypatch.setattr(exl3_module, "get_tensor_model_parallel_rank", lambda: 2)
+    prefix = "model.layers.3.mlp.experts"
+
+    assert (
+        config.normalize_rank_sliced_weight_name(
+            f"{prefix}.shared_h.gate_proj.rank2.suh"
+        )
+        == f"{prefix}.0.gate_proj.suh"
+    )
+    assert (
+        config.normalize_rank_sliced_weight_name(
+            f"{prefix}.shared_h.down_proj.rank1.svh"
+        )
+        is None
+    )
+    with pytest.raises(ValueError, match="requires suh"):
+        config.normalize_rank_sliced_weight_name(
+            f"{prefix}.shared_h.gate_proj.rank2.svh"
+        )
+    with pytest.raises(ValueError, match="must store H-side rotations"):
+        config.normalize_rank_sliced_weight_name(f"{prefix}.7.down_proj.rank2.svh")
+
+    legacy = Exl3Config()
+    legacy.maybe_update_config(
+        "unused", SimpleNamespace(hybrid_tr3_tail=_rank_sliced_metadata())
+    )
+    with pytest.raises(ValueError, match="does not declare"):
+        legacy.normalize_rank_sliced_weight_name(f"{prefix}.shared_h.up_proj.rank2.suh")
+
+
 def test_rank_sliced_parameter_preallocates_projection_major_slab(monkeypatch):
     monkeypatch.setattr(parameter_module, "get_tensor_model_parallel_rank", lambda: 0)
     monkeypatch.setattr(
@@ -344,6 +411,70 @@ def test_rank_sliced_parameter_preallocates_projection_major_slab(monkeypatch):
     )
     torch.testing.assert_close(param.exl3_tensors[(1, "w1")], w1)
     torch.testing.assert_close(param.exl3_tensors[(2, "w3")], w3)
+
+
+def test_rank_sliced_broadcast_pointer_table_repeats_one_physical_row():
+    slab = torch.ones((1, 128), dtype=torch.float16)
+
+    table = Exl3MoEMethod._pointer_table(slab, num_experts=4)
+
+    assert table.tolist() == [slab.data_ptr()] * 4
+    with pytest.raises(RuntimeError, match="per-expert or broadcast"):
+        Exl3MoEMethod._pointer_table(
+            torch.ones((2, 128), dtype=torch.float16), num_experts=4
+        )
+
+
+def test_rank_sliced_shared_h_create_weights_allocates_one_physical_row(
+    monkeypatch,
+):
+    monkeypatch.setattr(parameter_module, "get_tensor_model_parallel_rank", lambda: 0)
+    monkeypatch.setattr(
+        parameter_module, "get_tensor_model_parallel_world_size", lambda: 4
+    )
+    config = Exl3Config()
+    config.maybe_update_config(
+        "unused",
+        SimpleNamespace(
+            hybrid_tr3_tail=_rank_sliced_metadata(
+                rotation_layout="shared_h_v1",
+                shared_h_tensor_schema=(
+                    "model.layers.{L}.mlp.experts.shared_h.{proj}.rank{r}.{suh|svh}"
+                ),
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        exl3_module,
+        "get_current_vllm_config_or_none",
+        lambda: SimpleNamespace(
+            scheduler_config=SimpleNamespace(max_num_batched_tokens=8192),
+            model_config=SimpleNamespace(runner_type="generate"),
+        ),
+    )
+    layer = torch.nn.Module()
+    layer.layer_name = "model.layers.3.mlp.experts"
+    moe = SimpleNamespace(
+        moe_parallel_config=SimpleNamespace(use_ep=False, tp_rank=0, tp_size=4),
+        has_bias=False,
+    )
+    method = Exl3MoEMethod(config, moe)
+
+    method.create_weights(
+        layer,
+        num_experts=256,
+        hidden_size=6144,
+        intermediate_size_per_partition=512,
+        params_dtype=torch.bfloat16,
+    )
+
+    assert layer.exl3_shared_h_rotations
+    assert layer.w13_suh.exl3_num_experts == 1
+    assert layer.w2_svh.exl3_num_experts == 1
+    assert layer.w13_svh.exl3_num_experts == 256
+    assert layer.w2_suh.exl3_num_experts == 256
+    assert layer.w13_trellis.exl3_num_experts == 256
+    assert layer.w2_trellis.exl3_num_experts == 256
 
 
 def test_rank_sliced_weights_use_unified_fused_moe_contract(monkeypatch):
@@ -414,6 +545,62 @@ def test_rank_sliced_weights_use_unified_fused_moe_contract(monkeypatch):
     assert api.prepare_kwargs["w1_fp4"] is slabs["w13_trellis"]
     assert api.prepare_kwargs["w2_fp4"] is slabs["w2_trellis"]
     assert api.prepare_kwargs["trellis_mcg"] is marker
+
+
+def test_rank_sliced_weights_pass_shared_h_rows_without_expansion(monkeypatch):
+    experts = 3
+    hidden = intermediate = 128
+    bits = 3
+    slabs = {
+        "w13_trellis": torch.zeros(
+            (2, experts, hidden // 16, intermediate // 16, 16 * bits),
+            dtype=torch.int16,
+        ),
+        "w2_trellis": torch.zeros(
+            (experts, intermediate // 16, hidden // 16, 16 * bits),
+            dtype=torch.int16,
+        ),
+        "w13_suh": torch.ones((2, 1, hidden), dtype=torch.float16),
+        "w13_svh": torch.ones((2, experts, intermediate), dtype=torch.float16),
+        "w2_suh": torch.ones((experts, intermediate), dtype=torch.float16),
+        "w2_svh": torch.ones((1, hidden), dtype=torch.float16),
+    }
+
+    class FakeFusedMoe:
+        @staticmethod
+        def plan_weights(**kwargs):
+            return SimpleNamespace(source_format=kwargs["source_format"])
+
+        @staticmethod
+        def prepare_weights(**kwargs):
+            return SimpleNamespace(**kwargs)
+
+    monkeypatch.setattr(
+        exl3_module, "_load_sparkinfer_fused_moe", lambda: FakeFusedMoe()
+    )
+    method = object.__new__(Exl3MoEMethod)
+    method.quant_config = SimpleNamespace(bits=float(bits))
+    method._rank_sliced_backing = lambda _layer, name: slabs[name]
+    marker = torch.tensor(0xCBAC1FED - (1 << 32), dtype=torch.int32)
+    layer = SimpleNamespace(
+        local_num_experts=experts,
+        exl3_hidden_size=hidden,
+        exl3_intermediate_size_per_partition=intermediate,
+        exl3_params_dtype=torch.float16,
+        exl3_layer_bitrates=(bits,) * experts,
+        exl3_mixed_bitrate=False,
+        exl3_shared_h_rotations=True,
+        activation=MoEActivation.SILU,
+        w13_mcg=SimpleNamespace(exl3_tensors={(0, "w1"): marker}),
+    )
+
+    method._prepare_rank_sliced_weights(layer)
+
+    prepared = layer.exl3_trellis_weights
+    assert tuple(prepared.gate_suh.shape) == (1, hidden)
+    assert tuple(prepared.up_suh.shape) == (1, hidden)
+    assert tuple(prepared.down_svh.shape) == (1, hidden)
+    assert all(tuple(table.shape) == (experts,) for table in layer.exl3_pointer_tables)
 
 
 def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(monkeypatch):

--- a/tests/quantization/test_exl3.py
+++ b/tests/quantization/test_exl3.py
@@ -313,6 +313,7 @@ def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(monkeypat
         local_num_experts=experts,
         exl3_hidden_size=hidden,
         exl3_intermediate_size_per_partition=intermediate,
+        exl3_params_dtype=torch.float16,
         exl3_layer_bitrates=bitrates,
         activation=MoEActivation.SILU,
         layer_name="model.layers.3.mlp.experts",
@@ -324,6 +325,8 @@ def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(monkeypat
             name = f"{prefix}_{suffix}"
             backing = slabs.get(name)
             setattr(layer, name, parameter(shards, backing=backing))
+    marker = torch.tensor(0xCBAC1FED - (1 << 32), dtype=torch.int32)
+    layer.w13_mcg.exl3_tensors[(0, "w1")] = marker
 
     class FakeMixedApi:
         def __init__(self):
@@ -346,8 +349,23 @@ def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(monkeypat
         def combine_trellis_rotations(tier0, tier1):
             return tier0, tier1
 
+    class FakeFusedApi:
+        def __init__(self):
+            self.plans = []
+            self.prepared = []
+
+        def plan_weights(self, **kwargs):
+            self.plans.append(kwargs)
+            return SimpleNamespace(**kwargs)
+
+        def prepare_weights(self, **kwargs):
+            self.prepared.append(kwargs)
+            return SimpleNamespace(plan=kwargs["plan"])
+
     api = FakeMixedApi()
+    fused_api = FakeFusedApi()
     monkeypatch.setattr(exl3_module, "_load_b12x_mixed_trellis", lambda: api)
+    monkeypatch.setattr(exl3_module, "_load_b12x_fused_moe", lambda: fused_api)
     method = object.__new__(Exl3MoEMethod)
     method._rank_sliced_backing = lambda _layer, name: slabs[name]
 
@@ -376,6 +394,23 @@ def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(monkeypat
     ]
     assert layer.exl3_mixed_trellis["tier_ids"] == ((0, 2), (1, 3))
     assert layer.exl3_mixed_trellis["tier_bits"] == (3, 4)
+    assert [entry["trellis_bits"] for entry in fused_api.plans] == [3, 4]
+    assert [entry["trellis_tile_config"] for entry in fused_api.plans] == [
+        (64, 128, 64, 128),
+        (64, 128, 64, 128),
+    ]
+    assert all(entry["trellis_mcg"] is marker for entry in fused_api.prepared)
+    assert len(layer.exl3_mixed_trellis["serial_tiers"]) == 2
+    rotations = layer.exl3_mixed_trellis["rotations"]
+    for mixed_entry, serial_entry in zip(api.prepared, fused_api.prepared, strict=True):
+        assert (
+            mixed_entry["gate_suh"].untyped_storage().data_ptr()
+            == rotations.gate_suh.untyped_storage().data_ptr()
+        )
+        assert (
+            serial_entry["gate_suh"].untyped_storage().data_ptr()
+            == rotations.gate_suh.untyped_storage().data_ptr()
+        )
     assert layer.w13_trellis.exl3_tensors == {}
     assert layer.w2_trellis.exl3_tensors == {}
     assert layer.w13_suh.exl3_backing is None
@@ -388,6 +423,84 @@ def test_mixed_trellis_buffer_accounting_ignores_metadata() -> None:
     second = SimpleNamespace(alias=shared.view(2, 4), label="prefill")
 
     assert exl3_module._unique_tensor_storage_bytes(first, second) == 8
+
+
+def test_mixed_trellis_dispatches_decode_and_serial_prefill(monkeypatch):
+    class FakeMixedApi:
+        calls = 0
+
+        def run_mixed_trellis(self, x, *args):
+            self.calls += 1
+            return torch.ones_like(x)
+
+    class FakeFusedApi:
+        def __init__(self):
+            self.bindings = []
+
+        def bind(self, plan, **kwargs):
+            del plan
+            self.bindings.append(kwargs)
+            return kwargs
+
+        @staticmethod
+        def run(*, binding):
+            output = binding["output"]
+            if output is not None:
+                output.fill_(1)
+                return output
+            return torch.full_like(binding["a"], 2, dtype=torch.float32)
+
+    class FakePlan:
+        @staticmethod
+        def scratch_specs():
+            return [SimpleNamespace(shape=(16,), dtype=torch.uint8)]
+
+    mixed_api = FakeMixedApi()
+    fused_api = FakeFusedApi()
+    runtime = {
+        "mixed_api": mixed_api,
+        "fused_api": fused_api,
+        "decode": {"launch": object(), "buffers": object()},
+        "prefill_plans": (FakePlan(), FakePlan()),
+        "prefill_arena": torch.empty(16, dtype=torch.uint8),
+        "prefill_accum": torch.empty((16, 4), dtype=torch.float32),
+        "max_decode_m": 8,
+        "max_batched_tokens": 16,
+    }
+    tiers = (
+        {"weights": object(), "route_expert_map": torch.tensor([0, -1])},
+        {"weights": object(), "route_expert_map": torch.tensor([-1, 0])},
+    )
+    layer = SimpleNamespace(
+        exl3_mixed_trellis={
+            "tiers": (object(), object()),
+            "serial_tiers": tiers,
+            "global_to_combined": object(),
+            "descriptor_map": object(),
+            "rotations": object(),
+        }
+    )
+    method = object.__new__(Exl3MoEMethod)
+    monkeypatch.setattr(
+        method, "_mixed_rank_sliced_runtime", lambda layer, x, ids: runtime
+    )
+    weights = torch.ones((16, 2), dtype=torch.float32)
+    ids = torch.zeros((16, 2), dtype=torch.int64)
+
+    decode = method._apply_mixed_rank_sliced(
+        layer, torch.zeros((4, 4)), weights[:4], ids[:4]
+    )
+    prefill = method._apply_mixed_rank_sliced(layer, torch.zeros((16, 4)), weights, ids)
+
+    torch.testing.assert_close(decode, torch.ones_like(decode))
+    torch.testing.assert_close(prefill, torch.full_like(prefill, 3))
+    assert mixed_api.calls == 1
+    assert len(fused_api.bindings) == 2
+    assert (
+        fused_api.bindings[0]["output"].data_ptr()
+        == runtime["prefill_accum"].data_ptr()
+    )
+    assert fused_api.bindings[1]["output"] is None
 
 
 @pytest.mark.parametrize(

--- a/tests/quantization/test_exl3_online_cache.py
+++ b/tests/quantization/test_exl3_online_cache.py
@@ -1,0 +1,159 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.quantization.exl3_online_cache import (
+    Exl3OnlineCacheKey,
+    cache_path,
+    load_or_quantize,
+    resolve_encoder_identity,
+    resolve_model_identity,
+)
+
+
+def _key() -> Exl3OnlineCacheKey:
+    return Exl3OnlineCacheKey(
+        model_identity="model-identity",
+        encoder_identity="encoder-identity",
+        prefix="model.layers.0.self_attn.o_proj",
+        bits=6,
+        seed=123,
+        tp_world_size=4,
+        tp_rank=2,
+        input_size=128,
+        output_size=256,
+    )
+
+
+def _tensors(key: Exl3OnlineCacheKey) -> dict[str, torch.Tensor]:
+    return {
+        "trellis": torch.arange(
+            key.input_size // 16 * key.output_size // 16 * key.bits * 16,
+            dtype=torch.int16,
+        ).reshape(key.input_size // 16, key.output_size // 16, key.bits * 16),
+        "suh": torch.ones(key.input_size, dtype=torch.float16),
+        "svh": torch.full((key.output_size,), 2, dtype=torch.float16),
+    }
+
+
+def test_cache_round_trip_skips_second_quantization(tmp_path, monkeypatch):
+    monkeypatch.setenv("VLLM_EXL3_ONLINE_CACHE_DIR", str(tmp_path))
+    monkeypatch.setenv("VLLM_EXL3_ONLINE_CACHE_MODE", "readwrite")
+    key = _key()
+    calls = 0
+
+    def quantize():
+        nonlocal calls
+        calls += 1
+        return _tensors(key), 0.125
+
+    first = load_or_quantize(key, device=torch.device("cpu"), quantize=quantize)
+    second = load_or_quantize(key, device=torch.device("cpu"), quantize=quantize)
+
+    assert calls == 1
+    assert not first.hit
+    assert second.hit
+    assert second.proxy_error == pytest.approx(0.125)
+    assert second.path == cache_path(key)
+    for name, expected in _tensors(key).items():
+        assert torch.equal(second.tensors[name], expected)
+
+
+def test_corrupt_cache_is_replaced_atomically(tmp_path, monkeypatch):
+    monkeypatch.setenv("VLLM_EXL3_ONLINE_CACHE_DIR", str(tmp_path))
+    monkeypatch.setenv("VLLM_EXL3_ONLINE_CACHE_MODE", "readwrite")
+    key = _key()
+    path = cache_path(key)
+    path.parent.mkdir(parents=True)
+    path.write_bytes(b"not a safetensors file")
+    calls = 0
+
+    def quantize():
+        nonlocal calls
+        calls += 1
+        return _tensors(key), None
+
+    result = load_or_quantize(key, device=torch.device("cpu"), quantize=quantize)
+    reloaded = load_or_quantize(
+        key,
+        device=torch.device("cpu"),
+        quantize=lambda: pytest.fail("valid replacement must be reused"),
+    )
+
+    assert calls == 1
+    assert not result.hit
+    assert reloaded.hit
+
+
+def test_readonly_miss_does_not_publish(tmp_path, monkeypatch):
+    monkeypatch.setenv("VLLM_EXL3_ONLINE_CACHE_DIR", str(tmp_path))
+    monkeypatch.setenv("VLLM_EXL3_ONLINE_CACHE_MODE", "readonly")
+    key = _key()
+
+    result = load_or_quantize(
+        key,
+        device=torch.device("cpu"),
+        quantize=lambda: (_tensors(key), 0.5),
+    )
+
+    assert not result.hit
+    assert not cache_path(key).exists()
+
+
+def test_cache_key_covers_every_rank_local_encoding_input():
+    key = _key()
+    variants = [
+        replace(key, model_identity="other-model"),
+        replace(key, encoder_identity="other-encoder"),
+        replace(key, prefix="model.layers.1.self_attn.o_proj"),
+        replace(key, bits=5),
+        replace(key, seed=456),
+        replace(key, tp_world_size=8),
+        replace(key, tp_rank=3),
+        replace(key, input_size=256),
+        replace(key, output_size=128),
+    ]
+
+    assert len({key.digest(), *(variant.digest() for variant in variants)}) == 10
+
+
+def test_local_model_identity_tracks_metadata_and_shards(tmp_path):
+    model = tmp_path / "model"
+    model.mkdir()
+    config = model / "config.json"
+    shard = model / "model-00001-of-00001.safetensors"
+    config.write_text('{"model_type":"test"}', encoding="utf-8")
+    shard.write_bytes(b"weight payload")
+
+    before = resolve_model_identity(str(model))
+    config.write_text('{"model_type":"changed"}', encoding="utf-8")
+    after = resolve_model_identity(str(model))
+
+    assert before != after
+
+
+def test_hub_model_identity_tracks_resolved_revision():
+    first = resolve_model_identity("org/model", revision="commit-a")
+    second = resolve_model_identity("org/model", revision="commit-b")
+
+    assert first != second
+
+
+def test_encoder_identity_tracks_source_without_explicit_revision(tmp_path):
+    package = tmp_path / "exllamav3"
+    package.mkdir()
+    source = package / "quantize.py"
+    source.write_text("VALUE = 1\n", encoding="utf-8")
+    before = resolve_encoder_identity(package)
+    source.write_text("VALUE = 2\n", encoding="utf-8")
+    after = resolve_encoder_identity(package)
+
+    assert before != after
+    explicit = resolve_encoder_identity(package, revision="abc")
+    assert explicit == resolve_encoder_identity(package, revision="abc")

--- a/tests/quantization/test_exl3_online_cache.py
+++ b/tests/quantization/test_exl3_online_cache.py
@@ -10,6 +10,7 @@ import torch
 
 from vllm.model_executor.layers.quantization.exl3_online_cache import (
     Exl3OnlineCacheKey,
+    cache_mode,
     cache_path,
     load_or_quantize,
     resolve_encoder_identity,
@@ -103,7 +104,48 @@ def test_readonly_miss_does_not_publish(tmp_path, monkeypatch):
     )
 
     assert not result.hit
+    assert result.path is None
     assert not cache_path(key).exists()
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("off", "off"),
+        ("none", "off"),
+        ("readonly", "readonly"),
+        ("read-only", "readonly"),
+        ("readwrite", "readwrite"),
+        ("rw", "readwrite"),
+    ],
+)
+def test_cache_mode_aliases(raw, expected, monkeypatch):
+    monkeypatch.setenv("VLLM_EXL3_ONLINE_CACHE_MODE", raw)
+    assert cache_mode() == expected
+
+
+def test_cache_mode_rejects_unknown_value(monkeypatch):
+    monkeypatch.setenv("VLLM_EXL3_ONLINE_CACHE_MODE", "sometimes")
+    with pytest.raises(ValueError, match="must be off, readonly, or readwrite"):
+        cache_mode()
+
+
+def test_off_mode_neither_reads_nor_writes(tmp_path, monkeypatch):
+    monkeypatch.setenv("VLLM_EXL3_ONLINE_CACHE_DIR", str(tmp_path))
+    monkeypatch.setenv("VLLM_EXL3_ONLINE_CACHE_MODE", "off")
+    key = _key()
+    cache_path(key).parent.mkdir(parents=True)
+    cache_path(key).write_bytes(b"must not be read")
+
+    result = load_or_quantize(
+        key,
+        device=torch.device("cpu"),
+        quantize=lambda: (_tensors(key), 0.5),
+    )
+
+    assert not result.hit
+    assert result.path is None
+    assert cache_path(key).read_bytes() == b"must not be read"
 
 
 def test_cache_key_covers_every_rank_local_encoding_input():
@@ -143,6 +185,18 @@ def test_hub_model_identity_tracks_resolved_revision():
     second = resolve_model_identity("org/model", revision="commit-b")
 
     assert first != second
+
+    resolved = resolve_model_identity(
+        "org/model",
+        revision="main",
+        hf_config=type("Config", (), {"_commit_hash": "commit-a"})(),
+    )
+    assert resolved == first
+
+
+def test_hub_model_identity_rejects_unresolved_revision():
+    with pytest.raises(ValueError, match="requires a resolved revision"):
+        resolve_model_identity("org/model")
 
 
 def test_encoder_identity_tracks_source_without_explicit_revision(tmp_path):

--- a/tests/quantization/test_exl3_online_cache.py
+++ b/tests/quantization/test_exl3_online_cache.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from dataclasses import replace
 
+import filelock
 import pytest
 import torch
 
@@ -122,6 +123,39 @@ def test_cache_publish_failure_keeps_completed_encoding(tmp_path, monkeypatch):
     assert not result.hit
     assert result.path is None
     assert result.proxy_error == pytest.approx(0.25)
+
+
+def test_cache_lock_timeout_falls_back_to_uncached_encoding(tmp_path, monkeypatch):
+    monkeypatch.setenv("VLLM_EXL3_ONLINE_CACHE_DIR", str(tmp_path))
+    monkeypatch.setenv("VLLM_EXL3_ONLINE_CACHE_MODE", "readwrite")
+    key = _key()
+    observed_timeout = None
+
+    class HeldLock:
+        def __init__(self, lock_file, *, timeout):
+            nonlocal observed_timeout
+            self.lock_file = lock_file
+            observed_timeout = timeout
+
+        def __enter__(self):
+            raise filelock.Timeout(self.lock_file)
+
+        def __exit__(self, exc_type, exc, traceback):
+            return False
+
+    monkeypatch.setattr(filelock, "FileLock", HeldLock)
+
+    result = load_or_quantize(
+        key,
+        device=torch.device("cpu"),
+        quantize=lambda: (_tensors(key), 0.375),
+    )
+
+    assert observed_timeout == 600.0
+    assert not result.hit
+    assert result.path is None
+    assert result.proxy_error == pytest.approx(0.375)
+    assert not cache_path(key).exists()
 
 
 def test_cache_root_uses_vllm_cache_root(tmp_path, monkeypatch):

--- a/tests/quantization/test_exl3_online_cache.py
+++ b/tests/quantization/test_exl3_online_cache.py
@@ -16,6 +16,7 @@ from vllm.model_executor.layers.quantization.exl3_online_cache import (
     Exl3OnlineNonFiniteError,
     cache_mode,
     cache_path,
+    cache_root,
     load_or_quantize,
     resolve_encoder_identity,
     resolve_model_identity,
@@ -94,6 +95,40 @@ def test_corrupt_cache_is_replaced_atomically(tmp_path, monkeypatch):
     assert calls == 1
     assert not result.hit
     assert reloaded.hit
+
+
+def test_cache_publish_failure_keeps_completed_encoding(tmp_path, monkeypatch):
+    monkeypatch.setenv("VLLM_EXL3_ONLINE_CACHE_DIR", str(tmp_path))
+    monkeypatch.setenv("VLLM_EXL3_ONLINE_CACHE_MODE", "readwrite")
+    key = _key()
+    calls = 0
+
+    def quantize():
+        nonlocal calls
+        calls += 1
+        return _tensors(key), 0.25
+
+    def fail_save(*args, **kwargs):
+        raise RuntimeError("write failed")
+
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.quantization.exl3_online_cache._save",
+        fail_save,
+    )
+
+    result = load_or_quantize(key, device=torch.device("cpu"), quantize=quantize)
+
+    assert calls == 1
+    assert not result.hit
+    assert result.path is None
+    assert result.proxy_error == pytest.approx(0.25)
+
+
+def test_cache_root_uses_vllm_cache_root(tmp_path, monkeypatch):
+    monkeypatch.delenv("VLLM_EXL3_ONLINE_CACHE_DIR", raising=False)
+    monkeypatch.setenv("VLLM_CACHE_ROOT", str(tmp_path))
+
+    assert cache_root() == tmp_path / "exl3_online"
 
 
 @pytest.mark.parametrize("bad_field", ["suh", "svh", "proxy_error"])
@@ -241,9 +276,12 @@ def test_local_model_identity_tracks_metadata_and_shards(tmp_path):
 
     before = resolve_model_identity(str(model))
     config.write_text('{"model_type":"changed"}', encoding="utf-8")
-    after = resolve_model_identity(str(model))
+    after_config = resolve_model_identity(str(model))
+    shard.write_bytes(b"changed weight payload")
+    after_shard = resolve_model_identity(str(model))
 
-    assert before != after
+    assert before != after_config
+    assert after_config != after_shard
 
 
 def test_hub_model_identity_tracks_resolved_revision():

--- a/tests/quantization/test_exl3_online_cache.py
+++ b/tests/quantization/test_exl3_online_cache.py
@@ -8,8 +8,12 @@ from dataclasses import replace
 import pytest
 import torch
 
+from vllm.model_executor.layers.quantization.exl3 import (
+    _load_online_encoding_with_retry,
+)
 from vllm.model_executor.layers.quantization.exl3_online_cache import (
     Exl3OnlineCacheKey,
+    Exl3OnlineNonFiniteError,
     cache_mode,
     cache_path,
     load_or_quantize,
@@ -90,6 +94,68 @@ def test_corrupt_cache_is_replaced_atomically(tmp_path, monkeypatch):
     assert calls == 1
     assert not result.hit
     assert reloaded.hit
+
+
+@pytest.mark.parametrize("bad_field", ["suh", "svh", "proxy_error"])
+def test_nonfinite_encoding_is_rejected(tmp_path, monkeypatch, bad_field):
+    monkeypatch.setenv("VLLM_EXL3_ONLINE_CACHE_DIR", str(tmp_path))
+    monkeypatch.setenv("VLLM_EXL3_ONLINE_CACHE_MODE", "readwrite")
+    key = _key()
+
+    def quantize():
+        tensors = _tensors(key)
+        proxy_error = 0.125
+        if bad_field == "proxy_error":
+            proxy_error = float("nan")
+        else:
+            tensors[bad_field][0] = float("nan")
+        return tensors, proxy_error
+
+    with pytest.raises(Exl3OnlineNonFiniteError, match="non-finite"):
+        load_or_quantize(key, device=torch.device("cpu"), quantize=quantize)
+
+    assert not cache_path(key).exists()
+
+
+def test_online_encoding_retries_one_nonfinite_result(monkeypatch):
+    monkeypatch.setenv("VLLM_EXL3_ONLINE_CACHE_MODE", "off")
+    key = _key()
+    calls = 0
+
+    def quantize():
+        nonlocal calls
+        calls += 1
+        tensors = _tensors(key)
+        if calls == 1:
+            tensors["svh"][0] = float("nan")
+        return tensors, 0.125
+
+    result = _load_online_encoding_with_retry(
+        key, device=torch.device("cpu"), quantize=quantize
+    )
+
+    assert calls == 2
+    assert torch.isfinite(result.tensors["svh"]).all()
+
+
+def test_online_encoding_fails_after_second_nonfinite_result(monkeypatch):
+    monkeypatch.setenv("VLLM_EXL3_ONLINE_CACHE_MODE", "off")
+    key = _key()
+    calls = 0
+
+    def quantize():
+        nonlocal calls
+        calls += 1
+        tensors = _tensors(key)
+        tensors["suh"][0] = float("nan")
+        return tensors, 0.125
+
+    with pytest.raises(Exl3OnlineNonFiniteError, match="non-finite"):
+        _load_online_encoding_with_retry(
+            key, device=torch.device("cpu"), quantize=quantize
+        )
+
+    assert calls == 2
 
 
 def test_readonly_miss_does_not_publish(tmp_path, monkeypatch):

--- a/tests/quantization/test_exl3_prefill_plan.py
+++ b/tests/quantization/test_exl3_prefill_plan.py
@@ -118,7 +118,6 @@ class _FakeMixedTrellisApi:
         self.routed.append((topk_weights.clone(), topk_ids.clone()))
         return x.to(torch.float32)
 
-
 class _FakeExt:
     """Parity extension without exl3_moe_fused: chunk loop only."""
 
@@ -152,23 +151,14 @@ def _make_mixed_layer():
     layer.exl3_mixed_bitrate = True
     layer.exl3_mixed_trellis = {
         "tiers": (object(), object()),
+        "prefill_tiers": (object(), object()),
         "tier_ids": ((0, 1, 2, 3), (4, 5, 6, 7)),
         "tier_bits": (3, 4),
         "global_to_combined": object(),
         "descriptor_map": object(),
         "rotations": object(),
         "tile_config": (64, 128, 64, 128),
-        "serial_tile_config": (64, 128, 64, 128),
-        "serial_tiers": (
-            {
-                "weights": SimpleNamespace(plan=object()),
-                "route_expert_map": torch.tensor([0, 1, 2, 3, -1, -1, -1, -1]),
-            },
-            {
-                "weights": SimpleNamespace(plan=object()),
-                "route_expert_map": torch.tensor([-1, -1, -1, -1, 0, 1, 2, 3]),
-            },
-        ),
+        "prefill_tile_config": (128, 64, 64, 128),
     }
     return layer
 
@@ -339,18 +329,16 @@ def test_mixed_prefill_capacity_slices_rows_and_routing():
 
         out = method._apply_rank_sliced(layer, x, weights, ids)
 
-        assert [launch.size_m for launch in h.mixed_api.compiled] == [32]
-        assert [caps["max_tokens"] for caps in h.planned_caps()] == [128, 128]
-        assert [bound[1] for bound in h.api.bound] == [128, 128, 72, 72]
+        assert [launch.size_m for launch in h.mixed_api.compiled] == [32, 128]
+        assert [launch.moe_block_size for launch in h.mixed_api.compiled] == [8, 64]
+        assert h.mixed_api.compiled[1].force_tile_config == (128, 64, 64, 128)
+        assert not h.planned_caps()
+        assert not h.api.bound
         assert torch.equal(out, x)
         assert torch.equal(
-            torch.cat([route[0] for route in h.api.routed[::2]]), weights
+            torch.cat([route[0] for route in h.mixed_api.routed]), weights
         )
-        assert torch.equal(torch.cat([route[1] for route in h.api.routed[::2]]), ids)
-        assert all(
-            torch.equal(left[0], right[0]) and torch.equal(left[1], right[1])
-            for left, right in zip(h.api.routed[::2], h.api.routed[1::2], strict=True)
-        )
+        assert torch.equal(torch.cat([route[1] for route in h.mixed_api.routed]), ids)
 
 
 def test_prefill_capacity_cannot_exceed_scheduler_bound():

--- a/tests/quantization/test_exl3_prefill_plan.py
+++ b/tests/quantization/test_exl3_prefill_plan.py
@@ -160,6 +160,8 @@ def _make_mixed_layer():
         "global_to_combined": object(),
         "descriptor_map": object(),
         "rotations": object(),
+        "broadcast_suh": False,
+        "broadcast_svh": False,
         "tile_config": (64, 128, 64, 128),
         "prefill_tile_config": (128, 128, 128, 128),
     }
@@ -375,6 +377,22 @@ def test_mixed_runtime_policy_is_resolved_once(monkeypatch):
         assert first is second
         assert calls == 1
         assert len(h.mixed_api.compiled) == 2
+
+
+def test_mixed_runtime_forwards_shared_h_broadcast_contract():
+    with _Harness() as h:
+        method = _make_method()
+        layer = _make_mixed_layer()
+        layer.exl3_mixed_trellis["broadcast_suh"] = True
+        layer.exl3_mixed_trellis["broadcast_svh"] = True
+        x = torch.zeros((16, HIDDEN), dtype=torch.bfloat16)
+        ids = torch.zeros((16, TOPK), dtype=torch.int64)
+
+        method._mixed_rank_sliced_runtime(layer, x, ids)
+
+        assert len(h.mixed_api.compiled) == 2
+        assert all(launch.broadcast_suh is True for launch in h.mixed_api.compiled)
+        assert all(launch.broadcast_svh is True for launch in h.mixed_api.compiled)
 
 
 def test_prefill_capacity_cannot_exceed_scheduler_bound():

--- a/tests/quantization/test_exl3_prefill_plan.py
+++ b/tests/quantization/test_exl3_prefill_plan.py
@@ -212,6 +212,7 @@ class _Harness:
         )
         exl3_module._RANK_SLICED_RUNTIMES.clear()
         exl3_module._MIXED_TRELLIS_RUNTIMES.clear()
+        exl3_module._MIXED_TRELLIS_BUFFERS.clear()
         return self
 
     def __exit__(self, *exc):
@@ -230,6 +231,7 @@ class _Harness:
                 os.environ[name] = value
         exl3_module._RANK_SLICED_RUNTIMES.clear()
         exl3_module._MIXED_TRELLIS_RUNTIMES.clear()
+        exl3_module._MIXED_TRELLIS_BUFFERS.clear()
         return False
 
     def planned_caps(self):
@@ -377,6 +379,36 @@ def test_mixed_runtime_policy_is_resolved_once(monkeypatch):
         assert first is second
         assert calls == 1
         assert len(h.mixed_api.compiled) == 2
+
+
+def test_mixed_buffer_pool_is_scoped_to_target_or_draft_owner():
+    with _Harness() as h:
+        launch = SimpleNamespace(
+            hidden_size=HIDDEN,
+            intermediate_size=INTERMEDIATE,
+            size_m=32,
+            max_m_blocks=4,
+            tier0_num_experts=4,
+            tier1_num_experts=4,
+            rotation_input_dtype="bf16",
+            route_ids_dtype=torch.int64,
+        )
+        args = (
+            h.mixed_api,
+            launch,
+            torch.device("cpu"),
+            1,
+            32,
+            8,
+            (64, 128, 64, 128),
+            TOPK,
+        )
+        target = exl3_module._shared_mixed_buffers((1, False), *args)
+        target_again = exl3_module._shared_mixed_buffers((1, False), *args)
+        draft = exl3_module._shared_mixed_buffers((1, True), *args)
+
+        assert target_again is target
+        assert draft is not target
 
 
 def test_mixed_runtime_forwards_shared_h_broadcast_contract():

--- a/tests/quantization/test_exl3_prefill_plan.py
+++ b/tests/quantization/test_exl3_prefill_plan.py
@@ -158,7 +158,7 @@ def _make_mixed_layer():
         "descriptor_map": object(),
         "rotations": object(),
         "tile_config": (64, 128, 64, 128),
-        "prefill_tile_config": (128, 64, 64, 128),
+        "prefill_tile_config": (128, 128, 128, 128),
     }
     return layer
 
@@ -331,7 +331,7 @@ def test_mixed_prefill_capacity_slices_rows_and_routing():
 
         assert [launch.size_m for launch in h.mixed_api.compiled] == [32, 128]
         assert [launch.moe_block_size for launch in h.mixed_api.compiled] == [8, 64]
-        assert h.mixed_api.compiled[1].force_tile_config == (128, 64, 64, 128)
+        assert h.mixed_api.compiled[1].force_tile_config == (128, 128, 128, 128)
         assert not h.planned_caps()
         assert not h.api.bound
         assert torch.equal(out, x)

--- a/tests/quantization/test_exl3_prefill_plan.py
+++ b/tests/quantization/test_exl3_prefill_plan.py
@@ -99,6 +99,7 @@ class _FakeMixedTrellisApi:
     def __init__(self):
         self.compiled = []
         self.routed = []
+        self.calls = []
 
     def max_packed_route_slots(self, routed_rows, block_size, experts):
         del block_size, experts
@@ -114,9 +115,11 @@ class _FakeMixedTrellisApi:
         return SimpleNamespace(scratch=torch.empty(launch.size_m, dtype=torch.uint8))
 
     def run_mixed_trellis(self, *args):
-        x, topk_weights, topk_ids = args[0], args[3], args[4]
+        x, tier0, tier1, topk_weights, topk_ids = args[:5]
+        self.calls.append((int(x.shape[0]), tier0, tier1))
         self.routed.append((topk_weights.clone(), topk_ids.clone()))
         return x.to(torch.float32)
+
 
 class _FakeExt:
     """Parity extension without exl3_moe_fused: chunk loop only."""
@@ -334,11 +337,44 @@ def test_mixed_prefill_capacity_slices_rows_and_routing():
         assert h.mixed_api.compiled[1].force_tile_config == (128, 128, 128, 128)
         assert not h.planned_caps()
         assert not h.api.bound
+        assert [call[0] for call in h.mixed_api.calls] == [128, 72]
+        assert all(
+            call[1:] == layer.exl3_mixed_trellis["prefill_tiers"]
+            for call in h.mixed_api.calls
+        )
         assert torch.equal(out, x)
         assert torch.equal(
             torch.cat([route[0] for route in h.mixed_api.routed]), weights
         )
         assert torch.equal(torch.cat([route[1] for route in h.mixed_api.routed]), ids)
+
+
+def test_mixed_runtime_policy_is_resolved_once(monkeypatch):
+    calls = 0
+
+    def properties(device):
+        nonlocal calls
+        del device
+        calls += 1
+        return SimpleNamespace(
+            major=12,
+            multi_processor_count=1,
+            shared_memory_per_block_optin=1,
+        )
+
+    with _Harness() as h:
+        monkeypatch.setattr(torch.cuda, "get_device_properties", properties)
+        method = _make_method()
+        layer = _make_mixed_layer()
+        x = torch.zeros((16, HIDDEN), dtype=torch.bfloat16)
+        ids = torch.zeros((16, TOPK), dtype=torch.int64)
+
+        first = method._mixed_rank_sliced_runtime(layer, x, ids)
+        second = method._mixed_rank_sliced_runtime(layer, x, ids)
+
+        assert first is second
+        assert calls == 1
+        assert len(h.mixed_api.compiled) == 2
 
 
 def test_prefill_capacity_cannot_exceed_scheduler_bound():

--- a/tests/quantization/test_exl3_prefill_plan.py
+++ b/tests/quantization/test_exl3_prefill_plan.py
@@ -98,8 +98,10 @@ class _FakeFusedMoeApi:
 class _FakeMixedTrellisApi:
     def __init__(self):
         self.compiled = []
+        self.compiled3 = []
         self.routed = []
         self.calls = []
+        self.calls3 = []
 
     def max_packed_route_slots(self, routed_rows, block_size, experts):
         del block_size, experts
@@ -110,13 +112,28 @@ class _FakeMixedTrellisApi:
         self.compiled.append(launch)
         return launch
 
+    def compile_mixed_trellis3(self, **kwargs):
+        launch = SimpleNamespace(**kwargs)
+        self.compiled3.append(launch)
+        return launch
+
     def make_mixed_trellis_buffers(self, launch, **kwargs):
+        del kwargs
+        return SimpleNamespace(scratch=torch.empty(launch.size_m, dtype=torch.uint8))
+
+    def make_mixed_trellis3_buffers(self, launch, **kwargs):
         del kwargs
         return SimpleNamespace(scratch=torch.empty(launch.size_m, dtype=torch.uint8))
 
     def run_mixed_trellis(self, *args):
         x, tier0, tier1, topk_weights, topk_ids = args[:5]
         self.calls.append((int(x.shape[0]), tier0, tier1))
+        self.routed.append((topk_weights.clone(), topk_ids.clone()))
+        return x.to(torch.float32)
+
+    def run_mixed_trellis3(self, *args):
+        x, tier0, tier1, tier2, topk_weights, topk_ids = args[:6]
+        self.calls3.append((int(x.shape[0]), tier0, tier1, tier2))
         self.routed.append((topk_weights.clone(), topk_ids.clone()))
         return x.to(torch.float32)
 
@@ -157,6 +174,27 @@ def _make_mixed_layer():
         "prefill_tiers": (object(), object()),
         "tier_ids": ((0, 1, 2, 3), (4, 5, 6, 7)),
         "tier_bits": (3, 4),
+        "trellis_codebook": "mcg",
+        "global_to_combined": object(),
+        "descriptor_map": object(),
+        "rotations": object(),
+        "broadcast_suh": False,
+        "broadcast_svh": False,
+        "tile_config": (64, 128, 64, 128),
+        "prefill_tile_config": (128, 128, 128, 128),
+    }
+    return layer
+
+
+def _make_mixed3_layer():
+    layer = _make_layer()
+    layer.exl3_mixed_bitrate = True
+    layer.exl3_mixed_trellis = {
+        "tiers": (object(), object(), object()),
+        "prefill_tiers": (object(), object(), object()),
+        "tier_ids": ((0, 1, 2), (3, 4, 5), (6, 7)),
+        "tier_bits": (3, 4, 5),
+        "trellis_codebook": "mcg",
         "global_to_combined": object(),
         "descriptor_map": object(),
         "rotations": object(),
@@ -338,6 +376,9 @@ def test_mixed_prefill_capacity_slices_rows_and_routing():
 
         assert [launch.size_m for launch in h.mixed_api.compiled] == [32, 128]
         assert [launch.moe_block_size for launch in h.mixed_api.compiled] == [8, 64]
+        assert all(
+            launch.route_num_experts == EXPERTS for launch in h.mixed_api.compiled
+        )
         assert h.mixed_api.compiled[1].force_tile_config == (128, 128, 128, 128)
         assert not h.planned_caps()
         assert not h.api.bound
@@ -345,6 +386,36 @@ def test_mixed_prefill_capacity_slices_rows_and_routing():
         assert all(
             call[1:] == layer.exl3_mixed_trellis["prefill_tiers"]
             for call in h.mixed_api.calls
+        )
+        assert torch.equal(out, x)
+        assert torch.equal(
+            torch.cat([route[0] for route in h.mixed_api.routed]), weights
+        )
+        assert torch.equal(torch.cat([route[1] for route in h.mixed_api.routed]), ids)
+
+
+def test_three_tier_prefill_uses_native_b12x_dispatch():
+    with _Harness(env={"VLLM_EXL3_PREFILL_CAPACITY": "128"}) as h:
+        method = _make_method()
+        layer = _make_mixed3_layer()
+        rows = 200
+        x = torch.arange(rows, dtype=torch.bfloat16).unsqueeze(1).expand(-1, HIDDEN)
+        weights = torch.arange(rows * TOPK, dtype=torch.float32).reshape(rows, TOPK)
+        ids = torch.arange(rows * TOPK, dtype=torch.int64).reshape(rows, TOPK)
+        ids = ids.remainder(EXPERTS)
+
+        out = method._apply_rank_sliced(layer, x, weights, ids)
+
+        assert not h.mixed_api.compiled
+        assert [launch.size_m for launch in h.mixed_api.compiled3] == [32, 128]
+        assert all(launch.trellis_codebook == "mcg" for launch in h.mixed_api.compiled3)
+        assert all(
+            launch.route_num_experts == EXPERTS for launch in h.mixed_api.compiled3
+        )
+        assert [call[0] for call in h.mixed_api.calls3] == [128, 72]
+        assert all(
+            call[1:] == layer.exl3_mixed_trellis["prefill_tiers"]
+            for call in h.mixed_api.calls3
         )
         assert torch.equal(out, x)
         assert torch.equal(
@@ -409,6 +480,17 @@ def test_mixed_buffer_pool_is_scoped_to_target_or_draft_owner():
 
         assert target_again is target
         assert draft is not target
+
+        launch3 = SimpleNamespace(
+            **{
+                **vars(launch),
+                "tier2_num_experts": 1,
+            }
+        )
+        three_tier = exl3_module._shared_mixed_buffers(
+            (1, False), h.mixed_api, launch3, *args[2:]
+        )
+        assert three_tier is not target
 
 
 def test_mixed_runtime_forwards_shared_h_broadcast_contract():

--- a/tests/quantization/test_exl3_prefill_plan.py
+++ b/tests/quantization/test_exl3_prefill_plan.py
@@ -7,7 +7,8 @@ The planned Trellis API and the ExLlamaV3 extension are mocked; these tests
 prove backend policy only:
 
 * decode window m in [min, max] binds the decode plan;
-* max < m <= capacity binds the prefill plan (block_size_m=64 by default);
+* max < m <= scheduler capacity binds capacity-bounded prefill slices;
+* the opt-in prefill capacity defaults to the scheduler capacity;
 * m < min stays on the parity path with chunk-capped staging buffers;
 * VLLM_EXL3_PREFILL_TRELLIS=0 restores the single-plan parity behavior
   with full-capacity staging;
@@ -50,6 +51,7 @@ class _FakeFusedMoeApi:
     def __init__(self):
         self.planned = []
         self.bound = []
+        self.routed = []
 
     def Caps(self, **kwargs):
         return kwargs
@@ -60,12 +62,37 @@ class _FakeFusedMoeApi:
         return plan
 
     def bind(self, plan, *, scratch, a, experts, topk_weights, topk_ids):
-        del scratch, experts, topk_weights, topk_ids
+        del scratch, experts
         self.bound.append((plan, int(a.shape[0])))
-        return SimpleNamespace(plan=plan, m=int(a.shape[0]))
+        self.routed.append((topk_weights.clone(), topk_ids.clone()))
+        return SimpleNamespace(plan=plan, a=a)
 
     def run(self, *, binding):
-        return torch.zeros((binding.m, HIDDEN), dtype=torch.float32)
+        return binding.a.to(torch.float32)
+
+
+class _FakeMixedTrellisApi:
+    def __init__(self):
+        self.compiled = []
+        self.routed = []
+
+    def max_packed_route_slots(self, routed_rows, block_size, experts):
+        del block_size, experts
+        return routed_rows
+
+    def compile_mixed_trellis(self, **kwargs):
+        launch = SimpleNamespace(**kwargs)
+        self.compiled.append(launch)
+        return launch
+
+    def make_mixed_trellis_buffers(self, launch, **kwargs):
+        del kwargs
+        return SimpleNamespace(scratch=torch.empty(launch.size_m, dtype=torch.uint8))
+
+    def run_mixed_trellis(self, *args):
+        x, topk_weights, topk_ids = args[0], args[3], args[4]
+        self.routed.append((topk_weights.clone(), topk_ids.clone()))
+        return x.to(torch.float32)
 
 
 class _FakeExt:
@@ -96,6 +123,21 @@ def _make_layer():
     )
 
 
+def _make_mixed_layer():
+    layer = _make_layer()
+    layer.exl3_mixed_bitrate = True
+    layer.exl3_mixed_trellis = {
+        "tiers": (object(), object()),
+        "tier_ids": ((0, 1, 2, 3), (4, 5, 6, 7)),
+        "tier_bits": (3, 4),
+        "global_to_combined": object(),
+        "descriptor_map": object(),
+        "rotations": object(),
+        "tile_config": (64, 128, 64, 128),
+    }
+    return layer
+
+
 def _make_method():
     method = object.__new__(Exl3MoEMethod)
     method.quant_config = SimpleNamespace(
@@ -112,6 +154,7 @@ class _Harness:
         self._saved_capturing = None
         self.api = _FakeFusedMoeApi()
         self.ext = _FakeExt()
+        self.mixed_api = _FakeMixedTrellisApi()
 
     def __enter__(self):
         for name, value in self._env.items():
@@ -122,30 +165,41 @@ class _Harness:
                 os.environ[name] = value
         self._saved_loaders = (
             exl3_module._load_b12x_fused_moe,
+            exl3_module._load_b12x_mixed_trellis,
             exl3_module._load_exl3_ext,
         )
         exl3_module._load_b12x_fused_moe = lambda: self.api
+        exl3_module._load_b12x_mixed_trellis = lambda: self.mixed_api
         exl3_module._load_exl3_ext = lambda: self.ext
         self._saved_capturing = torch.cuda.is_current_stream_capturing
         torch.cuda.is_current_stream_capturing = lambda: False
         self._saved_current_device = torch.cuda.current_device
         torch.cuda.current_device = lambda: 0
+        self._saved_device_properties = torch.cuda.get_device_properties
+        torch.cuda.get_device_properties = lambda device: SimpleNamespace(
+            multi_processor_count=1,
+            shared_memory_per_block_optin=1,
+        )
         exl3_module._RANK_SLICED_RUNTIMES.clear()
+        exl3_module._MIXED_TRELLIS_RUNTIMES.clear()
         return self
 
     def __exit__(self, *exc):
         (
             exl3_module._load_b12x_fused_moe,
+            exl3_module._load_b12x_mixed_trellis,
             exl3_module._load_exl3_ext,
         ) = self._saved_loaders
         torch.cuda.is_current_stream_capturing = self._saved_capturing
         torch.cuda.current_device = self._saved_current_device
+        torch.cuda.get_device_properties = self._saved_device_properties
         for name, value in self._saved_env.items():
             if value is None:
                 os.environ.pop(name, None)
             else:
                 os.environ[name] = value
         exl3_module._RANK_SLICED_RUNTIMES.clear()
+        exl3_module._MIXED_TRELLIS_RUNTIMES.clear()
         return False
 
     def planned_caps(self):
@@ -159,24 +213,26 @@ def _apply(method, layer, m):
     return method._apply_rank_sliced(layer, x, weights, ids)
 
 
-def test_dual_plan_construction_and_dispatch():
-    with _Harness() as h:
+def test_opt_in_prefill_capacity_slices_dispatch():
+    with _Harness(env={"VLLM_EXL3_PREFILL_CAPACITY": "128"}) as h:
         method = _make_method()
         layer = _make_layer()
 
         out = _apply(method, layer, 16)
         assert out.dtype == torch.bfloat16 and out.shape == (16, HIDDEN)
-        # Two plans: decode (32, block 8) then prefill (capacity, block 64).
+        # Two plans: decode (32, block 8), then bounded prefill (block 64).
         assert [
             (caps["max_tokens"], caps["w4a16_block_size_m"])
             for caps in h.planned_caps()
-        ] == [(32, 8), (MAX_BATCHED, 64)]
+        ] == [(32, 8), (128, 64)]
         assert all(caps["route_num_experts"] == 0 for caps in h.planned_caps())
         assert h.api.bound[-1][0].caps["max_tokens"] == 32
 
         _apply(method, layer, 200)
-        assert h.api.bound[-1][0].caps["max_tokens"] == MAX_BATCHED
-        assert h.api.bound[-1][1] == 200
+        assert all(
+            bound[0].caps["max_tokens"] == 128 for bound in h.api.bound[-2:]
+        )
+        assert [bound[1] for bound in h.api.bound[-2:]] == [128, 72]
         assert not h.ext.moe_calls
 
         _apply(method, layer, 2)
@@ -188,6 +244,7 @@ def test_dual_plan_construction_and_dispatch():
         assert runtime["parity_rows"] == 128
         assert runtime["xh"].shape[0] == 128
         assert runtime["token_sorted"].numel() == 128 * TOPK
+        assert runtime["prefill_capacity"] == 128
 
         # Batches above the scheduler contract must fail before allocating a
         # replacement runtime or a larger Trellis arena during serving.
@@ -202,6 +259,86 @@ def test_dual_plan_construction_and_dispatch():
         assert tuple(exl3_module._RANK_SLICED_RUNTIMES) == runtime_keys
         assert len(exl3_module._RANK_SLICED_RUNTIMES) == runtime_count
         assert len(h.planned_caps()) == plan_count
+
+
+@pytest.mark.parametrize(
+    ("rows", "expected_slice_rows"),
+    ((127, [127]), (128, [128]), (129, [128, 1])),
+)
+def test_prefill_capacity_boundaries_preserve_rows_and_routing(
+    rows, expected_slice_rows
+):
+    with _Harness(env={"VLLM_EXL3_PREFILL_CAPACITY": "128"}) as h:
+        method = _make_method()
+        layer = _make_layer()
+        x = (
+            torch.arange(rows, dtype=torch.bfloat16)
+            .unsqueeze(1)
+            .expand(-1, HIDDEN)
+        )
+        weights = torch.arange(rows * TOPK, dtype=torch.float32).reshape(
+            rows, TOPK
+        )
+        ids = torch.arange(rows * TOPK, dtype=torch.int64).reshape(rows, TOPK)
+        ids = ids.remainder(EXPERTS)
+
+        out = method._apply_rank_sliced(layer, x, weights, ids)
+
+        assert [bound[1] for bound in h.api.bound] == expected_slice_rows
+        assert torch.equal(out, x)
+        assert torch.equal(
+            torch.cat([route[0] for route in h.api.routed]), weights
+        )
+        assert torch.equal(torch.cat([route[1] for route in h.api.routed]), ids)
+        assert all(bound[0] is h.api.bound[0][0] for bound in h.api.bound)
+
+
+def test_default_prefill_capacity_keeps_single_dispatch():
+    with _Harness() as h:
+        out = _apply(_make_method(), _make_layer(), 200)
+
+        assert h.planned_caps()[-1]["max_tokens"] == MAX_BATCHED
+        assert [bound[1] for bound in h.api.bound] == [200]
+        assert out.shape == (200, HIDDEN)
+
+
+def test_mixed_prefill_capacity_slices_rows_and_routing():
+    with _Harness(env={"VLLM_EXL3_PREFILL_CAPACITY": "128"}) as h:
+        method = _make_method()
+        layer = _make_mixed_layer()
+        rows = 200
+        x = (
+            torch.arange(rows, dtype=torch.bfloat16)
+            .unsqueeze(1)
+            .expand(-1, HIDDEN)
+        )
+        weights = torch.arange(rows * TOPK, dtype=torch.float32).reshape(
+            rows, TOPK
+        )
+        ids = torch.arange(rows * TOPK, dtype=torch.int64).reshape(rows, TOPK)
+        ids = ids.remainder(EXPERTS)
+
+        out = method._apply_rank_sliced(layer, x, weights, ids)
+
+        assert [launch.size_m for launch in h.mixed_api.compiled] == [32, 128]
+        assert [route[0].shape[0] for route in h.mixed_api.routed] == [128, 72]
+        assert torch.equal(out, x)
+        assert torch.equal(
+            torch.cat([route[0] for route in h.mixed_api.routed]), weights
+        )
+        assert torch.equal(
+            torch.cat([route[1] for route in h.mixed_api.routed]), ids
+        )
+
+
+def test_prefill_capacity_cannot_exceed_scheduler_bound():
+    env = {"VLLM_EXL3_PREFILL_CAPACITY": str(MAX_BATCHED + 1)}
+    with _Harness(env=env) as h:
+        with pytest.raises(
+            ValueError, match="cannot exceed max_num_batched_tokens"
+        ):
+            _apply(_make_method(), _make_layer(), 16)
+        assert not h.planned_caps()
 
 
 def test_prefill_trellis_disabled_restores_parity():
@@ -221,16 +358,19 @@ def test_prefill_trellis_disabled_restores_parity():
         runtime = next(iter(exl3_module._RANK_SLICED_RUNTIMES.values()))
         assert runtime["prefill_plan"] is None
         assert runtime["parity_rows"] == MAX_BATCHED
-        assert runtime["xh"].shape[0] == MAX_BATCHED
 
 
 def test_prefill_block_m_env_override():
-    with _Harness(env={"VLLM_EXL3_PREFILL_BLOCK_M": "48"}) as h:
+    env = {
+        "VLLM_EXL3_PREFILL_BLOCK_M": "48",
+        "VLLM_EXL3_PREFILL_CAPACITY": "128",
+    }
+    with _Harness(env=env) as h:
         method = _make_method()
         layer = _make_layer()
         _apply(method, layer, 40)
         assert h.planned_caps()[-1]["w4a16_block_size_m"] == 48
-        assert h.api.bound[-1][0].caps["max_tokens"] == MAX_BATCHED
+        assert h.api.bound[-1][0].caps["max_tokens"] == 128
 
 
 def test_parity_window_capacity_is_validated_before_planning():
@@ -259,7 +399,11 @@ def test_disabled_prefill_plan_keeps_full_parity_capacity():
 
 
 def test_explicit_parity_path_guarded_against_capture():
-    with _Harness(env={"VLLM_EXL3_TRELLIS_MIN_M": "4"}) as h:
+    env = {
+        "VLLM_EXL3_TRELLIS_MIN_M": "4",
+        "VLLM_EXL3_PREFILL_CAPACITY": "128",
+    }
+    with _Harness(env=env) as h:
         method = _make_method()
         layer = _make_layer()
         # Plan eagerly, then flip into "capturing" state.
@@ -268,18 +412,14 @@ def test_explicit_parity_path_guarded_against_capture():
         # Both trellis plans stay capture-safe.
         _apply(method, layer, 16)
         _apply(method, layer, 200)
-        assert h.api.bound[-1][1] == 200
+        assert [bound[1] for bound in h.api.bound[-2:]] == [128, 72]
         # The eager parity path must refuse to be recorded.
-        try:
+        with pytest.raises(RuntimeError, match="capture"):
             _apply(method, layer, 2)
-        except RuntimeError as err:
-            assert "capture" in str(err)
-        else:
-            raise AssertionError("parity path must raise during capture")
 
 
 if __name__ == "__main__":
-    test_dual_plan_construction_and_dispatch()
+    test_opt_in_prefill_capacity_slices_dispatch()
     test_prefill_trellis_disabled_restores_parity()
     test_prefill_block_m_env_override()
     test_explicit_parity_path_guarded_against_capture()

--- a/tests/quantization/test_exl3_prefill_plan.py
+++ b/tests/quantization/test_exl3_prefill_plan.py
@@ -424,7 +424,7 @@ def test_three_tier_prefill_uses_native_b12x_dispatch():
         assert torch.equal(torch.cat([route[1] for route in h.mixed_api.routed]), ids)
 
 
-def test_mixed_runtime_policy_is_resolved_once(monkeypatch):
+def test_mixed_runtime_policy_is_resolved_once():
     calls = 0
 
     def properties(device):
@@ -438,7 +438,7 @@ def test_mixed_runtime_policy_is_resolved_once(monkeypatch):
         )
 
     with _Harness() as h:
-        monkeypatch.setattr(torch.cuda, "get_device_properties", properties)
+        torch.cuda.get_device_properties = properties
         method = _make_method()
         layer = _make_mixed_layer()
         x = torch.zeros((16, HIDDEN), dtype=torch.bfloat16)

--- a/tests/quantization/test_exl3_prefill_plan.py
+++ b/tests/quantization/test_exl3_prefill_plan.py
@@ -61,13 +61,37 @@ class _FakeFusedMoeApi:
         self.planned.append(caps)
         return plan
 
-    def bind(self, plan, *, scratch, a, experts, topk_weights, topk_ids):
+    def bind(
+        self,
+        plan,
+        *,
+        scratch,
+        a,
+        experts,
+        topk_weights,
+        topk_ids,
+        route_expert_map=None,
+        output_expert_map=None,
+        output=None,
+    ):
         del scratch, experts
         self.bound.append((plan, int(a.shape[0])))
         self.routed.append((topk_weights.clone(), topk_ids.clone()))
-        return SimpleNamespace(plan=plan, a=a)
+        return SimpleNamespace(
+            plan=plan,
+            a=a,
+            route_expert_map=route_expert_map,
+            output_expert_map=output_expert_map,
+            output=output,
+        )
 
     def run(self, *, binding):
+        if binding.route_expert_map is not None:
+            tier_output = binding.a.to(torch.float32).mul(0.5)
+            if binding.output is not None:
+                binding.output.copy_(tier_output)
+                return binding.output
+            return tier_output
         return binding.a.to(torch.float32)
 
 
@@ -134,6 +158,17 @@ def _make_mixed_layer():
         "descriptor_map": object(),
         "rotations": object(),
         "tile_config": (64, 128, 64, 128),
+        "serial_tile_config": (64, 128, 64, 128),
+        "serial_tiers": (
+            {
+                "weights": SimpleNamespace(plan=object()),
+                "route_expert_map": torch.tensor([0, 1, 2, 3, -1, -1, -1, -1]),
+            },
+            {
+                "weights": SimpleNamespace(plan=object()),
+                "route_expert_map": torch.tensor([-1, -1, -1, -1, 0, 1, 2, 3]),
+            },
+        ),
     }
     return layer
 
@@ -229,9 +264,7 @@ def test_opt_in_prefill_capacity_slices_dispatch():
         assert h.api.bound[-1][0].caps["max_tokens"] == 32
 
         _apply(method, layer, 200)
-        assert all(
-            bound[0].caps["max_tokens"] == 128 for bound in h.api.bound[-2:]
-        )
+        assert all(bound[0].caps["max_tokens"] == 128 for bound in h.api.bound[-2:])
         assert [bound[1] for bound in h.api.bound[-2:]] == [128, 72]
         assert not h.ext.moe_calls
 
@@ -271,14 +304,8 @@ def test_prefill_capacity_boundaries_preserve_rows_and_routing(
     with _Harness(env={"VLLM_EXL3_PREFILL_CAPACITY": "128"}) as h:
         method = _make_method()
         layer = _make_layer()
-        x = (
-            torch.arange(rows, dtype=torch.bfloat16)
-            .unsqueeze(1)
-            .expand(-1, HIDDEN)
-        )
-        weights = torch.arange(rows * TOPK, dtype=torch.float32).reshape(
-            rows, TOPK
-        )
+        x = torch.arange(rows, dtype=torch.bfloat16).unsqueeze(1).expand(-1, HIDDEN)
+        weights = torch.arange(rows * TOPK, dtype=torch.float32).reshape(rows, TOPK)
         ids = torch.arange(rows * TOPK, dtype=torch.int64).reshape(rows, TOPK)
         ids = ids.remainder(EXPERTS)
 
@@ -286,9 +313,7 @@ def test_prefill_capacity_boundaries_preserve_rows_and_routing(
 
         assert [bound[1] for bound in h.api.bound] == expected_slice_rows
         assert torch.equal(out, x)
-        assert torch.equal(
-            torch.cat([route[0] for route in h.api.routed]), weights
-        )
+        assert torch.equal(torch.cat([route[0] for route in h.api.routed]), weights)
         assert torch.equal(torch.cat([route[1] for route in h.api.routed]), ids)
         assert all(bound[0] is h.api.bound[0][0] for bound in h.api.bound)
 
@@ -307,36 +332,31 @@ def test_mixed_prefill_capacity_slices_rows_and_routing():
         method = _make_method()
         layer = _make_mixed_layer()
         rows = 200
-        x = (
-            torch.arange(rows, dtype=torch.bfloat16)
-            .unsqueeze(1)
-            .expand(-1, HIDDEN)
-        )
-        weights = torch.arange(rows * TOPK, dtype=torch.float32).reshape(
-            rows, TOPK
-        )
+        x = torch.arange(rows, dtype=torch.bfloat16).unsqueeze(1).expand(-1, HIDDEN)
+        weights = torch.arange(rows * TOPK, dtype=torch.float32).reshape(rows, TOPK)
         ids = torch.arange(rows * TOPK, dtype=torch.int64).reshape(rows, TOPK)
         ids = ids.remainder(EXPERTS)
 
         out = method._apply_rank_sliced(layer, x, weights, ids)
 
-        assert [launch.size_m for launch in h.mixed_api.compiled] == [32, 128]
-        assert [route[0].shape[0] for route in h.mixed_api.routed] == [128, 72]
+        assert [launch.size_m for launch in h.mixed_api.compiled] == [32]
+        assert [caps["max_tokens"] for caps in h.planned_caps()] == [128, 128]
+        assert [bound[1] for bound in h.api.bound] == [128, 128, 72, 72]
         assert torch.equal(out, x)
         assert torch.equal(
-            torch.cat([route[0] for route in h.mixed_api.routed]), weights
+            torch.cat([route[0] for route in h.api.routed[::2]]), weights
         )
-        assert torch.equal(
-            torch.cat([route[1] for route in h.mixed_api.routed]), ids
+        assert torch.equal(torch.cat([route[1] for route in h.api.routed[::2]]), ids)
+        assert all(
+            torch.equal(left[0], right[0]) and torch.equal(left[1], right[1])
+            for left, right in zip(h.api.routed[::2], h.api.routed[1::2], strict=True)
         )
 
 
 def test_prefill_capacity_cannot_exceed_scheduler_bound():
     env = {"VLLM_EXL3_PREFILL_CAPACITY": str(MAX_BATCHED + 1)}
     with _Harness(env=env) as h:
-        with pytest.raises(
-            ValueError, match="cannot exceed max_num_batched_tokens"
-        ):
+        with pytest.raises(ValueError, match="cannot exceed max_num_batched_tokens"):
             _apply(_make_method(), _make_layer(), 16)
         assert not h.planned_caps()
 

--- a/tests/quantization/test_exl3_reconstruct_arena.py
+++ b/tests/quantization/test_exl3_reconstruct_arena.py
@@ -1,0 +1,193 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for the shared EXL3 prefill-reconstruct scratch arena.
+
+CPU-only; no CUDA, b12x, or exllamav3_ext required. The arena replaces one
+persistent fp16 buffer per (device, K, N-chunk) with one byte arena per
+device sized to the largest live geometry. Safety rests on two invariants
+these tests pin down:
+
+  * the scratch is written and fully consumed inside one eager
+    ``_reconstruct_hgemm_into`` call on one stream, so at most one geometry's
+    scratch is live at a time and every view can start at arena offset 0;
+  * a CUDA-graph capture bakes the arena address into replayed kernels, so a
+    capture-recorded arena is frozen and never reallocated; geometries that
+    no longer fit fall back to dedicated persistent buffers (the pre-arena
+    behaviour).
+"""
+
+import torch
+
+import vllm.model_executor.layers.quantization.exl3 as exl3_module
+
+# Small synthetic geometries (K, N); all multiples of 16 as the trellis
+# packing requires. The wide one exercises the chunk loop once
+# _EXL3_RECONSTRUCT_SLICE_N is narrowed in the harness below.
+GEOMETRIES = [
+    (256, 512),
+    (512, 256),
+    (256, 1024),
+    (1024, 256),
+    (256, 2048),
+]
+NARROW_SLICE_N = 512
+
+
+class _FakeExt:
+    """Tags every scratch write and verifies the tag at consumption."""
+
+    def __init__(self):
+        self._tag = 0.0
+        self._live = None
+        self.consumed = 0
+        self.views = []
+
+    def had_r_128(self, x, out, su, sv, scale):
+        if x.data_ptr() != out.data_ptr():
+            out.copy_(x)
+
+    def _write(self, view):
+        self._tag += 1.0
+        assert view.dtype == torch.float16
+        assert view.storage_offset() == 0, "arena views must start at offset 0"
+        row_bytes = ((view.shape[0] - 1) * view.stride(0) + view.shape[1]) * 2
+        assert row_bytes <= view.untyped_storage().nbytes(), "view out of bounds"
+        self.views.append(view)
+        view.fill_(self._tag)
+        self._live = (view, self._tag)
+
+    def reconstruct(self, view, trellis, bits, mcg, mul1):
+        self._write(view)
+
+    def reconstruct_slice(self, view, trellis, bits, mcg, mul1, start):
+        self._write(view)
+
+    def hgemm(self, x_had, view, out):
+        live, tag = self._live
+        assert bool((live == tag).all()), (
+            "scratch clobbered between reconstruct write and hgemm read"
+        )
+        self.consumed += 1
+        out.fill_(0.0)
+
+
+class _Harness:
+    def __init__(self, capturing=False):
+        self.ext = _FakeExt()
+        self._capturing = capturing
+
+    def set_capturing(self, value):
+        self._capturing = value
+
+    def __enter__(self):
+        self._saved_capturing = torch.cuda.is_current_stream_capturing
+        torch.cuda.is_current_stream_capturing = lambda: self._capturing
+        self._saved_current_device = torch.cuda.current_device
+        torch.cuda.current_device = lambda: 0
+        self._saved_load_ext = exl3_module._load_exl3_ext
+        exl3_module._load_exl3_ext = lambda: self.ext
+        self._saved_slice_n = exl3_module._EXL3_RECONSTRUCT_SLICE_N
+        exl3_module._EXL3_RECONSTRUCT_SLICE_N = NARROW_SLICE_N
+        exl3_module._EXL3_RECONSTRUCT_ARENA.clear()
+        exl3_module._EXL3_RECONSTRUCT_ARENA_FROZEN.clear()
+        exl3_module._EXL3_RECONSTRUCT_SCRATCH.clear()
+        return self
+
+    def __exit__(self, *exc):
+        torch.cuda.is_current_stream_capturing = self._saved_capturing
+        torch.cuda.current_device = self._saved_current_device
+        exl3_module._load_exl3_ext = self._saved_load_ext
+        exl3_module._EXL3_RECONSTRUCT_SLICE_N = self._saved_slice_n
+        exl3_module._EXL3_RECONSTRUCT_ARENA.clear()
+        exl3_module._EXL3_RECONSTRUCT_ARENA_FROZEN.clear()
+        exl3_module._EXL3_RECONSTRUCT_SCRATCH.clear()
+
+
+def _run(k, n, rows=8):
+    trellis = torch.zeros((k // 16, n // 16, 80), dtype=torch.int16)
+    x = torch.zeros((rows, k), dtype=torch.float16)
+    out = torch.empty((rows, n), dtype=torch.float16)
+    suh = torch.zeros((k,), dtype=torch.float16)
+    svh = torch.zeros((n,), dtype=torch.float16)
+    exl3_module._reconstruct_hgemm_into(out, x, trellis, suh, svh, False, False)
+
+
+def _expected_arena_bytes():
+    return max(2 * k * min(n, NARROW_SLICE_N) for k, n in GEOMETRIES)
+
+
+def test_arena_is_shared_and_sized_to_largest_geometry():
+    with _Harness() as h:
+        for k, n in GEOMETRIES:
+            _run(k, n)
+        assert list(exl3_module._EXL3_RECONSTRUCT_ARENA) == [0]
+        arena = exl3_module._EXL3_RECONSTRUCT_ARENA[0]
+        assert arena.numel() == _expected_arena_bytes()
+        assert not exl3_module._EXL3_RECONSTRUCT_SCRATCH
+        assert h.ext.consumed == sum(
+            -(-n // NARROW_SLICE_N) for _, n in GEOMETRIES
+        )
+
+
+def test_arena_view_matches_torch_empty_layout():
+    with _Harness():
+        for k, n in GEOMETRIES:
+            chunk = min(n, NARROW_SLICE_N)
+            view = exl3_module._reconstruct_scratch(torch.device("cpu"), k, chunk)
+            ref = torch.empty((k, chunk), dtype=torch.float16)
+            assert view.shape == ref.shape
+            assert view.stride() == ref.stride()
+            assert view.dtype == ref.dtype
+            assert view.is_contiguous()
+
+
+def test_scratch_survives_until_consumption_across_interleaving():
+    with _Harness() as h:
+        # Repeated interleaved layers, including the chunked wide geometry:
+        # any aliasing between a write and its consumption fails in hgemm.
+        for _ in range(3):
+            for k, n in GEOMETRIES:
+                _run(k, n)
+        assert h.ext.consumed == 3 * sum(
+            -(-n // NARROW_SLICE_N) for _, n in GEOMETRIES
+        )
+
+
+def test_arena_never_grows_during_capture_and_freezes_afterwards():
+    with _Harness() as h:
+        _run(256, 512)  # eager growth to 256 KiB
+        arena = exl3_module._EXL3_RECONSTRUCT_ARENA[0]
+        h.set_capturing(True)
+        # Same-size geometry under capture is served from the arena and
+        # freezes it.
+        view = exl3_module._reconstruct_scratch(torch.device("cpu"), 256, 512)
+        assert view.data_ptr() == arena.data_ptr()
+        assert 0 in exl3_module._EXL3_RECONSTRUCT_ARENA_FROZEN
+        # A bigger geometry under capture gets a dedicated buffer; the arena
+        # object is not replaced.
+        big = exl3_module._reconstruct_scratch(torch.device("cpu"), 1024, 256)
+        assert exl3_module._EXL3_RECONSTRUCT_ARENA[0] is arena
+        assert (0, 1024, 256) in exl3_module._EXL3_RECONSTRUCT_SCRATCH
+        # The dedicated buffer address is stable across calls (a replayed
+        # graph's baked pointer stays valid).
+        again = exl3_module._reconstruct_scratch(torch.device("cpu"), 1024, 256)
+        assert big.data_ptr() == again.data_ptr()
+        # After capture, the frozen arena still never reallocates.
+        h.set_capturing(False)
+        exl3_module._reconstruct_scratch(torch.device("cpu"), 256, 2048)
+        assert exl3_module._EXL3_RECONSTRUCT_ARENA[0] is arena
+        assert (0, 256, 2048) in exl3_module._EXL3_RECONSTRUCT_SCRATCH
+
+
+def test_unfrozen_arena_grows_eagerly_and_reuses_bytes():
+    with _Harness():
+        small = exl3_module._reconstruct_scratch(torch.device("cpu"), 256, 512)
+        assert exl3_module._EXL3_RECONSTRUCT_ARENA[0].numel() == 2 * 256 * 512
+        big = exl3_module._reconstruct_scratch(torch.device("cpu"), 1024, 512)
+        assert exl3_module._EXL3_RECONSTRUCT_ARENA[0].numel() == 2 * 1024 * 512
+        # A smaller geometry after growth reuses the same backing at offset 0.
+        small2 = exl3_module._reconstruct_scratch(torch.device("cpu"), 256, 512)
+        assert small2.data_ptr() == exl3_module._EXL3_RECONSTRUCT_ARENA[0].data_ptr()
+        assert small2.data_ptr() == big.data_ptr()
+        assert not exl3_module._EXL3_RECONSTRUCT_SCRATCH
+        del small

--- a/tests/quantization/test_exl3_warmup.py
+++ b/tests/quantization/test_exl3_warmup.py
@@ -1,0 +1,55 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.quantization.exl3 import (
+    warmup_exl3_mixed_trellis_route_pack,
+)
+
+
+def _model_with_mixed_trellis(mixed: dict) -> torch.nn.Module:
+    model = torch.nn.Module()
+    holder = torch.nn.Module()
+    holder.routed_experts = SimpleNamespace(
+        exl3_mixed_trellis=mixed,
+        layer_name="model.layers.3.mlp.experts",
+    )
+    model.add_module("holder", holder)
+    return model
+
+
+def test_mixed_trellis_warmup_delegates_each_runtime_state() -> None:
+    warmup = Mock(side_effect=(6, 12))
+    api = SimpleNamespace(warmup_mixed_trellis_route_pack=warmup)
+    decode = {"launch": object(), "buffers": object()}
+    prefill = {"launch": object(), "buffers": object()}
+    expert_map = object()
+    model = _model_with_mixed_trellis(
+        {
+            "runtime": {
+                "mixed_api": api,
+                "decode": decode,
+                "prefill": prefill,
+            },
+            "global_to_combined": expert_map,
+        }
+    )
+
+    assert warmup_exl3_mixed_trellis_route_pack(model) == 18
+    assert warmup.call_args_list == [
+        ((decode["launch"], decode["buffers"]), {"expert_map": expert_map}),
+        ((prefill["launch"], prefill["buffers"]), {"expert_map": expert_map}),
+    ]
+
+
+def test_mixed_trellis_warmup_fails_closed_without_profiled_runtime() -> None:
+    model = _model_with_mixed_trellis({"global_to_combined": object()})
+
+    with pytest.raises(RuntimeError, match="eager profile pass must plan"):
+        warmup_exl3_mixed_trellis_route_pack(model)
+
+
+def test_mixed_trellis_warmup_ignores_unrelated_models() -> None:
+    assert warmup_exl3_mixed_trellis_route_pack(torch.nn.Linear(4, 4)) == 0

--- a/tests/quantization/test_quantization_config_args.py
+++ b/tests/quantization/test_quantization_config_args.py
@@ -187,6 +187,35 @@ def test_resolve_rejects_modelopt_moe_override():
         )
 
 
+def test_resolve_allows_exl3_bf16_mxfp8_overlay():
+    args = resolve_quantization_config(
+        "exl3",
+        {
+            "linear": {"weight": "mxfp8"},
+            "shared_experts": "mxfp8",
+            "ignore": ["re:.*q_a_proj$", "lm_head"],
+        },
+    )
+
+    assert args.linear == QuantSpec(weight=kMxfp8Dynamic)
+    assert args.shared_experts == QuantSpec(weight=kMxfp8Dynamic)
+    assert args.ignore == ["re:.*q_a_proj$", "lm_head"]
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        {"linear": {"weight": "fp8_per_block_static"}},
+        {"linear": {"weight": "mxfp8", "activation": "mxfp8"}},
+        {"linear": {"weight": "mxfp8"}, "moe": "mxfp8"},
+        {"shared_experts": "mxfp8", "ignore": ["lm_head"]},
+    ],
+)
+def test_resolve_rejects_unsupported_exl3_overlay(config):
+    with pytest.raises(ValueError, match="checkpoint online overlay"):
+        resolve_quantization_config("exl3", config)
+
+
 def test_resolve_rejects_quantization_config_with_non_shorthand_quant():
     # If --quantization names something other than an online shorthand,
     # quantization_config is not allowed via this path (checkpoint quant

--- a/vllm/config/quantization.py
+++ b/vllm/config/quantization.py
@@ -193,8 +193,7 @@ def resolve_quantization_config(
     quantization: str | None,
     quantization_config: dict[str, Any] | QuantizationConfigArgs | None,
 ) -> QuantizationConfigArgs | None:
-    """Resolve `--quantization` shorthand and `--quantization-config` into a
-    QuantizationConfigArgs.
+    """Resolve quantization CLI settings into structured arguments.
 
     `quantization` may be a CLI shorthand that desugars into a base config via
     `_ONLINE_SHORTHANDS`. `quantization_config` is a dict or pre-built args
@@ -202,6 +201,18 @@ def resolve_quantization_config(
     `quantization_config` take precedence over the shorthand. Selected
     checkpoint formats accept online overlays for BF16 dense/shared-expert
     projections.
+
+    Args:
+        quantization: Quantization method name or online shorthand.
+        quantization_config: Explicit online quantization fields, if any.
+
+    Returns:
+        The resolved quantization arguments, or ``None`` when no online
+        configuration was requested.
+
+    Raises:
+        ValueError: If an explicit configuration cannot overlay the selected
+            checkpoint quantization method.
     """
     if isinstance(quantization_config, dict):
         quantization_config = QuantizationConfigArgs(**quantization_config)

--- a/vllm/config/quantization.py
+++ b/vllm/config/quantization.py
@@ -153,11 +153,14 @@ ONLINE_QUANT_SHORTHAND_NAMES: tuple[str, ...] = (
 )
 
 
-# Checkpoint formats that support overlaying online quantization on BF16 projections
-# which the checkpoint explicitly leaves unquantized (shared experts via
-# `shared_experts`, other dense linears via `linear`).
-_MODELOPT_ONLINE_OVERLAY_NAMES = frozenset(
-    {
+# Checkpoint formats that support overlaying online quantization on projections
+# which the checkpoint explicitly leaves in BF16 (shared experts via
+# `shared_experts`, other dense linears via `linear`). Each checkpoint backend
+# still owns the layer-level dispatch, so serialized weights always take
+# precedence over this overlay.
+_CHECKPOINT_ONLINE_OVERLAY_WEIGHTS = {
+    name: frozenset({kMxfp8Dynamic, kFp8Static128BlockSym})
+    for name in {
         "modelopt",
         "modelopt_fp4",
         "modelopt_mxfp8",
@@ -165,16 +168,15 @@ _MODELOPT_ONLINE_OVERLAY_NAMES = frozenset(
         "mxfp4",
         "nvfp4_nf3_hybrid",
     }
-)
+}
+_CHECKPOINT_ONLINE_OVERLAY_WEIGHTS["exl3"] = frozenset({kMxfp8Dynamic})
 
 
-_MODELOPT_ONLINE_OVERLAY_WEIGHTS = frozenset({kMxfp8Dynamic, kFp8Static128BlockSym})
-
-
-def _is_modelopt_online_overlay(
+def _is_checkpoint_online_overlay(
     quantization: str | None, args: QuantizationConfigArgs
 ) -> bool:
-    if quantization not in _MODELOPT_ONLINE_OVERLAY_NAMES or args.moe is not None:
+    supported_weights = _CHECKPOINT_ONLINE_OVERLAY_WEIGHTS.get(quantization)
+    if supported_weights is None or args.moe is not None:
         return False
     specs = [s for s in (args.linear, args.shared_experts) if s is not None]
     if not specs:
@@ -183,8 +185,7 @@ def _is_modelopt_online_overlay(
         # `ignore` only filters the dense-linear overlay.
         return False
     return all(
-        spec.weight in _MODELOPT_ONLINE_OVERLAY_WEIGHTS and spec.activation is None
-        for spec in specs
+        spec.weight in supported_weights and spec.activation is None for spec in specs
     )
 
 
@@ -198,22 +199,22 @@ def resolve_quantization_config(
     `quantization` may be a CLI shorthand that desugars into a base config via
     `_ONLINE_SHORTHANDS`. `quantization_config` is a dict or pre-built args
     object. When both are online settings, fields explicitly set in
-    `quantization_config` take precedence over the shorthand. ModelOpt accepts
-    online overlays for BF16 dense/shared-expert projections.
+    `quantization_config` take precedence over the shorthand. Selected
+    checkpoint formats accept online overlays for BF16 dense/shared-expert
+    projections.
     """
     if isinstance(quantization_config, dict):
         quantization_config = QuantizationConfigArgs(**quantization_config)
 
     if quantization is not None and quantization not in ONLINE_QUANT_SHORTHAND_NAMES:
-        if quantization_config is not None and not _is_modelopt_online_overlay(
+        if quantization_config is not None and not _is_checkpoint_online_overlay(
             quantization, quantization_config
         ):
             raise ValueError(
                 f"quantization_config is only supported when quantization is "
                 f"one of {sorted(ONLINE_QUANT_SHORTHAND_NAMES)}, or when "
-                f"using the ModelOpt online overlay (weight='mxfp8' or "
-                f"weight='fp8_per_block_static' on 'shared_experts' and/or "
-                f"'linear', optional 'ignore'), "
+                f"using a supported checkpoint online overlay on "
+                f"'shared_experts' and/or 'linear' (optional 'ignore'), "
                 f"got quantization={quantization!r}"
             )
         return quantization_config

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -2290,6 +2290,20 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_EXL3_PREFILL_CAPACITY": lambda: os.getenv("VLLM_EXL3_PREFILL_CAPACITY"),
     "VLLM_EXL3_PREFILL_TRELLIS": lambda: os.getenv("VLLM_EXL3_PREFILL_TRELLIS"),
     "VLLM_EXL3_PREFILL_BLOCK_M": lambda: os.getenv("VLLM_EXL3_PREFILL_BLOCK_M"),
+    # Deterministic online EXL3 encoding and its persistent rank-local cache.
+    "VLLM_EXL3_ONLINE_TRELLIS_BITS": lambda: os.getenv(
+        "VLLM_EXL3_ONLINE_TRELLIS_BITS"
+    ),
+    "VLLM_EXL3_ENCODER_SOURCE": lambda: os.getenv("VLLM_EXL3_ENCODER_SOURCE"),
+    "VLLM_EXL3_ENCODER_REVISION": lambda: os.getenv(
+        "VLLM_EXL3_ENCODER_REVISION"
+    ),
+    "VLLM_EXL3_ONLINE_CACHE_DIR": lambda: os.getenv(
+        "VLLM_EXL3_ONLINE_CACHE_DIR"
+    ),
+    "VLLM_EXL3_ONLINE_CACHE_MODE": lambda: os.getenv(
+        "VLLM_EXL3_ONLINE_CACHE_MODE"
+    ),
     # Prebuilt exllamav3 extension location and torch-ABI compatibility shim.
     "VLLM_EXL3_EXT_PATH": lambda: os.getenv("VLLM_EXL3_EXT_PATH"),
     "VLLM_EXL3_ABI_SHIM": lambda: os.getenv("VLLM_EXL3_ABI_SHIM"),

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -2290,6 +2290,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_EXL3_PREFILL_CAPACITY": lambda: os.getenv("VLLM_EXL3_PREFILL_CAPACITY"),
     "VLLM_EXL3_PREFILL_TRELLIS": lambda: os.getenv("VLLM_EXL3_PREFILL_TRELLIS"),
     "VLLM_EXL3_PREFILL_BLOCK_M": lambda: os.getenv("VLLM_EXL3_PREFILL_BLOCK_M"),
+    "VLLM_EXL3_R7_A1_MIN_ROWS": lambda: os.getenv("VLLM_EXL3_R7_A1_MIN_ROWS"),
+    "VLLM_EXL3_R7_DEBUG": lambda: os.getenv("VLLM_EXL3_R7_DEBUG"),
+    "VLLM_EXL3_R7_FUSED": lambda: os.getenv("VLLM_EXL3_R7_FUSED"),
+    "VLLM_EXL3_R7_FUSED_LAYERS": lambda: os.getenv("VLLM_EXL3_R7_FUSED_LAYERS"),
+    "VLLM_EXL3_R7_ROUTE_BLOCK": lambda: os.getenv("VLLM_EXL3_R7_ROUTE_BLOCK"),
     # Deterministic online EXL3 encoding and its persistent rank-local cache.
     "VLLM_EXL3_ONLINE_TRELLIS_BITS": lambda: os.getenv("VLLM_EXL3_ONLINE_TRELLIS_BITS"),
     "VLLM_EXL3_ENCODER_SOURCE": lambda: os.getenv("VLLM_EXL3_ENCODER_SOURCE"),

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -2287,6 +2287,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_EXL3_TRELLIS_MAX_M": lambda: os.getenv("VLLM_EXL3_TRELLIS_MAX_M"),
     "VLLM_EXL3_TRELLIS_BLOCK_M": lambda: os.getenv("VLLM_EXL3_TRELLIS_BLOCK_M"),
     "VLLM_EXL3_PREFILL_CHUNK": lambda: os.getenv("VLLM_EXL3_PREFILL_CHUNK"),
+    "VLLM_EXL3_PREFILL_CAPACITY": lambda: os.getenv(
+        "VLLM_EXL3_PREFILL_CAPACITY"
+    ),
     "VLLM_EXL3_PREFILL_TRELLIS": lambda: os.getenv("VLLM_EXL3_PREFILL_TRELLIS"),
     "VLLM_EXL3_PREFILL_BLOCK_M": lambda: os.getenv("VLLM_EXL3_PREFILL_BLOCK_M"),
     # Prebuilt exllamav3 extension location and torch-ABI compatibility shim.

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -2291,19 +2291,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_EXL3_PREFILL_TRELLIS": lambda: os.getenv("VLLM_EXL3_PREFILL_TRELLIS"),
     "VLLM_EXL3_PREFILL_BLOCK_M": lambda: os.getenv("VLLM_EXL3_PREFILL_BLOCK_M"),
     # Deterministic online EXL3 encoding and its persistent rank-local cache.
-    "VLLM_EXL3_ONLINE_TRELLIS_BITS": lambda: os.getenv(
-        "VLLM_EXL3_ONLINE_TRELLIS_BITS"
-    ),
+    "VLLM_EXL3_ONLINE_TRELLIS_BITS": lambda: os.getenv("VLLM_EXL3_ONLINE_TRELLIS_BITS"),
     "VLLM_EXL3_ENCODER_SOURCE": lambda: os.getenv("VLLM_EXL3_ENCODER_SOURCE"),
-    "VLLM_EXL3_ENCODER_REVISION": lambda: os.getenv(
-        "VLLM_EXL3_ENCODER_REVISION"
-    ),
-    "VLLM_EXL3_ONLINE_CACHE_DIR": lambda: os.getenv(
-        "VLLM_EXL3_ONLINE_CACHE_DIR"
-    ),
-    "VLLM_EXL3_ONLINE_CACHE_MODE": lambda: os.getenv(
-        "VLLM_EXL3_ONLINE_CACHE_MODE"
-    ),
+    "VLLM_EXL3_ENCODER_REVISION": lambda: os.getenv("VLLM_EXL3_ENCODER_REVISION"),
+    "VLLM_EXL3_ONLINE_CACHE_DIR": lambda: os.getenv("VLLM_EXL3_ONLINE_CACHE_DIR"),
+    "VLLM_EXL3_ONLINE_CACHE_MODE": lambda: os.getenv("VLLM_EXL3_ONLINE_CACHE_MODE"),
     # Prebuilt exllamav3 extension location and torch-ABI compatibility shim.
     "VLLM_EXL3_EXT_PATH": lambda: os.getenv("VLLM_EXL3_EXT_PATH"),
     "VLLM_EXL3_ABI_SHIM": lambda: os.getenv("VLLM_EXL3_ABI_SHIM"),

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -2287,15 +2287,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_EXL3_TRELLIS_MAX_M": lambda: os.getenv("VLLM_EXL3_TRELLIS_MAX_M"),
     "VLLM_EXL3_TRELLIS_BLOCK_M": lambda: os.getenv("VLLM_EXL3_TRELLIS_BLOCK_M"),
     "VLLM_EXL3_PREFILL_CHUNK": lambda: os.getenv("VLLM_EXL3_PREFILL_CHUNK"),
-    "VLLM_EXL3_PREFILL_CAPACITY": lambda: os.getenv(
-        "VLLM_EXL3_PREFILL_CAPACITY"
-    ),
+    "VLLM_EXL3_PREFILL_CAPACITY": lambda: os.getenv("VLLM_EXL3_PREFILL_CAPACITY"),
     "VLLM_EXL3_PREFILL_TRELLIS": lambda: os.getenv("VLLM_EXL3_PREFILL_TRELLIS"),
     "VLLM_EXL3_PREFILL_BLOCK_M": lambda: os.getenv("VLLM_EXL3_PREFILL_BLOCK_M"),
     # Prebuilt exllamav3 extension location and torch-ABI compatibility shim.
     "VLLM_EXL3_EXT_PATH": lambda: os.getenv("VLLM_EXL3_EXT_PATH"),
     "VLLM_EXL3_ABI_SHIM": lambda: os.getenv("VLLM_EXL3_ABI_SHIM"),
-
 }
 
 

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -764,6 +764,21 @@ def _resolve_prefill_capacity(max_batched_tokens: int) -> int:
 # capture reconstruct+hgemm, and decode throughput collapses (measured: 56.5 -> 22.6
 # tok/s at C1). Keeping both paths inside one custom op moves the choice to runtime.
 _EXL3_RECONSTRUCT_SLICE_N = 32768
+# One shared byte arena per device instead of one persistent fp16 buffer per
+# (device, K, N-chunk). The scratch is written by ext.reconstruct/
+# reconstruct_slice and fully consumed by ext.hgemm (or the fp8 scale probe's
+# amax) inside the same eager call on the same stream, and no view of it
+# outlives that call, so at most one geometry's scratch is ever live and the
+# arena only needs the bytes of the largest geometry. On a dense checkpoint
+# with 9 distinct geometries this replaces 790 MiB of persistent buffers with
+# one 170 MiB arena; the recovered bytes land in the KV pool because the
+# buffers allocate during the profiling prefill.
+_EXL3_RECONSTRUCT_ARENA: dict[int, torch.Tensor] = {}
+# Devices whose arena address has been recorded by a CUDA-graph capture. A
+# captured kernel bakes the scratch pointer, so a frozen arena must never be
+# reallocated; geometries that no longer fit fall back to a dedicated
+# persistent buffer below (the pre-arena behaviour, so never worse).
+_EXL3_RECONSTRUCT_ARENA_FROZEN: set[int] = set()
 _EXL3_RECONSTRUCT_SCRATCH: dict[tuple[int, int, int], torch.Tensor] = {}
 
 
@@ -784,15 +799,38 @@ def _prefill_reconstruct_rows() -> int:
 
 def _reconstruct_scratch(device: torch.device, k: int, n: int) -> torch.Tensor:
     index = device.index if device.index is not None else torch.cuda.current_device()
-    key = (index, k, n)
-    buf = _EXL3_RECONSTRUCT_SCRATCH.get(key)
-    if buf is None:
-        # One buffer per (device, K, N-chunk), reused by every layer of the same
-        # geometry, so peak scratch is bounded by the largest chunk rather than by
-        # the number of layers: 336 MB for a 5120x32768 chunk in fp16.
-        buf = torch.empty((k, n), dtype=torch.float16, device=device)
-        _EXL3_RECONSTRUCT_SCRATCH[key] = buf
-    return buf
+    nbytes = 2 * k * n  # fp16
+    capturing = torch.cuda.is_current_stream_capturing()
+    arena = _EXL3_RECONSTRUCT_ARENA.get(index)
+    if arena is None or arena.numel() < nbytes:
+        if capturing or index in _EXL3_RECONSTRUCT_ARENA_FROZEN:
+            # Growing reallocates, and a reallocated arena dangles every
+            # address a captured graph already baked. Give this geometry its
+            # own persistent buffer instead.
+            key = (index, k, n)
+            buf = _EXL3_RECONSTRUCT_SCRATCH.get(key)
+            if buf is None:
+                buf = torch.empty((k, n), dtype=torch.float16, device=device)
+                _EXL3_RECONSTRUCT_SCRATCH[key] = buf
+            return buf
+        arena = torch.empty((nbytes,), dtype=torch.uint8, device=device)
+        _EXL3_RECONSTRUCT_ARENA[index] = arena
+        logger.info(
+            "EXL3 reconstruct scratch arena grew to %.1f MiB "
+            "(device %d, geometry K=%d, chunk=%d)",
+            nbytes / (1 << 20),
+            index,
+            k,
+            n,
+        )
+    if capturing:
+        # A capture is recording the arena's address into a graph: freeze it.
+        _EXL3_RECONSTRUCT_ARENA_FROZEN.add(index)
+    # A leading narrow of a contiguous byte arena starts at storage offset 0,
+    # so the fp16 view keeps the allocator's 512-byte base alignment and has
+    # exactly the shape and strides torch.empty((k, n)) would produce: the
+    # kernels see an identical operand and the outputs stay byte-exact.
+    return arena[:nbytes].view(torch.float16).view(k, n)
 
 
 _EXL3_FP8_SCRATCH: dict[tuple[int, int, int], torch.Tensor] = {}

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -3515,10 +3515,12 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             device=layer.w13_trellis.device,
         )
 
-    # Fused-layer budget consumption is per method instance, not process
-    # global: a class attribute leaks the count across model loads in one
-    # process and makes which layers use the fused path order-dependent.
-    _r7_fused_layers = 0
+    # Fused-layer budget consumption is tracked on the shared Exl3Config, not
+    # on the method or the class. vLLM builds one quant_method per MoE layer,
+    # so an instance counter never accumulates and the budget is never
+    # enforced; a class attribute is the opposite failure, leaking the count
+    # across model loads in one process and making the fused/per-expert split
+    # order-dependent. The config is per model load and shared by its layers.
 
     @staticmethod
     def _r7_projection_tiers(layer: RoutedExperts):
@@ -3571,7 +3573,8 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         # exl3_moe_r7_fused, which the loader already selects per layer.
         budget = _r7_fused_layer_budget()
         if budget is not None:
-            if int(getattr(self, "_r7_fused_layers", 0)) >= budget:
+            used = int(getattr(self.quant_config, "_r7_fused_layers", 0))
+            if used >= budget:
                 return False
             # Charged only after this layer's tiers are frozen (see the
             # success path below): a failed packing attempt must not consume
@@ -3631,12 +3634,12 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         prepared_tiers = []
         prefill_tiers = []
         fc1_counts = []
+        tier_gate_counts = []  # real gate plane count per tier
         # Stack every tier BEFORE preparing any of them. prepare needs a
         # transient full-size counterpart for the phase it is not packing, and
         # that will not fit while the per-expert source tensors are still
         # resident alongside their stacked copies.
         stacks = []
-        tier_gate_counts = []  # glm52-r7-gate-tight: real gate plane count/tier
         for tier_id, bits in enumerate(tier_bits):
             gate_ids = [e for e in range(num_experts) if tiers["gate"][e] == tier_id]
             up_ids = [e for e in range(num_experts) if tiers["up"][e] == tier_id]
@@ -3656,10 +3659,10 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 [gate|up] buffer at out[base+index], so no padded (2,max) w13 is
                 ever materialised.
                 """
-                template = param.exl3_tensors[(expert_ids[0], shard_id)] if (
-                    expert_ids
-                ) else param.exl3_tensors[(0, shard_id)]
                 if out is None:
+                    if not expert_ids:
+                        raise ValueError("an empty tier requires a preallocated slab")
+                    template = param.exl3_tensors[(expert_ids[0], shard_id)]
                     out = torch.zeros(
                         (slots, *template.shape),
                         dtype=template.dtype,
@@ -3684,15 +3687,16 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                     del src
                 return out
 
-            gate_template = w13_param.exl3_tensors[
-                (gate_ids[0] if gate_ids else 0, "w1")
-            ]
-            # glm52-r7-gate-tight: fill the tight [gate|up] buffer DIRECTLY from
-            # the per-expert sources (each popped as consumed), so no padded
-            # (2,max) buffer is ever resident. The served w13 is exactly
-            # gate_count+up_count planes -> ~0.99 GiB/layer vs 1.18 padded.
-            # prepare_weights, which validates a [2,E] shape and builds a w13
-            # view we discard, gets a shared never-read ballast instead.
+            # Projection-tight w13: exactly gate_count + up_count planes, no
+            # padded (2, max) stack. Safe because the kernel is told the gate
+            # count explicitly (run_mixed_trellis gate_experts), so its
+            # cute.size(w13)//2 up-block base lands at gate_count*stride rather
+            # than being inferred from a padded extent. Padding instead costs
+            # ~1 extra plane per tier per layer, measured at -1.81 GiB of KV
+            # headroom at max_model_len 262144 on 4x96 GB.
+            expected_last = 16 * bits
+            _tmpl_id = gate_ids[0] if gate_ids else 0
+            gate_template = w13_param.exl3_tensors[(_tmpl_id, "w1")]
             gate_n = len(gate_ids)
             up_n = len(up_ids)
             w13 = torch.zeros(
@@ -3703,10 +3707,8 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             plane(gate_ids, "w1", w13_param, fc1_slots, out=w13, base=0)
             plane(up_ids, "w3", w13_param, fc1_slots, out=w13, base=gate_n)
             w2 = plane(down_ids, "w2", w2_param, fc2_slots)
-            w13_tight = w13
             tier_gate_counts.append(gate_n)
             torch.cuda.empty_cache()
-            expected_last = 16 * bits
             if (
                 int(w13.shape[-1]) != expected_last
                 or int(w2.shape[-1]) != expected_last
@@ -3724,7 +3726,6 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 slots: int = fc1_slots,
                 fc2_slots: int = fc2_slots,
                 bits: int = bits,
-                w13_tight: torch.Tensor = w13_tight,  # glm52-r7-gate-tight
                 gate_n: int = gate_n,
                 up_n: int = up_n,
             ):
@@ -3787,14 +3788,14 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                     if fc2_slots == slots
                     else _r7_fc1_ballast(slots, w2)
                 )
-                # prepare gets a shared never-read [2,slots] ballast (its w13
-                # view is discarded); the tight [gate|up] buffer is bound below.
+                # prepare validates a padded [2, slots] w13 and builds a view
+                # of it that is discarded here, so it gets a shared never-read
+                # ballast; the served w13 is the tight [gate|up] buffer bound
+                # below. The kernel sizes its w13 descriptor by gate_count
+                # (run_mixed_trellis gate_experts), so cute.size//2 lands the
+                # up-block base at gate_count*stride over that tight buffer.
                 fc1_prepared = call(slots, _r7_w13_ballast(slots, w13), fc1_w2)
-                # glm52-r7-gate-tight: bind the served w13 to the tight [gate|up]
-                # buffer. The kernel sizes its w13 descriptor by gate_count
-                # (companion gate-tight patch), so cute.size//2 lands the
-                # up-block base at gate_count*stride.
-                _tight_view = w13_tight.view(torch.int32).reshape(
+                _tight_view = w13.view(torch.int32).reshape(
                     max(gate_n + up_n, 1),
                     hidden_size // 16,
                     intermediate_size // 16,
@@ -3886,8 +3887,8 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             "tier_bits": tuple(tier_bits),
             # FC1 slot counts: what sizes the launch and the policy signature.
             "tier_ids": tuple(fc1_counts),
-            # glm52-r7-gate-tight: real gate plane count per tier, threaded to
-            # run_mixed_trellis so the w13 descriptor sizes by gate_count.
+            # Real gate plane count per tier, threaded to run_mixed_trellis so
+            # the w13 descriptor sizes by gate_count over the tight buffer.
             "tier_gate_experts": tuple(tier_gate_counts),
             "global_to_combined": global_to_combined,
             "descriptor_map": descriptor_map,
@@ -3900,7 +3901,11 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             "prefill_tile_config": prefill_tile_config,
         }
         if budget is not None:
-            self._r7_fused_layers = int(getattr(self, "_r7_fused_layers", 0)) + 1
+            # Charged only now: this layer's tiers are frozen, so a failed
+            # packing attempt cannot consume budget a later layer could use.
+            self.quant_config._r7_fused_layers = (
+                int(getattr(self.quant_config, "_r7_fused_layers", 0)) + 1
+            )
         layer.exl3_trellis_tile_config = tile_config
         if not hasattr(layer, "exl3_max_num_batched_tokens"):
             layer.exl3_max_num_batched_tokens = int(

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -34,7 +34,7 @@ from typing import TYPE_CHECKING, Any
 import torch
 from transformers import PretrainedConfig
 
-from vllm.config import get_current_vllm_config_or_none
+from vllm.config import CUDAGraphMode, get_current_vllm_config_or_none
 from vllm.config.quantization import QuantizationConfigArgs
 from vllm.distributed import (
     get_tensor_model_parallel_rank,
@@ -74,6 +74,9 @@ from vllm.model_executor.layers.quantization.online.mxfp8 import (
     Mxfp8OnlineLinearMethod,
     is_shared_expert_projection,
 )
+from vllm.model_executor.layers.quantization.utils.mxfp8_utils import (
+    MXFP8_BLOCK_SIZE,
+)
 from vllm.model_executor.layers.quantization.utils.quant_utils import kMxfp8Dynamic
 from vllm.model_executor.parameter import BasevLLMParameter
 from vllm.model_executor.utils import replace_parameter
@@ -96,6 +99,12 @@ _B12X_MIXED_TRELLIS_API: Any | None = None
 _B12X_TRELLIS_LINEAR_API: Any | None = None
 _EXL3_ONLINE_QUANTIZER: Any | None = None
 _EXL3_ONLINE_WARMED_SIGNATURES: set[tuple[int, int, int, int]] = set()
+# Serialized dense shapes whose exl3_gemm autotuning already ran eagerly,
+# keyed by (device_index, m, k, n, bits, codebook). The extension hashes its
+# own autotune cache over the same shape fields and the codebook selector, not
+# over weight pointers, so priming one shard primes every later shard with the
+# same geometry.
+_EXL3_GEMM_PRIMED_SIGNATURES: set[tuple[int, int, int, int, int, int]] = set()
 _B12X_TRELLIS_WARMED_DEVICES: set[int] = set()
 # The dense W4A16 kernel caps its temporary accumulation arena at
 # SMs * 4 * block_m * 256 fp32 elements.  SM120/SM121 devices supported by
@@ -789,6 +798,143 @@ def _exl3_gemm_fake(
     )
 
 
+def _graph_decode_enabled() -> bool:
+    """Return whether serialized dense EXL3 may run under CUDA graphs.
+
+    Off by default. ``exl3_gemm`` autotunes with timing launches on the first
+    call per shape bucket and those launches fault inside CUDA-graph capture,
+    so graphs are only permitted when the operator opts into the pre-capture
+    priming pass with ``VLLM_EXL3_GRAPH_DECODE=1``.
+    """
+
+    return os.environ.get("VLLM_EXL3_GRAPH_DECODE", "0") == "1"
+
+
+def _uniform_decode_query_len(vllm_config: Any) -> int:
+    """Rows one request contributes to a uniform decode batch."""
+
+    speculative_config = getattr(vllm_config, "speculative_config", None)
+    num_spec = getattr(speculative_config, "num_speculative_tokens", None)
+    return 1 + int(num_spec) if num_spec else 1
+
+
+def _graph_decode_capture_rows(vllm_config: Any) -> tuple[int, ...]:
+    """Return every row count a decode-only CUDA graph can replay.
+
+    ``cudagraph_capture_sizes`` is already final except for the spec-decode
+    alignment that ``CompilationConfig.adjust_cudagraph_sizes_for_spec_decode``
+    applies while the KV cache is initialized, i.e. after weights are loaded.
+    Priming therefore covers the superset that alignment can produce: every
+    configured size, that size rounded up to the uniform decode query length
+    (and to the sequence-parallel multiple when that pass binds captured
+    sizes), the small interactive request counts alignment always adds, and the
+    per-request row counts an MTP/draft layer sees for those sizes.
+    """
+
+    compilation_config = getattr(vllm_config, "compilation_config", None)
+    sizes = getattr(compilation_config, "cudagraph_capture_sizes", None)
+    if not sizes:
+        return ()
+    configured_max = getattr(compilation_config, "max_cudagraph_capture_size", None)
+    max_size = int(configured_max) if configured_max else max(int(s) for s in sizes)
+    rows = {int(size) for size in sizes if 0 < int(size) <= max_size}
+    query_len = _uniform_decode_query_len(vllm_config)
+    if query_len > 1:
+        multiples = [query_len]
+        pass_config = getattr(compilation_config, "pass_config", None)
+        parallel_config = getattr(vllm_config, "parallel_config", None)
+        tp_size = int(getattr(parallel_config, "tensor_parallel_size", 1) or 1)
+        if tp_size > 1 and getattr(pass_config, "enable_sp", False):
+            multiples.append(max(query_len, tp_size))
+        for multiple in multiples:
+            for size in tuple(rows):
+                rounded = -(-size // multiple) * multiple
+                if rounded <= max_size:
+                    rows.add(rounded)
+        rows.update(
+            query_len * requests
+            for requests in range(1, 33)
+            if query_len * requests <= max_size
+        )
+        # A draft/MTP layer consumes one row per request, not per drafted token.
+        rows.update(size // query_len for size in tuple(rows) if size >= query_len)
+    return tuple(sorted(rows))
+
+
+def _prime_exl3_gemm_rows(
+    trellis: torch.Tensor,
+    suh: torch.Tensor,
+    svh: torch.Tensor,
+    *,
+    has_mcg: bool,
+    has_mul1: bool,
+    rows: tuple[int, ...],
+    owner: str,
+) -> None:
+    """Autotune one serialized shard for every capturable row count.
+
+    exllamav3_ext hashes its autotune cache over the m bucket, k, n, K and the
+    codebook selector, so one zero-filled eager launch per row count here
+    removes every timing launch the same shape would otherwise attempt inside
+    CUDA-graph capture, and materializes the extension's per-device lock arena
+    outside capture. This is the serialized counterpart of
+    ``Exl3OnlineLinearMethod._warm_decode_shapes``.
+    """
+
+    device = trellis.device
+    device_index = device.index
+    if device_index is None:
+        device_index = torch.cuda.current_device()
+    k = int(trellis.shape[0]) * 16
+    n = int(trellis.shape[1]) * 16
+    bits = int(trellis.shape[2]) // 16
+    # Mirrors the extension's codebook selector: mcg=1, mul1=2, otherwise 0.
+    codebook = 1 if has_mcg else 2 if has_mul1 else 0
+    pending = [
+        int(m)
+        for m in rows
+        if (device_index, int(m), k, n, bits, codebook)
+        not in _EXL3_GEMM_PRIMED_SIGNATURES
+    ]
+    if not pending:
+        return
+    # One arena for the whole shape: a leading-row view of a contiguous buffer
+    # is itself contiguous, so the kernel contract holds without reallocating
+    # per row count.
+    source = torch.zeros((max(pending), k), dtype=torch.float16, device=device)
+    for m in pending:
+        try:
+            _exl3_gemm(
+                source.narrow(0, 0, m),
+                trellis,
+                suh,
+                svh,
+                has_mcg,
+                has_mul1,
+            )
+        except Exception as exc:
+            raise ValueError(
+                "The EXL3 quantization backend requires eager execution: "
+                "pass --enforce-eager (enforce_eager=True) or unset "
+                "VLLM_EXL3_GRAPH_DECODE. exl3_gemm autotuning could not be "
+                f"primed for {owner} at m={m}, K={k}, N={n}, bits={bits}, so "
+                "CUDA-graph capture of that shape would fault."
+            ) from exc
+        _EXL3_GEMM_PRIMED_SIGNATURES.add((device_index, m, k, n, bits, codebook))
+    torch.cuda.synchronize(device)
+    logger.info_once(
+        "EXL3 graph-decode priming: autotuned exl3_gemm for %d capture row "
+        "counts (m=%d..%d) at K=%d, N=%d, bits=%d, codebook=%d.",
+        len(pending),
+        pending[0],
+        pending[-1],
+        k,
+        n,
+        bits,
+        codebook,
+    )
+
+
 def _b12x_trellis_weight(
     trellis: torch.Tensor,
     suh: torch.Tensor,
@@ -967,6 +1113,10 @@ class Exl3Config(QuantizationConfig):
         self.version = version
         self.tensor_storage = tensor_storage or {}
         self._eager_checked = False
+        # Row counts a decode-only CUDA graph can replay, once the relaxation
+        # in _require_enforce_eager has granted graph decode. None means the
+        # serialized path stays eager and nothing is primed.
+        self.graph_decode_rows: tuple[int, ...] | None = None
         self.rank_sliced_metadata: dict[str, Any] | None = None
         self.rank_sliced_rotation_layout = _PER_EXPERT_ROTATION_LAYOUT
         self.rank_sliced_k_values: tuple[int, ...] | None = None
@@ -1347,6 +1497,52 @@ class Exl3Config(QuantizationConfig):
                 "overriding tie_word_embeddings so vLLM instantiates it."
             )
 
+    def _graph_decode_refusal(self, vllm_config: Any) -> str | None:
+        """Return why graph decode is refused for this run, or None to allow.
+
+        Only decode-only capture is admissible. The capture-size list bounds
+        every row count a decode graph replays, so those shapes can be primed
+        before capture, while a mode that also captures mixed prefill batches
+        would autotune inside capture at token counts the scheduler picks at
+        runtime.
+        """
+
+        if not _graph_decode_enabled():
+            return (
+                "VLLM_EXL3_GRAPH_DECODE is not 1, so the pre-capture exl3_gemm "
+                "priming pass is disabled"
+            )
+        compilation_config = getattr(vllm_config, "compilation_config", None)
+        mode = getattr(compilation_config, "cudagraph_mode", None)
+        if mode is None:
+            return "compilation_config.cudagraph_mode is unset"
+        if not bool(mode):
+            # CUDAGraphMode.NONE never captures, so nothing needs priming.
+            return None
+        if mode.mixed_mode() != CUDAGraphMode.NONE:
+            return (
+                f"cudagraph_mode={mode} also captures mixed prefill batches, "
+                "whose token counts are not enumerable before capture; select "
+                "decode-only capture with "
+                "--compilation-config '{\"cudagraph_mode\": \"FULL_DECODE_ONLY\"}'"
+            )
+        parallel_config = getattr(vllm_config, "parallel_config", None)
+        if getattr(parallel_config, "use_ubatching", False):
+            return (
+                "microbatched execution (DBO/ubatching) splits every captured "
+                "size across ubatches, so the row counts reaching a shard are "
+                "not the capture sizes this priming pass covers"
+            )
+        rows = _graph_decode_capture_rows(vllm_config)
+        if not rows:
+            return (
+                f"cudagraph_mode={mode} is decode-only but "
+                "compilation_config.cudagraph_capture_sizes is empty, so no "
+                "row count can be primed"
+            )
+        self.graph_decode_rows = rows
+        return None
+
     def _require_enforce_eager(self) -> None:
         if self.rank_sliced_metadata is not None:
             # The routed-expert fast path is eagerly planned before graph
@@ -1354,22 +1550,55 @@ class Exl3Config(QuantizationConfig):
             return
         # exllamav3_ext's exl3_gemm autotunes with timing launches on the first
         # call per (m-bucket, k, n, K) shape hash; under CUDA-graph capture
-        # those launches fault, and m-bucketing means a warmup pass cannot
-        # reliably cover every bucket. Fail fast at build time instead of
-        # faulting mid-capture.
+        # those launches fault. Decode-only capture is the one mode whose row
+        # counts are enumerable, so it can be primed exhaustively during weight
+        # loading (see Exl3LinearMethod._prime_graph_decode_shapes). Everything
+        # else fails fast at build time instead of faulting mid-capture.
         if self._eager_checked:
             return
         self._eager_checked = True
         vllm_config = get_current_vllm_config_or_none()
         if vllm_config is None:
             return
-        if not vllm_config.model_config.enforce_eager:
+        if vllm_config.model_config.enforce_eager:
+            return
+        refusal = self._graph_decode_refusal(vllm_config)
+        if refusal is not None:
             raise ValueError(
                 "The EXL3 quantization backend requires eager execution: "
                 "pass --enforce-eager (enforce_eager=True). exl3_gemm "
                 "autotunes with timing launches on first use per shape "
-                "bucket, which is incompatible with CUDA-graph capture."
+                "bucket, which is incompatible with CUDA-graph capture. "
+                f"Graph decode was not permitted because {refusal}."
             )
+        if self.graph_decode_rows:
+            logger.info_once(
+                "EXL3 graph decode enabled by VLLM_EXL3_GRAPH_DECODE: "
+                "cudagraph_mode=%s captures decode only; priming exl3_gemm for "
+                "%d row counts (m=%d..%d) during weight loading.",
+                vllm_config.compilation_config.cudagraph_mode,
+                len(self.graph_decode_rows),
+                self.graph_decode_rows[0],
+                self.graph_decode_rows[-1],
+            )
+
+    def _require_eager_moe_experts(self, prefix: str) -> None:
+        """Refuse graph decode for the dense correctness MoE path.
+
+        Non-rank-sliced routed experts issue one exl3_gemm per expert with a
+        row count only the router knows, so no priming pass can cover them.
+        """
+
+        if not self.graph_decode_rows:
+            return
+        raise ValueError(
+            "The EXL3 quantization backend requires eager execution for "
+            f"non-rank-sliced routed experts ({prefix or 'experts'}): pass "
+            "--enforce-eager (enforce_eager=True) or unset "
+            "VLLM_EXL3_GRAPH_DECODE. Graph decode primes dense linear shards "
+            "at the CUDA-graph capture sizes, but per-expert GEMM row counts "
+            "are chosen by the router at runtime and cannot be primed."
+        )
 
     def get_quant_method(
         self, layer: torch.nn.Module, prefix: str
@@ -1389,6 +1618,7 @@ class Exl3Config(QuantizationConfig):
         if isinstance(layer, RoutedExperts):
             if not self._moe_prefix_is_exl3(prefix, layer):
                 return None
+            self._require_eager_moe_experts(prefix)
             return Exl3MoEMethod(self, layer.moe_config)
         return None
 
@@ -1714,7 +1944,7 @@ class Exl3OnlineLinearMethod(_Fp8OnlineLinearBase):
         self.prefix = prefix
         self.model_identity = model_identity
         self.encoder_identity = encoder_identity
-        self.fallback: Mxfp8OnlineLinearMethod | None = None
+        self.fallback: QuantizeMethodBase | None = None
 
     def create_weights(
         self,
@@ -1731,7 +1961,28 @@ class Exl3OnlineLinearMethod(_Fp8OnlineLinearBase):
             input_size_per_partition, output_size_per_partition
         )
         if not layer.exl3_online_trellis:
-            self.fallback = Mxfp8OnlineLinearMethod()
+            # Trellis needs 128-aligned K and N; MXFP8 needs K divisible by 32.
+            # A shard that satisfies neither (e.g. the Qwen3.5/3.6/3.8 vision
+            # tower, K=1152 N=4304) has no online representation at all, so keep
+            # it unquantized instead of raising out of MXFP8 create_weights.
+            if input_size_per_partition % MXFP8_BLOCK_SIZE == 0:
+                self.fallback = Mxfp8OnlineLinearMethod()
+                logger.info_once(
+                    "EXL3 online Trellis retains MXFP8 for 128-unaligned shards "
+                    "(example %s: K=%d, N=%d).",
+                    self.prefix,
+                    input_size_per_partition,
+                    output_size_per_partition,
+                )
+            else:
+                self.fallback = UnquantizedLinearMethod()
+                logger.warning_once(
+                    "EXL3 online overlay keeps %s unquantized: K=%d is neither "
+                    "128-aligned for Trellis nor divisible by %d for MXFP8.",
+                    self.prefix,
+                    input_size_per_partition,
+                    MXFP8_BLOCK_SIZE,
+                )
             self.fallback.create_weights(
                 layer,
                 input_size_per_partition,
@@ -1740,13 +1991,6 @@ class Exl3OnlineLinearMethod(_Fp8OnlineLinearBase):
                 output_size,
                 params_dtype,
                 **extra_weight_attrs,
-            )
-            logger.info_once(
-                "EXL3 online Trellis retains MXFP8 for 128-unaligned shards "
-                "(example %s: K=%d, N=%d).",
-                self.prefix,
-                input_size_per_partition,
-                output_size_per_partition,
             )
             return
 
@@ -2036,6 +2280,44 @@ class Exl3LinearMethod(LinearMethodBase):
                 torch.float16,
             )
             _warm_b12x_trellis_device(trellis, suh, svh)
+
+        self._prime_graph_decode_shapes(layer)
+
+    def _prime_graph_decode_shapes(self, layer: torch.nn.Module) -> None:
+        """Autotune every capturable decode shape while still executing eagerly.
+
+        This is the serialized counterpart of
+        ``Exl3OnlineLinearMethod._warm_decode_shapes``: the online path warms
+        rows 1..6 because that is its entire decode window, whereas a captured
+        decode graph replays exactly the configured capture sizes. No-op unless
+        ``_require_enforce_eager`` granted graph decode.
+        """
+
+        rows = self.quant_config.graph_decode_rows
+        if not rows:
+            return
+        owner = getattr(layer, "prefix", layer.__class__.__name__)
+        for shard_id in layer.exl3_shard_ids:
+            trellis = layer.trellis.exl3_tensors[shard_id]
+            has_mcg = shard_id in layer.mcg.exl3_tensors
+            has_mul1 = shard_id in layer.mul1.exl3_tensors
+            if _b12x_trellis_k6_supported(
+                trellis,
+                has_mcg=has_mcg,
+                has_mul1=has_mul1,
+            ):
+                # The native K6 path picks its kernel from the shape alone and
+                # is already prepared and warmed above.
+                continue
+            _prime_exl3_gemm_rows(
+                trellis,
+                layer.suh.exl3_tensors[shard_id],
+                layer.svh.exl3_tensors[shard_id],
+                has_mcg=has_mcg,
+                has_mul1=has_mul1,
+                rows=rows,
+                owner=f"{owner}[{shard_id!r}]",
+            )
 
     def apply(
         self,

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -1876,7 +1876,7 @@ class Exl3Config(QuantizationConfig):
             self._require_eager_moe_experts(prefix)
             return Exl3MoEMethod(self, layer.moe_config)
         if layer.__class__.__name__ == "VocabParallelEmbedding":
-            if method := _get_embedding_overlay_method():
+            if method := _get_embedding_overlay_method(prefix):
                 return method
             return None
         return None
@@ -2163,35 +2163,40 @@ class Exl3Config(QuantizationConfig):
 _EMBED_OVERLAY_BITS_ENV = "VLLM_EXL3_EMBED_BITS"
 
 
-def _get_embedding_overlay_method() -> QuantizeMethodBase | None:
-    """Quantize the input embedding table, off by default.
+def _get_embedding_overlay_method(prefix: str = "") -> QuantizeMethodBase | None:
+    """Quantize input embeddings to per-row int8, off by default.
 
-    On Qwen3.8-27B the table is 248,320 x 5,120 in BF16 = 2.543 GB resident, second only to
-    the MLP stack, and it is pure lookup: no matmul, no accumulation, one row per token. That
-    makes it the cheapest large saving available, and on a 32 GB card it is the difference
-    between 196,608 and native 262,144 context - the measured KV shortfall there is 0.63 GiB
-    and int8 frees 1.18 GiB.
+    On Qwen3.8-27B the table is 248,320 x 5,120 in BF16 = 2.543 GB resident,
+    second only to the MLP stack, and it is pure lookup: no matmul, no
+    accumulation, one row per token. That makes it the cheapest large saving
+    available. ``VLLM_EXL3_EMBED_BITS=8`` enables it; 16 leaves BF16 intact.
 
-    int8 rather than FP8: both halve the table, but E4M3 carries three mantissa bits against
-    int8's seven, so per-row symmetric int8 is roughly an order of magnitude more accurate for
-    the same bytes. There is no tensor-core path to exploit here - the operation is a gather -
-    so FP8's throughput advantage does not apply.
+    int8 rather than FP8: both halve the table, but E4M3 carries three mantissa
+    bits against int8's seven. There is no tensor-core path to exploit in a
+    gather, so FP8's throughput advantage does not apply.
 
-    ``VLLM_EXL3_EMBED_BITS=8`` enables it. The head is untied on this architecture, so this
-    touches inputs only.
+    vLLM constructs an MTP embedding during draft-model load, then aliases the
+    draft to the target embedding. Applying the same int8 method during that
+    temporary load is harmless and lowers transient memory; there is deliberately
+    no separate draft width because it cannot affect resident weights or output.
     """
+    del prefix
     raw = os.environ.get(_EMBED_OVERLAY_BITS_ENV)
     if raw is None or not raw.strip():
         return None
     try:
         bits = int(raw)
     except ValueError:
-        raise ValueError(f"{_EMBED_OVERLAY_BITS_ENV} must be 8 or 16, got {raw!r}") from None
+        raise ValueError(
+            f"{_EMBED_OVERLAY_BITS_ENV} must be 8 or 16, got {raw!r}"
+        ) from None
     if bits == 16:
         return None
-    if bits != 8:
-        raise ValueError(f"{_EMBED_OVERLAY_BITS_ENV} supports 8 (int8) or 16 (off), got {bits}")
-    return Exl3Int8EmbeddingMethod()
+    if bits == 8:
+        return Exl3Int8EmbeddingMethod()
+    raise ValueError(
+        f"{_EMBED_OVERLAY_BITS_ENV} supports 8 (quantized) or 16 (off), got {bits}"
+    )
 
 
 class Exl3Int8EmbeddingMethod(QuantizeMethodBase):
@@ -2230,11 +2235,26 @@ class Exl3Int8EmbeddingMethod(QuantizeMethodBase):
         if weight.dtype == torch.int8:
             return
         out_dtype = weight.dtype
-        amax = weight.abs().amax(dim=1, keepdim=True).float().clamp_(min=1e-8)
-        scale = (amax / 127.0).to(torch.float32)
-        packed = torch.round(weight.float() / scale).clamp_(-127, 127).to(torch.int8)
+        source_bytes = weight.numel() * weight.element_size()
+        rows, columns = weight.shape
+        packed = torch.empty_like(weight, dtype=torch.int8)
+        scales = torch.empty(rows, dtype=out_dtype, device=weight.device)
+
+        # Quantize in bounded row chunks. Converting the complete Qwen3.8 table to
+        # float32 at once adds a 5.1 GB transient allocation and can defeat the
+        # 32 GB use case this overlay exists for.
+        rows_per_chunk = 4096
+        for start in range(0, rows, rows_per_chunk):
+            stop = min(start + rows_per_chunk, rows)
+            source = weight[start:stop]
+            scale = source.abs().amax(dim=1).float().clamp_(min=1e-8).div_(127.0)
+            work = source.float()
+            work.div_(scale.unsqueeze(1)).round_().clamp_(-127, 127)
+            packed[start:stop].copy_(work.to(torch.int8))
+            scales[start:stop].copy_(scale)
+
         layer.register_buffer("weight_int8", packed)
-        layer.register_buffer("weight_scale", scale.squeeze(1).to(out_dtype))
+        layer.register_buffer("weight_scale", scales)
         layer.exl3_embed_out_dtype = out_dtype
         # Release the BF16 table: it is 2.543 GB on this model and nothing reads it again.
         layer.weight = torch.nn.Parameter(
@@ -2242,22 +2262,29 @@ class Exl3Int8EmbeddingMethod(QuantizeMethodBase):
         )
         del weight
         torch.cuda.empty_cache()
+        packed_bytes = (
+            packed.numel() * packed.element_size()
+            + scales.numel() * scales.element_size()
+        )
         logger.info(
             "EXL3 int8 embedding overlay: %d x %d rows narrowed, %.3f GB -> %.3f GB",
-            packed.shape[0],
-            packed.shape[1],
-            packed.numel() * 2 / 1e9,
-            (packed.numel() + packed.shape[0] * 2) / 1e9,
+            rows,
+            columns,
+            source_bytes / 1e9,
+            packed_bytes / 1e9,
         )
 
     def apply(self, layer: torch.nn.Module, *args, **kwargs) -> torch.Tensor:
         raise NotImplementedError("the embedding overlay implements embedding(), not apply()")
 
     def embedding(self, layer: torch.nn.Module, input_: torch.Tensor) -> torch.Tensor:
-        rows = layer.weight_int8.index_select(0, input_.flatten())
-        scales = layer.weight_scale.index_select(0, input_.flatten()).unsqueeze(-1)
+        flat = input_.flatten()
+        rows = layer.weight_int8.index_select(0, flat)
+        scales = layer.weight_scale.index_select(0, flat).unsqueeze(-1)
         out = rows.to(layer.exl3_embed_out_dtype) * scales
         return out.view(*input_.shape, layer.weight_int8.shape[1])
+
+
 
 
 class Exl3Parameter(BasevLLMParameter):

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -595,9 +595,17 @@ def _r7_fused_enabled() -> bool:
 
 
 def _shared_mixed_buffers(
-    mixed_api, launch, device, sms, capacity, block_size_m, tile_config, topk
+    owner_token,
+    mixed_api,
+    launch,
+    device,
+    sms,
+    capacity,
+    block_size_m,
+    tile_config,
+    topk,
 ):
-    """One scratch arena per launch geometry. glm52-r7-sparkinfer."""
+    """One scratch arena per model/draft owner and launch geometry."""
 
     # glm52-r7-gate-tight: max_m_blocks is DELIBERATELY excluded from the key.
     # It derives from each layer's summed tier slots, which differ per layer
@@ -608,6 +616,7 @@ def _shared_mixed_buffers(
     # max_m_blocks seen; the arena is scratch, so a larger one serves any
     # smaller launch.
     key = (
+        owner_token,
         device.index if hasattr(device, "index") else device,
         int(capacity),
         int(block_size_m),
@@ -633,19 +642,24 @@ def _shared_mixed_buffers(
         # every layer's route-block count. Sizing it from the first layer would
         # under-allocate for a later, wider one; growing it thrashed (51
         # allocations, old arenas pinned by the runtimes already holding them).
-        worst = dataclasses.replace(
-            launch,
+        worst_max_m_blocks = (
+            mixed_api.max_packed_route_slots(
+                int(capacity) * int(topk), int(block_size_m), 512
+            )
+            + int(block_size_m)
+            - 1
+        ) // int(block_size_m)
+        overrides = dict(
             tier0_num_experts=256,
             tier1_num_experts=256,
-            max_m_blocks=(
-                mixed_api.max_packed_route_slots(
-                    int(capacity) * int(topk), int(block_size_m), 512
-                )
-                + int(block_size_m)
-                - 1
-            )
-            // int(block_size_m),
+            max_m_blocks=worst_max_m_blocks,
         )
+        if dataclasses.is_dataclass(launch):
+            worst = dataclasses.replace(launch, **overrides)
+        else:
+            # Production uses the dataclass. Retained API tests use a small
+            # namespace carrying the same public fields.
+            worst = SimpleNamespace(**{**vars(launch), **overrides})
         entry = mixed_api.make_mixed_trellis_buffers(
             worst, device=device, sms=sms
         )
@@ -957,27 +971,38 @@ class Exl3Config(QuantizationConfig):
                     "R7 EXL3 requires codebook='mcg' and bits='mixed_tensor'"
                 )
             layers = _r7.get("moe_layers")
-            try:
-                valid_layers = (
-                    isinstance(layers, (list, tuple))
-                    and len(layers) == 2
-                    and int(layers[0]) >= 0
-                    and int(layers[1]) >= int(layers[0])
+            valid_layers = (
+                isinstance(layers, (list, tuple))
+                and len(layers) == 2
+                and all(
+                    isinstance(value, int) and not isinstance(value, bool)
+                    for value in layers
                 )
-            except (TypeError, ValueError):
-                valid_layers = False
+                and layers[0] >= 0
+                and layers[1] >= layers[0]
+            )
             if not valid_layers:
-                raise ValueError("R7 EXL3 moe_layers must be [first, last]")
+                raise ValueError(
+                    "R7 EXL3 moe_layers must be two non-negative JSON integers "
+                    "[first, last] with last >= first"
+                )
             k_values = _r7.get("k_values")
             if not isinstance(k_values, (list, tuple)) or not k_values:
                 raise ValueError("R7 EXL3 k_values must be a non-empty list")
-            try:
-                invalid_k = sorted({int(value) for value in k_values} - {3, 4, 5})
-            except (TypeError, ValueError) as exc:
-                raise ValueError("R7 EXL3 k_values must contain integers") from exc
+            if any(
+                not isinstance(value, int) or isinstance(value, bool)
+                for value in k_values
+            ):
+                raise ValueError("R7 EXL3 k_values must contain JSON integers")
+            normalized_k = sorted(set(k_values))
+            invalid_k = sorted(set(normalized_k) - {3, 4, 5})
             if invalid_k:
                 raise ValueError(f"R7 EXL3 has unsupported k_values: {invalid_k}")
-            instance.r7_routed_experts = dict(_r7)
+            instance.r7_routed_experts = {
+                **_r7,
+                "moe_layers": tuple(layers),
+                "k_values": tuple(normalized_k),
+            }
         # --- end glm52-mdispatch ---
         return instance
 
@@ -3249,8 +3274,9 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         tier_signature = policy["tier_signature"]
         broadcast_suh = bool(mixed["broadcast_suh"])
         broadcast_svh = bool(mixed["broadcast_svh"])
+        owner_token = _runtime_owner_token(self.quant_config, layer)
         key = (
-            _runtime_owner_token(self.quant_config, layer),
+            owner_token,
             x.device.index,
             x.dtype,
             topk_ids.dtype,
@@ -3319,8 +3345,15 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 "capacity": capacity,
                 "launch": launch,
                 "buffers": _shared_mixed_buffers(
-                    mixed_api, launch, device, policy["sms"], capacity,
-                    block_size_m, tile_config, topk,
+                    owner_token,
+                    mixed_api,
+                    launch,
+                    device,
+                    policy["sms"],
+                    capacity,
+                    block_size_m,
+                    tile_config,
+                    topk,
                 ),
             }
 
@@ -3388,6 +3421,17 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             state: dict[str, Any],
             tiers: tuple[Any, Any],
         ) -> torch.Tensor:
+            run_kwargs = {}
+            gate_experts = mixed.get("tier_gate_experts")
+            up_experts = mixed.get("tier_up_experts")
+            if (gate_experts is None) != (up_experts is None):
+                raise RuntimeError(
+                    "projection-tight R7 tiers require paired gate/up counts"
+                )
+            if gate_experts is not None:
+                run_kwargs.update(
+                    gate_experts=gate_experts, up_experts=up_experts
+                )
             return (
                 runtime["mixed_api"]
                 .run_mixed_trellis(
@@ -3401,7 +3445,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                     mixed["rotations"],
                     state["launch"],
                     state["buffers"],
-                    gate_experts=mixed.get("tier_gate_experts"),
+                    **run_kwargs,
                 )
                 .to(slice_x.dtype)
             )
@@ -3485,6 +3529,9 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             self._r7_table_from_tensors(layer, group, attr, shard_id)
             for group, attr, shard_id in pointer_specs
         )
+        declared_k = set(
+            getattr(self.quant_config, "r7_routed_experts", {}).get("k_values", ())
+        )
 
         def projection_bits(group: str, shard_id: str) -> torch.Tensor:
             tensors = getattr(layer, f"{group}_trellis").exl3_tensors
@@ -3492,11 +3539,11 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 int(tensors[(expert_id, shard_id)].shape[2] // 16)
                 for expert_id in range(layer.local_num_experts)
             ]
-            invalid = sorted(set(values) - {3, 4, 5})
+            invalid = sorted(set(values) - declared_k)
             if invalid:
                 raise ValueError(
-                    f"R7 {shard_id} has unsupported bitrates {invalid}; "
-                    "expected only checkpoint-declared K3/K4/K5"
+                    f"R7 {shard_id} has bitrates {invalid} not declared by "
+                    f"r7_routed_experts.k_values={sorted(declared_k)}"
                 )
             return torch.tensor(
                 values,
@@ -3522,8 +3569,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
     # across model loads in one process and making the fused/per-expert split
     # order-dependent. The config is per model load and shared by its layers.
 
-    @staticmethod
-    def _r7_projection_tiers(layer: RoutedExperts):
+    def _r7_projection_tiers(self, layer: RoutedExperts):
         """Split experts into two bitrate tiers per projection.
 
         Returns (tier_bits, {projection: (tier_id_per_expert, ...)}) or None
@@ -3547,11 +3593,14 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             "down": widths("w2", "w2"),
         }
         present = sorted({b for values in projections.values() for b in values})
-        invalid = sorted(set(present) - {3, 4, 5})
+        declared_k = set(
+            getattr(self.quant_config, "r7_routed_experts", {}).get("k_values", ())
+        )
+        invalid = sorted(set(present) - declared_k)
         if invalid:
             raise ValueError(
-                f"R7 routed experts use unsupported bitrates {invalid}; "
-                "expected only checkpoint-declared K3/K4/K5"
+                f"R7 routed experts use bitrates {invalid} not declared by "
+                f"r7_routed_experts.k_values={sorted(declared_k)}"
             )
         if len(present) != 2:
             return None
@@ -3635,6 +3684,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         prefill_tiers = []
         fc1_counts = []
         tier_gate_counts = []  # real gate plane count per tier
+        tier_up_counts = []  # real up plane count per tier
         # Stack every tier BEFORE preparing any of them. prepare needs a
         # transient full-size counterpart for the phase it is not packing, and
         # that will not fit while the per-expert source tensors are still
@@ -3695,19 +3745,39 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             # ~1 extra plane per tier per layer, measured at -1.81 GiB of KV
             # headroom at max_model_len 262144 on 4x96 GB.
             expected_last = 16 * bits
-            _tmpl_id = gate_ids[0] if gate_ids else 0
-            gate_template = w13_param.exl3_tensors[(_tmpl_id, "w1")]
             gate_n = len(gate_ids)
             up_n = len(up_ids)
+            if gate_ids:
+                payload_template = w13_param.exl3_tensors[(gate_ids[0], "w1")]
+            elif up_ids:
+                payload_template = w13_param.exl3_tensors[(up_ids[0], "w3")]
+            else:
+                # This K may occur only in down. Use its dtype/device, but
+                # derive the FC1 geometry instead of borrowing expert 0 from
+                # another K or an already-consumed tier.
+                payload_template = w2_param.exl3_tensors[(down_ids[0], "w2")]
             w13 = torch.zeros(
-                (max(gate_n + up_n, 1), *gate_template.shape),
-                dtype=gate_template.dtype,
-                device=gate_template.device,
+                (
+                    max(gate_n + up_n, 1),
+                    hidden_size // 16,
+                    intermediate_size // 16,
+                    expected_last,
+                ),
+                dtype=payload_template.dtype,
+                device=payload_template.device,
             )
             plane(gate_ids, "w1", w13_param, fc1_slots, out=w13, base=0)
             plane(up_ids, "w3", w13_param, fc1_slots, out=w13, base=gate_n)
-            w2 = plane(down_ids, "w2", w2_param, fc2_slots)
+            if down_ids:
+                w2 = plane(down_ids, "w2", w2_param, fc2_slots)
+            else:
+                w2 = torch.zeros(
+                    (1, intermediate_size // 16, hidden_size // 16, expected_last),
+                    dtype=payload_template.dtype,
+                    device=payload_template.device,
+                )
             tier_gate_counts.append(gate_n)
+            tier_up_counts.append(up_n)
             torch.cuda.empty_cache()
             if (
                 int(w13.shape[-1]) != expected_last
@@ -3890,6 +3960,8 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             # Real gate plane count per tier, threaded to run_mixed_trellis so
             # the w13 descriptor sizes by gate_count over the tight buffer.
             "tier_gate_experts": tuple(tier_gate_counts),
+            # Real up counts make descriptor bounds independent of FC1 slots.
+            "tier_up_experts": tuple(tier_up_counts),
             "global_to_combined": global_to_combined,
             "descriptor_map": descriptor_map,
             "rotations": rotations,

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -20,6 +20,8 @@ one or initialize CUDA.
 from __future__ import annotations
 
 import ctypes
+import dataclasses
+import gc
 import importlib
 import os
 import re
@@ -102,6 +104,10 @@ _B12X_TRELLIS_WARMED_DEVICES: set[int] = set()
 _B12X_TRELLIS_C_TMP_CAP = 192 * 4 * 64 * 256
 _RANK_SLICED_RUNTIMES: dict[tuple[Any, ...], dict[str, Any]] = {}
 _MIXED_TRELLIS_RUNTIMES: dict[tuple[Any, ...], dict[str, Any]] = {}
+# glm52-r7-sparkinfer: keyed on launch geometry, shared across layers.
+_MIXED_TRELLIS_BUFFERS: dict[tuple[Any, ...], Any] = {}
+# glm52-r7-cudagraph: fused projection-wise mixed-K path
+_R7_GRAPH_RUNTIMES: dict[tuple[Any, ...], dict[str, Any]] = {}
 _NEXT_RUNTIME_SCOPE_ID = 0
 _MIXED_TRELLIS_ROUTE_BLOCK_SIZE = 8
 _GLM52_MIXED_TRELLIS_PREFILL_BLOCK_SIZE = 32
@@ -390,6 +396,11 @@ def _load_b12x_mixed_trellis() -> Any:
         ) from exc
     api = SimpleNamespace(
         build_tiered_maps=module.build_tiered_maps,
+        # glm52-r7-sparkinfer: absent on an unpatched SparkInfer, which the
+        # loader checks for before selecting the fused R7 path.
+        build_projection_tiered_maps=getattr(
+            module, "build_projection_tiered_maps", None
+        ),
         combine_trellis_rotations=module.combine_trellis_rotations,
         compile_mixed_trellis=module.compile_mixed_trellis,
         make_mixed_trellis_buffers=module.make_mixed_trellis_buffers,
@@ -463,6 +474,191 @@ def _positive_env_int(name: str, default: int) -> int:
     if value <= 0:
         raise ValueError(f"{name} must be positive, got {value}")
     return value
+
+
+def _resolve_r7_a1_min_rows(ext: Any) -> int:
+    """Rows at or above which the R7 MoE uses the A1 re-tile entry.
+
+    Returns 0 when A1 is unavailable or disabled, which keeps every launch on
+    exl3_moe_r7_fused. glm52-r7-a1-mixed.
+    """
+
+    if not hasattr(ext, "exl3_moe_r7_fused_retile"):
+        return 0
+    raw = os.environ.get("VLLM_EXL3_R7_A1_MIN_ROWS")
+    if raw is None:
+        # MEASURED OFF. At min_rows=33 (prefill only) A1 cost 14.7% prefill and
+        # 12.9-26.4% decode against an otherwise identical control on the same
+        # image (see A1_MEASUREMENT.md). The decode half of that should not be
+        # reachable at all, which is itself unexplained -- the leading suspect
+        # is the 100,352 B MOE_A1_SMEM_MAX_BYTES opt-in leaving almost no L1 on
+        # a 128 KiB unified SM, and the carve-out reconfiguration bleeding into
+        # neighbouring launches. Set to 33 to re-enable prefill-only A1, or 1 to
+        # take it everywhere; do not change this default without a control run.
+        return 0
+    value = int(raw)
+    if value < 0:
+        raise ValueError(
+            f"VLLM_EXL3_R7_A1_MIN_ROWS must be >= 0, got {value}"
+        )
+    return value
+
+
+def _r7_fused_layer_budget():
+    """Max layers to convert, or None for no cap. glm52-r7-sparkinfer."""
+
+    raw = os.environ.get("VLLM_EXL3_R7_FUSED_LAYERS")
+    if raw is None or raw == "":
+        return 48
+    value = int(raw)
+    return None if value < 0 else value
+
+
+_R7_FC1_BALLAST: dict[tuple[Any, ...], torch.Tensor] = {}
+
+
+def _r7_fc1_ballast(slots: int, like: torch.Tensor) -> torch.Tensor:
+    """Shared, never-read w2 stand-in for the FC1 prepare. glm52-r7-sparkinfer.
+
+    Keyed on the tail shape only. Keying on `slots` as well allocated a fresh
+    buffer for nearly every layer -- slots is the per-layer max(gate, up) count
+    -- and retained all of them, which is where the ~0.35 GiB/layer of load
+    growth came from. One buffer per (tail shape, dtype, device) is sized at the
+    maximum expert count and narrowed; narrowing the leading dimension of a
+    contiguous tensor stays contiguous, which is all prepare validates.
+    """
+
+    return _r7_ballast_view(int(slots), like)  # glm52-r7-gate-tight: shared pool
+
+
+_R7_W13_BALLAST: dict[tuple[Any, ...], torch.Tensor] = {}
+
+
+def _r7_w13_ballast(slots: int, like: torch.Tensor) -> torch.Tensor:
+    """Shared never-read [2, slots, ...] w13 stand-in for prepare. gate-tight.
+
+    prepare_weights requires the projection-major [2,E,...] w13 shape but only
+    validates it and returns a view this loader discards (rebinding w13 to the
+    tight [gate|up] buffer). So one zero buffer, sized to the max 2*slots and
+    reshaped from a contiguous flat prefix, serves every layer -- avoiding the
+    padded (2,max) allocation the earlier code kept resident (~0.6 GiB/layer).
+    """
+
+    plane = tuple(like.shape[1:])
+    slots = int(slots)
+    need = 2 * slots
+    return _r7_ballast_view(need, like).reshape(2, slots, *plane)
+
+
+_R7_BALLAST_POOL: dict[Any, torch.Tensor] = {}
+
+
+def _r7_ballast_view(planes: int, like: torch.Tensor) -> torch.Tensor:
+    """A view of ONE shared never-read scratch pool. glm52-r7-gate-tight.
+
+    prepare_weights validates w13/w2 shapes but this loader discards the views
+    it builds from them, so the contents are never read -- which means every
+    ballast request across layers, tiers and bitrates can alias one allocation.
+
+    Sizing per request instead re-allocated as tier sizes grew and fragmented
+    the heap enough to OOM during weight load; a per-bitrate max-size buffer
+    instead wasted ~2.1 GiB. One pool, allocated once at the worst case
+    (2 x 256 experts of the widest bitrate), costs ~0.8 GiB total and never
+    reallocates. The pool is int16-native and reshaped per request, so a K3
+    request simply uses a shorter contiguous prefix than a K4 one.
+    """
+
+    plane = tuple(like.shape[1:])
+    plane_elems = 1
+    for dim in plane:
+        plane_elems *= int(dim)
+    need_elems = int(planes) * plane_elems
+    key = (like.dtype, like.device)
+    pool = _R7_BALLAST_POOL.get(key)
+    if pool is None or int(pool.numel()) < need_elems:
+        # 512 planes = 2 projections x 256 experts, the structural maximum.
+        pool = torch.zeros(
+            max(need_elems, 512 * plane_elems), dtype=like.dtype, device=like.device
+        )
+        _R7_BALLAST_POOL[key] = pool
+    return pool[:need_elems].reshape(int(planes), *plane)
+
+
+def _r7_fused_enabled() -> bool:
+    """R7 on SparkInfer's fused MoE. glm52-r7-sparkinfer.
+
+    On by default; set VLLM_EXL3_R7_FUSED=0 to force exl3_moe_r7_fused for a
+    control run.
+    """
+
+    return os.environ.get("VLLM_EXL3_R7_FUSED", "1") != "0"
+
+
+def _shared_mixed_buffers(
+    mixed_api, launch, device, sms, capacity, block_size_m, tile_config, topk
+):
+    """One scratch arena per launch geometry. glm52-r7-sparkinfer."""
+
+    # glm52-r7-gate-tight: max_m_blocks is DELIBERATELY excluded from the key.
+    # It derives from each layer's summed tier slots, which differ per layer
+    # (262, 273, 272, ... on this checkpoint), so keying on it produced a
+    # separate ~574 MiB prefill arena for every distinct tier signature --
+    # ~4.6 GiB of duplicate scratch that logger.info_once hid from the logs.
+    # Instead one arena per launch geometry is grown to the largest
+    # max_m_blocks seen; the arena is scratch, so a larger one serves any
+    # smaller launch.
+    key = (
+        device.index if hasattr(device, "index") else device,
+        int(capacity),
+        int(block_size_m),
+        tuple(int(v) for v in tile_config),
+        int(topk),
+        int(launch.hidden_size),
+        int(launch.intermediate_size),
+        int(launch.size_m),
+        int(sms),
+        str(launch.rotation_input_dtype),
+        launch.route_ids_dtype,
+    )
+    # One arena per launch geometry, allocated ONCE. Growing it on a larger
+    # max_m_blocks thrashed (51 allocations, old arenas retained by the
+    # per-signature runtimes that already hold them), so the first arena for a
+    # geometry is sized by the first launch and reused. Scratch is indexed by
+    # the kernel's own bounds, and every launch sharing this key shares the
+    # capacity/block/tile/topk that size it.
+    entry = _MIXED_TRELLIS_BUFFERS.get(key)
+    if entry is None:
+        # Size the single arena for the STRUCTURAL worst case -- both tiers at
+        # the 256-expert maximum -- so one arena is provably large enough for
+        # every layer's route-block count. Sizing it from the first layer would
+        # under-allocate for a later, wider one; growing it thrashed (51
+        # allocations, old arenas pinned by the runtimes already holding them).
+        worst = dataclasses.replace(
+            launch,
+            tier0_num_experts=256,
+            tier1_num_experts=256,
+            max_m_blocks=(
+                mixed_api.max_packed_route_slots(
+                    int(capacity) * int(topk), int(block_size_m), 512
+                )
+                + int(block_size_m)
+                - 1
+            )
+            // int(block_size_m),
+        )
+        entry = mixed_api.make_mixed_trellis_buffers(
+            worst, device=device, sms=sms
+        )
+        _MIXED_TRELLIS_BUFFERS[key] = entry
+        logger.info(
+            "R7 fused MoE scratch arena (worst-case sized): capacity=%d "
+            "block_m=%d topk=%d max_m_blocks=%d",
+            int(capacity),
+            int(block_size_m),
+            int(topk),
+            int(worst.max_m_blocks),
+        )
+    return entry
 
 
 def _resolve_prefill_capacity(max_batched_tokens: int) -> int:
@@ -737,13 +933,53 @@ class Exl3Config(QuantizationConfig):
 
     @classmethod
     def from_config(cls, config: dict[str, Any]) -> Exl3Config:
-        return cls(
+        instance = cls(
             bits=config.get("bits"),
             head_bits=config.get("head_bits"),
             codebook=config.get("codebook"),
             version=config.get("version"),
             tensor_storage=config.get("tensor_storage"),
         )
+        # --- glm52-mdispatch: r7 routed experts describe themselves ---
+        # They are absent from `tensor_storage`; keep their block so codebook
+        # and layer-range lookups can resolve them.
+        _r7 = config.get("r7_routed_experts")
+        if _r7 is not None:
+            if not isinstance(_r7, dict):
+                raise ValueError("r7_routed_experts must be an object")
+            if _r7.get("schema") != "r7-complete-v2-checkpoint-v1":
+                raise ValueError(
+                    "unsupported R7 EXL3 schema: "
+                    f"{_r7.get('schema')!r}"
+                )
+            if _r7.get("codebook") != "mcg" or _r7.get("bits") != "mixed_tensor":
+                raise ValueError(
+                    "R7 EXL3 requires codebook='mcg' and bits='mixed_tensor'"
+                )
+            layers = _r7.get("moe_layers")
+            try:
+                valid_layers = (
+                    isinstance(layers, (list, tuple))
+                    and len(layers) == 2
+                    and int(layers[0]) >= 0
+                    and int(layers[1]) >= int(layers[0])
+                )
+            except (TypeError, ValueError):
+                valid_layers = False
+            if not valid_layers:
+                raise ValueError("R7 EXL3 moe_layers must be [first, last]")
+            k_values = _r7.get("k_values")
+            if not isinstance(k_values, (list, tuple)) or not k_values:
+                raise ValueError("R7 EXL3 k_values must be a non-empty list")
+            try:
+                invalid_k = sorted({int(value) for value in k_values} - {3, 4, 5})
+            except (TypeError, ValueError) as exc:
+                raise ValueError("R7 EXL3 k_values must contain integers") from exc
+            if invalid_k:
+                raise ValueError(f"R7 EXL3 has unsupported k_values: {invalid_k}")
+            instance.r7_routed_experts = dict(_r7)
+        # --- end glm52-mdispatch ---
+        return instance
 
     @classmethod
     def override_quantization_method(
@@ -752,9 +988,14 @@ class Exl3Config(QuantizationConfig):
         user_quant: str | None,
         hf_config: PretrainedConfig | None = None,
     ) -> str | None:
-        del hf_quant_cfg
         if user_quant is not None and user_quant != "exl3":
             return None
+        r7 = hf_quant_cfg.get("r7_routed_experts")
+        if (
+            isinstance(r7, dict)
+            and r7.get("schema") == "r7-complete-v2-checkpoint-v1"
+        ):
+            return "exl3"
         metadata = getattr(hf_config, "hybrid_tr3_tail", None)
         if isinstance(metadata, dict) and metadata.get("format") == _RANK_SLICED_FORMAT:
             return "exl3"
@@ -1229,6 +1470,16 @@ class Exl3Config(QuantizationConfig):
     def _moe_prefix_is_exl3(
         self, prefix: str, layer: torch.nn.Module | None = None
     ) -> bool:
+        # --- glm52-mdispatch: r7 routed experts are EXL3 too ---
+        # They are declared in `r7_routed_experts`, not `tensor_storage`, so
+        # stock detection returns False -> get_quant_method returns None ->
+        # fused_moe/routed_experts.py:209 SILENTLY substitutes
+        # UnquantizedFusedMoEMethod, allocating full-width BF16 expert buffers
+        # (~3.5x the real footprint) with no diagnostic. Fall through for
+        # everything else so the rank-sliced tail keeps its own detection.
+        if self._r7_layer_range_contains(prefix):
+            return True
+        # --- end glm52-mdispatch ---
         if self.rank_sliced_metadata is not None:
             match = re.search(r"layers\.(\d+)\b", prefix)
             if match is None:
@@ -1259,12 +1510,30 @@ class Exl3Config(QuantizationConfig):
     def codebook_for_prefix(self, prefix: str) -> str | None:
         if self.rank_sliced_metadata is not None:
             match = re.search(r"layers\.(\d+)\b", prefix)
-            if match is None:
-                return None
-            first, last = (int(v) for v in self.rank_sliced_metadata["moe_layers"])
-            return "mcg" if first <= int(match.group(1)) <= last else None
+            # --- glm52-mdispatch: hybrid checkpoints ---
+            # A rank-sliced TAIL does not make the whole checkpoint
+            # rank-sliced. Claim "mcg" only for layers actually inside
+            # moe_layers; every other prefix (dense/attention EXL3 recorded in
+            # tensor_storage, and the r7 routed experts) must still resolve
+            # below. Returning None here makes each of them fail as
+            # "unexpected codebook[None]" even though it ships an mcg marker.
+            if match is not None:
+                first, last = (
+                    int(v) for v in self.rank_sliced_metadata["moe_layers"]
+                )
+                if first <= int(match.group(1)) <= last:
+                    return "mcg"
+            # --- end glm52-mdispatch ---
         entry = self._storage_entry(prefix)
         if entry is None:
+            # --- glm52-mdispatch: r7 routed experts declare their own ---
+            # Without this the shipped mcg markers read as "unexpected
+            # codebook marker". Inert without an r7 block.
+            if self._r7_layer_range_contains(prefix):
+                _cb = getattr(self, "r7_routed_experts", {}).get("codebook")
+                if _cb in ("mcg", "mul1"):
+                    return str(_cb)
+            # --- end glm52-mdispatch ---
             return None
         suffixes = {name.rsplit(".", 1)[-1] for name in entry.get("stored_tensors", {})}
         if "mcg" in suffixes:
@@ -1273,11 +1542,48 @@ class Exl3Config(QuantizationConfig):
             return "mul1"
         return None
 
+    def _r7_layer_range_contains(self, prefix: str) -> bool:
+        """True when `prefix` names a layer inside r7_routed_experts.moe_layers.
+
+        glm52-mdispatch. The r7 layout keeps its own layer range instead of
+        appearing in `tensor_storage`; nothing in stock vLLM reads it.
+        """
+        r7 = getattr(self, "r7_routed_experts", None)
+        if not isinstance(r7, dict):
+            return False
+        # r7_routed_experts describes ROUTED EXPERTS only. Without this the
+        # range would also claim attention/dense prefixes in the same layers
+        # (e.g. kv_b_proj, which is BF16 here).
+        if ".mlp.experts" not in prefix:
+            return False
+        layers = r7.get("moe_layers")
+        if not (isinstance(layers, (list, tuple)) and len(layers) == 2):
+            return False
+        match = re.search(r"layers\.(\d+)\b", prefix)
+        if match is None:
+            return False
+        return int(layers[0]) <= int(match.group(1)) <= int(layers[1])
+
     def has_quantized_lm_head(self) -> bool:
         return self._is_exl3_prefix("lm_head")
 
     def normalize_rank_sliced_weight_name(self, name: str) -> str | None:
         """Drop non-local TP payloads and remove the serialized rank segment."""
+        # --- glm52-mdispatch: r7 shared rotations (topology-neutral) ---
+        # ONE h-side rotation per layer, shared by every expert, no rank
+        # segment. Rewrite into expert 0's slot; exl3_shared_h_rotations then
+        # makes the existing shared-parameter machinery serve it.
+        if getattr(self, "r7_routed_experts", None) is not None:
+            _r7 = re.match(
+                r"^(?P<experts_prefix>.+\.experts)\.r7_shared\."
+                r"(?P<field>gate_up_suh|down_svh)$",
+                name,
+            )
+            if _r7 is not None:
+                if _r7.group("field") == "gate_up_suh":
+                    return f"{_r7.group('experts_prefix')}.0.gate_proj.suh"
+                return f"{_r7.group('experts_prefix')}.0.down_proj.svh"
+        # --- end glm52-mdispatch ---
         if self.rank_sliced_metadata is None:
             return name
         shared_match = _SHARED_H_WEIGHT_RE.match(name)
@@ -2097,12 +2403,73 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         layer.exl3_hidden_size = hidden_size
         layer.exl3_intermediate_size_per_partition = intermediate_size_per_partition
         layer.exl3_params_dtype = params_dtype
+        # glm52-r7-cudagraph: checkpoint-driven; no serving env switch.
+        layer.exl3_r7_graph = self.quant_config._r7_layer_range_contains(
+            str(layer.layer_name)
+        )
+        # glm52-r7-prefill: plan the R7 arena against the scheduler contract
+        #
+        # The rank-sliced path reads scheduler_config.max_num_batched_tokens
+        # here and plans one prefill-sized arena from it. The R7 path had no
+        # equivalent, so it planned a fixed 128-row arena and re-entered the
+        # fused MoE once per 128 tokens. Stamp the same capacity, for the same
+        # reason the rank-sliced branch stamps it here and not at forward time:
+        # the profile pass and CUDA-graph capture both run after
+        # set_current_vllm_config has exited, where
+        # get_current_vllm_config_or_none() returns None.
+        #
+        # R7 layers take the `rank_sliced = False` branch below (their layer
+        # range is disjoint from rank_sliced_metadata["moe_layers"]), so they
+        # never reach the rank-sliced stamp.
+        if layer.exl3_r7_graph:
+            _r7_vllm_config = get_current_vllm_config_or_none()
+            _r7_scheduler = (
+                _r7_vllm_config.scheduler_config
+                if _r7_vllm_config is not None
+                else None
+            )
+            if (
+                _r7_scheduler is None
+                or getattr(_r7_scheduler, "max_num_batched_tokens", None) is None
+            ):
+                raise ValueError(
+                    "R7 EXL3 MoE requires scheduler_config."
+                    "max_num_batched_tokens to plan its staging arena; refusing "
+                    "to guess a capacity."
+                )
+            layer.exl3_r7_max_num_batched_tokens = int(
+                _r7_scheduler.max_num_batched_tokens
+            )
         rank_sliced = self.quant_config.rank_sliced_metadata is not None
+        # --- glm52-mdispatch: route per layer, not per checkpoint ---
+        # A checkpoint may carry a rank-sliced TAIL (e.g. hybrid_tr3_tail
+        # moe_layers [78,78], "carried_mtp78_only") alongside a body stored in
+        # a non-rank-sliced layout. Deciding globally drags the body onto the
+        # slab path, which stacks every expert at one bitrate and dies on
+        # mixed k. Honour the declared range instead, and stamp the decision on
+        # the layer so later branches agree with this one.
+        if rank_sliced:
+            _rs_layers = self.quant_config.rank_sliced_metadata.get("moe_layers")
+            _rs_match = re.search(r"layers\.(\d+)\b", str(layer.layer_name))
+            if (
+                isinstance(_rs_layers, (list, tuple))
+                and len(_rs_layers) == 2
+                and _rs_match is not None
+            ):
+                rank_sliced = (
+                    int(_rs_layers[0]) <= int(_rs_match.group(1)) <= int(_rs_layers[1])
+                )
+        layer.exl3_rank_sliced = rank_sliced
+        # --- end glm52-mdispatch ---
         shared_h = (
             rank_sliced
             and self.quant_config.rank_sliced_rotation_layout
             == _SHARED_H_ROTATION_LAYOUT
         )
+        # --- glm52-mdispatch: r7 layers share (w13,suh) and (w2,svh) ---
+        if self.quant_config._r7_layer_range_contains(str(layer.layer_name)):
+            shared_h = True
+        # --- end glm52-mdispatch ---
         layer.exl3_shared_h_rotations = shared_h
         if rank_sliced:
             checkpoint_tp = int(self.quant_config.rank_sliced_metadata["tp"])
@@ -2178,6 +2545,14 @@ class Exl3MoEMethod(FusedMoEMethodBase):
 
     def process_weights_after_loading(self, layer: RoutedExperts) -> None:
         required = {"w13": ("w1", "w3"), "w2": ("w2",)}
+        # --- glm52-mdispatch: r7 stores ONE gate_up_suh for gate AND up ---
+        # shared_h_v1 keeps a separate shared tensor per projection; r7 keeps
+        # one, because gate_proj and up_proj consume the same activation.
+        if getattr(layer, "exl3_shared_h_rotations", False):
+            _w13_suh = layer.w13_suh.exl3_tensors
+            if (0, "w1") in _w13_suh and (0, "w3") not in _w13_suh:
+                _w13_suh[(0, "w3")] = _w13_suh[(0, "w1")]
+        # --- end glm52-mdispatch ---
         missing: list[str] = []
         for prefix, shard_ids in required.items():
             for attr in ("suh", "svh", "trellis"):
@@ -2202,7 +2577,12 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 + (" ..." if len(missing) > 32 else "")
             )
         self._validate_codebooks(layer)
-        if self.quant_config.rank_sliced_metadata is None:
+        # glm52-mdispatch: per-layer routing (see create_weights)
+        if not getattr(
+            layer,
+            "exl3_rank_sliced",
+            self.quant_config.rank_sliced_metadata is not None,
+        ):
             self._shard_tensors_for_tensor_parallel(layer)
         device = layer.w13_trellis.device
         for prefix in ("w13", "w2"):
@@ -2213,8 +2593,58 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                         device=device, non_blocking=True
                     ).contiguous()
         self._validate_moe_shapes(layer)
+        # --- glm52-mdispatch: broadcast shared rotations on the std path ---
+        # `_apply_expert` indexes suh/svh by (expert_id, shard_id), so every
+        # expert needs a key. The rank-sliced path broadcasts a 1-row slab in
+        # `_select_rotation_rows`; the standard path has no equivalent. Alias
+        # the SAME device tensor into each expert's slot -- dict entries, not
+        # copies -- and never clobber a genuine per-expert tensor. Runs after
+        # the TP narrow and the device move so the alias is already final.
+        _rs = getattr(
+            layer,
+            "exl3_rank_sliced",
+            self.quant_config.rank_sliced_metadata is not None,
+        )
+        if getattr(layer, "exl3_shared_h_rotations", False) and not _rs:
+            for _group, _shards in (("w13", ("w1", "w3")), ("w2", ("w2",))):
+                _attr = "suh" if _group == "w13" else "svh"
+                _tensors = getattr(layer, f"{_group}_{_attr}").exl3_tensors
+                for _shard in _shards:
+                    _source = _tensors.get((0, _shard))
+                    if _source is None:
+                        continue
+                    for _expert in range(1, layer.local_num_experts):
+                        if (_expert, _shard) not in _tensors:
+                            _tensors[(_expert, _shard)] = _source
+        _dbg = os.environ.get("VLLM_EXL3_R7_DEBUG", "")
+        if _dbg and _dbg in str(getattr(layer, "layer_name", "")):
+            import torch as _t
+            _out = [f"R7DBG {layer.layer_name} rank={layer.exl3_tp_rank} "
+                    f"shared_h={getattr(layer, 'exl3_shared_h_rotations', None)} "
+                    f"rank_sliced={_rs} local_experts={layer.local_num_experts}"]
+            for _g, _a, _k in (("w13", "suh", (0, "w1")), ("w13", "suh", (5, "w3")),
+                               ("w13", "svh", (5, "w1")), ("w13", "trellis", (5, "w1")),
+                               ("w2", "suh", (5, "w2")), ("w2", "svh", (5, "w2")),
+                               ("w2", "trellis", (5, "w2"))):
+                _tt = getattr(layer, f"{_g}_{_a}").exl3_tensors.get(_k)
+                if _tt is None:
+                    _out.append(f"  {_g}_{_a}{_k}: MISSING")
+                else:
+                    _v = _tt.to(_t.float64)
+                    _out.append(f"  {_g}_{_a}{_k}: shape={tuple(_tt.shape)} "
+                                f"dtype={_tt.dtype} sum={_v.sum().item():.6f}")
+            print(chr(10).join(_out), flush=True)
+        # --- end glm52-mdispatch ---
 
-        if self.quant_config.rank_sliced_metadata is not None:
+        if getattr(layer, "exl3_r7_graph", False):
+            # glm52-r7-sparkinfer: prefer the fused mixed-Trellis kernel; layers
+            # carrying a third K on either phase keep exl3_moe_r7_fused.
+            if _r7_fused_enabled() and self._prepare_r7_sparkinfer_weights(layer):
+                layer.exl3_r7_fused = True
+                return
+            self._prepare_r7_graph_weights(layer)
+            return
+        if _rs:
             self._prepare_rank_sliced_weights(layer)
             return
 
@@ -2888,10 +3318,9 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             return {
                 "capacity": capacity,
                 "launch": launch,
-                "buffers": mixed_api.make_mixed_trellis_buffers(
-                    launch,
-                    device=device,
-                    sms=policy["sms"],
+                "buffers": _shared_mixed_buffers(
+                    mixed_api, launch, device, policy["sms"], capacity,
+                    block_size_m, tile_config, topk,
                 ),
             }
 
@@ -2972,6 +3401,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                     mixed["rotations"],
                     state["launch"],
                     state["buffers"],
+                    gate_experts=mixed.get("tier_gate_experts"),
                 )
                 .to(slice_x.dtype)
             )
@@ -3008,6 +3438,705 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 mixed["prefill_tiers"],
             )
             output[start:stop].copy_(slice_output)
+        return output
+
+    @staticmethod
+    def _r7_table_from_tensors(
+        layer: RoutedExperts,
+        group: str,
+        attr: str,
+        shard_id: str,
+    ) -> torch.Tensor:
+        tensors = getattr(layer, f"{group}_{attr}").exl3_tensors
+        rows = [
+            tensors[(expert_id, shard_id)]
+            for expert_id in range(layer.local_num_experts)
+        ]
+        if any(not row.is_contiguous() for row in rows):
+            raise RuntimeError(
+                f"R7 {group}_{attr}/{shard_id} contains a non-contiguous tensor"
+            )
+        return torch.tensor(
+            [row.data_ptr() for row in rows],
+            dtype=torch.int64,
+            device=rows[0].device,
+        )
+
+    def _prepare_r7_graph_weights(self, layer: RoutedExperts) -> None:
+        """Build pointer/K tables without modifying or restacking R7 payloads."""
+        ext = _load_exl3_ext()
+        if not hasattr(ext, "exl3_moe_r7_fused"):
+            raise RuntimeError(
+                "R7 CUDA-graph execution requires exl3_moe_r7_fused; "
+                "the extension and vLLM patches must be installed together"
+            )
+        pointer_specs = (
+            ("w13", "trellis", "w1"),
+            ("w13", "suh", "w1"),
+            ("w13", "svh", "w1"),
+            ("w13", "trellis", "w3"),
+            ("w13", "suh", "w3"),
+            ("w13", "svh", "w3"),
+            ("w2", "trellis", "w2"),
+            ("w2", "suh", "w2"),
+            ("w2", "svh", "w2"),
+        )
+        layer.exl3_r7_pointer_tables = tuple(
+            self._r7_table_from_tensors(layer, group, attr, shard_id)
+            for group, attr, shard_id in pointer_specs
+        )
+
+        def projection_bits(group: str, shard_id: str) -> torch.Tensor:
+            tensors = getattr(layer, f"{group}_trellis").exl3_tensors
+            values = [
+                int(tensors[(expert_id, shard_id)].shape[2] // 16)
+                for expert_id in range(layer.local_num_experts)
+            ]
+            invalid = sorted(set(values) - {3, 4, 5})
+            if invalid:
+                raise ValueError(
+                    f"R7 {shard_id} has unsupported bitrates {invalid}; "
+                    "expected only checkpoint-declared K3/K4/K5"
+                )
+            return torch.tensor(
+                values,
+                dtype=torch.int32,
+                device=layer.w13_trellis.device,
+            )
+
+        layer.exl3_r7_bitrates = (
+            projection_bits("w13", "w1"),
+            projection_bits("w13", "w3"),
+            projection_bits("w2", "w2"),
+        )
+        layer.exl3_r7_expert_map = torch.arange(
+            layer.local_num_experts,
+            dtype=torch.int64,
+            device=layer.w13_trellis.device,
+        )
+
+    # Fused-layer budget consumption is per method instance, not process
+    # global: a class attribute leaks the count across model loads in one
+    # process and makes which layers use the fused path order-dependent.
+    _r7_fused_layers = 0
+
+    @staticmethod
+    def _r7_projection_tiers(layer: RoutedExperts):
+        """Split experts into two bitrate tiers per projection.
+
+        Returns (tier_bits, {projection: (tier_id_per_expert, ...)}) or None
+        when any projection carries more than two distinct K, which keeps that
+        layer on exl3_moe_r7_fused. glm52-r7-sparkinfer.
+        """
+
+        # Derived from the payloads, not from layer.exl3_r7_bitrates: that
+        # attribute is built by _prepare_r7_graph_weights, which this path
+        # replaces and therefore has not run.
+        def widths(group: str, shard_id: str) -> list[int]:
+            tensors = getattr(layer, f"{group}_trellis").exl3_tensors
+            return [
+                int(tensors[(e, shard_id)].shape[2] // 16)
+                for e in range(int(layer.local_num_experts))
+            ]
+
+        projections = {
+            "gate": widths("w13", "w1"),
+            "up": widths("w13", "w3"),
+            "down": widths("w2", "w2"),
+        }
+        present = sorted({b for values in projections.values() for b in values})
+        invalid = sorted(set(present) - {3, 4, 5})
+        if invalid:
+            raise ValueError(
+                f"R7 routed experts use unsupported bitrates {invalid}; "
+                "expected only checkpoint-declared K3/K4/K5"
+            )
+        if len(present) != 2:
+            return None
+        lookup = {present[0]: 0, present[1]: 1}
+        return tuple(present), {
+            name: tuple(lookup[b] for b in values)
+            for name, values in projections.items()
+        }
+
+    def _prepare_r7_sparkinfer_weights(self, layer: RoutedExperts) -> bool:
+        """Pack R7 experts into SparkInfer tier stacks. False -> keep exl3_moe."""
+
+        split = self._r7_projection_tiers(layer)
+        if split is None:
+            return False
+        # The fused layout costs ~1.385 GiB/layer against ~1.031 GiB for the
+        # per-expert one, so converting all 75 exhausts the GPU around layer 58.
+        # Cap the count until that overhead is tracked down; the rest keep
+        # exl3_moe_r7_fused, which the loader already selects per layer.
+        budget = _r7_fused_layer_budget()
+        if budget is not None:
+            if int(getattr(self, "_r7_fused_layers", 0)) >= budget:
+                return False
+            # Charged only after this layer's tiers are frozen (see the
+            # success path below): a failed packing attempt must not consume
+            # budget that a later layer could have used.
+        tier_bits, tiers = split
+        mixed_api = _load_b12x_mixed_trellis()
+        if getattr(mixed_api, "build_projection_tiered_maps", None) is None:
+            raise RuntimeError(
+                "R7 fused MoE requires the projection-tier SparkInfer patch; "
+                "the kernel and loader patches must be installed together"
+            )
+        hidden_size = int(layer.exl3_hidden_size)
+        intermediate_size = int(layer.exl3_intermediate_size_per_partition)
+        num_experts = int(layer.local_num_experts)
+        w13_param = layer.w13_trellis
+        w2_param = layer.w2_trellis
+        device = w13_param.exl3_tensors[(0, "w1")].device
+
+        tile_config = self._mixed_trellis_tile_config(hidden_size, intermediate_size)
+        prefill_tile_config = self._mixed_trellis_prefill_tile_config(
+            hidden_size, intermediate_size
+        )
+
+        def rotation(group: str, attr: str, shard_id: str) -> torch.Tensor:
+            # glm52-r7-broadcast-rotations: R7 stores ONE shared row per
+            # layer (r7_shared.gate_up_suh / r7_shared.down_svh, [hidden]).
+            # r28's ABI v6 takes it as a broadcast row, so hand it (1, hidden)
+            # instead of num_experts bit-identical copies (~700 MiB saved).
+            tensors = getattr(layer, f"{group}_{attr}").exl3_tensors
+            return tensors[(0, shard_id)].unsqueeze(0).contiguous()
+
+        gate_suh = rotation("w13", "suh", "w1")
+        up_suh = rotation("w13", "suh", "w3")
+        down_svh = rotation("w2", "svh", "w2")
+        # Combined-expert indexed, so global order -- no tier reordering.
+        intermediate_rotations = torch.cat(
+            (
+                torch.stack([
+                    layer.w13_svh.exl3_tensors[(e, "w1")] for e in range(num_experts)
+                ]),
+                torch.stack([
+                    layer.w13_svh.exl3_tensors[(e, "w3")] for e in range(num_experts)
+                ]),
+                torch.stack([
+                    layer.w2_suh.exl3_tensors[(e, "w2")] for e in range(num_experts)
+                ]),
+            ),
+            dim=1,
+        ).contiguous()
+        rotations = SimpleNamespace(
+            intermediate=intermediate_rotations,
+            gate_suh=gate_suh,
+            up_suh=up_suh,
+            down_svh=down_svh,
+        )
+
+        prepared_tiers = []
+        prefill_tiers = []
+        fc1_counts = []
+        # Stack every tier BEFORE preparing any of them. prepare needs a
+        # transient full-size counterpart for the phase it is not packing, and
+        # that will not fit while the per-expert source tensors are still
+        # resident alongside their stacked copies.
+        stacks = []
+        tier_gate_counts = []  # glm52-r7-gate-tight: real gate plane count/tier
+        for tier_id, bits in enumerate(tier_bits):
+            gate_ids = [e for e in range(num_experts) if tiers["gate"][e] == tier_id]
+            up_ids = [e for e in range(num_experts) if tiers["up"][e] == tier_id]
+            down_ids = [e for e in range(num_experts) if tiers["down"][e] == tier_id]
+            fc1_slots = max(len(gate_ids), len(up_ids), 1)
+            fc2_slots = max(len(down_ids), 1)
+
+            def plane(expert_ids, shard_id, param, slots, out=None, row=0, base=None):
+                """Copy experts into a preallocated slab, releasing each source.
+
+                torch.stack would hold a whole extra layer while every source
+                expert is still resident, which accumulated until load OOMed
+                around layer 68 of 75. Popping each tensor out of exl3_tensors
+                as it is consumed keeps the extra to one expert.
+
+                glm52-r7-gate-tight: base!=None packs directly into a flat
+                [gate|up] buffer at out[base+index], so no padded (2,max) w13 is
+                ever materialised.
+                """
+                template = param.exl3_tensors[(expert_ids[0], shard_id)] if (
+                    expert_ids
+                ) else param.exl3_tensors[(0, shard_id)]
+                if out is None:
+                    out = torch.zeros(
+                        (slots, *template.shape),
+                        dtype=template.dtype,
+                        device=template.device,
+                    )
+                    target = out
+                    offset = 0
+                elif base is not None:
+                    target = out
+                    offset = int(base)
+                else:
+                    target = out[row]
+                    offset = 0
+                for index, expert_id in enumerate(expert_ids):
+                    src = param.exl3_tensors.pop((expert_id, shard_id), None)
+                    if src is None:
+                        raise RuntimeError(
+                            f"R7 fused: {shard_id} expert {expert_id} already "
+                            "consumed; a tier partition is not disjoint"
+                        )
+                    target[offset + index].copy_(src)
+                    del src
+                return out
+
+            gate_template = w13_param.exl3_tensors[
+                (gate_ids[0] if gate_ids else 0, "w1")
+            ]
+            # glm52-r7-gate-tight: fill the tight [gate|up] buffer DIRECTLY from
+            # the per-expert sources (each popped as consumed), so no padded
+            # (2,max) buffer is ever resident. The served w13 is exactly
+            # gate_count+up_count planes -> ~0.99 GiB/layer vs 1.18 padded.
+            # prepare_weights, which validates a [2,E] shape and builds a w13
+            # view we discard, gets a shared never-read ballast instead.
+            gate_n = len(gate_ids)
+            up_n = len(up_ids)
+            w13 = torch.zeros(
+                (max(gate_n + up_n, 1), *gate_template.shape),
+                dtype=gate_template.dtype,
+                device=gate_template.device,
+            )
+            plane(gate_ids, "w1", w13_param, fc1_slots, out=w13, base=0)
+            plane(up_ids, "w3", w13_param, fc1_slots, out=w13, base=gate_n)
+            w2 = plane(down_ids, "w2", w2_param, fc2_slots)
+            w13_tight = w13
+            tier_gate_counts.append(gate_n)
+            torch.cuda.empty_cache()
+            expected_last = 16 * bits
+            if (
+                int(w13.shape[-1]) != expected_last
+                or int(w2.shape[-1]) != expected_last
+            ):
+                raise ValueError(
+                    f"R7 fused tier{tier_id} K{bits} width mismatch: "
+                    f"w13={tuple(w13.shape)}, w2={tuple(w2.shape)}"
+                )
+
+            def prepare_tier(
+                cfg,
+                *,
+                w13: torch.Tensor = w13,
+                w2: torch.Tensor = w2,
+                slots: int = fc1_slots,
+                fc2_slots: int = fc2_slots,
+                bits: int = bits,
+                w13_tight: torch.Tensor = w13_tight,  # glm52-r7-gate-tight
+                gate_n: int = gate_n,
+                up_n: int = up_n,
+            ):
+                # prepare_weights validates w13 and w2 against one expert
+                # count, but per-projection tiering makes them differ (tier0
+                # here holds ~180 gate/up planes against ~25 down planes).
+                # Padding to a common count costs 49.8 GiB per rank on this
+                # checkpoint.
+                #
+                # For native trellis3_t256 the prepared FC2 fields are trivial:
+                # prepare.py returns w2=_trellis256_flat_native_view(w2) -- a
+                # dtype view, not a repack -- w2_scale = the shared four-byte
+                # dummy, and w2_global_scale = ones(num_experts). So FC2 is
+                # constructed directly at its own count and only FC1 goes
+                # through prepare. That removes the full-size counterpart
+                # tensor the earlier splice needed, which was OOMing at ~558
+                # MiB during load.
+                def call(n, w13_in, w2_in):
+                    return mixed_api.prepare_weights(
+                        w13=w13_in,
+                        w2=w2_in,
+                        hidden_size=hidden_size,
+                        intermediate_size=intermediate_size,
+                        num_experts=n,
+                        activation=layer.activation.value,
+                        fc1_tile_n=cfg[1],
+                        fc2_tile_n=cfg[3],
+                        params_dtype=torch.float16,
+                        w13_layout="trellis3_t256_proj",
+                        trellis_bits=bits,
+                        codebook="mcg",
+                        # prepare wants tier-local rows (or the broadcast
+                        # form); the launch wants the padded combined table.
+                        # Both are validate-and-carry here, and R7's gate/up
+                        # SUH really is one shared row, so the broadcast form
+                        # is the honest thing to hand prepare.
+                        gate_suh=gate_suh[:1].contiguous(),
+                        up_suh=up_suh[:1].contiguous(),
+                        intermediate_rotations=intermediate_rotations[:n]
+                        .contiguous(),
+                        down_svh=down_svh[:1].contiguous(),
+                        tile_config=cfg,
+                        # glm52-r7-ballast-dealias: a view into the ballast
+                        # pool would be stored verbatim in the frozen tier,
+                        # keeping the whole ~576 MiB allocation alive (192
+                        # live aliases per rank). Hand prepare an equivalent
+                        # standalone scalar so the pool can actually be freed.
+                        workspace=torch.zeros(
+                            1, dtype=torch.int32, device=w13_in.device
+                        ),
+                    )
+
+                # Ballast only: prepare validates w13 and w2 against one
+                # count, and the FC2 fields are rebuilt below, so this tensor's
+                # contents are never read. Allocating it per layer leaked
+                # ~200 MiB a layer and OOMed around layer 68 of 75, so it is
+                # cached and shared across every layer and tier.
+                fc1_w2 = (
+                    w2
+                    if fc2_slots == slots
+                    else _r7_fc1_ballast(slots, w2)
+                )
+                # prepare gets a shared never-read [2,slots] ballast (its w13
+                # view is discarded); the tight [gate|up] buffer is bound below.
+                fc1_prepared = call(slots, _r7_w13_ballast(slots, w13), fc1_w2)
+                # glm52-r7-gate-tight: bind the served w13 to the tight [gate|up]
+                # buffer. The kernel sizes its w13 descriptor by gate_count
+                # (companion gate-tight patch), so cute.size//2 lands the
+                # up-block base at gate_count*stride.
+                _tight_view = w13_tight.view(torch.int32).reshape(
+                    max(gate_n + up_n, 1),
+                    hidden_size // 16,
+                    intermediate_size // 16,
+                    8 * bits,
+                )
+                if fc2_slots == slots:
+                    return dataclasses.replace(fc1_prepared, w13=_tight_view)
+                return dataclasses.replace(
+                    fc1_prepared,
+                    w13=_tight_view,
+                    w2=w2.view(torch.int32).reshape(
+                        fc2_slots,
+                        intermediate_size // 16,
+                        hidden_size // 16,
+                        8 * bits,
+                    ),
+                    w2_scale=fc1_prepared.w2_scale,
+                    w2_global_scale=torch.ones(
+                        (fc2_slots,), dtype=torch.float32, device=device
+                    ),
+                )
+
+            fc1_counts.append(tuple(range(fc1_slots)))
+            stacks.append((prepare_tier, bits))
+
+        for prefix in ("w13", "w2"):
+            for suffix in ("suh", "svh", "trellis", "mcg", "mul1"):
+                param = getattr(layer, f"{prefix}_{suffix}")
+                param.exl3_tensors.clear()
+                param.exl3_backing = None
+                # Clearing the dict is not enough: the Parameter still owns the
+                # loaded storage, so the per-expert payload stays resident and
+                # the fused stacks accumulate on top of it -- ~1 GiB per layer,
+                # which OOMs partway through the 67 fused layers. Drop the
+                # parameter's own reference too. Nothing reads it after this
+                # point; the tier stacks are the only consumer from here on.
+                if isinstance(getattr(param, "data", None), torch.Tensor):
+                    param.data = torch.empty(
+                        0, dtype=param.data.dtype, device=param.data.device
+                    )
+        gc.collect()
+        torch.cuda.empty_cache()
+
+        # glm52-r7-pad-before-prepare: the padding MUST happen before the
+        # prepare loop. prepare stores the [:1]/[:n] slices it is handed as
+        # views, so padding afterwards leaves the unpadded originals pinned
+        # alongside the padded copies -- 448.5 MiB per rank on this model.
+        # Every combined-expert-indexed table is sized by the summed tier slot
+        # counts, not by the real expert count, so the padded stride applies to
+        # the rotations as well. Padding rows are never addressed: the kernel
+        # guards on 0 <= combined_expert < total and descriptor >= 0.
+        stride = sum(len(ids) for ids in fc1_counts)
+        if stride > num_experts:
+            pad = torch.zeros(
+                (stride - num_experts, intermediate_rotations.shape[1]),
+                dtype=intermediate_rotations.dtype,
+                device=intermediate_rotations.device,
+            )
+            intermediate_rotations = torch.cat(
+                (intermediate_rotations, pad), dim=0
+            ).contiguous()
+            # glm52-r7-broadcast-rotations: gate_suh/up_suh/down_svh are
+            # single broadcast rows now; padding them to `stride` would
+            # reinstate exactly the duplication this removes. Only the
+            # per-expert intermediate table is combined-expert indexed.
+            rotations = SimpleNamespace(
+                intermediate=intermediate_rotations,
+                gate_suh=gate_suh,
+                up_suh=up_suh,
+                down_svh=down_svh,
+            )
+
+        for prepare_tier_fn, _bits in stacks:
+            prepared_tiers.append(prepare_tier_fn(tile_config))
+            prefill_tiers.append(prepare_tier_fn(prefill_tile_config))
+            torch.cuda.empty_cache()
+
+
+        global_to_combined, descriptor_map = mixed_api.build_projection_tiered_maps(
+            tiers["gate"],
+            tiers["up"],
+            tiers["down"],
+            tier_slots=tuple(len(ids) for ids in fc1_counts),
+            device=device,
+        )
+        layer.exl3_mixed_trellis = {
+            "tiers": tuple(prepared_tiers),
+            "prefill_tiers": tuple(prefill_tiers),
+            "tier_bits": tuple(tier_bits),
+            # FC1 slot counts: what sizes the launch and the policy signature.
+            "tier_ids": tuple(fc1_counts),
+            # glm52-r7-gate-tight: real gate plane count per tier, threaded to
+            # run_mixed_trellis so the w13 descriptor sizes by gate_count.
+            "tier_gate_experts": tuple(tier_gate_counts),
+            "global_to_combined": global_to_combined,
+            "descriptor_map": descriptor_map,
+            "rotations": rotations,
+            # glm52-r7-broadcast-rotations: the shared runtime builder reads
+            # these by direct index; omitting them raises KeyError on r28.
+            "broadcast_suh": True,
+            "broadcast_svh": True,
+            "tile_config": tile_config,
+            "prefill_tile_config": prefill_tile_config,
+        }
+        if budget is not None:
+            self._r7_fused_layers = int(getattr(self, "_r7_fused_layers", 0)) + 1
+        layer.exl3_trellis_tile_config = tile_config
+        if not hasattr(layer, "exl3_max_num_batched_tokens"):
+            layer.exl3_max_num_batched_tokens = int(
+                layer.exl3_r7_max_num_batched_tokens
+            )
+        free_b, total_b = torch.cuda.mem_get_info(device)
+        logger.info(
+            "R7 fused mem %s: free=%.2fGiB alloc=%.2fGiB reserved=%.2fGiB",
+            layer.layer_name,
+            free_b / 2**30,
+            torch.cuda.memory_allocated(device) / 2**30,
+            torch.cuda.memory_reserved(device) / 2**30,
+        )
+        logger.info(
+            "R7 fused MoE %s: tier0=K%d(%d gate/%d up/%d down) tier1=K%d",
+            layer.layer_name,
+            tier_bits[0],
+            sum(1 for t in tiers["gate"] if t == 0),
+            sum(1 for t in tiers["up"] if t == 0),
+            sum(1 for t in tiers["down"] if t == 0),
+            tier_bits[1],
+        )
+        return True
+
+    def _r7_graph_runtime(
+        self,
+        layer: RoutedExperts,
+        x: torch.Tensor,
+        topk_ids: torch.Tensor,
+    ) -> dict[str, Any]:
+        # glm52-r7-prefill: the token batch and the per-expert route block are
+        # two independent quantities, and the previous plan collapsed them into
+        # one `chunk = 128`.
+        #
+        #   * The token batch is exl3_moe's `bsz = hidden_state.size(0)`. The
+        #     kernel imposes no upper bound on it: the only shape tie between
+        #     hidden_state and the staging buffers is
+        #     `temp_state_g.size(2) == hidden_state.size(1)` (the hidden dim).
+        #   * The route block is `max_tokens_per_expert = temp_state_g.size(1)`.
+        #     exl3_moe_kernel walks each expert's routed rows in blocks of that
+        #     many rows, and each block re-streams and re-decodes that expert's
+        #     whole gate/up/down trellis.
+        #
+        # Batching 128 tokens at a time therefore did not bound the arena (the
+        # route block did); it multiplied the number of fused-MoE entries per
+        # layer by ceil(max_num_batched_tokens / 128) and, because a 128-token
+        # batch routes only ~topk*128/num_experts rows to each expert, it made
+        # every expert tile a nearly empty M32 tile that still paid the full
+        # trellis decode. Planning the token batch at the scheduler capacity and
+        # keeping the route block at its previous value restores one entry per
+        # layer without changing the per-expert GEMM geometry.
+        max_batched_tokens = int(layer.exl3_r7_max_num_batched_tokens)
+        capacity = _resolve_prefill_capacity(max_batched_tokens)
+        # Same role as VLLM_EXL3_PREFILL_BLOCK_M on the rank-sliced plan. The
+        # default reproduces the previously measured per-expert tiling exactly.
+        route_block = _positive_env_int("VLLM_EXL3_R7_ROUTE_BLOCK", 128)
+        topk = int(topk_ids.shape[1])
+        device_index = x.device.index
+        key = (
+            _runtime_owner_token(self.quant_config, layer),
+            device_index,
+            int(layer.exl3_hidden_size),
+            int(layer.exl3_intermediate_size_per_partition),
+            int(layer.local_num_experts),
+            topk,
+            capacity,
+            route_block,
+        )
+        runtime = _R7_GRAPH_RUNTIMES.get(key)
+        if runtime is not None:
+            return runtime
+        if torch.cuda.is_current_stream_capturing():
+            raise RuntimeError(
+                "R7 EXL3 runtime was not planned during the eager profile pass"
+            )
+        ext = _load_exl3_ext()
+        concurrency = int(ext.exl3_moe_max_concurrency(torch.cuda.current_device()))
+        hidden_size = int(layer.exl3_hidden_size)
+        intermediate_size = int(layer.exl3_intermediate_size_per_partition)
+        num_experts = int(layer.local_num_experts)
+        route_capacity = capacity * topk
+        runtime = {
+            "ext": ext,
+            # glm52-r7-a1-mixed: resolved during the eager profile pass, never
+            # under capture, so the env read cannot vary between replays.
+            "a1_min_rows": _resolve_r7_a1_min_rows(ext),
+            "capacity": capacity,
+            "route_block": route_block,
+            # Staging sized by the token batch.
+            "xh": torch.empty(
+                (capacity, hidden_size), dtype=torch.float16, device=x.device
+            ),
+            "out32": torch.empty(
+                (capacity, hidden_size), dtype=torch.float32, device=x.device
+            ),
+            # Per-group scratch sized by the route block, unchanged.
+            "tg": torch.empty(
+                (concurrency, route_block, hidden_size),
+                dtype=torch.float16,
+                device=x.device,
+            ),
+            "tu": torch.empty(
+                (concurrency, route_block, hidden_size),
+                dtype=torch.float16,
+                device=x.device,
+            ),
+            "ig": torch.empty(
+                (concurrency, route_block, intermediate_size),
+                dtype=torch.float16,
+                device=x.device,
+            ),
+            "iu": torch.empty(
+                (concurrency, route_block, intermediate_size),
+                dtype=torch.float16,
+                device=x.device,
+            ),
+            # Bucket tables are indexed by expert, not by token.
+            "expert_count": torch.empty(
+                num_experts + 1, dtype=torch.int64, device=x.device
+            ),
+            "expert_offsets": torch.empty(
+                num_experts + 1, dtype=torch.int64, device=x.device
+            ),
+            # exl3_moe_fused requires token_sorted.numel() >= topk_ids.numel(),
+            # so these follow the token batch.
+            "token_sorted": torch.empty(
+                route_capacity, dtype=torch.int64, device=x.device
+            ),
+            "weight_sorted": torch.empty(
+                route_capacity, dtype=torch.float16, device=x.device
+            ),
+        }
+        _R7_GRAPH_RUNTIMES[key] = runtime
+        arena_mib = (
+            sum(
+                value.numel() * value.element_size()
+                for value in runtime.values()
+                if isinstance(value, torch.Tensor)
+            )
+            / (1 << 20)
+        )
+        logger.info_once(
+            "R7 EXL3 CUDA-graph runtime planned: capacity=%d route_block=%d "
+            "concurrency=%d topk=%d experts=%d arena=%.1fMiB a1_min_rows=%d",
+            capacity,
+            route_block,
+            concurrency,
+            topk,
+            num_experts,
+            arena_mib,
+            runtime["a1_min_rows"],
+        )
+        return runtime
+
+    def _apply_r7_graph(
+        self,
+        layer: RoutedExperts,
+        x: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+    ) -> torch.Tensor:
+        runtime = self._r7_graph_runtime(layer, x, topk_ids)
+        m = int(x.shape[0])
+        capacity = int(runtime["capacity"])
+        # glm52-r7-prefill: fail closed rather than silently re-chunking a batch
+        # the scheduler promised would not occur.
+        if m > int(layer.exl3_r7_max_num_batched_tokens):
+            raise ValueError(
+                "R7 EXL3 batch exceeds its planned capacity: "
+                f"m={m}, capacity={layer.exl3_r7_max_num_batched_tokens}"
+            )
+        output = torch.empty(
+            (m, int(layer.exl3_hidden_size)), dtype=x.dtype, device=x.device
+        )
+        gate_bits, up_bits, down_bits = layer.exl3_r7_bitrates
+        pointer_args = layer.exl3_r7_pointer_tables
+        ext = runtime["ext"]
+        # glm52-r7-a1-mixed: a pure function of the captured static shape.
+        a1_min_rows = int(runtime["a1_min_rows"])
+        expert_map = layer.exl3_r7_expert_map
+        # One entry per scheduler batch. The trip count is a pure function of
+        # the captured static shape, and is 1 for every CUDA-graph capture size
+        # and for every batch the scheduler can emit unless
+        # VLLM_EXL3_PREFILL_CAPACITY narrows the arena below the scheduler
+        # bound.
+        for start in range(0, m, capacity):
+            stop = min(start + capacity, m)
+            rows = stop - start
+            out32 = runtime["out32"][:rows]
+            if x.dtype == torch.float16:
+                # exl3_moe requires kHalf activations; x is already contiguous
+                # and read-only to the kernel, so the staging copy is dead work.
+                # Inert for BF16 activations, which take the branch below.
+                xh = x[start:stop]
+            else:
+                xh = runtime["xh"][:rows]
+                xh.copy_(x[start:stop])
+            out32.zero_()
+            launch = (
+                ext.exl3_moe_r7_fused_retile
+                if a1_min_rows and rows >= a1_min_rows
+                else ext.exl3_moe_r7_fused
+            )
+            launch(
+                xh,
+                out32,
+                topk_ids[start:stop],
+                topk_weights[start:stop],
+                expert_map,
+                runtime["expert_count"],
+                runtime["expert_offsets"],
+                runtime["token_sorted"],
+                runtime["weight_sorted"],
+                runtime["tg"],
+                runtime["tu"],
+                runtime["ig"],
+                runtime["iu"],
+                0,
+                gate_bits,
+                up_bits,
+                down_bits,
+                *pointer_args,
+                True,
+                False,
+                True,
+                False,
+                True,
+                False,
+                0.0,
+                0,
+            )
+            # Convert straight into the destination. `out32.to(x.dtype)`
+            # allocated a full (rows, hidden) FP32->BF16 temporary per entry and
+            # then copied it again; copy_ applies the identical rounding in one
+            # pass.
+            output[start:stop].copy_(out32)
         return output
 
     def _rank_sliced_runtime(
@@ -3399,6 +4528,14 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 True,
                 False,
                 0.0,
+                # --- glm52: exl3_moe num_active ---
+                # num_active: experts with 0 < token count <= max_tokens_per_expert.
+                # Sizes the launch only; the in-kernel ticket scheduler is
+                # work-conserving so any non-zero value gives the same result.
+                # 0 would make exl3_moe return immediately and leave the MoE
+                # output ALL ZERO. -1 is the documented "unknown" value and is
+                # what exl3_moe_fused itself passes through.
+                -1,
             )
         return out32.to(x.dtype)
 
@@ -3428,8 +4565,22 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         x_2d = x.reshape(-1, x.shape[-1]).contiguous()
         ids = topk_ids.reshape(x_2d.shape[0], -1).contiguous()
         weights = topk_weights.reshape_as(ids).to(torch.float32).contiguous()
-        if self.quant_config.rank_sliced_metadata is not None:
+        # glm52-mdispatch: per-layer routing (see create_weights)
+        if getattr(
+            layer,
+            "exl3_rank_sliced",
+            self.quant_config.rank_sliced_metadata is not None,
+        ):
             output = self._apply_rank_sliced(layer, x_2d, weights, ids)
+            return output.reshape(*original_shape, output.shape[-1])
+        if getattr(layer, "exl3_r7_fused", False):
+            # glm52-r7-sparkinfer: the prepared dict uses the mixed-Trellis
+            # contract exactly, so the existing launch, runtime planning and
+            # prefill chunking are reused unchanged.
+            output = self._apply_mixed_rank_sliced(layer, x_2d, weights, ids)
+            return output.reshape(*original_shape, output.shape[-1])
+        if getattr(layer, "exl3_r7_graph", False):
+            output = self._apply_r7_graph(layer, x_2d, weights, ids)
             return output.reshape(*original_shape, output.shape[-1])
 
         x_2d = x_2d.to(torch.float16)

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -744,6 +744,91 @@ def _resolve_prefill_capacity(max_batched_tokens: int) -> int:
     return prefill_capacity
 
 
+# ---------------------------------------------------------------------------
+# Prefill dispatch: reconstruct + hgemm above a row threshold.
+#
+# `exl3_gemm` is decode-shaped: it decodes the trellis once per output tile, so its
+# cost grows with M, while a dense GEMM against a materialised weight does not.
+# exllamav3's own `LinearEXL3.reconstruct_hgemm` switches path above 1024 rows for
+# exactly this reason. Measured with the extension `VLLM_EXL3_EXT_PATH` loads, on a
+# real Qwen3.8-27B EXL3 checkpoint (unfused sequence, reconstruct cost included):
+#
+#   geometry                 m=32   m=128   m=512   m=2048
+#   5120x17408   K5          0.30x   1.06x   2.61x   4.10x
+#   17408x5120   K6          0.35x   1.28x   3.10x   4.35x
+#   5120x248320  K6 (head)   0.32x   1.19x   3.23x   5.21x
+#
+# The threshold decision MUST be opaque to Dynamo. A Python-level `rows >= N` branch
+# around the two calls is resolved once at trace time - with vLLM's single compiled
+# range the profile run bakes in the prefill branch, the decode CUDA graphs then
+# capture reconstruct+hgemm, and decode throughput collapses (measured: 56.5 -> 22.6
+# tok/s at C1). Keeping both paths inside one custom op moves the choice to runtime.
+_EXL3_RECONSTRUCT_SLICE_N = 32768
+_EXL3_RECONSTRUCT_SCRATCH: dict[tuple[int, int, int], torch.Tensor] = {}
+
+
+def _prefill_reconstruct_rows() -> int:
+    """Row count at or above which reconstruct+hgemm replaces exl3_gemm (0 = off)."""
+    raw = os.environ.get("VLLM_EXL3_PREFILL_RECONSTRUCT_M")
+    if raw is None:
+        return 128
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise ValueError(
+            "VLLM_EXL3_PREFILL_RECONSTRUCT_M must be an integer row count "
+            f"(0 disables the reconstruct path), got {raw!r}"
+        ) from exc
+    return max(0, value)
+
+
+def _reconstruct_scratch(device: torch.device, k: int, n: int) -> torch.Tensor:
+    index = device.index if device.index is not None else torch.cuda.current_device()
+    key = (index, k, n)
+    buf = _EXL3_RECONSTRUCT_SCRATCH.get(key)
+    if buf is None:
+        # One buffer per (device, K, N-chunk), reused by every layer of the same
+        # geometry, so peak scratch is bounded by the largest chunk rather than by
+        # the number of layers: 336 MB for a 5120x32768 chunk in fp16.
+        buf = torch.empty((k, n), dtype=torch.float16, device=device)
+        _EXL3_RECONSTRUCT_SCRATCH[key] = buf
+    return buf
+
+
+def _reconstruct_hgemm_into(
+    output: torch.Tensor,
+    x: torch.Tensor,
+    trellis: torch.Tensor,
+    suh: torch.Tensor,
+    svh: torch.Tensor,
+    mcg: bool,
+    mul1: bool,
+) -> None:
+    """Materialise the weight and use a dense GEMM.
+
+    Same trellis, codebook and scales as `exl3_gemm`; only the summation order
+    differs, so outputs agree to ~3e-3 of output magnitude in fp16. Release receipts
+    check end-to-end distribution parity rather than relying on that bound.
+    """
+    ext = _load_exl3_ext()
+    bits = trellis.shape[2] // 16
+    k = trellis.shape[0] * 16
+    n = trellis.shape[1] * 16
+    x_had = torch.empty_like(x)
+    ext.had_r_128(x, x_had, suh, None, 1.0)
+    chunk = min(n, _EXL3_RECONSTRUCT_SLICE_N)
+    weight = _reconstruct_scratch(x.device, k, chunk)
+    for start in range(0, n, chunk):
+        end = min(start + chunk, n)
+        view = weight[:, : end - start]
+        if n <= chunk:
+            ext.reconstruct(view, trellis, bits, mcg, mul1)
+        else:
+            ext.reconstruct_slice(view, trellis, bits, mcg, mul1, start)
+        ext.hgemm(x_had, view, output[:, start:end])
+    ext.had_r_128(output, output, None, svh, 1.0)
+
+
 @torch.library.custom_op(
     "vllm::exl3_gemm",
     mutates_args=(),
@@ -765,6 +850,12 @@ def _exl3_gemm(
         dtype=torch.float16,
         device=x.device,
     )
+    # Runtime dispatch, inside the opaque op: the trellis kernel wins at decode row
+    # counts and loses by 4-5x at prefill row counts. See the table above.
+    threshold = _prefill_reconstruct_rows()
+    if threshold and x.shape[0] >= threshold:
+        _reconstruct_hgemm_into(output, x, trellis, suh, svh, mcg, mul1)
+        return output
     x_had = torch.empty_like(x)
     ext.exl3_gemm(
         x,

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -79,7 +79,7 @@ from vllm.model_executor.layers.quantization.utils.mxfp8_utils import (
 )
 from vllm.model_executor.layers.quantization.utils.quant_utils import kMxfp8Dynamic
 from vllm.model_executor.parameter import BasevLLMParameter
-from vllm.model_executor.utils import replace_parameter
+from vllm.model_executor.utils import replace_parameter, set_weight_attrs
 from vllm.transformers_utils.repo_utils import get_hf_file_to_dict
 
 if TYPE_CHECKING:
@@ -795,6 +795,137 @@ def _reconstruct_scratch(device: torch.device, k: int, n: int) -> torch.Tensor:
     return buf
 
 
+_EXL3_FP8_SCRATCH: dict[tuple[int, int, int], torch.Tensor] = {}
+_EXL3_FP8_WEIGHT_SCALE: dict[tuple[int, int], torch.Tensor] = {}
+_E4M3_MAX = 448.0
+
+
+def _prefill_fp8_enabled() -> bool:
+    """Whether the prefill GEMM may run in FP8 (off by default).
+
+    An FP8 matmul is 1.5-1.8x faster than fp16 on these shapes (SM120, measured), and
+    the reconstruct kernel can emit the column-major FP8 operand directly, so the win
+    is not eaten by a conversion pass. It costs numerics: both operands are narrowed to
+    E4M3, on the prefill path only - decode keeps the exact trellis kernel.
+    """
+    return os.environ.get("VLLM_EXL3_PREFILL_FP8", "0") == "1"
+
+
+def _fp8_scratch(device: torch.device, n: int, k: int) -> torch.Tensor:
+    index = device.index if device.index is not None else torch.cuda.current_device()
+    key = (index, n, k)
+    buf = _EXL3_FP8_SCRATCH.get(key)
+    if buf is None:
+        buf = torch.empty((n, k), dtype=torch.float8_e4m3fn, device=device)
+        _EXL3_FP8_SCRATCH[key] = buf
+    return buf
+
+
+def _fp8_weight_scale(
+    trellis: torch.Tensor, bits: int, mcg: bool, mul1: bool
+) -> torch.Tensor:
+    """Per-output-channel E4M3 scales for a trellis, measured once and cached.
+
+    Per-tensor scaling was measured and rejected: on this 27B model it cost +0.0139 mean
+    KLD against the fp16 prefill path, which is worse than official FP8. E4M3 carries three
+    mantissa bits, so one scale for a whole matrix spends most of them representing the
+    dynamic range of the loudest channel. One scale per column restores the ordinary
+    row-wise FP8 contract and costs a single float load per output row in the kernel.
+
+    The reconstructed matrix is the raw decoded weight - suh and svh act on the activation
+    and the output - so these scales are a property of the tensor and are computed once at
+    first prefill use.
+    """
+    key = (trellis.data_ptr(), bits)
+    scale = _EXL3_FP8_WEIGHT_SCALE.get(key)
+    if scale is None:
+        ext = _load_exl3_ext()
+        k = trellis.shape[0] * 16
+        n = trellis.shape[1] * 16
+        probe = _reconstruct_scratch(trellis.device, k, min(n, _EXL3_RECONSTRUCT_SLICE_N))
+        chunk = probe.shape[1]
+        scale = torch.empty((n,), dtype=torch.float32, device=trellis.device)
+        for start in range(0, n, chunk):
+            width = min(chunk, n - start)
+            view = probe[:, :width]
+            if n <= chunk:
+                ext.reconstruct(view, trellis, bits, mcg, mul1)
+            else:
+                ext.reconstruct_slice(view, trellis, bits, mcg, mul1, start)
+            amax = view.abs().amax(dim=0).float().clamp_(min=1e-6)
+            scale[start:start + width] = amax / _E4M3_MAX
+        _EXL3_FP8_WEIGHT_SCALE[key] = scale
+    return scale
+
+
+def _reconstruct_fp8_mm_into(
+    output: torch.Tensor,
+    x: torch.Tensor,
+    trellis: torch.Tensor,
+    suh: torch.Tensor,
+    svh: torch.Tensor,
+    mcg: bool,
+    mul1: bool,
+) -> bool:
+    """FP8 variant of the prefill path. Returns False if this shape cannot use it.
+
+    Row-wise scaling on both operands: one scale per token on the activation and one per
+    output channel on the weight. Per-tensor scaling was measured first and is not viable -
+    it cost +0.0139 mean KLD, more than the whole quantization budget of this checkpoint.
+    """
+    ext = _load_exl3_ext()
+    if not hasattr(ext, "reconstruct_fp8_slice"):
+        return False
+    bits = trellis.shape[2] // 16
+    k = trellis.shape[0] * 16
+    n = trellis.shape[1] * 16
+    chunk = min(n, _EXL3_RECONSTRUCT_SLICE_N)
+    if chunk % 128 or k % 16:
+        return False
+
+    scale_b_all = _fp8_weight_scale(trellis, bits, mcg, mul1)
+    if scale_b_all.numel() != n:
+        return False
+
+    x_had = torch.empty_like(x)
+    ext.had_r_128(x, x_had, suh, None, 1.0)
+    rows = x_had.shape[0]
+    row_amax = x_had.abs().amax(dim=1, keepdim=True).float().clamp_(min=1e-6)
+    scale_a_rows = row_amax / _E4M3_MAX
+    # _scaled_mm needs both extents padded to a multiple of 16; prefill chunks usually are,
+    # a prompt remainder is not, so pad rather than fall back to the slower path.
+    padded = (rows + 15) // 16 * 16
+    x8 = torch.empty((padded, k), dtype=torch.float8_e4m3fn, device=x.device)
+    x8[:rows].copy_(x_had / scale_a_rows)
+    scale_a = torch.ones((padded, 1), dtype=torch.float32, device=x.device)
+    scale_a[:rows].copy_(scale_a_rows)
+    if padded != rows:
+        x8[rows:].zero_()
+
+    for start in range(0, n, chunk):
+        end = min(start + chunk, n)
+        w8 = _fp8_scratch(x.device, end - start, k)
+        scale_b = scale_b_all[start:end].contiguous()
+        ext.reconstruct_fp8_slice(
+            w8, trellis, bits, mcg, mul1, start, 1.0, scale_b.reciprocal()
+        )
+        # out_dtype MUST be bfloat16 here. With row-wise scales and out_dtype=float16 this
+        # torch build returns silently wrong results - no error, ~6x relative error, and in
+        # serving it produced KLD 10.8 with 0.1 % top-1. bfloat16 output matches an fp32
+        # reference to 0.040 relative, the same as per-tensor scaling. The copy back into the
+        # fp16 output buffer converts.
+        part = torch._scaled_mm(
+            x8,
+            w8.t(),
+            scale_a=scale_a,
+            scale_b=scale_b.view(1, -1),
+            out_dtype=torch.bfloat16,
+        )
+        output[:, start:end].copy_(part[:rows])
+    ext.had_r_128(output, output, None, svh, 1.0)
+    return True
+
+
 def _reconstruct_hgemm_into(
     output: torch.Tensor,
     x: torch.Tensor,
@@ -854,6 +985,10 @@ def _exl3_gemm(
     # counts and loses by 4-5x at prefill row counts. See the table above.
     threshold = _prefill_reconstruct_rows()
     if threshold and x.shape[0] >= threshold:
+        if _prefill_fp8_enabled() and _reconstruct_fp8_mm_into(
+            output, x, trellis, suh, svh, mcg, mul1
+        ):
+            return output
         _reconstruct_hgemm_into(output, x, trellis, suh, svh, mcg, mul1)
         return output
     x_had = torch.empty_like(x)
@@ -1135,7 +1270,28 @@ def _b12x_trellis_linear_out(
     c_tmp: torch.Tensor,
     rotated_f16: torch.Tensor,
 ) -> None:
-    """Execute dense Trellis into graph-owned output and scratch tensors."""
+    """Execute dense Trellis into graph-owned output and scratch tensors.
+
+    B12X's native K6 kernel is a *decode* kernel and it is excellent at that: measured on
+    SM120 it beats reconstruct+GEMM by ~5x at m=1-8. At prefill row counts the ordering
+    reverses, because the trellis is streamed per output tile instead of materialised once:
+    at m=2048 reconstruct+FP8 is 2.07x faster on down_proj, 1.91x on attention in_proj and
+    1.76x on the head.
+
+    The K6/MCG shards therefore need the same runtime dispatch that PR #316 gave the generic
+    `exl3_gemm` path - and it has to live inside this opaque op, because a Python-level row
+    test around the two calls is resolved once at trace time and would bake the prefill
+    branch into the decode graphs.
+    """
+
+    threshold = _prefill_reconstruct_rows()
+    if threshold and x.shape[0] >= threshold:
+        if _prefill_fp8_enabled() and _reconstruct_fp8_mm_into(
+            output, x, trellis, suh, svh, True, False
+        ):
+            return
+        _reconstruct_hgemm_into(output, x, trellis, suh, svh, True, False)
+        return
 
     api = _load_b12x_trellis_linear()
     weight = _b12x_trellis_weight(trellis, suh, svh, x.dtype)
@@ -1719,7 +1875,12 @@ class Exl3Config(QuantizationConfig):
                 return None
             self._require_eager_moe_experts(prefix)
             return Exl3MoEMethod(self, layer.moe_config)
+        if layer.__class__.__name__ == "VocabParallelEmbedding":
+            if method := _get_embedding_overlay_method():
+                return method
+            return None
         return None
+
 
     def _get_bf16_online_linear_method(
         self, layer: torch.nn.Module, prefix: str
@@ -1996,6 +2157,107 @@ class Exl3Config(QuantizationConfig):
         if int(match.group("rank")) != get_tensor_model_parallel_rank():
             return None
         return f"{match.group('prefix')}.{match.group('field')}"
+
+
+
+_EMBED_OVERLAY_BITS_ENV = "VLLM_EXL3_EMBED_BITS"
+
+
+def _get_embedding_overlay_method() -> QuantizeMethodBase | None:
+    """Quantize the input embedding table, off by default.
+
+    On Qwen3.8-27B the table is 248,320 x 5,120 in BF16 = 2.543 GB resident, second only to
+    the MLP stack, and it is pure lookup: no matmul, no accumulation, one row per token. That
+    makes it the cheapest large saving available, and on a 32 GB card it is the difference
+    between 196,608 and native 262,144 context - the measured KV shortfall there is 0.63 GiB
+    and int8 frees 1.18 GiB.
+
+    int8 rather than FP8: both halve the table, but E4M3 carries three mantissa bits against
+    int8's seven, so per-row symmetric int8 is roughly an order of magnitude more accurate for
+    the same bytes. There is no tensor-core path to exploit here - the operation is a gather -
+    so FP8's throughput advantage does not apply.
+
+    ``VLLM_EXL3_EMBED_BITS=8`` enables it. The head is untied on this architecture, so this
+    touches inputs only.
+    """
+    raw = os.environ.get(_EMBED_OVERLAY_BITS_ENV)
+    if raw is None or not raw.strip():
+        return None
+    try:
+        bits = int(raw)
+    except ValueError:
+        raise ValueError(f"{_EMBED_OVERLAY_BITS_ENV} must be 8 or 16, got {raw!r}") from None
+    if bits == 16:
+        return None
+    if bits != 8:
+        raise ValueError(f"{_EMBED_OVERLAY_BITS_ENV} supports 8 (int8) or 16 (off), got {bits}")
+    return Exl3Int8EmbeddingMethod()
+
+
+class Exl3Int8EmbeddingMethod(QuantizeMethodBase):
+    """Per-row symmetric int8 storage for the input embedding table.
+
+    The checkpoint keeps BF16, so nothing about the artifact changes; the table is narrowed
+    once after loading and the BF16 copy is released. Each row carries its own scale, which is
+    what keeps the error small: a row is one token's vector, and rows differ in magnitude far
+    more than elements within a row do.
+    """
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: list[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ) -> None:
+        weight = torch.nn.Parameter(
+            torch.empty(
+                sum(output_partition_sizes),
+                input_size_per_partition,
+                dtype=params_dtype,
+            ),
+            requires_grad=False,
+        )
+        set_weight_attrs(weight, {"input_dim": 1, "output_dim": 0})
+        layer.register_parameter("weight", weight)
+        set_weight_attrs(weight, extra_weight_attrs)
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        weight = layer.weight.data
+        if weight.dtype == torch.int8:
+            return
+        out_dtype = weight.dtype
+        amax = weight.abs().amax(dim=1, keepdim=True).float().clamp_(min=1e-8)
+        scale = (amax / 127.0).to(torch.float32)
+        packed = torch.round(weight.float() / scale).clamp_(-127, 127).to(torch.int8)
+        layer.register_buffer("weight_int8", packed)
+        layer.register_buffer("weight_scale", scale.squeeze(1).to(out_dtype))
+        layer.exl3_embed_out_dtype = out_dtype
+        # Release the BF16 table: it is 2.543 GB on this model and nothing reads it again.
+        layer.weight = torch.nn.Parameter(
+            torch.empty(0, dtype=out_dtype, device=weight.device), requires_grad=False
+        )
+        del weight
+        torch.cuda.empty_cache()
+        logger.info(
+            "EXL3 int8 embedding overlay: %d x %d rows narrowed, %.3f GB -> %.3f GB",
+            packed.shape[0],
+            packed.shape[1],
+            packed.numel() * 2 / 1e9,
+            (packed.numel() + packed.shape[0] * 2) / 1e9,
+        )
+
+    def apply(self, layer: torch.nn.Module, *args, **kwargs) -> torch.Tensor:
+        raise NotImplementedError("the embedding overlay implements embedding(), not apply()")
+
+    def embedding(self, layer: torch.nn.Module, input_: torch.Tensor) -> torch.Tensor:
+        rows = layer.weight_int8.index_select(0, input_.flatten())
+        scales = layer.weight_scale.index_select(0, input_.flatten()).unsqueeze(-1)
+        out = rows.to(layer.exl3_embed_out_dtype) * scales
+        return out.view(*input_.shape, layer.weight_int8.shape[1])
 
 
 class Exl3Parameter(BasevLLMParameter):

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -992,7 +992,15 @@ def _prime_exl3_gemm_rows(
     # One arena for the whole shape: a leading-row view of a contiguous buffer
     # is itself contiguous, so the kernel contract holds without reallocating
     # per row count.
-    source = torch.zeros((max(pending), k), dtype=torch.float16, device=device)
+    #
+    # The probe data is randomised, not zeroed: exl3_gemm's autotuner selects a
+    # kernel configuration by *measured time*, and an all-zero activation can
+    # time differently from a real one, so a zero-primed graph run could select
+    # a different configuration than an eager run and then disagree with it on
+    # tied decode decisions. Magnitude 0.05 matches post-RMSNorm activations.
+    source = torch.randn(
+        (max(pending), k), dtype=torch.float16, device=device
+    ).mul_(0.05)
     for m in pending:
         try:
             _exl3_gemm(

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -61,6 +61,7 @@ from vllm.model_executor.layers.quantization.compressed_tensors.utils import (
 )
 from vllm.model_executor.layers.quantization.exl3_online_cache import (
     Exl3OnlineCacheKey,
+    cache_mode,
     load_or_quantize,
     resolve_encoder_identity,
     resolve_model_identity,
@@ -94,7 +95,6 @@ _SPARKINFER_MIXED_TRELLIS_API: Any | None = None
 _SPARKINFER_TRELLIS_LINEAR_API: Any | None = None
 _EXL3_ONLINE_QUANTIZER: Any | None = None
 _EXL3_ONLINE_WARMED_SIGNATURES: set[tuple[int, int, int, int]] = set()
-_SPARKINFER_TRELLIS_LINEAR_WEIGHTS: dict[tuple[Any, ...], Any] = {}
 _SPARKINFER_TRELLIS_WARMED_DEVICES: set[int] = set()
 # The dense W4A16 kernel caps its temporary accumulation arena at
 # SMs * 4 * block_m * 256 fp32 elements.  SM120/SM121 devices supported by
@@ -135,8 +135,7 @@ def _resolve_mixed_trellis_prefill_block_m(
         and int(intermediate_size) == 512
         and tier_signature == ((3, 192), (4, 64))
         and int(topk) == 8
-        and tuple(int(value) for value in prefill_tile_config)
-        == (128, 128, 32, 512)
+        and tuple(int(value) for value in prefill_tile_config) == (128, 128, 32, 512)
     )
     if qualified:
         return _GLM52_MIXED_TRELLIS_PREFILL_BLOCK_SIZE
@@ -215,6 +214,11 @@ def _load_exl3_online_quantizer() -> Any:
     quantize = importlib.import_module(
         f"{package_name}.modules.quant.exl3_lib.quantize"
     )
+    if not hasattr(quantize, "quantize_exl3"):
+        raise RuntimeError(
+            "VLLM_EXL3_ENCODER_SOURCE points to an incompatible ExLlamaV3 "
+            "encoder: modules.quant.exl3_lib.quantize has no quantize_exl3"
+        )
     _EXL3_ONLINE_QUANTIZER = quantize.quantize_exl3
     return _EXL3_ONLINE_QUANTIZER
 
@@ -532,15 +536,15 @@ def _sparkinfer_trellis_weight(
     """Prepare each online weight before capture and retain its native views."""
 
     api = _load_sparkinfer_trellis_linear()
-    key = (
-        trellis.device.index,
-        trellis.data_ptr(),
-        suh.data_ptr(),
-        svh.data_ptr(),
-        tuple(trellis.shape),
-        dtype,
-    )
-    weight = _SPARKINFER_TRELLIS_LINEAR_WEIGHTS.get(key)
+    # Keep prepared views on the owning tensor. A process-global pointer-keyed
+    # cache can alias after allocator address reuse and retains released models
+    # forever. This small reference cycle is collected with the tensor.
+    cache = getattr(trellis, "_vllm_sparkinfer_prepared_weights", None)
+    if cache is None:
+        cache = {}
+        trellis._vllm_sparkinfer_prepared_weights = cache
+    key = (id(suh), id(svh), dtype)
+    weight = cache.get(key)
     if weight is None:
         weight = api.prepare_weight(
             trellis,
@@ -549,7 +553,7 @@ def _sparkinfer_trellis_weight(
             codebook="mcg",
             params_dtype=dtype,
         )
-        _SPARKINFER_TRELLIS_LINEAR_WEIGHTS[key] = weight
+        cache[key] = weight
     return weight
 
 
@@ -818,6 +822,10 @@ class Exl3Config(QuantizationConfig):
                 "VLLM_EXL3_ENCODER_SOURCE is required when "
                 "VLLM_EXL3_ONLINE_TRELLIS_BITS is enabled"
             )
+        if cache_mode() == "off":
+            self._online_model_identity = "cache-disabled"
+            self._online_encoder_identity = "cache-disabled"
+            return
         resolved_revision = revision or getattr(hf_config, "_commit_hash", None)
         self._online_model_identity = resolve_model_identity(
             model_name,
@@ -1077,19 +1085,21 @@ class Exl3Config(QuantizationConfig):
     def _get_bf16_online_linear_method(
         self, layer: torch.nn.Module, prefix: str
     ) -> QuantizeMethodBase | None:
-        """Overlay MXFP8 only on linears absent from EXL3 tensor storage.
+        """Overlay online quantization on linears absent from EXL3 storage.
 
         EXL3-owned dense matrices are selected before this method and routed
         experts never enter it. Shared-expert projections have an independent
         spec so a broad ``linear`` overlay cannot quantize them accidentally.
+        When ``VLLM_EXL3_ONLINE_TRELLIS_BITS`` is set, eligible projections use
+        online EXL3 Trellis encoding instead of MXFP8.
 
         Args:
             layer: Candidate module for the online overlay.
             prefix: Fully qualified checkpoint module name.
 
         Returns:
-            An MXFP8 method for an eligible BF16 projection, otherwise
-            ``None``.
+            An online Trellis or MXFP8 method for an eligible BF16 projection,
+            otherwise ``None``.
 
         Raises:
             ValueError: If the EXL3 overlay requests an unsupported weight or
@@ -2397,16 +2407,12 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         return (128, 128, 128, 128)
 
     @staticmethod
-    def _mixed_trellis_prefill_tile_config(
-        hidden_size: int, intermediate_size: int
-    ):
+    def _mixed_trellis_prefill_tile_config(hidden_size: int, intermediate_size: int):
         # Route packing stays block-64, while SparkInfer's mixed-kernel ABI v2
         # executes FC2 as arithmetic-equivalent 8-row subtiles.  Reuse the
         # checkpoint's original one-grid tile geometry so prefill has the same
         # reduction order as the stock-r16 quality reference.
-        return Exl3MoEMethod._mixed_trellis_tile_config(
-            hidden_size, intermediate_size
-        )
+        return Exl3MoEMethod._mixed_trellis_tile_config(hidden_size, intermediate_size)
 
     def _prepare_mixed_rank_sliced_weights(self, layer: RoutedExperts) -> None:
         mixed_api = _load_b12x_mixed_trellis()
@@ -2730,45 +2736,71 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         topk_ids: torch.Tensor,
     ) -> dict[str, Any]:
         mixed = layer.exl3_mixed_trellis
-        max_decode_m = _positive_env_int("VLLM_EXL3_TRELLIS_MAX_M", 32)
-        max_batched_tokens = int(layer.exl3_max_num_batched_tokens)
-        prefill_capacity = _resolve_prefill_capacity(max_batched_tokens)
-        prefill_block_raw = os.environ.get("VLLM_EXL3_PREFILL_BLOCK_M")
-        prefill_block_m = _positive_env_int("VLLM_EXL3_PREFILL_BLOCK_M", 64)
-        if max_decode_m > max_batched_tokens:
-            max_decode_m = max_batched_tokens
         topk = int(topk_ids.shape[1])
-        tier_signature = tuple(
-            (int(bits), len(ids))
-            for bits, ids in zip(mixed["tier_bits"], mixed["tier_ids"], strict=True)
-        )
-        props = torch.cuda.get_device_properties(x.device)
-        prefill_block_m = _resolve_mixed_trellis_prefill_block_m(
-            configured_block_m=prefill_block_m,
-            explicit_override=bool(
+        policy = mixed.get("runtime_policy")
+        if policy is None:
+            max_decode_m = _positive_env_int("VLLM_EXL3_TRELLIS_MAX_M", 32)
+            max_batched_tokens = int(layer.exl3_max_num_batched_tokens)
+            prefill_capacity = _resolve_prefill_capacity(max_batched_tokens)
+            prefill_block_raw = os.environ.get("VLLM_EXL3_PREFILL_BLOCK_M")
+            configured_block_m = _positive_env_int("VLLM_EXL3_PREFILL_BLOCK_M", 64)
+            max_decode_m = min(max_decode_m, max_batched_tokens)
+            tier_signature = tuple(
+                (int(bits), len(ids))
+                for bits, ids in zip(mixed["tier_bits"], mixed["tier_ids"], strict=True)
+            )
+            props = torch.cuda.get_device_properties(x.device)
+            explicit_block_m = bool(
                 prefill_block_raw is not None and prefill_block_raw.strip()
-            ),
-            hidden_size=int(layer.exl3_hidden_size),
-            intermediate_size=int(layer.exl3_intermediate_size_per_partition),
-            tier_signature=tier_signature,
-            topk=topk,
-            device_major=int(getattr(props, "major", 0)),
-            prefill_tile_config=mixed["prefill_tile_config"],
-        )
-        logger.info_once(
-            "EXL3 mixed Trellis prefill block policy: selected=%d "
-            "configured=%d explicit=%s shape=%dx%d tiers=%s topk=%d "
-            "sm=%d tile=%s",
-            prefill_block_m,
-            _positive_env_int("VLLM_EXL3_PREFILL_BLOCK_M", 64),
-            bool(prefill_block_raw is not None and prefill_block_raw.strip()),
-            int(layer.exl3_hidden_size),
-            int(layer.exl3_intermediate_size_per_partition),
-            tier_signature,
-            topk,
-            int(getattr(props, "major", 0)),
-            mixed["prefill_tile_config"],
-        )
+            )
+            prefill_block_m = _resolve_mixed_trellis_prefill_block_m(
+                configured_block_m=configured_block_m,
+                explicit_override=explicit_block_m,
+                hidden_size=int(layer.exl3_hidden_size),
+                intermediate_size=int(layer.exl3_intermediate_size_per_partition),
+                tier_signature=tier_signature,
+                topk=topk,
+                device_major=int(getattr(props, "major", 0)),
+                prefill_tile_config=mixed["prefill_tile_config"],
+            )
+            policy = {
+                "device_index": x.device.index,
+                "topk": topk,
+                "max_decode_m": max_decode_m,
+                "max_batched_tokens": max_batched_tokens,
+                "prefill_capacity": prefill_capacity,
+                "prefill_block_m": prefill_block_m,
+                "tier_signature": tier_signature,
+                "sms": int(props.multi_processor_count),
+                "max_shared_mem": int(props.shared_memory_per_block_optin),
+            }
+            mixed["runtime_policy"] = policy
+            logger.info_once(
+                "EXL3 mixed Trellis prefill block policy: selected=%d "
+                "configured=%d explicit=%s shape=%dx%d tiers=%s topk=%d "
+                "sm=%d tile=%s",
+                prefill_block_m,
+                configured_block_m,
+                explicit_block_m,
+                int(layer.exl3_hidden_size),
+                int(layer.exl3_intermediate_size_per_partition),
+                tier_signature,
+                topk,
+                int(getattr(props, "major", 0)),
+                mixed["prefill_tile_config"],
+            )
+        elif policy["device_index"] != x.device.index or policy["topk"] != topk:
+            raise RuntimeError(
+                "mixed-bitrate EXL3 runtime geometry changed after planning: "
+                f"device/topk={x.device.index}/{topk}, expected "
+                f"{policy['device_index']}/{policy['topk']}"
+            )
+
+        max_decode_m = policy["max_decode_m"]
+        max_batched_tokens = policy["max_batched_tokens"]
+        prefill_capacity = policy["prefill_capacity"]
+        prefill_block_m = policy["prefill_block_m"]
+        tier_signature = policy["tier_signature"]
         key = (
             _runtime_owner_token(self.quant_config, layer),
             x.device.index,
@@ -2824,8 +2856,8 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 top_k=topk,
                 max_m_blocks=(route_slots + block_size_m - 1) // block_size_m,
                 moe_block_size=block_size_m,
-                sms=int(props.multi_processor_count),
-                max_shared_mem=int(props.shared_memory_per_block_optin),
+                sms=policy["sms"],
+                max_shared_mem=policy["max_shared_mem"],
                 force_tile_config=tile_config,
                 rotation_input_dtype=("bf16" if x.dtype == torch.bfloat16 else "fp16"),
                 route_ids_dtype=topk_ids.dtype,
@@ -2836,7 +2868,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 "buffers": mixed_api.make_mixed_trellis_buffers(
                     launch,
                     device=device,
-                    sms=int(props.multi_processor_count),
+                    sms=policy["sms"],
                 ),
             }
 
@@ -2865,9 +2897,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         _MIXED_TRELLIS_RUNTIMES[key] = runtime
         decode_bytes = _unique_tensor_storage_bytes(decode["buffers"])
         prefill_bytes = (
-            0
-            if prefill is None
-            else _unique_tensor_storage_bytes(prefill["buffers"])
+            0 if prefill is None else _unique_tensor_storage_bytes(prefill["buffers"])
         )
         logger.info_once(
             "EXL3 mixed Trellis runtime planned: tiers=%s one-grid decode=%d "
@@ -2897,6 +2927,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 f"m={m}, capacity={runtime['max_batched_tokens']}"
             )
         mixed = layer.exl3_mixed_trellis
+
         def run_state(
             slice_x: torch.Tensor,
             slice_weights: torch.Tensor,
@@ -2904,18 +2935,22 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             state: dict[str, Any],
             tiers: tuple[Any, Any],
         ) -> torch.Tensor:
-            return runtime["mixed_api"].run_mixed_trellis(
-                slice_x,
-                tiers[0],
-                tiers[1],
-                slice_weights,
-                slice_ids,
-                mixed["global_to_combined"],
-                mixed["descriptor_map"],
-                mixed["rotations"],
-                state["launch"],
-                state["buffers"],
-            ).to(slice_x.dtype)
+            return (
+                runtime["mixed_api"]
+                .run_mixed_trellis(
+                    slice_x,
+                    tiers[0],
+                    tiers[1],
+                    slice_weights,
+                    slice_ids,
+                    mixed["global_to_combined"],
+                    mixed["descriptor_map"],
+                    mixed["rotations"],
+                    state["launch"],
+                    state["buffers"],
+                )
+                .to(slice_x.dtype)
+            )
 
         if m <= runtime["max_decode_m"]:
             return run_state(

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -2466,6 +2466,12 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         tier_index = torch.tensor(tier_order, dtype=torch.long, device=device)
         combined_gate_suh = self._select_rotation_rows(gate_suh, tier_index)
         combined_up_suh = self._select_rotation_rows(up_suh, tier_index)
+        broadcast_suh = int(combined_gate_suh.shape[0]) == 1
+        if broadcast_suh != (int(combined_up_suh.shape[0]) == 1):
+            raise ValueError(
+                "mixed EXL3 gate/up SUH rotations must both be per-expert "
+                "or both broadcast"
+            )
         combined_intermediate_rotations = torch.cat(
             (
                 gate_svh.index_select(0, tier_index),
@@ -2475,6 +2481,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             dim=1,
         ).contiguous()
         combined_down_svh = self._select_rotation_rows(down_svh, tier_index)
+        broadcast_svh = int(combined_down_svh.shape[0]) == 1
         combined_rotations = SimpleNamespace(
             intermediate=combined_intermediate_rotations,
             gate_suh=combined_gate_suh,
@@ -2590,6 +2597,8 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             "global_to_combined": global_to_combined,
             "descriptor_map": descriptor_map,
             "rotations": combined_rotations,
+            "broadcast_suh": broadcast_suh,
+            "broadcast_svh": broadcast_svh,
             "tile_config": mixed_tile_config,
             "prefill_tile_config": prefill_tile_config,
         }
@@ -2801,6 +2810,8 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         prefill_capacity = policy["prefill_capacity"]
         prefill_block_m = policy["prefill_block_m"]
         tier_signature = policy["tier_signature"]
+        broadcast_suh = bool(mixed["broadcast_suh"])
+        broadcast_svh = bool(mixed["broadcast_svh"])
         key = (
             _runtime_owner_token(self.quant_config, layer),
             x.device.index,
@@ -2816,6 +2827,8 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             mixed["tile_config"],
             mixed["prefill_tile_config"],
             prefill_block_m,
+            broadcast_suh,
+            broadcast_svh,
         )
         runtime = _MIXED_TRELLIS_RUNTIMES.get(key)
         if runtime is not None:
@@ -2861,6 +2874,8 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 force_tile_config=tile_config,
                 rotation_input_dtype=("bf16" if x.dtype == torch.bfloat16 else "fp16"),
                 route_ids_dtype=topk_ids.dtype,
+                broadcast_suh=broadcast_suh,
+                broadcast_svh=broadcast_svh,
             )
             return {
                 "capacity": capacity,

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -292,6 +292,7 @@ def _positive_env_int(name: str, default: int) -> int:
         raise ValueError(f"{name} must be positive, got {value}")
     return value
 
+
 def _resolve_prefill_capacity(max_batched_tokens: int) -> int:
     """Resolve the optional EXL3 arena bound within the scheduler contract."""
 

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -63,6 +63,7 @@ from vllm.model_executor.layers.quantization.compressed_tensors.utils import (
 )
 from vllm.model_executor.layers.quantization.exl3_online_cache import (
     Exl3OnlineCacheKey,
+    Exl3OnlineNonFiniteError,
     cache_mode,
     load_or_quantize,
     resolve_encoder_identity,
@@ -120,6 +121,17 @@ _GLM52_MIXED_TRELLIS_BLOCK32_SIGNATURES = frozenset(
 )
 
 
+def _is_glm52_block32_tier_signature(
+    tier_signature: tuple[tuple[int, int], ...],
+) -> bool:
+    if tier_signature in _GLM52_MIXED_TRELLIS_BLOCK32_SIGNATURES:
+        return True
+    # Three-tier K3/K4/K5 uses a wider cooperative kernel. The block-64
+    # geometry needs 109,568 B of shared memory and cannot launch on SM120;
+    # block-32 is the qualified native geometry for every projection split.
+    return tuple(bits for bits, _ in tier_signature) == (3, 4, 5)
+
+
 def _resolve_mixed_trellis_prefill_block_m(
     *,
     configured_block_m: int,
@@ -145,7 +157,7 @@ def _resolve_mixed_trellis_prefill_block_m(
         and int(device_major) == 12
         and int(hidden_size) == 6144
         and int(intermediate_size) == 512
-        and tier_signature in _GLM52_MIXED_TRELLIS_BLOCK32_SIGNATURES
+        and _is_glm52_block32_tier_signature(tier_signature)
         and int(topk) == 8
         and tuple(int(value) for value in prefill_tile_config) == (128, 128, 32, 512)
     )
@@ -185,6 +197,32 @@ def _online_trellis_bits() -> int | None:
 
 def _online_trellis_shape_supported(input_size: int, output_size: int) -> bool:
     return input_size % _HADAMARD_BLOCK == 0 and output_size % _HADAMARD_BLOCK == 0
+
+
+def _load_online_encoding_with_retry(
+    cache_key: Exl3OnlineCacheKey,
+    *,
+    device: torch.device,
+    quantize: Any,
+) -> Any:
+    """Load/encode one online payload, retrying one non-finite encode."""
+
+    try:
+        return load_or_quantize(cache_key, device=device, quantize=quantize)
+    except Exl3OnlineNonFiniteError:
+        # The fallback encoder uses large randomized GPU reductions. A
+        # transient non-finite result must never become a persistent model
+        # weight, but one clean retry distinguishes that event from a
+        # reproducible checkpoint/encoder defect. The cache layer has already
+        # rejected and removed the invalid payload.
+        logger.warning(
+            "Online EXL3 K%d produced non-finite data for %s on TP rank %d; "
+            "retrying the deterministic encode once",
+            cache_key.bits,
+            cache_key.prefix,
+            cache_key.tp_rank,
+        )
+        return load_or_quantize(cache_key, device=device, quantize=quantize)
 
 
 def _load_exl3_online_quantizer() -> Any:
@@ -382,12 +420,8 @@ def _load_b12x_mixed_trellis() -> Any:
     if _B12X_MIXED_TRELLIS_API is not None:
         return _B12X_MIXED_TRELLIS_API
     try:
-        module = importlib.import_module(
-            "b12x.moe._shared.kernels.w4a16.mixed_trellis"
-        )
-        prepare = importlib.import_module(
-            "b12x.moe._shared.kernels.w4a16.prepare"
-        )
+        module = importlib.import_module("b12x.moe._shared.kernels.w4a16.mixed_trellis")
+        prepare = importlib.import_module("b12x.moe._shared.kernels.w4a16.prepare")
         host = importlib.import_module("b12x.moe._shared.kernels.w4a16.host")
     except Exception as exc:
         raise RuntimeError(
@@ -396,17 +430,22 @@ def _load_b12x_mixed_trellis() -> Any:
         ) from exc
     api = SimpleNamespace(
         build_tiered_maps=module.build_tiered_maps,
-        # glm52-r7-sparkinfer: absent on an unpatched SparkInfer, which the
+        # Absent on an older B12X build, which the
         # loader checks for before selecting the fused R7 path.
         build_projection_tiered_maps=getattr(
             module, "build_projection_tiered_maps", None
         ),
         combine_trellis_rotations=module.combine_trellis_rotations,
         compile_mixed_trellis=module.compile_mixed_trellis,
+        compile_mixed_trellis3=getattr(module, "compile_mixed_trellis3", None),
         make_mixed_trellis_buffers=module.make_mixed_trellis_buffers,
+        make_mixed_trellis3_buffers=getattr(
+            module, "make_mixed_trellis3_buffers", None
+        ),
         max_packed_route_slots=host.max_packed_route_slots,
         prepare_weights=prepare.prepare_trellis256_moe_weights,
         run_mixed_trellis=module.run_mixed_trellis,
+        run_mixed_trellis3=getattr(module, "run_mixed_trellis3", None),
         warmup_mixed_trellis_route_pack=module.warmup_mixed_trellis_route_pack,
     )
     _B12X_MIXED_TRELLIS_API = api
@@ -498,9 +537,7 @@ def _resolve_r7_a1_min_rows(ext: Any) -> int:
         return 0
     value = int(raw)
     if value < 0:
-        raise ValueError(
-            f"VLLM_EXL3_R7_A1_MIN_ROWS must be >= 0, got {value}"
-        )
+        raise ValueError(f"VLLM_EXL3_R7_A1_MIN_ROWS must be >= 0, got {value}")
     return value
 
 
@@ -509,7 +546,7 @@ def _r7_fused_layer_budget():
 
     raw = os.environ.get("VLLM_EXL3_R7_FUSED_LAYERS")
     if raw is None or raw == "":
-        return 48
+        return None
     value = int(raw)
     return None if value < 0 else value
 
@@ -585,7 +622,7 @@ def _r7_ballast_view(planes: int, like: torch.Tensor) -> torch.Tensor:
 
 
 def _r7_fused_enabled() -> bool:
-    """R7 on SparkInfer's fused MoE. glm52-r7-sparkinfer.
+    """R7 on B12X's fused MoE.
 
     On by default; set VLLM_EXL3_R7_FUSED=0 to force exl3_moe_r7_fused for a
     control run.
@@ -606,6 +643,8 @@ def _shared_mixed_buffers(
     topk,
 ):
     """One scratch arena per model/draft owner and launch geometry."""
+
+    tier_count = 3 if hasattr(launch, "tier2_num_experts") else 2
 
     # glm52-r7-gate-tight: max_m_blocks is DELIBERATELY excluded from the key.
     # It derives from each layer's summed tier slots, which differ per layer
@@ -628,6 +667,7 @@ def _shared_mixed_buffers(
         int(sms),
         str(launch.rotation_input_dtype),
         launch.route_ids_dtype,
+        tier_count,
     )
     # One arena per launch geometry, allocated ONCE. Growing it on a larger
     # max_m_blocks thrashed (51 allocations, old arenas retained by the
@@ -637,14 +677,29 @@ def _shared_mixed_buffers(
     # capacity/block/tile/topk that size it.
     entry = _MIXED_TRELLIS_BUFFERS.get(key)
     if entry is None:
-        # Size the single arena for the STRUCTURAL worst case -- both tiers at
-        # the 256-expert maximum -- so one arena is provably large enough for
-        # every layer's route-block count. Sizing it from the first layer would
-        # under-allocate for a later, wider one; growing it thrashed (51
-        # allocations, old arenas pinned by the runtimes already holding them).
+        # Routing has its own exact global-expert namespace. Projection slots
+        # may total up to 512, but they affect descriptor/weight addressing,
+        # not route-pack capacity. Size one arena from the compiled routing
+        # contract so every layer can share it without projection padding.
+        topk_sum = getattr(launch, "topk_sum", None)
+        if topk_sum is not None:
+            route_num_experts = int(topk_sum.route_num_experts)
+        elif hasattr(launch, "route_num_experts"):
+            route_num_experts = int(launch.route_num_experts)
+        else:
+            # Legacy mixed-Trellis launch objects predate the separate route
+            # namespace. Their tiers partition the routed experts directly,
+            # so the sum is exact. Projection-tight R7 launches always carry
+            # route_num_experts and never take this compatibility branch.
+            route_num_experts = sum(
+                int(getattr(launch, f"tier{tier_id}_num_experts"))
+                for tier_id in range(tier_count)
+            )
         worst_max_m_blocks = (
             mixed_api.max_packed_route_slots(
-                int(capacity) * int(topk), int(block_size_m), 512
+                int(capacity) * int(topk),
+                int(block_size_m),
+                route_num_experts,
             )
             + int(block_size_m)
             - 1
@@ -654,15 +709,26 @@ def _shared_mixed_buffers(
             tier1_num_experts=256,
             max_m_blocks=worst_max_m_blocks,
         )
+        if tier_count == 3:
+            # Only the sum is consumed by buffer planning. Keep every tier
+            # positive while representing the exact 512-slot structural cap.
+            overrides.update(tier1_num_experts=255, tier2_num_experts=1)
         if dataclasses.is_dataclass(launch):
             worst = dataclasses.replace(launch, **overrides)
         else:
             # Production uses the dataclass. Retained API tests use a small
             # namespace carrying the same public fields.
             worst = SimpleNamespace(**{**vars(launch), **overrides})
-        entry = mixed_api.make_mixed_trellis_buffers(
-            worst, device=device, sms=sms
+        make_buffers = (
+            mixed_api.make_mixed_trellis3_buffers
+            if tier_count == 3
+            else mixed_api.make_mixed_trellis_buffers
         )
+        if make_buffers is None:
+            raise RuntimeError(
+                "the installed B12X build lacks three-tier scratch support"
+            )
+        entry = make_buffers(worst, device=device, sms=sms)
         _MIXED_TRELLIS_BUFFERS[key] = entry
         logger.info(
             "R7 fused MoE scratch arena (worst-case sized): capacity=%d "
@@ -962,10 +1028,7 @@ class Exl3Config(QuantizationConfig):
             if not isinstance(_r7, dict):
                 raise ValueError("r7_routed_experts must be an object")
             if _r7.get("schema") != "r7-complete-v2-checkpoint-v1":
-                raise ValueError(
-                    "unsupported R7 EXL3 schema: "
-                    f"{_r7.get('schema')!r}"
-                )
+                raise ValueError(f"unsupported R7 EXL3 schema: {_r7.get('schema')!r}")
             if _r7.get("codebook") != "mcg" or _r7.get("bits") != "mixed_tensor":
                 raise ValueError(
                     "R7 EXL3 requires codebook='mcg' and bits='mixed_tensor'"
@@ -1016,10 +1079,7 @@ class Exl3Config(QuantizationConfig):
         if user_quant is not None and user_quant != "exl3":
             return None
         r7 = hf_quant_cfg.get("r7_routed_experts")
-        if (
-            isinstance(r7, dict)
-            and r7.get("schema") == "r7-complete-v2-checkpoint-v1"
-        ):
+        if isinstance(r7, dict) and r7.get("schema") == "r7-complete-v2-checkpoint-v1":
             return "exl3"
         metadata = getattr(hf_config, "hybrid_tr3_tail", None)
         if isinstance(metadata, dict) and metadata.get("format") == _RANK_SLICED_FORMAT:
@@ -1543,9 +1603,7 @@ class Exl3Config(QuantizationConfig):
             # below. Returning None here makes each of them fail as
             # "unexpected codebook[None]" even though it ships an mcg marker.
             if match is not None:
-                first, last = (
-                    int(v) for v in self.rank_sliced_metadata["moe_layers"]
-                )
+                first, last = (int(v) for v in self.rank_sliced_metadata["moe_layers"])
                 if first <= int(match.group(1)) <= last:
                     return "mcg"
             # --- end glm52-mdispatch ---
@@ -1666,6 +1724,8 @@ class Exl3Parameter(BasevLLMParameter):
         loaded_weight: torch.Tensor,
         shard_id: ShardId = None,
     ) -> None:
+        if getattr(loaded_weight, "_vllm_instanttensor_borrowed", False):
+            loaded_weight = loaded_weight.clone()
         self.exl3_tensors[shard_id] = loaded_weight.contiguous()
 
 
@@ -1835,7 +1895,11 @@ class Exl3OnlineLinearMethod(_Fp8OnlineLinearBase):
                 proxy_error
             )
 
-        result = load_or_quantize(cache_key, device=device, quantize=encode)
+        result = _load_online_encoding_with_retry(
+            cache_key,
+            device=device,
+            quantize=encode,
+        )
 
         layer.register_buffer(
             "exl3_online_trellis_weight",
@@ -2305,8 +2369,9 @@ class Exl3MoEParameter(BasevLLMParameter):
         num_experts: int = 0,
         shard_ids: tuple[str, ...] = (),
         preallocate: bool = False,
+        tp_slice: tuple[int, int, int, int] | None = None,
     ):
-        del num_experts, shard_ids, preallocate
+        del num_experts, shard_ids, preallocate, tp_slice
         data = torch.empty(0, dtype=torch.uint8)
         return super().__new__(cls, data=data, weight_loader=weight_loader)
 
@@ -2317,13 +2382,40 @@ class Exl3MoEParameter(BasevLLMParameter):
         num_experts: int = 0,
         shard_ids: tuple[str, ...] = (),
         preallocate: bool = False,
+        tp_slice: tuple[int, int, int, int] | None = None,
     ):
         self.exl3_tensors: dict[tuple[int, str], torch.Tensor] = {}
         self.exl3_backing: torch.Tensor | None = None
         self.exl3_num_experts = int(num_experts)
         self.exl3_shard_ids = tuple(shard_ids)
         self.exl3_preallocate = bool(preallocate)
+        self.exl3_tp_slice = tp_slice
         super().__init__(data=self.data, weight_loader=weight_loader)
+
+    def _slice_loaded_weight(self, loaded_weight: torch.Tensor) -> torch.Tensor:
+        """Materialize only the local TP range from an unsliced R7 tensor."""
+
+        if self.exl3_tp_slice is None:
+            return loaded_weight
+        dim, start, size, quantum = self.exl3_tp_slice
+        if start % quantum or size % quantum:
+            raise ValueError(
+                "EXL3 streaming TP slice is not quantum-aligned: "
+                f"start={start}, size={size}, quantum={quantum}"
+            )
+        offset = start // quantum
+        length = size // quantum
+        if offset + length > loaded_weight.shape[dim]:
+            raise ValueError(
+                "EXL3 streaming TP slice exceeds the loaded tensor: "
+                f"shape={tuple(loaded_weight.shape)}, dim={dim}, "
+                f"offset={offset}, length={length}"
+            )
+        sliced = loaded_weight.narrow(dim, offset, length)
+        # A dim-0 narrow can remain contiguous while retaining the full source
+        # storage. Clone that case so the InstantTensor staging allocation can
+        # be released; a non-contiguous narrow already needs materialization.
+        return sliced.clone() if sliced.is_contiguous() else sliced.contiguous()
 
     def load_exl3_weight(
         self,
@@ -2333,7 +2425,11 @@ class Exl3MoEParameter(BasevLLMParameter):
         shard_id: str,
     ) -> None:
         key = (int(expert_id), str(shard_id))
+        borrowed = getattr(loaded_weight, "_vllm_instanttensor_borrowed", False)
+        loaded_weight = self._slice_loaded_weight(loaded_weight)
         if not self.exl3_preallocate:
+            if borrowed and self.exl3_tp_slice is None:
+                loaded_weight = loaded_weight.clone()
             self.exl3_tensors[key] = loaded_weight.contiguous()
             return
         if self.exl3_num_experts <= 0 or shard_id not in self.exl3_shard_ids:
@@ -2465,6 +2561,15 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             layer.exl3_r7_max_num_batched_tokens = int(
                 _r7_scheduler.max_num_batched_tokens
             )
+        # R7 expert files contain unsliced tensors. Slice every payload while
+        # it is consumed instead of retaining the full model on every TP rank
+        # and slicing only after the loader has exhausted the checkpoint.
+        # At TP4 that changes the peak from the full ~320 GiB expert payload
+        # per rank to its local quarter and is required for 96 GiB GPUs.
+        r7_stream_tp = layer.exl3_r7_graph and layer.exl3_tp_size > 1
+        layer.exl3_r7_stream_tp_sliced = r7_stream_tp
+        r7_slice_start = layer.exl3_tp_rank * layer.exl3_intermediate_size_per_partition
+        r7_slice_size = layer.exl3_intermediate_size_per_partition
         rank_sliced = self.quant_config.rank_sliced_metadata is not None
         # --- glm52-mdispatch: route per layer, not per checkpoint ---
         # A checkpoint may carry a rank-sliced TAIL (e.g. hybrid_tr3_tail
@@ -2552,6 +2657,16 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                     (prefix == "w13" and suffix == "suh")
                     or (prefix == "w2" and suffix == "svh")
                 )
+                tp_slice = None
+                if r7_stream_tp:
+                    if (prefix, suffix) == ("w13", "svh"):
+                        tp_slice = (0, r7_slice_start, r7_slice_size, 1)
+                    elif (prefix, suffix) == ("w13", "trellis"):
+                        tp_slice = (1, r7_slice_start, r7_slice_size, 16)
+                    elif (prefix, suffix) == ("w2", "suh"):
+                        tp_slice = (0, r7_slice_start, r7_slice_size, 1)
+                    elif (prefix, suffix) == ("w2", "trellis"):
+                        tp_slice = (0, r7_slice_start, r7_slice_size, 16)
                 layer.register_parameter(
                     f"{prefix}_{suffix}",
                     Exl3MoEParameter(
@@ -2565,6 +2680,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                             if getattr(layer, "exl3_mixed_bitrate", False)
                             else {"suh", "svh", "trellis"}
                         ),
+                        tp_slice=tp_slice,
                     ),
                 )
 
@@ -2607,7 +2723,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             layer,
             "exl3_rank_sliced",
             self.quant_config.rank_sliced_metadata is not None,
-        ):
+        ) and not getattr(layer, "exl3_r7_stream_tp_sliced", False):
             self._shard_tensors_for_tensor_parallel(layer)
         device = layer.w13_trellis.device
         for prefix in ("w13", "w2"):
@@ -2644,27 +2760,36 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         _dbg = os.environ.get("VLLM_EXL3_R7_DEBUG", "")
         if _dbg and _dbg in str(getattr(layer, "layer_name", "")):
             import torch as _t
-            _out = [f"R7DBG {layer.layer_name} rank={layer.exl3_tp_rank} "
-                    f"shared_h={getattr(layer, 'exl3_shared_h_rotations', None)} "
-                    f"rank_sliced={_rs} local_experts={layer.local_num_experts}"]
-            for _g, _a, _k in (("w13", "suh", (0, "w1")), ("w13", "suh", (5, "w3")),
-                               ("w13", "svh", (5, "w1")), ("w13", "trellis", (5, "w1")),
-                               ("w2", "suh", (5, "w2")), ("w2", "svh", (5, "w2")),
-                               ("w2", "trellis", (5, "w2"))):
+
+            _out = [
+                f"R7DBG {layer.layer_name} rank={layer.exl3_tp_rank} "
+                f"shared_h={getattr(layer, 'exl3_shared_h_rotations', None)} "
+                f"rank_sliced={_rs} local_experts={layer.local_num_experts}"
+            ]
+            for _g, _a, _k in (
+                ("w13", "suh", (0, "w1")),
+                ("w13", "suh", (5, "w3")),
+                ("w13", "svh", (5, "w1")),
+                ("w13", "trellis", (5, "w1")),
+                ("w2", "suh", (5, "w2")),
+                ("w2", "svh", (5, "w2")),
+                ("w2", "trellis", (5, "w2")),
+            ):
                 _tt = getattr(layer, f"{_g}_{_a}").exl3_tensors.get(_k)
                 if _tt is None:
                     _out.append(f"  {_g}_{_a}{_k}: MISSING")
                 else:
                     _v = _tt.to(_t.float64)
-                    _out.append(f"  {_g}_{_a}{_k}: shape={tuple(_tt.shape)} "
-                                f"dtype={_tt.dtype} sum={_v.sum().item():.6f}")
+                    _out.append(
+                        f"  {_g}_{_a}{_k}: shape={tuple(_tt.shape)} "
+                        f"dtype={_tt.dtype} sum={_v.sum().item():.6f}"
+                    )
             print(chr(10).join(_out), flush=True)
         # --- end glm52-mdispatch ---
 
         if getattr(layer, "exl3_r7_graph", False):
-            # glm52-r7-sparkinfer: prefer the fused mixed-Trellis kernel; layers
-            # carrying a third K on either phase keep exl3_moe_r7_fused.
-            if _r7_fused_enabled() and self._prepare_r7_sparkinfer_weights(layer):
+            # Prefer the native two- or three-tier B12X mixed-Trellis kernel.
+            if _r7_fused_enabled() and self._prepare_r7_b12x_weights(layer):
                 layer.exl3_r7_fused = True
                 return
             self._prepare_r7_graph_weights(layer)
@@ -3056,6 +3181,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             "prefill_tiers": tuple(prefill_tiers),
             "tier_ids": tuple(tier_ids),
             "tier_bits": tuple(tiers),
+            "trellis_codebook": "mcg",
             "global_to_combined": global_to_combined,
             "descriptor_map": descriptor_map,
             "rotations": combined_rotations,
@@ -3274,6 +3400,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         tier_signature = policy["tier_signature"]
         broadcast_suh = bool(mixed["broadcast_suh"])
         broadcast_svh = bool(mixed["broadcast_svh"])
+        route_num_experts = int(layer.local_num_experts)
         owner_token = _runtime_owner_token(self.quant_config, layer)
         key = (
             owner_token,
@@ -3283,6 +3410,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             int(layer.exl3_hidden_size),
             int(layer.exl3_intermediate_size_per_partition),
             tier_signature,
+            route_num_experts,
             topk,
             max_decode_m,
             max_batched_tokens,
@@ -3310,7 +3438,11 @@ class Exl3MoEMethod(FusedMoEMethodBase):
 
         mixed_api = _load_b12x_mixed_trellis()
         device = x.device
-        total_experts = sum(experts for _, experts in tier_signature)
+        tier_count = len(tier_signature)
+        if tier_count not in (2, 3):
+            raise RuntimeError(
+                f"mixed Trellis requires two or three bitrate tiers, got {tier_count}"
+            )
 
         def make_state(
             capacity: int,
@@ -3320,16 +3452,31 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             route_slots = mixed_api.max_packed_route_slots(
                 capacity * topk,
                 block_size_m,
-                total_experts,
+                route_num_experts,
             )
-            launch = mixed_api.compile_mixed_trellis(
+            compile_mixed = (
+                mixed_api.compile_mixed_trellis3
+                if tier_count == 3
+                else mixed_api.compile_mixed_trellis
+            )
+            if compile_mixed is None:
+                raise RuntimeError(
+                    "the installed B12X build lacks native three-tier Trellis support"
+                )
+            tier_kwargs = {
+                f"tier{tier_id}_num_experts": experts
+                for tier_id, (_bits, experts) in enumerate(tier_signature)
+            }
+            tier_kwargs.update(
+                {
+                    f"tier{tier_id}_bits": bits
+                    for tier_id, (bits, _experts) in enumerate(tier_signature)
+                }
+            )
+            launch = compile_mixed(
                 size_m=capacity,
                 hidden_size=int(layer.exl3_hidden_size),
                 intermediate_size=int(layer.exl3_intermediate_size_per_partition),
-                tier0_num_experts=tier_signature[0][1],
-                tier1_num_experts=tier_signature[1][1],
-                tier0_bits=tier_signature[0][0],
-                tier1_bits=tier_signature[1][0],
                 top_k=topk,
                 max_m_blocks=(route_slots + block_size_m - 1) // block_size_m,
                 moe_block_size=block_size_m,
@@ -3340,6 +3487,9 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 route_ids_dtype=topk_ids.dtype,
                 broadcast_suh=broadcast_suh,
                 broadcast_svh=broadcast_svh,
+                trellis_codebook=mixed["trellis_codebook"],
+                route_num_experts=route_num_experts,
+                **tier_kwargs,
             )
             return {
                 "capacity": capacity,
@@ -3419,7 +3569,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             slice_weights: torch.Tensor,
             slice_ids: torch.Tensor,
             state: dict[str, Any],
-            tiers: tuple[Any, Any],
+            tiers: tuple[Any, ...],
         ) -> torch.Tensor:
             run_kwargs = {}
             gate_experts = mixed.get("tier_gate_experts")
@@ -3429,26 +3579,28 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                     "projection-tight R7 tiers require paired gate/up counts"
                 )
             if gate_experts is not None:
-                run_kwargs.update(
-                    gate_experts=gate_experts, up_experts=up_experts
-                )
-            return (
-                runtime["mixed_api"]
-                .run_mixed_trellis(
-                    slice_x,
-                    tiers[0],
-                    tiers[1],
-                    slice_weights,
-                    slice_ids,
-                    mixed["global_to_combined"],
-                    mixed["descriptor_map"],
-                    mixed["rotations"],
-                    state["launch"],
-                    state["buffers"],
-                    **run_kwargs,
-                )
-                .to(slice_x.dtype)
+                run_kwargs.update(gate_experts=gate_experts, up_experts=up_experts)
+            run_mixed = (
+                runtime["mixed_api"].run_mixed_trellis3
+                if len(tiers) == 3
+                else runtime["mixed_api"].run_mixed_trellis
             )
+            if run_mixed is None:
+                raise RuntimeError(
+                    "the installed B12X build lacks native three-tier Trellis support"
+                )
+            return run_mixed(
+                slice_x,
+                *tiers,
+                slice_weights,
+                slice_ids,
+                mixed["global_to_combined"],
+                mixed["descriptor_map"],
+                mixed["rotations"],
+                state["launch"],
+                state["buffers"],
+                **run_kwargs,
+            ).to(slice_x.dtype)
 
         if m <= runtime["max_decode_m"]:
             return run_state(
@@ -3570,11 +3722,10 @@ class Exl3MoEMethod(FusedMoEMethodBase):
     # order-dependent. The config is per model load and shared by its layers.
 
     def _r7_projection_tiers(self, layer: RoutedExperts):
-        """Split experts into two bitrate tiers per projection.
+        """Split experts into two or three bitrate tiers per projection.
 
         Returns (tier_bits, {projection: (tier_id_per_expert, ...)}) or None
-        when any projection carries more than two distinct K, which keeps that
-        layer on exl3_moe_r7_fused. glm52-r7-sparkinfer.
+        for layouts outside the native mixed-Trellis contracts.
         """
 
         # Derived from the payloads, not from layer.exl3_r7_bitrates: that
@@ -3602,24 +3753,25 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 f"R7 routed experts use bitrates {invalid} not declared by "
                 f"r7_routed_experts.k_values={sorted(declared_k)}"
             )
-        if len(present) != 2:
+        if len(present) not in (2, 3):
             return None
-        lookup = {present[0]: 0, present[1]: 1}
+        lookup = {bits: tier_id for tier_id, bits in enumerate(present)}
         return tuple(present), {
             name: tuple(lookup[b] for b in values)
             for name, values in projections.items()
         }
 
-    def _prepare_r7_sparkinfer_weights(self, layer: RoutedExperts) -> bool:
-        """Pack R7 experts into SparkInfer tier stacks. False -> keep exl3_moe."""
+    def _prepare_r7_b12x_weights(self, layer: RoutedExperts) -> bool:
+        """Pack R7 experts into native B12X tier stacks."""
 
         split = self._r7_projection_tiers(layer)
         if split is None:
             return False
-        # The fused layout costs ~1.385 GiB/layer against ~1.031 GiB for the
-        # per-expert one, so converting all 75 exhausts the GPU around layer 58.
-        # Cap the count until that overhead is tracked down; the rest keep
-        # exl3_moe_r7_fused, which the loader already selects per layer.
+        # Streaming TP slicing and prompt release of source tensors keep the
+        # native stacks within the checkpoint's steady-state footprint, so all
+        # supported layers are native by default. This remains a diagnostic
+        # cap only; a non-negative value can deliberately retain the external
+        # fallback after that many layers.
         budget = _r7_fused_layer_budget()
         if budget is not None:
             used = int(getattr(self.quant_config, "_r7_fused_layers", 0))
@@ -3632,9 +3784,21 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         mixed_api = _load_b12x_mixed_trellis()
         if getattr(mixed_api, "build_projection_tiered_maps", None) is None:
             raise RuntimeError(
-                "R7 fused MoE requires the projection-tier SparkInfer patch; "
+                "R7 fused MoE requires the projection-tier B12X API; "
                 "the kernel and loader patches must be installed together"
             )
+        if len(tier_bits) == 3 and any(
+            getattr(mixed_api, name, None) is None
+            for name in (
+                "compile_mixed_trellis3",
+                "make_mixed_trellis3_buffers",
+                "run_mixed_trellis3",
+            )
+        ):
+            raise RuntimeError(
+                "R7 K3/K4/K5 layers require native three-tier B12X support"
+            )
+        trellis_codebook = str(self.quant_config.r7_routed_experts["codebook"]).lower()
         hidden_size = int(layer.exl3_hidden_size)
         intermediate_size = int(layer.exl3_intermediate_size_per_partition)
         num_experts = int(layer.local_num_experts)
@@ -3661,15 +3825,15 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         # Combined-expert indexed, so global order -- no tier reordering.
         intermediate_rotations = torch.cat(
             (
-                torch.stack([
-                    layer.w13_svh.exl3_tensors[(e, "w1")] for e in range(num_experts)
-                ]),
-                torch.stack([
-                    layer.w13_svh.exl3_tensors[(e, "w3")] for e in range(num_experts)
-                ]),
-                torch.stack([
-                    layer.w2_suh.exl3_tensors[(e, "w2")] for e in range(num_experts)
-                ]),
+                torch.stack(
+                    [layer.w13_svh.exl3_tensors[(e, "w1")] for e in range(num_experts)]
+                ),
+                torch.stack(
+                    [layer.w13_svh.exl3_tensors[(e, "w3")] for e in range(num_experts)]
+                ),
+                torch.stack(
+                    [layer.w2_suh.exl3_tensors[(e, "w2")] for e in range(num_experts)]
+                ),
             ),
             dim=1,
         ).contiguous()
@@ -3826,7 +3990,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                         params_dtype=torch.float16,
                         w13_layout="trellis3_t256_proj",
                         trellis_bits=bits,
-                        codebook="mcg",
+                        codebook=trellis_codebook,
                         # prepare wants tier-local rows (or the broadcast
                         # form); the launch wants the padded combined table.
                         # Both are validate-and-carry here, and R7's gate/up
@@ -3834,8 +3998,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                         # is the honest thing to hand prepare.
                         gate_suh=gate_suh[:1].contiguous(),
                         up_suh=up_suh[:1].contiguous(),
-                        intermediate_rotations=intermediate_rotations[:n]
-                        .contiguous(),
+                        intermediate_rotations=intermediate_rotations[:n].contiguous(),
                         down_svh=down_svh[:1].contiguous(),
                         tile_config=cfg,
                         # glm52-r7-ballast-dealias: a view into the ballast
@@ -3853,11 +4016,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 # contents are never read. Allocating it per layer leaked
                 # ~200 MiB a layer and OOMed around layer 68 of 75, so it is
                 # cached and shared across every layer and tier.
-                fc1_w2 = (
-                    w2
-                    if fc2_slots == slots
-                    else _r7_fc1_ballast(slots, w2)
-                )
+                fc1_w2 = w2 if fc2_slots == slots else _r7_fc1_ballast(slots, w2)
                 # prepare validates a padded [2, slots] w13 and builds a view
                 # of it that is discarded here, so it gets a shared never-read
                 # ballast; the served w13 is the tight [gate|up] buffer bound
@@ -3943,7 +4102,6 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             prefill_tiers.append(prepare_tier_fn(prefill_tile_config))
             torch.cuda.empty_cache()
 
-
         global_to_combined, descriptor_map = mixed_api.build_projection_tiered_maps(
             tiers["gate"],
             tiers["up"],
@@ -3955,6 +4113,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             "tiers": tuple(prepared_tiers),
             "prefill_tiers": tuple(prefill_tiers),
             "tier_bits": tuple(tier_bits),
+            "trellis_codebook": trellis_codebook,
             # FC1 slot counts: what sizes the launch and the policy signature.
             "tier_ids": tuple(fc1_counts),
             # Real gate plane count per tier, threaded to run_mixed_trellis so
@@ -3991,15 +4150,14 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             torch.cuda.memory_allocated(device) / 2**30,
             torch.cuda.memory_reserved(device) / 2**30,
         )
-        logger.info(
-            "R7 fused MoE %s: tier0=K%d(%d gate/%d up/%d down) tier1=K%d",
-            layer.layer_name,
-            tier_bits[0],
-            sum(1 for t in tiers["gate"] if t == 0),
-            sum(1 for t in tiers["up"] if t == 0),
-            sum(1 for t in tiers["down"] if t == 0),
-            tier_bits[1],
+        tier_summary = ", ".join(
+            f"K{bits}("
+            f"{sum(1 for value in tiers['gate'] if value == tier_id)} gate/"
+            f"{sum(1 for value in tiers['up'] if value == tier_id)} up/"
+            f"{sum(1 for value in tiers['down'] if value == tier_id)} down)"
+            for tier_id, bits in enumerate(tier_bits)
         )
+        logger.info("R7 fused B12X MoE %s: %s", layer.layer_name, tier_summary)
         return True
 
     def _r7_graph_runtime(
@@ -4111,14 +4269,11 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             ),
         }
         _R7_GRAPH_RUNTIMES[key] = runtime
-        arena_mib = (
-            sum(
-                value.numel() * value.element_size()
-                for value in runtime.values()
-                if isinstance(value, torch.Tensor)
-            )
-            / (1 << 20)
-        )
+        arena_mib = sum(
+            value.numel() * value.element_size()
+            for value in runtime.values()
+            if isinstance(value, torch.Tensor)
+        ) / (1 << 20)
         logger.info_once(
             "R7 EXL3 CUDA-graph runtime planned: capacity=%d route_block=%d "
             "concurrency=%d topk=%d experts=%d arena=%.1fMiB a1_min_rows=%d",

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -24,7 +24,9 @@ import importlib
 import os
 import re
 import sys
-from types import SimpleNamespace
+import zlib
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
 from typing import TYPE_CHECKING, Any
 
 import torch
@@ -57,12 +59,20 @@ from vllm.model_executor.layers.quantization.base_config import (
 from vllm.model_executor.layers.quantization.compressed_tensors.utils import (
     should_ignore_layer,
 )
+from vllm.model_executor.layers.quantization.exl3_online_cache import (
+    Exl3OnlineCacheKey,
+    load_or_quantize,
+    resolve_encoder_identity,
+    resolve_model_identity,
+)
+from vllm.model_executor.layers.quantization.online.fp8 import _Fp8OnlineLinearBase
 from vllm.model_executor.layers.quantization.online.mxfp8 import (
     Mxfp8OnlineLinearMethod,
     is_shared_expert_projection,
 )
 from vllm.model_executor.layers.quantization.utils.quant_utils import kMxfp8Dynamic
 from vllm.model_executor.parameter import BasevLLMParameter
+from vllm.model_executor.utils import replace_parameter
 from vllm.transformers_utils.repo_utils import get_hf_file_to_dict
 
 if TYPE_CHECKING:
@@ -79,6 +89,19 @@ _HADAMARD_BLOCK = 128
 _EXL3_EXT: Any | None = None
 _B12X_FUSED_MOE_API: Any | None = None
 _B12X_MIXED_TRELLIS_API: Any | None = None
+_SPARKINFER_FUSED_MOE_API: Any | None = None
+_SPARKINFER_MIXED_TRELLIS_API: Any | None = None
+_SPARKINFER_TRELLIS_LINEAR_API: Any | None = None
+_EXL3_ONLINE_QUANTIZER: Any | None = None
+_EXL3_ONLINE_WARMED_SIGNATURES: set[tuple[int, int, int, int]] = set()
+_SPARKINFER_TRELLIS_LINEAR_WEIGHTS: dict[tuple[Any, ...], Any] = {}
+_SPARKINFER_TRELLIS_WARMED_DEVICES: set[int] = set()
+# The dense W4A16 kernel caps its temporary accumulation arena at
+# SMs * 4 * block_m * 256 fp32 elements.  SM120/SM121 devices supported by
+# this path have at most 192 SMs, and block_m never exceeds 64.  Keeping this
+# architecture bound here lets Inductor own and reuse the temporary across
+# layers instead of allocating inside CUDA graph capture.
+_SPARKINFER_TRELLIS_C_TMP_CAP = 192 * 4 * 64 * 256
 _RANK_SLICED_RUNTIMES: dict[tuple[Any, ...], dict[str, Any]] = {}
 _MIXED_TRELLIS_RUNTIMES: dict[tuple[Any, ...], dict[str, Any]] = {}
 _NEXT_RUNTIME_SCOPE_ID = 0
@@ -130,6 +153,70 @@ MIN_CAPTURABLE_TRELLIS_M = 1
 # Keep every supported row count on the native path by default; operators may
 # still raise the threshold explicitly as a diagnostic kill switch.
 _DEFAULT_TRELLIS_MIN_M = MIN_CAPTURABLE_TRELLIS_M
+
+
+def _online_trellis_bits() -> int | None:
+    raw = os.environ.get("VLLM_EXL3_ONLINE_TRELLIS_BITS")
+    if raw is None or not raw.strip():
+        return None
+    try:
+        bits = int(raw)
+    except ValueError:
+        raise ValueError(
+            f"VLLM_EXL3_ONLINE_TRELLIS_BITS must be an integer from 3 to 8, got {raw!r}"
+        ) from None
+    if bits not in range(3, 9):
+        raise ValueError(
+            f"VLLM_EXL3_ONLINE_TRELLIS_BITS must be from 3 to 8, got {bits}"
+        )
+    return bits
+
+
+def _online_trellis_shape_supported(input_size: int, output_size: int) -> bool:
+    return input_size % _HADAMARD_BLOCK == 0 and output_size % _HADAMARD_BLOCK == 0
+
+
+def _load_exl3_online_quantizer() -> Any:
+    """Load the encoder without importing ExLlamaV3's serving front end."""
+
+    global _EXL3_ONLINE_QUANTIZER
+    if _EXL3_ONLINE_QUANTIZER is not None:
+        return _EXL3_ONLINE_QUANTIZER
+
+    raw_root = os.environ.get("VLLM_EXL3_ENCODER_SOURCE")
+    if raw_root is None or not raw_root.strip():
+        raise RuntimeError(
+            "online EXL3 Trellis requires VLLM_EXL3_ENCODER_SOURCE to point "
+            "to the exllamav3 Python package directory"
+        )
+    package_root = Path(raw_root).resolve()
+    quantizer_path = package_root / "modules" / "quant" / "exl3_lib"
+    if not (quantizer_path / "quantize.py").is_file():
+        raise RuntimeError(
+            "VLLM_EXL3_ENCODER_SOURCE does not contain the ExLlamaV3 encoder: "
+            f"{package_root}"
+        )
+
+    package_name = "_vllm_exl3_encoder"
+    packages = {
+        package_name: package_root,
+        f"{package_name}.modules": package_root / "modules",
+        f"{package_name}.modules.quant": package_root / "modules" / "quant",
+        f"{package_name}.modules.quant.exl3_lib": quantizer_path,
+    }
+    for name, path in packages.items():
+        if name in sys.modules:
+            continue
+        module = ModuleType(name)
+        module.__path__ = [str(path)]
+        module.__package__ = name
+        sys.modules[name] = module
+
+    quantize = importlib.import_module(
+        f"{package_name}.modules.quant.exl3_lib.quantize"
+    )
+    _EXL3_ONLINE_QUANTIZER = quantize.quantize_exl3
+    return _EXL3_ONLINE_QUANTIZER
 
 
 def _is_draft_layer(layer: Any) -> bool:
@@ -304,6 +391,23 @@ def _load_b12x_mixed_trellis() -> Any:
     return api
 
 
+def _load_sparkinfer_trellis_linear() -> Any:
+    """Resolve the native dense Trellis API lazily."""
+
+    global _SPARKINFER_TRELLIS_LINEAR_API
+    if _SPARKINFER_TRELLIS_LINEAR_API is not None:
+        return _SPARKINFER_TRELLIS_LINEAR_API
+    try:
+        from sparkinfer.gemm import trellis_linear
+    except Exception as exc:
+        raise RuntimeError(
+            "Online EXL3 prefill requires sparkinfer.gemm.trellis_linear. "
+            "Install a matching SparkInfer build."
+        ) from exc
+    _SPARKINFER_TRELLIS_LINEAR_API = trellis_linear
+    return trellis_linear
+
+
 def _unique_tensor_storage_bytes(*buffers: Any) -> int:
     """Count unique tensor storage while ignoring buffer metadata fields."""
 
@@ -419,6 +523,166 @@ def _exl3_gemm_fake(
     )
 
 
+def _sparkinfer_trellis_weight(
+    trellis: torch.Tensor,
+    suh: torch.Tensor,
+    svh: torch.Tensor,
+    dtype: torch.dtype,
+) -> Any:
+    """Prepare each online weight before capture and retain its native views."""
+
+    api = _load_sparkinfer_trellis_linear()
+    key = (
+        trellis.device.index,
+        trellis.data_ptr(),
+        suh.data_ptr(),
+        svh.data_ptr(),
+        tuple(trellis.shape),
+        dtype,
+    )
+    weight = _SPARKINFER_TRELLIS_LINEAR_WEIGHTS.get(key)
+    if weight is None:
+        weight = api.prepare_weight(
+            trellis,
+            suh,
+            svh,
+            codebook="mcg",
+            params_dtype=dtype,
+        )
+        _SPARKINFER_TRELLIS_LINEAR_WEIGHTS[key] = weight
+    return weight
+
+
+def _sparkinfer_trellis_k6_supported(
+    trellis: torch.Tensor,
+    *,
+    has_mcg: bool,
+    has_mul1: bool,
+) -> bool:
+    """Gate the native path to the exact K6/MCG contract it implements."""
+
+    return bool(
+        has_mcg
+        and not has_mul1
+        and trellis.dtype == torch.int16
+        and trellis.ndim == 3
+        and int(trellis.shape[2]) == 96
+        and int(trellis.shape[0]) % 8 == 0
+        and int(trellis.shape[1]) % 8 == 0
+    )
+
+
+def _warm_sparkinfer_trellis_device(
+    trellis: torch.Tensor,
+    suh: torch.Tensor,
+    svh: torch.Tensor,
+) -> None:
+    """Build the runtime extension before any CUDA graph starts capturing."""
+
+    device_index = trellis.device.index
+    if device_index is None:
+        device_index = torch.cuda.current_device()
+    if device_index in _SPARKINFER_TRELLIS_WARMED_DEVICES:
+        return
+    source = torch.zeros(
+        (1, int(trellis.shape[0]) * 16),
+        dtype=torch.float16,
+        device=trellis.device,
+    )
+    _sparkinfer_trellis_linear(source, trellis, suh, svh)
+    torch.cuda.synchronize(trellis.device)
+    _SPARKINFER_TRELLIS_WARMED_DEVICES.add(device_index)
+
+
+def _sparkinfer_trellis_c_tmp_elements(rows: int, columns: int) -> int:
+    """Return graph-safe dense-W4A16 scratch capacity for one static shape."""
+
+    rows = int(rows)
+    columns = int(columns)
+    if rows <= 128:
+        # The cooperative K6 small-M kernel does not consume W4A16 scratch.
+        return 1
+    padded_rows = max(
+        ((rows + 47) // 48) * 48,
+        ((rows + 63) // 64) * 64,
+    )
+    return min(columns * padded_rows, _SPARKINFER_TRELLIS_C_TMP_CAP)
+
+
+@torch.library.custom_op(
+    "vllm::sparkinfer_trellis_linear_out",
+    mutates_args=("output", "gemm_output", "c_tmp", "rotated_f16"),
+    device_types="cuda",
+)
+def _sparkinfer_trellis_linear_out(
+    x: torch.Tensor,
+    trellis: torch.Tensor,
+    suh: torch.Tensor,
+    svh: torch.Tensor,
+    output: torch.Tensor,
+    gemm_output: torch.Tensor,
+    c_tmp: torch.Tensor,
+    rotated_f16: torch.Tensor,
+) -> None:
+    """Execute dense Trellis into graph-owned output and scratch tensors."""
+
+    api = _load_sparkinfer_trellis_linear()
+    weight = _sparkinfer_trellis_weight(trellis, suh, svh, x.dtype)
+    api.run(
+        x,
+        weight,
+        output=output,
+        gemm_output=gemm_output,
+        c_tmp=c_tmp,
+        rotated_f16=rotated_f16,
+    )
+
+
+@_sparkinfer_trellis_linear_out.register_fake
+def _sparkinfer_trellis_linear_out_fake(
+    x: torch.Tensor,
+    trellis: torch.Tensor,
+    suh: torch.Tensor,
+    svh: torch.Tensor,
+    output: torch.Tensor,
+    gemm_output: torch.Tensor,
+    c_tmp: torch.Tensor,
+    rotated_f16: torch.Tensor,
+) -> None:
+    del x, trellis, suh, svh, output, gemm_output, c_tmp, rotated_f16
+
+
+def _sparkinfer_trellis_linear(
+    x: torch.Tensor,
+    trellis: torch.Tensor,
+    suh: torch.Tensor,
+    svh: torch.Tensor,
+) -> torch.Tensor:
+    """Run every online-K6 batch through SparkInfer with explicit storage."""
+
+    output = torch.empty(
+        (x.shape[0], trellis.shape[1] * 16), dtype=x.dtype, device=x.device
+    )
+    gemm_output = torch.empty_like(output)
+    c_tmp = torch.empty(
+        (_sparkinfer_trellis_c_tmp_elements(x.shape[0], output.shape[1]),),
+        dtype=torch.float32,
+        device=x.device,
+    )
+    rotated_f16 = torch.empty_like(x)
+    _sparkinfer_trellis_linear_out(
+        x,
+        trellis,
+        suh,
+        svh,
+        output,
+        gemm_output,
+        c_tmp,
+        rotated_f16,
+    )
+    return output
+
+
 class Exl3Config(QuantizationConfig):
     """Configuration for modern and legacy EXL3 trellis checkpoints."""
 
@@ -441,6 +705,8 @@ class Exl3Config(QuantizationConfig):
         self.rank_sliced_rotation_layout = _PER_EXPERT_ROTATION_LAYOUT
         self.rank_sliced_k_values: tuple[int, ...] | None = None
         self.rank_sliced_bits_by_layer: dict[int, tuple[int, ...]] = {}
+        self._online_model_identity: str | None = None
+        self._online_encoder_identity: str | None = None
 
     def get_name(self) -> str:
         return "exl3"
@@ -489,6 +755,12 @@ class Exl3Config(QuantizationConfig):
         hf_config: PretrainedConfig | None = None,
         revision: str | None = None,
     ) -> None:
+        if _online_trellis_bits() is not None:
+            self._configure_online_cache_identity(
+                model_name,
+                hf_config=hf_config,
+                revision=revision,
+            )
         rank_sliced = getattr(hf_config, "hybrid_tr3_tail", None)
         if (
             isinstance(rank_sliced, dict)
@@ -530,6 +802,32 @@ class Exl3Config(QuantizationConfig):
 
         self._validate_storage_metadata()
         self._force_independent_lm_head(hf_config)
+
+    def _configure_online_cache_identity(
+        self,
+        model_name: str,
+        *,
+        hf_config: PretrainedConfig | None,
+        revision: str | None,
+    ) -> None:
+        if self._online_model_identity is not None:
+            return
+        encoder_source = os.getenv("VLLM_EXL3_ENCODER_SOURCE")
+        if encoder_source is None or not encoder_source.strip():
+            raise ValueError(
+                "VLLM_EXL3_ENCODER_SOURCE is required when "
+                "VLLM_EXL3_ONLINE_TRELLIS_BITS is enabled"
+            )
+        resolved_revision = revision or getattr(hf_config, "_commit_hash", None)
+        self._online_model_identity = resolve_model_identity(
+            model_name,
+            revision=resolved_revision,
+            hf_config=hf_config,
+        )
+        self._online_encoder_identity = resolve_encoder_identity(
+            encoder_source,
+            revision=os.getenv("VLLM_EXL3_ENCODER_REVISION"),
+        )
 
     def _configure_rank_sliced(self, metadata: dict[str, Any]) -> None:
         required = {
@@ -827,6 +1125,30 @@ class Exl3Config(QuantizationConfig):
                 "with no activation override."
             )
 
+        if (bits := _online_trellis_bits()) is not None:
+            if self._online_model_identity is None:
+                model_config = vllm_config.model_config
+                self._configure_online_cache_identity(
+                    model_config.model,
+                    hf_config=model_config.hf_config,
+                    revision=model_config.revision,
+                )
+            assert self._online_model_identity is not None
+            assert self._online_encoder_identity is not None
+            logger.warning_once(
+                "EXL3 BF16 online Trellis: encoding eligible non-EXL3 "
+                "linear weights at K=%d; 128-unaligned matrices retain the "
+                "configured MXFP8 path (module example: %s).",
+                bits,
+                prefix,
+            )
+            return Exl3OnlineLinearMethod(
+                bits=bits,
+                prefix=prefix,
+                model_identity=self._online_model_identity,
+                encoder_identity=self._online_encoder_identity,
+            )
+
         logger.info_once(
             "EXL3 BF16 online overlay: quantizing non-EXL3 %s projections "
             "to MXFP8 at load time (module example: %s).",
@@ -1007,6 +1329,218 @@ def _exl3_weight_loader(
     param.load_exl3_weight(loaded_weight, loaded_shard_id)
 
 
+class Exl3OnlineLinearMethod(_Fp8OnlineLinearBase):
+    """Encode eligible BF16 linear shards to cached dense EXL3 weights."""
+
+    def __init__(
+        self,
+        *,
+        bits: int,
+        prefix: str,
+        model_identity: str,
+        encoder_identity: str,
+    ) -> None:
+        super().__init__()
+        self.bits = bits
+        self.prefix = prefix
+        self.model_identity = model_identity
+        self.encoder_identity = encoder_identity
+        self.fallback: Mxfp8OnlineLinearMethod | None = None
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: list[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ) -> None:
+        output_size_per_partition = sum(output_partition_sizes)
+        layer.exl3_online_trellis = _online_trellis_shape_supported(
+            input_size_per_partition, output_size_per_partition
+        )
+        if not layer.exl3_online_trellis:
+            self.fallback = Mxfp8OnlineLinearMethod()
+            self.fallback.create_weights(
+                layer,
+                input_size_per_partition,
+                output_partition_sizes,
+                input_size,
+                output_size,
+                params_dtype,
+                **extra_weight_attrs,
+            )
+            logger.info_once(
+                "EXL3 online Trellis retains MXFP8 for 128-unaligned shards "
+                "(example %s: K=%d, N=%d).",
+                self.prefix,
+                input_size_per_partition,
+                output_size_per_partition,
+            )
+            return
+
+        super().create_weights(
+            layer,
+            input_size_per_partition,
+            output_partition_sizes,
+            input_size,
+            output_size,
+            params_dtype,
+            **extra_weight_attrs,
+        )
+        layer.exl3_online_input_size = input_size_per_partition
+        layer.exl3_online_output_size = output_size_per_partition
+
+    @staticmethod
+    def _h_data(input_size: int, device: torch.device) -> dict[str, Any]:
+        return {
+            "H": torch.zeros(
+                input_size, input_size, dtype=torch.float32, device="meta"
+            ),
+            "first_key": "vllm-online",
+            "count": 0,
+            "finalized": False,
+            "num_total": 0,
+            "inf_nan": torch.zeros(2, dtype=torch.long, device=device),
+            "device": device,
+        }
+
+    def _warm_decode_shapes(self, layer: torch.nn.Module) -> None:
+        device = layer.exl3_online_trellis_weight.device
+        _sparkinfer_trellis_weight(
+            layer.exl3_online_trellis_weight,
+            layer.exl3_online_suh,
+            layer.exl3_online_svh,
+            torch.float16,
+        )
+        device_index = device.index
+        if device_index is None:
+            device_index = torch.cuda.current_device()
+        signature = (
+            device_index,
+            layer.exl3_online_input_size,
+            layer.exl3_online_output_size,
+            self.bits,
+        )
+        if signature in _EXL3_ONLINE_WARMED_SIGNATURES:
+            return
+        for rows in range(1, 7):
+            source = torch.zeros(
+                (rows, layer.exl3_online_input_size),
+                dtype=torch.float16,
+                device=device,
+            )
+            _sparkinfer_trellis_linear(
+                source,
+                layer.exl3_online_trellis_weight,
+                layer.exl3_online_suh,
+                layer.exl3_online_svh,
+            )
+        torch.cuda.synchronize(device)
+        _EXL3_ONLINE_WARMED_SIGNATURES.add(signature)
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        if self.fallback is not None:
+            self.fallback.process_weights_after_loading(layer)
+            return
+        if getattr(layer, "_already_called_process_weights_after_loading", False):
+            return
+
+        device = layer.weight.device
+        seed = zlib.crc32(self.prefix.encode("utf-8")) & 0x7FFFFFFF
+        cache_key = Exl3OnlineCacheKey(
+            model_identity=self.model_identity,
+            encoder_identity=self.encoder_identity,
+            prefix=self.prefix,
+            bits=self.bits,
+            seed=seed,
+            tp_world_size=get_tensor_model_parallel_world_size(),
+            tp_rank=get_tensor_model_parallel_rank(),
+            input_size=layer.exl3_online_input_size,
+            output_size=layer.exl3_online_output_size,
+        )
+
+        def encode() -> tuple[dict[str, torch.Tensor], float]:
+            source = layer.weight.detach().t().float().contiguous()
+            quant_args = {
+                "K": self.bits,
+                "seed": seed,
+                "devices": [device],
+                "apply_out_scales": True,
+                "mcg": True,
+            }
+            quantize_exl3 = _load_exl3_online_quantizer()
+            _, proxy_error, tensors = quantize_exl3(
+                source,
+                self._h_data(layer.exl3_online_input_size, device),
+                quant_args,
+                return_weight_q=False,
+                verbose=False,
+            )
+            if not quant_args.get("q_fallback", False):
+                raise RuntimeError(
+                    "online EXL3 Trellis unexpectedly used calibrated LDLQ"
+                )
+            return {name: tensors[name] for name in ("trellis", "suh", "svh")}, float(
+                proxy_error
+            )
+
+        result = load_or_quantize(cache_key, device=device, quantize=encode)
+
+        layer.register_buffer(
+            "exl3_online_trellis_weight",
+            result.tensors["trellis"],
+            persistent=False,
+        )
+        layer.register_buffer(
+            "exl3_online_suh", result.tensors["suh"], persistent=False
+        )
+        layer.register_buffer(
+            "exl3_online_svh", result.tensors["svh"], persistent=False
+        )
+        replace_parameter(
+            layer,
+            "weight",
+            torch.empty(0, dtype=torch.uint8, device=device),
+        )
+        layer._already_called_process_weights_after_loading = True
+        self._warm_decode_shapes(layer)
+        logger.info(
+            "Online EXL3 K%d %s %s%s",
+            self.bits,
+            "cache hit for" if result.hit else "encoded",
+            self.prefix,
+            ""
+            if result.proxy_error is None
+            else f" (fallback proxy error {result.proxy_error:.8f})",
+        )
+
+    def apply(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if self.fallback is not None:
+            return self.fallback.apply(layer, x, bias)
+
+        original_shape = x.shape[:-1]
+        original_dtype = x.dtype
+        x_2d = x.reshape(-1, x.shape[-1]).to(torch.float16).contiguous()
+        output = _sparkinfer_trellis_linear(
+            x_2d,
+            layer.exl3_online_trellis_weight,
+            layer.exl3_online_suh,
+            layer.exl3_online_svh,
+        )
+        if bias is not None:
+            output = output + bias.to(dtype=output.dtype)
+        output = output.reshape(*original_shape, layer.exl3_online_output_size)
+        return output if output.dtype == original_dtype else output.to(original_dtype)
+
+
 class Exl3LinearMethod(LinearMethodBase):
     def __init__(self, quant_config: Exl3Config) -> None:
         self.quant_config = quant_config
@@ -1111,6 +1645,24 @@ class Exl3LinearMethod(LinearMethodBase):
                 param.exl3_tensors[shard_id] = tensor.to(
                     device=device, non_blocking=True
                 ).contiguous()
+
+        for shard_id in layer.exl3_shard_ids:
+            trellis = layer.trellis.exl3_tensors[shard_id]
+            if not _sparkinfer_trellis_k6_supported(
+                trellis,
+                has_mcg=shard_id in layer.mcg.exl3_tensors,
+                has_mul1=shard_id in layer.mul1.exl3_tensors,
+            ):
+                continue
+            suh = layer.suh.exl3_tensors[shard_id]
+            svh = layer.svh.exl3_tensors[shard_id]
+            _sparkinfer_trellis_weight(
+                trellis,
+                suh,
+                svh,
+                torch.float16,
+            )
+            _warm_sparkinfer_trellis_device(trellis, suh, svh)
 
     def apply(
         self,
@@ -1365,14 +1917,28 @@ class Exl3LinearMethod(LinearMethodBase):
             )
         if x.shape[-1] < packed_k:
             x = torch.nn.functional.pad(x, (0, packed_k - x.shape[-1]))
-        output = _exl3_gemm(
-            x,
+        has_mcg = shard_id in layer.mcg.exl3_tensors
+        has_mul1 = shard_id in layer.mul1.exl3_tensors
+        if _sparkinfer_trellis_k6_supported(
             trellis,
-            layer.suh.exl3_tensors[shard_id],
-            layer.svh.exl3_tensors[shard_id],
-            shard_id in layer.mcg.exl3_tensors,
-            shard_id in layer.mul1.exl3_tensors,
-        )
+            has_mcg=has_mcg,
+            has_mul1=has_mul1,
+        ):
+            output = _sparkinfer_trellis_linear(
+                x,
+                trellis,
+                layer.suh.exl3_tensors[shard_id],
+                layer.svh.exl3_tensors[shard_id],
+            )
+        else:
+            output = _exl3_gemm(
+                x,
+                trellis,
+                layer.suh.exl3_tensors[shard_id],
+                layer.svh.exl3_tensors[shard_id],
+                has_mcg,
+                has_mul1,
+            )
         logical_n = Exl3LinearMethod._output_shard_size(layer, shard_id)
         if output.shape[-1] < logical_n:
             raise ValueError(

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -396,6 +396,7 @@ def _load_b12x_mixed_trellis() -> Any:
         max_packed_route_slots=host.max_packed_route_slots,
         prepare_weights=prepare.prepare_trellis256_moe_weights,
         run_mixed_trellis=module.run_mixed_trellis,
+        warmup_mixed_trellis_route_pack=module.warmup_mixed_trellis_route_pack,
     )
     _B12X_MIXED_TRELLIS_API = api
     return api
@@ -2838,6 +2839,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         )
         runtime = _MIXED_TRELLIS_RUNTIMES.get(key)
         if runtime is not None:
+            mixed["runtime"] = runtime
             return runtime
         if torch.cuda.is_current_stream_capturing():
             raise RuntimeError(
@@ -2916,6 +2918,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             "prefill_capacity": prefill_capacity,
         }
         _MIXED_TRELLIS_RUNTIMES[key] = runtime
+        mixed["runtime"] = runtime
         decode_bytes = _unique_tensor_storage_bytes(decode["buffers"])
         prefill_bytes = (
             0 if prefill is None else _unique_tensor_storage_bytes(prefill["buffers"])
@@ -3504,4 +3507,57 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         return output[..., :logical_n]
 
 
-__all__ = ["Exl3Config", "Exl3LinearMethod", "Exl3MoEMethod"]
+def warmup_exl3_mixed_trellis_route_pack(model: torch.nn.Module) -> int:
+    """Materialize mixed-Trellis route-pack modules before KV sizing.
+
+    The first profile pass creates every layer's immutable mixed-Trellis
+    runtime. Route packing itself has power-of-two capacity specializations,
+    however, so profiling only the maximum batch leaves smaller decode,
+    speculative, and final-prefill-chunk modules lazy. Delegate enumeration to
+    B12X while those persistent CUDA allocations can still be measured by the
+    worker's second profile pass.
+    """
+    warmed = 0
+    seen_layers: set[int] = set()
+    for module in model.modules():
+        routed_experts = getattr(module, "routed_experts", module)
+        mixed = getattr(routed_experts, "exl3_mixed_trellis", None)
+        if not isinstance(mixed, dict) or id(routed_experts) in seen_layers:
+            continue
+        seen_layers.add(id(routed_experts))
+
+        runtime = mixed.get("runtime")
+        if runtime is None:
+            layer_name = getattr(routed_experts, "layer_name", "<unknown>")
+            raise RuntimeError(
+                "mixed-bitrate EXL3 route-pack warmup found no runtime for "
+                f"{layer_name}; the eager profile pass must plan the runtime "
+                "before kernel warmup"
+            )
+        api = runtime["mixed_api"]
+        warmup = getattr(api, "warmup_mixed_trellis_route_pack", None)
+        if not callable(warmup):
+            raise RuntimeError(
+                "mixed-bitrate EXL3 route-pack warmup requires a matching B12X build"
+            )
+
+        for state_name in ("decode", "prefill"):
+            state = runtime.get(state_name)
+            if state is None:
+                continue
+            warmed += int(
+                warmup(
+                    state["launch"],
+                    state["buffers"],
+                    expert_map=mixed["global_to_combined"],
+                )
+            )
+    return warmed
+
+
+__all__ = [
+    "Exl3Config",
+    "Exl3LinearMethod",
+    "Exl3MoEMethod",
+    "warmup_exl3_mixed_trellis_route_pack",
+]

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -1799,12 +1799,13 @@ class Exl3MoEMethod(FusedMoEMethodBase):
     def _mixed_trellis_prefill_tile_config(
         hidden_size: int, intermediate_size: int
     ):
-        if hidden_size % 128 or intermediate_size % 128:
-            raise ValueError(
-                "mixed rank-sliced EXL3 prefill requires hidden and "
-                "intermediate dimensions divisible by 128"
-            )
-        return (128, 64, 64, 128)
+        # Route packing stays block-64, while SparkInfer's mixed-kernel ABI v2
+        # executes FC2 as arithmetic-equivalent 8-row subtiles.  Reuse the
+        # checkpoint's original one-grid tile geometry so prefill has the same
+        # reduction order as the stock-r16 quality reference.
+        return Exl3MoEMethod._mixed_trellis_tile_config(
+            hidden_size, intermediate_size
+        )
 
     def _prepare_mixed_rank_sliced_weights(self, layer: RoutedExperts) -> None:
         mixed_api = _load_b12x_mixed_trellis()

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -90,18 +90,16 @@ _HADAMARD_BLOCK = 128
 _EXL3_EXT: Any | None = None
 _B12X_FUSED_MOE_API: Any | None = None
 _B12X_MIXED_TRELLIS_API: Any | None = None
-_SPARKINFER_FUSED_MOE_API: Any | None = None
-_SPARKINFER_MIXED_TRELLIS_API: Any | None = None
-_SPARKINFER_TRELLIS_LINEAR_API: Any | None = None
+_B12X_TRELLIS_LINEAR_API: Any | None = None
 _EXL3_ONLINE_QUANTIZER: Any | None = None
 _EXL3_ONLINE_WARMED_SIGNATURES: set[tuple[int, int, int, int]] = set()
-_SPARKINFER_TRELLIS_WARMED_DEVICES: set[int] = set()
+_B12X_TRELLIS_WARMED_DEVICES: set[int] = set()
 # The dense W4A16 kernel caps its temporary accumulation arena at
 # SMs * 4 * block_m * 256 fp32 elements.  SM120/SM121 devices supported by
 # this path have at most 192 SMs, and block_m never exceeds 64.  Keeping this
 # architecture bound here lets Inductor own and reuse the temporary across
 # layers instead of allocating inside CUDA graph capture.
-_SPARKINFER_TRELLIS_C_TMP_CAP = 192 * 4 * 64 * 256
+_B12X_TRELLIS_C_TMP_CAP = 192 * 4 * 64 * 256
 _RANK_SLICED_RUNTIMES: dict[tuple[Any, ...], dict[str, Any]] = {}
 _MIXED_TRELLIS_RUNTIMES: dict[tuple[Any, ...], dict[str, Any]] = {}
 _NEXT_RUNTIME_SCOPE_ID = 0
@@ -129,7 +127,7 @@ def _resolve_mixed_trellis_prefill_block_m(
 ) -> int:
     """Select the qualified GLM-5.2 mixed-K prefill route block.
 
-    SparkInfer's paired-M8 FC2 schedule makes block-32 numerically equivalent
+    B12X's paired-M8 FC2 schedule makes block-32 numerically equivalent
     to the established block-64 path while reducing scratch and improving the
     dominant large-prefill kernel on SM12x. The allowlist contains only tier
     partitions qualified end-to-end on GLM-5.2 checkpoints. Explicit operator
@@ -403,20 +401,20 @@ def _load_b12x_mixed_trellis() -> Any:
     return api
 
 
-def _load_sparkinfer_trellis_linear() -> Any:
+def _load_b12x_trellis_linear() -> Any:
     """Resolve the native dense Trellis API lazily."""
 
-    global _SPARKINFER_TRELLIS_LINEAR_API
-    if _SPARKINFER_TRELLIS_LINEAR_API is not None:
-        return _SPARKINFER_TRELLIS_LINEAR_API
+    global _B12X_TRELLIS_LINEAR_API
+    if _B12X_TRELLIS_LINEAR_API is not None:
+        return _B12X_TRELLIS_LINEAR_API
     try:
-        from sparkinfer.gemm import trellis_linear
+        from b12x.gemm import trellis_linear
     except Exception as exc:
         raise RuntimeError(
-            "Online EXL3 prefill requires sparkinfer.gemm.trellis_linear. "
-            "Install a matching SparkInfer build."
+            "Online EXL3 prefill requires b12x.gemm.trellis_linear. "
+            "Install a matching B12X build."
         ) from exc
-    _SPARKINFER_TRELLIS_LINEAR_API = trellis_linear
+    _B12X_TRELLIS_LINEAR_API = trellis_linear
     return trellis_linear
 
 
@@ -535,7 +533,7 @@ def _exl3_gemm_fake(
     )
 
 
-def _sparkinfer_trellis_weight(
+def _b12x_trellis_weight(
     trellis: torch.Tensor,
     suh: torch.Tensor,
     svh: torch.Tensor,
@@ -543,14 +541,14 @@ def _sparkinfer_trellis_weight(
 ) -> Any:
     """Prepare each online weight before capture and retain its native views."""
 
-    api = _load_sparkinfer_trellis_linear()
+    api = _load_b12x_trellis_linear()
     # Keep prepared views on the owning tensor. A process-global pointer-keyed
     # cache can alias after allocator address reuse and retains released models
     # forever. This small reference cycle is collected with the tensor.
-    cache = getattr(trellis, "_vllm_sparkinfer_prepared_weights", None)
+    cache = getattr(trellis, "_vllm_b12x_prepared_weights", None)
     if cache is None:
         cache = {}
-        trellis._vllm_sparkinfer_prepared_weights = cache
+        trellis._vllm_b12x_prepared_weights = cache
     key = (id(suh), id(svh), dtype)
     weight = cache.get(key)
     if weight is None:
@@ -565,7 +563,7 @@ def _sparkinfer_trellis_weight(
     return weight
 
 
-def _sparkinfer_trellis_k6_supported(
+def _b12x_trellis_k6_supported(
     trellis: torch.Tensor,
     *,
     has_mcg: bool,
@@ -584,7 +582,7 @@ def _sparkinfer_trellis_k6_supported(
     )
 
 
-def _warm_sparkinfer_trellis_device(
+def _warm_b12x_trellis_device(
     trellis: torch.Tensor,
     suh: torch.Tensor,
     svh: torch.Tensor,
@@ -594,19 +592,19 @@ def _warm_sparkinfer_trellis_device(
     device_index = trellis.device.index
     if device_index is None:
         device_index = torch.cuda.current_device()
-    if device_index in _SPARKINFER_TRELLIS_WARMED_DEVICES:
+    if device_index in _B12X_TRELLIS_WARMED_DEVICES:
         return
     source = torch.zeros(
         (1, int(trellis.shape[0]) * 16),
         dtype=torch.float16,
         device=trellis.device,
     )
-    _sparkinfer_trellis_linear(source, trellis, suh, svh)
+    _b12x_trellis_linear(source, trellis, suh, svh)
     torch.cuda.synchronize(trellis.device)
-    _SPARKINFER_TRELLIS_WARMED_DEVICES.add(device_index)
+    _B12X_TRELLIS_WARMED_DEVICES.add(device_index)
 
 
-def _sparkinfer_trellis_c_tmp_elements(rows: int, columns: int) -> int:
+def _b12x_trellis_c_tmp_elements(rows: int, columns: int) -> int:
     """Return graph-safe dense-W4A16 scratch capacity for one static shape."""
 
     rows = int(rows)
@@ -618,15 +616,15 @@ def _sparkinfer_trellis_c_tmp_elements(rows: int, columns: int) -> int:
         ((rows + 47) // 48) * 48,
         ((rows + 63) // 64) * 64,
     )
-    return min(columns * padded_rows, _SPARKINFER_TRELLIS_C_TMP_CAP)
+    return min(columns * padded_rows, _B12X_TRELLIS_C_TMP_CAP)
 
 
 @torch.library.custom_op(
-    "vllm::sparkinfer_trellis_linear_out",
+    "vllm::b12x_trellis_linear_out",
     mutates_args=("output", "gemm_output", "c_tmp", "rotated_f16"),
     device_types="cuda",
 )
-def _sparkinfer_trellis_linear_out(
+def _b12x_trellis_linear_out(
     x: torch.Tensor,
     trellis: torch.Tensor,
     suh: torch.Tensor,
@@ -638,8 +636,8 @@ def _sparkinfer_trellis_linear_out(
 ) -> None:
     """Execute dense Trellis into graph-owned output and scratch tensors."""
 
-    api = _load_sparkinfer_trellis_linear()
-    weight = _sparkinfer_trellis_weight(trellis, suh, svh, x.dtype)
+    api = _load_b12x_trellis_linear()
+    weight = _b12x_trellis_weight(trellis, suh, svh, x.dtype)
     api.run(
         x,
         weight,
@@ -650,8 +648,8 @@ def _sparkinfer_trellis_linear_out(
     )
 
 
-@_sparkinfer_trellis_linear_out.register_fake
-def _sparkinfer_trellis_linear_out_fake(
+@_b12x_trellis_linear_out.register_fake
+def _b12x_trellis_linear_out_fake(
     x: torch.Tensor,
     trellis: torch.Tensor,
     suh: torch.Tensor,
@@ -664,25 +662,25 @@ def _sparkinfer_trellis_linear_out_fake(
     del x, trellis, suh, svh, output, gemm_output, c_tmp, rotated_f16
 
 
-def _sparkinfer_trellis_linear(
+def _b12x_trellis_linear(
     x: torch.Tensor,
     trellis: torch.Tensor,
     suh: torch.Tensor,
     svh: torch.Tensor,
 ) -> torch.Tensor:
-    """Run every online-K6 batch through SparkInfer with explicit storage."""
+    """Run every online-K6 batch through B12X with explicit storage."""
 
     output = torch.empty(
         (x.shape[0], trellis.shape[1] * 16), dtype=x.dtype, device=x.device
     )
     gemm_output = torch.empty_like(output)
     c_tmp = torch.empty(
-        (_sparkinfer_trellis_c_tmp_elements(x.shape[0], output.shape[1]),),
+        (_b12x_trellis_c_tmp_elements(x.shape[0], output.shape[1]),),
         dtype=torch.float32,
         device=x.device,
     )
     rotated_f16 = torch.empty_like(x)
-    _sparkinfer_trellis_linear_out(
+    _b12x_trellis_linear_out(
         x,
         trellis,
         suh,
@@ -1427,7 +1425,7 @@ class Exl3OnlineLinearMethod(_Fp8OnlineLinearBase):
 
     def _warm_decode_shapes(self, layer: torch.nn.Module) -> None:
         device = layer.exl3_online_trellis_weight.device
-        _sparkinfer_trellis_weight(
+        _b12x_trellis_weight(
             layer.exl3_online_trellis_weight,
             layer.exl3_online_suh,
             layer.exl3_online_svh,
@@ -1450,7 +1448,7 @@ class Exl3OnlineLinearMethod(_Fp8OnlineLinearBase):
                 dtype=torch.float16,
                 device=device,
             )
-            _sparkinfer_trellis_linear(
+            _b12x_trellis_linear(
                 source,
                 layer.exl3_online_trellis_weight,
                 layer.exl3_online_suh,
@@ -1547,7 +1545,7 @@ class Exl3OnlineLinearMethod(_Fp8OnlineLinearBase):
         original_shape = x.shape[:-1]
         original_dtype = x.dtype
         x_2d = x.reshape(-1, x.shape[-1]).to(torch.float16).contiguous()
-        output = _sparkinfer_trellis_linear(
+        output = _b12x_trellis_linear(
             x_2d,
             layer.exl3_online_trellis_weight,
             layer.exl3_online_suh,
@@ -1666,7 +1664,7 @@ class Exl3LinearMethod(LinearMethodBase):
 
         for shard_id in layer.exl3_shard_ids:
             trellis = layer.trellis.exl3_tensors[shard_id]
-            if not _sparkinfer_trellis_k6_supported(
+            if not _b12x_trellis_k6_supported(
                 trellis,
                 has_mcg=shard_id in layer.mcg.exl3_tensors,
                 has_mul1=shard_id in layer.mul1.exl3_tensors,
@@ -1674,13 +1672,13 @@ class Exl3LinearMethod(LinearMethodBase):
                 continue
             suh = layer.suh.exl3_tensors[shard_id]
             svh = layer.svh.exl3_tensors[shard_id]
-            _sparkinfer_trellis_weight(
+            _b12x_trellis_weight(
                 trellis,
                 suh,
                 svh,
                 torch.float16,
             )
-            _warm_sparkinfer_trellis_device(trellis, suh, svh)
+            _warm_b12x_trellis_device(trellis, suh, svh)
 
     def apply(
         self,
@@ -1937,12 +1935,12 @@ class Exl3LinearMethod(LinearMethodBase):
             x = torch.nn.functional.pad(x, (0, packed_k - x.shape[-1]))
         has_mcg = shard_id in layer.mcg.exl3_tensors
         has_mul1 = shard_id in layer.mul1.exl3_tensors
-        if _sparkinfer_trellis_k6_supported(
+        if _b12x_trellis_k6_supported(
             trellis,
             has_mcg=has_mcg,
             has_mul1=has_mul1,
         ):
-            output = _sparkinfer_trellis_linear(
+            output = _b12x_trellis_linear(
                 x,
                 trellis,
                 layer.suh.exl3_tensors[shard_id],
@@ -2416,7 +2414,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
 
     @staticmethod
     def _mixed_trellis_prefill_tile_config(hidden_size: int, intermediate_size: int):
-        # Route packing stays block-64, while SparkInfer's mixed-kernel ABI v2
+        # Route packing stays block-64, while B12X's mixed-kernel ABI v2
         # executes FC2 as arithmetic-equivalent 8-row subtiles.  Reuse the
         # checkpoint's original one-grid tile geometry so prefill has the same
         # reduction order as the stock-r16 quality reference.

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -83,6 +83,41 @@ _RANK_SLICED_RUNTIMES: dict[tuple[Any, ...], dict[str, Any]] = {}
 _MIXED_TRELLIS_RUNTIMES: dict[tuple[Any, ...], dict[str, Any]] = {}
 _NEXT_RUNTIME_SCOPE_ID = 0
 _MIXED_TRELLIS_ROUTE_BLOCK_SIZE = 8
+_GLM52_MIXED_TRELLIS_PREFILL_BLOCK_SIZE = 32
+
+
+def _resolve_mixed_trellis_prefill_block_m(
+    *,
+    configured_block_m: int,
+    explicit_override: bool,
+    hidden_size: int,
+    intermediate_size: int,
+    tier_signature: tuple[tuple[int, int], ...],
+    topk: int,
+    device_major: int,
+    prefill_tile_config: tuple[int, int, int, int],
+) -> int:
+    """Select the qualified GLM-5.2 mixed-K prefill route block.
+
+    SparkInfer's paired-M8 FC2 schedule makes block-32 numerically equivalent
+    to the established block-64 path while reducing scratch and improving the
+    dominant large-prefill kernel on SM12x. Explicit operator tuning and every
+    other model geometry retain the configured value.
+    """
+
+    qualified = (
+        not explicit_override
+        and int(device_major) == 12
+        and int(hidden_size) == 6144
+        and int(intermediate_size) == 512
+        and tier_signature == ((3, 192), (4, 64))
+        and int(topk) == 8
+        and tuple(int(value) for value in prefill_tile_config)
+        == (128, 128, 32, 512)
+    )
+    if qualified:
+        return _GLM52_MIXED_TRELLIS_PREFILL_BLOCK_SIZE
+    return int(configured_block_m)
 
 
 # Smallest m the Trellis kernel path can service, and therefore the smallest
@@ -1934,13 +1969,24 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 else combined_down_svh[tier_slice]
             )
 
-            def prepare_tier(tile_config: tuple[int, int, int, int]):
+            def prepare_tier(
+                tile_config: tuple[int, int, int, int],
+                *,
+                w13: torch.Tensor = w13,
+                w2: torch.Tensor = w2,
+                expert_count: int = len(expert_ids),
+                bits: int = bits,
+                tier_gate_suh: torch.Tensor = tier_gate_suh,
+                tier_up_suh: torch.Tensor = tier_up_suh,
+                intermediate_rotations: torch.Tensor = intermediate_rotations,
+                tier_down_svh: torch.Tensor = tier_down_svh,
+            ):
                 return mixed_api.prepare_weights(
                     w13=w13,
                     w2=w2,
                     hidden_size=hidden_size,
                     intermediate_size=intermediate_size,
-                    num_experts=len(expert_ids),
+                    num_experts=expert_count,
                     activation=layer.activation.value,
                     fc1_tile_n=tile_config[1],
                     fc2_tile_n=tile_config[3],
@@ -2121,6 +2167,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         max_decode_m = _positive_env_int("VLLM_EXL3_TRELLIS_MAX_M", 32)
         max_batched_tokens = int(layer.exl3_max_num_batched_tokens)
         prefill_capacity = _resolve_prefill_capacity(max_batched_tokens)
+        prefill_block_raw = os.environ.get("VLLM_EXL3_PREFILL_BLOCK_M")
         prefill_block_m = _positive_env_int("VLLM_EXL3_PREFILL_BLOCK_M", 64)
         if max_decode_m > max_batched_tokens:
             max_decode_m = max_batched_tokens
@@ -2128,6 +2175,33 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         tier_signature = tuple(
             (int(bits), len(ids))
             for bits, ids in zip(mixed["tier_bits"], mixed["tier_ids"], strict=True)
+        )
+        props = torch.cuda.get_device_properties(x.device)
+        prefill_block_m = _resolve_mixed_trellis_prefill_block_m(
+            configured_block_m=prefill_block_m,
+            explicit_override=bool(
+                prefill_block_raw is not None and prefill_block_raw.strip()
+            ),
+            hidden_size=int(layer.exl3_hidden_size),
+            intermediate_size=int(layer.exl3_intermediate_size_per_partition),
+            tier_signature=tier_signature,
+            topk=topk,
+            device_major=int(getattr(props, "major", 0)),
+            prefill_tile_config=mixed["prefill_tile_config"],
+        )
+        logger.info_once(
+            "EXL3 mixed Trellis prefill block policy: selected=%d "
+            "configured=%d explicit=%s shape=%dx%d tiers=%s topk=%d "
+            "sm=%d tile=%s",
+            prefill_block_m,
+            _positive_env_int("VLLM_EXL3_PREFILL_BLOCK_M", 64),
+            bool(prefill_block_raw is not None and prefill_block_raw.strip()),
+            int(layer.exl3_hidden_size),
+            int(layer.exl3_intermediate_size_per_partition),
+            tier_signature,
+            topk,
+            int(getattr(props, "major", 0)),
+            mixed["prefill_tile_config"],
         )
         key = (
             _runtime_owner_token(self.quant_config, layer),
@@ -2161,7 +2235,6 @@ class Exl3MoEMethod(FusedMoEMethodBase):
 
         mixed_api = _load_b12x_mixed_trellis()
         device = x.device
-        props = torch.cuda.get_device_properties(device)
         total_experts = sum(experts for _, experts in tier_signature)
 
         def make_state(

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -293,6 +293,21 @@ def _positive_env_int(name: str, default: int) -> int:
     return value
 
 
+def _resolve_prefill_capacity(max_batched_tokens: int) -> int:
+    """Resolve the optional EXL3 arena bound within the scheduler contract."""
+
+    prefill_capacity = _positive_env_int(
+        "VLLM_EXL3_PREFILL_CAPACITY", max_batched_tokens
+    )
+    if prefill_capacity > max_batched_tokens:
+        raise ValueError(
+            "VLLM_EXL3_PREFILL_CAPACITY cannot exceed "
+            "max_num_batched_tokens: "
+            f"capacity={prefill_capacity}, max={max_batched_tokens}"
+        )
+    return prefill_capacity
+
+
 @torch.library.custom_op(
     "vllm::exl3_gemm",
     mutates_args=(),
@@ -1904,6 +1919,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         mixed = layer.exl3_mixed_trellis
         max_decode_m = _positive_env_int("VLLM_EXL3_TRELLIS_MAX_M", 32)
         max_batched_tokens = int(layer.exl3_max_num_batched_tokens)
+        prefill_capacity = _resolve_prefill_capacity(max_batched_tokens)
         prefill_block_m = _positive_env_int("VLLM_EXL3_PREFILL_BLOCK_M", 64)
         if max_decode_m > max_batched_tokens:
             max_decode_m = max_batched_tokens
@@ -1923,6 +1939,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             topk,
             max_decode_m,
             max_batched_tokens,
+            prefill_capacity,
             mixed["tile_config"],
             mixed["serial_tile_config"],
             prefill_block_m,
@@ -1991,7 +2008,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             scratch_bytes = 0
             for tier in mixed["serial_tiers"]:
                 caps = fused_api.Caps(
-                    max_tokens=max_batched_tokens,
+                    max_tokens=prefill_capacity,
                     num_topk=topk,
                     route_num_experts=total_experts,
                     device=device,
@@ -2008,7 +2025,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 scratch_bytes = max(scratch_bytes, size)
             prefill_arena = torch.empty(scratch_bytes, dtype=torch.uint8, device=device)
             prefill_accum = torch.empty(
-                (max_batched_tokens, int(layer.exl3_hidden_size)),
+                (prefill_capacity, int(layer.exl3_hidden_size)),
                 dtype=torch.float32,
                 device=device,
             )
@@ -2021,6 +2038,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             "prefill_accum": prefill_accum,
             "max_decode_m": max_decode_m,
             "max_batched_tokens": max_batched_tokens,
+            "prefill_capacity": prefill_capacity,
         }
         _MIXED_TRELLIS_RUNTIMES[key] = runtime
         decode_bytes = _unique_tensor_storage_bytes(decode["buffers"])
@@ -2031,9 +2049,10 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         )
         logger.info_once(
             "EXL3 mixed Trellis runtime planned: tiers=%s one-grid decode=%d "
-            "serial prefill=%d block_m=%d buffers=%.1f+%.1f MiB",
+            "serial prefill=%d/%d block_m=%d buffers=%.1f+%.1f MiB",
             tier_signature,
             max_decode_m,
+            prefill_capacity,
             max_batched_tokens,
             prefill_block_m,
             decode_bytes / (1 << 20),
@@ -2079,29 +2098,51 @@ class Exl3MoEMethod(FusedMoEMethodBase):
 
         if runtime["prefill_arena"] is None or runtime["prefill_accum"] is None:
             raise RuntimeError("mixed-K EXL3 serial prefill plan is unavailable")
-        accum = runtime["prefill_accum"][:m]
-        first = True
-        for plan, tier in zip(
-            runtime["prefill_plans"], mixed["serial_tiers"], strict=True
-        ):
-            binding = runtime["fused_api"].bind(
-                plan,
-                scratch=_scratch_view(
-                    runtime["prefill_arena"], plan.scratch_specs()[0]
-                ),
-                a=x,
-                experts=tier["weights"],
-                topk_weights=topk_weights,
-                topk_ids=topk_ids,
-                route_expert_map=tier["route_expert_map"],
-                output_expert_map=tier["route_expert_map"],
-                output=accum if first else None,
+        prefill_capacity = int(runtime["prefill_capacity"])
+
+        def run_serial_slice(
+            slice_x: torch.Tensor,
+            slice_weights: torch.Tensor,
+            slice_ids: torch.Tensor,
+        ) -> torch.Tensor:
+            slice_m = int(slice_x.shape[0])
+            accum = runtime["prefill_accum"][:slice_m]
+            first = True
+            for plan, tier in zip(
+                runtime["prefill_plans"], mixed["serial_tiers"], strict=True
+            ):
+                binding = runtime["fused_api"].bind(
+                    plan,
+                    scratch=_scratch_view(
+                        runtime["prefill_arena"], plan.scratch_specs()[0]
+                    ),
+                    a=slice_x,
+                    experts=tier["weights"],
+                    topk_weights=slice_weights,
+                    topk_ids=slice_ids,
+                    route_expert_map=tier["route_expert_map"],
+                    output_expert_map=tier["route_expert_map"],
+                    output=accum if first else None,
+                )
+                tier_output = runtime["fused_api"].run(binding=binding)
+                if not first:
+                    accum.add_(tier_output)
+                first = False
+            return accum.to(slice_x.dtype)
+
+        if m <= prefill_capacity:
+            return run_serial_slice(x, topk_weights, topk_ids)
+
+        output = torch.empty_like(x)
+        for start in range(0, m, prefill_capacity):
+            stop = min(start + prefill_capacity, m)
+            slice_output = run_serial_slice(
+                x[start:stop],
+                topk_weights[start:stop],
+                topk_ids[start:stop],
             )
-            output = runtime["fused_api"].run(binding=binding)
-            if not first:
-                accum.add_(output)
-            first = False
-        return accum.to(x.dtype)
+            output[start:stop].copy_(slice_output)
+        return output
 
     def _rank_sliced_runtime(
         self,
@@ -2133,12 +2174,19 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             raise ValueError(
                 "VLLM_EXL3_TRELLIS_MIN_M cannot exceed VLLM_EXL3_TRELLIS_MAX_M"
             )
-        # Batch-INVARIANT capacity. Including x.shape[0] here made the runtime
-        # cache key depend on the live batch, so any m above the planned capacity
-        # produced a cache MISS -- silently planning a fresh ~1 GiB arena mid-serve
-        # and making the capacity guard in _apply_rank_sliced unreachable. The
-        # planned capacity is a property of the layer, not of one forward pass.
+        # Both capacities are batch-invariant runtime properties. The scheduler
+        # bound remains fail-closed while a smaller opt-in Trellis capacity is
+        # handled by slicing at dispatch.
         max_batched_tokens = int(layer.exl3_max_num_batched_tokens)
+        prefill_capacity = _positive_env_int(
+            "VLLM_EXL3_PREFILL_CAPACITY", max_batched_tokens
+        )
+        if prefill_capacity > max_batched_tokens:
+            raise ValueError(
+                "VLLM_EXL3_PREFILL_CAPACITY cannot exceed "
+                "max_num_batched_tokens: "
+                f"capacity={prefill_capacity}, max={max_batched_tokens}"
+            )
         prefill_plan_enabled = prefill_trellis and max_batched_tokens > max_trellis_m
         parity_rows = (
             min(chunk, max_batched_tokens)
@@ -2173,6 +2221,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             prefill_trellis,
             prefill_block_m,
             layer.exl3_trellis_tile_config,
+            prefill_capacity,
         )
         runtime = _RANK_SLICED_RUNTIMES.get(key)
         if runtime is not None:
@@ -2216,7 +2265,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         prefill_scratch = None
         if prefill_plan_enabled:
             prefill_plan, prefill_scratch = _plan_with_scratch(
-                max_batched_tokens, prefill_block_m
+                prefill_capacity, prefill_block_m
             )
 
         ext = _load_exl3_ext()
@@ -2247,6 +2296,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             "min_trellis_m": min_trellis_m,
             "max_trellis_m": max_trellis_m,
             "max_batched_tokens": max_batched_tokens,
+            "prefill_capacity": prefill_capacity,
             "parity_rows": parity_rows,
             "topk": topk,
             "chunk": chunk,
@@ -2319,12 +2369,13 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         )
         logger.info_once(
             "EXL3 rank-sliced runtime planned: Trellis m=%d..%d block_m=%d, "
-            "prefill %s capacity=%d chunk=%d topk=%d",
+            "prefill %s scheduler_capacity=%d chunk=%d topk=%d",
             min_trellis_m,
             max_trellis_m,
             block_m,
             (
-                f"trellis block_m={prefill_block_m} arena={prefill_arena_mib:.1f}MiB"
+                f"trellis block_m={prefill_block_m} "
+                f"capacity={prefill_capacity} arena={prefill_arena_mib:.1f}MiB"
                 if prefill_plan is not None
                 else "parity"
             ),
@@ -2368,16 +2419,33 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                     "EXL3 batch exceeds its planned capacity: "
                     f"m={m}, capacity={runtime['max_batched_tokens']}"
                 )
-            binding = runtime["api"].bind(
-                runtime["prefill_plan"],
-                scratch=runtime["prefill_scratch"],
-                a=x,
-                experts=layer.exl3_trellis_weights,
-                topk_weights=topk_weights,
-                topk_ids=topk_ids,
-            )
-            output = runtime["api"].run(binding=binding)
-            return output.to(x.dtype)
+            prefill_capacity = int(runtime["prefill_capacity"])
+            if m <= prefill_capacity:
+                binding = runtime["api"].bind(
+                    runtime["prefill_plan"],
+                    scratch=runtime["prefill_scratch"],
+                    a=x,
+                    experts=layer.exl3_trellis_weights,
+                    topk_weights=topk_weights,
+                    topk_ids=topk_ids,
+                )
+                output = runtime["api"].run(binding=binding)
+                return output.to(x.dtype)
+
+            output = torch.empty_like(x)
+            for start in range(0, m, prefill_capacity):
+                stop = min(start + prefill_capacity, m)
+                binding = runtime["api"].bind(
+                    runtime["prefill_plan"],
+                    scratch=runtime["prefill_scratch"],
+                    a=x[start:stop],
+                    experts=layer.exl3_trellis_weights,
+                    topk_weights=topk_weights[start:stop],
+                    topk_ids=topk_ids[start:stop],
+                )
+                slice_output = runtime["api"].run(binding=binding)
+                output[start:stop].copy_(slice_output)
+            return output
 
         if torch.cuda.is_current_stream_capturing():
             raise RuntimeError(

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -105,9 +105,10 @@ _B12X_TRELLIS_WARMED_DEVICES: set[int] = set()
 _B12X_TRELLIS_C_TMP_CAP = 192 * 4 * 64 * 256
 _RANK_SLICED_RUNTIMES: dict[tuple[Any, ...], dict[str, Any]] = {}
 _MIXED_TRELLIS_RUNTIMES: dict[tuple[Any, ...], dict[str, Any]] = {}
-# glm52-r7-sparkinfer: keyed on launch geometry, shared across layers.
+# Mixed-bitrate scratch buffers are keyed by launch geometry and shared across
+# layers owned by the same model or draft runner.
 _MIXED_TRELLIS_BUFFERS: dict[tuple[Any, ...], Any] = {}
-# glm52-r7-cudagraph: fused projection-wise mixed-K path
+# The projection-wise mixed-bitrate fallback owns graph-stable runtime storage.
 _R7_GRAPH_RUNTIMES: dict[tuple[Any, ...], dict[str, Any]] = {}
 _NEXT_RUNTIME_SCOPE_ID = 0
 _MIXED_TRELLIS_ROUTE_BLOCK_SIZE = 8
@@ -516,24 +517,20 @@ def _positive_env_int(name: str, default: int) -> int:
 
 
 def _resolve_r7_a1_min_rows(ext: Any) -> int:
-    """Rows at or above which the R7 MoE uses the A1 re-tile entry.
+    """Resolve the row threshold for ``exl3_moe_r7_fused_retile``.
 
-    Returns 0 when A1 is unavailable or disabled, which keeps every launch on
-    exl3_moe_r7_fused. glm52-r7-a1-mixed.
+    Zero disables the retile entry and keeps every launch on
+    ``exl3_moe_r7_fused``.
     """
 
     if not hasattr(ext, "exl3_moe_r7_fused_retile"):
         return 0
     raw = os.environ.get("VLLM_EXL3_R7_A1_MIN_ROWS")
     if raw is None:
-        # MEASURED OFF. At min_rows=33 (prefill only) A1 cost 14.7% prefill and
-        # 12.9-26.4% decode against an otherwise identical control on the same
-        # image (see A1_MEASUREMENT.md). The decode half of that should not be
-        # reachable at all, which is itself unexplained -- the leading suspect
-        # is the 100,352 B MOE_A1_SMEM_MAX_BYTES opt-in leaving almost no L1 on
-        # a 128 KiB unified SM, and the carve-out reconfiguration bleeding into
-        # neighbouring launches. Set to 33 to re-enable prefill-only A1, or 1 to
-        # take it everywhere; do not change this default without a control run.
+        # Disabled by default. On RTX PRO 6000 Blackwell, a threshold of 33
+        # reduced prefill throughput by 14.7% and decode throughput by
+        # 12.9-26.4% under the conditions recorded in A1_MEASUREMENT.md.
+        # VLLM_EXL3_R7_A1_MIN_ROWS explicitly enables the retile entry.
         return 0
     value = int(raw)
     if value < 0:
@@ -542,7 +539,7 @@ def _resolve_r7_a1_min_rows(ext: Any) -> int:
 
 
 def _r7_fused_layer_budget():
-    """Max layers to convert, or None for no cap. glm52-r7-sparkinfer."""
+    """Return the mixed-bitrate B12X layer limit, or ``None`` when uncapped."""
 
     raw = os.environ.get("VLLM_EXL3_R7_FUSED_LAYERS")
     if raw is None or raw == "":
@@ -555,30 +552,26 @@ _R7_FC1_BALLAST: dict[tuple[Any, ...], torch.Tensor] = {}
 
 
 def _r7_fc1_ballast(slots: int, like: torch.Tensor) -> torch.Tensor:
-    """Shared, never-read w2 stand-in for the FC1 prepare. glm52-r7-sparkinfer.
+    """Return the shared FC2 placeholder required while preparing FC1.
 
-    Keyed on the tail shape only. Keying on `slots` as well allocated a fresh
-    buffer for nearly every layer -- slots is the per-layer max(gate, up) count
-    -- and retained all of them, which is where the ~0.35 GiB/layer of load
-    growth came from. One buffer per (tail shape, dtype, device) is sized at the
-    maximum expert count and narrowed; narrowing the leading dimension of a
-    contiguous tensor stays contiguous, which is all prepare validates.
+    ``prepare_weights`` validates this tensor but does not read it. The shared
+    pool is keyed by tail shape, dtype, and device, then narrowed to ``slots``;
+    including the layer-specific slot count in the key retains about
+    0.35 GiB of redundant storage per distinct layer geometry.
     """
 
-    return _r7_ballast_view(int(slots), like)  # glm52-r7-gate-tight: shared pool
+    return _r7_ballast_view(int(slots), like)
 
 
 _R7_W13_BALLAST: dict[tuple[Any, ...], torch.Tensor] = {}
 
 
 def _r7_w13_ballast(slots: int, like: torch.Tensor) -> torch.Tensor:
-    """Shared never-read [2, slots, ...] w13 stand-in for prepare. gate-tight.
+    """Return the shared ``[2, slots, ...]`` FC1 preparation placeholder.
 
-    prepare_weights requires the projection-major [2,E,...] w13 shape but only
-    validates it and returns a view this loader discards (rebinding w13 to the
-    tight [gate|up] buffer). So one zero buffer, sized to the max 2*slots and
-    reshaped from a contiguous flat prefix, serves every layer -- avoiding the
-    padded (2,max) allocation the earlier code kept resident (~0.6 GiB/layer).
+    ``prepare_weights`` requires a projection-major ``[2, E, ...]`` tensor but
+    only validates it. The loader binds the returned tier to a projection-tight
+    ``[gate | up]`` buffer, so every layer can alias one zero-filled pool.
     """
 
     plane = tuple(like.shape[1:])
@@ -591,18 +584,12 @@ _R7_BALLAST_POOL: dict[Any, torch.Tensor] = {}
 
 
 def _r7_ballast_view(planes: int, like: torch.Tensor) -> torch.Tensor:
-    """A view of ONE shared never-read scratch pool. glm52-r7-gate-tight.
+    """Return a view into the shared, never-read preparation pool.
 
-    prepare_weights validates w13/w2 shapes but this loader discards the views
-    it builds from them, so the contents are never read -- which means every
-    ballast request across layers, tiers and bitrates can alias one allocation.
-
-    Sizing per request instead re-allocated as tier sizes grew and fragmented
-    the heap enough to OOM during weight load; a per-bitrate max-size buffer
-    instead wasted ~2.1 GiB. One pool, allocated once at the worst case
-    (2 x 256 experts of the widest bitrate), costs ~0.8 GiB total and never
-    reallocates. The pool is int16-native and reshaped per request, so a K3
-    request simply uses a shorter contiguous prefix than a K4 one.
+    ``prepare_weights`` validates the shape but the loader discards every view
+    derived from this pool. One allocation therefore serves all layers, tiers,
+    and bitrates. Its 512-plane capacity covers two projections for 256 experts;
+    narrower encodings use a contiguous prefix.
     """
 
     plane = tuple(like.shape[1:])
@@ -622,10 +609,9 @@ def _r7_ballast_view(planes: int, like: torch.Tensor) -> torch.Tensor:
 
 
 def _r7_fused_enabled() -> bool:
-    """R7 on B12X's fused MoE.
+    """Return whether mixed-bitrate routed experts use fused B12X MoE.
 
-    On by default; set VLLM_EXL3_R7_FUSED=0 to force exl3_moe_r7_fused for a
-    control run.
+    ``VLLM_EXL3_R7_FUSED=0`` selects the projection-wise fallback.
     """
 
     return os.environ.get("VLLM_EXL3_R7_FUSED", "1") != "0"
@@ -646,14 +632,10 @@ def _shared_mixed_buffers(
 
     tier_count = 3 if hasattr(launch, "tier2_num_experts") else 2
 
-    # glm52-r7-gate-tight: max_m_blocks is DELIBERATELY excluded from the key.
-    # It derives from each layer's summed tier slots, which differ per layer
-    # (262, 273, 272, ... on this checkpoint), so keying on it produced a
-    # separate ~574 MiB prefill arena for every distinct tier signature --
-    # ~4.6 GiB of duplicate scratch that logger.info_once hid from the logs.
-    # Instead one arena per launch geometry is grown to the largest
-    # max_m_blocks seen; the arena is scratch, so a larger one serves any
-    # smaller launch.
+    # max_m_blocks is intentionally excluded from the key. It derives from
+    # projection-tier slot counts and varies by layer, while route capacity is
+    # fixed by the global-expert namespace below. Including it retains one
+    # approximately 574 MiB arena per distinct tier signature.
     key = (
         owner_token,
         device.index if hasattr(device, "index") else device,
@@ -669,12 +651,9 @@ def _shared_mixed_buffers(
         launch.route_ids_dtype,
         tier_count,
     )
-    # One arena per launch geometry, allocated ONCE. Growing it on a larger
-    # max_m_blocks thrashed (51 allocations, old arenas retained by the
-    # per-signature runtimes that already hold them), so the first arena for a
-    # geometry is sized by the first launch and reused. Scratch is indexed by
-    # the kernel's own bounds, and every launch sharing this key shares the
-    # capacity/block/tile/topk that size it.
+    # Each launch geometry owns one immutable arena. Every launch sharing this
+    # key also shares the capacity, block, tile, top-k, and routing dimensions
+    # that define the required storage.
     entry = _MIXED_TRELLIS_BUFFERS.get(key)
     if entry is None:
         # Routing has its own exact global-expert namespace. Projection slots
@@ -1020,9 +999,8 @@ class Exl3Config(QuantizationConfig):
             version=config.get("version"),
             tensor_storage=config.get("tensor_storage"),
         )
-        # --- glm52-mdispatch: r7 routed experts describe themselves ---
-        # They are absent from `tensor_storage`; keep their block so codebook
-        # and layer-range lookups can resolve them.
+        # Mixed-bitrate routed experts use the dedicated
+        # `r7_routed_experts` metadata block rather than `tensor_storage`.
         _r7 = config.get("r7_routed_experts")
         if _r7 is not None:
             if not isinstance(_r7, dict):
@@ -1066,7 +1044,6 @@ class Exl3Config(QuantizationConfig):
                 "moe_layers": tuple(layers),
                 "k_values": tuple(normalized_k),
             }
-        # --- end glm52-mdispatch ---
         return instance
 
     @classmethod
@@ -1554,16 +1531,11 @@ class Exl3Config(QuantizationConfig):
     def _moe_prefix_is_exl3(
         self, prefix: str, layer: torch.nn.Module | None = None
     ) -> bool:
-        # --- glm52-mdispatch: r7 routed experts are EXL3 too ---
-        # They are declared in `r7_routed_experts`, not `tensor_storage`, so
-        # stock detection returns False -> get_quant_method returns None ->
-        # fused_moe/routed_experts.py:209 SILENTLY substitutes
-        # UnquantizedFusedMoEMethod, allocating full-width BF16 expert buffers
-        # (~3.5x the real footprint) with no diagnostic. Fall through for
-        # everything else so the rank-sliced tail keeps its own detection.
+        # The `r7_routed_experts` metadata block is authoritative for its MoE
+        # layer range. Those weights are absent from `tensor_storage`, so they
+        # must be recognized here to avoid selecting an unquantized method.
         if self._r7_layer_range_contains(prefix):
             return True
-        # --- end glm52-mdispatch ---
         if self.rank_sliced_metadata is not None:
             match = re.search(r"layers\.(\d+)\b", prefix)
             if match is None:
@@ -1594,28 +1566,21 @@ class Exl3Config(QuantizationConfig):
     def codebook_for_prefix(self, prefix: str) -> str | None:
         if self.rank_sliced_metadata is not None:
             match = re.search(r"layers\.(\d+)\b", prefix)
-            # --- glm52-mdispatch: hybrid checkpoints ---
-            # A rank-sliced TAIL does not make the whole checkpoint
-            # rank-sliced. Claim "mcg" only for layers actually inside
-            # moe_layers; every other prefix (dense/attention EXL3 recorded in
-            # tensor_storage, and the r7 routed experts) must still resolve
-            # below. Returning None here makes each of them fail as
-            # "unexpected codebook[None]" even though it ships an mcg marker.
+            # Rank-sliced metadata applies only to its declared MoE layer
+            # range. Dense, attention, and mixed-bitrate routed-expert weights
+            # resolve their codebooks through their own metadata below.
             if match is not None:
                 first, last = (int(v) for v in self.rank_sliced_metadata["moe_layers"])
                 if first <= int(match.group(1)) <= last:
                     return "mcg"
-            # --- end glm52-mdispatch ---
         entry = self._storage_entry(prefix)
         if entry is None:
-            # --- glm52-mdispatch: r7 routed experts declare their own ---
-            # Without this the shipped mcg markers read as "unexpected
-            # codebook marker". Inert without an r7 block.
+            # Mixed-bitrate routed experts declare their codebook in
+            # `r7_routed_experts` rather than `tensor_storage`.
             if self._r7_layer_range_contains(prefix):
                 _cb = getattr(self, "r7_routed_experts", {}).get("codebook")
                 if _cb in ("mcg", "mul1"):
                     return str(_cb)
-            # --- end glm52-mdispatch ---
             return None
         suffixes = {name.rsplit(".", 1)[-1] for name in entry.get("stored_tensors", {})}
         if "mcg" in suffixes:
@@ -1627,15 +1592,14 @@ class Exl3Config(QuantizationConfig):
     def _r7_layer_range_contains(self, prefix: str) -> bool:
         """True when `prefix` names a layer inside r7_routed_experts.moe_layers.
 
-        glm52-mdispatch. The r7 layout keeps its own layer range instead of
-        appearing in `tensor_storage`; nothing in stock vLLM reads it.
+        The `r7_routed_experts` checkpoint schema stores its MoE layer range
+        independently from `tensor_storage`.
         """
         r7 = getattr(self, "r7_routed_experts", None)
         if not isinstance(r7, dict):
             return False
-        # r7_routed_experts describes ROUTED EXPERTS only. Without this the
-        # range would also claim attention/dense prefixes in the same layers
-        # (e.g. kv_b_proj, which is BF16 here).
+        # The metadata applies only to routed experts; attention and dense
+        # prefixes in the same layer can use a different storage format.
         if ".mlp.experts" not in prefix:
             return False
         layers = r7.get("moe_layers")
@@ -1651,10 +1615,9 @@ class Exl3Config(QuantizationConfig):
 
     def normalize_rank_sliced_weight_name(self, name: str) -> str | None:
         """Drop non-local TP payloads and remove the serialized rank segment."""
-        # --- glm52-mdispatch: r7 shared rotations (topology-neutral) ---
-        # ONE h-side rotation per layer, shared by every expert, no rank
-        # segment. Rewrite into expert 0's slot; exl3_shared_h_rotations then
-        # makes the existing shared-parameter machinery serve it.
+        # The checkpoint stores one hidden-side rotation per layer with no TP
+        # rank segment. Expert zero is the canonical storage slot; the loader
+        # aliases that tensor for the remaining experts.
         if getattr(self, "r7_routed_experts", None) is not None:
             _r7 = re.match(
                 r"^(?P<experts_prefix>.+\.experts)\.r7_shared\."
@@ -1665,7 +1628,6 @@ class Exl3Config(QuantizationConfig):
                 if _r7.group("field") == "gate_up_suh":
                     return f"{_r7.group('experts_prefix')}.0.gate_proj.suh"
                 return f"{_r7.group('experts_prefix')}.0.down_proj.svh"
-        # --- end glm52-mdispatch ---
         if self.rank_sliced_metadata is None:
             return name
         shared_match = _SHARED_H_WEIGHT_RE.match(name)
@@ -2523,24 +2485,14 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         layer.exl3_hidden_size = hidden_size
         layer.exl3_intermediate_size_per_partition = intermediate_size_per_partition
         layer.exl3_params_dtype = params_dtype
-        # glm52-r7-cudagraph: checkpoint-driven; no serving env switch.
+        # The checkpoint's routed-expert metadata selects this path; no
+        # serving-time switch is required.
         layer.exl3_r7_graph = self.quant_config._r7_layer_range_contains(
             str(layer.layer_name)
         )
-        # glm52-r7-prefill: plan the R7 arena against the scheduler contract
-        #
-        # The rank-sliced path reads scheduler_config.max_num_batched_tokens
-        # here and plans one prefill-sized arena from it. The R7 path had no
-        # equivalent, so it planned a fixed 128-row arena and re-entered the
-        # fused MoE once per 128 tokens. Stamp the same capacity, for the same
-        # reason the rank-sliced branch stamps it here and not at forward time:
-        # the profile pass and CUDA-graph capture both run after
-        # set_current_vllm_config has exited, where
-        # get_current_vllm_config_or_none() returns None.
-        #
-        # R7 layers take the `rank_sliced = False` branch below (their layer
-        # range is disjoint from rank_sliced_metadata["moe_layers"]), so they
-        # never reach the rank-sliced stamp.
+        # Plan the mixed-bitrate staging arena from the scheduler's maximum
+        # token batch while model-construction config is available. Profile and
+        # CUDA graph capture run after this config context has exited.
         if layer.exl3_r7_graph:
             _r7_vllm_config = get_current_vllm_config_or_none()
             _r7_scheduler = (
@@ -2570,13 +2522,9 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         r7_slice_start = layer.exl3_tp_rank * layer.exl3_intermediate_size_per_partition
         r7_slice_size = layer.exl3_intermediate_size_per_partition
         rank_sliced = self.quant_config.rank_sliced_metadata is not None
-        # --- glm52-mdispatch: route per layer, not per checkpoint ---
-        # A checkpoint may carry a rank-sliced TAIL (e.g. hybrid_tr3_tail
-        # moe_layers [78,78], "carried_mtp78_only") alongside a body stored in
-        # a non-rank-sliced layout. Deciding globally drags the body onto the
-        # slab path, which stacks every expert at one bitrate and dies on
-        # mixed k. Honour the declared range instead, and stamp the decision on
-        # the layer so later branches agree with this one.
+        # Rank-sliced metadata can cover only a subset of MoE layers. Record
+        # the per-layer decision so weight loading, preparation, and execution
+        # use the same storage contract.
         if rank_sliced:
             _rs_layers = self.quant_config.rank_sliced_metadata.get("moe_layers")
             _rs_match = re.search(r"layers\.(\d+)\b", str(layer.layer_name))
@@ -2589,16 +2537,14 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                     int(_rs_layers[0]) <= int(_rs_match.group(1)) <= int(_rs_layers[1])
                 )
         layer.exl3_rank_sliced = rank_sliced
-        # --- end glm52-mdispatch ---
         shared_h = (
             rank_sliced
             and self.quant_config.rank_sliced_rotation_layout
             == _SHARED_H_ROTATION_LAYOUT
         )
-        # --- glm52-mdispatch: r7 layers share (w13,suh) and (w2,svh) ---
+        # The mixed-bitrate schema stores one hidden-side rotation per layer.
         if self.quant_config._r7_layer_range_contains(str(layer.layer_name)):
             shared_h = True
-        # --- end glm52-mdispatch ---
         layer.exl3_shared_h_rotations = shared_h
         if rank_sliced:
             checkpoint_tp = int(self.quant_config.rank_sliced_metadata["tp"])
@@ -2685,14 +2631,12 @@ class Exl3MoEMethod(FusedMoEMethodBase):
 
     def process_weights_after_loading(self, layer: RoutedExperts) -> None:
         required = {"w13": ("w1", "w3"), "w2": ("w2",)}
-        # --- glm52-mdispatch: r7 stores ONE gate_up_suh for gate AND up ---
-        # shared_h_v1 keeps a separate shared tensor per projection; r7 keeps
-        # one, because gate_proj and up_proj consume the same activation.
+        # `r7_shared.gate_up_suh` is shared by gate and up projections because
+        # both consume the same activation.
         if getattr(layer, "exl3_shared_h_rotations", False):
             _w13_suh = layer.w13_suh.exl3_tensors
             if (0, "w1") in _w13_suh and (0, "w3") not in _w13_suh:
                 _w13_suh[(0, "w3")] = _w13_suh[(0, "w1")]
-        # --- end glm52-mdispatch ---
         missing: list[str] = []
         for prefix, shard_ids in required.items():
             for attr in ("suh", "svh", "trellis"):
@@ -2717,7 +2661,8 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 + (" ..." if len(missing) > 32 else "")
             )
         self._validate_codebooks(layer)
-        # glm52-mdispatch: per-layer routing (see create_weights)
+        # Apply TP slicing only to layers whose metadata does not already
+        # provide rank-local payloads.
         if not getattr(
             layer,
             "exl3_rank_sliced",
@@ -2733,13 +2678,9 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                         device=device, non_blocking=True
                     ).contiguous()
         self._validate_moe_shapes(layer)
-        # --- glm52-mdispatch: broadcast shared rotations on the std path ---
-        # `_apply_expert` indexes suh/svh by (expert_id, shard_id), so every
-        # expert needs a key. The rank-sliced path broadcasts a 1-row slab in
-        # `_select_rotation_rows`; the standard path has no equivalent. Alias
-        # the SAME device tensor into each expert's slot -- dict entries, not
-        # copies -- and never clobber a genuine per-expert tensor. Runs after
-        # the TP narrow and the device move so the alias is already final.
+        # `_apply_expert` indexes rotations by (expert_id, shard_id). For a
+        # shared-H checkpoint, populate every key with the same device tensor;
+        # these are aliases, not copies, and explicit per-expert tensors win.
         _rs = getattr(
             layer,
             "exl3_rank_sliced",
@@ -2784,8 +2725,6 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                         f"dtype={_tt.dtype} sum={_v.sum().item():.6f}"
                     )
             print(chr(10).join(_out), flush=True)
-        # --- end glm52-mdispatch ---
-
         if getattr(layer, "exl3_r7_graph", False):
             # Prefer the native two- or three-tier B12X mixed-Trellis kernel.
             if _r7_fused_enabled() and self._prepare_r7_b12x_weights(layer):
@@ -3811,10 +3750,9 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         )
 
         def rotation(group: str, attr: str, shard_id: str) -> torch.Tensor:
-            # glm52-r7-broadcast-rotations: R7 stores ONE shared row per
-            # layer (r7_shared.gate_up_suh / r7_shared.down_svh, [hidden]).
-            # r28's ABI v6 takes it as a broadcast row, so hand it (1, hidden)
-            # instead of num_experts bit-identical copies (~700 MiB saved).
+            # ABI v6 accepts `r7_shared.gate_up_suh` and
+            # `r7_shared.down_svh` as one `[1, hidden]` broadcast row. Expanding
+            # them to one identical row per expert costs about 700 MiB/rank.
             tensors = getattr(layer, f"{group}_{attr}").exl3_tensors
             return tensors[(0, shard_id)].unsqueeze(0).contiguous()
 
@@ -3863,14 +3801,10 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             def plane(expert_ids, shard_id, param, slots, out=None, row=0, base=None):
                 """Copy experts into a preallocated slab, releasing each source.
 
-                torch.stack would hold a whole extra layer while every source
-                expert is still resident, which accumulated until load OOMed
-                around layer 68 of 75. Popping each tensor out of exl3_tensors
-                as it is consumed keeps the extra to one expert.
-
-                glm52-r7-gate-tight: base!=None packs directly into a flat
-                [gate|up] buffer at out[base+index], so no padded (2,max) w13 is
-                ever materialised.
+                Consuming one source at a time limits transient storage to one
+                expert. When ``base`` is set, gate and up planes occupy a
+                projection-tight ``[gate | up]`` buffer without a padded
+                ``[2, max(gate, up)]`` intermediate.
                 """
                 if out is None:
                     if not expert_ids:
@@ -3973,9 +3907,8 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 # dtype view, not a repack -- w2_scale = the shared four-byte
                 # dummy, and w2_global_scale = ones(num_experts). So FC2 is
                 # constructed directly at its own count and only FC1 goes
-                # through prepare. That removes the full-size counterpart
-                # tensor the earlier splice needed, which was OOMing at ~558
-                # MiB during load.
+                # through prepare. A full-size counterpart is unnecessary and
+                # would add approximately 558 MiB of transient load storage.
                 def call(n, w13_in, w2_in):
                     return mixed_api.prepare_weights(
                         w13=w13_in,
@@ -4000,11 +3933,9 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                         intermediate_rotations=intermediate_rotations[:n].contiguous(),
                         down_svh=down_svh[:1].contiguous(),
                         tile_config=cfg,
-                        # glm52-r7-ballast-dealias: a view into the ballast
-                        # pool would be stored verbatim in the frozen tier,
-                        # keeping the whole ~576 MiB allocation alive (192
-                        # live aliases per rank). Hand prepare an equivalent
-                        # standalone scalar so the pool can actually be freed.
+                        # The prepared tier retains this object. A standalone
+                        # scalar avoids retaining the approximately 576 MiB
+                        # shared preparation pool through a one-element view.
                         workspace=torch.zeros(
                             1, dtype=torch.int32, device=w13_in.device
                         ),
@@ -4067,10 +3998,9 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         gc.collect()
         torch.cuda.empty_cache()
 
-        # glm52-r7-pad-before-prepare: the padding MUST happen before the
-        # prepare loop. prepare stores the [:1]/[:n] slices it is handed as
-        # views, so padding afterwards leaves the unpadded originals pinned
-        # alongside the padded copies -- 448.5 MiB per rank on this model.
+        # Padding must precede preparation because prepared tiers retain the
+        # slices they receive. Padding after preparation retains both tables,
+        # adding 448.5 MiB/rank for the qualified GLM-5.2 checkpoint.
         # Every combined-expert-indexed table is sized by the summed tier slot
         # counts, not by the real expert count, so the padded stride applies to
         # the rotations as well. Padding rows are never addressed: the kernel
@@ -4085,10 +4015,8 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             intermediate_rotations = torch.cat(
                 (intermediate_rotations, pad), dim=0
             ).contiguous()
-            # glm52-r7-broadcast-rotations: gate_suh/up_suh/down_svh are
-            # single broadcast rows now; padding them to `stride` would
-            # reinstate exactly the duplication this removes. Only the
-            # per-expert intermediate table is combined-expert indexed.
+            # gate_suh, up_suh, and down_svh are broadcast rows. Only the
+            # per-expert intermediate table uses combined-expert indexing.
             rotations = SimpleNamespace(
                 intermediate=intermediate_rotations,
                 gate_suh=gate_suh,
@@ -4123,8 +4051,8 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             "global_to_combined": global_to_combined,
             "descriptor_map": descriptor_map,
             "rotations": rotations,
-            # glm52-r7-broadcast-rotations: the shared runtime builder reads
-            # these by direct index; omitting them raises KeyError on r28.
+            # The B12X runtime uses these flags to interpret one-row hidden-side
+            # rotations as broadcast values.
             "broadcast_suh": True,
             "broadcast_svh": True,
             "tile_config": tile_config,
@@ -4165,9 +4093,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         x: torch.Tensor,
         topk_ids: torch.Tensor,
     ) -> dict[str, Any]:
-        # glm52-r7-prefill: the token batch and the per-expert route block are
-        # two independent quantities, and the previous plan collapsed them into
-        # one `chunk = 128`.
+        # Token-batch capacity and the per-expert route block are independent.
         #
         #   * The token batch is exl3_moe's `bsz = hidden_state.size(0)`. The
         #     kernel imposes no upper bound on it: the only shape tie between
@@ -4178,18 +4104,14 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         #     many rows, and each block re-streams and re-decodes that expert's
         #     whole gate/up/down trellis.
         #
-        # Batching 128 tokens at a time therefore did not bound the arena (the
-        # route block did); it multiplied the number of fused-MoE entries per
-        # layer by ceil(max_num_batched_tokens / 128) and, because a 128-token
-        # batch routes only ~topk*128/num_experts rows to each expert, it made
-        # every expert tile a nearly empty M32 tile that still paid the full
-        # trellis decode. Planning the token batch at the scheduler capacity and
-        # keeping the route block at its previous value restores one entry per
-        # layer without changing the per-expert GEMM geometry.
+        # The scheduler batch therefore sizes token staging, while the route
+        # block sizes per-expert scratch. Keeping these dimensions separate
+        # permits one fused-MoE entry per scheduler batch without changing the
+        # per-expert GEMM geometry.
         max_batched_tokens = int(layer.exl3_r7_max_num_batched_tokens)
         capacity = _resolve_prefill_capacity(max_batched_tokens)
-        # Same role as VLLM_EXL3_PREFILL_BLOCK_M on the rank-sliced plan. The
-        # default reproduces the previously measured per-expert tiling exactly.
+        # This is the mixed-bitrate counterpart of
+        # VLLM_EXL3_PREFILL_BLOCK_M for rank-sliced weights.
         route_block = _positive_env_int("VLLM_EXL3_R7_ROUTE_BLOCK", 128)
         topk = int(topk_ids.shape[1])
         device_index = x.device.index
@@ -4218,8 +4140,8 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         route_capacity = capacity * topk
         runtime = {
             "ext": ext,
-            # glm52-r7-a1-mixed: resolved during the eager profile pass, never
-            # under capture, so the env read cannot vary between replays.
+            # Resolve environment policy during profile planning so CUDA graph
+            # replays use an immutable launch choice.
             "a1_min_rows": _resolve_r7_a1_min_rows(ext),
             "capacity": capacity,
             "route_block": route_block,
@@ -4296,8 +4218,8 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         runtime = self._r7_graph_runtime(layer, x, topk_ids)
         m = int(x.shape[0])
         capacity = int(runtime["capacity"])
-        # glm52-r7-prefill: fail closed rather than silently re-chunking a batch
-        # the scheduler promised would not occur.
+        # The scheduler contract is a hard capacity bound; execution does not
+        # silently re-plan or allocate under CUDA graph capture.
         if m > int(layer.exl3_r7_max_num_batched_tokens):
             raise ValueError(
                 "R7 EXL3 batch exceeds its planned capacity: "
@@ -4309,7 +4231,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         gate_bits, up_bits, down_bits = layer.exl3_r7_bitrates
         pointer_args = layer.exl3_r7_pointer_tables
         ext = runtime["ext"]
-        # glm52-r7-a1-mixed: a pure function of the captured static shape.
+        # The retile decision is a pure function of the captured static shape.
         a1_min_rows = int(runtime["a1_min_rows"])
         expert_map = layer.exl3_r7_expert_map
         # One entry per scheduler batch. The trip count is a pure function of
@@ -4796,7 +4718,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         x_2d = x.reshape(-1, x.shape[-1]).contiguous()
         ids = topk_ids.reshape(x_2d.shape[0], -1).contiguous()
         weights = topk_weights.reshape_as(ids).to(torch.float32).contiguous()
-        # glm52-mdispatch: per-layer routing (see create_weights)
+        # Execute the storage path selected and recorded during weight creation.
         if getattr(
             layer,
             "exl3_rank_sliced",
@@ -4805,9 +4727,8 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             output = self._apply_rank_sliced(layer, x_2d, weights, ids)
             return output.reshape(*original_shape, output.shape[-1])
         if getattr(layer, "exl3_r7_fused", False):
-            # glm52-r7-sparkinfer: the prepared dict uses the mixed-Trellis
-            # contract exactly, so the existing launch, runtime planning and
-            # prefill chunking are reused unchanged.
+            # The prepared mapping implements the mixed-Trellis launch contract,
+            # including graph-stable scratch and prefill capacity planning.
             output = self._apply_mixed_rank_sliced(layer, x_2d, weights, ids)
             return output.reshape(*original_shape, output.shape[-1])
         if getattr(layer, "exl3_r7_graph", False):

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -712,6 +712,18 @@ class Exl3Config(QuantizationConfig):
         EXL3-owned dense matrices are selected before this method and routed
         experts never enter it. Shared-expert projections have an independent
         spec so a broad ``linear`` overlay cannot quantize them accidentally.
+
+        Args:
+            layer: Candidate module for the online overlay.
+            prefix: Fully qualified checkpoint module name.
+
+        Returns:
+            An MXFP8 method for an eligible BF16 projection, otherwise
+            ``None``.
+
+        Raises:
+            ValueError: If the EXL3 overlay requests an unsupported weight or
+                activation format.
         """
         if not isinstance(layer, LinearBase):
             return None
@@ -791,10 +803,17 @@ class Exl3Config(QuantizationConfig):
         if not source_leaves:
             return False
         base = prefix.rsplit(".", 1)[0] if "." in prefix else ""
-        return all(
+        source_is_exl3 = [
             self._is_exl3_prefix(f"{base}.{source}" if base else source)
             for source in source_leaves
-        )
+        ]
+        if any(source_is_exl3) and not all(source_is_exl3):
+            raise ValueError(
+                f"Packed EXL3 projection {prefix!r} mixes EXL3 and BF16 "
+                "source shards; a fused module must use one quantization "
+                "scheme."
+            )
+        return all(source_is_exl3)
 
     def _moe_prefix_is_exl3(
         self, prefix: str, layer: torch.nn.Module | None = None

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -107,6 +107,13 @@ _MIXED_TRELLIS_RUNTIMES: dict[tuple[Any, ...], dict[str, Any]] = {}
 _NEXT_RUNTIME_SCOPE_ID = 0
 _MIXED_TRELLIS_ROUTE_BLOCK_SIZE = 8
 _GLM52_MIXED_TRELLIS_PREFILL_BLOCK_SIZE = 32
+_GLM52_MIXED_TRELLIS_BLOCK32_SIGNATURES = frozenset(
+    {
+        ((3, 192), (4, 64)),
+        ((3, 206), (4, 50)),
+        ((3, 148), (4, 108)),
+    }
+)
 
 
 def _resolve_mixed_trellis_prefill_block_m(
@@ -124,8 +131,9 @@ def _resolve_mixed_trellis_prefill_block_m(
 
     SparkInfer's paired-M8 FC2 schedule makes block-32 numerically equivalent
     to the established block-64 path while reducing scratch and improving the
-    dominant large-prefill kernel on SM12x. Explicit operator tuning and every
-    other model geometry retain the configured value.
+    dominant large-prefill kernel on SM12x. The allowlist contains only tier
+    partitions qualified end-to-end on GLM-5.2 checkpoints. Explicit operator
+    tuning and every other model geometry retain the configured value.
     """
 
     qualified = (
@@ -133,7 +141,7 @@ def _resolve_mixed_trellis_prefill_block_m(
         and int(device_major) == 12
         and int(hidden_size) == 6144
         and int(intermediate_size) == 512
-        and tier_signature == ((3, 192), (4, 64))
+        and tier_signature in _GLM52_MIXED_TRELLIS_BLOCK32_SIGNATURES
         and int(topk) == 8
         and tuple(int(value) for value in prefill_tile_config) == (128, 128, 32, 512)
     )

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -264,6 +264,15 @@ def _unique_tensor_storage_bytes(*buffers: Any) -> int:
     return total
 
 
+def _scratch_view(backing: torch.Tensor, spec: Any) -> torch.Tensor:
+    """Return a typed plan-scratch view over a shared byte arena."""
+
+    nbytes = int(spec.dtype.itemsize)
+    for dim in spec.shape:
+        nbytes *= int(dim)
+    return backing.narrow(0, 0, nbytes).view(spec.dtype).view(tuple(spec.shape))
+
+
 def _positive_env_int(name: str, default: int) -> int:
     # An env var that is present but blank means "unset". Compose and Kubernetes
     # both render an unset variable as the empty string, so int("") would abort
@@ -1570,7 +1579,8 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         return (128, 128, 128, 128)
 
     def _prepare_mixed_rank_sliced_weights(self, layer: RoutedExperts) -> None:
-        api = _load_b12x_mixed_trellis()
+        mixed_api = _load_b12x_mixed_trellis()
+        fused_api = _load_b12x_fused_moe()
         num_experts = int(layer.local_num_experts)
         hidden_size = int(layer.exl3_hidden_size)
         intermediate_size = int(layer.exl3_intermediate_size_per_partition)
@@ -1609,9 +1619,36 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         down_suh = self._rank_sliced_backing(layer, "w2_suh")
         down_svh = self._rank_sliced_backing(layer, "w2_svh")
         device = gate_suh.device
-        tile_config = self._mixed_trellis_tile_config(hidden_size, intermediate_size)
+        mixed_tile_config = self._mixed_trellis_tile_config(
+            hidden_size, intermediate_size
+        )
+        serial_tile_config = self._trellis_tile_config(hidden_size, intermediate_size)
+        marker = layer.w13_mcg.exl3_tensors[(0, "w1")]
+        tier_order = tuple(
+            expert_id for expert_ids in tiers.values() for expert_id in expert_ids
+        )
+        tier_index = torch.tensor(tier_order, dtype=torch.long, device=device)
+        combined_gate_suh = gate_suh.index_select(0, tier_index).contiguous()
+        combined_up_suh = up_suh.index_select(0, tier_index).contiguous()
+        combined_intermediate_rotations = torch.cat(
+            (
+                gate_svh.index_select(0, tier_index),
+                up_svh.index_select(0, tier_index),
+                down_suh.index_select(0, tier_index),
+            ),
+            dim=1,
+        ).contiguous()
+        combined_down_svh = down_svh.index_select(0, tier_index).contiguous()
+        combined_rotations = SimpleNamespace(
+            intermediate=combined_intermediate_rotations,
+            gate_suh=combined_gate_suh,
+            up_suh=combined_up_suh,
+            down_svh=combined_down_svh,
+        )
         prepared_tiers = []
+        serial_tiers = []
         tier_ids = []
+        tier_offset = 0
         for bits, expert_ids in tiers.items():
             expected_last = 16 * bits
             w13 = torch.stack(
@@ -1651,27 +1688,21 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 )
 
             index = torch.tensor(expert_ids, dtype=torch.long, device=device)
-            tier_gate_suh = gate_suh.index_select(0, index).contiguous()
-            tier_up_suh = up_suh.index_select(0, index).contiguous()
-            intermediate_rotations = torch.cat(
-                (
-                    gate_svh.index_select(0, index),
-                    up_svh.index_select(0, index),
-                    down_suh.index_select(0, index),
-                ),
-                dim=1,
-            ).contiguous()
-            tier_down_svh = down_svh.index_select(0, index).contiguous()
+            tier_slice = slice(tier_offset, tier_offset + len(expert_ids))
+            tier_gate_suh = combined_gate_suh[tier_slice]
+            tier_up_suh = combined_up_suh[tier_slice]
+            intermediate_rotations = combined_intermediate_rotations[tier_slice]
+            tier_down_svh = combined_down_svh[tier_slice]
             prepared_tiers.append(
-                api.prepare_weights(
+                mixed_api.prepare_weights(
                     w13=w13,
                     w2=w2,
                     hidden_size=hidden_size,
                     intermediate_size=intermediate_size,
                     num_experts=len(expert_ids),
                     activation=layer.activation.value,
-                    fc1_tile_n=tile_config[1],
-                    fc2_tile_n=tile_config[3],
+                    fc1_tile_n=mixed_tile_config[1],
+                    fc2_tile_n=mixed_tile_config[3],
                     params_dtype=torch.float16,
                     w13_layout="trellis3_t256_proj",
                     trellis_bits=bits,
@@ -1680,25 +1711,64 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                     up_suh=tier_up_suh,
                     intermediate_rotations=intermediate_rotations,
                     down_svh=tier_down_svh,
-                    tile_config=tile_config,
+                    tile_config=mixed_tile_config,
                     workspace=w13.view(torch.int32).reshape(-1)[:1],
                 )
             )
+            serial_weight_plan = fused_api.plan_weights(
+                quant_modes="w4a16",
+                source_format="exl3_trellis_mcg",
+                activation=layer.activation.value,
+                params_dtype=layer.exl3_params_dtype,
+                num_experts=len(expert_ids),
+                hidden_size=hidden_size,
+                intermediate_size=intermediate_size,
+                w13_layout="w13",
+                trellis_bits=bits,
+                trellis_tile_config=serial_tile_config,
+            )
+            serial_weights = fused_api.prepare_weights(
+                plan=serial_weight_plan,
+                params_dtype=layer.exl3_params_dtype,
+                w1_fp4=w13,
+                w2_fp4=w2,
+                gate_suh=tier_gate_suh,
+                up_suh=tier_up_suh,
+                intermediate_rotations=intermediate_rotations,
+                down_svh=tier_down_svh,
+                trellis_mcg=marker,
+            )
+            route_expert_map = torch.full(
+                (num_experts,), -1, dtype=torch.int32, device=device
+            )
+            route_expert_map[index] = torch.arange(
+                len(expert_ids), dtype=torch.int32, device=device
+            )
+            serial_tiers.append(
+                {
+                    "bits": bits,
+                    "weights": serial_weights,
+                    "route_expert_map": route_expert_map,
+                }
+            )
             tier_ids.append(expert_ids)
+            tier_offset += len(expert_ids)
 
-        global_to_combined, descriptor_map = api.build_tiered_maps(
+        global_to_combined, descriptor_map = mixed_api.build_tiered_maps(
             tier_ids[0], tier_ids[1], device=device
         )
         layer.exl3_mixed_trellis = {
             "tiers": tuple(prepared_tiers),
+            "serial_tiers": tuple(serial_tiers),
             "tier_ids": tuple(tier_ids),
             "tier_bits": tuple(tiers),
             "global_to_combined": global_to_combined,
             "descriptor_map": descriptor_map,
-            "rotations": api.combine_trellis_rotations(*prepared_tiers),
-            "tile_config": tile_config,
+            "rotations": combined_rotations,
+            "tile_config": mixed_tile_config,
+            "serial_tile_config": serial_tile_config,
         }
-        layer.exl3_trellis_tile_config = tile_config
+        layer.exl3_trellis_tile_config = serial_tile_config
 
         # The prepared tier objects own compact, tier-ordered copies. Release
         # per-expert source tensors and the original rotation slabs now rather
@@ -1834,6 +1904,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         mixed = layer.exl3_mixed_trellis
         max_decode_m = _positive_env_int("VLLM_EXL3_TRELLIS_MAX_M", 32)
         max_batched_tokens = int(layer.exl3_max_num_batched_tokens)
+        prefill_block_m = _positive_env_int("VLLM_EXL3_PREFILL_BLOCK_M", 64)
         if max_decode_m > max_batched_tokens:
             max_decode_m = max_batched_tokens
         topk = int(topk_ids.shape[1])
@@ -1853,6 +1924,8 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             max_decode_m,
             max_batched_tokens,
             mixed["tile_config"],
+            mixed["serial_tile_config"],
+            prefill_block_m,
         )
         runtime = _MIXED_TRELLIS_RUNTIMES.get(key)
         if runtime is not None:
@@ -1868,18 +1941,19 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 f"{topk_ids.dtype}"
             )
 
-        api = _load_b12x_mixed_trellis()
+        mixed_api = _load_b12x_mixed_trellis()
+        fused_api = _load_b12x_fused_moe()
         device = x.device
         props = torch.cuda.get_device_properties(device)
         total_experts = sum(experts for _, experts in tier_signature)
 
-        def make_state(capacity: int) -> dict[str, Any]:
-            route_slots = api.max_packed_route_slots(
+        def make_decode_state(capacity: int) -> dict[str, Any]:
+            route_slots = mixed_api.max_packed_route_slots(
                 capacity * topk,
                 _MIXED_TRELLIS_ROUTE_BLOCK_SIZE,
                 total_experts,
             )
-            launch = api.compile_mixed_trellis(
+            launch = mixed_api.compile_mixed_trellis(
                 size_m=capacity,
                 hidden_size=int(layer.exl3_hidden_size),
                 intermediate_size=int(layer.exl3_intermediate_size_per_partition),
@@ -1900,37 +1974,70 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             return {
                 "capacity": capacity,
                 "launch": launch,
-                "buffers": api.make_mixed_trellis_buffers(
+                "buffers": mixed_api.make_mixed_trellis_buffers(
                     launch,
                     device=device,
                     sms=int(props.multi_processor_count),
                 ),
             }
 
-        decode = make_state(max_decode_m)
-        prefill = (
-            make_state(max_batched_tokens)
-            if max_batched_tokens > max_decode_m
-            else decode
-        )
+        decode = make_decode_state(max_decode_m)
+        prefill_plans = []
+        prefill_arena = None
+        prefill_accum = None
+        if max_batched_tokens > max_decode_m:
+            if os.environ.get("VLLM_EXL3_PREFILL_TRELLIS", "1") != "1":
+                raise ValueError("mixed-K EXL3 requires VLLM_EXL3_PREFILL_TRELLIS=1")
+            scratch_bytes = 0
+            for tier in mixed["serial_tiers"]:
+                caps = fused_api.Caps(
+                    max_tokens=max_batched_tokens,
+                    num_topk=topk,
+                    route_num_experts=total_experts,
+                    device=device,
+                    weight_plan=tier["weights"].plan,
+                    quant_mode="w4a16",
+                    w4a16_block_size_m=prefill_block_m,
+                )
+                plan = fused_api.plan(caps)
+                prefill_plans.append(plan)
+                spec = plan.scratch_specs()[0]
+                size = int(spec.dtype.itemsize)
+                for dim in spec.shape:
+                    size *= int(dim)
+                scratch_bytes = max(scratch_bytes, size)
+            prefill_arena = torch.empty(scratch_bytes, dtype=torch.uint8, device=device)
+            prefill_accum = torch.empty(
+                (max_batched_tokens, int(layer.exl3_hidden_size)),
+                dtype=torch.float32,
+                device=device,
+            )
         runtime = {
-            "api": api,
+            "mixed_api": mixed_api,
+            "fused_api": fused_api,
             "decode": decode,
-            "prefill": prefill,
+            "prefill_plans": tuple(prefill_plans),
+            "prefill_arena": prefill_arena,
+            "prefill_accum": prefill_accum,
             "max_decode_m": max_decode_m,
             "max_batched_tokens": max_batched_tokens,
         }
         _MIXED_TRELLIS_RUNTIMES[key] = runtime
-        buffer_bytes = _unique_tensor_storage_bytes(
-            decode["buffers"], prefill["buffers"]
+        decode_bytes = _unique_tensor_storage_bytes(decode["buffers"])
+        prefill_bytes = sum(
+            tensor.numel() * tensor.element_size()
+            for tensor in (prefill_arena, prefill_accum)
+            if tensor is not None
         )
         logger.info_once(
-            "EXL3 mixed Trellis runtime planned: tiers=%s decode_capacity=%d "
-            "prefill_capacity=%d buffers=%.1f MiB",
+            "EXL3 mixed Trellis runtime planned: tiers=%s one-grid decode=%d "
+            "serial prefill=%d block_m=%d buffers=%.1f+%.1f MiB",
             tier_signature,
             max_decode_m,
             max_batched_tokens,
-            buffer_bytes / (1 << 20),
+            prefill_block_m,
+            decode_bytes / (1 << 20),
+            prefill_bytes / (1 << 20),
         )
         return runtime
 
@@ -1948,23 +2055,53 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 "mixed-bitrate EXL3 batch exceeds planned capacity: "
                 f"m={m}, capacity={runtime['max_batched_tokens']}"
             )
-        state = (
-            runtime["decode"] if m <= runtime["max_decode_m"] else runtime["prefill"]
-        )
         mixed = layer.exl3_mixed_trellis
-        output = runtime["api"].run_mixed_trellis(
-            x,
-            mixed["tiers"][0],
-            mixed["tiers"][1],
-            topk_weights,
-            topk_ids,
-            mixed["global_to_combined"],
-            mixed["descriptor_map"],
-            mixed["rotations"],
-            state["launch"],
-            state["buffers"],
-        )
-        return output.to(x.dtype)
+        # The cooperative mixed-K grid wins at small M, but its SM120 path is
+        # currently limited to route block 8.  Homogeneous tier plans support
+        # block 64 and are substantially faster for prefill, so keep the
+        # one-grid launch for decode and dispatch large M through the two
+        # serial tiers until the mixed kernel gains an efficient large block.
+        if m <= runtime["max_decode_m"]:
+            state = runtime["decode"]
+            output = runtime["mixed_api"].run_mixed_trellis(
+                x,
+                mixed["tiers"][0],
+                mixed["tiers"][1],
+                topk_weights,
+                topk_ids,
+                mixed["global_to_combined"],
+                mixed["descriptor_map"],
+                mixed["rotations"],
+                state["launch"],
+                state["buffers"],
+            )
+            return output.to(x.dtype)
+
+        if runtime["prefill_arena"] is None or runtime["prefill_accum"] is None:
+            raise RuntimeError("mixed-K EXL3 serial prefill plan is unavailable")
+        accum = runtime["prefill_accum"][:m]
+        first = True
+        for plan, tier in zip(
+            runtime["prefill_plans"], mixed["serial_tiers"], strict=True
+        ):
+            binding = runtime["fused_api"].bind(
+                plan,
+                scratch=_scratch_view(
+                    runtime["prefill_arena"], plan.scratch_specs()[0]
+                ),
+                a=x,
+                experts=tier["weights"],
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
+                route_expert_map=tier["route_expert_map"],
+                output_expert_map=tier["route_expert_map"],
+                output=accum if first else None,
+            )
+            output = runtime["fused_api"].run(binding=binding)
+            if not first:
+                accum.add_(output)
+            first = False
+        return accum.to(x.dtype)
 
     def _rank_sliced_runtime(
         self,

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -1795,9 +1795,19 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             return (128, 128, 64, 256)
         return (128, 128, 128, 128)
 
+    @staticmethod
+    def _mixed_trellis_prefill_tile_config(
+        hidden_size: int, intermediate_size: int
+    ):
+        if hidden_size % 128 or intermediate_size % 128:
+            raise ValueError(
+                "mixed rank-sliced EXL3 prefill requires hidden and "
+                "intermediate dimensions divisible by 128"
+            )
+        return (128, 64, 64, 128)
+
     def _prepare_mixed_rank_sliced_weights(self, layer: RoutedExperts) -> None:
         mixed_api = _load_b12x_mixed_trellis()
-        fused_api = _load_b12x_fused_moe()
         num_experts = int(layer.local_num_experts)
         hidden_size = int(layer.exl3_hidden_size)
         intermediate_size = int(layer.exl3_intermediate_size_per_partition)
@@ -1839,8 +1849,9 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         mixed_tile_config = self._mixed_trellis_tile_config(
             hidden_size, intermediate_size
         )
-        serial_tile_config = self._trellis_tile_config(hidden_size, intermediate_size)
-        marker = layer.w13_mcg.exl3_tensors[(0, "w1")]
+        prefill_tile_config = self._mixed_trellis_prefill_tile_config(
+            hidden_size, intermediate_size
+        )
         tier_order = tuple(
             expert_id for expert_ids in tiers.values() for expert_id in expert_ids
         )
@@ -1863,7 +1874,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             down_svh=combined_down_svh,
         )
         prepared_tiers = []
-        serial_tiers = []
+        prefill_tiers = []
         tier_ids = []
         tier_offset = 0
         for bits, expert_ids in tiers.items():
@@ -1904,7 +1915,6 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                     f"expected={expected_w13}/{expected_w2}"
                 )
 
-            index = torch.tensor(expert_ids, dtype=torch.long, device=device)
             tier_slice = slice(tier_offset, tier_offset + len(expert_ids))
             tier_gate_suh = (
                 combined_gate_suh
@@ -1922,16 +1932,17 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 if int(combined_down_svh.shape[0]) == 1
                 else combined_down_svh[tier_slice]
             )
-            prepared_tiers.append(
-                mixed_api.prepare_weights(
+
+            def prepare_tier(tile_config: tuple[int, int, int, int]):
+                return mixed_api.prepare_weights(
                     w13=w13,
                     w2=w2,
                     hidden_size=hidden_size,
                     intermediate_size=intermediate_size,
                     num_experts=len(expert_ids),
                     activation=layer.activation.value,
-                    fc1_tile_n=mixed_tile_config[1],
-                    fc2_tile_n=mixed_tile_config[3],
+                    fc1_tile_n=tile_config[1],
+                    fc2_tile_n=tile_config[3],
                     params_dtype=torch.float16,
                     w13_layout="trellis3_t256_proj",
                     trellis_bits=bits,
@@ -1940,46 +1951,12 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                     up_suh=tier_up_suh,
                     intermediate_rotations=intermediate_rotations,
                     down_svh=tier_down_svh,
-                    tile_config=mixed_tile_config,
+                    tile_config=tile_config,
                     workspace=w13.view(torch.int32).reshape(-1)[:1],
                 )
-            )
-            serial_weight_plan = fused_api.plan_weights(
-                quant_modes="w4a16",
-                source_format="exl3_trellis_mcg",
-                activation=layer.activation.value,
-                params_dtype=layer.exl3_params_dtype,
-                num_experts=len(expert_ids),
-                hidden_size=hidden_size,
-                intermediate_size=intermediate_size,
-                w13_layout="w13",
-                trellis_bits=bits,
-                trellis_tile_config=serial_tile_config,
-            )
-            serial_weights = fused_api.prepare_weights(
-                plan=serial_weight_plan,
-                params_dtype=layer.exl3_params_dtype,
-                w1_fp4=w13,
-                w2_fp4=w2,
-                gate_suh=tier_gate_suh,
-                up_suh=tier_up_suh,
-                intermediate_rotations=intermediate_rotations,
-                down_svh=tier_down_svh,
-                trellis_mcg=marker,
-            )
-            route_expert_map = torch.full(
-                (num_experts,), -1, dtype=torch.int32, device=device
-            )
-            route_expert_map[index] = torch.arange(
-                len(expert_ids), dtype=torch.int32, device=device
-            )
-            serial_tiers.append(
-                {
-                    "bits": bits,
-                    "weights": serial_weights,
-                    "route_expert_map": route_expert_map,
-                }
-            )
+
+            prepared_tiers.append(prepare_tier(mixed_tile_config))
+            prefill_tiers.append(prepare_tier(prefill_tile_config))
             tier_ids.append(expert_ids)
             tier_offset += len(expert_ids)
 
@@ -1988,16 +1965,16 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         )
         layer.exl3_mixed_trellis = {
             "tiers": tuple(prepared_tiers),
-            "serial_tiers": tuple(serial_tiers),
+            "prefill_tiers": tuple(prefill_tiers),
             "tier_ids": tuple(tier_ids),
             "tier_bits": tuple(tiers),
             "global_to_combined": global_to_combined,
             "descriptor_map": descriptor_map,
             "rotations": combined_rotations,
             "tile_config": mixed_tile_config,
-            "serial_tile_config": serial_tile_config,
+            "prefill_tile_config": prefill_tile_config,
         }
-        layer.exl3_trellis_tile_config = serial_tile_config
+        layer.exl3_trellis_tile_config = mixed_tile_config
 
         # The prepared tier objects own compact, tier-ordered copies. Release
         # per-expert source tensors and the original rotation slabs now rather
@@ -2164,7 +2141,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             max_batched_tokens,
             prefill_capacity,
             mixed["tile_config"],
-            mixed["serial_tile_config"],
+            mixed["prefill_tile_config"],
             prefill_block_m,
         )
         runtime = _MIXED_TRELLIS_RUNTIMES.get(key)
@@ -2182,15 +2159,18 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             )
 
         mixed_api = _load_b12x_mixed_trellis()
-        fused_api = _load_b12x_fused_moe()
         device = x.device
         props = torch.cuda.get_device_properties(device)
         total_experts = sum(experts for _, experts in tier_signature)
 
-        def make_decode_state(capacity: int) -> dict[str, Any]:
+        def make_state(
+            capacity: int,
+            block_size_m: int,
+            tile_config: tuple[int, int, int, int],
+        ) -> dict[str, Any]:
             route_slots = mixed_api.max_packed_route_slots(
                 capacity * topk,
-                _MIXED_TRELLIS_ROUTE_BLOCK_SIZE,
+                block_size_m,
                 total_experts,
             )
             launch = mixed_api.compile_mixed_trellis(
@@ -2202,12 +2182,11 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 tier0_bits=tier_signature[0][0],
                 tier1_bits=tier_signature[1][0],
                 top_k=topk,
-                max_m_blocks=(route_slots + _MIXED_TRELLIS_ROUTE_BLOCK_SIZE - 1)
-                // _MIXED_TRELLIS_ROUTE_BLOCK_SIZE,
-                moe_block_size=_MIXED_TRELLIS_ROUTE_BLOCK_SIZE,
+                max_m_blocks=(route_slots + block_size_m - 1) // block_size_m,
+                moe_block_size=block_size_m,
                 sms=int(props.multi_processor_count),
                 max_shared_mem=int(props.shared_memory_per_block_optin),
-                force_tile_config=mixed["tile_config"],
+                force_tile_config=tile_config,
                 rotation_input_dtype=("bf16" if x.dtype == torch.bfloat16 else "fp16"),
                 route_ids_dtype=topk_ids.dtype,
             )
@@ -2221,58 +2200,38 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 ),
             }
 
-        decode = make_decode_state(max_decode_m)
-        prefill_plans = []
-        prefill_arena = None
-        prefill_accum = None
+        decode = make_state(
+            max_decode_m,
+            _MIXED_TRELLIS_ROUTE_BLOCK_SIZE,
+            mixed["tile_config"],
+        )
+        prefill = None
         if max_batched_tokens > max_decode_m:
             if os.environ.get("VLLM_EXL3_PREFILL_TRELLIS", "1") != "1":
                 raise ValueError("mixed-K EXL3 requires VLLM_EXL3_PREFILL_TRELLIS=1")
-            scratch_bytes = 0
-            for tier in mixed["serial_tiers"]:
-                caps = fused_api.Caps(
-                    max_tokens=prefill_capacity,
-                    num_topk=topk,
-                    route_num_experts=total_experts,
-                    device=device,
-                    weight_plan=tier["weights"].plan,
-                    quant_mode="w4a16",
-                    w4a16_block_size_m=prefill_block_m,
-                )
-                plan = fused_api.plan(caps)
-                prefill_plans.append(plan)
-                spec = plan.scratch_specs()[0]
-                size = int(spec.dtype.itemsize)
-                for dim in spec.shape:
-                    size *= int(dim)
-                scratch_bytes = max(scratch_bytes, size)
-            prefill_arena = torch.empty(scratch_bytes, dtype=torch.uint8, device=device)
-            prefill_accum = torch.empty(
-                (prefill_capacity, int(layer.exl3_hidden_size)),
-                dtype=torch.float32,
-                device=device,
+            prefill = make_state(
+                prefill_capacity,
+                prefill_block_m,
+                mixed["prefill_tile_config"],
             )
         runtime = {
             "mixed_api": mixed_api,
-            "fused_api": fused_api,
             "decode": decode,
-            "prefill_plans": tuple(prefill_plans),
-            "prefill_arena": prefill_arena,
-            "prefill_accum": prefill_accum,
+            "prefill": prefill,
             "max_decode_m": max_decode_m,
             "max_batched_tokens": max_batched_tokens,
             "prefill_capacity": prefill_capacity,
         }
         _MIXED_TRELLIS_RUNTIMES[key] = runtime
         decode_bytes = _unique_tensor_storage_bytes(decode["buffers"])
-        prefill_bytes = sum(
-            tensor.numel() * tensor.element_size()
-            for tensor in (prefill_arena, prefill_accum)
-            if tensor is not None
+        prefill_bytes = (
+            0
+            if prefill is None
+            else _unique_tensor_storage_bytes(prefill["buffers"])
         )
         logger.info_once(
             "EXL3 mixed Trellis runtime planned: tiers=%s one-grid decode=%d "
-            "serial prefill=%d/%d block_m=%d buffers=%.1f+%.1f MiB",
+            "one-grid prefill=%d/%d block_m=%d buffers=%.1f+%.1f MiB",
             tier_signature,
             max_decode_m,
             prefill_capacity,
@@ -2298,71 +2257,56 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 f"m={m}, capacity={runtime['max_batched_tokens']}"
             )
         mixed = layer.exl3_mixed_trellis
-        # The cooperative mixed-K grid wins at small M, but its SM120 path is
-        # currently limited to route block 8.  Homogeneous tier plans support
-        # block 64 and are substantially faster for prefill, so keep the
-        # one-grid launch for decode and dispatch large M through the two
-        # serial tiers until the mixed kernel gains an efficient large block.
-        if m <= runtime["max_decode_m"]:
-            state = runtime["decode"]
-            output = runtime["mixed_api"].run_mixed_trellis(
-                x,
-                mixed["tiers"][0],
-                mixed["tiers"][1],
-                topk_weights,
-                topk_ids,
+        def run_state(
+            slice_x: torch.Tensor,
+            slice_weights: torch.Tensor,
+            slice_ids: torch.Tensor,
+            state: dict[str, Any],
+            tiers: tuple[Any, Any],
+        ) -> torch.Tensor:
+            return runtime["mixed_api"].run_mixed_trellis(
+                slice_x,
+                tiers[0],
+                tiers[1],
+                slice_weights,
+                slice_ids,
                 mixed["global_to_combined"],
                 mixed["descriptor_map"],
                 mixed["rotations"],
                 state["launch"],
                 state["buffers"],
+            ).to(slice_x.dtype)
+
+        if m <= runtime["max_decode_m"]:
+            return run_state(
+                x,
+                topk_weights,
+                topk_ids,
+                runtime["decode"],
+                mixed["tiers"],
             )
-            return output.to(x.dtype)
 
-        if runtime["prefill_arena"] is None or runtime["prefill_accum"] is None:
-            raise RuntimeError("mixed-K EXL3 serial prefill plan is unavailable")
+        if runtime["prefill"] is None:
+            raise RuntimeError("mixed-K EXL3 one-grid prefill plan is unavailable")
         prefill_capacity = int(runtime["prefill_capacity"])
-
-        def run_serial_slice(
-            slice_x: torch.Tensor,
-            slice_weights: torch.Tensor,
-            slice_ids: torch.Tensor,
-        ) -> torch.Tensor:
-            slice_m = int(slice_x.shape[0])
-            accum = runtime["prefill_accum"][:slice_m]
-            first = True
-            for plan, tier in zip(
-                runtime["prefill_plans"], mixed["serial_tiers"], strict=True
-            ):
-                binding = runtime["fused_api"].bind(
-                    plan,
-                    scratch=_scratch_view(
-                        runtime["prefill_arena"], plan.scratch_specs()[0]
-                    ),
-                    a=slice_x,
-                    experts=tier["weights"],
-                    topk_weights=slice_weights,
-                    topk_ids=slice_ids,
-                    route_expert_map=tier["route_expert_map"],
-                    output_expert_map=tier["route_expert_map"],
-                    output=accum if first else None,
-                )
-                tier_output = runtime["fused_api"].run(binding=binding)
-                if not first:
-                    accum.add_(tier_output)
-                first = False
-            return accum.to(slice_x.dtype)
-
         if m <= prefill_capacity:
-            return run_serial_slice(x, topk_weights, topk_ids)
+            return run_state(
+                x,
+                topk_weights,
+                topk_ids,
+                runtime["prefill"],
+                mixed["prefill_tiers"],
+            )
 
         output = torch.empty_like(x)
         for start in range(0, m, prefill_capacity):
             stop = min(start + prefill_capacity, m)
-            slice_output = run_serial_slice(
+            slice_output = run_state(
                 x[start:stop],
                 topk_weights[start:stop],
                 topk_ids[start:stop],
+                runtime["prefill"],
+                mixed["prefill_tiers"],
             )
             output[start:stop].copy_(slice_output)
         return output

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -292,7 +292,6 @@ def _positive_env_int(name: str, default: int) -> int:
         raise ValueError(f"{name} must be positive, got {value}")
     return value
 
-
 def _resolve_prefill_capacity(max_batched_tokens: int) -> int:
     """Resolve the optional EXL3 arena bound within the scheduler contract."""
 
@@ -2178,15 +2177,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         # bound remains fail-closed while a smaller opt-in Trellis capacity is
         # handled by slicing at dispatch.
         max_batched_tokens = int(layer.exl3_max_num_batched_tokens)
-        prefill_capacity = _positive_env_int(
-            "VLLM_EXL3_PREFILL_CAPACITY", max_batched_tokens
-        )
-        if prefill_capacity > max_batched_tokens:
-            raise ValueError(
-                "VLLM_EXL3_PREFILL_CAPACITY cannot exceed "
-                "max_num_batched_tokens: "
-                f"capacity={prefill_capacity}, max={max_batched_tokens}"
-            )
+        prefill_capacity = _resolve_prefill_capacity(max_batched_tokens)
         prefill_plan_enabled = prefill_trellis and max_batched_tokens > max_trellis_m
         parity_rows = (
             min(chunk, max_batched_tokens)

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -163,9 +163,22 @@ def _runtime_scope_id(quant_config: Any) -> int:
 
 
 _RANK_SLICED_FORMAT = "exl3-trellis"
+_PER_EXPERT_ROTATION_LAYOUT = "per_expert_v1"
+_SHARED_H_ROTATION_LAYOUT = "shared_h_v1"
+_SHARED_H_TENSOR_SCHEMA = (
+    "model.layers.{L}.mlp.experts.shared_h.{proj}.rank{r}.{suh|svh}"
+)
 _RANK_SLICED_WEIGHT_RE = re.compile(
     r"^(?P<prefix>.+)\.rank(?P<rank>\d+)\."
     r"(?P<field>trellis|suh|svh|mcg|mul1)$"
+)
+_SHARED_H_WEIGHT_RE = re.compile(
+    r"^(?P<experts_prefix>.+\.experts)\.shared_h\."
+    r"(?P<projection>gate_proj|up_proj|down_proj)\.rank(?P<rank>\d+)\."
+    r"(?P<field>suh|svh)$"
+)
+_EXPERT_PROJECTION_RE = re.compile(
+    r"^.+\.experts\.\d+\.(?P<projection>gate_proj|up_proj|down_proj)$"
 )
 
 ShardId = str | int | tuple[int, ...] | None
@@ -390,6 +403,7 @@ class Exl3Config(QuantizationConfig):
         self.tensor_storage = tensor_storage or {}
         self._eager_checked = False
         self.rank_sliced_metadata: dict[str, Any] | None = None
+        self.rank_sliced_rotation_layout = _PER_EXPERT_ROTATION_LAYOUT
         self.rank_sliced_k_values: tuple[int, ...] | None = None
         self.rank_sliced_bits_by_layer: dict[int, tuple[int, ...]] = {}
 
@@ -517,7 +531,30 @@ class Exl3Config(QuantizationConfig):
                 "unsupported rank-sliced EXL3 tensor schema: "
                 f"{metadata['tensor_schema']!r}"
             )
+        rotation_layout = str(
+            metadata.get("rotation_layout", _PER_EXPERT_ROTATION_LAYOUT)
+        )
+        if rotation_layout not in {
+            _PER_EXPERT_ROTATION_LAYOUT,
+            _SHARED_H_ROTATION_LAYOUT,
+        }:
+            raise ValueError(
+                f"unsupported rank-sliced EXL3 rotation_layout: {rotation_layout!r}"
+            )
+        shared_schema = metadata.get("shared_h_tensor_schema")
+        if rotation_layout == _SHARED_H_ROTATION_LAYOUT:
+            if shared_schema != _SHARED_H_TENSOR_SCHEMA:
+                raise ValueError(
+                    "shared_h_v1 rank-sliced EXL3 requires "
+                    f"shared_h_tensor_schema={_SHARED_H_TENSOR_SCHEMA!r}"
+                )
+        elif shared_schema is not None:
+            raise ValueError(
+                "shared_h_tensor_schema is only valid with "
+                "rotation_layout='shared_h_v1'"
+            )
         self.rank_sliced_metadata = dict(metadata)
+        self.rank_sliced_rotation_layout = rotation_layout
         bits_field = metadata["bits"]
         if isinstance(bits_field, str) and bits_field.strip().lower() == "mixed":
             k_values = tuple(
@@ -869,9 +906,40 @@ class Exl3Config(QuantizationConfig):
         """Drop non-local TP payloads and remove the serialized rank segment."""
         if self.rank_sliced_metadata is None:
             return name
+        shared_match = _SHARED_H_WEIGHT_RE.match(name)
+        if shared_match is not None:
+            if self.rank_sliced_rotation_layout != _SHARED_H_ROTATION_LAYOUT:
+                raise ValueError(
+                    "rank-sliced EXL3 contains shared-H tensors but metadata "
+                    "does not declare rotation_layout='shared_h_v1'"
+                )
+            projection = shared_match.group("projection")
+            field = shared_match.group("field")
+            expected_field = "svh" if projection == "down_proj" else "suh"
+            if field != expected_field:
+                raise ValueError(
+                    "invalid shared-H EXL3 tensor: "
+                    f"projection={projection!r} requires {expected_field}, got {field}"
+                )
+            if int(shared_match.group("rank")) != get_tensor_model_parallel_rank():
+                return None
+            return f"{shared_match.group('experts_prefix')}.0.{projection}.{field}"
         match = _RANK_SLICED_WEIGHT_RE.match(name)
         if match is None:
             return name
+        if self.rank_sliced_rotation_layout == _SHARED_H_ROTATION_LAYOUT:
+            projection_match = _EXPERT_PROJECTION_RE.match(match.group("prefix"))
+            if projection_match is not None:
+                projection = projection_match.group("projection")
+                field = match.group("field")
+                is_h_side = (
+                    projection in {"gate_proj", "up_proj"} and field == "suh"
+                ) or (projection == "down_proj" and field == "svh")
+                if is_h_side:
+                    raise ValueError(
+                        "shared_h_v1 must store H-side rotations under "
+                        "experts.shared_h, not under an expert id"
+                    )
         if int(match.group("rank")) != get_tensor_model_parallel_rank():
             return None
         return f"{match.group('prefix')}.{match.group('field')}"
@@ -1412,6 +1480,12 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         layer.exl3_intermediate_size_per_partition = intermediate_size_per_partition
         layer.exl3_params_dtype = params_dtype
         rank_sliced = self.quant_config.rank_sliced_metadata is not None
+        shared_h = (
+            rank_sliced
+            and self.quant_config.rank_sliced_rotation_layout
+            == _SHARED_H_ROTATION_LAYOUT
+        )
+        layer.exl3_shared_h_rotations = shared_h
         if rank_sliced:
             checkpoint_tp = int(self.quant_config.rank_sliced_metadata["tp"])
             if checkpoint_tp != layer.exl3_tp_size:
@@ -1464,11 +1538,15 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             layer.exl3_mixed_bitrate = len(set(layer.exl3_layer_bitrates)) > 1
         for prefix, shard_ids in (("w13", ("w1", "w3")), ("w2", ("w2",))):
             for suffix in ("suh", "svh", "trellis", "mcg", "mul1"):
+                shared_parameter = shared_h and (
+                    (prefix == "w13" and suffix == "suh")
+                    or (prefix == "w2" and suffix == "svh")
+                )
                 layer.register_parameter(
                     f"{prefix}_{suffix}",
                     Exl3MoEParameter(
                         weight_loader=_exl3_moe_weight_loader,
-                        num_experts=num_experts,
+                        num_experts=1 if shared_parameter else num_experts,
                         shard_ids=shard_ids,
                         preallocate=rank_sliced
                         and suffix
@@ -1486,7 +1564,16 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         for prefix, shard_ids in required.items():
             for attr in ("suh", "svh", "trellis"):
                 tensors = getattr(layer, f"{prefix}_{attr}").exl3_tensors
-                for expert_id in range(layer.local_num_experts):
+                shared_parameter = getattr(
+                    layer, "exl3_shared_h_rotations", False
+                ) and (
+                    (prefix == "w13" and attr == "suh")
+                    or (prefix == "w2" and attr == "svh")
+                )
+                expert_ids = (
+                    (0,) if shared_parameter else range(layer.local_num_experts)
+                )
+                for expert_id in expert_ids:
                     for shard_id in shard_ids:
                         if (expert_id, shard_id) not in tensors:
                             missing.append(f"{prefix}_{attr}[{expert_id},{shard_id}]")
@@ -1588,8 +1675,20 @@ class Exl3MoEMethod(FusedMoEMethodBase):
                 for shard_id in shard_ids:
                     key = (expert_id, shard_id)
                     trellis = getattr(layer, f"{group}_trellis").exl3_tensors[key]
-                    suh = getattr(layer, f"{group}_suh").exl3_tensors[key]
-                    svh = getattr(layer, f"{group}_svh").exl3_tensors[key]
+                    suh_key = (
+                        (0, shard_id)
+                        if getattr(layer, "exl3_shared_h_rotations", False)
+                        and group == "w13"
+                        else key
+                    )
+                    svh_key = (
+                        (0, shard_id)
+                        if getattr(layer, "exl3_shared_h_rotations", False)
+                        and group == "w2"
+                        else key
+                    )
+                    suh = getattr(layer, f"{group}_suh").exl3_tensors[suh_key]
+                    svh = getattr(layer, f"{group}_svh").exl3_tensors[svh_key]
                     if (
                         trellis.dtype != torch.int16
                         or trellis.ndim != 3
@@ -1635,16 +1734,39 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         return backing
 
     @staticmethod
-    def _pointer_table(slab: torch.Tensor) -> torch.Tensor:
+    def _pointer_table(
+        slab: torch.Tensor,
+        *,
+        num_experts: int | None = None,
+    ) -> torch.Tensor:
         if slab.ndim < 2 or not slab[0].is_contiguous():
             raise RuntimeError("EXL3 pointer-table rows must be contiguous")
+        rows = int(slab.shape[0])
+        entries = rows if num_experts is None else int(num_experts)
+        if rows not in {1, entries}:
+            raise RuntimeError(
+                "EXL3 pointer-table rows must be per-expert or broadcast: "
+                f"rows={rows}, experts={entries}"
+            )
         step = slab.stride(0) * slab.element_size()
         base = slab.data_ptr()
         return torch.tensor(
-            [base + expert_id * step for expert_id in range(slab.shape[0])],
+            [
+                base + (0 if rows == 1 else expert_id) * step
+                for expert_id in range(entries)
+            ],
             dtype=torch.int64,
             device=slab.device,
         )
+
+    @staticmethod
+    def _select_rotation_rows(
+        rotations: torch.Tensor,
+        expert_ids: torch.Tensor,
+    ) -> torch.Tensor:
+        if int(rotations.shape[0]) == 1:
+            return rotations
+        return rotations.index_select(0, expert_ids).contiguous()
 
     @staticmethod
     def _trellis_tile_config(hidden_size: int, intermediate_size: int):
@@ -1723,8 +1845,8 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             expert_id for expert_ids in tiers.values() for expert_id in expert_ids
         )
         tier_index = torch.tensor(tier_order, dtype=torch.long, device=device)
-        combined_gate_suh = gate_suh.index_select(0, tier_index).contiguous()
-        combined_up_suh = up_suh.index_select(0, tier_index).contiguous()
+        combined_gate_suh = self._select_rotation_rows(gate_suh, tier_index)
+        combined_up_suh = self._select_rotation_rows(up_suh, tier_index)
         combined_intermediate_rotations = torch.cat(
             (
                 gate_svh.index_select(0, tier_index),
@@ -1733,7 +1855,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             ),
             dim=1,
         ).contiguous()
-        combined_down_svh = down_svh.index_select(0, tier_index).contiguous()
+        combined_down_svh = self._select_rotation_rows(down_svh, tier_index)
         combined_rotations = SimpleNamespace(
             intermediate=combined_intermediate_rotations,
             gate_suh=combined_gate_suh,
@@ -1784,10 +1906,22 @@ class Exl3MoEMethod(FusedMoEMethodBase):
 
             index = torch.tensor(expert_ids, dtype=torch.long, device=device)
             tier_slice = slice(tier_offset, tier_offset + len(expert_ids))
-            tier_gate_suh = combined_gate_suh[tier_slice]
-            tier_up_suh = combined_up_suh[tier_slice]
+            tier_gate_suh = (
+                combined_gate_suh
+                if int(combined_gate_suh.shape[0]) == 1
+                else combined_gate_suh[tier_slice]
+            )
+            tier_up_suh = (
+                combined_up_suh
+                if int(combined_up_suh.shape[0]) == 1
+                else combined_up_suh[tier_slice]
+            )
             intermediate_rotations = combined_intermediate_rotations[tier_slice]
-            tier_down_svh = combined_down_svh[tier_slice]
+            tier_down_svh = (
+                combined_down_svh
+                if int(combined_down_svh.shape[0]) == 1
+                else combined_down_svh[tier_slice]
+            )
             prepared_tiers.append(
                 mixed_api.prepare_weights(
                     w13=w13,
@@ -1972,13 +2106,22 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             down_suh,
             down_svh,
         )
-        layer.exl3_pointer_tables = tuple(self._pointer_table(slab) for slab in slabs)
+        layer.exl3_pointer_tables = tuple(
+            self._pointer_table(slab, num_experts=num_experts) for slab in slabs
+        )
         layer.exl3_expert_map = torch.arange(
             num_experts,
             dtype=torch.int64,
             device=w13.device,
         )
         layer.exl3_trellis_tile_config = tile_config
+        if getattr(layer, "exl3_shared_h_rotations", False):
+            saved_bytes = (num_experts - 1) * 3 * hidden_size * 2
+            logger.info_once(
+                "EXL3 shared-H rotation layout active; saving %.2f MiB per "
+                "routed-expert layer and TP rank",
+                saved_bytes / (1024 * 1024),
+            )
 
     def get_fused_moe_quant_config(
         self, layer: RoutedExperts

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -1481,10 +1481,10 @@ class Exl3Config(QuantizationConfig):
             logger.warning_once(
                 "EXL3 BF16 online Trellis: encoding eligible non-EXL3 "
                 "linear weights at K=%d; 128-unaligned matrices retain the "
-                "configured MXFP8 path (module example: %s).",
+                "configured MXFP8 path.",
                 bits,
-                prefix,
             )
+            logger.debug("EXL3 BF16 online Trellis overlay applied to %s", prefix)
             return Exl3OnlineLinearMethod(
                 bits=bits,
                 prefix=prefix,
@@ -1494,9 +1494,8 @@ class Exl3Config(QuantizationConfig):
 
         logger.info_once(
             "EXL3 BF16 online overlay: quantizing non-EXL3 %s projections "
-            "to MXFP8 at load time (module example: %s).",
+            "to MXFP8 at load time.",
             "shared-expert" if shared_expert else "dense-linear",
-            prefix,
         )
         logger.debug("EXL3 BF16 MXFP8 overlay applied to %s", prefix)
         return Mxfp8OnlineLinearMethod()

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -31,6 +31,7 @@ import torch
 from transformers import PretrainedConfig
 
 from vllm.config import get_current_vllm_config_or_none
+from vllm.config.quantization import QuantizationConfigArgs
 from vllm.distributed import (
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
@@ -53,6 +54,14 @@ from vllm.model_executor.layers.quantization.base_config import (
     QuantizationConfig,
     QuantizeMethodBase,
 )
+from vllm.model_executor.layers.quantization.compressed_tensors.utils import (
+    should_ignore_layer,
+)
+from vllm.model_executor.layers.quantization.online.mxfp8 import (
+    Mxfp8OnlineLinearMethod,
+    is_shared_expert_projection,
+)
+from vllm.model_executor.layers.quantization.utils.quant_utils import kMxfp8Dynamic
 from vllm.model_executor.parameter import BasevLLMParameter
 from vllm.transformers_utils.repo_utils import get_hf_file_to_dict
 
@@ -682,14 +691,66 @@ class Exl3Config(QuantizationConfig):
         if is_lm_head and not prefix:
             prefix = "lm_head"
         if isinstance(layer, LinearBase) or is_lm_head:
-            if not self._linear_prefix_is_exl3(prefix):
-                return UnquantizedLinearMethod()
-            return Exl3LinearMethod(self)
+            if self._linear_prefix_is_exl3(prefix):
+                return Exl3LinearMethod(self)
+            if not is_lm_head and (
+                method := self._get_bf16_online_linear_method(layer, prefix)
+            ):
+                return method
+            return UnquantizedLinearMethod()
         if isinstance(layer, RoutedExperts):
             if not self._moe_prefix_is_exl3(prefix, layer):
                 return None
             return Exl3MoEMethod(self, layer.moe_config)
         return None
+
+    def _get_bf16_online_linear_method(
+        self, layer: torch.nn.Module, prefix: str
+    ) -> QuantizeMethodBase | None:
+        """Overlay MXFP8 only on linears absent from EXL3 tensor storage.
+
+        EXL3-owned dense matrices are selected before this method and routed
+        experts never enter it. Shared-expert projections have an independent
+        spec so a broad ``linear`` overlay cannot quantize them accidentally.
+        """
+        if not isinstance(layer, LinearBase):
+            return None
+
+        vllm_config = get_current_vllm_config_or_none()
+        if vllm_config is None:
+            return None
+        args = vllm_config.model_config.quantization_config
+        if not isinstance(args, QuantizationConfigArgs):
+            return None
+
+        shared_expert = is_shared_expert_projection(prefix)
+        spec = args.shared_experts if shared_expert else args.linear
+        if spec is None:
+            return None
+        if (
+            not shared_expert
+            and args.ignore
+            and should_ignore_layer(
+                prefix,
+                ignore=args.ignore,
+                fused_mapping=self.packed_modules_mapping,
+            )
+        ):
+            return None
+        if spec.weight != kMxfp8Dynamic or spec.activation is not None:
+            raise ValueError(
+                "EXL3 BF16 online overlay only supports weight='mxfp8' "
+                "with no activation override."
+            )
+
+        logger.info_once(
+            "EXL3 BF16 online overlay: quantizing non-EXL3 %s projections "
+            "to MXFP8 at load time (module example: %s).",
+            "shared-expert" if shared_expert else "dense-linear",
+            prefix,
+        )
+        logger.debug("EXL3 BF16 MXFP8 overlay applied to %s", prefix)
+        return Mxfp8OnlineLinearMethod()
 
     def _storage_entry(self, prefix: str) -> dict[str, Any] | None:
         candidates = [prefix]

--- a/vllm/model_executor/layers/quantization/exl3_online_cache.py
+++ b/vllm/model_executor/layers/quantization/exl3_online_cache.py
@@ -1,0 +1,325 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Persistent cache for deterministic online EXL3 weight encoding."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+from collections.abc import Callable, Mapping
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+import filelock
+import torch
+from safetensors import safe_open
+from safetensors.torch import load_file, save_file
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+_CACHE_SCHEMA = 1
+_CACHE_TENSORS = frozenset({"trellis", "suh", "svh"})
+CacheMode = Literal["off", "readonly", "readwrite"]
+QuantizeFn = Callable[[], tuple[Mapping[str, torch.Tensor], float | None]]
+
+
+@dataclass(frozen=True)
+class Exl3OnlineCacheKey:
+    """All inputs that can change one rank-local online EXL3 payload."""
+
+    model_identity: str
+    encoder_identity: str
+    prefix: str
+    bits: int
+    seed: int
+    tp_world_size: int
+    tp_rank: int
+    input_size: int
+    output_size: int
+    codebook: str = "mcg"
+    apply_out_scales: bool = True
+    schema: int = _CACHE_SCHEMA
+
+    def canonical_json(self) -> str:
+        return json.dumps(asdict(self), sort_keys=True, separators=(",", ":"))
+
+    def digest(self) -> str:
+        return hashlib.sha256(self.canonical_json().encode()).hexdigest()
+
+
+@dataclass(frozen=True)
+class Exl3OnlineCacheResult:
+    tensors: dict[str, torch.Tensor]
+    proxy_error: float | None
+    hit: bool
+    path: Path | None
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        while chunk := source.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def resolve_model_identity(
+    model_name: str,
+    *,
+    revision: str | None = None,
+    hf_config: Any | None = None,
+) -> str:
+    """Fingerprint a Hub revision or a local checkpoint without reading weights."""
+
+    resolved_revision = revision or getattr(hf_config, "_commit_hash", None)
+    model_path = Path(model_name).expanduser()
+    if not model_path.exists():
+        payload = {
+            "kind": "hub",
+            "model": model_name,
+            "revision": resolved_revision or "unresolved",
+        }
+        return hashlib.sha256(json.dumps(payload, sort_keys=True).encode()).hexdigest()
+
+    model_path = model_path.resolve()
+    if model_path.is_file():
+        stat = model_path.stat()
+        payload = {
+            "kind": "file",
+            "path": str(model_path),
+            "size": stat.st_size,
+            "mtime_ns": stat.st_mtime_ns,
+        }
+        if stat.st_size <= 16 * 1024 * 1024:
+            payload["sha256"] = _sha256_file(model_path)
+        return hashlib.sha256(json.dumps(payload, sort_keys=True).encode()).hexdigest()
+
+    markers: list[tuple[str, str]] = []
+    for name in (
+        "config.json",
+        "quantization_config.json",
+        "model.safetensors.index.json",
+        "pytorch_model.bin.index.json",
+        "tier_bitmap.json",
+    ):
+        path = model_path / name
+        if path.is_file():
+            markers.append((name, _sha256_file(path)))
+
+    shards: list[tuple[str, str, int, int]] = []
+    for pattern in ("*.safetensors", "*.bin", "*.gguf"):
+        for path in sorted(model_path.glob(pattern)):
+            resolved = path.resolve()
+            stat = resolved.stat()
+            shards.append(
+                (
+                    path.name,
+                    str(resolved),
+                    stat.st_size,
+                    stat.st_mtime_ns,
+                )
+            )
+    payload = {
+        "kind": "directory",
+        "path": str(model_path),
+        "revision": resolved_revision,
+        "markers": markers,
+        "shards": shards,
+    }
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+
+
+def resolve_encoder_identity(
+    package_root: str | Path,
+    *,
+    revision: str | None = None,
+) -> str:
+    """Identify the encoder implementation used to produce cached tensors."""
+
+    root = Path(package_root).expanduser().resolve()
+    if revision and revision.strip():
+        payload = {"root": str(root), "revision": revision.strip()}
+    else:
+        files = [
+            (str(path.relative_to(root)), _sha256_file(path))
+            for path in sorted(root.rglob("*.py"))
+            if path.is_file()
+        ]
+        if not files:
+            raise ValueError(f"EXL3 encoder source contains no Python files: {root}")
+        payload = {"root": str(root), "files": files}
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+
+
+def cache_mode() -> CacheMode:
+    raw = os.getenv("VLLM_EXL3_ONLINE_CACHE_MODE", "readwrite").strip().lower()
+    aliases = {"read-only": "readonly", "rw": "readwrite", "none": "off"}
+    raw = aliases.get(raw, raw)
+    if raw not in {"off", "readonly", "readwrite"}:
+        raise ValueError(
+            "VLLM_EXL3_ONLINE_CACHE_MODE must be off, readonly, or readwrite; "
+            f"got {raw!r}"
+        )
+    return raw  # type: ignore[return-value]
+
+
+def cache_root() -> Path:
+    configured = os.getenv("VLLM_EXL3_ONLINE_CACHE_DIR")
+    if configured and configured.strip():
+        return Path(configured).expanduser()
+    vllm_root = Path(os.getenv("VLLM_CACHE_ROOT", "~/.cache/vllm")).expanduser()
+    return vllm_root / "exl3_online"
+
+
+def cache_path(key: Exl3OnlineCacheKey) -> Path:
+    digest = key.digest()
+    model_dir = key.model_identity[:20]
+    rank_dir = f"tp{key.tp_world_size}-rank{key.tp_rank}"
+    return (
+        cache_root()
+        / f"v{_CACHE_SCHEMA}"
+        / model_dir
+        / rank_dir
+        / f"{digest}.safetensors"
+    )
+
+
+def _validate_tensors(
+    tensors: Mapping[str, torch.Tensor], key: Exl3OnlineCacheKey
+) -> None:
+    if set(tensors) != _CACHE_TENSORS:
+        raise ValueError(
+            f"online EXL3 cache tensor set is {sorted(tensors)}, "
+            f"expected {sorted(_CACHE_TENSORS)}"
+        )
+    expected = {
+        "trellis": (
+            torch.int16,
+            (key.input_size // 16, key.output_size // 16, key.bits * 16),
+        ),
+        "suh": (torch.float16, (key.input_size,)),
+        "svh": (torch.float16, (key.output_size,)),
+    }
+    for name, (dtype, shape) in expected.items():
+        tensor = tensors[name]
+        if tensor.dtype != dtype or tuple(tensor.shape) != shape:
+            raise ValueError(
+                f"online EXL3 cache {name} has {tensor.dtype}/{tuple(tensor.shape)}, "
+                f"expected {dtype}/{shape}"
+            )
+        if not tensor.is_contiguous():
+            raise ValueError(f"online EXL3 cache {name} must be contiguous")
+
+
+def _load(path: Path, key: Exl3OnlineCacheKey) -> Exl3OnlineCacheResult:
+    with safe_open(path, framework="pt", device="cpu") as handle:
+        metadata = handle.metadata() or {}
+    if metadata.get("cache_key") != key.canonical_json():
+        raise ValueError("online EXL3 cache key metadata does not match")
+    tensors = load_file(path, device="cpu")
+    _validate_tensors(tensors, key)
+    raw_error = metadata.get("proxy_error")
+    proxy_error = None if raw_error in (None, "") else float(raw_error)
+    return Exl3OnlineCacheResult(dict(tensors), proxy_error, True, path)
+
+
+def _to_device(
+    result: Exl3OnlineCacheResult, device: torch.device
+) -> Exl3OnlineCacheResult:
+    tensors = {
+        name: tensor.to(device=device, non_blocking=False).contiguous()
+        for name, tensor in result.tensors.items()
+    }
+    return Exl3OnlineCacheResult(tensors, result.proxy_error, result.hit, result.path)
+
+
+def _quantize(
+    key: Exl3OnlineCacheKey,
+    quantize: QuantizeFn,
+    *,
+    path: Path | None,
+) -> Exl3OnlineCacheResult:
+    tensors, proxy_error = quantize()
+    tensors = {name: tensor.contiguous() for name, tensor in tensors.items()}
+    _validate_tensors(tensors, key)
+    return Exl3OnlineCacheResult(tensors, proxy_error, False, path)
+
+
+def _save(path: Path, key: Exl3OnlineCacheKey, result: Exl3OnlineCacheResult) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    cpu_tensors = {
+        name: tensor.detach().to(device="cpu").contiguous()
+        for name, tensor in result.tensors.items()
+    }
+    metadata = {
+        "cache_key": key.canonical_json(),
+        "proxy_error": "" if result.proxy_error is None else repr(result.proxy_error),
+    }
+    fd, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
+    )
+    os.close(fd)
+    temporary = Path(temporary_name)
+    try:
+        save_file(cpu_tensors, temporary, metadata=metadata)
+        with temporary.open("rb") as output:
+            os.fsync(output.fileno())
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def load_or_quantize(
+    key: Exl3OnlineCacheKey,
+    *,
+    device: torch.device,
+    quantize: QuantizeFn,
+) -> Exl3OnlineCacheResult:
+    """Load one rank-local payload or encode and atomically publish it."""
+
+    mode = cache_mode()
+    if mode == "off":
+        return _quantize(key, quantize, path=None)
+
+    path = cache_path(key)
+    if path.is_file():
+        try:
+            return _to_device(_load(path, key), device)
+        except Exception as exc:
+            logger.warning("Ignoring invalid online EXL3 cache %s: %s", path, exc)
+
+    if mode == "readonly":
+        return _quantize(key, quantize, path=path)
+
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        lock = filelock.FileLock(f"{path}.lock", mode=0o666)
+        with lock:
+            if path.is_file():
+                try:
+                    return _to_device(_load(path, key), device)
+                except Exception as exc:
+                    logger.warning(
+                        "Replacing invalid online EXL3 cache %s: %s", path, exc
+                    )
+                    path.unlink(missing_ok=True)
+            result = _quantize(key, quantize, path=path)
+            _save(path, key, result)
+            return result
+    except OSError as exc:
+        logger.warning(
+            "Online EXL3 cache is unavailable at %s; encoding without cache: %s",
+            path,
+            exc,
+        )
+        return _quantize(key, quantize, path=None)

--- a/vllm/model_executor/layers/quantization/exl3_online_cache.py
+++ b/vllm/model_executor/layers/quantization/exl3_online_cache.py
@@ -17,7 +17,7 @@ from typing import Any, Literal
 import filelock
 import torch
 from safetensors import safe_open
-from safetensors.torch import load_file, save_file
+from safetensors.torch import save_file
 
 from vllm.logger import init_logger
 
@@ -77,13 +77,19 @@ def resolve_model_identity(
 ) -> str:
     """Fingerprint a Hub revision or a local checkpoint without reading weights."""
 
-    resolved_revision = revision or getattr(hf_config, "_commit_hash", None)
+    resolved_revision = getattr(hf_config, "_commit_hash", None) or revision
     model_path = Path(model_name).expanduser()
     if not model_path.exists():
+        if not resolved_revision:
+            raise ValueError(
+                "online EXL3 caching requires a resolved revision for Hub "
+                f"checkpoint {model_name!r}; pass --revision or set "
+                "VLLM_EXL3_ONLINE_CACHE_MODE=off"
+            )
         payload = {
             "kind": "hub",
             "model": model_name,
-            "revision": resolved_revision or "unresolved",
+            "revision": resolved_revision,
         }
         return hashlib.sha256(json.dumps(payload, sort_keys=True).encode()).hexdigest()
 
@@ -174,6 +180,13 @@ def cache_mode() -> CacheMode:
 
 
 def cache_root() -> Path:
+    """Return the trusted online-weight cache directory.
+
+    Cached payloads become model weights after schema validation. The directory
+    must therefore be writable only by the serving user and trusted to the same
+    degree as the source checkpoint.
+    """
+
     configured = os.getenv("VLLM_EXL3_ONLINE_CACHE_DIR")
     if configured and configured.strip():
         return Path(configured).expanduser()
@@ -224,9 +237,10 @@ def _validate_tensors(
 def _load(path: Path, key: Exl3OnlineCacheKey) -> Exl3OnlineCacheResult:
     with safe_open(path, framework="pt", device="cpu") as handle:
         metadata = handle.metadata() or {}
-    if metadata.get("cache_key") != key.canonical_json():
-        raise ValueError("online EXL3 cache key metadata does not match")
-    tensors = load_file(path, device="cpu")
+        if metadata.get("cache_key") != key.canonical_json():
+            raise ValueError("online EXL3 cache key metadata does not match")
+        # ``safe_open`` exposes ``keys()`` but is not itself iterable.
+        tensors = {name: handle.get_tensor(name) for name in handle.keys()}  # noqa: SIM118
     _validate_tensors(tensors, key)
     raw_error = metadata.get("proxy_error")
     proxy_error = None if raw_error in (None, "") else float(raw_error)
@@ -299,11 +313,11 @@ def load_or_quantize(
             logger.warning("Ignoring invalid online EXL3 cache %s: %s", path, exc)
 
     if mode == "readonly":
-        return _quantize(key, quantize, path=path)
+        return _quantize(key, quantize, path=None)
 
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
-        lock = filelock.FileLock(f"{path}.lock", mode=0o666)
+        lock = filelock.FileLock(f"{path}.lock")
         with lock:
             if path.is_file():
                 try:

--- a/vllm/model_executor/layers/quantization/exl3_online_cache.py
+++ b/vllm/model_executor/layers/quantization/exl3_online_cache.py
@@ -27,6 +27,9 @@ logger = init_logger(__name__)
 
 _CACHE_SCHEMA = 1
 _CACHE_TENSORS = frozenset({"trellis", "suh", "svh"})
+# A competing loader may need several minutes to encode a large projection.
+# After this bound, local encoding is preferable to blocking model startup.
+_CACHE_LOCK_TIMEOUT_SECONDS = 600.0
 CacheMode = Literal["off", "readonly", "readwrite"]
 QuantizeFn = Callable[[], tuple[Mapping[str, torch.Tensor], float | None]]
 
@@ -337,7 +340,7 @@ def load_or_quantize(
 
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
-        lock = filelock.FileLock(f"{path}.lock")
+        lock = filelock.FileLock(f"{path}.lock", timeout=_CACHE_LOCK_TIMEOUT_SECONDS)
         with lock:
             if path.is_file():
                 try:
@@ -361,6 +364,15 @@ def load_or_quantize(
                     result.tensors, result.proxy_error, False, None
                 )
             return result
+    except filelock.Timeout as exc:
+        logger.warning(
+            "Online EXL3 cache lock remained held for %.0f seconds at %s; "
+            "encoding without cache: %s",
+            _CACHE_LOCK_TIMEOUT_SECONDS,
+            path,
+            exc,
+        )
+        return _quantize(key, quantize, path=None)
     except OSError as exc:
         logger.warning(
             "Online EXL3 cache is unavailable at %s; encoding without cache: %s",

--- a/vllm/model_executor/layers/quantization/exl3_online_cache.py
+++ b/vllm/model_executor/layers/quantization/exl3_online_cache.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 import os
 import tempfile
 from collections.abc import Callable, Mapping
@@ -27,6 +28,10 @@ _CACHE_SCHEMA = 1
 _CACHE_TENSORS = frozenset({"trellis", "suh", "svh"})
 CacheMode = Literal["off", "readonly", "readwrite"]
 QuantizeFn = Callable[[], tuple[Mapping[str, torch.Tensor], float | None]]
+
+
+class Exl3OnlineNonFiniteError(ValueError):
+    """An online EXL3 payload contains a non-finite scale or error metric."""
 
 
 @dataclass(frozen=True)
@@ -232,6 +237,19 @@ def _validate_tensors(
             )
         if not tensor.is_contiguous():
             raise ValueError(f"online EXL3 cache {name} must be contiguous")
+        if tensor.is_floating_point() and not torch.isfinite(tensor).all():
+            raise Exl3OnlineNonFiniteError(
+                f"online EXL3 cache {name} contains non-finite values for "
+                f"{key.prefix} (TP rank {key.tp_rank})"
+            )
+
+
+def _validate_proxy_error(proxy_error: float | None, key: Exl3OnlineCacheKey) -> None:
+    if proxy_error is not None and not math.isfinite(proxy_error):
+        raise Exl3OnlineNonFiniteError(
+            "online EXL3 encoder returned a non-finite proxy error for "
+            f"{key.prefix} (TP rank {key.tp_rank})"
+        )
 
 
 def _load(path: Path, key: Exl3OnlineCacheKey) -> Exl3OnlineCacheResult:
@@ -244,6 +262,7 @@ def _load(path: Path, key: Exl3OnlineCacheKey) -> Exl3OnlineCacheResult:
     _validate_tensors(tensors, key)
     raw_error = metadata.get("proxy_error")
     proxy_error = None if raw_error in (None, "") else float(raw_error)
+    _validate_proxy_error(proxy_error, key)
     return Exl3OnlineCacheResult(dict(tensors), proxy_error, True, path)
 
 
@@ -266,6 +285,7 @@ def _quantize(
     tensors, proxy_error = quantize()
     tensors = {name: tensor.contiguous() for name, tensor in tensors.items()}
     _validate_tensors(tensors, key)
+    _validate_proxy_error(proxy_error, key)
     return Exl3OnlineCacheResult(tensors, proxy_error, False, path)
 
 

--- a/vllm/model_executor/layers/quantization/exl3_online_cache.py
+++ b/vllm/model_executor/layers/quantization/exl3_online_cache.py
@@ -20,6 +20,7 @@ import torch
 from safetensors import safe_open
 from safetensors.torch import save_file
 
+import vllm.envs as envs
 from vllm.logger import init_logger
 
 logger = init_logger(__name__)
@@ -195,8 +196,7 @@ def cache_root() -> Path:
     configured = os.getenv("VLLM_EXL3_ONLINE_CACHE_DIR")
     if configured and configured.strip():
         return Path(configured).expanduser()
-    vllm_root = Path(os.getenv("VLLM_CACHE_ROOT", "~/.cache/vllm")).expanduser()
-    return vllm_root / "exl3_online"
+    return Path(envs.VLLM_CACHE_ROOT) / "exl3_online"
 
 
 def cache_path(key: Exl3OnlineCacheKey) -> Path:
@@ -329,7 +329,7 @@ def load_or_quantize(
     if path.is_file():
         try:
             return _to_device(_load(path, key), device)
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001 - invalid caches are regenerated
             logger.warning("Ignoring invalid online EXL3 cache %s: %s", path, exc)
 
     if mode == "readonly":
@@ -342,13 +342,24 @@ def load_or_quantize(
             if path.is_file():
                 try:
                     return _to_device(_load(path, key), device)
-                except Exception as exc:
+                except Exception as exc:  # noqa: BLE001 - invalid caches are replaced
                     logger.warning(
                         "Replacing invalid online EXL3 cache %s: %s", path, exc
                     )
                     path.unlink(missing_ok=True)
             result = _quantize(key, quantize, path=path)
-            _save(path, key, result)
+            try:
+                _save(path, key, result)
+            except Exception as exc:  # noqa: BLE001 - cache publication is optional
+                logger.warning(
+                    "Unable to publish online EXL3 cache %s; using the encoded "
+                    "weights for this process: %s",
+                    path,
+                    exc,
+                )
+                return Exl3OnlineCacheResult(
+                    result.tensors, result.proxy_error, False, None
+                )
             return result
     except OSError as exc:
         logger.warning(

--- a/vllm/model_executor/model_loader/utils.py
+++ b/vllm/model_executor/model_loader/utils.py
@@ -2,13 +2,13 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Utilities for selecting and loading models."""
 
+import gc
 import inspect
 import warnings
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import Any
 
-import gc
 import torch
 from torch import nn
 from typing_extensions import assert_never

--- a/vllm/model_executor/model_loader/utils.py
+++ b/vllm/model_executor/model_loader/utils.py
@@ -8,6 +8,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import Any
 
+import gc
 import torch
 from torch import nn
 from typing_extensions import assert_never
@@ -114,6 +115,22 @@ def process_weights_after_loading(
             # Repacking transients above can leave large amounts of memory in
             # the caching allocator, which starves the OS on UMA devices.
             release_device_memory_under_pressure(target_device)
+
+    # Every fused MoE layer is prepared by now, so no further R7 ballast
+    # request can occur. The pool is never-read scratch that would otherwise
+    # stay resident for the process lifetime at the direct expense of KV
+    # cache. Released once, here: releasing per layer refragments the heap
+    # and OOMs the load. Inert unless the EXL3 R7 path allocated it.
+    try:
+        from vllm.model_executor.layers.quantization import exl3 as _exl3_r7
+
+        _r7_pool = getattr(_exl3_r7, "_R7_BALLAST_POOL", None)
+        if _r7_pool:
+            _r7_pool.clear()
+            gc.collect()
+            torch.cuda.empty_cache()
+    except Exception:  # noqa: BLE001 - never block model load on cleanup
+        logger.debug("EXL3 R7 ballast release skipped", exc_info=True)
 
     # Initialize post-load attention weights for Attention, MLA, and MM encoder.
     # NOTE: Happens after other modules so we can easily decompress weights.

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -2196,7 +2196,19 @@ class GlmMoeDsaForCausalLM(DeepseekV2ForCausalLM):
 # Compatibility with
 # https://huggingface.co/deepseek-ai/DeepSeek-V3-Base/blob/main/configuration_deepseek.py
 def _skip_disabled_mtp_weight(config, name: str) -> bool:
-    """True when `name` belongs to an MTP layer that this config never builds."""
+    """Report whether a checkpoint weight targets a disabled MTP layer.
+
+    Args:
+        config: Model config carrying `num_nextn_predict_layers` and
+            `num_hidden_layers`. Malformed values are treated as "cannot
+            decide" rather than raised.
+        name: Checkpoint weight name as it appears in the safetensors index.
+
+    Returns:
+        True when MTP is disabled (`num_nextn_predict_layers == 0`) and
+        `name` addresses a layer at or beyond `num_hidden_layers`, i.e. an
+        MTP-layer tensor with no destination module; False otherwise.
+    """
 
     try:
         nextn = int(getattr(config, "num_nextn_predict_layers", 0) or 0)

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -24,6 +24,7 @@
 # limitations under the License.
 """Inference-only DeepseekV2/DeepseekV3 model."""
 
+import re
 import typing
 from collections.abc import Callable, Iterable
 from itertools import islice
@@ -1815,6 +1816,13 @@ class DeepseekV2Model(nn.Module):
             if "rotary_emb.inv_freq" in name:
                 continue
 
+            # When num_nextn_predict_layers == 0 the MTP layers are never
+            # built, so get_spec_layer_idx_from_weight_name does not divert
+            # their checkpoint tensors and they reach AutoWeightsLoader with
+            # no destination, raising KeyError (e.g.
+            # 'layers.78.eh_proj.weight'). Inert when MTP is enabled.
+            if _skip_disabled_mtp_weight(self.config, name):
+                continue
             spec_layer = get_spec_layer_idx_from_weight_name(self.config, name)
             if spec_layer is not None:
                 continue  # skip spec decode layers for main model
@@ -2187,6 +2195,20 @@ class GlmMoeDsaForCausalLM(DeepseekV2ForCausalLM):
 
 # Compatibility with
 # https://huggingface.co/deepseek-ai/DeepSeek-V3-Base/blob/main/configuration_deepseek.py
+def _skip_disabled_mtp_weight(config, name: str) -> bool:
+    """True when `name` belongs to an MTP layer that this config never builds."""
+
+    try:
+        nextn = int(getattr(config, "num_nextn_predict_layers", 0) or 0)
+        hidden = int(getattr(config, "num_hidden_layers", 0) or 0)
+    except (TypeError, ValueError):
+        return False
+    if nextn != 0 or hidden <= 0:
+        return False
+    match = re.search(r"(?:^|\.)layers\.(\d+)\.", name)
+    return match is not None and int(match.group(1)) >= hidden
+
+
 def get_spec_layer_idx_from_weight_name(
     config: DeepseekV2Config | DeepseekV3Config, weight_name: str
 ) -> int | None:

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -2241,11 +2241,12 @@ def get_spec_layer_idx_from_weight_name(
     layer_idx = _nonnegative_layer_count(config, "num_hidden_layers")
     if nextn is None or layer_idx is None or nextn == 0:
         return None
-    for i in range(nextn):
-        if weight_name.startswith(
-            f"model.layers.{layer_idx + i}."
-        ) or weight_name.startswith(f"layers.{layer_idx + i}."):
-            return layer_idx + i
+    match = re.match(r"^(?:model\.)?layers\.(\d+)\.", weight_name)
+    if match is None:
+        return None
+    weight_layer_idx = int(match.group(1))
+    if layer_idx <= weight_layer_idx < layer_idx + nextn:
+        return weight_layer_idx
     return None
 
 

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -24,6 +24,7 @@
 # limitations under the License.
 """Inference-only DeepseekV2/DeepseekV3 model."""
 
+import operator
 import re
 import typing
 from collections.abc import Callable, Iterable
@@ -2195,6 +2196,19 @@ class GlmMoeDsaForCausalLM(DeepseekV2ForCausalLM):
 
 # Compatibility with
 # https://huggingface.co/deepseek-ai/DeepSeek-V3-Base/blob/main/configuration_deepseek.py
+def _nonnegative_layer_count(config, name: str, *, default: int = 0) -> int | None:
+    """Return an integral layer count, or None for malformed config values."""
+
+    value = getattr(config, name, default)
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        value = operator.index(value)
+    except TypeError:
+        return None
+    return value if value >= 0 else None
+
+
 def _skip_disabled_mtp_weight(config, name: str) -> bool:
     """Report whether a checkpoint weight targets a disabled MTP layer.
 
@@ -2210,10 +2224,9 @@ def _skip_disabled_mtp_weight(config, name: str) -> bool:
         MTP-layer tensor with no destination module; False otherwise.
     """
 
-    try:
-        nextn = int(getattr(config, "num_nextn_predict_layers", 0) or 0)
-        hidden = int(getattr(config, "num_hidden_layers", 0) or 0)
-    except (TypeError, ValueError):
+    nextn = _nonnegative_layer_count(config, "num_nextn_predict_layers")
+    hidden = _nonnegative_layer_count(config, "num_hidden_layers")
+    if nextn is None or hidden is None:
         return False
     if nextn != 0 or hidden <= 0:
         return False
@@ -2224,16 +2237,15 @@ def _skip_disabled_mtp_weight(config, name: str) -> bool:
 def get_spec_layer_idx_from_weight_name(
     config: DeepseekV2Config | DeepseekV3Config, weight_name: str
 ) -> int | None:
-    if (
-        hasattr(config, "num_nextn_predict_layers")
-        and config.num_nextn_predict_layers > 0
-    ):
-        layer_idx = config.num_hidden_layers
-        for i in range(config.num_nextn_predict_layers):
-            if weight_name.startswith(
-                f"model.layers.{layer_idx + i}."
-            ) or weight_name.startswith(f"layers.{layer_idx + i}."):
-                return layer_idx + i
+    nextn = _nonnegative_layer_count(config, "num_nextn_predict_layers")
+    layer_idx = _nonnegative_layer_count(config, "num_hidden_layers")
+    if nextn is None or layer_idx is None or nextn == 0:
+        return None
+    for i in range(nextn):
+        if weight_name.startswith(
+            f"model.layers.{layer_idx + i}."
+        ) or weight_name.startswith(f"layers.{layer_idx + i}."):
+            return layer_idx + i
     return None
 
 

--- a/vllm/model_executor/warmup/kernel_warmup.py
+++ b/vllm/model_executor/warmup/kernel_warmup.py
@@ -23,6 +23,9 @@ from vllm.model_executor.kernels.linear.scaled_mm.b12x_tensor import (
     warmup_b12x_tensor_fp8_linear,
 )
 from vllm.model_executor.layers.fused_moe.b12x_moe import warmup_b12x_moe_dynamic
+from vllm.model_executor.layers.quantization.exl3 import (
+    warmup_exl3_mixed_trellis_route_pack,
+)
 from vllm.model_executor.warmup.b12x_sparse_indexer_warmup import (
     warmup_b12x_sparse_indexer,
 )
@@ -366,6 +369,16 @@ def kernel_warmup(worker: "Worker"):
         max_tokens=max(moe_token_counts),
         token_counts=moe_token_counts,
     )
+    free_before_exl3_warmup = torch.cuda.mem_get_info()[0]
+    warmed_exl3_route_pack = warmup_exl3_mixed_trellis_route_pack(worker.get_model())
+    if warmed_exl3_route_pack:
+        free_after_exl3_warmup = torch.cuda.mem_get_info()[0]
+        logger.info(
+            "Warmed up %d EXL3 mixed-Trellis route-pack variant(s); "
+            "free-memory delta %.1f MiB.",
+            warmed_exl3_route_pack,
+            (free_before_exl3_warmup - free_after_exl3_warmup) / (1 << 20),
+        )
 
     minimax_m3_msa_warmup(worker)
 


### PR DESCRIPTION
# [EXL3] share one reconstruct-scratch arena across dense prefill geometries

Stacked on #318 (same branch base `codex/gg-exl3-r7-k345-20260810`; the first
commits are #314/#316/#318 — review only the last one, `96972e10f5bf`).
Addresses dense EXL3 prefill **memory**, the scratch introduced by #316.

## Problem

#316's prefill dispatch keeps one persistent fp16 `(K, min(N, 32768))`
scratch per distinct `(device, K, N-chunk)` geometry, never freed
(`_EXL3_RECONSTRUCT_SCRATCH`). One geometry is bounded at 336 MB, but a real
dense checkpoint has many: Qwen3.8-27B (409 EXL3 modules) has 9 distinct
geometries, and the 8 that run during vLLM's profiling prefill hold
**790 MiB** for the lifetime of the process:

| geometry (K × chunk) | MiB | modules sharing it |
|---|---:|---:|
| 5120×17408 (gate/up) | 170.0 | 130 |
| 17408×5120 (down) | 170.0 | 65 |
| 5120×12288 (q) | 120.0 | 17 |
| 5120×10240 (GDN in_proj) | 100.0 | 48 |
| 10240×5120 (mtp.fc) | 100.0 | 1 |
| 5120×6144 (GDN ba) | 60.0 | 48 |
| 6144×5120 (o/out) | 60.0 | 65 |
| 5120×1024 (k/v) | 10.0 | 34 |
| head 5120×32768 (only at ≥128 sampled logit rows) | +320.0 | 1 |

Because the buffers allocate during the profiling prefill, they are inside
the measured peak and shrink the automatically sized KV pool byte for byte.

## Change

Replace the per-geometry dict with **one byte arena per device**, grow-to-max
while eager, serving every geometry a `(K, chunk)` fp16 view at offset 0.
This is the sharing rule #203 prescribed for the MoE arenas ("keep separate
*plans*, share the *bytes*") applied to the dense path, and it is sound for
the same reason: the scratch is written (`ext.reconstruct[_slice]`) and fully
consumed (`ext.hgemm`, or the FP8 scale probe's `amax`) inside one eager
`_reconstruct_hgemm_into`/`_fp8_weight_scale` call on one stream, and no view
outlives the call — so at most one geometry's scratch is ever live, and the
arena needs only the largest geometry's bytes (170 MiB here; 320 MiB if the
head's reconstruct ever runs).

The dict already shared one buffer per geometry across all 130 same-geometry
layers and across target/MTP-draft — serialized execution is a load-bearing
assumption of the *existing* code. The arena extends that assumption across
geometries and adds no new one. If model layers ever run concurrently on
independent streams, both the old dict and this arena need owner-local or
synchronized storage.

## What it provably does not change

**The kernels see identical operands.** The arena view is
`arena[:2*k*n].view(float16).view(k, n)`: contiguous, offset 0, identical
shape/strides/dtype to the `torch.empty((k, n))` it replaces. Same kernels,
same launch order, same values — only the backing allocation is shared.

Measured on an RTX 5090 A/B (Qwen3.8-27B-EXL3, MTP-3, `FULL_DECODE_ONLY`,
greedy):

- a 30-case deterministic vision suite returned **byte-identical answers on
  both arms** (24/30 correct on each, equal to the checkpoint's
  qualification reference);
- a full-window needle (258,925-token prompt, depth 0.5) retrieved exactly
  on the arena arm, 176.7 s wall vs the baseline qualification's 175.9 s;
- decode throughput unchanged: three warmed C1 runs 108.51–108.94 tok/s
  (baseline) vs 109.16–109.66 (arena); prefill 3,053.6 vs 3,042.9 tok/s;
  TTFT proxy 54.4 vs 54.6 ms.

One honest caveat from the same A/B: an 8-prompt **long-continuation greedy
probe** (256 tokens each) differed between the arms on 7/8 prompts — and the
control showed **two restarts of the unpatched baseline also differ 7/8**,
(as do two restarts of the arena arm), while an in-process repeat is 8/8
identical. The stack is not restart-deterministic on long greedy
continuations regardless of this patch (`exl3_gemm`'s autotuner selects
kernel configurations by measured time per process), so cross-restart text
equality is not a usable bit-exactness probe here. Within that envelope the
arms are indistinguishable.

## CUDA-graph safety

- At production defaults the reconstruct branch cannot be captured: it needs
  `m >= VLLM_EXL3_PREFILL_RECONSTRUCT_M` (128) while `FULL_DECODE_ONLY`
  capture rows stay far below that, so the arena is eager-only.
- If an operator configures capture sizes ≥ 128 with
  `VLLM_EXL3_GRAPH_DECODE=1`, a capture can record the arena's address. The
  patch freezes the arena the moment a capture serves from it: a frozen
  arena is **never reallocated**, and any geometry that no longer fits falls
  back to a dedicated persistent per-geometry buffer — exactly the previous
  behaviour, so the worst case is the status quo, never a dangling pointer.
- Eager growth is safe for the same reason the old dict's cross-layer reuse
  was: the caching allocator's stream-ordered reuse, plus no retained views.

## Measured effect (RTX 5090, Qwen3.8-27B-EXL3-K5K6-context, 262,144-token window, util 0.955)

| arm | Available KV cache | GPU KV cache size | max concurrency at 262,144 |
|---|---:|---:|---:|
| baseline (#318 head) | 9.28 GiB | 265,122 tokens | 1.01× |
| arena (this PR) | 9.88 GiB | **282,996 tokens** | 1.08× |

**+17,874 tokens (+6.74 %), ≈ +0.60 GiB of KV pool**, reproduced identically
across two server starts per arm. The arena grew three times during the
profiling prefill (60 → 100 → 170 MiB) and stabilized at the predicted
170 MiB; the startup log carries one INFO line per growth. The static
derivation predicted +620 MiB / +18,676 tokens; the measured pool gain is
95.7 % of that.

## Validation

- `tests/quantization/test_exl3_reconstruct_arena.py` (new, CPU-only, no
  CUDA/b12x/exllamav3_ext): arena sizing, view layout parity with
  `torch.empty`, write→consume integrity under interleaving including the
  chunked head geometry, capture freeze + dedicated-buffer fallback, eager
  grow/reuse. 5/5 pass.
- Existing `test_exl3_prefill_plan.py` + `test_exl3_warmup.py`: 19/19 pass
  unchanged.
- A shape-simulation harness additionally walked the checkpoint's 9 real
  geometries through the verbatim allocation path in three call orders and
  asserted every view in-bounds, offset-0/aligned, and non-overlapping for
  every reachable concurrent set.

## AI assistance

An AI agent (Claude) assisted with implementation, tests, and the memory
derivation. Michel Belleau is the human submitter and reviewed the diff and
the GPU evidence before requesting merge.
