### PR TITLE
[II] Restore native KV tails across mixed cache groups

### DIFF
--- a/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
@@ -30,8 +30,10 @@ from vllm.distributed.kv_transfer.kv_connector.v1.offloading.metrics import (
     _ConnectorMetricName,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.offloading.scheduler import (
+    GroupOffloadConfig,
     OffloadingConnectorScheduler,
     RequestOffloadState,
+    SchedulerOffloadConfig,
     get_sliding_window_size_in_chunks,
     is_store_reachable_swa_chunk,
 )
@@ -112,8 +114,8 @@ def test_partial_tail_store_uses_attention_and_recurrent_cow_sources():
     req_status = scheduler._req_status["req"]
     req_status.group_states[0].block_ids[:] = [11, 12]
     req_status.group_states[1].block_ids[:] = [0, 21]
-    scheduler.manager.prepare_store.side_effect = (
-        lambda keys, req_context: generate_store_output(keys)
+    scheduler.manager.prepare_store.side_effect = lambda keys, req_context: (
+        generate_store_output(keys)
     )
 
     output = SimpleNamespace(partial_tail_offloads={"req": [(1, 99, 28)]})
@@ -2775,6 +2777,7 @@ class TestEagle:
         req = MagicMock()
         req.request_id = "test-req"
         req.num_tokens = num_tokens
+        req.num_prompt_tokens = num_tokens
         req.kv_transfer_params = None
         num_hash_blocks = max(
             len(hashes) * scheduler.config.kv_group_configs[idx].hashes_per_chunk
@@ -2800,6 +2803,267 @@ class TestEagle:
                 scheduler.config.kv_group_configs[idx].group_idx, hashes
             )
         return state
+
+    @staticmethod
+    def _make_mixed_block_scheduler() -> OffloadingConnectorScheduler:
+        """Build a scaled target/DCP plus sliding-window draft geometry."""
+        groups = (
+            GroupOffloadConfig(
+                group_idx=0,
+                tokens_per_block=16,
+                tokens_per_chunk=16,
+                hashes_per_chunk=4,
+                kv_event_group_spec=MagicMock(),
+                sliding_window_size_in_chunks=None,
+            ),
+            GroupOffloadConfig(
+                group_idx=1,
+                tokens_per_block=4,
+                tokens_per_chunk=4,
+                hashes_per_chunk=1,
+                kv_event_group_spec=MagicMock(),
+                sliding_window_size_in_chunks=2,
+                is_eagle_group=True,
+            ),
+        )
+        scheduler = object.__new__(OffloadingConnectorScheduler)
+        scheduler.config = SchedulerOffloadConfig(
+            kv_group_configs=groups,
+            blocks_per_chunk=1,
+            tokens_per_hash=4,
+            num_workers=1,
+            offload_prompt_only=False,
+            supports_partial_tail=False,
+            finished_replay_tail_alignment_tokens=4,
+            replay_alignment_tokens=None,
+        )
+        scheduler.manager = MagicMock(spec=OffloadingManager)
+        scheduler.manager.on_new_request.return_value = RequestOffloadingContext(
+            policy=OffloadPolicy.BLOCK_LEVEL
+        )
+        scheduler._events_tracker = MagicMock()
+        scheduler._connector_stats = OffloadingConnectorStats()
+        scheduler._replay_reserve_tokens = 4
+        scheduler._partial_tail_block_size = 0
+        scheduler._lookup_groups = (0, 1)
+        scheduler._sliding_window_groups = (1,)
+        scheduler._mamba_align_size = None
+        scheduler._cow_source_groups = frozenset()
+        scheduler._chunks_being_loaded = None
+        scheduler._req_status = {}
+        scheduler._current_batch_load_jobs = {}
+        scheduler._current_batch_jobs_to_flush = set()
+        scheduler._current_batch_allocated_block_ids = set()
+        scheduler._block_id_to_pending_jobs = {}
+        scheduler._jobs = {}
+        scheduler._job_counter = 0
+        return scheduler
+
+    def test_finished_replay_tail_extends_mixed_block_hit(self):
+        """A draft boundary identifies stable data inside a target page.
+
+        The scaled geometry represents a 12,288-token DCP target block and a
+        768-token draft block. A 27-token prompt has one complete 16-token
+        target block. The completed-request tail restores through token 20
+        after confirming the draft key through token 24.
+        """
+        scheduler = self._make_mixed_block_scheduler()
+        assert scheduler.config.finished_replay_tail_alignment_tokens == 4
+
+        req_status = self._make_req_status(
+            scheduler,
+            num_tokens=27,
+            offload_keys_per_group=[[3], [0, 1, 2, 3, 4, 5]],
+        )
+        scheduler.manager.lookup.return_value = LookupResult.HIT
+
+        assert scheduler._lookup(req_status) == 20
+        assert req_status.partial_tail_boundary == 20
+
+    def test_finished_replay_tail_requires_eagle_stability_key(
+        self,
+    ):
+        """A missing post-boundary draft key keeps the complete target hit."""
+        scheduler = self._make_mixed_block_scheduler()
+        req_status = self._make_req_status(
+            scheduler,
+            num_tokens=27,
+            offload_keys_per_group=[[3], [0, 1, 2, 3, 4, 5]],
+        )
+
+        def lookup(key, req_context):
+            if get_offload_group_idx(key) == 1 and get_offload_block_hash(key) == b"5":
+                return LookupResult.MISS
+            return LookupResult.HIT
+
+        scheduler.manager.lookup.side_effect = lookup
+
+        assert scheduler._lookup(req_status) == 16
+        assert req_status.partial_tail_boundary is None
+
+    def test_finished_replay_tail_rejects_full_attention_hole(self):
+        """A missing interior draft key prevents partial-target replay."""
+        scheduler = self._make_mixed_block_scheduler()
+        scheduler.config = scheduler.config._replace(
+            kv_group_configs=(
+                scheduler.config.kv_group_configs[0],
+                scheduler.config.kv_group_configs[1]._replace(
+                    sliding_window_size_in_chunks=None
+                ),
+            )
+        )
+        req_status = self._make_req_status(
+            scheduler,
+            num_tokens=35,
+            offload_keys_per_group=[[3, 7], list(range(8))],
+        )
+
+        def lookup(key, req_context):
+            group_idx = get_offload_group_idx(key)
+            block_hash = get_offload_block_hash(key)
+            if group_idx == 0 and block_hash == b"7":
+                return LookupResult.MISS
+            if group_idx == 1 and block_hash == b"5":
+                return LookupResult.MISS
+            return LookupResult.HIT
+
+        scheduler.manager.lookup.side_effect = lookup
+
+        # The ordinary full-attention EAGLE lookup drops its trailing
+        # 4-token chunk, so the safe fallback is 12 rather than the target
+        # group's 16-token complete boundary.
+        assert scheduler._lookup(req_status) == 12
+        assert req_status.partial_tail_boundary is None
+
+    def test_finished_replay_tail_returns_tokens_after_local_hit(self):
+        """The connector API returns a delta beyond an existing GPU hit."""
+        scheduler = self._make_mixed_block_scheduler()
+        req_status = self._make_req_status(
+            scheduler,
+            num_tokens=27,
+            num_computed_tokens=8,
+            offload_keys_per_group=[[3], [0, 1, 2, 3, 4, 5]],
+        )
+        scheduler.manager.lookup.return_value = LookupResult.HIT
+
+        assert scheduler._lookup_finished_replay_tail(req_status, 8) == 12
+        assert req_status.partial_tail_boundary == 20
+
+    def test_finished_replay_tail_store_uses_final_target_page(
+        self,
+    ):
+        """Only the larger group's incomplete physical page is exported."""
+        scheduler = self._make_mixed_block_scheduler()
+        request = MagicMock()
+        request.request_id = "tail-store"
+        request.kv_transfer_params = None
+        request.num_prompt_tokens = 27
+        request.num_tokens = 28
+        request.status = RequestStatus.FINISHED_STOPPED
+        request.block_hashes = [BlockHash(str(i).encode()) for i in range(7)]
+        request.all_token_ids = list(range(28))
+        request.lora_request = None
+        request.is_finished.return_value = True
+        scheduler.on_new_request(request)
+        req_status = scheduler._req_status[request.request_id]
+        req_status.group_states[0].block_ids[:] = [11, 12]
+        req_status.group_states[1].block_ids[:] = [21, 22, 23, 24, 25, 26, 27]
+        scheduler.manager.prepare_store.side_effect = lambda keys, req_context: (
+            generate_store_output(keys)
+        )
+
+        jobs = scheduler._build_finished_replay_tail_store_jobs(
+            SimpleNamespace(finished_req_ids=[request.request_id])
+        )
+
+        assert len(jobs) == 1
+        [job_id] = jobs
+        src_spec = jobs[job_id].src_spec
+        assert isinstance(src_spec, GPULoadStoreSpec)
+        assert src_spec.block_ids.tolist() == [12]
+        assert src_spec.group_sizes == [1, 0]
+        assert src_spec.block_indices == [1, 0]
+        assert scheduler._block_id_to_pending_jobs == {12: {job_id}}
+
+    def test_finished_replay_tail_load_maps_partial_and_aligned_groups(
+        self,
+    ):
+        """Loading a replay tail maps the target page and draft window."""
+        scheduler = self._make_mixed_block_scheduler()
+        request = MagicMock()
+        request.request_id = "tail-load"
+        request.kv_transfer_params = None
+        request.num_prompt_tokens = 27
+        request.num_tokens = 27
+        request.block_hashes = [BlockHash(str(i).encode()) for i in range(7)]
+        request.all_token_ids = list(range(27))
+        request.lora_request = None
+        scheduler.on_new_request(request)
+        req_status = scheduler._req_status[request.request_id]
+        req_status.update_offload_keys()
+        scheduler.manager.lookup.return_value = LookupResult.HIT
+        assert scheduler._lookup(req_status) == 20
+
+        scheduler.update_state_after_alloc(
+            request,
+            KVCacheBlocks(
+                (
+                    [KVCacheBlock(31), KVCacheBlock(32)],
+                    [
+                        KVCacheBlock(0, is_null=True),
+                        KVCacheBlock(0, is_null=True),
+                        KVCacheBlock(0, is_null=True),
+                        KVCacheBlock(41),
+                        KVCacheBlock(42),
+                    ],
+                )
+            ),
+            num_external_tokens=20,
+        )
+
+        [load_job] = scheduler._current_batch_load_jobs.values()
+        dst_spec = load_job.dst_spec
+        assert isinstance(dst_spec, GPULoadStoreSpec)
+        assert dst_spec.block_ids.tolist() == [31, 32, 41, 42]
+        assert dst_spec.group_sizes == [2, 2]
+        assert dst_spec.block_indices == [0, 3]
+
+    def test_finished_replay_tail_retains_pruned_recurrent_boundary(self):
+        """A pruned recurrent group retains the completed-request boundary.
+
+        Four-token recurrent chunks are ordinarily retained only at the end
+        of each 16-token target-cache segment. A 27-token prompt has a stable
+        replay boundary at token 20, so chunk index 4 must remain reachable
+        even though it is not a normal segment-tail chunk.
+        """
+        scheduler = self._make_mixed_block_scheduler()
+        recurrent_group = scheduler.config.kv_group_configs[1]._replace(
+            is_eagle_group=False,
+            sliding_window_size_in_chunks=1,
+            alignment_chunk_count=4,
+        )
+        scheduler.config = scheduler.config._replace(
+            kv_group_configs=(
+                scheduler.config.kv_group_configs[0],
+                recurrent_group,
+            )
+        )
+        request = MagicMock()
+        request.num_prompt_tokens = 27
+        request.shared_prefix_boundary = None
+
+        reachable_ends = scheduler._reachable_tail_end_chunks(
+            recurrent_group, request, shift=0
+        )
+
+        assert reachable_ends == (5,)
+        assert is_store_reachable_swa_chunk(
+            absolute_chunk_index=4,
+            alignment_chunk_count=4,
+            sliding_window_chunks=1,
+            is_eagle_group=False,
+            reachable_tail_end_chunks=reachable_ends,
+        )
 
     # -------------------------------------------------------------------
     # Lookup unit tests: call _lookup() directly via request_runner

--- a/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
@@ -3040,6 +3040,31 @@ class TestEagle:
         assert src_spec.group_sizes == [1, 0, 1]
         assert src_spec.block_indices == [1, 0, 0]
 
+    def test_finished_replay_tail_store_respects_request_token_limit(self):
+        """A request-level offload cap also bounds completion-only stores."""
+        scheduler = self._make_mixed_block_scheduler()
+        request = MagicMock()
+        request.request_id = "limited-tail-store"
+        request.kv_transfer_params = {"max_offload_tokens": 16}
+        request.num_prompt_tokens = 35
+        request.num_tokens = 36
+        request.status = RequestStatus.FINISHED_STOPPED
+        request.block_hashes = [BlockHash(str(i).encode()) for i in range(9)]
+        request.all_token_ids = list(range(36))
+        request.lora_request = None
+        request.is_finished.return_value = True
+        scheduler.on_new_request(request)
+        req_status = scheduler._req_status[request.request_id]
+        req_status.group_states[0].block_ids[:] = [11, 12, 13]
+        req_status.group_states[1].block_ids[:] = list(range(21, 30))
+
+        jobs = scheduler._build_finished_replay_tail_store_jobs(
+            SimpleNamespace(finished_req_ids=[request.request_id])
+        )
+
+        assert jobs == {}
+        scheduler.manager.prepare_store.assert_not_called()
+
     @pytest.mark.parametrize("missing_source", [False, True])
     def test_finished_replay_tail_store_skips_unsafe_request(
         self, missing_source: bool

--- a/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
@@ -2901,6 +2901,19 @@ class TestEagle:
         assert scheduler._lookup(req_status) == 16
         assert req_status.partial_tail_boundary is None
 
+    def test_finished_replay_tail_bounds_long_prompt_lookup_to_next_page(self):
+        """A cold long-prompt lookup probes only the next target page."""
+        scheduler = self._make_mixed_block_scheduler()
+        req_status = self._make_req_status(
+            scheduler,
+            num_tokens=100_003,
+            offload_keys_per_group=[list(range(6_250)), list(range(25_000))],
+        )
+        scheduler.manager.lookup.return_value = LookupResult.MISS
+
+        assert scheduler._lookup_finished_replay_tail(req_status, 16) == 16
+        assert scheduler.manager.lookup.call_count == 3
+
     def test_finished_replay_tail_rejects_full_attention_hole(self):
         """A missing interior draft key prevents partial-target replay."""
         scheduler = self._make_mixed_block_scheduler()
@@ -2985,6 +2998,80 @@ class TestEagle:
         assert src_spec.block_indices == [1, 0]
         assert scheduler._block_id_to_pending_jobs == {12: {job_id}}
 
+    def test_finished_replay_tail_store_orders_partial_groups(self):
+        """Source block order follows cache-group order, not manager order."""
+        scheduler = self._make_mixed_block_scheduler()
+        third_group = scheduler.config.kv_group_configs[0]._replace(
+            group_idx=2,
+            tokens_per_block=32,
+            tokens_per_chunk=32,
+            hashes_per_chunk=8,
+        )
+        scheduler.config = scheduler.config._replace(
+            kv_group_configs=(*scheduler.config.kv_group_configs, third_group)
+        )
+        request = MagicMock()
+        request.request_id = "ordered-tail-store"
+        request.kv_transfer_params = None
+        request.num_prompt_tokens = 27
+        request.num_tokens = 28
+        request.status = RequestStatus.FINISHED_STOPPED
+        request.block_hashes = [BlockHash(str(i).encode()) for i in range(8)]
+        request.all_token_ids = list(range(28))
+        request.lora_request = None
+        request.is_finished.return_value = True
+        scheduler.on_new_request(request)
+        req_status = scheduler._req_status[request.request_id]
+        req_status.group_states[0].block_ids[:] = [11, 12]
+        req_status.group_states[1].block_ids[:] = [21, 22, 23, 24, 25, 26, 27]
+        req_status.group_states[2].block_ids[:] = [31]
+        scheduler.manager.prepare_store.side_effect = lambda keys, req_context: (
+            generate_store_output(reversed(keys))
+        )
+
+        jobs = scheduler._build_finished_replay_tail_store_jobs(
+            SimpleNamespace(finished_req_ids=[request.request_id])
+        )
+
+        [job] = jobs.values()
+        src_spec = job.src_spec
+        assert isinstance(src_spec, GPULoadStoreSpec)
+        assert src_spec.block_ids.tolist() == [12, 31]
+        assert src_spec.group_sizes == [1, 0, 1]
+        assert src_spec.block_indices == [1, 0, 0]
+
+    @pytest.mark.parametrize("missing_source", [False, True])
+    def test_finished_replay_tail_store_skips_unsafe_request(
+        self, missing_source: bool
+    ):
+        """Aborted requests and missing source pages publish no tail keys."""
+        scheduler = self._make_mixed_block_scheduler()
+        request = MagicMock()
+        request.request_id = "unsafe-tail-store"
+        request.kv_transfer_params = None
+        request.num_prompt_tokens = 27
+        request.num_tokens = 28
+        request.status = (
+            RequestStatus.FINISHED_STOPPED
+            if missing_source
+            else RequestStatus.FINISHED_ABORTED
+        )
+        request.block_hashes = [BlockHash(str(i).encode()) for i in range(7)]
+        request.all_token_ids = list(range(28))
+        request.lora_request = None
+        request.is_finished.return_value = True
+        scheduler.on_new_request(request)
+        req_status = scheduler._req_status[request.request_id]
+        req_status.group_states[0].block_ids[:] = [11, 0 if missing_source else 12]
+        req_status.group_states[1].block_ids[:] = [21, 22, 23, 24, 25, 26, 27]
+
+        jobs = scheduler._build_finished_replay_tail_store_jobs(
+            SimpleNamespace(finished_req_ids=[request.request_id])
+        )
+
+        assert jobs == {}
+        scheduler.manager.prepare_store.assert_not_called()
+
     def test_finished_replay_tail_load_maps_partial_and_aligned_groups(
         self,
     ):
@@ -3063,6 +3150,22 @@ class TestEagle:
             sliding_window_chunks=1,
             is_eagle_group=False,
             reachable_tail_end_chunks=reachable_ends,
+        )
+
+        scheduler.config = scheduler.config._replace(
+            finished_replay_tail_alignment_tokens=None,
+            replay_alignment_tokens=16,
+        )
+        fallback_ends = scheduler._reachable_tail_end_chunks(
+            recurrent_group, request, shift=0
+        )
+        assert fallback_ends == (4,)
+        assert is_store_reachable_swa_chunk(
+            absolute_chunk_index=3,
+            alignment_chunk_count=4,
+            sliding_window_chunks=1,
+            is_eagle_group=False,
+            reachable_tail_end_chunks=fallback_ends,
         )
 
     # -------------------------------------------------------------------

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -361,7 +361,9 @@ class SchedulerOffloadConfig(NamedTuple):
                     and config.tokens_per_chunk == replay_alignment
                 )
                 for group, config in zip(
-                    kv_cache_config.kv_cache_groups, kv_group_configs
+                    kv_cache_config.kv_cache_groups,
+                    kv_group_configs,
+                    strict=True,
                 )
             )
             if (
@@ -1035,6 +1037,18 @@ class OffloadingConnectorScheduler:
         ):
             return complete_hit
 
