### PR TITLE
fix(dspark): repair unaligned local prefix-cache restores

### DIFF
--- a/tests/v1/core/test_dspark_prefix_repair.py
+++ b/tests/v1/core/test_dspark_prefix_repair.py
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for the DSpark block-unaligned prefix repair.
+
+A local prefix-cache hit whose token count is not block-aligned restores
+tokens that never flowed through the target forward, so DFlash/DSpark draft
+KV does not exist for them and drafting fail-closes for the whole batch.
+The repair adopts only the block-aligned region and lets the residual tail
+prefill normally. These tests cover the scheduler-side clamp, its counters
+and its gating.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm.v1.core.kv_cache_manager import KVCacheBlocks
+
+from .utils import create_scheduler
+
+
+def _scheduler(speculative_method: str | None):
+    scheduler = create_scheduler(enable_prefix_caching=True, block_size=16)
+    if speculative_method is not None:
+        scheduler.vllm_config.speculative_config = SimpleNamespace(
+            method=speculative_method
+        )
+    return scheduler
+
+
+def _make_manager_stub(scheduler):
+    calls = []
+
+    def truncate_computed_blocks(blocks, num_computed_tokens):
+        calls.append(num_computed_tokens)
+        return blocks
+
+    manager = SimpleNamespace(
+        coordinator=scheduler.kv_cache_manager.coordinator,
+        truncate_computed_blocks=truncate_computed_blocks,
+    )
+    return manager, calls
+
+
+def _blocks():
+    return KVCacheBlocks(tuple())
+
+
+@pytest.mark.parametrize("speculative_method", ["dspark", "dflash"])
+def test_unaligned_hit_is_repaired_for_draft_speculation(speculative_method: str):
+    scheduler = _scheduler(speculative_method)
+    manager, truncate_calls = _make_manager_stub(scheduler)
+    scheduler.kv_cache_manager = manager
+
+    blocks, aligned, partial_tail = scheduler._repair_unaligned_dspark_prefix(
+        _blocks(), 33
+    )
+
+    assert aligned == 32
+    assert partial_tail == 1
+    assert truncate_calls == [32]
+    assert scheduler.num_dspark_prefix_repairs == 1
+    assert scheduler.num_dspark_prefix_repair_tokens == 1
+
+
+def test_aligned_hit_is_untouched_for_dspark():
+    scheduler = _scheduler("dspark")
+    manager, truncate_calls = _make_manager_stub(scheduler)
+    scheduler.kv_cache_manager = manager
+
+    blocks, aligned, partial_tail = scheduler._repair_unaligned_dspark_prefix(
+        _blocks(), 48
+    )
+
+    assert aligned == 48
+    assert partial_tail == 0
+    assert truncate_calls == []
+    assert scheduler.num_dspark_prefix_repairs == 0
+    assert scheduler.num_dspark_prefix_repair_tokens == 0
+
+
+@pytest.mark.parametrize("speculative_method", [None, "eagle"])
+def test_no_repair_without_supported_speculation(speculative_method: str | None):
+    scheduler = _scheduler(speculative_method)
+    manager, truncate_calls = _make_manager_stub(scheduler)
+    scheduler.kv_cache_manager = manager
+
+    blocks, aligned, partial_tail = scheduler._repair_unaligned_dspark_prefix(
+        _blocks(), 33
+    )
+
+    assert aligned == 33
+    assert partial_tail == 0
+    assert truncate_calls == []
+    assert scheduler.num_dspark_prefix_repairs == 0
+
+
+def test_no_repair_when_connector_present():
+    scheduler = _scheduler("dspark")
+    manager, truncate_calls = _make_manager_stub(scheduler)
+    scheduler.kv_cache_manager = manager
+    scheduler.connector = SimpleNamespace()
+
+    blocks, aligned, partial_tail = scheduler._repair_unaligned_dspark_prefix(
+        _blocks(), 33
+    )
+
+    assert aligned == 33
+    assert partial_tail == 0
+    assert truncate_calls == []
+    assert scheduler.num_dspark_prefix_repairs == 0
+
+
+@pytest.mark.parametrize(
+    "unsupported_mode",
+    ["dcp", "mamba_align", "partial_hash", "multiple_full_attention"],
+)
+def test_repair_preserves_excluded_cache_topologies(unsupported_mode: str):
+    scheduler = _scheduler("dspark")
+    manager, truncate_calls = _make_manager_stub(scheduler)
+    scheduler.kv_cache_manager = manager
+
+    if unsupported_mode == "dcp":
+        scheduler.dcp_world_size = 2
+    elif unsupported_mode == "mamba_align":
+        scheduler.need_mamba_block_aligned_split = True
+    elif unsupported_mode == "partial_hash":
+        manager.coordinator.enable_partial_hash_hits = True
+    else:
+        group = scheduler.kv_cache_config.kv_cache_groups[0]
+        scheduler.kv_cache_config = SimpleNamespace(kv_cache_groups=[group, group])
+
+    original_blocks = _blocks()
+    blocks, aligned, partial_tail = scheduler._repair_unaligned_dspark_prefix(
+        original_blocks, 33
+    )
+
+    assert blocks is original_blocks
+    assert aligned == 33
+    assert partial_tail == 0
+    assert truncate_calls == []
+    assert scheduler.num_dspark_prefix_repairs == 0

