### PR TITLE
perf(kv-cache): pack bounded hybrid attention pages

### DIFF
--- a/tests/model_executor/layers/test_attention_page_budget.py
+++ b/tests/model_executor/layers/test_attention_page_budget.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from vllm.model_executor.layers.attention.attention import (
+    _largest_kernel_block_within,
+)
+from vllm.v1.attention.backend import MultipleOf
+
+
+class _FixedPageBackend:
+    @staticmethod
+    def get_supported_kernel_block_sizes():
+        return [16, 32, 64]
+
+
+class _MultipleOfPageBackend:
+    @staticmethod
+    def get_supported_kernel_block_sizes():
+        return [MultipleOf(16)]
+
+
+def test_largest_fixed_block_within_shared_page():
+    assert _largest_kernel_block_within(_FixedPageBackend, 1024, 65536, 256) == 64
+
+
+def test_largest_multiple_within_shared_page():
+    assert (
+        _largest_kernel_block_within(
+            _MultipleOfPageBackend,
+            per_token_bytes=1024,
+            page_budget=1_511_424,
+            fallback=256,
+        )
+        == 1472
+    )
+
+
+def test_smallest_block_without_shared_page():
+    assert _largest_kernel_block_within(_MultipleOfPageBackend, 1024, None, 256) == 16

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -110,8 +110,21 @@ def _largest_kernel_block_within(
 
     sizes = attn_backend.get_supported_kernel_block_sizes()
     candidates = [s for s in sizes if isinstance(s, int)]
-    if not candidates:
-        candidates = [s.base for s in sizes if isinstance(s, MultipleOf)]
+    for size in sizes:
+        if not isinstance(size, MultipleOf):
+            continue
+        # ``MultipleOf`` describes an unbounded family, not just its base.
+        # Choose the largest member whose natural page fits the shared page.
+        # Treating it as only ``base`` can leave almost the entire shared page
+        # unused for a small sibling attention layer in a hybrid model.
+        largest = (
+            page_budget // per_token_bytes
+            if page_budget and per_token_bytes > 0
+            else size.base
+        )
+        largest -= largest % size.base
+        if largest >= size.base:
+            candidates.append(largest)
     if not candidates:
         return fallback
     smallest = min(candidates)
@@ -618,7 +631,11 @@ class Attention(nn.Module, AttentionLayerBase):
             # block that still fits the shared page so we waste fewer padding
             # bytes per block. Otherwise (page_size_padded is None) the smallest
             # block is fine — ``unify`` scales it up by an integer ratio.
-            shared_page = vllm_config.cache_config.skip_page_size_padded
+            page_budgets = (
+                vllm_config.cache_config.skip_page_size_padded,
+                vllm_config.cache_config.mamba_page_size_padded,
+            )
+            shared_page = max((p for p in page_budgets if p is not None), default=None)
             # The backend owns its packing
             sw_per_token = self.attn_backend.customize_spec(
                 SlidingWindowSpec(
@@ -634,6 +651,14 @@ class Attention(nn.Module, AttentionLayerBase):
             sw_block_size = _largest_kernel_block_within(
                 self.attn_backend, sw_per_token, shared_page, block_size
             )
+            if shared_page is not None:
+                logger.info_once(
+                    "Using sliding-window KV block size %d; its natural page "
+                    "uses %d of %d shared bytes.",
+                    sw_block_size,
+                    sw_block_size * sw_per_token,
+                    shared_page,
+                )
             return SlidingWindowSpec(
                 block_size=sw_block_size,
                 num_kv_heads=self.num_kv_heads,


### PR DESCRIPTION
## Purpose

Reduce padding in uniform-page hybrid KV caches when a bounded attention layer reports `MultipleOf(N)` kernel block-size support.

`MultipleOf(N)` describes every valid multiple of `N`, but the current selector treats it as only `N`. It also ignores an already-aligned Mamba page when `skip_page_size_padded` is unset. A small sliding-window draft layer can therefore use only a tiny fraction of the physical page shared with the target model.

This change uses the largest existing Mamba/skip page as the budget and selects the largest supported block that fits. It changes cache geometry only; kernels, weights, sampling, precision, and graph coverage are unchanged.

## Runtime A/B

Hardware/config: 4x RTX PRO 6000 Blackwell, TP4, C32, DFlash K8, B12X target attention, MXFP8 draft, 1M max model length, FP8 target KV. Both arms used the same source-locked runtime and overlay stack; only `attention.py` changed. The image was `local/glm53-jj-integrated:883d-b12x2fcf-r1` (base vLLM `e7097feb6`, B12X `2fcf23a0`), with the identical reviewed integration stack through `e4439d8bc` in both arms.

| Draft attention / KV | Block before | Block after | KV tokens before | KV tokens after | Gain |
|---|---:|---:|---:|---:|---:|
| FlashInfer XQA / FP8 | 16 | 64 | 1,489,675 | 2,237,978 | +50.23% |
| FlashAttention / BF16 | 16 | 1,152 | 1,517,675 | 2,708,338 | +78.45% |

For FA2/BF16, the 1,152-token block fills the 1,179,648-byte shared page exactly.

A matched three-seed, 4,096-token normal-sampling probe was verifier-neutral:

| FA2/BF16 | Output tok/s median | Verifier steps/s median | Accepted/draft median |
|---|---:|---:|---:|
| Before | 158.898 | 63.559 | 1.501 |
| After | 158.178 | 63.387 | 1.495 |

The deltas (-0.45%, -0.27%, and -0.39%) are within run/sampling variance. No temperature override was used.

## Validation

- Focused pytest in the serving runtime: `3 passed` (fixed-size family, `MultipleOf(16)`, and no-budget fallback).
- `uvx ruff check` on both changed files: passed.
- `uvx ruff format --check` on both changed files: passed.
- `git diff --check`: passed.
- The full TP4 service completed profiling and persistent CUDA-graph capture and remained healthy.

## Scope and alternatives

No open or closed PR was found that expands `MultipleOf` for hybrid page packing. PR #441 concerns parallel-draft group identity, not physical-page utilization.

Hard-coding a DFlash block size was rejected because backend support and page geometry vary. Changing draft KV dtype alone was also insufficient: the reduced payload remained padded to the same shared page.

## AI assistance disclosure

OpenAI Codex assisted with diagnosis, implementation, tests, runtime qualification, and PR preparation. The human submitter must review every changed line and understand and defend the behavior before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved attention memory allocation when multiple page-size constraints are present.
  * Selects the largest compatible block size within the available shared page budget, including supported size ranges.
  * Uses the most restrictive applicable page-size requirement to determine sliding-window allocation.
  * Added diagnostic logging for the selected block size and shared-page usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->