### PR TITLE
[II] Warm Kimi vision interpolation before KV allocation

### DIFF
--- a/tests/models/kimi_k3/test_vision_warmup.py
+++ b/tests/models/kimi_k3/test_vision_warmup.py
@@ -40,8 +40,16 @@ def test_warm_vision_position_interpolation_ignores_other_modules() -> None:
 def test_kimi_warmup_runs_vision_before_kda_state_exists(monkeypatch) -> None:
     model = torch.nn.Linear(2, 2)
     calls = []
-    warm_vision = Mock(side_effect=lambda model: calls.append("vision") or 1)
-    get_kda_layer = Mock(side_effect=lambda worker: calls.append("kda"))
+
+    def record_vision(_model):
+        calls.append("vision")
+        return 1
+
+    def record_kda(_worker):
+        calls.append("kda")
+
+    warm_vision = Mock(side_effect=record_vision)
+    get_kda_layer = Mock(side_effect=record_kda)
     monkeypatch.setattr(kimi_k3_triton_warmup.current_platform, "is_cuda", lambda: True)
     monkeypatch.setattr(
         kimi_k3_triton_warmup,

--- a/tests/models/kimi_k3/test_vision_warmup.py
+++ b/tests/models/kimi_k3/test_vision_warmup.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import torch
+
+from vllm.model_executor.models import kimi_k25_vit
+from vllm.model_executor.warmup import kimi_k3_triton_warmup
+from vllm.model_executor.warmup.kimi_k3_triton_warmup import (
+    _warm_vision_position_interpolation,
+)
+
+
+def test_warm_vision_position_interpolation(monkeypatch) -> None:
+    model = torch.nn.Sequential(
+        kimi_k25_vit.Learnable2DInterpPosEmbDivided_fixed(
+            height=14,
+            width=14,
+            num_frames=4,
+            dim=32,
+        )
+    )
+    get_rope_shape = Mock(return_value=torch.empty(64 * 64, 32))
+    monkeypatch.setattr(kimi_k25_vit, "get_rope_shape", get_rope_shape)
+
+    assert _warm_vision_position_interpolation(model) == 1
+    get_rope_shape.assert_called_once_with(
+        model[0].weight,
+        interpolation_mode="bicubic",
+        shape=(64, 64),
+    )
+
+
+def test_warm_vision_position_interpolation_ignores_other_modules() -> None:
+    assert _warm_vision_position_interpolation(torch.nn.Linear(2, 2)) == 0
+
+
+def test_kimi_warmup_runs_vision_before_kda_state_exists(monkeypatch) -> None:
+    model = torch.nn.Linear(2, 2)
+    warm_vision = Mock(return_value=1)
+    monkeypatch.setattr(kimi_k3_triton_warmup.current_platform, "is_cuda", lambda: True)
+    monkeypatch.setattr(
+        kimi_k3_triton_warmup,
+        "_warm_vision_position_interpolation",
+        warm_vision,
+    )
+    monkeypatch.setattr(kimi_k3_triton_warmup, "_get_kda_layer", lambda worker: None)
+
+    kimi_k3_triton_warmup.kimi_k3_triton_warmup(
+        SimpleNamespace(get_model=lambda: model)
+    )
+
+    warm_vision.assert_called_once_with(model)

--- a/tests/models/kimi_k3/test_vision_warmup.py
+++ b/tests/models/kimi_k3/test_vision_warmup.py
@@ -39,17 +39,21 @@ def test_warm_vision_position_interpolation_ignores_other_modules() -> None:
 
 def test_kimi_warmup_runs_vision_before_kda_state_exists(monkeypatch) -> None:
     model = torch.nn.Linear(2, 2)
-    warm_vision = Mock(return_value=1)
+    calls = []
+    warm_vision = Mock(side_effect=lambda model: calls.append("vision") or 1)
+    get_kda_layer = Mock(side_effect=lambda worker: calls.append("kda"))
     monkeypatch.setattr(kimi_k3_triton_warmup.current_platform, "is_cuda", lambda: True)
     monkeypatch.setattr(
         kimi_k3_triton_warmup,
         "_warm_vision_position_interpolation",
         warm_vision,
     )
-    monkeypatch.setattr(kimi_k3_triton_warmup, "_get_kda_layer", lambda worker: None)
+    monkeypatch.setattr(kimi_k3_triton_warmup, "_get_kda_layer", get_kda_layer)
 
     kimi_k3_triton_warmup.kimi_k3_triton_warmup(
         SimpleNamespace(get_model=lambda: model)
     )
 
     warm_vision.assert_called_once_with(model)
+    get_kda_layer.assert_called_once()
+    assert calls == ["vision", "kda"]

--- a/vllm/model_executor/warmup/kimi_k3_triton_warmup.py
+++ b/vllm/model_executor/warmup/kimi_k3_triton_warmup.py
@@ -18,6 +18,25 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 
+def _warm_vision_position_interpolation(model: torch.nn.Module) -> int:
+    from vllm.model_executor.models.kimi_k25_vit import (
+        Learnable2DInterpPosEmbDivided_fixed,
+        get_rope_shape,
+    )
+
+    warmed = 0
+    for module in model.modules():
+        if not isinstance(module, Learnable2DInterpPosEmbDivided_fixed):
+            continue
+        get_rope_shape(
+            module.weight,
+            interpolation_mode=module.interpolation_mode,
+            shape=(64, 64),
+        )
+        warmed += 1
+    return warmed
+
+
 def _get_kda_layer(worker: Worker) -> KimiK3DeltaAttention | None:
     from vllm.models.kimi_k3.nvidia.kda import KimiK3DeltaAttention
 
@@ -186,6 +205,15 @@ def kimi_k3_triton_warmup(worker: Worker) -> None:
     """Warm Kimi-K3 Triton kernels reachable by this server."""
     if not current_platform.is_cuda():
         return
+
+    warmed_vision_interpolators = _warm_vision_position_interpolation(
+        worker.get_model()
+    )
+    if warmed_vision_interpolators:
+        logger.info(
+            "Warmed up %d Kimi vision position interpolator(s).",
+            warmed_vision_interpolators,
+        )
 
     layer = _get_kda_layer(worker)
     if layer is None:

--- a/vllm/model_executor/warmup/kimi_k3_triton_warmup.py
+++ b/vllm/model_executor/warmup/kimi_k3_triton_warmup.py
@@ -19,6 +19,15 @@ logger = init_logger(__name__)
 
 
 def _warm_vision_position_interpolation(model: torch.nn.Module) -> int:
+    """Compile Kimi vision interpolation before KV-cache allocation.
+
+    Args:
+        model: Loaded model whose module tree may contain Kimi vision position
+            embeddings.
+
+    Returns:
+        Number of Kimi vision interpolation modules invoked.
+    """
     from vllm.model_executor.models.kimi_k25_vit import (
         Learnable2DInterpPosEmbDivided_fixed,
         get_rope_shape,


### PR DESCRIPTION
## Behavior

Kimi vision positional interpolation compiles during per-worker CUDA kernel warm-up. Every tensor-parallel worker compiles the dynamic interpolation before fixed KV-cache allocation, including workers that receive no image during model profiling.

## Technical reason

The Kimi vision encoder uses a dynamically compiled bicubic interpolation for learned two-dimensional position embeddings. Vision data parallelism assigns complete images to tensor-parallel workers, so a worker can encounter its first interpolation after the server has allocated its KV cache. PyTorch Inductor autotuning allocates a device-cache-sized benchmark buffer during that first call; a one-million-token deployment may have insufficient memory for the late allocation and terminate the engine with CUDA out of memory.

Running the interpolation through the Kimi JIT warm-up compiles and autotunes it while startup memory is available. Production requests retain the compiled implementation and require no additional KV-cache headroom.

## Compatibility

The warm-up activates only on CUDA and only when a loaded model contains the Kimi learned two-dimensional interpolation module. Models without that module are unchanged. Tensor-parallel geometry, output computation, vision weights, KV-cache capacity, and runtime image limits are unchanged.

## Validation

- `tests/models/kimi_k3/test_vision_warmup.py`: 3 passed.
- Ruff check and format validation passed for both modified files.
- Runtime: official Kimi-K3 MXFP4 with DSpark7, TP16/DCP16, physical GPU KV capacity 1,033,126 tokens, and maximum model length 1,000,000 tokens.
- All 16 tensor-parallel workers logged successful interpolation warm-up before fixed KV-cache allocation.
- Cold-start requests containing 1, 2, 4, and 5 distinct images returned HTTP 200 with `finish_reason=stop`; the model identified the supplied image count in every request.
- The qualified container completed without CUDA OOM, traceback, engine death, or restart.
- Three 512-token coding decodes produced 122.18 tok/s median. The corresponding source composition without this fix produced 114.68 tok/s median, so the warm-up does not introduce a measured decode regression.

Qualified image:

`voipmonitor/vllm:kimi-k3-production-dspark-lmcache-vllm227d058-b12xec6edd9-cu133-torch213-20260818-vision-warmup`

Registry digest:

`sha256:ef507800a48532978c6bc95df06d38b68252d74b5ea35a605817bc9201296444`

The machine-readable qualification receipt is stored in [`validation/kimi-k3-production-vision-warmup-20260818.json`](https://github.com/local-inference-lab/blackwell-llm-docker/blob/main/validation/kimi-k3-production-vision-warmup-20260818.json).

AI assistance was used to implement and test this change. The submitted diff and runtime contract were reviewed against the observed CUDA OOM stack before publication.
