### PR TITLE
Fix FlashInfer SM120 sparse MLA support for GLM5Next

### DIFF
--- a/tests/models/test_glm5next_pooled_indexer.py
+++ b/tests/models/test_glm5next_pooled_indexer.py
@@ -184,14 +184,21 @@ def test_glm53_packed_c4_metadata_uses_parent_stride() -> None:
 
 
 def _packed_main_cache(
-    *, device: torch.device, blocks: int, layers: int, block_size: int, layer: int
+    *,
+    device: torch.device,
+    blocks: int,
+    layers: int,
+    block_size: int,
+    layer: int,
+    record_bytes: int = 528,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    page_bytes = block_size * (528 + 33)
+    tail_bytes_per_token = 33 if record_bytes == 528 else 37
+    page_bytes = block_size * (record_bytes + tail_bytes_per_token)
     raw = torch.zeros(blocks * layers * page_bytes, dtype=torch.uint8, device=device)
     main = torch.as_strided(
         raw,
-        size=(blocks, block_size, 528),
-        stride=(layers * page_bytes, 528, 1),
+        size=(blocks, block_size, record_bytes),
+        stride=(layers * page_bytes, record_bytes, 1),
         storage_offset=layer * page_bytes,
     )
     return raw, main
@@ -244,16 +251,26 @@ def test_glm53_parent_table_width_tracks_dcp_sharding() -> None:
     )
 
 
-def test_glm53_packed_tail_reuses_c4_page_contract() -> None:
+@pytest.mark.parametrize(
+    ("record_bytes", "expected_parent_stride_pages"), [(528, 102), (656, 126)]
+)
+def test_glm53_packed_tail_reuses_c4_page_contract(
+    record_bytes: int, expected_parent_stride_pages: int
+) -> None:
     device = _require_glm_gpu()
     _, main = _packed_main_cache(
-        device=device, blocks=2, layers=3, block_size=512, layer=1
+        device=device,
+        blocks=2,
+        layers=3,
+        block_size=512,
+        layer=1,
+        record_bytes=record_bytes,
     )
     index_cache, subpages, parent_stride_pages = (
         Glm5NextPooledIndexer._index_cache_view(main)
     )
     assert subpages == 2
-    assert parent_stride_pages == 102
+    assert parent_stride_pages == expected_parent_stride_pages
     assert index_cache.stride() == (8448, 132, 1)
 
     generator = torch.Generator(device=device).manual_seed(55)

--- a/tests/v1/attention/test_flashinfer_sparse_mla_sm120_api.py
+++ b/tests/v1/attention/test_flashinfer_sparse_mla_sm120_api.py
@@ -4,6 +4,7 @@
 
 from types import SimpleNamespace
 
+import pytest
 import torch
 
 from vllm.config import set_current_vllm_config
@@ -12,10 +13,17 @@ from vllm.models.deepseek_v4.nvidia.flashinfer_sparse import (
 )
 from vllm.platforms.interface import DeviceCapability
 from vllm.utils import flashinfer as fi_utils
+from vllm.v1.attention.backend import MultipleOf
+from vllm.v1.attention.backends.mla import flashinfer_mla_sparse_sm120 as sm120_mod
 from vllm.v1.attention.backends.mla.flashinfer_mla_sparse import (
+    FlashInferMLASparseMetadata,
+    FlashInferMLASparseMetadataBuilder,
     FlashInferMLASparseSM120Backend,
 )
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
+from vllm.v1.kv_cache_interface import MLAAttentionSpec
+from vllm.v1.kv_cache_layout import KVCacheLayout
+from vllm.v1.worker.utils import select_common_block_size
 
 
 def _fake_vllm_config(model_type: str) -> SimpleNamespace:
@@ -62,6 +70,292 @@ def test_v32_glm_sm120_backend_accepts_glm_block_size(
         )
 
     assert invalid_reasons == []