--- a/tests/v1/core/test_dspark_prefix_repair_integration.py
+++ b/tests/v1/core/test_dspark_prefix_repair_integration.py
@@ -1,0 +1,327 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Integration tests for the DSpark block-unaligned prefix repair.
+
+A local prefix-cache hit whose token count is not block-aligned restores
+tokens that never flowed through the target forward, so DFlash/DSpark draft
+KV does not exist for them and drafting fail-closes for the whole batch.
+The repair adopts only the block-aligned region and lets the residual tail
+prefill normally, so the batch never reaches the fail-closed path.
+
+The four-group tests model the DeepSeek-V4 hybrid geometry (full-attention
+256 plus sliding-window 64, 4 and 8 token blocks). ``enable_partial_hash_hits``
+is False without a Mamba ``align`` group, so ordinary lookups in this geometry
+are 256-aligned and never exercise the repair; the tests therefore present the
+257-token lookup directly at the cache-manager boundary and drive the real
+admission and ``truncate_computed_blocks`` primitives. The truncated
+per-group block lists must equal exactly what a normal 256-aligned admission
+would adopt (1, 4, 64 and 32 blocks), which is why 256 is a valid clamp
+endpoint here: it is divisible by every group block size.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from tests.v1.core.test_prefix_caching import make_kv_cache_manager
+from vllm.utils.hashing import sha256
+from vllm.v1.core.kv_cache_utils import init_none_hash
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+    SlidingWindowSpec,
+)
+from vllm.v1.outputs import ModelRunnerOutput
+
+from .utils import create_requests, create_scheduler
+
+
+@pytest.fixture(autouse=True)
+def _auto_init_hash_fn():
+    init_none_hash(sha256)
+
+
+def _make_dspark_scheduler(async_scheduling: bool):
+    scheduler = create_scheduler(
+        enable_prefix_caching=True,
+        block_size=256,
+        async_scheduling=async_scheduling,
+    )
+    scheduler.vllm_config.speculative_config = SimpleNamespace(method="dspark")
+    return scheduler
+
+
+def _stub_unaligned_hit(scheduler, monkeypatch, hit_tokens: int):
+    """Let the cache lookup report an unaligned hit of hit_tokens.
+
+    The blocks are real blocks from the block pool (2 blocks cover
+    hit_tokens <= 512); truncate_computed_blocks and allocate_slots run for
+    real, so the whole admission path is exercised.
+    """
+    pool = scheduler.kv_cache_manager.block_pool
+    blocks = pool.get_new_blocks(2)
+
+    def fake_lookup(request):
+        wrapped = scheduler.kv_cache_manager.create_kv_cache_blocks(tuple([blocks]))
+        return wrapped, hit_tokens, 0
+
+    monkeypatch.setattr(scheduler.kv_cache_manager, "get_computed_blocks", fake_lookup)
+    return blocks
+
+
+@pytest.mark.parametrize("async_scheduling", [True, False])
+def test_unaligned_hit_is_clamped_during_admission(monkeypatch, async_scheduling: bool):
+    scheduler = _make_dspark_scheduler(async_scheduling)
+    request = create_requests(num_requests=1, num_tokens=300, block_size=256)[0]
+    scheduler.add_request(request)
+    _stub_unaligned_hit(scheduler, monkeypatch, 257)
+
+    output = scheduler.schedule()
+
+    new_req = output.scheduled_new_reqs[0]
+    # Aligned restored prefix; the 1-token tail prefills via num_scheduled_tokens.
+    assert new_req.num_computed_tokens == 256
+    assert output.num_scheduled_tokens[request.request_id] == 300 - 256
+    assert scheduler.num_dspark_prefix_repairs == 1
+    assert scheduler.num_dspark_prefix_repair_tokens == 1
+
+    stats = scheduler.make_stats()
+    assert stats is not None
+    assert stats.dspark_prefix_repairs == 1
+    assert stats.dspark_prefix_repair_tokens == 1
+    assert stats.dspark_prefix_suppressed_batches == 0
+    assert stats.dspark_prefix_suppressed_rows == 0
+
+
+def test_mixed_batch_repairs_only_the_unaligned_request(monkeypatch):
+    scheduler = _make_dspark_scheduler(async_scheduling=True)
+    unaligned = create_requests(num_requests=1, num_tokens=300, block_size=256)[0]
+    aligned = create_requests(
+        num_requests=1, num_tokens=300, block_size=256, req_ids=["aligned"]
+    )[0]
+    scheduler.add_request(unaligned)
+    scheduler.add_request(aligned)
+
+    pool = scheduler.kv_cache_manager.block_pool
+    blocks = pool.get_new_blocks(2)
+
+    def fake_lookup(request):
+        wrapped = scheduler.kv_cache_manager.create_kv_cache_blocks(tuple([blocks]))
+        hit = 257 if request.request_id != "aligned" else 256
+        return wrapped, hit, 0
+
+    monkeypatch.setattr(scheduler.kv_cache_manager, "get_computed_blocks", fake_lookup)
+
+    output = scheduler.schedule()
+
+    by_id = {r.req_id: r for r in output.scheduled_new_reqs}
+    assert by_id["aligned"].num_computed_tokens == 256
+    assert by_id["0"].num_computed_tokens == 256
+    assert scheduler.num_dspark_prefix_repairs == 1
+    assert scheduler.num_dspark_prefix_repair_tokens == 1
+
+
+def test_aligned_hit_is_untouched(monkeypatch):
+    scheduler = _make_dspark_scheduler(async_scheduling=False)
+    request = create_requests(num_requests=1, num_tokens=300, block_size=256)[0]
+    scheduler.add_request(request)
+    _stub_unaligned_hit(scheduler, monkeypatch, 256)
+
+    output = scheduler.schedule()
+
+    assert output.scheduled_new_reqs[0].num_computed_tokens == 256
+    assert scheduler.num_dspark_prefix_repairs == 0
+    assert scheduler.num_dspark_prefix_repair_tokens == 0
+
+
+def test_worker_suppression_counters_flow_into_scheduler_stats():
+    scheduler = _make_dspark_scheduler(async_scheduling=False)
+    request = create_requests(num_requests=1, num_tokens=300, block_size=256)[0]
+    scheduler.add_request(request)
+    scheduler_output = scheduler.schedule()
+    req_ids = list(scheduler_output.num_scheduled_tokens)
+    model_runner_output = ModelRunnerOutput(
+        req_ids=req_ids,
+        req_id_to_index={req_id: index for index, req_id in enumerate(req_ids)},
+        sampled_token_ids=[[0] for _ in req_ids],
+        prompt_logprobs_dict={},
+        dspark_suppressed_batches=1,
+        dspark_suppressed_rows=1,
+    )
+
+    scheduler.update_from_output(scheduler_output, model_runner_output)
+
+    stats = scheduler.make_stats()
+    assert stats is not None
+    assert stats.dspark_prefix_suppressed_batches == 1
+    assert stats.dspark_prefix_suppressed_rows == 1
+
+
+# DeepSeek-V4-like hybrid geometry: full attention on 256-token blocks plus
+# three sliding-window groups on 64, 4 and 8 token blocks. The scheduler
+# block size is the LCM (256), which every group block size divides. The
+# smallest config with the same manager and divisibility invariants; the
+# real DeepSeek-V4 config only scales the head counts and dtypes.
+FOUR_GROUP_BLOCK_SIZES = (256, 64, 4, 8)
+
+
+def _four_group_kv_cache_config(num_blocks: int) -> KVCacheConfig:
+    groups = [
+        KVCacheGroupSpec(
+            ["full"],
+            FullAttentionSpec(
+                block_size=FOUR_GROUP_BLOCK_SIZES[0],
+                num_kv_heads=1,
+                head_size=1,
+                dtype=torch.float32,
+            ),
+        )
+    ]
+    for block_size in FOUR_GROUP_BLOCK_SIZES[1:]:
+        groups.append(
+            KVCacheGroupSpec(
+                [f"swa_{block_size}"],
+                SlidingWindowSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                    sliding_window=block_size,
+                ),
+            )
+        )
+    return KVCacheConfig(
+        num_blocks=num_blocks,
+        kv_cache_tensors=[],
+        kv_cache_groups=groups,
+    )
+
+
+def _four_group_manager():
+    return make_kv_cache_manager(
+        _four_group_kv_cache_config(num_blocks=2048),
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=4,
+        log_stats=True,
+    )
+
+
+def _unaligned_lookup_blocks(manager):
+    """Per-group block lists a 257-token restore input presents.
+
+    Each list covers ceil(257 / group_block_size) blocks; the sliding-window
+    groups are null-padded like a real lookup, with only the in-window tail
+    block backed by a real page. Truncating these lists at 256 tokens must
+    produce exactly the lists a normal 256-aligned admission adopts
+    (1, 4, 64 and 32 blocks).
+    """
+    pool = manager.block_pool
+    null = pool.null_block
+    return [
+        pool.get_new_blocks(2),
+        [null, null, null] + pool.get_new_blocks(2),
+        [null] * 63 + pool.get_new_blocks(2),
+        [null] * 31 + pool.get_new_blocks(2),
+    ]
+
+
+@pytest.mark.parametrize("async_scheduling", [True, False])
+def test_four_group_unaligned_hit_repairs_to_aligned_admission(
+    monkeypatch, async_scheduling: bool
+):
+    scheduler = _make_dspark_scheduler(async_scheduling)
+    manager = _four_group_manager()
+    scheduler.kv_cache_manager = manager
+    scheduler.kv_cache_config = manager.kv_cache_config
+
+    request = create_requests(num_requests=1, num_tokens=257, block_size=256)[0]
+    scheduler.add_request(request)
+
+    hit_blocks = _unaligned_lookup_blocks(manager)
+
+    def fake_lookup(request):
+        wrapped = manager.create_kv_cache_blocks(tuple(hit_blocks))
+        return wrapped, 257, 0
+
+    monkeypatch.setattr(manager, "get_computed_blocks", fake_lookup)
+
+    output = scheduler.schedule()
+
+    new_req = output.scheduled_new_reqs[0]
+    # 1. Only the 256-token block-aligned prefix is adopted.
+    assert new_req.num_computed_tokens == 256
+    # 2. The 1-token tail goes through normal target prefill.
+    assert output.num_scheduled_tokens[request.request_id] == 1
+    # 4. Exactly one repair, moving exactly one token.
+    assert scheduler.num_dspark_prefix_repairs == 1
+    assert scheduler.num_dspark_prefix_repair_tokens == 1
+    # 5. The unaligned fail-closed DSpark suppression is never reached.
+    stats = scheduler.make_stats()
+    assert stats is not None
+    assert stats.dspark_prefix_repairs == 1
+    assert stats.dspark_prefix_repair_tokens == 1
+    assert stats.dspark_prefix_suppressed_batches == 0
+    assert stats.dspark_prefix_suppressed_rows == 0
+
+
+def test_four_group_truncation_slices_every_group():
+    """The real truncation must cut every group to the aligned endpoint.
+
+    Exercises the actual ``KVCacheManager.truncate_computed_blocks`` route
+    the repair uses: pure slicing at token count 256, which is divisible by
+    all four group block sizes, and no mutation of the input lookup.
+    """
+    manager = _four_group_manager()
+    hit_blocks = _unaligned_lookup_blocks(manager)
+    blocks = manager.create_kv_cache_blocks(tuple(hit_blocks))
+
+    truncated = manager.truncate_computed_blocks(blocks, 256)
+
+    # 3. The four block lists after truncation hold exactly 1, 4, 64, 32
+    # blocks.
+    assert [len(group) for group in truncated.blocks] == [1, 4, 64, 32]
+    # Non-mutating, byte-preserving slice: same block objects, input intact.
+    assert truncated.blocks[0][0] is blocks.blocks[0][0]
+    assert truncated.blocks[1][-1] is blocks.blocks[1][3]
+    assert [len(group) for group in blocks.blocks] == [2, 5, 65, 33]
+
+
+def test_four_group_aligned_hit_is_untouched(monkeypatch):
+    """A 256-aligned hit stays byte- and behavior-equivalent to the base."""
+    scheduler = _make_dspark_scheduler(async_scheduling=True)
+    manager = _four_group_manager()
+    scheduler.kv_cache_manager = manager
+    scheduler.kv_cache_config = manager.kv_cache_config
+
+    request = create_requests(num_requests=1, num_tokens=257, block_size=256)[0]
+    scheduler.add_request(request)
+
+    pool = manager.block_pool
+    null = pool.null_block
+    aligned_blocks = [
+        pool.get_new_blocks(1),
+        [null, null, null] + pool.get_new_blocks(1),
+        [null] * 63 + pool.get_new_blocks(1),
+        [null] * 31 + pool.get_new_blocks(1),
+    ]
+
+    def fake_lookup(request):
+        wrapped = manager.create_kv_cache_blocks(tuple(aligned_blocks))
+        return wrapped, 256, 0
+
+    monkeypatch.setattr(manager, "get_computed_blocks", fake_lookup)
+
+    output = scheduler.schedule()
+
+    new_req = output.scheduled_new_reqs[0]
+    assert new_req.num_computed_tokens == 256
+    assert output.num_scheduled_tokens[request.request_id] == 1
+    assert scheduler.num_dspark_prefix_repairs == 0
+    assert scheduler.num_dspark_prefix_repair_tokens == 0
+    # The aligned lookup lists are adopted unchanged: the request's first
+    # full-attention block is the exact block the lookup returned.
+    adopted = manager.get_block_ids(request.request_id)[0]
+    assert adopted[0] == aligned_blocks[0][0].block_id

