### PR TITLE
fix(dflash): replicate draft KV under DCP

### DIFF
--- a/tests/v1/attention/test_flashinfer_dcp_spec_reorder.py
+++ b/tests/v1/attention/test_flashinfer_dcp_spec_reorder.py
@@ -2,6 +2,9 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """FlashInfer GQA builder: reorder threshold under DCP with spec decode."""
 
+from types import SimpleNamespace
+from unittest.mock import Mock
+
 import pytest
 
 from vllm.platforms import current_platform
@@ -15,8 +18,10 @@ from tests.v1.attention.utils import create_vllm_config
 from vllm.config import SpeculativeConfig, set_current_vllm_config
 from vllm.v1.attention.backends import flashinfer as flashinfer_backend
 from vllm.v1.attention.backends.flashinfer import (
+    BatchDCPPrefillWrapper,
     FlashInferDecodeKernel,
     FlashInferMetadataBuilder,
+    _get_dcp_local_kv_page_metadata,
 )
 from vllm.v1.attention.backends.utils import PerLayerParameters
 from vllm.v1.kv_cache_interface import FullAttentionSpec
@@ -73,3 +78,85 @@ def test_flashinfer_gqa_dcp_spec_decode_clamps_reorder_threshold(monkeypatch):
         builder.flashinfer_trtllm_api_decode_kernel == FlashInferDecodeKernel.TRTLLM_GEN
     )
     assert builder.reorder_batch_threshold == 1
+
+
+def test_dcp_prefill_wrapper_preserves_noncausal_draft_mask() -> None:
+    wrapper = BatchDCPPrefillWrapper.__new__(BatchDCPPrefillWrapper)
+    wrapper._context = Mock()
+    wrapper._new_tokens = Mock()
+    indptr = torch.tensor([0, 3], dtype=torch.int32)
+
+    wrapper.plan(
+        qo_indptr_cpu=indptr,
+        paged_kv_indptr_cpu=torch.tensor([0, 1], dtype=torch.int32),
+        paged_kv_indices=torch.tensor([0], dtype=torch.int32),
+        paged_kv_last_page_len_cpu=torch.tensor([3], dtype=torch.int32),
+        page_size=16,
+        num_qo_heads=4,
+        dcp_world_size=2,
+        num_kv_heads=1,
+        head_dim=128,
+        sm_scale=0.1,
+        window_left=-1,
+        logits_soft_cap=None,
+        q_data_type=torch.bfloat16,
+        kv_cache_dtype=torch.float8_e4m3fn,
+        prefill_fixed_split_size=-1,
+        disable_split_kv=False,
+        causal=False,
+    )
+
+    assert wrapper._context.plan.call_args.kwargs["causal"] is False
+    assert wrapper._new_tokens.plan.call_args.kwargs["causal"] is False
+
+
+def test_flashinfer_selects_dcp_wrapper_for_noncausal_prefill(monkeypatch) -> None:
+    expected = object()
+    factory = Mock(return_value=expected)
+    monkeypatch.setattr(flashinfer_backend, "BatchDCPPrefillWrapper", factory)
+    monkeypatch.setattr(
+        flashinfer_backend,
+        "get_flashinfer_layout_string",
+        lambda _: "NHD",
+    )
+
+    builder = FlashInferMetadataBuilder.__new__(FlashInferMetadataBuilder)
+    builder.use_dcp = True
+    builder.dcp_a2a = False
+    builder._prefill_wrapper = None
+    builder.cache_config = SimpleNamespace(
+        get_resolved_kv_cache_layout=lambda: object()
+    )
+    builder._get_workspace_buffer = Mock(return_value=torch.empty(0))
+
+    assert builder._get_prefill_wrapper(causal=False) is expected
+    factory.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("rank", "expected_lengths", "expected_pages"),
+    [
+        (0, [0, 12, 17], [0, 1, 2]),
+        (1, [0, 12, 16], [0, 1, 1]),
+        (2, [0, 12, 16], [0, 1, 1]),
+        (3, [0, 8, 16], [0, 1, 1]),
+    ],
+)
+def test_dcp_flashinfer_page_metadata_is_rank_local(
+    rank: int,
+    expected_lengths: list[int],
+    expected_pages: list[int],
+) -> None:
+    # Global lengths 44 and 65 would incorrectly produce 3 and 5 native
+    # pages at page_size=16. DCP4 stores only the rank-local lengths below.
+    local_lens, local_lens_np, local_pages_np = _get_dcp_local_kv_page_metadata(
+        torch.tensor([0, 44, 65], dtype=torch.int32),
+        dcp_world_size=4,
+        dcp_rank=rank,
+        dcp_kv_cache_interleave_size=4,
+        page_size=16,
+    )
+
+    assert local_lens.tolist() == expected_lengths
+    assert local_lens_np.tolist() == expected_lengths
+    assert local_pages_np.tolist() == expected_pages

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -916,6 +916,81 @@ def test_prefill_hybrid_model_combinations(spec_types: list[str]):
     manager.free(req1)
 
 