+
+
+def test_glm5next_sm120_backend_accepts_512_head_size(monkeypatch) -> None:
+    monkeypatch.setattr(fi_utils, "has_flashinfer_sparse_mla_sm120", lambda: True)
+
+    with set_current_vllm_config(_fake_vllm_config("glm5_next")):
+        invalid_reasons = FlashInferMLASparseSM120Backend.validate_configuration(
+            head_size=512,
+            dtype=torch.bfloat16,
+            kv_cache_dtype="fp8",
+            block_size=256,
+            use_mla=True,
+            has_sink=False,
+            use_sparse=True,
+            use_mm_prefix=False,
+            use_per_head_quant_scales=False,
+            device_capability=DeviceCapability(12, 0),
+            attn_type="decoder",
+        )
+
+    assert invalid_reasons == []
+
+
+def test_glm5next_sm120_backend_publishes_packed_cache_geometry() -> None:
+    probe = MLAAttentionSpec(
+        block_size=256,
+        num_kv_heads=1,
+        head_size=512,
+        dtype=torch.uint8,
+        cache_dtype_str="fp8_ds_mla",
+        state_content_bytes=656,
+    )
+
+    with set_current_vllm_config(_fake_vllm_config("glm5_next")):
+        packed = FlashInferMLASparseSM120Backend.customize_spec(probe)
+
+    assert packed.state_content_bytes == 656
+    assert packed.page_tail_bytes_per_token == 37
+    assert packed.model_version == "glm5_next"
+    assert packed.page_size_bytes == 256 * (656 + 37)
+    assert FlashInferMLASparseSM120Backend.supported_kv_cache_layouts() == (
+        KVCacheLayout.BLHNC,
+    )
+
+
+def test_glm5next_sm120_backend_publishes_geometry_without_config_context() -> None:
+    probe = MLAAttentionSpec(
+        block_size=2304,
+        num_kv_heads=1,
+        head_size=512,
+        dtype=torch.uint8,
+        cache_dtype_str="fp8_ds_mla",
+        state_content_bytes=656,
+        model_version="glm5_next",
+    )
+
+    packed = FlashInferMLASparseSM120Backend.customize_spec(probe)
+
+    assert packed.state_content_bytes == 656
+    assert packed.page_tail_bytes_per_token == 37
+    assert packed.model_version == "glm5_next"
+    assert packed.page_size_bytes == 2304 * (656 + 37)
+
+
+def test_sm120_backend_does_not_reclassify_deepseek_v4_as_glm() -> None:
+    probe = MLAAttentionSpec(
+        block_size=256,
+        num_kv_heads=1,
+        head_size=512,
+        dtype=torch.uint8,
+        cache_dtype_str="fp8_ds_mla",
+        state_content_bytes=584,
+        model_version="deepseek_v4",
+    )
+
+    assert FlashInferMLASparseSM120Backend.customize_spec(probe) is probe
+
+
+def test_glm5next_sm120_backend_keeps_packed_manager_page_intact() -> None:
+    with set_current_vllm_config(_fake_vllm_config("glm5_next")):
+        supported = FlashInferMLASparseSM120Backend.get_supported_kernel_block_sizes()
+        selected = select_common_block_size(
+            2304,
+            [FlashInferMLASparseSM120Backend],
+        )
+
+    assert len(supported) == 1
+    assert isinstance(supported[0], MultipleOf)
+    assert supported[0].base == 64
+    assert selected == 2304
+
+
+@pytest.mark.parametrize("qk_rope_head_dim", [0, 64])
+@pytest.mark.parametrize("page_block_size", [64, 256, 2304])
+def test_sm120_forward_passes_active_topk_lengths(
+    monkeypatch, qk_rope_head_dim: int, page_block_size: int
+) -> None:
+    impl = sm120_mod.FlashInferMLASparseSM120Impl.__new__(
+        sm120_mod.FlashInferMLASparseSM120Impl
+    )
+    impl.num_heads = 2
+    impl.kv_lora_rank = 512
+    impl.qk_nope_head_dim = 256 if qk_rope_head_dim == 0 else 128
+    impl.qk_rope_head_dim = qk_rope_head_dim
+    impl.rope_pad = 64 if qk_rope_head_dim == 0 else 0
+    impl.kernel_qk_rope_head_dim = qk_rope_head_dim + impl.rope_pad
+    impl.scale = 0.125
+    impl.kv_scale_format = "arbitrary_fp32"
+    if qk_rope_head_dim == 0:
+        impl.topk_indices_buffer = torch.tensor(
+            [[4, 3, 2, 1, 9, 8, 7], [7, 6, 5, 4, 3, 2, 1]],
+            dtype=torch.int32,
+        )
+    else:
+        impl.topk_indices_buffer = torch.tensor(
+            [[4, 3, -1, -1], [7, 6, 5, -1]], dtype=torch.int32
+        )
+    impl._workspace_buffer = torch.empty(1, dtype=torch.uint8)
+
+    physical = torch.tensor([[20, 19, -1, -1], [23, 22, 21, -1]], dtype=torch.int32)
+    active_lens = torch.tensor([2, 3], dtype=torch.int32)
+    convert_kwargs = {}
+
+    converted = {}
+
+    def fake_convert(*args, **kwargs):
+        converted["indices"] = args[2].clone()
+        convert_kwargs.update(kwargs)
+        return physical, active_lens
+
+    call_kwargs = {}
+
+    def fake_flashinfer(**kwargs):
+        call_kwargs.update(kwargs)
+        return kwargs["out"]
+
+    monkeypatch.setattr(sm120_mod, "triton_filter_and_convert_dcp_index", fake_convert)
+    monkeypatch.setattr(
+        fi_utils, "flashinfer_trtllm_batch_decode_with_kv_cache_mla", fake_flashinfer
+    )
+
+    head_dim = 512 + qk_rope_head_dim
+    q = torch.empty(2, 2, head_dim, dtype=torch.bfloat16)
+    metadata = SimpleNamespace(
+        req_id_per_token=torch.tensor([0, 1], dtype=torch.int32),
+        block_table=torch.zeros(2, 1, dtype=torch.int32),
+        block_size=64,
+        topk_tokens=4,
+    )
+    out, lse = impl.forward_mqa(
+        q,
+        torch.empty(
+            1,
+            page_block_size,
+            656,
+            dtype=torch.uint8,
+        ),
+        metadata,
+        SimpleNamespace(),
+    )
+
+    assert convert_kwargs["return_valid_counts"] is True
+    assert convert_kwargs["dcp_size"] == 1
+    assert convert_kwargs["dcp_rank"] == 0
+    assert call_kwargs["backend"] == "sparse"
+    expected_kernel_rows = 2 if page_block_size == 64 else 65
+    assert call_kwargs["query"].shape[0] == expected_kernel_rows
+    assert call_kwargs["block_tables"].shape[0] == expected_kernel_rows
+    assert call_kwargs["seq_lens"].shape[0] == expected_kernel_rows
+    torch.testing.assert_close(call_kwargs["seq_lens"][:2], active_lens)
+    if page_block_size != 64:
+        assert torch.count_nonzero(call_kwargs["query"][2:]) == 0
+        assert torch.all(call_kwargs["block_tables"][2:] == -1)
+        assert torch.count_nonzero(call_kwargs["seq_lens"][2:]) == 0
+    if qk_rope_head_dim == 0:
+        torch.testing.assert_close(
+            converted["indices"],
+            torch.tensor([[4, 9, 8, 7], [7, 3, 2, 1]], dtype=torch.int32),
+        )
+        assert call_kwargs["query"].shape[-1] == 576
+        assert call_kwargs["qk_rope_head_dim"] == 64
+    else:
+        assert call_kwargs["query"].shape[-1] == 576
+        assert call_kwargs["qk_rope_head_dim"] == 64
+    assert out.shape == (2, 2, 512)
+    assert lse is None
+
+
+def test_sm120_nope_cache_update_zero_pads_rope(monkeypatch) -> None:
+    impl = sm120_mod.FlashInferMLASparseSM120Impl.__new__(
+        sm120_mod.FlashInferMLASparseSM120Impl
+    )
+    impl.rope_pad = 64
+    captured = {}
+
+    def fake_update(self, kv_c, k_pe, cache, slots, cache_dtype, scale):
+        captured["k_pe"] = k_pe
+
+    monkeypatch.setattr(sm120_mod.MLAAttentionImpl, "do_kv_cache_update", fake_update)
+    impl.do_kv_cache_update(
+        torch.empty(2, 512),
+        torch.empty(2, 1, 0),
+        torch.empty(1, 2, 656, dtype=torch.uint8),
+        torch.tensor([0, 1]),
+        "fp8_ds_mla",
+        torch.ones(1),
+    )
+
+    assert captured["k_pe"].shape == (2, 1, 64)
+    assert torch.count_nonzero(captured["k_pe"]) == 0
+
+
+def _selector_metadata_builder(capacity: int = 4):
+    builder = FlashInferMLASparseMetadataBuilder.__new__(
+        FlashInferMLASparseMetadataBuilder
+    )
+    builder.requires_glm_next_selector_metadata = True
+    builder._capture_default_state_slot_ids = torch.arange(capacity, dtype=torch.int32)
+    builder._capture_state_slot_ids = torch.empty(capacity, dtype=torch.int32)
+    builder._capture_state_is_fresh = torch.ones(capacity, dtype=torch.bool)
+    builder._capture_num_accepted_tokens = torch.ones(capacity, dtype=torch.int32)
+    builder._capture_is_prefilling = torch.zeros(capacity, dtype=torch.bool)
+    return builder
+
+
+def test_glm5next_flashinfer_stages_runtime_selector_metadata() -> None:
+    builder = _selector_metadata_builder()
+    staged = builder._stage_glm_next_selector_metadata(
+        num_reqs=2,
+        for_cudagraph_capture=False,
+        selector_state_slot_ids=torch.tensor([7, 3], dtype=torch.int32),
+        selector_state_is_fresh=torch.tensor([False, True]),
+        selector_num_accepted_tokens=torch.tensor([4, 1], dtype=torch.int32),
+        selector_is_prefilling=torch.tensor([False, True]),
+    )
+
+    torch.testing.assert_close(staged[0], torch.tensor([7, 3], dtype=torch.int32))
+    torch.testing.assert_close(staged[1], torch.tensor([False, True]))
+    torch.testing.assert_close(staged[2], torch.tensor([4, 1], dtype=torch.int32))
+    torch.testing.assert_close(staged[3], torch.tensor([False, True]))
+
+
+def test_glm5next_flashinfer_routes_short_extends_through_prefill() -> None:
+    builder = _selector_metadata_builder()
+    assert not builder._should_treat_short_extends_as_decodes()
+
+    builder.requires_glm_next_selector_metadata = False
+    assert builder._should_treat_short_extends_as_decodes()
+
+
+def test_glm5next_flashinfer_stages_capture_selector_metadata() -> None:
+    builder = _selector_metadata_builder()
+    staged = builder._stage_glm_next_selector_metadata(
+        num_reqs=3,
+        for_cudagraph_capture=True,
+        selector_state_slot_ids=None,
+        selector_state_is_fresh=None,
+        selector_num_accepted_tokens=None,
+        selector_is_prefilling=None,
+    )
+
+    torch.testing.assert_close(staged[0], torch.arange(3, dtype=torch.int32))
+    assert staged[1].all()
+    torch.testing.assert_close(staged[2], torch.ones(3, dtype=torch.int32))
+    assert not staged[3].any()
+
+
+def test_glm5next_flashinfer_rejects_missing_runtime_selector_metadata() -> None:
+    builder = _selector_metadata_builder()
+    with pytest.raises(RuntimeError, match="requires selector state slots"):
+        builder._stage_glm_next_selector_metadata(
+            num_reqs=1,
+            for_cudagraph_capture=False,
+            selector_state_slot_ids=None,
+            selector_state_is_fresh=None,
+            selector_num_accepted_tokens=None,
+            selector_is_prefilling=None,
+        )
+
+
+def test_glm5next_flashinfer_metadata_exposes_pooled_selector_fields() -> None:
+    assert FlashInferMLASparseMetadata.prefill_query_lens_cpu is None
+    assert FlashInferMLASparseMetadata.selector_state_slot_ids is None
+    assert FlashInferMLASparseMetadata.selector_state_is_fresh is None
+    assert FlashInferMLASparseMetadata.selector_num_accepted_tokens is None
+    assert FlashInferMLASparseMetadata.selector_is_prefilling is None
 
 
 def test_sm120_dsv4_capability_checks_exact_dispatch_shape(monkeypatch) -> None:

--- a/tests/v1/attention/test_indexer_dcp_localize.py
+++ b/tests/v1/attention/test_indexer_dcp_localize.py
@@ -672,6 +672,33 @@ def test_dcp_filter_compacts_valid_slots_for_sparse_kernel():
 
 
 @pytest.mark.skipif(not current_platform.is_cuda(), reason="This test requires CUDA")
+def test_dcp1_filter_still_compacts_interior_gaps():
+    num_topk = 128
+    req_id = torch.zeros(1, dtype=torch.int32, device="cuda")
+    token_indices = torch.full((1, num_topk), -1, dtype=torch.int32, device="cuda")
+    token_indices[0, :5] = torch.tensor(
+        [0, -1, 2, -1, 3], dtype=torch.int32, device="cuda"
+    )
+    block_table = torch.tensor([[10]], dtype=torch.int32, device="cuda")
+
+    out, valid_counts = triton_filter_and_convert_dcp_index(
+        req_id,
+        block_table,
+        token_indices,
+        dcp_size=1,
+        dcp_rank=0,
+        BLOCK_SIZE=4,
+        NUM_TOPK_TOKENS=num_topk,
+        return_valid_counts=True,
+    )
+
+    assert int(valid_counts.item()) == 3
+    assert (out[0, :3] >= 0).all()
+    assert (out[0, 3:] == -1).all()
+    assert set(out[0, :3].cpu().tolist()) == {40, 42, 43}
+
+
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="This test requires CUDA")
 @pytest.mark.parametrize("interleave", [1, 2])
 @pytest.mark.parametrize("dcp_rank", [0, 1])
 # 384 is not a power of two, so it exercises the multi-tile atomic allocator

