### PR TITLE
feat(lora): enable DeepSeek V4 LoRA with B12X W4A16 experts

### DIFF
--- a/tests/lora/test_lora_manager.py
+++ b/tests/lora/test_lora_manager.py
@@ -163,7 +163,12 @@ def test_wrap_replicated_linear_subclasses(default_vllm_config, dist_init, dummy
 
 def test_wrap_gate_linear(default_vllm_config, dist_init, dummy_model):
     model = dummy_model
-    model.add_module("router_gate", GateLinear(10, 4, bias=False))
+    router_gate = GateLinear(10, 4, bias=False)
+    router_gate.e_score_correction_bias = nn.Parameter(torch.randn(4))
+    router_gate.tid2eid = nn.Parameter(
+        torch.randint(0, 4, (10, 2)), requires_grad=False
+    )
+    model.add_module("router_gate", router_gate)
 
     manager = LoRAModelManager(
         model,
@@ -177,9 +182,10 @@ def test_wrap_gate_linear(default_vllm_config, dist_init, dummy_model):
         default_vllm_config,
     )
 
-    assert isinstance(
-        manager.model.get_submodule("router_gate"), ReplicatedLinearWithLoRA
-    )
+    wrapped_gate = manager.model.get_submodule("router_gate")
+    assert isinstance(wrapped_gate, ReplicatedLinearWithLoRA)
+    assert wrapped_gate.e_score_correction_bias is router_gate.e_score_correction_bias
+    assert wrapped_gate.tid2eid is router_gate.tid2eid
 
 
 def test_dedup_shared_module_across_paths(default_vllm_config, dist_init, dummy_model):

--- a/tests/model_executor/layers/test_b12x_moe_warmup.py
+++ b/tests/model_executor/layers/test_b12x_moe_warmup.py
@@ -321,7 +321,11 @@ def test_b12x_moe_run_binds_only_the_prepared_expert_owner(monkeypatch) -> None:
     }
 
 
-def test_b12x_experts_adapts_vllm_split_lora_storage_without_copy() -> None:
+def test_b12x_experts_adapts_vllm_split_lora_storage_without_copy(
+    monkeypatch,
+) -> None:
+    pytest.importorskip("b12x.moe.fused_moe")
+    monkeypatch.setattr(b12x_moe, "_is_current_stream_capturing", lambda: False)
     experts = _make_fake_b12x_experts()
     ctx = _make_fake_lora_context()
 
@@ -354,7 +358,9 @@ def test_b12x_experts_adapts_vllm_split_lora_storage_without_copy() -> None:
     )
 
 
-def test_b12x_experts_revalidates_mutated_lora_storage() -> None:
+def test_b12x_experts_revalidates_mutated_lora_storage(monkeypatch) -> None:
+    pytest.importorskip("b12x.moe.fused_moe")
+    monkeypatch.setattr(b12x_moe, "_is_current_stream_capturing", lambda: False)
     experts = _make_fake_b12x_experts()
     ctx = _make_fake_lora_context()
     experts.set_lora_context(ctx)
@@ -379,7 +385,9 @@ def test_b12x_experts_rejects_distinct_gate_up_lora_a() -> None:
         experts.set_lora_context(ctx)
 
 
-def test_b12x_experts_accepts_zero_padded_rank4_lora_cache() -> None:
+def test_b12x_experts_accepts_zero_padded_rank4_lora_cache(monkeypatch) -> None:
+    pytest.importorskip("b12x.moe.fused_moe")
+    monkeypatch.setattr(b12x_moe, "_is_current_stream_capturing", lambda: False)
     experts = _make_fake_b12x_experts()
     ctx = _make_fake_lora_context(rank_capacity=8)
 
@@ -410,7 +418,9 @@ def test_b12x_experts_rejects_nonzero_rank_padding() -> None:
         experts.set_lora_context(ctx)
 
 
-def test_b12x_experts_accepts_fused_3d_moe_lora_storage() -> None:
+def test_b12x_experts_accepts_fused_3d_moe_lora_storage(monkeypatch) -> None:
+    pytest.importorskip("b12x.moe.fused_moe")
+    monkeypatch.setattr(b12x_moe, "_is_current_stream_capturing", lambda: False)
     experts = _make_fake_b12x_experts()
     ctx = _make_fake_lora_context(rank_capacity=8, fused_w13=True)
 

--- a/tests/model_executor/layers/test_b12x_moe_warmup.py
+++ b/tests/model_executor/layers/test_b12x_moe_warmup.py
@@ -31,6 +31,13 @@ class _FakeStaticLoRA:
     token_lora_mapping: torch.Tensor
 
 
