### PR TITLE
fix(kimi_k3): load dense EXL3 DSpark drafts

### DIFF
--- a/tests/models/test_dspark_mla.py
+++ b/tests/models/test_dspark_mla.py
@@ -56,6 +56,13 @@ def test_dspark_mla_checkpoint_weight_mapping(checkpoint_name, runtime_name, sha
     ) == (runtime_name, shard_id)
 
 
+def test_dspark_mla_exposes_packed_quantization_mapping() -> None:
+    assert K3DSparkForCausalLM.packed_modules_mapping == {
+        "fused_qkv_a_proj": ["q_a_proj", "kv_a_proj_with_mqa"],
+        "gate_up_proj": ["gate_proj", "up_proj"],
+    }
+
+
 def test_dspark_mla_shares_frozen_target_weights_and_skips_training_head():
     assert not K3DSparkForCausalLM.has_own_embed_tokens
     assert not K3DSparkForCausalLM.has_own_lm_head
@@ -64,6 +71,50 @@ def test_dspark_mla_shares_frozen_target_weights_and_skips_training_head():
         "embed_tokens",
         "lm_head",
     }
+
+
+@pytest.mark.cpu_test
+def test_dspark_quant_config_aliases_runtime_layer_offset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    entries = {
+        "layers.0.mlp.down_proj": {"stored_tensors": {"down": {}}},
+        "model.layers.1.self_attn.q_b_proj": {"stored_tensors": {"q_b": {}}},
+        "context_proj": {"stored_tensors": {"context": {}}},
+    }
+    quant_config = SimpleNamespace(tensor_storage=entries)
+    vllm_config = SimpleNamespace(
+        quant_config=quant_config,
+        speculative_config=SimpleNamespace(
+            draft_model_config=SimpleNamespace(
+                hf_config=SimpleNamespace(num_hidden_layers=2)
+            )
+        ),
+    )
+
+    def fail_reparse(*args, **kwargs):
+        raise AssertionError("configured draft quantization must be reused")
+
+    monkeypatch.setattr(dspark_mla, "get_draft_quant_config", fail_reparse)
+
+    result = dspark_mla._prepare_dspark_quant_config(vllm_config, start_layer_id=5)
+
+    assert result is quant_config
+    assert entries["layers.5.mlp.down_proj"] is entries["layers.0.mlp.down_proj"]
+    assert (
+        entries["model.layers.6.self_attn.q_b_proj"]
+        is entries["model.layers.1.self_attn.q_b_proj"]
+    )
+    assert set(entries) == {
+        "layers.0.mlp.down_proj",
+        "model.layers.1.self_attn.q_b_proj",
+        "context_proj",
+        "layers.5.mlp.down_proj",
+        "model.layers.6.self_attn.q_b_proj",
+    }
+
+    dspark_mla._prepare_dspark_quant_config(vllm_config, start_layer_id=5)
+    assert len(entries) == 5
 
 
 @pytest.mark.cpu_test
