### PR TITLE
[II] Resume Mamba prefix hits on the recurrent checkpoint grid

### DIFF
--- a/tests/v1/worker/test_mamba_hybrid_model_state.py
+++ b/tests/v1/worker/test_mamba_hybrid_model_state.py
@@ -1,10 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 
 from vllm.platforms import current_platform
+from vllm.v1.core.sched.output import NewRequestData
 from vllm.v1.worker.gpu.model_states.mamba_hybrid import MambaHybridModelState
 
 
@@ -27,3 +30,35 @@ def test_postprocess_state_scalar_with_int32_mapping(
         [expected_value, 9, expected_value, 9], dtype=torch.int32, device="cuda"
     )
     torch.testing.assert_close(state.num_accepted_tokens_gpu, expected)
+
+
+@pytest.mark.parametrize(
+    ("num_computed_tokens", "expected_state_index"),
+    [(0, -1), (110_592, 8), (110_593, 9)],
+)
+def test_prefix_hit_uses_mamba_checkpoint_cadence(
+    num_computed_tokens: int, expected_state_index: int
+) -> None:
+    """A resumed request indexes recurrent checkpoints, not attention pages."""
+    state = object.__new__(MambaHybridModelState)
+    state.rope_state = None
+    state._align_mode = True
+    state.cache_config = SimpleNamespace(block_size=768, mamba_block_size=12_288)
+    state._mamba_block_size = 12_288
+    state._mamba_state_idx_gpu = torch.zeros(1, dtype=torch.int32)
+    state.num_accepted_tokens_gpu = torch.full((1,), 9, dtype=torch.int32)
+    request = NewRequestData(
+        req_id="prefix-hit",
+        prompt_token_ids=[],
+        mm_features=[],
+        sampling_params=None,
+        pooling_params=None,
+        block_ids=(),
+        num_computed_tokens=num_computed_tokens,
+        lora_request=None,
+    )
+
+    state.add_request(0, request)
+
+    assert state._mamba_state_idx_gpu.item() == expected_state_index
+    assert state.num_accepted_tokens_gpu.item() == 1

--- a/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
+++ b/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
@@ -73,6 +73,12 @@ class MambaHybridModelState(DefaultModelState):
         # columns and the running state_idx are kept GPU-resident.
         self._align_mode = self.cache_config.mamba_cache_mode == "align"
         if self._align_mode:
+            # The physical attention page and the logical recurrent-state
+            # checkpoint can have different token widths. Prefix-hit requests
+            # must resume from the recurrent-state grid used by MambaSpec.
+            self._mamba_block_size = (
+                self.cache_config.mamba_block_size or self.cache_config.block_size
+            )
             self._mamba_state_idx_gpu = torch.zeros(
                 self.max_num_reqs, dtype=torch.int32, device=self.device
             )
@@ -93,7 +99,7 @@ class MambaHybridModelState(DefaultModelState):
         if self._align_mode:
             # Seed the running state block from the resumed/prefilled position.
             self._mamba_state_idx_gpu[req_index].fill_(
-                (new_req_data.num_computed_tokens - 1) // self.cache_config.block_size
+                (new_req_data.num_computed_tokens - 1) // self._mamba_block_size
             )
 
     def _get_mamba_group_info(
@@ -109,6 +115,10 @@ class MambaHybridModelState(DefaultModelState):
                     specs.append(spec)
             assert specs, "no mamba layers in the model"
             assert all(specs[0] == s for s in specs)
+            assert specs[0].block_size == self._mamba_block_size, (
+                "Mamba state migration and cache allocation must use the same "
+                "checkpoint cadence"
+            )
             self._mamba_group_ids = group_ids
             self._mamba_spec = specs[0]
         return self._mamba_group_ids, self._mamba_spec


### PR DESCRIPTION
## Behavior

Model Runner V2 resumes align-mode recurrent state on the logical Mamba checkpoint grid. The physical attention-page width remains independent and is not used to index recurrent-state block tables.

## Technical reason

`MambaHybridModelState.add_request` initialized the running recurrent-state index with `cache_config.block_size`. That assumption is invalid when `mamba_block_size` defines a coarser checkpoint cadence than the physical attention page.

For a request resumed at 110,592 computed tokens with 768-token attention pages and 12,288-token recurrent checkpoints, the previous code selected recurrent block-table column 143. The valid recurrent state is column 8. The next prefill step therefore copied state from an unrelated or unallocated column and could corrupt long-context generation after a prefix-cache hit.

## Compatibility

Configurations whose physical attention page and Mamba checkpoint cadence are equal retain identical indexing. The change does not alter cache allocation, prefix matching, model kernels, speculative acceptance, or requests without align-mode recurrent caching.

## Validation

- Regression coverage exercises fresh, boundary-aligned, and one-token-past-boundary request positions with 768-token attention pages and 12,288-token recurrent checkpoints.
- The standalone reproducer reports state index 143 on unmodified Infernal Invocation and state index 8 with this change.
- Repository pre-commit checks passed, including Ruff, formatting, mypy, SPDX validation, and configuration validation.
- Kimi-K3 TP16/DCP16 with Inferact DSpark replayed an identical 112,301-token, five-image OMP request through LLMConduit. The cold request completed in 48.691 seconds and the 98.5%-hit replay completed in 6.225 seconds. Both returned coherent reasoning, content, and a valid tool call. The unmodified runtime returned no parsed reasoning, content, or tool call for the same replay and emitted malformed protocol tokens.
- A 500,224-token completion was repeated from a 491,520-token recurrent checkpoint. The cold request completed in 230.376 seconds and the cache-hit request completed in 8.394 seconds. All 16 sampled tokens and decoded text matched; the maximum sampled-token log-probability difference was 0.000104.

The qualified source composition is published as:

```text
voipmonitor/vllm:kimi-k3-upstream-aligned-dspark-nativekv-vllme96c97b-b12xf006681-cu133-torch213-20260821-r28
voipmonitor/vllm@sha256:e0a7d6f9f7e0ce7587d024520557b4b4399c04314623a7c5d78a3bf1882ecf71
vLLM tree: e96c97b7ff8556a26fda87b6a3e7fe1cb4891e7f
B12X tree: f0066813bd55e6e19b6a8d84ab47087510c12890
Docker recipe: local-inference-lab/blackwell-llm-docker@203e1a11a373a0486897a5a284409ba4417d0f7a
```