### PR TITLE
[II] Bound Kimi vision memory to request inputs

### DIFF
--- a/tests/models/kimi_k3/test_vision_projector.py
+++ b/tests/models/kimi_k3/test_vision_projector.py
@@ -80,11 +80,11 @@ class _SerializedFp8Projector(nn.Module):
             requires_grad=False,
         )
         self.pre_norm = nn.LayerNorm(4, dtype=torch.bfloat16)
-        self.input_dtype: torch.dtype | None = None
+        self.inputs: list[torch.Tensor] = []
 
     def forward(self, inputs: torch.Tensor) -> torch.Tensor:
-        self.input_dtype = inputs.dtype
-        return inputs
+        self.inputs.append(inputs)
+        return inputs + len(self.inputs)
 
 
 def test_kimi_projector_uses_norm_activation_dtype_for_fp8_weights():
@@ -95,9 +95,43 @@ def test_kimi_projector_uses_norm_activation_dtype_for_fp8_weights():
         [torch.randn(2, 4), torch.randn(1, 4)],
     )
 
-    assert projector.input_dtype == torch.bfloat16
+    assert len(projector.inputs) == 2
+    assert [inputs.shape for inputs in projector.inputs] == [(2, 4), (1, 4)]
+    assert all(inputs.dtype == torch.bfloat16 for inputs in projector.inputs)
     assert [output.shape for output in outputs] == [(2, 4), (1, 4)]
     assert all(output.dtype == torch.bfloat16 for output in outputs)
