### PR TITLE
feat(glm53): stabilize hybrid graph metadata

### DIFF
--- a/tests/models/kimi_k3/test_kda.py
+++ b/tests/models/kimi_k3/test_kda.py
@@ -33,6 +33,7 @@ from vllm.models.kimi_k3.nvidia.ops.recoverssm import (
     KDARecoverSSMCommitContext,
     kda_recoverssm_verify,
 )
+from vllm.models.kimi_k3.nvidia.ops.third_party.kda import chunk as kda_chunk
 from vllm.models.kimi_k3.nvidia.ops.third_party.kda import (
     chunk_kda,
     chunk_kda_with_fused_gate,
@@ -51,6 +52,60 @@ pytestmark = pytest.mark.skipif(
     not (current_platform.is_cuda_alike() or current_platform.is_xpu()),
     reason="The KDA kernels require a CUDA-alike or XPU device.",
 )
+
+
+def test_kda_threads_precomputed_chunk_offsets(monkeypatch) -> None:
+    sentinel = torch.tensor([0, 2], dtype=torch.int32)
+    captured: dict[str, torch.Tensor | None] = {}
+
+    monkeypatch.setattr(kda_chunk, "chunk_local_cumsum", lambda value, **_: value)
+
+    def capture(**kwargs):
+        captured.update(kwargs)
+        return kwargs["v"], None
+
+    monkeypatch.setattr(kda_chunk, "_chunk_kda_fwd_with_cumulative_g", capture)
+    tensor = torch.empty((1, 2, 1, 2))
+    kda_chunk.chunk_kda_fwd(
+        q=tensor,
+        k=tensor,
+        v=tensor,
+        g=tensor,
+        beta=tensor,
+        scale=1.0,
+        initial_state=tensor,
+        output_final_state=False,
+        chunk_indices=sentinel,
+        chunk_offsets=sentinel,
+    )
+
+    assert captured["chunk_indices"] is sentinel
+    assert captured["chunk_offsets"] is sentinel
+
+    captured.clear()
+    monkeypatch.setattr(
+        kda_chunk,
+        "fused_kda_gate_chunk_cumsum",
+        lambda raw_g, raw_beta, **_: (raw_g, raw_beta),
+    )
+    kda_chunk.chunk_kda_with_fused_gate_fwd(
+        q=tensor,
+        k=tensor,
+        v=tensor,
+        raw_g=tensor,
+        raw_beta=tensor,
+        A_log=tensor,
+        g_bias=None,
+        scale=1.0,
+        initial_state=tensor,
+        output_final_state=False,
+        chunk_indices=sentinel,
+        chunk_offsets=sentinel,
+    )
+
+    assert captured["chunk_indices"] is sentinel
+    assert captured["chunk_offsets"] is sentinel
+
 
 # The AMD and NVIDIA copies of the KDA kernels are vendored separately and are
 # free to diverge, so the shared-semantics tests below run against both.

--- a/tests/models/test_glm5next_pooled_indexer.py
+++ b/tests/models/test_glm5next_pooled_indexer.py
@@ -17,7 +17,14 @@ from vllm.models.glm5next.nvidia.ops.glm_kpool import (
     pool_seq_lens,
     update_decode_pools,
 )
-from vllm.models.glm5next.nvidia.pooled_indexer import Glm5NextPooledIndexer
+from vllm.models.glm5next.nvidia.pooled_indexer import (
+    Glm5NextPooledIndexer,
+    _PersistentPooledSelectorArena,
+)
+from vllm.models.glm5next_cudagraph import (
+    is_glm53_full_graph_path,
+    require_glm53_full_graph_capacity,
+)
 from vllm.platforms import current_platform
 from vllm.v1.attention.backends.mla.b12x_mla_sparse import B12xMLASparseMetadata
 from vllm.v1.kv_cache_interface import MLAAttentionSpec
@@ -35,6 +42,75 @@ def _require_glm_gpu() -> torch.device:
     ):
         pytest.skip("GLM-5.3 GPU tests require SM120 or SM121")
     return device
+
+
+def _glm53_full_config() -> SimpleNamespace:
+    return SimpleNamespace(
+        model_config=SimpleNamespace(
+            hf_text_config=SimpleNamespace(
+                model_type="glm5_next",
+                kv_lora_rank=512,
+                qk_nope_head_dim=256,
+                qk_rope_head_dim=0,
+                v_head_dim=256,
+                index_n_heads=32,
+                index_head_dim=128,
+                index_topk=2048,
+                index_kpool=4,
+            )
+        ),
+        attention_config=SimpleNamespace(backend="B12X"),
+        parallel_config=SimpleNamespace(
+            tensor_parallel_size=4,
+            decode_context_parallel_size=4,
+            cp_kv_cache_interleave_size=4,
+        ),
+        scheduler_config=SimpleNamespace(
+            max_num_seqs=4,
+            max_num_batched_tokens=32768,
+        ),
+        speculative_config=SimpleNamespace(num_speculative_tokens=3),
+    )
+
+
+def test_glm53_full_graph_gate_is_exact_and_bounded() -> None:
+    config = _glm53_full_config()
+    assert is_glm53_full_graph_path(config)
+    require_glm53_full_graph_capacity(config)
+
+    config.parallel_config.decode_context_parallel_size = 1
+    assert not is_glm53_full_graph_path(config)
+    config.parallel_config.decode_context_parallel_size = 4
+    config.scheduler_config.max_num_seqs = 9
+    with pytest.raises(ValueError, match="max_num_seqs"):
+        require_glm53_full_graph_capacity(config)
+
+
+def test_glm53_selector_arena_preserves_replay_addresses() -> None:
+    arena = _PersistentPooledSelectorArena(
+        max_num_seqs=4,
+        max_num_batched_tokens=16,
+        pool_table_width=8,
+        device=torch.device("cpu"),
+    )
+    pointers = (
+        arena.query_start_loc.data_ptr(),
+        arena.row_request_ids.data_ptr(),
+        arena.token_block_table.data_ptr(),
+    )
+    arena.stage_replay_metadata(
+        query_start_loc=torch.tensor([0, 4, 8], dtype=torch.int32),
+        req_id_per_token=torch.tensor([0] * 4 + [1] * 4, dtype=torch.int32),
+        num_reqs=2,
+        live_rows=8,
+    )
+    assert pointers == (
+        arena.query_start_loc.data_ptr(),
+        arena.row_request_ids.data_ptr(),
+        arena.token_block_table.data_ptr(),
+    )
+    with pytest.raises(ValueError, match="token capacity"):
+        arena.require_fits(num_reqs=2, num_tokens=17, pool_table_width=8)
 
 
 def _hadamard128(x: torch.Tensor) -> torch.Tensor:

