### PR TITLE
[II] Reuse Kimi vision Q/K buffers for RoPE

### DIFF
--- a/tests/models/kimi_k3/test_vision_projector.py
+++ b/tests/models/kimi_k3/test_vision_projector.py
@@ -14,6 +14,7 @@ from vllm.model_executor.layers.linear import (
 )
 from vllm.model_executor.models.kimi_k25_vit import (
     KimiK25MultiModalProjector,
+    apply_rope,
     mm_projector_forward,
 )
 from vllm.transformers_utils.configs.kimi_k3 import KimiK3VisionConfig
@@ -97,3 +98,29 @@ def test_kimi_projector_uses_norm_activation_dtype_for_fp8_weights():
     assert projector.input_dtype == torch.bfloat16
     assert [output.shape for output in outputs] == [(2, 4), (1, 4)]
     assert all(output.dtype == torch.bfloat16 for output in outputs)
+
+
+def test_kimi_vision_rope_reuses_packed_qk_buffers():
+    packed_qkv = torch.randn(17, 3, 4, 8, dtype=torch.bfloat16)
+    query, key, _ = torch.unbind(packed_qkv, dim=1)
+    phases = torch.randn(17, 4)
+    frequencies = torch.polar(torch.ones_like(phases), phases)
+
+    def reference(inputs: torch.Tensor) -> torch.Tensor:
+        complex_inputs = torch.view_as_complex(
+            inputs.float().view(*inputs.shape[:-1], -1, 2)
+        )
+        rotated = complex_inputs * frequencies.unsqueeze(-2)
+        return torch.view_as_real(rotated).flatten(-2).to(inputs.dtype)
+
+    expected_query = reference(query)
+    expected_key = reference(key)
+    query_pointer = query.data_ptr()
+    key_pointer = key.data_ptr()
+
+    output_query, output_key = apply_rope(query, key, frequencies)
+
+    assert output_query.data_ptr() == query_pointer
+    assert output_key.data_ptr() == key_pointer
+    torch.testing.assert_close(output_query, expected_query, rtol=0, atol=0)
+    torch.testing.assert_close(output_key, expected_key, rtol=0, atol=0)

--- a/vllm/model_executor/models/kimi_k25_vit.py
+++ b/vllm/model_executor/models/kimi_k25_vit.py
@@ -90,12 +90,18 @@ def apply_rope(
     _apply_rope_input_validation(xk, freqs_cis)
 
     freqs_cis = freqs_cis.unsqueeze(-2)  # ..., 1, head_dim/2
-    # ..., num_heads, head_dim/2
-    xq_ = torch.view_as_complex(xq.float().view(*xq.shape[:-1], -1, 2))
-    xk_ = torch.view_as_complex(xk.float().view(*xq.shape[:-1], -1, 2))
-    xq_out = torch.view_as_real(xq_ * freqs_cis).flatten(-2)  # ..., num_heads, head_dim
-    xk_out = torch.view_as_real(xk_ * freqs_cis).flatten(-2)  # ..., num_heads, head_dim
-    return xq_out.type_as(xq), xk_out.type_as(xk)
+
+    # Q and K are non-overlapping views of the packed QKV projection. Their
+    # unrotated values are dead after this call, so reuse those BF16 buffers
+    # instead of retaining two additional full-size outputs. Processing Q and
+    # K sequentially also permits the allocator to reuse the FP32 temporary.
+    xq_complex = torch.view_as_complex(xq.float().view(*xq.shape[:-1], -1, 2))
+    xq.copy_(torch.view_as_real(xq_complex * freqs_cis).flatten(-2))
+    del xq_complex
+
+    xk_complex = torch.view_as_complex(xk.float().view(*xk.shape[:-1], -1, 2))
+    xk.copy_(torch.view_as_real(xk_complex * freqs_cis).flatten(-2))
+    return xq, xk
 
 
 def get_1d_sincos_pos_embed_from_grid(embed_dim, pos):


### PR DESCRIPTION
## Behavior

Kimi vision RoPE writes rotated query and key values back into their non-overlapping views of the packed QKV projection.

## Technical reason

The unrotated query and key values are dead after RoPE. Reusing their BF16 storage removes two full-size output allocations and processing the tensors sequentially permits allocator reuse of the FP32 conversion temporary.

## Compatibility

- The input Q and K views are intentionally mutated; callers receive the same views.
- Frequency validation and BF16 rounding behavior are unchanged.
- The value projection is not modified.
- Text-only Kimi execution is unaffected.

## Validation

- `ruff check` and `ruff format --check` pass for the changed files.
- Four Kimi vision-projector tests pass.
- The RoPE test verifies Q/K storage identity and exact BF16 equality with the allocating reference expression.

