### PR TITLE
perf(glm5next): bind verified KDA prefixes without staging

### DIFF
--- a/tests/models/test_glm5next_model.py
+++ b/tests/models/test_glm5next_model.py
@@ -555,7 +555,7 @@ def test_glm5next_b12x_kda_plan_reserves_null_state_zero(monkeypatch) -> None:
     assert captured_caps["null_state_index"] == 0
 
 
-def test_glm5next_b12x_kda_binds_caller_scratch_per_run(monkeypatch) -> None:
+def test_glm5next_b12x_kda_binds_spec_tensors_without_staging(monkeypatch) -> None:
     scratch = torch.empty(32, dtype=torch.uint8)
     bindings: list[dict[str, object]] = []
     runs: list[object] = []
@@ -620,12 +620,52 @@ def test_glm5next_b12x_kda_binds_caller_scratch_per_run(monkeypatch) -> None:
         num_requests=1,
     )
     layer._run_b12x_kda_decode_post_conv(**kwargs)
-    layer._run_b12x_kda_decode_post_conv(**kwargs)
+    spec_kwargs = dict(
+        mixed_qkv=torch.ones(4, 6),
+        raw_g=torch.ones(4, 1, 2),
+        raw_beta=torch.ones(4, 1),
+        z=torch.ones(4, 1, 2),
+        output=torch.empty(4, 1, 2),
+        state_indices=torch.tensor([[1, 2], [2, 1]], dtype=torch.int32),
+        query_start_loc=torch.tensor([0, 2, 4], dtype=torch.int32),
+        num_accepted_tokens=torch.tensor([1, 2], dtype=torch.int32),
+        num_requests=2,
+    )
+    layer._run_b12x_kda_decode_post_conv(**spec_kwargs)
 
     assert len(bindings) == 2
     assert bindings[0] is not bindings[1]
     assert bindings[0]["scratch"] is scratch
     assert bindings[1]["scratch"] is scratch
+    assert bindings[0]["mixed_qkv"] is layer._b12x_kda_mixed_qkv
+    assert bindings[0]["raw_g"] is layer._b12x_kda_raw_g
+    assert bindings[0]["raw_beta"] is layer._b12x_kda_raw_beta
+    assert bindings[0]["z"] is layer._b12x_kda_z
+    assert bindings[0]["output"] is layer._b12x_kda_output
+    assert bindings[0]["query_start_loc"] is layer._b12x_kda_query_start_loc
+    assert bindings[0]["state_indices"] is layer._b12x_kda_state_indices
+    assert bindings[0]["num_tokens"] is layer._b12x_kda_num_tokens
+    torch.testing.assert_close(bindings[0]["mixed_qkv"][0], kwargs["mixed_qkv"][0])
+    assert bindings[1]["mixed_qkv"] is spec_kwargs["mixed_qkv"]
+    assert (
+        bindings[1]["num_accepted_tokens"].data_ptr()
+        == spec_kwargs["num_accepted_tokens"].data_ptr()
+    )
+    assert (
+        bindings[1]["query_start_loc"].data_ptr()
+        == spec_kwargs["query_start_loc"].data_ptr()
+    )
+    assert (
+        bindings[1]["state_indices"].data_ptr()
+        == spec_kwargs["state_indices"].data_ptr()
+    )
+    assert bindings[1]["num_tokens"] is layer._b12x_kda_num_tokens
+    assert bindings[1]["num_tokens"].item() == spec_kwargs["mixed_qkv"].shape[0]
+    assert (
+        bindings[1]["num_tokens"].data_ptr()
+        != spec_kwargs["query_start_loc"][2:].data_ptr()
+    )
+    assert bindings[1]["output"].data_ptr() == spec_kwargs["output"].data_ptr()
     assert len(runs) == 2
     assert runs[0] is bindings[0]
     assert runs[1] is bindings[1]

--- a/vllm/model_executor/layers/mamba/gdn/kimi_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/kimi_gdn_linear_attn.py
@@ -503,6 +503,7 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
             num_tokens > self._b12x_kda_max_tokens
             or num_requests > self._b12x_kda_max_seqs
             or state_columns > self._b12x_kda_state_index_columns