--- a/tests/v1/attention/test_gdn_metadata_builder.py
+++ b/tests/v1/attention/test_gdn_metadata_builder.py
@@ -17,12 +17,31 @@ from vllm.config.compilation import CUDAGraphMode
 from vllm.v1.attention.backends.gdn_attn import (
     GDNAttentionMetadata,
     GDNAttentionMetadataBuilder,
+    _PersistentGDNMetadataArena,
 )
 from vllm.v1.attention.backends.utils import mamba_get_block_table_tensor
 from vllm.v1.kv_cache_interface import MambaSpec
 
 BLOCK_SIZE = 16
 DEVICE = torch.device("cpu")
+
+
+def test_gdn_metadata_arena_has_fixed_bounded_storage() -> None:
+    arena = _PersistentGDNMetadataArena(
+        max_num_seqs=4,
+        max_num_batched_tokens=32,
+        num_spec=3,
+        device=DEVICE,
+    )
+    pointer = arena.query_start_loc.data_ptr()
+    staged = arena.stage(
+        arena.query_start_loc,
+        torch.tensor([0, 4, 8], dtype=torch.int32),
+    )
+    assert staged.data_ptr() == pointer
+    assert arena.query_start_loc.data_ptr() == pointer
+    with pytest.raises(ValueError, match="token capacity"):
+        arena.require_fits(num_reqs=4, num_tokens=33)
 
 
 @dataclass

--- a/vllm/model_executor/layers/mamba/gdn/kimi_gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn/kimi_gdn_linear_attn.py
@@ -308,6 +308,7 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
         self.o_norm = FusedRMSNormGated(self.head_dim, activation="sigmoid")
         self._b12x_kda_api: Any | None = None
         self._b12x_kda_plan = None
+        self._b12x_kda_binding = None
         self._initialize_b12x_kda_decode(vllm_config)
         self.o_proj = RowParallelLinear(
             self.projection_size,
@@ -343,20 +344,75 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
         ):
             return
 
-        max_seqs = int(vllm_config.scheduler_config.max_num_seqs)
+        max_live_seqs = int(vllm_config.scheduler_config.max_num_seqs)
         state_index_columns = max(1, self.num_spec + 1)
         if state_index_columns > 8:
             return
-        max_tokens = max_seqs * state_index_columns
+        max_decode_tokens = max_live_seqs * state_index_columns
+        max_cudagraph_tokens = int(
+            vllm_config.compilation_config.max_cudagraph_capture_size or 0
+        )
+        max_tokens = max(max_decode_tokens, max_cudagraph_tokens)
+        plan_max_seqs = max(
+            max_live_seqs,
+            (max_tokens + state_index_columns - 1) // state_index_columns,
+        )
 
         self._b12x_kda_api = api
         self._b12x_kda_max_tokens = max_tokens
-        self._b12x_kda_max_seqs = max_seqs
+        self._b12x_kda_max_live_seqs = max_live_seqs
+        self._b12x_kda_plan_max_seqs = plan_max_seqs
         self._b12x_kda_state_index_columns = state_index_columns
+        null_state_index = self.b12x_kda_null_state_index
+        self._b12x_kda_null_state_index = (
+            -1 if null_state_index is None else int(null_state_index)
+        )
 
+        provisional = self._make_b12x_kda_plan(max_state_slots=1)
+        factory = dict(device=device, dtype=torch.bfloat16)
+        self.register_buffer(
+            "_b12x_kda_mixed_qkv",
+            torch.empty(max_tokens, provisional.caps.packed_qkv_width, **factory),
+            persistent=False,
+        )
+        self.register_buffer(
+            "_b12x_kda_raw_g",
+            torch.empty(max_tokens, self.local_num_heads, self.head_dim, **factory),
+            persistent=False,
+        )
+        self.register_buffer(
+            "_b12x_kda_raw_beta",
+            torch.empty(max_tokens, self.local_num_heads, **factory),
+            persistent=False,
+        )
+        self.register_buffer(
+            "_b12x_kda_z",
+            torch.empty(max_tokens, self.local_num_heads, self.head_dim, **factory),
+            persistent=False,
+        )
+        self.register_buffer(
+            "_b12x_kda_output",
+            torch.empty(max_tokens, self.local_num_heads, self.head_dim, **factory),
+            persistent=False,
+        )
+        self.register_buffer(
+            "_b12x_kda_query_start_loc",
+            torch.zeros(plan_max_seqs + 1, dtype=torch.int32, device=device),
+            persistent=False,
+        )
         self.register_buffer(
             "_b12x_kda_num_accepted_tokens",
-            torch.ones(max_seqs, dtype=torch.int32, device=device),
+            torch.ones(plan_max_seqs, dtype=torch.int32, device=device),
+            persistent=False,
+        )
+        self.register_buffer(
+            "_b12x_kda_state_indices",
+            torch.full(
+                (plan_max_seqs, state_index_columns),
+                self._b12x_kda_null_state_index,
+                dtype=torch.int32,
+                device=device,
+            ),
             persistent=False,
         )
         self.register_buffer(
@@ -379,7 +435,7 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
             api.Caps(
                 device=current_platform.current_device(),
                 max_tokens=self._b12x_kda_max_tokens,
-                max_seqs=self._b12x_kda_max_seqs,
+                max_seqs=self._b12x_kda_plan_max_seqs,
                 max_state_slots=max_state_slots,
                 key_heads=self.local_num_heads,
                 value_heads=self.local_num_heads,
@@ -390,8 +446,7 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
                 state_dtype=self.get_state_dtype()[1],
                 gate_activation="sigmoid",
                 qk_l2norm=True,
-                null_state_index=self.b12x_kda_null_state_index,
-                kda_metadata_validation="trusted",
+                null_state_index=self._b12x_kda_null_state_index,
             )
         )
 
@@ -405,8 +460,27 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
         (scratch,) = get_b12x_scratch_buffers(plan)
         self._b12x_kda_scratch = scratch
         self._b12x_kda_plan = plan
+        self._b12x_kda_binding = api.bind_kda(
+            plan,
+            scratch=scratch,
+            mixed_qkv=self._b12x_kda_mixed_qkv,
+            raw_g=self._b12x_kda_raw_g,
+            raw_beta=self._b12x_kda_raw_beta,
+            z=self._b12x_kda_z,
+            A_log=self.A_log,
+            dt_bias=self.dt_bias.view(self.local_num_heads, self.head_dim),
+            norm_weight=self.o_norm.weight,
+            recurrent_state=recurrent_state,
+            query_start_loc=self._b12x_kda_query_start_loc,
+            num_accepted_tokens=self._b12x_kda_num_accepted_tokens,
+            state_indices=self._b12x_kda_state_indices,
+            num_seqs=self._b12x_kda_num_seqs,
+            num_tokens=self._b12x_kda_num_tokens,
+            output=self._b12x_kda_output,
+        )
 
     def unbind_kv_cache(self) -> None:
+        self._b12x_kda_binding = None
         self._b12x_kda_plan = None
         self._b12x_kda_scratch = None
         super().unbind_kv_cache()
@@ -423,8 +497,7 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
 
     def _can_use_b12x_kda_decode(self, m: GDNAttentionMetadata) -> bool:
         if (
-            self._b12x_kda_plan is None
-            or self._b12x_kda_scratch is None
+            self._b12x_kda_binding is None
             or m.num_prefills != 0
             or (m.num_decodes == 0 and m.num_spec_decodes == 0)
         ):
@@ -446,7 +519,6 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
     def _run_b12x_kda_decode_post_conv(
         self,
         *,
-        metadata: GDNAttentionMetadata,
         mixed_qkv: torch.Tensor,
         raw_g: torch.Tensor,
         raw_beta: torch.Tensor,
@@ -457,110 +529,54 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
         num_accepted_tokens: torch.Tensor | None,
         num_requests: int,
     ) -> None:
-        """Execute B12X KDA after the convolution projection.
-
-        Args:
-            metadata: Forward-context metadata used to share runtime-owned
-                packed metadata tensors across compatible layers.
-            mixed_qkv: Live packed query, key, and value projection.
-            raw_g: Live unactivated forget gate.
-            raw_beta: Live unactivated update gate.
-            z: Live output gate.
-            output: Caller-owned destination tensor.
-            state_indices: Packed recurrent-state indices.
-            query_start_loc: Packed request boundaries.
-            num_accepted_tokens: Accepted speculative-token counts, or ``None``
-                for one-token decode requests.
-            num_requests: Number of packed requests.
-
-        Raises:
-            RuntimeError: If the KDA plan or cache is unavailable.
-            ValueError: If the live batch exceeds the planned capacity.
-        """
+        binding = self._b12x_kda_binding
         api = self._b12x_kda_api
-        plan = self._b12x_kda_plan
-        scratch = self._b12x_kda_scratch
-        if api is None or plan is None or scratch is None:
+        if binding is None or api is None:
             raise RuntimeError("b12x KDA KV cache was not bound before inference")
         num_tokens = int(mixed_qkv.shape[0])
         state_columns = int(state_indices.shape[1])
         if (
             num_tokens > self._b12x_kda_max_tokens
-            or num_requests > self._b12x_kda_max_seqs
+            or num_requests > self._b12x_kda_max_live_seqs
             or state_columns > self._b12x_kda_state_index_columns
         ):
             raise ValueError(
                 "b12x KDA capacity exceeded: "
                 f"tokens={num_tokens}/{self._b12x_kda_max_tokens}, "
-                f"requests={num_requests}/{self._b12x_kda_max_seqs}, "
+                f"requests={num_requests}/{self._b12x_kda_max_live_seqs}, "
                 f"state_columns={state_columns}/"
                 f"{self._b12x_kda_state_index_columns}"
             )
 
