### PR TITLE
[II] Preserve Kimi parallel-draft KV group identity

### DIFF
--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -2937,9 +2937,39 @@ def test_k3_hybrid_group_size_is_model_and_cache_specific(
 
 @pytest.mark.parametrize("dcp_world_size", [8, 16])
 def test_k3_parallel_draft_groups_are_annotated_by_layer_contract(
-    monkeypatch: pytest.MonkeyPatch,
     dcp_world_size: int,
 ):
+    target = MLAAttentionSpec(
+        block_size=64,
+        num_kv_heads=1,
+        head_size=576,
+        dtype=torch.uint8,
+    )
+    partial_dcp = MLAAttentionSpec(
+        block_size=128,
+        num_kv_heads=1,
+        head_size=288,
+        dtype=torch.uint8,
+        dcp_kv_shard_count=8,
+    )
+    parallel_draft = SlidingWindowMLASpec(
+        block_size=64,
+        num_kv_heads=1,
+        head_size=576,
+        dtype=torch.uint8,
+        sliding_window=32768,
+        dcp_replicated=True,
+        non_causal_multi_token_decode=True,
+    )
+    specs: dict[str, KVCacheSpec] = {
+        # Names intentionally disagree with execution metadata so this test
+        # rejects name-based draft-group classification.
+        "draft_name_but_target.0": target,
+        "draft_name_but_target.1": target,
+        "partial_dcp_target.0": partial_dcp,
+        "ordinary_name.0": parallel_draft,
+        "ordinary_name.1": parallel_draft,
+    }
     config = SimpleNamespace(
         scheduler_config=SimpleNamespace(disable_hybrid_kv_cache_manager=False),
         parallel_config=SimpleNamespace(
@@ -2951,21 +2981,25 @@ def test_k3_parallel_draft_groups_are_annotated_by_layer_contract(
         ),
         speculative_config=SimpleNamespace(use_eagle=lambda: True),
     )
-    monkeypatch.setenv("VLLM_K3_KV_GROUP_SIZE", "2")
-    monkeypatch.setattr(
-        kv_cache_utils,
-        "group_and_unify_kv_cache_specs",
-        lambda *args, **kwargs: None,
-    )
 
-    groups = get_kv_cache_groups(config, _k3_hybrid_cache_specs())
+    groups = get_kv_cache_groups(config, specs)
 
-    assert any(group.is_eagle_group for group in groups)
+    # DCP8 uses generic uniform-page grouping. DCP16 recognizes the target and
+    # partial-DCP MLA lockstep and packs each semantic type into one group.
+    assert len(groups) == {8: 5, 16: 3}[dcp_world_size]
     for group in groups:
         contains_parallel_draft = any(
-            layer_name.startswith("draft.") for layer_name in group.layer_names
+            getattr(specs[layer_name], "non_causal_multi_token_decode", False)
+            for layer_name in group.layer_names
         )
         assert group.is_eagle_group is contains_parallel_draft
+
+    assert not next(
+        group for group in groups if "draft_name_but_target.0" in group.layer_names
+    ).is_eagle_group
+    assert next(
+        group for group in groups if "ordinary_name.0" in group.layer_names
+    ).is_eagle_group
 
 
 def test_group_and_unify_kv_cache_specs_mixed_page_size_groups():

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -2935,6 +2935,39 @@ def test_k3_hybrid_group_size_is_model_and_cache_specific(
     assert len(groups) == expected_groups
 
 
+@pytest.mark.parametrize("dcp_world_size", [8, 16])
+def test_k3_parallel_draft_groups_are_annotated_by_layer_contract(
+    monkeypatch: pytest.MonkeyPatch,
+    dcp_world_size: int,
+):
+    config = SimpleNamespace(
+        scheduler_config=SimpleNamespace(disable_hybrid_kv_cache_manager=False),
+        parallel_config=SimpleNamespace(
+            decode_context_parallel_size=dcp_world_size,
+            prefill_context_parallel_size=1,
+        ),
+        model_config=SimpleNamespace(
+            hf_config=SimpleNamespace(model_type="kimi_k3"),
+        ),
+        speculative_config=SimpleNamespace(use_eagle=lambda: True),
+    )
+    monkeypatch.setenv("VLLM_K3_KV_GROUP_SIZE", "2")
+    monkeypatch.setattr(
+        kv_cache_utils,
+        "group_and_unify_kv_cache_specs",
+        lambda *args, **kwargs: None,
+    )
+
+    groups = get_kv_cache_groups(config, _k3_hybrid_cache_specs())
+
+    assert any(group.is_eagle_group for group in groups)
+    for group in groups:
+        contains_parallel_draft = any(
+            layer_name.startswith("draft.") for layer_name in group.layer_names
+        )
+        assert group.is_eagle_group is contains_parallel_draft
+
+
 def test_group_and_unify_kv_cache_specs_mixed_page_size_groups():
     # DeepseekV4-style: differing page sizes across MLA and sliding-window MLA
     # layers do require tuple packing, so grouping must still be produced.

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -2003,6 +2003,14 @@ def _annotate_eagle_groups(
     topology-independent layer set. DeepSeek-V4 does not expose equivalent
     per-layer metadata, so its established final-layer rule remains the
     compatibility fallback.
+
+    Args:
+        vllm_config: Global model, scheduler, and speculative-decoding config.
+        kv_cache_spec: Cache specification keyed by attention-layer name.
+        kv_cache_groups: Cache groups to annotate in place.
+
+    Returns:
+        None.
     """
     spec_config = getattr(vllm_config, "speculative_config", None)
     if spec_config is None or not spec_config.use_eagle():

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1656,6 +1656,7 @@ def _promote_local_kv_cache_specs(
                     compress_ratio=spec.compress_ratio,
                     model_version=spec.model_version,
                     dcp_replicated=spec.dcp_replicated,
+                    non_causal_multi_token_decode=spec.non_causal_multi_token_decode,
                 )
             elif isinstance(spec, SlidingWindowSpec):
                 block_size = full_attention_block_size or spec.block_size
@@ -1990,14 +1991,33 @@ def _get_kv_cache_groups_uniform_groups(
     return [full_mla_group, *swa_mla_groups]
 
 
-def _annotate_eagle_groups_deepseek_v4(
+def _annotate_eagle_groups(
     vllm_config: VllmConfig,
     kv_cache_spec: dict[str, KVCacheSpec],
     kv_cache_groups: list[KVCacheGroupSpec],
 ) -> None:
-    spec_config = vllm_config.speculative_config
+    """Identify cache groups that contain speculative-draft attention.
+
+    Kimi parallel drafters expose their execution contract directly on each
+    MLA cache specification. This gives the cache planner an exact,
+    topology-independent layer set. DeepSeek-V4 does not expose equivalent
+    per-layer metadata, so its established final-layer rule remains the
+    compatibility fallback.
+    """
+    spec_config = getattr(vllm_config, "speculative_config", None)
     if spec_config is None or not spec_config.use_eagle():
         return
+
+    draft_layer_names = {
+        layer_name
+        for layer_name, spec in kv_cache_spec.items()
+        if getattr(spec, "non_causal_multi_token_decode", False)
+    }
+    if draft_layer_names:
+        for group in kv_cache_groups:
+            if draft_layer_names.intersection(group.layer_names):
+                group.is_eagle_group = True
+
     # Detection uses the merged MLA spec's model_version.
     if not any(
         getattr(spec, "model_version", None) == "deepseek_v4"
@@ -2046,12 +2066,16 @@ def get_kv_cache_groups(
         # KV cache of all layers are the same, which is true for
         # most models. Allocate the same amount of memory for
         # each layer.
-        return _get_kv_cache_groups_uniform_spec(kv_cache_spec)
+        kv_cache_groups = _get_kv_cache_groups_uniform_spec(kv_cache_spec)
+        _annotate_eagle_groups(vllm_config, kv_cache_spec, kv_cache_groups)
+        return kv_cache_groups
     elif uniform_spec := UniformTypeKVCacheSpecs.from_specs(kv_cache_spec):
         # All layers need the same number of token slots (e.g., all layers are
         # full attention, or all layers are sliding window attention with the
         # same window size). Put all layers into one group.
-        return _get_kv_cache_groups_uniform_type(uniform_spec)
+        kv_cache_groups = _get_kv_cache_groups_uniform_type(uniform_spec)
+        _annotate_eagle_groups(vllm_config, kv_cache_spec, kv_cache_groups)
+        return kv_cache_groups
     elif grouped_specs := group_and_unify_kv_cache_specs(
         kv_cache_spec,
         vllm_config.parallel_config.decode_context_parallel_size,
@@ -2062,7 +2086,7 @@ def get_kv_cache_groups(
         # attention in different sizes. Need to group layers into multiple
         # UniformTypeKVCacheSpecs.
         kv_cache_groups = _get_kv_cache_groups_uniform_groups(grouped_specs)
-        _annotate_eagle_groups_deepseek_v4(vllm_config, kv_cache_spec, kv_cache_groups)
+        _annotate_eagle_groups(vllm_config, kv_cache_spec, kv_cache_groups)
         return kv_cache_groups
 
     # Pull HiddenStateCacheSpec layers out before the general multi-group
@@ -2084,6 +2108,7 @@ def get_kv_cache_groups(
         fallback_groups = _try_get_full_allocation_fallback_groups(kv_cache_spec)
         if fallback_groups is None:
             raise
+        _annotate_eagle_groups(vllm_config, kv_cache_spec, fallback_groups)
         return fallback_groups
     model_config = getattr(vllm_config, "model_config", None)
     hf_config = getattr(model_config, "hf_config", None)
@@ -2132,6 +2157,7 @@ def get_kv_cache_groups(
             aligned = replace(spec, block_size=new_bs, page_size_padded=common_page)
             groups.append(KVCacheGroupSpec([name], aligned))
 
+    _annotate_eagle_groups(vllm_config, kv_cache_spec, groups)
     return groups
 
 


### PR DESCRIPTION
## Behavior

Preserves the `non_causal_multi_token_decode` layer contract when a
sliding-window MLA cache specification is promoted to an allocation-compatible
MLA specification. Cache groups are marked as speculative-draft groups only
when at least one member layer carries that metadata.

Native KV offload uses the annotation to exclude the volatile draft tail while
keeping target-model cache blocks reusable. The classification reads layer
metadata and contains no tensor-parallel rank count, decode-context-parallel
rank count, layer-name convention, or fixed cache-group index.

## Technical reason

Kimi parallel-draft MLA layers set
`non_causal_multi_token_decode=True`. Cache-spec promotion discarded that
field, so the native-offload scheduler classified every Kimi hybrid cache group
as speculative state. The invalid classification excluded 49,152 reusable
target tokens from a 134,219-token restore request.

The implementation adapts the Kimi group annotation from
[vllm-project/vllm#52047](https://github.com/vllm-project/vllm/pull/52047)
to Infernal Invocation's cache-spec promotion and cache-group construction
paths. The established DeepSeek-V4 final-layer fallback remains available for
model configurations without per-layer metadata.

## Compatibility

- Models without draft-layer metadata retain their existing grouping behavior.
- DeepSeek-V4 retains its model-version fallback.
- GPU KV capacity and cache tensor geometry are unchanged.
- The implementation supports TP/DCP topologies generically; TP8/DCP8 and
  TP16/DCP16 follow different grouping paths in the focused tests.

## Validation

Status: **implemented** and **qualified** for TP16/DCP16.

- Five focused cache-group tests passed.
- DCP8 coverage uses target MLA, partial-DCP MLA, and parallel-draft
  sliding-window MLA specifications through the generic uniform-page path.
- DCP16 coverage uses the lockstep partial-DCP path.
- Misleading layer names prove that draft membership follows metadata.
- Ruff check, Ruff format check, and `git diff --check` passed.

The full-model test used official Kimi-K3 MXFP4, Inferact DSpark K7,
TP16/DCP16, a 1,033,126-token physical FP8 GPU KV cache, and 32 GiB of native
host KV storage. The 134,219-token request contained five images.

| Metric | Result |
|---|---:|
| Detected draft cache groups | `[16]` |
| Host-hit tokens per restore | 122,880 |
| Recomputed tokens per restore | 11,339 |
| Median engine prefill, three restores | 9.239 s |
| Median engine TTFT, three restores | 9.544 s |
| Median host-to-device copy, 3,705,421,824 bytes | 0.166 s |
| Median end-to-end request time | 12.387 s |

All three restore requests returned HTTP 200, emitted a terminal SSE event,
contained no stream error, and leaked no Kimi protocol control marker.

Qualified image:
`voipmonitor/vllm@sha256:bd8a4be5e87c89f37548ee0502c1a0dc186e9058d57f3278927c1ef5d01e65fa`

Reproduction and machine-readable evidence:
[Kimi-K3 native host KV offload](https://github.com/local-inference-lab/rtx6kpro/blob/master/models/kimi-k3/native-host-kv-offload.md)

TP8 full-model execution is **unqualified**; DCP8 cache-group construction is
covered by the focused unit suite.
