### PR TITLE
[II] Encode Kimi precomputed padding as safe zero-weight routes

### DIFF
--- a/tests/models/kimi_k3/test_sequence_parallel.py
+++ b/tests/models/kimi_k3/test_sequence_parallel.py
@@ -489,7 +489,9 @@ def test_kimi_router_decodes_precomputed_topk_payload_without_copy():
     torch.testing.assert_close(ids, expected_ids)
 
 
-def test_kimi_router_marks_precomputed_padding_routes_inactive(monkeypatch):
+def test_kimi_router_encodes_precomputed_padding_as_zero_weight_routes(
+    monkeypatch,
+):
     router = kimi_model.KimiK3PrecomputedTopKRouter(
         top_k=16,
         global_num_experts=896,
@@ -519,9 +521,11 @@ def test_kimi_router_marks_precomputed_padding_routes_inactive(monkeypatch):
 
     assert weights.data_ptr() == payload.data_ptr()
     assert ids.data_ptr() == payload[num_tokens:].data_ptr()
-    torch.testing.assert_close(weights, expected_weights)
+    torch.testing.assert_close(weights[0], expected_weights[0])
+    torch.testing.assert_close(weights[1], torch.zeros(16))
+    torch.testing.assert_close(weights[2], expected_weights[2])
     torch.testing.assert_close(ids[0], expected_ids[0])
-    torch.testing.assert_close(ids[1], torch.full((16,), -1, dtype=torch.int32))
+    torch.testing.assert_close(ids[1], torch.zeros(16, dtype=torch.int32))
     torch.testing.assert_close(ids[2], expected_ids[2])
 
 

--- a/vllm/models/kimi_k3/nvidia/model.py
+++ b/vllm/models/kimi_k3/nvidia/model.py
@@ -683,7 +683,9 @@ class KimiK3PrecomputedTopKRouter(FusedTopKBiasRouter):
             if envs.VLLM_MOE_SKIP_PADDING and is_forward_context_available():
                 is_padding = get_forward_context().is_padding
                 if is_padding is not None:
-                    topk_ids.masked_fill_(is_padding[:num_tokens, None], -1)
+                    padding = is_padding[:num_tokens, None]
+                    topk_ids.masked_fill_(padding, 0)
+                    topk_weights.masked_fill_(padding, 0.0)
             return topk_weights, topk_ids
         return super()._compute_routing(
             hidden_states,


### PR DESCRIPTION
Kimi-K3 precomputed routing now represents CUDA Graph padding slots with expert ID 0 and route weight 0. This keeps every speculative weight address valid while preserving an exact zero contribution from padding.

The previous representation used expert ID -1. B12X native ModelOpt W4A16 small-M execution indexes route IDs directly, so padded graph inputs could produce `cudaErrorIllegalAddress` during DSpark graph warmup. Disabling padding skipping on the same checkpoint and launch geometry completed graph capture, isolating the failure to that representation.

Compatibility: the precomputed payload remains zero-copy; only padding rows are mutated. Active route IDs and weights are unchanged. Kernels that already understand negative inactive IDs are unaffected because they receive an equivalent zero-weight route.

Validation:
- five focused Kimi router tests pass;
- payload view identity remains unchanged;
- padding rows contain addressable IDs and exact zero weights;
- the unmodified B12X W4A16 kernel retains its 22.54 microsecond Kimi TP16 M=1 hot path instead of adding per-route bounds checks.