### PR TITLE
feat(glm5next): expose auxiliary states for DFlash2

### DIFF
--- a/tests/models/test_glm5next_model.py
+++ b/tests/models/test_glm5next_model.py
@@ -18,7 +18,7 @@ from vllm.model_executor.layers.quantization.modelopt import (
     ModelOptMixedPrecisionConfig,
 )
 from vllm.model_executor.models.glm4_1v import Glm4vForConditionalGeneration
-from vllm.model_executor.models.interfaces import supports_pp
+from vllm.model_executor.models.interfaces import supports_eagle3, supports_pp
 from vllm.models.glm5next.nvidia import attention as glm5next_attention
 from vllm.models.glm5next.nvidia.kda import Glm5NextLinearAttention
 from vllm.models.glm5next.nvidia.model import (
@@ -64,6 +64,43 @@ def test_glm5next_config_preserves_official_sparse_moe_fields() -> None:
     assert text_config.logit_scale == 0.5
     assert text_config.swiglu_limit == 10.0
     assert vision_config.swiglu_limit == 10.0
+
+
+def test_glm5next_exposes_aux_hidden_states_for_external_drafters() -> None:
+    assert supports_eagle3(Glm5NextForCausalLM)
+    assert supports_eagle3(Glm5NextForConditionalGeneration)
+
+
+def test_glm5next_uses_dflash_layer_boundaries_by_default() -> None:
+    expected = (6, 15, 25, 34, 43)
+    causal = Glm5NextForCausalLM.__new__(Glm5NextForCausalLM)
+    conditional = Glm5NextForConditionalGeneration.__new__(
+        Glm5NextForConditionalGeneration
+    )
+
+    assert causal.get_eagle3_default_aux_hidden_state_layers() == expected
+    assert conditional.get_eagle3_default_aux_hidden_state_layers() == expected
+
+
+def test_glm5next_aux_hidden_state_materializes_deferred_mhc() -> None:
+    hidden_states = torch.tensor([[[1.0, 3.0]]])
+    materialized = torch.tensor([[[2.0, 4.0], [6.0, 8.0]]])
+
+    class FakeLayer:
+        mhc = True
+        n = 2
+
+        def hc_post(self, hidden_states, residual, post, comb):
+            assert residual is not None
+            assert post is not None
+            assert comb is not None
+            return materialized
+
+    actual = Glm5NextModel._materialize_aux_hidden_state(
+        FakeLayer(), hidden_states, hidden_states, hidden_states, hidden_states
+    )
+
+    torch.testing.assert_close(actual, materialized.mean(dim=1))
 
 
 def test_glm5next_config_accepts_prebuilt_subconfigs() -> None:

--- a/vllm/models/glm5next/nvidia/model.py
+++ b/vllm/models/glm5next/nvidia/model.py
@@ -56,9 +56,11 @@ from vllm.model_executor.models.glm4_1v import (
     Glm4vForConditionalGeneration,
 )
 from vllm.model_executor.models.interfaces import (
+    EagleModelMixin,
     HasInnerState,
     IsHybrid,
     MixtureOfExperts,
+    SupportsEagle3,
 )
 from vllm.model_executor.models.utils import (
     AutoWeightsLoader,
@@ -98,6 +100,12 @@ _MHC_WEIGHT_RENAMES = (
     (".ffn_hc.base", ".hc_ffn_base"),
     (".ffn_hc.scale", ".hc_ffn_scale"),
 )
+
+# DFlash checkpoints number target decoder layers from zero, while vLLM's
+# auxiliary-state contract numbers layer boundaries (the embedding output is
+# boundary zero). These are therefore one greater than the checkpoint's
+# target_layer_ids [5, 14, 24, 33, 42].
+_GLM53_DFLASH_AUX_HIDDEN_STATE_LAYERS = (6, 15, 25, 34, 43)
 
 
 def _remap_glm5next_weight_name(name: str) -> str:
@@ -650,7 +658,7 @@ class Glm5NextDecoderLayer(nn.Module):
         )
 
 
-class Glm5NextModel(nn.Module):
+class Glm5NextModel(nn.Module, EagleModelMixin):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
 
@@ -747,6 +755,30 @@ class Glm5NextModel(nn.Module):
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.embed_tokens(input_ids)
 
+    @staticmethod
+    def _materialize_aux_hidden_state(
+        layer: Glm5NextDecoderLayer,
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor | None,
+        post: torch.Tensor | None,
+        comb: torch.Tensor | None,
+    ) -> torch.Tensor:
+        """Materialize a GLM layer-boundary state for an external drafter.
+
+        Args:
+            layer: Decoder layer that produced the boundary state.
+            hidden_states: Layer output, potentially before deferred mHC post-mixing.
+            residual: Deferred mHC residual streams, when mHC is active.
+            post: Deferred mHC post-layer mixing coefficients.
+            comb: Deferred mHC residual-stream mixing coefficients.
+
+        Returns:
+            The single-stream hidden state at the requested layer boundary.
+        """
+        if residual is None or not layer.mhc:
+            return hidden_states
+        return hc_contract(layer.hc_post(hidden_states, residual, post, comb), layer.n)
+
     def forward(
         self,
         input_ids: torch.Tensor | None,
@@ -754,7 +786,7 @@ class Glm5NextModel(nn.Module):
         intermediate_tensors: IntermediateTensors | None,
         inputs_embeds: torch.Tensor | None = None,
         **kwargs,
-    ) -> torch.Tensor:
+    ) -> torch.Tensor | tuple[torch.Tensor, list[torch.Tensor]]:
         if get_pp_group().is_first_rank:
             if inputs_embeds is not None:
                 hidden_states = inputs_embeds
