### PR TITLE
feat(glm5next): support B12X C4 DCP

### DIFF
--- a/tests/models/test_glm5next_pooled_indexer.py
+++ b/tests/models/test_glm5next_pooled_indexer.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import math
 import os
 
 import pytest
@@ -159,6 +160,28 @@ def test_glm53_packed_c4_metadata_uses_parent_stride() -> None:
         lengths.cpu(), torch.tensor([0, 1, 1, 2, 2], dtype=torch.int32)
     )
 
+    dcp_positions = torch.tensor(
+        [0, 3, 7, 11, 15, 19, 31], dtype=torch.int64, device=device
+    )
+    expected_by_rank = (
+        [0, 1, 1, 1, 1, 2, 2],
+        [0, 0, 1, 1, 1, 1, 2],
+        [0, 0, 0, 1, 1, 1, 2],
+        [0, 0, 0, 0, 1, 1, 2],
+    )
+    for rank, expected in enumerate(expected_by_rank):
+        local_lengths = torch.empty(7, dtype=torch.int32, device=device)
+        pool_seq_lens(
+            dcp_positions,
+            local_lengths,
+            dcp_size=4,
+            dcp_rank=rank,
+            pool_interleave=1,
+        )
+        torch.testing.assert_close(
+            local_lengths.cpu(), torch.tensor(expected, dtype=torch.int32)
+        )
+
 
 def _packed_main_cache(
     *, device: torch.device, blocks: int, layers: int, block_size: int, layer: int
@@ -191,6 +214,33 @@ def test_glm53_decode_table_capacity_uses_batched_token_limit() -> None:
     assert indexer._decode_block_table.shape[0] == indexer.max_tokens
     assert indexer._decode_block_table.shape[0] > (
         indexer.max_seqs * (indexer.max_speculative_tokens + 1)
+    )
+
+
+def test_glm53_parent_table_width_tracks_dcp_sharding() -> None:
+    max_model_len = 524288
+    block_size = 2304
+
+    assert Glm5NextPooledIndexer._max_parent_table_width(
+        max_model_len,
+        0,
+        block_size,
+        dcp_world_size=1,
+    ) == math.ceil(max_model_len / block_size)
+    assert Glm5NextPooledIndexer._max_parent_table_width(
+        max_model_len,
+        0,
+        block_size,
+        dcp_world_size=4,
+    ) == math.ceil(max_model_len / (block_size * 4))
+    assert (
+        Glm5NextPooledIndexer._max_parent_table_width(
+            block_size,
+            1,
+            block_size,
+            dcp_world_size=1,
+        )
+        == 2
     )
 
 

--- a/tests/v1/attention/test_b12x_sparse_mla_api.py
+++ b/tests/v1/attention/test_b12x_sparse_mla_api.py
@@ -234,7 +234,7 @@ def test_b12x_glm5_next_accepts_pool_aligned_dcp_without_speculation(
     assert invalid_reasons == []
 
 
-def test_b12x_glm5_next_rejects_dcp_with_speculation(monkeypatch) -> None:
+def test_b12x_glm5_next_accepts_dcp_with_speculation(monkeypatch) -> None:
     monkeypatch.setattr(b12x_mla_sparse, "get_b12x_sparse_mla", lambda: object())
     with set_current_vllm_config(
         _glm5_next_config(dcp_size=4, cp_interleave=4, speculative=True)
@@ -253,9 +253,7 @@ def test_b12x_glm5_next_rejects_dcp_with_speculation(monkeypatch) -> None:
             attn_type="decoder",
         )
 
-    assert invalid_reasons == [
-        "B12X GLM5Next C4 DCP does not yet support speculative decoding"
-    ]
+    assert invalid_reasons == []
 
 
 def test_b12x_glm5_next_accepts_dcp_with_prefix_caching(monkeypatch) -> None:

--- a/tests/v1/attention/test_b12x_sparse_mla_api.py
+++ b/tests/v1/attention/test_b12x_sparse_mla_api.py
@@ -104,7 +104,14 @@ def test_b12x_sparse_mla_accepts_glm_dsa_contract(monkeypatch) -> None:
     )
 
 
-def _glm5_next_config(*, dcp_size: int = 1, **overrides: int) -> SimpleNamespace:
+def _glm5_next_config(
+    *,
+    dcp_size: int = 1,
+    cp_interleave: int = 1,
+    speculative: bool = False,
+    prefix_caching: bool = False,
+    **overrides: int,
+) -> SimpleNamespace:
     recipe = dict(
         model_type="glm5_next_text",
         kv_lora_rank=512,
@@ -119,7 +126,12 @@ def _glm5_next_config(*, dcp_size: int = 1, **overrides: int) -> SimpleNamespace
     recipe.update(overrides)
     return SimpleNamespace(
         model_config=SimpleNamespace(hf_text_config=SimpleNamespace(**recipe)),
-        parallel_config=SimpleNamespace(decode_context_parallel_size=dcp_size),
+        parallel_config=SimpleNamespace(
+            decode_context_parallel_size=dcp_size,
+            cp_kv_cache_interleave_size=cp_interleave,
+        ),
+        speculative_config=object() if speculative else None,
+        cache_config=SimpleNamespace(enable_prefix_caching=prefix_caching),
     )
 
 
@@ -178,7 +190,7 @@ def test_b12x_glm5_next_keeps_hybrid_manager_page_unsplit() -> None:
     )
 
 
-def test_b12x_glm5_next_rejects_dcp(monkeypatch) -> None:
+def test_b12x_glm5_next_rejects_unaligned_dcp(monkeypatch) -> None:
     monkeypatch.setattr(b12x_mla_sparse, "get_b12x_sparse_mla", lambda: object())
     with set_current_vllm_config(_glm5_next_config(dcp_size=2)):
         invalid_reasons = B12xMLASparseBackend.validate_configuration(
@@ -196,8 +208,80 @@ def test_b12x_glm5_next_rejects_dcp(monkeypatch) -> None:
         )
 
     assert invalid_reasons == [
-        "B12X GLM5Next sparse MLA does not support decode context parallelism"
+        "B12X GLM5Next C4 DCP requires cp_kv_cache_interleave_size divisible by 4"
     ]
+
+
+def test_b12x_glm5_next_accepts_pool_aligned_dcp_without_speculation(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(b12x_mla_sparse, "get_b12x_sparse_mla", lambda: object())
+    with set_current_vllm_config(_glm5_next_config(dcp_size=4, cp_interleave=4)):
+        invalid_reasons = B12xMLASparseBackend.validate_configuration(
+            head_size=512,
+            dtype=torch.bfloat16,
+            kv_cache_dtype="fp8",
+            block_size=64,
+            use_mla=True,
+            has_sink=False,
+            use_sparse=True,
+            use_mm_prefix=False,
+            use_per_head_quant_scales=False,
+            device_capability=DeviceCapability(12, 0),
+            attn_type="decoder",
+        )
+
+    assert invalid_reasons == []
+
+
+def test_b12x_glm5_next_rejects_dcp_with_speculation(monkeypatch) -> None:
+    monkeypatch.setattr(b12x_mla_sparse, "get_b12x_sparse_mla", lambda: object())
+    with set_current_vllm_config(
+        _glm5_next_config(dcp_size=4, cp_interleave=4, speculative=True)
+    ):
+        invalid_reasons = B12xMLASparseBackend.validate_configuration(
+            head_size=512,
+            dtype=torch.bfloat16,
+            kv_cache_dtype="fp8",
+            block_size=64,
+            use_mla=True,
+            has_sink=False,
+            use_sparse=True,
+            use_mm_prefix=False,
+            use_per_head_quant_scales=False,
+            device_capability=DeviceCapability(12, 0),
+            attn_type="decoder",
+        )
+
+    assert invalid_reasons == [
+        "B12X GLM5Next C4 DCP does not yet support speculative decoding"
+    ]
+
+
+def test_b12x_glm5_next_accepts_dcp_with_prefix_caching(monkeypatch) -> None:
+    monkeypatch.setattr(b12x_mla_sparse, "get_b12x_sparse_mla", lambda: object())
+    with set_current_vllm_config(
+        _glm5_next_config(
+            dcp_size=4,
+            cp_interleave=4,
+            prefix_caching=True,
+        )
+    ):
+        invalid_reasons = B12xMLASparseBackend.validate_configuration(
+            head_size=512,
+            dtype=torch.bfloat16,
+            kv_cache_dtype="fp8",
+            block_size=64,
+            use_mla=True,
+            has_sink=False,
+            use_sparse=True,
+            use_mm_prefix=False,
+            use_per_head_quant_scales=False,
+            device_capability=DeviceCapability(12, 0),
+            attn_type="decoder",
+        )
+
+    assert invalid_reasons == []
 
 
 def test_b12x_glm5_next_rejects_dsv4_head_size(monkeypatch) -> None:
@@ -873,6 +957,7 @@ def test_b12x_dsa_indexer_uses_logical_slot_contract(monkeypatch) -> None:
     monkeypatch.setattr(b12x_indexer, "current_workspace_manager", lambda: _Workspace())
 
     output = torch.empty((3, 4), dtype=torch.int32)
+    scores = torch.empty((3, 4), dtype=torch.float32)
     b12x_indexer._run_paged_topk(
         q=torch.empty((3, 16, 128), dtype=torch.float8_e4m3fn),
         weights=torch.empty((3, 16, 1), dtype=torch.float32),
@@ -882,9 +967,12 @@ def test_b12x_dsa_indexer_uses_logical_slot_contract(monkeypatch) -> None:
         schedule_metadata=None,
         active_width=None,
         output=output,
+        scores=scores,
         topk=4,
         shared_page_table=True,
     )
+
+    assert calls["run"]["out_scores"] is scores
 
     builder = object.__new__(b12x_indexer.DeepseekV4B12xIndexerMetadataBuilder)
     builder.prefill_k_rows = 32768

--- a/tests/v1/spec_decode/test_eagle_draft_attn_metadata.py
+++ b/tests/v1/spec_decode/test_eagle_draft_attn_metadata.py
@@ -37,10 +37,14 @@ def _make_fake_speculator(
     fake_input_buffers = SimpleNamespace(
         query_start_loc=torch.zeros(max_num_reqs + 1, dtype=torch.int32),
         seq_lens=torch.zeros(max_num_reqs, dtype=torch.int32),
+        dcp_local_seq_lens=torch.zeros(max_num_reqs, dtype=torch.int32),
     )
     fake_block_tables = SimpleNamespace(
         input_block_tables=[torch.zeros(max_num_reqs, 4, dtype=torch.int32)],
         slot_mappings=torch.zeros(1, max_num_tokens, dtype=torch.int64),
+        cp_size=1,
+        cp_rank=0,
+        cp_interleave=1,
     )
     return SimpleNamespace(
         arange=torch.arange(max_num_reqs + 1, dtype=torch.int32, device="cpu"),
@@ -158,3 +162,37 @@ def test_build_draft_attn_metadata_forwards_model_specific_metadata():
         "draft_index": 1,
     }
     assert captured["model_specific_attn_metadata"] is model_metadata
+
+
+def test_build_draft_attn_metadata_populates_dcp_local_seq_lens():
+    fake = _make_fake_speculator()
+    fake.block_tables.cp_size = 4
+    fake.block_tables.cp_rank = 2
+    fake.block_tables.cp_interleave = 1
+    fake.input_buffers.seq_lens[:4] = torch.tensor([1, 2, 5, 8])
+
+    def fake_prepare(out, seq_lens, num_reqs, dcp_size, dcp_rank, interleave):
+        for index in range(num_reqs):
+            length = int(seq_lens[index])
+            rounds, remainder = divmod(length, dcp_size * interleave)
+            owned_remainder = min(max(remainder - dcp_rank * interleave, 0), interleave)
+            out[index] = rounds * interleave + owned_remainder
+
+    with patch.object(
+        base_speculator,
+        "prepare_dcp_local_seq_lens",
+        fake_prepare,
+    ):
+        captured = _run_build(
+            fake,
+            num_reqs=4,
+            num_reqs_padded=4,
+            num_tokens_padded=4,
+            base=torch.tensor([1, 2, 5, 8], dtype=torch.int32),
+            step=1,
+        )
+
+    assert torch.equal(
+        captured["dcp_local_seq_lens"],
+        torch.tensor([0, 0, 1, 2], dtype=torch.int32),
+    )

--- a/vllm/models/deepseek_v4/nvidia/b12x_indexer.py
+++ b/vllm/models/deepseek_v4/nvidia/b12x_indexer.py
@@ -195,6 +195,7 @@ def _run_paged_topk(
     schedule_metadata: torch.Tensor | None,
     active_width: torch.Tensor | None,
     output: torch.Tensor,
+    scores: torch.Tensor | None,
     topk: int,
     shared_page_table: bool,
 ) -> None:
@@ -234,6 +235,7 @@ def _run_paged_topk(
         page_size=module.PAGED_INDEX_PAGE_SIZE,
         expected_num_q_heads=int(q.shape[1]),
         out_indices=output,
+        out_scores=scores,
     )
 
 
@@ -312,6 +314,7 @@ class B12xC4SparseIndexer(nn.Module):
         seq_lens: torch.Tensor,
         block_table: torch.Tensor,
         output: torch.Tensor,
+        scores: torch.Tensor | None = None,
         shared_page_table: bool,
         schedule_metadata: torch.Tensor | None = None,
         active_width: torch.Tensor | None = None,
@@ -321,6 +324,12 @@ class B12xC4SparseIndexer(nn.Module):
             raise ValueError(
                 "B12x C4 output must have shape "
                 f"{(int(q.shape[0]), self.topk_tokens)}, got {tuple(output.shape)}."
+            )
+        if scores is not None and (
+            scores.shape != output.shape or scores.dtype != torch.float32
+        ):
+            raise ValueError(
+                "B12x C4 scores must be float32 with the same shape as output"
             )
         output.fill_(-1)
         _run_paged_topk(
@@ -332,6 +341,7 @@ class B12xC4SparseIndexer(nn.Module):
             schedule_metadata=schedule_metadata,
             active_width=active_width,
             output=output,
+            scores=scores,
             topk=self.topk_tokens,
             shared_page_table=shared_page_table,
         )
@@ -397,6 +407,7 @@ class B12xC4SparseIndexer(nn.Module):
                     schedule_metadata=None,
                     active_width=None,
                     output=output,
+                    scores=None,
                     topk=self.topk_tokens,
                     shared_page_table=True,
                 )
@@ -429,6 +440,7 @@ class B12xC4SparseIndexer(nn.Module):
                 schedule_metadata=decode.schedule_metadata,
                 active_width=active_width,
                 output=output,
+                scores=None,
                 topk=self.topk_tokens,
                 shared_page_table=False,
             )

--- a/vllm/models/glm5next/nvidia/ops/glm_kpool.py
+++ b/vllm/models/glm5next/nvidia/ops/glm_kpool.py
@@ -436,28 +436,54 @@ def gather_c4_block_table_rows(
 
 @triton.jit
 def _pool_seq_lens_kernel(
-    positions, output, rows, POOL_SIZE: tl.constexpr, BLOCK: tl.constexpr
+    positions,
+    output,
+    rows,
+    dcp_size,
+    dcp_rank,
+    pool_interleave,
+    POOL_SIZE: tl.constexpr,
+    BLOCK: tl.constexpr,
 ):
     row = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
     mask = row < rows
     position = tl.load(positions + row, mask=mask, other=-1).to(tl.int64)
-    pool_len = (position + 1) // POOL_SIZE
-    tl.store(output + row, pool_len, mask=mask)
+    global_pool_len = (position + 1) // POOL_SIZE
+    rounds = global_pool_len // (dcp_size * pool_interleave)
+    remainder = global_pool_len % (dcp_size * pool_interleave)
+    remainder = tl.maximum(remainder - dcp_rank * pool_interleave, 0)
+    remainder = tl.minimum(remainder, pool_interleave)
+    local_pool_len = rounds * pool_interleave + remainder
+    tl.store(output + row, local_pool_len, mask=mask)
 
 
-def pool_seq_lens(positions: torch.Tensor, output: torch.Tensor) -> None:
-    """Write the number of complete four-token pools visible to each row."""
+def pool_seq_lens(
+    positions: torch.Tensor,
+    output: torch.Tensor,
+    *,
+    dcp_size: int = 1,
+    dcp_rank: int = 0,
+    pool_interleave: int = 1,
+) -> None:
+    """Write the rank-local number of complete four-token pools per row."""
     rows = int(positions.shape[0])
     if positions.dtype != torch.int64 or positions.ndim != 1:
         raise TypeError("GLM positions must be int64 [rows]")
     if output.dtype != torch.int32 or output.shape != (rows,):
         raise ValueError("GLM pool sequence-length output must be int32 [rows]")
+    if dcp_size < 1 or not 0 <= dcp_rank < dcp_size:
+        raise ValueError("GLM pool DCP rank must be within the DCP world")
+    if pool_interleave < 1:
+        raise ValueError("GLM pool interleave must be positive")
     if rows:
         block = 256
         _pool_seq_lens_kernel[(triton.cdiv(rows, block),)](
             positions,
             output,
             rows,
+            dcp_size,
+            dcp_rank,
+            pool_interleave,
             POOL_SIZE=_POOL_SIZE,
             BLOCK=block,
             num_warps=4,

--- a/vllm/models/glm5next/nvidia/pooled_indexer.py
+++ b/vllm/models/glm5next/nvidia/pooled_indexer.py
@@ -13,6 +13,7 @@ from torch import nn
 
 from vllm.compilation.breakable_cudagraph import eager_break_during_capture
 from vllm.config import CacheConfig, CUDAGraphMode, VllmConfig
+from vllm.distributed import get_dcp_group
 from vllm.forward_context import get_forward_context
 from vllm.model_executor.layers.layernorm import LayerNorm
 from vllm.model_executor.layers.linear import ReplicatedLinear
@@ -20,6 +21,7 @@ from vllm.model_executor.layers.quantization.base_config import QuantizationConf
 from vllm.models.deepseek_v4.nvidia.b12x_indexer import (
     B12xC4SparseIndexer,
 )
+from vllm.v1.attention.backends.mla.b12x_indexer import _merge_dcp_topk
 
 if TYPE_CHECKING:
     from vllm.v1.attention.backends.mla.b12x_mla_sparse import (
@@ -110,6 +112,16 @@ class Glm5NextPooledIndexer(nn.Module):
         self.max_model_len = int(vllm_config.model_config.max_model_len)
         self.max_speculative_tokens = int(vllm_config.num_speculative_tokens)
         self.block_size = int(cache_config.block_size)
+        parallel_config = vllm_config.parallel_config
+        self.dcp_world_size = int(parallel_config.decode_context_parallel_size)
+        self.dcp_rank = get_dcp_group().rank_in_group if self.dcp_world_size > 1 else 0
+        token_interleave = int(parallel_config.cp_kv_cache_interleave_size)
+        if self.dcp_world_size > 1 and token_interleave % _POOL_SIZE:
+            raise ValueError(
+                "GLM C4 DCP requires cp_kv_cache_interleave_size to be "
+                f"divisible by {_POOL_SIZE}, got {token_interleave}"
+            )
+        self.pool_interleave = max(token_interleave // _POOL_SIZE, 1)
         if int(topk_indices_buffer.shape[0]) != self.max_tokens:
             raise ValueError("GLM token selection buffer has the wrong row capacity")
         if int(pool_topk_indices_buffer.shape[0]) != self.max_tokens:
@@ -205,6 +217,15 @@ class Glm5NextPooledIndexer(nn.Module):
             persistent=False,
         )
         self.register_buffer(
+            "_pool_scores",
+            torch.empty(
+                (self.max_tokens, _POOL_TOPK),
+                dtype=torch.float32,
+                device=device,
+            ),
+            persistent=False,
+        )
+        self.register_buffer(
             "_pool_block_table",
             torch.empty((self.max_seqs, 1), dtype=torch.int32, device=device),
             persistent=False,
@@ -227,6 +248,17 @@ class Glm5NextPooledIndexer(nn.Module):
     @property
     def _aligned_max_seq_len(self) -> int:
         return math.ceil(self.max_model_len / _POOL_SIZE) * _POOL_SIZE
+
+    @staticmethod
+    def _max_parent_table_width(
+        max_model_len: int,
+        max_speculative_tokens: int,
+        block_size: int,
+        dcp_world_size: int,
+    ) -> int:
+        return math.ceil(
+            (max_model_len + max_speculative_tokens) / (block_size * dcp_world_size)
+        )
 
     @staticmethod
     def _index_cache_view(
@@ -282,8 +314,11 @@ class Glm5NextPooledIndexer(nn.Module):
     def bind_main_kv_cache(self, main_cache: torch.Tensor) -> None:
         index_cache, subpages, parent_stride_pages = self._index_cache_view(main_cache)
         block_size = int(main_cache.shape[1])
-        parent_table_width = math.ceil(
-            (self._aligned_max_seq_len + self.max_speculative_tokens) / block_size
+        parent_table_width = self._max_parent_table_width(
+            self._aligned_max_seq_len,
+            self.max_speculative_tokens,
+            block_size,
+            self.dcp_world_size,
         )
         pool_table_width = parent_table_width * subpages
         device = main_cache.device
@@ -405,9 +440,16 @@ class Glm5NextPooledIndexer(nn.Module):
             parent_stride_pages=self._parent_stride_pages,
         )
         seq_lens = self._pool_seq_lens[:live_rows]
-        pool_seq_lens(positions[:live_rows], seq_lens)
+        pool_seq_lens(
+            positions[:live_rows],
+            seq_lens,
+            dcp_size=self.dcp_world_size,
+            dcp_rank=self.dcp_rank,
+            pool_interleave=self.pool_interleave,
+        )
         pool_ids = self.pool_topk_indices_buffer[:rows]
         pool_ids.fill_(-1)
+        pool_scores = self._pool_scores[:rows] if self.dcp_world_size > 1 else None
 
         if decode_rows:
             decode_table = self._decode_block_table[:decode_rows]
@@ -423,8 +465,17 @@ class Glm5NextPooledIndexer(nn.Module):
                 seq_lens=seq_lens[:decode_rows],
                 block_table=decode_table,
                 output=pool_ids[:decode_rows],
+                scores=(pool_scores[:decode_rows] if pool_scores is not None else None),
                 shared_page_table=False,
             )
+            if pool_scores is not None:
+                _merge_dcp_topk(
+                    pool_ids[:decode_rows],
+                    pool_scores[:decode_rows],
+                    self.dcp_rank,
+                    self.dcp_world_size,
+                    self.pool_interleave,
+                )
 
         if decode_rows < live_rows:
             query_lens_cpu = main_metadata.prefill_query_lens_cpu
@@ -444,8 +495,21 @@ class Glm5NextPooledIndexer(nn.Module):
                     seq_lens=seq_lens[row_start:row_end],
                     block_table=shared_table,
                     output=pool_ids[row_start:row_end],
+                    scores=(
+                        pool_scores[row_start:row_end]
+                        if pool_scores is not None
+                        else None
+                    ),
                     shared_page_table=True,
                 )
+                if pool_scores is not None:
+                    _merge_dcp_topk(
+                        pool_ids[row_start:row_end],
+                        pool_scores[row_start:row_end],
+                        self.dcp_rank,
+                        self.dcp_world_size,
+                        self.pool_interleave,
+                    )
                 row_start = row_end
             if row_start != live_rows:
                 raise RuntimeError(

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -96,8 +96,6 @@ def _glm_next_dcp_error(vllm_config: VllmConfig) -> str | None:
         return (
             "B12X GLM5Next C4 DCP requires cp_kv_cache_interleave_size divisible by 4"
         )
-    if vllm_config.speculative_config is not None:
-        return "B12X GLM5Next C4 DCP does not yet support speculative decoding"
     return None
 
 
@@ -608,6 +606,7 @@ class B12xMLASparseImpl(SparseMLACommonImpl[B12xMLASparseMetadata]):
         vllm_config = get_current_vllm_config()
         hf_config = vllm_config.model_config.hf_text_config
         self._is_glm_next = _is_glm_next_config(hf_config)
+        self.supports_mtp_with_cp_non_trivial_interleave_size = self._is_glm_next
         if self._is_glm_next:
             if recipe_error := _glm_next_recipe_error(hf_config):
                 raise ValueError(recipe_error)

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -86,6 +86,21 @@ def _glm_next_recipe_error(hf_config: object) -> str | None:
     return None
 
 
+def _glm_next_dcp_error(vllm_config: VllmConfig) -> str | None:
+    parallel_config = vllm_config.parallel_config
+    dcp_size = int(parallel_config.decode_context_parallel_size)
+    if dcp_size <= 1:
+        return None
+    interleave = int(parallel_config.cp_kv_cache_interleave_size)
+    if interleave % 4:
+        return (
+            "B12X GLM5Next C4 DCP requires cp_kv_cache_interleave_size divisible by 4"
+        )
+    if vllm_config.speculative_config is not None:
+        return "B12X GLM5Next C4 DCP does not yet support speculative decoding"
+    return None
+
+
 def _selected_index_block_stride_rows(
     kv_cache: torch.Tensor,
     *,
@@ -202,18 +217,8 @@ class B12xMLASparseBackend(AttentionBackend):
                     return recipe_error
                 if head_size != 512:
                     return "B12X GLM5Next sparse MLA requires head_size=512"
-                dcp_size = int(
-                    getattr(
-                        getattr(vllm_config, "parallel_config", None),
-                        "decode_context_parallel_size",
-                        1,
-                    )
-                )
-                if dcp_size > 1:
-                    return (
-                        "B12X GLM5Next sparse MLA does not support decode "
-                        "context parallelism"
-                    )
+                if dcp_error := _glm_next_dcp_error(vllm_config):
+                    return dcp_error
                 return None
             if head_size != 576:
                 return "B12X sparse MLA requires head_size=576"
@@ -288,22 +293,11 @@ class B12xMLASparseMetadataBuilder(
     ) -> None:
         hf_config = vllm_config.model_config.hf_text_config
         self.requires_glm_next_selector_metadata = _is_glm_next_config(hf_config)
-        configured_dcp_size = int(
-            getattr(
-                vllm_config.parallel_config,
-                "decode_context_parallel_size",
-                1,
-            )
-        )
-        if self.requires_glm_next_selector_metadata and configured_dcp_size > 1:
-            raise ValueError(
-                "B12X GLM5Next sparse MLA does not support decode context parallelism"
-            )
+        if self.requires_glm_next_selector_metadata and (
+            dcp_error := _glm_next_dcp_error(vllm_config)
+        ):
+            raise ValueError(dcp_error)
         super().__init__(kv_cache_spec, layer_names, vllm_config, device)
-        if self.requires_glm_next_selector_metadata and self.dcp_world_size > 1:
-            raise ValueError(
-                "B12X GLM5Next sparse MLA does not support decode context parallelism"
-            )
         self.supports_draft_decode_metadata_update = (
             self.requires_glm_next_selector_metadata
         )
@@ -450,6 +444,7 @@ class B12xMLASparseMetadataBuilder(
             if use_dcp and common.dcp_local_seq_lens is not None
             else common.seq_lens
         )
+        metadata.seq_lens = seq_lens
 
         if common.max_query_len <= 1 and num_tokens == common.num_reqs:
             per_token_lens = seq_lens[:num_tokens]
@@ -616,18 +611,8 @@ class B12xMLASparseImpl(SparseMLACommonImpl[B12xMLASparseMetadata]):
         if self._is_glm_next:
             if recipe_error := _glm_next_recipe_error(hf_config):
                 raise ValueError(recipe_error)
-            configured_dcp_size = int(
-                getattr(
-                    vllm_config.parallel_config,
-                    "decode_context_parallel_size",
-                    1,
-                )
-            )
-            if configured_dcp_size > 1 or self.dcp_world_size > 1:
-                raise ValueError(
-                    "B12X GLM5Next sparse MLA does not support decode context "
-                    "parallelism"
-                )
+            if dcp_error := _glm_next_dcp_error(vllm_config):
+                raise ValueError(dcp_error)
             if head_size != 512:
                 raise ValueError("B12X GLM5Next sparse MLA requires head_size=512.")
         else:

--- a/vllm/v1/worker/gpu/spec_decode/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/speculator.py
@@ -21,6 +21,7 @@ from vllm.v1.worker.gpu.attn_utils import (
     init_attn_backend,
 )
 from vllm.v1.worker.gpu.block_table import BlockTables
+from vllm.v1.worker.gpu.cp_utils import prepare_dcp_local_seq_lens
 from vllm.v1.worker.gpu.input_batch import InputBatch, InputBuffers
 from vllm.v1.worker.gpu.model_states.interface import ModelState
 from vllm.v1.worker.gpu.sample.gumbel import gumbel_sample
@@ -273,6 +274,16 @@ class DraftModelSpeculator(BaseSpeculator):
         query_start_loc_np: np.ndarray | None = None,
         dcp_local_seq_lens: torch.Tensor | None = None,
     ) -> dict[str, Any] | None:
+        if dcp_local_seq_lens is None and getattr(self.block_tables, "cp_size", 1) > 1:
+            prepare_dcp_local_seq_lens(
+                self.input_buffers.dcp_local_seq_lens,
+                self.input_buffers.seq_lens,
+                num_reqs,
+                self.block_tables.cp_size,
+                self.block_tables.cp_rank,
+                self.block_tables.cp_interleave,
+            )
+            dcp_local_seq_lens = self.input_buffers.dcp_local_seq_lens
         if query_start_loc_np is not None:
             # Non-uniform query layout (e.g. multi-module MTP's mixed
             # prefill/decode queries); num_query_per_req is ignored.


### PR DESCRIPTION
## Purpose

Enable GLM-5.3-Flash's B12X C4 sparse selector to run with decode context parallelism, including MTP speculative decoding and prefix-cache reuse.

The pooled selector now:

- Computes rank-local C4 pool lengths.
- Requests candidate scores from B12X.
- Merges each rank's pool candidates before expanding them to token indices.
- Sizes the parent page table for DCP-sharded cache blocks.
- Supplies DCP-local draft attention sequence lengths for non-trivially interleaved MTP.

The sparse MLA adapter accepts pool-aligned DCP configurations and publishes rank-local sequence lengths for the DCP attention merge.

The existing Jovian hybrid-cache coordinator already contains the DCP-aware partial-prefix and Mamba CoW work (`0db502c8d`, `ce0711866`), so this PR keeps the scheduler lineage intact and adds the GLM/B12X selector and draft-metadata plumbing required to exercise it.

## Validation

Static and focused tests:

- `ruff format --check`: passed
- `ruff check`: passed
- `git diff --check`: passed
- Focused changed-contract tests: passed
- Existing DCP hybrid prefix/CoW tests: 6 passed
- Draft attention metadata tests: 5 passed
- MTP/DCP configuration tests: 3 passed
- SM120 C4 metadata/pool-length GPU test: passed

Runtime canaries on 4x RTX PRO 6000 Blackwell, TP4:

- DCP4/MTP0 deterministic canary: healthy, zero restarts
- DCP4/MTP5/prefix-cache combined canary at commit `65ee12637`: healthy on the first boot, zero restarts, no OOM
- Runtime config: B12X attention/MoE/linear, `--decode-context-parallel-size 4`, interleave 4, `ag_rs`, `--enable-prefix-caching`, MTP 5, FP8 KV, 524,288 max context
- MTP5 counters after two deterministic chat requests: 140 accepted / 260 drafted tokens (53.8%)
- Prefix proof using two byte-identical raw completion requests:
  - 30,001 prompt tokens per request
  - first prefill wall time: 4.665s
  - repeated request wall time: 0.610s
  - second request reused 27,648 cached tokens (92.2% of its prompt; 7.65x lower wall time)
- KV capacity at 0.88 GPU memory utilization with MTP5 loaded: 15,305,176 logical tokens, or 29.19x 524,288-token contexts
- Earlier DCP4/MTP0 canary at 0.95 utilization reported 21,117,633 logical KV tokens (40.28x 524,288-token contexts)

Human review is required before merge.