### PR TITLE
perf(cudagraph): profile small FULL graph sets exactly

### DIFF
--- a/tests/v1/worker/test_gpu_model_runner_v2_cudagraph_profiling.py
+++ b/tests/v1/worker/test_gpu_model_runner_v2_cudagraph_profiling.py
@@ -51,6 +51,7 @@ class _FakeCudaGraphManager(cgu.CudaGraphManager):
         self._capture_mem_samples: list[int] | None = None
         self.use_breakable_cg = False
         self.graphs: dict[Any, Any] = {}
+        self.graph_capture_resources: dict[Any, Any] = {}
         self._graphs_captured = False
 
     def needs_capture(self) -> bool:
@@ -136,21 +137,39 @@ def test_profile_cudagraph_memory_no_graphs_tears_down(monkeypatch):
     assert runner.cudagraph_manager.pool == GLOBAL_POOL
 
 
-def test_profile_cudagraph_memory_samples_and_extrapolates(monkeypatch):
+def test_profile_cudagraph_memory_small_full_set_returns_exact_measurement(monkeypatch):
+    _patch_module(monkeypatch)
+    captured_bytes = 7 << 30
+    runner = _make_profiling_runner(
+        CUDAGraphMode.FULL,
+        num_full_descs=cgu._MAX_EXACT_FULL_GRAPH_PROFILING_GRAPHS,
+        captured_bytes=captured_bytes,
+    )
+
+    result = cgu.profile_cudagraph_memory(runner)
+
+    assert result == captured_bytes
+    assert runner.events == ["init", "capture", "teardown"]
+    assert runner.pool_during_capture == THROWAWAY_POOL
+    assert runner.cudagraph_manager.pool == GLOBAL_POOL
+    assert runner.cudagraph_manager._max_full_descs_to_capture is None
+
+
+def test_profile_cudagraph_memory_large_full_set_extrapolates(monkeypatch):
     _patch_module(monkeypatch)
     gib = 1 << 30
     # Measured delta 1000 MiB includes the sampled FULL graphs (100 + 20 MiB).
-    # Extrapolated FULL cost for 3 graphs: 100 + 2 * 20 = 140 MiB.
+    # Extrapolated FULL cost for 9 graphs: 100 + 8 * 20 = 260 MiB.
     runner = _make_profiling_runner(
         CUDAGraphMode.FULL,
-        num_full_descs=3,
+        num_full_descs=cgu._MAX_EXACT_FULL_GRAPH_PROFILING_GRAPHS + 1,
         captured_bytes=1000 * gib,
         mem_samples=[100 * gib, 20 * gib],
     )
 
     result = cgu.profile_cudagraph_memory(runner)
 
