### PR TITLE
fix(prefix-cache): allow hash-aligned DCP hybrid hits

### DIFF
--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
+++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
@@ -260,6 +260,187 @@ def test_hybrid_mamba_align_partial_hash_hit():
     assert manager.get_blocks("1").blocks[1][1].block_hash_num_tokens == 8
 
 
+def test_dcp8_hybrid_reuses_prefix_at_recurrent_block_boundary():
+    """A DCP-sharded attention block must not coarsen an aligned Mamba hit.
+
+    Kimi K3's production geometry has 1,536-token rank-local blocks and DCP8,
+    so full-attention blocks cover 12,288 logical tokens while recurrent state
+    is materialized every 1,536 tokens. Two prompts sharing 44,449 tokens can
+    therefore safely reuse through token 43,008, rather than falling back to
+    the previous 12,288-token boundary at 36,864.
+    """
+    local_block_size = 1536
+    dcp_world_size = 8
+    global_attention_block_size = local_block_size * dcp_world_size
+    producer_length = 44_449
+    consumer_length = 44_609
+    expected_hit = 43_008
+
+    kv_cache_config = KVCacheConfig(
+        num_blocks=128,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=local_block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    block_size=local_block_size,
+                    shapes=(1, 1),
+                    dtypes=(torch.float32,),
+                    mamba_cache_mode="align",
+                ),
+            ),
+        ],
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=65_536,
+        enable_caching=True,
+        scheduler_block_size=global_attention_block_size,
+        hash_block_size=local_block_size,
+        dcp_world_size=dcp_world_size,
+    )
+    assert [m.block_size for m in manager.coordinator.single_type_managers] == [
+        global_attention_block_size,
+        local_block_size,
+    ]
+
+    shared_tokens = [i % 251 for i in range(producer_length)]
+    producer = make_request("producer", shared_tokens, local_block_size, sha256)
+    computed_blocks, num_computed, _ = manager.get_computed_blocks(producer)
+    assert num_computed == 0
+
+    # Match the real scheduler: recurrent state is committed one rank-local
+    # block at a time, then the non-aligned prompt tail is computed last.
+    while producer.num_computed_tokens < producer.num_tokens:
+        num_new_tokens = min(
+            local_block_size,
+            producer.num_tokens - producer.num_computed_tokens,
+        )
+        new_blocks = manager.allocate_slots(
+            producer,
+            num_new_tokens,
+            num_new_computed_tokens=(
+                num_computed if producer.num_computed_tokens == 0 else 0
+            ),
+            new_computed_blocks=(
+                computed_blocks if producer.num_computed_tokens == 0 else None
+            ),
+        )
+        assert new_blocks is not None
+        producer.num_computed_tokens += num_new_tokens
+        manager.new_step_starts()
+
+    manager.free(producer)
+    manager.new_step_starts()
+
+    consumer = make_request(
+        "consumer",
+        shared_tokens + [252] * (consumer_length - producer_length),
+        local_block_size,
+        sha256,
+    )
+    computed_blocks, num_computed, _ = manager.get_computed_blocks(consumer)
+
+    assert num_computed == expected_hit
+    assert [len(group) for group in computed_blocks.blocks] == [4, 28]
+
+    new_blocks = manager.allocate_slots(
+        consumer,
+        consumer.num_tokens - num_computed,
+        num_new_computed_tokens=num_computed,
+        new_computed_blocks=computed_blocks,
+    )
+    assert new_blocks is not None
+    copies, _ = manager.take_kv_cache_block_copies()
+    # Only the DCP-sharded attention group resumes inside a physical block;
+    # Mamba lands on an already-materialized full recurrent-state boundary.
+    assert len(copies) == 1
+
+
+def test_dcp_hybrid_keeps_coarse_hits_when_recurrent_state_is_partial():
+    """DCP stays coarse when a hash boundary lacks a full recurrent state."""
+    hash_block_size = 4
+    scheduler_block_size = 8
+    kv_cache_config = KVCacheConfig(
+        num_blocks=64,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["full"],
+                FullAttentionSpec(
+                    block_size=4,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["mamba"],
+                MambaSpec(
+                    shapes=((1, 1),),
+                    dtypes=(torch.float32,),
+                    block_size=8,
+                    mamba_cache_mode="align",
+                ),
+            ),
+        ],
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config=kv_cache_config,
+        max_model_len=64,
+        enable_caching=True,
+        scheduler_block_size=scheduler_block_size,
+        hash_block_size=hash_block_size,
+        dcp_world_size=2,
+    )
+
+    shared_tokens = list(range(13))
+    producer = make_request("producer", shared_tokens, hash_block_size, sha256)
+    computed_blocks, num_computed, _ = manager.get_computed_blocks(producer)
+    assert num_computed == 0
+
+    while producer.num_computed_tokens < producer.num_tokens:
+        num_new_tokens = min(
+            hash_block_size,
+            producer.num_tokens - producer.num_computed_tokens,
+        )
+        new_blocks = manager.allocate_slots(
+            producer,
+            num_new_tokens,
+            num_new_computed_tokens=(
+                num_computed if producer.num_computed_tokens == 0 else 0
+            ),
+            new_computed_blocks=(
+                computed_blocks if producer.num_computed_tokens == 0 else None
+            ),
+        )
+        assert new_blocks is not None
+        producer.num_computed_tokens += num_new_tokens
+        manager.new_step_starts()
+
+    manager.free(producer)
+    manager.new_step_starts()
+
+    consumer = make_request(
+        "consumer",
+        shared_tokens + [13],
+        hash_block_size,
+        sha256,
+    )
+    _, num_computed, _ = manager.get_computed_blocks(consumer)
+
+    assert num_computed == scheduler_block_size
+
+
 def test_hybrid_mamba_partial_tail_owner_uses_cow_on_continue():
     hash_block_size = 2
     block_size = 2 * hash_block_size

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -697,13 +697,34 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                     "full-attention, Mamba, and dcp_replicated groups, got: "
                     f"{type(g.kv_cache_spec).__name__}."
                 )
