### PR TITLE
fix(dflash): isolate replicated draft cache groups

### DIFF
--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -2232,6 +2232,61 @@ def test_group_and_unify_kv_cache_specs_mixed_page_size_groups():
     assert layer_names == {"mla.0", "mla.1", "swa.0"}
 
 
+def test_group_dcp_replicated_dflash_draft():
+    target = new_mla_spec()
+    draft = SlidingWindowSpec(
+        block_size=16,
+        num_kv_heads=1,
+        head_size=64,
+        dtype=torch.float16,
+        sliding_window=2048,
+        dcp_replicated=True,
+    )
+    assert target.page_size_bytes != draft.page_size_bytes
+
+    specs = {"model.layers.0": target, "draft.layers.0": draft}
+    # DeepSeek-V4's UniformType tuple planner is not needed for DFlash.
+    assert group_and_unify_kv_cache_specs(specs) is None
+
+    groups = get_kv_cache_groups(_grouping_config(), specs)
+    draft_group = next(
+        group for group in groups if isinstance(group.kv_cache_spec, SlidingWindowSpec)
+    )
+    assert all(group.kv_cache_spec.block_size == 16 for group in groups)
+    assert draft_group.kv_cache_spec.dcp_replicated is True
+
+
+def test_group_dcp_replicated_dflash_draft_with_hybrid_target():
+    target_mla = new_mla_spec()
+    target_mamba = new_mamba_spec(page_size_padded=target_mla.page_size_bytes)
+    draft = SlidingWindowSpec(
+        block_size=256,
+        num_kv_heads=1,
+        head_size=64,
+        dtype=torch.float16,
+        sliding_window=2048,
+        dcp_replicated=True,
+    )
+    assert target_mla.page_size_bytes == target_mamba.page_size_bytes
+    assert draft.page_size_bytes % target_mla.page_size_bytes != 0
+
+    specs = {
+        "model.mla": target_mla,
+        "model.mamba": target_mamba,
+        "draft.attn": draft,
+    }
+    groups = get_kv_cache_groups(_grouping_config(), specs)
+
+    assert {name for group in groups for name in group.layer_names} == set(specs)
+    draft_group = next(group for group in groups if "draft.attn" in group.layer_names)
+    assert draft_group.kv_cache_spec == draft
+    target_groups = [group for group in groups if "draft.attn" not in group.layer_names]
+    assert all(
+        not getattr(group.kv_cache_spec, "dcp_replicated", False)
+        for group in target_groups
+    )
+
+
 def new_indexer_mla_spec(block_size=16):
     # Sparse-attention indexer k_cache: an MLAAttentionSpec with a much smaller
     # page size than the main MLA attention (uint8, small head), so their pages

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1600,6 +1600,37 @@ def group_and_unify_kv_cache_specs(
     return [mla_uniform_spec, *swa_uniform_specs]
 
 
+def group_dcp_replicated_draft_kv_cache_specs(
+    vllm_config: VllmConfig,
+    kv_cache_spec: dict[str, KVCacheSpec],
+) -> list[KVCacheGroupSpec] | None:
+    """Keep replicated speculative KV separate from a sharded target.
+
+    Replicated draft cache groups have different allocation and DCP semantics
+    from target cache groups. Group each partition independently so a hybrid
+    target retains its native grouping and page sizes instead of being
+    page-size-unified with the draft.
+    """
+    replicated = {
+        name: spec
+        for name, spec in kv_cache_spec.items()
+        if getattr(spec, "dcp_replicated", False)
+    }
+    if not replicated:
+        return None
+    sharded = {
+        name: spec
+        for name, spec in kv_cache_spec.items()
+        if not getattr(spec, "dcp_replicated", False)
+    }
+    if not sharded:
+        return None
+    return [
+        *get_kv_cache_groups(vllm_config, sharded),
+        *get_kv_cache_groups(vllm_config, replicated),
+    ]
+
+
 def _approximate_gcd(values: Sequence[int], *, lower_bound: int | None = None) -> int:
     """Pick a chunk size that minimizes total upward padding.
 
@@ -1784,6 +1815,10 @@ def get_kv_cache_groups(
         # full attention, or all layers are sliding window attention with the
         # same window size). Put all layers into one group.
         return _get_kv_cache_groups_uniform_type(uniform_spec)
+    elif replicated_groups := group_dcp_replicated_draft_kv_cache_specs(
+        vllm_config, kv_cache_spec
+    ):
+        return replicated_groups
     elif grouped_specs := group_and_unify_kv_cache_specs(kv_cache_spec):
         # DeepseekV4 case: All layers need the same number of token slots,
         # yet some layers are full attention while others are sliding window


### PR DESCRIPTION
## Status

Implemented. Qualified in the GLM-5.3-Flash TP4/DCP4 integration described below.

## Behavior

DCP-replicated speculative cache groups are grouped independently from DCP-sharded target cache groups. Each partition then uses the existing vLLM grouping logic.

This preserves the native MLA and Mamba page geometry of a hybrid target while preserving the DCP1 allocation geometry of a replicated DFlash draft cache. It prevents cross-model page-size unification from padding or resizing an incompatible target cache.

The behavior changes only a cache specification containing both `dcp_replicated=True` and non-replicated groups. Cache specifications with one replication mode retain the existing grouping path.

## Dependency

This pull request is stacked on local-inference-lab/vllm#513 at `e5e7bf99182833c6ce25042c29252bbb4107539c`. The base branch `deps/pr513-dflash-dcp` is an exact mirror of that revision so the review diff contains only the two files changed here.

Merge order: #513, then this pull request. Retarget this pull request to `dev/jovian-judgement` after #513 is present there.

## Reproducer

With #513 and without this commit:

- an MLA target plus a replicated sliding-window draft was page-size-unified instead of grouped independently;
- an MLA-plus-Mamba target plus an incompatible replicated draft page raised `NotImplementedError: Layer model.mla: page size is not divisible by the maximum page size and cannot be padded` during KV-cache grouping;
- GLM-5.3-Flash DCP4 startup stopped during CUDA-graph memory profiling for the same cache geometry.

The regression tests model both the MLA-only and MLA-plus-Mamba cases.

## Validation

Exact pull-request tree `dd361d82253fc1df223ec02e15027cc7c0fc4f8f`:

- `2 passed` for the two added grouping regressions in a source-overlay test image whose staged vLLM tree matched that hash.
- The broader CPU-only file run produced `66 passed, 22 failed`; every failure was an existing test constructing `DeviceConfig(device="auto")` without an available device. No implementation or assertion failure was observed outside that environment limitation.

Composed GLM-5.3-Flash integration tree `89e9e3c6cda543e53b950e4034f115dbd7543ec0`:

- `113 passed` across DFlash replicated-cache, DCP compatibility, mixed slot-mapping, and KV-cache grouping tests.
- Source-locked image `sha256:5d98788110b15f3e14c5668250d846da2cf819cf850d436d26aca1a1c5a52737` completed model loading, KV allocation, B12X warmup, and target plus DFlash2 CUDA graph capture without source bind mounts.
- Hardware: four RTX PRO 6000 Blackwell GPUs, physical devices 4–7; TP4, DCP4, interleave 4.
- Target: `local-inference-lab/GLM-5.3-Flash-NVFP4@520de24eabf507659eaef7c70f14fd584527facc`.
- Draft: `local-inference-lab/GLM-5.3-Flash-DFlash2-MXFP8@b6d33aa93fc1ac5b23a88251a1c0ce0bfe2ad17c`.
- B12X: `d56c1163b6e019d828ed24f135c2efd05fdca6ea`.
- Runtime backends: B12X target attention, NVFP4 MoE, MXFP8 draft linear kernels, and PCIe all-reduce; FlashAttention draft attention over replicated KV.
- CUDA graphs: full decode capture through concurrency 16 for target and DFlash2. GLM GDN selects `FULL_DECODE_ONLY`, so prefill remains outside a full graph.
- 30-second decode smoke: 153.3 tok/s at CC1 and 888.6 aggregate tok/s at CC16. Acceptance varied between runs; normalized engine throughput remained 62.2–62.4 steps/s at CC1 and reached 333.1 steps/s at CC16.
- 32,320-token prefill over a 30-second window: 10,529 client prompt tok/s.

## Review requirement

OpenAI Codex assisted with analysis, implementation, testing, and pull-request text. Every changed line requires human review before merge.
