### PR TITLE
[II] Materialize Kimi-K3 interleaved MLA decode queries

### DIFF
--- a/tests/kernels/test_safe_mla_query_bmm.py
+++ b/tests/kernels/test_safe_mla_query_bmm.py
@@ -75,3 +75,33 @@ def test_safe_mla_query_bmm_cuda_graph_replay():
     expected = torch.bmm(query.contiguous(), weight)
 
     torch.testing.assert_close(output.float(), expected.float(), rtol=5e-2, atol=5e-2)
+
+
+def test_safe_mla_query_bmm_kimi_materialized_query():
+    _require_safe_mla_query_bmm()
+    device = torch.device("cuda")
+    heads = 6
+    tokens = 14
+    q_dim = 128
+    latent_dim = 512
+    torch.manual_seed(2)
+
+    query_storage = torch.randn(
+        tokens, heads, q_dim + 64, dtype=torch.bfloat16, device=device
+    )
+    interleaved_query = query_storage[..., :q_dim].transpose(0, 1)
+    query = interleaved_query.contiguous()
+    weight = torch.randn(heads, q_dim, latent_dim, dtype=torch.bfloat16, device=device)
+    output = torch.empty(heads, tokens, latent_dim, dtype=torch.bfloat16, device=device)
+
+    assert not interleaved_query.is_contiguous()
+    assert query.is_contiguous()
+    torch.ops._C.safe_mla_query_bmm(query, weight, output)
+    expected = torch.bmm(query, weight)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        torch.ops._C.safe_mla_query_bmm(query, weight, output)
+    graph.replay()
+
+    torch.testing.assert_close(output.float(), expected.float(), rtol=5e-2, atol=5e-2)

--- a/tests/models/kimi_k3/test_mla_padding.py
+++ b/tests/models/kimi_k3/test_mla_padding.py
@@ -6,6 +6,64 @@ from types import SimpleNamespace
 import torch
 
 