--- a/tests/v1/metrics/test_loggers.py
+++ b/tests/v1/metrics/test_loggers.py
@@ -2,10 +2,10 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from types import SimpleNamespace
 from typing import cast
-from unittest.mock import Mock
+from unittest.mock import Mock, call
 
 from vllm.config import VllmConfig
-from vllm.v1.metrics.loggers import LoggingStatLogger
+from vllm.v1.metrics.loggers import LoggingStatLogger, PrometheusStatLogger
 from vllm.v1.metrics.stats import IterationStats, PrefillStats, SchedulerStats
 from vllm.v1.spec_decode.metrics import SpecDecodingLogging, SpecDecodingStats
 
@@ -70,3 +70,60 @@ def test_spec_decoding_log_reports_current_speculative_depth():
     message = log_args[0] % log_args[1:]
     assert "Mean acceptance length: 2.00" in message
     assert "Current speculative depth: 2" in message
+
+
+def test_prometheus_dspark_prefix_metrics_use_cumulative_deltas():
+    logger = object.__new__(PrometheusStatLogger)
+    logger._last_dspark_prefix_repairs = {}
+    logger._last_dspark_prefix_repair_tokens = {}
+    logger.counter_dspark_prefix_repairs = {0: Mock()}
+    logger.counter_dspark_prefix_repair_tokens = {0: Mock()}
+    logger.gauge_dspark_prefix_suppressed_batches = {0: Mock()}
+    logger.gauge_dspark_prefix_suppressed_rows = {0: Mock()}
+
+    logger._record_dspark_prefix_metrics(
+        SchedulerStats(
+            dspark_prefix_repairs=1,
+            dspark_prefix_repair_tokens=2,
+            dspark_prefix_suppressed_batches=3,
+            dspark_prefix_suppressed_rows=4,
+        ),
+        engine_idx=0,
+    )
+    logger._record_dspark_prefix_metrics(
+        SchedulerStats(
+            dspark_prefix_repairs=1,
+            dspark_prefix_repair_tokens=2,
+            dspark_prefix_suppressed_batches=3,
+            dspark_prefix_suppressed_rows=4,
+        ),
+        engine_idx=0,
+    )
+    logger._record_dspark_prefix_metrics(
+        SchedulerStats(
+            dspark_prefix_repairs=2,
+            dspark_prefix_repair_tokens=5,
+            dspark_prefix_suppressed_batches=6,
+            dspark_prefix_suppressed_rows=8,
+        ),
+        engine_idx=0,
+    )
+
+    assert logger.counter_dspark_prefix_repairs[0].inc.call_args_list == [
+        call(1),
+        call(1),
+    ]
+    assert logger.counter_dspark_prefix_repair_tokens[0].inc.call_args_list == [
+        call(2),
+        call(3),
+    ]
+    assert logger.gauge_dspark_prefix_suppressed_batches[0].set.call_args_list == [
+        call(3),
+        call(3),
+        call(6),
+    ]
+    assert logger.gauge_dspark_prefix_suppressed_rows[0].set.call_args_list == [
+        call(4),
+        call(4),
+        call(8),
+    ]

