### PR TITLE
[II] Reuse Kimi-K3 prefill output storage

### DIFF
--- a/tests/model_executor/layers/fused_moe/test_shared_experts_stream.py
+++ b/tests/model_executor/layers/fused_moe/test_shared_experts_stream.py
@@ -20,6 +20,22 @@ class _PartialOutputTransform(torch.nn.Module):
         return hidden_states
 
 
+class _BufferedPartialOutputTransform(torch.nn.Module):
+    output_is_tp_partial = True
+
+    def can_write_output(
+        self, hidden_states: torch.Tensor, output: torch.Tensor
+    ) -> bool:
+        return hidden_states.shape == output.shape
+
+    def forward(
+        self, hidden_states: torch.Tensor, output: torch.Tensor | None = None
+    ) -> torch.Tensor:
+        assert output is not None
+        output.copy_(hidden_states)
+        return output
+
+
 def test_aux_stream_output_lifetime_extends_to_consumer(monkeypatch) -> None:
     shared_experts = object.__new__(SharedExperts)
     aux_stream = Mock()
@@ -95,4 +111,66 @@ def test_tp_partial_output_transform_defers_shared_reduce(monkeypatch) -> None:
 
     assert len(reduced_inputs) == 1
     torch.testing.assert_close(reduced_inputs[0], shared_output + fused_output)
+    torch.testing.assert_close(actual, (shared_output + fused_output) * 2)
+
+
+def test_tp_partial_output_transform_reuses_dead_input(monkeypatch) -> None:
+    runner = object.__new__(MoERunner)
+    torch.nn.Module.__init__(runner)
+    runner.routed_output_transform = _BufferedPartialOutputTransform()
+    runner.routed_input_transform = None
+    runner.routed_scaling_factor = 1.0
+    runner.router = None
+    runner.layer_name = "test"
+    runner.moe_config = SimpleNamespace(
+        hidden_dim_unpadded=4,
+        is_sequence_parallel=False,
+        skip_final_all_reduce=False,
+        tp_size=2,
+        ep_size=1,
+    )
+    runner.routed_experts = SimpleNamespace(
+        quant_method=SimpleNamespace(
+            has_unpadded_output=False,
+            moe_kernel=SimpleNamespace(output_is_reduced=lambda: True),
+        )
+    )
+    runner._maybe_pad_hidden_states = MethodType(
+        lambda self, shared, routed: (routed, None, None),
+        runner,
+    )
+
+    shared_output = torch.full((2, 4), 2.0)
+    fused_output = torch.full((2, 4), 3.0)
+    runner._forward_entry = Mock(return_value=(shared_output, fused_output))
+    functional_reduce = Mock()
+    reduced_ptrs: list[int] = []
+
+    def all_reduce_in_place(hidden_states: torch.Tensor) -> torch.Tensor:
+        reduced_ptrs.append(hidden_states.data_ptr())
+        hidden_states.mul_(2)
+        return hidden_states
+
+    monkeypatch.setattr(
+        moe_runner_module,
+        "tensor_model_parallel_all_reduce",
+        functional_reduce,
+    )
+    monkeypatch.setattr(
+        moe_runner_module,
+        "tensor_model_parallel_all_reduce_in_place",
+        all_reduce_in_place,
+    )
+
+    dead_input = torch.zeros_like(shared_output)
+    dead_input_ptr = dead_input.data_ptr()
+    actual = runner.forward(
+        torch.zeros_like(shared_output),
+        router_logits=torch.empty(2, 1),
+        shared_experts_input=dead_input,
+    )
+
+    assert actual.data_ptr() == dead_input_ptr
+    assert reduced_ptrs == [dead_input_ptr]
+    functional_reduce.assert_not_called()
     torch.testing.assert_close(actual, (shared_output + fused_output) * 2)

--- a/tests/model_executor/layers/fused_moe/test_shared_experts_stream.py
+++ b/tests/model_executor/layers/fused_moe/test_shared_experts_stream.py
@@ -301,3 +301,74 @@ def test_tp_partial_output_transform_accumulates_into_reused_shared_input(
     assert actual.data_ptr() == input_ptr
     assert reduced_ptrs == [input_ptr]
     torch.testing.assert_close(actual, torch.full_like(actual, 10.0))
+
+
+def test_reused_shared_input_reduces_latent_output_in_place(monkeypatch) -> None:
+    runner = object.__new__(MoERunner)
+    torch.nn.Module.__init__(runner)
+    runner.routed_output_transform = _ResidualPartialOutputTransform()
+    runner.routed_input_transform = None
+    runner.routed_scaling_factor = 1.0
+    runner.router = None
+    runner.layer_name = "test"
+    runner.moe_config = SimpleNamespace(
+        hidden_dim_unpadded=4,
+        is_sequence_parallel=False,
+        skip_final_all_reduce=False,
+        tp_size=2,
+        ep_size=1,
+    )
+    runner.routed_experts = SimpleNamespace(
+        quant_method=SimpleNamespace(
+            has_unpadded_output=False,
+            moe_kernel=SimpleNamespace(output_is_reduced=lambda: False),
+        )
+    )
+    runner._maybe_pad_hidden_states = MethodType(
+        lambda self, shared, routed: (routed, None, None),
+        runner,
+    )
+    runner._shared_experts = SimpleNamespace(can_reuse_input=lambda value: True)
+
+    fused_output = torch.full((2, 4), 3.0)
+
+    def reuse_entry(*args):
+        shared_input = args[2]
+        shared_input.fill_(2)
+        return fused_output
+
+    runner._shared_input_reuse_entry = Mock(side_effect=reuse_entry)
+    runner._forward_entry = Mock()
+    functional_reduce = Mock()
+    reduced_ptrs: list[int] = []
+
+    def all_reduce_in_place(hidden_states: torch.Tensor) -> torch.Tensor:
+        reduced_ptrs.append(hidden_states.data_ptr())
+        hidden_states.mul_(2)
+        return hidden_states
+
+    monkeypatch.setattr(
+        moe_runner_module,
+        "tensor_model_parallel_all_reduce",
+        functional_reduce,
+    )
+    monkeypatch.setattr(
+        moe_runner_module,
+        "tensor_model_parallel_all_reduce_in_place",
+        all_reduce_in_place,
+    )
+
+    shared_input = torch.zeros_like(fused_output)
+    shared_input_ptr = shared_input.data_ptr()
+    fused_output_ptr = fused_output.data_ptr()
+    actual = runner.forward(
+        torch.zeros_like(fused_output),
+        router_logits=torch.empty(2, 1),
+        shared_experts_input=shared_input,
+    )
+
+    runner._forward_entry.assert_not_called()
+    functional_reduce.assert_not_called()
+    assert actual.data_ptr() == shared_input_ptr
+    assert reduced_ptrs == [fused_output_ptr, shared_input_ptr]
+    torch.testing.assert_close(actual, torch.full_like(actual, 16.0))

--- a/tests/model_executor/layers/fused_moe/test_shared_experts_stream.py
+++ b/tests/model_executor/layers/fused_moe/test_shared_experts_stream.py
@@ -10,7 +10,10 @@ import torch
 import vllm.model_executor.layers.fused_moe.runner.moe_runner as moe_runner_module
 import vllm.model_executor.layers.fused_moe.runner.shared_experts as shared_module
 from vllm.model_executor.layers.fused_moe.runner.moe_runner import MoERunner
-from vllm.model_executor.layers.fused_moe.runner.shared_experts import SharedExperts
+from vllm.model_executor.layers.fused_moe.runner.shared_experts import (
+    SharedExperts,
+    SharedExpertsOrder,
+)
 
 
 class _PartialOutputTransform(torch.nn.Module):
@@ -33,6 +36,38 @@ class _BufferedPartialOutputTransform(torch.nn.Module):
     ) -> torch.Tensor:
         assert output is not None
         output.copy_(hidden_states)
+        return output
+
+
+class _ResidualPartialOutputTransform(torch.nn.Module):
+    output_is_tp_partial = True
+
+    def can_accumulate_residual(
+        self, hidden_states: torch.Tensor, residual: torch.Tensor
+    ) -> bool:
+        return hidden_states.shape == residual.shape
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        assert residual is not None
+        residual.add_(hidden_states)
+        return residual
+
+
+class _InputReusingSharedLayer(torch.nn.Module):
+    def should_use_caller_output(self, hidden_states: torch.Tensor) -> bool:
+        return hidden_states.shape[0] >= 4
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        output: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        assert output is not None
+        output.copy_(hidden_states + 1)
         return output
 
 
@@ -59,6 +94,33 @@ def test_aux_stream_output_lifetime_extends_to_consumer(monkeypatch) -> None:
     shared_experts._layer.assert_called_once_with(shared_experts_input)
     consumer_stream.wait_stream.assert_called_once_with(aux_stream)
     output.record_stream.assert_called_once_with(consumer_stream)
