### PR TITLE
perf(glm5next): parallelize C4 prefill pool writes

### DIFF
--- a/tests/models/test_glm5next_pooled_indexer.py
+++ b/tests/models/test_glm5next_pooled_indexer.py
@@ -458,7 +458,7 @@ def test_glm53_decode_tail_completes_the_same_pool_as_prefill() -> None:
     torch.testing.assert_close(actual_scale, expected_scale.reshape(1), rtol=0, atol=0)
 
 
-def test_glm53_decode_writer_matches_batched_prefill_writer() -> None:
+def test_glm53_decode_writer_matches_parallel_prefill_writer() -> None:
     device = _require_glm_gpu()
     generator = torch.Generator(device=device).manual_seed(56)
     key = torch.randn(
@@ -486,9 +486,13 @@ def test_glm53_decode_writer_matches_batched_prefill_writer() -> None:
         key,
         gate,
         ape,
-        torch.tensor([-1, -1, -1, 0, -1, -1, -1, 1], device=device),
+        torch.tensor([-1, -1, -1, 3, -1, -1, -1, 7], device=device),
         torch.arange(8, dtype=torch.int64, device=device),
         1,
+        num_decode_requests=0,
+        max_query_len=8,
+        model_block_size=256,
+        parent_stride_pages=1,
     )
     for position in range(8):
         update_decode_pools(
@@ -500,16 +504,201 @@ def test_glm53_decode_writer_matches_batched_prefill_writer() -> None:
             gate[position : position + 1],
             ape,
             torch.tensor(
-                [position // 4 if position % 4 == 3 else -1],
+                [position if position % 4 == 3 else -1],
                 dtype=torch.int64,
                 device=device,
             ),
             torch.tensor([position], dtype=torch.int64, device=device),
             1,
+            model_block_size=256,
+            parent_stride_pages=1,
         )
 
     assert torch.equal(decode_cache, prefill_cache)
     assert torch.equal(decode_tail, prefill_tail)
+
+
+def test_glm53_parallel_prefill_preserves_boundary_tail_and_state_slots() -> None:
+    device = _require_glm_gpu()
+    generator = torch.Generator(device=device).manual_seed(5304)
+    key = torch.randn(
+        (10, 128), generator=generator, device=device, dtype=torch.bfloat16
+    )
+    gate = torch.randn(
+        (10, 128), generator=generator, device=device, dtype=torch.bfloat16
+    )
+    ape = torch.randn(
+        (4, 128), generator=generator, device=device, dtype=torch.bfloat16
+    )
+    initial_tail = torch.randn(
+        (2, 2, 4, 128), generator=generator, device=device, dtype=torch.bfloat16
+    )
+    sequential_tail = initial_tail.clone()
+    parallel_tail = initial_tail.clone()
+    sequential_cache = torch.zeros((2, 64, 132), dtype=torch.uint8, device=device)
+    parallel_cache = torch.zeros_like(sequential_cache)
+    state_slots = torch.tensor([1, 0], dtype=torch.int32, device=device)
+    query_start_loc = torch.tensor([0, 5, 10], dtype=torch.int32, device=device)
+    positions = torch.tensor(
+        [4099, 4100, 4101, 4102, 4103, 4099, 4100, 4101, 4102, 4103],
+        dtype=torch.int64,
+        device=device,
+    )
+    slot_mapping = torch.tensor(
+        [3, -1, -1, -1, 7, 259, -1, -1, -1, 263],
+        dtype=torch.int64,
+        device=device,
+    )
+    common = dict(model_block_size=256, parent_stride_pages=1)
+
+    update_decode_pools(
+        sequential_cache,
+        sequential_tail,
+        state_slots,
+        query_start_loc,
+        key,
+        gate,
+        ape,
+        slot_mapping,
+        positions,
+        2,
+        **common,
+    )
+    update_decode_pools(
+        parallel_cache,
+        parallel_tail,
+        state_slots,
+        query_start_loc,
+        key,
+        gate,
+        ape,
+        slot_mapping,
+        positions,
+        2,
+        num_decode_requests=0,
+        max_query_len=5,
+        **common,
+    )
+
+    assert torch.equal(parallel_cache, sequential_cache)
+    assert torch.equal(parallel_tail, sequential_tail)
+
+
+def test_glm53_parallel_prefill_coexists_with_decode_requests() -> None:
+    device = _require_glm_gpu()
+    generator = torch.Generator(device=device).manual_seed(5306)
+    key = torch.randn(
+        (9, 128), generator=generator, device=device, dtype=torch.bfloat16
+    )
+    gate = torch.randn(
+        (9, 128), generator=generator, device=device, dtype=torch.bfloat16
+    )
+    ape = torch.randn(
+        (4, 128), generator=generator, device=device, dtype=torch.bfloat16
+    )
+    initial_tail = torch.randn(
+        (2, 2, 4, 128), generator=generator, device=device, dtype=torch.bfloat16
+    )
+    mixed_tail = initial_tail.clone()
+    reference_tail = initial_tail.clone()
+    mixed_cache = torch.zeros((2, 64, 132), dtype=torch.uint8, device=device)
+    reference_cache = torch.zeros_like(mixed_cache)
+    state_slots = torch.tensor([0, 1], dtype=torch.int32, device=device)
+    positions = torch.tensor(
+        [3, 0, 1, 2, 3, 4, 5, 6, 7], dtype=torch.int64, device=device
+    )
+    slot_mapping = torch.tensor(
+        [3, -1, -1, -1, 259, -1, -1, -1, 263],
+        dtype=torch.int64,
+        device=device,
+    )
+    common = dict(model_block_size=256, parent_stride_pages=1)
+
+    update_decode_pools(
+        mixed_cache,
+        mixed_tail,
+        state_slots,
+        torch.tensor([0, 1, 9], dtype=torch.int32, device=device),
+        key,
+        gate,
+        ape,
+        slot_mapping,
+        positions,
+        2,
+        num_decode_requests=1,
+        max_query_len=8,
+        **common,
+    )
+    update_decode_pools(
+        reference_cache,
+        reference_tail,
+        state_slots[:1],
+        torch.tensor([0, 1], dtype=torch.int32, device=device),
+        key[:1],
+        gate[:1],
+        ape,
+        slot_mapping[:1],
+        positions[:1],
+        1,
+        **common,
+    )
+    update_decode_pools(
+        reference_cache,
+        reference_tail,
+        state_slots[1:],
+        torch.tensor([0, 8], dtype=torch.int32, device=device),
+        key[1:],
+        gate[1:],
+        ape,
+        slot_mapping[1:],
+        positions[1:],
+        1,
+        **common,
+    )
+
+    assert torch.equal(mixed_cache, reference_cache)
+    assert torch.equal(mixed_tail, reference_tail)
+
+
+def test_glm53_parallel_prefill_ignores_invalid_dummy_slots() -> None:
+    device = _require_glm_gpu()
+    generator = torch.Generator(device=device).manual_seed(5305)
+    key = torch.randn(
+        (8, 128), generator=generator, device=device, dtype=torch.bfloat16
+    )
+    gate = torch.randn(
+        (8, 128), generator=generator, device=device, dtype=torch.bfloat16
+    )
+    ape = torch.randn(
+        (4, 128), generator=generator, device=device, dtype=torch.bfloat16
+    )
+    cache = torch.zeros((1, 64, 132), dtype=torch.uint8, device=device)
+    initial_tail = torch.randn(
+        (1, 2, 4, 128), generator=generator, device=device, dtype=torch.bfloat16
+    )
+    tail = initial_tail.clone()
+
+    update_decode_pools(
+        cache,
+        tail,
+        torch.zeros(1, dtype=torch.int32, device=device),
+        torch.tensor([0, 8], dtype=torch.int32, device=device),
+        key,
+        gate,
+        ape,
+        torch.full((8,), -1, dtype=torch.int64, device=device),
+        torch.zeros(8, dtype=torch.int64, device=device),
+        1,
+        num_decode_requests=0,
+        max_query_len=8,
+        model_block_size=256,
+        parent_stride_pages=1,
+    )
+
+    assert torch.count_nonzero(cache).item() == 0
+    torch.testing.assert_close(tail[0, 0, 0], key[-1])
+    torch.testing.assert_close(tail[0, 1, 0], gate[-1])
+    assert torch.equal(tail[:, :, 1:], initial_tail[:, :, 1:])
 
 
 def test_glm53_tail_state_isolated_between_requests() -> None:

--- a/tests/models/test_glm5next_pooled_indexer.py
+++ b/tests/models/test_glm5next_pooled_indexer.py
@@ -10,6 +10,8 @@ from torch import nn
 
 from vllm.models.deepseek_v4.nvidia.b12x_indexer import _flatten_index_cache
 from vllm.models.glm5next.nvidia.ops.glm_kpool import (
+    _prefill_pool_kernel,
+    _prefill_tail_kernel,
     expand_c4_block_table,
     expand_pool_ids,
     gather_c4_block_table_rows,
@@ -34,6 +36,12 @@ def _require_glm_gpu() -> torch.device:
     ):
         pytest.skip("GLM-5.3 GPU tests require SM120 or SM121")
     return device
+
+
+@pytest.mark.parametrize("kernel", [_prefill_pool_kernel, _prefill_tail_kernel])
+def test_glm53_parallel_prefill_request_offset_stays_runtime(kernel) -> None:
+    assert kernel.do_not_specialize == ["request_offset"]
+    assert kernel.do_not_specialize_on_alignment == ["request_offset"]
 
 
 def _hadamard128(x: torch.Tensor) -> torch.Tensor:

--- a/vllm/models/glm5next/nvidia/ops/glm_kpool.py
+++ b/vllm/models/glm5next/nvidia/ops/glm_kpool.py
@@ -298,6 +298,8 @@ def _prefill_pool_kernel(
         slot_mapping + completion_row, mask=write_pool, other=-1
     ).to(tl.int64)
     write_pool &= main_cache_location >= 0
+    if write_pool == 0:
+        return
     parent_page = main_cache_location // model_block_size
     model_page_offset = main_cache_location - parent_page * model_block_size
     pool_offset = model_page_offset // POOL_SIZE

--- a/vllm/models/glm5next/nvidia/ops/glm_kpool.py
+++ b/vllm/models/glm5next/nvidia/ops/glm_kpool.py
@@ -251,7 +251,10 @@ def _decode_update_kernel(
         tl.store(tail + base + tail_stride_1 + dim, current_gate, mask=dim_mask)
 
 
-@triton.jit
+@triton.jit(
+    do_not_specialize=["request_offset"],
+    do_not_specialize_on_alignment=["request_offset"],
+)
 def _prefill_pool_kernel(
     cache_fp8,
     cache_fp32,
@@ -389,7 +392,10 @@ def _prefill_pool_kernel(
     )
 
 
-@triton.jit
+@triton.jit(
+    do_not_specialize=["request_offset"],
+    do_not_specialize_on_alignment=["request_offset"],
+)
 def _prefill_tail_kernel(
     tail,
     state_slots,

--- a/vllm/models/glm5next/nvidia/ops/glm_kpool.py
+++ b/vllm/models/glm5next/nvidia/ops/glm_kpool.py
@@ -251,6 +251,195 @@ def _decode_update_kernel(
         tl.store(tail + base + tail_stride_1 + dim, current_gate, mask=dim_mask)
 
 
+@triton.jit
+def _prefill_pool_kernel(
+    cache_fp8,
+    cache_fp32,
+    tail,
+    state_slots,
+    query_start_loc,
+    key,
+    gate,
+    ape,
+    slot_mapping,
+    positions,
+    page_stride_bytes,
+    model_block_size,
+    parent_stride_pages,
+    tail_stride_0,
+    tail_stride_1,
+    tail_stride_2,
+    key_stride_0,
+    gate_stride_0,
+    ape_stride_0,
+    request_offset,
+    PAGE_SIZE: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    POOL_SIZE: tl.constexpr,
+    FP8_MAX: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    request = request_offset + tl.program_id(0)
+    pool_ordinal = tl.program_id(1)
+    state_slot = tl.load(state_slots + request).to(tl.int64)
+    start = tl.load(query_start_loc + request).to(tl.int64)
+    end = tl.load(query_start_loc + request + 1).to(tl.int64)
+    has_rows = end > start
+    first_position = tl.load(positions + start, mask=has_rows, other=0).to(tl.int64)
+    first_physical_slot = first_position % POOL_SIZE
+    first_completion = start + (POOL_SIZE - 1 - first_physical_slot)
+    completion_row = first_completion + pool_ordinal * POOL_SIZE
+    write_pool = has_rows & (completion_row < end) & (state_slot >= 0)
+    completion_position = tl.load(
+        positions + completion_row, mask=write_pool, other=-1
+    ).to(tl.int64)
+    write_pool &= completion_position % POOL_SIZE == POOL_SIZE - 1
+    main_cache_location = tl.load(
+        slot_mapping + completion_row, mask=write_pool, other=-1
+    ).to(tl.int64)
+    write_pool &= main_cache_location >= 0
+    parent_page = main_cache_location // model_block_size
+    model_page_offset = main_cache_location - parent_page * model_block_size
+    pool_offset = model_page_offset // POOL_SIZE
+    child_page = pool_offset // PAGE_SIZE
+    child_offset = pool_offset - child_page * PAGE_SIZE
+    cache_location = (
+        parent_page * parent_stride_pages + child_page
+    ) * PAGE_SIZE + child_offset
+
+    dim = tl.arange(0, BLOCK_D)
+    dim_mask = dim < HEAD_DIM
+    maximum = tl.full((BLOCK_D,), -float("inf"), tl.float32)
+    for slot in tl.static_range(0, POOL_SIZE):
+        source_row = completion_row - (POOL_SIZE - 1 - slot)
+        from_current_chunk = source_row >= start
+        tail_offset = (
+            state_slot * tail_stride_0 + tail_stride_1 + slot * tail_stride_2 + dim
+        )
+        current_score = tl.load(
+            gate + source_row * gate_stride_0 + dim,
+            mask=dim_mask & write_pool & from_current_chunk,
+            other=0.0,
+        ).to(tl.float32)
+        previous_score = tl.load(
+            tail + tail_offset,
+            mask=dim_mask & write_pool & ~from_current_chunk,
+            other=0.0,
+        ).to(tl.float32)
+        score = tl.where(from_current_chunk, current_score, previous_score)
+        score += tl.load(
+            ape + slot * ape_stride_0 + dim,
+            mask=dim_mask & write_pool,
+            other=0.0,
+        ).to(tl.float32)
+        maximum = tl.maximum(maximum, score)
+
+    numerator = tl.zeros((BLOCK_D,), tl.float32)
+    denominator = tl.zeros((BLOCK_D,), tl.float32)
+    for slot in tl.static_range(0, POOL_SIZE):
+        source_row = completion_row - (POOL_SIZE - 1 - slot)
+        from_current_chunk = source_row >= start
+        tail_offset = state_slot * tail_stride_0 + slot * tail_stride_2 + dim
+        current_value = tl.load(
+            key + source_row * key_stride_0 + dim,
+            mask=dim_mask & write_pool & from_current_chunk,
+            other=0.0,
+        ).to(tl.float32)
+        previous_value = tl.load(
+            tail + tail_offset,
+            mask=dim_mask & write_pool & ~from_current_chunk,
+            other=0.0,
+        ).to(tl.float32)
+        value = tl.where(from_current_chunk, current_value, previous_value)
+        current_score = tl.load(
+            gate + source_row * gate_stride_0 + dim,
+            mask=dim_mask & write_pool & from_current_chunk,
+            other=0.0,
+        ).to(tl.float32)
+        previous_score = tl.load(
+            tail + tail_offset + tail_stride_1,
+            mask=dim_mask & write_pool & ~from_current_chunk,
+            other=0.0,
+        ).to(tl.float32)
+        score = tl.where(from_current_chunk, current_score, previous_score)
+        score += tl.load(
+            ape + slot * ape_stride_0 + dim,
+            mask=dim_mask & write_pool,
+            other=0.0,
+        ).to(tl.float32)
+        weight = tl.exp(score - maximum)
+        numerator += value * weight
+        denominator += weight
+
+    pooled = numerator / tl.maximum(denominator, 1e-20)
+    _write_pool(
+        cache_fp8,
+        cache_fp32,
+        cache_location,
+        pooled,
+        dim,
+        dim_mask,
+        write_pool,
+        page_stride_bytes,
+        PAGE_SIZE,
+        HEAD_DIM,
+        FP8_MAX,
+    )
+
+
+@triton.jit
+def _prefill_tail_kernel(
+    tail,
+    state_slots,
+    query_start_loc,
+    key,
+    gate,
+    positions,
+    request_offset,
+    tail_stride_0,
+    tail_stride_1,
+    tail_stride_2,
+    key_stride_0,
+    gate_stride_0,
+    HEAD_DIM: tl.constexpr,
+    POOL_SIZE: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    request = request_offset + tl.program_id(0)
+    state_slot = tl.load(state_slots + request).to(tl.int64)
+    start = tl.load(query_start_loc + request).to(tl.int64)
+    end = tl.load(query_start_loc + request + 1).to(tl.int64)
+    last_row = end - 1
+    has_rows = end > start
+    last_position = tl.load(positions + last_row, mask=has_rows, other=0).to(tl.int64)
+    last_physical_slot = last_position % POOL_SIZE
+    dim = tl.arange(0, BLOCK_D)
+    dim_mask = (dim < HEAD_DIM) & has_rows & (state_slot >= 0)
+    for slot in tl.static_range(0, POOL_SIZE):
+        distance = (last_physical_slot - slot + POOL_SIZE) % POOL_SIZE
+        source_row = last_row - distance
+        source_in_chunk = source_row >= start
+        source_position = tl.load(
+            positions + source_row,
+            mask=has_rows & source_in_chunk,
+            other=-1,
+        ).to(tl.int64)
+        write_slot = dim_mask & source_in_chunk & (source_position % POOL_SIZE == slot)
+        value = tl.load(
+            key + source_row * key_stride_0 + dim,
+            mask=write_slot,
+            other=0.0,
+        )
+        score = tl.load(
+            gate + source_row * gate_stride_0 + dim,
+            mask=write_slot,
+            other=0.0,
+        )
+        tail_offset = state_slot * tail_stride_0 + slot * tail_stride_2 + dim
+        tl.store(tail + tail_offset, value, mask=write_slot)
+        tl.store(tail + tail_offset + tail_stride_1, score, mask=write_slot)
+
+
 def update_decode_pools(
     kv_cache: torch.Tensor,
     tail: torch.Tensor,
@@ -263,10 +452,18 @@ def update_decode_pools(
     positions: torch.Tensor,
     num_requests: int,
     *,
+    num_decode_requests: int | None = None,
+    max_query_len: int | None = None,
     model_block_size: int | None = None,
     parent_stride_pages: int | None = None,
 ) -> None:
-    """Update raw tails and write every newly completed FP8 pool."""
+    """Update request tails and write every newly completed FP8 C4 pool.
+
+    Decode and speculative-decode requests retain ordered row processing. Prefill
+    requests use one program per completed pool and a separate final-tail update;
+    their positions must be consecutive within each request, as required by the
+    packed GLM MLA cache contract.
+    """
     if num_requests <= 0:
         return
     page_size = int(kv_cache.shape[1])
@@ -287,7 +484,17 @@ def update_decode_pools(
     assert parent_stride_pages is not None
     if parent_stride_pages <= 0:
         raise ValueError("GLM parent_stride_pages must be positive")
-    _decode_update_kernel[(num_requests,)](
+    if num_decode_requests is None:
+        num_decode_requests = num_requests
+    if not 0 <= num_decode_requests <= num_requests:
+        raise ValueError("GLM decode request count exceeds the request batch")
+    num_prefill_requests = num_requests - num_decode_requests
+    if num_prefill_requests and not packed_main_slots:
+        raise ValueError("parallel GLM prefill requires packed main-cache slots")
+    if num_prefill_requests and (max_query_len is None or max_query_len <= 0):
+        raise ValueError("parallel GLM prefill requires a positive max_query_len")
+
+    common_args = (
         kv_cache.view(torch.float8_e4m3fn),
         kv_cache.view(torch.float32),
         tail,
@@ -307,14 +514,48 @@ def update_decode_pools(
         int(key.stride(0)),
         int(gate.stride(0)),
         int(ape.stride(0)),
+    )
+    common_meta = dict(
         PAGE_SIZE=page_size,
         HEAD_DIM=_HEAD_DIM,
         POOL_SIZE=_POOL_SIZE,
         FP8_MAX=_FP8_MAX,
         BLOCK_D=128,
-        PACKED_MAIN_SLOTS=packed_main_slots,
         num_warps=4,
     )
+    if num_decode_requests:
+        _decode_update_kernel[(num_decode_requests,)](
+            *common_args,
+            PACKED_MAIN_SLOTS=packed_main_slots,
+            **common_meta,
+        )
+    if num_prefill_requests:
+        assert max_query_len is not None
+        _prefill_pool_kernel[
+            (num_prefill_requests, triton.cdiv(max_query_len, _POOL_SIZE))
+        ](
+            *common_args,
+            num_decode_requests,
+            **common_meta,
+        )
+        _prefill_tail_kernel[(num_prefill_requests,)](
+            tail,
+            state_slots,
+            query_start_loc,
+            key,
+            gate,
+            positions,
+            num_decode_requests,
+            int(tail.stride(0)),
+            int(tail.stride(1)),
+            int(tail.stride(2)),
+            int(key.stride(0)),
+            int(gate.stride(0)),
+            HEAD_DIM=_HEAD_DIM,
+            POOL_SIZE=_POOL_SIZE,
+            BLOCK_D=128,
+            num_warps=4,
+        )
 
 
 @triton.jit

--- a/vllm/models/glm5next/nvidia/pooled_indexer.py
+++ b/vllm/models/glm5next/nvidia/pooled_indexer.py
@@ -429,6 +429,8 @@ class Glm5NextPooledIndexer(nn.Module):
             main_metadata.slot_mapping[:rows],
             positions,
             num_reqs,
+            num_decode_requests=num_decodes,
+            max_query_len=int(main_metadata.max_query_len),
             model_block_size=self.block_size,
             parent_stride_pages=self._parent_stride_pages,
         )


### PR DESCRIPTION
## Result

Status: **implemented and correctness-qualified on SM120**. The kernel-level
performance result is qualified. The TP4 serving-throughput observation is
**research-only** because the comparison has one baseline run, three candidate
runs, and different observed host CPU load.

Packed GLM5Next prefill launches one Triton program per completed four-token
C4 pool and one program per request to persist the final tail. Decode and
speculative-decode requests retain the ordered row writer because a row may
depend on tail state written by the preceding row. The C4 top-k selector,
packed FP8 cache layout, and B12X key-driven-attention route are unchanged.

## Technical reason

The ordered writer assigns an entire request to one Triton program. A
4,080-token scheduler payload therefore serializes approximately 1,020
completed pools. Completed prefill pools are independent after the initial
partial-pool boundary: a program can read boundary values from the persistent
tail and construct one completed pool without communicating with another
program. A separate kernel writes only the four tail slots needed by a later
chunk.

Padded pool programs return before pooling, the fast Walsh-Hadamard transform,
and FP8 quantization. This preserves the rectangular launch required by Triton
while avoiding work for requests shorter than `max_query_len`.

## Operation contract and compatibility

- The parallel path requires packed main-cache slot mappings, as defined by the
  GLM5Next packed MLA cache contract.
- Callers that omit `num_decode_requests` retain the ordered writer.
- Mixed batches process the leading decode requests with the ordered writer and
  the trailing prefill requests with the parallel writer, matching vLLM
  attention-metadata ordering.
- Positions within each prefill request must be consecutive.
- Negative state slots and negative dummy cache slots do not write cache or
  tail state.
- Cache quantization, page addressing, B12X selector routing, decode behavior,
  speculative-decode behavior, and public cache layouts are unchanged.

## Duplicate-work check

The repository search found local pull request #496 and upstream vLLM pull
request vllm-project/vllm#53906.

- #496 gathers the visible packed FP8 page-tail cache and changes prefill
  ranking to a DeepGEMM path. This change retains the B12X selector and packed
  cache route and only parallelizes construction of completed C4 pools.
- vllm-project/vllm#53906 provides broad GLM-5.3 support through a different
  k-pool construction interface. It does not modify the
  `vllm/models/glm5next/nvidia/ops/glm_kpool.py` writer used by the
  `dev/jovian-judgement` branch.

The implementation therefore does not duplicate either change.

## Correctness validation

Source base: `dev/jovian-judgement` at
`da4d7be6c97434f6942292ed8abbf4b32dc44355`.
Source head: `334697f271be4932f87c4baa560fdfe11455e84d`.

Hardware: physical GPU 4,
`GPU-8800cf0c-1ba5-7136-d796-2a91f9e9586e`, NVIDIA RTX PRO 6000 Blackwell
Workstation Edition.

```bash
CUDA_VISIBLE_DEVICES=4 B12X_GLM53_GPU_TEST=1 \
  /opt/venv/bin/python -B -m pytest -q \
  tests/models/test_glm5next_pooled_indexer.py \
  -k "decode_writer_matches_parallel_prefill_writer or parallel_prefill_preserves_boundary_tail_and_state_slots or parallel_prefill_coexists_with_decode_requests or parallel_prefill_ignores_invalid_dummy_slots"
```

Result: `4 passed, 14 deselected`.

The cases compare ordered and parallel cache output and cover a pool crossing
a chunk boundary, permuted recurrent-state slots, mixed decode and prefill
requests, and invalid scheduler padding slots.

Repository pre-commit hooks and `git diff --check` pass for the three changed
files.

The runtime compile-key policy was also exercised with:

```bash
CUDA_VISIBLE_DEVICES=4 B12X_GLM53_GPU_TEST=1 \
  /opt/venv/bin/python -B -m pytest -q \
  tests/models/test_glm5next_pooled_indexer.py \
  -k "parallel_prefill"
```

Result: `6 passed, 14 deselected`. The two additional parameterized cases
assert that `request_offset` is excluded from value and alignment
specialization for both parallel kernels.

## Runtime compilation policy

The number of leading decode requests is scheduler state, not kernel geometry.
Leaving `request_offset` under Triton's default value and alignment
specialization creates kernels for zero/aligned offsets, the literal value
one, and other unaligned values. A fresh-cache SM120 reproducer launched mixed
batches with request offsets `0`, `1`, `16`, and `7`:

- base `caece40c66c5c0931788ffcf10d6855de6c80e91`: pool and tail cache
  cardinality progressed `1, 2, 2, 3`;
- head `334697f271be4932f87c4baa560fdfe11455e84d`: both cardinalities remained
  `1, 1, 1, 1`.

A real server log independently detected first-use JIT events for both kernels
when serving moved to a mixed request shape. Excluding the offset from both
specialization policies removes that unbounded scheduler-dependent compile
key.

Balanced 4,080-token CUDA graph replay checks measured the complete pool-plus-
tail launch at `6.528` and `6.560 us` on the base and `6.560` and `6.592 us`
on the head. The `0.5%` difference is within the event-timing spread; removing
the compile variants does not produce a measurable steady-state regression.

## Kernel performance qualification

Two rank-0 Torch traces used the same 4,080-token packed prefill payload, model
revision `local-inference-lab/GLM-5.3-Flash-NVFP4@520de24eabf507659eaef7c70f14fd584527facc`,
B12X revision `2fcf23a0ce269be27b2e03fece73d46e90e6aeea`, four RTX PRO
6000 Blackwell GPUs, tensor parallel size 4, FP8 KV cache, ModelOpt mixed
quantization, B12X attention, B12X MoE, and B12X PCIe all-reduce.

The baseline image used vLLM
`da4d7be6c97434f6942292ed8abbf4b32dc44355` and the ordered writer. The
candidate image used `caece40c66c5c0931788ffcf10d6855de6c80e91`.

Across 16 captured rank-0 model steps:

- ordered `_decode_update_kernel`: median `37.0371 ms`, range
  `36.8823-37.3433 ms`;
- parallel `_prefill_pool_kernel` plus `_prefill_tail_kernel`: median
  `0.076592 ms`, range `0.073727-0.078141 ms`.

Conclusion: completed-pool construction is no longer the serialized prefill
bottleneck for the measured 4,080-token payload.

## TP4 serving observation

The serving command used the same options in both comparison images:

```bash
/opt/venv/bin/python -m vllm.entrypoints.cli.main serve \
  local-inference-lab/GLM-5.3-Flash-NVFP4 \
  --served-model-name GLM-5.3-Flash-NVFP4 \
  --tensor-parallel-size 4 \
  --decode-context-parallel-size 1 \
  --mamba-cache-mode align \
  --enable-prefix-caching \
  --enable-chunked-prefill \
  --dtype bfloat16 \
  --kv-cache-dtype fp8 \
  --quantization modelopt_mixed \
  --attention-backend B12X \
  --block-size 256 \
  --moe-backend b12x \
  --load-format instanttensor \
  --gpu-memory-utilization 0.90 \
  --max-model-len 262144 \
  --max-num-seqs 16 \
  --max-num-batched-tokens 4096 \
  --compilation-config '{"cudagraph_mode":"FULL"}'
```

The client used 32,768-token standalone-prefill contexts for 30 seconds. The
ordered writer produced `11,395 tok/s` in one run. The parallel writer produced
`12,567`, `13,288`, and `12,489 tok/s`, with a median of `12,567 tok/s`.
Observed mean host CPU utilization was `4.4%` for the baseline and
`13.9-17.2%` for the candidate runs. The median difference is `+10.3%`, but the
unbalanced run count and host-load difference prevent a causal E2E performance
qualification.

## TP4 pull-request-stack integration

Status: **integration-qualified** for the serving configuration below. This
qualification establishes compatibility and absence of a prefill regression;
it does not attribute total serving throughput to this pull request alone.

The tested image contained B12X #252 at
`e57f9713ff634dc539269a2486045e85bb19a643`, B12X #253 at
`3c485daaa0140bf00d0172c55e3af83e445e2de5`, B12X #254 at
`09d783fa43e9cc1edc46a00d40aacba1b72c5825`, vLLM #495 at
`da60b74f2a6aadbb0dcb53a97590b159fae96431`, vLLM #504 at
`71ad9871ed6574cd559fbe123843c48013ea7c9`, and this pull request at
`334697f271be4932f87c4baa560fdfe11455e84d`. The resulting vLLM Git tree was
`87f4eaae790e50d8c8552f3b875a6665fa56bd42`. The image ID was
`sha256:a08156e54e2ad796769f4e8b75d07b46035d81aa34adba3b85020fef50d2af3c`.

The container exposed physical GPUs 4, 5, 6, and 7 as logical CUDA devices
0, 1, 2, and 3. Its operation routing selected B12X target attention, B12X
target MoE, B12X PCIe all-reduce, B12X draft attention, and Marlin draft MoE.
The server command was:

```bash
/opt/venv/bin/python -m vllm.entrypoints.cli.main serve /model \
  --served-model-name GLM-5.3-Flash \
  --host 0.0.0.0 \
  --port 5001 \
  --tensor-parallel-size 4 \
  --pipeline-parallel-size 1 \
  --decode-context-parallel-size 1 \
  --mamba-cache-mode align \
  --enable-prefix-caching \
  --enable-chunked-prefill \
  --dtype bfloat16 \
  --kv-cache-dtype fp8 \
  --quantization modelopt_mixed \
  --attention-backend B12X \
  --block-size 256 \
  --moe-backend b12x \
  --no-enable-flashinfer-autotune \
  --load-format instanttensor \
  --gpu-memory-utilization 0.95 \
  --max-model-len 1048576 \
  --max-num-seqs 32 \
  --max-num-batched-tokens 8192 \
  --max-cudagraph-capture-size 128 \
  --speculative-config '{"method":"mtp","num_speculative_tokens":3,"draft_sample_method":"probabilistic","rejection_sample_method":"standard","moe_backend":"marlin","attention_backend":"B12X"}' \
  --reasoning-parser glm45 \
  --tool-call-parser glm47 \
  --enable-auto-tool-choice
```

The runtime environment set `VLLM_ENABLE_PCIE_ALLREDUCE=1`,
`VLLM_PCIE_ALLREDUCE_BACKEND=b12x`, `VLLM_B12X_MOE_FP4_FORCE_A16=0`,
`CUTE_DSL_ARCH=sm_120a`, `NCCL_IB_DISABLE=1`, `NCCL_P2P_LEVEL=SYS`, and
`NCCL_PROTO=LL,LL128,Simple`.

The targeted model and pooled-indexer suite passed with `19 passed, 41
deselected`. A 32,768-token, 30-second client-ISL/TTFT run processed 32,321
prompt tokens in 2.485 seconds, or `13,005 input tok/s`, while host CPU
utilization averaged 4.47%. A 30-second MTP3 sweep produced `197.4`, `1,217.8`,
and `1,720.9 output tok/s` at concurrency 1, 16, and 32. The corresponding
verifier rates were `81.0`, `480.8`, and `683.0 steps/s`.

The runtime JIT monitor reported no `_prefill_pool_kernel` or
`_prefill_tail_kernel` compilation during the prefill and decode workloads.
At concurrency 32, three-token MTP presents 128 verifier rows, which is covered
by the configured graph capacity of 128. A rank-0 trace on commit
`caece40c66c5c0931788ffcf10d6855de6c80e91` captured four such worker steps
and contained one target full-graph replay and two draft full-graph replays per
step. Commit `334697f271be4932f87c4baa560fdfe11455e84d` changes only Triton
specialization metadata and its policy tests; the declared image completed all
configured graph captures and served the concurrency-32 workload without a
CUDA error.

The complete source composition, Docker launch contract, artifact hashes, and
startup-reliability limitation are recorded in
[vLLM issue #500](https://github.com/local-inference-lab/vllm/issues/500).

## AI assistance disclosure

AI assistance was used to implement the kernels and tests, perform duplicate
checks, run correctness and performance measurements, and prepare this
pull-request description. The human submitter must review and understand every
changed line before merge.
