### PR TITLE
[GG] fix(flashinfer): key persistent decode wrappers by captured shape (#396)

### DIFF
--- a/tests/v1/attention/test_flashinfer_decode_qlen_guard.py
+++ b/tests/v1/attention/test_flashinfer_decode_qlen_guard.py
@@ -1,17 +1,26 @@
-"""Persistent FlashInfer decode wrappers may only be reused when the runtime
-q_len_per_req equals the value frozen during wrapper planning (1 + K).
+"""Persistent FlashInfer decode wrappers may only be reused for the exact
+``(num_decodes, q_len_per_req)`` shape a CUDA-graph capture pass planned them
+with.
 
-The decode-classification ceiling (reorder_batch_threshold = 1 + 2K under
-parallel drafting) deliberately admits reduced-depth lone steps as decodes —
-spec truncation near max_tokens, short chunked-prefill tails fused with the
-spec step. Those steps must take the dynamic wrapper; routing them to a
-captured wrapper raises inside flashinfer's fast_decode_plan ("q_len_per_req
-is part of the frozen cudagraph shape: this wrapper was planned with 6,
-got 8|5") and kills the engine.
+Two independent hazards make the shape load-bearing:
 
-These tests pin the invariant and, deliberately, the distinction between the
-classification ceiling (1 + 2K) and the planned shape (1 + K): substituting
-reorder_batch_threshold for the planned length reintroduces the crash.
+* FlashInfer freezes ``q_len_per_req`` into a CUDA-graph wrapper and raises
+  inside ``fast_decode_plan`` when asked to replan for another one
+  ("q_len_per_req is part of the frozen cudagraph shape: this wrapper was
+  planned with 6, got 8|5").
+* A captured graph bakes in the *addresses* of its wrapper's plan buffers. The
+  dynamic wrapper rebinds ``_paged_kv_indptr_buf`` /
+  ``_paged_kv_last_page_len_buf`` and reallocates ``_qo_indptr_buf`` on every
+  plan, so a graph captured around it replays against freed memory
+  (cudaErrorIllegalAddress).
+
+Hence the planned shapes are recorded by capture, not derived from
+``1 + num_spec_tokens``: the V2 speculator's draft-decode graphs are captured
+at ``q_len == 1`` and a per-batch-size speculative depth schedule captures one
+verify shape per depth. These tests pin that recorded-shape contract and,
+deliberately, the distinction between the decode-classification ceiling
+(``reorder_batch_threshold == 1 + 2K`` under parallel drafting) and the planned
+shapes: substituting the ceiling reintroduces the crash.
 """
 
 from types import SimpleNamespace
@@ -30,6 +39,9 @@ K = 5
 PLANNED = 1 + K
 CEILING = 1 + 2 * K
 MAX_BS = 96
+# What a V2 + MTP-K capture pass plans: target verify graphs at q_len 1 + K and
+# the speculator's draft-decode graphs at q_len 1, for every captured size.
+CAPTURED = {(bs, q) for bs in (1, 8) for q in (1, PLANNED)}
 
 
 def _threshold_for(parallel_drafting: bool) -> int:
@@ -49,13 +61,14 @@ def _threshold_for(parallel_drafting: bool) -> int:
 
 
 def _eligible(q_len, *, num_reqs=1, pure_decode=True, max_bs=MAX_BS,
-              planned=PLANNED):
+              planned=CAPTURED, capturing=False):
     return persistent_decode_wrapper_eligible(
         pure_decode=pure_decode,
         num_decode_tokens=q_len * num_reqs,
         decode_cudagraph_max_bs=max_bs,
-        decode_q_len=q_len,
-        planned_decode_q_len=planned,
+        decode_shape=(num_reqs, q_len),
+        planned_decode_shapes=planned,
+        planning_for_capture=capturing,
     )
 
 
@@ -65,18 +78,51 @@ def test_classification_ceiling_is_not_planned_shape():
     assert CEILING != PLANNED
 
 
-def test_planned_shape_selects_persistent_wrapper():
+def test_planned_verify_shape_selects_persistent_wrapper():
     assert _eligible(PLANNED)
     assert _eligible(PLANNED, num_reqs=8)
 
 
+def test_planned_draft_decode_shape_selects_persistent_wrapper():
+    # The V2 speculator drafts one token per request per step, so its captured
+    # draft-decode graphs run q_len == 1. Demoting them to the dynamic wrapper
+    # is what made their replay fault with cudaErrorIllegalAddress.
+    assert _eligible(1)
+    assert _eligible(1, num_reqs=8)
+
+
+def test_capture_build_is_always_eligible():
+    # The capture-time build is what creates, plans and records the wrapper,
+    # so it must be admitted before its shape is in the recorded set.
+    assert _eligible(3, planned=set(), capturing=True)
+    assert _eligible(1, num_reqs=4, planned=set(), capturing=True)
+
+
 @pytest.mark.parametrize(
-    "q_len", [q for q in range(1, CEILING + 1) if q != PLANNED]
+    "q_len", [q for q in range(1, CEILING + 1) if q not in (1, PLANNED)]
 )
-def test_reduced_or_extended_depth_falls_back_to_dynamic(q_len):
+def test_uncaptured_depth_falls_back_to_dynamic(q_len):
     # Covers both observed crash signatures: q_len=5 (spec truncation near
     # max_tokens) and q_len=8 (chunked-prefill tail fused with spec step).
+    # Nothing replays a graph for these shapes, so replanning per call is safe.
     assert not _eligible(q_len)
+
+
+def test_shape_is_keyed_on_batch_size_too():
+    # A wrapper planned for another batch size has the wrong fixed_batch_size
+    # and the wrong buffer slices; FlashInfer would reject the replan.
+    assert not _eligible(PLANNED, num_reqs=4)
+    assert not _eligible(1, num_reqs=4)
+
+
+def test_depth_schedule_captures_one_verify_shape_per_depth():
+    # num_speculative_tokens_per_batch_size captures a verify graph per depth;
+    # every captured depth must reach its own persistent wrapper, and only the
+    # captured ones.
+    scheduled = {(1, 4), (2, 4), (4, 2), (8, 2)}
+    assert _eligible(4, num_reqs=2, planned=scheduled)
+    assert _eligible(2, num_reqs=8, planned=scheduled)
+    assert not _eligible(4, num_reqs=8, planned=scheduled)
 
 
 def test_above_ceiling_classifies_as_prefill():
@@ -94,12 +140,14 @@ def test_above_ceiling_classifies_as_prefill():
 
 def test_other_predicate_terms_still_gate():
     assert not _eligible(PLANNED, pure_decode=False)
-    assert not _eligible(PLANNED, num_reqs=32)  # over capacity
+    assert not _eligible(PLANNED, num_reqs=8, max_bs=8)  # over capacity
+    # Capacity and purity gate the capture build as well.
+    assert not _eligible(PLANNED, pure_decode=False, capturing=True)
 
 
 def test_no_spec_planned_length_is_one():
-    assert _eligible(1, planned=1)
-    assert not _eligible(2, planned=1)
+    assert _eligible(1, planned={(1, 1)})
+    assert not _eligible(2, planned={(1, 1)})
 
 
 def _indptr(*lens):
@@ -118,6 +166,7 @@ def _indptr(*lens):
         ((PLANNED,) * 3 + (0,), PLANNED), # total not divisible by num rows
         ((0, 0), 0),                      # all-padding
         ((5,), 5),                        # reduced-depth lone step
+        ((1, 1, 0), 1),                   # draft decode step with padding
     ],
 )
 def test_decode_q_len_ignores_zero_padding(lens, expected):
@@ -134,6 +183,7 @@ def test_zero_padded_planned_batch_keeps_persistent_wrapper():
         pure_decode=True,
         num_decode_tokens=sum(lens),
         decode_cudagraph_max_bs=MAX_BS,
-        decode_q_len=q_len,
-        planned_decode_q_len=PLANNED,
+        decode_shape=(len(lens), q_len),
+        planned_decode_shapes={(len(lens), PLANNED)},
+        planning_for_capture=False,
     )

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -3,6 +3,7 @@
 """Attention layer with FlashInfer."""
 
 import inspect
+from collections.abc import Collection
 from dataclasses import dataclass
 from enum import Enum
 from functools import cache, partial
@@ -622,25 +623,39 @@ def persistent_decode_wrapper_eligible(
     pure_decode: bool,
     num_decode_tokens: int,
     decode_cudagraph_max_bs: int,
-    decode_q_len: int,
-    planned_decode_q_len: int,
+    decode_shape: tuple[int, int],
+    planned_decode_shapes: Collection[tuple[int, int]],
+    planning_for_capture: bool,
 ) -> bool:
     """Whether a decode-classified batch may reuse a persistent (CUDA-graph)
     FlashInfer decode wrapper.
 
-    Persistent wrappers are planned once, during graph capture, with a frozen
-    ``q_len_per_req`` of exactly ``planned_decode_q_len`` (1 + num_spec_tokens;
-    1 without speculative decoding). Reuse is only sound when the runtime
-    per-request query length matches that frozen shape — FlashInfer's
-    ``fast_decode_plan`` hard-errors otherwise ("q_len_per_req is part of the
-    frozen cudagraph shape").
+    Persistent wrappers are created and planned during CUDA-graph capture, and
+    are keyed by the exact shape capture planned them with:
+    ``(num_decodes, q_len_per_req)``. Both halves are frozen. FlashInfer
+    refuses to replan a CUDA-graph wrapper for another query length
+    ("q_len_per_req is part of the frozen cudagraph shape"), and a captured
+    graph bakes in the *addresses* of the plan buffers its wrapper held at
+    capture time. The dynamic wrapper (``use_cuda_graph=False``) rebinds
+    ``_paged_kv_indptr_buf`` / ``_paged_kv_last_page_len_buf`` and reallocates
+    ``_qo_indptr_buf`` on every plan, so a graph captured around it replays
+    against freed memory (cudaErrorIllegalAddress). A batch a captured graph
+    will replay must therefore resolve to the very wrapper capture planned,
+    and a shape capture never planned must take the dynamic wrapper.
 
-    WARNING: ``planned_decode_q_len`` is NOT ``reorder_batch_threshold``. With
+    The admitted shapes are recorded by capture instead of derived from
+    ``1 + num_spec_tokens``, because that scalar is not the only FULL-captured
+    decode shape: the V2 speculator's draft-decode graphs run ``q_len == 1``
+    (one token per request per draft step), and a per-batch-size speculative
+    depth schedule captures one verify shape per depth.
+
+    WARNING: the admitted shapes are NOT ``reorder_batch_threshold``. With
     parallel drafting the decode-classification ceiling is
     ``1 + 2 * num_spec_tokens``, which deliberately admits reduced-depth steps
     (spec truncation near ``max_tokens``, short chunked-prefill tails fused
-    with the spec step). Those are valid decode batches, but they must take
-    the dynamic wrapper, which replans for the current shape on every call.
+    with the spec step). Those are valid decode batches, but unless capture
+    planned that exact shape they must take the dynamic wrapper, which replans
+    for the current shape on every call.
 
     Args:
         pure_decode: True when the batch contains no prefill requests.
@@ -648,20 +663,21 @@ def persistent_decode_wrapper_eligible(
         decode_cudagraph_max_bs: Token capacity the persistent wrappers were
             sized for ((1 + num_spec_tokens) * max_num_reqs, capped by
             ``max_cudagraph_capture_size``).
-        decode_q_len: Runtime per-request query length of the active
-            (non-padding) decode requests.
-        planned_decode_q_len: Frozen per-request query length the persistent
-            wrappers were planned with (1 + num_spec_tokens).
+        decode_shape: Runtime ``(num_decodes, q_len_per_req)`` of this batch;
+            the query length is that of the active (non-padding) decode
+            requests.
+        planned_decode_shapes: Shapes capture has planned a persistent wrapper
+            for (the keys of ``_decode_wrappers_cudagraph``).
+        planning_for_capture: True when this build *is* the capture-time build,
+            which is what creates and plans the persistent wrapper.
 
     Returns:
         True when the batch may be routed to the persistent (CUDA-graph)
         decode wrapper; False when it must use the dynamic wrapper.
     """
-    return (
-        pure_decode
-        and num_decode_tokens <= decode_cudagraph_max_bs
-        and decode_q_len == planned_decode_q_len
-    )
+    if not pure_decode or num_decode_tokens > decode_cudagraph_max_bs:
+        return False
+    return planning_for_capture or decode_shape in planned_decode_shapes
 
 
 def decode_q_len_from_indptr(qo_indptr_cpu: torch.Tensor, num_decodes: int) -> int:
@@ -735,18 +751,19 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             if speculative_config is not None
             else 0
         )
-        # The frozen per-request query length persistent decode wrappers are
-        # planned with during capture. See persistent_decode_wrapper_eligible
-        # for why this must never be conflated with reorder_batch_threshold.
-        self._planned_decode_q_len = 1 + num_spec_tokens
+        # Persistent decode wrappers are planned during CUDA-graph capture and
+        # keyed by the shape capture froze them with; see
+        # persistent_decode_wrapper_eligible.
+        self._planning_for_cudagraph_capture = False
         self.enable_cuda_graph = (
             self.compilation_config.cudagraph_mode.decode_mode() == CUDAGraphMode.FULL
         )
         if self.enable_cuda_graph:
-            # For full cudagraph capture, one `decode_wrapper` for each batch
-            # size is needed for FlashInfer.
+            # For full cudagraph capture, one `decode_wrapper` per captured
+            # (batch size, per-request query length) shape is needed for
+            # FlashInfer.
             self._decode_wrappers_cudagraph: dict[
-                int, BatchDecodeWithPagedKVCacheWrapper
+                tuple[int, int], BatchDecodeWithPagedKVCacheWrapper
             ] = {}
             self._decode_cudagraph_max_bs = (1 + num_spec_tokens) * max_num_reqs
             if self.compilation_config.max_cudagraph_capture_size is not None:
@@ -1092,9 +1109,13 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         assert self._prefill_wrapper is not None
         return self._prefill_wrapper
 
-    def _get_decode_wrapper(self, batch_size: int, use_cudagraph: bool = False):
+    def _get_decode_wrapper(
+        self, batch_size: int, decode_q_len: int, use_cudagraph: bool = False
+    ):
         if use_cudagraph:
-            decode_wrapper = self._decode_wrappers_cudagraph.get(batch_size, None)
+            decode_wrapper = self._decode_wrappers_cudagraph.get(
+                (batch_size, decode_q_len), None
+            )
         else:
             decode_wrapper = self._decode_wrapper
 
@@ -1126,7 +1147,9 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
 
             # save the decode wrapper
             if use_cudagraph:
-                self._decode_wrappers_cudagraph[batch_size] = decode_wrapper
+                self._decode_wrappers_cudagraph[(batch_size, decode_q_len)] = (
+                    decode_wrapper
+                )
             else:
                 self._decode_wrapper = decode_wrapper
 
@@ -1593,12 +1616,15 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                         pure_decode=pure_decode,
                         num_decode_tokens=num_decode_tokens,
                         decode_cudagraph_max_bs=self._decode_cudagraph_max_bs,
-                        decode_q_len=decode_q_len,
-                        planned_decode_q_len=self._planned_decode_q_len,
+                        decode_shape=(num_decodes, decode_q_len),
+                        planned_decode_shapes=self._decode_wrappers_cudagraph,
+                        planning_for_capture=self._planning_for_cudagraph_capture,
                     )
                 )
 
-                decode_wrapper = self._get_decode_wrapper(num_decodes, use_cudagraph)
+                decode_wrapper = self._get_decode_wrapper(
+                    num_decodes, decode_q_len, use_cudagraph
+                )
                 # Use the persistent buffer with padding length,
                 # instead of the same address but chunked version
                 # in atten_metadata when using cudagraph.
@@ -1631,6 +1657,21 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                 )
                 attn_metadata.decode = FIDecode(wrapper=decode_wrapper)
         return attn_metadata
+
+    @override
+    def build_for_cudagraph_capture(
+        self, common_attn_metadata: CommonAttentionMetadata
+    ) -> FlashInferMetadata:
+        # The capture-time build is what creates and plans the persistent
+        # decode wrappers, and records the (num_decodes, q_len_per_req) shape
+        # they are frozen with, so the replay-time build resolves to the same
+        # wrapper — and therefore to the plan buffer addresses the graph baked
+        # in. See persistent_decode_wrapper_eligible.
+        self._planning_for_cudagraph_capture = True
+        try:
+            return super().build_for_cudagraph_capture(common_attn_metadata)
+        finally:
+            self._planning_for_cudagraph_capture = False
 
     def use_cascade_attention(self, *args, **kwargs) -> bool:
         if self.kv_cache_spec.dtype != self.vllm_config.model_config.dtype:


### PR DESCRIPTION
Closes #396.

## Provenance

Reported and measured on a **downstream fork build**, not upstream: image
`localhost/vllm:gg-r34-patched` (manifest `sha256:6eca4c693f01b6f4e112c04eacd30673b7cfbba4150e6fe2ea3ba1bbfde14c27`,
vLLM `dev280+gilded.gnosis.v20`), model
`malaiwah/Qwen3.8-27B-EXL3-K5K6-context` — a **hybrid Qwen3.5** (GDN/mamba +
full-attention layers, EXL3-quantised linears, fp8 KV) with an **MTP-3**
speculator, one RTX 5090 (32,607 MiB, driver 610.57.04), FlashInfer decode
backend, `cudagraph_mode=FULL_DECODE_ONLY`, `VLLM_USE_V2_MODEL_RUNNER=1`.

## Symptom

With the V2 model runner and MTP-3, the engine dies deterministically (3/3
starts) inside `warmup_kernels`, before the server answers:

```
draft_tokens = self.speculator.propose(...)
  self._multi_step_decode(...)
    File ".../v1/worker/gpu/spec_decode/autoregressive/speculator.py", line 537
    self.decode_cudagraph_manager.run_fullgraph(batch_desc)
      File ".../v1/worker/gpu/cudagraph_utils.py", line 589
      self.graphs[desc].replay()
torch.AcceleratorError: CUDA error: an illegal memory access was encountered
```

The same build serves fine with V2 and **no** speculator, and with V2 + MTP-3
in eager mode. Only the captured draft-decode graph's *replay* faults.

## Root cause

`vllm/v1/attention/backends/flashinfer.py:1590-1601` admitted a batch to a
persistent (CUDA-graph) FlashInfer decode wrapper only when its per-request
query length equalled one hardcoded scalar,
`self._planned_decode_q_len = 1 + num_spec_tokens` (line 741). Every other
FULL-captured decode shape was therefore captured **and** replayed on the
*dynamic* wrapper:

* the V2 speculator's draft-decode graphs, which run `q_len == 1` — one token
  per request per draft step (`spec_decode/autoregressive/speculator.py:345`
  dispatches them with `uniform_token_count=1`);
* under `num_speculative_tokens_per_batch_size`, every reduced-depth verify
  shape (this profile captures 8 sizes x 2 depths).

The dynamic wrapper is not safe to capture a graph around. For
`use_cuda_graph=False`, `fast_plan_decode` (flashinfer.py:2465) falls through
to the full `plan()`, and flashinfer's `fast_decode_plan`
(`flashinfer/decode.py:3830-3837`) *rebinds* `_paged_kv_indptr_buf` /
`_paged_kv_last_page_len_buf` and *reallocates* `_qo_indptr_buf` on every
plan:

```python
    else:
        self._paged_kv_indptr_buf = indptr
        self._paged_kv_indices_buf = indices
        self._paged_kv_last_page_len_buf = last_page_len
        if self.use_tensor_cores:
            self._qo_indptr_buf = qo_indptr_host.to(self.device, ...)
```

A captured graph bakes in the *addresses* its wrapper held at capture time.
Those capture-time tensors are dropped when the capture-time metadata is, so
their memory is recycled; the replay then reads freed memory and the attention
kernel indexes out of bounds → `cudaErrorIllegalAddress`. The
`seq_lens.to('cpu')` host sync at `spec_decode/autoregressive/speculator.py:312`
is only where the asynchronous fault surfaces.

## Instrumented evidence

A probe (not part of this PR) wrapped `FlashInferMetadataBuilder.build` and
`.build_for_cudagraph_capture` and logged, per build, the wrapper the build
resolves to and that wrapper's plan-buffer addresses. Raw logs:
`logs/fiprobe-{u_probe,u_probe_pin,f_probe}.log`.

**Before** — the draft builder gets the dynamic wrapper at capture *and* at
replay, and its plan buffers move on every replay-time build, while the target
builder keeps a persistent wrapper at stable addresses:

```
phase=capture builder=12640 layer=language_model.model.layers.3.self_attn.attn tokens=32 wrapper=3008  cudagraph=True  fixed_bs=8 q_len=4 _paged_kv_indptr_buf=0x14e0003000 ... _qo_indptr_buf=0x26a0000800
phase=capture builder=51568 layer=mtp.layers.0.self_attn.attn              tokens=8  wrapper=96848 cudagraph=False fixed_bs=0 q_len=1 _paged_kv_indptr_buf=0x4a20000800 ... _qo_indptr_buf=0x4a20000c00
phase=replay  builder=51568 layer=mtp.layers.0.self_attn.attn              tokens=8  wrapper=96848 cudagraph=False fixed_bs=0 q_len=1 vs_capture=MOVED:_paged_kv_indptr_buf,_paged_kv_last_page_len_buf,_qo_indptr_buf _paged_kv_indptr_buf=0x4a20000e00 ... _qo_indptr_buf=0x4a20000a00
```

Counts for that run: 65 dynamic-wrapper builds, 17 replay builds with `MOVED`
plan buffers — and the run dies with `cudaErrorIllegalAddress`.

**Causality, not correlation** — a control run that changes nothing except
keeping the capture-time plan buffers *alive* (a probe-held reference, still
unpatched) no longer faults: the engine becomes ready and serves 8 greedy
completions. The fault is the freed capture-time plan buffers, not a
wrong-shaped kernel.

**After** — the draft builder gets its own persistent wrapper for its captured
shape, and every replay-time build resolves to the same buffers:

```
phase=capture builder=91104 layer=mtp.layers.0.self_attn.attn tokens=8 wrapper=7280 cudagraph=True fixed_bs=8 q_len=1 _paged_kv_indptr_buf=0x14e0074e00 ... _qo_indptr_buf=0x4a20000800
phase=replay  builder=91104 layer=mtp.layers.0.self_attn.attn tokens=8 wrapper=7280 cudagraph=True fixed_bs=8 q_len=1 vs_capture=IDENTICAL _paged_kv_indptr_buf=0x14e0074e00 ... _qo_indptr_buf=0x4a20000800
```

Counts: **0** dynamic-wrapper builds, 396 persistent-wrapper builds, **268
replay builds `IDENTICAL`, 0 `MOVED`**.

## The fix

Stop deriving the admissible query length from `1 + num_spec_tokens`, and
record the shapes capture actually plans instead:

* `_decode_wrappers_cudagraph` is keyed `(num_decodes, q_len_per_req)`;
* `build_for_cudagraph_capture` is overridden to mark the capture-time build,
  which is what creates, plans and records a persistent wrapper;
* `persistent_decode_wrapper_eligible` admits a batch to the persistent
  wrapper only for a recorded shape.

Capture and replay therefore resolve to the same wrapper — hence the same plan
buffers — for the draft-decode shape and for every captured verify depth,
while shapes no graph replays (spec truncation near `max_tokens`, chunked
prefill tails fused with a spec step) keep the dynamic wrapper that replans per
call. That property was the point of the previous scalar gate and it is
preserved.

## Before / after

| | before | after |
|---|---|---|
| V2 + MTP-3 static depth 3 | dies in warmup, `cudaErrorIllegalAddress` at `cudagraph_utils.py:589` (3/3) | ready in **53.0 s**, GPU KV 271,080 tokens, serves |
| V2 + MTP-3 + `num_speculative_tokens_per_batch_size=[[1,2,3],[3,8,1]]` | dies in the identical warmup replay | ready in **55.1 s**, GPU KV 268,101 tokens, serves |
| draft-decode replay builds with moved plan buffers | 17 | 0 |
| dynamic-wrapper builds under FULL decode capture | 65 | 0 |
| `tests/v1/attention/test_flashinfer_decode_qlen_guard.py` | 14 cases (scalar contract) | **26 passed** in-image (recorded-shape contract, draft `q_len==1`, per-depth schedule, capture build) |

## Cost

One persistent decode wrapper per captured decode shape instead of per
captured batch size: on this profile, 8 additional wrappers for the draft
(~8 MiB device int workspace each, `flashinfer/decode.py:871`), and one set per
captured depth when a depth schedule is used. Measured peak on this box:
32,092 MiB (V2 + MTP-3) vs 31,310 MiB (MRV1 baseline, same utilisation) — the
V2 runner accounts for most of that delta, but the extra wrappers are part of
it, and at `--gpu-memory-utilization 0.97` the engine is left with tens of MiB
of headroom.

## Not upstream

`upstream/main` @ `fe1c31715` cannot reach this. Its gate is
`enable_cuda_graph and pure_decode and num_decode_tokens <= _decode_cudagraph_max_bs`
(flashinfer.py:1678-1682) with **no** `q_len` term, it calls `fast_plan_decode`
**without** `q_len_per_req` (1697-1718), and it keys `_get_decode_wrapper` by
`num_decode_tokens` (1685) — upstream flattens a spec-decode batch into
single-token rows, so row count equals token count and capture/replay always
resolve to the same persistent wrapper. `persistent_decode_wrapper_eligible`,
`decode_q_len_from_indptr` and
`flashinfer_supports_uniform_multi_token_decode` do not exist upstream. The
regression arrived with this fork's uniform multi-token decode support, so this
PR is the right and only venue. (The *family* is public: FlashInfer documents
that `plan()` cannot be captured by a CUDA graph, and
flashinfer-ai/flashinfer#1832 documents non-uniform `q_len` in speculative
decode. Neither is this gate.)

## Measured after filing

Same box, same harness and frozen prompts as the fork's perf receipts; medians
of 3 timed repeats after a warm repeat; full probe completed `rc=0` in every
arm. Because the V2 runner needs ~800 MiB more than MRV1 on this profile (see
*Cost*), these arms run `--gpu-memory-utilization 0.95 --max-model-len 131072`,
with an **MRV1 baseline measured at the identical setting in the same window**:

| T=0 aggregate decode | C1 | C4 | C8 | accepted tok/step (C1 → C8) |
|---|---|---|---|---|
| MRV1 baseline (matched) | 82.78 | 255.75 | 301.63 | 2.16 → 2.14 |
| V2 + fix, static depth 3 | 82.75 | 273.36 | 312.89 | 2.11 → 2.14 |
| V2 + fix + depth schedule | **87.35** | 251.74 | **416.29 (+38.0 %)** | 2.25 → 1.69 |

The depth schedule is visibly doing what it claims: depth 3 at batch 1
(2.25 accepted tokens/step, 25.5 ms steps) and depth 1 at batch 8 (1.69,
31.3 ms steps). Greedy T=0 completions for 8 frozen prompts are identical
across two runs **within** each engine process in all four arms; cross-process
bit-exactness is not claimable on this stack and predates this change
(`exl3_gemm` autotune selects kernel configs by measured time per process:
baseline-vs-baseline restarts differ 7/8, within-instance repeats 8/8
identical), so the guard is within-process plus an acceptance-rate comparison.

## Still open (does not affect this fix)

* At `--gpu-memory-utilization 0.97` the V2 runner leaves tens of MiB free and
  the probe's first 2048-token prefill kills the engine with
  `torch.OutOfMemoryError: ... Tried to allocate 68.00 MiB ... 58.56 MiB is
  free` inside the EXL3 prefill reconstruct (`_reconstruct_hgemm_into` →
  `torch.empty_like(x)`), in **both** arms, with the depth schedule off and on.
  That is a memory-budget problem under the V2 runner, not a plan-buffer
  problem, and it means the throughput above is currently only reachable with a
  context/KV concession (234,256 KV tokens at 131072/0.95 against 272,570 on
  the published 262144/0.97 profile, -14.1 %). Serving the published profile
  under the V2 runner on a 32 GB card is **not** demonstrated.