+
+
+def test_shared_expert_reuses_input_only_for_synchronous_execution() -> None:
+    shared_experts = object.__new__(SharedExperts)
+    torch.nn.Module.__init__(shared_experts)
+    shared_experts.enable_dbo = False
+    shared_experts._output = [None, None]
+    shared_experts._layer = _InputReusingSharedLayer()
+    shared_experts._determine_shared_experts_order = MethodType(
+        lambda self, hidden_states: SharedExpertsOrder.NO_OVERLAP,
+        shared_experts,
+    )
+
+    shared_input = torch.arange(16).view(4, 4).float()
+    expected = shared_input + 1
+    input_ptr = shared_input.data_ptr()
+
+    assert shared_experts.can_reuse_input(shared_input)
+    shared_experts(
+        shared_input,
+        SharedExpertsOrder.NO_OVERLAP,
+        reuse_input=True,
+    )
+    output = shared_experts.output
+
+    assert output.data_ptr() == input_ptr
+    torch.testing.assert_close(output, expected)
 
 
 def test_tp_partial_output_transform_defers_shared_reduce(monkeypatch) -> None:
@@ -174,3 +236,68 @@ def test_tp_partial_output_transform_reuses_dead_input(monkeypatch) -> None:
     assert reduced_ptrs == [dead_input_ptr]
     functional_reduce.assert_not_called()
     torch.testing.assert_close(actual, (shared_output + fused_output) * 2)
+
+
+def test_tp_partial_output_transform_accumulates_into_reused_shared_input(
+    monkeypatch,
+) -> None:
+    runner = object.__new__(MoERunner)
+    torch.nn.Module.__init__(runner)
+    runner.routed_output_transform = _ResidualPartialOutputTransform()
+    runner.routed_input_transform = None
+    runner.routed_scaling_factor = 1.0
+    runner.router = None
+    runner.layer_name = "test"
+    runner.moe_config = SimpleNamespace(
+        hidden_dim_unpadded=4,
+        is_sequence_parallel=False,
+        skip_final_all_reduce=False,
+        tp_size=2,
+        ep_size=1,
+    )
+    runner.routed_experts = SimpleNamespace(
+        quant_method=SimpleNamespace(
+            has_unpadded_output=False,
+            moe_kernel=SimpleNamespace(output_is_reduced=lambda: True),
+        )
+    )
+    runner._maybe_pad_hidden_states = MethodType(
+        lambda self, shared, routed: (routed, None, None),
+        runner,
+    )
+    runner._shared_experts = SimpleNamespace(can_reuse_input=lambda value: True)
+
+    fused_output = torch.full((2, 4), 3.0)
+
+    def reuse_entry(*args):
+        shared_input = args[2]
+        shared_input.fill_(2)
+        return fused_output
+
+    runner._shared_input_reuse_entry = Mock(side_effect=reuse_entry)
+    runner._forward_entry = Mock()
+    reduced_ptrs: list[int] = []
+
+    def all_reduce_in_place(hidden_states: torch.Tensor) -> torch.Tensor:
+        reduced_ptrs.append(hidden_states.data_ptr())
+        hidden_states.mul_(2)
+        return hidden_states
+
+    monkeypatch.setattr(
+        moe_runner_module,
+        "tensor_model_parallel_all_reduce_in_place",
+        all_reduce_in_place,
+    )
+
+    shared_input = torch.zeros_like(fused_output)
+    input_ptr = shared_input.data_ptr()
+    actual = runner.forward(
+        torch.zeros_like(fused_output),
+        router_logits=torch.empty(2, 1),
+        shared_experts_input=shared_input,
+    )
+
+    runner._forward_entry.assert_not_called()
+    assert actual.data_ptr() == input_ptr
+    assert reduced_ptrs == [input_ptr]
+    torch.testing.assert_close(actual, torch.full_like(actual, 10.0))

--- a/tests/model_executor/layers/test_b12x_moe_warmup.py
+++ b/tests/model_executor/layers/test_b12x_moe_warmup.py
@@ -118,6 +118,22 @@ def test_b12x_moe_runner_uses_functional_custom_op(monkeypatch) -> None:
     assert forward_entry._qualified_op_name == "vllm::b12x_moe_forward"
 
 
