### PR TITLE
perf(fla): normalize tail alignment specialization

### DIFF
--- a/tests/kernels/core/test_fla_tail_length_specialization.py
+++ b/tests/kernels/core/test_fla_tail_length_specialization.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from typing import Any, cast
+
+import pytest
+import torch
+
+from vllm.third_party.flash_linear_attention.ops.kda import (
+    layer_norm_gated_fwd_kernel,
+)
+from vllm.third_party.flash_linear_attention.ops.l2norm import (
+    l2norm_fwd_kernel2,
+)
+
+
+def _specialization(kernel, *args):
+    _, _, _, _, binder = kernel.create_binder()
+    return binder(*args)[1]
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_l2norm_tail_length_reuses_aligned_specialization() -> None:
+    """A non-aligned prefill tail must reuse the startup-warmed kernel."""
+    x = torch.empty(1, dtype=torch.bfloat16, device="cuda")
+    y = torch.empty_like(x)
+
+    aligned = _specialization(l2norm_fwd_kernel2, x, y, 1e-6, 1536, 128, 128, 32)
+    tail = _specialization(l2norm_fwd_kernel2, x, y, 1e-6, 1177, 128, 128, 32)
+
+    assert tail == aligned
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_kda_gated_norm_tail_length_reuses_aligned_specialization() -> None:
+    """A non-aligned prefill tail must reuse the startup-warmed kernel."""
+    x = torch.empty(1, dtype=torch.bfloat16, device="cuda")
+    rstd = torch.empty(1, dtype=torch.float32, device="cuda")
+    kernel = cast(Any, layer_norm_gated_fwd_kernel).fn
+
+    def bind(length: int):
+        return _specialization(
+            kernel,
+            x,
+            x,
+            x,
+            x,
+            None,
+            None,
+            None,
+            None,
+            rstd,
+            1e-5,
+            length,
+            1,
+            128,
+            128,
+            16,
+            128,
+            "swish",
+            True,
+            False,
+            False,
+            True,
+            False,
+        )
+
+    assert bind(1177) == bind(1536)

