### PR TITLE
perf(dflash): align replicated cache pages with target

### DIFF
--- a/tests/v1/spec_decode/test_dflash_replicated_dcp.py
+++ b/tests/v1/spec_decode/test_dflash_replicated_dcp.py
@@ -184,3 +184,99 @@ def test_grouping_never_merges_replicated_draft_with_sharded_target():
         {"target.layer"},
         {"draft.layer"},
     ]
+
+
+def test_grouping_uses_memory_free_target_alignment_for_replicated_window():
+    target = FullAttentionSpec(
+        block_size=256,
+        num_kv_heads=8,
+        head_size=64,
+        dtype=torch.bfloat16,
+    )
+    draft = SlidingWindowSpec(
+        block_size=64,
+        num_kv_heads=2,
+        head_size=64,
+        dtype=torch.bfloat16,
+        sliding_window=2048,
+        page_size_padded=64 * 2 * 128 * 2,
+        dcp_replicated=True,
+    )
+    vllm_config = SimpleNamespace(
+        scheduler_config=SimpleNamespace(disable_hybrid_kv_cache_manager=False),
+        cache_config=SimpleNamespace(
+            block_size=256,
+            enable_prefix_caching=True,
+            prefix_match_unit=None,
+        ),
+        parallel_config=SimpleNamespace(decode_context_parallel_size=4),
+        kv_transfer_config=None,
+    )
+
+    grouped = get_kv_cache_groups(
+        vllm_config, {"target.layer": target, "draft.layer": draft}
+    )
+
+    aligned_draft = grouped[1].kv_cache_spec
+    assert isinstance(aligned_draft, SlidingWindowSpec)
+    assert aligned_draft.block_size == 256
+    assert aligned_draft.page_size_padded is None
+    assert resolve_kv_cache_block_sizes(
+        KVCacheConfig(128, [], grouped), vllm_config
+    ) == (1024, 256)
+
+
+def test_grouping_preserves_draft_block_when_alignment_would_grow_pool():
+    target = FullAttentionSpec(
+        block_size=256,
+        num_kv_heads=1,
+        head_size=64,
+        dtype=torch.bfloat16,
+    )
+    draft = SlidingWindowSpec(
+        block_size=64,
+        num_kv_heads=8,
+        head_size=64,
+        dtype=torch.bfloat16,
+        sliding_window=2048,
+        dcp_replicated=True,
+    )
+    vllm_config = SimpleNamespace(
+        scheduler_config=SimpleNamespace(disable_hybrid_kv_cache_manager=False)
+    )
+
+    grouped = get_kv_cache_groups(
+        vllm_config, {"target.layer": target, "draft.layer": draft}
+    )
+
+    preserved_draft = grouped[1].kv_cache_spec
+    assert isinstance(preserved_draft, SlidingWindowSpec)
+    assert preserved_draft.block_size == 64
+
+
+def test_grouping_preserves_backend_block_that_does_not_divide_target():
+    target = FullAttentionSpec(
+        block_size=192,
+        num_kv_heads=8,
+        head_size=64,
+        dtype=torch.bfloat16,
+    )
+    draft = SlidingWindowSpec(
+        block_size=128,
+        num_kv_heads=2,
+        head_size=64,
+        dtype=torch.bfloat16,
+        sliding_window=2048,
+        dcp_replicated=True,
+    )
+    vllm_config = SimpleNamespace(
+        scheduler_config=SimpleNamespace(disable_hybrid_kv_cache_manager=False)
+    )
+
+    grouped = get_kv_cache_groups(
+        vllm_config, {"target.layer": target, "draft.layer": draft}
+    )
+
+    preserved_draft = grouped[1].kv_cache_spec
+    assert isinstance(preserved_draft, SlidingWindowSpec)
+    assert preserved_draft.block_size == 128

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1625,10 +1625,44 @@ def group_dcp_replicated_draft_kv_cache_specs(
     }
     if not sharded:
         return None
-    return [
-        *get_kv_cache_groups(vllm_config, sharded),
-        *get_kv_cache_groups(vllm_config, replicated),
-    ]
+
+    sharded_groups = get_kv_cache_groups(vllm_config, sharded)
+    replicated_groups = get_kv_cache_groups(vllm_config, replicated)
+
+    # A replicated sliding-window draft can use the target's common physical
+    # block without changing the scheduler LCM. This reduces the number of
+    # shared BlockPool IDs needed to retain the draft window. Keep the
+    # backend-selected block when it does not divide the target alignment or
+    # when the enlarged natural draft pages would increase the pool stride.
+    target_block_alignment = math.gcd(
+        *(group.kv_cache_spec.block_size for group in sharded_groups)
+    )
+    aligned_replicated = {
+        name: replace(
+            spec,
+            block_size=target_block_alignment,
+            page_size_padded=None,
+        )
+        if isinstance(spec, SlidingWindowSpec)
+        and target_block_alignment > spec.block_size
+        and target_block_alignment % spec.block_size == 0
+        else spec
+        for name, spec in replicated.items()
+    }
+    if aligned_replicated != replicated:
+        candidate_groups = get_kv_cache_groups(vllm_config, aligned_replicated)
+        if _get_kv_cache_bytes_per_block(
+            candidate_groups
+        ) <= _get_kv_cache_bytes_per_block(sharded_groups):
+            logger.info(
+                "Aligned DCP-replicated sliding-window cache blocks to the "
+                "sharded target's %d-token physical block without increasing "
+                "the KV cache pool stride.",
+                target_block_alignment,
+            )
+            replicated_groups = candidate_groups
+
+    return [*sharded_groups, *replicated_groups]
 
 
 def _approximate_gcd(values: Sequence[int], *, lower_bound: int | None = None) -> int:


### PR DESCRIPTION
## Status

Qualified on four RTX PRO 6000 Blackwell GPUs with TP4 and DCP4. The change is stacked on the replicated/sharded cache-group isolation in #519; #519 is stacked on the DFlash DCP implementation in #513.

## Resulting behavior

DCP-replicated sliding-window draft cache groups retain the block selected by their attention backend while model KV specs are constructed. During mixed target/draft cache grouping, the planner promotes a smaller draft block to the greatest common physical block size of the sharded target groups only when both invariants hold:

- the backend-selected draft block divides the target alignment, so attention kernels can use the framework block-splitting contract;
- the enlarged natural draft pages fit within the target-determined shared BlockPool stride, so allocated KV bytes do not increase.

Incompatible geometry and candidates that would enlarge the pool preserve the backend-selected draft block. No user-facing configuration flag or model-specific block constant is added. Because the promoted block divides every sharded target block before DCP scaling, scheduler LCM does not increase.

## Compatibility impact

The optimization applies only when one cache specification contains both DCP-sharded groups and DCP-replicated sliding-window groups. DCP1, non-windowed replicated attention, caches without mixed replication modes, and memory-costly alignments retain their existing geometry.

## Validation

Source qualification used PR commit `fd47007a6adc95f1a947d80dc2fd50745e22bdcc` in integration commit `bfd30c0db01846a1de2e6a47d33aac3fb970b759` (tree `559049e2e214e3091d08138dab7ffe95cb10fd11`) over the source-qualified GLM-5.3 stack. B12X was `d56c1163b6e019d828ed24f135c2efd05fdca6ea`.

Models:

- target: `local-inference-lab/GLM-5.3-Flash-NVFP4@520de24eabf507659eaef7c70f14fd584527facc`
- draft: `local-inference-lab/GLM-5.3-Flash-DFlash2-MXFP8@b6d33aa93fc1ac5b23a88251a1c0ce0bfe2ad17c`

Runtime configuration:

```text
physical GPUs: 4,5,6,7
TP=4
DCP=4
CP_KV_CACHE_INTERLEAVE_SIZE=4
SPECULATOR=dflash
NUM_SPECULATIVE_TOKENS=7
DFLASH_ATTENTION_BACKEND=FLASH_ATTN
DFLASH_KV_CACHE_DTYPE=auto
CUDAGRAPH_MODE=FULL
MAX_CUDAGRAPH_CAPTURE_SIZE=128
MAX_NUM_BATCHED_TOKENS=8192
MAX_NUM_SEQS=32
MAX_MODEL_LEN=1048576
DCP_CKV_GATHER=1
B12X_PCIE_ALLREDUCE=1
--kv-cache-memory 12884901888
--additional-config {"glm53_kda_decode_backend":"auto"}
```

The GLM GDN backend resolves `FULL` to `FULL_DECODE_ONLY`; target and DFlash decode graphs were captured through concurrency 16.

At an identical 12 GiB KV budget and 906 physical blocks:

| Replicated draft block | Group-aware capacity | Change |
|---:|---:|---:|
| 1152 control | 5,688,681 tokens | — |
| 2304 planner alignment | 5,974,904 tokens | +286,223 (+5.03%) |

Three 30-second sustained decode runs:

| Geometry | CC1 steps/s | CC16 steps/s |
|---|---:|---:|
| 1152 control, mean | 62.041 | 330.026 |
| 2304 planner alignment, mean | 62.055 | 328.749 |
| Relative change | +0.02% | -0.39% |

Raw output throughput is acceptance-dependent. The 2304 runs averaged 139.7/783.0 tok/s at accepted lengths 2.252/2.382 for CC1/CC16; normalized steps/s is the kernel/scheduler comparison signal.

Three 32k standalone prefill captures with 30-second sampling windows measured 10,637, 10,100, and 10,708 prompt tok/s (mean 10,482). The source-qualified 1152 runtime measured 10,529 prompt tok/s under the same 32k methodology.

A 25,210-token prompt followed by 3,072 generated tokens crossed both cache geometries. The warmed 2304 runtime reproduced the 1152 output SHA-256 `acf8a33a8123fa87a857b83dcb089deb45f11d69af24010765ed183a92758637`. One first request after an empty JIT cache produced a different long-horizon continuation, so the hash is evidence for warmed-path parity rather than a cross-cold-start determinism guarantee.

Tests and static checks:

- `96 passed`: `tests/v1/core/test_kv_cache_utils.py` plus `tests/v1/spec_decode/test_dflash_replicated_dcp.py`
- `ruff check`: passed
- `ruff format --check`: passed

## Review requirement

OpenAI Codex assisted with implementation, tests, benchmarking, and pull-request text. Every changed line requires human review before merge.