@@ -776,10 +808,27 @@ class Glm5NextModel(nn.Module):
         if self.is_sequence_parallel:
             hidden_states = sp_shard(hidden_states)
 
-        for layer in self._active_layers:
-            hidden_states, residual, post, comb = layer(
-                positions, hidden_states, residual, post, comb
-            )
+        aux_hidden_states: list[torch.Tensor] = []
+        if not self.aux_hidden_state_layers:
+            for layer in self._active_layers:
+                hidden_states, residual, post, comb = layer(
+                    positions, hidden_states, residual, post, comb
+                )
+        else:
+            if self.start_layer in self.aux_hidden_state_layers:
+                aux_hidden_states.append(hidden_states)
+            for layer_idx, layer in enumerate(
+                self._active_layers, start=self.start_layer
+            ):
+                hidden_states, residual, post, comb = layer(
+                    positions, hidden_states, residual, post, comb
+                )
+                if layer_idx + 1 in self.aux_hidden_state_layers:
+                    aux_hidden_states.append(
+                        self._materialize_aux_hidden_state(
+                            layer, hidden_states, residual, post, comb
+                        )
+                    )
 
         if not get_pp_group().is_last_rank:
             # Pipeline parallelism is rejected because post/comb are the
@@ -789,9 +838,22 @@ class Glm5NextModel(nn.Module):
             )
 
         if self.is_sequence_parallel:
-            hidden_states = sp_all_gather(hidden_states)[:full_num_tokens]
+            if aux_hidden_states:
+                hidden_size = hidden_states.shape[-1]
+                packed_hidden_states = torch.cat(
+                    [hidden_states, *aux_hidden_states], dim=-1
+                )
+                packed_hidden_states = sp_all_gather(packed_hidden_states)
+                packed_hidden_states = packed_hidden_states[:full_num_tokens]
+                hidden_states, *aux_hidden_states = packed_hidden_states.split(
+                    hidden_size, dim=-1
+                )
+            else:
+                hidden_states = sp_all_gather(hidden_states)[:full_num_tokens]
 
         hidden_states = self.norm(hidden_states)
+        if aux_hidden_states:
+            return hidden_states, aux_hidden_states
         return hidden_states
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
@@ -957,8 +1019,14 @@ class Glm5NextModel(nn.Module):
         return loaded_params
 
 
-class Glm5NextForCausalLM(nn.Module, HasInnerState, MixtureOfExperts, IsHybrid):
+class Glm5NextForCausalLM(
+    nn.Module, HasInnerState, MixtureOfExperts, IsHybrid, SupportsEagle3
+):
     supports_pp: ClassVar[Literal[False]] = False
+
+    def get_eagle3_default_aux_hidden_state_layers(self) -> tuple[int, ...]:
+        """Return GLM-5.3 DFlash's default layer-boundary indices."""
+        return _GLM53_DFLASH_AUX_HIDDEN_STATE_LAYERS
 
     @staticmethod
     def get_model_state_cls():
@@ -1000,7 +1068,7 @@ class Glm5NextForCausalLM(nn.Module, HasInnerState, MixtureOfExperts, IsHybrid):
         intermediate_tensors: IntermediateTensors | None = None,
         inputs_embeds: torch.Tensor | None = None,
         **kwargs,
