### PR TITLE
[II] Gather uneven vision shards without TP padding

### DIFF
--- a/tests/distributed/test_pynccl.py
+++ b/tests/distributed/test_pynccl.py
@@ -257,7 +257,9 @@ def all_gatherv_worker_fn():
     device = f"cuda:{pynccl_comm.rank}"
 
     assert world_size <= 8
-    sizes = [81, 20, 57, 52, 81, 5, 49, 49][:world_size]
+    # A zero-length rank is required when fewer multimodal inputs than TP
+    # ranks are distributed across the model-parallel group.
+    sizes = [81, 0, 57, 52, 81, 5, 49, 49][:world_size]
     num_elems = sizes[rank]
     tensor = torch.arange(num_elems, dtype=torch.float32, device=device) + rank * 100
     result = torch.zeros(sum(sizes), dtype=torch.float32, device=device)

--- a/vllm/distributed/communication_op.py
+++ b/vllm/distributed/communication_op.py
@@ -29,7 +29,16 @@ def tensor_model_parallel_all_gather(
 def tensor_model_parallel_all_gatherv(
     input_: torch.Tensor, sizes: list[int], dim: int = 0
 ) -> torch.Tensor:
-    """All-gather variable-length tensor slices across the model-parallel group."""
+    """All-gather variable-length slices across the model-parallel group.
+
+    Args:
+        input_: Local tensor slice.
+        sizes: Slice length for each tensor-parallel rank.
+        dim: Dimension along which the slices are concatenated.
+
+    Returns:
+        Rank-ordered tensor slices concatenated along ``dim``.
+    """
     tp_group = get_tp_group()
     if tp_group.world_size == 1:
         return input_

--- a/vllm/distributed/communication_op.py
+++ b/vllm/distributed/communication_op.py
@@ -26,6 +26,16 @@ def tensor_model_parallel_all_gather(
     return get_tp_group().all_gather(input_, dim)
 
 
+def tensor_model_parallel_all_gatherv(
+    input_: torch.Tensor, sizes: list[int], dim: int = 0
+) -> torch.Tensor:
+    """All-gather variable-length tensor slices across the model-parallel group."""
+    tp_group = get_tp_group()
+    if tp_group.world_size == 1:
+        return input_
+    return tp_group.all_gatherv(input_, dim=dim, sizes=sizes)
+
+
 def tensor_model_parallel_reduce_scatter(
     input_: torch.Tensor, dim: int = -1
 ) -> torch.Tensor:

--- a/vllm/model_executor/models/vision.py
+++ b/vllm/model_executor/models/vision.py
@@ -17,6 +17,7 @@ from vllm.distributed import (
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
     tensor_model_parallel_all_gather,
+    tensor_model_parallel_all_gatherv,
 )
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
@@ -442,9 +443,8 @@ def run_dp_sharded_mrope_vision_model(
     # Get load balancing assignment with all metadata
     # image_to_tp_rank = [0, 2, 1, 3]
     # gpu_sample_counts = [1, 3]
-    # grouped_pixel_values_len = [1000, 350]
-    (image_to_tp_rank, gpu_sample_counts, grouped_pixel_values_len) = (
-        get_load_balance_assignment(patches_per_image, tp_size)
+    (image_to_tp_rank, gpu_sample_counts, _) = get_load_balance_assignment(
+        patches_per_image, tp_size
     )
 
     # cu_gpu_sample_counts = [0, 1, 4]
@@ -481,11 +481,23 @@ def run_dp_sharded_mrope_vision_model(
             vision_model.spatial_merge_size * vision_model.spatial_merge_size
         )
 
-    # Find the max length across all ranks
-    # The output embedding of every DP rank has to be
-    # padded to this length for tensor_model_parallel_all_gather
-    # to work
-    max_len_per_rank = max(grouped_pixel_values_len) // embed_dim_reduction_factor
+    patches_per_output_image = [
+        patch_size // embed_dim_reduction_factor for patch_size in patches_per_image
+    ]
+    output_lengths_per_rank = []
+    rank_image_offset = 0
+    for count in gpu_sample_counts:
+        rank_image_indices = image_to_tp_rank[
+            rank_image_offset : rank_image_offset + count
+        ]
+        output_lengths_per_rank.append(
+            sum(patches_per_output_image[i] for i in rank_image_indices)
+        )
+        rank_image_offset += count
+
+    if not grid_thw_list:
+        return ()
+
     local_grid_thw_list = [grid_thw_list[i] for i in image_idxs_local]
 
     # Run the vision model on the local pixel_values_local
@@ -514,46 +526,21 @@ def run_dp_sharded_mrope_vision_model(
                 dtype=pixel_values.dtype,
             )
 
-    # Pad the output based on max_len_per_rank
-    # for tensor_model_parallel_all_gather to work
-    current_len = image_embeds_local.shape[0]
-    if current_len < max_len_per_rank:
-        padding_size = max_len_per_rank - current_len
-        if rope_type == "rope_2d":
-            padding = torch.empty(
-                (
-                    padding_size,
-                    image_embeds_local.shape[1],
-                    image_embeds_local.shape[2],
-                ),
-                dtype=image_embeds_local.dtype,
-                device=image_embeds_local.device,
-            )
-        else:
-            padding = torch.empty(
-                (padding_size, image_embeds_local.shape[1]),
-                dtype=image_embeds_local.dtype,
-                device=image_embeds_local.device,
-            )
-        image_embeds_local_padded = torch.cat([image_embeds_local, padding], dim=0)
-    else:
-        image_embeds_local_padded = image_embeds_local
-
-    # Do all_gather to collect embeddings from all ranks
-    gathered_embeds = tensor_model_parallel_all_gather(image_embeds_local_padded, dim=0)
-
-    # Remove padding and reconstruct per-rank embeddings
-    rank_embeddings = list[torch.Tensor]()
-    for rank in range(tp_size):
-        start_idx = rank * max_len_per_rank
-        end_idx = start_idx + (
-            grouped_pixel_values_len[rank] // embed_dim_reduction_factor
+    expected_local_len = output_lengths_per_rank[tp_rank_local]
+    if image_embeds_local.shape[0] != expected_local_len:
+        raise ValueError(
+            "Vision encoder output length does not match the image-grid metadata: "
+            f"rank {tp_rank_local} produced {image_embeds_local.shape[0]} rows, "
+            f"expected {expected_local_len}"
         )
-        rank_embeddings.append(gathered_embeds[start_idx:end_idx])
 
-    patches_per_output_image = [
-        (patch_size // embed_dim_reduction_factor) for patch_size in patches_per_image
-    ]
+    # Gather only the rows produced by each rank. Padding every rank to the
+    # largest shard can multiply the transient allocation by the TP size when
+    # a request contains fewer images than tensor-parallel ranks.
+    gathered_embeds = tensor_model_parallel_all_gatherv(
+        image_embeds_local, sizes=output_lengths_per_rank, dim=0
+    )
+    rank_embeddings = list(gathered_embeds.split(output_lengths_per_rank, dim=0))
 
     # Reconstruct embeddings in the original order
     original_order_embeddings = [None] * len(grid_thw_list)


### PR DESCRIPTION
## Behavior

Sharded mRoPE vision execution gathers the exact number of embedding rows
produced by each tensor-parallel rank. Uniform shard sizes retain the existing
NCCL all-gather path. Uneven shard sizes use the existing variable-size PyNccl
collective, including zero-length ranks.

## Technical reason

Padding every rank to the largest vision shard scales transient memory with
tensor-parallel width. A single Kimi-K3 image on TP16 produced 1,792 useful
rows but allocated a 28,672-row, 224 MiB all-gather output on every GPU. The
variable-size collective allocates 14 MiB per GPU for the same BF16 embeddings.

## Compatibility

Embedding order, dtype, shape, and per-image reconstruction are unchanged.
Empty multimodal input returns an empty tuple. The implementation applies to
every model using `run_dp_sharded_mrope_vision_model` and uses communicator
APIs already implemented for CUDA and XPU.

## Validation

- PyNccl all-gatherv with one zero-length rank: passed on two GPUs.
- Single-image parity with one empty rank: passed on two GPUs.
- Three-image and five-image parity: passed on two GPUs.
- Empty input: passed on two GPUs.
- Uneven image assignment: passed on four GPUs.
- Kimi-K3-shaped TP16 harness: 224 MiB padded output versus 14 MiB variable
  output; gathered BF16 content matched exactly.
- Full `moonshotai/Kimi-K3` TP16/DCP16 replay: four archived OMP image blobs
  were warmed before replaying the original 106-message continuation with five
  images and 62 tool calls. LLMConduit returned HTTP 200 with 21 SSE events, a
  terminal done event, no stream error, and no Kimi control marker. The
  EngineCore remained healthy with 1,016,293 physical target KV tokens.
- Ruff, formatting, mypy, and the repository pre-commit suite: passed.

The full-model image and machine-readable receipt are documented in the
[Kimi-K3 runtime specification](https://github.com/local-inference-lab/rtx6kpro/blob/master/models/kimi-k3/production-runtime.md).
