### PR TITLE
[Bugfix][Kernel] Mark MHC post reduction serial

### DIFF
--- a/vllm/model_executor/kernels/mhc/tilelang_kernels.py
+++ b/vllm/model_executor/kernels/mhc/tilelang_kernels.py
@@ -523,7 +523,7 @@ def mhc_post_tilelang(
             T.copy(d_shared, d_local)
             for i_hco, i1_h in T.Parallel(hc, h_blk):
                 x_local[i_hco, i1_h] = c_local[i_hco] * d_local[i1_h]
-                for i_hci in T.vectorized(hc):
+                for i_hci in T.serial(hc):
                     x_local[i_hco, i1_h] += a_local[i_hci, i_hco] * b_local[i_hci, i1_h]
 
             T.copy(x_local, x[i_n, 0, i0_h * h_blk])


### PR DESCRIPTION
## Purpose

Fixes #506.

`mhc_post_tilelang` annotates a loop-carried FP32 accumulation as `T.vectorized(hc)`. TileLang cannot vectorize the shared scalar accumulator, silently lowers the loop to serial, and emits a warning once per worker. Marking the loop `T.serial(hc)` makes the existing lowering explicit and removes the misleading startup warning.

`T.unroll(hc)` was also evaluated. It is semantically valid, but repeated SM120 CUDA-event measurements showed a small regression versus both the current fallback and explicit serial, so this PR uses the conservative schedule.

| Loop annotation | 1 x 7168 median us | 128 x 7168 median us |
|---|---:|---:|
| Current vectorized -> serial fallback | 16.283 | 16.249 |
| Explicit serial, run 1 | 16.352 | 16.339 |
| Explicit serial, run 2 | 16.506 | 16.480 |
| Explicit unroll, run 1 | 16.911 | 16.920 |
| Explicit unroll, run 2 | 16.636 | 16.637 |

No pre-existing matching issue or PR was found after searching open and closed reports for `i_hci`, `mhc_post_tilelang`, `scalar accumulator`, and related TileLang/vectorization terms. The final diff received independent peer review with no blocking findings.

## Test Plan

- Run the focused TileLang MHC post-kernel numerical test on an NVIDIA GPU.
- Compile a TP=4 GLM-5.3-Flash engine and confirm the warning is absent.
- Run end-to-end short, structured-output, and long-context correctness probes.
- Run all applicable pre-commit hooks for the changed file.

## Test Result

Environment: TileLang 0.1.12, PyTorch 2.13.0, 4x RTX PRO 6000 Blackwell, vLLM runtime `6dc2f5166`, GLM-5.3-Flash K6, TP=4/DCP=4.

```text
$ python3 -m pytest /home/turnkey/patches/test_mhc_kernels.py::test_mhc_post_tilelang -q
........                                                                 [100%]
8 passed, 16 warnings in 10.89s
```

The eight cases cover `hc=4`, hidden sizes 4096 and 7168, and token counts 1, 4, 8, and 128.

- Patched TP=4 engine reached `Application startup complete`.
- Full startup log search for `i_hci|scalar accumulator|vectorized loop`: zero matches.
- End-to-end verifier passed arithmetic/factual/instruction probes, strict JSON structured output, and an exact 32,853-token prompt with 3/3 needles found at 15%, 55%, and 90% depths.
- `uvx pre-commit run --files vllm/model_executor/kernels/mhc/tilelang_kernels.py`: all applicable hooks passed.

## AI assistance disclosure

OpenAI Codex assisted with diagnosis, the one-line edit, and PR drafting. The human submitter authorized upstream publication; the final change was independently peer-reviewed and validated on the affected GPU/model path. The commit includes both `Assisted-by:` and DCO `Signed-off-by:` trailers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Updated residual contribution processing for more reliable channel-wise accumulation.
  * Preserved existing output behavior while changing the internal execution strategy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->