### PR TITLE
fix(cache): avoid target EAGLE drop for disaggregated DSpark

### DIFF
--- a/tests/v1/core/test_dspark_prefix_cache_policy.py
+++ b/tests/v1/core/test_dspark_prefix_cache_policy.py
@@ -17,6 +17,12 @@ def test_dspark_without_target_eagle_group_does_not_drop_target_cache_tail():
     assert selector(_spec("dspark"), _groups(False, False)) is False
 
 
+def test_dflash_without_target_eagle_group_does_not_drop_target_cache_tail():
+    selector = getattr(scheduler_module, "use_eagle_for_target_cache", None)
+    assert selector is not None, "target-cache EAGLE policy selector is missing"
+    assert selector(_spec("dflash"), _groups(False, False)) is False
+
+
 def test_explicit_target_eagle_group_keeps_cache_drop():
     selector = getattr(scheduler_module, "use_eagle_for_target_cache", None)
     assert selector is not None, "target-cache EAGLE policy selector is missing"

--- a/tests/v1/core/test_dspark_prefix_cache_policy.py
+++ b/tests/v1/core/test_dspark_prefix_cache_policy.py
@@ -1,0 +1,35 @@
+from types import SimpleNamespace
+
+from vllm.v1.core.sched import scheduler as scheduler_module
+
+
+def _spec(method: str, use_eagle: bool = True):
+    return SimpleNamespace(method=method, use_eagle=lambda: use_eagle)
+
+
+def _groups(*flags: bool):
+    return [SimpleNamespace(is_eagle_group=flag) for flag in flags]
+
+
+def test_dspark_without_target_eagle_group_does_not_drop_target_cache_tail():
+    selector = getattr(scheduler_module, "use_eagle_for_target_cache", None)
+    assert selector is not None, "target-cache EAGLE policy selector is missing"
+    assert selector(_spec("dspark"), _groups(False, False)) is False
+
+
+def test_explicit_target_eagle_group_keeps_cache_drop():
+    selector = getattr(scheduler_module, "use_eagle_for_target_cache", None)
+    assert selector is not None, "target-cache EAGLE policy selector is missing"
+    assert selector(_spec("dspark"), _groups(False, True)) is True
+
+
+def test_classic_eagle_keeps_legacy_unannotated_fallback():
+    selector = getattr(scheduler_module, "use_eagle_for_target_cache", None)
+    assert selector is not None, "target-cache EAGLE policy selector is missing"
+    assert selector(_spec("eagle3"), _groups(False, False)) is True
+
+
+def test_non_eagle_speculation_never_drops_target_cache_tail():
+    selector = getattr(scheduler_module, "use_eagle_for_target_cache", None)
+    assert selector is not None, "target-cache EAGLE policy selector is missing"
+    assert selector(_spec("ngram", use_eagle=False), _groups(True)) is False

--- a/tests/v1/core/test_dspark_prefix_cache_policy.py
+++ b/tests/v1/core/test_dspark_prefix_cache_policy.py
@@ -1,41 +1,51 @@
 from types import SimpleNamespace
 
-from vllm.v1.core.sched import scheduler as scheduler_module
+from vllm.v1.core.sched.scheduler import use_eagle_for_target_cache
 
 
-def _spec(method: str, use_eagle: bool = True):
+def _spec(method: str, use_eagle: bool = True) -> SimpleNamespace:
+    """Build a speculative-config stand-in.
+
+    Args:
+        method: Speculative method name the selector inspects.
+        use_eagle: Value returned by the config's ``use_eagle()`` query.
+
+    Returns:
+        An object exposing ``method`` and ``use_eagle()``.
+    """
     return SimpleNamespace(method=method, use_eagle=lambda: use_eagle)
 
 
