### PR TITLE
fix(glm5next): pin multimodal processor revision

### DIFF
--- a/tests/models/test_glm5next_model.py
+++ b/tests/models/test_glm5next_model.py
@@ -628,6 +628,40 @@ def test_glm5next_processor_resolves_repository_video_config(
     )
 
 
+def test_glm5next_processing_info_pins_processor_revision(monkeypatch) -> None:
+    from vllm.models.glm5next.nvidia.multimodal import Glm5NextProcessingInfo
+
+    calls = []
+    processor = object()
+
+    def fake_from_pretrained(model, **kwargs):
+        calls.append((model, kwargs))
+        return processor
+
+    monkeypatch.setattr(
+        glm5next_processor.Glm5NextProcessor,
+        "from_pretrained",
+        staticmethod(fake_from_pretrained),
+    )
+    info = SimpleNamespace(
+        ctx=SimpleNamespace(
+            model_config=SimpleNamespace(
+                model="local-inference-lab/GLM-5.3-Flash-NVFP4",
+                revision="checkpoint-commit",
+            )
+        )
+    )
+
+    assert Glm5NextProcessingInfo.get_hf_processor(info) is processor
+    assert Glm5NextProcessingInfo.get_hf_processor(info) is processor
+    assert calls == [
+        (
+            "local-inference-lab/GLM-5.3-Flash-NVFP4",
+            {"revision": "checkpoint-commit"},
+        )
+    ]
+
+
 def test_glm5next_processor_counts_video_only_tokens() -> None:
     class FakeVideoProcessor:
         merge_size = 2

--- a/vllm/models/glm5next/nvidia/multimodal.py
+++ b/vllm/models/glm5next/nvidia/multimodal.py
@@ -630,7 +630,10 @@ class Glm5NextProcessingInfo(Glm4vProcessingInfo):
         if proc is None:
             from vllm.transformers_utils.processors.glm5next import Glm5NextProcessor
 
-            proc = Glm5NextProcessor.from_pretrained(self.ctx.model_config.model)
+            proc = Glm5NextProcessor.from_pretrained(
+                self.ctx.model_config.model,
+                revision=self.ctx.model_config.revision,
+            )
             self._glm5_hf_processor = proc
         return proc
 


### PR DESCRIPTION
## Resulting behavior

Status: **implemented**.

The native GLM-5.3 processing stack passes `ModelConfig.revision` when it loads tokenizer, image-processor, and video-processor metadata. Repository-backed launches therefore resolve processor artifacts from the same checkpoint revision as model weights. Local checkpoint paths retain their established behavior.

This prevents a pinned model revision from silently combining its weights with processor metadata from a moving repository branch.

## Source contract

- Base: `local-inference-lab/vllm:dev/jovian-judgement` at `c79f35ca00e8e93e0943a0d79b85b22b18aac939`.
- Head: `1bb599d4215aee0c0aa6b7b7534ff98e9ef26cbe`.
- `ModelConfig.revision=None` preserves Hugging Face default revision resolution.
- Explicit revisions are forwarded unchanged to the repository-backed processor configuration lookup.

## Validation

- `tests/models/test_glm5next_model.py -k processor`: 3 passed, 28 deselected.
- Repository pre-commit hooks, including Ruff, mypy, SPDX, forbidden-import, and configuration checks: passed.
- `git diff --check`: passed.
- The composed TP4 runtime loaded target and draft checkpoints from pinned Hugging Face snapshot revisions and served an OpenAI-compatible completion.

## Duplicate-work check

Open upstream and `local-inference-lab/vllm` pull requests were searched for GLM processor, tokenizer, and revision propagation. No open focused pull request passes `ModelConfig.revision` through this GLM native processor path. `vllm-project/vllm#41834` is a broad DeepSeek V4 and GLM SM120 enablement branch and does not provide this focused revision-propagation contract.

## Review disclosure

OpenAI Codex assisted with implementation, tests, runtime qualification, and pull-request preparation. Human review of every changed line and the repository-revision contract is required before merge.
