### PR TITLE
feat(glm53): specialize FULL graph replay

### DIFF
--- a/tests/v1/cudagraph/test_cudagraph_manager.py
+++ b/tests/v1/cudagraph/test_cudagraph_manager.py
@@ -18,7 +18,10 @@ from vllm.config import (
 )
 from vllm.distributed.device_communicators import pynccl_allocator
 from vllm.v1.worker.gpu import cudagraph_utils as gpu_cudagraph_utils
-from vllm.v1.worker.gpu.cudagraph_utils import BatchExecutionDescriptor
+from vllm.v1.worker.gpu.cudagraph_utils import (
+    BatchExecutionDescriptor,
+    TargetExecutionBranch,
+)
 
 pytestmark = pytest.mark.cpu_test
 
@@ -45,6 +48,90 @@ def _create_vllm_config() -> MagicMock:
     vllm_config.speculative_config = None
     vllm_config.num_speculative_tokens = 0
     return vllm_config
+
+
+def test_branch_specialized_full_graphs_require_exact_decode_request_count():
+    desc = BatchExecutionDescriptor(
+        cg_mode=CUDAGraphMode.FULL,
+        num_tokens=16,
+        num_reqs=4,
+        uniform_token_count=4,
+        target_execution_branch=TargetExecutionBranch.SPEC_DECODE,
+    )
+
+    assert gpu_cudagraph_utils._is_compatible(
+        desc,
+        4,
+        16,
+        4,
+        0,
+        None,
+        TargetExecutionBranch.SPEC_DECODE,
+        branch_specialized=True,
+    )
+    assert not gpu_cudagraph_utils._is_compatible(
+        desc,
+        1,
+        4,
+        4,
+        0,
+        None,
+        TargetExecutionBranch.SPEC_DECODE,
+        branch_specialized=True,
+    )
+    assert not gpu_cudagraph_utils._is_compatible(
+        desc,
+        4,
+        16,
+        4,
+        0,
+        None,
+        TargetExecutionBranch.PREFILL,
+        branch_specialized=True,
+    )
+
+
+def test_branch_specialized_geometries_cover_prefill_spec_and_decode():
+    geometries = gpu_cudagraph_utils._branch_geometries(16, 8, 4)
+
+    assert (TargetExecutionBranch.PREFILL, 8, None, 2) in geometries
+    assert (TargetExecutionBranch.SPEC_DECODE, 4, 4, None) in geometries
+    assert not any(branch is TargetExecutionBranch.DECODE for branch, *_ in geometries)
+    assert (
+        TargetExecutionBranch.DECODE,
+        4,
+        1,
+        None,
+    ) in gpu_cudagraph_utils._branch_geometries(4, 8, 4)
+
+
+@pytest.mark.parametrize(
+    "mode",
+    [CUDAGraphMode.FULL_DECODE_ONLY, CUDAGraphMode.FULL_AND_PIECEWISE],
+)
+def test_separate_full_modes_preserve_decode_branch_identity(monkeypatch, mode):
+    monkeypatch.setattr(
+        "vllm.models.glm5next_cudagraph.is_glm53_full_graph_path",
+        lambda _config: True,
+    )
+    monkeypatch.setattr(
+        gpu_cudagraph_utils,
+        "get_pp_group",
+        lambda: SimpleNamespace(is_first_rank=True, is_last_rank=True),
+    )
+    manager = gpu_cudagraph_utils.CudaGraphManager(
+        vllm_config=_create_vllm_config(),
+        device=torch.device("cpu"),
+        cudagraph_mode=mode,
+        decode_query_len=4,
+    )
+
+    assert manager._branch_specialized_full_graphs
+    full_descriptors = manager._capture_descs[CUDAGraphMode.FULL]
+    assert full_descriptors
+    assert {
+        descriptor.target_execution_branch for descriptor in full_descriptors
+    } == {TargetExecutionBranch.SPEC_DECODE}
 
 
 def test_full_capture_sets_graph_pool_id_before_cuda_graph(monkeypatch):

