### PR TITLE
fix(glm): preserve sparse attention semantics during prefill

### DIFF
--- a/tests/model_executor/layers/test_mla_short_prefill_indexer.py
+++ b/tests/model_executor/layers/test_mla_short_prefill_indexer.py
@@ -8,6 +8,7 @@ import torch
 
 import vllm.model_executor.layers.sparse_attn_indexer as sparse_indexer
 from vllm.config import CUDAGraphMode
+from vllm.models.deepseek_v32.attention import DeepseekV32Attention
 from vllm.v1.attention.backends.mla.indexer import DeepseekV32IndexerMetadata
 
 INDEXER_LAYER = "model.layers.0.self_attn.indexer.k_cache"
@@ -45,7 +46,15 @@ def make_mla_metadata(*, use_dense_mha: bool = True, num_decode_tokens: int = 0)
 
 @pytest.mark.parametrize(
     "batch_kind",
-    ["short", "threshold_mismatch", "force_mqa", "mla_decode", "capture", "full"],
+    [
+        "short",
+        "threshold_mismatch",
+        "mqa_only_layer",
+        "force_mqa",
+        "mla_decode",
+        "capture",
+        "full",
+    ],
 )
 def test_short_prefill_updates_k_cache_before_scoring_decision(
     monkeypatch: pytest.MonkeyPatch,
@@ -132,6 +141,11 @@ def test_short_prefill_updates_k_cache_before_scoring_decision(
     topk_indices = torch.full((7, 2048), 17, dtype=torch.int32)
 
     def run_indexer():
+        if batch_kind == "mqa_only_layer":
+            assert not DeepseekV32Attention.supports_dense_mha_prefill
+            dense_mha_layer = ""
+        else:
+            dense_mha_layer = MLA_LAYER
         return sparse_indexer.sparse_attn_indexer(
             hidden_states,
             INDEXER_LAYER,
@@ -149,7 +163,7 @@ def test_short_prefill_updates_k_cache_before_scoring_decision(
             topk_indices,
             False,
             False,
-            MLA_LAYER,
+            dense_mha_layer,
         )
 
     if should_skip:

--- a/tests/v1/attention/test_flashinfer_sparse_mla_sm120_api.py
+++ b/tests/v1/attention/test_flashinfer_sparse_mla_sm120_api.py
@@ -32,6 +32,13 @@ def test_sm120_backend_uses_dedicated_backend_name() -> None:
     )
 
 
+def test_sm120_backend_uses_sparse_mqa_for_prefill() -> None:
+    impl_cls = FlashInferMLASparseSM120Backend.get_impl_cls()
+
+    assert impl_cls.is_sparse
+    assert not impl_cls.supports_dense_mha_prefill
+
+
 def test_v32_glm_sm120_backend_accepts_glm_block_size(
     monkeypatch,
 ) -> None:

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -649,6 +649,8 @@ class MLAAttention(nn.Module, AttentionLayerBase):
     3. Return the output tensor.
     """
 
+    supports_dense_mha_prefill: ClassVar[bool] = True
+
     def __init__(
         self,
         num_heads: int,
@@ -811,9 +813,11 @@ class MLAAttention(nn.Module, AttentionLayerBase):
         compilation_config.static_forward_context[prefix] = self
 
         self.prefill_backend: MLAPrefillBackend | None
-        if self.impl.is_sparse and not self.impl.supports_dense_mha_prefill:
+        if self.impl.is_sparse and not (
+            self.impl.supports_dense_mha_prefill and self.supports_dense_mha_prefill
+        ):
             logger.warning_once(
-                "Sparse MLA impl has no dense-MHA prefill path; using the top-k "
+                "Sparse MLA layer has no dense-MHA prefill path; using the top-k "
                 "MQA path only."
             )
             self.prefill_backend = None

--- a/vllm/models/deepseek_v32/attention.py
+++ b/vllm/models/deepseek_v32/attention.py
@@ -160,6 +160,7 @@ class DeepseekV32Attention(MLAAttention):
     indexer_cls: "type[DeepseekV32Indexer]" = DeepseekV32Indexer
 
     require_fp8_kv_cache: bool = True
+    supports_dense_mha_prefill = False
 
     def __init__(
         self,
@@ -265,6 +266,7 @@ class DeepseekV32Attention(MLAAttention):
             and not skip_topk
             and not self.use_pcp
             and current_platform.is_cuda()
+            and self.supports_dense_mha_prefill
         )
         self._dense_mha_metadata_layer_name = (
             self.layer_name if enable_short_prefill_scoring_skip else ""

--- a/vllm/v1/attention/backends/mla/flashinfer_mla_sparse_sm120.py
+++ b/vllm/v1/attention/backends/mla/flashinfer_mla_sparse_sm120.py
@@ -33,6 +33,7 @@ class FlashInferMLASparseSM120Impl(MLAAttentionImpl[FlashInferMLASparseMetadata]
     """SM120 FlashInfer sparse-MLA implementation."""
 
     is_sparse = True
+    supports_dense_mha_prefill = False
 
     def __init__(
         self,


### PR DESCRIPTION
## Resulting behavior

Sparse MLA prefill is selected only when both the model layer and the attention backend declare dense-MHA prefill support.

`DeepseekV32Attention`, which implements the GLM-5.2 sparse-attention layer, declares that dense MHA is not semantically equivalent to its indexed top-k attention. `FLASHINFER_MLA_SPARSE_SM120` also declares that it does not implement a dense-MHA prefill path. These configurations therefore retain the top-k MQA path for short and long prefills.

## Technical reason

Dense-MHA prefill is an optimization only for layers whose attention semantics are dense and whose backend implements that path. A backend capability alone cannot represent a sparse model layer's contract. Without the layer capability, GLM-5.2 could skip indexer scoring during short prefill when paired with a backend that advertises generic dense prefill support.

The implementation adapts upstream vLLM [#52512](https://github.com/vllm-project/vllm/pull/52512) and [#51395](https://github.com/vllm-project/vllm/pull/51395) to Infernal Invocation.

## Compatibility

- B12X sparse MLA behavior is unchanged because `B12xMLASparseImpl` already rejects dense-MHA prefill.
- FlashInfer SM120 sparse MLA now follows GLM-5.2 top-k semantics instead of selecting a generic dense prefill path.
- Dense MLA models and backends retain dense-MHA prefill support.
- CUDA graph shapes, cache layouts, and model weights are unchanged.

## Validation

Status: **qualified** for the source-level capability contract.

- 11 targeted tests passed.
- `ruff check`, `ruff format`, and `git diff --check` passed.
- The packaged r17 classes reported both `DeepseekV32Attention` and `FlashInferMLASparseSM120Impl` as dense-prefill capable; the tests assert the corrected model and backend capabilities and verify that the indexer scoring path remains active.
