### PR TITLE
[GG] perf(shm): make the message-queue busy-wait window tunable, default 2ms

### DIFF
--- a/vllm/distributed/device_communicators/shm_broadcast.py
+++ b/vllm/distributed/device_communicators/shm_broadcast.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import functools
+import math
 import pickle
 import sys
 import threading
@@ -113,6 +114,12 @@ class SpinCondition:
     await a notification on the zmq socket after a period of inactivity. This
     allows the readers to spin quickly, hence "SpinCondition".
 
+    `busy_loop_s` is how long a reader keeps spinning after its last successful
+    read before it parks; it defaults to VLLM_SHM_BROADCAST_BUSY_LOOP_S. Set it
+    longer than a burst of messages within one engine step and shorter than the
+    gap between steps: above one step the reader never parks at all, and spins
+    for the whole of a generation.
+
     To support clean shutdown, a separate thread in the reader's process must be
     able to wake the reader so that it can exit. A separate cancel() method is
     implemented with an in-process socket to allow this interruption.
@@ -137,6 +144,17 @@ class SpinCondition:
                 if busy_loop_s is not None
                 else envs.VLLM_SHM_BROADCAST_BUSY_LOOP_S
             )
+            # Reject incoherent windows before any socket is created. Infinity is
+            # the dangerous one: `current_time <= last_read + inf` is always true,
+            # so the reader stays in sched_yield() forever and never parks -- not
+            # even when idle, which is the case this class was added to fix.
+            # NaN and negatives merely disable spinning, but nothing sane sets
+            # them, so treat the whole class as a configuration error.
+            if not math.isfinite(self.busy_loop_s) or self.busy_loop_s < 0:
+                raise ValueError(
+                    "busy_loop_s must be finite and non-negative, got "
+                    f"{self.busy_loop_s!r} (VLLM_SHM_BROADCAST_BUSY_LOOP_S)"
+                )
 
             # Readers subscribe to write notifications
             self.local_notify_socket: zmq.Socket = context.socket(SUB)

--- a/vllm/distributed/device_communicators/shm_broadcast.py
+++ b/vllm/distributed/device_communicators/shm_broadcast.py
@@ -123,7 +123,7 @@ class SpinCondition:
         is_reader: bool,
         context: zmq.Context,
         notify_address: str,
-        busy_loop_s: float = 1,
+        busy_loop_s: float | None = None,
     ):
         self.is_reader = is_reader
 
@@ -132,7 +132,11 @@ class SpinCondition:
             self.last_read = time.monotonic()
 
             # Time to keep busy-looping on the shm buffer before going idle
-            self.busy_loop_s = busy_loop_s
+            self.busy_loop_s = (
+                busy_loop_s
+                if busy_loop_s is not None
+                else envs.VLLM_SHM_BROADCAST_BUSY_LOOP_S
+            )
 
             # Readers subscribe to write notifications
             self.local_notify_socket: zmq.Socket = context.socket(SUB)

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     VLLM_USE_MODELSCOPE: bool = False
     VLLM_USE_FASTOKENS: bool = False
     VLLM_RINGBUFFER_WARNING_INTERVAL: int = 60
+    VLLM_SHM_BROADCAST_BUSY_LOOP_S: float = 0.002
     VLLM_NCCL_SO_PATH: str | None = None
     LD_LIBRARY_PATH: str | None = None
     VLLM_ROCM_SLEEP_MEM_CHUNK_SIZE: int = 256
@@ -762,6 +763,19 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Interval in seconds to log a warning message when the ring buffer is full
     "VLLM_RINGBUFFER_WARNING_INTERVAL": lambda: int(
         os.environ.get("VLLM_RINGBUFFER_WARNING_INTERVAL", "60")
+    ),
+    # How long a shm message-queue reader keeps busy-polling the ring buffer
+    # after its last successful read before parking on the zmq notification
+    # socket. Spinning wins a few microseconds of wake-up latency; it costs a
+    # core held at max clock for the whole window.
+    #
+    # Raise it on a discrete-GPU server, where a spinning core is thermal noise
+    # and latency is all that matters. Keep it small on packages that share a
+    # thermal budget between CPU and GPU (e.g. NVIDIA GB10): there a reader that
+    # never parks pins a performance core at max clock for the entire decode
+    # phase, and the heat comes straight out of the GPU's headroom.
+    "VLLM_SHM_BROADCAST_BUSY_LOOP_S": lambda: float(
+        os.environ.get("VLLM_SHM_BROADCAST_BUSY_LOOP_S", "0.002")
     ),
     # path to cudatoolkit home directory, under which should be bin, include,
     # and lib directories.