--- a/tests/v1/spec_decode/test_async_draft_output.py
+++ b/tests/v1/spec_decode/test_async_draft_output.py
@@ -9,7 +9,7 @@ from vllm.v1.outputs import ModelRunnerOutput
 from vllm.v1.worker.gpu.async_utils import AsyncOutput
 
 
-def test_async_output_returns_draft_ids_on_same_event() -> None:
+def _make_async_output() -> AsyncOutput:
     output = object.__new__(AsyncOutput)
     output.copy_event_recorded = True
     output.copy_event = SimpleNamespace(synchronize=lambda: None)
@@ -23,6 +23,13 @@ def test_async_output_returns_draft_ids_on_same_event() -> None:
     output.model_runner_output = ModelRunnerOutput(
         req_ids=["req-0"], req_id_to_index={"req-0": 0}
     )
+    output.draft_req_ids = None
+    output.draft_token_ids_np = None
+    return output
+
+
+def test_async_output_returns_draft_ids_on_same_event() -> None:
+    output = _make_async_output()
     output.draft_req_ids = ["req-0"]
     output.draft_token_ids_np = np.array([[11, 12, -1]], dtype=np.int32)
 
@@ -32,3 +39,14 @@ def test_async_output_returns_draft_ids_on_same_event() -> None:
     assert model_output.draft_token_ids is not None
     assert model_output.draft_token_ids.req_ids == ["req-0"]
     assert model_output.draft_token_ids.draft_token_ids == [[11, 12]]
+
+
+def test_async_output_returns_counters_mutated_after_construction() -> None:
+    output = _make_async_output()
+    output.model_runner_output.dspark_suppressed_batches = 1
+    output.model_runner_output.dspark_suppressed_rows = 2
+
+    model_output = output.get_output()
+
+    assert model_output.dspark_suppressed_batches == 1
+    assert model_output.dspark_suppressed_rows == 2

--- a/tests/v1/spec_decode/test_dflash_prefix_cache_masking.py
+++ b/tests/v1/spec_decode/test_dflash_prefix_cache_masking.py
@@ -48,6 +48,51 @@ def test_unaligned_cached_prefix_detection():
     assert DFlashSpeculator._has_unaligned_cached_prefix(speculator, unaligned)
 
 