--- a/vllm/model_executor/layers/attention/sparse_mla_attention.py
+++ b/vllm/model_executor/layers/attention/sparse_mla_attention.py
@@ -106,6 +106,9 @@ class SparseMLACommonMetadataBuilder(AttentionMetadataBuilder[T]):
     require_uniform_decodes: ClassVar[bool] = False
     treat_short_extends_as_decodes: ClassVar[bool] = True
 
+    def _should_treat_short_extends_as_decodes(self) -> bool:
+        return self.treat_short_extends_as_decodes
+
     def __init__(
         self,
         kv_cache_spec: "AttentionSpec",
@@ -264,7 +267,7 @@ class SparseMLACommonMetadataBuilder(AttentionMetadataBuilder[T]):
             common_attn_metadata,
             decode_threshold=self.reorder_batch_threshold or 1,
             treat_short_extends_as_decodes=(
-                self.treat_short_extends_as_decodes and not self.use_pcp
+                self._should_treat_short_extends_as_decodes() and not self.use_pcp
             ),
             require_uniform=self.require_uniform_decodes,
         )

--- a/vllm/models/glm5next/nvidia/pooled_indexer.py
+++ b/vllm/models/glm5next/nvidia/pooled_indexer.py
@@ -46,7 +46,7 @@ _SELECTION_WIDTH = 2051
 _INDEX_CACHE_WIDTH = 132
 _INDEX_PAGE_SIZE = 64
 _INDEX_PAGE_BYTES = _INDEX_PAGE_SIZE * _INDEX_CACHE_WIDTH
-_MLA_RECORD_BYTES = 528
+_SUPPORTED_MLA_RECORD_BYTES = frozenset((528, 656))
 
 
 class Glm5NextPooledIndexer(nn.Module):
@@ -264,23 +264,28 @@ class Glm5NextPooledIndexer(nn.Module):
     def _index_cache_view(
         main_cache: torch.Tensor,
     ) -> tuple[torch.Tensor, int, int]:
+        record_bytes = int(main_cache.shape[-1]) if main_cache.ndim == 3 else -1
         if (
             main_cache.ndim != 3
             or main_cache.dtype != torch.uint8
-            or int(main_cache.shape[-1]) != _MLA_RECORD_BYTES
+            or record_bytes not in _SUPPORTED_MLA_RECORD_BYTES
         ):
-            raise ValueError("GLM MLA cache must be uint8 [pages, block, 528]")
+            supported = ", ".join(map(str, sorted(_SUPPORTED_MLA_RECORD_BYTES)))
+            raise ValueError(
+                "GLM MLA cache must be uint8 [pages, block, record], "
+                f"with record in {{{supported}}} bytes"
+            )
         pages, block_size, _ = map(int, main_cache.shape)
         if pages <= 0 or block_size % (_POOL_SIZE * _INDEX_PAGE_SIZE):
             raise ValueError(
                 "GLM MLA pages must contain a whole number of 64-pool C4 pages"
             )
-        if tuple(map(int, main_cache.stride()[1:])) != (_MLA_RECORD_BYTES, 1):
+        if tuple(map(int, main_cache.stride()[1:])) != (record_bytes, 1):
             raise ValueError("GLM MLA cache records must be contiguous within a page")
 
         subpages_per_parent = block_size // (_POOL_SIZE * _INDEX_PAGE_SIZE)
         parent_stride_bytes = int(main_cache.stride(0))
-        semantic_page_bytes = block_size * _MLA_RECORD_BYTES
+        semantic_page_bytes = block_size * record_bytes
         index_tail_bytes = subpages_per_parent * _INDEX_PAGE_BYTES
         if parent_stride_bytes < semantic_page_bytes + index_tail_bytes:
             raise ValueError("GLM MLA cache page does not contain its FP8 index tail")

