### PR TITLE
fix(b12x): make profiling warmup lifetime-safe

### DIFF
--- a/tests/kernels/moe/test_b12x.py
+++ b/tests/kernels/moe/test_b12x.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Tests for the b12x tensor-parallel MoE integration."""
 
+import weakref
 from dataclasses import dataclass, replace
 from types import SimpleNamespace
 
@@ -738,6 +739,8 @@ def test_b12x_moe_warmup_runs_each_planner_regime_once(
     )
     planned_tokens = []
     launched_tokens = []
+    launched_resources = []
+    synchronized = []
 
     with pytest.raises(RuntimeError, match="process_weights_after_loading"):
         experts.warmup_launches(layer, token_counts=(1,))
@@ -764,16 +767,38 @@ def test_b12x_moe_warmup_runs_each_planner_regime_once(
 
     def fake_run(**kwargs):
         launched_tokens.append(kwargs["hidden_states"].shape[0])
+        launched_resources.append(
+            tuple(
+                weakref.ref(kwargs[name])
+                for name in (
+                    "hidden_states",
+                    "output",
+                    "topk_ids",
+                    "topk_weights",
+                    "scratch",
+                )
+            )
+        )
+
+    def fake_synchronize():
+        assert all(
+            resource() is not None
+            for launch in launched_resources
+            for resource in launch
+        )
+        synchronized.append(True)
 
     monkeypatch.setattr(b12x, "_b12x_moe_execution_plan", fake_execution_plan)
     monkeypatch.setattr(b12x, "_run_b12x_moe_plan", fake_run)
     monkeypatch.setattr(experts, "_plan", fake_plan)
+    monkeypatch.setattr(b12x.torch.accelerator, "synchronize", fake_synchronize)
 
     warmed = experts.warmup_launches(layer, token_counts=(1, 2, 3, 4, 8))
 
     assert warmed == 3
     assert planned_tokens == [1, 3, 8]
     assert launched_tokens == planned_tokens
+    assert synchronized == [True]
 
 
 def test_b12x_moe_reload_reprepares_current_parameters(

--- a/tests/v1/worker/test_gpu_worker.py
+++ b/tests/v1/worker/test_gpu_worker.py
@@ -1,13 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from contextlib import contextmanager
 from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
 
 from vllm.utils.mem_constants import GiB_bytes
-from vllm.v1.worker import startup_plan
+from vllm.v1.worker import gpu_worker, startup_plan
 from vllm.v1.worker.startup_plan import (
     maybe_apply_startup_plan,
     maybe_save_startup_plan,
@@ -77,3 +78,69 @@ def test_startup_plan_apply_gate(plan_env):
     explicit = _plan_worker(kv_bytes=7 * GiB_bytes)
     maybe_apply_startup_plan(explicit)
     assert explicit.cache_config.kv_cache_memory_bytes == 7 * GiB_bytes
+
+
+def test_b12x_warmup_precedes_cudagraph_memory_profile(monkeypatch):
+    """B12X launch modules must be resolved before descriptor capture begins."""
+    events = []
+
+    model_runner = SimpleNamespace(
+        model_memory_usage=0,
+        profile_run=lambda: events.append("profile_run"),
+        profile_cudagraph_memory=lambda: events.append("profile_cudagraph_memory") or 0,
+    )
+    profile_result = SimpleNamespace(
+        total_consumed=10,
+        transient_peak_headroom=5,
+        after_profile=SimpleNamespace(free_memory=80),
+        non_kv_cache_memory=10,
+    )
+
+    @contextmanager
+    def fake_memory_profiling(*args, **kwargs):
+        yield profile_result
+
+    worker = SimpleNamespace(
+        cache_config=SimpleNamespace(
+            kv_cache_memory_bytes=None,
+            gpu_memory_utilization=0.9,
+        ),
+        model_runner=model_runner,
+        init_snapshot=SimpleNamespace(free_memory=100, total_memory=100),
+        requested_memory=90,
+        model_config=SimpleNamespace(multimodal_config=None),
+        parallel_config=SimpleNamespace(),
+        vllm_config=SimpleNamespace(
+            compilation_config=SimpleNamespace(
+                cudagraph_mode=gpu_worker.CUDAGraphMode.PIECEWISE,
+                cudagraph_capture_sizes=[8, 4],
+            )
+        ),
+    )
+
+    monkeypatch.setattr(gpu_worker, "maybe_apply_startup_plan", lambda worker: None)
+    monkeypatch.setattr(gpu_worker, "memory_profiling", fake_memory_profiling)
+    monkeypatch.setattr(
+        gpu_worker,
+        "current_platform",
+        SimpleNamespace(is_cuda_alike=lambda: True),
+    )
+    monkeypatch.setattr(
+        gpu_worker,
+        "b12x_warmup",
+        lambda worker, sizes: events.append(("b12x_warmup", tuple(sizes))),
+    )
+    monkeypatch.setattr(
+        gpu_worker,
+        "reserve_mm_ipc_gpu_memory",
+        lambda requested, *args: requested,
+    )
+
+    available = gpu_worker.Worker.determine_available_memory(worker)
+
+    assert events == [
+        "profile_run",
+        ("b12x_warmup", (8, 4)),
+        "profile_cudagraph_memory",
+    ]
+    assert available == 80

--- a/vllm/model_executor/layers/fused_moe/b12x.py
+++ b/vllm/model_executor/layers/fused_moe/b12x.py
@@ -640,6 +640,7 @@ class B12xExperts(mk.FusedMoEExpertsModular):
             signature = (execution_plan.implementation, execution_plan.execution)
             launch_tokens.setdefault(signature, tokens)
 
+        launch_resources: list[tuple[torch.Tensor, ...]] = []
         for tokens in launch_tokens.values():
             hidden_states = torch.zeros(
                 (tokens, int(prepared.hidden_size)),
@@ -671,6 +672,13 @@ class B12xExperts(mk.FusedMoEExpertsModular):
                 dtype=torch.uint8,
                 device=device,
             )
+            # B12X warmup launches may outlive the Python call that submits
+            # them. Retain every caller-owned input, output, and scratch tensor
+            # until device completion so the allocator cannot reuse an address
+            # while a warmup kernel still references it.
+            launch_resources.append(
+                (hidden_states, output, topk_ids, topk_weights, scratch)
+            )
             _run_b12x_moe_plan(
                 plan=plan,
                 scratch=scratch,
@@ -681,6 +689,8 @@ class B12xExperts(mk.FusedMoEExpertsModular):
                 output=output,
                 unit_scale_contract=self._quant_mode == "w4a16",
             )
+        if launch_resources:
+            torch.accelerator.synchronize()
         return len(launch_tokens)
 
     def workspace_shapes(

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -52,6 +52,7 @@ from vllm.distributed.weight_transfer import (
 )
 from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
+from vllm.model_executor.warmup.b12x_warmup import b12x_warmup
 from vllm.model_executor.warmup.kernel_warmup import kernel_warmup
 from vllm.multimodal.gpu_ipc_memory import reserve_mm_ipc_gpu_memory
 from vllm.platforms import current_platform
@@ -535,6 +536,14 @@ class Worker(WorkerBase):
             current_platform.is_cuda_alike()
             and self.vllm_config.compilation_config.cudagraph_mode != CUDAGraphMode.NONE
         ):
+            # Resolve B12X launch modules before the graph-memory profiler
+            # enters its descriptor capture loop. A disk-cache miss can run
+            # CUDA module initialization on first use, which is not a valid
+            # operation to introduce between breakable graph descriptors.
+            capture_sizes = list(
+                self.vllm_config.compilation_config.cudagraph_capture_sizes or []
+            )
+            b12x_warmup(self, capture_sizes)
             cudagraph_memory_estimate = self.model_runner.profile_cudagraph_memory()
 
         # Respect the opt-in flag as originally designed.


### PR DESCRIPTION
## Purpose

Resolve B12X launch modules before CUDA-graph memory profiling and keep every
caller-owned MoE warmup tensor alive until its asynchronous device work has
completed. An empty B12X kernel cache can otherwise initialize CUDA modules
between graph descriptors or reuse a warmup allocation while a submitted
kernel still references it.

## Resulting behavior

- Run model-provided B12X warmup after the activation-memory profile and before
  CUDA-graph memory descriptors are captured.
- Retain MoE warmup input, output, routing, and scratch tensors through
  `torch.accelerator.synchronize()`.
- Keep serving kernel selection, execution plans, and steady-state inference
  unchanged. The added synchronization executes only during model startup.

## Review-stack boundary

This pull request is based on #515 because profiling teardown must preserve
backend resources until graph destruction completes. Its diff contains only
B12X pre-profile warmup ordering and MoE warmup allocation ownership. The
GLM5Next full-CKV implementation is intentionally excluded.

## Duplicate-work check

Searches for B12X MoE warmup buffers, CUDA-graph memory profiling warmup, and
asynchronous warmup lifetime found no matching open pull request in
`local-inference-lab/vllm` or `vllm-project/vllm`.

## Validation

- `tests/model_executor/test_b12x_warmup.py`: 14 passed.
- MoE warmup allocation-lifetime regression: 1 passed, 36 deselected.
- GPU-worker profiling-order tests: 3 passed.
- Ruff check, Ruff format check, and `git diff --check`: passed.
- GLM-5.3-Flash-NVFP4 TP4/DCP4 completed three starts with a populated kernel
  cache and one start with an empty kernel cache on physical GPUs 4, 5, 6, and
  7. Every start completed profiling and production graph capture without
  `CUDA_LAUNCH_BLOCKING`.
- A 32k prefill smoke request after the empty-cache start produced 11,962
  prompt tok/s and left the service healthy.

## AI assistance disclosure

OpenAI Codex assisted with diagnosis, implementation, tests, runtime
qualification, and pull-request preparation. A human maintainer must review
every changed line and understand and defend the behavior before merge.