+@pytest.mark.parametrize("num_cached", [31, 33, 47, 49])
+def test_unaligned_detection_single_request(num_cached: int):
+    speculator = SimpleNamespace(
+        num_cached_tokens_np=np.array([num_cached], dtype=np.int32),
+        block_tables=SimpleNamespace(kernel_block_sizes=[16]),
+    )
+    batch = SimpleNamespace(
+        idx_mapping_np=np.array([0], dtype=np.int32),
+        num_reqs=1,
+    )
+    assert DFlashSpeculator._has_unaligned_cached_prefix(speculator, batch)
+
+
+@pytest.mark.parametrize("num_cached", [32, 48])
+def test_aligned_detection_single_request(num_cached: int):
+    speculator = SimpleNamespace(
+        num_cached_tokens_np=np.array([num_cached], dtype=np.int32),
+        block_tables=SimpleNamespace(kernel_block_sizes=[16]),
+    )
+    batch = SimpleNamespace(
+        idx_mapping_np=np.array([0], dtype=np.int32),
+        num_reqs=1,
+    )
+    assert not DFlashSpeculator._has_unaligned_cached_prefix(speculator, batch)
+
+
+@pytest.mark.parametrize(
+    "cached_counts,expected",
+    [
+        (np.array([32, 35], dtype=np.int32), True),
+        (np.array([32, 48], dtype=np.int32), False),
+    ],
+)
+def test_unaligned_detection_mixed_batch(cached_counts, expected: bool):
+    speculator = SimpleNamespace(
+        num_cached_tokens_np=cached_counts,
+        block_tables=SimpleNamespace(kernel_block_sizes=[16]),
+    )
+    batch = SimpleNamespace(
+        idx_mapping_np=np.arange(2, dtype=np.int32),
+        num_reqs=2,
+    )
+    assert DFlashSpeculator._has_unaligned_cached_prefix(speculator, batch) is expected
+
+
 def _make_block_table(num_reqs: int) -> torch.Tensor:
     # Distinct block ids per (request, slot) so shifts are detectable.
     table = torch.arange(
@@ -63,6 +108,12 @@ def _make_block_table(num_reqs: int) -> torch.Tensor:
         (BLOCK_SIZE * 3, 3),  # block-aligned hit (the common APC case)
         (BLOCK_SIZE * 3 + 5, 3),  # unaligned: floor to whole blocks
         (BLOCK_SIZE - 1, 0),  # less than one block: no-op
+        (BLOCK_SIZE * 2 - 1, 1),  # 31: floor 1 block
+        (BLOCK_SIZE * 2, 2),  # 32: aligned
+        (BLOCK_SIZE * 2 + 1, 2),  # 33: floor 2 blocks
+        (BLOCK_SIZE * 3 - 1, 2),  # 47: floor 2 blocks
+        (BLOCK_SIZE * 3, 3),  # 48: aligned
+        (BLOCK_SIZE * 3 + 1, 3),  # 49: floor 3 blocks
     ],
 )
 def test_shift_single_request(num_cached: int, expected_shift: int):
@@ -117,6 +168,36 @@ def test_shift_per_request_and_idx_mapping():
             block_table[batch_idx, :kept],
             original[batch_idx, shift:],
             msg=f"batch row {batch_idx} (slot {shift})",
+        )
+
+
+def test_shift_mixed_aligned_unaligned_batch():
+    # A mixed 32+35-token batch: both rows floor to a 2-block shift (the
+    # residual 3 tokens of the unaligned request are hidden by the repaired
+    # scheduler admission, never by the block-table shift).
+    num_reqs = 2
+    block_table = _make_block_table(num_reqs)
+    original = block_table.clone()
+    idx_mapping = torch.tensor([1, 0], dtype=torch.int32, device=DEVICE)
+    num_cached_tokens = torch.zeros(MAX_NUM_REQS, dtype=torch.int32, device=DEVICE)
+    num_cached_tokens[:2] = torch.tensor([35, 32], dtype=torch.int32, device=DEVICE)
+
+    seq_lens = torch.full(
+        (num_reqs,),
+        MAX_BLOCKS * BLOCK_SIZE,
+        dtype=torch.int32,
+        device=DEVICE,
+    )
+    shift_draft_block_tables(
+        block_table, idx_mapping, num_cached_tokens, seq_lens, BLOCK_SIZE
+    )
+
+    for batch_idx in range(num_reqs):
+        kept = MAX_BLOCKS - 2
+        torch.testing.assert_close(
+            block_table[batch_idx, :kept],
+            original[batch_idx, 2:],
+            msg=f"batch row {batch_idx}",
         )
 
 

--- a/tests/v1/worker/test_gpu_warmup_blocks.py
+++ b/tests/v1/worker/test_gpu_warmup_blocks.py
@@ -88,6 +88,9 @@ def _make_runner(
         kv_cache_config=SimpleNamespace(
             kv_cache_groups=kv_cache_groups, num_blocks=1024
         ),
+        cache_config=SimpleNamespace(block_size=BLOCK_SIZE),
+        verification_capacity_manager=None,
+        speculator=None,
         vllm_config=SimpleNamespace(num_lookahead_tokens=num_lookahead_tokens),
         kv_block_zeroer=None,
         kv_connector=SimpleNamespace(set_disabled=lambda disabled: None),

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -54,7 +54,7 @@ from vllm.v1.core.sched.request_queue import (
 )
 from vllm.v1.core.sched.utils import check_stop, remove_all
 from vllm.v1.engine import EngineCoreEventType, EngineCoreOutput, EngineCoreOutputs
-from vllm.v1.kv_cache_interface import KVCacheConfig, MambaSpec
+from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheConfig, MambaSpec
 from vllm.v1.metrics.perf import ModelMetrics, PerfStats
 from vllm.v1.metrics.stats import PrefixCacheStats, SchedulerStats
 from vllm.v1.outputs import DraftTokenIds, KVConnectorOutput, ModelRunnerOutput
@@ -178,6 +178,18 @@ class Scheduler(SchedulerInterface):
         self.block_size = block_size
         self.dcp_world_size = vllm_config.parallel_config.decode_context_parallel_size
         self.pcp_world_size = vllm_config.parallel_config.prefill_context_parallel_size
+
+        # DSpark prefix-repair accounting. When a cache lookup
+        # restores a block-unaligned prefix, only the block-aligned region is
+        # adopted and the tail prefills through the target so the draft KV
+        # becomes valid (otherwise DFlash/DSpark drafting fail-closes for the
+        # whole batch).
+        self.num_dspark_prefix_repairs = 0
+        self.num_dspark_prefix_repair_tokens = 0
+        # Worker-reported cumulative suppression counters,
+        # refreshed from the model runner output and exported via SchedulerStats.
+        self._dspark_suppressed_batches = 0
+        self._dspark_suppressed_rows = 0
 
         # req_id -> Request
         self.requests: dict[str, Request] = {}
@@ -479,6 +491,83 @@ class Scheduler(SchedulerInterface):
             self.kv_cache_manager.get_computed_blocks(request)
         )
         return blocks, num_local, shared_prefix_boundary, False
