### PR TITLE
[Bugfix] Gate hybrid+connector divergent local-hit path on connector opt-in [necessary but NOT sufficient — predicted 0/38 refuted, see comment]

### DIFF
--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -726,8 +726,31 @@ class Scheduler(SchedulerInterface):
                 # Get already-cached tokens.
                 if request.num_computed_tokens == 0:
                     # Get locally-cached tokens.
+                    #
+                    # The per-group (divergent) hybrid lookup below reports the
+                    # full-attention group's hit as the local prefix and relies
+                    # on the connector to restore the lagging recurrent (Mamba/
+                    # GDN) state at that boundary -- nixl does this in
+                    # _apply_prefix_caching. A connector that does not restore
+                    # lagging group state (e.g. LMCacheMPConnector) leaves the
+                    # Mamba state block at the resume boundary uninitialized:
+                    # attention KV is valid, the recurrent state is garbage,
+                    # and generation is silently corrupted for content in the
+                    # divergence window (receipts/lmcache-reuse-test.json:
+                    # 14/14 wrong with the connector vs 7/7 correct without,
+                    # at identical reuse geometry). Upstream vLLM gates this
+                    # path on supports_divergent_local_hybrid_hits (PR #48425
+                    # lineage); mirror that: connectors that do not opt in get
+                    # the reconciled min-across-groups hit from
+                    # get_computed_blocks, which only resumes where every
+                    # group's state exists.
                     if (
                         self.connector is not None
+                        and getattr(
+                            self.connector,
+                            "supports_divergent_local_hybrid_hits",
+                            False,
+                        )
                         and self.has_mamba_layers
                         and isinstance(
                             self.kv_cache_manager.coordinator,


### PR DESCRIPTION
Closes #402.

## Provenance

Derived directly from the reviewed, sha256-pinned patch file
`patches/gg-vllm-hybrid-divergent-hit-gate.patch` (sha256
`5f9ad10bedff87c4f37ce61bfe9be5cc9ed84dce99d9d3685c54b0341529839f`) in
`malaiwah/qwen38-27b-exl3` — applied with `git apply` onto
`dev/gilded-gnosis @ fa033bd4e`, not retyped. That commit's `scheduler.py` is
byte-identical to the copy vendored in the pinned r34 serving image's rootfs
(verified by direct diff before this PR was opened), so this is exactly what
ships today.

## Bug

See #402 for the full root cause and the four-arm ladder evidence
(`receipts/lmcache-reuse-test.json`): the hybrid per-group local prefix-cache
lookup in `Scheduler.schedule()` reports the full-attention group's hit as the
model-wide computed prefix whenever **any** KV connector is attached, and
relies on the connector to restore the lagging recurrent (Mamba/GDN) state at
that boundary. Only nixl's `_apply_prefix_caching` does that unconditionally.
`LMCacheMPConnector` does not, so generation resumes with an uninitialized or
stale recurrent state and is silently corrupted — HTTP 200, no crash — for
content inside the divergence window (measured: L0 no-connector control 0/38
failed vs L1cold/L2warm connector-attached 7/38, L3restart 38/38).

## Fix

Gate the per-group hybrid lookup on the connector opting in:

```python
if (
    self.connector is not None
    and getattr(self.connector, "supports_divergent_local_hybrid_hits", False)
    and self.has_mamba_layers
    and isinstance(self.kv_cache_manager.coordinator, HybridKVCacheCoordinator)
):
    ...
```

Connectors that don't set the flag (every connector on this branch today,
including LMCacheMPConnector) fall back to
`KVCacheCoordinator.get_computed_blocks()` — the reconciled min-across-groups
hit, which only resumes where every group's state, including the recurrent
one, actually exists. That is the same regime the clean L0 control ran under.

This mirrors upstream vLLM's own fix for this exact defect class —
**vllm-project/vllm#48425** (commit `229e01e9e`), which introduced
`supports_divergent_local_hybrid_hits` and this same gate. Our
`dev/gilded-gnosis` lineage predates that fix and carries neither the flag nor
the gate; a third party independently hit the identical bug on stock upstream
0.26.0 and cited #48425 as their fix
([LMCache/LMCache#4247](https://github.com/LMCache/LMCache/issues/4247)).

File touched: `vllm/v1/core/sched/scheduler.py`, one hunk at the
`if request.num_computed_tokens == 0:` block inside `Scheduler.schedule()`
(currently line 726 on `dev/gilded-gnosis @ fa033bd4e`; +23/-0, comment +
one `getattr` condition).

## Status: CPU-verified only. GPU behavioral proof pending.

**What is verified (CPU, this session):**
- Patch applies cleanly to `dev/gilded-gnosis @ fa033bd4e` (`git apply --check`, then applied)
- Round-trips byte-identical against the reviewed patch file
- Patched `vllm/v1/core/sched/scheduler.py` `py_compiles` clean

**What is NOT yet verified (explicitly, so this isn't mistaken for a proven fix):**
- No GPU behavioral test has been run against this patch. The predicted result
  — the four-arm ladder in `receipts/lmcache-reuse-test.json` re-run with this
  gate applied turns L1cold/L2warm from 7/38 failing to 0/38 — is a prediction
  from the root-cause analysis, not a measurement.
- That GPU ladder re-run is planned separately (not part of this PR) and is
  the gate for treating this as behaviorally proven, not just CPU-clean.

## Trigger condition / who this affects

Requires **both**: (a) a hybrid model (Mamba/GDN + full-attention layers) and
(b) an external KV connector attached. **No currently running GG serving is
affected** — the TB2.1 campaign's `sr1` image and in-flight AIBoss passes use
native vLLM prefix caching only, no `--kv-transfer-config`, no connector
attached.

## Tradeoff

A GG deployment running nixl P/D with a hybrid model loses the FA-hit
optimization until GG rebases the upstream capability-flag plumbing so nixl's
connector can set `supports_divergent_local_hybrid_hits=True` (nixl already
restores recurrent state unconditionally today, so it stays correct, just
un-opted-in). **Not applicable to this campaign, which does not use nixl.**

## DCO

Single commit, signed off: `Signed-off-by: Michel Belleau <michel.belleau@malaiwah.com>`.

## References

- Issue: #402
- `receipts/lmcache-fix.json`, `receipts/lmcache-reuse-test.json`,
  `patches/gg-vllm-hybrid-divergent-hit-gate.patch` (sha256
  `5f9ad10bedff87c4f37ce61bfe9be5cc9ed84dce99d9d3685c54b0341529839f`), all in
  <https://github.com/malaiwah/qwen38-27b-exl3>
- Mirrors: vllm-project/vllm#48425


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hybrid cache handling during request scheduling.
  * Prevents requests from resuming when required recurrent-state data is unavailable.
  * Uses safer, reconciled cache-hit behavior unless the connected cache explicitly supports independent group handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->