### PR TITLE
perf(kv-cache): preserve the unbounded attention group

### DIFF
--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -2248,7 +2248,52 @@ def _grouping_config():
     return SimpleNamespace(
         scheduler_config=SimpleNamespace(disable_hybrid_kv_cache_manager=False),
         speculative_config=None,
+        model_config=SimpleNamespace(max_model_len=1_048_576),
+        parallel_config=SimpleNamespace(decode_context_parallel_size=1),
+        cache_config=SimpleNamespace(mamba_cache_mode="align"),
+        max_in_flight_tokens=8192,
     )
+
+
+def test_bounded_draft_layers_do_not_split_unbounded_attention_group():
+    specs = {
+        **{f"full.{i}": new_kv_cache_spec() for i in range(11)},
+        **{f"mamba.{i}": new_mamba_spec() for i in range(34)},
+        **{f"draft.{i}": new_sliding_window_spec() for i in range(5)},
+    }
+
+    groups = get_kv_cache_groups(_grouping_config(), specs)
+
+    full_groups = [
+        group for group in groups if isinstance(group.kv_cache_spec, FullAttentionSpec)
+    ]
+    mamba_groups = [
+        group for group in groups if isinstance(group.kv_cache_spec, MambaSpec)
+    ]
+    draft_groups = [
+        group for group in groups if isinstance(group.kv_cache_spec, SlidingWindowSpec)
+    ]
+    assert [len(group.layer_names) for group in full_groups] == [11]
+    assert sorted(len(group.layer_names) for group in mamba_groups) == [8, 8, 9, 9]
+    assert [len(group.layer_names) for group in draft_groups] == [5]
+
+
+def test_unbounded_anchor_is_rejected_when_bounded_padding_costs_more():
+    specs = {
+        **{f"full.{i}": new_kv_cache_spec() for i in range(4)},
+        "mamba.0": new_mamba_spec(),
+    }
+
+    groups = get_kv_cache_groups(_grouping_config(), specs)
+
+    full_groups = [
+        group for group in groups if isinstance(group.kv_cache_spec, FullAttentionSpec)
+    ]
+    mamba_groups = [
+        group for group in groups if isinstance(group.kv_cache_spec, MambaSpec)
+    ]
+    assert [len(group.layer_names) for group in full_groups] == [1, 1, 1, 1]
+    assert [len(group.layer_names) for group in mamba_groups] == [1]
 
 
 def test_hidden_state_group_preserves_hybrid_prefix_cache_granularity():

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1125,6 +1125,7 @@ def is_kv_cache_type_attention_free(kv_cache_spec: dict[str, KVCacheSpec]) -> bo
 
 
 def _get_kv_cache_groups_uniform_page_size(
+    vllm_config: VllmConfig,
     kv_cache_spec: dict[str, KVCacheSpec],
 ) -> list[KVCacheGroupSpec]:
     """
@@ -1241,6 +1242,46 @@ def _get_kv_cache_groups_uniform_page_size(
         # layers while accommodating speculative decoding drafters that add
         # extra layers to one attention type.
         group_size = max_num_layers
+    unbounded_attention_buckets = [
+        i
+        for i, specs in enumerate(spec_buckets)
+        if all(isinstance(spec, FullAttentionSpec) for spec in specs)
+    ]
+    bounded_cache_types = (MambaSpec, SlidingWindowSpec, ChunkedLocalAttentionSpec)
+    if len(unbounded_attention_buckets) == 1:
+        unbounded_idx = unbounded_attention_buckets[0]
+        other_buckets_are_bounded = all(
+            i == unbounded_idx
+            or all(isinstance(spec, bounded_cache_types) for spec in specs)
+            for i, specs in enumerate(spec_buckets)
+        )
+        if other_buckets_are_bounded:
+            unbounded_group_size = len(layer_buckets[unbounded_idx])
+
+            def max_request_allocation_cost(candidate_size: int) -> int:
+                # All pages have the same byte size here. The common factor can
+                # be omitted, leaving pool pages per block (candidate_size)
+                # times blocks needed by one maximum-length request.
+                blocks_per_request = 0
+                for layers, specs in zip(layer_buckets, spec_buckets):
+                    merged_spec = specs[0].merge(specs)
+                    blocks_per_group = cdiv(
+                        merged_spec.max_memory_usage_bytes(vllm_config),
+                        merged_spec.page_size_bytes,
+                    )
+                    blocks_per_request += (
+                        cdiv(len(layers), candidate_size) * blocks_per_group
+                    )
+                return candidate_size * blocks_per_request
+
+            # A bounded state/window bucket should not split the only cache
+            # that grows over the full sequence when removing that split also
+            # improves max-context admission. Keep the existing heuristic when
+            # padding the bounded buckets would cost more than it saves.
+            if max_request_allocation_cost(
+                unbounded_group_size
+            ) < max_request_allocation_cost(group_size):
+                group_size = unbounded_group_size
     grouped_layers = []
     for layers in layer_buckets:
         num_padding_layers = group_size - len(layers) % group_size
@@ -1808,7 +1849,7 @@ def get_kv_cache_groups(
         if fallback_groups is None:
             raise
         return fallback_groups
-    groups = _get_kv_cache_groups_uniform_page_size(filtered_spec)
+    groups = _get_kv_cache_groups_uniform_page_size(vllm_config, filtered_spec)
 
     # Add hidden-state layers back with page aligned to the common page.
     if hidden_specs:


### PR DESCRIPTION
## Purpose

Avoid splitting the only sequence-growing attention cache merely because a speculative draft adds a smaller bounded cache bucket.

The generic uniform-page heuristic starts from the smallest layer bucket. For GLM-5.3 + DFlash2, five bounded draft layers therefore set a group width of five and split eleven full-context sparse-MLA layers across three cache groups. At long context, those extra full-attention groups cost far more than padding the bounded recurrent/window groups.

This change considers the single full-attention bucket as an alternate group width only when every other bucket is a bounded cache type. It then evaluates both layouts with the same max-context admission quantities used by the KV allocator and selects the alternate only when it reduces projected allocation cost. There are no model names or layer-count constants.

## Runtime A/B

Hardware/config: 4x RTX PRO 6000 Blackwell, TP4, C32, DFlash K8, B12X target attention, MXFP8 draft, FA2 draft attention/BF16 draft KV, 1M max model length, FP8 target KV. Both arms used the same source-locked runtime and overlays; only `kv_cache_utils.py` changed. Hybrid-page packing and exact six-graph profiling were held constant.

| Metric | Existing five-layer width | Admission-selected eleven-layer width | Delta |
|---|---:|---:|---:|
| Cache groups | 11 | 6 | -5 |
| Available KV memory | 23.79 GiB | 23.79 GiB | unchanged |
| GPU KV capacity | 2,861,135 | 3,699,887 | +838,752 (+29.32%) |
| 1M-request concurrency | 2.73x | 3.53x | +29.30% |
| Verifier steps/s median | 63.575 | 64.130 | +0.87% |
| Output tok/s median | 156.975 | 157.064 | +0.06% |

The final layout is one 11-layer full-attention group, four recurrent-state groups, and one bounded draft-window group. A fresh boot of the generalized implementation reproduced 3,699,887 tokens and completed persistent CUDA-graph capture. A matched three-seed, 4,096-token normal-sampling probe showed no runtime regression; no temperature override was used.

Together with #509 and the separately scoped exact graph-profiling candidate, the same boot increased capacity from 1,517,675 to 3,699,887 tokens (+143.78%). This PR attributes only the isolated 2,861,135 to 3,699,887 step above.

## Validation

- Focused pytest in the serving runtime: `3 passed`, covering the measured full/recurrent/draft layout, a counterexample where bounded padding costs more (the existing width is retained), and hidden-state group preservation.
- Combined focused hybrid-KV candidate assertions: `8/8 passed`.
- `uvx ruff check` on both changed files: passed.
- `uvx ruff format --check` on both changed files: passed.
- `git diff --check`: passed.
- TP4 startup, cache allocation, profiling capture, persistent capture, and health check: passed.

## Scope and alternatives

No open PR implements admission-cost-based hybrid group selection. Closed PR #336 exposed a Kimi-specific environment override; this PR instead keeps automatic behavior, contains no model guard, and rejects the alternate width whenever bounded padding would reduce max-context capacity. PRs #422 and #482 concern cache restore correctness, not group construction.

An unconditional full-attention anchor was rejected because layouts with a large full bucket and a tiny bounded bucket can waste more memory. A DFlash/GLM layer-count special case was also rejected.

## AI assistance disclosure

OpenAI Codex assisted with diagnosis, implementation, tests, runtime qualification, and PR preparation. The human submitter must review every changed line and understand and defend the behavior before merge.
