### PR TITLE
fix(distributed): delegate TP2 graph routing to B12X

### DIFF
--- a/serve-ds4-flash.sh
+++ b/serve-ds4-flash.sh
@@ -182,11 +182,7 @@ export VLLM_MULTI_STREAM_GEMM_TOKEN_THRESHOLD=${VLLM_MULTI_STREAM_GEMM_TOKEN_THR
 
 allreduce_mode=${ALLREDUCE_MODE:-auto}
 if [[ "${allreduce_mode}" == "auto" ]]; then
-  if [[ "${tp_size}" == "2" ]]; then
-    allreduce_mode=flashinfer-ipc
-  else
-    allreduce_mode=b12x
-  fi
+  allreduce_mode=b12x
 fi
 b12x_pcie_dma=$(bool_value B12X_PCIE_DMA "${B12X_PCIE_DMA:-0}")
 export VLLM_USE_B12X_PCIE_DMA=${b12x_pcie_dma}
@@ -195,7 +191,6 @@ case "${allreduce_mode}" in
   b12x)
     export VLLM_ENABLE_PCIE_ALLREDUCE=1
     export VLLM_PCIE_ALLREDUCE_BACKEND=b12x
-    export VLLM_PCIE_ONESHOT_ALLREDUCE_MAX_SIZE=${VLLM_PCIE_ONESHOT_ALLREDUCE_MAX_SIZE:-64KB}
     export VLLM_ALLOW_CUSTOM_ALLREDUCE_PCIE=0
     export PYTORCH_CUDA_ALLOC_CONF=${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True}
     ;;

--- a/tests/distributed/test_b12x_fused_all_reduce.py
+++ b/tests/distributed/test_b12x_fused_all_reduce.py
@@ -33,6 +33,7 @@ from vllm.distributed.device_communicators.custom_all_reduce import (
     _b12x_pcie_allreduce_max_size,
     _b12x_pcie_dma_min_bytes,
     _b12x_pcie_oneshot_limits,
+    _b12x_pcie_plain_route_generic_max_size,
     _load_b12x_pcie_recommended_max_bytes,
     get_b12x_pcie_allreduce,
 )
@@ -73,15 +74,18 @@ def make_b12x_custom_allreduce(
 ) -> tuple[CustomAllreduce, MagicMock]:
     runtime = MagicMock()
     runtime.for_stream.return_value.should_allreduce.return_value = True
+    runtime.for_stream.return_value.should_route_plain_allreduce.return_value = True
 
     custom_allreduce = object.__new__(CustomAllreduce)
     custom_allreduce.disabled = False
     custom_allreduce.world_size = world_size
     custom_allreduce._pcie_runtime = runtime
+    custom_allreduce._pcie_backend_name = "b12x"
     custom_allreduce._pcie_dma = None
     custom_allreduce._pcie_capture_stream = None
     custom_allreduce._pcie_capture_channel_id = None
     custom_allreduce._pcie_allreduce_max_size = allreduce_max_size
+    custom_allreduce._pcie_plain_route_generic_max_size = allreduce_max_size
     custom_allreduce._pcie_fused_add_rms_norm_max_size = fused_max_size
     custom_allreduce._pcie_logged_first_allreduce = False
     custom_allreduce._IS_CAPTURING = False
@@ -163,6 +167,7 @@ def test_b12x_eager_owner_fails_closed_on_second_stream_bind() -> None:
             raise RuntimeError("stream-affine logical owner rebound")
         channel = MagicMock()
         channel.should_allreduce.return_value = True
+        channel.should_route_plain_allreduce.return_value = True
         return channel
 
     runtime.for_stream.side_effect = for_stream
@@ -185,7 +190,41 @@ def test_b12x_hierarchical_allreduce_dispatches_above_world_size_eight() -> None
     inp = torch.randn(2, 4)
 
     assert custom_allreduce.should_custom_ar(inp)
-    runtime.for_stream.return_value.should_allreduce.assert_called_once_with(inp)
+    runtime.for_stream.return_value.should_route_plain_allreduce.assert_called_once_with(
+        inp,
+        generic_max_bytes=64,
+        graph_capture=False,
+    )
+
+
+def test_b12x_plain_route_receives_graph_capture_state() -> None:
+    custom_allreduce, runtime = make_b12x_custom_allreduce(
+        allreduce_max_size=512 * 1024,
+        fused_max_size=64,
+    )
+    custom_allreduce._pcie_plain_route_generic_max_size = 84 * 1024
+    custom_allreduce._IS_CAPTURING = True
+    inp = torch.empty((64, 4096), dtype=torch.bfloat16)
+
+    assert custom_allreduce.should_custom_ar(inp)
+    runtime.for_stream.return_value.should_route_plain_allreduce.assert_called_once_with(
+        inp,
+        generic_max_bytes=84 * 1024,
+        graph_capture=True,
+    )
+
+
+def test_b12x_plain_route_supports_runtime_without_policy_api() -> None:
+    custom_allreduce, runtime = make_b12x_custom_allreduce(
+        allreduce_max_size=64,
+        fused_max_size=64,
+    )
+    legacy_channel = SimpleNamespace(should_allreduce=MagicMock(return_value=True))
+    runtime.for_stream.return_value = legacy_channel
+    inp = torch.randn(2, 4)
+
+    assert custom_allreduce.should_custom_ar(inp)
+    legacy_channel.should_allreduce.assert_called_once_with(inp)
 
 
 def test_b12x_fused_allreduce_falls_back_above_its_cutoff() -> None:
@@ -468,6 +507,22 @@ def test_b12x_allreduce_limit_preserves_explicit_operator_value(
 
     assert _b12x_pcie_allreduce_max_size(16) == 64 * 1024
     recommender.assert_not_called()
+
+
+def test_b12x_plain_route_generic_limit_is_not_enlarged_by_runtime_policy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("VLLM_PCIE_ONESHOT_ALLREDUCE_MAX_SIZE", raising=False)
+
+    assert _b12x_pcie_plain_route_generic_max_size() == 84 * 1024
+
+
+def test_b12x_plain_route_generic_limit_preserves_operator_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VLLM_PCIE_ONESHOT_ALLREDUCE_MAX_SIZE", "64KB")
+
+    assert _b12x_pcie_plain_route_generic_max_size() == 64 * 1024
 
 
 def test_b12x_allreduce_limit_uses_vllm_default_without_b12x_policy(

--- a/tests/distributed/test_b12x_fused_all_reduce.py
+++ b/tests/distributed/test_b12x_fused_all_reduce.py
@@ -190,7 +190,8 @@ def test_b12x_hierarchical_allreduce_dispatches_above_world_size_eight() -> None
     inp = torch.randn(2, 4)
 
     assert custom_allreduce.should_custom_ar(inp)
-    runtime.for_stream.return_value.should_route_plain_allreduce.assert_called_once_with(
+    route_policy = runtime.for_stream.return_value.should_route_plain_allreduce
+    route_policy.assert_called_once_with(
         inp,
         generic_max_bytes=64,
         graph_capture=False,
@@ -207,7 +208,8 @@ def test_b12x_plain_route_receives_graph_capture_state() -> None:
     inp = torch.empty((64, 4096), dtype=torch.bfloat16)
 
     assert custom_allreduce.should_custom_ar(inp)
-    runtime.for_stream.return_value.should_route_plain_allreduce.assert_called_once_with(
+    route_policy = runtime.for_stream.return_value.should_route_plain_allreduce
+    route_policy.assert_called_once_with(
         inp,
         generic_max_bytes=84 * 1024,
         graph_capture=True,

--- a/tests/entrypoints/test_ds4_allreduce_launcher.py
+++ b/tests/entrypoints/test_ds4_allreduce_launcher.py
@@ -37,11 +37,11 @@ def _dry_run(tmp_path: Path, **overrides: str) -> str:
     return result.stderr
 
 
-def test_ds4_launcher_auto_selects_flashinfer_ipc_for_tp2(tmp_path: Path) -> None:
-    """Verify that automatic selection uses FlashInfer IPC at TP2."""
+def test_ds4_launcher_auto_selects_b12x_for_tp2(tmp_path: Path) -> None:
+    """Verify that automatic selection uses B12X policy at TP2."""
     output = _dry_run(tmp_path, TP="2")
 
-    assert "allreduce=flashinfer-ipc" in output
+    assert "allreduce=b12x" in output
 
 
 def test_ds4_launcher_auto_keeps_b12x_for_tp4(tmp_path: Path) -> None:

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -141,7 +141,11 @@ def _b12x_pcie_allreduce_max_size(world_size: int) -> int:
 
 
 def _b12x_pcie_plain_route_generic_max_size() -> int:
-    """Return the operator-controlled generic B12X/NCCL crossover."""
+    """Resolve the operator-controlled generic B12X/NCCL crossover.
+
+    Returns:
+        Maximum tensor size in bytes routed through the generic B12X path.
+    """
 
     configured = os.getenv("VLLM_PCIE_ONESHOT_ALLREDUCE_MAX_SIZE")
     if configured is not None:

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -140,6 +140,15 @@ def _b12x_pcie_allreduce_max_size(world_size: int) -> int:
     return resolved
 
 
+def _b12x_pcie_plain_route_generic_max_size() -> int:
+    """Return the operator-controlled generic B12X/NCCL crossover."""
+
+    configured = os.getenv("VLLM_PCIE_ONESHOT_ALLREDUCE_MAX_SIZE")
+    if configured is not None:
+        return _parse_byte_size(configured)
+    return _parse_byte_size(envs.VLLM_PCIE_ONESHOT_ALLREDUCE_MAX_SIZE)
+
+
 def _b12x_pcie_oneshot_limits(world_size: int) -> tuple[int, int, int]:
     allreduce_max_size = _b12x_pcie_allreduce_max_size(world_size)
     fused_max_size = _parse_byte_size(
@@ -364,6 +373,7 @@ class CustomAllreduce:
         self._pcie_capture_stream: torch.cuda.Stream | None = None
         self._pcie_capture_channel_id: str | None = None
         self._pcie_allreduce_max_size: int | None = None
+        self._pcie_plain_route_generic_max_size: int | None = None
         self._pcie_fused_add_rms_norm_max_size: int | None = None
         self._cpp_ar_cutoff_size: int | None = None
         self._cpp_ar_ignore_cutoff_max_rows = 0
@@ -599,6 +609,9 @@ class CustomAllreduce:
                 self._pcie_fused_add_rms_norm_max_size,
                 pcie_oneshot_buffer_size,
             ) = _b12x_pcie_oneshot_limits(world_size)
+            self._pcie_plain_route_generic_max_size = (
+                _b12x_pcie_plain_route_generic_max_size()
+            )
             if self.nccl_group is None:
                 logger.warning(
                     "Custom allreduce is disabled because %s PCIe oneshot "
@@ -1037,13 +1050,27 @@ class CustomAllreduce:
             return False
         if self._pcie_runtime is not None:
             inp_size = inp.numel() * inp.element_size()
+            channel = self._pcie_runtime.for_stream(
+                self._pcie_runtime_stream(),
+                channel_id=self._pcie_runtime_channel_id(),
+            )
+            should_route = getattr(channel, "should_route_plain_allreduce", None)
+            if self._pcie_backend_name == "b12x" and should_route is not None:
+                assert self._pcie_plain_route_generic_max_size is not None
+                runtime_accepts = should_route(
+                    inp,
+                    generic_max_bytes=self._pcie_plain_route_generic_max_size,
+                    graph_capture=(
+                        self._IS_CAPTURING
+                        or (inp.is_cuda and torch.cuda.is_current_stream_capturing())
+                    ),
+                )
+            else:
+                runtime_accepts = channel.should_allreduce(inp)
             use_custom = (
                 self._pcie_allreduce_max_size is not None
                 and inp_size <= self._pcie_allreduce_max_size
-                and self._pcie_runtime.for_stream(
-                    self._pcie_runtime_stream(),
-                    channel_id=self._pcie_runtime_channel_id(),
-                ).should_allreduce(inp)
+                and runtime_accepts
             )
             if (
                 not use_custom


### PR DESCRIPTION
## Status

**Qualified.** Runtime deployment requires [B12X PR #246](https://github.com/local-inference-lab/b12x/pull/246).

## Purpose

Delegate plain all-reduce routing to the B12X runtime so allocation capacity and the B12X/NCCL crossover are independent decisions. B12X can select its generation-safe TP2 graph transport for qualified small rows while preserving NCCL for larger rows and unsupported execution modes.

## Resulting behavior

- `ALLREDUCE_MODE=auto` selects B12X for DeepSeek V4 TP2 and TP4.
- vLLM passes CUDA-graph capture state and the operator-controlled generic crossover to `should_route_plain_allreduce`.
- The B12X-recommended allocation size covers the supported TP2 graph shape envelope without forcing every eligible tensor through B12X.
- `VLLM_PCIE_ONESHOT_ALLREDUCE_MAX_SIZE` remains an explicit operator override for the generic crossover.
- A B12X build without `should_route_plain_allreduce` retains the existing `should_allreduce` compatibility path.

B12X PR #246 implements the qualified TP2 graph policy: B12X through `M=64`, NCCL above `M=64`, eager execution through the existing pull transport, and graph peer-push through two generation-tagged slots.

## Compatibility

Merge B12X PR #246 before this PR. This integration remains source-compatible with a B12X runtime that lacks the policy method, but automatic TP2 routing requires #246. Unsupported shapes and modes retain the existing generic all-reduce route.

This PR is part of [issue #479](https://github.com/local-inference-lab/vllm/issues/479). The issue should close only after both repository changes are merged and release-qualified.

## Validation

- `tests/distributed/test_b12x_fused_all_reduce.py` and `tests/entrypoints/test_ds4_allreduce_launcher.py`: **30 passed** on two SM120 GPUs.
- Ruff check and format: pass.
- Mypy: pass.
- `shellcheck serve-ds4-flash.sh`: pass.
- The repository-wide shellcheck hook reports unrelated findings in launcher files outside this diff; the modified launcher passes direct shellcheck.

The end-to-end qualification used DeepSeek-V4-Flash-0731 with TP2/DCP1, fixed probabilistic DSpark K5, FULL CUDA graphs, CUDA 13.3, PyTorch 2.13, B12X commit `e6bf8496e0077b8da230f0bccbda7ce6ad8a9323`, and vLLM commit `b950122ee6ea060b9055a390646d6e96a72be547`. Twelve sequential streaming requests each completed 4,096 forced decode tokens: 49,152 completion tokens without a stall, timeout, process restart, or GPU loss. The server remained healthy after the sequence.

## AI assistance

AI assistance was used. The submitter reviewed the resulting diff and validation evidence.
