### PR TITLE
feat(exl3): add clean opt-in int8 embeddings

### DIFF
--- a/tests/quantization/test_exl3_int8_embedding.py
+++ b/tests/quantization/test_exl3_int8_embedding.py
@@ -1,0 +1,159 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import ast
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.quantization.exl3 import (
+    Exl3Config,
+    Exl3Int8EmbeddingMethod,
+    _encode_int8_embedding,
+)
+
+
+def _dequantize(q_weight: torch.Tensor, scales: torch.Tensor) -> torch.Tensor:
+    return q_weight.to(torch.float32) * scales.to(torch.float32).unsqueeze(1)
+
+
+def test_int8_integer_round_trip_is_exact() -> None:
+    expected = torch.arange(-127, 128, dtype=torch.int16).to(torch.int8).unsqueeze(0)
+    weight = expected.to(torch.float32) * 0.25
+
+    q_weight, scales = _encode_int8_embedding(weight, chunk_rows=1)
+
+    assert q_weight.dtype == torch.int8
+    assert scales.dtype == torch.float16
+    assert torch.equal(q_weight, expected)
+    assert torch.equal(_dequantize(q_weight, scales), weight)
+
+
+def test_int8_float_round_trip_respects_rowwise_error_bound() -> None:
+    generator = torch.Generator().manual_seed(1234)
+    weight = torch.randn((7, 19), generator=generator, dtype=torch.float32) * 3.0
+
+    q_weight, scales = _encode_int8_embedding(weight, chunk_rows=3)
+    reconstructed = _dequantize(q_weight, scales)
+    exact_scales = weight.abs().amax(dim=1) / 127.0
+    scale_rounding = (scales.float() - exact_scales).abs() * 127.0
+    bound = exact_scales / 2.0 + scale_rounding + 1.0e-6
+
+    assert torch.all((reconstructed - weight).abs() <= bound.unsqueeze(1))
+
+
+def test_int8_encoder_handles_zero_rows_and_empty_tables() -> None:
+    weight = torch.tensor([[0.0, 0.0, 0.0], [1.0, -1.0, 0.5]])
+
+    q_weight, scales = _encode_int8_embedding(weight, chunk_rows=1)
+    empty_q, empty_scales = _encode_int8_embedding(torch.empty((0, 3)))
+
+    assert torch.equal(q_weight[0], torch.zeros(3, dtype=torch.int8))
+    assert scales[0].isfinite()
+    assert torch.equal(_dequantize(q_weight, scales)[0], weight[0])
+    assert empty_q.shape == (0, 3)
+    assert empty_scales.shape == (0,)
+
+
+def test_int8_chunking_is_bit_identical() -> None:
+    weight = torch.linspace(-5.0, 7.0, 11 * 13).reshape(11, 13)
+
+    q_one, scale_one = _encode_int8_embedding(weight, chunk_rows=1)
+    q_four, scale_four = _encode_int8_embedding(weight, chunk_rows=4)
+    q_full, scale_full = _encode_int8_embedding(weight, chunk_rows=64)
+
+    assert torch.equal(q_one, q_four)
+    assert torch.equal(q_one, q_full)
+    assert torch.equal(scale_one, scale_four)
+    assert torch.equal(scale_one, scale_full)
+
+
+def test_quant_method_targets_exact_embedding_type_and_excludes_lm_head(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    embedding_type = type("VocabParallelEmbedding", (torch.nn.Module,), {})
+    lm_head_type = type("ParallelLMHead", (embedding_type,), {})
+    embedding_subclass = type("EmbeddingSubclass", (embedding_type,), {})
+    config = Exl3Config()
+    monkeypatch.setenv("VLLM_EXL3_EMBED_ONLINE_BITS", "8")
+
+    assert isinstance(
+        config.get_quant_method(embedding_type(), "model.embed_tokens"),
+        Exl3Int8EmbeddingMethod,
+    )
+    assert not isinstance(
+        config.get_quant_method(lm_head_type(), "lm_head"),
+        Exl3Int8EmbeddingMethod,
+    )
+    assert config.get_quant_method(embedding_subclass(), "model.embed_tokens") is None
+
+
+def test_quant_method_is_inert_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    embedding_type = type("VocabParallelEmbedding", (torch.nn.Module,), {})
+    monkeypatch.delenv("VLLM_EXL3_EMBED_ONLINE_BITS", raising=False)
+
+    assert Exl3Config().get_quant_method(embedding_type(), "model.embed_tokens") is None
+
+
+def _embedding_call_keywords(path: Path, class_name: str) -> set[str]:
+    tree = ast.parse(path.read_text())
+    class_node = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == class_name
+    )
+    init = next(
+        node
+        for node in class_node.body
+        if isinstance(node, ast.FunctionDef) and node.name == "__init__"
+    )
+    call = next(
+        node
+        for node in ast.walk(init)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "VocabParallelEmbedding"
+    )
+    return {keyword.arg for keyword in call.keywords if keyword.arg is not None}
+
+
+def test_qwen_target_and_mtp_wire_quant_config_and_prefix() -> None:
+    models = Path(__file__).parents[2] / "vllm" / "model_executor" / "models"
+
+    assert _embedding_call_keywords(models / "qwen3_5.py", "Qwen3_5Model") >= {
+        "quant_config",
+        "prefix",
+    }
+    assert _embedding_call_keywords(
+        models / "qwen3_5_mtp.py", "Qwen3_5MultiTokenPredictor"
+    ) >= {"quant_config", "prefix"}
+
+
+def test_post_load_surface_preserves_native_mtp_module_sharing() -> None:
+    method = Exl3Int8EmbeddingMethod()
+    embedding = torch.nn.Module()
+    embedding.register_parameter(
+        "weight",
+        torch.nn.Parameter(torch.arange(24, dtype=torch.bfloat16).reshape(6, 4), False),
+    )
+
+    method.process_weights_after_loading(embedding)
+    target = SimpleNamespace(embed_tokens=embedding)
+    draft = SimpleNamespace(embed_tokens=target.embed_tokens)
+
+    assert embedding.weight.shape == (0, 4)
+    assert draft.embed_tokens is target.embed_tokens
+    assert draft.embed_tokens.q_weight is target.embed_tokens.q_weight
+    assert draft.embed_tokens.embed_scale is target.embed_tokens.embed_scale
+
+
+def test_tied_embeddings_are_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("VLLM_EXL3_EMBED_ONLINE_BITS", "8")
+    hf_config = SimpleNamespace(tie_word_embeddings=True)
+
+    with pytest.raises(ValueError, match="tied word embeddings"):
+        Exl3Config._require_untied_int8_embedding(hf_config)
+    with pytest.raises(ValueError, match="tied word embeddings"):
+        Exl3Int8EmbeddingMethod().tie_weights(torch.nn.Module(), torch.nn.Module())

