### PR TITLE
[II] Bound Kimi-K3 DFlash auxiliary projection memory

### DIFF
--- a/tests/model_executor/test_b12x_mxfp8_input_accumulator.py
+++ b/tests/model_executor/test_b12x_mxfp8_input_accumulator.py
@@ -8,6 +8,7 @@ import pytest
 import torch
 
 from vllm.model_executor.kernels.linear.mxfp8 import b12x
+from vllm.platforms import current_platform
 
 
 def test_input_accumulator_fills_ordered_slices_and_reuses_output(monkeypatch):
@@ -71,9 +72,12 @@ def test_input_accumulator_fills_ordered_slices_and_reuses_output(monkeypatch):
     assert calls[3] == ("mm", storage, weight, 3, output, 3, "stream")
 
 
-@pytest.mark.skipif(not torch.accelerator.is_available(), reason="requires accelerator")
+@pytest.mark.skipif(
+    not current_platform.is_cuda() or not torch.accelerator.is_available(),
+    reason="requires CUDA",
+)
 def test_input_accumulator_runs_under_fullgraph_compile() -> None:
-    from b12x.gemm import mxfp8_linear
+    mxfp8_linear = pytest.importorskip("b12x.gemm.mxfp8_linear")
 
     tokens = 8
     width = 128

--- a/tests/model_executor/test_b12x_mxfp8_input_accumulator.py
+++ b/tests/model_executor/test_b12x_mxfp8_input_accumulator.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+import torch
+
+from vllm.model_executor.kernels.linear.mxfp8 import b12x
+
+
+def test_input_accumulator_fills_ordered_slices_and_reuses_output(monkeypatch):
+    calls: list[tuple[Any, ...]] = []
+    storage = SimpleNamespace()
+    output = torch.empty(8, 4)
+
+    class API:
+        @staticmethod
+        def empty_input(tokens, width, *, device):
+            calls.append(("empty", tokens, width, device))
+            return storage
+
+        @staticmethod
+        def quantize_input_slice(source, destination, *, destination_column):
+            calls.append(
+                (
+                    "quantize",
+                    source.clone(),
+                    destination,
+                    destination_column,
+                )
+            )
+
+        @staticmethod
+        def mm_quantized(
+            source,
+            weight,
+            *,
+            tokens,
+            out,
+            expected_m,
+            stream,
+        ):
+            calls.append(("mm", source, weight, tokens, out, expected_m, stream))
+            return out[:tokens]
+
+    monkeypatch.setattr(b12x, "_import_b12x_mxfp8", lambda: API)
+    monkeypatch.setattr(
+        b12x,
+        "current_stream",
+        lambda: SimpleNamespace(cuda_stream="stream"),
+    )
+    weight = SimpleNamespace(
+        in_features=6,
+        padded_in_features=6,
+        out_features=4,
+    )
+    layer = SimpleNamespace(b12x_mxfp8_packed_weight=weight)
+    accumulator = b12x.B12xMxfp8InputAccumulator(layer, output)
+
+    accumulator.begin(3)
+    accumulator.append(torch.ones(3, 2))
+    accumulator.append(torch.full((3, 4), 2.0))
+    result = accumulator.finish()
+
+    assert result.data_ptr() == output.data_ptr()
+    assert calls[0] == ("empty", 8, 6, output.device)
+    assert calls[1][0] == "quantize" and calls[1][3] == 0
+    assert calls[2][0] == "quantize" and calls[2][3] == 2
+    assert calls[3] == ("mm", storage, weight, 3, output, 3, "stream")
+
+
+@pytest.mark.skipif(not torch.accelerator.is_available(), reason="requires accelerator")
+def test_input_accumulator_runs_under_fullgraph_compile() -> None:
+    from b12x.gemm import mxfp8_linear
+
+    tokens = 8
+    width = 128
+    output_width = 64
+    first = torch.randn((tokens, width), device="cuda", dtype=torch.bfloat16).div_(4)
+    second = torch.randn_like(first).div_(4)
+    weight = torch.randn(
+        (output_width, 2 * width), device="cuda", dtype=torch.bfloat16
+    ).div_(8)
+    weight_values = weight.to(torch.float8_e4m3fn)
+    weight_scales = torch.full(
+        (output_width, 2 * width // 32),
+        127,
+        device="cuda",
+        dtype=torch.uint8,
+    )
+    packed = mxfp8_linear.pack_weight(weight_values, weight_scales)
+    layer = SimpleNamespace(b12x_mxfp8_packed_weight=packed)
+    output = torch.empty((tokens, output_width), device="cuda", dtype=torch.bfloat16)
+    accumulator = b12x.B12xMxfp8InputAccumulator(layer, output)
+
+    @torch.compile(fullgraph=True)
+    def compiled(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+        accumulator.begin(tokens)
+        accumulator.append(a)
+        accumulator.append(b)
+        return accumulator.finish()
+
+    actual = compiled(first, second).clone()
+    expected = mxfp8_linear.mm(torch.cat((first, second), dim=-1), packed)
+    torch.accelerator.synchronize()
+
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)

--- a/tests/model_executor/test_b12x_mxfp8_input_accumulator.py
+++ b/tests/model_executor/test_b12x_mxfp8_input_accumulator.py
@@ -34,7 +34,7 @@ def test_input_accumulator_fills_ordered_slices_and_reuses_output(monkeypatch):
             )
 
         @staticmethod