+
+    def _repair_unaligned_dspark_prefix_enabled(self) -> bool:
+        """Whether local prefix-cache hits must be repaired for DSpark.
+
+        DFlash/DSpark derive their draft KV from target hidden states, so
+        tokens restored from the prefix cache never have draft KV. A
+        block-unaligned restored prefix cannot be hidden by the draft
+        block-table shift and currently fail-closes drafting for the whole
+        batch. Only the speculators with this property need the repair.
+        """
+        speculative_config = self.vllm_config.speculative_config
+        if (
+            speculative_config is None
+            or speculative_config.method not in ("dspark", "dflash")
+            or self.connector is not None
+            or self.dcp_world_size != 1
+            or self.need_mamba_block_aligned_split
+            or getattr(
+                self.kv_cache_manager.coordinator, "enable_partial_hash_hits", False
+            )
+        ):
+            return False
+
+        groups = self.kv_cache_config.kv_cache_groups
+        if (
+            sum(isinstance(group.kv_cache_spec, FullAttentionSpec) for group in groups)
+            != 1
+        ):
+            return False
+
+        return all(
+            self.block_size % manager.block_size == 0
+            for manager in self.kv_cache_manager.coordinator.single_type_managers
+        )
+
+    def _repair_unaligned_dspark_prefix(
+        self, blocks: KVCacheBlocks, num_local_computed_tokens: int
+    ) -> tuple[KVCacheBlocks, int, int]:
+        """Clamp a block-unaligned local cache hit to its aligned prefix.
+
+        The residual tail is not adopted from the cache: it prefills through
+        the target forward so its hidden states produce valid DFlash/DSpark
+        draft KV. Without this repair a single unaligned request would
+        fail-close drafting for every aligned request in the same batch.
+
+        Args:
+            blocks: Computed-block lookup result for the request.
+            num_local_computed_tokens: Tokens restored from the local cache.
+
+        Returns:
+            (blocks, aligned_tokens, partial_tail): the truncated lookup
+            result, the aligned restored-token count, and the tail length
+            (0 when no repair was needed or applied).
+        """
+        if not self._repair_unaligned_dspark_prefix_enabled():
+            return blocks, num_local_computed_tokens, 0
+        partial_tail = num_local_computed_tokens % self.block_size
+        if partial_tail == 0:
+            return blocks, num_local_computed_tokens, 0
+        blocks = self.kv_cache_manager.truncate_computed_blocks(
+            blocks, num_local_computed_tokens - partial_tail
+        )
+        num_local_computed_tokens -= partial_tail
+        self.num_dspark_prefix_repairs += 1
+        self.num_dspark_prefix_repair_tokens += partial_tail
+        if self.num_dspark_prefix_repairs % 100 == 1:
+            logger.info(
+                "DSpark prefix repair: restored %d of %d cached tokens "
+                "(block-aligned) and the %d-token tail prefills normally "
+                "(repairs=%d, repair_tokens=%d).",
+                num_local_computed_tokens,
+                num_local_computed_tokens + partial_tail,
+                partial_tail,
+                self.num_dspark_prefix_repairs,
+                self.num_dspark_prefix_repair_tokens,
+            )
+        return blocks, num_local_computed_tokens, partial_tail
 
     def schedule(self, throttle_prefills: bool = False) -> SchedulerOutput:
         self.current_step += 1
@@ -806,6 +895,22 @@ class Scheduler(SchedulerInterface):
                         request.shared_prefix_boundary,
                         hit_diverged,
                     ) = self._get_local_prefix_cache_hit(request)
+
+                    # Repair a block-unaligned restored prefix
+                    # for DSpark. Adopt only the block-aligned region and let
+                    # the residual tail prefill through the target forward so
+                    # its target hidden states produce valid draft KV. Without
+                    # this, one unaligned request fail-closes DSpark drafting
+                    # for every aligned request in the same batch. The
+                    # connector path keeps its own tail arbitration and is not
+                    # touched here.
+                    (
+                        new_computed_blocks,
+                        num_new_local_computed_tokens,
+                        _,
+                    ) = self._repair_unaligned_dspark_prefix(
+                        new_computed_blocks, num_new_local_computed_tokens
+                    )
 
                     # Get externally-cached tokens if using a KVConnector.
                     # Even when reads are disabled, call the connector so it
@@ -1738,6 +1843,14 @@ class Scheduler(SchedulerInterface):
         num_nans_in_logits = model_runner_output.num_nans_in_logits
         kv_connector_output = model_runner_output.kv_connector_output
         ec_connector_output = model_runner_output.ec_connector_output
+
+        # Refresh the worker-reported suppression counters.
+        self._dspark_suppressed_batches = getattr(
+            model_runner_output, "dspark_suppressed_batches", 0
+        )
+        self._dspark_suppressed_rows = getattr(
+            model_runner_output, "dspark_suppressed_rows", 0
+        )
         cudagraph_stats = model_runner_output.cudagraph_stats
 
         # Every GPU write enqueued by this and earlier steps has completed, so it is
@@ -2653,6 +2766,10 @@ class Scheduler(SchedulerInterface):
             cudagraph_stats=cudagraph_stats,
             perf_stats=perf_stats,
             num_scheduled_prompt_tokens=num_scheduled_prompt_tokens,