--- a/tests/kernels/core/test_fla_tail_length_specialization.py
+++ b/tests/kernels/core/test_fla_tail_length_specialization.py
@@ -15,6 +15,17 @@ from vllm.third_party.flash_linear_attention.ops.l2norm import (
 
 
 def _specialization(kernel, *args):
+    """Resolve the Triton specialization key a kernel would compile for.
+
+    Args:
+        kernel: the Triton JIT function whose binder is created.
+        *args: the launch arguments, in the kernel's signature order, that
+            determine the specialization (tensors, scalars, constexprs).
+
+    Returns:
+        The specialization key the binder derives from ``args``; two launches
+        share a compiled kernel exactly when their keys are equal.
+    """
     _, _, _, _, binder = kernel.create_binder()
     return binder(*args)[1]
 
@@ -39,6 +50,14 @@ def test_kda_gated_norm_tail_length_reuses_aligned_specialization() -> None:
     kernel = cast(Any, layer_norm_gated_fwd_kernel).fn
 
     def bind(length: int):
+        """Specialization key of the gated-norm kernel for ``length`` rows.
+
+        Args:
+            length: the row count (token count) of the launch.
+
+        Returns:
+            The specialization key; the other launch arguments are fixed.
+        """
         return _specialization(
             kernel,
             x,

--- a/tests/kernels/core/test_fused_rms_norm_gated.py
+++ b/tests/kernels/core/test_fused_rms_norm_gated.py
@@ -4,12 +4,15 @@
 """Tests that FusedRMSNormGated decomposes correctly under torch.compile,
 matching the eager triton kernel output."""
 
+from typing import Any, cast
+
 import pytest
 import torch
 
 from vllm.platforms import current_platform
 from vllm.third_party.flash_linear_attention.ops.fused_norm_gate import (
     FusedRMSNormGated,
+    layer_norm_gated_fwd_kernel,
 )
 from vllm.utils.torch_utils import set_random_seed
 
@@ -21,6 +24,44 @@ NUM_TOKENS = [64, 128]
 ACTIVATIONS = ["swish", "sigmoid"]
 ELEMENTWISE_AFFINE = [True, False]
 SEEDS = [0]
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_tail_length_reuses_aligned_specialization() -> None:
+    """A non-aligned prefill tail must reuse the startup-warmed kernel."""
+    x = torch.empty(1, dtype=torch.bfloat16, device=DEVICE)
+    rstd = torch.empty(1, dtype=torch.float32, device=DEVICE)
+    kernel = cast(Any, layer_norm_gated_fwd_kernel).fn
+    _, _, _, _, binder = kernel.create_binder()
+
+    def bind(length: int):
+        return binder(
+            x,
+            x,
+            x,
+            x,
+            None,
+            None,
+            None,
+            None,
+            rstd,
+            1e-5,
+            length,
+            1,
+            128,
+            128,
+            16,
+            128,
+            "swish",
+            True,
+            False,
+            False,
+            True,
+            False,
+            False,
+        )[1]
+
+    assert bind(1177) == bind(1536)
 
 
 @pytest.mark.parametrize("num_tokens", NUM_TOKENS)

--- a/tests/kernels/core/test_fused_rms_norm_gated.py
+++ b/tests/kernels/core/test_fused_rms_norm_gated.py
@@ -35,6 +35,14 @@ def test_tail_length_reuses_aligned_specialization() -> None:
     _, _, _, _, binder = kernel.create_binder()
 
     def bind(length: int):
+        """Specialization key of the gated-norm kernel for ``length`` rows.
+
+        Args:
+            length: the row count (token count) of the launch.
+
+        Returns:
+            The specialization key; the other launch arguments are fixed.
+        """
         return binder(
             x,
             x,

--- a/vllm/third_party/flash_linear_attention/ops/fused_norm_gate.py
+++ b/vllm/third_party/flash_linear_attention/ops/fused_norm_gate.py
@@ -23,7 +23,7 @@ from vllm.utils.math_utils import cdiv, next_power_of_2
         "HAS_BIAS": lambda args: args["b"] is not None,
     }
 )
-@triton.jit
+@triton.jit(do_not_specialize_on_alignment=["T"])
 def layer_norm_gated_fwd_kernel(
     x,  # pointer to the input
     g,  # pointer to the gate

--- a/vllm/third_party/flash_linear_attention/ops/kda.py
+++ b/vllm/third_party/flash_linear_attention/ops/kda.py
@@ -153,7 +153,7 @@ def fused_recurrent_kda(
         "HAS_BIAS": lambda args: args["b"] is not None,
     }
 )
-@triton.jit
+@triton.jit(do_not_specialize_on_alignment=["T"])
 def layer_norm_gated_fwd_kernel(
     x,  # pointer to the input
     g,  # pointer to the gate

--- a/vllm/third_party/flash_linear_attention/ops/l2norm.py
+++ b/vllm/third_party/flash_linear_attention/ops/l2norm.py
@@ -75,7 +75,7 @@ def l2norm_fwd_kernel(
     tl.store(p_y, b_y.to(p_y.dtype.element_ty), boundary_check=(0, 1))
 
 
-@triton.jit
+@triton.jit(do_not_specialize_on_alignment=["M"])
 def l2norm_fwd_kernel2(
     X, Y, eps, M, N: tl.constexpr, BD: tl.constexpr, MBLOCK: tl.constexpr
 ):


### PR DESCRIPTION
## Summary
- mark FLA runtime tail row counts as alignment-independent Triton specialization inputs
- cover L2 normalization and both gated normalization kernels
- add binder-key regressions for aligned 1,536-row startup inputs and a 1,177-row prefill tail

## Why
Triton was specializing these runtime row counts on alignment, compiling separate variants for aligned startup shapes and non-aligned prefill tails even though kernel math and launch geometry do not depend on that alignment.

## Validation
- RED: the regression observed 6 distinct binder specializations before the decorator changes
- GREEN: focused GPU suite passed 19/19 and observed 2 specializations after the change
- post-rebase changed files are byte-identical to the GPU-validated commit
- `ruff check` and `git diff --check` pass

## Compatibility
No kernel math, block size, grid, dtype, or public API changes. This only removes alignment from the Triton cache key for runtime row-count arguments.

## AI assistance disclosure
Hermes Agent assisted with implementation, testing, and PR preparation. This is submitted as a draft for the human maintainer to review and understand before marking ready.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved CUDA kernel handling for non-aligned tail lengths in L2 normalization and gated layer normalization.
  - Reduced unnecessary kernel specialization, improving consistency and potentially lowering compilation overhead.

- **Tests**
  - Added CUDA regression coverage to verify that non-aligned tail lengths reuse existing aligned kernel specializations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->