-        # Partial hash hits are limited to full-attention + mamba ("align")
-        # without context parallelism.
-        self.enable_partial_hash_hits = dcp_world_size == 1 and any(
-            isinstance(g.kv_cache_spec, MambaSpec)
-            and g.kv_cache_spec.mamba_cache_mode == "align"
-            and g.kv_cache_spec.block_size > hash_block_size
-            for g in kv_cache_config.kv_cache_groups
+        # Fine-grained hash hits are safe when an aligned Mamba group can
+        # materialize recurrent state at every candidate boundary. Under DCP,
+        # full-attention blocks grow by the shard count while Mamba state stays
+        # replicated. Allow interior attention hits only when every aligned
+        # Mamba manager already has one complete state block per hash unit; this
+        # avoids requiring partial recurrent-state hand-off across DCP ranks.
+        aligned_mamba_managers = [
+            manager
+            for group, manager in zip(
+                kv_cache_config.kv_cache_groups,
+                self.single_type_managers,
+                strict=True,
+            )
+            if isinstance(group.kv_cache_spec, MambaSpec)
+            and group.kv_cache_spec.mamba_cache_mode == "align"
+        ]
+        has_fine_grained_group = any(
+            manager.supports_fine_grained_hash_lookup
+            and manager.block_size > hash_block_size
+            for manager in self.single_type_managers
+        )
+        dcp_mamba_states_are_hash_aligned = all(
+            manager.block_size == hash_block_size for manager in aligned_mamba_managers
+        )
+        self.enable_partial_hash_hits = (
+            bool(aligned_mamba_managers)
+            and has_fine_grained_group
+            and (dcp_world_size == 1 or dcp_mamba_states_are_hash_aligned)
         )
         self.verify_and_split_kv_cache_groups()
 


### PR DESCRIPTION
## Bug Description

Hybrid Mamba/attention models blanket-disable fine-grained prefix hits when
`dcp_world_size > 1`. This coarsens local APC hits to the DCP-expanded
full-attention block even when the recurrent manager already materializes a
complete state at every hash boundary.

For the reproduced geometry:

```text
local/cache block       1,536 tokens
DCP world size              8
attention block        12,288 tokens
producer prompt        44,449 tokens
consumer prompt        44,609 tokens
pre-fix local hit      36,864 tokens
safe recurrent boundary 43,008 tokens
```

## Root Cause

`HybridKVCacheCoordinator` enabled partial hash hits only when
`dcp_world_size == 1`. That guard treated two different cases as equivalent:

1. a DCP hash boundary where recurrent state would itself be partial; and
2. a DCP hash boundary that is already a complete aligned Mamba state, while
   only the DCP-sharded attention block is partial.

The second case does not need a new recurrent-state representation. It can use
the existing full Mamba state plus the existing full-attention partial-block
copy-on-write path.

## Fix

- Detect aligned Mamba managers participating in the hybrid coordinator.
- Require at least one cache group with a block larger than the hash unit.
- Preserve existing DCP1 behavior.
- Under DCP, enable fine-grained hits only when **every aligned recurrent
  manager block exactly equals the hash block size**.
- Keep the coarse scheduler-block fallback when recurrent state would be
  partial.

This does not change tensor layouts, kernels, DCP sharding, cache keys, or
sampling behavior.

## How to Verify

1. Run the exact DCP8 regression:

   ```bash
   pytest -q \
     tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py::test_dcp8_hybrid_reuses_prefix_at_recurrent_block_boundary
   ```

   Before the fix it fails with `36864 != 43008`; after the fix it passes.

2. Run the preserved-negative regression:

   ```bash
   pytest -q \
     tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py::test_dcp_hybrid_keeps_coarse_hits_when_recurrent_state_is_partial
   ```

   It verifies that a DCP recurrent block larger than the hash unit remains on
   the coarse boundary.

## Test Plan

- [x] Regression observed RED before implementation (`36864 != 43008`)
- [x] Partial-prefix suite: 24 passed
- [x] Prefix-caching + Mamba split suites: 113 passed
- [x] Single-type manager + primitives + KV geometry suites: 116 passed
- [x] Related scheduler/connector selectors: 7 passed
- [x] `ruff check` and `ruff format --check`
- [x] Independent pre-commit review: approved, no blocking issue
- [x] Runtime DCP8 exact-payload token-source and deterministic local equivalence
- [x] Compatible-restart external equivalence

## Runtime Qualification

Immutable image:

```text
sha256:c8d565820ef3736a866ee9d9f323414ca429061ec85ed528969b44ed28fc648b
```

Exact captured 44,449 -> 44,609 token pair, greedy sampling, seed 0:

| Arm | Local hit | External hit | Computed | TTFT | Semantic SHA-256 |
|---|---:|---:|---:|---:|---|
| cold control | 0 | 0 | 44,609 | 49.099 s | `57b2c985277ccd4463b67fd51d24ec7d0c75753d543fc566de6f7629511eb47c` |
| same-process local | 43,008 | 0 | 1,601 | 2.053 s | `57b2c985277ccd4463b67fd51d24ec7d0c75753d543fc566de6f7629511eb47c` |
| compatible-restart external | 0 | 36,864 | 7,745 | 11.690 s | `57b2c985277ccd4463b67fd51d24ec7d0c75753d543fc566de6f7629511eb47c` |

The local arm was byte/semantic equivalent and improved TTFT by **23.91x**.
The restarted external arm also remained byte/semantic equivalent and proves
that this change is compatible with LMCache's unchanged 12,288-token object
geometry. The local APC improvement is intentionally finer-grained than the
external L2 hit.

The immutable restart used the same OCI digest, logged `preserve-compatible`
with zero entries removed, retained 13,248 L2 files / 272,512,843,776 bytes,
and completed with restart count 0, no fatal log matches, and no inference-time
Triton JIT notices.

## Risk Assessment

**Low to medium.** The behavior change is restricted to hybrid aligned-Mamba
coordinators. DCP remains disabled whenever a candidate hash boundary lacks a
complete recurrent state. The negative regression locks that fallback in.

LMCache's external 12,288-token object geometry is unchanged; this PR improves
same-process local APC reuse only.


## AI assistance

AI assistance was used for the final patch review and patch-equivalent rebase. No tests or linters were rerun during final merge review.
