### PR TITLE
feat(dflash2): execute serialized MXFP8 projections natively

### DIFF
--- a/tests/v1/spec_decode/test_dflash2.py
+++ b/tests/v1/spec_decode/test_dflash2.py
@@ -60,6 +60,80 @@ def test_grouped_conv_matches_reference(block_size: int):
     torch.testing.assert_close(actual, expected.flatten(0, 1).flatten(-2))
 
 
+def test_dflash2_auxiliary_linears_use_draft_quantization(
+    monkeypatch, default_vllm_config
+):
+    """Every checkpoint-serialized DFlash2 linear receives its quant config."""
+    from torch import nn
+
+    import vllm.model_executor.models.qwen3_dflash2 as dflash2
+
+    class StubLinear(nn.Module):
+        def __init__(self, *args, quant_config=None, **kwargs):
+            super().__init__()
+            self.quant_config = quant_config
+
+    monkeypatch.setattr(dflash2, "ReplicatedLinear", StubLinear)
+    quant_config = object()
+    from vllm.config import set_current_vllm_config
+
+    with set_current_vllm_config(default_vllm_config):
+        grouped_conv = dflash2.DFlashGroupedConv(
+            hidden_size=16,
+            taps=2,
+            group_size=4,
+            block_size=8,
+            params_dtype=torch.float32,
+            quant_config=quant_config,
+            prefix="attention_conv",
+        )
+        selector = dflash2.CandidateSelector(
+            hidden_size=16,
+            vocab_size=32,
+            rank=4,
+            top_k=3,
+            params_dtype=torch.float32,
+            quant_config=quant_config,
+            prefix="candidate_selector",
+        )
+
+    assert grouped_conv.kernel_projection.quant_config is quant_config
+    assert selector.hidden_projection.quant_config is quant_config
+
+
+@pytest.mark.parametrize("mxfp8_layer", [0, 1])
+def test_dflash_context_projection_rejects_mixed_quantization(mxfp8_layer: int):
+    from torch import nn
+
+    from vllm.model_executor.layers.quantization.modelopt import (
+        ModelOptMxFp8LinearMethod,
+    )
+    from vllm.model_executor.models.qwen3_dflash import DFlashQwen3Model
+
+    class UnreadableWeight:
+        def __getitem__(self, _key):
+            raise AssertionError("weights must not be read before validation")
+
+    mxfp8_method = object.__new__(ModelOptMxFp8LinearMethod)
+    methods = [None, None]
+    methods[mxfp8_layer] = mxfp8_method
+    layers_attn = [
+        SimpleNamespace(
+            qkv_proj=SimpleNamespace(
+                quant_method=method,
+                q_size=1,
+                weight=UnreadableWeight(),
+            )
+        )
+        for method in methods
+    ]
+    model = object.__new__(DFlashQwen3Model)
+    nn.Module.__init__(model)
+
+    with pytest.raises(ValueError, match="Every DFlash attention layer"):
+        model._build_context_kv_buffers(layers_attn, has_bias=False)
+
+
 def test_selector_edges_match_sequential_reference():
     torch.manual_seed(1)
     batch, steps, top_k, rank = 2, 4, 3, 5

--- a/vllm/model_executor/models/qwen3_dflash.py
+++ b/vllm/model_executor/models/qwen3_dflash.py
@@ -472,6 +472,14 @@ class DFlashQwen3Model(nn.Module):
             self.config.hidden_size,
             eps=self.config.rms_norm_eps,
         )
+        # The context projection concatenates K/V weights from every draft
+        # layer. It is not a LinearBase module because its output layout is a
+        # DFlash-specific fusion. Serialized MXFP8 checkpoints retain an
+        # independently packed copy in this parameter container.
+        self._fused_kv_linear = nn.Module()
+        self._fused_kv_quant_method = None
+        self._fused_kv_weight: torch.Tensor | None = None
+        self._fused_kv_weight_scale: torch.Tensor | None = None
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         embeds = self.embed_tokens(input_ids)
@@ -486,11 +494,31 @@ class DFlashQwen3Model(nn.Module):
         layers_attn: list[nn.Module],
         has_bias: bool,
     ) -> None:
+        from vllm.model_executor.layers.quantization.modelopt import (
+            ModelOptMxFp8LinearMethod,
+        )
+
+        quant_methods = [a.qkv_proj.quant_method for a in layers_attn]
+        uses_mxfp8 = [
+            isinstance(method, ModelOptMxFp8LinearMethod) for method in quant_methods
+        ]
+        if any(uses_mxfp8) and not all(uses_mxfp8):
+            raise ValueError(
+                "Every DFlash attention layer must use the same MXFP8 "
+                "linear format for the fused context K/V projection."
+            )
+
         self._hidden_norm_weight = self.hidden_norm.weight.data
 
         # KV projection weights: [num_layers * 2 * kv_size, hidden_size]
         kv_weights = [a.qkv_proj.weight[a.q_size :] for a in layers_attn]
         self._fused_kv_weight = torch.cat(kv_weights, dim=0)