@@ -167,6 +218,130 @@ def test_replicated_markov_w1_requires_sharded_head(
 
     with pytest.raises(ValueError, match="requires VLLM_DSPARK_SHARD_MARKOV_HEAD"):
         DSparkMarkovHead(128, 128, 8, prefix="markov_head")
+
+
+@pytest.mark.cpu_test
+def test_k3_dspark_model_reuses_prepared_quant_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    quant_config = object()
+    projection_configs = []
+    decoder_configs = []
+
+    class DummyModule(nn.Module):
+        def __init__(self, *args, **kwargs):
+            super().__init__()
+            self.weight = nn.Parameter(torch.empty(0))
+
+    def make_projection(*args, **kwargs):
+        projection_configs.append(kwargs.get("quant_config"))
+        return DummyModule()
+
+    def make_decoder(*args, **kwargs):
+        decoder_configs.append(kwargs.get("quant_config"))
+        return DummyModule()
+
+    monkeypatch.setattr(
+        dspark_mla,
+        "_prepare_dspark_quant_config",
+        lambda vllm_config, start_layer_id: quant_config,
+    )
+    monkeypatch.setattr(
+        dspark_mla,
+        "get_draft_quant_config",
+        lambda _: (_ for _ in ()).throw(
+            AssertionError("decoder must reuse prepared quantization")
+        ),
+    )
+    monkeypatch.setattr(dspark_mla, "ColumnParallelLinear", make_projection)
+    monkeypatch.setattr(dspark_mla, "ReplicatedLinear", make_projection)
+    monkeypatch.setattr(dspark_mla, "MergedColumnParallelLinear", make_projection)
+    monkeypatch.setattr(dspark_mla, "RMSNorm", DummyModule)
+    monkeypatch.setattr(dspark_mla, "K3DSparkDecoderLayer", make_decoder)
+    monkeypatch.setattr(dspark_mla, "DSparkMarkovHead", DummyModule)
+
+    config = SimpleNamespace(
+        target_hidden_size=16,
+        num_target_layers=2,
+        hidden_size=8,
+        kv_lora_rank=3,
+        qk_rope_head_dim=1,
+        rms_norm_eps=1e-6,
+        num_hidden_layers=1,
+        vocab_size=128,
+        draft_vocab_size=128,
+        markov_rank=4,
+    )
+    vllm_config = SimpleNamespace(
+        speculative_config=SimpleNamespace(
+            draft_model_config=SimpleNamespace(hf_config=config)
+        ),
+        scheduler_config=SimpleNamespace(max_num_batched_tokens=16),
+        parallel_config=SimpleNamespace(tensor_parallel_size=1),
+    )
+
+    K3DSparkModel(vllm_config=vllm_config, start_layer_id=5, prefix="model")
+
+    assert decoder_configs == [quant_config]
+    assert projection_configs and all(
+        candidate is quant_config for candidate in projection_configs
+    )
+
+
+@pytest.mark.cpu_test
+def test_k3_dspark_quantized_context_projection_needs_no_dense_weight(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class QuantizedProjection(nn.Module):
+        def __init__(self, *args, **kwargs):
+            super().__init__()
+            self.register_parameter(
+                "trellis",
+                nn.Parameter(torch.empty(0, dtype=torch.int16), requires_grad=False),
+            )
+
+    class DummyModule(nn.Module):
+        def __init__(self, *args, **kwargs):
+            super().__init__()
+            self.weight = nn.Parameter(torch.empty(0))
+
+    monkeypatch.setattr(
+        dspark_mla,
+        "_prepare_dspark_quant_config",
+        lambda vllm_config, start_layer_id: object(),
+    )
+    monkeypatch.setattr(dspark_mla, "ReplicatedLinear", QuantizedProjection)
+    monkeypatch.setattr(dspark_mla, "MergedColumnParallelLinear", QuantizedProjection)
+    monkeypatch.setattr(dspark_mla, "RMSNorm", DummyModule)
+    monkeypatch.setattr(dspark_mla, "K3DSparkDecoderLayer", DummyModule)
+    monkeypatch.setattr(dspark_mla, "DSparkMarkovHead", DummyModule)
+
+    config = SimpleNamespace(
+        target_hidden_size=16,
+        num_target_layers=2,
+        hidden_size=8,
+        kv_lora_rank=3,
+        qk_rope_head_dim=1,
+        rms_norm_eps=1e-6,
+        num_hidden_layers=1,
+        vocab_size=128,
+        draft_vocab_size=128,
+        markov_rank=4,
+        target_layer_ids=(),
+    )
+    vllm_config = SimpleNamespace(
+        speculative_config=SimpleNamespace(
+            draft_model_config=SimpleNamespace(hf_config=config)
+        ),
+        scheduler_config=SimpleNamespace(max_num_batched_tokens=16),
+        parallel_config=SimpleNamespace(tensor_parallel_size=1),
+    )
+
+    model = K3DSparkModel(vllm_config=vllm_config, start_layer_id=5, prefix="model")
+
+    assert not hasattr(model.context_proj, "weight")
+    assert model._streamed_context_states.dtype == torch.get_default_dtype()
+    assert model._streamed_context_states.device == model.context_proj.trellis.device
 
 
 @pytest.mark.cpu_test

--- a/vllm/models/kimi_k3/nvidia/dspark_mla.py
+++ b/vllm/models/kimi_k3/nvidia/dspark_mla.py
@@ -26,6 +26,7 @@ from vllm.model_executor.layers.linear import (
     ReplicatedLinear,
 )
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     VocabParallelEmbedding,
 )
@@ -123,6 +124,39 @@ def _fill_compact_rope_cache(
     return cache
 
 
+def _prepare_dspark_quant_config(
+    vllm_config: VllmConfig,
+    start_layer_id: int,
+) -> QuantizationConfig | None:
+    quant_config = getattr(vllm_config, "quant_config", None)
+    if quant_config is None:
+        quant_config = get_draft_quant_config(vllm_config)
+    if quant_config is None:
+        return None
+
+    tensor_storage = getattr(quant_config, "tensor_storage", None)
+    if not isinstance(tensor_storage, dict) or start_layer_id == 0:
+        return quant_config
+
+    assert vllm_config.speculative_config is not None
+    num_layers = int(
+        vllm_config.speculative_config.draft_model_config.hf_config.num_hidden_layers
+    )
+    for prefix, entry in list(tensor_storage.items()):
+        parts = prefix.split(".")
+        try:
+            layers_index = parts.index("layers")
+            layer_index = int(parts[layers_index + 1])
+        except (ValueError, IndexError):
+            continue
+        if not 0 <= layer_index < num_layers:
+            continue
+        aliased = parts.copy()
+        aliased[layers_index + 1] = str(start_layer_id + layer_index)
+        tensor_storage.setdefault(".".join(aliased), entry)
+    return quant_config
+
+
 class K3DSparkDecoderLayer(nn.Module):
     def __init__(
         self,
@@ -132,9 +166,9 @@ class K3DSparkDecoderLayer(nn.Module):
         layer_idx: int,
         start_layer_id: int,
         prefix: str,
+        quant_config: QuantizationConfig | None,
     ) -> None:
         super().__init__()
-        quant_config = get_draft_quant_config(vllm_config)
         self.self_attn = MultiHeadLatentAttention(
             config=config,
             hidden_size=config.hidden_size,
@@ -209,7 +243,7 @@ class K3DSparkModel(nn.Module):
         super().__init__()
         assert vllm_config.speculative_config is not None
         self.config = vllm_config.speculative_config.draft_model_config.hf_config
-        self.quant_config = get_draft_quant_config(vllm_config)
+        self.quant_config = _prepare_dspark_quant_config(vllm_config, start_layer_id)
 
         # The frozen target embedding is aliased after the draft checkpoint loads.
         self.embed_tokens: nn.Module | None = None
@@ -259,6 +293,7 @@ class K3DSparkModel(nn.Module):
                     layer_idx=layer_idx,
                     start_layer_id=start_layer_id,
                     prefix=prefix,
+                    quant_config=self.quant_config,
                 )
                 for layer_idx in range(self.config.num_hidden_layers)
             ]
@@ -305,15 +340,17 @@ class K3DSparkModel(nn.Module):
         self._context_local_start = (
             int(getattr(self.context_proj, "tp_rank", 0)) * self._context_local_width
         )
-        context_proj_weight = self.context_proj.weight
+        context_proj_parameter = next(self.context_proj.parameters())
+        context_dtype = torch.get_default_dtype()
+        context_device = context_proj_parameter.device
         if self.context_proj_sharded:
             self.register_buffer(
                 "_streamed_context_states",
                 torch.empty(
                     self._max_num_context_tokens,
                     self._context_local_width,
-                    dtype=context_proj_weight.dtype,
-                    device=context_proj_weight.device,
+                    dtype=context_dtype,
+                    device=context_device,
                 ),
                 persistent=False,
             )
@@ -322,8 +359,8 @@ class K3DSparkModel(nn.Module):
                 "_streamed_context_states",
                 torch.empty(
                     0,
-                    dtype=context_proj_weight.dtype,
-                    device=context_proj_weight.device,
+                    dtype=context_dtype,
+                    device=context_device,
                 ),
                 persistent=False,
             )