+def _require_b12x_static_expert_lora() -> None:
+    """Skip tests unless the installed B12X exposes the companion LoRA API."""
+    fused_moe = pytest.importorskip("b12x.moe.fused_moe")
+    if not hasattr(fused_moe, "StaticExpertLoRA"):
+        pytest.skip("installed B12X does not expose StaticExpertLoRA")
+
+
 def _make_fake_prepared_experts(
     *,
     quant_mode: str = "nvfp4",
@@ -324,7 +331,7 @@ def test_b12x_moe_run_binds_only_the_prepared_expert_owner(monkeypatch) -> None:
 def test_b12x_experts_adapts_vllm_split_lora_storage_without_copy(
     monkeypatch,
 ) -> None:
-    pytest.importorskip("b12x.moe.fused_moe")
+    _require_b12x_static_expert_lora()
     monkeypatch.setattr(b12x_moe, "_is_current_stream_capturing", lambda: False)
     experts = _make_fake_b12x_experts()
     ctx = _make_fake_lora_context()
@@ -359,7 +366,7 @@ def test_b12x_experts_adapts_vllm_split_lora_storage_without_copy(
 
 
 def test_b12x_experts_revalidates_mutated_lora_storage(monkeypatch) -> None:
-    pytest.importorskip("b12x.moe.fused_moe")
+    _require_b12x_static_expert_lora()
     monkeypatch.setattr(b12x_moe, "_is_current_stream_capturing", lambda: False)
     experts = _make_fake_b12x_experts()
     ctx = _make_fake_lora_context()
@@ -386,7 +393,7 @@ def test_b12x_experts_rejects_distinct_gate_up_lora_a() -> None:
 
 
 def test_b12x_experts_accepts_zero_padded_rank4_lora_cache(monkeypatch) -> None:
-    pytest.importorskip("b12x.moe.fused_moe")
+    _require_b12x_static_expert_lora()
     monkeypatch.setattr(b12x_moe, "_is_current_stream_capturing", lambda: False)
     experts = _make_fake_b12x_experts()
     ctx = _make_fake_lora_context(rank_capacity=8)
@@ -419,7 +426,7 @@ def test_b12x_experts_rejects_nonzero_rank_padding() -> None:
 
 
 def test_b12x_experts_accepts_fused_3d_moe_lora_storage(monkeypatch) -> None:
-    pytest.importorskip("b12x.moe.fused_moe")
+    _require_b12x_static_expert_lora()
     monkeypatch.setattr(b12x_moe, "_is_current_stream_capturing", lambda: False)
     experts = _make_fake_b12x_experts()
     ctx = _make_fake_lora_context(rank_capacity=8, fused_w13=True)

--- a/tests/model_executor/layers/test_b12x_moe_warmup.py
+++ b/tests/model_executor/layers/test_b12x_moe_warmup.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from dataclasses import dataclass
 from types import SimpleNamespace
 
 import pytest
@@ -23,6 +24,11 @@ class _FakePlan:
     @staticmethod
     def scratch_specs():
         return [SimpleNamespace(dtype=torch.uint8, shape=(64,))]
+
+
+@dataclass(frozen=True)
+class _FakeStaticLoRA:
+    token_lora_mapping: torch.Tensor
 
 
 def _make_fake_prepared_experts(
@@ -789,6 +795,63 @@ def test_b12x_moe_workspace_limit_chunks_token_independent_launches(
     assert torch.equal(
         torch.cat([call["topk_weights"] for call in run_calls]), topk_weights
     )
+    assert torch.equal(output, hidden_states)
+
+
+def test_b12x_moe_workspace_chunks_slice_static_lora_token_mapping(
+    monkeypatch,
+) -> None:
+    run_calls = []
+
+    def fake_run(**kwargs):
+        run_calls.append(kwargs)
+        kwargs["output"].copy_(kwargs["a"])
+
+    monkeypatch.setenv("B12X_MOE_WORKSPACE_TOKEN_LIMIT", "2")
+    monkeypatch.setenv("B12X_MOE_FORCE_A16", "1")
+    monkeypatch.setattr(
+        b12x_moe,
+        "_plan_b12x_moe_fp4_scratch",
+        lambda **kwargs: _FakePlan(),
+    )
+    monkeypatch.setattr(b12x_moe, "_run_b12x_moe_fp4", fake_run)
+
+    experts = _make_fake_b12x_experts()
+    experts._prepared_experts = _make_fake_prepared_experts(quant_mode="w4a16")
+    token_mapping = torch.tensor([0, 0, -1, -1, 0], dtype=torch.int32)
+    experts._b12x_static_lora = _FakeStaticLoRA(token_mapping)
+    hidden_states = torch.arange(5 * 64, dtype=torch.bfloat16).view(5, 64)
+    output = torch.empty_like(hidden_states)
+    topk_ids = torch.arange(5 * 4, dtype=torch.int32).view(5, 4) % 8
+    topk_weights = torch.full((5, 4), 0.25, dtype=torch.float32)
+
+    experts.apply(
+        output=output,
+        hidden_states=hidden_states,
+        w1=torch.empty(0, dtype=torch.uint8),
+        w2=torch.empty(0, dtype=torch.uint8),
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        activation=MoEActivation.SWIGLUOAI_UNINTERLEAVE,
+        global_num_experts=8,
+        expert_map=None,
+        a1q_scale=None,
+        a2_scale=None,
+        workspace13=None,
+        workspace2=torch.empty(64, dtype=torch.uint8),
+        expert_tokens_meta=None,
+        apply_router_weight_on_input=False,
+    )
+
+    chunk_mappings = [
+        call["static_lora"].token_lora_mapping for call in run_calls
+    ]
+    assert [mapping.tolist() for mapping in chunk_mappings] == [
+        [0, 0],
+        [-1, -1],
+        [0],
+    ]
+    assert all(mapping.is_contiguous() for mapping in chunk_mappings)
     assert torch.equal(output, hidden_states)
 
 

--- a/tests/model_executor/layers/test_b12x_moe_warmup.py
+++ b/tests/model_executor/layers/test_b12x_moe_warmup.py
@@ -1,8 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import sys
 from dataclasses import dataclass
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 
 import pytest
 import torch
@@ -36,6 +37,15 @@ def _require_b12x_static_expert_lora() -> None:
     fused_moe = pytest.importorskip("b12x.moe.fused_moe")
     if not hasattr(fused_moe, "StaticExpertLoRA"):
         pytest.skip("installed B12X does not expose StaticExpertLoRA")
+
+
+def test_static_expert_lora_guard_skips_an_older_b12x(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    older_b12x = ModuleType("b12x.moe.fused_moe")
+    monkeypatch.setitem(sys.modules, "b12x.moe.fused_moe", older_b12x)
+    with pytest.raises(pytest.skip.Exception, match="does not expose"):
+        _require_b12x_static_expert_lora()
 
 
 def _make_fake_prepared_experts(

--- a/tests/model_executor/layers/test_b12x_moe_warmup.py
+++ b/tests/model_executor/layers/test_b12x_moe_warmup.py
@@ -93,6 +93,7 @@ def _make_fake_b12x_experts() -> b12x_moe.B12xExperts:
     experts._b12x_static_lora = None
     experts._b12x_lora_weight_signature = None
     experts._b12x_lora_mapping_ptr = None
+    experts._b12x_lora_packed_factors = {}
     return experts
 
 
@@ -101,34 +102,59 @@ def _make_fake_lora_context(
     num_experts: int = 8,
     hidden_size: int = 64,
     intermediate_size: int = 16,
+    rank_capacity: int = 4,
+    fused_w13: bool = False,
 ):
-    w13_a = torch.randn(
-        1, num_experts, 4, hidden_size, dtype=torch.bfloat16
+    w13_a = torch.zeros(
+        1, num_experts, rank_capacity, hidden_size, dtype=torch.bfloat16
     )
+    w13_a[:, :, :4].normal_()
+
+    def padded_b(output_size: int) -> torch.Tensor:
+        tensor = torch.zeros(
+            1,
+            num_experts,
+            output_size,
+            rank_capacity,
+            dtype=torch.bfloat16,
+        )
+        tensor[:, :, :, :4].normal_()
+        return tensor
+
+    def padded_a(input_size: int) -> torch.Tensor:
+        tensor = torch.zeros(
+            1,
+            num_experts,
+            rank_capacity,
+            input_size,
+            dtype=torch.bfloat16,
+        )
+        tensor[:, :, :4].normal_()
+        return tensor
+
+    if fused_w13:
+        w13_lora_a_stacked = (w13_a,)
+        w13_lora_b_stacked = (padded_b(2 * intermediate_size),)
+        w13_num_slices = 1
+    else:
+        w13_lora_a_stacked = (w13_a, w13_a.clone())
+        w13_lora_b_stacked = (
+            padded_b(intermediate_size),
+            padded_b(intermediate_size),
+        )
+        w13_num_slices = 2
+
     return SimpleNamespace(
         max_loras=1,
         fully_sharded=False,
         enable_moe_shared_loras=False,
-        w13_num_slices=2,
+        w13_num_slices=w13_num_slices,
         aux_stream=None,
         local_num_experts=num_experts,
-        w13_lora_a_stacked=(w13_a, w13_a.clone()),
-        w13_lora_b_stacked=(
-            torch.randn(
-                1, num_experts, intermediate_size, 4, dtype=torch.bfloat16
-            ),
-            torch.randn(
-                1, num_experts, intermediate_size, 4, dtype=torch.bfloat16
-            ),
-        ),
-        w2_lora_a_stacked=(
-            torch.randn(
-                1, num_experts, 4, intermediate_size, dtype=torch.bfloat16
-            ),
-        ),
-        w2_lora_b_stacked=(
-            torch.randn(1, num_experts, hidden_size, 4, dtype=torch.bfloat16),
-        ),
+        w13_lora_a_stacked=w13_lora_a_stacked,
+        w13_lora_b_stacked=w13_lora_b_stacked,
+        w2_lora_a_stacked=(padded_a(intermediate_size),),
+        w2_lora_b_stacked=(padded_b(hidden_size),),
         punica_wrapper=SimpleNamespace(
             token_mapping_meta=SimpleNamespace(
                 token_lora_mapping=torch.tensor([0, -1], dtype=torch.int32)
@@ -339,6 +365,49 @@ def test_b12x_experts_rejects_distinct_gate_up_lora_a() -> None:
 
     with pytest.raises(NotImplementedError, match="share W13 LoRA A"):
         experts.set_lora_context(ctx)
+
+
+def test_b12x_experts_accepts_zero_padded_rank4_lora_cache() -> None:
+    experts = _make_fake_b12x_experts()
+    ctx = _make_fake_lora_context(rank_capacity=8)
+
+    experts.set_lora_context(ctx)
+
+    adapter = experts._b12x_static_lora
+    assert adapter.w13_a.shape[1] == 4
+    assert adapter.w13_b.shape[2] == 4
+    assert adapter.w13_b_up.shape[2] == 4
+    assert adapter.w2_a.shape[1] == 4
+    assert adapter.w2_b.shape[2] == 4
+    assert adapter.w13_a.is_contiguous()
+    assert adapter.w13_b.is_contiguous()
+    assert adapter.w13_a.data_ptr() != ctx.w13_lora_a_stacked[0][0].data_ptr()
+
+    packed_ptr = adapter.w13_b.data_ptr()
+    ctx.w13_lora_b_stacked[0][:, :, :, :4].add_(1)
+    experts.set_lora_context(ctx)
+    assert experts._b12x_static_lora.w13_b.data_ptr() == packed_ptr
+
+
+def test_b12x_experts_rejects_nonzero_rank_padding() -> None:
+    experts = _make_fake_b12x_experts()
+    ctx = _make_fake_lora_context(rank_capacity=8)
+    ctx.w2_lora_b_stacked[0][0, 0, 0, 4] = 1
+
+    with pytest.raises(NotImplementedError, match="non-zero rank padding"):
+        experts.set_lora_context(ctx)
+
+
+def test_b12x_experts_accepts_fused_3d_moe_lora_storage() -> None:
+    experts = _make_fake_b12x_experts()
+    ctx = _make_fake_lora_context(rank_capacity=8, fused_w13=True)
+
+    experts.set_lora_context(ctx)
+
+    adapter = experts._b12x_static_lora
+    assert adapter.w13_b_up is None
+    assert adapter.w13_b.shape == (8, 32, 4)
+    assert adapter.w13_b.is_contiguous()
 
 
 def test_b12x_source_release_leaves_prepared_owner_as_storage_owner() -> None:

--- a/tests/model_executor/layers/test_b12x_moe_warmup.py
+++ b/tests/model_executor/layers/test_b12x_moe_warmup.py
@@ -90,7 +90,51 @@ def _make_fake_b12x_experts() -> b12x_moe.B12xExperts:
     experts._activation_amax_base_num_layers = None
     experts._activation_amax_state_key = None
     experts._activation_amax_layer_idx = None
+    experts._b12x_static_lora = None
+    experts._b12x_lora_weight_signature = None
+    experts._b12x_lora_mapping_ptr = None
     return experts
+
+
+def _make_fake_lora_context(
+    *,
+    num_experts: int = 8,
+    hidden_size: int = 64,
+    intermediate_size: int = 16,
+):
+    w13_a = torch.randn(
+        1, num_experts, 4, hidden_size, dtype=torch.bfloat16
+    )
+    return SimpleNamespace(
+        max_loras=1,
+        fully_sharded=False,
+        enable_moe_shared_loras=False,
+        w13_num_slices=2,
+        aux_stream=None,
+        local_num_experts=num_experts,
+        w13_lora_a_stacked=(w13_a, w13_a.clone()),
+        w13_lora_b_stacked=(
+            torch.randn(
+                1, num_experts, intermediate_size, 4, dtype=torch.bfloat16
+            ),
+            torch.randn(
+                1, num_experts, intermediate_size, 4, dtype=torch.bfloat16
+            ),
+        ),
+        w2_lora_a_stacked=(
+            torch.randn(
+                1, num_experts, 4, intermediate_size, dtype=torch.bfloat16
+            ),
+        ),
+        w2_lora_b_stacked=(
+            torch.randn(1, num_experts, hidden_size, 4, dtype=torch.bfloat16),
+        ),
+        punica_wrapper=SimpleNamespace(
+            token_mapping_meta=SimpleNamespace(
+                token_lora_mapping=torch.tensor([0, -1], dtype=torch.int32)
+            )
+        ),
+    )
 
 
 def _make_fake_moe_runner(fused_experts: object) -> MoERunner:
@@ -237,7 +281,64 @@ def test_b12x_moe_run_binds_only_the_prepared_expert_owner(monkeypatch) -> None:
         "activation_amax": None,
         "layer_idx": None,
         "route_expert_map": None,
+        "static_lora": None,
     }
+
+
+def test_b12x_experts_adapts_vllm_split_lora_storage_without_copy() -> None:
+    experts = _make_fake_b12x_experts()
+    ctx = _make_fake_lora_context()
+
+    experts.set_lora_context(ctx)
+
+    adapter = experts._b12x_static_lora
+    assert experts.supports_lora()
+    assert adapter.w13_a.data_ptr() == ctx.w13_lora_a_stacked[0][0].data_ptr()
+    assert adapter.w13_b.data_ptr() == ctx.w13_lora_b_stacked[0][0].data_ptr()
+    assert adapter.w13_b_up.data_ptr() == ctx.w13_lora_b_stacked[1][0].data_ptr()
+    assert adapter.w2_a.data_ptr() == ctx.w2_lora_a_stacked[0][0].data_ptr()
+    assert adapter.w2_b.data_ptr() == ctx.w2_lora_b_stacked[0][0].data_ptr()
+    assert (
+        adapter.token_lora_mapping.data_ptr()
+        == ctx.punica_wrapper.token_mapping_meta.token_lora_mapping.data_ptr()
+    )
+
+    experts.set_lora_context(ctx)
+    assert experts._b12x_static_lora is adapter
+
+    replacement_mapping = torch.tensor([-1, 0], dtype=torch.int32)
+    ctx.punica_wrapper.token_mapping_meta.token_lora_mapping = replacement_mapping
+    experts.set_lora_context(ctx)
+    assert experts._b12x_static_lora is not adapter
+    assert (
+        experts._b12x_static_lora.token_lora_mapping.data_ptr()
+        == replacement_mapping.data_ptr()
+    )
+
+
+def test_b12x_experts_revalidates_mutated_lora_storage() -> None:
+    experts = _make_fake_b12x_experts()
+    ctx = _make_fake_lora_context()
+    experts.set_lora_context(ctx)
+    first_adapter = experts._b12x_static_lora
+
+    ctx.w13_lora_b_stacked[0].add_(1)
+    experts.set_lora_context(ctx)
+
+    assert experts._b12x_static_lora is not first_adapter
+    assert (
+        experts._b12x_static_lora.w13_b.data_ptr()
+        == ctx.w13_lora_b_stacked[0][0].data_ptr()
+    )
+
+
+def test_b12x_experts_rejects_distinct_gate_up_lora_a() -> None:
+    experts = _make_fake_b12x_experts()
+    ctx = _make_fake_lora_context()
+    ctx.w13_lora_a_stacked[1].add_(1)
+
+    with pytest.raises(NotImplementedError, match="share W13 LoRA A"):
+        experts.set_lora_context(ctx)
 
 
 def test_b12x_source_release_leaves_prepared_owner_as_storage_owner() -> None:

--- a/tests/model_executor/layers/test_b12x_moe_warmup.py
+++ b/tests/model_executor/layers/test_b12x_moe_warmup.py
@@ -162,9 +162,13 @@ def _make_fake_lora_context(
         w2_lora_a_stacked=(padded_a(intermediate_size),),
         w2_lora_b_stacked=(padded_b(hidden_size),),
         punica_wrapper=SimpleNamespace(
+            token_lora_indices=torch.tensor([0, -1], dtype=torch.int64),
+            token_lora_indices_buffer=torch.tensor([0, -1, -1, -1], dtype=torch.int64),
             token_mapping_meta=SimpleNamespace(
-                token_lora_mapping=torch.tensor([0, -1], dtype=torch.int32)
-            )
+                # Deliberately stale compact scratch: B12X must retain the
+                # canonical mapping allocation above instead.
+                token_lora_mapping=torch.tensor([0, 0], dtype=torch.int32)
+            ),
         ),
     )
 
@@ -332,15 +336,17 @@ def test_b12x_experts_adapts_vllm_split_lora_storage_without_copy() -> None:
     assert adapter.w2_b.data_ptr() == ctx.w2_lora_b_stacked[0][0].data_ptr()
     assert (
         adapter.token_lora_mapping.data_ptr()
-        == ctx.punica_wrapper.token_mapping_meta.token_lora_mapping.data_ptr()
+        == ctx.punica_wrapper.token_lora_indices_buffer.data_ptr()
     )
+    assert adapter.token_lora_mapping.dtype == torch.int64
 
     experts.set_lora_context(ctx)
-    assert experts._b12x_static_lora is adapter
+    assert experts._b12x_static_lora is not adapter
+    assert experts._b12x_static_lora.w13_a.data_ptr() == adapter.w13_a.data_ptr()
 
-    replacement_mapping = torch.tensor([-1, 0], dtype=torch.int32)
-    ctx.punica_wrapper.token_mapping_meta.token_lora_mapping = replacement_mapping
-    experts.set_lora_context(ctx)
+    replacement_mapping = torch.tensor([-1, 0, -1, -1], dtype=torch.int64)
+    ctx.punica_wrapper.token_lora_indices_buffer = replacement_mapping
+    experts.refresh_lora_context()
     assert experts._b12x_static_lora is not adapter
     assert (
         experts._b12x_static_lora.token_lora_mapping.data_ptr()
@@ -843,9 +849,7 @@ def test_b12x_moe_workspace_chunks_slice_static_lora_token_mapping(
         apply_router_weight_on_input=False,
     )
 
-    chunk_mappings = [
-        call["static_lora"].token_lora_mapping for call in run_calls
-    ]
+    chunk_mappings = [call["static_lora"].token_lora_mapping for call in run_calls]
     assert [mapping.tolist() for mapping in chunk_mappings] == [
         [0, 0],
         [-1, -1],

--- a/tests/models/deepseek_v4/test_attention_stream_events.py
+++ b/tests/models/deepseek_v4/test_attention_stream_events.py
@@ -83,7 +83,9 @@ def test_gemm_and_attention_overlap_use_distinct_event_sets(monkeypatch) -> None
     )
     tensor = torch.empty(1)
 
-    attention_module.DeepseekV4Attention.attn_gemm_parallel_execute(layer, tensor)
+    attention_module.DeepseekV4Attention._run_parallel_input_projections(
+        layer, tensor
+    )
     attention_module.DeepseekV4Attention.attention_impl(
         layer,
         tensor,
@@ -159,3 +161,63 @@ def test_attention_overlap_uses_capture_private_events(monkeypatch) -> None:
     )
 
     assert calls == [(captured_events[0], tuple(captured_events[1:3]))]
+
+
+def test_input_projection_helpers_preserve_lora_wrappers(monkeypatch) -> None:
+    hidden_states = torch.tensor([[1.0, 2.0]])
+    indexer_base_weight = torch.tensor([[3.0, 4.0]])
+    compressor_calls = 0
+
+    def compressor_projection(x):
+        nonlocal compressor_calls
+        compressor_calls += 1
+        return x + 1, None
+
+    def fake_mm(left, right, *, out_dtype):
+        assert left is hidden_states
+        assert right.data_ptr() == indexer_base_weight.T.data_ptr()
+        assert out_dtype is torch.float32
+        return left + 3
+
+    def fake_execute_in_parallel(
+        default_fn,
+        aux_fns,
+        start_event,
+        done_events,
+        aux_streams,
+        enable,
+        **kwargs,
+    ):
+        del start_event, done_events, aux_streams, enable, kwargs
+        return default_fn(), [fn() if fn is not None else None for fn in aux_fns]
+
+    monkeypatch.setattr(attention_module.torch, "mm", fake_mm)
+    monkeypatch.setattr(
+        attention_module, "execute_in_parallel", fake_execute_in_parallel
+    )
+    layer = SimpleNamespace(
+        aux_stream_list=None,
+        compressor=SimpleNamespace(fused_wkv_wgate=compressor_projection),
+        indexer=SimpleNamespace(
+            weights_proj=lambda x: (x + 2, None),
+            compressor=SimpleNamespace(
+                fused_wkv_wgate=SimpleNamespace(
+                    base_layer=SimpleNamespace(weight=indexer_base_weight)
+                )
+            ),
+        ),
+        fused_wqa_wkv=lambda x: (x, None),
+        ln_events=[object() for _ in range(4)],
+    )
+
+    qr_kv, kv_score, indexer_kv_score, indexer_weights = (
+        attention_module.DeepseekV4Attention._run_parallel_input_projections(
+            layer, hidden_states
+        )
+    )
+
+    assert compressor_calls == 1
+    assert torch.equal(qr_kv, hidden_states)
+    assert torch.equal(kv_score, hidden_states + 1)
+    assert torch.equal(indexer_weights, hidden_states + 2)
+    assert torch.equal(indexer_kv_score, hidden_states + 3)

--- a/tests/models/deepseek_v4/test_lora.py
+++ b/tests/models/deepseek_v4/test_lora.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from vllm.model_executor.models.interfaces import supports_lora
+from vllm.models.deepseek_v4.nvidia.model import (
+    DeepseekV4ForCausalLM,
+    _make_deepseek_v4_weights_mapper,
+)
+
+
+def test_deepseek_v4_declares_lora_layout() -> None:
+    assert supports_lora(DeepseekV4ForCausalLM)
+    assert DeepseekV4ForCausalLM.is_3d_moe_weight
+    assert DeepseekV4ForCausalLM.lora_skip_prefixes == ["mtp."]
+    assert DeepseekV4ForCausalLM.packed_modules_mapping == {
+        "fused_wqa_wkv": ["q_a_proj", "kv_proj"],
+        "wq_b": ["q_b_proj"],
+        "wo_b": ["o_b_proj"],
+        "fused_wkv_wgate": ["kv_proj", "gate_proj"],
+        "gate_up_proj": ["gate_proj", "up_proj"],
+    }
+
+
+def test_deepseek_v4_maps_transformers_lora_parents() -> None:
+    mapper = _make_deepseek_v4_weights_mapper("fp4")
+
+    assert mapper._map_name(
+        "layers.0.self_attn.q_a_proj.lora_A.weight"
+    ) == "model.layers.0.attn.q_a_proj.lora_A.weight"
+    assert mapper._map_name(
+        "layers.0.mlp.experts.base_layer.lora_A.weight"
+    ) == "model.layers.0.ffn.experts.base_layer.lora_A.weight"
+    assert mapper._map_name(
+        "layers.0.mlp.shared_experts.gate_proj.lora_A.weight"
+    ) == "model.layers.0.ffn.shared_experts.gate_proj.lora_A.weight"

--- a/tests/v1/spec_decode/test_external_draft_attention_config.py
+++ b/tests/v1/spec_decode/test_external_draft_attention_config.py
@@ -1,10 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from contextlib import nullcontext
 from types import SimpleNamespace
 
 import pytest
+import torch.nn as nn
 
+from vllm.lora.layers.base import BaseLayerWithLoRA
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 from vllm.v1.worker.gpu.spec_decode.dflash import speculator as dflash_speculator
 from vllm.v1.worker.gpu.spec_decode.dspark import utils as dspark_utils
@@ -61,6 +64,71 @@ def test_dspark_loader_uses_external_draft_parallel_geometry(monkeypatch) -> Non
     assert loaded_config.attention_config.use_non_causal
     assert loaded_config.quant_config is draft_quant_config
     assert loaded_config.lora_config is None
+
+
+def test_dspark_loader_shares_unwrapped_lora_embed_and_lm_head(monkeypatch) -> None:
+    """The external draft shares base layers, never target LoRA wrappers."""
+
+    target_embed_base = nn.Identity()
+    target_lm_head_base = nn.Identity()
+    target_embed = BaseLayerWithLoRA()
+    target_embed.base_layer = target_embed_base
+    target_lm_head = BaseLayerWithLoRA()
+    target_lm_head.base_layer = target_lm_head_base
+    target_model = SimpleNamespace(
+        model=SimpleNamespace(embed_tokens=target_embed),
+        lm_head=target_lm_head,
+    )
+    draft_model = SimpleNamespace(
+        model=SimpleNamespace(embed_tokens=nn.Identity()),
+        lm_head=nn.Identity(),
+    )
+    draft_model_config = SimpleNamespace(hf_config=SimpleNamespace())
+    target_config = SimpleNamespace(
+        speculative_config=SimpleNamespace(
+            draft_model_config=draft_model_config,
+            attention_backend=AttentionBackendEnum.B12X_MLA,
+        )
+    )
+    draft_config = SimpleNamespace(
+        attention_config=SimpleNamespace(backend=None, use_non_causal=False),
+        quant_config=object(),
+        lora_config=object(),
+    )
+
+    monkeypatch.setattr(
+        dspark_utils,
+        "_create_draft_vllm_config",
+        lambda config: draft_config if config is target_config else None,
+    )
+    monkeypatch.setattr(dspark_utils, "get_model", lambda **_kwargs: draft_model)
+    monkeypatch.setattr(
+        dspark_utils,
+        "get_pp_group",
+        lambda: SimpleNamespace(world_size=1),
+    )
+    monkeypatch.setattr(dspark_utils, "_should_share", lambda *_args: True)
+    monkeypatch.setattr(
+        "vllm.compilation.backends.set_model_tag",
+        lambda _tag: nullcontext(),
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.models.qwen3_dflash.dflash_has_any_non_causal",
+        lambda _config: False,
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.models.utils.get_draft_quant_config",
+        lambda _config: None,
+    )
+
+    loaded = dspark_utils.load_dspark_model(target_model, target_config)
+
+    assert loaded is draft_model
+    assert loaded.model.embed_tokens is target_embed_base
+    assert loaded.lm_head is target_lm_head_base
+    assert loaded.model.embed_tokens is not target_embed
+    assert loaded.lm_head is not target_lm_head
+    assert draft_config.lora_config is None
 
 
 def test_dflash_attention_metadata_uses_external_draft_geometry(monkeypatch) -> None:

--- a/tests/v1/spec_decode/test_external_draft_attention_config.py
+++ b/tests/v1/spec_decode/test_external_draft_attention_config.py
@@ -23,6 +23,7 @@ def test_dspark_loader_uses_external_draft_parallel_geometry(monkeypatch) -> Non
         parallel_config=SimpleNamespace(decode_context_parallel_size=1),
         attention_config=SimpleNamespace(backend=None, use_non_causal=False),
         quant_config=object(),
+        lora_config=object(),
     )
     draft_quant_config = object()
     captured = {}
@@ -59,6 +60,7 @@ def test_dspark_loader_uses_external_draft_parallel_geometry(monkeypatch) -> Non
     assert loaded_config.attention_config.backend == AttentionBackendEnum.B12X_MLA
     assert loaded_config.attention_config.use_non_causal
     assert loaded_config.quant_config is draft_quant_config
+    assert loaded_config.lora_config is None
 
 
 def test_dflash_attention_metadata_uses_external_draft_geometry(monkeypatch) -> None:

--- a/vllm/lora/layers/fused_moe.py
+++ b/vllm/lora/layers/fused_moe.py
@@ -363,8 +363,7 @@ class FusedMoEWithLoRA(BaseLayerWithLoRA):
         assert tgt == 1, f"expert-dim mismatch: source {src.shape[0]} vs buffer {tgt}"
         return src[:1]
 
-    def reset_lora(self, index: int):
-        """Resets the lora weights at index back to 0."""
+    def _zero_lora_weights(self, index: int) -> None:
         for pos in range(self._w13_slices):
             self.w13_lora_a_stacked[pos][index] = 0
             self.w13_lora_b_stacked[pos][index] = 0
@@ -372,6 +371,20 @@ class FusedMoEWithLoRA(BaseLayerWithLoRA):
         self.w2_lora_a_stacked[0][index] = 0
         self.w2_lora_b_stacked[0][index] = 0
         self.adapter_enabled[index] = 0
+
+    def _refresh_expert_lora_context(self) -> None:
+        refresh = getattr(
+            self._moe_kernel.fused_experts,
+            "refresh_lora_context",
+            None,
+        )
+        if callable(refresh):
+            refresh()
+
+    def reset_lora(self, index: int):
+        """Resets the lora weights at index back to 0."""
+        self._zero_lora_weights(index)
+        self._refresh_expert_lora_context()
 
     #
 
@@ -386,7 +399,7 @@ class FusedMoEWithLoRA(BaseLayerWithLoRA):
         assert isinstance(lora_a, list)
         assert isinstance(lora_b, list)
 
-        self.reset_lora(index)
+        self._zero_lora_weights(index)
         self.adapter_enabled[index] = 1
 
         w1_lora_a, w2_lora_a, w3_lora_a = lora_a
@@ -442,6 +455,7 @@ class FusedMoEWithLoRA(BaseLayerWithLoRA):
         self.w2_lora_b_stacked[0][
             index, :, : sliced_w2_lora_b.shape[1], : sliced_w2_lora_b.shape[2]
         ].copy_(sliced_w2_lora_b, non_blocking=True)
+        self._refresh_expert_lora_context()
 
     def set_mapping(self, punica_wrapper):
         super().set_mapping(punica_wrapper)
@@ -585,7 +599,7 @@ class FusedMoE3DWithLoRA(FusedMoEWithLoRA):
         assert isinstance(lora_b, list)
         assert len(lora_a) == len(lora_b) == 2
 
-        self.reset_lora(index)
+        self._zero_lora_weights(index)
         self.adapter_enabled[index] = 1
 
         w13_lora_a, w2_lora_a = lora_a
@@ -610,6 +624,7 @@ class FusedMoE3DWithLoRA(FusedMoEWithLoRA):
         self.w2_lora_b_stacked[0][
             index, :, : sliced_w2_lora_b.shape[1], : sliced_w2_lora_b.shape[2]
         ].copy_(sliced_w2_lora_b, non_blocking=True)
+        self._refresh_expert_lora_context()
 
     @property
     def w13_input_size(self):

--- a/vllm/lora/layers/replicated_linear.py
+++ b/vllm/lora/layers/replicated_linear.py
@@ -22,6 +22,16 @@ class ReplicatedLinearWithLoRA(BaseLinearLayerWithLoRA):
         self.output_size = self.base_layer.output_size
         self.n_slices = 1
 
+    @property
+    def e_score_correction_bias(self) -> torch.Tensor | None:
+        """Forward specialized router metadata exposed by ``GateLinear``."""
+        return getattr(self.base_layer, "e_score_correction_bias", None)
+
+    @property
+    def tid2eid(self) -> torch.Tensor | None:
+        """Forward DeepSeek V4's optional hash-router lookup table."""
+        return getattr(self.base_layer, "tid2eid", None)
+
     def forward(
         self, input_: torch.Tensor
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor | None]:

--- a/vllm/lora/punica_wrapper/punica_base.py
+++ b/vllm/lora/punica_wrapper/punica_base.py
@@ -256,6 +256,17 @@ class PunicaWrapperBase(PunicaWrapperABC):
         return self._token_lora_indices[:token_lora_len]
 
     @property
+    def token_lora_indices_buffer(self) -> torch.Tensor:
+        """Return the stable backing allocation for token-to-LoRA indices.
+
+        ``token_lora_indices`` is a request-sized view whose length changes
+        whenever LoRA metadata is updated. Long-lived kernel contracts that
+        retain a tensor pointer must instead hold this allocation and consume
+        only the rows participating in the current forward pass.
+        """
+        return self._token_lora_indices
+
+    @property
     def sampler_indices(self) -> torch.Tensor:
         """
         This property is used to access the lora indices specifically for

--- a/vllm/model_executor/layers/fused_moe/b12x_moe.py
+++ b/vllm/model_executor/layers/fused_moe/b12x_moe.py
@@ -4,6 +4,7 @@
 
 import os
 from collections.abc import Iterable
+from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
@@ -685,6 +686,23 @@ def _is_current_stream_capturing() -> bool:
         return False
     is_capturing = getattr(cuda, "is_current_stream_capturing", None)
     return bool(is_capturing is not None and is_capturing())
+
+
+def _static_lora_for_token_range(
+    static_lora: Any | None, start: int, end: int
+) -> Any | None:
+    """Bind one chunk to the corresponding graph-dynamic LoRA token map."""
+    if static_lora is None or static_lora.token_lora_mapping is None:
+        return static_lora
+    token_mapping = static_lora.token_lora_mapping
+    if start < 0 or end < start or end > int(token_mapping.shape[0]):
+        raise ValueError(
+            "B12X LoRA token-map range is outside the live mapping: "
+            f"[{start}, {end}) vs {int(token_mapping.shape[0])} rows"
+        )
+    if start == 0 and end == int(token_mapping.shape[0]):
+        return static_lora
+    return replace(static_lora, token_lora_mapping=token_mapping[start:end])
 
 
 def _maybe_repeat_check_b12x_moe(
@@ -1797,6 +1815,9 @@ class B12xExperts(LoRAExpertsMixin, mk.FusedMoEExpertsModular):
             chunk_topk_weights = topk_weights[start:end]
             chunk_topk_ids = topk_ids[start:end]
             chunk_output = output[start:end]
+            chunk_static_lora = _static_lora_for_token_range(
+                self._b12x_static_lora, start, end
+            )
             plan = _plan_b12x_moe_fp4_scratch(
                 tokens=end - start,
                 topk=int(topk_ids.shape[1]),
@@ -1830,7 +1851,7 @@ class B12xExperts(LoRAExpertsMixin, mk.FusedMoEExpertsModular):
                 activation_amax=activation_amax,
                 layer_idx=activation_layer_idx,
                 route_expert_map=expert_map,
-                static_lora=self._b12x_static_lora,
+                static_lora=chunk_static_lora,
             )
             if capture_kquant:
                 assert prefix is not None
@@ -1852,7 +1873,7 @@ class B12xExperts(LoRAExpertsMixin, mk.FusedMoEExpertsModular):
                     plan=plan,
                     scratch=scratch,
                     route_expert_map=expert_map,
-                    static_lora=self._b12x_static_lora,
+                    static_lora=chunk_static_lora,
                 )
 
     def moe_sum(self, input: torch.Tensor, output: torch.Tensor) -> None:

--- a/vllm/model_executor/layers/fused_moe/b12x_moe.py
+++ b/vllm/model_executor/layers/fused_moe/b12x_moe.py
@@ -998,7 +998,13 @@ class B12xExperts(LoRAExpertsMixin, mk.FusedMoEExpertsModular):
             ctx.w2_lora_b_stacked[0][0], rank_dim=2, name="w2_b"
         )
 
-        from b12x.moe.fused_moe import StaticExpertLoRA
+        try:
+            from b12x.moe.fused_moe import StaticExpertLoRA
+        except ImportError as error:
+            raise RuntimeError(
+                "B12X W4A16 LoRA requires a B12X revision that exports "
+                "StaticExpertLoRA (local-inference-lab/b12x#240 or later)"
+            ) from error
 
         self._b12x_static_lora = StaticExpertLoRA(
             w13_a=w13_a_gate,

--- a/vllm/model_executor/layers/fused_moe/b12x_moe.py
+++ b/vllm/model_executor/layers/fused_moe/b12x_moe.py
@@ -845,6 +845,7 @@ class B12xExperts(LoRAExpertsMixin, mk.FusedMoEExpertsModular):
         self._b12x_static_lora: Any | None = None
         self._b12x_lora_weight_signature: tuple[tuple[int, int], ...] | None = None
         self._b12x_lora_mapping_ptr: int | None = None
+        self._b12x_lora_packed_factors: dict[str, torch.Tensor] = {}
 
     @staticmethod
     def _lora_weight_signature(ctx: MoELoRAContext) -> tuple[tuple[int, int], ...]:
@@ -856,6 +857,50 @@ class B12xExperts(LoRAExpertsMixin, mk.FusedMoEExpertsModular):
         )
         return tuple((tensor.data_ptr(), tensor._version) for tensor in tensors)
 
+    def _rank4_lora_factor(
+        self, tensor: torch.Tensor, *, rank_dim: int, name: str
+    ) -> torch.Tensor:
+        """Return stable contiguous rank-4 storage for one vLLM cache factor.
+
+        vLLM's smallest cache capacity is rank 8. Real rank-4 adapters occupy
+        its first four lanes and leave the rest zero. A narrow view retains
+        rank-8 row strides, so pack it once into persistent storage and update
+        that same allocation when vLLM mutates the source cache.
+        """
+        rank_capacity = tensor.shape[rank_dim]
+        if rank_capacity < 4:
+            raise NotImplementedError(
+                f"B12X W4A16 requires rank-4 expert LoRA; {name} has "
+                f"rank capacity {rank_capacity}"
+            )
+        if rank_capacity > 4:
+            padding = tensor.narrow(rank_dim, 4, rank_capacity - 4)
+            if torch.count_nonzero(padding).item() != 0:
+                raise NotImplementedError(
+                    "B12X W4A16 supports a rank-4 expert LoRA stored in a "
+                    f"zero-padded cache; {name} has non-zero rank padding"
+                )
+        view = tensor.narrow(rank_dim, 0, 4)
+        if view.is_contiguous():
+            return view
+
+        packed = self._b12x_lora_packed_factors.get(name)
+        if packed is None:
+            packed = torch.empty_like(view, memory_format=torch.contiguous_format)
+            self._b12x_lora_packed_factors[name] = packed
+        elif (
+            packed.shape != view.shape
+            or packed.dtype != view.dtype
+            or packed.device != view.device
+        ):
+            raise RuntimeError(
+                "B12X W4A16 static LoRA cache geometry changed after setup: "
+                f"{name} cached={tuple(packed.shape)}/{packed.dtype}/{packed.device}, "
+                f"live={tuple(view.shape)}/{view.dtype}/{view.device}"
+            )
+        packed.copy_(view)
+        return packed
+
     def set_lora_context(self, ctx: MoELoRAContext) -> None:
         super().set_lora_context(ctx)
         if ctx.max_loras != 1:
@@ -864,13 +909,15 @@ class B12xExperts(LoRAExpertsMixin, mk.FusedMoEExpertsModular):
             raise NotImplementedError("B12X W4A16 does not support sharded LoRA rank")
         if ctx.enable_moe_shared_loras:
             raise NotImplementedError("B12X W4A16 does not support shared-expert LoRA")
-        if ctx.w13_num_slices != 2:
-            raise NotImplementedError("B12X W4A16 requires gated W13 LoRA")
+        if ctx.w13_num_slices not in (1, 2):
+            raise NotImplementedError(
+                "B12X W4A16 requires fused or split gated W13 LoRA"
+            )
         if ctx.aux_stream is not None:
             raise NotImplementedError("B12X W4A16 LoRA runs inline on the main stream")
         if (
-            len(ctx.w13_lora_a_stacked) != 2
-            or len(ctx.w13_lora_b_stacked) != 2
+            len(ctx.w13_lora_a_stacked) != ctx.w13_num_slices
+            or len(ctx.w13_lora_b_stacked) != ctx.w13_num_slices
             or len(ctx.w2_lora_a_stacked) != 1
             or len(ctx.w2_lora_b_stacked) != 1
         ):
@@ -888,25 +935,45 @@ class B12xExperts(LoRAExpertsMixin, mk.FusedMoEExpertsModular):
         if _is_current_stream_capturing():
             raise RuntimeError("B12X W4A16 LoRA storage changed during graph capture")
 
-        w13_a_gate = ctx.w13_lora_a_stacked[0][0]
-        w13_a_up = ctx.w13_lora_a_stacked[1][0]
+        w13_a_gate = self._rank4_lora_factor(
+            ctx.w13_lora_a_stacked[0][0], rank_dim=1, name="w13_a_gate"
+        )
         if w13_a_gate.shape[0] != ctx.local_num_experts:
             raise NotImplementedError("B12X W4A16 requires per-expert W13 LoRA A")
-        if w13_a_gate.shape[1] != 4:
-            raise NotImplementedError("B12X W4A16 requires rank-4 expert LoRA")
-        if not torch.equal(w13_a_gate, w13_a_up):
-            raise NotImplementedError(
-                "B12X W4A16 currently requires gate/up to share W13 LoRA A"
+        if ctx.w13_num_slices == 2:
+            w13_a_up = self._rank4_lora_factor(
+                ctx.w13_lora_a_stacked[1][0], rank_dim=1, name="w13_a_up"
             )
+            if not torch.equal(w13_a_gate, w13_a_up):
+                raise NotImplementedError(
+                    "B12X W4A16 currently requires gate/up to share W13 LoRA A"
+                )
+            w13_b = self._rank4_lora_factor(
+                ctx.w13_lora_b_stacked[0][0], rank_dim=2, name="w13_b_gate"
+            )
+            w13_b_up = self._rank4_lora_factor(
+                ctx.w13_lora_b_stacked[1][0], rank_dim=2, name="w13_b_up"
+            )
+        else:
+            w13_b = self._rank4_lora_factor(
+                ctx.w13_lora_b_stacked[0][0], rank_dim=2, name="w13_b"
+            )
+            w13_b_up = None
+        w2_a = self._rank4_lora_factor(
+            ctx.w2_lora_a_stacked[0][0], rank_dim=1, name="w2_a"
+        )
+        w2_b = self._rank4_lora_factor(
+            ctx.w2_lora_b_stacked[0][0], rank_dim=2, name="w2_b"
+        )
 
         from b12x.moe.fused_moe import StaticExpertLoRA
 
         self._b12x_static_lora = StaticExpertLoRA(
             w13_a=w13_a_gate,
-            w13_b=ctx.w13_lora_b_stacked[0][0],
-            w13_b_up=ctx.w13_lora_b_stacked[1][0],
-            w2_a=ctx.w2_lora_a_stacked[0][0],
-            w2_b=ctx.w2_lora_b_stacked[0][0],
+            w13_b=w13_b,
+            w13_b_up=w13_b_up,
+            w2_a=w2_a,
+            w2_b=w2_b,
             token_lora_mapping=token_lora_mapping,
             adapter_slot=0,
         )

--- a/vllm/model_executor/layers/fused_moe/b12x_moe.py
+++ b/vllm/model_executor/layers/fused_moe/b12x_moe.py
@@ -941,14 +941,28 @@ class B12xExperts(LoRAExpertsMixin, mk.FusedMoEExpertsModular):
         ):
             raise ValueError("B12X W4A16 received invalid gated LoRA storage")
 
-        token_mapping_meta = ctx.punica_wrapper.token_mapping_meta
-        token_lora_mapping = token_mapping_meta.token_lora_mapping
+        # The compact kernel scratch can retain a preceding adapter mapping
+        # when a request contains no LoRA. Punica's primary allocation is
+        # refreshed for every request, including all-base (-1) batches.
+        token_lora_mapping = ctx.punica_wrapper.token_lora_indices_buffer
+        if token_lora_mapping.dtype not in (torch.int32, torch.int64):
+            raise TypeError(
+                "B12X W4A16 requires an int32/int64 token LoRA mapping, got "
+                f"{token_lora_mapping.dtype}"
+            )
+        if not token_lora_mapping.is_contiguous():
+            raise ValueError("B12X W4A16 requires contiguous token LoRA mapping")
         signature = self._lora_weight_signature(ctx)
         mapping_ptr = token_lora_mapping.data_ptr()
         if (
             signature == self._b12x_lora_weight_signature
-            and mapping_ptr == self._b12x_lora_mapping_ptr
+            and self._b12x_static_lora is not None
         ):
+            self._b12x_static_lora = replace(
+                self._b12x_static_lora,
+                token_lora_mapping=token_lora_mapping,
+            )
+            self._b12x_lora_mapping_ptr = mapping_ptr
             return
         if _is_current_stream_capturing():
             raise RuntimeError("B12X W4A16 LoRA storage changed during graph capture")
@@ -997,6 +1011,11 @@ class B12xExperts(LoRAExpertsMixin, mk.FusedMoEExpertsModular):
         )
         self._b12x_lora_weight_signature = signature
         self._b12x_lora_mapping_ptr = mapping_ptr
+
+    def refresh_lora_context(self) -> None:
+        """Refresh packed rank-4 factors after vLLM mutates its LoRA cache."""
+        if self._lora_context is not None:
+            self.set_lora_context(self._lora_context)
 
     def _quant_mode(self) -> str:
         source_format = self._source_format()
@@ -1290,12 +1309,11 @@ class B12xExperts(LoRAExpertsMixin, mk.FusedMoEExpertsModular):
     ):
         quant_mode = self._quant_mode()
 
-        if self._b12x_static_lora is not None:
-            if quant_mode != "w4a16":
-                raise RuntimeError(
-                    "B12X expert LoRA requires quant_mode='w4a16'; set "
-                    "B12X_MOE_FORCE_A16=1 for NVFP4 checkpoints"
-                )
+        if self._b12x_static_lora is not None and quant_mode != "w4a16":
+            raise RuntimeError(
+                "B12X expert LoRA requires quant_mode='w4a16'; set "
+                "B12X_MOE_FORCE_A16=1 for NVFP4 checkpoints"
+            )
         prepared = self._prepared_experts
         if prepared is not None:
             requested_dtype = str(params_dtype).removeprefix("torch.")

--- a/vllm/model_executor/layers/fused_moe/b12x_moe.py
+++ b/vllm/model_executor/layers/fused_moe/b12x_moe.py
@@ -20,6 +20,10 @@ from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEQuantConfig,
     RoutingMethodType,
 )
+from vllm.model_executor.layers.fused_moe.experts.lora_context import MoELoRAContext
+from vllm.model_executor.layers.fused_moe.experts.lora_experts_mixin import (
+    LoRAExpertsMixin,
+)
 from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
     TopKWeightAndReduceNoOP,
 )
@@ -589,6 +593,7 @@ def _run_b12x_moe_fp4(
     activation_amax: torch.Tensor | None = None,
     layer_idx: int | None = None,
     route_expert_map: torch.Tensor | None = None,
+    static_lora: Any | None = None,
 ) -> Any:
     """Call b12x MoE with caller-owned live scratch."""
     from b12x.moe.fused_moe import run as b12x_moe_fp4
@@ -610,6 +615,7 @@ def _run_b12x_moe_fp4(
         activation_amax=activation_amax,
         layer_idx=layer_idx,
         route_expert_map=route_expert_map,
+        static_lora=static_lora,
     )
     b12x_moe_fp4(binding=binding)
     return binding
@@ -693,6 +699,7 @@ def _maybe_repeat_check_b12x_moe(
     plan: Any,
     scratch: torch.Tensor,
     route_expert_map: torch.Tensor | None = None,
+    static_lora: Any | None = None,
 ) -> None:
     global _moe_repeat_check_reports
 
@@ -718,6 +725,7 @@ def _maybe_repeat_check_b12x_moe(
         plan=plan,
         scratch=scratch,
         route_expert_map=route_expert_map,
+        static_lora=static_lora,
     )
 
     original_f = original_output.float()
@@ -811,7 +819,7 @@ def _has_b12x() -> bool:
         return False
 
 
-class B12xExperts(mk.FusedMoEExpertsModular):
+class B12xExperts(LoRAExpertsMixin, mk.FusedMoEExpertsModular):
     """Native FP4 MoE backend powered by b12x kernels."""
 
     def __init__(
@@ -834,6 +842,76 @@ class B12xExperts(mk.FusedMoEExpertsModular):
         self._activation_amax_state_key: tuple[str, str, int] | None = None
         self._activation_amax_layer_idx: int | None = None
         self._kquant_capture_prefix: str | None = None
+        self._b12x_static_lora: Any | None = None
+        self._b12x_lora_weight_signature: tuple[tuple[int, int], ...] | None = None
+        self._b12x_lora_mapping_ptr: int | None = None
+
+    @staticmethod
+    def _lora_weight_signature(ctx: MoELoRAContext) -> tuple[tuple[int, int], ...]:
+        tensors = (
+            *ctx.w13_lora_a_stacked,
+            *ctx.w13_lora_b_stacked,
+            *ctx.w2_lora_a_stacked,
+            *ctx.w2_lora_b_stacked,
+        )
+        return tuple((tensor.data_ptr(), tensor._version) for tensor in tensors)
+
+    def set_lora_context(self, ctx: MoELoRAContext) -> None:
+        super().set_lora_context(ctx)
+        if ctx.max_loras != 1:
+            raise NotImplementedError("B12X W4A16 supports exactly one LoRA slot")
+        if ctx.fully_sharded:
+            raise NotImplementedError("B12X W4A16 does not support sharded LoRA rank")
+        if ctx.enable_moe_shared_loras:
+            raise NotImplementedError("B12X W4A16 does not support shared-expert LoRA")
+        if ctx.w13_num_slices != 2:
+            raise NotImplementedError("B12X W4A16 requires gated W13 LoRA")
+        if ctx.aux_stream is not None:
+            raise NotImplementedError("B12X W4A16 LoRA runs inline on the main stream")
+        if (
+            len(ctx.w13_lora_a_stacked) != 2
+            or len(ctx.w13_lora_b_stacked) != 2
+            or len(ctx.w2_lora_a_stacked) != 1
+            or len(ctx.w2_lora_b_stacked) != 1
+        ):
+            raise ValueError("B12X W4A16 received invalid gated LoRA storage")
+
+        token_mapping_meta = ctx.punica_wrapper.token_mapping_meta
+        token_lora_mapping = token_mapping_meta.token_lora_mapping
+        signature = self._lora_weight_signature(ctx)
+        mapping_ptr = token_lora_mapping.data_ptr()
+        if (
+            signature == self._b12x_lora_weight_signature
+            and mapping_ptr == self._b12x_lora_mapping_ptr
+        ):
+            return
+        if _is_current_stream_capturing():
+            raise RuntimeError("B12X W4A16 LoRA storage changed during graph capture")
+
+        w13_a_gate = ctx.w13_lora_a_stacked[0][0]
+        w13_a_up = ctx.w13_lora_a_stacked[1][0]
+        if w13_a_gate.shape[0] != ctx.local_num_experts:
+            raise NotImplementedError("B12X W4A16 requires per-expert W13 LoRA A")
+        if w13_a_gate.shape[1] != 4:
+            raise NotImplementedError("B12X W4A16 requires rank-4 expert LoRA")
+        if not torch.equal(w13_a_gate, w13_a_up):
+            raise NotImplementedError(
+                "B12X W4A16 currently requires gate/up to share W13 LoRA A"
+            )
+
+        from b12x.moe.fused_moe import StaticExpertLoRA
+
+        self._b12x_static_lora = StaticExpertLoRA(
+            w13_a=w13_a_gate,
+            w13_b=ctx.w13_lora_b_stacked[0][0],
+            w13_b_up=ctx.w13_lora_b_stacked[1][0],
+            w2_a=ctx.w2_lora_a_stacked[0][0],
+            w2_b=ctx.w2_lora_b_stacked[0][0],
+            token_lora_mapping=token_lora_mapping,
+            adapter_slot=0,
+        )
+        self._b12x_lora_weight_signature = signature
+        self._b12x_lora_mapping_ptr = mapping_ptr
 
     def _quant_mode(self) -> str:
         source_format = self._source_format()
@@ -1126,6 +1204,13 @@ class B12xExperts(mk.FusedMoEExpertsModular):
         params_dtype: torch.dtype,
     ):
         quant_mode = self._quant_mode()
+
+        if self._b12x_static_lora is not None:
+            if quant_mode != "w4a16":
+                raise RuntimeError(
+                    "B12X expert LoRA requires quant_mode='w4a16'; set "
+                    "B12X_MOE_FORCE_A16=1 for NVFP4 checkpoints"
+                )
         prepared = self._prepared_experts
         if prepared is not None:
             requested_dtype = str(params_dtype).removeprefix("torch.")
@@ -1592,6 +1677,11 @@ class B12xExperts(mk.FusedMoEExpertsModular):
         )
         quant_mode = self._quant_mode()
 
+        if self._b12x_static_lora is not None and expert_map is not None:
+            raise NotImplementedError(
+                "B12X W4A16 expert LoRA does not yet support expert parallel"
+            )
+
         if expert_map is not None:
             if quant_mode != "w4a16":
                 raise RuntimeError(
@@ -1673,6 +1763,7 @@ class B12xExperts(mk.FusedMoEExpertsModular):
                 activation_amax=activation_amax,
                 layer_idx=activation_layer_idx,
                 route_expert_map=expert_map,
+                static_lora=self._b12x_static_lora,
             )
             if capture_kquant:
                 assert prefix is not None
@@ -1694,10 +1785,11 @@ class B12xExperts(mk.FusedMoEExpertsModular):
                     plan=plan,
                     scratch=scratch,
                     route_expert_map=expert_map,
+                    static_lora=self._b12x_static_lora,
                 )
 
     def moe_sum(self, input: torch.Tensor, output: torch.Tensor) -> None:
-        raise NotImplementedError("LoRA is not supported for B12xExperts")
+        raise NotImplementedError("B12xExperts writes reduced output inline")
 
 
 def warmup_b12x_moe_dynamic(

--- a/vllm/models/deepseek_v4/attention.py
+++ b/vllm/models/deepseek_v4/attention.py
@@ -220,7 +220,14 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
         config = vllm_config.model_config.hf_config
         quant_config = vllm_config.quant_config
         cache_config = vllm_config.cache_config
-        self._use_b12x_wo = bool(envs.VLLM_USE_B12X_WO_PROJECTION)
+        self._use_b12x_wo = bool(
+            envs.VLLM_USE_B12X_WO_PROJECTION and vllm_config.lora_config is None
+        )
+        if envs.VLLM_USE_B12X_WO_PROJECTION and not self._use_b12x_wo:
+            logger.warning_once(
+                "Disabling the fused B12X DeepSeek-V4 WO projection because "
+                "LoRA is enabled; the generic projection preserves wo_b LoRA."
+            )
         self._b12x_wo_projection_weights: Any | None = None
         tp_size = get_tensor_model_parallel_world_size()
         layer_id = extract_layer_index(prefix)
@@ -688,11 +695,12 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
             compressor = self.compressor
 
             def compressor_kv_score() -> torch.Tensor:
-                return torch.mm(
-                    hidden_states,
-                    compressor.fused_wkv_wgate.weight.T,
-                    out_dtype=torch.float32,
-                )
+                # This packed projection can carry the adapter's compressor
+                # kv/gate LoRA. Calling the module preserves that delta.
+                projected = compressor.fused_wkv_wgate(hidden_states)
+                if isinstance(projected, tuple):
+                    projected = projected[0]
+                return projected.float()
 
             aux_fns[0] = compressor_kv_score
 
@@ -705,9 +713,13 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
                 return weights
 
             def indexer_compressor_kv_score() -> torch.Tensor:
+                # The adapter excludes the indexer compressor, but LoRA model
+                # management still wraps its supported linear module.
+                wrapped = indexer.compressor.fused_wkv_wgate
+                base = getattr(wrapped, "base_layer", wrapped)
                 return torch.mm(
                     hidden_states,
-                    indexer.compressor.fused_wkv_wgate.weight.T,
+                    base.weight.T,
                     out_dtype=torch.float32,
                 )
 

--- a/vllm/models/deepseek_v4/attention.py
+++ b/vllm/models/deepseek_v4/attention.py
@@ -49,7 +49,11 @@ from vllm.logger import init_logger
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.quantization import QuantizationConfig
+from vllm.model_executor.layers.quantization.utils.fp8_utils import (
+    deepgemm_post_process_fp8_weight_block,
+)
 from vllm.model_executor.models.utils import extract_layer_index
+from vllm.model_executor.utils import replace_parameter
 from vllm.models.deepseek_v4.common.rope import build_deepseek_v4_rope
 from vllm.models.deepseek_v4.compressor import DeepseekCompressor
 from vllm.triton_utils import tl, triton
@@ -490,6 +494,53 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
                 rank=rank,
                 hidden=hidden,
             )
+        )
+
+    def setup_generic_wo_projection(self) -> None:
+        """Prepare the LoRA-safe DeepGEMM WO-A grouped-einsum layout.
+
+        SM120 normally consumes the checkpoint's canonical 2-D WO tensors in
+        the fused B12X projection. LoRA must keep WO-B callable so its delta is
+        applied, which selects the generic DeepGEMM chain. Repack WO-A once
+        after ordinary quant-method finalization.
+        """
+        if self._use_b12x_wo:
+            return
+
+        wo_a_base = getattr(self.wo_a, "base_layer", self.wo_a)
+        if wo_a_base.weight.ndim == 3:
+            return
+        if wo_a_base.weight.ndim != 2:
+            raise RuntimeError(
+                "DeepSeek V4 generic WO-A expected a 2-D checkpoint tensor or "
+                f"3-D prepared tensor, got shape {tuple(wo_a_base.weight.shape)}"
+            )
+
+        scale_name = (
+            "weight_scale" if hasattr(wo_a_base, "weight_scale") else "weight_scale_inv"
+        )
+        weight_scale = getattr(wo_a_base, scale_name)
+        block_shape = tuple(getattr(wo_a_base, "weight_block_size", (128, 128)))
+        if block_shape != (128, 128):
+            raise NotImplementedError(
+                "DeepSeek V4 generic WO-A currently requires 128x128 FP8 "
+                f"blocks, got {block_shape}"
+            )
+
+        weight, weight_scale = deepgemm_post_process_fp8_weight_block(
+            wq=wo_a_base.weight,
+            ws=weight_scale,
+            quant_block_shape=block_shape,
+            use_e8m0=True,
+            is_bmm=True,
+            bmm_batch_size=self.n_local_groups,
+        )
+        replace_parameter(wo_a_base, "weight", weight)
+        replace_parameter(wo_a_base, scale_name, weight_scale)
+        logger.info_once(
+            "Prepared DeepSeek V4 generic WO-A for LoRA: weight=%s scale=%s",
+            tuple(weight.shape),
+            tuple(weight_scale.shape),
         )
 
     def _apply_b12x_wo_projection(

--- a/vllm/models/deepseek_v4/nvidia/model.py
+++ b/vllm/models/deepseek_v4/nvidia/model.py
@@ -1914,6 +1914,10 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
         for layer in islice(self.layers, self.start_layer, self.end_layer):
             layer.attn.setup_b12x_wo_projection()
 
+    def setup_generic_wo_projection(self) -> None:
+        for layer in islice(self.layers, self.start_layer, self.end_layer):
+            layer.attn.setup_generic_wo_projection()
+
 
 def _make_deepseek_v4_weights_mapper(expert_dtype: str) -> WeightsMapper:
     if expert_dtype == "fp4":
@@ -2096,6 +2100,11 @@ class DeepseekV4ForCausalLM(
         self.model.finalize_mhc_broadcast_weights()
         self.model.setup_b12x_wo_projection()
         return loaded_params
+
+    def process_weights_after_loading(self) -> None:
+        # After per-linear quant finalization, prepare generic WO-A when LoRA
+        # keeps WO-B callable instead of using the fused B12X projection.
+        self.model.setup_generic_wo_projection()
 
     def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
         return self.model.get_expert_mapping()

--- a/vllm/models/deepseek_v4/nvidia/model.py
+++ b/vllm/models/deepseek_v4/nvidia/model.py
@@ -59,6 +59,7 @@ from vllm.model_executor.models.interfaces import (
     EagleModelMixin,
     MixtureOfExperts,
     SupportsEagle3,
+    SupportsLoRA,
     SupportsPP,
 )
 from vllm.model_executor.models.utils import (
@@ -1946,6 +1947,8 @@ def _make_deepseek_v4_weights_mapper(expert_dtype: str) -> WeightsMapper:
             ".ffn.gate.bias": ".ffn.gate.e_score_correction_bias",
         },
         orig_to_new_substr={
+            ".self_attn.": ".attn.",
+            ".mlp.": ".ffn.",
             ".shared_experts.w2": ".shared_experts.down_proj",
         },
     )
@@ -1989,8 +1992,21 @@ class DeepseekV4MixtureOfExperts(MixtureOfExperts):
 
 
 class DeepseekV4ForCausalLM(
-    nn.Module, SupportsPP, SupportsEagle3, DeepseekV4MixtureOfExperts
+    nn.Module,
+    SupportsPP,
+    SupportsEagle3,
+    SupportsLoRA,
+    DeepseekV4MixtureOfExperts,
 ):
+    is_3d_moe_weight = True
+    lora_skip_prefixes = ["mtp."]
+    packed_modules_mapping = {
+        "fused_wqa_wkv": ["q_a_proj", "kv_proj"],
+        "wq_b": ["q_b_proj"],
+        "wo_b": ["o_b_proj"],
+        "fused_wkv_wgate": ["kv_proj", "gate_proj"],
+        "gate_up_proj": ["gate_proj", "up_proj"],
+    }
     model_cls = DeepseekV4Model
 
     # Default mapper assumes the original FP4-expert checkpoint layout.

--- a/vllm/models/deepseek_v4/nvidia/ops/o_proj.py
+++ b/vllm/models/deepseek_v4/nvidia/ops/o_proj.py
@@ -101,13 +101,19 @@ def deep_gemm_fp8_o_proj(
         device=o.device,
         dtype=torch.bfloat16,
     )
+    # LoRA management wraps supported linear modules even when an adapter does
+    # not target a particular projection. The fused einsum needs the raw wo_a
+    # tensor, while wo_b remains a normal callable so its LoRA delta applies.
+    wo_a_base = getattr(wo_a, "base_layer", wo_a)
     weight_scale = (
-        wo_a.weight_scale if hasattr(wo_a, "weight_scale") else wo_a.weight_scale_inv
+        wo_a_base.weight_scale
+        if hasattr(wo_a_base, "weight_scale")
+        else wo_a_base.weight_scale_inv
     )
     torch.ops.vllm.deepseek_v4_fp8_o_proj_einsum(
         o_fp8,
         o_scale,
-        wo_a.weight,
+        wo_a_base.weight,
         weight_scale,
         z,
         einsum_recipe[0],

--- a/vllm/v1/worker/gpu/spec_decode/dspark/utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/dspark/utils.py
@@ -7,6 +7,7 @@ import torch.nn as nn
 
 from vllm.config import VllmConfig
 from vllm.distributed.parallel_state import get_pp_group
+from vllm.lora.layers.base import BaseLayerWithLoRA
 from vllm.model_executor.model_loader import get_model
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 from vllm.v1.worker.gpu.spec_decode.eagle.utils import (
@@ -35,6 +36,9 @@ def load_dspark_model(target_model: nn.Module, vllm_config: VllmConfig) -> nn.Mo
     # Reusing target DCP geometry would partition a cache that every target rank
     # must populate and consume independently.
     draft_vllm_config = _create_draft_vllm_config(vllm_config)
+    # DSpark proposes for the target verifier; it is not part of the target
+    # adapter. Inheriting LoRA here can select incompatible draft projections.
+    draft_vllm_config.lora_config = None
     draft_vllm_config.attention_config.backend = backend
     draft_vllm_config.attention_config.use_non_causal = dflash_has_any_non_causal(
         draft_model_config.hf_config
@@ -69,6 +73,8 @@ def load_dspark_model(target_model: nn.Module, vllm_config: VllmConfig) -> nn.Mo
     draft_inner = draft_model.model
 
     target_embed = getattr(target_inner, "embed_tokens", None)
+    if isinstance(target_embed, BaseLayerWithLoRA):
+        target_embed = target_embed.base_layer
     draft_embed = getattr(draft_inner, "embed_tokens", None)
     if target_embed is not None and _should_share(
         draft_model, "has_own_embed_tokens", draft_embed, target_embed
@@ -78,6 +84,8 @@ def load_dspark_model(target_model: nn.Module, vllm_config: VllmConfig) -> nn.Mo
         draft_inner.embed_tokens = target_embed
 
     target_lm_head = get_target_lm_head(target_model, target_language_model)
+    if isinstance(target_lm_head, BaseLayerWithLoRA):
+        target_lm_head = target_lm_head.base_layer
     draft_lm_head = getattr(draft_model, "lm_head", None)
     if target_lm_head is not None and _should_share(
         draft_model, "has_own_lm_head", draft_lm_head, target_lm_head


### PR DESCRIPTION
## Purpose

Enable live LoRA serving for DeepSeek V4 with B12X's native SM120 W4A16
routed-expert backend.

This is the vLLM integration half of the feature and depends on the companion
B12X kernel PR:

`Depends on: local-inference-lab/b12x#240`

Before this change, vLLM could load a DeepSeek V4 adapter while the selected
B12X expert kernel silently consumed none of its routed-expert deltas. Several
model-specific paths could also bypass adapted projection modules or retain a
stale token-to-adapter mapping across requests.

This PR:

- declares DeepSeek V4's packed dense and 3-D expert LoRA mappings;
- translates vLLM's fused-MoE caches into B12X's one-slot, effective-rank-4
  expert-LoRA contract;
- accepts a zero-padded rank-8 cache only when its effective rank is four;
- supports fused 3-D and split gate/up W13 adapter storage;
- retains Punica's stable token-index backing allocation for CUDA graphs;
- refreshes B12X factor bindings after adapter set, replace, and reset;
- slices the live adapter map correctly during chunked MoE execution;
- preserves DeepSeek router metadata through `ReplicatedLinearWithLoRA`;
- keeps adapted compressor and WO-B projections callable rather than bypassing
  their LoRA deltas; and
- isolates the DSpark base proposer from the adapted target verifier.

Unsupported combinations fail closed instead of silently omitting an adapter
component or claiming B12X execution after selecting an unrelated fallback.

### Scope

The first qualified contract is deliberately narrow:

- DeepSeek V4 W4A16 routed experts on B12X;
- BF16 activations and BF16 LoRA factors;
- one active adapter slot;
- effective rank 4, including a validated zero-padded cache;
- fused or split gate/up W13 B storage;
- tensor parallel execution; and
- dynamic per-token base/adapter selection under CUDA graphs.

Not supported by this PR: expert parallelism, multiple active adapters, other
effective ranks, fully sharded LoRA rank, shared-expert LoRA inside the B12X
routed kernel, LoRA auxiliary-stream execution, MTP adapter modules, and other
activation-quantization modes.

### Duplicate-work check

No overlapping open LoRA PR was found in the target vLLM or B12X community
repositories in the public GitHub search performed on 2026-08-22. This change
targets `local-inference-lab/vllm`, not official vLLM mainline.

## Test Plan

Focused selections exercised the newly changed integration seams:

```bash
python -m pytest \
  tests/model_executor/layers/test_b12x_moe_warmup.py \
  -k 'adapts_vllm_split_lora_storage_without_copy or revalidates_mutated_lora_storage or accepts_zero_padded_rank4_lora_cache'

python -m pytest \
  tests/lora/test_lora_manager.py::test_wrap_gate_linear

python -m pytest \
  tests/v1/spec_decode/test_external_draft_attention_config.py
```

The broader focused integration run also covered:

- fused and split expert storage;
- rejection of nonzero rank padding;
- all-base requests following adapted requests;
- adapter set/reset/replacement;
- mixed base and adapted rows;
- chunk-local mapping slices;
- eager and CUDA-graph execution; and
- stable replay allocation.

Formatting and static checks run on all changed Python files:

```bash
ruff check <changed-files>
ruff format --check <changed-files>
python -m compileall <changed-files>
git diff --check
```

Full-model validation used DeepSeek-V4-Flash-0731 at TP4 on four RTX PRO 6000
Blackwell GPUs. The runtime retained B12X sparse MLA, B12X dense FP8 linears,
native B12X W4A16 experts, FP8 KV cache, and CUDA graphs. The serving sequence
was base -> LoRA -> base to detect adapter-state leakage.

## Test Result

- Focused B12X kernel qualification: `23 passed, 236 deselected`.
- Refreshed focused vLLM/B12X seam: `5 passed, 20 deselected`.
- Additional cache/mapping selection: `3 passed`.
- Router-wrapper selection: `1 passed`.
- DSpark configuration suite: `3 passed`.
- Ruff check, Ruff format check, compilation, and `git diff --check`: passed.
- Every fused/split, one/four-token vLLM-to-B12X seam comparison exceeded
  `0.99998` cosine against an independent FP32 oracle.
- Thirty-two alternating CUDA-graph replays allocated `0 B` and preserved live
  base/adapter row selection.
- A clean-branch base -> LoRA -> base TP4 smoke produced identical hashes for
  both base requests and a distinct adapted result.

Matched 256-token short-decode measurements:

| Arm | Median decode | Range | Change |
| :--- | ---: | :--- | ---: |
| Native base | 163.22 token/s | 155.80-163.63 | reference |
| Native live LoRA | 135.88 token/s | 135.46-136.02 | -16.75% |

The full-model cost is consistent with the measured 18.80% cost of the
decode-critical one-token expert-LoRA kernel. It does not resemble a generic
expert fallback collapse.

Across 740 natural output positions on another GPU architecture, the
base-normalized live-adapter effect had median weighted correlations of
`0.9675-0.9771` and projected amplitudes of `0.9660-0.9794`. These measurements
evaluate implementation fidelity, not subjective adapter quality.

A merge-and-requantize control retained only about 25-33% of the live adapter
effect and disagreed with native live execution on 7.42-10.55% of top-1
choices. This is why the adapter is applied live rather than baked into the
already quantized expert weights.

Complete full-model replay is prompt-dependent in the surrounding runtime,
including configurations that do not exercise the new routed-expert adapter
path. This PR therefore claims deterministic focused kernel/graph behavior,
not universal bitwise determinism for the whole server.

The complete repository CI matrix was not run locally. The pinned serving
image lacks some current-tree test dependencies and custom operations, so the
remaining gate is the repository CI/native development environment rather than
substituting incompatible binaries.

## AI assistance disclosure

OpenAI Codex assisted with implementation, tests, validation tooling,
experimental analysis, and drafting this description. The human submitter
reviewed the final change and is responsible for the design, measurements, and
claims.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results.
- [x] No separate documentation update is required; supported and unsupported configurations are documented in this PR.

</details>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added LoRA support for B12X fused mixture-of-experts models, including static mappings, cache management, and chunked execution.
  * Added LoRA support and configuration metadata for DeepSeek V4 models.
  * Preserved router metadata and stable token-mapping buffers for LoRA-enabled layers.

* **Bug Fixes**
  * Improved LoRA weight reset and context refresh behavior.
  * Fixed draft-model loading and projection handling with LoRA-wrapped layers.
  * Improved packed projection processing and expert configuration validation.
  * Ensured LoRA metadata remains available across wrapped layers and model components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->