+
+        if all(uses_mxfp8):
+            kv_scales = [a.qkv_proj.weight_scale[a.q_size :] for a in layers_attn]
+            self._fused_kv_weight_scale = torch.cat(kv_scales, dim=0)
+        else:
+            self._fused_kv_weight_scale = None
         if has_bias:
             kv_biases = [a.qkv_proj.bias[a.q_size :] for a in layers_attn]
             self._fused_kv_bias: torch.Tensor | None = torch.cat(kv_biases, dim=0)
@@ -546,6 +574,41 @@ class DFlashQwen3Model(nn.Module):
         # References to inner Attention layers for direct cache writes
         self._attn_layers = [layer.self_attn.attn for layer in self.layers]
 
+    def process_weights_after_loading(self) -> None:
+        """Pack the serialized MXFP8 context projection for its GEMM backend."""
+        from vllm.model_executor.layers.quantization.modelopt import (
+            ModelOptMxFp8LinearMethod,
+        )
+
+        quant_method = self.layers[0].self_attn.qkv_proj.quant_method
+        if not isinstance(quant_method, ModelOptMxFp8LinearMethod):
+            return
+        if self._fused_kv_weight is None or self._fused_kv_weight_scale is None:
+            raise RuntimeError(
+                "The DFlash MXFP8 context projection requires serialized K/V "
+                "weights and block scales to be fused during checkpoint loading."
+            )
+
+        output_size, input_size = self._fused_kv_weight.shape
+        self._fused_kv_linear.input_size_per_partition = input_size
+        self._fused_kv_linear.output_size_per_partition = output_size
+        self._fused_kv_linear.logical_widths = [output_size]
+        self._fused_kv_linear.register_parameter(
+            "weight", nn.Parameter(self._fused_kv_weight, requires_grad=False)
+        )
+        self._fused_kv_linear.register_parameter(
+            "weight_scale",
+            nn.Parameter(self._fused_kv_weight_scale, requires_grad=False),
+        )
+        quant_method.process_weights_after_loading(self._fused_kv_linear)
+        self._fused_kv_quant_method = quant_method
+        self._fused_kv_weight = None
+        self._fused_kv_weight_scale = None
+        logger.info_once(
+            "Using %s for the fused DFlash context K/V projection.",
+            type(quant_method.kernel).__name__,
+        )
+
     def _project_context_kv(
         self,
         context_states: torch.Tensor,
@@ -562,9 +625,18 @@ class DFlashQwen3Model(nn.Module):
             self._hidden_norm_weight,
             self._rms_norm_eps,
         )
-        all_kv_flat = F.linear(
-            normed_context_states, self._fused_kv_weight, self._fused_kv_bias
-        )
+        if self._fused_kv_quant_method is None:
+            if self._fused_kv_weight is None:
+                raise RuntimeError("DFlash context K/V projection is not initialized.")
+            all_kv_flat = F.linear(
+                normed_context_states, self._fused_kv_weight, self._fused_kv_bias
+            )
+        else:
+            all_kv_flat = self._fused_kv_quant_method.apply(
+                self._fused_kv_linear,
+                normed_context_states,
+                self._fused_kv_bias,
+            )
         # Single contiguous copy that separates K/V and transposes to
         # layer-major layout.  Result: [2, L, num_ctx, nkv, hd] contiguous.
         # Indexing dim-0 gives contiguous [L, num_ctx, nkv, hd] for K and V.
@@ -792,6 +864,10 @@ class DFlashQwen3ForCausalLM(Qwen3ForCausalLM):
         self.model.precompute_and_store_context_kv(
             context_states, context_positions, context_slot_mapping
         )
+
+    def process_weights_after_loading(self) -> None:
+        """Finalize the DFlash fused context projection after linear packing."""
+        self.model.process_weights_after_loading()
 
     def combine_hidden_states(
         self,

--- a/vllm/model_executor/models/qwen3_dflash2.py
+++ b/vllm/model_executor/models/qwen3_dflash2.py
@@ -51,6 +51,7 @@ class DFlashGroupedConv(nn.Module):
         group_size: int,
         block_size: int,
         params_dtype: torch.dtype,
+        quant_config: QuantizationConfig | None,
         prefix: str,
     ) -> None:
         super().__init__()