+def test_prefill_hybrid_dcp_sliding_window():
+    """DCP scales SWA cache pages, cache-hit lookup, and retention together."""
+    from vllm.v1.core.single_type_kv_cache_manager import SlidingWindowManager
+
+    block_size = 16
+    dcp_world_size = 4
+    effective_block_size = block_size * dcp_world_size
+    kv_cache_config = _make_hybrid_kv_cache_config(
+        block_size,
+        num_blocks=64,
+        spec_types=["full", "sliding_window_large"],
+    )
+    swa_group = kv_cache_config.kv_cache_groups[1]
+    kv_cache_config = replace(
+        kv_cache_config,
+        kv_cache_groups=[
+            kv_cache_config.kv_cache_groups[0],
+            replace(
+                swa_group,
+                kv_cache_spec=replace(
+                    swa_group.kv_cache_spec,
+                    sliding_window=2 * effective_block_size,
+                ),
+            ),
+        ],
+    )
+    manager = make_kv_cache_manager(
+        kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+        scheduler_block_size=effective_block_size,
+        dcp_world_size=dcp_world_size,
+    )
+
+    assert [m.block_size for m in manager.coordinator.single_type_managers] == [
+        effective_block_size,
+        effective_block_size,
+    ]
+    swa_spec = kv_cache_config.kv_cache_groups[1].kv_cache_spec
+    assert isinstance(swa_spec, SlidingWindowSpec)
+    assert SlidingWindowManager.reachable_block_mask(
+        start_block=0,
+        end_block=4,
+        alignment_tokens=effective_block_size,
+        kv_cache_spec=swa_spec,
+        use_eagle=False,
+        retention_interval=0,
+        reachable_boundaries=(3 * effective_block_size - 1,),
+        effective_block_size=effective_block_size,
+    ) == [True, True, False, False]
+
+    common_token_ids = [i for i in range(12) for _ in range(block_size)]
+    req0 = make_request("dcp-producer", common_token_ids + [12] * 7, block_size, sha256)
+    computed_blocks, num_computed_tokens, _ = manager.get_computed_blocks(req0)
+    assert num_computed_tokens == 0
+    assert (
+        manager.allocate_slots(
+            req0,
+            len(req0.prompt_token_ids),
+            num_computed_tokens,
+            computed_blocks,
+        )
+        is not None
+    )
+    manager.new_step_starts()
+
+    req1 = make_request("dcp-consumer", common_token_ids + [13] * 5, block_size, sha256)
+    computed_blocks, num_computed_tokens, _ = manager.get_computed_blocks(req1)
+
+    assert num_computed_tokens == len(common_token_ids)
+    assert [len(blocks) for blocks in computed_blocks.blocks] == [3, 3]
+    manager.free(req0)
+
+
 # Test cases with eagle enabled: Only test a single simple case for now.
 # - 2 groups: 1 full + 1 other
 _EAGLE_HYBRID_MODEL_TEST_CASES = [

--- a/tests/v1/core/test_swa_inflight_window_free.py
+++ b/tests/v1/core/test_swa_inflight_window_free.py
@@ -168,6 +168,24 @@ def test_swa_admission_cap_accounts_for_overlapping_batches():
     assert overlapped == 193
 
 
+def test_swa_admission_cap_accounts_for_dcp_shards():
+    spec = SlidingWindowSpec(
+        block_size=16,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        sliding_window=1024,
+    )
+    cap = spec.max_admission_blocks_per_request(
+        max_in_flight_tokens=1024,
+        max_model_len=16384,
+        kv_shard_count=4,
+    )
+    # Each local page covers 16 * DCP4 global tokens. The one extra block
+    # accounts for a window whose trailing edge is not page-aligned.
+    assert cap == 33
+
+
 def test_chunked_local_free_waits_for_in_flight_step():
     """Chunked-local attention frees whole chunks left of the current one, and
     is exposed to the same load-WAR: with async scheduling those chunks must
@@ -219,6 +237,22 @@ def test_chunked_local_admission_cap_accounts_for_overlapping_batches():
     )
     # One extra in-flight chunk is held back: (1024 + 2 * 1024) tokens.
     assert overlapped == 192
+
+
+def test_chunked_local_admission_cap_accounts_for_dcp_shards():
+    spec = ChunkedLocalAttentionSpec(
+        block_size=16,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        attention_chunk_size=1024,
+    )
+    cap = spec.max_admission_blocks_per_request(
+        max_in_flight_tokens=1024,
+        max_model_len=16384,
+        kv_shard_count=4,
+    )
+    assert cap == 32
 
 
 def test_connector_finish_frees_on_settled_basis():

--- a/tests/v1/spec_decode/test_dflash_replicated_dcp.py
+++ b/tests/v1/spec_decode/test_dflash_replicated_dcp.py
@@ -1,0 +1,186 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import torch
+
+from vllm.model_executor.layers.attention import Attention
+from vllm.model_executor.models.qwen3_dflash import DFlashAttention
+from vllm.v1.core.kv_cache_utils import (
+    get_kv_cache_groups,
+    resolve_kv_cache_block_sizes,
+)
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+    MLAAttentionSpec,
+    SlidingWindowSpec,
+)
+
+
+def test_dflash_marks_windowed_and_full_draft_kv_replicated(monkeypatch):
+    attn = object.__new__(DFlashAttention)
+    vllm_config = SimpleNamespace(
+        cache_config=SimpleNamespace(block_size=256),
+        parallel_config=SimpleNamespace(decode_context_parallel_size=4),
+    )
+    window_spec = SlidingWindowSpec(
+        block_size=64,
+        num_kv_heads=2,
+        head_size=128,
+        dtype=torch.float8_e4m3fn,
+        sliding_window=2048,
+    )
+    monkeypatch.setattr(
+        Attention,
+        "get_kv_cache_spec",
+        lambda self, config: window_spec,
+    )
+
+    spec = DFlashAttention.get_kv_cache_spec(attn, vllm_config)
+
+    assert isinstance(spec, SlidingWindowSpec)
+    # The target's 256-token block must not replace the backend-selected
+    # 64-token block of the windowed draft cache.
+    assert spec.block_size == 64
+    assert spec.sliding_window == 2048
+    assert spec.num_kv_heads == 2
+    assert spec.dcp_replicated is True
+
+    full_spec = FullAttentionSpec(
+        block_size=16,
+        num_kv_heads=2,
+        head_size=128,
+        dtype=torch.float8_e4m3fn,
+    )
+    monkeypatch.setattr(
+        Attention,
+        "get_kv_cache_spec",
+        lambda self, config: full_spec,
+    )
+
+    spec = DFlashAttention.get_kv_cache_spec(attn, vllm_config)
+
+    assert isinstance(spec, FullAttentionSpec)
+    assert spec.dcp_replicated is True
+
+
+def test_dflash_dcp1_does_not_mark_draft_kv_replicated(monkeypatch):
+    attn = object.__new__(DFlashAttention)
+    vllm_config = SimpleNamespace(
+        cache_config=SimpleNamespace(block_size=16),
+        parallel_config=SimpleNamespace(decode_context_parallel_size=1),
+    )
+    window_spec = SlidingWindowSpec(
+        block_size=16,
+        num_kv_heads=2,
+        head_size=128,
+        dtype=torch.bfloat16,
+        sliding_window=2048,
+    )
+    monkeypatch.setattr(
+        Attention,
+        "get_kv_cache_spec",
+        lambda self, config: window_spec,
+    )
+
+    spec = DFlashAttention.get_kv_cache_spec(attn, vllm_config)
+
+    assert isinstance(spec, SlidingWindowSpec)
+    assert spec.dcp_replicated is False
+
+
+def test_replicated_group_uses_unsharded_scheduler_and_table_geometry():
+    spec = SlidingWindowSpec(
+        block_size=16,
+        num_kv_heads=2,
+        head_size=128,
+        dtype=torch.bfloat16,
+        sliding_window=2048,
+        dcp_replicated=True,
+    )
+    vllm_config = SimpleNamespace(
+        cache_config=SimpleNamespace(
+            block_size=16,
+            enable_prefix_caching=False,
+            prefix_match_unit=None,
+        ),
+        parallel_config=SimpleNamespace(decode_context_parallel_size=4),
+        kv_transfer_config=None,
+    )
+    kv_cache_config = SimpleNamespace(
+        kv_cache_groups=[SimpleNamespace(kv_cache_spec=spec)]
+    )
+
+    assert resolve_kv_cache_block_sizes(kv_cache_config, vllm_config) == (16, 16)
+    assert spec.max_num_blocks_per_req(vllm_config, max_len=4096) == 256
+
+
+def test_mixed_target_and_replicated_draft_keep_distinct_dcp_geometry():
+    target = MLAAttentionSpec(
+        block_size=64,
+        num_kv_heads=1,
+        head_size=128,
+        dtype=torch.bfloat16,
+    )
+    draft = FullAttentionSpec(
+        block_size=64,
+        num_kv_heads=2,
+        head_size=128,
+        dtype=torch.bfloat16,
+        dcp_replicated=True,
+    )
+    vllm_config = SimpleNamespace(
+        cache_config=SimpleNamespace(
+            block_size=64,
+            enable_prefix_caching=True,
+            prefix_match_unit=None,
+        ),
+        parallel_config=SimpleNamespace(decode_context_parallel_size=4),
+        kv_transfer_config=None,
+    )
+    kv_cache_config = KVCacheConfig(
+        num_blocks=128,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(["target"], target),
+            KVCacheGroupSpec(["draft"], draft),
+        ],
+    )
+
+    # The target scheduler unit remains DCP4-sharded while the draft block
+    # hashes and table width retain ordinary DCP1 geometry.
+    assert resolve_kv_cache_block_sizes(kv_cache_config, vllm_config) == (256, 64)
+    assert target.max_num_blocks_per_req(vllm_config, max_len=4096) == 16
+    assert draft.max_num_blocks_per_req(vllm_config, max_len=4096) == 64
+
+
+def test_grouping_never_merges_replicated_draft_with_sharded_target():
+    target = FullAttentionSpec(
+        block_size=16,
+        num_kv_heads=2,
+        head_size=64,
+        dtype=torch.bfloat16,
+    )
+    draft = FullAttentionSpec(
+        block_size=16,
+        num_kv_heads=2,
+        head_size=64,
+        dtype=torch.bfloat16,
+        dcp_replicated=True,
+    )
+    assert target.page_size_bytes == draft.page_size_bytes
+
+    vllm_config = SimpleNamespace(
+        scheduler_config=SimpleNamespace(disable_hybrid_kv_cache_manager=False)
+    )
+    grouped = get_kv_cache_groups(
+        vllm_config, {"target.layer": target, "draft.layer": draft}
+    )
+
+    assert [set(group.layer_names) for group in grouped] == [
+        {"target.layer"},
+        {"draft.layer"},
+    ]

--- a/tests/v1/worker/test_cp_utils.py
+++ b/tests/v1/worker/test_cp_utils.py
@@ -1,10 +1,68 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from types import SimpleNamespace
+
 import pytest
 import torch
 
 from vllm.v1.attention.backends.utils import get_dcp_local_seq_lens
-from vllm.v1.worker.cp_utils import should_skip_dcp_context_attention
+from vllm.v1.worker import cp_utils
+from vllm.v1.worker.cp_utils import (
+    check_attention_cp_compatibility,
+    should_skip_dcp_context_attention,
+)
+
+
+@pytest.mark.parametrize("capability_name", ["new", "legacy"])
+def test_spec_decode_interleave_accepts_new_and_legacy_capabilities(
+    monkeypatch, capability_name: str
+) -> None:
+    impl = SimpleNamespace(
+        supports_spec_decoding_with_cp_non_trivial_interleave_size=(
+            capability_name == "new"
+        ),
+        supports_mtp_with_cp_non_trivial_interleave_size=(capability_name == "legacy"),
+        need_to_return_lse_for_decode=True,
+    )
+    monkeypatch.setattr(
+        cp_utils,
+        "get_layers_from_vllm_config",
+        lambda *_: {"layer": SimpleNamespace(impl=impl)},
+    )
+    config = SimpleNamespace(
+        parallel_config=SimpleNamespace(
+            prefill_context_parallel_size=1,
+            decode_context_parallel_size=2,
+            cp_kv_cache_interleave_size=4,
+        ),
+        speculative_config=SimpleNamespace(method="dflash"),
+    )
+
+    check_attention_cp_compatibility(config)
+
+
+def test_spec_decode_interleave_rejection_is_not_mtp_specific(monkeypatch) -> None:
+    impl = SimpleNamespace(
+        supports_spec_decoding_with_cp_non_trivial_interleave_size=False,
+        supports_mtp_with_cp_non_trivial_interleave_size=False,
+        need_to_return_lse_for_decode=True,
+    )
+    monkeypatch.setattr(
+        cp_utils,
+        "get_layers_from_vllm_config",
+        lambda *_: {"layer": SimpleNamespace(impl=impl)},
+    )
+    config = SimpleNamespace(
+        parallel_config=SimpleNamespace(
+            prefill_context_parallel_size=1,
+            decode_context_parallel_size=2,
+            cp_kv_cache_interleave_size=4,
+        ),
+        speculative_config=SimpleNamespace(method="dflash"),
+    )
+
+    with pytest.raises(AssertionError, match="Speculative decoding"):
+        check_attention_cp_compatibility(config)
 
 
 def test_skip_gate_only_for_zero_context():

--- a/tests/v1/worker/test_cp_utils.py
+++ b/tests/v1/worker/test_cp_utils.py
@@ -65,6 +65,41 @@ def test_spec_decode_interleave_rejection_is_not_mtp_specific(monkeypatch) -> No
         check_attention_cp_compatibility(config)
 
 
+def test_replicated_kv_group_executes_attention_as_dcp1(monkeypatch) -> None:
+    impl = SimpleNamespace(
+        dcp_world_size=4,
+        dcp_rank=3,
+        total_cp_world_size=4,
+        total_cp_rank=3,
+        need_to_return_lse_for_decode=True,
+    )
+    layer = SimpleNamespace(
+        impl=impl,
+        get_kv_cache_spec=lambda _config: SimpleNamespace(dcp_replicated=True),
+    )
+    monkeypatch.setattr(
+        cp_utils,
+        "get_layers_from_vllm_config",
+        lambda *_: {"draft.layer": layer},
+    )
+    config = SimpleNamespace(
+        parallel_config=SimpleNamespace(
+            prefill_context_parallel_size=1,
+            decode_context_parallel_size=4,
+            cp_kv_cache_interleave_size=1,
+        ),
+        speculative_config=SimpleNamespace(method="dflash"),
+    )
+
+    check_attention_cp_compatibility(config)
+
+    assert impl.dcp_world_size == 1
+    assert impl.dcp_rank == 0
+    assert impl.total_cp_world_size == 1
+    assert impl.total_cp_rank == 0
+    assert impl.need_to_return_lse_for_decode is False
+
+
 def test_skip_gate_only_for_zero_context():
     assert should_skip_dcp_context_attention(torch.zeros(3, dtype=torch.int32))
     assert not should_skip_dcp_context_attention(

--- a/tests/v1/worker/test_gpu_block_table.py
+++ b/tests/v1/worker/test_gpu_block_table.py
@@ -176,6 +176,62 @@ def test_dcp_slot_mapping_with_smaller_kernel_blocks(cp_rank: int):
     assert torch.equal(actual, expected)
 
 
+def test_dcp_slot_mapping_supports_replicated_and_sharded_groups():
+    device = torch.device("cuda")
+    block_tables = BlockTables(
+        block_sizes=[16, 16],
+        max_num_reqs=1,
+        max_num_batched_tokens=128,
+        max_num_blocks_per_group=[2, 2],
+        device=device,
+        kernel_block_sizes=[16, 16],
+        cp_size=4,
+        cp_rank=2,
+        cp_interleave=16,
+        group_cp_sizes=[4, 1],
+    )
+    block_tables.append_block_ids(
+        req_index=0,
+        new_block_ids=([5, 9], [20, 21]),
+        overwrite=True,
+    )
+    block_tables.apply_staged_writes()
+
+    idx_mapping = torch.zeros(1, dtype=torch.int32, device=device)
+    query_start_loc = torch.tensor([0, 128], dtype=torch.int32, device=device)
+    positions = torch.arange(128, dtype=torch.int64, device=device)
+    sharded, replicated = block_tables.compute_slot_mappings(
+        idx_mapping,
+        query_start_loc,
+        positions,
+        num_tokens_padded=128,
+    )
+
+    expected_sharded = torch.full((128,), -1, dtype=torch.int64, device=device)
+    expected_sharded[32:48] = torch.arange(
+        5 * 16, 6 * 16, dtype=torch.int64, device=device
+    )
+    expected_sharded[96:112] = torch.arange(
+        9 * 16, 10 * 16, dtype=torch.int64, device=device
+    )
+    expected_replicated = torch.full((128,), -1, dtype=torch.int64, device=device)
+    expected_replicated[:32] = torch.arange(
+        20 * 16, 22 * 16, dtype=torch.int64, device=device
+    )
+
+    assert torch.equal(sharded, expected_sharded)
+    assert torch.equal(replicated, expected_replicated)
+
+    # CuMem sleep/wake invalidates tensors allocated under the KV-cache pool.
+    # Layout reinitialization must restore the per-group topology values.
+    block_tables.group_cp_sizes.zero_()
+    block_tables.init_block_table_layout_tensors()
+    assert torch.equal(
+        block_tables.group_cp_sizes,
+        torch.tensor([4, 1], dtype=torch.int32, device=device),
+    )
+
+
 def test_v1_block_table_move_row_clears_vacated_row():
     """condense() moves the last row into a freed slot; the vacated row must
     not keep stale block ids. Padded dummy-run batches dereference stale rows

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -488,8 +488,11 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             self.attn_backend, kv_cache_dtype
         )
         if normalized_kv_cache_dtype != kv_cache_dtype:
