### PR TITLE
[II] Bound Kimi-K3 DSpark large-prefill auxiliary memory

### DIFF
--- a/tests/models/kimi_k3/test_eagle3.py
+++ b/tests/models/kimi_k3/test_eagle3.py
@@ -128,3 +128,61 @@ def test_kimi_linear_forward_extracts_attn_res_aux_hidden_states(monkeypatch):
     torch.testing.assert_close(aux_hidden_states[0], initial_hidden_states)
     torch.testing.assert_close(aux_hidden_states[1], prefix_sum + layer_hidden_states)
     assert final_attn_res.call_args.args[2] is block_residual
+
+
+def test_kimi_linear_forward_streams_auxiliary_states(monkeypatch):
+    model = _make_kimi_linear_model()
+    initial_hidden_states = torch.tensor([[1.0, 2.0]])
+    layer_hidden_states = torch.tensor([[3.0, 4.0]])
+    layer_residual = torch.tensor([[5.0, 6.0]])
+    projected = torch.tensor([[11.0, 12.0]])
+
+    class Projector:
+        def __init__(self):
+            self.calls = []
+            self.started_with = None
+
+        def can_stream_auxiliary_states(self, layer_ids, hidden_states):
+            return layer_ids == (0, 1) and hidden_states is initial_hidden_states
+
+        def begin_auxiliary_stream(self, hidden_states):
+            self.started_with = hidden_states
+
+        def accumulate_auxiliary_state(self, primary, residual):
+            self.calls.append((primary, residual))
+
+        def finish_auxiliary_stream(self):
+            return projected
+
+    projector = Projector()
+    model.set_aux_hidden_state_projector(projector)
+    object.__setattr__(model, "start_layer", 0)
+    object.__setattr__(model, "end_layer", 1)
+    object.__setattr__(
+        model,
+        "layers",
+        [Mock(return_value=(layer_hidden_states, None, layer_residual))],
+    )
+    object.__setattr__(model, "aux_hidden_state_layers", (0, 1))
+    object.__setattr__(model, "use_attn_res", False)
+    monkeypatch.setattr(
+        kimi_model,
+        "get_pp_group",
+        lambda: SimpleNamespace(is_first_rank=True, is_last_rank=True),
+    )
+
+    output, aux_hidden_states = model.forward(
+        input_ids=None,
+        positions=torch.tensor([0]),
+        intermediate_tensors=None,
+        inputs_embeds=initial_hidden_states,
+    )
+
+    torch.testing.assert_close(output, layer_hidden_states + layer_residual)
+    assert projector.started_with is initial_hidden_states
+    assert projector.calls == [
+        (initial_hidden_states, None),
+        (layer_hidden_states, layer_residual),
+    ]
+    assert len(aux_hidden_states) == 1
+    assert aux_hidden_states[0] is projected