--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -1648,6 +1648,24 @@ def test_is_uniform_decode() -> None:
     )
 
 
+def test_hybrid_prefill_disables_uniform_decode(monkeypatch) -> None:
+    scheduler_output = object()
+    monkeypatch.setattr(
+        gpu_model_runner_module,
+        "compute_iteration_details",
+        lambda output: SimpleNamespace(num_ctx_requests=1),
+    )
+
+    assert (
+        GPUModelRunner._compute_force_uniform_decode(scheduler_output, is_hybrid=True)
+        is False
+    )
+    assert (
+        GPUModelRunner._compute_force_uniform_decode(scheduler_output, is_hybrid=False)
+        is None
+    )
+
+
 @pytest.mark.skipif(
     not current_platform.is_cuda(),
     reason="Attention backend FLASHINFER is only supported on CUDA.",

--- a/vllm/models/glm5next_cudagraph.py
+++ b/vllm/models/glm5next_cudagraph.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CUDA graph qualification contract for GLM-5.3-Flash."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from vllm.config import VllmConfig
+
+MAX_FULL_GRAPH_SEQS = 4
+MAX_FULL_GRAPH_TOKENS = 32768
+_RECIPE = {
+    "kv_lora_rank": 512,
+    "qk_nope_head_dim": 256,
+    "qk_rope_head_dim": 0,
+    "v_head_dim": 256,
+    "index_n_heads": 32,
+    "index_head_dim": 128,
+    "index_topk": 2048,
+    "index_kpool": 4,
+}
+
+
+def _backend_name(backend: Any) -> str | None:
+    name = getattr(backend, "name", backend)
+    return name.upper() if isinstance(name, str) else None
+
+
+def is_glm53_full_graph_path(vllm_config: VllmConfig | None) -> bool:
+    """Return whether a config selects the qualified mixed FULL graph path."""
+    if vllm_config is None:
+        return False
+    hf_config = vllm_config.model_config.hf_text_config
+    if getattr(hf_config, "model_type", None) not in {
+        "glm5_next",
+        "glm5_next_text",
+    }:
+        return False
+    if any(getattr(hf_config, name, None) != value for name, value in _RECIPE.items()):
+        return False
+    if _backend_name(vllm_config.attention_config.backend) != "B12X":
+        return False
+    parallel = vllm_config.parallel_config
+    if (
+        parallel.tensor_parallel_size != 4
+        or parallel.decode_context_parallel_size != 4
+        or parallel.cp_kv_cache_interleave_size != 4
+    ):
+        return False
+    speculative = vllm_config.speculative_config
+    return speculative is not None and speculative.num_speculative_tokens == 3
+
+
+def require_glm53_full_graph_capacity(vllm_config: VllmConfig) -> None:
+    """Fail closed when scheduler bounds exceed qualified static arenas."""
+    scheduler = vllm_config.scheduler_config
+    if not 0 < scheduler.max_num_seqs <= MAX_FULL_GRAPH_SEQS:
+        raise ValueError(
+            "GLM-5.3 mixed FULL max_num_seqs exceeds the qualified "
+            f"capacity: {scheduler.max_num_seqs} > {MAX_FULL_GRAPH_SEQS}"
+        )
+    if not 0 < scheduler.max_num_batched_tokens <= MAX_FULL_GRAPH_TOKENS:
+        raise ValueError(
+            "GLM-5.3 mixed FULL max_num_batched_tokens exceeds the qualified "
+            f"capacity: {scheduler.max_num_batched_tokens} > "
+            f"{MAX_FULL_GRAPH_TOKENS}"
+        )

--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
@@ -18,6 +18,10 @@ from vllm.model_executor.layers.attention.sparse_mla_attention import (
     SparseMLACommonImpl,
     SparseMLACommonMetadataBuilder,
 )
+from vllm.models.glm5next_cudagraph import (
+    is_glm53_full_graph_path,
+    require_glm53_full_graph_capacity,
+)
 from vllm.platforms.interface import DeviceCapability
 from vllm.utils.b12x import get_b12x_sparse_mla
 from vllm.v1.attention.backend import (
@@ -34,7 +38,11 @@ from vllm.v1.attention.backends.mla.sparse_utils import (
     triton_filter_and_convert_dcp_index,
 )
 from vllm.v1.attention.backends.utils import get_dcp_local_seq_lens
-from vllm.v1.kv_cache_interface import AttentionSpec, MLAAttentionSpec
+from vllm.v1.kv_cache_interface import (
+    AttentionSpec,
+    KVCacheSpec,
+    MLAAttentionSpec,
+)
 from vllm.v1.kv_cache_layout import KVCacheLayout
 from vllm.v1.worker.workspace import (
     current_workspace_manager,
@@ -586,6 +594,35 @@ class B12xGLM5NextMLASparseMetadataBuilder(B12xMLASparseMetadataBuilder):
     # The pooled selector must commit every fresh or extended prompt row
     # through run_prefill; decode commits only accepted prior rows.
     treat_short_extends_as_decodes: ClassVar[bool] = False
+    _glm53_graph_safe_selector_marker = "fixed-address-vectorized-pooled-selector-v1"
+
+    @classmethod
+    def get_cudagraph_support(
+        cls,
+        vllm_config: VllmConfig,
+        kv_cache_spec: KVCacheSpec,
+    ) -> AttentionCGSupport:
+        if (
+            not isinstance(kv_cache_spec, AttentionSpec)
+            or not is_glm53_full_graph_path(vllm_config)
+            or kv_cache_spec.block_size != 2304
+            or kv_cache_spec.head_size != 512
+            or getattr(kv_cache_spec, "model_version", None) != "glm5_next"
+        ):
+            return AttentionCGSupport.UNIFORM_BATCH
+        require_glm53_full_graph_capacity(vllm_config)
+        from vllm.v1.attention.backends.gdn_attn import (
+            GDNAttentionMetadataBuilder,
+        )
+
+        marker = getattr(
+            GDNAttentionMetadataBuilder,
+            "_glm53_graph_safe_gdn_marker",
+            None,
+        )
+        if marker != "fixed-address-gdn-metadata-v1":
+            raise RuntimeError("GLM-5.3 mixed FULL requires graph-safe GDN metadata")
+        return AttentionCGSupport.ALWAYS
 
 
 class B12xMLASparseImpl(SparseMLACommonImpl[B12xMLASparseMetadata]):

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -2,8 +2,9 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import gc
 from collections import defaultdict
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
+from enum import Enum, auto
 from itertools import groupby, product
 from typing import TYPE_CHECKING, Any, NamedTuple, Protocol
 
@@ -51,10 +52,77 @@ class AttentionState(NamedTuple):
     slot_mappings: dict[str, torch.Tensor]
 
 
+class TargetExecutionBranch(Enum):
+    """Python/kernel branch captured by a target FULL graph."""
+
+    UNSPECIFIED = auto()
+    PREFILL = auto()
+    SPEC_DECODE = auto()
+    DECODE = auto()
+
+
+def derive_target_execution_branch(
+    *, has_prefill: bool, has_spec_decode: bool
+) -> TargetExecutionBranch:
+    if has_prefill:
+        return TargetExecutionBranch.PREFILL
+    if has_spec_decode:
+        return TargetExecutionBranch.SPEC_DECODE
+    return TargetExecutionBranch.DECODE
+
+
+def _request_count_is_compatible(
+    captured: int | None,
+    runtime: int,
+    branch: TargetExecutionBranch,
+    *,
+    branch_specialized: bool,
+) -> bool:
+    if captured is None:
+        return True
+    if branch_specialized and branch in {
+        TargetExecutionBranch.DECODE,
+        TargetExecutionBranch.SPEC_DECODE,
+    }:
+        return captured == runtime
+    return captured >= runtime
+
+
+def _branch_geometries(
+    num_tokens: int,
+    max_num_reqs: int,
+    decode_query_len: int,
+) -> list[tuple[TargetExecutionBranch, int, int | None, int | None]]:
+    prefill_reqs = min(num_tokens, max_num_reqs)
+    geometries: list[tuple[TargetExecutionBranch, int, int | None, int | None]] = [
+        (
+            TargetExecutionBranch.PREFILL,
+            prefill_reqs,
+            None,
+            (num_tokens + prefill_reqs - 1) // prefill_reqs,
+        )
+    ]
+    if num_tokens <= max_num_reqs:
+        geometries.append((TargetExecutionBranch.DECODE, num_tokens, 1, None))
+    if (
+        decode_query_len > 1
+        and num_tokens % decode_query_len == 0
+        and num_tokens // decode_query_len <= max_num_reqs
+    ):
+        geometries.append(
+            (
+                TargetExecutionBranch.SPEC_DECODE,
+                num_tokens // decode_query_len,
+                decode_query_len,
+                None,
+            )
+        )
+    return geometries
+
+
 @dataclass(frozen=True)
 class BatchExecutionDescriptor:
-    """Describes the shape of the batch and CG mode to run; this is used to make shape
-    matches between the capture and runtime."""
+    """Describes the shape and execution branch captured by a CUDA graph."""
 
     cg_mode: CUDAGraphMode
     num_tokens: int
@@ -64,6 +132,7 @@ class BatchExecutionDescriptor:
     # uniform_token_count unset, so this is what keeps a prefill batch out of one.
     max_query_len: int | None = None
     num_active_loras: int = 0
+    target_execution_branch: TargetExecutionBranch = TargetExecutionBranch.UNSPECIFIED
 
 
 class CreateForwardFn(Protocol):
@@ -85,6 +154,9 @@ def _is_compatible(
     uniform_token_count: int | None,
     num_active_loras: int,
     max_query_len: int | None,
+    target_execution_branch: TargetExecutionBranch,
+    *,
+    branch_specialized: bool,
 ) -> bool:
     # desc.uniform_token_count=None (PIECEWISE) can handle any uniform_token_count
     # desc.num_reqs=None means no request padding needed (PIECEWISE)
@@ -92,6 +164,13 @@ def _is_compatible(
     # caller that does not track max_query_len must not match one that does
     return (
         (
+            not branch_specialized
+            or (
+                desc.target_execution_branch is not TargetExecutionBranch.UNSPECIFIED
+                and desc.target_execution_branch is target_execution_branch
+            )
+        )
+        and (
             desc.uniform_token_count is None
             or desc.uniform_token_count == uniform_token_count
         )
@@ -99,7 +178,12 @@ def _is_compatible(
             desc.max_query_len is None
             or (max_query_len is not None and desc.max_query_len >= max_query_len)
         )
-        and (desc.num_reqs is None or desc.num_reqs >= num_reqs)
+        and _request_count_is_compatible(
+            desc.num_reqs,
+            num_reqs,
+            target_execution_branch,
+            branch_specialized=branch_specialized,
+        )
         and desc.num_tokens >= num_tokens
         and desc.num_active_loras == num_active_loras
     )
@@ -125,6 +209,13 @@ class CudaGraphManager:
         self.decode_query_len = decode_query_len
         self.varlen_decode = varlen_decode
         self.full_capture_request_sizes = full_capture_request_sizes
+        self._branch_specialized_full_graphs = False
+        if cudagraph_mode.has_mode(CUDAGraphMode.FULL):
+            from vllm.models.glm5next_cudagraph import (
+                is_glm53_full_graph_path,
+            )
+
+            self._branch_specialized_full_graphs = is_glm53_full_graph_path(vllm_config)
 
         self.dp_size = vllm_config.parallel_config.data_parallel_size
         self.tp_size = vllm_config.parallel_config.tensor_parallel_size
@@ -260,14 +351,35 @@ class CudaGraphManager:
             # Varlen decode graphs take any mix of 1..decode_query_len tokens per
             # request, worst case 1 token per request (or max_num_reqs)
             if capture_varlen_decode and num_tokens <= max_decode_tokens:
-                desc = BatchExecutionDescriptor(
-                    cg_mode=decode_mode,
-                    num_tokens=num_tokens,
-                    num_reqs=min(num_tokens, self.max_num_reqs),
-                    max_query_len=self.decode_query_len,
-                    num_active_loras=num_active_loras,
-                )
-                descs_by_mode[decode_mode].append(desc)
+                if self._branch_specialized_full_graphs:
+                    max_reqs = min(num_tokens, self.max_num_reqs)
+                    for num_reqs in range(1, max_reqs + 1):
+                        if num_tokens == num_reqs:
+                            branches = (TargetExecutionBranch.DECODE,)
+                        elif num_tokens <= num_reqs * self.decode_query_len:
+                            branches = (TargetExecutionBranch.SPEC_DECODE,)
+                        else:
+                            continue
+                        for branch in branches:
+                            descs_by_mode[decode_mode].append(
+                                BatchExecutionDescriptor(
+                                    cg_mode=decode_mode,
+                                    num_tokens=num_tokens,
+                                    num_reqs=num_reqs,
+                                    max_query_len=self.decode_query_len,
+                                    num_active_loras=num_active_loras,
+                                    target_execution_branch=branch,
+                                )
+                            )
+                else:
+                    desc = BatchExecutionDescriptor(
+                        cg_mode=decode_mode,
+                        num_tokens=num_tokens,
+                        num_reqs=min(num_tokens, self.max_num_reqs),
+                        max_query_len=self.decode_query_len,
+                        num_active_loras=num_active_loras,
+                    )
+                    descs_by_mode[decode_mode].append(desc)
             # Capture uniform decode specfifc graphs if required
             #  (i.e. separate decode routine)
             elif separate_decode_routine and decode_mode and not self.varlen_decode:
@@ -287,12 +399,20 @@ class CudaGraphManager:
                     ):
                         continue
 
+                    target_branch = TargetExecutionBranch.UNSPECIFIED
+                    if self._branch_specialized_full_graphs:
+                        target_branch = (
+                            TargetExecutionBranch.SPEC_DECODE
+                            if decode_query_len > 1
+                            else TargetExecutionBranch.DECODE
+                        )
                     desc = BatchExecutionDescriptor(
                         cg_mode=decode_mode,
                         num_tokens=rounded_num_tokens,
                         num_reqs=rounded_num_reqs,
                         uniform_token_count=decode_query_len,
                         num_active_loras=num_active_loras,
+                        target_execution_branch=target_branch,
                     )
 
                     # avoid duplicate graphs
@@ -305,16 +425,51 @@ class CudaGraphManager:
                 # For breakable PW graphs, break-point kernels read the real batch
                 # from the forward context; in-graph kernels handle the token padding
                 # themselves from the padded slot_mapping (rows with slot == -1).
-                num_reqs = None
-                if mixed_mode == CUDAGraphMode.FULL:
-                    num_reqs = min(num_tokens, self.max_num_reqs)
-                desc = BatchExecutionDescriptor(
-                    cg_mode=mixed_mode,
-                    num_tokens=num_tokens,
-                    num_reqs=num_reqs,
-                    num_active_loras=num_active_loras,
-                )
-                descs_by_mode[mixed_mode].append(desc)
+                geometries: Sequence[
+                    tuple[
+                        TargetExecutionBranch,
+                        int | None,
+                        int | None,
+                        int | None,
+                    ]
+                ] = [
+                    (
+                        TargetExecutionBranch.UNSPECIFIED,
+                        None,
+                        None,
+                        None,
+                    )
+                ]
+                if (
+                    mixed_mode == CUDAGraphMode.FULL
+                    and self._branch_specialized_full_graphs
+                ):
+                    geometries = _branch_geometries(
+                        num_tokens,
+                        self.max_num_reqs,
+                        self.decode_query_len,
+                    )
+                elif mixed_mode == CUDAGraphMode.FULL:
+                    geometries = [
+                        (
+                            TargetExecutionBranch.UNSPECIFIED,
+                            min(num_tokens, self.max_num_reqs),
+                            None,
+                            None,
+                        )
+                    ]
+                for branch, num_reqs, uniform_count, max_query_len in geometries:
+                    descs_by_mode[mixed_mode].append(
+                        BatchExecutionDescriptor(
+                            cg_mode=mixed_mode,
+                            num_tokens=num_tokens,
+                            num_reqs=num_reqs,
+                            uniform_token_count=uniform_count,
+                            max_query_len=max_query_len,
+                            num_active_loras=num_active_loras,
+                            target_execution_branch=branch,
+                        )
+                    )
 
         for mode, descs in descs_by_mode.items():
             descs.sort(key=lambda d: d.num_tokens, reverse=True)
@@ -439,6 +594,9 @@ class CudaGraphManager:
         uniform_token_count: int | None,
         num_active_loras: int,
         max_query_len: int | None = None,
+        target_execution_branch: TargetExecutionBranch = (
+            TargetExecutionBranch.UNSPECIFIED
+        ),
     ) -> BatchExecutionDescriptor:
         """Find matching cudagraph descriptor from priority-ordered candidates."""
 
@@ -453,6 +611,8 @@ class CudaGraphManager:
                     uniform_token_count,
                     effective_loras,
                     max_query_len,
+                    target_execution_branch,
+                    branch_specialized=self._branch_specialized_full_graphs,
                 ):
                     return desc
         return BatchExecutionDescriptor(
@@ -460,6 +620,7 @@ class CudaGraphManager:
             num_tokens=num_tokens,
             num_reqs=num_reqs,
             num_active_loras=effective_loras,
+            target_execution_branch=target_execution_branch,
         )
 
     def run_fullgraph(self, desc: BatchExecutionDescriptor):
@@ -574,6 +735,7 @@ class ModelCudaGraphManager(CudaGraphManager):
                 kv_cache_config,
                 full_cudagraph=desc.cg_mode == CUDAGraphMode.FULL,
                 max_query_len=desc.max_query_len,
+                target_execution_branch=desc.target_execution_branch,
             )
 
             # Capture with dummy rows marked as padding.
