### PR TITLE
[II] Align hybrid recurrent checkpoints with cache-group boundaries

### DIFF
--- a/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
@@ -42,6 +42,7 @@ from vllm.v1.kv_cache_interface import (
     ChunkedLocalAttentionSpec,
     FullAttentionSpec,
     KVCacheGroupSpec,
+    MambaSpec,
     SlidingWindowSpec,
 )
 from vllm.v1.kv_offload.base import (
@@ -112,8 +113,8 @@ def test_partial_tail_store_uses_attention_and_recurrent_cow_sources():
     req_status = scheduler._req_status["req"]
     req_status.group_states[0].block_ids[:] = [11, 12]
     req_status.group_states[1].block_ids[:] = [0, 21]
-    scheduler.manager.prepare_store.side_effect = (
-        lambda keys, req_context: generate_store_output(keys)
+    scheduler.manager.prepare_store.side_effect = lambda keys, req_context: (
+        generate_store_output(keys)
     )
 
     output = SimpleNamespace(partial_tail_offloads={"req": [(1, 99, 28)]})
@@ -3423,6 +3424,122 @@ class TestEagle:
         # 249, the tail of the first 1000-token chunk.)
         assert offsets == list(range(len(offsets))), (
             f"interior hole in stored blocks: {offsets}"
+        )
+
+    def test_mixed_mamba_store_is_invariant_to_prefill_chunk_budget(
+        self, request_runner
+    ):
+        """A larger prefill chunk must not remove reusable recurrent states.
+
+        This geometry is a 1:256 scale model of Kimi-K3 with DCP16: twelve
+        recurrent groups checkpoint on the 12,288-token target-attention
+        boundary, four target-attention groups use 12,288-token blocks, and
+        one EAGLE draft group uses a 32,768-token sliding window over
+        768-token blocks. Scheduler budgets of 3 and 16 model 768-token and
+        4,096-token prefill budgets.
+
+        Every target-attention boundary needs the corresponding recurrent
+        state. The externally reusable prefix therefore cannot depend on the
+        scheduler chunk budget.
+        """
+
+        target_block = 48
+        recurrent_block = target_block
+        physical_block = 3
+        draft_window = 128
+        prompt_tokens = 524
+
+        def make_groups() -> list[KVCacheGroupSpec]:
+            recurrent = [
+                KVCacheGroupSpec(
+                    [f"recurrent-{idx}"],
+                    MambaSpec(
+                        block_size=recurrent_block,
+                        shapes=((1,),),
+                        dtypes=(torch.float32,),
+                        mamba_cache_mode="align",
+                    ),
+                )
+                for idx in range(12)
+            ]
+            target = [
+                KVCacheGroupSpec(
+                    [f"target-{idx}"],
+                    FullAttentionSpec(
+                        block_size=target_block,
+                        num_kv_heads=1,
+                        head_size=1,
+                        dtype=torch.float32,
+                    ),
+                )
+                for idx in range(4)
+            ]
+            draft = KVCacheGroupSpec(
+                ["draft"],
+                SlidingWindowSpec(
+                    block_size=physical_block,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                    sliding_window=draft_window,
+                ),
+                is_eagle_group=True,
+            )
+            return [*recurrent, *target, draft]
+
+        def run(prefill_budget: int) -> tuple[int, list[int]]:
+            runner = request_runner(
+                block_size=physical_block,
+                num_gpu_blocks=1024,
+                async_scheduling=False,
+                kv_cache_groups=make_groups(),
+            )
+            runner.scheduler.max_num_scheduled_tokens = prefill_budget
+
+            stored_keys = set()
+
+            def prepare_store(keys, req_context):
+                keys = list(keys)
+                stored_keys.update(keys)
+                return generate_store_output(keys)
+
+            runner.manager.prepare_store.side_effect = prepare_store
+            token_ids = [0] * prompt_tokens
+            runner.new_request(token_ids=token_ids)
+            full_blocks, tail = divmod(prompt_tokens, recurrent_block)
+            prefill_steps = full_blocks * (recurrent_block // prefill_budget)
+            prefill_steps += (tail + prefill_budget - 1) // prefill_budget
+            runner._run(
+                [1] * prefill_steps + [EOS_TOKEN_ID],
+                complete_transfers=True,
+            )
+
+            group_counts = [0] * len(make_groups())
+            for key in stored_keys:
+                group_counts[get_offload_group_idx(key)] += 1
+
+            runner.scheduler.reset_prefix_cache()
+            runner.new_request(token_ids=token_ids)
+            req_status = runner.connector_scheduler._req_status[str(runner.req_id)]
+            req_status.update_offload_keys()
+            runner.manager.lookup.side_effect = lambda key, req_context: (
+                LookupResult.HIT if key in stored_keys else LookupResult.MISS
+            )
+            hit = runner.connector_scheduler._lookup(req_status)
+            assert hit is not None
+            return hit, group_counts
+
+        narrow_hit, narrow_counts = run(3)
+        wide_hit, wide_counts = run(16)
+
+        # Recurrent and target groups define the reusable full-context prefix.
+        # Sliding-window draft storage can legitimately vary with step shape.
+        assert wide_counts[:-1] == narrow_counts[:-1], (
+            "recurrent/target stored group counts differ: "
+            f"narrow={narrow_counts[:-1]}, wide={wide_counts[:-1]}"
+        )
+        assert wide_hit == narrow_hit == 480, (
+            f"external hit differs: narrow={narrow_hit}, wide={wide_hit}"
         )
 
     @pytest.mark.parametrize("async_scheduling", [True, False])

--- a/tests/v1/kv_connector/unit/offloading_connector/utils.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/utils.py
@@ -41,6 +41,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheConfig,
     KVCacheGroupSpec,
     KVCacheTensor,
+    MambaSpec,
 )
 from vllm.v1.kv_offload.base import (
     CanonicalKVCaches,
@@ -241,6 +242,15 @@ class RequestRunner:
                 )
             ]
 
+        mamba_modes = {
+            group.kv_cache_spec.mamba_cache_mode
+            for group in kv_cache_groups
+            if isinstance(group.kv_cache_spec, MambaSpec)
+        }
+        if mamba_modes:
+            assert len(mamba_modes) == 1
+            vllm_config.cache_config.mamba_cache_mode = mamba_modes.pop()
+
         kv_cache_tensors = [
             KVCacheTensor(
                 size=group.kv_cache_spec.page_size_bytes * num_gpu_blocks,
@@ -282,16 +292,23 @@ class RequestRunner:
         for group in kv_cache_groups:
             spec = group.kv_cache_spec
             for layer_name in group.layer_names:
-                # Shape follows FlashAttention layout:
-                # Shape: (num_blocks, 2, block_size, num_kv_heads, head_size)
-                kv_caches[layer_name] = torch.empty(
-                    num_gpu_blocks,
-                    2,
-                    spec.block_size,
-                    spec.num_kv_heads,
-                    spec.head_size,
-                    dtype=spec.dtype,
-                )
+                if isinstance(spec, MambaSpec):
+                    kv_caches[layer_name] = torch.empty(
+                        num_gpu_blocks,
+                        spec.page_size_bytes,
+                        dtype=torch.int8,
+                    )
+                else:
+                    # Shape follows FlashAttention layout:
+                    # (blocks, K/V, tokens, heads, head size).
+                    kv_caches[layer_name] = torch.empty(
+                        num_gpu_blocks,
+                        2,
+                        spec.block_size,
+                        spec.num_kv_heads,
+                        spec.head_size,
+                        dtype=spec.dtype,
+                    )
 
         with set_current_vllm_config(vllm_config):
             self.worker_connector.register_kv_caches(kv_caches)

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -915,7 +915,13 @@ class Platform:
             )
 
         if cache_config.mamba_cache_mode == "align":
-            cache_config.mamba_block_size = cache_config.block_size
+            # An explicitly configured Mamba block is the recurrent-state
+            # checkpoint cadence. It does not determine the physical page
+            # size: Mamba pages are padded to the attention page below. This
+            # permits a hybrid model to align recurrent checkpoints with a
+            # coarser attention or DCP boundary while retaining smaller
+            # physical attention pages.
+            cache_config.mamba_block_size = mamba_block_size or cache_config.block_size
 
         # Pad mamba page size to exactly match attention page size
         attn_page_size = cache_config.block_size * attn_page_size_1_token

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import itertools
+import math
 import time
 from collections import defaultdict, deque
 from collections.abc import Iterable
@@ -53,7 +54,7 @@ from vllm.v1.core.sched.request_queue import (
 )
 from vllm.v1.core.sched.utils import check_stop, remove_all
 from vllm.v1.engine import EngineCoreEventType, EngineCoreOutput, EngineCoreOutputs
-from vllm.v1.kv_cache_interface import KVCacheConfig
+from vllm.v1.kv_cache_interface import KVCacheConfig, MambaSpec
 from vllm.v1.metrics.perf import ModelMetrics, PerfStats
 from vllm.v1.metrics.stats import PrefixCacheStats, SchedulerStats
 from vllm.v1.outputs import DraftTokenIds, KVConnectorOutput, ModelRunnerOutput
@@ -314,6 +315,21 @@ class Scheduler(SchedulerInterface):
         self.need_mamba_block_aligned_split = (
             self.has_mamba_layers and self.cache_config.mamba_cache_mode == "align"
         )
+        mamba_block_sizes = [
+            group.kv_cache_spec.block_size
+            for group in kv_cache_config.kv_cache_groups
+            if isinstance(group.kv_cache_spec, MambaSpec)
+        ]
+        self.mamba_block_size = math.lcm(*mamba_block_sizes)
+        self.mamba_eagle_block_sizes = tuple(
+            manager.block_size
+            for group, manager in zip(
+                kv_cache_config.kv_cache_groups,
+                self.kv_cache_manager.coordinator.single_type_managers,
+                strict=True,
+            )
+            if group.is_eagle_group
+        )
         # A finer prefix_match_unit is configured: a mamba partial tail entry
         # can only be registered by a step ending exactly at the prompt's last
         # hash boundary, so the split adds that stop.
@@ -385,13 +401,29 @@ class Scheduler(SchedulerInterface):
         if start >= prefill_end:
             return num_new_tokens
 
-        block_size = self.cache_config.block_size
+        block_size = getattr(self, "mamba_block_size", self.cache_config.block_size)
         # The last block-aligned position whose state can be cached. With
         # Eagle, FullAttn prunes the last matching block, so back off one
         # block to avoid a Mamba cache miss.
         last_cache_position = request.num_tokens - request.num_tokens % block_size
         if self.use_eagle:
-            last_cache_position = max(last_cache_position - block_size, 0)
+            # EAGLE drops the last complete draft-attention block. Convert the
+            # resulting maximum reusable prefix to the recurrent-state grid.
+            # Older configurations without an annotated EAGLE group retain
+            # the conservative one-Mamba-block behavior.
+            eagle_block_sizes = getattr(self, "mamba_eagle_block_sizes", ()) or (
+                block_size,
+            )
+            eagle_cache_position = min(
+                max(
+                    request.num_tokens
+                    - request.num_tokens % eagle_block_size
+                    - eagle_block_size,
+                    0,
+                )
+                for eagle_block_size in eagle_block_sizes
+            )
+            last_cache_position = eagle_cache_position // block_size * block_size
 
         end = start + num_new_tokens
         # Invariant: slot p holds the state after exactly (p + 1) * block_size


### PR DESCRIPTION
## Behavior

Hybrid Mamba/attention serving can retain an explicitly configured recurrent-state checkpoint cadence while physical Mamba pages remain padded to the attention page size.

The scheduler derives recurrent alignment from the resolved `MambaSpec` groups. For EAGLE models, it converts the last reusable annotated draft-attention boundary onto the recurrent-state grid. A prefill budget smaller than the recurrent interval may therefore advance through private intermediate states and publish a checkpoint only on a boundary shared with target attention.

## Technical reason

`Platform._align_hybrid_block_size` previously replaced every align-mode `--mamba-block-size` with the physical attention block size. `Scheduler._mamba_block_aligned_split` also read the physical cache block directly. Those two behaviors coupled logical recurrent checkpoints to physical page geometry.

For Kimi-K3 TP16/DCP16, 768-token recurrent checkpoints combined with 4,096-token prefill budgets did not land on 12,288-token target-attention boundaries. Native offload could restore only the first common 61,440-token boundary. A 12,288-token recurrent cadence permits three 4,096-token prefill steps per target boundary without changing physical page bytes.

## Compatibility

- Default configurations are unchanged: when `--mamba-block-size` is not explicit, align mode still uses the physical attention block size.
- Physical KV page sizing and allocation are unchanged.
- Configurations without annotated EAGLE groups retain the conservative one-recurrent-block backoff.
- The behavior is model-independent for hybrid cache groups; Kimi-K3 TP16/DCP16 supplies the motivating geometry.

## Validation

- 21 focused scheduler and Mamba alignment tests passed.
- 45 broader Mamba, hybrid prefix-cache, and offloading tests passed.
- The scaled Kimi-K3 regression uses 12 recurrent groups, 4 target-attention groups, and one EAGLE draft group. Scheduler budgets representing 768 and 4,096 tokens both stored 11 checkpoints in every recurrent and target group and restored the same full-context prefix.
- Ruff and formatting checks passed.

Full-model TP16/DCP16 validation is tracked in the source-composed Kimi-K3 image qualification.

## Upstream relationship

- [vllm-project/vllm#46251](https://github.com/vllm-project/vllm/pull/46251) is a draft that separates logical block sizes from allocation size through a hierarchical allocator. This pull request does not import that unfinished allocator; Kimi-K3 already uses uniform physical page bytes.
- [vllm-project/vllm#52971](https://github.com/vllm-project/vllm/pull/52971) exports Kimi checkpoints from FlashKDA. It requires the FlashKDA prefill backend and addresses internal checkpoint export rather than explicit align-mode checkpoint cadence.