--- a/tests/quantization/test_exl3_int8_embedding.py
+++ b/tests/quantization/test_exl3_int8_embedding.py
@@ -1,18 +1,21 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-import ast
-from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 import torch
+
+import vllm.model_executor.layers.vocab_parallel_embedding as embedding_module
+import vllm.v1.spec_decode.llm_base_proposer as proposer_module
+from vllm.model_executor.layers.vocab_parallel_embedding import VocabParallelEmbedding
 
 from vllm.model_executor.layers.quantization.exl3 import (
     Exl3Config,
     Exl3Int8EmbeddingMethod,
     _encode_int8_embedding,
 )
+from vllm.v1.worker.gpu.spec_decode.eagle.utils import _should_share
 
 
 def _dequantize(q_weight: torch.Tensor, scales: torch.Tensor) -> torch.Tensor:
@@ -97,56 +100,203 @@ def test_quant_method_is_inert_when_unset(monkeypatch: pytest.MonkeyPatch) -> No
     assert Exl3Config().get_quant_method(embedding_type(), "model.embed_tokens") is None
 
 
-def _embedding_call_keywords(path: Path, class_name: str) -> set[str]:
-    tree = ast.parse(path.read_text())
-    class_node = next(
-        node
-        for node in tree.body
-        if isinstance(node, ast.ClassDef) and node.name == class_name
-    )
-    init = next(
-        node
-        for node in class_node.body
-        if isinstance(node, ast.FunctionDef) and node.name == "__init__"
-    )
-    call = next(
-        node
-        for node in ast.walk(init)
-        if isinstance(node, ast.Call)
-        and isinstance(node.func, ast.Name)
-        and node.func.id == "VocabParallelEmbedding"
-    )
-    return {keyword.arg for keyword in call.keywords if keyword.arg is not None}
-
-
-def test_qwen_target_and_mtp_wire_quant_config_and_prefix() -> None:
-    models = Path(__file__).parents[2] / "vllm" / "model_executor" / "models"
-
-    assert _embedding_call_keywords(models / "qwen3_5.py", "Qwen3_5Model") >= {
-        "quant_config",
-        "prefix",
-    }
-    assert _embedding_call_keywords(
-        models / "qwen3_5_mtp.py", "Qwen3_5MultiTokenPredictor"
-    ) >= {"quant_config", "prefix"}
-
-
-def test_post_load_surface_preserves_native_mtp_module_sharing() -> None:
-    method = Exl3Int8EmbeddingMethod()
+def _int8_embedding(
+    q_weight: torch.Tensor,
+    embed_scale: torch.Tensor,
+) -> torch.nn.Module:
     embedding = torch.nn.Module()
     embedding.register_parameter(
         "weight",
-        torch.nn.Parameter(torch.arange(24, dtype=torch.bfloat16).reshape(6, 4), False),
+        torch.nn.Parameter(
+            torch.empty((0, q_weight.shape[-1]), dtype=torch.bfloat16), False
+        ),
+    )
+    embedding.register_buffer("q_weight", q_weight.clone())
+    embedding.register_buffer("embed_scale", embed_scale.clone())
+    return embedding
+
+
+def _share_native_embedding(
+    monkeypatch: pytest.MonkeyPatch,
+    draft: torch.nn.Module,
+    target: torch.nn.Module,
+    has_own_embed_tokens: bool | None,
+) -> torch.nn.Module:
+    monkeypatch.setattr(
+        proposer_module,
+        "get_pp_group",
+        lambda: SimpleNamespace(world_size=1),
+    )
+    draft_model = SimpleNamespace(model=SimpleNamespace(embed_tokens=draft))
+    if has_own_embed_tokens is not None:
+        draft_model.has_own_embed_tokens = has_own_embed_tokens
+    proposer = SimpleNamespace(model=draft_model)
+    target_language_model = SimpleNamespace(
+        model=SimpleNamespace(embed_tokens=target)
     )
 