+            or num_tokens > num_requests * state_columns
         ):
             raise ValueError(
                 "b12x KDA capacity exceeded: "
@@ -511,6 +512,49 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
                 f"state_columns={state_columns}/"
                 f"{self._b12x_kda_state_index_columns}"
             )
+
+        scratch_buffers = current_workspace_manager().get_simultaneous(
+            *plan.shapes_and_dtypes()
+        )
+        if not scratch_buffers:
+            raise RuntimeError("b12x KDA plan did not expose caller scratch")
+        scratch: torch.Tensor | tuple[torch.Tensor, ...]
+        scratch = (
+            scratch_buffers[0] if len(scratch_buffers) == 1 else tuple(scratch_buffers)
+        )
+
+        if (
+            num_accepted_tokens is not None
+            and state_columns == self._b12x_kda_state_index_columns
+        ):
+            self._b12x_kda_num_seqs.fill_(num_requests)
+            self._b12x_kda_num_tokens.fill_(num_tokens)
+            query_start_loc = query_start_loc[: num_requests + 1]
+            binding = api.bind_kda(
+                plan,
+                scratch=scratch,
+                mixed_qkv=mixed_qkv,
+                raw_g=raw_g,
+                raw_beta=raw_beta,
+                z=z,
+                A_log=self.A_log,
+                dt_bias=self.dt_bias.view(self.local_num_heads, self.head_dim),
+                norm_weight=self.o_norm.weight,
+                recurrent_state=self.kv_cache[1],
+                query_start_loc=query_start_loc,
+                num_accepted_tokens=num_accepted_tokens[:num_requests],
+                state_indices=state_indices[:num_requests, :state_columns],
+                num_seqs=self._b12x_kda_num_seqs,
+                num_tokens=self._b12x_kda_num_tokens,
+                output=output[:num_tokens],
+            )
+            api.run_kda(
+                binding,
+                lower_bound=self.gate_lower_bound,
+                eps=self.o_norm.eps,
+                scale=self.head_dim**-0.5,
+            )
+            return
 
         self._b12x_kda_mixed_qkv[:num_tokens].copy_(mixed_qkv)
         self._b12x_kda_raw_g[:num_tokens].copy_(raw_g)
@@ -530,19 +574,8 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
             state_indices[:num_requests]
         )
         self._b12x_kda_num_seqs.fill_(num_requests)
-        self._b12x_kda_num_tokens.copy_(
-            query_start_loc[num_requests : num_requests + 1]
-        )
+        self._b12x_kda_num_tokens.fill_(num_tokens)
 
