### PR TITLE
[II] Allow expandable CUDA segments for local KV offload

### DIFF
--- a/tests/v1/kv_connector/unit/test_config.py
+++ b/tests/v1/kv_connector/unit/test_config.py
@@ -103,13 +103,18 @@ def _build_config(
     kv_connector: str | None,
     enable_sleep_mode: bool = False,
     enable_cumem_allocator: bool = False,
+    kv_connector_extra_config: dict | None = None,
 ) -> VllmConfig:
     """Build a VllmConfig that exercises _verify_kv_transfer_compat without
     requiring a real model (avoids HF downloads in CI)."""
     from types import SimpleNamespace
 
     kv_transfer_config = (
-        KVTransferConfig(kv_connector=kv_connector, kv_role="kv_both")
+        KVTransferConfig(
+            kv_connector=kv_connector,
+            kv_role="kv_both",
+            kv_connector_extra_config=kv_connector_extra_config or {},
+        )
         if kv_connector is not None
         else None
     )
@@ -150,6 +155,35 @@ def test_kv_connector_allows_expandable_segments_with_cumem_allocator(
     """Manual CuMem allocation must also bypass expandable_segments."""
     monkeypatch.setenv("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
     _build_config(kv_connector="NixlConnector", enable_cumem_allocator=True)
+
+
+@pytest.mark.parametrize(
+    "kv_connector", ["OffloadingConnector", "SimpleCPUOffloadConnector"]
+)
+def test_local_offload_allows_expandable_segments(monkeypatch, kv_connector):
+    """Local CPU copies do not retain GPU physical-page registrations."""
+    monkeypatch.setenv("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+    _build_config(kv_connector=kv_connector)
+
+
+@pytest.mark.parametrize("spec_name", ["TieringOffloadingSpec", "ExternalSpec"])
+def test_nonlocal_offloading_spec_with_expandable_segments_is_rejected(
+    monkeypatch, spec_name
+):
+    """Tiered and out-of-tree specs may retain GPU page registrations."""
+    monkeypatch.setenv("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+    with pytest.raises(ValueError, match="expandable_segments"):
+        _build_config(
+            kv_connector="OffloadingConnector",
+            kv_connector_extra_config={"spec_name": spec_name},
+        )
+
+
+def test_unknown_connector_with_expandable_segments_stays_rejected(monkeypatch):
+    """An unresolved connector has no verified VMM-safety contract."""
+    monkeypatch.setenv("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+    with pytest.raises(ValueError, match="expandable_segments"):
+        _build_config(kv_connector="SomeOOTConnector")
 
 
 def test_kv_connector_allows_other_alloc_conf(monkeypatch):

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1039,19 +1039,20 @@ class VllmConfig:
         # registrations pointing at stale physical pages after any remap,
         # producing RDMA failures like IBV_WC_REM_ACCESS_ERR /
         # NIXL_ERR_REMOTE_DISCONNECT at the first inter-node KV transfer.
-        # We can't enumerate every in-tree and out-of-tree connector that
-        # pins memory, so we conservatively reject the combination whenever
-        # any KV connector is configured.
-        #
         # CuMem allocator is exempt: CuMemAllocator.use_memory_pool toggles
         # expandable_segments off around its pool (see #40812), so the KV
         # cache allocated within that context lands on stable physical pages
         # even when the env var is set.
+        # Local copy-only connectors are also exempt when their connector
+        # class explicitly declares VMM-safe transfers. Unknown and
+        # out-of-tree connectors remain rejected by default.
         if "expandable_segments:True" not in os.environ.get(
             "PYTORCH_CUDA_ALLOC_CONF", ""
         ):
             return
         if self.model_config is not None and (self.model_config.enable_cumem_allocator):
+            return
+        if self._connector_supports_vmm_safe_transfers():
             return
 
         raise ValueError(
@@ -1061,11 +1062,29 @@ class VllmConfig:
             "allocator can remap KV cache virtual addresses to different "
             "physical pages, invalidating any pinned/registered KV memory "
             "(e.g. IB memory regions registered by NIXL or Mooncake). Either "
-            "unset expandable_segments:True or enable the cumem allocator "
+            "unset expandable_segments:True, enable the cumem allocator "
             "(sleep mode does this automatically and also "
             "routes KV allocations through CuMemAllocator's pool, where "
-            "expandable_segments is automatically disabled)."
+            "expandable_segments is automatically disabled), or use a "
+            "connector that declares SupportsVmmSafeTransfers."
         )
+
+    def _connector_supports_vmm_safe_transfers(self) -> bool:
+        """Resolve the connector's explicit CUDA VMM transfer contract."""
+        from vllm.distributed.kv_transfer.kv_connector.factory import (
+            KVConnectorFactory,
+        )
+        from vllm.distributed.kv_transfer.kv_connector.v1 import (
+            supports_vmm_safe_transfers,
+        )
+
+        try:
+            connector_cls = KVConnectorFactory.get_connector_class(
+                self.kv_transfer_config
+            )
+        except (AttributeError, ImportError, TypeError, ValueError):
+            return False
+        return supports_vmm_safe_transfers(connector_cls, self.kv_transfer_config)
 
     def __post_init__(self):
         """Verify configs are valid & consistent with each other."""

--- a/vllm/distributed/kv_transfer/kv_connector/v1/__init__.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/__init__.py
@@ -4,7 +4,9 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorBase_V1,
     KVConnectorRole,
     SupportsHMA,
+    SupportsVmmSafeTransfers,
     supports_hma,
+    supports_vmm_safe_transfers,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.decode_bench_connector import (  # noqa: E501
     DecodeBenchConnector,
@@ -15,5 +17,7 @@ __all__ = [
     "KVConnectorBase_V1",
     "supports_hma",
     "SupportsHMA",
+    "supports_vmm_safe_transfers",
+    "SupportsVmmSafeTransfers",
     "DecodeBenchConnector",
 ]

--- a/vllm/distributed/kv_transfer/kv_connector/v1/base.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/base.py
@@ -53,7 +53,7 @@ from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.outputs import KVConnectorOutput
 
 if TYPE_CHECKING:
-    from vllm.config import VllmConfig
+    from vllm.config import KVTransferConfig, VllmConfig
     from vllm.distributed.kv_events import KVCacheEvent, KVConnectorKVEvents
     from vllm.distributed.kv_transfer.kv_connector.v1.metrics import (
         KVConnectorPromMetrics,
@@ -119,6 +119,33 @@ def supports_hma(connector: Any) -> bool:
         return issubclass(connector, SupportsHMA)
     else:
         return isinstance(connector, SupportsHMA)
+
+
+class SupportsVmmSafeTransfers(ABC):
+    """Declare connector configurations that tolerate CUDA VMM remapping.
+
+    A qualifying configuration accesses GPU buffers through virtual addresses
+    at transfer time and does not retain GPU physical-page registrations
+    through RDMA, GPUDirect, GDS, or an equivalent interface.
+    """
+
+    @classmethod
+    @abstractmethod
+    def supports_vmm_safe_transfer_config(
+        cls, kv_transfer_config: "KVTransferConfig"
+    ) -> bool:
+        """Return whether this exact connector configuration is VMM-safe."""
+        raise NotImplementedError
+
+
+def supports_vmm_safe_transfers(
+    connector: Any, kv_transfer_config: "KVTransferConfig"
+) -> bool:
+    """Evaluate a connector's explicit VMM-safety contract."""
+    connector_cls = connector if isinstance(connector, type) else type(connector)
+    return issubclass(
+        connector_cls, SupportsVmmSafeTransfers
+    ) and connector_cls.supports_vmm_safe_transfer_config(kv_transfer_config)
 
 
 class KVConnectorRole(enum.Enum):

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading_connector.py
@@ -5,12 +5,13 @@ from typing import Any
 
 import torch
 
-from vllm.config import VllmConfig
+from vllm.config import KVTransferConfig, VllmConfig
 from vllm.distributed.kv_events import KVCacheEvent
 from vllm.distributed.kv_transfer.kv_connector.v1 import (
     KVConnectorBase_V1,
     KVConnectorRole,
     SupportsHMA,
+    SupportsVmmSafeTransfers,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorMetadata
 from vllm.distributed.kv_transfer.kv_connector.v1.metrics import (
@@ -46,7 +47,22 @@ from vllm.v1.outputs import KVConnectorOutput
 from vllm.v1.request import Request
 
 
-class OffloadingConnector(KVConnectorBase_V1, SupportsHMA):
+class OffloadingConnector(KVConnectorBase_V1, SupportsHMA, SupportsVmmSafeTransfers):
+    """KV offload with a configuration-selected storage implementation.
+
+    The built-in CPU implementation pins host storage for asynchronous copies
+    but never registers GPU cache pages. Tiered and out-of-tree implementations
+    may use RDMA and do not share that property.
+    """
+
+    @classmethod
+    def supports_vmm_safe_transfer_config(
+        cls, kv_transfer_config: KVTransferConfig
+    ) -> bool:
+        extra_config = kv_transfer_config.kv_connector_extra_config or {}
+        spec_name = extra_config.get("spec_name", "CPUOffloadingSpec")
+        return spec_name == "CPUOffloadingSpec"
+
     @property
     def prefer_cross_layer_blocks(self) -> bool:
         return True

--- a/vllm/distributed/kv_transfer/kv_connector/v1/simple_cpu_offload_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/simple_cpu_offload_connector.py
@@ -7,13 +7,14 @@ from typing import TYPE_CHECKING, Any
 
 import torch
 
-from vllm.config import VllmConfig
+from vllm.config import KVTransferConfig, VllmConfig
 from vllm.distributed.kv_events import KVCacheEvent
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorBase_V1,
     KVConnectorMetadata,
     KVConnectorRole,
     SupportsHMA,
+    SupportsVmmSafeTransfers,
 )
 from vllm.logger import init_logger
 from vllm.v1.core.sched.output import SchedulerOutput
@@ -51,8 +52,20 @@ _DISK_ONLY_KEYS = (
 )
 
 
-class SimpleCPUOffloadConnector(KVConnectorBase_V1, SupportsHMA):
-    """CPU KV cache offloading with custom kernel transfers and BlockPool LRU."""
+class SimpleCPUOffloadConnector(
+    KVConnectorBase_V1, SupportsHMA, SupportsVmmSafeTransfers
+):
+    """CPU KV offload using copy operations on GPU virtual addresses.
+
+    The connector does not retain GPU physical-page registrations, so its GPU
+    transfers tolerate PyTorch expandable CUDA VMM segments.
+    """
+
+    @classmethod
+    def supports_vmm_safe_transfer_config(
+        cls, kv_transfer_config: KVTransferConfig
+    ) -> bool:
+        return True
 
     @property
     def requires_kv_delivery(self) -> bool:


### PR DESCRIPTION
## Behavior

KV connector classes can declare whether a resolved connector configuration retains CUDA allocation addresses. Expandable CUDA segments are accepted for `OffloadingConnector` with `CPUOffloadingSpec` and for `SimpleCPUOffloadConnector`. Tiered offload, out-of-tree specifications, unresolved connectors, NIXL, and Mooncake remain rejected.

## Technical reason

The two accepted local CPU offload configurations perform bounded copies and do not retain GPU physical-page registrations. Rejecting expandable segments for those configurations causes avoidable fragmentation near a manually sized KV-cache limit. The compatibility decision must depend on the resolved connector configuration rather than only the connector class.

## Compatibility

Connectors without the capability declaration preserve the existing rejection. The capability is opt-in and receives the complete KV-transfer configuration. No transfer or cache data path changes.

## Validation

- 11 connector and expandable-segment compatibility tests: passed.
- Ruff, Python bytecode validation, and `git diff --check`: passed.
- Runtime qualification uses `OffloadingConnector` with `CPUOffloadingSpec`, vision, prefix caching, TP16/DCP16, and an explicitly sized physical KV cache.