-    ) -> torch.Tensor | IntermediateTensors:
+    ) -> torch.Tensor | IntermediateTensors | tuple[torch.Tensor, list[torch.Tensor]]:
         hidden_states = self.model(
             input_ids, positions, intermediate_tensors, inputs_embeds, **kwargs
         )
@@ -1066,7 +1134,7 @@ class Glm5NextForCausalLM(nn.Module, HasInnerState, MixtureOfExperts, IsHybrid):
     dummy_inputs=Glm4vDummyInputsBuilder,
 )
 class Glm5NextForConditionalGeneration(
-    Glm4vForConditionalGeneration, HasInnerState, IsHybrid
+    Glm4vForConditionalGeneration, HasInnerState, IsHybrid, SupportsEagle3
 ):
     # The text model (KDA + dense-MLA + MoE) is a hybrid mamba model. The
     # multimodal wrapper must declare the same interfaces so vLLM treats it as
@@ -1075,6 +1143,10 @@ class Glm5NextForConditionalGeneration(
     has_inner_state: ClassVar[Literal[True]] = True
     is_hybrid: ClassVar[Literal[True]] = True
     supports_pp: ClassVar[Literal[False]] = False  # type: ignore[assignment]
+
+    def get_eagle3_default_aux_hidden_state_layers(self) -> tuple[int, ...]:
+        """Return GLM-5.3 DFlash's default layer-boundary indices."""
+        return _GLM53_DFLASH_AUX_HIDDEN_STATE_LAYERS
 
     @staticmethod
     def get_model_state_cls():


### PR DESCRIPTION
## Summary

- expose requested GLM-5.3 target-layer features through the existing `SupportsEagle3` auxiliary-state interface
- materialize deferred mHC state with `hc_post` and contract its residual streams before capture
- gather final and auxiliary states in one sequence-parallel collective
- preserve the existing fast forward loop when no external drafter requests features

## Why

Jovian Judgement already contains the DFlash2 proposer, candidate selector, probabilistic drafting, rejection sampling, and non-causal draft attention. The missing piece for `incoai/GLM-5.3-Flash-DFlash2` was the GLM target hook that returns the five features the checkpoint was trained against (zero-based layers 5, 14, 24, 33, and 42).

GLM defers its mHC reconstruction, so capturing the raw loop tensor is not the trained target feature. This change reconstructs it with the layer-owned mHC operators before returning it through the existing auxiliary-state contract.

Duplicate check: no open GLM-5.3 DFlash or auxiliary-hidden-state PR targets `dev/jovian-judgement`.

## Validation

```text
python -m pytest -q tests/models/test_glm5next_model.py \
  -k "external_drafters or materializes_deferred_mhc or dflash_layer_boundaries"
3 passed, 25 deselected

ruff 0.14.0 check vllm/models/glm5next/nvidia/model.py tests/models/test_glm5next_model.py
All checks passed

ruff 0.14.0 format --check vllm/models/glm5next/nvidia/model.py tests/models/test_glm5next_model.py
2 files already formatted
```

Live TP4 SM120 qualification used normal model-card sampling (`temperature=1`, `top_p=0.95`) with seven draft tokens per K8 verification step:

- 59 verification steps / 413 proposed draft tokens
- 271 accepted draft tokens (65.6%)
- 4.59 accepted draft tokens per step, 5.59 tokens per verification including the target token
- seventh draft position accepted on 26/59 steps (44.1%)
- sustained single-stream code generation around 275-287 tok/s, peaking at 290 tok/s
- completed an Estonia C10/N60 run at 57/60, versus 56/60 for the matched MTP3 control; this is not presented as an accuracy gain, only as evidence against a DFlash-specific collapse

The target remained native B12X sparse MLA + NVFP4/A4 MoE + B12X PCIe all-reduce with FP8 KV.

## Scope

This does not change target weights, quantization, sampling, or the no-drafter path. External multimodal draft embeddings remain out of scope.

AI assistance was used for implementation, testing, and documentation; the commit includes an `Assisted-by` trailer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Eagle3 speculative decoding support for GLM-5-Next language and conditional-generation models.
  - Enabled collection and handling of auxiliary hidden states during model execution.

- **Tests**
  - Added coverage confirming Eagle3 support.
  - Added validation for deferred auxiliary hidden-state materialization and aggregation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