-        scratch_buffers = current_workspace_manager().get_simultaneous(
-            *plan.shapes_and_dtypes()
-        )
-        if not scratch_buffers:
-            raise RuntimeError("b12x KDA plan did not expose caller scratch")
-        scratch: torch.Tensor | tuple[torch.Tensor, ...]
-        scratch = (
-            scratch_buffers[0] if len(scratch_buffers) == 1 else tuple(scratch_buffers)
-        )
         binding = api.bind_kda(
             plan,
             scratch=scratch,


### PR DESCRIPTION
## Summary

- Bind GLM speculative verified-prefix tensors through B12X's existing `bind_kda` / `run_kda` contract instead of copying them into plan-sized staging buffers.
- Supply the actual projected row count through vLLM's dedicated live-token scalar, independently of the terminal query offset.
- Keep ordinary non-speculative KDA decode on the established staged path.

This PR remains stacked on #495 and requires local-inference-lab/b12x#253. B12X #252 is not a dependency.

## Why

During MTP or DFlash verification, vLLM already owns exact-size projected Q/K/V/gate tensors, accepted-prefix lengths, query offsets, state indices, and output storage. Directly binding those tensors removes per-layer staging copies without changing model math.

The independent live-token scalar is also a correctness requirement: B12X compares it with `query_start_loc[num_requests]`, so trailing live tokens cannot be left unowned by the packed request layout. Sampling, quantization, attention, MoE, and output math are unchanged.

## Correctness and tests

Focused vLLM test in the serving image:

```bash
/opt/venv/bin/python -m pytest --confcutdir=tests/models \
  tests/models/test_glm5next_model.py -q \
  -k b12x_kda_binds_spec_tensors_without_staging
```

Result: `1 passed, 38 deselected`.

The test proves ordinary decode still stages, speculative decode binds caller-owned tensors/output, and the direct route's `num_tokens` is the dedicated live-count buffer rather than a view of the terminal query offset.

The exact B12X #253 head passed its complete SM120 KDA file: `16/16 passed`. That includes two distinct reduced capacities under frozen kernel resolution, unchanged Triton cache cardinality, strided `raw_beta`, CUDA graph replay, and transactional terminal-offset rejection without recurrent-state mutation.

Static checks:

```bash
uvx ruff check vllm/model_executor/layers/mamba/gdn/kimi_gdn_linear_attn.py tests/models/test_glm5next_model.py
uvx ruff format --check vllm/model_executor/layers/mamba/gdn/kimi_gdn_linear_attn.py tests/models/test_glm5next_model.py
git diff --check da60b74f2a6aadbb0dcb53a97590b159fae96431...71ad9871ed6574cd559ffbe123843c48013ea7c9
```

All passed.

## Performance evidence

An earlier matched staged/direct-binding A/B isolated the same staging-removal mechanism before B12X's interface was refactored internally. Both arms used the same GLM-5.3-Flash-NVFP4 TP4 stack, W4A4 target MoE, probabilistic MTP3, FP8 KV, C32 capacity, 1M model length, 8,192-token batching, CUDA graphs capped at 128 rows, and normal model sampling.

| Arm | C1 delivered tok/s | C1 verifier steps/s | C30 aggregate tok/s | C30 verifier steps/s |
|---|---:|---:|---:|---:|
| staged control | 174.5 | 70.59 | 1,510.2 | 608.07 |
| direct binding, run 1 | 167.7 | 74.35 | 1,527.5 | 618.09 |
| direct binding, run 2 | 184.6 | 74.00 | 1,526.0 | 609.52 |

The isolated A/B supports the mechanism: C1 verifier work increased about 5.1%; mean C30 delivered throughput increased about 1.1%. Delivered C1 throughput varies with stochastic draft acceptance.

The exact final heads were requalified after the independent live-token fix. This is integration qualification, not isolated attribution to this PR:

| Run | Delivered tok/s | Verifier steps/s | Mean accepted length |
|---|---:|---:|---:|
| C1, final heads | 199.3 | 79.82 | 2.50 |

No temperature override was used. Ratio direction is candidate/control, higher is better.

Raw-result SHA-256:

- isolated staged control: `fde1050b574af48e31dece2ed3908730e78de33342e2df2ec1f6301d9ed780a4`
- isolated direct run 1: `42f4690dc6bbca86f194de02f748e5907d74c7b34458f7ead4e874fcc5dcd7b2`
- isolated direct run 2: `1119f71dc5a4cdbdd2d9fe198ce3b966d1dce1198ddcba86b8dc35f373b7ed72`
- final-head C1: `abc8891fcec2b1a98cbb90d0d5ea3520248fe8a31a40a1a3a26404558f3e1148`

Benchmark client: `llm_decode_bench` v0.4.29 at `29b8f0ecd16b061114adc3610a95e8f7a1979a69`.

## Provenance

- vLLM base (#495): `da60b74f2a6aadbb0dcb53a97590b159fae96431`
- vLLM head: `71ad9871ed6574cd559ffbe123843c48013ea7c9`
- B12X base: `2fcf23a0ce269be27b2e03fece73d46e90e6aeea`
- B12X #253 head: `3c485daaa0140bf00d0172c55e3af83e445e2de5`
- base serving image ID: `sha256:aef068522bbcfd6f0e4b865d39f8aca80d090af813c65960d743a0486d87f48c`; the exact PR source files were bind-mounted over that image.

The qualification box used four NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition GPUs at 300 W. During C1 all four were P1, memory clock was 16,365 MHz, graphics clocks were 2,265-2,302 MHz, and the active throttle mask was zero.

## Duplicate-work check

- #490 integrates the closed B12X #249 public single-token API; it does not cover speculative verified prefixes and is structurally different.
- #495 owns server-lifetime backend selection and caller scratch; this PR is stacked on it instead of duplicating it.
- Closed #491 was the integrated qualification tree; this PR contains only the focused caller change.
- Current searches found no open equivalent in `vllm-project/vllm` or local-inference-lab/vllm.

OpenAI Codex assisted with implementation, tests, profiling, benchmarking, and PR preparation. The human submitter must review and be able to defend every changed line before merge.