-            if cache_config is not None:
-                cache_config.cache_dtype = normalized_kv_cache_dtype
+            # The canonical format is a property of this MLA layer/backend,
+            # not of the process-wide cache configuration. Mutating the
+            # shared config contaminates non-MLA draft layers loaded later
+            # (for example, a DFlash draft would incorrectly request the
+            # target's fp8_ds_mla layout from generic FlashInfer attention).
             kv_cache_dtype = normalized_kv_cache_dtype
             logger.info_once(
                 "Using %s KV cache format for %s backend.",
@@ -2211,7 +2214,7 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
             self.determine_chunked_prefill_workspace_size(vllm_config)
         )
 
-        use_packed_fp8_cache = vllm_config.cache_config.cache_dtype == "fp8_ds_mla"
+        use_packed_fp8_cache = self.kv_cache_spec.cache_dtype_str == "fp8_ds_mla"
         self.dcp_manager: MLADCPManager | None = None
         if self.dcp_world_size > 1:
             # Note(hc): The local kvcache is incomplete when DCP is triggered,

--- a/vllm/model_executor/models/qwen3_dflash.py
+++ b/vllm/model_executor/models/qwen3_dflash.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import dataclasses
 import io
 from collections.abc import Iterable
 
@@ -35,6 +36,11 @@ from vllm.multimodal.inputs import NestedTensors
 from vllm.transformers_utils.config import set_default_rope_theta
 from vllm.transformers_utils.repo_utils import get_hf_file_bytes
 from vllm.v1.attention.backend import AttentionType
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheSpec,
+    SlidingWindowSpec,
+)
 from vllm.v1.worker.gpu.spec_decode.eagle.eagle3_utils import (
     get_eagle3_aux_layers_from_config,
 )
