### PR TITLE
[II] Bound Kimi-K3 MLA context-output lifetime

### DIFF
--- a/tests/models/kimi_k3/test_mla_padding.py
+++ b/tests/models/kimi_k3/test_mla_padding.py
@@ -3,6 +3,7 @@
 
 from types import SimpleNamespace
 
+import pytest
 import torch
 
 
@@ -120,6 +121,33 @@ def test_kimi_mla_defines_graph_padding_before_output_projection(monkeypatch):
 
     torch.testing.assert_close(output[:2], torch.full_like(output[:2], 3))
     torch.testing.assert_close(output[2:], torch.zeros_like(output[2:]))
+
+
+@pytest.mark.parametrize("query_dtype", [torch.bfloat16, torch.float8_e4m3fn])
+def test_kimi_mla_context_output_reuses_consumed_query_bytes(query_dtype):
+    from vllm.models.kimi_k3.nvidia import mla
+
+    query = torch.empty((4, 2, 256), dtype=query_dtype)
+    output = torch.randn((4, 2, 128), dtype=torch.bfloat16)
+
+    compact = mla._reuse_consumed_query_for_context_output(query, output)
+    compact.copy_(output)
+
+    assert compact.data_ptr() == query.data_ptr()
+    assert compact.shape == output.shape
+    assert compact.dtype == output.dtype
+    assert compact.is_contiguous()
+    torch.testing.assert_close(compact, output)
+
+
+def test_kimi_mla_context_output_rejects_insufficient_query_storage():
+    from vllm.models.kimi_k3.nvidia import mla
+
+    query = torch.empty((4, 2, 64), dtype=torch.bfloat16)
+    output = torch.empty((4, 2, 128), dtype=torch.bfloat16)
+
+    with pytest.raises(ValueError, match="too small"):
+        mla._reuse_consumed_query_for_context_output(query, output)
 
 
 def test_kimi_mla_caller_output_selection_preserves_decode_and_sp_paths():

--- a/vllm/models/kimi_k3/nvidia/mla.py
+++ b/vllm/models/kimi_k3/nvidia/mla.py
@@ -151,6 +151,24 @@ def _restore_merged_output_order(
     )
 
 
+def _reuse_consumed_query_for_context_output(
+    query: torch.Tensor,
+    output: torch.Tensor,
+) -> torch.Tensor:
+    """Return contiguous semantic-output storage backed by a consumed query."""
+    if not query.is_contiguous():
+        raise ValueError("Kimi-K3 MLA prefill query storage must be contiguous")
+    required_bytes = output.numel() * output.element_size()
+    query_bytes = query.view(torch.uint8).flatten()
+    if query_bytes.numel() < required_bytes:
+        raise ValueError(
+            "Kimi-K3 MLA prefill query storage is too small for compact context "
+            f"output: available={query_bytes.numel()} bytes, "
+            f"required={required_bytes} bytes"
+        )
+    return query_bytes[:required_bytes].view(output.dtype).view_as(output)
+
+
 class KimiShardedMergedColumnParallelLinear(MergedColumnParallelLinear):
     """Merged column projection with one gather and logical-shard reorder."""
 
@@ -1066,6 +1084,16 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
         )
 
         if has_context:
+            suffix_output, suffix_lse = output_prefill
+            out = out.view(-1, self.num_local_heads, self.v_head_dim)
+            # FlashAttention 2 pads Kimi-K3's 128-wide V to the 256-wide
+            # query/key head dimension. Preserve only the semantic V slice in
+            # caller-owned output storage before context attention allocates
+            # its equally large padded result. The merge kernel supports
+            # output aliasing its suffix input, so both padded results never
+            # need to be live at the same time.
+            out.copy_(suffix_output[..., : self.v_head_dim])
+            del output_prefill, suffix_output
             if self.dcp_world_size > 1:
                 context_output, context_lse = (
                     self.impl._context_parallel_compute_prefill_context(  # type: ignore[attr-defined]
@@ -1080,13 +1108,14 @@ class MultiHeadLatentAttention(nn.Module, AttentionLayerBase):
                 context_output, context_lse = self.impl._compute_prefill_context(  # type: ignore[attr-defined]
                     q, self._attn_read_kv_cache(), attn_metadata, self._k_scale
                 )
-            suffix_output, suffix_lse = output_prefill
-            out = out.view(-1, self.num_local_heads, self.v_head_dim)
+            compact_context_output = _reuse_consumed_query_for_context_output(q, out)
+            compact_context_output.copy_(context_output[..., : self.v_head_dim])
+            del context_output
             merge_attn_states(
                 output=out,
-                prefix_output=context_output[..., : self.v_head_dim],
+                prefix_output=compact_context_output,
                 prefix_lse=context_lse,
-                suffix_output=suffix_output[..., : self.v_head_dim],
+                suffix_output=out,
                 suffix_lse=suffix_lse,
             )
         elif not writes_out:


### PR DESCRIPTION
## Behavior

Kimi-K3 MLA context prefill now keeps only the semantic 128-wide V output
while the padded 256-wide context result is computed. After the query is
consumed, its storage holds the compact context result used by the attention
state merge.

Status: **implemented and qualified**.

## Technical reason

FlashAttention 2 pads Kimi-K3's 128-wide V output to the 256-wide Q/K head
dimension. At 4,096 tokens and six local heads, each padded BF16 result occupies
12,582,912 bytes per rank. Keeping suffix and context results live together
adds 201,326,592 bytes across TP16 while a physical one-million-token KV cache
is resident.

The suffix's semantic V slice is copied into the caller-owned final output
before context attention runs. The context result then moves into the consumed
query allocation, whose byte capacity is checked before reuse. The merge reads
both compact tensors and writes into the suffix/final output allocation.

## Compatibility

Decode, context-free prefill, output values, LSE values, head layout, cache
layout, DCP partitioning, and attention formulas are unchanged. BF16 and FP8
query storage are supported when their physical byte capacity can hold the
compact BF16 output; insufficient or non-contiguous storage fails explicitly.

## Validation

- Focused tests verify pointer reuse for BF16 and FP8 query storage and reject
  insufficient capacity.
- Kimi-K3 MLA padding, context merge, caller-output, decode, and
  sequence-parallel tests retain their existing behavior.
- Official Kimi-K3 MXFP4 with TP16/DCP16 and 4,096-token scheduler chunks
  completes a captured 208,026-token prompt plus 8,192 output tokens and a
  separate 524,288-token prompt.
- The qualified runtime starts with 1,058,823 physical target-KV tokens and
  completes a cold 8,192-token prefill without allocation failure.
- No-speculation decode measures 55.799 tok/s median for 256 input and 512
  output tokens, compared with 55.769 tok/s for the source-locked reference.
- `ruff check`, `ruff format --check`, `git diff --check`, and Python bytecode
  validation pass for the changed files.

Qualification artifacts are stored under
`/mnt/luke/kimi-k3-runs/merge-lse-alias-fix-20260822/full-r31-attnres-final-block-fix-1m/`
on the 16-GPU qualification host.
