### PR TITLE
fix(deepseek-v4): parse legacy direct DSML tool calls

### DIFF
--- a/tests/parser/engine/test_deepseek_v4.py
+++ b/tests/parser/engine/test_deepseek_v4.py
@@ -231,6 +231,54 @@ class TestMissingInvokeEnd:
         assert "Done." in collect_content(results)
 
 
+class TestLegacyDirectDsml:
+    """ASCII-pipe DSML invokes without an outer wrapper remain tool calls."""
+
+    @staticmethod
+    def _legacy_invoke(name: str, value: str) -> str:
+        return (
+            f'<|DSML|invoke name="{name}">\n'
+            f'<|DSML|parameter name="command" string="true">{value}'
+            "</|DSML|parameter>\n</|DSML|invoke>"
+        )
+
+    def test_non_streaming_two_direct_invokes_are_tool_calls(
+        self, mock_tokenizer, mock_request
+    ):
+        text = "Preamble.\n" + self._legacy_invoke("exec", "true")
+        text += "\n" + self._legacy_invoke("exec", "false")
+        parser = DeepSeekV4Parser(
+            mock_tokenizer, chat_template_kwargs={"thinking": False}
+        )
+
+        reasoning, content, tool_calls = parser.parse(text, mock_request)
+
+        assert reasoning is None
+        assert content is not None
+        assert content.rstrip() == "Preamble."
+        assert tool_calls is not None
+        assert [call.name for call in tool_calls] == ["exec", "exec"]
+        assert [json.loads(call.arguments) for call in tool_calls] == [
+            {"command": "true"},
+            {"command": "false"},
+        ]
+
+    def test_streaming_split_legacy_markers_do_not_leak(
+        self, mock_tokenizer, mock_request
+    ):
+        text = self._legacy_invoke("exec", "true")
+        parser = DeepSeekV4Parser(
+            mock_tokenizer, chat_template_kwargs={"thinking": False}
+        )
+        chunks = [text[i : i + 7] for i in range(0, len(text), 7)]
+
+        results = simulate_tool_streaming(parser, mock_request, chunks)
+
+        assert collect_function_name(results) == "exec"
+        assert json.loads(collect_tool_arguments(results)) == {"command": "true"}
+        assert "DSML" not in collect_content(results)
+
+
 # ── Thinking mode initial state ──────────────────────────────────────
 
 

--- a/tests/parser/engine/test_deepseek_v4.py
+++ b/tests/parser/engine/test_deepseek_v4.py
@@ -263,6 +263,23 @@ class TestLegacyDirectDsml:
             {"command": "false"},
         ]
 
+    def test_streaming_direct_invoke_returns_to_content(
+        self, mock_tokenizer, mock_request
+    ):
+        parser = DeepSeekV4Parser(
+            mock_tokenizer, chat_template_kwargs={"thinking": False}
+        )
+        text = self._legacy_invoke("exec", "true") + "\nCalls completed."
+
+        results = simulate_tool_streaming(parser, mock_request, [text])
+        finish_delta = parser.finish_streaming()
+        content = collect_content(results)
+        if finish_delta and finish_delta.content:
+            content += finish_delta.content
+
+        assert collect_function_name(results) == "exec"
+        assert content.strip() == "Calls completed."
+
     def test_streaming_split_legacy_markers_do_not_leak(
         self, mock_tokenizer, mock_request
     ):

--- a/vllm/parser/deepseek_v4.py
+++ b/vllm/parser/deepseek_v4.py
@@ -192,11 +192,11 @@ def deepseek_v4_config(thinking: bool = False) -> ParserEngineConfig:
             ),
             # The outer ``tool_calls`` wrapper is optional in legacy DSML.
             (ParserState.CONTENT, "INVOKE_PREFIX"): Transition(
-                ParserState.TOOL_NAME,
+                ParserState.TOOL_DIRECT_NAME,
                 (EventType.TOOL_CALL_START,),
             ),
             (ParserState.CONTENT, "INVOKE_PREFIX_LEGACY"): Transition(
-                ParserState.TOOL_NAME,
+                ParserState.TOOL_DIRECT_NAME,
                 (EventType.TOOL_CALL_START,),
             ),
             (ParserState.REASONING, "TOOL_START_LEGACY"): Transition(
@@ -204,11 +204,11 @@ def deepseek_v4_config(thinking: bool = False) -> ParserEngineConfig:
                 (EventType.REASONING_END,),
             ),
             (ParserState.REASONING, "INVOKE_PREFIX"): Transition(
-                ParserState.TOOL_NAME,
+                ParserState.TOOL_DIRECT_NAME,
                 (EventType.REASONING_END, EventType.TOOL_CALL_START),
             ),
             (ParserState.REASONING, "INVOKE_PREFIX_LEGACY"): Transition(
-                ParserState.TOOL_NAME,
+                ParserState.TOOL_DIRECT_NAME,
                 (EventType.REASONING_END, EventType.TOOL_CALL_START),
             ),
             (ParserState.TOOL_PREAMBLE, "INVOKE_PREFIX"): Transition(
@@ -223,12 +223,27 @@ def deepseek_v4_config(thinking: bool = False) -> ParserEngineConfig:
                 ParserState.TOOL_ARGS,
                 (),
             ),
