### PR TITLE
[II] fix(mtp): skip missing fused indexer shard when EXL3 keeps projections split

### DIFF
--- a/tests/models/test_deepseek_mtp_mxfp8_loader.py
+++ b/tests/models/test_deepseek_mtp_mxfp8_loader.py
@@ -12,6 +12,7 @@ from vllm.model_executor.layers.quantization.utils.mxfp8_utils import (
     dequant_mxfp8_to_bf16,
 )
 from vllm.model_executor.models.deepseek_mtp import (
+    DeepSeekMTP,
     _get_local_model_path,
     _try_load_fp8_linear_as_bf16,
 )
@@ -85,6 +86,60 @@ def test_mtp_fallback_loader_accepts_mxfp8_weight_scale():
     assert torch.equal(param.data, expected)
     assert "model.layers.78.self_attn.fused_qkv_a_proj.weight" in loaded
     assert pending == {}
+
+
+def test_mtp_indexer_loader_falls_back_to_split_parameters(monkeypatch):
+    prefix = "model.layers.78.mtp_block.self_attn.indexer"
+    wk = torch.nn.Parameter(torch.empty(2, 2, dtype=torch.bfloat16))
+    weights_proj = torch.nn.Parameter(torch.empty(2, 2, dtype=torch.bfloat16))
+
+    def load_parameter(param, loaded_weight):
+        param.data.copy_(loaded_weight)
+
+    wk.weight_loader = load_parameter
+    weights_proj.weight_loader = load_parameter
+    params = {
+        f"{prefix}.wk.weight": wk,
+        f"{prefix}.weights_proj.weight": weights_proj,
+    }
+    model = SimpleNamespace(
+        config=SimpleNamespace(n_routed_experts=0, n_shared_experts=0),
+        quant_config=None,
+        model=SimpleNamespace(mtp_start_layer_idx=78, num_mtp_layers=1),
+        named_parameters=lambda: params.items(),
+        _rewrite_spec_layer_name=lambda _layer, name: name,
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.models.deepseek_mtp."
+        "rocm_aiter_ops.is_fusion_moe_shared_experts_enabled",
+        lambda: False,
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.models.deepseek_mtp.fused_moe_make_expert_params_mapping",
+        lambda *args, **kwargs: [],
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.models.deepseek_mtp.get_pp_missing_layer_names",
+        lambda _model: set(),
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.models.deepseek_mtp.get_spec_layer_idx_from_weight_name",
+        lambda _config, name: 78 if ".layers.78." in name else None,
+    )
+    wk_weight = torch.full_like(wk, 1)
+    weights_proj_weight = torch.full_like(weights_proj, 2)
+
+    loaded = DeepSeekMTP.load_weights(
+        model,
+        [
+            (f"{prefix}.wk.weight", wk_weight),
+            (f"{prefix}.weights_proj.weight", weights_proj_weight),
+        ],
+    )
+
+    assert torch.equal(wk, wk_weight)
+    assert torch.equal(weights_proj, weights_proj_weight)
+    assert loaded == set(params)
 
 
 def test_mtp_serialized_probe_uses_target_revision_for_same_model(monkeypatch):

--- a/vllm/model_executor/models/deepseek_mtp.py
+++ b/vllm/model_executor/models/deepseek_mtp.py
@@ -814,6 +814,10 @@ class DeepSeekMTP(nn.Module, DeepseekV2MixtureOfExperts):
                         )
                     if not has_fused_target:
                         continue
