### PR TITLE
fix(cudagraph): retain profiling resources through teardown

### DIFF
--- a/tests/v1/cudagraph/test_breakable_cudagraph.py
+++ b/tests/v1/cudagraph/test_breakable_cudagraph.py
@@ -82,6 +82,8 @@ def test_breakable_wrapper_retains_capture_resources(monkeypatch):
     import vllm.compilation.breakable_cudagraph as breakable
     from vllm.v1.worker.workspace import retain_cuda_graph_capture_resource
 
+    lifecycle: list[str] = []
+
     class FakeCapture:
         def __init__(self, pool):
             self.pool = pool
@@ -102,13 +104,21 @@ def test_breakable_wrapper_retains_capture_resources(monkeypatch):
     resource = object()
 
     def runnable():
+        lifecycle.append("capture")
         assert retain_cuda_graph_capture_resource(resource)
         return object()
 
     monkeypatch.setattr(breakable, "validate_cudagraph_capturing_enabled", lambda: None)
     monkeypatch.setattr(breakable, "set_graph_pool_id", lambda _pool: None)
-    monkeypatch.setattr(breakable.gc, "collect", lambda: None)
-    monkeypatch.setattr(torch.accelerator, "empty_cache", lambda: None)
+    monkeypatch.setattr(
+        torch.accelerator,
+        "synchronize",
+        lambda: lifecycle.append("synchronize"),
+    )
+    monkeypatch.setattr(breakable.gc, "collect", lambda: lifecycle.append("collect"))
+    monkeypatch.setattr(
+        torch.accelerator, "empty_cache", lambda: lifecycle.append("empty-cache")
+    )
     monkeypatch.setattr(breakable, "get_offloader", lambda: FakeOffloader())
     monkeypatch.setattr(breakable, "BreakableCUDAGraphCapture", FakeCapture)
     monkeypatch.setattr(breakable, "weak_ref_tensors", lambda value: value)
@@ -121,6 +131,7 @@ def test_breakable_wrapper_retains_capture_resources(monkeypatch):
     wrapper._capture(entry, (), {})
 
     assert entry.resources == [resource]
+    assert lifecycle == ["synchronize", "collect", "empty-cache", "capture"]
 
 
 @pytest.fixture(autouse=True)

--- a/tests/v1/cudagraph/test_cudagraph_manager.py
+++ b/tests/v1/cudagraph/test_cudagraph_manager.py
@@ -47,6 +47,44 @@ def _create_vllm_config() -> MagicMock:
     return vllm_config
 
 