+            (ParserState.TOOL_DIRECT_NAME, "INVOKE_NAME_END"): Transition(
+                ParserState.TOOL_DIRECT_ARGS,
+                (),
+            ),
             (ParserState.TOOL_ARGS, "INVOKE_END"): Transition(
                 ParserState.TOOL_BETWEEN,
                 (EventType.TOOL_CALL_END,),
             ),
             (ParserState.TOOL_ARGS, "INVOKE_END_LEGACY"): Transition(
                 ParserState.TOOL_BETWEEN,
+                (EventType.TOOL_CALL_END,),
+            ),
+            # A direct invoke has no enclosing wrapper. Return to content so
+            # subsequent prose is not suppressed; a later direct invoke can
+            # start another call from CONTENT.
+            (ParserState.TOOL_DIRECT_ARGS, "INVOKE_END"): Transition(
+                ParserState.CONTENT,
+                (EventType.TOOL_CALL_END,),
+            ),
+            (ParserState.TOOL_DIRECT_ARGS, "INVOKE_END_LEGACY"): Transition(
+                ParserState.CONTENT,
                 (EventType.TOOL_CALL_END,),
             ),
             (ParserState.TOOL_ARGS, "TOOL_END"): Transition(
@@ -262,6 +277,8 @@ def deepseek_v4_config(thinking: bool = False) -> ParserEngineConfig:
             ParserState.REASONING: EventType.REASONING_CHUNK,
             ParserState.TOOL_NAME: EventType.TOOL_NAME,
             ParserState.TOOL_ARGS: EventType.ARG_VALUE_CHUNK,
+            ParserState.TOOL_DIRECT_NAME: EventType.TOOL_NAME,
+            ParserState.TOOL_DIRECT_ARGS: EventType.ARG_VALUE_CHUNK,
         },
         arg_converter=_dsml_arg_converter,
         arg_structural_chars=frozenset(">"),

--- a/vllm/parser/deepseek_v4.py
+++ b/vllm/parser/deepseek_v4.py
@@ -39,6 +39,7 @@ if TYPE_CHECKING:
     from vllm.tool_parsers.abstract_tool_parser import Tool
 
 _DSML = "｜DSML｜"
+_LEGACY_DSML = "|DSML|"
 
 DSML_THINK_START = "<think>"
 DSML_THINK_END = "</think>"
@@ -49,14 +50,24 @@ DSML_INVOKE_NAME_END = '">'
 DSML_INVOKE_END = f"</{_DSML}invoke>"
 DSML_PARAM_CLOSE = f"</{_DSML}parameter>"
 
+# Some older tool prompts contain ASCII-pipe DSML examples without the optional
+# ``tool_calls`` wrapper. The model can reproduce that input faithfully; parse
+# it as a compatibility variant instead of exposing protocol text as content.
+LEGACY_DSML_TOOL_START = f"<{_LEGACY_DSML}tool_calls>"
+LEGACY_DSML_TOOL_END = f"</{_LEGACY_DSML}tool_calls>"
+LEGACY_DSML_INVOKE_PREFIX = f'<{_LEGACY_DSML}invoke name="'
+LEGACY_DSML_INVOKE_END = f"</{_LEGACY_DSML}invoke>"
+LEGACY_DSML_PARAM_CLOSE = f"</{_LEGACY_DSML}parameter>"
+
 _ESCAPED_DSML = re.escape(_DSML)
+_DSML_TOKEN_RE = rf"(?:{_ESCAPED_DSML}|{re.escape(_LEGACY_DSML)})"
 _PARAM_RE = re.compile(
-    rf'<{_ESCAPED_DSML}parameter\s+name="([^"]+)"\s+string="(true|false)">'
-    rf"(.*?)</{_ESCAPED_DSML}parameter>",
+    rf'<{_DSML_TOKEN_RE}parameter\s+name="([^"]+)"\s+string="(true|false)">'
+    rf"(.*?)</{_DSML_TOKEN_RE}parameter>",
     re.DOTALL,
 )
 _PARTIAL_PARAM_RE = re.compile(
-    rf'<{_ESCAPED_DSML}parameter\s+name="([^"]+)"\s+string="(true|false)">'
+    rf'<{_DSML_TOKEN_RE}parameter\s+name="([^"]+)"\s+string="(true|false)">'
     rf"(.*)$",
     re.DOTALL,
 )
