### PR TITLE
[II] Select assembled Kimi router logits with CuTeDSL

### DIFF
--- a/tests/distributed/test_dcp_a2a.py
+++ b/tests/distributed/test_dcp_a2a.py
@@ -1899,6 +1899,33 @@ def test_kimi_projection_warmup_respects_transport_token_cap(monkeypatch):
     ]
 
 
+def test_kimi_router_topk_warmup_is_independent_of_dcp_world_size(monkeypatch):
+    from vllm.v1.attention.ops import dcp_alltoall
+
+    monkeypatch.setenv("VLLM_USE_B12X_DCP_A2A", "1")
+    group = _FakeCPGroup(12, object())  # type: ignore[arg-type]
+    calls: list[tuple[tuple[int, ...], tuple[int, ...]]] = []
+
+    def topk(router_logits, correction_bias):
+        calls.append((tuple(router_logits.shape), tuple(correction_bias.shape)))
+        return torch.empty(8, 16), torch.empty(8, 16, dtype=torch.int32)
+
+    monkeypatch.setattr(dcp_alltoall, "try_b12x_kimi_topk16", topk)
+    monkeypatch.setattr(
+        dcp_alltoall,
+        "_try_b12x_dcp_all_gather_pair",
+        lambda *args, **kwargs: pytest.fail("TP12 has no DCP gather runtime"),
+    )
+
+    warmed = dcp_alltoall.warmup_b12x_kimi_projection_gathers(
+        group,  # type: ignore[arg-type]
+        device=torch.device("cpu"),
+    )
+
+    assert warmed == 1
+    assert calls == [((8, 896), (896,))]
+
+
 def test_warmup_skips_unsupported_world_size(monkeypatch: pytest.MonkeyPatch):
     from vllm.v1.attention.ops import dcp_alltoall
 

--- a/tests/distributed/test_dcp_a2a.py
+++ b/tests/distributed/test_dcp_a2a.py
@@ -1800,6 +1800,65 @@ def test_b12x_kimi_batched_topk_requires_batched_router_binding(monkeypatch):
     assert result is None
 
 
+@pytest.mark.skipif(torch.accelerator.device_count() < 1, reason="CUDA is required.")
+def test_b12x_kimi_router_topk_is_stateless(monkeypatch):
+    from vllm.v1.attention.ops import dcp_alltoall
+
+    monkeypatch.setenv("VLLM_USE_B12X_DCP_A2A", "1")
+    monkeypatch.setenv("VLLM_DCP_A2A_MAX_TOKENS", "1")
+    router_logits = torch.zeros(8, 896, dtype=torch.float32, device="cuda")
+    correction_bias = torch.zeros(896, dtype=torch.float32, device="cuda")
+    received: dict[str, Any] = {}
+
+    def kimi_topk16(router, bias, weights, ids):
+        received.update(
+            router=router,
+            bias=bias,
+            weights=weights,
+            ids=ids,
+        )
+
+    monkeypatch.setattr(
+        dcp_alltoall,
+        "_load_b12x_kimi_topk16",
+        lambda: kimi_topk16,
+    )
+
+    actual = dcp_alltoall.try_b12x_kimi_topk16(
+        router_logits,
+        correction_bias,
+    )
+
+    assert actual is not None
+    weights, ids = actual
+    assert weights.shape == ids.shape == (8, 16)
+    assert weights.dtype == torch.float32
+    assert ids.dtype == torch.int32
+    assert received.pop("router") is router_logits
+    assert received.pop("bias") is correction_bias
+    assert received.pop("weights") is weights
+    assert received.pop("ids") is ids
+    assert received == {}
+
+
+def test_b12x_kimi_router_topk_requires_b12x_transport(monkeypatch):
+    from vllm.v1.attention.ops import dcp_alltoall
+
+    monkeypatch.delenv("VLLM_USE_B12X_DCP_A2A", raising=False)
+    monkeypatch.setattr(
+        dcp_alltoall,
+        "_load_b12x_kimi_topk16",
+        lambda: pytest.fail("disabled routing must not load B12X"),
+    )
+
+    result = dcp_alltoall.try_b12x_kimi_topk16(
+        torch.zeros(8, 896),
+        torch.zeros(896),
+    )
+
+    assert result is None
+
+
 def test_kimi_projection_warmup_respects_transport_token_cap(monkeypatch):
     from vllm.v1.attention.ops import dcp_alltoall
 