+@pytest.mark.parametrize("requires_raw_tokens", [False, True])
+def test_capture_token_inputs_match_runtime_embedding_contract(requires_raw_tokens):
+    """Prepared embeddings replace token IDs unless the model needs both."""
+
+    class Model:
+        requires_raw_input_tokens = requires_raw_tokens
+
+    input_ids = torch.arange(4, dtype=torch.int32)
+    inputs_embeds = torch.zeros((4, 8), dtype=torch.bfloat16)
+    model_inputs = {
+        "input_ids": input_ids,
+        "positions": torch.arange(4),
+        "inputs_embeds": inputs_embeds,
+    }
+
+    gpu_cudagraph_utils.normalize_model_token_inputs(Model(), model_inputs)
+
+    if requires_raw_tokens:
+        assert model_inputs["input_ids"] is input_ids
+    else:
+        assert model_inputs["input_ids"] is None
+    assert model_inputs["inputs_embeds"] is inputs_embeds
+
+
+def test_capture_token_inputs_keep_ids_without_embeddings():
+    """Text-only token input remains present when no embeddings are supplied."""
+    input_ids = torch.arange(4, dtype=torch.int32)
+    model_inputs = {
+        "input_ids": input_ids,
+        "positions": torch.arange(4),
+        "inputs_embeds": None,
+    }
+
+    gpu_cudagraph_utils.normalize_model_token_inputs(object(), model_inputs)
+
+    assert model_inputs["input_ids"] is input_ids
+
+
 def test_full_capture_sets_graph_pool_id_before_cuda_graph(monkeypatch):
     """FULL capture must set graph_pool_id before entering torch.cuda.graph().
 

--- a/tests/v1/worker/test_gpu_model_runner_v2_cudagraph_profiling.py
+++ b/tests/v1/worker/test_gpu_model_runner_v2_cudagraph_profiling.py
@@ -51,10 +51,31 @@ class _FakeCudaGraphManager(cgu.CudaGraphManager):
         self._capture_mem_samples: list[int] | None = None
         self.use_breakable_cg = False
         self.graphs: dict[Any, Any] = {}
+        self.graph_capture_resources: dict[Any, list[Any]] = {}
         self._graphs_captured = False
 
     def needs_capture(self) -> bool:
         return self._needs_capture
+
+
+class _RecordingGraph:
+    def __init__(self, lifecycle: list[str], name: str) -> None:
+        self.lifecycle = lifecycle
+        self.name = name
+
+    def reset(self) -> None:
+        self.lifecycle.append(f"reset-{self.name}")
+
+
+class _RecordingDict(dict[Any, Any]):
+    def __init__(self, lifecycle: list[str], name: str) -> None:
+        super().__init__()
+        self.lifecycle = lifecycle
+        self.name = name
+
+    def clear(self) -> None:
+        self.lifecycle.append(f"clear-{self.name}")
+        super().clear()
 
 
 def _make_profiling_runner(
@@ -108,6 +129,7 @@ def _patch_module(monkeypatch) -> None:
     # The profiler reads free GPU memory before/after to compute what it
     # retained; default to a constant (nothing retained).
     monkeypatch.setattr(cgu.torch.accelerator, "empty_cache", lambda: None)
+    monkeypatch.setattr(cgu.torch.accelerator, "synchronize", lambda: None)
     monkeypatch.setattr(
         cgu.torch.accelerator, "get_memory_info", lambda: (1 << 30, 1 << 30)
     )
@@ -282,23 +304,86 @@ def test_profile_cudagraph_memory_clears_captured_graphs(monkeypatch):
     _patch_module(monkeypatch)
     runner = _make_profiling_runner(CUDAGraphMode.FULL_AND_PIECEWISE)
 
-    cleared: list[str] = []
+    lifecycle: list[str] = []
+    monkeypatch.setattr(
+        cgu.torch.accelerator,
+        "synchronize",
+        lambda: lifecycle.append("synchronize"),
+    )
+    monkeypatch.setattr(
+        cgu.CUDAGraphWrapper,
+        "reset_all_graphs",
+        classmethod(lambda cls: lifecycle.append("reset-piecewise")),
+    )
+    monkeypatch.setattr(
+        cgu.BreakableCUDAGraphWrapper,
+        "reset_all_graphs",
+        classmethod(lambda cls: lifecycle.append("reset-breakable")),
+    )
     monkeypatch.setattr(
         cgu.CUDAGraphWrapper,
         "clear_all_graphs",
-        classmethod(lambda cls: cleared.append("piecewise")),
+        classmethod(lambda cls: lifecycle.append("clear-piecewise")),
     )
     monkeypatch.setattr(
         cgu.BreakableCUDAGraphWrapper,
         "clear_all_graphs",
-        classmethod(lambda cls: cleared.append("breakable")),
+        classmethod(lambda cls: lifecycle.append("clear-breakable")),
     )
+    runner.cudagraph_manager.graphs = _RecordingDict(lifecycle, "full")
+    runner.cudagraph_manager.graphs["profile"] = _RecordingGraph(lifecycle, "full")
+    runner.cudagraph_manager.graph_capture_resources = _RecordingDict(
+        lifecycle, "resources"
+    )
+    runner.cudagraph_manager.graph_capture_resources["profile"] = [object()]
 
     cgu.profile_cudagraph_memory(runner)
 
-    # Profiling captures are discarded so the real capture re-captures them
-    # against the KV cache.
-    assert cleared == ["piecewise", "breakable"]
+    # CUDA graph executables must be destroyed and synchronized before their
+    # B12X channel checkpoints and tensor workspaces are released.
+    assert lifecycle == [
+        "synchronize",
+        "reset-piecewise",
+        "reset-breakable",
+        "reset-full",
+        "synchronize",
+        "clear-piecewise",
+        "clear-breakable",
+        "clear-full",
+        "clear-resources",
+    ]
+
+
+def test_cuda_graph_wrappers_reset_executables_without_releasing_resources():
+    lifecycle: list[str] = []
+    piecewise = object.__new__(cgu.CUDAGraphWrapper)
+    piecewise_entry = SimpleNamespace(
+        cudagraph=_RecordingGraph(lifecycle, "piecewise"),
+        output=object(),
+    )
+    piecewise.concrete_cudagraph_entries = {"profile": piecewise_entry}
+
+    class _RecordingCapture:
+        def reset(self) -> None:
+            lifecycle.append("reset-breakable")
+
+    breakable = object.__new__(cgu.BreakableCUDAGraphWrapper)
+    breakable_entry = SimpleNamespace(
+        capture=_RecordingCapture(),
+        resources=[object()],
+    )
+    breakable.entries = {"profile": breakable_entry}
+
+    piecewise.reset_graphs()
+    breakable.reset_graphs()
+
+    assert lifecycle == ["reset-piecewise", "reset-breakable"]
+    assert piecewise_entry.cudagraph is None
+    assert piecewise_entry.output is not None
+    assert piecewise.concrete_cudagraph_entries == {"profile": piecewise_entry}
+    assert breakable_entry.capture is None
+    assert breakable_entry.resources
+    assert breakable.entries == {"profile": breakable_entry}
 
 
 def test_profile_cudagraph_memory_redirects_wrapper_pools(monkeypatch):
@@ -317,6 +402,9 @@ def test_profile_cudagraph_memory_redirects_wrapper_pools(monkeypatch):
             self.pool_during_capture: Any = None
 
         def clear_graphs(self) -> None:
+            pass
+
+        def reset_graphs(self) -> None:
             pass
 
     wrapper = _FakeWrapper()
@@ -349,6 +437,9 @@ def test_profile_cudagraph_memory_redirects_late_created_wrappers(monkeypatch):
             self.pool_during_capture: Any = None
 
         def clear_graphs(self) -> None:
+            pass
+
+        def reset_graphs(self) -> None:
             pass
 
     wrapper: _FakeWrapper | None = None
@@ -390,8 +481,9 @@ def test_profile_cudagraph_memory_redirects_speculator_managers(monkeypatch):
     def _capture_model() -> int:
         nonlocal pools_during_capture
         pools_during_capture = (prefill_manager.pool, decode_manager.pool)
-        prefill_manager.graphs["profile"] = object()
-        decode_manager.graphs["profile"] = object()
+        lifecycle: list[str] = []
+        prefill_manager.graphs["profile"] = _RecordingGraph(lifecycle, "prefill")
+        decode_manager.graphs["profile"] = _RecordingGraph(lifecycle, "decode")
         prefill_manager._graphs_captured = True
         decode_manager._graphs_captured = True
         return capture_model()
@@ -455,7 +547,7 @@ def test_v2_profiling_teardown_runs_cache_lifecycle_hooks(monkeypatch):
     assert runner.kv_caches == []
     assert runner.attn_groups == []
     assert runner.cudagraph_manager is None
-    assert runner.block_tables is None
+    assert not hasattr(runner, "block_tables")
     assert runner.pcp_manager is None
     assert runner.adaptive_verification is None
     assert not hasattr(runner, "kv_cache_config")

--- a/vllm/compilation/breakable_cudagraph.py
+++ b/vllm/compilation/breakable_cudagraph.py
@@ -151,6 +151,7 @@ class BreakableCUDAGraphCapture:
     def __init__(self, pool: Any | None = None) -> None:
         self.pool = pool
         self.segments: list[Callable[[], Any]] = []
+        self._graphs: list[torch.cuda.CUDAGraph] = []
         self._num_graphs: int = 0
         self._num_eager_breaks: int = 0
         self._current_graph: torch.cuda.CUDAGraph | None = None
@@ -188,6 +189,7 @@ class BreakableCUDAGraphCapture:
             return
         assert self._current_graph is not None
         self._current_graph.capture_end()
+        self._graphs.append(self._current_graph)
         self.segments.append(self._current_graph.replay)
         self._num_graphs += 1
         self._current_graph = None
@@ -213,6 +215,15 @@ class BreakableCUDAGraphCapture:
     def replay(self) -> None:
         for r in self.segments:
             r()
+
+    def reset(self) -> None:
+        """Destroy every graph segment after its pending work has completed."""
+        if self._capturing:
+            raise RuntimeError("Cannot reset an active breakable CUDA graph capture.")
+        for graph in self._graphs:
+            graph.reset()
+        self._graphs.clear()
+        self.segments.clear()
 
     # --- introspection ---------------------------------------------------
 
@@ -267,6 +278,12 @@ class BreakableCUDAGraphWrapper:
         for instance in list(cls._all_instances):
             instance.clear_graphs()
 
+    @classmethod
+    def reset_all_graphs(cls) -> None:
+        """Destroy graph segments without releasing entry-owned resources."""
+        for instance in list(cls._all_instances):
+            instance.reset_graphs()
+
     def __init__(
         self,
         runnable: Callable[..., Any],
@@ -306,6 +323,14 @@ class BreakableCUDAGraphWrapper:
 
     def clear_graphs(self) -> None:
         self.entries.clear()
+
+    def reset_graphs(self) -> None:
+        """Destroy graph segments while retaining their captured resources."""
+        for entry in self.entries.values():
+            capture = entry.capture
+            if capture is not None:
+                capture.reset()
+                entry.capture = None
 
     # --- dispatch --------------------------------------------------------
 
@@ -367,13 +392,16 @@ class BreakableCUDAGraphWrapper:
         else:
             set_graph_pool_id(current_platform.graph_pool_handle())
 
-        # Match torch.cuda.graph()'s pre-capture cleanup once per descriptor.
+        # Match torch.cuda.graph()'s pre-capture barrier and cleanup once per
+        # descriptor. The warmup immediately before this call may use shared
+        # communication scratch. Starting capture before that work completes
+        # lets the captured kernels race the warmup on the same storage.
         # We drive capture_begin/end directly and bypass torch.cuda.graph(),
-        # so its built-in gc + empty_cache never fire. Run them here once
-        # per _capture call -- NOT inside _begin_segment, since this capture
-        # session may issue many begin/end pairs (one per layer's break),
-        # and repeated gc would tank capture time the way it did for the
-        # pre-`gc_disable` piecewise path.
+        # so its synchronize + gc + empty_cache sequence never runs. Run it
+        # here once per _capture call -- NOT inside _begin_segment, since this
+        # capture session may issue many begin/end pairs (one per layer's
+        # break), and repeated cleanup would dominate capture time.
+        torch.accelerator.synchronize()
         gc.collect()
         torch.accelerator.empty_cache()
         # Sync the offloader's copy stream before capture so any in-flight

--- a/vllm/compilation/cuda_graph.py
+++ b/vllm/compilation/cuda_graph.py
@@ -175,6 +175,12 @@ class CUDAGraphWrapper:
         for instance in list(cls._all_instances):
             instance.clear_graphs()
 
+    @classmethod
+    def reset_all_graphs(cls) -> None:
+        """Destroy captured graph executables without releasing their entries."""
+        for instance in list(cls._all_instances):
+            instance.reset_graphs()
+
     def __init__(
         self,
         runnable: Callable[..., Any],
@@ -229,6 +235,14 @@ class CUDAGraphWrapper:
 
     def clear_graphs(self) -> None:
         self.concrete_cudagraph_entries.clear()
+
+    def reset_graphs(self) -> None:
+        """Destroy graph executables while retaining entry-owned tensors."""
+        for entry in self.concrete_cudagraph_entries.values():
+            graph = entry.cudagraph
+            if graph is not None:
+                graph.reset()
+                entry.cudagraph = None
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any | None:
         if not is_forward_context_available():

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -27,6 +27,7 @@ from vllm.distributed.parallel_state import (
 )
 from vllm.forward_context import BatchDescriptor, set_forward_context
 from vllm.logger import init_logger
+from vllm.model_executor.models.interfaces import requires_raw_input_tokens
 from vllm.model_executor.offloader.base import get_offloader
 from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
@@ -44,6 +45,23 @@ if TYPE_CHECKING:
     from vllm.v1.worker.gpu.model_runner import GPUModelRunner
 
 logger = init_logger(__name__)
+
+
+def normalize_model_token_inputs(
+    model: nn.Module,
+    model_inputs: dict[str, Any],
+) -> None:
+    """Keep token-input arguments identical between graph capture and replay.
+
+    Models that receive prepared embeddings normally omit ``input_ids``. Models
+    declaring ``requires_raw_input_tokens`` are the exception and receive both.
+    CUDA graph capture and ordinary execution must apply the same rule because
+    breakable graphs require an invariant set of tensor arguments and addresses.
+    """
+    if model_inputs.get("inputs_embeds") is not None and not (
+        requires_raw_input_tokens(model)
+    ):
+        model_inputs["input_ids"] = None
 
 
 class AttentionState(NamedTuple):
@@ -557,6 +575,7 @@ class ModelCudaGraphManager(CudaGraphManager):
                 "positions": input_buffers.positions[:num_tokens],
                 **model_state.prepare_dummy_inputs(num_reqs, num_tokens),
             }
+            normalize_model_token_inputs(model, model_inputs)
             if not self.is_first_pp_rank:
                 # Update for non-first PP ranks.
                 model_inputs["input_ids"] = None

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -357,6 +357,11 @@ class CudaGraphManager:
     def needs_capture(self) -> bool:
         return len(self._capture_descs) > 0
 
+    def reset_graphs(self) -> None:
+        """Destroy FULL graph executables while retaining captured resources."""
+        for graph in self.graphs.values():
+            graph.reset()
+
     @torch.inference_mode()
     def capture(
         self,
@@ -866,6 +871,18 @@ def profile_cudagraph_memory(runner: "GPUModelRunner") -> int:
     finally:
         compilation_counter.num_cudagraph_captured = saved_num_cudagraph_captured
         compilation_counter.num_gpu_runner_capture_triggers = saved_capture_triggers
+
+        # Graph reset can defer CUDA-side destruction. Keep graph entries and
+        # their Python-owned output/scratch tensors alive until every reset has
+        # completed; otherwise the allocator can reuse those addresses while
+        # the discarded profiling executable still references them.
+        torch.accelerator.synchronize()
+        CUDAGraphWrapper.reset_all_graphs()
+        BreakableCUDAGraphWrapper.reset_all_graphs()
+        for graph_manager in graph_managers:
+            graph_manager.reset_graphs()
+        torch.accelerator.synchronize()
+
         CUDAGraphWrapper.clear_all_graphs()
         BreakableCUDAGraphWrapper.clear_all_graphs()
         for graph_manager in graph_managers:
@@ -951,4 +968,5 @@ def _teardown_profiling_state(runner: "GPUModelRunner") -> None:
     runner.cache_config.num_gpu_blocks = None
     runner.maybe_remove_all_loras(runner.lora_config)
     gc.collect()
+    torch.accelerator.synchronize()
     torch.accelerator.empty_cache()

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -46,7 +46,6 @@ from vllm.model_executor.layers.mamba.ops.ssu_dispatch import (
     initialize_mamba_ssu_backend,
 )
 from vllm.model_executor.model_loader import get_model_loader
-from vllm.model_executor.models.interfaces import requires_raw_input_tokens
 from vllm.model_executor.offloader import (
     create_offloader,
     get_offloader,
@@ -93,6 +92,7 @@ from vllm.v1.worker.gpu.cp_utils import prepare_dcp_local_seq_lens
 from vllm.v1.worker.gpu.cudagraph_utils import (
     BatchExecutionDescriptor,
     ModelCudaGraphManager,
+    normalize_model_token_inputs,
 )
 from vllm.v1.worker.gpu.cudagraph_utils import (
     profile_cudagraph_memory as _profile_cudagraph_memory,
@@ -1670,9 +1670,6 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                     inputs_embeds = self.model_state.prepare_inputs_embeds(
                         scheduled_encoder_inputs, input_batch, self.req_states
                     )
-            if inputs_embeds is not None and not requires_raw_input_tokens(self.model):
-                input_ids = None
-
         model_inputs = {
             "input_ids": input_ids,
             "positions": input_batch.positions,
@@ -1682,6 +1679,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             # values above.
             **self.model_state.prepare_inputs(input_batch, self.req_states),
         }
+        normalize_model_token_inputs(self.model, model_inputs)
         if not self.is_first_pp_rank:
             # Update for non-first PP ranks.
             model_inputs["input_ids"] = None


### PR DESCRIPTION
## Purpose

Make CUDA-graph memory profiling preserve the tensor-address and resource
lifetime invariants required by FULL, PIECEWISE, and breakable graph capture.
Profiling graphs are temporary, but their executables may still reference
captured tensors and backend workspaces while teardown releases those objects.

## Resulting behavior

- Apply the same token-input normalization during capture and ordinary model
  execution. A model receiving prepared embeddings omits `input_ids` unless it
  declares that raw token IDs are required.
- Synchronize breakable capture with preceding warmup work before the first
  direct `capture_begin()` call.
- Retain graph entries and their Python-owned resources while resetting FULL,
  PIECEWISE, and breakable profiling graph executables.
- Synchronize graph destruction before releasing profiling KV storage and
  communication workspaces.

Production graph selection and steady-state dispatch are unchanged.

## Review-stack boundary

This pull request is based on #532 so the source-locked GLM-5.3 integration
has one linear review stack. Its diff contains only CUDA-graph input
normalization, profiling-graph resource lifetime, and associated tests; it
does not contain C4 indexer or GLM5Next cache behavior.

## Duplicate-work check

Searches for CUDA-graph profiling lifetime, workspace lifetime, and stable
capture inputs found no matching open pull request in
`local-inference-lab/vllm` or `vllm-project/vllm`.

Merged pull request #493 retains custom-operation resources owned by production
graphs. It does not reset temporary profiling graph executables before their
workspaces are released, and it does not enforce identical token-input
arguments between capture and replay. Pull request #511 changes graph-memory
measurement for small explicit FULL descriptor sets and is independent of
these lifetime invariants.

## Validation

- Targeted CUDA-graph tests: 35 passed.
- Ruff check, Ruff format check, and `git diff --check`: passed.
- Two GLM-5.3-Flash-NVFP4 TP4/DCP4 starts on physical GPUs 4, 5, 6, and 7
  completed profiling and production capture without
  `CUDA_LAUNCH_BLOCKING`.

## AI assistance disclosure

OpenAI Codex assisted with diagnosis, implementation, tests, runtime
qualification, and pull-request preparation. A human maintainer must review
every changed line and understand and defend the behavior before merge.