@@ -71,7 +72,7 @@ class DFlashGroupedConv(nn.Module):
             2 * taps * self.num_groups,
             bias=False,
             params_dtype=params_dtype,
-            quant_config=None,
+            quant_config=quant_config,
             prefix=maybe_prefix(prefix, "kernel_projection"),
             return_bias=False,
         )
@@ -130,6 +131,7 @@ class DFlash2Qwen3DecoderLayer(DFlashQwen3DecoderLayer):
             # Query tokens per request: the bonus token plus the mask tokens.
             block_size=1 + speculative_config.num_speculative_tokens,
             params_dtype=vllm_config.model_config.dtype,
+            quant_config=quant_config,
         )
         self.attention_conv = DFlashGroupedConv(
             **conv_args, prefix=maybe_prefix(prefix, "attention_conv")
@@ -193,6 +195,7 @@ class CandidateSelector(nn.Module):
         rank: int,
         top_k: int,
         params_dtype: torch.dtype,
+        quant_config: QuantizationConfig | None,
         prefix: str,
     ) -> None:
         super().__init__()
@@ -208,7 +211,7 @@ class CandidateSelector(nn.Module):
             rank,
             bias=False,
             params_dtype=params_dtype,
-            quant_config=None,
+            quant_config=quant_config,
             prefix=maybe_prefix(prefix, "hidden_projection"),
             return_bias=False,
         )
@@ -259,6 +262,7 @@ class DFlash2Qwen3Model(DFlashQwen3Model):
                 rank=int(draft_config["selector_rank"]),
                 top_k=int(draft_config["selector_top_k"]),
                 params_dtype=vllm_config.model_config.dtype,
+                quant_config=self.quant_config,
                 prefix=maybe_prefix(prefix, "candidate_selector"),
             )
 


### PR DESCRIPTION
## Resulting behavior

Status: **qualified** for the serialized ModelOpt MXFP8 checkpoint `local-inference-lab/GLM-5.3-Flash-DFlash2-MXFP8` at revision `b6d33aa93fc1ac5b23a88251a1c0ce0bfe2ad17c`.

DFlash2 propagates the draft quantization configuration into convolution and candidate-selector projections. After checkpoint loading, it constructs one fused context K/V projection from serialized MXFP8 values and E8M0 scales and executes that projection through the selected ModelOpt quantized linear kernel. The fused context path does not compute Q rows that are discarded by DFlash precomputation.

Unquantized DFlash checkpoints retain the fused BF16 projection. Every attention layer participating in one fused context projection must use the same MXFP8 state; a mixed MXFP8 and non-MXFP8 model fails before serialized weights are read.

## Source contract

- Base: `local-inference-lab/vllm:dev/jovian-judgement` at `c79f35ca00e8e93e0943a0d79b85b22b18aac939`.
- Head: `a1d4c8de40733b1f57c0960024444dd5d4f017d5`.
- Full-graph deployment dependency: `local-inference-lab/vllm#493`.
- Independent target and draft cache-format deployment dependency: `local-inference-lab/vllm#494`.
- Quantized fused context projection support is limited to `ModelOptMxFp8LinearMethod`. Other quantized formats retain their established behavior.

## Validation

- `tests/v1/spec_decode/test_dflash2.py`: 10 passed.
- Repository pre-commit hooks, including Ruff, mypy, SPDX, forbidden-import, and configuration checks: passed.
- `git diff --check`: passed.
- The composed TP4 runtime loaded the pinned GLM-5.3 NVFP4 target and MXFP8 DFlash2 draft, selected B12X MXFP8 draft linear kernels, captured all 16 DFlash2 full-graph shapes, and returned HTTP 200 for an OpenAI-compatible completion.
- Concurrency-16 decode for 30 seconds: 987.69 output tokens/s, 363.76 verifier steps/s, effective accepted length 2.7153, and zero request errors.
- Standalone 32,768-token cold prefill for 30 seconds: 12,692 input tokens/s over 10 samples.

## Duplicate-work check

`vllm-project/vllm#51620` provides a generic per-layer quantized fallback for DFlash-family context projection. That fallback calls every QKV projection and discards Q output. This pull request implements a materially different ModelOpt MXFP8 specialization: serialized values and scales are fused into one K/V-only projection and dispatched through the selected quantized linear kernel. The unquantized fast path remains unchanged.

No open `local-inference-lab/vllm` pull request implements the serialized ModelOpt MXFP8 DFlash2 projection contract.

## Review disclosure

OpenAI Codex assisted with implementation, checkpoint conversion, tests, full-graph qualification, benchmarking, and pull-request preparation. Human review of every changed line and the serialized scale-layout contract is required before merge.