+        # A completion-only key supplies data from the physical page directly
+        # after the ordinary complete hit. A boundary beyond every group's
+        # next page would require an intervening complete page that the
+        # ordinary lookup did not find, so it cannot produce a contiguous
+        # load. Bounding the scan also keeps a cold long-prompt lookup linear
+        # in the number of cache groups instead of the prompt length.
+        next_page_boundary = max(
+            cdiv(complete_boundary + 1, group.tokens_per_chunk) * group.tokens_per_chunk
+            for group in self.config.kv_group_configs
+        )
+        max_boundary = min(max_boundary, next_page_boundary)
+
         pending = False
         for boundary in range(max_boundary, complete_boundary, -alignment):
             boundary_pending = False
@@ -1226,7 +1240,10 @@ class OffloadingConnectorScheduler:
             block_indices = [0] * len(self.config.kv_group_configs)
             accepted_block_ids: list[int] = []
             accepted_keys: set[OffloadKey] = set(store_output.keys_to_store)
-            for key in store_output.keys_to_store:
+            for key in sorted(
+                store_output.keys_to_store,
+                key=lambda accepted_key: source_by_key[accepted_key][0],
+            ):
                 group_idx, block_id, block_idx = source_by_key[key]
                 group_sizes[group_idx] = 1
                 block_indices[group_idx] = block_idx
