### PR TITLE
[II] Preserve CUDA rotary without vendored Python kernels

### DIFF
--- a/tests/kernels/core/test_apply_rotary_emb.py
+++ b/tests/kernels/core/test_apply_rotary_emb.py
@@ -22,10 +22,28 @@ from vllm.config import (
     get_cached_compilation_config,
     set_current_vllm_config,
 )
+from vllm.model_executor.layers.rotary_embedding import common
 from vllm.model_executor.layers.rotary_embedding.common import ApplyRotaryEmb
 from vllm.platforms import current_platform
 
 CUDA_DEVICES = ["cuda:0"]
+
+
+def test_cuda_rotary_reraises_nameless_vendored_import_failure(
+    monkeypatch, default_vllm_config: VllmConfig
+) -> None:
+    """An existing vendored module must not hide its internal import failure."""
+
+    monkeypatch.setattr(current_platform, "is_cpu", lambda: True)
+    monkeypatch.setattr(current_platform, "is_cuda", lambda: True)
+
+    def raise_nameless(_name: str):
+        raise ModuleNotFoundError("vendored rotary initialization failed")
+
+    monkeypatch.setattr(common, "import_module", raise_nameless)
+
+    with pytest.raises(ModuleNotFoundError, match="initialization failed"):
+        ApplyRotaryEmb()
 
 
 def test_cuda_rotary_uses_native_path_without_vendored_kernel(

--- a/tests/kernels/core/test_apply_rotary_emb.py
+++ b/tests/kernels/core/test_apply_rotary_emb.py
@@ -22,9 +22,40 @@ from vllm.config import (
     get_cached_compilation_config,
     set_current_vllm_config,
 )
+from vllm.model_executor.layers.rotary_embedding.common import ApplyRotaryEmb
 from vllm.platforms import current_platform
 
 CUDA_DEVICES = ["cuda:0"]
+
+
+def test_cuda_rotary_uses_native_path_without_vendored_kernel(
+    monkeypatch, default_vllm_config: VllmConfig
+) -> None:
+    """A source-only runtime must retain rotary correctness."""
+
+    operation = ApplyRotaryEmb()
+    operation.apply_rotary_emb_vllm_flash_attn = None
+    x = torch.empty(1, 2, 1, 4)
+    cos = torch.empty(2, 2)
+    sin = torch.empty(2, 2)
+    expected = torch.empty_like(x)
+    calls: list[tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = []
+
+    def forward_native(
+        x_arg: torch.Tensor,
+        cos_arg: torch.Tensor,
+        sin_arg: torch.Tensor,
+    ) -> torch.Tensor:
+        calls.append((x_arg, cos_arg, sin_arg))
+        return expected
+
+    monkeypatch.setattr(operation, "forward_native", forward_native)
+
+    assert operation.forward_cuda(x, cos, sin) is expected
+    assert len(calls) == 1
+    assert calls[0][0] is x
+    assert calls[0][1] is cos
+    assert calls[0][2] is sin
 
 
 @dataclass

--- a/vllm/model_executor/layers/rotary_embedding/common.py
+++ b/vllm/model_executor/layers/rotary_embedding/common.py
@@ -142,6 +142,18 @@ class ApplyRotaryEmb(CustomOp):
                     "flash_attn.ops.triton.rotary"
                 ).apply_rotary
 
+        self.apply_rotary_emb_vllm_flash_attn = None
+        if current_platform.is_cuda():
+            try:
+                self.apply_rotary_emb_vllm_flash_attn = import_module(
+                    "vllm.vllm_flash_attn.layers.rotary"
+                ).apply_rotary_emb
+            except ModuleNotFoundError as error:
+                missing = error.name or ""
+                expected = "vllm.vllm_flash_attn.layers.rotary"
+                if not expected.startswith(missing):
+                    raise
+
     @staticmethod
     def forward_static(
         x: torch.Tensor,
@@ -232,7 +244,9 @@ class ApplyRotaryEmb(CustomOp):
         cos: torch.Tensor,
         sin: torch.Tensor,
     ) -> torch.Tensor:
-        from vllm.vllm_flash_attn.layers.rotary import apply_rotary_emb
+        apply_rotary_emb = self.apply_rotary_emb_vllm_flash_attn
+        if apply_rotary_emb is None:
+            return self.forward_native(x, cos, sin)
 
         x, cos, sin, origin_shape, origin_dtype = self._pre_process(x, cos, sin)
 

--- a/vllm/model_executor/layers/rotary_embedding/common.py
+++ b/vllm/model_executor/layers/rotary_embedding/common.py
@@ -151,7 +151,7 @@ class ApplyRotaryEmb(CustomOp):
             except ModuleNotFoundError as error:
                 missing = error.name or ""
                 expected = "vllm.vllm_flash_attn.layers.rotary"
-                if not expected.startswith(missing):
+                if not missing or not expected.startswith(missing):
                     raise
 
     @staticmethod


### PR DESCRIPTION
## Resulting behavior

CUDA `ApplyRotaryEmb` retains correct execution when the optional generated
`vllm.vllm_flash_attn.layers.rotary` Python module is absent from a
source-composed runtime. The vendored kernel remains preferred when available.
Only absence of that exact module namespace selects the native tensor
implementation; missing dependencies raised from an existing module remain
fatal. A nameless `ModuleNotFoundError` also remains fatal.

This permits Qwen3.8-VL engine initialization in a revision-pinned source
composition where `vllm.vllm_flash_attn` contains the compiled interface but
not the generated `layers` package. Without the fallback, vision-profile
rotary execution fails with:

```text
ModuleNotFoundError: No module named 'vllm.vllm_flash_attn.layers'
```

## Compatibility

The public tensor interface and vendored fast path are unchanged. A runtime
without the optional Python kernel uses the existing `forward_native`
implementation. CUDA source compositions that include the vendored module
retain their existing path.

Upstream pull request vllm-project/vllm#52121 is not a duplicate: it handles
an installed but ABI-unloadable `flash_attn.ops.triton.rotary` import during
initialization. This change handles the separate `forward_cuda` import of an
absent `vllm.vllm_flash_attn.layers.rotary` module.

## Validation

- Ruff passes for
  `vllm/model_executor/layers/rotary_embedding/common.py` and
  `tests/kernels/core/test_apply_rotary_emb.py`.
- The focused missing-vendored-kernel test passes.
- An import-boundary regression test and a pinned-runtime reproducer require a
  nameless `ModuleNotFoundError` to be re-raised while preserving fallback for
  the absent `vllm.vllm_flash_attn.layers` namespace.
- CUDA 13.3 / PyTorch 2.13 on SM120: a BF16 `[1, 32, 8, 128]` direct
  `forward_cuda` reproducer with the vendored module absent is bit-exact
  against `forward_native`.
- The revision-pinned Qwen3.8 runtime image passes 93 GPU tests, including the
  missing-module fallback and the preserved vendored-path contract.
- The image-default Qwen3.8 launcher initializes at
  `max_model_len=261632`, retains `torch.compile`, disables CUDA graphs, and
  retrieves all 8/8 deterministic short-context needles.
- The packed Qwen3.8 vision fixture executes successfully and describes the
  fixed image as red on the left and blue on the right. The serving aggregate
  classifies runtime functionality as qualified.

The immutable image uses this pull request at
`0942707892ca26c5b379fb9a6b88b3f8468a5adc` and is published by
[blackwell-llm-docker#27](https://github.com/local-inference-lab/blackwell-llm-docker/pull/27).
Pull-request head `a434f31d77ed0e18270809a20cb11b47e9ffc400` adds the
fail-closed nameless-import regression. The immutable image proves that its
vendored rotary namespace is absent, so the head change does not alter the
qualified missing-namespace fallback path.

AI assistance was used to inspect the runtime failure, implement the guarded
fallback, and prepare the test. The human submitter is responsible for
reviewing and defending every changed line.