-def _groups(*flags: bool):
+def _groups(*flags: bool) -> list[SimpleNamespace]:
+    """Build target KV-cache group stand-ins.
+
+    Args:
+        *flags: One ``is_eagle_group`` value per group.
+
+    Returns:
+        Objects exposing ``is_eagle_group`` in the given order.
+    """
     return [SimpleNamespace(is_eagle_group=flag) for flag in flags]
 
 
 def test_dspark_without_target_eagle_group_does_not_drop_target_cache_tail():
-    selector = getattr(scheduler_module, "use_eagle_for_target_cache", None)
-    assert selector is not None, "target-cache EAGLE policy selector is missing"
-    assert selector(_spec("dspark"), _groups(False, False)) is False
+    assert use_eagle_for_target_cache(_spec("dspark"), _groups(False, False)) is False
 
 
 def test_dflash_without_target_eagle_group_does_not_drop_target_cache_tail():
-    selector = getattr(scheduler_module, "use_eagle_for_target_cache", None)
-    assert selector is not None, "target-cache EAGLE policy selector is missing"
-    assert selector(_spec("dflash"), _groups(False, False)) is False
+    assert use_eagle_for_target_cache(_spec("dflash"), _groups(False, False)) is False
 
 
 def test_explicit_target_eagle_group_keeps_cache_drop():
-    selector = getattr(scheduler_module, "use_eagle_for_target_cache", None)
-    assert selector is not None, "target-cache EAGLE policy selector is missing"
-    assert selector(_spec("dspark"), _groups(False, True)) is True
+    assert use_eagle_for_target_cache(_spec("dspark"), _groups(False, True)) is True
 
 
 def test_classic_eagle_keeps_legacy_unannotated_fallback():
-    selector = getattr(scheduler_module, "use_eagle_for_target_cache", None)
-    assert selector is not None, "target-cache EAGLE policy selector is missing"
-    assert selector(_spec("eagle3"), _groups(False, False)) is True
+    assert use_eagle_for_target_cache(_spec("eagle3"), _groups(False, False)) is True
 
 
 def test_non_eagle_speculation_never_drops_target_cache_tail():
-    selector = getattr(scheduler_module, "use_eagle_for_target_cache", None)
-    assert selector is not None, "target-cache EAGLE policy selector is missing"
-    assert selector(_spec("ngram", use_eagle=False), _groups(True)) is False
+    assert (
+        use_eagle_for_target_cache(_spec("ngram", use_eagle=False), _groups(True))
+        is False
+    )

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -70,6 +70,24 @@ from vllm.v1.utils import compute_iteration_details, record_function_or_nullcont
 logger = init_logger(__name__)
 
 
+def use_eagle_for_target_cache(
+    speculative_config: Any | None,
+    kv_cache_groups: Iterable[Any],
+) -> bool:
+    """Whether target KV groups require EAGLE's last-hash drop.
+
+    DSpark and DFlash use EAGLE-style scheduling/lookahead but can keep their
+    draft KV outside the target cache groups. In that layout, falling back from
+    an empty ``is_eagle_group`` set to all target groups drops one valid target
+    prefix hash. Classic EAGLE keeps the historical unannotated fallback.
+    """
+    if speculative_config is None or not speculative_config.use_eagle():
+        return False
+    if any(group.is_eagle_group for group in kv_cache_groups):
+        return True
+    return speculative_config.method not in ("dspark", "dflash")
+
+
 class Scheduler(SchedulerInterface):
     def __init__(
         self,
@@ -270,6 +288,11 @@ class Scheduler(SchedulerInterface):
                 )
             self.use_eagle = speculative_config.use_eagle()
 
+        self.use_eagle_for_target_cache = use_eagle_for_target_cache(
+            speculative_config,
+            kv_cache_config.kv_cache_groups,
+        )
+
         # Create the KV cache manager.
         if hash_block_size is None:
             hash_block_size = block_size
@@ -279,7 +302,7 @@ class Scheduler(SchedulerInterface):
             max_model_len=self.max_model_len,
             max_in_flight_tokens=vllm_config.max_in_flight_tokens,
             enable_caching=self.cache_config.enable_prefix_caching,
