### PR TITLE
[II] Size B12X page tables for hybrid cache blocks

### DIFF
--- a/tests/v1/attention/test_b12x_attn.py
+++ b/tests/v1/attention/test_b12x_attn.py
@@ -105,9 +105,9 @@ def test_b12x_dense_can_share_page128_group() -> None:
     )
 
 
-def test_b12x_hybrid_align_reserves_expanded_page_table() -> None:
-    assert _max_page_table_width(4096, 128, 4096, "none") == 32
-    assert _max_page_table_width(4096, 128, 4096, "align") == 64
+def test_b12x_hybrid_reserves_expanded_page_table() -> None:
+    assert _max_page_table_width(4096, 128, 4096, False) == 32
+    assert _max_page_table_width(4096, 128, 4096, True) == 64
 
     storage_block_size = 3200
     expanded_width = (
@@ -116,7 +116,19 @@ def test_b12x_hybrid_align_reserves_expanded_page_table() -> None:
         * (storage_block_size // 128)
     )
     assert expanded_width == 50
-    assert expanded_width <= _max_page_table_width(4096, 128, 4096, "align")
+    assert expanded_width <= _max_page_table_width(4096, 128, 4096, True)
+
+    # Qwen3.5 hybrid cache expands 128-token attention pages into a
+    # 896-token storage block even when prefix caching is disabled. Rounding
+    # 65,536 tokens to storage blocks therefore produces 518 kernel pages.
+    storage_block_size = 896
+    expanded_width = (
+        (65536 + storage_block_size - 1)
+        // storage_block_size
+        * (storage_block_size // 128)
+    )
+    assert expanded_width == 518
+    assert expanded_width <= _max_page_table_width(65536, 128, 8192, True)
 
 
 def test_b12x_runtime_page_size_comes_from_static_cache_shape() -> None:

--- a/vllm/v1/attention/backends/b12x_attn.py
+++ b/vllm/v1/attention/backends/b12x_attn.py
@@ -86,13 +86,15 @@ def _max_page_table_width(
     max_model_len: int,
     block_size: int,
     max_num_batched_tokens: int,
-    mamba_cache_mode: str,
+    is_hybrid: bool,
 ) -> int:
     width = max(cdiv(max(max_model_len, 1), block_size), 1)
-    if mamba_cache_mode == "align":
+    if is_hybrid:
         # Hybrid cache setup can enlarge the storage block after attention
-        # layers are initialized. Its expansion into kernel-sized blocks adds
-        # at most one storage block of trailing page-table capacity.
+        # layers are initialized, including when prefix caching forces
+        # mamba_cache_mode to "none". Expanding a partially used final storage
+        # block into kernel-sized blocks adds at most one storage block of
+        # trailing page-table capacity.
         width += cdiv(max_num_batched_tokens, block_size)
     return width
 
@@ -709,7 +711,7 @@ class B12XPagedAttentionImpl(AttentionImpl[B12XPagedMetadata]):
                 max_model_len,
                 page_size,
                 max_batched,
-                cache_config.mamba_cache_mode,
+                model_config.is_hybrid,
             )
             for page_size in _B12X_SUPPORTED_PAGE_SIZES
         }


### PR DESCRIPTION
## Behavior

B12X paged-attention scratch planning reserves a trailing page-table margin for every hybrid model, independent of the configured Mamba cache mode. Pure-attention models retain their existing allocation.

## Technical reason

Hybrid cache grouping can enlarge an attention storage block after the B12X attention implementation is initialized. This also occurs when prefix caching is disabled: vLLM changes `mamba_cache_mode` to `none`, but it still aligns Qwen3.5 attention storage to the recurrent-state page size.

With Qwen3.5, `max_model_len=65536`, 128-token B12X pages, 8,192 scheduler tokens, and prefix caching disabled, the cache manager expands attention storage to 896-token blocks. Rounding the configured length to those blocks yields 518 kernel pages. The previous Mamba-mode condition reserved 512 columns and model profiling failed with:

```text
ValueError: page_table width=518 exceeds scratch capacity 512
```

`model_config.is_hybrid` is the invariant that determines whether storage-block expansion is possible. The existing one-scheduler-block upper bound then covers the partially used final storage block in both prefix-cache modes.

## Compatibility

The change only adds scratch capacity for hybrid models. It does not change live page-table contents, attention dispatch, kernel inputs, or pure-attention allocation. For the reproducer, the planned capacity increases from 512 to 576 pages.

## Duplicate-work check

Searches of open upstream and `local-inference-lab/vllm` pull requests and issues for B12X hybrid page-table capacity found no matching fix. B12X is specific to the Infernal Invocation branch, so no upstream vLLM source mapping exists.

## Validation

Base: `dev/infernal-invocation@b5f995e73e6b7fe27c9927477e277a151ebcc9e9`

```bash
PYTHONPATH=. /root/vllm/worktrees/vllm-k3-clean-integration-20260819/.venv/bin/python \
  -m pytest -q tests/v1/attention/test_b12x_attn.py
```

Result: 18 passed.

```bash
uvx --from ruff==0.15.12 ruff check \
  vllm/v1/attention/backends/b12x_attn.py \
  tests/v1/attention/test_b12x_attn.py
uvx --from ruff==0.15.12 ruff format --check \
  vllm/v1/attention/backends/b12x_attn.py \
  tests/v1/attention/test_b12x_attn.py
git diff --check dev/infernal-invocation...HEAD
```

Result: passed.

The revision-pinned CUDA 13.3 / PyTorch 2.13 image also ran the exact failing Qwen3.5 configuration on one RTX PRO 6000 Blackwell GPU: BF16 model, `max_model_len=65536`, 128-token B12X pages, 8,192 scheduler tokens, and prefix caching disabled. Engine initialization completed with a 515,776-token KV cache, and the 32,768-token probe wrote all 32,767 scored positions. The same configuration failed before this change with a 518-column runtime page table and 512-column scratch allocation.

## Development assistance

OpenAI Codex assisted with reproducer analysis, implementation, and test execution. Martin Vit reviewed the resulting diff and owns the change.
