### PR TITLE
perf(glm5next): use direct single-token KDA decode

### DIFF
--- a/tests/models/test_glm5next_model.py
+++ b/tests/models/test_glm5next_model.py
@@ -500,6 +500,64 @@ def test_glm5next_b12x_kda_plan_reserves_null_state_zero(monkeypatch) -> None:
     assert captured_caps["null_state_index"] == 0
 
 
+def test_glm5next_b12x_kda_ordinary_decode_uses_direct_inputs() -> None:
+    captured: dict[str, object] = {}
+    binding = object()
+
+    class FakeApi:
+        @staticmethod
+        def run_kda_single_token(bound: object, **kwargs: object) -> None:
+            captured["binding"] = bound
+            captured.update(kwargs)
+
+        @staticmethod
+        def run_kda(*args: object, **kwargs: object) -> None:
+            raise AssertionError("ordinary decode must not use packed KDA staging")
+
+    layer = Glm5NextLinearAttention.__new__(Glm5NextLinearAttention)
+    torch.nn.Module.__init__(layer)
+    layer._b12x_kda_api = FakeApi()
+    layer._b12x_kda_binding = binding
+    layer._b12x_kda_max_tokens = 16
+    layer._b12x_kda_max_seqs = 16
+    layer._b12x_kda_state_index_columns = 6
+    layer.gate_lower_bound = -5.0
+    layer.o_norm = SimpleNamespace(eps=1e-6)
+    layer.head_dim = 128
+
+    mixed_qkv = torch.empty(3, 384)
+    raw_g = torch.empty(3, 1, 128)
+    raw_beta = torch.empty(3, 1)
+    z = torch.empty(3, 1, 128)
+    output = torch.empty(3, 1, 128)
+    state_indices = torch.tensor([[1], [4], [7]], dtype=torch.int32)
+
+    layer._run_b12x_kda_decode_post_conv(
+        mixed_qkv=mixed_qkv,
+        raw_g=raw_g,
+        raw_beta=raw_beta,
+        z=z,
+        output=output,
+        state_indices=state_indices,
+        query_start_loc=torch.arange(4, dtype=torch.int32),
+        num_accepted_tokens=None,
+        num_requests=3,
+    )
+
+    assert captured == {
+        "binding": binding,
+        "mixed_qkv": mixed_qkv,
+        "raw_g": raw_g,
+        "raw_beta": raw_beta,
+        "z": z,
+        "state_indices": state_indices,
+        "output": output,
+        "lower_bound": -5.0,
+        "eps": 1e-6,
+        "scale": 128**-0.5,
+    }
+
+
 def test_glm5next_sparse_mla_selects_b12x_backend(monkeypatch) -> None:
     captured: dict[str, object] = {}
 

--- a/vllm/model_executor/layers/mamba/gdn/kimi_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/kimi_gdn_linear_attn.py
@@ -537,6 +537,31 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
                 f"{self._b12x_kda_state_index_columns}"
             )
 
+        # Ordinary decode contributes exactly one token and one scheduler-owned
+        # state slot per live request. Use the direct B12X specialization when
+        # available so this hot path does not stage metadata or copy inputs
+        # through the generic packed-decode buffers. Speculative decode keeps
+        # using run_kda(), which validates its variable-width state transaction.
+        if (
+            num_accepted_tokens is None
+            and num_tokens == num_requests
+            and state_columns == 1
+            and hasattr(api, "run_kda_single_token")
+        ):
+            api.run_kda_single_token(
+                binding,
+                mixed_qkv=mixed_qkv,
+                raw_g=raw_g,
+                raw_beta=raw_beta,
+                z=z,
+                state_indices=state_indices,
+                output=output,
+                lower_bound=self.gate_lower_bound,
+                eps=self.o_norm.eps,
+                scale=self.head_dim**-0.5,
+            )
+            return
+
         self._b12x_kda_mixed_qkv[:num_tokens].copy_(mixed_qkv)
         self._b12x_kda_raw_g[:num_tokens].copy_(raw_g)
         self._b12x_kda_raw_beta[:num_tokens].copy_(raw_beta)


### PR DESCRIPTION
## Resulting behavior

Ordinary GLM-5.3 decode dispatches directly to the B12X single-token KDA specialization when the installed B12X exposes it. The direct path forwards caller-owned tensors and scheduler-owned state indices without copying through the generic packed-decode staging buffers.

Speculative, mixed, and variable-width decode remain on `run_kda()`, including its device-side metadata and transaction validation. Older B12X installs keep the existing path through feature detection.

## Dependency

This is the vLLM integration counterpart to local-inference-lab/b12x#249. It is safe to merge before that PR because the dispatch is guarded by `hasattr(api, "run_kda_single_token")`.

## Validation

- Ruff check and format pass for both changed files.
- `git diff --check` passes.
- `tests/models/test_glm5next_model.py -k b12x_kda`: 3 passed, 28 deselected.
- B12X #249 GPU correctness suite: 16 passed, including numerical reference checks, CUDA-graph replay, rejected-draft rollback, null-state safety, and GLM TP8 geometry.
- Added identity assertions proving ordinary decode forwards the original tensors and does not invoke packed KDA staging.
- Source-locked TP4/DCP4/MTP5 GLM-5.3-Flash-NVFP4 canary completed both CUDA-graph capture stages and remained healthy with zero container restarts.
- Matched synthetic C1 sustained decode improved from 100.8 to 122.1 tok/s (+21%); prefill remained approximately 8.2k tok/s, as expected for this decode-only change.
- Deterministic hot-prefix Estonia completed correctly at 201.9 tok/s with 72.8% draft-token acceptance, 4.64 emitted tokens per target step, and 0.82s TTFT.
- Prefix caching was independently verified with identical 126k-token prompts: 14.99s cold versus 0.76s hot and 122,112 cache-hit tokens.

The serving measurements are single-run canary evidence, not a general performance guarantee. The separate B12X sparse-MLA prefill regression remains outside this PR.

## Duplicate check

Searched current open vLLM PRs for GLM, B12X, KDA, and decode work. No existing vLLM PR integrates the B12X #249 single-token API.

Assisted by OpenAI Codex. The operator reviewed the runtime scope; final human review remains required before merge.