--- a/tests/models/test_dspark_mla.py
+++ b/tests/models/test_dspark_mla.py
@@ -300,6 +300,7 @@ def test_k3_dspark_context_projection_uses_divisible_tp_geometry(
 def test_k3_dspark_streams_auxiliary_projection_into_tp_local_rows(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    torch.manual_seed(0)
     model = object.__new__(K3DSparkModel)
     nn.Module.__init__(model)
     model.config = SimpleNamespace(
@@ -338,7 +339,6 @@ def test_k3_dspark_streams_auxiliary_projection_into_tp_local_rows(
         lambda tensor: tensor,
     )
 
-    torch.manual_seed(0)
     first = torch.randn(1024, 4, dtype=torch.bfloat16)
     second = torch.randn(1024, 4, dtype=torch.bfloat16)
     residual = torch.randn(1024, 4, dtype=torch.bfloat16)
@@ -356,7 +356,16 @@ def test_k3_dspark_streams_auxiliary_projection_into_tp_local_rows(
         model.accumulate_auxiliary_state(second, residual)
         output = model.finish_auxiliary_stream()
 
-    torch.testing.assert_close(output, expected, rtol=2e-2, atol=2e-2)
+    # Streaming replaces one BF16 GEMM with an ordered sum of BF16 GEMMs, so
+    # cancellation can move individual low-magnitude elements by several
+    # ulps. Preserve the projected vector rather than requiring elementwise
+    # equality between the two legal BF16 accumulation orders.
+    mean_absolute_error = (output.float() - expected.float()).abs().mean()
+    cosine_similarity = torch.nn.functional.cosine_similarity(
+        output.float().flatten(), expected.float().flatten(), dim=0
+    )
+    assert mean_absolute_error.item() < 2e-3
+    assert cosine_similarity.item() > 0.9999
     assert model.is_streamed_context_states([output])
     assert not model.is_streamed_context_states([output])
     assert output.data_ptr() == model._streamed_context_states.data_ptr()

--- a/tests/models/test_dspark_mla.py
+++ b/tests/models/test_dspark_mla.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pytest
 import torch
@@ -176,6 +177,7 @@ def test_k3_dspark_uses_replicated_markov_head(monkeypatch: pytest.MonkeyPatch):
     class DummyModule(nn.Module):
         def __init__(self, *args, **kwargs):
             super().__init__()
+            self.weight = nn.Parameter(torch.empty(0))
 
     def make_markov_head(*args, **kwargs):
         markov_head_calls.append((args, kwargs))
@@ -243,6 +245,7 @@ def test_k3_dspark_context_projection_uses_divisible_tp_geometry(
     class DummyModule(nn.Module):
         def __init__(self, *args, **kwargs):
             super().__init__()
+            self.weight = nn.Parameter(torch.empty(0))
 
     def make_sharded_projection(*args, **kwargs):
         context_projection_calls.append((args, kwargs))
@@ -283,6 +286,8 @@ def test_k3_dspark_context_projection_uses_divisible_tp_geometry(
     )
 
     assert model.context_proj_sharded is expect_sharded
+    assert model._streamed_context_states.dtype == model.context_proj.weight.dtype
+    assert model._streamed_context_states.device == model.context_proj.weight.device
     assert bool(context_projection_calls) is expect_sharded
     if expect_sharded:
         args, kwargs = context_projection_calls[0]
@@ -314,6 +319,10 @@ def test_k3_dspark_streams_auxiliary_projection_into_tp_local_rows(
     model._streamed_aux_scratch = None
     model._streamed_aux_tokens = 0
     model._streamed_aux_index = 0
+    model._streamed_aux_generation = 0
+    model._completed_stream_generation = 0
+    model._consumed_stream_generation = 0
+    model._completed_stream_result = None
     model._context_local_width = 2
     model._context_local_start = 0
     model.register_buffer(
@@ -329,6 +338,7 @@ def test_k3_dspark_streams_auxiliary_projection_into_tp_local_rows(
         lambda tensor: tensor,
     )
 
+    torch.manual_seed(0)
     first = torch.randn(1024, 4, dtype=torch.bfloat16)
     second = torch.randn(1024, 4, dtype=torch.bfloat16)
     residual = torch.randn(1024, 4, dtype=torch.bfloat16)
@@ -348,7 +358,116 @@ def test_k3_dspark_streams_auxiliary_projection_into_tp_local_rows(
 
     torch.testing.assert_close(output, expected, rtol=2e-2, atol=2e-2)
     assert model.is_streamed_context_states([output])
+    assert not model.is_streamed_context_states([output])
     assert output.data_ptr() == model._streamed_context_states.data_ptr()
+
+    with torch.inference_mode():
+        model.begin_auxiliary_stream(first)
+        model.accumulate_auxiliary_state(first, None)
+        model.accumulate_auxiliary_state(second, residual)
+        next_output = model.finish_auxiliary_stream()
+
+    assert not model.is_streamed_context_states([output])
+    assert model.is_streamed_context_states([next_output])
+
+
+@pytest.mark.cpu_test
+def test_k3_dspark_streamed_auxiliary_normalization_uses_global_hidden_width(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model = object.__new__(K3DSparkModel)
+    nn.Module.__init__(model)
+    model.config = SimpleNamespace(
+        target_hidden_size=4,
+        hidden_size=4,
+        target_layer_ids=(0, 1),
+    )
+    model.context_proj_sharded = True
+    model.context_proj = nn.Linear(8, 2, bias=False, dtype=torch.bfloat16)
+    model.context_norm = SimpleNamespace(
+        weight=torch.tensor([0.5, 1.0, 1.5, 2.0], dtype=torch.bfloat16),
+        variance_epsilon=1e-5,
+    )
+    model.context_kv_proj = nn.Linear(2, 2, bias=False, dtype=torch.bfloat16)
+    model._max_num_context_tokens = 1024
+    model._streamed_aux_layer_ids = (1, 2)
+    model._streamed_aux_scratch = None
+    model._streamed_aux_tokens = 0
+    model._streamed_aux_index = 0
+    model._streamed_aux_generation = 0
+    model._completed_stream_generation = 0
+    model._consumed_stream_generation = 0
+    model._completed_stream_result = None
+    model._context_local_width = 2
+    model._context_local_start = 2
+    model.register_buffer(
+        "_streamed_context_states",
+        torch.empty(1024, 2, dtype=torch.bfloat16),
+        persistent=False,
+    )
+    model.bind_auxiliary_stream_scratch(torch.empty(1024, 4, dtype=torch.bfloat16))
+
+    first = torch.randn(1024, 4, dtype=torch.bfloat16)
+    second = torch.randn(1024, 4, dtype=torch.bfloat16)
+    combined = torch.cat((first, second), dim=-1)
+    local_projection = torch.nn.functional.linear(combined, model.context_proj.weight)
+    other_rank_projection = torch.randn_like(local_projection)
+
+    def add_other_rank_squared_norm(tensor: torch.Tensor) -> torch.Tensor:
+        tensor.add_(other_rank_projection.float().square().sum(dim=-1, keepdim=True))
+        return tensor
+
+    monkeypatch.setattr(
+        dspark_mla,
+        "tensor_model_parallel_all_reduce_in_place",
+        add_other_rank_squared_norm,
+    )
+    expected_scale = torch.rsqrt(
+        (
+            local_projection.float().square().sum(dim=-1, keepdim=True)
+            + other_rank_projection.float().square().sum(dim=-1, keepdim=True)
+        )
+        / model.config.hidden_size
+        + model.context_norm.variance_epsilon
+    ).to(local_projection.dtype)
+    expected = local_projection * expected_scale * model.context_norm.weight[2:4]
+
+    with torch.inference_mode():
+        model.begin_auxiliary_stream(first)
+        model.accumulate_auxiliary_state(first, None)
+        model.accumulate_auxiliary_state(second, None)
+        output = model.finish_auxiliary_stream()
+
+    torch.testing.assert_close(output, expected, rtol=2e-2, atol=2e-2)
+
+
+@pytest.mark.cpu_test
+def test_k3_dspark_disables_streaming_for_incompatible_scratch_width() -> None:
+    model = object.__new__(K3DSparkModel)
+    nn.Module.__init__(model)
+    model.config = SimpleNamespace(target_hidden_size=8)
+    model._max_num_context_tokens = 16
+    model._streamed_aux_scratch = torch.empty(16, 8)
+
+    assert not model.bind_auxiliary_stream_scratch(torch.empty(16, 4))
+    assert model._streamed_aux_scratch is None
+
+
+@pytest.mark.cpu_test
+def test_k3_dspark_preserves_fallback_when_target_has_no_stream_hook() -> None:
+    wrapper = object.__new__(K3DSparkForCausalLM)
+    nn.Module.__init__(wrapper)
+    wrapper.model = SimpleNamespace(bind_auxiliary_stream_scratch=Mock())
+    target_model = SimpleNamespace(
+        get_language_model=lambda: SimpleNamespace(model=object())
+    )
+
+    wrapper.bind_target_auxiliary_stream(
+        target_model,
+        torch.empty(16, 8),
+    )
+
+    wrapper.model.bind_auxiliary_stream_scratch.assert_not_called()
 
 
 @pytest.mark.cpu_test
@@ -394,11 +513,13 @@ def test_k3_dspark_projects_streamed_context_one_layer_at_a_time(
         "tensor_model_parallel_all_reduce_in_place",
         record_all_reduce,
     )
-    monkeypatch.setattr(
-        dspark_mla.ops,
-        "rms_norm",
-        lambda output, input_, weight, eps: output.copy_(input_),
-    )
+    rms_norm_io = []
+
+    def record_rms_norm(output, input_, weight, eps):
+        rms_norm_io.append((output, input_))
+        output.copy_(input_)
+
+    monkeypatch.setattr(dspark_mla.ops, "rms_norm", record_rms_norm)
     monkeypatch.setattr(dspark_mla.ops, "rotary_embedding", lambda *args: None)
     context = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
     positions = torch.tensor([5, 6])
@@ -418,6 +539,7 @@ def test_k3_dspark_projects_streamed_context_one_layer_at_a_time(
         expected.append(torch.nn.functional.linear(context, weight))
     torch.testing.assert_close(reduced[0], expected[0])
     torch.testing.assert_close(reduced[1], expected[1])
+    assert all(output.data_ptr() != input_.data_ptr() for output, input_ in rms_norm_io)
     assert len(cache_updates) == 1
     torch.testing.assert_close(cache_updates[0][0], expected[0][:, :2])
     torch.testing.assert_close(cache_updates[0][1], expected[0][:, 2:].view(2, 1, 1))

--- a/tests/models/test_dspark_mla.py
+++ b/tests/models/test_dspark_mla.py
@@ -288,6 +288,140 @@ def test_k3_dspark_context_projection_uses_divisible_tp_geometry(
         args, kwargs = context_projection_calls[0]
         assert args == (7168 * 5, 7168)
         assert kwargs["gather_output"] is True
+        assert kwargs["quant_config"] is None
+
+
+@pytest.mark.cpu_test
+def test_k3_dspark_streams_auxiliary_projection_into_tp_local_rows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model = object.__new__(K3DSparkModel)
+    nn.Module.__init__(model)
+    model.config = SimpleNamespace(
+        target_hidden_size=4,
+        hidden_size=2,
+        target_layer_ids=(0, 1),
+    )
+    model.context_proj_sharded = True
+    model.context_proj = nn.Linear(8, 2, bias=False, dtype=torch.bfloat16)
+    model.context_norm = SimpleNamespace(
+        weight=torch.tensor([0.75, 1.25], dtype=torch.bfloat16),
+        variance_epsilon=1e-5,
+    )
+    model.context_kv_proj = nn.Linear(2, 2, bias=False, dtype=torch.bfloat16)
+    model._max_num_context_tokens = 1024
+    model._streamed_aux_layer_ids = (1, 2)
+    model._streamed_aux_scratch = None
+    model._streamed_aux_tokens = 0
+    model._streamed_aux_index = 0
+    model._context_local_width = 2
+    model._context_local_start = 0
+    model.register_buffer(
+        "_streamed_context_states",
+        torch.empty(1024, 2, dtype=torch.bfloat16),
+        persistent=False,
+    )
+    scratch = torch.empty(1024, 4, dtype=torch.bfloat16)
+    model.bind_auxiliary_stream_scratch(scratch)
+    monkeypatch.setattr(
+        dspark_mla,
+        "tensor_model_parallel_all_reduce_in_place",
+        lambda tensor: tensor,
+    )
+
+    first = torch.randn(1024, 4, dtype=torch.bfloat16)
+    second = torch.randn(1024, 4, dtype=torch.bfloat16)
+    residual = torch.randn(1024, 4, dtype=torch.bfloat16)
+    combined = torch.cat((first, second + residual), dim=-1)
+    projected = torch.nn.functional.linear(combined, model.context_proj.weight)
+    expected = projected * torch.rsqrt(
+        projected.float().square().mean(dim=-1, keepdim=True) + 1e-5
+    ).to(projected.dtype)
+    expected *= model.context_norm.weight
+
+    assert model.can_stream_auxiliary_states((1, 2), first)
+    with torch.inference_mode():
+        model.begin_auxiliary_stream(first)
+        model.accumulate_auxiliary_state(first, None)
+        model.accumulate_auxiliary_state(second, residual)
+        output = model.finish_auxiliary_stream()
+
+    torch.testing.assert_close(output, expected, rtol=2e-2, atol=2e-2)
+    assert model.is_streamed_context_states([output])
+    assert output.data_ptr() == model._streamed_context_states.data_ptr()
+
+
+@pytest.mark.cpu_test
+def test_k3_dspark_projects_streamed_context_one_layer_at_a_time(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model = object.__new__(K3DSparkModel)
+    nn.Module.__init__(model)
+    model._context_local_start = 2
+    model._context_local_width = 2
+    model._context_kv_width = 3
+    model._context_kv_lora_rank = 2
+    model._context_rope_dim = 1
+    model._context_rms_norm_eps = 1e-5
+    model._context_kv_norm_weights = torch.ones(2, 2)
+    model.context_kv_proj = nn.Linear(4, 6, bias=False)
+    model.context_kv_proj.weight.data.copy_(torch.arange(24).view(6, 4))
+    cache_updates = []
+
+    class Attention:
+        def __init__(self):
+            self.rotary_emb = SimpleNamespace(head_size=1, is_neox_style=True)
+            self.impl = SimpleNamespace(
+                do_kv_cache_update=lambda *args: cache_updates.append(args)
+            )
+            self.kv_cache = object()
+            self.kv_cache_dtype = "bf16"
+            self._k_scale = 1.0
+
+    model.layers = [
+        SimpleNamespace(self_attn=Attention()),
+        SimpleNamespace(self_attn=Attention()),
+    ]
+    model._get_rope_inputs = lambda positions: (positions, torch.empty(0))
+    reduced = []
+
+    def record_all_reduce(tensor):
+        reduced.append(tensor.clone())
+        return tensor
+
+    monkeypatch.setattr(
+        dspark_mla,
+        "tensor_model_parallel_all_reduce_in_place",
+        record_all_reduce,
+    )
+    monkeypatch.setattr(
+        dspark_mla.ops,
+        "rms_norm",
+        lambda output, input_, weight, eps: output.copy_(input_),
+    )
+    monkeypatch.setattr(dspark_mla.ops, "rotary_embedding", lambda *args: None)
+    context = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    positions = torch.tensor([5, 6])
+    first_slots = torch.tensor([0, 1])
+
+    model._precompute_streamed_context_kv(
+        context,
+        positions,
+        [first_slots, None],
+    )
+
+    expected = []
+    for layer_index in range(2):
+        weight = model.context_kv_proj.weight[
+            layer_index * 3 : (layer_index + 1) * 3, 2:4
+        ]
+        expected.append(torch.nn.functional.linear(context, weight))
+    torch.testing.assert_close(reduced[0], expected[0])
+    torch.testing.assert_close(reduced[1], expected[1])
+    assert len(cache_updates) == 1
+    torch.testing.assert_close(cache_updates[0][0], expected[0][:, :2])
+    torch.testing.assert_close(cache_updates[0][1], expected[0][:, 2:].view(2, 1, 1))
+    assert cache_updates[0][3] is first_slots
 
 
 def test_context_kv_weights_are_loaded_as_merged_linear_shards():

--- a/tests/v1/spec_decode/test_dflash_cudagraph_lifetime.py
+++ b/tests/v1/spec_decode/test_dflash_cudagraph_lifetime.py
@@ -254,6 +254,54 @@ def test_dflash_context_precompute_keeps_eager_fallback():
     assert args[2] is context_slots
 
 
+def test_dflash_uses_streamed_context_without_copying_full_hidden_state():
+    speculator = object.__new__(DFlashSpeculator)
+    streamed = torch.randn(1024, 4)
+    retained = torch.full((1024, 8), float("nan"))
+    model = Mock()
+    model.is_streamed_context_states.return_value = True
+    speculator.model = model
+    speculator.hidden_states = retained
+    speculator.dynamic_physical_depth = False
+    speculator.num_speculative_steps = 7
+    speculator.num_query_per_req = 8
+    speculator.sample_from_anchor = False
+    speculator.max_model_len = 4096
+    speculator.draft_kv_window = None
+    speculator.context_positions = torch.arange(1024)
+    speculator._prepare_eplb_forward = Mock()
+    speculator._generate_draft = Mock()
+    speculator.draft_tokens = torch.zeros(1, 7, dtype=torch.int64)
+    input_batch = SimpleNamespace(
+        num_reqs=1,
+        num_tokens=1024,
+        seq_lens_cpu_upper_bound=torch.tensor([1024]),
+    )
+
+    result = DFlashSpeculator.propose(
+        speculator,
+        input_batch,
+        attn_metadata={},
+        slot_mappings={},
+        last_hidden_states=torch.empty(1024, 8),
+        aux_hidden_states=[streamed],
+        num_sampled=torch.zeros(1, dtype=torch.int32),
+        num_rejected=torch.zeros(1, dtype=torch.int32),
+        last_sampled=torch.zeros(1, dtype=torch.int32),
+        next_prefill_tokens=torch.zeros(1, dtype=torch.int32),
+        temperature=torch.zeros(1),
+        seeds=torch.zeros(1, dtype=torch.int64),
+        dummy_run=True,
+        skip_attn_for_dummy_run=True,
+    )
+
+    args = model.precompute_and_store_context_kv.call_args.args
+    assert args[0] is streamed
+    assert torch.isnan(retained).all()
+    speculator._generate_draft.assert_called_once()
+    assert result.shape == (1, 7)
+
+
 def test_dflash_input_warmup_copies_sampling_state(monkeypatch):
     temperature = torch.ones(2)
     seeds = torch.zeros(2, dtype=torch.int64)

--- a/tests/v1/spec_decode/test_dflash_cudagraph_lifetime.py
+++ b/tests/v1/spec_decode/test_dflash_cudagraph_lifetime.py
@@ -302,6 +302,27 @@ def test_dflash_uses_streamed_context_without_copying_full_hidden_state():
     assert result.shape == (1, 7)
 
 
+def test_dflash_streamed_context_bypasses_captured_context_graph():
+    manager = Mock()
+    manager.dispatch_context.return_value = SimpleNamespace(
+        cg_mode=CUDAGraphMode.FULL,
+        num_tokens=2048,
+    )
+    speculator = SimpleNamespace(context_cudagraph_manager=manager)
+
+    result = DFlashSpeculator._dispatch_context_batch(
+        speculator,
+        1024,
+        context_states_are_streamed=True,
+        dummy_run=False,
+        is_profile=False,
+    )
+
+    manager.dispatch_context.assert_not_called()
+    assert result.cg_mode == CUDAGraphMode.NONE
+    assert result.num_tokens == 1024
+
+
 def test_dflash_input_warmup_copies_sampling_state(monkeypatch):
     temperature = torch.ones(2)
     seeds = torch.zeros(2, dtype=torch.int64)

--- a/tests/v1/spec_decode/test_dspark_local_vocab_sampling.py
+++ b/tests/v1/spec_decode/test_dspark_local_vocab_sampling.py
@@ -11,6 +11,43 @@ from vllm.v1.worker.gpu.spec_decode.dspark import speculator as speculator_modul
 from vllm.v1.worker.gpu.spec_decode.dspark.speculator import DSparkSpeculator
 
 
+def test_kimi_dspark_binds_target_auxiliary_stream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scratch = torch.empty(16, 8)
+    binder = Mock()
+    model = SimpleNamespace(
+        bind_target_auxiliary_stream=binder,
+        draft_id_to_target_id=None,
+    )
+    speculator = SimpleNamespace(
+        vllm_config=object(),
+        hidden_states=scratch,
+        use_draft_token_capacity=False,
+        draft_logits=None,
+        _draft_topk=None,
+        _use_local_draft_argmax=False,
+        _capture_sharded_markov=False,
+        _markov_outside_cudagraph=False,
+    )
+    target_model = object()
+    monkeypatch.delenv("VLLM_DSPARK_SHARD_MARKOV_HEAD", raising=False)
+    monkeypatch.setattr(
+        speculator_module,
+        "load_dspark_model",
+        lambda _target_model, _vllm_config: model,
+    )
+
+    loaded = DSparkSpeculator.load_draft_model(
+        speculator,
+        target_model=target_model,
+        target_attn_layer_names=set(),
+    )
+
+    assert loaded is model
+    binder.assert_called_once_with(target_model, scratch)
+
+
 def test_sharded_markov_model_selects_local_sampling(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/vllm/models/kimi_k3/nvidia/dspark_mla.py
+++ b/vllm/models/kimi_k3/nvidia/dspark_mla.py
@@ -8,11 +8,16 @@ from typing import Any
 
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 
 import vllm._custom_ops as ops
 from vllm import envs
 from vllm.config import VllmConfig
-from vllm.distributed import get_tp_group, tensor_model_parallel_all_gather
+from vllm.distributed import (
+    get_tp_group,
+    tensor_model_parallel_all_gather,
+    tensor_model_parallel_all_reduce_in_place,
+)
 from vllm.logger import init_logger
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import (
@@ -40,6 +45,7 @@ from vllm.v1.worker.workspace import current_workspace_manager
 logger = init_logger(__name__)
 
 _COMPACT_ROPE_PROTECTED_IDS: set[int] = set()
+_STREAMED_AUX_MIN_TOKENS = 1024
 
 
 def _load_b12x_vocab_parallel_argmax() -> Any | None:
@@ -220,14 +226,16 @@ class K3DSparkModel(nn.Module):
         if self.context_proj_sharded:
             # Target auxiliary states are identical across TP ranks. Each rank
             # retains and evaluates only its output rows; the gathered result
-            # preserves the draft hidden-state layout exactly.
+            # preserves the draft hidden-state layout exactly. Keep this one
+            # projection in BF16: large-prefill streaming reads contiguous
+            # input-column slices before the complete target state exists.
             self.context_proj = ColumnParallelLinear(
                 context_input_size,
                 self.config.hidden_size,
                 bias=False,
                 gather_output=True,
                 return_bias=False,
-                quant_config=self.quant_config,
+                quant_config=None,
                 prefix=context_prefix,
             )
         else:
@@ -278,6 +286,42 @@ class K3DSparkModel(nn.Module):
         self._max_num_context_tokens = (
             vllm_config.scheduler_config.max_num_batched_tokens
         )
+        self._streamed_aux_layer_ids = tuple(
+            int(layer_id) + 1
+            for layer_id in getattr(self.config, "target_layer_ids", ())
+        )
+        self._streamed_aux_scratch: torch.Tensor | None = None
+        self._streamed_aux_tokens = 0
+        self._streamed_aux_index = 0
+        self._context_local_width = (
+            int(self.config.hidden_size) // tp_size
+            if self.context_proj_sharded
+            else int(self.config.hidden_size)
+        )
+        self._context_local_start = (
+            int(getattr(self.context_proj, "tp_rank", 0)) * self._context_local_width
+        )
+        model_dtype = getattr(
+            getattr(vllm_config, "model_config", None),
+            "dtype",
+            torch.get_default_dtype(),
+        )
+        if self.context_proj_sharded:
+            self.register_buffer(
+                "_streamed_context_states",
+                torch.empty(
+                    self._max_num_context_tokens,
+                    self._context_local_width,
+                    dtype=model_dtype,
+                ),
+                persistent=False,
+            )
+        else:
+            self.register_buffer(
+                "_streamed_context_states",
+                torch.empty(0, dtype=model_dtype),
+                persistent=False,
+            )
         self._compact_rope_enabled = bool(envs.VLLM_DSPARK_COMPACT_ROPE)
         if self._compact_rope_enabled:
             self._init_compact_rope()
@@ -391,6 +435,145 @@ class K3DSparkModel(nn.Module):
     def combine_hidden_states(self, hidden_states: torch.Tensor) -> torch.Tensor:
         return self.context_norm(self.context_proj(hidden_states))
 
+    def bind_auxiliary_stream_scratch(self, scratch: torch.Tensor) -> None:
+        """Bind caller-owned storage used to form one target auxiliary state."""
+        expected_width = int(self.config.target_hidden_size)
+        if scratch.ndim != 2 or scratch.shape[1] != expected_width:
+            raise ValueError(
+                "Kimi-K3 DSpark auxiliary scratch must have shape "
+                f"[tokens, {expected_width}], got {tuple(scratch.shape)}."
+            )
+        if scratch.shape[0] < self._max_num_context_tokens:
+            raise ValueError(
+                "Kimi-K3 DSpark auxiliary scratch has insufficient token capacity: "
+                f"capacity={scratch.shape[0]}, required={self._max_num_context_tokens}."
+            )
+        self._streamed_aux_scratch = scratch
+
+    def can_stream_auxiliary_states(
+        self,
+        layer_ids: tuple[int, ...],
+        hidden_states: torch.Tensor,
+    ) -> bool:
+        """Return whether a large target forward can use streamed projection."""
+        if not self.context_proj_sharded or self._streamed_aux_scratch is None:
+            return False
+        if hidden_states.ndim != 2 or hidden_states.shape[0] < _STREAMED_AUX_MIN_TOKENS:
+            return False
+        if tuple(layer_ids) != self._streamed_aux_layer_ids:
+            return False
+        if hidden_states.shape[1] != self.config.target_hidden_size:
+            return False
+        if hidden_states.dtype != self.context_proj.weight.dtype:
+            return False
+        if hidden_states.device != self.context_proj.weight.device:
+            return False
+        if self._streamed_aux_scratch.dtype != hidden_states.dtype:
+            return False
+        if self._streamed_aux_scratch.device != hidden_states.device:
+            return False
+        if hidden_states.is_cuda and torch.cuda.is_current_stream_capturing():
+            return False
+        context_kv_weight = getattr(self.context_kv_proj, "weight", None)
+        return context_kv_weight is not None and context_kv_weight.ndim == 2
+
+    def begin_auxiliary_stream(self, hidden_states: torch.Tensor) -> None:
+        """Start one ordered sequence of target auxiliary-state projections."""
+        if not self.can_stream_auxiliary_states(
+            self._streamed_aux_layer_ids, hidden_states
+        ):
+            raise RuntimeError(
+                "Kimi-K3 DSpark auxiliary streaming was started for an "
+                "unsupported tensor geometry."
+            )
+        self._streamed_aux_tokens = int(hidden_states.shape[0])
+        self._streamed_aux_index = 0
+
+    def accumulate_auxiliary_state(
+        self,
+        primary: torch.Tensor,
+        residual: torch.Tensor | None,
+    ) -> None:
+        """Project one target state into its TP-local draft-hidden rows."""
+        index = self._streamed_aux_index
+        if index >= len(self._streamed_aux_layer_ids):
+            raise RuntimeError("Kimi-K3 DSpark received too many auxiliary states.")
+        num_tokens = self._streamed_aux_tokens
+        if tuple(primary.shape) != (num_tokens, self.config.target_hidden_size):
+            raise ValueError(
+                "Kimi-K3 DSpark auxiliary state shape changed during projection: "
+                f"got={tuple(primary.shape)}, tokens={num_tokens}, "
+                f"width={self.config.target_hidden_size}."
+            )
+        assert self._streamed_aux_scratch is not None
+        scratch = self._streamed_aux_scratch[:num_tokens]
+        if residual is None:
+            scratch.copy_(primary)
+        else:
+            torch.add(primary, residual, out=scratch)
+
+        input_width = int(self.config.target_hidden_size)
+        weight = self.context_proj.weight[
+            :, index * input_width : (index + 1) * input_width
+        ]
+        output = self._streamed_context_states[:num_tokens]
+        if index == 0:
+            torch.mm(scratch, weight.t(), out=output)
+        else:
+            torch.addmm(
+                output,
+                scratch,
+                weight.t(),
+                beta=1.0,
+                alpha=1.0,
+                out=output,
+            )
+        self._streamed_aux_index = index + 1
+
+    def finish_auxiliary_stream(self) -> torch.Tensor:
+        """Normalize and return the TP-local projected target context."""
+        expected = len(self._streamed_aux_layer_ids)
+        if self._streamed_aux_index != expected:
+            raise RuntimeError(
+                "Kimi-K3 DSpark auxiliary stream ended with an incomplete "
+                f"projection: received={self._streamed_aux_index}, expected={expected}."
+            )
+        output = self._streamed_context_states[: self._streamed_aux_tokens]
+        squared_norm = torch.linalg.vector_norm(
+            output,
+            ord=2,
+            dim=-1,
+            keepdim=True,
+            dtype=torch.float32,
+        ).square_()
+        tensor_model_parallel_all_reduce_in_place(squared_norm)
+        squared_norm.div_(self.config.hidden_size).add_(
+            self.context_norm.variance_epsilon
+        )
+        squared_norm.rsqrt_()
+        output.mul_(squared_norm.to(dtype=output.dtype))
+
+        output.mul_(
+            self.context_norm.weight[
+                self._context_local_start : self._context_local_start
+                + self._context_local_width
+            ]
+        )
+        return output
+
+    def is_streamed_context_states(self, states: list[torch.Tensor]) -> bool:
+        """Return whether ``states`` is the completed TP-local stream output."""
+        if not self.context_proj_sharded or len(states) != 1:
+            return False
+        candidate = states[0]
+        expected = self._streamed_context_states[: self._streamed_aux_tokens]
+        return (
+            candidate.shape == expected.shape
+            and candidate.dtype == expected.dtype
+            and candidate.device == expected.device
+            and candidate.data_ptr() == expected.data_ptr()
+        )
+
     @torch.inference_mode()
     def precompute_and_store_context_kv(
         self,
@@ -436,6 +619,15 @@ class K3DSparkModel(nn.Module):
         context_positions: torch.Tensor,
         context_slot_mapping: torch.Tensor | list[torch.Tensor | None] | None,
     ) -> None:
+        if (
+            self.context_proj_sharded
+            and context_states.shape[-1] == self._context_local_width
+        ):
+            self._precompute_streamed_context_kv(
+                context_states, context_positions, context_slot_mapping
+            )
+            return
+
         num_ctx = context_states.shape[0]
         num_layers = self._num_context_layers
 
@@ -538,6 +730,72 @@ class K3DSparkModel(nn.Module):
                 attn.kv_cache_dtype,
                 attn._k_scale,
             )
+
+    def _precompute_streamed_context_kv(
+        self,
+        context_states: torch.Tensor,
+        context_positions: torch.Tensor,
+        context_slot_mapping: torch.Tensor | list[torch.Tensor | None] | None,
+    ) -> None:
+        """Project TP-local context one draft layer at a time."""
+        num_ctx = int(context_states.shape[0])
+        full_weight = self.context_kv_proj.weight
+        if full_weight.ndim != 2:
+            raise RuntimeError(
+                "Streamed Kimi-K3 DSpark context KV requires an unquantized "
+                "two-dimensional fused projection weight."
+            )
+
+        rope_positions, rope_cos_sin_cache = self._get_rope_inputs(context_positions)
+        rotary_emb = self.layers[0].self_attn.rotary_emb
+        assert rotary_emb is not None
+
+        for layer_idx, layer in enumerate(self.layers):
+            row_start = layer_idx * self._context_kv_width
+            weight = full_weight[
+                row_start : row_start + self._context_kv_width,
+                self._context_local_start : self._context_local_start
+                + self._context_local_width,
+            ]
+            layer_kv = F.linear(context_states, weight)
+            tensor_model_parallel_all_reduce_in_place(layer_kv)
+
+            kv_c = layer_kv[:, : self._context_kv_lora_rank].contiguous()
+            ops.rms_norm(
+                kv_c,
+                kv_c,
+                self._context_kv_norm_weights[layer_idx],
+                self._context_rms_norm_eps,
+            )
+            k_pe = layer_kv[:, self._context_kv_lora_rank :].contiguous()
+            k_pe = k_pe.view(num_ctx, 1, self._context_rope_dim)
+            ops.rotary_embedding(
+                rope_positions,
+                k_pe,
+                None,
+                rotary_emb.head_size,
+                rope_cos_sin_cache,
+                rotary_emb.is_neox_style,
+            )
+
+            slot_mapping = (
+                context_slot_mapping[layer_idx]
+                if isinstance(context_slot_mapping, (list, tuple))
+                else context_slot_mapping
+            )
+            if slot_mapping is None:
+                del layer_kv, kv_c, k_pe
+                continue
+            attn = layer.self_attn
+            attn.impl.do_kv_cache_update(
+                kv_c,
+                k_pe,
+                attn.kv_cache,
+                slot_mapping,
+                attn.kv_cache_dtype,
+                attn._k_scale,
+            )
+            del layer_kv, kv_c, k_pe
 
     def _has_uniform_block_layout(
         self,
@@ -652,6 +910,30 @@ class K3DSparkForCausalLM(nn.Module):
 
     def combine_hidden_states(self, hidden_states: torch.Tensor) -> torch.Tensor:
         return self.model.combine_hidden_states(hidden_states)
+
+    def bind_target_auxiliary_stream(
+        self,
+        target_model: nn.Module,
+        scratch: torch.Tensor,
+    ) -> None:
+        """Connect the target's large-prefill states to the draft projector."""
+        get_language_model = getattr(target_model, "get_language_model", None)
+        target_language_model = (
+            get_language_model() if callable(get_language_model) else target_model
+        )
+        target_inner = getattr(target_language_model, "model", None)
+        setter = getattr(target_inner, "set_aux_hidden_state_projector", None)
+        if not callable(setter):
+            raise TypeError(
+                "Kimi-K3 DSpark auxiliary streaming requires a target model "
+                "that accepts a memory-bounded auxiliary-state projector."
+            )
+        self.model.bind_auxiliary_stream_scratch(scratch)
+        setter(self.model)
+
+    def is_streamed_context_states(self, states: list[torch.Tensor]) -> bool:
+        """Return whether target auxiliary states are already TP-local."""
+        return self.model.is_streamed_context_states(states)
 
     def get_draft_kv_cache_layer_names(self) -> list[str]:
         return [layer.self_attn.layer_name for layer in self.model.layers]

--- a/vllm/models/kimi_k3/nvidia/dspark_mla.py
+++ b/vllm/models/kimi_k3/nvidia/dspark_mla.py
@@ -293,6 +293,10 @@ class K3DSparkModel(nn.Module):
         self._streamed_aux_scratch: torch.Tensor | None = None
         self._streamed_aux_tokens = 0
         self._streamed_aux_index = 0
+        self._streamed_aux_generation = 0
+        self._completed_stream_generation = 0
+        self._consumed_stream_generation = 0
+        self._completed_stream_result: torch.Tensor | None = None
         self._context_local_width = (
             int(self.config.hidden_size) // tp_size
             if self.context_proj_sharded
@@ -301,25 +305,26 @@ class K3DSparkModel(nn.Module):
         self._context_local_start = (
             int(getattr(self.context_proj, "tp_rank", 0)) * self._context_local_width
         )
-        model_dtype = getattr(
-            getattr(vllm_config, "model_config", None),
-            "dtype",
-            torch.get_default_dtype(),
-        )
+        context_proj_weight = self.context_proj.weight
         if self.context_proj_sharded:
             self.register_buffer(
                 "_streamed_context_states",
                 torch.empty(
                     self._max_num_context_tokens,
                     self._context_local_width,
-                    dtype=model_dtype,
+                    dtype=context_proj_weight.dtype,
+                    device=context_proj_weight.device,
                 ),
                 persistent=False,
             )
         else:
             self.register_buffer(
                 "_streamed_context_states",
-                torch.empty(0, dtype=model_dtype),
+                torch.empty(
+                    0,
+                    dtype=context_proj_weight.dtype,
+                    device=context_proj_weight.device,
+                ),
                 persistent=False,
             )
         self._compact_rope_enabled = bool(envs.VLLM_DSPARK_COMPACT_ROPE)
@@ -435,20 +440,25 @@ class K3DSparkModel(nn.Module):
     def combine_hidden_states(self, hidden_states: torch.Tensor) -> torch.Tensor:
         return self.context_norm(self.context_proj(hidden_states))
 
-    def bind_auxiliary_stream_scratch(self, scratch: torch.Tensor) -> None:
+    def bind_auxiliary_stream_scratch(self, scratch: torch.Tensor) -> bool:
         """Bind caller-owned storage used to form one target auxiliary state."""
         expected_width = int(self.config.target_hidden_size)
         if scratch.ndim != 2 or scratch.shape[1] != expected_width:
-            raise ValueError(
-                "Kimi-K3 DSpark auxiliary scratch must have shape "
-                f"[tokens, {expected_width}], got {tuple(scratch.shape)}."
+            logger.warning_once(
+                "Kimi-K3 DSpark auxiliary streaming is disabled because its "
+                "caller-owned scratch has shape %s instead of [tokens, %d].",
+                tuple(scratch.shape),
+                expected_width,
             )
+            self._streamed_aux_scratch = None
+            return False
         if scratch.shape[0] < self._max_num_context_tokens:
             raise ValueError(
                 "Kimi-K3 DSpark auxiliary scratch has insufficient token capacity: "
                 f"capacity={scratch.shape[0]}, required={self._max_num_context_tokens}."
             )
         self._streamed_aux_scratch = scratch
+        return True
 
     def can_stream_auxiliary_states(
         self,
@@ -488,6 +498,8 @@ class K3DSparkModel(nn.Module):
             )
         self._streamed_aux_tokens = int(hidden_states.shape[0])
         self._streamed_aux_index = 0
+        self._streamed_aux_generation += 1
+        self._completed_stream_result = None
 
     def accumulate_auxiliary_state(
         self,
@@ -559,20 +571,28 @@ class K3DSparkModel(nn.Module):
                 + self._context_local_width
             ]
         )
+        self._completed_stream_generation = self._streamed_aux_generation
+        self._completed_stream_result = output
         return output
 
     def is_streamed_context_states(self, states: list[torch.Tensor]) -> bool:
-        """Return whether ``states`` is the completed TP-local stream output."""
+        """Claim the completed TP-local stream output exactly once."""
         if not self.context_proj_sharded or len(states) != 1:
             return False
         candidate = states[0]
         expected = self._streamed_context_states[: self._streamed_aux_tokens]
-        return (
-            candidate.shape == expected.shape
+        matches = (
+            candidate is self._completed_stream_result
+            and self._completed_stream_generation > self._consumed_stream_generation
+            and candidate.shape == expected.shape
             and candidate.dtype == expected.dtype
             and candidate.device == expected.device
             and candidate.data_ptr() == expected.data_ptr()
         )
+        if matches:
+            self._consumed_stream_generation = self._completed_stream_generation
+            self._completed_stream_result = None
+        return matches
 
     @torch.inference_mode()
     def precompute_and_store_context_kv(
@@ -760,9 +780,14 @@ class K3DSparkModel(nn.Module):
             layer_kv = F.linear(context_states, weight)
             tensor_model_parallel_all_reduce_in_place(layer_kv)
 
-            kv_c = layer_kv[:, : self._context_kv_lora_rank].contiguous()
+            kv_c = layer_kv[:, : self._context_kv_lora_rank]
+            normalized_kv_c = torch.empty(
+                (num_ctx, self._context_kv_lora_rank),
+                dtype=kv_c.dtype,
+                device=kv_c.device,
+            )
             ops.rms_norm(
-                kv_c,
+                normalized_kv_c,
                 kv_c,
                 self._context_kv_norm_weights[layer_idx],
                 self._context_rms_norm_eps,
@@ -784,18 +809,18 @@ class K3DSparkModel(nn.Module):
                 else context_slot_mapping
             )
             if slot_mapping is None:
-                del layer_kv, kv_c, k_pe
+                del layer_kv, kv_c, normalized_kv_c, k_pe
                 continue
             attn = layer.self_attn
             attn.impl.do_kv_cache_update(
-                kv_c,
+                normalized_kv_c,
                 k_pe,
                 attn.kv_cache,
                 slot_mapping,
                 attn.kv_cache_dtype,
                 attn._k_scale,
             )
-            del layer_kv, kv_c, k_pe
+            del layer_kv, kv_c, normalized_kv_c, k_pe
 
     def _has_uniform_block_layout(
         self,
@@ -924,11 +949,13 @@ class K3DSparkForCausalLM(nn.Module):
         target_inner = getattr(target_language_model, "model", None)
         setter = getattr(target_inner, "set_aux_hidden_state_projector", None)
         if not callable(setter):
-            raise TypeError(
-                "Kimi-K3 DSpark auxiliary streaming requires a target model "
-                "that accepts a memory-bounded auxiliary-state projector."
+            logger.warning_once(
+                "Kimi-K3 DSpark auxiliary streaming is disabled because the "
+                "target model does not expose an auxiliary-state projector hook."
             )
-        self.model.bind_auxiliary_stream_scratch(scratch)
+            return
+        if not self.model.bind_auxiliary_stream_scratch(scratch):
+            return
         setter(self.model)
 
     def is_streamed_context_states(self, states: list[torch.Tensor]) -> bool:

--- a/vllm/models/kimi_k3/nvidia/model.py
+++ b/vllm/models/kimi_k3/nvidia/model.py
@@ -5,7 +5,7 @@
 import math
 import os
 from collections.abc import Iterable
-from typing import Any, cast
+from typing import Any, Protocol, cast
 
 import regex as re
 import torch
@@ -133,6 +133,27 @@ from ..common.mm_preprocess import (
 )
 
 logger = init_logger(__name__)
+
+
+class AuxiliaryStateProjector(Protocol):
+    """Consumer that projects target auxiliary states as they are produced."""
+
+    def can_stream_auxiliary_states(
+        self,
+        layer_ids: tuple[int, ...],
+        hidden_states: torch.Tensor,
+    ) -> bool: ...
+
+    def begin_auxiliary_stream(self, hidden_states: torch.Tensor) -> None: ...
+
+    def accumulate_auxiliary_state(
+        self,
+        primary: torch.Tensor,
+        residual: torch.Tensor | None,
+    ) -> None: ...
+
+    def finish_auxiliary_stream(self) -> torch.Tensor: ...
+
 
 # Token-count cutoff for overlapping the MoE router gate with the routed-expert
 # down projection on a separate CUDA stream (latent MoE). At or below this many
@@ -1455,7 +1476,10 @@ class KimiLinearModel(nn.Module, EagleModelMixin, SupportsQuant):
         # Bypass nn.Module registration because the draft is not a target child.
         object.__setattr__(self, "_aux_hidden_state_projector", None)
 
-    def set_aux_hidden_state_projector(self, projector: Any | None) -> None:
+    def set_aux_hidden_state_projector(
+        self,
+        projector: AuxiliaryStateProjector | None,
+    ) -> None:
         """Bind a non-owning consumer for memory-bounded auxiliary states."""
         object.__setattr__(self, "_aux_hidden_state_projector", projector)
 

--- a/vllm/models/kimi_k3/nvidia/model.py
+++ b/vllm/models/kimi_k3/nvidia/model.py
@@ -1451,6 +1451,13 @@ class KimiLinearModel(nn.Module, EagleModelMixin, SupportsQuant):
         assert config.num_attention_heads % world_size == 0, (
             "num_attention_heads must be divisible by world_size"
         )
+        # A draft may bind an auxiliary-state projector after both models load.
+        # Bypass nn.Module registration because the draft is not a target child.
+        object.__setattr__(self, "_aux_hidden_state_projector", None)
+
+    def set_aux_hidden_state_projector(self, projector: Any | None) -> None:
+        """Bind a non-owning consumer for memory-bounded auxiliary states."""
+        object.__setattr__(self, "_aux_hidden_state_projector", projector)
 
     def make_empty_intermediate_tensors(
         self,
@@ -1508,10 +1515,29 @@ class KimiLinearModel(nn.Module, EagleModelMixin, SupportsQuant):
             hidden_states = sp_shard(hidden_states)
             assert residual is None, "Currently, SP is not supported with PP"
 
-        # sharded aux hidden states when sp is enabled
+        projector = getattr(self, "_aux_hidden_state_projector", None)
+        pp_group = get_pp_group()
+        stream_aux_hidden_states = bool(
+            projector is not None
+            and not self.use_sequence_parallel
+            and pp_group.is_first_rank
+            and pp_group.is_last_rank
+            and projector.can_stream_auxiliary_states(
+                self.aux_hidden_state_layers, hidden_states
+            )
+        )
+        if stream_aux_hidden_states:
+            projector.begin_auxiliary_stream(hidden_states)
+
+        # Auxiliary states remain sequence-parallel shards until the final gather.
         aux_hidden_states: list[torch.Tensor] = []
         if self.start_layer in self.aux_hidden_state_layers:
-            if self.use_attn_res or residual is None:
+            if stream_aux_hidden_states:
+                projector.accumulate_auxiliary_state(
+                    hidden_states,
+                    None if self.use_attn_res else residual,
+                )
+            elif self.use_attn_res or residual is None:
                 aux_hidden_states.append(hidden_states)
             else:
                 aux_hidden_states.append(hidden_states + residual)
@@ -1540,14 +1566,20 @@ class KimiLinearModel(nn.Module, EagleModelMixin, SupportsQuant):
                 residual=residual,
             )
             if (layer_idx + 1) in self.aux_hidden_state_layers:
-                if self.use_attn_res:
+                if stream_aux_hidden_states and self.use_attn_res:
+                    assert prefix_sum is not None
+                    projector.accumulate_auxiliary_state(prefix_sum, hidden_states)
+                elif stream_aux_hidden_states:
+                    assert residual is not None
+                    projector.accumulate_auxiliary_state(hidden_states, residual)
+                elif self.use_attn_res:
                     assert prefix_sum is not None
                     aux_hidden_state = prefix_sum + hidden_states
+                    aux_hidden_states.append(aux_hidden_state)
                 else:
                     assert residual is not None
                     aux_hidden_state = hidden_states + residual
-
-                aux_hidden_states.append(aux_hidden_state)
+                    aux_hidden_states.append(aux_hidden_state)
 
         assert hidden_states is not None
         assert residual is not None
@@ -1577,6 +1609,9 @@ class KimiLinearModel(nn.Module, EagleModelMixin, SupportsQuant):
             )
         else:
             hidden_states = hidden_states + residual
+
+        if stream_aux_hidden_states:
+            aux_hidden_states.append(projector.finish_auxiliary_stream())
 
         if self.use_sequence_parallel:
             if aux_hidden_states:

--- a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
@@ -719,20 +719,38 @@ class DFlashSpeculator(DraftModelSpeculator):
         # number of rejected tokens, we maintain the size of input_ids and
         # hidden_states the same as the target model's. This means, we pad each
         # request's query length to include any rejected positions.
-        if aux_hidden_states:
+        is_streamed_context_states = getattr(
+            self.model, "is_streamed_context_states", None
+        )
+        context_states_are_streamed = bool(
+            aux_hidden_states
+            and callable(is_streamed_context_states)
+            and is_streamed_context_states(aux_hidden_states)
+        )
+        if context_states_are_streamed:
+            assert aux_hidden_states is not None
+            context_states = aux_hidden_states[0]
+        elif aux_hidden_states:
             hidden_states = self.model.combine_hidden_states(
                 torch.cat(aux_hidden_states, dim=-1)
             )
+            self.hidden_states[:num_target_tokens].copy_(
+                hidden_states[:num_target_tokens]
+            )
+            context_states = self.hidden_states[:num_target_tokens]
         else:
             hidden_states = last_hidden_states
-        self.hidden_states[:num_target_tokens].copy_(hidden_states[:num_target_tokens])
+            self.hidden_states[:num_target_tokens].copy_(
+                hidden_states[:num_target_tokens]
+            )
+            context_states = self.hidden_states[:num_target_tokens]
 
         if dummy_run and skip_attn_for_dummy_run:
             # Memory profiling path: block_tables / kv_cache_config are not initialized.
             # Since DFlash needs to build its own attention metadata, we must skip the
             # preparation in this path and run a minimal forward pass.
             self.model.precompute_and_store_context_kv(
-                self.hidden_states[:num_target_tokens],
+                context_states,
                 self.context_positions[:num_target_tokens],
             )
             # DFlash processes all speculative tokens in one forward pass,
@@ -832,11 +850,23 @@ class DFlashSpeculator(DraftModelSpeculator):
             ]
         else:
             context_slots = self._context_slot_mappings[0][:num_target_tokens]
-        self._precompute_context_kv(
-            num_target_tokens,
-            context_batch_desc,
-            context_slots,
-        )
+        if context_states_are_streamed:
+            if context_batch_desc.cg_mode != CUDAGraphMode.NONE:
+                raise RuntimeError(
+                    "Streamed target context cannot use a captured DFlash "
+                    "context-KV graph."
+                )
+            self.model.precompute_and_store_context_kv(
+                context_states,
+                self.context_positions[:num_target_tokens],
+                context_slots,
+            )
+        else:
+            self._precompute_context_kv(
+                num_target_tokens,
+                context_batch_desc,
+                context_slots,
+            )
 
         # Every DFlash step has exactly num_query_per_req tokens, so we can use FULL CGs
         batch_desc, num_tokens_across_dp = dispatch_cg_and_sync_dp(

--- a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
@@ -571,6 +571,27 @@ class DFlashSpeculator(DraftModelSpeculator):
             context_slots,
         )
 
+    def _dispatch_context_batch(
+        self,
+        num_target_tokens: int,
+        *,
+        context_states_are_streamed: bool,
+        dummy_run: bool,
+        is_profile: bool,
+    ) -> BatchExecutionDescriptor:
+        """Select eager execution for streamed caller-owned context states."""
+        if (
+            self.context_cudagraph_manager is not None
+            and not context_states_are_streamed
+            and not (dummy_run or is_profile)
+        ):
+            return self.context_cudagraph_manager.dispatch_context(num_target_tokens)
+        return BatchExecutionDescriptor(
+            cg_mode=CUDAGraphMode.NONE,
+            num_tokens=num_target_tokens,
+            num_reqs=None,
+        )
+
     def _generate_draft(
         self,
         num_reqs: int,
@@ -771,16 +792,12 @@ class DFlashSpeculator(DraftModelSpeculator):
         # The query slot mapping is written into the shared BlockTables slot_mappings.
         # That buffer's address is what the captured CUDA graph reads from at replay.
         assert self.draft_kv_cache_group_id >= 0
-        if self.context_cudagraph_manager is not None and not (dummy_run or is_profile):
-            context_batch_desc = self.context_cudagraph_manager.dispatch_context(
-                num_target_tokens
-            )
-        else:
-            context_batch_desc = BatchExecutionDescriptor(
-                cg_mode=CUDAGraphMode.NONE,
-                num_tokens=num_target_tokens,
-                num_reqs=None,
-            )
+        context_batch_desc = self._dispatch_context_batch(
+            num_target_tokens,
+            context_states_are_streamed=context_states_are_streamed,
+            dummy_run=dummy_run,
+            is_profile=is_profile,
+        )
         context_num_tokens_padded = context_batch_desc.num_tokens
         # Support multiple draft KV cache groups by preparing inputs once for each
         for i, gid in enumerate(self.draft_kv_cache_group_ids):
@@ -851,11 +868,7 @@ class DFlashSpeculator(DraftModelSpeculator):
         else:
             context_slots = self._context_slot_mappings[0][:num_target_tokens]
         if context_states_are_streamed:
-            if context_batch_desc.cg_mode != CUDAGraphMode.NONE:
-                raise RuntimeError(
-                    "Streamed target context cannot use a captured DFlash "
-                    "context-KV graph."
-                )
+            assert context_batch_desc.cg_mode == CUDAGraphMode.NONE
             self.model.precompute_and_store_context_kv(
                 context_states,
                 self.context_positions[:num_target_tokens],

--- a/vllm/v1/worker/gpu/spec_decode/dspark/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dspark/speculator.py
@@ -180,6 +180,9 @@ class DSparkSpeculator(DFlashSpeculator):
         target_attn_layer_names: set[str],
     ) -> torch.nn.Module:
         model = load_dspark_model(target_model, self.vllm_config)
+        bind_auxiliary_stream = getattr(model, "bind_target_auxiliary_stream", None)
+        if callable(bind_auxiliary_stream):
+            bind_auxiliary_stream(target_model, self.hidden_states)
         confidence_head = getattr(
             getattr(model, "model", None), "confidence_head", None
         )


### PR DESCRIPTION
## Behavior

Kimi-K3 DSpark prefill with at least 1,024 target tokens streams each requested target auxiliary state into the TP-sharded draft context projection. The target uses caller-owned scratch instead of retaining five full `[tokens, 7168]` tensors. Draft context KV is projected and inserted one layer at a time instead of materializing the fused five-layer tensor.

The TP-sharded context projection remains BF16 because input-column streaming requires an uncompressed two-dimensional weight. The output accumulator uses the projection weight's device and dtype. Each completed streamed result has one generation and can be claimed once, so a stale view with the same storage address cannot be accepted by a later draft step.

Unsupported scratch geometry or a target without the streaming hook retains the materialized auxiliary-state path. Insufficient token capacity remains a startup error because it violates the scheduler allocation contract. Streamed DFlash context-KV preparation stays eager even when the context graph manager has a matching FULL graph; query decoding can still use its configured graph.

Small-token decode, non-sharded projection, sequence parallelism, pipeline parallelism, and target CUDA graph capture retain the materialized auxiliary-state path. Target-model verification is unchanged; numerical differences are limited to speculative proposals.

## Technical reason

A 4,096-token target chunk otherwise retains five 56 MiB auxiliary states before DSpark combines them and then allocates cross-layer draft-KV intermediates. Near a physically allocated one-million-token KV cache, the first auxiliary addition can fail despite adequate startup capacity. Streaming retains one caller-owned target-width scratch tensor, one TP-local draft accumulator, and one draft-layer KV output.

The RMSNorm operation uses distinct input and output storage as required by its custom-operation schema. The input is a strided view of the layer projection, so the normalized destination replaces the previous contiguous input copy and does not increase the transient allocation.

## Validation

Status: implemented and model-free qualified.

- `46 passed` across `tests/models/test_dspark_mla.py`, `tests/models/kimi_k3/test_eagle3.py`, `tests/v1/spec_decode/test_dflash_cudagraph_lifetime.py`, and `tests/v1/spec_decode/test_dspark_local_vocab_sampling.py` in the CUDA 13.3 / PyTorch 2.13 runtime image.
- Ruff 0.14.0 check and format validation pass for all modified files.
- TP16 CUDA, RTX PRO 6000 Blackwell, BF16, 4,096 rows: streamed context projection cosine similarity `0.999993`, maximum absolute difference `0.125` against the materialized formulation.
- TP16 CUDA, five 576-row draft-KV projections: cosine similarity `0.999978`, maximum absolute difference `0.0625` against replicated full-context GEMM.
- Caller-owned `[4096, 7168]` residual addition removes a measured 56 MiB allocation. Streamed context projection removes the concatenated 280 MiB target-state tensor and retains only a 3.5 MiB TP-local accumulator per rank.
- Full-checkpoint commit `3a55cc1fda0` completed a 134,219-token, five-image TP16/DCP16 request and an immediate native host-KV restore with HTTP 200 and 128 output tokens. Commit `506cba33f24` adds review hardening and is included in the combined full-checkpoint qualification image.

Full-checkpoint publication requires the combined Kimi-K3 source composition to pass cold prefill, host-KV restore, no-spec decode, DSpark, and DFlash qualification.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved large-context speculative decoding for Kimi K3 and DSpark models with streamed auxiliary hidden states.
  * Added more efficient context KV preparation, tensor-parallel processing, normalization, and buffer reuse.

* **Bug Fixes**
  * Prevented unnecessary hidden-state copying and overwriting during draft token generation.
  * Improved handling of streamed contexts and unsupported configurations.

* **Tests**
  * Added comprehensive coverage for streaming projections, KV preparation, buffer handling, model integration, and regression scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->