### PR TITLE
[II] Force-reject grammar-invalid speculative drafts

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import dataclasses
 from concurrent.futures import Future
+from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 import pytest
@@ -3258,6 +3259,42 @@ def test_grammar_compile_error_finishes_only_request(async_grammar: bool):
     assert [req.req_id for req in next_output.scheduled_new_reqs] == [
         healthy_request.request_id
     ]
+
+
+@pytest.mark.parametrize(
+    "invalid_spec_tokens,expected_invalid_counts",
+    [({"structured": 2}, [2]), (None, [0])],
+)
+def test_get_grammar_bitmask_forwards_invalid_draft_counts(
+    invalid_spec_tokens, expected_invalid_counts
+):
+    scheduler = object.__new__(Scheduler)
+    scheduler.requests = {
+        "plain": SimpleNamespace(use_structured_output=False, is_prefill_chunk=False),
+        "structured": SimpleNamespace(
+            use_structured_output=True, is_prefill_chunk=False
+        ),
+    }
+    scheduler.structured_output_manager = Mock()
+    scheduler.structured_output_manager.grammar_bitmask.return_value = Mock()
+    scheduler_output = SimpleNamespace(
+        has_structured_output_requests=True,
+        num_scheduled_tokens={"plain": 1, "structured": 4},
+        scheduled_spec_decode_tokens={"structured": [1, 2, 3]},
+        num_invalid_spec_tokens=invalid_spec_tokens,
+    )
+
+    grammar_output = scheduler.get_grammar_bitmask(scheduler_output)
+
+    assert grammar_output is not None
+    assert grammar_output.structured_output_request_ids == ["structured"]
+    assert grammar_output.num_spec_tokens == [3]
+    assert grammar_output.num_invalid_spec_tokens == expected_invalid_counts
+    scheduler.structured_output_manager.grammar_bitmask.assert_called_once_with(
+        scheduler.requests,
+        ["structured"],
+        scheduler_output.scheduled_spec_decode_tokens,
+    )
 
 
 def test_abort_request_when_structured_output_fsm_cannot_advance():

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -3277,6 +3277,7 @@ def test_get_grammar_bitmask_forwards_invalid_draft_counts(
     }
     scheduler.structured_output_manager = Mock()
     scheduler.structured_output_manager.grammar_bitmask.return_value = Mock()