@@ -1604,7 +1621,10 @@ class OffloadingConnectorScheduler:
         alignment_tokens = (
             self.config.replay_alignment_tokens
             if group_config.uses_sparse_retention
-            else self.config.finished_replay_tail_alignment_tokens
+            else (
+                self.config.finished_replay_tail_alignment_tokens
+                or self.config.replay_alignment_tokens
+            )
         )
         if alignment_tokens is None:
             return ()

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -4,6 +4,7 @@ import time
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
 from itertools import chain, islice
+from math import lcm
 from typing import Any, NamedTuple
 
 import vllm.envs as envs
@@ -188,6 +189,10 @@ class SchedulerOffloadConfig(NamedTuple):
     num_workers: int
     offload_prompt_only: bool
     supports_partial_tail: bool
+    # Token alignment for a completed request's immutable replay tail. This
+    # permits a smaller cache group to identify a stable prefix inside the
+    # final physical block of a larger cache group.
+    finished_replay_tail_alignment_tokens: int | None = None
     # Token alignment of the per-request "replay boundary" tail (see
     # OffloadingConnectorScheduler._reachable_tail_end_chunks). Set to the
     # full-attention alignment size when sparse retention
@@ -330,6 +335,48 @@ class SchedulerOffloadConfig(NamedTuple):
             and vllm_config.parallel_config.decode_context_parallel_size == 1
         )
 
