### PR TITLE
[II] Bound Kimi-K3 vision loading and preprocessing memory

### DIFF
--- a/tests/models/kimi_k3/test_mm_preprocess.py
+++ b/tests/models/kimi_k3/test_mm_preprocess.py
@@ -25,11 +25,15 @@ class _Tokenizer:
 
 
 class _ProcessingContext:
-    def __init__(self) -> None:
+    def __init__(self, mm_processor_kwargs: dict[str, object] | None = None) -> None:
+        multimodal_config = SimpleNamespace(
+            mm_processor_kwargs=mm_processor_kwargs,
+        )
         self.model_config = SimpleNamespace(
             model="moonshotai/Kimi-K3",
             revision="test-revision",
             trust_remote_code=True,
+            get_multimodal_config=lambda: multimodal_config,
         )
         self._hf_config = SimpleNamespace(media_placeholder_token_id=42)
 
@@ -71,3 +75,73 @@ def test_kimi_k3_selects_native_image_processor_when_available(
             KimiK25FusedVisionProcessor if numba_available else None
         ),
     }
+
+
+def test_kimi_k3_applies_static_image_patch_limits(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    image_processor = SimpleNamespace(
+        media_proc_cfg={
+            "in_patch_limit": 65536,
+            "patch_limit_on_one_side": 512,
+        },
+        media_tokens_calculator=lambda _media: 1,
+    )
+    monkeypatch.setattr(mm_preprocess, "is_numba_available", lambda: False)
+    monkeypatch.setattr(
+        mm_preprocess,
+        "cached_get_image_processor",
+        lambda *_args, **_kwargs: image_processor,
+    )
+
+    info = mm_preprocess.KimiK3ProcessingInfo(  # type: ignore[arg-type]
+        _ProcessingContext(
+            {
+                "in_patch_limit": 49152,
+                "patch_limit_on_one_side": 384,
+            }
+        )
+    )
+
+    assert info.image_processor is not image_processor
+    assert info.image_processor.media_proc_cfg == {
+        "in_patch_limit": 49152,
+        "patch_limit_on_one_side": 384,
+    }
+    assert image_processor.media_proc_cfg == {
+        "in_patch_limit": 65536,
+        "patch_limit_on_one_side": 512,
+    }
+
+
+@pytest.mark.parametrize(
+    ("processor_kwargs", "message"),
+    [
+        ({"in_patch_limit": True}, "positive integer"),
+        ({"in_patch_limit": 65537}, "exceeds the checkpoint limit"),
+        ({"patch_limit_on_one_side": 513}, "exceeds the checkpoint limit"),
+    ],
+)
+def test_kimi_k3_rejects_invalid_image_patch_limits(
+    monkeypatch: pytest.MonkeyPatch,
+    processor_kwargs: dict[str, object],
+    message: str,
+):
+    image_processor = SimpleNamespace(
+        media_proc_cfg={
+            "in_patch_limit": 65536,
+            "patch_limit_on_one_side": 512,
+        },
+        media_tokens_calculator=lambda _media: 1,
+    )
+    monkeypatch.setattr(mm_preprocess, "is_numba_available", lambda: False)
+    monkeypatch.setattr(
+        mm_preprocess,
+        "cached_get_image_processor",
+        lambda *_args, **_kwargs: image_processor,
+    )
+
+    with pytest.raises(ValueError, match=message):
+        mm_preprocess.KimiK3ProcessingInfo(  # type: ignore[arg-type]
+            _ProcessingContext(processor_kwargs)
+        )

--- a/vllm/model_executor/layers/quantization/online/mxfp8.py
+++ b/vllm/model_executor/layers/quantization/online/mxfp8.py
@@ -95,7 +95,15 @@ class Mxfp8OnlineLinearMethod(_Fp8OnlineLinearBase):
         replace_parameter(layer, "weight", weight_fp8.data)
         replace_parameter(layer, "weight_scale", weight_scale.data)
 
-        self.kernel.process_weights_after_loading(layer)
+        weight_shape = tuple(layer.weight.shape)
+        try:
+            self.kernel.process_weights_after_loading(layer)
+        except RuntimeError as error:
+            prefix = getattr(layer, "prefix", type(layer).__name__)
+            raise RuntimeError(
+                "MXFP8 weight preparation failed for "
+                f"{prefix} with weight shape {weight_shape}"
+            ) from error
 
         layer._already_called_process_weights_after_loading = True
 

--- a/vllm/model_executor/layers/quantization/utils/marlin_utils_fp8.py
+++ b/vllm/model_executor/layers/quantization/utils/marlin_utils_fp8.py
@@ -475,6 +475,34 @@ def prepare_mxfp8_layer_for_marlin(layer: torch.nn.Module) -> None:
     qweight = qweight.T.contiguous()
     qweight = marlin_pad_qweight(qweight, part_size_n, part_size_k, padded_n, padded_k)
 
+    # qweight owns an independent contiguous copy at this point. The source
+    # FP8 parameter is no longer needed, and retaining it while the Marlin
+    # output is allocated makes peak memory proportional to three full weight
+    # buffers. Keep an empty registered parameter so reload metadata remains
+    # available until the final packed parameter replaces it below.
+    replace_parameter(
+        layer,
+        "weight",
+        torch.empty(0, dtype=layer.weight.dtype, device=device),
+    )
+
+    # Online quantization can leave reusable allocator blocks split across
+    # sizes that are unsuitable for the final contiguous Marlin output. This
+    # matters when expandable segments are disabled for pointer-stable KV
+    # cache integrations. Release inactive blocks only under low physical
+    # memory; active model tensors and qweight remain allocated.
+    free_bytes, _ = torch.cuda.mem_get_info(device)
+    minimum_free_bytes = max(1 << 30, 2 * qweight.numel() * qweight.element_size())
+    if free_bytes < minimum_free_bytes:
+        logger.info(
+            "Releasing inactive CUDA allocator blocks before MXFP8 Marlin "
+            "repack for %s (%d MiB free, %d MiB required).",
+            getattr(layer, "prefix", type(layer).__name__),
+            free_bytes >> 20,
+            minimum_free_bytes >> 20,
+        )
+        torch.cuda.empty_cache()
+
     marlin_qweight = ops.gptq_marlin_repack(
         b_q_weight=qweight,
         perm=perm,

--- a/vllm/models/kimi_k3/common/mm_preprocess.py
+++ b/vllm/models/kimi_k3/common/mm_preprocess.py
@@ -4,6 +4,7 @@
 
 import math
 from collections.abc import Mapping, Sequence
+from copy import deepcopy
 from typing import Any, cast
 
 import torch
@@ -35,6 +36,63 @@ from vllm.transformers_utils.processors.kimi_k25_vision_fused import (
 from vllm.utils.import_utils import is_numba_available
 
 logger = init_logger(__name__)
+
+
+_PATCH_LIMIT_KEYS = ("in_patch_limit", "patch_limit_on_one_side")
+
+
+def _apply_image_patch_limits(
+    image_processor: Any,
+    processor_kwargs: Mapping[str, object],
+) -> Any:
+    """Return a processor with deployment-wide Kimi image limits applied.
+
+    Kimi's image processor resizes inputs to ``in_patch_limit`` and
+    ``patch_limit_on_one_side``. Restricting those checkpoint defaults bounds
+    both the startup memory profile and request-time vision activations. The
+    cached checkpoint processor is copied so another model configuration in
+    the same process cannot inherit these deployment-specific limits.
+    """
+    overrides = {
+        key: processor_kwargs[key]
+        for key in _PATCH_LIMIT_KEYS
+        if key in processor_kwargs
+    }
+    if not overrides:
+        return image_processor
+
+    media_proc_cfg = getattr(image_processor, "media_proc_cfg", None)
+    if not isinstance(media_proc_cfg, Mapping):
+        raise ValueError(
+            "Kimi-K3 image patch limits require an image processor with "
+            "a media_proc_cfg mapping"
+        )
+
+    bounded_cfg = dict(media_proc_cfg)
+    for key, value in overrides.items():
+        if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+            raise ValueError(f"Kimi-K3 {key} must be a positive integer")
+        checkpoint_limit = bounded_cfg.get(key)
+        if not isinstance(checkpoint_limit, int) or checkpoint_limit <= 0:
+            raise ValueError(
+                f"Kimi-K3 checkpoint does not define a positive {key} limit"
+            )
+        if value > checkpoint_limit:
+            raise ValueError(
+                f"Kimi-K3 {key}={value} exceeds the checkpoint limit "
+                f"of {checkpoint_limit}"
+            )
+        bounded_cfg[key] = value
+
+    bounded_processor = deepcopy(image_processor)
+    bounded_processor.media_proc_cfg = bounded_cfg
+    logger.info(
+        "Kimi-K3 image processing limits: in_patch_limit=%d, "
+        "patch_limit_on_one_side=%d",
+        bounded_cfg["in_patch_limit"],
+        bounded_cfg["patch_limit_on_one_side"],
+    )
+    return bounded_processor
 
 
 def navit_resize_image(
@@ -116,6 +174,14 @@ class KimiK3ProcessingInfo(BaseProcessingInfo):
             trust_remote_code=self.ctx.model_config.trust_remote_code,
             processor_cls_overrides=processor_cls,
         )
+        get_mm_config = getattr(self.ctx.model_config, "get_multimodal_config", None)
+        if get_mm_config is not None:
+            mm_config = get_mm_config()
+            processor_kwargs = mm_config.mm_processor_kwargs or {}
+            image_processor = _apply_image_patch_limits(
+                image_processor,
+                processor_kwargs,
+            )
 
         # Resolve token ID from the tokenizer because transformers v5
         # may remap token IDs vs config.json.

--- a/vllm/models/kimi_k3/nvidia/model.py
+++ b/vllm/models/kimi_k3/nvidia/model.py
@@ -1987,9 +1987,15 @@ class KimiK3ForConditionalGeneration(
                 quant_config=self._maybe_ignore_quant_config(quant_config),
                 prefix=maybe_prefix(prefix, "vision_tower"),
             )
-            if self._maybe_ignore_quant_config(quant_config) is not None:
+            vision_has_deferred_weights = any(
+                parameter.is_meta for parameter in self.vision_tower.parameters()
+            )
+            if (
+                self._maybe_ignore_quant_config(quant_config) is not None
+                and not vision_has_deferred_weights
+            ):
                 self.vision_tower = self.vision_tower.to(device=self.device)
-            else:
+            elif self._maybe_ignore_quant_config(quant_config) is None:
                 self.vision_tower = self.vision_tower.to(
                     device=self.device, dtype=model_config.dtype
                 )
@@ -2027,9 +2033,15 @@ class KimiK3ForConditionalGeneration(
                 quant_config=self._maybe_ignore_quant_config(quant_config),
                 prefix=maybe_prefix(prefix, "mm_projector"),
             )
-            if self._maybe_ignore_quant_config(quant_config) is not None:
+            projector_has_deferred_weights = any(
+                parameter.is_meta for parameter in self.mm_projector.parameters()
+            )
+            if (
+                self._maybe_ignore_quant_config(quant_config) is not None
+                and not projector_has_deferred_weights
+            ):
                 self.mm_projector = self.mm_projector.to(device=self.device)
-            else:
+            elif self._maybe_ignore_quant_config(quant_config) is None:
                 self.mm_projector = self.mm_projector.to(
                     device=self.device, dtype=model_config.dtype
                 )


### PR DESCRIPTION
## Behavior

Kimi-K3 deployments can lower `in_patch_limit` and `patch_limit_on_one_side` through `--mm-processor-kwargs`. The processor validates both values against checkpoint limits and applies them to an isolated processor copy.

InstantTensor may leave vision and projector parameters on the meta device until their weights arrive. Model construction preserves those deferred parameters. Weight-only MXFP8 preparation releases the superseded FP8 parameter before allocating the Marlin-packed output and reports the module name and weight shape when preparation fails.

## Technical reason

Kimi-K3 resizes every image before encoder execution. Applying the configured patch bounds during multimodal profiling and request preprocessing places a deterministic upper bound on vision activations. Moving unresolved meta parameters or retaining both source and packed MXFP8 weights raises startup memory enough to prevent the official checkpoint, vision encoder, speculative draft, and one-million-token cache from fitting together on 96 GiB GPUs.

## Compatibility

Checkpoint patch limits remain the upper bound. Text-only deployments, processors without patch-limit overrides, and non-deferred parameters retain their established behavior. The MXFP8 allocator release runs only after an independent contiguous quantized weight exists and only releases inactive CUDA allocator blocks when physical free memory is below the repack requirement.

## Validation

- `uvx ruff check` passes for all five changed files.
- `uvx ruff format --check` passes for all five changed files.
- `tests/models/kimi_k3/test_mm_preprocess.py`: 6 passed.
- TP16/DCP16 Kimi-K3 served a native image request with `in_patch_limit=40960`, `patch_limit_on_one_side=512`, and weight-only MXFP8 vision/projector projections.
- Vision/projector model storage measured 853.270 MiB/GPU in BF16 and 444.457 MiB/GPU with MXFP8 weights plus retained residual tensors, a reduction of 408.812 MiB/GPU.

## Duplicate check

No open `local-inference-lab/vllm` pull request matched Kimi-K3 vision patch bounds or deferred vision MXFP8 loading. Pull request #382 covers bounded InstantTensor checkpoint staging; it does not change multimodal processor limits, meta-parameter movement, or Marlin repack lifetime.

AI assistance was used to implement, test, and document the change. The submitter reviewed the complete diff and the stated validation evidence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable image patch limits for Kimi-K3 image processing, with validation against model limits.
  * Improved support for deferred vision-model weights during initialization.

* **Bug Fixes**
  * Prevented unintended modification of cached image processors.
  * Improved error messages for MXFP8 weight-processing failures.
  * Reduced CUDA memory pressure during MXFP8 model preparation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->