-            use_eagle=self.use_eagle,
+            use_eagle=self.use_eagle_for_target_cache,
             log_stats=self.log_stats,
             enable_kv_cache_events=self.enable_kv_cache_events,
             dcp_world_size=self.dcp_world_size,
@@ -406,7 +429,7 @@ class Scheduler(SchedulerInterface):
         # Eagle, FullAttn prunes the last matching block, so back off one
         # block to avoid a Mamba cache miss.
         last_cache_position = request.num_tokens - request.num_tokens % block_size
-        if self.use_eagle:
+        if getattr(self, "use_eagle_for_target_cache", self.use_eagle):
             # EAGLE drops the last complete draft-attention block. Convert the
             # resulting maximum reusable prefix to the recurrent-state grid.
             # Older configurations without an annotated EAGLE group retain

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -80,6 +80,13 @@ def use_eagle_for_target_cache(
     draft KV outside the target cache groups. In that layout, falling back from
     an empty ``is_eagle_group`` set to all target groups drops one valid target
     prefix hash. Classic EAGLE keeps the historical unannotated fallback.
+
+    Args:
+        speculative_config: Active speculative-decoding configuration, if any.
+        kv_cache_groups: Target-cache groups inspected for explicit EAGLE state.
+
+    Returns:
+        Whether target-cache prefix matching must drop EAGLE's trailing hash.
     """
     if speculative_config is None or not speculative_config.use_eagle():
         return False


### PR DESCRIPTION
## Bug Description

Remote/disaggregated DSpark uses EAGLE-style scheduling lookahead, but it does not add an EAGLE KV-cache group to the target model. `SpeculativeConfig.use_eagle()` nevertheless returned `True`, so the cache coordinator's unannotated fallback marked every target KV group as EAGLE and dropped one valid target prefix hash.

For a DCP8 hybrid target with a 1,536-token prefix match unit, a valid 13,824-token local hit was therefore reported as 12,288 local tokens plus a 1,536-token external transfer.

## Root Cause

One `use_eagle` boolean represented two different concerns:

- scheduling/lookahead behavior required by DSpark and DFlash;
- EAGLE's last-block drop for target KV-cache groups.

When no target group had `is_eagle_group=True`, the legacy coordinator fallback applied the second behavior to all target groups. That fallback is appropriate for older classic EAGLE integrations, but not for disaggregated DSpark/DFlash drafts whose KV is outside the target cache groups.

## Fix

- Add a target-cache-specific EAGLE policy selector.
- Keep DSpark/DFlash scheduling lookahead unchanged.
- Apply the target last-hash drop for DSpark/DFlash only when an actual target KV group is explicitly marked as EAGLE.
- Preserve the historical unannotated fallback for classic EAGLE/EAGLE3/MTP integrations.
- Use the target-cache policy for KV-cache manager construction and Mamba cache-boundary alignment.

## How to Verify

1. Configure a hybrid DCP target with `prefix_match_unit=1536` and remote DSpark.
2. Populate a 14,009-token prefix and replay it in the same process.
3. Confirm `local_cache_hit=13824`, `external_kv_transfer=0`, rather than `12288 + 1536`.
4. Clear local APC/L1 and replay from external storage; confirm `external_kv_transfer=13824`.

## Test Plan

- [x] New target-cache policy tests: 5 passed (DSpark, DFlash, explicit EAGLE, classic EAGLE, non-EAGLE)
- [x] Mamba aligned-chunk scheduler tests: 20 passed
- [x] Partial-prefix/COW tests: 25 passed
- [x] Ruff check/format and `py_compile` passed
- [x] Immutable production image gates: LMCache 74 + vLLM 29 tests passed
- [x] Production qualification: local APC 13,824; external restore 13,824; identical cold/local/external semantic SHA-256

## Risk Assessment

Low to medium. The change is limited to target prefix-cache drop policy. DSpark/DFlash scheduling and lookahead still use the existing `use_eagle` behavior. Explicitly annotated target EAGLE groups and classic EAGLE's legacy fallback are preserved.