-        def mm_quantized(
+        def mm_quantized_into(
             source,
             weight,
             *,

--- a/tests/models/kimi_k3/test_aux_attn_res_stream.py
+++ b/tests/models/kimi_k3/test_aux_attn_res_stream.py
@@ -1,0 +1,197 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Which value the DFlash drafter is fed under AttnRes.
+
+`_capture_aux_hidden_stream` picks the weights it mixes against from one of
+three places depending on where the tapped layer sits, and returns the plain
+running prefix when the feature is off. The mixture itself is the kernel's
+job and is covered by ``test_attn_res.py``; what is asserted here is the
+selection, which is the part that can silently feed the drafter the wrong
+tensor.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.models.kimi_k3.nvidia import model as k3_model
+
+END_LAYER = 4
+
+
+def _weights(tag: float) -> SimpleNamespace:
+    """A norm/projection pair that is identifiable by value."""
+    return SimpleNamespace(
+        weight=torch.full((2,), tag),
+        variance_epsilon=tag,
+    )
+
+
+def _stub_model(*, enabled: bool, use_attn_res: bool = True) -> SimpleNamespace:
+    """A stand-in carrying only what the tap reads.
+
+    Constructing the real model needs a distributed init and weights, and none
+    of it participates in the selection under test.
+    """
+    consumers = []
+    for i in range(END_LAYER):
+        consumers.append(
+            SimpleNamespace(
+                self_attention_res_norm=_weights(float(i)),
+                self_attention_res_proj=SimpleNamespace(
+                    weight=torch.full((1, 2), float(i))
+                ),
+                prev_valid_blocks=i,
+            )
+        )
+    return SimpleNamespace(
+        _aux_attn_res_stream=enabled,
+        use_attn_res=use_attn_res,
+        end_layer=END_LAYER,
+        layers=consumers,
+        output_attn_res_norm=_weights(99.0),
+        output_attn_res_proj=SimpleNamespace(weight=torch.full((1, 2), 99.0)),
+        num_attn_res_blocks=99,
+    )
+
+
+@pytest.fixture
+def recorder(monkeypatch):
+    """Replace the kernel so the call it would have made is inspectable."""
+    calls = []
+
+    def _fake_attn_res(
+        prefix,
+        delta,
+        block_residual,
+        norm_weight,
+        proj_weight,
+        output_norm_weight,
+        **kwargs,
+    ):
+        calls.append(
+            SimpleNamespace(
+                prefix=prefix,
+                delta=delta,
+                block_residual=block_residual,
+                norm_weight=norm_weight,
+                proj_weight=proj_weight,
+                kwargs=kwargs,
+            )
+        )
+        return torch.full_like(prefix, -1.0)
+
+    monkeypatch.setattr(k3_model, "attn_res", _fake_attn_res)
+    return calls
+
+
+def _set_last_rank(monkeypatch, is_last: bool):
+    monkeypatch.setattr(
+        k3_model,
+        "get_pp_group",
+        lambda: SimpleNamespace(is_last_rank=is_last),
+    )
+
+
+def _call(stub, layer_idx, prefix_sum, pending_mlp_out, block_residual):
+    return k3_model.KimiLinearModel._capture_aux_hidden_stream(
+        stub, layer_idx, prefix_sum, pending_mlp_out, block_residual
+    )
+
+
+@pytest.mark.parametrize(
+    "enabled,use_attn_res", [(False, True), (True, False), (False, False)]
+)
+def test_disabled_reproduces_the_plain_residual_sum(
+    recorder, monkeypatch, enabled, use_attn_res
+):
+    """Off, the tap must be exactly the sum it replaced.
+
+    Both conditions matter. `use_attn_res` is what constructs the norm and
+    projection weights, so without it the lookups below would raise rather
+    than fall back.
+    """
+    _set_last_rank(monkeypatch, True)
+    prefix_sum = torch.tensor([1.0, 2.0])
+    pending = torch.tensor([0.5, 0.25])
+
+    got = _call(
+        _stub_model(enabled=enabled, use_attn_res=use_attn_res),
+        0,
+        prefix_sum,
+        pending,
+        torch.zeros(2),
+    )
+
+    torch.testing.assert_close(got, prefix_sum + pending)
+    assert not recorder, "the kernel must not run when the tap is off"
+
+
+def test_taps_the_consumer_layer_when_one_follows(recorder, monkeypatch):
+    """The value the next layer reads is the mixture against *its* weights,
+    so the tap has to reach forward rather than use the current layer's."""
+    _set_last_rank(monkeypatch, True)
+
+    _call(_stub_model(enabled=True), 1, torch.zeros(2), None, torch.zeros(2))
+
+    assert len(recorder) == 1
+    call = recorder[0]
+    # Layer 2's weights, not layer 1's.
+    torch.testing.assert_close(call.norm_weight, torch.full((2,), 2.0))
+    assert call.kwargs["num_blocks"] == 2
+
+
+def test_last_layer_on_the_final_rank_uses_the_output_aggregation(
+    recorder, monkeypatch
+):
+    """Nothing downstream but the model's own output-side mixture."""
+    _set_last_rank(monkeypatch, True)
+
+    _call(
+        _stub_model(enabled=True), END_LAYER - 1, torch.zeros(2), None, torch.zeros(2)
+    )
+
+    assert len(recorder) == 1
+    torch.testing.assert_close(recorder[0].norm_weight, torch.full((2,), 99.0))
+    assert recorder[0].kwargs["num_blocks"] == 99
+
+
+def test_last_layer_of_a_non_final_stage_falls_back(recorder, monkeypatch):
+    """The consumer lives on the next rank and the output aggregation only
+    exists on the last one, so there is nothing here to mix against.
+
+    This is the case that would otherwise reach for weights this rank never
+    constructs. The forward guard is `layer_idx + 1 < end_layer`, where
+    `end_layer` is the rank's own exclusive bound from `get_pp_indices`, so a
+    `PPMissingLayer` is unreachable by construction -- the fallback below is
+    what makes that true rather than merely likely.
+    """
+    _set_last_rank(monkeypatch, False)
+    prefix_sum = torch.tensor([3.0, 4.0])
+
+    got = _call(
+        _stub_model(enabled=True), END_LAYER - 1, prefix_sum, None, torch.zeros(2)
+    )
+
+    torch.testing.assert_close(got, prefix_sum)
+    assert not recorder, "no weights exist on this rank to mix against"
+
+
+def test_pending_mlp_output_is_folded_in_rather_than_passed_as_delta(
+    recorder, monkeypatch
+):
+    """The kernel writes an applied delta back into the prefix in place, which
+    would double-add it into the live residual stream, so the pending output
+    has to arrive already summed into the prefix with `delta` left None."""
+    _set_last_rank(monkeypatch, True)
+    prefix_sum = torch.tensor([1.0, 2.0])
+    pending = torch.tensor([0.5, 0.25])
+
+    _call(_stub_model(enabled=True), 0, prefix_sum, pending, torch.zeros(2))
+
+    assert len(recorder) == 1
+    assert recorder[0].delta is None
+    torch.testing.assert_close(recorder[0].prefix, prefix_sum + pending)
+    # And the caller's tensor is not mutated on the way.
+    torch.testing.assert_close(prefix_sum, torch.tensor([1.0, 2.0]))

--- a/tests/models/kimi_k3/test_aux_attn_res_stream.py
+++ b/tests/models/kimi_k3/test_aux_attn_res_stream.py
@@ -34,6 +34,14 @@ def _stub_model(*, enabled: bool, use_attn_res: bool = True) -> SimpleNamespace:
     Constructing the real model needs a distributed init and weights, and none
     of it participates in the selection under test.
     """
+    model = SimpleNamespace(
+        _aux_attn_res_stream=enabled,
+        use_attn_res=use_attn_res,
+        end_layer=END_LAYER,
+    )
+    if not use_attn_res:
+        return model
+
     consumers = []
     for i in range(END_LAYER):
         consumers.append(
@@ -45,15 +53,11 @@ def _stub_model(*, enabled: bool, use_attn_res: bool = True) -> SimpleNamespace:
                 prev_valid_blocks=i,
             )
         )
-    return SimpleNamespace(
-        _aux_attn_res_stream=enabled,
-        use_attn_res=use_attn_res,
-        end_layer=END_LAYER,
-        layers=consumers,
-        output_attn_res_norm=_weights(99.0),
-        output_attn_res_proj=SimpleNamespace(weight=torch.full((1, 2), 99.0)),
-        num_attn_res_blocks=99,
-    )
+    model.layers = consumers
+    model.output_attn_res_norm = _weights(99.0)
+    model.output_attn_res_proj = SimpleNamespace(weight=torch.full((1, 2), 99.0))
+    model.num_attn_res_blocks = 99
+    return model
 
 
 @pytest.fixture
@@ -139,6 +143,7 @@ def test_taps_the_consumer_layer_when_one_follows(recorder, monkeypatch):
     call = recorder[0]
     # Layer 2's weights, not layer 1's.
     torch.testing.assert_close(call.norm_weight, torch.full((2,), 2.0))
+    torch.testing.assert_close(call.proj_weight, torch.full((2,), 2.0))
     assert call.kwargs["num_blocks"] == 2
 
 
@@ -154,6 +159,7 @@ def test_last_layer_on_the_final_rank_uses_the_output_aggregation(
 
     assert len(recorder) == 1
     torch.testing.assert_close(recorder[0].norm_weight, torch.full((2,), 99.0))
+    torch.testing.assert_close(recorder[0].proj_weight, torch.full((2,), 99.0))
     assert recorder[0].kwargs["num_blocks"] == 99
 
 

--- a/tests/models/kimi_k3/test_eagle3.py
+++ b/tests/models/kimi_k3/test_eagle3.py
@@ -22,6 +22,7 @@ def _make_kimi_linear_model() -> KimiLinearModel:
     object.__setattr__(model, "aux_hidden_state_layers", (2,))
     object.__setattr__(model, "use_sequence_parallel", False)
     object.__setattr__(model, "reuse_attn_res_output", True)
+    object.__setattr__(model, "use_attn_res", False)
     return model
 
 
@@ -190,6 +191,63 @@ def test_kimi_linear_forward_streams_auxiliary_states(monkeypatch):
     ]
     assert len(aux_hidden_states) == 1
     assert aux_hidden_states[0] is projected
+
+
+def test_attn_res_stream_capture_receives_layer_outputs_in_order(monkeypatch):
+    """Verify the positional contract between ``forward`` and the capture tap."""
+    model = _make_kimi_linear_model()
+    initial_hidden_states = torch.tensor([[1.0, 2.0]])
+    layer_hidden_states = torch.tensor([[3.0, 4.0]])
+    prefix_sum = torch.tensor([[5.0, 6.0]])
+    block_residual = torch.tensor([[[7.0, 8.0]]])
+    captured = torch.tensor([[11.0, 12.0]])
+
+    object.__setattr__(model, "start_layer", 0)
+    object.__setattr__(model, "end_layer", 1)
+    object.__setattr__(
+        model,
+        "layers",
+        [Mock(return_value=(layer_hidden_states, prefix_sum, block_residual))],
+    )
+    object.__setattr__(model, "aux_hidden_state_layers", (1,))
+    object.__setattr__(model, "use_attn_res", True)
+    object.__setattr__(model, "num_attn_res_blocks", 1)
+    object.__setattr__(
+        model,
+        "output_attn_res_norm",
+        SimpleNamespace(weight=torch.ones(2), variance_epsilon=1e-5),
+    )
+    object.__setattr__(
+        model,
+        "output_attn_res_proj",
+        SimpleNamespace(weight=torch.ones(1, 2)),
+    )
+    monkeypatch.setattr(
+        kimi_model,
+        "get_pp_group",
+        lambda: SimpleNamespace(is_first_rank=True, is_last_rank=True),
+    )
+    monkeypatch.setattr(kimi_model, "attn_res", Mock(return_value=torch.zeros(1, 2)))
+    monkeypatch.setenv("VLLM_KIMI_K3_AUX_ATTN_RES_STREAM", "1")
+
+    capture = Mock(return_value=captured)
+    monkeypatch.setattr(KimiLinearModel, "_capture_aux_hidden_stream", capture)
+
+    _, aux_hidden_states = model.forward(
+        input_ids=None,
+        positions=torch.tensor([0]),
+        intermediate_tensors=None,
+        inputs_embeds=initial_hidden_states,
+    )
+
+    layer_idx, got_prefix, got_pending, got_residual = capture.call_args.args
+    assert layer_idx == 0
+    assert got_prefix is prefix_sum
+    assert got_pending is layer_hidden_states
+    assert got_residual is block_residual
+    torch.testing.assert_close(aux_hidden_states[0], captured)
+
+
 def test_kimi_attn_res_workspace_is_reused_and_sliced():
     model = _make_kimi_linear_model()
     object.__setattr__(model, "num_attn_res_blocks", 3)

--- a/tests/models/kimi_k3/test_eagle3.py
+++ b/tests/models/kimi_k3/test_eagle3.py
@@ -193,6 +193,82 @@ def test_kimi_linear_forward_streams_auxiliary_states(monkeypatch):
     assert aux_hidden_states[0] is projected
 
 
+def test_kimi_linear_forward_streams_attn_res_mixtures(monkeypatch):
+    """A streaming consumer receives the same pre-norm mixture as fallback."""
+    model = _make_kimi_linear_model()
+    initial_hidden_states = torch.tensor([[1.0, 2.0]])
+    layer_hidden_states = torch.tensor([[3.0, 4.0]])
+    prefix_sum = torch.tensor([[5.0, 6.0]])
+    block_residual = torch.tensor([[[7.0, 8.0]]])
+    captured = torch.tensor([[11.0, 12.0]])
+    projected = torch.tensor([[13.0, 14.0]])
+
+    class Projector:
+        def __init__(self):
+            self.calls = []
+
+        def can_stream_auxiliary_states(self, layer_ids, hidden_states):
+            return layer_ids == (1,) and hidden_states is initial_hidden_states
+
+        def begin_auxiliary_stream(self, hidden_states):
+            assert hidden_states is initial_hidden_states
+
+        def accumulate_auxiliary_state(self, primary, residual):
+            self.calls.append((primary, residual))
+
+        def finish_auxiliary_stream(self):
+            return projected
+
+    projector = Projector()
+    model.set_aux_hidden_state_projector(projector)
+    object.__setattr__(model, "start_layer", 0)
+    object.__setattr__(model, "end_layer", 1)
+    object.__setattr__(
+        model,
+        "layers",
+        [Mock(return_value=(layer_hidden_states, prefix_sum, block_residual))],
+    )
+    object.__setattr__(model, "aux_hidden_state_layers", (1,))
+    object.__setattr__(model, "use_attn_res", True)
+    object.__setattr__(model, "num_attn_res_blocks", 1)
+    object.__setattr__(
+        model,
+        "output_attn_res_norm",
+        SimpleNamespace(weight=torch.ones(2), variance_epsilon=1e-5),
+    )
+    object.__setattr__(
+        model,
+        "output_attn_res_proj",
+        SimpleNamespace(weight=torch.ones(1, 2)),
+    )
+    monkeypatch.setattr(
+        kimi_model,
+        "get_pp_group",
+        lambda: SimpleNamespace(is_first_rank=True, is_last_rank=True),
+    )
+    monkeypatch.setattr(kimi_model, "attn_res", Mock(return_value=torch.zeros(1, 2)))
+    monkeypatch.setenv("VLLM_KIMI_K3_AUX_ATTN_RES_STREAM", "1")
+    capture = Mock(return_value=captured)
+    monkeypatch.setattr(KimiLinearModel, "_capture_aux_hidden_stream", capture)
+
+    _, aux_hidden_states = model.forward(
+        input_ids=None,
+        positions=torch.tensor([0]),
+        intermediate_tensors=None,
+        inputs_embeds=initial_hidden_states,
+    )
+
+    capture.assert_called_once_with(
+        0,
+        prefix_sum,
+        layer_hidden_states,
+        block_residual,
+    )
+    assert projector.calls == [(captured, None)]
+    assert len(aux_hidden_states) == 1
+    assert aux_hidden_states[0] is projected
+
+
 def test_attn_res_stream_capture_receives_layer_outputs_in_order(monkeypatch):
     """Verify the positional contract between ``forward`` and the capture tap."""
     model = _make_kimi_linear_model()

--- a/tests/models/test_qwen3_dflash_streaming.py
+++ b/tests/models/test_qwen3_dflash_streaming.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import torch
+from torch import nn
+
+from vllm.model_executor.models.qwen3_dflash import DFlashQwen3Model
+
+
+class _Accumulator:
+    input_width = 8
+    max_tokens = 2048
+
+    def __init__(self, output: torch.Tensor):
+        self.output = output
+        self.tokens = 0
+        self.inputs: list[torch.Tensor] = []
+
+    def begin(self, tokens: int) -> None:
+        self.tokens = tokens
+        self.inputs.clear()
+
+    def append(self, source: torch.Tensor) -> None:
+        self.inputs.append(source.clone())
+
+    def finish(self) -> torch.Tensor:
+        self.output[: self.tokens].fill_(7)
+        return self.output[: self.tokens]
+
+
+def test_dflash_streams_auxiliary_states_and_claims_result_once() -> None:
+    model = object.__new__(DFlashQwen3Model)
+    nn.Module.__init__(model)
+    model.config = SimpleNamespace(hidden_size=4)
+    model.use_aux_hidden_state = True
+    model._target_hidden_size = 4
+    model._streamed_aux_layer_ids = (2, 4)
+    model._streamed_aux_tokens = 0
+    model._streamed_aux_index = 0
+    model._streamed_aux_generation = 0
+    model._completed_stream_generation = 0
+    model._consumed_stream_generation = 0
+    model._completed_stream_result = None
+    scratch = torch.empty(2048, 4)
+    accumulator = _Accumulator(scratch)
+    model.bind_auxiliary_stream(accumulator, scratch)
+
+    first = torch.ones(1024, 4)
+    second = torch.full((1024, 4), 2.0)
+    residual = torch.full((1024, 4), 3.0)
+    assert model.can_stream_auxiliary_states((2, 4), first)
+
+    model.begin_auxiliary_stream(first)
+    model.accumulate_auxiliary_state(first, None)
+    model.accumulate_auxiliary_state(second, residual)
+    result = model.finish_auxiliary_stream()
+
+    torch.testing.assert_close(accumulator.inputs[0], first)
+    torch.testing.assert_close(accumulator.inputs[1], second + residual)
+    assert model.is_streamed_context_states([result])
+    assert not model.is_streamed_context_states([result])

--- a/tests/models/test_qwen3_dflash_streaming.py
+++ b/tests/models/test_qwen3_dflash_streaming.py
@@ -3,6 +3,7 @@
 
 from types import SimpleNamespace
 
+import pytest
 import torch
 from torch import nn
 
@@ -61,3 +62,45 @@ def test_dflash_streams_auxiliary_states_and_claims_result_once() -> None:
     torch.testing.assert_close(accumulator.inputs[1], second + residual)
     assert model.is_streamed_context_states([result])
     assert not model.is_streamed_context_states([result])
+
+
+def test_dflash_narrows_output_scratch_for_target_residual_staging() -> None:
+    """A narrower target state may reuse the draft output buffer safely."""
+    model = object.__new__(DFlashQwen3Model)
+    nn.Module.__init__(model)
+    model.config = SimpleNamespace(hidden_size=6)
+    model.use_aux_hidden_state = True
+    model._target_hidden_size = 4
+    model._streamed_aux_layer_ids = (2, 4)
+    model._streamed_aux_tokens = 0
+    model._streamed_aux_index = 0
+    model._streamed_aux_generation = 0
+    model._completed_stream_generation = 0
+    model._consumed_stream_generation = 0
+    model._completed_stream_result = None
+    scratch = torch.empty(2048, 6)
+    accumulator = _Accumulator(scratch)
+    model.bind_auxiliary_stream(accumulator, scratch)
+
+    primary = torch.full((1024, 4), 2.0)
+    residual = torch.full((1024, 4), 3.0)
+    model.begin_auxiliary_stream(primary)
+    model.accumulate_auxiliary_state(primary, residual)
+
+    assert len(accumulator.inputs) == 1
+    torch.testing.assert_close(
+        accumulator.inputs[0],
+        torch.full((1024, 4), 5.0),
+    )
+
+
+def test_dflash_rejects_output_scratch_narrower_than_target_state() -> None:
+    """Streaming must fall back when target residuals cannot fit the scratch."""
+    model = object.__new__(DFlashQwen3Model)
+    nn.Module.__init__(model)
+    model.config = SimpleNamespace(hidden_size=4)
+    model._target_hidden_size = 6
+    scratch = torch.empty(2048, 4)
+
+    with pytest.raises(ValueError, match="at least 6 wide"):
+        model.bind_auxiliary_stream(_Accumulator(scratch), scratch)

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -247,6 +247,7 @@ if TYPE_CHECKING:
     VLLM_USE_FUSED_MOE_GROUPED_TOPK: bool = True
     VLLM_MOE_SKIP_PADDING: bool = True
     VLLM_KIMI_K3_SHARD_SP_SHARED_EXPERT: bool = False
+    VLLM_KIMI_K3_AUX_ATTN_RES_STREAM: bool = False
     VLLM_BLOCKSCALE_FP8_GEMM_FLASHINFER: bool = True
     VLLM_USE_FLASHINFER_MOE_INT4: bool = False
     VLLM_FLASHINFER_AUTOTUNE_CACHE_DIR: str | None = None
@@ -1843,6 +1844,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # serving.
     "VLLM_KIMI_K3_SHARD_SP_SHARED_EXPERT": lambda: bool(
         int(os.getenv("VLLM_KIMI_K3_SHARD_SP_SHARED_EXPERT", "0"))
+    ),
+    # Kimi K3 only, and unrelated to the MoE flags above. Tap the pre-norm
+    # AttnRes mixture, rather than the post-mixture sum, as the auxiliary
+    # hidden state handed to a DFlash drafter. This changes the numerics the
+    # speculator sees, so it is off by default while the effect is measured.
+    "VLLM_KIMI_K3_AUX_ATTN_RES_STREAM": lambda: bool(
+        int(os.getenv("VLLM_KIMI_K3_AUX_ATTN_RES_STREAM", "0"))
     ),
     # Allow use of FlashInfer FP8 block-scale GEMM for linear layers.
     # This uses TensorRT-LLM kernels and requires SM90+ (Hopper).

--- a/vllm/model_executor/kernels/linear/mxfp8/b12x.py
+++ b/vllm/model_executor/kernels/linear/mxfp8/b12x.py
@@ -39,6 +39,111 @@ _B12X_MXFP8: Any | None = None
 _B12X_MXFP8_MISSING = False
 
 
+class B12xMxfp8InputAccumulator:
+    """Incrementally assemble one retained MXFP8 linear input.
+
+    Each appended BF16/FP16 tensor occupies a disjoint feature slice. The
+    completed input is consumed by the layer's original packed weight and dense
+    GEMM, so feature-slice lifetime changes without changing GEMM accumulation.
+    """
+
+    def __init__(
+        self,
+        layer: torch.nn.Module,
+        output: torch.Tensor,
+    ) -> None:
+        packed_weight = getattr(layer, "b12x_mxfp8_packed_weight", None)
+        if packed_weight is None:
+            raise ValueError("layer does not have a B12X MXFP8 packed weight")
+        mxfp8 = _import_b12x_mxfp8()
+        if mxfp8 is None:
+            raise ImportError("b12x.gemm.mxfp8_linear is not importable")
+        for name in ("empty_input", "mm_quantized", "quantize_input_slice"):
+            if not callable(getattr(mxfp8, name, None)):
+                raise ImportError(f"b12x.gemm.mxfp8_linear missing callable {name}")
+        if output.ndim != 2:
+            raise ValueError(
+                f"output must have shape [max_tokens,N], got {tuple(output.shape)}"
+            )
+        if int(output.shape[1]) != int(packed_weight.out_features):
+            raise ValueError(
+                "output width does not match packed weight: "
+                f"output={output.shape[1]}, weight={packed_weight.out_features}"
+            )
+        if int(packed_weight.in_features) != int(packed_weight.padded_in_features):
+            raise ValueError(
+                "incremental MXFP8 input requires a weight whose input width "
+                "does not need K padding"
+            )
+
+        self._mxfp8 = mxfp8
+        self._packed_weight = packed_weight
+        self._output = output
+        self._input = mxfp8.empty_input(
+            int(output.shape[0]),
+            int(packed_weight.in_features),
+            device=output.device,
+        )
+        self._tokens = 0
+        self._next_column = 0
+
+    @property
+    def input_width(self) -> int:
+        return int(self._packed_weight.in_features)
+
+    @property
+    def max_tokens(self) -> int:
+        return int(self._output.shape[0])
+
+    def begin(self, tokens: int) -> None:
+        tokens = int(tokens)
+        if tokens <= 0 or tokens > self.max_tokens:
+            raise ValueError(f"tokens must be in [1,{self.max_tokens}], got {tokens}")
+        self._tokens = tokens
+        self._next_column = 0
+
+    def append(self, source: torch.Tensor) -> None:
+        if self._tokens <= 0:
+            raise RuntimeError("incremental MXFP8 input has not been started")
+        source_2d = source.reshape(-1, source.shape[-1]).contiguous()
+        if int(source_2d.shape[0]) != self._tokens:
+            raise ValueError(
+                "source row count changed during incremental quantization: "
+                f"source={source_2d.shape[0]}, expected={self._tokens}"
+            )
+        width = int(source_2d.shape[1])
+        if self._next_column + width > self.input_width:
+            raise ValueError(
+                "source slices exceed the packed linear input width: "
+                f"next_column={self._next_column}, width={width}, "
+                f"input_width={self.input_width}"
+            )
+        self._mxfp8.quantize_input_slice(
+            source_2d,
+            self._input,
+            destination_column=self._next_column,
+        )
+        self._next_column += width
+
+    def finish(self) -> torch.Tensor:
+        if self._next_column != self.input_width:
+            raise RuntimeError(
+                "incremental MXFP8 input is incomplete: "
+                f"filled={self._next_column}, required={self.input_width}"
+            )
+        output = self._mxfp8.mm_quantized(
+            self._input,
+            self._packed_weight,
+            tokens=self._tokens,
+            out=self._output,
+            expected_m=self._tokens,
+            stream=current_stream().cuda_stream,
+        )
+        self._tokens = 0
+        self._next_column = 0
+        return output
+
+
 def _import_b12x_mxfp8() -> Any | None:
     global _B12X_MXFP8, _B12X_MXFP8_MISSING
     if _B12X_MXFP8 is not None:

--- a/vllm/model_executor/kernels/linear/mxfp8/b12x.py
+++ b/vllm/model_executor/kernels/linear/mxfp8/b12x.py
@@ -58,7 +58,7 @@ class B12xMxfp8InputAccumulator:
         mxfp8 = _import_b12x_mxfp8()
         if mxfp8 is None:
             raise ImportError("b12x.gemm.mxfp8_linear is not importable")
-        for name in ("empty_input", "mm_quantized", "quantize_input_slice"):
+        for name in ("empty_input", "mm_quantized_into", "quantize_input_slice"):
             if not callable(getattr(mxfp8, name, None)):
                 raise ImportError(f"b12x.gemm.mxfp8_linear missing callable {name}")
         if output.ndim != 2:
@@ -131,7 +131,7 @@ class B12xMxfp8InputAccumulator:
                 "incremental MXFP8 input is incomplete: "
                 f"filled={self._next_column}, required={self.input_width}"
             )
-        output = self._mxfp8.mm_quantized(
+        output = self._mxfp8.mm_quantized_into(
             self._input,
             self._packed_weight,
             tokens=self._tokens,

--- a/vllm/model_executor/models/qwen3_dflash.py
+++ b/vllm/model_executor/models/qwen3_dflash.py
@@ -4,6 +4,7 @@
 import dataclasses
 import io
 from collections.abc import Iterable, Mapping
+from typing import Any
 
 import torch
 import torch.nn.functional as F
@@ -60,6 +61,7 @@ logger = init_logger(__name__)
 
 
 _SLIDING_ATTENTION = "sliding_attention"
+_STREAMED_AUX_MIN_TOKENS = 1024
 
 
 def _retain_dflash_weight(weight: torch.Tensor) -> torch.Tensor:
@@ -483,6 +485,20 @@ class DFlashQwen3Model(nn.Module):
                 prefix=maybe_prefix(prefix, "fc"),
                 return_bias=False,
             )
+        self._streamed_aux_layer_ids = tuple(
+            get_eagle3_aux_layers_from_config(vllm_config.speculative_config) or ()
+        )
+        self._target_hidden_size = int(
+            getattr(self.config, "target_hidden_size", None) or self.config.hidden_size
+        )
+        self._streamed_aux_accumulator: Any | None = None
+        self._streamed_aux_scratch: torch.Tensor | None = None
+        self._streamed_aux_tokens = 0
+        self._streamed_aux_index = 0
+        self._streamed_aux_generation = 0
+        self._completed_stream_generation = 0
+        self._consumed_stream_generation = 0
+        self._completed_stream_result: torch.Tensor | None = None
         self.hidden_norm = RMSNorm(
             self.config.hidden_size,
             eps=self.config.rms_norm_eps,
@@ -499,6 +515,118 @@ class DFlashQwen3Model(nn.Module):
             is_mask = (input_ids == self.mask_token_id).unsqueeze(-1)
             embeds = torch.where(is_mask, self.mask_embedding.to(embeds.dtype), embeds)
         return embeds
+
+    def bind_auxiliary_stream(
+        self,
+        accumulator: Any,
+        scratch: torch.Tensor,
+    ) -> None:
+        """Bind retained storage for large target auxiliary-state projections."""
+        if scratch.ndim != 2 or int(scratch.shape[1]) != int(self.config.hidden_size):
+            raise ValueError(
+                "DFlash auxiliary output scratch must have shape "
+                f"[max_tokens,{self.config.hidden_size}], got {tuple(scratch.shape)}"
+            )
+        self._streamed_aux_accumulator = accumulator
+        self._streamed_aux_scratch = scratch
+
+    def can_stream_auxiliary_states(
+        self,
+        layer_ids: tuple[int, ...],
+        hidden_states: torch.Tensor,
+    ) -> bool:
+        """Return whether a target forward can release auxiliary states early."""
+        accumulator = self._streamed_aux_accumulator
+        scratch = self._streamed_aux_scratch
+        if accumulator is None or scratch is None or not self.use_aux_hidden_state:
+            return False
+        if hidden_states.ndim != 2 or hidden_states.shape[0] < _STREAMED_AUX_MIN_TOKENS:
+            return False
+        if tuple(layer_ids) != self._streamed_aux_layer_ids:
+            return False
+        if hidden_states.shape[1] * len(layer_ids) != accumulator.input_width:
+            return False
+        if hidden_states.shape[0] > accumulator.max_tokens:
+            return False
+        if (
+            hidden_states.dtype != scratch.dtype
+            or hidden_states.device != scratch.device
+        ):
+            return False
+        return not (hidden_states.is_cuda and torch.cuda.is_current_stream_capturing())
+
+    def begin_auxiliary_stream(self, hidden_states: torch.Tensor) -> None:
+        """Start one ordered sequence of target auxiliary-state slices."""
+        if not self.can_stream_auxiliary_states(
+            self._streamed_aux_layer_ids, hidden_states
+        ):
+            raise RuntimeError(
+                "DFlash auxiliary streaming was started for an unsupported geometry"
+            )
+        self._streamed_aux_tokens = int(hidden_states.shape[0])
+        self._streamed_aux_index = 0
+        self._streamed_aux_generation += 1
+        self._completed_stream_result = None
+        self._streamed_aux_accumulator.begin(self._streamed_aux_tokens)
+
+    def accumulate_auxiliary_state(
+        self,
+        primary: torch.Tensor,
+        residual: torch.Tensor | None,
+    ) -> None:
+        """Quantize one complete target state into the retained linear input."""
+        if self._streamed_aux_index >= len(self._streamed_aux_layer_ids):
+            raise RuntimeError("DFlash received too many auxiliary states")
+        expected_shape = (self._streamed_aux_tokens, self._target_hidden_size)
+        if tuple(primary.shape) != expected_shape:
+            raise ValueError(
+                "DFlash auxiliary state shape changed during streaming: "
+                f"got={tuple(primary.shape)}, expected={expected_shape}"
+            )
+        source = primary
+        if residual is not None:
+            if tuple(residual.shape) != expected_shape:
+                raise ValueError(
+                    "DFlash auxiliary residual shape changed during streaming: "
+                    f"got={tuple(residual.shape)}, expected={expected_shape}"
+                )
+            assert self._streamed_aux_scratch is not None
+            source = self._streamed_aux_scratch[: self._streamed_aux_tokens]
+            torch.add(primary, residual, out=source)
+        self._streamed_aux_accumulator.append(source)
+        self._streamed_aux_index += 1
+
+    def finish_auxiliary_stream(self) -> torch.Tensor:
+        """Project the assembled MXFP8 input with the draft's original FC."""
+        expected = len(self._streamed_aux_layer_ids)
+        if self._streamed_aux_index != expected:
+            raise RuntimeError(
+                "DFlash auxiliary stream ended before every configured state "
+                f"was received: received={self._streamed_aux_index}, "
+                f"expected={expected}"
+            )
+        output = self._streamed_aux_accumulator.finish()
+        self._completed_stream_generation = self._streamed_aux_generation
+        self._completed_stream_result = output
+        return output
+
+    def is_streamed_context_states(self, states: list[torch.Tensor]) -> bool:
+        """Claim one completed streamed projection exactly once."""
+        if len(states) != 1 or self._completed_stream_result is None:
+            return False
+        candidate = states[0]
+        expected = self._completed_stream_result
+        matches = (
+            self._completed_stream_generation > self._consumed_stream_generation
+            and candidate is expected
+            and candidate.shape == expected.shape
+            and candidate.dtype == expected.dtype
+            and candidate.device == expected.device
+            and candidate.data_ptr() == expected.data_ptr()
+        )
+        if matches:
+            self._consumed_stream_generation = self._completed_stream_generation
+        return matches
 
     def _build_context_kv_buffers(
         self,
@@ -853,6 +981,52 @@ class DFlashQwen3ForCausalLM(Qwen3ForCausalLM):
         if needs_squeeze:
             result = result.squeeze(0)
         return result
+
+    def bind_target_auxiliary_stream(
+        self,
+        target_model: nn.Module,
+        scratch: torch.Tensor,
+    ) -> None:
+        """Connect a Kimi target to the memory-bounded MXFP8 FC input."""
+        get_language_model = getattr(target_model, "get_language_model", None)
+        target_language_model = (
+            get_language_model() if callable(get_language_model) else target_model
+        )
+        target_inner = getattr(target_language_model, "model", None)
+        setter = getattr(target_inner, "set_aux_hidden_state_projector", None)
+        if not callable(setter):
+            logger.warning_once(
+                "DFlash auxiliary streaming is disabled because the target "
+                "model does not expose an auxiliary-state projector hook."
+            )
+            return
+        if not self.model.use_aux_hidden_state:
+            return
+        try:
+            from vllm.model_executor.kernels.linear.mxfp8.b12x import (
+                B12xMxfp8InputAccumulator,
+            )
+
+            accumulator = B12xMxfp8InputAccumulator(self.model.fc, scratch)
+        except (ImportError, ValueError) as error:
+            logger.warning_once(
+                "DFlash auxiliary streaming is disabled: %s",
+                error,
+            )
+            return
+        self.model.bind_auxiliary_stream(accumulator, scratch)
+        setter(self.model)
+        logger.info_once(
+            "DFlash auxiliary projection uses staged B12X MXFP8 input: "
+            "max_tokens=%d input_width=%d output_width=%d.",
+            accumulator.max_tokens,
+            accumulator.input_width,
+            int(scratch.shape[1]),
+        )
+
+    def is_streamed_context_states(self, states: list[torch.Tensor]) -> bool:
+        """Return whether target auxiliary states are already FC-projected."""
+        return self.model.is_streamed_context_states(states)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
         model_weights = {}

--- a/vllm/model_executor/models/qwen3_dflash.py
+++ b/vllm/model_executor/models/qwen3_dflash.py
@@ -527,6 +527,12 @@ class DFlashQwen3Model(nn.Module):
                 "DFlash auxiliary output scratch must have shape "
                 f"[max_tokens,{self.config.hidden_size}], got {tuple(scratch.shape)}"
             )
+        if int(scratch.shape[1]) < self._target_hidden_size:
+            raise ValueError(
+                "DFlash auxiliary output scratch also stages target residual "
+                f"sums and must be at least {self._target_hidden_size} wide, "
+                f"got {scratch.shape[1]}"
+            )
         self._streamed_aux_accumulator = accumulator
         self._streamed_aux_scratch = scratch
 
@@ -591,7 +597,9 @@ class DFlashQwen3Model(nn.Module):
                     f"got={tuple(residual.shape)}, expected={expected_shape}"
                 )
             assert self._streamed_aux_scratch is not None
-            source = self._streamed_aux_scratch[: self._streamed_aux_tokens]
+            source = self._streamed_aux_scratch[
+                : self._streamed_aux_tokens, : self._target_hidden_size
+            ]
             torch.add(primary, residual, out=source)
         self._streamed_aux_accumulator.append(source)
         self._streamed_aux_index += 1

--- a/vllm/model_executor/models/qwen3_dflash.py
+++ b/vllm/model_executor/models/qwen3_dflash.py
@@ -574,6 +574,13 @@ class DFlashQwen3Model(nn.Module):
         self._streamed_aux_generation += 1
         self._completed_stream_result = None
         self._streamed_aux_accumulator.begin(self._streamed_aux_tokens)
+        logger.info_once(
+            "DFlash staged auxiliary projection is active: "
+            "tokens=%d target_width=%d slices=%d.",
+            self._streamed_aux_tokens,
+            self._target_hidden_size,
+            len(self._streamed_aux_layer_ids),
+        )
 
     def accumulate_auxiliary_state(
         self,

--- a/vllm/models/kimi_k3/nvidia/model.py
+++ b/vllm/models/kimi_k3/nvidia/model.py
@@ -1931,6 +1931,15 @@ class KimiLinearModel(nn.Module, EagleModelMixin, SupportsQuant):
         ``delta`` is deliberate: the kernel writes an applied delta back into
         the prefix in place, which would double-add it into the live residual
         stream.
+
+        Args:
+            layer_idx: Index of the layer that produced the pending MLP output.
+            prefix_sum: Running prefix for the active AttnRes block.
+            pending_mlp_out: MLP output to fold into the running prefix, if any.
+            block_residual: Committed AttnRes block bank for the active rows.
+
+        Returns:
+            Auxiliary hidden states for the configured DFlash capture mode.
         """
         prefix = prefix_sum if pending_mlp_out is None else prefix_sum + pending_mlp_out
         # `use_attn_res` is what constructs the norm and projection weights this

--- a/vllm/models/kimi_k3/nvidia/model.py
+++ b/vllm/models/kimi_k3/nvidia/model.py
@@ -2092,12 +2092,14 @@ class KimiLinearModel(nn.Module, EagleModelMixin, SupportsQuant):
             )
         )
         if stream_aux_hidden_states:
+            assert projector is not None
             projector.begin_auxiliary_stream(hidden_states)
 
         # Auxiliary states remain sequence-parallel shards until the final gather.
         aux_hidden_states: list[torch.Tensor] = []
         if self.start_layer in self.aux_hidden_state_layers:
             if stream_aux_hidden_states:
+                assert projector is not None
                 projector.accumulate_auxiliary_state(
                     hidden_states,
                     None if self.use_attn_res else residual,
@@ -2138,9 +2140,18 @@ class KimiLinearModel(nn.Module, EagleModelMixin, SupportsQuant):
             )
             if (layer_idx + 1) in self.aux_hidden_state_layers:
                 if stream_aux_hidden_states and self.use_attn_res:
+                    assert projector is not None
                     assert prefix_sum is not None
-                    projector.accumulate_auxiliary_state(prefix_sum, hidden_states)
+                    assert residual is not None
+                    auxiliary_state = self._capture_aux_hidden_stream(
+                        layer_idx,
+                        prefix_sum,
+                        hidden_states,
+                        residual,
+                    )
+                    projector.accumulate_auxiliary_state(auxiliary_state, None)
                 elif stream_aux_hidden_states:
+                    assert projector is not None
                     assert residual is not None
                     projector.accumulate_auxiliary_state(hidden_states, residual)
                 elif self.use_attn_res:
@@ -2186,6 +2197,7 @@ class KimiLinearModel(nn.Module, EagleModelMixin, SupportsQuant):
             hidden_states = hidden_states + residual
 
         if stream_aux_hidden_states:
+            assert projector is not None
             aux_hidden_states.append(projector.finish_auxiliary_stream())
 
         if self.use_sequence_parallel:

--- a/vllm/models/kimi_k3/nvidia/model.py
+++ b/vllm/models/kimi_k3/nvidia/model.py
@@ -1891,6 +1891,85 @@ class KimiLinearModel(nn.Module, EagleModelMixin, SupportsQuant):
             }
         )
 
+    def _set_aux_hidden_state_layers(self, layers: tuple[int, ...]) -> None:
+        super()._set_aux_hidden_state_layers(layers)
+        if self.use_attn_res:
+            # Emitted once, at configuration time. Which layers are tapped and
+            # which convention is in force are the two things you need to
+            # confirm from a running process, and neither is recoverable from
+            # the served output.
+            logger.info_once(
+                "Kimi-K3 aux hidden capture: layers=%s mode=%s "
+                "(VLLM_KIMI_K3_AUX_ATTN_RES_STREAM=%d)",
+                layers,
+                "attn_res_stream" if self._aux_attn_res_stream else "prefix_only",
+                int(self._aux_attn_res_stream),
+            )
+
+    @property
+    def _aux_attn_res_stream(self) -> bool:
+        return envs.VLLM_KIMI_K3_AUX_ATTN_RES_STREAM
+
+    def _capture_aux_hidden_stream(
+        self,
+        layer_idx: int,
+        prefix_sum: torch.Tensor,
+        pending_mlp_out: torch.Tensor | None,
+        block_residual: torch.Tensor,
+    ) -> torch.Tensor:
+        """Auxiliary feature tapped after ``layer_idx`` under AttnRes.
+
+        The wire between layers only carries the current block's running prefix;
+        the committed blocks live in the bank. The value the next consumer
+        actually reads is the pre-norm AttnRes mixture over
+        ``bank[:num_blocks] + prefix``, which is what the DFlash drafters were
+        trained against. ``attn_res`` with no delta, no block write and no
+        output norm computes exactly that and leaves both the prefix and the
+        bank untouched.
+
+        Folding the pending MLP output into the prefix rather than passing it as
+        ``delta`` is deliberate: the kernel writes an applied delta back into
+        the prefix in place, which would double-add it into the live residual
+        stream.
+        """
+        prefix = prefix_sum if pending_mlp_out is None else prefix_sum + pending_mlp_out
+        # `use_attn_res` is what constructs the norm and projection weights this
+        # reads; without it there is no mixture to compute and the attribute
+        # lookups below would raise.
+        if not (self._aux_attn_res_stream and self.use_attn_res):
+            return prefix
+
+        if layer_idx + 1 < self.end_layer:
+            consumer = self.layers[layer_idx + 1]
+            score_norm = consumer.self_attention_res_norm
+            score_proj = consumer.self_attention_res_proj
+            num_blocks = consumer.prev_valid_blocks
+        elif get_pp_group().is_last_rank:
+            # Nothing downstream but the model's own output-side aggregation.
+            score_norm = self.output_attn_res_norm
+            score_proj = self.output_attn_res_proj
+            num_blocks = self.num_attn_res_blocks
+        else:
+            # Last layer of a non-final pipeline stage: the consumer lives on
+            # the next rank and the output-side aggregation only exists on the
+            # last one, so there is nothing here to mix against. Falling back
+            # to the running prefix keeps the tap defined rather than reaching
+            # for weights this rank does not construct.
+            return prefix
+
+        return attn_res(
+            prefix,
+            None,
+            block_residual,
+            score_norm.weight,
+            score_proj.weight.squeeze(0),
+            None,
+            num_blocks=num_blocks,
+            block_write_idx=-1,
+            eps=score_norm.variance_epsilon,
+            output_norm_eps=0.0,
+        )
+
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.embed_tokens(input_ids)
 
@@ -1993,6 +2072,9 @@ class KimiLinearModel(nn.Module, EagleModelMixin, SupportsQuant):
         pp_group = get_pp_group()
         stream_aux_hidden_states = bool(
             projector is not None
+            # The streaming projector consumes plain residual sums. DFlash
+            # AttnRes capture requires the pre-norm mixture computed below.
+            and not self._aux_attn_res_stream
             and not self.use_sequence_parallel
             and pp_group.is_first_rank
             and pp_group.is_last_rank
@@ -2054,7 +2136,10 @@ class KimiLinearModel(nn.Module, EagleModelMixin, SupportsQuant):
                     projector.accumulate_auxiliary_state(hidden_states, residual)
                 elif self.use_attn_res:
                     assert prefix_sum is not None
-                    aux_hidden_state = prefix_sum + hidden_states
+                    assert residual is not None
+                    aux_hidden_state = self._capture_aux_hidden_stream(
+                        layer_idx, prefix_sum, hidden_states, residual
+                    )
                     aux_hidden_states.append(aux_hidden_state)
                 else:
                     assert residual is not None

--- a/vllm/models/kimi_k3/nvidia/model.py
+++ b/vllm/models/kimi_k3/nvidia/model.py
@@ -2081,9 +2081,6 @@ class KimiLinearModel(nn.Module, EagleModelMixin, SupportsQuant):
         pp_group = get_pp_group()
         stream_aux_hidden_states = bool(
             projector is not None
-            # The streaming projector consumes plain residual sums. DFlash
-            # AttnRes capture requires the pre-norm mixture computed below.
-            and not self._aux_attn_res_stream
             and not self.use_sequence_parallel
             and pp_group.is_first_rank
             and pp_group.is_last_rank

--- a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
@@ -367,6 +367,9 @@ class DFlashSpeculator(DraftModelSpeculator):
         target_attn_layer_names: set[str],
     ) -> nn.Module:
         model = load_dflash_model(target_model, self.vllm_config)
+        bind_auxiliary_stream = getattr(model, "bind_target_auxiliary_stream", None)
+        if callable(bind_auxiliary_stream):
+            bind_auxiliary_stream(target_model, self.hidden_states)
         maybe_load_mask_embedding(
             model,
             self.draft_model_config.model,


### PR DESCRIPTION
## Purpose

Kimi-K3 DFlash consumes six target-model auxiliary states with width 7,168.
For a 4,096-token scheduler step, retaining and concatenating those BF16 states
creates a 336 MiB tensor before MXFP8 input quantization creates another 168
MiB tensor. The overlapping allocations prevent long-context DFlash serving
even when model weights and the physical KV cache fit.

## Dependencies

- [vLLM #460](https://github.com/local-inference-lab/vllm/pull/460)
  supplies the pre-normalization AttnRes mixture consumed by Kimi-K3 DFlash.
- [B12X #241](https://github.com/local-inference-lab/b12x/pull/241)
  supplies caller-owned staged MXFP8 input and output storage.

Merge vLLM #460 and B12X #241 before this pull request. This branch contains
the exact two commits from vLLM #460 so the combined runtime can be tested;
GitHub removes those commits from the diff after #460 reaches
`dev/infernal-invocation`.

## Behavior

A compatible B12X MXFP8 draft projection consumes each target auxiliary state
as the target produces it. The state is quantized into retained MXFP8 input,
its BF16 storage is released, and the existing draft FC runs once after all
slices arrive. Output is written directly into the caller-owned draft buffer.
The operation preserves per-32-column MXFP8 groups and the original GEMM
accumulation order.

The staged path is restricted to large, non-captured target forwards using a
compatible B12X linear. Decode-sized forwards, unsupported linears, and other
DFlash models retain the list-and-concatenate path. Kimi-K3 AttnRes input uses
the same pre-normalization mixture in both paths.

## Validation

- Pre-commit hooks passed for every changed file, including Ruff, mypy, SPDX,
  forbidden-import, and configuration checks.
- Focused DFlash, Kimi-K3, and B12X accumulator tests: 15 passed, 1 skipped.
- B12X staged-input tests cover eager execution, CUDA Graph replay, and
  `torch.compile` full-graph execution.
- At `M=4096`, six `K=7168` slices, and `N=7168`, staged direct-output and
  concatenated projection outputs are bitwise equal. Peak allocation falls
  from 1,278,083,584 to 663,355,904 bytes, a 48.10% reduction.
- The TP16/DCP16 server logged
  `DFlash staged auxiliary projection is active: tokens=4096 target_width=7168 slices=6.`
  during a scheduler forward and completed a 524,288-token prompt plus 64
  generated tokens.
- Seven normalized DFlash runs measured 155.341 tok/s versus 147.987 tok/s for
  the same source composition with a temporary dense output, +4.969%.
- Target-only measured 55.807 tok/s and DSpark measured 122.706 tok/s with
  output hashes identical to their controls.

The qualified image is
`voipmonitor/vllm@sha256:e009bb404211c67164f1009bda97823f35578285b6779a7614ed1f97c1f8c338`.
Its embedded vLLM tree is
`e755f87b8e00d76e1aeacfa0835a2c7608925390`.

No open official-vLLM pull request implements bounded staged MXFP8 auxiliary
input. [vllm-project/vllm #50457](https://github.com/vllm-project/vllm/pull/50457)
changes DFlash prefix-cache geometry and does not change auxiliary-state
projection memory. The B12X adapter remains local; a backend-neutral auxiliary
state consumer is suitable for official vLLM when an official backend exposes
staged or prequantized input.

Reproduction commands and machine-readable receipts are in the
[Kimi-K3 runtime specification](https://github.com/local-inference-lab/rtx6kpro/blob/master/models/kimi-k3/production-runtime.md).

OpenAI Codex assisted with implementation and validation. The submitter
reviewed the resulting source and runtime evidence.