@@ -878,6 +915,10 @@ class K3DSparkModel(nn.Module):
 
 
 class K3DSparkForCausalLM(nn.Module):
+    packed_modules_mapping = {
+        "fused_qkv_a_proj": ["q_a_proj", "kv_a_proj_with_mqa"],
+        "gate_up_proj": ["gate_proj", "up_proj"],
+    }
     has_own_embed_tokens = False
     has_own_lm_head = False
     draft_id_to_target_id = None

--- a/vllm/models/kimi_k3/nvidia/dspark_mla.py
+++ b/vllm/models/kimi_k3/nvidia/dspark_mla.py
@@ -128,6 +128,22 @@ def _prepare_dspark_quant_config(
     vllm_config: VllmConfig,
     start_layer_id: int,
 ) -> QuantizationConfig | None:
+    """Resolve the draft quantization config for runtime layer names.
+
+    The draft's quantization config is the one the vLLM config carries, else
+    the draft-model one. A config with per-tensor storage keyed by checkpoint
+    layer index (``...layers.<i>...``) gains an alias for each entry under the
+    runtime index ``start_layer_id + i``, so the draft layers, which are named
+    after the target layers they follow, resolve their own storage entries.
+
+    Args:
+        vllm_config: Configuration of the draft model run.
+        start_layer_id: Runtime index of the first draft layer.
+
+    Returns:
+        The quantization config with runtime-name aliases, or ``None`` when
+        the draft is not quantized.
+    """
     quant_config = getattr(vllm_config, "quant_config", None)
     if quant_config is None:
         quant_config = get_draft_quant_config(vllm_config)


