### PR TITLE
feat(spec_decode): run the Kimi-K3 DSpark draft on a dedicated remote GPU

### DIFF
--- a/tests/v1/spec_decode/test_acceptance_length_controller.py
+++ b/tests/v1/spec_decode/test_acceptance_length_controller.py
@@ -260,6 +260,22 @@ def test_runner_v2_limits_drafts_to_adaptive_depth():
     )
 
 
+def test_runner_v2_allows_scheduler_to_disable_speculation():
+    draft_tokens = torch.tensor([[1, 2, 3], [4, 5, 6]])
+
+    limited = limit_draft_tokens(
+        draft_tokens,
+        num_speculative_tokens=0,
+        max_num_speculative_tokens=3,
+    )
+
+    assert limited.shape == (2, 0)
+    assert (
+        limited.untyped_storage().data_ptr()
+        == draft_tokens.untyped_storage().data_ptr()
+    )
+
+
 def test_synthetic_scheduler_output_uses_default_speculative_depth():
     output = SchedulerOutput.make_empty()
 

--- a/tests/v1/spec_decode/test_k3_dspark_remote_speculator.py
+++ b/tests/v1/spec_decode/test_k3_dspark_remote_speculator.py
@@ -356,6 +356,7 @@ def test_remote_probabilistic_sampler_uses_standard_draft_stream(monkeypatch):
         for actual, expected in zip(
             recorded["args"],
             (logits, idx_mapping, temperature, seeds, positions + 1000),
+            strict=True,
         )
     )
     assert recorded["kwargs"]["apply_temperature"] is True

--- a/tests/v1/spec_decode/test_k3_dspark_remote_speculator.py
+++ b/tests/v1/spec_decode/test_k3_dspark_remote_speculator.py
@@ -55,6 +55,32 @@ def test_remote_tokens_copy_supports_adaptive_depth():
     ]
 
 
+def test_remote_speculator_accepts_scheduler_selected_zero_depth():
+    proxy = RemoteK3DSparkSpeculator.__new__(RemoteK3DSparkSpeculator)
+    proxy.num_speculative_steps = 3
+    proxy.draft_tokens = torch.full((4, 3), -1, dtype=torch.int64)
+    batch = SimpleNamespace(num_reqs=2)
+    empty = torch.empty(0)
+
+    output = proxy.propose(
+        batch,
+        {},
+        {},
+        empty,
+        None,
+        empty,
+        empty,
+        empty,
+        empty,
+        empty,
+        empty,
+        num_speculative_tokens=0,
+    )
+
+    assert output.shape == (2, 0)
+    assert output.is_contiguous()
+
+
 def test_adaptive_depth_output_is_contiguous_for_tp_broadcast():
     draft_tokens = torch.arange(24, dtype=torch.int64).view(3, 8)
 

--- a/tests/v1/spec_decode/test_k3_dspark_remote_speculator.py
+++ b/tests/v1/spec_decode/test_k3_dspark_remote_speculator.py
@@ -7,11 +7,13 @@ import numpy as np
 import pytest
 import torch
 
+import vllm.v1.worker.gpu.spec_decode.dspark.remote_speculator as remote_speculator
 from vllm.v1.worker.gpu.spec_decode.dspark.remote_speculator import (
     RemoteK3DSparkSpeculator,
     _anchor_positions_from_context,
     _build_valid_context_plan,
     _contiguous_draft_output,
+    _decode_bfloat16_logits_frame,
     _RetainedRequestPrefix,
 )
 
@@ -150,3 +152,127 @@ def test_remote_prefix_match_rejects_history_before_cold_bootstrap():
         proxy._find_reconnect_source(torch.arange(96, dtype=torch.int32), 96, {"new"})
         == "old"
     )
+
+
+def test_decode_remote_bfloat16_logits_frame_validates_metadata():
+    logits = torch.tensor(
+        [[[1.0, -2.0], [3.5, 0.25]]],
+        dtype=torch.bfloat16,
+    )
+    frame = logits.view(torch.uint16).numpy().tobytes()
+    response = {
+        "logits": {
+            "capability": "dflash_logits_bf16_v1",
+            "dtype": "bfloat16",
+            "shape": [1, 2, 2],
+            "nbytes": len(frame),
+        },
+        "_logits_frame": frame,
+    }
+
+    decoded = _decode_bfloat16_logits_frame(response, (1, 2, 2))
+
+    assert torch.equal(decoded, logits)
+
+
+def test_decode_remote_logits_rejects_truncated_frame():
+    response = {
+        "logits": {
+            "capability": "dflash_logits_bf16_v1",
+            "dtype": "bfloat16",
+            "shape": [1, 2, 2],
+            "nbytes": 8,
+        },
+        "_logits_frame": b"\0\0",
+    }
+
+    with pytest.raises(ValueError, match="byte count mismatch"):
+        _decode_bfloat16_logits_frame(response, (1, 2, 2))
+
+
+def test_remote_probabilistic_sampling_uses_persistent_request_rows():
+    proxy = RemoteK3DSparkSpeculator.__new__(RemoteK3DSparkSpeculator)
+    proxy.draft_logits = torch.zeros(4, 3, 5, dtype=torch.bfloat16)
+    proxy._remote_logits = torch.arange(
+        4 * 3 * 5,
+        dtype=torch.bfloat16,
+    ).reshape(4, 3, 5)
+    proxy._remote_sample_positions = torch.tensor(
+        [[10, 11, -1], [-1, -1, -1], [20, 21, -1], [-1, -1, -1]],
+        dtype=torch.int64,
+    )
+    proxy.draft_tokens = torch.full((4, 3), -1, dtype=torch.int64)
+    recorded = {}
+
+    def sample(**kwargs):
+        recorded.update(kwargs)
+        return torch.tensor([101, 102, 201, 202], dtype=torch.int64)
+
+    proxy._sample_probabilistic_draft = sample
+    batch = SimpleNamespace(
+        num_reqs=3,
+        idx_mapping=torch.tensor([2, 0, 3], dtype=torch.int32),
+    )
+    temperature = torch.ones(4, dtype=torch.float32)
+    seeds = torch.arange(4, dtype=torch.int64)
+
+    proxy._sample_remote_probabilistic(batch, temperature, seeds, 2)
+
+    assert recorded["idx_mapping"].tolist() == [2, 2, 3, 3]
+    assert recorded["positions"].tolist() == [8, 9, 18, 19]
+    assert recorded["draft_step"].tolist() == [0, 1, 0, 1]
+    assert proxy.draft_tokens.tolist() == [
+        [101, 102, -1],
+        [-1, -1, -1],
+        [201, 202, -1],
+        [-1, -1, -1],
+    ]
+
+
+def test_remote_probabilistic_sampler_uses_standard_draft_stream(monkeypatch):
+    proxy = RemoteK3DSparkSpeculator.__new__(RemoteK3DSparkSpeculator)
+    proxy.use_fp64_gumbel = True
+    logits = torch.zeros(2, 5, dtype=torch.bfloat16)
+    idx_mapping = torch.tensor([3, 1], dtype=torch.int32)
+    temperature = torch.ones(4, dtype=torch.float32)
+    seeds = torch.arange(4, dtype=torch.int64)
+    positions = torch.tensor([8, 9], dtype=torch.int64)
+    draft_step = torch.tensor([0, 1], dtype=torch.int64)
+    draft_logits = torch.zeros(4, 3, 5, dtype=torch.bfloat16)
+    recorded = {}
+
+    monkeypatch.setattr(
+        remote_speculator,
+        "draft_gumbel_pos",
+        lambda value: value + 1000,
+    )
+
+    def sample(*args, **kwargs):
+        recorded["args"] = args
+        recorded["kwargs"] = kwargs
+        return torch.tensor([7, 8], dtype=torch.int64)
+
+    monkeypatch.setattr(remote_speculator, "gumbel_sample", sample)
+
+    sampled = proxy._sample_probabilistic_draft(
+        logits=logits,
+        positions=positions,
+        idx_mapping=idx_mapping,
+        temperature=temperature,
+        seeds=seeds,
+        draft_step=draft_step,
+        draft_logits=draft_logits,
+    )
+
+    assert sampled.tolist() == [7, 8]
+    assert all(
+        torch.equal(actual, expected)
+        for actual, expected in zip(
+            recorded["args"],
+            (logits, idx_mapping, temperature, seeds, positions + 1000),
+        )
+    )
+    assert recorded["kwargs"]["apply_temperature"] is True
+    assert recorded["kwargs"]["use_fp64"] is True
+    assert recorded["kwargs"]["logits_cache"] is draft_logits
+    assert torch.equal(recorded["kwargs"]["logits_cache_col"], draft_step)

--- a/tests/v1/spec_decode/test_k3_dspark_remote_speculator.py
+++ b/tests/v1/spec_decode/test_k3_dspark_remote_speculator.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+from vllm.v1.worker.gpu.spec_decode.dspark.remote_speculator import (
+    RemoteK3DSparkSpeculator,
+    _anchor_positions_from_context,
+    _build_valid_context_plan,
+    _contiguous_draft_output,
+    _RetainedRequestPrefix,
+)
+
+
+def test_build_valid_context_plan_drops_rejected_tail_rows():
+    batch = SimpleNamespace(
+        num_reqs=2,
+        num_scheduled_tokens=np.array([4, 3], dtype=np.int32),
+        num_computed_tokens_np=np.array([10, 20], dtype=np.int32),
+    )
+
+    indices, counts = _build_valid_context_plan(batch, [2, 0])
+
+    assert indices == [0, 1, 4, 5, 6]
+    assert counts == [2, 3]
+
+
+def test_anchor_positions_follow_actual_valid_context_rows():
+    positions = torch.tensor([24, 25, 26, 80, 81], dtype=torch.int64)
+
+    anchors = _anchor_positions_from_context([3, 2], positions)
+
+    assert anchors == [27, 82]
+
+
+def test_remote_tokens_copy_supports_adaptive_depth():
+    proxy = RemoteK3DSparkSpeculator.__new__(RemoteK3DSparkSpeculator)
+    proxy.device = torch.device("cpu")
+    proxy.draft_tokens = torch.full((3, 8), -1, dtype=torch.int64)
+
+    proxy._copy_tokens_from_response(
+        {"tokens": [[11, 12], [21, 22]]},
+        active_indices=[0, 2],
+        num_speculative_tokens=2,
+    )
+
+    assert proxy.draft_tokens.tolist() == [
+        [11, 12, -1, -1, -1, -1, -1, -1],
+        [-1, -1, -1, -1, -1, -1, -1, -1],
+        [21, 22, -1, -1, -1, -1, -1, -1],
+    ]
+
+
+def test_adaptive_depth_output_is_contiguous_for_tp_broadcast():
+    draft_tokens = torch.arange(24, dtype=torch.int64).view(3, 8)
+
+    output = _contiguous_draft_output(draft_tokens, 2, 3)
+
+    assert output.is_contiguous()
+    assert output.tolist() == [[0, 1, 2], [8, 9, 10]]
+
+
+@pytest.mark.parametrize("rejected", [[5, 0], [-1, 0]])
+def test_build_valid_context_plan_rejects_invalid_counts(rejected):
+    batch = SimpleNamespace(
+        num_reqs=2,
+        num_scheduled_tokens=np.array([4, 3], dtype=np.int32),
+        num_computed_tokens_np=np.array([0, 0], dtype=np.int32),
+    )
+
+    with pytest.raises(ValueError, match="Invalid valid-context length"):
+        _build_valid_context_plan(batch, rejected)
+
+
+def _make_prefix_matcher() -> RemoteK3DSparkSpeculator:
+    proxy = RemoteK3DSparkSpeculator.__new__(RemoteK3DSparkSpeculator)
+    proxy._known_requests = {"old"}
+    proxy._remote_block_size = 16
+    proxy._remote_window_size = 32
+    proxy._remote_prefix_cache_tokens = 128
+    proxy._retained_prefixes = {
+        "old": _RetainedRequestPrefix(
+            token_ids=torch.arange(96, dtype=torch.int32),
+            committed_end=96,
+            context_start=0,
+            serial=1,
+        )
+    }
+    return proxy
+
+
+def test_remote_prefix_match_requires_exact_token_identity():
+    proxy = _make_prefix_matcher()
+    matching = torch.arange(80, dtype=torch.int32)
+
+    assert proxy._find_reconnect_source(matching, 80, {"new"}) == "old"
+
+    mismatched = matching.clone()
+    mismatched[40] = -1
+    assert proxy._find_reconnect_source(mismatched, 80, {"new"}) is None
+
+
+def test_remote_prefix_match_rejects_range_evicted_from_projected_cache():
+    proxy = _make_prefix_matcher()
+    proxy._remote_prefix_cache_tokens = 48
+    matching = torch.arange(40, dtype=torch.int32)
+
+    assert proxy._find_reconnect_source(matching, 40, {"new"}) is None
+
+
+def test_remote_prefix_match_rejects_history_before_cold_bootstrap():
+    proxy = _make_prefix_matcher()
+    proxy._retained_prefixes["old"].context_start = 64
+
+    assert (
+        proxy._find_reconnect_source(torch.arange(80, dtype=torch.int32), 80, {"new"})
+        is None
+    )
+    assert (
+        proxy._find_reconnect_source(torch.arange(96, dtype=torch.int32), 96, {"new"})
+        == "old"
+    )

--- a/tests/v1/spec_decode/test_k3_dspark_remote_speculator.py
+++ b/tests/v1/spec_decode/test_k3_dspark_remote_speculator.py
@@ -8,6 +8,7 @@ import pytest
 import torch
 
 import vllm.v1.worker.gpu.spec_decode.dspark.remote_speculator as remote_speculator