+    scheduler.structured_output_manager.has_grammar_bonus_token.return_value = True
     scheduler_output = SimpleNamespace(
         has_structured_output_requests=True,
         num_scheduled_tokens={"plain": 1, "structured": 4},
@@ -3289,11 +3290,15 @@ def test_get_grammar_bitmask_forwards_invalid_draft_counts(
     assert grammar_output is not None
     assert grammar_output.structured_output_request_ids == ["structured"]
     assert grammar_output.num_spec_tokens == [3]
+    assert grammar_output.has_bonus_token == [True]
     assert grammar_output.num_invalid_spec_tokens == expected_invalid_counts
     scheduler.structured_output_manager.grammar_bitmask.assert_called_once_with(
         scheduler.requests,
         ["structured"],
         scheduler_output.scheduled_spec_decode_tokens,
+    )
+    scheduler.structured_output_manager.has_grammar_bonus_token.assert_called_once_with(
+        [1, 2, 3]
     )
 
 

--- a/tests/v1/sample/test_rejection_sampler.py
+++ b/tests/v1/sample/test_rejection_sampler.py
@@ -14,6 +14,7 @@ from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.rejection_sampler import (
     PLACEHOLDER_TOKEN_ID,
     RejectionSampler,
+    force_reject_invalid_draft_suffixes,
     sample_recovered_tokens,
 )
 from vllm.v1.sample.sampler import Sampler, SamplerOutput
@@ -1183,3 +1184,77 @@ def test_placeholder_draft_token_rejected_random(rejection_sampler):
     assert sampled[0, 1].item() == vocab_size - 1
     recovered = sampled[0, 2].item()
     assert 0 <= recovered < vocab_size
+
+
+def test_forced_grammar_rejection_recovers_from_target_distribution(
+    rejection_sampler,
+):
+    logits = torch.tensor(
+        [[float("-inf"), 0.0, 0.0]], dtype=torch.float32, device=DEVICE_TYPE
+    )
+    draft_probs = torch.tensor(
+        [[0.0, 0.5, 0.5]], dtype=torch.float32, device=DEVICE_TYPE
+    )
+    metadata = create_sampling_metadata(
+        all_greedy=False,
+        temperature=torch.ones(1, dtype=torch.float32, device=DEVICE_TYPE),
+        generators={0: torch.Generator(device=DEVICE_TYPE).manual_seed(0)},
+    )
+    spec_decode_metadata = create_spec_decode_metadata([[0]], logits)
+    mock_sampler_output(
+        rejection_sampler, torch.tensor([1], dtype=torch.int32, device=DEVICE_TYPE)
+    )
+
+    output = rejection_sampler(
+        spec_decode_metadata,
+        draft_probs=draft_probs,
+        logits=logits,
+        sampling_metadata=metadata,
+        num_invalid_draft_tokens=[1],
+    )
+
+    assert output.sampled_token_ids[0, 0].item() in {1, 2}
+    assert output.sampled_token_ids[0, 1].item() == PLACEHOLDER_TOKEN_ID
+
+
+def test_force_rejects_only_the_invalid_suffix_for_each_request():
+    drafts = torch.tensor([10, 11, 12, 20, 21, 30], dtype=torch.int32)
+    draft_probs = torch.ones((6, 4), dtype=torch.float32)
+
+    sanitized, sanitized_probs = force_reject_invalid_draft_suffixes(
+        drafts,
+        draft_probs,
+        num_draft_tokens=[3, 2, 1],
+        num_invalid_draft_tokens=[1, 2, 0],
+    )
+
+    assert sanitized.tolist() == [10, 11, -1, -1, -1, 30]
+    assert drafts.tolist() == [10, 11, 12, 20, 21, 30]
+    assert sanitized_probs is not None
+    assert torch.equal(sanitized_probs[[0, 1, 5]], torch.ones((3, 4)))
+    assert not sanitized_probs[[2, 3, 4]].any()
+
+
+@pytest.mark.parametrize(
+    "drafts,widths,invalid",
+    [
+        ([1, 2], [2], [3]),
+        ([1, 2], [2], [1, 0]),
+        ([1], [2], [1]),
+    ],
+)
+def test_force_rejection_rejects_misaligned_metadata(drafts, widths, invalid):
+    with pytest.raises(ValueError):
+        force_reject_invalid_draft_suffixes(
+            torch.tensor(drafts, dtype=torch.int32), None, widths, invalid
+        )
+
+
+def test_force_rejection_rejects_misaligned_draft_probabilities():
+    with pytest.raises(ValueError):
+        force_reject_invalid_draft_suffixes(
+            torch.tensor([1, 2], dtype=torch.int32),
+            torch.ones((1, 4)),
+            [2],
+            [1],
+        )

--- a/tests/v1/spec_decode/test_rejection_sampler_utils.py
+++ b/tests/v1/spec_decode/test_rejection_sampler_utils.py
@@ -367,6 +367,37 @@ def test_placeholder_draft_token_rejected():
     assert (recovered >= 0).all() and (recovered < VOCAB_SIZE).all()
 
 
+def test_placeholder_stochastic_recovery_matches_target_distribution():
+    """A forced grammar rejection must recover from p, not residual p - q."""
+    torch.manual_seed(0)
+    device = "cuda"
+    num_trials = 8192
+    K = 1
+
+    target_logits_1d = torch.full(
+        (VOCAB_SIZE,), float("-inf"), device=device, dtype=torch.float32
+    )
+    target_logits_1d[:4] = torch.tensor([0.7, 0.1, -0.4, -0.9], device=device)
+    draft_logits_1d = torch.full_like(target_logits_1d, float("-inf"))
+    draft_logits_1d[:4] = torch.tensor([-1.0, 1.5, -0.5, 0.5], device=device)
+
+    inputs = _build_rejection_sample_inputs(
+        target_logits_1d,
+        draft_logits_1d,
+        K,
+        temperature=1.0,
+        num_trials=num_trials,
+    )
+    inputs["draft_sampled"].view(num_trials, K + 1)[:, 1:] = -1
+
+    sampled, num_sampled = rejection_sample(**inputs, num_speculative_steps=K)
+
+    assert torch.equal(num_sampled, torch.ones_like(num_sampled))
+    _assert_distribution_match(
+        sampled[:, 0], torch.softmax(target_logits_1d, dim=0), device
+    )
+
+
 @pytest.mark.parametrize("has_draft_logits", [True, False])
 @pytest.mark.parametrize("num_placeholders", [1, 2])
 def test_block_verification_placeholder_truncates_block(

--- a/tests/v1/structured_output/test_utils.py
+++ b/tests/v1/structured_output/test_utils.py
@@ -134,6 +134,7 @@ def test_apply_grammar_bitmask_preserves_source_offsets_after_draft_trimming(
             dtype=np.int32,
         ),
         num_spec_tokens=[3, 3],
+        num_invalid_spec_tokens=[0, 0],
     )
     input_batch = SimpleNamespace(req_ids=["trimmed-request", "full-request"])
     logits = torch.zeros((6, 32))

--- a/tests/v1/structured_output/test_utils.py
+++ b/tests/v1/structured_output/test_utils.py
@@ -1,8 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-import pytest
+from types import SimpleNamespace
 
+import numpy as np
+import pytest
+import torch
+
+from vllm.v1.core.sched.output import GrammarOutput
+from vllm.v1.structured_output import utils
 from vllm.v1.structured_output.backend_xgrammar import (
     has_xgrammar_unsupported_json_features,
 )
@@ -104,3 +110,53 @@ def test_supported_json_features(supported_schema):
     assert not has_xgrammar_unsupported_json_features(supported_schema), (
         "Schema should be supported"
     )
+
+
+def test_apply_grammar_bitmask_preserves_source_offsets_after_draft_trimming(
+    monkeypatch,
+):
+    """A trimmed request must not shift another request's grammar rows.
+
+    The scheduler serializes masks at its scheduled speculative width. A worker
+    may trim grammar-invalid drafts before applying those masks, so source and
+    destination offsets must be advanced with their respective widths.
+    """
+    scheduler_output = SimpleNamespace(
+        scheduled_spec_decode_tokens={
+            "trimmed-request": [1],
+            "full-request": [2, 3, 4],
+        }
+    )
+    grammar_output = GrammarOutput(
+        structured_output_request_ids=["trimmed-request", "full-request"],
+        grammar_bitmask=np.array(
+            [[10], [11], [12], [13], [20], [21], [22], [23]],
+            dtype=np.int32,
+        ),
+        num_spec_tokens=[3, 3],
+    )
+    input_batch = SimpleNamespace(req_ids=["trimmed-request", "full-request"])
+    logits = torch.zeros((6, 32))
+    applied_bitmask = None
+
+    def capture_bitmask(logits, bitmask, indices):
+        nonlocal applied_bitmask
+        applied_bitmask = bitmask.clone()
+        assert indices is None
+
+    monkeypatch.setattr(
+        utils,
+        "xgr",
+        SimpleNamespace(apply_token_bitmask_inplace=capture_bitmask),
+    )
+    monkeypatch.setattr(utils, "PIN_MEMORY", False)
+
+    utils.apply_grammar_bitmask(
+        scheduler_output,
+        grammar_output,
+        input_batch,
+        logits,
+    )
+
+    assert applied_bitmask is not None
+    assert applied_bitmask[:, 0].tolist() == [10, 13, 20, 21, 22, 23]

--- a/tests/v1/structured_output/test_utils.py
+++ b/tests/v1/structured_output/test_utils.py
@@ -134,6 +134,7 @@ def test_apply_grammar_bitmask_preserves_source_offsets_after_draft_trimming(
             dtype=np.int32,
         ),
         num_spec_tokens=[3, 3],
+        has_bonus_token=[True, True],
         num_invalid_spec_tokens=[0, 0],
     )
     input_batch = SimpleNamespace(req_ids=["trimmed-request", "full-request"])
@@ -161,3 +162,47 @@ def test_apply_grammar_bitmask_preserves_source_offsets_after_draft_trimming(
 
     assert applied_bitmask is not None
     assert applied_bitmask[:, 0].tolist() == [10, 13, 20, 21, 22, 23]
+
+
+def test_apply_grammar_bitmask_skips_omitted_diffusion_bonus_rows(monkeypatch):
+    """An omitted source bonus row must not consume the next request's mask."""
+    scheduler_output = SimpleNamespace(
+        scheduled_spec_decode_tokens={
+            "diffusion-request": [1],
+            "later-request": [2, 3, 4],
+        }
+    )
+    grammar_output = GrammarOutput(
+        structured_output_request_ids=["diffusion-request", "later-request"],
+        grammar_bitmask=np.array([[10], [20], [21], [22], [23]], dtype=np.int32),
+        num_spec_tokens=[1, 3],
+        has_bonus_token=[False, True],
+        num_invalid_spec_tokens=[0, 0],
+    )
+    input_batch = SimpleNamespace(req_ids=["diffusion-request", "later-request"])
+    logits = torch.zeros((6, 32))
+    applied_bitmask = None
+    applied_indices = None
+
+    def capture_bitmask(logits, bitmask, indices):
+        nonlocal applied_bitmask, applied_indices
+        applied_bitmask = bitmask.clone()
+        applied_indices = indices
+
+    monkeypatch.setattr(
+        utils,
+        "xgr",
+        SimpleNamespace(apply_token_bitmask_inplace=capture_bitmask),
+    )
+    monkeypatch.setattr(utils, "PIN_MEMORY", False)
+
+    utils.apply_grammar_bitmask(
+        scheduler_output,
+        grammar_output,
+        input_batch,
+        logits,
+    )
+
+    assert applied_bitmask is not None
+    assert applied_bitmask[:, 0].tolist() == [10, -1, 20, 21, 22, 23]
+    assert applied_indices == [0, 2, 3, 4, 5]

--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -38,7 +38,12 @@ from vllm.utils.torch_utils import set_random_seed
 from vllm.v1.attention.backend import MultipleOf
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 from vllm.v1.core.kv_cache_utils import estimate_max_model_len, get_kv_cache_configs
-from vllm.v1.core.sched.output import CachedRequestData, NewRequestData, SchedulerOutput
+from vllm.v1.core.sched.output import (
+    CachedRequestData,
+    GrammarOutput,
+    NewRequestData,
+    SchedulerOutput,
+)
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheConfig,
@@ -144,6 +149,72 @@ def model_runner():
 
 
 model_runner_2 = model_runner
+
+
+def test_invalid_grammar_suffix_counts_follow_compact_worker_order():
+    runner = SimpleNamespace(
+        input_batch=SimpleNamespace(req_ids=["plain", "structured-a", "structured-b"])
+    )
+    grammar_output = GrammarOutput(
+        structured_output_request_ids=["structured-b", "structured-a"],
+        grammar_bitmask=np.empty((0, 0), dtype=np.int32),
+        num_spec_tokens=[4, 3],
+        num_invalid_spec_tokens=[3, 1],
+    )
+    spec_decode_metadata = SimpleNamespace(num_draft_tokens=[1, 2, 3])
+
+    assert GPUModelRunner._get_invalid_draft_counts(
+        runner, grammar_output, spec_decode_metadata
+    ) == [0, 0, 2]
+
+
+@pytest.mark.parametrize(
+    "request_ids,widths,invalid,error",
+    [
+        (["a", "a"], [1, 1], [0, 0], "duplicate"),
+        (["a"], [1, 2], [0], "align"),
+        (["a"], [1], None, "missing"),
+        (["a"], [1], [2], "outside"),
+    ],
+)
+def test_invalid_grammar_suffix_counts_validate_serialized_metadata(
+    request_ids, widths, invalid, error
+):
+    runner = SimpleNamespace(input_batch=SimpleNamespace(req_ids=["a"]))
+    grammar_output = GrammarOutput(
+        structured_output_request_ids=request_ids,
+        grammar_bitmask=np.empty((0, 0), dtype=np.int32),
+        num_spec_tokens=widths,
+        num_invalid_spec_tokens=invalid,
+    )
+    spec_decode_metadata = SimpleNamespace(num_draft_tokens=[1])
+
+    with pytest.raises(ValueError, match=error):
+        GPUModelRunner._get_invalid_draft_counts(
+            runner, grammar_output, spec_decode_metadata
+        )
+
+
+def test_sample_forwards_invalid_draft_counts_to_rejection_sampler():
+    runner = object.__new__(GPUModelRunner)
+    runner.input_batch = SimpleNamespace(
+        sampling_metadata=Mock(),
+        update_async_output_token_ids=Mock(),
+    )
+    runner.use_async_scheduling = False
+    runner._get_spec_decode_draft_probs = Mock(return_value=None)
+    runner.rejection_sampler = Mock(return_value="sampler-output")
+    spec_decode_metadata = SimpleNamespace()
+
+    output = GPUModelRunner._sample(
+        runner,
+        torch.zeros(1, 2),
+        spec_decode_metadata,
+        [1],
+    )
+
+    assert output == "sampler-output"
+    assert runner.rejection_sampler.call_args.args[4] == [1]
 
 
 def _schedule_new_request(*req_ids: str) -> SchedulerOutput:

--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -159,6 +159,7 @@ def test_invalid_grammar_suffix_counts_follow_compact_worker_order():
         structured_output_request_ids=["structured-b", "structured-a"],
         grammar_bitmask=np.empty((0, 0), dtype=np.int32),
         num_spec_tokens=[4, 3],
+        has_bonus_token=[True, True],
         num_invalid_spec_tokens=[3, 1],
     )
     spec_decode_metadata = SimpleNamespace(num_draft_tokens=[1, 2, 3])
@@ -185,6 +186,7 @@ def test_invalid_grammar_suffix_counts_validate_serialized_metadata(
         structured_output_request_ids=request_ids,
         grammar_bitmask=np.empty((0, 0), dtype=np.int32),
         num_spec_tokens=widths,
+        has_bonus_token=[True] * len(request_ids),
         num_invalid_spec_tokens=invalid,
     )
     spec_decode_metadata = SimpleNamespace(num_draft_tokens=[1])

--- a/tests/v1/worker/test_gpu_model_runner_v2.py
+++ b/tests/v1/worker/test_gpu_model_runner_v2.py
@@ -19,6 +19,7 @@ def _grammar_output() -> GrammarOutput:
         structured_output_request_ids=["structured-b", "structured-a"],
         grammar_bitmask=np.empty((0, 0), dtype=np.int32),
         num_spec_tokens=[4, 3],
+        has_bonus_token=[True, True],
         num_invalid_spec_tokens=[3, 1],
     )
 