### PR DESCRIPTION
## Summary

Enable Kimi-K3 DSpark draft layers to consume dense EXL3 checkpoints without changing the unquantized BF16 path.

The DSpark model names its runtime attention/MLP layers after an offset reserved for the target-side layer namespace. A five-layer draft therefore constructs quantized linears under `model.layers.5..9`, while its checkpoint metadata is keyed by `layers.0..4`. The model also reparsed a fresh draft quantization config inside each decoder layer, discarding the packed-module mapping applied by the model loader. As a result, valid EXL3 tensors were not selected and the loader constructed ordinary dense weights instead.

This change:

- reuses the already configured `vllm_config.quant_config` for every draft layer;
- adds idempotent metadata aliases from checkpoint layer indices to the runtime offset without changing stored tensor names;
- declares the packed source mappings for fused q/kv-a and gate/up projections;
- derives streamed context scratch placement from any projection parameter and uses the current activation dtype, so packed linears do not require a dense `.weight` parameter.

If no draft quantization config is present, all paths continue to receive `None` and retain the existing BF16 behavior.

## Compatibility and invariants

- Metadata aliases preserve the original checkpoint keys; weight loading still consumes the original stored tensor names.
- Packed gate/up projections are quantized only when both source projections are present in the quantization metadata.
- Mixed q-a/kv-a projections remain unquantized unless both sources use the same quantized format.
- Quantized context projections allocate BF16 activation scratch on the packed parameter's device.
- This PR does not add or change an EXL3 CUDA kernel or checkpoint format.

## Validation

### Unit and static checks

```text
python -m pytest tests/models/test_dspark_mla.py -q
31 passed

ruff check vllm/models/kimi_k3/nvidia/dspark_mla.py tests/models/test_dspark_mla.py
All checks passed!

ruff format --check vllm/models/kimi_k3/nvidia/dspark_mla.py tests/models/test_dspark_mla.py
2 files already formatted

python -m py_compile vllm/models/kimi_k3/nvidia/dspark_mla.py tests/models/test_dspark_mla.py
git diff --check
```

The new tests cover configured-config reuse, runtime layer aliases, packed-module declarations, idempotence, and a quantized context projection with no dense `.weight` attribute.

### Full model qualification

Single-stream qualification used a five-layer Inferact Kimi-K3 DSpark draft with an EXL3 MCG K2 checkpoint on an RTX 3090 (SM86), while the Kimi-K3 target remained live:

- full checkpoint closure: 26 quantized matrices, 104 packed tensors, all MCG markers and source hashes verified;
- full model load and post-load processing completed;
- dedicated draft KV smoke passed with 279,600-token capacity;
- CUDA graphs captured for `B1K1`, `B1K2`, `B1K3`, `B2K1`, `B2K2`, and `B2K3`;
- eager fallbacks: 0;
- draft allocation: 6.998 GiB;
- container restarts/OOMs: 0.

Deterministic direct-target A/B, three 800-token runs per draft, same prompt/seed, `temperature=0`, `ignore_eos=true`:

| Draft | Decode average | Range | Acceptance length |
|---|---:|---:|---:|
| BF16 | 44.77 tok/s | 44.66-44.91 | 2.569 |
| EXL3 MCG K2 | 46.49 tok/s | 46.45-46.54 | 2.530 |

The final concatenated reasoning/content output was byte-identical between BF16 and EXL3 runs (3,693 characters, SHA-256 `9e112899297062dd615f8472ee1279beab37120fb769bd3d6c456c5a0032e6e0`). Mean draft GPU query time fell from 8.85 ms to 6.12 ms, and draft allocation fell from 10.56 GiB to 7.00 GiB.

### Known concurrency limitation

A subsequent live two-request test exposed a separate remote-draft concurrency failure: the first request continued generating, the second was deferred, and the target eventually logged a 30-second ZeroMQ receive timeout (`zmq.error.Again`) from the draft RPC. The deployment was immediately reverted to the BF16 draft; both requests then resumed. The measurements above therefore qualify single-stream EXL3 loading/numerics/performance only and must not be interpreted as production-readiness for the current remote B2 path. Reproduction and repair of that concurrency path are follow-up work; this loader PR does not claim to fix it.

## Duplicate-work check

Searches for open `K3 DSpark EXL3` and `quantized DSpark` PRs found no implementation of this loader fix. PR #473 concerns DFlash auxiliary projection memory, and PR #465 adds remote DSpark transport; neither handles dense EXL3 metadata/configuration in `K3DSparkModel`.

## AI assistance

Hermes Agent assisted with source analysis, test construction, and validation. The submitted diff and all reported tests/results were reviewed and executed by the submitter.