+def test_kimi_mla_absorbed_weight_preallocation_uses_local_heads():
+    from vllm.model_executor.layers.attention.mla_attention import (
+        _preallocate_absorbed_mla_weights,
+    )
+
+    projection = torch.nn.Module()
+    projection.weight = torch.nn.Parameter(torch.empty((1, 1)))
+    attention = SimpleNamespace(
+        num_heads=96,
+        num_local_heads=6,
+        kv_lora_rank=512,
+        qk_nope_head_dim=128,
+        v_head_dim=128,
+        kv_b_proj=projection,
+    )
+
+    w_uv, w_uk_t = _preallocate_absorbed_mla_weights(attention, torch.bfloat16)
+
+    assert w_uv is not None
+    assert w_uk_t is not None
+    assert w_uv.shape == (6, 512, 128)
+    assert w_uk_t.shape == (6, 128, 512)
+    assert w_uv.is_contiguous()
+    assert w_uk_t.is_contiguous()
+
+
+def test_kimi_mla_decode_query_materializes_interleaved_heads(monkeypatch):
+    from vllm.models.kimi_k3.nvidia import mla
+
+    attention = object.__new__(mla.MultiHeadLatentAttention)
+    torch.nn.Module.__init__(attention)
+    attention.kv_lora_rank = 5
+    attention.W_UK_T = torch.nn.Parameter(
+        torch.randn((2, 3, 5), dtype=torch.bfloat16), requires_grad=False
+    )
+    query_storage = torch.randn((4, 2, 7), dtype=torch.bfloat16)
+    query = query_storage[..., :3]
+    calls = []
+
+    def safe_bmm(q, weight, output, *, use_safe_op):
+        calls.append((q, weight, use_safe_op))
+        torch.bmm(q.contiguous(), weight, out=output)
+
+    monkeypatch.setattr(mla, "_run_mla_query_bmm", safe_bmm)
+
+    result = attention._absorb_decode_query(query)
+
+    assert len(calls) == 1
+    captured_query, captured_weight, use_safe_op = calls[0]
+    assert captured_query.data_ptr() != query.data_ptr()
+    assert captured_query.shape == query.transpose(0, 1).shape
+    assert captured_query.is_contiguous()
+    assert captured_weight is attention.W_UK_T
+    assert use_safe_op is True
+    expected = torch.bmm(query.transpose(0, 1).contiguous(), attention.W_UK_T)
+    torch.testing.assert_close(result, expected.transpose(0, 1))
+
+
 def test_kimi_mla_defines_graph_padding_before_output_projection(monkeypatch):
     from vllm.models.kimi_k3.nvidia import mla
 

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -419,9 +419,12 @@ def _preallocate_absorbed_mla_weights(
         RuntimeError: If neither the source projection nor reusable absorbed
             weights identify the target device.
     """
-    w_uv_shape = (layer.num_heads, layer.kv_lora_rank, layer.v_head_dim)
+    # Model-specific MLA wrappers may retain the global head count while their
+    # absorbed projection is tensor-parallel and therefore uses local heads.
+    num_heads = getattr(layer, "num_local_heads", layer.num_heads)
+    w_uv_shape = (num_heads, layer.kv_lora_rank, layer.v_head_dim)
     w_uk_t_shape = (
-        layer.num_heads,
+        num_heads,
         layer.qk_nope_head_dim,
         layer.kv_lora_rank,
     )

--- a/vllm/models/kimi_k3/nvidia/mla.py
+++ b/vllm/models/kimi_k3/nvidia/mla.py
@@ -52,6 +52,10 @@ from vllm.model_executor.layers.attention.attention import (
     set_default_quant_scales,
     should_load_quant_weights,
 )
+from vllm.model_executor.layers.attention.mla_attention import (
+    _preallocate_absorbed_mla_weights,
+    _run_mla_query_bmm,
+)
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import (
@@ -526,6 +530,7 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
         projected into latent space by ``W_UK_T`` and the attention output is
         projected back to ``v`` by ``W_UV`` -- avoiding materializing full K/V.
         """
+        pre_w_uv, pre_w_uk_t = _preallocate_absorbed_mla_weights(self, act_dtype)
         kv_b_proj_weight = get_and_maybe_dequant_weights(
             self.kv_b_proj, out_dtype=act_dtype
         ).T
@@ -542,9 +547,17 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
             [self.qk_nope_head_dim, self.v_head_dim], dim=-1
         )
         # (L, N, V) -> (N, L, V)
-        replace_parameter(self, "W_UV", W_UV.transpose(0, 1), prefer_copy=True)
+        w_uv = W_UV.transpose(0, 1)
+        if pre_w_uv is not None:
+            pre_w_uv.copy_(w_uv)
+            w_uv = pre_w_uv
+        replace_parameter(self, "W_UV", w_uv, prefer_copy=True)
         # (L, N, P) -> (N, P, L)