@@ -60,6 +61,7 @@ def test_invalid_grammar_suffix_counts_project_active_width(
         structured_output_request_ids=["structured"],
         grammar_bitmask=np.empty((0, 0), dtype=np.int32),
         num_spec_tokens=[source_width],
+        has_bonus_token=[True],
         num_invalid_spec_tokens=[source_invalid],
     )
     input_batch = SimpleNamespace(
@@ -87,6 +89,7 @@ def test_invalid_grammar_suffix_counts_validate_metadata(
         structured_output_request_ids=request_ids,
         grammar_bitmask=np.empty((0, 0), dtype=np.int32),
         num_spec_tokens=widths,
+        has_bonus_token=[True] * len(request_ids),
         num_invalid_spec_tokens=invalid,
     )
     input_batch = SimpleNamespace(

--- a/tests/v1/worker/test_gpu_model_runner_v2.py
+++ b/tests/v1/worker/test_gpu_model_runner_v2.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU coverage for V2 structured-output/speculative-decode transport."""
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import Mock
+
+import numpy as np
+import pytest
+import torch
+
+from vllm.v1.core.sched.output import GrammarOutput
+from vllm.v1.worker.gpu.model_runner import GPUModelRunner, _get_invalid_draft_counts
+
+
+def _grammar_output() -> GrammarOutput:
+    return GrammarOutput(
+        structured_output_request_ids=["structured-b", "structured-a"],
+        grammar_bitmask=np.empty((0, 0), dtype=np.int32),
+        num_spec_tokens=[4, 3],
+        num_invalid_spec_tokens=[3, 1],
+    )
+
+
+def _grammar_input_batch() -> SimpleNamespace:
+    return SimpleNamespace(
+        req_ids=["plain", "structured-a", "structured-b"],
+        num_draft_tokens_per_req=np.array([0, 2, 3], dtype=np.int32),
+        cu_num_logits_np=np.array([0, 1, 4, 8], dtype=np.int32),
+    )
+
+
+def test_invalid_grammar_suffix_counts_follow_reorder_and_compaction():
+    assert _get_invalid_draft_counts(_grammar_output(), _grammar_input_batch()) == [
+        0,
+        0,
+        2,
+    ]
+    new_request_batch = SimpleNamespace(
+        req_ids=["new"],
+        num_draft_tokens_per_req=np.array([2], dtype=np.int32),
+    )
+    assert _get_invalid_draft_counts(_grammar_output(), new_request_batch) is None
+
+
+@pytest.mark.parametrize(
+    "source_width,source_invalid,active_width,expected",
+    [
+        (4, 0, 4, None),
+        (4, 4, 4, [4]),
+        (4, 3, 2, [1]),
+        (4, 3, 1, None),
+    ],
+)
+def test_invalid_grammar_suffix_counts_project_active_width(
+    source_width, source_invalid, active_width, expected
+):
+    grammar_output = GrammarOutput(
+        structured_output_request_ids=["structured"],
+        grammar_bitmask=np.empty((0, 0), dtype=np.int32),
+        num_spec_tokens=[source_width],
+        num_invalid_spec_tokens=[source_invalid],
+    )
+    input_batch = SimpleNamespace(
+        req_ids=["structured"],
+        num_draft_tokens_per_req=np.array([active_width], dtype=np.int32),
+    )
+
+    assert _get_invalid_draft_counts(grammar_output, input_batch) == expected
+
+
+@pytest.mark.parametrize(
+    "request_ids,widths,invalid,active_widths,error",
+    [
+        (["a", "a"], [1, 1], [0, 0], [1], "duplicate"),
+        (["a"], [1, 2], [0], [1], "align"),
+        (["a"], [1], None, [1], "missing"),
+        (["a"], [1], [2], [1], "outside"),
+        (["a"], [1], [0], [2], "active"),
+    ],
+)
+def test_invalid_grammar_suffix_counts_validate_metadata(
+    request_ids, widths, invalid, active_widths, error
+):
+    grammar_output = GrammarOutput(
+        structured_output_request_ids=request_ids,
+        grammar_bitmask=np.empty((0, 0), dtype=np.int32),
+        num_spec_tokens=widths,
+        num_invalid_spec_tokens=invalid,
+    )
+    input_batch = SimpleNamespace(
+        req_ids=["a"],
+        num_draft_tokens_per_req=np.array(active_widths, dtype=np.int32),
+    )
+
+    with pytest.raises(ValueError, match=error):
+        _get_invalid_draft_counts(grammar_output, input_batch)
+
+
+def test_sample_forwards_projected_grammar_rejections():
+    input_batch = _grammar_input_batch()
+    input_batch.num_draft_tokens = 5
+    input_batch.logits_indices = torch.arange(8)
+    input_batch.max_query_len = 4
+    runner: Any = GPUModelRunner.__new__(GPUModelRunner)
+    runner.model = SimpleNamespace(compute_logits=lambda _: torch.zeros(8, 4))
+    runner.structured_outputs_worker = SimpleNamespace(
+        apply_grammar_bitmask=lambda *_: None
+    )
+    runner.rejection_sampler = Mock(
+        return_value=SimpleNamespace(num_sampled=None, num_rejected=None)
+    )
+    runner.speculator = SimpleNamespace(draft_logits=None, online_sts=None)
+    runner.verification_capacity_manager = None
+
+    GPUModelRunner.sample(runner, torch.zeros(8, 1), input_batch, _grammar_output())
+
+    assert runner.rejection_sampler.call_args.args[3] == [0, 0, 2]
+
+
+def test_sample_without_grammar_forwards_no_invalid_counts():
+    input_batch = _grammar_input_batch()
+    input_batch.num_draft_tokens = 5
+    input_batch.logits_indices = torch.arange(8)
+    input_batch.max_query_len = 4
+    runner: Any = GPUModelRunner.__new__(GPUModelRunner)
+    runner.model = SimpleNamespace(compute_logits=lambda _: torch.zeros(8, 4))
+    runner.rejection_sampler = Mock(
+        return_value=SimpleNamespace(num_sampled=None, num_rejected=None)
+    )
+    runner.speculator = SimpleNamespace(draft_logits=None, online_sts=None)
+    runner.verification_capacity_manager = None
+
+    GPUModelRunner.sample(runner, torch.zeros(8, 1), input_batch, None)
+
+    assert runner.rejection_sampler.call_args.args[3] is None

--- a/tests/v1/worker/test_gpu_rejection_sampler_chunking.py
+++ b/tests/v1/worker/test_gpu_rejection_sampler_chunking.py
@@ -13,6 +13,7 @@ from vllm.platforms import current_platform
 from vllm.v1.worker.gpu.spec_decode.rejection_sampler import (
     RejectionSampler,
     _iter_request_chunks,
+    force_reject_invalid_draft_suffixes,
 )
 
 
@@ -24,6 +25,36 @@ def test_iter_request_chunks_preserves_request_boundaries():
         (2, 3),
         (3, 4),
     ]
+
+
+def test_force_reject_invalid_draft_suffixes_marks_only_compact_tail():
+    draft_sampled = torch.tensor([90, 91, 11, 12, 92, 21, 22, 23])
+    sanitized = force_reject_invalid_draft_suffixes(
+        draft_sampled,
+        np.array([0, 1, 4, 8], dtype=np.int32),
+        [0, 0, 2],
+    )
+
+    assert sanitized.tolist() == [90, 91, 11, 12, 92, 21, -1, -1]
+    assert draft_sampled.tolist() == [90, 91, 11, 12, 92, 21, 22, 23]
+
+
+@pytest.mark.parametrize(
+    "draft_sampled,cu_num_logits,invalid_counts",
+    [
+        (torch.tensor([1, 2]), np.array([0, 2], dtype=np.int32), [3]),
+        (torch.tensor([1, 2]), np.array([0, 2], dtype=np.int32), [1, 0]),
+        (torch.tensor([1]), np.array([0, 2], dtype=np.int32), [1]),
+        (torch.tensor([1, 2]), np.array([[0, 2]], dtype=np.int32), [1]),
+    ],
+)
+def test_force_reject_invalid_draft_suffixes_validates_metadata(
+    draft_sampled, cu_num_logits, invalid_counts
+):
+    with pytest.raises(ValueError):
+        force_reject_invalid_draft_suffixes(
+            draft_sampled, cu_num_logits, invalid_counts
+        )
 
 
 @pytest.mark.skipif(not current_platform.is_cuda(), reason="Requires CUDA")

--- a/tests/v1/worker/test_gpu_structured_outputs.py
+++ b/tests/v1/worker/test_gpu_structured_outputs.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import numpy as np
+
+from vllm.v1.worker.gpu.structured_outputs import _build_grammar_row_mapping
+
+
+def test_grammar_mapping_preserves_bonus_rows_after_zero_draft_budget():
+    """Zero draft capacity retains each request's scheduled bonus mask."""
+    source_indices, logits_indices = _build_grammar_row_mapping(
+        req_ids=["low", "high", "prefill"],
+        grammar_req_ids=["low", "high", "prefill"],
+        grammar_num_spec_tokens=[2, 2, 0],
+        cu_num_logits_np=np.array([0, 1, 2, 3], dtype=np.int32),
+        num_draft_tokens_per_req=np.array([0, 0, 0], dtype=np.int32),
+        num_bonus_tokens=1,
+    )
+
+    assert source_indices == [2, 5, 6]
+    assert logits_indices == [0, 1, 2]
+
+
+def test_grammar_mapping_selects_active_drafts_from_each_source_group():
+    """Compaction preserves per-request draft rows and the final bonus row."""
+    source_indices, logits_indices = _build_grammar_row_mapping(
+        req_ids=["plain", "trimmed", "full"],
+        grammar_req_ids=["trimmed", "full"],
+        grammar_num_spec_tokens=[3, 3],
+        cu_num_logits_np=np.array([0, 1, 3, 7], dtype=np.int32),
+        num_draft_tokens_per_req=np.array([0, 1, 3], dtype=np.int32),
+        num_bonus_tokens=1,
+    )
+
+    assert source_indices == [0, 3, 4, 5, 6, 7]
+    assert logits_indices == [1, 2, 3, 4, 5, 6]
+
+
+def test_grammar_mapping_supports_non_speculative_batches():
+    """A batch without draft tokens maps one bonus row per grammar request."""
+    source_indices, logits_indices = _build_grammar_row_mapping(
+        req_ids=["plain", "grammar"],
+        grammar_req_ids=["grammar"],
+        grammar_num_spec_tokens=[0],
+        cu_num_logits_np=np.array([0, 1, 2], dtype=np.int32),
+        num_draft_tokens_per_req=None,
+        num_bonus_tokens=1,
+    )
+
+    assert source_indices == [0]
+    assert logits_indices == [1]

--- a/tests/v1/worker/test_gpu_structured_outputs.py
+++ b/tests/v1/worker/test_gpu_structured_outputs.py
@@ -12,6 +12,7 @@ def test_grammar_mapping_preserves_bonus_rows_after_zero_draft_budget():
         req_ids=["low", "high", "prefill"],
         grammar_req_ids=["low", "high", "prefill"],
         grammar_num_spec_tokens=[2, 2, 0],
+        grammar_has_bonus_token=[True, True, True],
         cu_num_logits_np=np.array([0, 1, 2, 3], dtype=np.int32),
         num_draft_tokens_per_req=np.array([0, 0, 0], dtype=np.int32),
         num_bonus_tokens=1,
@@ -27,6 +28,7 @@ def test_grammar_mapping_selects_active_drafts_from_each_source_group():
         req_ids=["plain", "trimmed", "full"],
         grammar_req_ids=["trimmed", "full"],
         grammar_num_spec_tokens=[3, 3],
+        grammar_has_bonus_token=[True, True],
         cu_num_logits_np=np.array([0, 1, 3, 7], dtype=np.int32),
         num_draft_tokens_per_req=np.array([0, 1, 3], dtype=np.int32),
         num_bonus_tokens=1,
@@ -42,6 +44,7 @@ def test_grammar_mapping_supports_non_speculative_batches():
         req_ids=["plain", "grammar"],
         grammar_req_ids=["grammar"],
         grammar_num_spec_tokens=[0],
+        grammar_has_bonus_token=[True],
         cu_num_logits_np=np.array([0, 1, 2], dtype=np.int32),
         num_draft_tokens_per_req=None,
         num_bonus_tokens=1,
@@ -49,3 +52,19 @@ def test_grammar_mapping_supports_non_speculative_batches():
 
     assert source_indices == [0]
     assert logits_indices == [1]
+
+
+def test_grammar_mapping_advances_past_unmapped_diffusion_bonus_rows():
+    """Serialized diffusion bonus rows advance source offsets without logits."""
+    source_indices, logits_indices = _build_grammar_row_mapping(
+        req_ids=["diffusion", "no-canvas", "later"],
+        grammar_req_ids=["diffusion", "no-canvas", "later"],
+        grammar_num_spec_tokens=[1, 0, 2],
+        grammar_has_bonus_token=[False, True, False],
+        cu_num_logits_np=np.array([0, 1, 1, 3], dtype=np.int32),
+        num_draft_tokens_per_req=np.array([1, 0, 2], dtype=np.int32),
+        num_bonus_tokens=0,
+    )
+
+    assert source_indices == [0, 2, 3]
+    assert logits_indices == [0, 1, 2]

--- a/vllm/v1/core/sched/output.py
+++ b/vllm/v1/core/sched/output.py
@@ -299,3 +299,6 @@ class GrammarOutput:
     # structured output request. Worker-side draft trimming may reduce the
     # number of logits without changing this compact source layout.
     num_spec_tokens: list[int]
+    # Number of grammar-invalid draft tokens per structured request. This is
+    # forwarded to the worker so a stale draft snapshot cannot be accepted.
+    num_invalid_spec_tokens: list[int]

--- a/vllm/v1/core/sched/output.py
+++ b/vllm/v1/core/sched/output.py
@@ -295,3 +295,7 @@ class GrammarOutput:
     structured_output_request_ids: list[str]
     # Bitmask ordered as structured_output_request_ids.
     grammar_bitmask: "npt.NDArray[np.int32]"
+    # Number of speculative rows represented in grammar_bitmask for each
+    # structured output request. Worker-side draft trimming may reduce the
+    # number of logits without changing this compact source layout.
+    num_spec_tokens: list[int]

--- a/vllm/v1/core/sched/output.py
+++ b/vllm/v1/core/sched/output.py
@@ -299,6 +299,9 @@ class GrammarOutput:
     # structured output request. Worker-side draft trimming may reduce the
     # number of logits without changing this compact source layout.
     num_spec_tokens: list[int]
+    # Whether grammar_bitmask contains the per-request bonus row. Diffusion
+    # requests that already have scheduled positions omit this source row.
+    has_bonus_token: list[bool]
     # Number of grammar-invalid draft tokens per structured request. This is
     # forwarded to the worker so a stale draft snapshot cannot be accepted.
     num_invalid_spec_tokens: list[int]

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1695,10 +1695,16 @@ class Scheduler(SchedulerInterface):
             len(scheduler_output.scheduled_spec_decode_tokens.get(req_id, ()))
             for req_id in structured_output_request_ids
         ]
+        invalid_spec_tokens = scheduler_output.num_invalid_spec_tokens or {}
+        num_invalid_spec_tokens = [
+            invalid_spec_tokens.get(req_id, 0)
+            for req_id in structured_output_request_ids
+        ]
         return GrammarOutput(
             structured_output_request_ids,
             bitmask,
             num_spec_tokens,
+            num_invalid_spec_tokens,
         )
 
     def update_from_output(

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1691,7 +1691,15 @@ class Scheduler(SchedulerInterface):
             structured_output_request_ids,
             scheduler_output.scheduled_spec_decode_tokens,
         )
-        return GrammarOutput(structured_output_request_ids, bitmask)
+        num_spec_tokens = [
+            len(scheduler_output.scheduled_spec_decode_tokens.get(req_id, ()))
+            for req_id in structured_output_request_ids
+        ]
+        return GrammarOutput(
+            structured_output_request_ids,
+            bitmask,
+            num_spec_tokens,
+        )
 
     def update_from_output(
         self,

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1695,6 +1695,12 @@ class Scheduler(SchedulerInterface):
             len(scheduler_output.scheduled_spec_decode_tokens.get(req_id, ()))
             for req_id in structured_output_request_ids
         ]
+        has_bonus_token = [
+            self.structured_output_manager.has_grammar_bonus_token(
+                scheduler_output.scheduled_spec_decode_tokens.get(req_id, ())
+            )
+            for req_id in structured_output_request_ids
+        ]
         invalid_spec_tokens = scheduler_output.num_invalid_spec_tokens or {}
         num_invalid_spec_tokens = [
             invalid_spec_tokens.get(req_id, 0)
@@ -1704,6 +1710,7 @@ class Scheduler(SchedulerInterface):
             structured_output_request_ids,
             bitmask,
             num_spec_tokens,
+            has_bonus_token,
             num_invalid_spec_tokens,
         )
 

--- a/vllm/v1/sample/rejection_sampler.py
+++ b/vllm/v1/sample/rejection_sampler.py
@@ -35,6 +35,48 @@ GREEDY_TEMPERATURE: tl.constexpr = 0
 MAX_SPEC_LEN = 128
 
 
+def force_reject_invalid_draft_suffixes(
+    draft_token_ids: torch.Tensor,
+    draft_probs: torch.Tensor | None,
+    num_draft_tokens: list[int],
+    num_invalid_draft_tokens: list[int] | None,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Replace grammar-invalid draft suffixes with rejection placeholders."""
+    if num_invalid_draft_tokens is None:
+        return draft_token_ids, draft_probs
+    if len(num_invalid_draft_tokens) != len(num_draft_tokens):
+        raise ValueError("invalid draft counts must align with batch requests")
+
+    total_drafts = sum(num_draft_tokens)
+    if draft_token_ids.numel() != total_drafts:
+        raise ValueError("draft ids must align with per-request draft counts")
+    if not any(num_invalid_draft_tokens):
+        return draft_token_ids, draft_probs
+
+    sanitized = draft_token_ids.clone()
+    forced_reject_mask = torch.zeros(
+        total_drafts, dtype=torch.bool, device=draft_token_ids.device
+    )
+    offset = 0
+    for num_drafts, num_invalid in zip(
+        num_draft_tokens, num_invalid_draft_tokens, strict=True
+    ):
+        if not 0 <= num_invalid <= num_drafts:
+            raise ValueError("invalid draft count is outside its request width")
+        if num_invalid:
+            start = offset + num_drafts - num_invalid
+            sanitized[start : offset + num_drafts] = PLACEHOLDER_TOKEN_ID
+            forced_reject_mask[start : offset + num_drafts] = True
+        offset += num_drafts
+
+    if draft_probs is not None:
+        if draft_probs.shape[0] != total_drafts:
+            raise ValueError("draft probabilities must align with draft ids")
+        draft_probs = draft_probs.clone()
+        draft_probs.masked_fill_(forced_reject_mask.unsqueeze(1), 0)
+    return sanitized, draft_probs
+
+
 class RejectionSampler(nn.Module):
     """
     The implementation strictly follows the algorithm described in
@@ -97,6 +139,7 @@ class RejectionSampler(nn.Module):
         # [num_tokens + batch_size, vocab_size]
         logits: torch.Tensor,
         sampling_metadata: SamplingMetadata,
+        num_invalid_draft_tokens: list[int] | None = None,
     ) -> SamplerOutput:
         """
         Args:
@@ -170,8 +213,14 @@ class RejectionSampler(nn.Module):
             sampling_metadata,
         )
 
-        output_token_ids = rejection_sample(
+        draft_token_ids, draft_probs = force_reject_invalid_draft_suffixes(
             metadata.draft_token_ids,
+            draft_probs,
+            metadata.num_draft_tokens,
+            num_invalid_draft_tokens,
+        )
+        output_token_ids = rejection_sample(
+            draft_token_ids,
             metadata.num_draft_tokens,
             metadata.max_spec_len,
             metadata.cu_num_draft_tokens,

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -216,6 +216,14 @@ class StructuredOutputManager:
     ) -> Future:
         return self.executor_for_fillmask.submit(self._fill_bitmasks, batch)
 
+    def has_grammar_bonus_token(
+        self, scheduled_spec_decode_tokens: Sequence[int]
+    ) -> bool:
+        """Whether a request contributes a bonus row to the compact mask."""
+        return not (
+            self.vllm_config.model_config.is_diffusion and scheduled_spec_decode_tokens
+        )
+
     def grammar_bitmask(
         self,
         requests: dict[str, "Request"],
@@ -339,7 +347,7 @@ class StructuredOutputManager:
                     cumulative_index += 1
                 # Diffusion LLMs don't sample a bonus token after the
                 # scheduled positions, so skip its bitmask in that case.
-                if not (self.vllm_config.model_config.is_diffusion and req_tokens):
+                if self.has_grammar_bonus_token(req_tokens):
                     # bonus_apply must be True when the bonus-row position
                     # should be grammar-constrained. Two triggers:
                     # - should_fill_bitmask(request): reasoning was already
@@ -380,9 +388,7 @@ class StructuredOutputManager:
                 # After unifying the `openai_gptoss` and non-`openai_gptoss` styles,
                 # it can be removed.
                 request.structured_output_request.reasoning_ended = (
-                    reasoner.is_reasoning_end_for_prompt(
-                        request.prompt_token_ids or []
-                    )
+                    reasoner.is_reasoning_end_for_prompt(request.prompt_token_ids or [])
                 )
             return request.structured_output_request.reasoning_ended
         return True

--- a/vllm/v1/structured_output/utils.py
+++ b/vllm/v1/structured_output/utils.py
@@ -131,14 +131,24 @@ def apply_grammar_bitmask(
     )
     sorted_bitmask = sorted_bitmask_tensor.numpy()
     cumulative_index = 0
-    for req_id in grammar_output.structured_output_request_ids:
-        num_spec_tokens = len(spec_tokens.get(req_id, ()))
+    for req_id, num_grammar_spec_tokens in zip(
+        grammar_output.structured_output_request_ids,
+        grammar_output.num_spec_tokens,
+        strict=True,
+    ):
+        num_worker_spec_tokens = len(spec_tokens.get(req_id, ()))
+        assert num_worker_spec_tokens <= num_grammar_spec_tokens
         if (logit_idx := struct_out_req_batch_indices.get(req_id)) is not None:
-            for i in range(1 + num_spec_tokens):
+            for i in range(num_worker_spec_tokens):
                 bitmask_index = logit_idx + i
                 sorted_bitmask[bitmask_index] = grammar_bitmask[cumulative_index + i]
                 out_indices.append(bitmask_index)
-        cumulative_index += 1 + num_spec_tokens
+            bonus_index = logit_idx + num_worker_spec_tokens
+            sorted_bitmask[bonus_index] = grammar_bitmask[
+                cumulative_index + num_grammar_spec_tokens
+            ]
+            out_indices.append(bonus_index)
+        cumulative_index += 1 + num_grammar_spec_tokens
 
     # Copy async to device.
     grammar_bitmask = sorted_bitmask_tensor.to(logits.device, non_blocking=True)

--- a/vllm/v1/structured_output/utils.py
+++ b/vllm/v1/structured_output/utils.py
@@ -131,9 +131,10 @@ def apply_grammar_bitmask(
     )
     sorted_bitmask = sorted_bitmask_tensor.numpy()
     cumulative_index = 0
-    for req_id, num_grammar_spec_tokens in zip(
+    for req_id, num_grammar_spec_tokens, has_bonus_token in zip(
         grammar_output.structured_output_request_ids,
         grammar_output.num_spec_tokens,
+        grammar_output.has_bonus_token,
         strict=True,
     ):
         num_worker_spec_tokens = len(spec_tokens.get(req_id, ()))
@@ -143,12 +144,13 @@ def apply_grammar_bitmask(
                 bitmask_index = logit_idx + i
                 sorted_bitmask[bitmask_index] = grammar_bitmask[cumulative_index + i]
                 out_indices.append(bitmask_index)
-            bonus_index = logit_idx + num_worker_spec_tokens
-            sorted_bitmask[bonus_index] = grammar_bitmask[
-                cumulative_index + num_grammar_spec_tokens
-            ]
-            out_indices.append(bonus_index)
-        cumulative_index += 1 + num_grammar_spec_tokens
+            if has_bonus_token:
+                bonus_index = logit_idx + num_worker_spec_tokens
+                sorted_bitmask[bonus_index] = grammar_bitmask[
+                    cumulative_index + num_grammar_spec_tokens
+                ]
+                out_indices.append(bonus_index)
+        cumulative_index += int(has_bonus_token) + num_grammar_spec_tokens
 
     # Copy async to device.
     grammar_bitmask = sorted_bitmask_tensor.to(logits.device, non_blocking=True)

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -500,6 +500,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 max_num_logits=self.max_num_reqs * self.decode_query_len,
                 vocab_size=self.vocab_size,
                 device=self.device,
+                num_bonus_tokens=self.model_state.num_new_sampled_tokens_per_step,
             )
 
         if self.is_pooling_model and self.is_last_pp_rank:
@@ -1606,6 +1607,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                     input_batch,
                     grammar_output.structured_output_request_ids,
                     grammar_output.grammar_bitmask,
+                    grammar_output.num_spec_tokens,
                 )
 
         if input_batch.num_draft_tokens == 0 or self.rejection_sampler is None:

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -220,6 +220,49 @@ def _profile_batch_phase(input_batch: InputBatch, dummy_run: bool = False) -> st
     return "prefill"
 
 
+def _get_invalid_draft_counts(
+    grammar_output: GrammarOutput | None, input_batch: InputBatch
+) -> list[int] | None:
+    """Map compact grammar-invalid suffixes to the active worker batch."""
+    if grammar_output is None or input_batch.num_draft_tokens_per_req is None:
+        return None
+    if grammar_output.num_invalid_spec_tokens is None:
+        raise ValueError("structured speculative batch is missing invalid draft counts")
+
+    request_ids = grammar_output.structured_output_request_ids
+    source_widths = grammar_output.num_spec_tokens
+    invalid_source_widths = grammar_output.num_invalid_spec_tokens
+    if not (len(request_ids) == len(source_widths) == len(invalid_source_widths)):
+        raise ValueError("grammar rejection counts must align with request ids")
+
+    invalid_by_request = dict(
+        zip(
+            request_ids,
+            zip(source_widths, invalid_source_widths, strict=True),
+            strict=True,
+        )
+    )
+    if len(invalid_by_request) != len(request_ids):
+        raise ValueError("grammar rejection counts contain duplicate request ids")
+
+    invalid_counts = []
+    for request_id, active_width in zip(
+        input_batch.req_ids, input_batch.num_draft_tokens_per_req, strict=True
+    ):
+        source_width, source_invalid = invalid_by_request.get(
+            request_id, (int(active_width), 0)
+        )
+        if not 0 <= source_invalid <= source_width:
+            raise ValueError("invalid draft count is outside its source width")
+        if not 0 <= active_width <= source_width:
+            raise ValueError("active draft width is outside its source width")
+        invalid_counts.append(
+            max(int(active_width) - (source_width - source_invalid), 0)
+        )
+
+    return invalid_counts if any(invalid_counts) else None
+
+
 class GPUModelRunner(LoRAModelRunnerMixin):
     def __init__(self, vllm_config: VllmConfig, device: torch.device):
         self.vllm_config = vllm_config
@@ -1618,6 +1661,9 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             # Rejection sampling for spec decoding.
             assert self.rejection_sampler is not None
             assert self.speculator is not None
+            num_invalid_draft_tokens = _get_invalid_draft_counts(
+                grammar_output, input_batch
+            )
             with record_function_or_nullcontext(
                 f"vllm:v2/target/{phase}/rejection_sample"
             ):
@@ -1626,6 +1672,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                     input_batch,
                     # Draft logits are needed for probabilistic rejection sampling.
                     self.speculator.draft_logits,
+                    num_invalid_draft_tokens,
                 )
 
         online_sts = self.speculator.online_sts if self.speculator else None

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -1651,6 +1651,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                     grammar_output.structured_output_request_ids,
                     grammar_output.grammar_bitmask,
                     grammar_output.num_spec_tokens,
+                    grammar_output.has_bonus_token,
                 )
 
         if input_batch.num_draft_tokens == 0 or self.rejection_sampler is None:

--- a/vllm/v1/worker/gpu/spec_decode/rejection_sampler.py
+++ b/vllm/v1/worker/gpu/spec_decode/rejection_sampler.py
@@ -32,6 +32,42 @@ MAX_CHUNK_BYTES = 2**30  # 1GB
 _FP32_BYTES = 4
 
 
+def force_reject_invalid_draft_suffixes(
+    draft_sampled: torch.Tensor,
+    cu_num_logits_np: np.ndarray,
+    num_invalid_draft_tokens: list[int] | None,
+) -> torch.Tensor:
+    """Replace grammar-rejected draft suffixes with rejection placeholders.
+
+    Async scheduling can leave this worker with an unfiltered draft snapshot
+    while the scheduler has already rejected a trailing grammar-invalid
+    suffix. The rejection kernels treat ``-1`` as a forced rejection and
+    recover from the grammar-masked target distribution.
+    """
+    if num_invalid_draft_tokens is None:
+        return draft_sampled
+    if cu_num_logits_np.ndim != 1 or cu_num_logits_np.size == 0:
+        raise ValueError("invalid cumulative logits metadata")
+    num_reqs = cu_num_logits_np.size - 1
+    if len(num_invalid_draft_tokens) != num_reqs:
+        raise ValueError("invalid draft counts must align with batch requests")
+    if draft_sampled.numel() != int(cu_num_logits_np[-1]):
+        raise ValueError("draft samples must align with cumulative logits")
+    if not any(num_invalid_draft_tokens):
+        return draft_sampled
+
+    sanitized = draft_sampled.clone()
+    for req_idx, num_invalid in enumerate(num_invalid_draft_tokens):
+        start = int(cu_num_logits_np[req_idx])
+        end = int(cu_num_logits_np[req_idx + 1])
+        num_drafts = end - start - 1
+        if not 0 <= num_invalid <= num_drafts:
+            raise ValueError("invalid draft count is outside its request width")
+        if num_invalid:
+            sanitized[end - num_invalid : end] = -1
+    return sanitized
+
+
 def _iter_request_chunks(
     cu_num_logits: np.ndarray, max_chunk_logits: int
 ) -> Iterator[tuple[int, int]]:
@@ -250,6 +286,7 @@ class RejectionSampler:
         logits: torch.Tensor,
         input_batch: InputBatch,
         draft_logits: torch.Tensor | None = None,
+        num_invalid_draft_tokens: list[int] | None = None,
     ) -> SamplerOutput:
         # NOTE(woosuk): We intentionally compute num_nans before sampling to make clear
         # that num_nans is computed before applying penalties and temperature.
@@ -258,6 +295,11 @@ class RejectionSampler:
         draft_sampled = input_batch.input_ids[input_batch.logits_indices]
         draft_sampled.masked_fill_(
             input_batch.is_padding[input_batch.logits_indices], -1
+        )
+        draft_sampled = force_reject_invalid_draft_suffixes(
+            draft_sampled,
+            input_batch.cu_num_logits_np,
+            num_invalid_draft_tokens,
         )
         pos = input_batch.positions[input_batch.logits_indices]
 

--- a/vllm/v1/worker/gpu/structured_outputs.py
+++ b/vllm/v1/worker/gpu/structured_outputs.py
@@ -9,8 +9,61 @@ from vllm.v1.worker.gpu.buffer_utils import async_copy_to_gpu
 from vllm.v1.worker.gpu.input_batch import InputBatch
 
 
+def _build_grammar_row_mapping(
+    req_ids: list[str],
+    grammar_req_ids: list[str],
+    grammar_num_spec_tokens: list[int],
+    cu_num_logits_np: np.ndarray,
+    num_draft_tokens_per_req: np.ndarray | None,
+    num_bonus_tokens: int,
+) -> tuple[list[int], list[int]]:
+    """Map serialized grammar rows to the active compact logits layout."""
+    assert len(grammar_req_ids) == len(grammar_num_spec_tokens)
+    assert num_bonus_tokens in (0, 1)
+
+    req_id_to_idx = {req_id: i for i, req_id in enumerate(req_ids)}
+    source_indices: list[int] = []
+    logits_indices: list[int] = []
+    source_offset = 0
+
+    for grammar_req_id, num_source_drafts in zip(
+        grammar_req_ids,
+        grammar_num_spec_tokens,
+        strict=True,
+    ):
+        req_idx = req_id_to_idx[grammar_req_id]
+        num_active_drafts = (
+            0
+            if num_draft_tokens_per_req is None
+            else int(num_draft_tokens_per_req[req_idx])
+        )
+        assert 0 <= num_active_drafts <= num_source_drafts
+
+        logits_start = int(cu_num_logits_np[req_idx])
+        num_active_logits = int(
+            cu_num_logits_np[req_idx + 1] - cu_num_logits_np[req_idx]
+        )
+        assert num_active_logits == num_active_drafts + num_bonus_tokens
+
+        source_indices.extend(range(source_offset, source_offset + num_active_drafts))
+        logits_indices.extend(range(logits_start, logits_start + num_active_drafts))
+        if num_bonus_tokens:
+            source_indices.append(source_offset + num_source_drafts)
+            logits_indices.append(logits_start + num_active_drafts)
+
+        source_offset += num_source_drafts + num_bonus_tokens
+
+    return source_indices, logits_indices
+
+
 class StructuredOutputsWorker:
-    def __init__(self, max_num_logits: int, vocab_size: int, device: torch.device):
+    def __init__(
+        self,
+        max_num_logits: int,
+        vocab_size: int,
+        device: torch.device,
+        num_bonus_tokens: int,
+    ):
         self.logits_indices = torch.zeros(
             max_num_logits, dtype=torch.int32, device=device
         )
@@ -19,6 +72,7 @@ class StructuredOutputsWorker:
         )
         self.device = device
         self.copy_stream = torch.cuda.Stream()
+        self.num_bonus_tokens = num_bonus_tokens
 
     def apply_grammar_bitmask(
         self,
@@ -26,26 +80,30 @@ class StructuredOutputsWorker:
         input_batch: InputBatch,
         grammar_req_ids: list[str],
         grammar_bitmask: np.ndarray,
+        grammar_num_spec_tokens: list[int],
     ) -> None:
         if not grammar_req_ids:
             return
 
-        # Asynchronously copy the bitmask to GPU.
+        source_indices, mapping = _build_grammar_row_mapping(
+            input_batch.req_ids,
+            grammar_req_ids,
+            grammar_num_spec_tokens,
+            input_batch.cu_num_logits_np,
+            input_batch.num_draft_tokens_per_req,
+            self.num_bonus_tokens,
+        )
+        expected_source_rows = sum(
+            num_drafts + self.num_bonus_tokens for num_drafts in grammar_num_spec_tokens
+        )
+        assert grammar_bitmask.shape[0] == expected_source_rows
+        grammar_bitmask = grammar_bitmask[source_indices]
+
+        # Asynchronously copy the active bitmask rows to GPU.
         with torch.cuda.stream(self.copy_stream):
             bitmask = async_copy_to_gpu(
                 grammar_bitmask, out=self.grammar_bitmask[: grammar_bitmask.shape[0]]
             )
-
-        # Construct bitmask -> logits mapping
-        mapping: list[int] = []
-        req_ids = input_batch.req_ids
-        cu_num_logits = input_batch.cu_num_logits_np.tolist()
-        req_id_to_idx = {req_id: i for i, req_id in enumerate(req_ids)}
-        for grammar_req_id in grammar_req_ids:
-            req_idx = req_id_to_idx[grammar_req_id]
-            logits_start_idx = cu_num_logits[req_idx]
-            logits_end_idx = cu_num_logits[req_idx + 1]
-            mapping.extend(range(logits_start_idx, logits_end_idx))
 
         # Asynchronously copy the mapping to GPU.
         with torch.cuda.stream(self.copy_stream):

--- a/vllm/v1/worker/gpu/structured_outputs.py
+++ b/vllm/v1/worker/gpu/structured_outputs.py
@@ -13,12 +13,17 @@ def _build_grammar_row_mapping(
     req_ids: list[str],
     grammar_req_ids: list[str],
     grammar_num_spec_tokens: list[int],
+    grammar_has_bonus_token: list[bool],
     cu_num_logits_np: np.ndarray,
     num_draft_tokens_per_req: np.ndarray | None,
     num_bonus_tokens: int,
 ) -> tuple[list[int], list[int]]:
     """Map serialized grammar rows to the active compact logits layout."""
-    assert len(grammar_req_ids) == len(grammar_num_spec_tokens)
+    assert (
+        len(grammar_req_ids)
+        == len(grammar_num_spec_tokens)
+        == len(grammar_has_bonus_token)
+    )
     assert num_bonus_tokens in (0, 1)
 
     req_id_to_idx = {req_id: i for i, req_id in enumerate(req_ids)}
@@ -26,9 +31,10 @@ def _build_grammar_row_mapping(
     logits_indices: list[int] = []
     source_offset = 0
 
-    for grammar_req_id, num_source_drafts in zip(
+    for grammar_req_id, num_source_drafts, has_source_bonus_token in zip(
         grammar_req_ids,
         grammar_num_spec_tokens,
+        grammar_has_bonus_token,
         strict=True,
     ):
         req_idx = req_id_to_idx[grammar_req_id]
@@ -48,10 +54,11 @@ def _build_grammar_row_mapping(
         source_indices.extend(range(source_offset, source_offset + num_active_drafts))
         logits_indices.extend(range(logits_start, logits_start + num_active_drafts))
         if num_bonus_tokens:
+            assert has_source_bonus_token
             source_indices.append(source_offset + num_source_drafts)
             logits_indices.append(logits_start + num_active_drafts)
 
-        source_offset += num_source_drafts + num_bonus_tokens
+        source_offset += num_source_drafts + int(has_source_bonus_token)
 
     return source_indices, logits_indices
 
@@ -81,6 +88,7 @@ class StructuredOutputsWorker:
         grammar_req_ids: list[str],
         grammar_bitmask: np.ndarray,
         grammar_num_spec_tokens: list[int],
+        grammar_has_bonus_token: list[bool],
     ) -> None:
         if not grammar_req_ids:
             return
@@ -89,12 +97,16 @@ class StructuredOutputsWorker:
             input_batch.req_ids,
             grammar_req_ids,
             grammar_num_spec_tokens,
+            grammar_has_bonus_token,
             input_batch.cu_num_logits_np,
             input_batch.num_draft_tokens_per_req,
             self.num_bonus_tokens,
         )
         expected_source_rows = sum(
-            num_drafts + self.num_bonus_tokens for num_drafts in grammar_num_spec_tokens
+            num_drafts + int(has_bonus_token)
+            for num_drafts, has_bonus_token in zip(
+                grammar_num_spec_tokens, grammar_has_bonus_token, strict=True
+            )
         )
         assert grammar_bitmask.shape[0] == expected_source_rows
         grammar_bitmask = grammar_bitmask[source_indices]

--- a/vllm/v1/worker/gpu/warmup.py
+++ b/vllm/v1/worker/gpu/warmup.py
@@ -367,7 +367,9 @@ def warmup_kernels(
                 (len(req_ids), bitmask_width), fill_value=-1, dtype=np.int32
             )
             grammar_output = GrammarOutput(
-                structured_output_request_ids=req_ids, grammar_bitmask=grammar_bitmask
+                structured_output_request_ids=req_ids,
+                grammar_bitmask=grammar_bitmask,
+                num_spec_tokens=[0] * len(req_ids),
             )
 
         worker_sample_tokens(grammar_output)

--- a/vllm/v1/worker/gpu/warmup.py
+++ b/vllm/v1/worker/gpu/warmup.py
@@ -370,6 +370,7 @@ def warmup_kernels(
                 structured_output_request_ids=req_ids,
                 grammar_bitmask=grammar_bitmask,
                 num_spec_tokens=[0] * len(req_ids),
+                has_bonus_token=[True] * len(req_ids),
                 num_invalid_spec_tokens=[0] * len(req_ids),
             )
 

--- a/vllm/v1/worker/gpu/warmup.py
+++ b/vllm/v1/worker/gpu/warmup.py
@@ -370,6 +370,7 @@ def warmup_kernels(
                 structured_output_request_ids=req_ids,
                 grammar_bitmask=grammar_bitmask,
                 num_spec_tokens=[0] * len(req_ids),
+                num_invalid_spec_tokens=[0] * len(req_ids),
             )
 
         worker_sample_tokens(grammar_output)

--- a/vllm/v1/worker/gpu/warmup.py
+++ b/vllm/v1/worker/gpu/warmup.py
@@ -583,6 +583,7 @@ def _profile_sps_curve(
         if sps_debug:
             events = model_runner._sps_debug_events
             model_runner._sps_debug_events = None
+            assert events is not None
             # Skip the warmup iters; report mean verify/draft GPU ms.
             timed = events[warmup_iters:]
             if timed:

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -256,6 +256,19 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 
+def _project_invalid_draft_suffix_count(
+    source_width: int,
+    source_invalid: int,
+    active_width: int,
+) -> int:
+    """Project a serialized invalid suffix onto the worker's compact width."""
+    if not 0 <= source_invalid <= source_width:
+        raise ValueError("invalid draft count is outside its source width")
+    if not 0 <= active_width <= source_width:
+        raise ValueError("active draft width is outside its source width")
+    return max(active_width - (source_width - source_invalid), 0)
+
+
 def _get_parameter_for_reload(model: nn.Module, name: str) -> nn.Parameter:
     """Resolve checkpoint names without changing the model's module tree."""
     module_name, _, parameter_name = name.rpartition(".")
@@ -3792,6 +3805,7 @@ class GPUModelRunner(
         self,
         logits: torch.Tensor | None,
         spec_decode_metadata: SpecDecodeMetadata | None,
+        num_invalid_draft_tokens: list[int] | None = None,
     ) -> SamplerOutput:
         # Sample the next token and get logprobs if needed.
         sampling_metadata = self.input_batch.sampling_metadata
@@ -3816,8 +3830,54 @@ class GPUModelRunner(
             draft_probs,
             logits,
             sampling_metadata,
+            num_invalid_draft_tokens,
         )
         return sampler_output
+
+    def _get_invalid_draft_counts(
+        self,
+        grammar_output: "GrammarOutput | None",
+        spec_decode_metadata: SpecDecodeMetadata | None,
+    ) -> list[int] | None:
+        """Translate scheduler grammar rejections to worker batch order."""
+        if grammar_output is None or spec_decode_metadata is None:
+            return None
+        if grammar_output.num_invalid_spec_tokens is None:
+            raise ValueError(
+                "structured speculative batch is missing invalid draft counts"
+            )
+
+        request_ids = grammar_output.structured_output_request_ids
+        source_widths = grammar_output.num_spec_tokens
+        invalid_source_widths = grammar_output.num_invalid_spec_tokens
+        if not (len(request_ids) == len(source_widths) == len(invalid_source_widths)):
+            raise ValueError("grammar rejection counts must align with request ids")
+
+        invalid_by_request = dict(
+            zip(
+                request_ids,
+                zip(source_widths, invalid_source_widths, strict=True),
+                strict=True,
+            )
+        )
+        if len(invalid_by_request) != len(request_ids):
+            raise ValueError("grammar rejection counts contain duplicate request ids")
+
+        invalid_counts = []
+        for request_id, active_width in zip(
+            self.input_batch.req_ids,
+            spec_decode_metadata.num_draft_tokens,
+            strict=True,
+        ):
+            source_width, source_invalid = invalid_by_request.get(
+                request_id, (active_width, 0)
+            )
+            invalid_counts.append(
+                _project_invalid_draft_suffix_count(
+                    source_width, source_invalid, active_width
+                )
+            )
+        return invalid_counts if any(invalid_counts) else None
 
     def _bookkeeping_sync(
         self,
@@ -4745,8 +4805,13 @@ class GPUModelRunner(
                 scheduler_output, grammar_output, self.input_batch, logits
             )
 
+        num_invalid_draft_tokens = self._get_invalid_draft_counts(
+            grammar_output, spec_decode_metadata
+        )
         with record_function_or_nullcontext("gpu_model_runner: sample"):
-            sampler_output = self._sample(logits, spec_decode_metadata)
+            sampler_output = self._sample(
+                logits, spec_decode_metadata, num_invalid_draft_tokens
+            )
 
         self._update_states_after_model_execute(
             sampler_output.sampled_token_ids, scheduler_output


### PR DESCRIPTION
Follow-up to #294. #294 preserves the source width of grammar bitmasks after draft trimming; this change closes the remaining acceptance race by carrying grammar-invalid trailing-draft counts to the active rejection sampler.

The V2 runner maps source counts onto its compacted/reordered worker batch and forces only the invalid suffix to reject against grammar-masked target logits. The V1 compatibility runner receives the same treatment and additionally zeros forced-reject draft-probability rows so residual recovery samples from the target distribution.

Safety: missing or inconsistent structured speculative metadata fails closed. Warmup sends explicit zero counts.

Focused CPU tests: 37 passed; Ruff and mypy passed. CUDA/model qualification remains required before merge.

Prepared with AI assistance; please review the full diff and CI/model evaluation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved structured-output support during speculative decoding, including correct handling of draft and bonus tokens.
  * Invalid grammar-constrained draft suffixes are now rejected and safely resampled from the target distribution.
  * Improved consistency of grammar masking and token validation when requests use different speculative-token counts.
  * Added validation for malformed or mismatched speculative-decoding metadata to prevent incorrect sampling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->