### PR TITLE
fix(attention): preserve per-group KV cache formats

### DIFF
--- a/tests/v1/attention/test_group_head_counts.py
+++ b/tests/v1/attention/test_group_head_counts.py
@@ -14,6 +14,7 @@ from vllm.v1.attention.backends.cpu_attn import (
     CPUAttentionMetadataBuilder,
 )
 from vllm.v1.attention.backends.flash_attn import FlashAttentionMetadataBuilder
+from vllm.v1.attention.backends.utils import get_kv_cache_dtype_from_layers
 
 requires_cpu = pytest.mark.skipif(
     not current_platform.is_cpu(), reason="CPU attention backend"
@@ -127,3 +128,18 @@ def test_flash_attention_geometry_comes_from_the_group():
     assert builder.num_heads_q == 16
     assert builder.num_heads_kv == 2
     assert builder.headdim == 64
+
+
+def test_kv_cache_dtype_comes_from_the_attention_group():
+    """A draft attention group can use a different cache format than its target."""
+    layers = {
+        "draft.layer.0": SimpleNamespace(kv_cache_dtype="fp8"),
+        "draft.layer.1": SimpleNamespace(kv_cache_dtype="fp8"),
+    }
+    with patch(
+        "vllm.v1.attention.backends.utils.get_layers_from_vllm_config",
+        return_value=layers,
+    ):
+        cache_dtype = get_kv_cache_dtype_from_layers(MagicMock(), list(layers))
+
+    assert cache_dtype == "fp8"

--- a/tests/v1/worker/test_attn_utils.py
+++ b/tests/v1/worker/test_attn_utils.py
@@ -28,6 +28,7 @@ from vllm.v1.worker.gpu.attn_utils import (
     build_attn_metadata,
     get_attn_cg_support,
     get_query_lens_mismatch_unsupported_backend,
+    synchronize_attention_impl_kv_cache_layout,
 )
 from vllm.v1.worker.utils import (
     AttentionGroup,
@@ -77,6 +78,26 @@ class _CachingMetadataBuilder:
             slot_mapping=slot_mapping,
             reused=metadata,
         )
+
+
+def test_attention_impl_cache_layout_preserves_model_specific_dtype():
+    target_cache_config = SimpleNamespace(
+        cache_dtype="fp8_ds_mla", kv_cache_layout=None
+    )
+    draft_cache_config = SimpleNamespace(cache_dtype="fp8", kv_cache_layout=None)
+    layers = {
+        "target": SimpleNamespace(
+            impl=SimpleNamespace(cache_config=target_cache_config)
+        ),
+        "draft": SimpleNamespace(impl=SimpleNamespace(cache_config=draft_cache_config)),
+    }
+
+    synchronize_attention_impl_kv_cache_layout(layers, "BLHNC")
+
+    assert target_cache_config.kv_cache_layout == "BLHNC"
+    assert draft_cache_config.kv_cache_layout == "BLHNC"
+    assert target_cache_config.cache_dtype == "fp8_ds_mla"
+    assert draft_cache_config.cache_dtype == "fp8"
 
 
 def test_attention_checks_preserve_global_and_target_scoped_support():

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -69,6 +69,7 @@ from vllm.v1.attention.backend import (
 from vllm.v1.attention.backends.utils import (
     get_dcp_local_seq_lens,
     get_flashinfer_layout_string,
+    get_kv_cache_dtype_from_layers,
     get_num_attention_heads_from_layers,
     get_per_layer_parameters,
     infer_global_hyperparameters,
@@ -759,7 +760,10 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         self.page_size = self.kv_cache_spec.block_size
 
         if self.kv_cache_spec.kv_quant_mode != KVQuantMode.NONE:
-            self.cache_dtype = self.cache_config.cache_dtype
+            self.cache_dtype = (
+                get_kv_cache_dtype_from_layers(vllm_config, layer_names)
+                or self.cache_config.cache_dtype
+            )
             # Cannot use self.kv_cache_spec.dtype here because kv_cache_spec
             # storage dtype may not be the same as the op dtype (uint8 vs fp8_e4m3)
             self.is_kvcache_nvfp4 = self.cache_dtype.startswith("nvfp4")

--- a/vllm/v1/attention/backends/utils.py
+++ b/vllm/v1/attention/backends/utils.py
@@ -387,6 +387,34 @@ def get_num_attention_heads_from_layers(
     return heads.pop()
 
 
+def get_kv_cache_dtype_from_layers(
+    vllm_config: VllmConfig, layer_names: list[str]
+) -> str | None:
+    """Return the KV-cache format shared by one attention group.
+
+    Args:
+        vllm_config: Engine configuration containing the attention layers.
+        layer_names: Names of the layers in the attention group.
+
+    Returns:
+        The shared cache format, or ``None`` when the group has no attention
+        layers.
+    """
+    attn_layers = get_layers_from_vllm_config(
+        vllm_config,
+        AttentionLayerBase,  # type: ignore[type-abstract]
+        layer_names,
+    )
+    if not attn_layers:
+        return None
+    cache_dtypes = {cast(Any, layer).kv_cache_dtype for layer in attn_layers.values()}
+    assert len(cache_dtypes) == 1, (
+        "All layers in one attention group must share kv_cache_dtype; "
+        f"got {cache_dtypes} for {layer_names}."
+    )
+    return cache_dtypes.pop()
+
+
 def infer_global_hyperparameters(
     per_layer_params: dict[str, PerLayerParameters],
 ) -> PerLayerParameters:

--- a/vllm/v1/worker/gpu/attn_utils.py
+++ b/vllm/v1/worker/gpu/attn_utils.py
@@ -73,6 +73,24 @@ def get_shared_kv_cache_layers(vllm_config: VllmConfig):
     }
 
 
+def synchronize_attention_impl_kv_cache_layout(
+    attn_layers: Mapping[str, AttentionLayerBase],
+    resolved_layout: str | None,
+) -> None:
+    """Give every attention implementation the allocated cache layout.
+
+    A speculative model can own a CacheConfig copy so its cache dtype differs
+    from the target model. The engine resolves one physical layout for all
+    cache groups, while dtype remains specific to each model-owned copy.
+    """
+    if resolved_layout is None:
+        return
+    for layer in attn_layers.values():
+        impl_cache_config = getattr(getattr(layer, "impl", None), "cache_config", None)
+        if impl_cache_config is not None:
+            impl_cache_config.kv_cache_layout = resolved_layout
+
+
 def init_attn_backend(
     kv_cache_config: KVCacheConfig,
     vllm_config: VllmConfig,
@@ -98,6 +116,10 @@ def init_attn_backend(
 
         layer_type = cast(type[Any], AttentionLayerBase)
         attn_layers = get_layers_from_vllm_config(vllm_config, layer_type, layer_names)
+
+        synchronize_attention_impl_kv_cache_layout(
+            attn_layers, vllm_config.cache_config.kv_cache_layout
+        )
 
         group_map: dict[tuple[tuple[str, str], KVCacheSpec, int], AttentionGroup] = {}
         group_order: list[tuple[tuple[str, str], KVCacheSpec, int]] = []


### PR DESCRIPTION
## Resulting behavior

Status: **implemented**.

Each attention group resolves its KV-cache dtype from the layers assigned to that group. Model-owned attention implementations receive the engine-selected physical cache layout without replacing their group-specific logical dtype.

A speculative draft can therefore use a cache format supported by its attention backend while the target uses a different format. Target-only serving and attention groups whose layers share one global cache format retain their established behavior.

## Source contract

- Base: `local-inference-lab/vllm:dev/jovian-judgement` at `c79f35ca00e8e93e0943a0d79b85b22b18aac939`.
- Head: `eca8a6bca19f210a30fbb0bb6942556f8243cb14`.
- All attention layers within one cache group must resolve to one cache dtype. A mixed dtype inside one group fails validation.
- The physical layout remains selected by the engine cache configuration and is propagated to every model-owned implementation.

## Validation

- `tests/v1/attention/test_group_head_counts.py` and `tests/v1/worker/test_attn_utils.py`: 23 passed.
- Repository pre-commit hooks, including Ruff, mypy, SPDX, forbidden-import, and configuration checks: passed.
- `git diff --check`: passed.
- The composed TP4 GLM-5.3 target-plus-DFlash2 runtime initialized separate target and draft attention groups, captured all configured graph shapes, and served an OpenAI-compatible completion.

## Duplicate-work check

Related open pull requests implement different contracts:

- `vllm-project/vllm#53979` enables non-causal FlashAttention 2 reads from NVFP4 pages; it does not resolve cache dtype per attention group.
- `vllm-project/vllm#48392` replicates dense draft KV heads for decode-context parallelism; it does not preserve independent target and draft cache formats under decode-context parallel size 1.
- `local-inference-lab/vllm#488` implements GLM CKV gathering and retention under decode-context parallelism; it does not provide this per-group dtype and physical-layout propagation.

## Review disclosure

OpenAI Codex assisted with implementation, tests, runtime qualification, and pull-request preparation. Human review of every changed line and the attention-group cache contract is required before merge.
