### PR TITLE
[II] fix(ds4): use B12X DeepSeek attention namespaces

### DIFF
--- a/tests/model_executor/layers/test_sparse_attn_indexer_b12x.py
+++ b/tests/model_executor/layers/test_sparse_attn_indexer_b12x.py
@@ -142,7 +142,7 @@ def _install_fake_b12x_indexer(
     b12x_mod.__path__ = []
     attention_mod: Any = types.ModuleType("b12x.attention")
     attention_mod.__path__ = []
-    indexer_mod: Any = types.ModuleType("b12x.attention.nsa_indexer")
+    indexer_mod: Any = types.ModuleType("b12x.attention.dsa_indexer")
     indexer_mod.__path__ = []
 
     class _Caps:
@@ -243,22 +243,22 @@ def _install_fake_b12x_indexer(
     indexer_mod.plan_paged_schedule = build_paged_mqa_schedule_metadata
 
     b12x_mod.attention = attention_mod
-    attention_mod.nsa_indexer = indexer_mod
+    attention_mod.dsa_indexer = indexer_mod
     monkeypatch.setitem(sys.modules, "b12x", b12x_mod)
     monkeypatch.setitem(sys.modules, "b12x.attention", attention_mod)
     monkeypatch.setitem(
         sys.modules,
-        "b12x.attention.nsa_indexer",
+        "b12x.attention.dsa_indexer",
         indexer_mod,
     )
 
 
 def _install_fake_b12x_dcp_merge(monkeypatch, run_row_topk, *, world_size: int):
-    tiled_topk_mod: Any = types.ModuleType("b12x.attention.nsa_indexer.tiled_topk")
+    tiled_topk_mod: Any = types.ModuleType("b12x.attention.dsa_indexer.tiled_topk")
     tiled_topk_mod.run_row_topk = run_row_topk
     monkeypatch.setitem(
         sys.modules,
-        "b12x.attention.nsa_indexer.tiled_topk",
+        "b12x.attention.dsa_indexer.tiled_topk",
         tiled_topk_mod,
     )
 

--- a/tests/models/deepseek_v4/test_b12x_compressed_mla_workspace.py
+++ b/tests/models/deepseek_v4/test_b12x_compressed_mla_workspace.py
@@ -43,7 +43,7 @@ def _install_recording_b12x(monkeypatch, caps_calls: list[SimpleNamespace]):
     b12x.__path__ = []
     attention = types.ModuleType("b12x.attention")
     attention.__path__ = []
-    compressed_mla = types.ModuleType("b12x.attention.compressed_mla")
+    compressed_mla = types.ModuleType("b12x.attention.compressed_sparse_mla")
 
     def caps(**kwargs) -> SimpleNamespace:
         return SimpleNamespace(**kwargs)
@@ -74,7 +74,7 @@ def _install_recording_b12x(monkeypatch, caps_calls: list[SimpleNamespace]):
     monkeypatch.setitem(sys.modules, "b12x.attention", attention)
     monkeypatch.setitem(
         sys.modules,
-        "b12x.attention.compressed_mla",
+        "b12x.attention.compressed_sparse_mla",
         compressed_mla,
     )
     return split_chunks_for_contract
@@ -431,7 +431,7 @@ def test_real_b12x_reserve_dominates_runtime_envelope(
     runtime_widths: tuple[int, ...],
     expected_reserve_mib: float,
 ) -> None:
-    compressed_mla = pytest.importorskip("b12x.attention.compressed_mla")
+    compressed_mla = pytest.importorskip("b12x.attention.compressed_sparse_mla")
     workspace = _RecordingWorkspaceManager()
     monkeypatch.setattr(b12x_mod, "current_workspace_manager", lambda: workspace)
     layer = _make_layer(
@@ -464,7 +464,7 @@ def test_real_b12x_reserve_dominates_runtime_envelope(
 def test_mns64_contract_does_not_grow_production_mnb8192_scratch(
     monkeypatch,
 ) -> None:
-    compressed_mla = pytest.importorskip("b12x.attention.compressed_mla")
+    compressed_mla = pytest.importorskip("b12x.attention.compressed_sparse_mla")
     workspace = _RecordingWorkspaceManager()
     monkeypatch.setattr(b12x_mod, "current_workspace_manager", lambda: workspace)
     max_rows = 8192

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -1069,17 +1069,17 @@ def _run_b12x_paged_topk(
     live K-row window (a metadata tensor, not an in-kernel reduction); when
     None, b12x falls back to the capacity cap.
     """
-    from b12x.attention.nsa_indexer import (
+    from b12x.attention.dsa_indexer import (
         PAGED_INDEX_PAGE_SIZE,
         index_topk_fp8,
     )
-    from b12x.attention.nsa_indexer import (
+    from b12x.attention.dsa_indexer import (
         SOURCE_LAYOUT_PAGED as INDEXER_SOURCE_LAYOUT_PAGED,
     )
-    from b12x.attention.nsa_indexer import (
+    from b12x.attention.dsa_indexer import (
         Caps as B12XIndexerScratchCaps,
     )
-    from b12x.attention.nsa_indexer import (
+    from b12x.attention.dsa_indexer import (
         plan as plan_indexer_scratch,
     )
 
@@ -1148,7 +1148,7 @@ def _merge_b12x_dcp_topk(
             "cross-rank candidate merge."
         )
 
-    from b12x.attention.nsa_indexer.tiled_topk import run_row_topk
+    from b12x.attention.dsa_indexer.tiled_topk import run_row_topk
 
     from vllm.distributed.parallel_state import get_indexer_dcp_group
     from vllm.v1.attention.backends.mla.sparse_utils import (
@@ -1302,7 +1302,7 @@ def _merge_b12x_dcp_topk_by_owner(
             "DCP owner top-k local rows must alias their TP query partition"
         )
 
-    from b12x.attention.nsa_indexer.tiled_topk import run_row_topk
+    from b12x.attention.dsa_indexer.tiled_topk import run_row_topk
 
     from vllm.v1.attention.backends.mla.sparse_utils import (
         triton_convert_dcp_local_topk_to_global,
@@ -1524,10 +1524,10 @@ def _prewarm_b12x_contiguous_prefill_variants(
         return
 
     try:
-        from b12x.attention.nsa_indexer.contiguous_kernel import (
+        from b12x.attention.dsa_indexer.contiguous_kernel import (
             run_contiguous_logits_kernel,
         )
-        from b12x.attention.nsa_indexer.tiled_topk import run_tiled_topk
+        from b12x.attention.dsa_indexer.tiled_topk import run_tiled_topk
     except (AttributeError, ImportError, ModuleNotFoundError):
         return
 
@@ -1624,16 +1624,16 @@ def _reserve_b12x_paged_indexer_scratch(
     device: torch.device,
     shared_page_table: bool = False,
 ) -> None:
-    from b12x.attention.nsa_indexer import (
+    from b12x.attention.dsa_indexer import (
         PAGED_INDEX_PAGE_SIZE,
     )
-    from b12x.attention.nsa_indexer import (
+    from b12x.attention.dsa_indexer import (
         SOURCE_LAYOUT_PAGED as INDEXER_SOURCE_LAYOUT_PAGED,
     )
-    from b12x.attention.nsa_indexer import (
+    from b12x.attention.dsa_indexer import (
         Caps as B12XIndexerScratchCaps,
     )
-    from b12x.attention.nsa_indexer import (
+    from b12x.attention.dsa_indexer import (
         plan as plan_indexer_scratch,
     )
 

--- a/vllm/model_executor/warmup/b12x_sparse_indexer_warmup.py
+++ b/vllm/model_executor/warmup/b12x_sparse_indexer_warmup.py
@@ -52,7 +52,7 @@ def _fused_decode_warmup_rows(
     max_pages: int,
     device: torch.device,
 ) -> tuple[int, ...]:
-    from b12x.attention.nsa_indexer.fused_indexer import (
+    from b12x.attention.dsa_indexer.fused_indexer import (
         fused_indexer_decode_warmup_rows,
     )
 

--- a/vllm/models/deepseek_v4/nvidia/b12x.py
+++ b/vllm/models/deepseek_v4/nvidia/b12x.py
@@ -327,16 +327,16 @@ def _run_compressed_mla(
     {16,32,64,128} by the outer wrapper). Indices are global slot ids, so no
     indexed page table is needed.
     """
-    from b12x.attention.compressed_mla import (
+    from b12x.attention.compressed_sparse_mla import (
         Caps as B12XCompressedMLAScratchCaps,
     )
-    from b12x.attention.compressed_mla import (
+    from b12x.attention.compressed_sparse_mla import (
         plan as plan_compressed_mla_scratch,
     )
-    from b12x.attention.compressed_mla import (
+    from b12x.attention.compressed_sparse_mla import (
         run as compressed_mla_decode_forward,
     )
-    from b12x.attention.compressed_mla import (
+    from b12x.attention.compressed_sparse_mla import (
         split_chunks_for_contract as compressed_mla_split_chunks_for_contract,
     )
 
@@ -565,13 +565,13 @@ class DeepseekV4B12xMLAAttention(DeepseekV4FlashMLAAttention):
         return view
 
     def _reserve_dummy_compressed_mla_scratch(self, q: torch.Tensor) -> None:
-        from b12x.attention.compressed_mla import (
+        from b12x.attention.compressed_sparse_mla import (
             Caps as B12XCompressedMLAScratchCaps,
         )
-        from b12x.attention.compressed_mla import (
+        from b12x.attention.compressed_sparse_mla import (
             plan as plan_compressed_mla_scratch,
         )
-        from b12x.attention.compressed_mla import (
+        from b12x.attention.compressed_sparse_mla import (
             split_chunks_for_contract as compressed_mla_split_chunks_for_contract,
         )
 

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -1053,10 +1053,10 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
         if schedule_seq_lens.dim() != 1:
             return None
 
-        from b12x.attention.nsa_indexer import (
+        from b12x.attention.dsa_indexer import (
             plan_paged_schedule as build_paged_mqa_schedule_metadata,
         )
-        from b12x.attention.nsa_indexer import (
+        from b12x.attention.dsa_indexer import (
             uses_paged_schedule as uses_paged_mqa_schedule,
         )
 


### PR DESCRIPTION
## Purpose

DeepSeek V4 serving must import the public attention namespaces declared by B12X `master`.

B12X commit `3ae0bf3a443047997d625d44ca24da8bd78904d5` exposes compressed sparse MLA as `b12x.attention.compressed_sparse_mla`. B12X commit `429a971340ed12e564e07e10ce1f2dbef65bcc7f` exposes the DeepSeek Sparse Attention indexer as `b12x.attention.dsa_indexer`. Both commits intentionally remove the former namespaces without compatibility aliases.

Infernal Invocation still imported the removed module paths during scratch planning, memory profiling, indexer warmup, and decode. A source-locked installation therefore failed before CUDA graph capture.

## Resulting behavior

- Compressed sparse MLA scratch planning, split-contract queries, and decode dispatch use `b12x.attention.compressed_sparse_mla`.
- DeepSeek Sparse Attention planning, metadata construction, top-k dispatch, warmup, and tests use `b12x.attention.dsa_indexer`.
- Workspace sizing, tensor contracts, launch policy, and numerical operations are unchanged.
- Integration tests install fake modules under the public paths, so a B12X namespace change cannot be hidden by testing a removed module.

## Compatibility

The integration requires the public B12X API at or after commits `3ae0bf3a` and `429a9713`. It does not restore removed aliases in B12X.

## Validation

- Commit hooks: passed, including Ruff, formatting, mypy, SPDX, and import checks.
- `tests/models/deepseek_v4/test_b12x_compressed_mla_workspace.py`: 24 passed with B12X `master` plus PR #246; two pin-memory cases require an NVIDIA driver and were excluded from the CPU-only run.
- Public DSA API import gate: passed for planner, paged metadata, contiguous logits, tiled top-k, row top-k, and fused-indexer warmup symbols.
- Python bytecode compilation: passed for all changed production and test modules.
- Source-locked runtime gate: model weights load successfully with `compressed_sparse_mla`; the unpatched DSA import fails at memory profiling. Full TP2 runtime qualification will be attached after the release composition includes both commits.

## Duplicate check

No open pull request matching the B12X compressed sparse MLA or DSA indexer namespace migration exists in `vllm-project/vllm` or `local-inference-lab/vllm` as of 2026-08-26.

AI assistance was used to inspect the source-lock failures, update the namespace contract, and run the listed checks. Every changed line and the runtime evidence were reviewed by the submitter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated B12X sparse attention and compressed MLA integration to use the current backend interfaces.
  - Improved compatibility for DeepSeek V4 execution, scheduling, warmup, and workspace management.
  - Updated validation coverage to reflect the current B12X attention components, helping prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->