-    method.process_weights_after_loading(embedding)
-    target = SimpleNamespace(embed_tokens=embedding)
-    draft = SimpleNamespace(embed_tokens=target.embed_tokens)
+    proposer_module.SpecDecodeBaseProposer._maybe_share_embeddings(
+        proposer, target_language_model
+    )
+    return draft_model.model.embed_tokens
 
-    assert embedding.weight.shape == (0, 4)
-    assert draft.embed_tokens is target.embed_tokens
-    assert draft.embed_tokens.q_weight is target.embed_tokens.q_weight
-    assert draft.embed_tokens.embed_scale is target.embed_tokens.embed_scale
+
+def test_quantized_embedding_comparison_uses_rows_and_scales() -> None:
+    q_weight = torch.tensor([[1, 2, 3], [4, 5, 6]], dtype=torch.int8)
+    scales = torch.tensor([0.25, 0.5], dtype=torch.float16)
+    target = _int8_embedding(q_weight, scales)
+    equal = _int8_embedding(q_weight, scales)
+    distinct_rows = _int8_embedding(q_weight.clone(), scales)
+    distinct_rows.q_weight[1, 2] += 1
+    distinct_scales = _int8_embedding(q_weight, scales.clone())
+    distinct_scales.embed_scale[0] *= 2
+    mtp = SimpleNamespace(has_own_embed_tokens=False)
+    wrong_width = _int8_embedding(torch.ones((2, 4), dtype=torch.int8), scales)
+    owner = SimpleNamespace(has_own_embed_tokens=True)
+
+    assert _should_share(owner, "has_own_embed_tokens", equal, target)
+    assert not _should_share(owner, "has_own_embed_tokens", distinct_rows, target)
+    assert not _should_share(owner, "has_own_embed_tokens", distinct_scales, target)
+    assert not _should_share(owner, "has_own_embed_tokens", None, target)
+    assert _should_share(
+        mtp,
+        "has_own_embed_tokens",
+        equal,
+        target,
+        validate_embedding_compatibility=True,
+    )
+    assert not _should_share(
+        mtp,
+        "has_own_embed_tokens",
+        wrong_width,
+        target,
+        validate_embedding_compatibility=True,
+    )
+    assert torch.equal(equal.weight, distinct_rows.weight)
+
+
+def test_native_eagle_shares_only_equal_quantized_embeddings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    q_weight = torch.tensor([[1, 2], [3, 4]], dtype=torch.int8)
+    scales = torch.tensor([0.5, 0.25], dtype=torch.float16)
+    target = _int8_embedding(q_weight, scales)
+    equal = _int8_embedding(q_weight, scales)
+    distinct = _int8_embedding(q_weight, scales)
+    distinct.q_weight[0, 0] += 1
+
+    shared = _share_native_embedding(monkeypatch, equal, target, True)
+    kept = _share_native_embedding(monkeypatch, distinct, target, True)
+
+    assert shared is target
+    assert kept is distinct
+
+
+def test_native_mtp_sharing_validates_width_and_quantization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    q_weight = torch.tensor([[1, 2, 3], [4, 5, 6]], dtype=torch.int8)
+    scales = torch.tensor([0.5, 0.25], dtype=torch.float16)
+    target = _int8_embedding(q_weight, scales)
+    compatible = _int8_embedding(q_weight + 1, scales)
+    wrong_width = _int8_embedding(torch.ones((2, 4), dtype=torch.int8), scales)
+    dense = torch.nn.Embedding(2, 3)
+
+    shared = _share_native_embedding(monkeypatch, compatible, target, None)
+    kept_width = _share_native_embedding(monkeypatch, wrong_width, target, None)
+    kept_quantization = _share_native_embedding(monkeypatch, dense, target, None)
+
+    assert shared is target
+    assert kept_width is wrong_width
+    assert kept_quantization is dense
+
+
+def test_embedding_dequantizes_multidimensional_ids_and_zero_rows() -> None:
+    method = Exl3Int8EmbeddingMethod()
+    embedding = torch.nn.Module()
+    weight = torch.tensor(
+        [[0.0, 0.0, 0.0], [1.0, -1.0, 0.5], [2.0, 4.0, -2.0]],
+        dtype=torch.float32,
+    )
+    embedding.register_parameter(
+        "weight", torch.nn.Parameter(weight.clone(), requires_grad=False)
+    )
+    method.process_weights_after_loading(embedding)
+    input_ids = torch.tensor([[0, 2], [1, 0]])
+
+    output = method.embedding(embedding, input_ids)
+    expected = _dequantize(embedding.q_weight, embedding.embed_scale)[input_ids]
+
+    assert output.shape == (2, 2, 3)
+    assert torch.equal(output, expected)
+    assert torch.count_nonzero(output[input_ids == 0]) == 0
+
+
+def test_vocab_parallel_int8_embedding_masks_and_all_reduces(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VLLM_EXL3_EMBED_ONLINE_BITS", "8")
+    monkeypatch.setattr(
+        embedding_module, "get_tensor_model_parallel_world_size", lambda: 2
+    )
+    monkeypatch.setattr(embedding_module, "get_tensor_model_parallel_rank", lambda: 0)
+    monkeypatch.setattr(
+        embedding_module, "get_virtual_tp_vocab_padding_size", lambda size: size
+    )
+    def eager_mask(
+        input_: torch.Tensor,
+        org_start: int,
+        org_end: int,
+        org_padding: int,
+        added_start: int,
+        added_end: int,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        org_mask = (input_ >= org_start) & (input_ < org_end)
+        added_mask = (input_ >= added_start) & (input_ < added_end)
+        added_offset = added_start - (org_end - org_start) - org_padding
+        valid_offset = (org_start * org_mask) + (added_offset * added_mask)
+        valid_mask = org_mask | added_mask
+        return valid_mask * (input_ - valid_offset), ~valid_mask
+
+    monkeypatch.setattr(embedding_module, "get_masked_input_and_mask", eager_mask)
+    local_outputs: list[torch.Tensor] = []
+    peer_output = torch.tensor(
+        [[[0.0, 0.0], [5.0, 6.0]], [[0.0, 0.0], [7.0, 8.0]]]
+    )
+
+    def fake_all_reduce(output: torch.Tensor) -> torch.Tensor:
+        local_outputs.append(output.clone())
+        return output + peer_output
+
+    monkeypatch.setattr(
+        embedding_module, "tensor_model_parallel_all_reduce", fake_all_reduce
+    )
+    embedding = VocabParallelEmbedding(
+        4,
+        2,
+        params_dtype=torch.float32,
+        padding_size=1,
+        quant_config=Exl3Config(),
+        prefix="model.embed_tokens",
+    )
+    assert isinstance(embedding.quant_method, Exl3Int8EmbeddingMethod)
+    embedding.weight.data.zero_()
+    embedding.quant_method.process_weights_after_loading(embedding)
+    embedding.q_weight.copy_(
+        torch.tensor([[2, 4], [6, 8]], dtype=torch.int8)
+    )
+    embedding.embed_scale.fill_(0.5)
+
+    output = embedding(torch.tensor([[0, 2], [1, 3]]))
+
+    assert torch.equal(
+        local_outputs[0],
+        torch.tensor([[[1.0, 2.0], [0.0, 0.0]], [[3.0, 4.0], [0.0, 0.0]]]),
+    )
+    assert torch.equal(
+        output,
+        torch.tensor([[[1.0, 2.0], [5.0, 6.0]], [[3.0, 4.0], [7.0, 8.0]]]),
+    )
 
 
 def test_tied_embeddings_are_rejected(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -28,6 +28,7 @@ from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 
 import torch
+from torch.nn.parameter import Parameter
 from transformers import PretrainedConfig
 
 from vllm.config import get_current_vllm_config_or_none
@@ -54,6 +55,7 @@ from vllm.model_executor.layers.quantization.base_config import (
     QuantizeMethodBase,
 )
 from vllm.model_executor.parameter import BasevLLMParameter
+from vllm.model_executor.utils import set_weight_attrs
 from vllm.transformers_utils.repo_utils import get_hf_file_to_dict
 
 if TYPE_CHECKING:
@@ -74,6 +76,135 @@ _RANK_SLICED_RUNTIMES: dict[tuple[Any, ...], dict[str, Any]] = {}
 _MIXED_TRELLIS_RUNTIMES: dict[tuple[Any, ...], dict[str, Any]] = {}
 _NEXT_RUNTIME_SCOPE_ID = 0
 _MIXED_TRELLIS_ROUTE_BLOCK_SIZE = 8
+_EMBED_INT8_CHUNK_ROWS = 16384
+
+
+def _embed_online_bits() -> int | None:
+    """Return 8 when online int8 embeddings are enabled, otherwise None."""
+    raw = os.environ.get("VLLM_EXL3_EMBED_ONLINE_BITS")
+    if raw is None or not raw.strip() or raw.strip() == "0":
+        return None
+    try:
+        bits = int(raw)
+    except ValueError:
+        bits = -1
+    if bits != 8:
+        raise ValueError(
+            "VLLM_EXL3_EMBED_ONLINE_BITS must be unset, 0, or 8; "
+            f"got {raw!r}"
+        )
+    return bits
+
+
+def _encode_int8_embedding(
+    weight: torch.Tensor,
+    chunk_rows: int = _EMBED_INT8_CHUNK_ROWS,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Encode rows independently as symmetric int8 with fp16 scales."""
+    if weight.ndim != 2:
+        raise ValueError(f"embedding weight must be rank 2, got {weight.ndim}")
+    if chunk_rows <= 0:
+        raise ValueError(f"chunk_rows must be positive, got {chunk_rows}")
+
+    rows, hidden = weight.shape
+    q_weight = torch.empty((rows, hidden), dtype=torch.int8, device=weight.device)
+    scales = torch.empty(rows, dtype=torch.float16, device=weight.device)
+    for start in range(0, rows, chunk_rows):
+        stop = min(start + chunk_rows, rows)
+        chunk = weight[start:stop].to(torch.float32)
+        row_max = chunk.abs().amax(dim=1)
+        scale = torch.where(
+            row_max == 0,
+            torch.ones_like(row_max),
+            row_max / 127.0,
+        )
+        q_weight[start:stop] = (
+            (chunk / scale.unsqueeze(1)).round().clamp(-127, 127).to(torch.int8)
+        )
+        scales[start:stop] = scale.to(torch.float16)
+    return q_weight, scales
+
+
+class Exl3Int8EmbeddingMethod(QuantizeMethodBase):
+    """Load a normal embedding, then replace its BF16 rows with int8 rows."""
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: list[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs: Any,
+    ) -> None:
+        del input_size, output_size
+        weight = Parameter(
+            torch.empty(
+                sum(output_partition_sizes),
+                input_size_per_partition,
+                dtype=params_dtype,
+            ),
+            requires_grad=False,
+        )
+        set_weight_attrs(weight, {"input_dim": 1, "output_dim": 0})
+        layer.register_parameter("weight", weight)
+        set_weight_attrs(weight, extra_weight_attrs)
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        weight = layer.weight.detach()
+        rows, hidden = weight.shape
+        dtype = weight.dtype
+        device = weight.device
+        q_weight, scales = _encode_int8_embedding(weight)
+
+        del layer.weight
+        del weight
+        layer.register_buffer("q_weight", q_weight, persistent=False)
+        layer.register_buffer("embed_scale", scales, persistent=False)
+        layer.embed_output_dtype = dtype
+        # Native target/MTP sharing inspects ``weight.shape[-1]`` before it
+        # shares the whole module. Keep that surface without retaining storage.
+        layer.register_parameter(
+            "weight",
+            Parameter(torch.empty((0, hidden), dtype=dtype, device=device), False),
+        )
+        if device.type == "cuda":
+            torch.cuda.empty_cache()
+        logger.info(
+            "EXL3 int8 embedding conversion complete: rows=%d hidden=%d",
+            rows,
+            hidden,
+        )
+
+    def apply(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        del layer, x, bias
+        raise NotImplementedError(
+            "Exl3Int8EmbeddingMethod supports embedding lookup only"
+        )
+
+    def embedding(self, layer: torch.nn.Module, input_: torch.Tensor) -> torch.Tensor:
+        """Gather and dequantize using CUDA-graph-capturable tensor operations."""
+        dtype = layer.embed_output_dtype
+        rows = layer.q_weight[input_].to(dtype)
+        scales = layer.embed_scale[input_].to(dtype).unsqueeze(-1)
+        return rows * scales
+
+    def tie_weights(
+        self,
+        layer: torch.nn.Module,
+        embed_tokens: torch.nn.Module,
+    ) -> torch.nn.Module:
+        del layer, embed_tokens
+        raise ValueError(
+            "VLLM_EXL3_EMBED_ONLINE_BITS=8 is incompatible with tied "
+            "word embeddings"
+        )
 
 
 # Smallest m the Trellis kernel path can service, and therefore the smallest
@@ -407,6 +538,7 @@ class Exl3Config(QuantizationConfig):
         hf_config: PretrainedConfig | None = None,
         revision: str | None = None,
     ) -> None:
+        self._require_untied_int8_embedding(hf_config)
         rank_sliced = getattr(hf_config, "hybrid_tr3_tail", None)
         if (
             isinstance(rank_sliced, dict)
@@ -605,6 +737,25 @@ class Exl3Config(QuantizationConfig):
         if bad:
             raise ValueError("Invalid EXL3 tensor metadata: " + "; ".join(bad[:16]))
 
+    @staticmethod
+    def _require_untied_int8_embedding(
+        hf_config: PretrainedConfig | None,
+    ) -> None:
+        if hf_config is None or _embed_online_bits() is None:
+            return
+        configs: list[Any] = [hf_config]
+        try:
+            text_config = hf_config.get_text_config()
+        except (AttributeError, TypeError):
+            text_config = None
+        if text_config is not None and text_config is not hf_config:
+            configs.append(text_config)
+        if any(getattr(config, "tie_word_embeddings", False) for config in configs):
+            raise ValueError(
+                "VLLM_EXL3_EMBED_ONLINE_BITS=8 is incompatible with tied "
+                "word embeddings"
+            )
+
     def _force_independent_lm_head(self, hf_config: PretrainedConfig | None) -> None:
         if hf_config is None or not self.has_quantized_lm_head():
             return
@@ -654,6 +805,9 @@ class Exl3Config(QuantizationConfig):
         self, layer: torch.nn.Module, prefix: str
     ) -> QuantizeMethodBase | None:
         self._require_enforce_eager()
+        if layer.__class__.__name__ == "VocabParallelEmbedding":
+            if _embed_online_bits() is not None:
+                return Exl3Int8EmbeddingMethod()
         is_lm_head = layer.__class__.__name__ == "ParallelLMHead"
         if is_lm_head and not prefix:
             prefix = "lm_head"
@@ -2444,4 +2598,9 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         return output[..., :logical_n]
 
 
-__all__ = ["Exl3Config", "Exl3LinearMethod", "Exl3MoEMethod"]
+__all__ = [
+    "Exl3Config",
+    "Exl3Int8EmbeddingMethod",
+    "Exl3LinearMethod",
+    "Exl3MoEMethod",
+]

--- a/vllm/model_executor/layers/quantization/exl3.py
+++ b/vllm/model_executor/layers/quantization/exl3.py
@@ -163,8 +163,8 @@ class Exl3Int8EmbeddingMethod(QuantizeMethodBase):
         layer.register_buffer("q_weight", q_weight, persistent=False)
         layer.register_buffer("embed_scale", scales, persistent=False)
         layer.embed_output_dtype = dtype
-        # Native target/MTP sharing inspects ``weight.shape[-1]`` before it
-        # shares the whole module. Keep that surface without retaining storage.
+        # Preserve the generic embedding-width surface without retaining dense
+        # storage. Equality checks must use q_weight and embed_scale instead.
         layer.register_parameter(
             "weight",
             Parameter(torch.empty((0, hidden), dtype=dtype, device=device), False),

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -243,6 +243,8 @@ class Qwen3_5Model(Qwen3NextModel):
         self.embed_tokens = VocabParallelEmbedding(
             self.vocab_size,
             config.hidden_size,
+            quant_config=self.quant_config,
+            prefix=maybe_prefix(prefix, "embed_tokens"),
         )
 
         def get_layer(prefix: str):

--- a/vllm/model_executor/models/qwen3_5_mtp.py
+++ b/vllm/model_executor/models/qwen3_5_mtp.py
@@ -83,6 +83,8 @@ class Qwen3_5MultiTokenPredictor(nn.Module):
         self.embed_tokens = VocabParallelEmbedding(
             self.vocab_size,
             config.hidden_size,
+            quant_config=quant_config,
+            prefix=maybe_prefix(prefix, "embed_tokens"),
         )
 
         # Workaround: mtp.fc is stored as BF16 in NVFP4 checkpoints but is

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -65,6 +65,10 @@ from vllm.v1.spec_decode.utils import (
 from vllm.v1.utils import CpuGpuBuffer
 from vllm.v1.worker.dp_utils import coordinate_batch_across_dp
 from vllm.v1.worker.gpu.spec_decode.dflash.utils import maybe_load_mask_embedding
+from vllm.v1.worker.gpu.spec_decode.eagle.utils import (
+    embedding_quantization_compatible,
+    embeddings_equal,
+)
 from vllm.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
 from vllm.v1.worker.utils import AttentionGroup
 
@@ -1527,24 +1531,18 @@ class SpecDecodeBaseProposer:
                 )
 
             share_embeddings = False
+            draft_embed = getattr(self.model.model, "embed_tokens", None)
             if hasattr(self.model, "has_own_embed_tokens"):
                 # EAGLE model
                 if not self.model.has_own_embed_tokens:
                     share_embeddings = True
                     logger.info(
                         "Detected EAGLE model without its own embed_tokens in the"
-                        " checkpoint. Sharing target model embedding weights with the"
-                        " draft model."
+                        " checkpoint. Sharing target model embedding weights with"
+                        " the draft model."
                     )
-                elif (
-                    isinstance(target_embed_tokens.weight, torch.Tensor)
-                    and isinstance(self.model.model.embed_tokens.weight, torch.Tensor)
-                    # TODO: Offload to CPU for comparison to avoid extra GPU memory
-                    # usage in CI testing environments with limited GPU memory
-                    and torch.equal(
-                        target_embed_tokens.weight.cpu(),
-                        self.model.model.embed_tokens.weight.cpu(),
-                    )
+                elif draft_embed is not None and embeddings_equal(
+                    draft_embed, target_embed_tokens
                 ):
                     share_embeddings = True
                     logger.info(
@@ -1552,38 +1550,32 @@ class SpecDecodeBaseProposer:
                         " model. Sharing target model embedding weights with the draft"
                         " model."
                     )
-                else:
+
+                if not share_embeddings:
                     logger.info(
-                        "Detected EAGLE model with distinct embed_tokens weights. "
-                        "Keeping separate embedding weights from the target model."
+                        "Detected EAGLE model with distinct or incompatible "
+                        "embed_tokens weights. Keeping separate embedding weights "
+                        "from the target model."
                     )
             else:
-                # MTP model
-                share_embeddings = True
-                logger.info(
-                    "Detected MTP model. "
-                    "Sharing target model embedding weights with the draft model."
+                # Native MTP embeddings are aliases, but the modules must have
+                # matching widths and quantization representations.
+                share_embeddings = (
+                    draft_embed is not None
+                    and embedding_quantization_compatible(
+                        draft_embed, target_embed_tokens
+                    )
                 )
-
-            if share_embeddings:
-                draft_embed = self.model.model.embed_tokens
-                # Only share when both models use the same embedding width.
-                # Guard with isinstance so non-Tensor weights (e.g. in tests)
-                # are not affected — mirrors the weight-equality check above.
-                if isinstance(target_embed_tokens.weight, torch.Tensor) and isinstance(
-                    draft_embed.weight, torch.Tensor
-                ):
-                    target_dim = target_embed_tokens.weight.shape[-1]
-                    draft_dim = draft_embed.weight.shape[-1]
-                    if target_dim != draft_dim:
-                        share_embeddings = False
-                        logger.info(
-                            "Target embedding dim (%d) differs from draft "
-                            "embedding dim (%d). Keeping separate embedding "
-                            "weights.",
-                            target_dim,
-                            draft_dim,
-                        )
+                if share_embeddings:
+                    logger.info(
+                        "Detected MTP model. "
+                        "Sharing target model embedding weights with the draft model."
+                    )
+                else:
+                    logger.info(
+                        "Detected MTP model with incompatible embedding width or "
+                        "quantization. Keeping separate embedding weights."
+                    )
 
             if share_embeddings:
                 if hasattr(self.model.model, "embed_tokens"):

--- a/vllm/v1/worker/gpu/spec_decode/eagle/utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/eagle/utils.py
@@ -70,20 +70,98 @@ def _create_draft_vllm_config(vllm_config: VllmConfig) -> VllmConfig:
     return draft_vllm_config
 
 
-def _should_share(eagle: nn.Module, flag: str, draft, target) -> bool:
-    """Share when the draft has no own copy, or its copy matches the target."""
+def _tensor_equal(left: torch.Tensor, right: torch.Tensor) -> bool:
+    if left.shape != right.shape or left.dtype != right.dtype:
+        return False
+    if left.device != right.device:
+        return torch.equal(left.cpu(), right.cpu())
+    if left.is_cuda and torch.accelerator.get_memory_info(left.device)[0] < (
+        left.numel() * left.element_size()
+    ):
+        return torch.equal(left.cpu(), right.cpu())
+    return torch.equal(left, right)
 
-    if not getattr(eagle, flag, False) or draft is None:
-        return True
+
+def embedding_quantization_compatible(draft: nn.Module, target: nn.Module) -> bool:
+    """Return whether two embeddings have the same width and representation."""
+    draft_q = getattr(draft, "q_weight", None)
+    target_q = getattr(target, "q_weight", None)
+    draft_scale = getattr(draft, "embed_scale", None)
+    target_scale = getattr(target, "embed_scale", None)
+    quantized = (draft_q, target_q, draft_scale, target_scale)
+    if any(isinstance(tensor, torch.Tensor) for tensor in quantized):
+        if not (
+            isinstance(draft_q, torch.Tensor)
+            and isinstance(target_q, torch.Tensor)
+            and isinstance(draft_scale, torch.Tensor)
+            and isinstance(target_scale, torch.Tensor)
+        ):
+            return False
+        return (
+            draft_q.ndim == 2
+            and target_q.ndim == 2
+            and draft_scale.ndim == 1
+            and target_scale.ndim == 1
+            and draft_q.dtype == target_q.dtype
+            and draft_scale.dtype == target_scale.dtype
+            and draft_q.shape[-1] == target_q.shape[-1]
+            and draft_q.shape[0] == draft_scale.shape[0]
+            and target_q.shape[0] == target_scale.shape[0]
+        )
+
+    draft_weight = getattr(draft, "weight", None)
+    target_weight = getattr(target, "weight", None)
+    return (
+        isinstance(draft_weight, torch.Tensor)
+        and isinstance(target_weight, torch.Tensor)
+        and draft_weight.ndim == 2
+        and target_weight.ndim == 2
+        and draft_weight.shape[-1] == target_weight.shape[-1]
+    )
+
+
+def embeddings_equal(draft: nn.Module, target: nn.Module) -> bool:
+    """Compare the real dense or row-wise-int8 embedding representation."""
+    if not embedding_quantization_compatible(draft, target):
+        return False
+
+    draft_q = getattr(draft, "q_weight", None)
+    target_q = getattr(target, "q_weight", None)
+    if isinstance(draft_q, torch.Tensor) and isinstance(target_q, torch.Tensor):
+        return _tensor_equal(draft_q, target_q) and _tensor_equal(
+            draft.embed_scale, target.embed_scale
+        )
+
+    draft_weight = draft.weight
+    target_weight = target.weight
+    if draft_weight.numel() == 0 or target_weight.numel() == 0:
+        return False
+    return _tensor_equal(draft_weight, target_weight)
+
+
+def _should_share(
+    eagle: nn.Module,
+    flag: str,
+    draft,
+    target,
+    *,
+    validate_embedding_compatibility: bool = False,
+) -> bool:
+    """Share absent weights, or an owned copy that matches the target."""
+    has_own_copy = getattr(eagle, flag, False)
     if target is None:
         return False
-    # torch.equal on GPU allocates a bool mask the size of the input.
-    # Use the faster GPU path when there is plenty of headroom;
-    # otherwise compare on CPU.
-    w = draft.weight
-    if w.is_cuda and torch.accelerator.get_memory_info(w.device)[0] < w.numel() * 2:
-        return torch.equal(w.cpu(), target.weight.cpu())
-    return torch.equal(w, target.weight)
+    if not has_own_copy:
+        if flag == "has_own_embed_tokens" and validate_embedding_compatibility:
+            return draft is not None and embedding_quantization_compatible(
+                draft, target
+            )
+        return True
+    if draft is None:
+        return False
+    if flag == "has_own_embed_tokens":
+        return embeddings_equal(draft, target)
+    return _tensor_equal(draft.weight, target.weight)
 
 
 def get_target_lm_head(target_model: nn.Module, target_language_model: nn.Module):
@@ -130,7 +208,11 @@ def load_eagle_model(target_model: nn.Module, vllm_config: VllmConfig) -> nn.Mod
             target_embed = target_embed.base_layer
         draft_embed = getattr(draft_inner, "embed_tokens", None)
         if target_embed is not None and _should_share(
-            eagle_model, "has_own_embed_tokens", draft_embed, target_embed
+            eagle_model,
+            "has_own_embed_tokens",
+            draft_embed,
+            target_embed,
+            validate_embedding_compatibility=speculative_config.method == "mtp",
         ):
             if draft_embed is not None:
                 del draft_inner.embed_tokens


### PR DESCRIPTION
## Replacement for #436

Clean, single-purpose replacement for closed PR #436. Direct child of `fa033bd4`; DCO-signed; no development-stack history, import-time monkey hook, int6/Trellis path, or unrelated EXL3 work.

## Feature

Opt-in **int8 only** token embeddings for exact `VocabParallelEmbedding` tables:

- per-row symmetric int8 + fp16 scale;
- chunked load-time encoding to bound transients;
- BF16 table released after conversion;
- graph-safe gather/cast/scale at lookup;
- exact-type gate excludes `ParallelLMHead`;
- zero rows handled safely;
- explicit Qwen target and MTP `quant_config` + `prefix` constructor wiring;
- inert when unset; tied embeddings rejected.

No import hook is needed because model constructors pass the quantization context explicitly.

## Native sharing correctness

The compatibility `[0,H]` weight stub is metadata only and is never used to infer embedding equality:

- EAGLE models with owned embeddings compare real `q_weight` and `embed_scale` tensors;
- distinct, incomplete, or mixed quantization representations do not share;
- native MTP sharing remains unconditional only after width and quantization-representation compatibility checks in both proposer paths;
- ordinary EAGLE models without an owned embedding copy retain the established sharing behavior.

## Evidence correction

The isolated evidence is int8 only: mean KLD delta **+0.0000650485**, 95% source-cluster bootstrap CI **[+0.0000045718, +0.0001318019]** on 136 v3 contexts. `0.002700` was a body/checkpoint result and is not used here. No fidelity claim is made for int6 or Trellis.

Evidence: https://github.com/malaiwah/qwen38-27b-exl3/blob/main/receipts/paired-ctx-embed8.json

## Verification

The repository verifier pins the exact base, two-commit chain, six-file set, patched blobs, clean patch application, absence of hook/int6/Trellis symbols, constructor wiring, and sharing contract.

Focused tests executed against the immutable r34 environment with the patched files mounted over the exact public base:

```text
12 passed, 15 warnings in 4.09s
```

Coverage includes integer/float roundtrip bounds, zero rows, chunking identity, exact-type LM-head exclusion, unset inertness, tied-weight rejection, multidimensional lookup, TP masking/all-reduce, and equal/distinct EAGLE plus native-MTP sharing.

Real CUDA post-load/graph capture, multi-rank NCCL, full memory/context, text, vision, and MTP qualification remains an explicit AIBoss gate before default use.

AI assistance was used to implement and adversarially review the clean extraction; patch identity and focused tests were independently executed as described.