+        # A completed request may safely export the immutable prefix of an
+        # append-only attention page. A Mamba group can participate only when
+        # the replay boundary is one of its complete, densely retained blocks;
+        # recurrent state inside a partial page must never be relabeled as an
+        # earlier boundary. One GPU block per offload chunk lets the worker
+        # copy a containing attention page without sub-page transfer metadata.
+        # The least common multiple of the draft-group chunk sizes is a
+        # complete draft boundary and can identify a stable prefix inside a
+        # larger target-cache page.
+        finished_replay_tail_alignment_tokens: int | None = None
+        eagle_chunk_sizes = [
+            config.tokens_per_chunk
+            for config in kv_group_configs
+            if config.is_eagle_group
+        ]
+        if eagle_chunk_sizes and spec.blocks_per_chunk == 1:
+            group_chunk_sizes = [config.tokens_per_chunk for config in kv_group_configs]
+            replay_alignment = lcm(*eagle_chunk_sizes)
+            groups_support_replay_tail = all(
+                isinstance(group.kv_cache_spec, (FullAttentionSpec, SlidingWindowSpec))
+                or (
+                    isinstance(group.kv_cache_spec, MambaSpec)
+                    and retention_interval is None
+                    and config.tokens_per_chunk == replay_alignment
+                )
+                for group, config in zip(
+                    kv_cache_config.kv_cache_groups, kv_group_configs
+                )
+            )
+            if (
+                groups_support_replay_tail
+                and replay_alignment % spec.tokens_per_hash == 0
+                and any(size != replay_alignment for size in group_chunk_sizes)
+            ):
+                finished_replay_tail_alignment_tokens = replay_alignment
+                logger.info(
+                    "KV offloading: completed-request replay tails use a "
+                    "%d-token boundary across cache-group chunks %s.",
+                    replay_alignment,
+                    group_chunk_sizes,
+                )
+
         return cls(
             num_workers=vllm_config.parallel_config.world_size,
             kv_group_configs=kv_group_configs,
@@ -337,6 +384,9 @@ class SchedulerOffloadConfig(NamedTuple):
             tokens_per_hash=spec.tokens_per_hash,
             offload_prompt_only=spec.offload_prompt_only,
             supports_partial_tail=supports_partial_tail,
+            finished_replay_tail_alignment_tokens=(
+                finished_replay_tail_alignment_tokens
+            ),
             replay_alignment_tokens=(
                 alignment_tokens
                 if any(group.uses_sparse_retention for group in kv_group_configs)
@@ -950,10 +1000,130 @@ class OffloadingConnectorScheduler:
         hash_idx = boundary_tokens // self.config.tokens_per_hash - 1
         return make_offload_key(request.block_hashes[hash_idx], group_idx)
 
+    def _finished_replay_tail_boundary(self, request: Request) -> int | None:
+        """Return the largest stable replay boundary for a finished request."""
+        alignment = self.config.finished_replay_tail_alignment_tokens
+        if alignment is None:
+            return None
+        # Preserve the final prompt token for target logprob production. Draft
+        # groups additionally require one complete chunk beyond the restored
+        # boundary to prove that their trailing state is no longer volatile.
+        max_boundary = request.num_prompt_tokens - self._replay_reserve_tokens
+        boundary = round_down(max_boundary, alignment)
+        return boundary if boundary > 0 else None
+
+    def _lookup_finished_replay_tail(
+        self,
+        req_status: RequestOffloadState,
+        complete_hit: int,
+    ) -> int | None:
+        """Find an immutable completed-request tail beyond complete chunks.
+
+        The boundary key is loaded for every group. An EAGLE/MTP group also
+        needs a later full-chunk key as a stability witness; the witness is
+        checked and retained but is not copied into the request's restored
+        prefix.
+        """
+        max_boundary = self._finished_replay_tail_boundary(req_status.req)
+        alignment = self.config.finished_replay_tail_alignment_tokens
+        local_tokens = req_status.num_locally_computed_tokens
+        complete_boundary = local_tokens + complete_hit
+        if (
+            max_boundary is None
+            or alignment is None
+            or max_boundary <= complete_boundary
+        ):
+            return complete_hit
+
+        pending = False
+        for boundary in range(max_boundary, complete_boundary, -alignment):
+            boundary_pending = False
+            boundary_missed = False
+            # At least one group must carry a completion-only boundary key.
+            # Besides supplying the larger group's partial physical page, this
+            # key proves that the source request reached an immutable terminal
+            # state. An all-aligned boundary has no such marker and remains on
+            # the ordinary complete-chunk lookup path.
+            if not any(
+                boundary % group.tokens_per_chunk
+                for group in self.config.kv_group_configs
+            ):
+                continue
+
+            for group_config, group_state in zip(
+                self.config.kv_group_configs, req_status.group_states
+            ):
+                tokens_per_chunk = group_config.tokens_per_chunk
+                end_chunk_idx = boundary // tokens_per_chunk
+                if boundary % tokens_per_chunk:
+                    keys = [
+                        self._make_boundary_key(
+                            req_status.req, group_config.group_idx, boundary
+                        )
+                    ]
+                elif group_config.sliding_window_size_in_chunks is None:
+                    # A full-attention group must be contiguous from the
+                    # already-qualified complete hit through the finer replay
+                    # boundary. Checking only the final key would admit a
+                    # host-cache hole that prepare_load cannot materialize.
+                    start_chunk_idx = complete_boundary // tokens_per_chunk
+                    keys = group_state.offload_keys[start_chunk_idx:end_chunk_idx]
+                    if len(keys) != end_chunk_idx - start_chunk_idx:
+                        boundary_missed = True
+                        break
+                else:
+                    # Windowed attention and recurrent state need only their
+                    # terminal window at the selected replay boundary.
+                    window = group_config.sliding_window_size_in_chunks
+                    start_chunk_idx = max(0, end_chunk_idx - window)
+                    keys = group_state.offload_keys[start_chunk_idx:end_chunk_idx]
+                    if len(keys) != end_chunk_idx - start_chunk_idx:
+                        boundary_missed = True
+                        break
+                if group_config.is_eagle_group:
+                    keys.append(
+                        self._make_boundary_key(
+                            req_status.req,
+                            group_config.group_idx,
+                            boundary + group_config.tokens_per_chunk,
+                        )
+                    )
+                for key in keys:
+                    result = self.manager.lookup(key, req_status.req_context)
+                    if result is LookupResult.MISS:
+                        boundary_missed = True
+                        break
+                    if result in (LookupResult.HIT_PENDING, LookupResult.RETRY):
+                        boundary_pending = True
+                if boundary_missed:
+                    break
+
+            pending |= boundary_pending
+            if not boundary_missed and not boundary_pending:
+                for group_config in self.config.kv_group_configs:
+                    key = self._make_boundary_key(
+                        req_status.req, group_config.group_idx, boundary
+                    )
+                    self._events_tracker.record_partial_lookup(
+                        req_status.req, group_config, boundary, key
+                    )
+                req_status.partial_tail_boundary = boundary
+                return boundary - local_tokens
+
+        if pending and complete_hit == 0:
+            return None
+        return complete_hit
+
     def _lookup(self, req_status: RequestOffloadState) -> int | None:
         complete_hit = self._lookup_complete_chunks(req_status)
         req_status.partial_tail_boundary = None
-        if complete_hit is None or not self.config.supports_partial_tail:
+        if complete_hit is None:
+            return complete_hit
+
+        replay_tail_hit = self._lookup_finished_replay_tail(req_status, complete_hit)
+        if replay_tail_hit is None or replay_tail_hit > complete_hit:
+            return replay_tail_hit
+        if not self.config.supports_partial_tail:
             return complete_hit
 
         local_tokens = req_status.num_locally_computed_tokens
@@ -997,6 +1167,96 @@ class OffloadingConnectorScheduler:
         if pending and complete_hit == 0:
             return None
         return complete_hit
+
+    def _build_finished_replay_tail_store_jobs(
+        self,
+        scheduler_output: SchedulerOutput,
+    ) -> dict[int, TransferJob]:
+        """Store immutable prefix data from completed requests' final pages."""
+        if self.config.finished_replay_tail_alignment_tokens is None:
+            return {}
+
+        store_jobs: dict[int, TransferJob] = {}
+        for req_id in scheduler_output.finished_req_ids or ():
+            req_status = self._req_status.get(req_id)
+            if req_status is None:
+                continue
+            req = req_status.req
+            if req.status is RequestStatus.FINISHED_ABORTED:
+                continue
+            boundary = self._finished_replay_tail_boundary(req)
+            if boundary is None:
+                continue
+
+            partial_groups = [
+                config
+                for config in self.config.kv_group_configs
+                if boundary % config.tokens_per_chunk != 0
+            ]
+            if not partial_groups:
+                continue
+
+            keys: list[OffloadKey] = []
+            source_by_key: dict[OffloadKey, tuple[int, int, int]] = {}
+            source_missing = False
+            for group_config in partial_groups:
+                group_idx = group_config.group_idx
+                block_idx = (boundary - 1) // group_config.tokens_per_block
+                group_blocks = req_status.group_states[group_idx].block_ids
+                if block_idx >= len(group_blocks) or group_blocks[block_idx] == 0:
+                    source_missing = True
+                    break
+                key = self._make_boundary_key(req, group_idx, boundary)
+                block_id = group_blocks[block_idx]
+                keys.append(key)
+                source_by_key[key] = (group_idx, block_id, block_idx)
+            if source_missing or not keys:
+                continue
+
+            store_output = self.manager.prepare_store(keys, req_status.req_context)
+            if store_output is None:
+                self._connector_stats.increase_counter(
+                    _ConnectorMetricName.ALLOCATION_FAILURE
+                )
+                continue
+            if not store_output.keys_to_store:
+                continue
+
+            group_sizes = [0] * len(self.config.kv_group_configs)
+            block_indices = [0] * len(self.config.kv_group_configs)
+            accepted_block_ids: list[int] = []
+            accepted_keys: set[OffloadKey] = set(store_output.keys_to_store)
+            for key in store_output.keys_to_store:
+                group_idx, block_id, block_idx = source_by_key[key]
+                group_sizes[group_idx] = 1
+                block_indices[group_idx] = block_idx
+                accepted_block_ids.append(block_id)
+                self._events_tracker.record_partial_store(
+                    req, self.config.kv_group_configs[group_idx], boundary, key
+                )
+
+            job_id = self._generate_job_id()
+            req_status.transfer_jobs.add(job_id)
+            for block_id in accepted_block_ids:
+                self._block_id_to_pending_jobs.setdefault(block_id, set()).add(job_id)
+            self._jobs[job_id] = TransferJobStatus(
+                req_id=req_id,
+                pending_count=self.config.num_workers,
+                keys=accepted_keys,
+                is_store=True,
+                fenced_block_ids=accepted_block_ids,
+            )
+            store_jobs[job_id] = TransferJob(
+                req_id=req_id,
+                src_spec=GPULoadStoreSpec(
+                    accepted_block_ids,
+                    group_sizes=group_sizes,
+                    block_indices=block_indices,
+                ),
+                dst_spec=store_output.store_spec,
+            )
+
+        return store_jobs
 
     def on_new_request(self, request: Request) -> None:
         """Called when a new request is added to the scheduler."""
@@ -1334,8 +1594,19 @@ class OffloadingConnectorScheduler:
         Clamp each boundary to the latest point that every group can service,
         including a complete EAGLE/MTP peek chunk.
         """
-        alignment_tokens = self.config.replay_alignment_tokens
-        if alignment_tokens is None or not group_config.uses_sparse_retention:
+        # Sparse-retention groups use the full-attention replay alignment.
+        # Dense recurrent/windowed groups can still be pruned to target-cache
+        # segment boundaries by ``alignment_chunk_count``. When completed-
+        # request replay is enabled, retain their state at the finer draft
+        # boundary while prefill owns the corresponding historical state;
+        # recurrent state cannot be reconstructed from the request's final
+        # block table after generation has advanced past that boundary.
+        alignment_tokens = (
+            self.config.replay_alignment_tokens
+            if group_config.uses_sparse_retention
+            else self.config.finished_replay_tail_alignment_tokens
+        )
+        if alignment_tokens is None:
             return ()
 
         latest_serviceable = req.num_prompt_tokens - self._replay_reserve_tokens
@@ -1598,11 +1869,16 @@ class OffloadingConnectorScheduler:
                 for jid in self._block_id_to_pending_jobs[bid]
             )
 
-        partial_store_jobs = self._build_partial_tail_store_jobs(scheduler_output)
         normal_store_jobs = self._build_store_jobs(scheduler_output)
+        partial_store_jobs = self._build_partial_tail_store_jobs(scheduler_output)
+        replay_tail_store_jobs = self._build_finished_replay_tail_store_jobs(
+            scheduler_output
+        )
         meta = OffloadingConnectorMetadata(
             load_jobs=self._current_batch_load_jobs,
-            store_jobs=partial_store_jobs | normal_store_jobs,
+            store_jobs=(
+                normal_store_jobs | partial_store_jobs | replay_tail_store_jobs
+            ),
             jobs_to_flush=self._current_batch_jobs_to_flush,
         )
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -206,6 +206,16 @@ class SchedulerOffloadConfig(NamedTuple):
         vllm_config: VllmConfig,
         kv_cache_config: KVCacheConfig,
     ) -> "SchedulerOffloadConfig":
+        """Build scheduler-side offload geometry from the cache plan.
+
+        Args:
+            spec: Connector chunking and hashing configuration.
+            vllm_config: Model, scheduler, and parallel runtime configuration.
+            kv_cache_config: Allocated cache groups and their attention specs.
+
+        Returns:
+            Immutable group geometry and replay-boundary capabilities.
+        """
         # Determine the alignment token count from the full-attention group(s).
         # This is the tokens_per_chunk of the full-attention group; load
         # hits are always aligned to this boundary, so SWA blocks earlier in
@@ -1003,7 +1013,14 @@ class OffloadingConnectorScheduler:
         return make_offload_key(request.block_hashes[hash_idx], group_idx)
 
     def _finished_replay_tail_boundary(self, request: Request) -> int | None:
-        """Return the largest stable replay boundary for a finished request."""
+        """Return the largest stable replay boundary for a finished request.
+
+        Args:
+            request: Completed request whose prompt prefix may be exported.
+
+        Returns:
+            Positive aligned token boundary, or ``None`` when none is stable.
+        """
         alignment = self.config.finished_replay_tail_alignment_tokens
         if alignment is None:
             return None
@@ -1025,6 +1042,14 @@ class OffloadingConnectorScheduler:
         needs a later full-chunk key as a stability witness; the witness is
         checked and retained but is not copied into the request's restored
         prefix.
+
+        Args:
+            req_status: Connector state and keys for the request being matched.
+            complete_hit: Tokens matched by ordinary complete-chunk lookup.
+
+        Returns:
+            Additional external-hit tokens after any local prefix, or ``None``
+            while a required asynchronous lookup is pending.
         """
         max_boundary = self._finished_replay_tail_boundary(req_status.req)
         alignment = self.config.finished_replay_tail_alignment_tokens
@@ -1186,7 +1211,14 @@ class OffloadingConnectorScheduler:
         self,
         scheduler_output: SchedulerOutput,
     ) -> dict[int, TransferJob]:
-        """Store immutable prefix data from completed requests' final pages."""
+        """Build stores for immutable data in completed requests' final pages.
+
+        Args:
+            scheduler_output: Finished request IDs and batch scheduling result.
+
+        Returns:
+            Transfer jobs keyed by scheduler-generated job ID.
+        """
         if self.config.finished_replay_tail_alignment_tokens is None:
             return {}
 
@@ -1201,6 +1233,15 @@ class OffloadingConnectorScheduler:
             boundary = self._finished_replay_tail_boundary(req)
             if boundary is None:
                 continue
+            if req_status.max_offload_tokens is not None:
+                alignment = self.config.finished_replay_tail_alignment_tokens
+                assert alignment is not None
+                boundary = min(
+                    boundary,
+                    round_down(req_status.max_offload_tokens, alignment),
+                )
+                if boundary == 0:
+                    continue
 
             partial_groups = [
                 config


### PR DESCRIPTION
## Behavior

Status: implemented. TP16/DCP16 runtime qualification covers commit
`2be610a9cc`; the additional safety checks at the PR head are unit-tested.

Native host KV offload can restore a completed request at the
speculative-draft cache boundary when larger target-attention pages are only
partially filled. The scheduler retains recurrent checkpoints during prefill,
exports immutable data from containing target pages after completion, and maps
every cache group to the same token boundary during replay.

## Activation and dependency

The replay-tail path activates only when all of these conditions hold:

- one GPU block per offload chunk;
- at least one speculative-draft cache group;
- draft chunk sizes have a common hash-aligned boundary;
- cache groups use compatible dense attention, sliding-window attention, or
  aligned dense recurrent state;
- at least one cache-group chunk is larger than the draft boundary.

PR #441 supplies metadata-based Kimi draft-group classification. The two PRs
target `dev/infernal-invocation` independently and may be merged in either
order. Without #441, conservative group classification keeps this optimization
dormant for Kimi-K3.

## Safety contract

A replay-tail hit requires:

- a completion-only key from every partially filled larger page;
- contiguous keys for full-attention groups beyond the ordinary complete hit;
- the terminal window for windowed or recurrent groups;
- one later complete speculative-draft key as a stability witness.

Aborted requests do not create replay-tail entries. Uniform and unsupported
cache layouts retain complete-chunk behavior. Lookup probes are bounded to the
physical page after the ordinary complete hit; a farther boundary could not be
loaded contiguously. Accepted source blocks are ordered by cache-group index
before constructing positional load metadata. Non-sparse retention falls back
to the existing replay alignment when completed-tail alignment is unavailable. Completion-only stores also honor each request’s `max_offload_tokens` limit.

## Validation

Twelve focused replay-tail tests pass in the CUDA 13.3/PyTorch 2.13 runtime
image. They cover mixed block geometry, missing completion or draft keys,
full-attention holes, local-prefix deltas, bounded long-prompt lookup, partial
page stores, manager-order independence, request-level token limits, aborted and missing-source requests,
load mappings, and recurrent-boundary retention. `ruff check`, `ruff format
--check`, `py_compile`, and `git diff --check` pass.

Full-model qualification at commit `2be610a9cc` used official Kimi-K3 MXFP4
with Inferact DSpark7, TP16/DCP16, 1,033,126 GPU KV token positions, a 32 GiB
native host tier, and a 134,219-token multimodal request.

| Metric | Complete target pages | Replay-tail path |
|---|---:|---:|
| External hit tokens | 122,880 | 132,864 |
| Recomputed prompt tokens | 11,339 | 1,355 |
| Engine prefill | 9.239 s median | 1.270 s median |
| API TTFT | 9.544 s median | 1.577 s median |
| Host-to-GPU copy | 0.166 s median | 0.173 s median |
| Host KV bytes after cold seed | 12,706,283,520 | 13,361,135,616 |

Three replay repetitions returned HTTP 200, emitted terminal stream events,
contained no protocol control markers, and restored the same 132,864-token
boundary. The exact source tree, launch command, receipts, and limitations are
documented in the [Kimi-K3 native host KV offload specification](https://github.com/local-inference-lab/rtx6kpro/blob/f2923ac1b67eccc3d6d73226e936da6ba6e43967/models/kimi-k3/native-host-kv-offload.md).