### PR TITLE
[II] feat(kvarn): KVarN MLA attention backend with packed Triton ops

### DIFF
--- a/tests/config/test_kvarn_v2_config.py
+++ b/tests/config/test_kvarn_v2_config.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from vllm.config import VllmConfig
+from vllm.platforms.cuda import CudaPlatform
+from vllm.v1.attention.backends.registry import AttentionBackendEnum
+
+
+def _kvarn_config(*, async_scheduling: bool = True) -> VllmConfig:
+    config = VllmConfig()
+    config.model_config = SimpleNamespace(  # type: ignore[assignment]
+        is_mm_prefix_lm=False, use_mla=True
+    )
+    config.cache_config.cache_dtype = "kvarn_mla_k5_g64"
+    config.cache_config.block_size = 64
+    config.cache_config.enable_prefix_caching = False
+    config.cache_config.kv_offloading_size = None
+    config.cache_config.kv_cache_dtype_skip_layers = []
+    config.attention_config.backend = AttentionBackendEnum.B12X_MLA_SPARSE
+    config.parallel_config.enable_dbo = False
+    config.scheduler_config.async_scheduling = async_scheduling
+    config.kv_transfer_config = None
+    return config
+
+
+def _mtp_config(**overrides) -> SimpleNamespace:
+    values = {
+        "method": "mtp",
+        "num_speculative_tokens": 4,
+        "parallel_drafting": False,
+        "attention_backend": AttentionBackendEnum.B12X_MLA_SPARSE,
+        "kv_cache_dtype": "kvarn_mla_k5_g64",
+        "moe_backend": "b12x",
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+@pytest.mark.parametrize("async_scheduling", [False, True])
+def test_mla_kvarn_admits_sync_and_async_native_draft(
+    async_scheduling: bool,
+) -> None:
+    config = _kvarn_config(async_scheduling=async_scheduling)
+    config.speculative_config = _mtp_config()  # type: ignore[assignment]
+
+    CudaPlatform.check_and_update_config(config)
+
+
+@pytest.mark.parametrize("method", ["ngram", "ngram_gpu"])
+def test_mla_kvarn_admits_ngram_speculation_without_a_draft_cache(
+    method: str,
+) -> None:
+    config = _kvarn_config()
+    config.speculative_config = SimpleNamespace(  # type: ignore[assignment]
+        method=method,
+        num_speculative_tokens=4,
+    )
+
+    CudaPlatform.check_and_update_config(config)
+
+
+@pytest.mark.parametrize(
+    ("feature", "value", "message"),
+    [
+        ("prefix", True, "prefix caching"),
+        ("offload", 1.0, "offloading"),
+        ("transfer", SimpleNamespace(), "KV transfer"),
+        ("dbo", True, "dual-batch overlap"),
+        ("mixed_dtype", ["0"], "mixed KV-cache dtypes"),
+        ("backend", None, "B12X_MLA_SPARSE"),
+        ("block", 32, "block-size 64"),
+        ("non_mla", False, "MLA model"),
+    ],
+)
+def test_mla_kvarn_rejects_unsupported_features(
+    feature: str,
+    value: Any,
+    message: str,
+) -> None:
+    config = _kvarn_config()
+    if feature == "prefix":
+        config.cache_config.enable_prefix_caching = value
+    elif feature == "offload":
+        config.cache_config.kv_offloading_size = value
+    elif feature == "transfer":
+        config.kv_transfer_config = value
+    elif feature == "dbo":
+        config.parallel_config.enable_dbo = value
+    elif feature == "backend":
+        config.attention_config.backend = value
+    elif feature == "block":
+        config.cache_config.block_size = value
+    elif feature == "non_mla":
+        config.model_config.use_mla = value  # type: ignore[misc]
+    else:
+        config.cache_config.kv_cache_dtype_skip_layers = value
+
+    with pytest.raises(ValueError, match=message):
+        CudaPlatform.check_and_update_config(config)
+
+
+@pytest.mark.parametrize(
+    ("override", "message"),
+    [
+        ({"attention_backend": None}, "speculative.*B12X_MLA_SPARSE"),
+        ({"kv_cache_dtype": None}, "speculative.*kvarn_mla_k5_g64"),
+    ],
+)
+def test_mla_kvarn_requires_explicit_native_draft_config(
+    override: dict[str, object],
+    message: str,
+) -> None:
+    config = _kvarn_config()
+    config.speculative_config = _mtp_config(**override)  # type: ignore[assignment]
+
+    with pytest.raises(ValueError, match=message):
+        CudaPlatform.check_and_update_config(config)
+
+
+def test_mla_kvarn_explicit_draft_config_is_native() -> None:
+    config = _kvarn_config()
+    config.speculative_config = _mtp_config()  # type: ignore[assignment]
+
+    CudaPlatform.check_and_update_config(config)
+
+    spec = config.speculative_config
+    assert spec is not None
+    assert spec.attention_backend is AttentionBackendEnum.B12X_MLA_SPARSE
+    assert spec.kv_cache_dtype == "kvarn_mla_k5_g64"
+    assert spec.moe_backend == "b12x"

--- a/tests/v1/attention/test_kvarn.py
+++ b/tests/v1/attention/test_kvarn.py
@@ -1,0 +1,873 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from dataclasses import replace
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.quantization.kvarn.config import (
+    KVarNConfig,
+    KVarNMLAConfig,
+)
+from vllm.utils.torch_utils import get_kv_cache_torch_dtype
+from vllm.v1.attention.backends.kvarn_attn import (
+    KVarNAttentionBackend,
+    KVarNAttentionImpl,
+    _build_hadamard,
+)
+from vllm.v1.attention.backends.mla.kvarn_mla_state import (
+    KVarNMLALiveBlockTracker,
+    KVarNMLAStateManager,
+)
+from vllm.v1.attention.ops.kvarn_decode import _unpack_lowbit, kvarn_hadamard
+from vllm.v1.attention.ops.kvarn_store import (
+    _pack_lowbit,
+    kvarn_store_tile_k_batch_from_sinkhorn,
+)
+from vllm.v1.attention.ops.triton_kvarn_decode import adaptive_num_kv_splits
+from vllm.v1.core.kv_cache_utils import unify_kv_cache_spec_page_size
+from vllm.v1.kv_cache_interface import (
+    KVarNFullAttentionSpec,
+    KVarNSlidingWindowSpec,
+)
+
+
+def test_k5_uses_dense_little_endian_bitstream() -> None:
+    codes = torch.arange(8, dtype=torch.uint8)
+
+    packed = _pack_lowbit(codes, bits=5)
+
+    assert packed.tolist() == [32, 136, 65, 138, 57]
+    assert torch.equal(_unpack_lowbit(packed, 8, bits=5), codes)
+
+
+@pytest.mark.parametrize(
+    ("bits", "codes", "expected"),
+    (
+        (2, torch.arange(8, dtype=torch.uint8) % 4, [228, 228]),
+        (4, torch.arange(8, dtype=torch.uint8), [16, 50, 84, 118]),
+    ),
+)
+def test_byte_aligned_lowbit_packers(
+    bits: int, codes: torch.Tensor, expected: list[int]
+) -> None:
+    packed = _pack_lowbit(codes, bits=bits)
+
+    assert packed.tolist() == expected
+    assert torch.equal(_unpack_lowbit(packed, len(codes), bits=bits), codes)
+
+
+def _reconstruct_batched_k(record: dict[str, torch.Tensor], group: int) -> torch.Tensor:
+    q = _unpack_lowbit(record["q_packed_uint8"], group, bits=5).float()
+    return (
+        q * record["s_col_K"].float().unsqueeze(-1)
+        + record["zp_K"].float().unsqueeze(-1)
+    ) * record["s_row_K"].float().unsqueeze(-2)
+
+
+def test_affine_refit_reduces_original_space_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    generator = torch.Generator().manual_seed(7)
+    balanced = torch.randn(2, 16, 64, generator=generator)
+    s_col = torch.linspace(0.05, 4.0, 64).repeat(2, 1)
+    s_row = torch.linspace(0.25, 2.0, 16).repeat(2, 1)
+    original = balanced * s_row.unsqueeze(-1) * s_col.unsqueeze(-2)
+
+    monkeypatch.setenv("KVARN_AFFINE_REFIT", "0")
+    rtn = kvarn_store_tile_k_batch_from_sinkhorn(balanced, s_col, s_row, bits=5)
+    monkeypatch.setenv("KVARN_AFFINE_REFIT", "1")
+    refit = kvarn_store_tile_k_batch_from_sinkhorn(balanced, s_col, s_row, bits=5)
+
+    rtn_error = (_reconstruct_batched_k(rtn, 64) - original).square().mean()
+    refit_error = (_reconstruct_batched_k(refit, 64) - original).square().mean()
+    assert refit_error < rtn_error
+
+
+def test_affine_refit_defaults_on_for_five_bit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    generator = torch.Generator().manual_seed(13)
+    balanced = torch.randn(2, 16, 64, generator=generator)
+    s_col = torch.linspace(0.1, 2.0, 64).repeat(2, 1)
+    s_row = torch.linspace(0.5, 1.5, 16).repeat(2, 1)
+
+    monkeypatch.delenv("KVARN_AFFINE_REFIT", raising=False)
+    default = kvarn_store_tile_k_batch_from_sinkhorn(balanced, s_col, s_row, bits=5)
+    monkeypatch.setenv("KVARN_AFFINE_REFIT", "1")
+    explicit = kvarn_store_tile_k_batch_from_sinkhorn(balanced, s_col, s_row, bits=5)
+
+    for name in default:
+        assert torch.equal(default[name], explicit[name])
+
+
+def test_k5_layout_and_exact_pool_storage_sizes() -> None:
+    standard = KVarNConfig(
+        head_dim=128,
+        key_bits=5,
+        value_bits=5,
+        group=64,
+    )
+    mla = KVarNMLAConfig()
+
+    assert standard.tile_bytes_aligned == 11392
+    assert standard.tile_bytes_aligned // standard.group == 178
+    assert standard._slot_bytes_per_layer(num_kv_heads=2) == 65536
+    assert replace(standard, tail_dtype="fp8")._slot_bytes_per_layer(2) == 33280
+    assert mla.tile_bytes == 30848
+    assert mla.bytes_per_token == 482
+    assert mla.pool_slot_bytes == 40960
+    assert standard.resident_blocks_per_seq == 19
+    assert mla.resident_blocks_per_seq == 3
+    assert mla.pool_slots(10, 20) == 49
+    assert mla.pool_slots(10, 640) == 58
+    assert mla.pool_slots(10, 20, max_rollback_tokens=8) == 61
+
+
+def test_standard_precision_tail_defaults_to_float16() -> None:
+    assert KVarNConfig(head_dim=128).tail_dtype == "float16"
+
+
+def test_k5v5_public_default_disables_retained_tail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("KVARN_TAIL_TOKENS", raising=False)
+
+    k5v5 = KVarNConfig.from_cache_dtype("kvarn_k5v5_g64", head_dim=128)
+    k4v4 = KVarNConfig.from_cache_dtype("kvarn_k4v4_g128", head_dim=128)
+
+    assert k5v5.precision_tail_tokens == 0
+    assert k5v5.resident_blocks_per_seq == 2
+    assert k4v4.precision_tail_tokens == 1024
+
+
+def test_mla_config_ignores_standard_tail_overrides(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("KVARN_TAIL_TOKENS", "1024")
+    monkeypatch.setenv("KVARN_SINK_TOKENS", "1024")
+
+    config = KVarNMLAConfig.from_cache_dtype("kvarn_mla_k5_g64")
+
+    assert config.resident_blocks_per_seq == 3
+    assert config.boundary_tokens == 128
+    assert not hasattr(config, "precision_tail_tokens")
+
+
+def test_only_standard_kvarn_forces_v1_model_runner() -> None:
+    from vllm.config import VllmConfig
+
+    config = VllmConfig()
+    config.cache_config.cache_dtype = "kvarn_k5v5_g64"
+    assert "KVarN KV cache" in config._get_v2_model_runner_unsupported_features()
+
+    config.cache_config.cache_dtype = "kvarn_mla_k5_g64"
+    assert "KVarN KV cache" not in config._get_v2_model_runner_unsupported_features()
+
+
+def test_k5v5_uses_128_splits_for_long_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("KVARN_NUM_KV_SPLITS", raising=False)
+    k5v5 = KVarNConfig.from_cache_dtype("kvarn_k5v5_g64", head_dim=128)
+    k4v4 = KVarNConfig.from_cache_dtype("kvarn_k4v4_g128", head_dim=128)
+
+    assert adaptive_num_kv_splits(256, k5v5) == 32
+    assert adaptive_num_kv_splits(257, k5v5) == 128
+    assert adaptive_num_kv_splits(257, k4v4) == 64
+
+
+def test_float16_precision_tail_is_supported(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("KVARN_TAIL_DTYPE", "float16")
+
+    assert KVarNConfig.from_cache_dtype("kvarn_k4v4_g128", 128).tail_dtype == "float16"
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA Hadacore")
+@pytest.mark.parametrize("rows", (1, 3))
+def test_hadacore_uses_padded_return_tensor(rows: int) -> None:
+    device = torch.device("cuda")
+    hadamard = _build_hadamard(128, device)
+    value = torch.randn(rows, 128, device=device, dtype=torch.float16)
+
+    expected = value.float() @ hadamard
+    actual = kvarn_hadamard(value, hadamard).float()
+
+    torch.testing.assert_close(actual, expected, atol=2e-3, rtol=2e-3)
+
+
+def test_k4v2_is_a_public_standard_cache_dtype() -> None:
+    cache_dtype = "kvarn_k4v2_g128"
+    config = KVarNConfig.from_cache_dtype(cache_dtype, head_dim=128)
+
+    assert (config.key_bits, config.value_bits, config.group) == (4, 2, 128)
+    assert cache_dtype in KVarNAttentionBackend.supported_kv_cache_dtypes
+    assert 128 in KVarNAttentionBackend.get_supported_kernel_block_sizes()
+    assert get_kv_cache_torch_dtype(cache_dtype) == torch.uint8
+
+
+def test_k4v4_is_a_public_standard_cache_dtype() -> None:
+    cache_dtype = "kvarn_k4v4_g128"
+    config = KVarNConfig.from_cache_dtype(cache_dtype, head_dim=128)
+
+    assert (config.key_bits, config.value_bits, config.group) == (4, 4, 128)
+    assert cache_dtype in KVarNAttentionBackend.supported_kv_cache_dtypes
+    assert 128 in KVarNAttentionBackend.get_supported_kernel_block_sizes()
+    assert get_kv_cache_torch_dtype(cache_dtype) == torch.uint8
+
+
+def test_cutedsl_decode_requires_explicit_opt_in(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("KVARN_CUTEDSL", raising=False)
+    impl = object.__new__(KVarNAttentionImpl)
+
+    assert not impl._can_use_cutedsl_decode(torch.device("cuda"))
+
+
+def test_cutedsl_decode_rejects_k5_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("KVARN_CUTEDSL", "1")
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda device: (12, 0))
+    impl = object.__new__(KVarNAttentionImpl)
+    impl.kvarn_config = KVarNConfig.from_cache_dtype("kvarn_k5v5_g64", 128)
+    impl._activation_dtype = torch.float16
+    impl.num_heads = 32
+    impl.num_kv_heads = 8
+    impl.sliding_window = 0
+    impl._max_model_len = 32768
+    impl.scale = 128**-0.5
+
+    assert not impl._can_use_cutedsl_decode(torch.device("cuda"))
+
+
+def test_kvarn_page_unification_packs_multiple_group_tiles() -> None:
+    full = KVarNFullAttentionSpec(
+        block_size=64,
+        num_kv_heads=2,
+        head_size=128,
+        dtype=torch.uint8,
+        tile_size=11392,
+    )
+    sliding = KVarNSlidingWindowSpec(
+        block_size=64,
+        num_kv_heads=4,
+        head_size=128,
+        dtype=torch.uint8,
+        sliding_window=4096,
+        tile_size=11392,
+    )
+
+    unified = unify_kv_cache_spec_page_size({"full": full, "sliding": sliding})
+
+    assert unified["full"].block_size == 128
+    assert unified["sliding"].block_size == 64
+    assert unified["full"].page_size_bytes == unified["sliding"].page_size_bytes
+
+
+def test_mla_ownership_metadata_survives_unpadding_and_ubatching() -> None:
+    from vllm.v1.attention.backend import CommonAttentionMetadata
+    from vllm.v1.worker.ubatch_utils import UBatchSlice, split_attn_metadata
+
+    block_fills = {0: 64, 1: 64, 3: 32}
+    query_start_loc = torch.tensor([0, 1, 2], dtype=torch.int32)
+    seq_lens = torch.tensor([10, 20], dtype=torch.int32)
+    metadata = CommonAttentionMetadata(
+        query_start_loc=query_start_loc,
+        query_start_loc_cpu=query_start_loc,
+        seq_lens=seq_lens,
+        _seq_lens_cpu=seq_lens,
+        _num_computed_tokens_cpu=torch.tensor([9, 19], dtype=torch.int32),
+        num_reqs=2,
+        num_actual_tokens=2,
+        max_query_len=1,
+        max_seq_len=20,
+        block_table_tensor=torch.tensor([[0], [1]], dtype=torch.int32),
+        slot_mapping=torch.tensor([9, 19], dtype=torch.int64),
+        seq_lens_cpu_upper_bound=seq_lens,
+        kvarn_mla_block_fills=block_fills,
+    )
+
+    unpadded = metadata.unpadded(1, 1)
+    ubatches = split_attn_metadata(
+        [
+            UBatchSlice(slice(0, 1), slice(0, 1)),
+            UBatchSlice(slice(1, 2), slice(1, 2)),
+        ],
+        metadata,
+    )
+
+    assert unpadded.kvarn_mla_block_fills is block_fills
+    assert all(ubatch.kvarn_mla_block_fills is block_fills for ubatch in ubatches)
+
+
+class _FakeMLAImpl:
+    layer_name = "layer.0"
+    _is_kvarn_mla = True
+    _kvarn_group_key = None
+    device = torch.device("cpu")
+    _kvarn_pool_size = 32
+
+    def __init__(self) -> None:
+        self.flushed: list[int] = []
+
+    def _flush_kvarn_mla_blocks(
+        self, block_ids: torch.Tensor, pool_slots: torch.Tensor
+    ) -> None:
+        self.flushed.extend(block_ids.tolist())
+
+
+def test_mla_preserves_bounded_live_blocks_across_unscheduled_steps() -> None:
+    KVarNMLAStateManager._impls.clear()
+    KVarNMLAStateManager.reset_cache_bindings()
+    config = KVarNMLAConfig()
+    impl = _FakeMLAImpl()
+    KVarNMLAStateManager.register(impl)
+
+    def prepare(block_fills: dict[int, int]) -> dict[int, int]:
+        metadata = SimpleNamespace(kvarn_mla_block_fills=block_fills)
+        KVarNMLAStateManager.prepare_step(
+            ("layer.0",), ["layer.0"], metadata, config, dcp_world_size=1
+        )
+        return dict(KVarNMLAStateManager._groups[("layer.0",)].mapping)
+
+    live_a = {0: 64, 1: 64, 3: 32}
+    live_b = {4: 64, 5: 64, 7: 32}
+    mapping_a = prepare(live_a)
+    mapping_b = prepare(live_a | live_b)
+    mapping_a_returned = prepare(live_a | live_b)
+
+    assert set(mapping_a) == set(live_a)
+    for block_id, slot in mapping_a.items():
+        assert mapping_b[block_id] == slot
+        assert mapping_a_returned[block_id] == slot
+    assert impl.flushed == []
+
+    prepare(live_b)
+    assert set(KVarNMLAStateManager._groups[("layer.0",)].mapping) == set(live_b)
+    assert impl.flushed == [0, 1]
+
+    KVarNMLAStateManager._impls.clear()
+    KVarNMLAStateManager.reset_cache_bindings()
+
+
+def test_mla_prefill_tracks_every_written_block_without_device_readback() -> None:
+    KVarNMLAStateManager._impls.clear()
+    KVarNMLAStateManager.reset_cache_bindings()
+    config = KVarNMLAConfig()
+    impl = _FakeMLAImpl()
+    KVarNMLAStateManager.register(impl)
+
+    def prepare(block_fills: dict[int, int]) -> None:
+        metadata = SimpleNamespace(kvarn_mla_block_fills=block_fills)
+        KVarNMLAStateManager.prepare_step(
+            ("layer.0",), ["layer.0"], metadata, config, dcp_world_size=1
+        )
+
+    prepare({0: 64, 1: 64, 2: 64, 3: 32})
+    state = KVarNMLAStateManager._groups[("layer.0",)]
+    assert set(state.mapping) == {0, 1, 2, 3}
+    assert state.block_fill[2] == 64
+
+    prepare({0: 64, 1: 64, 3: 64})
+    assert set(state.mapping) == {0, 1, 3}
+    assert impl.flushed == [2]
+
+    KVarNMLAStateManager._impls.clear()
+    KVarNMLAStateManager.reset_cache_bindings()
+
+
+def test_mla_live_tracker_is_bounded_and_generation_aware() -> None:
+    tracker = KVarNMLALiveBlockTracker({0: (64, 128, 1, 1, 0, 1)})
+    request_a = SimpleNamespace(
+        block_ids=([0, 1, 2, 3],),
+        num_computed_tokens=0,
+    )
+    request_b = SimpleNamespace(
+        block_ids=([4, 5, 6, 7],),
+        num_computed_tokens=0,
+    )
+    requests = {"a": request_a, "b": request_b}
+
+    tracker.update(requests, {"a": 224}, (), ())
+    assert tracker.block_fills(0) == {0: 64, 1: 64, 2: 64, 3: 32}
+    tracker.update(requests, {"b": 224}, (), ())
+    assert tracker.block_fills(0) == {
+        0: 64,
+        1: 64,
+        3: 32,
+        4: 64,
+        5: 64,
+        6: 64,
+        7: 32,
+    }
+
+    tracker.update(requests, {}, (), ("a",))
+    assert tracker.block_fills(0) == {4: 64, 5: 64, 7: 32}
+
+    request_a.block_ids = ([8, 9, 10, 11],)
+    request_a.num_computed_tokens = 224
+    tracker.update(requests, {"a": 1}, (), ())
+    assert tracker.block_fills(0) == {
+        4: 64,
+        5: 64,
+        7: 32,
+        8: 64,
+        9: 64,
+        11: 33,
+    }
+
+
+def test_mla_live_tracker_unions_dbo_slices_and_shared_prefix() -> None:
+    tracker = KVarNMLALiveBlockTracker({0: (64, 128, 1, 1, 0, 1)})
+    request_a = SimpleNamespace(
+        block_ids=([0, 1, 2, 3],),
+        num_computed_tokens=0,
+    )
+    request_b = SimpleNamespace(
+        block_ids=([0, 1, 6, 7],),
+        num_computed_tokens=0,
+    )
+    requests = {"a": request_a, "b": request_b}
+
+    tracker.update(requests, {"a": 224, "b": 224}, (), ())
+    assert tracker.block_fills(0) == {
+        0: 64,
+        1: 64,
+        2: 64,
+        3: 32,
+        6: 64,
+        7: 32,
+    }
+
+    tracker.update(requests, {}, ("a",), ())
+    assert tracker.block_fills(0) == {0: 64, 1: 64, 7: 32}
+
+
+def test_mla_async_spec_rollback_keeps_possible_boundary_blocks() -> None:
+    tracker = KVarNMLALiveBlockTracker({0: (64, 128, 1, 1, 0, 1)})
+    request = SimpleNamespace(
+        block_ids=([0, 1, 2, 3],),
+        num_computed_tokens=194,
+    )
+    requests = {"a": request}
+
+    tracker.update(
+        requests,
+        {"a": 2},
+        (),
+        (),
+        rollback_tokens={"a": 4},
+    )
+    assert tracker.block_fills(0) == {
+        0: 64,
+        1: 64,
+        2: 64,
+        3: None,
+    }
+
+    tracker.resolve_async("a", request, actual_end_tokens=193)
+    tracker.update(requests, {}, (), ())
+    assert tracker.block_fills(0) == {
+        0: 64,
+        1: 64,
+        2: 64,
+        3: 1,
+    }
+
+    tracker.update(requests, {}, (), ())
+    assert tracker.block_fills(0) == {0: 64, 1: 64, 3: 1}
+
+
+def test_mla_unknown_rollback_block_retires_without_flush() -> None:
+    KVarNMLAStateManager._impls.clear()
+    KVarNMLAStateManager.reset_cache_bindings()
+    config = KVarNMLAConfig()
+    impl = _FakeMLAImpl()
+    KVarNMLAStateManager.register(impl)
+    group_key = ("layer.0",)
+
+    metadata = SimpleNamespace(kvarn_mla_block_fills={0: 64, 1: 64, 2: 64, 3: 64})
+    KVarNMLAStateManager.prepare_step(
+        group_key,
+        ["layer.0"],
+        metadata,
+        config,
+        dcp_world_size=1,
+    )
+    state = KVarNMLAStateManager._groups[group_key]
+    assert state.block_fill[3] == 64
+
+    metadata.kvarn_mla_block_fills[3] = None
+    KVarNMLAStateManager.prepare_step(
+        group_key,
+        ["layer.0"],
+        metadata,
+        config,
+        dcp_world_size=1,
+    )
+    assert 3 in state.mapping
+    assert 3 not in state.block_fill
+
+    metadata.kvarn_mla_block_fills = {0: 64, 1: 64, 2: 64}
+    KVarNMLAStateManager.prepare_step(
+        group_key,
+        ["layer.0"],
+        metadata,
+        config,
+        dcp_world_size=1,
+    )
+    assert 3 not in state.mapping
+    assert 3 not in impl.flushed
+
+    KVarNMLAStateManager._impls.clear()
+    KVarNMLAStateManager.reset_cache_bindings()
+
+
+def test_mla_live_tracker_maps_hybrid_dcp_blocks() -> None:
+    tracker = KVarNMLALiveBlockTracker({0: (64, 128, 4, 2, 1, 1)})
+    request = SimpleNamespace(
+        block_ids=([10],),
+        num_computed_tokens=0,
+    )
+
+    tracker.update({"request": request}, {"request": 225}, (), ())
+
+    assert tracker.block_fills(0) == {40: 64, 41: 48}
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_mla_fused_serializer_matches_reference(monkeypatch) -> None:
+    from vllm.v1.attention.ops.kvarn_mla import pack_kvarn_mla_blocks
+    from vllm.v1.attention.ops.triton_kvarn_sinkhorn import (
+        kvarn_sinkhorn_triton,
+    )
+
+    monkeypatch.delenv("KVARN_RTN_QUANTILE", raising=False)
+    monkeypatch.setenv("KVARN_AFFINE_REFIT", "1")
+    config = KVarNMLAConfig()
+    device = torch.device("cuda")
+    generator = torch.Generator(device=device).manual_seed(19)
+    latent_pool = torch.randn(
+        1,
+        config.group,
+        config.latent_dim,
+        dtype=torch.bfloat16,
+        device=device,
+        generator=generator,
+    ).to(torch.float8_e4m3fn)
+    rope_pool = torch.randn(
+        1,
+        config.group,
+        config.rope_dim,
+        dtype=torch.bfloat16,
+        device=device,
+        generator=generator,
+    )
+    latent_tiles = latent_pool.float().transpose(1, 2).contiguous()
+    balanced, s_col, s_row = kvarn_sinkhorn_triton(
+        latent_tiles,
+        iterations=config.sinkhorn_iters,
+    )
+    packed = kvarn_store_tile_k_batch_from_sinkhorn(
+        balanced,
+        s_col,
+        s_row,
+        bits=config.bits,
+    )
+    expected = torch.zeros(
+        1,
+        config.tile_bytes,
+        dtype=torch.uint8,
+        device=device,
+    )
+    expected[:, : config.latent_packed_bytes].copy_(
+        packed["q_packed_uint8"].reshape(1, -1)
+    )
+    expected[:, config.latent_s_col_offset : config.latent_zp_offset].copy_(
+        packed["s_col_K"].contiguous().view(torch.uint8)
+    )
+    expected[:, config.latent_zp_offset : config.latent_s_row_offset].copy_(
+        packed["zp_K"].contiguous().view(torch.uint8)
+    )
+    expected[:, config.latent_s_row_offset : config.rope_offset].copy_(
+        packed["s_row_K"].contiguous().view(torch.uint8)
+    )
+    expected[:, config.rope_offset :].copy_(
+        rope_pool.contiguous().view(torch.uint8).reshape(1, -1)
+    )
+
+    cache = torch.zeros(
+        1,
+        config.group,
+        config.bytes_per_token,
+        dtype=torch.uint8,
+        device=device,
+    )
+    block_ids = torch.zeros(1, dtype=torch.long, device=device)
+    pack_kvarn_mla_blocks(
+        cache,
+        latent_pool,
+        rope_pool,
+        block_ids,
+        block_ids,
+        config,
+    )
+
+    assert torch.equal(cache.view(torch.uint8).reshape(1, -1), expected)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_bf16_sparse_attention_writes_into_query_workspace() -> None:
+    from vllm.v1.attention.ops.xpu_mla_sparse import (
+        triton_bf16_mla_sparse_interface,
+    )
+
+    device = torch.device("cuda")
+    generator = torch.Generator(device=device).manual_seed(29)
+    q = torch.randn(
+        1,
+        8,
+        576,
+        dtype=torch.bfloat16,
+        device=device,
+        generator=generator,
+    )
+    kv = torch.randn(
+        16,
+        1,
+        576,
+        dtype=torch.bfloat16,
+        device=device,
+        generator=generator,
+    )
+    indices = torch.arange(16, dtype=torch.int32, device=device).view(1, 1, -1)
+    expected, _, _ = triton_bf16_mla_sparse_interface(
+        q,
+        kv,
+        indices,
+        sm_scale=576**-0.5,
+    )
+
+    q_workspace = q.clone()
+    out_workspace = q_workspace[..., :512]
+    actual, lse, max_logits = triton_bf16_mla_sparse_interface(
+        q_workspace,
+        kv,
+        indices,
+        sm_scale=576**-0.5,
+        out=out_workspace,
+        return_lse=False,
+        return_max_logits=False,
+    )
+
+    assert actual.data_ptr() == q_workspace.data_ptr()
+    assert lse.numel() == 1
+    assert max_logits.numel() == 1
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_mla_bounded_ownership_preserves_sink_and_current_payload() -> None:
+    from vllm.v1.attention.ops.kvarn_mla import materialize_selected_kvarn_mla
+
+    KVarNMLAStateManager._impls.clear()
+    KVarNMLAStateManager.reset_cache_bindings()
+    device = torch.device("cuda")
+    config = KVarNMLAConfig()
+
+    class PayloadImpl:
+        layer_name = "layer.0"
+        _is_kvarn_mla = True
+        _kvarn_group_key = None
+
+        def __init__(self) -> None:
+            pool_size = config.pool_slots(2, 256)
+            self.device = device
+            self._kvarn_latent_pool = torch.empty(
+                pool_size,
+                config.group,
+                config.latent_dim,
+                device=device,
+                dtype=torch.float8_e4m3fn,
+            )
+            self._kvarn_rope_pool = torch.empty(
+                pool_size,
+                config.group,
+                config.rope_dim,
+                device=device,
+                dtype=torch.bfloat16,
+            )
+            self._kvarn_pool_size = pool_size
+
+        def _flush_kvarn_mla_blocks(
+            self, block_ids: torch.Tensor, pool_slots: torch.Tensor
+        ) -> None:
+            raise AssertionError("live exact blocks must not be flushed")
+
+    impl = PayloadImpl()
+    KVarNMLAStateManager.register(impl)
+    cache = torch.zeros(
+        8,
+        config.group,
+        config.bytes_per_token,
+        device=device,
+        dtype=torch.uint8,
+    )
+
+    def prepare(
+        block_fills: dict[int, int],
+    ) -> tuple[dict[int, int], torch.Tensor]:
+        metadata = SimpleNamespace(kvarn_mla_block_fills=block_fills)
+        group_key = ("layer.0",)
+        KVarNMLAStateManager.prepare_step(
+            group_key, ["layer.0"], metadata, config, dcp_world_size=1
+        )
+        mirror = KVarNMLAStateManager.ensure_mirror(group_key, device, 8)
+        return dict(KVarNMLAStateManager._groups[group_key].mapping), mirror
+
+    def materialize(mirror: torch.Tensor) -> torch.Tensor:
+        selected = torch.cat(
+            (
+                torch.arange(0, 64, device=device, dtype=torch.int32),
+                torch.arange(192, 224, device=device, dtype=torch.int32),
+            )
+        ).view(1, -1)
+        dense = torch.empty(2, config.group, 576, device=device, dtype=torch.bfloat16)
+        remapped = torch.empty_like(selected)
+        materialize_selected_kvarn_mla(
+            selected,
+            cache,
+            mirror,
+            impl._kvarn_latent_pool,
+            impl._kvarn_rope_pool,
+            dense,
+            remapped,
+            config,
+        )
+        return dense.view(-1, 576).index_select(0, remapped.flatten())
+
+    live_a = {0: 64, 1: 64, 3: 32}
+    live_b = {4: 64, 5: 64, 7: 32}
+    mapping_a, mirror = prepare(live_a)
+    generator = torch.Generator(device=device).manual_seed(19)
+    for block_id in live_a:
+        slot = mapping_a[block_id]
+        impl._kvarn_latent_pool[slot].copy_(
+            torch.randn(
+                64, 512, device=device, dtype=torch.bfloat16, generator=generator
+            )
+        )
+        impl._kvarn_rope_pool[slot].copy_(
+            torch.randn(
+                64, 64, device=device, dtype=torch.bfloat16, generator=generator
+            )
+        )
+    before = materialize(mirror)
+
+    mapping_b, _ = prepare(live_a | live_b)
+    for block_id in live_b:
+        slot = mapping_b[block_id]
+        impl._kvarn_latent_pool[slot].fill_(3)
+        impl._kvarn_rope_pool[slot].fill_(3)
+    mapping_returned, mirror = prepare(live_a | live_b)
+    after = materialize(mirror)
+
+    assert {block_id: mapping_returned[block_id] for block_id in live_a} == mapping_a
+    assert torch.equal(after, before)
+
+    KVarNMLAStateManager._impls.clear()
+    KVarNMLAStateManager.reset_cache_bindings()
+
+
+def test_mla_materialization_returns_bf16_sparse_working_set(monkeypatch) -> None:
+    from vllm.v1.attention.backends.mla.b12x_mla_sparse import B12xMLASparseImpl
+    from vllm.v1.attention.ops import kvarn_mla
+
+    config = KVarNMLAConfig()
+    dense_cache = torch.empty(1, config.group, config.latent_dim + config.rope_dim)
+    remapped = torch.empty(1, 2, dtype=torch.int32)
+    impl = SimpleNamespace(
+        _kvarn_config=config,
+        _kvarn_block_to_slot=torch.zeros(1, dtype=torch.int32),
+        _kvarn_remapped_indices=remapped,
+        _kvarn_physical_slots=torch.arange(config.group, dtype=torch.int32),
+        _decode_max_rows=1,
+        _kvarn_latent_pool=torch.empty(1),
+        _kvarn_rope_pool=torch.empty(1),
+        _kvarn_dense_cache=dense_cache,
+    )
+
+    def fake_materialize(*args) -> None:
+        args[5].fill_(1)
+        args[6].copy_(torch.tensor([[0, 1]], dtype=torch.int32))
+
+    monkeypatch.setattr(kvarn_mla, "materialize_selected_kvarn_mla", fake_materialize)
+
+    cache, selected = B12xMLASparseImpl._materialize_kvarn_mla_cache(
+        impl,
+        torch.tensor([[3, 4]], dtype=torch.int32),
+        SimpleNamespace(),
+        torch.empty(1),
+    )
+
+    assert cache is dense_cache
+    assert torch.equal(selected, torch.tensor([[0, 1]], dtype=torch.int32))
+    assert torch.all(cache == 1)
+
+
+def test_mla_prefill_materializes_the_physical_page_arena(monkeypatch) -> None:
+    from vllm.v1.attention.backends.mla.b12x_mla_sparse import B12xMLASparseImpl
+    from vllm.v1.attention.ops import kvarn_mla
+
+    config = KVarNMLAConfig()
+    num_pages = 4
+    page_rows = num_pages * config.group
+    dense_cache = torch.empty(
+        num_pages, config.group, config.latent_dim + config.rope_dim
+    )
+    remapped = torch.empty(2, 2, dtype=torch.int32)
+    physical_slots = torch.arange(page_rows, dtype=torch.int32)
+    impl = SimpleNamespace(
+        _kvarn_config=config,
+        _kvarn_block_to_slot=torch.zeros(num_pages, dtype=torch.int32),
+        _kvarn_remapped_indices=remapped,
+        _kvarn_physical_slots=physical_slots,
+        _decode_max_rows=1,
+        _kvarn_latent_pool=torch.empty(1),
+        _kvarn_rope_pool=torch.empty(1),
+        _kvarn_dense_cache=dense_cache,
+    )
+    captured: dict[str, torch.Tensor] = {}
+
+    def fake_materialize_physical(*args) -> None:
+        captured["physical_slots"] = args[0]
+        args[6].fill_(1)
+        args[7].copy_(torch.tensor([[1, 2], [65, 66]], dtype=torch.int32))
+
+    monkeypatch.setattr(
+        kvarn_mla,
+        "materialize_physical_kvarn_mla",
+        fake_materialize_physical,
+    )
+
+    cache, selected = B12xMLASparseImpl._materialize_kvarn_mla_cache(
+        impl,
+        torch.tensor([[3, 4], [7, 8]], dtype=torch.int32),
+        SimpleNamespace(),
+        torch.empty(num_pages),
+    )
+
+    assert cache is dense_cache
+    assert captured["physical_slots"] is physical_slots
+    assert torch.equal(selected, torch.tensor([[1, 2], [65, 66]]))
+
+
+def test_mla_rejects_standard_kvarn_dtype() -> None:
+    with pytest.raises(ValueError, match="kvarn_mla_k5_g64"):
+        KVarNMLAConfig.from_cache_dtype("kvarn_k5v5_g64")

--- a/tests/v1/attention/test_kvarn.py
+++ b/tests/v1/attention/test_kvarn.py
@@ -312,6 +312,9 @@ class _FakeMLAImpl:
     _kvarn_group_key = None
     device = torch.device("cpu")
     _kvarn_pool_size = 32
+    _kvarn_cache_ref: object | None = None
+    _kvarn_latent_pool: object | None = None
+    _kvarn_rope_pool: object | None = None
 
     def __init__(self) -> None:
         self.flushed: list[int] = []
@@ -620,6 +623,176 @@ def test_mla_fused_serializer_matches_reference(monkeypatch) -> None:
     )
 
     assert torch.equal(cache.view(torch.uint8).reshape(1, -1), expected)
+
+
+def test_mla_reentry_rehydrates_only_flushed_blocks(monkeypatch) -> None:
+    import vllm.v1.attention.ops.kvarn_mla as kvarn_mla_ops
+
+    rehydrated: list[tuple[list[int], list[int]]] = []
+
+    def fake_rehydrate(
+        cache_ref, latent_pool, rope_pool, block_ids, pool_slots, config
+    ) -> None:
+        rehydrated.append((block_ids.tolist(), pool_slots.tolist()))
+
+    monkeypatch.setattr(kvarn_mla_ops, "rehydrate_kvarn_mla_blocks", fake_rehydrate)
+
+    KVarNMLAStateManager._impls.clear()
+    KVarNMLAStateManager.reset_cache_bindings()
+    config = KVarNMLAConfig()
+    impl = _FakeMLAImpl()
+    impl._kvarn_cache_ref = object()
+    impl._kvarn_latent_pool = object()
+    impl._kvarn_rope_pool = object()
+    KVarNMLAStateManager.register(impl)
+    group_key = ("layer.0",)
+
+    def prepare(block_fills: dict[int, int | None]) -> None:
+        metadata = SimpleNamespace(kvarn_mla_block_fills=block_fills)
+        KVarNMLAStateManager.prepare_step(
+            group_key,
+            ["layer.0"],
+            metadata,
+            config,
+            dcp_world_size=1,
+        )
+
+    # Own block 0 at full fill, then retire it: the retire-flush packs its
+    # rows into the paged record, so a later re-entry is restorable.
+    prepare({0: 64})
+    assert rehydrated == []
+    prepare({})
+    assert impl.flushed == [0]
+    assert KVarNMLAStateManager._groups[group_key].flushed == {0}
+
+    # A partial re-fill does not invalidate the packed copy yet, but retiring
+    # below full fill does: the record no longer matches the block content.
+    prepare({0: 32})
+    assert rehydrated == [([0], [KVarNMLAStateManager._groups[group_key].mapping[0]])]
+    prepare({})
+    assert KVarNMLAStateManager._groups[group_key].flushed == set()
+
+    # Re-entering a block without a valid packed copy must not rehydrate:
+    # every row it exposes is scattered by the acquiring step instead.
+    prepare({0: 64})
+    assert len(rehydrated) == 1
+
+    KVarNMLAStateManager._impls.clear()
+    KVarNMLAStateManager.reset_cache_bindings()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_mla_rehydrate_restores_recycled_slot_from_packed_record(
+    monkeypatch,
+) -> None:
+    from vllm.v1.attention.ops.kvarn_mla import (
+        pack_kvarn_mla_blocks,
+        rehydrate_kvarn_mla_blocks,
+    )
+
+    monkeypatch.delenv("KVARN_RTN_QUANTILE", raising=False)
+    monkeypatch.setenv("KVARN_AFFINE_REFIT", "1")
+    config = KVarNMLAConfig()
+    device = torch.device("cuda")
+    generator = torch.Generator(device=device).manual_seed(41)
+    latent_pool = (
+        torch.randn(
+            2,
+            config.group,
+            config.latent_dim,
+            dtype=torch.bfloat16,
+            device=device,
+            generator=generator,
+        )
+        .to(torch.float8_e4m3fn)
+        .to(torch.bfloat16)
+    )
+    rope_pool = torch.randn(
+        2,
+        config.group,
+        config.rope_dim,
+        dtype=torch.bfloat16,
+        device=device,
+        generator=generator,
+    )
+    rope_source = rope_pool[0].clone()
+    cache = torch.zeros(
+        4,
+        config.group,
+        config.bytes_per_token,
+        dtype=torch.uint8,
+        device=device,
+    )
+    block_ids = torch.tensor([2], dtype=torch.long, device=device)
+    pool_slots = torch.tensor([0], dtype=torch.long, device=device)
+    pack_kvarn_mla_blocks(
+        cache,
+        latent_pool,
+        rope_pool,
+        block_ids,
+        pool_slots,
+        config,
+    )
+
+    # Recycle the slot: the pool row now belongs to another block, as when a
+    # LIFO free-list hands a retired slot to a prefix-cache-hit block.
+    other = torch.Generator(device=device).manual_seed(97)
+    latent_pool[0] = torch.randn(
+        config.group,
+        config.latent_dim,
+        dtype=torch.bfloat16,
+        device=device,
+        generator=other,
+    )
+    rope_pool[0] = torch.randn(
+        config.group,
+        config.rope_dim,
+        dtype=torch.bfloat16,
+        device=device,
+        generator=other,
+    )
+
+    rehydrate_kvarn_mla_blocks(
+        cache,
+        latent_pool,
+        rope_pool,
+        block_ids,
+        pool_slots,
+        config,
+    )
+
+    # RoPE is serialized losslessly (BF16 copy) and must match exactly.
+    assert torch.equal(rope_pool[0], rope_source)
+
+    # Latent round-trips the 5-bit packed record: compare against the same
+    # dequantization computed directly from the packed bytes.
+    flat = cache.reshape(cache.shape[0], -1)[2]
+    value_indices = torch.arange(config.latent_dim * config.group, device=device)
+    bit_offsets = value_indices * config.bits
+    lo = flat[bit_offsets // 8].to(torch.int64)
+    hi = flat[bit_offsets // 8 + 1].to(torch.int64)
+    q = ((lo | (hi << 8)) >> (bit_offsets % 8)) & ((1 << config.bits) - 1)
+    q = q.reshape(config.latent_dim, config.group).float()
+    s_col = (
+        flat[config.latent_s_col_offset : config.latent_zp_offset]
+        .view(torch.float16)
+        .float()
+    )
+    zp = (
+        flat[config.latent_zp_offset : config.latent_s_row_offset]
+        .view(torch.float16)
+        .float()
+    )
+    s_row = (
+        flat[config.latent_s_row_offset : config.rope_offset]
+        .view(torch.float16)
+        .float()
+    )
+    expected = ((q * s_col.unsqueeze(1) + zp.unsqueeze(1)) * s_row.unsqueeze(0)).t()
+    assert torch.equal(
+        latent_pool[0],
+        expected.to(torch.bfloat16),
+    )
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")

--- a/tests/v1/attention/test_kvarn_v2.py
+++ b/tests/v1/attention/test_kvarn_v2.py
@@ -1,0 +1,290 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from dataclasses import fields
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.quantization.kvarn.config import KVarNMLAConfig
+from vllm.v1.attention.backends.mla.b12x_mla_sparse import (
+    B12xMLASparseImpl,
+    _kvarn_mla_workspace_envelope,
+)
+from vllm.v1.attention.ops.kvarn_mla import (
+    materialize_physical_kvarn_mla,
+    materialize_selected_kvarn_mla,
+    remap_kvarn_mla_physical_indices,
+    scatter_kvarn_mla_exact,
+)
+
+
+def test_mla_config_has_fixed_page_and_pool_geometry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("KVARN_TAIL_DTYPE", "invalid-legacy-value")
+
+    config = KVarNMLAConfig.from_cache_dtype("kvarn_mla_k5_g64")
+
+    assert "tail_dtype" not in {field.name for field in fields(config)}
+    assert not hasattr(config, "tail_slot_bytes")
+    assert config.group == 64
+    assert config.latent_dim == 512
+    assert config.rope_dim == 64
+    assert config.tile_bytes == 30_848
+    assert config.bytes_per_token == 482
+    assert config.pool_slot_bytes == 40_960
+    assert config.pool_slot_bytes == config.group * (
+        config.latent_dim + config.rope_dim * 2
+    )
+
+
+def test_mla_config_rejects_non_mla_kvarn_dtype() -> None:
+    with pytest.raises(ValueError, match="kvarn_mla_k5_g64"):
+        KVarNMLAConfig.from_cache_dtype("kvarn_k5v5_g64")
+
+
+def test_mla_workspace_is_bounded_by_allocated_pages() -> None:
+    envelope = _kvarn_mla_workspace_envelope(
+        num_kv_pages=4_097,
+        group_size=64,
+        latent_dim=512,
+        rope_dim=64,
+        max_batched_tokens=4_096,
+        max_active_rows=40,
+        topk_tokens=2_048,
+        boundary_blocks=8,
+        rollback_blocks=9,
+    )
+
+    assert envelope.dense_rows == 262_208
+    assert envelope.remap_elements == 8_388_608
+    assert envelope.rotation_rows == 4_096
+    assert envelope.physical_slot_rows == 262_208
+    assert envelope.dense_bytes == 302_063_616
+    assert envelope.total_bytes == 340_861_184
+    assert envelope.dense_bytes != 2_416_508_928
+
+
+def test_mla_workspace_uses_stable_physical_page_rows_and_resets() -> None:
+    config = KVarNMLAConfig()
+
+    class FakeImpl:
+        _is_kvarn_mla = True
+        device = torch.device("cpu")
+        _kvarn_config = config
+        _vllm_config = SimpleNamespace(
+            scheduler_config=SimpleNamespace(
+                max_num_batched_tokens=8,
+                max_num_seqs=1,
+                async_scheduling=False,
+            ),
+            speculative_config=None,
+            model_config=SimpleNamespace(
+                hf_config=SimpleNamespace(index_topk=4),
+            ),
+        )
+        _max_batched = 8
+        _decode_max_rows = 1
+        topk_tokens = 4
+        _kvarn_boundary_blocks = 1
+        _kvarn_rollback_blocks = 0
+        _kvarn_dense_cache = None
+        _kvarn_remapped_indices = None
+        _kvarn_rotated_scratch = None
+        _kvarn_physical_slots = None
+
+    impl = FakeImpl()
+    B12xMLASparseImpl._kvarn_instances.add(impl)
+    B12xMLASparseImpl.initialize_kvarn_workspaces(3, impl.device)
+
+    assert impl._kvarn_dense_cache is not None
+    assert impl._kvarn_remapped_indices is not None
+    assert impl._kvarn_rotated_scratch is not None
+    assert impl._kvarn_physical_slots is not None
+    assert impl._kvarn_dense_cache.shape == (3, 64, 576)
+    assert impl._kvarn_remapped_indices.shape == (8, 4)
+    assert impl._kvarn_rotated_scratch.shape == (8, 512)
+    torch.testing.assert_close(
+        impl._kvarn_physical_slots,
+        torch.arange(192, dtype=torch.int32),
+    )
+    physical_ptr = impl._kvarn_physical_slots.data_ptr()
+    B12xMLASparseImpl.initialize_kvarn_workspaces(3, impl.device)
+    assert impl._kvarn_physical_slots.data_ptr() == physical_ptr
+
+    B12xMLASparseImpl.reset_kv_cache_binding_state()
+    assert impl._kvarn_dense_cache is None
+    assert impl._kvarn_remapped_indices is None
+    assert impl._kvarn_rotated_scratch is None
+    assert impl._kvarn_physical_slots is None
+    assert not B12xMLASparseImpl._kvarn_shared_dense
+    assert not B12xMLASparseImpl._kvarn_shared_physical_slots
+
+
+def test_mla_operation_workspaces_reject_invalid_shapes_and_types() -> None:
+    config = KVarNMLAConfig()
+    cache = torch.empty(1, 64, config.bytes_per_token, dtype=torch.uint8)
+    block_to_slot = torch.zeros(1, dtype=torch.int32)
+    latent_pool = torch.empty(1, 64, 512, dtype=torch.float8_e4m3fn)
+    rope_pool = torch.empty(1, 64, 64, dtype=torch.bfloat16)
+    output = torch.empty(1, 64, 576, dtype=torch.bfloat16)
+    remapped = torch.empty(1, dtype=torch.int32)
+
+    with pytest.raises(ValueError, match="selected indices"):
+        materialize_selected_kvarn_mla(
+            torch.zeros(1, dtype=torch.int64),
+            cache,
+            block_to_slot,
+            latent_pool,
+            rope_pool,
+            output,
+            remapped,
+            config,
+        )
+    with pytest.raises(ValueError, match="physical-slot workspace"):
+        materialize_physical_kvarn_mla(
+            torch.arange(63, dtype=torch.int32),
+            torch.zeros(1, dtype=torch.int32),
+            cache,
+            block_to_slot,
+            latent_pool,
+            rope_pool,
+            output,
+            remapped,
+            config,
+        )
+    with pytest.raises(ValueError, match="physical index buffers"):
+        remap_kvarn_mla_physical_indices(
+            torch.zeros(1, dtype=torch.int64),
+            remapped,
+            max_physical_slots=64,
+        )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_exact_scatter_cannot_write_through_invalid_block_or_pool_indices() -> None:
+    device = torch.device("cuda")
+    config = KVarNMLAConfig()
+    latent = torch.ones(
+        4,
+        config.latent_dim,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    rope = torch.full(
+        (4, config.rope_dim),
+        2,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    slot_mapping = torch.tensor([5, 64, 128, 192], dtype=torch.int32, device=device)
+    block_to_slot = torch.tensor([0, 2, -1], dtype=torch.int32, device=device)
+    latent_pool = torch.zeros(
+        2,
+        config.group,
+        config.latent_dim,
+        dtype=torch.float8_e4m3fn,
+        device=device,
+    )
+    rope_pool = torch.zeros(
+        2,
+        config.group,
+        config.rope_dim,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+
+    scatter_kvarn_mla_exact(
+        latent,
+        rope,
+        slot_mapping,
+        block_to_slot,
+        latent_pool,
+        rope_pool,
+    )
+
+    torch.testing.assert_close(latent_pool[0, 5], latent[0].to(torch.float8_e4m3fn))
+    torch.testing.assert_close(rope_pool[0, 5], rope[0])
+    assert torch.count_nonzero(latent_pool[1]) == 0
+    assert torch.count_nonzero(rope_pool[1]) == 0
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_selected_materialization_bounds_pool_and_cache_indices() -> None:
+    device = torch.device("cuda")
+    config = KVarNMLAConfig()
+    cache = torch.zeros(
+        1,
+        config.group,
+        config.bytes_per_token,
+        dtype=torch.uint8,
+        device=device,
+    )
+    block_to_slot = torch.tensor([2], dtype=torch.int32, device=device)
+    latent_pool = torch.ones(
+        1,
+        config.group,
+        config.latent_dim,
+        dtype=torch.float8_e4m3fn,
+        device=device,
+    )
+    rope_pool = torch.ones(
+        1,
+        config.group,
+        config.rope_dim,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    selected = torch.tensor(
+        [[0, 63, 64, -1]],
+        dtype=torch.int32,
+        device=device,
+    )
+    output = torch.full(
+        (4, config.latent_dim + config.rope_dim),
+        7,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    remapped = torch.empty_like(selected)
+
+    materialize_selected_kvarn_mla(
+        selected,
+        cache,
+        block_to_slot,
+        latent_pool,
+        rope_pool,
+        output,
+        remapped,
+        config,
+    )
+
+    torch.testing.assert_close(output[:2], torch.zeros_like(output[:2]))
+    torch.testing.assert_close(output[2:], torch.full_like(output[2:], 7))
+    torch.testing.assert_close(
+        remapped.cpu(),
+        torch.tensor([[0, 1, -1, -1]], dtype=torch.int32),
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_physical_remap_rejects_out_of_arena_indices() -> None:
+    selected = torch.tensor(
+        [[0, 63, 64, -1]],
+        dtype=torch.int32,
+        device="cuda",
+    )
+    remapped = torch.empty_like(selected)
+
+    remap_kvarn_mla_physical_indices(
+        selected,
+        remapped,
+        max_physical_slots=64,
+    )
+
+    torch.testing.assert_close(
+        remapped.cpu(),
+        torch.tensor([[0, 63, -1, -1]], dtype=torch.int32),
+    )

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -46,6 +46,7 @@ from vllm.v1.kv_cache_interface import (
     ChunkedLocalAttentionSpec,
     FullAttentionSpec,
     HiddenStateCacheSpec,
+    KVarNFullAttentionSpec,
     KVCacheConfig,
     KVCacheGroupSpec,
     KVCacheSpec,
@@ -1905,6 +1906,172 @@ def test_resolve_kv_cache_block_sizes_ignores_virtual_pcp():
     assert kv_cache_utils.resolve_kv_cache_block_sizes(
         kv_cache_config, vllm_config
     ) == (512, 512)
+
+
+def _make_kvarn_mla_sizing_config() -> SimpleNamespace:
+    return SimpleNamespace(
+        scheduler_config=SimpleNamespace(
+            max_num_batched_tokens=128,
+            max_num_seqs=8,
+            async_scheduling=False,
+        ),
+        speculative_config=None,
+        model_config=SimpleNamespace(hf_config=SimpleNamespace(index_topk=32)),
+        parallel_config=SimpleNamespace(
+            decode_context_parallel_size=1,
+            prefill_context_parallel_size=1,
+        ),
+        cache_config=SimpleNamespace(num_gpu_blocks_override=None),
+        kv_transfer_config=None,
+    )
+
+
+def _kvarn_mla_sizing_spec(head_size: int = 576) -> MLAAttentionSpec:
+    return MLAAttentionSpec(
+        block_size=64,
+        num_kv_heads=1,
+        head_size=head_size,
+        dtype=torch.uint8,
+        cache_dtype_str="kvarn_mla_k5_g64",
+    )
+
+
+def test_kvarn_mla_workspace_sizing_exact_fit_and_one_page_over() -> None:
+    from vllm.model_executor.layers.quantization.kvarn.config import KVarNMLAConfig
+
+    vllm_config = _make_kvarn_mla_sizing_config()
+    spec = _kvarn_mla_sizing_spec()
+    groups = [KVCacheGroupSpec(["layer.0", "layer.1"], spec)]
+    packed_bytes_per_block = 2 * spec.page_size_bytes
+    workspace_config = KVarNMLAConfig.from_cache_dtype(spec.cache_dtype_str)
+
+    def required_bytes(num_blocks: int) -> int:
+        return (
+            packed_bytes_per_block * num_blocks
+            + workspace_config.workspace_envelope(vllm_config, num_blocks).total_bytes
+        )
+
+    exact_13 = kv_cache_utils.get_kv_cache_config_from_groups(
+        vllm_config, groups, required_bytes(13)
+    )
+    one_byte_short_of_14 = kv_cache_utils.get_kv_cache_config_from_groups(
+        vllm_config, groups, required_bytes(14) - 1
+    )
+    exact_14 = kv_cache_utils.get_kv_cache_config_from_groups(
+        vllm_config, groups, required_bytes(14)
+    )
+
+    assert exact_13.num_blocks == 13
+    assert one_byte_short_of_14.num_blocks == 13
+    assert exact_14.num_blocks == 14
+    assert sum(tensor.size for tensor in exact_14.kv_cache_tensors) + (
+        workspace_config.workspace_envelope(
+            vllm_config, exact_14.num_blocks
+        ).total_bytes
+    ) == required_bytes(14)
+
+
+def test_kvarn_mla_workspace_is_charged_once_for_all_local_layers() -> None:
+    from vllm.model_executor.layers.quantization.kvarn.config import KVarNMLAConfig
+
+    vllm_config = _make_kvarn_mla_sizing_config()
+    spec = _kvarn_mla_sizing_spec()
+    groups = [KVCacheGroupSpec(["layer.0", "layer.1", "layer.2"], spec)]
+    num_blocks = 17
+    packed_bytes = len(groups[0].layer_names) * spec.page_size_bytes * num_blocks
+    workspace_bytes = (
+        KVarNMLAConfig.from_cache_dtype(spec.cache_dtype_str)
+        .workspace_envelope(vllm_config, num_blocks)
+        .total_bytes
+    )
+
+    config = kv_cache_utils.get_kv_cache_config_from_groups(
+        vllm_config, groups, packed_bytes + workspace_bytes
+    )
+
+    assert config.num_blocks == num_blocks
+
+
+def test_kvarn_mla_ngram_override_requires_combined_budget() -> None:
+    from vllm.model_executor.layers.quantization.kvarn.config import KVarNMLAConfig
+
+    vllm_config = _make_kvarn_mla_sizing_config()
+    vllm_config.speculative_config = SimpleNamespace(
+        method="ngram", num_speculative_tokens=3
+    )
+    vllm_config.cache_config.num_gpu_blocks_override = 9
+    spec = _kvarn_mla_sizing_spec()
+    groups = [KVCacheGroupSpec(["layer.0"], spec)]
+    workspace_bytes = (
+        KVarNMLAConfig.from_cache_dtype(spec.cache_dtype_str)
+        .workspace_envelope(vllm_config, 9)
+        .total_bytes
+    )
+    required_bytes = 9 * spec.page_size_bytes + workspace_bytes
+
+    config = kv_cache_utils.get_kv_cache_config_from_groups(
+        vllm_config, groups, required_bytes
+    )
+    assert config.num_blocks == 9
+
+    with pytest.raises(ValueError, match="num_gpu_blocks_override=9 requires"):
+        kv_cache_utils.get_kv_cache_config_from_groups(
+            vllm_config, groups, required_bytes - 1
+        )
+
+
+def test_kvarn_mla_rejects_incompatible_shared_workspace_geometries() -> None:
+    vllm_config = _make_kvarn_mla_sizing_config()
+    groups = [
+        KVCacheGroupSpec(["layer.0"], _kvarn_mla_sizing_spec()),
+        KVCacheGroupSpec(["layer.1"], _kvarn_mla_sizing_spec(head_size=640)),
+    ]
+
+    with pytest.raises(ValueError, match="multiple incompatible cache geometries"):
+        kv_cache_utils.get_kv_cache_config_from_groups(
+            vllm_config, groups, available_memory=1_000_000_000
+        )
+
+
+def test_non_kvarn_page_count_does_not_reserve_mla_workspace() -> None:
+    vllm_config = _make_kvarn_mla_sizing_config()
+    spec = MLAAttentionSpec(
+        block_size=64,
+        num_kv_heads=1,
+        head_size=576,
+        dtype=torch.uint8,
+    )
+    groups = [KVCacheGroupSpec(["layer.0", "layer.1"], spec)]
+    bytes_per_block = len(groups[0].layer_names) * spec.page_size_bytes
+
+    config = kv_cache_utils.get_kv_cache_config_from_groups(
+        vllm_config,
+        groups,
+        available_memory=23 * bytes_per_block + bytes_per_block - 1,
+    )
+
+    assert config.num_blocks == 23
+
+
+def test_generic_kvarn_page_count_does_not_reserve_mla_workspace() -> None:
+    vllm_config = _make_kvarn_mla_sizing_config()
+    spec = KVarNFullAttentionSpec(
+        block_size=64,
+        num_kv_heads=2,
+        head_size=128,
+        dtype=torch.uint8,
+        tile_size=11392,
+    )
+    groups = [KVCacheGroupSpec(["layer.0", "layer.1"], spec)]
+    bytes_per_block = len(groups[0].layer_names) * spec.page_size_bytes
+
+    config = kv_cache_utils.get_kv_cache_config_from_groups(
+        vllm_config,
+        groups,
+        available_memory=11 * bytes_per_block + bytes_per_block - 1,
+    )
+
+    assert config.num_blocks == 11
 
 
 def test_replicated_mla_uses_lockstep_pool_capacity_and_contiguous_tensors():

--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -35,6 +35,10 @@ CacheDType = Literal[
     "fp8_per_token_head",
     "nvfp4",
     "nvfp4_4over6",
+    "kvarn_k4v2_g128",
+    "kvarn_k4v4_g128",
+    "kvarn_k5v5_g64",
+    "kvarn_mla_k5_g64",
 ]
 MambaDType = Literal["auto", "float32", "float16", "bfloat16"]
 MambaCacheMode = Literal["all", "align", "none"]

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -2435,6 +2435,14 @@ class VllmConfig:
         if model_config is not None and model_config.enable_prompt_embeds:
             unsupported.append("prompt embeds")
 
+        cache_dtype = self.cache_config.cache_dtype
+        if (
+            isinstance(cache_dtype, str)
+            and cache_dtype.startswith("kvarn_")
+            and cache_dtype != "kvarn_mla_k5_g64"
+        ):
+            unsupported.append("KVarN KV cache")
+
         if self.cache_config.kv_sharing_fast_prefill:
             # Will be added by https://github.com/vllm-project/vllm/pull/35045
             unsupported.append("KV sharing fast prefill")

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -420,6 +420,7 @@ class Attention(nn.Module, AttentionLayerBase):
             kv_sharing_target_layer_name,
             **extra_impl_args,
         )
+        self.impl.layer_name = prefix  # type: ignore[attr-defined]
         self.backend = AttentionBackendEnum[self.attn_backend.get_name()]
         self.dtype = dtype
 
@@ -607,7 +608,27 @@ class Attention(nn.Module, AttentionLayerBase):
         # Should not be called for enc-dec attention.
         assert self.attn_type == AttentionType.DECODER
         quant_mode = get_kv_quant_mode(self.kv_cache_dtype)
-        if self.sliding_window is not None:
+        if self.sliding_window is not None and self.kv_cache_dtype.startswith("kvarn_"):
+            from vllm.model_executor.layers.quantization.kvarn.config import (
+                KVarNConfig,
+            )
+            from vllm.v1.kv_cache_interface import KVarNSlidingWindowSpec
+
+            kvarn_config = KVarNConfig.from_cache_dtype(
+                self.kv_cache_dtype, self.head_size
+            )
+            return KVarNSlidingWindowSpec(
+                block_size=block_size,
+                num_kv_heads=self.num_kv_heads,
+                head_size=self.head_size,
+                head_size_v=self.head_size_v,
+                dtype=self.kv_cache_torch_dtype,
+                sliding_window=self.sliding_window,
+                tile_size=kvarn_config.tile_bytes_aligned,
+                quant_group_size=kvarn_config.group,
+            )
+
+        elif self.sliding_window is not None:
             assert not self.attn_backend.is_mla(), (
                 "MLA is not supported for sliding window"
             )
@@ -658,6 +679,24 @@ class Attention(nn.Module, AttentionLayerBase):
                 dtype=self.kv_cache_torch_dtype,
                 kv_quant_mode=quant_mode,
                 tq_slot_size=tq_config.slot_size_aligned,
+            )
+        elif self.kv_cache_dtype.startswith("kvarn_"):
+            from vllm.model_executor.layers.quantization.kvarn.config import (
+                KVarNConfig,
+            )
+            from vllm.v1.kv_cache_interface import KVarNFullAttentionSpec
+
+            kvarn_config = KVarNConfig.from_cache_dtype(
+                self.kv_cache_dtype, self.head_size
+            )
+            return KVarNFullAttentionSpec(
+                block_size=block_size,
+                num_kv_heads=self.num_kv_heads,
+                head_size=self.head_size,
+                head_size_v=self.head_size_v,
+                dtype=self.kv_cache_torch_dtype,
+                tile_size=kvarn_config.tile_bytes_aligned,
+                quant_group_size=kvarn_config.group,
             )
         else:
             return FullAttentionSpec(

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -598,6 +598,8 @@ def _canonicalize_sparse_mla_kv_cache_dtype(
     kv_cache_dtype: CacheDType,
 ) -> CacheDType:
     backend_name = attn_backend.get_name()
+    if backend_name == "B12X_MLA_SPARSE" and kv_cache_dtype == "kvarn_mla_k5_g64":
+        return kv_cache_dtype
     if backend_name == "B12X_MLA_SPARSE" and kv_cache_dtype == "nvfp4_ds_mla":
         # B12X reads the packed 432B NVFP4 MLA record natively; do NOT coerce
         # it to fp8_ds_mla. [nvfp4_reader_port]
@@ -793,6 +795,7 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             indexer=indexer,
             **extra_impl_args,
         )
+        self.impl.layer_name = prefix  # type: ignore[attr-defined]
         self.q_pad_num_heads = getattr(self.impl, "q_pad_num_heads", None)
         self.use_safe_mla_query_bmm = getattr(
             self.impl, "use_safe_mla_query_bmm", False
@@ -1267,7 +1270,11 @@ class MLAAttention(nn.Module, AttentionLayerBase):
         k_c_normed = k_c_normed[:num_actual_toks, ...]
         k_pe = k_pe[:num_actual_toks, ...]
 
-        if fp8_attention and self.kv_cache_dtype not in ("fp8_ds_mla", "nvfp4_ds_mla"):
+        if (
+            fp8_attention
+            and not self.kv_cache_dtype.startswith("kvarn_")
+            and self.kv_cache_dtype not in ("fp8_ds_mla", "nvfp4_ds_mla")
+        ):
             kv_cache = kv_cache.view(current_platform.fp8_dtype())
 
         assert (
@@ -1298,6 +1305,7 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             )
             use_mha = (use_dense_mha or use_masked_mha) and not (
                 self._vllm_config.attention_config.sparse_mla_force_mqa
+                or self.kv_cache_dtype.startswith("kvarn_")
             )
             if not use_mha:
                 num_mqa_tokens = q.size(0)

--- a/vllm/model_executor/layers/quantization/kvarn/__init__.py
+++ b/vllm/model_executor/layers/quantization/kvarn/__init__.py
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""KVarN variance-normalized KV-cache quantization.
+
+Hadamard rotation and iterative log-domain variance normalization precede
+dense little-endian K5/V5 packing. Keys are quantized per channel and values
+per token. Completed history is packed while sink and recent tiles remain in
+an FP8 precision-tail pool by default.
+"""
+
+from vllm.model_executor.layers.quantization.kvarn.config import KVarNConfig
+
+__all__ = ["KVarNConfig"]

--- a/vllm/model_executor/layers/quantization/kvarn/config.py
+++ b/vllm/model_executor/layers/quantization/kvarn/config.py
@@ -1,0 +1,683 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""KVarN configuration."""
+
+import math
+import os
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, ClassVar
+
+from vllm.logger import init_logger
+
+if TYPE_CHECKING:
+    from vllm.config import VllmConfig
+
+# Named KVarN presets: each maps to a frozen set of config parameters.
+# The trailing g<N> encodes the variance-normalization tile size, which must
+# equal the vLLM block size. g128 is the current design point; g64 trades a
+# little compression (more per-tile scale overhead per token) for finer
+# quantization granularity (each tile's scales adapt to fewer tokens).
+#
+# Bit-width is fully parameterized in the quantizer and kernels (key_bits /
+# value_bits), and the tile size flows through cfg.group everywhere (storage
+# layout, Triton GROUP constexpr, flush / slot math), so additional presets are
+# a one-line addition here. Keys carry more quantization sensitivity than values
+# (key error propagates through the softmax exponentials, value error is averaged
+# out by the softmax weights), so the shipped preset spends more bits on keys.
+KVARN_PRESETS: dict[str, dict[str, int]] = {
+    "kvarn_k4v2_g128": {"key_bits": 4, "value_bits": 2, "group": 128},
+    "kvarn_k4v4_g128": {"key_bits": 4, "value_bits": 4, "group": 128},
+    "kvarn_k4v2_g64": {"key_bits": 4, "value_bits": 2, "group": 64},
+    "kvarn_k4v4_g64": {"key_bits": 4, "value_bits": 4, "group": 64},
+    "kvarn_k5v5_g64": {"key_bits": 5, "value_bits": 5, "group": 64},
+}
+
+DEFAULT_KVARN_TAIL_TOKENS = 1024
+DEFAULT_KVARN_K5V5_TAIL_TOKENS = 0
+DEFAULT_KVARN_TAIL_DTYPE = "float16"
+
+logger = init_logger(__name__)
+
+_MLA_SPEC_DECODE_MAX_Q_ENV = "VLLM_B12X_MLA_SPEC_DECODE_MAX_Q"
+_MLA_SPEC_EXTEND_MODE_ENV = "VLLM_B12X_MLA_SPEC_EXTEND_AS_DECODE"
+_BF16_BYTES = 2
+_INT32_BYTES = 4
+
+
+def _cdiv(value: int, divisor: int) -> int:
+    return (value + divisor - 1) // divisor
+
+
+@dataclass(frozen=True)
+class KVarNMLAWorkspaceEnvelope:
+    dense_rows: int
+    remap_elements: int
+    rotation_rows: int
+    physical_slot_rows: int
+    dense_bytes: int
+    total_bytes: int
+
+
+def kvarn_mla_workspace_envelope(
+    *,
+    num_kv_pages: int,
+    group_size: int,
+    latent_dim: int,
+    rope_dim: int,
+    max_batched_tokens: int,
+    max_active_rows: int,
+    topk_tokens: int,
+    boundary_blocks: int,
+    rollback_blocks: int,
+) -> KVarNMLAWorkspaceEnvelope:
+    """Return the shared dense-workspace envelope for one local worker."""
+    positive = {
+        "num_kv_pages": num_kv_pages,
+        "group_size": group_size,
+        "latent_dim": latent_dim,
+        "rope_dim": rope_dim,
+        "max_batched_tokens": max_batched_tokens,
+        "max_active_rows": max_active_rows,
+        "topk_tokens": topk_tokens,
+    }
+    invalid = {name: value for name, value in positive.items() if value <= 0}
+    if boundary_blocks < 0 or rollback_blocks < 0:
+        invalid.update(
+            boundary_blocks=boundary_blocks,
+            rollback_blocks=rollback_blocks,
+        )
+    if invalid:
+        raise ValueError(f"Invalid KVarN MLA workspace dimensions: {invalid}")
+
+    page_rows = num_kv_pages * group_size
+    selected_rows = max_active_rows * topk_tokens
+    transient_rows = (
+        _cdiv(max_batched_tokens, group_size) + boundary_blocks + rollback_blocks
+    ) * group_size
+    dense_rows = (
+        _cdiv(max(page_rows, selected_rows, transient_rows), group_size) * group_size
+    )
+    remap_elements = max_batched_tokens * topk_tokens
+    dense_bytes = dense_rows * (latent_dim + rope_dim) * _BF16_BYTES
+    total_bytes = (
+        dense_bytes
+        + remap_elements * _INT32_BYTES
+        + max_batched_tokens * latent_dim * _BF16_BYTES
+        + page_rows * _INT32_BYTES
+    )
+    return KVarNMLAWorkspaceEnvelope(
+        dense_rows=dense_rows,
+        remap_elements=remap_elements,
+        rotation_rows=max_batched_tokens,
+        physical_slot_rows=page_rows,
+        dense_bytes=dense_bytes,
+        total_bytes=total_bytes,
+    )
+
+
+def _positive_env_int(name: str, default: int) -> int:
+    value = os.getenv(name)
+    if value is None or value == "":
+        return default
+    try:
+        parsed = int(value)
+    except ValueError:
+        logger.warning("Ignoring invalid %s=%r; using %d", name, value, default)
+        return default
+    if parsed <= 0:
+        logger.warning("Ignoring non-positive %s=%r; using %d", name, value, default)
+        return default
+    return parsed
+
+
+def _kvarn_mla_decode_settings() -> tuple[int, bool, bool]:
+    spec_decode_max_q = _positive_env_int(_MLA_SPEC_DECODE_MAX_Q_ENV, 8)
+    mode = os.getenv(_MLA_SPEC_EXTEND_MODE_ENV, "auto").strip().lower()
+    disabled_modes = {"0", "false", "off", "no"}
+    forced_modes = {"1", "true", "on", "yes"}
+    if mode not in {"auto", *disabled_modes, *forced_modes}:
+        raise ValueError(
+            f"{_MLA_SPEC_EXTEND_MODE_ENV} must be auto, 0, or 1 (got {mode!r})"
+        )
+    return spec_decode_max_q, mode not in disabled_modes, mode in forced_modes
+
+
+@dataclass
+class KVarNConfig:
+    """Configuration for KVarN KV-cache quantization.
+
+    Pipeline per (block, head):
+      1. Hadamard rotation along head_dim (orthonormal, applied via external GEMM).
+      2. Iterative log-domain variance-normalization (Sinkhorn-like) over the
+         [D, group] tile for K (per-channel orientation) and [group, D] tile for
+         V (per-token orientation).
+      3. Asymmetric per-row RTN at `key_bits` / `value_bits`.
+      4. Absorb the per-row RTN scale and zero-point into the matching
+         sinkhorn scale axis (K: into per-channel; V: into per-token-in-tile).
+         Reconstruction: ``x = (q * absorbed_scale + absorbed_zp) * other_scale``.
+
+    Cache layout (per (block, head)) is a single packed record — see the
+    backend's `get_kv_cache_shape` override. There is no per-token slot
+    because the scales are tile-shared; the block boundary IS the tile.
+
+    Args:
+        head_dim: Attention head dimension (power of 2; tested at 128).
+        key_bits: Bits per key element (default 4).
+        value_bits: Bits per value element (default 4).
+        group: KVarN tile size in tokens. Must equal vLLM block_size so that
+            one vLLM block = one KVarN tile per head.
+        sinkhorn_iters: Iterations of the alternating column/row std-norm in
+            the variance-normalization loop (default 8; lossless vs 16).
+        boundary_skip_layers: Number of leading / trailing transformer layers
+            to keep in fp16 (KVarN's sink/residual analogue). Default 2 mirrors
+            TurboQuant's default.
+    """
+
+    head_dim: int = 128
+    key_bits: int = 4
+    value_bits: int = 4
+    group: int = 128
+    # converges by ~4 iters; 8 lossless vs 16 (validated Qwen3-4B + Qwen3.6-27B AIME)
+    sinkhorn_iters: int = 8
+    sink_tokens: int = 128  # leading tokens retained in the precision tail
+    precision_tail_tokens: int = DEFAULT_KVARN_TAIL_TOKENS
+    """Most-recent tokens retained in the higher-precision side pool."""
+    tail_dtype: str = DEFAULT_KVARN_TAIL_DTYPE
+    boundary_skip_layers: int = (
+        0  # layer-level skipping off by default; sink_tokens replaces it
+    )
+
+    # ── derived: storage layout ──────────────────────────────────────────────
+    @property
+    def k_packed_bytes(self) -> int:
+        """Packed bytes for one K tile per head: D * group * key_bits / 8."""
+        return math.ceil(self.head_dim * self.group * self.key_bits / 8)
+
+    @property
+    def v_packed_bytes(self) -> int:
+        """Packed bytes for one V tile per head: group * D * value_bits / 8."""
+        return math.ceil(self.group * self.head_dim * self.value_bits / 8)
+
+    @property
+    def k_scale_bytes(self) -> int:
+        """fp16 bytes for K scales: s_col_K' [D] + zp_K' [D] + s_row_K [group].
+
+        s_col_K' = rtn_scale ⊙ s_chan_sinkhorn  (per-channel absorbed scale)
+        zp_K'    = rtn_zp    ⊙ s_chan_sinkhorn  (per-channel absorbed zero)
+        s_row_K  = s_tok_sinkhorn               (per-token-in-tile)
+        """
+        return (2 * self.head_dim + self.group) * 2
+
+    @property
+    def v_scale_bytes(self) -> int:
+        """fp16 bytes for V scales: s_col_V [D] + s_row_V' [group] + zp_V' [group].
+
+        s_col_V  = s_chan_sinkhorn              (per-channel, untouched)
+        s_row_V' = rtn_scale ⊙ s_tok_sinkhorn   (per-token-in-tile absorbed scale)
+        zp_V'    = rtn_zp    ⊙ s_tok_sinkhorn   (per-token-in-tile absorbed zero)
+        """
+        return (self.head_dim + 2 * self.group) * 2
+
+    @property
+    def tile_bytes(self) -> int:
+        """Total packed bytes per (block, head): K + V combined."""
+        return (
+            self.k_packed_bytes
+            + self.k_scale_bytes
+            + self.v_packed_bytes
+            + self.v_scale_bytes
+        )
+
+    @property
+    def tile_bytes_aligned(self) -> int:
+        """tile_bytes rounded up for nicer Triton loads.
+
+        For head_dim >= 256 we round the PER-TOKEN slot (tile_bytes / group) up to
+        a power of 2. This is required for models with heterogeneous head_dim
+        (e.g. Gemma-4: 256 sliding-window layers + 512 global layers): the raw
+        slot has a fixed per-token-group scale term that doesn't scale with D, so
+        slot(512)/slot(256) is not an integer and vLLM's KV-cache page-size
+        unification (which scales block_size by that ratio) fails. Power-of-2 slots
+        make the ratio an exact power of 2. head_dim<=128 keeps the tight 8-byte
+        alignment (the common case; no padding). Trailing pad only — offsets are
+        unchanged, so the layout/kernels are byte-compatible."""
+        if self.head_dim >= 256:
+            slot = math.ceil(self.tile_bytes / self.group)
+            slot_pow2 = 1 << (slot - 1).bit_length()
+            return slot_pow2 * self.group
+        return ((self.tile_bytes + 7) // 8) * 8
+
+    # ── slot byte offsets within one tile (used by the kernels) ──────────────
+    @property
+    def k_packed_offset(self) -> int:
+        return 0
+
+    @property
+    def k_s_col_offset(self) -> int:
+        return self.k_packed_offset + self.k_packed_bytes
+
+    @property
+    def k_zp_offset(self) -> int:
+        return self.k_s_col_offset + self.head_dim * 2
+
+    @property
+    def k_s_row_offset(self) -> int:
+        return self.k_zp_offset + self.head_dim * 2
+
+    @property
+    def v_packed_offset(self) -> int:
+        return self.k_s_row_offset + self.group * 2
+
+    @property
+    def v_s_col_offset(self) -> int:
+        return self.v_packed_offset + self.v_packed_bytes
+
+    @property
+    def v_s_row_offset(self) -> int:
+        return self.v_s_col_offset + self.head_dim * 2
+
+    @property
+    def v_zp_offset(self) -> int:
+        return self.v_s_row_offset + self.group * 2
+
+    # ── precision-tail pool sizing ───────────────────────────────────────────
+    # A tile cannot be packed until all `group` tokens exist. The fixed side
+    # pool retains sink, recent, and in-progress tiles in the configured tail
+    # dtype (FP8 by default) and must be allocated before CUDA graph capture.
+    # Its size bounds scheduler concurrency; `max_supported_seqs` caps the
+    # configured request count to the chosen memory budget.
+    # The pool and the paged KV cache draw from the SAME pot: the memory left
+    # after model weights (i.e. `gpu_memory_utilization · total − weights`).
+    # Sizing the pool as a fixed fraction of *total* GPU memory was the bug
+    # behind the concurrency cap: on a 4B/24GB card the pool got 0.08·24≈1.9 GB and
+    # concurrency capped to ~30 while the KV cache sat at ~3% utilization —
+    # ~10 GB of usable memory wasted. We instead give the pool a share of the
+    # post-weight usable envelope (POOL_USABLE_SHARE), which auto-scales: a small
+    # model on a big card gets a large pool (high concurrency), a model that
+    # nearly fills the card gets a small one (degrades to cap≈1, never OOMs).
+    # The legacy fraction-of-total path is kept as a fallback for when the weight
+    # size can't be read. Both are tunable via KVARN_POOL_MEM_FRAC (interpreted
+    # as share-of-usable when weights are known, else fraction-of-total).
+    POOL_MEM_FRAC_DEFAULT = 0.08  # legacy: fraction of TOTAL (fallback)
+    POOL_USABLE_SHARE_DEFAULT = 0.5  # share of (util·total − weights)
+
+    def _slot_bytes_per_layer(self, num_kv_heads: int) -> int:
+        """Bytes for one K/V precision-tail pool slot in one layer."""
+        element_size = 1 if self.tail_dtype == "fp8" else 2
+        data_bytes = self.group * num_kv_heads * self.head_dim * 2 * element_size
+        scale_bytes = (
+            self.group * num_kv_heads * 2 * 2 if self.tail_dtype == "fp8" else 0
+        )
+        return data_bytes + scale_bytes
+
+    @property
+    def resident_blocks_per_seq(self) -> int:
+        """Maximum exact blocks intersecting the sink or precision tail."""
+        tail_blocks = 0
+        if self.precision_tail_tokens > 0:
+            tail_blocks = math.ceil(
+                (self.precision_tail_tokens + self.group - 1) / self.group
+            )
+        sink_blocks = math.ceil(self.sink_tokens / self.group)
+        return tail_blocks + sink_blocks
+
+    def pool_slots(self, max_num_seqs: int, max_num_batched_tokens: int) -> int:
+        """Structural peak of exact pool slots needed in one scheduler step."""
+        prefill_blocks = math.ceil(max_num_batched_tokens / self.group)
+        resident = self.resident_blocks_per_seq * max_num_seqs
+        return max(resident + prefill_blocks + 8, 8)
+
+    def pool_budget_bytes(
+        self,
+        total_gpu_bytes: int,
+        gpu_memory_utilization: float | None = None,
+        weight_bytes: int | None = None,
+    ) -> int:
+        """GPU bytes the precision-tail pool is allowed to occupy.
+
+        Preferred (weight-aware): a share of the post-weight usable envelope,
+        ``share · (gpu_memory_utilization · total − weight_bytes)``. This is the
+        memory the pool and the paged KV cache actually compete for, so the
+        budget tracks real headroom instead of an arbitrary slice of the whole
+        card. ``share`` comes from KVARN_POOL_MEM_FRAC or
+        POOL_USABLE_SHARE_DEFAULT.
+
+        Fallback (weights unknown): the legacy ``frac · total`` with
+        POOL_MEM_FRAC_DEFAULT, so behaviour is unchanged when we cannot read the
+        weight size."""
+        env = os.environ.get("KVARN_POOL_MEM_FRAC")
+        if weight_bytes is not None and gpu_memory_utilization is not None:
+            share = float(env) if env is not None else self.POOL_USABLE_SHARE_DEFAULT
+            usable = gpu_memory_utilization * total_gpu_bytes - weight_bytes
+            return max(0, int(share * usable))
+        frac = float(env) if env is not None else self.POOL_MEM_FRAC_DEFAULT
+        return int(total_gpu_bytes * frac)
+
+    def max_supported_seqs(
+        self,
+        total_gpu_bytes: int,
+        num_kv_heads: int,
+        num_layers: int,
+        max_num_batched_tokens: int,
+        frac: float | None = None,
+        gpu_memory_utilization: float | None = None,
+        weight_bytes: int | None = None,
+    ) -> int:
+        """Largest max_num_seqs whose exact pool fits the configured budget.
+
+        The bound includes every block that can intersect the precision tail,
+        the optional sink block, blocks touched by one chunked-prefill step,
+        and fixed allocator headroom.
+        """
+        if frac is not None:
+            budget = int(total_gpu_bytes * frac)
+        else:
+            budget = self.pool_budget_bytes(
+                total_gpu_bytes, gpu_memory_utilization, weight_bytes
+            )
+        slot_bytes = self._slot_bytes_per_layer(num_kv_heads) * max(num_layers, 1)
+        max_slots = int(budget / slot_bytes)
+        prefill_blocks = math.ceil(max_num_batched_tokens / self.group)
+        per_seq = max(self.resident_blocks_per_seq, 1)
+        return max(1, (max_slots - prefill_blocks - 8) // per_seq)
+
+    def pool_bytes(
+        self,
+        max_num_seqs: int,
+        max_num_batched_tokens: int,
+        num_kv_heads: int,
+        num_layers: int,
+    ) -> int:
+        """Total GPU bytes occupied by the precision-tail pool on this rank.
+
+        Pool slots are summed over every KVarN layer and reserved before the
+        lazy layer-level allocation can compete with the paged cache.
+        """
+        slots = self.pool_slots(max_num_seqs, max_num_batched_tokens)
+        return slots * self._slot_bytes_per_layer(num_kv_heads) * max(num_layers, 1)
+
+    @staticmethod
+    def num_kvarn_layers(model_config, parallel_config) -> int:
+        """Number of attention layers spanned by the precision-tail pool.
+
+        Hybrid models allocate the pool only for attention layers; dense
+        transformers use their total layer count.
+        """
+        try:
+            n = model_config.get_num_layers_by_block_type(parallel_config, "attention")
+            if n and n > 0:
+                return n
+        except Exception:
+            pass
+        return model_config.get_num_layers(parallel_config)
+
+    @staticmethod
+    def estimate_weight_bytes(model: str, tensor_parallel_size: int = 1) -> int | None:
+        """Best-effort per-rank model weight size in bytes, read from the
+        checkpoint files on disk (exact, and cheap, with no CUDA context, which
+        the early `check_and_update_config` hook must avoid). Returns None if the
+        files can't be located, so the caller falls back to the legacy budget.
+
+        Resolves a local directory directly, or the local HF cache snapshot for
+        a repo id (never downloads). Prefers the shards named in a
+        `*.safetensors.index.json` (or `*.bin.index.json`) manifest, which is
+        exactly the set the loader reads. This avoids double-counting a repo that
+        ships both a single consolidated checkpoint and the sharded HF set (e.g.
+        Mistral-7B-Instruct-v0.3 carries `consolidated.safetensors` alongside
+        `model-0000n-of-0000m.safetensors`, which a plain glob sums to ~2x the
+        real weight size). Divides by the tensor-parallel degree (weights shard
+        ~evenly across ranks)."""
+        import glob as _glob
+        import json as _json
+
+        try:
+            d = model
+            if not os.path.isdir(d):
+                # Repo id: resolve the already-cached snapshot, if any.
+                try:
+                    from vllm.transformers_utils.repo_utils import hf_api
+
+                    d = hf_api().snapshot_download(model, local_files_only=True)
+                except Exception:
+                    return None
+
+            # 1) Prefer the loader's own manifest: sum only the shards it lists,
+            #    so a stray consolidated/single-file copy is not double-counted.
+            for ext in ("safetensors", "bin"):
+                indexes = _glob.glob(
+                    os.path.join(d, "**", f"*.{ext}.index.json"), recursive=True
+                )
+                if not indexes:
+                    continue
+                try:
+                    with open(indexes[0]) as fh:
+                        weight_map = _json.load(fh).get("weight_map", {})
+                    base = os.path.dirname(indexes[0])
+                    names = sorted(set(weight_map.values()))
+                    shards = [os.path.join(base, s) for s in names]
+                    # Trust the manifest only when every listed shard is on
+                    # disk: a partial set would under-estimate the weights and
+                    # over-grow the pool budget, so fall through to the
+                    # conservative glob instead.
+                    if names and all(os.path.exists(p) for p in shards):
+                        total = sum(os.path.getsize(p) for p in shards)
+                        if total > 0:
+                            return total // max(tensor_parallel_size, 1)
+                except Exception:
+                    pass  # fall through to the single-file / glob paths
+
+            # 2) No usable manifest: prefer a canonical single-file checkpoint.
+            for single in ("model.safetensors", "consolidated.safetensors"):
+                p = os.path.join(d, single)
+                if os.path.exists(p):
+                    total = os.path.getsize(p)
+                    if total > 0:
+                        return total // max(tensor_parallel_size, 1)
+
+            # 3) Fallback: sum whatever weight shards are present.
+            files = _glob.glob(os.path.join(d, "**", "*.safetensors"), recursive=True)
+            if not files:
+                files = _glob.glob(os.path.join(d, "**", "*.bin"), recursive=True)
+            if not files:
+                return None
+            total = sum(os.path.getsize(f) for f in files)
+            if total <= 0:
+                return None
+            return total // max(tensor_parallel_size, 1)
+        except Exception:
+            return None
+
+    @staticmethod
+    def get_boundary_skip_layers(num_layers: int, n: int = 2) -> list[str]:
+        """First-N + last-N transformer layer indices as strings, suitable
+        for vLLM's ``kv_cache_dtype_skip_layers``. Mirrors TurboQuant
+        (`TurboQuantConfig.get_boundary_skip_layers`)."""
+        if n <= 0 or num_layers <= 0:
+            return []
+        n = min(n, num_layers // 2)
+        first = list(range(n))
+        last = list(range(num_layers - n, num_layers))
+        return [str(i) for i in sorted(set(first + last))]
+
+    @staticmethod
+    def from_cache_dtype(cache_dtype: str, head_dim: int) -> "KVarNConfig":
+        """Create a config from a preset string like ``"kvarn_k4v4"``."""
+        if cache_dtype not in KVARN_PRESETS:
+            valid = ", ".join(KVARN_PRESETS.keys())
+            raise ValueError(
+                f"Unknown KVarN cache dtype: {cache_dtype!r}. Valid: {valid}"
+            )
+        preset = KVARN_PRESETS[cache_dtype]
+        # Optional env override for Sinkhorn iteration count (KVARN_SINKHORN_ITERS).
+        # Default 16 mirrors the paper; useful for testing convergence at large
+        # model scale (e.g. 48-layer 30B-A3B-Thinking-2507 may benefit from more).
+        iters = int(os.environ.get("KVARN_SINKHORN_ITERS", "8"))
+        sink_tokens = int(os.environ.get("KVARN_SINK_TOKENS", "128"))
+        default_tail_tokens = (
+            DEFAULT_KVARN_K5V5_TAIL_TOKENS
+            if cache_dtype == "kvarn_k5v5_g64"
+            else DEFAULT_KVARN_TAIL_TOKENS
+        )
+        precision_tail_tokens = int(
+            os.environ.get("KVARN_TAIL_TOKENS", str(default_tail_tokens))
+        )
+        tail_dtype = os.environ.get(
+            "KVARN_TAIL_DTYPE", DEFAULT_KVARN_TAIL_DTYPE
+        ).lower()
+        if tail_dtype not in ("float16", "bfloat16", "fp8"):
+            raise ValueError(
+                "KVARN_TAIL_DTYPE must be 'float16', 'bfloat16', or 'fp8', "
+                f"got {tail_dtype!r}"
+            )
+        return KVarNConfig(
+            head_dim=head_dim,
+            key_bits=preset["key_bits"],
+            value_bits=preset["value_bits"],
+            group=preset["group"],
+            sinkhorn_iters=iters,
+            sink_tokens=sink_tokens,
+            precision_tail_tokens=precision_tail_tokens,
+            tail_dtype=tail_dtype,
+        )
+
+
+@dataclass(frozen=True)
+class KVarNMLAConfig:
+    """Packed KVarN latent plus exact BF16 RoPE layout for MLA caches.
+
+    Live boundary, sink, and current latent blocks always use FP8 E4M3 side
+    storage. Their RoPE values always use BF16 side storage.
+    """
+
+    latent_dim: int = 512
+    rope_dim: int = 64
+    bits: int = 5
+    group: int = 64
+    sinkhorn_iters: int = 8
+    boundary_tokens: ClassVar[int] = 128
+
+    @property
+    def latent_packed_bytes(self) -> int:
+        return math.ceil(self.latent_dim * self.group * self.bits / 8)
+
+    @property
+    def latent_scale_bytes(self) -> int:
+        return (2 * self.latent_dim + self.group) * 2
+
+    @property
+    def rope_bytes(self) -> int:
+        return self.group * self.rope_dim * 2
+
+    @property
+    def latent_s_col_offset(self) -> int:
+        return self.latent_packed_bytes
+
+    @property
+    def latent_zp_offset(self) -> int:
+        return self.latent_s_col_offset + self.latent_dim * 2
+
+    @property
+    def latent_s_row_offset(self) -> int:
+        return self.latent_zp_offset + self.latent_dim * 2
+
+    @property
+    def rope_offset(self) -> int:
+        return self.latent_s_row_offset + self.group * 2
+
+    @property
+    def tile_bytes(self) -> int:
+        return self.rope_offset + self.rope_bytes
+
+    @property
+    def bytes_per_token(self) -> int:
+        assert self.tile_bytes % self.group == 0
+        return self.tile_bytes // self.group
+
+    @property
+    def resident_blocks_per_seq(self) -> int:
+        return math.ceil(self.boundary_tokens / self.group) + 1
+
+    def pool_slots(
+        self,
+        max_num_seqs: int,
+        max_num_batched_tokens: int,
+        max_rollback_tokens: int = 0,
+    ) -> int:
+        prefill_blocks = math.ceil(max_num_batched_tokens / self.group)
+        resident = self.resident_blocks_per_seq * max_num_seqs
+        boundary_overlap = max_num_seqs
+        rollback_blocks = (
+            math.ceil(max_num_seqs * max_rollback_tokens / self.group) + max_num_seqs
+            if max_rollback_tokens
+            else 0
+        )
+        return max(
+            resident + prefill_blocks + boundary_overlap + rollback_blocks + 8,
+            8,
+        )
+
+    @property
+    def pool_slot_bytes(self) -> int:
+        return self.group * (self.latent_dim + self.rope_dim * 2)
+
+    def max_active_rows(self, vllm_config: "VllmConfig") -> int:
+        """Maximum decode/verify rows sharing the dense physical arena."""
+        scheduler_config = vllm_config.scheduler_config
+        max_batched = int(scheduler_config.max_num_batched_tokens)
+        max_num_seqs = int(scheduler_config.max_num_seqs)
+        spec_decode_max_q, spec_extend_enabled, spec_extend_forced = (
+            _kvarn_mla_decode_settings()
+        )
+        q_per_req = 1
+        spec_config = getattr(vllm_config, "speculative_config", None)
+        if (
+            spec_extend_enabled
+            and spec_config is not None
+            and getattr(spec_config, "num_speculative_tokens", None)
+        ):
+            q_per_req = 1 + int(spec_config.num_speculative_tokens)
+        if spec_extend_forced:
+            q_per_req = max(q_per_req, spec_decode_max_q)
+        max_active_rows = min(max_num_seqs * q_per_req, max_batched)
+        return max(max_active_rows, max_num_seqs)
+
+    def workspace_envelope(
+        self, vllm_config: "VllmConfig", num_kv_pages: int
+    ) -> KVarNMLAWorkspaceEnvelope:
+        """Size shared physical staging allocated once by a local worker."""
+        scheduler_config = vllm_config.scheduler_config
+        max_num_seqs = int(scheduler_config.max_num_seqs)
+        max_rollback_tokens = 0
+        spec_config = getattr(vllm_config, "speculative_config", None)
+        if (
+            scheduler_config.async_scheduling
+            and spec_config is not None
+            and getattr(spec_config, "num_speculative_tokens", None)
+        ):
+            max_rollback_tokens = int(spec_config.num_speculative_tokens)
+        rollback_blocks = (
+            _cdiv(max_num_seqs * max_rollback_tokens, self.group) + max_num_seqs
+            if max_rollback_tokens
+            else 0
+        )
+        return kvarn_mla_workspace_envelope(
+            num_kv_pages=num_kv_pages,
+            group_size=self.group,
+            latent_dim=self.latent_dim,
+            rope_dim=self.rope_dim,
+            max_batched_tokens=int(scheduler_config.max_num_batched_tokens),
+            max_active_rows=self.max_active_rows(vllm_config),
+            topk_tokens=int(vllm_config.model_config.hf_config.index_topk),
+            boundary_blocks=max_num_seqs,
+            rollback_blocks=rollback_blocks,
+        )
+
+    @classmethod
+    def from_cache_dtype(cls, cache_dtype: str) -> "KVarNMLAConfig":
+        if cache_dtype != "kvarn_mla_k5_g64":
+            raise ValueError(
+                f"MLA KVarN requires 'kvarn_mla_k5_g64', got {cache_dtype!r}"
+            )
+        return cls(
+            sinkhorn_iters=int(os.environ.get("KVARN_SINKHORN_ITERS", "8")),
+        )

--- a/vllm/model_executor/layers/quantization/kvarn/sinkhorn.py
+++ b/vllm/model_executor/layers/quantization/kvarn/sinkhorn.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Log-domain iterative variance-normalization for KVarN.
+
+Algorithm: alternating column-wise and row-wise standard-deviation
+normalization in log space, tracking the lowest-imbalance state seen
+across all iterations (the best-so-far selection).
+
+Pure-PyTorch reference implementation; the Triton port lives in
+``vllm/v1/attention/ops/triton_kvarn_sinkhorn.py``.
+
+Both the single-tile and batched-tile variants return the same triple
+``(balanced, s_col, s_row)`` where ``balanced = tile / s_col / s_row``
+has equalised row and column standard deviation.
+
+Naming convention: ``s_col`` is the scale along **axis 1** (varies across
+columns), ``s_row`` is along **axis 0** (varies across rows). The
+"per-channel" vs "per-token" semantic mapping depends on tile orientation:
+
+  - K tile is ``[D, group]`` (rows = channels, cols = tokens) → ``s_row`` is
+    per-channel, ``s_col`` is per-token.
+  - V tile is ``[group, D]`` (rows = tokens, cols = channels) → ``s_row`` is
+    per-token, ``s_col`` is per-channel.
+
+This module is intentionally pure (no model imports, no vLLM context) so
+that ``pytest`` can exercise it as a unit.
+"""
+
+from __future__ import annotations
+
+import torch
+
+_DEFAULT_ITERATIONS = 16
+_CLIP_STD_MIN = 1e-3
+_CLIP_STD_MAX = 1e3
+_LOG_S_MIN = -0.3
+_LOG_S_MAX = 10.0
+
+
+def _imbalance(tile: torch.Tensor) -> torch.Tensor:
+    """Sum of column-std spread and row-std spread.
+
+    Lower is better; a perfectly balanced tile has ``imbalance == 2`` (each
+    std max equals its std min). The Sinkhorn loop tracks the lowest value
+    seen and returns the corresponding scales.
+    """
+    sc = tile.std(dim=-2)  # along rows ⇒ per-column std
+    sr = tile.std(dim=-1)  # along cols ⇒ per-row std
+    return sc.amax(dim=-1) / sc.amin(dim=-1).clamp_min(1e-8) + sr.amax(
+        dim=-1
+    ) / sr.amin(dim=-1).clamp_min(1e-8)
+
+
+def variance_normalize(
+    tile: torch.Tensor, iterations: int = _DEFAULT_ITERATIONS
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Single-tile log-domain Sinkhorn balancing.
+
+    Args:
+        tile: [R, C] fp32 (or any real dtype; will be cast to fp32 internally).
+        iterations: number of alternating col/row passes (default 16).
+
+    Returns:
+        balanced [R, C] fp32 — variance-normalised tile.
+        s_col    [1, C] fp32 — column scale (best-so-far).
+        s_row    [R, 1] fp32 — row scale    (best-so-far).
+        such that ``balanced = tile / s_col / s_row``.
+    """
+    m = tile.float()
+    R, C = m.shape
+    dev = m.device
+
+    log_s_col = torch.zeros(1, C, device=dev)
+    log_s_row = torch.zeros(R, 1, device=dev)
+
+    cur = m / log_s_col.exp() / log_s_row.exp()
+    score_best = _imbalance(cur)
+    sc_best = log_s_col.exp().clone()
+    sr_best = log_s_row.exp().clone()
+
+    for _ in range(iterations):
+        col_std = cur.std(dim=0, keepdim=True).clamp(_CLIP_STD_MIN, _CLIP_STD_MAX)
+        log_s_col = (log_s_col + col_std.log()).clip(_LOG_S_MIN, _LOG_S_MAX)
+        cur = m / log_s_col.exp() / log_s_row.exp()
+
+        row_std = cur.std(dim=1, keepdim=True).clamp(_CLIP_STD_MIN, _CLIP_STD_MAX)
+        log_s_row = (log_s_row + row_std.log()).clip(_LOG_S_MIN, _LOG_S_MAX)
+        cur = m / log_s_col.exp() / log_s_row.exp()
+
+        score = _imbalance(cur)
+        if score <= score_best:
+            score_best = score
+            sc_best = log_s_col.exp().clone()
+            sr_best = log_s_row.exp().clone()
+
+    balanced = m / sc_best / sr_best
+    return balanced, sc_best, sr_best
+
+
+def variance_normalize_batched(
+    tiles: torch.Tensor, iterations: int = _DEFAULT_ITERATIONS
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Batched version: tiles is [N, R, C].
+
+    Returns balanced, s_col [N,1,C], s_row [N,R,1].
+
+    The best-so-far selection is done per-tile via a mask on the imbalance scalar.
+    """
+    m = tiles.float()
+    N, R, C = m.shape
+    dev = m.device
+
+    log_s_col = torch.zeros(N, 1, C, device=dev)
+    log_s_row = torch.zeros(N, R, 1, device=dev)
+
+    cur = m / log_s_col.exp() / log_s_row.exp()
+    score_best = _imbalance(cur)
+    sc_best = log_s_col.exp().clone()
+    sr_best = log_s_row.exp().clone()
+
+    for _ in range(iterations):
+        col_std = cur.std(dim=1, keepdim=True).clamp(_CLIP_STD_MIN, _CLIP_STD_MAX)
+        log_s_col = (log_s_col + col_std.log()).clip(_LOG_S_MIN, _LOG_S_MAX)
+        cur = m / log_s_col.exp() / log_s_row.exp()
+
+        row_std = cur.std(dim=2, keepdim=True).clamp(_CLIP_STD_MIN, _CLIP_STD_MAX)
+        log_s_row = (log_s_row + row_std.log()).clip(_LOG_S_MIN, _LOG_S_MAX)
+        cur = m / log_s_col.exp() / log_s_row.exp()
+
+        score = _imbalance(cur)
+        better = score <= score_best
+        if better.any():
+            mask = better.view(N, 1, 1).to(log_s_col.dtype)
+            sc_best = mask * log_s_col.exp() + (1 - mask) * sc_best
+            sr_best = mask * log_s_row.exp() + (1 - mask) * sr_best
+            score_best = torch.where(better, score, score_best)
+
+    balanced = m / sc_best / sr_best
+    return balanced, sc_best, sr_best

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -2004,19 +2004,16 @@ def sparse_attn_indexer(
                 continue
 
             if use_b12x_indexer:
-                if chunk.num_reqs != 1:
-                    raise RuntimeError(
-                        "B12X sparse prefill requires single-request chunks so "
-                        "the page table can be row-shared without packing."
-                    )
                 if qs_active:
                     rel_start = qs_row_start - chunk.token_start
                     rel_end = qs_row_end - chunk.token_start
                     cu_seqlen_ks = chunk.cu_seqlen_ks[rel_start:rel_end]
                     cu_seqlen_ke = chunk.cu_seqlen_ke[rel_start:rel_end]
+                    token_to_seq = chunk.token_to_seq[rel_start:rel_end]
                 else:
                     cu_seqlen_ks = chunk.cu_seqlen_ks
                     cu_seqlen_ke = chunk.cu_seqlen_ke
+                    token_to_seq = chunk.token_to_seq
                 row_has_no_kv = cu_seqlen_ke <= cu_seqlen_ks
                 seq_lens = torch.where(
                     row_has_no_kv,
@@ -2036,10 +2033,15 @@ def sparse_attn_indexer(
                 active_page_width = min(
                     active_page_width, int(chunk.block_table.shape[1])
                 )
-                block_table = chunk.block_table[:1, :active_page_width].expand(
-                    int(q_slice.shape[0]),
-                    active_page_width,
-                )
+                if chunk.num_reqs == 1:
+                    block_table = chunk.block_table[:1, :active_page_width].expand(
+                        int(q_slice.shape[0]),
+                        active_page_width,
+                    )
+                else:
+                    block_table = chunk.block_table.index_select(
+                        0, token_to_seq.to(torch.long)
+                    )[:, :active_page_width]
                 topk_scores = None
                 if dcp_world_size > 1:
                     if topk_scores_buffer is None:
@@ -2059,7 +2061,7 @@ def sparse_attn_indexer(
                     topk_indices=topk_indices,
                     topk_tokens=topk_tokens,
                     topk_scores=topk_scores,
-                    shared_page_table=True,
+                    shared_page_table=chunk.num_reqs == 1,
                     output_physical_slots=output_physical_slots,
                 )
                 if dcp_global_topk:

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -152,6 +152,7 @@ def _get_backend_priorities(
                 AttentionBackendEnum.TRITON_ATTN,
                 AttentionBackendEnum.FLEX_ATTENTION,
                 AttentionBackendEnum.TURBOQUANT,
+                AttentionBackendEnum.KVARN,
             ]
         else:
             return [
@@ -160,6 +161,7 @@ def _get_backend_priorities(
                 AttentionBackendEnum.TRITON_ATTN,
                 AttentionBackendEnum.FLEX_ATTENTION,
                 AttentionBackendEnum.TURBOQUANT,
+                AttentionBackendEnum.KVARN,
             ]
 
 
@@ -350,6 +352,123 @@ class CudaPlatformBase(Platform):
                 "setting in %%USERPROFILE%%\\.wslconfig and run "
                 "`wsl --shutdown`."
             )
+
+        cache_config = vllm_config.cache_config
+        cache_dtype = cache_config.cache_dtype
+        is_kvarn = isinstance(cache_dtype, str) and cache_dtype.startswith("kvarn_")
+        if is_kvarn:
+            if cache_config.enable_prefix_caching:
+                raise ValueError(
+                    "KVarN precision tails do not yet support prefix caching. "
+                    "Disable prefix caching explicitly."
+                )
+            if cache_config.kv_offloading_size is not None:
+                raise ValueError("KVarN does not yet support KV cache offloading.")
+            if vllm_config.kv_transfer_config is not None:
+                raise ValueError(
+                    "KVarN does not yet support KV transfer or disaggregated serving."
+                )
+            if model_config is None:
+                return
+            if cache_dtype == "kvarn_mla_k5_g64" and not model_config.use_mla:
+                raise ValueError("kvarn_mla_k5_g64 requires an MLA model.")
+
+            if model_config.use_mla:
+                if cache_dtype != "kvarn_mla_k5_g64":
+                    raise ValueError(
+                        "MLA KVarN requires kv_cache_dtype='kvarn_mla_k5_g64'."
+                    )
+                backend = vllm_config.attention_config.backend
+                if backend not in (
+                    "B12X_MLA_SPARSE",
+                    AttentionBackendEnum.B12X_MLA_SPARSE,
+                ):
+                    raise ValueError(
+                        "kvarn_mla_k5_g64 requires --attention-backend B12X_MLA_SPARSE."
+                    )
+                if cache_config.block_size != 64:
+                    raise ValueError(
+                        "kvarn_mla_k5_g64 requires --block-size 64; "
+                        f"got {cache_config.block_size}."
+                    )
+                if cache_config.kv_cache_dtype_skip_layers:
+                    raise ValueError(
+                        "MLA KVarN does not support mixed KV-cache dtypes."
+                    )
+                if parallel_config.enable_dbo:
+                    raise ValueError(
+                        "MLA KVarN does not yet support dual-batch overlap because "
+                        "its dequantization workspace is shared across layers."
+                    )
+                spec_config = vllm_config.speculative_config
+                if spec_config is not None and getattr(
+                    spec_config, "method", None
+                ) not in {
+                    "ngram",
+                    "ngram_gpu",
+                }:
+                    if getattr(spec_config, "attention_backend", None) not in (
+                        "B12X_MLA_SPARSE",
+                        AttentionBackendEnum.B12X_MLA_SPARSE,
+                    ):
+                        raise ValueError(
+                            "MLA KVarN speculative decoding requires explicit "
+                            "attention_backend='B12X_MLA_SPARSE'."
+                        )
+                    if (
+                        getattr(spec_config, "kv_cache_dtype", None)
+                        != "kvarn_mla_k5_g64"
+                    ):
+                        raise ValueError(
+                            "MLA KVarN speculative decoding requires explicit "
+                            "kv_cache_dtype='kvarn_mla_k5_g64'."
+                        )
+
+            else:
+                from vllm.model_executor.layers.quantization.kvarn.config import (
+                    KVarNConfig,
+                )
+
+                head_size = model_config.get_head_size()
+                if (
+                    parallel_config.decode_context_parallel_size > 1
+                    or parallel_config.prefill_context_parallel_size > 1
+                ):
+                    raise ValueError(
+                        "Standard KVarN does not support decode or prefill "
+                        "context parallelism."
+                    )
+                if cache_config.kv_cache_dtype_skip_layers:
+                    raise ValueError(
+                        "Standard KVarN does not support mixed KV-cache dtypes."
+                    )
+
+                if head_size not in (128, 256, 512):
+                    raise ValueError(
+                        "KVarN requires head_dim 128, 256, or 512; "
+                        f"the model uses {head_size}."
+                    )
+                kvarn_config = KVarNConfig.from_cache_dtype(cache_dtype, head_size)
+                supported = kvarn_config.max_supported_seqs(
+                    total_gpu_bytes=cls.get_device_total_memory(),
+                    num_kv_heads=model_config.get_num_kv_heads(parallel_config),
+                    num_layers=KVarNConfig.num_kvarn_layers(
+                        model_config, parallel_config
+                    ),
+                    max_num_batched_tokens=scheduler_config.max_num_batched_tokens,
+                    gpu_memory_utilization=cache_config.gpu_memory_utilization,
+                    weight_bytes=kvarn_config.estimate_weight_bytes(
+                        model_config.model,
+                        tensor_parallel_size=parallel_config.tensor_parallel_size,
+                    ),
+                )
+                if scheduler_config.max_num_seqs > supported:
+                    logger.warning(
+                        "KVarN precision-tail pool caps max_num_seqs from %d to %d.",
+                        scheduler_config.max_num_seqs,
+                        supported,
+                    )
+                    scheduler_config.max_num_seqs = supported
 
     @classmethod
     def get_current_memory_usage(

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -3,6 +3,7 @@
 import contextlib
 import enum
 import functools
+import math
 import os
 import platform
 import sys
@@ -702,7 +703,21 @@ class Platform:
             if cache_config.cache_dtype != "auto"
             else model_config.dtype
         )
-        primary_page = per_token_page_bytes(primary_dtype, cache_config.cache_dtype)
+        if cache_config.cache_dtype.startswith("kvarn_") and not model_config.use_mla:
+            from vllm.model_executor.layers.quantization.kvarn.config import (
+                KVarNConfig,
+            )
+
+            kvarn_config = KVarNConfig.from_cache_dtype(
+                cache_config.cache_dtype, model_config.get_head_size()
+            )
+            primary_page = (
+                kvarn_config.tile_bytes_aligned
+                * model_config.get_num_kv_heads(parallel_config)
+                // kvarn_config.group
+            )
+        else:
+            primary_page = per_token_page_bytes(primary_dtype, cache_config.cache_dtype)
 
         # Per-token page of every higher-precision padded spec sharing the pool.
         padded_pages: list[int] = []
@@ -796,8 +811,26 @@ class Platform:
 
         kv_quant_mode = get_kv_quant_mode(cache_config.cache_dtype)
 
-        # Compute attention page size for 1 token
-        if model_config.use_mla:
+        # Compute attention page size for one token. KVarN's dense 5-bit
+        # payload is group-locked and cannot use FullAttentionSpec's raw uint8
+        # formula.
+        is_standard_kvarn = (
+            cache_config.cache_dtype.startswith("kvarn_") and not model_config.use_mla
+        )
+        if is_standard_kvarn:
+            from vllm.model_executor.layers.quantization.kvarn.config import (
+                KVarNConfig,
+            )
+
+            kvarn_config = KVarNConfig.from_cache_dtype(
+                cache_config.cache_dtype, model_config.get_head_size()
+            )
+            attn_page_size_1_token = (
+                kvarn_config.tile_bytes_aligned
+                * model_config.get_num_kv_heads(parallel_config)
+                // kvarn_config.group
+            )
+        elif model_config.use_mla:
             attn_page_size_1_token = MLAAttentionSpec(
                 block_size=1,
                 num_kv_heads=model_config.get_num_kv_heads(parallel_config),
@@ -862,6 +895,22 @@ class Platform:
         ).page_size_bytes
 
         if mamba_page_size == 0:
+            return
+        if is_standard_kvarn:
+            # Keep group-64 quantization tiles while allowing multiple tiles to
+            # share one hybrid cache page. This preserves KVarN's
+            # bytes/token instead of padding every 64-token tile to a Mamba
+            # state page.
+            tile_page_size = (
+                kvarn_config.tile_bytes_aligned
+                * model_config.get_num_kv_heads(parallel_config)
+            )
+            tiles_per_page = max(
+                math.ceil(mamba_page_size / tile_page_size),
+                1,
+            )
+            cache_config.block_size = kvarn_config.group * tiles_per_page
+            cache_config.mamba_page_size_padded = tile_page_size * tiles_per_page
             return
 
         # mamba_block_size here should either be user specified value or None

--- a/vllm/utils/torch_utils.py
+++ b/vllm/utils/torch_utils.py
@@ -50,6 +50,10 @@ STR_DTYPE_TO_TORCH_DTYPE = {
     "turboquant_4bit_nc": torch.uint8,
     "turboquant_k3v4_nc": torch.uint8,
     "turboquant_3bit_nc": torch.uint8,
+    "kvarn_k4v2_g128": torch.uint8,
+    "kvarn_k4v4_g128": torch.uint8,
+    "kvarn_k5v5_g64": torch.uint8,
+    "kvarn_mla_k5_g64": torch.uint8,
     "nvfp4": torch.uint8,
     "nvfp4_4over6": torch.uint8,
 }
@@ -77,7 +81,7 @@ PIN_MEMORY = is_pin_memory_available()
 
 def is_quantized_kv_cache(kv_cache_dtype: str) -> bool:
     return (
-        kv_cache_dtype.startswith("fp8")
+        kv_cache_dtype.startswith(("fp8", "kvarn_"))
         or kv_cache_dtype.endswith("per_token_head")
         or kv_cache_dtype.startswith("nvfp4")
     )

--- a/vllm/v1/attention/backend.py
+++ b/vllm/v1/attention/backend.py
@@ -547,6 +547,9 @@ class CommonAttentionMetadata:
     block_table_tensor: torch.Tensor
     slot_mapping: torch.Tensor
 
+    kvarn_mla_block_fills: dict[int, int | None] | None = None
+    """Exact physical blocks; ``None`` marks a conservatively unknown fill."""
+
     causal: bool | torch.Tensor = True
     max_req_tokens: int = 0
 
@@ -747,6 +750,7 @@ class CommonAttentionMetadata:
             is_prefilling=maybe_slice_reqs(self.is_prefilling),
             rswa_prefix_lens=maybe_slice_reqs(self.rswa_prefix_lens),
             replayssm_decode_base_cpu=maybe_slice_reqs(self.replayssm_decode_base_cpu),
+            kvarn_mla_block_fills=self.kvarn_mla_block_fills,
         )
 
 

--- a/vllm/v1/attention/backends/kvarn_attn.py
+++ b/vllm/v1/attention/backends/kvarn_attn.py
@@ -1,0 +1,2774 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""KVarN K5/V5 precision-tail attention backend.
+
+Each vLLM block is one group-locked quantization tile. Completed history tiles
+are Hadamard-rotated, variance-normalized, and stored as dense little-endian
+K5/V5 records. Sink and recent tiles stay in a side pool whose default storage
+dtype is FP8.
+
+The first prefill chunk attends over raw model-dtype K/V. Decode and speculative
+verify use fused Triton kernels that read packed history and the precision tail
+directly. Chunked-prefill continuations materialize rotated K/V for
+FlashAttention until a direct packed prefill kernel is available.
+"""
+
+from __future__ import annotations
+
+import functools
+import math
+import os
+from dataclasses import dataclass
+from typing import ClassVar
+from weakref import WeakSet
+
+import torch
+import torch.nn.functional as F
+
+from vllm.config.cache import CacheDType
+from vllm.v1.attention.backend import (
+    AttentionBackend,
+    AttentionCGSupport,
+    AttentionImpl,
+    AttentionLayer,
+    AttentionMetadata,
+    AttentionMetadataBuilder,
+    AttentionType,
+    CommonAttentionMetadata,
+    MultipleOf,
+)
+from vllm.v1.attention.backends.fa_utils import (
+    get_flash_attn_version,
+    is_flash_attn_varlen_func_available,
+)
+from vllm.v1.attention.backends.utils import split_decodes_and_prefills
+from vllm.v1.attention.ops.kvarn_decode import (
+    kvarn_dequant_tile_k,
+    kvarn_dequant_tile_v,
+    kvarn_hadamard,
+)
+from vllm.v1.attention.ops.kvarn_store import (
+    kvarn_store_tile_k_batch_from_sinkhorn,
+    kvarn_store_tile_v_batch_from_sinkhorn,
+)
+from vllm.v1.attention.ops.triton_kvarn_decode import kvarn_decode_attention
+from vllm.v1.attention.ops.triton_kvarn_sinkhorn import kvarn_sinkhorn_triton
+
+_HAS_FLASH_ATTN = is_flash_attn_varlen_func_available()
+if _HAS_FLASH_ATTN:
+    from vllm.v1.attention.backends.fa_utils import flash_attn_varlen_func
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Hadamard cache (one D×D matrix per (head_dim, device))
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+@functools.cache
+def _hadamard_cached(d: int, device_str: str) -> torch.Tensor:
+    """Sylvester Hadamard, normalised, cached per (d, device)."""
+    H = torch.ones(1, 1)
+    while H.shape[0] < d:
+        H = torch.cat([torch.cat([H, H], 1), torch.cat([H, -H], 1)], 0)
+    return (H / math.sqrt(d)).to(torch.device(device_str)).float()
+
+
+def _build_hadamard(d: int, device: torch.device) -> torch.Tensor:
+    return _hadamard_cached(d, str(torch.device(device)))
+
+
+def _sinkhorn_pack_kv(K_tiles, V_tiles, cfg):
+    """Sinkhorn-balance and pack a batch of K and V tiles.
+
+    K tiles use ``[N, D, group]`` and V tiles use ``[N, group, D]``. Equal
+    shapes share one Triton launch; non-square orientations use separate
+    launches because their reduction axes differ.
+    """
+    if K_tiles.shape[1:] == V_tiles.shape[1:]:
+        nk = K_tiles.shape[0]
+        bal, sc, sr = kvarn_sinkhorn_triton(
+            torch.cat([K_tiles, V_tiles], dim=0),
+            iterations=cfg.sinkhorn_iters,
+        )
+        K_out = kvarn_store_tile_k_batch_from_sinkhorn(
+            bal[:nk], sc[:nk], sr[:nk], bits=cfg.key_bits
+        )
+        V_out = kvarn_store_tile_v_batch_from_sinkhorn(
+            bal[nk:], sc[nk:], sr[nk:], bits=cfg.value_bits
+        )
+    else:
+        kbal, ksc, ksr = kvarn_sinkhorn_triton(K_tiles, iterations=cfg.sinkhorn_iters)
+        vbal, vsc, vsr = kvarn_sinkhorn_triton(V_tiles, iterations=cfg.sinkhorn_iters)
+        K_out = kvarn_store_tile_k_batch_from_sinkhorn(
+            kbal, ksc, ksr, bits=cfg.key_bits
+        )
+        V_out = kvarn_store_tile_v_batch_from_sinkhorn(
+            vbal, vsc, vsr, bits=cfg.value_bits
+        )
+    return K_out, V_out
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Backend metadata classes
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class KVarNAttentionBackend(AttentionBackend):
+    """Attention backend using KVarN KV-cache compression."""
+
+    accept_output_buffer: bool = True
+    forward_includes_kv_cache_update: bool = False
+
+    supported_dtypes: ClassVar[list[torch.dtype]] = [
+        torch.float16,
+        torch.bfloat16,
+    ]
+    supported_kv_cache_dtypes: ClassVar[list[CacheDType]] = [
+        "kvarn_k4v2_g128",
+        "kvarn_k4v4_g128",
+        "kvarn_k5v5_g64",
+    ]
+
+    @staticmethod
+    def get_name() -> str:
+        return "KVARN"
+
+    @staticmethod
+    def get_supported_kernel_block_sizes() -> list[int | MultipleOf]:
+        return [64, 128]
+
+    @classmethod
+    def get_preferred_block_size(cls, default_block_size: int) -> int:
+        # The active preset pins the tile size (..._g64 / ..._g128), and
+        # get_kv_cache_shape asserts block_size == cfg.group. The generic
+        # fallback returns the MINIMUM supported size (64) whenever the
+        # framework default (16) is unsupported — which breaks any g128 preset
+        # run without an explicit --block-size (a g128 deployment then builds
+        # its cache with 64-token kernel blocks and dies on the assert, e.g.
+        # hybrid models without spec decode). Prefer the preset's group.
+        from vllm.config.vllm import get_current_vllm_config
+        from vllm.model_executor.layers.quantization.kvarn.config import (
+            KVARN_PRESETS,
+        )
+
+        try:
+            cache_dtype = get_current_vllm_config().cache_config.cache_dtype
+        except Exception:
+            cache_dtype = None
+        if isinstance(cache_dtype, str) and cache_dtype in KVARN_PRESETS:
+            return KVARN_PRESETS[cache_dtype]["group"]
+        return super().get_preferred_block_size(default_block_size)
+
+    @classmethod
+    def supports_attn_type(cls, attn_type: str) -> bool:
+        return attn_type == AttentionType.DECODER
+
+    @classmethod
+    def supports_non_causal(cls) -> bool:
+        # Causality is purely a masking choice; the KV quantization is
+        # independent of it. The per-token verify path attends each query row
+        # to [0, vq_seqlen[row]) — a flat full-context length per row gives
+        # bidirectional attention (used by DFlash cross-attention drafting).
+        return True
+
+    @classmethod
+    def supports_per_head_quant_scales(cls) -> bool:
+        return False
+
+    @staticmethod
+    def get_impl_cls() -> type[KVarNAttentionImpl]:
+        return KVarNAttentionImpl
+
+    @staticmethod
+    def get_builder_cls() -> type[KVarNMetadataBuilder]:
+        return KVarNMetadataBuilder
+
+    @staticmethod
+    def get_kv_cache_shape(
+        num_blocks: int,
+        block_size: int,
+        num_kv_heads: int,
+        head_size: int,
+        cache_dtype_str: str = "kvarn_k5v5_g64",
+    ) -> tuple[int, ...]:
+        """3D shape: one contiguous ``tile_bytes_aligned`` record per (block, head).
+
+        KVarN's scales are tile-shared, so each block and head owns one
+        contiguous record. The shape has no per-position dimension because K
+        and V share that record.
+
+        The total bytes per block are
+        ``num_kv_heads * tile_bytes_aligned``; ``KVarNFullAttentionSpec`` uses
+        the same value for cache memory accounting.
+        """
+        from vllm.model_executor.layers.quantization.kvarn.config import (
+            KVarNConfig,
+        )
+
+        cfg = KVarNConfig.from_cache_dtype(cache_dtype_str, head_size)
+        assert block_size == cfg.group, (
+            f"KVarN requires block_size ({block_size}) == group ({cfg.group})."
+        )
+        return (num_blocks, num_kv_heads, cfg.tile_bytes_aligned)
+
+    @classmethod
+    def supports_kv_cache_dtype(cls, kv_cache_dtype: CacheDType | None) -> bool:
+        if kv_cache_dtype is None:
+            return False
+        return kv_cache_dtype.startswith("kvarn_") and not kv_cache_dtype.startswith(
+            "kvarn_mla"
+        )
+
+    @classmethod
+    def supports_head_size(cls, head_size: int) -> bool:
+        return head_size in (128, 256, 512)
+
+    @classmethod
+    def supports_mm_prefix(cls) -> bool:
+        # Image/audio prefix correctness has not been validated.
+        return False
+
+
+@dataclass
+class KVarNMetadata(AttentionMetadata):
+    """Metadata for KVarN attention (mirrors ``TurboQuantMetadata``)."""
+
+    seq_lens: torch.Tensor
+    slot_mapping: torch.Tensor
+    block_table: torch.Tensor
+    query_start_loc: torch.Tensor
+    num_actual_tokens: int = 0
+    max_query_len: int = 0
+    max_seq_len: int = 0
+    is_prefill: bool = False
+    num_decodes: int = 0
+    num_decode_tokens: int = 0
+    tiles_per_page: int = 1
+    # True if any multi-query request (query_len > 1) also has cached context
+    # (seq_len > query_len): a speculative-decode verify step or a chunked-
+    # prefill continuation. Such steps MUST attend over the cached K/V, so they
+    # route to the context-aware path rather than _prefill_first_chunk (which
+    # assumes a fresh prompt, cached_len == 0). Computed once in build() from
+    # CPU arrays (no GPU sync).
+    has_cached_multiquery: bool = False
+    # Precomputed once per batch in the metadata builder and reused across all
+    # 28+ layer forward calls. Saves 28× .tolist() syncs per decode token.
+    seq_lens_cpu: list[int] | None = None
+    block_table_cpu: list[list[int]] | None = None
+    slot_mapping_cpu: list[int] | None = None
+    # Stage α-2 capture-correct decode metadata. The block_table-driven
+    # build-packed-KV kernel reads block_table / seq_lens / fa_cu_seqlens_k
+    # directly (all PERSISTENT buffers updated in-place by the builder), so a
+    # captured CUDA graph sees fresh data on every replay.
+    fa_cu_seqlens_q: torch.Tensor | None = None  # [B+1] int32 (persistent)
+    fa_cu_seqlens_k: torch.Tensor | None = (
+        None  # [B+1] int32 (persistent prefix sum of seq_lens)
+    )
+    fa_max_blocks_per_req: int = 0  # ceil(max_model_len / group): grid dim
+    fa_max_seqlen_k_fixed: int = 0  # = max_model_len; fixed FA grid bound
+    # Verify (spec-as-decode) plan: one virtual kernel row per decode-portion
+    # query token. Persistent buffers (pointers baked into captured graphs),
+    # filled CPU-side in build(). None when the decode portion is single-token.
+    vq_req: torch.Tensor | None = None  # [num_decode_tokens] int32 block-table row
+    vq_seqlen: torch.Tensor | None = None  # [num_decode_tokens] int32 causal length
+    vq_qlen: int = 0  # uniform decode query len (>=2), else 0
+    # Non-causal (bidirectional) attention: each query row attends to the full
+    # context (no bottom-right causal staircase). Set by DFlash cross-attention
+    # drafting via CommonAttentionMetadata.causal=False. When False, the verify
+    # plan stores a flat full-context length per row instead of committed+j+1.
+    causal: bool = True
+
+
+class KVarNMetadataBuilder(AttentionMetadataBuilder[KVarNMetadata]):
+    """Builds ``KVarNMetadata`` from scheduler output."""
+
+    # UNIFORM_BATCH: spec-decode verify steps (uniform query length
+    # 1 + num_spec) are graph-capturable via the fused verify kernel — the
+    # whole MTP step replays as ONE full graph like vanilla FA, instead of
+    # ~num_layers eager attention calls between piecewise segments per step
+    # (the dominant MTP overhead once the materialize round-trip was gone;
+    # the gap to vanilla was 0.65-0.85x and worse under TP). All Python
+    # state mutation (slot allocation, sink marking, tile-boundary flush,
+    # the vq verify plan) happens in KVarNMetadataBuilder.build() between
+    # captured graph replays; the forward is pure tensor ops.
+    # KVARN_FUSED_VERIFY=0 reverts to single-token-only support.
+    _cudagraph_support: ClassVar[AttentionCGSupport] = (
+        AttentionCGSupport.UNIFORM_BATCH
+        if os.environ.get("KVARN_FUSED_VERIFY", "1") == "1"
+        else AttentionCGSupport.UNIFORM_SINGLE_TOKEN_DECODE
+    )
+
+    def __init__(self, kv_cache_spec, layer_names, vllm_config, device):
+        super().__init__(kv_cache_spec, layer_names, vllm_config, device)
+        # spec-as-decode: verify steps (query_len <= 1 + num_spec) classify
+        # as decodes and carry a vq plan (see build()) for the fused verify
+        # kernel; the threshold is derived from speculative_config by the
+        # base helper.
+        self._init_reorder_batch_threshold(
+            1,
+            supports_spec_as_decode=(os.environ.get("KVARN_FUSED_VERIFY", "1") == "1"),
+        )
+        # KV-cache-group key, must match KVarNAttentionImpl._group_key for this
+        # group's layers so the builder mutates the right group's slot allocator.
+        # (head_size, num_kv_heads, sliding_window) — see impl._group_key.
+        # TRUE per-group identity = this builder's exact layer set. A config
+        # proxy (head,kv,sw) is NOT enough: vLLM splits same-config layers into
+        # multiple groups (Gemma-4's repeating pattern -> 5 sliding groups all
+        # head256/16kv/1024), each with its own block_id space. The builder tags
+        # its impls with this key in build() (impls don't reliably carry a name).
+        self._layer_names = list(layer_names)
+        self._layer_names_set = set(self._layer_names)
+        self._group_key = tuple(sorted(self._layer_names))
+        # Stage α-2: per-block fill tracking — block_id -> tokens present in
+        # the pool for that block after the current step. Keyed by PHYSICAL
+        # block (never by request or by the sink block id): vLLM's prefix
+        # caching shares physical blocks across live requests and recycles ids
+        # across finished ones, so any request-identity proxy collides under
+        # sharing (the repetition-collapse / stale-tile class). A
+        # partial block has exactly one writer, so the value has a single
+        # source. Drives flush-on-reclaim: a finished request's complete block
+        # must be flushed (a future prefix-cache hit may read it), a partial
+        # one is safe to discard (vLLM never prefix-caches partial blocks).
+        self._block_fill: dict[int, int] = {}
+        # Retired sinks: finished requests' sink blocks, kept RESIDENT in the
+        # fp16 pool (insertion order = retirement order) instead of flushed on
+        # reclaim. A prefix-cache hit re-adopts the block with its fp16 data
+        # byte-identical — preserving KVarN's fp16-sink accuracy on multi-turn
+        # traffic, where every follow-up turn reuses the previous turn's first
+        # block. Evicted (flushed to int4, so later cache hits still find a
+        # valid tile) lazily, oldest first, only when slot allocation runs
+        # dry — residency therefore never shrinks live capacity.
+        self._retired_sinks: dict[int, None] = {}
+
+        # Max model length (for the fixed FA grid bound + max_blocks_per_req).
+        try:
+            self._max_model_len = vllm_config.model_config.max_model_len
+        except Exception:
+            self._max_model_len = 4096
+
+        # KVarN tile / group size (= vLLM block size). Sourced from the configured
+        # kv-cache dtype so non-128 groups (e.g. g64) drive the flush + slot math
+        # in build() correctly. Every storage / kernel path already reads
+        # cfg.group; this is the one place the builder needs it without an impl
+        # handle. Falls back to 128 if it cannot be parsed.
+        self._group = 128
+        self._tail_tokens = 0
+        self._sink_tokens = 0
+        from vllm.model_executor.layers.quantization.kvarn.config import KVarNConfig
+
+        cache_dtype = vllm_config.cache_config.cache_dtype
+        head_dim = vllm_config.model_config.get_head_size()
+        config = KVarNConfig.from_cache_dtype(cache_dtype, head_dim)
+        self._group = config.group
+        self._tail_tokens = config.precision_tail_tokens
+        self._sink_tokens = config.sink_tokens
+
+        # Persistent cu_seqlens buffers (allocated lazily in build()).
+        self._cu_seqlens_q_buf: torch.Tensor = None  # type: ignore[assignment]
+        self._cu_seqlens_k_buf: torch.Tensor = None  # type: ignore[assignment]
+        self._cu_seqlens_q_host: torch.Tensor = None  # type: ignore[assignment]
+        self._cu_seqlens_k_host: torch.Tensor = None  # type: ignore[assignment]
+        # Persistent verify-plan buffers (allocated lazily in build()).
+        self._vq_req_buf: torch.Tensor = None  # type: ignore[assignment]
+        self._vq_seqlen_buf: torch.Tensor = None  # type: ignore[assignment]
+        self._vq_req_host: torch.Tensor = None  # type: ignore[assignment]
+        self._vq_seqlen_host: torch.Tensor = None  # type: ignore[assignment]
+        max_tokens = vllm_config.scheduler_config.max_num_batched_tokens
+        self._slot_mapping_buf = torch.empty(
+            max_tokens,
+            dtype=torch.int64,
+            device=device,
+        )
+        self._slot_mapping_host = torch.empty(
+            max_tokens,
+            dtype=torch.int64,
+            pin_memory=True,
+        )
+
+    def build_for_cudagraph_capture(
+        self, common_attn_metadata: CommonAttentionMetadata
+    ) -> KVarNMetadata:
+        return self.build(0, common_attn_metadata)
+
+    def build(self, common_prefix_len, common_attn_metadata, fast_build=False):
+        cam = common_attn_metadata
+        assert self.reorder_batch_threshold is not None
+        num_decodes, num_prefills, num_decode_tokens, _ = split_decodes_and_prefills(
+            cam, decode_threshold=self.reorder_batch_threshold
+        )
+        # Pre-materialise CPU views ONCE per batch. Every layer's forward()
+        # would otherwise re-issue these syncs (28+ syncs/token for Qwen3-0.6B).
+        # Use the framework's cached CPU copy of seq_lens (cam.seq_lens_cpu) to
+        # avoid an extra GPU->CPU sync per step (build-overhead reduction).
+        _slc = getattr(cam, "seq_lens_cpu", None)
+        seq_lens_cpu = _slc.tolist() if _slc is not None else cam.seq_lens.tolist()
+        # Per-request query length this step (already on CPU; no extra sync).
+        # query_len > 1 for prefill chunks and for speculative-decode verify
+        # steps (MTP / draft). Used by flush detection to compute the COMMITTED
+        # token count (seq_len - query_len) so speculative tokens that may still
+        # be rejected are never quantized into the permanent int4 cache.
+        _qsl = getattr(cam, "query_start_loc_cpu", None)
+        if _qsl is not None:
+            _qsl_l = _qsl.tolist()
+            query_lens_cpu = [_qsl_l[i + 1] - _qsl_l[i] for i in range(len(_qsl_l) - 1)]
+        else:
+            query_lens_cpu = [1] * len(seq_lens_cpu)
+        # The framework's slot mapping is computed on the GPU after the current
+        # block table is committed. Reading the persistent GPU block table back
+        # here races the V2 runner's asynchronous table updates; slot IDs are
+        # therefore the CPU allocator's authoritative physical-tile input.
+        slot_mapping_cpu = cam.slot_mapping.tolist()
+        device = cam.seq_lens.device
+
+        # ── Stage α-2: capture-correct metadata ──────────────────────────
+        # The decode driver uses ONE block_table-driven kernel that reads the
+        # PERSISTENT block_table / seq_lens / cu_seqlens directly, so no
+        # per-step derived task tensors (which would be stale under graph
+        # replay). We only need cu_seqlens_k (prefix sum of seq_lens) and
+        # cu_seqlens_q (= arange(B+1)), both kept in PERSISTENT buffers and
+        # updated in place so captured graphs see fresh values.
+        B = len(seq_lens_cpu)
+        GROUP = self._group  # KVarN tile size (= block size); 64 or 128
+        cu_seqlens_k_h = [0]
+        for sl in seq_lens_cpu:
+            cu_seqlens_k_h.append(cu_seqlens_k_h[-1] + sl)
+
+        # ── Stage α-2: assign pool slots for every block_id touched this
+        # step. The allocator state is class-level on KVarNAttentionImpl
+        # and we mutate it here (in the builder, outside any captured
+        # region). do_kv_cache_update then only READS block_to_slot_t.
+        from vllm.v1.attention.backends.kvarn_attn import (
+            KVarNAttentionImpl,
+        )  # local import
+
+        # The precision pool is an insertion-ordered cache of physical KVarN
+        # tiles. Current writes are protected; when capacity is needed, stale
+        # partial tiles are discarded and the oldest complete non-sink tiles
+        # are packed first. The pool is sized for every live request's sink and
+        # configured precision tail, so pressure only evicts history beyond
+        # that structural working set.
+        gk = self._group_key
+        tiles_per_page = 1
+        slot_mapping_t = cam.slot_mapping
+        blocks_needed: set[int] = set()
+        sink_write_blocks: set[int] = set()
+        slot_cursor = 0
+        for b, seq_len in enumerate(seq_lens_cpu):
+            query_len = query_lens_cpu[b] if b < len(query_lens_cpu) else 1
+            first_position = max(int(seq_len) - int(query_len), 0)
+            for j in range(int(query_len)):
+                if slot_cursor >= len(slot_mapping_cpu):
+                    break
+                slot = int(slot_mapping_cpu[slot_cursor])
+                slot_cursor += 1
+                if slot < 0:
+                    continue
+                bid, offset = divmod(slot, GROUP)
+                blocks_needed.add(bid)
+                if offset == 0:
+                    self._block_fill[bid] = 0
+                self._block_fill[bid] = max(self._block_fill.get(bid, 0), offset + 1)
+                if first_position + j < self._sink_tokens:
+                    sink_write_blocks.add(bid)
+        active_rows = [
+            (int(seq_len), int(query_lens_cpu[b]))
+            for b, seq_len in enumerate(seq_lens_cpu)
+            if b < len(query_lens_cpu) and int(query_lens_cpu[b]) > 0
+        ]
+        fresh_batch = bool(active_rows) and all(
+            seq_len <= query_len for seq_len, query_len in active_rows
+        )
+
+        # Claim THIS group's impls by layer name and tag them with the exact
+        # cache-group key before binding allocator mirrors.
+        group_impls = [
+            impl
+            for impl in KVarNAttentionImpl._all_impls
+            if getattr(impl, "layer_name", None) in self._layer_names_set
+        ]
+        for impl in group_impls:
+            impl._group_key = gk
+        if group_impls:
+            impl0 = group_impls[0]
+            impl0._ensure_pool(
+                device, num_blocks_hint=max(blocks_needed, default=0) + 1
+            )
+            mkey = (device, gk)
+            b2s_t = KVarNAttentionImpl._block_to_slot_t_per_device[mkey]
+            is_sink_t = KVarNAttentionImpl._is_sink_t_per_device[mkey]
+            dict_map = KVarNAttentionImpl._block_to_slot_dict[gk]
+            free_slots = KVarNAttentionImpl._free_slots[gk]
+            sinks = KVarNAttentionImpl._global_sink_blocks[gk]
+            if fresh_batch:
+                # Prefix caching is rejected for KVarN. When every scheduled
+                # row starts a fresh request, no previous resident tile can
+                # still have an owner; drop that stale precision state before
+                # physical block IDs are recycled for the new batch.
+                for bid in [bid for bid in dict_map if bid not in blocks_needed]:
+                    slot = dict_map.pop(bid)
+                    self._block_fill.pop(bid, None)
+                    free_slots.append(slot)
+                    sinks.discard(bid)
+                    if bid < is_sink_t.shape[0]:
+                        is_sink_t[bid] = False
+                    if bid < b2s_t.shape[0]:
+                        b2s_t[bid] = -1
+
+            for bid in sink_write_blocks:
+                sinks.add(bid)
+                if bid < is_sink_t.shape[0]:
+                    is_sink_t[bid] = True
+
+            new_blocks = [bid for bid in blocks_needed if bid not in dict_map]
+            num_to_evict = max(len(new_blocks) - len(free_slots), 0)
+            if num_to_evict:
+                candidates = [bid for bid in dict_map if bid not in blocks_needed]
+                partial = [
+                    bid for bid in candidates if self._block_fill.get(bid, 0) < GROUP
+                ]
+                complete = [
+                    bid
+                    for bid in candidates
+                    if self._block_fill.get(bid, 0) >= GROUP and bid not in sinks
+                ]
+                complete_sinks = [
+                    bid
+                    for bid in candidates
+                    if self._block_fill.get(bid, 0) >= GROUP and bid in sinks
+                ]
+                evict_ids = (partial + complete + complete_sinks)[:num_to_evict]
+                if len(evict_ids) != num_to_evict:
+                    raise RuntimeError(
+                        "KVarN pool exhausted: "
+                        f"need {len(new_blocks)} new tiles with "
+                        f"{len(free_slots)} free and {len(candidates)} evictable"
+                    )
+
+                flush_ids = [
+                    bid for bid in evict_ids if self._block_fill.get(bid, 0) >= GROUP
+                ]
+                if flush_ids:
+                    flush_pairs = [
+                        (impl, bid, impl._kv_cache_ref)
+                        for impl in group_impls
+                        for bid in flush_ids
+                        if getattr(impl, "_kv_cache_ref", None) is not None
+                    ]
+                    if len(flush_pairs) != len(group_impls) * len(flush_ids):
+                        raise RuntimeError(
+                            "KVarN precision pool filled before cache binding"
+                        )
+                    KVarNAttentionImpl._batched_flush(flush_pairs)
+
+                for bid in evict_ids:
+                    slot = dict_map.pop(bid)
+                    self._block_fill.pop(bid, None)
+                    free_slots.append(slot)
+                    sinks.discard(bid)
+                    if bid < is_sink_t.shape[0]:
+                        is_sink_t[bid] = False
+                    if bid < b2s_t.shape[0]:
+                        b2s_t[bid] = -1
+
+            for bid in new_blocks:
+                slot = free_slots.pop()
+                dict_map[bid] = slot
+                if bid < b2s_t.shape[0]:
+                    b2s_t[bid] = slot
+                KVarNAttentionImpl._max_known_block_id[gk] = max(
+                    KVarNAttentionImpl._max_known_block_id.get(gk, 0), bid
+                )
+
+        # ── Persistent cu_seqlens buffers (in-place updated) ─────────────
+        # A captured graph bakes in tensor addresses, so cu_seqlens MUST live
+        # in fixed buffers updated in place — not recreated each step.
+        cap = B + 1
+        if self._cu_seqlens_q_buf is None or self._cu_seqlens_q_buf.shape[0] < cap:
+            new_cap = max(cap, 257)  # default max_num_seqs headroom
+            self._cu_seqlens_q_buf = torch.empty(
+                new_cap, dtype=torch.int32, device=device
+            )
+            self._cu_seqlens_k_buf = torch.empty(
+                new_cap, dtype=torch.int32, device=device
+            )
+            self._cu_seqlens_q_host = torch.empty(
+                new_cap, dtype=torch.int32, pin_memory=True
+            )
+            self._cu_seqlens_k_host = torch.empty(
+                new_cap, dtype=torch.int32, pin_memory=True
+            )
+        for i in range(B + 1):
+            self._cu_seqlens_q_host[i] = i
+            self._cu_seqlens_k_host[i] = cu_seqlens_k_h[i]
+        fa_cu_seqlens_q = self._cu_seqlens_q_buf[: B + 1]
+        fa_cu_seqlens_k = self._cu_seqlens_k_buf[: B + 1]
+        fa_cu_seqlens_q.copy_(self._cu_seqlens_q_host[: B + 1], non_blocking=True)
+        fa_cu_seqlens_k.copy_(self._cu_seqlens_k_host[: B + 1], non_blocking=True)
+
+        # ── Verify (spec-as-decode) plan ─────────────────────────────────
+        # When the decode portion carries multi-token queries (an MTP verify
+        # step; query_len <= reorder threshold), build one virtual kernel row
+        # per decode token: its block-table row and its bottom-right causal
+        # length (committed + idx + 1). Persistent buffers, CPU-filled here,
+        # so the fused verify kernel is CUDA-graph-capturable (pointers stay
+        # stable across replays; only values change).
+        vq_req_t = vq_seqlen_t = None
+        vq_qlen = 0
+        if num_decodes > 0 and num_decode_tokens > num_decodes:
+            if (
+                self._vq_req_buf is None
+                or self._vq_req_buf.shape[0] < num_decode_tokens
+            ):
+                vq_cap = max(num_decode_tokens, 4096)
+                self._vq_req_buf = torch.empty(vq_cap, dtype=torch.int32, device=device)
+                self._vq_seqlen_buf = torch.empty(
+                    vq_cap, dtype=torch.int32, device=device
+                )
+                self._vq_req_host = torch.empty(
+                    vq_cap, dtype=torch.int32, pin_memory=True
+                )
+                self._vq_seqlen_host = torch.empty(
+                    vq_cap, dtype=torch.int32, pin_memory=True
+                )
+            # Non-causal (DFlash cross-attention): every query row attends to
+            # the full context, so its per-row limit is the whole seq_len, not
+            # the bottom-right causal staircase committed+j+1.
+            non_causal = not getattr(cam, "causal", True)
+            i = 0
+            uniform = query_lens_cpu[0] if num_decodes else 0
+            for b in range(num_decodes):
+                ql = query_lens_cpu[b] if b < len(query_lens_cpu) else 1
+                if ql != uniform:
+                    uniform = 0
+                committed = max(seq_lens_cpu[b] - ql, 0)
+                full = committed + ql
+                for j in range(ql):
+                    self._vq_req_host[i] = b
+                    self._vq_seqlen_host[i] = full if non_causal else committed + j + 1
+                    i += 1
+            # Uniform query length -> the shared-dequant verify kernel (the
+            # request's tokens share each block's dequant); this is always the
+            # case under uniform-batch graph capture. The shared kernel bakes
+            # the bottom-right causal staircase internally, so non-causal must
+            # fall back to the per-token path (which honours the flat per-row
+            # limit above) — force vq_qlen=0 in that case.
+            vq_qlen = uniform if (uniform >= 2 and not non_causal) else 0
+            vq_req_t = self._vq_req_buf[:num_decode_tokens]
+            vq_seqlen_t = self._vq_seqlen_buf[:num_decode_tokens]
+            vq_req_t.copy_(self._vq_req_host[:num_decode_tokens], non_blocking=True)
+            vq_seqlen_t.copy_(
+                self._vq_seqlen_host[:num_decode_tokens], non_blocking=True
+            )
+
+        max_blocks_per_req = (self._max_model_len + GROUP - 1) // GROUP
+
+        # A multi-query request with cached context (seq_len > query_len) is a
+        # speculative-decode verify step or a chunked-prefill continuation —
+        # its query tokens must attend over the cached K/V, not just each other.
+        # Detected here from CPU arrays (no GPU sync) so forward() can route it
+        # to the context-aware path. Fresh first-chunk prefill has
+        # seq_len == query_len on every row → flag stays False.
+        has_cached_multiquery = any(
+            query_lens_cpu[b] > 1 and seq_lens_cpu[b] > query_lens_cpu[b]
+            for b in range(min(B, len(query_lens_cpu)))
+        )
+
+        return KVarNMetadata(
+            seq_lens=cam.seq_lens,
+            block_table=cam.block_table_tensor,
+            query_start_loc=cam.query_start_loc,
+            slot_mapping=slot_mapping_t,
+            num_actual_tokens=cam.num_actual_tokens,
+            max_query_len=cam.max_query_len,
+            max_seq_len=cam.max_seq_len,
+            is_prefill=(cam.max_query_len > 1),
+            num_decodes=num_decodes,
+            num_decode_tokens=num_decode_tokens,
+            tiles_per_page=tiles_per_page,
+            has_cached_multiquery=has_cached_multiquery,
+            seq_lens_cpu=seq_lens_cpu,
+            # The allocator is driven by authoritative physical slot IDs.
+            # Keep the optional CPU table unset.
+            block_table_cpu=None,
+            slot_mapping_cpu=slot_mapping_cpu,
+            fa_cu_seqlens_q=fa_cu_seqlens_q,
+            fa_cu_seqlens_k=fa_cu_seqlens_k,
+            fa_max_blocks_per_req=max_blocks_per_req,
+            fa_max_seqlen_k_fixed=self._max_model_len,
+            vq_req=vq_req_t,
+            vq_seqlen=vq_seqlen_t,
+            vq_qlen=vq_qlen,
+            causal=getattr(cam, "causal", True),
+        )
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Attention impl
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class KVarNAttentionImpl(AttentionImpl["KVarNMetadata"]):
+    """KVarN attention implementation.
+
+    Slow PyTorch decode for Stage 3b.2 — replaced by Triton in Stage 4.
+    """
+
+    supports_quant_query_input: bool = False
+
+    # Shared decode scratch — these are per-step throwaway buffers used by
+    # `kvarn_decode_attention`. Sharing across all impl instances (one set
+    # per device) avoids 28× memory waste on the per-layer attention.
+    # Lazily allocated by `_ensure_pool` on the first non-capture call.
+    _shared_q_fp32_buf: ClassVar[dict[torch.device, torch.Tensor]] = {}
+    _shared_q_rot_fp32_buf: ClassVar[dict[torch.device, torch.Tensor]] = {}
+    _shared_q_rot_fp16_buf: ClassVar[dict[torch.device, torch.Tensor]] = {}
+    _shared_out_rot_fp32_buf: ClassVar[dict[torch.device, torch.Tensor]] = {}
+    _shared_output_fp32_buf: ClassVar[dict[torch.device, torch.Tensor]] = {}
+    _shared_fused_out_buf: ClassVar[dict[torch.device, torch.Tensor]] = {}
+    _shared_mid_o_buf: ClassVar[
+        dict[torch.device, torch.Tensor]
+    ] = {}  # split-K partials
+    _shared_mid_lse_buf: ClassVar[dict[torch.device, torch.Tensor]] = {}
+    _shared_fa_K_buf: ClassVar[dict[torch.device, torch.Tensor]] = {}
+    _shared_fa_V_buf: ClassVar[dict[torch.device, torch.Tensor]] = {}
+
+    # ── Stage α-2: class-level shared sparse slot allocator ──────────────────
+    # Single source of truth across all 28 KVarNAttentionImpl instances:
+    #   _block_to_slot_dict[block_id] → slot      (Python, CPU)
+    #   _block_to_slot_t_per_device[device][block_id] → slot int32    (GPU mirror)
+    #   _is_sink_t_per_device[device][block_id] → bool                (GPU mirror)
+    # All allocator mutations happen in KVarNMetadataBuilder.build(), which
+    # runs once per step OUTSIDE any captured CUDA-graph region. The captured
+    # do_kv_cache_update kernel just reads block_to_slot_t.
+    # Allocator state, scoped PER KV-CACHE-GROUP (key = group_key tuple), because
+    # block_ids are only unique WITHIN a group. CPU dicts keyed by group_key; GPU
+    # mirrors keyed by (device, group_key). See `self._group_key`.
+    _block_to_slot_dict: ClassVar[dict[tuple, dict[int, int]]] = {}
+    _global_sink_blocks: ClassVar[dict[tuple, set[int]]] = {}
+    _free_slots: ClassVar[dict[tuple, list[int]]] = {}
+    _allocator_pool_size: ClassVar[dict[tuple, int]] = {}
+    _block_to_slot_t_per_device: ClassVar[dict[tuple, torch.Tensor]] = {}
+    _is_sink_t_per_device: ClassVar[dict[tuple, torch.Tensor]] = {}
+    _max_known_block_id: ClassVar[dict[tuple, int]] = {}
+    # Kernel shapes whose Sinkhorn, K5/V5 store, and decode variants have
+    # already been compiled during pool initialization.
+    _kernel_warmed: ClassVar[set] = set()
+
+    # Registry of impls so the builder can enumerate per-layer pools when
+    # it needs to update sink markers / trigger flushes.
+    _all_impls: ClassVar[WeakSet[KVarNAttentionImpl]] = WeakSet()
+    _tiles_dumped: ClassVar[bool] = False
+
+    @classmethod
+    def _impls_for_group(cls, group_key: tuple) -> list[KVarNAttentionImpl]:
+        """Impls belonging to one KV-cache group (same group_key)."""
+        return [i for i in cls._all_impls if i._group_key == group_key]
+
+    @classmethod
+    def reset_kv_cache_binding_state(cls) -> None:
+        cls._block_to_slot_dict.clear()
+        cls._global_sink_blocks.clear()
+        cls._free_slots.clear()
+        cls._allocator_pool_size.clear()
+        cls._block_to_slot_t_per_device.clear()
+        cls._is_sink_t_per_device.clear()
+        cls._max_known_block_id.clear()
+        for impl in cls._all_impls:
+            impl._kv_cache_ref = None
+            impl._block_to_slot_t = None
+            impl._is_sink_t = None
+            impl._group_key = (
+                impl.head_size,
+                impl.num_kv_heads,
+                impl.sliding_window,
+            )
+
+    def __init__(
+        self,
+        num_heads: int,
+        head_size: int,
+        scale: float,
+        num_kv_heads: int | None = None,
+        alibi_slopes: list[float] | None = None,
+        sliding_window: int | None = None,
+        kv_cache_dtype: str = "auto",
+        logits_soft_cap: float | None = None,
+        attn_type: str = AttentionType.DECODER,
+        kv_sharing_target_layer_name: str | None = None,
+        **kwargs,
+    ):
+        self.num_heads = num_heads
+        self.head_size = head_size
+        self.scale = scale
+        self.num_kv_heads = num_kv_heads if num_kv_heads is not None else num_heads
+        self.num_kv_groups = num_heads // self.num_kv_heads
+        self.kv_cache_dtype = kv_cache_dtype
+        # Sliding-window layers (e.g. Gemma-4: 50/60 layers, window 1024) only
+        # attend to the last `sliding_window` keys. Stored so the decode kernel
+        # can bound its block loop to the window — without this it reads the FULL
+        # history every step (16x too much work + wrong output past the window).
+        self.sliding_window = sliding_window or 0
+        # KV-cache-group key. KVarN's slot allocator + GPU mirrors are keyed by
+        # block_id, but vLLM gives each KV-cache group an INDEPENDENT block_id
+        # space. Heterogeneous models put KVarN layers in >1 group (e.g. Gemma-4:
+        # sliding head256/16kv + global head512/4kv), so a single global allocator
+        # aliases the two groups' block_ids -> wrong slots -> garbage. Scope all
+        # allocator state by this key so each group has its own slot space.
+        # (head_size, num_kv_heads, sliding_window) uniquely identifies the group
+        # and is computable identically by the per-group builder and each impl.
+        self._group_key = (head_size, self.num_kv_heads, self.sliding_window)
+        if os.environ.get("KVARN_DBG_LAYERS") == "1":
+            print(
+                f"[KVARN_LAYER] head_size={head_size} num_heads={num_heads} "
+                f"num_kv_heads={self.num_kv_heads} "
+                f"sliding_window={self.sliding_window}",
+                flush=True,
+            )
+
+        from vllm.model_executor.layers.quantization.kvarn.config import (
+            KVarNConfig,
+        )
+
+        self.kvarn_config = KVarNConfig.from_cache_dtype(kv_cache_dtype, head_size)
+        self._activation_dtype = torch.get_default_dtype()
+        if self.kvarn_config.tail_dtype == "fp8":
+            self._tail_cache_dtype = torch.float8_e4m3fn
+        elif self.kvarn_config.tail_dtype == "float16":
+            self._tail_cache_dtype = torch.float16
+        else:
+            self._tail_cache_dtype = torch.bfloat16
+
+        # Fixed precision-tail pool. A group-level allocator maps physical
+        # block IDs to slots shared across every attention layer in the group.
+        # Completed non-resident blocks are packed between graph replays.
+        # [POOL_SIZE, group, Hk, D], FP8 by default.
+        self._tail_K_pool: torch.Tensor = None  # type: ignore[assignment]
+        self._tail_V_pool: torch.Tensor = None  # type: ignore[assignment]
+        # Per-token, per-KV-head FP16 scales for the FP8 pools. BF16 tails use
+        # singleton one-valued tensors so kernel signatures stay uniform.
+        self._tail_K_scale_pool: torch.Tensor = None  # type: ignore[assignment]
+        self._tail_V_scale_pool: torch.Tensor = None  # type: ignore[assignment]
+        # Per-instance shorthand views of the class-level per-device tensors
+        # (so kernels can read without dict lookups). Re-bound on every
+        # _ensure_pool call.
+        self._is_sink_t: torch.Tensor | None = None  # [num_blocks] bool
+        self._block_to_slot_t: torch.Tensor | None = None  # [num_blocks] int32
+        self._block_lookup_size: int = 0
+
+        # Cached fp16 Hadamard for the rotate-on-store matmul in
+        # do_kv_cache_update (avoids a per-call .float() cast that allocates).
+        self._H_fp16: torch.Tensor | None = None
+
+        # Store-side rotation scratch (pre-allocated by _ensure_pool so the
+        # captured forward never allocates). Shapes:
+        #   _k_rot_scratch  [max_num_batched_tokens, Hk, D] fp16
+        #   _v_rot_scratch  [max_num_batched_tokens, Hk, D] fp16
+        self._k_rot_scratch: torch.Tensor = None  # type: ignore[assignment]
+        self._v_rot_scratch: torch.Tensor = None  # type: ignore[assignment]
+
+        # Reference to this layer's int4 kv_cache, captured on the first
+        # forward(). The metadata builder uses it to drive tile-boundary
+        # flushes into this layer's cache (outside the captured region).
+        self._kv_cache_ref: torch.Tensor | None = None
+
+        # Stage 5.a Step 7 — decode scratch. These instance attrs are
+        # bound by `_ensure_pool` to per-device class-shared tensors so all
+        # 28 attention layers reuse a single set of buffers.
+        self._q_fp32_buf: torch.Tensor | None = None
+        self._q_rot_fp32_buf: torch.Tensor | None = None
+        self._q_rot_fp16_buf: torch.Tensor | None = None
+        self._out_rot_fp32_buf: torch.Tensor | None = None
+        self._output_fp32_buf: torch.Tensor | None = None
+        self._fused_out_buf: torch.Tensor | None = None
+        self._mid_o_buf: torch.Tensor | None = None
+        self._mid_lse_buf: torch.Tensor | None = None
+        self._fa_K_buf: torch.Tensor = None  # type: ignore[assignment]
+        self._fa_V_buf: torch.Tensor = None  # type: ignore[assignment]
+        self._use_cutedsl_decode = False
+
+        self.fa_version = get_flash_attn_version(head_size=head_size)
+
+        # Look up serving caps so scratch can be sized once, generously
+        # enough that capture probes don't trigger a resize inside the
+        # captured region. Falls back to conservative defaults if the
+        # global config isn't available (unit tests, etc).
+        try:
+            from vllm.config import get_current_vllm_config
+
+            _cfg = get_current_vllm_config()
+            self._max_num_seqs = _cfg.scheduler_config.max_num_seqs
+            self._max_num_batched_tokens = _cfg.scheduler_config.max_num_batched_tokens
+            self._max_model_len = _cfg.model_config.max_model_len
+            self._num_hidden_layers = getattr(
+                _cfg.model_config.hf_config, "num_hidden_layers", 32
+            )
+        except Exception:
+            self._max_num_seqs = 256
+            self._max_num_batched_tokens = 8192
+            self._num_hidden_layers = 32
+            self._max_model_len = 4096
+
+        # Register so the metadata builder can find us (slot allocation /
+        # sink marking / flush triggers all enumerate _all_impls).
+        type(self)._all_impls.add(self)
+
+    # ── helpers ──────────────────────────────────────────────────────────────
+
+    def _can_use_cutedsl_decode(self, device: torch.device) -> bool:
+        # Fixed-split scratch traffic still regresses full-model decode, so the
+        # CuTeDSL path remains an explicit experiment rather than an auto choice.
+        mode = os.environ.get("KVARN_CUTEDSL", "0").lower()
+        if mode not in ("1", "true", "on"):
+            return False
+        cfg = self.kvarn_config
+        supported = (
+            torch.cuda.get_device_capability(device) == (12, 0)
+            and self._activation_dtype == torch.float16
+            and cfg.head_dim == 128
+            and cfg.group == 128
+            and cfg.key_bits == 4
+            and cfg.value_bits == 2
+            and cfg.tail_dtype in ("fp8", "float16")
+            and self.num_heads == 32
+            and self.num_kv_heads == 8
+            and self.sliding_window == 0
+            and self._max_model_len <= 65536
+            and math.isclose(
+                self.scale,
+                1.0 / math.sqrt(128),
+                rel_tol=1e-6,
+                abs_tol=1e-8,
+            )
+        )
+        if not supported:
+            return False
+        import cutlass.cute  # noqa: F401
+        import quack.compile_utils  # noqa: F401
+
+        return True
+
+    def _ensure_pool(self, device: torch.device, num_blocks_hint: int = 0) -> None:
+        """Lazy-allocate the GPU tail pool + lookup tensors + decode scratch.
+
+        Stage α-2: pool is a *fixed-size* sparse buffer
+        ([POOL_SIZE, group, Hk, D]). A class-level allocator maps block_id →
+        slot (with a GPU lookup tensor `_block_to_slot_t_per_device[device]`
+        sized to num_blocks). Pool size = ~2 × max_num_seqs (covers
+        sink + in-progress tail for the largest captured batch).
+
+        All allocation happens BEFORE the captured forward, so
+        do_kv_cache_update can be pure tensor ops.
+        """
+        if torch.cuda.is_current_stream_capturing():
+            return
+        cfg = self.kvarn_config
+        cls = type(self)
+
+        # Pool: fixed size, per-instance because each layer holds unique K/V.
+        if self._tail_K_pool is None:
+            # Size the pool to the structural peak for the *capped* concurrency:
+            # sink + in-progress tail per active request, plus the full blocks a
+            # chunked prefill can touch. max_num_seqs has already been clamped in
+            # the platform's check_and_update_config so this peak fits the pool
+            # memory budget — making the pool both exhaustion-safe (the scheduler
+            # can never exceed it) and OOM-safe (it is <= the budget). No
+            # per-model tuning; KVARN_POOL_SLOTS still pins the count exactly.
+            env_slots = int(os.environ.get("KVARN_POOL_SLOTS", "0"))
+            if env_slots > 0:
+                pool_size = max(env_slots, 64)
+            else:
+                pool_size = cfg.pool_slots(
+                    self._max_num_seqs, self._max_num_batched_tokens
+                )
+            self._tail_K_pool = torch.zeros(
+                pool_size,
+                cfg.group,
+                self.num_kv_heads,
+                cfg.head_dim,
+                dtype=self._tail_cache_dtype,
+                device=device,
+            )
+            self._tail_V_pool = torch.zeros_like(self._tail_K_pool)
+            scale_shape = (
+                (pool_size, cfg.group, self.num_kv_heads)
+                if cfg.tail_dtype == "fp8"
+                else (pool_size, 1, 1)
+            )
+            self._tail_K_scale_pool = torch.ones(
+                scale_shape,
+                dtype=torch.float16,
+                device=device,
+            )
+            self._tail_V_scale_pool = torch.ones_like(self._tail_K_scale_pool)
+        else:
+            pool_size = self._tail_K_pool.shape[0]
+
+        # Per-GROUP allocator state — ensure it exists for THIS group_key.
+        # Decoupled from the per-impl pool allocation above: the impl's
+        # _group_key is set to the proxy in __init__ and later RE-TAGGED to the
+        # true (per-group) key by the builder, so the pool may already exist
+        # under a stale key when this group_key is first seen. Idempotent.
+        gk = self._group_key
+        if gk not in cls._free_slots:
+            cls._free_slots[gk] = list(range(pool_size - 1, -1, -1))
+            cls._allocator_pool_size[gk] = pool_size
+            cls._block_to_slot_dict[gk] = {}
+            cls._global_sink_blocks[gk] = set()
+
+        # GPU lookup tensors, keyed by (device, group_key): each KV-cache group
+        # has its own block_id space, so the two groups must NOT share a mirror.
+        gk = self._group_key
+        mkey = (device, gk)
+        num_blocks = max(num_blocks_hint, cls._max_known_block_id.get(gk, 0) + 1, 1024)
+        existing = cls._block_to_slot_t_per_device.get(mkey)
+        if existing is None or existing.shape[0] < num_blocks:
+            new_b2s = torch.full((num_blocks,), -1, dtype=torch.int32, device=device)
+            new_is_sink = torch.zeros(num_blocks, dtype=torch.bool, device=device)
+            # Re-sync from this group's CPU state (rare, only on resize / first init).
+            for bid, slot in cls._block_to_slot_dict.get(gk, {}).items():
+                if bid < num_blocks:
+                    new_b2s[bid] = slot
+            for bid in cls._global_sink_blocks.get(gk, set()):
+                if bid < num_blocks:
+                    new_is_sink[bid] = True
+            cls._block_to_slot_t_per_device[mkey] = new_b2s
+            cls._is_sink_t_per_device[mkey] = new_is_sink
+        # Per-instance shorthand pointers so the decode driver / kernels read
+        # without dict lookups in the hot path.
+        self._is_sink_t = cls._is_sink_t_per_device[mkey]
+        self._block_to_slot_t = cls._block_to_slot_t_per_device[mkey]
+        self._block_lookup_size = self._block_to_slot_t.shape[0]
+        self._use_cutedsl_decode = self._can_use_cutedsl_decode(device)
+
+        # Cached fp16 Hadamard for the rotate-on-store matmul.
+        if self._H_fp16 is None:
+            self._H_fp16 = (
+                self._hadamard(device).to(self._activation_dtype).contiguous()
+            )
+
+        # One-time flush-kernel warmup. The Sinkhorn + int4-store
+        # kernels are exercised ONLY at a tile-boundary flush, which never
+        # happens during vLLM's profiling/dummy run (no request crosses a block
+        # boundary there). So they JIT-compile on the FIRST real flush DURING
+        # serving — a multi-hundred-ms stall that surfaces as a latency spike
+        # and a `jit_monitor` "JIT compilation during inference" warning, and
+        # disproportionately hurts low-concurrency aggregate throughput (the
+        # one-time cost lands inside a small measured window). Compile them here,
+        # once per shape/config, at pool-init time (outside any captured region)
+        # using the exact tile shapes the flush uses, so serving never pays it.
+        warm_key = (
+            device,
+            cfg.head_dim,
+            cfg.group,
+            cfg.key_bits,
+            cfg.value_bits,
+            cfg.tail_dtype,
+        )
+        if warm_key not in cls._kernel_warmed:
+            k_dummy = torch.zeros(
+                1, cfg.head_dim, cfg.group, dtype=self._activation_dtype, device=device
+            )
+            v_dummy = torch.zeros(
+                1, cfg.group, cfg.head_dim, dtype=self._activation_dtype, device=device
+            )
+            _sinkhorn_pack_kv(k_dummy, v_dummy, cfg)
+            cls._kernel_warmed.add(warm_key)
+
+        # Decode-kernel warmup. The DECODE kernels (fused
+        # single-stage incl. its @triton.autotune sweep, split-K stage1/2, and
+        # the packed-KV build kernel) never run during vLLM's prefill-shaped
+        # profiling, so their one-time JIT + autotune cost (including the
+        # autotuner's benchmark scratch) used to land in the FIRST real decode —
+        # which, since v0.21, is the CUDA-graph memory estimation warmup. The
+        # estimate then absorbed those one-time costs and over-charged "graph
+        # memory" by GiBs, directly shrinking the derived KV-cache capacity.
+        # Warm them here (profile time) on tiny synthetic state instead: the
+        # cost is charged once to the memory profile, and the graph estimate
+        # measures only real graph-pool memory. Keyed per (device, shape combo).
+        dec_key = (
+            "decode",
+            device,
+            cfg.head_dim,
+            cfg.group,
+            cfg.key_bits,
+            cfg.value_bits,
+            self.num_heads,
+            self.num_kv_heads,
+            int(getattr(self, "sliding_window", 0) or 0),
+            cfg.tail_dtype,
+            self._use_cutedsl_decode,
+        )
+        if dec_key not in cls._kernel_warmed:
+            self._warm_decode_kernels(device)
+            cls._kernel_warmed.add(dec_key)
+
+        # Store-side rotation scratch.
+        if self._k_rot_scratch is None:
+            q_rows = max(self._max_num_batched_tokens, 1)
+            self._k_rot_scratch = torch.empty(
+                q_rows,
+                self.num_kv_heads,
+                cfg.head_dim,
+                dtype=self._activation_dtype,
+                device=device,
+            )
+            self._v_rot_scratch = torch.empty_like(self._k_rot_scratch)
+        # Decode scratch sized from vllm_config, SHARED across all impl
+        # instances on this device (one set per device).
+        D = cfg.head_dim
+        Hq = self.num_heads
+        Hk = self.num_kv_heads
+        # Decode scratch rows. The decode driver indexes these buffers by
+        # N = B * Hq (decode batch * query heads), so they must hold the largest
+        # decode N as well as any prefill token count. A decode step (incl. its
+        # CUDA-graph capture batch) has at most max_num_seqs queries, so the
+        # decode bound is max_num_seqs * Hq. Sizing to the max of that and
+        # max_num_batched_tokens makes the buffers correct for ANY
+        # max_num_batched_tokens (the old code silently assumed
+        # max_num_batched_tokens >= max_num_seqs * Hq, which breaks when it is
+        # set low — e.g. a small chunked-prefill budget on a wide model).
+        q_rows = max(self._max_num_batched_tokens, self._max_num_seqs * Hq, 1)
+        # FA packed K/V scratch holds the total KV tokens attended in ONE
+        # decode step (= sum of the batch's context lengths). The theoretical
+        # bound max_num_seqs * max_model_len is pathological (e.g. 256×8192 =
+        # 2.1M tokens ≈ 8.6 GB) and would starve the actual KV cache. Cap it at
+        # FA_SCRATCH_CAP tokens (~1 GB of fp16 K+V) — enough for typical
+        # serving and for the bench (single request up to max_model_len). The
+        # scratch is per-step, shared across all layers, allocated ONCE.
+        FA_SCRATCH_CAP = 262144
+        fa_rows = max(
+            min(self._max_num_seqs * self._max_model_len, FA_SCRATCH_CAP),
+            self._max_model_len,
+            4096,
+        )
+        cls = type(self)
+        # Key the shared decode scratch by (device, D, Hk), NOT device alone:
+        # heterogeneous-head models (e.g. Gemma-4: 256-dim/16-kv sliding layers +
+        # 512-dim/4-kv global layers) have multiple (head_dim, kv_heads) combos,
+        # and a buffer sized for one combo's D/Hk is the wrong width for another
+        # (caused a reshape(N,512)-on-256-wide-buffer crash). One scratch set per
+        # combo (Gemma-4 = 2 sets; cost is small).
+        bkey = (device, D, Hk, self._activation_dtype)
+        if bkey not in cls._shared_q_fp32_buf:
+            cls._shared_q_fp32_buf[bkey] = torch.empty(
+                q_rows, D, dtype=torch.float32, device=device
+            )
+            cls._shared_q_rot_fp32_buf[bkey] = torch.empty(
+                q_rows, D, dtype=torch.float32, device=device
+            )
+            cls._shared_q_rot_fp16_buf[bkey] = torch.empty(
+                q_rows, D, dtype=self._activation_dtype, device=device
+            )
+            cls._shared_out_rot_fp32_buf[bkey] = torch.empty(
+                q_rows, D, dtype=torch.float32, device=device
+            )
+            cls._shared_output_fp32_buf[bkey] = torch.empty(
+                q_rows, D, dtype=torch.float32, device=device
+            )
+            cls._shared_fused_out_buf[bkey] = torch.empty(
+                q_rows, D, dtype=self._activation_dtype, device=device
+            )
+        from vllm.v1.attention.ops.triton_kvarn_decode import adaptive_num_kv_splits
+
+        # Split-K partial buffers, sized to EXACTLY what the split-K decode path
+        # can index: it runs ONLY on pure single-query decode steps, whose row
+        # count is N = B*Hq with B <= max_num_seqs — NOT q_rows (which is
+        # max_num_batched_tokens-driven and sized the buffer ~85x too big at
+        # typical configs: 256 MiB instead of ~3 MiB for max_num_seqs=2/Hq=24/
+        # 64 splits). Split count matches the driver's
+        # adaptive helper (same max_model_len) or a larger adaptive count would
+        # overflow a smaller buffer; the driver additionally falls back to the
+        # single-stage kernel if N ever exceeds the buffer rows (defensive —
+        # e.g. an oversized padded dummy batch).
+        _splits = adaptive_num_kv_splits(
+            (self._max_model_len + cfg.group - 1) // cfg.group,
+            cfg,
+        )
+        if self._use_cutedsl_decode:
+            _splits = 128
+        # Rows are bounded by the split-K REGIME, not max_num_seqs: the driver
+        # only takes split-K when B*Hk <= sm_count (otherwise the single-stage
+        # kernel runs), so the most rows it can ever index is (sm_count//Hk)*Hq
+        # = sm_count*Q_PER_KV, independent of max_num_seqs. Sizing to
+        # max_num_seqs*Hq over-reserved this fp32 partial buffer ~10-20x at high
+        # concurrency, where it competes directly with the int4 KV cache. The
+        # driver still falls back to single-stage if N ever exceeds these rows
+        # (defensive), and split-K is never disabled for a batch it would take
+        # (B*Hk<=sm_count => N=B*Hq <= (sm_count//Hk)*Hq).
+        _sm = (
+            getattr(self, "_sm_count", 0)
+            or torch.cuda.get_device_properties(device).multi_processor_count
+        )
+        mid_rows = max((_sm // max(Hk, 1)) * Hq, Hq, 1)
+        _ex_mid = cls._shared_mid_o_buf.get(bkey)
+        if (
+            _ex_mid is None
+            or _ex_mid.shape[0] < mid_rows
+            or _ex_mid.shape[1] != _splits
+        ):
+            cls._shared_mid_o_buf[bkey] = torch.empty(
+                mid_rows, _splits, D, dtype=torch.float32, device=device
+            )
+            cls._shared_mid_lse_buf[bkey] = torch.empty(
+                mid_rows, _splits, dtype=torch.float32, device=device
+            )
+        if (
+            bkey not in cls._shared_fa_K_buf
+            or cls._shared_fa_K_buf[bkey].shape[0] < fa_rows
+        ):
+            cls._shared_fa_K_buf[bkey] = torch.zeros(
+                fa_rows, Hk, D, dtype=self._activation_dtype, device=device
+            )
+            cls._shared_fa_V_buf[bkey] = torch.zeros_like(cls._shared_fa_K_buf[bkey])
+        # Mirror to instance attrs for fast access by the decode driver.
+        self._q_fp32_buf = cls._shared_q_fp32_buf[bkey]
+        self._q_rot_fp32_buf = cls._shared_q_rot_fp32_buf[bkey]
+        self._q_rot_fp16_buf = cls._shared_q_rot_fp16_buf[bkey]
+        self._out_rot_fp32_buf = cls._shared_out_rot_fp32_buf[bkey]
+        self._output_fp32_buf = cls._shared_output_fp32_buf[bkey]
+        self._fused_out_buf = cls._shared_fused_out_buf[bkey]
+        self._mid_o_buf = cls._shared_mid_o_buf[bkey]
+        self._mid_lse_buf = cls._shared_mid_lse_buf[bkey]
+        self._fa_K_buf = cls._shared_fa_K_buf[bkey]
+        self._fa_V_buf = cls._shared_fa_V_buf[bkey]
+
+    def _warm_decode_kernels(self, device: torch.device) -> None:
+        """Compile + autotune every decode-path Triton kernel on tiny synthetic
+        state (see the note at the call site in ``_ensure_pool``).
+        Uses throwaway tensors only — never touches the real cache/pool."""
+        from vllm.v1.attention.ops.triton_kvarn_decode import (
+            _kvarn_build_packed_kv_kernel,
+            _kvarn_fused_decode_kernel,
+            _kvarn_fused_decode_stage1,
+            _kvarn_fused_decode_stage2,
+            adaptive_num_kv_splits,
+        )
+
+        cfg = self.kvarn_config
+        D, G = cfg.head_dim, cfg.group
+        Hq, Hk = self.num_heads, self.num_kv_heads
+        B, n_blocks = 8, 4
+        sw = int(getattr(self, "sliding_window", 0) or 0)
+
+        cache = torch.zeros(
+            B * n_blocks,
+            Hk,
+            cfg.tile_bytes_aligned,
+            dtype=torch.uint8,
+            device=device,
+        )
+        pool_k = torch.zeros(1, G, Hk, D, dtype=self._tail_cache_dtype, device=device)
+        pool_v = torch.zeros_like(pool_k)
+        scale_shape = (1, G, Hk) if cfg.tail_dtype == "fp8" else (1, 1, 1)
+        pool_ks = torch.ones(scale_shape, dtype=torch.float16, device=device)
+        pool_vs = torch.ones_like(pool_ks)
+        b2s = torch.full((B * n_blocks,), -1, dtype=torch.int32, device=device)
+        bt = torch.arange(B * n_blocks, dtype=torch.int32, device=device).view(
+            B, n_blocks
+        )
+        sl = torch.full((B,), n_blocks * G, dtype=torch.int32, device=device)
+        q = torch.zeros(B, Hq, D, dtype=self._activation_dtype, device=device)
+        out = torch.zeros_like(q)
+
+        qpk = Hq // Hk
+        qpk_pad = 1 << (qpk - 1).bit_length() if qpk > 1 else 1
+        common = dict(
+            MAX_BLOCKS_PER_REQ=n_blocks,
+            D=D,
+            GROUP=G,
+            TILES_PER_PAGE=1,
+            Q_PER_KV=qpk,
+            Q_PER_KV_PAD=qpk_pad,
+            SLIDING_WINDOW=sw,
+            K_BITS=cfg.key_bits,
+            V_BITS=cfg.value_bits,
+            NUM_BLOCKS_LOOKUP=B * n_blocks,
+            K_PACKED_OFFSET=cfg.k_packed_offset,
+            K_S_COL_OFFSET=cfg.k_s_col_offset,
+            K_ZP_OFFSET=cfg.k_zp_offset,
+            K_S_ROW_OFFSET=cfg.k_s_row_offset,
+            V_PACKED_OFFSET=cfg.v_packed_offset,
+            V_S_COL_OFFSET=cfg.v_s_col_offset,
+            V_S_ROW_OFFSET=cfg.v_s_row_offset,
+            V_ZP_OFFSET=cfg.v_zp_offset,
+            VQ_INDIRECT=False,
+            TAIL_SCALED=cfg.tail_dtype == "fp8",
+        )
+        # 1. Single-stage fused kernel — runs the @triton.autotune sweep.
+        # (sl doubles as the unused Req_row_ptr dummy; see VQ_INDIRECT.)
+        _kvarn_fused_decode_kernel[(B, Hk)](
+            q,
+            sl,
+            bt,
+            sl,
+            b2s,
+            cache,
+            pool_k,
+            pool_v,
+            pool_ks,
+            pool_vs,
+            out,
+            self.scale,
+            Hq * D,
+            D,
+            bt.stride(0),
+            cache.stride(0),
+            cache.stride(1),
+            pool_k.stride(0),
+            pool_k.stride(1),
+            pool_k.stride(2),
+            pool_ks.stride(0),
+            pool_ks.stride(1),
+            pool_ks.stride(2),
+            Hq * D,
+            D,
+            **common,
+        )
+        # 2. Split-K stage1 + stage2, with the exact split count and launch
+        # knobs the decode driver will use for this deployment.
+        splits = adaptive_num_kv_splits((self._max_model_len + G - 1) // G, cfg)
+        mid_o = torch.zeros(B * Hq, splits, D, dtype=torch.float32, device=device)
+        mid_lse = torch.zeros(B * Hq, splits, dtype=torch.float32, device=device)
+        # stage1 is @triton.autotune'd; this warmup launch triggers its sweep
+        # here (pre-CUDA-graph-capture) so capture never benchmarks.
+        _kvarn_fused_decode_stage1[(B, Hk, splits)](
+            q,
+            sl,
+            bt,
+            sl,
+            b2s,
+            cache,
+            pool_k,
+            pool_v,
+            pool_ks,
+            pool_vs,
+            mid_o,
+            mid_lse,
+            self.scale,
+            Hq * D,
+            D,
+            bt.stride(0),
+            cache.stride(0),
+            cache.stride(1),
+            pool_k.stride(0),
+            pool_k.stride(1),
+            pool_k.stride(2),
+            pool_ks.stride(0),
+            pool_ks.stride(1),
+            pool_ks.stride(2),
+            mid_o.stride(0),
+            mid_o.stride(1),
+            mid_lse.stride(0),
+            NUM_KV_SPLITS=splits,
+            HQ=Hq,
+            **common,
+        )
+        out2d = out.view(B * Hq, D)
+        _kvarn_fused_decode_stage2[(B * Hq,)](
+            mid_o,
+            mid_lse,
+            out2d,
+            mid_o.stride(0),
+            mid_o.stride(1),
+            mid_lse.stride(0),
+            out2d.stride(0),
+            D=D,
+            NUM_KV_SPLITS=splits,
+            num_warps=2,
+        )
+        # 2b. VQ_INDIRECT (fused spec-verify) specializations — separate
+        # compiled variants; warm them so the FIRST MTP verify step doesn't
+        # pay the Triton JIT mid-serving.
+        vq_rows = torch.zeros(B, dtype=torch.int32, device=device)
+        common_vq = dict(common, VQ_INDIRECT=True)
+        _kvarn_fused_decode_kernel[(B, Hk)](
+            q,
+            vq_rows,
+            bt,
+            sl,
+            b2s,
+            cache,
+            pool_k,
+            pool_v,
+            pool_ks,
+            pool_vs,
+            out,
+            self.scale,
+            Hq * D,
+            D,
+            bt.stride(0),
+            cache.stride(0),
+            cache.stride(1),
+            pool_k.stride(0),
+            pool_k.stride(1),
+            pool_k.stride(2),
+            pool_ks.stride(0),
+            pool_ks.stride(1),
+            pool_ks.stride(2),
+            Hq * D,
+            D,
+            **common_vq,
+        )
+        _kvarn_fused_decode_stage1[(B, Hk, splits)](
+            q,
+            vq_rows,
+            bt,
+            sl,
+            b2s,
+            cache,
+            pool_k,
+            pool_v,
+            pool_ks,
+            pool_vs,
+            mid_o,
+            mid_lse,
+            self.scale,
+            Hq * D,
+            D,
+            bt.stride(0),
+            cache.stride(0),
+            cache.stride(1),
+            pool_k.stride(0),
+            pool_k.stride(1),
+            pool_k.stride(2),
+            pool_ks.stride(0),
+            pool_ks.stride(1),
+            pool_ks.stride(2),
+            mid_o.stride(0),
+            mid_o.stride(1),
+            mid_lse.stride(0),
+            NUM_KV_SPLITS=splits,
+            HQ=Hq,
+            **common_vq,
+        )
+        # 2c. Shared-dequant verify kernel (uniform-QLEN spec verify) — runs
+        # its @triton.autotune sweep here so capture never benchmarks. QLEN is
+        # the deployment's 1 + num_speculative_tokens.
+        try:
+            from vllm.config import get_current_vllm_config
+
+            _spec = get_current_vllm_config().speculative_config
+            _qlen = 1 + int(_spec.num_speculative_tokens) if _spec else 0
+        except Exception:
+            _qlen = 0
+        if _qlen >= 2:
+            from vllm.v1.attention.ops.triton_kvarn_decode import (
+                _kvarn_fused_verify_stage1,
+            )
+
+            nq = B * _qlen
+            sl_vq = sl.repeat_interleave(_qlen)
+            qv = torch.zeros(nq, Hq, D, dtype=self._activation_dtype, device=device)
+            mid_o_v = torch.zeros(
+                nq * Hq, splits, D, dtype=torch.float32, device=device
+            )
+            mid_lse_v = torch.zeros(nq * Hq, splits, dtype=torch.float32, device=device)
+            common_v = dict(common)
+            _kvarn_fused_verify_stage1[(B, Hk, splits)](
+                qv,
+                bt,
+                sl_vq,
+                b2s,
+                cache,
+                pool_k,
+                pool_v,
+                pool_ks,
+                pool_vs,
+                mid_o_v,
+                mid_lse_v,
+                self.scale,
+                Hq * D,
+                D,
+                bt.stride(0),
+                cache.stride(0),
+                cache.stride(1),
+                pool_k.stride(0),
+                pool_k.stride(1),
+                pool_k.stride(2),
+                pool_ks.stride(0),
+                pool_ks.stride(1),
+                pool_ks.stride(2),
+                mid_o_v.stride(0),
+                mid_o_v.stride(1),
+                mid_lse_v.stride(0),
+                QLEN=_qlen,
+                HQ=Hq,
+                NUM_KV_SPLITS=splits,
+                **common_v,
+            )
+        # 3. Packed-KV build kernel (materialize fallback + the cached-multiquery
+        # spec-verify path).
+        kp = torch.zeros(
+            B * n_blocks * G,
+            Hk,
+            D,
+            dtype=self._activation_dtype,
+            device=device,
+        )
+        vp = torch.zeros_like(kp)
+        cu_k = torch.arange(B + 1, dtype=torch.int32, device=device) * (n_blocks * G)
+        _kvarn_build_packed_kv_kernel[(B * n_blocks, Hk)](
+            bt,
+            sl,
+            cu_k,
+            b2s,
+            cache,
+            pool_k,
+            pool_v,
+            pool_ks,
+            pool_vs,
+            kp,
+            vp,
+            bt.stride(0),
+            cache.stride(0),
+            cache.stride(1),
+            pool_k.stride(0),
+            pool_k.stride(1),
+            pool_k.stride(2),
+            pool_ks.stride(0),
+            pool_ks.stride(1),
+            pool_ks.stride(2),
+            kp.stride(0),
+            kp.stride(1),
+            MAX_BLOCKS_PER_REQ=n_blocks,
+            D=D,
+            GROUP=G,
+            K_BITS=cfg.key_bits,
+            V_BITS=cfg.value_bits,
+            NUM_BLOCKS_LOOKUP=B * n_blocks,
+            K_PACKED_OFFSET=cfg.k_packed_offset,
+            K_S_COL_OFFSET=cfg.k_s_col_offset,
+            K_ZP_OFFSET=cfg.k_zp_offset,
+            K_S_ROW_OFFSET=cfg.k_s_row_offset,
+            V_PACKED_OFFSET=cfg.v_packed_offset,
+            TILES_PER_PAGE=1,
+            V_S_COL_OFFSET=cfg.v_s_col_offset,
+            V_S_ROW_OFFSET=cfg.v_s_row_offset,
+            V_ZP_OFFSET=cfg.v_zp_offset,
+            num_warps=4,
+            num_stages=2,
+            TAIL_SCALED=cfg.tail_dtype == "fp8",
+        )
+        if self._use_cutedsl_decode:
+            from vllm.v1.attention.ops.cutedsl_kvarn_decode import (
+                run as cutedsl_kvarn_stage1,
+            )
+
+            cute_splits = 128
+            cute_mid_o = torch.zeros(
+                B * Hq,
+                cute_splits,
+                D,
+                dtype=torch.float32,
+                device=device,
+            )
+            cute_mid_lse = torch.full(
+                (B * Hq, cute_splits),
+                -torch.inf,
+                dtype=torch.float32,
+                device=device,
+            )
+            cutedsl_kvarn_stage1(
+                q,
+                cache,
+                pool_k,
+                pool_v,
+                pool_ks,
+                pool_vs,
+                bt,
+                sl,
+                b2s,
+                cute_mid_o,
+                cute_mid_lse,
+                cute_splits,
+                self.kv_cache_dtype,
+            )
+            _kvarn_fused_decode_stage2[(B * Hq,)](
+                cute_mid_o,
+                cute_mid_lse,
+                out.view(B * Hq, D),
+                cute_mid_o.stride(0),
+                cute_mid_o.stride(1),
+                cute_mid_lse.stride(0),
+                out.view(B * Hq, D).stride(0),
+                D=D,
+                NUM_KV_SPLITS=cute_splits,
+                num_warps=2,
+            )
+        torch.accelerator.synchronize(device)
+
+    def _batch_slot_mapping_cpu(self) -> list[int] | None:
+        """Return the slot_mapping CPU list cached on this step's metadata, or
+        None if unavailable. Looks up via the forward context so we don't need
+        the caller to plumb it through."""
+        try:
+            from vllm.forward_context import get_forward_context
+
+            ctx = get_forward_context()
+        except Exception:
+            return None
+        md = getattr(ctx, "attn_metadata", None)
+        if md is None:
+            return None
+        if isinstance(md, dict):
+            for m in md.values():
+                if isinstance(m, KVarNMetadata):
+                    return m.slot_mapping_cpu
+            return None
+        if isinstance(md, list):
+            for entry in md:
+                if isinstance(entry, dict):
+                    for m in entry.values():
+                        if isinstance(m, KVarNMetadata):
+                            return m.slot_mapping_cpu
+            return None
+        return getattr(md, "slot_mapping_cpu", None)
+
+    def _hadamard(self, device: torch.device) -> torch.Tensor:
+        return _build_hadamard(self.head_size, device)
+
+    def _flat_block(
+        self, kv_cache: torch.Tensor, block_id: int, head: int
+    ) -> torch.Tensor:
+        """Contiguous packed record for one physical quantization subtile."""
+        tiles = kv_cache.view(
+            -1,
+            self.num_kv_heads,
+            self.kvarn_config.tile_bytes_aligned,
+        )
+        return tiles[block_id, head]
+
+    def _write_packed(
+        self,
+        kv_cache: torch.Tensor,
+        block_id: int,
+        head: int,
+        store_K: dict[str, torch.Tensor],
+        store_V: dict[str, torch.Tensor],
+    ) -> None:
+        cfg = self.kvarn_config
+        flat = self._flat_block(kv_cache, block_id, head)
+
+        # K packed bytes
+        ko = cfg.k_packed_offset
+        flat[ko : ko + cfg.k_packed_bytes] = (
+            store_K["q_packed_uint8"].reshape(-1).to(torch.uint8)
+        )
+        # K s_col, zp (per-channel, length D, fp16)
+        flat[cfg.k_s_col_offset : cfg.k_s_col_offset + cfg.head_dim * 2].view(
+            torch.float16
+        )[:] = store_K["s_col_K"]
+        flat[cfg.k_zp_offset : cfg.k_zp_offset + cfg.head_dim * 2].view(torch.float16)[
+            :
+        ] = store_K["zp_K"]
+        flat[cfg.k_s_row_offset : cfg.k_s_row_offset + cfg.group * 2].view(
+            torch.float16
+        )[:] = store_K["s_row_K"]
+
+        # V packed bytes
+        vo = cfg.v_packed_offset
+        flat[vo : vo + cfg.v_packed_bytes] = (
+            store_V["q_packed_uint8"].reshape(-1).to(torch.uint8)
+        )
+        flat[cfg.v_s_col_offset : cfg.v_s_col_offset + cfg.head_dim * 2].view(
+            torch.float16
+        )[:] = store_V["s_col_V"]
+        flat[cfg.v_s_row_offset : cfg.v_s_row_offset + cfg.group * 2].view(
+            torch.float16
+        )[:] = store_V["s_row_V"]
+        flat[cfg.v_zp_offset : cfg.v_zp_offset + cfg.group * 2].view(torch.float16)[
+            :
+        ] = store_V["zp_V"]
+
+    def _read_block_dequantized(
+        self,
+        kv_cache: torch.Tensor,
+        block_id: int,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Read a full quantized block and return (K, V) in unrotated frame.
+
+        Returns:
+            K: [group, num_kv_heads, head_dim] fp16
+            V: [group, num_kv_heads, head_dim] fp16
+        """
+        cfg = self.kvarn_config
+        group = cfg.group
+        D = cfg.head_dim
+        device = kv_cache.device
+
+        K_out = torch.empty(
+            group, self.num_kv_heads, D, dtype=self._activation_dtype, device=device
+        )
+        V_out = torch.empty(
+            group, self.num_kv_heads, D, dtype=self._activation_dtype, device=device
+        )
+
+        H = self._hadamard(device)  # [D, D] fp32
+
+        for h in range(self.num_kv_heads):
+            flat = self._flat_block(kv_cache, block_id, h)
+
+            # Dense bit-stream payload. Supported groups make every per-channel
+            # row byte-aligned even when five-bit codes cross byte boundaries.
+            k_row_bytes = math.ceil(group * cfg.key_bits / 8)
+            k_packed = flat[
+                cfg.k_packed_offset : cfg.k_packed_offset + cfg.k_packed_bytes
+            ].view(D, k_row_bytes)
+            s_col_K = flat[cfg.k_s_col_offset : cfg.k_s_col_offset + D * 2].view(
+                torch.float16
+            )
+            zp_K = flat[cfg.k_zp_offset : cfg.k_zp_offset + D * 2].view(torch.float16)
+            s_row_K = flat[cfg.k_s_row_offset : cfg.k_s_row_offset + group * 2].view(
+                torch.float16
+            )
+            K_rot_DG = kvarn_dequant_tile_k(
+                k_packed, s_col_K, zp_K, s_row_K, group=group, bits=cfg.key_bits
+            )
+            # Un-rotate: [D, group] → [group, D] (= K rows-tokens),
+            # then ⋅H to undo rotation
+            K_unrot = K_rot_DG.T @ H  # [group, D]
+            K_out[:, h, :] = K_unrot.to(self._activation_dtype)
+
+            v_row_bytes = math.ceil(D * cfg.value_bits / 8)
+            v_packed = flat[
+                cfg.v_packed_offset : cfg.v_packed_offset + cfg.v_packed_bytes
+            ].view(group, v_row_bytes)
+            s_col_V = flat[cfg.v_s_col_offset : cfg.v_s_col_offset + D * 2].view(
+                torch.float16
+            )
+            s_row_V = flat[cfg.v_s_row_offset : cfg.v_s_row_offset + group * 2].view(
+                torch.float16
+            )
+            zp_V = flat[cfg.v_zp_offset : cfg.v_zp_offset + group * 2].view(
+                torch.float16
+            )
+            V_rot_GD = kvarn_dequant_tile_v(
+                v_packed, s_col_V, s_row_V, zp_V, head_dim=D, bits=cfg.value_bits
+            )
+            V_unrot = V_rot_GD @ H  # [group, D]
+            V_out[:, h, :] = V_unrot.to(self._activation_dtype)
+
+        return K_out, V_out
+
+    def _tail_pool_float(
+        self,
+        pool: torch.Tensor,
+        scale_pool: torch.Tensor,
+        index,
+    ) -> torch.Tensor:
+        values = pool[index].float()
+        if self.kvarn_config.tail_dtype == "fp8":
+            values.mul_(scale_pool[index].float().unsqueeze(-1))
+        return values
+
+    def _flush_tail(self, block_id: int, kv_cache: torch.Tensor) -> None:
+        """Quantize a fully-filled tail buffer and write it into the cache.
+
+        Stage α-2 sparse pool: pool slot = _block_to_slot_dict[block_id].
+        Data is already rotated (rotation happens at do_kv_cache_update),
+        so no `@ H` step here.
+        """
+        cfg = self.kvarn_config
+        cls = type(self)
+        slot = cls._block_to_slot_dict.get(self._group_key, {}).get(block_id)
+        if slot is None:
+            # Block has no pool slot — nothing to flush.
+            return
+        K_rot = self._tail_pool_float(self._tail_K_pool, self._tail_K_scale_pool, slot)
+        V_rot = self._tail_pool_float(self._tail_V_pool, self._tail_V_scale_pool, slot)
+
+        # Build batched per-head tiles (rows = absorb axis for each)
+        K_tiles = K_rot.permute(1, 2, 0).contiguous()  # [Hk, D, group]
+        V_tiles = V_rot.permute(1, 0, 2).contiguous()  # [Hk, group, D]
+
+        # Sinkhorn + pack (fused launch when square head_dim==group, else
+        # separate K/V launches — see _sinkhorn_pack_kv).
+        K_out, V_out = _sinkhorn_pack_kv(K_tiles, V_tiles, cfg)
+        Hk = self.num_kv_heads
+
+        for h in range(Hk):
+            store_K = {k: v[h] for k, v in K_out.items()}
+            store_V = {k: v[h] for k, v in V_out.items()}
+            self._write_packed(kv_cache, block_id, h, store_K, store_V)
+
+        # NOTE: the pool slot is NOT freed here. The slot index addresses the
+        # SAME row in every layer's pool, so it must stay allocated until ALL
+        # layers have flushed their data into int4. The builder frees it once,
+        # after iterating every impl (see "Free the flushed blocks' slots" in
+        # build()). Freeing here would let layer 0's flush drop the slot, after
+        # which layers 1..N find no slot (`.get()` → None) and silently skip
+        # writing their packed cache record and corrupting all later layers.
+
+    @classmethod
+    def _batched_flush(cls, flush_pairs: list) -> None:
+        """Flush many ``(impl, block_id, kv_cache)`` tiles to K5/V5.
+
+        The default vectorized path replaces per-tile Python GPU operations
+        with one gather and one cache write per layer and bounded block chunk.
+        ``KVARN_FAST_FLUSH=0`` retains the reference path for diagnostics.
+        """
+        if not flush_pairs:
+            return
+        if os.environ.get("KVARN_FAST_FLUSH", "1") != "1":
+            return cls._batched_flush_legacy(flush_pairs)
+
+        cfg = flush_pairs[0][0].kvarn_config
+        Hk = flush_pairs[0][0].num_kv_heads
+        D = cfg.head_dim
+        G = cfg.group
+        T = cfg.tile_bytes_aligned
+        kpb = cfg.k_packed_bytes
+        vpb = cfg.v_packed_bytes
+
+        # Group by impl (layer); every impl flushes the SAME block set (the
+        # builder cross-products flush_block_ids with group_impls) and pool slot
+        # indices are shared across layers, so per impl we have (kvc, bids, slots).
+        by_impl: dict = {}
+        for impl, bid, kvc in flush_pairs:
+            slot = cls._block_to_slot_dict.get(impl._group_key, {}).get(bid)
+            if slot is None:
+                continue
+            e = by_impl.get(id(impl))
+            if e is None:
+                e = [impl, kvc, [], []]
+                by_impl[id(impl)] = e
+            e[2].append(bid)
+            e[3].append(slot)
+        if not by_impl:
+            return
+
+        # Block-chunk so one Sinkhorn launch stays bounded (~2k [R,C] tiles).
+        CHUNK_BLOCKS = max(1, 2048 // max(Hk, 1))
+        indices_by_group: dict[
+            tuple, tuple[list[int], list[int], torch.Tensor, torch.Tensor]
+        ] = {}
+        for impl, kvc, bids, slots in by_impl.values():
+            if kvc is None:
+                continue
+            dev = impl._tail_K_pool.device
+            index_key = (impl._group_key, dev)
+            indices = indices_by_group.get(index_key)
+            if indices is None or indices[0] != bids or indices[1] != slots:
+                slots_dev = torch.as_tensor(slots, dtype=torch.long, device=dev)
+                bids_dev = torch.as_tensor(bids, dtype=torch.long, device=dev)
+                indices_by_group[index_key] = (bids, slots, bids_dev, slots_dev)
+            else:
+                bids_dev, slots_dev = indices[2:]
+            for c0 in range(0, len(bids), CHUNK_BLOCKS):
+                bchunk = bids[c0 : c0 + CHUNK_BLOCKS]
+                nB = len(bchunk)
+                slot_t = slots_dev[c0 : c0 + CHUNK_BLOCKS]
+                bid_t = bids_dev[c0 : c0 + CHUNK_BLOCKS]
+                # One gather per chunk (was nB tiny .float() ops).
+                K_rot = impl._tail_pool_float(
+                    impl._tail_K_pool, impl._tail_K_scale_pool, slot_t
+                )
+                V_rot = impl._tail_pool_float(
+                    impl._tail_V_pool, impl._tail_V_scale_pool, slot_t
+                )
+                # Tiles: K [N, D, G] (absorb=channel), V [N, G, D] (absorb=token).
+                K_tiles = K_rot.permute(0, 2, 3, 1).reshape(nB * Hk, D, G)
+                V_tiles = V_rot.permute(0, 2, 1, 3).reshape(nB * Hk, G, D)
+                K_out, V_out = _sinkhorn_pack_kv(K_tiles, V_tiles, cfg)
+                # Assemble one contiguous record without a second full-record
+                # padding copy.
+                M = nB * Hk
+                parts = [
+                    K_out["q_packed_uint8"].reshape(M, kpb),
+                    K_out["s_col_K"].contiguous().view(torch.uint8),
+                    K_out["zp_K"].contiguous().view(torch.uint8),
+                    K_out["s_row_K"].contiguous().view(torch.uint8),
+                    V_out["q_packed_uint8"].reshape(M, vpb),
+                    V_out["s_col_V"].contiguous().view(torch.uint8),
+                    V_out["s_row_V"].contiguous().view(torch.uint8),
+                    V_out["zp_V"].contiguous().view(torch.uint8),
+                ]
+                if cfg.tile_bytes < T:
+                    parts.append(parts[0].new_zeros(M, T - cfg.tile_bytes))
+                rec = torch.cat(parts, dim=1)
+                # One scatter per chunk (was nB*Hk _write_packed calls).
+                kvc.view(-1, Hk, T)[bid_t] = rec.view(nB, Hk, T)
+
+    @classmethod
+    def _batched_flush_legacy(cls, flush_pairs: list) -> None:
+        """Flush many (impl, block_id, kv_cache) tiles via batched Sinkhorn + RTN.
+
+        Replaces the per-(layer, block) Python loop calling `_flush_tail`. At
+        burst with many layers × many lockstep boundary crossings, the per-call
+        kernel-launch + Python-iter overhead dominated; Sinkhorn and the RTN-
+        pack are per-tile-independent, so stacking is numerically identical
+        (no accuracy change).
+
+        Chunked at CHUNK_PAIRS to bound the transient gather memory — at peak
+        (48 layers × ~73 lockstep reqs = ~3.5k pairs), the unchunked stack hits
+        >2 GB of fp32 working memory and OOMs on a memory-tight burst.
+        """
+        if not flush_pairs:
+            return
+        CHUNK_PAIRS = 256
+        cfg = flush_pairs[0][0].kvarn_config
+        Hk = flush_pairs[0][0].num_kv_heads
+        # Pre-filter pairs that still have a pool slot (some may have been freed
+        # by a sibling impl's flush already during this builder call).
+        filt: list[tuple] = []
+        for impl, bid, kvc in flush_pairs:
+            slot = cls._block_to_slot_dict.get(impl._group_key, {}).get(bid)
+            if slot is None:
+                continue
+            filt.append((impl, bid, kvc, slot))
+        if not filt:
+            return
+        for c0 in range(0, len(filt), CHUNK_PAIRS):
+            chunk = filt[c0 : c0 + CHUNK_PAIRS]
+            N = len(chunk)
+            # Gather pool data for this chunk.
+            K_list = [
+                impl._tail_pool_float(impl._tail_K_pool, impl._tail_K_scale_pool, slot)
+                for impl, _, _, slot in chunk
+            ]
+            V_list = [
+                impl._tail_pool_float(impl._tail_V_pool, impl._tail_V_scale_pool, slot)
+                for impl, _, _, slot in chunk
+            ]
+            K_stack = torch.stack(K_list, dim=0)  # [N, G, Hk, D]
+            V_stack = torch.stack(V_list, dim=0)
+            # Optional: dump first chunk's raw (pre-Sinkhorn) tiles for outlier
+            # analysis (KVARN_DUMP_TILES=/path/to/file.pt).
+            dump_path = os.environ.get("KVARN_DUMP_TILES", "")
+            if dump_path and not getattr(cls, "_tiles_dumped", False):
+                cls._tiles_dumped = True
+                # Capture per-tile (layer_idx, block_id) for per-layer analysis.
+                # layer_idx pulled from impl.layer_name
+                # (e.g. "model.layers.7.self_attn")
+                # via a regex fallback to enumerate index if name parsing fails.
+                import regex as re
+
+                lyr_ids, blk_ids = [], []
+                for impl, bid, _, _ in chunk:
+                    name = getattr(impl, "layer_name", "") or ""
+                    m = re.search(r"layers\.(\d+)\b", name)
+                    lyr_ids.append(int(m.group(1)) if m else -1)
+                    blk_ids.append(int(bid))
+                torch.save(
+                    {
+                        "K_stack": K_stack.detach().cpu(),
+                        "V_stack": V_stack.detach().cpu(),
+                        "layer_ids": lyr_ids,
+                        "block_ids": blk_ids,
+                        "Hk": flush_pairs[0][0].num_kv_heads,
+                        "G": cfg.group,
+                        "D": cfg.head_dim,
+                        "key_bits": cfg.key_bits,
+                        "value_bits": cfg.value_bits,
+                        "sinkhorn_iters": cfg.sinkhorn_iters,
+                    },
+                    dump_path,
+                )
+                print(
+                    f"[KVARN] dumped {N} (layer,block) pre-Sinkhorn tiles "
+                    f"→ {dump_path}",
+                    flush=True,
+                )
+                print(f"[KVARN] layer_ids in dump: {sorted(set(lyr_ids))}", flush=True)
+            del K_list, V_list
+            # K tile per Sinkhorn batch row: [D, G] (absorb = channel).
+            K_tiles = K_stack.permute(0, 2, 3, 1).reshape(
+                N * Hk, K_stack.shape[3], K_stack.shape[1]
+            )
+            V_tiles = V_stack.permute(0, 2, 1, 3).reshape(
+                N * Hk, V_stack.shape[1], V_stack.shape[3]
+            )
+            del K_stack, V_stack
+            # Sinkhorn + pack (fused when square head_dim==group, else separate
+            # K/V launches for non-square head_dim=256 — see _sinkhorn_pack_kv).
+            K_out, V_out = _sinkhorn_pack_kv(K_tiles, V_tiles, cfg)
+            del K_tiles, V_tiles
+            # Distribute packed results to each (layer, block, head) cache slot.
+            for i, (impl, bid, kvc, _) in enumerate(chunk):
+                for h in range(Hk):
+                    idx = i * Hk + h
+                    store_K = {k: v[idx] for k, v in K_out.items()}
+                    store_V = {k: v[idx] for k, v in V_out.items()}
+                    impl._write_packed(kvc, bid, h, store_K, store_V)
+            del K_out, V_out
+
+    # ── do_kv_cache_update ───────────────────────────────────────────────────
+
+    def do_kv_cache_update(
+        self,
+        layer: torch.nn.Module,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        kv_cache: torch.Tensor,
+        slot_mapping: torch.Tensor,
+    ) -> None:
+        """Append incoming tokens to the per-block fp16 tail buffers.
+
+        We DO NOT flush here. Flushing requires the block_table (to know
+        which block IDs are "sink" blocks for each request), which is only
+        available via ``attn_metadata`` in ``forward()``. The flush is
+        therefore deferred to ``_flush_eligible_tails``, invoked at the top
+        of ``forward()``.
+        """
+        # Stage α-2: fully tensorised store. rotate(k, v) by H_fp16 → scatter
+        # into pool at slot=block_id directly. No Python loop, no allocator,
+        # no dict mutation. Safe inside a captured CUDA graph.
+        cfg = self.kvarn_config
+        N = slot_mapping.shape[0]
+        if N <= 0:
+            return
+        device = key.device
+        Hk = self.num_kv_heads
+        D = self.head_size
+
+        if self._tail_K_pool is None and key.dtype in (
+            torch.float16,
+            torch.bfloat16,
+        ):
+            self._activation_dtype = key.dtype
+        if key.dtype != self._activation_dtype:
+            key = key.to(self._activation_dtype)
+            value = value.to(self._activation_dtype)
+
+        # Ensure pool + lookup tensors + rotation scratch exist (no-op during
+        # capture; first call before capture sizes pool to kv_cache num_blocks).
+        self._ensure_pool(
+            device,
+            num_blocks_hint=kv_cache.shape[0],
+        )
+
+        # Reshape to (N, Hk, D) — view, no copy (key/value already fp16).
+        k_view = key[:N].view(N, Hk, D)
+        v_view = value[:N].view(N, Hk, D)
+
+        # Hadacore applies the normalized transform in place on the
+        # preallocated graph-safe scratch.
+        k_rot = kvarn_hadamard(k_view, self._H_fp16, out=self._k_rot_scratch[:N])
+        v_rot = kvarn_hadamard(v_view, self._H_fp16, out=self._v_rot_scratch[:N])
+
+        # Scatter via the sparse pool indirection. Slot lookup (block_id →
+        # pool slot) is done inside the kernel against the GPU
+        # _block_to_slot_t tensor (mutated only by the metadata builder).
+        from vllm.v1.attention.ops.triton_kvarn_decode import (
+            _kvarn_scatter_store_kernel,
+        )
+
+        _kvarn_scatter_store_kernel[(N, Hk)](
+            k_rot,
+            v_rot,
+            slot_mapping[:N],
+            self._block_to_slot_t,
+            self._tail_K_pool,
+            self._tail_V_pool,
+            self._tail_K_scale_pool,
+            self._tail_V_scale_pool,
+            k_rot.stride(0),
+            k_rot.stride(1),
+            self._tail_K_pool.stride(0),
+            self._tail_K_pool.stride(1),
+            self._tail_K_pool.stride(2),
+            self._tail_K_scale_pool.stride(0),
+            self._tail_K_scale_pool.stride(1),
+            self._tail_K_scale_pool.stride(2),
+            GROUP=cfg.group,
+            D=D,
+            NUM_BLOCKS_LOOKUP=self._block_lookup_size,
+            TAIL_SCALED=cfg.tail_dtype == "fp8",
+            num_warps=2,
+            num_stages=2,
+        )
+        # No CPU bookkeeping here — fill tracking + flush triggering live in
+        # KVarNMetadataBuilder.build() (outside the captured region). This
+        # method is now pure tensor ops, safe inside a captured CUDA graph.
+
+    # ── forward ──────────────────────────────────────────────────────────────
+
+    def forward(
+        self,
+        layer: AttentionLayer,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        kv_cache: torch.Tensor,
+        attn_metadata: KVarNMetadata,
+        output: torch.Tensor | None = None,
+        output_scale: torch.Tensor | None = None,
+        output_block_scale: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        num_tokens = query.shape[0]
+        device = query.device
+
+        if output is None:
+            output = torch.zeros(
+                num_tokens,
+                self.num_heads * self.head_size,
+                dtype=query.dtype,
+                device=device,
+            )
+        if attn_metadata is None:
+            return output.fill_(0)
+
+        N = attn_metadata.num_actual_tokens
+        if N <= 0:
+            return output.fill_(0)
+
+        # Make sure pool + block-lookup tensors exist and cover num_blocks.
+        self._ensure_pool(
+            kv_cache.device,
+            num_blocks_hint=kv_cache.shape[0],
+        )
+        # Cache the kv_cache ref so the metadata builder can drive flushes
+        # into this layer's int4 cache (outside the captured region).
+        self._kv_cache_ref = kv_cache
+
+        # Flush is now triggered from KVarNMetadataBuilder.build() between
+        # captured graph replays — nothing to do here at the top of forward.
+
+        # Attention compute stays in the model dtype independently of the
+        # precision-tail storage dtype.
+        if query.dtype != self._activation_dtype:
+            query = query.to(self._activation_dtype)
+            key = key.to(self._activation_dtype)
+            value = value.to(self._activation_dtype)
+
+        q = query[:N].view(N, self.num_heads, self.head_size)
+
+        if not attn_metadata.is_prefill:
+            attn_out = self._decode_path(q, kv_cache, attn_metadata)
+        elif (
+            attn_metadata.vq_seqlen is not None and attn_metadata.num_decode_tokens == N
+        ):
+            # Pure multi-token decode batch = a spec-decode verify step
+            # (uniform query length under graph capture). One fused-kernel
+            # pass over the vq plan — fully graph-capturable.
+            attn_out = self._verify_decode_path(q, kv_cache, attn_metadata)
+        elif attn_metadata.num_decodes == 0:
+            if attn_metadata.has_cached_multiquery:
+                # Speculative-decode verify (or chunked-prefill continuation):
+                # the query tokens have cached history that must be attended.
+                # _prefill_first_chunk would drop it; use the context-aware path.
+                attn_out = self._cached_multiquery_path(q, kv_cache, attn_metadata)
+            else:
+                k = key[:N].view(N, self.num_kv_heads, self.head_size)
+                v = value[:N].view(N, self.num_kv_heads, self.head_size)
+                attn_out = self._prefill_first_chunk(q, k, v, attn_metadata, kv_cache)
+        else:
+            # Mixed batch — split into decode + prefill portions, same as TurboQuant.
+            attn_out = self._mixed_batch_path(
+                q, key[:N], value[:N], kv_cache, attn_metadata
+            )
+
+        if output.ndim == 3:
+            output[:N] = attn_out.to(output.dtype)
+        else:
+            output[:N] = attn_out.reshape(N, -1).to(output.dtype)
+        return output
+
+    # ── attention sub-paths ──────────────────────────────────────────────────
+
+    def _flash_varlen(
+        self,
+        q,
+        k,
+        v,
+        cu_q,
+        cu_k,
+        max_q,
+        max_k,
+        causal=True,
+    ) -> torch.Tensor:
+        if self.fa_version is None:
+            return flash_attn_varlen_func(
+                q=q,
+                k=k,
+                v=v,
+                cu_seqlens_q=cu_q,
+                cu_seqlens_k=cu_k,
+                max_seqlen_q=max_q,
+                max_seqlen_k=max_k,
+                softmax_scale=self.scale,
+                causal=causal,
+            )
+        return flash_attn_varlen_func(
+            q=q,
+            k=k,
+            v=v,
+            cu_seqlens_q=cu_q,
+            cu_seqlens_k=cu_k,
+            max_seqlen_q=max_q,
+            max_seqlen_k=max_k,
+            softmax_scale=self.scale,
+            causal=causal,
+            fa_version=self.fa_version,
+        )
+
+    def _prefill_first_chunk(
+        self,
+        q,
+        k,
+        v,
+        attn_metadata: KVarNMetadata,
+        kv_cache: torch.Tensor,
+    ) -> torch.Tensor:
+        """First-chunk prefill: every request's full prompt is in the current
+        batch, so attention runs on raw K/V via flash_attn_varlen. The K/V
+        have already been written to the cache by `do_kv_cache_update`."""
+        causal = getattr(attn_metadata, "causal", True)
+        # FlashAttention caps head_dim at 256; the head_dim-512 global layers of
+        # Gemma-4 must use the SDPA path (handles arbitrary head_dim). Prefill is
+        # a one-time cost (decode dominates at long context), so SDPA here is fine.
+        if _HAS_FLASH_ATTN and self.head_size <= 256:
+            return self._flash_varlen(
+                q,
+                k,
+                v,
+                cu_q=attn_metadata.query_start_loc,
+                cu_k=attn_metadata.query_start_loc,
+                max_q=attn_metadata.max_query_len,
+                max_k=attn_metadata.max_query_len,
+                causal=causal,
+            )
+        # Per-request SDPA fallback (e.g. when flash_attn isn't available).
+        outputs = []
+        qsl = attn_metadata.query_start_loc.tolist()
+        for r in range(len(qsl) - 1):
+            qs, qe = qsl[r], qsl[r + 1]
+            if qe <= qs:
+                continue
+            q_r = q[qs:qe].transpose(0, 1).unsqueeze(0)  # [1, Hq, q_len, D]
+            k_r = k[qs:qe].transpose(0, 1).unsqueeze(0)
+            v_r = v[qs:qe].transpose(0, 1).unsqueeze(0)
+            o = F.scaled_dot_product_attention(
+                q_r,
+                k_r,
+                v_r,
+                is_causal=causal,
+                scale=self.scale,
+                enable_gqa=self.num_kv_heads < self.num_heads,
+            )
+            outputs.append(o[0].transpose(0, 1))  # [q_len, Hq, D]
+        return (
+            torch.cat(outputs, dim=0)
+            if outputs
+            else torch.empty(
+                0,
+                self.num_heads,
+                self.head_size,
+                device=q.device,
+                dtype=q.dtype,
+            )
+        )
+
+    def _gather_request_kv(
+        self,
+        kv_cache: torch.Tensor,
+        block_table_row: torch.Tensor,
+        seq_len: int,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Reconstruct full fp16 K and V for one request from cached blocks
+        + tail buffers. Returns (K [seq_len, Hk, D], V [seq_len, Hk, D])."""
+        cfg = self.kvarn_config
+        group = cfg.group
+        n_full = seq_len // group
+        tail_len = seq_len % group
+        device = kv_cache.device
+        D = self.head_size
+
+        # Stage α-2: pool stores ROTATED K/V indexed by block_id directly.
+        # The slow fallback consumer (_decode_path_slow → SDPA) expects
+        # un-rotated K/V, so apply H^-1 (= H^T for orthonormal H).
+        H = self._hadamard(device)  # [D, D] fp32
+
+        def _unrot_pool(x: torch.Tensor) -> torch.Tensor:
+            return (x @ H.T).to(self._activation_dtype)
+
+        # Stage α-2: a block lives in the fp16 pool iff it has a slot
+        # (sinks + in-progress tails). Flushed blocks have their slot freed
+        # and live in the int4 cache.
+        dict_map = type(self)._block_to_slot_dict.get(self._group_key, {})
+
+        K_parts: list[torch.Tensor] = []
+        V_parts: list[torch.Tensor] = []
+
+        for i in range(n_full):
+            block_id = int(block_table_row[i].item())
+            slot = dict_map.get(block_id)
+            if slot is not None:
+                K_parts.append(
+                    _unrot_pool(
+                        self._tail_pool_float(
+                            self._tail_K_pool, self._tail_K_scale_pool, slot
+                        )
+                    )
+                )
+                V_parts.append(
+                    _unrot_pool(
+                        self._tail_pool_float(
+                            self._tail_V_pool, self._tail_V_scale_pool, slot
+                        )
+                    )
+                )
+            else:
+                K_blk, V_blk = self._read_block_dequantized(kv_cache, block_id)
+                K_parts.append(K_blk)
+                V_parts.append(V_blk)
+
+        if tail_len > 0:
+            block_id = int(block_table_row[n_full].item())
+            slot = dict_map.get(block_id)
+            if slot is not None:
+                tail_index = (slot, slice(None, tail_len))
+                K_parts.append(
+                    _unrot_pool(
+                        self._tail_pool_float(
+                            self._tail_K_pool,
+                            self._tail_K_scale_pool,
+                            tail_index,
+                        )
+                    )
+                )
+                V_parts.append(
+                    _unrot_pool(
+                        self._tail_pool_float(
+                            self._tail_V_pool,
+                            self._tail_V_scale_pool,
+                            tail_index,
+                        )
+                    )
+                )
+            else:
+                K_parts.append(
+                    torch.zeros(
+                        tail_len,
+                        self.num_kv_heads,
+                        D,
+                        dtype=self._activation_dtype,
+                        device=device,
+                    )
+                )
+                V_parts.append(torch.zeros_like(K_parts[-1]))
+
+        K = (
+            torch.cat(K_parts, dim=0)
+            if K_parts
+            else torch.empty(
+                0,
+                self.num_kv_heads,
+                D,
+                dtype=self._activation_dtype,
+                device=device,
+            )
+        )
+        V = torch.cat(V_parts, dim=0) if V_parts else torch.empty_like(K)
+        return K, V
+
+    def _decode_path(
+        self,
+        q: torch.Tensor,
+        kv_cache: torch.Tensor,
+        attn_metadata: KVarNMetadata,
+    ) -> torch.Tensor:
+        """Triton-driven decode: in-kernel dequant + scoring + weighted V,
+        with the in-progress fp16 tail buffers combined via LSE in PyTorch.
+
+        Assumes one query token per request (the standard decode regime).
+        For mixed-query-length decode steps (e.g. speculative decoding), this
+        path falls back to ``_decode_path_slow`` which materialises fp16 K/V
+        and runs SDPA — retained for correctness in edge cases.
+        """
+        # If every request contributes exactly one query token, the Triton
+        # kernel's (B, Hq) launch shape is valid; otherwise fall back.
+        # Use the precomputed Python-int max_query_len (NOT a GPU reduction +
+        # host branch — that would force a sync, forbidden during CUDA graph
+        # capture).
+        if attn_metadata.max_query_len > 1:
+            return self._cached_multiquery_path(q, kv_cache, attn_metadata)
+
+        # q shape: [num_decode_tokens, num_heads, head_dim]
+        # num_decode_tokens == B (one token per request)
+        return kvarn_decode_attention(
+            query=q,
+            kv_cache=kv_cache,
+            hadamard=self._hadamard(q.device),
+            scale=self.scale,
+            cfg=self.kvarn_config,
+            impl=self,
+            md=attn_metadata,
+        )
+
+    def _decode_path_slow(
+        self,
+        q: torch.Tensor,
+        kv_cache: torch.Tensor,
+        attn_metadata: KVarNMetadata,
+    ) -> torch.Tensor:
+        """Fallback: full fp16 dequant + SDPA. Used for multi-query-per-request
+        decode steps (e.g. speculative decoding) where the Triton kernel's
+        ``(B, Hq)`` per-program shape would mishandle the per-token mapping.
+        """
+        num_reqs = attn_metadata.block_table.shape[0]
+        seq_lens = attn_metadata.seq_lens.tolist()
+        qsl = attn_metadata.query_start_loc.tolist()
+        out = torch.empty(
+            q.shape[0], self.num_heads, self.head_size, dtype=q.dtype, device=q.device
+        )
+        for r in range(num_reqs):
+            q_start, q_end = qsl[r], qsl[r + 1]
+            if q_end <= q_start:
+                continue
+            seq_len = seq_lens[r]
+            K_full, V_full = self._gather_request_kv(
+                kv_cache,
+                attn_metadata.block_table[r],
+                seq_len,
+            )
+            q_r = q[q_start:q_end].transpose(0, 1).unsqueeze(0).float()
+            K_t = K_full.transpose(0, 1).unsqueeze(0).float()
+            V_t = V_full.transpose(0, 1).unsqueeze(0).float()
+            cached_len = seq_len - (q_end - q_start)
+            q_pos = (
+                torch.arange(q_end - q_start, device=q.device).unsqueeze(1) + cached_len
+            )
+            k_pos = torch.arange(seq_len, device=q.device).unsqueeze(0)
+            mask = k_pos <= q_pos
+            o = F.scaled_dot_product_attention(
+                q_r,
+                K_t,
+                V_t,
+                attn_mask=mask,
+                scale=self.scale,
+                enable_gqa=self.num_kv_heads < self.num_heads,
+            )
+            out[q_start:q_end] = o[0].transpose(0, 1).to(q.dtype)
+        return out
+
+    def _verify_decode_path(
+        self,
+        q: torch.Tensor,
+        kv_cache: torch.Tensor,
+        attn_metadata: KVarNMetadata,
+    ) -> torch.Tensor:
+        """Spec-as-decode verify using the builder's persistent vq plan.
+
+        Capture-safe: the vq buffers are persistent (filled CPU-side in
+        build() between replays), the block-table/seq-len bound is the
+        deployment constant, and the driver's intermediates are created
+        inside the captured region (graph-pool managed) — same pattern as
+        the single-token fused decode.
+        """
+        md = attn_metadata
+        group = self.kvarn_config.group
+        max_ctx_blocks = max((self._max_model_len + group - 1) // group, 1)
+        from vllm.v1.attention.ops.triton_kvarn_decode import (
+            kvarn_verify_attention,
+        )
+
+        B = md.block_table.shape[0]
+        return kvarn_verify_attention(
+            q,
+            kv_cache,
+            md.block_table,
+            self.scale,
+            self.kvarn_config,
+            self,
+            md.vq_req,
+            md.vq_seqlen,
+            max_ctx_blocks,
+            qlen=md.vq_qlen,
+            seq_lens=md.seq_lens[:B],
+        )
+
+    def _fused_verify_path(
+        self,
+        q: torch.Tensor,
+        kv_cache: torch.Tensor,
+        attn_metadata: KVarNMetadata,
+    ) -> torch.Tensor:
+        """Speculative-decode verify via the fused dual-source kernel.
+
+        Each query token becomes a virtual kernel row with its own
+        bottom-right causal length (cached_len + idx + 1) and an indirection
+        to its request's block-table row — so the verify step reads int4
+        tiles + the fp16 pool directly instead of materializing the whole
+        context to fp16 scratch every step (O(context)/step; the
+        long-context MTP collapse: measured 88 -> 45 tok/s from 2K -> 32K
+        with the materialize route vs near-flat without MTP).
+
+        Eager-only (verify steps are not graph-captured): fresh small
+        tensors per call are fine.
+        """
+        md = attn_metadata
+        B = md.block_table.shape[0]
+        n_tok = q.shape[0]
+        device = q.device
+        group = self.kvarn_config.group
+
+        qsl = md.query_start_loc[: B + 1].to(torch.long)
+        qlens = qsl[1:] - qsl[:-1]  # [B]
+        vq_req_long = torch.repeat_interleave(
+            torch.arange(B, device=device), qlens
+        )  # [n_tok]
+        pos_in_req = torch.arange(n_tok, device=device) - qsl[:-1][vq_req_long]
+        committed = md.seq_lens[:B].to(torch.long) - qlens
+        vq_seqlen = (committed[vq_req_long] + pos_in_req + 1).to(torch.int32)
+        vq_req = vq_req_long.to(torch.int32)
+
+        max_ctx_blocks = min(
+            (int(md.max_seq_len) + group - 1) // group, md.block_table.shape[1]
+        )
+        max_ctx_blocks = max(max_ctx_blocks, 1)
+
+        from vllm.v1.attention.ops.triton_kvarn_decode import (
+            kvarn_verify_attention,
+        )
+
+        return kvarn_verify_attention(
+            q,
+            kv_cache,
+            md.block_table,
+            self.scale,
+            self.kvarn_config,
+            self,
+            vq_req,
+            vq_seqlen,
+            max_ctx_blocks,
+        )
+
+    def _cached_multiquery_path(
+        self,
+        q: torch.Tensor,
+        kv_cache: torch.Tensor,
+        attn_metadata: KVarNMetadata,
+    ) -> torch.Tensor:
+        """Multi-query tokens with cached history (a speculative-decode verify
+        step or a chunked-prefill continuation), batched.
+
+        Builds the batch's rotated fp16 K/V with the ONE block_table-driven
+        Triton kernel (``_kvarn_build_packed_kv_kernel``) and runs a single
+        ``flash_attn_varlen`` call. FA's varlen causal mask is bottom-right
+        aligned when ``seqlen_q < seqlen_k``, i.e. query token ``t`` attends
+        keys ``<= cached_len + t`` — exactly the spec-verify / continuation
+        semantics, so no explicit mask is needed.
+
+        Replaces ``_decode_path_slow`` on this route: the per-request Python
+        gather (per-block ``.item()`` syncs + Python dequant + fp32 SDPA, per
+        layer, per step) made MTP decode unusably slow (< 5 tok/s) and its
+        transient fp32 materializations inflated the CUDA-graph memory
+        estimate by GiBs, collapsing the derived KV-cache capacity. The slow
+        path remains the fallback for head_dim > 256 (FA's cap) or a batch
+        whose total KV exceeds the shared materialize scratch.
+        """
+        md = attn_metadata
+        B = md.block_table.shape[0]
+        # Small-qlen multi-query (the spec-decode verify step: every decode
+        # step under MTP) goes to the FUSED verify kernel: per-token virtual
+        # rows over the dual-source decode kernel, no fp16 materialization.
+        # Routed by CONTEXT depth (measured, Qwen3.6-27B AWQ single stream):
+        # materialize wins short context (88 vs 81 tok/s @2K — its one
+        # write+read is cheap there and the fused per-call overhead shows);
+        # fused wins long context (51 vs 45 @32K, growing with depth — the
+        # materialize round-trip is the O(context)/step MTP
+        # slowdown). Crossover ~12K; default threshold 64 blocks (8K).
+        # The materialize+FA route also keeps LARGE qlen (chunked-prefill
+        # continuations), where one materialization amortizes over thousands
+        # of query tokens. KVARN_FUSED_VERIFY=0 forces materialize always.
+        _group = self.kvarn_config.group
+        if (
+            os.environ.get("KVARN_FUSED_VERIFY", "1") == "1"
+            and md.max_query_len <= int(os.environ.get("KVARN_FUSED_VERIFY_MAXQ", "8"))
+            and (int(md.max_seq_len) + _group - 1) // _group
+            >= int(os.environ.get("KVARN_FUSED_VERIFY_MIN_BLOCKS", "64"))
+            and B > 0
+        ):
+            return self._fused_verify_path(q, kv_cache, md)
+        if not _HAS_FLASH_ATTN or self.head_size > 256 or self._fa_K_buf is None:
+            return self._decode_path_slow(q, kv_cache, md)
+
+        seq_lens = md.seq_lens[:B].to(torch.int32)
+        cu_k = F.pad(torch.cumsum(seq_lens, 0, dtype=torch.int32), (1, 0))
+        total_k = int(cu_k[-1].item())
+        if total_k <= 0 or total_k > self._fa_K_buf.shape[0]:
+            return self._decode_path_slow(q, kv_cache, md)
+
+        cfg = self.kvarn_config
+        group = cfg.group
+        D = self.head_size
+        Hk = self.num_kv_heads
+        max_k = int(md.max_seq_len)
+        max_blocks = min((max_k + group - 1) // group, md.block_table.shape[1])
+        max_blocks = max(max_blocks, 1)
+
+        from vllm.v1.attention.ops.triton_kvarn_decode import (
+            _kvarn_build_packed_kv_kernel,
+        )
+
+        K_packed = self._fa_K_buf
+        V_packed = self._fa_V_buf
+        _kvarn_build_packed_kv_kernel[(B * max_blocks, Hk)](
+            md.block_table,
+            seq_lens,
+            cu_k,
+            self._block_to_slot_t,
+            kv_cache,
+            self._tail_K_pool,
+            self._tail_V_pool,
+            self._tail_K_scale_pool,
+            self._tail_V_scale_pool,
+            K_packed,
+            V_packed,
+            md.block_table.stride(0),
+            kv_cache.stride(0),
+            kv_cache.stride(1),
+            self._tail_K_pool.stride(0),
+            self._tail_K_pool.stride(1),
+            self._tail_K_pool.stride(2),
+            self._tail_K_scale_pool.stride(0),
+            self._tail_K_scale_pool.stride(1),
+            self._tail_K_scale_pool.stride(2),
+            K_packed.stride(0),
+            K_packed.stride(1),
+            MAX_BLOCKS_PER_REQ=max_blocks,
+            D=D,
+            GROUP=group,
+            K_BITS=cfg.key_bits,
+            V_BITS=cfg.value_bits,
+            NUM_BLOCKS_LOOKUP=self._block_lookup_size,
+            K_PACKED_OFFSET=cfg.k_packed_offset,
+            K_S_COL_OFFSET=cfg.k_s_col_offset,
+            K_ZP_OFFSET=cfg.k_zp_offset,
+            K_S_ROW_OFFSET=cfg.k_s_row_offset,
+            TILES_PER_PAGE=md.tiles_per_page,
+            V_PACKED_OFFSET=cfg.v_packed_offset,
+            V_S_COL_OFFSET=cfg.v_s_col_offset,
+            V_S_ROW_OFFSET=cfg.v_s_row_offset,
+            V_ZP_OFFSET=cfg.v_zp_offset,
+            TAIL_SCALED=cfg.tail_dtype == "fp8",
+            num_warps=4,
+            num_stages=2,
+        )
+
+        # The packed K/V are in the rotated frame (the store path rotates before
+        # quantizing / pooling), so rotate q in and un-rotate the output — same
+        # fp16 Hadamard as the store side, so QK^T is invariant.
+        H16 = (
+            self._H_fp16
+            if self._H_fp16 is not None
+            else self._hadamard(q.device).to(self._activation_dtype)
+        )
+        n_tok = q.shape[0]
+        q_rot = kvarn_hadamard(q.reshape(-1, D), H16).view(n_tok, self.num_heads, D)
+        out_rot = self._flash_varlen(
+            q_rot,
+            K_packed[:total_k],
+            V_packed[:total_k],
+            cu_q=md.query_start_loc[: B + 1],
+            cu_k=cu_k,
+            max_q=md.max_query_len,
+            max_k=max_k,
+            causal=getattr(md, "causal", True),
+        )
+        return kvarn_hadamard(out_rot.reshape(-1, D), H16).view(
+            n_tok, self.num_heads, D
+        )
+
+    def _mixed_batch_path(
+        self,
+        q: torch.Tensor,
+        k_all: torch.Tensor,
+        v_all: torch.Tensor,
+        kv_cache: torch.Tensor,
+        attn_metadata: KVarNMetadata,
+    ) -> torch.Tensor:
+        """Split mixed batch into decode-then-prefill, mirroring TurboQuant."""
+        num_decodes = attn_metadata.num_decodes
+        num_decode_tokens = attn_metadata.num_decode_tokens
+        N = attn_metadata.num_actual_tokens
+
+        out = torch.empty(
+            N, self.num_heads, self.head_size, dtype=q.dtype, device=q.device
+        )
+
+        # Build the Stage α-2 fa_* fields for the decode subset. This path
+        # always runs eager (mixed batches aren't graph-captured), so fresh
+        # (non-persistent) tensors are fine.
+        group = self.kvarn_config.group
+        dec_seq_lens = attn_metadata.seq_lens[:num_decodes].to(torch.int32)
+        dec_cu_k = torch.nn.functional.pad(
+            torch.cumsum(dec_seq_lens, dim=0), (1, 0)
+        ).to(torch.int32)
+        dec_cu_q = torch.arange(num_decodes + 1, dtype=torch.int32, device=q.device)
+        mbpr = (self._max_model_len + group - 1) // group
+        decode_meta = KVarNMetadata(
+            seq_lens=attn_metadata.seq_lens[:num_decodes],
+            slot_mapping=attn_metadata.slot_mapping[:num_decode_tokens],
+            block_table=attn_metadata.block_table[:num_decodes],
+            query_start_loc=attn_metadata.query_start_loc[: num_decodes + 1],
+            num_actual_tokens=num_decode_tokens,
+            max_query_len=1,
+            max_seq_len=attn_metadata.max_seq_len,
+            is_prefill=False,
+            fa_cu_seqlens_q=dec_cu_q,
+            fa_cu_seqlens_k=dec_cu_k,
+            fa_max_blocks_per_req=mbpr,
+            fa_max_seqlen_k_fixed=self._max_model_len,
+            causal=getattr(attn_metadata, "causal", True),
+        )
+        if attn_metadata.vq_seqlen is not None:
+            # Spec-as-decode: the decode portion carries multi-token verify
+            # queries — use the vq plan (mixed batches run eager, slices ok).
+            # vq_req is set together with vq_seqlen (never None when it is not).
+            assert attn_metadata.vq_req is not None
+            decode_meta.vq_req = attn_metadata.vq_req[:num_decode_tokens]
+            decode_meta.vq_seqlen = attn_metadata.vq_seqlen[:num_decode_tokens]
+            decode_meta.vq_qlen = attn_metadata.vq_qlen
+            out[:num_decode_tokens] = self._verify_decode_path(
+                q[:num_decode_tokens],
+                kv_cache,
+                decode_meta,
+            )
+        else:
+            out[:num_decode_tokens] = self._decode_path(
+                q[:num_decode_tokens],
+                kv_cache,
+                decode_meta,
+            )
+
+        prefill_seq_lens = attn_metadata.seq_lens[num_decodes:]
+        prefill_qsl = attn_metadata.query_start_loc[num_decodes:] - num_decode_tokens
+        prefill_meta = KVarNMetadata(
+            seq_lens=prefill_seq_lens,
+            slot_mapping=attn_metadata.slot_mapping[num_decode_tokens:N],
+            block_table=attn_metadata.block_table[num_decodes:],
+            query_start_loc=prefill_qsl,
+            num_actual_tokens=N - num_decode_tokens,
+            max_query_len=attn_metadata.max_query_len,
+            # avoid a per-step .item() D2H sync; the global max is a safe
+            # upper bound for the prefill kernel
+            max_seq_len=attn_metadata.max_seq_len,
+            is_prefill=True,
+            causal=getattr(attn_metadata, "causal", True),
+        )
+        if attn_metadata.has_cached_multiquery:
+            # The multi-query (prefill-classified) requests here are speculative
+            # -decode verify steps / chunked-prefill continuations with cached
+            # history — attend over the cached K/V, not just the new tokens.
+            out[num_decode_tokens:] = self._cached_multiquery_path(
+                q[num_decode_tokens:],
+                kv_cache,
+                prefill_meta,
+            )
+        else:
+            k_pref = k_all[num_decode_tokens:].view(
+                -1, self.num_kv_heads, self.head_size
+            )
+            v_pref = v_all[num_decode_tokens:].view(
+                -1, self.num_kv_heads, self.head_size
+            )
+            out[num_decode_tokens:] = self._prefill_first_chunk(
+                q[num_decode_tokens:],
+                k_pref,
+                v_pref,
+                prefill_meta,
+                kv_cache,
+            )
+        return out

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -3213,7 +3213,17 @@ class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
             ckv_workspace = prefetch_state.get_ckv_workspace(self._ckv_workspace_nbytes)
             if layer_idx is not None and self._ckv_prefetch_depth > 0:
                 prefetch_state.enter_layer(layer_idx)
-                prefetch_state.register_cache(layer_idx, kv_cache)
+                # The prefetch registry must hold a per-layer cache. For
+                # KVarN MLA ``kv_cache`` is the cross-layer SHARED FP8
+                # staging view materialized from this layer's paged slice;
+                # registering it poisons every prefetched layer, whose
+                # side-stream gathers would then read this one tensor
+                # (identical wrong KV for every layer). The packed paged
+                # cache itself is not gatherable in this format, so KVarN
+                # MLA keeps no registry entry and every gather stays on the
+                # synchronous per-layer path below.
+                if not self._is_kvarn_mla:
+                    prefetch_state.register_cache(layer_idx, kv_cache)
             pending = (
                 prefetch_state.pending_layers.pop(layer_idx, None)
                 if layer_idx is not None and self._ckv_prefetch_depth > 0

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -26,6 +26,7 @@ ONE ``get_simultaneous`` call so they never alias.
 """
 
 import inspect
+import math
 import os
 import weakref
 from dataclasses import dataclass
@@ -43,6 +44,10 @@ from vllm.model_executor.layers.attention.mla_attention import get_mla_dims
 from vllm.model_executor.layers.mla_cache_format import (
     NVFP4_MLA_CACHE_FORMAT,
 )
+from vllm.model_executor.layers.quantization.kvarn.config import (
+    kvarn_mla_workspace_envelope as _kvarn_mla_workspace_envelope,
+)
+from vllm.platforms import current_platform
 from vllm.platforms.interface import DeviceCapability
 from vllm.triton_utils import tl, triton
 from vllm.v1.attention.backend import (
@@ -63,6 +68,7 @@ from vllm.v1.attention.backends.utils import (
     get_dcp_local_seq_lens,
     split_decodes_and_prefills,
 )
+from vllm.v1.attention.ops.kvarn_decode import kvarn_hadamard
 from vllm.v1.kv_cache_interface import AttentionSpec
 from vllm.v1.worker.workspace import current_workspace_manager
 
@@ -723,6 +729,7 @@ class B12xMLASparseBackend(AttentionBackend):
         "nvfp4_ds_mla",
         "fp8",  # aliases for fp8_ds_mla on this backend
         "fp8_e4m3",
+        "kvarn_mla_k5_g64",
     ]
 
     @staticmethod
@@ -795,6 +802,17 @@ class B12xMLASparseBackend(AttentionBackend):
         head_size: int,
         cache_dtype_str: str = "auto",
     ) -> tuple[int, ...]:
+        if cache_dtype_str == "kvarn_mla_k5_g64":
+            from vllm.model_executor.layers.quantization.kvarn.config import (
+                KVarNMLAConfig,
+            )
+
+            config = KVarNMLAConfig.from_cache_dtype(cache_dtype_str)
+            if block_size != config.group:
+                raise ValueError(
+                    f"MLA KVarN requires block_size={config.group}, got {block_size}"
+                )
+            return (num_blocks, 1, config.tile_bytes)
         if cache_dtype_str == "fp8_ds_mla":
             # V32 fp8_ds_mla packed: 656 B/token (512 NoPE + 16 inline FP32
             # scales + 128 BF16 RoPE). Mirrors the FlashMLA / SPARSE_MLA_SM120
@@ -884,6 +902,15 @@ class B12xMLASparseMetadataBuilder(AttentionMetadataBuilder[B12xMLASparseMetadat
         self.kv_cache_spec = kv_cache_spec
         self.model_config = vllm_config.model_config
         self.device = device
+        self.kvarn_config = None
+        cache_dtype_str = getattr(kv_cache_spec, "cache_dtype_str", None)
+        if cache_dtype_str == "kvarn_mla_k5_g64":
+            from vllm.model_executor.layers.quantization.kvarn.config import (
+                KVarNMLAConfig,
+            )
+
+            self.kvarn_config = KVarNMLAConfig.from_cache_dtype(cache_dtype_str)
+            self.supports_exact_metadata_reuse = False
 
         self.mla_dims = get_mla_dims(self.model_config)
         self.topk_tokens = vllm_config.model_config.hf_config.index_topk
@@ -902,6 +929,14 @@ class B12xMLASparseMetadataBuilder(AttentionMetadataBuilder[B12xMLASparseMetadat
 
         max_tokens = vllm_config.scheduler_config.max_num_batched_tokens
         max_seqs = vllm_config.scheduler_config.max_num_seqs
+        if self.kvarn_config is not None:
+            num_kv_pages = vllm_config.cache_config.num_gpu_blocks
+            if num_kv_pages is None or num_kv_pages <= 0:
+                raise RuntimeError(
+                    "KVarN MLA workspace initialization requires the allocated "
+                    "local KV page count before metadata builders are created"
+                )
+            B12xMLASparseImpl.initialize_kvarn_workspaces(int(num_kv_pages), device)
         from vllm import envs as envs_mod
 
         ckv_gather_requested = envs_mod.VLLM_B12X_MLA_CKV_GATHER
@@ -969,6 +1004,18 @@ class B12xMLASparseMetadataBuilder(AttentionMetadataBuilder[B12xMLASparseMetadat
         fast_build: bool = False,
     ) -> B12xMLASparseMetadata:
         cm = common_attn_metadata
+        if self.kvarn_config is not None:
+            from vllm.v1.attention.backends.mla.kvarn_mla_state import (
+                KVarNMLAStateManager,
+            )
+
+            KVarNMLAStateManager.prepare_step(
+                tuple(self.layer_names),
+                self.layer_names,
+                cm,
+                self.kvarn_config,
+                self.dcp_world_size,
+            )
         num_tokens = cm.num_actual_tokens
         if cm.max_query_len <= 1 and num_tokens == cm.num_reqs:
             num_decodes = cm.num_reqs
@@ -1239,7 +1286,7 @@ class B12xMLASparseMetadataBuilder(AttentionMetadataBuilder[B12xMLASparseMetadat
 class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
     """b12x unified sparse-MLA implementation (decode + extend/prefill)."""
 
-    is_sparse = True
+    is_sparse: ClassVar[bool] = True
     can_return_lse_for_decode: bool = True
     # B12X handles decode and extend inside its own top-k MQA kernels; the
     # generic dense-MHA prefill path assumes cache layouts it never validated.
@@ -1253,6 +1300,12 @@ class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
     _all_layer_kv_caches: list[torch.Tensor | None] = []
     _shared_gather_event: torch.cuda.Event | None = None
     _shared_gather_buf_idx: int = 0
+    _kvarn_shared_dense: ClassVar[dict[tuple, torch.Tensor]] = {}
+    _kvarn_shared_remapped: ClassVar[dict[tuple, torch.Tensor]] = {}
+    _kvarn_shared_rotated: ClassVar[dict[tuple, torch.Tensor]] = {}
+    _kvarn_shared_physical_slots: ClassVar[dict[tuple, torch.Tensor]] = {}
+    _kvarn_instances: ClassVar[weakref.WeakSet] = weakref.WeakSet()
+    _kvarn_hadamard: ClassVar[dict[torch.device, torch.Tensor]] = {}
 
     def __init__(
         self,
@@ -1280,11 +1333,20 @@ class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
                 "B12X_MLA_SPARSE only supports decoder self-attention"
             )
 
+        self.layer_name = ""
         self.num_heads = num_heads
         self.head_size = head_size
         self.scale = float(scale)
         self.num_kv_heads = num_kv_heads
         self.kv_cache_dtype = kv_cache_dtype
+        self._is_kvarn_mla = self.kv_cache_dtype == "kvarn_mla_k5_g64"
+        self._kvarn_config = None
+        if self._is_kvarn_mla:
+            from vllm.model_executor.layers.quantization.kvarn.config import (
+                KVarNMLAConfig,
+            )
+
+            self._kvarn_config = KVarNMLAConfig.from_cache_dtype(self.kv_cache_dtype)
         self._kv_fp8_rope = bool(
             self.kv_cache_dtype == "nvfp4_ds_mla" and _kv_fp8_rope_enabled()
         )
@@ -1360,6 +1422,7 @@ class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
         from vllm.config import get_current_vllm_config
 
         vllm_config = get_current_vllm_config()
+        self._vllm_config = vllm_config
         parallel_config = vllm_config.parallel_config
         self.dcp_workspace_non_dbo = not bool(parallel_config.enable_dbo)
         self.dcp_world_size = parallel_config.decode_context_parallel_size
@@ -1454,8 +1517,84 @@ class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
         self._decode_max_rows = min(max_num_seqs * q_per_req, max_batched)
         if self._decode_max_rows < max_num_seqs:
             self._decode_max_rows = max_num_seqs
+        if self._is_kvarn_mla:
+            assert self._kvarn_config is not None
+            assert self._decode_max_rows == self._kvarn_config.max_active_rows(
+                vllm_config
+            )
 
         self._max_batched = int(max_batched)
+        self._kvarn_group_key: tuple[str, ...] | None = None
+        self._kvarn_cache_ref: torch.Tensor | None = None
+        self._kvarn_block_to_slot: torch.Tensor | None = None
+        if self._is_kvarn_mla:
+            assert self._kvarn_config is not None
+            kvarn_config = self._kvarn_config
+            max_rollback_tokens = (
+                int(spec.num_speculative_tokens)
+                if vllm_config.scheduler_config.async_scheduling
+                and spec is not None
+                and getattr(spec, "num_speculative_tokens", None)
+                else 0
+            )
+            self._kvarn_pool_size = kvarn_config.pool_slots(
+                max_num_seqs,
+                max_batched,
+                max_rollback_tokens,
+            )
+            self._kvarn_latent_pool = torch.zeros(
+                self._kvarn_pool_size,
+                kvarn_config.group,
+                kvarn_config.latent_dim,
+                dtype=torch.float8_e4m3fn,
+                device=self.device,
+            )
+            self._kvarn_rope_pool = torch.zeros(
+                self._kvarn_pool_size,
+                kvarn_config.group,
+                kvarn_config.rope_dim,
+                dtype=torch.bfloat16,
+                device=self.device,
+            )
+            self._kvarn_boundary_blocks = max_num_seqs
+            self._kvarn_rollback_blocks = (
+                _cdiv(
+                    max_num_seqs * max_rollback_tokens,
+                    kvarn_config.group,
+                )
+                + max_num_seqs
+                if max_rollback_tokens
+                else 0
+            )
+            self._kvarn_dense_cache: torch.Tensor | None = None
+            self._kvarn_remapped_indices: torch.Tensor | None = None
+            self._kvarn_rotated_scratch: torch.Tensor | None = None
+            self._kvarn_physical_slots: torch.Tensor | None = None
+            cls = type(self)
+            cls._kvarn_instances.add(self)
+            if self.device not in cls._kvarn_hadamard:
+                hadamard = torch.ones(1, 1, dtype=torch.float32)
+                while hadamard.shape[0] < kvarn_config.latent_dim:
+                    hadamard = torch.cat(
+                        [
+                            torch.cat([hadamard, hadamard], dim=1),
+                            torch.cat([hadamard, -hadamard], dim=1),
+                        ],
+                        dim=0,
+                    )
+                cls._kvarn_hadamard[self.device] = (
+                    hadamard.div(math.sqrt(kvarn_config.latent_dim))
+                    .to(self.device, dtype=torch.bfloat16)
+                    .contiguous()
+                )
+            self._kvarn_h = cls._kvarn_hadamard[self.device]
+            from vllm.v1.attention.backends.mla.kvarn_mla_state import (
+                KVarNMLAStateManager,
+            )
+
+            KVarNMLAStateManager.register(self)
+        else:
+            self._kvarn_pool_size = 0
 
         # Lazily import B12X only on this opt-in path.
         from b12x.attention.sparse_mla import (
@@ -1538,7 +1677,8 @@ class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
 
         ckv_gather_requested = envs_mod.VLLM_B12X_MLA_CKV_GATHER
         self._ckv_gather_enabled = ckv_gather_requested and (
-            self.dcp_world_size > 1
+            not self._is_kvarn_mla
+            and self.dcp_world_size > 1
             and self.pcp_world_size == 1
             and self.num_heads % _HEAD_ALIGNMENT == 0
             and self.dcp_workspace_non_dbo
@@ -1697,6 +1837,92 @@ class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
         self.supports_quant_query_input = False
 
     @classmethod
+    def initialize_kvarn_workspaces(
+        cls, num_kv_pages: int, device: torch.device
+    ) -> None:
+        """Allocate graph-static KVarN staging after local pages are known."""
+        matching = [
+            impl
+            for impl in cls._kvarn_instances
+            if impl._is_kvarn_mla and impl.device == device
+        ]
+        for impl in matching:
+            config = impl._kvarn_config
+            assert config is not None
+            envelope = config.workspace_envelope(impl._vllm_config, num_kv_pages)
+            runtime_envelope = _kvarn_mla_workspace_envelope(
+                num_kv_pages=num_kv_pages,
+                group_size=config.group,
+                latent_dim=config.latent_dim,
+                rope_dim=config.rope_dim,
+                max_batched_tokens=impl._max_batched,
+                max_active_rows=impl._decode_max_rows,
+                topk_tokens=impl.topk_tokens,
+                boundary_blocks=impl._kvarn_boundary_blocks,
+                rollback_blocks=impl._kvarn_rollback_blocks,
+            )
+            if runtime_envelope != envelope:
+                raise ValueError(
+                    "KVarN MLA runtime geometry does not match the workspace "
+                    "geometry budgeted from VllmConfig"
+                )
+            key = (
+                device,
+                num_kv_pages,
+                envelope,
+                impl.topk_tokens,
+                config.group,
+                config.latent_dim,
+                config.rope_dim,
+            )
+            if key not in cls._kvarn_shared_dense:
+                if device.type == "cuda":
+                    free_bytes, _ = current_platform.mem_get_info()
+                    reusable_bytes = max(
+                        torch.accelerator.memory_reserved(device)
+                        - torch.accelerator.memory_allocated(device),
+                        0,
+                    )
+                    if envelope.total_bytes > free_bytes + reusable_bytes:
+                        raise MemoryError(
+                            "KVarN MLA graph workspace requires "
+                            f"{envelope.total_bytes} bytes but only "
+                            f"{free_bytes + reusable_bytes} bytes are available"
+                        )
+                dense = torch.empty(
+                    envelope.dense_rows // config.group,
+                    config.group,
+                    config.latent_dim + config.rope_dim,
+                    dtype=torch.bfloat16,
+                    device=device,
+                )
+                remapped = torch.empty(
+                    impl._max_batched,
+                    impl.topk_tokens,
+                    dtype=torch.int32,
+                    device=device,
+                )
+                rotated = torch.empty(
+                    envelope.rotation_rows,
+                    config.latent_dim,
+                    dtype=torch.bfloat16,
+                    device=device,
+                )
+                physical_slots = torch.arange(
+                    envelope.physical_slot_rows,
+                    dtype=torch.int32,
+                    device=device,
+                )
+                cls._kvarn_shared_dense[key] = dense
+                cls._kvarn_shared_remapped[key] = remapped
+                cls._kvarn_shared_rotated[key] = rotated
+                cls._kvarn_shared_physical_slots[key] = physical_slots
+            impl._kvarn_dense_cache = cls._kvarn_shared_dense[key]
+            impl._kvarn_remapped_indices = cls._kvarn_shared_remapped[key]
+            impl._kvarn_rotated_scratch = cls._kvarn_shared_rotated[key]
+            impl._kvarn_physical_slots = cls._kvarn_shared_physical_slots[key]
+
+    @classmethod
     def reset_kv_cache_binding_state(cls) -> None:
         """Drop prefetch state whose pointers belong to an old KV cache.
 
@@ -1716,6 +1942,209 @@ class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
         cls._shared_gather_buf_idx = 0
         for registry in tuple(_CKV_PREFETCH_STATE_REGISTRIES):
             registry.clear()
+        for impl in tuple(cls._kvarn_instances):
+            impl._kvarn_dense_cache = None
+            impl._kvarn_remapped_indices = None
+            impl._kvarn_rotated_scratch = None
+            impl._kvarn_physical_slots = None
+        cls._kvarn_shared_dense.clear()
+        cls._kvarn_shared_remapped.clear()
+        cls._kvarn_shared_rotated.clear()
+        cls._kvarn_shared_physical_slots.clear()
+        from vllm.v1.attention.backends.mla.kvarn_mla_state import (
+            KVarNMLAStateManager,
+        )
+
+        KVarNMLAStateManager.reset_cache_bindings()
+
+    def _ensure_kvarn_mla_cache(self, kv_cache: torch.Tensor) -> None:
+        if not self._is_kvarn_mla:
+            return
+        if self._kvarn_group_key is None:
+            raise RuntimeError(
+                "MLA KVarN metadata must establish exact-block ownership before use"
+            )
+        from vllm.v1.attention.backends.mla.kvarn_mla_state import (
+            KVarNMLAStateManager,
+        )
+
+        self._kvarn_block_to_slot = KVarNMLAStateManager.ensure_mirror(
+            self._kvarn_group_key,
+            kv_cache.device,
+            kv_cache.shape[0],
+        )
+        if self._kvarn_physical_slots is None:
+            raise RuntimeError(
+                "KVarN MLA graph workspace was not initialized before cache use"
+            )
+        assert self._kvarn_config is not None
+        planned_pages = self._kvarn_physical_slots.numel() // self._kvarn_config.group
+        if kv_cache.shape[0] != planned_pages:
+            raise RuntimeError(
+                "KVarN MLA cache page count changed after workspace allocation: "
+                f"planned {planned_pages}, got {kv_cache.shape[0]}"
+            )
+        if self._kvarn_block_to_slot.shape[0] < planned_pages:
+            raise RuntimeError(
+                "KVarN MLA exact-slot map is smaller than the allocated cache"
+            )
+        self._kvarn_cache_ref = kv_cache
+
+    def _flush_kvarn_mla_blocks(
+        self, block_ids: torch.Tensor, pool_slots: torch.Tensor
+    ) -> None:
+        if self._kvarn_cache_ref is None or block_ids.numel() == 0:
+            return
+        assert self._kvarn_config is not None
+        from vllm.v1.attention.ops.kvarn_mla import pack_kvarn_mla_blocks
+
+        pack_kvarn_mla_blocks(
+            self._kvarn_cache_ref,
+            self._kvarn_latent_pool,
+            self._kvarn_rope_pool,
+            block_ids,
+            pool_slots,
+            self._kvarn_config,
+        )
+
+    def _materialize_kvarn_mla_cache(
+        self,
+        selected_indices: torch.Tensor,
+        _attn_metadata: B12xMLASparseMetadata,
+        kv_cache: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        assert self._kvarn_config is not None
+        assert self._kvarn_block_to_slot is not None
+        if (
+            self._kvarn_dense_cache is None
+            or self._kvarn_remapped_indices is None
+            or self._kvarn_physical_slots is None
+        ):
+            raise RuntimeError("KVarN MLA graph workspace is not initialized")
+        from vllm.v1.attention.ops.kvarn_mla import (
+            materialize_physical_kvarn_mla,
+            materialize_selected_kvarn_mla,
+        )
+
+        num_rows, width = selected_indices.shape
+        remap_elements = num_rows * width
+        if remap_elements > self._kvarn_remapped_indices.numel():
+            raise ValueError(
+                "KVarN MLA remap workspace has "
+                f"{self._kvarn_remapped_indices.numel()} entries, "
+                f"requires {remap_elements}"
+            )
+        remapped = self._kvarn_remapped_indices.view(-1)[:remap_elements].view(
+            num_rows, width
+        )
+        if num_rows <= self._decode_max_rows:
+            materialize_selected_kvarn_mla(
+                selected_indices,
+                kv_cache,
+                self._kvarn_block_to_slot,
+                self._kvarn_latent_pool,
+                self._kvarn_rope_pool,
+                self._kvarn_dense_cache,
+                remapped,
+                self._kvarn_config,
+            )
+        else:
+            materialize_physical_kvarn_mla(
+                self._kvarn_physical_slots,
+                selected_indices,
+                kv_cache,
+                self._kvarn_block_to_slot,
+                self._kvarn_latent_pool,
+                self._kvarn_rope_pool,
+                self._kvarn_dense_cache,
+                remapped,
+                self._kvarn_config,
+            )
+        return self._kvarn_dense_cache, remapped
+
+    def _stage_kvarn_mla_fp8_cache(
+        self,
+        selected_indices: torch.Tensor,
+        _attn_metadata: B12xMLASparseMetadata,
+        kv_cache: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        assert self._kvarn_config is not None
+        assert self._kvarn_block_to_slot is not None
+        if (
+            self._kvarn_dense_cache is None
+            or self._kvarn_remapped_indices is None
+            or self._kvarn_physical_slots is None
+        ):
+            raise RuntimeError("KVarN MLA graph workspace is not initialized")
+        from vllm.v1.attention.ops.kvarn_mla import (
+            stage_physical_kvarn_mla_fp8,
+        )
+
+        num_rows, width = selected_indices.shape
+        remap_elements = num_rows * width
+        if remap_elements > self._kvarn_remapped_indices.numel():
+            raise ValueError(
+                "KVarN MLA remap workspace has "
+                f"{self._kvarn_remapped_indices.numel()} entries, "
+                f"requires {remap_elements}"
+            )
+        remapped = self._kvarn_remapped_indices.view(-1)[:remap_elements].view(
+            num_rows, width
+        )
+        page_rows = kv_cache.shape[0] * self._kvarn_config.group
+        required_bytes = page_rows * 656
+        byte_workspace = self._kvarn_dense_cache.view(torch.uint8).view(-1)
+        if byte_workspace.numel() < required_bytes:
+            raise ValueError(
+                f"KVarN MLA FP8 workspace has fewer than {required_bytes} bytes"
+            )
+        records = byte_workspace[:required_bytes].view(page_rows, 656)
+        stage_physical_kvarn_mla_fp8(
+            self._kvarn_physical_slots,
+            selected_indices,
+            kv_cache,
+            self._kvarn_block_to_slot,
+            self._kvarn_latent_pool,
+            self._kvarn_rope_pool,
+            records,
+            remapped,
+            self._kvarn_config,
+        )
+        return records.view(-1, self.block_size, 656), remapped
+
+    def _forward_kvarn_mla(
+        self,
+        q: torch.Tensor,
+        dense_cache: torch.Tensor,
+        selected_indices: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        assert self._kvarn_config is not None
+        from vllm.v1.attention.ops.xpu_mla_sparse import (
+            triton_bf16_mla_sparse_interface,
+        )
+
+        latent_dim = self._kvarn_config.latent_dim
+        dense = dense_cache.view(-1, latent_dim + self._kvarn_config.rope_dim)
+        out, _, lse = triton_bf16_mla_sparse_interface(
+            q,
+            dense.unsqueeze(1),
+            selected_indices.unsqueeze(1),
+            sm_scale=self.scale,
+            d_v=latent_dim,
+            block_dpe=self._kvarn_config.rope_dim,
+            out=q[..., :latent_dim],
+            return_lse=self.need_to_return_lse_for_decode,
+            return_max_logits=False,
+        )
+        return (
+            self._restore_kvarn_mla_output(out),
+            lse if self.need_to_return_lse_for_decode else None,
+        )
+
+    def _restore_kvarn_mla_output(self, output: torch.Tensor) -> torch.Tensor:
+        if not self._is_kvarn_mla:
+            return output
+        return kvarn_hadamard(output, self._kvarn_h)
 
     def do_kv_cache_update(
         self,
@@ -1733,6 +2162,43 @@ class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
         b12x package writer API, which does not replace or perturb the stock
         writer used by KV_FP8_ROPE=0.
         """
+        if self._is_kvarn_mla:
+            if kv_cache.numel() == 0 or slot_mapping is None:
+                return
+            if self._kvarn_group_key is None:
+                return
+            assert self._kvarn_config is not None
+            self._ensure_kvarn_mla_cache(kv_cache)
+            assert self._kvarn_block_to_slot is not None
+            num_tokens = slot_mapping.numel()
+            if self._kvarn_rotated_scratch is None:
+                raise RuntimeError("KVarN MLA graph workspace is not initialized")
+            if num_tokens > self._kvarn_rotated_scratch.shape[0]:
+                raise ValueError(
+                    "KVarN MLA rotation workspace has "
+                    f"{self._kvarn_rotated_scratch.shape[0]} rows, "
+                    f"requires {num_tokens}"
+                )
+            if kv_c_normed.numel() < num_tokens * self._kvarn_config.latent_dim:
+                raise ValueError("KVarN MLA latent input has too few elements")
+            if k_pe.numel() < num_tokens * self._kvarn_config.rope_dim:
+                raise ValueError("KVarN MLA RoPE input has too few elements")
+            latent = kv_c_normed[:num_tokens].reshape(
+                num_tokens, self._kvarn_config.latent_dim
+            )
+            rotated = self._kvarn_rotated_scratch[:num_tokens]
+            kvarn_hadamard(latent, self._kvarn_h, out=rotated)
+            from vllm.v1.attention.ops.kvarn_mla import scatter_kvarn_mla_exact
+
+            scatter_kvarn_mla_exact(
+                rotated,
+                k_pe[:num_tokens].reshape(num_tokens, self._kvarn_config.rope_dim),
+                slot_mapping.reshape(-1),
+                self._kvarn_block_to_slot,
+                self._kvarn_latent_pool,
+                self._kvarn_rope_pool,
+            )
+            return
         if not self._kv_fp8_rope:
             return super().do_kv_cache_update(
                 kv_c_normed,
@@ -2296,7 +2762,11 @@ class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
         tokens — not just the local rank's share — into the correct slots
         of the rank-ordered gathered buffer.
         """
-        if self._ckv_current_chunk_kv_c is None or num_actual_toks == 0:
+        if (
+            self._ckv_current_chunk_kv_c is None
+            or self._ckv_current_chunk_kpe is None
+            or num_actual_toks == 0
+        ):
             return
         kv_c = self._ckv_current_chunk_kv_c[:num_actual_toks]
         assert self._ckv_current_chunk_kpe is not None
@@ -2310,7 +2780,8 @@ class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
         if global_seq_lens is None:
             return
         global_seq_lens = global_seq_lens[:num_reqs]
-        assert attn_metadata.req_id_per_token is not None
+        if attn_metadata.req_id_per_token is None:
+            return
         req_ids = attn_metadata.req_id_per_token[:num_actual_toks].to(torch.int64)
         global_seq_per_token = global_seq_lens[req_ids].to(torch.int32)
 
@@ -2333,7 +2804,8 @@ class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
         ).to(torch.int64)
 
         rank_req_starts = attn_metadata.dcp_rank_req_starts
-        assert rank_req_starts is not None
+        if rank_req_starts is None:
+            return
         flat_idx = owner * num_reqs + req_ids
         # ``dcp_rank_req_starts`` is a ``[dcp, :num_reqs]`` slice of a
         # ``[dcp, max_seqs]`` buffer, so it is non-contiguous whenever
@@ -2506,14 +2978,21 @@ class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
         attn_metadata: B12xMLASparseMetadata,
         layer: AttentionLayer,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        if self._is_kvarn_mla and self._kvarn_group_key is None:
+            q_tensor = q[0] if isinstance(q, tuple) else q
+            output_shape = (*q_tensor.shape[:-1], self.kv_lora_rank)
+            return torch.zeros(
+                output_shape, dtype=q_tensor.dtype, device=q_tensor.device
+            ), None
         # Stored by MultiHeadLatentAttentionWrapper as a host float. Avoid
         # reading device state or allocating per-call CUDA state; the CuTe
         # launch receives this as a runtime scalar.
         latent_scale = float(getattr(layer, "_nvfp4_mla_outer_scale", 1.0))
         kernel_format_kwargs = self._b12x_kernel_format_kwargs(latent_scale)
         query_rows = q[0].shape[0] if isinstance(q, tuple) else q.shape[0]
-        use_ckv_gather = self.dcp_prefill_ckv_gather_eligible(
-            attn_metadata, int(query_rows)
+        use_ckv_gather = (
+            not self._is_kvarn_mla
+            and self.dcp_prefill_ckv_gather_eligible(attn_metadata, int(query_rows))
         )
         workspace_tensors = self._borrow_workspaces()
         q_workspace = workspace_tensors[0]
@@ -2544,7 +3023,13 @@ class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
                 )
             q_buffer = q_buffer[:num_actual_toks]
             q_all = q_buffer[:, :num_input_heads]
-            ops.concat_mla_q(ql_nope, q_pe, q_all)
+            if self._is_kvarn_mla:
+                q_all[..., : self.kv_lora_rank].copy_(
+                    kvarn_hadamard(ql_nope, self._kvarn_h)
+                )
+                q_all[..., self.kv_lora_rank :].copy_(q_pe)
+            else:
+                ops.concat_mla_q(ql_nope, q_pe, q_all)
         else:
             num_actual_toks = q.shape[0]
             num_input_heads = q.shape[1]
@@ -2565,6 +3050,13 @@ class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
             )
             if not exact_workspace_alias:
                 q_all.copy_(q.contiguous())
+            if self._is_kvarn_mla:
+                q_all[..., : self.kv_lora_rank].copy_(
+                    kvarn_hadamard(
+                        q[..., : self.kv_lora_rank],
+                        self._kvarn_h,
+                    )
+                )
 
         assert self.topk_indices_buffer is not None
         topk_indices = self.topk_indices_buffer[:num_actual_toks]
@@ -2648,29 +3140,58 @@ class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
             selected_indices = topk_indices
             nsa_cache_seqlens = per_token_cache
 
-        # KV cache -> paged rank-3 uint8. B12X unified SM120 kernels consume
-        # flat slot ids in selected_indices, but compute raw byte offsets as:
-        #   block = slot // page_size, local = slot % page_size
-        # so the cache tensor itself must expose a per-block stride of
-        # block_size * record_bytes. The older split path used a token-flat
-        # (num_slots, 1, bytes) view; that makes stride(0) one record and breaks
-        # the unified block-stride contract.
-        kv_u8 = kv_c_and_k_pe_cache.view(torch.uint8)
-        if kv_u8.ndim == 3 and kv_u8.shape[1] == self.block_size:
-            kv_cache = kv_u8
-        elif kv_u8.ndim == 3 and kv_u8.shape[1] == 1:
-            if kv_u8.shape[0] % self.block_size != 0:
-                raise ValueError(
-                    "B12X_MLA_SPARSE flat KV cache rows must be divisible by "
-                    f"block_size={self.block_size}; got {kv_u8.shape[0]}"
-                )
-            kv_cache = kv_u8.reshape(-1, self.block_size, kv_u8.shape[-1])
-        else:
-            raise ValueError(
-                f"B12X_MLA_SPARSE expected {self.kv_cache_dtype} KV cache as "
-                f"(blocks,{self.block_size},bytes) or (slots,1,bytes), got "
-                f"{tuple(kv_u8.shape)}"
+        if self._is_kvarn_mla:
+            self._ensure_kvarn_mla_cache(kv_c_and_k_pe_cache)
+            use_spec_decode_kernel = self.spec_extend_as_decode and (
+                self.spec_extend_as_decode_force or attn_metadata.is_spec_decode
             )
+            use_decode_kernel = attn_metadata.max_query_len <= 1 or (
+                use_spec_decode_kernel
+                and attn_metadata.max_query_len <= self.spec_decode_max_q
+                and num_actual_toks <= attn_metadata.num_reqs * self.spec_decode_max_q
+                and num_actual_toks <= self._decode_max_rows
+            )
+            if use_decode_kernel:
+                dense_cache, selected_indices = self._materialize_kvarn_mla_cache(
+                    selected_indices,
+                    attn_metadata,
+                    kv_c_and_k_pe_cache,
+                )
+                return self._forward_kvarn_mla(
+                    q_all[:num_actual_toks, : self._input_num_heads],
+                    dense_cache,
+                    selected_indices,
+                )
+            kv_cache, selected_indices = self._stage_kvarn_mla_fp8_cache(
+                selected_indices,
+                attn_metadata,
+                kv_c_and_k_pe_cache,
+            )
+            kernel_format_kwargs = {"latent_scale": 1.0, "scale_format": 1}
+        else:
+            # KV cache -> paged rank-3 uint8. B12X unified SM120 kernels consume
+            # flat slot ids in selected_indices, but compute raw byte offsets as:
+            #   block = slot // page_size, local = slot % page_size
+            # so the cache tensor itself must expose a per-block stride of
+            # block_size * record_bytes. The older split path used a token-flat
+            # (num_slots, 1, bytes) view; that makes stride(0) one record and breaks
+            # the unified block-stride contract.
+            kv_u8 = kv_c_and_k_pe_cache.view(torch.uint8)
+            if kv_u8.ndim == 3 and kv_u8.shape[1] == self.block_size:
+                kv_cache = kv_u8
+            elif kv_u8.ndim == 3 and kv_u8.shape[1] == 1:
+                if kv_u8.shape[0] % self.block_size != 0:
+                    raise ValueError(
+                        "B12X_MLA_SPARSE flat KV cache rows must be divisible by "
+                        f"block_size={self.block_size}; got {kv_u8.shape[0]}"
+                    )
+                kv_cache = kv_u8.reshape(-1, self.block_size, kv_u8.shape[-1])
+            else:
+                raise ValueError(
+                    f"B12X_MLA_SPARSE expected {self.kv_cache_dtype} KV cache as "
+                    f"(blocks,{self.block_size},bytes) or (slots,1,bytes), got "
+                    f"{tuple(kv_u8.shape)}"
+                )
         if not kv_cache.is_contiguous():
             raise ValueError(
                 "B12X_MLA_SPARSE requires a contiguous native paged KV cache; "
@@ -2817,7 +3338,7 @@ class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
                     dense_out.copy_(out[:, : self._input_num_heads, :])
                     out = dense_out
                     lse = lse[:, : self._input_num_heads]
-                return out, lse
+                return self._restore_kvarn_mla_output(out), lse
             out = cast(
                 torch.Tensor,
                 self._sparse_mla_decode_forward(
@@ -2834,7 +3355,7 @@ class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
                 dense_out = dense_out_workspace[:num_actual_toks]
                 dense_out.copy_(out[:, : self._input_num_heads, :])
                 out = dense_out
-            return out, None
+            return self._restore_kvarn_mla_output(out), None
         else:
             # Extend / prefill -> single-pass unified prefill (no split-K
             # scratch needed; only output_buffer is read). b12x supports 8-head
@@ -2892,4 +3413,4 @@ class B12xMLASparseImpl(MLAAttentionImpl[B12xMLASparseMetadata]):
                 out = dense_out
                 if lse is not None:
                     lse = lse[:, : self._input_num_heads]
-        return out, lse
+        return self._restore_kvarn_mla_output(out), lse

--- a/vllm/v1/attention/backends/mla/kvarn_mla_state.py
+++ b/vllm/v1/attention/backends/mla/kvarn_mla_state.py
@@ -1,0 +1,464 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Lifecycle management for MLA KVarN precision-tail pool slots."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Protocol
+from weakref import WeakSet
+
+import torch
+
+from vllm.model_executor.layers.quantization.kvarn.config import KVarNMLAConfig
+
+if TYPE_CHECKING:
+    from vllm.v1.attention.backend import CommonAttentionMetadata
+
+
+class KVarNMLAImpl(Protocol):
+    layer_name: str
+    _is_kvarn_mla: bool
+    _kvarn_group_key: tuple[str, ...] | None
+    _kvarn_pool_size: int
+    device: torch.device
+
+    def _flush_kvarn_mla_blocks(
+        self, block_ids: torch.Tensor, pool_slots: torch.Tensor
+    ) -> None: ...
+
+
+class KVarNMLARequestState(Protocol):
+    block_ids: tuple[list[int], ...]
+    num_computed_tokens: int
+
+
+@dataclass
+class KVarNMLALiveBlockTracker:
+    """Tracks persistent and per-step exact blocks from scheduler CPU state."""
+
+    group_configs: dict[int, tuple[int, int, int, int, int, int]]
+    request_blocks: dict[str, dict[int, dict[int, int | None]]] = field(
+        default_factory=dict
+    )
+    step_blocks: dict[int, dict[int, int | None]] = field(default_factory=dict)
+    pending_blocks: dict[str, dict[int, dict[int, int]]] = field(default_factory=dict)
+    resolved_blocks: dict[str, dict[int, dict[int, int]]] = field(default_factory=dict)
+
+    @staticmethod
+    def _physical_block_id(
+        block_ids: list[int],
+        logical_block: int,
+        blocks_per_manager_block: int,
+    ) -> int:
+        manager_block, subblock = divmod(logical_block, blocks_per_manager_block)
+        return block_ids[manager_block] * blocks_per_manager_block + subblock
+
+    @staticmethod
+    def _local_num_tokens(
+        num_tokens: int,
+        dcp_world_size: int,
+        dcp_rank: int,
+        dcp_interleave: int,
+    ) -> int:
+        cycle = dcp_world_size * dcp_interleave
+        full_cycles, remainder = divmod(num_tokens, cycle)
+        return full_cycles * dcp_interleave + min(
+            max(remainder - dcp_rank * dcp_interleave, 0),
+            dcp_interleave,
+        )
+
+    @staticmethod
+    def _merge_fill(
+        blocks: dict[int, int | None],
+        block_id: int,
+        fill: int | None,
+    ) -> None:
+        if block_id not in blocks:
+            blocks[block_id] = fill
+            return
+        current = blocks[block_id]
+        if fill is not None and (current is None or fill > current):
+            blocks[block_id] = fill
+
+    def _persistent_group_blocks(
+        self,
+        block_ids: list[int],
+        group_size: int,
+        sink_tokens: int,
+        blocks_per_manager_block: int,
+        local_min_end: int,
+        local_max_end: int,
+    ) -> dict[int, int | None]:
+        num_logical_blocks = min(
+            math.ceil(local_max_end / group_size),
+            len(block_ids) * blocks_per_manager_block,
+        )
+        if num_logical_blocks == 0:
+            return {}
+
+        blocks: dict[int, int | None] = {}
+        sink_blocks = min(
+            math.ceil(sink_tokens / group_size),
+            num_logical_blocks,
+        )
+        for logical_block in range(sink_blocks):
+            fill = min(
+                group_size,
+                max(local_min_end - logical_block * group_size, 0),
+            )
+            blocks[
+                self._physical_block_id(
+                    block_ids,
+                    logical_block,
+                    blocks_per_manager_block,
+                )
+            ] = fill or None
+
+        first_current = max(math.ceil(local_min_end / group_size) - 1, 0)
+        for logical_block in range(first_current, num_logical_blocks):
+            fill = min(
+                group_size,
+                max(local_min_end - logical_block * group_size, 0),
+            )
+            self._merge_fill(
+                blocks,
+                self._physical_block_id(
+                    block_ids,
+                    logical_block,
+                    blocks_per_manager_block,
+                ),
+                fill or None,
+            )
+        return blocks
+
+    def _consume_resolved(self, req_id: str) -> None:
+        for group_id, blocks in self.resolved_blocks.pop(req_id, {}).items():
+            step_blocks = self.step_blocks[group_id]
+            for block_id, fill in blocks.items():
+                self._merge_fill(step_blocks, block_id, fill)
+
+    def resolve_async(
+        self,
+        req_id: str,
+        request: KVarNMLARequestState,
+        actual_end_tokens: int,
+    ) -> None:
+        """Resolve conservative ownership after async spec acceptance is known."""
+        pending = self.pending_blocks.pop(req_id, None)
+        if pending is None:
+            return
+
+        groups: dict[int, dict[int, int | None]] = {}
+        resolved: dict[int, dict[int, int]] = {}
+        for (
+            group_id,
+            (
+                group_size,
+                sink_tokens,
+                blocks_per_manager_block,
+                dcp_world_size,
+                dcp_rank,
+                dcp_interleave,
+            ),
+        ) in self.group_configs.items():
+            if group_id >= len(request.block_ids) or actual_end_tokens <= 0:
+                continue
+            local_end = self._local_num_tokens(
+                actual_end_tokens,
+                dcp_world_size,
+                dcp_rank,
+                dcp_interleave,
+            )
+            block_ids = request.block_ids[group_id]
+            groups[group_id] = self._persistent_group_blocks(
+                block_ids,
+                group_size,
+                sink_tokens,
+                blocks_per_manager_block,
+                local_end,
+                local_end,
+            )
+
+            resolved_group: dict[int, int] = {}
+            for block_id, logical_block in pending.get(group_id, {}).items():
+                fill = min(
+                    group_size,
+                    max(local_end - logical_block * group_size, 0),
+                )
+                if fill:
+                    resolved_group[block_id] = fill
+            if resolved_group:
+                resolved[group_id] = resolved_group
+
+        self.request_blocks[req_id] = groups
+        if resolved:
+            self.resolved_blocks[req_id] = resolved
+
+    def update(
+        self,
+        requests: Mapping[str, KVarNMLARequestState],
+        scheduled_tokens: Mapping[str, int],
+        finished_req_ids: Iterable[str],
+        preempted_req_ids: Iterable[str],
+        rollback_tokens: Mapping[str, int] | None = None,
+    ) -> None:
+        self.step_blocks = {group_id: {} for group_id in self.group_configs}
+        removed = set(finished_req_ids)
+        removed.update(preempted_req_ids)
+        for req_id in removed:
+            self.request_blocks.pop(req_id, None)
+            self.pending_blocks.pop(req_id, None)
+            self.resolved_blocks.pop(req_id, None)
+        for req_id in tuple(self.resolved_blocks):
+            self._consume_resolved(req_id)
+
+        rollback_tokens = rollback_tokens or {}
+        for req_id, num_scheduled_tokens in scheduled_tokens.items():
+            request = requests.get(req_id)
+            if request is None:
+                continue
+            start_tokens = request.num_computed_tokens
+            if req_id in self.pending_blocks:
+                self.resolve_async(req_id, request, start_tokens)
+                self._consume_resolved(req_id)
+
+            rollback = rollback_tokens.get(req_id, 0)
+            min_start_tokens = max(start_tokens - rollback, 0)
+            min_end_tokens = min_start_tokens + num_scheduled_tokens
+            max_end_tokens = start_tokens + num_scheduled_tokens
+            groups: dict[int, dict[int, int | None]] = {}
+            pending: dict[int, dict[int, int]] = {}
+            for (
+                group_id,
+                (
+                    group_size,
+                    sink_tokens,
+                    blocks_per_manager_block,
+                    dcp_world_size,
+                    dcp_rank,
+                    dcp_interleave,
+                ),
+            ) in self.group_configs.items():
+                if group_id >= len(request.block_ids) or max_end_tokens <= 0:
+                    continue
+                local_min_start = self._local_num_tokens(
+                    min_start_tokens,
+                    dcp_world_size,
+                    dcp_rank,
+                    dcp_interleave,
+                )
+                local_min_end = self._local_num_tokens(
+                    min_end_tokens,
+                    dcp_world_size,
+                    dcp_rank,
+                    dcp_interleave,
+                )
+                local_max_end = self._local_num_tokens(
+                    max_end_tokens,
+                    dcp_world_size,
+                    dcp_rank,
+                    dcp_interleave,
+                )
+                block_ids = request.block_ids[group_id]
+                num_logical_blocks = min(
+                    math.ceil(local_max_end / group_size),
+                    len(block_ids) * blocks_per_manager_block,
+                )
+                if num_logical_blocks == 0:
+                    continue
+
+                groups[group_id] = self._persistent_group_blocks(
+                    block_ids,
+                    group_size,
+                    sink_tokens,
+                    blocks_per_manager_block,
+                    local_min_end,
+                    local_max_end,
+                )
+
+                if local_min_start < local_max_end:
+                    first_touched = local_min_start // group_size
+                    last_touched = min(
+                        (local_max_end - 1) // group_size,
+                        num_logical_blocks - 1,
+                    )
+                    step_blocks = self.step_blocks[group_id]
+                    pending_group: dict[int, int] = {}
+                    for logical_block in range(first_touched, last_touched + 1):
+                        block_id = self._physical_block_id(
+                            block_ids,
+                            logical_block,
+                            blocks_per_manager_block,
+                        )
+                        fill = min(
+                            group_size,
+                            max(local_min_end - logical_block * group_size, 0),
+                        )
+                        self._merge_fill(step_blocks, block_id, fill or None)
+                        pending_group[block_id] = logical_block
+                    if rollback and pending_group:
+                        pending[group_id] = pending_group
+            self.request_blocks[req_id] = groups
+            if pending:
+                self.pending_blocks[req_id] = pending
+            else:
+                self.pending_blocks.pop(req_id, None)
+
+    def block_fills(self, group_id: int) -> dict[int, int | None]:
+        fills = dict(self.step_blocks.get(group_id, {}))
+        for groups in self.request_blocks.values():
+            for block_id, fill in groups.get(group_id, {}).items():
+                self._merge_fill(fills, block_id, fill)
+        return fills
+
+
+@dataclass
+class _GroupState:
+    pool_size: int
+    mapping: dict[int, int] = field(default_factory=dict)
+    free_slots: list[int] = field(default_factory=list)
+    block_fill: dict[int, int] = field(default_factory=dict)
+    mirrors: dict[torch.device, torch.Tensor] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        self.free_slots = list(range(self.pool_size - 1, -1, -1))
+
+
+class KVarNMLAStateManager:
+    """Shares physical-block-to-tail-slot ownership across MLA layers."""
+
+    _impls: WeakSet[KVarNMLAImpl] = WeakSet()
+    _groups: dict[tuple[str, ...], _GroupState] = {}
+
+    @classmethod
+    def register(cls, impl: KVarNMLAImpl) -> None:
+        cls._impls.add(impl)
+
+    @classmethod
+    def reset_cache_bindings(cls) -> None:
+        cls._groups.clear()
+        for impl in cls._impls:
+            impl._kvarn_group_key = None
+            impl._kvarn_cache_ref = None  # type: ignore[attr-defined]
+            impl._kvarn_block_to_slot = None  # type: ignore[attr-defined]
+
+    @classmethod
+    def ensure_mirror(
+        cls,
+        group_key: tuple[str, ...],
+        device: torch.device,
+        num_blocks: int,
+    ) -> torch.Tensor:
+        state = cls._groups[group_key]
+        mirror = state.mirrors.get(device)
+        if mirror is None or mirror.shape[0] < num_blocks:
+            mirror = torch.full((num_blocks,), -1, dtype=torch.int32, device=device)
+            state.mirrors[device] = mirror
+            cls._sync_mirror(state, mirror)
+        return mirror
+
+    @staticmethod
+    def _sync_mirror(state: _GroupState, mirror: torch.Tensor) -> None:
+        mirror.fill_(-1)
+        if not state.mapping:
+            return
+        block_ids = torch.tensor(
+            list(state.mapping), dtype=torch.long, device=mirror.device
+        )
+        slots = torch.tensor(
+            list(state.mapping.values()), dtype=torch.int32, device=mirror.device
+        )
+        valid = block_ids < mirror.shape[0]
+        mirror[block_ids[valid]] = slots[valid]
+
+    @staticmethod
+    def _update_mirror(mirror: torch.Tensor, updates: dict[int, int]) -> None:
+        if not updates:
+            return
+        block_ids = torch.tensor(list(updates), dtype=torch.long, device=mirror.device)
+        slots = torch.tensor(
+            list(updates.values()), dtype=torch.int32, device=mirror.device
+        )
+        valid = block_ids < mirror.shape[0]
+        mirror[block_ids[valid]] = slots[valid]
+
+    @classmethod
+    def prepare_step(
+        cls,
+        group_key: tuple[str, ...],
+        layer_names: list[str],
+        common_metadata: CommonAttentionMetadata,
+        config: KVarNMLAConfig,
+        dcp_world_size: int,
+    ) -> None:
+        impls = [
+            impl
+            for impl in cls._impls
+            if impl._is_kvarn_mla and impl.layer_name in layer_names
+        ]
+        if not impls:
+            return
+        for impl in impls:
+            impl._kvarn_group_key = group_key
+
+        pool_size = min(impl._kvarn_pool_size for impl in impls)
+        state = cls._groups.get(group_key)
+        if state is None:
+            state = _GroupState(pool_size=pool_size)
+            cls._groups[group_key] = state
+        elif state.pool_size != pool_size:
+            raise RuntimeError(
+                "MLA KVarN layers in one cache group must share pool size"
+            )
+
+        block_fills = common_metadata.kvarn_mla_block_fills
+        if block_fills is None:
+            raise RuntimeError("MLA KVarN requires exact-block ownership metadata")
+        needed = set(block_fills)
+        for block_id, fill in block_fills.items():
+            if fill is None:
+                state.block_fill.pop(block_id, None)
+            else:
+                state.block_fill[block_id] = max(
+                    state.block_fill.get(block_id, 0), fill
+                )
+
+        retired = [block_id for block_id in state.mapping if block_id not in needed]
+        flush_ids = [
+            block_id
+            for block_id in retired
+            if state.block_fill.get(block_id, 0) >= config.group
+        ]
+        if flush_ids:
+            device = impls[0].device
+            block_ids = torch.tensor(flush_ids, dtype=torch.long, device=device)
+            pool_slots = torch.tensor(
+                [state.mapping[block_id] for block_id in flush_ids],
+                dtype=torch.long,
+                device=device,
+            )
+            for impl in impls:
+                impl._flush_kvarn_mla_blocks(block_ids, pool_slots)
+
+        for block_id in retired:
+            state.free_slots.append(state.mapping.pop(block_id))
+            state.block_fill.pop(block_id, None)
+
+        missing = sorted(needed.difference(state.mapping))
+        if len(missing) > len(state.free_slots):
+            raise RuntimeError(
+                "MLA KVarN exact-block pool exhausted: "
+                f"need {len(missing)} slots, have {len(state.free_slots)}. "
+                "Reduce max_num_seqs or max_num_batched_tokens."
+            )
+        mirror_updates = {block_id: -1 for block_id in retired}
+        for block_id in missing:
+            slot = state.free_slots.pop()
+            state.mapping[block_id] = slot
+            mirror_updates[block_id] = slot
+
+        for mirror in state.mirrors.values():
+            cls._update_mirror(mirror, mirror_updates)

--- a/vllm/v1/attention/backends/mla/kvarn_mla_state.py
+++ b/vllm/v1/attention/backends/mla/kvarn_mla_state.py
@@ -322,6 +322,7 @@ class _GroupState:
     free_slots: list[int] = field(default_factory=list)
     block_fill: dict[int, int] = field(default_factory=dict)
     mirrors: dict[torch.device, torch.Tensor] = field(default_factory=dict)
+    flushed: set[int] = field(default_factory=set)
 
     def __post_init__(self) -> None:
         self.free_slots = list(range(self.pool_size - 1, -1, -1))
@@ -442,10 +443,18 @@ class KVarNMLAStateManager:
             )
             for impl in impls:
                 impl._flush_kvarn_mla_blocks(block_ids, pool_slots)
+            # The paged packed copy of these blocks is now valid, so a later
+            # prefix-cache hit can restore exact rows from it.
+            state.flushed.update(flush_ids)
 
         for block_id in retired:
             state.free_slots.append(state.mapping.pop(block_id))
-            state.block_fill.pop(block_id, None)
+            fill = state.block_fill.pop(block_id, 0)
+            if fill < config.group:
+                # A block retired below full fill has no packed copy of its
+                # current content, so it can never be served from the paged
+                # record.
+                state.flushed.discard(block_id)
 
         missing = sorted(needed.difference(state.mapping))
         if len(missing) > len(state.free_slots):
@@ -459,6 +468,40 @@ class KVarNMLAStateManager:
             slot = state.free_slots.pop()
             state.mapping[block_id] = slot
             mirror_updates[block_id] = slot
+
+        # A missing block whose rows were persisted by a retire-flush is a
+        # prefix-cache hit (or an equivalent re-entry): no step will ever
+        # scatter its pre-computed rows again, but the freshly popped slot
+        # still holds another block's exact rows. Restore this block's rows
+        # from its packed paged record so exact-pool readers see its own KV.
+        # Blocks without a packed copy are genuinely fresh: every row they
+        # will ever expose is written by scatter in the acquiring step, which
+        # overwrites whatever the recycled slot held.
+        rehydrate_ids = [block_id for block_id in missing if block_id in state.flushed]
+        if rehydrate_ids:
+            from vllm.v1.attention.ops.kvarn_mla import rehydrate_kvarn_mla_blocks
+
+            device = impls[0].device
+            block_ids = torch.tensor(rehydrate_ids, dtype=torch.long, device=device)
+            pool_slots = torch.tensor(
+                [state.mapping[block_id] for block_id in rehydrate_ids],
+                dtype=torch.long,
+                device=device,
+            )
+            for impl in impls:
+                cache_ref = getattr(impl, "_kvarn_cache_ref", None)
+                latent_pool = getattr(impl, "_kvarn_latent_pool", None)
+                rope_pool = getattr(impl, "_kvarn_rope_pool", None)
+                if cache_ref is None or latent_pool is None or rope_pool is None:
+                    continue
+                rehydrate_kvarn_mla_blocks(
+                    cache_ref,
+                    latent_pool,
+                    rope_pool,
+                    block_ids,
+                    pool_slots,
+                    config,
+                )
 
         for mirror in state.mirrors.values():
             cls._update_mirror(mirror, mirror_updates)

--- a/vllm/v1/attention/backends/registry.py
+++ b/vllm/v1/attention/backends/registry.py
@@ -134,6 +134,7 @@ class AttentionBackendEnum(Enum, metaclass=_AttentionBackendEnumMeta):
     CPU_ATTN = "vllm.v1.attention.backends.cpu_attn.CPUAttentionBackend"
     CPU_MLA = "vllm.v1.attention.backends.mla.cpu_mla.CPUMLABackend"
     TURBOQUANT = "vllm.v1.attention.backends.turboquant_attn.TurboQuantAttentionBackend"
+    KVARN = "vllm.v1.attention.backends.kvarn_attn.KVarNAttentionBackend"
     # Placeholder for third-party/custom backends - must be registered before use
     # set to None to avoid alias with other backend, whose value is an empty string
     CUSTOM = None

--- a/vllm/v1/attention/ops/cutedsl_kvarn_decode.py
+++ b/vllm/v1/attention/ops/cutedsl_kvarn_decode.py
@@ -1,0 +1,577 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import math
+from functools import cache
+
+import cutlass
+import cutlass.cute as cute
+import torch
+from cuda.bindings.driver import CUstream
+from cutlass import Float8E4M3FN, Float16, Float32, Int32, Uint8, Uint16, Uint32
+from cutlass.cute.nvgpu import warp
+from quack.compile_utils import make_fake_tensor
+
+from vllm.cute_utils import mma_sync, recast_val
+from vllm.utils.torch_utils import current_stream
+
+
+class KVarNK4V2MmaStage1:
+    D = 128
+    GROUP = 128
+    HQ = 32
+    HK = 8
+    QPK = 4
+    THREADS = 128
+    RECORDS_PER_TILE = 1
+    TILE_TOKENS = 128
+    SMEM_BYTES = 40192
+    K_BITS = 4
+    V_BITS = 2
+    K_PACKED_OFFSET = 0
+    K_S_COL_OFFSET = 8192
+    K_ZP_OFFSET = 8448
+    K_S_ROW_OFFSET = 8704
+    V_PACKED_OFFSET = 8960
+    V_S_COL_OFFSET = 13056
+    V_S_ROW_OFFSET = 13312
+    V_ZP_OFFSET = 13568
+    TILE_BYTES = 13824
+
+    def __init__(self, tail_scaled: bool):
+        self.tail_scaled = tail_scaled
+
+    @cute.jit
+    def _load_f16(self, kv: cute.Tensor, page: Int32, hk: Int32, offset: Int32):
+        lo = Uint16(kv[page, hk, offset])
+        hi = Uint16(kv[page, hk, offset + Int32(1)])
+        return recast_val(lo | (hi << Uint16(8)), Float16).to(Float32)
+
+    @cute.jit
+    def __call__(
+        self,
+        q: cute.Tensor,
+        kv: cute.Tensor,
+        tail_k: cute.Tensor,
+        tail_v: cute.Tensor,
+        tail_ks: cute.Tensor,
+        tail_vs: cute.Tensor,
+        block_table: cute.Tensor,
+        seq_lens: cute.Tensor,
+        block_to_slot: cute.Tensor,
+        mid_o: cute.Tensor,
+        mid_lse: cute.Tensor,
+        num_splits: Int32,
+        stream: CUstream,
+    ):
+        batch = q.shape[0]
+        self.kernel(
+            q,
+            kv,
+            tail_k,
+            tail_v,
+            tail_ks,
+            tail_vs,
+            block_table,
+            seq_lens,
+            block_to_slot,
+            mid_o,
+            mid_lse,
+            num_splits,
+        ).launch(
+            grid=[num_splits, batch * self.HK, 1],
+            block=[self.THREADS, 1, 1],
+            smem=self.SMEM_BYTES,
+            stream=stream,
+            min_blocks_per_mp=1,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        q: cute.Tensor,
+        kv: cute.Tensor,
+        tail_k: cute.Tensor,
+        tail_v: cute.Tensor,
+        tail_ks: cute.Tensor,
+        tail_vs: cute.Tensor,
+        block_table: cute.Tensor,
+        seq_lens: cute.Tensor,
+        block_to_slot: cute.Tensor,
+        mid_o: cute.Tensor,
+        mid_lse: cute.Tensor,
+        num_splits: Int32,
+    ):
+        tid, _, _ = cute.arch.thread_idx()
+        split, bhk, _ = cute.arch.block_idx()
+        b = bhk // Int32(self.HK)
+        hk = bhk - b * Int32(self.HK)
+        warp_id = cute.arch.warp_idx()
+        lane_id = cute.arch.lane_idx()
+        head = warp_id
+        num_records = (seq_lens[b] + Int32(self.GROUP - 1)) // Int32(self.GROUP)
+
+        smem = cutlass.utils.SmemAllocator()
+        sK = smem.allocate_tensor(
+            Float16,
+            cute.make_layout((self.TILE_TOKENS, self.D), stride=(self.D, 1)),
+            byte_alignment=16,
+        )
+        sQ = smem.allocate_tensor(
+            Float16,
+            cute.make_layout((self.RECORDS_PER_TILE * 8, self.D), stride=(self.D, 1)),
+            byte_alignment=16,
+        )
+        sScore = smem.allocate_tensor(
+            Float32,
+            cute.make_layout(
+                (self.QPK, self.TILE_TOKENS), stride=(self.TILE_TOKENS, 1)
+            ),
+            byte_alignment=16,
+        )
+        sP = smem.allocate_tensor(
+            Float16,
+            cute.make_layout((8, self.TILE_TOKENS), stride=(self.TILE_TOKENS, 1)),
+            byte_alignment=16,
+        )
+        sZq = smem.allocate_tensor(
+            Float32,
+            cute.make_layout((self.RECORDS_PER_TILE, self.QPK), stride=(self.QPK, 1)),
+        )
+        sStats = smem.allocate_tensor(
+            Float32, cute.make_layout((2, self.QPK), stride=(self.QPK, 1))
+        )
+        sGlobal = smem.allocate_tensor(
+            Float32, cute.make_layout((2, self.QPK), stride=(self.QPK, 1))
+        )
+        sMerge = smem.allocate_tensor(
+            Float32, cute.make_layout((2, self.QPK), stride=(self.QPK, 1))
+        )
+
+        elems = 8
+        mma_k = 16
+        ldsm_atom = cute.make_copy_atom(warp.LdMatrix8x8x16bOp(num_matrices=4), Float16)
+        rAccum = cute.make_rmem_tensor((4, 2, 1), Float32)
+        rAccum.fill(0.0)
+        if tid < Int32(self.QPK):
+            sGlobal[0, tid] = -Float32.inf
+            sGlobal[1, tid] = Float32(0.0)
+        cute.arch.sync_threads()
+
+        num_tiles = (num_records + Int32(self.RECORDS_PER_TILE - 1)) // Int32(
+            self.RECORDS_PER_TILE
+        )
+        for tile_iter in cutlass.range_constexpr(8):
+            logical = split + Int32(tile_iter) * num_splits
+            if logical < num_tiles:
+                start = logical * Int32(self.TILE_TOKENS)
+                valid = cutlass.min(Int32(self.TILE_TOKENS), seq_lens[b] - start)
+                record_offset = tid // Int32(self.GROUP)
+                token_local = tid - record_offset * Int32(self.GROUP)
+                record_index = logical * Int32(self.RECORDS_PER_TILE) + record_offset
+                safe_record = cutlass.min(record_index, num_records - Int32(1))
+                page = block_table[b, safe_record]
+                pool_slot = block_to_slot[page]
+
+                if pool_slot >= Int32(0):
+                    k_scale = (
+                        tail_ks[pool_slot, token_local, hk].to(Float32)
+                        if cutlass.const_expr(self.tail_scaled)
+                        else Float32(1.0)
+                    )
+                    for d in cutlass.range_constexpr(self.D):
+                        kval = (
+                            tail_k[pool_slot, token_local, hk, d].to(Float32) * k_scale
+                        )
+                        sK[tid, d] = kval.to(Float16) if tid < valid else Float16(0.0)
+                else:
+                    for d in cutlass.range_constexpr(self.D):
+                        bit_offset = token_local * Int32(self.K_BITS)
+                        byte_offset = (
+                            Int32(self.K_PACKED_OFFSET)
+                            + d * Int32(self.GROUP * self.K_BITS // 8)
+                            + bit_offset // Int32(8)
+                        )
+                        packed = Uint32(kv[page, hk, byte_offset]) | (
+                            Uint32(kv[page, hk, byte_offset + Int32(1)]) << Uint32(8)
+                        )
+                        shift = Uint32(bit_offset & Int32(7))
+                        code = Float32(
+                            (packed >> shift) & Uint32((1 << self.K_BITS) - 1)
+                        )
+                        sK[tid, d] = code.to(Float16) if tid < valid else Float16(0.0)
+
+                for record in cutlass.range_constexpr(self.RECORDS_PER_TILE):
+                    q_record = logical * Int32(self.RECORDS_PER_TILE) + Int32(record)
+                    q_safe_record = cutlass.min(q_record, num_records - Int32(1))
+                    q_page = block_table[b, q_safe_record]
+                    q_pool_slot = block_to_slot[q_page]
+                    if q_pool_slot >= Int32(0):
+                        for h in cutlass.range_constexpr(8):
+                            sQ[record * 8 + h, tid] = (
+                                (
+                                    q[b, hk * self.QPK + h, tid].to(Float32)
+                                    / math.sqrt(self.D)
+                                ).to(Float16)
+                                if h < self.QPK
+                                else Float16(0.0)
+                            )
+                        if warp_id < Int32(self.QPK):
+                            sZq[record, warp_id] = Float32(0.0)
+                    else:
+                        s_col = self._load_f16(
+                            kv,
+                            q_page,
+                            hk,
+                            Int32(self.K_S_COL_OFFSET) + tid * Int32(2),
+                        )
+                        for h in cutlass.range_constexpr(8):
+                            sQ[record * 8 + h, tid] = (
+                                (
+                                    q[b, hk * self.QPK + h, tid].to(Float32)
+                                    * s_col
+                                    / math.sqrt(self.D)
+                                ).to(Float16)
+                                if h < self.QPK
+                                else Float16(0.0)
+                            )
+                        if warp_id < Int32(self.QPK):
+                            zpart = Float32(0.0)
+                            for j in cutlass.range_constexpr(4):
+                                d = lane_id + Int32(j * 32)
+                                zpart += (
+                                    q[
+                                        b,
+                                        hk * self.QPK + warp_id,
+                                        d,
+                                    ].to(Float32)
+                                    * self._load_f16(
+                                        kv,
+                                        q_page,
+                                        hk,
+                                        Int32(self.K_ZP_OFFSET) + d * Int32(2),
+                                    )
+                                    / math.sqrt(self.D)
+                                )
+                            sZq[record, warp_id] = cute.arch.warp_reduction_sum(zpart)
+                for h in cutlass.range_constexpr(self.QPK, 8):
+                    sP[h, tid] = Float16(0.0)
+                cute.arch.sync_threads()
+
+                qk_warps = self.GROUP // 32
+                qk_record = warp_id // Int32(qk_warps)
+                sK_warp = cute.local_tile(sK, (32, self.D), (warp_id, 0))
+                sQ_record = cute.local_tile(sQ, (8, self.D), (qk_record, 0))
+                sK_ldsm = cute.zipped_divide(
+                    sK_warp, (16, cute.make_layout((elems, 2)))
+                )
+                sQ_ldsm = cute.zipped_divide(
+                    sQ_record, (8, cute.make_layout((elems, 4)))
+                )
+                sK_ldsm = sK_ldsm[(lane_id % 16, (None, lane_id // 16)), None]
+                sQ_ldsm = sQ_ldsm[(lane_id % 8, (None, lane_id // 8)), None]
+                rQ = cute.make_rmem_tensor(((4, 2), 4, 1), Float16)
+                rK = cute.make_rmem_tensor((8, 2, 8), Float16)
+                rC = cute.make_rmem_tensor((4, 2, 1), Float32)
+                cute.copy(
+                    ldsm_atom,
+                    sQ_ldsm[None, (0, None)],
+                    rQ[None, None, 0],
+                )
+                rC.fill(0.0)
+                for k in cutlass.range_constexpr(self.D // mma_k):
+                    cute.copy(
+                        ldsm_atom,
+                        sK_ldsm[None, (None, k)],
+                        rK[None, None, k],
+                    )
+                    for m in cutlass.range_constexpr(2):
+                        rC[None, m, 0] = mma_sync(
+                            rK[None, m, k],
+                            rQ[(None, k % 2), k // 2, 0],
+                            rC[None, m, 0],
+                        )
+
+                score_record = logical * Int32(self.RECORDS_PER_TILE) + qk_record
+                score_safe_record = cutlass.min(score_record, num_records - Int32(1))
+                score_page = block_table[b, score_safe_record]
+                score_pool_slot = block_to_slot[score_page]
+                for i in cutlass.range_constexpr(4):
+                    for j in cutlass.range_constexpr(2):
+                        token = warp_id * Int32(32) + Int32(i * 8) + lane_id // Int32(4)
+                        token_in_record = token - qk_record * Int32(self.GROUP)
+                        h = (lane_id % Int32(4)) * Int32(2) + Int32(j)
+                        if h < Int32(self.QPK):
+                            score = rC[i * 2 + j]
+                            if score_pool_slot < Int32(0):
+                                score = (score + sZq[qk_record, h]) * self._load_f16(
+                                    kv,
+                                    score_page,
+                                    hk,
+                                    Int32(self.K_S_ROW_OFFSET)
+                                    + token_in_record * Int32(2),
+                                )
+                            sScore[h, token] = score if token < valid else -Float32.inf
+                cute.arch.sync_threads()
+
+                local_max = -Float32.inf
+                for j in cutlass.range_constexpr(self.TILE_TOKENS // 32):
+                    token = lane_id + Int32(j * 32)
+                    local_max = cute.arch.fmax(local_max, sScore[head, token])
+                maxv = cute.arch.warp_reduction_max(local_max)
+                local_sum = Float32(0.0)
+                for j in cutlass.range_constexpr(self.TILE_TOKENS // 32):
+                    token = lane_id + Int32(j * 32)
+                    p = (
+                        cute.math.exp2(
+                            (sScore[head, token] - maxv) * math.log2(math.e),
+                            fastmath=True,
+                        )
+                        if token < valid
+                        else Float32(0.0)
+                    )
+                    local_sum += p
+                    sP[head, token] = p.to(Float16)
+                denom = cute.arch.warp_reduction_sum(local_sum)
+                if lane_id == Int32(0):
+                    sStats[0, head] = maxv
+                    sStats[1, head] = denom
+                cute.arch.sync_threads()
+
+                sV = cute.make_tensor(
+                    sK.iterator,
+                    cute.make_layout(
+                        (self.D, self.TILE_TOKENS),
+                        stride=(self.TILE_TOKENS, 1),
+                    ),
+                )
+                if pool_slot >= Int32(0):
+                    v_scale = (
+                        tail_vs[pool_slot, token_local, hk].to(Float32)
+                        if cutlass.const_expr(self.tail_scaled)
+                        else Float32(1.0)
+                    )
+                    for d in cutlass.range_constexpr(self.D):
+                        vval = (
+                            tail_v[pool_slot, token_local, hk, d].to(Float32) * v_scale
+                        )
+                        sV[d, tid] = vval.to(Float16) if tid < valid else Float16(0.0)
+                else:
+                    s_row = self._load_f16(
+                        kv,
+                        page,
+                        hk,
+                        Int32(self.V_S_ROW_OFFSET) + token_local * Int32(2),
+                    )
+                    zp_v = self._load_f16(
+                        kv,
+                        page,
+                        hk,
+                        Int32(self.V_ZP_OFFSET) + token_local * Int32(2),
+                    )
+                    for d in cutlass.range_constexpr(self.D):
+                        s_col = self._load_f16(
+                            kv,
+                            page,
+                            hk,
+                            Int32(self.V_S_COL_OFFSET) + d * Int32(2),
+                        )
+                        bit_offset = d * Int32(self.V_BITS)
+                        byte_offset = (
+                            Int32(self.V_PACKED_OFFSET)
+                            + token_local * Int32(self.D * self.V_BITS // 8)
+                            + bit_offset // Int32(8)
+                        )
+                        packed = Uint32(kv[page, hk, byte_offset]) | (
+                            Uint32(kv[page, hk, byte_offset + Int32(1)]) << Uint32(8)
+                        )
+                        shift = Uint32(bit_offset & Int32(7))
+                        code = Float32(
+                            (packed >> shift) & Uint32((1 << self.V_BITS) - 1)
+                        )
+                        vval = (code * s_row + zp_v) * s_col
+                        sV[d, tid] = vval.to(Float16) if tid < valid else Float16(0.0)
+                cute.arch.sync_threads()
+
+                sV_warp = cute.local_tile(sV, (32, self.TILE_TOKENS), (warp_id, 0))
+                sV_ldsm = cute.zipped_divide(
+                    sV_warp, (16, cute.make_layout((elems, 2)))
+                )
+                sP_ldsm = cute.zipped_divide(sP, (8, cute.make_layout((elems, 4))))
+                sV_ldsm = sV_ldsm[(lane_id % 16, (None, lane_id // 16)), None]
+                sP_ldsm = sP_ldsm[(lane_id % 8, (None, lane_id // 8)), None]
+                rP = cute.make_rmem_tensor(((4, 2), self.TILE_TOKENS // 32, 1), Float16)
+                rV = cute.make_rmem_tensor((8, 2, self.TILE_TOKENS // mma_k), Float16)
+                rO = cute.make_rmem_tensor((4, 2, 1), Float32)
+                cute.copy(
+                    ldsm_atom,
+                    sP_ldsm[None, (0, None)],
+                    rP[None, None, 0],
+                )
+                rO.fill(0.0)
+                for k in cutlass.range_constexpr(self.TILE_TOKENS // mma_k):
+                    cute.copy(
+                        ldsm_atom,
+                        sV_ldsm[None, (None, k)],
+                        rV[None, None, k],
+                    )
+                    for m in cutlass.range_constexpr(2):
+                        rO[None, m, 0] = mma_sync(
+                            rV[None, m, k],
+                            rP[(None, k % 2), k // 2, 0],
+                            rO[None, m, 0],
+                        )
+
+                if tid < Int32(self.QPK):
+                    h = tid
+                    merged_max = cute.arch.fmax(sGlobal[0, h], sStats[0, h])
+                    alpha = cute.math.exp2(
+                        (sGlobal[0, h] - merged_max) * math.log2(math.e),
+                        fastmath=True,
+                    )
+                    beta = cute.math.exp2(
+                        (sStats[0, h] - merged_max) * math.log2(math.e),
+                        fastmath=True,
+                    )
+                    sMerge[0, h] = alpha
+                    sMerge[1, h] = beta
+                    sGlobal[0, h] = merged_max
+                    sGlobal[1, h] = sGlobal[1, h] * alpha + sStats[1, h] * beta
+                cute.arch.sync_threads()
+                for i in cutlass.range_constexpr(4):
+                    for j in cutlass.range_constexpr(2):
+                        h = (lane_id % Int32(4)) * Int32(2) + Int32(j)
+                        if h < Int32(self.QPK):
+                            rAccum[i * 2 + j] = (
+                                rAccum[i * 2 + j] * sMerge[0, h]
+                                + rO[i * 2 + j] * sMerge[1, h]
+                            )
+                cute.arch.sync_threads()
+
+        for i in cutlass.range_constexpr(4):
+            for j in cutlass.range_constexpr(2):
+                d = warp_id * Int32(32) + Int32(i * 8) + lane_id // Int32(4)
+                h = (lane_id % Int32(4)) * Int32(2) + Int32(j)
+                if h < Int32(self.QPK):
+                    row = b * Int32(self.HQ) + hk * Int32(self.QPK) + h
+                    mid_o[row, split, d] = (
+                        rAccum[i * 2 + j] / sGlobal[1, h]
+                        if sGlobal[1, h] > Float32(0.0)
+                        else Float32(0.0)
+                    )
+        if tid < Int32(self.QPK):
+            row = b * Int32(self.HQ) + hk * Int32(self.QPK) + tid
+            mid_lse[row, split] = (
+                sGlobal[0, tid] + cute.math.log(sGlobal[1, tid], fastmath=True)
+                if sGlobal[1, tid] > Float32(0.0)
+                else -Float32.inf
+            )
+
+
+class KVarNK4V4MmaStage1(KVarNK4V2MmaStage1):
+    V_BITS = 4
+    V_S_COL_OFFSET = 17152
+    V_S_ROW_OFFSET = 17408
+    V_ZP_OFFSET = 17664
+    TILE_BYTES = 17920
+
+
+class KVarNK5V5MmaStage1(KVarNK4V2MmaStage1):
+    RECORDS_PER_TILE = 2
+    SMEM_BYTES = 43008
+    GROUP = 64
+    K_BITS = 5
+    V_BITS = 5
+    K_PACKED_OFFSET = 0
+    K_S_COL_OFFSET = 5120
+    K_ZP_OFFSET = 5376
+    K_S_ROW_OFFSET = 5632
+    V_PACKED_OFFSET = 5760
+    V_S_COL_OFFSET = 10880
+    V_S_ROW_OFFSET = 11136
+    V_ZP_OFFSET = 11264
+    TILE_BYTES = 11392
+
+
+def _stream() -> CUstream:
+    return CUstream(current_stream().cuda_stream)
+
+
+@cache
+def compile_kernel(cache_dtype: str, tail_scaled: bool):
+    B, P, S, NB, R, NS, SA, SH, L = (cute.sym_int() for _ in range(9))
+    tail_type = Float8E4M3FN if tail_scaled else Float16
+    if cache_dtype == "kvarn_k4v2_g128":
+        kernel_cls = KVarNK4V2MmaStage1
+    elif cache_dtype == "kvarn_k4v4_g128":
+        kernel_cls = KVarNK4V4MmaStage1
+    elif cache_dtype == "kvarn_k5v5_g64":
+        kernel_cls = KVarNK5V5MmaStage1
+    else:
+        raise ValueError(f"Unsupported CuTeDSL KVarN format: {cache_dtype}")
+    args = (
+        make_fake_tensor(Float16, (B, 32, 128), divisibility=8),
+        make_fake_tensor(
+            Uint8,
+            (P, 8, kernel_cls.TILE_BYTES),
+            divisibility=16,
+        ),
+        make_fake_tensor(
+            tail_type,
+            (S, kernel_cls.GROUP, 8, 128),
+            divisibility=8,
+        ),
+        make_fake_tensor(
+            tail_type,
+            (S, kernel_cls.GROUP, 8, 128),
+            divisibility=8,
+        ),
+        make_fake_tensor(Float16, (S, SA, SH), divisibility=1),
+        make_fake_tensor(Float16, (S, SA, SH), divisibility=1),
+        make_fake_tensor(Int32, (B, NB), divisibility=4),
+        make_fake_tensor(Int32, (B,), divisibility=4),
+        make_fake_tensor(Int32, (L,), divisibility=4),
+        make_fake_tensor(Float32, (R, NS, 128), divisibility=4),
+        make_fake_tensor(Float32, (R, NS), divisibility=1),
+        Int32(1),
+        _stream(),
+    )
+    return cute.compile(
+        kernel_cls(tail_scaled),
+        *args,
+        options="--enable-tvm-ffi",
+    )
+
+
+def run(
+    q,
+    kv,
+    tail_k,
+    tail_v,
+    tail_ks,
+    tail_vs,
+    block_table,
+    seq_lens,
+    block_to_slot,
+    mid_o,
+    mid_lse,
+    num_splits,
+    cache_dtype,
+):
+    compile_kernel(cache_dtype, tail_k.dtype == torch.float8_e4m3fn)(
+        q,
+        kv,
+        tail_k,
+        tail_v,
+        tail_ks,
+        tail_vs,
+        block_table,
+        seq_lens,
+        block_to_slot,
+        mid_o,
+        mid_lse,
+        num_splits,
+        _stream(),
+    )

--- a/vllm/v1/attention/ops/kvarn_decode.py
+++ b/vllm/v1/attention/ops/kvarn_decode.py
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""KVarN tile-level dequant reference (pure PyTorch).
+
+Inverse of ``kvarn_store_tile_{k,v}``. Produces the dequantized tile in the
+**rotated** frame; the caller is responsible for the inverse Hadamard
+(matmul with H, which is its own inverse) and any subsequent attention math.
+
+The Triton port (Stage 4) lives in ``triton_kvarn_decode.py`` and must
+produce numerically equivalent outputs (cosine ≥ 0.999 vs this reference).
+"""
+
+from __future__ import annotations
+
+import torch
+
+from vllm import _custom_ops as ops
+
+
+def kvarn_hadamard(
+    value: torch.Tensor,
+    fallback_matrix: torch.Tensor,
+    *,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Apply the normalized Sylvester Hadamard transform.
+
+    CUDA uses vLLM's in-place Hadacore kernel. The matrix path keeps CPU
+    references and unsupported builds functional.
+    """
+    if value.is_cuda and hasattr(torch.ops._C, "hadacore_transform"):
+        if out is None:
+            out = value.contiguous().clone()
+        else:
+            out.copy_(value)
+        transformed = ops.hadacore_transform(
+            out.reshape(-1, value.shape[-1]), inplace=True
+        )
+        if transformed.data_ptr() != out.data_ptr():
+            out.copy_(transformed.reshape_as(out))
+        return out
+    if out is None:
+        return torch.matmul(value, fallback_matrix)
+    torch.matmul(value, fallback_matrix, out=out)
+    return out
+
+
+def _unpack_4bit(packed: torch.Tensor, original_last_dim: int) -> torch.Tensor:
+    """Inverse of ``kvarn_store::_pack_4bit``.
+
+    ``packed`` has shape ``[..., original_last_dim // 2]`` uint8; returns
+    shape ``[..., original_last_dim]`` uint8 with values in [0, 15].
+    """
+    assert original_last_dim % 2 == 0
+    lo = packed & 0xF
+    hi = (packed >> 4) & 0xF
+    out = torch.empty(
+        *packed.shape[:-1],
+        original_last_dim,
+        dtype=torch.uint8,
+        device=packed.device,
+    )
+    out[..., 0::2] = lo
+    out[..., 1::2] = hi
+    return out
+
+
+def _unpack_lowbit(
+    packed: torch.Tensor, original_last_dim: int, bits: int
+) -> torch.Tensor:
+    """Unpack the dense little-endian bit stream produced by ``_pack_lowbit``."""
+    if not 1 <= bits <= 8:
+        raise ValueError(f"bits must be in [1, 8], got {bits}")
+    value_indices = torch.arange(
+        original_last_dim, dtype=torch.int64, device=packed.device
+    )
+    bit_offsets = value_indices * bits
+    bit_numbers = torch.arange(bits, dtype=torch.int64, device=packed.device)
+    source_bits = bit_offsets[:, None] + bit_numbers[None, :]
+    source_bytes = torch.div(source_bits, 8, rounding_mode="floor")
+    shifts = source_bits.remainder(8)
+    loaded = packed[..., source_bytes]
+    bits_unpacked = (loaded >> shifts) & 1
+    weights = 1 << bit_numbers
+    return (bits_unpacked * weights).sum(dim=-1).to(torch.uint8)
+
+
+def kvarn_dequant_tile_k(
+    q_packed_uint8: torch.Tensor,
+    s_col_K: torch.Tensor,
+    zp_K: torch.Tensor,
+    s_row_K: torch.Tensor,
+    group: int,
+    bits: int = 4,
+) -> torch.Tensor:
+    """Dequantize one K tile back to the rotated ``[D, group]`` frame.
+
+    Args:
+        q_packed_uint8 : ``[D, group // (8//bits)]`` uint8.
+        s_col_K        : ``[D]`` fp16  — absorbed per-channel scale.
+        zp_K           : ``[D]`` fp16  — absorbed per-channel zero.
+        s_row_K        : ``[group]`` fp16 — per-token-in-tile sinkhorn scale.
+        group          : tile width in tokens.
+        bits           : quant bit-width of K (default 4).
+
+    Returns:
+        ``[D, group]`` fp32 dequantized tile in the rotated frame.
+        Identity: ``out[r,c] = (q[r,c] * s_col_K[r] + zp_K[r]) * s_row_K[c]``.
+    """
+    q = _unpack_lowbit(q_packed_uint8, group, bits).float()  # [D, group]
+    s_col = s_col_K.float().unsqueeze(-1)  # [D, 1]
+    zp = zp_K.float().unsqueeze(-1)  # [D, 1]
+    s_row = s_row_K.float().unsqueeze(0)  # [1, group]
+    return (q * s_col + zp) * s_row
+
+
+def kvarn_dequant_tile_v(
+    q_packed_uint8: torch.Tensor,
+    s_col_V: torch.Tensor,
+    s_row_V: torch.Tensor,
+    zp_V: torch.Tensor,
+    head_dim: int,
+    bits: int = 4,
+) -> torch.Tensor:
+    """Dequantize one V tile back to the rotated ``[group, D]`` frame.
+
+    Args:
+        q_packed_uint8 : ``[group, D // (8//bits)]`` uint8.
+        s_col_V        : ``[D]`` fp16  — per-channel sinkhorn scale (untouched).
+        s_row_V        : ``[group]`` fp16 — absorbed per-token-in-tile scale.
+        zp_V           : ``[group]`` fp16 — absorbed per-token-in-tile zero.
+        head_dim       : tile width in channels.
+        bits           : quant bit-width of V (default 4; k4v2 uses 2).
+
+    Returns:
+        ``[group, head_dim]`` fp32 dequantized tile in the rotated frame.
+        Identity: ``out[t,c] = (q[t,c] * s_row_V[t] + zp_V[t]) * s_col_V[c]``.
+    """
+    q = _unpack_lowbit(q_packed_uint8, head_dim, bits).float()  # [group, D]
+    s_row = s_row_V.float().unsqueeze(-1)  # [group, 1]
+    zp = zp_V.float().unsqueeze(-1)  # [group, 1]
+    s_col = s_col_V.float().unsqueeze(0)  # [1, D]
+    return (q * s_row + zp) * s_col

--- a/vllm/v1/attention/ops/kvarn_mla.py
+++ b/vllm/v1/attention/ops/kvarn_mla.py
@@ -1,0 +1,711 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""KVarN K5 cache operations for MLA latent caches."""
+
+from __future__ import annotations
+
+import os
+
+import torch
+
+from vllm.model_executor.layers.quantization.kvarn.config import KVarNMLAConfig
+from vllm.triton_utils import tl, triton
+from vllm.v1.attention.ops.kvarn_store import (
+    kvarn_store_tile_k_batch_from_sinkhorn,
+)
+from vllm.v1.attention.ops.triton_kvarn_sinkhorn import kvarn_sinkhorn_triton
+
+
+@triton.jit
+def _unpack_dense_bits(payload_ptr, value_indices, mask, bits: tl.constexpr):
+    bit_offsets = value_indices * bits
+    byte_offsets = bit_offsets // 8
+    shifts = bit_offsets % 8
+    lo = tl.load(payload_ptr + byte_offsets, mask=mask, other=0).to(tl.uint32)
+    hi = tl.load(payload_ptr + byte_offsets + 1, mask=mask, other=0).to(tl.uint32)
+    return ((lo | (hi << 8)) >> shifts) & ((1 << bits) - 1)
+
+
+@triton.jit
+def _scatter_kvarn_mla_exact_kernel(
+    latent_ptr,
+    rope_ptr,
+    slot_mapping_ptr,
+    block_to_slot_ptr,
+    latent_pool_ptr,
+    rope_pool_ptr,
+    latent_stride_t: tl.constexpr,
+    rope_stride_t: tl.constexpr,
+    latent_pool_stride_s: tl.constexpr,
+    latent_pool_stride_t: tl.constexpr,
+    rope_pool_stride_s: tl.constexpr,
+    rope_pool_stride_t: tl.constexpr,
+    NUM_BLOCKS: tl.constexpr,
+    NUM_POOL_SLOTS: tl.constexpr,
+    GROUP: tl.constexpr,
+    LATENT_DIM: tl.constexpr,
+    ROPE_DIM: tl.constexpr,
+):
+    token = tl.program_id(0)
+    physical_slot = tl.load(slot_mapping_ptr + token)
+    valid_slot = physical_slot >= 0
+    block = physical_slot // GROUP
+    offset = physical_slot % GROUP
+    pool_slot = tl.load(
+        block_to_slot_ptr + block,
+        mask=valid_slot & (block < NUM_BLOCKS),
+        other=-1,
+    )
+    valid = (
+        valid_slot
+        & (block < NUM_BLOCKS)
+        & (pool_slot >= 0)
+        & (pool_slot < NUM_POOL_SLOTS)
+    )
+    safe_pool_slot = tl.where(valid, pool_slot, 0)
+
+    latent_cols = tl.arange(0, LATENT_DIM)
+    latent = tl.load(latent_ptr + token * latent_stride_t + latent_cols)
+    tl.store(
+        latent_pool_ptr
+        + safe_pool_slot * latent_pool_stride_s
+        + offset * latent_pool_stride_t
+        + latent_cols,
+        latent,
+        mask=valid,
+    )
+
+    rope_cols = tl.arange(0, ROPE_DIM)
+    rope = tl.load(rope_ptr + token * rope_stride_t + rope_cols)
+    tl.store(
+        rope_pool_ptr
+        + safe_pool_slot * rope_pool_stride_s
+        + offset * rope_pool_stride_t
+        + rope_cols,
+        rope,
+        mask=valid,
+    )
+
+
+def scatter_kvarn_mla_exact(
+    latent_rotated: torch.Tensor,
+    rope: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    block_to_slot: torch.Tensor,
+    latent_pool: torch.Tensor,
+    rope_pool: torch.Tensor,
+) -> None:
+    num_tokens = slot_mapping.shape[0]
+    if num_tokens == 0:
+        return
+    if latent_rotated.shape[0] < num_tokens or rope.shape[0] < num_tokens:
+        raise ValueError("KVarN MLA exact scatter inputs have too few rows")
+    if latent_pool.shape[0] != rope_pool.shape[0]:
+        raise ValueError("KVarN MLA exact latent/RoPE pools must have equal slots")
+    if not slot_mapping.is_contiguous() or not block_to_slot.is_contiguous():
+        raise ValueError("KVarN MLA exact scatter index buffers must be contiguous")
+    _scatter_kvarn_mla_exact_kernel[(num_tokens,)](
+        latent_rotated,
+        rope,
+        slot_mapping,
+        block_to_slot,
+        latent_pool,
+        rope_pool,
+        latent_rotated.stride(0),
+        rope.stride(0),
+        latent_pool.stride(0),
+        latent_pool.stride(1),
+        rope_pool.stride(0),
+        rope_pool.stride(1),
+        NUM_BLOCKS=block_to_slot.shape[0],
+        NUM_POOL_SLOTS=latent_pool.shape[0],
+        GROUP=latent_pool.shape[1],
+        LATENT_DIM=latent_pool.shape[2],
+        ROPE_DIM=rope_pool.shape[2],
+        num_warps=4,
+    )
+
+
+@triton.jit
+def _round_to_even(values):
+    lower = tl.floor(values)
+    fraction = values - lower
+    lower_int = lower.to(tl.int32)
+    ties_up = (lower_int & 1) != 0
+    return tl.where(
+        fraction > 0.5,
+        lower + 1.0,
+        tl.where(fraction < 0.5, lower, lower + ties_up),
+    )
+
+
+@triton.jit
+def _quantize_rtn(values, lower, scale, qmax: tl.constexpr):
+    return tl.maximum(
+        tl.minimum(_round_to_even((values - lower) / scale), qmax),
+        0.0,
+    )
+
+
+@triton.jit
+def _serialize_kvarn_mla_blocks_kernel(
+    balanced_ptr,
+    s_col_ptr,
+    s_row_ptr,
+    rope_pool_ptr,
+    block_ids_ptr,
+    pool_slots_ptr,
+    cache_ptr,
+    balanced_stride_n: tl.constexpr,
+    balanced_stride_r: tl.constexpr,
+    s_col_stride_n: tl.constexpr,
+    s_row_stride_n: tl.constexpr,
+    rope_pool_stride_s: tl.constexpr,
+    rope_pool_stride_t: tl.constexpr,
+    cache_stride_b: tl.constexpr,
+    GROUP: tl.constexpr,
+    LATENT_DIM: tl.constexpr,
+    ROPE_DIM: tl.constexpr,
+    BITS: tl.constexpr,
+    PACKED_ROW_BYTES: tl.constexpr,
+    S_COL_OFFSET: tl.constexpr,
+    ZP_OFFSET: tl.constexpr,
+    S_ROW_OFFSET: tl.constexpr,
+    ROPE_OFFSET: tl.constexpr,
+    AFFINE_REFIT: tl.constexpr,
+):
+    program = tl.program_id(0)
+    tile = program // LATENT_DIM
+    row = program % LATENT_DIM
+    tokens = tl.arange(0, GROUP)
+    values = tl.load(
+        balanced_ptr + tile * balanced_stride_n + row * balanced_stride_r + tokens
+    ).to(tl.float32)
+
+    qmax: tl.constexpr = (1 << BITS) - 1
+    lower = tl.min(values, axis=0)
+    upper = tl.max(values, axis=0)
+    quant_scale = tl.maximum((upper - lower) / qmax, 1e-10)
+    scale = quant_scale
+    zero = lower
+    codes = _quantize_rtn(values, lower, quant_scale, qmax)
+
+    if AFFINE_REFIT:
+        token_scales = tl.load(s_col_ptr + tile * s_col_stride_n + tokens).to(
+            tl.float32
+        )
+        weights = token_scales * token_scales
+        weight_sum = tl.maximum(tl.sum(weights, axis=0), 1e-20)
+        code_mean = tl.sum(weights * codes, axis=0) / weight_sum
+        value_mean = tl.sum(weights * values, axis=0) / weight_sum
+        centered_codes = codes - code_mean
+        denominator = tl.sum(weights * centered_codes * centered_codes, axis=0)
+        numerator = tl.sum(
+            weights * centered_codes * (values - value_mean),
+            axis=0,
+        )
+        fitted_scale = tl.maximum(numerator / tl.maximum(denominator, 1e-20), 1e-10)
+        fitted_zero = value_mean - fitted_scale * code_mean
+        usable = denominator > 1e-20
+        scale = tl.where(usable, fitted_scale, scale)
+        zero = tl.where(usable, fitted_zero, zero)
+
+    physical_block = tl.load(block_ids_ptr + tile)
+    record = cache_ptr + physical_block * cache_stride_b
+    row_scale = tl.load(s_row_ptr + tile * s_row_stride_n + row).to(tl.float32)
+    fp16_record = record.to(tl.pointer_type(tl.float16))
+    tl.store(fp16_record + S_COL_OFFSET // 2 + row, row_scale * scale)
+    tl.store(fp16_record + ZP_OFFSET // 2 + row, row_scale * zero)
+
+    packed_offsets = tl.arange(0, 64)
+    packed_mask = packed_offsets < PACKED_ROW_BYTES
+    bit_offsets = packed_offsets * 8
+    source = bit_offsets // BITS
+    shifts = bit_offsets % BITS
+
+    source0 = tl.load(
+        balanced_ptr + tile * balanced_stride_n + row * balanced_stride_r + source,
+        mask=packed_mask & (source < GROUP),
+        other=lower,
+    ).to(tl.float32)
+    source1 = tl.load(
+        balanced_ptr + tile * balanced_stride_n + row * balanced_stride_r + source + 1,
+        mask=packed_mask & (source + 1 < GROUP),
+        other=lower,
+    ).to(tl.float32)
+    source2 = tl.load(
+        balanced_ptr + tile * balanced_stride_n + row * balanced_stride_r + source + 2,
+        mask=packed_mask & (source + 2 < GROUP),
+        other=lower,
+    ).to(tl.float32)
+    code0 = _quantize_rtn(source0, lower, quant_scale, qmax).to(tl.uint32)
+    code1 = _quantize_rtn(source1, lower, quant_scale, qmax).to(tl.uint32)
+    code2 = _quantize_rtn(source2, lower, quant_scale, qmax).to(tl.uint32)
+    words = code0 | (code1 << BITS) | (code2 << (2 * BITS))
+    packed = (words >> shifts) & 0xFF
+    tl.store(
+        record + row * PACKED_ROW_BYTES + packed_offsets,
+        packed.to(tl.uint8),
+        mask=packed_mask,
+    )
+
+    shared_offsets = tl.arange(0, 64)
+    shared_mask = shared_offsets < GROUP
+    token_scales = tl.load(
+        s_col_ptr + tile * s_col_stride_n + shared_offsets,
+        mask=shared_mask,
+    )
+    tl.store(
+        fp16_record + S_ROW_OFFSET // 2 + shared_offsets,
+        token_scales,
+        mask=(row == 0) & shared_mask,
+    )
+
+    pool_slot = tl.load(pool_slots_ptr + tile)
+    rope = tl.load(
+        rope_pool_ptr
+        + pool_slot * rope_pool_stride_s
+        + row * rope_pool_stride_t
+        + shared_offsets,
+        mask=(row < GROUP) & (shared_offsets < ROPE_DIM),
+    )
+    rope_record = (record + ROPE_OFFSET).to(tl.pointer_type(tl.bfloat16))
+    tl.store(
+        rope_record + row * ROPE_DIM + shared_offsets,
+        rope,
+        mask=(row < GROUP) & (shared_offsets < ROPE_DIM),
+    )
+
+
+def _serialize_kvarn_mla_blocks(
+    kv_cache: torch.Tensor,
+    rope_pool: torch.Tensor,
+    block_ids: torch.Tensor,
+    pool_slots: torch.Tensor,
+    balanced: torch.Tensor,
+    s_col: torch.Tensor,
+    s_row: torch.Tensor,
+    config: KVarNMLAConfig,
+) -> None:
+    packed_row_bytes = config.latent_packed_bytes // config.latent_dim
+    _serialize_kvarn_mla_blocks_kernel[(block_ids.numel() * config.latent_dim,)](
+        balanced,
+        s_col,
+        s_row,
+        rope_pool,
+        block_ids,
+        pool_slots,
+        kv_cache.view(torch.uint8),
+        balanced.stride(0),
+        balanced.stride(1),
+        s_col.stride(0),
+        s_row.stride(0),
+        rope_pool.stride(0),
+        rope_pool.stride(1),
+        kv_cache.view(torch.uint8).stride(0),
+        GROUP=config.group,
+        LATENT_DIM=config.latent_dim,
+        ROPE_DIM=config.rope_dim,
+        BITS=config.bits,
+        PACKED_ROW_BYTES=packed_row_bytes,
+        S_COL_OFFSET=config.latent_s_col_offset,
+        ZP_OFFSET=config.latent_zp_offset,
+        S_ROW_OFFSET=config.latent_s_row_offset,
+        ROPE_OFFSET=config.rope_offset,
+        AFFINE_REFIT=os.environ.get("KVARN_AFFINE_REFIT", "1") == "1",
+        num_warps=4,
+    )
+
+
+def pack_kvarn_mla_blocks(
+    kv_cache: torch.Tensor,
+    latent_pool: torch.Tensor,
+    rope_pool: torch.Tensor,
+    block_ids: torch.Tensor,
+    pool_slots: torch.Tensor,
+    config: KVarNMLAConfig,
+) -> None:
+    """Quantize complete latent tiles and serialize exact BF16 RoPE tiles."""
+    if block_ids.numel() == 0:
+        return
+    latent = latent_pool.index_select(0, pool_slots).float()
+    latent_tiles = latent.transpose(1, 2).contiguous()
+    balanced, s_col, s_row = kvarn_sinkhorn_triton(
+        latent_tiles, iterations=config.sinkhorn_iters
+    )
+    quantile = float(os.environ.get("KVARN_RTN_QUANTILE", "") or 0.0)
+    if config.bits == 5 and quantile <= 0.0:
+        _serialize_kvarn_mla_blocks(
+            kv_cache,
+            rope_pool,
+            block_ids,
+            pool_slots,
+            balanced,
+            s_col,
+            s_row,
+            config,
+        )
+        return
+    packed = kvarn_store_tile_k_batch_from_sinkhorn(
+        balanced, s_col, s_row, bits=config.bits
+    )
+
+    num_blocks = block_ids.numel()
+    records = torch.zeros(
+        (num_blocks, config.tile_bytes), dtype=torch.uint8, device=kv_cache.device
+    )
+    records[:, : config.latent_packed_bytes].copy_(
+        packed["q_packed_uint8"].reshape(num_blocks, -1)
+    )
+    records[
+        :,
+        config.latent_s_col_offset : config.latent_zp_offset,
+    ].copy_(packed["s_col_K"].contiguous().view(torch.uint8))
+    records[
+        :,
+        config.latent_zp_offset : config.latent_s_row_offset,
+    ].copy_(packed["zp_K"].contiguous().view(torch.uint8))
+    records[:, config.latent_s_row_offset : config.rope_offset].copy_(
+        packed["s_row_K"].contiguous().view(torch.uint8)
+    )
+    rope = rope_pool.index_select(0, pool_slots).to(torch.bfloat16).contiguous()
+    records[:, config.rope_offset :].copy_(
+        rope.view(torch.uint8).reshape(num_blocks, -1)
+    )
+    kv_cache.view(torch.uint8).reshape(kv_cache.shape[0], -1).index_copy_(
+        0, block_ids, records
+    )
+
+
+@triton.jit
+def _materialize_selected_kvarn_mla_kernel(
+    selected_ptr,
+    cache_ptr,
+    block_to_slot_ptr,
+    latent_pool_ptr,
+    rope_pool_ptr,
+    output_ptr,
+    selected_stride: tl.constexpr,
+    cache_stride_b: tl.constexpr,
+    latent_pool_stride_s: tl.constexpr,
+    latent_pool_stride_t: tl.constexpr,
+    rope_pool_stride_s: tl.constexpr,
+    rope_pool_stride_t: tl.constexpr,
+    output_stride: tl.constexpr,
+    NUM_BLOCKS: tl.constexpr,
+    NUM_POOL_SLOTS: tl.constexpr,
+    GROUP: tl.constexpr,
+    LATENT_DIM: tl.constexpr,
+    ROPE_DIM: tl.constexpr,
+    BITS: tl.constexpr,
+    PACKED_BYTES: tl.constexpr,
+    S_COL_OFFSET: tl.constexpr,
+    ZP_OFFSET: tl.constexpr,
+    S_ROW_OFFSET: tl.constexpr,
+    ROPE_OFFSET: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    row = tl.program_id(0)
+    cols = tl.program_id(1) * BLOCK_D + tl.arange(0, BLOCK_D)
+    width = LATENT_DIM + ROPE_DIM
+    col_mask = cols < width
+    physical_slot = tl.load(selected_ptr + row * selected_stride)
+    valid_slot = physical_slot >= 0
+    block = physical_slot // GROUP
+    token = physical_slot % GROUP
+    valid_block = valid_slot & (block < NUM_BLOCKS)
+    pool_slot = tl.load(block_to_slot_ptr + block, mask=valid_block, other=-1)
+    exact = valid_block & (pool_slot >= 0) & (pool_slot < NUM_POOL_SLOTS)
+    safe_pool_slot = tl.where(exact, pool_slot, 0)
+    safe_block = tl.where(valid_block, block, 0)
+    record = cache_ptr + safe_block * cache_stride_b
+
+    latent_mask = col_mask & (cols < LATENT_DIM) & valid_block
+    body_latent_mask = latent_mask & ~exact
+    latent_indices = cols * GROUP + token
+    q = _unpack_dense_bits(record, latent_indices, body_latent_mask, BITS).to(
+        tl.float32
+    )
+    fp16_record = record.to(tl.pointer_type(tl.float16))
+    s_col = tl.load(
+        fp16_record + S_COL_OFFSET // 2 + cols,
+        mask=body_latent_mask,
+        other=0.0,
+    )
+    zp = tl.load(
+        fp16_record + ZP_OFFSET // 2 + cols,
+        mask=body_latent_mask,
+        other=0.0,
+    )
+    s_row = tl.load(
+        fp16_record + S_ROW_OFFSET // 2 + token,
+        mask=valid_block & ~exact,
+        other=0.0,
+    )
+    body_latent = (q * s_col + zp) * s_row
+    exact_latent = tl.load(
+        latent_pool_ptr
+        + safe_pool_slot * latent_pool_stride_s
+        + token * latent_pool_stride_t
+        + cols,
+        mask=latent_mask & exact,
+        other=0.0,
+    ).to(tl.float32)
+    latent = tl.where(exact, exact_latent, body_latent)
+
+    rope_cols = cols - LATENT_DIM
+    rope_mask = col_mask & (cols >= LATENT_DIM)
+    body_rope_ptr = (record + ROPE_OFFSET).to(tl.pointer_type(tl.bfloat16))
+    body_rope = tl.load(
+        body_rope_ptr + token * ROPE_DIM + rope_cols,
+        mask=rope_mask & valid_block & ~exact,
+        other=0.0,
+    ).to(tl.float32)
+    exact_rope = tl.load(
+        rope_pool_ptr
+        + safe_pool_slot * rope_pool_stride_s
+        + token * rope_pool_stride_t
+        + rope_cols,
+        mask=rope_mask & exact,
+        other=0.0,
+    ).to(tl.float32)
+    rope_value = tl.where(exact, exact_rope, body_rope)
+    value = tl.where(cols < LATENT_DIM, latent, rope_value)
+    tl.store(
+        output_ptr + row * output_stride + cols,
+        value,
+        mask=col_mask & valid_block,
+    )
+
+
+@triton.jit
+def _linearize_selected_kernel(
+    selected_ptr,
+    remapped_ptr,
+    n_elements: tl.constexpr,
+    max_physical_slots: tl.constexpr,
+):
+    offsets = tl.program_id(0) * 256 + tl.arange(0, 256)
+    mask = offsets < n_elements
+    selected = tl.load(selected_ptr + offsets, mask=mask, other=-1)
+    valid = (selected >= 0) & (selected < max_physical_slots)
+    tl.store(remapped_ptr + offsets, tl.where(valid, offsets, -1), mask=mask)
+
+
+def materialize_selected_kvarn_mla(
+    selected_indices: torch.Tensor,
+    kv_cache: torch.Tensor,
+    block_to_slot: torch.Tensor,
+    latent_pool: torch.Tensor,
+    rope_pool: torch.Tensor,
+    output: torch.Tensor,
+    remapped: torch.Tensor | None,
+    config: KVarNMLAConfig,
+) -> None:
+    if selected_indices.dtype != torch.int32 or not selected_indices.is_contiguous():
+        raise ValueError("KVarN MLA selected indices must be contiguous int32")
+    if not output.is_contiguous():
+        raise ValueError("KVarN MLA dense workspace must be contiguous")
+    if latent_pool.shape[0] != rope_pool.shape[0]:
+        raise ValueError("KVarN MLA exact latent/RoPE pools must have equal slots")
+    if block_to_slot.numel() < kv_cache.shape[0]:
+        raise ValueError("KVarN MLA block-to-slot map is smaller than the cache")
+    if block_to_slot.dtype != torch.int32:
+        raise ValueError("KVarN MLA block-to-slot map must be int32")
+
+    flat_selected = selected_indices.view(-1)
+    flat_output = output.view(-1, config.latent_dim + config.rope_dim)
+    rows = flat_selected.numel()
+    if rows > flat_output.shape[0]:
+        raise ValueError(
+            f"KVarN MLA dense workspace has {flat_output.shape[0]} rows, "
+            f"requires {rows}"
+        )
+    flat_remapped = None
+    if remapped is not None:
+        if remapped.dtype != torch.int32 or not remapped.is_contiguous():
+            raise ValueError("KVarN MLA remap workspace must be contiguous int32")
+        flat_remapped = remapped.view(-1)
+        if rows > flat_remapped.numel():
+            raise ValueError(
+                f"KVarN MLA remap workspace has {flat_remapped.numel()} entries, "
+                f"requires {rows}"
+            )
+    if rows == 0:
+        return
+
+    grid = (rows, triton.cdiv(config.latent_dim + config.rope_dim, 64))
+    _materialize_selected_kvarn_mla_kernel[grid](
+        flat_selected,
+        kv_cache.view(torch.uint8),
+        block_to_slot,
+        latent_pool,
+        rope_pool,
+        flat_output,
+        1,
+        kv_cache.view(torch.uint8).stride(0),
+        latent_pool.stride(0),
+        latent_pool.stride(1),
+        rope_pool.stride(0),
+        rope_pool.stride(1),
+        flat_output.stride(0),
+        NUM_BLOCKS=kv_cache.shape[0],
+        NUM_POOL_SLOTS=latent_pool.shape[0],
+        GROUP=config.group,
+        LATENT_DIM=config.latent_dim,
+        ROPE_DIM=config.rope_dim,
+        BITS=config.bits,
+        PACKED_BYTES=config.latent_packed_bytes,
+        S_COL_OFFSET=config.latent_s_col_offset,
+        ZP_OFFSET=config.latent_zp_offset,
+        S_ROW_OFFSET=config.latent_s_row_offset,
+        ROPE_OFFSET=config.rope_offset,
+        BLOCK_D=64,
+        num_warps=4,
+    )
+    if flat_remapped is not None:
+        _linearize_selected_kernel[(triton.cdiv(rows, 256),)](
+            flat_selected,
+            flat_remapped,
+            n_elements=rows,
+            max_physical_slots=kv_cache.shape[0] * config.group,
+        )
+
+
+@triton.jit
+def _copy_bounded_physical_indices_kernel(
+    selected_ptr,
+    remapped_ptr,
+    n_elements: tl.constexpr,
+    max_physical_slots: tl.constexpr,
+):
+    offsets = tl.program_id(0) * 256 + tl.arange(0, 256)
+    mask = offsets < n_elements
+    physical = tl.load(selected_ptr + offsets, mask=mask, other=-1)
+    valid = (physical >= 0) & (physical < max_physical_slots)
+    tl.store(remapped_ptr + offsets, tl.where(valid, physical, -1), mask=mask)
+
+
+def remap_kvarn_mla_physical_indices(
+    selected_indices: torch.Tensor,
+    remapped: torch.Tensor,
+    *,
+    max_physical_slots: int,
+) -> None:
+    if (
+        selected_indices.dtype != torch.int32
+        or remapped.dtype != torch.int32
+        or not selected_indices.is_contiguous()
+        or not remapped.is_contiguous()
+    ):
+        raise ValueError("KVarN MLA physical index buffers must be contiguous int32")
+    rows = selected_indices.numel()
+    if rows > remapped.numel():
+        raise ValueError(
+            f"KVarN MLA remap workspace has {remapped.numel()} entries, requires {rows}"
+        )
+    if rows == 0:
+        return
+    _copy_bounded_physical_indices_kernel[(triton.cdiv(rows, 256),)](
+        selected_indices.view(-1),
+        remapped.view(-1),
+        n_elements=rows,
+        max_physical_slots=max_physical_slots,
+    )
+
+
+def materialize_physical_kvarn_mla(
+    physical_slots: torch.Tensor,
+    selected_indices: torch.Tensor,
+    kv_cache: torch.Tensor,
+    block_to_slot: torch.Tensor,
+    latent_pool: torch.Tensor,
+    rope_pool: torch.Tensor,
+    output: torch.Tensor,
+    remapped: torch.Tensor,
+    config: KVarNMLAConfig,
+) -> None:
+    """Materialize the local page arena at its stable physical row indices."""
+    page_rows = kv_cache.shape[0] * config.group
+    if (
+        physical_slots.dtype != torch.int32
+        or not physical_slots.is_contiguous()
+        or physical_slots.numel() != page_rows
+    ):
+        raise ValueError(
+            "KVarN MLA physical-slot workspace must be contiguous int32 "
+            f"with {page_rows} entries"
+        )
+    materialize_selected_kvarn_mla(
+        physical_slots,
+        kv_cache,
+        block_to_slot,
+        latent_pool,
+        rope_pool,
+        output,
+        None,
+        config,
+    )
+    remap_kvarn_mla_physical_indices(
+        selected_indices,
+        remapped,
+        max_physical_slots=page_rows,
+    )
+
+
+def stage_physical_kvarn_mla_fp8(
+    physical_slots: torch.Tensor,
+    selected_indices: torch.Tensor,
+    kv_cache: torch.Tensor,
+    block_to_slot: torch.Tensor,
+    latent_pool: torch.Tensor,
+    rope_pool: torch.Tensor,
+    output_records: torch.Tensor,
+    remapped: torch.Tensor,
+    config: KVarNMLAConfig,
+) -> None:
+    """Stage the local page arena in SparkInfer's physical token order."""
+    try:
+        from b12x.attention.kvarn_mla import stage_k5_as_fp8_records
+    except (ImportError, AttributeError) as exc:
+        raise RuntimeError(
+            "KVarN MLA requires a b12x build with "
+            "b12x.attention.kvarn_mla.stage_k5_as_fp8_records"
+        ) from exc
+
+    page_rows = kv_cache.shape[0] * config.group
+    if (
+        physical_slots.dtype != torch.int32
+        or not physical_slots.is_contiguous()
+        or physical_slots.numel() != page_rows
+    ):
+        raise ValueError(
+            "KVarN MLA physical-slot workspace must be contiguous int32 "
+            f"with {page_rows} entries"
+        )
+    if (
+        output_records.dtype != torch.uint8
+        or not output_records.is_contiguous()
+        or output_records.shape != (page_rows, 656)
+    ):
+        raise ValueError(f"KVarN MLA FP8 workspace must have shape ({page_rows}, 656)")
+    if output_records.data_ptr() % 16:
+        raise ValueError("KVarN MLA FP8 workspace must be 16-byte aligned")
+    if block_to_slot.numel() < kv_cache.shape[0]:
+        raise ValueError("KVarN MLA block-to-slot map is smaller than the cache")
+    if latent_pool.shape[0] != rope_pool.shape[0]:
+        raise ValueError("KVarN MLA exact latent/RoPE pools must have equal slots")
+
+    stage_k5_as_fp8_records(
+        physical_slots,
+        kv_cache,
+        block_to_slot,
+        latent_pool,
+        rope_pool,
+        output_records,
+    )
+    remap_kvarn_mla_physical_indices(
+        selected_indices,
+        remapped,
+        max_physical_slots=page_rows,
+    )

--- a/vllm/v1/attention/ops/kvarn_mla.py
+++ b/vllm/v1/attention/ops/kvarn_mla.py
@@ -573,6 +573,123 @@ def materialize_selected_kvarn_mla(
 
 
 @triton.jit
+def _rehydrate_kvarn_mla_blocks_kernel(
+    cache_ptr,
+    block_ids_ptr,
+    pool_slots_ptr,
+    latent_pool_ptr,
+    rope_pool_ptr,
+    cache_stride_b,
+    latent_pool_stride_s,
+    latent_pool_stride_t,
+    rope_pool_stride_s,
+    rope_pool_stride_t,
+    BLOCK_L: tl.constexpr,
+    BLOCK_R: tl.constexpr,
+    GROUP: tl.constexpr,
+    LATENT_DIM: tl.constexpr,
+    ROPE_DIM: tl.constexpr,
+    BITS: tl.constexpr,
+    S_COL_OFFSET: tl.constexpr,
+    ZP_OFFSET: tl.constexpr,
+    S_ROW_OFFSET: tl.constexpr,
+    ROPE_OFFSET: tl.constexpr,
+):
+    """Rebuild exact pool rows for one packed block from its paged record.
+
+    Inverse of ``pack_kvarn_mla_blocks``: dequantizes the packed latent tile
+    and copies the serialized RoPE rows back into the exact side pool so a
+    cache-hit block that re-enters ownership reads its own KV instead of a
+    recycled slot's previous occupant.
+    """
+    entry = tl.program_id(0)
+    token = tl.program_id(1)
+    block = tl.load(block_ids_ptr + entry)
+    slot = tl.load(pool_slots_ptr + entry)
+    record = cache_ptr + block * cache_stride_b
+
+    cols = tl.arange(0, BLOCK_L)
+    latent_mask = cols < LATENT_DIM
+    q = _unpack_dense_bits(record, cols * GROUP + token, latent_mask, BITS).to(
+        tl.float32
+    )
+    fp16_record = record.to(tl.pointer_type(tl.float16))
+    s_col = tl.load(fp16_record + S_COL_OFFSET // 2 + cols, mask=latent_mask, other=0.0)
+    zp = tl.load(fp16_record + ZP_OFFSET // 2 + cols, mask=latent_mask, other=0.0)
+    s_row = tl.load(fp16_record + S_ROW_OFFSET // 2 + token)
+    latent = (q * s_col + zp) * s_row
+    tl.store(
+        latent_pool_ptr
+        + slot * latent_pool_stride_s
+        + token * latent_pool_stride_t
+        + cols,
+        latent.to(latent_pool_ptr.dtype.element_ty),
+        mask=latent_mask,
+    )
+
+    rope_cols = tl.arange(0, BLOCK_R)
+    rope_mask = rope_cols < ROPE_DIM
+    body_rope = tl.load(
+        (record + ROPE_OFFSET).to(tl.pointer_type(tl.bfloat16))
+        + token * ROPE_DIM
+        + rope_cols,
+        mask=rope_mask,
+        other=0.0,
+    )
+    tl.store(
+        rope_pool_ptr
+        + slot * rope_pool_stride_s
+        + token * rope_pool_stride_t
+        + rope_cols,
+        body_rope,
+        mask=rope_mask,
+    )
+
+
+def rehydrate_kvarn_mla_blocks(
+    kv_cache: torch.Tensor,
+    latent_pool: torch.Tensor,
+    rope_pool: torch.Tensor,
+    block_ids: torch.Tensor,
+    pool_slots: torch.Tensor,
+    config: KVarNMLAConfig,
+) -> None:
+    """Restore exact-pool rows for packed blocks (paged record -> pool slot)."""
+    if block_ids.numel() == 0:
+        return
+    if latent_pool.shape[0] != rope_pool.shape[0]:
+        raise ValueError("KVarN MLA exact latent/RoPE pools must have equal slots")
+    if block_ids.dtype != torch.long or pool_slots.dtype != torch.long:
+        raise ValueError("KVarN MLA rehydrate index buffers must be int64")
+    if not block_ids.is_contiguous() or not pool_slots.is_contiguous():
+        raise ValueError("KVarN MLA rehydrate index buffers must be contiguous")
+    cache_bytes = kv_cache.view(torch.uint8)
+    _rehydrate_kvarn_mla_blocks_kernel[(block_ids.numel(), config.group)](
+        cache_bytes,
+        block_ids,
+        pool_slots,
+        latent_pool,
+        rope_pool,
+        cache_bytes.stride(0),
+        latent_pool.stride(0),
+        latent_pool.stride(1),
+        rope_pool.stride(0),
+        rope_pool.stride(1),
+        BLOCK_L=triton.next_power_of_2(config.latent_dim),
+        BLOCK_R=triton.next_power_of_2(config.rope_dim),
+        GROUP=config.group,
+        LATENT_DIM=config.latent_dim,
+        ROPE_DIM=config.rope_dim,
+        BITS=config.bits,
+        S_COL_OFFSET=config.latent_s_col_offset,
+        ZP_OFFSET=config.latent_zp_offset,
+        S_ROW_OFFSET=config.latent_s_row_offset,
+        ROPE_OFFSET=config.rope_offset,
+        num_warps=4,
+    )
+
+
+@triton.jit
 def _copy_bounded_physical_indices_kernel(
     selected_ptr,
     remapped_ptr,

--- a/vllm/v1/attention/ops/kvarn_store.py
+++ b/vllm/v1/attention/ops/kvarn_store.py
@@ -1,0 +1,340 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""KVarN tile-level store reference (pure PyTorch).
+
+Quantizes one tile of K (or V) per call. The Triton port (Stage 4) lives in
+``triton_kvarn_store.py`` and must produce byte-identical outputs.
+
+Inputs to the K path are tile-shaped ``[D, group]`` (channels × tokens — the
+KIVI K-axis orientation) **after** Hadamard rotation. Inputs to the V path
+are tile-shaped ``[group, D]`` (tokens × channels — the KIVI V-axis
+orientation) also after Hadamard rotation. The Hadamard rotation is applied
+externally via a cuBLAS GEMM, identically to TurboQuant's MSE path.
+
+The output is a packed record matching the cache layout from
+``KVarNConfig`` — see that file for byte offsets.
+"""
+
+from __future__ import annotations
+
+import os
+
+import torch
+
+from vllm.model_executor.layers.quantization.kvarn.sinkhorn import (
+    variance_normalize,
+)
+
+
+def _rtn_range(t: torch.Tensor, dim: int):
+    """Per-row range. With KVARN_RTN_QUANTILE=q > 0 (e.g. 0.005), uses
+    percentiles [q, 1-q] instead of min/max — values outside get clamped at
+    quantize time, sacrificing outliers for finer bulk resolution. Critical
+    for k2v2 on models like Qwen3-30B-A3B-Thinking where K outliers
+    (max/std ≈ 6) waste 2-bit resolution.
+    """
+    q_str = os.environ.get("KVARN_RTN_QUANTILE", "")
+    if q_str and float(q_str) > 0:
+        q = float(q_str)
+        lo = torch.quantile(t, q, dim=dim, keepdim=True)
+        hi = torch.quantile(t, 1.0 - q, dim=dim, keepdim=True)
+        return lo, hi
+    return t.amin(dim=dim, keepdim=True), t.amax(dim=dim, keepdim=True)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Asymmetric per-row RTN
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _asymmetric_rtn_per_row(
+    tile: torch.Tensor, bits: int
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Per-row asymmetric RTN over the full row (no sub-grouping).
+
+    Args:
+        tile: [R, C] fp32.
+        bits: Integer width in [1, 8].
+
+    Returns:
+        q     [R, C] int32 in [0, 2^bits - 1]
+        scale [R, 1] fp32
+        zp    [R, 1] fp32  (= row minimum)
+    """
+    qmax = (1 << bits) - 1
+    lo = tile.amin(dim=1, keepdim=True)
+    hi = tile.amax(dim=1, keepdim=True)
+    scale = ((hi - lo) / qmax).clamp_min(1e-10)
+    zp = lo
+    q = torch.clamp(torch.round((tile - zp) / scale), 0, qmax).to(torch.int32)
+    return q, scale, zp
+
+
+def _weighted_affine_refit(
+    tile: torch.Tensor,
+    q: torch.Tensor,
+    other_scale: torch.Tensor,
+    scale: torch.Tensor,
+    zp: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Refit fixed integer codes for original-space squared error."""
+    weights = other_scale.float().square().unsqueeze(-2)
+    q_float = q.float()
+    weight_sum = weights.sum(dim=-1, keepdim=True).clamp_min(1e-20)
+    q_mean = (weights * q_float).sum(dim=-1, keepdim=True) / weight_sum
+    tile_mean = (weights * tile).sum(dim=-1, keepdim=True) / weight_sum
+    q_centered = q_float - q_mean
+    denominator = (weights * q_centered.square()).sum(dim=-1, keepdim=True)
+    numerator = (weights * q_centered * (tile - tile_mean)).sum(dim=-1, keepdim=True)
+    fitted_scale = (numerator / denominator.clamp_min(1e-20)).clamp_min(1e-10)
+    fitted_zp = tile_mean - fitted_scale * q_mean
+    usable = denominator > 1e-20
+    return (
+        torch.where(usable, fitted_scale, scale),
+        torch.where(usable, fitted_zp, zp),
+    )
+
+
+def _quantize_rows(
+    tile: torch.Tensor,
+    bits: int,
+    other_scale: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    qmax = (1 << bits) - 1
+    lo, hi = _rtn_range(tile, dim=-1)
+    scale = ((hi - lo) / qmax).clamp_min(1e-10)
+    zp = lo
+    q = torch.clamp(torch.round((tile - zp) / scale), 0, qmax).to(torch.int32)
+    default_refit = "1" if bits == 5 else "0"
+    if os.environ.get("KVARN_AFFINE_REFIT", default_refit) == "1":
+        scale, zp = _weighted_affine_refit(tile, q, other_scale, scale, zp)
+    return q, scale, zp
+
+
+def _pack_4bit(q: torch.Tensor) -> torch.Tensor:
+    """Pack 4-bit ints (last dim even) into uint8 pairs, two-per-byte.
+
+    Layout: low nibble = even-indexed, high nibble = odd-indexed.
+    """
+    assert q.shape[-1] % 2 == 0, "last dim must be even for 4-bit pairing"
+    q = q.to(torch.uint8) & 0xF
+    lo = q[..., 0::2]
+    hi = q[..., 1::2]
+    return (lo | (hi << 4)).to(torch.uint8)
+
+
+def _pack_2bit(q: torch.Tensor) -> torch.Tensor:
+    """Pack four 2-bit integers per byte in little-endian order."""
+    assert q.shape[-1] % 4 == 0, "last dim must be divisible by four"
+    values = (q.to(torch.uint8) & 0x3).view(*q.shape[:-1], -1, 4)
+    return (
+        values[..., 0]
+        | (values[..., 1] << 2)
+        | (values[..., 2] << 4)
+        | (values[..., 3] << 6)
+    )
+
+
+def _pack_lowbit(q: torch.Tensor, bits: int) -> torch.Tensor:
+    """Pack integer codes into a dense little-endian bit stream.
+
+    The code at index ``i`` begins at bit ``i * bits``. This is the BeeLlama
+    KVarN layout and supports widths that do not divide a byte, notably K5/V5.
+    """
+    if not 1 <= bits <= 8:
+        raise ValueError(f"bits must be in [1, 8], got {bits}")
+    q = q.to(torch.uint8) & ((1 << bits) - 1)
+    last_dim = q.shape[-1]
+    packed_bytes = (last_dim * bits + 7) // 8
+    if bits == 2 and last_dim % 4 == 0:
+        return _pack_2bit(q)
+    if bits == 4 and last_dim % 2 == 0:
+        return _pack_4bit(q)
+    bit_positions = torch.arange(packed_bytes * 8, dtype=torch.int64, device=q.device)
+    source_indices = torch.div(bit_positions, bits, rounding_mode="floor")
+    valid = source_indices < last_dim
+    source_indices = source_indices.clamp_max(max(last_dim - 1, 0))
+    source_bits = bit_positions.remainder(bits)
+    source = q[..., source_indices]
+    bit_values = ((source >> source_bits) & 1) * valid
+    bit_values = bit_values.reshape(*q.shape[:-1], packed_bytes, 8)
+    byte_weights = 1 << torch.arange(8, dtype=torch.uint8, device=q.device)
+    return (bit_values * byte_weights).sum(dim=-1).to(torch.uint8)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# K tile store: per-channel RTN, [D, group] orientation
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def kvarn_store_tile_k(
+    k_tile_rotated: torch.Tensor,
+    bits: int,
+    sinkhorn_iters: int = 16,
+) -> dict[str, torch.Tensor]:
+    """Quantize one rotated K tile.
+
+    Args:
+        k_tile_rotated: ``[D, group]`` fp32 / fp16 — channels × tokens, *after*
+            Hadamard rotation along head_dim. Caller is responsible for the
+            external ``(K @ H).T`` GEMM.
+        bits: key bit-width (typically 4).
+        sinkhorn_iters: log-domain iterations.
+
+    Returns dict with packed cache record:
+        q_packed_uint8 : ``[D, group/2]`` uint8 — 4-bit pairs (low=even, high=odd)
+        s_col_K        : ``[D]``        fp16   — absorbed per-channel scale
+        zp_K           : ``[D]``        fp16   — absorbed per-channel zero
+        s_row_K        : ``[group]``    fp16   — per-token-in-tile sinkhorn scale
+    """
+    if not 1 <= bits <= 8:
+        raise ValueError(f"bits must be in [1, 8], got {bits}")
+    tile = k_tile_rotated.float()
+    D, G = tile.shape
+
+    balanced, s_col_sinkhorn, s_row_sinkhorn = variance_normalize(
+        tile, iterations=sinkhorn_iters
+    )
+    # In [D, group] orientation:
+    #   s_col_sinkhorn is [1, G] = per-token-in-tile
+    #   s_row_sinkhorn is [D, 1] = per-channel
+    s_chan = s_row_sinkhorn  # [D, 1]
+    s_tok = s_col_sinkhorn  # [1, G]
+
+    q, rtn_scale, rtn_zp = _quantize_rows(balanced, bits, s_tok.squeeze(0))
+    s_col_K = (s_chan * rtn_scale).squeeze(-1)
+    zp_K = (s_chan * rtn_zp).squeeze(-1)
+    s_row_K = s_tok.squeeze(0)
+
+    q_packed = _pack_lowbit(q, bits)
+
+    return {
+        "q_packed_uint8": q_packed,
+        "s_col_K": s_col_K.to(torch.float16),
+        "zp_K": zp_K.to(torch.float16),
+        "s_row_K": s_row_K.to(torch.float16),
+    }
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# V tile store: per-token RTN, [group, D] orientation
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def kvarn_store_tile_k_batch_from_sinkhorn(
+    balanced: torch.Tensor,
+    s_col: torch.Tensor,
+    s_row: torch.Tensor,
+    bits: int,
+) -> dict[str, torch.Tensor]:
+    """Batched K-path RTN + scale absorption + 4-bit packing.
+
+    Assumes the sinkhorn step already ran (e.g. via the Triton kernel).
+
+    Args:
+        balanced : ``[N, D, group]`` fp32 — sinkhorn-balanced K tiles.
+        s_col    : ``[N, group]`` fp32 — per-token sinkhorn scale (axis-1).
+        s_row    : ``[N, D]``     fp32 — per-channel sinkhorn scale (axis-0).
+        bits     : key bit-width (4).
+
+    Returns dict of per-tile (N-batched) tensors:
+        q_packed_uint8 : ``[N, D, group/2]`` uint8
+        s_col_K        : ``[N, D]``         fp16 — absorbed per-channel scale
+        zp_K           : ``[N, D]``         fp16 — absorbed per-channel zero
+        s_row_K        : ``[N, group]``     fp16 — per-token sinkhorn scale
+    """
+    q, scale, zp = _quantize_rows(balanced, bits, s_col)
+    s_col_K = s_row * scale.squeeze(-1)
+    zp_K = s_row * zp.squeeze(-1)
+    s_row_K = s_col
+    s_col_K = s_col_K.to(torch.float16)
+    zp_K = zp_K.to(torch.float16)
+    s_row_K = s_row_K.to(torch.float16)
+    q_packed = _pack_lowbit(q, bits)
+    return {
+        "q_packed_uint8": q_packed,
+        "s_col_K": s_col_K,
+        "zp_K": zp_K,
+        "s_row_K": s_row_K,
+    }
+
+
+def kvarn_store_tile_v_batch_from_sinkhorn(
+    balanced: torch.Tensor,
+    s_col: torch.Tensor,
+    s_row: torch.Tensor,
+    bits: int,
+) -> dict[str, torch.Tensor]:
+    """Batched V-path RTN + scale absorption + 4-bit packing.
+
+    Args:
+        balanced : ``[N, group, D]`` fp32 — sinkhorn-balanced V tiles.
+        s_col    : ``[N, D]``     fp32 — per-channel sinkhorn scale (axis-1).
+        s_row    : ``[N, group]`` fp32 — per-token-in-tile sinkhorn scale (axis-0).
+        bits     : value bit-width (4).
+
+    Returns dict of per-tile (N-batched) tensors mirroring `kvarn_store_tile_v`.
+    """
+    q, scale, zp = _quantize_rows(balanced, bits, s_col)
+    s_row_V = s_row * scale.squeeze(-1)
+    zp_V = s_row * zp.squeeze(-1)
+    s_col_V = s_col
+    s_row_V = s_row_V.to(torch.float16)
+    zp_V = zp_V.to(torch.float16)
+    s_col_V = s_col_V.to(torch.float16)
+    q_packed = _pack_lowbit(q, bits)
+    return {
+        "q_packed_uint8": q_packed,
+        "s_col_V": s_col_V,
+        "s_row_V": s_row_V,
+        "zp_V": zp_V,
+    }
+
+
+def kvarn_store_tile_v(
+    v_tile_rotated: torch.Tensor,
+    bits: int,
+    sinkhorn_iters: int = 16,
+) -> dict[str, torch.Tensor]:
+    """Quantize one rotated V tile.
+
+    Args:
+        v_tile_rotated: ``[group, D]`` fp32 / fp16 — tokens × channels, *after*
+            Hadamard rotation along head_dim. Caller is responsible for the
+            external ``V @ H`` GEMM.
+        bits: value bit-width (typically 4).
+        sinkhorn_iters: log-domain iterations.
+
+    Returns dict with packed cache record:
+        q_packed_uint8 : ``[group, D/2]`` uint8 — 4-bit pairs
+        s_col_V        : ``[D]``          fp16   — per-channel scale (untouched)
+        s_row_V        : ``[group]``      fp16   — absorbed per-token-in-tile scale
+        zp_V           : ``[group]``      fp16   — absorbed per-token-in-tile zero
+    """
+    if not 1 <= bits <= 8:
+        raise ValueError(f"bits must be in [1, 8], got {bits}")
+    tile = v_tile_rotated.float()
+    G, D = tile.shape
+
+    balanced, s_col_sinkhorn, s_row_sinkhorn = variance_normalize(
+        tile, iterations=sinkhorn_iters
+    )
+    # In [group, D] orientation:
+    #   s_col_sinkhorn is [1, D] = per-channel
+    #   s_row_sinkhorn is [G, 1] = per-token-in-tile
+    s_chan = s_col_sinkhorn  # [1, D]
+    s_tok = s_row_sinkhorn  # [G, 1]
+
+    q, rtn_scale, rtn_zp = _quantize_rows(balanced, bits, s_chan.squeeze(0))
+    s_row_V = (s_tok * rtn_scale).squeeze(-1)
+    zp_V = (s_tok * rtn_zp).squeeze(-1)
+    s_col_V = s_chan.squeeze(0)
+
+    q_packed = _pack_lowbit(q, bits)
+
+    return {
+        "q_packed_uint8": q_packed,
+        "s_col_V": s_col_V.to(torch.float16),
+        "s_row_V": s_row_V.to(torch.float16),
+        "zp_V": zp_V.to(torch.float16),
+    }

--- a/vllm/v1/attention/ops/triton_kvarn_decode.py
+++ b/vllm/v1/attention/ops/triton_kvarn_decode.py
@@ -1,0 +1,1602 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""KVarN decode and speculative-verify Triton kernels.
+
+Filled KV tiles are stored as dense K5/V5 records. Decode and verify attend
+directly over packed history plus the bounded precision-tail pool without
+materializing the full context. Metadata is built once per scheduler step and
+reused by every attention layer.
+"""
+
+from __future__ import annotations
+
+import os
+
+import torch
+
+from vllm.triton_utils import tl, triton
+from vllm.v1.attention.ops.kvarn_decode import kvarn_hadamard
+
+# Number of KV-sequence splits for the split-K flash-decoding kernel. More
+# splits = better load-balancing of ragged burst seqlens across SMs, at the cost
+# of a larger fp32 partial-output scratch + more stage-2 combine work.
+KVARN_NUM_KV_SPLITS = int(os.environ.get("KVARN_NUM_KV_SPLITS", "16"))
+KVARN_MAX_KV_SPLITS = 64
+KVARN_K5V5_MAX_KV_SPLITS = 128
+_DECODE_AUTOTUNE_CONFIGS = [
+    triton.Config({"BLOCK_N": 32}, num_warps=2, num_stages=1),
+    triton.Config({"BLOCK_N": 32}, num_warps=2, num_stages=2),
+    triton.Config({"BLOCK_N": 32}, num_warps=4, num_stages=1),
+    triton.Config({"BLOCK_N": 32}, num_warps=4, num_stages=2),
+    triton.Config({"BLOCK_N": 64}, num_warps=4, num_stages=1),
+    triton.Config({"BLOCK_N": 64}, num_warps=4, num_stages=2),
+]
+
+
+def adaptive_num_kv_splits(max_blocks_per_req: int, cfg=None) -> int:
+    """Choose a deployment-constant split count for packed decode.
+
+    Thirty-two splits avoid under-occupancy through 256 blocks. Longer K5/V5
+    G64 contexts use 128 splits; paired Qwen3-4B measurements improved 16K and
+    32K decode versus both 32 and 64 splits. Other formats retain the 64-split
+    cap. ``KVARN_NUM_KV_SPLITS`` overrides the schedule.
+    """
+    env = os.environ.get("KVARN_NUM_KV_SPLITS")
+    if env is not None:
+        return int(env)
+    if max_blocks_per_req <= 256:
+        return 32
+    if (
+        cfg is not None
+        and cfg.key_bits == 5
+        and cfg.value_bits == 5
+        and cfg.group == 64
+    ):
+        return KVARN_K5V5_MAX_KV_SPLITS
+    return KVARN_MAX_KV_SPLITS
+
+
+@triton.jit
+def _unpack_dense_bits(payload_ptr, value_indices, bits: tl.constexpr):
+    """Load dense little-endian bit-stream codes at arbitrary indices."""
+    bit_offsets = value_indices * bits
+    byte_offsets = bit_offsets // 8
+    shifts = bit_offsets % 8
+    lo = tl.load(payload_ptr + byte_offsets).to(tl.uint32)
+    hi = tl.load(
+        payload_ptr + byte_offsets + 1,
+        mask=shifts + bits > 8,
+        other=0,
+    ).to(tl.uint32)
+    return ((lo | (hi << 8)) >> shifts) & ((1 << bits) - 1)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Stage α-2 scatter store: writes (already-rotated) k, v into the tail pool at
+# positions derived from slot_mapping. Replaces the Python for-loop in
+# do_kv_cache_update so the whole store path is capturable.
+#
+# Pool layout: [POOL_SIZE, group, Hk, D] in the configured tail dtype.
+# The sparse block-to-slot lookup uses -1 for blocks in the packed cache.
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+@triton.jit
+def _kvarn_scatter_store_kernel(
+    K_in_ptr,  # [N, Hk, D]                    fp16 (already rotated)
+    V_in_ptr,  # [N, Hk, D]                    fp16
+    Slot_mapping_ptr,  # [N]                           int32   (slot < 0 ⇒ pad)
+    Block_to_slot_ptr,  # [num_blocks_lookup]           int32   (-1 = no slot)
+    Pool_K_ptr,  # [POOL_SIZE, group, Hk, D]     fp16
+    Pool_V_ptr,  # [POOL_SIZE, group, Hk, D]     fp16
+    Pool_K_scale_ptr,  # [POOL_SIZE, group, Hk] fp16
+    Pool_V_scale_ptr,  # [POOL_SIZE, group, Hk] fp16
+    # strides
+    stride_in_n,
+    stride_in_h,
+    stride_pool_b,
+    stride_pool_t,
+    stride_pool_h,
+    stride_scale_b,
+    stride_scale_t,
+    stride_scale_h,
+    # constexprs
+    GROUP: tl.constexpr,
+    D: tl.constexpr,
+    NUM_BLOCKS_LOOKUP: tl.constexpr,
+    TAIL_SCALED: tl.constexpr,
+):
+    """Scatter one (token, kv_head) row from k, v into pool[slot, pos, hk, :].
+    slot = Block_to_slot_ptr[slot_mapping[i] // GROUP],
+    pos  = slot_mapping[i] % GROUP.
+    Skips i where slot_mapping < 0 (padding) or block_to_slot < 0 (no slot
+    yet — shouldn't happen if the metadata builder pre-allocated correctly).
+    Grid: (N, Hk).
+    """
+    i = tl.program_id(0)
+    hk = tl.program_id(1)
+
+    sm = tl.load(Slot_mapping_ptr + i)
+    if sm < 0:
+        return
+
+    block_id = sm // GROUP
+    pos = (sm % GROUP).to(tl.int64)
+    in_range = (block_id >= 0) & (block_id < NUM_BLOCKS_LOOKUP)
+    if not in_range:
+        return
+    pool_slot = tl.load(Block_to_slot_ptr + block_id)
+    if pool_slot < 0:
+        return
+
+    d = tl.arange(0, D)
+    src_offs = i * stride_in_n + hk * stride_in_h + d
+    k_row = tl.load(K_in_ptr + src_offs)
+    v_row = tl.load(V_in_ptr + src_offs)
+
+    dst_offs = (
+        pool_slot.to(tl.int64) * stride_pool_b
+        + pos * stride_pool_t
+        + hk * stride_pool_h
+        + d
+    )
+    if TAIL_SCALED:
+        k_amax = tl.max(tl.abs(k_row.to(tl.float32)), axis=0)
+        v_amax = tl.max(tl.abs(v_row.to(tl.float32)), axis=0)
+        k_scale = tl.maximum(k_amax / 448.0, 1.0e-6)
+        v_scale = tl.maximum(v_amax / 448.0, 1.0e-6)
+        scale_off = (
+            pool_slot.to(tl.int64) * stride_scale_b
+            + pos * stride_scale_t
+            + hk * stride_scale_h
+        )
+        tl.store(Pool_K_scale_ptr + scale_off, k_scale)
+        tl.store(Pool_V_scale_ptr + scale_off, v_scale)
+        tl.store(Pool_K_ptr + dst_offs, k_row / k_scale)
+        tl.store(Pool_V_ptr + dst_offs, v_row / v_scale)
+    else:
+        tl.store(Pool_K_ptr + dst_offs, k_row)
+        tl.store(Pool_V_ptr + dst_offs, v_row)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Stage α-2 capture-correct: ONE block_table-driven build-packed-KV kernel.
+# Reads persistent block tables and sequence lengths, materializing model-dtype
+# K/V only for the explicit FlashAttention fallback. Tail blocks are copied
+# from the side pool; packed blocks are dequantized in place.
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+@triton.jit
+def _kvarn_build_packed_kv_kernel(
+    Block_table_ptr,  # [B, max_blocks]                          int32
+    Seq_lens_ptr,  # [B]                                      int32
+    Cu_seqlens_ptr,  # [B+1] int32 (prefix sum of seq_lens)
+    Block_to_slot_ptr,  # [num_blocks_lookup] int32 (-1 = packed cache)
+    KV_cache_ptr,  # [num_blocks, num_kv_heads, TILE_BYTES]   uint8
+    Tail_K_pool_ptr,  # [POOL_SIZE, group, Hk, D]                fp16 (rotated)
+    Tail_V_pool_ptr,  # [POOL_SIZE, group, Hk, D]                fp16
+    Tail_K_scale_ptr,  # [POOL_SIZE, group, Hk] fp16
+    Tail_V_scale_ptr,  # [POOL_SIZE, group, Hk] fp16
+    K_out_ptr,  # [max_total_tokens, Hk, D]                fp16 (packed, rotated)
+    V_out_ptr,  # [max_total_tokens, Hk, D]                fp16
+    # strides
+    stride_bt_b,
+    stride_kv_b,
+    stride_kv_h,
+    stride_pool_b,
+    stride_pool_t,
+    stride_pool_h,
+    stride_scale_b,
+    stride_scale_t,
+    stride_scale_h,
+    stride_out_t,
+    stride_out_h,
+    # constexprs
+    MAX_BLOCKS_PER_REQ: tl.constexpr,
+    D: tl.constexpr,
+    GROUP: tl.constexpr,
+    TILES_PER_PAGE: tl.constexpr,
+    K_BITS: tl.constexpr,
+    V_BITS: tl.constexpr,
+    NUM_BLOCKS_LOOKUP: tl.constexpr,
+    K_PACKED_OFFSET: tl.constexpr,
+    K_S_COL_OFFSET: tl.constexpr,
+    K_ZP_OFFSET: tl.constexpr,
+    K_S_ROW_OFFSET: tl.constexpr,
+    V_PACKED_OFFSET: tl.constexpr,
+    V_S_COL_OFFSET: tl.constexpr,
+    V_S_ROW_OFFSET: tl.constexpr,
+    V_ZP_OFFSET: tl.constexpr,
+    TAIL_SCALED: tl.constexpr,
+):
+    """Grid: (B * MAX_BLOCKS_PER_REQ, Hk). One (request-block, head) per program.
+    b is always < B by construction (grid dim 0 == B*MAX_BLOCKS_PER_REQ), so no
+    runtime-B guard is needed — avoiding it keeps the kernel free of a
+    non-constexpr early-return that Triton's type inference mishandles."""
+    bk = tl.program_id(0)
+    hk = tl.program_id(1)
+    b = bk // MAX_BLOCKS_PER_REQ
+    k = bk % MAX_BLOCKS_PER_REQ
+
+    seq_len = tl.load(Seq_lens_ptr + b)
+    # tokens this block contributes = clamp(seq_len - k*GROUP, 0, GROUP).
+    # n_tok <= 0 ⇒ padding program (block beyond this request's length).
+    rem = seq_len - k * GROUP
+    n_tok = tl.minimum(tl.maximum(rem, 0), GROUP)
+    if n_tok <= 0:
+        return
+
+    block_id = tl.load(Block_table_ptr + b * stride_bt_b + k)
+    dst_base = tl.load(Cu_seqlens_ptr + b).to(tl.int64) + k.to(tl.int64) * GROUP
+
+    d_offs = tl.arange(0, D)
+    g_offs = tl.arange(0, GROUP)
+    g_mask = g_offs < n_tok
+
+    # Always-tensor slot lookup (masked load → -1 when block_id out of range).
+    # Avoids mixing a Python int with a tensor across the branch below, which
+    # Triton's type inference rejects in the general-batch compilation.
+    in_range = (block_id >= 0) & (block_id < NUM_BLOCKS_LOOKUP)
+    safe_bid = tl.where(in_range, block_id, 0)
+    pool_slot = tl.load(Block_to_slot_ptr + safe_bid, mask=in_range, other=-1)
+
+    out_addrs = (
+        (dst_base + g_offs)[:, None] * stride_out_t
+        + hk * stride_out_h
+        + d_offs[None, :]
+    )
+
+    if pool_slot >= 0:
+        # Rotated tokens in the sink / in-progress precision-tail pool.
+        pool_base = pool_slot.to(tl.int64) * stride_pool_b + hk * stride_pool_h
+        src_addrs = pool_base + g_offs[:, None] * stride_pool_t + d_offs[None, :]
+        K_chunk = tl.load(
+            Tail_K_pool_ptr + src_addrs, mask=g_mask[:, None], other=0.0
+        ).to(tl.float32)
+        V_chunk = tl.load(
+            Tail_V_pool_ptr + src_addrs, mask=g_mask[:, None], other=0.0
+        ).to(tl.float32)
+        if TAIL_SCALED:
+            scale_addrs = (
+                pool_slot.to(tl.int64) * stride_scale_b
+                + g_offs * stride_scale_t
+                + hk * stride_scale_h
+            )
+            K_chunk *= tl.load(Tail_K_scale_ptr + scale_addrs, mask=g_mask, other=1.0)[
+                :, None
+            ]
+            V_chunk *= tl.load(Tail_V_scale_ptr + scale_addrs, mask=g_mask, other=1.0)[
+                :, None
+            ]
+        tl.store(K_out_ptr + out_addrs, K_chunk, mask=g_mask[:, None])
+        tl.store(V_out_ptr + out_addrs, V_chunk, mask=g_mask[:, None])
+    else:
+        # Quantized block: dequantize the dense bit stream in-place. K5/V5
+        # codes may cross byte boundaries, unlike the older 2/4-bit presets.
+        tile_base = block_id.to(tl.int64) * stride_kv_b + hk * stride_kv_h
+
+        sk_lo = tl.load(KV_cache_ptr + tile_base + K_S_COL_OFFSET + d_offs * 2).to(
+            tl.uint16
+        )
+        sk_hi = tl.load(KV_cache_ptr + tile_base + K_S_COL_OFFSET + d_offs * 2 + 1).to(
+            tl.uint16
+        )
+        s_col_K = ((sk_lo | (sk_hi << 8)).to(tl.float16, bitcast=True)).to(tl.float32)
+        zk_lo = tl.load(KV_cache_ptr + tile_base + K_ZP_OFFSET + d_offs * 2).to(
+            tl.uint16
+        )
+        zk_hi = tl.load(KV_cache_ptr + tile_base + K_ZP_OFFSET + d_offs * 2 + 1).to(
+            tl.uint16
+        )
+        zp_K = ((zk_lo | (zk_hi << 8)).to(tl.float16, bitcast=True)).to(tl.float32)
+        srk_lo = tl.load(KV_cache_ptr + tile_base + K_S_ROW_OFFSET + g_offs * 2).to(
+            tl.uint16
+        )
+        srk_hi = tl.load(KV_cache_ptr + tile_base + K_S_ROW_OFFSET + g_offs * 2 + 1).to(
+            tl.uint16
+        )
+        s_row_K = ((srk_lo | (srk_hi << 8)).to(tl.float16, bitcast=True)).to(tl.float32)
+
+        k_indices = d_offs[:, None] * GROUP + g_offs[None, :]
+        q_K = _unpack_dense_bits(
+            KV_cache_ptr + tile_base + K_PACKED_OFFSET,
+            k_indices,
+            K_BITS,
+        ).to(tl.float32)
+        K_rot = (q_K * s_col_K[:, None] + zp_K[:, None]) * s_row_K[
+            None, :
+        ]  # [D, GROUP]
+        K_rot_out = tl.trans(K_rot)  # [GROUP, D]
+
+        scv_lo = tl.load(KV_cache_ptr + tile_base + V_S_COL_OFFSET + d_offs * 2).to(
+            tl.uint16
+        )
+        scv_hi = tl.load(KV_cache_ptr + tile_base + V_S_COL_OFFSET + d_offs * 2 + 1).to(
+            tl.uint16
+        )
+        s_col_V = ((scv_lo | (scv_hi << 8)).to(tl.float16, bitcast=True)).to(tl.float32)
+        srv_lo = tl.load(KV_cache_ptr + tile_base + V_S_ROW_OFFSET + g_offs * 2).to(
+            tl.uint16
+        )
+        srv_hi = tl.load(KV_cache_ptr + tile_base + V_S_ROW_OFFSET + g_offs * 2 + 1).to(
+            tl.uint16
+        )
+        s_row_V = ((srv_lo | (srv_hi << 8)).to(tl.float16, bitcast=True)).to(tl.float32)
+        zpv_lo = tl.load(KV_cache_ptr + tile_base + V_ZP_OFFSET + g_offs * 2).to(
+            tl.uint16
+        )
+        zpv_hi = tl.load(KV_cache_ptr + tile_base + V_ZP_OFFSET + g_offs * 2 + 1).to(
+            tl.uint16
+        )
+        zp_V = ((zpv_lo | (zpv_hi << 8)).to(tl.float16, bitcast=True)).to(tl.float32)
+
+        v_indices = g_offs[:, None] * D + d_offs[None, :]
+        q_V = _unpack_dense_bits(
+            KV_cache_ptr + tile_base + V_PACKED_OFFSET,
+            v_indices,
+            V_BITS,
+        ).to(tl.float32)
+        V_rot = (q_V * s_row_V[:, None] + zp_V[:, None]) * s_col_V[
+            None, :
+        ]  # [GROUP, D]
+
+        tl.store(K_out_ptr + out_addrs, K_rot_out.to(tl.float16), mask=g_mask[:, None])
+        tl.store(V_out_ptr + out_addrs, V_rot.to(tl.float16), mask=g_mask[:, None])
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# FUSED decode: dequantize K5/V5 in registers with online softmax.
+# Reads packed history and the precision-tail pool directly, never
+# materializing full model-dtype K/V buffers to HBM.
+#
+# One-stage flash-decode (correctness-first): grid (B, Hq). Each program handles
+# one (request, query-head), loops that request's KV blocks with online softmax.
+# Split-K parallelism over KV is a later optimization for long context.
+#
+# AUTO-TUNED across BLOCK_N ∈ {16, 32, 64}. The autotune key (D, GROUP, Q_PER_KV,
+# K_BITS, V_BITS) makes Triton re-tune per model architecture × quant config:
+# - Q_PER_KV=2 (Qwen3-0.6B) / =4 (Qwen3-4B) / =8 (Qwen3-30B-A3B, 32B) typically
+#   favour different BLOCK_N; the autotuner picks once on first call and caches.
+# - num_warps=8 was empirically slower at Q_PER_KV=8 (tl.dot with small M
+#   under-utilises threads), so we only include 4 warps; if that turns out wrong
+#   for some model, extending the config list is cheap.
+# - num_stages=3 vs 2 showed no difference in the micro-bench; we keep =2.
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+@triton.autotune(
+    configs=_DECODE_AUTOTUNE_CONFIGS,
+    key=["D", "GROUP", "Q_PER_KV", "K_BITS", "V_BITS"],
+)
+@triton.jit
+def _kvarn_fused_decode_kernel(
+    Q_ptr,  # [B, Hq, D]                               fp16 (rotated)
+    Req_row_ptr,  # [B] int32 — block-table row per program row (VQ_INDIRECT)
+    Block_table_ptr,  # [B, max_blocks]                          int32
+    Seq_lens_ptr,  # [B]                                      int32
+    Block_to_slot_ptr,  # [num_blocks_lookup] int32 (-1 = packed cache)
+    KV_cache_ptr,  # [num_blocks, num_kv_heads, TILE_BYTES]   uint8
+    Tail_K_pool_ptr,  # [POOL_SIZE, group, Hk, D]                fp16 (rotated)
+    Tail_V_pool_ptr,  # [POOL_SIZE, group, Hk, D]                fp16
+    Tail_K_scale_ptr,  # [POOL_SIZE, group, Hk] fp16
+    Tail_V_scale_ptr,  # [POOL_SIZE, group, Hk] fp16
+    Out_ptr,  # [B, Hq, D]                               fp16 (rotated out)
+    scale,
+    # strides
+    stride_q_b,
+    stride_q_h,
+    stride_bt_b,
+    stride_kv_b,
+    stride_kv_h,
+    stride_pool_b,
+    stride_pool_t,
+    stride_pool_h,
+    stride_scale_b,
+    stride_scale_t,
+    stride_scale_h,
+    stride_o_b,
+    stride_o_h,
+    # constexprs
+    MAX_BLOCKS_PER_REQ: tl.constexpr,
+    D: tl.constexpr,
+    GROUP: tl.constexpr,
+    TILES_PER_PAGE: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    Q_PER_KV: tl.constexpr,
+    Q_PER_KV_PAD: tl.constexpr,
+    SLIDING_WINDOW: tl.constexpr,
+    K_BITS: tl.constexpr,
+    V_BITS: tl.constexpr,
+    NUM_BLOCKS_LOOKUP: tl.constexpr,
+    K_PACKED_OFFSET: tl.constexpr,
+    K_S_COL_OFFSET: tl.constexpr,
+    K_ZP_OFFSET: tl.constexpr,
+    K_S_ROW_OFFSET: tl.constexpr,
+    V_PACKED_OFFSET: tl.constexpr,
+    V_S_COL_OFFSET: tl.constexpr,
+    V_S_ROW_OFFSET: tl.constexpr,
+    V_ZP_OFFSET: tl.constexpr,
+    VQ_INDIRECT: tl.constexpr,
+    TAIL_SCALED: tl.constexpr,
+):
+    # GQA head-grouping: ONE program per (request, KV head) serves all Q_PER_KV
+    # query heads sharing a KV head reuse each dequantized K5/V5 tile. This
+    # avoids Q_PER_KV redundant unpack operations.
+    # Q_PER_KV is padded to a power of 2 (Q_PER_KV_PAD) because tl.arange / tl.dot
+    # require pow2 dims; padded query heads are masked off (e.g. Qwen3.5 GQA 24/4
+    # = ratio 6 -> pad to 8).
+    #
+    # VQ_INDIRECT (multi-query verify): program row b is a QUERY TOKEN, not a
+    # request — Req_row_ptr[b] gives its block-table row and Seq_lens_ptr[b] its
+    # bottom-right causal length (cached_len + token_idx + 1). Q/Out stay
+    # token-major, so everything else is unchanged: the speculative-decode
+    # verify reads the same dual-source packed-cache plus precision-tail path
+    # instead of materializing the whole context.
+    b = tl.program_id(0)
+    hk = tl.program_id(1)
+    qh = tl.arange(0, Q_PER_KV_PAD)  # padded query-head lane
+    qmask = qh < Q_PER_KV  # real heads in this group
+    hq0 = hk * Q_PER_KV
+
+    bt_row = b
+    if VQ_INDIRECT:
+        bt_row = tl.load(Req_row_ptr + b)
+    seq_len = tl.load(Seq_lens_ptr + b)
+    # Padded rows (uniform-batch graph capture/replay pads the token count)
+    # carry seq_len <= 0: nothing to attend, the output row is never read.
+    if seq_len <= 0:
+        return
+
+    d_offs = tl.arange(0, D)
+
+    # q: [Q_PER_KV_PAD, D] — padded lanes masked to 0 (no OOB read past Hq).
+    q = tl.load(
+        Q_ptr + b * stride_q_b + (hq0 + qh)[:, None] * stride_q_h + d_offs[None, :],
+        mask=qmask[:, None],
+        other=0.0,
+    ).to(tl.float32)
+
+    m_i = tl.full([Q_PER_KV_PAD], -float("inf"), dtype=tl.float32)
+    l_i = tl.zeros([Q_PER_KV_PAD], dtype=tl.float32)
+    acc = tl.zeros([Q_PER_KV_PAD, D], dtype=tl.float32)
+
+    n_blocks = (seq_len + GROUP - 1) // GROUP
+    # Sliding-window: this query (last token) only attends to the last
+    # SLIDING_WINDOW keys, so start the block loop at the first block that
+    # overlaps the window (massive saving: ~window/GROUP blocks instead of all).
+    win_start = 0
+    blk_lo = 0
+    if SLIDING_WINDOW > 0:
+        win_start = tl.maximum(seq_len - SLIDING_WINDOW, 0)
+        blk_lo = win_start // GROUP
+    for k in range(blk_lo, n_blocks):
+        rem = seq_len - k * GROUP
+        n_tok = tl.minimum(tl.maximum(rem, 0), GROUP)
+
+        block_id = tl.load(Block_table_ptr + bt_row * stride_bt_b + k)
+        in_range = (block_id >= 0) & (block_id < NUM_BLOCKS_LOOKUP)
+        safe_bid = tl.where(in_range, block_id, 0)
+        pool_slot = tl.load(Block_to_slot_ptr + safe_bid, mask=in_range, other=-1)
+
+        tile_base = block_id.to(tl.int64) * stride_kv_b + hk * stride_kv_h
+        safe_slot = tl.where(pool_slot >= 0, pool_slot, 0)
+        pool_base = safe_slot.to(tl.int64) * stride_pool_b + hk * stride_pool_h
+
+        # Per-channel (per-d) K/V scales — constant across the 128 tokens; load
+        # once. fp16 fields live at even byte offsets in the uint8 tile, so load
+        # them as a single uint16 (half the L1 transactions of the lo/hi byte
+        # pair). (Garbage but unused for pool blocks.)
+        ku16 = (KV_cache_ptr + tile_base).to(tl.pointer_type(tl.uint16))
+        s_col_K = (
+            tl.load(ku16 + (K_S_COL_OFFSET // 2) + d_offs)
+            .to(tl.float16, bitcast=True)
+            .to(tl.float32)
+        )
+        zp_K = (
+            tl.load(ku16 + (K_ZP_OFFSET // 2) + d_offs)
+            .to(tl.float16, bitcast=True)
+            .to(tl.float32)
+        )
+        s_col_V = (
+            tl.load(ku16 + (V_S_COL_OFFSET // 2) + d_offs)
+            .to(tl.float16, bitcast=True)
+            .to(tl.float32)
+        )
+
+        for c0 in range(0, GROUP, BLOCK_N):
+            cols = c0 + tl.arange(0, BLOCK_N)  # [BN] token indices in tile
+            cmask = cols < n_tok
+            if SLIDING_WINDOW > 0:  # mask keys before the window boundary
+                cmask = cmask & ((k * GROUP + cols) >= win_start)
+
+            if pool_slot >= 0:
+                # Already-rotated tokens in the sink / precision-tail pool.
+                src = pool_base + cols[:, None] * stride_pool_t + d_offs[None, :]
+                Kc = tl.load(Tail_K_pool_ptr + src, mask=cmask[:, None], other=0.0).to(
+                    tl.float32
+                )
+                Vc = tl.load(Tail_V_pool_ptr + src, mask=cmask[:, None], other=0.0).to(
+                    tl.float32
+                )
+                if TAIL_SCALED:
+                    scale_src = (
+                        safe_slot.to(tl.int64) * stride_scale_b
+                        + cols * stride_scale_t
+                        + hk * stride_scale_h
+                    )
+                    Kc *= tl.load(Tail_K_scale_ptr + scale_src, mask=cmask, other=1.0)[
+                        :, None
+                    ]
+                    Vc *= tl.load(Tail_V_scale_ptr + scale_src, mask=cmask, other=1.0)[
+                        :, None
+                    ]
+                K_dg = tl.trans(Kc)  # [D, BN]
+            else:
+                s_row_K = (
+                    tl.load(ku16 + (K_S_ROW_OFFSET // 2) + cols)
+                    .to(tl.float16, bitcast=True)
+                    .to(tl.float32)
+                )
+                k_indices = d_offs[:, None] * GROUP + cols[None, :]
+                q_K = _unpack_dense_bits(
+                    KV_cache_ptr + tile_base + K_PACKED_OFFSET,
+                    k_indices,
+                    K_BITS,
+                ).to(tl.float32)
+                K_dg = (q_K * s_col_K[:, None] + zp_K[:, None]) * s_row_K[
+                    None, :
+                ]  # [D, BN]
+
+                s_row_V = (
+                    tl.load(ku16 + (V_S_ROW_OFFSET // 2) + cols)
+                    .to(tl.float16, bitcast=True)
+                    .to(tl.float32)
+                )  # [BN]
+                zp_V = (
+                    tl.load(ku16 + (V_ZP_OFFSET // 2) + cols)
+                    .to(tl.float16, bitcast=True)
+                    .to(tl.float32)
+                )  # [BN]
+                v_indices = cols[:, None] * D + d_offs[None, :]
+                q_V = _unpack_dense_bits(
+                    KV_cache_ptr + tile_base + V_PACKED_OFFSET,
+                    v_indices,
+                    V_BITS,
+                ).to(tl.float32)
+                Vc = (q_V * s_row_V[:, None] + zp_V[:, None]) * s_col_V[
+                    None, :
+                ]  # [BN, D]
+
+            scores = tl.dot(q, K_dg)
+            scores = tl.where(cmask[None, :], scores * scale, -float("inf"))
+            m_new = tl.maximum(m_i, tl.max(scores, axis=1))  # [Q_PER_KV]
+            p = tl.exp(scores - m_new[:, None])  # [Q_PER_KV, BN]
+            alpha = tl.exp(m_i - m_new)  # [Q_PER_KV]
+            l_i = l_i * alpha + tl.sum(p, axis=1)
+            acc = acc * alpha[:, None] + tl.dot(p, Vc)  # [Q_PER_KV, D]
+            m_i = m_new
+
+    out = (acc / l_i[:, None]).to(tl.float16)  # [Q_PER_KV_PAD, D]
+    tl.store(
+        Out_ptr + b * stride_o_b + (hq0 + qh)[:, None] * stride_o_h + d_offs[None, :],
+        out,
+        mask=qmask[:, None],
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# SPLIT-K (flash-decoding) variant: stage 1 computes partial attention over a
+# contiguous slice of each request's KV blocks; the extra grid dim parallelizes
+# the KV sequence so ragged burst seqlens are load-balanced across SMs. Stage 2
+# combines the per-split partials via the log-sum-exp trick. This is what makes
+# the decode kernel competitive with TurboQuant's _tq_decode_stage1 at burst.
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+# AUTO-TUNED across BLOCK_N x num_warps x num_stages (keyed per model arch ×
+# quant config, like the single-stage kernel). Stage1 was previously launched
+# with a hardcoded BLOCK_N=16 / num_warps=4; the microbench (Qwen3-4B) showed
+# BLOCK_N=32 / num_warps=2 is ~25-40% faster across 4.6K-32K ctx. Split-K is
+# LSE-combined so BLOCK_N never affects the output. Warmed in
+# _warm_decode_kernels (pre-CUDA-graph-capture), so autotune never triggers
+# mid-capture.
+@triton.autotune(
+    configs=_DECODE_AUTOTUNE_CONFIGS,
+    key=["D", "GROUP", "Q_PER_KV", "K_BITS", "V_BITS"],
+)
+@triton.jit
+def _kvarn_fused_decode_stage1(
+    Q_ptr,
+    Req_row_ptr,
+    Block_table_ptr,
+    Seq_lens_ptr,
+    Block_to_slot_ptr,
+    KV_cache_ptr,
+    Tail_K_pool_ptr,
+    Tail_V_pool_ptr,
+    Tail_K_scale_ptr,
+    Tail_V_scale_ptr,
+    MidO_ptr,  # [N, NUM_KV_SPLITS, D]            fp32 (O_s = acc/l per split)
+    MidLse_ptr,  # [N, NUM_KV_SPLITS]               fp32 (lse_s = m + log l)
+    scale,
+    stride_q_b,
+    stride_q_h,
+    stride_bt_b,
+    stride_kv_b,
+    stride_kv_h,
+    stride_pool_b,
+    stride_pool_t,
+    stride_pool_h,
+    stride_scale_b,
+    stride_scale_t,
+    stride_scale_h,
+    stride_mo_n,
+    stride_mo_s,  # MidO: row (N), split
+    stride_ml_n,  # MidLse: row (N)
+    MAX_BLOCKS_PER_REQ: tl.constexpr,
+    D: tl.constexpr,
+    GROUP: tl.constexpr,
+    TILES_PER_PAGE: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    Q_PER_KV: tl.constexpr,
+    NUM_KV_SPLITS: tl.constexpr,
+    HQ: tl.constexpr,
+    K_BITS: tl.constexpr,
+    V_BITS: tl.constexpr,
+    Q_PER_KV_PAD: tl.constexpr,
+    SLIDING_WINDOW: tl.constexpr,
+    NUM_BLOCKS_LOOKUP: tl.constexpr,
+    K_PACKED_OFFSET: tl.constexpr,
+    K_S_COL_OFFSET: tl.constexpr,
+    K_ZP_OFFSET: tl.constexpr,
+    K_S_ROW_OFFSET: tl.constexpr,
+    V_PACKED_OFFSET: tl.constexpr,
+    V_S_COL_OFFSET: tl.constexpr,
+    V_S_ROW_OFFSET: tl.constexpr,
+    V_ZP_OFFSET: tl.constexpr,
+    VQ_INDIRECT: tl.constexpr,
+    TAIL_SCALED: tl.constexpr,
+):
+    b = tl.program_id(0)
+    hk = tl.program_id(1)
+    split = tl.program_id(2)
+    qh = tl.arange(0, Q_PER_KV_PAD)  # padded to pow2; mask below
+    qmask = qh < Q_PER_KV
+    hq0 = hk * Q_PER_KV
+
+    # VQ_INDIRECT: row b is a query TOKEN (verify step); see the single-stage
+    # kernel's note. Block table via Req_row_ptr, causal length via Seq_lens.
+    bt_row = b
+    if VQ_INDIRECT:
+        bt_row = tl.load(Req_row_ptr + b)
+    seq_len = tl.load(Seq_lens_ptr + b)
+    n_blocks = (seq_len + GROUP - 1) // GROUP
+    blocks_per_split = (n_blocks + NUM_KV_SPLITS - 1) // NUM_KV_SPLITS
+    blk_lo = split * blocks_per_split
+    blk_hi = tl.minimum(blk_lo + blocks_per_split, n_blocks)
+
+    d_offs = tl.arange(0, D)
+    q = tl.load(
+        Q_ptr + b * stride_q_b + (hq0 + qh)[:, None] * stride_q_h + d_offs[None, :],
+        mask=qmask[:, None],
+        other=0.0,
+    ).to(tl.float32)
+
+    m_i = tl.full([Q_PER_KV_PAD], -float("inf"), dtype=tl.float32)
+    l_i = tl.zeros([Q_PER_KV_PAD], dtype=tl.float32)
+    acc = tl.zeros([Q_PER_KV_PAD, D], dtype=tl.float32)
+
+    for k in range(blk_lo, blk_hi):
+        rem = seq_len - k * GROUP
+        n_tok = tl.minimum(tl.maximum(rem, 0), GROUP)
+        block_id = tl.load(Block_table_ptr + bt_row * stride_bt_b + k)
+        in_range = (block_id >= 0) & (block_id < NUM_BLOCKS_LOOKUP)
+        safe_bid = tl.where(in_range, block_id, 0)
+        pool_slot = tl.load(Block_to_slot_ptr + safe_bid, mask=in_range, other=-1)
+        tile_base = block_id.to(tl.int64) * stride_kv_b + hk * stride_kv_h
+        safe_slot = tl.where(pool_slot >= 0, pool_slot, 0)
+        pool_base = safe_slot.to(tl.int64) * stride_pool_b + hk * stride_pool_h
+
+        # Single uint16 load per fp16 scale (half the L1 transactions of the
+        # lo/hi byte pair); fp16 fields are at even byte offsets in the tile.
+        ku16 = (KV_cache_ptr + tile_base).to(tl.pointer_type(tl.uint16))
+        s_col_K = (
+            tl.load(ku16 + (K_S_COL_OFFSET // 2) + d_offs)
+            .to(tl.float16, bitcast=True)
+            .to(tl.float32)
+        )
+        zp_K = (
+            tl.load(ku16 + (K_ZP_OFFSET // 2) + d_offs)
+            .to(tl.float16, bitcast=True)
+            .to(tl.float32)
+        )
+        s_col_V = (
+            tl.load(ku16 + (V_S_COL_OFFSET // 2) + d_offs)
+            .to(tl.float16, bitcast=True)
+            .to(tl.float32)
+        )
+
+        for c0 in range(0, GROUP, BLOCK_N):
+            cols = c0 + tl.arange(0, BLOCK_N)
+            cmask = cols < n_tok
+            if SLIDING_WINDOW > 0:
+                cmask = cmask & (
+                    (k * GROUP + cols) >= tl.maximum(seq_len - SLIDING_WINDOW, 0)
+                )
+            if pool_slot >= 0:
+                src = pool_base + cols[:, None] * stride_pool_t + d_offs[None, :]
+                Kc = tl.load(Tail_K_pool_ptr + src, mask=cmask[:, None], other=0.0).to(
+                    tl.float32
+                )
+                Vc = tl.load(Tail_V_pool_ptr + src, mask=cmask[:, None], other=0.0).to(
+                    tl.float32
+                )
+                if TAIL_SCALED:
+                    scale_src = (
+                        safe_slot.to(tl.int64) * stride_scale_b
+                        + cols * stride_scale_t
+                        + hk * stride_scale_h
+                    )
+                    Kc *= tl.load(Tail_K_scale_ptr + scale_src, mask=cmask, other=1.0)[
+                        :, None
+                    ]
+                    Vc *= tl.load(Tail_V_scale_ptr + scale_src, mask=cmask, other=1.0)[
+                        :, None
+                    ]
+                K_dg = tl.trans(Kc)
+            else:
+                s_row_K = (
+                    tl.load(ku16 + (K_S_ROW_OFFSET // 2) + cols)
+                    .to(tl.float16, bitcast=True)
+                    .to(tl.float32)
+                )
+                k_indices = d_offs[:, None] * GROUP + cols[None, :]
+                q_K = _unpack_dense_bits(
+                    KV_cache_ptr + tile_base + K_PACKED_OFFSET,
+                    k_indices,
+                    K_BITS,
+                ).to(tl.float32)
+                K_dg = (q_K * s_col_K[:, None] + zp_K[:, None]) * s_row_K[None, :]
+                s_row_V = (
+                    tl.load(ku16 + (V_S_ROW_OFFSET // 2) + cols)
+                    .to(tl.float16, bitcast=True)
+                    .to(tl.float32)
+                )
+                zp_V = (
+                    tl.load(ku16 + (V_ZP_OFFSET // 2) + cols)
+                    .to(tl.float16, bitcast=True)
+                    .to(tl.float32)
+                )
+                v_indices = cols[:, None] * D + d_offs[None, :]
+                q_V = _unpack_dense_bits(
+                    KV_cache_ptr + tile_base + V_PACKED_OFFSET,
+                    v_indices,
+                    V_BITS,
+                ).to(tl.float32)
+                Vc = (q_V * s_row_V[:, None] + zp_V[:, None]) * s_col_V[None, :]
+
+            scores = tl.dot(q, K_dg)
+            scores = tl.where(cmask[None, :], scores * scale, -float("inf"))
+            m_new = tl.maximum(m_i, tl.max(scores, axis=1))
+            p = tl.exp(scores - m_new[:, None])
+            alpha = tl.exp(m_i - m_new)
+            l_i = l_i * alpha + tl.sum(p, axis=1)
+            acc = acc * alpha[:, None] + tl.dot(p, Vc)
+            m_i = m_new
+
+    # Partial output O_s = acc / l_i and lse_s = m_i + log(l_i); empty split → 0 / -inf.
+    nonempty = l_i > 0
+    O_s = acc / tl.where(nonempty, l_i, 1.0)[:, None]  # [Q_PER_KV, D]
+    lse_s = tl.where(
+        nonempty, m_i + tl.log(tl.where(nonempty, l_i, 1.0)), -float("inf")
+    )
+    rows = b * HQ + hq0 + qh  # [Q_PER_KV_PAD] (= N rows)
+    tl.store(
+        MidO_ptr + rows[:, None] * stride_mo_n + split * stride_mo_s + d_offs[None, :],
+        O_s,
+        mask=qmask[:, None],
+    )
+    tl.store(MidLse_ptr + rows * stride_ml_n + split, lse_s, mask=qmask)
+
+
+@triton.jit
+def _kvarn_fused_decode_stage2(
+    MidO_ptr,  # [N, NUM_KV_SPLITS, D] fp32
+    MidLse_ptr,  # [N, NUM_KV_SPLITS]    fp32
+    Out_ptr,  # [N, D] fp16
+    stride_mo_n,
+    stride_mo_s,
+    stride_ml_n,
+    stride_o_n,
+    D: tl.constexpr,
+    NUM_KV_SPLITS: tl.constexpr,
+):
+    # One program per output row (= one (request, query-head)). Combine splits.
+    n = tl.program_id(0)
+    d_offs = tl.arange(0, D)
+    s_offs = tl.arange(0, NUM_KV_SPLITS)
+    lse = tl.load(MidLse_ptr + n * stride_ml_n + s_offs)  # [SPLITS]
+    g = tl.max(lse, axis=0)  # global max lse
+    w = tl.exp(lse - g)  # [SPLITS] weights
+    denom = tl.sum(w, axis=0)
+    # weighted sum of partial outputs
+    o_parts = tl.load(
+        MidO_ptr + n * stride_mo_n + s_offs[:, None] * stride_mo_s + d_offs[None, :]
+    )  # [SPLITS, D]
+    out = tl.sum(w[:, None] * o_parts, axis=0) / denom  # [D]
+    tl.store(Out_ptr + n * stride_o_n + d_offs, out.to(tl.float16))
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Python driver
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def kvarn_decode_attention(
+    query: torch.Tensor,  # [B, Hq, D]   fp16/bf16
+    kv_cache: torch.Tensor,  # [num_blocks, num_kv_heads, TILE_BYTES] uint8
+    hadamard: torch.Tensor,  # [D, D]       fp32
+    scale: float,
+    cfg,
+    impl,  # KVarNAttentionImpl (has pool + scratch buffers)
+    md,  # KVarNMetadata (carries the precomputed task plan)
+) -> torch.Tensor:
+    """Attend directly over packed history and the precision-tail pool.
+
+    The fused path rotates the query, unpacks K5/V5 in registers, performs
+    online softmax, and restores the output frame. The explicit fallback
+    materializes model-dtype K/V before calling FlashAttention.
+    """
+    from vllm.v1.attention.backends.fa_utils import flash_attn_varlen_func
+
+    B, Hq, D = query.shape
+    tiles_per_page = 1
+    Hk = kv_cache.shape[1]
+    device = query.device
+    out_dtype = query.dtype
+    group = cfg.group
+    N = B * Hq  # rows for the 2D Q rotation matmul
+
+    # 1. Q rotation into the persistent graph-safe buffer.
+    H16 = impl._H_fp16 if impl._H_fp16 is not None else hadamard.to(query.dtype)
+    q_rot_fp16 = kvarn_hadamard(
+        query.reshape(N, D),
+        H16,
+        out=impl._q_rot_fp16_buf[:N],
+    )
+
+    # 2+3. Attention. Two paths (KVARN_FUSED_DECODE, default fused):
+    #   FUSED      — read packed history and the tail directly, unpacking in
+    #                registers without a model-dtype K/V round trip.
+    #   MATERIALIZE — build packed fp16 K/V then stock FlashAttention (≥2.25x
+    #                FP16 KV traffic; kept for A/B and as a fallback).
+    max_blocks_per_req = md.fa_max_blocks_per_req
+    use_fused = os.environ.get("KVARN_FUSED_DECODE", "1") == "1"
+    # Both the single-stage kernel and stage1 are @triton.autotune'd over
+    # BLOCK_N/num_warps (keyed on D/GROUP/Q_PER_KV/K_BITS/V_BITS) — no
+    # BLOCK_N/num_warps/num_stages passed at the launch sites.
+    _qpk = Hq // Hk
+    # Pad Q_PER_KV to a power of 2 for tl.arange / tl.dot (e.g. Qwen3.5 GQA
+    # 24q/4kv = ratio 6 -> 8); padded query heads are masked off in-kernel.
+    _qpk_pad = 1 << (_qpk - 1).bit_length() if _qpk > 1 else 1
+    common = dict(
+        MAX_BLOCKS_PER_REQ=max_blocks_per_req,
+        D=D,
+        GROUP=group,
+        TILES_PER_PAGE=tiles_per_page,
+        Q_PER_KV=_qpk,
+        Q_PER_KV_PAD=_qpk_pad,
+        SLIDING_WINDOW=int(getattr(impl, "sliding_window", 0) or 0),
+        K_BITS=cfg.key_bits,
+        V_BITS=cfg.value_bits,
+        NUM_BLOCKS_LOOKUP=impl._block_lookup_size,
+        K_PACKED_OFFSET=cfg.k_packed_offset,
+        K_S_COL_OFFSET=cfg.k_s_col_offset,
+        K_ZP_OFFSET=cfg.k_zp_offset,
+        K_S_ROW_OFFSET=cfg.k_s_row_offset,
+        V_PACKED_OFFSET=cfg.v_packed_offset,
+        V_S_COL_OFFSET=cfg.v_s_col_offset,
+        V_S_ROW_OFFSET=cfg.v_s_row_offset,
+        V_ZP_OFFSET=cfg.v_zp_offset,
+        VQ_INDIRECT=False,
+        TAIL_SCALED=cfg.tail_dtype == "fp8",
+    )
+    # SPLIT-K (KVARN_SPLIT_K=1): two-stage flash-decoding — only a win in the
+    # LOW-batch / long-context regime (few programs ⇒ the KV-split dim adds the
+    # missing parallelism). At BURST (high batch) the single-stage (B,Hk) grid
+    # already saturates the GPU, so split-K's mid-buffer round-trip + stage-2 +
+    # empty-split waste roughly HALVE throughput. Default: single-stage.
+    use_fused = use_fused and True
+    # Split-K decision. Single-stage grid is (B, Hk) programs, each serially
+    # walking the WHOLE context; at long context that serial loop dominates and
+    # leaves the GPU under-occupied -> split-K parallelizes the KV dim for a big
+    # win (Qwen3.5-27B head_dim256 16K: 0.59x -> 0.96x same-batch, and lets KVarN
+    # out-throughput FP16's max feasible batch). But at short context / high
+    # occupancy the mid-buffer round-trip + stage-2 + empty-split waste roughly
+    # HALVE throughput. So auto-enable only in the long-context, under-occupied
+    # regime; KVARN_SPLIT_K env (0/1) is an explicit override.
+    # The split-K mid buffers are sized for the pure-decode regime
+    # (max_num_seqs * Hq rows); never split if this batch would overflow them
+    # (defensive — real decode batches always fit, but a padded dummy run can
+    # be wider). The single-stage kernel handles any batch size.
+    _mid_fits = impl._mid_o_buf is not None and impl._mid_o_buf.shape[0] >= N
+    _sk_env = os.environ.get("KVARN_SPLIT_K")
+    if _sk_env is not None:
+        split_k = use_fused and _sk_env == "1" and _mid_fits
+    else:
+        sm_count = (
+            getattr(impl, "_sm_count", 0)
+            or torch.cuda.get_device_properties(device).multi_processor_count
+        )
+        # long context (>= ~16 blocks of group tokens) AND single-stage grid does
+        # not already fill the SMs.
+        # Sliding-window layers read only ~window/GROUP blocks (single-stage is
+        # plenty + the windowed loop is in the single-stage kernel), so never split.
+        _sw = int(getattr(impl, "sliding_window", 0) or 0)
+        split_k = (
+            use_fused
+            and (_sw <= 0)
+            and (max_blocks_per_req >= 16)
+            and (B * Hk <= sm_count)
+            and _mid_fits
+        )
+    use_cutedsl = bool(getattr(impl, "_use_cutedsl_decode", False)) and _mid_fits
+    if use_cutedsl:
+        from vllm.v1.attention.ops.cutedsl_kvarn_decode import (
+            run as cutedsl_kvarn_stage1,
+        )
+
+        splits = 128
+        mid_o = impl._mid_o_buf
+        mid_lse = impl._mid_lse_buf
+        fused_out = impl._fused_out_buf[:N]
+        with torch.profiler.record_function("kvarn_cutedsl_decode_s1"):
+            cutedsl_kvarn_stage1(
+                q_rot_fp16.view(B, Hq, D),
+                kv_cache,
+                impl._tail_K_pool,
+                impl._tail_V_pool,
+                impl._tail_K_scale_pool,
+                impl._tail_V_scale_pool,
+                md.block_table,
+                md.seq_lens,
+                impl._block_to_slot_t,
+                mid_o,
+                mid_lse,
+                splits,
+                impl.kv_cache_dtype,
+            )
+        with torch.profiler.record_function("kvarn_cutedsl_decode_s2"):
+            _kvarn_fused_decode_stage2[(N,)](
+                mid_o,
+                mid_lse,
+                fused_out,
+                mid_o.stride(0),
+                mid_o.stride(1),
+                mid_lse.stride(0),
+                fused_out.stride(0),
+                D=D,
+                NUM_KV_SPLITS=splits,
+                num_warps=2,
+            )
+        output_rot = fused_out
+
+    elif use_fused and not split_k:
+        fused_out = impl._fused_out_buf[:N]  # [N, D] fp16
+        with torch.profiler.record_function("kvarn_fused_decode"):
+            _kvarn_fused_decode_kernel[(B, Hk)](
+                q_rot_fp16,
+                md.seq_lens,
+                md.block_table,
+                md.seq_lens,
+                impl._block_to_slot_t,
+                kv_cache,
+                impl._tail_K_pool,
+                impl._tail_V_pool,
+                impl._tail_K_scale_pool,
+                impl._tail_V_scale_pool,
+                fused_out,
+                scale,
+                Hq * D,
+                D,
+                md.block_table.stride(0),
+                kv_cache.stride(0),
+                kv_cache.stride(1),
+                impl._tail_K_pool.stride(0),
+                impl._tail_K_pool.stride(1),
+                impl._tail_K_pool.stride(2),
+                impl._tail_K_scale_pool.stride(0),
+                impl._tail_K_scale_pool.stride(1),
+                impl._tail_K_scale_pool.stride(2),
+                Hq * D,
+                D,
+                **common,  # autotune fills BLOCK_N + warps + stages
+            )
+        output_rot = fused_out
+    elif split_k:
+        SPLITS = adaptive_num_kv_splits(max_blocks_per_req, cfg)
+        mid_o = impl._mid_o_buf
+        mid_lse = impl._mid_lse_buf
+        fused_out = impl._fused_out_buf[:N]
+        with torch.profiler.record_function("kvarn_fused_decode_s1"):
+            _kvarn_fused_decode_stage1[(B, Hk, SPLITS)](
+                q_rot_fp16,
+                md.seq_lens,
+                md.block_table,
+                md.seq_lens,
+                impl._block_to_slot_t,
+                kv_cache,
+                impl._tail_K_pool,
+                impl._tail_V_pool,
+                impl._tail_K_scale_pool,
+                impl._tail_V_scale_pool,
+                mid_o,
+                mid_lse,
+                scale,
+                Hq * D,
+                D,
+                md.block_table.stride(0),
+                kv_cache.stride(0),
+                kv_cache.stride(1),
+                impl._tail_K_pool.stride(0),
+                impl._tail_K_pool.stride(1),
+                impl._tail_K_pool.stride(2),
+                impl._tail_K_scale_pool.stride(0),
+                impl._tail_K_scale_pool.stride(1),
+                impl._tail_K_scale_pool.stride(2),
+                mid_o.stride(0),
+                mid_o.stride(1),
+                mid_lse.stride(0),
+                NUM_KV_SPLITS=SPLITS,
+                HQ=Hq,
+                **common,  # BLOCK_N/warps autotuned
+            )
+        with torch.profiler.record_function("kvarn_fused_decode_s2"):
+            _kvarn_fused_decode_stage2[(N,)](
+                mid_o,
+                mid_lse,
+                fused_out,
+                mid_o.stride(0),
+                mid_o.stride(1),
+                mid_lse.stride(0),
+                fused_out.stride(0),
+                D=D,
+                NUM_KV_SPLITS=SPLITS,
+                num_warps=2,
+            )
+        output_rot = fused_out
+    else:
+        K_packed = impl._fa_K_buf
+        V_packed = impl._fa_V_buf
+        with torch.profiler.record_function("kvarn_build_packed_kv"):
+            _kvarn_build_packed_kv_kernel[(B * max_blocks_per_req, Hk)](
+                md.block_table,
+                md.seq_lens,
+                md.fa_cu_seqlens_k,
+                impl._block_to_slot_t,
+                kv_cache,
+                impl._tail_K_pool,
+                impl._tail_V_pool,
+                impl._tail_K_scale_pool,
+                impl._tail_V_scale_pool,
+                K_packed,
+                V_packed,
+                md.block_table.stride(0),
+                kv_cache.stride(0),
+                kv_cache.stride(1),
+                impl._tail_K_pool.stride(0),
+                impl._tail_K_pool.stride(1),
+                impl._tail_K_pool.stride(2),
+                impl._tail_K_scale_pool.stride(0),
+                impl._tail_K_scale_pool.stride(1),
+                impl._tail_K_scale_pool.stride(2),
+                K_packed.stride(0),
+                K_packed.stride(1),
+                MAX_BLOCKS_PER_REQ=max_blocks_per_req,
+                D=D,
+                GROUP=group,
+                TILES_PER_PAGE=tiles_per_page,
+                K_BITS=cfg.key_bits,
+                V_BITS=cfg.value_bits,
+                NUM_BLOCKS_LOOKUP=impl._block_lookup_size,
+                K_PACKED_OFFSET=cfg.k_packed_offset,
+                K_S_COL_OFFSET=cfg.k_s_col_offset,
+                K_ZP_OFFSET=cfg.k_zp_offset,
+                K_S_ROW_OFFSET=cfg.k_s_row_offset,
+                V_PACKED_OFFSET=cfg.v_packed_offset,
+                V_S_COL_OFFSET=cfg.v_s_col_offset,
+                V_S_ROW_OFFSET=cfg.v_s_row_offset,
+                V_ZP_OFFSET=cfg.v_zp_offset,
+                TAIL_SCALED=cfg.tail_dtype == "fp8",
+                num_warps=4,
+                num_stages=2,
+            )
+        with torch.profiler.record_function("kvarn_flash_attn"):
+            output_rot = flash_attn_varlen_func(
+                q=q_rot_fp16.view(B, Hq, D),
+                k=K_packed,
+                v=V_packed,
+                cu_seqlens_q=md.fa_cu_seqlens_q,
+                cu_seqlens_k=md.fa_cu_seqlens_k,
+                max_seqlen_q=1,
+                max_seqlen_k=md.fa_max_seqlen_k_fixed,
+                softmax_scale=scale,
+                causal=False,
+            )
+
+    # 4. Un-rotate output — single fp16 tensor-core matmul (V was rotated, so
+    #    the attention output lives in the rotated frame). out = out_rot · H.
+    with torch.profiler.record_function("kvarn_output_unrotation"):
+        out_unrot = kvarn_hadamard(output_rot.reshape(N, D), H16)
+        return out_unrot.view(B, Hq, D).to(out_dtype)
+
+
+def kvarn_verify_attention(
+    query: torch.Tensor,  # [NQ, Hq, D]  fp16/bf16 (token-major)
+    kv_cache: torch.Tensor,  # [num_blocks, Hk, TILE_BYTES] uint8
+    block_table: torch.Tensor,  # [B, max_blocks] int32
+    scale: float,
+    cfg,
+    impl,  # KVarNAttentionImpl
+    vq_req: torch.Tensor,  # [NQ] int32 — block-table row per token
+    vq_seqlen: torch.Tensor,  # [NQ] int32 — causal len: cached+i+1
+    max_ctx_blocks: int,  # ceil(max context / group) upper bound
+    qlen: int = 0,  # uniform query length (>= 2), else 0
+    seq_lens: torch.Tensor | None = None,  # [B] int32 (uniform path)
+) -> torch.Tensor:
+    """Fused multi-query verify over packed history and the precision tail.
+
+    Two modes:
+    - UNIFORM (qlen >= 2, the captured/common case): one program per
+      (request, kv head, split) — the request's QLEN tokens SHARE each
+      block's dequant, so KV bytes and dequant ALU match single-token decode.
+    - per-token fallback (qlen == 0, non-uniform eager batches): one program
+      per (query token, kv head) via the vq plan; QLEN-x redundant dequant.
+
+    Output: ``[NQ, Hq, D]`` in ``query``'s dtype, un-rotated frame.
+    """
+    NQ, Hq, D = query.shape
+    tiles_per_page = 1
+    Hk = kv_cache.shape[1]
+    device = query.device
+    out_dtype = query.dtype
+    group = cfg.group
+    Nrows = NQ * Hq
+
+    H16 = (
+        impl._H_fp16
+        if impl._H_fp16 is not None
+        else impl._hadamard(device).to(torch.float16)
+    )
+    q_rot = kvarn_hadamard(query.reshape(Nrows, D).to(H16.dtype), H16)
+
+    _qpk = Hq // Hk
+    _qpk_pad = 1 << (_qpk - 1).bit_length() if _qpk > 1 else 1
+    common = dict(
+        MAX_BLOCKS_PER_REQ=max_ctx_blocks,
+        D=D,
+        GROUP=group,
+        TILES_PER_PAGE=tiles_per_page,
+        Q_PER_KV=_qpk,
+        Q_PER_KV_PAD=_qpk_pad,
+        SLIDING_WINDOW=int(getattr(impl, "sliding_window", 0) or 0),
+        K_BITS=cfg.key_bits,
+        V_BITS=cfg.value_bits,
+        NUM_BLOCKS_LOOKUP=impl._block_lookup_size,
+        K_PACKED_OFFSET=cfg.k_packed_offset,
+        K_S_COL_OFFSET=cfg.k_s_col_offset,
+        K_ZP_OFFSET=cfg.k_zp_offset,
+        K_S_ROW_OFFSET=cfg.k_s_row_offset,
+        V_PACKED_OFFSET=cfg.v_packed_offset,
+        V_S_COL_OFFSET=cfg.v_s_col_offset,
+        V_S_ROW_OFFSET=cfg.v_s_row_offset,
+        V_ZP_OFFSET=cfg.v_zp_offset,
+        TAIL_SCALED=cfg.tail_dtype == "fp8",
+    )
+
+    out_rot = torch.empty(NQ, Hq, D, dtype=torch.float16, device=device)
+
+    _m = qlen * (1 << ((Hq // Hk) - 1).bit_length() if Hq // Hk > 1 else 1)
+    if (
+        qlen >= 2
+        and seq_lens is not None
+        and NQ % qlen == 0
+        and (_m & (_m - 1)) == 0  # Q-tile rows must be a power of 2
+        # DEFAULT OFF: numerically validated in isolation (matches the
+        # per-token kernel within fp32 reduction noise on live inputs,
+        # incl. on the failing trajectory), but serving with it corrupts
+        # the MTP drafter's proposals (invalid [-1,...] spec tokens,
+        # embedding index asserts at temperature>0, degenerate greedy
+        # output) through a mechanism not yet isolated — suspicion is an
+        # interaction with async scheduling / drafter metadata rather
+        # than kernel math. Re-enable for debugging only.
+        and os.environ.get("KVARN_SHARED_VERIFY", "0") == "1"
+    ):
+        # SHARED-DEQUANT uniform path: split-K shaped (SPLITS=1 degenerates
+        # cleanly); stage2 combines into the flat [NQ*Hq, D] output.
+        B = NQ // qlen
+        SPLITS = (
+            adaptive_num_kv_splits(max_ctx_blocks, cfg)
+            if max_ctx_blocks >= 16
+            and B * Hk
+            <= (
+                getattr(impl, "_sm_count", 0)
+                or torch.cuda.get_device_properties(device).multi_processor_count
+            )
+            else 1
+        )
+        mid_o = torch.empty(Nrows, SPLITS, D, dtype=torch.float32, device=device)
+        mid_lse = torch.empty(Nrows, SPLITS, dtype=torch.float32, device=device)
+        _kvarn_fused_verify_stage1[(B, Hk, SPLITS)](
+            q_rot,
+            block_table,
+            vq_seqlen,
+            impl._block_to_slot_t,
+            kv_cache,
+            impl._tail_K_pool,
+            impl._tail_V_pool,
+            impl._tail_K_scale_pool,
+            impl._tail_V_scale_pool,
+            mid_o,
+            mid_lse,
+            scale,
+            Hq * D,
+            D,
+            block_table.stride(0),
+            kv_cache.stride(0),
+            kv_cache.stride(1),
+            impl._tail_K_pool.stride(0),
+            impl._tail_K_pool.stride(1),
+            impl._tail_K_pool.stride(2),
+            impl._tail_K_scale_pool.stride(0),
+            impl._tail_K_scale_pool.stride(1),
+            impl._tail_K_scale_pool.stride(2),
+            mid_o.stride(0),
+            mid_o.stride(1),
+            mid_lse.stride(0),
+            QLEN=qlen,
+            HQ=Hq,
+            NUM_KV_SPLITS=SPLITS,
+            **common,
+        )
+        out_flat = out_rot.view(Nrows, D)
+        _kvarn_fused_decode_stage2[(Nrows,)](
+            mid_o,
+            mid_lse,
+            out_flat,
+            mid_o.stride(0),
+            mid_o.stride(1),
+            mid_lse.stride(0),
+            out_flat.stride(0),
+            D=D,
+            NUM_KV_SPLITS=SPLITS,
+            num_warps=2,
+        )
+        out_unrot = kvarn_hadamard(out_rot.reshape(Nrows, D), H16)
+        return out_unrot.view(NQ, Hq, D).to(out_dtype)
+
+    common["VQ_INDIRECT"] = True
+
+    # Split-K mirrors the decode driver's heuristic: long context with too few
+    # programs to fill the SMs. Verify batches are tiny (NQ <= maxq * B), so
+    # long-context verify nearly always wants the split.
+    sm_count = (
+        getattr(impl, "_sm_count", 0)
+        or torch.cuda.get_device_properties(device).multi_processor_count
+    )
+    _sw = int(getattr(impl, "sliding_window", 0) or 0)
+    _sk_env = os.environ.get("KVARN_SPLIT_K")
+    if _sk_env is not None:
+        split_k = _sk_env == "1"
+    else:
+        split_k = (_sw <= 0) and (max_ctx_blocks >= 16) and (NQ * Hk <= sm_count)
+
+    if not split_k:
+        _kvarn_fused_decode_kernel[(NQ, Hk)](
+            q_rot,
+            vq_req,
+            block_table,
+            vq_seqlen,
+            impl._block_to_slot_t,
+            kv_cache,
+            impl._tail_K_pool,
+            impl._tail_V_pool,
+            impl._tail_K_scale_pool,
+            impl._tail_V_scale_pool,
+            out_rot,
+            scale,
+            Hq * D,
+            D,
+            block_table.stride(0),
+            kv_cache.stride(0),
+            kv_cache.stride(1),
+            impl._tail_K_pool.stride(0),
+            impl._tail_K_pool.stride(1),
+            impl._tail_K_pool.stride(2),
+            impl._tail_K_scale_pool.stride(0),
+            impl._tail_K_scale_pool.stride(1),
+            impl._tail_K_scale_pool.stride(2),
+            Hq * D,
+            D,
+            **common,
+        )
+    else:
+        SPLITS = adaptive_num_kv_splits(max_ctx_blocks, cfg)
+        mid_o = torch.empty(Nrows, SPLITS, D, dtype=torch.float32, device=device)
+        mid_lse = torch.empty(Nrows, SPLITS, dtype=torch.float32, device=device)
+        _kvarn_fused_decode_stage1[(NQ, Hk, SPLITS)](
+            q_rot,
+            vq_req,
+            block_table,
+            vq_seqlen,
+            impl._block_to_slot_t,
+            kv_cache,
+            impl._tail_K_pool,
+            impl._tail_V_pool,
+            impl._tail_K_scale_pool,
+            impl._tail_V_scale_pool,
+            mid_o,
+            mid_lse,
+            scale,
+            Hq * D,
+            D,
+            block_table.stride(0),
+            kv_cache.stride(0),
+            kv_cache.stride(1),
+            impl._tail_K_pool.stride(0),
+            impl._tail_K_pool.stride(1),
+            impl._tail_K_pool.stride(2),
+            impl._tail_K_scale_pool.stride(0),
+            impl._tail_K_scale_pool.stride(1),
+            impl._tail_K_scale_pool.stride(2),
+            mid_o.stride(0),
+            mid_o.stride(1),
+            mid_lse.stride(0),
+            NUM_KV_SPLITS=SPLITS,
+            HQ=Hq,
+            **common,  # BLOCK_N/warps autotuned
+        )
+        out_flat = out_rot.view(Nrows, D)
+        _kvarn_fused_decode_stage2[(Nrows,)](
+            mid_o,
+            mid_lse,
+            out_flat,
+            mid_o.stride(0),
+            mid_o.stride(1),
+            mid_lse.stride(0),
+            out_flat.stride(0),
+            D=D,
+            NUM_KV_SPLITS=SPLITS,
+            num_warps=2,
+        )
+
+    out_unrot = kvarn_hadamard(out_rot.reshape(Nrows, D), H16)
+    return out_unrot.view(NQ, Hq, D).to(out_dtype)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# SHARED-DEQUANT verify kernel: one program per (REQUEST, kv-head, split) — all
+# QLEN verify tokens of a request share each block's dequant (the per-token
+# VQ_INDIRECT path above re-walks the context once per token, i.e. QLEN
+# redundant dequants). Q tile is [QLEN * Q_PER_KV_PAD, D] with a per-row
+# bottom-right causal limit: row (token j, lane h) attends kv positions
+# < seq_len - QLEN + j + 1. Uniform QLEN is a constexpr (uniform-batch graph
+# capture guarantees it); non-uniform eager batches fall back to the per-token
+# kernel. Scale vectors are loaded via fp16 pointer casts (the tile offsets are
+# 2-byte aligned) instead of the byte-pair loads of the older kernels.
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+@triton.autotune(
+    configs=_DECODE_AUTOTUNE_CONFIGS,
+    key=["D", "GROUP", "Q_PER_KV", "QLEN", "K_BITS", "V_BITS"],
+)
+@triton.jit
+def _kvarn_fused_verify_stage1(
+    Q_ptr,  # [NQ = B*QLEN, Hq, D] fp16 (rotated, token-major)
+    Block_table_ptr,  # [B, max_blocks] int32
+    Seq_lens_ptr,  # [NQ] int32 — the vq plan (per-token causal lengths);
+    # the request's FULL length is its LAST token's entry.
+    # Built CPU-side in the builder: under async spec
+    # decode the device seq_lens tensor can disagree with
+    # the builder's CPU view, and the CPU view is the one
+    # the (validated) per-token path uses.
+    Block_to_slot_ptr,
+    KV_cache_ptr,
+    Tail_K_pool_ptr,
+    Tail_V_pool_ptr,
+    Tail_K_scale_ptr,
+    Tail_V_scale_ptr,
+    MidO_ptr,  # [NQ*Hq, NUM_KV_SPLITS, D] fp32
+    MidLse_ptr,  # [NQ*Hq, NUM_KV_SPLITS]    fp32
+    scale,
+    stride_q_t,
+    stride_q_h,
+    stride_bt_b,
+    stride_kv_b,
+    stride_kv_h,
+    stride_pool_b,
+    stride_pool_t,
+    stride_pool_h,
+    stride_scale_b,
+    stride_scale_t,
+    stride_scale_h,
+    stride_mo_n,
+    stride_mo_s,
+    stride_ml_n,
+    MAX_BLOCKS_PER_REQ: tl.constexpr,  # unused; kept for launch-dict parity
+    D: tl.constexpr,
+    GROUP: tl.constexpr,
+    TILES_PER_PAGE: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    QLEN: tl.constexpr,
+    Q_PER_KV: tl.constexpr,
+    Q_PER_KV_PAD: tl.constexpr,
+    HQ: tl.constexpr,
+    NUM_KV_SPLITS: tl.constexpr,
+    SLIDING_WINDOW: tl.constexpr,
+    K_BITS: tl.constexpr,
+    V_BITS: tl.constexpr,
+    NUM_BLOCKS_LOOKUP: tl.constexpr,
+    K_PACKED_OFFSET: tl.constexpr,
+    K_S_COL_OFFSET: tl.constexpr,
+    K_ZP_OFFSET: tl.constexpr,
+    K_S_ROW_OFFSET: tl.constexpr,
+    V_PACKED_OFFSET: tl.constexpr,
+    V_S_COL_OFFSET: tl.constexpr,
+    V_S_ROW_OFFSET: tl.constexpr,
+    V_ZP_OFFSET: tl.constexpr,
+    TAIL_SCALED: tl.constexpr,
+):
+    b = tl.program_id(0)
+    hk = tl.program_id(1)
+    split = tl.program_id(2)
+
+    seq_len = tl.load(Seq_lens_ptr + b * QLEN + (QLEN - 1))
+    # Padded rows (uniform-batch capture/replay) carry seq_len <= 0.
+    if seq_len <= 0:
+        return
+
+    M: tl.constexpr = QLEN * Q_PER_KV_PAD
+    r = tl.arange(0, M)
+    j = r // Q_PER_KV_PAD  # token idx in request
+    lane = r % Q_PER_KV_PAD  # query-head lane
+    rmask = lane < Q_PER_KV
+    limit = seq_len - QLEN + j + 1  # [M] causal kv limit
+    hq0 = hk * Q_PER_KV
+    d_offs = tl.arange(0, D)
+
+    tok_row = b * QLEN + j  # [M] token-major Q row
+    q = tl.load(
+        Q_ptr
+        + tok_row[:, None] * stride_q_t
+        + (hq0 + lane)[:, None] * stride_q_h
+        + d_offs[None, :],
+        mask=rmask[:, None],
+        other=0.0,
+    ).to(tl.float32)  # [M, D]
+
+    m_i = tl.full([M], -float("inf"), dtype=tl.float32)
+    l_i = tl.zeros([M], dtype=tl.float32)
+    acc = tl.zeros([M, D], dtype=tl.float32)
+
+    n_blocks = (seq_len + GROUP - 1) // GROUP
+    blocks_per_split = (n_blocks + NUM_KV_SPLITS - 1) // NUM_KV_SPLITS
+    blk_lo = split * blocks_per_split
+    blk_hi = tl.minimum(blk_lo + blocks_per_split, n_blocks)
+
+    for k in range(blk_lo, blk_hi):
+        rem = seq_len - k * GROUP
+        n_tok = tl.minimum(tl.maximum(rem, 0), GROUP)
+        block_id = tl.load(Block_table_ptr + b * stride_bt_b + k)
+        in_range = (block_id >= 0) & (block_id < NUM_BLOCKS_LOOKUP)
+        safe_bid = tl.where(in_range, block_id, 0)
+        pool_slot = tl.load(Block_to_slot_ptr + safe_bid, mask=in_range, other=-1)
+        tile_base = block_id.to(tl.int64) * stride_kv_b + hk * stride_kv_h
+        safe_slot = tl.where(pool_slot >= 0, pool_slot, 0)
+        pool_base = safe_slot.to(tl.int64) * stride_pool_b + hk * stride_pool_h
+
+        # Per-channel scales — direct fp16 loads (2-byte-aligned offsets).
+        s_col_K = tl.load(
+            (KV_cache_ptr + tile_base + K_S_COL_OFFSET).to(tl.pointer_type(tl.float16))
+            + d_offs
+        ).to(tl.float32)
+        zp_K = tl.load(
+            (KV_cache_ptr + tile_base + K_ZP_OFFSET).to(tl.pointer_type(tl.float16))
+            + d_offs
+        ).to(tl.float32)
+        s_col_V = tl.load(
+            (KV_cache_ptr + tile_base + V_S_COL_OFFSET).to(tl.pointer_type(tl.float16))
+            + d_offs
+        ).to(tl.float32)
+
+        for c0 in range(0, GROUP, BLOCK_N):
+            cols = c0 + tl.arange(0, BLOCK_N)
+            cmask = cols < n_tok
+            kvpos = k * GROUP + cols  # [BN]
+
+            if pool_slot >= 0:
+                src = pool_base + cols[:, None] * stride_pool_t + d_offs[None, :]
+                Kc = tl.load(Tail_K_pool_ptr + src, mask=cmask[:, None], other=0.0).to(
+                    tl.float32
+                )
+                Vc = tl.load(Tail_V_pool_ptr + src, mask=cmask[:, None], other=0.0).to(
+                    tl.float32
+                )
+                if TAIL_SCALED:
+                    scale_src = (
+                        safe_slot.to(tl.int64) * stride_scale_b
+                        + cols * stride_scale_t
+                        + hk * stride_scale_h
+                    )
+                    Kc *= tl.load(Tail_K_scale_ptr + scale_src, mask=cmask, other=1.0)[
+                        :, None
+                    ]
+                    Vc *= tl.load(Tail_V_scale_ptr + scale_src, mask=cmask, other=1.0)[
+                        :, None
+                    ]
+                K_dg = tl.trans(Kc)  # [D, BN]
+            else:
+                s_row_K = tl.load(
+                    (KV_cache_ptr + tile_base + K_S_ROW_OFFSET).to(
+                        tl.pointer_type(tl.float16)
+                    )
+                    + cols
+                ).to(tl.float32)
+                k_indices = d_offs[:, None] * GROUP + cols[None, :]
+                q_K = _unpack_dense_bits(
+                    KV_cache_ptr + tile_base + K_PACKED_OFFSET,
+                    k_indices,
+                    K_BITS,
+                ).to(tl.float32)
+                K_dg = (q_K * s_col_K[:, None] + zp_K[:, None]) * s_row_K[None, :]
+                s_row_V = tl.load(
+                    (KV_cache_ptr + tile_base + V_S_ROW_OFFSET).to(
+                        tl.pointer_type(tl.float16)
+                    )
+                    + cols
+                ).to(tl.float32)
+                zp_V = tl.load(
+                    (KV_cache_ptr + tile_base + V_ZP_OFFSET).to(
+                        tl.pointer_type(tl.float16)
+                    )
+                    + cols
+                ).to(tl.float32)
+                v_indices = cols[:, None] * D + d_offs[None, :]
+                q_V = _unpack_dense_bits(
+                    KV_cache_ptr + tile_base + V_PACKED_OFFSET,
+                    v_indices,
+                    V_BITS,
+                ).to(tl.float32)
+                Vc = (q_V * s_row_V[:, None] + zp_V[:, None]) * s_col_V[None, :]
+
+            scores = tl.dot(q, K_dg)  # [M, BN]
+            smask = cmask[None, :] & (kvpos[None, :] < limit[:, None])
+            if SLIDING_WINDOW > 0:
+                smask = smask & (
+                    kvpos[None, :] >= tl.maximum(limit[:, None] - SLIDING_WINDOW, 0)
+                )
+            scores = tl.where(smask, scores * scale, -float("inf"))
+            m_new = tl.maximum(m_i, tl.max(scores, axis=1))
+            p = tl.exp(scores - m_new[:, None])
+            alpha = tl.exp(m_i - m_new)
+            l_i = l_i * alpha + tl.sum(p, axis=1)
+            acc = acc * alpha[:, None] + tl.dot(p, Vc)
+            m_i = m_new
+
+    nonempty = l_i > 0
+    O_s = acc / tl.where(nonempty, l_i, 1.0)[:, None]
+    lse_s = tl.where(
+        nonempty, m_i + tl.log(tl.where(nonempty, l_i, 1.0)), -float("inf")
+    )
+    rows = tok_row * HQ + hq0 + lane  # [M] N-row index
+    tl.store(
+        MidO_ptr + rows[:, None] * stride_mo_n + split * stride_mo_s + d_offs[None, :],
+        O_s,
+        mask=rmask[:, None],
+    )
+    tl.store(MidLse_ptr + rows * stride_ml_n + split, lse_s, mask=rmask)

--- a/vllm/v1/attention/ops/triton_kvarn_sinkhorn.py
+++ b/vllm/v1/attention/ops/triton_kvarn_sinkhorn.py
@@ -1,0 +1,482 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Triton fused log-domain iterative variance-normalization for KVarN.
+
+Matches the PyTorch reference in
+``vllm/model_executor/layers/quantization/kvarn/sinkhorn.py`` semantically —
+same 16 alternating col/row std-normalization passes, same best-so-far
+tracking via the imbalance metric, same clamps. One Triton program per
+``[R, C]`` tile; the grid dim is the number of tiles in the batch.
+
+For ``R = C = 128`` the full tile is 64 KB fp32 — fits in a single Triton
+block's register/SMEM budget on current GPUs.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from vllm.triton_utils import tl, triton
+
+_CLIP_STD_MIN = 1e-3
+_CLIP_STD_MAX = 1e3
+_LOG_S_MIN = -0.3
+_LOG_S_MAX = 10.0
+
+
+@triton.jit
+def _sinkhorn_log_kernel(
+    Tile_ptr,  # [N, R, C] fp32 input — rotated tile
+    Balanced_ptr,  # [N, R, C] fp32 output
+    SCol_ptr,  # [N, C] fp32 output (s_col, per-column)
+    SRow_ptr,  # [N, R] fp32 output (s_row, per-row)
+    # Strides
+    stride_tn,
+    stride_tr,
+    stride_bn,
+    stride_br,
+    stride_sc_n,
+    stride_sr_n,
+    # Dims
+    R: tl.constexpr,
+    C: tl.constexpr,
+    ITERATIONS: tl.constexpr,
+    # Algorithm params (kept as tl.constexpr for the compiler)
+    CLIP_STD_MIN: tl.constexpr,
+    CLIP_STD_MAX: tl.constexpr,
+    LOG_S_MIN: tl.constexpr,
+    LOG_S_MAX: tl.constexpr,
+):
+    """One program per tile. Loads a R x C tile into registers, does
+    ``ITERATIONS`` alternating col/row log-domain normalizations, tracks
+    the best-so-far (lowest-imbalance) scales, and writes (balanced, s_col,
+    s_row).
+    """
+    pid = tl.program_id(0)
+
+    r_offs = tl.arange(0, R)
+    c_offs = tl.arange(0, C)
+
+    # Load tile [R, C] into registers
+    tile_base = pid * stride_tn
+    tile_ptrs = Tile_ptr + tile_base + r_offs[:, None] * stride_tr + c_offs[None, :]
+    tile = tl.load(tile_ptrs).to(tl.float32)
+
+    # log_s_col [C], log_s_row [R]; initialised at zero (exp = 1)
+    log_s_col = tl.zeros([C], dtype=tl.float32)
+    log_s_row = tl.zeros([R], dtype=tl.float32)
+
+    # cur = tile / s_col / s_row = tile (with mu = 1 initially)
+    cur = tile
+
+    # ── initial imbalance score + best snapshot ───────────────────────────
+    col_mean0 = tl.sum(cur, axis=0) / R
+    col_var0 = tl.sum(cur * cur, axis=0) / R - col_mean0 * col_mean0
+    col_std0 = tl.sqrt(tl.maximum(col_var0 * R / (R - 1), 0.0))
+    row_mean0 = tl.sum(cur, axis=1) / C
+    row_var0 = tl.sum(cur * cur, axis=1) / C - row_mean0 * row_mean0
+    row_std0 = tl.sqrt(tl.maximum(row_var0 * C / (C - 1), 0.0))
+    col_max0 = tl.max(col_std0)
+    col_min0 = tl.maximum(tl.min(col_std0), 1e-8)
+    row_max0 = tl.max(row_std0)
+    row_min0 = tl.maximum(tl.min(row_std0), 1e-8)
+    score_best = col_max0 / col_min0 + row_max0 / row_min0
+
+    sc_best = tl.exp(log_s_col)
+    sr_best = tl.exp(log_s_row)
+
+    # ── iterations ────────────────────────────────────────────────────────
+    for _ in tl.static_range(ITERATIONS):
+        # Update column scales from cur's per-column std
+        col_mean = tl.sum(cur, axis=0) / R
+        col_var = tl.sum(cur * cur, axis=0) / R - col_mean * col_mean
+        col_std = tl.sqrt(tl.maximum(col_var * R / (R - 1), 0.0))
+        col_std_clipped = tl.maximum(tl.minimum(col_std, CLIP_STD_MAX), CLIP_STD_MIN)
+        log_s_col = log_s_col + tl.log(col_std_clipped)
+        log_s_col = tl.maximum(tl.minimum(log_s_col, LOG_S_MAX), LOG_S_MIN)
+        s_col_lin = tl.exp(log_s_col)
+        s_row_lin = tl.exp(log_s_row)
+        cur = tile / s_col_lin[None, :] / s_row_lin[:, None]
+
+        # Update row scales from new cur's per-row std
+        row_mean = tl.sum(cur, axis=1) / C
+        row_var = tl.sum(cur * cur, axis=1) / C - row_mean * row_mean
+        row_std = tl.sqrt(tl.maximum(row_var * C / (C - 1), 0.0))
+        row_std_clipped = tl.maximum(tl.minimum(row_std, CLIP_STD_MAX), CLIP_STD_MIN)
+        log_s_row = log_s_row + tl.log(row_std_clipped)
+        log_s_row = tl.maximum(tl.minimum(log_s_row, LOG_S_MAX), LOG_S_MIN)
+        s_col_lin = tl.exp(log_s_col)
+        s_row_lin = tl.exp(log_s_row)
+        cur = tile / s_col_lin[None, :] / s_row_lin[:, None]
+
+        # Imbalance score at this candidate
+        col_mean_n = tl.sum(cur, axis=0) / R
+        col_var_n = tl.sum(cur * cur, axis=0) / R - col_mean_n * col_mean_n
+        col_std_n = tl.sqrt(tl.maximum(col_var_n * R / (R - 1), 0.0))
+        row_mean_n = tl.sum(cur, axis=1) / C
+        row_var_n = tl.sum(cur * cur, axis=1) / C - row_mean_n * row_mean_n
+        row_std_n = tl.sqrt(tl.maximum(row_var_n * C / (C - 1), 0.0))
+        col_max_n = tl.max(col_std_n)
+        col_min_n = tl.maximum(tl.min(col_std_n), 1e-8)
+        row_max_n = tl.max(row_std_n)
+        row_min_n = tl.maximum(tl.min(row_std_n), 1e-8)
+        score = col_max_n / col_min_n + row_max_n / row_min_n
+
+        better = score <= score_best
+        sc_best = tl.where(better, s_col_lin, sc_best)
+        sr_best = tl.where(better, s_row_lin, sr_best)
+        score_best = tl.where(better, score, score_best)
+
+    # ── final: balanced = tile / sc_best / sr_best, write outputs ─────────
+    balanced = tile / sc_best[None, :] / sr_best[:, None]
+    bal_ptrs = (
+        Balanced_ptr + pid * stride_bn + r_offs[:, None] * stride_br + c_offs[None, :]
+    )
+    tl.store(bal_ptrs, balanced)
+    tl.store(SCol_ptr + pid * stride_sc_n + c_offs, sc_best)
+    tl.store(SRow_ptr + pid * stride_sr_n + r_offs, sr_best)
+
+
+@triton.jit
+def _axis_std_kernel(
+    Values,
+    Output,
+    stride_n,
+    stride_outer,
+    N_OUTER: tl.constexpr,
+    WIDTH: tl.constexpr,
+    TRANSPOSED: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    n = pid // N_OUTER
+    outer = pid % N_OUTER
+    offsets = tl.arange(0, WIDTH)
+    if TRANSPOSED:
+        pointers = Values + n * stride_n + offsets * stride_outer + outer
+    else:
+        pointers = Values + n * stride_n + outer * stride_outer + offsets
+    values = tl.load(pointers).to(tl.float32)
+    mean = tl.sum(values, axis=0) / WIDTH
+    centered = values - mean
+    std = tl.sqrt(tl.sum(centered * centered, axis=0) / (WIDTH - 1))
+    tl.store(Output + pid, std)
+
+
+@triton.jit
+def _normalize_columns_kernel(
+    Tiles,
+    Current,
+    LogSCol,
+    LogSRow,
+    stride_n,
+    stride_r,
+    R: tl.constexpr,
+    C: tl.constexpr,
+    CLIP_STD_MIN: tl.constexpr,
+    CLIP_STD_MAX: tl.constexpr,
+    LOG_S_MIN: tl.constexpr,
+    LOG_S_MAX: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    n = pid // C
+    col = pid % C
+    rows = tl.arange(0, R)
+    pointers = Current + n * stride_n + rows * stride_r + col
+    values = tl.load(pointers).to(tl.float32)
+    mean = tl.sum(values, axis=0) / R
+    centered = values - mean
+    std = tl.sqrt(tl.sum(centered * centered, axis=0) / (R - 1))
+    std = tl.maximum(tl.minimum(std, CLIP_STD_MAX), CLIP_STD_MIN)
+    log_s_col = tl.load(LogSCol + n * C + col) + tl.log(std)
+    log_s_col = tl.maximum(tl.minimum(log_s_col, LOG_S_MAX), LOG_S_MIN)
+    tl.store(LogSCol + n * C + col, log_s_col)
+    log_s_row = tl.load(LogSRow + n * R + rows)
+    tile = tl.load(Tiles + n * stride_n + rows * stride_r + col).to(tl.float32)
+    tl.store(pointers, tile / tl.exp(log_s_col) / tl.exp(log_s_row))
+
+
+@triton.jit
+def _normalize_rows_kernel(
+    Tiles,
+    Current,
+    LogSCol,
+    LogSRow,
+    RowStd,
+    stride_n,
+    stride_r,
+    R: tl.constexpr,
+    C: tl.constexpr,
+    CLIP_STD_MIN: tl.constexpr,
+    CLIP_STD_MAX: tl.constexpr,
+    LOG_S_MIN: tl.constexpr,
+    LOG_S_MAX: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    n = pid // R
+    row = pid % R
+    cols = tl.arange(0, C)
+    pointers = Current + n * stride_n + row * stride_r + cols
+    values = tl.load(pointers).to(tl.float32)
+    mean = tl.sum(values, axis=0) / C
+    centered = values - mean
+    std = tl.sqrt(tl.sum(centered * centered, axis=0) / (C - 1))
+    std = tl.maximum(tl.minimum(std, CLIP_STD_MAX), CLIP_STD_MIN)
+    log_s_row = tl.load(LogSRow + n * R + row) + tl.log(std)
+    log_s_row = tl.maximum(tl.minimum(log_s_row, LOG_S_MAX), LOG_S_MIN)
+    tl.store(LogSRow + n * R + row, log_s_row)
+    log_s_col = tl.load(LogSCol + n * C + cols)
+    tile = tl.load(Tiles + n * stride_n + row * stride_r + cols).to(tl.float32)
+    current = tile / tl.exp(log_s_row) / tl.exp(log_s_col)
+    tl.store(pointers, current)
+    current_mean = tl.sum(current, axis=0) / C
+    current_centered = current - current_mean
+    current_std = tl.sqrt(tl.sum(current_centered * current_centered, axis=0) / (C - 1))
+    tl.store(RowStd + n * R + row, current_std)
+
+
+@triton.jit
+def _update_best_kernel(
+    ColStd,
+    RowStd,
+    LogSCol,
+    LogSRow,
+    BestImbalance,
+    BestSCol,
+    BestSRow,
+    R: tl.constexpr,
+    C: tl.constexpr,
+):
+    n = tl.program_id(0)
+    rows = tl.arange(0, R)
+    cols = tl.arange(0, C)
+    row_std = tl.load(RowStd + n * R + rows)
+    col_std = tl.load(ColStd + n * C + cols)
+    imbalance = tl.max(row_std) / tl.maximum(tl.min(row_std), 1e-8)
+    imbalance += tl.max(col_std) / tl.maximum(tl.min(col_std), 1e-8)
+    best = tl.load(BestImbalance + n)
+    better = imbalance <= best
+    tl.store(BestImbalance + n, tl.where(better, imbalance, best))
+    tl.store(
+        BestSCol + n * C + cols,
+        tl.exp(tl.load(LogSCol + n * C + cols)),
+        mask=better,
+    )
+    tl.store(
+        BestSRow + n * R + rows,
+        tl.exp(tl.load(LogSRow + n * R + rows)),
+        mask=better,
+    )
+
+
+@triton.jit
+def _finalize_tiled_kernel(
+    Tiles,
+    Balanced,
+    BestSCol,
+    BestSRow,
+    stride_n,
+    stride_r,
+    R: tl.constexpr,
+    C: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    n = pid // R
+    row = pid % R
+    cols = tl.arange(0, C)
+    tile = tl.load(Tiles + n * stride_n + row * stride_r + cols).to(tl.float32)
+    s_col = tl.load(BestSCol + n * C + cols)
+    s_row = tl.load(BestSRow + n * R + row)
+    tl.store(
+        Balanced + n * stride_n + row * stride_r + cols,
+        tile / s_col / s_row,
+    )
+
+
+def _sinkhorn_tiled(
+    tiles: torch.Tensor,
+    iterations: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    N, R, C = tiles.shape
+    current = tiles.clone()
+    balanced = torch.empty_like(tiles)
+    log_s_col = torch.zeros(N, C, dtype=torch.float32, device=tiles.device)
+    log_s_row = torch.zeros(N, R, dtype=torch.float32, device=tiles.device)
+    s_col = torch.ones_like(log_s_col)
+    s_row = torch.ones_like(log_s_row)
+    col_std = torch.empty_like(log_s_col)
+    row_std = torch.empty_like(log_s_row)
+    best_imbalance = torch.full(
+        (N,), float("inf"), dtype=torch.float32, device=tiles.device
+    )
+
+    _axis_std_kernel[(N * C,)](
+        current,
+        col_std,
+        current.stride(0),
+        current.stride(1),
+        N_OUTER=C,
+        WIDTH=R,
+        TRANSPOSED=True,
+    )
+    _axis_std_kernel[(N * R,)](
+        current,
+        row_std,
+        current.stride(0),
+        current.stride(1),
+        N_OUTER=R,
+        WIDTH=C,
+        TRANSPOSED=False,
+    )
+    _update_best_kernel[(N,)](
+        col_std,
+        row_std,
+        log_s_col,
+        log_s_row,
+        best_imbalance,
+        s_col,
+        s_row,
+        R=R,
+        C=C,
+    )
+    for _ in range(iterations):
+        _normalize_columns_kernel[(N * C,)](
+            tiles,
+            current,
+            log_s_col,
+            log_s_row,
+            tiles.stride(0),
+            tiles.stride(1),
+            R=R,
+            C=C,
+            CLIP_STD_MIN=_CLIP_STD_MIN,
+            CLIP_STD_MAX=_CLIP_STD_MAX,
+            LOG_S_MIN=_LOG_S_MIN,
+            LOG_S_MAX=_LOG_S_MAX,
+        )
+        _normalize_rows_kernel[(N * R,)](
+            tiles,
+            current,
+            log_s_col,
+            log_s_row,
+            row_std,
+            tiles.stride(0),
+            tiles.stride(1),
+            R=R,
+            C=C,
+            CLIP_STD_MIN=_CLIP_STD_MIN,
+            CLIP_STD_MAX=_CLIP_STD_MAX,
+            LOG_S_MIN=_LOG_S_MIN,
+            LOG_S_MAX=_LOG_S_MAX,
+        )
+        _axis_std_kernel[(N * C,)](
+            current,
+            col_std,
+            current.stride(0),
+            current.stride(1),
+            N_OUTER=C,
+            WIDTH=R,
+            TRANSPOSED=True,
+        )
+        _update_best_kernel[(N,)](
+            col_std,
+            row_std,
+            log_s_col,
+            log_s_row,
+            best_imbalance,
+            s_col,
+            s_row,
+            R=R,
+            C=C,
+        )
+    _finalize_tiled_kernel[(N * R,)](
+        tiles,
+        balanced,
+        s_col,
+        s_row,
+        tiles.stride(0),
+        tiles.stride(1),
+        R=R,
+        C=C,
+    )
+    return balanced, s_col, s_row
+
+
+def kvarn_sinkhorn_triton(
+    tiles: torch.Tensor, iterations: int = 16
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Triton driver for ``_sinkhorn_log_kernel``.
+
+    Args:
+        tiles: ``[N, R, C]`` fp32 (or any real dtype, cast inside). Both R
+            and C must be compile-time-constant power-of-2 values; we hard-
+            code R = C = 128 for the first PR.
+        iterations: number of alternating col/row passes (default 16).
+
+    Returns:
+        balanced: ``[N, R, C]`` fp32.
+        s_col:    ``[N, C]`` fp32.
+        s_row:    ``[N, R]`` fp32.
+    """
+    assert tiles.ndim == 3
+    N, R, C = tiles.shape
+    tiles = tiles.contiguous().to(torch.float32)
+    device = tiles.device
+
+    # The Triton kernel loads the WHOLE [R, C] tile into one program's registers
+    # and unrolls the iteration loop. At large head_dim that tile is huge (e.g.
+    # head_dim 512 -> [512, 128] = 256 KB) and the Triton compiler hangs/explodes
+    # (128/256 compile fine). Route large tiles to the batched PyTorch Sinkhorn
+    # (identical algorithm). Flush is infrequent + off the decode hot path, so the
+    # cost is fine; head_dim<=256 keeps the fast kernel.
+
+    if 256 < max(R, C) <= 512 and min(R, C) <= 128:
+        return _sinkhorn_tiled(tiles, iterations)
+
+    if max(R, C) > 256:
+        from vllm.model_executor.layers.quantization.kvarn.sinkhorn import (
+            variance_normalize_batched,
+        )
+
+        bal, s_col_b, s_row_b = variance_normalize_batched(tiles, iterations=iterations)
+        return (
+            bal.contiguous(),
+            s_col_b.reshape(N, C).contiguous(),
+            s_row_b.reshape(N, R).contiguous(),
+        )
+
+    balanced = torch.empty(N, R, C, dtype=torch.float32, device=device)
+    s_col = torch.empty(N, C, dtype=torch.float32, device=device)
+    s_row = torch.empty(N, R, dtype=torch.float32, device=device)
+
+    _sinkhorn_log_kernel[(N,)](
+        tiles,
+        balanced,
+        s_col,
+        s_row,
+        tiles.stride(0),
+        tiles.stride(1),
+        balanced.stride(0),
+        balanced.stride(1),
+        s_col.stride(0),
+        s_row.stride(0),
+        R=R,
+        C=C,
+        ITERATIONS=iterations,
+        CLIP_STD_MIN=_CLIP_STD_MIN,
+        CLIP_STD_MAX=_CLIP_STD_MAX,
+        LOG_S_MIN=_LOG_S_MIN,
+        LOG_S_MAX=_LOG_S_MAX,
+        # num_warps=8, not 4: the program keeps the whole [R, C] fp32 tile (plus
+        # a working copy) live, so at 4 warps the per-thread footprint is several
+        # KB of registers -> the compiler spills to CUDA local memory, and the
+        # driver permanently reserves local_bytes x max_threads x num_SMs of
+        # device memory for the context (~2 GiB on a 188-SM part for the
+        # [256, 128] tile; a missing-KV-capacity component). 8 warps
+        # halves the per-thread footprint: ~70% less reserved local memory AND
+        # ~4x faster flush (the spills were also the kernel's bottleneck).
+        # Balanced-tile output is unchanged within fp32 reduction noise (~5e-7
+        # rel); 16 warps saves a bit more memory but is 2x slower than 8.
+        num_warps=8,
+        num_stages=2,
+    )
+    return balanced, s_col, s_row

--- a/vllm/v1/attention/ops/xpu_mla_sparse.py
+++ b/vllm/v1/attention/ops/xpu_mla_sparse.py
@@ -40,6 +40,8 @@ def _bf16_mla_sparse_kernel(
     BLOCK_DV: tl.constexpr,  # block size for dim_v
     BLOCK_DMODEL: tl.constexpr,  # block size for dim_nope
     BLOCK_DPE: tl.constexpr,  # block size for positional embedding
+    RETURN_LSE: tl.constexpr,
+    RETURN_MAX_LOGITS: tl.constexpr,
     LOGE2: tl.constexpr,
 ):
     cur_q = tl.program_id(0)
@@ -154,9 +156,10 @@ def _bf16_mla_sparse_kernel(
     # rescaling
     acc /= e_sum[:, None]
 
-    max_logits = e_max * LOGE2
-    # calculate lse
-    lse = max_logits + tl.log2(e_sum) * LOGE2
+    if RETURN_LSE or RETURN_MAX_LOGITS:
+        max_logits = e_max * LOGE2
+    if RETURN_LSE:
+        lse = max_logits + tl.log2(e_sum) * LOGE2
 
     # write output
     offs_o = (
@@ -172,8 +175,10 @@ def _bf16_mla_sparse_kernel(
     )
 
     offs_lse = cur_q * stride_lse + cur_head
-    tl.store(softmax_lse_ptr + offs_lse, lse, mask=mask_h)
-    tl.store(max_logits_ptr + offs_lse, max_logits, mask=mask_h)
+    if RETURN_LSE:
+        tl.store(softmax_lse_ptr + offs_lse, lse, mask=mask_h)
+    if RETURN_MAX_LOGITS:
+        tl.store(max_logits_ptr + offs_lse, max_logits, mask=mask_h)
 
 
 # reference implementation of bf16 sparse prefill kernel
@@ -185,10 +190,12 @@ def triton_bf16_mla_sparse_interface(
     d_v: int = 512,
     block_dpe: int = 64,
     out: torch.Tensor | None = None,
+    return_lse: bool = True,
+    return_max_logits: bool = True,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """
-    out : [num_tokens, num_heads_q, d_v]; when passed in, it is zeroed and
-        written directly (avoids a caller-side copy).
+    out : [num_tokens, num_heads_q, d_v]; when passed in, it is fully
+        overwritten directly (avoids a caller-side allocation and copy).
     max_logits : [num_tokens, num_heads_q]
     lse : logsumexp, [num_tokens, num_heads_q]
 
@@ -237,12 +244,16 @@ def triton_bf16_mla_sparse_interface(
         assert out.dtype == q.dtype, (
             f"out dtype {out.dtype} must match q dtype {q.dtype}"
         )
-        out.zero_()
-    softmax_lse = torch.zeros(
-        (num_tokens, num_heads_q), dtype=torch.float32, device=q.device
+    aux_shape = (num_tokens, num_heads_q)
+    softmax_lse = torch.empty(
+        aux_shape if return_lse else (1,),
+        dtype=torch.float32,
+        device=q.device,
     )
-    max_logits = torch.zeros(
-        (num_tokens, num_heads_q), dtype=torch.float32, device=q.device
+    max_logits = torch.empty(
+        aux_shape if return_max_logits else (1,),
+        dtype=torch.float32,
+        device=q.device,
     )
 
     k = kv
@@ -282,6 +293,8 @@ def triton_bf16_mla_sparse_interface(
         BLOCK_DMODEL=BLOCK_DMODEL,
         BLOCK_DPE=BLOCK_DPE,
         LOGE2=LOGE2,
+        RETURN_LSE=return_lse,
+        RETURN_MAX_LOGITS=return_max_logits,
     )
 
     return out, max_logits, softmax_lse

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -24,6 +24,8 @@ from vllm.v1.kv_cache_interface import (
     ChunkedLocalAttentionSpec,
     FullAttentionSpec,
     HiddenStateCacheSpec,
+    KVarNFullAttentionSpec,
+    KVarNSlidingWindowSpec,
     KVCacheConfig,
     KVCacheGroupSpec,
     KVCacheSpec,
@@ -1011,6 +1013,102 @@ def may_override_num_blocks(vllm_config: VllmConfig, num_blocks: int) -> int:
     return num_blocks
 
 
+def _get_kvarn_mla_workspace_config(
+    kv_cache_groups: list[KVCacheGroupSpec],
+) -> Any | None:
+    """Return the one shared MLA workspace geometry used by this worker."""
+    kvarn_specs: list[MLAAttentionSpec] = []
+    for group in kv_cache_groups:
+        group_spec = group.kv_cache_spec
+        specs: Iterable[KVCacheSpec]
+        if isinstance(group_spec, UniformTypeKVCacheSpecs):
+            specs = group_spec.kv_cache_specs.values()
+        else:
+            specs = (group_spec,)
+        kvarn_specs.extend(
+            spec
+            for spec in specs
+            if isinstance(spec, MLAAttentionSpec)
+            and spec.cache_dtype_str == "kvarn_mla_k5_g64"
+        )
+
+    if not kvarn_specs:
+        return None
+    from vllm.model_executor.layers.quantization.kvarn.config import KVarNMLAConfig
+
+    geometries: dict[tuple[Any, ...], KVarNMLAConfig] = {}
+    for spec in kvarn_specs:
+        assert spec.cache_dtype_str is not None
+        config = KVarNMLAConfig.from_cache_dtype(spec.cache_dtype_str)
+        geometry = (
+            spec.block_size,
+            spec.num_kv_heads,
+            spec.head_size,
+            spec.dtype,
+            config.group,
+            config.latent_dim,
+            config.rope_dim,
+            config.bits,
+        )
+        geometries.setdefault(geometry, config)
+
+    if len(geometries) != 1:
+        raise ValueError(
+            "A local worker cannot share one KVarN MLA workspace across "
+            f"multiple incompatible cache geometries: {tuple(geometries)}"
+        )
+    return next(iter(geometries.values()))
+
+
+def _get_kvarn_mla_num_blocks(
+    vllm_config: VllmConfig,
+    kv_cache_groups: list[KVCacheGroupSpec],
+    available_memory: int,
+    packed_bytes_per_block: int,
+) -> int | None:
+    """Solve packed-cache plus shared-workspace capacity, if MLA KVarN is used."""
+    config = _get_kvarn_mla_workspace_config(kv_cache_groups)
+    if config is None:
+        return None
+
+    def required_memory(num_pages: int) -> int:
+        workspace_bytes = config.workspace_envelope(vllm_config, num_pages).total_bytes
+        return packed_bytes_per_block * num_pages + workspace_bytes
+
+    override = vllm_config.cache_config.num_gpu_blocks_override
+    if override is not None:
+        if override <= 0:
+            return override
+        required_bytes = required_memory(override)
+        if required_bytes > available_memory:
+            raise ValueError(
+                f"num_gpu_blocks_override={override} requires {required_bytes} "
+                "bytes for packed KVarN MLA cache pages and the shared workspace, "
+                f"but only {available_memory} bytes are available"
+            )
+        return override
+
+    max_pages_without_workspace = max(
+        int(available_memory // packed_bytes_per_block), 0
+    )
+    if max_pages_without_workspace == 0:
+        return 0
+
+    def fits(num_pages: int) -> bool:
+        return required_memory(num_pages) <= available_memory
+
+    if not fits(1):
+        return 0
+    low, high = 1, max_pages_without_workspace
+    while low < high:
+        mid = (low + high + 1) // 2
+        if fits(mid):
+            low = mid
+        else:
+            high = mid - 1
+    return low
+
+
 def _pool_bytes_per_block(
     vllm_config: VllmConfig, kv_cache_groups: list[KVCacheGroupSpec]
 ) -> int:
@@ -1148,6 +1246,19 @@ def unify_kv_cache_spec_page_size(
             new_spec: KVCacheSpec = replace(
                 layer_spec, page_size_padded=target_page_size
             )
+            assert new_spec.page_size_bytes == target_page_size
+            new_kv_cache_spec[layer_name] = new_spec
+        elif isinstance(layer_spec, (KVarNFullAttentionSpec, KVarNSlidingWindowSpec)):
+            real_page_size = layer_spec.real_page_size_bytes
+            if target_page_size % real_page_size == 0:
+                ratio = target_page_size // real_page_size
+                new_spec = replace(
+                    layer_spec,
+                    block_size=layer_spec.block_size * ratio,
+                    page_size_padded=None,
+                )
+            else:
+                new_spec = replace(layer_spec, page_size_padded=target_page_size)
             assert new_spec.page_size_bytes == target_page_size
             new_kv_cache_spec[layer_name] = new_spec
         else:
@@ -1484,7 +1595,14 @@ def _get_kv_cache_config_packed(
     ):
         tensor_slots = _get_lockstep_mla_tensor_slots(kv_cache_groups)
         total_num_bytes_per_block = sum(page_size for page_size, _ in tensor_slots)
-        num_blocks = available_memory // total_num_bytes_per_block
+        num_blocks = _get_kvarn_mla_num_blocks(
+            vllm_config,
+            kv_cache_groups,
+            available_memory,
+            total_num_bytes_per_block,
+        )
+        if num_blocks is None:
+            num_blocks = available_memory // total_num_bytes_per_block
         num_blocks = may_override_num_blocks(vllm_config, num_blocks)
         return num_blocks, [
             KVCacheTensor(size=page_size * num_blocks, shared_by=slot)
@@ -1493,7 +1611,14 @@ def _get_kv_cache_config_packed(
 
     block_stride, layers_by_offset = _get_packed_kv_cache_layout(kv_cache_groups)
 
-    num_blocks = available_memory // block_stride
+    num_blocks = _get_kvarn_mla_num_blocks(
+        vllm_config,
+        kv_cache_groups,
+        available_memory,
+        block_stride,
+    )
+    if num_blocks is None:
+        num_blocks = available_memory // block_stride
     num_blocks = may_override_num_blocks(vllm_config, num_blocks)
 
     total_size = block_stride * num_blocks
@@ -1544,9 +1669,12 @@ def get_kv_cache_config_from_groups(
         # Special case: all layers have the same type of KV cache but with
         # different hidden sizes. Allocate different amount of memory for each
         # layer based on its hidden size.
-        num_blocks = (
-            available_memory // kv_cache_groups[0].kv_cache_spec.page_size_bytes
+        bytes_per_block = kv_cache_groups[0].kv_cache_spec.page_size_bytes
+        num_blocks = _get_kvarn_mla_num_blocks(
+            vllm_config, kv_cache_groups, available_memory, bytes_per_block
         )
+        if num_blocks is None:
+            num_blocks = available_memory // bytes_per_block
         num_blocks = may_override_num_blocks(vllm_config, num_blocks)
         per_layer_specs = kv_cache_groups[0].kv_cache_spec.kv_cache_specs
         kv_cache_tensors = [
@@ -1577,9 +1705,18 @@ def get_kv_cache_config_from_groups(
             [group.kv_cache_spec for group in kv_cache_groups]
         )
         assert group_size > 0, "group_size must be greater than 0"
-        num_blocks = get_num_blocks(
-            vllm_config, group_size, available_memory, page_size
+        num_blocks = _get_kvarn_mla_num_blocks(
+            vllm_config,
+            kv_cache_groups,
+            available_memory,
+            page_size * group_size,
         )
+        if num_blocks is None:
+            num_blocks = get_num_blocks(
+                vllm_config, group_size, available_memory, page_size
+            )
+        else:
+            num_blocks = may_override_num_blocks(vllm_config, num_blocks)
         kv_cache_tensors = []
         for i in range(group_size):
             shared_by = []
@@ -2265,6 +2402,23 @@ def _max_memory_usage_bytes_from_groups(
     return group_size * page_size * blocks_needed
 
 
+def _max_memory_usage_with_kvarn_mla_workspace(
+    vllm_config: VllmConfig,
+    kv_cache_groups: list[KVCacheGroupSpec],
+) -> int:
+    packed_bytes = _max_memory_usage_bytes_from_groups(vllm_config, kv_cache_groups)
+    workspace_config = _get_kvarn_mla_workspace_config(kv_cache_groups)
+    if workspace_config is None or packed_bytes == 0:
+        return packed_bytes
+    required_pages = cdiv(
+        packed_bytes, _pool_bytes_per_block(vllm_config, kv_cache_groups)
+    )
+    return (
+        packed_bytes
+        + workspace_config.workspace_envelope(vllm_config, required_pages).total_bytes
+    )
+
+
 def _estimate_max_model_len_from_groups(
     vllm_config: VllmConfig,
     kv_cache_groups: list[KVCacheGroupSpec],
@@ -2279,7 +2433,7 @@ def _estimate_max_model_len_from_groups(
     def fits(model_len: int) -> bool:
         vllm_config.model_config.max_model_len = model_len
         return (
-            _max_memory_usage_bytes_from_groups(vllm_config, kv_cache_groups)
+            _max_memory_usage_with_kvarn_mla_workspace(vllm_config, kv_cache_groups)
             <= available_memory
         )
 
@@ -2471,12 +2625,10 @@ def get_kv_cache_configs(
         for worker_spec in kv_cache_specs
     ]
 
-    # If `num_gpu_blocks_override` is set, the cache size that will actually
-    # be allocated is decoupled from the profiled `available_memory`:
-    # `may_override_num_blocks` in `get_kv_cache_config_from_groups` clamps
-    # `num_blocks` to the override. Reflect that in `available_memory` here so
-    # auto-fit, the admission check, and the per-worker config builder all
-    # plan against the same effective capacity.
+    # An override defines the effective cache capacity used by auto-fit,
+    # admission, and tensor planning. KVarN MLA still validates that its packed
+    # pages plus the separately allocated shared workspace fit the profiled
+    # per-worker allocation before replacing it with this effective capacity.
     override = vllm_config.cache_config.num_gpu_blocks_override
     if override is not None:
         adjusted_memory: list[int] = []
@@ -2499,7 +2651,20 @@ def get_kv_cache_configs(
                 profiled_num_blocks,
                 override,
             )
-            adjusted_memory.append(override * bytes_per_block)
+            effective_memory = override * bytes_per_block
+            workspace_config = _get_kvarn_mla_workspace_config(groups)
+            if workspace_config is not None and override > 0:
+                effective_memory += workspace_config.workspace_envelope(
+                    vllm_config, override
+                ).total_bytes
+                if effective_memory > avail_mem:
+                    raise ValueError(
+                        f"num_gpu_blocks_override={override} requires "
+                        f"{effective_memory} bytes for packed KVarN MLA cache "
+                        "pages and the shared workspace, but only "
+                        f"{avail_mem} bytes are available"
+                    )
+            adjusted_memory.append(effective_memory)
         available_memory = adjusted_memory
 
     if vllm_config.model_config.original_max_model_len == -1:
@@ -2513,7 +2678,11 @@ def get_kv_cache_configs(
             continue
         _check_enough_kv_cache_memory(
             avail_mem,
-            partial(_max_memory_usage_bytes_from_groups, vllm_config, groups),
+            partial(
+                _max_memory_usage_with_kvarn_mla_workspace,
+                vllm_config,
+                groups,
+            ),
             vllm_config.model_config.max_model_len,
             partial(_estimate_max_model_len_from_groups, vllm_config, groups),
         )

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -20,6 +20,8 @@ from vllm.v1.kv_cache_interface import (
     CrossAttentionSpec,
     FullAttentionSpec,
     HiddenStateCacheSpec,
+    KVarNFullAttentionSpec,
+    KVarNSlidingWindowSpec,
     KVCacheSpec,
     MambaSpec,
     MLAAttentionSpec,
@@ -95,6 +97,7 @@ class SingleTypeKVCacheManager(ABC):
         self._record_new_block_ids = needs_kv_cache_zeroing and type(kv_cache_spec) in (
             FullAttentionSpec,
             TQFullAttentionSpec,
+            KVarNFullAttentionSpec,
             MLAAttentionSpec,
             HiddenStateCacheSpec,
         )
@@ -1945,6 +1948,11 @@ def register_all_kvcache_specs(vllm_config):
         SlidingWindowManager,
         uniform_type_base_spec=SlidingWindowMLASpec,
     )
+    KVCacheSpecRegistry.register(
+        KVarNSlidingWindowSpec,
+        SlidingWindowManager,
+        uniform_type_base_spec=KVarNSlidingWindowSpec,
+    )
 
     KVCacheSpecRegistry.register(
         MambaSpec, MambaManager, uniform_type_base_spec=MambaSpec
@@ -1963,6 +1971,11 @@ def register_all_kvcache_specs(vllm_config):
     # FullAttentionSpec subclasses — grouped with FullAttentionSpec
     KVCacheSpecRegistry.register(
         TQFullAttentionSpec,
+        FullAttentionManager,
+        uniform_type_base_spec=FullAttentionSpec,
+    )
+    KVCacheSpecRegistry.register(
+        KVarNFullAttentionSpec,
         FullAttentionManager,
         uniform_type_base_spec=FullAttentionSpec,
     )

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -466,6 +466,39 @@ class TQFullAttentionSpec(FullAttentionSpec):
 
 
 @dataclass(frozen=True, kw_only=True)
+class KVarNFullAttentionSpec(FullAttentionSpec):
+    """Full-attention spec with group-sized KVarN tiles."""
+
+    tile_size: int = 0
+    quant_group_size: int = 64
+
+    @property
+    def real_page_size_bytes(self) -> int:
+        if self.tile_size > 0:
+            return (
+                self.num_kv_heads
+                * self.tile_size
+                * (self.block_size // self.quant_group_size)
+            )
+        return super().real_page_size_bytes
+
+    @classmethod
+    def merge(cls, specs: list[Self]) -> Self:
+        merged = super().merge(specs)
+        assert all(spec.tile_size == specs[0].tile_size for spec in specs), (
+            "All KVarN layers in one cache group must use the same tile size."
+        )
+        assert all(
+            spec.quant_group_size == specs[0].quant_group_size for spec in specs
+        ), "All KVarN layers in one cache group must use the same quantization group."
+        return replace(
+            merged,
+            tile_size=specs[0].tile_size,
+            quant_group_size=specs[0].quant_group_size,
+        )
+
+
+@dataclass(frozen=True, kw_only=True)
 class MLAAttentionSpec(FullAttentionSpec):
     # TODO(Lucas/Chen): less hacky way to do this
     cache_dtype_str: str | None = None
@@ -486,6 +519,18 @@ class MLAAttentionSpec(FullAttentionSpec):
 
     @property
     def real_page_size_bytes(self) -> int:
+        if self.cache_dtype_str == "kvarn_mla_k5_g64":
+            from vllm.model_executor.layers.quantization.kvarn.config import (
+                KVarNMLAConfig,
+            )
+
+            config = KVarNMLAConfig.from_cache_dtype(self.cache_dtype_str)
+            if self.block_size != config.group:
+                raise ValueError(
+                    "MLA KVarN requires block_size "
+                    f"{config.group}, got {self.block_size}."
+                )
+            return config.tile_bytes
         if self.cache_dtype_str == "nvfp4_ds_mla":
             # NVFP4 MLA latent: 432 B/token (256B E2M1 NoPE + 32B E4M3 group-16
             # scales + 16B pad + 128B BF16 RoPE). Same record for the
@@ -736,6 +781,36 @@ class SlidingWindowSpec(AttentionSpec):
             isinstance(spec, SlidingWindowSpec)
             and spec.sliding_window == self.sliding_window
             and spec.dcp_replicated == self.dcp_replicated
+            for spec in kv_cache_specs.values()
+        )
+
+
+@dataclass(frozen=True, kw_only=True)
+class KVarNSlidingWindowSpec(SlidingWindowSpec):
+    """Sliding-window spec with group-sized KVarN tiles."""
+
+    tile_size: int = 0
+    quant_group_size: int = 64
+
+    @property
+    def real_page_size_bytes(self) -> int:
+        if self.tile_size > 0:
+            return (
+                self.num_kv_heads
+                * self.tile_size
+                * (self.block_size // self.quant_group_size)
+            )
+        return super().real_page_size_bytes
+
+    def is_uniform_with_collection(
+        self, kv_cache_specs: dict[str, KVCacheSpec]
+    ) -> bool:
+        return all(
+            isinstance(spec, KVarNSlidingWindowSpec)
+            and spec.sliding_window == self.sliding_window
+            and spec.dcp_replicated == self.dcp_replicated
+            and spec.tile_size == self.tile_size
+            and spec.quant_group_size == self.quant_group_size
             for spec in kv_cache_specs.values()
         )
 

--- a/vllm/v1/worker/ubatch_utils.py
+++ b/vllm/v1/worker/ubatch_utils.py
@@ -246,6 +246,7 @@ def _make_metadata_with_slice(
         seq_lens_cpu_upper_bound=seq_lens_cpu_upper_bound,
         _seq_lens_cpu=seq_lens_cpu,
         _num_computed_tokens_cpu=num_computed_tokens_cpu,
+        kvarn_mla_block_fills=attn_metadata.kvarn_mla_block_fills,
     )
 
 


### PR DESCRIPTION
## What

The KVarN execution layer, on top of PR #<kvarn-cache-formats>:

- Triton kernels: `ops/kvarn_store.py` (pack K/KV into group-normalized
  low-bit records + FP8 live/boundary side storage), `ops/kvarn_mla.py`
  (stage/gather/remap the page arena; `stage_physical_kvarn_mla_fp8` stages
  records through `b12x.attention.kvarn_mla.stage_k5_as_fp8_records` — the
  single external-package touchpoint, lazy import with a fail-closed error),
  `ops/triton_kvarn_decode.py` (adaptive-split decode attention),
  `ops/triton_kvarn_sinkhorn.py` (iterative variance normalization),
  `ops/cutedsl_kvarn_decode.py` (SM120 CuteDSL decode variant, capability-
  gated), `ops/kvarn_decode.py` (bit unpack + Hadamard helpers).
- `backends/kvarn_attn.py`: the standard (non-MLA) KVARN backend with the
  precision-tail pool lifecycle; registered in the backend priority tables
  (docs table updated).
- `backends/mla/kvarn_mla_state.py`: live/pending/resolved exact-block
  bookkeeping shared between the runner and the B12X impl.
- `b12x_mla_sparse.py`: serve `kvarn_mla_k5_g64` on B12X_MLA_SPARSE — packed
  geometry, `_validate_dcp_prefill_workspace_contract` (fail-closed whitelist
  of validated TP/DCP topologies {4,4},{6,2},{6,3},{6,6},{8,2},{8,4},{8,8} and
  geometry: q_head_dim 576 / kv_lora_rank 512 / v_head_dim 256), KVarN excluded
  from CKV gather, and routed prefill always through the packed MQA path.
- `platforms/cuda.py`: fail-closed config validation — prefix caching, KV
  offloading, KV transfer, DBO, mixed dtypes rejected; MLA KVarN requires
  B12X_MLA_SPARSE + block 64; native speculation requires the draft to declare
  the same backend/dtype; standard KVarN requires head_dim ∈ {128,256,512} and
  reports itself unsupported on the v2 model runner.
- `CommonAttentionMetadata.kvarn_mla_block_fills` (default None) survives
  unpadded() and split_attn_metadata().

## Why + evidence (measured, our rig: 5× RTX PRO 6000 Blackwell, GLM-5.2
EXL3-TR3 3.40 bpw)

The published checkpoint serves on this stack (records under
glm52-shared-h-current/runs/, JSON):

- Packed-path CUDA parity: `kvarn-k4-native-parity/report.json` —
  `direct_packed_kvarn_mla_real_cuda_parity` PASS (seed 20260801), including
  fail-closed rejection of unsupported geometry
  ("native K5 decode requires M1/M4/M16, H64, D576").
- Self-describing dtype parse (CPU, no GPU needed):
  `dtype-selfdescribing-parse-cpu/manifest.json` — all stages passed.
- Serving decode (C1, sustained 30 s windows):
  `full-expert-340-compact-kvarn-c1-32k-matched-speed.json` → 101.0 tok/s @32K;
  `full-expert-340-k5-matched-c1-throughput.json` → 76.6/85.2/88.2/89.8 tok/s
  @0/8K/32K/128K.
- Final packaged state (findings.md 2026-08-17/18): decode 86-87 tps C1,
  AL 2.84-2.94, prefill 32K ≈ 2,345 tok/s, 819K-token context proven at 3.40
  bpw with KLD 0.0558 — the KVarN packed cache is what fits that context.

## Not duplicating an existing PR

#249 (deepseek_v2 per-layer expert widths + exl3.py), #297 (exl3 K2 bitrate),
#240 (qwen3_5 EXL3 loading): zero overlap — this PR touches no model loader,
no exl3.py, no qwen3_5. The merged II EXL3 commits own the Trellis/MoE side;
KVarN is the KV-cache side and is absent from II today. b12x package internals
(reader kernels) live in a paired b12x PR (lukealonso/b12x `kvarn/native-reader`);
this PR contains only the vllm-side glue and will fail closed (clear RuntimeError)
until that package provides `b12x.attention.kvarn_mla`.

## Tests

New: `tests/v1/attention/test_kvarn.py` (33 tests — packing/unpacking, store,
decode, sinkhorn vs NumPy reference, metadata unpadding/ubatching, capability
gates; CUDA-marked where kernels run), `tests/v1/attention/test_kvarn_v2.py`
(8 tests), `tests/config/test_kvarn_v2_config.py` (15 tests — platform gate
admits sync+async native draft, ngram without draft cache, rejects each
unsupported feature).

Run on the ported tree:

    pytest tests/v1/attention/test_kvarn.py tests/v1/attention/test_kvarn_v2.py \
           tests/config/test_kvarn_v2_config.py tests/v1/core/test_kv_cache_utils.py -q
    → 162 passed   (GPU: SM120; Triton kernels JIT-compiled in-run)

Model evaluation: KLD panel for the published checkpoint (dtype-cutover study)
is in the model assets; serving numbers above are from the same stack.

## AI assistance

Ported and adapted to dev/infernal-invocation by an AI agent (Claude Opus 4.5)
under human direction from battle-tested fork commits; attribution in commit
trailers.
```

### Diffstat

```
 tests/config/test_kvarn_v2_config.py               |  135 +
 tests/v1/attention/test_kvarn.py                   |  873 ++++++++++
 tests/v1/attention/test_kvarn_v2.py                |  290 ++++
 vllm/config/vllm.py                                |    8 +
 vllm/model_executor/layers/attention/attention.py  |   41 +-
 .../layers/attention/mla_attention.py              |   10 +-
 .../layers/sparse_attn_indexer.py                  |   22 +-
 vllm/platforms/cuda.py                             |  119 +
 vllm/v1/attention/backend.py                       |    4 +
 vllm/v1/attention/backends/kvarn_attn.py           | 2774 +++++++++++++
 vllm/v1/attention/backends/mla/b12x_mla_sparse.py  |  585 ++--
 vllm/v1/attention/backends/mla/kvarn_mla_state.py  |  464 ++++
 vllm/v1/attention/backends/registry.py             |    1 +
 vllm/v1/attention/ops/cutedsl_kvarn_decode.py      |  577 ++++
 vllm/v1/attention/ops/kvarn_decode.py              |  143 +
 vllm/v1/attention/ops/kvarn_mla.py                 |  711 ++++
 vllm/v1/attention/ops/kvarn_store.py               |  340 ++++
 vllm/v1/attention/ops/triton_kvarn_decode.py       | 1602 ++++++++++
 vllm/v1/attention/ops/triton_kvarn_sinkhorn.py     |  482 ++++
 vllm/v1/attention/ops/xpu_mla_sparse.py            |   37 +-
 vllm/v1/worker/ubatch_utils.py                     |    1 +
 docs/design/attention_backends.md                  |    7 +
 21 files changed, 9163 insertions(+), 56 deletions(-)
```

---

---
**Depends on:**
- #424 (KVarN cache formats) — this branch is stacked on it. Until #424 merges, the diff below shows both PRs; the PR-only delta is `pr-ii/kvarn-cache-formats..pr-ii/kvarn-mla-backend`.
- lukealonso/b12x#231 (KVarN packed-latent staging + native reader) — runtime dependency; fails closed with a clear RuntimeError until that lands.