+    assert torch.equal(outputs[0], projector.inputs[0] + 1)
+    assert torch.equal(outputs[1], projector.inputs[1] + 2)
+
+
+def test_kimi_projector_rejects_empty_vision_output():
+    with pytest.raises(
+        ValueError, match="Kimi vision projection requires at least one image feature"
+    ):
+        mm_projector_forward(_SerializedFp8Projector(), [])
+
+
+class _DeterministicProjector(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.pre_norm = nn.LayerNorm(4)
+        self.linear = nn.Linear(4, 3, bias=False)
+
+    def forward(self, inputs: torch.Tensor) -> torch.Tensor:
+        return self.linear(self.pre_norm(inputs))
+
+
+def test_kimi_projector_preserves_batched_projection_results():
+    torch.manual_seed(1)
+    projector = _DeterministicProjector()
+    inputs = [torch.randn(2, 4), torch.randn(3, 4)]
+    expected = torch.split(projector(torch.cat(inputs)), [2, 3])
+
+    outputs = mm_projector_forward(projector, inputs)
+
+    assert len(outputs) == len(expected)
+    for output, reference in zip(outputs, expected):
+        torch.testing.assert_close(output, reference)
 
 
 def test_kimi_vision_rope_reuses_packed_qk_buffers():

--- a/tests/models/kimi_k3/test_vision_warmup.py
+++ b/tests/models/kimi_k3/test_vision_warmup.py
@@ -13,6 +13,43 @@ from vllm.model_executor.warmup.kimi_k3_triton_warmup import (
 )
 
 
+def _full_grid_rope_reference(
+    rope: kimi_k25_vit.Rope2DPosEmbRepeated,
+    shapes: list[list[int]],
+) -> torch.Tensor:
+    flat_pos = torch.arange(rope.max_height * rope.max_width).float()
+    x_pos = flat_pos % rope.max_width
+    y_pos = flat_pos // rope.max_width
+    dim_range = torch.arange(0, rope.dim, 4).float()
+    freqs = 1.0 / (rope.theta_base ** (dim_range / rope.dim))
+    x_freqs = torch.outer(x_pos, freqs).float()
+    y_freqs = torch.outer(y_pos, freqs).float()
+    x_cis = torch.polar(torch.ones_like(x_freqs), x_freqs)
+    y_cis = torch.polar(torch.ones_like(y_freqs), y_freqs)
+    table = torch.cat(
+        [x_cis.unsqueeze(dim=-1), y_cis.unsqueeze(dim=-1)], dim=-1
+    ).reshape(rope.max_height, rope.max_width, -1)
+    return torch.cat(
+        [table[:h, :w].reshape(-1, rope.dim // 2).repeat(t, 1) for t, h, w in shapes]
+    )
+
+
+def test_vision_rope_materializes_only_requested_grids() -> None:
+    rope = kimi_k25_vit.Rope2DPosEmbRepeated(
+        dim=32,
+        max_height=11,
+        max_width=13,
+    )
+    shapes = [[1, 3, 5], [2, 4, 2], [1, 3, 5]]
+
+    actual = rope.get_freqs_cis(shapes, device=torch.device("cpu"))
+    expected = _full_grid_rope_reference(rope, shapes)
+
+    assert torch.equal(actual, expected)
+    assert actual.shape == (46, 16)
+    assert not hasattr(rope, "freqs_cis")
+
+
 def test_warm_vision_position_interpolation(monkeypatch) -> None:
     model = torch.nn.Sequential(
         kimi_k25_vit.Learnable2DInterpPosEmbDivided_fixed(

--- a/vllm/model_executor/models/kimi_k25_vit.py
+++ b/vllm/model_executor/models/kimi_k25_vit.py
@@ -840,21 +840,24 @@ class MoonViT3dPretrainedModel(nn.Module):
 
 @torch.inference_mode()
 def mm_projector_forward(mm_projector: torch.nn.Module, vt_output: list[torch.Tensor]):
-    """Apply MM projector to vision tower outputs."""
-    num_embedding_list = [x.shape[0] for x in vt_output]
-    batched = torch.cat(vt_output, dim=0)
+    """Apply the projector without concatenating independent image features."""
+    if not vt_output:
+        raise ValueError("Kimi vision projection requires at least one image feature")
+
     projector_norm = getattr(mm_projector, "pre_norm", None)
     if projector_norm is None:
         projector_norm = getattr(mm_projector, "post_norm", None)
     projector_dtype = (
-        projector_norm.weight.dtype if projector_norm is not None else batched.dtype
+        projector_norm.weight.dtype if projector_norm is not None else None
     )
-    if batched.dtype != projector_dtype:
-        batched = batched.to(projector_dtype)
-    proj_out = mm_projector(batched)
-    proj_out = proj_out.reshape(-1, proj_out.shape[-1])
-    proj_out = torch.split(proj_out, num_embedding_list)
-    return proj_out
+
+    projected = []
+    for image_features in vt_output:
+        if projector_dtype is not None and image_features.dtype != projector_dtype:
+            image_features = image_features.to(projector_dtype)
+        output = mm_projector(image_features)
+        projected.append(output.reshape(-1, output.shape[-1]))
+    return tuple(projected)
 
 
 @torch.inference_mode()

--- a/vllm/model_executor/models/kimi_k25_vit.py
+++ b/vllm/model_executor/models/kimi_k25_vit.py
@@ -282,27 +282,28 @@ class Rope2DPosEmbRepeated(nn.Module):
             f"max_width={self.max_width}, theta_base={self.theta_base}"
         )
 
-    def _precompute_freqs_cis(self, device: torch.device) -> torch.Tensor:
-        """Calculate the cis(freqs) for each position in the 2D grid."""
-        N = self.max_height * self.max_width
-        flat_pos = torch.arange(0, N).float().to(device)
-        x_pos = flat_pos % self.max_width
-        y_pos = flat_pos // self.max_width
-        dim_range = (
-            torch.arange(0, self.dim, 4)[: (self.dim // 4)].float().to(device)
-        )  # C/4
+    def _compute_grid_freqs_cis(
+        self, height: int, width: int, device: torch.device
+    ) -> torch.Tensor:
+        """Calculate rotary frequencies for one requested image grid."""
+        x_pos = torch.arange(width, dtype=torch.float32, device=device)
+        y_pos = torch.arange(height, dtype=torch.float32, device=device)
+        dim_range = torch.arange(0, self.dim, 4, dtype=torch.float32, device=device)[
+            : (self.dim // 4)
+        ]
         freqs = 1.0 / (self.theta_base ** (dim_range / self.dim))
-        x_freqs = torch.outer(x_pos, freqs).float()  # N, C/4
-        y_freqs = torch.outer(y_pos, freqs).float()  # N, C/4
-        x_cis = torch.polar(torch.ones_like(x_freqs), x_freqs)  # N, C/4
-        y_cis = torch.polar(torch.ones_like(y_freqs), y_freqs)  # N, C/4
-        # N, C/4, 2
-        freqs_cis = torch.cat(
-            [x_cis.unsqueeze(dim=-1), y_cis.unsqueeze(dim=-1)], dim=-1
+        x_freqs = torch.outer(x_pos, freqs).float()
+        y_freqs = torch.outer(y_pos, freqs).float()
+        x_cis = torch.polar(torch.ones_like(x_freqs), x_freqs)
+        y_cis = torch.polar(torch.ones_like(y_freqs), y_freqs)
+        freqs_cis = torch.stack(
+            (
+                x_cis.unsqueeze(0).expand(height, -1, -1),
+                y_cis.unsqueeze(1).expand(-1, width, -1),
+            ),
+            dim=-1,
         )
-        # max_height, max_width, C/2
-        freqs_cis = freqs_cis.reshape(self.max_height, self.max_width, -1)
-        return freqs_cis
+        return freqs_cis.reshape(height * width, self.dim // 2)
 
     def get_freqs_cis(
         self, grid_thws: torch.Tensor | list[list[int]], device: torch.device
@@ -314,11 +315,6 @@ class Rope2DPosEmbRepeated(nn.Module):
         Returns:
             freqs_cis: tensor of shape (sum(t * height * width), dim//2)
         """
-        if not hasattr(self, "freqs_cis"):
-            self.register_buffer(
-                "freqs_cis", self._precompute_freqs_cis(device), persistent=False
-            )
-
         shapes = grid_thws if isinstance(grid_thws, list) else grid_thws.tolist()
         assert all(
             1 <= h <= self.max_height and 1 <= w <= self.max_width for t, h, w in shapes
@@ -327,14 +323,15 @@ class Rope2DPosEmbRepeated(nn.Module):
             self.max_height,
             self.max_width,
         )
-        freqs_cis = torch.cat(
-            [
-                self.freqs_cis[:h, :w].reshape(-1, self.dim // 2).repeat(t, 1)
-                for t, h, w in shapes
-            ],
-            dim=0,
-        )
-        return freqs_cis
+        grids: dict[tuple[int, int], torch.Tensor] = {}
+        result = []
+        for t, h, w in shapes:
+            grid = grids.get((h, w))
+            if grid is None:
+                grid = self._compute_grid_freqs_cis(h, w, device)
+                grids[(h, w)] = grid
+            result.append(grid.repeat(t, 1))
+        return torch.cat(result, dim=0)
 
 
 class MLP2(nn.Module):


### PR DESCRIPTION
## Behavior

Kimi MoonViT bounds rotary-position and multimodal-projector memory by the
images present in each request:

- two-dimensional rotary frequencies are computed only for requested grid
  dimensions, with repeated dimensions sharing a request-local table;
- independent image feature tensors are projected separately, so serialized
  FP8 and Marlin workspace scales with the largest image instead of the sum of
  every image in the request;
- query and key rotary application reuses their consumed BF16 projection
  buffers and rotates each temporary complex tensor in place.

The configured 512-by-512 grid remains an input-validation limit. Projected
features retain input order, activation dtype, row count, and hidden width.

Status: **implemented and qualified**.

## Technical reason

`Rope2DPosEmbRepeated` previously materialized a complex64 table for every
position in the configured grid. `mm_projector_forward` then concatenated all
image features before executing the projector. `apply_rope` also retained
separate full-size query and key products. None of those allocations is
required by the MoonViT arithmetic, and each becomes material when Kimi-K3 is
served beside a 950,000-token physical KV cache.

For a 36-by-36 grid at head dimension 128, request-sized rotary construction
reduces the measured CUDA allocation peak from 340,018,176 bytes to 1,990,656
bytes while producing bit-identical CPU and CUDA output.

For the exact tensor-parallel projector partition and three 1,332-row image
features, per-image projection reduces the retained-plus-transient peak from
104,388,608 bytes to 70,289,408 bytes. The 34,099,200-byte reduction is 32.52
MiB per rank.

For the production `[20160, 12, 128]` query geometry, in-place complex rotary
multiplication reduces the measured CUDA peak from 236.250 MiB to 118.125 MiB.
The BF16 result is bit-identical, and the warm median changes from 0.414 ms to
0.390 ms.

## Compatibility

- Grid validation and output shapes are unchanged.
- Rotary output is bit-identical to full-grid construction for the tested
  Kimi-K3 geometries.
- Query and key inputs are non-overlapping views whose unrotated values are
  dead after `apply_rope`; the function already returns rotated tensors.
- Per-image projection is numerically equivalent to concatenated projection;
  the projector contains no cross-row operation.
- Text-only execution, checkpoint schemas, model weights, KV capacity, and
  image-count policy are unchanged.
- Empty vision feature lists fail with an explicit error instead of reaching
  `torch.cat` with an invalid input.

## Validation

- Ten focused CPU tests pass after rebasing onto
  `dev/infernal-invocation@b5f995e73e6b7fe27c9927477e277a151ebcc9e9`.
- Ruff lint and formatting checks pass for all changed files.
- Model-free CUDA harnesses exercise the Kimi-K3 tensor shapes and validate
  exact BF16 output, buffer reuse, and the allocation reductions above.
- The official `moonshotai/Kimi-K3` MXFP4 checkpoint served on 16 RTX PRO 6000
  Blackwell GPUs with TP16/DCP16, a 4,096-token scheduler chunk, and 950,000
  physical FP8 KV tokens. A four-image request used grids `[1,168,120]`,
  `[1,168,120]`, `[1,168,120]`, and `[1,72,66]`, totaling 65,232 patches and
  16,448 prompt tokens. It returned HTTP 200 in 10.70 seconds without an OOM,
  engine restart, or cache reduction. The same request exhausted memory before
  the in-place rotary-product change.
- A separate six-image request returned HTTP 200, confirming that the runtime
  does not impose the obsolete five-image request cap.
- Qualified container:
  `voipmonitor/vllm@sha256:32ff80279164365b21cdb420d7a22101be704df42b66db2c17d64d5e0558f240`.
- Qualified vLLM tree:
  `6e843eb0f26cc60aa068b97b917e55d2d3a96a3f`.

## Upstream relationship

No equivalent open or merged vLLM change was found. Upstream pull request
#50400 fuses vision Q/K rotary application, and draft pull request #53168
implements another MoonViT Q/K rotary kernel. Neither bounds frequency-table
construction, the multi-image projector transient, and the rotary-product
temporary covered here.

AI assistance from OpenAI Codex was used for implementation and validation.
The human submitter must review every changed line and be able to defend the
change before merge.
