### PR TITLE
perf(glm5next): accelerate C4 prefill

### DIFF
--- a/tests/models/test_glm5next_pooled_indexer.py
+++ b/tests/models/test_glm5next_pooled_indexer.py
@@ -384,38 +384,39 @@ def test_glm53_deepgemm_prefill_matches_b12x_on_packed_tail(
 ) -> None:
     device = _require_glm_gpu()
     _, main = _packed_main_cache(
-        device=device, blocks=2, layers=3, block_size=512, layer=1
+        device=device, blocks=2, layers=3, block_size=2304, layer=1
     )
     index_cache, _, parent_stride_pages = Glm5NextPooledIndexer._index_cache_view(main)
-    virtual_page = parent_stride_pages
-    page = index_cache[virtual_page]
-    quant = page.as_strided(
-        (64, 128), (128, 1), storage_offset=page.storage_offset()
-    ).view(torch.float8_e4m3fn)
-    scales = page.as_strided(
-        (64 * 4,),
-        (1,),
-        storage_offset=page.storage_offset() + 64 * 128,
-    ).view(torch.float32)
+    virtual_pages = list(range(parent_stride_pages, parent_stride_pages + 9))
     generator = torch.Generator(device=device).manual_seed(5303)
-    quant.copy_(
-        torch.randn((64, 128), generator=generator, device=device).to(
-            torch.float8_e4m3fn
+    for virtual_page in virtual_pages:
+        page = index_cache[virtual_page]
+        quant = page.as_strided(
+            (64, 128), (128, 1), storage_offset=page.storage_offset()
+        ).view(torch.float8_e4m3fn)
+        scales = page.as_strided(
+            (64 * 4,),
+            (1,),
+            storage_offset=page.storage_offset() + 64 * 128,
+        ).view(torch.float32)
+        quant.copy_(
+            torch.randn((64, 128), generator=generator, device=device).to(
+                torch.float8_e4m3fn
+            )
         )
-    )
-    scales.copy_(
-        torch.exp2(
-            torch.randint(-3, 3, (64,), generator=generator, device=device).float()
+        scales.copy_(
+            torch.exp2(
+                torch.randint(-3, 3, (64,), generator=generator, device=device).float()
+            )
         )
-    )
     q = torch.randn(
         (3, 32, 128), generator=generator, device=device, dtype=torch.float32
     ).to(torch.float8_e4m3fn)
     weights = torch.randn(
         (3, 32), generator=generator, device=device, dtype=torch.float32
     )
-    seq_lens = torch.tensor([16, 37, 64], dtype=torch.int32, device=device)
-    block_table = torch.tensor([[virtual_page]], dtype=torch.int32, device=device)
+    seq_lens = torch.tensor([513, 545, 576], dtype=torch.int32, device=device)
+    block_table = torch.tensor([virtual_pages], dtype=torch.int32, device=device)
     topk = 512
 
     from vllm.utils.b12x import get_b12x_dsa_indexer
@@ -428,7 +429,7 @@ def test_glm53_deepgemm_prefill_matches_b12x_on_packed_tail(
             source_layout=module.SOURCE_LAYOUT_PAGED,
             num_q_heads=32,
             max_q_rows=3,
-            max_page_table_width=1,
+            max_page_table_width=len(virtual_pages),
             topk=topk,
             mode="prefill",
             shared_page_table=True,
@@ -440,7 +441,7 @@ def test_glm53_deepgemm_prefill_matches_b12x_on_packed_tail(
     )
     binding = plan.bind(
         scratch=scratch,
-        real_page_table=block_table.expand(3, 1),
+        real_page_table=block_table.expand(3, -1),
         cache_seqlens_int32=seq_lens,
         expected_num_q_heads=32,
         shared_page_table=True,
@@ -475,12 +476,12 @@ def test_glm53_deepgemm_prefill_matches_b12x_on_packed_tail(
         kv_cache=index_cache,
         seq_lens=seq_lens,
         block_table=block_table,
-        gather_cu_seq_lens=torch.tensor([0, 64], dtype=torch.int32, device=device),
+        gather_cu_seq_lens=torch.tensor([0, 576], dtype=torch.int32, device=device),
         row_starts=torch.zeros(3, dtype=torch.int32, device=device),
         output=actual,
         topk=topk,
-        total_k_rows=64,
-        workspace_k_rows=64,
+        total_k_rows=576,
+        workspace_k_rows=576,
     )
     torch.accelerator.synchronize()
 

--- a/tests/models/test_glm5next_pooled_indexer.py
+++ b/tests/models/test_glm5next_pooled_indexer.py
@@ -8,6 +8,7 @@ import pytest
 import torch
 from torch import nn
 
+from vllm.models.deepseek_v4.nvidia import b12x_indexer
 from vllm.models.deepseek_v4.nvidia.b12x_indexer import _flatten_index_cache
 from vllm.models.glm5next.nvidia.ops.glm_kpool import (
     expand_c4_block_table,
@@ -123,10 +124,12 @@ def test_glm53_selector_prefill_lengths_do_not_require_attention_backend() -> No
         num_decode_tokens=1,
         prefill=None,
         prefill_query_lens_cpu=torch.tensor([3], dtype=torch.int32),
+        prefill_seq_lens_cpu=torch.tensor([8], dtype=torch.int32),
     )
 
     assert metadata.prefill is None
     assert metadata.prefill_query_lens_cpu.tolist() == [3]
+    assert metadata.prefill_seq_lens_cpu.tolist() == [8]
 
 
 def test_glm53_packed_c4_metadata_uses_parent_stride() -> None:
@@ -374,6 +377,117 @@ def test_glm53_packed_tail_scores_through_existing_c4_indexer() -> None:
     torch.accelerator.synchronize()
     assert torch.accelerator.memory_allocated() == allocated
     assert set(output[0, :2].tolist()) == {0, 1}
+
+
+def test_glm53_deepgemm_prefill_matches_b12x_on_packed_tail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    device = _require_glm_gpu()
+    _, main = _packed_main_cache(
+        device=device, blocks=2, layers=3, block_size=512, layer=1
+    )
+    index_cache, _, parent_stride_pages = Glm5NextPooledIndexer._index_cache_view(main)
+    virtual_page = parent_stride_pages
+    page = index_cache[virtual_page]
+    quant = page.as_strided(
+        (64, 128), (128, 1), storage_offset=page.storage_offset()
+    ).view(torch.float8_e4m3fn)
+    scales = page.as_strided(
+        (64 * 4,),
+        (1,),
+        storage_offset=page.storage_offset() + 64 * 128,
+    ).view(torch.float32)
+    generator = torch.Generator(device=device).manual_seed(5303)
+    quant.copy_(
+        torch.randn((64, 128), generator=generator, device=device).to(
+            torch.float8_e4m3fn
+        )
+    )
+    scales.copy_(
+        torch.exp2(
+            torch.randint(-3, 3, (64,), generator=generator, device=device).float()
+        )
+    )
+    q = torch.randn(
+        (3, 32, 128), generator=generator, device=device, dtype=torch.float32
+    ).to(torch.float8_e4m3fn)
+    weights = torch.randn(
+        (3, 32), generator=generator, device=device, dtype=torch.float32
+    )
+    seq_lens = torch.tensor([16, 37, 64], dtype=torch.int32, device=device)
+    block_table = torch.tensor([[virtual_page]], dtype=torch.int32, device=device)
+    topk = 512
+
+    from vllm.utils.b12x import get_b12x_dsa_indexer
+
+    module = get_b12x_dsa_indexer()
+    assert module is not None
+    plan = module.plan(
+        module.Caps(
+            device=device,
+            source_layout=module.SOURCE_LAYOUT_PAGED,
+            num_q_heads=32,
+            max_q_rows=3,
+            max_page_table_width=1,
+            topk=topk,
+            mode="prefill",
+            shared_page_table=True,
+        )
+    )
+    scratch = tuple(
+        torch.empty(shape, dtype=dtype, device=device)
+        for shape, dtype in plan.shapes_and_dtypes()
+    )
+    binding = plan.bind(
+        scratch=scratch,
+        real_page_table=block_table.expand(3, 1),
+        cache_seqlens_int32=seq_lens,
+        expected_num_q_heads=32,
+        shared_page_table=True,
+        output_physical_slots=False,
+    )
+    expected = torch.empty((3, topk), dtype=torch.int32, device=device)
+    module.index_topk_fp8(
+        q_fp8=q,
+        weights=weights,
+        index_k_cache=_flatten_index_cache(index_cache),
+        binding=binding,
+        page_size=64,
+        expected_num_q_heads=32,
+        out_indices=expected,
+    )
+
+    class Workspace:
+        def get_simultaneous(self, *specs):
+            return tuple(
+                torch.empty(shape, dtype=dtype, device=device) for shape, dtype in specs
+            )
+
+    monkeypatch.setattr(
+        b12x_indexer,
+        "current_workspace_manager",
+        lambda: Workspace(),
+    )
+    actual = torch.empty_like(expected)
+    b12x_indexer._run_deepgemm_prefill_topk(
+        q=q,
+        weights=weights,
+        kv_cache=index_cache,
+        seq_lens=seq_lens,
+        block_table=block_table,
+        gather_cu_seq_lens=torch.tensor([0, 64], dtype=torch.int32, device=device),
+        row_starts=torch.zeros(3, dtype=torch.int32, device=device),
+        output=actual,
+        topk=topk,
+        total_k_rows=64,
+        workspace_k_rows=64,
+    )
+    torch.accelerator.synchronize()
+
+    assert torch.equal(
+        torch.sort(actual, dim=-1).values,
+        torch.sort(expected, dim=-1).values,
+    )
 
 
 def test_glm53_pool_write_matches_fp8_reference() -> None:

--- a/tests/models/test_glm5next_pooled_indexer.py
+++ b/tests/models/test_glm5next_pooled_indexer.py
@@ -572,7 +572,7 @@ def test_glm53_decode_tail_completes_the_same_pool_as_prefill() -> None:
     torch.testing.assert_close(actual_scale, expected_scale.reshape(1), rtol=0, atol=0)
 
 
-def test_glm53_decode_writer_matches_batched_prefill_writer() -> None:
+def test_glm53_decode_writer_matches_parallel_prefill_writer() -> None:
     device = _require_glm_gpu()
     generator = torch.Generator(device=device).manual_seed(56)
     key = torch.randn(
@@ -600,9 +600,13 @@ def test_glm53_decode_writer_matches_batched_prefill_writer() -> None:
         key,
         gate,
         ape,
-        torch.tensor([-1, -1, -1, 0, -1, -1, -1, 1], device=device),
+        torch.tensor([-1, -1, -1, 3, -1, -1, -1, 7], device=device),
         torch.arange(8, dtype=torch.int64, device=device),
         1,
+        num_decode_requests=0,
+        max_query_len=8,
+        model_block_size=256,
+        parent_stride_pages=1,
     )
     for position in range(8):
         update_decode_pools(
@@ -614,16 +618,125 @@ def test_glm53_decode_writer_matches_batched_prefill_writer() -> None:
             gate[position : position + 1],
             ape,
             torch.tensor(
-                [position // 4 if position % 4 == 3 else -1],
+                [position if position % 4 == 3 else -1],
                 dtype=torch.int64,
                 device=device,
             ),
             torch.tensor([position], dtype=torch.int64, device=device),
             1,
+            model_block_size=256,
+            parent_stride_pages=1,
         )
 
     assert torch.equal(decode_cache, prefill_cache)
     assert torch.equal(decode_tail, prefill_tail)
+
+
+def test_glm53_parallel_prefill_preserves_boundary_tail_and_state_slots() -> None:
+    device = _require_glm_gpu()
+    generator = torch.Generator(device=device).manual_seed(5304)
+    key = torch.randn(
+        (10, 128), generator=generator, device=device, dtype=torch.bfloat16
+    )
+    gate = torch.randn(
+        (10, 128), generator=generator, device=device, dtype=torch.bfloat16
+    )
+    ape = torch.randn(
+        (4, 128), generator=generator, device=device, dtype=torch.bfloat16
+    )
+    initial_tail = torch.randn(
+        (2, 2, 4, 128), generator=generator, device=device, dtype=torch.bfloat16
+    )
+    sequential_tail = initial_tail.clone()
+    parallel_tail = initial_tail.clone()
+    sequential_cache = torch.zeros((2, 64, 132), dtype=torch.uint8, device=device)
+    parallel_cache = torch.zeros_like(sequential_cache)
+    state_slots = torch.tensor([1, 0], dtype=torch.int32, device=device)
+    query_start_loc = torch.tensor([0, 5, 10], dtype=torch.int32, device=device)
+    positions = torch.tensor(
+        [4099, 4100, 4101, 4102, 4103, 4099, 4100, 4101, 4102, 4103],
+        dtype=torch.int64,
+        device=device,
+    )
+    slot_mapping = torch.tensor(
+        [3, -1, -1, -1, 7, 259, -1, -1, -1, 263],
+        dtype=torch.int64,
+        device=device,
+    )
+    common = dict(model_block_size=256, parent_stride_pages=1)
+
+    update_decode_pools(
+        sequential_cache,
+        sequential_tail,
+        state_slots,
+        query_start_loc,
+        key,
+        gate,
+        ape,
+        slot_mapping,
+        positions,
+        2,
+        **common,
+    )
+    update_decode_pools(
+        parallel_cache,
+        parallel_tail,
+        state_slots,
+        query_start_loc,
+        key,
+        gate,
+        ape,
+        slot_mapping,
+        positions,
+        2,
+        num_decode_requests=0,
+        max_query_len=5,
+        **common,
+    )
+
+    assert torch.equal(parallel_cache, sequential_cache)
+    assert torch.equal(parallel_tail, sequential_tail)
+
+
+def test_glm53_parallel_prefill_ignores_invalid_dummy_slots() -> None:
+    device = _require_glm_gpu()
+    generator = torch.Generator(device=device).manual_seed(5305)
+    key = torch.randn(
+        (8, 128), generator=generator, device=device, dtype=torch.bfloat16
+    )
+    gate = torch.randn(
+        (8, 128), generator=generator, device=device, dtype=torch.bfloat16
+    )
+    ape = torch.randn(
+        (4, 128), generator=generator, device=device, dtype=torch.bfloat16
+    )
+    cache = torch.zeros((1, 64, 132), dtype=torch.uint8, device=device)
+    initial_tail = torch.randn(
+        (1, 2, 4, 128), generator=generator, device=device, dtype=torch.bfloat16
+    )
+    tail = initial_tail.clone()
+
+    update_decode_pools(
+        cache,
+        tail,
+        torch.zeros(1, dtype=torch.int32, device=device),
+        torch.tensor([0, 8], dtype=torch.int32, device=device),
+        key,
+        gate,
+        ape,
+        torch.full((8,), -1, dtype=torch.int64, device=device),
+        torch.zeros(8, dtype=torch.int64, device=device),
+        1,
+        num_decode_requests=0,
+        max_query_len=8,
+        model_block_size=256,
+        parent_stride_pages=1,
+    )
+
+    assert torch.count_nonzero(cache).item() == 0
+    torch.testing.assert_close(tail[0, 0, 0], key[-1])
+    torch.testing.assert_close(tail[0, 1, 0], gate[-1])
+    assert torch.equal(tail[:, :, 1:], initial_tail[:, :, 1:])
 
 
 def test_glm53_tail_state_isolated_between_requests() -> None:

--- a/tests/v1/attention/test_b12x_sparse_mla_api.py
+++ b/tests/v1/attention/test_b12x_sparse_mla_api.py
@@ -170,10 +170,14 @@ def test_b12x_glm5_next_cache_spec_and_layout(monkeypatch) -> None:
     assert invalid_reasons == []
     assert unidentified == probe
     assert packed_by_glm_backend.state_content_bytes == 528
-    assert packed_by_glm_backend.page_size_padded == 64 * 528 + 16 * 128 * 2
+    assert packed_by_glm_backend.page_size_padded is None
+    assert packed_by_glm_backend.page_tail_bytes_per_token == 33
+    assert packed_by_glm_backend.page_size_bytes == 64 * (528 + 33)
     assert packed_by_glm_backend.model_version == "glm5_next"
     assert packed.state_content_bytes == 528
-    assert packed.page_size_padded == 64 * 528 + 16 * 128 * 2
+    assert packed.page_size_padded is None
+    assert packed.page_tail_bytes_per_token == 33
+    assert packed.page_size_bytes == 64 * (528 + 33)
     assert packed.model_version == "glm5_next"
     assert packed_without_config_context == packed
     assert layouts == (KVCacheLayout.BLHNC,)
@@ -515,7 +519,7 @@ def test_glm_selector_metadata_builder_stages_padded_rows_and_capture(
     monkeypatch.setattr(
         SparseMLACommonMetadataBuilder,
         "build",
-        lambda *args, **kwargs: SimpleNamespace(),
+        lambda *args, **kwargs: SimpleNamespace(num_prefills=0),
     )
     builder = _bare_glm_selector_metadata_builder()
     common = SimpleNamespace(
@@ -591,7 +595,7 @@ def test_glm_selector_metadata_builder_requires_complete_runtime_state(
     monkeypatch.setattr(
         SparseMLACommonMetadataBuilder,
         "build",
-        lambda *args, **kwargs: SimpleNamespace(),
+        lambda *args, **kwargs: SimpleNamespace(num_prefills=0),
     )
     builder = _bare_glm_selector_metadata_builder()
     common = SimpleNamespace(

--- a/vllm/models/deepseek_v4/nvidia/b12x_indexer.py
+++ b/vllm/models/deepseek_v4/nvidia/b12x_indexer.py
@@ -8,10 +8,12 @@ from typing import Any, cast
 import torch
 from torch import nn
 
+from vllm import _custom_ops as ops
 from vllm.config import CUDAGraphMode, VllmConfig
 from vllm.forward_context import get_forward_context
 from vllm.platforms import current_platform
 from vllm.utils.b12x import get_b12x_dsa_indexer
+from vllm.utils.deep_gemm import fp8_fp4_mqa_logits
 from vllm.v1.attention.backend import AttentionCGSupport
 from vllm.v1.attention.backends.mla.indexer import (
     DeepseekV4IndexerBackend,
@@ -239,6 +241,95 @@ def _run_paged_topk(
     )
 
 
+def _run_deepgemm_prefill_topk(
+    *,
+    q: torch.Tensor,
+    weights: torch.Tensor,
+    kv_cache: torch.Tensor,
+    seq_lens: torch.Tensor,
+    block_table: torch.Tensor,
+    gather_cu_seq_lens: torch.Tensor,
+    row_starts: torch.Tensor,
+    output: torch.Tensor,
+    topk: int,
+    total_k_rows: int,
+    workspace_k_rows: int,
+) -> None:
+    """Gather a shared paged cache and score prefill rows with DeepGEMM."""
+    q_rows = int(q.shape[0])
+    expected_cache_tail = (_INDEX_PAGE_SIZE, _INDEX_HEAD_DIM + _INDEX_SCALE_BYTES)
+    if q.ndim != 3 or int(q.shape[2]) != _INDEX_HEAD_DIM:
+        raise ValueError(
+            "DeepGEMM C4 prefill queries must have shape [rows, heads, 128]"
+        )
+    if weights.shape != (q_rows, int(q.shape[1])) or weights.dtype != torch.float32:
+        raise ValueError("DeepGEMM C4 prefill weights must be FP32 [rows, heads]")
+    if (
+        kv_cache.ndim != 3
+        or kv_cache.dtype != torch.uint8
+        or tuple(kv_cache.shape[1:]) != expected_cache_tail
+    ):
+        raise ValueError("DeepGEMM C4 prefill cache must be uint8 [pages, 64, 132]")
+    if seq_lens.shape != (q_rows,) or seq_lens.dtype != torch.int32:
+        raise ValueError("DeepGEMM C4 prefill lengths must be int32 [rows]")
+    if block_table.ndim != 2 or int(block_table.shape[0]) != 1:
+        raise ValueError("DeepGEMM C4 prefill requires one shared page-table row")
+    if gather_cu_seq_lens.shape != (2,) or gather_cu_seq_lens.dtype != torch.int32:
+        raise ValueError("DeepGEMM C4 gather boundaries must be int32 [2]")
+    if row_starts.shape != (q_rows,) or row_starts.dtype != torch.int32:
+        raise ValueError("DeepGEMM C4 row starts must be int32 [rows]")
+    if output.shape != (q_rows, int(topk)) or output.dtype != torch.int32:
+        raise ValueError("DeepGEMM C4 prefill output must be int32 [rows, topk]")
+    if not 0 <= int(total_k_rows) <= int(workspace_k_rows):
+        raise ValueError(
+            "DeepGEMM C4 gathered length exceeds workspace capacity: "
+            f"length={total_k_rows}, capacity={workspace_k_rows}"
+        )
+
+    output.fill_(-1)
+    if q_rows == 0 or total_k_rows == 0:
+        return
+
+    active_pages = (int(total_k_rows) + _INDEX_PAGE_SIZE - 1) // _INDEX_PAGE_SIZE
+    if active_pages > int(block_table.shape[1]):
+        raise ValueError(
+            "DeepGEMM C4 page table does not cover the gathered prefix: "
+            f"required={active_pages}, available={block_table.shape[1]}"
+        )
+
+    k_quant_full, k_scale_full = current_workspace_manager().get_simultaneous(
+        ((max(int(workspace_k_rows), 1), _INDEX_HEAD_DIM), q.dtype),
+        ((max(int(workspace_k_rows), 1), _INDEX_SCALE_BYTES), torch.uint8),
+    )
+    k_quant = k_quant_full[:total_k_rows]
+    k_scale_bytes = k_scale_full[:total_k_rows]
+    ops.cp_gather_indexer_k_quant_cache(
+        kv_cache,
+        k_quant,
+        k_scale_bytes,
+        block_table[:, :active_pages],
+        gather_cu_seq_lens,
+    )
+    logits = fp8_fp4_mqa_logits(
+        (q, None),
+        (k_quant, k_scale_bytes.view(torch.float32).squeeze(-1)),
+        weights,
+        row_starts,
+        seq_lens,
+        clean_logits=False,
+    )
+    ops.top_k_per_row_prefill(
+        logits,
+        row_starts,
+        seq_lens,
+        output,
+        q_rows,
+        int(logits.stride(0)),
+        int(logits.stride(1)),
+        int(topk),
+    )
+
+
 class B12xC4SparseIndexer(nn.Module):
     """Shared C4 FP8 paged indexer used by DeepSeek V4 and GLM-5.3-Flash."""
 
@@ -301,6 +392,18 @@ class B12xC4SparseIndexer(nn.Module):
             if shared_page_table:
                 _assert_prefill_route(plan)
             current_workspace_manager().get_simultaneous(*plan.shapes_and_dtypes())
+        current_workspace_manager().get_simultaneous(
+            ((max(self.max_model_len, 1), _INDEX_HEAD_DIM), q.dtype),
+            (
+                (max(self.max_model_len, 1), _INDEX_SCALE_BYTES),
+                torch.uint8,
+            ),
+        )
+        torch.empty(
+            (max(q_rows, 1), max(self.max_model_len, 1)),
+            dtype=torch.float32,
+            device=q.device,
+        )
 
     def reserve_profile_workspace(self, q: torch.Tensor) -> None:
         self._reserve_profile_workspace(q)
@@ -344,6 +447,35 @@ class B12xC4SparseIndexer(nn.Module):
             scores=scores,
             topk=self.topk_tokens,
             shared_page_table=shared_page_table,
+        )
+        return output
+
+    def run_deepgemm_prefill_topk(
+        self,
+        *,
+        q: torch.Tensor,
+        weights: torch.Tensor,
+        kv_cache: torch.Tensor,
+        seq_lens: torch.Tensor,
+        block_table: torch.Tensor,
+        gather_cu_seq_lens: torch.Tensor,
+        row_starts: torch.Tensor,
+        output: torch.Tensor,
+        total_k_rows: int,
+    ) -> torch.Tensor:
+        """Use DeepGEMM for shared-page-table C4 prefill selection."""
+        _run_deepgemm_prefill_topk(
+            q=q,
+            weights=weights,
+            kv_cache=kv_cache,
+            seq_lens=seq_lens,
+            block_table=block_table,
+            gather_cu_seq_lens=gather_cu_seq_lens,
+            row_starts=row_starts,
+            output=output,
+            topk=self.topk_tokens,
+            total_k_rows=int(total_k_rows),
+            workspace_k_rows=self.max_model_len,
         )
         return output
 

--- a/vllm/models/glm5next/nvidia/ops/glm_kpool.py
+++ b/vllm/models/glm5next/nvidia/ops/glm_kpool.py
@@ -251,6 +251,195 @@ def _decode_update_kernel(
         tl.store(tail + base + tail_stride_1 + dim, current_gate, mask=dim_mask)
 
 
+@triton.jit
+def _prefill_pool_kernel(
+    cache_fp8,
+    cache_fp32,
+    tail,
+    state_slots,
+    query_start_loc,
+    key,
+    gate,
+    ape,
+    slot_mapping,
+    positions,
+    request_offset,
+    page_stride_bytes,
+    model_block_size,
+    parent_stride_pages,
+    tail_stride_0,
+    tail_stride_1,
+    tail_stride_2,
+    key_stride_0,
+    gate_stride_0,
+    ape_stride_0,
+    PAGE_SIZE: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    POOL_SIZE: tl.constexpr,
+    FP8_MAX: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    request = request_offset + tl.program_id(0)
+    pool_ordinal = tl.program_id(1)
+    state_slot = tl.load(state_slots + request).to(tl.int64)
+    start = tl.load(query_start_loc + request).to(tl.int64)
+    end = tl.load(query_start_loc + request + 1).to(tl.int64)
+    has_rows = end > start
+    first_position = tl.load(positions + start, mask=has_rows, other=0).to(tl.int64)
+    first_physical_slot = first_position % POOL_SIZE
+    first_completion = start + (POOL_SIZE - 1 - first_physical_slot)
+    completion_row = first_completion + pool_ordinal * POOL_SIZE
+    write_pool = has_rows & (completion_row < end) & (state_slot >= 0)
+    completion_position = tl.load(
+        positions + completion_row, mask=write_pool, other=-1
+    ).to(tl.int64)
+    write_pool &= completion_position % POOL_SIZE == POOL_SIZE - 1
+    main_cache_location = tl.load(
+        slot_mapping + completion_row, mask=write_pool, other=-1
+    ).to(tl.int64)
+    write_pool &= main_cache_location >= 0
+    parent_page = main_cache_location // model_block_size
+    model_page_offset = main_cache_location - parent_page * model_block_size
+    pool_offset = model_page_offset // POOL_SIZE
+    child_page = pool_offset // PAGE_SIZE
+    child_offset = pool_offset - child_page * PAGE_SIZE
+    cache_location = (
+        parent_page * parent_stride_pages + child_page
+    ) * PAGE_SIZE + child_offset
+
+    dim = tl.arange(0, BLOCK_D)
+    dim_mask = dim < HEAD_DIM
+    maximum = tl.full((BLOCK_D,), -float("inf"), tl.float32)
+    for slot in tl.static_range(0, POOL_SIZE):
+        source_row = completion_row - (POOL_SIZE - 1 - slot)
+        from_current_chunk = source_row >= start
+        tail_offset = (
+            state_slot * tail_stride_0 + tail_stride_1 + slot * tail_stride_2 + dim
+        )
+        current_score = tl.load(
+            gate + source_row * gate_stride_0 + dim,
+            mask=dim_mask & write_pool & from_current_chunk,
+            other=0.0,
+        ).to(tl.float32)
+        previous_score = tl.load(
+            tail + tail_offset,
+            mask=dim_mask & write_pool & ~from_current_chunk,
+            other=0.0,
+        ).to(tl.float32)
+        score = tl.where(from_current_chunk, current_score, previous_score)
+        score += tl.load(
+            ape + slot * ape_stride_0 + dim,
+            mask=dim_mask & write_pool,
+            other=0.0,
+        ).to(tl.float32)
+        maximum = tl.maximum(maximum, score)
+
+    numerator = tl.zeros((BLOCK_D,), tl.float32)
+    denominator = tl.zeros((BLOCK_D,), tl.float32)
+    for slot in tl.static_range(0, POOL_SIZE):
+        source_row = completion_row - (POOL_SIZE - 1 - slot)
+        from_current_chunk = source_row >= start
+        tail_offset = state_slot * tail_stride_0 + slot * tail_stride_2 + dim
+        current_value = tl.load(
+            key + source_row * key_stride_0 + dim,
+            mask=dim_mask & write_pool & from_current_chunk,
+            other=0.0,
+        ).to(tl.float32)
+        previous_value = tl.load(
+            tail + tail_offset,
+            mask=dim_mask & write_pool & ~from_current_chunk,
+            other=0.0,
+        ).to(tl.float32)
+        value = tl.where(from_current_chunk, current_value, previous_value)
+        current_score = tl.load(
+            gate + source_row * gate_stride_0 + dim,
+            mask=dim_mask & write_pool & from_current_chunk,
+            other=0.0,
+        ).to(tl.float32)
+        previous_score = tl.load(
+            tail + tail_offset + tail_stride_1,
+            mask=dim_mask & write_pool & ~from_current_chunk,
+            other=0.0,
+        ).to(tl.float32)
+        score = tl.where(from_current_chunk, current_score, previous_score)
+        score += tl.load(
+            ape + slot * ape_stride_0 + dim,
+            mask=dim_mask & write_pool,
+            other=0.0,
+        ).to(tl.float32)
+        weight = tl.exp(score - maximum)
+        numerator += value * weight
+        denominator += weight
+
+    pooled = numerator / tl.maximum(denominator, 1e-20)
+    _write_pool(
+        cache_fp8,
+        cache_fp32,
+        cache_location,
+        pooled,
+        dim,
+        dim_mask,
+        write_pool,
+        page_stride_bytes,
+        PAGE_SIZE,
+        HEAD_DIM,
+        FP8_MAX,
+    )
+
+
+@triton.jit
+def _prefill_tail_kernel(
+    tail,
+    state_slots,
+    query_start_loc,
+    key,
+    gate,
+    positions,
+    request_offset,
+    tail_stride_0,
+    tail_stride_1,
+    tail_stride_2,
+    key_stride_0,
+    gate_stride_0,
+    HEAD_DIM: tl.constexpr,
+    POOL_SIZE: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    request = request_offset + tl.program_id(0)
+    state_slot = tl.load(state_slots + request).to(tl.int64)
+    start = tl.load(query_start_loc + request).to(tl.int64)
+    end = tl.load(query_start_loc + request + 1).to(tl.int64)
+    last_row = end - 1
+    has_rows = end > start
+    last_position = tl.load(positions + last_row, mask=has_rows, other=0).to(tl.int64)
+    last_physical_slot = last_position % POOL_SIZE
+    dim = tl.arange(0, BLOCK_D)
+    dim_mask = (dim < HEAD_DIM) & has_rows & (state_slot >= 0)
+    for slot in tl.static_range(0, POOL_SIZE):
+        distance = (last_physical_slot - slot + POOL_SIZE) % POOL_SIZE
+        source_row = last_row - distance
+        source_in_chunk = source_row >= start
+        source_position = tl.load(
+            positions + source_row,
+            mask=has_rows & source_in_chunk,
+            other=-1,
+        ).to(tl.int64)
+        write_slot = dim_mask & source_in_chunk & (source_position % POOL_SIZE == slot)
+        value = tl.load(
+            key + source_row * key_stride_0 + dim,
+            mask=write_slot,
+            other=0.0,
+        )
+        score = tl.load(
+            gate + source_row * gate_stride_0 + dim,
+            mask=write_slot,
+            other=0.0,
+        )
+        tail_offset = state_slot * tail_stride_0 + slot * tail_stride_2 + dim
+        tl.store(tail + tail_offset, value, mask=write_slot)
+        tl.store(tail + tail_offset + tail_stride_1, score, mask=write_slot)
+
+
 def update_decode_pools(
     kv_cache: torch.Tensor,
     tail: torch.Tensor,
@@ -263,10 +452,18 @@ def update_decode_pools(
     positions: torch.Tensor,
     num_requests: int,
     *,
+    num_decode_requests: int | None = None,
+    max_query_len: int | None = None,
     model_block_size: int | None = None,
     parent_stride_pages: int | None = None,
 ) -> None:
-    """Update raw tails and write every newly completed FP8 pool."""
+    """Update request tails and write every newly completed FP8 C4 pool.
+
+    Decode and speculative-decode requests retain ordered row processing. Prefill
+    requests use one program per completed pool and a separate final-tail update;
+    their positions must be consecutive within each request, as required by the
+    packed GLM MLA cache contract.
+    """
     if num_requests <= 0:
         return
     page_size = int(kv_cache.shape[1])
@@ -287,7 +484,17 @@ def update_decode_pools(
     assert parent_stride_pages is not None
     if parent_stride_pages <= 0:
         raise ValueError("GLM parent_stride_pages must be positive")
-    _decode_update_kernel[(num_requests,)](
+    if num_decode_requests is None:
+        num_decode_requests = num_requests
+    if not 0 <= num_decode_requests <= num_requests:
+        raise ValueError("GLM decode request count exceeds the request batch")
+    num_prefill_requests = num_requests - num_decode_requests
+    if num_prefill_requests and not packed_main_slots:
+        raise ValueError("parallel GLM prefill requires packed main-cache slots")
+    if num_prefill_requests and (max_query_len is None or max_query_len <= 0):
+        raise ValueError("parallel GLM prefill requires a positive max_query_len")
+
+    common_args = (
         kv_cache.view(torch.float8_e4m3fn),
         kv_cache.view(torch.float32),
         tail,
@@ -307,14 +514,49 @@ def update_decode_pools(
         int(key.stride(0)),
         int(gate.stride(0)),
         int(ape.stride(0)),
+    )
+    common_meta = dict(
         PAGE_SIZE=page_size,
         HEAD_DIM=_HEAD_DIM,
         POOL_SIZE=_POOL_SIZE,
         FP8_MAX=_FP8_MAX,
         BLOCK_D=128,
-        PACKED_MAIN_SLOTS=packed_main_slots,
         num_warps=4,
     )
+    if num_decode_requests:
+        _decode_update_kernel[(num_decode_requests,)](
+            *common_args,
+            PACKED_MAIN_SLOTS=packed_main_slots,
+            **common_meta,
+        )
+    if num_prefill_requests:
+        assert max_query_len is not None
+        _prefill_pool_kernel[
+            (num_prefill_requests, triton.cdiv(max_query_len, _POOL_SIZE))
+        ](
+            *common_args[:10],
+            num_decode_requests,
+            *common_args[10:],
+            **common_meta,
+        )
+        _prefill_tail_kernel[(num_prefill_requests,)](
+            tail,
+            state_slots,
+            query_start_loc,
+            key,
+            gate,
+            positions,
+            num_decode_requests,
+            int(tail.stride(0)),
+            int(tail.stride(1)),
+            int(tail.stride(2)),
+            int(key.stride(0)),
+            int(gate.stride(0)),
+            HEAD_DIM=_HEAD_DIM,
+            POOL_SIZE=_POOL_SIZE,
+            BLOCK_D=128,
+            num_warps=4,
+        )
 
 
 @triton.jit

--- a/vllm/models/glm5next/nvidia/ops/glm_kpool.py
+++ b/vllm/models/glm5next/nvidia/ops/glm_kpool.py
@@ -263,7 +263,6 @@ def _prefill_pool_kernel(
     ape,
     slot_mapping,
     positions,
-    request_offset,
     page_stride_bytes,
     model_block_size,
     parent_stride_pages,
@@ -273,6 +272,7 @@ def _prefill_pool_kernel(
     key_stride_0,
     gate_stride_0,
     ape_stride_0,
+    request_offset,
     PAGE_SIZE: tl.constexpr,
     HEAD_DIM: tl.constexpr,
     POOL_SIZE: tl.constexpr,
@@ -534,9 +534,8 @@ def update_decode_pools(
         _prefill_pool_kernel[
             (num_prefill_requests, triton.cdiv(max_query_len, _POOL_SIZE))
         ](
-            *common_args[:10],
+            *common_args,
             num_decode_requests,
-            *common_args[10:],
             **common_meta,
         )
         _prefill_tail_kernel[(num_prefill_requests,)](

--- a/vllm/models/glm5next/nvidia/pooled_indexer.py
+++ b/vllm/models/glm5next/nvidia/pooled_indexer.py
@@ -439,6 +439,8 @@ class Glm5NextPooledIndexer(nn.Module):
             main_metadata.slot_mapping[:rows],
             positions,
             num_reqs,
+            num_decode_requests=num_decodes,
+            max_query_len=int(main_metadata.max_query_len),
             model_block_size=self.block_size,
             parent_stride_pages=self._parent_stride_pages,
         )

--- a/vllm/models/glm5next/nvidia/pooled_indexer.py
+++ b/vllm/models/glm5next/nvidia/pooled_indexer.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""GLM-5.3 C4 pooling around the shared b12x FP8 paged indexer."""
+"""GLM-5.3 C4 pooling with B12X decode and DeepGEMM prefill selection."""
 
 from __future__ import annotations
 
@@ -50,7 +50,7 @@ _MLA_RECORD_BYTES = 528
 
 
 class Glm5NextPooledIndexer(nn.Module):
-    """Produce GLM C4 pools, select them with b12x, and expand token IDs."""
+    """Produce C4 pools, select them by execution phase, and expand token IDs."""
 
     def __init__(
         self,
@@ -223,6 +223,16 @@ class Glm5NextPooledIndexer(nn.Module):
                 dtype=torch.float32,
                 device=device,
             ),
+            persistent=False,
+        )
+        self.register_buffer(
+            "_pool_seq_starts",
+            torch.zeros(self.max_tokens, dtype=torch.int32, device=device),
+            persistent=False,
+        )
+        self.register_buffer(
+            "_gather_cu_seq_lens",
+            torch.zeros((self.max_seqs, 2), dtype=torch.int32, device=device),
             persistent=False,
         )
         self.register_buffer(
@@ -479,29 +489,49 @@ class Glm5NextPooledIndexer(nn.Module):
 
         if decode_rows < live_rows:
             query_lens_cpu = main_metadata.prefill_query_lens_cpu
-            if query_lens_cpu is None:
+            request_seq_lens_cpu = main_metadata.prefill_seq_lens_cpu
+            if query_lens_cpu is None or request_seq_lens_cpu is None:
                 raise RuntimeError("GLM selector prefill metadata is incomplete")
+            if len(query_lens_cpu) != len(request_seq_lens_cpu):
+                raise RuntimeError(
+                    "GLM selector prefill request metadata has inconsistent lengths"
+                )
             row_start = decode_rows
             for local_request, query_len in enumerate(query_lens_cpu.tolist()):
                 row_end = row_start + int(query_len)
                 request = num_decodes + local_request
-                shared_table = self._pool_block_table[request : request + 1].expand(
-                    int(query_len), -1
-                )
-                self.indexer_op.run_paged_topk(
-                    q=q_fp8[row_start:row_end],
-                    weights=weights[row_start:row_end],
-                    kv_cache=index_cache,
-                    seq_lens=seq_lens[row_start:row_end],
-                    block_table=shared_table,
-                    output=pool_ids[row_start:row_end],
-                    scores=(
-                        pool_scores[row_start:row_end]
-                        if pool_scores is not None
-                        else None
-                    ),
-                    shared_page_table=True,
-                )
+                if self.dcp_world_size > 1:
+                    assert pool_scores is not None
+                    shared_table = self._pool_block_table[request : request + 1].expand(
+                        int(query_len), -1
+                    )
+                    self.indexer_op.run_paged_topk(
+                        q=q_fp8[row_start:row_end],
+                        weights=weights[row_start:row_end],
+                        kv_cache=index_cache,
+                        seq_lens=seq_lens[row_start:row_end],
+                        block_table=shared_table,
+                        output=pool_ids[row_start:row_end],
+                        scores=pool_scores[row_start:row_end],
+                        shared_page_table=True,
+                    )
+                else:
+                    total_pool_len = (
+                        int(request_seq_lens_cpu[local_request]) // _POOL_SIZE
+                    )
+                    gather_cu_seq_lens = self._gather_cu_seq_lens[local_request]
+                    gather_cu_seq_lens[1].fill_(total_pool_len)
+                    self.indexer_op.run_deepgemm_prefill_topk(
+                        q=q_fp8[row_start:row_end],
+                        weights=weights[row_start:row_end],
+                        kv_cache=index_cache,
+                        seq_lens=seq_lens[row_start:row_end],
+                        block_table=self._pool_block_table[request : request + 1],
+                        gather_cu_seq_lens=gather_cu_seq_lens,
+                        row_starts=self._pool_seq_starts[row_start:row_end],
+                        output=pool_ids[row_start:row_end],
+                        total_k_rows=total_pool_len,
+                    )
                 if pool_scores is not None:
                     _merge_dcp_topk(
                         pool_ids[row_start:row_end],

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -265,6 +265,7 @@ class B12xMLASparseMetadata(AttentionMetadata):
     prefill_max_seq_len: int = 0
     prefill: MLACommonPrefillMetadata | None = None
     prefill_query_lens_cpu: torch.Tensor | None = None
+    prefill_seq_lens_cpu: torch.Tensor | None = None
     block_size: int = 64
     topk_tokens: int = 2048
     cp_kv_cache_interleave_size: int = 1
@@ -490,6 +491,14 @@ class B12xMLASparseMetadataBuilder(
             metadata.prefill_query_lens_cpu = torch.diff(
                 common.query_start_loc_cpu[prefill_start:prefill_end]
             )
+            seq_lens_cpu_source = (
+                common.seq_lens_cpu_upper_bound
+                if common.seq_lens_cpu_upper_bound is not None
+                else common.seq_lens_cpu
+            )
+            metadata.prefill_seq_lens_cpu = seq_lens_cpu_source[
+                prefill_start : prefill_start + metadata.num_prefills
+            ].clone()
         (
             metadata.selector_state_slot_ids,
             metadata.selector_state_is_fresh,


### PR DESCRIPTION
## Resulting behavior

Status: **implemented** and **qualified** for GLM-5.3 C4 prefill at tensor parallel size 4 and decode-context parallel size 1.

GLM C4 decode retains the B12X paged selector. C4 prefill gathers the visible packed FP8 page-tail cache into caller-owned workspace and uses DeepGEMM to rank candidates. Host-side sequence lengths bound each request to its visible pool prefix.

Completed C4 pools are updated by independent Triton programs. Each request updates its own partial tail, while decode and speculative-decode rows retain ordered processing. The prefill path requires packed main-cache slots and consecutive positions.

## Source contract

- Base: `local-inference-lab/vllm:dev/jovian-judgement` at `c79f35ca00e8e93e0943a0d79b85b22b18aac939`.
- Head: `70bdc4d51e571b75d7e1a7e1721a488b35aadb83`.
- The B12X paged decode ABI and cache layout are unchanged.
- QSA page-tail tests assert 33 bytes per token independently from fixed page padding.
- The prefill request offset is an append-only kernel argument so the shared launch tuple cannot shift positional arguments.

## Validation

- Focused GLM pooled-indexer and B12X sparse-MLA tests: 20 passed, 14 accelerator-dependent tests skipped, 9 deselected.
- A physical SM120 oracle compared DeepGEMM and B12X ranking over 576 visible candidates at top-k 512: passed.
- For 4,096 query rows and pool contexts from 4,096 through 32,768 tokens, the DeepGEMM prefill ranking path measured 6.5-24.1% faster than B12X prefill ranking.
- Repository pre-commit hooks, including Ruff, mypy, SPDX, forbidden-import, and configuration checks: passed.
- `git diff --check`: passed.
- The composed TP4 runtime sustained 12,692 input tokens/s in a 32,768-token cold-prefill profile over 30 seconds.

## Duplicate-work check

Related pull requests implement different execution modes:

- `local-inference-lab/vllm#488` gathers full compressed KV state for GLM decode-context-parallel prefill and overlaps DCP communication. This pull request qualifies DCP1 packed-cache gathering, DeepGEMM ranking, and parallel C4 pool updates.
- `vllm-project/vllm#41834` contains DeepSeek V4 SM120 sparse-indexer and prefill work, but it does not implement the GLM C4 page-tail gather and pool-update contract in this pull request.

## Review disclosure

OpenAI Codex assisted with implementation, tests, GPU oracle validation, profiling, benchmarking, and pull-request preparation. Human review of every changed line and the packed-cache ABI is required before merge.
