### PR TITLE
perf(glm5next): run B12X KDA on live layer tensors

### DIFF
--- a/tests/models/test_glm5next_model.py
+++ b/tests/models/test_glm5next_model.py
@@ -743,6 +743,106 @@ def test_glm5next_b12x_kda_plan_reserves_null_state_zero(monkeypatch) -> None:
     assert captured_caps["null_state_index"] == 0
 
 
+def test_b12x_kda_validates_shared_metadata_once_and_uses_live_tensors(
+    monkeypatch,
+) -> None:
+    calls: dict[str, list] = {"bind": [], "validate": [], "run": []}
+
+    class FakeApi:
+        @staticmethod
+        def bind_kda_metadata(plan, **kwargs):
+            metadata_binding = SimpleNamespace(plan=plan, **kwargs)
+            calls["bind"].append(metadata_binding)
+            return metadata_binding
+
+        @staticmethod
+        def validate_kda_metadata(metadata_binding):
+            validated = SimpleNamespace(binding=metadata_binding)
+            calls["validate"].append(validated)
+            return validated
+
+        @staticmethod
+        def run_kda_prevalidated(binding, metadata, **kwargs):
+            calls["run"].append((binding, metadata, kwargs))
+
+    forward_context = SimpleNamespace(additional_kwargs={})
+    monkeypatch.setattr(
+        kimi_gdn_linear_attn,
+        "get_forward_context",
+        lambda: forward_context,
+    )
+
+    plan = SimpleNamespace(caps=SimpleNamespace(max_state_slots=32))
+    api = FakeApi()
+
+    def make_layer(binding):
+        layer = KimiGatedDeltaNetAttention.__new__(KimiGatedDeltaNetAttention)
+        torch.nn.Module.__init__(layer)
+        layer._b12x_kda_binding = binding
+        layer._b12x_kda_api = api
+        layer._b12x_kda_direct = True
+        layer._b12x_kda_plan = plan
+        layer._b12x_kda_scratch = torch.empty(16, dtype=torch.uint8)
+        layer._b12x_kda_num_accepted_tokens = torch.zeros(2, dtype=torch.int32)
+        layer._b12x_kda_num_seqs = torch.zeros(1, dtype=torch.int32)
+        layer._b12x_kda_num_tokens = torch.zeros(1, dtype=torch.int32)
+        layer._b12x_kda_max_tokens = 2
+        layer._b12x_kda_max_seqs = 2
+        layer._b12x_kda_state_index_columns = 1
+        layer._b12x_kda_mixed_qkv = torch.full((2, 3), 71.0)
+        layer._b12x_kda_raw_g = torch.full((2, 1, 1), 72.0)
+        layer._b12x_kda_raw_beta = torch.full((2, 1), 73.0)
+        layer._b12x_kda_z = torch.full((2, 1, 1), 74.0)
+        layer._b12x_kda_output = torch.full((2, 1, 1), 75.0)
+        layer.gate_lower_bound = -5.0
+        layer.head_dim = 1
+        layer.o_norm = SimpleNamespace(eps=1e-6)
+        return layer
+
+    layers = [make_layer(object()), make_layer(object())]
+    metadata = object()
+    mixed_qkv = torch.arange(6, dtype=torch.float32).view(2, 3)
+    raw_g = torch.ones(2, 1, 1)
+    raw_beta = torch.ones(2, 1)
+    z = torch.ones(2, 1, 1)
+    outputs = [torch.empty(2, 1, 1), torch.empty(2, 1, 1)]
+    state_indices = torch.tensor([[3], [4]], dtype=torch.int32)
+    query_start_loc = torch.tensor([0, 1, 2], dtype=torch.int32)
+
+    for layer, output in zip(layers, outputs):
+        layer._run_b12x_kda_decode_post_conv(
+            metadata=metadata,
+            mixed_qkv=mixed_qkv,
+            raw_g=raw_g,
+            raw_beta=raw_beta,
+            z=z,
+            output=output,
+            state_indices=state_indices,
+            query_start_loc=query_start_loc,
+            num_accepted_tokens=None,
+            num_requests=2,
+        )
+
+    assert len(calls["bind"]) == 1
+    assert len(calls["validate"]) == 1
+    assert len(calls["run"]) == 2
+    assert calls["run"][0][1] is calls["run"][1][1]
+    for (_, _, kwargs), output in zip(calls["run"], outputs):
+        assert kwargs["mixed_qkv"] is mixed_qkv
+        assert kwargs["raw_g"] is raw_g
+        assert kwargs["raw_beta"] is raw_beta
+        assert kwargs["z"] is z
+        assert kwargs["output"] is output
+    assert torch.equal(
+        layers[0]._b12x_kda_num_accepted_tokens,
+        torch.ones(2, dtype=torch.int32),
+    )
+    assert layers[0]._b12x_kda_num_seqs.item() == 2
+    assert layers[0]._b12x_kda_num_tokens.item() == 2
+    assert torch.equal(layers[0]._b12x_kda_mixed_qkv, torch.full((2, 3), 71.0))
+    assert torch.equal(layers[1]._b12x_kda_mixed_qkv, torch.full((2, 3), 71.0))
+
+
 def test_glm5next_sparse_mla_selects_b12x_backend(monkeypatch) -> None:
     captured: dict[str, object] = {}
 