@@ -169,6 +175,27 @@ def _resolve_layer_attention(
     return sliding_window, _dflash_layer_causal(config, layer_idx)
 
 
+class DFlashAttention(Attention):
+    """Attention with DFlash-specific KV allocation semantics.
+
+    DFlash draft attention has no cross-rank reduction for sequence-sharded
+    KV. Under DCP, each rank therefore stores the complete draft KV sequence
+    and executes the draft attention as a local DCP1 operation. Sliding-window
+    drafts stay window bounded so replication does not allocate full-context
+    draft KV.
+    """
+
+    def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec | None:
+        dcp_replicated = vllm_config.parallel_config.decode_context_parallel_size > 1
+        spec = super().get_kv_cache_spec(vllm_config)
+        # Preserve the parent layer's backend-specific cache geometry. In
+        # particular, sliding-window attention chooses its own kernel-sized
+        # block independently of the target model's --block-size.
+        if dcp_replicated and isinstance(spec, (FullAttentionSpec, SlidingWindowSpec)):
+            spec = dataclasses.replace(spec, dcp_replicated=True)
+        return spec
+
+
 class DFlashQwen3Attention(nn.Module):
     """Attention for DFlash speculative decoding.
 
@@ -244,7 +271,7 @@ class DFlashQwen3Attention(nn.Module):
         )
 
         self.sliding_window = sliding_window
-        self.attn = Attention(
+        self.attn = DFlashAttention(
             self.num_heads,
             self.head_dim,
             self.scaling,

--- a/vllm/v1/attention/backend.py
+++ b/vllm/v1/attention/backend.py
@@ -807,8 +807,11 @@ class AttentionImplBase(ABC, Generic[T]):
     supports_pcp: bool = False
     # Whether the attention impl supports Decode Context Parallelism.
     supports_dcp: bool = True
-    # Whether the attention impl(or ops) supports MTP
-    # when cp_kv_cache_interleave_size > 1
+    # Whether the attention implementation supports speculative decoding when
+    # cp_kv_cache_interleave_size > 1.
+    supports_spec_decoding_with_cp_non_trivial_interleave_size: bool = False
+    # Backward-compatible spelling for out-of-tree backends. This originally
+    # guarded every speculative method despite referring specifically to MTP.
     supports_mtp_with_cp_non_trivial_interleave_size: bool = False
 
     # some attention backends might not always want to return lse

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -409,15 +409,21 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
         self.max_num_splits = 0  # No upper bound on the number of splits.
         self.aot_schedule = get_flash_attn_version() == 3
 
-        try:
-            from vllm.distributed.parallel_state import get_dcp_group
-
-            self.dcp_world_size = get_dcp_group().world_size
-            self.dcp_rank = get_dcp_group().rank_in_group
-        except AssertionError:
-            # DCP might not be initialized in testing
+        if getattr(kv_cache_spec, "dcp_replicated", False):
+            # A replicated KV group is complete on every rank and must use
+            # ordinary local attention metadata rather than DCP partitioning.
             self.dcp_world_size = 1
             self.dcp_rank = 0
+        else:
+            try:
+                from vllm.distributed.parallel_state import get_dcp_group
+
+                self.dcp_world_size = get_dcp_group().world_size
+                self.dcp_rank = get_dcp_group().rank_in_group
+            except AssertionError:
+                # DCP might not be initialized in testing
+                self.dcp_world_size = 1
+                self.dcp_rank = 0
 
         # Fused draft decode reuses the captured metadata object across draft
         # steps. For DCP, build-time host-side decisions such as

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -763,17 +763,25 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                     self._decode_cudagraph_max_bs,
                     self.compilation_config.max_cudagraph_capture_size,
                 )
-        try:
-            self.dcp_world_size = get_dcp_group().world_size
-            self.dcp_rank = get_dcp_group().rank_in_group
-            self.dcp_kv_cache_interleave_size = (
-                vllm_config.parallel_config.dcp_kv_cache_interleave_size
-            )
-        except AssertionError:
-            # DCP might not be initialized in testing
+        if getattr(kv_cache_spec, "dcp_replicated", False):
+            # Every rank owns the complete KV sequence for this group. Build
+            # ordinary local attention metadata instead of partitioning it a
+            # second time through the global DCP topology.
             self.dcp_world_size = 1
             self.dcp_rank = 0
             self.dcp_kv_cache_interleave_size = 1
+        else:
+            try:
+                self.dcp_world_size = get_dcp_group().world_size
+                self.dcp_rank = get_dcp_group().rank_in_group
+                self.dcp_kv_cache_interleave_size = (
+                    vllm_config.parallel_config.dcp_kv_cache_interleave_size
+                )
+            except AssertionError:
+                # DCP might not be initialized in testing
+                self.dcp_world_size = 1
+                self.dcp_rank = 0
+                self.dcp_kv_cache_interleave_size = 1
         self.use_dcp = self.dcp_world_size > 1
         self.dcp_a2a = (
             self.use_dcp and vllm_config.parallel_config.dcp_comm_backend == "a2a"

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -312,6 +312,7 @@ class BatchDCPPrefillWrapper:
         kv_cache_dtype: torch.dtype,
         prefill_fixed_split_size: int,
         disable_split_kv: bool,
+        causal: bool,
     ):
         """Plan the prefill operation with given parameters."""
         self._context.plan(
@@ -339,7 +340,7 @@ class BatchDCPPrefillWrapper:
             num_kv_heads=num_kv_heads,
             head_dim_qk=head_dim,
             head_dim_vo=head_dim,
-            causal=True,  # This is newtokens run
+            causal=causal,
             sm_scale=sm_scale,
             window_left=window_left,
             logits_soft_cap=logits_soft_cap,
@@ -389,6 +390,34 @@ class BatchDCPPrefillWrapper:
             lse_query,
         )
         return out
+
+
+def _get_dcp_local_kv_page_metadata(
+    seq_lens_cpu: torch.Tensor,
+    dcp_world_size: int,
+    dcp_rank: int,
+    dcp_kv_cache_interleave_size: int,
+    page_size: int,
+) -> tuple[torch.Tensor, np.ndarray, np.ndarray]:
+    """Return rank-local KV lengths and FlashInfer page geometry.
+
+    A DCP cache page holds ``page_size`` tokens from one rank, while one
+    scheduler block spans ``page_size * dcp_world_size`` global tokens.  The
+    native FlashInfer wrapper consumes rank-local pages, so deriving its page
+    counts or last-page lengths from global sequence lengths makes it read
+    later pages that do not belong to the rank.  This is especially damaging
+    for multi-token speculative queries, whose draft attention then reads
+    unrelated cache contents.
+    """
+    local_seq_lens_cpu = get_dcp_local_seq_lens(
+        seq_lens_cpu,
+        dcp_world_size,
+        dcp_rank,
+        dcp_kv_cache_interleave_size,
+    )
+    local_seq_lens_np = local_seq_lens_cpu.numpy()
+    local_num_blocks_np = (local_seq_lens_np + (page_size - 1)) // page_size
+    return local_seq_lens_cpu, local_seq_lens_np, local_num_blocks_np
 
 
 class FlashInferBackend(AttentionBackend):
@@ -1126,11 +1155,16 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         self,
         causal: bool = True,
     ) -> BatchPrefillWithPagedKVCacheWrapper | BatchDCPPrefillWrapper:
-        if not causal:
-            if self.use_dcp:
-                raise NotImplementedError(
-                    "FlashInfer non-causal prefill is not supported with DCP yet."
+        if self.use_dcp:
+            if self._prefill_wrapper is None:
+                self._prefill_wrapper = BatchDCPPrefillWrapper(
+                    kv_layout=get_flashinfer_layout_string(self.kv_cache_layout),
+                    workspace_buffer=self._get_workspace_buffer(),
+                    dcp_a2a=self.dcp_a2a,
                 )
+            return self._prefill_wrapper
+
+        if not causal:
             if self.is_kvcache_nvfp4:
                 raise NotImplementedError(
                     "FlashInfer non-causal attention is not supported with "
@@ -1161,34 +1195,27 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             return self._noncausal_prefill_wrapper
 
         if self._prefill_wrapper is None:
-            if self.use_dcp:
-                self._prefill_wrapper = BatchDCPPrefillWrapper(
-                    kv_layout=get_flashinfer_layout_string(self.kv_cache_layout),
-                    workspace_buffer=self._get_workspace_buffer(),
-                    dcp_a2a=self.dcp_a2a,
+            if self.has_sinks and current_platform.is_device_capability_family(120):
+                assert not self.is_kvcache_nvfp4
+                self._prefill_wrapper = BatchAttentionWithAttentionSinkWrapper(
+                    self._get_workspace_buffer(),
+                    get_flashinfer_layout_string(self.kv_cache_layout),
+                    backend="auto",
+                    q_data_type=self.q_data_type_prefill,
+                    kv_data_type=self.kv_cache_dtype,
+                    head_dim_qk=self.head_dim,
+                    head_dim_vo=self.head_dim,
+                    window_left=self.window_left,
                 )
             else:
-                if self.has_sinks and current_platform.is_device_capability_family(120):
-                    assert not self.is_kvcache_nvfp4
-                    self._prefill_wrapper = BatchAttentionWithAttentionSinkWrapper(
-                        self._get_workspace_buffer(),
-                        get_flashinfer_layout_string(self.kv_cache_layout),
-                        backend="auto",
-                        q_data_type=self.q_data_type_prefill,
-                        kv_data_type=self.kv_cache_dtype,
-                        head_dim_qk=self.head_dim,
-                        head_dim_vo=self.head_dim,
-                        window_left=self.window_left,
-                    )
-                else:
-                    # NVFP4 KV cache requires the trtllm-gen backend inside
-                    # the wrapper; fa2/fa3 do not support nvfp4.
-                    backend = "trtllm-gen" if self.is_kvcache_nvfp4 else "auto"
-                    self._prefill_wrapper = BatchPrefillWithPagedKVCacheWrapper(
-                        self._get_workspace_buffer(),
-                        get_flashinfer_layout_string(self.kv_cache_layout),
-                        backend=backend,
-                    )
+                # NVFP4 KV cache requires the trtllm-gen backend inside
+                # the wrapper; fa2/fa3 do not support nvfp4.
+                backend = "trtllm-gen" if self.is_kvcache_nvfp4 else "auto"
+                self._prefill_wrapper = BatchPrefillWithPagedKVCacheWrapper(
+                    self._get_workspace_buffer(),
+                    get_flashinfer_layout_string(self.kv_cache_layout),
+                    backend=backend,
+                )
         assert self._prefill_wrapper is not None
         return self._prefill_wrapper
 
@@ -1356,10 +1383,6 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             causal or self.use_dedicated_xqa
         )
 
-        if not causal and self.use_dcp:
-            raise NotImplementedError(
-                "FlashInfer non-causal prefill is not supported with DCP yet."
-            )
         if not causal and self.use_trtllm_decode_attention:
             logger.warning_once(
                 "Using FlashInfer for draft model non-causal attention; TRTLLM "
@@ -1431,6 +1454,9 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         # Adjust seq_lens_cpu for DCP
         if self.use_dcp:
             assert seq_lens_cpu is not None
+            # Do not modify CommonAttentionMetadata's shared host buffer when
+            # stripping this builder's current query tokens.
+            seq_lens_cpu = seq_lens_cpu.clone()
             if num_prefills > 0:
                 qo_indptr_prefill_cpu = (
                     qo_indptr_cpu[num_decodes:] - qo_indptr_cpu[num_decodes]
@@ -1442,11 +1468,12 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                     seq_lens_cpu[num_decodes:] - query_lens_prefill_cpu
                 )
 
-            seq_lens_cpu = get_dcp_local_seq_lens(
+            seq_lens_cpu, seq_lens_np, num_blocks_np = _get_dcp_local_kv_page_metadata(
                 seq_lens_cpu,
                 self.dcp_world_size,
                 self.dcp_rank,
                 self.dcp_kv_cache_interleave_size,
+                page_size,
             )
 
         # Adjust num_block_np for cascade attention
@@ -1606,6 +1633,7 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                         kv_cache_dtype=self.kv_cache_dtype,
                         prefill_fixed_split_size=self.prefill_fixed_split_size,
                         disable_split_kv=self.disable_split_kv,
+                        causal=attn_metadata.causal,
                     )
                 else:
                     assert isinstance(
@@ -1750,6 +1778,7 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
 
 class FlashInferImpl(AttentionImpl):
     can_return_lse_for_decode: bool = True
+    supports_spec_decoding_with_cp_non_trivial_interleave_size: bool = True
 
     def __init__(
         self,
@@ -2119,7 +2148,7 @@ class FlashInferImpl(AttentionImpl):
                         self.logits_soft_cap or 0.0
                     )
                     assert prefill_wrapper._new_tokens._sm_scale == self.scale
-                    assert prefill_wrapper._new_tokens._causal
+                    assert prefill_wrapper._new_tokens._causal == attn_metadata.causal
 
                     prefill_wrapper.run(
                         layer,

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -606,7 +606,9 @@ class B12xMLASparseImpl(SparseMLACommonImpl[B12xMLASparseMetadata]):
         vllm_config = get_current_vllm_config()
         hf_config = vllm_config.model_config.hf_text_config
         self._is_glm_next = _is_glm_next_config(hf_config)
-        self.supports_mtp_with_cp_non_trivial_interleave_size = self._is_glm_next
+        self.supports_spec_decoding_with_cp_non_trivial_interleave_size = (
+            self._is_glm_next
+        )
         if self._is_glm_next:
             if recipe_error := _glm_next_recipe_error(hf_config):
                 raise ValueError(recipe_error)

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -847,7 +847,9 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                     drop_eagle_block=drop_eagle_block,
                     alignment_tokens=self._cache_hit_alignment_tokens,
                     dcp_world_size=(
-                        self.dcp_world_size
+                        1
+                        if getattr(spec, "dcp_replicated", False)
+                        else self.dcp_world_size
                         if isinstance(spec, (FullAttentionSpec, SlidingWindowSpec))
                         else 1
                     ),
@@ -916,7 +918,9 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                 drop_eagle_block=use_eagle,
                 alignment_tokens=self._cache_hit_alignment_tokens,
                 dcp_world_size=(
-                    self.dcp_world_size
+                    1
+                    if getattr(spec, "dcp_replicated", False)
+                    else self.dcp_world_size
                     if isinstance(spec, (FullAttentionSpec, SlidingWindowSpec))
                     else 1
                 ),

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -610,13 +610,16 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
         )
         assert pcp_world_size == 1, "PCP not support hybrid attn now."
         if dcp_world_size > 1:
-            # DCP shards full-attention KV across ranks and replicates Mamba
-            # state; other spec types (e.g. sliding window) have no DCP-aware
-            # handling yet, so reject them explicitly.
+            # DCP shards full- and sliding-window attention KV across ranks and
+            # replicates Mamba state. Other spec types still lack DCP-aware
+            # cache-hit and retention geometry, so reject them explicitly.
             for g in kv_cache_config.kv_cache_groups:
-                assert isinstance(g.kv_cache_spec, (FullAttentionSpec, MambaSpec)), (
+                assert isinstance(
+                    g.kv_cache_spec,
+                    (FullAttentionSpec, SlidingWindowSpec, MambaSpec),
+                ), (
                     "DCP with hybrid KV cache layouts only supports "
-                    "full-attention and Mamba groups, got: "
+                    "full-attention, sliding-window, and Mamba groups, got: "
                     f"{type(g.kv_cache_spec).__name__}."
                 )
         # Fine-grained hash hits require Mamba "align" and compatible cache
@@ -845,7 +848,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                     alignment_tokens=self._cache_hit_alignment_tokens,
                     dcp_world_size=(
                         self.dcp_world_size
-                        if isinstance(spec, FullAttentionSpec)
+                        if isinstance(spec, (FullAttentionSpec, SlidingWindowSpec))
                         else 1
                     ),
                 )
@@ -912,6 +915,11 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                 kv_cache_spec=spec,
                 drop_eagle_block=use_eagle,
                 alignment_tokens=self._cache_hit_alignment_tokens,
+                dcp_world_size=(
+                    self.dcp_world_size
+                    if isinstance(spec, (FullAttentionSpec, SlidingWindowSpec))
+                    else 1
+                ),
             )
             for gid, blks in zip(group_ids, blocks):
                 hit_blocks[gid] = blks

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -655,9 +655,10 @@ def resolve_kv_cache_block_sizes(
 
     - ``scheduler_block_size`` is the token-alignment invariant used by the
       scheduler (e.g. for ``num_computed_tokens`` rounding). Single group:
-      ``cache_config.block_size * dcp``. Multiple groups: LCM of every
-      group's effective block size. Attention groups are scaled by DCP;
-      Mamba groups keep their full per-rank state and are not scaled.
+      ``cache_config.block_size`` scaled by DCP unless the group is replicated.
+      Multiple groups: LCM of every group's effective block size. Sharded
+      attention groups are scaled by DCP; Mamba and replicated attention
+      groups keep their full per-rank state and are not scaled.
     - ``hash_block_size`` is the granularity at which ``Request.block_hashes``
       is computed. Single group: equals scheduler block size. Multiple groups:
       ``cache_config.prefix_match_unit`` override if set, else the GCD of
@@ -670,12 +671,16 @@ def resolve_kv_cache_block_sizes(
     groups = kv_cache_config.kv_cache_groups
 
     if len(groups) <= 1:
-        bs = cache_config.block_size * dcp
+        replicated = len(groups) == 1 and getattr(
+            groups[0].kv_cache_spec, "dcp_replicated", False
+        )
+        bs = cache_config.block_size * (1 if replicated else dcp)
         return bs, bs
 
     group_block_sizes = [
         g.kv_cache_spec.block_size * dcp
         if isinstance(g.kv_cache_spec, AttentionSpec)
+        and not getattr(g.kv_cache_spec, "dcp_replicated", False)
         else g.kv_cache_spec.block_size
         for g in groups
     ]

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -75,7 +75,7 @@ class SingleTypeKVCacheManager(ABC):
         self.block_size = kv_cache_spec.block_size
         self.dcp_world_size = dcp_world_size
         self.pcp_world_size = pcp_world_size
-        if dcp_world_size > 1:
+        if dcp_world_size > 1 and not getattr(kv_cache_spec, "dcp_replicated", False):
             self.block_size *= dcp_world_size
         self.kv_cache_spec = kv_cache_spec
         self.block_pool = block_pool
@@ -702,7 +702,7 @@ class FullAttentionManager(SingleTypeKVCacheManager):
             "and chunked local attention groups"
         )
         block_size = kv_cache_spec.block_size
-        if dcp_world_size > 1:
+        if dcp_world_size > 1 and not getattr(kv_cache_spec, "dcp_replicated", False):
             # DCP shards each block's KV across ranks; hashes must be viewed at
             # the sharded block size.
             block_size *= dcp_world_size
@@ -919,7 +919,9 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
         )
         assert dcp_world_size >= 1
         assert pcp_world_size == 1, "PCP not support sliding window attn now."
-        block_size = kv_cache_spec.block_size * dcp_world_size
+        block_size = kv_cache_spec.block_size * (
+            1 if kv_cache_spec.dcp_replicated else dcp_world_size
+        )
         # Fine-grained partial hits are not supported for sliding window now
         assert alignment_tokens % block_size == 0, (
             "SlidingWindowManager does not support fine-grained (partial) cache hits"
@@ -1906,7 +1908,11 @@ def get_manager_for_kv_cache_spec(
         kv_cache_spec,
         (SlidingWindowSpec, ChunkedLocalAttentionSpec),
     ):
-        kv_shard_count = int(kwargs.get("dcp_world_size", 1))
+        kv_shard_count = (
+            1
+            if getattr(kv_cache_spec, "dcp_replicated", False)
+            else int(kwargs.get("dcp_world_size", 1))
+        )
         kwargs["max_admission_blocks_per_request"] = (
             kv_cache_spec.max_admission_blocks_per_request(
                 max_in_flight_tokens=max_in_flight_tokens,

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -460,6 +460,7 @@ class SingleTypeKVCacheManager(ABC):
             use_eagle=self.use_eagle,
             retention_interval=retention_interval,
             reachable_boundaries=reachable_boundaries,
+            effective_block_size=self.block_size,
         )
         self.block_pool.cache_full_blocks(
             request=request,
@@ -483,6 +484,7 @@ class SingleTypeKVCacheManager(ABC):
         use_eagle: bool,
         retention_interval: int | None = None,
         reachable_boundaries: Sequence[int] = (),
+        effective_block_size: int | None = None,
     ) -> list[bool] | None:
         """Per-block mask for ``cache_full_blocks``. ``None`` means cache
         every (non-null) block — the default for full attention.
@@ -915,23 +917,24 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
         assert isinstance(kv_cache_spec, SlidingWindowSpec), (
             "SlidingWindowManager can only be used for sliding window groups"
         )
-        assert dcp_world_size == 1, "DCP not support sliding window attn now."
+        assert dcp_world_size >= 1
         assert pcp_world_size == 1, "PCP not support sliding window attn now."
+        block_size = kv_cache_spec.block_size * dcp_world_size
         # Fine-grained partial hits are not supported for sliding window now
-        assert alignment_tokens % kv_cache_spec.block_size == 0, (
+        assert alignment_tokens % block_size == 0, (
             "SlidingWindowManager does not support fine-grained (partial) cache hits"
         )
         block_hashes = resolve_block_hashes(
             block_hashes,
             block_pool.hash_block_size,
-            kv_cache_spec.block_size,
+            block_size,
             supports_fine_grained_hash_lookup=cls.supports_fine_grained_hash_lookup,
             alignment_tokens=alignment_tokens,
         )
 
         # The number of contiguous blocks needed for a prefix cache hit.
         sliding_window_contiguous_blocks = cls._contiguous_blocks_for_hit(
-            kv_cache_spec.sliding_window, kv_cache_spec.block_size, drop_eagle_block
+            kv_cache_spec.sliding_window, block_size, drop_eagle_block
         )
 
         # TODO: reduce i by sliding_window_contiguous_blocks when cache miss, to
@@ -939,12 +942,11 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
         # O(max_num_blocks / sliding_window_contiguous_blocks +
         # sliding_window_contiguous_blocks),
         # which is good for low cache hit rate scenarios.
-        max_num_blocks = max_length // kv_cache_spec.block_size
+        max_num_blocks = max_length // block_size
         computed_blocks: tuple[list[KVCacheBlock], ...] = tuple(
             [block_pool.null_block] * max_num_blocks
             for _ in range(len(kv_cache_group_ids))
         )
-        block_size = kv_cache_spec.block_size
         num_contiguous_blocks = 0
         match_found = False
         # Search from right to left and early stop when a match is found.
@@ -1008,14 +1010,14 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
         use_eagle: bool,
         retention_interval: int | None = None,
         reachable_boundaries: Sequence[int] = (),
+        effective_block_size: int | None = None,
     ) -> list[bool] | None:
         assert isinstance(kv_cache_spec, SlidingWindowSpec)
         if alignment_tokens is None:
             # Fast path: when the coordinator imposes no alignment constraint.
             return None
-        assert alignment_tokens % kv_cache_spec.block_size == 0
-
-        block_size = kv_cache_spec.block_size
+        block_size = effective_block_size or kv_cache_spec.block_size
+        assert alignment_tokens % block_size == 0
         # Contiguous blocks a hit needs at a boundary (incl. the EAGLE peek).
         need = cls._contiguous_blocks_for_hit(
             window_size=kv_cache_spec.sliding_window,
@@ -1383,6 +1385,7 @@ class MambaManager(SingleTypeKVCacheManager):
         use_eagle: bool,
         retention_interval: int | None = None,
         reachable_boundaries: Sequence[int] = (),
+        effective_block_size: int | None = None,
     ) -> list[bool] | None:
         """Sparse Mamba state-snapshot retention.
 
@@ -1400,7 +1403,7 @@ class MambaManager(SingleTypeKVCacheManager):
             # Dense caching (default) or no alignment constraint imposed.
             return None
         assert isinstance(kv_cache_spec, MambaSpec)
-        block_size = kv_cache_spec.block_size
+        block_size = effective_block_size or kv_cache_spec.block_size
         mask = [False] * (end_block - start_block)
 
         # (1) Segment-boundary states. A Mamba hit needs exactly the single
@@ -1903,10 +1906,12 @@ def get_manager_for_kv_cache_spec(
         kv_cache_spec,
         (SlidingWindowSpec, ChunkedLocalAttentionSpec),
     ):
+        kv_shard_count = int(kwargs.get("dcp_world_size", 1))
         kwargs["max_admission_blocks_per_request"] = (
             kv_cache_spec.max_admission_blocks_per_request(
                 max_in_flight_tokens=max_in_flight_tokens,
                 max_model_len=max_model_len,
+                kv_shard_count=kv_shard_count,
             )
         )
     manager = manager_class(kv_cache_spec, **kwargs)

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -665,7 +665,10 @@ class ChunkedLocalAttentionSpec(AttentionSpec):
     attention_chunk_size: int
 
     def max_admission_blocks_per_request(
-        self, max_in_flight_tokens: int, max_model_len: int
+        self,
+        max_in_flight_tokens: int,
+        max_model_len: int,
+        kv_shard_count: int = 1,
     ) -> int:
         """Per-request admission cap, in blocks.
 
@@ -681,12 +684,15 @@ class ChunkedLocalAttentionSpec(AttentionSpec):
         num_tokens = min(
             self.attention_chunk_size + max_in_flight_tokens, max_model_len
         )
-        return cdiv(num_tokens, self.block_size)
+        return cdiv(num_tokens, self.block_size * kv_shard_count)
 
     def max_memory_usage_bytes(self, vllm_config: VllmConfig) -> int:
         max_blocks = self.max_admission_blocks_per_request(
             max_in_flight_tokens=vllm_config.max_in_flight_tokens,
             max_model_len=vllm_config.model_config.max_model_len,
+            kv_shard_count=(
+                vllm_config.parallel_config.decode_context_parallel_size
+            ),
         )
         return max_blocks * self.page_size_bytes
 
@@ -711,7 +717,10 @@ class SlidingWindowSpec(AttentionSpec):
     extra_retained_tokens: int = 0
 
     def max_admission_blocks_per_request(
-        self, max_in_flight_tokens: int, max_model_len: int
+        self,
+        max_in_flight_tokens: int,
+        max_model_len: int,
+        kv_shard_count: int = 1,
     ) -> int:
         """Per-request admission cap, in blocks.
 
@@ -736,15 +745,15 @@ class SlidingWindowSpec(AttentionSpec):
         # +1 because the sliding window may not start from the beginning of
         # the block. E.g. block size 4 and num_token 4 needs two blocks
         # [XXCD][EF] to store the 6-token window [CDEF].
-        return cdiv(num_tokens, self.block_size) + 1
+        return cdiv(num_tokens, self.block_size * kv_shard_count) + 1
 
     def max_memory_usage_bytes(self, vllm_config: VllmConfig) -> int:
-        assert vllm_config.parallel_config.decode_context_parallel_size == 1, (
-            "DCP not support sliding window."
-        )
         max_blocks = self.max_admission_blocks_per_request(
             max_in_flight_tokens=vllm_config.max_in_flight_tokens,
             max_model_len=vllm_config.model_config.max_model_len,
+            kv_shard_count=(
+                vllm_config.parallel_config.decode_context_parallel_size
+            ),
         )
         return max_blocks * self.page_size_bytes
 

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -228,8 +228,11 @@ class KVCacheSpec:
             f"Unsupported KV cache spec type: {type(self)}. "
             "Please register it using @register_kv_cache_spec decorator."
         )
+        replicated = getattr(self, "dcp_replicated", False)
         return all(
-            isinstance(spec, uniform_type_base_spec) for spec in kv_cache_specs.values()
+            isinstance(spec, uniform_type_base_spec)
+            and getattr(spec, "dcp_replicated", False) == replicated
+            for spec in kv_cache_specs.values()
         )
 
 
@@ -428,7 +431,11 @@ class AttentionSpec(KVCacheSpec):
 
     def max_num_blocks_per_req(self, vllm_config: VllmConfig, max_len: int) -> int:
         parallel_config = vllm_config.parallel_config
-        kv_shard_count = parallel_config.decode_context_parallel_size
+        kv_shard_count = (
+            1
+            if getattr(self, "dcp_replicated", False)
+            else parallel_config.decode_context_parallel_size
+        )
         return cdiv(max_len, self.block_size * kv_shard_count)
 
 
@@ -450,18 +457,25 @@ class FullAttentionSpec(AttentionSpec):
     attention_chunk_size: int | None = None
 
     non_causal: bool = False
+    """Whether the layer attends non-causally (e.g. Prefix LM).
+
+    Carried on the spec so the engine core, which collects specs from all
+    workers before the scheduler is built, can adjust scheduling policy
+    (chunked prefill / prefix caching) regardless of tensor-parallel layout.
+    It does not affect the KV cache layout itself.
     """
-    Whether the layer attends non-causally (e.g. Prefix LM). Carried on the
-    spec so the engine core, which collects specs from all workers before the
-    scheduler is built, can adjust scheduling policy (chunked prefill / prefix
-    caching) regardless of tensor-parallel layout. It does not affect the KV
-    cache layout itself.
+
+    dcp_replicated: bool = False
+    """Whether every DCP rank stores the complete KV sequence.
+
+    This is used by external draft models whose TP-local attention should
+    remain a DCP1 operation while the target model shards its cache with DCP.
     """
 
     def max_memory_usage_bytes(self, vllm_config: VllmConfig) -> int:
         max_model_len = vllm_config.model_config.max_model_len
         dcp_world_size = vllm_config.parallel_config.decode_context_parallel_size
-        if dcp_world_size > 1:
+        if dcp_world_size > 1 and not self.dcp_replicated:
             max_model_len = cdiv(max_model_len, dcp_world_size)
         return cdiv(max_model_len, self.block_size) * self.page_size_bytes
 
@@ -498,6 +512,11 @@ class FullAttentionSpec(AttentionSpec):
         assert not any(isinstance(spec, MLAAttentionSpec) for spec in specs), (
             "MLAAttentionSpec should be merged in MLAAttentionSpec.merge"
         )
+        replicated = {spec.dcp_replicated for spec in specs}
+        assert len(replicated) == 1, (
+            "All attention layers in the same KV cache group must use the "
+            "same DCP replication mode."
+        )
         merged_spec = cls(
             block_size=specs[0].block_size,
             num_kv_heads=specs[0].num_kv_heads,
@@ -514,6 +533,7 @@ class FullAttentionSpec(AttentionSpec):
             # If any layer in the group is non-causal, treat the group as
             # non-causal so the engine core disables incompatible scheduling.
             non_causal=any(spec.non_causal for spec in specs),
+            dcp_replicated=replicated.pop(),
         )
         for spec in specs:
             for f in fields(AttentionSpec):
@@ -690,9 +710,7 @@ class ChunkedLocalAttentionSpec(AttentionSpec):
         max_blocks = self.max_admission_blocks_per_request(
             max_in_flight_tokens=vllm_config.max_in_flight_tokens,
             max_model_len=vllm_config.model_config.max_model_len,
-            kv_shard_count=(
-                vllm_config.parallel_config.decode_context_parallel_size
-            ),
+            kv_shard_count=(vllm_config.parallel_config.decode_context_parallel_size),
         )
         return max_blocks * self.page_size_bytes
 
@@ -709,6 +727,8 @@ class ChunkedLocalAttentionSpec(AttentionSpec):
 @dataclass(frozen=True, kw_only=True)
 class SlidingWindowSpec(AttentionSpec):
     sliding_window: int
+    dcp_replicated: bool = False
+    """Whether every DCP rank stores this complete window-bounded cache."""
     # The trailing edge of the window is extended by ``extra_retained_tokens``
     # so that those extra trailing tokens' blocks are retained (but not
     # attended). This is needed for multi-module spec decoding which can
@@ -752,7 +772,9 @@ class SlidingWindowSpec(AttentionSpec):
             max_in_flight_tokens=vllm_config.max_in_flight_tokens,
             max_model_len=vllm_config.model_config.max_model_len,
             kv_shard_count=(
-                vllm_config.parallel_config.decode_context_parallel_size
+                1
+                if self.dcp_replicated
+                else vllm_config.parallel_config.decode_context_parallel_size
             ),
         )
         return max_blocks * self.page_size_bytes
@@ -763,6 +785,7 @@ class SlidingWindowSpec(AttentionSpec):
         return all(
             isinstance(spec, SlidingWindowSpec)
             and spec.sliding_window == self.sliding_window
+            and spec.dcp_replicated == self.dcp_replicated
             for spec in kv_cache_specs.values()
         )
 
@@ -797,16 +820,18 @@ class SlidingWindowMLASpec(SlidingWindowSpec):
         model_version_set = set(spec.model_version for spec in specs)
         sliding_window_set = set(spec.sliding_window for spec in specs)
         extra_retained_set = set(spec.extra_retained_tokens for spec in specs)
+        dcp_replicated_set = set(spec.dcp_replicated for spec in specs)
         assert (
             len(cache_dtype_str_set) == 1
             and len(tokens_per_state_set) == 1
             and len(model_version_set) == 1
             and len(sliding_window_set) == 1
             and len(extra_retained_set) == 1
+            and len(dcp_replicated_set) == 1
         ), (
             "All attention layers in the same KV cache group must use the same "
             "quantization method, tokens per state, model version, sliding "
-            "window size, and retained token count."
+            "window size, retained token count, and DCP replication mode."
         )
         return cls(
             block_size=specs[0].block_size,
@@ -818,6 +843,7 @@ class SlidingWindowMLASpec(SlidingWindowSpec):
             state_content_bytes=specs[0].state_content_bytes,
             sliding_window=sliding_window_set.pop(),
             extra_retained_tokens=extra_retained_set.pop(),
+            dcp_replicated=dcp_replicated_set.pop(),
             cache_dtype_str=cache_dtype_str_set.pop(),
             tokens_per_state=tokens_per_state_set.pop(),
             model_version=model_version_set.pop(),
@@ -829,6 +855,7 @@ class SlidingWindowMLASpec(SlidingWindowSpec):
         return all(
             isinstance(spec, SlidingWindowMLASpec)
             and spec.sliding_window == self.sliding_window
+            and spec.dcp_replicated == self.dcp_replicated
             for spec in kv_cache_specs.values()
         )
 
@@ -958,6 +985,7 @@ class SinkFullAttentionSpec(FullAttentionSpec):
             sliding_window=cls.merge_window_sizes(sliding_window),
             attention_chunk_size=cls.merge_window_sizes(attention_chunk_size),
             non_causal=any(spec.non_causal for spec in specs),
+            dcp_replicated=specs[0].dcp_replicated,
         )
         for spec in specs:
             for f in fields(AttentionSpec):
@@ -988,6 +1016,13 @@ class UniformTypeKVCacheSpecs(KVCacheSpec):
     @property
     def page_size_bytes(self) -> int:
         return sum(spec.page_size_bytes for spec in self.kv_cache_specs.values())
+
+    @property
+    def dcp_replicated(self) -> bool:
+        return all(
+            getattr(spec, "dcp_replicated", False)
+            for spec in self.kv_cache_specs.values()
+        )
 
     def max_memory_usage_bytes(self, vllm_config: VllmConfig) -> int:
         max_num_pages = max(

--- a/vllm/v1/worker/cp_utils.py
+++ b/vllm/v1/worker/cp_utils.py
@@ -38,8 +38,17 @@ def check_attention_cp_compatibility(vllm_config: VllmConfig) -> None:
             if layer_impl is None:
                 continue
             if vllm_config.speculative_config is not None and interleave_size > 1:
-                assert layer_impl.supports_mtp_with_cp_non_trivial_interleave_size, (
-                    "MTP with cp_kv_cache_interleave_size > 1 is not "
+                supports_spec_decode = getattr(
+                    layer_impl,
+                    "supports_spec_decoding_with_cp_non_trivial_interleave_size",
+                    False,
+                ) or getattr(
+                    layer_impl,
+                    "supports_mtp_with_cp_non_trivial_interleave_size",
+                    False,
+                )
+                assert supports_spec_decode, (
+                    "Speculative decoding with cp_kv_cache_interleave_size > 1 is not "
                     f"supported in {layer_impl.__class__.__name__}."
                 )
             if dcp_size > 1:

--- a/vllm/v1/worker/cp_utils.py
+++ b/vllm/v1/worker/cp_utils.py
@@ -37,6 +37,18 @@ def check_attention_cp_compatibility(vllm_config: VllmConfig) -> None:
             layer_impl = getattr(layer, "impl", None)
             if layer_impl is None:
                 continue
+            get_spec = getattr(layer, "get_kv_cache_spec", None)
+            spec = get_spec(vllm_config) if get_spec is not None else None
+            if getattr(spec, "dcp_replicated", False):
+                # This group already contains the full sequence on every rank.
+                # Execute it as local DCP1 attention; another DCP partition and
+                # LSE reduction would duplicate/perturb the replicated cache.
+                layer_impl.dcp_world_size = 1
+                layer_impl.dcp_rank = 0
+                layer_impl.total_cp_world_size = 1
+                layer_impl.total_cp_rank = 0
+                layer_impl.need_to_return_lse_for_decode = False
+                continue
             if vllm_config.speculative_config is not None and interleave_size > 1:
                 supports_spec_decode = getattr(
                     layer_impl,

--- a/vllm/v1/worker/gpu/block_table.py
+++ b/vllm/v1/worker/gpu/block_table.py
@@ -26,6 +26,7 @@ class BlockTables:
         cp_size: int = 1,
         cp_rank: int = 0,
         cp_interleave: int = 1,
+        group_cp_sizes: list[int] | None = None,
     ):
         self.block_sizes = block_sizes
         self.kernel_block_sizes = kernel_block_sizes
@@ -36,6 +37,10 @@ class BlockTables:
         self.cp_size = cp_size
         self.cp_rank = cp_rank
         self.cp_interleave = cp_interleave
+        if group_cp_sizes is None:
+            group_cp_sizes = [cp_size] * len(block_sizes)
+        assert len(group_cp_sizes) == len(block_sizes)
+        self.group_cp_sizes_list = list(group_cp_sizes)
 
         self.num_kv_cache_groups = len(self.block_sizes)
         assert len(max_num_blocks_per_group) == self.num_kv_cache_groups
@@ -104,6 +109,9 @@ class BlockTables:
         )
         self.kernel_block_sizes_tensor = torch.tensor(
             self.kernel_block_sizes, dtype=torch.int32, device=self.device
+        )
+        self.group_cp_sizes = torch.tensor(
+            self.group_cp_sizes_list, dtype=torch.int32, device=self.device
         )
         self.input_block_table_ptrs = self._make_ptr_tensor(self.input_block_tables)
 
@@ -205,8 +213,11 @@ class BlockTables:
             positions,
             self.block_table_ptrs,
             self.block_table_strides,
+            self.num_blocks.gpu,
+            self.num_blocks.gpu.stride(0),
             self.block_sizes_tensor,
             self.kernel_block_sizes_tensor,
+            self.group_cp_sizes,
             slot_mappings,
             slot_mappings.stride(0),
             self.cp_rank,
@@ -268,6 +279,12 @@ def _gather_block_tables_kernel(
         block_ids = tl.load(src_row_ptr + offset, mask=offset < num_blocks)
         tl.store(dst_row_ptr + offset, block_ids, mask=offset < num_blocks)
 
+    # A recycled/windowed group can shrink its active row. Clear the old tail
+    # so metadata consumers cannot observe stale block IDs.
+    for i in tl.range(num_blocks, max_num_blocks, BLOCK_SIZE):
+        offset = i + tl.arange(0, BLOCK_SIZE)
+        tl.store(dst_row_ptr + offset, 0, mask=offset < max_num_blocks)
+
 
 @triton.jit
 def _compute_slot_mappings_kernel(
@@ -277,8 +294,11 @@ def _compute_slot_mappings_kernel(
     pos,  # [num_tokens]
     block_table_ptrs,  # [num_kv_cache_groups]
     block_table_strides,  # [num_kv_cache_groups]
+    num_blocks_ptr,  # [num_kv_cache_groups, max_num_reqs]
+    num_blocks_stride,
     block_sizes,  # [num_kv_cache_groups]
     kernel_block_sizes,  # [num_kv_cache_groups]
+    group_cp_sizes,  # [num_kv_cache_groups]
     slot_mappings_ptr,  # [num_kv_cache_groups, max_num_tokens]
     slot_mappings_stride,
     cp_rank,
@@ -305,10 +325,13 @@ def _compute_slot_mappings_kernel(
 
     block_table_ptr = _load_ptr(block_table_ptrs + group_id, tl.int32)
     block_table_stride = tl.load(block_table_strides + group_id)
+    group_num_blocks_ptr = num_blocks_ptr + group_id * num_blocks_stride
     kv_block_size = tl.load(block_sizes + group_id)
     kernel_block_size = tl.load(kernel_block_sizes + group_id)
+    group_cp_size = tl.load(group_cp_sizes + group_id)
 
     req_state_idx = tl.load(idx_mapping + batch_idx)
+    num_blocks = tl.load(group_num_blocks_ptr + req_state_idx)
     start_idx = tl.load(query_start_loc + batch_idx)
     end_idx = tl.load(query_start_loc + batch_idx + 1)
     for i in range(start_idx, end_idx, TRITON_BLOCK_SIZE):
@@ -321,24 +344,28 @@ def _compute_slot_mappings_kernel(
             is_local = True
         else:
             # Context parallelism is used.
-            virtual_block_size = kv_block_size * CP_SIZE
+            virtual_block_size = kv_block_size * group_cp_size
             virtual_block_indices = positions // virtual_block_size
             virtual_block_offsets = positions % virtual_block_size
-            is_local = virtual_block_offsets // CP_INTERLEAVE % CP_SIZE == cp_rank
-            rounds = virtual_block_offsets // (CP_INTERLEAVE * CP_SIZE)
+            group_cp_rank = cp_rank % group_cp_size
+            is_local = (
+                virtual_block_offsets // CP_INTERLEAVE % group_cp_size == group_cp_rank
+            )
+            rounds = virtual_block_offsets // (CP_INTERLEAVE * group_cp_size)
             remainder = virtual_block_offsets % CP_INTERLEAVE
             local_offsets = rounds * CP_INTERLEAVE + remainder
             local_positions = virtual_block_indices * kv_block_size + local_offsets
 
         block_indices = local_positions // kernel_block_size
         block_offsets = local_positions % kernel_block_size
+        valid_block = is_local & (block_indices < num_blocks)
         block_numbers = tl.load(
             block_table_ptr + req_state_idx * block_table_stride + block_indices,
-            mask=is_local,
+            mask=valid_block,
             other=0,
         )
         slot_ids = block_numbers * kernel_block_size + block_offsets
         if CP_SIZE != 1:
-            slot_ids = tl.where(is_local, slot_ids, PAD_ID)
+            slot_ids = tl.where(valid_block, slot_ids, PAD_ID)
 
         tl.store(slot_mapping_ptr + offset, slot_ids, mask=offset < end_idx)

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -541,9 +541,13 @@ class GPUModelRunner(LoRAModelRunnerMixin):
 
         block_sizes = []
         max_num_blocks_per_group = []
+        group_cp_sizes = []
         for kv_cache_group in kv_cache_config.kv_cache_groups:
             spec = kv_cache_group.kv_cache_spec
             block_sizes.append(spec.block_size)
+            group_cp_sizes.append(
+                1 if getattr(spec, "dcp_replicated", False) else self.dcp_size
+            )
             # Let each cache type account for CP. Attention KV is DCP-sharded,
             # while Mamba/GDN recurrent state is replicated across DCP ranks.
             max_num_blocks = spec.max_num_blocks_per_req(
@@ -558,6 +562,15 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             else:
                 max_num_blocks = get_block_table_width(max_num_blocks, spec.block_size)
             max_num_blocks_per_group.append(max_num_blocks)
+
+        if any(cp_size != self.dcp_size for cp_size in group_cp_sizes):
+            logger.info_once(
+                "KV cache group CP geometry: configured_cp=%d, "
+                "effective_group_cp=%s, block_sizes=%s",
+                self.dcp_size,
+                tuple(group_cp_sizes),
+                tuple(block_sizes),
+            )
 
         target_attn_layer_names = None
         if isinstance(self.speculator, DraftModelSpeculator):
@@ -601,6 +614,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             cp_size=self.dcp_size,
             cp_rank=self.dcp_rank,
             cp_interleave=self.cp_interleave,
+            group_cp_sizes=group_cp_sizes,
         )
         self.pcp_manager = pcp.maybe_build_pcp_manager(
             self.vllm_config,

--- a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
@@ -400,6 +400,8 @@ class DFlashSpeculator(DraftModelSpeculator):
         assert self.draft_kv_cache_group_id >= 0
         # Support multiple draft KV cache groups by preparing inputs once for each
         for i, gid in enumerate(self.draft_kv_cache_group_ids):
+            group_cp_size = self.block_tables.group_cp_sizes_list[gid]
+            group_cp_rank = self.block_tables.cp_rank % group_cp_size
             prepare_dflash_inputs(
                 self.input_buffers,
                 self.block_tables.slot_mappings[gid],
@@ -419,8 +421,8 @@ class DFlashSpeculator(DraftModelSpeculator):
                 seeds,
                 self.block_tables.input_block_tables[gid],
                 self.block_tables.kernel_block_sizes[gid],
-                self.block_tables.cp_rank,
-                self.block_tables.cp_size,
+                group_cp_rank,
+                group_cp_size,
                 self.block_tables.cp_interleave,
                 self.parallel_drafting_token_id,
                 self.num_query_per_req,


### PR DESCRIPTION
## Summary

Make external DFlash2 draft attention correct under decode context parallelism.

The target model continues to sequence-shard its KV cache across DCP ranks. DFlash draft layers instead keep a complete, window-bounded draft sequence on every rank and execute draft attention with effective DCP1 geometry. This is required because DFlash owns TP-local KV heads and has no cross-rank attention/LSE reduction that could reconstruct a sequence-sharded proposal distribution.

The prior sequence-sharded implementation served valid text, but materially changed the draft distribution: matched-corpus token acceptance fell from the DCP1 control's 35.31% to 26.65% under DCP4. The exact-head replicated implementation restores acceptance to 35.30%.

## Changes

- retain the original DFlash/DCP capability, dtype-isolation, non-causal FlashInfer, slot-mapping, and recycling-capacity fixes;
- add an explicit `dcp_replicated` property to full and sliding-window attention specs and keep replicated and sharded layers in separate cache groups;
- preserve the parent attention layer's backend-selected sliding-window block geometry rather than replacing it with the target model block size;
- use effective DCP1 geometry for replicated-group memory sizing, scheduler/hash alignment, cache lookup/admission, and per-request table width;
- carry per-group CP sizes through GPU block tables and DFlash input preparation while target groups retain configured DCP4 geometry;
- build FlashInfer/FlashAttention metadata for replicated groups as local rank-0/DCP1 attention and suppress cross-rank LSE reduction for those layers;
- bounds-check slot mappings against each live group row and clear stale gathered-table tails across reuse; and
- add focused coverage for spec tagging, DCP1 behavior, backend-native sliding-window blocks, mixed scheduler/table geometry, group separation, CP mutation, and sharded/replicated slot mapping.

## Why replicated draft pages are safe

Each DCP rank holds the complete token sequence for its own TP-local draft KV heads. The draft attention kernel therefore sees the same sequence geometry it sees at DCP1, while the existing TP execution still owns head partitioning and downstream collectives. The scheduler and block manager treat draft pages as an opaque replicated group; target KV pages remain sequence-sharded. No cross-rank KV gather or draft LSE reconstruction is required.

## Validation

Base: `local-inference-lab/vllm:dev/jovian-judgement` at `766acf0e218a075432e6c45755cd561ab765ec2d`.

Validated commit: `e5e7bf99182833c6ce25042c29252bbb4107539c`.

Exact-head local validation image ID: `sha256:b8c7e789613d6beed5ced80f89d665bf2b0330e1d4335c7d9852cc52aa98ef37`. This image was built from an archive of validated commit `e5e7bf99182833c6ce25042c29252bbb4107539c`; it was not published as a community image.

Runtime configuration:

- GLM-5.3-Flash NVFP4 target, FP8 KV cache;
- DFlash2 external draft, seven speculative tokens;
- TP4, DCP4, interleave 4;
- BLHNC layout, 131,072 maximum model length, 16 maximum sequences;
- resolved group geometry: ten target groups at effective CP4 / 2,304-token blocks and the DFlash group at effective CP1 / 16-token blocks;
- 31.16 GiB KV allocation, 834,314-token pool, reported 6.37x concurrency at 131,072 tokens; and
- LMCache intentionally omitted from this focused DFlash/DCP proof.

Test evidence:

- final focused replicated-DCP suite: `5 passed` against the corrected embedded image source;
- attention CP suite: `9 passed`;
- GPU block-table focused suite: `5 passed, 4 deselected`;
- earlier current-Jovian focused suite: `12 passed, 1 skipped`;
- `git diff --check`: passed; and
- full `pre-commit run --files` across all 14 changed source/test files: passed, including Ruff check/format, mypy, typos, SPDX, forbidden imports, CUDA API checks, and configuration validation.

Runtime evidence:

- service health: HTTP 200;
- exact-head matched corpus: 8/8 valid responses and 2,048 completion tokens;
- exact-head replicated DCP4: 1,458 / 4,130 accepted draft tokens = **35.30%**; position 0: 453 / 590 = **76.78%**;
- exact-head vision request: correctly transcribed the deterministic test image as `Hello, AI world!`;
- exact-head long-window correctness: 2/2 valid 128-token completions at 25,125 and 25,126 prompt tokens, well beyond the draft's 2,048-token sliding window;
- prior identical-code DCP1 control: 1,461 / 4,137 = **35.31%**; position 0: 466 / 591 = **78.85%**; and
- rejected sequence-sharded DCP4 control: 1,332 / 4,998 = **26.65%**; position 0 approximately **61.1%**.

## Known limitations / separate integrations

- The production LMCache configuration is not part of this focused proof. Its 2,304-token manager-page integration with multi-layer DFlash under the BLHNC layout is being validated separately and should not be conflated with DFlash/DCP correctness.
- DFlash2 reports that it does not consume target-model external multimodal embeddings, so multimodal requests use text-only draft inputs while the target model remains authoritative.
- E2E performance has not yet been qualified. FlashInfer's existing speculative-shape limitation runs DFlash draft attention eagerly, which may reduce decode throughput; target prefill is not directly affected by this graph fallback. This PR does not change CUDA-graph selection.
