### PR TITLE
[II] Bound B12X MoE workspace per launch

### DIFF
--- a/tests/model_executor/layers/test_b12x_moe_warmup.py
+++ b/tests/model_executor/layers/test_b12x_moe_warmup.py
@@ -432,12 +432,15 @@ def test_b12x_moe_warmup_uses_workspace_token_limit(monkeypatch) -> None:
         "_dynamic_moe_warmup_tokens",
         lambda *, topk, quant_mode, requested_tokens: requested_tokens,
     )
+
+    def record_plan(**kwargs):
+        planned_tokens.append(kwargs["tokens"])
+        return _FakePlan().launch_plan
+
     monkeypatch.setattr(
         b12x_moe,
         "_plan_b12x_moe_execution",
-        lambda **kwargs: (
-            planned_tokens.append(kwargs["tokens"]) or _FakePlan().launch_plan
-        ),
+        record_plan,
     )
     monkeypatch.setattr(
         b12x_moe,

--- a/tests/model_executor/layers/test_b12x_moe_warmup.py
+++ b/tests/model_executor/layers/test_b12x_moe_warmup.py
@@ -422,12 +422,159 @@ def test_b12x_moe_warmup_runs_one_launch_per_planner_regime(monkeypatch) -> None
     assert run_tokens == [3, 8]
 
 
+def test_b12x_moe_warmup_uses_workspace_token_limit(monkeypatch) -> None:
+    planned_tokens = []
+    run_tokens = []
+
+    monkeypatch.setenv("B12X_MOE_WORKSPACE_TOKEN_LIMIT", "4")
+    monkeypatch.setattr(
+        b12x_moe,
+        "_dynamic_moe_warmup_tokens",
+        lambda *, topk, quant_mode, requested_tokens: requested_tokens,
+    )
+    monkeypatch.setattr(
+        b12x_moe,
+        "_plan_b12x_moe_execution",
+        lambda **kwargs: (
+            planned_tokens.append(kwargs["tokens"]) or _FakePlan().launch_plan
+        ),
+    )
+    monkeypatch.setattr(
+        b12x_moe,
+        "_plan_b12x_moe_fp4_scratch",
+        lambda **kwargs: _FakePlan(),
+    )
+    monkeypatch.setattr(
+        b12x_moe,
+        "_run_b12x_moe_fp4",
+        lambda **kwargs: run_tokens.append(kwargs["a"].shape[0]),
+    )
+
+    experts = _make_fake_b12x_experts()
+    layer = SimpleNamespace(
+        w13_weight=torch.empty(8, 32, 32, dtype=torch.uint8),
+        w2_weight=torch.empty(8, 64, 8, dtype=torch.uint8),
+        activation=MoEActivation.SWIGLUOAI_UNINTERLEAVE,
+        apply_router_weight_on_input=False,
+    )
+
+    warmed = experts.warmup_dynamic_launches(layer, token_counts=(8,))
+
+    assert warmed == 1
+    assert planned_tokens == [4]
+    assert run_tokens == [4]
+
+
+def test_b12x_moe_workspace_limit_is_disabled_for_kquant_capture(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("B12X_MOE_WORKSPACE_TOKEN_LIMIT", "2")
+    monkeypatch.setenv("VLLM_KQUANT_CAPTURE_DIR", "/tmp/kquant-capture")
+
+    assert b12x_moe._moe_workspace_tokens(5) == 5
+
+
 def test_b12x_force_a16_nvfp4_selects_w4a16(monkeypatch) -> None:
     monkeypatch.setenv("B12X_MOE_FORCE_A16", "1")
 
     experts = _make_fake_b12x_experts()
 
     assert experts._quant_mode() == "w4a16"
+
+
+def test_b12x_moe_workspace_limit_bounds_scratch_not_output(monkeypatch) -> None:
+    planned_tokens = []
+
+    def fake_plan(**kwargs):
+        planned_tokens.append(kwargs["tokens"])
+        return _FakePlan()
+
+    monkeypatch.setenv("B12X_MOE_WORKSPACE_TOKEN_LIMIT", "2")
+    monkeypatch.setattr(b12x_moe, "_plan_b12x_moe_fp4_scratch", fake_plan)
+
+    experts = _make_fake_b12x_experts()
+    workspace13, workspace2, output = experts.workspace_shapes(
+        M=5,
+        N=32,
+        K=64,
+        topk=4,
+        global_num_experts=8,
+        local_num_experts=8,
+        expert_tokens_meta=None,
+        activation=MoEActivation.SWIGLUOAI_UNINTERLEAVE,
+    )
+
+    assert planned_tokens == [2]
+    assert workspace13 == (0,)
+    assert workspace2 == (32,)
+    assert output == (5, 64)
+
+
+def test_b12x_moe_workspace_limit_chunks_token_independent_launches(
+    monkeypatch,
+) -> None:
+    planned_tokens = []
+    run_calls = []
+
+    def fake_plan(**kwargs):
+        planned_tokens.append(kwargs["tokens"])
+        return _FakePlan()
+
+    def fake_run(**kwargs):
+        run_calls.append(kwargs)
+        kwargs["output"].copy_(kwargs["a"])
+
+    monkeypatch.setenv("B12X_MOE_WORKSPACE_TOKEN_LIMIT", "2")
+    monkeypatch.setenv("B12X_MOE_FORCE_A16", "1")
+    monkeypatch.setattr(b12x_moe, "_plan_b12x_moe_fp4_scratch", fake_plan)
+    monkeypatch.setattr(b12x_moe, "_run_b12x_moe_fp4", fake_run)
+
+    local_num_experts = 8
+    global_num_experts = 12
+    experts = _make_fake_b12x_experts()
+    experts._prepared_experts = _make_fake_prepared_experts(
+        quant_mode="w4a16",
+        num_experts=local_num_experts,
+    )
+    expert_map = torch.tensor(
+        [0, -1, 1, -1, 2, -1, 3, 4, -1, 5, 6, 7],
+        dtype=torch.int32,
+    )
+    hidden_states = torch.arange(5 * 64, dtype=torch.bfloat16).view(5, 64)
+    output = torch.empty_like(hidden_states)
+    topk_ids = torch.arange(5 * 4, dtype=torch.int32).view(5, 4) % 12
+    topk_weights = torch.full((5, 4), 0.25, dtype=torch.float32)
+
+    experts.apply(
+        output=output,
+        hidden_states=hidden_states,
+        w1=torch.empty(0, dtype=torch.uint8),
+        w2=torch.empty(0, dtype=torch.uint8),
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        activation=MoEActivation.SWIGLUOAI_UNINTERLEAVE,
+        global_num_experts=global_num_experts,
+        expert_map=expert_map,
+        a1q_scale=None,
+        a2_scale=None,
+        workspace13=None,
+        workspace2=torch.empty(64, dtype=torch.uint8),
+        expert_tokens_meta=None,
+        apply_router_weight_on_input=False,
+    )
+
+    assert planned_tokens == [2, 2, 1]
+    assert [call["a"].shape[0] for call in run_calls] == [2, 2, 1]
+    assert all(call["route_expert_map"] is expert_map for call in run_calls)
+    assert all(
+        call["plan"] is not None and call["output"].shape == call["a"].shape
+        for call in run_calls
+    )
+    assert torch.equal(torch.cat([call["topk_ids"] for call in run_calls]), topk_ids)
+    assert torch.equal(
+        torch.cat([call["topk_weights"] for call in run_calls]), topk_weights
+    )
+    assert torch.equal(output, hidden_states)
 
 
 def test_b12x_activation_amax_registers_stable_vllm_owned_tensor(

--- a/vllm/model_executor/layers/fused_moe/b12x_moe.py
+++ b/vllm/model_executor/layers/fused_moe/b12x_moe.py
@@ -66,6 +66,25 @@ def _env_first(*names: str) -> str | None:
     return None
 
 
+def _moe_workspace_token_limit() -> int:
+    """Return the maximum token rows processed by one B12X MoE launch.
+
+    A zero value leaves the logical batch unbounded. KQuant calibration keeps
+    one launch per logical batch because its sampling coordinates are defined
+    over the complete row range.
+    """
+    if os.getenv("VLLM_KQUANT_CAPTURE_DIR"):
+        return 0
+    return max(_env_int("B12X_MOE_WORKSPACE_TOKEN_LIMIT", 0), 0)
+
+
+def _moe_workspace_tokens(num_tokens: int) -> int:
+    """Bound one launch's scratch geometry without changing output shape."""
+    num_tokens = max(int(num_tokens), 1)
+    limit = _moe_workspace_token_limit()
+    return min(num_tokens, limit) if limit else num_tokens
+
+
 def _moe_repeat_check_enabled() -> bool:
     return _env_flag("B12X_MOE_REPEAT_CHECK") or _env_flag("VLLM_B12X_MOE_REPEAT_CHECK")
 
@@ -1365,6 +1384,7 @@ class B12xExperts(mk.FusedMoEExpertsModular):
                 quant_mode=meta.quant_mode,
                 requested_tokens=requested_tokens,
             )
+            tokens = _moe_workspace_tokens(tokens)
             launch_plan = _plan_b12x_moe_execution(
                 tokens=tokens,
                 topk=meta.topk,
@@ -1513,7 +1533,7 @@ class B12xExperts(mk.FusedMoEExpertsModular):
         ):
             swiglu_limit = None
         plan = _plan_b12x_moe_fp4_scratch(
-            tokens=max(int(M), 1),
+            tokens=_moe_workspace_tokens(M),
             topk=int(topk),
             device=device,
             quant_mode=quant_mode,
@@ -1590,42 +1610,8 @@ class B12xExperts(mk.FusedMoEExpertsModular):
             swiglu_limit = None
         topk_ids = _normalize_b12x_moe_topk_ids(topk_ids)
         topk_weights = _normalize_b12x_moe_topk_weights(topk_weights)
-        plan = _plan_b12x_moe_fp4_scratch(
-            tokens=int(hidden_states.shape[0]),
-            topk=int(topk_ids.shape[1]),
-            device=hidden_states.device,
-            quant_mode=quant_mode,
-            experts=prepared,
-            apply_router_weight_on_input=(
-                apply_router_weight_on_input
-                if apply_router_weight_on_input is not None
-                else False
-            ),
-            swiglu_limit=swiglu_limit,
-            swiglu_alpha=swiglu_alpha,
-            swiglu_beta=swiglu_beta,
-            collect_activation_amax=activation_amax is not None,
-            route_num_experts=(
-                int(global_num_experts) if expert_map is not None else 0
-            ),
-        )
-        scratch = _workspace2_as_b12x_scratch(workspace2, plan)
-
-        binding = _run_b12x_moe_fp4(
-            a=hidden_states,
-            experts=prepared,
-            topk_weights=topk_weights,
-            topk_ids=topk_ids,
-            output=output,
-            input_scales_static=input_scales_static,
-            unit_scale_contract=unit_scale_contract,
-            plan=plan,
-            scratch=scratch,
-            activation_amax=activation_amax,
-            layer_idx=activation_layer_idx,
-            route_expert_map=expert_map,
-        )
-        if os.getenv("VLLM_KQUANT_CAPTURE_DIR"):
+        capture_kquant = bool(os.getenv("VLLM_KQUANT_CAPTURE_DIR"))
+        if capture_kquant:
             from vllm.model_executor.layers.fused_moe.kquant_capture import (
                 collect_kquant_mid,
             )
@@ -1635,25 +1621,69 @@ class B12xExperts(mk.FusedMoEExpertsModular):
                 raise RuntimeError(
                     "KQuant capture was enabled after B12X weight preparation"
                 )
-            collect_kquant_mid(
-                prefix=prefix,
-                binding=binding,
-                topk_weights=topk_weights,
-                topk_ids=topk_ids,
-            )
-        if activation_amax is None:
-            _maybe_repeat_check_b12x_moe(
-                original_output=output,
-                a=hidden_states,
+
+        num_tokens = int(hidden_states.shape[0])
+        tokens_per_launch = _moe_workspace_tokens(num_tokens)
+        for start in range(0, num_tokens, tokens_per_launch):
+            end = min(start + tokens_per_launch, num_tokens)
+            chunk_hidden_states = hidden_states[start:end]
+            chunk_topk_weights = topk_weights[start:end]
+            chunk_topk_ids = topk_ids[start:end]
+            chunk_output = output[start:end]
+            plan = _plan_b12x_moe_fp4_scratch(
+                tokens=end - start,
+                topk=int(topk_ids.shape[1]),
+                device=hidden_states.device,
+                quant_mode=quant_mode,
                 experts=prepared,
-                topk_weights=topk_weights,
-                topk_ids=topk_ids,
+                apply_router_weight_on_input=(
+                    apply_router_weight_on_input
+                    if apply_router_weight_on_input is not None
+                    else False
+                ),
+                swiglu_limit=swiglu_limit,
+                swiglu_alpha=swiglu_alpha,
+                swiglu_beta=swiglu_beta,
+                collect_activation_amax=activation_amax is not None,
+                route_num_experts=(
+                    int(global_num_experts) if expert_map is not None else 0
+                ),
+            )
+            scratch = _workspace2_as_b12x_scratch(workspace2, plan)
+            binding = _run_b12x_moe_fp4(
+                a=chunk_hidden_states,
+                experts=prepared,
+                topk_weights=chunk_topk_weights,
+                topk_ids=chunk_topk_ids,
+                output=chunk_output,
                 input_scales_static=input_scales_static,
                 unit_scale_contract=unit_scale_contract,
                 plan=plan,
                 scratch=scratch,
+                activation_amax=activation_amax,
+                layer_idx=activation_layer_idx,
                 route_expert_map=expert_map,
             )
+            if capture_kquant:
+                collect_kquant_mid(
+                    prefix=prefix,
+                    binding=binding,
+                    topk_weights=chunk_topk_weights,
+                    topk_ids=chunk_topk_ids,
+                )
+            if activation_amax is None:
+                _maybe_repeat_check_b12x_moe(
+                    original_output=chunk_output,
+                    a=chunk_hidden_states,
+                    experts=prepared,
+                    topk_weights=chunk_topk_weights,
+                    topk_ids=chunk_topk_ids,
+                    input_scales_static=input_scales_static,
+                    unit_scale_contract=unit_scale_contract,
+                    plan=plan,
+                    scratch=scratch,
+                    route_expert_map=expert_map,
+                )
 
     def moe_sum(self, input: torch.Tensor, output: torch.Tensor) -> None:
         raise NotImplementedError("LoRA is not supported for B12xExperts")

--- a/vllm/model_executor/layers/fused_moe/b12x_moe.py
+++ b/vllm/model_executor/layers/fused_moe/b12x_moe.py
@@ -1675,6 +1675,7 @@ class B12xExperts(mk.FusedMoEExpertsModular):
                 route_expert_map=expert_map,
             )
             if capture_kquant:
+                assert prefix is not None
                 collect_kquant_mid(
                     prefix=prefix,
                     binding=binding,

--- a/vllm/model_executor/layers/fused_moe/b12x_moe.py
+++ b/vllm/model_executor/layers/fused_moe/b12x_moe.py
@@ -72,6 +72,9 @@ def _moe_workspace_token_limit() -> int:
     A zero value leaves the logical batch unbounded. KQuant calibration keeps
     one launch per logical batch because its sampling coordinates are defined
     over the complete row range.
+
+    Returns:
+        Maximum rows per launch, or zero when launch rows are unbounded.
     """
     if os.getenv("VLLM_KQUANT_CAPTURE_DIR"):
         return 0
@@ -79,7 +82,14 @@ def _moe_workspace_token_limit() -> int:
 
 
 def _moe_workspace_tokens(num_tokens: int) -> int:
-    """Bound one launch's scratch geometry without changing output shape."""
+    """Bound one launch's scratch geometry without changing output shape.
+
+    Args:
+        num_tokens: Logical token rows requested by the caller.
+
+    Returns:
+        Token rows represented by one B12X scratch plan or launch.
+    """
     num_tokens = max(int(num_tokens), 1)
     limit = _moe_workspace_token_limit()
     return min(num_tokens, limit) if limit else num_tokens


### PR DESCRIPTION
## Behavior

`B12X_MOE_WORKSPACE_TOKEN_LIMIT` bounds the token rows represented by one B12X MoE scratch plan without reducing the logical output shape. Token-independent MoE execution is split into consecutive row chunks when the logical batch exceeds the limit.

The default value is zero, which preserves unbounded execution. KQuant capture remains one launch per logical batch because its sampling coordinates cover the complete row range.

## Technical reason

Explicit large scheduler chunks can otherwise size temporary B12X scratch from the complete scheduler capacity. Separating launch geometry from logical output geometry permits a bounded scratch allocation while preserving routed expert IDs, expert maps, weights, and output row order.

## Compatibility

- Opt-in through `B12X_MOE_WORKSPACE_TOKEN_LIMIT`.
- No behavior change when the variable is unset or zero.
- KQuant capture ignores the limit.
- Expert-parallel maps are shared by every row chunk; token-dependent tensors are sliced consistently.

## Validation

- `ruff check` and `ruff format --check` pass for the changed files.
- Four focused unit tests pass for warmup planning, workspace geometry, routed row chunking, and KQuant capture behavior.
- Integrated runtime condition: official Kimi-K3 MXFP4 target, Inferact DSpark7 MXFP8 draft, TP16/DCP16, effective 4096-token scheduler chunks, `B12X_MOE_WORKSPACE_TOKEN_LIMIT=4096`, and B12X PR #238.
- Integrated result: 1,057,049 physical KV-cache tokens and median prefill throughput of 3,861.7 tok/s at 8k, 3,732.5 tok/s at 32k, and 3,554.4 tok/s at 64k.



## Integrated numerical qualification

Status: **qualified** with B12X PR #238 for teacher-forced distributions at
2,048-token context.

This vLLM change preserves logical output geometry and row order. The
integrated 4,096-token profile also enables the bounded FP32 route accumulator
from B12X PR #238, which changes floating-point addition order and therefore
requires distribution-level validation.

A shared-LM-head, full-vocabulary replay covers 1,024 Kimi-K3 contexts and
2,096,128 scored positions. The complete materialized-versus-bounded result is
mean KLD 0.003135632 and 98.4209% top-1 agreement. A 64-context stratified
runtime-repeat control measures a paired bounded excess of +0.000049403 KLD
with a 95% interval of [-0.000111022, +0.000257288]. The interval crosses zero,
so no fidelity loss beyond runtime-repeat variation is detected. Bitwise
identity remains unsupported.

The [method and complete results](https://github.com/local-inference-lab/rtx6kpro/blob/master/models/kimi-k3/full-mxfp4-p4096-prefill.md#distribution-fidelity-qualification)
include exact checkpoint, topology, kernel, capture, comparator, and artifact
identities.