### PR TITLE
[II] feat(kvarn): self-describing KVarN KV cache formats and scheduler sizing

### DIFF
--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -46,6 +46,7 @@ from vllm.v1.kv_cache_interface import (
     ChunkedLocalAttentionSpec,
     FullAttentionSpec,
     HiddenStateCacheSpec,
+    KVarNFullAttentionSpec,
     KVCacheConfig,
     KVCacheGroupSpec,
     KVCacheSpec,
@@ -1905,6 +1906,172 @@ def test_resolve_kv_cache_block_sizes_ignores_virtual_pcp():
     assert kv_cache_utils.resolve_kv_cache_block_sizes(
         kv_cache_config, vllm_config
     ) == (512, 512)
+
+
+def _make_kvarn_mla_sizing_config() -> SimpleNamespace:
+    return SimpleNamespace(
+        scheduler_config=SimpleNamespace(
+            max_num_batched_tokens=128,
+            max_num_seqs=8,
+            async_scheduling=False,
+        ),
+        speculative_config=None,
+        model_config=SimpleNamespace(hf_config=SimpleNamespace(index_topk=32)),
+        parallel_config=SimpleNamespace(
+            decode_context_parallel_size=1,
+            prefill_context_parallel_size=1,
+        ),
+        cache_config=SimpleNamespace(num_gpu_blocks_override=None),
+        kv_transfer_config=None,
+    )
+
+
+def _kvarn_mla_sizing_spec(head_size: int = 576) -> MLAAttentionSpec:
+    return MLAAttentionSpec(
+        block_size=64,
+        num_kv_heads=1,
+        head_size=head_size,
+        dtype=torch.uint8,
+        cache_dtype_str="kvarn_mla_k5_g64",
+    )
+
+
+def test_kvarn_mla_workspace_sizing_exact_fit_and_one_page_over() -> None:
+    from vllm.model_executor.layers.quantization.kvarn.config import KVarNMLAConfig
+
+    vllm_config = _make_kvarn_mla_sizing_config()
+    spec = _kvarn_mla_sizing_spec()
+    groups = [KVCacheGroupSpec(["layer.0", "layer.1"], spec)]
+    packed_bytes_per_block = 2 * spec.page_size_bytes
+    workspace_config = KVarNMLAConfig.from_cache_dtype(spec.cache_dtype_str)
+
+    def required_bytes(num_blocks: int) -> int:
+        return (
+            packed_bytes_per_block * num_blocks
+            + workspace_config.workspace_envelope(vllm_config, num_blocks).total_bytes
+        )
+
+    exact_13 = kv_cache_utils.get_kv_cache_config_from_groups(
+        vllm_config, groups, required_bytes(13)
+    )
+    one_byte_short_of_14 = kv_cache_utils.get_kv_cache_config_from_groups(
+        vllm_config, groups, required_bytes(14) - 1
+    )
+    exact_14 = kv_cache_utils.get_kv_cache_config_from_groups(
+        vllm_config, groups, required_bytes(14)
+    )
+
+    assert exact_13.num_blocks == 13
+    assert one_byte_short_of_14.num_blocks == 13
+    assert exact_14.num_blocks == 14
+    assert sum(tensor.size for tensor in exact_14.kv_cache_tensors) + (
+        workspace_config.workspace_envelope(
+            vllm_config, exact_14.num_blocks
+        ).total_bytes
+    ) == required_bytes(14)
+
+
+def test_kvarn_mla_workspace_is_charged_once_for_all_local_layers() -> None:
+    from vllm.model_executor.layers.quantization.kvarn.config import KVarNMLAConfig
+
+    vllm_config = _make_kvarn_mla_sizing_config()
+    spec = _kvarn_mla_sizing_spec()
+    groups = [KVCacheGroupSpec(["layer.0", "layer.1", "layer.2"], spec)]
+    num_blocks = 17
+    packed_bytes = len(groups[0].layer_names) * spec.page_size_bytes * num_blocks
+    workspace_bytes = (
+        KVarNMLAConfig.from_cache_dtype(spec.cache_dtype_str)
+        .workspace_envelope(vllm_config, num_blocks)
+        .total_bytes
+    )
+
+    config = kv_cache_utils.get_kv_cache_config_from_groups(
+        vllm_config, groups, packed_bytes + workspace_bytes
+    )
+
+    assert config.num_blocks == num_blocks
+
+
+def test_kvarn_mla_ngram_override_requires_combined_budget() -> None:
+    from vllm.model_executor.layers.quantization.kvarn.config import KVarNMLAConfig
+
+    vllm_config = _make_kvarn_mla_sizing_config()
+    vllm_config.speculative_config = SimpleNamespace(
+        method="ngram", num_speculative_tokens=3
+    )
+    vllm_config.cache_config.num_gpu_blocks_override = 9
+    spec = _kvarn_mla_sizing_spec()
+    groups = [KVCacheGroupSpec(["layer.0"], spec)]
+    workspace_bytes = (
+        KVarNMLAConfig.from_cache_dtype(spec.cache_dtype_str)
+        .workspace_envelope(vllm_config, 9)
+        .total_bytes
+    )
+    required_bytes = 9 * spec.page_size_bytes + workspace_bytes
+
+    config = kv_cache_utils.get_kv_cache_config_from_groups(
+        vllm_config, groups, required_bytes
+    )
+    assert config.num_blocks == 9
+
+    with pytest.raises(ValueError, match="num_gpu_blocks_override=9 requires"):
+        kv_cache_utils.get_kv_cache_config_from_groups(
+            vllm_config, groups, required_bytes - 1
+        )
+
+
+def test_kvarn_mla_rejects_incompatible_shared_workspace_geometries() -> None:
+    vllm_config = _make_kvarn_mla_sizing_config()
+    groups = [
+        KVCacheGroupSpec(["layer.0"], _kvarn_mla_sizing_spec()),
+        KVCacheGroupSpec(["layer.1"], _kvarn_mla_sizing_spec(head_size=640)),
+    ]
+
+    with pytest.raises(ValueError, match="multiple incompatible cache geometries"):
+        kv_cache_utils.get_kv_cache_config_from_groups(
+            vllm_config, groups, available_memory=1_000_000_000
+        )
+
+
+def test_non_kvarn_page_count_does_not_reserve_mla_workspace() -> None:
+    vllm_config = _make_kvarn_mla_sizing_config()
+    spec = MLAAttentionSpec(
+        block_size=64,
+        num_kv_heads=1,
+        head_size=576,
+        dtype=torch.uint8,
+    )
+    groups = [KVCacheGroupSpec(["layer.0", "layer.1"], spec)]
+    bytes_per_block = len(groups[0].layer_names) * spec.page_size_bytes
+
+    config = kv_cache_utils.get_kv_cache_config_from_groups(
+        vllm_config,
+        groups,
+        available_memory=23 * bytes_per_block + bytes_per_block - 1,
+    )
+
+    assert config.num_blocks == 23
+
+
+def test_generic_kvarn_page_count_does_not_reserve_mla_workspace() -> None:
+    vllm_config = _make_kvarn_mla_sizing_config()
+    spec = KVarNFullAttentionSpec(
+        block_size=64,
+        num_kv_heads=2,
+        head_size=128,
+        dtype=torch.uint8,
+        tile_size=11392,
+    )
+    groups = [KVCacheGroupSpec(["layer.0", "layer.1"], spec)]
+    bytes_per_block = len(groups[0].layer_names) * spec.page_size_bytes
+
+    config = kv_cache_utils.get_kv_cache_config_from_groups(
+        vllm_config,
+        groups,
+        available_memory=11 * bytes_per_block + bytes_per_block - 1,
+    )
+
+    assert config.num_blocks == 11
 
 
 def test_replicated_mla_uses_lockstep_pool_capacity_and_contiguous_tensors():

--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -35,6 +35,10 @@ CacheDType = Literal[
     "fp8_per_token_head",
     "nvfp4",
     "nvfp4_4over6",
+    "kvarn_k4v2_g128",
+    "kvarn_k4v4_g128",
+    "kvarn_k5v5_g64",
+    "kvarn_mla_k5_g64",
 ]
 MambaDType = Literal["auto", "float32", "float16", "bfloat16"]
 MambaCacheMode = Literal["all", "align", "none"]

--- a/vllm/model_executor/layers/quantization/kvarn/__init__.py
+++ b/vllm/model_executor/layers/quantization/kvarn/__init__.py
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""KVarN variance-normalized KV-cache quantization.
+
+Hadamard rotation and iterative log-domain variance normalization precede
+dense little-endian K5/V5 packing. Keys are quantized per channel and values
+per token. Completed history is packed while sink and recent tiles remain in
+an FP8 precision-tail pool by default.
+"""
+
+from vllm.model_executor.layers.quantization.kvarn.config import KVarNConfig
+
+__all__ = ["KVarNConfig"]

--- a/vllm/model_executor/layers/quantization/kvarn/config.py
+++ b/vllm/model_executor/layers/quantization/kvarn/config.py
@@ -1,0 +1,683 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""KVarN configuration."""
+
+import math
+import os
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, ClassVar
+
+from vllm.logger import init_logger
+
+if TYPE_CHECKING:
+    from vllm.config import VllmConfig
+
+# Named KVarN presets: each maps to a frozen set of config parameters.
+# The trailing g<N> encodes the variance-normalization tile size, which must
+# equal the vLLM block size. g128 is the current design point; g64 trades a
+# little compression (more per-tile scale overhead per token) for finer
+# quantization granularity (each tile's scales adapt to fewer tokens).
+#
+# Bit-width is fully parameterized in the quantizer and kernels (key_bits /
+# value_bits), and the tile size flows through cfg.group everywhere (storage
+# layout, Triton GROUP constexpr, flush / slot math), so additional presets are
+# a one-line addition here. Keys carry more quantization sensitivity than values
+# (key error propagates through the softmax exponentials, value error is averaged
+# out by the softmax weights), so the shipped preset spends more bits on keys.
+KVARN_PRESETS: dict[str, dict[str, int]] = {
+    "kvarn_k4v2_g128": {"key_bits": 4, "value_bits": 2, "group": 128},
+    "kvarn_k4v4_g128": {"key_bits": 4, "value_bits": 4, "group": 128},
+    "kvarn_k4v2_g64": {"key_bits": 4, "value_bits": 2, "group": 64},
+    "kvarn_k4v4_g64": {"key_bits": 4, "value_bits": 4, "group": 64},
+    "kvarn_k5v5_g64": {"key_bits": 5, "value_bits": 5, "group": 64},
+}
+
+DEFAULT_KVARN_TAIL_TOKENS = 1024
+DEFAULT_KVARN_K5V5_TAIL_TOKENS = 0
+DEFAULT_KVARN_TAIL_DTYPE = "float16"
+
+logger = init_logger(__name__)
+
+_MLA_SPEC_DECODE_MAX_Q_ENV = "VLLM_B12X_MLA_SPEC_DECODE_MAX_Q"
+_MLA_SPEC_EXTEND_MODE_ENV = "VLLM_B12X_MLA_SPEC_EXTEND_AS_DECODE"
+_BF16_BYTES = 2
+_INT32_BYTES = 4
+
+
+def _cdiv(value: int, divisor: int) -> int:
+    return (value + divisor - 1) // divisor
+
+
+@dataclass(frozen=True)
+class KVarNMLAWorkspaceEnvelope:
+    dense_rows: int
+    remap_elements: int
+    rotation_rows: int
+    physical_slot_rows: int
+    dense_bytes: int
+    total_bytes: int
+
+
+def kvarn_mla_workspace_envelope(
+    *,
+    num_kv_pages: int,
+    group_size: int,
+    latent_dim: int,
+    rope_dim: int,
+    max_batched_tokens: int,
+    max_active_rows: int,
+    topk_tokens: int,
+    boundary_blocks: int,
+    rollback_blocks: int,
+) -> KVarNMLAWorkspaceEnvelope:
+    """Return the shared dense-workspace envelope for one local worker."""
+    positive = {
+        "num_kv_pages": num_kv_pages,
+        "group_size": group_size,
+        "latent_dim": latent_dim,
+        "rope_dim": rope_dim,
+        "max_batched_tokens": max_batched_tokens,
+        "max_active_rows": max_active_rows,
+        "topk_tokens": topk_tokens,
+    }
+    invalid = {name: value for name, value in positive.items() if value <= 0}
+    if boundary_blocks < 0 or rollback_blocks < 0:
+        invalid.update(
+            boundary_blocks=boundary_blocks,
+            rollback_blocks=rollback_blocks,
+        )
+    if invalid:
+        raise ValueError(f"Invalid KVarN MLA workspace dimensions: {invalid}")
+
+    page_rows = num_kv_pages * group_size
+    selected_rows = max_active_rows * topk_tokens
+    transient_rows = (
+        _cdiv(max_batched_tokens, group_size) + boundary_blocks + rollback_blocks
+    ) * group_size
+    dense_rows = (
+        _cdiv(max(page_rows, selected_rows, transient_rows), group_size) * group_size
+    )
+    remap_elements = max_batched_tokens * topk_tokens
+    dense_bytes = dense_rows * (latent_dim + rope_dim) * _BF16_BYTES
+    total_bytes = (
+        dense_bytes
+        + remap_elements * _INT32_BYTES
+        + max_batched_tokens * latent_dim * _BF16_BYTES
+        + page_rows * _INT32_BYTES
+    )
+    return KVarNMLAWorkspaceEnvelope(
+        dense_rows=dense_rows,
+        remap_elements=remap_elements,
+        rotation_rows=max_batched_tokens,
+        physical_slot_rows=page_rows,
+        dense_bytes=dense_bytes,
+        total_bytes=total_bytes,
+    )
+
+
+def _positive_env_int(name: str, default: int) -> int:
+    value = os.getenv(name)
+    if value is None or value == "":
+        return default
+    try:
+        parsed = int(value)
+    except ValueError:
+        logger.warning("Ignoring invalid %s=%r; using %d", name, value, default)
+        return default
+    if parsed <= 0:
+        logger.warning("Ignoring non-positive %s=%r; using %d", name, value, default)
+        return default
+    return parsed
+
+
+def _kvarn_mla_decode_settings() -> tuple[int, bool, bool]:
+    spec_decode_max_q = _positive_env_int(_MLA_SPEC_DECODE_MAX_Q_ENV, 8)
+    mode = os.getenv(_MLA_SPEC_EXTEND_MODE_ENV, "auto").strip().lower()
+    disabled_modes = {"0", "false", "off", "no"}
+    forced_modes = {"1", "true", "on", "yes"}
+    if mode not in {"auto", *disabled_modes, *forced_modes}:
+        raise ValueError(
+            f"{_MLA_SPEC_EXTEND_MODE_ENV} must be auto, 0, or 1 (got {mode!r})"
+        )
+    return spec_decode_max_q, mode not in disabled_modes, mode in forced_modes
+
+
+@dataclass
+class KVarNConfig:
+    """Configuration for KVarN KV-cache quantization.
+
+    Pipeline per (block, head):
+      1. Hadamard rotation along head_dim (orthonormal, applied via external GEMM).
+      2. Iterative log-domain variance-normalization (Sinkhorn-like) over the
+         [D, group] tile for K (per-channel orientation) and [group, D] tile for
+         V (per-token orientation).
+      3. Asymmetric per-row RTN at `key_bits` / `value_bits`.
+      4. Absorb the per-row RTN scale and zero-point into the matching
+         sinkhorn scale axis (K: into per-channel; V: into per-token-in-tile).
+         Reconstruction: ``x = (q * absorbed_scale + absorbed_zp) * other_scale``.
+
+    Cache layout (per (block, head)) is a single packed record — see the
+    backend's `get_kv_cache_shape` override. There is no per-token slot
+    because the scales are tile-shared; the block boundary IS the tile.
+
+    Args:
+        head_dim: Attention head dimension (power of 2; tested at 128).
+        key_bits: Bits per key element (default 4).
+        value_bits: Bits per value element (default 4).
+        group: KVarN tile size in tokens. Must equal vLLM block_size so that
+            one vLLM block = one KVarN tile per head.
+        sinkhorn_iters: Iterations of the alternating column/row std-norm in
+            the variance-normalization loop (default 8; lossless vs 16).
+        boundary_skip_layers: Number of leading / trailing transformer layers
+            to keep in fp16 (KVarN's sink/residual analogue). Default 2 mirrors
+            TurboQuant's default.
+    """
+
+    head_dim: int = 128
+    key_bits: int = 4
+    value_bits: int = 4
+    group: int = 128
+    # converges by ~4 iters; 8 lossless vs 16 (validated Qwen3-4B + Qwen3.6-27B AIME)
+    sinkhorn_iters: int = 8
+    sink_tokens: int = 128  # leading tokens retained in the precision tail
+    precision_tail_tokens: int = DEFAULT_KVARN_TAIL_TOKENS
+    """Most-recent tokens retained in the higher-precision side pool."""
+    tail_dtype: str = DEFAULT_KVARN_TAIL_DTYPE
+    boundary_skip_layers: int = (
+        0  # layer-level skipping off by default; sink_tokens replaces it
+    )
+
+    # ── derived: storage layout ──────────────────────────────────────────────
+    @property
+    def k_packed_bytes(self) -> int:
+        """Packed bytes for one K tile per head: D * group * key_bits / 8."""
+        return math.ceil(self.head_dim * self.group * self.key_bits / 8)
+
+    @property
+    def v_packed_bytes(self) -> int:
+        """Packed bytes for one V tile per head: group * D * value_bits / 8."""
+        return math.ceil(self.group * self.head_dim * self.value_bits / 8)
+
+    @property
+    def k_scale_bytes(self) -> int:
+        """fp16 bytes for K scales: s_col_K' [D] + zp_K' [D] + s_row_K [group].
+
+        s_col_K' = rtn_scale ⊙ s_chan_sinkhorn  (per-channel absorbed scale)
+        zp_K'    = rtn_zp    ⊙ s_chan_sinkhorn  (per-channel absorbed zero)
+        s_row_K  = s_tok_sinkhorn               (per-token-in-tile)
+        """
+        return (2 * self.head_dim + self.group) * 2
+
+    @property
+    def v_scale_bytes(self) -> int:
+        """fp16 bytes for V scales: s_col_V [D] + s_row_V' [group] + zp_V' [group].
+
+        s_col_V  = s_chan_sinkhorn              (per-channel, untouched)
+        s_row_V' = rtn_scale ⊙ s_tok_sinkhorn   (per-token-in-tile absorbed scale)
+        zp_V'    = rtn_zp    ⊙ s_tok_sinkhorn   (per-token-in-tile absorbed zero)
+        """
+        return (self.head_dim + 2 * self.group) * 2
+
+    @property
+    def tile_bytes(self) -> int:
+        """Total packed bytes per (block, head): K + V combined."""
+        return (
+            self.k_packed_bytes
+            + self.k_scale_bytes
+            + self.v_packed_bytes
+            + self.v_scale_bytes
+        )
+
+    @property
+    def tile_bytes_aligned(self) -> int:
+        """tile_bytes rounded up for nicer Triton loads.
+
+        For head_dim >= 256 we round the PER-TOKEN slot (tile_bytes / group) up to
+        a power of 2. This is required for models with heterogeneous head_dim
+        (e.g. Gemma-4: 256 sliding-window layers + 512 global layers): the raw
+        slot has a fixed per-token-group scale term that doesn't scale with D, so
+        slot(512)/slot(256) is not an integer and vLLM's KV-cache page-size
+        unification (which scales block_size by that ratio) fails. Power-of-2 slots
+        make the ratio an exact power of 2. head_dim<=128 keeps the tight 8-byte
+        alignment (the common case; no padding). Trailing pad only — offsets are
+        unchanged, so the layout/kernels are byte-compatible."""
+        if self.head_dim >= 256:
+            slot = math.ceil(self.tile_bytes / self.group)
+            slot_pow2 = 1 << (slot - 1).bit_length()
+            return slot_pow2 * self.group
+        return ((self.tile_bytes + 7) // 8) * 8
+
+    # ── slot byte offsets within one tile (used by the kernels) ──────────────
+    @property
+    def k_packed_offset(self) -> int:
+        return 0
+
+    @property
+    def k_s_col_offset(self) -> int:
+        return self.k_packed_offset + self.k_packed_bytes
+
+    @property
+    def k_zp_offset(self) -> int:
+        return self.k_s_col_offset + self.head_dim * 2
+
+    @property
+    def k_s_row_offset(self) -> int:
+        return self.k_zp_offset + self.head_dim * 2
+
+    @property
+    def v_packed_offset(self) -> int:
+        return self.k_s_row_offset + self.group * 2
+
+    @property
+    def v_s_col_offset(self) -> int:
+        return self.v_packed_offset + self.v_packed_bytes
+
+    @property
+    def v_s_row_offset(self) -> int:
+        return self.v_s_col_offset + self.head_dim * 2
+
+    @property
+    def v_zp_offset(self) -> int:
+        return self.v_s_row_offset + self.group * 2
+
+    # ── precision-tail pool sizing ───────────────────────────────────────────
+    # A tile cannot be packed until all `group` tokens exist. The fixed side
+    # pool retains sink, recent, and in-progress tiles in the configured tail
+    # dtype (FP8 by default) and must be allocated before CUDA graph capture.
+    # Its size bounds scheduler concurrency; `max_supported_seqs` caps the
+    # configured request count to the chosen memory budget.
+    # The pool and the paged KV cache draw from the SAME pot: the memory left
+    # after model weights (i.e. `gpu_memory_utilization · total − weights`).
+    # Sizing the pool as a fixed fraction of *total* GPU memory was the bug
+    # behind the concurrency cap: on a 4B/24GB card the pool got 0.08·24≈1.9 GB and
+    # concurrency capped to ~30 while the KV cache sat at ~3% utilization —
+    # ~10 GB of usable memory wasted. We instead give the pool a share of the
+    # post-weight usable envelope (POOL_USABLE_SHARE), which auto-scales: a small
+    # model on a big card gets a large pool (high concurrency), a model that
+    # nearly fills the card gets a small one (degrades to cap≈1, never OOMs).
+    # The legacy fraction-of-total path is kept as a fallback for when the weight
+    # size can't be read. Both are tunable via KVARN_POOL_MEM_FRAC (interpreted
+    # as share-of-usable when weights are known, else fraction-of-total).
+    POOL_MEM_FRAC_DEFAULT = 0.08  # legacy: fraction of TOTAL (fallback)
+    POOL_USABLE_SHARE_DEFAULT = 0.5  # share of (util·total − weights)
+
+    def _slot_bytes_per_layer(self, num_kv_heads: int) -> int:
+        """Bytes for one K/V precision-tail pool slot in one layer."""
+        element_size = 1 if self.tail_dtype == "fp8" else 2
+        data_bytes = self.group * num_kv_heads * self.head_dim * 2 * element_size
+        scale_bytes = (
+            self.group * num_kv_heads * 2 * 2 if self.tail_dtype == "fp8" else 0
+        )
+        return data_bytes + scale_bytes
+
+    @property
+    def resident_blocks_per_seq(self) -> int:
+        """Maximum exact blocks intersecting the sink or precision tail."""
+        tail_blocks = 0
+        if self.precision_tail_tokens > 0:
+            tail_blocks = math.ceil(
+                (self.precision_tail_tokens + self.group - 1) / self.group
+            )
+        sink_blocks = math.ceil(self.sink_tokens / self.group)
+        return tail_blocks + sink_blocks
+
+    def pool_slots(self, max_num_seqs: int, max_num_batched_tokens: int) -> int:
+        """Structural peak of exact pool slots needed in one scheduler step."""
+        prefill_blocks = math.ceil(max_num_batched_tokens / self.group)
+        resident = self.resident_blocks_per_seq * max_num_seqs
+        return max(resident + prefill_blocks + 8, 8)
+
+    def pool_budget_bytes(
+        self,
+        total_gpu_bytes: int,
+        gpu_memory_utilization: float | None = None,
+        weight_bytes: int | None = None,
+    ) -> int:
+        """GPU bytes the precision-tail pool is allowed to occupy.
+
+        Preferred (weight-aware): a share of the post-weight usable envelope,
+        ``share · (gpu_memory_utilization · total − weight_bytes)``. This is the
+        memory the pool and the paged KV cache actually compete for, so the
+        budget tracks real headroom instead of an arbitrary slice of the whole
+        card. ``share`` comes from KVARN_POOL_MEM_FRAC or
+        POOL_USABLE_SHARE_DEFAULT.
+
+        Fallback (weights unknown): the legacy ``frac · total`` with
+        POOL_MEM_FRAC_DEFAULT, so behaviour is unchanged when we cannot read the
+        weight size."""
+        env = os.environ.get("KVARN_POOL_MEM_FRAC")
+        if weight_bytes is not None and gpu_memory_utilization is not None:
+            share = float(env) if env is not None else self.POOL_USABLE_SHARE_DEFAULT
+            usable = gpu_memory_utilization * total_gpu_bytes - weight_bytes
+            return max(0, int(share * usable))
+        frac = float(env) if env is not None else self.POOL_MEM_FRAC_DEFAULT
+        return int(total_gpu_bytes * frac)
+
+    def max_supported_seqs(
+        self,
+        total_gpu_bytes: int,
+        num_kv_heads: int,
+        num_layers: int,
+        max_num_batched_tokens: int,
+        frac: float | None = None,
+        gpu_memory_utilization: float | None = None,
+        weight_bytes: int | None = None,
+    ) -> int:
+        """Largest max_num_seqs whose exact pool fits the configured budget.
+
+        The bound includes every block that can intersect the precision tail,
+        the optional sink block, blocks touched by one chunked-prefill step,
+        and fixed allocator headroom.
+        """
+        if frac is not None:
+            budget = int(total_gpu_bytes * frac)
+        else:
+            budget = self.pool_budget_bytes(
+                total_gpu_bytes, gpu_memory_utilization, weight_bytes
+            )
+        slot_bytes = self._slot_bytes_per_layer(num_kv_heads) * max(num_layers, 1)
+        max_slots = int(budget / slot_bytes)
+        prefill_blocks = math.ceil(max_num_batched_tokens / self.group)
+        per_seq = max(self.resident_blocks_per_seq, 1)
+        return max(1, (max_slots - prefill_blocks - 8) // per_seq)
+
+    def pool_bytes(
+        self,
+        max_num_seqs: int,
+        max_num_batched_tokens: int,
+        num_kv_heads: int,
+        num_layers: int,
+    ) -> int:
+        """Total GPU bytes occupied by the precision-tail pool on this rank.
+
+        Pool slots are summed over every KVarN layer and reserved before the
+        lazy layer-level allocation can compete with the paged cache.
+        """
+        slots = self.pool_slots(max_num_seqs, max_num_batched_tokens)
+        return slots * self._slot_bytes_per_layer(num_kv_heads) * max(num_layers, 1)
+
+    @staticmethod
+    def num_kvarn_layers(model_config, parallel_config) -> int:
+        """Number of attention layers spanned by the precision-tail pool.
+
+        Hybrid models allocate the pool only for attention layers; dense
+        transformers use their total layer count.
+        """
+        try:
+            n = model_config.get_num_layers_by_block_type(parallel_config, "attention")
+            if n and n > 0:
+                return n
+        except Exception:
+            pass
+        return model_config.get_num_layers(parallel_config)
+
+    @staticmethod
+    def estimate_weight_bytes(model: str, tensor_parallel_size: int = 1) -> int | None:
+        """Best-effort per-rank model weight size in bytes, read from the
+        checkpoint files on disk (exact, and cheap, with no CUDA context, which
+        the early `check_and_update_config` hook must avoid). Returns None if the
+        files can't be located, so the caller falls back to the legacy budget.
+
+        Resolves a local directory directly, or the local HF cache snapshot for
+        a repo id (never downloads). Prefers the shards named in a
+        `*.safetensors.index.json` (or `*.bin.index.json`) manifest, which is
+        exactly the set the loader reads. This avoids double-counting a repo that
+        ships both a single consolidated checkpoint and the sharded HF set (e.g.
+        Mistral-7B-Instruct-v0.3 carries `consolidated.safetensors` alongside
+        `model-0000n-of-0000m.safetensors`, which a plain glob sums to ~2x the
+        real weight size). Divides by the tensor-parallel degree (weights shard
+        ~evenly across ranks)."""
+        import glob as _glob
+        import json as _json
+
+        try:
+            d = model
+            if not os.path.isdir(d):
+                # Repo id: resolve the already-cached snapshot, if any.
+                try:
+                    from vllm.transformers_utils.repo_utils import hf_api
+
+                    d = hf_api().snapshot_download(model, local_files_only=True)
+                except Exception:
+                    return None
+
+            # 1) Prefer the loader's own manifest: sum only the shards it lists,
+            #    so a stray consolidated/single-file copy is not double-counted.
+            for ext in ("safetensors", "bin"):
+                indexes = _glob.glob(
+                    os.path.join(d, "**", f"*.{ext}.index.json"), recursive=True
+                )
+                if not indexes:
+                    continue
+                try:
+                    with open(indexes[0]) as fh:
+                        weight_map = _json.load(fh).get("weight_map", {})
+                    base = os.path.dirname(indexes[0])
+                    names = sorted(set(weight_map.values()))
+                    shards = [os.path.join(base, s) for s in names]
+                    # Trust the manifest only when every listed shard is on
+                    # disk: a partial set would under-estimate the weights and
+                    # over-grow the pool budget, so fall through to the
+                    # conservative glob instead.
+                    if names and all(os.path.exists(p) for p in shards):
+                        total = sum(os.path.getsize(p) for p in shards)
+                        if total > 0:
+                            return total // max(tensor_parallel_size, 1)
+                except Exception:
+                    pass  # fall through to the single-file / glob paths
+
+            # 2) No usable manifest: prefer a canonical single-file checkpoint.
+            for single in ("model.safetensors", "consolidated.safetensors"):
+                p = os.path.join(d, single)
+                if os.path.exists(p):
+                    total = os.path.getsize(p)
+                    if total > 0:
+                        return total // max(tensor_parallel_size, 1)
+
+            # 3) Fallback: sum whatever weight shards are present.
+            files = _glob.glob(os.path.join(d, "**", "*.safetensors"), recursive=True)
+            if not files:
+                files = _glob.glob(os.path.join(d, "**", "*.bin"), recursive=True)
+            if not files:
+                return None
+            total = sum(os.path.getsize(f) for f in files)
+            if total <= 0:
+                return None
+            return total // max(tensor_parallel_size, 1)
+        except Exception:
+            return None
+
+    @staticmethod
+    def get_boundary_skip_layers(num_layers: int, n: int = 2) -> list[str]:
+        """First-N + last-N transformer layer indices as strings, suitable
+        for vLLM's ``kv_cache_dtype_skip_layers``. Mirrors TurboQuant
+        (`TurboQuantConfig.get_boundary_skip_layers`)."""
+        if n <= 0 or num_layers <= 0:
+            return []
+        n = min(n, num_layers // 2)
+        first = list(range(n))
+        last = list(range(num_layers - n, num_layers))
+        return [str(i) for i in sorted(set(first + last))]
+
+    @staticmethod
+    def from_cache_dtype(cache_dtype: str, head_dim: int) -> "KVarNConfig":
+        """Create a config from a preset string like ``"kvarn_k4v4"``."""
+        if cache_dtype not in KVARN_PRESETS:
+            valid = ", ".join(KVARN_PRESETS.keys())
+            raise ValueError(
+                f"Unknown KVarN cache dtype: {cache_dtype!r}. Valid: {valid}"
+            )
+        preset = KVARN_PRESETS[cache_dtype]
+        # Optional env override for Sinkhorn iteration count (KVARN_SINKHORN_ITERS).
+        # Default 16 mirrors the paper; useful for testing convergence at large
+        # model scale (e.g. 48-layer 30B-A3B-Thinking-2507 may benefit from more).
+        iters = int(os.environ.get("KVARN_SINKHORN_ITERS", "8"))
+        sink_tokens = int(os.environ.get("KVARN_SINK_TOKENS", "128"))
+        default_tail_tokens = (
+            DEFAULT_KVARN_K5V5_TAIL_TOKENS
+            if cache_dtype == "kvarn_k5v5_g64"
+            else DEFAULT_KVARN_TAIL_TOKENS
+        )
+        precision_tail_tokens = int(
+            os.environ.get("KVARN_TAIL_TOKENS", str(default_tail_tokens))
+        )
+        tail_dtype = os.environ.get(
+            "KVARN_TAIL_DTYPE", DEFAULT_KVARN_TAIL_DTYPE
+        ).lower()
+        if tail_dtype not in ("float16", "bfloat16", "fp8"):
+            raise ValueError(
+                "KVARN_TAIL_DTYPE must be 'float16', 'bfloat16', or 'fp8', "
+                f"got {tail_dtype!r}"
+            )
+        return KVarNConfig(
+            head_dim=head_dim,
+            key_bits=preset["key_bits"],
+            value_bits=preset["value_bits"],
+            group=preset["group"],
+            sinkhorn_iters=iters,
+            sink_tokens=sink_tokens,
+            precision_tail_tokens=precision_tail_tokens,
+            tail_dtype=tail_dtype,
+        )
+
+
+@dataclass(frozen=True)
+class KVarNMLAConfig:
+    """Packed KVarN latent plus exact BF16 RoPE layout for MLA caches.
+
+    Live boundary, sink, and current latent blocks always use FP8 E4M3 side
+    storage. Their RoPE values always use BF16 side storage.
+    """
+
+    latent_dim: int = 512
+    rope_dim: int = 64
+    bits: int = 5
+    group: int = 64
+    sinkhorn_iters: int = 8
+    boundary_tokens: ClassVar[int] = 128
+
+    @property
+    def latent_packed_bytes(self) -> int:
+        return math.ceil(self.latent_dim * self.group * self.bits / 8)
+
+    @property
+    def latent_scale_bytes(self) -> int:
+        return (2 * self.latent_dim + self.group) * 2
+
+    @property
+    def rope_bytes(self) -> int:
+        return self.group * self.rope_dim * 2
+
+    @property
+    def latent_s_col_offset(self) -> int:
+        return self.latent_packed_bytes
+
+    @property
+    def latent_zp_offset(self) -> int:
+        return self.latent_s_col_offset + self.latent_dim * 2
+
+    @property
+    def latent_s_row_offset(self) -> int:
+        return self.latent_zp_offset + self.latent_dim * 2
+
+    @property
+    def rope_offset(self) -> int:
+        return self.latent_s_row_offset + self.group * 2
+
+    @property
+    def tile_bytes(self) -> int:
+        return self.rope_offset + self.rope_bytes
+
+    @property
+    def bytes_per_token(self) -> int:
+        assert self.tile_bytes % self.group == 0
+        return self.tile_bytes // self.group
+
+    @property
+    def resident_blocks_per_seq(self) -> int:
+        return math.ceil(self.boundary_tokens / self.group) + 1
+
+    def pool_slots(
+        self,
+        max_num_seqs: int,
+        max_num_batched_tokens: int,
+        max_rollback_tokens: int = 0,
+    ) -> int:
+        prefill_blocks = math.ceil(max_num_batched_tokens / self.group)
+        resident = self.resident_blocks_per_seq * max_num_seqs
+        boundary_overlap = max_num_seqs
+        rollback_blocks = (
+            math.ceil(max_num_seqs * max_rollback_tokens / self.group) + max_num_seqs
+            if max_rollback_tokens
+            else 0
+        )
+        return max(
+            resident + prefill_blocks + boundary_overlap + rollback_blocks + 8,
+            8,
+        )
+
+    @property
+    def pool_slot_bytes(self) -> int:
+        return self.group * (self.latent_dim + self.rope_dim * 2)
+
+    def max_active_rows(self, vllm_config: "VllmConfig") -> int:
+        """Maximum decode/verify rows sharing the dense physical arena."""
+        scheduler_config = vllm_config.scheduler_config
+        max_batched = int(scheduler_config.max_num_batched_tokens)
+        max_num_seqs = int(scheduler_config.max_num_seqs)
+        spec_decode_max_q, spec_extend_enabled, spec_extend_forced = (
+            _kvarn_mla_decode_settings()
+        )
+        q_per_req = 1
+        spec_config = getattr(vllm_config, "speculative_config", None)
+        if (
+            spec_extend_enabled
+            and spec_config is not None
+            and getattr(spec_config, "num_speculative_tokens", None)
+        ):
+            q_per_req = 1 + int(spec_config.num_speculative_tokens)
+        if spec_extend_forced:
+            q_per_req = max(q_per_req, spec_decode_max_q)
+        max_active_rows = min(max_num_seqs * q_per_req, max_batched)
+        return max(max_active_rows, max_num_seqs)
+
+    def workspace_envelope(
+        self, vllm_config: "VllmConfig", num_kv_pages: int
+    ) -> KVarNMLAWorkspaceEnvelope:
+        """Size shared physical staging allocated once by a local worker."""
+        scheduler_config = vllm_config.scheduler_config
+        max_num_seqs = int(scheduler_config.max_num_seqs)
+        max_rollback_tokens = 0
+        spec_config = getattr(vllm_config, "speculative_config", None)
+        if (
+            scheduler_config.async_scheduling
+            and spec_config is not None
+            and getattr(spec_config, "num_speculative_tokens", None)
+        ):
+            max_rollback_tokens = int(spec_config.num_speculative_tokens)
+        rollback_blocks = (
+            _cdiv(max_num_seqs * max_rollback_tokens, self.group) + max_num_seqs
+            if max_rollback_tokens
+            else 0
+        )
+        return kvarn_mla_workspace_envelope(
+            num_kv_pages=num_kv_pages,
+            group_size=self.group,
+            latent_dim=self.latent_dim,
+            rope_dim=self.rope_dim,
+            max_batched_tokens=int(scheduler_config.max_num_batched_tokens),
+            max_active_rows=self.max_active_rows(vllm_config),
+            topk_tokens=int(vllm_config.model_config.hf_config.index_topk),
+            boundary_blocks=max_num_seqs,
+            rollback_blocks=rollback_blocks,
+        )
+
+    @classmethod
+    def from_cache_dtype(cls, cache_dtype: str) -> "KVarNMLAConfig":
+        if cache_dtype != "kvarn_mla_k5_g64":
+            raise ValueError(
+                f"MLA KVarN requires 'kvarn_mla_k5_g64', got {cache_dtype!r}"
+            )
+        return cls(
+            sinkhorn_iters=int(os.environ.get("KVARN_SINKHORN_ITERS", "8")),
+        )

--- a/vllm/model_executor/layers/quantization/kvarn/sinkhorn.py
+++ b/vllm/model_executor/layers/quantization/kvarn/sinkhorn.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Log-domain iterative variance-normalization for KVarN.
+
+Algorithm: alternating column-wise and row-wise standard-deviation
+normalization in log space, tracking the lowest-imbalance state seen
+across all iterations (the best-so-far selection).
+
+Pure-PyTorch reference implementation; the Triton port lives in
+``vllm/v1/attention/ops/triton_kvarn_sinkhorn.py``.
+
+Both the single-tile and batched-tile variants return the same triple
+``(balanced, s_col, s_row)`` where ``balanced = tile / s_col / s_row``
+has equalised row and column standard deviation.
+
+Naming convention: ``s_col`` is the scale along **axis 1** (varies across
+columns), ``s_row`` is along **axis 0** (varies across rows). The
+"per-channel" vs "per-token" semantic mapping depends on tile orientation:
+
+  - K tile is ``[D, group]`` (rows = channels, cols = tokens) → ``s_row`` is
+    per-channel, ``s_col`` is per-token.
+  - V tile is ``[group, D]`` (rows = tokens, cols = channels) → ``s_row`` is
+    per-token, ``s_col`` is per-channel.
+
+This module is intentionally pure (no model imports, no vLLM context) so
+that ``pytest`` can exercise it as a unit.
+"""
+
+from __future__ import annotations
+
+import torch
+
+_DEFAULT_ITERATIONS = 16
+_CLIP_STD_MIN = 1e-3
+_CLIP_STD_MAX = 1e3
+_LOG_S_MIN = -0.3
+_LOG_S_MAX = 10.0
+
+
+def _imbalance(tile: torch.Tensor) -> torch.Tensor:
+    """Sum of column-std spread and row-std spread.
+
+    Lower is better; a perfectly balanced tile has ``imbalance == 2`` (each
+    std max equals its std min). The Sinkhorn loop tracks the lowest value
+    seen and returns the corresponding scales.
+    """
+    sc = tile.std(dim=-2)  # along rows ⇒ per-column std
+    sr = tile.std(dim=-1)  # along cols ⇒ per-row std
+    return sc.amax(dim=-1) / sc.amin(dim=-1).clamp_min(1e-8) + sr.amax(
+        dim=-1
+    ) / sr.amin(dim=-1).clamp_min(1e-8)
+
+
+def variance_normalize(
+    tile: torch.Tensor, iterations: int = _DEFAULT_ITERATIONS
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Single-tile log-domain Sinkhorn balancing.
+
+    Args:
+        tile: [R, C] fp32 (or any real dtype; will be cast to fp32 internally).
+        iterations: number of alternating col/row passes (default 16).
+
+    Returns:
+        balanced [R, C] fp32 — variance-normalised tile.
+        s_col    [1, C] fp32 — column scale (best-so-far).
+        s_row    [R, 1] fp32 — row scale    (best-so-far).
+        such that ``balanced = tile / s_col / s_row``.
+    """
+    m = tile.float()
+    R, C = m.shape
+    dev = m.device
+
+    log_s_col = torch.zeros(1, C, device=dev)
+    log_s_row = torch.zeros(R, 1, device=dev)
+
+    cur = m / log_s_col.exp() / log_s_row.exp()
+    score_best = _imbalance(cur)
+    sc_best = log_s_col.exp().clone()
+    sr_best = log_s_row.exp().clone()
+
+    for _ in range(iterations):
+        col_std = cur.std(dim=0, keepdim=True).clamp(_CLIP_STD_MIN, _CLIP_STD_MAX)
+        log_s_col = (log_s_col + col_std.log()).clip(_LOG_S_MIN, _LOG_S_MAX)
+        cur = m / log_s_col.exp() / log_s_row.exp()
+
+        row_std = cur.std(dim=1, keepdim=True).clamp(_CLIP_STD_MIN, _CLIP_STD_MAX)
+        log_s_row = (log_s_row + row_std.log()).clip(_LOG_S_MIN, _LOG_S_MAX)
+        cur = m / log_s_col.exp() / log_s_row.exp()
+
+        score = _imbalance(cur)
+        if score <= score_best:
+            score_best = score
+            sc_best = log_s_col.exp().clone()
+            sr_best = log_s_row.exp().clone()
+
+    balanced = m / sc_best / sr_best
+    return balanced, sc_best, sr_best
+
+
+def variance_normalize_batched(
+    tiles: torch.Tensor, iterations: int = _DEFAULT_ITERATIONS
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Batched version: tiles is [N, R, C].
+
+    Returns balanced, s_col [N,1,C], s_row [N,R,1].
+
+    The best-so-far selection is done per-tile via a mask on the imbalance scalar.
+    """
+    m = tiles.float()
+    N, R, C = m.shape
+    dev = m.device
+
+    log_s_col = torch.zeros(N, 1, C, device=dev)
+    log_s_row = torch.zeros(N, R, 1, device=dev)
+
+    cur = m / log_s_col.exp() / log_s_row.exp()
+    score_best = _imbalance(cur)
+    sc_best = log_s_col.exp().clone()
+    sr_best = log_s_row.exp().clone()
+
+    for _ in range(iterations):
+        col_std = cur.std(dim=1, keepdim=True).clamp(_CLIP_STD_MIN, _CLIP_STD_MAX)
+        log_s_col = (log_s_col + col_std.log()).clip(_LOG_S_MIN, _LOG_S_MAX)
+        cur = m / log_s_col.exp() / log_s_row.exp()
+
+        row_std = cur.std(dim=2, keepdim=True).clamp(_CLIP_STD_MIN, _CLIP_STD_MAX)
+        log_s_row = (log_s_row + row_std.log()).clip(_LOG_S_MIN, _LOG_S_MAX)
+        cur = m / log_s_col.exp() / log_s_row.exp()
+
+        score = _imbalance(cur)
+        better = score <= score_best
+        if better.any():
+            mask = better.view(N, 1, 1).to(log_s_col.dtype)
+            sc_best = mask * log_s_col.exp() + (1 - mask) * sc_best
+            sr_best = mask * log_s_row.exp() + (1 - mask) * sr_best
+            score_best = torch.where(better, score, score_best)
+
+    balanced = m / sc_best / sr_best
+    return balanced, sc_best, sr_best

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -3,6 +3,7 @@
 import contextlib
 import enum
 import functools
+import math
 import os
 import platform
 import sys
@@ -702,7 +703,21 @@ class Platform:
             if cache_config.cache_dtype != "auto"
             else model_config.dtype
         )
-        primary_page = per_token_page_bytes(primary_dtype, cache_config.cache_dtype)
+        if cache_config.cache_dtype.startswith("kvarn_") and not model_config.use_mla:
+            from vllm.model_executor.layers.quantization.kvarn.config import (
+                KVarNConfig,
+            )
+
+            kvarn_config = KVarNConfig.from_cache_dtype(
+                cache_config.cache_dtype, model_config.get_head_size()
+            )
+            primary_page = (
+                kvarn_config.tile_bytes_aligned
+                * model_config.get_num_kv_heads(parallel_config)
+                // kvarn_config.group
+            )
+        else:
+            primary_page = per_token_page_bytes(primary_dtype, cache_config.cache_dtype)
 
         # Per-token page of every higher-precision padded spec sharing the pool.
         padded_pages: list[int] = []
@@ -796,8 +811,26 @@ class Platform:
 
         kv_quant_mode = get_kv_quant_mode(cache_config.cache_dtype)
 
-        # Compute attention page size for 1 token
-        if model_config.use_mla:
+        # Compute attention page size for one token. KVarN's dense 5-bit
+        # payload is group-locked and cannot use FullAttentionSpec's raw uint8
+        # formula.
+        is_standard_kvarn = (
+            cache_config.cache_dtype.startswith("kvarn_") and not model_config.use_mla
+        )
+        if is_standard_kvarn:
+            from vllm.model_executor.layers.quantization.kvarn.config import (
+                KVarNConfig,
+            )
+
+            kvarn_config = KVarNConfig.from_cache_dtype(
+                cache_config.cache_dtype, model_config.get_head_size()
+            )
+            attn_page_size_1_token = (
+                kvarn_config.tile_bytes_aligned
+                * model_config.get_num_kv_heads(parallel_config)
+                // kvarn_config.group
+            )
+        elif model_config.use_mla:
             attn_page_size_1_token = MLAAttentionSpec(
                 block_size=1,
                 num_kv_heads=model_config.get_num_kv_heads(parallel_config),
@@ -862,6 +895,22 @@ class Platform:
         ).page_size_bytes
 
         if mamba_page_size == 0:
+            return
+        if is_standard_kvarn:
+            # Keep group-64 quantization tiles while allowing multiple tiles to
+            # share one hybrid cache page. This preserves KVarN's
+            # bytes/token instead of padding every 64-token tile to a Mamba
+            # state page.
+            tile_page_size = (
+                kvarn_config.tile_bytes_aligned
+                * model_config.get_num_kv_heads(parallel_config)
+            )
+            tiles_per_page = max(
+                math.ceil(mamba_page_size / tile_page_size),
+                1,
+            )
+            cache_config.block_size = kvarn_config.group * tiles_per_page
+            cache_config.mamba_page_size_padded = tile_page_size * tiles_per_page
             return
 
         # mamba_block_size here should either be user specified value or None

--- a/vllm/utils/torch_utils.py
+++ b/vllm/utils/torch_utils.py
@@ -50,6 +50,10 @@ STR_DTYPE_TO_TORCH_DTYPE = {
     "turboquant_4bit_nc": torch.uint8,
     "turboquant_k3v4_nc": torch.uint8,
     "turboquant_3bit_nc": torch.uint8,
+    "kvarn_k4v2_g128": torch.uint8,
+    "kvarn_k4v4_g128": torch.uint8,
+    "kvarn_k5v5_g64": torch.uint8,
+    "kvarn_mla_k5_g64": torch.uint8,
     "nvfp4": torch.uint8,
     "nvfp4_4over6": torch.uint8,
 }
@@ -77,7 +81,7 @@ PIN_MEMORY = is_pin_memory_available()
 
 def is_quantized_kv_cache(kv_cache_dtype: str) -> bool:
     return (
-        kv_cache_dtype.startswith("fp8")
+        kv_cache_dtype.startswith(("fp8", "kvarn_"))
         or kv_cache_dtype.endswith("per_token_head")
         or kv_cache_dtype.startswith("nvfp4")
     )

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -24,6 +24,8 @@ from vllm.v1.kv_cache_interface import (
     ChunkedLocalAttentionSpec,
     FullAttentionSpec,
     HiddenStateCacheSpec,
+    KVarNFullAttentionSpec,
+    KVarNSlidingWindowSpec,
     KVCacheConfig,
     KVCacheGroupSpec,
     KVCacheSpec,
@@ -1011,6 +1013,102 @@ def may_override_num_blocks(vllm_config: VllmConfig, num_blocks: int) -> int:
     return num_blocks
 
 
+def _get_kvarn_mla_workspace_config(
+    kv_cache_groups: list[KVCacheGroupSpec],
+) -> Any | None:
+    """Return the one shared MLA workspace geometry used by this worker."""
+    kvarn_specs: list[MLAAttentionSpec] = []
+    for group in kv_cache_groups:
+        group_spec = group.kv_cache_spec
+        specs: Iterable[KVCacheSpec]
+        if isinstance(group_spec, UniformTypeKVCacheSpecs):
+            specs = group_spec.kv_cache_specs.values()
+        else:
+            specs = (group_spec,)
+        kvarn_specs.extend(
+            spec
+            for spec in specs
+            if isinstance(spec, MLAAttentionSpec)
+            and spec.cache_dtype_str == "kvarn_mla_k5_g64"
+        )
+
+    if not kvarn_specs:
+        return None
+    from vllm.model_executor.layers.quantization.kvarn.config import KVarNMLAConfig
+
+    geometries: dict[tuple[Any, ...], KVarNMLAConfig] = {}
+    for spec in kvarn_specs:
+        assert spec.cache_dtype_str is not None
+        config = KVarNMLAConfig.from_cache_dtype(spec.cache_dtype_str)
+        geometry = (
+            spec.block_size,
+            spec.num_kv_heads,
+            spec.head_size,
+            spec.dtype,
+            config.group,
+            config.latent_dim,
+            config.rope_dim,
+            config.bits,
+        )
+        geometries.setdefault(geometry, config)
+
+    if len(geometries) != 1:
+        raise ValueError(
+            "A local worker cannot share one KVarN MLA workspace across "
+            f"multiple incompatible cache geometries: {tuple(geometries)}"
+        )
+    return next(iter(geometries.values()))
+
+
+def _get_kvarn_mla_num_blocks(
+    vllm_config: VllmConfig,
+    kv_cache_groups: list[KVCacheGroupSpec],
+    available_memory: int,
+    packed_bytes_per_block: int,
+) -> int | None:
+    """Solve packed-cache plus shared-workspace capacity, if MLA KVarN is used."""
+    config = _get_kvarn_mla_workspace_config(kv_cache_groups)
+    if config is None:
+        return None
+
+    def required_memory(num_pages: int) -> int:
+        workspace_bytes = config.workspace_envelope(vllm_config, num_pages).total_bytes
+        return packed_bytes_per_block * num_pages + workspace_bytes
+
+    override = vllm_config.cache_config.num_gpu_blocks_override
+    if override is not None:
+        if override <= 0:
+            return override
+        required_bytes = required_memory(override)
+        if required_bytes > available_memory:
+            raise ValueError(
+                f"num_gpu_blocks_override={override} requires {required_bytes} "
+                "bytes for packed KVarN MLA cache pages and the shared workspace, "
+                f"but only {available_memory} bytes are available"
+            )
+        return override
+
+    max_pages_without_workspace = max(
+        int(available_memory // packed_bytes_per_block), 0
+    )
+    if max_pages_without_workspace == 0:
+        return 0
+
+    def fits(num_pages: int) -> bool:
+        return required_memory(num_pages) <= available_memory
+
+    if not fits(1):
+        return 0
+    low, high = 1, max_pages_without_workspace
+    while low < high:
+        mid = (low + high + 1) // 2
+        if fits(mid):
+            low = mid
+        else:
+            high = mid - 1
+    return low
+
+
 def _pool_bytes_per_block(
     vllm_config: VllmConfig, kv_cache_groups: list[KVCacheGroupSpec]
 ) -> int:
@@ -1148,6 +1246,19 @@ def unify_kv_cache_spec_page_size(
             new_spec: KVCacheSpec = replace(
                 layer_spec, page_size_padded=target_page_size
             )
+            assert new_spec.page_size_bytes == target_page_size
+            new_kv_cache_spec[layer_name] = new_spec
+        elif isinstance(layer_spec, (KVarNFullAttentionSpec, KVarNSlidingWindowSpec)):
+            real_page_size = layer_spec.real_page_size_bytes
+            if target_page_size % real_page_size == 0:
+                ratio = target_page_size // real_page_size
+                new_spec = replace(
+                    layer_spec,
+                    block_size=layer_spec.block_size * ratio,
+                    page_size_padded=None,
+                )
+            else:
+                new_spec = replace(layer_spec, page_size_padded=target_page_size)
             assert new_spec.page_size_bytes == target_page_size
             new_kv_cache_spec[layer_name] = new_spec
         else:
@@ -1484,7 +1595,14 @@ def _get_kv_cache_config_packed(
     ):
         tensor_slots = _get_lockstep_mla_tensor_slots(kv_cache_groups)
         total_num_bytes_per_block = sum(page_size for page_size, _ in tensor_slots)
-        num_blocks = available_memory // total_num_bytes_per_block
+        num_blocks = _get_kvarn_mla_num_blocks(
+            vllm_config,
+            kv_cache_groups,
+            available_memory,
+            total_num_bytes_per_block,
+        )
+        if num_blocks is None:
+            num_blocks = available_memory // total_num_bytes_per_block
         num_blocks = may_override_num_blocks(vllm_config, num_blocks)
         return num_blocks, [
             KVCacheTensor(size=page_size * num_blocks, shared_by=slot)
@@ -1493,7 +1611,14 @@ def _get_kv_cache_config_packed(
 
     block_stride, layers_by_offset = _get_packed_kv_cache_layout(kv_cache_groups)
 
-    num_blocks = available_memory // block_stride
+    num_blocks = _get_kvarn_mla_num_blocks(
+        vllm_config,
+        kv_cache_groups,
+        available_memory,
+        block_stride,
+    )
+    if num_blocks is None:
+        num_blocks = available_memory // block_stride
     num_blocks = may_override_num_blocks(vllm_config, num_blocks)
 
     total_size = block_stride * num_blocks
@@ -1544,9 +1669,12 @@ def get_kv_cache_config_from_groups(
         # Special case: all layers have the same type of KV cache but with
         # different hidden sizes. Allocate different amount of memory for each
         # layer based on its hidden size.
-        num_blocks = (
-            available_memory // kv_cache_groups[0].kv_cache_spec.page_size_bytes
+        bytes_per_block = kv_cache_groups[0].kv_cache_spec.page_size_bytes
+        num_blocks = _get_kvarn_mla_num_blocks(
+            vllm_config, kv_cache_groups, available_memory, bytes_per_block
         )
+        if num_blocks is None:
+            num_blocks = available_memory // bytes_per_block
         num_blocks = may_override_num_blocks(vllm_config, num_blocks)
         per_layer_specs = kv_cache_groups[0].kv_cache_spec.kv_cache_specs
         kv_cache_tensors = [
@@ -1577,9 +1705,18 @@ def get_kv_cache_config_from_groups(
             [group.kv_cache_spec for group in kv_cache_groups]
         )
         assert group_size > 0, "group_size must be greater than 0"
-        num_blocks = get_num_blocks(
-            vllm_config, group_size, available_memory, page_size
+        num_blocks = _get_kvarn_mla_num_blocks(
+            vllm_config,
+            kv_cache_groups,
+            available_memory,
+            page_size * group_size,
         )
+        if num_blocks is None:
+            num_blocks = get_num_blocks(
+                vllm_config, group_size, available_memory, page_size
+            )
+        else:
+            num_blocks = may_override_num_blocks(vllm_config, num_blocks)
         kv_cache_tensors = []
         for i in range(group_size):
             shared_by = []
@@ -2265,6 +2402,23 @@ def _max_memory_usage_bytes_from_groups(
     return group_size * page_size * blocks_needed
 
 
+def _max_memory_usage_with_kvarn_mla_workspace(
+    vllm_config: VllmConfig,
+    kv_cache_groups: list[KVCacheGroupSpec],
+) -> int:
+    packed_bytes = _max_memory_usage_bytes_from_groups(vllm_config, kv_cache_groups)
+    workspace_config = _get_kvarn_mla_workspace_config(kv_cache_groups)
+    if workspace_config is None or packed_bytes == 0:
+        return packed_bytes
+    required_pages = cdiv(
+        packed_bytes, _pool_bytes_per_block(vllm_config, kv_cache_groups)
+    )
+    return (
+        packed_bytes
+        + workspace_config.workspace_envelope(vllm_config, required_pages).total_bytes
+    )
+
+
 def _estimate_max_model_len_from_groups(
     vllm_config: VllmConfig,
     kv_cache_groups: list[KVCacheGroupSpec],
@@ -2279,7 +2433,7 @@ def _estimate_max_model_len_from_groups(
     def fits(model_len: int) -> bool:
         vllm_config.model_config.max_model_len = model_len
         return (
-            _max_memory_usage_bytes_from_groups(vllm_config, kv_cache_groups)
+            _max_memory_usage_with_kvarn_mla_workspace(vllm_config, kv_cache_groups)
             <= available_memory
         )
 
@@ -2471,12 +2625,10 @@ def get_kv_cache_configs(
         for worker_spec in kv_cache_specs
     ]
 
-    # If `num_gpu_blocks_override` is set, the cache size that will actually
-    # be allocated is decoupled from the profiled `available_memory`:
-    # `may_override_num_blocks` in `get_kv_cache_config_from_groups` clamps
-    # `num_blocks` to the override. Reflect that in `available_memory` here so
-    # auto-fit, the admission check, and the per-worker config builder all
-    # plan against the same effective capacity.
+    # An override defines the effective cache capacity used by auto-fit,
+    # admission, and tensor planning. KVarN MLA still validates that its packed
+    # pages plus the separately allocated shared workspace fit the profiled
+    # per-worker allocation before replacing it with this effective capacity.
     override = vllm_config.cache_config.num_gpu_blocks_override
     if override is not None:
         adjusted_memory: list[int] = []
@@ -2499,7 +2651,20 @@ def get_kv_cache_configs(
                 profiled_num_blocks,
                 override,
             )
-            adjusted_memory.append(override * bytes_per_block)
+            effective_memory = override * bytes_per_block
+            workspace_config = _get_kvarn_mla_workspace_config(groups)
+            if workspace_config is not None and override > 0:
+                effective_memory += workspace_config.workspace_envelope(
+                    vllm_config, override
+                ).total_bytes
+                if effective_memory > avail_mem:
+                    raise ValueError(
+                        f"num_gpu_blocks_override={override} requires "
+                        f"{effective_memory} bytes for packed KVarN MLA cache "
+                        "pages and the shared workspace, but only "
+                        f"{avail_mem} bytes are available"
+                    )
+            adjusted_memory.append(effective_memory)
         available_memory = adjusted_memory
 
     if vllm_config.model_config.original_max_model_len == -1:
@@ -2513,7 +2678,11 @@ def get_kv_cache_configs(
             continue
         _check_enough_kv_cache_memory(
             avail_mem,
-            partial(_max_memory_usage_bytes_from_groups, vllm_config, groups),
+            partial(
+                _max_memory_usage_with_kvarn_mla_workspace,
+                vllm_config,
+                groups,
+            ),
             vllm_config.model_config.max_model_len,
             partial(_estimate_max_model_len_from_groups, vllm_config, groups),
         )

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -20,6 +20,8 @@ from vllm.v1.kv_cache_interface import (
     CrossAttentionSpec,
     FullAttentionSpec,
     HiddenStateCacheSpec,
+    KVarNFullAttentionSpec,
+    KVarNSlidingWindowSpec,
     KVCacheSpec,
     MambaSpec,
     MLAAttentionSpec,
@@ -95,6 +97,7 @@ class SingleTypeKVCacheManager(ABC):
         self._record_new_block_ids = needs_kv_cache_zeroing and type(kv_cache_spec) in (
             FullAttentionSpec,
             TQFullAttentionSpec,
+            KVarNFullAttentionSpec,
             MLAAttentionSpec,
             HiddenStateCacheSpec,
         )
@@ -1945,6 +1948,11 @@ def register_all_kvcache_specs(vllm_config):
         SlidingWindowManager,
         uniform_type_base_spec=SlidingWindowMLASpec,
     )
+    KVCacheSpecRegistry.register(
+        KVarNSlidingWindowSpec,
+        SlidingWindowManager,
+        uniform_type_base_spec=KVarNSlidingWindowSpec,
+    )
 
     KVCacheSpecRegistry.register(
         MambaSpec, MambaManager, uniform_type_base_spec=MambaSpec
@@ -1963,6 +1971,11 @@ def register_all_kvcache_specs(vllm_config):
     # FullAttentionSpec subclasses — grouped with FullAttentionSpec
     KVCacheSpecRegistry.register(
         TQFullAttentionSpec,
+        FullAttentionManager,
+        uniform_type_base_spec=FullAttentionSpec,
+    )
+    KVCacheSpecRegistry.register(
+        KVarNFullAttentionSpec,
         FullAttentionManager,
         uniform_type_base_spec=FullAttentionSpec,
     )

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -466,6 +466,39 @@ class TQFullAttentionSpec(FullAttentionSpec):
 
 
 @dataclass(frozen=True, kw_only=True)
+class KVarNFullAttentionSpec(FullAttentionSpec):
+    """Full-attention spec with group-sized KVarN tiles."""
+
+    tile_size: int = 0
+    quant_group_size: int = 64
+
+    @property
+    def real_page_size_bytes(self) -> int:
+        if self.tile_size > 0:
+            return (
+                self.num_kv_heads
+                * self.tile_size
+                * (self.block_size // self.quant_group_size)
+            )
+        return super().real_page_size_bytes
+
+    @classmethod
+    def merge(cls, specs: list[Self]) -> Self:
+        merged = super().merge(specs)
+        assert all(spec.tile_size == specs[0].tile_size for spec in specs), (
+            "All KVarN layers in one cache group must use the same tile size."
+        )
+        assert all(
+            spec.quant_group_size == specs[0].quant_group_size for spec in specs
+        ), "All KVarN layers in one cache group must use the same quantization group."
+        return replace(
+            merged,
+            tile_size=specs[0].tile_size,
+            quant_group_size=specs[0].quant_group_size,
+        )
+
+
+@dataclass(frozen=True, kw_only=True)
 class MLAAttentionSpec(FullAttentionSpec):
     # TODO(Lucas/Chen): less hacky way to do this
     cache_dtype_str: str | None = None
@@ -486,6 +519,18 @@ class MLAAttentionSpec(FullAttentionSpec):
 
     @property
     def real_page_size_bytes(self) -> int:
+        if self.cache_dtype_str == "kvarn_mla_k5_g64":
+            from vllm.model_executor.layers.quantization.kvarn.config import (
+                KVarNMLAConfig,
+            )
+
+            config = KVarNMLAConfig.from_cache_dtype(self.cache_dtype_str)
+            if self.block_size != config.group:
+                raise ValueError(
+                    "MLA KVarN requires block_size "
+                    f"{config.group}, got {self.block_size}."
+                )
+            return config.tile_bytes
         if self.cache_dtype_str == "nvfp4_ds_mla":
             # NVFP4 MLA latent: 432 B/token (256B E2M1 NoPE + 32B E4M3 group-16
             # scales + 16B pad + 128B BF16 RoPE). Same record for the
@@ -736,6 +781,36 @@ class SlidingWindowSpec(AttentionSpec):
             isinstance(spec, SlidingWindowSpec)
             and spec.sliding_window == self.sliding_window
             and spec.dcp_replicated == self.dcp_replicated
+            for spec in kv_cache_specs.values()
+        )
+
+
+@dataclass(frozen=True, kw_only=True)
+class KVarNSlidingWindowSpec(SlidingWindowSpec):
+    """Sliding-window spec with group-sized KVarN tiles."""
+
+    tile_size: int = 0
+    quant_group_size: int = 64
+
+    @property
+    def real_page_size_bytes(self) -> int:
+        if self.tile_size > 0:
+            return (
+                self.num_kv_heads
+                * self.tile_size
+                * (self.block_size // self.quant_group_size)
+            )
+        return super().real_page_size_bytes
+
+    def is_uniform_with_collection(
+        self, kv_cache_specs: dict[str, KVCacheSpec]
+    ) -> bool:
+        return all(
+            isinstance(spec, KVarNSlidingWindowSpec)
+            and spec.sliding_window == self.sliding_window
+            and spec.dcp_replicated == self.dcp_replicated
+            and spec.tile_size == self.tile_size
+            and spec.quant_group_size == self.quant_group_size
             for spec in kv_cache_specs.values()
         )
 


### PR DESCRIPTION
## What

KVarN (K-variance-normalized) KV cache formats: low-bit latent KV records with
per-group variance normalization (Sinkhorn-balanced), where the cache dtype
string is the sole, self-describing carrier of geometry — `kvarn_mla_k5_g64`
(MLA packed latent, 5-bit, group 64) and the standard variants
`kvarn_k4v2_g128` / `kvarn_k4v4_g128` / `kvarn_k5v5_g64` (key/value bits +
group tile). No env override exists for the width; downstream geometry gates
fail closed on any width/group combination the kernels do not implement.

- `vllm/model_executor/layers/quantization/kvarn/`: `config.py` (dtype
  registry + parsing, KVarNConfig / KVarNMLAConfig geometry, shared
  precision-tail workspace envelope math, weight-size estimation),
  `sinkhorn.py` (NumPy reference normalization used by the tests).
- `kv_cache_interface` + `single_type_kv_cache_manager`: KVarNFullAttentionSpec
  / KVarNSlidingWindowSpec with group-locked tile sizes; MLAAttentionSpec
  carries `cache_dtype_str` so packed layouts stay self-describing end to end.
- `kv_cache_utils`: `_get_kvarn_mla_workspace_config` +
  `_get_kvarn_mla_num_blocks` charge the shared MLA dequantization workspace
  **once** for all local layers (it is shared across layers, unlike per-layer
  pages) and solve packed pages + workspace as one budget; incompatible shared
  geometries on one worker raise instead of guessing.
- `platforms/interface.py`: per-token page-size computation for the
  group-locked KVarN tiles (cannot use FullAttentionSpec's raw uint8 formula).
- `torch_utils.get_kv_cache_torch_dtype`: KVarN dtype strings → uint8 storage.

Foundation for the KVarN MLA attention backend (follow-up PR); this PR is
self-contained and fully CPU-testable.

## Why

Serving JPsequeira/GLM-5.2-EXL3-TR3-3.40bpw-KVarN-K4V2 (public) requires the
KVarN cache format the checkpoint was quantized for. KVarN packs 5-bit
group-normalized latents into ~432-byte records, which is what makes 819K-token
contexts fit at ≥3.4 bpw on this class of hardware (evidence in the follow-up
backend PR).

## Not duplicating an existing PR

- #249 (heterogeneous per-layer expert widths: deepseek_v2 + exl3.py) — no
  file or mechanism overlap; this PR touches no model code and no exl3 code.
- #297 (exl3 k_values += 2) — exl3.py untouched here.
- #240 (qwen3_5 rank-sliced EXL3 loading) — untouched.
- Merged II EXL3 commits (`fa51e84c5e`, `75548a03c4`, `d9e617b311`) and the
  DCP line (`be8479c970` #245 et al.) — no KVarN code exists anywhere in
  dev/infernal-invocation today (verified: zero kvarn paths in the tree).

## Tests

Existing coverage extended: `tests/v1/core/test_kv_cache_utils.py` +167 lines —
exact-fit/one-page-over workspace sizing, workspace charged once across local
layers, ngram override requires the combined budget (fails closed), shared
geometries must be compatible (raises), and non-KVarN/generic-KVarN page counts
do not reserve the MLA workspace.

Run on the ported tree (SM120 workstation, `.venv` torch 2.11.0+cu130):

    pytest tests/v1/core/test_kv_cache_utils.py -q
    → 106 passed

Model-affecting? No — this PR adds cache-format plumbing that is inert unless a
KVarN dtype is selected; no default behavior changes. Kernel accuracy evidence
for the format itself is attached to the backend PR.

## AI assistance

Ported and adapted to dev/infernal-invocation by an AI agent (Claude Opus 4.5)
under human direction from battle-tested fork commits; every line was written
and measured first in our serving stack. Commit trailers carry attribution.
```

### Diffstat

```
 tests/v1/core/test_kv_cache_utils.py               | 167 +++++
 vllm/config/cache.py                               |   4 +
 .../layers/quantization/kvarn/__init__.py          |   13 +
 .../layers/quantization/kvarn/config.py            |  683 +++++++++++++++++
 .../layers/quantization/kvarn/sinkhorn.py          |  139 ++++
 vllm/platforms/interface.py                         |   55 +-
 vllm/utils/torch_utils.py                          |    6 +-
 vllm/v1/core/kv_cache_utils.py                     | 199 +++++-
 vllm/v1/core/single_type_kv_cache_manager.py       |   13 +
 vllm/v1/kv_cache_interface.py                       |   75 +++
 10 files changed, 1335 insertions(+), 19 deletions(-)
```

---