--- a/tests/models/test_glm5next_model.py
+++ b/tests/models/test_glm5next_model.py
@@ -743,10 +743,8 @@ def test_glm5next_b12x_kda_plan_reserves_null_state_zero(monkeypatch) -> None:
     assert captured_caps["null_state_index"] == 0
 
 
-def test_b12x_kda_validates_shared_metadata_once_and_uses_live_tensors(
-    monkeypatch,
-) -> None:
-    calls: dict[str, list] = {"bind": [], "validate": [], "run": []}
+def test_b12x_kda_binds_metadata_once_and_uses_live_tensors(monkeypatch) -> None:
+    calls: dict[str, list] = {"bind": [], "run": []}
 
     class FakeApi:
         @staticmethod
@@ -756,13 +754,7 @@ def test_b12x_kda_validates_shared_metadata_once_and_uses_live_tensors(
             return metadata_binding
 
         @staticmethod
-        def validate_kda_metadata(metadata_binding):
-            validated = SimpleNamespace(binding=metadata_binding)
-            calls["validate"].append(validated)
-            return validated
-
-        @staticmethod
-        def run_kda_prevalidated(binding, metadata, **kwargs):
+        def run_kda_live(binding, metadata, **kwargs):
             calls["run"].append((binding, metadata, kwargs))
 
     forward_context = SimpleNamespace(additional_kwargs={})
@@ -780,9 +772,8 @@ def test_b12x_kda_validates_shared_metadata_once_and_uses_live_tensors(
         torch.nn.Module.__init__(layer)
         layer._b12x_kda_binding = binding
         layer._b12x_kda_api = api
-        layer._b12x_kda_direct = True
+        layer._b12x_kda_live_tensors = True
         layer._b12x_kda_plan = plan
-        layer._b12x_kda_scratch = torch.empty(16, dtype=torch.uint8)
         layer._b12x_kda_num_accepted_tokens = torch.zeros(2, dtype=torch.int32)
         layer._b12x_kda_num_seqs = torch.zeros(1, dtype=torch.int32)
         layer._b12x_kda_num_tokens = torch.zeros(1, dtype=torch.int32)
@@ -824,7 +815,6 @@ def test_b12x_kda_validates_shared_metadata_once_and_uses_live_tensors(
         )
 
     assert len(calls["bind"]) == 1
-    assert len(calls["validate"]) == 1
     assert len(calls["run"]) == 2
     assert calls["run"][0][1] is calls["run"][1][1]
     for (_, _, kwargs), output in zip(calls["run"], outputs):

--- a/vllm/model_executor/layers/mamba/gdn/kimi_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/kimi_gdn_linear_attn.py
@@ -309,7 +309,7 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
         self._b12x_kda_api: Any | None = None
         self._b12x_kda_plan = None
         self._b12x_kda_binding = None
-        self._b12x_kda_direct = False
+        self._b12x_kda_live_tensors = False
         self._initialize_b12x_kda_decode(vllm_config)
         self.o_proj = RowParallelLinear(
             self.projection_size,
@@ -352,13 +352,8 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
         max_tokens = max_seqs * state_index_columns
 
         self._b12x_kda_api = api
-        self._b12x_kda_direct = all(
-            hasattr(api, name)
-            for name in (
-                "bind_kda_metadata",
-                "validate_kda_metadata",
-                "run_kda_prevalidated",
-            )
+        self._b12x_kda_live_tensors = all(
+            hasattr(api, name) for name in ("bind_kda_metadata", "run_kda_live")
         )
         self._b12x_kda_max_tokens = max_tokens
         self._b12x_kda_max_seqs = max_seqs
@@ -526,6 +521,26 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
         num_accepted_tokens: torch.Tensor | None,
         num_requests: int,
     ) -> None:
+        """Execute B12X KDA after the convolution projection.
+
+        Args:
+            metadata: Forward-context metadata used to share one statically
+                checked packed-metadata binding across compatible layers.
+            mixed_qkv: Live packed query, key, and value projection.
+            raw_g: Live unactivated forget gate.
+            raw_beta: Live unactivated update gate.
+            z: Live output gate.
+            output: Caller-owned destination tensor.
+            state_indices: Packed recurrent-state indices.
+            query_start_loc: Packed request boundaries.
+            num_accepted_tokens: Accepted speculative-token counts, or ``None``
+                for one-token decode requests.
+            num_requests: Number of packed requests.
+
+        Raises:
+            RuntimeError: If the KDA cache binding is unavailable.
+            ValueError: If the live batch exceeds the planned capacity.
+        """
         binding = self._b12x_kda_binding
         api = self._b12x_kda_api
         if binding is None or api is None:
@@ -545,10 +560,10 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
                 f"{self._b12x_kda_state_index_columns}"
             )
 
-        if self._b12x_kda_direct:
+        if self._b12x_kda_live_tensors:
             forward_context = get_forward_context()
             cache = forward_context.additional_kwargs.setdefault(
-                "b12x_kda_validated_metadata", {}
+                "b12x_kda_bound_metadata", {}
             )
             cache_key = (
                 id(metadata),
@@ -557,12 +572,10 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
                 state_columns,
                 self._b12x_kda_plan.caps.max_state_slots,
             )
-            validated_metadata = cache.get(cache_key)
-            if validated_metadata is None:
+            bound_metadata = cache.get(cache_key)
+            if bound_metadata is None:
                 query_start_loc = query_start_loc[: num_requests + 1]
-                state_indices = state_indices[
-                    :num_requests, : self._b12x_kda_state_index_columns
-                ]
+                state_indices = state_indices[:num_requests, :state_columns]
                 if num_accepted_tokens is None:
                     accepted_tokens = self._b12x_kda_num_accepted_tokens[:num_requests]
                     accepted_tokens.fill_(1)
@@ -572,9 +585,8 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
                 self._b12x_kda_num_tokens.copy_(
                     query_start_loc[num_requests : num_requests + 1]
                 )
-                metadata_binding = api.bind_kda_metadata(
+                bound_metadata = api.bind_kda_metadata(
                     self._b12x_kda_plan,
-                    scratch=self._b12x_kda_scratch,
                     query_start_loc=query_start_loc,
                     num_accepted_tokens=accepted_tokens,
                     state_indices=state_indices,
@@ -583,11 +595,10 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
                     max_tokens=num_tokens,
                     max_seqs=num_requests,
                 )
-                validated_metadata = api.validate_kda_metadata(metadata_binding)
-                cache[cache_key] = validated_metadata
-            api.run_kda_prevalidated(
+                cache[cache_key] = bound_metadata
+            api.run_kda_live(
                 binding,
-                validated_metadata,
+                bound_metadata,
                 mixed_qkv=mixed_qkv,
                 raw_g=raw_g,
                 raw_beta=raw_beta,

--- a/vllm/model_executor/layers/mamba/gdn/kimi_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/kimi_gdn_linear_attn.py
@@ -309,6 +309,7 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
         self._b12x_kda_api: Any | None = None
         self._b12x_kda_plan = None
         self._b12x_kda_binding = None
+        self._b12x_kda_direct = False
         self._initialize_b12x_kda_decode(vllm_config)
         self.o_proj = RowParallelLinear(
             self.projection_size,
@@ -351,6 +352,14 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
         max_tokens = max_seqs * state_index_columns
 
         self._b12x_kda_api = api
+        self._b12x_kda_direct = all(
+            hasattr(api, name)
+            for name in (
+                "bind_kda_metadata",
+                "validate_kda_metadata",
+                "run_kda_prevalidated",
+            )
+        )
         self._b12x_kda_max_tokens = max_tokens
         self._b12x_kda_max_seqs = max_seqs
         self._b12x_kda_state_index_columns = state_index_columns
@@ -506,6 +515,7 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
     def _run_b12x_kda_decode_post_conv(
         self,
         *,
+        metadata: GDNAttentionMetadata,
         mixed_qkv: torch.Tensor,
         raw_g: torch.Tensor,
         raw_beta: torch.Tensor,
@@ -534,6 +544,60 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
                 f"state_columns={state_columns}/"
                 f"{self._b12x_kda_state_index_columns}"
             )
+
+        if self._b12x_kda_direct:
+            forward_context = get_forward_context()
+            cache = forward_context.additional_kwargs.setdefault(
+                "b12x_kda_validated_metadata", {}
+            )
+            cache_key = (
+                id(metadata),
+                num_tokens,
+                num_requests,
+                state_columns,
+                self._b12x_kda_plan.caps.max_state_slots,
+            )
+            validated_metadata = cache.get(cache_key)
+            if validated_metadata is None:
+                query_start_loc = query_start_loc[: num_requests + 1]
+                state_indices = state_indices[
+                    :num_requests, : self._b12x_kda_state_index_columns
+                ]
+                if num_accepted_tokens is None:
+                    accepted_tokens = self._b12x_kda_num_accepted_tokens[:num_requests]
+                    accepted_tokens.fill_(1)
+                else:
+                    accepted_tokens = num_accepted_tokens[:num_requests]
+                self._b12x_kda_num_seqs.fill_(num_requests)
+                self._b12x_kda_num_tokens.copy_(
+                    query_start_loc[num_requests : num_requests + 1]
+                )
+                metadata_binding = api.bind_kda_metadata(
+                    self._b12x_kda_plan,
+                    scratch=self._b12x_kda_scratch,
+                    query_start_loc=query_start_loc,
+                    num_accepted_tokens=accepted_tokens,
+                    state_indices=state_indices,
+                    num_seqs=self._b12x_kda_num_seqs,
+                    num_tokens=self._b12x_kda_num_tokens,
+                    max_tokens=num_tokens,
+                    max_seqs=num_requests,
+                )
+                validated_metadata = api.validate_kda_metadata(metadata_binding)
+                cache[cache_key] = validated_metadata
+            api.run_kda_prevalidated(
+                binding,
+                validated_metadata,
+                mixed_qkv=mixed_qkv,
+                raw_g=raw_g,
+                raw_beta=raw_beta,
+                z=z,
+                output=output,
+                lower_bound=self.gate_lower_bound,
+                eps=self.o_norm.eps,
+                scale=self.head_dim**-0.5,
+            )
+            return
 
         self._b12x_kda_mixed_qkv[:num_tokens].copy_(mixed_qkv)
         self._b12x_kda_raw_g[:num_tokens].copy_(raw_g)
@@ -750,6 +814,7 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
                 assert g2_spec is not None
                 core_attn_out_spec = core_attn_out[:, : mixed_qkv_spec.shape[0]]
                 self._run_b12x_kda_decode_post_conv(
+                    metadata=m,
                     mixed_qkv=mixed_qkv_spec,
                     raw_g=g1_spec[0],
                     raw_beta=beta_spec[0],
@@ -928,6 +993,7 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
                     assert g2_ns is not None
                     core_attn_out_non_spec = core_attn_out[:, : mixed_qkv_ns.shape[0]]
                     self._run_b12x_kda_decode_post_conv(
+                        metadata=m,
                         mixed_qkv=mixed_qkv_ns,
                         raw_g=g1_ns[0],
                         raw_beta=beta_ns[0],


### PR DESCRIPTION
Status: qualified for GLM-5.3 decode at TP4, DCP1, concurrency 1, without speculative decoding.

Companion dependency: local-inference-lab/b12x#258 provides the additive prevalidated KDA interface. The vLLM integration feature-detects that interface and retains the per-layer staging path when it is unavailable.

## Resulting behavior

GLM-5.3 B12X decode validates packed request metadata once in each forward context. Every compatible KDA layer then passes its live convolution output, forget gate, update gate, output gate, and destination buffer to B12X. The validation cache is scoped to one forward context and keyed by attention metadata identity, live token and request geometry, state-index columns, and recurrent-state capacity.

Prefill routing is unchanged. The computation remains B12X KDA; no DeepGEMM, TileLang, or alternate attention backend is selected.

## Technical reason

The staged path copied five live tensors per KDA layer and repeated three metadata-validation kernels per layer. A rank-0 Torch trace measured 2,090 CUDA kernels and 7,689.985 microseconds per stable model step. The live-tensor path with B12X#258 measured 1,604 CUDA kernels and 6,954.152 microseconds. A fused Triton/FLA recurrence reference measured 1,614 CUDA kernels and 6,915.751 microseconds on its source-locked stack.

## Compatibility

- B12X installations with bind_kda_metadata, validate_kda_metadata, and run_kda_prevalidated use the live-tensor path.
- B12X installations without any of those methods retain bind_kda and run_kda staging behavior.
- Speculative and non-speculative decode retain their packed state-index and accepted-token contracts.
- Prefill behavior and backend selection are unchanged.

## Validation

Hardware and serving conditions:

- Four RTX PRO 6000 Blackwell Workstation Edition GPUs, physical devices 4,5,6,7
- Tensor parallel 4; decode context parallel 1
- GLM-5.3-Flash-NVFP4 target checkpoint
- W4A4 MoE with VLLM_B12X_MOE_FP4_FORCE_A16=0
- FP8 KV cache
- B12X KDA, MoE, linear, and PCIe all-reduce paths
- Full decode CUDA graphs
- Concurrency 1, 30-second sustained decode, no MTP

| KDA execution path | Server generation throughput |
| --- | ---: |
| Per-layer staged B12X | 129.314 tok/s |
| Triton/FLA fused recurrence | 140.580 tok/s |
| Live-tensor B12X, run 1 | 140.610 tok/s |
| Live-tensor B12X, run 2 | 140.544 tok/s |

Test evidence:

- Focused vLLM tests pass for one shared validation across two layer consumers, live tensor identity, and GLM null-state planning.
- B12X KDA tests pass 15 of 15 on one RTX PRO 6000 Blackwell GPU.
- TP4 serving captures and replays full decode CUDA graphs.
- The full vLLM pre-commit suite for the changed files passes, including ruff, formatting, mypy, SPDX, forbidden-import, and CUDA API checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved b12x KDA decoding efficiency by reusing shared metadata and live tensor data across attention layers.
  * Updated supported decoding paths to reduce unnecessary buffer handling.
* **Compatibility**
  * Preserved the existing decoding behavior when the optimized interface is unavailable.
* **Reliability**
  * Expanded coverage for shared metadata reuse, live decoding, kernel execution, and per-layer token tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->