@@ -666,10 +828,20 @@ def prepare_inputs_to_capture(
     kv_cache_config: KVCacheConfig,
     full_cudagraph: bool,
     max_query_len: int | None = None,
+    target_execution_branch: TargetExecutionBranch = (
+        TargetExecutionBranch.UNSPECIFIED
+    ),
 ) -> AttentionState:
     input_batch = InputBatch.make_dummy(
         num_reqs, num_tokens, input_buffers, max_query_len=max_query_len
     )
+    if target_execution_branch is TargetExecutionBranch.PREFILL:
+        input_batch.is_prefilling_np.fill(True)
+        input_batch.prefill_len_np[:] = input_batch.num_scheduled_tokens
+        input_batch.num_computed_prefill_tokens_np.fill(0)
+        input_batch.has_prefill = True
+    elif target_execution_branch is TargetExecutionBranch.DECODE:
+        assert num_tokens == num_reqs
     input_block_tables = block_tables.get_dummy_block_tables(num_reqs)
     slot_mappings = block_tables.get_dummy_slot_mappings(num_tokens)
     slot_mappings_by_layer = build_slot_mappings_by_layer(

--- a/vllm/v1/worker/gpu/dp_utils.py
+++ b/vllm/v1/worker/gpu/dp_utils.py
@@ -10,6 +10,7 @@ from vllm.distributed.parallel_state import get_dp_group
 from vllm.v1.worker.gpu.cudagraph_utils import (
     BatchExecutionDescriptor,
     CudaGraphManager,
+    TargetExecutionBranch,
 )
 
 
@@ -23,6 +24,9 @@ def sync_cudagraph_and_dp_padding(
     dp_rank: int,
     max_query_len: int | None = None,
     num_active_loras: int = 0,
+    target_execution_branch: TargetExecutionBranch = (
+        TargetExecutionBranch.UNSPECIFIED
+    ),
 ) -> tuple[BatchExecutionDescriptor, torch.Tensor | None]:
     """
     Coordinates the batch descriptor and DP padding across all ranks.
@@ -87,6 +91,7 @@ def sync_cudagraph_and_dp_padding(
         synced_uniform_token_count,
         num_active_loras=num_active_loras,
         max_query_len=synced_max_query_len,
+        target_execution_branch=target_execution_branch,
     )
 
     # Update num_tokens_across_dp to reflect padded size.
@@ -105,6 +110,9 @@ def dispatch_cg_and_sync_dp(
     max_query_len: int | None = None,
     need_eager: bool = False,
     num_active_loras: int = 0,
+    target_execution_branch: TargetExecutionBranch = (
+        TargetExecutionBranch.UNSPECIFIED
+    ),
 ) -> tuple[BatchExecutionDescriptor, torch.Tensor | None]:
     if need_eager:
         batch_desc = BatchExecutionDescriptor(
@@ -112,6 +120,7 @@ def dispatch_cg_and_sync_dp(
             num_tokens=num_tokens,
             num_reqs=num_reqs,
             num_active_loras=num_active_loras,
+            target_execution_branch=target_execution_branch,
         )
     else:
         assert cudagraph_manager is not None, (
@@ -124,6 +133,7 @@ def dispatch_cg_and_sync_dp(
             uniform_token_count,
             num_active_loras=num_active_loras,
             max_query_len=max_query_len,
+            target_execution_branch=target_execution_branch,
         )
 
     if dp_size == 1:
@@ -139,4 +149,5 @@ def dispatch_cg_and_sync_dp(
         dp_rank,
         max_query_len=max_query_len,
         num_active_loras=num_active_loras,
+        target_execution_branch=target_execution_branch,
     )

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -93,6 +93,7 @@ from vllm.v1.worker.gpu.cp_utils import prepare_dcp_local_seq_lens
 from vllm.v1.worker.gpu.cudagraph_utils import (
     BatchExecutionDescriptor,
     ModelCudaGraphManager,
+    derive_target_execution_branch,
 )
 from vllm.v1.worker.gpu.cudagraph_utils import (
     profile_cudagraph_memory as _profile_cudagraph_memory,
@@ -1542,6 +1543,10 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             # cross-attention cache with dynamic encoder outputs.
             skip_compiled = True
 
+        target_execution_branch = derive_target_execution_branch(
+            has_prefill=bool(batch_req_state and batch_req_state.has_prefill),
+            has_spec_decode=bool(scheduler_output.scheduled_spec_decode_tokens),
+        )
         batch_desc, num_tokens_across_dp = dispatch_cg_and_sync_dp(
             self.cudagraph_manager,
             num_reqs,
@@ -1552,6 +1557,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             max_query_len=max_query_len,
             need_eager=is_profile or skip_compiled,
             num_active_loras=num_active_loras,
+            target_execution_branch=target_execution_branch,
         )
 
         if batch_desc.num_tokens == 0:

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -212,7 +212,11 @@ from vllm.v1.spec_decode.step3p5 import Step3p5MTPProposer
 from vllm.v1.spec_decode.suffix_decoding import SuffixDecodingProposer
 from vllm.v1.spec_decode.utils import update_num_computed_tokens_for_batch_change
 from vllm.v1.structured_output.utils import apply_grammar_bitmask
-from vllm.v1.utils import CpuGpuBuffer, record_function_or_nullcontext
+from vllm.v1.utils import (
+    CpuGpuBuffer,
+    compute_iteration_details,
+    record_function_or_nullcontext,
+)
 from vllm.v1.worker import mamba_utils
 from vllm.v1.worker.block_table import SlotMappingMode
 from vllm.v1.worker.cp_utils import (
@@ -4012,6 +4016,17 @@ class GPUModelRunner(
             else force_uniform_decode
         )
 
+    @staticmethod
+    def _compute_force_uniform_decode(
+        scheduler_output: "SchedulerOutput",
+        is_hybrid: bool,
+    ) -> bool | None:
+        if not is_hybrid:
+            return None
+        if compute_iteration_details(scheduler_output).num_ctx_requests > 0:
+            return False
+        return None
+
     def _allow_microbatching(
         self, num_reqs: int, num_scheduled_tokens_np: np.ndarray
     ) -> bool:
@@ -4386,6 +4401,9 @@ class GPUModelRunner(
                     scheduler_output.num_common_prefix_blocks,
                 )
 
+            force_uniform_decode = self._compute_force_uniform_decode(
+                scheduler_output, self.model_config.is_hybrid
+            )
             (
                 cudagraph_mode,
                 batch_desc,
@@ -4402,7 +4420,14 @@ class GPUModelRunner(
                 allow_microbatching=self._allow_microbatching(
                     num_reqs, num_scheduled_tokens_np
                 ),
+                force_uniform_decode=force_uniform_decode,
             )
+
+            if force_uniform_decode is False and cudagraph_mode == CUDAGraphMode.FULL:
+                raise RuntimeError(
+                    "hybrid prefill or mixed batch was dispatched to a FULL "
+                    "decode graph"
+                )
 
             logger.debug(
                 "Running batch with cudagraph_mode: %s, batch_descriptor: %s, "


### PR DESCRIPTION
## Summary

Extracts the GLM-5.3 CUDA-graph routing and replay contract from the D16 reference PR into one reviewable feature.

### Behavior

- preserves `FULL_DECODE_ONLY` and `PIECEWISE` fallback behavior
- enables `FULL` only for the qualified GLM/B12X profile
- keys target graphs by execution branch: `PREFILL`, `SPEC_DECODE`, `DECODE`
- keys decode/spec-decode graphs by exact live request count
- rejects cross-branch or larger-row fallback instead of silently replaying incompatible captures
- synchronizes branch selection across DP ranks and falls back to eager when ranks disagree
- preserves correct dummy-run branch selection during capture

This includes the production outcomes from private D16 commits `e0f8f9d`, `eb39710`, `bbf1efb`, `e5c0a70`, `3527013`, and `fb931d2`; diagnostic-only tracing commits are intentionally excluded.

## Why separate

Supersedes the graph portion of #522 after maintainer feedback that the complete stack was too large to review. LMCache, persistent metadata, lifecycle, and benchmark evidence are split into subsequent PRs.

## Verification

- AST parse: 8 changed Python files
- `git diff --check`: clean
- D16 runtime qualification on 4× RTX PRO 6000 Blackwell:
  - exact 1M context
  - TP4 / DCP4 / MTP3
  - correct 199,974-token retrieval
  - C1 regression restored from ~22 tok/s to qualified behavior
  - no OOM, CUDA error, or restart during qualification

Broad CI is intentionally delegated to repository CI; the controller was not used for GPU builds or full-suite execution.

## AI assistance disclosure

AI assistance was used for implementation and test construction. Devin Kuhn reviewed and directed the end-to-end behavior.

## Final D22 production receipt (2026-08-30)

The reviewed production derivative captured FULL target, prefill, decode, and MTP graphs on TP4/DCP4 without global `CUDA_LAUNCH_BLOCKING`. All four ranks completed graph capture in 6 seconds with 0.96 GiB capture memory per rank. The live container remained healthy with restart count 0 and no Xid, illegal memory access, CUDA error, OOM, EngineDead, or `lockhandle` output.

Fleet-owned immutable deployment receipt: Apple-Federal-Credit-Union/fleet-infra#309.