--- a/tests/models/kimi_k3/test_sequence_parallel.py
+++ b/tests/models/kimi_k3/test_sequence_parallel.py
@@ -525,6 +525,43 @@ def test_kimi_router_marks_precomputed_padding_routes_inactive(monkeypatch):
     torch.testing.assert_close(ids[2], expected_ids[2])
 
 
+def test_kimi_router_selects_experts_with_b12x_for_full_logits(monkeypatch):
+    correction_bias = nn.Parameter(torch.zeros(896))
+    router = kimi_model.KimiK3PrecomputedTopKRouter(
+        top_k=16,
+        global_num_experts=896,
+        e_score_correction_bias=correction_bias,
+        renormalize=True,
+        routed_scaling_factor=1.0,
+        scoring_func="sigmoid",
+    )
+    hidden_states = torch.empty(8, 4)
+    router_logits = torch.empty(8, 896, dtype=torch.float32)
+    expected = (torch.empty(8, 16), torch.empty(8, 16, dtype=torch.int32))
+    received: dict[str, torch.Tensor] = {}
+
+    def select_experts(logits: torch.Tensor, bias: torch.Tensor):
+        received.update(logits=logits, bias=bias)
+        return expected
+
+    monkeypatch.setattr(
+        kimi_model,
+        "try_select_kimi_routed_experts",
+        select_experts,
+    )
+
+    actual = router._compute_routing(
+        hidden_states,
+        router_logits,
+        torch.int32,
+    )
+
+    assert actual is expected
+    assert received.pop("logits") is router_logits
+    assert received.pop("bias").data_ptr() == correction_bias.data.data_ptr()
+    assert received == {}
+
+
 def test_kimi_router_uses_standard_routing_for_non_payload(monkeypatch):
     router = kimi_model.KimiK3PrecomputedTopKRouter(
         top_k=16,

--- a/vllm/models/kimi_k3/nvidia/model.py
+++ b/vllm/models/kimi_k3/nvidia/model.py
@@ -113,6 +113,7 @@ from vllm.models.kimi_k3.nvidia.tp_projection import (
     gather_kimi_sharded_projection,
     gather_kimi_sharded_projection_pair,
     try_gather_kimi_sharded_projection_pair_topk,
+    try_select_kimi_routed_experts,
 )
 from vllm.multimodal import MULTIMODAL_REGISTRY
 from vllm.multimodal.inputs import NestedTensors
@@ -645,6 +646,26 @@ class KimiK3PrecomputedTopKRouter(FusedTopKBiasRouter):
         input_ids: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         num_tokens = hidden_states.shape[0]
+        if (
+            self.top_k == 16
+            and self.global_num_experts == 896
+            and self.scoring_func == "sigmoid"
+            and self.renormalize
+            and self.routed_scaling_factor == 1.0
+            and indices_type in (None, torch.int32)
+            and input_ids is None
+            and self.e_score_correction_bias is not None
+            and router_logits.shape == (num_tokens, 896)
+            and router_logits.dtype == torch.float32
+            and router_logits.device == hidden_states.device
+            and router_logits.is_contiguous()
+        ):
+            selected = try_select_kimi_routed_experts(
+                router_logits,
+                self.e_score_correction_bias.data,
+            )
+            if selected is not None:
+                return selected
         if (
             self.top_k == 16
             and self.global_num_experts == 896

--- a/vllm/models/kimi_k3/nvidia/tp_projection.py
+++ b/vllm/models/kimi_k3/nvidia/tp_projection.py
@@ -166,3 +166,17 @@ def try_gather_kimi_sharded_projection_pair_topk(
         correction_bias,
         _get_kimi_projection_group(),
     )
+
+
+def try_select_kimi_routed_experts(
+    router_logits: torch.Tensor,
+    correction_bias: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor] | None:
+    """Use B12X CuTeDSL expert selection for assembled Kimi router logits."""
+    select_topk = getattr(dcp_alltoall, "try_b12x_kimi_topk16", None)
+    if select_topk is None:
+        return None
+    return select_topk(
+        router_logits,
+        correction_bias,
+    )

--- a/vllm/v1/attention/ops/dcp_alltoall.py
+++ b/vllm/v1/attention/ops/dcp_alltoall.py
@@ -89,6 +89,15 @@ def _load_b12x_dcp_a2a_pool() -> Any | None:
     return PCIeDCPA2APool
 
 
+@lru_cache(maxsize=1)
+def _load_b12x_kimi_topk16() -> Any | None:
+    try:
+        from b12x.comm.pcie import kimi_topk16
+    except (AttributeError, ImportError):
+        return None
+    return kimi_topk16
+
+
 def _b12x_dcp_init_failed(
     cp_group: GroupCoordinator,
     device: torch.device,
@@ -670,6 +679,57 @@ def try_dcp_b12x_all_gather_pair_kimi_topk(
     return gathered_down, routing_payload
 
 
+def try_b12x_kimi_topk16(
+    router_logits: torch.Tensor,
+    correction_bias: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor] | None:
+    """Select Kimi-K3 experts after router-logit assembly.
+
+    This stateless CuTeDSL operation is local to each rank and does not create
+    PCIe communication channels. Unsupported inputs return ``None`` so the
+    caller can use the vLLM router.
+    """
+    if not envs.VLLM_USE_B12X_DCP_A2A or router_logits.ndim != 2:
+        return None
+    rows = int(router_logits.shape[0])
+    if (
+        rows < 1
+        or rows > _KIMI_PAIRED_MAX_BATCH_SIZE
+        or router_logits.shape != (rows, _KIMI_ROUTER_WIDTH)
+        or router_logits.dtype != torch.float32
+        or correction_bias.shape != (_KIMI_ROUTER_WIDTH,)
+        or correction_bias.dtype != torch.float32
+        or not router_logits.is_cuda
+        or not correction_bias.is_cuda
+        or router_logits.device != correction_bias.device
+        or not router_logits.is_contiguous()
+        or not correction_bias.is_contiguous()
+    ):
+        return None
+
+    kimi_topk16 = _load_b12x_kimi_topk16()
+    if kimi_topk16 is None:
+        return None
+
+    topk_weights = torch.empty(
+        (rows, _KIMI_ROUTER_TOPK),
+        device=router_logits.device,
+        dtype=torch.float32,
+    )
+    topk_ids = torch.empty(
+        (rows, _KIMI_ROUTER_TOPK),
+        device=router_logits.device,
+        dtype=torch.int32,
+    )
+    kimi_topk16(
+        router_logits,
+        correction_bias,
+        topk_weights,
+        topk_ids,
+    )
+    return topk_weights, topk_ids
+
+
 def warmup_b12x_kimi_projection_gathers(
     projection_group: GroupCoordinator,
     *,
@@ -730,6 +790,17 @@ def warmup_b12x_kimi_projection_gathers(
         )
         if batched is not None:
             warmed += 1
+    router_logits = torch.zeros(
+        (_KIMI_PAIRED_MAX_BATCH_SIZE, _KIMI_ROUTER_WIDTH),
+        device=device,
+        dtype=torch.float32,
+    )
+    selected = try_b12x_kimi_topk16(
+        router_logits,
+        correction_bias,
+    )
+    if selected is not None:
+        warmed += 1
     return warmed
 
 

--- a/vllm/v1/attention/ops/dcp_alltoall.py
+++ b/vllm/v1/attention/ops/dcp_alltoall.py
@@ -735,10 +735,28 @@ def warmup_b12x_kimi_projection_gathers(
     *,
     device: torch.device,
 ) -> int:
-    """Compile B12X Kimi paired-projection graph operations eagerly."""
+    """Compile B12X Kimi projection and routing graph operations eagerly."""
     world_size = projection_group.world_size
-    if not envs.VLLM_USE_B12X_DCP_A2A or world_size not in _B12X_DCP_WORLD_SIZES:
+    if not envs.VLLM_USE_B12X_DCP_A2A:
         return 0
+
+    correction_bias = torch.zeros(
+        (_KIMI_ROUTER_WIDTH,),
+        device=device,
+        dtype=torch.float32,
+    )
+    router_logits = torch.zeros(
+        (_KIMI_PAIRED_MAX_BATCH_SIZE, _KIMI_ROUTER_WIDTH),
+        device=device,
+        dtype=torch.float32,
+    )
+    selected = try_b12x_kimi_topk16(
+        router_logits,
+        correction_bias,
+    )
+    warmed = int(selected is not None)
+    if world_size not in _B12X_DCP_WORLD_SIZES:
+        return warmed
 
     token_cap = envs.VLLM_DCP_A2A_MAX_TOKENS
     pair_batch = (
@@ -758,7 +776,6 @@ def warmup_b12x_kimi_projection_gathers(
         device=device,
         dtype=torch.float32,
     )
-    warmed = 0
     paired = _try_b12x_dcp_all_gather_pair(
         local_down,
         local_router,
@@ -768,11 +785,6 @@ def warmup_b12x_kimi_projection_gathers(
     if paired is not None:
         warmed += 1
 
-    correction_bias = torch.zeros(
-        (_KIMI_ROUTER_WIDTH,),
-        device=device,
-        dtype=torch.float32,
-    )
     fused = try_dcp_b12x_all_gather_pair_kimi_topk(
         local_down[:1],
         local_router[:1],
@@ -790,17 +802,6 @@ def warmup_b12x_kimi_projection_gathers(
         )
         if batched is not None:
             warmed += 1
-    router_logits = torch.zeros(
-        (_KIMI_PAIRED_MAX_BATCH_SIZE, _KIMI_ROUTER_WIDTH),
-        device=device,
-        dtype=torch.float32,
-    )
-    selected = try_b12x_kimi_topk16(
-        router_logits,
-        correction_bias,
-    )
-    if selected is not None:
-        warmed += 1
     return warmed
 
 


### PR DESCRIPTION
## Status

Implemented and runtime-qualified for Kimi-K3 routed-MoE selection with one through eight assembled router rows.

## Behavior

- Selects Kimi-K3 routed experts through the B12X stateless CuTeDSL operation when vLLM already owns complete contiguous FP32 router logits.
- Preserves the 896-expert, sigmoid, correction-bias, top-16, normalized-weight, and routing-scale contract.
- Prewarms the eight-row operation before CUDA Graph capture independently of DCP collective topology, including TP12.
- Uses caller-owned output tensors during CUDA Graph replay.
- Retains the combined B12X gather-selection path when projection transport returns a routing payload.
- Retains vLLM top-k selection when the B12X binding or exact Kimi-K3 contract is unavailable.

## Technical reason

A DCP projection pool may be sized for one transport row while speculative target verification assembles two through eight router rows through the exact projection fallback. Running vLLM sigmoid and top-k on those complete rows costs about 20.9 microseconds per target cycle in the measured DSpark configuration. The stateless B12X operation performs the same selection without allocating a second eight-row IPC projection pool.

The stateless operation has no communication or tensor-parallel world-size dependency. Its eager prewarm therefore runs even when the B12X DCP collective does not support the active world size; this keeps TP12 CUDA Graph capture from encountering a cold launcher.

## Dependencies

- vLLM #386 provides Kimi-K3 paired projection transport and the routing-payload path.
- B12X #224 provides the stateless CuTeDSL Kimi top-16 operation.

## Compatibility

The optimization requires `VLLM_USE_B12X_DCP_A2A` and the public B12X `kimi_topk16` binding. The stateless selection itself is topology-independent. Missing bindings, unsupported geometries, unsupported dtypes, token batches above eight, MegaMoE, and input-routed execution retain their established paths. The integration adds no C++, CUDA source, native extension, or environment variable.

## Validation

- The original focused vLLM CUDA tests reported 3 passed and 117 deselected.
- B12X communication tests reported 64 passed.
- Direct GPU qualification for rows one through eight matched vLLM expert IDs and FP32 routing weights exactly and replayed under CUDA Graphs with zero replay allocation.
- DSpark trace: vLLM sigmoid plus top-k measured 20.896 microseconds at median; B12X CuTeDSL top-16 measured 6.240 microseconds at median, a 3.35x kernel reduction and a 14.656-microsecond target-cycle saving.
- DFlash trace: vLLM sigmoid plus top-k measured about 32.24 microseconds at median; B12X CuTeDSL top-16 measured 6.975 microseconds at median, about a 4.6x kernel reduction.
- Official Kimi-K3 MXFP4, TP16/DCP16, Inferact seven-token DSpark draft: 119.975 output tok/s, 30.174 target cycles/s, and 0.4275 acceptance at median across eight fixed-command runs.
- The TP12 prewarm regression test was added but not executed, per the requested accelerated review. No lint or formatting checks were run for that follow-up commit.

The runtime used container digest `sha256:9230c19c6b16ca6216613360619b0cca2356dba65c2297c99817750b3f9e4b83`.

AI assistance was used for implementation, validation, rebase review, and the TP12 lifecycle correction. The human submitter remains responsible for reviewing the resulting diff and validation evidence.