+def test_b12x_moe_runner_uses_shared_input_reuse_custom_op(monkeypatch) -> None:
+    monkeypatch.setattr(
+        moe_runner,
+        "current_platform",
+        SimpleNamespace(is_tpu=lambda: False, is_cpu=lambda: False),
+    )
+
+    runner = _make_fake_moe_runner(object.__new__(b12x_moe.B12xExperts))
+
+    forward_entry = runner._select_shared_input_reuse_forward()
+
+    assert forward_entry._qualified_op_name == (
+        "vllm::b12x_moe_forward_shared_input_reuse"
+    )
+
+
 def test_non_b12x_moe_runner_keeps_generic_custom_op(monkeypatch) -> None:
     monkeypatch.setattr(
         moe_runner,
@@ -132,16 +148,42 @@ def test_non_b12x_moe_runner_keeps_generic_custom_op(monkeypatch) -> None:
     assert forward_entry._qualified_op_name == "vllm::moe_forward"
 
 
+def test_non_b12x_moe_runner_keeps_generic_shared_input_reuse_op(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        moe_runner,
+        "current_platform",
+        SimpleNamespace(is_tpu=lambda: False, is_cpu=lambda: False),
+    )
+
+    runner = _make_fake_moe_runner(object())
+
+    forward_entry = runner._select_shared_input_reuse_forward()
+
+    assert forward_entry._qualified_op_name == "vllm::moe_forward_shared_input_reuse"
+
+
 def test_b12x_moe_custom_op_matches_generic_mutation_contract() -> None:
     b12x_schema = str(torch.ops.vllm.b12x_moe_forward.default._schema)
     b12x_shared_schema = str(torch.ops.vllm.b12x_moe_forward_shared.default._schema)
     generic_schema = str(torch.ops.vllm.moe_forward.default._schema)
     generic_shared_schema = str(torch.ops.vllm.moe_forward_shared.default._schema)
+    b12x_reuse_schema = str(
+        torch.ops.vllm.b12x_moe_forward_shared_input_reuse.default._schema
+    )
+    generic_reuse_schema = str(
+        torch.ops.vllm.moe_forward_shared_input_reuse.default._schema
+    )
 
     assert "Tensor(a0!) hidden_states" in generic_schema
     assert "Tensor(a0!) hidden_states" in generic_shared_schema
     assert "Tensor(a0!) hidden_states" in b12x_schema
     assert "Tensor(a0!) hidden_states" in b12x_shared_schema
+    assert "Tensor(a0!) hidden_states" in generic_reuse_schema
+    assert "!)? shared_experts_input" in generic_reuse_schema
+    assert "Tensor(a0!) hidden_states" in b12x_reuse_schema
+    assert "!)? shared_experts_input" in b12x_reuse_schema
 
 
 def test_b12x_moe_run_binds_only_the_prepared_expert_owner(monkeypatch) -> None:

--- a/tests/models/kimi_k3/test_mlp_tensor_lifetime.py
+++ b/tests/models/kimi_k3/test_mlp_tensor_lifetime.py
@@ -6,6 +6,7 @@ import pytest
 import torch
 from torch import nn
 
+from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import UnquantizedLinearMethod
 from vllm.models.kimi_k3.nvidia.model import (
     KimiMLP,
@@ -51,6 +52,19 @@ class _DownInto(nn.Module):
         self.output_size = hidden_size
         self.reduce_results = tp_size > 1
         self.tp_size = tp_size
+
+
+def _make_rms_norm(hidden_size: int) -> RMSNorm:
+    norm = object.__new__(RMSNorm)
+    nn.Module.__init__(norm)
+    norm.hidden_size = hidden_size
+    norm.variance_epsilon = 1e-5
+    norm.variance_size_override = None
+    norm.has_weight = True
+    norm.pass_weight = True
+    norm.pass_weight_add = True
+    norm.weight = nn.Parameter(torch.ones(hidden_size), requires_grad=False)
+    return norm
 
 
 def test_mlp_releases_gate_up_before_down_projection() -> None:
@@ -180,6 +194,52 @@ def test_routed_output_transform_keeps_decode_on_allocating_path() -> None:
     output = torch.empty(8, 4)
 
     assert not transform.can_write_output(hidden_states, output)
+
+
+def test_routed_output_transform_normalizes_consumed_prefill_latent_in_place(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    norm = _make_rms_norm(4)
+    transform = KimiRoutedOutputTransform(norm, nn.Identity(), layer_idx=0)
+    hidden_states = torch.arange(16).view(4, 4).float()
+    expected = hidden_states.clone()
+    input_pointer = hidden_states.data_ptr()
+    calls: list[tuple[int, int, float]] = []
+
+    def _rms_norm(
+        output: torch.Tensor,
+        input_tensor: torch.Tensor,
+        weight: torch.Tensor,
+        epsilon: float,
+    ) -> None:
+        calls.append((output.data_ptr(), input_tensor.data_ptr(), epsilon))
+        output.copy_(input_tensor.clone() * weight)
+
+    monkeypatch.setattr(
+        KimiRoutedOutputTransform,
+        "can_normalize_routed_latent_in_place",
+        lambda _self, _hidden_states: True,
+    )
+    monkeypatch.setattr(
+        "vllm.models.kimi_k3.nvidia.model.ops.rms_norm",
+        _rms_norm,
+    )
+
+    with torch.inference_mode():
+        actual = transform.normalize_routed_latent(hidden_states)
+
+    assert actual.data_ptr() == input_pointer
+    assert calls == [(input_pointer, input_pointer, 1e-5)]
+    torch.testing.assert_close(actual, expected)
+
+
+def test_routed_output_transform_keeps_cpu_latent_on_allocating_norm_path() -> None:
+    norm = _make_rms_norm(4)
+    transform = KimiRoutedOutputTransform(norm, nn.Identity(), layer_idx=0)
+    hidden_states = torch.arange(4096).view(1024, 4).float()
+
+    with torch.inference_mode():
+        assert not transform.can_normalize_routed_latent_in_place(hidden_states)
 
 
 def test_routed_output_transform_accumulates_prefill_in_bounded_tiles() -> None:

--- a/tests/models/kimi_k3/test_mlp_tensor_lifetime.py
+++ b/tests/models/kimi_k3/test_mlp_tensor_lifetime.py
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import weakref
+
+import pytest
+import torch
+from torch import nn
+
+from vllm.model_executor.layers.linear import UnquantizedLinearMethod
+from vllm.models.kimi_k3.nvidia.model import KimiMLP
+
+
+class _GateUp(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.output_ref: weakref.ReferenceType[torch.Tensor] | None = None
+
+    def forward(self, x: torch.Tensor):
+        output = torch.cat((x, x), dim=-1)
+        self.output_ref = weakref.ref(output)
+        return output, None
+
+
+class _Activation(nn.Module):
+    def forward(self, gate_up: torch.Tensor) -> torch.Tensor:
+        return gate_up.chunk(2, dim=-1)[0].clone()
+
+
+class _Down(nn.Module):
+    def __init__(self, gate_up: _GateUp) -> None:
+        super().__init__()
+        self.gate_up = gate_up
+
+    def forward(self, x: torch.Tensor):
+        assert self.gate_up.output_ref is not None
+        assert self.gate_up.output_ref() is None
+        return x, None
+
+
+class _DownInto(nn.Module):
+    def __init__(self, hidden_size: int, tp_size: int = 1) -> None:
+        super().__init__()
+        self.quant_method = UnquantizedLinearMethod()
+        self.input_is_parallel = True
+        self.bias = None
+        self.weight = nn.Parameter(torch.eye(hidden_size))
+        self.output_size = hidden_size
+        self.reduce_results = tp_size > 1
+        self.tp_size = tp_size
+
+
+def test_mlp_releases_gate_up_before_down_projection() -> None:
+    mlp = KimiMLP.__new__(KimiMLP)
+    nn.Module.__init__(mlp)
+    gate_up = _GateUp()
+    mlp.gate_up_proj = gate_up
+    mlp.act_fn = _Activation()
+    mlp.down_proj = _Down(gate_up)
+    mlp.shard_sequence_parallel = False
+
+    input_tensor = torch.randn(2, 4)
+    torch.testing.assert_close(mlp(input_tensor), input_tensor)
+
+
+def test_mlp_reuses_caller_output_for_unquantized_down_projection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mlp = KimiMLP.__new__(KimiMLP)
+    nn.Module.__init__(mlp)
+    gate_up = _GateUp()
+    mlp.gate_up_proj = gate_up
+    mlp.act_fn = _Activation()
+    mlp.down_proj = _DownInto(hidden_size=4, tp_size=2)
+    mlp.shard_sequence_parallel = False
+
+    reduced_ptrs: list[int] = []
+
+    def _all_reduce_in_place(output: torch.Tensor) -> torch.Tensor:
+        reduced_ptrs.append(output.data_ptr())
+        output.mul_(2)
+        return output
+
+    monkeypatch.setattr(
+        "vllm.models.kimi_k3.nvidia.model.tensor_model_parallel_all_reduce_in_place",
+        _all_reduce_in_place,
+    )
+
+    input_tensor = torch.randn(2, 4)
+    expected = input_tensor * 2
+    input_ptr = input_tensor.data_ptr()
+    with torch.inference_mode():
+        output = mlp(input_tensor, output=input_tensor)
+
+    assert output.data_ptr() == input_ptr
+    assert reduced_ptrs == [input_ptr]
+    torch.testing.assert_close(output, expected)
+    assert gate_up.output_ref is not None
+    assert gate_up.output_ref() is None
+
+
+def test_mlp_rejects_activation_output_as_caller_output() -> None:
+    mlp = KimiMLP.__new__(KimiMLP)
+    nn.Module.__init__(mlp)
+    mlp.down_proj = _DownInto(hidden_size=4)
+
+    activation = torch.randn(2, 4)
+    with pytest.raises(ValueError, match="must not alias"):
+        mlp._down_proj_into(activation, activation)
+
+
+def test_mlp_preserves_functional_decode_collective() -> None:
+    mlp = KimiMLP.__new__(KimiMLP)
+    nn.Module.__init__(mlp)
+    mlp.down_proj = _DownInto(hidden_size=4, tp_size=2)
+
+    assert not mlp.should_use_caller_output(torch.empty(8, 4))
+    assert mlp.should_use_caller_output(torch.empty(1024, 4))

--- a/tests/models/kimi_k3/test_mlp_tensor_lifetime.py
+++ b/tests/models/kimi_k3/test_mlp_tensor_lifetime.py
@@ -7,7 +7,11 @@ import torch
 from torch import nn
 
 from vllm.model_executor.layers.linear import UnquantizedLinearMethod
-from vllm.models.kimi_k3.nvidia.model import KimiMLP
+from vllm.models.kimi_k3.nvidia.model import (
+    KimiMLP,
+    KimiPaddedRowParallelLinear,
+    KimiRoutedOutputTransform,
+)
 
 
 class _GateUp(nn.Module):
@@ -115,3 +119,54 @@ def test_mlp_preserves_functional_decode_collective() -> None:
 
     assert not mlp.should_use_caller_output(torch.empty(8, 4))
     assert mlp.should_use_caller_output(torch.empty(1024, 4))
+
+
+def test_routed_output_transform_reuses_full_width_prefill_input() -> None:
+    projection = object.__new__(KimiPaddedRowParallelLinear)
+    nn.Module.__init__(projection)
+    projection.input_pad = 0
+    projection.input_is_parallel = False
+    projection.tp_size = 2
+    projection.tp_rank = 0
+    projection.output_size = 4
+    projection.reduce_results = False
+    projection.quant_method = UnquantizedLinearMethod()
+    projection.register_parameter("bias", None)
+    projection.weight = nn.Parameter(
+        torch.arange(12).view(4, 3).float(), requires_grad=False
+    )
+
+    transform = KimiRoutedOutputTransform(None, projection, layer_idx=0)
+    hidden_states = torch.arange(1024 * 6).view(1024, 6).float()
+    output = torch.empty(1024, 4)
+    output_ptr = output.data_ptr()
+    expected = torch.mm(hidden_states[:, :3], projection.weight.t())
+
+    assert transform.can_write_output(hidden_states, output)
+    with torch.inference_mode():
+        actual = transform(hidden_states, output=output)
+
+    assert actual.data_ptr() == output_ptr
+    torch.testing.assert_close(actual, expected)
+
+
+def test_routed_output_transform_keeps_decode_on_allocating_path() -> None:
+    projection = object.__new__(KimiPaddedRowParallelLinear)
+    nn.Module.__init__(projection)
+    projection.input_pad = 0
+    projection.input_is_parallel = False
+    projection.tp_size = 2
+    projection.tp_rank = 0
+    projection.output_size = 4
+    projection.reduce_results = False
+    projection.quant_method = UnquantizedLinearMethod()
+    projection.register_parameter("bias", None)
+    projection.weight = nn.Parameter(
+        torch.arange(12).view(4, 3).float(), requires_grad=False
+    )
+
+    transform = KimiRoutedOutputTransform(None, projection, layer_idx=0)
+    hidden_states = torch.arange(8 * 6).view(8, 6).float()
+    output = torch.empty(8, 4)
+
+    assert not transform.can_write_output(hidden_states, output)

--- a/tests/models/kimi_k3/test_mlp_tensor_lifetime.py
+++ b/tests/models/kimi_k3/test_mlp_tensor_lifetime.py
@@ -112,13 +112,23 @@ def test_mlp_rejects_activation_output_as_caller_output() -> None:
         mlp._down_proj_into(activation, activation)
 
 
-def test_mlp_preserves_functional_decode_collective() -> None:
+def test_mlp_caller_output_selection_uses_prefill_threshold() -> None:
     mlp = KimiMLP.__new__(KimiMLP)
     nn.Module.__init__(mlp)
     mlp.down_proj = _DownInto(hidden_size=4, tp_size=2)
+    mlp.shard_sequence_parallel = False
 
     assert not mlp.should_use_caller_output(torch.empty(8, 4))
     assert mlp.should_use_caller_output(torch.empty(1024, 4))
+
+
+def test_mlp_caller_output_selection_rejects_sequence_parallel() -> None:
+    mlp = KimiMLP.__new__(KimiMLP)
+    nn.Module.__init__(mlp)
+    mlp.down_proj = _DownInto(hidden_size=4, tp_size=2)
+    mlp.shard_sequence_parallel = True
+
+    assert not mlp.should_use_caller_output(torch.empty(1024, 4))
 
 
 def test_routed_output_transform_reuses_full_width_prefill_input() -> None:

--- a/tests/models/kimi_k3/test_mlp_tensor_lifetime.py
+++ b/tests/models/kimi_k3/test_mlp_tensor_lifetime.py
@@ -180,3 +180,33 @@ def test_routed_output_transform_keeps_decode_on_allocating_path() -> None:
     output = torch.empty(8, 4)
 
     assert not transform.can_write_output(hidden_states, output)
+
+
+def test_routed_output_transform_accumulates_prefill_in_bounded_tiles() -> None:
+    projection = object.__new__(KimiPaddedRowParallelLinear)
+    nn.Module.__init__(projection)
+    projection.input_pad = 0
+    projection.input_is_parallel = False
+    projection.tp_size = 2
+    projection.tp_rank = 0
+    projection.output_size = 2048
+    projection.reduce_results = False
+    projection.quant_method = UnquantizedLinearMethod()
+    projection.register_parameter("bias", None)
+    projection.weight = nn.Parameter(
+        torch.arange(2048 * 3).view(2048, 3).float() / 1024,
+        requires_grad=False,
+    )
+
+    transform = KimiRoutedOutputTransform(None, projection, layer_idx=0)
+    hidden_states = torch.arange(1024 * 6).view(1024, 6).float() / 1024
+    residual = torch.arange(1024 * 2048).view(1024, 2048).float() / 2048
+    expected = residual + torch.mm(hidden_states[:, :3], projection.weight.t())
+    residual_ptr = residual.data_ptr()
+
+    assert transform.can_accumulate_residual(hidden_states, residual)
+    with torch.inference_mode():
+        actual = transform(hidden_states, residual=residual)
+
+    assert actual.data_ptr() == residual_ptr
+    torch.testing.assert_close(actual, expected)

--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -14,6 +14,7 @@ from vllm.distributed import (
     get_ep_group,
     get_pcp_group,
     tensor_model_parallel_all_reduce,
+    tensor_model_parallel_all_reduce_in_place,
 )
 from vllm.distributed.eplb.eplb_state import EplbLayerState
 from vllm.forward_context import (
@@ -411,6 +412,7 @@ class MoERunner(MoERunnerInterface):
     def apply_routed_output_transform(
         self,
         fused_output: torch.Tensor,
+        output: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """Apply transform to routed expert output (e.g., latent to full dim).
 
@@ -419,9 +421,29 @@ class MoERunner(MoERunnerInterface):
         the full hidden dimension before combining with shared expert output.
         """
         if self.routed_output_transform is not None:
-            r = self.routed_output_transform(fused_output)
+            if output is None:
+                r = self.routed_output_transform(fused_output)
+            else:
+                r = self.routed_output_transform(fused_output, output=output)
             fused_output = r[0] if isinstance(r, tuple) else r
         return fused_output
+
+    def _get_routed_output_buffer(
+        self,
+        fused_output: torch.Tensor,
+        shared_experts_input: torch.Tensor | None,
+    ) -> torch.Tensor | None:
+        """Return dead caller storage accepted by the output transform."""
+        if shared_experts_input is None or self.routed_output_transform is None:
+            return None
+        can_write_output = getattr(
+            self.routed_output_transform, "can_write_output", None
+        )
+        if can_write_output is None or not can_write_output(
+            fused_output, shared_experts_input
+        ):
+            return None
+        return shared_experts_input
 
     def _maybe_apply_routed_scale_to_output(
         self,
@@ -499,6 +521,8 @@ class MoERunner(MoERunnerInterface):
         states: torch.Tensor,
         trunc_size: int | None,
         output_is_reduced: bool | None = None,
+        *,
+        in_place: bool = False,
     ) -> torch.Tensor:
         """All-reduce the combined output if needed.
 
@@ -526,7 +550,10 @@ class MoERunner(MoERunnerInterface):
             and (self.moe_config.tp_size > 1 or self.moe_config.ep_size > 1)
             and not output_is_reduced
         ):
-            states = tensor_model_parallel_all_reduce(states)
+            if in_place:
+                states = tensor_model_parallel_all_reduce_in_place(states)
+            else:
+                states = tensor_model_parallel_all_reduce(states)
 
         return states[..., :trunc_size] if trunc_size is not None else states
 
@@ -822,18 +849,32 @@ class MoERunner(MoERunnerInterface):
             shared_output, fused_output
         )
 
-        # Apply output transform (e.g. latent -> full dim)
-        fused_output = self.apply_routed_output_transform(fused_output)
+        # The shared-expert input is dead after _forward_entry returns. Output
+        # transforms that explicitly accept caller-owned storage may reuse it
+        # for allocation-sensitive prefill projections.
+        routed_output_buffer = self._get_routed_output_buffer(
+            fused_output, shared_experts_input
+        )
+        fused_output = self.apply_routed_output_transform(
+            fused_output, output=routed_output_buffer
+        )
         if output_transform_is_tp_partial:
             fused_output_is_reduced = False
 
         if shared_output is not None:
-            result = shared_output + fused_output
+            if routed_output_buffer is not None:
+                fused_output.add_(shared_output)
+                result = fused_output
+            else:
+                result = shared_output + fused_output
         else:
             result = fused_output
 
         result = self._maybe_reduce_final_output(
-            result, og_hidden_dim_post_xform, fused_output_is_reduced
+            result,
+            og_hidden_dim_post_xform,
+            fused_output_is_reduced,
+            in_place=routed_output_buffer is not None,
         )
 
         return self._maybe_add_zero_expert_output(result)

--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -598,12 +598,15 @@ class MoERunner(MoERunnerInterface):
         self,
         fused_output: torch.Tensor,
         fused_output_is_reduced: bool,
+        *,
+        in_place: bool = False,
     ) -> tuple[torch.Tensor, bool]:
         """All-reduce latent routed output before its output transform.
 
         Latent MoE output transforms may contain non-linear ops, e.g. RMSNorm.
         TP partial routed outputs must be summed in latent space before such
-        transforms are applied.
+        transforms are applied. ``in_place`` is valid only when the local
+        partial tensor has no consumer after the collective.
         """
         if (
             self.routed_output_transform is not None
@@ -611,7 +614,10 @@ class MoERunner(MoERunnerInterface):
             and (self.moe_config.tp_size > 1 or self.moe_config.ep_size > 1)
             and not fused_output_is_reduced
         ):
-            fused_output = tensor_model_parallel_all_reduce(fused_output)
+            if in_place:
+                fused_output = tensor_model_parallel_all_reduce_in_place(fused_output)
+            else:
+                fused_output = tensor_model_parallel_all_reduce(fused_output)
             fused_output_is_reduced = True
         return fused_output, fused_output_is_reduced
 
@@ -949,6 +955,7 @@ class MoERunner(MoERunnerInterface):
             self._maybe_reduce_routed_output_before_transform(
                 fused_output,
                 fused_output_is_reduced,
+                in_place=reuse_shared_experts_input,
             )
         )
 

--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -189,8 +189,47 @@ def _moe_forward_shared_fake(
     return shared_out, fused_out
 
 
-# NOTE: `moe_forward` and `moe_forward_shared` being opaque custom ops is a
-# load-bearing assumption for the MoE-LoRA dual-stream path.
+def _moe_forward_shared_input_reuse(
+    hidden_states: torch.Tensor,
+    router_logits: torch.Tensor,
+    shared_experts_input: torch.Tensor | None,
+    input_ids: torch.Tensor | None,
+    layer_name: _layer_name_type,
+    hidden_dim_unpadded: int,
+) -> torch.Tensor:
+    """Run MoE while overwriting the consumed shared-expert input.
+
+    The dedicated operator schema declares the input mutation without exposing
+    an aliased output, which keeps functionalization and CUDA Graph ownership
+    explicit.
+    """
+    if shared_experts_input is None:
+        raise ValueError("Shared-expert input reuse requires a shared input tensor")
+    layer = get_layer_from_name(_resolve_layer_name(layer_name))
+    result = layer._forward_impl(
+        hidden_states,
+        router_logits,
+        shared_experts_input,
+        input_ids,
+        reuse_shared_experts_input=True,
+    )
+    if not isinstance(result, tuple):
+        raise RuntimeError("Shared-expert input reuse requires separate MoE outputs")
+    shared_output, fused_output = result
+    if (
+        shared_output.shape != shared_experts_input.shape
+        or shared_output.untyped_storage().data_ptr()
+        != shared_experts_input.untyped_storage().data_ptr()
+    ):
+        raise RuntimeError(
+            "Shared expert did not write its result into the declared input buffer"
+        )
+    return fused_output
+
+
+# The MoE entry points are opaque custom ops. This is a load-bearing assumption
+# for the MoE-LoRA dual-stream path. Input-reuse variants have a separate schema
+# because functionalization must know that the shared-expert input is mutated.
 direct_register_custom_op(
     op_name="moe_forward",
     op_func=_moe_forward,
@@ -223,6 +262,24 @@ direct_register_custom_op(
     op_func=_moe_forward_shared,
     mutates_args=["hidden_states"],
     fake_impl=_moe_forward_shared_fake,
+    tags=(torch.Tag.needs_fixed_stride_order,),
+)
+
+
+direct_register_custom_op(
+    op_name="moe_forward_shared_input_reuse",
+    op_func=_moe_forward_shared_input_reuse,
+    mutates_args=["hidden_states", "shared_experts_input"],
+    fake_impl=_moe_forward_fake,
+    tags=(torch.Tag.needs_fixed_stride_order,),
+)
+
+
+direct_register_custom_op(
+    op_name="b12x_moe_forward_shared_input_reuse",
+    op_func=_moe_forward_shared_input_reuse,
+    mutates_args=["hidden_states", "shared_experts_input"],
+    fake_impl=_moe_forward_fake,
     tags=(torch.Tag.needs_fixed_stride_order,),
 )
 
@@ -306,6 +363,11 @@ class MoERunner(MoERunnerInterface):
         self.layer_name = layer_name
 
         self._forward_entry = self._select_forward()
+        self._shared_input_reuse_entry = (
+            self._select_shared_input_reuse_forward()
+            if self._shared_experts is not None
+            else None
+        )
 
         # For smuggling this layer into the fused moe custom op
         register_layer_for_moe_forward_op(get_current_vllm_config(), self)
@@ -334,6 +396,14 @@ class MoERunner(MoERunnerInterface):
             if self._shared_experts is None
             else torch.ops.vllm.moe_forward_shared
         )
+
+    def _select_shared_input_reuse_forward(self) -> Callable:
+        """Select the MoE operator whose schema declares shared-input mutation."""
+        if current_platform.is_tpu() or current_platform.is_cpu():
+            return _moe_forward_shared_input_reuse
+        if self._uses_b12x_moe_kernel:
+            return torch.ops.vllm.b12x_moe_forward_shared_input_reuse
+        return torch.ops.vllm.moe_forward_shared_input_reuse
 
     @property
     def shared_experts(self) -> SharedExperts | None:
@@ -412,6 +482,7 @@ class MoERunner(MoERunnerInterface):
     def apply_routed_output_transform(
         self,
         fused_output: torch.Tensor,
+        residual: torch.Tensor | None = None,
         output: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """Apply transform to routed expert output (e.g., latent to full dim).
@@ -421,10 +492,15 @@ class MoERunner(MoERunnerInterface):
         the full hidden dimension before combining with shared expert output.
         """
         if self.routed_output_transform is not None:
-            if output is None:
-                r = self.routed_output_transform(fused_output)
-            else:
+            if residual is not None:
+                r = self.routed_output_transform(
+                    fused_output,
+                    residual=residual,
+                )
+            elif output is not None:
                 r = self.routed_output_transform(fused_output, output=output)
+            else:
+                r = self.routed_output_transform(fused_output)
             fused_output = r[0] if isinstance(r, tuple) else r
         return fused_output
 
@@ -432,6 +508,7 @@ class MoERunner(MoERunnerInterface):
         self,
         fused_output: torch.Tensor,
         shared_experts_input: torch.Tensor | None,
+        shared_output: torch.Tensor | None,
     ) -> torch.Tensor | None:
         """Return dead caller storage accepted by the output transform."""
         if shared_experts_input is None or self.routed_output_transform is None:
@@ -443,7 +520,29 @@ class MoERunner(MoERunnerInterface):
             fused_output, shared_experts_input
         ):
             return None
+        if (
+            shared_output is not None
+            and shared_output.untyped_storage().data_ptr()
+            == shared_experts_input.untyped_storage().data_ptr()
+        ):
+            return None
         return shared_experts_input
+
+    def _can_accumulate_routed_output_residual(
+        self,
+        fused_output: torch.Tensor,
+        shared_output: torch.Tensor | None,
+    ) -> bool:
+        """Return whether the output transform can consume a shared residual."""
+        if shared_output is None or self.routed_output_transform is None:
+            return False
+        can_accumulate_residual = getattr(
+            self.routed_output_transform, "can_accumulate_residual", None
+        )
+        return bool(
+            can_accumulate_residual is not None
+            and can_accumulate_residual(fused_output, shared_output)
+        )
 
     def _maybe_apply_routed_scale_to_output(
         self,
@@ -631,10 +730,15 @@ class MoERunner(MoERunnerInterface):
         self,
         shared_experts_input: torch.Tensor | None,
         order: SharedExpertsOrder,
+        reuse_input: bool = False,
     ):
         if self._shared_experts is not None:
             assert shared_experts_input is not None
-            self._shared_experts(shared_experts_input, order)
+            self._shared_experts(
+                shared_experts_input,
+                order,
+                reuse_input=reuse_input,
+            )
 
     def _apply_quant_method(
         self,
@@ -642,6 +746,7 @@ class MoERunner(MoERunnerInterface):
         router_logits: torch.Tensor,
         shared_experts_input: torch.Tensor | None,
         input_ids: torch.Tensor | None = None,
+        reuse_shared_experts_input: bool = False,
     ) -> tuple[torch.Tensor | None, torch.Tensor]:
         """Run expert routing and the fused MoE kernel via the quant method.
 
@@ -650,7 +755,9 @@ class MoERunner(MoERunnerInterface):
         (shared_expert_output, fused_expert_output).
         """
         self._maybe_apply_shared_experts(
-            shared_experts_input, SharedExpertsOrder.NO_OVERLAP
+            shared_experts_input,
+            SharedExpertsOrder.NO_OVERLAP,
+            reuse_input=reuse_shared_experts_input,
         )
 
         if self.routed_experts.quant_method.is_monolithic:
@@ -792,7 +899,19 @@ class MoERunner(MoERunnerInterface):
             )
         )
 
-        result = self._forward_entry(
+        shared_experts = getattr(self, "_shared_experts", None)
+        reuse_shared_experts_input = bool(
+            shared_experts_input is not None
+            and shared_experts is not None
+            and shared_experts.can_reuse_input(shared_experts_input)
+        )
+        forward_entry = (
+            self._shared_input_reuse_entry
+            if reuse_shared_experts_input
+            else self._forward_entry
+        )
+        assert forward_entry is not None
+        result = forward_entry(
             hidden_states,
             router_logits,
             shared_experts_input,
@@ -814,6 +933,10 @@ class MoERunner(MoERunnerInterface):
 
         # Extract outputs from result
         shared_output, fused_output = _unpack(result)
+        if reuse_shared_experts_input:
+            assert shared_experts_input is not None
+            assert shared_output is None
+            shared_output = shared_experts_input
 
         if og_hidden_dim_pre_xform is not None:
             fused_output = fused_output[..., :og_hidden_dim_pre_xform]
@@ -849,15 +972,28 @@ class MoERunner(MoERunnerInterface):
             shared_output, fused_output
         )
 
-        # The shared-expert input is dead after _forward_entry returns. Output
-        # transforms that explicitly accept caller-owned storage may reuse it
-        # for allocation-sensitive prefill projections.
+        # The shared-expert input has been consumed when the MoE entry returns.
+        # An output transform may use that storage when the shared result has a
+        # separate allocation. If the shared result already occupies the input
+        # storage, the routed projection accumulates into it with bounded scratch.
         routed_output_buffer = self._get_routed_output_buffer(
-            fused_output, shared_experts_input
+            fused_output,
+            shared_experts_input,
+            shared_output,
+        )
+        routed_output_residual = (
+            shared_output
+            if routed_output_buffer is None
+            and self._can_accumulate_routed_output_residual(fused_output, shared_output)
+            else None
         )
         fused_output = self.apply_routed_output_transform(
-            fused_output, output=routed_output_buffer
+            fused_output,
+            residual=routed_output_residual,
+            output=routed_output_buffer,
         )
+        if routed_output_residual is not None:
+            shared_output = None
         if output_transform_is_tp_partial:
             fused_output_is_reduced = False
 
@@ -874,7 +1010,9 @@ class MoERunner(MoERunnerInterface):
             result,
             og_hidden_dim_post_xform,
             fused_output_is_reduced,
-            in_place=routed_output_buffer is not None,
+            in_place=(
+                routed_output_buffer is not None or routed_output_residual is not None
+            ),
         )
 
         return self._maybe_add_zero_expert_output(result)
@@ -940,6 +1078,7 @@ class MoERunner(MoERunnerInterface):
         router_logits: torch.Tensor,
         shared_experts_input: torch.Tensor | None,
         input_ids: torch.Tensor | None = None,
+        reuse_shared_experts_input: bool = False,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
         """Entry point called by the custom op to run the MoE computation.
 
@@ -983,6 +1122,7 @@ class MoERunner(MoERunnerInterface):
                 router_logits=router_logits,
                 shared_experts_input=shared_experts_input,
                 input_ids=input_ids,
+                reuse_shared_experts_input=reuse_shared_experts_input,
             )
 
             return self._maybe_combine(

--- a/vllm/model_executor/layers/fused_moe/runner/shared_experts.py
+++ b/vllm/model_executor/layers/fused_moe/runner/shared_experts.py
@@ -160,10 +160,29 @@ class SharedExperts(torch.nn.Module):
         self._output[self._output_idx] = None
         return output
 
+    def can_reuse_input(self, shared_experts_input: torch.Tensor) -> bool:
+        """Return whether the shared expert can overwrite its consumed input.
+
+        Input reuse is valid only for synchronous execution. Overlapped shared
+        experts retain their input until the auxiliary or modular kernel has
+        finished reading it. The wrapped layer must explicitly opt in and
+        validate the tensor shape and execution mode.
+        """
+        should_use_caller_output = getattr(
+            self._layer, "should_use_caller_output", None
+        )
+        return bool(
+            should_use_caller_output is not None
+            and self._determine_shared_experts_order(shared_experts_input)
+            == SharedExpertsOrder.NO_OVERLAP
+            and should_use_caller_output(shared_experts_input)
+        )
+
     def forward(
         self,
         shared_experts_input: torch.Tensor,
         order: SharedExpertsOrder,
+        reuse_input: bool = False,
     ):
         experts_order = self._determine_shared_experts_order(shared_experts_input)
 
@@ -172,7 +191,19 @@ class SharedExperts(torch.nn.Module):
 
         assert self._output[self._output_idx] is None
 
-        if order == SharedExpertsOrder.MULTI_STREAM_OVERLAPPED:
+        if reuse_input:
+            if order != SharedExpertsOrder.NO_OVERLAP or not self.can_reuse_input(
+                shared_experts_input
+            ):
+                raise ValueError(
+                    "Shared-expert input reuse requires synchronous execution "
+                    "and an input-reuse-capable layer"
+                )
+            self._output[self._output_idx] = self._layer(
+                shared_experts_input,
+                output=shared_experts_input,
+            )
+        elif order == SharedExpertsOrder.MULTI_STREAM_OVERLAPPED:
             self._output[self._output_idx] = self._run_in_aux_stream(
                 shared_experts_input
             )

--- a/vllm/models/kimi_k3/nvidia/model.py
+++ b/vllm/models/kimi_k3/nvidia/model.py
@@ -20,6 +20,7 @@ from vllm.distributed import (
     tensor_model_parallel_all_reduce,
     tensor_model_parallel_all_reduce_in_place,
 )
+from vllm.distributed.utils import split_tensor_along_last_dim
 from vllm.forward_context import get_forward_context, is_forward_context_available
 from vllm.logger import init_logger
 from vllm.model_executor.layers.activation import SiluAndMul, SituAndMul
@@ -336,6 +337,8 @@ class KimiMLP(nn.Module):
 
 
 class KimiRoutedOutputTransform(nn.Module):
+    _CALLER_OUTPUT_MIN_TOKENS = 1024
+
     def __init__(
         self,
         norm: RMSNorm | None,
@@ -359,6 +362,7 @@ class KimiRoutedOutputTransform(nn.Module):
         self,
         hidden_states: torch.Tensor,
         residual: torch.Tensor | None = None,
+        output: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """Project the routed latent back to the hidden dim.
 
@@ -368,16 +372,49 @@ class KimiRoutedOutputTransform(nn.Module):
                 accumulate into. A replicated projection consumes it in the
                 GEMM's beta-add epilogue; a TP-sharded projection adds the two
                 rank-local partials before their shared all-reduce.
+            output: Dead caller-owned storage for the routed projection. This
+                preserves the separate projection and shared-output addition.
         """
+        if residual is not None and output is not None:
+            raise ValueError(
+                "Kimi routed output transform accepts either residual or output"
+            )
         self.capture_routed_latent(hidden_states)
         if self.norm is not None:
             hidden_states = self.norm(hidden_states)
         if residual is not None and isinstance(self.up_proj, ReplicatedLinear):
             return residual.addmm_(hidden_states, self.up_proj.weight.t())
-        hidden_states, _ = self.up_proj(hidden_states)
+        if output is not None:
+            if not self.can_write_output(hidden_states, output):
+                raise ValueError(
+                    "Kimi routed output transform cannot write the supplied buffer"
+                )
+            hidden_states, _ = self.up_proj.forward_into(hidden_states, output)
+        else:
+            hidden_states, _ = self.up_proj(hidden_states)
         if residual is not None:
             hidden_states.add_(residual)
         return hidden_states
+
+    def can_write_output(
+        self, hidden_states: torch.Tensor, output: torch.Tensor
+    ) -> bool:
+        """Check the prefill-only caller-owned output contract."""
+        return (
+            isinstance(self.up_proj, KimiPaddedRowParallelLinear)
+            and isinstance(self.up_proj.quant_method, UnquantizedLinearMethod)
+            and self.up_proj.bias is None
+            and not envs.VLLM_BATCH_INVARIANT
+            and hidden_states.ndim == 2
+            and output.ndim == 2
+            and hidden_states.shape[0] >= self._CALLER_OUTPUT_MIN_TOKENS
+            and output.shape == (hidden_states.shape[0], self.up_proj.output_size)
+            and output.dtype == hidden_states.dtype
+            and output.device == hidden_states.device
+            and output.is_contiguous()
+            and output.untyped_storage().data_ptr()
+            != hidden_states.untyped_storage().data_ptr()
+        )
 
     @property
     def output_is_tp_partial(self) -> bool:
@@ -514,6 +551,35 @@ class KimiPaddedRowParallelLinear(RowParallelLinear):
         if self.input_pad:
             x = torch.nn.functional.pad(x, (0, self.input_pad))
         return super().forward(x)
+
+    def forward_into(
+        self, x: torch.Tensor, output: torch.Tensor
+    ) -> tuple[torch.Tensor, None]:
+        """Write an unquantized rank-local projection into caller storage."""
+        if not isinstance(self.quant_method, UnquantizedLinearMethod):
+            raise ValueError("Caller-owned output requires an unquantized projection")
+        if self.bias is not None or self.reduce_results:
+            raise ValueError(
+                "Caller-owned output requires a bias-free unreduced projection"
+            )
+        if x.ndim != 2 or output.ndim != 2:
+            raise ValueError("Caller-owned output requires 2D tensors")
+        if self.input_pad:
+            x = torch.nn.functional.pad(x, (0, self.input_pad))
+        if self.input_is_parallel:
+            input_parallel = x
+        else:
+            input_parallel = split_tensor_along_last_dim(
+                x, num_partitions=self.tp_size
+            )[self.tp_rank].contiguous()
+        expected_shape = (input_parallel.shape[0], self.output_size)
+        if output.shape != expected_shape:
+            raise ValueError(
+                f"Caller-owned output has shape {tuple(output.shape)}; "
+                f"expected {expected_shape}"
+            )
+        torch.mm(input_parallel, self.weight.t(), out=output)
+        return output, None
 
 
 class KimiK3MegaMoEExperts(DeepseekV4MegaMoEExperts):

--- a/vllm/models/kimi_k3/nvidia/model.py
+++ b/vllm/models/kimi_k3/nvidia/model.py
@@ -18,6 +18,7 @@ from vllm.distributed import (
     get_pp_group,
     get_tensor_model_parallel_world_size,
     tensor_model_parallel_all_reduce,
+    tensor_model_parallel_all_reduce_in_place,
 )
 from vllm.forward_context import get_forward_context, is_forward_context_available
 from vllm.logger import init_logger
@@ -42,6 +43,7 @@ from vllm.model_executor.layers.linear import (
     MergedColumnParallelLinear,
     ReplicatedLinear,
     RowParallelLinear,
+    UnquantizedLinearMethod,
 )
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.mamba.gdn.kimi_gdn_linear_attn import (
@@ -198,6 +200,8 @@ class KimiMLP(nn.Module):
     block still ends with one collective per direction.
     """
 
+    _CALLER_OUTPUT_MIN_TOKENS = 1024
+
     def __init__(
         self,
         hidden_size: int,
@@ -251,8 +255,65 @@ class KimiMLP(nn.Module):
                 "Only silu and situ are supported."
             )
 
-    def forward(self, x):
+    @property
+    def supports_caller_output(self) -> bool:
+        """Whether the down projection can write into caller-owned storage."""
+        return (
+            isinstance(self.down_proj.quant_method, UnquantizedLinearMethod)
+            and self.down_proj.input_is_parallel
+            and self.down_proj.bias is None
+            and not envs.VLLM_BATCH_INVARIANT
+        )
+
+    def should_use_caller_output(self, x: torch.Tensor) -> bool:
+        """Use donated storage only for allocation-sensitive prefill GEMMs."""
+        return (
+            self.supports_caller_output
+            and x.ndim == 2
+            and x.shape[0] >= self._CALLER_OUTPUT_MIN_TOKENS
+        )
+
+    def _down_proj_into(self, x: torch.Tensor, output: torch.Tensor) -> torch.Tensor:
+        if not self.supports_caller_output:
+            raise ValueError(
+                "KimiMLP caller-owned output requires an unquantized, "
+                "bias-free row-parallel down projection"
+            )
+        if x.ndim != 2 or output.ndim != 2:
+            raise ValueError("KimiMLP caller-owned output requires 2D tensors")
+        expected_shape = (x.shape[0], self.down_proj.output_size)
+        if tuple(output.shape) != expected_shape:
+            raise ValueError(
+                "KimiMLP caller-owned output has shape "
+                f"{tuple(output.shape)}; expected {expected_shape}"
+            )
+        if not output.is_contiguous() or output.dtype != x.dtype:
+            raise ValueError(
+                "KimiMLP caller-owned output must be contiguous and match "
+                "the activation dtype"
+            )
+        if output.untyped_storage().data_ptr() == x.untyped_storage().data_ptr():
+            raise ValueError(
+                "KimiMLP caller-owned output must not alias the down-projection input"
+            )
+
+        torch.mm(x, self.down_proj.weight.t(), out=output)
+        if self.down_proj.reduce_results and self.down_proj.tp_size > 1:
+            output = tensor_model_parallel_all_reduce_in_place(output)
+        return output
+
+    def forward(
+        self, x: torch.Tensor, output: torch.Tensor | None = None
+    ) -> torch.Tensor:
+        # Decoder layers may donate their normalized hidden-state storage. The
+        # gate/up projection has consumed that tensor before the down
+        # projection writes the donated buffer.
         if self.shard_sequence_parallel:
+            if output is not None:
+                raise ValueError(
+                    "KimiMLP caller-owned output is incompatible with "
+                    "sequence-parallel input gathering"
+                )
             # Each rank holds a weight shard but only its own tokens, so it
             # cannot finish those tokens alone: gather the full token set,
             # compute this rank's partial for all of them, then reduce-scatter,
@@ -260,7 +321,15 @@ class KimiMLP(nn.Module):
             x = sp_all_gather(x)
         gate_up, _ = self.gate_up_proj(x)
         x = self.act_fn(gate_up)
-        x, _ = self.down_proj(x)
+        # The gated activation no longer reads the packed gate/up projection.
+        # Release that large prefill tensor before down_proj allocates its
+        # output; retaining both tensors can exceed the available device
+        # memory at large scheduler chunk sizes.
+        del gate_up
+        if output is None:
+            x, _ = self.down_proj(x)
+        else:
+            x = self._down_proj_into(x, output)
         if self.shard_sequence_parallel:
             x = sp_reduce_scatter(x)
         return x
@@ -1363,7 +1432,12 @@ class KimiDecoderLayer(nn.Module):
         )
 
         # MoE/MLP.
-        hidden_states = self.mlp(hidden_states)
+        if isinstance(self.mlp, KimiMLP) and self.mlp.should_use_caller_output(
+            hidden_states
+        ):
+            hidden_states = self.mlp(hidden_states, output=hidden_states)
+        else:
+            hidden_states = self.mlp(hidden_states)
         return hidden_states, prefix_sum, residual
 
 

--- a/vllm/models/kimi_k3/nvidia/model.py
+++ b/vllm/models/kimi_k3/nvidia/model.py
@@ -12,6 +12,7 @@ import torch
 from torch import nn
 
 import vllm.envs as envs
+from vllm import _custom_ops as ops
 from vllm.config import VllmConfig
 from vllm.distributed import (
     get_ep_group,
@@ -408,7 +409,8 @@ class KimiRoutedOutputTransform(nn.Module):
         """Project the routed latent back to the hidden dim.
 
         Args:
-            hidden_states: Routed expert output in latent space.
+            hidden_states: Consumed routed expert output in latent space.
+                Eligible prefill tensors may be normalized in place.
             residual: Optional tensor of the up-projection's output shape to
                 accumulate into. A replicated projection consumes it in the
                 GEMM's beta-add epilogue; a TP-sharded projection adds the two
@@ -422,7 +424,7 @@ class KimiRoutedOutputTransform(nn.Module):
             )
         self.capture_routed_latent(hidden_states)
         if self.norm is not None:
-            hidden_states = self.norm(hidden_states)
+            hidden_states = self.normalize_routed_latent(hidden_states)
         if residual is not None and isinstance(self.up_proj, ReplicatedLinear):
             return residual.addmm_(hidden_states, self.up_proj.weight.t())
         if residual is not None and isinstance(
@@ -445,6 +447,40 @@ class KimiRoutedOutputTransform(nn.Module):
         if residual is not None:
             hidden_states.add_(residual)
         return hidden_states
+
+    def can_normalize_routed_latent_in_place(self, hidden_states: torch.Tensor) -> bool:
+        """Check whether the consumed prefill latent can hold its RMSNorm."""
+        norm = self.norm
+        return (
+            norm is not None
+            and not envs.VLLM_BATCH_INVARIANT
+            and not torch.is_grad_enabled()
+            and norm.pass_weight
+            and norm.variance_size_override is None
+            and hidden_states.is_cuda
+            and hidden_states.dtype == torch.bfloat16
+            and hidden_states.ndim == 2
+            and hidden_states.shape[0] >= self._CALLER_OUTPUT_MIN_TOKENS
+            and hidden_states.shape[1] == norm.hidden_size
+            and hidden_states.is_contiguous()
+            and norm.weight.device == hidden_states.device
+            and norm.weight.dtype == hidden_states.dtype
+        )
+
+    def normalize_routed_latent(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """Normalize a consumed routed latent with bounded prefill storage."""
+        norm = self.norm
+        if norm is None:
+            return hidden_states
+        if self.can_normalize_routed_latent_in_place(hidden_states):
+            ops.rms_norm(
+                hidden_states,
+                hidden_states,
+                norm.weight.data,
+                norm.variance_epsilon,
+            )
+            return hidden_states
+        return cast(torch.Tensor, norm(hidden_states))
 
     def can_accumulate_residual(
         self, hidden_states: torch.Tensor, residual: torch.Tensor

--- a/vllm/models/kimi_k3/nvidia/model.py
+++ b/vllm/models/kimi_k3/nvidia/model.py
@@ -425,6 +425,15 @@ class KimiRoutedOutputTransform(nn.Module):
             hidden_states = self.norm(hidden_states)
         if residual is not None and isinstance(self.up_proj, ReplicatedLinear):
             return residual.addmm_(hidden_states, self.up_proj.weight.t())
+        if residual is not None and isinstance(
+            self.up_proj, KimiPaddedRowParallelLinear
+        ):
+            if not self.can_accumulate_residual(hidden_states, residual):
+                raise ValueError(
+                    "Kimi routed output transform cannot accumulate into the "
+                    "supplied residual"
+                )
+            return self.up_proj.accumulate_into(hidden_states, residual)
         if output is not None:
             if not self.can_write_output(hidden_states, output):
                 raise ValueError(
@@ -436,6 +445,29 @@ class KimiRoutedOutputTransform(nn.Module):
         if residual is not None:
             hidden_states.add_(residual)
         return hidden_states
+
+    def can_accumulate_residual(
+        self, hidden_states: torch.Tensor, residual: torch.Tensor
+    ) -> bool:
+        """Check the prefill-only tiled residual-accumulation contract."""
+        return (
+            isinstance(self.up_proj, KimiPaddedRowParallelLinear)
+            and isinstance(self.up_proj.quant_method, UnquantizedLinearMethod)
+            and getattr(self.up_proj, "weight", None) is not None
+            and self.up_proj.bias is None
+            and not self.up_proj.reduce_results
+            and not envs.VLLM_BATCH_INVARIANT
+            and hidden_states.ndim == 2
+            and residual.ndim == 2
+            and hidden_states.shape[0] >= self._CALLER_OUTPUT_MIN_TOKENS
+            and residual.shape == (hidden_states.shape[0], self.up_proj.output_size)
+            and residual.dtype == hidden_states.dtype
+            and residual.device == hidden_states.device
+            and residual.is_contiguous()
+            and self.up_proj.output_size % self.up_proj._ACCUMULATION_TILE_ROWS == 0
+            and residual.untyped_storage().data_ptr()
+            != hidden_states.untyped_storage().data_ptr()
+        )
 
     def can_write_output(
         self, hidden_states: torch.Tensor, output: torch.Tensor
@@ -568,6 +600,8 @@ class KimiColumnParallelGate(KimiPaddedColumnParallelLinear):
 class KimiPaddedRowParallelLinear(RowParallelLinear):
     """Row-parallel linear with a zero-padded input axis."""
 
+    _ACCUMULATION_TILE_ROWS = 1024
+
     def weight_loader(self, param: nn.Parameter, loaded_weight: torch.Tensor) -> None:
         input_dim = getattr(param, "input_dim", None)
         if input_dim is None or getattr(param, "is_sharded_weight", False):
@@ -622,6 +656,70 @@ class KimiPaddedRowParallelLinear(RowParallelLinear):
             )
         torch.mm(input_parallel, self.weight.t(), out=output)
         return output, None
+
+    def accumulate_into(self, x: torch.Tensor, output: torch.Tensor) -> torch.Tensor:
+        """Add an unquantized rank-local projection using bounded scratch.
+
+        The output dimension is processed in fixed row tiles. Each tile is
+        rounded to BF16 by ``torch.mm`` before it is added to the BF16
+        residual, matching the allocating projection-then-add operation while
+        avoiding a full-width projection allocation.
+        """
+        if not isinstance(self.quant_method, UnquantizedLinearMethod):
+            raise ValueError("Residual accumulation requires an unquantized projection")
+        if self.bias is not None or self.reduce_results:
+            raise ValueError(
+                "Residual accumulation requires a bias-free unreduced projection"
+            )
+        if x.ndim != 2 or output.ndim != 2:
+            raise ValueError("Residual accumulation requires 2D tensors")
+        if self.input_pad:
+            x = torch.nn.functional.pad(x, (0, self.input_pad))
+        if self.input_is_parallel:
+            input_parallel = x
+        else:
+            input_parallel = split_tensor_along_last_dim(
+                x, num_partitions=self.tp_size
+            )[self.tp_rank].contiguous()
+        expected_shape = (input_parallel.shape[0], self.output_size)
+        if output.shape != expected_shape:
+            raise ValueError(
+                f"Residual output has shape {tuple(output.shape)}; "
+                f"expected {expected_shape}"
+            )
+        if (
+            not output.is_contiguous()
+            or output.dtype != input_parallel.dtype
+            or output.device != input_parallel.device
+        ):
+            raise ValueError(
+                "Residual output must be contiguous and match the projection input"
+            )
+        if (
+            output.untyped_storage().data_ptr()
+            == input_parallel.untyped_storage().data_ptr()
+        ):
+            raise ValueError("Residual output must not alias the projection input")
+        tile_rows = self._ACCUMULATION_TILE_ROWS
+        if self.output_size % tile_rows:
+            raise ValueError(
+                "Residual accumulation requires an output size divisible by "
+                f"{tile_rows}"
+            )
+        scratch = torch.empty(
+            (input_parallel.shape[0], tile_rows),
+            dtype=output.dtype,
+            device=output.device,
+        )
+        for row_start in range(0, self.output_size, tile_rows):
+            row_end = row_start + tile_rows
+            torch.mm(
+                input_parallel,
+                self.weight[row_start:row_end].t(),
+                out=scratch,
+            )
+            output[:, row_start:row_end].add_(scratch)
+        return output
 
 
 class KimiK3MegaMoEExperts(DeepseekV4MegaMoEExperts):

--- a/vllm/models/kimi_k3/nvidia/model.py
+++ b/vllm/models/kimi_k3/nvidia/model.py
@@ -258,23 +258,51 @@ class KimiMLP(nn.Module):
 
     @property
     def supports_caller_output(self) -> bool:
-        """Whether the down projection can write into caller-owned storage."""
+        """Report whether the down projection accepts caller-owned storage.
+
+        Returns:
+            ``True`` for a materialized, unquantized, bias-free row-parallel
+            projection outside batch-invariant execution.
+        """
         return (
             isinstance(self.down_proj.quant_method, UnquantizedLinearMethod)
+            and getattr(self.down_proj, "weight", None) is not None
             and self.down_proj.input_is_parallel
             and self.down_proj.bias is None
             and not envs.VLLM_BATCH_INVARIANT
         )
 
     def should_use_caller_output(self, x: torch.Tensor) -> bool:
-        """Use donated storage only for allocation-sensitive prefill GEMMs."""
+        """Select caller-owned storage for allocation-sensitive prefill GEMMs.
+
+        Args:
+            x: Down-projection input used to classify the token batch.
+
+        Returns:
+            ``True`` when the projection supports caller storage, sequence
+            parallelism is disabled, and the input has at least 1,024 rows.
+        """
         return (
             self.supports_caller_output
+            and not self.shard_sequence_parallel
             and x.ndim == 2
             and x.shape[0] >= self._CALLER_OUTPUT_MIN_TOKENS
         )
 
     def _down_proj_into(self, x: torch.Tensor, output: torch.Tensor) -> torch.Tensor:
+        """Write the row-parallel down projection into consumed caller storage.
+
+        Args:
+            x: Gated activation consumed by the down projection.
+            output: Contiguous output storage owned by the caller.
+
+        Returns:
+            The supplied output tensor after projection and TP reduction.
+
+        Raises:
+            ValueError: If the projection or output buffer violates the
+                caller-owned output contract.
+        """
         if not self.supports_caller_output:
             raise ValueError(
                 "KimiMLP caller-owned output requires an unquantized, "
@@ -306,6 +334,19 @@ class KimiMLP(nn.Module):
     def forward(
         self, x: torch.Tensor, output: torch.Tensor | None = None
     ) -> torch.Tensor:
+        """Apply the gated MLP and optionally reuse caller-owned output storage.
+
+        Args:
+            x: Hidden states consumed by the gate/up projection.
+            output: Optional storage for the down-projection result.
+
+        Returns:
+            Projected hidden states.
+
+        Raises:
+            ValueError: If caller storage is supplied with sequence-parallel
+                execution or violates the down-projection contract.
+        """
         # Decoder layers may donate their normalized hidden-state storage. The
         # gate/up projection has consumed that tensor before the down
         # projection writes the donated buffer.
@@ -403,6 +444,7 @@ class KimiRoutedOutputTransform(nn.Module):
         return (
             isinstance(self.up_proj, KimiPaddedRowParallelLinear)
             and isinstance(self.up_proj.quant_method, UnquantizedLinearMethod)
+            and getattr(self.up_proj, "weight", None) is not None
             and self.up_proj.bias is None
             and not envs.VLLM_BATCH_INVARIANT
             and hidden_states.ndim == 2


### PR DESCRIPTION
## Behavior

Kimi-K3 reuses consumed hidden-state storage for allocation-sensitive BF16
prefill projections:

- dense transformer MLP down projections write into the normalized decoder
  input after the gate/up projection consumes it;
- synchronous shared-expert down projections write into their consumed input
  through an opaque MoE operator that declares the input mutation;
- TP-sharded routed-MoE output projections write into a dead input buffer when
  one is available, or add 1,024 output rows at a time into the shared-expert
  result using an 8 MiB BF16 scratch tensor;
- combined TP partials use caller-owned storage for the final all-reduce.

The storage-reuse paths require contiguous two-dimensional batches with at
least 1,024 tokens, materialized unquantized bias-free projections, and
non-sequence-parallel execution. Shared experts must run synchronously.
Decode-sized batches, overlapped shared-expert execution, batch-invariant
execution, sequence parallelism, quantized projections, and transforms without
an explicit caller-output contract retain the allocating path.

## Technical reason

A 4,096-token Kimi-K3 hidden-state tensor with width 7,168 occupies 58,720,256
bytes in BF16. The dense MLP path previously allocated one additional tensor
of this size. The latent MoE path could allocate another full-width tensor for
the shared-expert down projection, one for the routed output projection, and
one for the shared-plus-routed sum. A runtime retaining a physical
one-million-token KV cache does not have enough headroom for those transient
allocations.

All donor tensors are consumed before reuse. A dedicated custom-op schema
declares shared-input mutation without returning an aliased tensor. The tiled
routed projection rounds each matrix product to BF16 before a separate BF16
addition, preserving the projection-then-add numerical contract.

## Compatibility

Projection inputs, SituGLU activation, weights, BF16 operation order,
routed/shared addition order, and TP reduction semantics are unchanged. Output
reuse is opt-in through explicit layer and transform contracts. Unsupported
execution modes retain the functional allocation and collective paths.

## Validation

- Thirty-four targeted unit tests cover tensor lifetime, caller ownership,
  mutation schemas, B12X and generic operator selection, pointer reuse, output
  alias rejection, materialized-weight and sequence-parallel guards,
  prefill/decode selection, residual accumulation, and functional versus
  in-place collectives.
- Ruff, formatting validation, Python bytecode validation, and
  `git diff --check` pass.
- A full-graph `torch.compile` reproducer confirms mutation of the optional
  shared input through the dedicated opaque MoE operator.
- Dense TP16 production shape `[4096, 2112] @ [2112, 7168]` writes a
  bitwise-identical result with zero additional live or peak bytes at the
  GEMM.
- Routed TP16 production shape `[4096, 3584] -> [4096, 7168]` is bitwise
  identical after the shared-output addition. The allocating transform plus
  addition grows peak allocation by 117,440,512 bytes. Caller-owned projection
  grows peak allocation by 1,835,008 bytes. Tiled residual accumulation grows
  peak allocation by 10,223,616 bytes and adds zero live bytes.
- On an RTX PRO 6000 Blackwell GPU, the isolated TP16 routed projection takes
  0.051 ms with a full allocating output and 0.127 ms with bounded tiled
  accumulation.
- CUDA Graph replay is bitwise identical for dense caller-owned projection,
  routed caller-owned projection, and tiled routed residual accumulation.

Full-checkpoint long-context qualification is required before publishing a
runtime image.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced temporary memory allocations during Kimi and mixture-of-experts execution by reusing eligible input and output buffers.
  * Added safe in-place residual accumulation and tensor-parallel reductions where supported.
  * Improved tiled processing for routed outputs to manage memory usage efficiently.

* **Bug Fixes**
  * Added validation to prevent unsafe buffer reuse, including incompatible shapes, layouts, devices, data types, or aliasing.

* **Tests**
  * Expanded coverage for prefill and decode behavior, sequence-parallel execution, shared-expert reuse, routed outputs, and custom operator selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->