@@ -135,6 +146,11 @@ def deepseek_v4_config(thinking: bool = False) -> ParserEngineConfig:
             "INVOKE_NAME_END": DSML_INVOKE_NAME_END,
             "INVOKE_END": DSML_INVOKE_END,
             "PARAM_CLOSE": DSML_PARAM_CLOSE,
+            "TOOL_START_LEGACY": LEGACY_DSML_TOOL_START,
+            "TOOL_END_LEGACY": LEGACY_DSML_TOOL_END,
+            "INVOKE_PREFIX_LEGACY": LEGACY_DSML_INVOKE_PREFIX,
+            "INVOKE_END_LEGACY": LEGACY_DSML_INVOKE_END,
+            "PARAM_CLOSE_LEGACY": LEGACY_DSML_PARAM_CLOSE,
         },
         token_id_terminals={
             "THINK_START": DSML_THINK_START,
@@ -170,7 +186,36 @@ def deepseek_v4_config(thinking: bool = False) -> ParserEngineConfig:
                 ParserState.TOOL_PREAMBLE,
                 (),
             ),
+            (ParserState.CONTENT, "TOOL_START_LEGACY"): Transition(
+                ParserState.TOOL_PREAMBLE,
+                (),
+            ),
+            # The outer ``tool_calls`` wrapper is optional in legacy DSML.
+            (ParserState.CONTENT, "INVOKE_PREFIX"): Transition(
+                ParserState.TOOL_NAME,
+                (EventType.TOOL_CALL_START,),
+            ),
+            (ParserState.CONTENT, "INVOKE_PREFIX_LEGACY"): Transition(
+                ParserState.TOOL_NAME,
+                (EventType.TOOL_CALL_START,),
+            ),
+            (ParserState.REASONING, "TOOL_START_LEGACY"): Transition(
+                ParserState.TOOL_PREAMBLE,
+                (EventType.REASONING_END,),
+            ),
+            (ParserState.REASONING, "INVOKE_PREFIX"): Transition(
+                ParserState.TOOL_NAME,
+                (EventType.REASONING_END, EventType.TOOL_CALL_START),
+            ),
+            (ParserState.REASONING, "INVOKE_PREFIX_LEGACY"): Transition(
+                ParserState.TOOL_NAME,
+                (EventType.REASONING_END, EventType.TOOL_CALL_START),
+            ),
             (ParserState.TOOL_PREAMBLE, "INVOKE_PREFIX"): Transition(
+                ParserState.TOOL_NAME,
+                (EventType.TOOL_CALL_START,),
+            ),
+            (ParserState.TOOL_PREAMBLE, "INVOKE_PREFIX_LEGACY"): Transition(
                 ParserState.TOOL_NAME,
                 (EventType.TOOL_CALL_START,),
             ),
@@ -182,7 +227,15 @@ def deepseek_v4_config(thinking: bool = False) -> ParserEngineConfig:
                 ParserState.TOOL_BETWEEN,
                 (EventType.TOOL_CALL_END,),
             ),
+            (ParserState.TOOL_ARGS, "INVOKE_END_LEGACY"): Transition(
+                ParserState.TOOL_BETWEEN,
+                (EventType.TOOL_CALL_END,),
+            ),
             (ParserState.TOOL_ARGS, "TOOL_END"): Transition(
+                ParserState.CONTENT,
+                (EventType.TOOL_CALL_END,),
+            ),
+            (ParserState.TOOL_ARGS, "TOOL_END_LEGACY"): Transition(
                 ParserState.CONTENT,
                 (EventType.TOOL_CALL_END,),
             ),
@@ -191,7 +244,15 @@ def deepseek_v4_config(thinking: bool = False) -> ParserEngineConfig:
                 ParserState.TOOL_NAME,
                 (EventType.TOOL_CALL_START,),
             ),
+            (ParserState.TOOL_BETWEEN, "INVOKE_PREFIX_LEGACY"): Transition(
+                ParserState.TOOL_NAME,
+                (EventType.TOOL_CALL_START,),
+            ),
             (ParserState.TOOL_BETWEEN, "TOOL_END"): Transition(
+                ParserState.CONTENT,
+                (),
+            ),
+            (ParserState.TOOL_BETWEEN, "TOOL_END_LEGACY"): Transition(
                 ParserState.CONTENT,
                 (),
             ),