-        replace_parameter(self, "W_UK_T", W_UK.permute(1, 2, 0), prefer_copy=True)
+        w_uk_t = W_UK.permute(1, 2, 0)
+        if pre_w_uk_t is not None:
+            pre_w_uk_t.copy_(w_uk_t)
+            w_uk_t = pre_w_uk_t
+        replace_parameter(self, "W_UK_T", w_uk_t, prefer_copy=True)
 
         quant_method = (
             self.quant_config.get_quant_method(self, prefix=self.layer_name)
@@ -572,6 +585,25 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
         out = out.view(-1, self.num_local_heads, self.v_head_dim)
         # (N, B, L) x (N, L, V) -> (N, B, V) written transposed into (B, N, V)
         torch.bmm(x, self.W_UV, out=out.transpose(0, 1))
+
+    def _absorb_decode_query(self, q_nope: torch.Tensor) -> torch.Tensor:
+        """Project the Kimi decode query into MLA latent space.
+
+        The NoPE component is an interleaved head view of the combined
+        NoPE/RoPE projection. Tensor-core cuBLAS batched-GEMM algorithms may
+        issue vector reads beyond the logical matrix when the batch stride is
+        smaller than a matrix's storage span. Materializing head-major storage
+        gives every batch matrix an independent contiguous range.
+        """
+        query = q_nope.transpose(0, 1).contiguous()
+        output = query.new_empty((query.shape[0], query.shape[1], self.kv_lora_rank))
+        _run_mla_query_bmm(
+            query,
+            self.W_UK_T,
+            output,
+            use_safe_op=True,
+        )
+        return output.transpose(0, 1)
 
     def _attn_read_kv_cache(self) -> torch.Tensor:
         """Latent cache as seen by the attention read kernels (decode / context).
@@ -760,7 +792,7 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
                 [self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1
             )
             # BMM1: absorb q_nope into latent space. (N,B,P) x (N,P,L) -> (B,N,L)
-            ql_nope = torch.bmm(mqa_q_nope.transpose(0, 1), self.W_UK_T).transpose(0, 1)
+            ql_nope = self._absorb_decode_query(mqa_q_nope)
             # Fused: concat mqa_q = [ql_nope | q_pe] and insert the decode-token
             # latent into the paged cache (one launch, right before forward_mqa).
             mqa_q = self._decode_concat_cache(


### PR DESCRIPTION
## Behavior

Kimi-K3 NVIDIA MLA decode materializes the transposed NoPE query into contiguous head-major storage before the absorbed query projection. Materialized W_UV and W_UK_T weights use contiguous tensor-parallel-local head storage.

## Technical reason

The NoPE query is an interleaved view of the combined NoPE/RoPE projection. For the TP16 decode geometry, each logical query matrix has shape [14, 128], while adjacent head matrices start only 192 BF16 elements apart. Tensor-core cuBLAS batched-GEMM implementations may vector-read past the logical matrix boundary. A native CUDA allocator page boundary exposed that read as Xid 31 and CUBLAS_STATUS_INTERNAL_ERROR.

Head-major materialization gives every batch matrix an independent contiguous allocation. The absorbed BF16 matrix multiplication and output values are unchanged.

## Compatibility

The runtime change is limited to Kimi-K3 NVIDIA MLA decode. Generic absorbed-weight allocation uses num_local_heads only when a model wrapper declares it; other models retain num_heads. B12X interfaces, DCP cache geometry, attention results, and builds without the CUDA operation are unchanged.

## Validation

- Exact BF16 geometry [6, 14, 128] x [6, 128, 512], PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False: 1,000 eager calls and 1,000 CUDA Graph replays matched the contiguous reference with zero observed absolute difference.
- Kimi MLA unit suite: 3 passed.
- Ruff check and format validation passed for all modified files.
- Official Kimi-K3 MXFP4 target with Inferact DSpark7, TP16/DCP16, B12X MLA, LMCache, prefix caching, vision enabled, native CUDA allocator: one cold 14-token request and 20 additional unique 14-token requests completed with HTTP 200.
- OMP-compatible replay: 60,922 prompt tokens and 124 completion tokens completed with HTTP 200, a terminal done event, a valid tool call, and no Kimi control markers.
- Long-context qualification: 520,002 prompt tokens followed by 64 decoded tokens completed with HTTP 200 in 646.57 seconds; output remained coherent and the server stayed healthy.
- Kernel and server logs contained no Xid, illegal-memory, or cuBLAS errors after the fix.
- A 119-token coding prompt followed by 512 decoded tokens completed in 4.43 seconds, or 115.69 decoded tokens per second end-to-end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kimi K3 MLA inference for tensor-parallel configurations with locally sharded attention heads.
  * Fixed decode-time query projection for tightly packed, non-contiguous tensor views.
  * Improved preallocated weight handling to ensure correct tensor shapes, strides, and numerical results.

* **Tests**
  * Added coverage for varied query sizes and Kimi K3 MLA weight allocation and decode projection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->