+            dspark_prefix_repairs=self.num_dspark_prefix_repairs,
+            dspark_prefix_repair_tokens=self.num_dspark_prefix_repair_tokens,
+            dspark_prefix_suppressed_batches=self._dspark_suppressed_batches,
+            dspark_prefix_suppressed_rows=self._dspark_suppressed_rows,
         )
 
     def make_spec_decoding_stats(

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -536,6 +536,59 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
                 gauge_waiting_by_reason, per_engine_labelvalues_with_reason
             )
 
+        # DSpark prefix repair/suppression counters.
+        counter_dspark_prefix_repairs = self._counter_cls(
+            name="vllm:dspark_prefix_repairs_total",
+            documentation=(
+                "Requests whose block-unaligned restored prefix was repaired "
+                "for DFlash/DSpark drafting (tail prefilled through the "
+                "target)."
+            ),
+            labelnames=labelnames,
+        )
+        self.counter_dspark_prefix_repairs = create_metric_per_engine(
+            counter_dspark_prefix_repairs, per_engine_labelvalues
+        )
+        counter_dspark_prefix_repair_tokens = self._counter_cls(
+            name="vllm:dspark_prefix_repair_tokens_total",
+            documentation=(
+                "Tail tokens moved from the restored prefix to normal prefill "
+                "by the DFlash/DSpark prefix repair."
+            ),
+            labelnames=labelnames,
+        )
+        self.counter_dspark_prefix_repair_tokens = create_metric_per_engine(
+            counter_dspark_prefix_repair_tokens, per_engine_labelvalues
+        )
+        gauge_dspark_prefix_suppressed_batches = self._gauge_cls(
+            name="vllm:dspark_prefix_suppressed_batches",
+            documentation=(
+                "Cumulative batches whose DFlash/DSpark drafting was "
+                "suppressed by a block-unaligned restored prefix "
+                "(fail-closed)."
+            ),
+            multiprocess_mode="mostrecent",
+            labelnames=labelnames,
+        )
+        self.gauge_dspark_prefix_suppressed_batches = create_metric_per_engine(
+            gauge_dspark_prefix_suppressed_batches, per_engine_labelvalues
+        )
+        gauge_dspark_prefix_suppressed_rows = self._gauge_cls(
+            name="vllm:dspark_prefix_suppressed_rows",
+            documentation=(
+                "Cumulative request rows whose DFlash/DSpark drafting was "
+                "suppressed by a block-unaligned restored prefix "
+                "(fail-closed)."
+            ),
+            multiprocess_mode="mostrecent",
+            labelnames=labelnames,
+        )
+        self.gauge_dspark_prefix_suppressed_rows = create_metric_per_engine(
+            gauge_dspark_prefix_suppressed_rows, per_engine_labelvalues
+        )
+        self._last_dspark_prefix_repairs: dict[int, int] = {}
+        self._last_dspark_prefix_repair_tokens: dict[int, int] = {}
+
         gauge_engine_sleep_state = self._gauge_cls(
             name="vllm:engine_sleep_state",
             documentation=(
@@ -1101,6 +1154,34 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
             metrics_info["engine"] = str(engine_index)
             info_gauge.labels(**metrics_info).set(1)
 
+    def _record_dspark_prefix_metrics(
+        self, scheduler_stats: SchedulerStats, engine_idx: int
+    ) -> None:
+        """Record cumulative DSpark prefix-repair metrics as deltas."""
+        prev_repairs = self._last_dspark_prefix_repairs.get(engine_idx, 0)
+        if scheduler_stats.dspark_prefix_repairs > prev_repairs:
+            self.counter_dspark_prefix_repairs[engine_idx].inc(
+                scheduler_stats.dspark_prefix_repairs - prev_repairs
+            )
+        self._last_dspark_prefix_repairs[engine_idx] = (
+            scheduler_stats.dspark_prefix_repairs
+        )
+
+        prev_repair_tokens = self._last_dspark_prefix_repair_tokens.get(engine_idx, 0)
+        if scheduler_stats.dspark_prefix_repair_tokens > prev_repair_tokens:
+            self.counter_dspark_prefix_repair_tokens[engine_idx].inc(
+                scheduler_stats.dspark_prefix_repair_tokens - prev_repair_tokens
+            )
+        self._last_dspark_prefix_repair_tokens[engine_idx] = (
+            scheduler_stats.dspark_prefix_repair_tokens
+        )
+        self.gauge_dspark_prefix_suppressed_batches[engine_idx].set(
+            scheduler_stats.dspark_prefix_suppressed_batches
+        )
+        self.gauge_dspark_prefix_suppressed_rows[engine_idx].set(
+            scheduler_stats.dspark_prefix_suppressed_rows
+        )
+
     def record(
         self,
         scheduler_stats: SchedulerStats | None,
@@ -1125,6 +1206,8 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
                 scheduler_stats.num_skipped_waiting_reqs
             )
             self.gauge_kv_cache_usage[engine_idx].set(scheduler_stats.kv_cache_usage)
+
+            self._record_dspark_prefix_metrics(scheduler_stats, engine_idx)
 
             self.counter_prefix_cache_queries[engine_idx].inc(
                 scheduler_stats.prefix_cache_stats.queries

--- a/vllm/v1/metrics/stats.py
+++ b/vllm/v1/metrics/stats.py
@@ -206,6 +206,13 @@ class SchedulerStats:
     spec_decoding_stats: SpecDecodingStats | None = None
     kv_connector_stats: dict[str, Any] | None = None
 
+    # Cumulative DSpark prefix-repair and suppression counters
+    # (scheduler-side repairs + worker-reported fail-closed suppressions).
+    dspark_prefix_repairs: int = 0
+    dspark_prefix_repair_tokens: int = 0
+    dspark_prefix_suppressed_batches: int = 0
+    dspark_prefix_suppressed_rows: int = 0
+
     waiting_lora_adapters: dict[str, int] = field(default_factory=dict)
     running_lora_adapters: dict[str, int] = field(default_factory=dict)
 

--- a/vllm/v1/outputs.py
+++ b/vllm/v1/outputs.py
@@ -298,6 +298,12 @@ class ModelRunnerOutput:
     # req_id -> num_nans_in_logits
     num_nans_in_logits: dict[str, int] | None = None
 
+    # Cumulative DSpark prefix-suppression counters reported
+    # by the worker's draft speculator (block-unaligned fail-closed batches
+    # and rows). The engine core exports them as metrics.
+    dspark_suppressed_batches: int = 0
+    dspark_suppressed_rows: int = 0
+
     # information related to cudagraph execution
     cudagraph_stats: CUDAGraphStat | None = None
 

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -2249,6 +2249,15 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                     num_spec_tokens_to_schedule,
                     self.num_speculative_steps,
                 )
+                # propose() records unaligned cached-prefix suppressions. Update
+                # the shared output only after that call so async output observes
+                # the current cumulative counters rather than the prior step.
+                model_runner_output.dspark_suppressed_batches = getattr(
+                    self.speculator, "num_unaligned_prefix_suppressed_batches", 0
+                )
+                model_runner_output.dspark_suppressed_rows = getattr(
+                    self.speculator, "num_unaligned_prefix_suppressed_rows", 0
+                )
             with record_function_or_nullcontext(
                 f"vllm:v2/speculator/{phase}/store_draft_tokens"
             ):

--- a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
@@ -133,6 +133,13 @@ class DFlashSpeculator(DraftModelSpeculator):
         )
         self.num_cached_tokens_np = np.zeros(self.max_num_reqs, dtype=np.int32)
 
+        # Suppression accounting for batches that still hit the
+        # block-unaligned fail-closed path (e.g. external/connector-restored
+        # tokens). Observable counters so the fleet-level suppress ratio can be
+        # measured after the scheduler-side repair is deployed.
+        self.num_unaligned_prefix_suppressed_batches = 0
+        self.num_unaligned_prefix_suppressed_rows = 0
+
         # Per-mask-token sampling buffers. Flattened from (num_reqs, num_spec_tokens).
         max_num_sampled_tokens = self.max_num_reqs * self.num_speculative_steps
         self.sample_indices = torch.zeros(
@@ -708,11 +715,17 @@ class DFlashSpeculator(DraftModelSpeculator):
         num_reqs = input_batch.num_reqs
         num_target_tokens = input_batch.num_tokens
         if not dummy_run and self._has_unaligned_cached_prefix(input_batch):
-            logger.warning_once(
-                "DFlash/DSpark drafting is disabled for a batch containing a "
-                "block-unaligned cache-restored prefix because draft KV is "
-                "not available for the restored partial block."
-            )
+            self.num_unaligned_prefix_suppressed_batches += 1
+            self.num_unaligned_prefix_suppressed_rows += num_reqs
+            if self.num_unaligned_prefix_suppressed_batches % 100 == 1:
+                logger.warning(
+                    "DFlash/DSpark drafting is disabled for a batch containing "
+                    "a block-unaligned cache-restored prefix because draft KV "
+                    "is not available for the restored partial block. "
+                    "Suppressed so far: %d batches, %d rows.",
+                    self.num_unaligned_prefix_suppressed_batches,
+                    self.num_unaligned_prefix_suppressed_rows,
+                )
             self.draft_tokens[:num_reqs].fill_(-1)
             return self.draft_tokens[:num_reqs]
         active_num_speculative_steps = self.num_speculative_steps


### PR DESCRIPTION
## Summary

A connector-free local prefix-cache lookup can theoretically report a block-unaligned restored prefix. DFlash/DSpark cannot derive draft KV for that tail, so drafting fail-closes for the batch. This change adopts only the scheduler-block-aligned prefix and target-prefills the tail.

The change is deliberately conservative:

- DSpark/DFlash only;
- DCP=1 only;
- no Mamba-align or partial-hash-hit mode;
- exactly one full-attention group, with every cache-manager block size dividing the scheduler block size;
- connectors and excluded topologies keep their existing fail-closed behavior.

It also exports repair/suppression counters. The counter snapshot occurs after proposal, and focused regressions cover async output retention, worker-to-scheduler transport, and cumulative Prometheus deltas.

## Why this is not a duplicate

The base branch already contains the whole-block masking foundation from upstream #47926. This is an admission-side tail-repair follow-up; it does not port the broader hybrid/Mamba reconciliation work discussed in #50457. Open PR #466 is a distinct disaggregated-EAGLE target-cache policy change. The current aligned APC workload normally yields aligned hits, so this is a correctness/observability safeguard, not a measured throughput improvement.

## Validation

- CPU: `tests/v1/core/test_dspark_prefix_repair.py`, `tests/v1/core/test_dspark_prefix_repair_integration.py`, `tests/v1/spec_decode/test_async_draft_output.py`, `tests/v1/metrics/test_loggers.py`, and `tests/v1/metrics/test_stats.py` — 37 passed.
- GPU: `tests/v1/spec_decode/test_dflash_prefix_cache_masking.py` and `tests/v1/worker/test_gpu_warmup_blocks.py` — 50 passed.
- GPU: `tests/v1/worker/test_gpu_model_runner_v2_draft_capacity.py` — 27 passed.
- Ruff check, Ruff format check, and `git diff --check` passed.

## Model / serving evaluation

This patch changes only the defensive unaligned-restored-prefix path. In the current connector-free aligned APC topology that path is not reached; therefore there is no tok/s or model-quality claim. The CPU admission integration checks the 257-to-256 clamp, one-token target-prefill tail, four-group 256/64/4/8 truncation, and unchanged aligned hits. GPU suites validate the DFlash and V2 runner paths.

AI assistance was used to prepare this PR. A human owner must review all changed lines and complete normal upstream/maintainer review before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic repair for eligible unaligned cached prefixes, preserving aligned cache hits and handling mixed batches.
  * Added support for tracking suppressed batches and rows during speculative decoding.
  * Added Prometheus metrics for prefix repairs, repaired tokens, and suppression counts.
* **Bug Fixes**
  * Prevented unsupported cache configurations from being altered during prefix repair.
* **Tests**
  * Expanded coverage for synchronous and asynchronous scheduling, hybrid caches, alignment handling, and metric reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->