### PR TITLE
perf(spec-decode): bound autoregressive draft prefill graph memory

### DIFF
--- a/tests/v1/worker/test_gpu_autoregressive_speculator.py
+++ b/tests/v1/worker/test_gpu_autoregressive_speculator.py
@@ -20,7 +20,10 @@ from vllm.model_executor.models.mistral_large_3_eagle import (
 )
 from vllm.v1.attention.backends import flash_attn as flash_attn_module
 from vllm.v1.attention.backends.flash_attn import FlashAttentionMetadata
-from vllm.v1.worker.gpu.cudagraph_utils import BatchExecutionDescriptor
+from vllm.v1.worker.gpu.cudagraph_utils import (
+    BatchExecutionDescriptor,
+    CudaGraphManager,
+)
 from vllm.v1.worker.gpu.model_states.default import DefaultModelState
 from vllm.v1.worker.gpu.spec_decode import speculator as base_spec_module
 from vllm.v1.worker.gpu.spec_decode.autoregressive import speculator as spec_module
@@ -102,41 +105,60 @@ class _QSAIntervalLifecycle:
         self.calls.append("compact_topk")
 
 
-@pytest.mark.parametrize(
-    ("piecewise_prefill", "expected_prefill_mode"),
-    [
-        (False, CUDAGraphMode.FULL_AND_PIECEWISE),
-        (True, CUDAGraphMode.PIECEWISE),
-    ],
-)
-def test_autoregressive_speculator_can_limit_draft_prefill_to_piecewise_graphs(
+def test_autoregressive_speculator_uses_sparse_full_draft_prefill_graphs(
     monkeypatch,
-    piecewise_prefill: bool,
-    expected_prefill_mode: CUDAGraphMode,
 ) -> None:
-    manager_modes: list[CUDAGraphMode] = []
+    manager_args: list[tuple[CUDAGraphMode, dict[str, Any]]] = []
 
     def make_manager(_config, _device, mode, *args, **kwargs):
-        manager_modes.append(mode)
+        manager_args.append((mode, kwargs))
         return SimpleNamespace()
 
-    monkeypatch.setenv(
-        "VLLM_SPECULATOR_PREFILL_PIECEWISE",
-        "1" if piecewise_prefill else "0",
-    )
     monkeypatch.setattr(spec_module, "SpeculatorCudaGraphManager", make_manager)
 
     speculator = object.__new__(_TestSpeculator)
     speculator.vllm_config = SimpleNamespace()
     speculator.device = torch.device("cpu")
     speculator.num_speculative_steps = 5
+    speculator.max_num_reqs = 32
 
     speculator.init_cudagraph_manager(CUDAGraphMode.FULL_AND_PIECEWISE)
 
-    assert manager_modes == [
-        expected_prefill_mode,
-        CUDAGraphMode.FULL_DECODE_ONLY,
+    assert manager_args == [
+        (
+            CUDAGraphMode.FULL_AND_PIECEWISE,
+            {"full_capture_request_sizes": frozenset({1, 2, 4, 8, 16, 32})},
+        ),
+        (CUDAGraphMode.FULL_DECODE_ONLY, {}),
     ]
+
+
+def test_cudagraph_manager_excludes_uncaptured_full_candidates() -> None:
+    manager = object.__new__(CudaGraphManager)
+    manager.compilation_config = SimpleNamespace(
+        cudagraph_capture_sizes=[1, 2, 4, *range(8, 193, 8)],
+        max_cudagraph_capture_size=192,
+    )
+    manager.cudagraph_mode = CUDAGraphMode.FULL_AND_PIECEWISE
+    manager.max_num_reqs = 32
+    manager.decode_query_len = 6
+    manager.varlen_decode = False
+    manager.vllm_config = SimpleNamespace(speculative_config=None)
+    manager.lora_capture_cases = [0]
+    manager.full_capture_request_sizes = frozenset({1, 2, 4, 8, 16, 32})
+    manager._capture_descs = {}
+    manager._candidates = {}
+
+    manager._init_candidates()
+
+    full_descs = manager._capture_descs[CUDAGraphMode.FULL]
+    assert {desc.num_tokens for desc in full_descs} == {6, 12, 24, 48, 96, 192}
+    assert all(
+        desc.cg_mode != CUDAGraphMode.FULL
+        or desc.num_tokens in {6, 12, 24, 48, 96, 192}
+        for candidates in manager._candidates.values()
+        for desc in candidates
+    )
 
 
 def _mock_base_model_load(monkeypatch):

--- a/tests/v1/worker/test_gpu_autoregressive_speculator.py
+++ b/tests/v1/worker/test_gpu_autoregressive_speculator.py
@@ -102,6 +102,43 @@ class _QSAIntervalLifecycle:
         self.calls.append("compact_topk")
 
 
+@pytest.mark.parametrize(
+    ("piecewise_prefill", "expected_prefill_mode"),
+    [
+        (False, CUDAGraphMode.FULL_AND_PIECEWISE),
+        (True, CUDAGraphMode.PIECEWISE),
+    ],
+)
+def test_autoregressive_speculator_can_limit_draft_prefill_to_piecewise_graphs(
+    monkeypatch,
+    piecewise_prefill: bool,
+    expected_prefill_mode: CUDAGraphMode,
+) -> None:
+    manager_modes: list[CUDAGraphMode] = []
+
+    def make_manager(_config, _device, mode, *args, **kwargs):
+        manager_modes.append(mode)
+        return SimpleNamespace()
+
+    monkeypatch.setenv(
+        "VLLM_SPECULATOR_PREFILL_PIECEWISE",
+        "1" if piecewise_prefill else "0",
+    )
+    monkeypatch.setattr(spec_module, "SpeculatorCudaGraphManager", make_manager)
+
+    speculator = object.__new__(_TestSpeculator)
+    speculator.vllm_config = SimpleNamespace()
+    speculator.device = torch.device("cpu")
+    speculator.num_speculative_steps = 5
+
+    speculator.init_cudagraph_manager(CUDAGraphMode.FULL_AND_PIECEWISE)
+
+    assert manager_modes == [
+        expected_prefill_mode,
+        CUDAGraphMode.FULL_DECODE_ONLY,
+    ]
+
+
 def _mock_base_model_load(monkeypatch):
     monkeypatch.setattr(
         base_spec_module,

--- a/tests/v1/worker/test_gpu_autoregressive_speculator.py
+++ b/tests/v1/worker/test_gpu_autoregressive_speculator.py
@@ -129,7 +129,7 @@ def test_autoregressive_speculator_uses_sparse_full_draft_prefill_graphs(
             CUDAGraphMode.FULL_AND_PIECEWISE,
             {"full_capture_request_sizes": frozenset({1, 2, 4, 8, 16, 32})},
         ),
-        (CUDAGraphMode.FULL_DECODE_ONLY, {}),
+        (CUDAGraphMode.FULL_DECODE_ONLY, {"decode_query_len": 1}),
     ]
 
 

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -321,6 +321,7 @@ if TYPE_CHECKING:
     VLLM_ELASTIC_EP_SCALE_UP_LAUNCH: bool = False
     VLLM_ELASTIC_EP_DRAIN_REQUESTS: bool = False
     VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS: bool = True
+    VLLM_SPECULATOR_PREFILL_PIECEWISE: bool = False
     VLLM_NIXL_EP_MAX_NUM_RANKS: int = 32
     VLLM_XPU_ENABLE_XPU_GRAPH: bool = False
     VLLM_XPU_USE_SAMPLER_KERNEL: bool = True
@@ -2138,6 +2139,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # memory allocation. Enabled by default as of v0.21.0
     "VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS": lambda: bool(
         int(os.getenv("VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS", "1"))
+    ),
+    # Use piecewise CUDA graphs for autoregressive draft prefill while
+    # retaining the configured graph mode for decode.
+    "VLLM_SPECULATOR_PREFILL_PIECEWISE": lambda: bool(
+        int(os.getenv("VLLM_SPECULATOR_PREFILL_PIECEWISE", "0"))
     ),
     # NIXL EP environment variables
     "VLLM_NIXL_EP_MAX_NUM_RANKS": lambda: int(

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -321,7 +321,6 @@ if TYPE_CHECKING:
     VLLM_ELASTIC_EP_SCALE_UP_LAUNCH: bool = False
     VLLM_ELASTIC_EP_DRAIN_REQUESTS: bool = False
     VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS: bool = True
-    VLLM_SPECULATOR_PREFILL_PIECEWISE: bool = False
     VLLM_NIXL_EP_MAX_NUM_RANKS: int = 32
     VLLM_XPU_ENABLE_XPU_GRAPH: bool = False
     VLLM_XPU_USE_SAMPLER_KERNEL: bool = True
@@ -2139,11 +2138,6 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # memory allocation. Enabled by default as of v0.21.0
     "VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS": lambda: bool(
         int(os.getenv("VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS", "1"))
-    ),
-    # Use piecewise CUDA graphs for autoregressive draft prefill while
-    # retaining the configured graph mode for decode.
-    "VLLM_SPECULATOR_PREFILL_PIECEWISE": lambda: bool(
-        int(os.getenv("VLLM_SPECULATOR_PREFILL_PIECEWISE", "0"))
     ),
     # NIXL EP environment variables
     "VLLM_NIXL_EP_MAX_NUM_RANKS": lambda: int(

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -114,6 +114,7 @@ class CudaGraphManager:
         decode_query_len: int,
         lora_capture_cases: list[int] | None = None,
         varlen_decode: bool = False,
+        full_capture_request_sizes: frozenset[int] | None = None,
     ):
         self.vllm_config = vllm_config
         self.device = device
@@ -123,6 +124,7 @@ class CudaGraphManager:
         self.cudagraph_mode = cudagraph_mode
         self.decode_query_len = decode_query_len
         self.varlen_decode = varlen_decode
+        self.full_capture_request_sizes = full_capture_request_sizes
 
         self.dp_size = vllm_config.parallel_config.data_parallel_size
         self.tp_size = vllm_config.parallel_config.tensor_parallel_size
@@ -254,6 +256,11 @@ class CudaGraphManager:
                         rounded_num_tokens > max_decode_tokens
                         or rounded_num_tokens > max_cg_capture_size
                         or rounded_num_reqs > self.max_num_reqs
+                    ):
+                        continue
+                    if (
+                        self.full_capture_request_sizes is not None
+                        and rounded_num_reqs not in self.full_capture_request_sizes
                     ):
                         continue
 

--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
@@ -5,6 +5,7 @@ from typing import Any
 import torch
 import torch.nn as nn
 
+from vllm import envs
 from vllm.config import VllmConfig
 from vllm.config.compilation import CUDAGraphMode
 from vllm.forward_context import BatchDescriptor, set_forward_context
@@ -139,10 +140,25 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
 
     def init_cudagraph_manager(self, cudagraph_mode: CUDAGraphMode) -> None:
         # Initialize cudagraph manager for draft prefill (draft position 0).
+        prefill_cudagraph_mode = cudagraph_mode
+        if envs.VLLM_SPECULATOR_PREFILL_PIECEWISE:
+            if cudagraph_mode.has_piecewise_cudagraphs():
+                prefill_cudagraph_mode = CUDAGraphMode.PIECEWISE
+                logger.info_once(
+                    "Using piecewise-only CUDA graphs for autoregressive "
+                    "draft prefill; decode graph mode remains %s.",
+                    cudagraph_mode.decode_mode().name,
+                )
+            else:
+                logger.warning_once(
+                    "VLLM_SPECULATOR_PREFILL_PIECEWISE=1 was ignored because "
+                    "cudagraph mode %s has no piecewise graphs.",
+                    cudagraph_mode.name,
+                )
         self.prefill_cudagraph_manager = SpeculatorCudaGraphManager(
             self.vllm_config,
             self.device,
-            cudagraph_mode,
+            prefill_cudagraph_mode,
             self.num_speculative_steps + 1,
         )
 

--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
@@ -5,7 +5,6 @@ from typing import Any
 import torch
 import torch.nn as nn
 
-from vllm import envs
 from vllm.config import VllmConfig
 from vllm.config.compilation import CUDAGraphMode
 from vllm.forward_context import BatchDescriptor, set_forward_context
@@ -25,6 +24,17 @@ from vllm.v1.worker.gpu.spec_decode.speculator import DraftModelSpeculator
 from vllm.v1.worker.utils import AttentionGroup, get_uniform_decode_token_count
 
 logger = init_logger(__name__)
+
+
+def _sparse_full_capture_request_sizes(max_num_reqs: int) -> frozenset[int]:
+    """Return power-of-two request capacities, including the configured maximum."""
+    request_sizes = []
+    request_size = 1
+    while request_size < max_num_reqs:
+        request_sizes.append(request_size)
+        request_size *= 2
+    request_sizes.append(max_num_reqs)
+    return frozenset(request_sizes)
 
 
 class AutoRegressiveSpeculator(DraftModelSpeculator):
@@ -140,26 +150,15 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
 
     def init_cudagraph_manager(self, cudagraph_mode: CUDAGraphMode) -> None:
         # Initialize cudagraph manager for draft prefill (draft position 0).
-        prefill_cudagraph_mode = cudagraph_mode
-        if envs.VLLM_SPECULATOR_PREFILL_PIECEWISE:
-            if cudagraph_mode.has_piecewise_cudagraphs():
-                prefill_cudagraph_mode = CUDAGraphMode.PIECEWISE
-                logger.info_once(
-                    "Using piecewise-only CUDA graphs for autoregressive "
-                    "draft prefill; decode graph mode remains %s.",
-                    cudagraph_mode.decode_mode().name,
-                )
-            else:
-                logger.warning_once(
-                    "VLLM_SPECULATOR_PREFILL_PIECEWISE=1 was ignored because "
-                    "cudagraph mode %s has no piecewise graphs.",
-                    cudagraph_mode.name,
-                )
+        full_capture_request_sizes = _sparse_full_capture_request_sizes(
+            self.max_num_reqs
+        )
         self.prefill_cudagraph_manager = SpeculatorCudaGraphManager(
             self.vllm_config,
             self.device,
-            prefill_cudagraph_mode,
+            cudagraph_mode,
             self.num_speculative_steps + 1,
+            full_capture_request_sizes=full_capture_request_sizes,
         )
 
         # PIECEWISE cudagraphs are not supported for draft decodes.


### PR DESCRIPTION
## Purpose

Bound autoregressive draft-prefill CUDA-graph memory while retaining FULL replay for common decode request capacities. The draft-position-0 manager now captures a sparse power-of-two request ladder and leaves PIECEWISE available for non-uniform prefill shapes.

For MTP5 with `max_num_seqs=32`, the selected request capacities are `1, 2, 4, 8, 16, 32`, corresponding to token capacities `6, 12, 24, 48, 96, 192`. Candidate construction excludes every other FULL descriptor, so runtime dispatch cannot select a graph that was not captured.

## Why this is separate

This PR is focused on the autoregressive speculator's graph-capture policy. It does not duplicate the GLM kernel work in #495, #496, or #498, nor the CKV/DCP changes in #488. PR #503 was an aggregate reproduction snapshot and was closed as a duplicate; this surviving PR contains only the generally useful graph-memory change.

Duplicate searches found no local-inference-lab PR implementing a sparse FULL ladder for this manager. Upstream #43776 disables full EAGLE prefill graphs for live multimodal batches; it addresses multimodal correctness rather than bounded capture selection for autoregressive draft prefill.

## Validation

Source checks:

- `uvx ruff check` on all touched Python files: passed.
- `uvx ruff format` on all touched Python files: passed.
- `git diff --check`: passed.
- Focused Linux pytest in the source-locked SM120 image: `2 passed, 24 deselected`.

Runtime qualification used the reviewed sparse-FULL policy on 4x RTX PRO 6000 Blackwell at stock clocks with GLM-5.3-Flash-NVFP4, TP4, DCP4, MTP5, FP8 KV, B12X attention, Humming MoE, B12X linear, C32/B4096/524k, and FULL+PIECEWISE graphs.

- Capture evidence: target `27 PIECEWISE + 25 FULL`; MTP prefill `27 PIECEWISE + 6 FULL`; MTP decode `7 FULL`.
- Boot: 10,835,285 usable KV tokens, 9.64 GiB graph pool, CKV full gather active, zero restarts.
- Estonia c30/high: five runs scored `29, 29, 29, 27, 30`, averaging 28.8/30; 144/150 pass, zero errors, zero max-token truncations.
- Sustained prefill: 8K 8,666 tok/s, 64K 9,485 tok/s, 128K 9,393 tok/s.
- Sustained decode at 0/8K context: C1 105/112 tok/s, C8 550/541 tok/s, C32 1,166/1,183 tok/s; zero cell errors and zero server restarts.
- Compared with the prior qualified piecewise-prefill image, prefill changed by +1.2%/+0.2%/0.0%; C32 decode changed by -0.4%/+0.5%.

The reproducible community derivative is published at `ghcr.io/jackzampolin/glm53-flash-nvfp4-jovian@sha256:8defdcb4a8b282ae9d5889e098cda289c09cdce67da006612df37fb858b0aa7b`. Its release integration commit `a66b522873907084f6240e8866a1d681c749b4db` is the previously qualified production lineage plus commits patch-equivalent to this PR head.

## Review disclosure

OpenAI Codex assisted with implementation, tests, runtime qualification, and PR preparation. This remains a draft until Jack or another maintainer reviews every changed line and can defend the behavior end-to-end.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved autoregressive speculation CUDA graph handling by using sparse request-capacity captures.
  * Excluded unsupported request counts from uniform decode graph selection.
  * Preserved the configured maximum request capacity while reducing unnecessary graph captures.

* **Tests**
  * Added coverage for sparse prefill graph initialization and valid CUDA graph candidate filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->