-        forward_context = get_forward_context()
-        cache = forward_context.additional_kwargs.setdefault(
-            "b12x_kda_metadata_tensors", {}
+        self._b12x_kda_mixed_qkv[:num_tokens].copy_(mixed_qkv)
+        self._b12x_kda_raw_g[:num_tokens].copy_(raw_g)
+        self._b12x_kda_raw_beta[:num_tokens].copy_(raw_beta)
+        self._b12x_kda_z[:num_tokens].copy_(z)
+        self._b12x_kda_query_start_loc.zero_()
+        self._b12x_kda_query_start_loc[: num_requests + 1].copy_(
+            query_start_loc[: num_requests + 1]
         )
-        cache_key = (
-            id(metadata),
-            num_tokens,
-            num_requests,
-            state_columns,
-            plan.caps.max_state_slots,
+        self._b12x_kda_num_accepted_tokens.fill_(1)
+        if num_accepted_tokens is not None:
+            self._b12x_kda_num_accepted_tokens[:num_requests].copy_(
+                num_accepted_tokens[:num_requests]
+            )
+        self._b12x_kda_state_indices.fill_(self._b12x_kda_null_state_index)
+        self._b12x_kda_state_indices[:num_requests, :state_columns].copy_(
+            state_indices[:num_requests]
         )
-        bound_metadata = cache.get(cache_key)
-        if bound_metadata is None:
-            query_start_loc = query_start_loc[: num_requests + 1]
-            state_indices = state_indices[:num_requests, :state_columns]
-            if num_accepted_tokens is None:
-                accepted_tokens = self._b12x_kda_num_accepted_tokens[:num_requests]
-                accepted_tokens.fill_(1)
-            else:
-                accepted_tokens = num_accepted_tokens[:num_requests]
-            self._b12x_kda_num_seqs.fill_(num_requests)
-            self._b12x_kda_num_tokens.copy_(
-                query_start_loc[num_requests : num_requests + 1]
-            )
-            bound_metadata = (
-                query_start_loc,
-                accepted_tokens,
-                state_indices,
-                self._b12x_kda_num_seqs,
-                self._b12x_kda_num_tokens,
-            )
-            cache[cache_key] = bound_metadata
-        (
-            query_start_loc,
-            accepted_tokens,
-            state_indices,
-            num_seqs,
-            num_tokens_tensor,
-        ) = bound_metadata
+        self._b12x_kda_num_seqs.fill_(num_requests)
+        self._b12x_kda_num_tokens.copy_(
+            query_start_loc[num_requests : num_requests + 1]
+        )
 
-        binding = api.bind_kda(
-            plan,
-            scratch=scratch,
-            mixed_qkv=mixed_qkv,
-            raw_g=raw_g,
-            raw_beta=raw_beta,
-            z=z,
-            A_log=self.A_log,
-            dt_bias=self.dt_bias.view(self.local_num_heads, self.head_dim),
-            norm_weight=self.o_norm.weight,
-            recurrent_state=self.kv_cache[1],
-            query_start_loc=query_start_loc,
-            num_accepted_tokens=accepted_tokens,
-            state_indices=state_indices,
-            num_seqs=num_seqs,
-            num_tokens=num_tokens_tensor,
-            output=output,
-        )
         api.run_kda(
             binding,
             lower_bound=self.gate_lower_bound,
             eps=self.o_norm.eps,
             scale=self.head_dim**-0.5,
         )
+        output[:num_tokens].copy_(self._b12x_kda_output[:num_tokens])
 
     def forward(
         self,
@@ -747,7 +763,6 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
                 assert g2_spec is not None
                 core_attn_out_spec = core_attn_out[:, : mixed_qkv_spec.shape[0]]
                 self._run_b12x_kda_decode_post_conv(
-                    metadata=m,
                     mixed_qkv=mixed_qkv_spec,
                     raw_g=g1_spec[0],
                     raw_beta=beta_spec[0],
@@ -926,7 +941,6 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
                     assert g2_ns is not None
                     core_attn_out_non_spec = core_attn_out[:, : mixed_qkv_ns.shape[0]]
                     self._run_b12x_kda_decode_post_conv(
-                        metadata=m,
                         mixed_qkv=mixed_qkv_ns,
                         raw_g=g1_ns[0],
                         raw_beta=beta_ns[0],

--- a/vllm/models/glm5next/nvidia/pooled_indexer.py
+++ b/vllm/models/glm5next/nvidia/pooled_indexer.py
@@ -11,7 +11,6 @@ import torch
 import torch.nn.functional as F
 from torch import nn
 
-from vllm.compilation.breakable_cudagraph import eager_break_during_capture
 from vllm.config import CacheConfig, CUDAGraphMode, VllmConfig
 from vllm.distributed import get_dcp_group
 from vllm.forward_context import get_forward_context
@@ -47,6 +46,69 @@ _INDEX_CACHE_WIDTH = 132
 _INDEX_PAGE_SIZE = 64
 _INDEX_PAGE_BYTES = _INDEX_PAGE_SIZE * _INDEX_CACHE_WIDTH
 _MLA_RECORD_BYTES = 528
+
+
+class _PersistentPooledSelectorArena:
+    """Fixed-address selector metadata and workspaces."""
+
+    def __init__(
+        self,
+        *,
+        max_num_seqs: int,
+        max_num_batched_tokens: int,
+        pool_table_width: int,
+        device: torch.device,
+    ) -> None:
+        if min(max_num_seqs, max_num_batched_tokens, pool_table_width) <= 0:
+            raise ValueError("GLM selector arena capacities must be positive")
+        self.request_rows = max_num_seqs
+        self.token_rows = max_num_batched_tokens
+        self.pool_table_width = pool_table_width
+        self.request_block_table = torch.empty(
+            (max_num_seqs, pool_table_width),
+            dtype=torch.int32,
+            device=device,
+        )
+        self.token_block_table = torch.empty(
+            (max_num_batched_tokens, pool_table_width),
+            dtype=torch.int32,
+            device=device,
+        )
+        self.pool_seq_lens = torch.empty(
+            max_num_batched_tokens, dtype=torch.int32, device=device
+        )
+        self.pool_scores = torch.empty(
+            (max_num_batched_tokens, _POOL_TOPK),
+            dtype=torch.float32,
+            device=device,
+        )
+        self.query_start_loc = torch.empty(
+            max_num_seqs + 1, dtype=torch.int32, device=device
+        )
+        self.row_request_ids = torch.empty(
+            max_num_batched_tokens, dtype=torch.int32, device=device
+        )
+
+    def require_fits(
+        self, *, num_reqs: int, num_tokens: int, pool_table_width: int
+    ) -> None:
+        if num_reqs > self.request_rows:
+            raise ValueError("GLM selector request capacity exceeded")
+        if num_tokens > self.token_rows:
+            raise ValueError("GLM selector token capacity exceeded")
+        if pool_table_width != self.pool_table_width:
+            raise ValueError("GLM selector pool-table geometry changed")
+
+    def stage_replay_metadata(
+        self,
+        *,
+        query_start_loc: torch.Tensor,
+        req_id_per_token: torch.Tensor,
+        num_reqs: int,
+        live_rows: int,
+    ) -> None:
+        self.query_start_loc[: num_reqs + 1].copy_(query_start_loc[: num_reqs + 1])
+        self.row_request_ids[:live_rows].copy_(req_id_per_token[:live_rows])
 
 
 class Glm5NextPooledIndexer(nn.Module):
@@ -210,34 +272,7 @@ class Glm5NextPooledIndexer(nn.Module):
             ),
             persistent=False,
         )
-        self.register_buffer(
-            "_pool_seq_lens",
-            torch.empty(self.max_tokens, dtype=torch.int32, device=device),
-            persistent=False,
-        )
-        self.register_buffer(
-            "_pool_scores",
-            torch.empty(
-                (self.max_tokens, _POOL_TOPK),
-                dtype=torch.float32,
-                device=device,
-            ),
-            persistent=False,
-        )
-        self.register_buffer(
-            "_pool_block_table",
-            torch.empty((self.max_seqs, 1), dtype=torch.int32, device=device),
-            persistent=False,
-        )
-        self.register_buffer(
-            "_decode_block_table",
-            torch.empty(
-                (self.max_tokens, 1),
-                dtype=torch.int32,
-                device=device,
-            ),
-            persistent=False,
-        )
+        self._selector_arena: _PersistentPooledSelectorArena | None = None
         self._weights_proj_fp32: torch.Tensor | None = None
         self._index_cache: torch.Tensor | None = None
         self._parent_table_width = 0
@@ -321,14 +356,21 @@ class Glm5NextPooledIndexer(nn.Module):
         )
         pool_table_width = parent_table_width * subpages
         device = main_cache.device
-        self._pool_block_table = torch.empty(
-            (self.max_seqs, pool_table_width), dtype=torch.int32, device=device
-        )
-        self._decode_block_table = torch.empty(
-            (self.max_tokens, pool_table_width),
-            dtype=torch.int32,
-            device=device,
-        )
+        arena = self._selector_arena
+        if arena is None:
+            arena = _PersistentPooledSelectorArena(
+                max_num_seqs=self.max_seqs,
+                max_num_batched_tokens=self.max_tokens,
+                pool_table_width=pool_table_width,
+                device=device,
+            )
+            self._selector_arena = arena
+        else:
+            arena.require_fits(
+                num_reqs=self.max_seqs,
+                num_tokens=self.max_tokens,
+                pool_table_width=pool_table_width,
+            )
         self._index_cache = index_cache
         self._parent_table_width = parent_table_width
         self._subpages_per_parent = subpages
@@ -350,7 +392,6 @@ class Glm5NextPooledIndexer(nn.Module):
             raise RuntimeError("GLM selector state-slot metadata is missing")
         return cast(torch.Tensor, slots)
 
-    @eager_break_during_capture
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -406,7 +447,6 @@ class Glm5NextPooledIndexer(nn.Module):
         num_reqs = int(main_metadata.num_reqs)
         live_rows = int(main_metadata.num_actual_tokens)
         decode_rows = int(main_metadata.num_decode_tokens)
-        num_decodes = int(main_metadata.num_decodes)
         if not 0 <= decode_rows <= live_rows <= rows:
             raise RuntimeError(
                 "GLM selector token counts are inconsistent: "
@@ -419,11 +459,25 @@ class Glm5NextPooledIndexer(nn.Module):
                 f"actual={actual_table_width}, required={self._parent_table_width}"
             )
 
+        arena = self._selector_arena
+        if arena is None:
+            raise RuntimeError("GLM selector arena is not bound")
+        arena.require_fits(
+            num_reqs=num_reqs,
+            num_tokens=live_rows,
+            pool_table_width=(self._parent_table_width * self._subpages_per_parent),
+        )
+        arena.stage_replay_metadata(
+            query_start_loc=main_metadata.query_start_loc,
+            req_id_per_token=main_metadata.req_id_per_token,
+            num_reqs=num_reqs,
+            live_rows=live_rows,
+        )
         update_decode_pools(
             index_cache,
             self._tail,
             state_slots,
-            main_metadata.query_start_loc,
+            arena.query_start_loc,
             normalized_key,
             gate,
             self.index_kpool_compress_ape,
@@ -435,12 +489,12 @@ class Glm5NextPooledIndexer(nn.Module):
         )
         expand_c4_block_table(
             main_metadata.block_table[:num_reqs, : self._parent_table_width],
-            self._pool_block_table,
+            arena.request_block_table,
             rows=num_reqs,
             subpages_per_parent=self._subpages_per_parent,
             parent_stride_pages=self._parent_stride_pages,
         )
-        seq_lens = self._pool_seq_lens[:live_rows]
+        seq_lens = arena.pool_seq_lens[:live_rows]
         pool_seq_lens(
             positions[:live_rows],
             seq_lens,
@@ -450,72 +504,31 @@ class Glm5NextPooledIndexer(nn.Module):
         )
         pool_ids = self.pool_topk_indices_buffer[:rows]
         pool_ids.fill_(-1)
-        pool_scores = self._pool_scores[:rows] if self.dcp_world_size > 1 else None
-
-        if decode_rows:
-            decode_table = self._decode_block_table[:decode_rows]
-            gather_c4_block_table_rows(
-                self._pool_block_table,
-                main_metadata.req_id_per_token[:decode_rows],
-                decode_table,
+        pool_scores = arena.pool_scores[:live_rows] if self.dcp_world_size > 1 else None
+        token_block_table = arena.token_block_table[:live_rows]
+        gather_c4_block_table_rows(
+            arena.request_block_table,
+            arena.row_request_ids[:live_rows],
+            token_block_table,
+        )
+        self.indexer_op.run_paged_topk(
+            q=q_fp8[:live_rows],
+            weights=weights[:live_rows],
+            kv_cache=index_cache,
+            seq_lens=seq_lens,
+            block_table=token_block_table,
+            output=pool_ids[:live_rows],
+            scores=pool_scores,
+            shared_page_table=False,
+        )
+        if pool_scores is not None:
+            _merge_dcp_topk(
+                pool_ids[:live_rows],
+                pool_scores,
+                self.dcp_rank,
+                self.dcp_world_size,
+                self.pool_interleave,
             )
-            self.indexer_op.run_paged_topk(
-                q=q_fp8[:decode_rows],
-                weights=weights[:decode_rows],
-                kv_cache=index_cache,
-                seq_lens=seq_lens[:decode_rows],
-                block_table=decode_table,
-                output=pool_ids[:decode_rows],
-                scores=(pool_scores[:decode_rows] if pool_scores is not None else None),
-                shared_page_table=False,
-            )
-            if pool_scores is not None:
-                _merge_dcp_topk(
-                    pool_ids[:decode_rows],
-                    pool_scores[:decode_rows],
-                    self.dcp_rank,
-                    self.dcp_world_size,
-                    self.pool_interleave,
-                )
-
-        if decode_rows < live_rows:
-            query_lens_cpu = main_metadata.prefill_query_lens_cpu
-            if query_lens_cpu is None:
-                raise RuntimeError("GLM selector prefill metadata is incomplete")
-            row_start = decode_rows
-            for local_request, query_len in enumerate(query_lens_cpu.tolist()):
-                row_end = row_start + int(query_len)
-                request = num_decodes + local_request
-                shared_table = self._pool_block_table[request : request + 1].expand(
-                    int(query_len), -1
-                )
-                self.indexer_op.run_paged_topk(
-                    q=q_fp8[row_start:row_end],
-                    weights=weights[row_start:row_end],
-                    kv_cache=index_cache,
-                    seq_lens=seq_lens[row_start:row_end],
-                    block_table=shared_table,
-                    output=pool_ids[row_start:row_end],
-                    scores=(
-                        pool_scores[row_start:row_end]
-                        if pool_scores is not None
-                        else None
-                    ),
-                    shared_page_table=True,
-                )
-                if pool_scores is not None:
-                    _merge_dcp_topk(
-                        pool_ids[row_start:row_end],
-                        pool_scores[row_start:row_end],
-                        self.dcp_rank,
-                        self.dcp_world_size,
-                        self.pool_interleave,
-                    )
-                row_start = row_end
-            if row_start != live_rows:
-                raise RuntimeError(
-                    "GLM selector prefill row accounting is inconsistent"
-                )
 
         output = self.topk_indices_buffer[:rows]
         output.fill_(-1)

--- a/vllm/models/kimi_k3/nvidia/ops/third_party/kda/chunk.py
+++ b/vllm/models/kimi_k3/nvidia/ops/third_party/kda/chunk.py
@@ -196,6 +196,7 @@ def recompute_w_u_fwd(
     gk: torch.Tensor | None = None,
     cu_seqlens: torch.Tensor | None = None,
     chunk_indices: torch.Tensor | None = None,
+    chunk_offsets: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     B, T, H, K, V = *k.shape, v.shape[-1]
     BT = A.shape[-1]
@@ -596,6 +597,7 @@ def _chunk_kda_fwd_with_cumulative_g(
     output_final_state: bool,
     cu_seqlens: torch.Tensor | None = None,
     chunk_indices: torch.Tensor | None = None,
+    chunk_offsets: torch.Tensor | None = None,
     chunk_size: int = FLA_CHUNK_SIZE,
     safe_gate: bool = False,
 ):
@@ -622,6 +624,7 @@ def _chunk_kda_fwd_with_cumulative_g(
         gk=g,
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
+        chunk_offsets=chunk_offsets,
     )
     del A
     h, v_new, final_state = chunk_gated_delta_rule_fwd_h(
@@ -633,6 +636,7 @@ def _chunk_kda_fwd_with_cumulative_g(
         output_final_state=output_final_state,
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
+        chunk_offsets=chunk_offsets,
         use_exp2=True,
     )
     del w, u, kg
@@ -662,13 +666,12 @@ def chunk_kda_fwd(
     initial_state: torch.Tensor,
     output_final_state: bool,
     cu_seqlens: torch.Tensor | None = None,
+    chunk_indices: torch.Tensor | None = None,
+    chunk_offsets: torch.Tensor | None = None,
 ):
     chunk_size = FLA_CHUNK_SIZE
-    chunk_indices = (
-        prepare_chunk_indices(cu_seqlens, chunk_size)
-        if cu_seqlens is not None
-        else None
-    )
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
     g = chunk_local_cumsum(
         g,
         chunk_size=chunk_size,
@@ -689,6 +692,7 @@ def chunk_kda_fwd(
         output_final_state=output_final_state,
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
+        chunk_offsets=chunk_offsets,
         chunk_size=chunk_size,
     )
 
@@ -706,13 +710,12 @@ def chunk_kda_with_fused_gate_fwd(
     output_final_state: bool,
     lower_bound: float | None = None,
     cu_seqlens: torch.Tensor | None = None,
+    chunk_indices: torch.Tensor | None = None,
+    chunk_offsets: torch.Tensor | None = None,
 ):
     chunk_size = FLA_CHUNK_SIZE
-    chunk_indices = (
-        prepare_chunk_indices(cu_seqlens, chunk_size)
-        if cu_seqlens is not None
-        else None
-    )
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
     g, beta = fused_kda_gate_chunk_cumsum(
         raw_g,
         raw_beta=raw_beta,
@@ -720,6 +723,7 @@ def chunk_kda_with_fused_gate_fwd(
         g_bias=g_bias,
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
+        chunk_offsets=chunk_offsets,
         chunk_size=chunk_size,
         lower_bound=lower_bound,
     )
@@ -734,6 +738,7 @@ def chunk_kda_with_fused_gate_fwd(
         output_final_state=output_final_state,
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
+        chunk_offsets=chunk_offsets,
         chunk_size=chunk_size,
         safe_gate=lower_bound is not None,
     )
@@ -750,7 +755,8 @@ def chunk_kda(
     output_final_state: bool = False,
     use_qk_l2norm_in_kernel: bool = False,
     cu_seqlens: torch.Tensor | None = None,
-    **kwargs,
+    chunk_indices: torch.Tensor | None = None,
+    chunk_offsets: torch.Tensor | None = None,
 ):
     if scale is None:
         scale = k.shape[-1] ** -0.5
@@ -769,6 +775,8 @@ def chunk_kda(
         initial_state=initial_state.contiguous(),
         output_final_state=output_final_state,
         cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        chunk_offsets=chunk_offsets,
     )
     return o, final_state
 
@@ -787,7 +795,8 @@ def chunk_kda_with_fused_gate(
     lower_bound: float | None = None,
     use_qk_l2norm_in_kernel: bool = False,
     cu_seqlens: torch.Tensor | None = None,
-    **kwargs,
+    chunk_indices: torch.Tensor | None = None,
+    chunk_offsets: torch.Tensor | None = None,
 ):
     """Run chunk KDA from raw gate and beta projections."""
     if scale is None:
@@ -810,6 +819,8 @@ def chunk_kda_with_fused_gate(
         output_final_state=output_final_state,
         lower_bound=lower_bound,
         cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        chunk_offsets=chunk_offsets,
     )
     return o, final_state
 

--- a/vllm/v1/attention/backends/gdn_attn.py
+++ b/vllm/v1/attention/backends/gdn_attn.py
@@ -8,7 +8,10 @@ from typing import Literal
 import torch
 
 from vllm.config import VllmConfig
-from vllm.utils.torch_utils import async_tensor_h2d
+from vllm.models.glm5next_cudagraph import (
+    is_glm53_full_graph_path,
+    require_glm53_full_graph_capacity,
+)
 from vllm.v1.attention.backend import (
     AttentionBackend,
     AttentionCGSupport,
@@ -17,11 +20,10 @@ from vllm.v1.attention.backend import (
 )
 from vllm.v1.attention.backends.utils import (
     NULL_BLOCK_ID,
-    compute_causal_conv1d_metadata,
     mamba_get_block_table_tensor,
     split_decodes_and_prefills,
 )
-from vllm.v1.kv_cache_interface import MambaSpec
+from vllm.v1.kv_cache_interface import KVCacheSpec, MambaSpec
 
 
 class GDNAttentionBackend(AttentionBackend):
@@ -85,10 +87,175 @@ class GDNAttentionMetadata:
     seq_lens: torch.Tensor | None = None
 
 
+class _PersistentGDNMetadataArena:
+    """Fixed-address metadata storage bounded by scheduler maxima."""
+
+    def __init__(
+        self,
+        *,
+        max_num_seqs: int,
+        max_num_batched_tokens: int,
+        num_spec: int,
+        device: torch.device,
+    ) -> None:
+        if max_num_seqs <= 0 or max_num_batched_tokens <= 0:
+            raise ValueError("GDN metadata arena capacities must be positive")
+        self.request_rows = max_num_seqs
+        self.token_rows = max_num_batched_tokens
+        self.state_width = num_spec + 1
+        chunk_rows = (max_num_batched_tokens + 63) // 64 + max_num_seqs
+        conv_rows = 2 * max(1024, (max_num_batched_tokens + 7) // 8 + max_num_seqs)
+        self.query_start_loc = torch.empty(
+            max_num_seqs + 1, dtype=torch.int32, device=device
+        )
+        self.prefill_query_start_loc = torch.empty_like(self.query_start_loc)
+        self.seq_lens = torch.empty(max_num_seqs, dtype=torch.int32, device=device)
+        self.state_indices = torch.empty(
+            (max_num_seqs, self.state_width), dtype=torch.int32, device=device
+        )
+        self.has_initial_state = torch.empty(
+            max_num_seqs, dtype=torch.bool, device=device
+        )
+        self.chunk_indices = torch.empty(
+            (chunk_rows, 2), dtype=torch.int32, device=device
+        )
+        self.chunk_offsets = torch.empty(
+            max_num_seqs + 1, dtype=torch.int32, device=device
+        )
+        self.batch_ptr = torch.full(
+            (conv_rows,), NULL_BLOCK_ID, dtype=torch.int32, device=device
+        )
+        self.token_chunk_offset_ptr = torch.full_like(self.batch_ptr, NULL_BLOCK_ID)
+        self.spec_sequence_masks = torch.empty(
+            max_num_seqs, dtype=torch.bool, device=device
+        )
+        self.num_accepted_tokens = torch.empty(
+            max_num_seqs, dtype=torch.int32, device=device
+        )
+        self.spec_query_start_loc = torch.empty_like(self.query_start_loc)
+        self.non_spec_query_start_loc = torch.empty_like(self.query_start_loc)
+        self.spec_state_indices = torch.empty_like(self.state_indices)
+        self.non_spec_state_indices = torch.empty(
+            max_num_seqs, dtype=torch.int32, device=device
+        )
+        self.spec_token_indices = torch.empty(
+            max_num_batched_tokens, dtype=torch.int32, device=device
+        )
+        self.non_spec_token_indices = torch.empty_like(self.spec_token_indices)
+        pin_memory = device.type == "cuda"
+        self._conv_batch_cpu = torch.empty(
+            conv_rows, dtype=torch.int32, pin_memory=pin_memory
+        )
+        self._conv_offset_cpu = torch.empty_like(
+            self._conv_batch_cpu, pin_memory=pin_memory
+        )
+        self._conv_nums_cpu = torch.empty(
+            max_num_seqs, dtype=torch.int32, pin_memory=pin_memory
+        )
+        self.nums_dict = {
+            8: {
+                "nums": self._conv_nums_cpu,
+                "tot": 0,
+                "mlist": self._conv_batch_cpu,
+                "mlist_len": 0,
+                "offsetlist": self._conv_offset_cpu,
+                "batch_ptr": self.batch_ptr,
+                "token_chunk_offset_ptr": self.token_chunk_offset_ptr,
+            }
+        }
+
+    def require_fits(self, *, num_reqs: int, num_tokens: int) -> None:
+        if num_reqs > self.request_rows:
+            raise ValueError("GDN metadata request capacity exceeded")
+        if num_tokens > self.token_rows:
+            raise ValueError("GDN metadata token capacity exceeded")
+
+    @staticmethod
+    def stage(
+        storage: torch.Tensor,
+        value: torch.Tensor,
+        *,
+        fill: int | bool | None = None,
+    ) -> torch.Tensor:
+        rows = value.shape[0]
+        if rows > storage.shape[0]:
+            raise ValueError("GDN metadata arena staging capacity exceeded")
+        storage[:rows].copy_(value, non_blocking=True)
+        if fill is not None and rows < storage.shape[0]:
+            storage[rows:].fill_(fill)
+        return storage[:rows]
+
+    def stage_causal_conv(
+        self, query_start_loc_cpu: torch.Tensor
+    ) -> tuple[dict, torch.Tensor, torch.Tensor]:
+        num_reqs = query_start_loc_cpu.numel() - 1
+        if num_reqs > self.request_rows:
+            raise ValueError("GDN causal-conv request capacity exceeded")
+        total_programs = 0
+        for request_idx in range(num_reqs):
+            seq_len = int(
+                query_start_loc_cpu[request_idx + 1] - query_start_loc_cpu[request_idx]
+            )
+            num_programs = (seq_len + 7) // 8
+            self._conv_nums_cpu[request_idx] = num_programs
+            end = total_programs + num_programs
+            if end > self.batch_ptr.shape[0]:
+                raise ValueError("GDN causal-conv program capacity exceeded")
+            self._conv_batch_cpu[total_programs:end].fill_(request_idx)
+            if num_programs:
+                torch.arange(
+                    num_programs,
+                    dtype=torch.int32,
+                    out=self._conv_offset_cpu[total_programs:end],
+                )
+            total_programs = end
+        self.batch_ptr.fill_(NULL_BLOCK_ID)
+        self.token_chunk_offset_ptr.fill_(NULL_BLOCK_ID)
+        self.batch_ptr[:total_programs].copy_(
+            self._conv_batch_cpu[:total_programs], non_blocking=True
+        )
+        self.token_chunk_offset_ptr[:total_programs].copy_(
+            self._conv_offset_cpu[:total_programs], non_blocking=True
+        )
+        entry = self.nums_dict[8]
+        entry["tot"] = total_programs
+        entry["mlist_len"] = total_programs
+        return self.nums_dict, self.batch_ptr, self.token_chunk_offset_ptr
+
+
 class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]):
     kv_cache_spec: MambaSpec
     _cudagraph_support = AttentionCGSupport.UNIFORM_BATCH
+    _glm53_graph_safe_gdn_marker = "fixed-address-gdn-metadata-v1"
     supports_update_block_table: bool = True
+
+    @classmethod
+    def get_cudagraph_support(
+        cls,
+        vllm_config: VllmConfig,
+        kv_cache_spec: KVCacheSpec,
+    ) -> AttentionCGSupport:
+        if (
+            not isinstance(kv_cache_spec, MambaSpec)
+            or not is_glm53_full_graph_path(vllm_config)
+            or kv_cache_spec.block_size != 2304
+        ):
+            return AttentionCGSupport.UNIFORM_BATCH
+        require_glm53_full_graph_capacity(vllm_config)
+        from vllm.v1.attention.backends.mla.b12x_mla_sparse import (
+            B12xGLM5NextMLASparseMetadataBuilder,
+        )
+
+        marker = getattr(
+            B12xGLM5NextMLASparseMetadataBuilder,
+            "_glm53_graph_safe_selector_marker",
+            None,
+        )
+        if marker != "fixed-address-vectorized-pooled-selector-v1":
+            raise RuntimeError(
+                "GLM-5.3 mixed FULL requires graph-safe pooled selection"
+            )
+        return AttentionCGSupport.ALWAYS
 
     mamba_aligned_state_indices: torch.Tensor | None = None
 
@@ -172,6 +339,14 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             dtype=torch.int32,
             device=device,
         )
+        self.arena = _PersistentGDNMetadataArena(
+            max_num_seqs=vllm_config.scheduler_config.max_num_seqs,
+            max_num_batched_tokens=(
+                vllm_config.scheduler_config.max_num_batched_tokens
+            ),
+            num_spec=self.num_spec,
+            device=device,
+        )
 
     def _get_state_indices(
         self,
@@ -222,15 +397,15 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
         )
 
         assert prefill_query_start_loc_cpu is not None
+        chunk_indices = prepare_chunk_indices(
+            prefill_query_start_loc_cpu, FLA_CHUNK_SIZE
+        )
+        chunk_offsets = prepare_chunk_offsets(
+            prefill_query_start_loc_cpu, FLA_CHUNK_SIZE
+        )
         return (
-            async_tensor_h2d(
-                prepare_chunk_indices(prefill_query_start_loc_cpu, FLA_CHUNK_SIZE),
-                device=device,
-            ),
-            async_tensor_h2d(
-                prepare_chunk_offsets(prefill_query_start_loc_cpu, FLA_CHUNK_SIZE),
-                device=device,
-            ),
+            self.arena.stage(self.arena.chunk_indices, chunk_indices),
+            self.arena.stage(self.arena.chunk_offsets, chunk_offsets),
         )
 
     def build(  # type: ignore[override]
@@ -242,8 +417,12 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
         fast_build: bool = False,
     ) -> GDNAttentionMetadata:
         m = common_attn_metadata
+        self.arena.require_fits(num_reqs=m.num_reqs, num_tokens=m.num_actual_tokens)
 
-        query_start_loc = m.query_start_loc
+        query_start_loc = self.arena.stage(
+            self.arena.query_start_loc, m.query_start_loc
+        )
+        seq_lens = self.arena.stage(self.arena.seq_lens, m.seq_lens)
         query_start_loc_cpu = m.query_start_loc_cpu
         nums_dict, batch_ptr, token_chunk_offset_ptr = None, None, None
         block_table_tensor = self._get_state_indices(
@@ -268,8 +447,12 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
                 spec_sequence_masks = None
                 spec_sequence_masks_cpu = None
             else:
-                spec_sequence_masks = async_tensor_h2d(
-                    spec_sequence_masks_cpu, device=query_start_loc.device
+                spec_sequence_masks = self.arena.stage(
+                    self.arena.spec_sequence_masks,
+                    spec_sequence_masks_cpu.to(
+                        device=query_start_loc.device, non_blocking=True
+                    ),
+                    fill=False,
                 )
 
         if spec_sequence_masks is None:
@@ -436,11 +619,8 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             if spec_sequence_masks_cpu is not None:
                 has_initial_state = has_initial_state[~spec_sequence_masks_cpu]
                 assert non_spec_query_start_loc_cpu is not None
-            nums_dict, batch_ptr, token_chunk_offset_ptr = (
-                compute_causal_conv1d_metadata(
-                    non_spec_query_start_loc_cpu,
-                    device=query_start_loc.device,
-                )
+            nums_dict, batch_ptr, token_chunk_offset_ptr = self.arena.stage_causal_conv(
+                non_spec_query_start_loc_cpu
             )
             if spec_sequence_masks is None and num_decodes > 0:
                 prefill_has_initial_state = has_initial_state[num_decodes:]
@@ -448,6 +628,25 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
                 prefill_has_initial_state = has_initial_state
         else:
             has_initial_state = None
+
+        if prefill_query_start_loc is not None:
+            prefill_query_start_loc = self.arena.stage(
+                self.arena.prefill_query_start_loc,
+                prefill_query_start_loc,
+            )
+        if prefill_state_indices is not None:
+            storage = (
+                self.arena.state_indices
+                if prefill_state_indices.ndim == 2
+                else self.arena.non_spec_state_indices
+            )
+            prefill_state_indices = self.arena.stage(storage, prefill_state_indices)
+        if prefill_has_initial_state is not None:
+            prefill_has_initial_state = self.arena.stage(
+                self.arena.has_initial_state,
+                prefill_has_initial_state,
+                fill=False,
+            )
 
         # Function code counted on either presency non-spec decode or spec decode,
         # but not both.
@@ -554,7 +753,7 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             batch_ptr=batch_ptr,
             token_chunk_offset_ptr=token_chunk_offset_ptr,
             num_reqs=m.num_reqs,
-            seq_lens=m.seq_lens,
+            seq_lens=seq_lens,
         )
         return attn_metadata
 
@@ -682,11 +881,16 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
     def build_for_cudagraph_capture(
         self, common_attn_metadata: CommonAttentionMetadata
     ):
-        """
-        This method builds the metadata for full cudagraph capture.
-        Currently, only decode is supported for full cudagraphs with Mamba.
-        """
+        """Build capture metadata under the selected path's capacity contract."""
         m = common_attn_metadata
+
+        if is_glm53_full_graph_path(self.vllm_config):
+            self.arena.require_fits(num_reqs=m.num_reqs, num_tokens=m.num_actual_tokens)
+            if m.is_prefilling is not None and bool(m.is_prefilling.any()):
+                return self.build(0, m, None, None)
+            accepted = self.arena.num_accepted_tokens[: m.num_reqs]
+            torch.diff(m.query_start_loc, out=accepted)
+            return self.build(0, m, accepted, (accepted - 1).cpu())
 
         assert (
             m.num_reqs <= self.decode_cudagraph_max_bs


### PR DESCRIPTION
## Summary

Adds graph-stable metadata storage for GLM-5.3 hybrid execution. This PR is stacked on #523 and contains only the persistent metadata/KDA delta.

### Behavior

- fixed-address GDN metadata arena sized for the qualified capture envelope
- graph-safe pooled-selector arena and vectorized row selection
- separate KDA live-request and graph-plan capacities
- capture capacity includes the maximum CUDA-graph token shape
- precomputed KDA chunk indices and offsets are reused through captured execution
- fail-closed capacity checks instead of reallocating captured metadata
- preserves the newer Jovian live-tensor B12X KDA binding from merged PR #521

This extracts the production behavior from D16 commits `95e8533`, `9c9d73c`, `e83f736`, `3d39898`, `3c4e5b1`, and `42aee72`.

## Verification

- AST parse: 7 changed Python files
- `git diff --check`: clean
- D16 runtime qualification exercised these paths under TP4/DCP4/MTP3 FULL capture and replay

Broad CI is left to repository CI; no GPU builds were run on the controller.

## AI assistance disclosure

AI assistance was used for implementation and test construction. Devin Kuhn reviewed and directed the behavior.

## Final D22 production receipt (2026-08-30)

The reviewed production derivative retained fixed-address hybrid metadata and registered the exact DCP layout `[2304, 2304, 2304, 9216]` across four CUDA-IPC allocations. FULL graph capture and post-reload raw generation remained coherent with restart count 0 and no Xid/OOM/EngineDead.

Fleet-owned immutable deployment receipt: Apple-Federal-Credit-Union/fleet-infra#309.

## Required dependency on #523

This PR is source-dependent on #523 because it imports `vllm.models.glm5next_cudagraph`, which #523 introduces. GitHub cannot target a contributor-fork branch as the base of an upstream PR, so this PR intentionally remains based on `dev/jovian-judgement` for now.

**Merge order:** merge #523 first, then rebase this branch onto the updated `dev/jovian-judgement` before merging #524. Until that rebase, #524 is not independently import-complete and should not be merged. The implementation is kept separate to preserve the requested feature-by-feature review boundary rather than duplicating #523's graph code here.