@@ -2420,6 +2434,7 @@ def compile_factors() -> dict[str, object]:
         "VLLM_RPC_BASE_PATH",
         "VLLM_USE_MODELSCOPE",
         "VLLM_RINGBUFFER_WARNING_INTERVAL",
+        "VLLM_SHM_BROADCAST_BUSY_LOOP_S",
         "VLLM_DEBUG_DUMP_PATH",
         "VLLM_PORT",
         "VLLM_CACHE_ROOT",


### PR DESCRIPTION
## Problem

`SpinCondition` busy-waits for `busy_loop_s` after each read before parking on its zmq
notification socket. The default is `1`, which was chosen to fix **idle** CPU burn
(#19036) and does that job well.

But during generation a message arrives every engine step, so `last_read + 1s` is always
in the future and the `poller.poll()` branch is unreachable — the reader spins from the
first token to the last. The 1 s only ever expires when the server is genuinely idle.

`py-spy` on a 4-node GLM-5.2 deployment (TP=4, DCP=4) under `c=8` decode:

```
sched_yield        (vllm/distributed/utils.py:48)
wait               (shm_broadcast.py:196)   <- the busy_loop_s branch
acquire_read       (shm_broadcast.py:698)
dequeue            (shm_broadcast.py:779)
worker_busy_loop   (multiproc_executor.py:1005)
```

Sampling for 20 s, the share of on-CPU samples inside that busy-wait:

| process | CPU | in shm_broadcast |
| --- | --- | --- |
| `VLLM::Worker_TP0_DCP0` | 386% | 98.3% |
| `VLLM::EngineCore` | 99% | 99.9% |

Only **rank 0's node** pays this. Remote workers take the `_is_remote_reader` path into
`MessageQueue.recv()` and block properly in zmq, so the cost lands entirely on the node
that also runs the API server and the scheduler.

On a discrete-GPU server two spinning cores are thermal noise. On packages that share a
thermal budget between CPU and GPU (NVIDIA GB10 / DGX Spark here) they are not — the
spinning core's heat comes out of the GPU's headroom. Measured on that hardware the
package ran ~23 °C hotter than the GPU die while the GPU drew only 25 W, i.e. the hottest
component in an inference server was the CPU doing nothing.

## Change

Expose the window as `VLLM_SHM_BROADCAST_BUSY_LOOP_S` and default it to **2 ms**, rather
than swapping one hard-coded constant for another. Deployments that want the old
latency-first behaviour set it back to `1`.

2 ms is chosen to be longer than a burst of back-to-back messages within one step, and
far shorter than the gap between steps. For reference the decode step interval measured
here is ~310 ms at `c=8` and ~110 ms at `c=1`, so the window has ~50x margin even against
the fastest steps observed; any value well under one step gets the same result.

It is listed in `ignored_factors` — a runtime scheduling knob, not a codegen input, so
toggling it must not invalidate the `torch.compile` cache.

## Measurements

Same image, one env var flipped, two boots, `c=8` decode on real prose prompts:

| | `=1` (current default) | `=0.002` |
| --- | --- | --- |
| head `Worker_TP0` | 385% | **290%** |
| head `EngineCore` | 98% | **0.5%** |
| head load average | 4.83 | **2.6** |
| head SoC peak | 90.9 °C | **76.9 °C** |
| per-step latency | 314.5 ms | 314.3 ms |
| spec-decode acceptance | 62.4% | 63.3% |
| aggregate throughput | 70.0 tok/s | ~70 tok/s |

Throughput is flat by construction: this removes CPU spin, not GPU work. A wake-up of
tens of microseconds against a ~310 ms step is unmeasurable, and the measurement agrees.
Before the change the head ran 10–14 °C hotter than every worker; after it, it is the
coolest node in the cluster.

Idle behaviour is unchanged — 2 ms still parks the reader, which is all the original 1 s
was protecting. Head sits at 3.5% CPU at rest.

`py-spy` after the change shows both threads `(idle)` in `poll (zmq/sugar/poll.py:106)`
during active decode, i.e. taking the park branch.

## Notes

This does not touch the workers' own CPU use, which is native CUDA/NCCL spin and a
separate mechanism.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration for shared-memory broadcast busy-loop duration through the `VLLM_SHM_BROADCAST_BUSY_LOOP_S` environment variable.
  * Reader instances now use the configured duration, with a default of 0.002 seconds.
  * Individual instances can optionally override the environment setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->