--- a/vllm/parser/engine/parser_engine_config.py
+++ b/vllm/parser/engine/parser_engine_config.py
@@ -33,6 +33,8 @@ class ParserState(Enum):
     TOOL_NAME = auto()
     TOOL_ARGS = auto()
     TOOL_BETWEEN = auto()
+    TOOL_DIRECT_NAME = auto()
+    TOOL_DIRECT_ARGS = auto()
 
 
 @dataclass(frozen=True, slots=True)

--- a/vllm/parser/engine/streaming_parser_engine.py
+++ b/vllm/parser/engine/streaming_parser_engine.py
@@ -264,6 +264,8 @@ class StreamingParserEngine:
             ParserState.TOOL_ARGS,
             ParserState.TOOL_NAME,
             ParserState.TOOL_BETWEEN,
+            ParserState.TOOL_DIRECT_NAME,
+            ParserState.TOOL_DIRECT_ARGS,
         ):
             if self.tool_index >= 0:
                 events.append(
@@ -314,6 +316,8 @@ class StreamingParserEngine:
             ParserState.TOOL_NAME,
             ParserState.TOOL_ARGS,
             ParserState.TOOL_BETWEEN,
+            ParserState.TOOL_DIRECT_NAME,
+            ParserState.TOOL_DIRECT_ARGS,
         }
     )
 
@@ -389,7 +393,7 @@ class StreamingParserEngine:
         if self.state == ParserState.MESSAGE_HEADER:
             self._message_header_buffer += text
             return []
-        if self.state == ParserState.TOOL_ARGS:
+        if self.state in (ParserState.TOOL_ARGS, ParserState.TOOL_DIRECT_ARGS):
             if self.config.tool_args_json:
                 return self._feed_args_text(text)
             return [
@@ -419,8 +423,9 @@ class StreamingParserEngine:
         message_header = ""
 
         if (
-            self.state == ParserState.TOOL_ARGS
-            and transition.next_state != ParserState.TOOL_ARGS
+            self.state in (ParserState.TOOL_ARGS, ParserState.TOOL_DIRECT_ARGS)
+            and transition.next_state
+            not in (ParserState.TOOL_ARGS, ParserState.TOOL_DIRECT_ARGS)
             and self._args_buffer
         ):
             events.append(
@@ -457,7 +462,7 @@ class StreamingParserEngine:
                 )
             )
 
-        if self.state == ParserState.TOOL_ARGS:
+        if self.state in (ParserState.TOOL_ARGS, ParserState.TOOL_DIRECT_ARGS):
             self._args_brace_depth = 0
             self._args_in_string = False
             self._args_escape_next = False


### PR DESCRIPTION
# Fix DeepSeek V4 legacy direct-DSML tool calls leaking as assistant content

## Summary

DeepSeek V4 can emit tool calls in a legacy direct DSML form:

```xml
<|DSML|invoke name="exec">
<|DSML|parameter name="command" string="true">true</|DSML|parameter>
</|DSML|invoke>
```

The DeepSeek V4 parser only recognized the fullwidth `｜DSML｜` spelling and
expected an enclosing `<｜DSML｜tool_calls>` wrapper. When the model emitted the
direct ASCII form above, the parser did not produce `tool_calls`; the protocol
markup was returned as ordinary assistant content instead.

This patch makes the parser backward-compatible with both DSML spellings and
with direct invokes that omit the optional outer wrapper.

## Changes

- Accept ASCII `|DSML|` as well as fullwidth `｜DSML｜` markers.
- Accept direct `<…invoke>` blocks without a `tool_calls` wrapper.
- Support multiple direct invokes in one completion.
- Handle legacy markers split across streaming deltas.
- Preserve assistant content following a direct invoke.
- Add parser regression coverage for both non-streaming and streaming cases.

## Reproduction

Before this change, parsing the direct ASCII payload twenty times gave:

```text
iterations=20 leaks=20 structured=0
```

With this change:

```text
iterations=20 leaks=0 structured=20
```

The focused DeepSeek V4 parser test suite passes:

```text
67 passed
```

## Notes

- The compatibility path is intentionally parser-only. It does not alter model
  prompts, tool schemas, speculative decoding, or client behaviour.
- The standard fullwidth/wrapped DSML path remains unchanged.
- This addresses parsing of the observed output syntax. The specific prompt
  condition that makes a model choose the legacy syntax can vary by client and
  is outside this patch's scope.

## Test command

```bash
python -m pytest -q --confcutdir=tests/parser/engine \
  tests/parser/engine/test_deepseek_v4.py
```