+                # EXL3 may keep the indexer projections split to preserve the
+                # checkpoint's per-projection quantization metadata.
+                if param_name == "wk_weights_proj" and name_mapped not in params_dict:
+                    continue
                 name = name_mapped
 
                 if _try_load_fp8_linear_as_bf16(


### PR DESCRIPTION
## What

Four lines in `deepseek_mtp.py::load_weights`. EXL3 checkpoints may serialize
the MTP draft indexer with separate `wk` / `weights_proj` tensors to preserve
per-projection quantization metadata, while the runtime registers the fused
`wk_weights_proj` module. The stacked-mapping loop then misses in params_dict
and raises KeyError instead of letting the split tensors fall through to the
per-parameter loader. Skip the fused mapping when its target is absent —
mirroring the fused_qkv_a_proj fallback directly above it.

## Why

Battle-tested in our serving image: findings.md (2026-08-17, MCG3 draft
section) records that the image's deepseek_mtp.py predated this guard and the
fork file (with the guard) had to be baked in to boot the EXL3 MCG3 MTP draft;
all subsequent serving numbers (86-87 tps, AL 2.84-2.94) ran with it. Generic:
any EXL3 MTP checkpoint with split indexer projections needs it, independent of
model family.

## Not duplicating an existing PR

- #240 adds rank-sliced name normalization to qwen3_5 MTP load_weights —
  different model file, different mechanism (name remap vs fused-shard skip).
- ccf27d3532 (landed) added rank-sliced expert handling to this same file; the
  split-indexer guard is the one piece of our fork's version II does not have
  (verified: `grep wk_weights_proj` guard absent in dev/infernal-invocation).
- #249/#297: no overlap (loader fallback, not expert widths or bitrate).

## Tests

New `test_mtp_indexer_loader_falls_back_to_split_parameters` in the existing
`tests/models/test_deepseek_mtp_mxfp8_loader.py` (extended, not a new file):
loads split wk/weights_proj through DeepSeekMTP.load_weights against a
SimpleNamespace model with the fused params absent, asserts both land via the
fallback loader and nothing else is touched.

    pytest tests/models/test_deepseek_mtp_mxfp8_loader.py -q
    → 4 passed, 1 pre-existing failure

The one failure (`test_glm_nextn_keeps_serialized_quantized_modules_targeted_by_config`)
reproduces identically on pristine dev/infernal-invocation (verified via git
stash A/B) — pre-existing, unrelated to this change.

## AI assistance

Isolated and ported by an AI agent (Claude Opus 4.5) under human direction from
a battle-tested fork commit; attribution in commit trailers.
```

### Diffstat

```
 tests/models/test_deepseek_mtp_mxfp8_loader.py | 55 ++++++++++++++++++
 vllm/model_executor/models/deepseek_mtp.py     |  4 ++
 2 files changed, 59 insertions(+)
```

---

## 3. Verification summary (all run in `~/pr-work/vllm` against II head `d6e0bb7c81`)

| Check | Result |
|---|---|
| `py_compile` all changed files, each branch head | 0 errors (10/31/42/2 files) |
| pre-commit (ruff, typos, SPDX, forbidden imports, torch-cuda, etc.) | Passed on full port and PR-4 files |
| mypy-3.10 hook on all 42 changed .py files | Passed (incl. tests/config strict group) |
| `pytest tests/v1/core/test_kv_cache_utils.py` (PR1 tree) | 106 passed |
| `pytest` kvarn attention+config+core (PR2 tree) | 162 passed |
| `pytest` runner suites (PR3 tree) | 62 passed |
| Full battery at stack tip | 222 passed; 2 failures pre-existing on pristine II (caplog ordering; GPU OOM w/ 91.7 GiB held by foreign processes) |
| Stacked union vs verified full port | byte-identical (`git diff` empty) |
| `gh pr create` | **never run** |

Environment notes: `.venv` torch 2.11.0+cu130, SM120 GPU present — Triton
kernels in the kvarn tests JIT-compiled and ran on-GPU. The two package-level
runtime touchpoints: `b12x.attention.kvarn_mla.stage_k5_as_fp8_records` (lazy,
fail-closed; paired b12x PR `kvarn/native-reader` provides it) — no other
cross-package symbols are referenced (verified by grep; env knobs live in the
b12x package, not vllm/envs.py).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DeepSeek MTP checkpoint loading for split indexer projection parameters.
  * Unsupported split projections are now safely ignored when their destination parameters are unavailable.
  * Added coverage to prevent regressions in loading split indexer weights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->