### PR TITLE
scheduler: skip speculative decoding when all scheduled requests need <=1 output token

### DIFF
--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1092,6 +1092,19 @@ class Scheduler(SchedulerInterface):
                 len(num_scheduled_tokens)
             ]
 
+        # Skip speculative decoding when every scheduled request needs at most
+        # one output token. Drafting cannot pay off for a 1-token output, so the
+        # draft pass plus verification is pure added latency. Only fires when no
+        # running request is scheduled, so an in-flight multi-token generation
+        # can never lose its draft tokens.
+        if (
+            num_spec_tokens_to_schedule > 0
+            and scheduled_new_reqs
+            and not scheduled_running_reqs
+            and all(req.max_tokens <= 1 for req in scheduled_new_reqs)
+        ):
+            num_spec_tokens_to_schedule = 0
+
         scheduler_output = SchedulerOutput(
             scheduled_new_reqs=new_reqs_data,
             scheduled_cached_reqs=cached_reqs_data,

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1104,6 +1104,17 @@ class Scheduler(SchedulerInterface):
             and all(req.max_tokens <= 1 for req in scheduled_new_reqs)
         ):
             num_spec_tokens_to_schedule = 0
+            # NOTE: allocate_slots (called above for each request) already
+            # reserved KV blocks for self.num_lookahead_tokens speculative
+            # slots. We cannot retroactively shrink that reservation here
+            # because it was made per-request during the scheduling loop,
+            # before this aggregate skip condition is evaluated. The
+            # reservation is harmless: these are single-token requests
+            # (max_tokens <= 1) that finish immediately after one decode
+            # step, so the extra blocks are released at the next scheduling
+            # iteration. Zeroing num_spec_tokens_to_schedule prevents the
+            # draft model from running, which is the source of the wasted
+            # latency we are avoiding.
 
         scheduler_output = SchedulerOutput(
             scheduled_new_reqs=new_reqs_data,


### PR DESCRIPTION
Supersedes #437 and #438. **Please close both** — #438 was my mistake: I branched it from `vllm-project/main` while targeting this repo's `main`, which produced a 3035-file diff. This PR is branched from `local-inference-lab/main` and is **1 file, +13 lines**, DCO-signed, `ruff check`/`ruff format`/`F821` clean.

## What

When a scheduled batch contains only new requests (no running ones) and every one has `max_tokens <= 1`, set `num_spec_tokens_to_schedule = 0`. Speculation cannot help a 1-token output, so the draft pass plus verification is pure added latency.

The guard requires `scheduled_running_reqs` to be empty, so an in-flight multi-token generation can never lose its draft tokens. Note `scheduled_new_reqs` has already been extended with resumed requests at that point, and a resumed request keeps its original `max_tokens`, so the check stays conservative.

## Measured

RTX 5090 (31.4 GiB), Qwen3.8-27B EXL3, MTP=6:

| | before | after |
|---|---|---|
| 1-token request latency | 141 ms | **127 ms** |
| 2051-token prefill bench | 7445 tok/s | **7635 tok/s** (+2.5%) |
| TG on normal requests | 189.8 tok/s | 189.8 tok/s (unchanged) |

This shape is more common than it looks: every `max_tokens=1` call, every prefill-throughput benchmark, and every embedding/classification-style request.

## Heads-up: interaction with the V2 model runner

Worth flagging because it bit me. Your newer image (`gilded-gnosis-v20-...-vllm4d006a4`) ships a V2 runner + `AutoRegressiveSpeculator` that this repo's published `main` does not yet contain. On that code, a scheduler-selected depth of **0 raises** in two places rather than meaning "propose nothing":

- `vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py` — `propose()`: `ValueError: num_speculative_tokens must be between 1 and 6, got 0`
- `vllm/v1/worker/gpu/spec_decode/utils.py` — `limit_draft_tokens()`: `RuntimeError: Scheduler selected an invalid speculative-token count 0`

The second one is a guard-ordering issue: three lines below the range check, the function **already tolerates an empty draft** (`if draft_tokens.shape[1] == 0: return draft_tokens`).

So with the V1 runner this PR is a pure win, but on the V2 path it needs both to accept 0 (returning a `[num_reqs, 0]` slice). I have those two 7-line fixes working locally and can send them as a follow-up PR the moment that code is on `main` — just tell me where you'd like it.

Why it matters there: with the V2 runner the MTP draft loop gets CUDA-graph captured, which on our hardware was worth **+32% TG** (essay 70.9 -> 93.6 tok/s, fox 141.9 -> 185.6). nsys showed the draft phase was 88% of every decode step and running fully eager on V1, which has no `speculator.capture` at all.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduling for requests that produce only a single token by avoiding unnecessary speculative decoding when no requests are already in progress.
  * This helps reduce scheduling overhead and improves resource efficiency for applicable requests.
  * Speculative reservations are now handled consistently across scheduling iterations, supporting more predictable request processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->