--- a/vllm/v1/attention/backends/mla/flashinfer_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/flashinfer_mla_sparse.py
@@ -2,13 +2,13 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """FlashInfer sparse MLA attention backend."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, ClassVar
 
 import torch
 
 from vllm import envs
-from vllm.config import VllmConfig
+from vllm.config import VllmConfig, get_current_vllm_config_or_none
 from vllm.config.cache import CacheDType
 from vllm.logger import init_logger
 from vllm.model_executor.layers.attention.mla_attention import MLACommonPrefillMetadata
@@ -31,13 +31,42 @@ from vllm.v1.attention.backends.mla.sparse_utils import (
     triton_convert_req_index_to_global_index,
     triton_filter_and_convert_dcp_index,
 )
-from vllm.v1.kv_cache_interface import AttentionSpec
+from vllm.v1.kv_cache_interface import AttentionSpec, MLAAttentionSpec
+from vllm.v1.kv_cache_layout import KVCacheLayout
 
 if TYPE_CHECKING:
     from vllm.model_executor.models.deepseek_v2 import Indexer
     from vllm.v1.attention.backend import CommonAttentionMetadata
 
 logger = init_logger(__name__)
+
+_GLM_NEXT_MODEL_TYPES = frozenset(("glm5_next", "glm5_next_text"))
+# FlashInfer's SM120 GLM_NSA kernel is instantiated for a 576-wide query and
+# a 656-byte packed record: 512 FP8 latent bytes, 16 bytes of scales, and a
+# 64-element BF16 RoPE payload. GLM5Next has no RoPE payload, so its backend
+# implementation zero-pads that final region rather than publishing an
+# unsupported 528-byte kernel layout.
+_GLM_NEXT_CACHE_RECORD_BYTES = 656
+# The selector consumes 33 bytes/token (one 132-byte C4 record per four
+# tokens).  With a 656-byte FlashInfer state record, four extra padding bytes
+# per token make every 256-token unit an exact multiple of the C4 page size.
+# This also preserves the invariant for the 2,304-token hybrid-manager page.
+# The pooled indexer leaves that padding unused.
+_GLM_NEXT_PACKED_TAIL_BYTES_PER_TOKEN = 37
+
+
+def _current_hf_text_config() -> object | None:
+    config = get_current_vllm_config_or_none()
+    if config is None or config.model_config is None:
+        return None
+    return config.model_config.hf_text_config
+
+
+def _is_glm_next_spec(spec: AttentionSpec) -> bool:
+    if isinstance(spec, MLAAttentionSpec) and spec.model_version == "glm5_next":
+        return True
+    hf_config = _current_hf_text_config()
+    return getattr(hf_config, "model_type", None) in _GLM_NEXT_MODEL_TYPES
 
 
 class _FlashInferMLASparseBackendBase(AttentionBackend):
@@ -143,8 +172,48 @@ class FlashInferMLASparseSM120Backend(_FlashInferMLASparseBackendBase):
     def get_name() -> str:
         return "FLASHINFER_MLA_SPARSE_SM120"
 
+    @classmethod
+    def customize_spec(cls, spec: AttentionSpec) -> AttentionSpec:
+        if not _is_glm_next_spec(spec):
+            return spec
+        if not isinstance(spec, MLAAttentionSpec):
+            raise TypeError(
+                "FlashInfer SM120 GLM5Next sparse MLA requires an "
+                f"MLAAttentionSpec, got {type(spec).__name__}."
+            )
+        if spec.head_size != 512:
+            raise ValueError(
+                "FlashInfer SM120 GLM5Next sparse MLA requires head_size=512, "
+                f"got {spec.head_size}."
+            )
+        return replace(
+            spec,
+            state_content_bytes=_GLM_NEXT_CACHE_RECORD_BYTES,
+            page_tail_bytes_per_token=_GLM_NEXT_PACKED_TAIL_BYTES_PER_TOKEN,
+            model_version="glm5_next",
+        )
+
+    @classmethod
+    def supported_kv_cache_layouts(cls) -> tuple[KVCacheLayout, ...]:
+        # Keep the GLM pooled-index tail adjacent to its parent MLA page.
+        return (KVCacheLayout.BLHNC,)
+
+    @classmethod
+    def get_supported_head_sizes(cls) -> list[int]:
+        # The SM120 launcher accepts both DeepSeek's 512+64 MLA query and
+        # GLM5Next's 512-wide non-RoPE query. The shared SM10 backend remains
+        # restricted to the 576-wide DeepSeek layout.
+        return [512, 576]
+
     @staticmethod
     def get_supported_kernel_block_sizes() -> list[int | MultipleOf]:
+        hf_config = _current_hf_text_config()
+        if getattr(hf_config, "model_type", None) in _GLM_NEXT_MODEL_TYPES:
+            # The pooled-index tail is appended to the manager page. Keeping
+            # that page intact preserves the semantic-state/tail boundary;
+            # splitting it into smaller kernel pages would interleave neither
+            # region correctly under a block-outermost layout.
+            return [MultipleOf(64)]
         return [64, 256]
 
     @staticmethod
@@ -229,11 +298,16 @@ class FlashInferMLASparseMetadata(AttentionMetadata):
     num_decode_tokens: int
     prefill_max_seq_len: int = 0
     prefill: MLACommonPrefillMetadata | None = None
+    prefill_query_lens_cpu: torch.Tensor | None = None
 
     # Sparse-specific
     block_size: int = 64
     topk_tokens: int = 2048
     cp_kv_cache_interleave_size: int = 1
+    selector_state_slot_ids: torch.Tensor | None = None
+    selector_state_is_fresh: torch.Tensor | None = None
+    selector_num_accepted_tokens: torch.Tensor | None = None
+    selector_is_prefilling: torch.Tensor | None = None
 
 
 class FlashInferMLASparseMetadataBuilder(
@@ -243,6 +317,7 @@ class FlashInferMLASparseMetadataBuilder(
 
     metadata_cls = FlashInferMLASparseMetadata
     _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.UNIFORM_BATCH
+    requires_glm_next_selector_metadata: bool
 
     def __init__(
         self,
@@ -251,7 +326,31 @@ class FlashInferMLASparseMetadataBuilder(
         vllm_config: VllmConfig,
         device: torch.device,
     ) -> None:
+        hf_config = vllm_config.model_config.hf_text_config
+        self.requires_glm_next_selector_metadata = (
+            getattr(hf_config, "model_type", None) in _GLM_NEXT_MODEL_TYPES
+        )
         super().__init__(kv_cache_spec, layer_names, vllm_config, device)
+        self.supports_draft_decode_metadata_update = (
+            self.requires_glm_next_selector_metadata
+        )
+        if self.requires_glm_next_selector_metadata:
+            max_reqs = int(vllm_config.scheduler_config.max_num_seqs)
+            self._capture_default_state_slot_ids = torch.arange(
+                max_reqs, dtype=torch.int32, device=device
+            )
+            self._capture_state_slot_ids = torch.empty(
+                max_reqs, dtype=torch.int32, device=device
+            )
+            self._capture_state_is_fresh = torch.ones(
+                max_reqs, dtype=torch.bool, device=device
+            )
+            self._capture_num_accepted_tokens = torch.ones(
+                max_reqs, dtype=torch.int32, device=device
+            )
+            self._capture_is_prefilling = torch.zeros(
+                max_reqs, dtype=torch.bool, device=device
+            )
 
         num_q_heads = vllm_config.model_config.get_num_attention_heads(
             vllm_config.parallel_config
@@ -264,6 +363,174 @@ class FlashInferMLASparseMetadataBuilder(
             supports_spec_as_decode=True,
             supports_dcp_with_varlen=True,
         )
+
+    def _should_treat_short_extends_as_decodes(self) -> bool:
+        # Every fresh or extended GLM prompt row must update the pooled
+        # selector before it can be routed as decode.
+        return not self.requires_glm_next_selector_metadata
+
+    def _stage_glm_next_selector_metadata(
+        self,
+        *,
+        num_reqs: int,
+        for_cudagraph_capture: bool,
+        selector_state_slot_ids: torch.Tensor | None,
+        selector_state_is_fresh: torch.Tensor | None,
+        selector_num_accepted_tokens: torch.Tensor | None,
+        selector_is_prefilling: torch.Tensor | None,
+    ) -> tuple[
+        torch.Tensor | None,
+        torch.Tensor | None,
+        torch.Tensor | None,
+        torch.Tensor | None,
+    ]:
+        values = (
+            selector_state_slot_ids,
+            selector_state_is_fresh,
+            selector_num_accepted_tokens,
+            selector_is_prefilling,
+        )
+        if not self.requires_glm_next_selector_metadata:
+            if any(value is not None for value in values):
+                raise TypeError(
+                    "GLM5Next selector metadata was provided to a non-GLM "
+                    "FlashInfer sparse MLA builder"
+                )
+            return (None, None, None, None)
+
+        capacity = int(self._capture_state_slot_ids.numel())
+        if not 0 <= num_reqs <= capacity:
+            raise ValueError(
+                "GLM5Next selector request count exceeds the metadata buffer "
+                f"capacity: num_reqs={num_reqs}, capacity={capacity}"
+            )
+        if not for_cudagraph_capture and any(value is None for value in values):
+            raise RuntimeError(
+                "FlashInfer GLM5Next sparse MLA requires selector state slots, "
+                "fresh flags, accepted-token counts, and prefill flags"
+            )
+
+        if for_cudagraph_capture:
+            self._capture_state_slot_ids[:num_reqs].copy_(
+                self._capture_default_state_slot_ids[:num_reqs]
+            )
+            self._capture_state_is_fresh[:num_reqs].fill_(True)
+            self._capture_num_accepted_tokens[:num_reqs].fill_(1)
+            self._capture_is_prefilling[:num_reqs].fill_(False)
+        else:
+            typed_values = tuple(value for value in values if value is not None)
+            if any(
+                value.ndim != 1 or value.numel() < num_reqs for value in typed_values
+            ):
+                raise ValueError(
+                    "GLM5Next selector metadata must be one-dimensional and "
+                    "cover every padded request row"
+                )
+            self._capture_state_slot_ids[:num_reqs].fill_(-1)
+            self._capture_state_is_fresh[:num_reqs].fill_(True)
+            self._capture_num_accepted_tokens[:num_reqs].fill_(1)
+            self._capture_is_prefilling[:num_reqs].fill_(False)
+            assert selector_state_slot_ids is not None
+            assert selector_state_is_fresh is not None
+            assert selector_num_accepted_tokens is not None
+            assert selector_is_prefilling is not None
+            self._capture_state_slot_ids[:num_reqs].copy_(
+                selector_state_slot_ids[:num_reqs]
+            )
+            self._capture_state_is_fresh[:num_reqs].copy_(
+                selector_state_is_fresh[:num_reqs]
+            )
+            self._capture_num_accepted_tokens[:num_reqs].copy_(
+                selector_num_accepted_tokens[:num_reqs]
+            )
+            self._capture_is_prefilling[:num_reqs].copy_(
+                selector_is_prefilling[:num_reqs]
+            )
+
+        return (
+            self._capture_state_slot_ids[:num_reqs],
+            self._capture_state_is_fresh[:num_reqs],
+            self._capture_num_accepted_tokens[:num_reqs],
+            self._capture_is_prefilling[:num_reqs],
+        )
+
+    def _build(
+        self,
+        common_prefix_len: int,
+        common_attn_metadata: "CommonAttentionMetadata",
+        fast_build: bool = False,
+        *,
+        for_cudagraph_capture: bool,
+        selector_state_slot_ids: torch.Tensor | None = None,
+        selector_state_is_fresh: torch.Tensor | None = None,
+        selector_num_accepted_tokens: torch.Tensor | None = None,
+        selector_is_prefilling: torch.Tensor | None = None,
+    ) -> FlashInferMLASparseMetadata:
+        metadata = super().build(
+            common_prefix_len, common_attn_metadata, fast_build=fast_build
+        )
+        if metadata.num_prefills:
+            prefill_start = metadata.num_decodes
+            prefill_end = prefill_start + metadata.num_prefills + 1
+            metadata.prefill_query_lens_cpu = torch.diff(
+                common_attn_metadata.query_start_loc_cpu[prefill_start:prefill_end]
+            )
+        (
+            metadata.selector_state_slot_ids,
+            metadata.selector_state_is_fresh,
+            metadata.selector_num_accepted_tokens,
+            metadata.selector_is_prefilling,
+        ) = self._stage_glm_next_selector_metadata(
+            num_reqs=common_attn_metadata.num_reqs,
+            for_cudagraph_capture=for_cudagraph_capture,
+            selector_state_slot_ids=selector_state_slot_ids,
+            selector_state_is_fresh=selector_state_is_fresh,
+            selector_num_accepted_tokens=selector_num_accepted_tokens,
+            selector_is_prefilling=selector_is_prefilling,
+        )
+        return metadata
+
+    def build(
+        self,
+        common_prefix_len: int,
+        common_attn_metadata: "CommonAttentionMetadata",
+        fast_build: bool = False,
+        selector_state_slot_ids: torch.Tensor | None = None,
+        selector_state_is_fresh: torch.Tensor | None = None,
+        selector_num_accepted_tokens: torch.Tensor | None = None,
+        selector_is_prefilling: torch.Tensor | None = None,
+    ) -> FlashInferMLASparseMetadata:
+        return self._build(
+            common_prefix_len,
+            common_attn_metadata,
+            fast_build,
+            for_cudagraph_capture=False,
+            selector_state_slot_ids=selector_state_slot_ids,
+            selector_state_is_fresh=selector_state_is_fresh,
+            selector_num_accepted_tokens=selector_num_accepted_tokens,
+            selector_is_prefilling=selector_is_prefilling,
+        )
+
+    def build_for_cudagraph_capture(
+        self,
+        common_attn_metadata: "CommonAttentionMetadata",
+    ) -> FlashInferMLASparseMetadata:
+        return self._build(
+            common_prefix_len=0,
+            common_attn_metadata=common_attn_metadata,
+            for_cudagraph_capture=True,
+        )
+
+    def update_draft_decode_metadata(
+        self,
+        metadata: FlashInferMLASparseMetadata,
+    ) -> None:
+        accepted = metadata.selector_num_accepted_tokens
+        if not self.requires_glm_next_selector_metadata or accepted is None:
+            raise RuntimeError(
+                "GLM5Next draft decode metadata requires accepted-token counts"
+            )
+        accepted.fill_(1)
 
 
 class FlashInferMLASparseTRTLLMMetadataBuilder(FlashInferMLASparseMetadataBuilder):

--- a/vllm/v1/attention/backends/mla/flashinfer_mla_sparse_sm120.py
+++ b/vllm/v1/attention/backends/mla/flashinfer_mla_sparse_sm120.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """SM120 implementation variant for ``FLASHINFER_MLA_SPARSE_SM120``."""
 
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 import torch
 
@@ -16,11 +16,13 @@ from vllm.v1.attention.backends.mla.flashinfer_mla_sparse import (
     _get_workspace_buffer,
 )
 from vllm.v1.attention.backends.mla.sparse_utils import (
-    triton_convert_req_index_to_global_index,
+    triton_filter_and_convert_dcp_index,
 )
 
 if TYPE_CHECKING:
     from vllm.model_executor.models.deepseek_v2 import Indexer
+
+_FLASHINFER_DECODE_MAX_TOKENS = 64
 
 
 def _kv_scale_format_for_model(model_type: str | None) -> str:
@@ -74,6 +76,16 @@ class FlashInferMLASparseSM120Impl(MLAAttentionImpl[FlashInferMLASparseMetadata]
         self.kv_lora_rank: int = mla_args["kv_lora_rank"]
         self.qk_nope_head_dim: int = mla_args["qk_nope_head_dim"]
         self.qk_rope_head_dim: int = mla_args["qk_rope_head_dim"]
+        self.rope_pad = 0
+        if self.qk_rope_head_dim == 0:
+            if self.kv_lora_rank != 512:
+                raise NotImplementedError(
+                    "FLASHINFER_MLA_SPARSE_SM120 pads NoPE MLA into the "
+                    "576-wide GLM_NSA geometry, which requires "
+                    f"kv_lora_rank=512; got {self.kv_lora_rank}."
+                )
+            self.rope_pad = 64
+        self.kernel_qk_rope_head_dim = self.qk_rope_head_dim + self.rope_pad
         from vllm.config import get_current_vllm_config
 
         vllm_config = get_current_vllm_config()
@@ -112,25 +124,76 @@ class FlashInferMLASparseSM120Impl(MLAAttentionImpl[FlashInferMLASparseMetadata]
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         if isinstance(q, tuple):
             q = torch.cat(q, dim=-1)
+        if self.rope_pad:
+            q = torch.nn.functional.pad(q, (0, self.rope_pad))
 
         num_actual_toks = q.shape[0]
 
         assert self.topk_indices_buffer is not None
         topk_indices = self.topk_indices_buffer[:num_actual_toks]
 
-        topk_indices_physical = cast(
-            torch.Tensor,
-            triton_convert_req_index_to_global_index(
-                attn_metadata.req_id_per_token[:num_actual_toks],
-                attn_metadata.block_table,
-                topk_indices,
-                BLOCK_SIZE=attn_metadata.block_size,
-                NUM_TOPK_TOKENS=topk_indices.shape[1],
-            ),
+        # GLM's pooled selector emits 2048 history candidates followed by up
+        # to three unpooled recent tokens. FlashInfer instantiates a fixed
+        # 2048-wide GLM_NSA kernel, so retain the recent tail and drop the same
+        # number of lowest-ranked history candidates.
+        kernel_topk = attn_metadata.topk_tokens
+        extra_topk = topk_indices.shape[1] - kernel_topk
+        if extra_topk < 0:
+            raise ValueError(
+                "FlashInfer sparse MLA candidate buffer is narrower than its "
+                f"kernel width: {topk_indices.shape[1]} < {kernel_topk}."
+            )
+        if extra_topk:
+            topk_indices = torch.cat(
+                (
+                    topk_indices[:, : kernel_topk - extra_topk],
+                    topk_indices[:, -extra_topk:],
+                ),
+                dim=1,
+            )
+
+        topk_indices_physical, topk_lens = triton_filter_and_convert_dcp_index(
+            attn_metadata.req_id_per_token[:num_actual_toks],
+            attn_metadata.block_table,
+            topk_indices,
+            dcp_size=1,
+            dcp_rank=0,
+            BLOCK_SIZE=attn_metadata.block_size,
+            NUM_TOPK_TOKENS=kernel_topk,
+            return_valid_counts=True,
         )
 
+        # FlashInfer's standalone SM120 sparse-decode kernels require a
+        # 64-token physical cache page. GLM's pooled selector intentionally
+        # keeps a larger manager page so its C4 index tail remains adjacent to
+        # the MLA cache. For a decode-sized batch on that layout, pad the row
+        # count just beyond FlashInfer's decode cutoff and use its paged
+        # attention implementation. The dummy rows have no valid candidates
+        # and are discarded below.
+        cache_page_size = int(kv_c_and_k_pe_cache.shape[-2])
+        if num_actual_toks <= _FLASHINFER_DECODE_MAX_TOKENS and cache_page_size != 64:
+            padded_num_toks = _FLASHINFER_DECODE_MAX_TOKENS + 1
+            pad_rows = padded_num_toks - num_actual_toks
+            q = torch.cat(
+                (q, q.new_zeros((pad_rows, *q.shape[1:]))),
+                dim=0,
+            )
+            topk_indices_physical = torch.cat(
+                (
+                    topk_indices_physical,
+                    topk_indices_physical.new_full(
+                        (pad_rows, topk_indices_physical.shape[1]), -1
+                    ),
+                ),
+                dim=0,
+            )
+            topk_lens = torch.cat(
+                (topk_lens, topk_lens.new_zeros((pad_rows,))),
+                dim=0,
+            )
+
         output = q.new_empty(
-            (num_actual_toks, self.num_heads, self.kv_lora_rank),
+            (q.shape[0], self.num_heads, self.kv_lora_rank),
             dtype=q.dtype,
         )
 
@@ -147,14 +210,42 @@ class FlashInferMLASparseSM120Impl(MLAAttentionImpl[FlashInferMLASparseMetadata]
             workspace_buffer=self._workspace_buffer,
             qk_nope_head_dim=self.qk_nope_head_dim,
             kv_lora_rank=self.kv_lora_rank,
-            qk_rope_head_dim=self.qk_rope_head_dim,
+            qk_rope_head_dim=self.kernel_qk_rope_head_dim,
             block_tables=topk_indices_physical.unsqueeze(1),
-            seq_lens=None,
-            max_seq_len=attn_metadata.topk_tokens,
+            # The fused index conversion compacts every valid slot to the row
+            # prefix, and these lengths mask its remaining -1 tail.
+            seq_lens=topk_lens,
+            max_seq_len=kernel_topk,
             out=output.unsqueeze(1),
             bmm1_scale=self.scale,
             bmm2_scale=1.0,
-            sparse_mla_top_k=attn_metadata.topk_tokens,
+            sparse_mla_top_k=kernel_topk,
+            backend="sparse",
             kv_scale_format=self.kv_scale_format,
         )
-        return out.squeeze(1), None
+        return out.squeeze(1)[:num_actual_toks], None
+
+    def do_kv_cache_update(
+        self,
+        kv_c_normed: torch.Tensor,
+        k_pe: torch.Tensor,
+        kv_cache: torch.Tensor,
+        slot_mapping: torch.Tensor,
+        kv_cache_dtype: str,
+        k_scale: torch.Tensor,
+    ) -> None:
+        if self.rope_pad:
+            if int(k_pe.shape[-1]) != 0:
+                raise ValueError(
+                    "FlashInfer GLM5Next cache padding requires a zero-width "
+                    f"RoPE tensor, got shape={tuple(k_pe.shape)}."
+                )
+            k_pe = k_pe.new_zeros((*k_pe.shape[:-1], self.rope_pad))
+        super().do_kv_cache_update(
+            kv_c_normed,
+            k_pe,
+            kv_cache,
+            slot_mapping,
+            kv_cache_dtype,
+            k_scale,
+        )

--- a/vllm/v1/attention/backends/mla/sparse_utils.py
+++ b/vllm/v1/attention/backends/mla/sparse_utils.py
@@ -339,7 +339,7 @@ def triton_filter_and_convert_dcp_index(
     assert token_indices.dtype == torch.int32
     assert token_indices.shape[1] == NUM_TOPK_TOKENS
 
-    if dcp_size == 1:
+    if dcp_size == 1 and not compact_valid_to_front:
         return triton_convert_req_index_to_global_index(
             req_id,
             block_table,


### PR DESCRIPTION
## Summary

Complete the vLLM side of FlashInfer SM120 sparse-MLA support for GLM5Next.
This covers the model-owned pooled selector, GLM's non-RoPE query geometry,
the packed FP8 KV/index-cache layout, and the active sparse-index contract.

The matching FlashInfer kernel change is
[voipmonitor/flashinfer#2](https://github.com/voipmonitor/flashinfer/pull/2),
tested here at commit
`64c2c521d34748179757cec8b9a14f2e2f31c721`.

## Changes

- Admit GLM5Next's 512-wide non-RoPE model head on the SM120 backend while
  retaining the shared SM10 backend's existing 576-wide restriction.
- Pad GLM's query and zero-width RoPE cache input to FlashInfer's 576-wide
  GLM_NSA kernel geometry.
- Publish the actual 656-byte packed FlashInfer state record and a
  37-byte/token model-owned tail. Of that tail, 33 bytes/token hold the C4
  pooled index and four bytes/token preserve exact 256-token C4-page
  alignment.
- Require BLHNC and preserve the resolved 2,304-token hybrid-manager page so
  the pooled-index tail remains adjacent to its MLA page.
- Compact valid sparse indices, pass per-row active top-k lengths, preserve
  GLM's recent-token tail when reducing 2,051 selector candidates to the
  2,048-wide kernel contract, and route non-64-page decode batches through
  the page-aware prefill kernel.
- Carry GLM selector state slots, freshness flags, accepted-token counts, and
  prefill flags through eager and CUDA-graph metadata construction.
- Avoid classifying DeepSeek-V4's 512-wide SM120 cache as GLM when model-config
  context is unavailable; only an explicit GLM model version or live GLM
  config activates the GLM packing.

## Validation

- vLLM modified-file pre-commit suite: passed, including Ruff check/format,
  typos, mypy, SPDX, forbidden-import, and configuration checks.
- Focused vLLM SM120 backend API suite in the release environment:
  `22 passed`.
- Matching FlashInfer native SM120 suite on RTX 5090 / SM120:
  `141 passed in 16.52s`.
- Exact AOT module with JIT disabled: production page-2,304 GLM cases passed
  for TP4's 16 local heads and the 32-head variant.
- FlashInfer AOT module SHA-256:
  `ce157a627f7ecafae707b46bbd4dd89b26b1893ae2a3669e2fd6e90b19e1e6c1`.
- Exact image under qualification:
  `glm53-production:flashinfer-page2304-fix-20260829`
  (`sha256:17f2690ea69119e7bbb7b6c88315d05bbe4f84cc6790394f6b2d8eba35e7bd8c`).
- Frozen-panel KLD: **PENDING_ACTIVE_RUN**.

The exact-image run uses NVFP4 weights, FP8 KV cache, TP4, a requested
256-token block resolved to the production 2,304-token manager page,
`FLASHINFER_DISABLE_JIT=1`, and the AOT module above.

## Base

`local-inference-lab/vllm:dev/jovian-judgement` at
`766acf0e218a075432e6c45755cd561ab765ec2d`.