-    assert result == (1000 - (100 + 20) + (100 + 2 * 20)) * gib
+    assert result == (1000 - (100 + 20) + (100 + 8 * 20)) * gib
     # Bootstrap, capture, and teardown run in order.
     assert runner.events == ["init", "capture", "teardown"]
     # Capture must use a throwaway pool, not the persistent global pool.

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -707,6 +707,9 @@ def prepare_inputs_to_capture(
 # Number of FULL graphs captured during profiling; the total FULL capture
 # cost is extrapolated from this sample to avoid a second full capture.
 _FULL_GRAPH_PROFILING_SAMPLES = 2
+# Capture small FULL graph sets exactly. This avoids extrapolation error while
+# keeping profiling bounded for the large default capture grid.
+_MAX_EXACT_FULL_GRAPH_PROFILING_GRAPHS = 8
 # Floor for the extrapolated per-graph cost (driver overhead per graph).
 _MIN_PER_GRAPH_BYTES = 1 << 20
 
@@ -807,18 +810,28 @@ def profile_cudagraph_memory(runner: "GPUModelRunner") -> int:
         for wrapper in all_wrappers:
             original_pools[id(wrapper)] = wrapper.graph_pool
             wrapper.graph_pool = manager.pool
-        manager._max_full_descs_to_capture = _FULL_GRAPH_PROFILING_SAMPLES
+        num_full_graphs = len(manager._capture_descs.get(CUDAGraphMode.FULL, []))
+        profile_full_graphs_exactly = (
+            num_full_graphs <= _MAX_EXACT_FULL_GRAPH_PROFILING_GRAPHS
+        )
+        manager._max_full_descs_to_capture = (
+            None if profile_full_graphs_exactly else _FULL_GRAPH_PROFILING_SAMPLES
+        )
         mem_samples: list[int] = []
-        manager._capture_mem_samples = mem_samples
+        manager._capture_mem_samples = (
+            None if profile_full_graphs_exactly else mem_samples
+        )
 
         measured = int(runner.capture_model())
+
+        if profile_full_graphs_exactly:
+            return measured
 
         # The measured delta covers PIECEWISE, encoder and speculator graphs
         # plus the sampled FULL graphs; swap the sampled FULL cost for the
         # extrapolated total. FULL and PIECEWISE share one pool here just as
         # they share the global pool at runtime, so the overlap is not
         # double-counted.
-        num_full_graphs = len(manager._capture_descs.get(CUDAGraphMode.FULL, []))
         full_estimate = _extrapolate_full_graph_memory(mem_samples, num_full_graphs)
         return max(measured - sum(mem_samples) + full_estimate, 0)
     finally:


### PR DESCRIPTION
## Purpose

Measure small explicit FULL CUDA-graph sets exactly during V2 KV-memory profiling instead of extrapolating every graph from the two largest captures.

The existing two-sample estimator is intentionally bounded for large default grids. For a deployment that explicitly has only six FULL descriptors, however, capturing all six during the throwaway profile is cheap and removes the systematic error described in #201. Sets larger than eight retain the existing sampled/extrapolated path.

This is independent of #502: that PR reduces which autoregressive-draft graphs exist; this PR improves the memory estimate when the resulting FULL set is small.

## Runtime A/B

Hardware/config: 4x RTX PRO 6000 Blackwell, TP4, C32, DFlash K8, 1M max model length, FULL+PIECEWISE graphs at rows 8/16/32/64/128/256. Both arms used the same source-locked runtime and hybrid-page fix; only `cudagraph_utils.py` changed.

| Metric | Two-sample extrapolation | Exact six-graph profile | Delta |
|---|---:|---:|---:|
| Graph reservation | 9.47 GiB | 8.20 GiB | -1.27 GiB |
| Available KV memory | 22.52 GiB | 23.79 GiB | +1.27 GiB |
| GPU KV capacity | 2,708,338 | 2,861,135 | +152,797 (+5.64%) |
| Persistent capture pool | 3.74 GiB | 3.73 GiB | -0.01 GiB |
| Profiling capture time | 9 s | 11 s | +2 s startup only |

The exact 8.20 GiB reservation is intentionally larger than the later 3.73 GiB persistent-pool delta: the profiling pass creates resources that remain resident and are reused by persistent capture. This change removes only the measured extrapolation error; it does not substitute the later pool delta or under-reserve those resources.

A matched three-seed, 4,096-token normal-sampling probe remained verifier-neutral (63.387 to 63.575 verifier steps/s). The service retained all six configured FULL graphs and remained healthy. No temperature override was used.

## Validation

- Focused pytest in the serving runtime: `3 passed` (exact small set, sampled large set, and no-graph teardown).
- `uvx ruff check` on both changed files: passed.
- `uvx ruff format --check` on both changed files: passed.
- `git diff --check`: passed.
- Both profiling capture and persistent capture completed on TP4.

## Scope and alternatives

This addresses the small-set extrapolation component of #201 and contributes to #501, but does not claim to solve all retained B12X graph-resource memory. #502 changes draft graph selection and is already included in this branch's `dev/jovian-judgement` base.

Always profiling every default graph was rejected because startup cost would be unbounded for large grids. Interpolation from a third sample remains useful for large sets, but adds complexity without improving the exact six-shape case. The threshold of eight bounds the extra profiling work to six additional FULL captures at most.

No open PR was found that exactly profiles small FULL descriptor sets. PRs #168/#172/#180 concern graph-pool lifecycle and startup accounting; they do not replace the two-sample extrapolation for this path.

## AI assistance disclosure

OpenAI Codex assisted with diagnosis, implementation, tests, runtime qualification, and PR preparation. The human submitter must review every changed line and understand and defend the behavior before merge.
