### PR TITLE
perf(glm5next): apply MoE router gate once

### DIFF
--- a/tests/models/test_glm5next_model.py
+++ b/tests/models/test_glm5next_model.py
@@ -26,6 +26,7 @@ from vllm.models.glm5next.nvidia.model import (
     Glm5NextForCausalLM,
     Glm5NextForConditionalGeneration,
     Glm5NextModel,
+    Glm5NextMoE,
     _load_glm5next_fused_conv1d,
     _remap_glm5next_weight_name,
 )
@@ -124,6 +125,97 @@ def test_glm5next_kda_adapts_shared_out_buffer_forward(monkeypatch) -> None:
     actual = layer(hidden_states, positions)
 
     torch.testing.assert_close(actual, hidden_states + positions[:, None])
+
+
+def test_glm5next_moe_applies_external_gate_once() -> None:
+    layer = Glm5NextMoE.__new__(Glm5NextMoE)
+    torch.nn.Module.__init__(layer)
+    layer.is_sequence_parallel = False
+
+    class CountingGate(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.calls = 0
+
+        def forward(self, hidden_states):
+            self.calls += 1
+            return hidden_states + 1, None
+
+    class RecordingExperts(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.router_input = None
+
+        def forward(self, *, hidden_states, router_logits):
+            self.router_input = router_logits
+            return hidden_states
+
+    layer.gate = CountingGate()
+    layer.experts = RecordingExperts()
+    hidden_states = torch.randn(2, 4)
+
+    actual = layer(hidden_states)
+
+    assert layer.gate.calls == 1
+    torch.testing.assert_close(layer.experts.router_input, hidden_states + 1)
+    torch.testing.assert_close(actual, hidden_states)
+
+
+def test_glm5next_moe_does_not_give_gate_to_runner(monkeypatch) -> None:
+    from vllm.models.glm5next.nvidia import model as glm5next_model
+
+    class FakeGate(torch.nn.Module):
+        out_dtype = torch.float32
+        e_score_correction_bias = None
+
+        def __init__(self, *args, **kwargs):
+            super().__init__()
+
+    class FakeExperts(torch.nn.Module):
+        pass
+
+    factory_kwargs = {}
+
+    def fake_factory(**kwargs):
+        factory_kwargs.update(kwargs)
+        return FakeExperts()
+
+    ep_group = SimpleNamespace(
+        device_group=SimpleNamespace(size=lambda: 1),
+        rank_in_group=0,
+    )
+    monkeypatch.setattr(
+        glm5next_model, "get_tensor_model_parallel_world_size", lambda: 1
+    )
+    monkeypatch.setattr(glm5next_model, "get_tensor_model_parallel_rank", lambda: 0)
+    monkeypatch.setattr(glm5next_model, "get_ep_group", lambda: ep_group)
+    monkeypatch.setattr(
+        glm5next_model, "_get_moe_router_dtype", lambda config: torch.float32
+    )
+    monkeypatch.setattr(glm5next_model, "GateLinear", FakeGate)
+    monkeypatch.setattr(glm5next_model, "FusedMoEFactory", fake_factory)
+
+    config = SimpleNamespace(
+        routed_scaling_factor=1.0,
+        n_routed_experts=8,
+        n_shared_experts=None,
+        hidden_act="silu",
+        hidden_size=16,
+        topk_method=None,
+        moe_intermediate_size=8,
+        num_experts_per_token=2,
+        moe_renormalize=False,
+    )
+    parallel_config = SimpleNamespace(
+        use_sequence_parallel_moe=False,
+        eplb_config=SimpleNamespace(num_redundant_experts=0),
+        enable_eplb=False,
+    )
+
+    layer = Glm5NextMoE(config, parallel_config)
+
+    assert isinstance(layer.gate, FakeGate)
+    assert "gate" not in factory_kwargs
 
 
 def test_glm5next_kda_splits_mixed_decode_prefill_batch(monkeypatch) -> None:

--- a/vllm/models/glm5next/nvidia/model.py
+++ b/vllm/models/glm5next/nvidia/model.py
@@ -257,7 +257,6 @@ class Glm5NextMoE(nn.Module):
 
         self.experts = FusedMoEFactory(
             shared_experts=self.shared_experts,
-            gate=self.gate,
             num_experts=config.n_routed_experts,
             top_k=config.num_experts_per_token,
             hidden_size=config.hidden_size,
@@ -292,11 +291,10 @@ class Glm5NextMoE(nn.Module):
         if self.is_sequence_parallel and not already_sequence_parallel:
             hidden_states = sequence_parallel_chunk(hidden_states)
 
-        # The router is always external (self.gate); main's MoERunner expects
-        # pre-computed router_logits, so compute them here unconditionally.
         router_logits, _ = self.gate(hidden_states)
         final_hidden_states = self.experts(
-            hidden_states=hidden_states, router_logits=router_logits
+            hidden_states=hidden_states,
+            router_logits=router_logits,
         )
 
         if self.is_sequence_parallel and not already_sequence_parallel:


### PR DESCRIPTION
## Purpose

Avoid applying the GLM-5.3 routed-expert gate twice.

`Glm5NextMoE` gave `self.gate` to `FusedMoEFactory`, whose `MoERunner`
derived router logits from `hidden_states`. The model wrapper also applied the
same gate before calling the runner, so every MoE layer launched two identical
router GEMMs while the runner discarded the first result.

Keep the gate in the model wrapper and stop giving it to `FusedMoEFactory`.
The runner now receives the real router logits computed by the model exactly
once; no placeholder tensor or optional custom-op contract is needed. Routing
math and precision are unchanged. Add regression tests for both parts of that
contract: the wrapper applies the gate once, and the factory does not own it.

No overlapping change was found in the current `dev/jovian-judgement` head or
open PR #488.

## Test Plan

- Run the focused model tests:
  `pytest -q tests/models/test_glm5next_model.py -k 'moe_applies_external_gate_once or moe_does_not_give_gate_to_runner'`
- Compare sustained MTP0 C1 decode before and after on the same TP4 Blackwell
  host, exact model/cache/config, native B12X W4A4 routed experts, and normal
  sampling:

  `llm_decode_bench.py --host <host> --port 5001 --model GLM-5.3-Flash --contexts 0 --concurrency 1 --duration 30 --display-mode plain --no-hw-monitor`

## Test Result

- Focused regression tests: 2 passed in the exact serving runtime.
- Matched baseline (`e7097feb`, B12X `2fcf23a`): 123.23 tok/s.
- Patched repeats: 126.97, 127.00, 127.03 tok/s.
- Mean sustained C1 decode: 123.23 -> 127.00 tok/s, **+3.06%**.
- All performance runs used normal sampling; no temperature override or reduced
  output-token setting was used.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR is described.
- [x] The test plan provides commands.
- [x] The test results provide a matched before/after comparison.
- [x] No documentation update is required for this internal model execution fix.
</details>