+from vllm import envs
 from vllm.v1.worker.gpu.spec_decode.dspark.remote_speculator import (
     RemoteK3DSparkSpeculator,
     _anchor_positions_from_context,
@@ -31,6 +32,23 @@ def test_build_valid_context_plan_drops_rejected_tail_rows():
     assert counts == [2, 3]
 
 
+def test_remote_k3_environment_registry_preserves_legacy_fallback(monkeypatch):
+    monkeypatch.delenv("VLLM_K3_DRAFT_REMOTE_TIMEOUT_MS", raising=False)
+    monkeypatch.setenv("VLLM_K3_DSPARK_REMOTE_TIMEOUT_MS", "1234")
+    monkeypatch.setenv("VLLM_K3_DRAFT_REMOTE_ADDRESS", "tcp://127.0.0.1:9000")
+    monkeypatch.setenv("VLLM_K3_DSPARK_REMOTE_ADDRESS", "tcp://127.0.0.1:9001")
+    monkeypatch.setenv("VLLM_K3_DRAFT_TIMING_LOG_INTERVAL", "7")
+    envs.disable_envs_cache()
+    try:
+        assert envs.VLLM_K3_DRAFT_REMOTE_TIMEOUT_MS == 1234
+        assert envs.VLLM_K3_DSPARK_REMOTE_TIMEOUT_MS == 1234
+        assert envs.VLLM_K3_DRAFT_REMOTE_ADDRESS == "tcp://127.0.0.1:9000"
+        assert envs.VLLM_K3_DSPARK_REMOTE_ADDRESS == "tcp://127.0.0.1:9001"
+        assert envs.VLLM_K3_DRAFT_TIMING_LOG_INTERVAL == 7
+    finally:
+        envs.disable_envs_cache()
+
+
 def test_anchor_positions_follow_actual_valid_context_rows():
     positions = torch.tensor([24, 25, 26, 80, 81], dtype=torch.int64)
 
@@ -42,6 +60,7 @@ def test_anchor_positions_follow_actual_valid_context_rows():
 def test_remote_tokens_copy_supports_adaptive_depth():
     proxy = RemoteK3DSparkSpeculator.__new__(RemoteK3DSparkSpeculator)
     proxy.device = torch.device("cpu")
+    proxy.vocab_size = 100
     proxy.draft_tokens = torch.full((3, 8), -1, dtype=torch.int64)
 
     proxy._copy_tokens_from_response(
@@ -55,6 +74,73 @@ def test_remote_tokens_copy_supports_adaptive_depth():
         [-1, -1, -1, -1, -1, -1, -1, -1],
         [21, 22, -1, -1, -1, -1, -1, -1],
     ]
+
+
+@pytest.mark.parametrize("invalid_token", [-1, 100, True, 1.5])
+def test_remote_tokens_reject_invalid_vocab_ids(invalid_token):
+    proxy = RemoteK3DSparkSpeculator.__new__(RemoteK3DSparkSpeculator)
+    proxy.device = torch.device("cpu")
+    proxy.vocab_size = 100
+    proxy.draft_tokens = torch.full((1, 2), -1, dtype=torch.int64)
+
+    with pytest.raises(ValueError, match="out-of-vocabulary"):
+        proxy._copy_tokens_from_response(
+            {"tokens": [[1, invalid_token]]},
+            active_indices=[0],
+            num_speculative_tokens=2,
+        )
+
+
+def test_failed_proposal_discards_all_uncertain_local_state():
+    proxy = RemoteK3DSparkSpeculator.__new__(RemoteK3DSparkSpeculator)
+    proxy.num_speculative_steps = 2
+    proxy.draft_tokens = torch.full((2, 2), 7, dtype=torch.int64)
+    proxy._probabilistic = False
+    proxy._tp_rank = 0
+    proxy._known_requests = {"first", "second", "retained"}
+    proxy._disabled_requests = set()
+    proxy._active_requests = {"first", "second"}
+    proxy._retained_prefixes = {
+        request_id: _RetainedRequestPrefix(
+            token_ids=torch.arange(2),
+            committed_end=2,
+            context_start=0,
+            serial=index,
+        )
+        for index, request_id in enumerate(proxy._known_requests)
+    }
+    broadcasts = []
+    proxy._tp_group = SimpleNamespace(
+        broadcast=lambda tensor, src: broadcasts.append((tensor.clone(), src))
+    )
+
+    def fail(*_args, **_kwargs):
+        raise RuntimeError("transport failed")
+
+    proxy._rank0_propose = fail
+    batch = SimpleNamespace(num_reqs=2, req_ids=["first", "second"])
+    empty = torch.empty(0)
+
+    output = proxy.propose(
+        batch,
+        {},
+        {},
+        empty,
+        None,
+        empty,
+        empty,
+        empty,
+        empty,
+        empty,
+        empty,
+    )
+
+    assert output.tolist() == [[-1, -1], [-1, -1]]
+    assert proxy._disabled_requests == {"first", "second"}
+    assert proxy._known_requests == {"retained"}
+    assert proxy._active_requests == set()
+    assert set(proxy._retained_prefixes) == {"retained"}
+    assert len(broadcasts) == 1
 
 
 def test_remote_speculator_accepts_scheduler_selected_zero_depth():

--- a/tests/v1/spec_decode/test_k3_dspark_remote_speculator.py
+++ b/tests/v1/spec_decode/test_k3_dspark_remote_speculator.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import json
 from types import SimpleNamespace
 
 import numpy as np
@@ -100,6 +101,7 @@ def test_failed_proposal_discards_all_uncertain_local_state():
     proxy._known_requests = {"first", "second", "retained"}
     proxy._disabled_requests = set()
     proxy._active_requests = {"first", "second"}
+    proxy._stale_remote_requests = set()
     proxy._retained_prefixes = {
         request_id: _RetainedRequestPrefix(
             token_ids=torch.arange(2),
@@ -137,6 +139,7 @@ def test_failed_proposal_discards_all_uncertain_local_state():
 
     assert output.tolist() == [[-1, -1], [-1, -1]]
     assert proxy._disabled_requests == {"first", "second"}
+    assert proxy._stale_remote_requests == {"first", "second"}
     assert proxy._known_requests == {"retained"}
     assert proxy._active_requests == set()
     assert set(proxy._retained_prefixes) == {"retained"}
@@ -363,3 +366,91 @@ def test_remote_probabilistic_sampler_uses_standard_draft_stream(monkeypatch):
     assert recorded["kwargs"]["use_fp64"] is True
     assert recorded["kwargs"]["logits_cache"] is draft_logits
     assert torch.equal(recorded["kwargs"]["logits_cache_col"], draft_step)
+
+
+def _make_stale_proxy() -> RemoteK3DSparkSpeculator:
+    proxy = RemoteK3DSparkSpeculator.__new__(RemoteK3DSparkSpeculator)
+    proxy._known_requests = {"live"}
+    proxy._disabled_requests = {"failed", "gone"}
+    proxy._active_requests = {"live"}
+    proxy._stale_remote_requests = {"failed", "gone"}
+    proxy._retained_prefixes = {}
+    return proxy
+
+
+def test_failed_proposal_marks_known_requests_stale():
+    proxy = RemoteK3DSparkSpeculator.__new__(RemoteK3DSparkSpeculator)
+    proxy._known_requests = {"first", "retained"}
+    proxy._disabled_requests = set()
+    proxy._active_requests = {"first"}
+    proxy._stale_remote_requests = set()
+    proxy._retained_prefixes = {}
+
+    proxy._discard_failed_requests(["first", "never_sent"])
+
+    assert proxy._disabled_requests == {"first", "never_sent"}
+    assert proxy._stale_remote_requests == {"first"}
+    assert proxy._known_requests == {"retained"}
+
+
+def test_stale_release_frees_remote_slots_and_re_enables_requests():
+    proxy = _make_stale_proxy()
+    sent = []
+
+    def rpc(parts):
+        sent.append(json.loads(parts[0]))
+        return {"ok": True}
+
+    proxy._rpc = rpc
+
+    proxy._release_stale_remote_requests()
+
+    assert sent == [
+        {
+            "protocol": remote_speculator.PROTOCOL_VERSION,
+            "op": "FREE",
+            "request_ids": ["failed", "gone"],
+        }
+    ]
+    assert proxy._stale_remote_requests == set()
+    assert proxy._disabled_requests == set()
+    assert proxy._known_requests == {"live"}
+
+
+def test_stale_release_keeps_requests_disabled_until_free_succeeds():
+    proxy = _make_stale_proxy()
+
+    def fail(_parts):
+        raise RuntimeError("transport down")
+
+    proxy._rpc = fail
+
+    with pytest.raises(RuntimeError, match="transport down"):
+        proxy._release_stale_remote_requests()
+
+    assert proxy._stale_remote_requests == {"failed", "gone"}
+    assert proxy._disabled_requests == {"failed", "gone"}
+
+
+def test_failed_reconnect_forgets_the_source_and_marks_both_ids_stale():
+    proxy = RemoteK3DSparkSpeculator.__new__(RemoteK3DSparkSpeculator)
+    proxy._known_requests = {"source"}
+    proxy._stale_remote_requests = set()
+    proxy._retained_prefixes = {
+        "source": _RetainedRequestPrefix(
+            token_ids=torch.arange(4),
+            committed_end=4,
+            context_start=0,
+            serial=1,
+        )
+    }
+
+    def fail(_parts):
+        raise RuntimeError("transport down")
+
+    proxy._rpc = fail
+
+    assert not proxy._reconnect_request("source", "request", 4, torch.arange(4))
+    assert proxy._known_requests == set()
+    assert proxy._retained_prefixes == {}
+    assert proxy._stale_remote_requests == {"source", "request"}

--- a/tests/v1/spec_decode/test_k3_dspark_standalone.py
+++ b/tests/v1/spec_decode/test_k3_dspark_standalone.py
@@ -9,6 +9,7 @@ import torch
 from vllm.entrypoints.k3_dspark_rpc import (
     DraftKVSlotAllocator,
     ProjectedContextCache,
+    _encode_bfloat16_logits_frame,
 )
 from vllm.entrypoints.k3_dspark_standalone import (
     EMBED_TENSOR,
@@ -170,3 +171,30 @@ def test_projected_context_cache_rejects_device_mismatch():
 
     with pytest.raises(ValueError, match="device mismatch"):
         cache.append(0, states)
+
+
+def test_encode_bfloat16_logits_frame_preserves_shape_and_bits():
+    logits = torch.tensor(
+        [[[1.0, -2.0], [3.5, 0.25]]],
+        dtype=torch.bfloat16,
+    )
+
+    metadata, frame = _encode_bfloat16_logits_frame(logits)
+
+    assert metadata == {
+        "capability": "dflash_logits_bf16_v1",
+        "dtype": "bfloat16",
+        "shape": [1, 2, 2],
+        "nbytes": 8,
+    }
+    decoded = (
+        torch.frombuffer(bytearray(frame), dtype=torch.uint16)
+        .view(torch.bfloat16)
+        .reshape(1, 2, 2)
+    )
+    assert torch.equal(decoded, logits)
+
+
+def test_encode_logits_rejects_non_bfloat16_input():
+    with pytest.raises(ValueError, match="must be bfloat16"):
+        _encode_bfloat16_logits_frame(torch.zeros(1, 2, dtype=torch.float32))

--- a/tests/v1/spec_decode/test_k3_dspark_standalone.py
+++ b/tests/v1/spec_decode/test_k3_dspark_standalone.py
@@ -1,0 +1,172 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import json
+
+import pytest
+import torch
+
+from vllm.entrypoints.k3_dspark_rpc import (
+    DraftKVSlotAllocator,
+    ProjectedContextCache,
+)
+from vllm.entrypoints.k3_dspark_standalone import (
+    EMBED_TENSOR,
+    LM_HEAD_TENSOR,
+    resolve_shared_weight_files,
+)
+
+
+def _write_index(root, weight_map):
+    (root / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": weight_map})
+    )
+
+
+def test_resolve_shared_weight_files_requires_both_target_tensors(tmp_path):
+    shard = tmp_path / "shared.safetensors"
+    shard.touch()
+    _write_index(tmp_path, {EMBED_TENSOR: shard.name})
+
+    with pytest.raises(KeyError, match=LM_HEAD_TENSOR):
+        resolve_shared_weight_files(tmp_path)
+
+
+def test_resolve_shared_weight_files_resolves_checkpoint_shards(tmp_path):
+    shard = tmp_path / "shared.safetensors"
+    shard.touch()
+    _write_index(
+        tmp_path,
+        {
+            EMBED_TENSOR: shard.name,
+            LM_HEAD_TENSOR: shard.name,
+        },
+    )
+
+    resolved = resolve_shared_weight_files(tmp_path)
+
+    assert resolved == {
+        EMBED_TENSOR: shard.resolve(),
+        LM_HEAD_TENSOR: shard.resolve(),
+    }
+
+
+def test_resolve_shared_weight_files_rejects_path_escape(tmp_path):
+    outside = tmp_path.parent / "outside.safetensors"
+    outside.touch()
+    _write_index(
+        tmp_path,
+        {
+            EMBED_TENSOR: f"../{outside.name}",
+            LM_HEAD_TENSOR: f"../{outside.name}",
+        },
+    )
+
+    with pytest.raises(ValueError, match="escapes"):
+        resolve_shared_weight_files(tmp_path)
+
+
+def test_draft_kv_slot_allocator_keeps_rolling_blocks_unique():
+    allocator = DraftKVSlotAllocator(
+        num_cache_blocks=11,
+        block_size=4,
+        window_size=16,
+        max_requests=2,
+    )
+    first, created = allocator.get_or_allocate("first")
+    second, _ = allocator.get_or_allocate("second")
+
+    assert created
+    assert allocator.physical_block_range(first) == slice(1, 6)
+    assert allocator.physical_block_range(second) == slice(6, 11)
+    blocks, local_len = allocator.block_table(first, 21)
+    assert blocks == [2, 3, 4, 5, 1]
+    assert len(blocks) == len(set(blocks))
+    assert local_len == 17
+
+
+def test_draft_kv_slot_allocator_reuses_freed_request_slot():
+    allocator = DraftKVSlotAllocator(
+        num_cache_blocks=6,
+        block_size=4,
+        window_size=16,
+        max_requests=1,
+    )
+    original, _ = allocator.get_or_allocate("original")
+    with pytest.raises(RuntimeError, match="capacity exhausted"):
+        allocator.get_or_allocate("other")
+
+    assert allocator.free("original") is original
+    replacement, created = allocator.get_or_allocate("replacement")
+    assert created
+    assert replacement.slot == original.slot
+
+
+def test_draft_kv_slot_allocator_rebinds_without_changing_slot():
+    allocator = DraftKVSlotAllocator(
+        num_cache_blocks=6,
+        block_size=4,
+        window_size=16,
+        max_requests=1,
+    )
+    original, _ = allocator.get_or_allocate("original")
+
+    rebound = allocator.rebind("original", "replacement")
+
+    assert rebound is original
+    assert rebound.request_id == "replacement"
+    assert allocator.get("original") is None
+    assert allocator.get("replacement") is rebound
+
+
+def test_projected_context_cache_rewinds_and_overwrites_exact_prefix():
+    cache = ProjectedContextCache(hidden_size=2, max_tokens=8, chunk_size=4)
+    initial = torch.arange(16, dtype=torch.bfloat16).view(8, 2)
+    cache.append(0, initial)
+
+    replacement = torch.tensor([[100, 101], [102, 103]], dtype=torch.bfloat16)
+    cache.append(5, replacement)
+
+    assert cache.start_position == 0
+    assert cache.end_position == 7
+    assert torch.equal(cache.read(0, 5), initial[:5])
+    assert torch.equal(cache.read(5, 7), replacement)
+
+
+def test_projected_context_cache_evicts_old_rows_without_regaining_them():
+    cache = ProjectedContextCache(hidden_size=1, max_tokens=6, chunk_size=4)
+    cache.append(0, torch.arange(8, dtype=torch.bfloat16).view(8, 1))
+
+    assert cache.start_position == 2
+    assert cache.has_range(2, 8)
+    assert not cache.has_range(1, 8)
+
+    cache.append(5, torch.tensor([[50], [60]], dtype=torch.bfloat16))
+    assert cache.start_position == 2
+    assert cache.end_position == 7
+    with pytest.raises(ValueError, match="unavailable"):
+        cache.read(1, 7)
+
+
+def test_projected_context_cache_tracks_configured_device():
+    cache = ProjectedContextCache(
+        hidden_size=2,
+        max_tokens=4,
+        chunk_size=2,
+        device=torch.device("cpu"),
+    )
+    states = torch.arange(8, dtype=torch.bfloat16).view(4, 2)
+
+    cache.append(0, states)
+
+    assert cache.device == torch.device("cpu")
+    assert cache.read(0, 4).device == cache.device
+    assert cache.allocated_bytes == states.numel() * states.element_size()
+
+
+def test_projected_context_cache_rejects_device_mismatch():
+    cache = ProjectedContextCache(hidden_size=2, max_tokens=4)
+    states = torch.empty((1, 2), dtype=torch.bfloat16, device="meta")
+
+    with pytest.raises(ValueError, match="device mismatch"):
+        cache.append(0, states)

--- a/tests/v1/spec_decode/test_k3_dspark_standalone.py
+++ b/tests/v1/spec_decode/test_k3_dspark_standalone.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import json
+import sys
 
 import pytest
 import torch
@@ -9,11 +10,17 @@ import torch
 from vllm.entrypoints.k3_dspark_rpc import (
     DraftKVSlotAllocator,
     ProjectedContextCache,
+    _cuda_graph_shapes,
     _encode_bfloat16_logits_frame,
+    _projected_context_capacity_bytes,
+    _validate_proposal_address,
 )
 from vllm.entrypoints.k3_dspark_standalone import (
     EMBED_TENSOR,
     LM_HEAD_TENSOR,
+    _parse_args,
+    _status_http_code,
+    _validate_single_block_smoke_span,
     resolve_shared_weight_files,
 )
 
@@ -120,6 +127,114 @@ def test_draft_kv_slot_allocator_rebinds_without_changing_slot():
     assert allocator.get("replacement") is rebound
 
 
+def test_draft_kv_slot_allocator_vectorizes_rolling_slots():
+    allocator = DraftKVSlotAllocator(
+        num_cache_blocks=11,
+        block_size=4,
+        window_size=16,
+        max_requests=2,
+    )
+    allocator.get_or_allocate("first")
+    state, _ = allocator.get_or_allocate("second")
+    positions = torch.arange(2, 27, dtype=torch.int64)
+
+    slots = allocator.cache_slots(state, positions)
+
+    assert slots.tolist() == [
+        allocator.cache_slot(state, int(position)) for position in positions
+    ]
+
+
+def test_projected_context_capacity_includes_chunk_straddling():
+    capacity = _projected_context_capacity_bytes(
+        max_requests=2,
+        max_tokens=4,
+        hidden_size=3,
+        chunk_size=4,
+    )
+
+    assert capacity == 2 * 2 * 4 * 3 * 2
+
+
+def test_cuda_graph_shapes_cover_every_accepted_request():
+    assert _cuda_graph_shapes(3, 3) == [
+        (3, 3),
+        (3, 2),
+        (3, 1),
+        (2, 3),
+        (2, 2),
+        (2, 1),
+        (1, 3),
+        (1, 2),
+        (1, 1),
+    ]
+
+
+@pytest.mark.parametrize(
+    "address",
+    ["tcp://127.0.0.1:8092", "tcp://[::1]:8092", "ipc:///tmp/k3.sock"],
+)
+def test_proposal_address_accepts_local_transports(address):
+    _validate_proposal_address(address, allow_unsafe_remote=False)
+
+
+@pytest.mark.parametrize(
+    "address",
+    ["tcp://0.0.0.0:8092", "tcp://*:8092", "tcp://192.0.2.10:8092"],
+)
+def test_proposal_address_rejects_unauthenticated_remote_bind(address):
+    with pytest.raises(ValueError, match="no authentication"):
+        _validate_proposal_address(address, allow_unsafe_remote=False)
+
+    _validate_proposal_address(address, allow_unsafe_remote=True)
+
+
+def test_dspark_smoke_span_must_fit_its_mapped_block():
+    _validate_single_block_smoke_span(1, 15, 16)
+
+    with pytest.raises(ValueError, match="single mapped KV block"):
+        _validate_single_block_smoke_span(1, 16, 16)
+
+
+def test_health_is_live_before_readiness():
+    assert _status_http_code("/healthz", ready=False) == 200
+    assert _status_http_code("/readyz", ready=False) == 503
+    assert _status_http_code("/readyz", ready=True) == 200
+
+
+@pytest.mark.parametrize(
+    "invalid_args",
+    [
+        ["--num-speculative-tokens", "0"],
+        ["--max-num-batched-tokens", "0"],
+        ["--max-num-seqs", "0"],
+        ["--draft-kv-cache-gib", "nan"],
+        ["--draft-kv-window", "0"],
+        ["--draft-kv-window", "17"],
+        ["--cuda-graph-warmups", "0"],
+        ["--port", "65536"],
+    ],
+)
+def test_standalone_cli_rejects_invalid_numeric_values(monkeypatch, invalid_args):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "k3-draft",
+            "--draft-model",
+            "/draft",
+            "--target-weights",
+            "/target",
+            "--target-config",
+            "/config",
+            *invalid_args,
+        ],
+    )
+
+    with pytest.raises(SystemExit):
+        _parse_args()
+
+
 def test_projected_context_cache_rewinds_and_overwrites_exact_prefix():
     cache = ProjectedContextCache(hidden_size=2, max_tokens=8, chunk_size=4)
     initial = torch.arange(16, dtype=torch.bfloat16).view(8, 2)
@@ -147,6 +262,29 @@ def test_projected_context_cache_evicts_old_rows_without_regaining_them():
     assert cache.end_position == 7
     with pytest.raises(ValueError, match="unavailable"):
         cache.read(1, 7)
+
+
+def test_projected_context_cache_bounds_large_append_allocation():
+    cache = ProjectedContextCache(
+        hidden_size=1,
+        max_tokens=4,
+        chunk_size=4,
+    )
+
+    cache.append(0, torch.arange(12, dtype=torch.bfloat16).view(12, 1))
+
+    assert cache.start_position == 8
+    assert cache.end_position == 12
+    assert torch.equal(
+        cache.read(8, 12),
+        torch.arange(8, 12, dtype=torch.bfloat16).view(4, 1),
+    )
+    assert cache.allocated_bytes <= _projected_context_capacity_bytes(
+        max_requests=1,
+        max_tokens=4,
+        hidden_size=1,
+        chunk_size=4,
+    )
 
 
 def test_projected_context_cache_tracks_configured_device():

--- a/tests/v1/spec_decode/test_k3_dspark_standalone.py
+++ b/tests/v1/spec_decode/test_k3_dspark_standalone.py
@@ -3,16 +3,19 @@
 
 import json
 import sys
+import threading
 
 import pytest
 import torch
 
 from vllm.entrypoints.k3_dspark_rpc import (
     DraftKVSlotAllocator,
+    K3DSparkDraftEngine,
     ProjectedContextCache,
     _cuda_graph_shapes,
     _encode_bfloat16_logits_frame,
     _projected_context_capacity_bytes,
+    _required_int_field,
     _validate_proposal_address,
 )
 from vllm.entrypoints.k3_dspark_standalone import (
@@ -23,6 +26,7 @@ from vllm.entrypoints.k3_dspark_standalone import (
     _validate_single_block_smoke_span,
     resolve_shared_weight_files,
 )
+from vllm.v1.worker.gpu.spec_decode.utils import draft_query_len
 
 
 def _write_index(root, weight_map):
@@ -336,3 +340,47 @@ def test_encode_bfloat16_logits_frame_preserves_shape_and_bits():
 def test_encode_logits_rejects_non_bfloat16_input():
     with pytest.raises(ValueError, match="must be bfloat16"):
         _encode_bfloat16_logits_frame(torch.zeros(1, 2, dtype=torch.float32))
+
+
+@pytest.mark.parametrize(
+    "header",
+    (
+        {"anchor_token_id": 3},
+        {"anchor_position": "7"},
+        {"anchor_position": True},
+    ),
+)
+def test_propose_request_integer_fields_are_validated(header):
+    with pytest.raises(ValueError, match="anchor_position"):
+        _required_int_field(header, "anchor_position")
+    assert _required_int_field({"anchor_position": 7}, "anchor_position") == 7
+
+
+def test_reset_of_unknown_request_is_a_no_op():
+    engine = K3DSparkDraftEngine.__new__(K3DSparkDraftEngine)
+    engine._lock = threading.Lock()
+    engine.allocator = DraftKVSlotAllocator(
+        num_cache_blocks=6,
+        block_size=4,
+        window_size=16,
+        max_requests=1,
+    )
+    cleared = []
+    engine._clear_state_cache = lambda state, **_kwargs: cleared.append(
+        state.request_id
+    )
+    known, _ = engine.allocator.get_or_allocate("known")
+
+    engine.reset(["unknown", "known"])
+
+    assert cleared == ["known"]
+    assert engine.allocator.get("unknown") is None
+    assert engine.allocator.get("known") is known
+
+
+@pytest.mark.parametrize(
+    ("method", "depth", "expected"),
+    (("dspark", 3, 3), ("dflash", 3, 4)),
+)
+def test_draft_query_len_follows_the_anchor_sampling_rule(method, depth, expected):
+    assert draft_query_len(method, depth) == expected

--- a/vllm/entrypoints/k3_dspark_rpc.py
+++ b/vllm/entrypoints/k3_dspark_rpc.py
@@ -10,12 +10,16 @@ server protocol.
 
 from __future__ import annotations
 
+import ipaddress
 import json
+import math
 import os
 import threading
 import time
+from contextlib import suppress
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
+from urllib.parse import urlsplit
 
 import torch
 import zmq
@@ -40,6 +44,61 @@ logger = init_logger(__name__)
 
 PROTOCOL_VERSION = 2
 LOGITS_CAPABILITY = "dflash_logits_bf16_v1"
+PROJECTED_CONTEXT_CHUNK_SIZE = 256
+
+
+def _projected_context_capacity_bytes(
+    *,
+    max_requests: int,
+    max_tokens: int,
+    hidden_size: int,
+    chunk_size: int = PROJECTED_CONTEXT_CHUNK_SIZE,
+) -> int:
+    """Return the worst-case aggregate projected-context allocation."""
+    if min(max_requests, max_tokens, hidden_size, chunk_size) <= 0:
+        raise ValueError("Projected context cache dimensions must be positive")
+    # A retained interval can straddle one more chunk than max_tokens alone
+    # would suggest (for example [1, chunk_size + 1)).
+    chunks_per_request = (max_tokens + 2 * chunk_size - 2) // chunk_size
+    return max_requests * chunks_per_request * chunk_size * hidden_size * 2
+
+
+def _cuda_graph_shapes(
+    max_batch_size: int,
+    max_speculative_tokens: int,
+) -> list[tuple[int, int]]:
+    """Enumerate every draft shape accepted by the standalone server."""
+    if max_batch_size < 1 or max_speculative_tokens < 1:
+        raise ValueError("CUDA graph batch size and depth must be positive")
+    shapes = [
+        (batch_size, depth)
+        for batch_size in range(1, max_batch_size + 1)
+        for depth in range(1, max_speculative_tokens + 1)
+    ]
+    return sorted(shapes, reverse=True)
+
+
+def _validate_proposal_address(
+    address: str,
+    *,
+    allow_unsafe_remote: bool,
+) -> None:
+    """Reject unauthenticated non-local proposal sockets by default."""
+    parsed = urlsplit(address)
+    if parsed.scheme in ("ipc", "inproc"):
+        return
+    if parsed.scheme != "tcp" or parsed.hostname is None or parsed.port is None:
+        raise ValueError(f"Unsupported K3 proposal address: {address!r}")
+    hostname = parsed.hostname
+    is_loopback = hostname.lower() == "localhost"
+    with suppress(ValueError):
+        is_loopback = is_loopback or ipaddress.ip_address(hostname).is_loopback
+    if not is_loopback and not allow_unsafe_remote:
+        raise ValueError(
+            "K3 proposal RPC has no authentication; refusing non-loopback "
+            f"address {address!r}. Pass --allow-unsafe-remote-rpc only on a "
+            "trusted, isolated network."
+        )
 
 
 def _encode_bfloat16_logits_frame(
@@ -125,8 +184,16 @@ class ProjectedContextCache:
         if first_position < self.end_position:
             self._truncate(first_position)
 
-        offset = 0
         num_rows = int(states.shape[0])
+        final_end = first_position + num_rows
+        new_start = max(self.start_position, final_end - self.max_tokens)
+        # Evict before allocating incoming chunks so the configured retained
+        # capacity is also a bound on transient device allocation.
+        for chunk_idx in list(self._chunks):
+            if (chunk_idx + 1) * self.chunk_size <= new_start:
+                del self._chunks[chunk_idx]
+
+        offset = max(0, new_start - first_position)
         while offset < num_rows:
             position = first_position + offset
             chunk_idx, chunk_offset = divmod(position, self.chunk_size)
@@ -144,14 +211,8 @@ class ProjectedContextCache:
             )
             offset += count
 
-        self.end_position = first_position + num_rows
-        self.start_position = max(
-            self.start_position,
-            self.end_position - self.max_tokens,
-        )
-        for chunk_idx in list(self._chunks):
-            if (chunk_idx + 1) * self.chunk_size <= self.start_position:
-                del self._chunks[chunk_idx]
+        self.end_position = final_end
+        self.start_position = new_start
 
     def has_range(self, start_position: int, end_position: int) -> bool:
         return (
@@ -289,6 +350,28 @@ class DraftKVSlotAllocator:
             position % self.block_size
         )
 
+    def cache_slots(
+        self,
+        state: DraftRequestState,
+        positions: torch.Tensor,
+    ) -> torch.Tensor:
+        """Vectorize rolling physical-slot mapping for one request."""
+        if positions.ndim != 1 or positions.dtype != torch.int64:
+            raise ValueError("Draft cache positions must be a 1D int64 tensor")
+        absolute_blocks = torch.div(
+            positions,
+            self.block_size,
+            rounding_mode="floor",
+        )
+        physical_blocks = (
+            1
+            + state.slot * self.blocks_per_request
+            + torch.remainder(absolute_blocks, self.blocks_per_request)
+        )
+        return physical_blocks * self.block_size + torch.remainder(
+            positions, self.block_size
+        )
+
     def block_table(
         self, state: DraftRequestState, sequence_end: int
     ) -> tuple[list[int], int]:
@@ -399,6 +482,7 @@ class K3DSparkDraftEngine:
         *,
         max_requests: int,
         window_size: int,
+        prefix_cache_gib: float,
         device: torch.device,
     ) -> None:
         self.runtime = runtime
@@ -435,6 +519,12 @@ class K3DSparkDraftEngine:
         self.max_context_tokens = int(
             runtime.vllm_config.scheduler_config.max_num_batched_tokens
         )
+        self.max_batch_size = int(runtime.vllm_config.scheduler_config.max_num_seqs)
+        if max_requests < self.max_batch_size:
+            raise ValueError(
+                "Retained request capacity must cover every accepted batch: "
+                f"retained={max_requests}, batch={self.max_batch_size}"
+            )
         self.prefix_cache_tokens = int(
             os.environ.get(
                 "VLLM_K3_DRAFT_PREFIX_CACHE_TOKENS",
@@ -447,6 +537,24 @@ class K3DSparkDraftEngine:
                 f"draft KV window ({self.allocator.window_size}), got "
                 f"{self.prefix_cache_tokens}"
             )
+        if not math.isfinite(prefix_cache_gib) or prefix_cache_gib <= 0:
+            raise ValueError("Draft prefix cache GiB must be positive and finite")
+        self.prefix_cache_capacity_bytes = int(prefix_cache_gib * 1024**3)
+        self.prefix_cache_required_bytes = _projected_context_capacity_bytes(
+            max_requests=max_requests,
+            max_tokens=self.prefix_cache_tokens,
+            hidden_size=self.hidden_size,
+        )
+        if self.prefix_cache_required_bytes > self.prefix_cache_capacity_bytes:
+            raise ValueError(
+                "Projected context cache can exceed its configured aggregate "
+                "budget: required="
+                f"{self.prefix_cache_required_bytes / 1024**3:.3f} GiB, "
+                f"budget={prefix_cache_gib:.3f} GiB, requests={max_requests}, "
+                f"tokens={self.prefix_cache_tokens}, width={self.hidden_size}"
+            )
+        self._validate_prefix_cache_available_memory()
+
         self._positions_staging = torch.empty(
             self.max_context_tokens,
             dtype=torch.int64,
@@ -457,7 +565,7 @@ class K3DSparkDraftEngine:
             dtype=torch.bfloat16,
             pin_memory=True,
         )
-        self._lock = threading.Lock()
+        self._lock = threading.RLock()
         self.proposal_count = 0
         self.last_latency_ms = 0.0
         self.last_timing_ms: dict[str, float] = {}
@@ -469,8 +577,20 @@ class K3DSparkDraftEngine:
         self.cuda_graph_capture_seconds = 0.0
         self.cuda_graph_memory_gib = 0.0
         self.cuda_graph_replay_count = 0
-        self.cuda_graph_eager_fallback_count = 0
         self._cuda_graphs: dict[tuple[int, int], _DraftCudaGraphState] = {}
+
+    def _validate_prefix_cache_available_memory(self) -> None:
+        """Account for model, draft KV, and any captured graph allocations."""
+        if self.device.type == "cuda":
+            free_bytes, _ = torch.cuda.mem_get_info(self.device)
+            if self.prefix_cache_required_bytes > free_bytes:
+                raise ValueError(
+                    "Projected context cache worst case does not fit after model "
+                    "and draft runtime allocation: "
+                    "required="
+                    f"{self.prefix_cache_required_bytes / 1024**3:.3f} GiB, "
+                    f"free={free_bytes / 1024**3:.3f} GiB"
+                )
 
     def _make_cuda_graph_state(
         self,
@@ -485,6 +605,12 @@ class K3DSparkDraftEngine:
             if self.method == "dspark"
             else 1 + num_speculative_tokens
         )
+        if query_len > self.allocator.block_size:
+            raise ValueError(
+                "Draft CUDA graph dummy sequence must fit in one mapped KV "
+                f"block: query_len={query_len}, "
+                f"block_size={self.allocator.block_size}"
+            )
         num_tokens = batch_size * query_len
         max_blocks = self.allocator.blocks_per_request
         input_ids = torch.empty(num_tokens, dtype=torch.int64, device=self.device)
@@ -649,8 +775,12 @@ class K3DSparkDraftEngine:
         state.captured_logits = logits
 
     @torch.inference_mode()
-    def capture_cuda_graphs(self, *, warmups: int = 2) -> None:
-        """Capture all DSpark or DFlash shapes selectable by this server."""
+    def capture_cuda_graphs(
+        self,
+        *,
+        warmups: int = 2,
+    ) -> None:
+        """Capture every DSpark or DFlash shape accepted by this server."""
         if warmups < 1:
             raise ValueError("Draft CUDA graph capture requires at least one warmup")
         if self._cuda_graphs:
@@ -664,15 +794,10 @@ class K3DSparkDraftEngine:
         # buffers on demand; capturing a smaller shape first and then resizing
         # that workspace for B2/K3 leaves the earlier graph with stale device
         # pointers and causes an illegal access on replay.
-        shapes = [
-            (batch_size, depth)
-            for batch_size in range(
-                self.runtime.vllm_config.scheduler_config.max_num_seqs,
-                0,
-                -1,
-            )
-            for depth in range(self.max_speculative_tokens, 0, -1)
-        ]
+        shapes = _cuda_graph_shapes(
+            self.max_batch_size,
+            self.max_speculative_tokens,
+        )
         logger.info(
             "Capturing %d standalone K3 %s CUDA graphs on %s: %s",
             len(shapes),
@@ -711,6 +836,7 @@ class K3DSparkDraftEngine:
             0.0,
             (torch.cuda.memory_allocated(self.device) - allocated_before) / 1024**3,
         )
+        self._validate_prefix_cache_available_memory()
         logger.info(
             "Standalone K3 %s CUDA graphs ready in %.2fs; allocated_delta=%.3f GiB",
             self.method,
@@ -750,39 +876,55 @@ class K3DSparkDraftEngine:
                 self.allocator.free(request_id)
 
     def clear(self) -> None:
-        self.free(self.allocator.request_ids)
+        with self._lock:
+            for request_id in self.allocator.request_ids:
+                self.allocator.free(request_id)
+
+    def _prefix_cache_bytes_by_device(self) -> tuple[int, int]:
+        total = 0
+        host = 0
+        for request_id in self.allocator.request_ids:
+            state = self.allocator.get(request_id)
+            if state is None or state.context_cache is None:
+                continue
+            allocated = state.context_cache.allocated_bytes
+            total += allocated
+            if state.context_cache.device.type == "cpu":
+                host += allocated
+        return total, host
 
     @property
     def prefix_cache_bytes(self) -> int:
-        return sum(
-            state.context_cache.allocated_bytes
-            for request_id in self.allocator.request_ids
-            if (state := self.allocator.get(request_id)) is not None
-            and state.context_cache is not None
-        )
+        with self._lock:
+            total, _ = self._prefix_cache_bytes_by_device()
+            return total
+
+    @property
+    def active_requests(self) -> int:
+        with self._lock:
+            return self.allocator.active_requests
 
     @property
     def prefix_cache_host_bytes(self) -> int:
-        return sum(
-            state.context_cache.allocated_bytes
-            for request_id in self.allocator.request_ids
-            if (state := self.allocator.get(request_id)) is not None
-            and state.context_cache is not None
-            and state.context_cache.device.type == "cpu"
-        )
+        with self._lock:
+            _, host = self._prefix_cache_bytes_by_device()
+            return host
 
     @property
     def prefix_cache_device_bytes(self) -> int:
-        return self.prefix_cache_bytes - self.prefix_cache_host_bytes
+        with self._lock:
+            total, host = self._prefix_cache_bytes_by_device()
+            return total - host
 
     @property
     def mean_timing_ms(self) -> dict[str, float]:
-        if self.proposal_count <= 0:
-            return {}
-        return {
-            key: value / self.proposal_count
-            for key, value in self._timing_totals_ms.items()
-        }
+        with self._lock:
+            if self.proposal_count <= 0:
+                return {}
+            return {
+                key: value / self.proposal_count
+                for key, value in self._timing_totals_ms.items()
+            }
 
     def _record_timing(self, timing_ms: dict[str, float]) -> None:
         self.last_timing_ms = timing_ms
@@ -817,13 +959,9 @@ class K3DSparkDraftEngine:
             positions = torch.arange(start, end, dtype=torch.int64)
             context_gpu = context_states.to(self.device, non_blocking=True)
             positions_gpu = positions.to(self.device, non_blocking=True)
-            slots = torch.tensor(
-                [
-                    self.allocator.cache_slot(state, position)
-                    for position in range(start, end)
-                ],
-                dtype=torch.int64,
-                device=self.device,
+            slots = self.allocator.cache_slots(state, positions).to(
+                self.device,
+                non_blocking=True,
             )
             self.model.precompute_and_store_context_kv(
                 context_gpu,
@@ -931,9 +1069,9 @@ class K3DSparkDraftEngine:
             else self.model.combine_hidden_states(context_input)
         )
 
-        slots: list[int] = []
+        slots_cpu = torch.empty_like(positions_cpu)
         offset = 0
-        for state, count in zip(states, context_counts):
+        for state, count in zip(states, context_counts, strict=True):
             req_positions = positions_cpu[offset : offset + count]
             if count:
                 first = int(req_positions[0])
@@ -948,19 +1086,18 @@ class K3DSparkDraftEngine:
                         f"Context positions for {state.request_id!r} are not contiguous"
                     )
                 state.committed_end = int(req_positions[-1]) + 1
-                slots.extend(
-                    self.allocator.cache_slot(state, int(position))
-                    for position in req_positions
+                slots_cpu[offset : offset + count].copy_(
+                    self.allocator.cache_slots(state, req_positions)
                 )
             offset += count
-        slot_mapping = torch.tensor(slots, dtype=torch.int64, device=self.device)
+        slot_mapping = slots_cpu.to(self.device, non_blocking=True)
         self.model.precompute_and_store_context_kv(
             context_states,
             positions,
             slot_mapping,
         )
         offset = 0
-        for state, count in zip(states, context_counts):
+        for state, count in zip(states, context_counts, strict=True):
             if count:
                 first_position = int(positions_cpu[offset])
                 if state.context_cache is None:
@@ -995,7 +1132,10 @@ class K3DSparkDraftEngine:
         seq_lens: list[int] = []
 
         for state, anchor_position, anchor_token_id in zip(
-            states, anchor_positions, anchor_token_ids
+            states,
+            anchor_positions,
+            anchor_token_ids,
+            strict=True,
         ):
             if anchor_position != state.committed_end:
                 raise ValueError(
@@ -1023,27 +1163,30 @@ class K3DSparkDraftEngine:
 
         if self.cuda_graph_enabled:
             graph_state = self._cuda_graphs.get((batch_size, num_speculative_tokens))
-            if graph_state is not None:
-                graph_state.stage(
-                    input_ids=input_ids,
-                    positions=positions,
-                    slots=slots,
-                    block_rows=block_rows,
-                    seq_lens=seq_lens,
+            if graph_state is None:
+                raise AssertionError(
+                    "Accepted K3 request shape was not captured: "
+                    f"B{batch_size}K{num_speculative_tokens}"
                 )
-                assert graph_state.graph is not None
-                graph_state.graph.replay()
-                self.cuda_graph_replay_count += 1
-                logits = graph_state.captured_logits
-                if self.method == "dflash":
-                    assert logits is not None
-                    logits = logits.view(
-                        batch_size,
-                        num_speculative_tokens,
-                        -1,
-                    )
-                return graph_state.output_tokens, logits
-            self.cuda_graph_eager_fallback_count += 1
+            graph_state.stage(
+                input_ids=input_ids,
+                positions=positions,
+                slots=slots,
+                block_rows=block_rows,
+                seq_lens=seq_lens,
+            )
+            assert graph_state.graph is not None
+            graph_state.graph.replay()
+            self.cuda_graph_replay_count += 1
+            logits = graph_state.captured_logits
+            if self.method == "dflash":
+                assert logits is not None
+                logits = logits.view(
+                    batch_size,
+                    num_speculative_tokens,
+                    -1,
+                )
+            return graph_state.output_tokens, logits
 
         max_blocks = max(len(row) for row in block_rows)
         block_table = torch.zeros(
@@ -1148,10 +1291,9 @@ class K3DSparkDraftEngine:
         requests = header.get("requests")
         if not isinstance(requests, list) or not requests:
             raise ValueError("PROPOSE requires a non-empty requests list")
-        if len(requests) > self.allocator.max_requests:
+        if len(requests) > self.max_batch_size:
             raise ValueError(
-                f"Batch has {len(requests)} requests, max is "
-                f"{self.allocator.max_requests}"
+                f"Batch has {len(requests)} requests, max is {self.max_batch_size}"
             )
         num_speculative_tokens = int(
             header.get("num_speculative_tokens", self.max_speculative_tokens)
@@ -1174,23 +1316,26 @@ class K3DSparkDraftEngine:
                 f"PROPOSE expected {expected_frames} tensor frames, got {len(frames)}"
             )
         context_width = self.hidden_size if projected else self.raw_context_width
-        if total_context:
-            positions_cpu = self._decode_host_tensor(
-                frames[0], dtype=torch.int64, shape=(total_context,)
-            )
-            context_cpu = self._decode_host_tensor(
-                frames[1],
-                dtype=torch.bfloat16,
-                shape=(total_context, context_width),
-            )
-        else:
-            positions_cpu = torch.empty(0, dtype=torch.int64)
-            context_cpu = torch.empty((0, context_width), dtype=torch.bfloat16)
-        decoded_at = time.perf_counter()
-
         lock_started = time.perf_counter()
         with self._lock:
             lock_acquired = time.perf_counter()
+            decode_started = time.perf_counter()
+            # Both decoders reuse shared pinned staging tensors, so frame
+            # decoding must remain inside the same serialization boundary as
+            # the GPU submission that consumes those views.
+            if total_context:
+                positions_cpu = self._decode_host_tensor(
+                    frames[0], dtype=torch.int64, shape=(total_context,)
+                )
+                context_cpu = self._decode_host_tensor(
+                    frames[1],
+                    dtype=torch.bfloat16,
+                    shape=(total_context, context_width),
+                )
+            else:
+                positions_cpu = torch.empty(0, dtype=torch.int64)
+                context_cpu = torch.empty((0, context_width), dtype=torch.bfloat16)
+            decoded_at = time.perf_counter()
             gpu_start = torch.cuda.Event(enable_timing=True)
             context_end = torch.cuda.Event(enable_timing=True)
             query_end = torch.cuda.Event(enable_timing=True)
@@ -1252,9 +1397,10 @@ class K3DSparkDraftEngine:
                 ]
             logits_copied = time.perf_counter()
             self.proposal_count += 1
-            self.last_latency_ms = (logits_copied - started) * 1000
+            latency_ms = (logits_copied - started) * 1000
+            self.last_latency_ms = latency_ms
             timing_ms = {
-                "decode_frames": (decoded_at - started) * 1000,
+                "decode_frames": (decoded_at - decode_started) * 1000,
                 "lock_wait": (lock_acquired - lock_started) * 1000,
                 "host_submit": (submit_done - lock_acquired) * 1000,
                 "gpu_context": gpu_start.elapsed_time(context_end),
@@ -1262,17 +1408,18 @@ class K3DSparkDraftEngine:
                 "gpu_wait": (sync_done - submit_done) * 1000,
                 "tokens_d2h": (tokens_copied - sync_done) * 1000,
                 "logits_d2h": (logits_copied - tokens_copied) * 1000,
-                "total": self.last_latency_ms,
+                "total": latency_ms,
             }
             self._record_timing(timing_ms)
+            active_requests = self.allocator.active_requests
         response = {
             "ok": True,
             "protocol": PROTOCOL_VERSION,
             "tokens": tokens,
             "logits": logits_metadata,
-            "latency_ms": self.last_latency_ms,
+            "latency_ms": latency_ms,
             "timing_ms": timing_ms,
-            "active_requests": self.allocator.active_requests,
+            "active_requests": active_requests,
         }
         if logits_frame is not None:
             response["_logits_frame"] = logits_frame
@@ -1286,7 +1433,12 @@ class K3DSparkZMQServer:
         *,
         address: str,
         stop: threading.Event,
+        allow_unsafe_remote: bool = False,
     ) -> None:
+        _validate_proposal_address(
+            address,
+            allow_unsafe_remote=allow_unsafe_remote,
+        )
         self.engine = engine
         self.address = address
         self.stop = stop
@@ -1306,7 +1458,8 @@ class K3DSparkZMQServer:
             raise RuntimeError(self.error)
 
     def join(self, timeout: float = 5.0) -> None:
-        self._thread.join(timeout=timeout)
+        if self._thread.ident is not None:
+            self._thread.join(timeout=timeout)
 
     def _handle(self, parts: list[bytes]) -> dict[str, Any]:
         if not parts:
@@ -1326,11 +1479,19 @@ class K3DSparkZMQServer:
                 "protocol": PROTOCOL_VERSION,
                 "op": "PONG",
                 "method": self.engine.method,
-                "active_requests": self.engine.allocator.active_requests,
+                "active_requests": self.engine.active_requests,
                 "max_requests": self.engine.allocator.max_requests,
+                "max_batch_size": self.engine.max_batch_size,
+                "max_speculative_tokens": self.engine.max_speculative_tokens,
                 "block_size": self.engine.allocator.block_size,
                 "window_size": self.engine.allocator.window_size,
                 "prefix_cache_tokens": self.engine.prefix_cache_tokens,
+                "prefix_cache_capacity_bytes": (
+                    self.engine.prefix_cache_capacity_bytes
+                ),
+                "prefix_cache_required_bytes": (
+                    self.engine.prefix_cache_required_bytes
+                ),
                 "prefix_cache_device": str(self.engine.device),
                 "cold_bootstrap_count": self.engine.cold_bootstrap_count,
                 "cuda_graph_enabled": self.engine.cuda_graph_enabled,
@@ -1359,7 +1520,7 @@ class K3DSparkZMQServer:
             return {
                 "ok": True,
                 "protocol": PROTOCOL_VERSION,
-                "active_requests": self.engine.allocator.active_requests,
+                "active_requests": self.engine.active_requests,
             }
         if op == "RECONNECT":
             source_request_id = header.get("source_request_id")

--- a/vllm/entrypoints/k3_dspark_rpc.py
+++ b/vllm/entrypoints/k3_dspark_rpc.py
@@ -39,6 +39,24 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 PROTOCOL_VERSION = 2
+LOGITS_CAPABILITY = "dflash_logits_bf16_v1"
+
+
+def _encode_bfloat16_logits_frame(
+    logits: torch.Tensor,
+) -> tuple[dict[str, Any], bytes]:
+    """Encode contiguous draft logits as a versioned binary RPC frame."""
+    if logits.dtype != torch.bfloat16:
+        raise ValueError(f"Draft logits must be bfloat16, got {logits.dtype}")
+    logits_cpu = logits.detach().contiguous().cpu()
+    frame = logits_cpu.view(torch.uint16).numpy().tobytes()
+    metadata = {
+        "capability": LOGITS_CAPABILITY,
+        "dtype": "bfloat16",
+        "shape": list(logits_cpu.shape),
+        "nbytes": len(frame),
+    }
+    return metadata, frame
 
 
 class ProjectedContextCache:
@@ -964,7 +982,7 @@ class K3DSparkDraftEngine:
         anchor_positions: list[int],
         anchor_token_ids: list[int],
         num_speculative_tokens: int,
-    ) -> torch.Tensor:
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
         batch_size = len(states)
         sample_from_anchor = self.method == "dspark"
         query_len = (
@@ -1016,7 +1034,15 @@ class K3DSparkDraftEngine:
                 assert graph_state.graph is not None
                 graph_state.graph.replay()
                 self.cuda_graph_replay_count += 1
-                return graph_state.output_tokens
+                logits = graph_state.captured_logits
+                if self.method == "dflash":
+                    assert logits is not None
+                    logits = logits.view(
+                        batch_size,
+                        num_speculative_tokens,
+                        -1,
+                    )
+                return graph_state.output_tokens, logits
             self.cuda_graph_eager_fallback_count += 1
 
         max_blocks = max(len(row) for row in block_rows)
@@ -1097,13 +1123,11 @@ class K3DSparkDraftEngine:
 
         if self.method == "dflash":
             sample_hidden = hidden.view(batch_size, query_len, -1)[:, 1:]
-            return (
-                self.model.compute_logits(
-                    sample_hidden.reshape(batch_size * num_speculative_tokens, -1)
-                )
-                .argmax(dim=-1)
-                .view(batch_size, num_speculative_tokens)
+            logits = self.model.compute_logits(
+                sample_hidden.reshape(batch_size * num_speculative_tokens, -1)
             )
+            logits = logits.view(batch_size, num_speculative_tokens, -1)
+            return logits.argmax(dim=-1), logits
 
         base_logits = self.model.compute_draft_logits(hidden).view(
             batch_size, query_len, -1
@@ -1116,7 +1140,7 @@ class K3DSparkDraftEngine:
             markov = self.model.markov_bias(self.model.markov_embed(previous))
             previous = (base_logits[:, step] + markov).argmax(dim=-1)
             draft_tokens[:, step].copy_(previous)
-        return draft_tokens
+        return draft_tokens, None
 
     @torch.inference_mode()
     def propose(self, header: dict[str, Any], frames: list[bytes]) -> dict[str, Any]:
@@ -1136,6 +1160,9 @@ class K3DSparkDraftEngine:
             raise ValueError(
                 f"num_speculative_tokens must be in [1, {self.max_speculative_tokens}]"
             )
+        return_logits = bool(header.get("return_logits", False))
+        if return_logits and self.method != "dflash":
+            raise ValueError("Probabilistic logits are supported only for DFlash")
         projected = bool(header.get("projected", False))
         context_counts = [int(req.get("context_count", 0)) for req in requests]
         if any(count < 0 for count in context_counts):
@@ -1197,7 +1224,7 @@ class K3DSparkDraftEngine:
             context_end.record()
             anchor_positions = [int(req["anchor_position"]) for req in requests]
             anchor_token_ids = [int(req["anchor_token_id"]) for req in requests]
-            draft_tokens = self._run_query_block(
+            draft_tokens, draft_logits = self._run_query_block(
                 states,
                 anchor_positions,
                 anchor_token_ids,
@@ -1209,8 +1236,23 @@ class K3DSparkDraftEngine:
             sync_done = time.perf_counter()
             tokens = draft_tokens.cpu().tolist()
             tokens_copied = time.perf_counter()
+            logits_metadata = None
+            logits_frame = None
+            if return_logits:
+                assert draft_logits is not None
+                logits_metadata, logits_frame = _encode_bfloat16_logits_frame(
+                    draft_logits
+                )
+                logits_metadata["sample_positions"] = [
+                    [
+                        anchor_position + step + 1
+                        for step in range(num_speculative_tokens)
+                    ]
+                    for anchor_position in anchor_positions
+                ]
+            logits_copied = time.perf_counter()
             self.proposal_count += 1
-            self.last_latency_ms = (tokens_copied - started) * 1000
+            self.last_latency_ms = (logits_copied - started) * 1000
             timing_ms = {
                 "decode_frames": (decoded_at - started) * 1000,
                 "lock_wait": (lock_acquired - lock_started) * 1000,
@@ -1219,17 +1261,22 @@ class K3DSparkDraftEngine:
                 "gpu_query": context_end.elapsed_time(query_end),
                 "gpu_wait": (sync_done - submit_done) * 1000,
                 "tokens_d2h": (tokens_copied - sync_done) * 1000,
+                "logits_d2h": (logits_copied - tokens_copied) * 1000,
                 "total": self.last_latency_ms,
             }
             self._record_timing(timing_ms)
-        return {
+        response = {
             "ok": True,
             "protocol": PROTOCOL_VERSION,
             "tokens": tokens,
+            "logits": logits_metadata,
             "latency_ms": self.last_latency_ms,
             "timing_ms": timing_ms,
             "active_requests": self.allocator.active_requests,
         }
+        if logits_frame is not None:
+            response["_logits_frame"] = logits_frame
+        return response
 
 
 class K3DSparkZMQServer:
@@ -1288,6 +1335,9 @@ class K3DSparkZMQServer:
                 "cold_bootstrap_count": self.engine.cold_bootstrap_count,
                 "cuda_graph_enabled": self.engine.cuda_graph_enabled,
                 "cuda_graph_shapes": self.engine.cuda_graph_shapes,
+                "capabilities": (
+                    [LOGITS_CAPABILITY] if self.engine.method == "dflash" else []
+                ),
             }
         if op == "CLEAR":
             self.engine.clear()
@@ -1353,7 +1403,11 @@ class K3DSparkZMQServer:
                         "protocol": PROTOCOL_VERSION,
                         "error": f"{type(exc).__name__}: {exc}",
                     }
-                socket.send_json(response)
+                logits_frame = response.pop("_logits_frame", None)
+                if logits_frame is None:
+                    socket.send_json(response)
+                else:
+                    socket.send_multipart([json.dumps(response).encode(), logits_frame])
         except Exception as exc:
             self.error = f"{type(exc).__name__}: {exc}"
             logger.exception("K3 DSpark proposal server failed")

--- a/vllm/entrypoints/k3_dspark_rpc.py
+++ b/vllm/entrypoints/k3_dspark_rpc.py
@@ -1,0 +1,1363 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Host-staged RPC for a dedicated Kimi-K3 draft GPU.
+
+The verifier and RTX 3090 do not have CUDA peer access on the target host, so
+the first transport deliberately uses ZMQ multipart frames backed by host
+memory.  The protocol is small and versioned so a verifier-side proxy can be
+added without coupling the standalone process to the generic EAGLE draft
+server protocol.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import torch
+import zmq
+
+from vllm.config.vllm import set_current_vllm_config
+from vllm.forward_context import set_forward_context
+from vllm.logger import init_logger
+from vllm.model_executor.layers.attention.mla_attention import (
+    MLACommonDecodeMetadata,
+    MLACommonMetadata,
+)
+from vllm.v1.attention.backend import CommonAttentionMetadata
+from vllm.v1.worker.gpu.spec_decode.eagle.eagle3_utils import (
+    get_eagle3_aux_layers_from_config,
+)
+from vllm.v1.worker.gpu.spec_decode.utils import get_parallel_drafting_token_id
+
+if TYPE_CHECKING:
+    from vllm.entrypoints.k3_dspark_standalone import StandaloneRuntime
+
+logger = init_logger(__name__)
+
+PROTOCOL_VERSION = 2
+
+
+class ProjectedContextCache:
+    """Bounded, chunked cache of projected DSpark context states.
+
+    The standalone draft server keeps this cache on the draft device.  Keeping
+    the projected rows on CPU forced a blocking D2H copy after every proposal,
+    even though the rows are normally consumed again by the same GPU during a
+    prefix reconnect.  CPU remains the default for lightweight unit tests and
+    callers which explicitly want host storage.
+    """
+
+    def __init__(
+        self,
+        *,
+        hidden_size: int,
+        max_tokens: int,
+        chunk_size: int = 256,
+        initial_position: int = 0,
+        device: torch.device | str = "cpu",
+    ) -> None:
+        if hidden_size <= 0 or max_tokens <= 0 or chunk_size <= 0:
+            raise ValueError("Projected context cache dimensions must be positive")
+        if initial_position < 0:
+            raise ValueError("Projected context cache position cannot be negative")
+        self.hidden_size = hidden_size
+        self.max_tokens = max_tokens
+        self.chunk_size = chunk_size
+        self.device = torch.device(device)
+        self.start_position = initial_position
+        self.end_position = initial_position
+        self._chunks: dict[int, torch.Tensor] = {}
+
+    def _truncate(self, end_position: int) -> None:
+        if not self.start_position <= end_position <= self.end_position:
+            raise ValueError(
+                "Cannot truncate projected context outside its retained range: "
+                f"retained=[{self.start_position}, {self.end_position}), "
+                f"requested_end={end_position}"
+            )
+        first_discarded_chunk = (end_position + self.chunk_size - 1) // self.chunk_size
+        for chunk_idx in list(self._chunks):
+            if chunk_idx >= first_discarded_chunk:
+                del self._chunks[chunk_idx]
+        self.end_position = end_position
+
+    def append(self, first_position: int, states: torch.Tensor) -> None:
+        if states.device != self.device:
+            raise ValueError(
+                "Projected context cache device mismatch: "
+                f"cache={self.device}, states={states.device}"
+            )
+        if states.dtype != torch.bfloat16 or states.ndim != 2:
+            raise ValueError("Projected context states must be a 2D BF16 tensor")
+        if states.shape[1] != self.hidden_size:
+            raise ValueError(
+                f"Projected context width is {states.shape[1]}, expected "
+                f"{self.hidden_size}"
+            )
+        if first_position < self.start_position or first_position > self.end_position:
+            raise ValueError(
+                "Projected context append is not contiguous with retained state: "
+                f"retained=[{self.start_position}, {self.end_position}), "
+                f"first={first_position}"
+            )
+        if first_position < self.end_position:
+            self._truncate(first_position)
+
+        offset = 0
+        num_rows = int(states.shape[0])
+        while offset < num_rows:
+            position = first_position + offset
+            chunk_idx, chunk_offset = divmod(position, self.chunk_size)
+            count = min(num_rows - offset, self.chunk_size - chunk_offset)
+            chunk = self._chunks.get(chunk_idx)
+            if chunk is None:
+                chunk = torch.empty(
+                    (self.chunk_size, self.hidden_size),
+                    dtype=torch.bfloat16,
+                    device=self.device,
+                )
+                self._chunks[chunk_idx] = chunk
+            chunk[chunk_offset : chunk_offset + count].copy_(
+                states[offset : offset + count]
+            )
+            offset += count
+
+        self.end_position = first_position + num_rows
+        self.start_position = max(
+            self.start_position,
+            self.end_position - self.max_tokens,
+        )
+        for chunk_idx in list(self._chunks):
+            if (chunk_idx + 1) * self.chunk_size <= self.start_position:
+                del self._chunks[chunk_idx]
+
+    def has_range(self, start_position: int, end_position: int) -> bool:
+        return (
+            self.start_position <= start_position <= end_position <= self.end_position
+        )
+
+    def read(self, start_position: int, end_position: int) -> torch.Tensor:
+        if not self.has_range(start_position, end_position):
+            raise ValueError(
+                "Projected context range is unavailable: "
+                f"retained=[{self.start_position}, {self.end_position}), "
+                f"requested=[{start_position}, {end_position})"
+            )
+        output = torch.empty(
+            (end_position - start_position, self.hidden_size),
+            dtype=torch.bfloat16,
+            device=self.device,
+        )
+        offset = 0
+        while start_position + offset < end_position:
+            position = start_position + offset
+            chunk_idx, chunk_offset = divmod(position, self.chunk_size)
+            count = min(
+                end_position - position,
+                self.chunk_size - chunk_offset,
+            )
+            chunk = self._chunks.get(chunk_idx)
+            if chunk is None:
+                raise RuntimeError(
+                    f"Projected context chunk {chunk_idx} is unexpectedly missing"
+                )
+            output[offset : offset + count].copy_(
+                chunk[chunk_offset : chunk_offset + count]
+            )
+            offset += count
+        return output
+
+    def truncate(self, end_position: int) -> None:
+        if end_position < self.end_position:
+            self._truncate(end_position)
+
+    @property
+    def allocated_bytes(self) -> int:
+        return sum(
+            chunk.numel() * chunk.element_size() for chunk in self._chunks.values()
+        )
+
+
+@dataclass
+class DraftRequestState:
+    request_id: str
+    slot: int
+    committed_end: int = 0
+    context_start: int = 0
+    context_cache: ProjectedContextCache | None = None
+
+
+class DraftKVSlotAllocator:
+    """Assign fixed rolling MLA block ranges to a small request batch."""
+
+    def __init__(
+        self,
+        *,
+        num_cache_blocks: int,
+        block_size: int,
+        window_size: int,
+        max_requests: int,
+    ) -> None:
+        if window_size <= 0 or window_size % block_size != 0:
+            raise ValueError(
+                "DSpark KV window must be a positive block-size multiple, got "
+                f"window={window_size}, block_size={block_size}"
+            )
+        self.block_size = block_size
+        self.window_size = window_size
+        self.max_requests = max_requests
+        # The vLLM rolling window may retain window + block_size - 1 tokens
+        # while it waits for the next whole-block shift.
+        self.blocks_per_request = window_size // block_size + 1
+        required = 1 + max_requests * self.blocks_per_request
+        if required > num_cache_blocks:
+            raise ValueError(
+                "Dedicated draft KV cache is too small for the requested rolling "
+                f"slots: required_blocks={required}, available={num_cache_blocks}"
+            )
+        self._free_slots = list(range(max_requests))
+        self._states: dict[str, DraftRequestState] = {}
+
+    def get_or_allocate(self, request_id: str) -> tuple[DraftRequestState, bool]:
+        state = self._states.get(request_id)
+        if state is not None:
+            return state, False
+        if not self._free_slots:
+            raise RuntimeError(
+                f"DSpark request capacity exhausted (max={self.max_requests})"
+            )
+        slot = self._free_slots.pop(0)
+        state = DraftRequestState(request_id=request_id, slot=slot)
+        self._states[request_id] = state
+        return state, True
+
+    def free(self, request_id: str) -> DraftRequestState | None:
+        state = self._states.pop(request_id, None)
+        if state is not None:
+            self._free_slots.append(state.slot)
+            self._free_slots.sort()
+        return state
+
+    def get(self, request_id: str) -> DraftRequestState | None:
+        return self._states.get(request_id)
+
+    def rebind(self, source_request_id: str, request_id: str) -> DraftRequestState:
+        state = self._states.get(source_request_id)
+        if state is None:
+            raise KeyError(f"Unknown DSpark source request {source_request_id!r}")
+        if source_request_id == request_id:
+            return state
+        if request_id in self._states:
+            raise ValueError(f"DSpark request {request_id!r} already exists")
+        del self._states[source_request_id]
+        state.request_id = request_id
+        self._states[request_id] = state
+        return state
+
+    def physical_block(self, state: DraftRequestState, position: int) -> int:
+        absolute_block = position // self.block_size
+        return (
+            1
+            + state.slot * self.blocks_per_request
+            + absolute_block % self.blocks_per_request
+        )
+
+    def cache_slot(self, state: DraftRequestState, position: int) -> int:
+        return self.physical_block(state, position) * self.block_size + (
+            position % self.block_size
+        )
+
+    def block_table(
+        self, state: DraftRequestState, sequence_end: int
+    ) -> tuple[list[int], int]:
+        if sequence_end <= 0:
+            raise ValueError(f"sequence_end must be positive, got {sequence_end}")
+        first_block = (
+            max(state.context_start, sequence_end - self.window_size) // self.block_size
+        )
+        end_block = (sequence_end + self.block_size - 1) // self.block_size
+        blocks = [
+            1
+            + state.slot * self.blocks_per_request
+            + absolute_block % self.blocks_per_request
+            for absolute_block in range(first_block, end_block)
+        ]
+        local_sequence_len = sequence_end - first_block * self.block_size
+        if local_sequence_len > self.window_size + self.block_size - 1:
+            raise AssertionError("rolling DSpark sequence length exceeded its window")
+        if len(blocks) > self.blocks_per_request:
+            raise AssertionError("rolling DSpark block table aliases a live block")
+        return blocks, local_sequence_len
+
+    def physical_block_range(self, state: DraftRequestState) -> slice:
+        start = 1 + state.slot * self.blocks_per_request
+        return slice(start, start + self.blocks_per_request)
+
+    @property
+    def active_requests(self) -> int:
+        return len(self._states)
+
+    @property
+    def request_ids(self) -> list[str]:
+        return list(self._states)
+
+
+@dataclass
+class _DraftCudaGraphState:
+    """Persistent inputs and output for one standalone draft graph shape."""
+
+    batch_size: int
+    num_speculative_tokens: int
+    query_len: int
+    input_ids: torch.Tensor
+    positions: torch.Tensor
+    slots: torch.Tensor
+    seq_lens: torch.Tensor
+    block_table: torch.Tensor
+    output_tokens: torch.Tensor
+    input_ids_host: torch.Tensor
+    positions_host: torch.Tensor
+    slots_host: torch.Tensor
+    seq_lens_host: torch.Tensor
+    block_table_host: torch.Tensor
+    attn_metadata: dict[str, Any]
+    slot_mapping: dict[str, torch.Tensor]
+    graph: torch.cuda.CUDAGraph | None = None
+    captured_hidden: torch.Tensor | None = None
+    captured_logits: torch.Tensor | None = None
+
+    def stage(
+        self,
+        *,
+        input_ids: list[int],
+        positions: list[int],
+        slots: list[int],
+        block_rows: list[list[int]],
+        seq_lens: list[int],
+    ) -> None:
+        """Copy one request batch into address-stable graph inputs."""
+        expected_tokens = self.batch_size * self.query_len
+        if not (
+            len(input_ids) == len(positions) == len(slots) == expected_tokens
+            and len(block_rows) == len(seq_lens) == self.batch_size
+        ):
+            raise ValueError("Draft CUDA graph input shape mismatch")
+
+        self.input_ids_host.copy_(torch.tensor(input_ids, dtype=torch.int64))
+        self.positions_host.copy_(torch.tensor(positions, dtype=torch.int64))
+        self.slots_host.copy_(torch.tensor(slots, dtype=torch.int64))
+        self.seq_lens_host.copy_(torch.tensor(seq_lens, dtype=torch.int32))
+        self.block_table_host.zero_()
+        for row_idx, row in enumerate(block_rows):
+            if len(row) > self.block_table_host.shape[1]:
+                raise ValueError(
+                    "Draft block table exceeds CUDA graph capacity: "
+                    f"row={len(row)}, capacity={self.block_table_host.shape[1]}"
+                )
+            self.block_table_host[row_idx, : len(row)].copy_(
+                torch.tensor(row, dtype=torch.int32)
+            )
+
+        # All copies and the replay are enqueued on the same stream. The
+        # proposal's final query event synchronizes before these pinned host
+        # buffers can be reused by the next (serialized) RPC.
+        self.input_ids.copy_(self.input_ids_host, non_blocking=True)
+        self.positions.copy_(self.positions_host, non_blocking=True)
+        self.slots.copy_(self.slots_host, non_blocking=True)
+        self.seq_lens.copy_(self.seq_lens_host, non_blocking=True)
+        self.block_table.copy_(self.block_table_host, non_blocking=True)
+
+
+class K3DSparkDraftEngine:
+    """Minimal greedy K3 draft scheduler backed by the 3090 KV cache."""
+
+    def __init__(
+        self,
+        runtime: StandaloneRuntime,
+        *,
+        max_requests: int,
+        window_size: int,
+        device: torch.device,
+    ) -> None:
+        self.runtime = runtime
+        self.model = runtime.model
+        self.method = runtime.method
+        self.device = device
+        self.max_model_len = int(runtime.vllm_config.model_config.max_model_len)
+        first_cache = next(iter(runtime.kv_caches.values()))
+        self.allocator = DraftKVSlotAllocator(
+            num_cache_blocks=int(first_cache.shape[0]),
+            block_size=runtime.kv_cache_block_size,
+            window_size=window_size,
+            max_requests=max_requests,
+        )
+        speculative_config = runtime.vllm_config.speculative_config
+        assert speculative_config is not None
+        draft_config = speculative_config.draft_model_config.hf_config
+        self.hidden_size = int(draft_config.hidden_size)
+        aux_layers = get_eagle3_aux_layers_from_config(speculative_config)
+        if not aux_layers:
+            raise ValueError(
+                f"K3 {self.method} config does not declare target auxiliary layers"
+            )
+        self.num_aux_layers = len(aux_layers)
+        target_hidden_size = int(
+            getattr(draft_config, "target_hidden_size", None)
+            or draft_config.hidden_size
+        )
+        self.raw_context_width = int(target_hidden_size * self.num_aux_layers)
+        self.mask_token_id = get_parallel_drafting_token_id(draft_config)
+        self.max_speculative_tokens = int(
+            runtime.vllm_config.speculative_config.num_speculative_tokens
+        )
+        self.max_context_tokens = int(
+            runtime.vllm_config.scheduler_config.max_num_batched_tokens
+        )
+        self.prefix_cache_tokens = int(
+            os.environ.get(
+                "VLLM_K3_DRAFT_PREFIX_CACHE_TOKENS",
+                os.environ.get("VLLM_K3_DSPARK_PREFIX_CACHE_TOKENS", "131072"),
+            )
+        )
+        if self.prefix_cache_tokens < self.allocator.window_size:
+            raise ValueError(
+                "VLLM_K3_DRAFT_PREFIX_CACHE_TOKENS must be at least the "
+                f"draft KV window ({self.allocator.window_size}), got "
+                f"{self.prefix_cache_tokens}"
+            )
+        self._positions_staging = torch.empty(
+            self.max_context_tokens,
+            dtype=torch.int64,
+            pin_memory=True,
+        )
+        self._context_staging = torch.empty(
+            self.max_context_tokens * self.raw_context_width,
+            dtype=torch.bfloat16,
+            pin_memory=True,
+        )
+        self._lock = threading.Lock()
+        self.proposal_count = 0
+        self.last_latency_ms = 0.0
+        self.last_timing_ms: dict[str, float] = {}
+        self._timing_totals_ms: dict[str, float] = {}
+        self.cold_bootstrap_count = 0
+        self.reconnect_count = 0
+        self.last_reconnect_latency_ms = 0.0
+        self.cuda_graph_enabled = False
+        self.cuda_graph_capture_seconds = 0.0
+        self.cuda_graph_memory_gib = 0.0
+        self.cuda_graph_replay_count = 0
+        self.cuda_graph_eager_fallback_count = 0
+        self._cuda_graphs: dict[tuple[int, int], _DraftCudaGraphState] = {}
+
+    def _make_cuda_graph_state(
+        self,
+        batch_size: int,
+        num_speculative_tokens: int,
+    ) -> _DraftCudaGraphState:
+        if self.method == "dflash" and self.runtime.attn_metadata_builder is None:
+            raise RuntimeError("K3 DFlash attention metadata builder is missing")
+
+        query_len = (
+            num_speculative_tokens
+            if self.method == "dspark"
+            else 1 + num_speculative_tokens
+        )
+        num_tokens = batch_size * query_len
+        max_blocks = self.allocator.blocks_per_request
+        input_ids = torch.empty(num_tokens, dtype=torch.int64, device=self.device)
+        positions = torch.empty(num_tokens, dtype=torch.int64, device=self.device)
+        slots = torch.empty(num_tokens, dtype=torch.int64, device=self.device)
+        seq_lens = torch.empty(batch_size, dtype=torch.int32, device=self.device)
+        block_table = torch.zeros(
+            (batch_size, max_blocks), dtype=torch.int32, device=self.device
+        )
+        output_tokens = torch.empty(
+            (batch_size, num_speculative_tokens),
+            dtype=torch.int64,
+            device=self.device,
+        )
+
+        input_ids_host = torch.empty(num_tokens, dtype=torch.int64, pin_memory=True)
+        positions_host = torch.empty(num_tokens, dtype=torch.int64, pin_memory=True)
+        slots_host = torch.empty(num_tokens, dtype=torch.int64, pin_memory=True)
+        seq_lens_host = torch.empty(batch_size, dtype=torch.int32, pin_memory=True)
+        block_table_host = torch.zeros(
+            (batch_size, max_blocks), dtype=torch.int32, pin_memory=True
+        )
+
+        # The graph's launch topology is shape-static, while seq_lens remains
+        # a live tensor. Triton BF16 attention uses seq_lens to bound the KV
+        # scan; this conservative upper bound therefore does not force every
+        # replay to scan the full rolling window.
+        max_seq_len = self.allocator.window_size + self.allocator.block_size - 1
+        query_start_cpu = torch.arange(
+            0,
+            (batch_size + 1) * query_len,
+            query_len,
+            dtype=torch.int32,
+        )
+        query_start_gpu = query_start_cpu.to(self.device)
+        if self.method == "dflash":
+            common = CommonAttentionMetadata(
+                query_start_loc=query_start_gpu,
+                query_start_loc_cpu=query_start_cpu,
+                seq_lens=seq_lens,
+                seq_lens_cpu_upper_bound=torch.full(
+                    (batch_size,), max_seq_len, dtype=torch.int32
+                ),
+                max_seq_len=max_seq_len,
+                num_reqs=batch_size,
+                num_actual_tokens=num_tokens,
+                max_query_len=query_len,
+                block_table_tensor=block_table,
+                slot_mapping=slots,
+                causal=True,
+            )
+            assert self.runtime.attn_metadata_builder is not None
+            metadata = self.runtime.attn_metadata_builder.build(0, common)
+        else:
+            metadata = MLACommonMetadata(
+                num_reqs=batch_size,
+                max_query_len=query_len,
+                max_seq_len=max_seq_len,
+                num_actual_tokens=num_tokens,
+                query_start_loc=query_start_gpu,
+                slot_mapping=slots,
+                num_decodes=batch_size,
+                num_decode_tokens=num_tokens,
+                num_prefills=0,
+                causal=False,
+                head_dim=int(next(iter(self.runtime.kv_caches.values())).shape[-1]),
+                prefill=None,
+                decode=MLACommonDecodeMetadata(
+                    block_table=block_table,
+                    seq_lens=seq_lens,
+                    dcp_tot_seq_lens=None,
+                ),
+            )
+        attn_metadata = {layer_name: metadata for layer_name in self.runtime.kv_caches}
+        slot_mapping = {layer_name: slots for layer_name in self.runtime.kv_caches}
+        state = _DraftCudaGraphState(
+            batch_size=batch_size,
+            num_speculative_tokens=num_speculative_tokens,
+            query_len=query_len,
+            input_ids=input_ids,
+            positions=positions,
+            slots=slots,
+            seq_lens=seq_lens,
+            block_table=block_table,
+            output_tokens=output_tokens,
+            input_ids_host=input_ids_host,
+            positions_host=positions_host,
+            slots_host=slots_host,
+            seq_lens_host=seq_lens_host,
+            block_table_host=block_table_host,
+            attn_metadata=attn_metadata,
+            slot_mapping=slot_mapping,
+        )
+
+        # Seed capture with valid, isolated dummy sequences. Runtime replay
+        # overwrites every graph input before use.
+        dummy_input_ids: list[int] = []
+        dummy_positions: list[int] = []
+        dummy_slots: list[int] = []
+        dummy_rows: list[list[int]] = []
+        for request_idx in range(batch_size):
+            dummy_input_ids.append(0)
+            dummy_input_ids.extend([self.mask_token_id] * (query_len - 1))
+            dummy_positions.extend(range(query_len))
+            dummy_slots.extend(
+                request_idx * self.allocator.block_size + position
+                for position in range(query_len)
+            )
+            dummy_rows.append([request_idx])
+        state.stage(
+            input_ids=dummy_input_ids,
+            positions=dummy_positions,
+            slots=dummy_slots,
+            block_rows=dummy_rows,
+            seq_lens=[query_len] * batch_size,
+        )
+        return state
+
+    def _run_cuda_graph_state(
+        self,
+        state: _DraftCudaGraphState,
+    ) -> None:
+        num_tokens = state.batch_size * state.query_len
+        with (
+            set_current_vllm_config(self.runtime.draft_vllm_config),
+            set_forward_context(
+                state.attn_metadata,
+                self.runtime.draft_vllm_config,
+                num_tokens=num_tokens,
+                skip_compiled=True,
+                slot_mapping=state.slot_mapping,
+            ),
+        ):
+            hidden = self.model(
+                input_ids=state.input_ids,
+                positions=state.positions,
+            )
+        if self.method == "dflash":
+            sample_hidden = hidden.view(state.batch_size, state.query_len, -1)[:, 1:]
+            logits = self.model.compute_logits(
+                sample_hidden.reshape(
+                    state.batch_size * state.num_speculative_tokens, -1
+                )
+            )
+            state.output_tokens.copy_(
+                logits.argmax(dim=-1).view(
+                    state.batch_size, state.num_speculative_tokens
+                )
+            )
+        else:
+            logits = self.model.compute_draft_logits(hidden).view(
+                state.batch_size, state.query_len, -1
+            )
+            previous = state.input_ids.view(state.batch_size, state.query_len)[:, 0]
+            for step in range(state.query_len):
+                markov = self.model.markov_bias(self.model.markov_embed(previous))
+                previous = (logits[:, step] + markov).argmax(dim=-1)
+                state.output_tokens[:, step].copy_(previous)
+        # Retain graph-owned outputs so their backing allocations cannot be
+        # recycled while captured nodes still reference them.
+        state.captured_hidden = hidden
+        state.captured_logits = logits
+
+    @torch.inference_mode()
+    def capture_cuda_graphs(self, *, warmups: int = 2) -> None:
+        """Capture all DSpark or DFlash shapes selectable by this server."""
+        if warmups < 1:
+            raise ValueError("Draft CUDA graph capture requires at least one warmup")
+        if self._cuda_graphs:
+            return
+
+        started = time.perf_counter()
+        allocated_before = torch.cuda.memory_allocated(self.device)
+        capture_stream = torch.cuda.Stream(device=self.device)
+        capture_stream.wait_stream(torch.cuda.current_stream(self.device))
+        # Capture the largest shape first. Triton MLA grows shared workspace
+        # buffers on demand; capturing a smaller shape first and then resizing
+        # that workspace for B2/K3 leaves the earlier graph with stale device
+        # pointers and causes an illegal access on replay.
+        shapes = [
+            (batch_size, depth)
+            for batch_size in range(
+                self.runtime.vllm_config.scheduler_config.max_num_seqs,
+                0,
+                -1,
+            )
+            for depth in range(self.max_speculative_tokens, 0, -1)
+        ]
+        logger.info(
+            "Capturing %d standalone K3 %s CUDA graphs on %s: %s",
+            len(shapes),
+            self.method,
+            self.device,
+            ", ".join(f"B{batch_size}K{depth}" for batch_size, depth in shapes),
+        )
+        with torch.cuda.stream(capture_stream):
+            for batch_size, depth in shapes:
+                state = self._make_cuda_graph_state(batch_size, depth)
+                for _ in range(warmups):
+                    self._run_cuda_graph_state(state)
+                capture_stream.synchronize()
+
+                graph = torch.cuda.CUDAGraph()
+                with torch.cuda.graph(
+                    graph,
+                    stream=capture_stream,
+                ):
+                    self._run_cuda_graph_state(state)
+                state.graph = graph
+                self._cuda_graphs[(batch_size, depth)] = state
+
+        torch.cuda.current_stream(self.device).wait_stream(capture_stream)
+        torch.cuda.synchronize(self.device)
+        # Dummy capture rows only touch these reserved low blocks. Block zero
+        # is never assigned; live request allocation clears its own full range.
+        max_dummy_blocks = int(self.runtime.vllm_config.scheduler_config.max_num_seqs)
+        for cache in self.runtime.kv_caches.values():
+            cache[:max_dummy_blocks].zero_()
+        torch.cuda.synchronize(self.device)
+
+        self.cuda_graph_enabled = True
+        self.cuda_graph_capture_seconds = time.perf_counter() - started
+        self.cuda_graph_memory_gib = max(
+            0.0,
+            (torch.cuda.memory_allocated(self.device) - allocated_before) / 1024**3,
+        )
+        logger.info(
+            "Standalone K3 %s CUDA graphs ready in %.2fs; allocated_delta=%.3f GiB",
+            self.method,
+            self.cuda_graph_capture_seconds,
+            self.cuda_graph_memory_gib,
+        )
+
+    @property
+    def cuda_graph_shapes(self) -> list[str]:
+        return [
+            f"B{batch_size}K{depth}" for batch_size, depth in sorted(self._cuda_graphs)
+        ]
+
+    def _clear_state_cache(
+        self,
+        state: DraftRequestState,
+        *,
+        clear_context: bool = True,
+    ) -> None:
+        block_range = self.allocator.physical_block_range(state)
+        for cache in self.runtime.kv_caches.values():
+            cache[block_range].zero_()
+        state.committed_end = 0
+        state.context_start = 0
+        if clear_context:
+            state.context_cache = None
+
+    def reset(self, request_ids: list[str]) -> None:
+        with self._lock:
+            for request_id in request_ids:
+                state, _ = self.allocator.get_or_allocate(request_id)
+                self._clear_state_cache(state)
+
+    def free(self, request_ids: list[str]) -> None:
+        with self._lock:
+            for request_id in request_ids:
+                self.allocator.free(request_id)
+
+    def clear(self) -> None:
+        self.free(self.allocator.request_ids)
+
+    @property
+    def prefix_cache_bytes(self) -> int:
+        return sum(
+            state.context_cache.allocated_bytes
+            for request_id in self.allocator.request_ids
+            if (state := self.allocator.get(request_id)) is not None
+            and state.context_cache is not None
+        )
+
+    @property
+    def prefix_cache_host_bytes(self) -> int:
+        return sum(
+            state.context_cache.allocated_bytes
+            for request_id in self.allocator.request_ids
+            if (state := self.allocator.get(request_id)) is not None
+            and state.context_cache is not None
+            and state.context_cache.device.type == "cpu"
+        )
+
+    @property
+    def prefix_cache_device_bytes(self) -> int:
+        return self.prefix_cache_bytes - self.prefix_cache_host_bytes
+
+    @property
+    def mean_timing_ms(self) -> dict[str, float]:
+        if self.proposal_count <= 0:
+            return {}
+        return {
+            key: value / self.proposal_count
+            for key, value in self._timing_totals_ms.items()
+        }
+
+    def _record_timing(self, timing_ms: dict[str, float]) -> None:
+        self.last_timing_ms = timing_ms
+        for key, value in timing_ms.items():
+            self._timing_totals_ms[key] = self._timing_totals_ms.get(key, 0.0) + value
+
+    def _restore_projected_context(
+        self,
+        state: DraftRequestState,
+        prefix_end: int,
+    ) -> int:
+        context_cache = state.context_cache
+        if context_cache is None:
+            raise ValueError(
+                f"No projected context is retained for {state.request_id!r}"
+            )
+        restore_start = max(0, prefix_end - self.allocator.window_size)
+        restore_start = (
+            restore_start // self.allocator.block_size * self.allocator.block_size
+        )
+        if not context_cache.has_range(restore_start, prefix_end):
+            raise ValueError(
+                f"Projected context for {state.request_id!r} cannot restore "
+                f"prefix_end={prefix_end}; retained="
+                f"[{context_cache.start_position}, {context_cache.end_position})"
+            )
+
+        self._clear_state_cache(state, clear_context=False)
+        for start in range(restore_start, prefix_end, self.max_context_tokens):
+            end = min(prefix_end, start + self.max_context_tokens)
+            context_states = context_cache.read(start, end)
+            positions = torch.arange(start, end, dtype=torch.int64)
+            context_gpu = context_states.to(self.device, non_blocking=True)
+            positions_gpu = positions.to(self.device, non_blocking=True)
+            slots = torch.tensor(
+                [
+                    self.allocator.cache_slot(state, position)
+                    for position in range(start, end)
+                ],
+                dtype=torch.int64,
+                device=self.device,
+            )
+            self.model.precompute_and_store_context_kv(
+                context_gpu,
+                positions_gpu,
+                slots,
+            )
+        state.committed_end = prefix_end
+        state.context_start = restore_start
+        context_cache.truncate(prefix_end)
+        return restore_start
+
+    def reconnect(
+        self,
+        source_request_id: str,
+        request_id: str,
+        prefix_end: int,
+    ) -> dict[str, Any]:
+        started = time.perf_counter()
+        with self._lock:
+            state = self.allocator.get(source_request_id)
+            if state is None:
+                raise KeyError(f"Unknown DSpark source request {source_request_id!r}")
+            context_cache = state.context_cache
+            restore_start = max(0, prefix_end - self.allocator.window_size)
+            restore_start = (
+                restore_start // self.allocator.block_size * self.allocator.block_size
+            )
+            if (
+                prefix_end <= 0
+                or context_cache is None
+                or not context_cache.has_range(restore_start, prefix_end)
+            ):
+                retained = (
+                    None
+                    if context_cache is None
+                    else [context_cache.start_position, context_cache.end_position]
+                )
+                raise ValueError(
+                    f"Cannot reconnect {source_request_id!r} at {prefix_end}; "
+                    f"retained={retained}"
+                )
+            state = self.allocator.rebind(source_request_id, request_id)
+            restored_start = self._restore_projected_context(state, prefix_end)
+            torch.accelerator.synchronize()
+            self.reconnect_count += 1
+            self.last_reconnect_latency_ms = (time.perf_counter() - started) * 1000
+            return {
+                "ok": True,
+                "protocol": PROTOCOL_VERSION,
+                "request_id": request_id,
+                "restored_start": restored_start,
+                "prefix_end": prefix_end,
+                "latency_ms": self.last_reconnect_latency_ms,
+                "active_requests": self.allocator.active_requests,
+            }
+
+    def _decode_host_tensor(
+        self,
+        frame: bytes,
+        *,
+        dtype: torch.dtype,
+        shape: tuple[int, ...],
+    ) -> torch.Tensor:
+        element_size = torch.tensor([], dtype=dtype).element_size()
+        expected = element_size
+        for dim in shape:
+            expected *= dim
+        if len(frame) != expected:
+            raise ValueError(
+                f"Tensor frame has {len(frame)} bytes, expected {expected} for "
+                f"shape={shape}, dtype={dtype}"
+            )
+        source = torch.frombuffer(frame, dtype=dtype)
+        if dtype == torch.int64:
+            staging = self._positions_staging
+        elif dtype == torch.bfloat16:
+            staging = self._context_staging
+        else:
+            raise TypeError(f"Unsupported DSpark RPC tensor dtype: {dtype}")
+        if source.numel() > staging.numel():
+            raise ValueError(
+                f"Tensor frame exceeds pinned staging capacity: "
+                f"elements={source.numel()}, capacity={staging.numel()}"
+            )
+        output = staging[: source.numel()]
+        output.copy_(source)
+        return output.view(shape)
+
+    def _append_context(
+        self,
+        states: list[DraftRequestState],
+        context_counts: list[int],
+        positions_cpu: torch.Tensor,
+        context_cpu: torch.Tensor,
+        *,
+        projected: bool,
+    ) -> None:
+        if positions_cpu.numel() == 0:
+            return
+        positions = positions_cpu.to(self.device, non_blocking=True)
+        context_input = context_cpu.to(self.device, non_blocking=True)
+        context_states = (
+            context_input
+            if projected
+            else self.model.combine_hidden_states(context_input)
+        )
+
+        slots: list[int] = []
+        offset = 0
+        for state, count in zip(states, context_counts):
+            req_positions = positions_cpu[offset : offset + count]
+            if count:
+                first = int(req_positions[0])
+                if first > state.committed_end:
+                    raise ValueError(
+                        f"Context gap for {state.request_id!r}: "
+                        f"expected <= {state.committed_end}, got {first}"
+                    )
+                expected = torch.arange(first, first + count, dtype=torch.int64)
+                if not torch.equal(req_positions, expected):
+                    raise ValueError(
+                        f"Context positions for {state.request_id!r} are not contiguous"
+                    )
+                state.committed_end = int(req_positions[-1]) + 1
+                slots.extend(
+                    self.allocator.cache_slot(state, int(position))
+                    for position in req_positions
+                )
+            offset += count
+        slot_mapping = torch.tensor(slots, dtype=torch.int64, device=self.device)
+        self.model.precompute_and_store_context_kv(
+            context_states,
+            positions,
+            slot_mapping,
+        )
+        offset = 0
+        for state, count in zip(states, context_counts):
+            if count:
+                first_position = int(positions_cpu[offset])
+                if state.context_cache is None:
+                    state.context_cache = ProjectedContextCache(
+                        hidden_size=self.hidden_size,
+                        max_tokens=self.prefix_cache_tokens,
+                        initial_position=first_position,
+                        device=self.device,
+                    )
+                state.context_cache.append(
+                    first_position,
+                    context_states[offset : offset + count],
+                )
+            offset += count
+
+    def _run_query_block(
+        self,
+        states: list[DraftRequestState],
+        anchor_positions: list[int],
+        anchor_token_ids: list[int],
+        num_speculative_tokens: int,
+    ) -> torch.Tensor:
+        batch_size = len(states)
+        sample_from_anchor = self.method == "dspark"
+        query_len = (
+            num_speculative_tokens if sample_from_anchor else 1 + num_speculative_tokens
+        )
+        input_ids: list[int] = []
+        positions: list[int] = []
+        slots: list[int] = []
+        block_rows: list[list[int]] = []
+        seq_lens: list[int] = []
+
+        for state, anchor_position, anchor_token_id in zip(
+            states, anchor_positions, anchor_token_ids
+        ):
+            if anchor_position != state.committed_end:
+                raise ValueError(
+                    f"Anchor position for {state.request_id!r} must equal the "
+                    f"committed context end ({state.committed_end}), got "
+                    f"{anchor_position}"
+                )
+            sequence_end = anchor_position + query_len
+            if sequence_end > self.max_model_len:
+                raise ValueError(
+                    f"Draft query exceeds max_model_len={self.max_model_len}: "
+                    f"end={sequence_end}"
+                )
+            input_ids.append(anchor_token_id)
+            input_ids.extend([self.mask_token_id] * (query_len - 1))
+            req_positions = range(anchor_position, sequence_end)
+            positions.extend(req_positions)
+            slots.extend(
+                self.allocator.cache_slot(state, position)
+                for position in range(anchor_position, sequence_end)
+            )
+            row, local_seq_len = self.allocator.block_table(state, sequence_end)
+            block_rows.append(row)
+            seq_lens.append(local_seq_len)
+
+        if self.cuda_graph_enabled:
+            graph_state = self._cuda_graphs.get((batch_size, num_speculative_tokens))
+            if graph_state is not None:
+                graph_state.stage(
+                    input_ids=input_ids,
+                    positions=positions,
+                    slots=slots,
+                    block_rows=block_rows,
+                    seq_lens=seq_lens,
+                )
+                assert graph_state.graph is not None
+                graph_state.graph.replay()
+                self.cuda_graph_replay_count += 1
+                return graph_state.output_tokens
+            self.cuda_graph_eager_fallback_count += 1
+
+        max_blocks = max(len(row) for row in block_rows)
+        block_table = torch.zeros(
+            (batch_size, max_blocks), dtype=torch.int32, device=self.device
+        )
+        for row_idx, row in enumerate(block_rows):
+            block_table[row_idx, : len(row)] = torch.tensor(
+                row, dtype=torch.int32, device=self.device
+            )
+        input_ids_gpu = torch.tensor(input_ids, dtype=torch.int64, device=self.device)
+        positions_gpu = torch.tensor(positions, dtype=torch.int64, device=self.device)
+        slots_gpu = torch.tensor(slots, dtype=torch.int64, device=self.device)
+        seq_lens_gpu = torch.tensor(seq_lens, dtype=torch.int32, device=self.device)
+        query_start_loc = torch.arange(
+            0,
+            (batch_size + 1) * query_len,
+            query_len,
+            dtype=torch.int32,
+            device=self.device,
+        )
+        if self.method == "dflash":
+            query_start_loc_cpu = torch.arange(
+                0,
+                (batch_size + 1) * query_len,
+                query_len,
+                dtype=torch.int32,
+            )
+            common = CommonAttentionMetadata(
+                query_start_loc=query_start_loc,
+                query_start_loc_cpu=query_start_loc_cpu,
+                seq_lens=seq_lens_gpu,
+                seq_lens_cpu_upper_bound=torch.tensor(seq_lens, dtype=torch.int32),
+                max_seq_len=max(seq_lens),
+                num_reqs=batch_size,
+                num_actual_tokens=batch_size * query_len,
+                max_query_len=query_len,
+                block_table_tensor=block_table,
+                slot_mapping=slots_gpu,
+                causal=True,
+            )
+            if self.runtime.attn_metadata_builder is None:
+                raise RuntimeError("K3 DFlash attention metadata builder is missing")
+            metadata = self.runtime.attn_metadata_builder.build(0, common)
+        else:
+            metadata = MLACommonMetadata(
+                num_reqs=batch_size,
+                max_query_len=query_len,
+                max_seq_len=max(seq_lens),
+                num_actual_tokens=batch_size * query_len,
+                query_start_loc=query_start_loc,
+                slot_mapping=slots_gpu,
+                num_decodes=batch_size,
+                num_decode_tokens=batch_size * query_len,
+                num_prefills=0,
+                causal=False,
+                head_dim=int(next(iter(self.runtime.kv_caches.values())).shape[-1]),
+                prefill=None,
+                decode=MLACommonDecodeMetadata(
+                    block_table=block_table,
+                    seq_lens=seq_lens_gpu,
+                    dcp_tot_seq_lens=None,
+                ),
+            )
+        attn_metadata = {layer_name: metadata for layer_name in self.runtime.kv_caches}
+        slot_mapping = {layer_name: slots_gpu for layer_name in self.runtime.kv_caches}
+        with (
+            set_current_vllm_config(self.runtime.draft_vllm_config),
+            set_forward_context(
+                attn_metadata,
+                self.runtime.draft_vllm_config,
+                num_tokens=batch_size * query_len,
+                skip_compiled=True,
+                slot_mapping=slot_mapping,
+            ),
+        ):
+            hidden = self.model(input_ids=input_ids_gpu, positions=positions_gpu)
+
+        if self.method == "dflash":
+            sample_hidden = hidden.view(batch_size, query_len, -1)[:, 1:]
+            return (
+                self.model.compute_logits(
+                    sample_hidden.reshape(batch_size * num_speculative_tokens, -1)
+                )
+                .argmax(dim=-1)
+                .view(batch_size, num_speculative_tokens)
+            )
+
+        base_logits = self.model.compute_draft_logits(hidden).view(
+            batch_size, query_len, -1
+        )
+        previous = torch.tensor(anchor_token_ids, dtype=torch.int64, device=self.device)
+        draft_tokens = torch.empty(
+            (batch_size, query_len), dtype=torch.int64, device=self.device
+        )
+        for step in range(query_len):
+            markov = self.model.markov_bias(self.model.markov_embed(previous))
+            previous = (base_logits[:, step] + markov).argmax(dim=-1)
+            draft_tokens[:, step].copy_(previous)
+        return draft_tokens
+
+    @torch.inference_mode()
+    def propose(self, header: dict[str, Any], frames: list[bytes]) -> dict[str, Any]:
+        started = time.perf_counter()
+        requests = header.get("requests")
+        if not isinstance(requests, list) or not requests:
+            raise ValueError("PROPOSE requires a non-empty requests list")
+        if len(requests) > self.allocator.max_requests:
+            raise ValueError(
+                f"Batch has {len(requests)} requests, max is "
+                f"{self.allocator.max_requests}"
+            )
+        num_speculative_tokens = int(
+            header.get("num_speculative_tokens", self.max_speculative_tokens)
+        )
+        if not 1 <= num_speculative_tokens <= self.max_speculative_tokens:
+            raise ValueError(
+                f"num_speculative_tokens must be in [1, {self.max_speculative_tokens}]"
+            )
+        projected = bool(header.get("projected", False))
+        context_counts = [int(req.get("context_count", 0)) for req in requests]
+        if any(count < 0 for count in context_counts):
+            raise ValueError("context_count cannot be negative")
+        total_context = sum(context_counts)
+        expected_frames = 2 if total_context else 0
+        if len(frames) != expected_frames:
+            raise ValueError(
+                f"PROPOSE expected {expected_frames} tensor frames, got {len(frames)}"
+            )
+        context_width = self.hidden_size if projected else self.raw_context_width
+        if total_context:
+            positions_cpu = self._decode_host_tensor(
+                frames[0], dtype=torch.int64, shape=(total_context,)
+            )
+            context_cpu = self._decode_host_tensor(
+                frames[1],
+                dtype=torch.bfloat16,
+                shape=(total_context, context_width),
+            )
+        else:
+            positions_cpu = torch.empty(0, dtype=torch.int64)
+            context_cpu = torch.empty((0, context_width), dtype=torch.bfloat16)
+        decoded_at = time.perf_counter()
+
+        lock_started = time.perf_counter()
+        with self._lock:
+            lock_acquired = time.perf_counter()
+            gpu_start = torch.cuda.Event(enable_timing=True)
+            context_end = torch.cuda.Event(enable_timing=True)
+            query_end = torch.cuda.Event(enable_timing=True)
+            gpu_start.record()
+            states: list[DraftRequestState] = []
+            for req in requests:
+                request_id = req.get("request_id")
+                if not isinstance(request_id, str) or not request_id:
+                    raise ValueError("Every request requires a non-empty request_id")
+                state, created = self.allocator.get_or_allocate(request_id)
+                if bool(req.get("reset", False)) or created:
+                    self._clear_state_cache(state)
+                    reset_position = int(req.get("reset_position", 0))
+                    if not 0 <= reset_position <= self.max_model_len:
+                        raise ValueError(
+                            "Draft reset_position must be in model bounds, got "
+                            f"{reset_position}"
+                        )
+                    state.committed_end = reset_position
+                    state.context_start = reset_position
+                    if reset_position:
+                        self.cold_bootstrap_count += 1
+                states.append(state)
+            self._append_context(
+                states,
+                context_counts,
+                positions_cpu,
+                context_cpu,
+                projected=projected,
+            )
+            context_end.record()
+            anchor_positions = [int(req["anchor_position"]) for req in requests]
+            anchor_token_ids = [int(req["anchor_token_id"]) for req in requests]
+            draft_tokens = self._run_query_block(
+                states,
+                anchor_positions,
+                anchor_token_ids,
+                num_speculative_tokens,
+            )
+            query_end.record()
+            submit_done = time.perf_counter()
+            query_end.synchronize()
+            sync_done = time.perf_counter()
+            tokens = draft_tokens.cpu().tolist()
+            tokens_copied = time.perf_counter()
+            self.proposal_count += 1
+            self.last_latency_ms = (tokens_copied - started) * 1000
+            timing_ms = {
+                "decode_frames": (decoded_at - started) * 1000,
+                "lock_wait": (lock_acquired - lock_started) * 1000,
+                "host_submit": (submit_done - lock_acquired) * 1000,
+                "gpu_context": gpu_start.elapsed_time(context_end),
+                "gpu_query": context_end.elapsed_time(query_end),
+                "gpu_wait": (sync_done - submit_done) * 1000,
+                "tokens_d2h": (tokens_copied - sync_done) * 1000,
+                "total": self.last_latency_ms,
+            }
+            self._record_timing(timing_ms)
+        return {
+            "ok": True,
+            "protocol": PROTOCOL_VERSION,
+            "tokens": tokens,
+            "latency_ms": self.last_latency_ms,
+            "timing_ms": timing_ms,
+            "active_requests": self.allocator.active_requests,
+        }
+
+
+class K3DSparkZMQServer:
+    def __init__(
+        self,
+        engine: K3DSparkDraftEngine,
+        *,
+        address: str,
+        stop: threading.Event,
+    ) -> None:
+        self.engine = engine
+        self.address = address
+        self.stop = stop
+        self.ready = threading.Event()
+        self.error: str | None = None
+        self._thread = threading.Thread(
+            target=self._run,
+            name="k3-draft-zmq",
+            daemon=True,
+        )
+
+    def start(self) -> None:
+        self._thread.start()
+        if not self.ready.wait(timeout=10):
+            raise TimeoutError(f"K3 draft proposal socket did not bind: {self.address}")
+        if self.error is not None:
+            raise RuntimeError(self.error)
+
+    def join(self, timeout: float = 5.0) -> None:
+        self._thread.join(timeout=timeout)
+
+    def _handle(self, parts: list[bytes]) -> dict[str, Any]:
+        if not parts:
+            raise ValueError("Empty DSpark RPC message")
+        header = json.loads(parts[0])
+        if not isinstance(header, dict):
+            raise ValueError("DSpark RPC header must be a JSON object")
+        if int(header.get("protocol", -1)) != PROTOCOL_VERSION:
+            raise ValueError(
+                f"Unsupported protocol {header.get('protocol')}; "
+                f"expected {PROTOCOL_VERSION}"
+            )
+        op = str(header.get("op", "")).upper()
+        if op == "PING":
+            return {
+                "ok": True,
+                "protocol": PROTOCOL_VERSION,
+                "op": "PONG",
+                "method": self.engine.method,
+                "active_requests": self.engine.allocator.active_requests,
+                "max_requests": self.engine.allocator.max_requests,
+                "block_size": self.engine.allocator.block_size,
+                "window_size": self.engine.allocator.window_size,
+                "prefix_cache_tokens": self.engine.prefix_cache_tokens,
+                "prefix_cache_device": str(self.engine.device),
+                "cold_bootstrap_count": self.engine.cold_bootstrap_count,
+                "cuda_graph_enabled": self.engine.cuda_graph_enabled,
+                "cuda_graph_shapes": self.engine.cuda_graph_shapes,
+            }
+        if op == "CLEAR":
+            self.engine.clear()
+            return {
+                "ok": True,
+                "protocol": PROTOCOL_VERSION,
+                "active_requests": 0,
+            }
+        if op in ("RESET", "FREE"):
+            request_ids = header.get("request_ids")
+            if not isinstance(request_ids, list) or not all(
+                isinstance(req_id, str) and req_id for req_id in request_ids
+            ):
+                raise ValueError(f"{op} requires request_ids: list[str]")
+            if op == "RESET":
+                self.engine.reset(request_ids)
+            else:
+                self.engine.free(request_ids)
+            return {
+                "ok": True,
+                "protocol": PROTOCOL_VERSION,
+                "active_requests": self.engine.allocator.active_requests,
+            }
+        if op == "RECONNECT":
+            source_request_id = header.get("source_request_id")
+            request_id = header.get("request_id")
+            if not isinstance(source_request_id, str) or not source_request_id:
+                raise ValueError("RECONNECT requires source_request_id")
+            if not isinstance(request_id, str) or not request_id:
+                raise ValueError("RECONNECT requires request_id")
+            return self.engine.reconnect(
+                source_request_id,
+                request_id,
+                int(header.get("prefix_end", 0)),
+            )
+        if op == "PROPOSE":
+            return self.engine.propose(header, parts[1:])
+        raise ValueError(f"Unknown K3 draft RPC operation: {op!r}")
+
+    def _run(self) -> None:
+        context = zmq.Context()
+        socket = context.socket(zmq.REP)
+        socket.setsockopt(zmq.LINGER, 0)
+        try:
+            socket.bind(self.address)
+            logger.info(
+                "K3 %s proposal RPC listening on %s",
+                self.engine.method,
+                self.address,
+            )
+            self.ready.set()
+            poller = zmq.Poller()
+            poller.register(socket, zmq.POLLIN)
+            while not self.stop.is_set():
+                if not dict(poller.poll(250)).get(socket):
+                    continue
+                try:
+                    response = self._handle(socket.recv_multipart())
+                except Exception as exc:
+                    logger.exception("K3 DSpark proposal request failed")
+                    response = {
+                        "ok": False,
+                        "protocol": PROTOCOL_VERSION,
+                        "error": f"{type(exc).__name__}: {exc}",
+                    }
+                socket.send_json(response)
+        except Exception as exc:
+            self.error = f"{type(exc).__name__}: {exc}"
+            logger.exception("K3 DSpark proposal server failed")
+            self.ready.set()
+        finally:
+            socket.close()
+            context.term()

--- a/vllm/entrypoints/k3_dspark_rpc.py
+++ b/vllm/entrypoints/k3_dspark_rpc.py
@@ -35,7 +35,10 @@ from vllm.v1.attention.backend import CommonAttentionMetadata
 from vllm.v1.worker.gpu.spec_decode.eagle.eagle3_utils import (
     get_eagle3_aux_layers_from_config,
 )
-from vllm.v1.worker.gpu.spec_decode.utils import get_parallel_drafting_token_id
+from vllm.v1.worker.gpu.spec_decode.utils import (
+    draft_query_len,
+    get_parallel_drafting_token_id,
+)
 
 if TYPE_CHECKING:
     from vllm.entrypoints.k3_dspark_standalone import StandaloneRuntime
@@ -473,6 +476,25 @@ class _DraftCudaGraphState:
         self.block_table.copy_(self.block_table_host, non_blocking=True)
 
 
+def _required_int_field(request: dict[str, Any], name: str) -> int:
+    """Return an integer request field, rejecting a missing or non-integer one.
+
+    Args:
+        request: One PROPOSE request header entry.
+        name: Field name.
+
+    Returns:
+        The field value as ``int``.
+
+    Raises:
+        ValueError: The field is absent or not an integer.
+    """
+    value = request.get(name)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"PROPOSE request field {name!r} must be an integer")
+    return value
+
+
 class K3DSparkDraftEngine:
     """Minimal greedy K3 draft scheduler backed by the 3090 KV cache."""
 
@@ -865,10 +887,12 @@ class K3DSparkDraftEngine:
             state.context_cache = None
 
     def reset(self, request_ids: list[str]) -> None:
+        """Drop the retained state of known requests; unknown ids are no-ops."""
         with self._lock:
             for request_id in request_ids:
-                state, _ = self.allocator.get_or_allocate(request_id)
-                self._clear_state_cache(state)
+                state = self.allocator.get(request_id)
+                if state is not None:
+                    self._clear_state_cache(state)
 
     def free(self, request_ids: list[str]) -> None:
         with self._lock:
@@ -931,6 +955,11 @@ class K3DSparkDraftEngine:
         for key, value in timing_ms.items():
             self._timing_totals_ms[key] = self._timing_totals_ms.get(key, 0.0) + value
 
+    def _window_restore_start(self, prefix_end: int) -> int:
+        """Return the block-aligned first position a window restore rebuilds."""
+        start = max(0, prefix_end - self.allocator.window_size)
+        return start // self.allocator.block_size * self.allocator.block_size
+
     def _restore_projected_context(
         self,
         state: DraftRequestState,
@@ -941,10 +970,7 @@ class K3DSparkDraftEngine:
             raise ValueError(
                 f"No projected context is retained for {state.request_id!r}"
             )
-        restore_start = max(0, prefix_end - self.allocator.window_size)
-        restore_start = (
-            restore_start // self.allocator.block_size * self.allocator.block_size
-        )
+        restore_start = self._window_restore_start(prefix_end)
         if not context_cache.has_range(restore_start, prefix_end):
             raise ValueError(
                 f"Projected context for {state.request_id!r} cannot restore "
@@ -985,10 +1011,7 @@ class K3DSparkDraftEngine:
             if state is None:
                 raise KeyError(f"Unknown DSpark source request {source_request_id!r}")
             context_cache = state.context_cache
-            restore_start = max(0, prefix_end - self.allocator.window_size)
-            restore_start = (
-                restore_start // self.allocator.block_size * self.allocator.block_size
-            )
+            restore_start = self._window_restore_start(prefix_end)
             if (
                 prefix_end <= 0
                 or context_cache is None
@@ -1121,10 +1144,7 @@ class K3DSparkDraftEngine:
         num_speculative_tokens: int,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         batch_size = len(states)
-        sample_from_anchor = self.method == "dspark"
-        query_len = (
-            num_speculative_tokens if sample_from_anchor else 1 + num_speculative_tokens
-        )
+        query_len = draft_query_len(self.method, num_speculative_tokens)
         input_ids: list[int] = []
         positions: list[int] = []
         slots: list[int] = []
@@ -1367,8 +1387,12 @@ class K3DSparkDraftEngine:
                 projected=projected,
             )
             context_end.record()
-            anchor_positions = [int(req["anchor_position"]) for req in requests]
-            anchor_token_ids = [int(req["anchor_token_id"]) for req in requests]
+            anchor_positions = [
+                _required_int_field(req, "anchor_position") for req in requests
+            ]
+            anchor_token_ids = [
+                _required_int_field(req, "anchor_token_id") for req in requests
+            ]
             draft_tokens, draft_logits = self._run_query_block(
                 states,
                 anchor_positions,
@@ -1483,6 +1507,7 @@ class K3DSparkZMQServer:
                 "max_requests": self.engine.allocator.max_requests,
                 "max_batch_size": self.engine.max_batch_size,
                 "max_speculative_tokens": self.engine.max_speculative_tokens,
+                "max_context_tokens": self.engine.max_context_tokens,
                 "block_size": self.engine.allocator.block_size,
                 "window_size": self.engine.allocator.window_size,
                 "prefix_cache_tokens": self.engine.prefix_cache_tokens,
@@ -1555,8 +1580,11 @@ class K3DSparkZMQServer:
             while not self.stop.is_set():
                 if not dict(poller.poll(250)).get(socket):
                     continue
+                # A REP socket may reply only after a receive succeeded, so a
+                # receive failure is a transport failure, not a request error.
+                parts = socket.recv_multipart()
                 try:
-                    response = self._handle(socket.recv_multipart())
+                    response = self._handle(parts)
                 except Exception as exc:
                     logger.exception("K3 DSpark proposal request failed")
                     response = {
@@ -1573,6 +1601,10 @@ class K3DSparkZMQServer:
             self.error = f"{type(exc).__name__}: {exc}"
             logger.exception("K3 DSpark proposal server failed")
             self.ready.set()
+            # Without a proposal loop the process serves nothing; stopping it
+            # makes the failure visible to the supervisor instead of leaving
+            # a status endpoint that still reports the transport as ready.
+            self.stop.set()
         finally:
             socket.close()
             context.term()

--- a/vllm/entrypoints/k3_dspark_standalone.py
+++ b/vllm/entrypoints/k3_dspark_standalone.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import signal
 import threading
 import time
@@ -38,6 +39,66 @@ logger = init_logger(__name__)
 EMBED_TENSOR = "language_model.model.embed_tokens.weight"
 LM_HEAD_TENSOR = "language_model.lm_head.weight"
 SHARED_TENSORS = (EMBED_TENSOR, LM_HEAD_TENSOR)
+DRAFT_KV_BLOCK_SIZE = 16
+
+
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("value must be at least 1")
+    return parsed
+
+
+def _non_negative_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("value must be non-negative")
+    return parsed
+
+
+def _positive_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed) or parsed <= 0:
+        raise argparse.ArgumentTypeError("value must be positive and finite")
+    return parsed
+
+
+def _positive_block_multiple(value: str) -> int:
+    parsed = _positive_int(value)
+    if parsed % DRAFT_KV_BLOCK_SIZE != 0:
+        raise argparse.ArgumentTypeError(
+            f"value must be a multiple of {DRAFT_KV_BLOCK_SIZE}"
+        )
+    return parsed
+
+
+def _tcp_port(value: str) -> int:
+    parsed = int(value)
+    if not 1 <= parsed <= 65535:
+        raise argparse.ArgumentTypeError("port must be in [1, 65535]")
+    return parsed
+
+
+def _validate_single_block_smoke_span(
+    context_len: int,
+    query_len: int,
+    block_size: int,
+) -> None:
+    """Ensure the DSpark smoke test's one-row block table is sufficient."""
+    if context_len < 0 or query_len < 1 or block_size < 1:
+        raise ValueError("Smoke-test context, query, and block sizes are invalid")
+    if context_len + query_len > block_size:
+        raise ValueError(
+            "DSpark smoke sequence exceeds its single mapped KV block: "
+            f"context={context_len}, query={query_len}, block_size={block_size}"
+        )
+
+
+def _status_http_code(path: str, ready: bool) -> int:
+    """Keep liveness independent from model readiness."""
+    if path == "/healthz":
+        return 200
+    return 200 if ready else 503
 
 
 @dataclass
@@ -57,6 +118,7 @@ class RuntimeStatus:
     allocated_gib: float = 0.0
     reserved_gib: float = 0.0
     draft_kv_cache_gib: float = 0.0
+    draft_prefix_cache_gib: float = 0.0
     draft_kv_cache_blocks: int = 0
     draft_kv_cache_token_capacity: int = 0
     draft_kv_cache_smoke: bool = False
@@ -244,7 +306,7 @@ def _build_vllm_config(args: argparse.Namespace):
         decode_context_parallel_size=1,
         max_num_batched_tokens=args.max_num_batched_tokens,
         max_num_seqs=args.max_num_seqs,
-        block_size=16,
+        block_size=DRAFT_KV_BLOCK_SIZE,
         enable_prefix_caching=False,
         enforce_eager=True,
         compilation_config={"custom_ops": ["none"]},
@@ -423,6 +485,11 @@ def _load_runtime(args: argparse.Namespace, status: RuntimeStatus) -> Standalone
 
         status.phase = "allocating_draft_kv_cache"
         block_size = int(vllm_config.cache_config.block_size)
+        if args.draft_kv_window % block_size != 0:
+            raise ValueError(
+                "--draft-kv-window must be a cache-block multiple: "
+                f"window={args.draft_kv_window}, block_size={block_size}"
+            )
         kv_caches, num_blocks = _allocate_draft_kv_cache(
             model,
             method=args.method,
@@ -496,6 +563,11 @@ def _run_eager_smoke(runtime: StandaloneRuntime, device: torch.device) -> int:
     query_len = runtime.vllm_config.speculative_config.num_speculative_tokens
     if not sample_from_anchor:
         query_len += 1
+    _validate_single_block_smoke_span(
+        context_len,
+        query_len,
+        runtime.kv_cache_block_size,
+    )
     mask_token_id = get_parallel_drafting_token_id(draft_config)
     input_ids = torch.tensor(
         [draft_config.bos_token_id] + [mask_token_id] * (query_len - 1),
@@ -652,18 +724,22 @@ def _run_dflash_eager_smoke(
     return token
 
 
-def _make_handler(status: RuntimeStatus, proposal_engine: Any | None = None):
+def _make_handler(
+    status: RuntimeStatus,
+    proposal_engine_ref: list[Any | None] | None = None,
+):
     class StatusHandler(BaseHTTPRequestHandler):
         def do_GET(self) -> None:  # noqa: N802
             if self.path not in ("/", "/healthz", "/readyz", "/v1/status"):
                 self.send_error(404)
                 return
             payload = asdict(status)
+            proposal_engine = (
+                proposal_engine_ref[0] if proposal_engine_ref is not None else None
+            )
             if proposal_engine is not None:
                 payload["proposal_count"] = proposal_engine.proposal_count
-                payload["proposal_active_requests"] = (
-                    proposal_engine.allocator.active_requests
-                )
+                payload["proposal_active_requests"] = proposal_engine.active_requests
                 payload["proposal_max_requests"] = (
                     proposal_engine.allocator.max_requests
                 )
@@ -679,6 +755,9 @@ def _make_handler(status: RuntimeStatus, proposal_engine: Any | None = None):
                 )
                 payload["proposal_prefix_cache_tokens"] = (
                     proposal_engine.prefix_cache_tokens
+                )
+                payload["proposal_prefix_cache_capacity_gib"] = (
+                    proposal_engine.prefix_cache_capacity_bytes / 1024**3
                 )
                 payload["proposal_prefix_cache_host_gib"] = (
                     proposal_engine.prefix_cache_host_bytes / 1024**3
@@ -701,46 +780,36 @@ def _make_handler(status: RuntimeStatus, proposal_engine: Any | None = None):
                 payload["proposal_cuda_graph_replay_count"] = (
                     proposal_engine.cuda_graph_replay_count
                 )
-                payload["proposal_cuda_graph_eager_fallback_count"] = (
-                    proposal_engine.cuda_graph_eager_fallback_count
-                )
             body = json.dumps(payload, sort_keys=True).encode()
-            code = 200 if status.ready else 503
+            code = _status_http_code(self.path, status.ready)
             self.send_response(code)
             self.send_header("Content-Type", "application/json")
             self.send_header("Content-Length", str(len(body)))
             self.end_headers()
             self.wfile.write(body)
 
-        def log_message(self, format: str, *args: object) -> None:
+        def log_message(self, format: str, *args: object) -> None:  # noqa: A002
             logger.info("DSpark status HTTP: %s", format % args)
 
     return StatusHandler
 
 
 def _serve_status(
-    args: argparse.Namespace,
-    status: RuntimeStatus,
+    server: ThreadingHTTPServer,
     stop: threading.Event,
-    proposal_engine: Any | None = None,
 ) -> None:
-    server = ThreadingHTTPServer(
-        (args.host, args.port), _make_handler(status, proposal_engine)
-    )
     server.timeout = 0.5
-
-    def request_stop(signum: int, _frame: object) -> None:
-        logger.info("Received signal %d; stopping DSpark status server", signum)
-        stop.set()
-
-    signal.signal(signal.SIGINT, request_stop)
-    signal.signal(signal.SIGTERM, request_stop)
+    host, port = server.server_address[:2]
     logger.info(
-        "DSpark status endpoint listening on http://%s:%d", args.host, args.port
+        "DSpark status endpoint listening on http://%s:%d",
+        host,
+        port,
     )
-    while not stop.is_set():
-        server.handle_request()
-    server.server_close()
+    try:
+        while not stop.is_set():
+            server.handle_request()
+    finally:
+        server.server_close()
 
 
 def _parse_args() -> argparse.Namespace:
@@ -749,20 +818,35 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--draft-model", type=Path, required=True)
     parser.add_argument("--target-weights", type=Path, required=True)
     parser.add_argument("--target-config", type=Path, required=True)
-    parser.add_argument("--device", type=int, default=0)
+    parser.add_argument("--device", type=_non_negative_int, default=0)
     parser.add_argument("--host", default="127.0.0.1")
-    parser.add_argument("--port", type=int, default=8091)
-    parser.add_argument("--num-speculative-tokens", type=int, default=3)
-    parser.add_argument("--max-model-len", type=int, default=32768)
-    parser.add_argument("--max-num-batched-tokens", type=int, default=64)
-    parser.add_argument("--max-num-seqs", type=int, default=2)
-    parser.add_argument("--max-retained-requests", type=int)
-    parser.add_argument("--draft-kv-cache-gib", type=float, default=1.0)
-    parser.add_argument("--draft-kv-window", type=int, default=32768)
+    parser.add_argument("--port", type=_tcp_port, default=8091)
+    parser.add_argument("--num-speculative-tokens", type=_positive_int, default=3)
+    parser.add_argument("--max-model-len", type=_positive_int, default=32768)
+    parser.add_argument("--max-num-batched-tokens", type=_positive_int, default=64)
+    parser.add_argument("--max-num-seqs", type=_positive_int, default=2)
+    parser.add_argument("--max-retained-requests", type=_positive_int)
+    parser.add_argument("--draft-kv-cache-gib", type=_positive_float, default=1.0)
+    parser.add_argument(
+        "--draft-prefix-cache-gib",
+        type=_positive_float,
+        default=4.0,
+        help="Aggregate GPU budget for retained projected context states.",
+    )
+    parser.add_argument(
+        "--draft-kv-window",
+        type=_positive_block_multiple,
+        default=32768,
+    )
     parser.add_argument("--proposal-address", default="tcp://127.0.0.1:8092")
+    parser.add_argument(
+        "--allow-unsafe-remote-rpc",
+        action="store_true",
+        help="Allow unauthenticated proposal RPC on a non-loopback address.",
+    )
     parser.add_argument("--disable-proposal-transport", action="store_true")
     parser.add_argument("--enable-cuda-graph", action="store_true")
-    parser.add_argument("--cuda-graph-warmups", type=int, default=2)
+    parser.add_argument("--cuda-graph-warmups", type=_positive_int, default=2)
     parser.add_argument("--skip-smoke-test", action="store_true")
     parser.add_argument("--exit-after-load", action="store_true")
     args = parser.parse_args()
@@ -776,15 +860,40 @@ def _parse_args() -> argparse.Namespace:
 
 def main() -> None:
     args = _parse_args()
+    stop = threading.Event()
+    proposal_server = None
+    status_server = None
+    status_thread = None
     status = RuntimeStatus(
         draft_model=str(args.draft_model),
         method=args.method,
         target_weights=str(args.target_weights),
         num_speculative_tokens=args.num_speculative_tokens,
         max_model_len=args.max_model_len,
+        draft_prefix_cache_gib=args.draft_prefix_cache_gib,
         draft_kv_window=args.draft_kv_window,
     )
     try:
+        proposal_engine_ref: list[Any | None] = [None]
+        status_server = ThreadingHTTPServer(
+            (args.host, args.port),
+            _make_handler(status, proposal_engine_ref),
+        )
+        status_thread = threading.Thread(
+            target=_serve_status,
+            args=(status_server, stop),
+            name="k3-draft-status-http",
+            daemon=True,
+        )
+
+        def request_stop(signum: int, _frame: object) -> None:
+            logger.info("Received signal %d; stopping K3 draft server", signum)
+            stop.set()
+
+        signal.signal(signal.SIGINT, request_stop)
+        signal.signal(signal.SIGTERM, request_stop)
+        status_thread.start()
+
         runtime = _load_runtime(args, status)
         if not args.skip_smoke_test:
             status.phase = "eager_smoke_test"
@@ -792,9 +901,7 @@ def main() -> None:
                 runtime, torch.device("cuda", args.device)
             )
             status.draft_kv_cache_smoke = True
-        stop = threading.Event()
         proposal_engine = None
-        proposal_server = None
         if not args.disable_proposal_transport:
             status.phase = "starting_proposal_transport"
             from vllm.entrypoints.k3_dspark_rpc import (
@@ -810,15 +917,20 @@ def main() -> None:
                     else args.max_num_seqs
                 ),
                 window_size=args.draft_kv_window,
+                prefix_cache_gib=args.draft_prefix_cache_gib,
                 device=torch.device("cuda", args.device),
             )
             if args.enable_cuda_graph:
                 status.phase = f"capturing_{args.method}_cuda_graphs"
-                proposal_engine.capture_cuda_graphs(warmups=args.cuda_graph_warmups)
+                proposal_engine.capture_cuda_graphs(
+                    warmups=args.cuda_graph_warmups,
+                )
+            proposal_engine_ref[0] = proposal_engine
             proposal_server = K3DSparkZMQServer(
                 proposal_engine,
                 address=args.proposal_address,
                 stop=stop,
+                allow_unsafe_remote=args.allow_unsafe_remote_rpc,
             )
             proposal_server.start()
             status.proposal_transport_ready = True
@@ -833,14 +945,20 @@ def main() -> None:
         if args.exit_after_load:
             print(json.dumps(asdict(status), sort_keys=True), flush=True)
             return
-        _serve_status(args, status, stop, proposal_engine)
-        if proposal_server is not None:
-            proposal_server.join()
+        status_thread.join()
     except Exception as exc:
         status.phase = "failed"
         status.error = f"{type(exc).__name__}: {exc}"
         logger.exception("Standalone K3 draft startup failed")
         raise
+    finally:
+        stop.set()
+        if proposal_server is not None:
+            proposal_server.join()
+        if status_thread is not None and status_thread.ident is not None:
+            status_thread.join(timeout=5.0)
+        elif status_server is not None:
+            status_server.server_close()
 
 
 if __name__ == "__main__":

--- a/vllm/entrypoints/k3_dspark_standalone.py
+++ b/vllm/entrypoints/k3_dspark_standalone.py
@@ -1,0 +1,847 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Load a Kimi-K3 draft model on a dedicated single GPU.
+
+The process loads either DSpark or DFlash plus the target embedding and LM
+head, without loading the Kimi-K3 target transformer. Draft weights, KV cache,
+attention workspace, and proposal compute stay on this process's GPU.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import signal
+import threading
+import time
+from dataclasses import asdict, dataclass
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+
+import torch
+import torch.nn as nn
+from safetensors import safe_open
+
+from vllm.config.vllm import set_current_vllm_config
+from vllm.engine.arg_utils import EngineArgs
+from vllm.forward_context import set_forward_context
+from vllm.logger import init_logger
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
+    VocabParallelEmbedding,
+)
+from vllm.utils.torch_utils import set_default_torch_dtype
+from vllm.v1.worker.workspace import init_workspace_manager
+
+logger = init_logger(__name__)
+
+EMBED_TENSOR = "language_model.model.embed_tokens.weight"
+LM_HEAD_TENSOR = "language_model.lm_head.weight"
+SHARED_TENSORS = (EMBED_TENSOR, LM_HEAD_TENSOR)
+
+
+@dataclass
+class RuntimeStatus:
+    phase: str = "starting"
+    ready: bool = False
+    proposal_transport_ready: bool = False
+    device: str = ""
+    compute_capability: str = ""
+    torch_version: str = torch.__version__
+    torch_arches: tuple[str, ...] = ()
+    draft_model: str = ""
+    method: str = ""
+    target_weights: str = ""
+    num_speculative_tokens: int = 0
+    max_model_len: int = 0
+    allocated_gib: float = 0.0
+    reserved_gib: float = 0.0
+    draft_kv_cache_gib: float = 0.0
+    draft_kv_cache_blocks: int = 0
+    draft_kv_cache_token_capacity: int = 0
+    draft_kv_cache_smoke: bool = False
+    draft_kv_window: int = 0
+    proposal_address: str | None = None
+    proposal_count: int = 0
+    proposal_active_requests: int = 0
+    proposal_last_latency_ms: float = 0.0
+    smoke_token: int | None = None
+    load_seconds: float = 0.0
+    error: str | None = None
+
+
+class _TargetLanguageModel(nn.Module):
+    def __init__(self, vocab_size: int, hidden_size: int) -> None:
+        super().__init__()
+        self.embed_tokens = VocabParallelEmbedding(
+            vocab_size,
+            hidden_size,
+            params_dtype=torch.bfloat16,
+            prefix="model.embed_tokens",
+            disable_tp=True,
+        )
+
+
+class StandaloneTargetFacade(nn.Module):
+    """Only the two frozen target modules that DSpark shares."""
+
+    def __init__(self, vocab_size: int, hidden_size: int) -> None:
+        super().__init__()
+        self.model = _TargetLanguageModel(vocab_size, hidden_size)
+        self.lm_head = ParallelLMHead(
+            vocab_size,
+            hidden_size,
+            params_dtype=torch.bfloat16,
+            prefix="lm_head",
+            disable_tp=True,
+        )
+
+    def get_language_model(self) -> StandaloneTargetFacade:
+        return self
+
+
+@dataclass
+class StandaloneRuntime:
+    vllm_config: Any
+    draft_vllm_config: Any
+    target_facade: StandaloneTargetFacade
+    model: nn.Module
+    kv_caches: dict[str, torch.Tensor]
+    kv_cache_block_size: int
+    method: str
+    attn_metadata_builder: Any | None = None
+
+
+def resolve_shared_weight_files(target_weights: Path) -> dict[str, Path]:
+    """Resolve the two shared tensors through a safetensors index."""
+    root = target_weights.resolve()
+    index_path = root / "model.safetensors.index.json"
+    if not index_path.is_file():
+        raise FileNotFoundError(f"Target weight index is missing: {index_path}")
+
+    index = json.loads(index_path.read_text())
+    weight_map = index.get("weight_map")
+    if not isinstance(weight_map, dict):
+        raise ValueError(f"Invalid safetensors weight_map in {index_path}")
+
+    resolved: dict[str, Path] = {}
+    for tensor_name in SHARED_TENSORS:
+        relative = weight_map.get(tensor_name)
+        if not isinstance(relative, str):
+            raise KeyError(f"Target tensor is absent from the index: {tensor_name}")
+        tensor_path = (root / relative).resolve()
+        if not tensor_path.is_relative_to(root):
+            raise ValueError(
+                f"Target tensor path escapes the checkpoint root: {tensor_path}"
+            )
+        if not tensor_path.is_file():
+            raise FileNotFoundError(f"Target tensor file is missing: {tensor_path}")
+        resolved[tensor_name] = tensor_path
+    return resolved
+
+
+def _load_module_weight(
+    module: VocabParallelEmbedding,
+    tensor_name: str,
+    tensor_path: Path,
+    device: torch.device,
+) -> None:
+    logger.info("Loading shared target tensor %s from %s", tensor_name, tensor_path)
+    with safe_open(str(tensor_path), framework="pt", device=str(device)) as handle:
+        if tensor_name not in set(handle.keys()):
+            raise KeyError(f"{tensor_name} is absent from {tensor_path}")
+        loaded_weight = handle.get_tensor(tensor_name)
+        if loaded_weight.dtype != torch.bfloat16:
+            raise TypeError(
+                f"{tensor_name} must be bfloat16, got {loaded_weight.dtype}"
+            )
+        module.weight_loader(module.weight, loaded_weight)
+        del loaded_weight
+    torch.accelerator.empty_cache()
+
+
+def load_shared_target_weights(
+    target: StandaloneTargetFacade,
+    target_weights: Path,
+    device: torch.device,
+) -> None:
+    files = resolve_shared_weight_files(target_weights)
+    _load_module_weight(
+        target.model.embed_tokens,
+        EMBED_TENSOR,
+        files[EMBED_TENSOR],
+        device,
+    )
+    _load_module_weight(
+        target.lm_head,
+        LM_HEAD_TENSOR,
+        files[LM_HEAD_TENSOR],
+        device,
+    )
+
+
+def _validate_cuda_runtime(device: torch.device) -> tuple[str, tuple[str, ...]]:
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is not available in the DSpark container")
+    major, minor = torch.cuda.get_device_capability(device)
+    expected_arch = f"sm_{major}{minor}"
+    arches = tuple(torch.cuda.get_arch_list())
+    if expected_arch not in arches:
+        raise RuntimeError(
+            f"PyTorch does not contain {expected_arch}; compiled arches are {arches}"
+        )
+    if major < 8:
+        raise RuntimeError(
+            f"Kimi-K3 DSpark BF16 requires compute capability >= 8.0, got "
+            f"{major}.{minor}"
+        )
+    return f"{major}.{minor}", arches
+
+
+def _init_single_gpu_distributed() -> None:
+    from vllm.distributed.parallel_state import (
+        ensure_model_parallel_initialized,
+        init_distributed_environment,
+        model_parallel_is_initialized,
+    )
+    from vllm.utils.network_utils import get_open_port
+
+    if model_parallel_is_initialized():
+        return
+    init_distributed_environment(
+        world_size=1,
+        rank=0,
+        local_rank=0,
+        distributed_init_method=f"tcp://127.0.0.1:{get_open_port()}",
+        backend="gloo",
+    )
+    ensure_model_parallel_initialized(
+        tensor_model_parallel_size=1,
+        pipeline_model_parallel_size=1,
+    )
+
+
+def _build_vllm_config(args: argparse.Namespace):
+    attention_backend = "TRITON_ATTN" if args.method == "dflash" else "TRITON_MLA"
+    speculative_config = {
+        "model": str(args.draft_model),
+        "method": args.method,
+        "num_speculative_tokens": args.num_speculative_tokens,
+        "attention_backend": attention_backend,
+        "kv_cache_dtype": "bfloat16",
+        "draft_sample_method": "greedy",
+        "rejection_sample_method": "block",
+        "max_model_len": args.max_model_len,
+    }
+    engine_args = EngineArgs(
+        model=str(args.target_config),
+        tokenizer_mode="skip",
+        skip_tokenizer_init=True,
+        dtype="bfloat16",
+        kv_cache_dtype="bfloat16",
+        max_model_len=args.max_model_len,
+        tensor_parallel_size=1,
+        decode_context_parallel_size=1,
+        max_num_batched_tokens=args.max_num_batched_tokens,
+        max_num_seqs=args.max_num_seqs,
+        block_size=16,
+        enable_prefix_caching=False,
+        enforce_eager=True,
+        compilation_config={"custom_ops": ["none"]},
+        kernel_config={
+            "ir_op_priority": {
+                "rms_norm": ["native"],
+                "fused_add_rms_norm": ["native"],
+            },
+            "linear_backend": "torch",
+        },
+        load_format="safetensors",
+        use_tqdm_on_load=False,
+        speculative_config=speculative_config,
+    )
+    return engine_args.create_engine_config(headless=True)
+
+
+def _allocate_draft_kv_cache(
+    model: nn.Module,
+    *,
+    method: str,
+    block_size: int,
+    cache_gib: float,
+    device: torch.device,
+) -> tuple[dict[str, torch.Tensor], int]:
+    """Allocate and bind the draft model's private BF16 KV cache."""
+    if cache_gib <= 0:
+        raise ValueError(f"--draft-kv-cache-gib must be positive, got {cache_gib}")
+
+    if method == "dflash":
+        attentions = [layer.self_attn.attn for layer in model.model.layers]
+    else:
+        attentions = [layer.self_attn for layer in model.model.layers]
+    if not attentions:
+        raise RuntimeError("K3 draft model does not expose any attention layers")
+
+    if method == "dflash":
+        cache_shapes = {
+            (
+                int(attn.impl.num_kv_heads),
+                int(attn.impl.head_size),
+            )
+            for attn in attentions
+        }
+        if len(cache_shapes) != 1:
+            raise ValueError(f"K3 DFlash layers have mixed KV shapes: {cache_shapes}")
+        num_kv_heads, head_size = cache_shapes.pop()
+        bytes_per_block_all_layers = (
+            len(attentions)
+            * block_size
+            * num_kv_heads
+            * 2
+            * head_size
+            * torch.tensor([], dtype=torch.bfloat16).element_size()
+        )
+    else:
+        latent_widths = {
+            int(attn.kv_lora_rank + attn.qk_rope_head_dim) for attn in attentions
+        }
+        if len(latent_widths) != 1:
+            raise ValueError(
+                f"K3 DSpark draft layers have mixed MLA widths: {latent_widths}"
+            )
+        latent_width = latent_widths.pop()
+        bytes_per_block_all_layers = (
+            len(attentions)
+            * block_size
+            * latent_width
+            * torch.tensor([], dtype=torch.bfloat16).element_size()
+        )
+    num_blocks = int(cache_gib * 1024**3) // bytes_per_block_all_layers
+    # Block zero is deliberately never assigned to a live request.
+    if num_blocks < 2:
+        minimum_mib = 2 * bytes_per_block_all_layers / 1024**2
+        raise ValueError(
+            "The draft KV cache must fit a null block plus one data block; "
+            f"minimum={minimum_mib:.2f} MiB"
+        )
+
+    caches: dict[str, torch.Tensor] = {}
+    for attn in attentions:
+        if method == "dflash":
+            # TritonAttention exposes logical B,H,N,2D while its preferred
+            # physical layout is B,N,H,2D on CUDA.
+            physical = torch.zeros(
+                (num_blocks, block_size, num_kv_heads, 2 * head_size),
+                dtype=torch.bfloat16,
+                device=device,
+            )
+            cache = physical.permute(0, 2, 1, 3)
+        else:
+            cache = torch.zeros(
+                (num_blocks, block_size, latent_width),
+                dtype=torch.bfloat16,
+                device=device,
+            )
+        attn.bind_kv_cache(cache)
+        caches[attn.layer_name] = cache
+    return caches, num_blocks
+
+
+def _build_dflash_metadata_builder(
+    model: nn.Module,
+    draft_vllm_config: Any,
+    device: torch.device,
+) -> Any:
+    from vllm.v1.worker.utils import AttentionGroup
+
+    attentions = [layer.self_attn.attn for layer in model.model.layers]
+    layer_names = [attn.layer_name for attn in attentions]
+    first = attentions[0]
+    backend = first.get_attn_backend()
+    if backend.get_name() != "TRITON_ATTN":
+        raise ValueError(
+            f"Standalone K3 DFlash requires TRITON_ATTN, got {backend.get_name()}"
+        )
+    kv_spec = first.get_kv_cache_spec(draft_vllm_config)
+    if kv_spec is None:
+        raise RuntimeError("K3 DFlash attention did not return a KV cache spec")
+    group = AttentionGroup(backend, layer_names, kv_spec, 0)
+    group.create_metadata_builders(
+        draft_vllm_config,
+        device,
+        kernel_block_size=int(draft_vllm_config.cache_config.block_size),
+    )
+    return group.get_metadata_builder()
+
+
+def _load_runtime(args: argparse.Namespace, status: RuntimeStatus) -> StandaloneRuntime:
+    start = time.perf_counter()
+    device = torch.device("cuda", args.device)
+    torch.cuda.set_device(device)
+    status.device = torch.cuda.get_device_name(device)
+    status.compute_capability, status.torch_arches = _validate_cuda_runtime(device)
+    status.phase = "building_config"
+
+    vllm_config = _build_vllm_config(args)
+    speculative_config = vllm_config.speculative_config
+    assert speculative_config is not None
+    draft_config = speculative_config.draft_model_config.hf_config
+
+    status.phase = "loading_shared_target_weights"
+    with set_current_vllm_config(vllm_config):
+        _init_single_gpu_distributed()
+        init_workspace_manager(device, num_lanes=2)
+        with torch.device(device), set_default_torch_dtype(torch.bfloat16):
+            target = StandaloneTargetFacade(
+                vocab_size=draft_config.vocab_size,
+                hidden_size=draft_config.hidden_size,
+            )
+        load_shared_target_weights(target, args.target_weights, device)
+
+        status.phase = f"loading_{args.method}"
+        from vllm.v1.worker.gpu.spec_decode.eagle.utils import (
+            _create_draft_vllm_config,
+        )
+
+        if args.method == "dflash":
+            from vllm.v1.worker.gpu.spec_decode.dflash.utils import (
+                load_dflash_model,
+                maybe_load_mask_embedding,
+            )
+
+            model = load_dflash_model(target, vllm_config)
+            maybe_load_mask_embedding(
+                model,
+                str(args.draft_model),
+                int(draft_config.dflash_config["mask_token_id"]),
+            )
+        else:
+            from vllm.v1.worker.gpu.spec_decode.dspark.utils import load_dspark_model
+
+            model = load_dspark_model(target, vllm_config)
+        model.eval()
+        draft_vllm_config = _create_draft_vllm_config(vllm_config)
+
+        status.phase = "allocating_draft_kv_cache"
+        block_size = int(vllm_config.cache_config.block_size)
+        kv_caches, num_blocks = _allocate_draft_kv_cache(
+            model,
+            method=args.method,
+            block_size=block_size,
+            cache_gib=args.draft_kv_cache_gib,
+            device=device,
+        )
+        status.draft_kv_cache_blocks = num_blocks
+        status.draft_kv_cache_token_capacity = (num_blocks - 1) * block_size
+        status.draft_kv_cache_gib = (
+            sum(cache.numel() * cache.element_size() for cache in kv_caches.values())
+            / 1024**3
+        )
+
+    torch.accelerator.synchronize()
+    status.load_seconds = time.perf_counter() - start
+    status.allocated_gib = torch.cuda.memory_allocated(device) / 1024**3
+    status.reserved_gib = torch.cuda.memory_reserved(device) / 1024**3
+    metadata_builder = (
+        _build_dflash_metadata_builder(model, draft_vllm_config, device)
+        if args.method == "dflash"
+        else None
+    )
+    return StandaloneRuntime(
+        vllm_config,
+        draft_vllm_config,
+        target,
+        model,
+        kv_caches,
+        block_size,
+        args.method,
+        metadata_builder,
+    )
+
+
+@torch.inference_mode()
+def _run_eager_smoke(runtime: StandaloneRuntime, device: torch.device) -> int:
+    if runtime.method == "dflash":
+        return _run_dflash_eager_smoke(runtime, device)
+
+    from vllm.model_executor.layers.attention.mla_attention import (
+        MLACommonDecodeMetadata,
+        MLACommonMetadata,
+    )
+    from vllm.v1.worker.gpu.spec_decode.utils import (
+        get_parallel_drafting_token_id,
+    )
+
+    model = runtime.model
+    draft_config = runtime.vllm_config.speculative_config.draft_model_config.hf_config
+    num_aux_layers = int(draft_config.num_target_layers)
+    hidden_size = int(draft_config.hidden_size)
+
+    aux = torch.zeros(
+        (1, num_aux_layers * hidden_size),
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    context_len = 1
+    positions = torch.zeros(context_len, dtype=torch.int64, device=device)
+    context = model.combine_hidden_states(aux)
+    data_block = 1
+    context_slots = torch.tensor(
+        [data_block * runtime.kv_cache_block_size],
+        dtype=torch.int64,
+        device=device,
+    )
+    model.precompute_and_store_context_kv(context, positions, context_slots)
+
+    sample_from_anchor = bool(getattr(draft_config, "sample_from_anchor", True))
+    query_len = runtime.vllm_config.speculative_config.num_speculative_tokens
+    if not sample_from_anchor:
+        query_len += 1
+    mask_token_id = get_parallel_drafting_token_id(draft_config)
+    input_ids = torch.tensor(
+        [draft_config.bos_token_id] + [mask_token_id] * (query_len - 1),
+        dtype=torch.int64,
+        device=device,
+    )
+    query_positions = torch.arange(
+        context_len,
+        context_len + query_len,
+        dtype=torch.int64,
+        device=device,
+    )
+    query_slots = torch.arange(
+        data_block * runtime.kv_cache_block_size + context_len,
+        data_block * runtime.kv_cache_block_size + context_len + query_len,
+        dtype=torch.int64,
+        device=device,
+    )
+    query_start_loc = torch.tensor([0, query_len], dtype=torch.int32, device=device)
+    block_table = torch.tensor([[data_block]], dtype=torch.int32, device=device)
+    seq_lens = torch.tensor([context_len + query_len], dtype=torch.int32, device=device)
+    metadata = MLACommonMetadata(
+        num_reqs=1,
+        max_query_len=query_len,
+        max_seq_len=context_len + query_len,
+        num_actual_tokens=query_len,
+        query_start_loc=query_start_loc,
+        slot_mapping=query_slots,
+        num_decodes=1,
+        num_decode_tokens=query_len,
+        num_prefills=0,
+        causal=False,
+        # MLA metadata validates the cached latent width, not the full Q/K
+        # projection width.
+        head_dim=int(next(iter(runtime.kv_caches.values())).shape[-1]),
+        prefill=None,
+        decode=MLACommonDecodeMetadata(
+            block_table=block_table,
+            seq_lens=seq_lens,
+            dcp_tot_seq_lens=None,
+        ),
+    )
+    attn_metadata = {layer_name: metadata for layer_name in runtime.kv_caches}
+    slot_mapping = {layer_name: query_slots for layer_name in runtime.kv_caches}
+    with (
+        set_current_vllm_config(runtime.draft_vllm_config),
+        set_forward_context(
+            attn_metadata,
+            runtime.draft_vllm_config,
+            num_tokens=query_len,
+            skip_compiled=True,
+            slot_mapping=slot_mapping,
+        ),
+    ):
+        hidden = model(input_ids=input_ids, positions=query_positions)
+    base_logits = model.compute_draft_logits(hidden[-1:])
+    markov = model.markov_bias(model.markov_embed(input_ids[-1:]))
+    token = int((base_logits + markov).argmax(dim=-1).item())
+    torch.accelerator.synchronize()
+    for cache in runtime.kv_caches.values():
+        cache[data_block].zero_()
+    return token
+
+
+@torch.inference_mode()
+def _run_dflash_eager_smoke(
+    runtime: StandaloneRuntime,
+    device: torch.device,
+) -> int:
+    from vllm.v1.attention.backend import CommonAttentionMetadata
+    from vllm.v1.worker.gpu.spec_decode.eagle.eagle3_utils import (
+        get_eagle3_aux_layers_from_config,
+    )
+    from vllm.v1.worker.gpu.spec_decode.utils import (
+        get_parallel_drafting_token_id,
+    )
+
+    speculative_config = runtime.vllm_config.speculative_config
+    assert speculative_config is not None
+    draft_config = speculative_config.draft_model_config.hf_config
+    aux_layers = get_eagle3_aux_layers_from_config(speculative_config)
+    if not aux_layers:
+        raise ValueError("K3 DFlash config does not declare target auxiliary layers")
+
+    raw_context = torch.zeros(
+        (1, len(aux_layers) * int(draft_config.hidden_size)),
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    context = runtime.model.combine_hidden_states(raw_context)
+    block_size = runtime.kv_cache_block_size
+    context_position = torch.zeros(1, dtype=torch.int64, device=device)
+    context_slot = torch.tensor([block_size], dtype=torch.int64, device=device)
+    runtime.model.precompute_and_store_context_kv(
+        context,
+        context_position,
+        context_slot,
+    )
+
+    query_len = int(speculative_config.num_speculative_tokens) + 1
+    sequence_end = 1 + query_len
+    block_ids = list(range(1, 1 + (sequence_end + block_size - 1) // block_size))
+    input_ids = torch.tensor(
+        [draft_config.bos_token_id]
+        + [get_parallel_drafting_token_id(draft_config)] * (query_len - 1),
+        dtype=torch.int64,
+        device=device,
+    )
+    positions = torch.arange(1, sequence_end, dtype=torch.int64, device=device)
+    slots = torch.tensor(
+        [
+            block_ids[position // block_size] * block_size + position % block_size
+            for position in range(1, sequence_end)
+        ],
+        dtype=torch.int64,
+        device=device,
+    )
+    query_start_cpu = torch.tensor([0, query_len], dtype=torch.int32)
+    query_start_gpu = query_start_cpu.to(device)
+    seq_lens = torch.tensor([sequence_end], dtype=torch.int32, device=device)
+    block_table = torch.tensor([block_ids], dtype=torch.int32, device=device)
+    common = CommonAttentionMetadata(
+        query_start_loc=query_start_gpu,
+        query_start_loc_cpu=query_start_cpu,
+        seq_lens=seq_lens,
+        seq_lens_cpu_upper_bound=torch.tensor([sequence_end], dtype=torch.int32),
+        max_seq_len=sequence_end,
+        num_reqs=1,
+        num_actual_tokens=query_len,
+        max_query_len=query_len,
+        block_table_tensor=block_table,
+        slot_mapping=slots,
+        causal=True,
+    )
+    assert runtime.attn_metadata_builder is not None
+    metadata = runtime.attn_metadata_builder.build(0, common)
+    attn_metadata = {layer_name: metadata for layer_name in runtime.kv_caches}
+    slot_mapping = {layer_name: slots for layer_name in runtime.kv_caches}
+    with (
+        set_current_vllm_config(runtime.draft_vllm_config),
+        set_forward_context(
+            attn_metadata,
+            runtime.draft_vllm_config,
+            num_tokens=query_len,
+            skip_compiled=True,
+            slot_mapping=slot_mapping,
+        ),
+    ):
+        hidden = runtime.model(input_ids=input_ids, positions=positions)
+    token = int(runtime.model.compute_logits(hidden[1:2]).argmax(dim=-1).item())
+    torch.accelerator.synchronize()
+    for cache in runtime.kv_caches.values():
+        cache[1 : 1 + len(block_ids)].zero_()
+    return token
+
+
+def _make_handler(status: RuntimeStatus, proposal_engine: Any | None = None):
+    class StatusHandler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802
+            if self.path not in ("/", "/healthz", "/readyz", "/v1/status"):
+                self.send_error(404)
+                return
+            payload = asdict(status)
+            if proposal_engine is not None:
+                payload["proposal_count"] = proposal_engine.proposal_count
+                payload["proposal_active_requests"] = (
+                    proposal_engine.allocator.active_requests
+                )
+                payload["proposal_max_requests"] = (
+                    proposal_engine.allocator.max_requests
+                )
+                payload["proposal_last_latency_ms"] = proposal_engine.last_latency_ms
+                payload["proposal_last_timing_ms"] = proposal_engine.last_timing_ms
+                payload["proposal_mean_timing_ms"] = proposal_engine.mean_timing_ms
+                payload["proposal_cold_bootstrap_count"] = (
+                    proposal_engine.cold_bootstrap_count
+                )
+                payload["proposal_reconnect_count"] = proposal_engine.reconnect_count
+                payload["proposal_last_reconnect_latency_ms"] = (
+                    proposal_engine.last_reconnect_latency_ms
+                )
+                payload["proposal_prefix_cache_tokens"] = (
+                    proposal_engine.prefix_cache_tokens
+                )
+                payload["proposal_prefix_cache_host_gib"] = (
+                    proposal_engine.prefix_cache_host_bytes / 1024**3
+                )
+                payload["proposal_prefix_cache_gpu_gib"] = (
+                    proposal_engine.prefix_cache_device_bytes / 1024**3
+                )
+                payload["proposal_cuda_graph_enabled"] = (
+                    proposal_engine.cuda_graph_enabled
+                )
+                payload["proposal_cuda_graph_shapes"] = (
+                    proposal_engine.cuda_graph_shapes
+                )
+                payload["proposal_cuda_graph_capture_seconds"] = (
+                    proposal_engine.cuda_graph_capture_seconds
+                )
+                payload["proposal_cuda_graph_memory_gib"] = (
+                    proposal_engine.cuda_graph_memory_gib
+                )
+                payload["proposal_cuda_graph_replay_count"] = (
+                    proposal_engine.cuda_graph_replay_count
+                )
+                payload["proposal_cuda_graph_eager_fallback_count"] = (
+                    proposal_engine.cuda_graph_eager_fallback_count
+                )
+            body = json.dumps(payload, sort_keys=True).encode()
+            code = 200 if status.ready else 503
+            self.send_response(code)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, format: str, *args: object) -> None:
+            logger.info("DSpark status HTTP: %s", format % args)
+
+    return StatusHandler
+
+
+def _serve_status(
+    args: argparse.Namespace,
+    status: RuntimeStatus,
+    stop: threading.Event,
+    proposal_engine: Any | None = None,
+) -> None:
+    server = ThreadingHTTPServer(
+        (args.host, args.port), _make_handler(status, proposal_engine)
+    )
+    server.timeout = 0.5
+
+    def request_stop(signum: int, _frame: object) -> None:
+        logger.info("Received signal %d; stopping DSpark status server", signum)
+        stop.set()
+
+    signal.signal(signal.SIGINT, request_stop)
+    signal.signal(signal.SIGTERM, request_stop)
+    logger.info(
+        "DSpark status endpoint listening on http://%s:%d", args.host, args.port
+    )
+    while not stop.is_set():
+        server.handle_request()
+    server.server_close()
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--method", choices=("dspark", "dflash"), default="dspark")
+    parser.add_argument("--draft-model", type=Path, required=True)
+    parser.add_argument("--target-weights", type=Path, required=True)
+    parser.add_argument("--target-config", type=Path, required=True)
+    parser.add_argument("--device", type=int, default=0)
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8091)
+    parser.add_argument("--num-speculative-tokens", type=int, default=3)
+    parser.add_argument("--max-model-len", type=int, default=32768)
+    parser.add_argument("--max-num-batched-tokens", type=int, default=64)
+    parser.add_argument("--max-num-seqs", type=int, default=2)
+    parser.add_argument("--max-retained-requests", type=int)
+    parser.add_argument("--draft-kv-cache-gib", type=float, default=1.0)
+    parser.add_argument("--draft-kv-window", type=int, default=32768)
+    parser.add_argument("--proposal-address", default="tcp://127.0.0.1:8092")
+    parser.add_argument("--disable-proposal-transport", action="store_true")
+    parser.add_argument("--enable-cuda-graph", action="store_true")
+    parser.add_argument("--cuda-graph-warmups", type=int, default=2)
+    parser.add_argument("--skip-smoke-test", action="store_true")
+    parser.add_argument("--exit-after-load", action="store_true")
+    args = parser.parse_args()
+    if (
+        args.max_retained_requests is not None
+        and args.max_retained_requests < args.max_num_seqs
+    ):
+        parser.error("--max-retained-requests must be >= --max-num-seqs")
+    return args
+
+
+def main() -> None:
+    args = _parse_args()
+    status = RuntimeStatus(
+        draft_model=str(args.draft_model),
+        method=args.method,
+        target_weights=str(args.target_weights),
+        num_speculative_tokens=args.num_speculative_tokens,
+        max_model_len=args.max_model_len,
+        draft_kv_window=args.draft_kv_window,
+    )
+    try:
+        runtime = _load_runtime(args, status)
+        if not args.skip_smoke_test:
+            status.phase = "eager_smoke_test"
+            status.smoke_token = _run_eager_smoke(
+                runtime, torch.device("cuda", args.device)
+            )
+            status.draft_kv_cache_smoke = True
+        stop = threading.Event()
+        proposal_engine = None
+        proposal_server = None
+        if not args.disable_proposal_transport:
+            status.phase = "starting_proposal_transport"
+            from vllm.entrypoints.k3_dspark_rpc import (
+                K3DSparkDraftEngine,
+                K3DSparkZMQServer,
+            )
+
+            proposal_engine = K3DSparkDraftEngine(
+                runtime,
+                max_requests=(
+                    args.max_retained_requests
+                    if args.max_retained_requests is not None
+                    else args.max_num_seqs
+                ),
+                window_size=args.draft_kv_window,
+                device=torch.device("cuda", args.device),
+            )
+            if args.enable_cuda_graph:
+                status.phase = f"capturing_{args.method}_cuda_graphs"
+                proposal_engine.capture_cuda_graphs(warmups=args.cuda_graph_warmups)
+            proposal_server = K3DSparkZMQServer(
+                proposal_engine,
+                address=args.proposal_address,
+                stop=stop,
+            )
+            proposal_server.start()
+            status.proposal_transport_ready = True
+            status.proposal_address = args.proposal_address
+            status.phase = "ready"
+        else:
+            status.phase = "ready_without_transport"
+        status.ready = True
+        status.allocated_gib = torch.cuda.memory_allocated(args.device) / 1024**3
+        status.reserved_gib = torch.cuda.memory_reserved(args.device) / 1024**3
+        logger.info("Standalone K3 draft is loaded: %s", json.dumps(asdict(status)))
+        if args.exit_after_load:
+            print(json.dumps(asdict(status), sort_keys=True), flush=True)
+            return
+        _serve_status(args, status, stop, proposal_engine)
+        if proposal_server is not None:
+            proposal_server.join()
+    except Exception as exc:
+        status.phase = "failed"
+        status.error = f"{type(exc).__name__}: {exc}"
+        logger.exception("Standalone K3 draft startup failed")
+        raise
+
+
+if __name__ == "__main__":
+    main()

--- a/vllm/entrypoints/k3_dspark_standalone.py
+++ b/vllm/entrypoints/k3_dspark_standalone.py
@@ -535,13 +535,17 @@ def _run_eager_smoke(runtime: StandaloneRuntime, device: torch.device) -> int:
         MLACommonMetadata,
     )
     from vllm.v1.worker.gpu.spec_decode.utils import (
+        draft_query_len,
         get_parallel_drafting_token_id,
     )
 
     model = runtime.model
     draft_config = runtime.vllm_config.speculative_config.draft_model_config.hf_config
     num_aux_layers = int(draft_config.num_target_layers)
-    hidden_size = int(draft_config.hidden_size)
+    # The context projection consumes target-width auxiliary states.
+    hidden_size = int(
+        getattr(draft_config, "target_hidden_size", None) or draft_config.hidden_size
+    )
 
     aux = torch.zeros(
         (1, num_aux_layers * hidden_size),
@@ -559,10 +563,10 @@ def _run_eager_smoke(runtime: StandaloneRuntime, device: torch.device) -> int:
     )
     model.precompute_and_store_context_kv(context, positions, context_slots)
 
-    sample_from_anchor = bool(getattr(draft_config, "sample_from_anchor", True))
-    query_len = runtime.vllm_config.speculative_config.num_speculative_tokens
-    if not sample_from_anchor:
-        query_len += 1
+    query_len = draft_query_len(
+        runtime.method,
+        runtime.vllm_config.speculative_config.num_speculative_tokens,
+    )
     _validate_single_block_smoke_span(
         context_len,
         query_len,
@@ -642,6 +646,7 @@ def _run_dflash_eager_smoke(
         get_eagle3_aux_layers_from_config,
     )
     from vllm.v1.worker.gpu.spec_decode.utils import (
+        draft_query_len,
         get_parallel_drafting_token_id,
     )
 
@@ -667,7 +672,10 @@ def _run_dflash_eager_smoke(
         context_slot,
     )
 
-    query_len = int(speculative_config.num_speculative_tokens) + 1
+    query_len = draft_query_len(
+        runtime.method,
+        int(speculative_config.num_speculative_tokens),
+    )
     sequence_end = 1 + query_len
     block_ids = list(range(1, 1 + (sequence_end + block_size - 1) // block_size))
     input_ids = torch.tensor(
@@ -946,6 +954,13 @@ def main() -> None:
             print(json.dumps(asdict(status), sort_keys=True), flush=True)
             return
         status_thread.join()
+        if proposal_server is not None and proposal_server.error is not None:
+            # The proposal loop stopped the process: surface its failure as
+            # the exit status instead of a clean shutdown.
+            status.proposal_transport_ready = False
+            raise RuntimeError(
+                f"K3 draft proposal transport failed: {proposal_server.error}"
+            )
     except Exception as exc:
         status.phase = "failed"
         status.error = f"{type(exc).__name__}: {exc}"

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -66,6 +66,11 @@ if TYPE_CHECKING:
     VLLM_DSPARK_FP8_DRAFT_HEAD: bool = False
     VLLM_MLA_CHUNKED_PREFILL_WORKSPACE_SIZE: int = 0
     VLLM_K3_KV_GROUP_SIZE: int = 0
+    VLLM_K3_DRAFT_REMOTE_ADDRESS: str | None = None
+    VLLM_K3_DSPARK_REMOTE_ADDRESS: str | None = None
+    VLLM_K3_DRAFT_REMOTE_TIMEOUT_MS: int = 30000
+    VLLM_K3_DSPARK_REMOTE_TIMEOUT_MS: int = 30000
+    VLLM_K3_DRAFT_TIMING_LOG_INTERVAL: int = 0
     VLLM_DSPARK_DRAFT_KV_WINDOW: int = 0
     VLLM_DSPARK_COMPACT_ROPE: bool = False
     VLLM_DSPARK_SHARD_MARKOV_HEAD: bool = False
@@ -1156,6 +1161,22 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Bound the number of physical Kimi-K3 layers sharing each hybrid-cache
     # block table. Zero preserves the general grouping heuristic.
     "VLLM_K3_KV_GROUP_SIZE": lambda: int(os.getenv("VLLM_K3_KV_GROUP_SIZE", "0")),
+    # Route Kimi-K3 draft work to a dedicated standalone GPU process. Keep the
+    # DSpark-prefixed names as compatibility aliases for existing deployments.
+    "VLLM_K3_DRAFT_REMOTE_ADDRESS": lambda: os.getenv("VLLM_K3_DRAFT_REMOTE_ADDRESS"),
+    "VLLM_K3_DSPARK_REMOTE_ADDRESS": lambda: os.getenv("VLLM_K3_DSPARK_REMOTE_ADDRESS"),
+    "VLLM_K3_DRAFT_REMOTE_TIMEOUT_MS": lambda: int(
+        os.getenv(
+            "VLLM_K3_DRAFT_REMOTE_TIMEOUT_MS",
+            os.getenv("VLLM_K3_DSPARK_REMOTE_TIMEOUT_MS", "30000"),
+        )
+    ),
+    "VLLM_K3_DSPARK_REMOTE_TIMEOUT_MS": lambda: int(
+        os.getenv("VLLM_K3_DSPARK_REMOTE_TIMEOUT_MS", "30000")
+    ),
+    "VLLM_K3_DRAFT_TIMING_LOG_INTERVAL": lambda: int(
+        os.getenv("VLLM_K3_DRAFT_TIMING_LOG_INTERVAL", "0")
+    ),
     # Limit an external DSpark draft to a replicated rolling MLA KV tail while
     # the target model retains its complete context. Target verification makes
     # the setting quality-safe, but acceptance may change with the window.

--- a/vllm/v1/worker/gpu/buffer_utils.py
+++ b/vllm/v1/worker/gpu/buffer_utils.py
@@ -152,6 +152,12 @@ class StagedWriteTensor:
         self.write_starts = new_buffer(self.num_rows, dtype=torch.int32)
         self.write_cu_lens = new_buffer(self.num_rows, dtype=torch.int32)
 
+    @property
+    def cpu(self) -> torch.Tensor | None:
+        """Return the host backing tensor when this tensor uses UVA."""
+        uva_buf = getattr(self, "_uva_buf", None)
+        return None if uva_buf is None else uva_buf.cpu
+
     def stage_write(
         self, index: int, start: int, x: Iterable[int] | Iterable[float]
     ) -> None:

--- a/vllm/v1/worker/gpu/buffer_utils.py
+++ b/vllm/v1/worker/gpu/buffer_utils.py
@@ -132,6 +132,7 @@ class StagedWriteTensor:
         self.device = device
         self.max_concurrency = max_concurrency
 
+        self._uva_buf: UvaBuffer | None = None
         if not uva_instead_of_gpu:
             # Create a GPU tensor (default)
             self.gpu = torch.zeros(size, dtype=dtype, device=device)
@@ -155,8 +156,7 @@ class StagedWriteTensor:
     @property
     def cpu(self) -> torch.Tensor | None:
         """Return the host backing tensor when this tensor uses UVA."""
-        uva_buf = getattr(self, "_uva_buf", None)
-        return None if uva_buf is None else uva_buf.cpu
+        return None if self._uva_buf is None else self._uva_buf.cpu
 
     def stage_write(
         self, index: int, start: int, x: Iterable[int] | Iterable[float]

--- a/vllm/v1/worker/gpu/input_batch.py
+++ b/vllm/v1/worker/gpu/input_batch.py
@@ -105,6 +105,11 @@ class InputBatch:
     max_req_tokens: int | None = None
     valid_num_draft_tokens_per_req: np.ndarray | None = None
 
+    # Optional host view of the request token table. Remote speculators use
+    # this to verify that a target prefix-cache hit belongs to retained draft
+    # state before reconnecting it. The tensor is shared, not copied.
+    all_token_ids_cpu: torch.Tensor | None = None
+
     # When > 0, dummy batches carry seeded-random token ids instead of zeros.
     # All-zero ids embed identically, so every dummy token routes to the SAME
     # MoE experts — grouped expert reads collapse and the profiled cost of a

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -1562,6 +1562,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             prompt_lens=prompt_lens,
             max_req_tokens=max_req_tokens,
             valid_num_draft_tokens_per_req=valid_num_draft_tokens_per_req,
+            all_token_ids_cpu=self.req_states.all_token_ids.cpu,
         )
         # InputBuffers are reused across real, dummy, and captured batches.
         # Clear stale padding before a capacity manager optionally marks a

--- a/vllm/v1/worker/gpu/spec_decode/__init__.py
+++ b/vllm/v1/worker/gpu/spec_decode/__init__.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import os
+
 import torch
 
 from vllm.config import VllmConfig
@@ -9,12 +11,36 @@ def init_speculator(vllm_config: VllmConfig, device: torch.device):
     speculative_config = vllm_config.speculative_config
     assert speculative_config is not None
     if speculative_config.method == "dflash":
+        remote_address = os.environ.get("VLLM_K3_DRAFT_REMOTE_ADDRESS")
+        if remote_address:
+            from vllm.v1.worker.gpu.spec_decode.dspark.remote_speculator import (
+                RemoteK3DSparkSpeculator,
+            )
+
+            return RemoteK3DSparkSpeculator(
+                vllm_config,
+                device,
+                address=remote_address,
+            )
         from vllm.v1.worker.gpu.spec_decode.dflash.speculator import (
             DFlashSpeculator,
         )
 
         return DFlashSpeculator(vllm_config, device)
     elif speculative_config.method == "dspark":
+        remote_address = os.environ.get(
+            "VLLM_K3_DRAFT_REMOTE_ADDRESS"
+        ) or os.environ.get("VLLM_K3_DSPARK_REMOTE_ADDRESS")
+        if remote_address:
+            from vllm.v1.worker.gpu.spec_decode.dspark.remote_speculator import (
+                RemoteK3DSparkSpeculator,
+            )
+
+            return RemoteK3DSparkSpeculator(
+                vllm_config,
+                device,
+                address=remote_address,
+            )
         from vllm.v1.worker.gpu.spec_decode.dspark.speculator import (
             DSparkSpeculator,
         )

--- a/vllm/v1/worker/gpu/spec_decode/__init__.py
+++ b/vllm/v1/worker/gpu/spec_decode/__init__.py
@@ -1,9 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-import os
-
 import torch
 
+from vllm import envs
 from vllm.config import VllmConfig
 
 
@@ -11,7 +10,7 @@ def init_speculator(vllm_config: VllmConfig, device: torch.device):
     speculative_config = vllm_config.speculative_config
     assert speculative_config is not None
     if speculative_config.method == "dflash":
-        remote_address = os.environ.get("VLLM_K3_DRAFT_REMOTE_ADDRESS")
+        remote_address = envs.VLLM_K3_DRAFT_REMOTE_ADDRESS
         if remote_address:
             from vllm.v1.worker.gpu.spec_decode.dspark.remote_speculator import (
                 RemoteK3DSparkSpeculator,
@@ -28,9 +27,9 @@ def init_speculator(vllm_config: VllmConfig, device: torch.device):
 
         return DFlashSpeculator(vllm_config, device)
     elif speculative_config.method == "dspark":
-        remote_address = os.environ.get(
-            "VLLM_K3_DRAFT_REMOTE_ADDRESS"
-        ) or os.environ.get("VLLM_K3_DSPARK_REMOTE_ADDRESS")
+        remote_address = (
+            envs.VLLM_K3_DRAFT_REMOTE_ADDRESS or envs.VLLM_K3_DSPARK_REMOTE_ADDRESS
+        )
         if remote_address:
             from vllm.v1.worker.gpu.spec_decode.dspark.remote_speculator import (
                 RemoteK3DSparkSpeculator,

--- a/vllm/v1/worker/gpu/spec_decode/dspark/remote_speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dspark/remote_speculator.py
@@ -728,6 +728,11 @@ class RemoteK3DSparkSpeculator(BaseSpeculator):
             if num_speculative_tokens is not None
             else self.num_speculative_steps
         )
+        # A scheduler can intentionally disable speculation for one step (for
+        # example, a request with max_tokens=1). ModelRunner treats an empty
+        # second dimension as a normal non-speculative step.
+        if active_k == 0:
+            return self.draft_tokens[: input_batch.num_reqs, :0].contiguous()
         if not 1 <= active_k <= self.num_speculative_steps:
             raise ValueError(
                 f"Remote DSpark depth must be in [1, "

--- a/vllm/v1/worker/gpu/spec_decode/dspark/remote_speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dspark/remote_speculator.py
@@ -1,0 +1,770 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Verifier-side proxy for a dedicated RTX 3090 K3 draft process."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+import zmq
+
+from vllm.config import VllmConfig
+from vllm.distributed import get_tp_group
+from vllm.logger import init_logger
+from vllm.v1.worker.gpu.input_batch import InputBatch
+from vllm.v1.worker.gpu.spec_decode.eagle.eagle3_utils import (
+    get_eagle3_aux_layers_from_config,
+)
+from vllm.v1.worker.gpu.spec_decode.speculator import (
+    BaseSpeculator,
+    CUDAGraphCapturePhase,
+)
+
+logger = init_logger(__name__)
+
+PROTOCOL_VERSION = 2
+
+
+@dataclass
+class _RetainedRequestPrefix:
+    token_ids: torch.Tensor
+    committed_end: int
+    context_start: int
+    serial: int
+
+
+def _build_valid_context_plan(
+    input_batch: InputBatch,
+    rejected_counts: list[int],
+) -> tuple[list[int], list[int]]:
+    """Return valid row indices and per-request counts."""
+    if len(rejected_counts) != input_batch.num_reqs:
+        raise ValueError("Rejected-token count does not match the request batch")
+    gather_indices: list[int] = []
+    valid_counts: list[int] = []
+    offset = 0
+    for request_idx, (scheduled, rejected) in enumerate(
+        zip(input_batch.num_scheduled_tokens.tolist(), rejected_counts)
+    ):
+        valid = int(scheduled) - int(rejected)
+        if not 0 <= valid <= int(scheduled):
+            raise ValueError(
+                f"Invalid valid-context length for request {request_idx}: "
+                f"scheduled={scheduled}, rejected={rejected}"
+            )
+        gather_indices.extend(range(offset, offset + valid))
+        valid_counts.append(valid)
+        offset += int(scheduled)
+    return gather_indices, valid_counts
+
+
+def _anchor_positions_from_context(
+    context_counts: list[int], context_positions: torch.Tensor
+) -> list[int]:
+    """Return the position immediately following each request's context."""
+    anchors: list[int] = []
+    offset = 0
+    for count in context_counts:
+        if count <= 0:
+            raise ValueError("Every remote draft request requires context rows")
+        offset += count
+        anchors.append(int(context_positions[offset - 1]) + 1)
+    if offset != context_positions.numel():
+        raise ValueError("Remote draft context counts do not match the position tensor")
+    return anchors
+
+
+def _contiguous_draft_output(
+    draft_tokens: torch.Tensor,
+    num_reqs: int,
+    num_speculative_tokens: int,
+) -> torch.Tensor:
+    """Return the active TP-broadcast region with a compact row stride."""
+    return draft_tokens[:num_reqs, :num_speculative_tokens].contiguous()
+
+
+class RemoteK3DSparkSpeculator(BaseSpeculator):
+    """Forward target auxiliary states to a standalone greedy draft server."""
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        device: torch.device,
+        *,
+        address: str,
+    ) -> None:
+        self.vllm_config = vllm_config
+        self.device = device
+        self.speculative_config = vllm_config.speculative_config
+        assert self.speculative_config is not None
+        self.method = str(self.speculative_config.method)
+        if self.method not in ("dspark", "dflash"):
+            raise ValueError(f"Unsupported remote K3 draft method: {self.method}")
+        if self.speculative_config.draft_sample_method != "greedy":
+            raise ValueError("Remote K3 draft currently supports greedy drafting only")
+        if self.speculative_config.rejection_sample_method != "block":
+            raise ValueError(
+                "Remote K3 draft currently requires block rejection sampling"
+            )
+        if vllm_config.model_config.dtype != torch.bfloat16:
+            raise ValueError("Remote K3 DSpark transport currently requires BF16")
+        self.num_speculative_steps = int(self.speculative_config.num_speculative_tokens)
+        self.max_num_reqs = int(vllm_config.scheduler_config.max_num_seqs)
+        self.max_num_tokens = int(vllm_config.scheduler_config.max_num_batched_tokens)
+        draft_hf_config = self.speculative_config.draft_model_config.hf_config
+        aux_layers = get_eagle3_aux_layers_from_config(self.speculative_config)
+        if not aux_layers:
+            raise ValueError(
+                f"Remote K3 {self.method} config does not declare auxiliary layers"
+            )
+        self.num_aux_layers = len(aux_layers)
+        target_hidden_size = int(
+            getattr(draft_hf_config, "target_hidden_size", None)
+            or draft_hf_config.hidden_size
+        )
+        self.raw_context_width = int(target_hidden_size * self.num_aux_layers)
+        self.address = address
+        self.timeout_ms = int(
+            os.environ.get(
+                "VLLM_K3_DRAFT_REMOTE_TIMEOUT_MS",
+                os.environ.get("VLLM_K3_DSPARK_REMOTE_TIMEOUT_MS", "30000"),
+            )
+        )
+        self.supports_mm_inputs = False
+        self.draft_logits: torch.Tensor | None = None
+        self.draft_tokens = torch.full(
+            (self.max_num_reqs, self.num_speculative_steps),
+            -1,
+            dtype=torch.int64,
+            device=device,
+        )
+        self._known_requests: set[str] = set()
+        self._disabled_requests: set[str] = set()
+        self._active_requests: set[str] = set()
+        self._retained_prefixes: dict[str, _RetainedRequestPrefix] = {}
+        self._retained_serial = 0
+        self._remote_max_requests = self.max_num_reqs
+        self._remote_block_size = 1
+        self._remote_window_size = 0
+        self._remote_prefix_cache_tokens = 0
+        self._timing_log_interval = int(
+            os.environ.get("VLLM_K3_DRAFT_TIMING_LOG_INTERVAL", "0")
+        )
+        if self._timing_log_interval < 0:
+            raise ValueError("VLLM_K3_DRAFT_TIMING_LOG_INTERVAL must be >= 0")
+        self._timing_count = 0
+        self._timing_totals_ms: dict[str, float] = {}
+
+        tp_group = get_tp_group()
+        self._tp_group = tp_group
+        self._tp_rank = int(tp_group.rank_in_group)
+        self._zmq_context: zmq.Context | None = None
+        self._socket: zmq.Socket | None = None
+        if self._tp_rank == 0:
+            # P2P is unavailable on the target host. Keep the mandatory D2H
+            # hop off pageable memory so it can be queued directly after the
+            # target forward on the current stream.
+            self._positions_staging = torch.empty(
+                self.max_num_tokens,
+                dtype=torch.int64,
+                pin_memory=True,
+            )
+            self._context_staging = torch.empty(
+                (self.max_num_tokens, self.raw_context_width),
+                dtype=vllm_config.model_config.dtype,
+                pin_memory=True,
+            )
+            self._rejected_staging = torch.empty(
+                self.max_num_reqs,
+                dtype=torch.int32,
+                pin_memory=True,
+            )
+            self._anchor_staging = torch.empty(
+                self.max_num_reqs,
+                dtype=torch.int64,
+                pin_memory=True,
+            )
+            self._zmq_context = zmq.Context()
+            self._connect()
+            response = self._rpc(
+                [json.dumps({"protocol": PROTOCOL_VERSION, "op": "PING"}).encode()]
+            )
+            if response.get("op") != "PONG":
+                raise RuntimeError(f"Unexpected K3 draft health response: {response}")
+            if response.get("method") != self.method:
+                raise RuntimeError(
+                    "Remote K3 draft method mismatch: "
+                    f"target={self.method}, server={response.get('method')}"
+                )
+            self._remote_max_requests = int(
+                response.get("max_requests", self.max_num_reqs)
+            )
+            self._remote_block_size = int(response.get("block_size", 1))
+            self._remote_window_size = int(response.get("window_size", 0))
+            self._remote_prefix_cache_tokens = int(
+                response.get("prefix_cache_tokens", 0)
+            )
+            if int(response.get("active_requests", 0)):
+                # A restarted verifier cannot safely identify state left by an
+                # older process, so establish a clean protocol epoch.
+                self._rpc(
+                    [json.dumps({"protocol": PROTOCOL_VERSION, "op": "CLEAR"}).encode()]
+                )
+
+        logger.info(
+            "Remote K3 %s proxy initialized: address=%s, TP rank=%d, K=%d",
+            self.method,
+            address,
+            self._tp_rank,
+            self.num_speculative_steps,
+        )
+
+    def _connect(self) -> None:
+        assert self._zmq_context is not None
+        if self._socket is not None:
+            self._socket.close()
+        socket = self._zmq_context.socket(zmq.REQ)
+        socket.setsockopt(zmq.LINGER, 0)
+        socket.setsockopt(zmq.SNDTIMEO, self.timeout_ms)
+        socket.setsockopt(zmq.RCVTIMEO, self.timeout_ms)
+        socket.connect(self.address)
+        self._socket = socket
+
+    def _rpc(self, frames: list[bytes]) -> dict[str, Any]:
+        assert self._socket is not None
+        try:
+            self._socket.send_multipart(frames)
+            response = self._socket.recv_json()
+        except Exception:
+            self._connect()
+            raise
+        if not isinstance(response, dict) or not response.get("ok", False):
+            raise RuntimeError(f"K3 DSpark RPC failed: {response}")
+        if int(response.get("protocol", -1)) != PROTOCOL_VERSION:
+            raise RuntimeError(f"K3 DSpark protocol mismatch: {response}")
+        return response
+
+    def init_cudagraph_manager(self, cudagraph_mode=None) -> None:
+        """The standalone drafter owns its CUDA graph lifecycle."""
+
+    def capture(self, *, capture_phase: CUDAGraphCapturePhase) -> None:
+        """The verifier has no local draft graph to capture."""
+
+    def _free_remote_requests(self, request_ids: set[str] | list[str]) -> None:
+        remote_request_ids = sorted(set(request_ids) & self._known_requests)
+        if not remote_request_ids:
+            return
+        self._rpc(
+            [
+                json.dumps(
+                    {
+                        "protocol": PROTOCOL_VERSION,
+                        "op": "FREE",
+                        "request_ids": remote_request_ids,
+                    }
+                ).encode()
+            ]
+        )
+        self._known_requests.difference_update(remote_request_ids)
+        for request_id in remote_request_ids:
+            self._retained_prefixes.pop(request_id, None)
+
+    def _ensure_remote_capacity(self, current_request_ids: set[str]) -> None:
+        while len(self._known_requests) >= self._remote_max_requests:
+            candidates = self._known_requests - current_request_ids
+            if not candidates:
+                raise RuntimeError(
+                    "Remote DSpark request capacity is exhausted by active requests"
+                )
+            request_id = min(
+                candidates,
+                key=lambda req_id: (
+                    self._retained_prefixes[req_id].serial
+                    if req_id in self._retained_prefixes
+                    else -1
+                ),
+            )
+            self._free_remote_requests({request_id})
+
+    @staticmethod
+    def _token_prefix(
+        input_batch: InputBatch,
+        request_idx: int,
+        prefix_end: int,
+    ) -> torch.Tensor | None:
+        token_table = input_batch.all_token_ids_cpu
+        if token_table is None or prefix_end < 0:
+            return None
+        state_idx = int(input_batch.idx_mapping_np[request_idx])
+        if state_idx < 0 or prefix_end > token_table.shape[1]:
+            return None
+        return token_table[state_idx, :prefix_end]
+
+    def _can_restore_prefix(
+        self,
+        retained: _RetainedRequestPrefix,
+        prefix_end: int,
+    ) -> bool:
+        if (
+            prefix_end <= 0
+            or retained.committed_end < prefix_end
+            or self._remote_window_size <= 0
+            or self._remote_prefix_cache_tokens < self._remote_window_size
+        ):
+            return False
+        restore_start = max(0, prefix_end - self._remote_window_size)
+        restore_start = (
+            restore_start // self._remote_block_size * self._remote_block_size
+        )
+        retained_start = max(
+            retained.context_start,
+            retained.committed_end - self._remote_prefix_cache_tokens,
+        )
+        return restore_start >= retained_start
+
+    def _find_reconnect_source(
+        self,
+        token_prefix: torch.Tensor,
+        prefix_end: int,
+        current_request_ids: set[str],
+    ) -> str | None:
+        candidates: list[tuple[int, int, str]] = []
+        for request_id in self._known_requests - current_request_ids:
+            retained = self._retained_prefixes.get(request_id)
+            if retained is None or not self._can_restore_prefix(retained, prefix_end):
+                continue
+            if torch.equal(retained.token_ids[:prefix_end], token_prefix):
+                candidates.append(
+                    (
+                        retained.committed_end - prefix_end,
+                        -retained.serial,
+                        request_id,
+                    )
+                )
+        return min(candidates)[2] if candidates else None
+
+    def _reconnect_request(
+        self,
+        source_request_id: str,
+        request_id: str,
+        prefix_end: int,
+        token_prefix: torch.Tensor,
+    ) -> bool:
+        try:
+            response = self._rpc(
+                [
+                    json.dumps(
+                        {
+                            "protocol": PROTOCOL_VERSION,
+                            "op": "RECONNECT",
+                            "source_request_id": source_request_id,
+                            "request_id": request_id,
+                            "prefix_end": prefix_end,
+                        }
+                    ).encode()
+                ]
+            )
+        except Exception:
+            logger.exception(
+                "Remote K3 DSpark prefix reconnect failed: source=%s, "
+                "request=%s, prefix_end=%d",
+                source_request_id,
+                request_id,
+                prefix_end,
+            )
+            return False
+
+        self._retained_prefixes.pop(source_request_id)
+        self._known_requests.discard(source_request_id)
+        self._known_requests.add(request_id)
+        self._retained_serial += 1
+        self._retained_prefixes[request_id] = _RetainedRequestPrefix(
+            token_ids=token_prefix.clone(),
+            committed_end=prefix_end,
+            context_start=int(response.get("restored_start", 0)),
+            serial=self._retained_serial,
+        )
+        logger.info(
+            "Remote K3 DSpark prefix reconnected: source=%s, request=%s, "
+            "prefix_end=%d, restored_start=%s, latency_ms=%.1f",
+            source_request_id,
+            request_id,
+            prefix_end,
+            response.get("restored_start"),
+            float(response.get("latency_ms", 0.0)),
+        )
+        return True
+
+    def _remember_prefix(
+        self,
+        input_batch: InputBatch,
+        request_idx: int,
+        request_id: str,
+        committed_end: int,
+        context_start: int | None = None,
+    ) -> None:
+        token_prefix = self._token_prefix(input_batch, request_idx, committed_end)
+        if token_prefix is None:
+            return
+        previous = self._retained_prefixes.get(request_id)
+        if context_start is None:
+            context_start = previous.context_start if previous is not None else 0
+        self._retained_serial += 1
+        self._retained_prefixes[request_id] = _RetainedRequestPrefix(
+            token_ids=token_prefix.clone(),
+            committed_end=committed_end,
+            context_start=context_start,
+            serial=self._retained_serial,
+        )
+
+    def _copy_tokens_from_response(
+        self,
+        response: dict[str, Any],
+        active_indices: list[int],
+        num_speculative_tokens: int,
+    ) -> None:
+        tokens = response.get("tokens")
+        expected_shape = (len(active_indices), num_speculative_tokens)
+        if (
+            not isinstance(tokens, list)
+            or len(tokens) != expected_shape[0]
+            or any(
+                not isinstance(row, list) or len(row) != expected_shape[1]
+                for row in tokens
+            )
+        ):
+            raise ValueError(
+                f"Remote DSpark token response has the wrong shape; "
+                f"expected={expected_shape}, got={tokens!r}"
+            )
+        remote_tokens = torch.tensor(tokens, dtype=torch.int64, device=self.device)
+        active_gpu = torch.tensor(active_indices, dtype=torch.int64, device=self.device)
+        # ``draft_tokens`` is allocated at the configured maximum depth, while
+        # adaptive speculation and the per-batch schedule can request a
+        # smaller depth for an individual step.  Copy into the matching width
+        # instead of requiring every response to have the maximum width.
+        self.draft_tokens[:, :num_speculative_tokens].index_copy_(
+            0, active_gpu, remote_tokens
+        )
+
+    def _record_timing(self, timing_ms: dict[str, float]) -> None:
+        if self._timing_log_interval <= 0:
+            return
+        self._timing_count += 1
+        for key, value in timing_ms.items():
+            self._timing_totals_ms[key] = self._timing_totals_ms.get(key, 0.0) + value
+        if self._timing_count < self._timing_log_interval:
+            return
+        means = {
+            key: value / self._timing_count
+            for key, value in self._timing_totals_ms.items()
+        }
+        logger.info(
+            "Remote K3 %s timing over %d proposals (ms): %s",
+            self.method,
+            self._timing_count,
+            ", ".join(f"{key}={value:.3f}" for key, value in means.items()),
+        )
+        self._timing_count = 0
+        self._timing_totals_ms.clear()
+
+    def _rank0_propose(
+        self,
+        input_batch: InputBatch,
+        aux_hidden_states: list[torch.Tensor] | None,
+        num_sampled: torch.Tensor,
+        num_rejected: torch.Tensor,
+        last_sampled: torch.Tensor,
+        next_prefill_tokens: torch.Tensor,
+        num_speculative_tokens: int,
+    ) -> None:
+        started = time.perf_counter()
+        if aux_hidden_states is None or len(aux_hidden_states) != self.num_aux_layers:
+            raise ValueError(
+                f"Remote K3 {self.method} requires {self.num_aux_layers} configured "
+                "target auxiliary hidden states"
+            )
+
+        num_reqs = input_batch.num_reqs
+        current_request_ids = set(input_batch.req_ids)
+        previous_active_requests = self._active_requests
+        self._disabled_requests.intersection_update(current_request_ids)
+        idx_mapping = input_batch.idx_mapping[:num_reqs].long()
+        sampled_counts = num_sampled[:num_reqs]
+        sampled_anchors = last_sampled[idx_mapping, 0]
+        prefill_anchors = next_prefill_tokens[0, idx_mapping]
+        anchor_tokens = torch.where(
+            sampled_counts > 0,
+            sampled_anchors,
+            prefill_anchors,
+        ).to(torch.int64)
+        # Queue both small D2H copies and wait once.  The same stream owns the
+        # preceding token-table update, so this synchronization also makes the
+        # UVA-backed table safe for prefix matching below.
+        rejected_staging = self._rejected_staging[:num_reqs]
+        anchor_staging = self._anchor_staging[:num_reqs]
+        rejected_staging.copy_(num_rejected[:num_reqs], non_blocking=True)
+        anchor_staging.copy_(anchor_tokens, non_blocking=True)
+        torch.cuda.current_stream(self.device).synchronize()
+        rejected_counts = rejected_staging.tolist()
+        anchor_tokens_cpu = anchor_staging.tolist()
+        gather_indices, valid_counts = _build_valid_context_plan(
+            input_batch, rejected_counts
+        )
+        metadata_ready = time.perf_counter()
+
+        active_indices: list[int] = []
+        requests: list[dict[str, Any]] = []
+        request_context_starts: list[int | None] = []
+        selected_gather_indices: list[int] = []
+        gather_offset = 0
+        for request_idx, request_id in enumerate(input_batch.req_ids):
+            valid_count = valid_counts[request_idx]
+            request_gather = gather_indices[gather_offset : gather_offset + valid_count]
+            gather_offset += valid_count
+            if request_id in self._disabled_requests or valid_count <= 0:
+                continue
+            first_position = int(input_batch.num_computed_tokens_np[request_idx])
+            is_continuing = (
+                request_id in previous_active_requests
+                and request_id in self._known_requests
+            )
+            reset = False
+            context_start: int | None = None
+            if not is_continuing:
+                if first_position == 0:
+                    if request_id in self._known_requests:
+                        self._free_remote_requests({request_id})
+                    self._ensure_remote_capacity(current_request_ids)
+                    reset = True
+                    context_start = 0
+                else:
+                    token_prefix = self._token_prefix(
+                        input_batch,
+                        request_idx,
+                        first_position,
+                    )
+                    source_request_id: str | None = None
+                    if token_prefix is not None:
+                        retained = self._retained_prefixes.get(request_id)
+                        if (
+                            request_id in self._known_requests
+                            and retained is not None
+                            and self._can_restore_prefix(retained, first_position)
+                            and torch.equal(
+                                retained.token_ids[:first_position], token_prefix
+                            )
+                        ):
+                            source_request_id = request_id
+                        else:
+                            source_request_id = self._find_reconnect_source(
+                                token_prefix,
+                                first_position,
+                                current_request_ids,
+                            )
+                    if source_request_id is None or token_prefix is None:
+                        if request_id in self._known_requests:
+                            self._free_remote_requests({request_id})
+                        self._ensure_remote_capacity(current_request_ids)
+                        reset = True
+                        context_start = first_position
+                        logger.warning(
+                            "Remote K3 %s cold-bootstrapping cache-restored "
+                            "request %s at position %d from %d fresh context "
+                            "rows; target verification preserves correctness.",
+                            self.method,
+                            request_id,
+                            first_position,
+                            valid_count,
+                        )
+                    elif not self._reconnect_request(
+                        source_request_id,
+                        request_id,
+                        first_position,
+                        token_prefix,
+                    ):
+                        self._disabled_requests.add(request_id)
+                        continue
+            requests.append(
+                {
+                    "request_id": request_id,
+                    "reset": reset,
+                    "reset_position": first_position if reset else 0,
+                    "context_count": valid_count,
+                    "anchor_token_id": int(anchor_tokens_cpu[request_idx]),
+                }
+            )
+            self._known_requests.add(request_id)
+            active_indices.append(request_idx)
+            request_context_starts.append(context_start)
+            selected_gather_indices.extend(request_gather)
+
+        self._active_requests = self._known_requests & current_request_ids
+        if not active_indices:
+            return
+        requests_ready = time.perf_counter()
+
+        indices_gpu = torch.tensor(
+            selected_gather_indices, dtype=torch.int64, device=self.device
+        )
+        positions = input_batch.positions.index_select(0, indices_gpu)
+        context = torch.cat(
+            [hidden.index_select(0, indices_gpu) for hidden in aux_hidden_states],
+            dim=-1,
+        )
+        num_context_rows = int(context.shape[0])
+        if num_context_rows > self.max_num_tokens:
+            raise ValueError(
+                f"Remote DSpark context has {num_context_rows} rows, max is "
+                f"{self.max_num_tokens}"
+            )
+        if context.shape[1] != self.raw_context_width:
+            raise ValueError(
+                f"Remote DSpark context width is {context.shape[1]}, expected "
+                f"{self.raw_context_width}"
+            )
+        context_ready = time.perf_counter()
+        positions_staging = self._positions_staging[:num_context_rows]
+        context_staging = self._context_staging[:num_context_rows]
+        positions_staging.copy_(positions, non_blocking=True)
+        context_staging.copy_(context, non_blocking=True)
+        torch.cuda.current_stream(self.device).synchronize()
+        context_copied = time.perf_counter()
+        anchor_positions = _anchor_positions_from_context(
+            [int(request["context_count"]) for request in requests],
+            positions_staging,
+        )
+        for request, anchor_position in zip(requests, anchor_positions):
+            request["anchor_position"] = anchor_position
+        positions_frame = positions_staging.numpy().tobytes()
+        # NumPy has inconsistent bfloat16 support; preserve its exact bits as u16.
+        context_frame = context_staging.view(torch.uint16).numpy().tobytes()
+        serialized = time.perf_counter()
+        header = {
+            "protocol": PROTOCOL_VERSION,
+            "op": "PROPOSE",
+            "projected": False,
+            "num_speculative_tokens": num_speculative_tokens,
+            "requests": requests,
+        }
+        response = self._rpc(
+            [json.dumps(header).encode(), positions_frame, context_frame]
+        )
+        rpc_done = time.perf_counter()
+        self._copy_tokens_from_response(
+            response,
+            active_indices,
+            num_speculative_tokens,
+        )
+        output_copied = time.perf_counter()
+        timing_ms = {
+            "metadata_d2h": (metadata_ready - started) * 1000,
+            "request_plan": (requests_ready - metadata_ready) * 1000,
+            "context_gather": (context_ready - requests_ready) * 1000,
+            "context_d2h": (context_copied - context_ready) * 1000,
+            "serialize": (serialized - context_copied) * 1000,
+            "rpc_roundtrip": (rpc_done - serialized) * 1000,
+            "tokens_h2d": (output_copied - rpc_done) * 1000,
+            "client_total": (output_copied - started) * 1000,
+        }
+        server_timing = response.get("timing_ms")
+        if isinstance(server_timing, dict):
+            for key, value in server_timing.items():
+                if isinstance(value, int | float):
+                    timing_ms[f"server_{key}"] = float(value)
+        self._record_timing(timing_ms)
+        for request_idx, request, anchor_position, context_start in zip(
+            active_indices,
+            requests,
+            anchor_positions,
+            request_context_starts,
+        ):
+            self._remember_prefix(
+                input_batch,
+                request_idx,
+                str(request["request_id"]),
+                anchor_position,
+                context_start,
+            )
+
+    @torch.inference_mode()
+    def propose(
+        self,
+        input_batch: InputBatch,
+        attn_metadata: dict[str, Any],
+        slot_mappings: dict[str, torch.Tensor],
+        last_hidden_states: torch.Tensor,
+        aux_hidden_states: list[torch.Tensor] | None,
+        num_sampled: torch.Tensor,
+        num_rejected: torch.Tensor,
+        last_sampled: torch.Tensor,
+        next_prefill_tokens: torch.Tensor,
+        temperature: torch.Tensor,
+        seeds: torch.Tensor,
+        num_speculative_tokens: int | None = None,
+        num_tokens_across_dp: torch.Tensor | None = None,
+        dummy_run: bool = False,
+        skip_attn_for_dummy_run: bool = False,
+        mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None,
+        is_profile: bool = False,
+    ) -> torch.Tensor:
+        del (
+            attn_metadata,
+            slot_mappings,
+            last_hidden_states,
+            temperature,
+            seeds,
+            num_tokens_across_dp,
+            skip_attn_for_dummy_run,
+            mm_inputs,
+        )
+        active_k = (
+            int(num_speculative_tokens)
+            if num_speculative_tokens is not None
+            else self.num_speculative_steps
+        )
+        if not 1 <= active_k <= self.num_speculative_steps:
+            raise ValueError(
+                f"Remote DSpark depth must be in [1, "
+                f"{self.num_speculative_steps}], got {active_k}"
+            )
+        output = self.draft_tokens[: input_batch.num_reqs, :active_k]
+        output.fill_(-1)
+        if self._tp_rank == 0 and not (dummy_run or is_profile):
+            try:
+                self._rank0_propose(
+                    input_batch,
+                    aux_hidden_states,
+                    num_sampled,
+                    num_rejected,
+                    last_sampled,
+                    next_prefill_tokens,
+                    active_k,
+                )
+            except Exception:
+                output.fill_(-1)
+                # The verifier cannot know whether a timed-out request mutated
+                # remote KV. Fail closed for those requests until they leave
+                # the active batch; FREE remains safe even if the server never
+                # created the state.
+                self._disabled_requests.update(input_batch.req_ids)
+                logger.exception(
+                    "Remote K3 DSpark proposal failed; drafting is disabled for "
+                    "this step"
+                )
+        # Slicing the active depth from the max-width persistent buffer leaves
+        # a larger row stride whenever adaptive K is below the configured
+        # maximum. NCCL broadcast requires a contiguous tensor. Materialize
+        # only the tiny [batch, K] result after rank 0 has populated it.
+        output = _contiguous_draft_output(
+            self.draft_tokens,
+            input_batch.num_reqs,
+            active_k,
+        )
+        self._tp_group.broadcast(output, src=0)
+        return output

--- a/vllm/v1/worker/gpu/spec_decode/dspark/remote_speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dspark/remote_speculator.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import json
+import math
 import os
 import time
 from dataclasses import dataclass
@@ -17,6 +18,7 @@ from vllm.config import VllmConfig
 from vllm.distributed import get_tp_group
 from vllm.logger import init_logger
 from vllm.v1.worker.gpu.input_batch import InputBatch
+from vllm.v1.worker.gpu.sample.gumbel import gumbel_sample
 from vllm.v1.worker.gpu.spec_decode.eagle.eagle3_utils import (
     get_eagle3_aux_layers_from_config,
 )
@@ -24,6 +26,7 @@ from vllm.v1.worker.gpu.spec_decode.speculator import (
     BaseSpeculator,
     CUDAGraphCapturePhase,
 )
+from vllm.v1.worker.gpu.spec_decode.utils import draft_gumbel_pos
 
 logger = init_logger(__name__)
 
@@ -88,8 +91,42 @@ def _contiguous_draft_output(
     return draft_tokens[:num_reqs, :num_speculative_tokens].contiguous()
 
 
+LOGITS_CAPABILITY = "dflash_logits_bf16_v1"
+
+
+def _decode_bfloat16_logits_frame(
+    response: dict[str, Any],
+    expected_shape: tuple[int, int, int],
+) -> torch.Tensor:
+    """Decode and validate a BF16 draft-logit multipart frame."""
+    metadata = response.get("logits")
+    frame = response.get("_logits_frame")
+    if not isinstance(metadata, dict) or not isinstance(frame, bytes):
+        raise ValueError("Remote DFlash response is missing its logits frame")
+    if metadata.get("capability") != LOGITS_CAPABILITY:
+        raise ValueError(f"Unsupported logits capability: {metadata}")
+    if metadata.get("dtype") != "bfloat16":
+        raise ValueError(f"Unsupported logits dtype: {metadata}")
+    if tuple(metadata.get("shape", ())) != expected_shape:
+        raise ValueError(
+            f"Remote DFlash logits shape mismatch: expected={expected_shape}, "
+            f"metadata={metadata}"
+        )
+    expected_nbytes = math.prod(expected_shape) * 2
+    if metadata.get("nbytes") != expected_nbytes or len(frame) != expected_nbytes:
+        raise ValueError(
+            "Remote DFlash logits byte count mismatch: "
+            f"expected={expected_nbytes}, metadata={metadata}, frame={len(frame)}"
+        )
+    return (
+        torch.frombuffer(bytearray(frame), dtype=torch.uint16)
+        .view(torch.bfloat16)
+        .reshape(expected_shape)
+    )
+
+
 class RemoteK3DSparkSpeculator(BaseSpeculator):
-    """Forward target auxiliary states to a standalone greedy draft server."""
+    """Forward target auxiliary states to a standalone draft server."""
 
     def __init__(
         self,
@@ -105,8 +142,12 @@ class RemoteK3DSparkSpeculator(BaseSpeculator):
         self.method = str(self.speculative_config.method)
         if self.method not in ("dspark", "dflash"):
             raise ValueError(f"Unsupported remote K3 draft method: {self.method}")
-        if self.speculative_config.draft_sample_method != "greedy":
-            raise ValueError("Remote K3 draft currently supports greedy drafting only")
+        sample_method = self.speculative_config.draft_sample_method
+        if sample_method not in ("greedy", "probabilistic"):
+            raise ValueError(f"Unsupported remote draft sample method: {sample_method}")
+        self._probabilistic = sample_method == "probabilistic"
+        if self._probabilistic and self.method != "dflash":
+            raise ValueError("Remote probabilistic sampling supports DFlash only")
         if self.speculative_config.rejection_sample_method != "block":
             raise ValueError(
                 "Remote K3 draft currently requires block rejection sampling"
@@ -128,6 +169,8 @@ class RemoteK3DSparkSpeculator(BaseSpeculator):
             or draft_hf_config.hidden_size
         )
         self.raw_context_width = int(target_hidden_size * self.num_aux_layers)
+        self.vocab_size = int(draft_hf_config.vocab_size)
+        self.use_fp64_gumbel = bool(vllm_config.model_config.use_fp64_gumbel)
         self.address = address
         self.timeout_ms = int(
             os.environ.get(
@@ -137,6 +180,28 @@ class RemoteK3DSparkSpeculator(BaseSpeculator):
         )
         self.supports_mm_inputs = False
         self.draft_logits: torch.Tensor | None = None
+        self._remote_logits: torch.Tensor | None = None
+        self._remote_sample_positions: torch.Tensor | None = None
+        if self._probabilistic:
+            head_dtype = vllm_config.model_config.head_dtype
+            if head_dtype != torch.bfloat16:
+                raise ValueError(
+                    "Remote probabilistic DFlash transport requires a BF16 head, "
+                    f"got {head_dtype}"
+                )
+            shape = (
+                self.max_num_reqs,
+                self.num_speculative_steps,
+                self.vocab_size,
+            )
+            self.draft_logits = torch.zeros(shape, dtype=head_dtype, device=device)
+            self._remote_logits = torch.zeros(shape, dtype=head_dtype, device=device)
+            self._remote_sample_positions = torch.full(
+                shape[:2],
+                -1,
+                dtype=torch.int64,
+                device=device,
+            )
         self.draft_tokens = torch.full(
             (self.max_num_reqs, self.num_speculative_steps),
             -1,
@@ -189,6 +254,16 @@ class RemoteK3DSparkSpeculator(BaseSpeculator):
                 dtype=torch.int64,
                 pin_memory=True,
             )
+            if self._probabilistic:
+                self._logits_staging = torch.empty(
+                    (
+                        self.max_num_reqs,
+                        self.num_speculative_steps,
+                        self.vocab_size,
+                    ),
+                    dtype=torch.bfloat16,
+                    pin_memory=True,
+                )
             self._zmq_context = zmq.Context()
             self._connect()
             response = self._rpc(
@@ -200,6 +275,11 @@ class RemoteK3DSparkSpeculator(BaseSpeculator):
                 raise RuntimeError(
                     "Remote K3 draft method mismatch: "
                     f"target={self.method}, server={response.get('method')}"
+                )
+            capabilities = response.get("capabilities", [])
+            if self._probabilistic and LOGITS_CAPABILITY not in capabilities:
+                raise RuntimeError(
+                    "Remote DFlash server does not advertise probabilistic logits"
                 )
             self._remote_max_requests = int(
                 response.get("max_requests", self.max_num_reqs)
@@ -239,10 +319,17 @@ class RemoteK3DSparkSpeculator(BaseSpeculator):
         assert self._socket is not None
         try:
             self._socket.send_multipart(frames)
-            response = self._socket.recv_json()
+            response_frames = self._socket.recv_multipart()
         except Exception:
             self._connect()
             raise
+        if not 1 <= len(response_frames) <= 2:
+            raise RuntimeError(
+                f"K3 draft RPC returned {len(response_frames)} response frames"
+            )
+        response = json.loads(response_frames[0])
+        if len(response_frames) == 2:
+            response["_logits_frame"] = response_frames[1]
         if not isinstance(response, dict) or not response.get("ok", False):
             raise RuntimeError(f"K3 DSpark RPC failed: {response}")
         if int(response.get("protocol", -1)) != PROTOCOL_VERSION:
@@ -452,6 +539,106 @@ class RemoteK3DSparkSpeculator(BaseSpeculator):
             0, active_gpu, remote_tokens
         )
 
+    def _copy_logits_from_response(
+        self,
+        response: dict[str, Any],
+        active_indices: list[int],
+        num_speculative_tokens: int,
+    ) -> None:
+        assert self._remote_logits is not None
+        assert self._remote_sample_positions is not None
+        expected_shape = (
+            len(active_indices),
+            num_speculative_tokens,
+            self.vocab_size,
+        )
+        logits = _decode_bfloat16_logits_frame(response, expected_shape)
+        sample_positions = response["logits"].get("sample_positions")
+        expected_positions = expected_shape[:2]
+        if (
+            not isinstance(sample_positions, list)
+            or len(sample_positions) != expected_positions[0]
+            or any(
+                not isinstance(row, list) or len(row) != expected_positions[1]
+                for row in sample_positions
+            )
+        ):
+            raise ValueError(
+                "Remote DFlash sample positions have the wrong shape: "
+                f"expected={expected_positions}, got={sample_positions!r}"
+            )
+        active_gpu = torch.tensor(active_indices, dtype=torch.int64, device=self.device)
+        logits_staging = self._logits_staging[
+            : len(active_indices), :num_speculative_tokens
+        ]
+        logits_staging.copy_(logits)
+        self._remote_logits.index_copy_(
+            0,
+            active_gpu,
+            logits_staging.to(self.device, non_blocking=True),
+        )
+        positions = torch.tensor(
+            sample_positions,
+            dtype=torch.int64,
+            device=self.device,
+        )
+        self._remote_sample_positions.index_copy_(0, active_gpu, positions)
+
+    def _sample_remote_probabilistic(
+        self,
+        input_batch: InputBatch,
+        temperature: torch.Tensor,
+        seeds: torch.Tensor,
+        num_speculative_tokens: int,
+    ) -> None:
+        assert self.draft_logits is not None
+        assert self._remote_logits is not None
+        assert self._remote_sample_positions is not None
+        logger.info_once(
+            "Remote K3 DFlash probabilistic sampling is active with "
+            "full-vocabulary BF16 logits"
+        )
+        num_reqs = input_batch.num_reqs
+        positions = self._remote_sample_positions[:num_reqs, :num_speculative_tokens]
+        request_rows, draft_steps = torch.where(positions >= 0)
+        if request_rows.numel() == 0:
+            return
+        idx_mapping = input_batch.idx_mapping[:num_reqs].index_select(0, request_rows)
+        logits = self._remote_logits[request_rows, draft_steps].contiguous()
+        sampled = self._sample_probabilistic_draft(
+            logits=logits,
+            positions=positions[request_rows, draft_steps] - 2,
+            idx_mapping=idx_mapping,
+            temperature=temperature,
+            seeds=seeds,
+            draft_step=draft_steps,
+            draft_logits=self.draft_logits,
+        )
+        self.draft_tokens[request_rows, draft_steps] = sampled
+
+    def _sample_probabilistic_draft(
+        self,
+        logits: torch.Tensor,
+        positions: torch.Tensor,
+        idx_mapping: torch.Tensor,
+        temperature: torch.Tensor,
+        seeds: torch.Tensor,
+        draft_step: torch.Tensor,
+        draft_logits: torch.Tensor,
+    ) -> torch.Tensor:
+        """Sample remote logits from the standard disjoint draft stream."""
+        return gumbel_sample(
+            logits,
+            idx_mapping,
+            temperature,
+            seeds,
+            draft_gumbel_pos(positions),
+            apply_temperature=True,
+            logits_cache=draft_logits,
+            logits_cache_col=draft_step,
+            use_fp64=self.use_fp64_gumbel,
+        )
+
     def _record_timing(self, timing_ms: dict[str, float]) -> None:
         if self._timing_log_interval <= 0:
             return
@@ -650,6 +837,7 @@ class RemoteK3DSparkSpeculator(BaseSpeculator):
             "op": "PROPOSE",
             "projected": False,
             "num_speculative_tokens": num_speculative_tokens,
+            "return_logits": self._probabilistic,
             "requests": requests,
         }
         response = self._rpc(
@@ -661,6 +849,12 @@ class RemoteK3DSparkSpeculator(BaseSpeculator):
             active_indices,
             num_speculative_tokens,
         )
+        if self._probabilistic:
+            self._copy_logits_from_response(
+                response,
+                active_indices,
+                num_speculative_tokens,
+            )
         output_copied = time.perf_counter()
         timing_ms = {
             "metadata_d2h": (metadata_ready - started) * 1000,
@@ -717,8 +911,6 @@ class RemoteK3DSparkSpeculator(BaseSpeculator):
             attn_metadata,
             slot_mappings,
             last_hidden_states,
-            temperature,
-            seeds,
             num_tokens_across_dp,
             skip_attn_for_dummy_run,
             mm_inputs,
@@ -740,6 +932,13 @@ class RemoteK3DSparkSpeculator(BaseSpeculator):
             )
         output = self.draft_tokens[: input_batch.num_reqs, :active_k]
         output.fill_(-1)
+        if self._probabilistic:
+            assert self.draft_logits is not None
+            assert self._remote_logits is not None
+            assert self._remote_sample_positions is not None
+            self.draft_logits.zero_()
+            self._remote_logits.zero_()
+            self._remote_sample_positions.fill_(-1)
         if self._tp_rank == 0 and not (dummy_run or is_profile):
             try:
                 self._rank0_propose(
@@ -762,6 +961,17 @@ class RemoteK3DSparkSpeculator(BaseSpeculator):
                     "Remote K3 DSpark proposal failed; drafting is disabled for "
                     "this step"
                 )
+        if self._probabilistic and not (dummy_run or is_profile):
+            assert self._remote_logits is not None
+            assert self._remote_sample_positions is not None
+            self._tp_group.broadcast(self._remote_logits, src=0)
+            self._tp_group.broadcast(self._remote_sample_positions, src=0)
+            self._sample_remote_probabilistic(
+                input_batch,
+                temperature,
+                seeds,
+                active_k,
+            )
         # Slicing the active depth from the max-width persistent buffer leaves
         # a larger row stride whenever adaptive K is below the configured
         # maximum. NCCL broadcast requires a contiguous tensor. Materialize

--- a/vllm/v1/worker/gpu/spec_decode/dspark/remote_speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dspark/remote_speculator.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 import json
 import math
-import os
 import time
 from dataclasses import dataclass
 from typing import Any
@@ -14,6 +13,7 @@ from typing import Any
 import torch
 import zmq
 
+from vllm import envs
 from vllm.config import VllmConfig
 from vllm.distributed import get_tp_group
 from vllm.logger import init_logger
@@ -52,7 +52,11 @@ def _build_valid_context_plan(
     valid_counts: list[int] = []
     offset = 0
     for request_idx, (scheduled, rejected) in enumerate(
-        zip(input_batch.num_scheduled_tokens.tolist(), rejected_counts)
+        zip(
+            input_batch.num_scheduled_tokens.tolist(),
+            rejected_counts,
+            strict=True,
+        )
     ):
         valid = int(scheduled) - int(rejected)
         if not 0 <= valid <= int(scheduled):
@@ -169,15 +173,18 @@ class RemoteK3DSparkSpeculator(BaseSpeculator):
             or draft_hf_config.hidden_size
         )
         self.raw_context_width = int(target_hidden_size * self.num_aux_layers)
-        self.vocab_size = int(draft_hf_config.vocab_size)
+        self.vocab_size = int(vllm_config.model_config.get_vocab_size())
+        draft_vocab_size = int(draft_hf_config.vocab_size)
+        if draft_vocab_size != self.vocab_size:
+            raise ValueError(
+                "Remote K3 draft and target vocabulary sizes must match: "
+                f"draft={draft_vocab_size}, target={self.vocab_size}"
+            )
         self.use_fp64_gumbel = bool(vllm_config.model_config.use_fp64_gumbel)
         self.address = address
-        self.timeout_ms = int(
-            os.environ.get(
-                "VLLM_K3_DRAFT_REMOTE_TIMEOUT_MS",
-                os.environ.get("VLLM_K3_DSPARK_REMOTE_TIMEOUT_MS", "30000"),
-            )
-        )
+        self.timeout_ms = envs.VLLM_K3_DRAFT_REMOTE_TIMEOUT_MS
+        if self.timeout_ms < 1:
+            raise ValueError("VLLM_K3_DRAFT_REMOTE_TIMEOUT_MS must be positive")
         self.supports_mm_inputs = False
         self.draft_logits: torch.Tensor | None = None
         self._remote_logits: torch.Tensor | None = None
@@ -217,9 +224,7 @@ class RemoteK3DSparkSpeculator(BaseSpeculator):
         self._remote_block_size = 1
         self._remote_window_size = 0
         self._remote_prefix_cache_tokens = 0
-        self._timing_log_interval = int(
-            os.environ.get("VLLM_K3_DRAFT_TIMING_LOG_INTERVAL", "0")
-        )
+        self._timing_log_interval = envs.VLLM_K3_DRAFT_TIMING_LOG_INTERVAL
         if self._timing_log_interval < 0:
             raise ValueError("VLLM_K3_DRAFT_TIMING_LOG_INTERVAL must be >= 0")
         self._timing_count = 0
@@ -284,6 +289,26 @@ class RemoteK3DSparkSpeculator(BaseSpeculator):
             self._remote_max_requests = int(
                 response.get("max_requests", self.max_num_reqs)
             )
+            remote_max_batch_size = int(
+                response.get("max_batch_size", self._remote_max_requests)
+            )
+            if self.max_num_reqs > remote_max_batch_size:
+                raise RuntimeError(
+                    "Remote K3 draft batch capacity is smaller than the target "
+                    f"scheduler: remote={remote_max_batch_size}, "
+                    f"target={self.max_num_reqs}"
+                )
+            remote_max_depth = int(
+                response.get(
+                    "max_speculative_tokens",
+                    self.num_speculative_steps,
+                )
+            )
+            if self.num_speculative_steps > remote_max_depth:
+                raise RuntimeError(
+                    "Remote K3 draft depth is smaller than the target scheduler: "
+                    f"remote={remote_max_depth}, target={self.num_speculative_steps}"
+                )
             self._remote_block_size = int(response.get("block_size", 1))
             self._remote_window_size = int(response.get("window_size", 0))
             self._remote_prefix_cache_tokens = int(
@@ -359,6 +384,15 @@ class RemoteK3DSparkSpeculator(BaseSpeculator):
         )
         self._known_requests.difference_update(remote_request_ids)
         for request_id in remote_request_ids:
+            self._retained_prefixes.pop(request_id, None)
+
+    def _discard_failed_requests(self, request_ids: list[str]) -> None:
+        """Forget all local state whose remote mutation is now uncertain."""
+        failed = set(request_ids)
+        self._disabled_requests.update(failed)
+        self._known_requests.difference_update(failed)
+        self._active_requests.difference_update(failed)
+        for request_id in failed:
             self._retained_prefixes.pop(request_id, None)
 
     def _ensure_remote_capacity(self, current_request_ids: set[str]) -> None:
@@ -528,6 +562,15 @@ class RemoteK3DSparkSpeculator(BaseSpeculator):
             raise ValueError(
                 f"Remote DSpark token response has the wrong shape; "
                 f"expected={expected_shape}, got={tokens!r}"
+            )
+        if any(
+            type(token) is not int or not 0 <= token < self.vocab_size
+            for row in tokens
+            for token in row
+        ):
+            raise ValueError(
+                "Remote DSpark token response contains an out-of-vocabulary "
+                f"token; vocab_size={self.vocab_size}, tokens={tokens!r}"
             )
         remote_tokens = torch.tensor(tokens, dtype=torch.int64, device=self.device)
         active_gpu = torch.tensor(active_indices, dtype=torch.int64, device=self.device)
@@ -826,7 +869,11 @@ class RemoteK3DSparkSpeculator(BaseSpeculator):
             [int(request["context_count"]) for request in requests],
             positions_staging,
         )
-        for request, anchor_position in zip(requests, anchor_positions):
+        for request, anchor_position in zip(
+            requests,
+            anchor_positions,
+            strict=True,
+        ):
             request["anchor_position"] = anchor_position
         positions_frame = positions_staging.numpy().tobytes()
         # NumPy has inconsistent bfloat16 support; preserve its exact bits as u16.
@@ -877,6 +924,7 @@ class RemoteK3DSparkSpeculator(BaseSpeculator):
             requests,
             anchor_positions,
             request_context_starts,
+            strict=True,
         ):
             self._remember_prefix(
                 input_batch,
@@ -953,10 +1001,10 @@ class RemoteK3DSparkSpeculator(BaseSpeculator):
             except Exception:
                 output.fill_(-1)
                 # The verifier cannot know whether a timed-out request mutated
-                # remote KV. Fail closed for those requests until they leave
-                # the active batch; FREE remains safe even if the server never
-                # created the state.
-                self._disabled_requests.update(input_batch.req_ids)
+                # remote KV. Fail closed until those requests leave the active
+                # batch, and discard every local record tied to that uncertain
+                # remote state.
+                self._discard_failed_requests(input_batch.req_ids)
                 logger.exception(
                     "Remote K3 DSpark proposal failed; drafting is disabled for "
                     "this step"

--- a/vllm/v1/worker/gpu/spec_decode/dspark/remote_speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dspark/remote_speculator.py
@@ -216,8 +216,16 @@ class RemoteK3DSparkSpeculator(BaseSpeculator):
             device=device,
         )
         self._known_requests: set[str] = set()
+        # Requests skipped by proposals: a failed RPC left their remote state
+        # uncertain, or a reconnect failed. Each id stays here until it leaves
+        # the batch or the stale sweep below releases it.
         self._disabled_requests: set[str] = set()
         self._active_requests: set[str] = set()
+        # Ids whose remote slot may still exist after a failed RPC. The next
+        # proposal frees them first (FREE is a no-op for unknown ids), which
+        # reclaims the slot and re-enables the requests: their next proposal
+        # then resets the remote state from fresh context rows.
+        self._stale_remote_requests: set[str] = set()
         self._retained_prefixes: dict[str, _RetainedRequestPrefix] = {}
         self._retained_serial = 0
         self._remote_max_requests = self.max_num_reqs
@@ -309,6 +317,16 @@ class RemoteK3DSparkSpeculator(BaseSpeculator):
                     "Remote K3 draft depth is smaller than the target scheduler: "
                     f"remote={remote_max_depth}, target={self.num_speculative_steps}"
                 )
+            remote_max_context_tokens = response.get("max_context_tokens")
+            if remote_max_context_tokens is not None and self.max_num_tokens > int(
+                remote_max_context_tokens
+            ):
+                raise RuntimeError(
+                    "Remote K3 draft context-row capacity is smaller than the "
+                    "target scheduler's batch: "
+                    f"remote={int(remote_max_context_tokens)}, "
+                    f"target={self.max_num_tokens}"
+                )
             self._remote_block_size = int(response.get("block_size", 1))
             self._remote_window_size = int(response.get("window_size", 0))
             self._remote_prefix_cache_tokens = int(
@@ -367,8 +385,24 @@ class RemoteK3DSparkSpeculator(BaseSpeculator):
     def capture(self, *, capture_phase: CUDAGraphCapturePhase) -> None:
         """The verifier has no local draft graph to capture."""
 
-    def _free_remote_requests(self, request_ids: set[str] | list[str]) -> None:
-        remote_request_ids = sorted(set(request_ids) & self._known_requests)
+    def _free_remote_requests(
+        self,
+        request_ids: set[str] | list[str],
+        *,
+        known_only: bool = True,
+    ) -> None:
+        """Free remote draft state.
+
+        Args:
+            request_ids: Request ids whose remote state is released.
+            known_only: Free only ids the verifier still tracks. ``False``
+                also frees ids dropped after a failed RPC; the server treats
+                an unknown id as already free.
+        """
+        remote_request_ids = set(request_ids)
+        if known_only:
+            remote_request_ids &= self._known_requests
+        remote_request_ids = sorted(remote_request_ids)
         if not remote_request_ids:
             return
         self._rpc(
@@ -390,10 +424,27 @@ class RemoteK3DSparkSpeculator(BaseSpeculator):
         """Forget all local state whose remote mutation is now uncertain."""
         failed = set(request_ids)
         self._disabled_requests.update(failed)
+        self._stale_remote_requests.update(failed & self._known_requests)
         self._known_requests.difference_update(failed)
         self._active_requests.difference_update(failed)
         for request_id in failed:
             self._retained_prefixes.pop(request_id, None)
+
+    def _release_stale_remote_requests(self) -> None:
+        """Free remote slots left by failed RPCs and re-enable their requests.
+
+        Runs before a proposal. A transport failure here raises to the
+        proposal's failure path, which keeps every id stale for a later
+        attempt. After a successful FREE the requests draft again: nothing
+        local refers to their old remote state, so their next proposal is a
+        reset or a cold bootstrap.
+        """
+        if not self._stale_remote_requests:
+            return
+        stale = set(self._stale_remote_requests)
+        self._free_remote_requests(stale, known_only=False)
+        self._stale_remote_requests.clear()
+        self._disabled_requests.difference_update(stale)
 
     def _ensure_remote_capacity(self, current_request_ids: set[str]) -> None:
         while len(self._known_requests) >= self._remote_max_requests:
@@ -498,6 +549,12 @@ class RemoteK3DSparkSpeculator(BaseSpeculator):
                 request_id,
                 prefix_end,
             )
+            # The server may or may not have rebound the source slot. Neither
+            # id is trusted any more: both are freed before the next proposal,
+            # after which the request cold-bootstraps.
+            self._retained_prefixes.pop(source_request_id, None)
+            self._known_requests.discard(source_request_id)
+            self._stale_remote_requests.update({source_request_id, request_id})
             return False
 
         self._retained_prefixes.pop(source_request_id)
@@ -724,6 +781,7 @@ class RemoteK3DSparkSpeculator(BaseSpeculator):
         current_request_ids = set(input_batch.req_ids)
         previous_active_requests = self._active_requests
         self._disabled_requests.intersection_update(current_request_ids)
+        self._release_stale_remote_requests()
         idx_mapping = input_batch.idx_mapping[:num_reqs].long()
         sampled_counts = num_sampled[:num_reqs]
         sampled_anchors = last_sampled[idx_mapping, 0]

--- a/vllm/v1/worker/gpu/spec_decode/utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/utils.py
@@ -34,6 +34,8 @@ def limit_draft_tokens(
             "Speculator returned unsupported draft shape "
             f"{tuple(draft_tokens.shape)}; expected a 2D tensor."
         )
+    if num_speculative_tokens == 0:
+        return draft_tokens[:, :0]
     if not 1 <= num_speculative_tokens <= max_num_speculative_tokens:
         raise RuntimeError(
             "Scheduler selected an invalid speculative-token count "

--- a/vllm/v1/worker/gpu/spec_decode/utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/utils.py
@@ -113,6 +113,23 @@ class DraftTokensHandler:
         return DraftTokenIds(self.req_ids, draft_token_ids)
 
 
+def draft_query_len(method: str, num_speculative_tokens: int) -> int:
+    """Return the draft query rows one proposal step runs.
+
+    Args:
+        method: ``"dspark"`` samples every draft token from the anchor row,
+            so the query holds ``num_speculative_tokens`` rows; ``"dflash"``
+            prepends the anchor to the mask rows.
+        num_speculative_tokens: Draft depth of the step.
+
+    Returns:
+        The number of query rows, including the anchor row for DFlash.
+    """
+    if method == "dspark":
+        return int(num_speculative_tokens)
+    return 1 + int(num_speculative_tokens)
+
+
 def get_parallel_drafting_token_id(hf_config) -> int:
     """Resolve the mask token id used for parallel drafting slots.
 


### PR DESCRIPTION
## What

Adds a verifier-side proxy (`RemoteK3DSparkSpeculator`) and a standalone draft server (`vllm.entrypoints.k3_dspark_standalone` + `k3_dspark_rpc`) so the DSpark draft model executes on its own single GPU while the target runs TP/DCP on separate GPUs. Draft weights, KV, Markov head, and CUDA graphs live entirely on the draft process; the target exchanges context and proposals over a versioned ZMQ/TCP protocol (`PROTOCOL_VERSION=2`).

This is the transport used by the qualified 8-GPU production runtime: a TP8/DCP8 Kimi-K3 target on 8 RTX PRO 6000 Blackwell GPUs has no VRAM headroom for the BF16 draft, so a ninth GPU (RTX 3090) hosts the draft and serves proposals over loopback TCP.

## Behavior and invariants

- `VLLM_K3_DRAFT_REMOTE_ADDRESS` (or legacy `VLLM_K3_DSPARK_REMOTE_ADDRESS`) selects the remote path at speculator construction; unset preserves the existing local DSpark/DFlash path. `VLLM_K3_DRAFT_REMOTE_TIMEOUT_MS` bounds each RPC; `VLLM_K3_DRAFT_TIMING_LOG_INTERVAL` controls periodic draft-timing logs.
- `propose()` matches `BaseSpeculator`'s signature; rank 0 performs RPC and all ranks consume the broadcast result.
- Fail closed: any RPC failure fills draft tokens with -1, disables affected requests until they leave the batch, and discards local known/active/retained-prefix records so uncertain remote state cannot be reconnected.
- Retained-prefix reconnection validates a target prefix-cache hit against retained draft state via a host-visible view of the request token table (`InputBatch.all_token_ids_cpu`, backed by `StagedWriteTensor.cpu`).
- CUDA-graph capture interface preserved: `init_cudagraph_manager` and `capture(capture_phase=...)` conform to `BaseSpeculator`.

## Compatibility

No behavior change when the remote address is unset. The draft side supports DSpark and DFlash checkpoints on a single GPU, including Ampere-class cards.

## Validation

- 19 new CPU unit tests pass: `tests/v1/spec_decode/test_k3_dspark_remote_speculator.py`, `tests/v1/spec_decode/test_k3_dspark_standalone.py` (run under the r29 upstream-aligned image against this branch).
- Production-qualified serving `lukealonso/Kimi-K3-QSRT-K2` TP8/DCP8 with the Inferact BF16 DSpark draft on a dedicated RTX 3090 (remote proposal over `tcp://127.0.0.1:8092`), including LMCache external prefix-hit replay through the retained-prefix reconnection path.

## Limitations

One remote draft process (draft TP1); TCP transport; probabilistic transport currently supports DFlash only; block rejection remains required on the verifier.

AI assistance was used in the preparation of the original change. The probabilistic follow-up below requires a fresh human review before this PR is ready to merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added remote K3 DSpark/DFlash speculative decoding over ZeroMQ.
  * Added probabilistic DFlash drafting with BF16 logits support.
  * Added a standalone draft-model runtime with configurable transport, CUDA graph support, health/status endpoints, and lifecycle controls.
  * Added prefix reconnection, adaptive-depth proposals, cache management, and GPU/host memory tracking.
  * Added support for disabling speculation when zero draft tokens are scheduled.
* **Bug Fixes**
  * Improved validation and safe handling of context plans, cached prefixes, request data, response frames, and device compatibility.
* **Tests**
  * Added coverage for remote logits, sampling, checkpoint resolution, KV-cache reuse, prefix handling, and projected-context caching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Probabilistic remote DFlash follow-up

Commit `a2397d9787a` adds an opt-in `dflash_logits_bf16_v1` capability. DFlash servers return pre-temperature full-vocabulary BF16 logits in a second ZMQ multipart frame only when requested. The verifier validates the frame, broadcasts it across TP ranks, samples with the standard disjoint draft Gumbel stream, and retains raw logits for block rejection. Existing greedy clients continue to receive the original single JSON frame.

Validation for this follow-up:

- `tests/v1/spec_decode/test_k3_dspark_remote_speculator.py`: 14 passed.
- `tests/v1/spec_decode/test_k3_dspark_standalone.py`: 12 passed.
- Ruff check and format check passed on all four changed files.
- Full-vocabulary 163,840-way BF16 GPU Gumbel/cache smoke passed.
- Production TP8/DCP8 Kimi-K3 target plus dedicated original DFlash server passed temperature-1.0 generation, direct/gateway text and Vision canaries, and an exact 990,000-token prefill without OOM or restart.

Duplicate check: searches in `vllm-project/vllm` and `local-inference-lab/vllm` found no separate open PR for probabilistic remote K3 DFlash transport; this updates the existing remote-transport PR rather than opening a duplicate.

AI assistance was used for this follow-up. It requires human review of every new line before merge; publication as a non-draft does not waive this requirement.


## CodeRabbit review follow-up

Commits `af68421b8e0` and `47fa270455f` address all inline findings and the applicable nitpicks from the CodeRabbit reviews: aggregate projected-context memory is budgeted and revalidated after graph capture; pinned staging and allocator reads are serialized; unauthenticated non-loopback RPC is rejected by default; smoke/capture block spans, CLI values, remote token IDs, and target/draft capacities are validated; failed proposal state and both HTTP/ZMQ lifecycles are cleaned up; liveness is available during load; K3 settings use `vllm.envs`; lockstep zips are strict; and rolling slot mapping is vectorized.

Per the deployment requirement, CUDA graph mode does not use eager fallback. The server captures every accepted `(batch, K)` combination, advertises its batch/depth bounds during PING, and the verifier rejects incompatible capacity during initialization, so a valid runtime request cannot be uncaptured. This intentionally supersedes the optional suggestion to reduce the graph matrix and retain eager fallback.

Validation: Ruff 0.16.1 format/check passed; 114 focused remote-speculator, standalone, and environment-registry tests passed in the upstream-aligned draft image.

AI assistance was used for this follow-up. Human review of every new line remains required before merge; the PR is published for review at the operator’s request.



## Publication status

Published as a non-draft on 2026-09-07 at the operator’s explicit request to expose all prepared PRs in local-inference-lab. Existing qualification evidence and limitations above are unchanged. No code, deployment configuration, merge approval or automatic merge is changed by this status update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KxvNwugeU8RJFd7WRYwNLG
